### PR TITLE
Remove unused, undocumented clean-shared target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -160,7 +160,6 @@ LIBS=   libcrypto.a libssl.a
 SHARED_CRYPTO=libcrypto$(SHLIB_EXT)
 SHARED_SSL=libssl$(SHLIB_EXT)
 SHARED_LIBS={- '$(SHARED_CRYPTO) $(SHARED_SSL)' if (!$config{no_shared}) -}
-SHARED_LIBS_LINK_EXTS={- $config{shared_link_extensions} -}
 SHARED_LDFLAGS={- $target{shared_ldflag} -}
 
 GENERAL=        Makefile
@@ -311,20 +310,6 @@ libssl$(SHLIB_EXT): libcrypto$(SHLIB_EXT) libssl.a
 		echo "There's no support for shared libraries on this platform" >&2; \
 		exit 1; \
 	fi
-
-clean-shared:
-	@set -e; for i in $(SHLIBDIRS); do \
-		if [ -n "$(SHARED_LIBS_LINK_EXTS)" ]; then \
-			tmp="$(SHARED_LIBS_LINK_EXTS)"; \
-			for j in $${tmp:-x}; do \
-				( set -x; rm -f lib$$i$$j ); \
-			done; \
-		fi; \
-		( set -x; rm -f lib$$i$(SHLIB_EXT) ); \
-		if expr "$(PLATFORM)" : "Cygwin" >/dev/null; then \
-			( set -x; rm -f cyg$$i$(SHLIB_EXT) lib$$i$(SHLIB_EXT).a ); \
-		fi; \
-	done
 
 link-shared:
 	@ set -e; for i in $(SHLIBDIRS); do \


### PR DESCRIPTION
Also removes the make variable SHARED_LIBS_LINK_EXTS, only used by
the clean-shared target.

When shared library linking was moved to the separate Makefile.shared
in commit 30afcc072acd4f70590fec68bf0590da4e4f1883, this target was
skipped.  Prior to that commit, clean-shared was invoked as a
dependency of build-shared, but afterward it was no longer referenced
anywhere in the tree.

Instead of porting the functionality over to Makefile.shared, just
remove it entirely, as it appears to be unused.