### PR TITLE
dsa: fix key generation for too short seed value.

### DIFF
--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -172,7 +172,7 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
             if (!BN_GENCB_call(cb, 0, m++))
                 goto err;
 
-            if (!seed_len) {
+            if (!seed_len || !seed_in) {
                 if (RAND_bytes(seed, qsize) <= 0)
                     goto err;
                 seed_is_random = 1;


### PR DESCRIPTION
If the seed value for dsa key generation is too short (< qsize)
uninitialized memory from stack is used as the seed for first round of
key generation. From the code comments it appears that the intention is
to replace the seed with a random value in that case, so that's what is
done here. Another option would be just returning an error.