### PR TITLE
Adds cross compiling with mingw-w64 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,49 @@
 language: c
 
 addons:
- apt_packages:
-  - binutils-mingw-w64
-  - gcc-mingw-w64
+  apt_packages:
+    - binutils-mingw-w64
+    - gcc-mingw-w64
 
 os:
- - linux
- - osx
+  - linux
+  - osx
 
 compiler:
- - clang
- - gcc
- - i686-w64-mingw32-gcc
- - x86_64-w64-mingw32-gcc
+  - clang
+  - gcc
+  - i686-w64-mingw32-gcc
+  - x86_64-w64-mingw32-gcc
 
 env:
- - CONFIG_OPTS=""
- - CONFIG_OPTS="--debug"
- - CONFIG_OPTS="shared"
+  - CONFIG_OPTS=""
+  - CONFIG_OPTS="--debug"
+  - CONFIG_OPTS="shared"
 
 matrix:
- exclude:
-  - os: osx
-   compiler: i686-w64-mingw32-gcc
-  - os: osx
-   compiler: x86_64-w64-mingw32-gcc
+  exclude:
+    - os: osx
+      compiler: i686-w64-mingw32-gcc
+    - os: osx
+      compiler: x86_64-w64-mingw32-gcc
 
 before_script:
- - if [ "$CC" == i686-w64-mingw32-gcc -o "$CC" == x86_64-w64-mingw32-gcc ]; then
-   export CROSS_COMPILE=${CC%%gcc};
-   unset CC; ./Configure mingw64 no-asm $CONFIG_OPTS;
-  else
-   ./config $CONFIG_OPTS;
-  fi
+  - if [ "$CC" == i686-w64-mingw32-gcc -o "$CC" == x86_64-w64-mingw32-gcc ]; then
+      export CROSS_COMPILE=${CC%%gcc};
+      unset CC; ./Configure mingw64 no-asm $CONFIG_OPTS;
+    else
+      ./config $CONFIG_OPTS;
+    fi
 
 script:
- - make
- - if [ -z "$CROSS_COMPILE" ]; then
-    make test;
-   fi
+  - make
+  - if [ -z "$CROSS_COMPILE" ]; then
+      make test;
+    fi
 
 notifications:
   recipient:
-   - openssl-dev@openssl.org
+    - openssl-dev@openssl.org
   email:
     on_success: change
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: c
 
+addons:
+ apt_packages:
+  - binutils-mingw-w64
+  - gcc-mingw-w64
+
 os:
  - linux
  - osx
@@ -7,14 +12,34 @@ os:
 compiler:
  - clang
  - gcc
+ - i686-w64-mingw32-gcc
+ - x86_64-w64-mingw32-gcc
 
 env:
  - CONFIG_OPTS=""
  - CONFIG_OPTS="--debug"
  - CONFIG_OPTS="shared"
 
+matrix:
+ exclude:
+  - os: osx
+   compiler: i686-w64-mingw32-gcc
+  - os: osx
+   compiler: x86_64-w64-mingw32-gcc
+
+before_script:
+ - if [ "$CC" == i686-w64-mingw32-gcc -o "$CC" == x86_64-w64-mingw32-gcc ]; then
+   export CROSS_COMPILE=${CC%%gcc};
+   unset CC; ./Configure mingw64 no-asm $CONFIG_OPTS;
+  else
+   ./config $CONFIG_OPTS;
+  fi
+
 script:
- - ./config $CONFIG_OPTS && make && make test
+ - make
+ - if [ -z "$CROSS_COMPILE" ]; then
+    make test;
+   fi
 
 notifications:
   recipient:


### PR DESCRIPTION
This modification to the CI script shows that the master branch does not work with Ubuntu's default installation of 32/64 bit Mingw-w64. I cherry-picked the [CI-commit onto the branch OpenSSL_1_0_2-stable](https://github.com/frankmorgner/openssl/commit/54bd559a6c538456b301e9a6688f438676b0960d), where each configuration works as expected, see https://travis-ci.org/frankmorgner/openssl/builds/80625980.

I suspect that df2ee0e27d2db02660c1d15fe6a3e38be9df0a60 is causing this trouble, but I don't see how to fix this.