### PR TITLE
Ensure allocation size fits into size_t

### DIFF
--- a/crypto/evp/scrypt.c
+++ b/crypto/evp/scrypt.c
@@ -213,6 +213,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     unsigned char *B;
     uint32_t *X, *V, *T;
     uint64_t i, Blen, Vlen;
+    size_t allocsize;
 
     /* Sanity check parameters */
     /* initial check, r,p must be non zero, N >= 2 and a power of 2 */
@@ -242,7 +243,8 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     Blen = p * 128 * r;
 
     /*
-     * Check 32 * r * (N + 2) * sizeof(uint32_t) fits in uint64_t.
+     * Check 32 * r * (N + 2) * sizeof(uint32_t) fits in
+     * uint64_t and also size_t (their sizes are unrelated).
      * This is combined size V, X and T (section 4)
      */
     i = UINT64_MAX / (32 * sizeof(uint32_t));
@@ -254,10 +256,15 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     if (Blen > UINT64_MAX - Vlen)
         return 0;
 
+    /* check total allocated size fits in size_t */
+    allocsize = (size_t)(Blen + Vlen);
+    if ((Blen + Vlen) != allocsize)
+        return 0;
+
     if (maxmem == 0)
         maxmem = SCRYPT_MAX_MEM;
 
-    if (Blen + Vlen > maxmem) {
+    if (allocsize > maxmem) {
         EVPerr(EVP_F_EVP_PBE_SCRYPT, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;
     }
@@ -266,7 +273,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     if (key == NULL)
         return 1;
 
-    B = OPENSSL_malloc(Blen + Vlen);
+    B = OPENSSL_malloc(allocsize);
     if (B == NULL)
         return 0;
     X = (uint32_t *)(B + Blen);
@@ -294,7 +301,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     BIO_dump_fp(stderr, (char *)key, keylen);
 #endif
  err:
-    OPENSSL_clear_free(B, Blen + Vlen);
+    OPENSSL_clear_free(B, allocsize);
     return rv;
 }
 #endif


### PR DESCRIPTION
This caused two C4244 Visual C++ warnings when `size_t` is 32-bit. I guess the calling code somehow ensures it doesn't ask for too much memory but it's more reliable to check again right before actual allocation.