### PR TITLE
Allow ChaCha20-Poly1305 in DTLS

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -235,8 +235,7 @@ int dtls1_do_write(SSL *s, int type)
 
     if (s->write_hash) {
         if (s->enc_write_ctx
-            && ((EVP_CIPHER_CTX_mode(s->enc_write_ctx) == EVP_CIPH_GCM_MODE) ||
-                (EVP_CIPHER_CTX_mode(s->enc_write_ctx) == EVP_CIPH_CCM_MODE)))
+            && (EVP_CIPHER_CTX_flags(s->enc_write_ctx) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0)
             mac_size = 0;
         else
             mac_size = EVP_MD_CTX_size(s->write_hash);

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -235,7 +235,8 @@ int dtls1_do_write(SSL *s, int type)
 
     if (s->write_hash) {
         if (s->enc_write_ctx
-            && (EVP_CIPHER_CTX_flags(s->enc_write_ctx) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0)
+            && (EVP_CIPHER_CTX_flags(s->enc_write_ctx) &
+                EVP_CIPH_FLAG_AEAD_CIPHER) != 0)
             mac_size = 0;
         else
             mac_size = EVP_MD_CTX_size(s->write_hash);


### PR DESCRIPTION
GCM and CCM are modes of operation for block ciphers only. ChaCha20-Poly1305 operates in neither of them but it is AEAD. This change also enables future AEAD ciphers to be available for use with DTLS.