### PR TITLE
Add support for aes-128/192/256-ctr to the cryptodev engine.

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -147,6 +147,9 @@ static struct {
 	{ CRYPTO_AES_CBC,		NID_aes_128_cbc,	16,	16, },
 	{ CRYPTO_AES_CBC,		NID_aes_192_cbc,	16,	24, },
 	{ CRYPTO_AES_CBC,		NID_aes_256_cbc,	16,	32, },
+	{ CRYPTO_AES_CTR,		NID_aes_128_ctr,	14,	16, },
+	{ CRYPTO_AES_CTR,		NID_aes_192_ctr,	14,	24, },
+	{ CRYPTO_AES_CTR,		NID_aes_256_ctr,	14,	32, },
 	{ CRYPTO_BLF_CBC,		NID_bf_cbc,		8,	16, },
 	{ CRYPTO_CAST_CBC,		NID_cast5_cbc,		8,	16, },
 	{ CRYPTO_SKIPJACK_CBC,		NID_undef,		0,	 0, },
@@ -600,6 +603,45 @@ const EVP_CIPHER cryptodev_aes_256_cbc = {
 	NULL
 };
 
+const EVP_CIPHER cryptodev_aes_ctr = {
+	NID_aes_128_ctr,
+	16, 16, 14,
+	EVP_CIPH_CTR_MODE,
+	cryptodev_init_key,
+	cryptodev_cipher,
+	cryptodev_cleanup,
+	sizeof(struct dev_crypto_state),
+	EVP_CIPHER_set_asn1_iv,
+	EVP_CIPHER_get_asn1_iv,
+	NULL
+};
+
+const EVP_CIPHER cryptodev_aes_ctr_192 = {
+	NID_aes_192_ctr,
+	16, 24, 14,
+	EVP_CIPH_CTR_MODE,
+	cryptodev_init_key,
+	cryptodev_cipher,
+	cryptodev_cleanup,
+	sizeof(struct dev_crypto_state),
+	EVP_CIPHER_set_asn1_iv,
+	EVP_CIPHER_get_asn1_iv,
+	NULL
+};
+
+const EVP_CIPHER cryptodev_aes_ctr_256 = {
+	NID_aes_256_ctr,
+	16, 32, 14,
+	EVP_CIPH_CTR_MODE,
+	cryptodev_init_key,
+	cryptodev_cipher,
+	cryptodev_cleanup,
+	sizeof(struct dev_crypto_state),
+	EVP_CIPHER_set_asn1_iv,
+	EVP_CIPHER_get_asn1_iv,
+	NULL
+};
+
 /*
  * Registered by the ENGINE when used to find out how to deal with
  * a particular NID in the ENGINE. this says what we'll do at the
@@ -636,6 +678,15 @@ cryptodev_engine_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
 		break;
 	case NID_aes_256_cbc:
 		*cipher = &cryptodev_aes_256_cbc;
+		break;
+	case NID_aes_128_ctr:
+		*cipher = &cryptodev_aes_ctr;
+		break;
+	case NID_aes_192_ctr:
+		*cipher = &cryptodev_aes_ctr_192;
+		break;
+	case NID_aes_256_ctr:
+		*cipher = &cryptodev_aes_ctr_256;
 		break;
 	default:
 		*cipher = NULL;


### PR DESCRIPTION
This can be used to speed up SRTP with libsrtp, e.g. on TI omap/sitara based devices.
