### PR TITLE
S server cmd

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -192,31 +192,43 @@ void wait_for_async(SSL *s);
         OPT_V__LAST
 
 # define OPT_V_OPTIONS \
-        { "policy", OPT_V_POLICY, 's' }, \
-        { "purpose", OPT_V_PURPOSE, 's' }, \
-        { "verify_name", OPT_V_VERIFY_NAME, 's' }, \
-        { "verify_depth", OPT_V_VERIFY_DEPTH, 'p' }, \
-        { "attime", OPT_V_ATTIME, 'M' }, \
-        { "verify_hostname", OPT_V_VERIFY_HOSTNAME, 's' }, \
-        { "verify_email", OPT_V_VERIFY_EMAIL, 's' }, \
-        { "verify_ip", OPT_V_VERIFY_IP, 's' }, \
-        { "ignore_critical", OPT_V_IGNORE_CRITICAL, '-' }, \
-        { "issuer_checks", OPT_V_ISSUER_CHECKS, '-' }, \
+        { "policy", OPT_V_POLICY, 's', "adds policy to the acceptable policy set"}, \
+        { "purpose", OPT_V_PURPOSE, 's', \
+            "Set the acceptable purpose of the certificate chain"}, \
+        { "verify_name", OPT_V_VERIFY_NAME, 's', "verify name"}, \
+        { "verify_depth", OPT_V_VERIFY_DEPTH, 'p', \
+            "Limit the maximum depth of the certificate chain"}, \
+        { "attime", OPT_V_ATTIME, 'M', "Set the verification time" }, \
+        { "verify_hostname", OPT_V_VERIFY_HOSTNAME, 's', \
+            "check peer certificate matches \"host\"" }, \
+        { "verify_email", OPT_V_VERIFY_EMAIL, 's', \
+            "check peer certificate matches \"host\"" }, \
+        { "verify_ip", OPT_V_VERIFY_IP, 's', \
+            "check peer certificate matches \"ipaddr\"" }, \
+        { "ignore_critical", OPT_V_IGNORE_CRITICAL, '-', \
+            "Disable critical extension checking"}, \
+        { "issuer_checks", OPT_V_ISSUER_CHECKS, '-', \
+            "Enable debugging of certificate issuer checks"}, \
         { "crl_check", OPT_V_CRL_CHECK, '-', "Check that peer cert has not been revoked" }, \
         { "crl_check_all", OPT_V_CRL_CHECK_ALL, '-', "Also check all certs in the chain" }, \
-        { "policy_check", OPT_V_POLICY_CHECK, '-' }, \
-        { "explicit_policy", OPT_V_EXPLICIT_POLICY, '-' }, \
-        { "inhibit_any", OPT_V_INHIBIT_ANY, '-' }, \
-        { "inhibit_map", OPT_V_INHIBIT_MAP, '-' }, \
-        { "x509_strict", OPT_V_X509_STRICT, '-' }, \
+        { "policy_check", OPT_V_POLICY_CHECK, '-', "Enable certificate policy checking"}, \
+        { "explicit_policy", OPT_V_EXPLICIT_POLICY, '-', "Set the \"require explicit policy\""}, \
+        { "inhibit_any", OPT_V_INHIBIT_ANY, '-', "Set the \"inhibit any policy\"\""}, \
+        { "inhibit_map", OPT_V_INHIBIT_MAP, '-', "Set the \"inhibit policy mapping\"" }, \
+        { "x509_strict", OPT_V_X509_STRICT, '-', \
+            "Strictly apply X509 rules in verification"}, \
         { "extended_crl", OPT_V_EXTENDED_CRL, '-' }, \
-        { "use_deltas", OPT_V_USE_DELTAS, '-' }, \
-        { "policy_print", OPT_V_POLICY_PRINT, '-' }, \
-        { "check_ss_sig", OPT_V_CHECK_SS_SIG, '-' }, \
-        { "trusted_first", OPT_V_TRUSTED_FIRST, '-', "Use locally-trusted CA's first in building chain" }, \
-        { "suiteB_128_only", OPT_V_SUITEB_128_ONLY, '-' }, \
-        { "suiteB_128", OPT_V_SUITEB_128, '-' }, \
-        { "suiteB_192", OPT_V_SUITEB_192, '-' }, \
+        { "use_deltas", OPT_V_USE_DELTAS, '-', \
+            "Enable indirect CRLs and CRLs signed by different keys"}, \
+        { "policy_print", OPT_V_POLICY_PRINT, '-', "Notify callback that policy is OK"}, \
+        { "check_ss_sig", OPT_V_CHECK_SS_SIG, '-', \
+            "Enable checking of the root CA self signed certificate signature"}, \
+        { "trusted_first", OPT_V_TRUSTED_FIRST, '-', \
+            "Use locally-trusted CA's first in building chain (enabled by default)" }, \
+        { "suiteB_128_only", OPT_V_SUITEB_128_ONLY, '-', "Suite B 128 bit only mode"}, \
+        { "suiteB_128", OPT_V_SUITEB_128, '-', \
+            "Suite B 128 bit mode allowing 192 bit algorithms"}, \
+        { "suiteB_192", OPT_V_SUITEB_192, '-', "Suite B 192 bit only mode" }, \
         { "partial_chain", OPT_V_PARTIAL_CHAIN, '-' }, \
         { "no_alt_chains", OPT_V_NO_ALT_CHAINS, '-', "Only use the first cert chain found" }, \
         { "no_check_time", OPT_V_NO_CHECK_TIME, '-', "Do not check validity against current time" }
@@ -262,12 +274,15 @@ void wait_for_async(SSL *s);
         OPT_X__LAST
 
 # define OPT_X_OPTIONS \
-        { "xkey", OPT_X_KEY, '<' }, \
-        { "xcert", OPT_X_CERT, '<' }, \
-        { "xchain", OPT_X_CHAIN, '<' }, \
-        { "xchain_build", OPT_X_CHAIN_BUILD, '-' }, \
-        { "xcertform", OPT_X_CERTFORM, 'F' }, \
-        { "xkeyform", OPT_X_KEYFORM, 'F' }
+        { "xkey", OPT_X_KEY, '<', "key for Extended certificates"}, \
+        { "xcert", OPT_X_CERT, '<', "cert for Extended certificates"}, \
+        { "xchain", OPT_X_CHAIN, '<', "chain for Extended certificates"}, \
+        { "xchain_build", OPT_X_CHAIN_BUILD, '-', \
+            "build certificate chain for the extended certificates"}, \
+        { "xcertform", OPT_X_CERTFORM, 'F', \
+            "format of Extended certificate (PEM or DER) PEM default " }, \
+        { "xkeyform", OPT_X_KEYFORM, 'F', \
+            "format of Exnteded certificate's key (PEM or DER) PEM default"}
 
 # define OPT_X_CASES \
         OPT_X__FIRST: case OPT_X__LAST: break; \
@@ -285,7 +300,7 @@ void wait_for_async(SSL *s);
 # define OPT_S_ENUM \
         OPT_S__FIRST=3000, \
         OPT_S_NOSSL3, OPT_S_NOTLS1, OPT_S_NOTLS1_1, OPT_S_NOTLS1_2, \
-        OPT_S_BUGS, OPT_S_NO_COMP, OPT_S_ECDHSINGLE, OPT_S_NOTICKET, \
+        OPT_S_BUGS, OPT_S_NO_COMP, OPT_S_NOTICKET, \
         OPT_S_SERVERPREF, OPT_S_LEGACYRENEG, OPT_S_LEGACYCONN, \
         OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_STRICT, OPT_S_SIGALGS, \
         OPT_S_CLIENTSIGALGS, OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, \
@@ -293,21 +308,25 @@ void wait_for_async(SSL *s);
         OPT_S__LAST
 
 # define OPT_S_OPTIONS \
-        {"no_ssl3", OPT_S_NOSSL3, '-' }, \
-        {"no_tls1", OPT_S_NOTLS1, '-' }, \
-        {"no_tls1_1", OPT_S_NOTLS1_1, '-' }, \
-        {"no_tls1_2", OPT_S_NOTLS1_2, '-' }, \
-        {"bugs", OPT_S_BUGS, '-' }, \
+        {"no_ssl3", OPT_S_NOSSL3, '-',"Just disable SSLv3" }, \
+        {"no_tls1", OPT_S_NOTLS1, '-', "Just disable TLSv1"}, \
+        {"no_tls1_1", OPT_S_NOTLS1_1, '-', "Just disable TLSv1.1" }, \
+        {"no_tls1_2", OPT_S_NOTLS1_2, '-', "Just disable TLSv1.2"}, \
+        {"bugs", OPT_S_BUGS, '-', "Turn on SSL bug compatibility"}, \
         {"no_comp", OPT_S_NO_COMP, '-', "Disable SSL/TLS compression (default)" }, \
         {"comp", OPT_S_COMP, '-', "Use SSL/TLS-level compression" }, \
-        {"ecdh_single", OPT_S_ECDHSINGLE, '-' }, \
-        {"no_ticket", OPT_S_NOTICKET, '-' }, \
-        {"serverpref", OPT_S_SERVERPREF, '-' }, \
-        {"legacy_renegotiation", OPT_S_LEGACYRENEG, '-' }, \
-        {"legacy_server_connect", OPT_S_LEGACYCONN, '-' }, \
-        {"no_resumption_on_reneg", OPT_S_ONRESUMP, '-' }, \
+        {"no_ticket", OPT_S_NOTICKET, '-', \
+            "Disable use of TLS session tickets"}, \
+        {"serverpref", OPT_S_SERVERPREF, '-', "Use server's cipher preferences"}, \
+        {"legacy_renegotiation", OPT_S_LEGACYRENEG, '-', \
+            "Enable use of legacy renegotiation (dangerous)"}, \
+        {"legacy_server_connect", OPT_S_LEGACYCONN, '-', \
+            "Allow initial connection to servers that don't support RI"}, \
+        {"no_resumption_on_reneg", OPT_S_ONRESUMP, '-', \
+            "Disallow session resumption on renegotiation"}, \
         {"no_legacy_server_connect", OPT_S_NOLEGACYCONN, '-' }, \
-        {"strict", OPT_S_STRICT, '-' }, \
+        {"strict", OPT_S_STRICT, '-', \
+            "Enforce strict certificate checks as per TLS standard"}, \
         {"sigalgs", OPT_S_SIGALGS, 's', \
             "Signature algorithms to support (colon-separated list)" }, \
         {"client_sigalgs", OPT_S_CLIENTSIGALGS, 's', \
@@ -318,8 +337,10 @@ void wait_for_async(SSL *s);
         {"named_curve", OPT_S_NAMEDCURVE, 's', \
             "Elliptic curve used for ECDHE (server-side only)" }, \
         {"cipher", OPT_S_CIPHER, 's', }, \
-        {"dhparam", OPT_S_DHPARAM, '<' }, \
-        {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-' }
+        {"dhparam", OPT_S_DHPARAM, '<', \
+            "DH parameter file to use, in cert file if not specified"}, \
+        {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \
+            "Perform all sorts of protocol violations for testing purposes"}
 
 # define OPT_S_CASES \
         OPT_S__FIRST: case OPT_S__LAST: break; \
@@ -330,7 +351,6 @@ void wait_for_async(SSL *s);
         case OPT_S_BUGS: \
         case OPT_S_NO_COMP: \
         case OPT_S_COMP: \
-        case OPT_S_ECDHSINGLE: \
         case OPT_S_NOTICKET: \
         case OPT_S_SERVERPREF: \
         case OPT_S_LEGACYRENEG: \

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -217,7 +217,8 @@ void wait_for_async(SSL *s);
         { "inhibit_map", OPT_V_INHIBIT_MAP, '-', "Set the \"inhibit policy mapping\"" }, \
         { "x509_strict", OPT_V_X509_STRICT, '-', \
             "Strictly apply X509 rules in verification"}, \
-        { "extended_crl", OPT_V_EXTENDED_CRL, '-' }, \
+        { "extended_crl", OPT_V_EXTENDED_CRL, '-', \
+       	    "Enable extended CRL features such as indirect CRLs, alternate CRL signing keys"}, \
         { "use_deltas", OPT_V_USE_DELTAS, '-', \
             "Enable indirect CRLs and CRLs signed by different keys"}, \
         { "policy_print", OPT_V_POLICY_PRINT, '-', "Notify callback that policy is OK"}, \
@@ -229,7 +230,9 @@ void wait_for_async(SSL *s);
         { "suiteB_128", OPT_V_SUITEB_128, '-', \
             "Suite B 128 bit mode allowing 192 bit algorithms"}, \
         { "suiteB_192", OPT_V_SUITEB_192, '-', "Suite B 192 bit only mode" }, \
-        { "partial_chain", OPT_V_PARTIAL_CHAIN, '-' }, \
+        { "partial_chain", OPT_V_PARTIAL_CHAIN, '-', \
+       	    "verification succeeds even if a complete chain cannot be built, "}, \
+        {OPT_MORE_STR, 0, 0, "provided a chain to a trusted certificate can be constructed"}, \
         { "no_alt_chains", OPT_V_NO_ALT_CHAINS, '-', "Only use the first cert chain found" }, \
         { "no_check_time", OPT_V_NO_CHECK_TIME, '-', "Do not check validity against current time" }
 
@@ -324,7 +327,8 @@ void wait_for_async(SSL *s);
             "Allow initial connection to servers that don't support RI"}, \
         {"no_resumption_on_reneg", OPT_S_ONRESUMP, '-', \
             "Disallow session resumption on renegotiation"}, \
-        {"no_legacy_server_connect", OPT_S_NOLEGACYCONN, '-' }, \
+        {"no_legacy_server_connect", OPT_S_NOLEGACYCONN, '-', \
+            "Disallow initial connection to servers that don't support RI"}, \
         {"strict", OPT_S_STRICT, '-', \
             "Enforce strict certificate checks as per TLS standard"}, \
         {"sigalgs", OPT_S_SIGALGS, 's', \
@@ -336,7 +340,7 @@ void wait_for_async(SSL *s);
             "Elliptic curves to advertise (colon-separated list)" }, \
         {"named_curve", OPT_S_NAMEDCURVE, 's', \
             "Elliptic curve used for ECDHE (server-side only)" }, \
-        {"cipher", OPT_S_CIPHER, 's', }, \
+        {"cipher", OPT_S_CIPHER, 's', "Specify cipher list to be used"}, \
         {"dhparam", OPT_S_DHPARAM, '<', \
             "DH parameter file to use, in cert file if not specified"}, \
         {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -202,7 +202,7 @@ void wait_for_async(SSL *s);
         { "verify_hostname", OPT_V_VERIFY_HOSTNAME, 's', \
             "check peer certificate matches \"host\"" }, \
         { "verify_email", OPT_V_VERIFY_EMAIL, 's', \
-            "check peer certificate matches \"host\"" }, \
+            "check peer certificate matches \"email\"" }, \
         { "verify_ip", OPT_V_VERIFY_IP, 's', \
             "check peer certificate matches \"ipaddr\"" }, \
         { "ignore_critical", OPT_V_IGNORE_CRITICAL, '-', \

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -823,15 +823,18 @@ typedef enum OPTION_choice {
 
 OPTIONS s_server_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
-    {"port", OPT_PORT, 'p'},
+    {"port", OPT_PORT, 'p',
+     "TCP/IP port to listen on for connections (default is " PORT ")"},
     {"accept", OPT_ACCEPT, 's',
-     "TCP/IP port or service to accept on (default is " PORT ")"},
+     "TCP/IP optional host and port to accept on (default is " PORT ")"},
 #ifdef AF_UNIX
     {"unix", OPT_UNIX, 's', "Unix domain socket to accept on"},
 #endif
     {"4", OPT_4, '-', "Use IPv4 only"},
     {"6", OPT_6, '-', "Use IPv6 only"},
+#ifdef AF_UNIX
     {"unlink", OPT_UNLINK, '-', "For -unix, unlink existing socket first"},
+#endif
     {"context", OPT_CONTEXT, 's', "Set session ID context"},
     {"verify", OPT_VERIFY, 'n', "Turn on peer certificate verification"},
     {"Verify", OPT_UPPER_V_VERIFY, 'n',
@@ -860,7 +863,8 @@ OPTIONS s_server_options[] = {
     {"crlf", OPT_CRLF, '-', "Convert LF from terminal into CRLF"},
     {"debug", OPT_DEBUG, '-', "Print more output"},
     {"msg", OPT_MSG, '-', "Show protocol messages"},
-    {"msgfile", OPT_MSGFILE, '>'},
+    {"msgfile", OPT_MSGFILE, '>',
+     "File to send output of -msg or -trace, instead of stdout"},
     {"state", OPT_STATE, '-', "Print the SSL states"},
     {"CAfile", OPT_CAFILE, '<', "PEM format file of CA's"},
     {"CApath", OPT_CAPATH, '/', "PEM format directory of CA's"},
@@ -893,33 +897,50 @@ OPTIONS s_server_options[] = {
      "Export keying material using label"},
     {"keymatexportlen", OPT_KEYMATEXPORTLEN, 'p',
      "Export len bytes of keying material (default 20)"},
-    {"CRL", OPT_CRL, '<'},
-    {"crl_download", OPT_CRL_DOWNLOAD, '-'},
-    {"cert_chain", OPT_CERT_CHAIN, '<'},
-    {"dcert_chain", OPT_DCERT_CHAIN, '<'},
-    {"chainCApath", OPT_CHAINCAPATH, '/'},
-    {"verifyCApath", OPT_VERIFYCAPATH, '/'},
-    {"no_cache", OPT_NO_CACHE, '-'},
-    {"ext_cache", OPT_EXT_CACHE, '-'},
-    {"CRLform", OPT_CRLFORM, 'F'},
-    {"verify_return_error", OPT_VERIFY_RET_ERROR, '-'},
-    {"verify_quiet", OPT_VERIFY_QUIET, '-'},
-    {"build_chain", OPT_BUILD_CHAIN, '-'},
-    {"chainCAfile", OPT_CHAINCAFILE, '<'},
-    {"verifyCAfile", OPT_VERIFYCAFILE, '<'},
-    {"ign_eof", OPT_IGN_EOF, '-'},
-    {"no_ign_eof", OPT_NO_IGN_EOF, '-'},
-    {"status", OPT_STATUS, '-'},
-    {"status_verbose", OPT_STATUS_VERBOSE, '-'},
-    {"status_timeout", OPT_STATUS_TIMEOUT, 'n'},
-    {"status_url", OPT_STATUS_URL, 's'},
-    {"trace", OPT_TRACE, '-'},
-    {"security_debug", OPT_SECURITY_DEBUG, '-'},
-    {"security_debug_verbose", OPT_SECURITY_DEBUG_VERBOSE, '-'},
+    {"CRL", OPT_CRL, '<', "CRL file to use"},
+    {"crl_download", OPT_CRL_DOWNLOAD, '-',
+     "Download CRL from distribution points"},
+    {"cert_chain", OPT_CERT_CHAIN, '<',
+     "certificate chain file in PEM format"},
+    {"dcert_chain", OPT_DCERT_CHAIN, '<',
+     "second certificate chain file in PEM format"},
+    {"chainCApath", OPT_CHAINCAPATH, '/',
+     "use dir as certificate store path to build CA certificate chain"},
+    {"verifyCApath", OPT_VERIFYCAPATH, '/',
+     "use dir as certificate store path to verify CA certificate"},
+    {"no_cache", OPT_NO_CACHE, '-', "Disable session cache"},
+    {"ext_cache", OPT_EXT_CACHE, '-',
+     "Disable internal cache, setup and use external cache"},
+    {"CRLform", OPT_CRLFORM, 'F', "CRL format (PEM or DER) PEM is default" },
+    {"verify_return_error", OPT_VERIFY_RET_ERROR, '-',
+     "Close connection on verification error"},
+    {"verify_quiet", OPT_VERIFY_QUIET, '-',
+     "No verify output except verify errors"},
+    {"build_chain", OPT_BUILD_CHAIN, '-', "Build certificate chain"},
+    {"chainCAfile", OPT_CHAINCAFILE, '<',
+     "CA file for certificate chain (PEM format)"},
+    {"verifyCAfile", OPT_VERIFYCAFILE, '<',
+     "CA file for certificate verification (PEM format)"},
+    {"ign_eof", OPT_IGN_EOF, '-', "ignore input eof (default when -quiet)"},
+    {"no_ign_eof", OPT_NO_IGN_EOF, '-', "Do not ignore input eof"},
+    {"status", OPT_STATUS, '-', "Request certificate status from server"},
+    {"status_verbose", OPT_STATUS_VERBOSE, '-',
+     "Print more output in certificate status callback"},
+    {"status_timeout", OPT_STATUS_TIMEOUT, 'n',
+     "Status request responder timeout"},
+    {"status_url", OPT_STATUS_URL, 's', "Status request fallback URL"},
+#ifndef OPENSSL_NO_SSL_TRACE
+    {"trace", OPT_TRACE, '-', "trace protocol messages"},
+#endif
+    {"security_debug", OPT_SECURITY_DEBUG, '-',
+     "Print output from SSL/TLS security framework"},
+    {"security_debug_verbose", OPT_SECURITY_DEBUG_VERBOSE, '-',
+     "Print more output from SSL/TLS security framework"},
     {"brief", OPT_BRIEF, '-'},
     {"rev", OPT_REV, '-'},
     {"async", OPT_ASYNC, '-', "Operate in asynchronous mode"},
-    {"ssl_config", OPT_SSL_CONFIG, 's'},
+    {"ssl_config", OPT_SSL_CONFIG, 's', \
+     "Configure SSL_CTX using the configuration 'val'"},
     OPT_S_OPTIONS,
     OPT_V_OPTIONS,
     OPT_X_OPTIONS,
@@ -951,7 +972,7 @@ OPTIONS s_server_options[] = {
     {"tls1_2", OPT_TLS1_2, '-', "just talk TLSv1.2"},
 #endif
 #ifndef OPENSSL_NO_DTLS
-    {"dtls", OPT_DTLS, '-'},
+    {"dtls", OPT_DTLS, '-', "Use any DTLS version"},
     {"timeout", OPT_TIMEOUT, '-', "Enable timeouts"},
     {"mtu", OPT_MTU, 'p', "Set link layer MTU"},
     {"chain", OPT_CHAIN, '-', "Read a certificate chain"},
@@ -978,7 +999,7 @@ OPTIONS s_server_options[] = {
      "Set the advertised protocols for the ALPN extension (comma-separated list)"},
 #endif
 #ifndef OPENSSL_NO_ENGINE
-    {"engine", OPT_ENGINE, 's'},
+    {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
 #endif
     {NULL}
 };
@@ -1680,12 +1701,12 @@ int s_server_main(int argc, char *argv[])
     }
 
     ctx = SSL_CTX_new(meth);
-    if (sdebug)
-        ssl_ctx_security_debug(ctx, sdebug);
     if (ctx == NULL) {
         ERR_print_errors(bio_err);
         goto end;
     }
+    if (sdebug)
+        ssl_ctx_security_debug(ctx, sdebug);
     if (ssl_config) {
         if (SSL_CTX_config(ctx, ssl_config) == 0) {
             BIO_printf(bio_err, "Error using configuration \"%s\"\n",

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -936,8 +936,10 @@ OPTIONS s_server_options[] = {
      "Print output from SSL/TLS security framework"},
     {"security_debug_verbose", OPT_SECURITY_DEBUG_VERBOSE, '-',
      "Print more output from SSL/TLS security framework"},
-    {"brief", OPT_BRIEF, '-'},
-    {"rev", OPT_REV, '-'},
+    {"brief", OPT_BRIEF, '-', \
+     "Restrict output to brief summary of connection parameters"},
+    {"rev", OPT_REV, '-',
+     "act as a simple test server which just sends back with the received text reversed"},
     {"async", OPT_ASYNC, '-', "Operate in asynchronous mode"},
     {"ssl_config", OPT_SSL_CONFIG, 's', \
      "Configure SSL_CTX using the configuration 'val'"},


### PR DESCRIPTION
* added missing help option messages
* ecdh_single option is removed as it is a no-op and not an option
supported in earlier versions
* ssl_ctx_security_debug() was invoked before ctx check for NULL
* trusted_first option can be removed, as it is always enabled in 1.1.
But not removed the option, require confirmation.