### PR TITLE
Fix memory leak

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -582,6 +582,8 @@ void SSL_free(SSL *s)
 # ifndef OPENSSL_NO_EC
     if (s->tlsext_ecpointformatlist)
         OPENSSL_free(s->tlsext_ecpointformatlist);
+    if (s->tlsext_ecpointformatlist_length)
+        OPENSSL_free(s->tlsext_ecpointformatlist_length);
     if (s->tlsext_ellipticcurvelist)
         OPENSSL_free(s->tlsext_ellipticcurvelist);
 # endif                         /* OPENSSL_NO_EC */


### PR DESCRIPTION
"s->tlsext_ecpointformatlist_length" which allocated in ssl/t1_lib.c:2120 should be free when SSL_free() is called.