### PR TITLE
document -nextprotoneg option in man pages

### DIFF
--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -48,6 +48,7 @@ B<openssl> B<s_client>
 [B<-serverinfo types>]
 [B<-auth>]
 [B<-auth_require_reneg>]
+[B<-nextprotoneg protocols>]
 
 =head1 DESCRIPTION
 
@@ -288,6 +289,17 @@ supplemental data if the server also sent the authorization extensions in the Se
 =item B<-auth_require_reneg>
 
 only send RFC 5878 client and server authorization extensions during renegotiation.
+
+=item B<-nextprotoneg protocols>
+
+enable Next Protocol Negotiation TLS extension and provide a list of
+comma-separated protocol names that the client should advertise
+support for. The list should contain most wanted protocols first.
+Protocol names are printable ASCII strings, for example "http/1.1" or
+"spdy/3".
+Empty list of protocols is treated specially and will cause the client to
+advertise support for the TLS extension but disconnect just after
+reciving ServerHello with a list of server supported protocols.
 
 =back
 

--- a/doc/apps/s_server.pod
+++ b/doc/apps/s_server.pod
@@ -61,6 +61,8 @@ B<openssl> B<s_server>
 [B<-auth>]
 [B<-auth_require_reneg>]
 [B<-no_resumption_on_reneg>]
+[B<-nextprotoneg protocols>]
+
 =head1 DESCRIPTION
 
 The B<s_server> command implements a generic SSL/TLS server which listens
@@ -336,6 +338,14 @@ only send RFC 5878 client and server authorization extensions during renegotiati
 
 set SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION flag.  Required in order to receive supplemental data
 during renegotiation if auth and auth_require_reneg are set.
+
+=item B<-nextprotoneg protocols>
+
+enable Next Protocol Negotiation TLS extension and provide a
+comma-separated list of supported protocol names.
+The list should contain most wanted protocols first.
+Protocol names are printable ASCII strings, for example "http/1.1" or
+"spdy/3".
 
 =back
 


### PR DESCRIPTION
Add description of the option to advertise support of
Next Protocol Negotiation extension (-nextprotoneg) to
man pages of s_client and s_server.
