### PR TITLE
Fix unhandled error condition in sslv2 client hello parsing.

### DIFF
--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -1014,6 +1014,9 @@ int ssl3_get_client_hello(SSL *s)
         if (!PACKET_get_net_2(&pkt, &csl)
                 || !PACKET_get_net_2(&pkt, &sil)
                 || !PACKET_get_net_2(&pkt, &cl)) {
+            SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+            al = SSL_AD_DECODE_ERROR;
+            goto f_err;
         }
 
         if (csl == 0) {

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -1014,7 +1014,7 @@ int ssl3_get_client_hello(SSL *s)
         if (!PACKET_get_net_2(&pkt, &csl)
                 || !PACKET_get_net_2(&pkt, &sil)
                 || !PACKET_get_net_2(&pkt, &cl)) {
-            SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+            SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_RECORD_LENGTH_MISMATCH);
             al = SSL_AD_DECODE_ERROR;
             goto f_err;
         }


### PR DESCRIPTION
--strict-warnings started showing warnings for this today...

Surely an error should be raised if these reads fail?