### PR TITLE
Disable EGD support by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
  Changes between 1.0.2e and 1.1.0  [xx XXX xxxx]
 
+  *) EGD is no longer supported by default; use enable-egd when
+     configuring.
+     [Rich Salz]
+
   *) The distribution now has Makefile.in files, which are used to
      create Makefile's when Configure is run.  *Configure must be run
      before trying to build now.*

--- a/Configure
+++ b/Configure
@@ -14,7 +14,7 @@ use File::Spec::Functions;
 
 # see INSTALL for instructions.
 
-my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [experimental-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--test-sanity] [--config=FILE] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [experimental-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--test-sanity] [--config=FILE] os/compiler[:flags]\n";
 
 # Options:
 #
@@ -50,6 +50,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [experimenta
 # no-asm        do not use assembler
 # no-dso        do not compile in any native shared-library methods. This
 #               will ensure that all methods just return NULL.
+# no-egd        do not compile support for the entropy-gathering daemon APIs
 # [no-]zlib     [don't] compile support for zlib compression.
 # zlib-dynamic	Like "zlib", but the zlib library is expected to be a shared
 #		library and will be loaded in run-time by the OpenSSL library.
@@ -905,6 +906,7 @@ my @disablables = (
 
 my %disabled = ( # "what"         => "comment" [or special keyword "experimental"]
 		 "ec_nistp_64_gcc_128" => "default",
+		 "egd"            => "default",
 		 "jpake"          => "experimental",
 		 "md2"            => "default",
 		 "rc5"            => "default",

--- a/apps/app_rand.c
+++ b/apps/app_rand.c
@@ -126,6 +126,7 @@ int app_RAND_load_file(const char *file, int dont_warn)
 
     if (file == NULL)
         file = RAND_file_name(buffer, sizeof buffer);
+#ifndef OPENSSL_NO_EGD
     else if (RAND_egd(file) > 0) {
         /*
          * we try if the given filename is an EGD socket. if it is, we don't
@@ -134,6 +135,7 @@ int app_RAND_load_file(const char *file, int dont_warn)
         egdsocket = 1;
         return 1;
     }
+#endif
     if (file == NULL || !RAND_load_file(file, -1)) {
         if (RAND_status() == 0) {
             if (!dont_warn) {
@@ -161,7 +163,9 @@ long app_RAND_load_files(char *name)
     char *p, *n;
     int last;
     long tot = 0;
+#ifndef OPENSSL_NO_EGD
     int egd;
+#endif
 
     for (;;) {
         last = 0;
@@ -174,10 +178,12 @@ long app_RAND_load_files(char *name)
         if (*n == '\0')
             break;
 
+#ifndef OPENSSL_NO_EGD
         egd = RAND_egd(n);
         if (egd > 0)
             tot += egd;
         else
+#endif
             tot += RAND_load_file(n, -1);
         if (last)
             break;

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -95,7 +95,9 @@
  *   RAND_egd() is a wrapper for RAND_egd_bytes() with numbytes=255.
  */
 
-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_NETWARE) || defined(OPENSSL_SYS_VOS) || defined(OPENSSL_SYS_UEFI)
+#ifndef OPENSSL_NO_EGD
+
+# if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_NETWARE) || defined(OPENSSL_SYS_VOS) || defined(OPENSSL_SYS_UEFI)
 int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
 {
     return (-1);
@@ -110,26 +112,26 @@ int RAND_egd_bytes(const char *path, int bytes)
 {
     return (-1);
 }
-#else
-# include <openssl/opensslconf.h>
-# include OPENSSL_UNISTD
-# include <stddef.h>
-# include <sys/types.h>
-# include <sys/socket.h>
-# ifndef NO_SYS_UN_H
-#  ifdef OPENSSL_SYS_VXWORKS
-#   include <streams/un.h>
-#  else
-#   include <sys/un.h>
-#  endif
 # else
+#  include <openssl/opensslconf.h>
+#  include OPENSSL_UNISTD
+#  include <stddef.h>
+#  include <sys/types.h>
+#  include <sys/socket.h>
+#  ifndef NO_SYS_UN_H
+#   ifdef OPENSSL_SYS_VXWORKS
+#    include <streams/un.h>
+#   else
+#    include <sys/un.h>
+#   endif
+#  else
 struct sockaddr_un {
     short sun_family;           /* AF_UNIX */
     char sun_path[108];         /* path name (gag) */
 };
-# endif                         /* NO_SYS_UN_H */
-# include <string.h>
-# include <errno.h>
+#  endif                         /* NO_SYS_UN_H */
+#  include <string.h>
+#  include <errno.h>
 
 int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
 {
@@ -155,25 +157,25 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
             success = 1;
         else {
             switch (errno) {
-# ifdef EINTR
+#  ifdef EINTR
             case EINTR:
-# endif
-# ifdef EAGAIN
+#  endif
+#  ifdef EAGAIN
             case EAGAIN:
-# endif
-# ifdef EINPROGRESS
+#  endif
+#  ifdef EINPROGRESS
             case EINPROGRESS:
-# endif
-# ifdef EALREADY
+#  endif
+#  ifdef EALREADY
             case EALREADY:
-# endif
+#  endif
                 /* No error, try again */
                 break;
-# ifdef EISCONN
+#  ifdef EISCONN
             case EISCONN:
                 success = 1;
                 break;
-# endif
+#  endif
             default:
                 goto err;       /* failure */
             }
@@ -190,12 +192,12 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
                 numbytes += num;
             else {
                 switch (errno) {
-# ifdef EINTR
+#  ifdef EINTR
                 case EINTR:
-# endif
-# ifdef EAGAIN
+#  endif
+#  ifdef EAGAIN
                 case EAGAIN:
-# endif
+#  endif
                     /* No error, try again */
                     break;
                 default:
@@ -213,12 +215,12 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
                 numbytes += num;
             else {
                 switch (errno) {
-# ifdef EINTR
+#  ifdef EINTR
                 case EINTR:
-# endif
-# ifdef EAGAIN
+#  endif
+#  ifdef EAGAIN
                 case EAGAIN:
-# endif
+#  endif
                     /* No error, try again */
                     break;
                 default:
@@ -242,12 +244,12 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
                 numbytes += num;
             else {
                 switch (errno) {
-# ifdef EINTR
+#  ifdef EINTR
                 case EINTR:
-# endif
-# ifdef EAGAIN
+#  endif
+#  ifdef EAGAIN
                 case EAGAIN:
-# endif
+#  endif
                     /* No error, try again */
                     break;
                 default:
@@ -285,4 +287,10 @@ int RAND_egd(const char *path)
     return (RAND_egd_bytes(path, 255));
 }
 
+# endif
+
+#else /* OPENSSL_NO_EGD */
+# if PEDANTIC
+static void *dummy = &dummy;
+# endif
 #endif

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -244,7 +244,7 @@ int RAND_poll(void)
 {
     unsigned long l;
     pid_t curr_pid = getpid();
-#  if defined(DEVRANDOM) || defined(DEVRANDOM_EGD)
+#  if defined(DEVRANDOM) || (!defined(OPENSS_NO_EGD) && defined(DEVRANDOM_EGD))
     unsigned char tmpbuf[ENTROPY_NEEDED];
     int n = 0;
 #  endif
@@ -254,7 +254,7 @@ int RAND_poll(void)
     int fd;
     unsigned int i;
 #  endif
-#  ifdef DEVRANDOM_EGD
+#  if !defined(OPENSSL_NO_EGD) && defined(DEVRANDOM_EGD)
     static const char *egdsockets[] = { DEVRANDOM_EGD, NULL };
     const char **egdsocket = NULL;
 #  endif
@@ -371,7 +371,7 @@ int RAND_poll(void)
     }
 #  endif                        /* defined(DEVRANDOM) */
 
-#  ifdef DEVRANDOM_EGD
+#  if !defined(OPENSSL_NO_EGD) && defined(DEVRANDOM_EGD)
     /*
      * Use an EGD socket to read entropy from an EGD or PRNGD entropy
      * collecting daemon.
@@ -388,7 +388,7 @@ int RAND_poll(void)
     }
 #  endif                        /* defined(DEVRANDOM_EGD) */
 
-#  if defined(DEVRANDOM) || defined(DEVRANDOM_EGD)
+#  if defined(DEVRANDOM) || (!defined(OPENSSL_NO_EGD) && defined(DEVRANDOM_EGD))
     if (n > 0) {
         RAND_add(tmpbuf, sizeof tmpbuf, (double)n);
         OPENSSL_cleanse(tmpbuf, n);
@@ -404,7 +404,7 @@ int RAND_poll(void)
     l = time(NULL);
     RAND_add(&l, sizeof(l), 0.0);
 
-#  if defined(DEVRANDOM) || defined(DEVRANDOM_EGD)
+#  if defined(DEVRANDOM) || (!defined(OPENSSL_NO_EGD) && defined(DEVRANDOM_EGD))
     return 1;
 #  else
     return 0;

--- a/e_os.h
+++ b/e_os.h
@@ -90,7 +90,7 @@ extern "C" {
  */
 #  define DEVRANDOM "/dev/urandom","/dev/random","/dev/srandom"
 # endif
-# ifndef DEVRANDOM_EGD
+# if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
 /*
  * set this to a comma-separated list of 'egd' sockets to try out. These
  * sockets will be tried in the order listed in case accessing the device

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -105,9 +105,11 @@ int RAND_load_file(const char *file, long max_bytes);
 int RAND_write_file(const char *file);
 const char *RAND_file_name(char *file, size_t num);
 int RAND_status(void);
+# ifndef OPENSSL_NO_EGD
 int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes);
 int RAND_egd(const char *path);
 int RAND_egd_bytes(const char *path, int bytes);
+# endif
 int RAND_poll(void);
 
 # if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)

--- a/util/libeay.num
+++ b/util/libeay.num
@@ -1754,7 +1754,7 @@ DES_crypt                               2249	1_1_0	EXIST::FUNCTION:DES
 PEM_write_bio_X509_REQ_NEW              2250	1_1_0	EXIST::FUNCTION:
 PEM_write_X509_REQ_NEW                  2251	1_1_0	EXIST::FUNCTION:
 BIO_callback_ctrl                       2252	1_1_0	EXIST::FUNCTION:
-RAND_egd                                2253	1_1_0	EXIST::FUNCTION:
+RAND_egd                                2253	1_1_0	EXIST::FUNCTION:EGD
 RAND_status                             2254	1_1_0	EXIST::FUNCTION:
 bn_dump1                                2255	1_1_0	NOEXIST::FUNCTION:
 DES_check_key_parity                    2256	1_1_0	EXIST::FUNCTION:DES
@@ -1809,7 +1809,7 @@ X509_ALGOR_cmp                          2398	1_1_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_set_key_length           2399	1_1_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_ctrl                     2400	1_1_0	EXIST::FUNCTION:
 BN_mod_exp_mont_word                    2401	1_1_0	EXIST::FUNCTION:
-RAND_egd_bytes                          2402	1_1_0	EXIST::FUNCTION:
+RAND_egd_bytes                          2402	1_1_0	EXIST::FUNCTION:EGD
 X509_REQ_get1_email                     2403	1_1_0	EXIST::FUNCTION:
 X509_get1_email                         2404	1_1_0	EXIST::FUNCTION:
 X509_email_free                         2405	1_1_0	EXIST::FUNCTION:
@@ -2436,7 +2436,7 @@ X509V3_EXT_nconf_nid                    2942	1_1_0	EXIST::FUNCTION:
 ASN1_SEQUENCE_it                        2943	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 ASN1_SEQUENCE_it                        2943	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 UI_set_default_method                   2944	1_1_0	EXIST::FUNCTION:
-RAND_query_egd_bytes                    2945	1_1_0	EXIST::FUNCTION:
+RAND_query_egd_bytes                    2945	1_1_0	EXIST::FUNCTION:EGD
 UI_method_get_writer                    2946	1_1_0	EXIST::FUNCTION:
 UI_OpenSSL                              2947	1_1_0	EXIST::FUNCTION:
 PEM_def_callback                        2948	1_1_0	EXIST::FUNCTION:

--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -140,6 +140,7 @@ and [options] can be one of
 	no-srp					- No SRP
 	no-ec					- No EC
 	no-engine				- No engine
+	no-egd					- No EGD
 	no-hw					- No hw
 	nasm 					- Use NASM for x86 asm
 	nw-nasm					- Use NASM x86 asm for NetWare
@@ -1390,6 +1391,7 @@ sub read_options
 		"no-ec" => \$no_ec,
 		"no-gost" => \$no_gost,
 		"no-engine" => \$no_engine,
+		"no-egd" => 0,
 		"no-hw" => \$no_hw,
 		"just-ssl" =>
 			[\$no_rc2, \$no_idea, \$no_des, \$no_bf, \$no_cast,

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -84,6 +84,8 @@ my @known_algorithms = ( "RC2", "RC4", "RC5", "IDEA", "DES", "BF",
                          "CRYPTO_MDEBUG",
 			 # Engines
                          "STATIC_ENGINE", "ENGINE", "HW", "GMP",
+			 # Entropy Gathering
+			 "EGD",
                          # X.509v3 Signed Certificate Timestamps
                          "SCT",
 			 # RFC3779


### PR DESCRIPTION
The entropy-gathering daemon is used only on a small number of machines.
Provide a configure knob so that EGD support can be disabled by default
but re-enabled on those systems that do need it.