### PR TITLE
Add support for Linux syscall "getrandom".

### DIFF
--- a/crypto/engine/Makefile
+++ b/crypto/engine/Makefile
@@ -22,13 +22,13 @@ LIBSRC= eng_err.c eng_lib.c eng_list.c eng_init.c eng_ctrl.c \
 	tb_rsa.c tb_dsa.c tb_ecdsa.c tb_dh.c tb_ecdh.c tb_rand.c tb_store.c \
 	tb_cipher.c tb_digest.c tb_pkmeth.c tb_asnmth.c \
 	eng_openssl.c eng_cnf.c eng_dyn.c eng_cryptodev.c \
-	eng_rdrand.c
+	eng_rdrand.c eng_linux_getrandom.c
 LIBOBJ= eng_err.o eng_lib.o eng_list.o eng_init.o eng_ctrl.o \
 	eng_table.o eng_pkey.o eng_fat.o eng_all.o \
 	tb_rsa.o tb_dsa.o tb_ecdsa.o tb_dh.o tb_ecdh.o tb_rand.o tb_store.o \
 	tb_cipher.o tb_digest.o tb_pkmeth.o tb_asnmth.o \
 	eng_openssl.o eng_cnf.o eng_dyn.o eng_cryptodev.o \
-	eng_rdrand.o
+	eng_rdrand.o eng_linux_getrandom.o
 
 SRC= $(LIBSRC)
 
@@ -267,6 +267,20 @@ eng_rdrand.o: ../../include/openssl/safestack.h ../../include/openssl/sha.h
 eng_rdrand.o: ../../include/openssl/stack.h ../../include/openssl/symhacks.h
 eng_rdrand.o: ../../include/openssl/x509.h ../../include/openssl/x509_vfy.h
 eng_rdrand.o: eng_rdrand.c
+eng_linux_getrandom.o: ../../include/openssl/asn1.h ../../include/openssl/bio.h
+eng_linux_getrandom.o: ../../include/openssl/buffer.h ../../include/openssl/crypto.h
+eng_linux_getrandom.o: ../../include/openssl/e_os2.h ../../include/openssl/ec.h
+eng_linux_getrandom.o: ../../include/openssl/ecdh.h ../../include/openssl/ecdsa.h
+eng_linux_getrandom.o: ../../include/openssl/engine.h ../../include/openssl/err.h
+eng_linux_getrandom.o: ../../include/openssl/evp.h ../../include/openssl/lhash.h
+eng_linux_getrandom.o: ../../include/openssl/obj_mac.h ../../include/openssl/objects.h
+eng_linux_getrandom.o: ../../include/openssl/opensslconf.h
+eng_linux_getrandom.o: ../../include/openssl/opensslv.h ../../include/openssl/ossl_typ.h
+eng_linux_getrandom.o: ../../include/openssl/pkcs7.h ../../include/openssl/rand.h
+eng_linux_getrandom.o: ../../include/openssl/safestack.h ../../include/openssl/sha.h
+eng_linux_getrandom.o: ../../include/openssl/stack.h ../../include/openssl/symhacks.h
+eng_linux_getrandom.o: ../../include/openssl/x509.h ../../include/openssl/x509_vfy.h
+eng_linux_getrandom.o: eng_linux_getrandom.c
 eng_table.o: ../../e_os.h ../../include/openssl/asn1.h
 eng_table.o: ../../include/openssl/bio.h ../../include/openssl/buffer.h
 eng_table.o: ../../include/openssl/crypto.h ../../include/openssl/e_os2.h

--- a/crypto/engine/eng_all.c
+++ b/crypto/engine/eng_all.c
@@ -76,6 +76,7 @@ void ENGINE_load_builtin_engines(void)
 #ifndef OPENSSL_NO_RDRAND
 	ENGINE_load_rdrand();
 #endif
+	ENGINE_load_linux_getrandom();
 	ENGINE_load_dynamic();
 #ifndef OPENSSL_NO_STATIC_ENGINE
 #ifndef OPENSSL_NO_HW

--- a/crypto/engine/eng_linux_getrandom.c
+++ b/crypto/engine/eng_linux_getrandom.c
@@ -1,0 +1,145 @@
+#include <openssl/opensslconf.h>
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#ifdef HAVE_SYS_SYSCTL_H
+#include <sys/sysctl.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <openssl/engine.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+
+#ifndef SYS_getrandom
+
+#if (defined(__i386)   || defined(__i386__)   || defined(_M_IX86) || \
+     defined(__x86_64) || defined(__x86_64__))
+#ifdef __LP64__
+#define SYS_getrandom 318
+#else
+#define SYS_getrandom 355
+#endif // __LP64__
+#endif // x86 or amd64
+
+#endif // !defined(SYS_getrandom)
+
+#if defined(OPENSSL_SYS_LINUX) && defined(SYS_getrandom)
+
+// see <linux>/include/uapi/linux/random.h
+#ifndef GRND_NONBLOCK
+#define GRND_NONBLOCK 0x0001
+#endif
+#ifndef GRND_RANDOM
+#define GRND_RANDOM 0x0002
+#endif
+
+static int sys_getrandom_ex (const unsigned char *buf, size_t buflen,
+							 const unsigned int flags)
+	{
+	int pre_errno = errno;
+	unsigned char *p = (unsigned char *)buf;
+
+	while (buflen)
+		{
+		int ret = 0; // ret < 0 is an error, else: number of bytes returned
+		int chunk = buflen > 256 ? 256 : buflen; // min(256, buflen);
+
+		do {
+			ret = syscall(SYS_getrandom, p, chunk, flags);
+		} while (ret == -1 && errno == EINTR);
+		if (ret < 0)
+			return ret;
+
+		p += ret;
+		buflen -= ret;
+		}
+
+	errno = pre_errno;
+	return 1;
+	}
+
+static int get_random_bytes (unsigned char *buf, int buflen)
+	{
+		if (buflen < 0)
+			return (-1);
+		return sys_getrandom_ex(buf, (size_t)buflen, GRND_RANDOM);
+	}
+
+static int get_pseudorandom_bytes (unsigned char *buf, int buflen)
+	{
+		if (buflen < 0)
+			return (-1);
+		return sys_getrandom_ex(buf, (size_t)buflen, 0);
+	}
+
+/* Consumes a few bytes of entropy by issuing the syscall. */
+static int linux_has_syscall_getrandom (void)
+	{
+		int pre_errno = errno;
+		unsigned long buf;
+		syscall(SYS_getrandom, (unsigned char*)&buf, sizeof(unsigned long),
+			GRND_NONBLOCK);
+		if (errno == ENOSYS)
+			return 0;
+		errno = pre_errno;
+		return 1;
+	}
+
+static int random_status (void)
+{	return 1;	}
+
+static RAND_METHOD linux_getrandom_meth =
+	{
+	NULL,	/* seed */
+	get_random_bytes,
+	NULL,	/* cleanup */
+	NULL,	/* add */
+	get_pseudorandom_bytes,
+	random_status,
+	};
+
+static int linux_getrandom_init(ENGINE *e)
+{	return 1;	}
+
+static const char *engine_e_linux_getrandom_id = "linux_getrandom";
+static const char *engine_e_linux_getrandom_name = "Linux syscall: getrandom";
+
+static int bind_helper(ENGINE *e)
+	{
+	if (!ENGINE_set_id(e, engine_e_linux_getrandom_id) ||
+	    !ENGINE_set_name(e, engine_e_linux_getrandom_name) ||
+	    !ENGINE_set_init_function(e, linux_getrandom_init) ||
+	    !ENGINE_set_RAND(e, &linux_getrandom_meth) )
+		return 0;
+
+	return 1;
+	}
+
+static ENGINE *ENGINE_linux_getrandom(void)
+	{
+	ENGINE *ret = ENGINE_new();
+	if(!ret)
+		return NULL;
+	if(!bind_helper(ret))
+		{
+		ENGINE_free(ret);
+		return NULL;
+		}
+	return ret;
+	}
+
+void ENGINE_load_linux_getrandom (void)
+	{
+	if (linux_has_syscall_getrandom() == 1)
+		{
+		ENGINE *toadd = ENGINE_linux_getrandom();
+		if(!toadd) return;
+		ENGINE_add(toadd);
+		ENGINE_free(toadd);
+		ERR_clear_error();
+		}
+	}
+#else // !(defined(OPENSSL_SYS_LINUX) && defined(SYS_getrandom))
+void ENGINE_load_linux_getrandom (void) {}
+#endif

--- a/crypto/engine/eng_linux_getrandom.c
+++ b/crypto/engine/eng_linux_getrandom.c
@@ -113,6 +113,7 @@ static int bind_helper(ENGINE *e)
 	{
 	if (!ENGINE_set_id(e, engine_e_linux_getrandom_id) ||
 	    !ENGINE_set_name(e, engine_e_linux_getrandom_name) ||
+	    !ENGINE_set_flags(e, ENGINE_FLAGS_NO_REGISTER_ALL) ||
 	    !ENGINE_set_init_function(e, linux_getrandom_init) ||
 	    !ENGINE_set_RAND(e, &linux_getrandom_meth) )
 		return 0;

--- a/crypto/engine/eng_linux_getrandom.c
+++ b/crypto/engine/eng_linux_getrandom.c
@@ -22,6 +22,10 @@
 #endif // __LP64__
 #endif // x86 or amd64
 
+#ifdef __aarch64__
+#define SYS_getrandom 384
+#endif
+
 #endif // !defined(SYS_getrandom)
 
 #if defined(OPENSSL_SYS_LINUX) && defined(SYS_getrandom)

--- a/crypto/engine/engine.h
+++ b/crypto/engine/engine.h
@@ -352,6 +352,7 @@ void ENGINE_load_gost(void);
 #endif
 void ENGINE_load_cryptodev(void);
 void ENGINE_load_rdrand(void);
+void ENGINE_load_linux_getrandom(void);
 void ENGINE_load_builtin_engines(void);
 
 /* Get and set global flags (ENGINE_TABLE_FLAG_***) for the implementation


### PR DESCRIPTION
Implements the syscall "getrandom", available in Linux 3.17, as new engine in a LIBC-agnostic way.

Please note that the engine is not available if the syscall is not implemented (ENOSYS returned).