### PR TITLE
Repair SSLv2 session reuse

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -576,7 +576,7 @@ int ssl_get_prev_session(SSL *s, unsigned char *session_id, int len,
     if (len < 0 || len > SSL_MAX_SSL_SESSION_ID_LENGTH)
         goto err;
 
-    if (session_id + len > limit) {
+    if (limit != NULL && session_id + len > limit) {
         fatal = 1;
         goto err;
     }


### PR DESCRIPTION
Note: this is a direct pull request against 1.0.2, since the SSLv2 code
has been removed entirely from master.  s_client -ssl2 -reconnect is
sufficient to trigger the issue and confirm the fix.

Commit 5e0a80c on master ("Fix ssl_get_prev_session overrun";
5101c35c on OpenSSL-1_0_2-stable) added a check that the extent of the
supplied session id string does not surpass the supplied end limit
pointer.  However, it did not take into account that
s2_srvr.c:get_client_hello() passes NULL for that limit parameter,
causing the check to always fail and breaking SSLv2 session reuse.

The limit parameter was added to ssl_get_prev_session() by commit
6434abbfc6a, which added support for RFC4507 (actually RFC5077)
session tickets.  At that time, the limit parameter was only used
by tls1_process_ticket(), which explicitly rejected non-TLS versions
of SSL, so there was no need to pass in a reasonable value from
the SSLv2-only caller.  Only with the introduction of the explicit
overrun check in commit 5e0a80c is an actual end boundary pointer
needed; the natural boundary is the end of the data that has been
read so far.