### PR TITLE
Adds crypto-mdebug as a valid option

### DIFF
--- a/Configure
+++ b/Configure
@@ -834,6 +834,7 @@ my @disablables = (
     "cmac",
     "cms",
     "comp",
+    "crypto-mdebug",
     "ct",
     "deprecated",
     "des",


### PR DESCRIPTION
Adds crypto-mdebug as a valid option. Fixes https://github.com/openssl/openssl/issues/537