### PR TITLE
check null pointer

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1484,7 +1484,11 @@ STACK_OF(SSL_CIPHER) *ssl_bytes_to_cipher_list(SSL *s, unsigned char *p,
         return (NULL);
     }
     if ((skp == NULL) || (*skp == NULL))
+        {
         sk = sk_SSL_CIPHER_new_null(); /* change perhaps later */
+        if(sk == NULL)
+            return NULL;
+        }
     else {
         sk = *skp;
         sk_SSL_CIPHER_zero(sk);


### PR DESCRIPTION
In function ssl_bytes_to_cipher_list,
if "sk_SSL_CIPHER_new_null returns null (because of not enough memory), "sk_SSL_CIPHER_push" will cause segmentation fault.