### PR TITLE
Return an exit code if report fails

### DIFF
--- a/util/selftest.pl
+++ b/util/selftest.pl
@@ -199,3 +199,6 @@ while (<IN>) {
 }
 print "\nTest report in file $report\n";
 
+if ($ok != 2) {
+        die;
+}


### PR DESCRIPTION

If one automates the make process and does a proper check with ``make report`` one is depended on a  proper return code. As of now there's none.

This would fix it 
