### PR TITLE
Increase buffer sizes for cert passwords on the CLI

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -160,7 +160,7 @@ int pkcs12_main(int argc, char **argv)
 {
     char *infile = NULL, *outfile = NULL, *keyname = NULL, *certfile = NULL;
     char *name = NULL, *csp_name = NULL;
-    char pass[50], macpass[50];
+    char pass[2048], macpass[2048];
     int export_cert = 0, options = 0, chain = 0, twopass = 0, keytype = 0;
     int iter = PKCS12_DEFAULT_ITER, maciter = PKCS12_DEFAULT_ITER;
 # ifndef OPENSSL_NO_RC2


### PR DESCRIPTION
This allows decryption of files with passwords longer than 50 characters.