### PR TITLE
Minor tidying around the ocsp app

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -521,7 +521,7 @@ int ocsp_main(int argc, char **argv)
             goto end;
     }
 
-    if (rsignfile && !rdb) {
+    if (rsignfile) {
         if (!rkeyfile)
             rkeyfile = rsignfile;
         rsigner = load_cert(rsignfile, FORMAT_PEM,

--- a/doc/apps/ocsp.pod
+++ b/doc/apps/ocsp.pod
@@ -140,7 +140,7 @@ Additional certificates to include in the signed request.
 =item B<-nonce>, B<-no_nonce>
 
 Add an OCSP nonce extension to a request or disable OCSP nonce addition.
-Normally if an OCSP request is input using the B<respin> option no
+Normally if an OCSP request is input using the B<reqin> option no
 nonce is added: using the B<nonce> option will force addition of a nonce.
 If an OCSP request is being created (using B<cert> and B<serial> options)
 a nonce is automatically added specifying B<no_nonce> overrides this.
@@ -167,7 +167,8 @@ specify the responder URL. Both HTTP and HTTPS (SSL/TLS) URLs can be specified.
 
 if the B<host> option is present then the OCSP request is sent to the host
 B<hostname> on port B<port>. B<path> specifies the HTTP path name to use
-or "/" by default.
+or "/" by default.  This is equivalent to specifying B<-url> with scheme
+http:// and the given hostname, port, and pathname.
 
 =item B<-header name=value>
 
@@ -297,7 +298,7 @@ information.
 If the B<index> option is specified the B<ocsp> utility is in responder mode, otherwise
 it is in client mode. The request(s) the responder processes can be either specified on
 the command line (using B<issuer> and B<serial> options), supplied in a file (using the
-B<respin> option) or via external OCSP clients (if B<port> or B<url> is specified).
+B<reqin> option) or via external OCSP clients (if B<port> or B<url> is specified).
 
 If the B<index> option is present then the B<CA> and B<rsigner> options must also be
 present.
@@ -402,7 +403,7 @@ format of revocation is also inefficient for large quantities of revocation
 data.
 
 It is possible to run the B<ocsp> application in responder mode via a CGI
-script using the B<respin> and B<respout> options.
+script using the B<reqin> and B<respout> options.
 
 =head1 EXAMPLES
 
@@ -411,14 +412,14 @@ Create an OCSP request and write it to a file:
  openssl ocsp -issuer issuer.pem -cert c1.pem -cert c2.pem -reqout req.der
 
 Send a query to an OCSP responder with URL http://ocsp.myhost.com/ save the 
-response to a file and print it out in text form
+response to a file, print it out in text form, and verify the response:
 
  openssl ocsp -issuer issuer.pem -cert c1.pem -cert c2.pem \
      -url http://ocsp.myhost.com/ -resp_text -respout resp.der
 
 Read in an OCSP response and print out text form:
 
- openssl ocsp -respin resp.der -text
+ openssl ocsp -respin resp.der -text -noverify
 
 OCSP server on port 8888 using a standard B<ca> configuration, and a separate
 responder certificate. All requests and responses are printed to a file.
@@ -431,13 +432,13 @@ As above but exit after processing one request:
  openssl ocsp -index demoCA/index.txt -port 8888 -rsigner rcert.pem -CA demoCA/cacert.pem
      -nrequest 1
 
-Query status information using internally generated request:
+Query status information using an internally generated request:
 
  openssl ocsp -index demoCA/index.txt -rsigner rcert.pem -CA demoCA/cacert.pem
      -issuer demoCA/cacert.pem -serial 1
 
-Query status information using request read from a file, write response to a
-second file.
+Query status information using request read from a file, and write the response
+to a second file.
 
  openssl ocsp -index demoCA/index.txt -rsigner rcert.pem -CA demoCA/cacert.pem
      -reqin req.der -respout resp.der


### PR DESCRIPTION
Some grammar and clarity fixes for the man page and remove an always-true conditional.

I'm still unsure if requiring -noverify for just doing a DER-to-text response conversion is the best option; see the email thread on openssl-dev.