### PR TITLE
fix ssl_next_proto_validate

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2333,11 +2333,11 @@ int ssl_parse_clienthello_tlsext(SSL *s, PACKET *pkt)
  */
 static char ssl_next_proto_validate(PACKET *pkt)
 {
-    unsigned int len;
+    PACKET tmp_protocol;
 
     while (PACKET_remaining(pkt)) {
-        if (!PACKET_get_1(pkt, &len)
-                || !PACKET_forward(pkt, len))
+        if (!PACKET_get_length_prefixed_1(pkt, &tmp_protocol)
+                || PACKET_remaining(&tmp_protocol) == 0)
             return 0;
     }
 


### PR DESCRIPTION
`ssl_next_proto_validate` is not validating the length of each advertised protocol name.
This change was introduced by commit 50932c4af2fdd1da01203e9fabe176f9c106882b.