### PR TITLE
Mark OpenSSLDie noreturn, supersedes #525

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -550,7 +550,7 @@ typedef void *CRYPTO_MEM_LEAK_CB (unsigned long, const char *, int, size_t,
 void CRYPTO_mem_leaks_cb(CRYPTO_MEM_LEAK_CB *cb);
 
 /* die if we have to */
-void OpenSSLDie(const char *file, int line, const char *assertion);
+noreturn void OpenSSLDie(const char *file, int line, const char *assertion);
 # define OPENSSL_assert(e)       (void)((e) ? 0 : (OpenSSLDie(__FILE__, __LINE__, #e),1))
 
 unsigned int *OPENSSL_ia32cap_loc(void);

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -550,7 +550,7 @@ typedef void *CRYPTO_MEM_LEAK_CB (unsigned long, const char *, int, size_t,
 void CRYPTO_mem_leaks_cb(CRYPTO_MEM_LEAK_CB *cb);
 
 /* die if we have to */
-noreturn void OpenSSLDie(const char *file, int line, const char *assertion);
+ossl_noreturn void OpenSSLDie(const char *file, int line, const char *assertion);
 # define OPENSSL_assert(e)       (void)((e) ? 0 : (OpenSSLDie(__FILE__, __LINE__, #e),1))
 
 unsigned int *OPENSSL_ia32cap_loc(void);

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -353,11 +353,11 @@ typedef unsigned __int64 uint64_t;
 # ifdef __STDC_VERSION__
 #  if (__STDC_VERSION__ >= 201112L)
 #   include <stdnoreturn.h>
-#  elif defined(__GNUC__)
-#   define noreturn __attribute__((noreturn))
-#  else
-#   define noreturn
 #  endif
+# elif defined(__GNUC__)
+#  define noreturn __attribute__((noreturn))
+# else
+#  define noreturn
 # endif
 
 #ifdef  __cplusplus

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -350,10 +350,10 @@ typedef unsigned __int64 uint64_t;
 #  endif
 # endif
 
-# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-#  define ossl_noreturn _Noreturn
-# elif defined(__GNUC__)
+# if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 7)
 #  define ossl_noreturn __attribute__((noreturn))
+# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  define ossl_noreturn _Noreturn
 # else
 #  define ossl_noreturn
 # endif

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -350,6 +350,16 @@ typedef unsigned __int64 uint64_t;
 #  endif
 # endif
 
+# ifdef __STDC_VERSION__
+#  if (__STDC_VERSION__ >= 201112L)
+#   include <stdnoreturn.h>
+#  elif defined(__GNUC__)
+#   define noreturn __attribute__((noreturn))
+#  else
+#   define noreturn
+#  endif
+# endif
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -350,14 +350,12 @@ typedef unsigned __int64 uint64_t;
 #  endif
 # endif
 
-# ifdef __STDC_VERSION__
-#  if (__STDC_VERSION__ >= 201112L)
-#   include <stdnoreturn.h>
-#  endif
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  define ossl_noreturn _Noreturn
 # elif defined(__GNUC__)
-#  define noreturn __attribute__((noreturn))
+#  define ossl_noreturn __attribute__((noreturn))
 # else
-#  define noreturn
+#  define ossl_noreturn
 # endif
 
 #ifdef  __cplusplus


### PR DESCRIPTION
This is the revised version of PR #525.

It is good practice to mark functions that don't return as `noreturn`/`_Noreturn`. The former is a definition found in `stdnoreturn.h`, the latter is the actual keyword. Both are available from C11 onwards. If C11 is not used, optionally fall back to the GCC-specific `__attribute__((noreturn))` or to nothing at all if the compiler is not GCC.

This change particularly helps in reducing static analysis false positives.