### PR TITLE
Prevent a NULL dereference in X509_REQ_check_private_key.

### DIFF
--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -122,6 +122,8 @@ int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k)
     int ok = 0;
 
     xk = X509_REQ_get_pubkey(x);
+    if (xk == NULL)
+        return (ok);
     switch (EVP_PKEY_cmp(xk, k)) {
     case 1:
         ok = 1;


### PR DESCRIPTION
I saw 28a00bcd and went looking for similar bugs.

Here `EVP_PKEY_cmp` assumes its arguments are non-`NULL`.