### PR TITLE
pkeyutl: allow peer key to reside on a hardware token (pkcs11)  Open ssl 1 0 2 stable

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -78,7 +78,7 @@ static EVP_PKEY_CTX *init_ctx(int *pkeysize,
                               int   impl);
 
 static int setup_peer(BIO *err, EVP_PKEY_CTX *ctx, int peerform,
-                      const char *file);
+                      const char *file, ENGINE* e);
 
 static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
                     unsigned char *out, size_t *poutlen,
@@ -149,7 +149,7 @@ int MAIN(int argc, char **argv)
         } else if (!strcmp(*argv, "-peerkey")) {
             if (--argc < 1)
                 badarg = 1;
-            else if (!setup_peer(bio_err, ctx, peerform, *(++argv)))
+            else if (!setup_peer(bio_err, ctx, peerform, *(++argv), e))
                 badarg = 1;
         } else if (!strcmp(*argv, "-passin")) {
             if (--argc < 1)
@@ -479,16 +479,20 @@ static EVP_PKEY_CTX *init_ctx(int *pkeysize,
 }
 
 static int setup_peer(BIO *err, EVP_PKEY_CTX *ctx, int peerform,
-                      const char *file)
+                      const char *file, ENGINE* e)
 {
     EVP_PKEY *peer = NULL;
+    ENGINE* engine = NULL;
     int ret;
     if (!ctx) {
         BIO_puts(err, "-peerkey command before -inkey\n");
         return 0;
     }
 
-    peer = load_pubkey(bio_err, file, peerform, 0, NULL, NULL, "Peer Key");
+    if (peerform == FORMAT_ENGINE)
+      engine = e;
+    
+    peer = load_pubkey(bio_err, file, peerform, 0, NULL, engine, "Peer Key");
 
     if (!peer) {
         BIO_printf(bio_err, "Error reading peer key %s\n", file);


### PR DESCRIPTION
Enables `pkeyutl.c` to derive shared symmetric key (ECDH) with a public key on the PKCS11-accessible hardware token:
```
$ openssl pkeyutl -engine pkcs11 -peerform engine -derive -inkey t256-ec-priv.pem -peerkey id_03 -hexdump
engine "pkcs11" set.
0000 - 2c 3a cc 09 d0 7c 02 14-55 1e fc fb 86 e9 a4 87   ,:...|..U.......
0010 - 33 c5 77 71 ae d2 f0 ff-f4 24 f6 3c e8 6a 76 fe   3.wq.....$.<.jv.
$ pkcs11-tool -l --slot 1 --module /Library/OpenSC/lib/opensc-pkcs11.so --derive -m ECDH1-COFACTOR-DERIVE -d 03 -i t256-ec-pub.der -o t256-ecdh-shared.bin
Logging in to "PIV_II (PIV Card Holder pin)".
Please enter User PIN:
Using derive algorithm 0x00001051 ECDH1-COFACTOR-DERIVE
$ od -t x1 t256-ecdh-shared.bin
0000   2c  3a  cc  09  d0  7c  02  14  55  1e  fc  fb  86  e9  a4  87
0020   33  c5  77  71  ae  d2  f0  ff  f4  24  f6  3c  e8  6a  76  fe
0040
```

The above example demonstrates that the derivation is correct - shared secret derived from ECDH private key in a file and ECDH public key on the card matches the one derived on the card from its ECDH private key and the given public key from a file. 

* `t256-ec-priv.pem` is a file containing ECDH private key (in PEM format).
*  `t256-ec-pub.der` is a file containing ECDH public key (in DER format - need it for OpenSC tools).
* on the card: using slot 9d (`KEY MAN key` and `KEY MAN pubkey`) containing ECDH derivation key pair.

Oh, and of course the only commit in this PR that matters is https://github.com/openssl/openssl/commit/6fdd76220f3bcbf35076aeca32a7026db3a7a454

All the others are already merged (I think), but somehow Github does not show it. :-(