### PR TITLE
Defines OSSL_SSIZE_MAX

### DIFF
--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -71,14 +71,6 @@
 
 #include "e_os.h"
 
-/* VxWorks defines SSIZE_MAX with an empty value causing compile errors */
-#if defined(OPENSSL_SYS_VXWORKS)
-# undef SSIZE_MAX
-#endif
-#ifndef SSIZE_MAX
-# define SSIZE_MAX INT_MAX
-#endif
-
 static int bio_new(BIO *bio);
 static int bio_free(BIO *bio);
 static int bio_read(BIO *bio, char *buf, int size);
@@ -294,8 +286,8 @@ static ossl_ssize_t bio_nread(BIO *bio, char **buf, size_t num_)
     struct bio_bio_st *b, *peer_b;
     ossl_ssize_t num, available;
 
-    if (num_ > SSIZE_MAX)
-        num = SSIZE_MAX;
+    if (num_ > OSSL_SSIZE_MAX)
+        num = OSSL_SSIZE_MAX;
     else
         num = (ossl_ssize_t) num_;
 
@@ -450,8 +442,8 @@ static ossl_ssize_t bio_nwrite(BIO *bio, char **buf, size_t num_)
     struct bio_bio_st *b;
     ossl_ssize_t num, space;
 
-    if (num_ > SSIZE_MAX)
-        num = SSIZE_MAX;
+    if (num_ > OSSL_SSIZE_MAX)
+        num = OSSL_SSIZE_MAX;
     else
         num = (ossl_ssize_t) num_;
 

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -262,17 +262,21 @@ extern "C" {
 # ifdef _WIN32
 #  ifdef _WIN64
 #   define ossl_ssize_t __int64
+#   define OSSL_SSIZE_MAX _I64_MAX
 #  else
 #   define ossl_ssize_t int
+#   define OSSL_SSIZE_MAX INT_MAX
 #  endif
 # endif
 
 # if defined(__ultrix) && !defined(ssize_t)
 #  define ossl_ssize_t int
+#  define OSSL_SSIZE_MAX INT_MAX
 # endif
 
 # ifndef ossl_ssize_t
 #  define ossl_ssize_t ssize_t
+#  define OSSL_SSIZE_MAX SSIZE_MAX
 # endif
 
 # ifdef DEBUG_UNUSED


### PR DESCRIPTION
ossl_ssize_t varies in size, depending on the platform, so it is useful to also have its max value defined.

Updated bss_bio.c to use this, instead of defining SSIZE_MAX itself (and getting it wrong on 64-bit platforms that don't define SSIZE_MAX).