### PR TITLE
Add option to disable async

### DIFF
--- a/Configure
+++ b/Configure
@@ -227,6 +227,7 @@ my @dtls = qw(dtls1 dtls1_2);
 my @disablables = (
     "aes",
     "asm",
+    "async",
     "bf",
     "camellia",
     "capieng",
@@ -741,7 +742,7 @@ foreach (sort (keys %disabled))
 		my ($ALGO, $algo);
 		($ALGO = $algo = $_) =~ tr/[\-a-z]/[_A-Z]/;
 
-		if (/^asm$/ || /^err$/ || /^hw$/ || /^hw-/)
+		if (/^asm$/ || /^err$/ || /^hw$/ || /^hw-/ || /^async$/)
 			{
 			push @{$config{openssl_other_defines}}, "OPENSSL_NO_$ALGO";
 			print " OPENSSL_NO_$ALGO";

--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -53,7 +53,7 @@
 #define OPENSSL_ASYNC_ARCH_ASYNC_POSIX_H
 #include <openssl/e_os2.h>
 
-#if (defined(OPENSSL_SYS_UNIX) || defined(OPENSSL_SYS_CYGWIN)) && defined(OPENSSL_THREADS)
+#if (defined(OPENSSL_SYS_UNIX) || defined(OPENSSL_SYS_CYGWIN)) && defined(OPENSSL_THREADS) && !defined(OPENSSL_NO_ASYNC)
 
 # include <unistd.h>
 

--- a/crypto/async/arch/async_win.h
+++ b/crypto/async/arch/async_win.h
@@ -54,7 +54,7 @@
  * This is the same detection used in cryptlib to set up the thread local
  * storage that we depend on, so just copy that
  */
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(OPENSSL_NO_ASYNC)
 #include <openssl/async.h>
 # define ASYNC_WIN
 # define ASYNC_ARCH

--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -142,6 +142,7 @@ and [options] can be one of
 	no-engine				- No engine
 	no-egd					- No EGD
 	no-hw					- No hw
+	no-async                                - No Async (use NULL)
 	nasm 					- Use NASM for x86 asm
 	nw-nasm					- Use NASM x86 asm for NetWare
 	nw-mwasm				- Use Metrowerks x86 asm for NetWare
@@ -296,6 +297,7 @@ $cflags.=" -DOPENSSL_NO_EC"   if $no_ec;
 $cflags.=" -DOPENSSL_NO_GOST" if $no_gost;
 $cflags.=" -DOPENSSL_NO_ENGINE"   if $no_engine;
 $cflags.=" -DOPENSSL_NO_HW"   if $no_hw;
+$cflags.=" -DOPENSSL_NO_ASYNC" if $no_async;
 $cflags.=" -DOPENSSL_FIPS"    if $fips;
 $cflags.=" -DOPENSSL_NO_JPAKE"    if $no_jpake;
 $cflags.=" -DOPENSSL_NO_EC2M"    if $no_ec2m;
@@ -1411,6 +1413,7 @@ sub read_options
 		"no-engine" => \$no_engine,
 		"no-egd" => 0,
 		"no-hw" => \$no_hw,
+		"no-async" => \$no_async,
 		"just-ssl" =>
 			[\$no_rc2, \$no_idea, \$no_des, \$no_bf, \$no_cast,
 			  \$no_md2, \$no_mdc2, \$no_dsa, \$no_dh,


### PR DESCRIPTION
Add no-async option to Configure that forces ASYNC_NULL.
Related to RT1979
An embedded system or replacement C library (e.g. musl or uClibc)
may not support the *context APIs that are needed for async operation.

Compiles with musl. Ran unit tests, async tests skipped as expected.