### PR TITLE
x509_vfy: release memory also when running in error path.

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -348,6 +348,7 @@ int X509_verify_cert(X509_STORE_CTX *ctx)
             x = xtmp;
             if (!sk_X509_push(ctx->chain, x)) {
                 X509_free(xtmp);
+                sk_X509_free(sktmp);
                 X509err(X509_F_X509_VERIFY_CERT, ERR_R_MALLOC_FAILURE);
                 return 0;
             }


### PR DESCRIPTION
A small issue found by static analysis.