### PR TITLE
Fix for memcpy() and strcmp() being undefined.

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -112,6 +112,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h> /* for memcpy() and strcmp() */
 #define USE_SOCKETS
 #include "apps.h"
 #undef USE_SOCKETS


### PR DESCRIPTION
clang says: "s_cb.c:958:9: error: implicitly declaring library function 'memcpy'"