### PR TITLE
Add initial AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,60 @@
+platform:
+    - x86
+    - x64
+
+environment:
+    matrix:
+        - VSVER: 9
+        - VSVER: 10
+        - VSVER: 11
+        - VSVER: 12
+        - VSVER: 14
+
+configuration:
+    - plain
+    - shared
+
+matrix:
+    allow_failures:
+        - platform: x64
+          VSVER: 9
+        - platform: x64
+          VSVER: 10
+        - platform: x64
+          VSVER: 11
+
+before_build:
+    - ps: >-
+        If ($env:Platform -Match "x86") {
+            $env:VCVARS_PLATFORM="x86"
+            $env:TARGET="VC-WIN32"
+            $env:DO="do_ms"
+        } Else {
+            $env:VCVARS_PLATFORM="amd64"
+            $env:TARGET="VC-WIN64A"
+            $env:DO="do_win64a"
+        }
+    - ps: >-
+        If ($env:Configuration -Like "*shared*") {
+            $env:MAK="ntdll.mak"
+        } Else {
+            $env:MAK="nt.mak"
+        }
+    - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
+    - call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
+    - perl Configure %TARGET% no-asm
+    - call ms\%DO%
+
+build_script:
+    - nmake /f ms\%MAK%
+
+test_script:
+    - nmake /f ms\%MAK% test
+
+notifications:
+    - provider: Email
+      to:
+          - openssl-commits@openssl.org
+      on_build_success: false
+      on_build_failure: true
+      on_build_status_changed: true


### PR DESCRIPTION
Original patch by Frank Morgner.

(AppVeyor is a continuous integration system like Travis CI, that provides support for Windows build environments).

This supersedes #400. Changes include:

* Added more VS versions
* Test suite is run
* Removed debug builds (not supported by OpenSSL)
* Added non-shared "plain" builds
* Enable email notifications for openssl-commits@openssl.org

Like Travis CI, AppVeyor needs to be manually enabled for this repository, see http://www.appveyor.com/docs

I only tested this on master, but it should probably be backported to 1.0.2 and 1.0.1 like Travis (there is a configuration option in the AppVeyor settings page for the project that let you disable builds for branches that dion't have the `appveyor.yml` configuration file. IMO it should be selected).