### PR TITLE
Fix regression in ASN1_UTCTIME_cmp_time_t

### DIFF
--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -249,7 +249,7 @@ int ASN1_UTCTIME_cmp_time_t(const ASN1_UTCTIME *s, time_t t)
     if (!OPENSSL_gmtime(&t, &ttm))
         return -2;
 
-    if (!OPENSSL_gmtime_diff(&day, &sec, &stm, &ttm))
+    if (!OPENSSL_gmtime_diff(&day, &sec, &ttm, &stm))
         return -2;
 
     if (day > 0)


### PR DESCRIPTION
Previously, ASN1_UTCTIME_cmp_time_t would return 1 if s > t, -1 if
s < t, and 0 if s == t.

This behavior was broken in a refactor (904348a4922333106b613754136305db229475ea), resulting in the opposite
time comparison behavior.