### PR TITLE
mark openssl configuration as loaded at end of OPENSSL_config

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -92,6 +92,7 @@ void OPENSSL_config(const char *config_name)
                                CONF_MFLAGS_DEFAULT_SECTION |
                                CONF_MFLAGS_IGNORE_MISSING_FILE);
 #endif
+    openssl_configured = 1;
 }
 
 void OPENSSL_no_config()


### PR DESCRIPTION
this avoids problems when OPENSSL_config is called twice,
e.g. adding engines twice will fail.

Signed-off-by: Marcus Meissner <meissner@suse.de>