### PR TITLE
Change assert by normal error on d1_both.c

### DIFF
--- a/ssl/d1_both.c
+++ b/ssl/d1_both.c
@@ -260,8 +260,10 @@ int dtls1_do_write(SSL *s, int type)
     if (!dtls1_query_mtu(s))
         return -1;
 
-    OPENSSL_assert(s->d1->mtu >= dtls1_min_mtu(s)); /* should have something
-                                                     * reasonable now */
+    if (s->d1->mtu < dtls1_min_mtu(s))
+        /* should have something
+         * reasonable now */
+        return -1;
 
     if (s->init_off == 0 && type == SSL3_RT_HANDSHAKE)
         OPENSSL_assert(s->init_num ==


### PR DESCRIPTION
Related to https://github.com/openssl/openssl/issues/346

The bug seems to be fixed, but the assertion if MTU calculation fails is too much excessive. We have a server with hundreds of dtls connections, so this was causing the whole server to exit. Changing the assertion by an error should be more than enough. 