### PR TITLE
Fbroda ts date

### DIFF
--- a/crypto/ts/ts_verify_ctx.c
+++ b/crypto/ts/ts_verify_ctx.c
@@ -91,6 +91,11 @@ int TS_VERIFY_CTX_add_flags(TS_VERIFY_CTX *ctx, int f)
     return ctx->flags;
 }
 
+X509_VERIFY_PARAM *TS_VERIFY_CTX_get_store_param(TS_VERIFY_CTX *ctx) 
+{
+    return ctx->store->param;
+}
+
 int TS_VERIFY_CTX_set_flags(TS_VERIFY_CTX *ctx, int f)
 {
     ctx->flags = f;

--- a/doc/apps/ts.pod
+++ b/doc/apps/ts.pod
@@ -40,6 +40,7 @@ B<-reply>
 
 B<openssl> B<ts>
 B<-verify>
+[B<-attime> timestamp]
 [B<-data> file_to_hash]
 [B<-digest> digest_bytes]
 [B<-queryfile> request.tsq]
@@ -285,6 +286,12 @@ stamp token is valid and matches a particular time stamp request or
 data file. The B<-verify> command does not use the configuration file.
 
 =over 4
+
+=item B<-attime timestamp>
+
+Perform validation checks using time specified by B<timestamp> and not
+current system time. B<timestamp> is the number of seconds since
+01.01.1970 (UNIX time).
 
 =item B<-data> file_to_hash
 

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -510,6 +510,7 @@ TS_VERIFY_CTX *TS_VERIFY_CTX_new(void);
 void TS_VERIFY_CTX_init(TS_VERIFY_CTX *ctx);
 void TS_VERIFY_CTX_free(TS_VERIFY_CTX *ctx);
 void TS_VERIFY_CTX_cleanup(TS_VERIFY_CTX *ctx);
+X509_VERIFY_PARAM *TS_VERIFY_CTX_get_store_param(TS_VERIFY_CTX *ctx);
 int TS_VERIFY_CTX_set_flags(TS_VERIFY_CTX *ctx, int f);
 int TS_VERIFY_CTX_add_flags(TS_VERIFY_CTX *ctx, int f);
 BIO *TS_VERIFY_CTX_set_data(TS_VERIFY_CTX *ctx, BIO *b);


### PR DESCRIPTION
This set of changes would add an option -attime to "openssl ts -verify" similar to the -attime option in "openssl verify". This is needed for verifying timestamp responses with expired certificates. Changes to documentation included. 