### PR TITLE
Allow s390x asm output files to be in subdirs

### DIFF
--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -92,7 +92,7 @@ if ($flavour =~ /3[12]/) {
 	$g="g";
 }
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 $softonly=0;	# allow hardware support

--- a/crypto/bn/asm/s390x-gf2m.pl
+++ b/crypto/bn/asm/s390x-gf2m.pl
@@ -35,7 +35,7 @@ if ($flavour =~ /3[12]/) {
         $g="g";
 }
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 $stdframe=16*$SIZE_T+4*8;

--- a/crypto/bn/asm/s390x-mont.pl
+++ b/crypto/bn/asm/s390x-mont.pl
@@ -54,7 +54,7 @@ if ($flavour =~ /3[12]/) {
 	$g="g";
 }
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 $stdframe=16*$SIZE_T+4*8;

--- a/crypto/modes/asm/ghash-s390x.pl
+++ b/crypto/modes/asm/ghash-s390x.pl
@@ -47,7 +47,7 @@ if ($flavour =~ /3[12]/) {
 	$g="g";
 }
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 $softonly=0;

--- a/crypto/rc4/asm/rc4-s390x.pl
+++ b/crypto/rc4/asm/rc4-s390x.pl
@@ -33,7 +33,7 @@ if ($flavour =~ /3[12]/) {
 	$g="g";
 }
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 $rp="%r14";

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -43,7 +43,7 @@ if ($flavour =~ /3[12]/) {
 	$g="g";
 }
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 $K_00_39="%r0"; $K=$K_00_39;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -64,7 +64,7 @@ $tbl="%r13";
 $T1="%r14";
 $sp="%r15";
 
-while (($output=shift) && ($output!~/^\w[\w\-]*\.\w+$/)) {}
+while (($output=shift) && ($output!~/^\w[\w\-\/]*\.\w+$/)) {}
 open STDOUT,">$output";
 
 if ($output =~ /512/) {


### PR DESCRIPTION
Minor update to the 'output' regular expressions in s390x asm perl scripts to allow '/' character.  This change enables users to specify the s390x asm output files to be generated into a sub-directory.  i.e.

      perl crypto/sha/asm/sha512-s390x.pl 31 mysubdir/sha512-s390x.s

Motivation behind the change was highlighted by Node.js (and potentially other things), which packages OpenSSL as one of its dependencies, and generates the asm files into platform specific sub-directories.  

Without the change, we'd either:

1.  Generate the output into the current directory and move it afterwards (unpleasant complexity and inconsistencies in build toolchain).
2.  Have the generated assembly code be printed to *stdout*, and capture it.  Unfortunately, this option does not work, as [sha512-s390x.pl](https://github.com/openssl/openssl/blob/master/crypto/sha/asm/sha512-s390x.pl#L70-L98) uses the name of an accepted `$output` to determine whether to generate SHA256 vs SHA512 sequences.
