### PR TITLE
Uninitialized memory causes segmentation fault

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -165,6 +165,7 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
                 EVPerr(EVP_F_EVP_CIPHERINIT_EX, ERR_R_MALLOC_FAILURE);
                 return 0;
             }
+            (void) memset(ctx->cipher_data, 0, ctx->cipher->ctx_size);
         } else {
             ctx->cipher_data = NULL;
         }


### PR DESCRIPTION
EVP_CIPHER_CTX_clearnup() may call ctx->cipher->cleanup() to cleanup the context 'ctx->cipher_data' before it gets initialized by a call to ctx->cipher->init().   This causes a segmentation fault.

ctx->cipher_data should be initialized to 0s.