### PR TITLE
add ECC strings to ciphers(1), point out difference between DH and ECDH

### DIFF
--- a/doc/apps/ciphers.pod
+++ b/doc/apps/ciphers.pod
@@ -184,6 +184,8 @@ included.
 the cipher suites offering no authentication. This is currently the anonymous
 DH algorithms and anonymous ECDH algorithms. These cipher suites are vulnerable
 to a "man in the middle" attack and so their use is normally discouraged.
+It also includes SRP cipher suites that do not use server certificates
+for additional authentication.
 
 =item B<kRSA>, B<aRSA>, B<RSA>
 


### PR DESCRIPTION
- Make a clear distinction between DH and ECDH key exchange.
- Group all key exchange cipher suite identifiers, first DH then ECDH
- add descriptions for all supported `*DH*` identifiers
- add ECDSA authentication descriptions
- add example showing how to disable all suites that offer no
  authentication or encryption
