### PR TITLE
c_rehash: Avoid some buggy uses of regexp in argument parsing

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -15,13 +15,13 @@ my $symlink_exists=eval {symlink("",""); 1};
 my $removelinks = 1;
 
 ##  Parse flags.
-while ( $ARGV[0] =~ '-.*' ) {
+while ( $ARGV[0] =~ /^-/ ) {
     my $flag = shift @ARGV;
     last if ( $flag eq '--');
-    if ( $flag =~ /-old/) {
+    if ( $flag eq '-old' ) {
 	    $x509hash = "-subject_hash_old";
 	    $crlhash = "-hash_old";
-    } elsif ( $flag =~ /-h/) {
+    } elsif ( $flag eq '-h' ) {
 	    help();
     } elsif ( $flag eq '-n' ) {
 	    $removelinks = 0;


### PR DESCRIPTION
The regexp was unanchored, the expression `-.*` could be anywhere in the
argument for it to match. This includes within directory names.  Without
this change, giving c_rehash a path containing - would make it error out
with "Usage error; try -help".

This commit also changes some options from being matched via regexp to
being matched for identity with eq for the same reason (having "-h"
somewhere in your argument was enough for it to show help and exit).


To reproduce, try one of

* `c_rehash /some/path/with-dash`

This will print the `Usage error; try -help` error, as if the argument was an
unknown flag.

* `c_rehash /some/path/with-dash-and-h`

This will print the help text, since -h is found within the argument.