### PR TITLE
fix renegotiation error under full duplex flow

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4766,7 +4766,19 @@ int ssl3_write(SSL *s, const void *buf, int len)
 		{
 		ret=s->method->ssl_write_bytes(s,SSL3_RT_APPLICATION_DATA,
 			buf,len);
-		if (ret <= 0) return(ret);
+		if (ret <= 0)
+			{
+			if (s->s3->in_read_app_data == 2)
+				{
+				s->in_handshake++;
+				ret=s->method->ssl_write_bytes(s,
+					SSL3_RT_APPLICATION_DATA,buf,len);
+				s->in_handshake--;
+				if (ret <= 0) return(ret);
+				}
+			else
+				return(ret);
+			}
 		}
 
 	return(ret);

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -1694,35 +1694,8 @@ start:
 		SSLerr(SSL_F_SSL3_READ_BYTES,ERR_R_INTERNAL_ERROR);
 		goto f_err;
 	case SSL3_RT_APPLICATION_DATA:
-		/* At this point, we were expecting handshake data,
-		 * but have application data.  If the library was
-		 * running inside ssl3_read() (i.e. in_read_app_data
-		 * is set) and it makes sense to read application data
-		 * at this point (session renegotiation not yet started),
-		 * we will indulge it.
-		 */
-		if (s->s3->in_read_app_data &&
-			(s->s3->total_renegotiations != 0) &&
-			((
-				(s->state & SSL_ST_CONNECT) &&
-				(s->state >= SSL3_ST_CW_CLNT_HELLO_A) &&
-				(s->state <= SSL3_ST_CR_SRVR_HELLO_A)
-				) || (
-					(s->state & SSL_ST_ACCEPT) &&
-					(s->state <= SSL3_ST_SW_HELLO_REQ_A) &&
-					(s->state >= SSL3_ST_SR_CLNT_HELLO_A)
-					)
-				))
-			{
-			s->s3->in_read_app_data=2;
-			return(-1);
-			}
-		else
-			{
-			al=SSL_AD_UNEXPECTED_MESSAGE;
-			SSLerr(SSL_F_SSL3_READ_BYTES,SSL_R_UNEXPECTED_RECORD);
-			goto f_err;
-			}
+		s->s3->in_read_app_data=2;
+		return(-1);
 		}
 	/* not reached */
 


### PR DESCRIPTION
When `ssl3_write_bytes` failed because handshaking but there are pending application data, just try to send using current state.

The test case is:

server command:
```
yes "hello client" | openssl s_server -accept 1111 -state -CAfile ca.pem -cert server.pem -key server.pem
```

client command:
```
yes R | openssl s_client -connect localhost:1111 -state
```