### PR TITLE
Fixes problems with access to keys on hardware token

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -419,8 +419,13 @@ static EVP_PKEY_CTX *init_ctx(int *pkeysize,
     if (!pkey)
         goto end;
 
-    ctx = EVP_PKEY_CTX_new(pkey, e);
-
+    if ((keyform == FORMAT_ENGINE) && (strncmp(ENGINE_get_name(e),"pkcs11 engine", strlen("pkcs11 engine"))==0)) {
+      fprintf(stderr, "engine name = \"%s\"\n", ENGINE_get_name(e));
+      ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    } else {
+      ctx = EVP_PKEY_CTX_new(pkey, e);
+    }
+    
     EVP_PKEY_free(pkey);
 
     if (!ctx)

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -74,7 +74,8 @@ static void usage(void);
 
 static EVP_PKEY_CTX *init_ctx(int *pkeysize,
                               char *keyfile, int keyform, int key_type,
-                              char *passargin, int pkey_op, ENGINE *e);
+                              char *passargin, int pkey_op, ENGINE *e,
+                              int   impl);
 
 static int setup_peer(BIO *err, EVP_PKEY_CTX *ctx, int peerform,
                       const char *file);
@@ -97,6 +98,7 @@ int MAIN(int argc, char **argv)
     EVP_PKEY_CTX *ctx = NULL;
     char *passargin = NULL;
     int keysize = -1;
+    int engine_impl = 0;
 
     unsigned char *buf_in = NULL, *buf_out = NULL, *sig = NULL;
     size_t buf_outlen;
@@ -137,7 +139,7 @@ int MAIN(int argc, char **argv)
             else {
                 ctx = init_ctx(&keysize,
                                *(++argv), keyform, key_type,
-                               passargin, pkey_op, e);
+                               passargin, pkey_op, e, engine_impl);
                 if (!ctx) {
                     BIO_puts(bio_err, "Error initializing context\n");
                     ERR_print_errors(bio_err);
@@ -171,6 +173,8 @@ int MAIN(int argc, char **argv)
                 badarg = 1;
             else
                 e = setup_engine(bio_err, *(++argv), 0);
+        } else if (!strcmp(*argv, "-engine_impl")) {
+                engine_impl = 1;
         }
 #endif
         else if (!strcmp(*argv, "-pubin"))
@@ -369,6 +373,7 @@ static void usage()
 #ifndef OPENSSL_NO_ENGINE
     BIO_printf(bio_err,
                "-engine e       use engine e, possibly a hardware device.\n");
+    BIO_printf(bio_err, "-engine_impl    access key through the engine\n");
 #endif
     BIO_printf(bio_err, "-passin arg     pass phrase source\n");
 
@@ -376,10 +381,12 @@ static void usage()
 
 static EVP_PKEY_CTX *init_ctx(int *pkeysize,
                               char *keyfile, int keyform, int key_type,
-                              char *passargin, int pkey_op, ENGINE *e)
+                              char *passargin, int pkey_op, ENGINE *e,
+                              int   engine_impl)
 {
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
+    ENGINE *impl = NULL;
     char *passin = NULL;
     int rv = -1;
     X509 *x;
@@ -418,12 +425,13 @@ static EVP_PKEY_CTX *init_ctx(int *pkeysize,
 
     if (!pkey)
         goto end;
-
-    if ((keyform == FORMAT_ENGINE) && (strncmp(ENGINE_get_name(e),"pkcs11 engine", strlen("pkcs11 engine"))==0)) {
-      ctx = EVP_PKEY_CTX_new(pkey, NULL);
-    } else {
-      ctx = EVP_PKEY_CTX_new(pkey, e);
-    }
+        
+#ifndef OPENSSL_NO_ENGINE
+    if (engine_impl)
+	impl = e;
+#endif
+            
+    ctx = EVP_PKEY_CTX_new(pkey, impl);
     
     EVP_PKEY_free(pkey);
 

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -420,7 +420,6 @@ static EVP_PKEY_CTX *init_ctx(int *pkeysize,
         goto end;
 
     if ((keyform == FORMAT_ENGINE) && (strncmp(ENGINE_get_name(e),"pkcs11 engine", strlen("pkcs11 engine"))==0)) {
-      fprintf(stderr, "engine name = \"%s\"\n", ENGINE_get_name(e));
       ctx = EVP_PKEY_CTX_new(pkey, NULL);
     } else {
       ctx = EVP_PKEY_CTX_new(pkey, e);

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -522,8 +522,9 @@ static void int_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
     for (i = 0; i < mx; i++) {
         if (storage[i] && storage[i]->free_func) {
             ptr = CRYPTO_get_ex_data(ad, i);
-            storage[i]->free_func(obj, ptr, ad, i,
-                                  storage[i]->argl, storage[i]->argp);
+	    if (ptr)
+            	storage[i]->free_func(obj, ptr, ad, i,
+                                      storage[i]->argl, storage[i]->argp);
         }
     }
     if (storage)


### PR DESCRIPTION
1. Enables pkeyutl to directly access keys on a hardware token via `engine_pkcs11`.

2. Fixes crash in `ex_data.c` (around line 525) when the retrieved pointer happens to be NULL (zero).

I'm pretty sure these would apply to the master branch as well.