### PR TITLE
clear memory to avoid CVE-2014-0160 (Heartbleed)

### DIFF
--- a/ssl/d1_both.c
+++ b/ssl/d1_both.c
@@ -1362,6 +1362,9 @@ dtls1_process_heartbeat(SSL *s)
 		buffer = OPENSSL_malloc(write_length);
 		bp = buffer;
 
+	        /* clear memory to avoid CVE-2014-0160 */
+                memset(bp, 0x00, write_length);
+
 		/* Enter response type, length and copy payload */
 		*bp++ = TLS1_HB_RESPONSE;
 		s2n(payload, bp);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3994,6 +3994,8 @@ tls1_process_heartbeat(SSL *s)
 		 */
 		buffer = OPENSSL_malloc(1 + 2 + payload + padding);
 		bp = buffer;
+                /* clear memory to avoid CVE-2014-0160 */
+                memset(bp, 0x00, 1 + 2 + payload + padding);
 		
 		/* Enter response type, length and copy payload */
 		*bp++ = TLS1_HB_RESPONSE;


### PR DESCRIPTION
Ensure that the memory buffer used for the heartbeat response is cleared before copying the client-provided contents. This avoids responding with previous memory contents due to e.g. a malicious client providing an input payload that is smaller than the requested length.
