### PR TITLE
Implement HKDF algorithm (RFC 5869)

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -90,7 +90,8 @@ static const EVP_PKEY_METHOD *standard_methods[] = {
 #ifndef OPENSSL_NO_DH
     &dhx_pkey_meth,
 #endif
-    &tls1_prf_pkey_meth
+    &tls1_prf_pkey_meth,
+    &hkdf_pkey_meth
 };
 
 DECLARE_OBJ_BSEARCH_CMP_FN(const EVP_PKEY_METHOD *, const EVP_PKEY_METHOD *,

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -131,6 +131,7 @@ extern const EVP_PKEY_METHOD ec_pkey_meth;
 extern const EVP_PKEY_METHOD hmac_pkey_meth;
 extern const EVP_PKEY_METHOD rsa_pkey_meth;
 extern const EVP_PKEY_METHOD tls1_prf_pkey_meth;
+extern const EVP_PKEY_METHOD hkdf_pkey_meth;
 
 struct evp_md_st {
     int type;

--- a/crypto/kdf/Makefile.in
+++ b/crypto/kdf/Makefile.in
@@ -15,8 +15,8 @@ CFLAGS= $(INCLUDES) $(CFLAG) $(SHARED_CFLAG)
 GENERAL=Makefile
 
 LIB=$(TOP)/libcrypto.a
-LIBSRC=tls1_prf.c kdf_err.c
-LIBOBJ=tls1_prf.o kdf_err.o
+LIBSRC=tls1_prf.c kdf_err.c hkdf.c
+LIBOBJ=tls1_prf.o kdf_err.o hkdf.o
 
 SRC= $(LIBSRC)
 

--- a/crypto/kdf/build.info
+++ b/crypto/kdf/build.info
@@ -1,3 +1,3 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
-        tls1_prf.c kdf_err.c
+        tls1_prf.c kdf_err.c hkdf.c

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -1,0 +1,332 @@
+/* ====================================================================
+ * Copyright (c) 2016 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/hmac.h>
+#include <openssl/kdf.h>
+#include <openssl/evp.h>
+#include "internal/cryptlib.h"
+#include "internal/evp_int.h"
+
+#define HKDF_MAXBUF 1024
+
+static unsigned char *HKDF(const EVP_MD *evp_md,
+                           const unsigned char *salt, size_t salt_len,
+                           const unsigned char *key, size_t key_len,
+                           const unsigned char *info, size_t info_len,
+                           unsigned char *okm, size_t okm_len);
+
+static unsigned char *HKDF_Extract(const EVP_MD *evp_md,
+                                   const unsigned char *salt, size_t salt_len,
+                                   const unsigned char *key, size_t key_len,
+                                   unsigned char *prk, size_t *prk_len);
+
+static unsigned char *HKDF_Expand(const EVP_MD *evp_md,
+                                  const unsigned char *prk, size_t prk_len,
+                                  const unsigned char *info, size_t info_len,
+                                  unsigned char *okm, size_t okm_len);
+
+typedef struct {
+    const EVP_MD *md;
+    unsigned char *salt;
+    size_t salt_len;
+    unsigned char *key;
+    size_t key_len;
+    unsigned char info[HKDF_MAXBUF];
+    size_t info_len;
+} HKDF_PKEY_CTX;
+
+static int pkey_hkdf_init(EVP_PKEY_CTX *ctx)
+{
+    HKDF_PKEY_CTX *kctx;
+
+    kctx = OPENSSL_zalloc(sizeof(*kctx));
+    if (kctx == NULL)
+        return 0;
+
+    ctx->data = kctx;
+
+    return 1;
+}
+
+static void pkey_hkdf_cleanup(EVP_PKEY_CTX *ctx)
+{
+    HKDF_PKEY_CTX *kctx = ctx->data;
+    OPENSSL_clear_free(kctx->salt, kctx->salt_len);
+    OPENSSL_clear_free(kctx->key, kctx->key_len);
+    OPENSSL_cleanse(kctx->info, kctx->info_len);
+    OPENSSL_free(kctx);
+}
+
+static int pkey_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
+{
+    HKDF_PKEY_CTX *kctx = ctx->data;
+
+    switch (type) {
+    case EVP_PKEY_CTRL_HKDF_MD:
+        if (p2 == NULL)
+            return 0;
+
+        kctx->md = p2;
+        return 1;
+
+    case EVP_PKEY_CTRL_HKDF_SALT:
+        if (p1 == 0 || p2 == NULL)
+            return 1;
+
+        if (p1 < 0)
+            return 0;
+
+        if (kctx->salt != NULL)
+            OPENSSL_clear_free(kctx->salt, kctx->salt_len);
+
+        kctx->salt = OPENSSL_memdup(p2, p1);
+        if (kctx->salt == NULL)
+            return 0;
+
+        kctx->salt_len = p1;
+        return 1;
+
+    case EVP_PKEY_CTRL_HKDF_KEY:
+        if (p1 < 0)
+            return 0;
+
+        if (kctx->key != NULL)
+            OPENSSL_clear_free(kctx->key, kctx->key_len);
+
+        kctx->key = OPENSSL_memdup(p2, p1);
+        if (kctx->key == NULL)
+            return 0;
+
+        kctx->key_len  = p1;
+        return 1;
+
+    case EVP_PKEY_CTRL_HKDF_INFO:
+        if (p1 == 0 || p2 == NULL)
+            return 1;
+
+        if (p1 < 0 || p1 > (int)(HKDF_MAXBUF - kctx->info_len))
+            return 0;
+
+        memcpy(kctx->info + kctx->info_len, p2, p1);
+        kctx->info_len += p1;
+        return 1;
+
+    default:
+        return -2;
+
+    }
+}
+
+static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
+                              const char *value)
+{
+    if (strcmp(type, "md") == 0)
+        return EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_get_digestbyname(value));
+
+    if (strcmp(type, "salt") == 0)
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
+
+    if (strcmp(type, "hexsalt") == 0)
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
+
+    if (strcmp(type, "key") == 0)
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_KEY, value);
+
+    if (strcmp(type, "hexkey") == 0)
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_KEY, value);
+
+    if (strcmp(type, "info") == 0)
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
+
+    if (strcmp(type, "hexinfo") == 0)
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
+
+    return -2;
+}
+
+static int pkey_hkdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
+                            size_t *keylen)
+{
+    HKDF_PKEY_CTX *kctx = ctx->data;
+
+    if (kctx->md == NULL || kctx->key == NULL)
+        return 0;
+
+    if (HKDF(kctx->md, kctx->salt, kctx->salt_len, kctx->key, kctx->key_len,
+             kctx->info, kctx->info_len, key, *keylen) == NULL)
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+const EVP_PKEY_METHOD hkdf_pkey_meth = {
+    EVP_PKEY_HKDF,
+    0,
+    pkey_hkdf_init,
+    0,
+    pkey_hkdf_cleanup,
+
+    0, 0,
+    0, 0,
+
+    0,
+    0,
+
+    0,
+    0,
+
+    0, 0,
+
+    0, 0, 0, 0,
+
+    0, 0,
+
+    0, 0,
+
+    0,
+    pkey_hkdf_derive,
+    pkey_hkdf_ctrl,
+    pkey_hkdf_ctrl_str
+};
+
+static unsigned char *HKDF(const EVP_MD *evp_md,
+                           const unsigned char *salt, size_t salt_len,
+                           const unsigned char *key, size_t key_len,
+                           const unsigned char *info, size_t info_len,
+                           unsigned char *okm, size_t okm_len)
+{
+    unsigned char prk[EVP_MAX_MD_SIZE];
+    size_t prk_len;
+
+    if (!HKDF_Extract(evp_md, salt, salt_len, key, key_len, prk, &prk_len))
+        return NULL;
+
+    return HKDF_Expand(evp_md, prk, prk_len, info, info_len, okm, okm_len);
+}
+
+static unsigned char *HKDF_Extract(const EVP_MD *evp_md,
+                                   const unsigned char *salt, size_t salt_len,
+                                   const unsigned char *key, size_t key_len,
+                                   unsigned char *prk, size_t *prk_len)
+{
+    unsigned int tmp_len;
+
+    if (!HMAC(evp_md, salt, salt_len, key, key_len, prk, &tmp_len))
+        return NULL;
+
+    *prk_len = tmp_len;
+    return prk;
+}
+
+static unsigned char *HKDF_Expand(const EVP_MD *evp_md,
+                                  const unsigned char *prk, size_t prk_len,
+                                  const unsigned char *info, size_t info_len,
+                                  unsigned char *okm, size_t okm_len)
+{
+    HMAC_CTX *hmac;
+
+    unsigned int i;
+
+    unsigned char prev[EVP_MAX_MD_SIZE];
+
+    size_t done_len = 0, dig_len = EVP_MD_size(evp_md);
+
+    size_t n = okm_len / dig_len;
+    if (okm_len % dig_len)
+        n++;
+
+    if (n > 255)
+        return NULL;
+
+    if ((hmac = HMAC_CTX_new()) == NULL)
+        return NULL;
+
+    if (!HMAC_Init_ex(hmac, prk, prk_len, evp_md, NULL))
+        goto err;
+
+    for (i = 1; i <= n; i++) {
+        size_t copy_len;
+        const unsigned char ctr = i;
+
+        if (i > 1) {
+            if (!HMAC_Init_ex(hmac, NULL, 0, NULL, NULL))
+                goto err;
+
+            if (!HMAC_Update(hmac, prev, dig_len))
+                goto err;
+        }
+
+        if (!HMAC_Update(hmac, info, info_len))
+            goto err;
+
+        if (!HMAC_Update(hmac, &ctr, 1))
+            goto err;
+
+        if (!HMAC_Final(hmac, prev, NULL))
+            goto err;
+
+        copy_len = (done_len + dig_len > okm_len) ?
+                       okm_len - done_len :
+                       dig_len;
+
+        memcpy(okm + done_len, prev, copy_len);
+
+        done_len += copy_len;
+    }
+
+    HMAC_CTX_free(hmac);
+    return okm;
+
+ err:
+    HMAC_CTX_free(hmac);
+    return NULL;
+}

--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -60,9 +60,9 @@
  * [including the GNU Public Licence.]
  */
 
-#define NUM_NID 1036
-#define NUM_SN 1029
-#define NUM_LN 1029
+#define NUM_NID 1037
+#define NUM_SN 1030
+#define NUM_LN 1030
 #define NUM_OBJ 951
 
 static const unsigned char lvalues[6722]={
@@ -2704,6 +2704,7 @@ static const ASN1_OBJECT nid_objs[NUM_NID]={
 {"pkInitKDC","Signing KDC Response",NID_pkInitKDC,7,&(lvalues[6696]),0},
 {"X25519","X25519",NID_X25519,9,&(lvalues[6703]),0},
 {"X448","X448",NID_X448,9,&(lvalues[6712]),0},
+{"HKDF","hkdf",NID_hkdf,0,NULL,0},
 };
 
 static const unsigned int sn_objs[NUM_SN]={
@@ -2813,6 +2814,7 @@ static const unsigned int sn_objs[NUM_SN]={
 67,	/* "DSA-old" */
 297,	/* "DVCS" */
 99,	/* "GN" */
+1036,	/* "HKDF" */
 855,	/* "HMAC" */
 780,	/* "HMAC-MD5" */
 781,	/* "HMAC-SHA1" */
@@ -4152,6 +4154,7 @@ static const unsigned int ln_objs[NUM_LN]={
 1012,	/* "grasshopper-ecb" */
 1017,	/* "grasshopper-mac" */
 1014,	/* "grasshopper-ofb" */
+1036,	/* "hkdf" */
 855,	/* "hmac" */
 780,	/* "hmac-md5" */
 781,	/* "hmac-sha1" */

--- a/crypto/objects/obj_mac.num
+++ b/crypto/objects/obj_mac.num
@@ -1033,3 +1033,4 @@ pkInitClientAuth		1032
 pkInitKDC		1033
 X25519		1034
 X448		1035
+hkdf		1036

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -1444,6 +1444,9 @@ secg-scheme 14 3 : dhSinglePass-cofactorDH-sha512kdf-scheme
 # NID for TLS1 PRF
                             : TLS1-PRF          : tls1-prf
 
+# NID for HKDF
+                            : HKDF              : hkdf
+
 # RFC 4556
 1 3 6 1 5 2 3 : id-pkinit
 id-pkinit 4                     : pkInitClientAuth      : PKINIT Client Auth

--- a/doc/crypto/EVP_PKEY_HKDF.pod
+++ b/doc/crypto/EVP_PKEY_HKDF.pod
@@ -1,0 +1,103 @@
+=pod
+
+=head1 NAME
+
+EVP_PKEY_HKDF; EVP_PKEY_CTX_set_hkdf_md, EVP_PKEY_CTX_set1_hkdf_salt,
+EVP_PKEY_CTX_set1_hkdf_key, EVP_PKEY_CTX_add1_hkdf_info -
+HMAC-based Extract-and-Expand key derivation algorithm
+
+=head1 SYNOPSIS
+
+ #include <openssl/kdf.h>
+
+ int EVP_PKEY_CTX_set_hkdf_md(EVP_PKEY_CTX *pctx, const EVP_MD *md);
+
+ int EVP_PKEY_CTX_set1_hkdf_salt(EVP_PKEY_CTX *pctx, unsigned char *salt,
+                                 int saltlen);
+
+ int EVP_PKEY_CTX_set1_hkdf_key(EVP_PKEY_CTX *pctx, unsigned char *key,
+                                int keylen);
+
+ int EVP_PKEY_CTX_add1_hkdf_info(EVP_PKEY_CTX *pctx, unsigned char *info,
+                                 int infolen);
+
+=head1 DESCRIPTION
+
+The EVP_PKEY_HKDF alogorithm implements the HKDF key derivation function.
+HKDF follows the "extract-then-expand" paradigm, where the KDF logically
+consists of two modules. The first stage takes the input keying material
+and "extracts" from it a fixed-length pseudorandom key K. The second stage
+"expands" the key K into several additional pseudorandom keys (the output
+of the KDF).
+
+EVP_PKEY_set_hkdf_md() sets the message digest associated with the HKDF.
+
+EVP_PKEY_CTX_set1_hkdf_salt() sets the salt to B<saltlen> bytes of the
+buffer B<salt>. Any existing value is replaced.
+
+EVP_PKEY_CTX_set_hkdf_key() sets the key to B<keylen> bytes of the buffer
+B<key>. Any existing value is replaced.
+
+EVP_PKEY_CTX_add1_hkdf_info() sets the info value to B<infolen> bytes of the
+buffer B<info>. If a value is already set, it is appended to the existing
+value.
+
+=head1 NOTES
+
+All these functions are implemented as macros.
+
+A context for HKDF can be obtained by calling:
+
+ EVP_PKEY_CTX *pctx = EVP_PKEY_new_id(EVP_PKEY_HKDF, NULL);
+
+The digest, key, salt and info values must be set before a key is derived or
+an error occurs.
+
+The total length of the info buffer cannot exceed 1024 bytes in length: this
+should be more than enough for any normal use of HKDF.
+
+The output length of the KDF is specified by the length parameter in the
+EVP_PKEY_derive() function. Since the output length is variable, setting
+the buffer to B<NULL> is not meaningful for HKDF.
+
+Optimised versions of HKDF can be implemented in an ENGINE.
+
+=head1 RETURN VALUES
+
+All these functions return 1 for success and 0 or a negative value for failure.
+In particular a return value of -2 indicates the operation is not supported by
+the public key algorithm.
+
+=head1 EXAMPLE
+
+This example derives 10 bytes using SHA-256 with the secret key "secret",
+salt value "salt" and info value "label":
+
+ EVP_PKEY_CTX *pctx;
+ unsigned char out[10];
+ size_t outlen = sizeof(out);
+ pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+
+ if (EVP_PKEY_derive_init(pctx) <= 0)
+    /* Error */
+ if (EVP_PKEY_CTX_set_hkdf_md(pctx, EVP_sha256()) <= 0)
+    /* Error */
+ if (EVP_PKEY_CTX_set1_salt(pctx, "salt", 4) <= 0)
+    /* Error */
+ if (EVP_PKEY_CTX_set1_key(pctx, "secret", 6) <= 0)
+    /* Error */
+ if (EVP_PKEY_CTX_add1_hkdf_info(pctx, "label", 6) <= 0)
+    /* Error */
+ if (EVP_PKEY_derive(pctx, out, &outlen) <= 0)
+    /* Error */
+
+=head1 CONFORMING TO
+
+RFC 5869
+
+=head1 SEE ALSO
+
+L<EVP_PKEY_CTX_new(3)>,
+L<EVP_PKEY_derive(3)>,
+
+=cut

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -99,6 +99,7 @@
 # define EVP_PKEY_HMAC   NID_hmac
 # define EVP_PKEY_CMAC   NID_cmac
 # define EVP_PKEY_TLS1_PRF NID_tls1_prf
+# define EVP_PKEY_HKDF   NID_hkdf
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -61,6 +61,10 @@ extern "C" {
 # define EVP_PKEY_CTRL_TLS_MD       (EVP_PKEY_ALG_CTRL)
 # define EVP_PKEY_CTRL_TLS_SECRET   (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_TLS_SEED     (EVP_PKEY_ALG_CTRL + 2)
+# define EVP_PKEY_CTRL_HKDF_MD      (EVP_PKEY_ALG_CTRL + 3)
+# define EVP_PKEY_CTRL_HKDF_SALT    (EVP_PKEY_ALG_CTRL + 4)
+# define EVP_PKEY_CTRL_HKDF_KEY     (EVP_PKEY_ALG_CTRL + 5)
+# define EVP_PKEY_CTRL_HKDF_INFO    (EVP_PKEY_ALG_CTRL + 6)
 
 # define EVP_PKEY_CTX_set_tls1_prf_md(pctx, md) \
             EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
@@ -73,6 +77,22 @@ extern "C" {
 # define EVP_PKEY_CTX_add1_tls1_prf_seed(pctx, seed, seedlen) \
             EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
                               EVP_PKEY_CTRL_TLS_SEED, seedlen, (void *)seed)
+
+# define EVP_PKEY_CTX_set_hkdf_md(pctx, md) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_HKDF_MD, 0, (void *)md)
+
+# define EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt, saltlen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_HKDF_SALT, saltlen, (void *)salt)
+
+# define EVP_PKEY_CTX_set1_hkdf_key(pctx, key, keylen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_HKDF_KEY, keylen, (void *)key)
+
+# define EVP_PKEY_CTX_add1_hkdf_info(pctx, info, infolen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_HKDF_INFO, infolen, (void *)info)
 
 /* BEGIN ERROR CODES */
 /*

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -4511,6 +4511,10 @@
 #define LN_tls1_prf             "tls1-prf"
 #define NID_tls1_prf            1021
 
+#define SN_hkdf         "HKDF"
+#define LN_hkdf         "hkdf"
+#define NID_hkdf                1036
+
 #define SN_id_pkinit            "id-pkinit"
 #define NID_id_pkinit           1031
 #define OBJ_id_pkinit           1L,3L,6L,1L,5L,2L,3L

--- a/test/evptests.txt
+++ b/test/evptests.txt
@@ -3019,6 +3019,82 @@ Ctrl.Seed = hexseed:02
 Output = 03
 Result = KDF_DERIVE_ERROR
 
+# HKDF tests, from RFC5869 test vectors
+
+KDF = HKDF
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865
+
+KDF = HKDF
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f
+Ctrl.salt = hexsalt:606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf
+Ctrl.info = hexinfo:b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+Output = b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87
+
+KDF = HKDF
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f
+Ctrl.salt = hexsalt:606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf
+Ctrl.info = hexinfo:b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+Output = 0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
+
+KDF = HKDF
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 00
+Result = KDF_DERIVE_ERROR
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 00
+Result = KDF_DERIVE_ERROR
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.info = info:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
+
+KDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
 
 # ECDH tests
 


### PR DESCRIPTION
This PR implements the HMAC-based Extract-and-Expand Key Derivation Function (HKDF) as defined in RFC 5869.

It is required to implement the QUIC and TLS 1.3 protocols (among others).