### PR TITLE
Use the shlib wrapper when running nptest

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -173,7 +173,7 @@ alltests: \
 
 test_np: $(NPTEST)$(EXE_EXT)
 	@echo $(START) $@
-	./$(NPTEST)
+	../util/shlib_wrap.sh ./$(NPTEST)
 
 test_evp: $(EVPTEST)$(EXE_EXT) evptests.txt
 	@echo $(START) $@


### PR DESCRIPTION
Since there seems to be no way to avoid linking to libssl and libcrypto, just
wrap the test. This unbreaks "shared" builds when using clang and/or OS X.

EDIT: fixed typos.