### PR TITLE
RT4262: Configure always asks for make depend

### DIFF
--- a/Configure
+++ b/Configure
@@ -589,12 +589,12 @@ my %disabled = ( # "what"         => "comment" [or special keyword "experimental
 		 "md2"            => "default",
 		 "rc5"            => "default",
 		 "sctp"           => "default",
-		 "shared"         => "default",
+		 "shared"         => "default(no-depflags)",
 		 "ssl-trace"	  => "default",
 		 "store"	  => "experimental",
 		 "unit-test"	  => "default",
-		 "zlib"           => "default",
-		 "zlib-dynamic"   => "default",
+		 "zlib"           => "default(no-depflags)",
+		 "zlib-dynamic"   => "default(no-depflags)",
 		 "crypto-mdebug"  => "default",
 	       );
 my @experimental = ();


### PR DESCRIPTION
When ./config is run, the Configure script always complains about
'make depend? needing to be run because the $default_depflags and
$depflags do not match.

Recent changes to Configure automatically create $default_depflags,
but takes special exceptions for shared, zip, hw and asm, which are
not normally put into $default_depflags but are put into |$depflags|
causing a mismatch leading to the warning.

Add (no-depflags) to the shared and zlib options in the disabled
table. This precludes them from being added to the $default_depflags.