### PR TITLE
Document -trusted_first option in man pages and help.

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -716,6 +716,7 @@ int MAIN(int argc, char **argv)
 		BIO_printf (bio_err, "-text          include or delete text MIME headers\n");
 		BIO_printf (bio_err, "-CApath dir    trusted certificates directory\n");
 		BIO_printf (bio_err, "-CAfile file   trusted certificates file\n");
+		BIO_printf (bio_err, "-trusted_first use locally trusted certificates first when building trust chain\n");
 		BIO_printf (bio_err, "-crl_check     check revocation status of signer's certificate using CRLs\n");
 		BIO_printf (bio_err, "-crl_check_all check revocation status of signer's certificate chain using CRLs\n");
 #ifndef OPENSSL_NO_ENGINE

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -626,6 +626,7 @@ int MAIN(int argc, char **argv)
 		BIO_printf (bio_err, "-path              path to use in OCSP request\n");
 		BIO_printf (bio_err, "-CApath dir        trusted certificates directory\n");
 		BIO_printf (bio_err, "-CAfile file       trusted certificates file\n");
+		BIO_printf (bio_err, "-trusted_first     use locally trusted CA's first when building trust chain\n");
 		BIO_printf (bio_err, "-VAfile file       validator certificates file\n");
 		BIO_printf (bio_err, "-validity_period n maximum validity discrepancy in seconds\n");
 		BIO_printf (bio_err, "-status_age n      maximum status age in seconds\n");

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -334,6 +334,7 @@ static void sc_usage(void)
 	BIO_printf(bio_err," -pass arg     - private key file pass phrase source\n");
 	BIO_printf(bio_err," -CApath arg   - PEM format directory of CA's\n");
 	BIO_printf(bio_err," -CAfile arg   - PEM format file of CA's\n");
+	BIO_printf(bio_err," -trusted_first - Use local CA's first when building trust chain\n");
 	BIO_printf(bio_err," -reconnect    - Drop and re-make the connection with the same Session-ID\n");
 	BIO_printf(bio_err," -pause        - sleep(1) after each read(2) and write(2) system call\n");
 	BIO_printf(bio_err," -showcerts    - show all certificates in the chain\n");

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -526,6 +526,7 @@ static void sv_usage(void)
 	BIO_printf(bio_err," -state        - Print the SSL states\n");
 	BIO_printf(bio_err," -CApath arg   - PEM format directory of CA's\n");
 	BIO_printf(bio_err," -CAfile arg   - PEM format file of CA's\n");
+	BIO_printf(bio_err," -trusted_first - Use locally trusted CA's first when building trust chain\n");
 	BIO_printf(bio_err," -nocert       - Don't use any certificates (Anon-DH)\n");
 	BIO_printf(bio_err," -cipher arg   - play with 'openssl ciphers' to see what goes here\n");
 	BIO_printf(bio_err," -serverpref   - Use server's cipher preferences\n");

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -179,6 +179,7 @@ static void s_time_usage(void)
                 file if not specified by this option\n\
 -CApath arg   - PEM format directory of CA's\n\
 -CAfile arg   - PEM format file of CA's\n\
+-trusted_first - Use locally trusted CA's first when building trust chain\n\
 -cipher       - preferred cipher to use, play with 'openssl ciphers'\n\n";
 
 	printf( "usage: s_time <args>\n\n" );

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -479,6 +479,7 @@ int MAIN(int argc, char **argv)
 		BIO_printf (bio_err, "-text          include or delete text MIME headers\n");
 		BIO_printf (bio_err, "-CApath dir    trusted certificates directory\n");
 		BIO_printf (bio_err, "-CAfile file   trusted certificates file\n");
+		BIO_printf (bio_err, "-trusted_first use locally trusted CA's first when building trust chain\n");
 		BIO_printf (bio_err, "-crl_check     check revocation status of signer's certificate using CRLs\n");
 		BIO_printf (bio_err, "-crl_check_all check revocation status of signer's certificate chain using CRLs\n");
 #ifndef OPENSSL_NO_ENGINE

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -383,7 +383,7 @@ int MAIN(int argc, char **argv)
 		   "ts -verify [-data file_to_hash] [-digest digest_bytes] "
 		   "[-queryfile request.tsq] "
 		   "-in response.tsr [-token_in] "
-		   "-CApath ca_path -CAfile ca_file.pem "
+		   "-CApath ca_path -CAfile ca_file.pem -trusted_first"
 		   "-untrusted cert_file.pem\n");
  cleanup:
 	/* Clean up. */

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -245,7 +245,7 @@ int MAIN(int argc, char **argv)
 
 end:
 	if (ret == 1) {
-		BIO_printf(bio_err,"usage: verify [-verbose] [-CApath path] [-CAfile file] [-purpose purpose] [-crl_check]");
+		BIO_printf(bio_err,"usage: verify [-verbose] [-CApath path] [-CAfile file] [-trusted_first] [-purpose purpose] [-crl_check]");
 #ifndef OPENSSL_NO_ENGINE
 		BIO_printf(bio_err," [-engine e]");
 #endif

--- a/doc/apps/cms.pod
+++ b/doc/apps/cms.pod
@@ -35,6 +35,7 @@ B<openssl> B<cms>
 [B<-print>]
 [B<-CAfile file>]
 [B<-CApath dir>]
+[B<-trusted_first>]
 [B<-md digest>]
 [B<-[cipher]>]
 [B<-nointern>]
@@ -244,6 +245,12 @@ a directory containing trusted CA certificates, only used with
 B<-verify>. This directory must be a standard certificate directory: that
 is a hash of each subject name (using B<x509 -hash>) should be linked
 to each certificate.
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory before untrusted certificates
+from the message when building the trust chain to verify certificates.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-md digest>
 

--- a/doc/apps/ocsp.pod
+++ b/doc/apps/ocsp.pod
@@ -29,6 +29,7 @@ B<openssl> B<ocsp>
 [B<-path>]
 [B<-CApath dir>]
 [B<-CAfile file>]
+[B<-trusted_first>]
 [B<-VAfile file>]
 [B<-validity_period n>]
 [B<-status_age n>]
@@ -137,6 +138,13 @@ or "/" by default.
 
 file or pathname containing trusted CA certificates. These are used to verify
 the signature on the OCSP response.
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory over certificates provided
+in the response or residing in other certificates file when building the trust
+chain to verify responder certificate.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-verify_other file>
 

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -18,6 +18,7 @@ B<openssl> B<s_client>
 [B<-pass arg>]
 [B<-CApath directory>]
 [B<-CAfile filename>]
+[B<-trusted_first>]
 [B<-reconnect>]
 [B<-pause>]
 [B<-showcerts>]
@@ -116,7 +117,7 @@ also used when building the client certificate chain.
 A file containing trusted certificates to use during server authentication
 and to use when attempting to build the client certificate chain.
 
-=item B<-purpose, -ignore_critical, -issuer_checks, -crl_check, -crl_check_all, -policy_check, -extended_crl, -x509_strict, -policy -check_ss_sig>
+=item B<-purpose, -ignore_critical, -issuer_checks, -crl_check, -crl_check_all, -policy_check, -extended_crl, -x509_strict, -policy -check_ss_sig, -trusted_first>
 
 Set various certificate chain valiadition option. See the
 L<B<verify>|verify(1)> manual page for details.

--- a/doc/apps/s_server.pod
+++ b/doc/apps/s_server.pod
@@ -34,6 +34,7 @@ B<openssl> B<s_server>
 [B<-state>]
 [B<-CApath directory>]
 [B<-CAfile filename>]
+[B<-trusted_first>]
 [B<-nocert>]
 [B<-cipher cipherlist>]
 [B<-quiet>]
@@ -182,6 +183,12 @@ A file containing trusted certificates to use during client authentication
 and to use when attempting to build the server certificate chain. The list
 is also used in the list of acceptable client CAs passed to the client when
 a certificate is requested.
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory before certificates in untrusted
+file when building the trust chain to verify client certificates.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-state>
 

--- a/doc/apps/s_time.pod
+++ b/doc/apps/s_time.pod
@@ -14,6 +14,7 @@ B<openssl> B<s_time>
 [B<-key filename>]
 [B<-CApath directory>]
 [B<-CAfile filename>]
+[B<-trusted_first>]
 [B<-reuse>]
 [B<-new>]
 [B<-verify depth>]
@@ -75,6 +76,12 @@ also used when building the client certificate chain.
 
 A file containing trusted certificates to use during server authentication
 and to use when attempting to build the client certificate chain.
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory over certificates provided
+by the server when building the trust chain to verify server certificate.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-new>
 

--- a/doc/apps/smime.pod
+++ b/doc/apps/smime.pod
@@ -15,6 +15,9 @@ B<openssl> B<smime>
 [B<-pk7out>]
 [B<-[cipher]>]
 [B<-in file>]
+[B<-CAfile file>]
+[B<-CApath dir>]
+[B<-trusted_first>]
 [B<-certfile file>]
 [B<-signer file>]
 [B<-recip  file>]
@@ -145,6 +148,12 @@ a directory containing trusted CA certificates, only used with
 B<-verify>. This directory must be a standard certificate directory: that
 is a hash of each subject name (using B<x509 -hash>) should be linked
 to each certificate.
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory over certificates provided
+in the message when building the trust chain to verify server certificate.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-md digest>
 

--- a/doc/apps/ts.pod
+++ b/doc/apps/ts.pod
@@ -46,6 +46,7 @@ B<-verify>
 [B<-token_in>]
 [B<-CApath> trusted_cert_path]
 [B<-CAfile> trusted_certs.pem]
+[B<-trusted_first>]
 [B<-untrusted> cert_file.pem]
 
 =head1 DESCRIPTION
@@ -315,7 +316,6 @@ The name of the directory containing the trused CA certificates of the
 client. See the similar option of L<verify(1)|verify(1)> for additional
 details. Either this option or B<-CAfile> must be specified. (Optional)
 
-
 =item B<-CAfile> trusted_certs.pem
 
 The name of the file containing a set of trusted self-signed CA 
@@ -323,6 +323,12 @@ certificates in PEM format. See the similar option of
 L<verify(1)|verify(1)> for additional details. Either this option 
 or B<-CApath> must be specified.
 (Optional)
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory before certificates in untrusted
+file when building the trust chain to verify certificates.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-untrusted> cert_file.pem
 

--- a/doc/apps/verify.pod
+++ b/doc/apps/verify.pod
@@ -9,6 +9,7 @@ verify - Utility to verify certificates.
 B<openssl> B<verify>
 [B<-CApath directory>]
 [B<-CAfile file>]
+[B<-trusted_first>]
 [B<-purpose purpose>]
 [B<-policy arg>]
 [B<-ignore_critical>]
@@ -56,6 +57,12 @@ in PEM format concatenated together.
 
 A file of untrusted certificates. The file should contain multiple certificates
 in PEM format concatenated together.
+
+=item B<-trusted_first>
+
+Use certificates in CA file or CA directory before certificates in untrusted
+file when building the trust chain to verify certificates.
+This is mainly useful in environments with Bridge CA or Cross-Certified CAs.
 
 =item B<-purpose purpose>
 


### PR DESCRIPTION
Add -trusted_first description to help messages and man pages
of tools that deal with certificate verification.
