### PR TITLE
RT3885 OpenSSL fails to cross-compile on 32-bit->64-bit

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -192,13 +192,19 @@ my %globals;
 	}
 	$ret;
     }
+    sub myoct {
+        my $v = shift;
+	return $v if ($v =~ /^0x[0-9a-f]{9,16}/i); # if 64-bit hex leave as-is
+        use integer;
+        return oct($v);
+    }
     sub out {
     	my $self = shift;
 
 	if ($gas) {
 	    # Solaris /usr/ccs/bin/as can't handle multiplications
 	    # in $self->{value}
-	    $self->{value} =~ s/(?<![\w\$\.])(0x?[0-9a-f]+)/oct($1)/egi;
+	    $self->{value} =~ s/(?<![\w\$\.])(0x?[0-9a-f]+)/myoct($1)/egi;
 	    $self->{value} =~ s/([0-9]+\s*[\*\/\%]\s*[0-9]+)/eval($1)/eg;
 	    sprintf "\$%s",$self->{value};
 	} else {


### PR DESCRIPTION
Older 32-bit versions of perl cannot handle 64-bit numbers, so when
the x86_64-xlate.pl script encounters a 64-bit number, the oct()
function munges it into a double-precision rather than a 64-bit
integer. In this case, we know it's either a hex number or an octal
number. So, if 64-bit hex, just pass through as hex string, otherwise
allow oct() to handle it. There are some cases where immediate constants
are multiplied together. The script assumes decimal numbers during mul,
div, mod operations, so by handling only 64-bit numbers in this manner,
the impact of this patch is minimized.

This is a problem in ghash-x86_64.pl (ghash-x86_64.s), and the solution
has an impact all 64-bit platforms. Ran the unit tests to make sure it's
OK.