### PR TITLE
Makes openssl compile with no-sock parameter.

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -785,6 +785,8 @@ static int load_pkcs12(BIO *err, BIO *in, const char *desc,
 	return ret;
 	}
 
+#ifndef OPENSSL_NO_SOCK
+
 int load_cert_crl_http(const char *url, BIO *err,
 					X509 **pcert, X509_CRL **pcrl)
 	{
@@ -847,17 +849,23 @@ int load_cert_crl_http(const char *url, BIO *err,
 	return rv;
 	}
 
+#endif
+
 X509 *load_cert(BIO *err, const char *file, int format,
 	const char *pass, ENGINE *e, const char *cert_descrip)
 	{
 	X509 *x=NULL;
 	BIO *cert;
 
+#ifndef OPENSSL_NO_SOCK
+
 	if (format == FORMAT_HTTP)
 		{
 		load_cert_crl_http(file, err, &x, NULL);
 		return x;
 		}
+
+#endif
 
 	if ((cert=BIO_new(BIO_s_file())) == NULL)
 		{
@@ -934,11 +942,15 @@ X509_CRL *load_crl(const char *infile, int format)
 	X509_CRL *x=NULL;
 	BIO *in=NULL;
 
+#ifndef OPENSSL_NO_SOCK
+
 	if (format == FORMAT_HTTP)
 		{
 		load_cert_crl_http(infile, bio_err, NULL, &x);
 		return x;
 		}
+
+#endif
 
 	in=BIO_new(BIO_s_file());
 	if (in == NULL)

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1321,6 +1321,8 @@ static int send_ocsp_response(BIO *cbio, OCSP_RESPONSE *resp)
 	return 1;
 	}
 
+#ifndef OPENSSL_NO_SOCK
+
 static OCSP_RESPONSE *query_responder(BIO *err, BIO *cbio, const char *path,
 				      const STACK_OF(CONF_VALUE) *headers,
 				      OCSP_REQUEST *req, int req_timeout)
@@ -1467,4 +1469,5 @@ OCSP_RESPONSE *process_responder(BIO *err, OCSP_REQUEST *req,
 	return resp;
 	}
 
+#endif
 #endif

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -63,6 +63,8 @@
 #define USE_SOCKETS
 #include "cryptlib.h"
 
+#ifndef OPENSSL_NO_SOCK
+
 #include <openssl/bio.h>
 #ifndef OPENSSL_NO_DGRAM
 
@@ -1914,4 +1916,5 @@ static void get_current_time(struct timeval *t)
 #endif
 	}
 
+#endif
 #endif


### PR DESCRIPTION
Previously, under Windows VS2008, if the following was executed:

perl Configure VC-WIN32 no-asm no-sock --prefix="C:\Users\Administrator\Documents\openssl\builddir"
perl util\mkdef.pl crypto ssl update
ms\do_ms
nmake -f ms\nt.mak

then the build would fail. This is because not all socket-related functions were under #ifndef OPENSSL_NO_SOCK.

After my changes, the build succeeds, and all tests from running "nmake -f ms\nt.mak test" pass.