### PR TITLE
Make engine_pkey_meths_free & engine_pkey_asn1_meths_free optional

### DIFF
--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -126,8 +126,11 @@ int engine_free_util(ENGINE *e, int locked)
 		}
 #endif
 	/* Free up any dynamically allocated public key methods */
-	engine_pkey_meths_free(e);
-	engine_pkey_asn1_meths_free(e);
+	if (!(ENGINE_get_flags(e) & ENGINE_FLAGS_NO_PKEY_METH_FREE))
+		engine_pkey_meths_free(e);
+	if (!(ENGINE_get_flags(e) & ENGINE_FLAGS_NO_PKEY_ASN1_METH_FREE))
+		engine_pkey_asn1_meths_free(e);
+
 	/* Give the ENGINE a chance to do any structural cleanup corresponding
 	 * to allocation it did in its constructor (eg. unload error strings) */
 	if(e->destroy)

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -125,6 +125,19 @@ int engine_free_util(ENGINE *e, int locked)
 		abort();
 		}
 #endif
+
+	/* unregister the engine */
+	ENGINE_unregister_ciphers(e);
+	ENGINE_unregister_digests(e);
+	ENGINE_unregister_RSA(e);
+	ENGINE_unregister_DSA(e);
+	ENGINE_unregister_DH(e);
+	ENGINE_unregister_ECDH(e);
+	ENGINE_unregister_ECDSA(e);
+	ENGINE_unregister_RAND(e);
+	ENGINE_unregister_pkey_meths(e);
+	ENGINE_unregister_pkey_asn1_meths(e);
+
 	/* Free up any dynamically allocated public key methods */
 	if (!(ENGINE_get_flags(e) & ENGINE_FLAGS_NO_PKEY_METH_FREE))
 		engine_pkey_meths_free(e);

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -174,9 +174,10 @@ int engine_table_register(ENGINE_TABLE **table, ENGINE_CLEANUP_CB *cleanup,
 						ENGINE_R_INIT_FAILED);
 				goto end;
 				}
-			if(fnd->funct)
-				engine_unlocked_finish(fnd->funct, 0);
+			ENGINE *old = fnd->funct;
 			fnd->funct = e;
+			if(old)
+				engine_unlocked_finish(old, 0);
 			fnd->uptodate = 1;
 			}
 		nids++;

--- a/crypto/engine/engine.h
+++ b/crypto/engine/engine.h
@@ -148,6 +148,16 @@ extern "C" {
 
 #define ENGINE_FLAGS_NO_REGISTER_ALL	(int)0x0008
 
+
+
+/* This flag is for engines using static global asn1 pkey meth data
+ * Setting the flag prevents OpenSSL to free the data,the engine has to take
+ * free memory on its own
+ */
+#define ENGINE_FLAGS_NO_PKEY_METH_FREE	(int)0x0010
+#define ENGINE_FLAGS_NO_PKEY_ASN1_METH_FREE	(int)0x0020
+
+
 /* ENGINEs can support their own command types, and these flags are used in
  * ENGINE_CTRL_GET_CMD_FLAGS to indicate to the caller what kind of input each
  * command expects. Currently only numeric and string input is supported. If a


### PR DESCRIPTION
These patches fix the issue https://github.com/openssl/openssl/issues/25
It 
 * adds two ENGINE_FLAGS to  make engine_pkey_meths_free and engine_pkey_asn1_meths_free optional
 * unregisters the engines registered ciphers/digests/... before destroying the engine
 * adds reference counting to gost, so gost can keep track of resources on his own
