### PR TITLE
Add Haiku support.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1741,6 +1741,35 @@ sub vms_info {
         shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
         ranlib           => "$ENV{'RANLIB'}",
     },
+    "haiku-common" => {
+        template         => 1,
+        cc               => "cc",
+        cflags           => add_before(picker(default => "-DL_ENDIAN -Wall",
+                                              debug   => "-g -O0",
+                                              release => "-O2"),
+                                       threads("-D_REENTRANT")),
+        sys_id           => "HAIKU",
+        lflags           => "-lnetwork",
+        perlasm_scheme   => "elf",
+        thread_scheme    => "pthreads",
+        dso_scheme       => "dlfcn",
+        shared_target    => "haiku-shared",
+        shared_cflag     => "-fPIC",
+        shared_ldflag    => "-shared",
+        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+    },
+    "haiku-x86" => {
+        inherit_from     => [ "haiku-common", asm("x86_elf_asm") ],
+        cflags           => add(picker(default => "",
+                                       release => "-fomit-frame-pointer")),
+        bn_ops           => "BN_LLONG",
+    },
+    "haiku-x86_64" => {
+        inherit_from     => [ "haiku-common", asm("x86_64_asm") ],
+        cflags           => add("-m64"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+    },
+
 
     ##### VMS
     "vms-generic" => {

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -561,11 +561,11 @@ symlink.hpux:
 symlink.cygwin symlink.alpha-osf1 symlink.tru64 symlink.tru64-rpath:
 
 # Compatibility targets
-link_dso.bsd-gcc-shared link_dso.linux-shared link_dso.gnu-shared: link_dso.gnu
+link_dso.bsd-gcc-shared link_dso.linux-shared link_dso.gnu-shared link_dso.haiku-shared: link_dso.gnu
 link_shlib.bsd-gcc-shared: link_shlib.linux-shared
-link_shlib.gnu-shared: link_shlib.gnu
-link_app.bsd-gcc-shared link_app.linux-shared link_app.gnu-shared: link_app.gnu
-symlink.bsd-gcc-shared symlink.bsd-shared symlink.linux-shared symlink.gnu-shared: symlink.gnu
+link_shlib.gnu-shared link_shlib.haiku-shared: link_shlib.gnu
+link_app.bsd-gcc-shared link_app.linux-shared link_app.gnu-shared link_app.haiku-shared: link_app.gnu
+symlink.bsd-gcc-shared symlink.bsd-shared symlink.linux-shared symlink.gnu-shared symlink.haiku-shared: symlink.gnu
 link_dso.bsd-shared: link_dso.bsd
 link_shlib.bsd-shared: link_shlib.bsd
 link_app.bsd-shared: link_app.bsd

--- a/config
+++ b/config
@@ -202,6 +202,10 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
 	echo "${MACHINE}-whatever-freebsd"; exit 0
 	;;
 
+    Haiku:*)
+	echo "${MACHINE}-whatever-haiku"; exit 0
+	;;
+
     NetBSD:*:*:*386*)
         echo "`(/usr/sbin/sysctl -n hw.model || /sbin/sysctl -n hw.model) | sed 's,.*\(.\)86-class.*,i\186,'`-whatever-netbsd"; exit 0
 	;;
@@ -724,6 +728,8 @@ case "$GUESSOS" in
 			*ELF*)	OUT="BSD-x86-elf" ;;
 			*)	OUT="BSD-x86"; options="$options no-sse2" ;;
 			esac ;;
+  x86_64-*-haiku)	OUT="haiku-x86_64" ;;
+  *-*-haiku)		OUT="haiku-x86" ;;
   *-*-*bsd*)		OUT="BSD-generic32" ;;
 
   *-*-osf)		OUT="osf1-alpha-cc" ;;

--- a/e_os.h
+++ b/e_os.h
@@ -552,6 +552,13 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
+/* haiku */
+# if defined(OPENSSL_SYS_HAIKU)
+#  include <sys/select.h>
+#  include <sys/time.h>
+# endif
+/* end haiku */
+
 #define OSSL_NELEM(x)    (sizeof(x)/sizeof(x[0]))
 
 #ifdef  __cplusplus


### PR DESCRIPTION
Build support for Haiku is missing at the moment.

This patch updates the build scripts to build on Haiku, this includes x86 and x86_64.
It apply directly to master. Please consider applying.

PS: this is the follow up to the ticket [RT2392](https://rt.openssl.org/Ticket/Display.html?id=2392)