### PR TITLE
Wrong definition of the macro SSL_set1_sigalgs in ssl.h

### DIFF
--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -2092,7 +2092,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTX_set1_sigalgs_list(ctx, s) \
         SSL_CTX_ctrl(ctx,SSL_CTRL_SET_SIGALGS_LIST,0,(char *)s)
 # define SSL_set1_sigalgs(ctx, slist, slistlen) \
-        SSL_ctrl(ctx,SSL_CTRL_SET_SIGALGS,clistlen,(int *)slist)
+        SSL_ctrl(ctx,SSL_CTRL_SET_SIGALGS,slistlen,(int *)slist)
 # define SSL_set1_sigalgs_list(ctx, s) \
         SSL_ctrl(ctx,SSL_CTRL_SET_SIGALGS_LIST,0,(char *)s)
 # define SSL_CTX_set1_client_sigalgs(ctx, slist, slistlen) \


### PR DESCRIPTION
Error in the definition of the macro SSL_set1_sigalgs(ctx, slist,
slistlen): the third parameter 'slistlen' not used in the substitution
code; used 'clistlen' instead. As a result of this, compilation error
occurs when any application uses this macro.