### PR TITLE
Use unsigned type to exclude potential overflow

### DIFF
--- a/crypto/asn1/x_pkey.c
+++ b/crypto/asn1/x_pkey.c
@@ -71,7 +71,7 @@ int i2d_X509_PKEY(X509_PKEY *a, unsigned char **pp)
 
 X509_PKEY *d2i_X509_PKEY(X509_PKEY **a, const unsigned char **pp, long length)
 	{
-	int i;
+	unsigned int i;
 	M_ASN1_D2I_vars(a,X509_PKEY *,X509_PKEY_new);
 
 	M_ASN1_D2I_Init();


### PR DESCRIPTION
If the IV of a private keys' encryption algorithm is very long, assigning the IV
length value to a signed int may result in a negative value. While d2i_X509_PKEY
validates that the length is below EVP_MAX_IV_LENGTH, it does not check for
negative values before memcpy'ing the IV. With the change, the length value is
assigned to an unsigned int variable, excluding a potential out-of-bounds write
via the memcpy.