### PR TITLE
document -nextprotoneg option in man pages

### DIFF
--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -77,6 +77,7 @@ B<openssl> B<s_client>
 [B<-rand file(s)>]
 [B<-serverinfo types>]
 [B<-status>]
+[B<-nextprotoneg protocols>]
 
 =head1 DESCRIPTION
 
@@ -332,6 +333,17 @@ file.
 
 sends a certificate status request to the server (OCSP stapling). The server
 response (if any) is printed out.
+
+=item B<-nextprotoneg protocols>
+
+enable Next Protocol Negotiation TLS extension and provide a list of
+comma-separated protocol names that the client should advertise
+support for. The list should contain most wanted protocols first.
+Protocol names are printable ASCII strings, for example "http/1.1" or
+"spdy/3".
+Empty list of protocols is treated specially and will cause the client to
+advertise support for the TLS extension but disconnect just after
+reciving ServerHello with a list of server supported protocols.
 
 =back
 

--- a/doc/apps/s_server.pod
+++ b/doc/apps/s_server.pod
@@ -88,6 +88,8 @@ B<openssl> B<s_server>
 [B<-status_verbose>]
 [B<-status_timeout nsec>]
 [B<-status_url url>]
+[B<-nextprotoneg protocols>]
+
 =head1 DESCRIPTION
 
 The B<s_server> command implements a generic SSL/TLS server which listens
@@ -386,6 +388,14 @@ sets the timeout for OCSP response to B<nsec> seconds.
 sets a fallback responder URL to use if no responder URL is present in the
 server certificate. Without this option an error is returned if the server
 certificate does not contain a responder address.
+
+=item B<-nextprotoneg protocols>
+
+enable Next Protocol Negotiation TLS extension and provide a
+comma-separated list of supported protocol names.
+The list should contain most wanted protocols first.
+Protocol names are printable ASCII strings, for example "http/1.1" or
+"spdy/3".
 
 =back
 


### PR DESCRIPTION
Add description of the option to advertise support of
Next Protocol Negotiation extension (-nextprotoneg) to
man pages of s_client and s_server.

Obsoletes pull request #123