### PR TITLE
Add extended master secret support to thwart Triple Handshake attacks

### DIFF
--- a/ssl/s3_clnt.c
+++ b/ssl/s3_clnt.c
@@ -2473,6 +2473,8 @@ int ssl3_send_client_key_exchange(SSL *s)
 	{
 	unsigned char *p;
 	int n;
+	unsigned char *final_pre_ms = NULL;
+	int final_pre_ms_len = 0;
 	unsigned long alg_k;
 #ifndef OPENSSL_NO_RSA
 	unsigned char *q;
@@ -2488,6 +2490,10 @@ int ssl3_send_client_key_exchange(SSL *s)
 	unsigned char *encodedPoint = NULL;
 	int encoded_pt_len = 0;
 	BN_CTX * bn_ctx = NULL;
+#endif
+
+#ifndef OPENSSL_NO_SRP
+	int is_srp_kex = 0;
 #endif
 
 	if (s->state == SSL3_ST_CW_KEY_EXCH_A)
@@ -2557,10 +2563,13 @@ int ssl3_send_client_key_exchange(SSL *s)
 				n+=2;
 				}
 
-			s->session->master_key_length=
-				s->method->ssl3_enc->generate_master_secret(s,
-					s->session->master_key,
-					tmp_buf,sizeof tmp_buf);
+			final_pre_ms = (unsigned char *)OPENSSL_malloc(sizeof tmp_buf);
+			if (final_pre_ms == NULL) {
+				OPENSSL_cleanse(tmp_buf,sizeof tmp_buf);
+				return(-1);
+			}
+			final_pre_ms_len = sizeof tmp_buf;
+			memcpy(final_pre_ms,tmp_buf,sizeof tmp_buf);
 			OPENSSL_cleanse(tmp_buf,sizeof tmp_buf);
 			}
 #endif
@@ -2689,12 +2698,15 @@ int ssl3_send_client_key_exchange(SSL *s)
 			p+=outl;
 			n+=outl + 2;
 
-			s->session->master_key_length=
-				s->method->ssl3_enc->generate_master_secret(s,
-					s->session->master_key,
-					tmp_buf, sizeof tmp_buf);
-
-			OPENSSL_cleanse(tmp_buf, sizeof tmp_buf);
+			final_pre_ms = (unsigned char *)OPENSSL_malloc(sizeof tmp_buf);
+			if (final_pre_ms == NULL) {
+				OPENSSL_cleanse(tmp_buf,sizeof tmp_buf);
+				OPENSSL_cleanse(epms, outl);
+				return(-1);
+			}
+			final_pre_ms_len = sizeof tmp_buf;
+			memcpy(final_pre_ms,tmp_buf,sizeof tmp_buf);
+			OPENSSL_cleanse(tmp_buf,sizeof tmp_buf);
 			OPENSSL_cleanse(epms, outl);
 			}
 #endif
@@ -2778,10 +2790,13 @@ int ssl3_send_client_key_exchange(SSL *s)
 				goto err;
 				}
 
-			/* generate master key from the result */
-			s->session->master_key_length=
-				s->method->ssl3_enc->generate_master_secret(s,
-					s->session->master_key,p,n);
+			final_pre_ms = (unsigned char *)OPENSSL_malloc(n);
+			if (final_pre_ms == NULL) {
+				memset(p,0,n);
+				return(-1);
+			}
+			final_pre_ms_len = n;
+			memcpy(final_pre_ms,p,n);
 			/* clean up */
 			memset(p,0,n);
 
@@ -2936,11 +2951,13 @@ int ssl3_send_client_key_exchange(SSL *s)
 				goto err;
 				}
 
-			/* generate master key from the result */
-			s->session->master_key_length = s->method->ssl3_enc \
-			    -> generate_master_secret(s, 
-				s->session->master_key,
-				p, n);
+			final_pre_ms = (unsigned char *)OPENSSL_malloc(n);
+			if (final_pre_ms == NULL) {
+				memset(p, 0, n);
+				return(-1);
+			}
+			final_pre_ms_len = n;
+			memcpy(final_pre_ms,p,n);
 
 			memset(p, 0, n); /* clean up */
 
@@ -3078,9 +3095,13 @@ int ssl3_send_client_key_exchange(SSL *s)
 				s->s3->flags |= TLS1_FLAGS_SKIP_CERT_VERIFY;
 				}
 			EVP_PKEY_CTX_free(pkey_ctx);
-			s->session->master_key_length=
-				s->method->ssl3_enc->generate_master_secret(s,
-					s->session->master_key,premaster_secret,32);
+			final_pre_ms = (unsigned char *)OPENSSL_malloc(32);
+			if (final_pre_ms == NULL) {
+				EVP_PKEY_free(pub_key);
+				return(-1);
+			}
+			final_pre_ms_len = 32;
+			memcpy(final_pre_ms,premaster_secret,32);
 			EVP_PKEY_free(pub_key);
 
 			}
@@ -3110,11 +3131,7 @@ int ssl3_send_client_key_exchange(SSL *s)
 				goto err;
 				}
 
-			if ((s->session->master_key_length = SRP_generate_client_master_secret(s,s->session->master_key))<0)
-				{
-				SSLerr(SSL_F_SSL3_SEND_CLIENT_KEY_EXCHANGE,ERR_R_INTERNAL_ERROR);
-				goto err;
-				}
+			is_srp_kex = 1;
 			}
 #endif
 #ifndef OPENSSL_NO_PSK
@@ -3192,13 +3209,17 @@ int ssl3_send_client_key_exchange(SSL *s)
 				goto psk_err;
 				}
 
-			s->session->master_key_length =
-				s->method->ssl3_enc->generate_master_secret(s,
-					s->session->master_key,
-					psk_or_pre_ms, pre_ms_len);
+			final_pre_ms = (unsigned char *)OPENSSL_malloc(pre_ms_len);
+			if (final_pre_ms == NULL) {
+				psk_err =1;
+				goto psk_err;
+			}
+			final_pre_ms_len = pre_ms_len;
+			memcpy(final_pre_ms,psk_or_pre_ms,pre_ms_len);
 			s2n(identity_len, p);
 			memcpy(p, identity, identity_len);
 			n = 2 + identity_len;
+
 			psk_err = 0;
 		psk_err:
 			OPENSSL_cleanse(identity, sizeof(identity));
@@ -3224,7 +3245,32 @@ int ssl3_send_client_key_exchange(SSL *s)
 		}
 
 	/* SSL3_ST_CW_KEY_EXCH_B */
-	return ssl_do_write(s);
+	if (ssl_do_write(s) == 1)
+			{
+#ifndef OPENSSL_NO_SRP
+			if (is_srp_kex)
+				{
+				if ((s->session->master_key_length = SRP_generate_client_master_secret(s,s->session->master_key))<0)
+					{
+					SSLerr(SSL_F_SSL3_SEND_CLIENT_KEY_EXCHANGE,ERR_R_INTERNAL_ERROR);
+					goto err;
+					}
+				}
+			else
+				{
+#endif
+			s->session->master_key_length =
+					s->method->ssl3_enc->generate_master_secret(s,
+							s->session->master_key,
+							final_pre_ms, final_pre_ms_len);
+			OPENSSL_cleanse(final_pre_ms,final_pre_ms_len);
+			OPENSSL_free(final_pre_ms);
+#ifndef OPENSSL_NO_SRP
+				}
+#endif
+			return (1);
+			}
+
 err:
 #ifndef OPENSSL_NO_ECDH
 	BN_CTX_free(bn_ctx);

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -173,8 +173,9 @@ extern "C" {
 /* SSLeay version number for ASN.1 encoding of the session information */
 /* Version 0 - initial version
  * Version 1 - added the optional peer certificate
+ * Version 2 - added extended master key information
  */
-#define SSL_SESSION_ASN1_VERSION 0x0001
+#define SSL_SESSION_ASN1_VERSION 0x0002
 
 /* text strings for the ciphers */
 #define SSL_TXT_NULL_WITH_MD5		SSL2_TXT_NULL_WITH_MD5			
@@ -488,7 +489,8 @@ struct ssl_method_st
  *	Ticket_lifetime_hint [9] EXPLICIT INTEGER, -- server's lifetime hint for session ticket
  *	Ticket [10]             EXPLICIT OCTET STRING, -- session ticket (clients only)
  *	Compression_meth [11]   EXPLICIT OCTET STRING, -- optional compression method
- *	SRP_username [ 12 ] EXPLICIT OCTET STRING -- optional SRP username
+ *	SRP_username [ 12 ] EXPLICIT OCTET STRING, -- optional SRP username
+ *	Extended_master_key [ 13 ]	EXPLICIT OCTET STRING	-- whether the master key is extended
  *	}
  * Look in ssl/ssl_asn1.c for more details
  * I'm using EXPLICIT tags so I can read the damn things using asn1parse :-).
@@ -571,6 +573,7 @@ struct ssl_session_st
 #ifndef OPENSSL_NO_SRP
 	char *srp_username;
 #endif
+	unsigned char extended_master_key;
 	};
 
 #endif
@@ -781,6 +784,8 @@ struct ssl_session_st
 
 #define SSL_get_secure_renegotiation_support(ssl) \
 	SSL_ctrl((ssl), SSL_CTRL_GET_RI_SUPPORT, 0, NULL)
+#define SSL_get_extended_master_secret_support(ssl) \
+	SSL_ctrl((ssl), SSL_CTRL_GET_EXT_MS_SUPPORT, 0, NULL)
 
 #ifndef OPENSSL_NO_HEARTBEATS
 #define SSL_heartbeat(ssl) \
@@ -1837,6 +1842,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 #define SSL_CERT_SET_SERVER			3
 
 #define SSL_CTRL_SET_DH_AUTO			118
+
+#define SSL_CTRL_GET_EXT_MS_SUPPORT			91
 
 #define DTLSv1_get_timeout(ssl, arg) \
 	SSL_ctrl(ssl,DTLS_CTRL_GET_TIMEOUT,0, (void *)arg)

--- a/ssl/ssl3.h
+++ b/ssl/ssl3.h
@@ -578,6 +578,8 @@ typedef struct ssl3_state_st
         unsigned char previous_server_finished_len;
         int send_connection_binding; /* TODOEKR */
 
+        int extended_ms_seen;
+
 #ifndef OPENSSL_NO_NEXTPROTONEG
 	/* Set if we saw the Next Protocol Negotiation extension from our peer. */
 	int next_proto_neg_seen;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1150,6 +1150,10 @@ long SSL_ctrl(SSL *s,int cmd,long larg,void *parg)
 		if (s->s3)
 			return s->s3->send_connection_binding;
 		else return 0;
+	case SSL_CTRL_GET_EXT_MS_SUPPORT:
+		if (s->session)
+			return s->session->extended_master_key;
+		else return 0;
 	case SSL_CTRL_CERT_FLAGS:
 		return(s->cert->cert_flags|=larg);
 	case SSL_CTRL_CLEAR_CERT_FLAGS:

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1147,6 +1147,7 @@ int	ssl3_setup_write_buffer(SSL *s);
 int	ssl3_release_read_buffer(SSL *s);
 int	ssl3_release_write_buffer(SSL *s);
 int	ssl3_digest_cached_records(SSL *s);
+int	ssl3_digest_handshake_log(SSL *s, unsigned char *digest, unsigned int digest_maxlen);
 int	ssl3_new(SSL *s);
 void	ssl3_free(SSL *s);
 int	ssl3_accept(SSL *s);

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -165,6 +165,9 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
 		{
 		if (BIO_printf(bp,"%02X",x->master_key[i]) <= 0) goto err;
 		}
+	if (BIO_printf(bp,"\n    Extended Master-Key: %s",
+			x->extended_master_key ? "Yes" : "No") <= 0)
+		goto err;
 	if (BIO_puts(bp,"\n    Key-Arg   : ") <= 0) goto err;
 	if (x->key_arg_length == 0)
 		{

--- a/ssl/tls1.h
+++ b/ssl/tls1.h
@@ -246,6 +246,11 @@ extern "C" {
  */
 #define TLSEXT_TYPE_encrypt_then_mac	22
 
+/* Extension type for Extended Master Secret
+ * https://tools.ietf.org/id/draft-ietf-tls-session-hash.txt
+ */
+ #define TLSEXT_TYPE_master_secret		23
+
 /* ExtensionType value from RFC4507 */
 #define TLSEXT_TYPE_session_ticket		35
 
@@ -776,7 +781,7 @@ SSL_CTX_callback_ctrl(ssl,SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB,(void (*)(void))cb)
 
 #define TLS1_FINISH_MAC_LENGTH		12
 
-#define TLS_MD_MAX_CONST_SIZE			20
+#define TLS_MD_MAX_CONST_SIZE			22
 #define TLS_MD_CLIENT_FINISH_CONST		"client finished"
 #define TLS_MD_CLIENT_FINISH_CONST_SIZE		15
 #define TLS_MD_SERVER_FINISH_CONST		"server finished"
@@ -793,6 +798,8 @@ SSL_CTX_callback_ctrl(ssl,SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB,(void (*)(void))cb)
 #define TLS_MD_IV_BLOCK_CONST_SIZE		8
 #define TLS_MD_MASTER_SECRET_CONST		"master secret"
 #define TLS_MD_MASTER_SECRET_CONST_SIZE		13
+#define TLS_MD_EXTENDED_MASTER_SECRET_CONST	"extended master secret"
+#define TLS_MD_EXTENDED_MASTER_SECRET_CONST_SIZE	22
 
 #ifdef CHARSET_EBCDIC
 #undef TLS_MD_CLIENT_FINISH_CONST
@@ -811,6 +818,8 @@ SSL_CTX_callback_ctrl(ssl,SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB,(void (*)(void))cb)
 #define TLS_MD_IV_BLOCK_CONST         "\x49\x56\x20\x62\x6c\x6f\x63\x6b"  /*IV block*/
 #undef TLS_MD_MASTER_SECRET_CONST
 #define TLS_MD_MASTER_SECRET_CONST    "\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"  /*master secret*/
+#undef TLS_MD_EXTENDED_MASTER_SECRET_CONST
+#define TLS_MD_EXTENDED_MASTER_SECRET_CONST    "\x65\x78\x74\x65\x63\x64\x65\x64\x20\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"  /*extended master secret*/
 #endif
 
 /* TLS Session Ticket extension struct */


### PR DESCRIPTION
According to the TLS WG decision to adopt the triple handshake fix, I am proposing a patch that implements the extended master secret extension in OpenSSL.