### PR TITLE
Do not treat 0 return value from BIO_get_fd() as error

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1200,7 +1200,7 @@ static OCSP_RESPONSE *query_responder(BIO *cbio, const char *path,
         return NULL;
     }
 
-    if (BIO_get_fd(cbio, &fd) <= 0) {
+    if (BIO_get_fd(cbio, &fd) < 0) {
         BIO_puts(bio_err, "Can't get connection fd\n");
         goto err;
     }


### PR DESCRIPTION
0 is a valid file descriptor.

RT#4068

(AFAICT this is the only instance where BIO_get_fd is used incorrectly)