### PR TITLE
Mark OpenSSLDie noreturn

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -120,6 +120,14 @@
 # include <stdlib.h>
 # include <time.h>
 
+# if __STDC_VERSION__ >= 201112L
+#  include <stdnoreturn.h>
+# elif defined(__GNUC__)
+#  define noreturn __attribute__((noreturn))
+# else
+#  define noreturn
+# endif
+
 # include <openssl/e_os2.h>
 
 # ifndef OPENSSL_NO_STDIO
@@ -550,7 +558,7 @@ typedef void *CRYPTO_MEM_LEAK_CB (unsigned long, const char *, int, size_t,
 void CRYPTO_mem_leaks_cb(CRYPTO_MEM_LEAK_CB *cb);
 
 /* die if we have to */
-void OpenSSLDie(const char *file, int line, const char *assertion);
+noreturn void OpenSSLDie(const char *file, int line, const char *assertion);
 # define OPENSSL_assert(e)       (void)((e) ? 0 : (OpenSSLDie(__FILE__, __LINE__, #e),1))
 
 unsigned int *OPENSSL_ia32cap_loc(void);


### PR DESCRIPTION
It is good practice to mark functions that don't return as `noreturn`/`_Noreturn`. The former is a definition found in `stdnoreturn.h`, the latter is the actual keyword. Both are available from C11 onwards. If C11 is not used, optionally fall back to the GCC-specific `__attribute__((noreturn))` or to nothing at all if the compiler is not GCC.

This change particularly helps in reducing static analysis false positives.