### PR TITLE
Fix NAME section in SSL_CTX_use_serverinfo.pod

### DIFF
--- a/doc/ssl/SSL_CTX_use_serverinfo.pod
+++ b/doc/ssl/SSL_CTX_use_serverinfo.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-SSL_CTX_use_serverinfo, SSL_CTX_use_serverinfo_file
+SSL_CTX_use_serverinfo, SSL_CTX_use_serverinfo_file - use serverinfo extension
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
extract-names.pl run on this podfile produced an empty output,
consequently causing install_docs target to create a symlink
with an invalid name:

installing man3/SSL_CTX_use_serverinfo.3
.3 => SSL_CTX_use_serverinfo.3