### PR TITLE
Properly handle RFC5280 DNS Name Constraints that start with a dot as in mozilla::pkix

### DIFF
--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -395,13 +395,13 @@ static int nc_dns(ASN1_IA5STRING *dns, ASN1_IA5STRING *base)
 	if (!*baseptr)
 		return X509_V_OK;
 	/* Otherwise can add zero or more components on the left so
-	 * compare RHS and if dns is longer and expect '.' as preceding
-	 * character.
+	 * compare RHS and if dns is longer, expect '.' either as preceding
+	 * character in dns name or leading character in base constraint.
 	 */
 	if (dns->length > base->length)
 		{
 		dnsptr += dns->length - base->length;
-		if (dnsptr[-1] != '.')
+		if (!(dnsptr[-1] != '.' != baseptr[0] != '.'))
 			return X509_V_ERR_PERMITTED_VIOLATION;
 		}
 


### PR DESCRIPTION
Stock openssl breaks when enforcing DNS restrictions that start with a leading dot (e.g. 'DNS:.foo.bar' ). This does not work well with CAs that SHOULD NOT be able to sign certs for any domain such as "foo.bar" itself, but SHOULD be able to sign certs for subdomain-only DNS names, such as "host.foo.bar".
This commit allows strict DNS restrictions to be enforced properly by openssl. 
These restrictions are already supported by mozilla::pkix https://hg.mozilla.org/mozilla-central/file/e9b2b72f4e6c/security/nss/lib/certdb/genname.c:1216