### PR TITLE
Accessors for TS_STATUS_INFO

### DIFF
--- a/crypto/ts/ts_rsp_utils.c
+++ b/crypto/ts/ts_rsp_utils.c
@@ -397,3 +397,18 @@ int TS_STATUS_INFO_set_status(TS_STATUS_INFO *a, int i)
 {
     return ASN1_INTEGER_set(a->status, i);
 }
+
+ASN1_INTEGER *TS_STATUS_INFO_get_status(TS_STATUS_INFO *a)
+{
+    return a->status;
+}
+
+STACK_OF(ASN1_UTF8STRING) *TS_STATUS_INFO_get_text(TS_STATUS_INFO *a)
+{
+    return a->text;
+}
+
+ASN1_BIT_STRING *TS_STATUS_INFO_get_failure_info(TS_STATUS_INFO *a)
+{
+    return a->failure_info;
+}

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -225,6 +225,11 @@ int TS_REQ_set_version(TS_REQ *a, long version);
 long TS_REQ_get_version(const TS_REQ *a);
 
 int TS_STATUS_INFO_set_status(TS_STATUS_INFO *a, int i);
+ASN1_INTEGER *TS_STATUS_INFO_get_status(TS_STATUS_INFO *a);
+
+STACK_OF(ASN1_UTF8STRING) *TS_STATUS_INFO_get_text(TS_STATUS_INFO *a);
+
+ASN1_BIT_STRING *TS_STATUS_INFO_get_failure_info(TS_STATUS_INFO *a);
 
 int TS_REQ_set_msg_imprint(TS_REQ *a, TS_MSG_IMPRINT *msg_imprint);
 TS_MSG_IMPRINT *TS_REQ_get_msg_imprint(TS_REQ *a);


### PR DESCRIPTION
TS_STATUS_INFO_get_status(), TS_STATUS_INFO_get_text() and TS_STATUS_INFO_get_failure_info() accessors for a TS_STATUS_INFO.