### PR TITLE
dsatest: use the correct BIO to print the test error

### DIFF
--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -247,7 +247,7 @@ static int dsa_cb(int p, int n, BN_GENCB *arg)
     (void)BIO_flush(BN_GENCB_get_arg(arg));
 
     if (!ok && (p == 0) && (num > 1)) {
-        BIO_printf((BIO *)arg, "error in dsatest\n");
+        BIO_printf(BN_GENCB_get_arg(arg), "error in dsatest\n");
         return 0;
     }
     return 1;


### PR DESCRIPTION
(crash will only show up if you modify DSA internals ... like e.g. for FIPS purposes)