### PR TITLE
RT4148

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
  Changes between 1.0.2f and 1.1.0  [xx XXX xxxx]
 
+  *) RSA_padding_check_PKCS1_type_1 now accepts inputs with and without
+     the leading 0-byte.
+     [Emilia Käsper]
+
   *) The signature of the session callback configured with
      SSL_CTX_sess_set_get_cb was changed. The read-only input buffer
      was explicitly marked as 'const unsigned char*' instead of

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -97,7 +97,28 @@ int RSA_padding_check_PKCS1_type_1(unsigned char *to, int tlen,
     const unsigned char *p;
 
     p = from;
-    if ((num != (flen + 1)) || (*(p++) != 01)) {
+
+    /*
+     * The format is
+     * 00 || 01 || PS || 00 || D
+     * PS - padding string, at least 8 bytes of FF
+     * D  - data.
+     */
+
+    if (num < 11)
+        return -1;
+
+    /* Accept inputs with and without the leading 0-byte. */
+    if (num == flen) {
+        if ((*p++) != 0x00) {
+            RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_1,
+                   RSA_R_INVALID_PADDING);
+            return -1;
+        }
+        flen--;
+    }
+
+    if ((num != (flen + 1)) || (*(p++) != 0x01)) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_1,
                RSA_R_BLOCK_TYPE_IS_NOT_01);
         return (-1);


### PR DESCRIPTION
Accept leading 0-byte in PKCS1 type 1 padding. Internally, the byte is
stripped by BN_bn2bin but external callers may have other expectations.