### PR TITLE
Add hash algorithms SHA-512/224 and SHA-512/256

### DIFF
--- a/crypto/evp/evp.h
+++ b/crypto/evp/evp.h
@@ -687,6 +687,8 @@ const EVP_MD *EVP_sha256(void);
 #ifndef OPENSSL_NO_SHA512
 const EVP_MD *EVP_sha384(void);
 const EVP_MD *EVP_sha512(void);
+const EVP_MD *EVP_sha512_224(void);
+const EVP_MD *EVP_sha512_256(void);
 #endif
 #ifndef OPENSSL_NO_MDC2
 const EVP_MD *EVP_mdc2(void);

--- a/crypto/evp/evp_fips.c
+++ b/crypto/evp/evp_fips.c
@@ -105,6 +105,8 @@ const EVP_MD *EVP_sha224(void)  { return FIPS_evp_sha224(); }
 const EVP_MD *EVP_sha256(void)  { return FIPS_evp_sha256(); }
 const EVP_MD *EVP_sha384(void)  { return FIPS_evp_sha384(); }
 const EVP_MD *EVP_sha512(void)  { return FIPS_evp_sha512(); }
+const EVP_MD *EVP_sha512_224(void)  { return FIPS_evp_sha512_224(); }
+const EVP_MD *EVP_sha512_256(void)  { return FIPS_evp_sha512_256(); }
 
 const EVP_MD *EVP_dss(void)  { return FIPS_evp_dss(); }
 const EVP_MD *EVP_dss1(void)  { return FIPS_evp_dss1(); }

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -372,6 +372,8 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
 #define SHA256_Init	private_SHA256_Init
 #define SHA384_Init	private_SHA384_Init
 #define SHA512_Init	private_SHA512_Init
+#define SHA512_224_Init	private_SHA512_224_Init
+#define SHA512_256_Init	private_SHA512_256_Init
 
 #define BF_set_key	private_BF_set_key
 #define CAST_set_key	private_CAST_set_key

--- a/crypto/evp/m_sha1.c
+++ b/crypto/evp/m_sha1.c
@@ -161,6 +161,10 @@ static int init384(EVP_MD_CTX *ctx)
 	{ return SHA384_Init(ctx->md_data); }
 static int init512(EVP_MD_CTX *ctx)
 	{ return SHA512_Init(ctx->md_data); }
+static int init512_224(EVP_MD_CTX *ctx)
+	{ return SHA512_224_Init(ctx->md_data); }
+static int init512_256(EVP_MD_CTX *ctx)
+	{ return SHA512_256_Init(ctx->md_data); }
 /* See comment in SHA224/256 section */
 static int update512(EVP_MD_CTX *ctx,const void *data,size_t count)
 	{ return SHA512_Update(ctx->md_data,data,count); }
@@ -204,6 +208,44 @@ static const EVP_MD sha512_md=
 
 const EVP_MD *EVP_sha512(void)
 	{ return(&sha512_md); }
+
+static const EVP_MD sha512_224_md=
+	{
+	NID_sha512_224,
+	NID_sha512_224WithRSAEncryption,
+	SHA512_224_DIGEST_LENGTH,
+	EVP_MD_FLAG_PKEY_METHOD_SIGNATURE|EVP_MD_FLAG_DIGALGID_ABSENT,
+	init512_224,
+	update512,
+	final512,
+	NULL,
+	NULL,
+	EVP_PKEY_RSA_method,
+	SHA512_CBLOCK,
+	sizeof(EVP_MD *)+sizeof(SHA512_CTX),
+	};
+
+const EVP_MD *EVP_sha512_224(void)
+	{ return(&sha512_224_md); }
+
+static const EVP_MD sha512_256_md=
+	{
+	NID_sha512_256,
+	NID_sha512_256WithRSAEncryption,
+	SHA512_256_DIGEST_LENGTH,
+	EVP_MD_FLAG_PKEY_METHOD_SIGNATURE|EVP_MD_FLAG_DIGALGID_ABSENT,
+	init512_256,
+	update512,
+	final512,
+	NULL,
+	NULL,
+	EVP_PKEY_RSA_method,
+	SHA512_CBLOCK,
+	sizeof(EVP_MD *)+sizeof(SHA512_CTX),
+	};
+
+const EVP_MD *EVP_sha512_256(void)
+	{ return(&sha512_256_md); }
 #endif	/* ifndef OPENSSL_NO_SHA512 */
 
 #endif

--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -62,12 +62,12 @@
  * [including the GNU Public Licence.]
  */
 
-#define NUM_NID 920
-#define NUM_SN 913
-#define NUM_LN 913
-#define NUM_OBJ 857
+#define NUM_NID 924
+#define NUM_SN 917
+#define NUM_LN 917
+#define NUM_OBJ 861
 
-static const unsigned char lvalues[5974]={
+static const unsigned char lvalues[6010]={
 0x2A,0x86,0x48,0x86,0xF7,0x0D,               /* [  0] OBJ_rsadsi */
 0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,          /* [  6] OBJ_pkcs */
 0x2A,0x86,0x48,0x86,0xF7,0x0D,0x02,0x02,     /* [ 13] OBJ_md2 */
@@ -919,6 +919,10 @@ static const unsigned char lvalues[5974]={
 0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x01,0x08,/* [5946] OBJ_mgf1 */
 0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x01,0x0A,/* [5955] OBJ_rsassaPss */
 0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x01,0x07,/* [5964] OBJ_rsaesOaep */
+0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x01,0x0F,/* [5973] OBJ_sha512_224WithRSAEncryption */
+0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x01,0x10,/* [5982] OBJ_sha512_256WithRSAEncryption */
+0x60,0x86,0x48,0x01,0x65,0x03,0x04,0x02,0x05,/* [5991] OBJ_sha512_224 */
+0x60,0x86,0x48,0x01,0x65,0x03,0x04,0x02,0x06,/* [6000] OBJ_sha512_256 */
 };
 
 static const ASN1_OBJECT nid_objs[NUM_NID]={
@@ -2399,6 +2403,12 @@ static const ASN1_OBJECT nid_objs[NUM_NID]={
 {"AES-256-CBC-HMAC-SHA1","aes-256-cbc-hmac-sha1",
 	NID_aes_256_cbc_hmac_sha1,0,NULL,0},
 {"RSAES-OAEP","rsaesOaep",NID_rsaesOaep,9,&(lvalues[5964]),0},
+{"RSA-SHA512-224","sha512-224WithRSAEncryption",
+	NID_sha512_224WithRSAEncryption,9,&(lvalues[5973]),0},
+{"RSA-SHA512-256","sha512-256WithRSAEncryption",
+	NID_sha512_256WithRSAEncryption,9,&(lvalues[5982]),0},
+{"SHA512-224","sha512-224",NID_sha512_224,9,&(lvalues[5991]),0},
+{"SHA512-256","sha512-256",NID_sha512_256,9,&(lvalues[6000]),0},
 };
 
 static const unsigned int sn_objs[NUM_SN]={
@@ -2566,6 +2576,8 @@ static const unsigned int sn_objs[NUM_SN]={
 668,	/* "RSA-SHA256" */
 669,	/* "RSA-SHA384" */
 670,	/* "RSA-SHA512" */
+920,	/* "RSA-SHA512-224" */
+921,	/* "RSA-SHA512-256" */
 919,	/* "RSAES-OAEP" */
 912,	/* "RSASSA-PSS" */
 777,	/* "SEED-CBC" */
@@ -2578,6 +2590,8 @@ static const unsigned int sn_objs[NUM_SN]={
 672,	/* "SHA256" */
 673,	/* "SHA384" */
 674,	/* "SHA512" */
+922,	/* "SHA512-224" */
+923,	/* "SHA512-256" */
 188,	/* "SMIME" */
 167,	/* "SMIME-CAPS" */
 100,	/* "SN" */
@@ -4183,6 +4197,10 @@ static const unsigned int ln_objs[NUM_LN]={
 673,	/* "sha384" */
 669,	/* "sha384WithRSAEncryption" */
 674,	/* "sha512" */
+922,	/* "sha512-224" */
+920,	/* "sha512-224WithRSAEncryption" */
+923,	/* "sha512-256" */
+921,	/* "sha512-256WithRSAEncryption" */
 670,	/* "sha512WithRSAEncryption" */
 42,	/* "shaWithRSAEncryption" */
 52,	/* "signingTime" */
@@ -4830,6 +4848,8 @@ static const unsigned int obj_objs[NUM_OBJ]={
 669,	/* OBJ_sha384WithRSAEncryption      1 2 840 113549 1 1 12 */
 670,	/* OBJ_sha512WithRSAEncryption      1 2 840 113549 1 1 13 */
 671,	/* OBJ_sha224WithRSAEncryption      1 2 840 113549 1 1 14 */
+920,	/* OBJ_sha512_224WithRSAEncryption  1 2 840 113549 1 1 15 */
+921,	/* OBJ_sha512_256WithRSAEncryption  1 2 840 113549 1 1 16 */
 28,	/* OBJ_dhKeyAgreement               1 2 840 113549 1 3 1 */
  9,	/* OBJ_pbeWithMD2AndDES_CBC         1 2 840 113549 1 5 1 */
 10,	/* OBJ_pbeWithMD5AndDES_CBC         1 2 840 113549 1 5 3 */
@@ -4914,6 +4934,8 @@ static const unsigned int obj_objs[NUM_OBJ]={
 673,	/* OBJ_sha384                       2 16 840 1 101 3 4 2 2 */
 674,	/* OBJ_sha512                       2 16 840 1 101 3 4 2 3 */
 675,	/* OBJ_sha224                       2 16 840 1 101 3 4 2 4 */
+922,	/* OBJ_sha512_224                   2 16 840 1 101 3 4 2 5 */
+923,	/* OBJ_sha512_256                   2 16 840 1 101 3 4 2 6 */
 802,	/* OBJ_dsa_with_SHA224              2 16 840 1 101 3 4 3 1 */
 803,	/* OBJ_dsa_with_SHA256              2 16 840 1 101 3 4 3 2 */
 71,	/* OBJ_netscape_cert_type           2 16 840 1 113730 1 1 */

--- a/crypto/objects/obj_mac.h
+++ b/crypto/objects/obj_mac.h
@@ -615,6 +615,16 @@
 #define NID_sha224WithRSAEncryption		671
 #define OBJ_sha224WithRSAEncryption		OBJ_pkcs1,14L
 
+#define SN_sha512_224WithRSAEncryption		"RSA-SHA512-224"
+#define LN_sha512_224WithRSAEncryption		"sha512-224WithRSAEncryption"
+#define NID_sha512_224WithRSAEncryption		920
+#define OBJ_sha512_224WithRSAEncryption		OBJ_pkcs1,15L
+
+#define SN_sha512_256WithRSAEncryption		"RSA-SHA512-256"
+#define LN_sha512_256WithRSAEncryption		"sha512-256WithRSAEncryption"
+#define NID_sha512_256WithRSAEncryption		921
+#define OBJ_sha512_256WithRSAEncryption		OBJ_pkcs1,16L
+
 #define SN_pkcs3		"pkcs3"
 #define NID_pkcs3		27
 #define OBJ_pkcs3		OBJ_pkcs,3L
@@ -2785,6 +2795,16 @@
 #define LN_sha224		"sha224"
 #define NID_sha224		675
 #define OBJ_sha224		OBJ_nist_hashalgs,4L
+
+#define SN_sha512_224		"SHA512-224"
+#define LN_sha512_224		"sha512-224"
+#define NID_sha512_224		922
+#define OBJ_sha512_224		OBJ_nist_hashalgs,5L
+
+#define SN_sha512_256		"SHA512-256"
+#define LN_sha512_256		"sha512-256"
+#define NID_sha512_256		923
+#define OBJ_sha512_256		OBJ_nist_hashalgs,6L
 
 #define OBJ_dsa_with_sha2		OBJ_nistAlgorithms,3L
 

--- a/crypto/objects/obj_mac.num
+++ b/crypto/objects/obj_mac.num
@@ -917,3 +917,7 @@ aes_128_cbc_hmac_sha1		916
 aes_192_cbc_hmac_sha1		917
 aes_256_cbc_hmac_sha1		918
 rsaesOaep		919
+sha512_224WithRSAEncryption		920
+sha512_256WithRSAEncryption		921
+sha512_224		922
+sha512_256		923

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -174,6 +174,8 @@ pkcs1 11		: RSA-SHA256		: sha256WithRSAEncryption
 pkcs1 12		: RSA-SHA384		: sha384WithRSAEncryption
 pkcs1 13		: RSA-SHA512		: sha512WithRSAEncryption
 pkcs1 14		: RSA-SHA224		: sha224WithRSAEncryption
+pkcs1 15		: RSA-SHA512-224	: sha512-224WithRSAEncryption
+pkcs1 16		: RSA-SHA512-256	: sha512-256WithRSAEncryption
 
 pkcs 3			: pkcs3
 pkcs3 1			:			: dhKeyAgreement
@@ -906,6 +908,8 @@ nist_hashalgs 1		: SHA256		: sha256
 nist_hashalgs 2		: SHA384		: sha384
 nist_hashalgs 3		: SHA512		: sha512
 nist_hashalgs 4		: SHA224		: sha224
+nist_hashalgs 5		: SHA512-224		: sha512-224
+nist_hashalgs 6		: SHA512-256		: sha512-256
 
 # OIDs for dsa-with-sha224 and dsa-with-sha256
 !Alias dsa_with_sha2 nistAlgorithms 3

--- a/crypto/sha/sha.h
+++ b/crypto/sha/sha.h
@@ -158,6 +158,8 @@ void SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
 
 #define SHA384_DIGEST_LENGTH	48
 #define SHA512_DIGEST_LENGTH	64
+#define SHA512_224_DIGEST_LENGTH	SHA224_DIGEST_LENGTH
+#define SHA512_256_DIGEST_LENGTH	SHA256_DIGEST_LENGTH
 
 #ifndef OPENSSL_NO_SHA512
 /*
@@ -195,6 +197,8 @@ typedef struct SHA512state_st
 #ifdef OPENSSL_FIPS
 int private_SHA384_Init(SHA512_CTX *c);
 int private_SHA512_Init(SHA512_CTX *c);
+int private_SHA512_224_Init(SHA512_CTX *c);
+int private_SHA512_256_Init(SHA512_CTX *c);
 #endif
 int SHA384_Init(SHA512_CTX *c);
 int SHA384_Update(SHA512_CTX *c, const void *data, size_t len);
@@ -204,6 +208,14 @@ int SHA512_Init(SHA512_CTX *c);
 int SHA512_Update(SHA512_CTX *c, const void *data, size_t len);
 int SHA512_Final(unsigned char *md, SHA512_CTX *c);
 unsigned char *SHA512(const unsigned char *d, size_t n,unsigned char *md);
+int SHA512_224_Init(SHA512_CTX *c);
+int SHA512_224_Update(SHA512_CTX *c, const void *data, size_t len);
+int SHA512_224_Final(unsigned char *md, SHA512_CTX *c);
+unsigned char *SHA512_224(const unsigned char *d, size_t n,unsigned char *md);
+int SHA512_256_Init(SHA512_CTX *c);
+int SHA512_256_Update(SHA512_CTX *c, const void *data, size_t len);
+int SHA512_256_Final(unsigned char *md, SHA512_CTX *c);
+unsigned char *SHA512_256(const unsigned char *d, size_t n,unsigned char *md);
 void SHA512_Transform(SHA512_CTX *c, const unsigned char *data);
 #endif
 

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -91,6 +91,38 @@ fips_md_init(SHA512)
         return 1;
 	}
 
+fips_md_init_ctx(SHA512_224, SHA512)
+	{
+	c->h[0]=U64(0x8c3d37c819544da2);
+	c->h[1]=U64(0x73e1996689dcd4d6);
+	c->h[2]=U64(0x1dfab7ae32ff9c82);
+	c->h[3]=U64(0x679dd514582f9fcf);
+	c->h[4]=U64(0x0f6d2b697bd44da8);
+	c->h[5]=U64(0x77e36f7304c48942);
+	c->h[6]=U64(0x3f9d85a86a1d36c8);
+	c->h[7]=U64(0x1112e6ad91d692a1);
+
+        c->Nl=0;        c->Nh=0;
+        c->num=0;       c->md_len=SHA512_224_DIGEST_LENGTH;
+        return 1;
+	}
+
+fips_md_init_ctx(SHA512_256, SHA512)
+	{
+	c->h[0]=U64(0x22312194fc2bf72c);
+	c->h[1]=U64(0x9f555fa3c84c64c2);
+	c->h[2]=U64(0x2393b86b6f53b151);
+	c->h[3]=U64(0x963877195940eabd);
+	c->h[4]=U64(0x96283ee2a88effe3);
+	c->h[5]=U64(0xbe5e1e2553863992);
+	c->h[6]=U64(0x2b0199fc2c85b8aa);
+	c->h[7]=U64(0x0eb72ddc81c52ca2);
+
+        c->Nl=0;        c->Nh=0;
+        c->num=0;       c->md_len=SHA512_256_DIGEST_LENGTH;
+        return 1;
+	}
+
 #ifndef SHA512_ASM
 static
 #endif
@@ -167,6 +199,40 @@ int SHA512_Final (unsigned char *md, SHA512_CTX *c)
 				*(md++)	= (unsigned char)(t);
 				}
 			break;
+		case SHA512_224_DIGEST_LENGTH:
+			/* this digest length is not multiple of 8 */
+			for (n=0;n<(SHA512_224_DIGEST_LENGTH+7)/8;n++)
+				{
+				SHA_LONG64 t = c->h[n];
+
+				*(md++)	= (unsigned char)(t>>56);
+				*(md++)	= (unsigned char)(t>>48);
+				*(md++)	= (unsigned char)(t>>40);
+				*(md++)	= (unsigned char)(t>>32);
+				if (n!=SHA512_224_DIGEST_LENGTH/8)
+					{
+					*(md++)	= (unsigned char)(t>>24);
+					*(md++)	= (unsigned char)(t>>16);
+					*(md++)	= (unsigned char)(t>>8);
+					*(md++)	= (unsigned char)(t);
+					}
+				}
+			break;
+		case SHA512_256_DIGEST_LENGTH:
+			for (n=0;n<SHA512_256_DIGEST_LENGTH/8;n++)
+				{
+				SHA_LONG64 t = c->h[n];
+
+				*(md++)	= (unsigned char)(t>>56);
+				*(md++)	= (unsigned char)(t>>48);
+				*(md++)	= (unsigned char)(t>>40);
+				*(md++)	= (unsigned char)(t>>32);
+				*(md++)	= (unsigned char)(t>>24);
+				*(md++)	= (unsigned char)(t>>16);
+				*(md++)	= (unsigned char)(t>>8);
+				*(md++)	= (unsigned char)(t);
+				}
+			break;
 		/* ... as well as make sure md_len is not abused. */
 		default:	return 0;
 		}
@@ -175,6 +241,12 @@ int SHA512_Final (unsigned char *md, SHA512_CTX *c)
 	}
 
 int SHA384_Final (unsigned char *md,SHA512_CTX *c)
+{   return SHA512_Final (md,c);   }
+
+int SHA512_224_Final (unsigned char *md,SHA512_CTX *c)
+{   return SHA512_Final (md,c);   }
+
+int SHA512_256_Final (unsigned char *md,SHA512_CTX *c)
 {   return SHA512_Final (md,c);   }
 
 int SHA512_Update (SHA512_CTX *c, const void *_data, size_t len)
@@ -231,6 +303,12 @@ int SHA512_Update (SHA512_CTX *c, const void *_data, size_t len)
 int SHA384_Update (SHA512_CTX *c, const void *data, size_t len)
 {   return SHA512_Update (c,data,len);   }
 
+int SHA512_224_Update (SHA512_CTX *c, const void *data, size_t len)
+{   return SHA512_Update (c,data,len);   }
+
+int SHA512_256_Update (SHA512_CTX *c, const void *data, size_t len)
+{   return SHA512_Update (c,data,len);   }
+
 void SHA512_Transform (SHA512_CTX *c, const unsigned char *data)
 	{
 #ifndef SHA512_BLOCK_CAN_MANAGE_UNALIGNED_DATA
@@ -263,6 +341,32 @@ unsigned char *SHA512(const unsigned char *d, size_t n, unsigned char *md)
 	SHA512_Init(&c);
 	SHA512_Update(&c,d,n);
 	SHA512_Final(md,&c);
+	OPENSSL_cleanse(&c,sizeof(c));
+	return(md);
+	}
+
+unsigned char *SHA512_224(const unsigned char *d, size_t n, unsigned char *md)
+	{
+	SHA512_CTX c;
+	static unsigned char m[SHA512_224_DIGEST_LENGTH];
+
+	if (md == NULL) md=m;
+	SHA512_224_Init(&c);
+	SHA512_Update(&c,d,n);
+	SHA512_224_Final(md,&c);
+	OPENSSL_cleanse(&c,sizeof(c));
+	return(md);
+	}
+
+unsigned char *SHA512_256(const unsigned char *d, size_t n, unsigned char *md)
+	{
+	SHA512_CTX c;
+	static unsigned char m[SHA512_256_DIGEST_LENGTH];
+
+	if (md == NULL) md=m;
+	SHA512_256_Init(&c);
+	SHA512_Update(&c,d,n);
+	SHA512_256_Final(md,&c);
 	OPENSSL_cleanse(&c,sizeof(c));
 	return(md);
 	}

--- a/crypto/sha/sha512t.c
+++ b/crypto/sha/sha512t.c
@@ -73,6 +73,42 @@ unsigned char app_d3[SHA384_DIGEST_LENGTH] = {
 	0x07,0xb8,0xb3,0xdc,0x38,0xec,0xc4,0xeb,
 	0xae,0x97,0xdd,0xd8,0x7f,0x3d,0x89,0x85 };
 
+unsigned char app_e1[SHA512_224_DIGEST_LENGTH] = {
+	0x46,0x34,0x27,0x0f,0x70,0x7b,0x6a,0x54,
+	0xda,0xae,0x75,0x30,0x46,0x08,0x42,0xe2,
+	0x0e,0x37,0xed,0x26,0x5c,0xee,0xe9,0xa4,
+	0x3e,0x89,0x24,0xaa };
+
+unsigned char app_e2[SHA512_224_DIGEST_LENGTH] = {
+	0x23,0xfe,0xc5,0xbb,0x94,0xd6,0x0b,0x23,
+	0x30,0x81,0x92,0x64,0x0b,0x0c,0x45,0x33,
+	0x35,0xd6,0x64,0x73,0x4f,0xe4,0x0e,0x72,
+	0x68,0x67,0x4a,0xf9 };
+
+unsigned char app_e3[SHA512_224_DIGEST_LENGTH] = {
+	0x37,0xab,0x33,0x1d,0x76,0xf0,0xd3,0x6d,
+	0xe4,0x22,0xbd,0x0e,0xde,0xb2,0x2a,0x28,
+	0xac,0xcd,0x48,0x7b,0x7a,0x84,0x53,0xae,
+	0x96,0x5d,0xd2,0x87 };
+
+unsigned char app_f1[SHA512_256_DIGEST_LENGTH] = {
+	0x53,0x04,0x8e,0x26,0x81,0x94,0x1e,0xf9,
+	0x9b,0x2e,0x29,0xb7,0x6b,0x4c,0x7d,0xab,
+	0xe4,0xc2,0xd0,0xc6,0x34,0xfc,0x6d,0x46,
+	0xe0,0xe2,0xf1,0x31,0x07,0xe7,0xaf,0x23 };
+
+unsigned char app_f2[SHA512_256_DIGEST_LENGTH] = {
+	0x39,0x28,0xe1,0x84,0xfb,0x86,0x90,0xf8,
+	0x40,0xda,0x39,0x88,0x12,0x1d,0x31,0xbe,
+	0x65,0xcb,0x9d,0x3e,0xf8,0x3e,0xe6,0x14,
+	0x6f,0xea,0xc8,0x61,0xe1,0x9b,0x56,0x3a };
+
+unsigned char app_f3[SHA512_256_DIGEST_LENGTH] = {
+	0x9a,0x59,0xa0,0x52,0x93,0x01,0x87,0xa9,
+	0x70,0x38,0xca,0xe6,0x92,0xf3,0x07,0x08,
+	0xaa,0x64,0x91,0x92,0x3e,0xf5,0x19,0x43,
+	0x94,0xdc,0x68,0xd5,0x6c,0x74,0xfb,0x21 };
+
 int main (int argc,char **argv)
 { unsigned char md[SHA512_DIGEST_LENGTH];
   int		i;
@@ -170,6 +206,90 @@ int main (int argc,char **argv)
     EVP_MD_CTX_cleanup (&evp);
 
     if (memcmp(md,app_d3,sizeof(app_d3)))
+    {	fflush(stdout);
+	fprintf(stderr,"\nTEST 3 of 3 failed.\n");
+	return 1;
+    }
+    else
+	fprintf(stdout,"."); fflush(stdout);
+
+    fprintf(stdout," passed.\n"); fflush(stdout);
+
+    fprintf(stdout,"Testing SHA-512/224 ");
+
+    EVP_Digest ("abc",3,md,NULL,EVP_sha512_224(),NULL);
+    if (memcmp(md,app_e1,sizeof(app_e1)))
+    {	fflush(stdout);
+	fprintf(stderr,"\nTEST 1 of 3 failed.\n");
+	return 1;
+    }
+    else
+	fprintf(stdout,"."); fflush(stdout);
+
+    EVP_Digest ("abcdefgh""bcdefghi""cdefghij""defghijk"
+		"efghijkl""fghijklm""ghijklmn""hijklmno"
+		"ijklmnop""jklmnopq""klmnopqr""lmnopqrs"
+		"mnopqrst""nopqrstu",112,md,NULL,EVP_sha512_224(),NULL);
+    if (memcmp(md,app_e2,sizeof(app_e2)))
+    {	fflush(stdout);
+	fprintf(stderr,"\nTEST 2 of 3 failed.\n");
+	return 1;
+    }
+    else
+	fprintf(stdout,"."); fflush(stdout);
+
+    EVP_MD_CTX_init (&evp);
+    EVP_DigestInit_ex (&evp,EVP_sha512_224(),NULL);
+    for (i=0;i<1000000;i+=64)
+	EVP_DigestUpdate (&evp,	"aaaaaaaa""aaaaaaaa""aaaaaaaa""aaaaaaaa"
+				"aaaaaaaa""aaaaaaaa""aaaaaaaa""aaaaaaaa",
+				(1000000-i)<64?1000000-i:64);
+    EVP_DigestFinal_ex (&evp,md,NULL);
+    EVP_MD_CTX_cleanup (&evp);
+
+    if (memcmp(md,app_e3,sizeof(app_e3)))
+    {	fflush(stdout);
+	fprintf(stderr,"\nTEST 3 of 3 failed.\n");
+	return 1;
+    }
+    else
+	fprintf(stdout,"."); fflush(stdout);
+
+    fprintf(stdout," passed.\n"); fflush(stdout);
+
+    fprintf(stdout,"Testing SHA-512/256 ");
+
+    EVP_Digest ("abc",3,md,NULL,EVP_sha512_256(),NULL);
+    if (memcmp(md,app_f1,sizeof(app_f1)))
+    {	fflush(stdout);
+	fprintf(stderr,"\nTEST 1 of 3 failed.\n");
+	return 1;
+    }
+    else
+	fprintf(stdout,"."); fflush(stdout);
+
+    EVP_Digest ("abcdefgh""bcdefghi""cdefghij""defghijk"
+		"efghijkl""fghijklm""ghijklmn""hijklmno"
+		"ijklmnop""jklmnopq""klmnopqr""lmnopqrs"
+		"mnopqrst""nopqrstu",112,md,NULL,EVP_sha512_256(),NULL);
+    if (memcmp(md,app_f2,sizeof(app_f2)))
+    {	fflush(stdout);
+	fprintf(stderr,"\nTEST 2 of 3 failed.\n");
+	return 1;
+    }
+    else
+	fprintf(stdout,"."); fflush(stdout);
+
+    EVP_MD_CTX_init (&evp);
+    EVP_DigestInit_ex (&evp,EVP_sha512_256(),NULL);
+    for (i=0;i<1000000;i+=64)
+	EVP_DigestUpdate (&evp,	"aaaaaaaa""aaaaaaaa""aaaaaaaa""aaaaaaaa"
+				"aaaaaaaa""aaaaaaaa""aaaaaaaa""aaaaaaaa",
+				(1000000-i)<64?1000000-i:64);
+    EVP_DigestFinal_ex (&evp,md,NULL);
+    EVP_MD_CTX_cleanup (&evp);
+
+    if (memcmp(md,app_f3,sizeof(app_f3)))
     {	fflush(stdout);
 	fprintf(stderr,"\nTEST 3 of 3 failed.\n");
 	return 1;

--- a/ms/test.bat
+++ b/ms/test.bat
@@ -31,6 +31,14 @@ echo sha1test
 sha1test
 if errorlevel 1 goto done
 
+echo sha256t
+sha256t
+if errorlevel 1 goto done
+
+echo sha512t
+sha512t
+if errorlevel 1 goto done
+
 echo md5test
 md5test
 if errorlevel 1 goto done

--- a/util/libeay.num
+++ b/util/libeay.num
@@ -4312,3 +4312,15 @@ BIO_dgram_sctp_wait_for_dry             4679	EXIST::FUNCTION:SCTP
 BIO_s_datagram_sctp                     4680	EXIST::FUNCTION:DGRAM,SCTP
 BIO_dgram_is_sctp                       4681	EXIST::FUNCTION:SCTP
 BIO_dgram_sctp_notification_cb          4682	EXIST::FUNCTION:SCTP
+SHA512_256_Final                        4683	EXIST::FUNCTION:SHA,SHA512
+EVP_sha512_256                          4684	EXIST::FUNCTION:SHA,SHA512
+SHA512_224_Final                        4685	EXIST::FUNCTION:SHA,SHA512
+SHA512_224_Update                       4686	EXIST::FUNCTION:SHA,SHA512
+private_SHA512_256_Init                 4687	EXIST:OPENSSL_FIPS:FUNCTION:SHA,SHA512
+SHA512_256_Init                         4688	EXIST::FUNCTION:SHA,SHA512
+SHA512_256_Update                       4689	EXIST::FUNCTION:SHA,SHA512
+SHA512_256                              4690	EXIST::FUNCTION:SHA,SHA512
+SHA512_224                              4691	EXIST::FUNCTION:SHA,SHA512
+SHA512_224_Init                         4692	EXIST::FUNCTION:SHA,SHA512
+private_SHA512_224_Init                 4693	EXIST:OPENSSL_FIPS:FUNCTION:SHA,SHA512
+EVP_sha512_224                          4694	EXIST::FUNCTION:SHA,SHA512


### PR DESCRIPTION
The hash algorithms SHA-512/224 and SHA-512/256 are two of the seven
FIPS 180-4, Secure Hash Standard Approved algorithms for generating a
condensed representation of a message (message digest).

http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf

Test values of the implementation of SHA-512/224 and SHA-512/256 are
available here:

http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf
http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_256.pdf
http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA2_Additional.pdf

With id-sha512-224 and id-sha512-256 NIST has registered two Secure Hash
Algorithm object identifiers:

http://csrc.nist.gov/groups/ST/crypto_apps_infra/csor/algorithms.html#Hash

With sha512-224WithRSAEncryption and sha512-256WithRSAEncryption two
OIDs for RSA signatures are defined in the PKCS #1 Version 2.2 RSA
Cryptography Standard:

http://www.emc.com/emc-plus/rsa-labs/pkcs/files/h11300-wp-pkcs-1v2-2-rsa-cryptography-standard.pdf
ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-2.asn