### PR TITLE
Fix Valgrind Error: Conditional jump or move depends on uninitialised…

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -205,6 +205,8 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
             if (ctx->md_data == NULL) {
                 EVPerr(EVP_F_EVP_DIGESTINIT_EX, ERR_R_MALLOC_FAILURE);
                 return 0;
+            } else {
+                memset(ctx->md_data,0,type->ctx_size);
             }
         }
     }


### PR DESCRIPTION
… value(s)

Fix Unitialised Memory Valgrind Error:

==30323== Conditional jump or move depends on uninitialised value(s)
==30323== at 0x80C943F: ssl3_read_bytes (s3_pkt.c:1091)
==30323== by 0x80CA0C2: ssl3_get_message (s3_both.c:539)
==30323== by 0x80C9A55: ssl3_get_finished (s3_both.c:246)
==30323== by 0x80C3586: ssl3_connect (s3_clnt.c:549)
==30323== by 0x80DA5BB: SSL_connect (ssl_lib.c:943)
==30323== by 0x80B9585: openSSLConnectionPb (ssl_connection.c:524)
==30323== by 0x4050681: commsOpenClientSocket (bClientSocket.c:126)
==30323== by 0x404F1A4: commsThread (smcomms.c:812)
==30323== by 0x4529A48: start_thread (in /lib/libpthread-2.12.so)
==30323== by 0x21CE1D: clone (in /lib/libc-2.12.so)
==30323== Uninitialised value was created by a heap allocation
==30323== at 0x40072B2: malloc (vg_replace_malloc.c:270)
==30323== by 0x80F244B: default_malloc_ex (mem.c:79)
==30323== by 0x80F29D7: CRYPTO_malloc (mem.c:312)
==30323== by 0x81179E3: EVP_DigestInit_ex (digest.c:210)
==30323== by 0x80FDA44: HMAC_Init_ex (hmac.c:130)
==30323== by 0x815307D: pkey_hmac_ctrl (hm_pmeth.c:198)
==30323== by 0x81207A6: EVP_PKEY_CTX_ctrl (pmeth_lib.c:408)
==30323== by 0x811798D: EVP_DigestInit_ex (digest.c:225)
==30323== by 0x8121C78: do_sigver_init (m_sigver.c:114)
==30323== by 0x80D1679: tls1_PRF (t1_enc.c:179)