### PR TITLE
Added backslash in front of first hash of pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # editor artefacts
 *.swp
 .#*
-#*#
+\#*#
 *~
 
 # Top level excludes


### PR DESCRIPTION
See http://git-scm.com/docs/gitignore
If the first character is a hash and isn't escaped using a backslash, it's seen as a comment.