### PR TITLE
Fix git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ TAGS
 /ms/*.rc
 /ms/*.def
 /ms/*.mak
+/inc32
+/out32
+/tmp32
+/out32.dbg
+/tmp32.dbg


### PR DESCRIPTION
Building project on windows creates several auto generated files. Added these files to ignore list to prevent marking repository as dirty.
