### PR TITLE
Fix Valgrind Error: Conditional jump or move depends on uninitialised…

### DIFF
--- a/crypto/rsa/rsa_eay.c
+++ b/crypto/rsa/rsa_eay.c
@@ -188,6 +188,7 @@ static int RSA_eay_public_encrypt(int flen, const unsigned char *from,
         RSAerr(RSA_F_RSA_EAY_PUBLIC_ENCRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
     }
+    memset(buf,0,num);
 
     switch (padding) {
     case RSA_PKCS1_PADDING:


### PR DESCRIPTION
… value(s)

==29489== Conditional jump or move depends on uninitialised value(s)
==29489== at 0x8171D09: RSA_padding_add_PKCS1_type_2 (rsa_pk1.c:169)
==29489== by 0x816FF08: RSA_eay_public_encrypt (rsa_eay.c:198)
==29489== by 0x810EBC2: RSA_public_encrypt (rsa_crpt.c:86)
==29489== by 0x80C1723: ssl3_send_client_key_exchange (s3_clnt.c:2410)
==29489== by 0x80C35C8: ssl3_connect (s3_clnt.c:406)
==29489== by 0x80DA5BB: SSL_connect (ssl_lib.c:943)
==29489== by 0x80CD21B: ssl23_connect (s23_clnt.c:805)
==29489== by 0x80DA5D2: SSL_connect (ssl_lib.c:943)
==29489== by 0x80B9585: openSSLConnectionPb (ssl_connection.c:524)
==29489== by 0x4050681: commsOpenClientSocket (bClientSocket.c:126)
==29489== by 0x404F1A4: commsThread (smcomms.c:812)
==29489== by 0x4529A48: start_thread (in /lib/libpthread-2.12.so)
==29489== Uninitialised value was created by a heap allocation
==29489== at 0x40072B2: malloc (vg_replace_malloc.c:270)
==29489== by 0x80F244B: default_malloc_ex (mem.c:79)
==29489== by 0x80F29D7: CRYPTO_malloc (mem.c:312)
==29489== by 0x816FCEA: RSA_eay_public_encrypt (rsa_eay.c:188)
==29489== by 0x810EBC2: RSA_public_encrypt (rsa_crpt.c:86)
==29489== by 0x80C1723: ssl3_send_client_key_exchange (s3_clnt.c:2410)
==29489== by 0x80C35C8: ssl3_connect (s3_clnt.c:406)
==29489== by 0x80DA5BB: SSL_connect (ssl_lib.c:943)
==29489== by 0x80CD21B: ssl23_connect (s23_clnt.c:805)
==29489== by 0x80DA5D2: SSL_connect (ssl_lib.c:943)
==29489== by 0x80B9585: openSSLConnectionPb (ssl_connection.c:524)
==29489== by 0x4050681: commsOpenClientSocket (bClientSocket.c:126)