### PR TITLE
Possibility to bind connection to local interface: ticket #2578

### DIFF
--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -168,13 +168,13 @@ int ssl_print_point_formats(BIO *out, SSL *s);
 int ssl_print_curves(BIO *out, SSL *s, int noshared);
 #endif
 int ssl_print_tmp_key(BIO *out, SSL *s);
-int init_client(int *sock, const char *remote_host, int port, const char* local_host, int type);
+int init_client(int *sock, const char *remote_host, int port, const char* local_host, unsigned short local_port, int type);
 #ifndef NO_SYS_UN_H
 int init_client_unix(int *sock, const char *server);
 #endif
 int should_retry(int i);
-int extract_port(const char *str, short *port_ptr);
-int extract_host_port(char *str,char **host_ptr,unsigned char *ip,short *p);
+int extract_port(const char *str, unsigned short *port_ptr);
+int extract_host_port(char *str,char **host_ptr,unsigned char *ip,unsigned short *p, short port_required);
 
 long MS_CALLBACK bio_dump_callback(BIO *bio, int cmd, const char *argp,
 				   int argi, long argl, long ret);

--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -168,7 +168,7 @@ int ssl_print_point_formats(BIO *out, SSL *s);
 int ssl_print_curves(BIO *out, SSL *s, int noshared);
 #endif
 int ssl_print_tmp_key(BIO *out, SSL *s);
-int init_client(int *sock, const char *server, int port, int type);
+int init_client(int *sock, const char *remote_host, int port, const char* local_host, int type);
 #ifndef NO_SYS_UN_H
 int init_client_unix(int *sock, const char *server);
 #endif

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -324,7 +324,7 @@ static void sc_usage(void)
 	BIO_printf(bio_err," -host host     - use -connect instead\n");
 	BIO_printf(bio_err," -port port     - use -connect instead\n");
 	BIO_printf(bio_err," -connect host:port - connect over TCP/IP (default is %s:%s)\n",SSL_HOST_NAME,PORT_STR);
-	BIO_printf(bio_err," -localip arg  - specify local address to use\n");
+	BIO_printf(bio_err," -bind IP:port  - specify local IP and optionally port to use\n");
 	BIO_printf(bio_err," -unix path    - connect over unix domain sockets\n");
 	BIO_printf(bio_err," -verify arg   - turn on peer certificate verification\n");
 	BIO_printf(bio_err," -cert arg     - certificate file to use, PEM format assumed\n");
@@ -626,10 +626,11 @@ int MAIN(int argc, char **argv)
 	int cbuf_len,cbuf_off;
 	int sbuf_len,sbuf_off;
 	fd_set readfds,writefds;
-	short port=PORT;
 	int full_log=1;
 	char *remote_host=SSL_HOST_NAME;
 	char *local_ip=NULL;
+	unsigned short remote_port=PORT;
+	unsigned short local_port=0;
 	const char *unix_path = NULL;
 	char *xmpphost = NULL;
 	char *cert_file=NULL,*key_file=NULL,*chain_file=NULL;
@@ -755,19 +756,20 @@ static char *jpake_secret = NULL;
 		else if	(strcmp(*argv,"-port") == 0)
 			{
 			if (--argc < 1) goto bad;
-			port=atoi(*(++argv));
-			if (port == 0) goto bad;
+			remote_port=atoi(*(++argv));
+			if (remote_port == 0) goto bad;
 			}
 		else if (strcmp(*argv,"-connect") == 0)
 			{
 			if (--argc < 1) goto bad;
-			if (!extract_host_port(*(++argv),&remote_host,NULL,&port))
+			if (!extract_host_port(*(++argv),&remote_host,NULL,&remote_port,1))
 				goto bad;
 			}
-		else if (strcmp(*argv,"-localip") == 0)
+		else if (strcmp(*argv,"-bind") == 0)
 			{
 			if (--argc < 1) goto bad;
-				local_ip=*(++argv);
+			if( !extract_host_port(*(++argv),&local_ip,NULL,&local_port,0) )
+				goto bad;
 			}
 		else if (strcmp(*argv,"-unix") == 0)
 			{
@@ -1518,7 +1520,7 @@ bad:
 
 re_start:
 
-	if ((!unix_path && (init_client(&s,remote_host,port,local_ip,socket_type) == 0)) ||
+	if ((!unix_path && (init_client(&s,remote_host,remote_port,local_ip,local_port,socket_type) == 0)) ||
 			(unix_path && (init_client_unix(&s,unix_path) == 0)))
 		{
 		BIO_printf(bio_err,"connect:errno=%d\n",get_last_socket_error());

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -324,6 +324,7 @@ static void sc_usage(void)
 	BIO_printf(bio_err," -host host     - use -connect instead\n");
 	BIO_printf(bio_err," -port port     - use -connect instead\n");
 	BIO_printf(bio_err," -connect host:port - connect over TCP/IP (default is %s:%s)\n",SSL_HOST_NAME,PORT_STR);
+	BIO_printf(bio_err," -localip arg  - specify local address to use\n");
 	BIO_printf(bio_err," -unix path    - connect over unix domain sockets\n");
 	BIO_printf(bio_err," -verify arg   - turn on peer certificate verification\n");
 	BIO_printf(bio_err," -cert arg     - certificate file to use, PEM format assumed\n");
@@ -627,7 +628,8 @@ int MAIN(int argc, char **argv)
 	fd_set readfds,writefds;
 	short port=PORT;
 	int full_log=1;
-	char *host=SSL_HOST_NAME;
+	char *remote_host=SSL_HOST_NAME;
+	char *local_ip=NULL;
 	const char *unix_path = NULL;
 	char *xmpphost = NULL;
 	char *cert_file=NULL,*key_file=NULL,*chain_file=NULL;
@@ -748,7 +750,7 @@ static char *jpake_secret = NULL;
 		if	(strcmp(*argv,"-host") == 0)
 			{
 			if (--argc < 1) goto bad;
-			host= *(++argv);
+			remote_host= *(++argv);
 			}
 		else if	(strcmp(*argv,"-port") == 0)
 			{
@@ -759,8 +761,13 @@ static char *jpake_secret = NULL;
 		else if (strcmp(*argv,"-connect") == 0)
 			{
 			if (--argc < 1) goto bad;
-			if (!extract_host_port(*(++argv),&host,NULL,&port))
+			if (!extract_host_port(*(++argv),&remote_host,NULL,&port))
 				goto bad;
+			}
+		else if (strcmp(*argv,"-localip") == 0)
+			{
+			if (--argc < 1) goto bad;
+				local_ip=*(++argv);
 			}
 		else if (strcmp(*argv,"-unix") == 0)
 			{
@@ -1499,7 +1506,7 @@ bad:
 	if (con  &&  (kctx = kssl_ctx_new()) != NULL)
                 {
 		SSL_set0_kssl_ctx(con, kctx);
-                kssl_ctx_setstring(kctx, KSSL_SERVER, host);
+                kssl_ctx_setstring(kctx, KSSL_SERVER, remote_host);
 		}
 #endif	/* OPENSSL_NO_KRB5  */
 /*	SSL_set_cipher_list(con,"RC4-MD5"); */
@@ -1511,7 +1518,7 @@ bad:
 
 re_start:
 
-	if ((!unix_path && (init_client(&s,host,port,socket_type) == 0)) ||
+	if ((!unix_path && (init_client(&s,remote_host,port,local_ip,socket_type) == 0)) ||
 			(unix_path && (init_client_unix(&s,unix_path) == 0)))
 		{
 		BIO_printf(bio_err,"connect:errno=%d\n",get_last_socket_error());
@@ -1735,7 +1742,7 @@ SSL_set_tlsext_status_ids(con, ids);
 		BIO_printf(sbio,"<stream:stream "
 		    "xmlns:stream='http://etherx.jabber.org/streams' "
 		    "xmlns='jabber:client' to='%s' version='1.0'>", xmpphost ?
-			   xmpphost : host);
+			   xmpphost : remote_host);
 		seen = BIO_read(sbio,mbuf,BUFSIZZ);
 		mbuf[seen] = 0;
 		while (!strstr(mbuf, "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'") &&

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1009,7 +1009,7 @@ int MAIN(int argc, char *argv[])
 	{
 	X509_VERIFY_PARAM *vpm = NULL;
 	int badarg = 0;
-	short port=PORT;
+	unsigned short port=PORT;
 	const char *unix_path=NULL;
 	int unlink_unix_path=0;
 	int (*server_cb)(char *hostname, int s, int stype, unsigned char *context);

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -96,8 +96,8 @@ static struct hostent *GetHostByName(const char *name);
 static void ssl_sock_cleanup(void);
 #endif
 static int ssl_sock_init(void);
-static int init_client_ip(int *sock, const unsigned char ip[4], int port,
-			  int type);
+static int init_client_ip(int *sock, const unsigned char remote_ip[4], int port,
+			  const unsigned char local_ip[4], int type);
 static int init_server(int *sock, int port, int type);
 static int init_server_long(int *sock, int port,char *ip, int type);
 static int do_accept(int acc_sock, int *sock, char **host);
@@ -233,18 +233,24 @@ static int ssl_sock_init(void)
 	return(1);
 	}
 
-int init_client(int *sock, const char *host, int port, int type)
+int init_client(int *sock, const char *remote_host, int port, const char *local_host, int type)
 	{
-	unsigned char ip[4];
+	unsigned char remote_ip[4];
+	unsigned char local_ip[4];
 
-	ip[0] = ip[1] = ip[2] = ip[3] = 0;
-	if (!host_ip(host,&(ip[0])))
+	remote_ip[0] = remote_ip[1] = remote_ip[2] = remote_ip[3] = 0;
+	if (!host_ip(remote_host,&(remote_ip[0])))
 		return 0;
-	return init_client_ip(sock,ip,port,type);
+
+	local_ip[0] = local_ip[1] = local_ip[2] = local_ip[3] = 0;
+	if (local_host!=NULL && !host_ip(local_host,&(local_ip[0])))
+		return 0;
+
+	return init_client_ip(sock,remote_ip,port,local_ip,type);
 	}
 
-static int init_client_ip(int *sock, const unsigned char ip[4], int port,
-			  int type)
+static int init_client_ip(int *sock, const unsigned char remote_ip[4], int port,
+			  const unsigned char local_ip[4], int type)
 	{
 	unsigned long addr;
 	struct sockaddr_in them;
@@ -256,10 +262,10 @@ static int init_client_ip(int *sock, const unsigned char ip[4], int port,
 	them.sin_family=AF_INET;
 	them.sin_port=htons((unsigned short)port);
 	addr=(unsigned long)
-		((unsigned long)ip[0]<<24L)|
-		((unsigned long)ip[1]<<16L)|
-		((unsigned long)ip[2]<< 8L)|
-		((unsigned long)ip[3]);
+		((unsigned long)remote_ip[0]<<24L)|
+		((unsigned long)remote_ip[1]<<16L)|
+		((unsigned long)remote_ip[2]<< 8L)|
+		((unsigned long)remote_ip[3]);
 	them.sin_addr.s_addr=htonl(addr);
 
 	if (type == SOCK_STREAM)
@@ -277,7 +283,21 @@ static int init_client_ip(int *sock, const unsigned char ip[4], int port,
 		if (i < 0) { closesocket(s); perror("keepalive"); return(0); }
 		}
 #endif
+	if(0!=local_ip[0])
+		{
+		struct sockaddr_in me;
+		memset((char*)&me,0,sizeof(me));
+		me.sin_family = AF_INET;
+		addr=(unsigned long)
+			((unsigned long)local_ip[0]<<24L)|
+			((unsigned long)local_ip[1]<<16L)|
+			((unsigned long)local_ip[2]<< 8L)|
+			((unsigned long)local_ip[3]);
+		me.sin_addr.s_addr = htonl(addr);
 
+		if( bind(s,(struct sockaddr *)&me,sizeof(me)) == -1 )
+			{ closesocket(s); perror("bind"); return(0); }
+		}
 	if (connect(s,(struct sockaddr *)&them,sizeof(them)) == -1)
 		{ closesocket(s); perror("connect"); return(0); }
 	*sock=s;

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -9,7 +9,7 @@ s_client - SSL/TLS client program
 
 B<openssl> B<s_client>
 [B<-connect host:port>]
-[B<-localip IP>]
+[B<-bind IP:port>]
 [B<-verify depth>]
 [B<-verify_return_error>]
 [B<-cert filename>]
@@ -70,10 +70,11 @@ manual page.
 This specifies the host and optional port to connect to. If not specified
 then an attempt is made to connect to the local host on port 4433.
 
-=item B<-localip IP>
+=item B<-bind IP:port>
 
-This optional argument specifies IP address assigned to another interface 
-then the one which connect(2) chooses by default. 
+This argument specifies IP address and optionally a port assigned to another
+interface then the one which connect(2) chooses by default. If port parameter
+is not provided, then port from ephemeral port range is used. 
 
 =item B<-cert certname>
 

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -9,6 +9,7 @@ s_client - SSL/TLS client program
 
 B<openssl> B<s_client>
 [B<-connect host:port>]
+[B<-localip IP>]
 [B<-verify depth>]
 [B<-verify_return_error>]
 [B<-cert filename>]
@@ -68,6 +69,11 @@ manual page.
 
 This specifies the host and optional port to connect to. If not specified
 then an attempt is made to connect to the local host on port 4433.
+
+=item B<-localip IP>
+
+This optional argument specifies IP address assigned to another interface 
+then the one which connect(2) chooses by default. 
 
 =item B<-cert certname>
 


### PR DESCRIPTION
This patch implements possibility to specify source IP in s_client from which connection should be made. Feature is useful in case when machines has many network interfaces and user wants to make connection from interface that is not used by default.
