### PR TITLE
Fix build on mingw

### DIFF
--- a/include/openssl/asn1t.h
+++ b/include/openssl/asn1t.h
@@ -102,6 +102,9 @@ extern "C" {
         { \
                 static const ASN1_ITEM local_it = {
 
+#  define static_ASN1_ITEM_start(itname) \
+        ASN1_ITEM_start(itname)
+
 #  define ASN1_ITEM_end(itname) \
                 }; \
         return &local_it; \


### PR DESCRIPTION
When OPENSSL_EXPORT_VAR_AS_FUNCTION is defined, the static_ASN1_ITEM_start
macro doesn't exist so the build fails. This problem was introduced in
commit df2ee0e.

(as discussed in #398)