### PR TITLE
mingw config: remove -march=i486 compiler flag

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1155,7 +1155,7 @@
     "mingw" => {
         inherit_from     => [ asm("x86_asm") ],
         cc               => "gcc",
-        cflags           => "-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -march=i486 -Wall",
+        cflags           => "-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -Wall",
         debug_cflags     => "-g -O0",
         release_clags    => "-O3 -fomit-frame-pointer",
         thread_cflag     => "-D_MT",


### PR DESCRIPTION
It's better to leave this to the C compiler default or let it be set explicitly (f.e. when building for embedded systems using old x86 instruction sets). In any case it's best not to set it back _by default_ to such an old compatibility level as 486 is.