### PR TITLE
Unmix two error returns by removing the dead one.

### DIFF
--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -369,7 +369,6 @@ int ssl3_accept(SSL *s)
                      */
                     if (al != TLS1_AD_UNKNOWN_PSK_IDENTITY)
                         SSLerr(SSL_F_SSL3_ACCEPT, SSL_R_CLIENTHELLO_TLSEXT);
-                    ret = SSL_TLSEXT_ERR_ALERT_FATAL;
                     ret = -1;
                     s->state = SSL_ST_ERR;
                     goto end;


### PR DESCRIPTION
Here ret is set to SSL_TLSEXT_ERR_ALERT_FATAL like would be done in
the TLSv1 code, but it seems the intention here is really just to set
ret to -1; the alert is sent above.