### PR TITLE
Allow setting custom cipher strings in the openssl config file.

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -131,6 +131,11 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
     if (!cnf)
         return 1;
 
+    /* This is unrelated but added here because everyone calls
+     * CONF_modules_load(), but no other conf function.
+     */
+    CONF_profile_load(cnf);
+
     if (appname)
         vsection = NCONF_get_string(cnf, NULL, appname);
 
@@ -401,6 +406,7 @@ void CONF_modules_unload(int all)
 {
     int i;
     CONF_MODULE *md;
+    CONF_profile_unload();
     CONF_modules_finish();
     /* unload modules in reverse order */
     for (i = sk_CONF_MODULE_num(supported_modules) - 1; i >= 0; i--) {

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -199,6 +199,9 @@ int CONF_parse_list(const char *list, int sep, int nospc,
                     int (*list_cb) (const char *elem, int len, void *usr),
                     void *arg);
 
+int CONF_profile_load(const CONF *cnf);
+void CONF_profile_unload(void);
+
 void OPENSSL_load_builtin_modules(void);
 
 /* BEGIN ERROR CODES */

--- a/include/openssl/conf_api.h
+++ b/include/openssl/conf_api.h
@@ -80,6 +80,8 @@ char *_CONF_get_string(const CONF *conf, const char *section,
 long _CONF_get_number(const CONF *conf, const char *section,
                       const char *name);
 
+STACK_OF(CONF_VALUE) *_CONF_get_policy_values(void);
+
 int _CONF_new_data(CONF *conf);
 void _CONF_free_data(CONF *conf);
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -69,6 +69,7 @@ V3NAMETEST=	v3nametest
 HEARTBEATTEST=  heartbeat_test
 CONSTTIMETEST=  constant_time_test
 VERIFYEXTRATEST=	verify_extra_test
+CONFPROFILETEST=	conf_profile_test
 
 TESTS=		alltests
 
@@ -85,7 +86,7 @@ EXE=	$(BNTEST)$(EXE_EXT) $(ECTEST)$(EXE_EXT)  $(ECDSATEST)$(EXE_EXT) $(ECDHTEST)
 	$(JPAKETEST)$(EXE_EXT) $(SECMEMTEST)$(EXE_EXT) \
 	$(SRPTEST)$(EXE_EXT) $(V3NAMETEST)$(EXE_EXT) \
 	$(HEARTBEATTEST)$(EXE_EXT) $(P5_CRPT2_TEST)$(EXE_EXT) \
-	$(CONSTTIMETEST)$(EXE_EXT) $(VERIFYEXTRATEST)$(EXE_EXT)
+	$(CONSTTIMETEST)$(EXE_EXT) $(VERIFYEXTRATEST)$(EXE_EXT) $(CONFPROFILETEST)$(EXE_EXT)
 
 # $(METHTEST)$(EXE_EXT)
 
@@ -99,7 +100,8 @@ OBJ=	$(BNTEST).o $(ECTEST).o  $(ECDSATEST).o $(ECDHTEST).o $(IDEATEST).o \
 	$(BFTEST).o  $(SSLTEST).o  $(DSATEST).o  $(EXPTEST).o $(RSATEST).o \
 	$(EVPTEST).o $(EVPEXTRATEST).o $(IGETEST).o $(JPAKETEST).o $(V3NAMETEST).o \
 	$(GOST2814789TEST).o $(HEARTBEATTEST).o $(P5_CRPT2_TEST).o \
-	$(CONSTTIMETEST).o $(VERIFYEXTRATEST).o testutil.o
+	$(CONSTTIMETEST).o $(VERIFYEXTRATEST).o testutil.o \
+	$(CONFPROFILETEST).o
 
 SRC=	$(BNTEST).c $(ECTEST).c  $(ECDSATEST).c $(ECDHTEST).c $(IDEATEST).c \
 	$(MD2TEST).c  $(MD4TEST).c $(MD5TEST).c \
@@ -110,7 +112,8 @@ SRC=	$(BNTEST).c $(ECTEST).c  $(ECDSATEST).c $(ECDHTEST).c $(IDEATEST).c \
 	$(BFTEST).c  $(SSLTEST).c $(DSATEST).c   $(EXPTEST).c $(RSATEST).c \
 	$(EVPTEST).c $(EVPEXTRATEST).c $(IGETEST).c $(JPAKETEST).c $(V3NAMETEST).c \
 	$(GOST2814789TEST).c $(HEARTBEATTEST).c $(P5_CRPT2_TEST).c \
-	$(CONSTTIMETEST).c $(VERIFYEXTRATEST).c testutil.c
+	$(CONSTTIMETEST).c $(VERIFYEXTRATEST).c testutil.c \
+	$(CONFPROFILETEST).c
 
 HEADER=	testutil.h
 
@@ -151,7 +154,7 @@ alltests: \
 	test_ige test_jpake test_secmem \
 	test_srp test_cms test_v3name test_ocsp \
 	test_gost2814789 test_heartbeat test_p5_crpt2 \
-	test_constant_time test_verify_extra
+	test_constant_time test_verify_extra test_conf_profile
 
 test_evp: $(EVPTEST)$(EXE_EXT) evptests.txt
 	@echo $(START) $@
@@ -400,6 +403,10 @@ test_constant_time: $(CONSTTIMETEST)$(EXE_EXT)
 	@echo $(START) $@
 	../util/shlib_wrap.sh ./$(CONSTTIMETEST)
 
+test_conf_profile: $(CONFPROFILETEST)$(EXE_EXT)
+	@echo $(START) $@
+	../util/shlib_wrap.sh ./$(CONFPROFILETEST)
+
 test_verify_extra: $(VERIFYEXTRATEST)$(EXE_EXT)
 	@echo $(START) $@
 	../util/shlib_wrap.sh ./$(VERIFYEXTRATEST)
@@ -591,6 +598,9 @@ $(HEARTBEATTEST)$(EXE_EXT): $(HEARTBEATTEST).o $(DLIBCRYPTO) testutil.o
 $(CONSTTIMETEST)$(EXE_EXT): $(CONSTTIMETEST).o
 	@target=$(CONSTTIMETEST) $(BUILD_CMD)
 
+$(CONFPROFILETEST)$(EXE_EXT): $(CONFPROFILETEST).o
+	@target=$(CONFPROFILETEST) $(BUILD_CMD)
+
 $(VERIFYEXTRATEST)$(EXE_EXT): $(VERIFYEXTRATEST).o
 	@target=$(VERIFYEXTRATEST) $(BUILD_CMD)
 
@@ -630,6 +640,9 @@ casttest.o: ../include/openssl/opensslconf.h casttest.c
 constant_time_test.o: ../e_os.h ../include/internal/constant_time_locl.h
 constant_time_test.o: ../include/openssl/e_os2.h
 constant_time_test.o: ../include/openssl/opensslconf.h constant_time_test.c
+conf_profile_test.o: ../e_os.h ../include/internal/constant_time_locl.h ../apps/apps.h
+conf_profile_test.o: ../include/openssl/e_os2.h
+conf_profile_test.o: ../include/openssl/opensslconf.h conf_profile_test.c
 destest.o: ../include/openssl/des.h ../include/openssl/e_os2.h
 destest.o: ../include/openssl/opensslconf.h destest.c
 dhtest.o: ../e_os.h ../include/openssl/bio.h ../include/openssl/bn.h

--- a/test/conf_profile_test.c
+++ b/test/conf_profile_test.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+static
+BIO *dup_bio_in(void)
+{
+    return BIO_new_fp(stdin, BIO_NOCLOSE | BIO_FP_TEXT);
+}
+
+static
+BIO *dup_bio_out(void)
+{
+    BIO *b = BIO_new_fp(stdout, BIO_NOCLOSE | BIO_FP_TEXT);
+    return b;
+}
+
+static BIO *bio_open_default_(const char *filename, const char *mode, int quiet)
+{
+    BIO *ret;
+
+    if (filename == NULL || strcmp(filename, "-") == 0) {
+        ret = *mode == 'r' ? dup_bio_in() : dup_bio_out();
+        if (quiet) {
+            ERR_clear_error();
+            return ret;
+        }
+        if (ret != NULL)
+            return ret;
+        fprintf(stderr,
+                   "Can't open %s, %s\n",
+                   *mode == 'r' ? "stdin" : "stdout", strerror(errno));
+    } else {
+        ret = BIO_new_file(filename, mode);
+        if (quiet) {
+            ERR_clear_error();
+            return ret;
+        }
+        if (ret != NULL)
+            return ret;
+        fprintf(stderr,
+                   "Can't open %s for %s, %s\n",
+                   filename,
+                   *mode == 'r' ? "reading" : "writing", strerror(errno));
+    }
+    return NULL;
+}
+
+int
+main()
+{
+    CONF *conf;
+    BIO *in;
+    long errline;
+    int ret;
+    unsigned ciphers_num, high_ciphers_num;
+    SSL_CTX *ctx = NULL;
+
+    OpenSSL_add_all_algorithms();
+    ERR_load_crypto_strings();
+
+    in = bio_open_default_("profiles-openssl.cnf", "r", 1);
+    if (in == NULL) {
+        fprintf(stderr, "unable to open configuration file\n");
+        exit(1);
+    }
+
+    conf = NCONF_new(NULL);
+    if (conf == NULL) {
+        fprintf(stderr, "unable to init configuration\n");
+        exit(1);
+    }
+
+    ret = NCONF_load_bio(conf, in, &errline);
+    if (ret <= 0) {
+    	fprintf(stderr, "cannot load file: %ld\n", errline);
+    	exit(1);
+    }
+
+    if (CONF_modules_load(conf, NULL, 0) <= 0) {
+    	fprintf(stderr, "failed in CONF_modules_load\n");
+    	exit(1);
+    }
+
+    ctx = SSL_CTX_new(TLSv1_client_method());
+    if (ctx == NULL) {
+    	fprintf(stderr, "failed in SSL_CTX_new\n");
+    	exit(1);
+    }
+
+#define CHECK_CIPHERS(x, num) \
+    if (SSL_CTX_set_cipher_list(ctx, x) <= 0) { \
+    	fprintf(stderr, "error checking %s\n", x); \
+    	exit(1); \
+    } \
+    { \
+    SSL *ssl = NULL; \
+    STACK_OF(SSL_CIPHER) *sk = NULL; \
+    ssl = SSL_new(ctx); \
+    if (ssl == NULL) exit(1); \
+    sk = SSL_get_ciphers(ssl); \
+    ciphers_num = sk_SSL_CIPHER_num(sk); \
+    if (num != -1 && ciphers_num != num) { \
+    	fprintf(stderr, "unexpected number of ciphers (%d) for profile %s\n", ciphers_num, x); \
+    	exit(1); \
+    } \
+    SSL_free(ssl); \
+    }
+
+    CHECK_CIPHERS("HIGH", -1);
+    high_ciphers_num = ciphers_num;
+    CHECK_CIPHERS("PROFILE=PROFILE1", 2);
+    CHECK_CIPHERS("PROFILE=PROFILE2", 1);
+    CHECK_CIPHERS("PROFILE=PROFILE-HIGH", high_ciphers_num);
+
+    /* verify the cipher in profile2 */
+    
+
+    if (SSL_CTX_set_cipher_list(ctx, "PROFILE3") > 0) {
+    	fprintf(stderr, "error checking inexistant profile\n");
+    	exit(1);
+    }
+    SSL_CTX_free(ctx);
+    BIO_free(in);
+    CONF_modules_unload(1);
+
+    return 0;
+}

--- a/test/profiles-openssl.cnf
+++ b/test/profiles-openssl.cnf
@@ -1,0 +1,25 @@
+#
+# OpenSSL example configuration file.
+# This is mostly being used for generation of certificate requests.
+#
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= .
+RANDFILE		= $ENV::HOME/.rnd
+
+# Extra OBJECT IDENTIFIER info:
+#oid_file		= $ENV::HOME/.oid
+oid_section		= new_oids
+
+# To use this configuration file with the "-extfile" option of the
+# "openssl x509" utility, name here the section containing the
+# X.509v3 extensions to use:
+# extensions		= 
+# (Alternatively, use a configuration file that has only
+# X.509v3 extensions in its main [= default] section.)
+
+[ cipher_profiles ]
+PROFILE1 = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384
+PROFILE2 = ECDHE-RSA-AES128-GCM-SHA256
+PROFILE-HIGH = HIGH


### PR DESCRIPTION
When the PROFILE=KEYWORD is specified as a cipher string, openssl will
expand the keyword to the defined cipher string in the configuration
file under section "cipher_profiles". That requires the default
(or any other) configuration file to be loaded.

An example entry in the configuration file:
[ cipher_profiles ]
PROFILE1 = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384
PROFILE2 = HIGH

Also in: http://rt.openssl.org/Ticket/Display.html?id=3299
