### PR TITLE
Ignoring auto generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,15 @@
 /test/evptests.txt
 lib
 Makefile.save
-*.bak
 tags
 TAGS
+*.bak
+/ms/*.rc
+/ms/*.def
+/ms/*.mak
+/inc32
+/out32
+/tmp32
+/out32.dbg
+/tmp32.dbg
+/ms/uptable.*


### PR DESCRIPTION
Building project on windows creates several auto generated files. Added these files to ignore list to prevent marking repository as dirty.