### PR TITLE
Heartbeat test

### DIFF
--- a/ssl/heartbeat_test.c
+++ b/ssl/heartbeat_test.c
@@ -44,6 +44,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef OPENSSL_NO_HEARTBEATS
+
 /* As per https://tools.ietf.org/html/rfc6520#section-4 */
 #define MIN_PADDING_SIZE	16
 
@@ -453,3 +455,11 @@ int main(int argc, char *argv[])
 		}
 	return EXIT_SUCCESS;
 	}
+
+#else /* OPENSSL_NO_HEARTBEATS*/
+
+int main(int argc, char *argv[])
+	{
+		return EXIT_SUCCESS;
+	}
+#endif /* OPENSSL_NO_HEARTBEATS */


### PR DESCRIPTION
Fix for heartbeat_test compile failure when -DOPENSSL_NO_HEARTBEATS is defined. Problem reported on 2014-05-22 by Lukas Tribus on openssl-dev. Ported to OpenSSL_1_0_1-stable and OpenSSL_1_0_2-stable as well.
