### PR TITLE
Fix potential read buffer overflow in PACKET_strndup()

### DIFF
--- a/crypto/buffer/buf_str.c
+++ b/crypto/buffer/buf_str.c
@@ -57,6 +57,7 @@
  */
 
 #include <stdio.h>
+#include <limits.h>
 #include "internal/cryptlib.h"
 #include <openssl/buffer.h>
 
@@ -85,12 +86,18 @@ char *BUF_strndup(const char *str, size_t siz)
 
     siz = BUF_strnlen(str, siz);
 
+    if (siz >= INT_MAX)
+        return (NULL);
+
     ret = OPENSSL_malloc(siz + 1);
     if (ret == NULL) {
         BUFerr(BUF_F_BUF_STRNDUP, ERR_R_MALLOC_FAILURE);
         return (NULL);
     }
-    BUF_strlcpy(ret, str, siz + 1);
+
+    memcpy(ret, str, siz);
+    ret[siz] = '\0';
+
     return (ret);
 }
 

--- a/include/openssl/buffer.h
+++ b/include/openssl/buffer.h
@@ -90,7 +90,13 @@ size_t BUF_MEM_grow(BUF_MEM *str, size_t len);
 size_t BUF_MEM_grow_clean(BUF_MEM *str, size_t len);
 size_t BUF_strnlen(const char *str, size_t maxlen);
 char *BUF_strdup(const char *str);
+
+/*
+ * Returns a pointer to a new string which is a duplicate of the string |str|,
+ * but guarantees to never read past the first |siz| bytes of |str|.
+ */
 char *BUF_strndup(const char *str, size_t siz);
+
 void *BUF_memdup(const void *data, size_t siz);
 void BUF_reverse(unsigned char *out, unsigned char *in, size_t siz);
 


### PR DESCRIPTION
Due to its use of BUF_strndup() (which in turn uses BUF_strlcpy()) the
strlen() function will get called on the input data. However, since the
input data may not end in a NUL-byte, strlen() will read from invalid
memory.

Here's the address sanitizer report for the `packettest` test (which is how
I found the problem):

```
==2296==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffdbf63923a at pc 0x7f470fe2f92b bp 0x7ffdbf639130 sp 0x7ffdbf6388e0
READ of size 5 at 0x7ffdbf63923a thread T0
    #0 0x7f470fe2f92a in strlen (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x6d92a)
    #1 0x40a969 in BUF_strlcpy /home/ghedo/devel/openssl/crypto/buffer/buf_str.c:121
    #2 0x40a798 in BUF_strndup /home/ghedo/devel/openssl/crypto/buffer/buf_str.c:93
    #3 0x402abd in PACKET_strndup ../ssl/packet_locl.h:398
    #4 0x404e6b in test_PACKET_strndup /home/ghedo/devel/openssl/test/packettest.c:269
    #5 0x406370 in main /home/ghedo/devel/openssl/test/packettest.c:444
    #6 0x7f470f836b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    #7 0x4019e8  (/home/ghedo/devel/openssl/test/packettest+0x4019e8)

Address 0x7ffdbf63923a is located in stack of thread T0 at offset 106 in frame
    #0 0x404d3a in test_PACKET_strndup /home/ghedo/devel/openssl/test/packettest.c:259

  This frame has 4 object(s):
    [32, 40) 'data'
    [96, 106) 'buf' <== Memory access at offset 106 overflows this variable
    [160, 170) 'buf2'
    [224, 248) 'pkt'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ??:0 strlen
Shadow bytes around the buggy address:
  0x100037ebf1f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100037ebf200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100037ebf210: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100037ebf220: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100037ebf230: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f4
=>0x100037ebf240: f4 f4 f2 f2 f2 f2 00[02]f4 f4 f2 f2 f2 f2 00 02
  0x100037ebf250: f4 f4 f2 f2 f2 f2 00 00 00 f4 f3 f3 f3 f3 00 00
  0x100037ebf260: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f4 f4 f4
  0x100037ebf270: f2 f2 f2 f2 00 00 00 f4 f2 f2 f2 f2 00 00 00 00
  0x100037ebf280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100037ebf290: 00 00 00 00 00 00 00 00 00 00 00 07 f3 f3 f3 f3
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==2296==ABORTING
```