### PR TITLE
Unit tests for PKCS#5 PBKDF2 HMAC

### DIFF
--- a/crypto/evp/Makefile
+++ b/crypto/evp/Makefile
@@ -13,7 +13,7 @@ AR=		ar r
 CFLAGS= $(INCLUDES) $(CFLAG)
 
 GENERAL=Makefile
-TEST=evp_test.c
+TEST=evp_test.c p5_crpt2_test.c
 TESTDATA=evptests.txt
 APPS=
 

--- a/crypto/evp/p5_crpt2_test.c
+++ b/crypto/evp/p5_crpt2_test.c
@@ -61,6 +61,14 @@
 #include <openssl/err.h>
 #include <openssl/conf.h>
 
+#ifdef OPENSSL_NO_SHA
+int main(int argc, char *argv[])
+{
+    printf("No SHA support\n");
+    return(0);
+}
+#else
+
 typedef struct {
 	const char *pass;
 	int passlen;
@@ -113,7 +121,7 @@ hexdump(FILE *f, const char *title, const unsigned char *s, int l) {
 	int i;
 	fprintf(f, "%s", title);
 	for(i=0; i < l ; i++) {
-		fprintf(f, " 0x%02x", s[i]);
+		fprintf(f, "%02x", s[i]);
 	}
 	fprintf(f, "\n");
 }
@@ -192,9 +200,15 @@ int main(int argc,char **argv) {
 
 	printf("PKCS5_PBKDF2_HMAC() tests ");
 	for (i=0; test->pass != NULL; i++, test++) {
+#ifndef OPENSSL_NO_SHA0
 		test_p5_pbkdf2(i, "sha1", test, sha1_results[i]);
+#endif
+#ifndef OPENSSL_NO_SHA256
 		test_p5_pbkdf2(i, "sha256", test, sha256_results[i]);
+#endif
+#ifndef OPENSSL_NO_SHA512
 		test_p5_pbkdf2(i, "sha512", test, sha512_results[i]);
+#endif
 		printf(".");
 	}
 	printf(" done\n");
@@ -209,3 +223,4 @@ int main(int argc,char **argv) {
 	CRYPTO_mem_leaks_fp(stderr);
 	return 0;
 }
+#endif /* OPENSSL_NO_SHA */

--- a/test/Makefile
+++ b/test/Makefile
@@ -62,6 +62,7 @@ SSLTEST=	ssltest
 RSATEST=	rsa_test
 ENGINETEST=	enginetest
 EVPTEST=	evp_test
+P5_CRPT2_TEST=	p5_crpt2_test
 IGETEST=	igetest
 JPAKETEST=	jpaketest
 SRPTEST=	srptest
@@ -98,7 +99,7 @@ EXE=	$(BNTEST)$(EXE_EXT) $(ECTEST)$(EXE_EXT)  $(ECDSATEST)$(EXE_EXT) $(ECDHTEST)
 	$(BFTEST)$(EXE_EXT) $(CASTTEST)$(EXE_EXT) $(SSLTEST)$(EXE_EXT) \
 	$(EXPTEST)$(EXE_EXT) $(DSATEST)$(EXE_EXT) $(RSATEST)$(EXE_EXT) \
 	$(EVPTEST)$(EXE_EXT) $(IGETEST)$(EXE_EXT) $(JPAKETEST)$(EXE_EXT) $(SRPTEST)$(EXE_EXT) \
-	$(V3NAMETEST)$(EXE_EXT)
+	$(V3NAMETEST)$(EXE_EXT) $(P5_CRPT2_TEST)$(EXE_EXT)
 
 FIPSEXE=$(FIPS_SHATEST)$(EXE_EXT) $(FIPS_DESTEST)$(EXE_EXT) \
 	$(FIPS_RANDTEST)$(EXE_EXT) $(FIPS_AESTEST)$(EXE_EXT) \
@@ -127,7 +128,7 @@ OBJ=	$(BNTEST).o $(ECTEST).o  $(ECDSATEST).o $(ECDHTEST).o $(IDEATEST).o \
 	$(FIPS_TEST_SUITE).o $(FIPS_DHVS).o $(FIPS_ECDSAVS).o \
 	$(FIPS_ECDHVS).o $(FIPS_CMACTEST).o $(FIPS_ALGVS).o \
 	$(EVPTEST).o $(IGETEST).o $(JPAKETEST).o $(V3NAMETEST).o \
-	$(GOST2814789TEST).o
+	$(GOST2814789TEST).o $(P5_CRPT2_TEST).o
 SRC=	$(BNTEST).c $(ECTEST).c  $(ECDSATEST).c $(ECDHTEST).c $(IDEATEST).c \
 	$(MD2TEST).c  $(MD4TEST).c $(MD5TEST).c \
 	$(HMACTEST).c $(WPTEST).c \
@@ -142,7 +143,7 @@ SRC=	$(BNTEST).c $(ECTEST).c  $(ECDSATEST).c $(ECDHTEST).c $(IDEATEST).c \
 	$(FIPS_TEST_SUITE).c $(FIPS_DHVS).c $(FIPS_ECDSAVS).c \
 	$(FIPS_ECDHVS).c $(FIPS_CMACTEST).c $(FIPS_ALGVS).c \
 	$(EVPTEST).c $(IGETEST).c $(JPAKETEST).c $(V3NAMETEST).c \
-	$(GOST2814789TEST).c
+	$(GOST2814789TEST).c $(P5_CRPT2_TEST).c
 
 EXHEADER= 
 HEADER=	$(EXHEADER)
@@ -190,10 +191,13 @@ alltests: \
 	test_gen test_req test_pkcs7 test_verify test_dh test_dsa \
 	test_ss test_ca test_engine test_evp test_ssl test_tsa test_ige \
 	test_jpake test_srp test_cms test_v3name test_ocsp \
-	test_gost2814789
+	test_gost2814789 test_p5_crpt2
 
 test_evp: $(EVPTEST) evptests.txt
 	../util/shlib_wrap.sh ./$(EVPTEST) evptests.txt
+
+test_p5_crpt2: $(P5_CRPT2_TEST)
+	../util/shlib_wrap.sh ./$(P5_CRPT2_TEST)
 
 test_des: $(DESTEST)
 	../util/shlib_wrap.sh ./$(DESTEST)
@@ -590,6 +594,9 @@ $(ENGINETEST)$(EXE_EXT): $(ENGINETEST).o $(DLIBCRYPTO)
 
 $(EVPTEST)$(EXE_EXT): $(EVPTEST).o $(DLIBCRYPTO)
 	@target=$(EVPTEST); $(BUILD_CMD)
+
+$(P5_CRPT2_TEST)$(EXE_EXT): $(P5_CRPT2_TEST).o $(DLIBCRYPTO)
+	@target=$(P5_CRPT2_TEST); $(BUILD_CMD)
 
 $(ECDSATEST)$(EXE_EXT): $(ECDSATEST).o $(DLIBCRYPTO)
 	@target=$(ECDSATEST); $(BUILD_CMD)


### PR DESCRIPTION
The pull request implements tests for PKCS5_PBKDF2_HMAC() with sha1, sha256 and sha512 digest. The tests are loosely based on evptest.c
