### PR TITLE
RT4265: Fix s_server.c when SRTP is disabled

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1434,7 +1434,9 @@ int s_server_main(int argc, char *argv[])
             goto opthelp;
 #endif
         case OPT_SRTP_PROFILES:
+#ifndef OPENSSL_NO_SRTP
             srtp_profiles = opt_arg();
+#endif
             break;
         case OPT_KEYMATEXPORT:
             keymatexportlabel = opt_arg();


### PR DESCRIPTION
The srtp_profiles varible is not #ifdef'd out when SRTP is disabled.