### PR TITLE
Make TESTS= work with "nmake -f ms/ntdll.mak tests"

### DIFF
--- a/util/pl/BC-32.pl
+++ b/util/pl/BC-32.pl
@@ -112,7 +112,7 @@ $target: $deps force.$target
 	set BIN_D=\$(BIN_D)
 	set TEST_D=\$(TEST_D)
 	set PERL=\$(PERL)
-	\$(PERL) test\\$test_cmd
+	\$(PERL) test\\$test_cmd \$(TESTS)
 force.$target:
 EOF
 }

--- a/util/pl/VC-32.pl
+++ b/util/pl/VC-32.pl
@@ -319,7 +319,7 @@ $target: $deps force.$target
 	set BIN_D=\$(BIN_D)
 	set TEST_D=\$(TEST_D)
 	set PERL=\$(PERL)
-	\$(PERL) test\\$test_cmd
+	\$(PERL) test\\$test_cmd \$(TESTS)
 force.$target:
 EOF
 }

--- a/util/pl/unix.pl
+++ b/util/pl/unix.pl
@@ -203,7 +203,7 @@ sub do_test_rule {
     my $ret = <<"EOF";
 $target: $deps force.$target
 	TOP=. BIN_D=\$(BIN_D) TEST_D=\$(TEST_D) \\
-	    PERL=\$(PERL) \$(PERL) test/$test_cmd
+	    PERL=\$(PERL) \$(PERL) test/$test_cmd \$(TESTS)
 force.$target:
 
 EOF


### PR DESCRIPTION
This works on Linux with Make already, and allows running only specified tests.