### PR TITLE
Fix compiling in directories with spaces

### DIFF
--- a/util/copy.pl
+++ b/util/copy.pl
@@ -1,7 +1,7 @@
 #!/usr/local/bin/perl
 
 use Fcntl;
-
+use File::Glob ':glob';
 
 # copy.pl
 
@@ -19,7 +19,7 @@ foreach $arg (@ARGV) {
 		next;
 		}
 	$arg =~ s|\\|/|g;	# compensate for bug/feature in cygwin glob...
-	foreach (glob $arg)
+	foreach (bsd_glob $arg)
 		{
 		push @filelist, $_;
 		}
@@ -34,7 +34,7 @@ if ($fnum <= 1)
 
 $dest = pop @filelist;
 	
-if ($fnum > 2 && ! -d $dest)
+if ($fnum > 2 && ! -d "$dest")
 	{
 	die "Destination must be a directory";
 	}

--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -575,7 +575,7 @@ $cp2 = $cp unless defined $cp2;
 
 $extra_install= <<"EOF";
 	\$(CP) \"\$(INCO_D)${o}*.\[ch\]\" \"\$(INSTALLTOP)${o}include${o}openssl\"
-	\$(CP) \"\$(BIN_D)$o\$(E_EXE)$exep \$(INSTALLTOP)${o}bin\"
+	\$(CP) \"\$(BIN_D)$o\$(E_EXE)$exep\" \"\$(INSTALLTOP)${o}bin\"
 	\$(MKDIR) \"\$(OPENSSLDIR)\"
 	\$(CP) apps${o}openssl.cnf \"\$(OPENSSLDIR)\"
 EOF


### PR DESCRIPTION
This fix helps especially building OpenSSL on Windows when using Jenkins as the default build directory contains spaces in its pathname.

This patch requires the bsd_glob functions of Perl to be available which usually should be the case for any reasonable Perl configuration.