### PR TITLE
check bn_new return value

### DIFF
--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -163,8 +163,10 @@ static int bn_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 {
     BIGNUM *bn;
 
-    if (!*pval)
-        bn_new(pval, it);
+    if (!*pval){
+        if(!bn_new(pval, it))
+            return 0;
+    }
     bn = (BIGNUM *)*pval;
     if (!BN_bin2bn(cont, len, bn)) {
         bn_free(pval, it);


### PR DESCRIPTION
If "bn_new" fail, bn = (BIGNUM *)*pval == NULL.
and in next function "BN_bin2bn", if bn is NULL, it will be realloced as follow:
if (ret == NULL)
      ret = bn = BN_new();

If "BN_bin2bn" sucess,  *pval is still a NULL pointer, but bn_c2i will return sucess, and no one free the bn malloced in BN_bin2bn.

Also in function d2i_PublicKey:

        if ((ret->pkey.rsa = d2i_RSAPublicKey(NULL,
                                              (const unsigned char **)pp,
                                              length)) == NULL) {
            ASN1err(ASN1_F_D2I_PUBLICKEY, ERR_R_ASN1_LIB);
            goto err;
        }
Although RSAPublicKey return sucess ,but ret->pkey.rsa.n or ret->pkey.rsa.e is still null .

I found this problem in my machine with high loading, and it caused segmentfault and memory leak.I fixed it by checking bn_new return value.