### PR TITLE
Makefile.shared: add SHARED_RCFLAGS setting

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -282,7 +282,7 @@ link_a.cygwin:
 	fi; \
 	dll_name=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX; \
 	$(PERL) util/mkrc.pl $$dll_name | \
-		$(CROSS_COMPILE)windres -o rc.o; \
+		$(CROSS_COMPILE)windres $(SHARED_RCFLAGS) -o rc.o; \
 	extras="$$extras rc.o"; \
 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \


### PR DESCRIPTION
It allows to pass CPU platform flag (`-F`) to `windres` tool, so that 
a dual-target mingw distro can be used to build the non-default target.