### PR TITLE
Create ~/.rnd with mode 0600 instead of 0666

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -80,6 +80,7 @@
 #endif
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>
+# include <fcntl.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
Because of a missing include <fcntl.h> we don't have O_CREATE and don't create
the file with open() using mode 0600 but fall back to using fopen() with the
default umask followed by a chmod().

Problem found by Jakub Wilk jwilk@debian.org.
