### PR TITLE
Initialize next_proto in s_server - resolves incorrect attempts to free

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1065,7 +1065,7 @@ int MAIN(int argc, char *argv[])
         tlsextctx tlsextcbp = {NULL, NULL, SSL_TLSEXT_ERR_ALERT_WARNING};
 # ifndef OPENSSL_NO_NEXTPROTONEG
 	const char *next_proto_neg_in = NULL;
-	tlsextnextprotoctx next_proto;
+	tlsextnextprotoctx next_proto = { NULL, 0};
 	const char *alpn_in = NULL;
 	tlsextalpnctx alpn_ctx = { NULL, 0};
 # endif


### PR DESCRIPTION
Encountered an error running:

openssl s_server help

Which would normally generate the s_server options.  Initializing next_proto resolves the issue.
