### PR TITLE
Supply a build rule for the recently added nptest

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -504,6 +504,9 @@ BUILD_CMD_STATIC=shlib_target=; \
 $(RSATEST)$(EXE_EXT): $(RSATEST).o $(DLIBCRYPTO)
 	@target=$(RSATEST); $(BUILD_CMD)
 
+$(NPTEST)$(EXE_EXT): $(NPTEST).o $(DLIBCRYPTO)
+	@target=$(NPTEST); $(BUILD_CMD)
+
 $(BNTEST)$(EXE_EXT): $(BNTEST).o $(DLIBCRYPTO)
 	@target=$(BNTEST); $(BUILD_CMD)
 


### PR DESCRIPTION
Commit d4ab70f27cb7e518e6a9d6323c996cc3feb7496b added a test program
to check that the NULL pointer is represented as all zero bits, but
did not specify a build rule for that new executable.  On many platforms,
the implicit rule sufficed, since nptest is a very simple program, but
for at least darwin-i386-cc, an explicit rule is needed.  On darwin-i386-cc,
the implicit rule targetted a 64-bit executable, but the object file
containing the definition of main was a 32-bit object, which the linker
excluded from consideration, resulting in a link failure due to no
definition for _main.

Add the missing build rule to fix the build on such platforms.