### PR TITLE
OpenSSL 1.0.1 - Retrieve/Display Server Temporary Keys

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,11 @@
 
  Changes between 1.0.1m and 1.0.1n [xx XXX xxxx]
 
+  *) New ctrl to retrieve server temporary keys received during key exchange.
+     Print bit lengths in s_client. For ECDH, also print named curve. Back
+     ported from 1.0.2.
+     [mancha security <mancha1@zoho.com>]
+
   *) Reject DH handshakes with parameters shorter than 768 bits.
      [Kurt Roeckx and Emilia Kasper]
 

--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -161,6 +161,7 @@ int MS_CALLBACK verify_callback(int ok, X509_STORE_CTX *ctx);
 int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file);
 int set_cert_key_stuff(SSL_CTX *ctx, X509 *cert, EVP_PKEY *key);
 #endif
+int ssl_print_tmp_key(BIO *out, SSL *s);
 int init_client(int *sock, char *server, int port, int type);
 int should_retry(int i);
 int extract_port(char *str, short *port_ptr);

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -272,6 +272,38 @@ int set_cert_key_stuff(SSL_CTX *ctx, X509 *cert, EVP_PKEY *key)
     return 1;
 }
 
+int ssl_print_tmp_key(BIO *out, SSL *s)
+{
+    EVP_PKEY *key;
+
+    if (!SSL_get_server_tmp_key(s, &key))
+        return 1;
+    BIO_puts(out, "Server Temp Key: ");
+    switch (EVP_PKEY_id(key)) {
+    case EVP_PKEY_RSA:
+        BIO_printf(out, "RSA, %d bits\n", EVP_PKEY_bits(key));
+        break;
+
+    case EVP_PKEY_DH:
+        BIO_printf(out, "DH, %d bits\n", EVP_PKEY_bits(key));
+        break;
+
+    case EVP_PKEY_EC:
+        {
+            EC_KEY *ec = EVP_PKEY_get1_EC_KEY(key);
+            int nid;
+            const char *cname;
+            nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
+            EC_KEY_free(ec);
+            cname = OBJ_nid2sn(nid);
+            BIO_printf(out, "ECDH, %s, %d bits\n",
+                        cname, EVP_PKEY_bits(key));
+        }
+    }
+    EVP_PKEY_free(key);
+    return 1;
+}
+
 long MS_CALLBACK bio_dump_callback(BIO *bio, int cmd, const char *argp,
                                    int argi, long argl, long ret)
 {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1969,6 +1969,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
         } else {
             BIO_printf(bio, "---\nNo client certificate CA names sent\n");
         }
+        ssl_print_tmp_key(bio, s);
         p = SSL_get_shared_ciphers(s, buf, sizeof buf);
         if (p != NULL) {
             /*

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -1767,6 +1767,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_CLEAR_MODE                     78
 # define SSL_CTRL_GET_EXTRA_CHAIN_CERTS          82
 # define SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS        83
+# define SSL_CTRL_GET_SERVER_TMP_KEY             109
 # define SSL_CTRL_CHECK_PROTO_VERSION            119
 # define DTLS_CTRL_SET_LINK_MTU                  120
 # define DTLS_CTRL_GET_LINK_MIN_MTU              121
@@ -1806,6 +1807,9 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_CTX_ctrl(ctx,SSL_CTRL_GET_EXTRA_CHAIN_CERTS,0,px509)
 # define SSL_CTX_clear_extra_chain_certs(ctx) \
         SSL_CTX_ctrl(ctx,SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS,0,NULL)
+# define SSL_get_server_tmp_key(s, pk) \
+        SSL_ctrl(s,SSL_CTRL_GET_SERVER_TMP_KEY,0,pk)
+
 # ifndef OPENSSL_NO_BIO
 BIO_METHOD *BIO_f_ssl(void);
 BIO *BIO_new_ssl(SSL_CTX *ctx, int client);


### PR DESCRIPTION
OpenSSL 1.0.2 introduced a ctrl to retrieve server temporary keys received during key exchange.

Relevant bit lengths (*i.e.* RSA modulus, FF DH group, ECDH prime bit length for GF(*p*) and degree for GF(*2<sup>m</sup>*)) are displayed by `s_client`. In the case of ECDH, named curves are also displayed.

In the aftermath of [Logjam](https://weakdh.org/), many are interested in testing servers for small group sizes in fixed field Diffie-Hellman (*cf.* [thread](http://marc.info/?t=143228955200002&r=1&w=2)).

My pull request back ports this valuable functionality to OpenSSL 1.0.1.
<hr>
&nbsp;&nbsp;&nbsp;&nbsp;Diagnosing Logjam exposure (per [OpenSSL blog](https://www.openssl.org/blog/blog/2015/05/20/logjam-freak-upcoming-changes/)):

&nbsp;&nbsp;&nbsp;&nbsp;`openssl s_client -connect www.example.com:443 -cipher "EDH" | grep "Server Temp Key"`