### PR TITLE
Ensure 64-bit shift no matter which size 'long' has

### DIFF
--- a/crypto/evp/scrypt.c
+++ b/crypto/evp/scrypt.c
@@ -228,7 +228,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
      */
 
     if (16 * r <= LOG2_UINT64_MAX) {
-        if (N >= (1UL << (16 * r)))
+        if (N >= (((uint64_t)1) << (16 * r)))
             return 0;
     }
 


### PR DESCRIPTION
Original code yields C4334 Visual C++ warning because `1UL` is of type `unsigned long` which is 32-bit on Windows, so 32-bit shift happens.