### PR TITLE
Change tar owner and group to just 0

### DIFF
--- a/Makefile.org
+++ b/Makefile.org
@@ -493,7 +493,7 @@ TABLE: Configure Configurations/*.conf
 # and read directly, requiring GNU-Tar. Call "make TAR=gtar dist" if the normal
 # tar does not support the --files-from option.
 TAR_COMMAND=$(TAR) $(TARFLAGS) --files-from $(TARFILE).list \
-	                       --owner openssl:0 --group openssl:0 \
+	                       --owner 0 --group 0 \
 			       --transform 's|^|$(NAME)/|' \
 			       -cvf -
 


### PR DESCRIPTION
It seems like some tar versions don't like the name:id form for
--owner and --group.  The closest known anonymous user being 0 (root),
that seems to be the most appropriate user/group to assign ownership
to.  It matters very little when unpacking either way.

_(this is meant for master, 1.0.2 and 1.0.1)_
