### PR TITLE
WIP: Add Travis builds with Clang v3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 
 script:
     - make
-    - if [ -z "$CROSS_COMPILE" ]; then make test; fi
+    - if [ -z "$CROSS_COMPILE" ]; then HARNESS_VERBOSE=yes make test; fi
 
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: c
 
 addons:
-    apt_packages:
-        - binutils-mingw-w64
-        - gcc-mingw-w64
+    apt:
+        packages:
+            - clang-3.6
+            - gcc-5
+            - binutils-mingw-w64
+            - gcc-mingw-w64
+        sources:
+            - llvm-toolchain-precise-3.6
+            - ubuntu-toolchain-r-test
 
 os:
     - linux
@@ -11,7 +17,9 @@ os:
 
 compiler:
     - clang
+    - clang-3.6
     - gcc
+    - gcc-5
     - i686-w64-mingw32-gcc
     - x86_64-w64-mingw32-gcc
 
@@ -21,7 +29,21 @@ env:
     - CONFIG_OPTS="--debug --strict-warnings"
 
 matrix:
+    include:
+        - os: linux
+          compiler: clang-3.6
+          env: CONFIG_OPTS="--debug --strict-warnings -fsanitize=address"
+        - os: linux
+          compiler: clang-3.6
+          env: CONFIG_OPTS="--debug --strict-warnings -fPIE -pie -fsanitize=memory"
+        - os: linux
+          compiler: gcc-5
+          env: CONFIG_OPTS="--debug --strict-warnings -fsanitize=address"
     exclude:
+        - os: osx
+          compiler: clang-3.6
+        - os: osx
+          compiler: gcc-5
         - os: osx
           compiler: i686-w64-mingw32-gcc
         - os: osx


### PR DESCRIPTION
This includes additional debug builds with address sanitizer and memory sanitizer enabled.

This is on top of #429 to avoid merge failures (I've kept them separate because I don't know if this works, so don't review yet).

Clang also supports a "memory sanitizer" additionally to asan, but I wasn't able to make it work locally due to an incompatibility with recent Linux versions. I hope this works on Travis.