### PR TITLE
Automatically add the Host header when sending an OCSP request.

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -805,6 +805,9 @@ int MAIN(int argc, char **argv)
 	else if (host)
 		{
 #ifndef OPENSSL_NO_SOCK
+                if (!X509V3_add_value("Host", host, &headers))
+                        goto end;
+
 		resp = process_responder(bio_err, req, host, path,
 					port, use_ssl, headers, req_timeout);
 		if (!resp)


### PR DESCRIPTION
Automatically add the Host header when sending an OSCP request over
HTTP to enable support for servers that use name based vhosts.