### PR TITLE
Fix build with no-heartbeats and enable-unit-test

### DIFF
--- a/ssl/ssl_utst.c
+++ b/ssl/ssl_utst.c
@@ -59,8 +59,13 @@
 static const struct openssl_ssl_test_functions ssl_test_functions = {
     ssl_init_wbio_buffer,
     ssl3_setup_buffers,
+# ifdef OPENSSL_NO_HEARTBEATS
+    NULL,
+    NULL
+# else
     tls1_process_heartbeat,
     dtls1_process_heartbeat
+# endif
 };
 
 const struct openssl_ssl_test_functions *SSL_test_functions(void)


### PR DESCRIPTION
The internal heartbeat functions are not available for testing
if they are not being built at all.  (This change is somewhat moot,
as the only tests controlled by enable-unit-test are for heartbeats,
but perhaps that will change in the future.)  Use NULL as a
placeholder for these nonexistant functions in this case.