### PR TITLE
Fix build failure

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -584,7 +584,7 @@
     },
     "linux-arm64ilp32" => {  # https://wiki.linaro.org/Platform/arm64-ilp32
         inherit_from     => [ "linux-generic32", asm("aarch64_asm") ],
-        cflags           => "-mabi=ilp32 -Wall"
+        cflags           => "-mabi=ilp32 -Wall",
         bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR",
         perlasm_scheme   => "linux64",
         shared_ldflag    => "-mabi=ilp32",


### PR DESCRIPTION
Properly format configuration config

Otherwise the ./config script fails with errors like:

> Operating system: x86_64-whatever-linux2
> This system (linux-x86_64) is not supported. See file INSTALL for details.

The failure was introduced by a93d3e0.