### PR TITLE
Get Windows amd64 build working from a bare cmd shell

### DIFF
--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -7,6 +7,7 @@ if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
+$dir =~ s/\\/\//g;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or
 ( $xlate="${dir}perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";

--- a/ms/uplink-x86_64.pl
+++ b/ms/uplink-x86_64.pl
@@ -2,6 +2,7 @@
 
 $output=shift;
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
+$dir =~ s/\\/\//g;
 open OUT,"| \"$^X\" ${dir}../crypto/perlasm/x86_64-xlate.pl $output";
 *STDOUT=*OUT;
 push(@INC,"${dir}.");


### PR DESCRIPTION
I needed to convert Windows `\` to `/` to get the amd64 build working in my environment.
