### PR TITLE
RT4263: Fix store with opaque data

### DIFF
--- a/crypto/store/str_lib.c
+++ b/crypto/store/str_lib.c
@@ -420,7 +420,7 @@ EVP_PKEY *STORE_generate_key(STORE *s, OPENSSL_ITEM attributes[],
         STOREerr(STORE_F_STORE_GENERATE_KEY, STORE_R_FAILED_GENERATING_KEY);
         return 0;
     }
-    CRYPTO_add(&object->data.key->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(object->data.key);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif
@@ -444,7 +444,7 @@ EVP_PKEY *STORE_get_private_key(STORE *s, OPENSSL_ITEM attributes[],
         STOREerr(STORE_F_STORE_GET_PRIVATE_KEY, STORE_R_FAILED_GETTING_KEY);
         return 0;
     }
-    CRYPTO_add(&object->data.key->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(object->data.key);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif
@@ -474,7 +474,7 @@ int STORE_store_private_key(STORE *s, EVP_PKEY *data,
         return 0;
     }
 
-    CRYPTO_add(&data->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(data);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif
@@ -578,7 +578,7 @@ EVP_PKEY *STORE_list_private_key_next(STORE *s, void *handle)
                  STORE_R_FAILED_LISTING_KEYS);
         return 0;
     }
-    CRYPTO_add(&object->data.key->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(object->data.key);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif
@@ -628,7 +628,7 @@ EVP_PKEY *STORE_get_public_key(STORE *s, OPENSSL_ITEM attributes[],
         STOREerr(STORE_F_STORE_GET_PUBLIC_KEY, STORE_R_FAILED_GETTING_KEY);
         return 0;
     }
-    CRYPTO_add(&object->data.key->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(object->data.key);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif
@@ -658,7 +658,7 @@ int STORE_store_public_key(STORE *s, EVP_PKEY *data,
         return 0;
     }
 
-    CRYPTO_add(&data->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(data);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif
@@ -762,7 +762,7 @@ EVP_PKEY *STORE_list_public_key_next(STORE *s, void *handle)
                  STORE_R_FAILED_LISTING_KEYS);
         return 0;
     }
-    CRYPTO_add(&object->data.key->references, 1, CRYPTO_LOCK_EVP_PKEY);
+    EVP_PKEY_up_ref(object->data.key);
 #ifdef REF_PRINT
     REF_PRINT("EVP_PKEY", data);
 #endif


### PR DESCRIPTION
When experimental-store is enabled, it does not compile due to the
change to opaque data structures.

Change CRYPTO_add() to EVP_PKEY_up_ref() as needed.