### PR TITLE
Learn from the lessons of GOTOFAIL

### DIFF
--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -137,11 +137,13 @@ static int pkey_rsa_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
 
 static int setup_tbuf(RSA_PKEY_CTX *ctx, EVP_PKEY_CTX *pk)
 {
-    if (ctx->tbuf)
+    if (ctx->tbuf) {
         return 1;
+    }
     ctx->tbuf = OPENSSL_malloc(EVP_PKEY_size(pk->pkey));
-    if (ctx->tbuf == NULL)
+    if (ctx->tbuf == NULL) {
         return 0;
+    }
     return 1;
 }
 
@@ -210,13 +212,16 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
                 return -1;
             ret = RSA_private_encrypt(RSA_size(rsa), rctx->tbuf,
                                       sig, rsa, RSA_NO_PADDING);
-        } else
+        } else {
             return -1;
-    } else
+        }
+    } else {
         ret = RSA_private_encrypt(tbslen, tbs, sig, ctx->pkey->pkey.rsa,
                                   rctx->pad_mode);
-    if (ret < 0)
+    }
+    if (ret < 0) {
         return ret;
+    }
     *siglen = ret;
     return 1;
 }
@@ -230,13 +235,15 @@ static int pkey_rsa_verifyrecover(EVP_PKEY_CTX *ctx,
 
     if (rctx->md) {
         if (rctx->pad_mode == RSA_X931_PADDING) {
-            if (!setup_tbuf(rctx, ctx))
+            if (!setup_tbuf(rctx, ctx)) {
                 return -1;
+            }
             ret = RSA_public_decrypt(siglen, sig,
                                      rctx->tbuf, ctx->pkey->pkey.rsa,
                                      RSA_X931_PADDING);
-            if (ret < 1)
+            if (ret < 1) {
                 return 0;
+            }
             ret--;
             if (rctx->tbuf[ret] != RSA_X931_hash_id(EVP_MD_type(rctx->md))) {
                 RSAerr(RSA_F_PKEY_RSA_VERIFYRECOVER,
@@ -248,23 +255,28 @@ static int pkey_rsa_verifyrecover(EVP_PKEY_CTX *ctx,
                        RSA_R_INVALID_DIGEST_LENGTH);
                 return 0;
             }
-            if (rout)
+            if (rout) {
                 memcpy(rout, rctx->tbuf, ret);
+            }
         } else if (rctx->pad_mode == RSA_PKCS1_PADDING) {
             size_t sltmp;
             ret = int_rsa_verify(EVP_MD_type(rctx->md),
                                  NULL, 0, rout, &sltmp,
                                  sig, siglen, ctx->pkey->pkey.rsa);
-            if (ret <= 0)
+            if (ret <= 0) {
                 return 0;
+            }
             ret = sltmp;
-        } else
+        } else {
             return -1;
-    } else
+        }
+    } else {
         ret = RSA_public_decrypt(siglen, sig, rout, ctx->pkey->pkey.rsa,
                                  rctx->pad_mode);
-    if (ret < 0)
+    }
+    if (ret < 0) {
         return ret;
+    }
     *routlen = ret;
     return 1;
 }
@@ -277,42 +289,49 @@ static int pkey_rsa_verify(EVP_PKEY_CTX *ctx,
     RSA *rsa = ctx->pkey->pkey.rsa;
     size_t rslen;
     if (rctx->md) {
-        if (rctx->pad_mode == RSA_PKCS1_PADDING)
+        if (rctx->pad_mode == RSA_PKCS1_PADDING) {
             return RSA_verify(EVP_MD_type(rctx->md), tbs, tbslen,
                               sig, siglen, rsa);
+        }
         if (rctx->pad_mode == RSA_X931_PADDING) {
-            if (pkey_rsa_verifyrecover(ctx, NULL, &rslen, sig, siglen) <= 0)
+            if (pkey_rsa_verifyrecover(ctx, NULL, &rslen, sig, siglen) <= 0) {
                 return 0;
+            }
         } else if (rctx->pad_mode == RSA_PKCS1_PSS_PADDING) {
             int ret;
-            if (!setup_tbuf(rctx, ctx))
+            if (!setup_tbuf(rctx, ctx)) {
                 return -1;
+            }
             ret = RSA_public_decrypt(siglen, sig, rctx->tbuf,
                                      rsa, RSA_NO_PADDING);
-            if (ret <= 0)
+            if (ret <= 0) {
                 return 0;
+            }
             ret = RSA_verify_PKCS1_PSS_mgf1(rsa, tbs,
                                             rctx->md, rctx->mgf1md,
                                             rctx->tbuf, rctx->saltlen);
-            if (ret <= 0)
+            if (ret <= 0) {
                 return 0;
+            }
             return 1;
-        } else
+        } else {
             return -1;
+        }
     } else {
-        if (!setup_tbuf(rctx, ctx))
+        if (!setup_tbuf(rctx, ctx)) {
             return -1;
+        }
         rslen = RSA_public_decrypt(siglen, sig, rctx->tbuf,
                                    rsa, rctx->pad_mode);
-        if (rslen == 0)
+        if (rslen == 0) {
             return 0;
+        }
     }
 
-    if ((rslen != tbslen) || memcmp(tbs, rctx->tbuf, rslen))
+    if ((rslen != tbslen) || memcmp(tbs, rctx->tbuf, rslen)) {
         return 0;
-
+    }
     return 1;
-
 }
 
 static int pkey_rsa_encrypt(EVP_PKEY_CTX *ctx,
@@ -323,21 +342,25 @@ static int pkey_rsa_encrypt(EVP_PKEY_CTX *ctx,
     RSA_PKEY_CTX *rctx = ctx->data;
     if (rctx->pad_mode == RSA_PKCS1_OAEP_PADDING) {
         int klen = RSA_size(ctx->pkey->pkey.rsa);
-        if (!setup_tbuf(rctx, ctx))
+        if (!setup_tbuf(rctx, ctx)) {
             return -1;
+        }
         if (!RSA_padding_add_PKCS1_OAEP_mgf1(rctx->tbuf, klen,
                                              in, inlen,
                                              rctx->oaep_label,
                                              rctx->oaep_labellen,
-                                             rctx->md, rctx->mgf1md))
+                                             rctx->md, rctx->mgf1md)) {
             return -1;
+        }
         ret = RSA_public_encrypt(klen, rctx->tbuf, out,
                                  ctx->pkey->pkey.rsa, RSA_NO_PADDING);
-    } else
+    } else {
         ret = RSA_public_encrypt(inlen, in, out, ctx->pkey->pkey.rsa,
                                  rctx->pad_mode);
-    if (ret < 0)
+    }
+    if (ret < 0) {
         return ret;
+    }
     *outlen = ret;
     return 1;
 }
@@ -350,26 +373,32 @@ static int pkey_rsa_decrypt(EVP_PKEY_CTX *ctx,
     RSA_PKEY_CTX *rctx = ctx->data;
     if (rctx->pad_mode == RSA_PKCS1_OAEP_PADDING) {
         int i;
-        if (!setup_tbuf(rctx, ctx))
+        if (!setup_tbuf(rctx, ctx)) {
             return -1;
+        }
         ret = RSA_private_decrypt(inlen, in, rctx->tbuf,
                                   ctx->pkey->pkey.rsa, RSA_NO_PADDING);
-        if (ret <= 0)
+        if (ret <= 0) {
             return ret;
+        }
         for (i = 0; i < ret; i++) {
-            if (rctx->tbuf[i])
+            if (rctx->tbuf[i]) {
                 break;
+            }
         }
         ret = RSA_padding_check_PKCS1_OAEP_mgf1(out, ret, rctx->tbuf + i,
                                                 ret - i, ret,
                                                 rctx->oaep_label,
                                                 rctx->oaep_labellen,
                                                 rctx->md, rctx->mgf1md);
-    } else
+    } else {
         ret = RSA_private_decrypt(inlen, in, out, ctx->pkey->pkey.rsa,
                                   rctx->pad_mode);
-    if (ret < 0)
+    }
+    
+    if (ret < 0) {
         return ret;
+    }
     *outlen = ret;
     return 1;
 }
@@ -377,8 +406,9 @@ static int pkey_rsa_decrypt(EVP_PKEY_CTX *ctx,
 static int check_padding_md(const EVP_MD *md, int padding)
 {
     int mdnid;
-    if (!md)
+    if (!md) {
         return 1;
+    }
 
     mdnid = EVP_MD_type(md);
 
@@ -424,20 +454,25 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     switch (type) {
     case EVP_PKEY_CTRL_RSA_PADDING:
         if ((p1 >= RSA_PKCS1_PADDING) && (p1 <= RSA_PKCS1_PSS_PADDING)) {
-            if (!check_padding_md(rctx->md, p1))
+            if (!check_padding_md(rctx->md, p1)) {
                 return 0;
+            }
             if (p1 == RSA_PKCS1_PSS_PADDING) {
                 if (!(ctx->operation &
-                      (EVP_PKEY_OP_SIGN | EVP_PKEY_OP_VERIFY)))
+                      (EVP_PKEY_OP_SIGN | EVP_PKEY_OP_VERIFY))) {
                     goto bad_pad;
-                if (!rctx->md)
+                }
+                if (!rctx->md) {
                     rctx->md = EVP_sha1();
+                }
             }
             if (p1 == RSA_PKCS1_OAEP_PADDING) {
-                if (!(ctx->operation & EVP_PKEY_OP_TYPE_CRYPT))
+                if (!(ctx->operation & EVP_PKEY_OP_TYPE_CRYPT)) {
                     goto bad_pad;
-                if (!rctx->md)
+                }
+                if (!rctx->md) {
                     rctx->md = EVP_sha1();
+                }
             }
             rctx->pad_mode = p1;
             return 1;
@@ -457,9 +492,9 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             RSAerr(RSA_F_PKEY_RSA_CTRL, RSA_R_INVALID_PSS_SALTLEN);
             return -2;
         }
-        if (type == EVP_PKEY_CTRL_GET_RSA_PSS_SALTLEN)
+        if (type == EVP_PKEY_CTRL_GET_RSA_PSS_SALTLEN) {
             *(int *)p2 = rctx->saltlen;
-        else {
+        } else {
             if (p1 < -2)
                 return -2;
             rctx->saltlen = p1;
@@ -475,8 +510,9 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     case EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP:
-        if (!p2)
+        if (!p2) {
             return -2;
+        }
         BN_free(rctx->pub_exp);
         rctx->pub_exp = p2;
         return 1;
@@ -487,15 +523,17 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             RSAerr(RSA_F_PKEY_RSA_CTRL, RSA_R_INVALID_PADDING_MODE);
             return -2;
         }
-        if (type == EVP_PKEY_CTRL_GET_RSA_OAEP_MD)
+        if (type == EVP_PKEY_CTRL_GET_RSA_OAEP_MD) {
             *(const EVP_MD **)p2 = rctx->md;
-        else
+        } else {
             rctx->md = p2;
+        }
         return 1;
 
     case EVP_PKEY_CTRL_MD:
-        if (!check_padding_md(p2, rctx->pad_mode))
+        if (!check_padding_md(p2, rctx->pad_mode)) {
             return 0;
+        }
         rctx->md = p2;
         return 1;
 
@@ -511,12 +549,14 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             return -2;
         }
         if (type == EVP_PKEY_CTRL_GET_RSA_MGF1_MD) {
-            if (rctx->mgf1md)
+            if (rctx->mgf1md) {
                 *(const EVP_MD **)p2 = rctx->mgf1md;
-            else
+            } else {
                 *(const EVP_MD **)p2 = rctx->md;
-        } else
+            }
+        } else {
             rctx->mgf1md = p2;
+        }
         return 1;
 
     case EVP_PKEY_CTRL_RSA_OAEP_LABEL:
@@ -573,21 +613,21 @@ static int pkey_rsa_ctrl_str(EVP_PKEY_CTX *ctx,
     }
     if (strcmp(type, "rsa_padding_mode") == 0) {
         int pm;
-        if (strcmp(value, "pkcs1") == 0)
+        if (strcmp(value, "pkcs1") == 0) {
             pm = RSA_PKCS1_PADDING;
-        else if (strcmp(value, "sslv23") == 0)
+        } else if (strcmp(value, "sslv23") == 0) {
             pm = RSA_SSLV23_PADDING;
-        else if (strcmp(value, "none") == 0)
+        } else if (strcmp(value, "none") == 0) {
             pm = RSA_NO_PADDING;
-        else if (strcmp(value, "oeap") == 0)
+        } else if (strcmp(value, "oeap") == 0) {
             pm = RSA_PKCS1_OAEP_PADDING;
-        else if (strcmp(value, "oaep") == 0)
+        } else if (strcmp(value, "oaep") == 0) {
             pm = RSA_PKCS1_OAEP_PADDING;
-        else if (strcmp(value, "x931") == 0)
+        } else if (strcmp(value, "x931") == 0) {
             pm = RSA_X931_PADDING;
-        else if (strcmp(value, "pss") == 0)
+        } else if (strcmp(value, "pss") == 0) {
             pm = RSA_PKCS1_PSS_PADDING;
-        else {
+        } else {
             RSAerr(RSA_F_PKEY_RSA_CTRL_STR, RSA_R_UNKNOWN_PADDING_TYPE);
             return -2;
         }
@@ -609,11 +649,13 @@ static int pkey_rsa_ctrl_str(EVP_PKEY_CTX *ctx,
     if (strcmp(type, "rsa_keygen_pubexp") == 0) {
         int ret;
         BIGNUM *pubexp = NULL;
-        if (!BN_asc2bn(&pubexp, value))
+        if (!BN_asc2bn(&pubexp, value)) {
             return 0;
+        }
         ret = EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, pubexp);
-        if (ret <= 0)
+        if (ret <= 0) {
             BN_free(pubexp);
+        }
         return ret;
     }
 
@@ -639,11 +681,13 @@ static int pkey_rsa_ctrl_str(EVP_PKEY_CTX *ctx,
         long lablen;
         int ret;
         lab = string_to_hex(value, &lablen);
-        if (!lab)
+        if (!lab) {
             return 0;
+        }
         ret = EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, lab, lablen);
-        if (ret <= 0)
+        if (ret <= 0) {
             OPENSSL_free(lab);
+        }
         return ret;
     }
 
@@ -658,12 +702,14 @@ static int pkey_rsa_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     int ret;
     if (rctx->pub_exp == NULL) {
         rctx->pub_exp = BN_new();
-        if (rctx->pub_exp == NULL || !BN_set_word(rctx->pub_exp, RSA_F4))
+        if (rctx->pub_exp == NULL || !BN_set_word(rctx->pub_exp, RSA_F4)) {
             return 0;
+        }
     }
     rsa = RSA_new();
-    if (rsa == NULL)
+    if (rsa == NULL) {
         return 0;
+    }
     if (ctx->pkey_gencb) {
         pcb = BN_GENCB_new();
         if (pcb == NULL) {
@@ -671,14 +717,16 @@ static int pkey_rsa_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
             return 0;
         }
         evp_pkey_set_cb_translate(pcb, ctx);
-    } else
+    } else {
         pcb = NULL;
+    }
     ret = RSA_generate_key_ex(rsa, rctx->nbits, rctx->pub_exp, pcb);
     BN_GENCB_free(pcb);
-    if (ret > 0)
+    if (ret > 0) {
         EVP_PKEY_assign_RSA(pkey, rsa);
-    else
+    } else {
         RSA_free(rsa);
+    }
     return ret;
 }
 


### PR DESCRIPTION
Use explicit braces around if statements to prevent catastrophes down the line.