### PR TITLE
Fix "primarility" typo

### DIFF
--- a/apps/prime.c
+++ b/apps/prime.c
@@ -60,7 +60,7 @@ typedef enum OPTION_choice {
 OPTIONS prime_options[] = {
     {OPT_HELP_STR, 1, '-', "Usage: %s [options] [number...]\n"},
     {OPT_HELP_STR, 1, '-',
-        "  number Number to check for primarility\n"},
+        "  number Number to check for primality\n"},
     {"help", OPT_HELP, '-', "Display this summary"},
     {"hex", OPT_HEX, '-', "Hex output"},
     {"generate", OPT_GENERATE, '-', "Generate a prime"},


### PR DESCRIPTION
There's a typo in `prime_options` strings.