### PR TITLE
Add support for async jobs in OpenSSL speed

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1580,19 +1580,7 @@ int speed_main(int argc, char **argv)
         loopargs[i].buf = loopargs[i].buf_malloc + misalign;
         loopargs[i].buf2 = loopargs[i].buf2_malloc + misalign;
         loopargs[i].siglen = app_malloc(sizeof(unsigned int), "signature length");
-#ifndef OPENSSL_NO_DSA
-        memset(loopargs[i].dsa_key, 0, sizeof(loopargs[i].dsa_key));
-#endif
-#ifndef OPENSSL_NO_RSA
-        memset(loopargs[i].rsa_key, 0, sizeof(loopargs[i].rsa_key));
-        for (k = 0; k < RSA_NUM; k++)
-            loopargs[i].rsa_key[k] = NULL;
-#endif
 #ifndef OPENSSL_NO_EC
-        for (k = 0; k < EC_NUM; k++)
-            loopargs[i].ecdsa[k] = NULL;
-        for (k = 0; k < EC_NUM; k++)
-            loopargs[i].ecdh_a[k] = loopargs[i].ecdh_b[k] = NULL;
         loopargs[i].secret_a = app_malloc(MAX_ECDH_SIZE, "ECDH secret a");
         loopargs[i].secret_b = app_malloc(MAX_ECDH_SIZE, "ECDH secret b");
 #endif
@@ -2828,15 +2816,11 @@ int speed_main(int argc, char **argv)
  end:
     ERR_print_errors(bio_err);
     for (i = 0; i < loopargs_len; i++) {
-        if (loopargs[i].buf_malloc != NULL)
-            OPENSSL_free(loopargs[i].buf_malloc);
-        if (loopargs[i].buf2_malloc != NULL)
-            OPENSSL_free(loopargs[i].buf2_malloc);
-        if (loopargs[i].siglen != NULL)
-            OPENSSL_free(loopargs[i].siglen);
+        OPENSSL_free(loopargs[i].buf_malloc);
+        OPENSSL_free(loopargs[i].buf2_malloc);
+        OPENSSL_free(loopargs[i].siglen);
     }
-    if (loopargs != NULL)
-        OPENSSL_free(loopargs);
+    OPENSSL_free(loopargs);
 #ifndef OPENSSL_NO_RSA
     for (i = 0; i < loopargs_len; i++) {
         for (k = 0; k < RSA_NUM; k++)
@@ -2857,10 +2841,8 @@ int speed_main(int argc, char **argv)
             EC_KEY_free(loopargs[i].ecdh_a[k]);
             EC_KEY_free(loopargs[i].ecdh_b[k]);
         }
-	if (loopargs[i].secret_a)
-		OPENSSL_free(loopargs[i].secret_a);
-	if (loopargs[i].secret_b)
-		OPENSSL_free(loopargs[i].secret_b);
+        OPENSSL_free(loopargs[i].secret_a);
+        OPENSSL_free(loopargs[i].secret_b);
     }
 #endif
     if (async_jobs > 0)

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1136,10 +1136,6 @@ static int run_benchmark(int async_jobs, int (*loop_function)(void *), loopargs_
     int i = 0;
     OSSL_ASYNC_FD job_fd = 0;
     size_t num_job_fds = 0;
-#if defined(ASYNC_POSIX)
-    fd_set waitfdset;
-    OSSL_ASYNC_FD max_fd = 0;
-#endif
 
     run = 1;
 
@@ -1171,89 +1167,46 @@ static int run_benchmark(int async_jobs, int (*loop_function)(void *), loopargs_
         }
     }
 
-#if defined(ASYNC_POSIX)
-    FD_ZERO(&waitfdset);
-
-    /* Add to the wait set all the fds that are already in the WAIT_CTX
-     * This is required when the same ctx is used multiple times
-     * For the purpose of speed, each job can be associated to at most one fd
-     */
-    for (i = 0; i < async_jobs && num_inprogress > 0; i++) {
-        if (loopargs[i].inprogress_job == NULL)
-            continue;
-
-        if (!ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, NULL, &num_job_fds)
-                || num_job_fds > 1) {
-            BIO_printf(bio_err, "Too many fds in ASYNC_WAIT_CTX\n");
-            ERR_print_errors(bio_err);
-            error = 1;
-            break;
-        }
-        ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, &job_fd, &num_job_fds);
-        FD_SET(job_fd, &waitfdset);
-        if (job_fd > max_fd)
-            max_fd = job_fd;
-    }
-#endif
 
     while (num_inprogress > 0) {
-#if defined(ASYNC_POSIX)
+#if defined(ASYNC_WIN)
+        DWORD avail = 0;
+#elif defined(ASYNC_POSIX)
         int select_result = 0;
-        struct timeval select_timeout;
-        select_timeout.tv_sec = 0;
-        select_timeout.tv_usec = 0;
+        OSSL_ASYNC_FD max_fd = 0;
+        fd_set waitfdset;
+        FD_ZERO(&waitfdset);
 
-        for (i = 0; i < async_jobs; i++) {
-            if (loopargs[i].inprogress_job != NULL) {
-                /* Consider only changed fds to minimize the operations on waitfdset */
-                OSSL_ASYNC_FD add_fd, del_fd;
-                size_t num_add_fds, num_del_fds;
-                if (!ASYNC_WAIT_CTX_get_changed_fds(loopargs[i].wait_ctx, NULL,
-                                                    &num_add_fds, NULL, &num_del_fds)) {
-                    BIO_printf(bio_err, "Failure in ASYNC_WAIT_CTX\n");
-                    ERR_print_errors(bio_err);
-                    error = 1;
-                    break;
-                }
-                if (num_add_fds > 1 || num_del_fds > 1) {
-                    BIO_printf(bio_err, "Too many fds have changed in ASYNC_WAIT_CTX\n");
-                    ERR_print_errors(bio_err);
-                    error = 1;
-                    break;
-                }
-                if (num_add_fds == 0 && num_del_fds == 0)
-                    continue;
+        for (i = 0; i < async_jobs && num_inprogress > 0; i++) {
+            if (loopargs[i].inprogress_job == NULL)
+                continue;
 
-                ASYNC_WAIT_CTX_get_changed_fds(loopargs[i].wait_ctx, &add_fd, &num_add_fds,
-                                               &del_fd, &num_del_fds);
-
-                if (num_del_fds == 1)
-                    FD_CLR(del_fd, &waitfdset);
-
-                if (num_add_fds == 1) {
-                    FD_SET(add_fd, &waitfdset);
-                    if (add_fd > max_fd)
-                        max_fd = add_fd;
-                }
+            if (!ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, NULL, &num_job_fds)
+                    || num_job_fds > 1) {
+                BIO_printf(bio_err, "Too many fds in ASYNC_WAIT_CTX\n");
+                ERR_print_errors(bio_err);
+                error = 1;
+                break;
             }
+            ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, &job_fd, &num_job_fds);
+            FD_SET(job_fd, &waitfdset);
+            if (job_fd > max_fd)
+                max_fd = job_fd;
         }
-        select_result = select(max_fd + 1, &waitfdset, NULL, NULL, &select_timeout);
 
+        select_result = select(max_fd + 1, &waitfdset, NULL, NULL, NULL);
         if (select_result == -1 && errno == EINTR)
             continue;
 
         if (select_result == -1) {
-                BIO_printf(bio_err, "Failure in the select\n");
-                ERR_print_errors(bio_err);
-                error = 1;
-                break;
+            BIO_printf(bio_err, "Failure in the select\n");
+            ERR_print_errors(bio_err);
+            error = 1;
+            break;
         }
 
         if (select_result == 0)
             continue;
-
-#elif defined(ASYNC_WIN)
-        DWORD avail = 0;
 #endif
 
         for (i = 0; i < async_jobs; i++) {
@@ -1290,9 +1243,6 @@ static int run_benchmark(int async_jobs, int (*loop_function)(void *), loopargs_
                         total_op_count += job_op_count;
                     }
                     --num_inprogress;
-#if defined(ASYNC_POSIX)
-                    FD_CLR(job_fd, &waitfdset);
-#endif
                     loopargs[i].inprogress_job = NULL;
                     break;
                 case ASYNC_NO_JOBS:


### PR DESCRIPTION
Summary of the changes:

* Move the calls to the crypto operations inside wrapper functions.
  This is required because `ASYNC_start_job()` takes a function as an argument.

* Add new function `run_benchmark()` that manages the jobs for all the operations.
  In the POSIX case it uses a `select()` to receive the events from the engine and resume the jobs that are paused, while in the WIN case it uses `PeekNamedPipe()`

* Add new option argument `async_jobs` to enable and specify the number of async jobs

Example:

    openssl speed -engine dasync -elapsed -async_jobs 32 rsa2048