### PR TITLE
Fix wrong numbers being passed as string lengths

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3022,7 +3022,7 @@ static int www_body(char *hostname, int s, int stype, unsigned char *context)
 
 		/* else we have data */
 		if (	((www == 1) && (strncmp("GET ",buf,4) == 0)) ||
-			((www == 2) && (strncmp("GET /stats ",buf,10) == 0)))
+			((www == 2) && (strncmp("GET /stats ",buf,11) == 0)))
 			{
 			char *p;
 			X509 *peer;

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -368,7 +368,7 @@ static int asn1_cb(const char *elem, int len, void *bitstr)
 			arg->format = ASN1_GEN_FORMAT_UTF8;
 		else if (!strncmp(vstart, "HEX", 3))
 			arg->format = ASN1_GEN_FORMAT_HEX;
-		else if (!strncmp(vstart, "BITLIST", 3))
+		else if (!strncmp(vstart, "BITLIST", 7))
 			arg->format = ASN1_GEN_FORMAT_BITLIST;
 		else
 			{

--- a/crypto/asn1/asn1_par.c
+++ b/crypto/asn1/asn1_par.c
@@ -375,7 +375,7 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length, int offse
 					}
 				else
 					{
-					if (BIO_write(bp,"BAD ENUMERATED",11) <= 0)
+					if (BIO_write(bp,"BAD ENUMERATED",14) <= 0)
 						goto end;
 					}
 				M_ASN1_ENUMERATED_free(bs);


### PR DESCRIPTION
This resolves https://github.com/openssl/openssl/issues/43 and one more similar problem outlined in http://www.viva64.com/en/b/0250/