### PR TITLE
fix ciphers man page typo

### DIFF
--- a/doc/apps/ciphers.pod
+++ b/doc/apps/ciphers.pod
@@ -205,7 +205,7 @@ keys or either respectively.
 cipher suites using ephemeral ECDH key agreement, including anonymous
 cipher suites.
 
-=item B<EECDHE>
+=item B<EECDH>
 
 cipher suites using authenticated ephemeral ECDH key agreement.
 


### PR DESCRIPTION
the alias supported by OpenSSL 1.0.1 is "EECDH" not "EECDHE"