### PR TITLE
Added new DTLS-SRTP protection profiles from RFC 7714

### DIFF
--- a/include/openssl/srtp.h
+++ b/include/openssl/srtp.h
@@ -130,6 +130,10 @@ extern "C" {
 # define SRTP_NULL_SHA1_80      0x0005
 # define SRTP_NULL_SHA1_32      0x0006
 
+/* AEAD SRTP protection profiles from RFC 7714 */
+# define SRTP_AEAD_AES_128_GCM  0x0007
+# define SRTP_AEAD_AES_256_GCM  0x0008
+
 # ifndef OPENSSL_NO_SRTP
 
 __owur int SSL_CTX_set_tlsext_use_srtp(SSL_CTX *ctx, const char *profiles);

--- a/ssl/d1_srtp.c
+++ b/ssl/d1_srtp.c
@@ -129,6 +129,14 @@ static SRTP_PROTECTION_PROFILE srtp_known_profiles[] = {
      "SRTP_AES128_CM_SHA1_32",
      SRTP_AES128_CM_SHA1_32,
      },
+    {
+     "SRTP_AEAD_AES_128_GCM",
+     SRTP_AEAD_AES_128_GCM
+     },
+    {
+     "SRTP_AEAD_AES_256_GCM",
+     SRTP_AEAD_AES_256_GCM
+     },
     {0}
 };
 


### PR DESCRIPTION
RFC 7714 was published recently with new SRTP profiles. This simple PR adds it to the existing DTLS-SRTP implementation.