### PR TITLE
ssl_set_pkey() unnecessarily updates certificates

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -138,6 +138,12 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
         EVPerr(EVP_F_EVP_PKEY_COPY_PARAMETERS, EVP_R_MISSING_PARAMETERS);
         goto err;
     }
+
+    if (!EVP_PKEY_missing_parameters(to) &&
+        EVP_PKEY_cmp_parameters(to, from) == 1) {
+        return 1;
+    }
+
     if (from->ameth && from->ameth->param_copy)
         return from->ameth->param_copy(to, from);
  err:


### PR DESCRIPTION
Some key types types (EC, DSA, DH, but not RSA) have separate parameters
that are needed for correct operation. When ssl_set_pkey() is called
(via SSL_use_PrivateKey), it copies these parameters from the newly set
private key into the public key of the CERT structure. This could lead
to a modification of the X509 structure while it is being used in
another thread.

This parameter copy is unconditional, and always occurs during
ssl_set_pkey(). The proposed solution is to modify the copy routine
EVP_PKEY_copy_parameters() to check for parameter equality via the
EVP_PKEY_cmp_parameters() function before doing the actual copy. If the
parameters match, then success is returned and no copy is performed.
(But also check to see if the parameters are there before the compare.)

This avoids unnecessary modification of the certificate structure and
avoids the crash. The parameters may be copied on the first setting of
the private key, but after that, the parameters will be equal and not
copied any more.

There is minimal locking around the SSL_use_PrivateKey() and other
corresponding code, so adding additional locking would not suffice.