### PR TITLE
Fix clang compiler warning where %ld is used for uint64_t on Mac OS X.

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -567,8 +567,8 @@ int enc_main(int argc, char **argv)
 
     ret = 0;
     if (verbose) {
-        BIO_printf(bio_err, "bytes read   :%8ld\n", BIO_number_read(in));
-        BIO_printf(bio_err, "bytes written:%8ld\n", BIO_number_written(out));
+        BIO_printf(bio_err, "bytes read   :%8"PRIu64"\n", BIO_number_read(in));
+        BIO_printf(bio_err, "bytes written:%8"PRIu64"\n", BIO_number_written(out));
     }
  end:
     ERR_print_errors(bio_err);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2092,7 +2092,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
         ssl_print_tmp_key(bio, s);
 
         BIO_printf(bio,
-                   "---\nSSL handshake has read %ld bytes and written %ld bytes\n",
+                   "---\nSSL handshake has read %"PRIu64" bytes and written %"PRIu64" bytes\n",
                    BIO_number_read(SSL_get_rbio(s)),
                    BIO_number_written(SSL_get_wbio(s)));
     }

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -294,6 +294,22 @@ typedef unsigned __int64 uint64_t;
 #  include <stdint.h>
 # endif
 
+/*
+ * We need a format operator for some client tools for uint64_t.
+ * This is an attempt at doing so in a portable manner.
+ * If we can't use a built-in definition, we'll revert to the previous
+ * behavior that was hard-coded but now causing compiler warnings on
+ * some systems (e.g. Mac OS X).
+ */
+# ifndef PRIu64
+#  if (__STDC_VERSION__ >= 199901L)
+#   include <inttypes.h>
+#  endif
+#  ifndef PRIu64
+#   define PRIu64 "lu"
+#  endif
+# endif
+
 #ifdef  __cplusplus
 }
 #endif


### PR DESCRIPTION
clang suggests %llu instead, but it isn't clear that is portable on all platforms.

C99 and above define a handy macro for us, so we try to use that definition and fall back to current definition if needed (though we switch to 'u' for unsigned).