### PR TITLE
Support link time optimization with GCC

### DIFF
--- a/Configure
+++ b/Configure
@@ -1419,6 +1419,7 @@ my $shared_ldflag = $table{$target}->{shared_ldflag};
 my $shared_extension = $table{$target}->{shared_extension};
 my $ranlib = $ENV{'RANLIB'} || $table{$target}->{ranlib};
 my $ar = $ENV{'AR'} || "ar";
+my $nm = $ENV{'NM'} || "nm";
 my $arflags = $table{$target}->{arflags};
 my $multilib = $table{$target}->{multilib};
 
@@ -1867,6 +1868,7 @@ while (<IN>)
 	else	{
 		s/^CC=.*$/CC= $cc/;
 		s/^AR=\s*ar/AR= $ar/;
+		s/^NM=\s*nm/NM= $nm/;
 		s/^RANLIB=.*/RANLIB= $ranlib/;
 		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $ecc eq "gcc" || $ecc eq "clang";
 		}


### PR DESCRIPTION
Even with this fix, when using`-flto` the build fails with this error:

```
asm/x86_64-gcc.c: Assembler messages:
asm/x86_64-gcc.c:196: Error: operand type mismatch for `div'
lto-wrapper: fatal error: gcc returned 1 exit status
compilation terminated.
```

Which comes from https://github.com/openssl/openssl/blob/master/crypto/bn/asm/x86_64-gcc.c#L196, not sure what that is about though (@dot-asm?)

Also, maybe when GCC is detected, the `gcc-` variants of the common build tools should be used by default?