### PR TITLE
[v2] implement -no_tlsext

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -427,6 +427,9 @@ static void sc_usage(void)
                " -keymatexport label   - Export keying material using label\n");
     BIO_printf(bio_err,
                " -keymatexportlen len  - Export len bytes of keying material (default 20)\n");
+    BIO_printf(bio_err,
+               " -no_tlsext        - Don't send any TLS extensions (breaks servername, NPN and ALPN among others)\n");
+
 }
 
 #ifndef OPENSSL_NO_TLSEXT

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -73,6 +73,7 @@ B<openssl> B<s_client>
 [B<-engine id>]
 [B<-tlsextdebug>]
 [B<-no_ticket>]
+[B<-no_tlsext>]
 [B<-sess_out filename>]
 [B<-sess_in filename>]
 [B<-rand file(s)>]
@@ -297,6 +298,13 @@ print out a hex dump of any TLS extensions received from the server.
 =item B<-no_ticket>
 
 disable RFC4507bis session ticket support. 
+
+=item B<-no_tlsext>
+
+disable sending any and all TLS extensions in Client Hello message.
+
+Note that this will break other options like B<-servername>, B<-nextprotoneg>
+or B<-alpn>.
 
 =item B<-sess_out filename>
 

--- a/doc/ssl/SSL_CONF_cmd.pod
+++ b/doc/ssl/SSL_CONF_cmd.pod
@@ -127,6 +127,11 @@ Disables support for SSL/TLS compression, same as setting B<SSL_OP_NO_COMPRESS>.
 
 Disables support for session tickets, same as setting B<SSL_OP_NO_TICKET>.
 
+=item B<-no_tlsext>
+
+Disables sending any and all TLS extensions in Client Hello, including session
+tickets, supported curves, heartbeat, etc. same as setting B<SSL_OP_NO_TLSEXT>.
+
 =item B<-serverpref>
 
 Use server and not client preference order when determining which cipher suite,
@@ -295,6 +300,11 @@ B<ServerPreference> use server and not client preference order when
 determining which cipher suite, signature algorithm or elliptic curve
 to use for an incoming connection.  Equivalent to
 B<SSL_OP_CIPHER_SERVER_PREFERENCE>. Only used by servers.
+
+B<TLSExtensions>: send TLS extensions in Client Hello, set by default.
+Note that disabling extensions will break other options like SRP, ALPN, NPN or
+server name indication among others. Inverse of B<SSL_OP_NO_TLSEXT>: that is
+B<-TLSExtensions> is the same as setting B<SSL_OP_NO_TLSEXT>.
 
 B<NoResumptionOnRenegotiation> set
 B<SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION> flag. Only used by servers.

--- a/doc/ssl/SSL_CTX_set_options.pod
+++ b/doc/ssl/SSL_CTX_set_options.pod
@@ -191,6 +191,14 @@ Do not use the SSLv3 protocol.
 
 Do not use the TLSv1 protocol.
 
+=item SSL_OP_NO_TLSEXT
+
+Don't send any TLS extensions in client hello, even if it will break other
+options like SRP, ALPN, NPN, server name indication, etc.
+
+Required for interoperability with particularly broken servers that don't
+tolerate any extensions in Client Hello.
+
 =item SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
 
 When performing renegotiation as a server, always start a new session

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -575,6 +575,10 @@ struct ssl_session_st {
 # define SSL_OP_MICROSOFT_SESS_ID_BUG                    0x0
 # define SSL_OP_NETSCAPE_CHALLENGE_BUG                   0x0
 
+/* Disables sending any TLS extensions in client hello, even if required
+ * by used protocol version, ciphers or other options */
+# define SSL_OP_NO_TLSEXT                                0x00000400L
+
 /*
  * Disable SSL 3.0/TLS 1.0 CBC vulnerability workaround that was added in
  * OpenSSL 0.9.6d.  Usually (depending on the application protocol) the

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -94,6 +94,8 @@ typedef struct {
         {str, (int)(sizeof(str) - 1), SSL_TFLAG_SERVER, flag}
 #define SSL_FLAG_TBL_CLI(str, flag) \
         {str, (int)(sizeof(str) - 1), SSL_TFLAG_CLIENT, flag}
+#define SSL_FLAG_TBL_CLI_INV(str, flag) \
+	{str, (int)(sizeof(str) - 1), SSL_TFLAG_INV|SSL_TFLAG_CLIENT, flag}
 #define SSL_FLAG_TBL_INV(str, flag) \
         {str, (int)(sizeof(str) - 1), SSL_TFLAG_INV|SSL_TFLAG_BOTH, flag}
 #define SSL_FLAG_TBL_SRV_INV(str, flag) \
@@ -215,6 +217,7 @@ static int ctrl_str_option(SSL_CONF_CTX *cctx, const char *cmd)
         SSL_FLAG_TBL_CERT("debug_broken_protocol",
                           SSL_CERT_FLAG_BROKEN_PROTOCOL),
 #endif
+		SSL_FLAG_TBL_CLI("no_tlsext", SSL_OP_NO_TLSEXT),
     };
     cctx->tbl = ssl_option_single;
     cctx->ntbl = sizeof(ssl_option_single) / sizeof(ssl_flag_tbl);
@@ -351,6 +354,7 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_SRV("ECDHSingle", SSL_OP_SINGLE_ECDH_USE),
         SSL_FLAG_TBL("UnsafeLegacyRenegotiation",
                      SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION),
+        SSL_FLAG_TBL_CLI_INV("TLSExtensions", SSL_OP_NO_TLSEXT),
     };
     if (!(cctx->flags & SSL_CONF_FLAG_FILE))
         return -2;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1167,6 +1167,10 @@ unsigned char *ssl_add_clienthello_tlsext(SSL *s, unsigned char *buf,
     if (s->client_version == SSL3_VERSION)
         goto done;
 
+    /* skip all options if asked for it */
+    if (s->options & SSL_OP_NO_TLSEXT)
+        goto done;
+
     if (s->tlsext_hostname != NULL) {
         /* Add TLS extension servername to the Client Hello message */
         unsigned long size_str;


### PR DESCRIPTION
Some servers implement TLS1.0 but are intolerant to any and all
extensions sent by clients. Implement option to disable sending
of the extensions completely.

Obsoletes pull #198.

v2 changes:
- rebase on current master
- changes the option to client only (as suggested by @mattcaswell )
