### PR TITLE
Fix Valgrind Error: Conditional jump or move depends on uninitialised…

### DIFF
--- a/ssl/s3_clnt.c
+++ b/ssl/s3_clnt.c
@@ -2373,6 +2373,7 @@ int ssl3_send_client_key_exchange(SSL *s)
             if (!pms)
                 goto memerr;
 
+            memset(pms,0,pmslen);
             if (s->session->peer == NULL) {
                 /*
                  * We should always have a server certificate with SSL_kRSA.


### PR DESCRIPTION
… value(s)

Fix Valgrind Error (Output below based upon 1.0.1k):

==5127== Conditional jump or move depends on uninitialised value(s)
==5127== at 0x8171D09: RSA_padding_add_PKCS1_type_2 (rsa_pk1.c:169)
==5127== by 0x816FFF8: RSA_eay_public_encrypt (rsa_eay.c:199)
==5127== by 0x810EBC2: RSA_public_encrypt (rsa_crpt.c:86)
==5127== by 0x80C1723: ssl3_send_client_key_exchange (s3_clnt.c:2411)
==5127== by 0x80C35C8: ssl3_connect (s3_clnt.c:406)
==5127== by 0x80DA5BB: SSL_connect (ssl_lib.c:943)
==5127== by 0x80CD21B: ssl23_connect (s23_clnt.c:805)
==5127== by 0x80DA5D2: SSL_connect (ssl_lib.c:943)
==5127== by 0x80B9585: openSSLConnectionPb (ssl_connection.c:524)
==5127== by 0x4050681: commsOpenClientSocket (bClientSocket.c:126)
==5127== by 0x404F1A4: commsThread (smcomms.c:812)
==5127== by 0x4529A48: start_thread (in /lib/libpthread-2.12.so)
==5127== Uninitialised value was created by a stack allocation
==5127== at 0x80C1626: ssl3_send_client_key_exchange (s3_clnt.c:2341)