### PR TITLE
Fix behavior of unspecified number of requests for OCSP responder to match documentation

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -666,9 +666,11 @@ int ocsp_main(int argc, char **argv)
 
     /* If running as responder don't verify our own response */
     if (cbio) {
-        if (--accept_count <= 0) {
-            ret = 0;
-            goto end;
+        if (accept_count != -1) { /* unlimited */
+            if (--accept_count <= 0) {
+                ret = 0;
+                goto end;
+            }
         }
         BIO_free_all(cbio);
         cbio = NULL;


### PR DESCRIPTION
Documentation states that "-nrequest pnum Number of requests to accept (default unlimited)", but in practice not specifying "-nrequest" would have the affect of accepting only 1 request.