### PR TITLE
Add Clang 3.6 and additional GCC 5 builds to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: c
 addons:
     apt:
         packages:
+            - clang-3.6
             - gcc-5
             - binutils-mingw-w64
             - gcc-mingw-w64
         sources:
+            - llvm-toolchain-precise-3.6
             - ubuntu-toolchain-r-test
 
 os:
@@ -15,6 +17,7 @@ os:
 
 compiler:
     - clang
+    - clang-3.6
     - gcc
     - gcc-5
     - i686-w64-mingw32-gcc
@@ -28,9 +31,20 @@ env:
 matrix:
     include:
         - os: linux
+          compiler: clang-3.6
+          env: CONFIG_OPTS="-fsanitize=address"
+        - os: linux
+          compiler: clang-3.6
+          env: CONFIG_OPTS="--debug --strict-warnings -fsanitize=address"
+        - os: linux
+          compiler: gcc-5
+          env: CONFIG_OPTS="-fsanitize=address"
+        - os: linux
           compiler: gcc-5
           env: CONFIG_OPTS="--debug --strict-warnings -fsanitize=address"
     exclude:
+        - os: osx
+          compiler: clang-3.6
         - os: osx
           compiler: gcc-5
         - os: osx


### PR DESCRIPTION
Follow-up to f386742.

(I already squashed the changes into a single commit to make merging easier).