### PR TITLE
MinGW32 bug includes winsock.h and winsock2.h

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -236,8 +236,10 @@ extern "C" {
         * it's sufficient to check for specific Winsock2 API availability
         * at run-time [DSO_global_lookup is recommended]...
         */
+#ifndef _WINSOCK_H
 #    include <winsock2.h>
 #    include <ws2tcpip.h>
+#endif
        /* yes, they have to be #included prior to <windows.h> */
 #   endif
 #   include <windows.h>


### PR DESCRIPTION
Compiling in windows with **MinGW32**, *windows.h* includes *winsock.h*, lately in *e_os.h*, it tries to include *winsock2.h* and *ws2tcpip.h*, which is incompatible with winsock.h. Until now, the only solution was to define OPENSSL_NO_SOCK but it disables this functionallity.