### PR TITLE
Rewrite "min" in natural way

### DIFF
--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -117,8 +117,8 @@ char *X509_NAME_oneline(X509_NAME *a, char *buf, int len)
             type == V_ASN1_PRINTABLESTRING ||
             type == V_ASN1_TELETEXSTRING ||
             type == V_ASN1_VISIBLESTRING || type == V_ASN1_IA5STRING) {
-            ascii2ebcdic(ebcdic_buf, q, (num > sizeof ebcdic_buf)
-                         ? sizeof ebcdic_buf : num);
+            ascii2ebcdic(ebcdic_buf, q, ((sizeof(ebcdic_buf)) < num)
+                         ? sizeof(ebcdic_buf) : num);
             q = ebcdic_buf;
         }
 #endif


### PR DESCRIPTION
This expression is what "min" function does and it's usually written as `a < b ? a : b` but original code has `b > a ? a : b` which is exactly the same bu harder to read.