### PR TITLE
Fix BIO_printf function replaces the last char of the output with \0 under certain conditions.

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -734,7 +734,7 @@ doapr_outch(
     assert(*sbuffer != NULL || buffer != NULL);
 
     if (buffer) {
-	while (*currlen >= *maxlen) {
+	while (*currlen >= *maxlen - 1 ) {
 	    if (*buffer == NULL) {
 		if (*maxlen == 0)
 		    *maxlen = 1024;


### PR DESCRIPTION
I was contacted the same problem to the mailing list in the past, have requested even here because it was ignored.

http://marc.info/?l=openssl-users&m=137722533630452&w=2