### PR TITLE
Encompassing only entire statements and expressions with preprocessor conditionals.

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -57,6 +57,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <time.h>
 #include <string.h>
 #include "apps.h"
@@ -1136,22 +1137,23 @@ static int auto_info(X509_REQ *req, STACK_OF(CONF_VALUE) *dn_sk,
          */
         for (p = v->name; *p; p++)
 #ifndef CHARSET_EBCDIC
-            if ((*p == ':') || (*p == ',') || (*p == '.')) {
+            bool skipCharacters = ((*p == ':') || (*p == ',') || (*p == '.'));
 #else
-            if ((*p == os_toascii[':']) || (*p == os_toascii[','])
-                || (*p == os_toascii['.'])) {
+            bool skipCharacters = ((*p == os_toascii[':']) || (*p == os_toascii[','])
+                || (*p == os_toascii['.']));
 #endif
+            if (skipCharacters) {
                 p++;
                 if (*p)
                     type = p;
                 break;
             }
 #ifndef CHARSET_EBCDIC
-        if (*p == '+')
+        bool isPlusCharacter = (*p == '+');
 #else
-        if (*p == os_toascii['+'])
+        bool isPlusCharacter = (*p == os_toascii['+']);
 #endif
-        {
+        if (isPlusCharacter) {
             p++;
             mval = -1;
         } else

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -141,6 +141,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -1826,11 +1827,11 @@ int s_server_main(int argc, char *argv[])
     }
 #ifndef OPENSSL_NO_PSK
 # ifdef OPENSSL_NO_JPAKE
-    if (psk_key != NULL)
+    bool keyInUse = (psk_key != NULL);
 # else
-    if (psk_key != NULL || jpake_secret)
+    bool keyInUse = (psk_key != NULL || jpake_secret);
 # endif
-    {
+    if (keyInUse) {
         if (s_debug)
             BIO_printf(bio_s_out,
                        "PSK key given or JPAKE in use, setting server callback\n");


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.