### PR TITLE
RT3863 ECC: Add missing NULL check. Set a flag

### DIFF
--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -742,6 +742,7 @@ int ec_GF2m_simple_make_affine(const EC_GROUP *group, EC_POINT *point,
         goto err;
     if (!BN_one(point->Z))
         goto err;
+    point->Z_is_one = 1;
 
     ret = 1;
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -384,6 +384,8 @@ int EC_KEY_set_public_key_affine_coordinates(EC_KEY *key, BIGNUM *x,
 
     tx = BN_CTX_get(ctx);
     ty = BN_CTX_get(ctx);
+    if (ty == NULL)
+        goto err;
 
 #ifndef OPENSSL_NO_EC2M
     tmp_nid = EC_METHOD_get_field_type(EC_GROUP_method_of(key->group));


### PR DESCRIPTION
Fix for RT3863. I hit both these bugs when implementing a custom EC_METHOD.

Set point->Z_is_one flag after setting point->Z to one. Also check BIGNUM for NULL before passing it to get_affine_coordinates.