### PR TITLE
Tls tickets

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4546,19 +4546,19 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
             SESS_TICKET_KEY *keys = parg;
             if (!keys)
                 return 48;
-            if (larg > 0 && larg % sizeof(SESS_TICKET_KEY) != 0) {
+            if ((larg > 0) && ((larg % sizeof(SESS_TICKET_KEY)) != 0)) {
                 SSLerr(SSL_F_SSL3_CTX_CTRL, SSL_R_INVALID_TICKET_KEYS_LENGTH);
                 return 0;
             }
             if (cmd == SSL_CTRL_SET_TLSEXT_TICKET_KEYS) {
-                SSL_CTX_set_tlsext_ticket_key_list(ctx, keys, larg / sizeof(SESS_TICKET_KEY));
+                SSL_CTX_set_tlsext_ticket_key_list(ctx, keys, larg / (long)sizeof(SESS_TICKET_KEY));
             } else if (ctx->ticket_key_list == NULL ||
                     ctx->ticket_key_list->all == NULL ||
                     ctx->ticket_key_list->all_len < 1) {
                 SSLerr(SSL_F_SSL3_CTX_CTRL, ERR_R_PASSED_NULL_PARAMETER);
                 return 0;
             } else {
-                if (larg != ctx->ticket_key_list->all_len * sizeof(SESS_TICKET_KEY)) {
+                if (larg != (ctx->ticket_key_list->all_len * (long)sizeof(SESS_TICKET_KEY))) {
                     SSLerr(SSL_F_SSL3_CTX_CTRL, SSL_R_INVALID_TICKET_KEYS_LENGTH);
                     return 0;
                 }

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -3226,22 +3226,15 @@ int ssl3_send_newsession_ticket(SSL *s)
         p = ssl_handshake_start(s);
         /*
          * Initialize HMAC and cipher contexts. If callback present it does
-         * all the work otherwise use generated values from parent ctx.
+         * all the work otherwise use default callback.
          */
         if (tctx->tlsext_ticket_key_cb) {
             if (tctx->tlsext_ticket_key_cb(s, key_name, iv, &ctx,
                                            &hctx, 1) < 0)
                 goto err;
         } else {
-            if (RAND_bytes(iv, 16) <= 0)
+            if (handle_session_tickets(s, key_name, iv, &ctx, &hctx, 1) <= 0)
                 goto err;
-            if (!EVP_EncryptInit_ex(&ctx, EVP_aes_128_cbc(), NULL,
-                                    tctx->tlsext_tick_aes_key, iv))
-                goto err;
-            if (!HMAC_Init_ex(&hctx, tctx->tlsext_tick_hmac_key, 16,
-                              EVP_sha256(), NULL))
-                goto err;
-            memcpy(key_name, tctx->tlsext_tick_key_name, 16);
         }
 
         /*

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -223,6 +223,8 @@ static ERR_STRING_DATA SSL_str_functs[] = {
     {ERR_FUNC(SSL_F_SSL_CTX_SET_SESSION_ID_CONTEXT),
      "SSL_CTX_set_session_id_context"},
     {ERR_FUNC(SSL_F_SSL_CTX_SET_SSL_VERSION), "SSL_CTX_set_ssl_version"},
+    {ERR_FUNC(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST),
+     "SSL_CTX_set_tlsext_ticket_key_list"},
     {ERR_FUNC(SSL_F_SSL_CTX_SET_TRUST), "SSL_CTX_set_trust"},
     {ERR_FUNC(SSL_F_SSL_CTX_USE_CERTIFICATE), "SSL_CTX_use_certificate"},
     {ERR_FUNC(SSL_F_SSL_CTX_USE_CERTIFICATE_ASN1),

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1205,6 +1205,12 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         return (ctx->cert->cert_flags |= larg);
     case SSL_CTRL_CLEAR_CERT_FLAGS:
         return (ctx->cert->cert_flags &= ~larg);
+    case SSL_CTRL_TLS_TICKET_SUCCESS:
+        return (ctx->stats.tls_ticket_success);
+    case SSL_CTRL_TLS_TICKET_RENEW:
+        return (ctx->stats.tls_ticket_renew);
+    case SSL_CTRL_TLS_TICKET_FAIL:
+        return (ctx->stats.tls_ticket_fail);
     default:
         return (ctx->method->ssl_ctx_ctrl(ctx, cmd, larg, parg));
     }
@@ -1744,9 +1750,9 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
 
     /* Setup RFC5077 ticket keys */
     SESS_TICKET_KEY key;
-    if ((RAND_bytes(key.key_name, KEY_ELEM_LEN) <= 0)
-        || (RAND_bytes(key.hmac_key, KEY_ELEM_LEN) <= 0)
-        || (RAND_bytes(key.aes_key, KEY_ELEM_LEN) <= 0))
+    if ((RAND_bytes(key.key_name.elem, SESS_TICKET_ELEM_SIZE) <= 0)
+        || (RAND_bytes(key.hmac_key.elem, SESS_TICKET_ELEM_SIZE) <= 0)
+        || (RAND_bytes(key.aes_key.elem, SESS_TICKET_ELEM_SIZE) <= 0))
         ret->options |= SSL_OP_NO_TICKET;
     else
         SSL_CTX_set_tlsext_ticket_keys(ret, (unsigned char*)&key, sizeof(SESS_TICKET_KEY));
@@ -3304,15 +3310,16 @@ void *SSL_CTX_get0_security_ex_data(const SSL_CTX *ctx)
 }
 
 /* Must be called with non-null keys. */
-SESS_TICKET_KEY *find_ticket_key(SESS_TICKET_KEY_LIST *keys,
-                                 unsigned char key_name[KEY_ELEM_LEN]) {
+static SESS_TICKET_KEY *find_ticket_key(SESS_TICKET_KEY_LIST *keys,
+                                 SESS_TICKET_ELEM* key_name) {
     int i;
     if (keys != NULL) {
         for (i = 0; i < keys->all_len; i++) {
             SESS_TICKET_KEY *key = &keys->all[i];
-            if (memcmp(key->key_name, key_name, KEY_ELEM_LEN) == 0)
+            if (memcmp(key->key_name.elem, key_name->elem, sizeof(key_name->elem)) == 0) {
                 return key;
         }
+    }
     }
     return NULL;
 }
@@ -3321,8 +3328,9 @@ SESS_TICKET_KEY *find_ticket_key(SESS_TICKET_KEY_LIST *keys,
 void SESS_TICKET_KEY_LIST_free(SESS_TICKET_KEY_LIST *key_list) {
     int lock_result;
 
-    if (key_list == NULL)
+    if (key_list == NULL) {
         return;
+    }
 
     lock_result = CRYPTO_add(&key_list->references, -1, CRYPTO_LOCK_SSL_CTX);
 # ifdef REF_PRINT
@@ -3341,11 +3349,13 @@ void SESS_TICKET_KEY_LIST_free(SESS_TICKET_KEY_LIST *key_list) {
     free(key_list);
 }
 
-int handle_session_tickets_inner(SESS_TICKET_KEY_LIST *key_list,
-                                 unsigned char key_name[KEY_ELEM_LEN], unsigned char iv[EVP_MAX_IV_LENGTH],
+static int handle_session_tickets_inner(SSL *s,
+                                 SESS_TICKET_KEY_LIST *key_list,
+                                 SESS_TICKET_ELEM *key_name, SESS_TICKET_IV *iv,
                                  EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc) {
-    if (key_list == NULL || key_list->all == NULL)
+    if (key_list == NULL || key_list->all == NULL) {
         return SSL_RESUME_ERROR;
+    }
 
     /* Request has no ticket, or unrecognized ticket, or we are renewing based on
      * a recognized ticket: Encrypt a new ticket to send to the client. */
@@ -3353,26 +3363,30 @@ int handle_session_tickets_inner(SESS_TICKET_KEY_LIST *key_list,
         /* The first key in the list is used for all new tickets. */
         SESS_TICKET_KEY *key = &key_list->all[0];
 
-        if (RAND_bytes(iv, EVP_MAX_IV_LENGTH) <= 0)
+        if (RAND_bytes(iv->iv, EVP_MAX_IV_LENGTH) <= 0) {
             return SSL_RESUME_ERROR; /* insufficient random */
-        EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key->aes_key, iv);
-        HMAC_Init_ex(hctx, key->hmac_key, KEY_ELEM_LEN, EVP_sha256(), NULL);
-        memcpy(key_name, key->key_name, KEY_ELEM_LEN);
+        }
+        EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key->aes_key.elem, iv->iv);
+        HMAC_Init_ex(hctx, key->hmac_key.elem, SESS_TICKET_ELEM_SIZE, EVP_sha256(), NULL);
+        memcpy(key_name->elem, key->key_name.elem, sizeof(key_name->elem));
         return SSL_RESUME_SUCCESS;
     } else {
         /* Request has session ticket. */
         SESS_TICKET_KEY *key = find_ticket_key(key_list, key_name);
-        if (!key) {
+        if (key == NULL) {
             /* if the key is so old that it's no longer in our list, we have to do a full handshake. */
+            s->ctx->stats.tls_ticket_fail++;
             return SSL_RESUME_NOPE;
         }
-        EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key->aes_key, iv);
-        HMAC_Init_ex(hctx, key->hmac_key, KEY_ELEM_LEN, EVP_sha256(), NULL);
+        EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key->aes_key.elem, iv->iv);
+        HMAC_Init_ex(hctx, key->hmac_key.elem, SESS_TICKET_ELEM_SIZE, EVP_sha256(), NULL);
         if (key != &key_list->all[0]) {
             /* Successful resume, but key is stale. Function will be called again with
                enc = 1 to re-encrypt the session parameters with the current key. */
+            s->ctx->stats.tls_ticket_renew++;
             return SSL_RESUME_SUCCESS_RENEW;
         }
+        s->ctx->stats.tls_ticket_success++;
         return SSL_RESUME_SUCCESS;
     }
 }
@@ -3381,18 +3395,19 @@ int handle_session_tickets_inner(SESS_TICKET_KEY_LIST *key_list,
  * This function handles reference counting and calls into an inner function for the
  * key lookup. */
 int handle_session_tickets(SSL *s,
-                           unsigned char key_name[KEY_ELEM_LEN], unsigned char iv[EVP_MAX_IV_LENGTH],
+                           SESS_TICKET_ELEM *key_name, SESS_TICKET_IV *iv,
                            EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc) {
     /* It's possible s->ctx->ticket_key_list gets changed while we are
      * looking for the right key. So we save a pointer and increment the
      * reference count so it doesn't get deleted from under us. */
     CRYPTO_w_lock(CRYPTO_LOCK_SSL_CTX);
     SESS_TICKET_KEY_LIST *list = s->ctx->ticket_key_list;
-    if (list != NULL)
+    if (list != NULL) {
         list->references++;
+    }
     CRYPTO_w_unlock(CRYPTO_LOCK_SSL_CTX);
 
-    int code = handle_session_tickets_inner(list, key_name, iv, ctx, hctx, enc);
+    int code = handle_session_tickets_inner(s, list, key_name, iv, ctx, hctx, enc);
 
     SESS_TICKET_KEY_LIST_free(list);
     return code;
@@ -3416,37 +3431,36 @@ int handle_session_tickets(SSL *s,
  *
  * OpenSSL makes a copy of the keys, and overwrites the input. */
 void SSL_CTX_set_tlsext_ticket_key_list(SSL_CTX *ctx, SESS_TICKET_KEY *keys, int len) {
-    if (keys == NULL || len < 1 || INT_MAX / sizeof(SESS_TICKET_KEY) < len) {
-        SSLerr(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST,ERR_R_PASSED_NULL_PARAMETER);
-        return;
-    }
+  if (keys == NULL || len < 1) {
+    SSLerr(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST,ERR_R_PASSED_NULL_PARAMETER);
+    return;
+  }
 
-    SESS_TICKET_KEY_LIST *old_list,
-                         *new_list = OPENSSL_malloc(sizeof(SESS_TICKET_KEY_LIST));
+  SESS_TICKET_KEY_LIST *new_list = OPENSSL_malloc(sizeof(SESS_TICKET_KEY_LIST));
+  unsigned int list_byte_len = sizeof(SESS_TICKET_KEY) * len;
+  if (new_list == NULL) {
+    SSLerr(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST,ERR_R_MALLOC_FAILURE);
+    OPENSSL_cleanse(keys, list_byte_len);
+    return;
+  }
+  new_list->references = 1;
+  new_list->all = (SESS_TICKET_KEY*)OPENSSL_malloc(list_byte_len);
+  new_list->all_len = len;
+  if (new_list->all == NULL) {
+    SSLerr(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST,ERR_R_MALLOC_FAILURE);
+    OPENSSL_cleanse(keys, list_byte_len);
+    return;
+  }
 
-    if (new_list == NULL) {
-        SSLerr(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST,ERR_R_MALLOC_FAILURE);
-        OPENSSL_cleanse(keys, sizeof(SESS_TICKET_KEY) * len);
-        return;
-    }
-    new_list->references = 1;
-    new_list->all = (SESS_TICKET_KEY*)OPENSSL_malloc(sizeof(SESS_TICKET_KEY) * len);
-    new_list->all_len = len;
-    if (new_list->all == NULL) {
-        SSLerr(SSL_F_SSL_CTX_SET_TLSEXT_TICKET_KEY_LIST,ERR_R_MALLOC_FAILURE);
-        OPENSSL_cleanse(keys, sizeof(SESS_TICKET_KEY) * len);
-        return;
-    }
+  memcpy(new_list->all, keys, list_byte_len);
+  OPENSSL_cleanse(keys, list_byte_len);
 
-    memcpy(new_list->all, keys, len * sizeof(SESS_TICKET_KEY));
-    OPENSSL_cleanse(keys, sizeof(SESS_TICKET_KEY) * len);
+  CRYPTO_w_lock(CRYPTO_LOCK_SSL_CTX);
+  SESS_TICKET_KEY_LIST *old_list = ctx->ticket_key_list;
+  ctx->ticket_key_list = new_list;
+  CRYPTO_w_unlock(CRYPTO_LOCK_SSL_CTX);
 
-    CRYPTO_w_lock(CRYPTO_LOCK_SSL_CTX);
-    old_list = ctx->ticket_key_list;
-    ctx->ticket_key_list = new_list;
-    CRYPTO_w_unlock(CRYPTO_LOCK_SSL_CTX);
-
-    SESS_TICKET_KEY_LIST_free(old_list);
+  SESS_TICKET_KEY_LIST_free(old_list);
 }
 
 IMPLEMENT_OBJ_BSEARCH_GLOBAL_CMP_FN(SSL_CIPHER, SSL_CIPHER, ssl_cipher_id);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -863,10 +863,10 @@ struct ssl_ctx_st {
     /* TLS extensions servername callback */
     int (*tlsext_servername_callback) (SSL *, int *, void *);
     void *tlsext_servername_arg;
-    /* RFC 4507 session ticket keys */
-    unsigned char tlsext_tick_key_name[16];
-    unsigned char tlsext_tick_hmac_key[16];
-    unsigned char tlsext_tick_aes_key[16];
+
+    /* A set of session ticket keys for RFC 5077 resumption. */
+    SESS_TICKET_KEY_LIST* ticket_key_list;
+
     /* Callback to support customisation of ticket key setting */
     int (*tlsext_ticket_key_cb) (SSL *ssl,
                                  unsigned char *name, unsigned char *iv,

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -772,6 +772,9 @@ struct ssl_ctx_st {
                                  * indicates that the application is
                                  * supplying session-id's from other
                                  * processes - spooky :-) */
+        int tls_ticket_success; /* tls ticket session resumptions (primary key) */
+        int tls_ticket_renew;   /* tls ticket session upgrades (non-primary key) */
+        int tls_ticket_fail;    /* tls ticket session renewal failure */
     } stats;
 
     int references;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3069,7 +3069,11 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     if (tctx->tlsext_ticket_key_cb != NULL) {
         rv = tctx->tlsext_ticket_key_cb(s, nctick, nctick + 16, &ctx, &hctx, 0);
     } else {
-        rv = handle_session_tickets(s, nctick, nctick + 16, &ctx, &hctx, 0);
+      SESS_TICKET_ELEM key_name;
+      memcpy(key_name.elem, nctick, 16);
+      SESS_TICKET_IV iv;
+      memcpy(iv.iv, nctick+16, 16);
+      rv = handle_session_tickets(s, &key_name, &iv, &ctx, &hctx, 0);
     }
 
     if (rv < 0)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3056,31 +3056,29 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     HMAC_CTX hctx;
     EVP_CIPHER_CTX ctx;
     SSL_CTX *tctx = s->initial_ctx;
+    unsigned char *nctick = (unsigned char *)etick;
+    int rv;
+
     /* Need at least keyname + iv + some encrypted data */
     if (eticklen < 48)
         return 2;
     /* Initialize session ticket encryption and HMAC contexts */
     HMAC_CTX_init(&hctx);
     EVP_CIPHER_CTX_init(&ctx);
-    if (tctx->tlsext_ticket_key_cb) {
-        unsigned char *nctick = (unsigned char *)etick;
-        int rv = tctx->tlsext_ticket_key_cb(s, nctick, nctick + 16,
-                                            &ctx, &hctx, 0);
-        if (rv < 0)
-            return -1;
-        if (rv == 0)
-            return 2;
-        if (rv == 2)
-            renew_ticket = 1;
+
+    if (tctx->tlsext_ticket_key_cb != NULL) {
+        rv = tctx->tlsext_ticket_key_cb(s, nctick, nctick + 16, &ctx, &hctx, 0);
     } else {
-        /* Check key name matches */
-        if (memcmp(etick, tctx->tlsext_tick_key_name, 16))
-            return 2;
-        HMAC_Init_ex(&hctx, tctx->tlsext_tick_hmac_key, 16,
-                     EVP_sha256(), NULL);
-        EVP_DecryptInit_ex(&ctx, EVP_aes_128_cbc(), NULL,
-                           tctx->tlsext_tick_aes_key, etick + 16);
+        rv = handle_session_tickets(s, nctick, nctick + 16, &ctx, &hctx, 0);
     }
+
+    if (rv < 0)
+        return -1;
+    if (rv == 0)
+        return 2;
+    if (rv == 2)
+        renew_ticket = 1;
+
     /*
      * Attempt to process session ticket, first conduct sanity and integrity
      * checks on ticket.


### PR DESCRIPTION
The existing API for managing RFC 5077 TLS ticket keys is cumbersome: callers must either specify a key once at startup or they must implement a complicated callback API.

This new API allows a caller to set a list of TLS ticket keys. The first key in the list is preferred, and any other keys in the list will be accepted with an upgrade to a ticket with the preferred key. This scheme allows groups of servers to implement seamless key rotation strategies.

The original patch comes from Twitter's https://github.com/twitter/sslconfig

RT: [openssl.org #4108]
