### PR TITLE
Fix potential buffer overrun

### DIFF
--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -265,7 +265,7 @@ static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
         spec2len = (filespec2 ? strlen(filespec2) : 0);
         len = spec2len + (filespec1 ? strlen(filespec1) : 0);
 
-        if (filespec2 && filespec2[spec2len - 1] == '/') {
+        if (spec2len && filespec2[spec2len - 1] == '/') {
             spec2len--;
             len--;
         }


### PR DESCRIPTION
This was found with Cppcheck. In the original code `filespec2` is checked for being null on line 268 and then unconditionally passed into `strcpy()` on line 277. That makes no sense.

The real problem though is that if `filespec2` points to an empty string then `spec2len - 1` underflows and a buffer overrun may occur.