### PR TITLE
Fix quoting error in SRP printf

### DIFF
--- a/apps/srp.c
+++ b/apps/srp.c
@@ -483,7 +483,7 @@ bad:
 	/* Lets get the config section we are using */
 		if (section == NULL)
 			{
-			VERBOSE BIO_printf(bio_err,"trying to read " ENV_DEFAULT_SRP " in \" BASE_SECTION \"\n");
+			VERBOSE BIO_printf(bio_err,"trying to read " ENV_DEFAULT_SRP " in " BASE_SECTION "\n");
 
 			section=NCONF_get_string(conf,BASE_SECTION,ENV_DEFAULT_SRP);
 			if (section == NULL)


### PR DESCRIPTION
The code is trying to interpolate the value of the BASE_SECTION macro,
but due to excess escaping, it instead prints the string "BASE_SECTION".