### PR TITLE
Improve XMPP protocol support for starttls on s_client 

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -350,6 +350,7 @@ static void sc_usage(void)
 	BIO_printf(bio_err,"                 'prot' defines which one to assume.  Currently,\n");
 	BIO_printf(bio_err,"                 only \"smtp\", \"pop3\", \"imap\", \"ftp\" and \"xmpp\"\n");
 	BIO_printf(bio_err,"                 are supported.\n");
+	BIO_printf(bio_err," -xmpphost host - When used with \"-starttls xmpp\" specifies the virtual host.\n");
 #ifndef OPENSSL_NO_ENGINE
 	BIO_printf(bio_err," -engine id    - Initialise and use the specified engine\n");
 #endif
@@ -571,6 +572,7 @@ int MAIN(int argc, char **argv)
 	short port=PORT;
 	int full_log=1;
 	char *host=SSL_HOST_NAME;
+	char *xmpphost = NULL;
 	char *cert_file=NULL,*key_file=NULL,*chain_file=NULL;
 	int cert_format = FORMAT_PEM, key_format = FORMAT_PEM;
 	char *passarg = NULL, *pass = NULL;
@@ -697,6 +699,11 @@ static char *jpake_secret = NULL;
 			if (--argc < 1) goto bad;
 			if (!extract_host_port(*(++argv),&host,NULL,&port))
 				goto bad;
+			}
+		else if	(strcmp(*argv,"-xmpphost") == 0)
+			{
+			if (--argc < 1) goto bad;
+			xmpphost= *(++argv);
 			}
 		else if	(strcmp(*argv,"-verify") == 0)
 			{
@@ -1586,7 +1593,7 @@ SSL_set_tlsext_status_ids(con, ids);
 		int seen = 0;
 		BIO_printf(sbio,"<stream:stream "
 		    "xmlns:stream='http://etherx.jabber.org/streams' "
-		    "xmlns='jabber:client' to='%s' version='1.0'>", host);
+		    "xmlns='jabber:client' to='%s' version='1.0'>", xmpphost? xmpphost:host);
 		seen = BIO_read(sbio,mbuf,BUFSIZZ);
 		mbuf[seen] = 0;
 		while (!strstr(mbuf, "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'") &&

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -37,6 +37,7 @@ B<openssl> B<s_client>
 [B<-bugs>]
 [B<-cipher cipherlist>]
 [B<-starttls protocol>]
+[B<-xmpphost hostname>]
 [B<-engine id>]
 [B<-tlsextdebug>]
 [B<-no_ticket>]
@@ -223,6 +224,13 @@ command for more information.
 send the protocol-specific message(s) to switch to TLS for communication.
 B<protocol> is a keyword for the intended protocol.  Currently, the only
 supported keywords are "smtp", "pop3", "imap", "ftp" and "xmpp".
+
+=item B<-xmpphost hostname>
+
+This option, when used with "-starttls xmpp", specifies the host for the
+"to" attribute of the stream element.
+If this option is not specified, then the host specified with "-connect"
+will be used.
 
 =item B<-tlsextdebug>
 


### PR DESCRIPTION
I submit this patches time ago to the [openssl mailing list](https://rt.openssl.org/Ticket/Display.html?id=2860&user=guest&pass=guest) but got not answer. 
I have rebased the patches on top of current master and I'm retrying submitting it here with the hope that it will caught more attention.

This pull request fixes the support for XMPP on openssl s_client. A number of reports on Internet complain about this. Examples:
- https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/654493
- https://bugzilla.redhat.com/show_bug.cgi?id=608239
- http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=671672
- https://rt.openssl.org/Ticket/Display.html?user=guest&pass=guest&id=2638
- https://rt.openssl.org/Ticket/Display.html?id=2812&user=guest&pass=guest
