### PR TITLE
Fix BIO_get_accept_socket so that "port-only" input works on FreeBSD.

### DIFF
--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -467,6 +467,12 @@ int BIO_get_accept_socket(char *host, int bind_mode)
                 hint.ai_family = AF_INET;
                 h = NULL;
             }
+        } else {
+            /*
+             * If no host specified, assume '*' is the intention and treat
+             * in the same manner as '*' is above.
+             */
+            hint.ai_family = AF_INET;
         }
 
         if ((*p_getaddrinfo.f) (h, p, &hint, &res))


### PR DESCRIPTION
Without this fix "openssl ocsp -port xxx" will cause "openssl s_server -status" calls to hang on FreeBSD.

I'm not 100% sure this is the right overall fix... my knowledge here is weak, but it is verified to fix the problem I was having.