### PR TITLE
FIXED misleading behavior of aes_gcm_cipher() when fed with empty input ...

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1461,7 +1461,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 
 	if (!gctx->iv_set)
 		return -1;
-	if (in)
+	if (in && len)
 		{
 		if (out == NULL)
 			{


### PR DESCRIPTION
...buffer

FIXED misleading difference in behavior of aes_gcm_cipher() when empty input buffer is supplied by means of:
1. setting "in" argument to NULL 
2. and by setting "len" argument to 0