### PR TITLE
Use resource files when building for VC-CE

### DIFF
--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -463,7 +463,7 @@ LINK=$link
 LFLAGS=$lflags
 RSC=$rsc
 
-# The output directory for everything intersting
+# The output directory for everything interesting
 OUT_D=$out_dir
 # The output directory for all the temporary muck
 TMP_D=$tmp_dir
@@ -632,7 +632,7 @@ printf OUT "  #define DATE \"%s\"\n", scalar gmtime();
 printf OUT "#endif\n";
 close(OUT);
 
-# Strip of trailing ' '
+# Strip off trailing ' '
 foreach (keys %lib_obj) { $lib_obj{$_}=&clean_up_ws($lib_obj{$_}); }
 $test=&clean_up_ws($test);
 $e_exe=&clean_up_ws($e_exe);
@@ -683,7 +683,7 @@ foreach (values %lib_nam)
 	}
 
 # hack to add version info on MSVC
-if (($platform eq "VC-WIN32") || ($platform eq "VC-WIN64A")
+if (($platform eq "VC-WIN32") || ($platform eq "VC-WIN64A") || ($platform eq "VC-CE")
 	|| ($platform eq "VC-WIN64I") || ($platform eq "VC-NT")) {
     $rules.= <<"EOF";
 \$(OBJ_D)\\\$(CRYPTO).res: ms\\version32.rc
@@ -908,7 +908,8 @@ sub do_defs
 		$ret.=$t;
 		}
 	# hack to add version info on MSVC
-	if ($shlib && (($platform eq "VC-WIN32") || ($platfrom eq "VC-WIN64I") || ($platform eq "VC-WIN64A") || ($platform eq "VC-NT")))
+	if ($shlib && (($platform eq "VC-WIN32") || ($platfrom eq "VC-WIN64I") || ($platform eq "VC-CE")
+	 || ($platform eq "VC-WIN64A") || ($platform eq "VC-NT")))
 		{
 		if ($var eq "CRYPTOOBJ")
 			{ $ret.="\$(OBJ_D)\\\$(CRYPTO).res "; }


### PR DESCRIPTION
This change simply adds the ability to build for Windows CE
and still have a version resource file used.

Plus a couple of spelling errors in comments are fixed.

Change-Id: I7cc6a67b01109b1eeb7c30c53b47362495888347