### PR TITLE
Fix version documentation (cherry pick for 0.9.8)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
  Changes between 0.9.8y and 0.9.8za [xx XXX xxxx]
 
+  *) Harmonize version and its documentation. -f flag is used to display
+     compilation flags.
+     [mancha <mancha1@zoho.com>]
+
   *) Fix for the attack described in the paper "Recovering OpenSSL
      ECDSA Nonces Using the FLUSH+RELOAD Cache Side-channel Attack"
      by Yuval Yarom and Naomi Benger. Details can be obtained from:

--- a/doc/apps/version.pod
+++ b/doc/apps/version.pod
@@ -13,6 +13,7 @@ B<openssl version>
 [B<-o>]
 [B<-f>]
 [B<-p>]
+[B<-d>]
 
 =head1 DESCRIPTION
 
@@ -38,7 +39,7 @@ the date the current version of OpenSSL was built.
 
 option information: various options set when the library was built.
 
-=item B<-c>
+=item B<-f>
 
 compilation flags.
 


### PR DESCRIPTION
Specify -f is for compilation flags. Add -d to synopsis section.

(cherry picked from commit 8acb953880bc7fc5ed4e339de06dff0a213fa274)

Conflicts:
	CHANGES