### PR TITLE
Cleanup header analysis

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -488,7 +488,7 @@ int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *plen,
 int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher)
 {
     const EVP_CIPHER *enc = NULL;
-    char *p, c;
+    char *dekinfostart, c;
     char **header_pp = &header;
 
     cipher->cipher = NULL;
@@ -521,7 +521,7 @@ int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher)
     }
     header += 10;
 
-    p = header;
+    dekinfostart = header;
     for (;;) {
         c = *header;
 #ifndef CHARSET_EBCDIC
@@ -535,9 +535,8 @@ int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher)
         header++;
     }
     *header = '\0';
-    cipher->cipher = enc = EVP_get_cipherbyname(p);
+    cipher->cipher = enc = EVP_get_cipherbyname(dekinfostart);
     *header = c;
-    header++;
 
     if (enc == NULL) {
         PEMerr(PEM_F_PEM_GET_EVP_CIPHER_INFO, PEM_R_UNSUPPORTED_ENCRYPTION);


### PR DESCRIPTION
Cppcheck hinted that the last `header++;` has no effect. So I analyzed this code a bit deeper. Indeed the last `++` is useless. Variables names were sometimes horrible so I suggested better ones.