### PR TITLE
New cipher and cipher modes standardized in Russia

### DIFF
--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -62,9 +62,9 @@
  * [including the GNU Public Licence.]
  */
 
-#define NUM_NID 1009
-#define NUM_SN 1002
-#define NUM_LN 1002
+#define NUM_NID 1018
+#define NUM_SN 1011
+#define NUM_LN 1011
 #define NUM_OBJ 936
 
 static const unsigned char lvalues[6604]={
@@ -2658,6 +2658,15 @@ static const ASN1_OBJECT nid_objs[NUM_NID]={
 	&(lvalues[6593]),0},
 {"issuerSignTool","Signing Tool of Issuer",NID_issuerSignTool,5,
 	&(lvalues[6598]),0},
+{"gost89-cbc","gost89-cbc",NID_gost89_cbc,0,NULL,0},
+{"gost89-ecb","gost89-ecb",NID_gost89_ecb,0,NULL,0},
+{"gost89-ctr","gost89-ctr",NID_gost89_ctr,0,NULL,0},
+{"grasshopper-ecb","grasshopper-ecb",NID_grasshopper_ecb,0,NULL,0},
+{"grasshopper-ctr","grasshopper-ctr",NID_grasshopper_ctr,0,NULL,0},
+{"grasshopper-ofb","grasshopper-ofb",NID_grasshopper_ofb,0,NULL,0},
+{"grasshopper-cbc","grasshopper-cbc",NID_grasshopper_cbc,0,NULL,0},
+{"grasshopper-cfb","grasshopper-cfb",NID_grasshopper_cfb,0,NULL,0},
+{"grasshopper-mac","grasshopper-mac",NID_grasshopper_mac,0,NULL,0},
 };
 
 static const unsigned int sn_objs[NUM_SN]={
@@ -3025,10 +3034,19 @@ static const unsigned int sn_objs[NUM_SN]={
 979,	/* "gost2012_256" */
 980,	/* "gost2012_512" */
 813,	/* "gost89" */
+1009,	/* "gost89-cbc" */
 814,	/* "gost89-cnt" */
 975,	/* "gost89-cnt-12" */
+1011,	/* "gost89-ctr" */
+1010,	/* "gost89-ecb" */
 812,	/* "gost94" */
 850,	/* "gost94cc" */
+1015,	/* "grasshopper-cbc" */
+1016,	/* "grasshopper-cfb" */
+1013,	/* "grasshopper-ctr" */
+1012,	/* "grasshopper-ecb" */
+1017,	/* "grasshopper-mac" */
+1014,	/* "grasshopper-ofb" */
 797,	/* "hmacWithMD5" */
 163,	/* "hmacWithSHA1" */
 798,	/* "hmacWithSHA224" */
@@ -4053,8 +4071,17 @@ static const unsigned int ln_objs[NUM_LN]={
 601,	/* "generic cryptogram" */
 99,	/* "givenName" */
 976,	/* "gost-mac-12" */
+1009,	/* "gost89-cbc" */
 814,	/* "gost89-cnt" */
 975,	/* "gost89-cnt-12" */
+1011,	/* "gost89-ctr" */
+1010,	/* "gost89-ecb" */
+1015,	/* "grasshopper-cbc" */
+1016,	/* "grasshopper-cfb" */
+1013,	/* "grasshopper-ctr" */
+1012,	/* "grasshopper-ecb" */
+1017,	/* "grasshopper-mac" */
+1014,	/* "grasshopper-ofb" */
 855,	/* "hmac" */
 780,	/* "hmac-md5" */
 781,	/* "hmac-sha1" */

--- a/crypto/objects/obj_mac.num
+++ b/crypto/objects/obj_mac.num
@@ -1006,3 +1006,12 @@ OGRN		1005
 SNILS		1006
 subjectSignTool		1007
 issuerSignTool		1008
+gost89_cbc		1009
+gost89_ecb		1010
+gost89_ctr		1011
+grasshopper_ecb		1012
+grasshopper_ctr		1013
+grasshopper_ofb		1014
+grasshopper_cbc		1015
+grasshopper_cfb		1016
+grasshopper_mac		1017

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -1171,6 +1171,9 @@ cryptopro 20		: gost94	: GOST R 34.10-94
 cryptopro 21		: gost89 		: GOST 28147-89
 			: gost89-cnt
 			: gost89-cnt-12
+			: gost89-cbc
+			: gost89-ecb
+			: gost89-ctr
 !Cname id-Gost28147-89-MAC
 cryptopro 22		: gost-mac	: GOST 28147-89 MAC
 			: gost-mac-12
@@ -1279,6 +1282,14 @@ member-body 643 100 1		: OGRN	: OGRN
 member-body 643 100 3		: SNILS	: SNILS
 member-body 643 100 111	: subjectSignTool	: Signing Tool of Subject
 member-body 643 100 112	: issuerSignTool	: Signing Tool of Issuer
+
+#GOST R34.13-2015 Grasshopper "Kuznechik"
+			: grasshopper-ecb
+			: grasshopper-ctr
+			: grasshopper-ofb
+			: grasshopper-cbc
+			: grasshopper-cfb
+			: grasshopper-mac
 
 # Definitions for Camellia cipher - CBC MODE
 

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -3735,6 +3735,15 @@
 #define SN_gost89_cnt_12                "gost89-cnt-12"
 #define NID_gost89_cnt_12               975
 
+#define SN_gost89_cbc           "gost89-cbc"
+#define NID_gost89_cbc          1009
+
+#define SN_gost89_ecb           "gost89-ecb"
+#define NID_gost89_ecb          1010
+
+#define SN_gost89_ctr           "gost89-ctr"
+#define NID_gost89_ctr          1011
+
 #define SN_id_Gost28147_89_MAC          "gost-mac"
 #define LN_id_Gost28147_89_MAC          "GOST 28147-89 MAC"
 #define NID_id_Gost28147_89_MAC         815
@@ -4052,6 +4061,24 @@
 #define LN_issuerSignTool               "Signing Tool of Issuer"
 #define NID_issuerSignTool              1008
 #define OBJ_issuerSignTool              OBJ_member_body,643L,100L,112L
+
+#define SN_grasshopper_ecb              "grasshopper-ecb"
+#define NID_grasshopper_ecb             1012
+
+#define SN_grasshopper_ctr              "grasshopper-ctr"
+#define NID_grasshopper_ctr             1013
+
+#define SN_grasshopper_ofb              "grasshopper-ofb"
+#define NID_grasshopper_ofb             1014
+
+#define SN_grasshopper_cbc              "grasshopper-cbc"
+#define NID_grasshopper_cbc             1015
+
+#define SN_grasshopper_cfb              "grasshopper-cfb"
+#define NID_grasshopper_cfb             1016
+
+#define SN_grasshopper_mac              "grasshopper-mac"
+#define NID_grasshopper_mac             1017
 
 #define SN_camellia_128_cbc             "CAMELLIA-128-CBC"
 #define LN_camellia_128_cbc             "camellia-128-cbc"


### PR DESCRIPTION
This pull request introduces short names and NIDs for Russian GOST ciphers according the GOST R 34.13-2015