### PR TITLE
Fix major bugs in CRYPTO_128_unwrap()

### DIFF
--- a/crypto/modes/wrap128.c
+++ b/crypto/modes/wrap128.c
@@ -201,16 +201,16 @@ size_t CRYPTO_128_unwrap(void *key, const unsigned char *iv,
     unsigned char got_iv[8];
 
     ret = crypto_128_unwrap_raw(key, got_iv, out, in, inlen, block);
-    if (ret != inlen)
-        return ret;
+    if (ret == 0)
+        return 0;
 
     if (!iv)
         iv = default_iv;
-    if (CRYPTO_memcmp(out, iv, 8)) {
-        OPENSSL_cleanse(out, inlen);
+    if (CRYPTO_memcmp(got_iv, iv, 8)) {
+        OPENSSL_cleanse(out, ret);
         return 0;
     }
-    return inlen;
+    return ret;
 }
 
 /** Wrapping according to RFC 5649 section 4.1.

--- a/crypto/modes/wrap128.c
+++ b/crypto/modes/wrap128.c
@@ -81,9 +81,9 @@ static const unsigned char default_aiv[] = {
  *
  *  @param[in]  key    Key value.
  *  @param[in]  iv     IV value. Length = 8 bytes. NULL = use default_iv.
- *  @param[in]  in     Plain text as n 64-bit blocks, n >= 2.
+ *  @param[in]  in     Plaintext as n 64-bit blocks, n >= 2.
  *  @param[in]  inlen  Length of in.
- *  @param[out] out    Cipher text. Minimal buffer length = (inlen + 8) bytes.
+ *  @param[out] out    Ciphertext. Minimal buffer length = (inlen + 8) bytes.
  *                     Input and output buffers can overlap if block function
  *                     supports that.
  *  @param[in]  block  Block processing function.
@@ -127,19 +127,19 @@ size_t CRYPTO_128_wrap(void *key, const unsigned char *iv,
 }
 
 /** Unwrapping according to RFC 3394 section 2.2.2 steps 1-2.
- *  IV check (step 3) is responsibility of the caller.
+ *  The IV check (step 3) is responsibility of the caller.
  *
  *  @param[in]  key    Key value.
  *  @param[out] iv     Unchecked IV value. Minimal buffer length = 8 bytes.
- *  @param[out] out    Plain text without IV.
+ *  @param[out] out    Plaintext without IV.
  *                     Minimal buffer length = (inlen - 8) bytes.
  *                     Input and output buffers can overlap if block function
  *                     supports that.
- *  @param[in]  in     Ciphertext text as n 64-bit blocks
+ *  @param[in]  in     Ciphertext as n 64-bit blocks.
  *  @param[in]  inlen  Length of in.
  *  @param[in]  block  Block processing function.
  *  @return            0 if inlen is out of range [24, CRYPTO128_WRAP_MAX]
- *                     or if inlen is not multiply of 8.
+ *                     or if inlen is not a multiple of 8.
  *                     Output length otherwise.
  */
 static size_t crypto_128_unwrap_raw(void *key, unsigned char *iv,
@@ -174,21 +174,22 @@ static size_t crypto_128_unwrap_raw(void *key, unsigned char *iv,
     return inlen;
 }
 
-/** Unwrapping according to RFC 3394 section 2.2.2 including IV check.
- *  First block of plain text have to match supplied IV otherwise an error is
- *  returned.
+/** Unwrapping according to RFC 3394 section 2.2.2, including the IV check.
+ *  The first block of plaintext has to match the supplied IV, otherwise an
+ *  error is returned.
  *
  *  @param[in]  key    Key value.
- *  @param[out] iv     Unchecked IV value. Minimal buffer length = 8 bytes.
- *  @param[out] out    Plain text without IV.
+ *  @param[out] iv     IV value to match against. Length = 8 bytes.
+ *                     NULL = use default_iv.
+ *  @param[out] out    Plaintext without IV.
  *                     Minimal buffer length = (inlen - 8) bytes.
  *                     Input and output buffers can overlap if block function
  *                     supports that.
- *  @param[in]  in     Ciphertext text as n 64-bit blocks
+ *  @param[in]  in     Ciphertext as n 64-bit blocks.
  *  @param[in]  inlen  Length of in.
  *  @param[in]  block  Block processing function.
  *  @return            0 if inlen is out of range [24, CRYPTO128_WRAP_MAX]
- *                     or if inlen is not multiply of 8
+ *                     or if inlen is not a multiple of 8
  *                     or if IV doesn't match expected value.
  *                     Output length otherwise.
  */
@@ -216,10 +217,10 @@ size_t CRYPTO_128_unwrap(void *key, const unsigned char *iv,
  *
  *  @param[in]  key    Key value.
  *  @param[in]  icv    (Non-standard) IV, 4 bytes. NULL = use default_aiv.
- *  @param[out] out    Cipher text. Minimal buffer length = (inlen + 15) bytes.
+ *  @param[out] out    Ciphertext. Minimal buffer length = (inlen + 15) bytes.
  *                     Input and output buffers can overlap if block function
  *                     supports that.
- *  @param[in]  in     Plain text as n 64-bit blocks, n >= 2.
+ *  @param[in]  in     Plaintext as n 64-bit blocks, n >= 2.
  *  @param[in]  inlen  Length of in.
  *  @param[in]  block  Block processing function.
  *  @return            0 if inlen is out of range [1, CRYPTO128_WRAP_MAX].
@@ -282,14 +283,14 @@ size_t CRYPTO_128_wrap_pad(void *key, const unsigned char *icv,
  *
  *  @param[in]  key    Key value.
  *  @param[in]  icv    (Non-standard) IV, 4 bytes. NULL = use default_aiv.
- *  @param[out] out    Plain text. Minimal buffer length = inlen bytes.
+ *  @param[out] out    Plaintext. Minimal buffer length = inlen bytes.
  *                     Input and output buffers can overlap if block function
  *                     supports that.
- *  @param[in]  in     Ciphertext text as n 64-bit blocks
+ *  @param[in]  in     Ciphertext as n 64-bit blocks.
  *  @param[in]  inlen  Length of in.
  *  @param[in]  block  Block processing function.
  *  @return            0 if inlen is out of range [16, CRYPTO128_WRAP_MAX],
- *                     or if inlen is not multiply of 8
+ *                     or if inlen is not a multiple of 8
  *                     or if IV and message length indicator doesn't match.
  *                     Output length if unwrapping succeeded and IV matches.
  */
@@ -308,7 +309,7 @@ size_t CRYPTO_128_unwrap_pad(void *key, const unsigned char *icv,
     static unsigned char zeros[8] = { 0x0 };
     size_t ret;
 
-    /* Section 4.2: Cipher text length has to be (n+1) 64-bit blocks. */
+    /* Section 4.2: Ciphertext length has to be (n+1) 64-bit blocks. */
     if ((inlen & 0x7) != 0 || inlen < 16 || inlen >= CRYPTO128_WRAP_MAX)
         return 0;
 


### PR DESCRIPTION
`crypto/modes/wrap128.c` was heavily refactored to support AES Key Wrap with Padding, and four bugs were introduced into `CRYPTO_128_unwrap()` at that time:

* `crypto_128_unwrap_raw()`'s return value (`ret`) is checked incorrectly, and the function immediately returns `ret` in (almost) all cases. This makes the IV checking code later in the function unreachable, but callers think the IV check succeeded since `CRYPTO_128_unwrap()`'s return value is non-zero.

  FIX: Return `0` (error) if `crypto_128_unwrap_raw()` returned `0` (error).

* `crypto_128_unwrap_raw()` writes the IV to the `got_iv` buffer, not to the first 8 bytes of the output buffer (`out`) as the IV checking code expects.  This makes the IV check fail.

  FIX: Compare `iv` to `got_iv`, not `out`.

* The data written to the output buffer (`out`) is "cleansed" if the IV check fails, but the code passes `OPENSSL_cleanse()` the input buffer length (`inlen`) instead of the number of bytes that `crypto_128_unwrap_raw()` wrote to the output buffer (`ret`).  This means that `OPENSSL_cleanse()` could potentially write past the end of `out`.

  FIX: Change `inlen` to `ret` in the `OPENSSL_cleanse()` call.

* `CRYPTO_128_unwrap()` is returning the length of the input buffer (`inlen`) instead of the number of bytes written to the output buffer (`ret`).  This could cause the caller to read past the end of `out`.

  FIX: Return `ret` instead of `inlen` at the end of the function.

Also fix minor issues in the Doxygen comments in `crypto/modes/wrap128.c`.