### PR TITLE
Remaining memory management fixes of RT #3198

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -132,7 +132,7 @@ static int fmtfp(char **, char **, size_t *, size_t *,
                  LDOUBLE, int, int, int);
 static int doapr_outch(char **, char **, size_t *, size_t *, int);
 static int _dopr(char **sbuffer, char **buffer,
-                 size_t *maxlen, size_t *retlen, int *truncated,
+                 size_t *maxlen, size_t *retlen,
                  const char *format, va_list args);
 
 /* format read states */
@@ -168,7 +168,7 @@ static int
 _dopr(char **sbuffer,
       char **buffer,
       size_t *maxlen,
-      size_t *retlen, int *truncated, const char *format, va_list args)
+      size_t *retlen, const char *format, va_list args)
 {
     char ch;
     LLONG value;
@@ -422,9 +422,6 @@ _dopr(char **sbuffer,
             break;
         }
     }
-    *truncated = (currlen > *maxlen - 1);
-    if (*truncated)
-        currlen = *maxlen - 1;
     if(!doapr_outch(sbuffer, buffer, &currlen, maxlen, '\0'))
         return 0;
     *retlen = currlen - 1;
@@ -803,10 +800,9 @@ int BIO_vprintf(BIO *bio, const char *format, va_list args)
     char *hugebufp = hugebuf;
     size_t hugebufsize = sizeof(hugebuf);
     char *dynbuf = NULL;
-    int ignored;
 
     dynbuf = NULL;
-    if (!_dopr(&hugebufp, &dynbuf, &hugebufsize, &retlen, &ignored, format,
+    if (!_dopr(&hugebufp, &dynbuf, &hugebufsize, &retlen, format,
                 args)) {
         OPENSSL_free(dynbuf);
         return -1;
@@ -842,19 +838,15 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
 int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)
 {
     size_t retlen;
-    int truncated;
 
-    if(!_dopr(&buf, NULL, &n, &retlen, &truncated, format, args))
+    /*
+     * In case of truncation, return -1 like traditional snprintf.
+     * (Current drafts for ISO/IEC 9899 say snprintf should return the
+     * number of characters that would have been written, had the buffer
+     * been large enough.)
+     */
+    if(!_dopr(&buf, NULL, &n, &retlen, format, args))
         return -1;
 
-    if (truncated)
-        /*
-         * In case of truncation, return -1 like traditional snprintf.
-         * (Current drafts for ISO/IEC 9899 say snprintf should return the
-         * number of characters that would have been written, had the buffer
-         * been large enough.)
-         */
-        return -1;
-    else
-        return (retlen <= INT_MAX) ? (int)retlen : -1;
+    return (retlen <= INT_MAX) ? (int)retlen : -1;
 }

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -1231,7 +1231,7 @@ static void zapparams(struct crypt_kop *kop)
 
     for (i = 0; i < kop->crk_iparams + kop->crk_oparams; i++) {
         if (kop->crk_param[i].crp_p)
-            free(kop->crk_param[i].crp_p);
+            OPENSSL_free(kop->crk_param[i].crp_p);
         kop->crk_param[i].crp_p = NULL;
         kop->crk_param[i].crp_nbits = 0;
     }
@@ -1244,16 +1244,24 @@ cryptodev_asym(struct crypt_kop *kop, int rlen, BIGNUM *r, int slen,
     int fd, ret = -1;
 
     if ((fd = get_asym_dev_crypto()) < 0)
-        return (ret);
+        return ret;
 
     if (r) {
-        kop->crk_param[kop->crk_iparams].crp_p = calloc(rlen, sizeof(char));
+        kop->crk_param[kop->crk_iparams].crp_p = OPENSSL_zalloc(rlen);
+        if (kop->crk_param[kop->crk_iparams].crp_p == NULL)
+            return ret;
         kop->crk_param[kop->crk_iparams].crp_nbits = rlen * 8;
         kop->crk_oparams++;
     }
     if (s) {
         kop->crk_param[kop->crk_iparams + 1].crp_p =
-            calloc(slen, sizeof(char));
+            OPENSSL_zalloc(slen);
+        /* No need to free the kop->crk_iparams parameter if it was allocated,
+         * callers of this routine have to free allocated parameters through
+         * zapparams both in case of success and failure
+         */
+        if (kop->crk_param[kop->crk_iparams+1].crp_p == NULL)
+            return ret;
         kop->crk_param[kop->crk_iparams + 1].crp_nbits = slen * 8;
         kop->crk_oparams++;
     }
@@ -1266,7 +1274,7 @@ cryptodev_asym(struct crypt_kop *kop, int rlen, BIGNUM *r, int slen,
         ret = 0;
     }
 
-    return (ret);
+    return ret;
 }
 
 static int

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -432,7 +432,8 @@ void ssl3_init_finished_mac(SSL *s)
 {
     ssl3_free_digest_list(s);
     s->s3->handshake_buffer = BIO_new(BIO_s_mem());
-    (void)BIO_set_close(s->s3->handshake_buffer, BIO_CLOSE);
+    if (s->s3->handshake_buffer != NULL)
+        (void)BIO_set_close(s->s3->handshake_buffer, BIO_CLOSE);
 }
 
 /*


### PR DESCRIPTION
These are the four remaining patches from https://github.com/openssl/openssl/pull/131 that are still relevant to today's master. Some of my previous patches got independently written/discovered by other people in the mean time (e.g. https://github.com/jmaebe/openssl/commit/db35ad63c34fde448c7c9792c75bb5195fee4c26 is very similar to 9d9e37744cd5119f9921315864d1cd28717173cd , although that my version didn't change *maxlen nor leak memory in case (re)allocation fails unlike the code that got committed).