### PR TITLE
Prevent the compiler from converting "secure" memcmp() into canonical one.

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -401,8 +401,11 @@ void *OPENSSL_stderr(void)	{ return stderr; }
 int CRYPTO_memcmp(const void *in_a, const void *in_b, size_t len)
 	{
 	size_t i;
-	const unsigned char *a = in_a;
-	const unsigned char *b = in_b;
+	/* Must use "pointers to volatile" to tell the compiler to never
+	 * attempt optimizing the reads. Otherwise the compiler is allowed
+	 * to use LTO and convert this function into canonical version. */
+	const volatile unsigned char *a = in_a;
+	const volatile unsigned char *b = in_b;
 	unsigned char x = 0;
 
 	for (i = 0; i < len; i++)


### PR DESCRIPTION
Current implementation of "secure" memcmp() is not that secure - the compiler can use LTO and see that the calling code only tests for zero values and then convert it into canonical, not "secure" version.