### PR TITLE
Fix Cisco DTLS support

### DIFF
--- a/ssl/d1_both.c
+++ b/ssl/d1_both.c
@@ -1094,6 +1094,7 @@ int dtls1_buffer_message(SSL *s, int is_ccs)
     pitem *item;
     hm_fragment *frag;
     unsigned char seq64be[8];
+    unsigned int expected_hdr_len;
 
     /*
      * this function is called immediately after a message has been
@@ -1107,13 +1108,15 @@ int dtls1_buffer_message(SSL *s, int is_ccs)
 
     memcpy(frag->fragment, s->init_buf->data, s->init_num);
 
-    if (is_ccs) {
-        OPENSSL_assert(s->d1->w_msg_hdr.msg_len +
-                       DTLS1_CCS_HEADER_LENGTH == (unsigned int)s->init_num);
-    } else {
-        OPENSSL_assert(s->d1->w_msg_hdr.msg_len +
-                       DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num);
-    }
+    if (!is_ccs)
+        expected_hdr_len = DTLS1_HM_HEADER_LENGTH;
+    else if (s->version == DTLS1_BAD_VER)
+        expected_hdr_len = 3;
+    else
+        expected_hdr_len = DTLS1_CCS_HEADER_LENGTH;
+
+    OPENSSL_assert(s->d1->w_msg_hdr.msg_len +
+                   expected_hdr_len == (unsigned int)s->init_num);
 
     frag->msg_header.msg_len = s->d1->w_msg_hdr.msg_len;
     frag->msg_header.seq = s->d1->w_msg_hdr.seq;

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -270,7 +270,7 @@ void dtls1_clear(SSL *s)
 
     ssl3_clear(s);
     if (s->options & SSL_OP_CISCO_ANYCONNECT)
-        s->version = DTLS1_BAD_VER;
+        s->client_version = s->version = DTLS1_BAD_VER;
     else if (s->method->version == DTLS_ANY_VERSION)
         s->version = DTLS1_2_VERSION;
     else


### PR DESCRIPTION
I have had to add a configure time check for the OpenConnect VPN client, instructing users not to use the OpenSSL 1.0.2 release. The fixes the regressions, and it would be good if it could make it into the 1.0.2a release. Each patch is already filed in its respective RT ticket.