### PR TITLE
Fix BN_gcd errors for curves with even order that do not play nicely …

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -328,13 +328,18 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     } else
         BN_zero(group->cofactor);
 
+ 
     /*
-     * We ignore the return value because some groups have an order with
+     * Some groups have an order with
      * factors of two, which makes the Montgomery setup fail.
      * |group->mont_data| will be NULL in this case.
      */
-    ec_precompute_mont_data(group);
+    if (BN_is_odd(group->order)) {
+        return ec_precompute_mont_data(group);
+    }
 
+    BN_MONT_CTX_free(group->mont_data);
+    group->mont_data = NULL;
     return 1;
 }
 


### PR DESCRIPTION
…with Montgomery arithmetic

I was getting errors for curves with even order. This patch squelches the errors.

139858767824544:error:0306E06C:lib(3):func(110):reason(108):bn_gcd.c:233:
139858767824544:error:0306E06C:lib(3):func(110):reason(108):bn_gcd.c:233:

