### PR TITLE
Propagate tlsext_status_type from SSL_CTX to SSL to allow OCSP stapling ...

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4184,6 +4184,9 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
 			}
 		return 1;
 		}
+	case SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE:
+		ctx->tlsext_status_type = larg;
+		break;
 
 #ifdef TLSEXT_TYPE_opaque_prf_input
 	case SSL_CTRL_SET_TLSEXT_OPAQUE_PRF_INPUT_CB_ARG:

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -1137,6 +1137,9 @@ struct ssl_ctx_st
 	size_t tlsext_ellipticcurvelist_length;
 	unsigned char *tlsext_ellipticcurvelist;
 # endif /* OPENSSL_NO_EC */
+
+	/* ext status type used for CSR extension (OCSP Stapling) */
+	int tlsext_status_type; 
 	};
 
 #endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -349,7 +349,7 @@ SSL *SSL_new(SSL_CTX *ctx)
 	s->tlsext_debug_cb = 0;
 	s->tlsext_debug_arg = NULL;
 	s->tlsext_ticket_expected = 0;
-	s->tlsext_status_type = -1;
+	s->tlsext_status_type = ctx->tlsext_status_type;
 	s->tlsext_status_expected = 0;
 	s->tlsext_ocsp_ids = NULL;
 	s->tlsext_ocsp_exts = NULL;
@@ -2040,6 +2040,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
 
 	ret->tlsext_status_cb = 0;
 	ret->tlsext_status_arg = NULL;
+	ret->tlsext_status_type = -1;
 
 # ifndef OPENSSL_NO_NEXTPROTONEG
 	ret->next_protos_advertised_cb = 0;

--- a/ssl/tls1.h
+++ b/ssl/tls1.h
@@ -388,6 +388,9 @@ SSL_CTX_callback_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB,(void (*)(void))cb)
 #define SSL_CTX_set_tlsext_status_arg(ssl, arg) \
 SSL_CTX_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB_ARG,0, (void *)arg)
 
+#define SSL_CTX_set_tlsext_status_type(ssl, type) \
+SSL_CTX_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE,type, NULL)
+
 #define SSL_set_tlsext_opaque_prf_input(s, src, len) \
 SSL_ctrl(s,SSL_CTRL_SET_TLSEXT_OPAQUE_PRF_INPUT, len, src)
 #define SSL_CTX_set_tlsext_opaque_prf_input_callback(ctx, cb) \


### PR DESCRIPTION
This patch was authored by Joe Urciuoli.  This patch allows OCSP stapling to work with libcurl.  Applications that use libcurl with OpenSSL have access to the SSL_CTX reference, not the SSL reference.  Without this patch it's not possible to use OCSP stapling with TLS.