### PR TITLE
Add initial Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: c
+
+os:
+ - linux
+ - osx
+
+compiler:
+ - clang
+ - gcc
+
+env:
+ - CONFIG_OPTS=""
+ - CONFIG_OPTS="--debug"
+ - CONFIG_OPTS="shared"
+
+script:
+ - ./config $CONFIG_OPTS && make && make test
+
+notifications:
+  recipient:
+   - openssl-dev@openssl.org
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This supersedes #63.

Among other things it supports building with both gcc and clang on Linux and OS X (but the latter needs to be enabled manually by the Travis team) and supports multiple build configurations ("vanilla", "--debug" and "shared", more can be easily added).

See https://travis-ci.org/ghedo/openssl/builds/76612407 for an example build run.