### PR TITLE
Help text small improvement

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -508,8 +508,12 @@ static void sv_usage(void)
 	BIO_printf(bio_err," -srpvfile file      - The verifier file for SRP\n");
 	BIO_printf(bio_err," -srpuserseed string - A seed string for a default user salt.\n");
 #endif
+#ifndef OPENSSL_NO_SSL2
 	BIO_printf(bio_err," -ssl2         - Just talk SSLv2\n");
+#endif
+#ifndef OPENSSL_NO_SSL3
 	BIO_printf(bio_err," -ssl3         - Just talk SSLv3\n");
+#endif
 	BIO_printf(bio_err," -tls1_2       - Just talk TLSv1.2\n");
 	BIO_printf(bio_err," -tls1_1       - Just talk TLSv1.1\n");
 	BIO_printf(bio_err," -tls1         - Just talk TLSv1\n");
@@ -518,8 +522,12 @@ static void sv_usage(void)
 	BIO_printf(bio_err," -timeout      - Enable timeouts\n");
 	BIO_printf(bio_err," -mtu          - Set link layer MTU\n");
 	BIO_printf(bio_err," -chain        - Read a certificate chain\n");
+#ifndef OPENSSL_NO_SSL2
 	BIO_printf(bio_err," -no_ssl2      - Just disable SSLv2\n");
+#endif
+#ifndef OPENSSL_NO_SSL3
 	BIO_printf(bio_err," -no_ssl3      - Just disable SSLv3\n");
+#endif
 	BIO_printf(bio_err," -no_tls1      - Just disable TLSv1\n");
 	BIO_printf(bio_err," -no_tls1_1    - Just disable TLSv1.1\n");
 	BIO_printf(bio_err," -no_tls1_2    - Just disable TLSv1.2\n");


### PR DESCRIPTION
Hello everyone,

I have struggled trying to understand why, in a Debian distro, I was 
not able to run the openssl command line tool forcing ssl3,  the tool 
has kept showing me
the help text :

xxx@xxx:~/sslsniff$ ./openssl/apps/openssl s_server -cipher AES256-SHA 
-accept 4433 -www -CAfile client.crt -verify 1 -key server.pem -cert 
server.crt  -ssl3
WARNING: can't open config file: /usr/local/ssl/openssl.cnf
verify depth is 1
*unknown option -ssl3*
usage: s_server [args ...]
 -accept port  - TCP/IP port to accept on (default is 4433)
[...]
 -ssl2         - Just talk SSLv2
 -ssl3         - Just talk SSLv3
 -tls1_2       - Just talk TLSv1.2
 -tls1_1       - Just talk TLSv1.1
 -tls1         - Just talk TLSv1
 -dtls1        - Just talk DTLSv1
[...]

It shows the ssl3 option but in fact the software was not compiled with 
such support (./config -no-ssl3). With this change the -ssl2 -ssl3 
-no_ssl2 -no_ssl3 should
be printed out only when such support was enabled at compile time. I 
have done my best reading the wiki about how to submit patches but I am 
not sure everything complies with the procedure, sorry in advance.
