### PR TITLE
BIO_debug_callback: Fix output on 64-bit machines

### DIFF
--- a/crypto/bio/bio_cb.c
+++ b/crypto/bio/bio_cb.c
@@ -70,14 +70,17 @@ long MS_CALLBACK BIO_debug_callback(BIO *bio, int cmd, const char *argp,
 	MS_STATIC char buf[256];
 	char *p;
 	long r=1;
+	int len;
 	size_t p_maxlen;
 
 	if (BIO_CB_RETURN & cmd)
 		r=ret;
 
-	BIO_snprintf(buf,sizeof buf,"BIO[%08lX]:",(unsigned long)bio);
-	p= &(buf[14]);
-	p_maxlen = sizeof buf - 14;
+	len = BIO_snprintf(buf,sizeof buf,"BIO[%p]: ",(void *)bio);
+
+	p = buf + len;
+	p_maxlen = sizeof buf - len;
+
 	switch (cmd)
 		{
 	case BIO_CB_FREE:


### PR DESCRIPTION
BIO_debug_callback() should not assume that the hexadecimal representation of a pointer fits in 8 characters since that isn't a valid assumption on 64-bit machines.  Also, it shouldn't cast from (BIO *) to (unsigned long), which is a dodgy cast to make on LLP64 systems like 64-bit Windows.