### PR TITLE
Visual studio 2015 (VS2015) iob_func build fix

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -315,7 +315,7 @@ static __inline unsigned int _strlen31(const char *str)
 #    undef isxdigit
 #   endif
 #   if defined(_MSC_VER) && !defined(_DLL) && defined(stdin)
-#    if _MSC_VER>=1300
+#    if _MSC_VER>=1300 && _MSC_VER<1900
 #     undef stdin
 #     undef stdout
 #     undef stderr


### PR DESCRIPTION
In VS2015 stdout changed from (&__iob_func()[1]) to (__acrt_iob_func(1)) breaking openssl/e_os.h.  This change fixed unresolved external symbols to iob_func for me.