### PR TITLE
Adds initial AppVeyor CI configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+platform:
+  - x86
+  - x64
+
+environment:
+  matrix:
+    - VSVER: 12
+    - VSVER: 10
+
+configuration:
+  - --debug
+  - shared
+
+matrix:
+  allow_failures:
+    # not included in AppVeyor right now
+    - platform: x64
+      VSVER: 10
+
+before_build:
+  - ps: >-
+      If ($env:Platform -Match "x86") {
+        $env:VCVARS_PLATFORM="x86"
+        $env:TARGET="VC-WIN32"
+        $env:DO="do_ms"
+      } Else {
+        $env:VCVARS_PLATFORM="amd64"
+        $env:TARGET="VC-WIN64A"
+        $env:DO="do_win64a"
+      }
+  - ps: >-
+      If ($env:Configuration -Like "*--debug*") {
+        $env:TARGET="debug-$env:TARGET"
+      }
+  - ps: >-
+      If ($env:Configuration -Like "*shared*") {
+        $env:MAK="ntdll.mak"
+      } Else {
+        $env:MAK="nt.mak"
+      }
+  - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
+  - echo "Using Visual Studio %VSVER%.0 at %VSCOMNTOOLS%"
+  - call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
+  - perl Configure %TARGET% no-asm
+  - call ms\%DO%
+
+build_script:
+  - nmake /f ms\%MAK%


### PR DESCRIPTION
This PR automatically builds OpenSSL with VC via AppVeyor. Activation and configuration is similar to Travis-CI.

I did this modification on top of OpenSSL_1_0_2-stable, because the VC compiler complains about some new data structure design, that have been introduced in master (see also https://github.com/openssl/openssl/pull/398).