### PR TITLE
Add an OCSP_SINGLERESP_get0_id() accessor to the OCSP_CERTID of a OCSP_SINGLERESP.

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -386,3 +386,8 @@ int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
 
     return ret;
 }
+
+OCSP_CERTID *OCSP_SINGLERESP_get0_id(OCSP_SINGLERESP *single)
+{
+    return single->certId;
+}

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -359,6 +359,7 @@ void *OCSP_SINGLERESP_get1_ext_d2i(OCSP_SINGLERESP *x, int nid, int *crit,
 int OCSP_SINGLERESP_add1_ext_i2d(OCSP_SINGLERESP *x, int nid, void *value,
                                  int crit, unsigned long flags);
 int OCSP_SINGLERESP_add_ext(OCSP_SINGLERESP *x, X509_EXTENSION *ex, int loc);
+OCSP_CERTID *OCSP_SINGLERESP_get0_id(OCSP_SINGLERESP *x);
 
 DECLARE_ASN1_FUNCTIONS(OCSP_SINGLERESP)
 DECLARE_ASN1_FUNCTIONS(OCSP_CERTSTATUS)


### PR DESCRIPTION
Add an OCSP_SINGLERESP_get0_id() accessor to the OCSP_CERTID of a OCSP_SINGLERESP.

It is possible to do it the other way around using OCSP_resp_find(), but this is
more efficient when you have a tree indexed by OCSP_CERTID, like haproxy does.