### PR TITLE
x86_64 asm: fix bn_mul_mont on odd-len BNs

### DIFF
--- a/crypto/bn/asm/x86_64-mont.pl
+++ b/crypto/bn/asm/x86_64-mont.pl
@@ -174,7 +174,7 @@ $code.=<<___;
 
 	mulq	$m1			# np[j]*m1
 	cmp	$num,$j
-	jne	.L1st
+	jl	.L1st
 
 	add	%rax,$hi1
 	mov	($ap),%rax		# ap[0]
@@ -240,7 +240,7 @@ $code.=<<___;
 
 	mulq	$m1			# np[j]*m1
 	cmp	$num,$j
-	jne	.Linner
+	jl	.Linner
 
 	add	%rax,$hi1
 	mov	($ap),%rax		# ap[0]

--- a/crypto/bn/asm/x86_64-mont5.pl
+++ b/crypto/bn/asm/x86_64-mont5.pl
@@ -207,7 +207,7 @@ $code.=<<___;
 
 	mulq	$m1			# np[j]*m1
 	cmp	$num,$j
-	jne	.L1st
+	jl	.L1st
 
 	movq	%xmm0,$m0		# bp[1]
 
@@ -290,7 +290,7 @@ $code.=<<___;
 
 	mulq	$m1			# np[j]*m1
 	cmp	$num,$j
-	jne	.Linner
+	jl	.Linner
 
 	movq	%xmm0,$m0		# bp[i+1]
 


### PR DESCRIPTION
Fix index overflow in bn_mul_mont and bn_mul_mont_gather5.