### PR TITLE
Avoiding to compile parts of statements with preprocessor conditionals.

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1134,24 +1134,28 @@ static int auto_info(X509_REQ *req, STACK_OF(CONF_VALUE) *dn_sk,
         /*
          * Skip past any leading X. X: X, etc to allow for multiple instances
          */
-        for (p = v->name; *p; p++)
+        for (p = v->name; *p; p++){
+            int spec_char;
 #ifndef CHARSET_EBCDIC
-            if ((*p == ':') || (*p == ',') || (*p == '.')) {
+            spec_char = ((*p == ':') || (*p == ',') || (*p == '.'));
 #else
-            if ((*p == os_toascii[':']) || (*p == os_toascii[','])
-                || (*p == os_toascii['.'])) {
+            spec_char = ((*p == os_toascii[':']) || (*p == os_toascii[','])
+                    || (*p == os_toascii['.']));
 #endif
+            if (spec_char){
                 p++;
                 if (*p)
                     type = p;
                 break;
             }
+        }
+        int plus_char;
 #ifndef CHARSET_EBCDIC
-        if (*p == '+')
+        plus_char = (*p == ‘+’);
 #else
-        if (*p == os_toascii['+'])
+        plus_char = (*p == os_toascii[‘+’]);
 #endif
-        {
+        if (plus_char){
             p++;
             mval = -1;
         } else

--- a/apps/req.c
+++ b/apps/req.c
@@ -1118,7 +1118,7 @@ static int auto_info(X509_REQ *req, STACK_OF(CONF_VALUE) *dn_sk,
                      STACK_OF(CONF_VALUE) *attr_sk, int attribs,
                      unsigned long chtype)
 {
-    int i;
+    int i, spec_char, plus_char;
     char *p, *q;
     char *type;
     CONF_VALUE *v;
@@ -1135,7 +1135,6 @@ static int auto_info(X509_REQ *req, STACK_OF(CONF_VALUE) *dn_sk,
          * Skip past any leading X. X: X, etc to allow for multiple instances
          */
         for (p = v->name; *p; p++){
-            int spec_char;
 #ifndef CHARSET_EBCDIC
             spec_char = ((*p == ':') || (*p == ',') || (*p == '.'));
 #else
@@ -1149,7 +1148,6 @@ static int auto_info(X509_REQ *req, STACK_OF(CONF_VALUE) *dn_sk,
                 break;
             }
         }
-        int plus_char;
 #ifndef CHARSET_EBCDIC
         plus_char = (*p == ‘+’);
 #else

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1825,12 +1825,13 @@ int s_server_main(int argc, char *argv[])
                                                        not_resumable_sess_cb);
     }
 #ifndef OPENSSL_NO_PSK
+    int key_in_use;
 # ifdef OPENSSL_NO_JPAKE
-    if (psk_key != NULL)
+    key_in_use = (psk_key != NULL);
 # else
-    if (psk_key != NULL || jpake_secret)
+    key_in_use = (psk_key != NULL || jpake_secret);
 # endif
-    {
+    if (key_in_use){
         if (s_debug)
             BIO_printf(bio_s_out,
                        "PSK key given or JPAKE in use, setting server callback\n");

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1020,6 +1020,7 @@ int s_server_main(int argc, char *argv[])
 #ifndef OPENSSL_NO_PSK
     /* by default do not send a PSK identity hint */
     static char *psk_identity_hint = NULL;
+    int key_in_use;
 #endif
 #ifndef OPENSSL_NO_SRP
     char *srpuserseed = NULL;
@@ -1825,7 +1826,6 @@ int s_server_main(int argc, char *argv[])
                                                        not_resumable_sess_cb);
     }
 #ifndef OPENSSL_NO_PSK
-    int key_in_use;
 # ifdef OPENSSL_NO_JPAKE
     key_in_use = (psk_key != NULL);
 # else

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -95,7 +95,7 @@ int i2a_ASN1_STRING(BIO *bp, ASN1_STRING *a, int type)
 
 int a2i_ASN1_STRING(BIO *bp, ASN1_STRING *bs, char *buf, int size)
 {
-    int i, j, k, m, n, again, bufsize;
+    int i, j, k, m, n, again, bufsize, spec_char;
     unsigned char *s = NULL, *sp;
     unsigned char *bufp;
     int num = 0, slen = 0, first = 1;
@@ -122,7 +122,6 @@ int a2i_ASN1_STRING(BIO *bp, ASN1_STRING *bs, char *buf, int size)
         again = (buf[i - 1] == '\\');
 
         for (j = i - 1; j > 0; j--) {
-            int spec_char;
 #ifndef CHARSET_EBCDIC
             spec_char = (!(((buf[j] >= '0') && (buf[j] <= '9')) ||
                   ((buf[j] >= 'a') && (buf[j] <= 'f')) ||

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -122,19 +122,20 @@ int a2i_ASN1_STRING(BIO *bp, ASN1_STRING *bs, char *buf, int size)
         again = (buf[i - 1] == '\\');
 
         for (j = i - 1; j > 0; j--) {
+            int spec_char;
 #ifndef CHARSET_EBCDIC
-            if (!(((buf[j] >= '0') && (buf[j] <= '9')) ||
+            spec_char = (!(((buf[j] >= '0') && (buf[j] <= '9')) ||
                   ((buf[j] >= 'a') && (buf[j] <= 'f')) ||
-                  ((buf[j] >= 'A') && (buf[j] <= 'F'))))
+                  ((buf[j] >= 'A') && (buf[j] <= 'F'))));
 #else
             /*
              * This #ifdef is not strictly necessary, since the characters
              * A...F a...f 0...9 are contiguous (yes, even in EBCDIC - but
              * not the whole alphabet). Nevertheless, isxdigit() is faster.
              */
-            if (!isxdigit(buf[j]))
+            spec_char = (!isxdigit(buf[j]));
 #endif
-            {
+            if (spec_char){
                 i = j;
                 break;
             }

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -494,6 +494,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     struct sockaddr *to = NULL;
     bio_dgram_data *data = NULL;
     int sockopt_val = 0;
+    int d_errno;
 # if defined(OPENSSL_SYS_LINUX) && (defined(IP_MTU_DISCOVER) || defined(IP_MTU))
     socklen_t sockopt_len;      /* assume that system supporting IP_MTU is
                                  * modern enough to define socklen_t */
@@ -847,7 +848,6 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_GET_SEND_TIMER_EXP:
         /* fall-through */
     case BIO_CTRL_DGRAM_GET_RECV_TIMER_EXP:
-        int d_errno;
 # ifdef OPENSSL_SYS_WINDOWS
         d_errno = (data->_errno == WSAETIMEDOUT);
 # else

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -847,12 +847,13 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_GET_SEND_TIMER_EXP:
         /* fall-through */
     case BIO_CTRL_DGRAM_GET_RECV_TIMER_EXP:
+        int d_errno;
 # ifdef OPENSSL_SYS_WINDOWS
-        if (data->_errno == WSAETIMEDOUT)
+        d_errno = (data->_errno == WSAETIMEDOUT);
 # else
-        if (data->_errno == EAGAIN)
+        d_errno = (data->_errno == EAGAIN);
 # endif
-        {
+        if (d_errno){
             ret = 1;
             data->_errno = 0;
         } else

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -1303,7 +1303,7 @@ int X509V3_NAME_from_section(X509_NAME *nm, STACK_OF(CONF_VALUE) *dn_sk,
                              unsigned long chtype)
 {
     CONF_VALUE *v;
-    int i, mval;
+    int i, mval, spec_char, plus_char;
     char *p, *type;
     if (!nm)
         return 0;
@@ -1315,7 +1315,6 @@ int X509V3_NAME_from_section(X509_NAME *nm, STACK_OF(CONF_VALUE) *dn_sk,
          * Skip past any leading X. X: X, etc to allow for multiple instances
          */
         for (p = type; *p; p++){
-            int spec_char;
 #ifndef CHARSET_EBCDIC
             spec_char = ((*p == ':') || (*p == ',') || (*p == '.'));
 #else
@@ -1329,7 +1328,6 @@ int X509V3_NAME_from_section(X509_NAME *nm, STACK_OF(CONF_VALUE) *dn_sk,
                 break;
             }
         }
-        int plus_char;
 #ifndef CHARSET_EBCDIC
         plus_char = (*type == '+');
 #else

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -1314,25 +1314,28 @@ int X509V3_NAME_from_section(X509_NAME *nm, STACK_OF(CONF_VALUE) *dn_sk,
         /*
          * Skip past any leading X. X: X, etc to allow for multiple instances
          */
-        for (p = type; *p; p++)
+        for (p = type; *p; p++){
+            int spec_char;
 #ifndef CHARSET_EBCDIC
-            if ((*p == ':') || (*p == ',') || (*p == '.'))
+            spec_char = ((*p == ':') || (*p == ',') || (*p == '.'));
 #else
-            if ((*p == os_toascii[':']) || (*p == os_toascii[','])
-                || (*p == os_toascii['.']))
+            spec_char = ((*p == os_toascii[':']) || (*p == os_toascii[','])
+                    || (*p == os_toascii['.']));
 #endif
-            {
+            if (spec_char){
                 p++;
                 if (*p)
                     type = p;
                 break;
             }
+        }
+        int plus_char;
 #ifndef CHARSET_EBCDIC
-        if (*type == '+')
+        plus_char = (*type == '+');
 #else
-        if (*type == os_toascii['+'])
+        plus_char = (*type == os_toascii['+']);
 #endif
-        {
+        if (plus_char){
             mval = -1;
             type++;
         } else


### PR DESCRIPTION
As discussed in pull request #465, I'm submitting a new pull request with the goal of removing all conditional directives of the following pattern:

#ifdef A
if (condition_1)
#else
if (condition_2)
#endif
{
// code
}

I have used a tool that searches for this pattern and I have refactored them manually. We are able to detect other patterns of conditional directives that split up parts of statements to refactor manually (if it contributes to OpenSSL).

Let me know if there are other patterns that are important to refactor in order to improve code understanding and so on.