### PR TITLE
Fix x86_64 nmake masm build (VS2015 toolchain) Take 2

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -7,7 +7,7 @@ TOP=		..
 CC=		cc
 INCLUDE=	-I. -I$(TOP) -I../include -Iinclude $(ZLIB_INCLUDE)
 # INCLUDES targets sudbirs!
-INCLUDES=	-I.. -I../.. -I../modes -I../include -I../../include $(ZLIB_INCLUDE)
+INCLUDES=	-I.. -I../.. -I../modes -I../ct -I../include -I../../include $(ZLIB_INCLUDE)
 CFLAG=		-g
 MAKEDEPPROG=	makedepend
 MAKEDEPEND=	$(TOP)/util/domd $(TOP) -MD $(MAKEDEPPROG)

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -541,7 +541,7 @@ my %globals;
 					$v="$current_segment\tENDS\n" if ($current_segment);
 					$current_segment = ".text\$";
 					$v.="$current_segment\tSEGMENT ";
-					$v.=$masm>=$masmref ? "ALIGN(256)" : "PAGE";
+					$v.=$masm>=$masmref ? "ALIGN(4096)" : "PAGE";
 					$v.=" 'CODE'";
 				    }
 				    $self->{value} = $v;

--- a/crypto/x509v3/v3_scts.c
+++ b/crypto/x509v3/v3_scts.c
@@ -61,7 +61,7 @@
 #include <openssl/asn1.h>
 #include <openssl/x509v3.h>
 #include "ext_dat.h"
-#include "crypto/ct/ct_locl.h"
+#include "ct_locl.h"
 
 #ifndef OPENSSL_NO_CT
 /* Signature and hash algorithms from RFC 5246 */


### PR DESCRIPTION
* Make ct_locl.h include consistent with other private headers
* Add -I../ct so x509v3 can include certificate transparency header
* Fixes MASM x86_64 assembler error on the ecp_nistz256-x86_64 constant table

The ecp_nistz256-x86_64 constant table specifies 4096 byte alignment which conflicts with the 256 byte alignment for text pages in x86_64-xlate.pl which causes MASM to fail with the following error (presumably because MASM doesn't allow the alignment to be greater than the section alignment):

````
  Building OpenSSL
          set ASM=ml64 /c /Cp /Cx /Zi
          perl crypto\ec\asm\ecp_nistz256-x86_64.pl tmp32\ecp_nistz256-x86_64.asm
          ml64 /c /Cp /Cx /Zi /Fotmp32\ecp_nistz256-x86_64.obj tmp32\ecp_nistz256-x86_64.asm
  Microsoft (R) Macro Assembler (x64) Version 14.00.23026.0
  Copyright (C) Microsoft Corporation.  All rights reserved.

  Assembling: tmp32\ecp_nistz256-x86_64.asm
  tmp32\ecp_nistz256-x86_64.asm(5)ze
  tmp32\ecp_nistz256-x86_64.asm(5) : error A2189:invalid combination with segment
  alignment :NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual
  Studio 14.0\VC\BIN\amd64\ml64.EXE"' : return code '0x1'
  Stop.
````

An alterntive would be to lower the alignment of the ecp_nistz256-x86_64 constant table to 256 bytes.