### PR TITLE
RT3513: req doesn't display attributes using utf8string

### DIFF
--- a/crypto/asn1/t_req.c
+++ b/crypto/asn1/t_req.c
@@ -200,6 +200,7 @@ get_next:
 				if (BIO_puts(bp,":") <= 0) goto err;
 				if (	(type == V_ASN1_PRINTABLESTRING) ||
 					(type == V_ASN1_T61STRING) ||
+					(type == V_ASN1_UTF8STRING) ||
 					(type == V_ASN1_IA5STRING))
 					{
 					if (BIO_write(bp,(char *)bs->data,bs->length)


### PR DESCRIPTION
CSR attributes are written (by 'req') in utf8string, but displaying printed output ('-text') won't show them and instead displays 'unable to print attribute'.


I believe this fixes RT3513, though it's not just limited to challengePassword.

http://rt.openssl.org/Ticket/Display.html?id=3513&user=guest&pass=guest