### PR TITLE
Fix the logic choosing which verify locations to use

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1375,7 +1375,7 @@ bad:
 
 	SSL_CTX_set_verify(ctx,verify,verify_callback);
 
-	if ((!SSL_CTX_load_verify_locations(ctx,CAfile,CApath)) ||
+	if ((!SSL_CTX_load_verify_locations(ctx,CAfile,CApath)) &&
 		(!SSL_CTX_set_default_verify_paths(ctx)))
 		{
 		/* BIO_printf(bio_err,"error setting default verify locations\n"); */

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1805,7 +1805,7 @@ bad:
 		}
 #endif
 
-	if ((!SSL_CTX_load_verify_locations(ctx,CAfile,CApath)) ||
+	if ((!SSL_CTX_load_verify_locations(ctx,CAfile,CApath)) &&
 		(!SSL_CTX_set_default_verify_paths(ctx)))
 		{
 		/* BIO_printf(bio_err,"X509_load_verify_locations\n"); */
@@ -1878,7 +1878,7 @@ bad:
 		else
 			SSL_CTX_sess_set_cache_size(ctx2,128);
 
-		if ((!SSL_CTX_load_verify_locations(ctx2,CAfile,CApath)) ||
+		if ((!SSL_CTX_load_verify_locations(ctx2,CAfile,CApath)) &&
 			(!SSL_CTX_set_default_verify_paths(ctx2)))
 			{
 			ERR_print_errors(bio_err);

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -373,7 +373,7 @@ int MAIN(int argc, char **argv)
 
 	SSL_load_error_strings();
 
-	if ((!SSL_CTX_load_verify_locations(tm_ctx,CAfile,CApath)) ||
+	if ((!SSL_CTX_load_verify_locations(tm_ctx,CAfile,CApath)) &&
 		(!SSL_CTX_set_default_verify_paths(tm_ctx)))
 		{
 		/* BIO_printf(bio_err,"error setting default verify locations\n"); */

--- a/crypto/threads/mttest.c
+++ b/crypto/threads/mttest.c
@@ -306,12 +306,18 @@ bad:
 			SSL_FILETYPE_PEM);
 		}
 
-	if (	(!SSL_CTX_load_verify_locations(s_ctx,CAfile,CApath)) ||
-		(!SSL_CTX_set_default_verify_paths(s_ctx)) ||
-		(!SSL_CTX_load_verify_locations(c_ctx,CAfile,CApath)) ||
+	if (	(!SSL_CTX_load_verify_locations(s_ctx,CAfile,CApath)) &&
+		(!SSL_CTX_set_default_verify_paths(s_ctx)))
+		{
+		fprintf(stderr,"SSL_load_verify_locations_server\n");
+		ERR_print_errors(bio_err);
+		goto end;
+		}
+
+	if (	(!SSL_CTX_load_verify_locations(c_ctx,CAfile,CApath)) &&
 		(!SSL_CTX_set_default_verify_paths(c_ctx)))
 		{
-		fprintf(stderr,"SSL_load_verify_locations\n");
+		fprintf(stderr,"SSL_load_verify_locations_client\n");
 		ERR_print_errors(bio_err);
 		goto end;
 		}

--- a/ssl/ssltest.c
+++ b/ssl/ssltest.c
@@ -1490,12 +1490,18 @@ bad:
 			SSL_FILETYPE_PEM);
 		}
 
-	if (	(!SSL_CTX_load_verify_locations(s_ctx,CAfile,CApath)) ||
-		(!SSL_CTX_set_default_verify_paths(s_ctx)) ||
-		(!SSL_CTX_load_verify_locations(c_ctx,CAfile,CApath)) ||
+	if (	(!SSL_CTX_load_verify_locations(s_ctx,CAfile,CApath)) &&
+		(!SSL_CTX_set_default_verify_paths(s_ctx)))
+		{
+		/* fprintf(stderr,"SSL_load_verify_locations_server\n"); */
+		ERR_print_errors(bio_err);
+		/* goto end; */
+		}
+
+	if (	(!SSL_CTX_load_verify_locations(c_ctx,CAfile,CApath)) &&
 		(!SSL_CTX_set_default_verify_paths(c_ctx)))
 		{
-		/* fprintf(stderr,"SSL_load_verify_locations\n"); */
+		/* fprintf(stderr,"SSL_load_verify_locations_client\n"); */
 		ERR_print_errors(bio_err);
 		/* goto end; */
 		}


### PR DESCRIPTION
This commit has security implications for simple clients that use `openssl s_client`. To demostrate the issue described in the commit message do:

```
openssl s_client -connect github.com:443 -verify_return_error -quiet -verify 105 -CAfile my_ca.pem
```

Where `my_ca.pem` is any certificate file other than the one that actually signed github's cert. This should fail, but it currently succeeds.

This pull request fixes that. Together with the annoyance that if you _don't_ specify a `CAfile` in the above command it fails, though it should have succeeded. :)

Discovered and debugged together with @errge. 

---

The intention was obviously to use the user-specified CAfile and CApath _and_ if that fails (eg. user didn't specify anything) to use the defaults. Having `||` instead of `&&` has two implications:
1. If the user doesn't specify anything, we don't use the defaults, so
   verification will always fail. This is mostly a nuisance.
2. If the user _does_ specify something for `CAfile` or `CApath`, we will
   load the defaults _too_. Which have security implications: A simple
   client implementation with `openssl s_client` that wants to check that
   it's talking to the right server by specifying a private CAfile fails
   to achieve the promised security (as the server's certificate will also
   be checked against the default CA list).
