### PR TITLE
free  parameter after sk_push fail

### DIFF
--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -600,6 +600,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
             len -= p - q;
             if (!sk_ASN1_VALUE_push((STACK_OF(ASN1_VALUE) *)*val, skfield)) {
                 ASN1err(ASN1_F_ASN1_TEMPLATE_NOEXP_D2I, ERR_R_MALLOC_FAILURE);
+                ASN1_item_free(skfield, ASN1_ITEM_ptr(tt->item));
                 goto err;
             }
         }


### PR DESCRIPTION
As before, you know,  i am dealing with something with high loading.
ssl3_get_client_certificate will decode client's certificate by using d2i_X509, but it doesn't run well.
I found the problem like this way:
    for(i=0; i<1024/*or other*/, i++)
    {
        g_malloc_return_null = i; //malloc will  return null when  g_malloc_return_null  >= g_malloc_num 
        g_malloc_num  = g_free_num = 0;//increace in OPENSSL_malloc and OPENSSL_free
        d2i_X509(NULL ,buf , len);
        X509_free(x);
        if(g_malloc_num != g_free_num)
        {
            /*OK, memory leak */
            break;
        }
    }


tips:
I'm using openssl 0.97 but i find this problem existing in master, maybe also in other branch.