### PR TITLE
Fixed problem with multiple load-unload of comp zlib

### DIFF
--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -416,8 +416,13 @@ err:
 void COMP_zlib_cleanup(void)
 	{
 #ifdef ZLIB_SHARED
-	if (zlib_dso)
-		DSO_free(zlib_dso);
+    if (zlib_loaded){
+	    if (zlib_dso){
+		    DSO_free(zlib_dso);
+            zlib_dso = NULL;
+        }
+        zlib_loaded = 0;
+    }
 #endif
 	}
 


### PR DESCRIPTION
Executing COMP_zlib_cleanup() to remove a memory leak did not allow to reload the comp zlib again.