### PR TITLE
Fix versioned GCC detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_script:
 
 script:
     - cd _srcdist
+    - make depend
     - make
     - if [ -n "$CROSS_COMPILE" ]; then
           export EXE_SHELL="wine" WINEPREFIX=`pwd`;

--- a/Configure
+++ b/Configure
@@ -1789,12 +1789,13 @@ if (defined($api)) {
 }
 
 my $ecc = $cc;
+$ecc = "gcc" if `$cc --version 2>&1` =~ /gcc/;
 $ecc = "clang" if `$cc --version 2>&1` =~ /clang/;
 
 if ($strict_warnings)
 	{
 	my $wopt;
-	die "ERROR --strict-warnings requires gcc or clang" unless ($ecc =~ /gcc(-\d(\.\d)*)?$/ or $ecc =~ /clang$/);
+	die "ERROR --strict-warnings requires gcc or clang" unless ($ecc =~ /gcc$/ or $ecc =~ /clang$/);
 	foreach $wopt (split /\s+/, $gcc_devteam_warn)
 		{
 		$cflags .= " $wopt" unless ($cflags =~ /(^|\s)$wopt(\s|$)/)


### PR DESCRIPTION
Basically this fixes "make depend" when using e.g. "CC=gcc-5" and also makes Travis run "make depend".