### PR TITLE
Fix verify_extra test

### DIFF
--- a/test/recipes/70-test_verify_extra.t
+++ b/test/recipes/70-test_verify_extra.t
@@ -1,5 +1,15 @@
 #! /usr/bin/perl
 
-use OpenSSL::Test::Simple;
+use OpenSSL::Test qw/:DEFAULT top_file/;
 
-simple_test("test_verify_extra", "verify_extra_test");
+my $prog = "verify_extra_test";
+
+setup("test_verify_extra");
+
+plan tests => 1;
+
+my $test = test([$prog, top_file("test", "certs/roots.pem"),
+                        top_file("test", "certs/untrusted.pem"),
+                        top_file("test", "certs/bad.pem")]);
+
+ok(run($test), "running $prog");


### PR DESCRIPTION
verify_extra_test requires arguments, so simple_test() is not enough.

/cc @levitte 