### PR TITLE
Set verify_mode according to the new CTX in SSL_set_SSL_CTX

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2843,6 +2843,7 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
     CRYPTO_add(&ctx->references, 1, CRYPTO_LOCK_SSL_CTX);
     SSL_CTX_free(ssl->ctx); /* decrement reference count */
     ssl->ctx = ctx;
+    ssl->verify_mode=ctx->verify_mode;
 
     return (ssl->ctx);
 }


### PR DESCRIPTION
When we deal with SNI, but the serveral CTX have different verify mode, this is useful.
I have this need in one of my project.
