### PR TITLE
[Configure] Make --with-zlib-* work with configdata.pm

### DIFF
--- a/Configure
+++ b/Configure
@@ -596,11 +596,11 @@ foreach (@argvcopy)
 			}
 		elsif (/^--with-zlib-lib=(.*)$/)
 			{
-			$withargs{"zlib-lib"}=$1;
+			$withargs{zlib_lib}=$1;
 			}
 		elsif (/^--with-zlib-include=(.*)$/)
 			{
-			$withargs{"zlib-include"}="-I$1";
+			$withargs{zlib_include}="-I$1";
 			}
 		elsif (/^--with-fipslibdir=(.*)$/)
 			{
@@ -937,9 +937,9 @@ if ($zlib)
 	$config{cflags} = "-DZLIB $config{cflags}";
 	if (defined($disabled{"zlib-dynamic"}))
 		{
-		if (defined($withargs{"zlib-lib"}))
+		if (defined($withargs{zlib_lib}))
 			{
-			$config{ex_libs} .= " -L" . $withargs{"zlib-lib"} . " -lz";
+			$config{ex_libs} .= " -L" . $withargs{zlib_lib} . " -lz";
 			}
 		else
 			{

--- a/Makefile.in
+++ b/Makefile.in
@@ -110,8 +110,8 @@ POLY1305_ASM_OBJ= {- $target{poly1305_obj} -}
 PERLASM_SCHEME= {- $target{perlasm_scheme} -}
 
 # Zlib stuff
-ZLIB_INCLUDE={- $withargs{zlib-include} -}
-LIBZLIB={- $withargs{zlib-lib} -}
+ZLIB_INCLUDE={- $withargs{zlib_include} -}
+LIBZLIB={- $withargs{zlib_lib} -}
 
 # This is the location of fipscanister.o and friends.
 # The FIPS module build will place it $(INSTALLTOP)/lib


### PR DESCRIPTION
    $ ./Configure enable-zlib --with-zlib-lib=/usr/lib --with-zlib-include=/usr/include

Fails because the generated configdata.pm produces

    our %withargs = (
      zlib-include => "-I/usr/include",
      zlib-lib => "/usr/lib",
    );

Which creates the following errors during configuration.

    Bareword "zlib" not allowed while "strict subs" in use at configdata.pm line 134.
    Bareword "zlib" not allowed while "strict subs" in use at configdata.pm line 134.
    Compilation failed in require.
    BEGIN failed--compilation aborted.

This diff renames use of 'zlib-include' and 'zlib-lib' to 'zlib_include' and 'zlib_lib'.