### PR TITLE
Fix build with no-ripemd

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -429,7 +429,7 @@ OPT_PAIR doit_choices[] = {
 #ifndef OPENSSL_NO_WHIRLPOOL
     {"whirlpool", D_WHIRLPOOL},
 #endif
-#ifndef OPENSSL_NO_RIPEMD
+#ifndef OPENSSL_NO_RMD160
     {"ripemd", D_RMD160},
     {"rmd160", D_RMD160},
     {"ripemd160", D_RMD160},
@@ -605,7 +605,7 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_WHIRLPOOL
     unsigned char whirlpool[WHIRLPOOL_DIGEST_LENGTH];
 #endif
-#ifndef OPENSSL_NO_RIPEMD
+#ifndef OPENSSL_NO_RMD160
     unsigned char rmd160[RIPEMD160_DIGEST_LENGTH];
 #endif
 #ifndef OPENSSL_NO_RC4


### PR DESCRIPTION
Commit 4b618848f9beb8271f24883694e097caa70013c0 consolidated
OPENSSL_NO_RIPEMD and OPENSSL_NO_RIPEMD160 into OPENSSL_NO_RMD160,
but a couple instances were missed in that cleanup.