### PR TITLE
Implement default threadid callback for Unix (fixes #426)

### DIFF
--- a/crypto/thr_id.c
+++ b/crypto/thr_id.c
@@ -119,6 +119,11 @@
 #ifndef OPENSSL_NO_DEPRECATED
 static unsigned long (*id_callback) (void) = 0;
 #endif
+
+#if defined(__unix__) || defined(unix)
+# include <pthread.h>
+#endif
+
 static void (*threadid_callback) (CRYPTO_THREADID *) = 0;
 
 /*
@@ -199,6 +204,8 @@ void CRYPTO_THREADID_current(CRYPTO_THREADID *id)
     /* Else pick a backup */
 #if defined(OPENSSL_SYS_WIN32)
     CRYPTO_THREADID_set_numeric(id, (unsigned long)GetCurrentThreadId());
+#elif defined(__unix__) || defined(unix)
+    CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
 #else
     /* For everything else, default to using the address of 'errno' */
     CRYPTO_THREADID_set_pointer(id, (void *)&errno);

--- a/doc/crypto/threads.pod
+++ b/doc/crypto/threads.pod
@@ -86,10 +86,10 @@ fill in B<id> directly, but should use CRYPTO_THREADID_set_numeric() if thread
 IDs are numeric, or CRYPTO_THREADID_set_pointer() if they are pointer-based.
 If the application does not register such a callback using
 CRYPTO_THREADID_set_callback(), then a default implementation is used - on
-Windows and BeOS this uses the system's default thread identifying APIs, and on
-all other platforms it uses the address of B<errno>. The latter is satisfactory
-for thread-safety if and only if the platform has a thread-local error number
-facility.
+Windows and BeOS this uses the system's default thread identifying APIs, on Unix
+it uses the ID of the current pthread and on all other platforms it uses the
+address of B<errno>. The latter is satisfactory for thread-safety if and only if
+the platform has a thread-local error number facility.
 
 Once threadid_func() is registered, or if the built-in default implementation is
 to be used;


### PR DESCRIPTION
There are also examples in [the test file](https://github.com/openssl/openssl/blob/master/crypto/threads/mttest.c#L115) for Irix, Solaris, BeOS, and Netware; however I'm not familiar with these OSes so I haven't added fallbacks for these. Let me know if I should.