### PR TITLE
Fix broken "openssl genrsa" and other misc option issues

### DIFF
--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -141,6 +141,7 @@ int genrsa_main(int argc, char **argv)
             break;
         case OPT_OUT:
             outfile = opt_arg();
+            break;
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
             break;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -200,6 +200,7 @@ int pkeyutl_main(int argc, char **argv)
             break;
         case OPT_REV:
             rev = 1;
+            break;
         case OPT_ENCRYPT:
             pkey_op = EVP_PKEY_OP_ENCRYPT;
             break;

--- a/apps/req.c
+++ b/apps/req.c
@@ -344,7 +344,6 @@ int req_main(int argc, char **argv)
         case OPT_NO_ASN1_KLUDGE:
             kludge = 0;
             break;
-            multirdn = 1;
         case OPT_DAYS:
             days = atoi(opt_arg());
             break;


### PR DESCRIPTION
genrsa is missing a break; statement after capturing the out file argument and as such many spurious warnings about missing engines are displayed (at least on Mac OS X systems, I didn't see these warnings on Linux earlier today).

A quick grep revealed 2 other similar issues.