### PR TITLE
explicitText encoding

### DIFF
--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -353,6 +353,12 @@ The B<ia5org> option changes the type of the I<organization> field. In RFC2459
 it can only be of type DisplayText. In RFC3280 IA5Strring is also permissible.
 Some software (for example some versions of MSIE) may require ia5org.
 
+ASN1 type of explicitText can be specified by prepending B<UTF8>,
+B<BMP> or B<VISIBLE> prefix followed by colon. For example:
+
+ [notice]
+ explicitText="UTF8:Explicit Text Here"
+
 =head2 Policy Constraints
 
 This is a multi-valued extension which consisting of the names


### PR DESCRIPTION
It is defined  in RFC 5280 that explicitText in UserNotice is DisplayText, which can be of UTF8String, VisibleString, BMPString or IA5String type. However, it is always set to VisibleString now.

This patch allows user to decide for the type of explicitText by prepending it by UTF8, UTF8String, IA5STRING, IA5, BMPSTRING, BMP, VISIBLE or VISIBLESTRING. (as in nconf)

Original functionality was preserved.
