### PR TITLE
More build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ matrix:
           compiler: i686-w64-mingw32-gcc
         - os: osx
           compiler: x86_64-w64-mingw32-gcc
+    allow_failures:
+        - compiler: i686-w64-mingw32-gcc
+          env: CONFIG_OPTS="--debug --strict-warnings"
+        - compiler: x86_64-w64-mingw32-gcc
+          env: CONFIG_OPTS="--debug --strict-warnings"
 
 before_script:
     - if [ "$CC" == i686-w64-mingw32-gcc ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ compiler:
 env:
     - CONFIG_OPTS=""
     - CONFIG_OPTS="shared"
-    - CONFIG_OPTS="-d --strict-warnings"
+    - CONFIG_OPTS="--debug --strict-warnings"
 
 matrix:
     exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,5 @@ script:
     - if [ -z "$CROSS_COMPILE" ]; then make test; fi
 
 notifications:
-    recipient:
-        - openssl-commits@openssl.org
     email:
-        on_success: change
-        on_failure: always
+        - openssl-commits@openssl.org

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1174,7 +1174,7 @@
     "mingw" => {
         inherit_from     => [ asm("x86_asm") ],
         cc               => "gcc",
-        cflags           => "-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -march=i486 -Wall",
+        cflags           => "-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -march=i486 -Wall -Wno-pedantic-ms-format",
         debug_cflags     => "-g -O0",
         release_clags    => "-O3 -fomit-frame-pointer",
         thread_cflag     => "-D_MT",
@@ -1199,7 +1199,7 @@
         # Applink is never engaged and can as well be omitted.
         inherit_from     => [ asm("x86_64_asm") ],
         cc               => "gcc",
-        cflags           => "-mno-cygwin -DL_ENDIAN -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE",
+        cflags           => "-mno-cygwin -DL_ENDIAN -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE -Wno-pedantic-ms-format",
         debug_cflags     => "-g -O0",
         release_clags    => "-O3",
         thread_cflag     => "-D_MT",

--- a/crypto/bn/bn_dh.c
+++ b/crypto/bn/bn_dh.c
@@ -248,7 +248,8 @@ static const BN_ULONG dh2048_256_q[] = {
 
 /* Macro to make a BIGNUM from static data */
 
-# define make_dh_bn(x) const BIGNUM _bignum_##x = { (BN_ULONG *) x, \
+# define make_dh_bn(x) extern const BIGNUM _bignum_##x; \
+                       const BIGNUM _bignum_##x = { (BN_ULONG *) x, \
                         OSSL_NELEM(x),\
                         OSSL_NELEM(x),\
                         0, BN_FLG_STATIC_DATA };

--- a/test/packettest.c
+++ b/test/packettest.c
@@ -242,16 +242,16 @@ static int test_PACKET_copy_bytes(unsigned char buf[BUF_LEN])
 
 static int test_PACKET_copy_all(unsigned char buf[BUF_LEN])
 {
-    unsigned char dup[BUF_LEN];
+    unsigned char tmp[BUF_LEN];
     PACKET pkt;
     size_t len;
 
     if (       !PACKET_buf_init(&pkt, buf, BUF_LEN)
-               || !PACKET_copy_all(&pkt, dup, BUF_LEN, &len)
+               || !PACKET_copy_all(&pkt, tmp, BUF_LEN, &len)
                || len != BUF_LEN
-               || memcmp(buf, dup, BUF_LEN) != 0
+               || memcmp(buf, tmp, BUF_LEN) != 0
                || PACKET_remaining(&pkt) != BUF_LEN
-               || PACKET_copy_all(&pkt, dup, BUF_LEN - 1, &len)) {
+               || PACKET_copy_all(&pkt, tmp, BUF_LEN - 1, &len)) {
         fprintf(stderr, "test_PACKET_copy_bytes() failed\n");
         return 0;
     }


### PR DESCRIPTION
Don't know if anyone is working on this, but the first patch fixes a clang warning which makes the build fail due to --strict-warnings. The other reverts 1d4ddb4e1a088f1333c4bb155c52c7f94e572bca and follow-up to make mingw debug build work again (this is only in master).

This should make all Travis builds work again.