### PR TITLE
Remove or ignore unused arguments.

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -218,8 +218,9 @@ int chopup_args(ARGS *arg, char *buf)
 }
 
 #ifndef APP_INIT
-int app_init(long mesgwin)
+int app_init(long _1)
 {
+    osslunused1();
     return (1);
 }
 #endif
@@ -677,8 +678,7 @@ int load_cert_crl_http(const char *url, X509 **pcert, X509_CRL **pcrl)
     return rv;
 }
 
-X509 *load_cert(const char *file, int format,
-                const char *pass, ENGINE *e, const char *cert_descrip)
+X509 *load_cert(const char *file, int format, const char *cert_descrip)
 {
     X509 *x = NULL;
     BIO *cert;
@@ -907,7 +907,7 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
 }
 
 static int load_certs_crls(const char *file, int format,
-                           const char *pass, ENGINE *e, const char *desc,
+                           const char *pass, const char *desc,
                            STACK_OF(X509) **pcerts,
                            STACK_OF(X509_CRL) **pcrls)
 {
@@ -1005,18 +1005,18 @@ void* app_malloc(int sz, const char *what)
  * Initialize or extend, if *certs != NULL,  a certificate stack.
  */
 int load_certs(const char *file, STACK_OF(X509) **certs, int format,
-               const char *pass, ENGINE *e, const char *desc)
+               const char *pass, const char *desc)
 {
-    return load_certs_crls(file, format, pass, e, desc, certs, NULL);
+    return load_certs_crls(file, format, pass, desc, certs, NULL);
 }
 
 /*
  * Initialize or extend, if *crls != NULL,  a certificate stack.
  */
 int load_crls(const char *file, STACK_OF(X509_CRL) **crls, int format,
-              const char *pass, ENGINE *e, const char *desc)
+              const char *pass, const char *desc)
 {
-    return load_certs_crls(file, format, pass, e, desc, NULL, crls);
+    return load_certs_crls(file, format, pass, desc, NULL, crls);
 }
 
 #define X509V3_EXT_UNKNOWN_MASK         (0xfL << 16)
@@ -1303,7 +1303,7 @@ X509_STORE *setup_verify(char *CAfile, char *CApath, int noCAfile, int noCApath)
 
 #ifndef OPENSSL_NO_ENGINE
 /* Try to load an engine in a shareable library */
-static ENGINE *try_load_engine(const char *engine, int debug)
+static ENGINE *try_load_engine(const char *engine)
 {
     ENGINE *e = ENGINE_by_id("dynamic");
     if (e) {
@@ -1327,7 +1327,7 @@ ENGINE *setup_engine(const char *engine, int debug)
             return NULL;
         }
         if ((e = ENGINE_by_id(engine)) == NULL
-            && (e = try_load_engine(engine, debug)) == NULL) {
+            && (e = try_load_engine(engine)) == NULL) {
             BIO_printf(bio_err, "invalid engine \"%s\"\n", engine);
             ERR_print_errors(bio_err);
             return NULL;
@@ -2321,13 +2321,14 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
  * anything.
  */
 
-static STACK_OF(X509_CRL) *crls_http_cb(X509_STORE_CTX *ctx, X509_NAME *nm)
+static STACK_OF(X509_CRL) *crls_http_cb(X509_STORE_CTX *ctx, X509_NAME *_1)
 {
     X509 *x;
     STACK_OF(X509_CRL) *crls = NULL;
     X509_CRL *crl;
     STACK_OF(DIST_POINT) *crldp;
 
+    osslunused1();
     crls = sk_X509_CRL_new_null();
     if (!crls)
         return NULL;

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -475,8 +475,7 @@ int set_ext_copy(int *copy_type, const char *arg);
 int copy_extensions(X509 *x, X509_REQ *req, int copy_type);
 int app_passwd(char *arg1, char *arg2, char **pass1, char **pass2);
 int add_oid_section(CONF *conf);
-X509 *load_cert(const char *file, int format,
-                const char *pass, ENGINE *e, const char *cert_descrip);
+X509 *load_cert(const char *file, int format, const char *cert_descrip);
 X509_CRL *load_crl(const char *infile, int format);
 int load_cert_crl_http(const char *url, X509 **pcert, X509_CRL **pcrl);
 EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
@@ -484,9 +483,9 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
 EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
                       const char *pass, ENGINE *e, const char *key_descrip);
 int load_certs(const char *file, STACK_OF(X509) **certs, int format,
-               const char *pass, ENGINE *e, const char *cert_descrip);
+               const char *pass, const char *cert_descrip);
 int load_crls(const char *file, STACK_OF(X509_CRL) **crls, int format,
-              const char *pass, ENGINE *e, const char *cert_descrip);
+              const char *pass, const char *cert_descrip);
 X509_STORE *setup_verify(char *CAfile, char *CApath,
                          int noCAfile, int noCApath);
 int ctx_set_verify_locations(SSL_CTX *ctx, const char *CAfile,

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -153,8 +153,7 @@ static int certify_cert(X509 **xret, char *infile, EVP_PKEY *pkey, X509 *x509,
                         int multirdn, int email_dn, char *startdate,
                         char *enddate, long days, int batch, char *ext_sect,
                         CONF *conf, int verbose, unsigned long certopt,
-                        unsigned long nameopt, int default_op, int ext_copy,
-                        ENGINE *e);
+                        unsigned long nameopt, int default_op, int ext_copy);
 static int certify_spkac(X509 **xret, char *infile, EVP_PKEY *pkey,
                          X509 *x509, const EVP_MD *dgst,
                          STACK_OF(OPENSSL_STRING) *sigopts,
@@ -607,7 +606,7 @@ end_of_options:
             lookup_fail(section, ENV_CERTIFICATE);
             goto end;
         }
-        x509 = load_cert(certfile, FORMAT_PEM, NULL, e, "CA certificate");
+        x509 = load_cert(certfile, FORMAT_PEM, "CA certificate");
         if (x509 == NULL)
             goto end;
 
@@ -964,7 +963,7 @@ end_of_options:
                              db, serial, subj, chtype, multirdn, email_dn,
                              startdate, enddate, days, batch, extensions,
                              conf, verbose, certopt, nameopt, default_op,
-                             ext_copy, e);
+                             ext_copy);
             if (j < 0)
                 goto end;
             if (j > 0) {
@@ -1265,7 +1264,7 @@ end_of_options:
             goto end;
         } else {
             X509 *revcert;
-            revcert = load_cert(infile, FORMAT_PEM, NULL, e, infile);
+            revcert = load_cert(infile, FORMAT_PEM, infile);
             if (revcert == NULL)
                 goto end;
             if (dorevoke == 2)
@@ -1391,15 +1390,14 @@ static int certify_cert(X509 **xret, char *infile, EVP_PKEY *pkey, X509 *x509,
                         int multirdn, int email_dn, char *startdate,
                         char *enddate, long days, int batch, char *ext_sect,
                         CONF *lconf, int verbose, unsigned long certopt,
-                        unsigned long nameopt, int default_op, int ext_copy,
-                        ENGINE *e)
+                        unsigned long nameopt, int default_op, int ext_copy)
 {
     X509 *req = NULL;
     X509_REQ *rreq = NULL;
     EVP_PKEY *pktmp = NULL;
     int ok = -1, i;
 
-    if ((req = load_cert(infile, FORMAT_PEM, NULL, e, infile)) == NULL)
+    if ((req = load_cert(infile, FORMAT_PEM, infile)) == NULL)
         goto end;
     if (verbose)
         X509_print(bio_err, req);

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -100,11 +100,11 @@ OPTIONS ciphers_options[] = {
 };
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int dummy_psk(SSL *ssl, const char *hint, char *identity,
-                              unsigned int max_identity_len,
-                              unsigned char *psk,
-                              unsigned int max_psk_len)
+static unsigned int dummy_psk(SSL *_1, const char *_2, char *_3,
+                              unsigned int _4, unsigned char *_5,
+                              unsigned int _6)
 {
+    osslunused6();
     return 0;
 }
 #endif

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -550,7 +550,7 @@ int cms_main(int argc, char **argv)
             if (operation == SMIME_ENCRYPT) {
                 if (encerts == NULL && (encerts = sk_X509_new_null()) == NULL)
                     goto end;
-                cert = load_cert(opt_arg(), FORMAT_PEM, NULL, e,
+                cert = load_cert(opt_arg(), FORMAT_PEM,
                                  "recipient certificate file");
                 if (cert == NULL)
                     goto end;
@@ -725,7 +725,7 @@ int cms_main(int argc, char **argv)
             if ((encerts = sk_X509_new_null()) == NULL)
                 goto end;
         while (*argv) {
-            if ((cert = load_cert(*argv, FORMAT_PEM, NULL, e,
+            if ((cert = load_cert(*argv, FORMAT_PEM,
                                   "recipient certificate file")) == NULL)
                 goto end;
             sk_X509_push(encerts, cert);
@@ -735,7 +735,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (certfile) {
-        if (!load_certs(certfile, &other, FORMAT_PEM, NULL, e,
+        if (!load_certs(certfile, &other, FORMAT_PEM, NULL,
                         "certificate file")) {
             ERR_print_errors(bio_err);
             goto end;
@@ -743,7 +743,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (recipfile && (operation == SMIME_DECRYPT)) {
-        if ((recip = load_cert(recipfile, FORMAT_PEM, NULL, e,
+        if ((recip = load_cert(recipfile, FORMAT_PEM,
                                "recipient certificate file")) == NULL) {
             ERR_print_errors(bio_err);
             goto end;
@@ -751,7 +751,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (operation == SMIME_SIGN_RECEIPT) {
-        if ((signer = load_cert(signerfile, FORMAT_PEM, NULL, e,
+        if ((signer = load_cert(signerfile, FORMAT_PEM,
                                 "receipt signer certificate file")) == NULL) {
             ERR_print_errors(bio_err);
             goto end;
@@ -968,8 +968,7 @@ int cms_main(int argc, char **argv)
             signerfile = sk_OPENSSL_STRING_value(sksigners, i);
             keyfile = sk_OPENSSL_STRING_value(skkeys, i);
 
-            signer = load_cert(signerfile, FORMAT_PEM, NULL,
-                               e, "signer certificate");
+            signer = load_cert(signerfile, FORMAT_PEM, "signer certificate");
             if (!signer)
                 goto end;
             key = load_key(keyfile, keyform, 0, passin, e, "signing key file");

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -73,7 +73,7 @@
 int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
           EVP_PKEY *key, unsigned char *sigin, int siglen,
           const char *sig_name, const char *md_name,
-          const char *file, BIO *bmd);
+          const char *file);
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -403,7 +403,7 @@ int dgst_main(int argc, char **argv)
     if (argc == 0) {
         BIO_set_fp(in, stdin, BIO_NOCLOSE);
         ret = do_fp(out, buf, inp, separator, out_bin, sigkey, sigbuf,
-                    siglen, NULL, NULL, "stdin", bmd);
+                    siglen, NULL, NULL, "stdin");
     } else {
         const char *md_name = NULL, *sig_name = NULL;
         if (!out_bin) {
@@ -426,7 +426,7 @@ int dgst_main(int argc, char **argv)
                 continue;
             } else
                 r = do_fp(out, buf, inp, separator, out_bin, sigkey, sigbuf,
-                          siglen, sig_name, md_name, argv[i], bmd);
+                          siglen, sig_name, md_name, argv[i]);
             if (r)
                 ret = r;
             (void)BIO_reset(bmd);
@@ -448,7 +448,7 @@ int dgst_main(int argc, char **argv)
 int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
           EVP_PKEY *key, unsigned char *sigin, int siglen,
           const char *sig_name, const char *md_name,
-          const char *file, BIO *bmd)
+          const char *file)
 {
     size_t len;
     int i;

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -430,10 +430,11 @@ int dhparam_main(int argc, char **argv)
     return (ret);
 }
 
-static int dh_cb(int p, int n, BN_GENCB *cb)
+static int dh_cb(int p, int _1, BN_GENCB *cb)
 {
     char c = '*';
 
+    osslunused1();
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -329,10 +329,11 @@ int dsaparam_main(int argc, char **argv)
     return (ret);
 }
 
-static int dsa_cb(int p, int n, BN_GENCB *cb)
+static int dsa_cb(int p, int _1, BN_GENCB *cb)
 {
     char c = '*';
 
+    osslunused1();
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -363,7 +363,7 @@ int ecparam_main(int argc, char **argv)
             goto end;
         if (!EC_GROUP_get_order(group, ec_order, NULL))
             goto end;
-        if (!EC_GROUP_get_cofactor(group, ec_cofactor, NULL))
+        if (!EC_GROUP_get_cofactor(group, ec_cofactor,  NULL))
             goto end;
 
         if (!ec_p || !ec_a || !ec_b || !ec_gen || !ec_order || !ec_cofactor)

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -94,8 +94,9 @@ OPTIONS engine_options[] = {
     {NULL}
 };
 
-static void identity(char *ptr)
+static void identity(char *_1)
 {
+    osslunused1();
 }
 
 static int append_buf(char **buf, int *size, const char *s)
@@ -269,10 +270,11 @@ static int util_verbose(ENGINE *e, int verbose, BIO *out, const char *indent)
 }
 
 static void util_do_cmds(ENGINE *e, STACK_OF(OPENSSL_STRING) *cmds,
-                         BIO *out, const char *indent)
+                         BIO *out, const char *_1)
 {
     int loop, res, num = sk_OPENSSL_STRING_num(cmds);
 
+    osslunused1();
     if (num < 0) {
         BIO_printf(out, "[Error]: internal stack error\n");
         return;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -218,10 +218,11 @@ int genrsa_main(int argc, char **argv)
     return (ret);
 }
 
-static int genrsa_cb(int p, int n, BN_GENCB *cb)
+static int genrsa_cb(int p, int _1, BN_GENCB *cb)
 {
     char c = '*';
 
+    osslunused1();
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -115,8 +115,7 @@ static void make_ocsp_response(OCSP_RESPONSE **resp, OCSP_REQUEST *req,
 
 static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser);
 static BIO *init_responder(const char *port);
-static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
-                        const char *port);
+static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio);
 static int send_ocsp_response(BIO *cbio, OCSP_RESPONSE *resp);
 static OCSP_RESPONSE *query_responder(BIO *cbio, const char *host,
                                       const char *path,
@@ -405,8 +404,7 @@ int ocsp_main(int argc, char **argv)
             path = opt_arg();
             break;
         case OPT_ISSUER:
-            issuer = load_cert(opt_arg(), FORMAT_PEM,
-                               NULL, NULL, "issuer certificate");
+            issuer = load_cert(opt_arg(), FORMAT_PEM, "issuer certificate");
             if (issuer == NULL)
                 goto end;
             if (issuers == NULL) {
@@ -417,8 +415,7 @@ int ocsp_main(int argc, char **argv)
             break;
         case OPT_CERT:
             X509_free(cert);
-            cert = load_cert(opt_arg(), FORMAT_PEM,
-                             NULL, NULL, "certificate");
+            cert = load_cert(opt_arg(), FORMAT_PEM, "certificate");
             if (cert == NULL)
                 goto end;
             if (cert_id_md == NULL)
@@ -524,16 +521,14 @@ int ocsp_main(int argc, char **argv)
     if (rsignfile) {
         if (!rkeyfile)
             rkeyfile = rsignfile;
-        rsigner = load_cert(rsignfile, FORMAT_PEM,
-                            NULL, NULL, "responder certificate");
+        rsigner = load_cert(rsignfile, FORMAT_PEM, "responder certificate");
         if (!rsigner) {
             BIO_printf(bio_err, "Error loading responder certificate\n");
             goto end;
         }
-        rca_cert = load_cert(rca_filename, FORMAT_PEM,
-                             NULL, NULL, "CA certificate");
+        rca_cert = load_cert(rca_filename, FORMAT_PEM, "CA certificate");
         if (rcertfile) {
-            if (!load_certs(rcertfile, &rother, FORMAT_PEM, NULL, NULL,
+            if (!load_certs(rcertfile, &rother, FORMAT_PEM, NULL,
                             "responder other certificates"))
                 goto end;
         }
@@ -548,7 +543,7 @@ int ocsp_main(int argc, char **argv)
  redo_accept:
 
     if (acbio) {
-        if (!do_responder(&req, &cbio, acbio, port))
+        if (!do_responder(&req, &cbio, acbio))
             goto end;
         if (!req) {
             resp =
@@ -570,14 +565,13 @@ int ocsp_main(int argc, char **argv)
     if (signfile) {
         if (!keyfile)
             keyfile = signfile;
-        signer = load_cert(signfile, FORMAT_PEM,
-                           NULL, NULL, "signer certificate");
+        signer = load_cert(signfile, FORMAT_PEM, "signer certificate");
         if (!signer) {
             BIO_printf(bio_err, "Error loading signer certificate\n");
             goto end;
         }
         if (sign_certfile) {
-            if (!load_certs(sign_certfile, &sign_other, FORMAT_PEM, NULL, NULL,
+            if (!load_certs(sign_certfile, &sign_other, FORMAT_PEM, NULL,
                             "signer certificates"))
                 goto end;
         }
@@ -700,7 +694,7 @@ int ocsp_main(int argc, char **argv)
     if (vpmtouched)
         X509_STORE_set1_param(store, vpm);
     if (verify_certfile) {
-        if (!load_certs(verify_certfile, &verify_other, FORMAT_PEM, NULL, NULL,
+        if (!load_certs(verify_certfile, &verify_other, FORMAT_PEM, NULL,
                         "validator certificate"))
             goto end;
     }
@@ -1076,8 +1070,7 @@ static int urldecode(char *p)
     return (int)(out - save);
 }
 
-static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
-                        const char *port)
+static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio)
 {
     int len;
     OCSP_REQUEST *req = NULL;

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -578,8 +578,9 @@ int help_main(int argc, char **argv)
     return 0;
 }
 
-int exit_main(int argc, char **argv)
+int exit_main(int _1, char **_2)
 {
+    osslunused2();
     return EXIT_THE_PROGRAM;
 }
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -395,7 +395,7 @@ int pkcs12_main(int argc, char **argv)
 
         /* Load in all certs in input file */
         if (!(options & NOCERTS)) {
-            if (!load_certs(infile, &certs, FORMAT_PEM, NULL, e,
+            if (!load_certs(infile, &certs, FORMAT_PEM, NULL,
                             "certificates"))
                 goto export_end;
 
@@ -424,7 +424,7 @@ int pkcs12_main(int argc, char **argv)
 
         /* Add any more certificates asked for */
         if (certfile) {
-            if (!load_certs(certfile, &certs, FORMAT_PEM, NULL, e,
+            if (!load_certs(certfile, &certs, FORMAT_PEM, NULL,
                             "certificates from certfile"))
                 goto export_end;
         }

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -389,7 +389,7 @@ static EVP_PKEY_CTX *init_ctx(int *pkeysize,
         break;
 
     case KEY_CERT:
-        x = load_cert(keyfile, keyform, NULL, e, "Certificate");
+        x = load_cert(keyfile, keyform, "Certificate");
         if (x) {
             pkey = X509_get_pubkey(x);
             X509_free(x);

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -229,7 +229,7 @@ int rsautl_main(int argc, char **argv)
         break;
 
     case KEY_CERT:
-        x = load_cert(keyfile, keyformat, NULL, e, "Certificate");
+        x = load_cert(keyfile, keyformat, "Certificate");
         if (x) {
             pkey = X509_get_pubkey(x);
             X509_free(x);

--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -149,11 +149,11 @@ typedef fd_mask fd_set;
 #define PORT            "4433"
 #define PROTOCOL        "tcp"
 
+typedef int (*do_server_cb)(int s, int stype, unsigned char *context);
 int do_server(int *accept_sock, const char *host, const char *port,
               int family, int type,
-              int (*cb) (const char *hostname, int s, int stype,
-                         unsigned char *context), unsigned char *context,
-              int naccept);
+              do_server_cb cb,
+              unsigned char *context, int naccept);
 #ifdef HEADER_X509_H
 int verify_callback(int ok, X509_STORE_CTX *ctx);
 #endif

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -495,11 +495,11 @@ int ssl_print_tmp_key(BIO *out, SSL *s)
 }
 
 long bio_dump_callback(BIO *bio, int cmd, const char *argp,
-                       int argi, long argl, long ret)
+                       int argi, long _1, long ret)
 {
-    BIO *out;
+    BIO *out = (BIO *)BIO_get_callback_arg(bio);
 
-    out = (BIO *)BIO_get_callback_arg(bio);
+    osslunused1();
     if (out == NULL)
         return (ret);
 
@@ -611,7 +611,7 @@ static STRINT_PAIR handshakes[] = {
 };
 
 void msg_cb(int write_p, int version, int content_type, const void *buf,
-            size_t len, SSL *ssl, void *arg)
+            size_t len, SSL *_1, void *arg)
 {
     BIO *bio = arg;
     const char *str_write_p = write_p ? ">>>" : "<<<";
@@ -619,6 +619,7 @@ void msg_cb(int write_p, int version, int content_type, const void *buf,
     const char *str_content_type = "", *str_details1 = "", *str_details2 = "";
     const unsigned char* bp = buf;
 
+    osslunused1();
     if (version == SSL3_VERSION ||
         version == TLS1_VERSION ||
         version == TLS1_1_VERSION ||
@@ -728,12 +729,13 @@ static STRINT_PAIR tlsext_types[] = {
     {NULL}
 };
 
-void tlsext_cb(SSL *s, int client_server, int type,
+void tlsext_cb(SSL *_1, int client_server, int type,
                const unsigned char *data, int len, void *arg)
 {
     BIO *bio = arg;
     const char *extname = lookup(type, tlsext_types, "unknown");
 
+    osslunused1();
     BIO_printf(bio, "TLS %s extension \"%s\" (id=%d), len=%d\n",
                client_server ? "server" : "client", extname, type, len);
     BIO_dump(bio, (const char *)data, len);
@@ -972,7 +974,7 @@ int load_excert(SSL_EXCERT **pexc)
             return 0;
         }
         exc->cert = load_cert(exc->certfile, exc->certform,
-                              NULL, NULL, "Server Certificate");
+                              "Server Certificate");
         if (!exc->cert)
             return 0;
         if (exc->keyfile) {
@@ -986,7 +988,7 @@ int load_excert(SSL_EXCERT **pexc)
             return 0;
         if (exc->chainfile) {
             if (!load_certs(exc->chainfile, &exc->chain, FORMAT_PEM, NULL,
-                            NULL, "Server Chain"))
+                            "Server Chain"))
                 return 0;
         }
     }
@@ -1198,10 +1200,11 @@ void print_ssl_summary(SSL *s)
 }
 
 int config_ctx(SSL_CONF_CTX *cctx, STACK_OF(OPENSSL_STRING) *str,
-               SSL_CTX *ctx, int no_jpake)
+               SSL_CTX *ctx, int _1)
 {
     int i;
 
+    osslunused1();
     SSL_CONF_CTX_set_ssl_ctx(cctx, ctx);
     for (i = 0; i < sk_OPENSSL_STRING_num(str); i += 2) {
         const char *flag = sk_OPENSSL_STRING_value(str, i);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -244,7 +244,7 @@ static char *psk_identity = "Client_identity";
  * char *psk_key=NULL; by default PSK is not used
  */
 
-static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
+static unsigned int psk_client_cb(SSL *_1, const char *hint, char *identity,
                                   unsigned int max_identity_len,
                                   unsigned char *psk,
                                   unsigned int max_psk_len)
@@ -253,6 +253,7 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
     int ret;
     BIGNUM *bn = NULL;
 
+    osslunused1();
     if (c_debug)
         BIO_printf(bio_c_out, "psk_client_cb\n");
     if (!hint) {
@@ -310,10 +311,12 @@ typedef struct tlsextctx_st {
     int ack;
 } tlsextctx;
 
-static int ssl_servername_cb(SSL *s, int *ad, void *arg)
+static int ssl_servername_cb(SSL *s, int *_1, void *arg)
 {
     tlsextctx *p = (tlsextctx *) arg;
     const char *hn = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+
+    osslunused1();
     if (SSL_get_servername_type(s) != -1)
         p->ack = !SSL_session_reused(s) && hn != NULL;
     else
@@ -412,13 +415,14 @@ static int ssl_srp_verify_param_cb(SSL *s, void *arg)
 
 # define PWD_STRLEN 1024
 
-static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
+static char *ssl_give_srp_client_pwd_cb(SSL *_1, void *arg)
 {
     SRP_ARG *srp_arg = (SRP_ARG *)arg;
     char *pass = app_malloc(PWD_STRLEN + 1, "SRP password buffer");
     PW_CB_DATA cb_tmp;
     int l;
 
+    osslunused1();
     cb_tmp.password = (char *)srp_arg->srppassin;
     cb_tmp.prompt_info = "SRP user";
     if ((l = password_callback(pass, PWD_STRLEN, 0, &cb_tmp)) < 0) {
@@ -445,12 +449,13 @@ typedef struct tlsextnextprotoctx_st {
 
 static tlsextnextprotoctx next_proto;
 
-static int next_proto_cb(SSL *s, unsigned char **out, unsigned char *outlen,
+static int next_proto_cb(SSL *_1, unsigned char **out, unsigned char *outlen,
                          const unsigned char *in, unsigned int inlen,
                          void *arg)
 {
     tlsextnextprotoctx *ctx = arg;
 
+    osslunused1();
     if (!c_quiet) {
         /* We can assume that |in| is syntactically valid. */
         unsigned i;
@@ -470,13 +475,14 @@ static int next_proto_cb(SSL *s, unsigned char **out, unsigned char *outlen,
 }
 #endif                         /* ndef OPENSSL_NO_NEXTPROTONEG */
 
-static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
+static int serverinfo_cli_parse_cb(SSL *_1, unsigned int ext_type,
                                    const unsigned char *in, size_t inlen,
-                                   int *al, void *arg)
+                                   int *_2, void *_3)
 {
     char pem_name[100];
     unsigned char ext_buf[4 + 65536];
 
+    osslunused3();
     /* Reconstruct the type/len fields prior to extension data */
     ext_buf[0] = ext_type >> 8;
     ext_buf[1] = ext_type & 0xFF;
@@ -1419,8 +1425,7 @@ int s_client_main(int argc, char **argv)
     }
 
     if (cert_file) {
-        cert = load_cert(cert_file, cert_format,
-                         NULL, e, "client certificate file");
+        cert = load_cert(cert_file, cert_format, "client certificate file");
         if (cert == NULL) {
             ERR_print_errors(bio_err);
             goto end;
@@ -1428,7 +1433,7 @@ int s_client_main(int argc, char **argv)
     }
 
     if (chain_file) {
-        if (!load_certs(chain_file, &chain, FORMAT_PEM, NULL, e,
+        if (!load_certs(chain_file, &chain, FORMAT_PEM, NULL,
                         "client certificate chain"))
             goto end;
     }

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -221,10 +221,8 @@ int init_client(int *sock, const char *host, const char *port,
  * 0 on failure, something other on success.
  */
 int do_server(int *accept_sock, const char *host, const char *port,
-              int family, int type,
-              int (*cb) (const char *hostname, int s, int stype,
-                         unsigned char *context), unsigned char *context,
-              int naccept)
+              int family, int type, do_server_cb cb,
+              unsigned char *context, int naccept)
 {
     int asock = 0;
     int sock;
@@ -297,7 +295,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
 #endif
                 name = BIO_ADDR_hostname_string(accepted_addr, 0);
         }
-        i = (*cb) (name, sock, type, context);
+        i = (*cb)(sock, type, context);
         OPENSSL_free(name);
         BIO_ADDR_free(accepted_addr);
         if (type == SOCK_STREAM)

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -458,7 +458,7 @@ int smime_main(int argc, char **argv)
             goto end;
         while (*argv) {
             cert = load_cert(*argv, FORMAT_PEM,
-                             NULL, e, "recipient certificate file");
+                             "recipient certificate file");
             if (cert == NULL)
                 goto end;
             sk_X509_push(encerts, cert);
@@ -468,7 +468,7 @@ int smime_main(int argc, char **argv)
     }
 
     if (certfile) {
-        if (!load_certs(certfile, &other, FORMAT_PEM, NULL, e,
+        if (!load_certs(certfile, &other, FORMAT_PEM, NULL,
                         "certificate file")) {
             ERR_print_errors(bio_err);
             goto end;
@@ -476,8 +476,8 @@ int smime_main(int argc, char **argv)
     }
 
     if (recipfile && (operation == SMIME_DECRYPT)) {
-        if ((recip = load_cert(recipfile, FORMAT_PEM, NULL,
-                                e, "recipient certificate file")) == NULL) {
+        if ((recip = load_cert(recipfile, FORMAT_PEM,
+                               "recipient certificate file")) == NULL) {
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -572,8 +572,8 @@ int smime_main(int argc, char **argv)
         for (i = 0; i < sk_OPENSSL_STRING_num(sksigners); i++) {
             signerfile = sk_OPENSSL_STRING_value(sksigners, i);
             keyfile = sk_OPENSSL_STRING_value(skkeys, i);
-            signer = load_cert(signerfile, FORMAT_PEM, NULL,
-                               e, "signer certificate");
+            signer = load_cert(signerfile, FORMAT_PEM,
+                               "signer certificate");
             if (!signer)
                 goto end;
             key = load_key(keyfile, keyform, 0, passin, e, "signing key file");

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -245,8 +245,10 @@ static int rnd_fake = 0;
 # endif
 
 static SIGRETTYPE sig_done(int sig);
-static SIGRETTYPE sig_done(int sig)
+
+static SIGRETTYPE sig_done(int _1)
 {
+    osslunused1();
     signal(SIGALRM, sig_done);
     run = 0;
 }
@@ -1781,7 +1783,7 @@ int speed_main(int argc, char **argv)
 
         /* DSA_generate_key(dsa_key[j]); */
         /* DSA_sign_setup(dsa_key[j],NULL); */
-        st = DSA_sign(EVP_PKEY_DSA, buf, 20, buf2, &kk, dsa_key[j]);
+        st = DSA_sign(0, buf, 20, buf2, &kk, dsa_key[j]);
         if (st == 0) {
             BIO_printf(bio_err,
                        "DSA sign failure.  No DSA sign will be done.\n");
@@ -1792,7 +1794,7 @@ int speed_main(int argc, char **argv)
                                dsa_c[j][0], dsa_bits[j], DSA_SECONDS);
             Time_F(START);
             for (count = 0, run = 1; COND(dsa_c[j][0]); count++) {
-                st = DSA_sign(EVP_PKEY_DSA, buf, 20, buf2, &kk, dsa_key[j]);
+                st = DSA_sign(0, buf, 20, buf2, &kk, dsa_key[j]);
                 if (st == 0) {
                     BIO_printf(bio_err, "DSA sign failure\n");
                     ERR_print_errors(bio_err);
@@ -1809,7 +1811,7 @@ int speed_main(int argc, char **argv)
             rsa_count = count;
         }
 
-        st = DSA_verify(EVP_PKEY_DSA, buf, 20, buf2, kk, dsa_key[j]);
+        st = DSA_verify(0, buf, 20, buf2, kk, dsa_key[j]);
         if (st <= 0) {
             BIO_printf(bio_err,
                        "DSA verify failure.  No DSA verify will be done.\n");
@@ -1820,7 +1822,7 @@ int speed_main(int argc, char **argv)
                                dsa_c[j][1], dsa_bits[j], DSA_SECONDS);
             Time_F(START);
             for (count = 0, run = 1; COND(dsa_c[j][1]); count++) {
-                st = DSA_verify(EVP_PKEY_DSA, buf, 20, buf2, kk, dsa_key[j]);
+                st = DSA_verify(0, buf, 20, buf2, kk, dsa_key[j]);
                 if (st <= 0) {
                     BIO_printf(bio_err, "DSA verify failure\n");
                     ERR_print_errors(bio_err);
@@ -2196,6 +2198,7 @@ int speed_main(int argc, char **argv)
 static void print_message(const char *s, long num, int length)
 {
 #ifdef SIGALRM
+    osslargused(num);
     BIO_printf(bio_err,
                mr ? "+DT:%s:%d:%d\n"
                : "Doing %s for %ds on %d size blocks: ", s, SECONDS, length);
@@ -2213,6 +2216,7 @@ static void pkey_print_message(const char *str, const char *str2, long num,
                                int bits, int tm)
 {
 #ifdef SIGALRM
+    osslargused(num);
     BIO_printf(bio_err,
                mr ? "+DTP:%d:%s:%s:%d\n"
                : "Doing %d bit %s %s's for %ds: ", bits, str, str2, tm);

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -992,7 +992,8 @@ static X509_STORE *create_cert_store(char *CApath, char *CAfile)
     return NULL;
 }
 
-static int verify_cb(int ok, X509_STORE_CTX *ctx)
+static int verify_cb(int ok, X509_STORE_CTX *_1)
 {
+    osslunused1();
     return ok;
 }

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -625,12 +625,12 @@ int x509_main(int argc, char **argv)
             EVP_PKEY_free(pkey);
         }
     } else
-        x = load_cert(infile, informat, NULL, e, "Certificate");
+        x = load_cert(infile, informat, "Certificate");
 
     if (x == NULL)
         goto end;
     if (CA_flag) {
-        xca = load_cert(CAfile, CAformat, NULL, e, "CA Certificate");
+        xca = load_cert(CAfile, CAformat, "CA Certificate");
         if (xca == NULL)
             goto end;
     }

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -206,7 +206,7 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
 
 void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
-                        const AES_KEY *key2, const unsigned char *ivec,
+                        const AES_KEY *_1, const unsigned char *ivec,
                         const int enc)
 {
     size_t n;
@@ -218,6 +218,7 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
     const unsigned char *iv;
     const unsigned char *iv2;
 
+    osslunused1();
     OPENSSL_assert(in && out && key && ivec);
     OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));
     OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -82,13 +82,14 @@ void *ASN1_d2i_fp(void *(*xnew) (void), d2i_of_void *d2i, FILE *in, void **x)
 }
 # endif
 
-void *ASN1_d2i_bio(void *(*xnew) (void), d2i_of_void *d2i, BIO *in, void **x)
+void *ASN1_d2i_bio(void *(*_1) (void), d2i_of_void *d2i, BIO *in, void **x)
 {
     BUF_MEM *b = NULL;
     const unsigned char *p;
     void *ret = NULL;
     int len;
 
+    osslunused1();
     len = asn1_d2i_read_bio(in, &b);
     if (len < 0)
         goto err;

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -295,10 +295,11 @@ static int traverse_string(const unsigned char *p, int len, int inform,
 
 /* Just count number of characters */
 
-static int in_utf8(unsigned long value, void *arg)
+static int in_utf8(unsigned long _1, void *arg)
 {
-    int *nchar;
-    nchar = arg;
+    int *nchar = arg;
+
+    osslunused1();
     (*nchar)++;
     return 1;
 }

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -91,8 +91,9 @@ static int oid_module_init(CONF_IMODULE *md, const CONF *cnf)
     return 1;
 }
 
-static void oid_module_finish(CONF_IMODULE *md)
+static void oid_module_finish(CONF_IMODULE *_1)
 {
+    osslunused1();
     OBJ_cleanup();
 }
 

--- a/crypto/asn1/asn_mstbl.c
+++ b/crypto/asn1/asn_mstbl.c
@@ -85,8 +85,9 @@ static int stbl_module_init(CONF_IMODULE *md, const CONF *cnf)
     return 1;
 }
 
-static void stbl_module_finish(CONF_IMODULE *md)
+static void stbl_module_finish(CONF_IMODULE *_1)
 {
+    osslunused1();
     ASN1_STRING_TABLE_cleanup();
 }
 

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -52,6 +52,7 @@
  *
  */
 
+#include <e_os.h>
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/bio.h>
@@ -146,12 +147,13 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     return NULL;
 }
 
-static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
+static int ndef_prefix(BIO *_1, unsigned char **pbuf, int *plen, void *parg)
 {
     NDEF_SUPPORT *ndef_aux;
     unsigned char *p;
     int derlen;
 
+    osslunused1();
     if (!parg)
         return 0;
 
@@ -174,11 +176,12 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     return 1;
 }
 
-static int ndef_prefix_free(BIO *b, unsigned char **pbuf, int *plen,
+static int ndef_prefix_free(BIO *_1, unsigned char **pbuf, int *plen,
                             void *parg)
 {
     NDEF_SUPPORT *ndef_aux;
 
+    osslunused1();
     if (!parg)
         return 0;
 
@@ -203,7 +206,7 @@ static int ndef_suffix_free(BIO *b, unsigned char **pbuf, int *plen,
     return 1;
 }
 
-static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
+static int ndef_suffix(BIO *_1, unsigned char **pbuf, int *plen, void *parg)
 {
     NDEF_SUPPORT *ndef_aux;
     unsigned char *p;
@@ -211,6 +214,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     const ASN1_AUX *aux;
     ASN1_STREAM_ARG sarg;
 
+    osslunused1();
     if (!parg)
         return 0;
 

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -60,11 +60,13 @@
 #include <openssl/buffer.h>
 #include <openssl/asn1.h>
 
-int i2a_ASN1_STRING(BIO *bp, ASN1_STRING *a, int type)
+int i2a_ASN1_STRING(BIO *bp, ASN1_STRING *a, int _1)
 {
     int i, n = 0;
     static const char *h = "0123456789ABCDEF";
     char buf[2];
+
+    osslunused1();
 
     if (a == NULL)
         return (0);

--- a/crypto/asn1/nsseq.c
+++ b/crypto/asn1/nsseq.c
@@ -58,13 +58,15 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <e_os.h>
 #include <openssl/asn1t.h>
 #include <openssl/x509.h>
 #include <openssl/objects.h>
 
-static int nsseq_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                    void *exarg)
+static int nsseq_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                    void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_NEW_POST) {
         NETSCAPE_CERT_SEQUENCE *nsseq;
         nsseq = (NETSCAPE_CERT_SEQUENCE *)*pval;

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -273,7 +273,7 @@ static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, size_t saltlen,
 
 int PKCS5_v2_scrypt_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int passlen, ASN1_TYPE *param,
-                             const EVP_CIPHER *c, const EVP_MD *md, int en_de)
+                             const EVP_CIPHER *_1, const EVP_MD *_2, int en_de)
 {
     unsigned char *salt, key[EVP_MAX_KEY_LENGTH];
     uint64_t p, r, N;
@@ -282,6 +282,7 @@ int PKCS5_v2_scrypt_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
     int rv = 0;
     SCRYPT_PARAMS *sparam = NULL;
 
+    osslunused2();
     if (EVP_CIPHER_CTX_cipher(ctx) == NULL) {
         EVPerr(EVP_F_PKCS5_V2_SCRYPT_KEYIVGEN, EVP_R_NO_CIPHER_SET);
         goto err;

--- a/crypto/asn1/p8_pkey.c
+++ b/crypto/asn1/p8_pkey.c
@@ -62,9 +62,11 @@
 #include <openssl/x509.h>
 
 /* Minor tweak to operation: zero private key data */
-static int pkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                   void *exarg)
+static int pkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                   void *_2)
 {
+    osslunused2();
+
     /* Since the structure must still be valid use ASN1_OP_FREE_PRE */
     if (operation == ASN1_OP_FREE_PRE) {
         PKCS8_PRIV_KEY_INFO *key = (PKCS8_PRIV_KEY_INFO *)*pval;

--- a/crypto/asn1/t_pkey.c
+++ b/crypto/asn1/t_pkey.c
@@ -91,13 +91,14 @@ int ASN1_buf_print(BIO *bp, unsigned char *buf, size_t buflen, int indent)
 }
 
 int ASN1_bn_print(BIO *bp, const char *number, const BIGNUM *num,
-                  unsigned char *ign, int indent)
+                  unsigned char *_1, int indent)
 {
     int n, rv = 0;
     const char *neg;
     unsigned char *buf = NULL, *tmp = NULL;
     int buflen;
 
+    osslunused1();
     if (num == NULL)
         return 1;
     neg = BN_is_negative(num) ? "-" : "";

--- a/crypto/asn1/tasn_prn.c
+++ b/crypto/asn1/tasn_prn.c
@@ -402,8 +402,7 @@ static int asn1_print_fsname(BIO *out, int indent,
     return 1;
 }
 
-static int asn1_print_boolean_ctx(BIO *out, int boolval,
-                                  const ASN1_PCTX *pctx)
+static int asn1_print_boolean_ctx(BIO *out, int boolval)
 {
     const char *str;
     switch (boolval) {
@@ -427,8 +426,7 @@ static int asn1_print_boolean_ctx(BIO *out, int boolval,
 
 }
 
-static int asn1_print_integer_ctx(BIO *out, ASN1_INTEGER *str,
-                                  const ASN1_PCTX *pctx)
+static int asn1_print_integer_ctx(BIO *out, ASN1_INTEGER *str)
 {
     char *s;
     int ret = 1;
@@ -439,8 +437,7 @@ static int asn1_print_integer_ctx(BIO *out, ASN1_INTEGER *str,
     return ret;
 }
 
-static int asn1_print_oid_ctx(BIO *out, const ASN1_OBJECT *oid,
-                              const ASN1_PCTX *pctx)
+static int asn1_print_oid_ctx(BIO *out, const ASN1_OBJECT *oid)
 {
     char objbuf[80];
     const char *ln;
@@ -453,8 +450,7 @@ static int asn1_print_oid_ctx(BIO *out, const ASN1_OBJECT *oid,
     return 1;
 }
 
-static int asn1_print_obstring_ctx(BIO *out, ASN1_STRING *str, int indent,
-                                   const ASN1_PCTX *pctx)
+static int asn1_print_obstring_ctx(BIO *out, ASN1_STRING *str, int indent)
 {
     if (str->type == V_ASN1_BIT_STRING) {
         if (BIO_printf(out, " (%ld unused bits)\n", str->flags & 0x7) <= 0)
@@ -523,13 +519,13 @@ static int asn1_primitive_print(BIO *out, ASN1_VALUE **fld,
             int boolval = *(int *)fld;
             if (boolval == -1)
                 boolval = it->size;
-            ret = asn1_print_boolean_ctx(out, boolval, pctx);
+            ret = asn1_print_boolean_ctx(out, boolval);
         }
         break;
 
     case V_ASN1_INTEGER:
     case V_ASN1_ENUMERATED:
-        ret = asn1_print_integer_ctx(out, str, pctx);
+        ret = asn1_print_integer_ctx(out, str);
         break;
 
     case V_ASN1_UTCTIME:
@@ -541,12 +537,12 @@ static int asn1_primitive_print(BIO *out, ASN1_VALUE **fld,
         break;
 
     case V_ASN1_OBJECT:
-        ret = asn1_print_oid_ctx(out, (const ASN1_OBJECT *)*fld, pctx);
+        ret = asn1_print_oid_ctx(out, (const ASN1_OBJECT *)*fld);
         break;
 
     case V_ASN1_OCTET_STRING:
     case V_ASN1_BIT_STRING:
-        ret = asn1_print_obstring_ctx(out, str, indent, pctx);
+        ret = asn1_print_obstring_ctx(out, str, indent);
         needlf = 0;
         break;
 

--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -107,8 +107,9 @@ ASN1_ITEM_start(CBIGNUM)
         ASN1_ITYPE_PRIMITIVE, V_ASN1_INTEGER, NULL, 0, &cbignum_pf, BN_SENSITIVE, "CBIGNUM"
 ASN1_ITEM_end(CBIGNUM)
 
-static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *_1)
 {
+    osslunused1();
     *pval = (ASN1_VALUE *)BN_new();
     if (*pval != NULL)
         return 1;
@@ -116,8 +117,9 @@ static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
         return 0;
 }
 
-static int bn_secure_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static int bn_secure_new(ASN1_VALUE **pval, const ASN1_ITEM *_1)
 {
+    osslunused1();
     *pval = (ASN1_VALUE *)BN_secure_new();
     if (*pval != NULL)
         return 1;
@@ -136,11 +138,13 @@ static void bn_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
     *pval = NULL;
 }
 
-static int bn_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
-                  const ASN1_ITEM *it)
+static int bn_i2c(ASN1_VALUE **pval, unsigned char *cont, int *_1,
+                  const ASN1_ITEM *_2)
 {
     BIGNUM *bn;
     int pad;
+
+    osslunused2();
     if (!*pval)
         return -1;
     bn = (BIGNUM *)*pval;
@@ -158,10 +162,11 @@ static int bn_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
 }
 
 static int bn_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
-                  int utype, char *free_cont, const ASN1_ITEM *it)
+                  int _1, char *_2, const ASN1_ITEM *it)
 {
     BIGNUM *bn;
 
+    osslunused2();
     if (*pval == NULL && !bn_new(pval, it))
         return 0;
     bn = (BIGNUM *)*pval;

--- a/crypto/asn1/x_long.c
+++ b/crypto/asn1/x_long.c
@@ -105,7 +105,7 @@ static void long_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
     *(long *)pval = it->size;
 }
 
-static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
+static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *_1,
                     const ASN1_ITEM *it)
 {
     long ltmp;
@@ -114,6 +114,7 @@ static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
     /* this exists to bypass broken gcc optimization */
     char *cp = (char *)pval;
 
+    osslunused1();
     /* use memcpy, because we may not be long aligned */
     memcpy(&ltmp, cp, sizeof(long));
 
@@ -152,12 +153,14 @@ static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
 }
 
 static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
-                    int utype, char *free_cont, const ASN1_ITEM *it)
+                    int _1, char *_2, const ASN1_ITEM *it)
 {
     int neg, i;
     long ltmp;
     unsigned long utmp = 0;
     char *cp = (char *)pval;
+
+    osslunused2();
     if (len > (int)sizeof(long)) {
         ASN1err(ASN1_F_LONG_C2I, ASN1_R_INTEGER_TOO_LARGE_FOR_LONG);
         return 0;
@@ -188,8 +191,9 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     return 1;
 }
 
-static int long_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      int indent, const ASN1_PCTX *pctx)
+static int long_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                      int _2, const ASN1_PCTX *_3)
 {
+    osslunused3();
     return BIO_printf(out, "%ld\n", *(long *)pval);
 }

--- a/crypto/asn1/x_pubkey.c
+++ b/crypto/asn1/x_pubkey.c
@@ -69,9 +69,10 @@
 #endif
 
 /* Minor tweak to operation: free up EVP_PKEY */
-static int pubkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                     void *exarg)
+static int pubkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                     void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_FREE_POST) {
         X509_PUBKEY *pubkey = (X509_PUBKEY *)*pval;
         EVP_PKEY_free(pubkey->pkey);

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -82,10 +82,11 @@
  * Returns the file descriptor on success or INVALID_SOCKET on failure.  On
  * failure errno is set, and a status is added to the OpenSSL error stack.
  */
-int BIO_socket(int domain, int socktype, int protocol, int options)
+int BIO_socket(int domain, int socktype, int protocol, int _1)
 {
     int sock = -1;
 
+    osslunused1();
     if (BIO_sock_init() != 1)
         return INVALID_SOCKET;
 

--- a/crypto/bio/bio_cb.c
+++ b/crypto/bio/bio_cb.c
@@ -62,8 +62,8 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 
-long BIO_debug_callback(BIO *bio, int cmd, const char *argp,
-                        int argi, long argl, long ret)
+long BIO_debug_callback(BIO *bio, int cmd, const char *_1,
+                        int argi, long _2, long ret)
 {
     BIO *b;
     char buf[256];
@@ -72,6 +72,7 @@ long BIO_debug_callback(BIO *bio, int cmd, const char *argp,
     int len;
     size_t p_maxlen;
 
+    osslunused2();
     if (BIO_CB_RETURN & cmd)
         r = ret;
 

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -428,8 +428,9 @@ static void xcloselog(BIO *bp)
 
 # else                          /* Unix/Watt32 */
 
-static void xopenlog(BIO *bp, char *name, int level)
+static void xopenlog(BIO *_1, char *name, int level)
 {
+    osslunused1();
 #  ifdef WATT32                 /* djgpp/DOS */
     openlog(name, LOG_PID | LOG_CONS | LOG_NDELAY, level);
 #  else
@@ -437,13 +438,15 @@ static void xopenlog(BIO *bp, char *name, int level)
 #  endif
 }
 
-static void xsyslog(BIO *bp, int priority, const char *string)
+static void xsyslog(BIO *_1, int priority, const char *string)
 {
+    osslunused1();
     syslog(priority, "%s", string);
 }
 
-static void xcloselog(BIO *bp)
+static void xcloselog(BIO *_1)
 {
+    osslunused1();
     closelog();
 }
 

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -100,20 +100,23 @@ static int null_free(BIO *a)
     return (1);
 }
 
-static int null_read(BIO *b, char *out, int outl)
+static int null_read(BIO *_1, char *_2, int _3)
 {
+    osslunused3();
     return (0);
 }
 
-static int null_write(BIO *b, const char *in, int inl)
+static int null_write(BIO *_1, const char *_2, int inl)
 {
+    osslunused2();
     return (inl);
 }
 
-static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
+static long null_ctrl(BIO *_1, int cmd, long _2, void *_3)
 {
     long ret = 1;
 
+    osslunused3();
     switch (cmd) {
     case BIO_CTRL_RESET:
     case BIO_CTRL_EOF:
@@ -135,13 +138,15 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static int null_gets(BIO *bp, char *buf, int size)
+static int null_gets(BIO *_1, char *_2, int _3)
 {
+    osslunused3();
     return (0);
 }
 
-static int null_puts(BIO *bp, const char *str)
+static int null_puts(BIO *_1, const char *str)
 {
+    osslunused1();
     if (str == NULL)
         return (0);
     return (strlen(str));

--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -761,7 +761,7 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
 
 int bn_probable_prime_dh(BIGNUM *rnd, int bits,
                          const BIGNUM *add, const BIGNUM *rem, BN_CTX *ctx);
-int bn_probable_prime_dh_retry(BIGNUM *rnd, int bits, BN_CTX *ctx);
+int bn_probable_prime_dh_retry(BIGNUM *rnd, int bits);
 int bn_probable_prime_dh_coprime(BIGNUM *rnd, int bits, BN_CTX *ctx);
 
 #ifdef  __cplusplus

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -399,7 +399,7 @@ int BN_is_prime_fasttest_ex(const BIGNUM *a, int checks, BN_CTX *ctx_passed,
     return (ret);
 }
 
-int bn_probable_prime_dh_retry(BIGNUM *rnd, int bits, BN_CTX *ctx)
+int bn_probable_prime_dh_retry(BIGNUM *rnd, int bits)
 {
     int i;
     int ret = 0;

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -89,8 +89,9 @@ void BN_RECP_CTX_free(BN_RECP_CTX *recp)
         OPENSSL_free(recp);
 }
 
-int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *ctx)
+int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *_1)
 {
+    osslunused1();
     if (!BN_copy(&(recp->N), d))
         return 0;
     BN_zero(&(recp->Nr));

--- a/crypto/cmac/cm_ameth.c
+++ b/crypto/cmac/cm_ameth.c
@@ -62,8 +62,9 @@
  * length and to free up a CMAC key.
  */
 
-static int cmac_size(const EVP_PKEY *pkey)
+static int cmac_size(const EVP_PKEY *_1)
 {
+    osslunused1();
     return EVP_MAX_BLOCK_LENGTH;
 }
 

--- a/crypto/cmac/cm_pmeth.c
+++ b/crypto/cmac/cm_pmeth.c
@@ -106,16 +106,18 @@ static int int_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     return 1;
 }
 
-static int cmac_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
+static int cmac_signctx_init(EVP_PKEY_CTX *_1, EVP_MD_CTX *mctx)
 {
+    osslunused1();
     EVP_MD_CTX_set_flags(mctx, EVP_MD_CTX_FLAG_NO_INIT);
     EVP_MD_CTX_set_update_fn(mctx, int_update);
     return 1;
 }
 
 static int cmac_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
-                        EVP_MD_CTX *mctx)
+                        EVP_MD_CTX *_1)
 {
+    osslunused1();
     return CMAC_Final(ctx->data, sig, siglen);
 }
 

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -51,6 +51,7 @@
  * ====================================================================
  */
 
+#include <e_os.h>
 #include <openssl/asn1t.h>
 #include <openssl/pem.h>
 #include <openssl/x509v3.h>
@@ -87,9 +88,10 @@ ASN1_NDEF_SEQUENCE(CMS_EncapsulatedContentInfo) = {
 } static_ASN1_NDEF_SEQUENCE_END(CMS_EncapsulatedContentInfo)
 
 /* Minor tweak to operation: free up signer key, cert */
-static int cms_si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                     void *exarg)
+static int cms_si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                     void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_FREE_POST) {
         CMS_SignerInfo *si = (CMS_SignerInfo *)*pval;
         EVP_PKEY_free(si->pkey);
@@ -162,10 +164,12 @@ ASN1_CHOICE(CMS_KeyAgreeRecipientIdentifier) = {
   ASN1_IMP(CMS_KeyAgreeRecipientIdentifier, d.rKeyId, CMS_RecipientKeyIdentifier, 0)
 } static_ASN1_CHOICE_END(CMS_KeyAgreeRecipientIdentifier)
 
-static int cms_rek_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int cms_rek_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                      void *_2)
 {
     CMS_RecipientEncryptedKey *rek = (CMS_RecipientEncryptedKey *)*pval;
+
+    osslunused2();
     if (operation == ASN1_OP_FREE_POST) {
         EVP_PKEY_free(rek->pkey);
     }
@@ -188,10 +192,12 @@ ASN1_CHOICE(CMS_OriginatorIdentifierOrKey) = {
   ASN1_IMP(CMS_OriginatorIdentifierOrKey, d.originatorKey, CMS_OriginatorPublicKey, 1)
 } static_ASN1_CHOICE_END(CMS_OriginatorIdentifierOrKey)
 
-static int cms_kari_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                       void *exarg)
+static int cms_kari_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                       void *_2)
 {
     CMS_KeyAgreeRecipientInfo *kari = (CMS_KeyAgreeRecipientInfo *)*pval;
+
+    osslunused2();
     if (operation == ASN1_OP_NEW_POST) {
         kari->ctx = EVP_CIPHER_CTX_new();
         if (kari->ctx == NULL)
@@ -239,9 +245,10 @@ ASN1_SEQUENCE(CMS_OtherRecipientInfo) = {
 } static_ASN1_SEQUENCE_END(CMS_OtherRecipientInfo)
 
 /* Free up RecipientInfo additional data */
-static int cms_ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                     void *exarg)
+static int cms_ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                     void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_FREE_PRE) {
         CMS_RecipientInfo *ri = (CMS_RecipientInfo *)*pval;
         if (ri->type == CMS_RECIPINFO_TRANS) {
@@ -322,11 +329,13 @@ ASN1_ADB(CMS_ContentInfo) = {
 } ASN1_ADB_END(CMS_ContentInfo, 0, contentType, 0, &cms_default_tt, NULL);
 
 /* CMS streaming support */
-static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
+static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
                   void *exarg)
 {
     ASN1_STREAM_ARG *sarg = exarg;
     CMS_ContentInfo *cms = NULL;
+
+    osslunused1();
     if (pval)
         cms = (CMS_ContentInfo *)*pval;
     else

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -271,8 +271,7 @@ CMS_ContentInfo *CMS_EncryptedData_encrypt(BIO *in, const EVP_CIPHER *cipher,
 static int cms_signerinfo_verify_cert(CMS_SignerInfo *si,
                                       X509_STORE *store,
                                       STACK_OF(X509) *certs,
-                                      STACK_OF(X509_CRL) *crls,
-                                      unsigned int flags)
+                                      STACK_OF(X509_CRL) *crls)
 {
     X509_STORE_CTX ctx;
     X509 *signer;
@@ -353,8 +352,7 @@ int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
             crls = CMS_get1_crls(cms);
         for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
             si = sk_CMS_SignerInfo_value(sinfos, i);
-            if (!cms_signerinfo_verify_cert(si, store,
-                                            cms_certs, crls, flags))
+            if (!cms_signerinfo_verify_cert(si, store, cms_certs, crls))
                 goto err;
         }
     }
@@ -851,6 +849,7 @@ int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
 CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
 {
     CMS_ContentInfo *cms;
+
     if (comp_nid <= 0)
         comp_nid = NID_zlib_compression;
     cms = cms_CompressedData_create(comp_nid);
@@ -869,15 +868,16 @@ CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
 
 #else
 
-int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
-                   unsigned int flags)
+int CMS_uncompress(CMS_ContentInfo *_1, BIO *_2, BIO *_3, unsigned int _4)
 {
+    osslunused4();
     CMSerr(CMS_F_CMS_UNCOMPRESS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
     return 0;
 }
 
-CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
+CMS_ContentInfo *CMS_compress(BIO *_1, int _2, unsigned int _3)
 {
+    osslunused3();
     CMSerr(CMS_F_CMS_COMPRESS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
     return NULL;
 }

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -672,7 +672,8 @@ static int def_is_number(const CONF *conf, char c)
     return IS_NUMBER(conf, c);
 }
 
-static int def_to_int(const CONF *conf, char c)
+static int def_to_int(const CONF *_1, char c)
 {
+    osslunused1();
     return c - '0';
 }

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -113,8 +113,7 @@ static CONF_MODULE *module_add(DSO *dso, const char *name,
 static CONF_MODULE *module_find(char *name);
 static int module_init(CONF_MODULE *pmod, char *name, char *value,
                        const CONF *cnf);
-static CONF_MODULE *module_load_dso(const CONF *cnf, char *name, char *value,
-                                    unsigned long flags);
+static CONF_MODULE *module_load_dso(const CONF *cnf, char *name, char *value);
 
 /* Main function: load modules from a CONF structure */
 
@@ -204,7 +203,7 @@ static int module_run(const CONF *cnf, char *name, char *value,
 
     /* Module not found: try to load DSO */
     if (!md && !(flags & CONF_MFLAGS_NO_DSO))
-        md = module_load_dso(cnf, name, value, flags);
+        md = module_load_dso(cnf, name, value);
 
     if (!md) {
         if (!(flags & CONF_MFLAGS_SILENT)) {
@@ -230,8 +229,7 @@ static int module_run(const CONF *cnf, char *name, char *value,
 }
 
 /* Load a module from a DSO */
-static CONF_MODULE *module_load_dso(const CONF *cnf, char *name, char *value,
-                                    unsigned long flags)
+static CONF_MODULE *module_load_dso(const CONF *cnf, char *name, char *value)
 {
     DSO *dso = NULL;
     conf_init_func *ifunc;

--- a/crypto/des/rpc_enc.c
+++ b/crypto/des/rpc_enc.c
@@ -57,13 +57,16 @@
 
 #include "rpc_des.h"
 #include "des_locl.h"
+#include "e_os.h"
 
 int _des_crypt(char *buf, int len, struct desparams *desp);
-int _des_crypt(char *buf, int len, struct desparams *desp)
+
+int _des_crypt(char *_1, int len, struct desparams *desp)
 {
     DES_key_schedule ks;
     int enc;
 
+    osslunused1();
     DES_set_key_unchecked(&desp->des_key, &ks);
     enc = (desp->des_dir == ENCRYPT) ? DES_ENCRYPT : DES_DECRYPT;
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -324,8 +324,7 @@ static int dh_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
     return i2d_dhp(pkey, pkey->pkey.dh, pder);
 }
 
-static int do_dh_print(BIO *bp, const DH *x, int indent,
-                       ASN1_PCTX *ctx, int ptype)
+static int do_dh_print(BIO *bp, const DH *x, int indent, int ptype)
 {
     unsigned char *m = NULL;
     int reason = ERR_R_BUF_LIB;
@@ -377,18 +376,18 @@ static int do_dh_print(BIO *bp, const DH *x, int indent,
         goto err;
     indent += 4;
 
-    if (!ASN1_bn_print(bp, "private-key:", priv_key, m, indent))
+    if (!ASN1_bn_print(bp, "private-key:", priv_key, NULL, indent))
         goto err;
-    if (!ASN1_bn_print(bp, "public-key:", pub_key, m, indent))
+    if (!ASN1_bn_print(bp, "public-key:", pub_key, NULL, indent))
         goto err;
 
-    if (!ASN1_bn_print(bp, "prime:", x->p, m, indent))
+    if (!ASN1_bn_print(bp, "prime:", x->p, NULL, indent))
         goto err;
-    if (!ASN1_bn_print(bp, "generator:", x->g, m, indent))
+    if (!ASN1_bn_print(bp, "generator:", x->g, NULL, indent))
         goto err;
-    if (x->q && !ASN1_bn_print(bp, "subgroup order:", x->q, m, indent))
+    if (x->q && !ASN1_bn_print(bp, "subgroup order:", x->q, NULL, indent))
         goto err;
-    if (x->j && !ASN1_bn_print(bp, "subgroup factor:", x->j, m, indent))
+    if (x->j && !ASN1_bn_print(bp, "subgroup factor:", x->j, NULL, indent))
         goto err;
     if (x->seed) {
         int i;
@@ -407,7 +406,7 @@ static int do_dh_print(BIO *bp, const DH *x, int indent,
         if (BIO_write(bp, "\n", 1) <= 0)
             return (0);
     }
-    if (x->counter && !ASN1_bn_print(bp, "counter:", x->counter, m, indent))
+    if (x->counter && !ASN1_bn_print(bp, "counter:", x->counter, NULL, indent))
         goto err;
     if (x->length != 0) {
         BIO_indent(bp, indent, 128);
@@ -535,26 +534,29 @@ static int dh_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 }
 
 static int dh_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                          ASN1_PCTX *ctx)
+                          ASN1_PCTX *_1)
 {
-    return do_dh_print(bp, pkey->pkey.dh, indent, ctx, 0);
+    osslunused1();
+    return do_dh_print(bp, pkey->pkey.dh, indent, 0);
 }
 
 static int dh_public_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                           ASN1_PCTX *ctx)
+                           ASN1_PCTX *_1)
 {
-    return do_dh_print(bp, pkey->pkey.dh, indent, ctx, 1);
+    osslunused1();
+    return do_dh_print(bp, pkey->pkey.dh, indent, 1);
 }
 
 static int dh_private_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                            ASN1_PCTX *ctx)
+                            ASN1_PCTX *_1)
 {
-    return do_dh_print(bp, pkey->pkey.dh, indent, ctx, 2);
+    osslunused1();
+    return do_dh_print(bp, pkey->pkey.dh, indent, 2);
 }
 
 int DHparams_print(BIO *bp, const DH *x)
 {
-    return do_dh_print(bp, x, 4, NULL, 0);
+    return do_dh_print(bp, x, 4, 0);
 }
 
 #ifndef OPENSSL_NO_CMS
@@ -562,11 +564,11 @@ static int dh_cms_decrypt(CMS_RecipientInfo *ri);
 static int dh_cms_encrypt(CMS_RecipientInfo *ri);
 #endif
 
-static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int dh_pkey_ctrl(EVP_PKEY *_1, int op, long arg1, void *arg2)
 {
+    osslunused1();
     switch (op) {
 #ifndef OPENSSL_NO_CMS
-
     case ASN1_PKEY_CTRL_CMS_ENVELOPE:
         if (arg1 == 1)
             return dh_cms_decrypt(arg2);

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -64,9 +64,10 @@
 #include <openssl/asn1t.h>
 
 /* Override the default free and new methods */
-static int dh_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
+static int dh_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                 void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)DH_new();
         if (*pval != NULL)

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -466,15 +466,15 @@ static int do_dsa_print(BIO *bp, const DSA *x, int off, int ptype)
             goto err;
     }
 
-    if (!ASN1_bn_print(bp, "priv:", priv_key, m, off))
+    if (!ASN1_bn_print(bp, "priv:", priv_key, NULL, off))
         goto err;
-    if (!ASN1_bn_print(bp, "pub: ", pub_key, m, off))
+    if (!ASN1_bn_print(bp, "pub: ", pub_key, NULL, off))
         goto err;
-    if (!ASN1_bn_print(bp, "P:   ", x->p, m, off))
+    if (!ASN1_bn_print(bp, "P:   ", x->p, NULL, off))
         goto err;
-    if (!ASN1_bn_print(bp, "Q:   ", x->q, m, off))
+    if (!ASN1_bn_print(bp, "Q:   ", x->q, NULL, off))
         goto err;
-    if (!ASN1_bn_print(bp, "G:   ", x->g, m, off))
+    if (!ASN1_bn_print(bp, "G:   ", x->g, NULL, off))
         goto err;
     ret = 1;
  err:
@@ -501,20 +501,23 @@ static int dsa_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
 }
 
 static int dsa_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                           ASN1_PCTX *ctx)
+                           ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 0);
 }
 
 static int dsa_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                         ASN1_PCTX *ctx)
+                         ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 1);
 }
 
 static int dsa_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                          ASN1_PCTX *ctx)
+                          ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 2);
 }
 
@@ -536,11 +539,13 @@ static int old_dsa_priv_encode(const EVP_PKEY *pkey, unsigned char **pder)
     return i2d_DSAPrivateKey(pkey->pkey.dsa, pder);
 }
 
-static int dsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
-                         const ASN1_STRING *sig, int indent, ASN1_PCTX *pctx)
+static int dsa_sig_print(BIO *bp, const X509_ALGOR *_1,
+                         const ASN1_STRING *sig, int indent, ASN1_PCTX *_2)
 {
     DSA_SIG *dsa_sig;
     const unsigned char *p;
+
+    osslunused2();
     if (!sig) {
         if (BIO_puts(bp, "\n") <= 0)
             return 0;
@@ -564,9 +569,9 @@ static int dsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
         if (BIO_write(bp, "\n", 1) != 1)
             goto err;
 
-        if (!ASN1_bn_print(bp, "r:   ", dsa_sig->r, m, indent))
+        if (!ASN1_bn_print(bp, "r:   ", dsa_sig->r, NULL, indent))
             goto err;
-        if (!ASN1_bn_print(bp, "s:   ", dsa_sig->s, m, indent))
+        if (!ASN1_bn_print(bp, "s:   ", dsa_sig->s, NULL, indent))
             goto err;
         rv = 1;
  err:

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -64,9 +64,10 @@
 #include <openssl/rand.h>
 
 /* Override the default new methods */
-static int sig_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int sig_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                  void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_NEW_PRE) {
         DSA_SIG *sig;
         sig = OPENSSL_malloc(sizeof(*sig));
@@ -90,9 +91,10 @@ ASN1_SEQUENCE_cb(DSA_SIG, sig_cb) = {
 IMPLEMENT_ASN1_FUNCTIONS_const(DSA_SIG)
 
 /* Override the default free and new methods */
-static int dsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int dsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                  void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)DSA_new();
         if (*pval != NULL)
@@ -139,10 +141,12 @@ DSA *DSAparams_dup(DSA *dsa)
     return ASN1_item_dup(ASN1_ITEM_rptr(DSAparams), dsa);
 }
 
-int DSA_sign(int type, const unsigned char *dgst, int dlen,
+int DSA_sign(int _1, const unsigned char *dgst, int dlen,
              unsigned char *sig, unsigned int *siglen, DSA *dsa)
 {
     DSA_SIG *s;
+
+    osslunused1();
     RAND_seed(dgst, dlen);
     s = DSA_do_sign(dgst, dlen, dsa);
     if (s == NULL) {
@@ -161,7 +165,7 @@ int DSA_sign(int type, const unsigned char *dgst, int dlen,
  *      0: incorrect signature
  *     -1: error
  */
-int DSA_verify(int type, const unsigned char *dgst, int dgst_len,
+int DSA_verify(int _1, const unsigned char *dgst, int dgst_len,
                const unsigned char *sigbuf, int siglen, DSA *dsa)
 {
     DSA_SIG *s;
@@ -170,6 +174,7 @@ int DSA_verify(int type, const unsigned char *dgst, int dgst_len,
     int derlen = -1;
     int ret = -1;
 
+    osslunused1();
     s = DSA_SIG_new();
     if (s == NULL)
         return (ret);

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -120,7 +120,7 @@ static int pkey_dsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
                          size_t *siglen, const unsigned char *tbs,
                          size_t tbslen)
 {
-    int ret, type;
+    int ret;
     unsigned int sltmp;
     DSA_PKEY_CTX *dctx = ctx->data;
     DSA *dsa = ctx->pkey->pkey.dsa;
@@ -128,14 +128,12 @@ static int pkey_dsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
     if (dctx->md) {
         if (tbslen != (size_t)EVP_MD_size(dctx->md))
             return 0;
-        type = EVP_MD_type(dctx->md);
     } else {
         if (tbslen != SHA_DIGEST_LENGTH)
             return 0;
-        type = NID_sha1;
     }
 
-    ret = DSA_sign(type, tbs, tbslen, sig, &sltmp, dsa);
+    ret = DSA_sign(0, tbs, tbslen, sig, &sltmp, dsa);
 
     if (ret <= 0)
         return ret;
@@ -147,21 +145,19 @@ static int pkey_dsa_verify(EVP_PKEY_CTX *ctx,
                            const unsigned char *sig, size_t siglen,
                            const unsigned char *tbs, size_t tbslen)
 {
-    int ret, type;
+    int ret;
     DSA_PKEY_CTX *dctx = ctx->data;
     DSA *dsa = ctx->pkey->pkey.dsa;
 
     if (dctx->md) {
         if (tbslen != (size_t)EVP_MD_size(dctx->md))
             return 0;
-        type = EVP_MD_type(dctx->md);
     } else {
         if (tbslen != SHA_DIGEST_LENGTH)
             return 0;
-        type = NID_sha1;
     }
 
-    ret = DSA_verify(type, tbs, tbslen, sig, siglen, dsa);
+    ret = DSA_verify(0, tbs, tbslen, sig, siglen, dsa);
 
     return ret;
 }

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -266,11 +266,12 @@ static DSO_FUNC_TYPE dlfcn_bind_func(DSO *dso, const char *symname)
     return u.sym;
 }
 
-static char *dlfcn_merger(DSO *dso, const char *filespec1,
+static char *dlfcn_merger(DSO *_1, const char *filespec1,
                           const char *filespec2)
 {
     char *merged;
 
+    osslunused1();
     if (!filespec1 && !filespec2) {
         DSOerr(DSO_F_DLFCN_MERGER, ERR_R_PASSED_NULL_PARAMETER);
         return (NULL);

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -202,9 +202,11 @@ int ec_GF2m_simple_group_copy(EC_GROUP *dest, const EC_GROUP *src)
 /* Set the curve parameters of an EC_GROUP structure. */
 int ec_GF2m_simple_group_set_curve(EC_GROUP *group,
                                    const BIGNUM *p, const BIGNUM *a,
-                                   const BIGNUM *b, BN_CTX *ctx)
+                                   const BIGNUM *b, BN_CTX *_1)
 {
     int ret = 0, i;
+
+    osslunused1();
 
     /* group->field */
     if (!BN_copy(group->field, p))
@@ -241,10 +243,11 @@ int ec_GF2m_simple_group_set_curve(EC_GROUP *group,
  * then there values will not be set but the method will return with success.
  */
 int ec_GF2m_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
-                                   BIGNUM *a, BIGNUM *b, BN_CTX *ctx)
+                                   BIGNUM *a, BIGNUM *b, BN_CTX *_1)
 {
     int ret = 0;
 
+    osslunused1();
     if (p != NULL) {
         if (!BN_copy(p, group->field))
             return 0;
@@ -372,9 +375,9 @@ int ec_GF2m_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
  * Set an EC_POINT to the point at infinity. A point at infinity is
  * represented by having Z=0.
  */
-int ec_GF2m_simple_point_set_to_infinity(const EC_GROUP *group,
-                                         EC_POINT *point)
+int ec_GF2m_simple_point_set_to_infinity(const EC_GROUP *_1, EC_POINT *point)
 {
+    osslunused1();
     point->Z_is_one = 0;
     BN_zero(point->Z);
     return 1;
@@ -384,12 +387,14 @@ int ec_GF2m_simple_point_set_to_infinity(const EC_GROUP *group,
  * Set the coordinates of an EC_POINT using affine coordinates. Note that
  * the simple implementation only uses affine coordinates.
  */
-int ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *group,
+int ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *_1,
                                                 EC_POINT *point,
                                                 const BIGNUM *x,
-                                                const BIGNUM *y, BN_CTX *ctx)
+                                                const BIGNUM *y, BN_CTX *_2)
 {
     int ret = 0;
+
+    osslunused2();
     if (x == NULL || y == NULL) {
         ECerr(EC_F_EC_GF2M_SIMPLE_POINT_SET_AFFINE_COORDINATES,
               ERR_R_PASSED_NULL_PARAMETER);
@@ -419,10 +424,11 @@ int ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *group,
 int ec_GF2m_simple_point_get_affine_coordinates(const EC_GROUP *group,
                                                 const EC_POINT *point,
                                                 BIGNUM *x, BIGNUM *y,
-                                                BN_CTX *ctx)
+                                                BN_CTX *_1)
 {
     int ret = 0;
 
+    osslunused1();
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GF2M_SIMPLE_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);
@@ -587,9 +593,9 @@ int ec_GF2m_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
 }
 
 /* Indicates whether the given point is the point at infinity. */
-int ec_GF2m_simple_is_at_infinity(const EC_GROUP *group,
-                                  const EC_POINT *point)
+int ec_GF2m_simple_is_at_infinity(const EC_GROUP *_1, const EC_POINT *point)
 {
+    osslunused1();
     return BN_is_zero(point->Z);
 }
 

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -467,20 +467,23 @@ static int eckey_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
 }
 
 static int eckey_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                             ASN1_PCTX *ctx)
+                             ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PARAM);
 }
 
 static int eckey_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                           ASN1_PCTX *ctx)
+                           ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PUBLIC);
 }
 
 static int eckey_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                            ASN1_PCTX *ctx)
+                            ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PRIVATE);
 }
 

--- a/crypto/ec/ec_lcl.h
+++ b/crypto/ec/ec_lcl.h
@@ -70,6 +70,7 @@
 
 #include <stdlib.h>
 
+#include <e_os.h>
 #include <openssl/obj_mac.h>
 #include <openssl/ec.h>
 #include <openssl/bn.h>

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -352,8 +352,9 @@ BN_MONT_CTX *EC_GROUP_get_mont_data(const EC_GROUP *group)
     return group->mont_data;
 }
 
-int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, BN_CTX *ctx)
+int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, BN_CTX *_1)
 {
+    osslunused1();
     if (group->order == NULL)
         return 0;
     if (!BN_copy(order, group->order))
@@ -374,10 +375,9 @@ int EC_GROUP_order_bits(const EC_GROUP *group)
     return 0;
 }
 
-int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor,
-                          BN_CTX *ctx)
+int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor, BN_CTX *_1)
 {
-
+    osslunused1();
     if (group->cofactor == NULL)
         return 0;
     if (!BN_copy(cofactor, group->cofactor))

--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -118,7 +118,7 @@ int ossl_ecdh_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
     group = EC_KEY_get0_group(ecdh);
 
     if (EC_KEY_get_flags(ecdh) & EC_FLAG_COFACTOR_ECDH) {
-        if (!EC_GROUP_get_cofactor(group, x, ctx) ||
+        if (!EC_GROUP_get_cofactor(group, x, NULL) ||
             !BN_mul(x, x, priv_key, ctx)) {
             ECerr(EC_F_OSSL_ECDH_COMPUTE_KEY, ERR_R_MALLOC_FAILURE);
             goto err;

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -63,11 +63,13 @@
 #include <openssl/ec.h>
 #include "ec_lcl.h"
 
-int ossl_ecdsa_sign(int type, const unsigned char *dgst, int dlen,
+int ossl_ecdsa_sign(int _1, const unsigned char *dgst, int dlen,
                     unsigned char *sig, unsigned int *siglen,
                     const BIGNUM *kinv, const BIGNUM *r, EC_KEY *eckey)
 {
     ECDSA_SIG *s;
+
+    osslunused1();
     RAND_seed(dgst, dlen);
     s = ECDSA_do_sign_ex(dgst, dlen, kinv, r, eckey);
     if (s == NULL) {
@@ -348,7 +350,7 @@ ECDSA_SIG *ossl_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
  *      0: incorrect signature
  *     -1: error
  */
-int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
+int ossl_ecdsa_verify(int _1, const unsigned char *dgst, int dgst_len,
                       const unsigned char *sigbuf, int sig_len, EC_KEY *eckey)
 {
     ECDSA_SIG *s;
@@ -357,6 +359,7 @@ int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
     int derlen = -1;
     int ret = -1;
 
+    osslunused1();
     s = ECDSA_SIG_new();
     if (s == NULL)
         return (ret);

--- a/crypto/ec/eck_prn.c
+++ b/crypto/ec/eck_prn.c
@@ -279,36 +279,31 @@ int ECPKParameters_print(BIO *bp, const EC_GROUP *x, int off)
                 goto err;
 
             /* print the polynomial */
-            if ((p != NULL) && !ASN1_bn_print(bp, "Polynomial:", p, buffer,
-                                              off))
+            if ((p != NULL) && !ASN1_bn_print(bp, "Polynomial:", p, NULL, off))
                 goto err;
         } else {
-            if ((p != NULL) && !ASN1_bn_print(bp, "Prime:", p, buffer, off))
+            if ((p != NULL) && !ASN1_bn_print(bp, "Prime:", p, NULL, off))
                 goto err;
         }
-        if ((a != NULL) && !ASN1_bn_print(bp, "A:   ", a, buffer, off))
+        if ((a != NULL) && !ASN1_bn_print(bp, "A:   ", a, NULL, off))
             goto err;
-        if ((b != NULL) && !ASN1_bn_print(bp, "B:   ", b, buffer, off))
+        if ((b != NULL) && !ASN1_bn_print(bp, "B:   ", b, NULL, off))
             goto err;
         if (form == POINT_CONVERSION_COMPRESSED) {
-            if ((gen != NULL) && !ASN1_bn_print(bp, gen_compressed, gen,
-                                                buffer, off))
+            if ((gen != NULL) && !ASN1_bn_print(bp, gen_compressed, gen, NULL, off))
                 goto err;
         } else if (form == POINT_CONVERSION_UNCOMPRESSED) {
-            if ((gen != NULL) && !ASN1_bn_print(bp, gen_uncompressed, gen,
-                                                buffer, off))
+            if ((gen != NULL) && !ASN1_bn_print(bp, gen_uncompressed, gen, NULL, off))
                 goto err;
         } else {                /* form == POINT_CONVERSION_HYBRID */
 
-            if ((gen != NULL) && !ASN1_bn_print(bp, gen_hybrid, gen,
-                                                buffer, off))
+            if ((gen != NULL) && !ASN1_bn_print(bp, gen_hybrid, gen, NULL, off))
                 goto err;
         }
-        if ((order != NULL) && !ASN1_bn_print(bp, "Order: ", order,
-                                              buffer, off))
+        if ((order != NULL) && !ASN1_bn_print(bp, "Order: ", order, NULL, off))
             goto err;
         if ((cofactor != NULL) && !ASN1_bn_print(bp, "Cofactor: ", cofactor,
-                                                 buffer, off))
+                                                 NULL, off))
             goto err;
         if (seed && !print_bin(bp, "Seed:", seed, seed_len, off))
             goto err;

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -265,8 +265,9 @@ int ec_GFp_mont_field_decode(const EC_GROUP *group, BIGNUM *r,
 }
 
 int ec_GFp_mont_field_set_to_one(const EC_GROUP *group, BIGNUM *r,
-                                 BN_CTX *ctx)
+                                 BN_CTX *_1)
 {
+    osslunused1();
     if (group->field_data2 == NULL) {
         ECerr(EC_F_EC_GFP_MONT_FIELD_SET_TO_ONE, EC_R_NOT_INITIALIZED);
         return 0;

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1277,11 +1277,12 @@ int ec_GFp_nistp224_group_set_curve(EC_GROUP *group, const BIGNUM *p,
 int ec_GFp_nistp224_point_get_affine_coordinates(const EC_GROUP *group,
                                                  const EC_POINT *point,
                                                  BIGNUM *x, BIGNUM *y,
-                                                 BN_CTX *ctx)
+                                                 BN_CTX *_1)
 {
     felem z1, z2, x_in, y_in, x_out, y_out;
     widefelem tmp;
 
+    osslunused1();
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GFP_NISTP224_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1894,12 +1894,13 @@ int ec_GFp_nistp256_group_set_curve(EC_GROUP *group, const BIGNUM *p,
 int ec_GFp_nistp256_point_get_affine_coordinates(const EC_GROUP *group,
                                                  const EC_POINT *point,
                                                  BIGNUM *x, BIGNUM *y,
-                                                 BN_CTX *ctx)
+                                                 BN_CTX *_1)
 {
     felem z1, z2, x_in, y_in;
     smallfelem x_out, y_out;
     longfelem tmp;
 
+    osslunused1();
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GFP_NISTP256_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1722,11 +1722,12 @@ int ec_GFp_nistp521_group_set_curve(EC_GROUP *group, const BIGNUM *p,
 int ec_GFp_nistp521_point_get_affine_coordinates(const EC_GROUP *group,
                                                  const EC_POINT *point,
                                                  BIGNUM *x, BIGNUM *y,
-                                                 BN_CTX *ctx)
+                                                 BN_CTX *_1)
 {
     felem z1, z2, x_in, y_in, x_out, y_out;
     largefelem tmp;
 
+    osslunused1();
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GFP_NISTP521_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1337,7 +1337,7 @@ err:
 
 __owur static int ecp_nistz256_get_affine(const EC_GROUP *group,
                                           const EC_POINT *point,
-                                          BIGNUM *x, BIGNUM *y, BN_CTX *ctx)
+                                          BIGNUM *x, BIGNUM *y, BN_CTX *_1)
 {
     BN_ULONG z_inv2[P256_LIMBS];
     BN_ULONG z_inv3[P256_LIMBS];
@@ -1346,6 +1346,7 @@ __owur static int ecp_nistz256_get_affine(const EC_GROUP *group,
     BN_ULONG point_x[P256_LIMBS], point_y[P256_LIMBS], point_z[P256_LIMBS];
     BN_ULONG x_ret[P256_LIMBS], y_ret[P256_LIMBS];
 
+    osslunused1();
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_ECP_NISTZ256_GET_AFFINE, EC_R_POINT_AT_INFINITY);
         return 0;

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -395,9 +395,9 @@ int ec_GFp_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
     return 1;
 }
 
-int ec_GFp_simple_point_set_to_infinity(const EC_GROUP *group,
-                                        EC_POINT *point)
+int ec_GFp_simple_point_set_to_infinity(const EC_GROUP *_1, EC_POINT *point)
 {
+    osslunused1();
     point->Z_is_one = 0;
     BN_zero(point->Z);
     return 1;
@@ -972,8 +972,9 @@ int ec_GFp_simple_dbl(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a,
     return ret;
 }
 
-int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
+int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *_1)
 {
+    osslunused1();
     if (EC_POINT_is_at_infinity(group, point) || BN_is_zero(point->Y))
         /* point is its own inverse */
         return 1;
@@ -981,8 +982,9 @@ int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
     return BN_usub(point->Y, group->field, point->Y);
 }
 
-int ec_GFp_simple_is_at_infinity(const EC_GROUP *group, const EC_POINT *point)
+int ec_GFp_simple_is_at_infinity(const EC_GROUP *_1, const EC_POINT *point)
 {
+    osslunused1();
     return BN_is_zero(point->Z);
 }
 

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -224,9 +224,11 @@ static int int_engine_module_init(CONF_IMODULE *md, const CONF *cnf)
     return 1;
 }
 
-static void int_engine_module_finish(CONF_IMODULE *md)
+static void int_engine_module_finish(CONF_IMODULE *_1)
 {
     ENGINE *e;
+
+    osslunused1();
     while ((e = sk_ENGINE_pop(initialized_engines)))
         ENGINE_finish(e);
     sk_ENGINE_free(initialized_engines);

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -103,11 +103,11 @@ static int int_ctrl_cmd_by_num(const ENGINE_CMD_DEFN *defn, unsigned int num)
     return -1;
 }
 
-static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
-                           void (*f) (void))
+static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p)
 {
     int idx;
     char *s = (char *)p;
+
     /* Take care of the easy one first (eg. it requires no searches) */
     if (cmd == ENGINE_CTRL_GET_FIRST_CMD_TYPE) {
         if ((e->cmd_defns == NULL) || int_ctrl_cmd_is_null(e->cmd_defns))
@@ -206,7 +206,7 @@ int ENGINE_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
     case ENGINE_CTRL_GET_DESC_FROM_CMD:
     case ENGINE_CTRL_GET_CMD_FLAGS:
         if (ctrl_exists && !(e->flags & ENGINE_FLAGS_MANUAL_CMD_CTRL))
-            return int_ctrl_helper(e, cmd, i, p, f);
+            return int_ctrl_helper(e, cmd, i, p);
         if (!ctrl_exists) {
             ENGINEerr(ENGINE_F_ENGINE_CTRL, ENGINE_R_NO_CONTROL_FUNCTION);
             /*

--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -180,10 +180,11 @@ static void int_free_str(char *s)
  * a "free" handler and that will get called if an ENGINE is being destroyed
  * and there was an ex_data element corresponding to our context type.
  */
-static void dynamic_data_ctx_free_func(void *parent, void *ptr,
-                                       CRYPTO_EX_DATA *ad, int idx, long argl,
-                                       void *argp)
+static void dynamic_data_ctx_free_func(void *_1, void *ptr,
+                                       CRYPTO_EX_DATA *_2, int _3, long _4,
+                                       void *_5)
 {
+    osslunused5();
     if (ptr) {
         dynamic_data_ctx *ctx = (dynamic_data_ctx *)ptr;
         DSO_free(ctx->dynamic_dso);
@@ -314,29 +315,32 @@ void engine_load_dynamic_internal(void)
     ERR_clear_error();
 }
 
-static int dynamic_init(ENGINE *e)
+static int dynamic_init(ENGINE *_1)
 {
     /*
      * We always return failure - the "dynamic" engine itself can't be used
      * for anything.
      */
+    osslunused1();
     return 0;
 }
 
-static int dynamic_finish(ENGINE *e)
+static int dynamic_finish(ENGINE *_1)
 {
     /*
      * This should never be called on account of "dynamic_init" always
      * failing.
      */
+    osslunused1();
     return 0;
 }
 
-static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*_1) (void))
 {
     dynamic_data_ctx *ctx = dynamic_get_data_ctx(e);
     int initialised;
 
+    osslunused1();
     if (!ctx) {
         ENGINEerr(ENGINE_F_DYNAMIC_CTRL, ENGINE_R_NOT_LOADED);
         return 0;

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -247,11 +247,12 @@ typedef struct {
 } TEST_RC4_KEY;
 # define test(ctx) ((TEST_RC4_KEY *)EVP_CIPHER_CTX_cipher_data(ctx))
 static int test_rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             const unsigned char *_1, int _2)
 {
 # ifdef TEST_ENG_OPENSSL_RC4_P_INIT
     fprintf(stderr, "(TEST_ENG_OPENSSL_RC4) test_init_key() called\n");
 # endif
+    osslunused2();
     memcpy(&test(ctx)->key[0], key, EVP_CIPHER_CTX_key_length(ctx));
     RC4_set_key(&test(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx),
                 test(ctx)->key);
@@ -336,9 +337,10 @@ static int test_cipher_nids(const int **nids)
     return pos;
 }
 
-static int openssl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
+static int openssl_ciphers(ENGINE *_1, const EVP_CIPHER **cipher,
                            const int **nids, int nid)
 {
+    osslunused1();
     if (!cipher) {
         /* We are returning a list of supported nids */
         return test_cipher_nids(nids);
@@ -432,9 +434,10 @@ static int test_digest_nids(const int **nids)
     return pos;
 }
 
-static int openssl_digests(ENGINE *e, const EVP_MD **digest,
+static int openssl_digests(ENGINE *_1, const EVP_MD **digest,
                            const int **nids, int nid)
 {
+    osslunused1();
     if (!digest) {
         /* We are returning a list of supported nids */
         return test_digest_nids(nids);
@@ -455,12 +458,13 @@ static int openssl_digests(ENGINE *e, const EVP_MD **digest,
 #endif
 
 #ifdef TEST_ENG_OPENSSL_PKEY
-static EVP_PKEY *openssl_load_privkey(ENGINE *eng, const char *key_id,
-                                      UI_METHOD *ui_method,
-                                      void *callback_data)
+static EVP_PKEY *openssl_load_privkey(ENGINE *_1, const char *key_id,
+                                      UI_METHOD *_2, void *_3)
 {
     BIO *in;
     EVP_PKEY *key;
+
+    osslunused3();
     fprintf(stderr, "(TEST_ENG_OPENSSL_PKEY)Loading Private key %s\n",
             key_id);
     in = BIO_new_file(key_id, "r");
@@ -680,8 +684,9 @@ static int ossl_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 
 #endif
 
-int openssl_destroy(ENGINE *e)
+int openssl_destroy(ENGINE *_1)
 {
+    osslunused1();
     test_sha_md_destroy();
 #ifdef TEST_ENG_OPENSSL_RC4
     test_r4_cipher_destroy();

--- a/crypto/engine/eng_rdrand.c
+++ b/crypto/engine/eng_rdrand.c
@@ -55,6 +55,7 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>
+#include <e_os.h>
 
 #if (defined(__i386)   || defined(__i386__)   || defined(_M_IX86) || \
      defined(__x86_64) || defined(__x86_64__) || \
@@ -98,8 +99,9 @@ static RAND_METHOD rdrand_meth = {
     random_status,
 };
 
-static int rdrand_init(ENGINE *e)
+static int rdrand_init(ENGINE *_1)
 {
+    osslunused1();
     return 1;
 }
 

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -205,10 +205,12 @@ typedef struct {
     int len;
 } ENGINE_FIND_STR;
 
-static void look_str_cb(int nid, STACK_OF(ENGINE) *sk, ENGINE *def, void *arg)
+static void look_str_cb(int nid, STACK_OF(ENGINE) *sk, ENGINE *_1, void *arg)
 {
     ENGINE_FIND_STR *lk = arg;
     int i;
+
+    osslunused1();
     if (lk->ameth)
         return;
     for (i = 0; i < sk_ENGINE_num(sk); i++) {

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -852,8 +852,9 @@ void ERR_remove_thread_state(const CRYPTO_THREADID *id)
 }
 
 #if OPENSSL_API_COMPAT < 0x10000000L
-void ERR_remove_state(unsigned long pid)
+void ERR_remove_state(unsigned long _1)
 {
+    osslunused1();
     ERR_remove_thread_state(NULL);
 }
 #endif

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -85,10 +85,11 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
 }
 
 #ifndef OPENSSL_NO_STDIO
-static int print_fp(const char *str, size_t len, void *fp)
+static int print_fp(const char *str, size_t _1, void *fp)
 {
     BIO bio;
 
+    osslunused1();
     BIO_set(&bio, BIO_s_file());
     BIO_set_fp(&bio, fp, BIO_NOCLOSE);
 

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -57,6 +57,7 @@
 # include <assert.h>
 # include <openssl/aes.h>
 # include "internal/evp_int.h"
+# include "evp_locl.h"
 # include "modes_lcl.h"
 # include <openssl/rand.h>
 
@@ -289,11 +290,12 @@ void gcm_ghash_avx(u64 Xi[2], const u128 Htable[16], const u8 *in,
 #  endif
 
 static int aesni_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                          const unsigned char *iv, int enc)
+                          const unsigned char *_1, int enc)
 {
     int ret, mode;
     EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
 
+    osslunused1();
     mode = EVP_CIPHER_CTX_mode(ctx);
     if ((mode == EVP_CIPH_ECB_MODE || mode == EVP_CIPH_CBC_MODE)
         && !enc) {
@@ -367,9 +369,11 @@ static int aesni_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                             const unsigned char *in, size_t len);
 
 static int aesni_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                              const unsigned char *iv, int enc)
+                              const unsigned char *iv, int _1)
 {
     EVP_AES_GCM_CTX *gctx = EVP_C_DATA(EVP_AES_GCM_CTX,ctx);
+
+    osslunused1();
     if (!iv && !key)
         return 1;
     if (key) {
@@ -1054,11 +1058,12 @@ void HWAES_ctr32_encrypt_blocks(const unsigned char *in, unsigned char *out,
         BLOCK_CIPHER_generic(nid,keylen,1,16,ctr,ctr,CTR,flags)
 
 static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        const unsigned char *_1, int enc)
 {
     int ret, mode;
     EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
 
+    osslunused1();
     mode = EVP_CIPHER_CTX_mode(ctx);
     if ((mode == EVP_CIPH_ECB_MODE || mode == EVP_CIPH_CBC_MODE)
         && !enc)
@@ -1447,9 +1452,11 @@ static int aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 }
 
 static int aes_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            const unsigned char *iv, int _1)
 {
     EVP_AES_GCM_CTX *gctx = EVP_C_DATA(EVP_AES_GCM_CTX,ctx);
+
+    osslunused1();
     if (!iv && !key)
         return 1;
     if (key) {
@@ -1790,9 +1797,11 @@ BLOCK_CIPHER_custom(NID_aes, 128, 1, 12, gcm, GCM,
     BLOCK_CIPHER_custom(NID_aes, 256, 1, 12, gcm, GCM,
                     EVP_CIPH_FLAG_AEAD_CIPHER | CUSTOM_FLAGS)
 
-static int aes_xts_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
+static int aes_xts_ctrl(EVP_CIPHER_CTX *c, int type, int _1, void *ptr)
 {
     EVP_AES_XTS_CTX *xctx = EVP_C_DATA(EVP_AES_XTS_CTX,c);
+
+    osslunused1();
     if (type == EVP_CTRL_COPY) {
         EVP_CIPHER_CTX *out = ptr;
         EVP_AES_XTS_CTX *xctx_out = EVP_C_DATA(EVP_AES_XTS_CTX,out);
@@ -2029,9 +2038,11 @@ static int aes_ccm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 }
 
 static int aes_ccm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            const unsigned char *iv, int _1)
 {
     EVP_AES_CCM_CTX *cctx = EVP_C_DATA(EVP_AES_CCM_CTX,ctx);
+
+    osslunused1();
     if (!iv && !key)
         return 1;
     if (key)
@@ -2209,9 +2220,11 @@ typedef struct {
 } EVP_AES_WRAP_CTX;
 
 static int aes_wrap_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             const unsigned char *iv, int _1)
 {
     EVP_AES_WRAP_CTX *wctx = EVP_C_DATA(EVP_AES_WRAP_CTX,ctx);
+
+    osslunused1();
     if (!iv && !key)
         return 1;
     if (key) {
@@ -2458,9 +2471,11 @@ void HWAES_ocb_decrypt(const unsigned char *in, unsigned char *out,
 #  endif
 
 static int aes_ocb_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            const unsigned char *iv, int _1)
 {
     EVP_AES_OCB_CTX *octx = EVP_C_DATA(EVP_AES_OCB_CTX,ctx);
+
+    osslunused1();
     if (!iv && !key)
         return 1;
     if (key) {

--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -59,6 +59,7 @@
 # include <openssl/aes.h>
 # include <openssl/sha.h>
 # include <openssl/rand.h>
+# include "evp_locl.h"
 # include "modes_lcl.h"
 # include "internal/evp_int.h"
 
@@ -120,11 +121,12 @@ void aesni256_cbc_sha1_dec(const void *inp, void *out, size_t blocks,
 
 static int aesni_cbc_hmac_sha1_init_key(EVP_CIPHER_CTX *ctx,
                                         const unsigned char *inkey,
-                                        const unsigned char *iv, int enc)
+                                        const unsigned char *_1, int enc)
 {
     EVP_AES_HMAC_SHA1 *key = data(ctx);
     int ret;
 
+    osslunused1();
     if (enc)
         ret = aesni_set_encrypt_key(inkey,
                                     EVP_CIPHER_CTX_key_length(ctx) * 8,

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -60,6 +60,7 @@
 # include <openssl/sha.h>
 # include <openssl/rand.h>
 # include "modes_lcl.h"
+# include "evp_locl.h"
 # include "internal/evp_int.h"
 
 # ifndef EVP_CIPH_FLAG_AEAD_CIPHER
@@ -116,11 +117,12 @@ int aesni_cbc_sha256_enc(const void *inp, void *out, size_t blocks,
 
 static int aesni_cbc_hmac_sha256_init_key(EVP_CIPHER_CTX *ctx,
                                           const unsigned char *inkey,
-                                          const unsigned char *iv, int enc)
+                                          const unsigned char *_1, int enc)
 {
     EVP_AES_HMAC_SHA256 *key = data(ctx);
     int ret;
 
+    osslunused1();
     if (enc)
         memset(&key->ks, 0, sizeof(key->ks.rd_key)),
             ret = aesni_set_encrypt_key(inkey,

--- a/crypto/evp/e_bf.c
+++ b/crypto/evp/e_bf.c
@@ -77,8 +77,9 @@ IMPLEMENT_BLOCK_CIPHER(bf, ks, BF, EVP_BF_KEY, NID_bf, 8, 16, 8, 64,
                        EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 
 static int bf_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                       const unsigned char *iv, int enc)
+                        const unsigned char *_1, int _2)
 {
+    osslunused2();
     BF_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;
 }

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -64,6 +64,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <openssl/camellia.h>
 # include "internal/evp_int.h"
 # include "modes_lcl.h"
+# include "evp_locl.h"
 
 static int camellia_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                              const unsigned char *iv, int enc);
@@ -255,11 +256,12 @@ const EVP_CIPHER *EVP_camellia_##keylen##_##mode(void) \
 
 /* The subkey for Camellia is generated. */
 static int camellia_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             const unsigned char *_1, int enc)
 {
     int ret, mode;
     EVP_CAMELLIA_KEY *dat = EVP_C_DATA(EVP_CAMELLIA_KEY,ctx);
 
+    osslunused1();
     ret = Camellia_set_key(key, EVP_CIPHER_CTX_key_length(ctx) * 8, &dat->ks);
     if (ret < 0) {
         EVPerr(EVP_F_CAMELLIA_INIT_KEY, EVP_R_CAMELLIA_KEY_SETUP_FAILED);

--- a/crypto/evp/e_cast.c
+++ b/crypto/evp/e_cast.c
@@ -79,8 +79,9 @@ IMPLEMENT_BLOCK_CIPHER(cast5, ks, CAST, EVP_CAST_KEY,
                        EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 
 static int cast_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+                         const unsigned char *_1, int _2)
 {
+    osslunused2();
     CAST_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;
 }

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -73,11 +73,12 @@ typedef struct {
 
 static int chacha_init_key(EVP_CIPHER_CTX *ctx,
                            const unsigned char user_key[CHACHA_KEY_SIZE],
-                           const unsigned char iv[CHACHA_CTR_SIZE], int enc)
+                           const unsigned char iv[CHACHA_CTR_SIZE], int _1)
 {
     EVP_CHACHA_KEY *key = data(ctx);
     unsigned int i;
 
+    osslunused1();
     if (user_key)
         for (i = 0; i < CHACHA_KEY_SIZE; i+=4) {
             key->key.d[i/4] = CHACHA_U8TOU32(user_key+i);

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -247,11 +247,12 @@ BLOCK_CIPHER_defs(des, EVP_DES_KEY, NID_des, 8, 8, 8, 64,
                      EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, des_ctrl)
 
 static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        const unsigned char *_1, int _2)
 {
     DES_cblock *deskey = (DES_cblock *)key;
     EVP_DES_KEY *dat = (EVP_DES_KEY *) EVP_CIPHER_CTX_cipher_data(ctx);
 
+    osslunused2();
     dat->stream.cbc = NULL;
 # if defined(SPARC_DES_CAPABLE)
     if (SPARC_DES_CAPABLE) {
@@ -268,9 +269,10 @@ static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     return 1;
 }
 
-static int des_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
+static int des_ctrl(EVP_CIPHER_CTX *_1, int type, int _2, void *ptr)
 {
 
+    osslunused2();
     switch (type) {
     case EVP_CTRL_RAND_KEY:
         if (RAND_bytes(ptr, 8) <= 0)

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -268,11 +268,12 @@ BLOCK_CIPHER_defs(des_ede, DES_EDE_KEY, NID_des_ede, 8, 16, 8, 64,
                      des_ede3_init_key, NULL, NULL, NULL, des3_ctrl)
 
 static int des_ede_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            const unsigned char *_1, int _2)
 {
     DES_cblock *deskey = (DES_cblock *)key;
     DES_EDE_KEY *dat = data(ctx);
 
+    osslunused2();
     dat->stream.cbc = NULL;
 # if defined(SPARC_DES_CAPABLE)
     if (SPARC_DES_CAPABLE) {
@@ -295,11 +296,12 @@ static int des_ede_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 }
 
 static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             const unsigned char *_1, int _2)
 {
     DES_cblock *deskey = (DES_cblock *)key;
     DES_EDE_KEY *dat = data(ctx);
 
+    osslunused2();
     dat->stream.cbc = NULL;
 # if defined(SPARC_DES_CAPABLE)
     if (SPARC_DES_CAPABLE) {
@@ -321,11 +323,11 @@ static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     return 1;
 }
 
-static int des3_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
+static int des3_ctrl(EVP_CIPHER_CTX *ctx, int type, int _1, void *ptr)
 {
-
     DES_cblock *deskey = ptr;
 
+    osslunused1();
     switch (type) {
     case EVP_CTRL_RAND_KEY:
         if (RAND_bytes(ptr, EVP_CIPHER_CTX_key_length(ctx)) <= 0)

--- a/crypto/evp/e_idea.c
+++ b/crypto/evp/e_idea.c
@@ -95,8 +95,9 @@ BLOCK_CIPHER_func_cbc(idea, idea, EVP_IDEA_KEY, ks)
                   EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 
 static int idea_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+                         const unsigned char *_1, int enc)
 {
+    osslunused1();
     if (!enc) {
         if (EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_OFB_MODE)
             enc = 1;

--- a/crypto/evp/e_null.c
+++ b/crypto/evp/e_null.c
@@ -83,15 +83,17 @@ const EVP_CIPHER *EVP_enc_null(void)
     return (&n_cipher);
 }
 
-static int null_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+static int null_init_key(EVP_CIPHER_CTX *_1, const unsigned char *_2,
+                         const unsigned char *_3, int _4)
 {
+    osslunused4();
     return 1;
 }
 
-static int null_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+static int null_cipher(EVP_CIPHER_CTX *_1, unsigned char *out,
                        const unsigned char *in, size_t inl)
 {
+    osslunused1();
     if (in != out)
         memcpy(out, in, inl);
     return 1;

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -129,8 +129,9 @@ const EVP_CIPHER *EVP_rc2_40_cbc(void)
 }
 
 static int rc2_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        const unsigned char *_1, int _2)
 {
+    osslunused2();
     RC2_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx),
                 key, data(ctx)->key_bits);
     return 1;

--- a/crypto/evp/e_rc4.c
+++ b/crypto/evp/e_rc4.c
@@ -118,8 +118,9 @@ const EVP_CIPHER *EVP_rc4_40(void)
 }
 
 static int rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        const unsigned char *_1, int _2)
 {
+    osslunused2();
     RC4_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;
 }

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -59,6 +59,7 @@
 # include <openssl/objects.h>
 # include <openssl/rc4.h>
 # include <openssl/md5.h>
+# include "evp_locl.h"
 # include "internal/evp_int.h"
 
 # ifndef EVP_CIPH_FLAG_AEAD_CIPHER
@@ -85,10 +86,11 @@ void rc4_md5_enc(RC4_KEY *key, const void *in0, void *out,
 
 static int rc4_hmac_md5_init_key(EVP_CIPHER_CTX *ctx,
                                  const unsigned char *inkey,
-                                 const unsigned char *iv, int enc)
+                                 const unsigned char *_1, int _2)
 {
     EVP_RC4_HMAC_MD5 *key = data(ctx);
 
+    osslunused2();
     RC4_set_key(&key->ks, EVP_CIPHER_CTX_key_length(ctx), inkey);
 
     MD5_Init(&key->head);       /* handy when benchmarking */

--- a/crypto/evp/e_rc5.c
+++ b/crypto/evp/e_rc5.c
@@ -112,8 +112,9 @@ static int rc5_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 }
 
 static int r_32_12_16_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                               const unsigned char *iv, int enc)
+                               const unsigned char *_1, int _2)
 {
+    osslunused2();
     RC5_32_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx),
                    key, data(ctx)->rounds);
     return 1;

--- a/crypto/evp/e_seed.c
+++ b/crypto/evp/e_seed.c
@@ -60,6 +60,7 @@
 # include <assert.h>
 # include <openssl/seed.h>
 # include "internal/evp_int.h"
+# include "evp_locl.h"
 
 static int seed_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                          const unsigned char *iv, int enc);
@@ -72,8 +73,9 @@ IMPLEMENT_BLOCK_CIPHER(seed, ks, SEED, EVP_SEED_KEY, NID_seed,
                        16, 16, 16, 128, 0, seed_init_key, 0, 0, 0, 0)
 
 static int seed_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+                         const unsigned char *_1, int _2)
 {
+    osslunused2();
     SEED_set_key(key, &EVP_C_DATA(EVP_SEED_KEY,ctx)->ks);
     return 1;
 }

--- a/crypto/evp/e_xcbc_d.c
+++ b/crypto/evp/e_xcbc_d.c
@@ -98,10 +98,11 @@ const EVP_CIPHER *EVP_desx_cbc(void)
 }
 
 static int desx_cbc_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             const unsigned char *_1, int _2)
 {
     DES_cblock *deskey = (DES_cblock *)key;
 
+    osslunused2();
     DES_set_key_unchecked(deskey, &data(ctx)->ks);
     memcpy(&data(ctx)->inw[0], &key[8], 8);
     memcpy(&data(ctx)->outw[0], &key[16], 8);

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -56,6 +56,7 @@
  *
  */
 
+#include <e_os.h>
 /* EVP_MD_CTX related stuff */
 
 struct evp_md_ctx_st {

--- a/crypto/evp/m_null.c
+++ b/crypto/evp/m_null.c
@@ -61,19 +61,23 @@
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 #include "internal/evp_int.h"
+#include "evp_locl.h"
 
-static int init(EVP_MD_CTX *ctx)
+static int init(EVP_MD_CTX *_1)
 {
+    osslunused1();
     return 1;
 }
 
-static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
+static int update(EVP_MD_CTX *_1, const void *_2, size_t _3)
 {
+    osslunused3();
     return 1;
 }
 
-static int final(EVP_MD_CTX *ctx, unsigned char *md)
+static int final(EVP_MD_CTX *_1, unsigned char *_2)
 {
+    osslunused2();
     return 1;
 }
 

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -196,15 +196,15 @@ main()
  */
 
 int PKCS5_v2_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
-                          ASN1_TYPE *param, const EVP_CIPHER *c,
-                          const EVP_MD *md, int en_de)
+                          ASN1_TYPE *param, const EVP_CIPHER *_1,
+                          const EVP_MD *_2, int en_de)
 {
     PBE2PARAM *pbe2 = NULL;
     const EVP_CIPHER *cipher;
     EVP_PBE_KEYGEN *kdf;
-
     int rv = 0;
 
+    osslunused2();
     pbe2 = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), param);
     if (pbe2 == NULL) {
         EVPerr(EVP_F_PKCS5_V2_PBE_KEYIVGEN, EVP_R_DECODE_ERROR);
@@ -245,7 +245,7 @@ int PKCS5_v2_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
 
 int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int passlen, ASN1_TYPE *param,
-                             const EVP_CIPHER *c, const EVP_MD *md, int en_de)
+                             const EVP_CIPHER *_1, const EVP_MD *_2, int en_de)
 {
     unsigned char *salt, key[EVP_MAX_KEY_LENGTH];
     int saltlen, iter;
@@ -255,6 +255,7 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
     PBKDF2PARAM *kdf = NULL;
     const EVP_MD *prfmd;
 
+    osslunused2();
     if (EVP_CIPHER_CTX_cipher(ctx) == NULL) {
         EVPerr(EVP_F_PKCS5_V2_PBKDF2_KEYIVGEN, EVP_R_NO_CIPHER_SET);
         goto err;

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -190,20 +190,22 @@ void CRYPTO_cleanup_all_ex_data(void)
  * Unregister a new index by replacing the callbacks with no-ops.
  * Any in-use instances are leaked.
  */
-static void dummy_new(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
-                     long argl, void *argp)
+static void dummy_new(void *_1, void *_2, CRYPTO_EX_DATA *_3, int _4,
+                     long _5, void *_6)
 {
+    osslunused6();
 }
 
-static void dummy_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
-                       long argl, void *argp)
+static void dummy_free(void *_1, void *_2, CRYPTO_EX_DATA *_3, int _4,
+                       long _5, void *_6)
 {
+    osslunused6();
 }
 
-static int dummy_dup(CRYPTO_EX_DATA *to, CRYPTO_EX_DATA *from,
-                     void *from_d, int idx,
-                     long argl, void *argp)
+static int dummy_dup(CRYPTO_EX_DATA *_1, CRYPTO_EX_DATA *_2,
+                     void *_3, int _4, long _5, void *_6)
 {
+    osslunused6();
     return 0;
 }
 

--- a/crypto/hmac/hm_ameth.c
+++ b/crypto/hmac/hm_ameth.c
@@ -68,8 +68,9 @@
  * length and to free up an HMAC key.
  */
 
-static int hmac_size(const EVP_PKEY *pkey)
+static int hmac_size(const EVP_PKEY *_1)
 {
+    osslunused1();
     return EVP_MAX_MD_SIZE;
 }
 
@@ -83,8 +84,9 @@ static void hmac_key_free(EVP_PKEY *pkey)
     }
 }
 
-static int hmac_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int hmac_pkey_ctrl(EVP_PKEY *_1, int op, long _2, void *arg2)
 {
+    osslunused2();
     switch (op) {
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
         *(int *)arg2 = NID_sha256;

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -133,8 +133,7 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
         ret = malloc(num);
     }
 #else
-    (void)file;
-    (void)line;
+    osslargused(file); osslargused(line);
     ret = malloc(num);
 #endif
 
@@ -182,8 +181,7 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
         return ret;
     }
 #else
-    (void)file;
-    (void)line;
+    osslargused(file); osslargused(line);
 #endif
     return realloc(str, num);
 
@@ -219,8 +217,7 @@ void *CRYPTO_clear_realloc(void *str, size_t old_len, size_t num,
         ret = malloc(num);
     }
 #else
-    (void)file;
-    (void)line;
+    osslargused(file); osslargused(line);
     ret = malloc(num);
 #endif
 

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -307,7 +307,7 @@ static void sh_add_to_list(char **list, char *ptr)
     *list = ptr;
 }
 
-static void sh_remove_from_list(char *ptr, char *list)
+static void sh_remove_from_list(char *ptr)
 {
     SH_LIST *temp, *temp2;
 
@@ -484,7 +484,7 @@ static char *sh_malloc(size_t size)
         /* remove from bigger list */
         OPENSSL_assert(!sh_testbit(temp, slist, sh.bitmalloc));
         sh_clearbit(temp, slist, sh.bittable);
-        sh_remove_from_list(temp, sh.freelist[slist]);
+        sh_remove_from_list(temp);
         OPENSSL_assert(temp != sh.freelist[slist]);
 
         /* done with bigger list */
@@ -510,7 +510,7 @@ static char *sh_malloc(size_t size)
     chunk = sh.freelist[list];
     OPENSSL_assert(sh_testbit(chunk, list, sh.bittable));
     sh_setbit(chunk, list, sh.bitmalloc);
-    sh_remove_from_list(chunk, sh.freelist[list]);
+    sh_remove_from_list(chunk);
 
     OPENSSL_assert(WITHIN_ARENA(chunk));
 
@@ -539,10 +539,10 @@ static void sh_free(char *ptr)
         OPENSSL_assert(ptr != NULL);
         OPENSSL_assert(!sh_testbit(ptr, list, sh.bitmalloc));
         sh_clearbit(ptr, list, sh.bittable);
-        sh_remove_from_list(ptr, sh.freelist[list]);
+        sh_remove_from_list(ptr);
         OPENSSL_assert(!sh_testbit(ptr, list, sh.bitmalloc));
         sh_clearbit(buddy, list, sh.bittable);
-        sh_remove_from_list(buddy, sh.freelist[list]);
+        sh_remove_from_list(buddy);
 
         list--;
 

--- a/crypto/modes/cfb128.c
+++ b/crypto/modes/cfb128.c
@@ -222,12 +222,13 @@ static void cfbr_encrypt_block(const unsigned char *in, unsigned char *out,
 /* N.B. This expects the input to be packed, MS bit first */
 void CRYPTO_cfb128_1_encrypt(const unsigned char *in, unsigned char *out,
                              size_t bits, const void *key,
-                             unsigned char ivec[16], int *num,
+                             unsigned char ivec[16], int *_1,
                              int enc, block128_f block)
 {
     size_t n;
     unsigned char c[1], d[1];
 
+    osslunused1();
     assert(in && out && key && ivec && num);
     assert(*num == 0);
 
@@ -241,11 +242,12 @@ void CRYPTO_cfb128_1_encrypt(const unsigned char *in, unsigned char *out,
 
 void CRYPTO_cfb128_8_encrypt(const unsigned char *in, unsigned char *out,
                              size_t length, const void *key,
-                             unsigned char ivec[16], int *num,
+                             unsigned char ivec[16], int *_1,
                              int enc, block128_f block)
 {
     size_t n;
 
+    osslunused1();
     assert(in && out && key && ivec && num);
     assert(*num == 0);
 

--- a/crypto/modes/modes_lcl.h
+++ b/crypto/modes/modes_lcl.h
@@ -5,6 +5,7 @@
  * ====================================================================
  */
 
+#include <e_os.h>
 #include <openssl/modes.h>
 
 #if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)

--- a/crypto/ocsp/ocsp_prn.c
+++ b/crypto/ocsp/ocsp_prn.c
@@ -76,9 +76,9 @@ static int ocsp_certid_print(BIO *bp, OCSP_CERTID *a, int indent)
     BIO_printf(bp, "%*sHash Algorithm: ", indent, "");
     i2a_ASN1_OBJECT(bp, a->hashAlgorithm.algorithm);
     BIO_printf(bp, "\n%*sIssuer Name Hash: ", indent, "");
-    i2a_ASN1_STRING(bp, &a->issuerNameHash, V_ASN1_OCTET_STRING);
+    i2a_ASN1_STRING(bp, &a->issuerNameHash, 0);
     BIO_printf(bp, "\n%*sIssuer Key Hash: ", indent, "");
-    i2a_ASN1_STRING(bp, &a->issuerKeyHash, V_ASN1_OCTET_STRING);
+    i2a_ASN1_STRING(bp, &a->issuerKeyHash, 0);
     BIO_printf(bp, "\n%*sSerial Number: ", indent, "");
     i2a_ASN1_INTEGER(bp, &a->serialNumber);
     BIO_printf(bp, "\n");
@@ -227,7 +227,7 @@ int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *o, unsigned long flags)
         X509_NAME_print_ex(bp, rid->value.byName, 0, XN_FLAG_ONELINE);
         break;
     case V_OCSP_RESPID_KEY:
-        i2a_ASN1_STRING(bp, rid->value.byKey, V_ASN1_OCTET_STRING);
+        i2a_ASN1_STRING(bp, rid->value.byKey, 0);
         break;
     }
 

--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -62,19 +62,17 @@
 #include <string.h>
 
 static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
-                            STACK_OF(X509) *certs, X509_STORE *st,
-                            unsigned long flags);
+                            STACK_OF(X509) *certs, unsigned long flags);
 static X509 *ocsp_find_signer_sk(STACK_OF(X509) *certs, OCSP_RESPID *id);
-static int ocsp_check_issuer(OCSP_BASICRESP *bs, STACK_OF(X509) *chain,
-                             unsigned long flags);
+static int ocsp_check_issuer(OCSP_BASICRESP *bs, STACK_OF(X509) *chain);
 static int ocsp_check_ids(STACK_OF(OCSP_SINGLERESP) *sresp,
                           OCSP_CERTID **ret);
 static int ocsp_match_issuerid(X509 *cert, OCSP_CERTID *cid,
                                STACK_OF(OCSP_SINGLERESP) *sresp);
-static int ocsp_check_delegated(X509 *x, int flags);
+static int ocsp_check_delegated(X509 *x);
 static int ocsp_req_find_signer(X509 **psigner, OCSP_REQUEST *req,
                                 X509_NAME *nm, STACK_OF(X509) *certs,
-                                X509_STORE *st, unsigned long flags);
+                                unsigned long flags);
 
 /* Verify a basic response message */
 
@@ -85,8 +83,8 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
     STACK_OF(X509) *chain = NULL;
     STACK_OF(X509) *untrusted = NULL;
     X509_STORE_CTX ctx;
-    int i, ret = 0;
-    ret = ocsp_find_signer(&signer, bs, certs, st, flags);
+    int i, ret = ocsp_find_signer(&signer, bs, certs, flags);
+
     if (!ret) {
         OCSPerr(OCSP_F_OCSP_BASIC_VERIFY,
                 OCSP_R_SIGNER_CERTIFICATE_NOT_FOUND);
@@ -146,7 +144,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
          * At this point we have a valid certificate chain need to verify it
          * against the OCSP issuer criteria.
          */
-        ret = ocsp_check_issuer(bs, chain, flags);
+        ret = ocsp_check_issuer(bs, chain);
 
         /* If fatal error or valid match then finish */
         if (ret != 0)
@@ -175,11 +173,11 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
 }
 
 static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
-                            STACK_OF(X509) *certs, X509_STORE *st,
-                            unsigned long flags)
+                            STACK_OF(X509) *certs, unsigned long flags)
 {
     X509 *signer;
     OCSP_RESPID *rid = &bs->tbsResponseData.responderId;
+
     if ((signer = ocsp_find_signer_sk(certs, rid))) {
         *psigner = signer;
         return 2;
@@ -221,8 +219,7 @@ static X509 *ocsp_find_signer_sk(STACK_OF(X509) *certs, OCSP_RESPID *id)
     return NULL;
 }
 
-static int ocsp_check_issuer(OCSP_BASICRESP *bs, STACK_OF(X509) *chain,
-                             unsigned long flags)
+static int ocsp_check_issuer(OCSP_BASICRESP *bs, STACK_OF(X509) *chain)
 {
     STACK_OF(OCSP_SINGLERESP) *sresp;
     X509 *signer, *sca;
@@ -251,7 +248,7 @@ static int ocsp_check_issuer(OCSP_BASICRESP *bs, STACK_OF(X509) *chain,
             return i;
         if (i) {
             /* We have a match, if extensions OK then success */
-            if (ocsp_check_delegated(signer, flags))
+            if (ocsp_check_delegated(signer))
                 return 1;
             return 0;
         }
@@ -350,7 +347,7 @@ static int ocsp_match_issuerid(X509 *cert, OCSP_CERTID *cid,
 
 }
 
-static int ocsp_check_delegated(X509 *x, int flags)
+static int ocsp_check_delegated(X509 *x)
 {
     if ((X509_get_extension_flags(x) & EXFLAG_XKUSAGE)
         && (X509_get_extended_key_usage(x) & XKU_OCSP_SIGN))
@@ -384,7 +381,7 @@ int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
         return 0;
     }
     nm = gen->d.directoryName;
-    ret = ocsp_req_find_signer(&signer, req, nm, certs, store, flags);
+    ret = ocsp_req_find_signer(&signer, req, nm, certs, flags);
     if (ret <= 0) {
         OCSPerr(OCSP_F_OCSP_REQUEST_VERIFY,
                 OCSP_R_SIGNER_CERTIFICATE_NOT_FOUND);
@@ -431,7 +428,7 @@ int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
 
 static int ocsp_req_find_signer(X509 **psigner, OCSP_REQUEST *req,
                                 X509_NAME *nm, STACK_OF(X509) *certs,
-                                X509_STORE *st, unsigned long flags)
+                                unsigned long flags)
 {
     X509 *signer;
     if (!(flags & OCSP_NOINTERN)) {

--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -156,10 +156,12 @@ const X509V3_EXT_METHOD v3_ocsp_serviceloc = {
     NULL
 };
 
-static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
+static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *_1, void *in, BIO *bp,
                           int ind)
 {
     OCSP_CRLID *a = in;
+
+    osslunused1();
     if (a->crlUrl) {
         if (BIO_printf(bp, "%*scrlUrl: ", ind, "") <= 0)
             goto err;
@@ -189,9 +191,10 @@ static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
     return 0;
 }
 
-static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
+static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *_1, void *cutoff,
                             BIO *bp, int ind)
 {
+    osslunused1();
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
     if (!ASN1_GENERALIZEDTIME_print(bp, cutoff))
@@ -199,9 +202,10 @@ static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
     return 1;
 }
 
-static int i2r_object(const X509V3_EXT_METHOD *method, void *oid, BIO *bp,
+static int i2r_object(const X509V3_EXT_METHOD *_1, void *oid, BIO *bp,
                       int ind)
 {
+    osslunused1();
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
     if (i2a_ASN1_OBJECT(bp, oid) <= 0)
@@ -261,37 +265,41 @@ static void ocsp_nonce_free(void *a)
     ASN1_OCTET_STRING_free(a);
 }
 
-static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
+static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *_1, void *nonce,
                           BIO *out, int indent)
 {
+    osslunused1();
     if (BIO_printf(out, "%*s", indent, "") <= 0)
         return 0;
-    if (i2a_ASN1_STRING(out, nonce, V_ASN1_OCTET_STRING) <= 0)
+    if (i2a_ASN1_STRING(out, nonce, 0) <= 0)
         return 0;
     return 1;
 }
 
 /* Nocheck is just a single NULL. Don't print anything and always set it */
 
-static int i2r_ocsp_nocheck(const X509V3_EXT_METHOD *method, void *nocheck,
-                            BIO *out, int indent)
+static int i2r_ocsp_nocheck(const X509V3_EXT_METHOD *_1, void *_2,
+                            BIO *_3, int _4)
 {
+    osslunused4();
     return 1;
 }
 
-static void *s2i_ocsp_nocheck(const X509V3_EXT_METHOD *method,
-                              X509V3_CTX *ctx, const char *str)
+static void *s2i_ocsp_nocheck(const X509V3_EXT_METHOD *_1,
+                              X509V3_CTX *_2, const char *_3)
 {
+    osslunused3();
     return ASN1_NULL_new();
 }
 
-static int i2r_ocsp_serviceloc(const X509V3_EXT_METHOD *method, void *in,
+static int i2r_ocsp_serviceloc(const X509V3_EXT_METHOD *_1, void *in,
                                BIO *bp, int ind)
 {
     int i;
     OCSP_SERVICELOC *a = in;
     ACCESS_DESCRIPTION *ad;
 
+    osslunused1();
     if (BIO_printf(bp, "%*sIssuer: ", ind, "") <= 0)
         goto err;
     if (X509_NAME_print_ex(bp, a->issuer, 0, XN_FLAG_ONELINE) <= 0)

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -120,9 +120,9 @@ static int read_lebn(const unsigned char **in, unsigned int nbyte, BIGNUM **r)
 /* Salt length for PVK files */
 # define PVK_SALTLEN             0x10
 
-static EVP_PKEY *b2i_rsa(const unsigned char **in, unsigned int length,
+static EVP_PKEY *b2i_rsa(const unsigned char **in,
                          unsigned int bitlen, int ispub);
-static EVP_PKEY *b2i_dss(const unsigned char **in, unsigned int length,
+static EVP_PKEY *b2i_dss(const unsigned char **in,
                          unsigned int bitlen, int ispub);
 
 static int do_blob_header(const unsigned char **in, unsigned int length,
@@ -235,9 +235,9 @@ static EVP_PKEY *do_b2i(const unsigned char **in, unsigned int length,
         return NULL;
     }
     if (isdss)
-        return b2i_dss(&p, length, bitlen, ispub);
+        return b2i_dss(&p, bitlen, ispub);
     else
-        return b2i_rsa(&p, length, bitlen, ispub);
+        return b2i_rsa(&p, bitlen, ispub);
 }
 
 static EVP_PKEY *do_b2i_bio(BIO *in, int ispub)
@@ -268,16 +268,16 @@ static EVP_PKEY *do_b2i_bio(BIO *in, int ispub)
     }
 
     if (isdss)
-        ret = b2i_dss(&p, length, bitlen, ispub);
+        ret = b2i_dss(&p, bitlen, ispub);
     else
-        ret = b2i_rsa(&p, length, bitlen, ispub);
+        ret = b2i_rsa(&p, bitlen, ispub);
 
  err:
     OPENSSL_free(buf);
     return ret;
 }
 
-static EVP_PKEY *b2i_dss(const unsigned char **in, unsigned int length,
+static EVP_PKEY *b2i_dss(const unsigned char **in,
                          unsigned int bitlen, int ispub)
 {
     const unsigned char *p = *in;
@@ -327,7 +327,7 @@ static EVP_PKEY *b2i_dss(const unsigned char **in, unsigned int length,
     return NULL;
 }
 
-static EVP_PKEY *b2i_rsa(const unsigned char **in, unsigned int length,
+static EVP_PKEY *b2i_rsa(const unsigned char **in,
                          unsigned int bitlen, int ispub)
 {
     const unsigned char *p = *in;

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -78,12 +78,13 @@ ASN1_ADB(PKCS7) = {
 } ASN1_ADB_END(PKCS7, 0, type, 0, &p7default_tt, NULL);
 
 /* PKCS#7 streaming support */
-static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
+static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
                   void *exarg)
 {
     ASN1_STREAM_ARG *sarg = exarg;
     PKCS7 **pp7 = (PKCS7 **)pval;
 
+    osslunused1();
     switch (operation) {
 
     case ASN1_OP_STREAM_PRE:
@@ -128,9 +129,10 @@ ASN1_NDEF_SEQUENCE(PKCS7_SIGNED) = {
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_SIGNED)
 
 /* Minor tweak to operation: free up EVP_PKEY */
-static int si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
+static int si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                 void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_FREE_POST) {
         PKCS7_SIGNER_INFO *si = (PKCS7_SIGNER_INFO *)*pval;
         EVP_PKEY_free(si->pkey);
@@ -171,9 +173,10 @@ ASN1_NDEF_SEQUENCE(PKCS7_ENVELOPE) = {
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENVELOPE)
 
 /* Minor tweak to operation: free up X509 */
-static int ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
+static int ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                 void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_FREE_POST) {
         PKCS7_RECIP_INFO *ri = (PKCS7_RECIP_INFO *)*pval;
         X509_free(ri->cert);

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -62,11 +62,12 @@
 #include "internal/asn1_int.h"
 #include "internal/evp_int.h"
 
-long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
+long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *_1)
 {
     int nid;
     long ret;
 
+    osslunused1();
     nid = OBJ_obj2nid(p7->type);
 
     switch (cmd) {

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -235,22 +235,22 @@ static int do_rsa_print(BIO *bp, const RSA *x, int off, int priv)
         str = "Modulus:";
         s = "Exponent:";
     }
-    if (!ASN1_bn_print(bp, str, x->n, m, off))
+    if (!ASN1_bn_print(bp, str, x->n, NULL, off))
         goto err;
-    if (!ASN1_bn_print(bp, s, x->e, m, off))
+    if (!ASN1_bn_print(bp, s, x->e, NULL, off))
         goto err;
     if (priv) {
-        if (!ASN1_bn_print(bp, "privateExponent:", x->d, m, off))
+        if (!ASN1_bn_print(bp, "privateExponent:", x->d, NULL, off))
             goto err;
-        if (!ASN1_bn_print(bp, "prime1:", x->p, m, off))
+        if (!ASN1_bn_print(bp, "prime1:", x->p, NULL, off))
             goto err;
-        if (!ASN1_bn_print(bp, "prime2:", x->q, m, off))
+        if (!ASN1_bn_print(bp, "prime2:", x->q, NULL, off))
             goto err;
-        if (!ASN1_bn_print(bp, "exponent1:", x->dmp1, m, off))
+        if (!ASN1_bn_print(bp, "exponent1:", x->dmp1, NULL, off))
             goto err;
-        if (!ASN1_bn_print(bp, "exponent2:", x->dmq1, m, off))
+        if (!ASN1_bn_print(bp, "exponent2:", x->dmq1, NULL, off))
             goto err;
-        if (!ASN1_bn_print(bp, "coefficient:", x->iqmp, m, off))
+        if (!ASN1_bn_print(bp, "coefficient:", x->iqmp, NULL, off))
             goto err;
     }
     ret = 1;
@@ -260,14 +260,16 @@ static int do_rsa_print(BIO *bp, const RSA *x, int off, int priv)
 }
 
 static int rsa_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                         ASN1_PCTX *ctx)
+                         ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_rsa_print(bp, pkey->pkey.rsa, indent, 0);
 }
 
 static int rsa_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                          ASN1_PCTX *ctx)
+                          ASN1_PCTX *_1)
 {
+    osslunused1();
     return do_rsa_print(bp, pkey->pkey.rsa, indent, 1);
 }
 
@@ -374,8 +376,9 @@ static int rsa_pss_param_print(BIO *bp, RSA_PSS_PARAMS *pss,
 }
 
 static int rsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
-                         const ASN1_STRING *sig, int indent, ASN1_PCTX *pctx)
+                         const ASN1_STRING *sig, int indent, ASN1_PCTX *_1)
 {
+    osslunused1();
     if (OBJ_obj2nid(sigalg->algorithm) == NID_rsassaPss) {
         int rv;
         RSA_PSS_PARAMS *pss;
@@ -393,9 +396,11 @@ static int rsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
     return 1;
 }
 
-static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int rsa_pkey_ctrl(EVP_PKEY *_1, int op, long arg1, void *arg2)
 {
     X509_ALGOR *alg = NULL;
+
+    osslunused1();
     switch (op) {
 
     case ASN1_PKEY_CTRL_PKCS7_SIGN:
@@ -681,10 +686,11 @@ static int rsa_cms_verify(CMS_SignerInfo *si)
  * is encountered requiring special handling. We currently only handle PSS.
  */
 
-static int rsa_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
-                           X509_ALGOR *sigalg, ASN1_BIT_STRING *sig,
+static int rsa_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *_1, void *_2,
+                           X509_ALGOR *sigalg, ASN1_BIT_STRING *_3,
                            EVP_PKEY *pkey)
 {
+    osslunused3();
     /* Sanity check: make sure it is PSS */
     if (OBJ_obj2nid(sigalg->algorithm) != NID_rsassaPss) {
         RSAerr(RSA_F_RSA_ITEM_VERIFY, RSA_R_UNSUPPORTED_SIGNATURE_TYPE);
@@ -704,6 +710,7 @@ static int rsa_cms_sign(CMS_SignerInfo *si)
     X509_ALGOR *alg;
     EVP_PKEY_CTX *pkctx = CMS_SignerInfo_get0_pkey_ctx(si);
     ASN1_STRING *os = NULL;
+
     CMS_SignerInfo_get0_algs(si, NULL, NULL, NULL, &alg);
     if (pkctx) {
         if (EVP_PKEY_CTX_get_rsa_padding(pkctx, &pad_mode) <= 0)
@@ -724,12 +731,14 @@ static int rsa_cms_sign(CMS_SignerInfo *si)
 }
 #endif
 
-static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
+static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *_1, void *_2,
                          X509_ALGOR *alg1, X509_ALGOR *alg2,
-                         ASN1_BIT_STRING *sig)
+                         ASN1_BIT_STRING *_3)
 {
     int pad_mode;
     EVP_PKEY_CTX *pkctx = EVP_MD_CTX_pkey_ctx(ctx);
+
+    osslunused3();
     if (EVP_PKEY_CTX_get_rsa_padding(pkctx, &pad_mode) <= 0)
         return 0;
     if (pad_mode == RSA_PKCS1_PADDING)

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -64,9 +64,10 @@
 #include <openssl/asn1t.h>
 
 /* Override the default free and new methods */
-static int rsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int rsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                  void *_2)
 {
+    osslunused2();
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)RSA_new();
         if (*pval != NULL)

--- a/crypto/rsa/rsa_none.c
+++ b/crypto/rsa/rsa_none.c
@@ -78,9 +78,9 @@ int RSA_padding_add_none(unsigned char *to, int tlen,
 }
 
 int RSA_padding_check_none(unsigned char *to, int tlen,
-                           const unsigned char *from, int flen, int num)
+                           const unsigned char *from, int flen, int _1)
 {
-
+    osslunused1();
     if (flen > tlen) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_NONE, RSA_R_DATA_TOO_LARGE);
         return (-1);

--- a/crypto/rsa/rsa_null.c
+++ b/crypto/rsa/rsa_null.c
@@ -102,42 +102,48 @@ const RSA_METHOD *RSA_null_method(void)
     return (&rsa_null_meth);
 }
 
-static int RSA_null_public_encrypt(int flen, const unsigned char *from,
-                                   unsigned char *to, RSA *rsa, int padding)
+static int RSA_null_public_encrypt(int _1, const unsigned char *_2,
+                                   unsigned char *_3, RSA *_4, int _5)
 {
+    osslunused5();
     RSAerr(RSA_F_RSA_NULL_PUBLIC_ENCRYPT, RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
 }
 
-static int RSA_null_private_encrypt(int flen, const unsigned char *from,
-                                    unsigned char *to, RSA *rsa, int padding)
+static int RSA_null_private_encrypt(int _1, const unsigned char *_2,
+                                    unsigned char *_3, RSA *_4, int _5)
 {
+    osslunused5();
     RSAerr(RSA_F_RSA_NULL_PRIVATE_ENCRYPT,
            RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
 }
 
-static int RSA_null_private_decrypt(int flen, const unsigned char *from,
-                                    unsigned char *to, RSA *rsa, int padding)
+static int RSA_null_private_decrypt(int _1, const unsigned char *_2,
+                                    unsigned char *_3, RSA *_4, int _5)
 {
+    osslunused5();
     RSAerr(RSA_F_RSA_NULL_PRIVATE_DECRYPT,
            RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
 }
 
-static int RSA_null_public_decrypt(int flen, const unsigned char *from,
-                                   unsigned char *to, RSA *rsa, int padding)
+static int RSA_null_public_decrypt(int _1, const unsigned char *_2,
+                                   unsigned char *_3, RSA *_4, int _5)
 {
+    osslunused5();
     RSAerr(RSA_F_RSA_NULL_PUBLIC_DECRYPT, RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
 }
 
-static int RSA_null_init(RSA *rsa)
+static int RSA_null_init(RSA *_1)
 {
+    osslunused1();
     return (1);
 }
 
-static int RSA_null_finish(RSA *rsa)
+static int RSA_null_finish(RSA *_1)
 {
+    osslunused1();
     return (1);
 }

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -597,7 +597,7 @@ static int rsa_ossl_private_decrypt(int flen, const unsigned char *from,
         r = RSA_padding_check_SSLv23(to, num, buf, j, num);
         break;
     case RSA_NO_PADDING:
-        r = RSA_padding_check_none(to, num, buf, j, num);
+        r = RSA_padding_check_none(to, num, buf, j, 0);
         break;
     default:
         RSAerr(RSA_F_RSA_OSSL_PRIVATE_DECRYPT, RSA_R_UNKNOWN_PADDING_TYPE);
@@ -693,10 +693,10 @@ static int rsa_ossl_public_decrypt(int flen, const unsigned char *from,
         r = RSA_padding_check_PKCS1_type_1(to, num, buf, i, num);
         break;
     case RSA_X931_PADDING:
-        r = RSA_padding_check_X931(to, num, buf, i, num);
+        r = RSA_padding_check_X931(to, buf, i, num);
         break;
     case RSA_NO_PADDING:
-        r = RSA_padding_check_none(to, num, buf, i, num);
+        r = RSA_padding_check_none(to, num, buf, i, 0);
         break;
     default:
         RSAerr(RSA_F_RSA_OSSL_PUBLIC_DECRYPT, RSA_R_UNKNOWN_PADDING_TYPE);

--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -174,8 +174,7 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
             unsigned int sltmp;
             if (rctx->pad_mode != RSA_PKCS1_PADDING)
                 return -1;
-            ret = RSA_sign_ASN1_OCTET_STRING(NID_mdc2,
-                                             tbs, tbslen, sig, &sltmp, rsa);
+            ret = RSA_sign_ASN1_OCTET_STRING(0, tbs, tbslen, sig, &sltmp, rsa);
 
             if (ret <= 0)
                 return ret;

--- a/crypto/rsa/rsa_saos.c
+++ b/crypto/rsa/rsa_saos.c
@@ -62,7 +62,7 @@
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 
-int RSA_sign_ASN1_OCTET_STRING(int type,
+int RSA_sign_ASN1_OCTET_STRING(int _1,
                                const unsigned char *m, unsigned int m_len,
                                unsigned char *sigret, unsigned int *siglen,
                                RSA *rsa)
@@ -71,6 +71,7 @@ int RSA_sign_ASN1_OCTET_STRING(int type,
     int i, j, ret = 1;
     unsigned char *p, *s;
 
+    osslunused1();
     sig.type = V_ASN1_OCTET_STRING;
     sig.length = m_len;
     sig.data = (unsigned char *)m;
@@ -99,7 +100,7 @@ int RSA_sign_ASN1_OCTET_STRING(int type,
     return (ret);
 }
 
-int RSA_verify_ASN1_OCTET_STRING(int dtype,
+int RSA_verify_ASN1_OCTET_STRING(int _1,
                                  const unsigned char *m,
                                  unsigned int m_len, unsigned char *sigbuf,
                                  unsigned int siglen, RSA *rsa)
@@ -109,6 +110,7 @@ int RSA_verify_ASN1_OCTET_STRING(int dtype,
     const unsigned char *p;
     ASN1_OCTET_STRING *sig = NULL;
 
+    osslunused1();
     if (siglen != (unsigned int)RSA_size(rsa)) {
         RSAerr(RSA_F_RSA_VERIFY_ASN1_OCTET_STRING,
                RSA_R_WRONG_SIGNATURE_LENGTH);

--- a/crypto/rsa/rsa_x931.c
+++ b/crypto/rsa/rsa_x931.c
@@ -100,7 +100,7 @@ int RSA_padding_add_X931(unsigned char *to, int tlen,
     return (1);
 }
 
-int RSA_padding_check_X931(unsigned char *to, int tlen,
+int RSA_padding_check_X931(unsigned char *to,
                            const unsigned char *from, int flen, int num)
 {
     int i = 0, j;

--- a/crypto/ts/ts_asn1.c
+++ b/crypto/ts/ts_asn1.c
@@ -204,10 +204,11 @@ static int ts_resp_set_tst_info(TS_RESP *a)
     return 1;
 }
 
-static int ts_resp_cb(int op, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int ts_resp_cb(int op, ASN1_VALUE **pval, const ASN1_ITEM *_1, void *_2)
 {
     TS_RESP *ts_resp = (TS_RESP *)*pval;
+
+    osslunused2();
     if (op == ASN1_OP_NEW_POST) {
         ts_resp->tst_info = NULL;
     } else if (op == ASN1_OP_FREE_POST) {

--- a/crypto/ts/ts_lcl.h
+++ b/crypto/ts/ts_lcl.h
@@ -52,6 +52,7 @@
  *
  */
 
+#include "e_os.h"
 
 /*-
  * MessageImprint ::= SEQUENCE  {

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -91,10 +91,11 @@ static ASN1_GENERALIZEDTIME
                                     unsigned);
 
 /* Default callback for response generation. */
-static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, void *data)
+static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, void *_1)
 {
     ASN1_INTEGER *serial = ASN1_INTEGER_new();
 
+    osslunused1();
     if (serial == NULL)
         goto err;
     if (!ASN1_INTEGER_set(serial, 1))
@@ -110,10 +111,12 @@ static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, void *data)
 
 #if defined(OPENSSL_SYS_UNIX)
 
-static int def_time_cb(struct TS_resp_ctx *ctx, void *data,
+static int def_time_cb(struct TS_resp_ctx *ctx, void *_1,
                        long *sec, long *usec)
 {
     struct timeval tv;
+
+    osslunused1();
     if (gettimeofday(&tv, NULL) != 0) {
         TSerr(TS_F_DEF_TIME_CB, TS_R_TIME_SYSCALL_ERROR);
         TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
@@ -148,9 +151,10 @@ static int def_time_cb(struct TS_resp_ctx *ctx, void *data,
 
 #endif
 
-static int def_extension_cb(struct TS_resp_ctx *ctx, X509_EXTENSION *ext,
-                            void *data)
+static int def_extension_cb(struct TS_resp_ctx *ctx, X509_EXTENSION *_1,
+                            void *_2)
 {
+    osslunused2();
     TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
                                 "Unsupported extension.");
     TS_RESP_CTX_add_failure_info(ctx, TS_INFO_UNACCEPTED_EXTENSION);

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -125,7 +125,7 @@ static int allocate_string_stack(UI *ui)
     return 0;
 }
 
-static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
+static UI_STRING *general_allocate_prompt(const char *prompt,
                                           int prompt_freeable,
                                           enum UI_string_types type,
                                           int input_flags, char *result_buf)
@@ -154,7 +154,7 @@ static int general_allocate_string(UI *ui, const char *prompt,
                                    const char *test_buf)
 {
     int ret = -1;
-    UI_STRING *s = general_allocate_prompt(ui, prompt, prompt_freeable,
+    UI_STRING *s = general_allocate_prompt(prompt, prompt_freeable,
                                            type, input_flags, result_buf);
 
     if (s) {
@@ -197,7 +197,7 @@ static int general_allocate_boolean(UI *ui,
             }
         }
 
-        s = general_allocate_prompt(ui, prompt, prompt_freeable,
+        s = general_allocate_prompt(prompt, prompt_freeable,
                                     type, input_flags, result_buf);
 
         if (s) {
@@ -440,10 +440,11 @@ const char *UI_get0_result(UI *ui, int i)
     return UI_get0_result_string(sk_UI_STRING_value(ui->strings, i));
 }
 
-static int print_error(const char *str, size_t len, UI *ui)
+static int print_error(const char *str, size_t _1, UI *ui)
 {
     UI_STRING uis;
 
+    osslunused1();
     memset(&uis, 0, sizeof(uis));
     uis.type = UIT_ERROR;
     uis.out_string = str;
@@ -510,8 +511,9 @@ int UI_process(UI *ui)
     return ok;
 }
 
-int UI_ctrl(UI *ui, int cmd, long i, void *p, void (*f) (void))
+int UI_ctrl(UI *ui, int cmd, long i, void *_1, void (*_2) (void))
 {
+    osslunused2();
     if (ui == NULL) {
         UIerr(UI_F_UI_CTRL, ERR_R_PASSED_NULL_PARAMETER);
         return -1;

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -329,8 +329,9 @@ UI_METHOD *UI_OpenSSL(void)
  * The following function makes sure that info and error strings are printed
  * before any prompt.
  */
-static int write_string(UI *ui, UI_STRING *uis)
+static int write_string(UI *_1, UI_STRING *uis)
 {
+    osslunused1();
     switch (UI_get_string_type(uis)) {
     case UIT_ERROR:
     case UIT_INFO:
@@ -460,8 +461,9 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
 }
 
 /* Internal functions to open, handle and close a channel to the console.  */
-static int open_console(UI *ui)
+static int open_console(UI *_1)
 {
+    osslunused1();
     CRYPTO_w_lock(CRYPTO_LOCK_UI);
     is_a_tty = 1;
 
@@ -512,8 +514,9 @@ static int open_console(UI *ui)
     return 1;
 }
 
-static int noecho_console(UI *ui)
+static int noecho_console(UI *_1)
 {
+    osslunused1();
 #ifdef TTY_FLAGS
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
     tty_new.TTY_FLAGS &= ~ECHO;
@@ -536,8 +539,9 @@ static int noecho_console(UI *ui)
     return 1;
 }
 
-static int echo_console(UI *ui)
+static int echo_console(UI *_1)
 {
+    osslunused1();
 #if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
     tty_new.TTY_FLAGS |= ECHO;
@@ -560,8 +564,9 @@ static int echo_console(UI *ui)
     return 1;
 }
 
-static int close_console(UI *ui)
+static int close_console(UI *_1)
 {
+    osslunused1();
     if (tty_in != stdin)
         fclose(tty_in);
     if (tty_out != stderr)

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -116,12 +116,13 @@ X509_LOOKUP_METHOD *X509_LOOKUP_hash_dir(void)
 }
 
 static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
-                    char **retp)
+                    char **_1)
 {
     int ret = 0;
     BY_DIR *ld;
     char *dir = NULL;
 
+    osslunused1();
     ld = (BY_DIR *)ctx->method_data;
 
     switch (cmd) {

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -86,11 +86,12 @@ X509_LOOKUP_METHOD *X509_LOOKUP_file(void)
 }
 
 static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
-                        long argl, char **ret)
+                        long argl, char **_1)
 {
     int ok = 0;
     char *file;
 
+    osslunused1();
     switch (cmd) {
     case X509_L_FILE_LOAD:
         if (argl == X509_FILETYPE_DEFAULT) {

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -351,10 +351,11 @@ ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)
 }
 
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,
-                               int atrtype, void *data)
+                               int atrtype, void *_1)
 {
-    ASN1_TYPE *ttmp;
-    ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
+    ASN1_TYPE *ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
+
+    osslunused1();
     if (!ttmp)
         return NULL;
     if (atrtype != ASN1_TYPE_get(ttmp)) {

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -282,8 +282,9 @@ static int trust_1oid(X509_TRUST *trust, X509 *x, int flags)
     return obj_trust(trust->arg1, x, flags);
 }
 
-static int trust_compat(X509_TRUST *trust, X509 *x, int flags)
+static int trust_compat(X509_TRUST *_1, X509 *x, int flags)
 {
+    osslunused1();
     /* Call for side-effect of computing hash and caching extensions */
     X509_check_purpose(x, -1, 0);
     if ((flags & X509_TRUST_NO_SS_COMPAT) == 0 && x->ex_flags & EXFLAG_SS)

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -145,8 +145,9 @@ static int check_crl_chain(X509_STORE_CTX *ctx,
 
 static int internal_verify(X509_STORE_CTX *ctx);
 
-static int null_callback(int ok, X509_STORE_CTX *e)
+static int null_callback(int ok, X509_STORE_CTX *_1)
 {
+    osslunused1();
     return ok;
 }
 
@@ -1173,11 +1174,13 @@ static int check_crl_path(X509_STORE_CTX *ctx, X509 *x)
  * RFC5280 version
  */
 
-static int check_crl_chain(X509_STORE_CTX *ctx,
+static int check_crl_chain(X509_STORE_CTX *_1,
                            STACK_OF(X509) *cert_path,
                            STACK_OF(X509) *crl_path)
 {
     X509 *cert_ta, *crl_ta;
+
+    osslunused1();
     cert_ta = sk_X509_value(cert_path, sk_X509_num(cert_path) - 1);
     crl_ta = sk_X509_value(crl_path, sk_X509_num(crl_path) - 1);
     if (!X509_cmp(cert_ta, crl_ta))
@@ -1890,11 +1893,13 @@ int X509_get_pubkey_parameters(EVP_PKEY *pkey, STACK_OF(X509) *chain)
 /* Make a delta CRL as the diff between two full CRLs */
 
 X509_CRL *X509_CRL_diff(X509_CRL *base, X509_CRL *newer,
-                        EVP_PKEY *skey, const EVP_MD *md, unsigned int flags)
+                        EVP_PKEY *skey, const EVP_MD *md, unsigned int _1)
 {
     X509_CRL *crl = NULL;
     int i;
     STACK_OF(X509_REVOKED) *revs = NULL;
+
+    osslunused1();
     /* CRLs can't be delta already */
     if (base->base_crl_number || newer->base_crl_number) {
         X509err(X509_F_X509_CRL_DIFF, X509_R_CRL_ALREADY_DELTA);
@@ -2351,9 +2356,9 @@ void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags)
     X509_VERIFY_PARAM_set_flags(ctx->param, flags);
 }
 
-void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
-                             time_t t)
+void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, time_t t, unsigned long _1)
 {
+    osslunused1();
     X509_VERIFY_PARAM_set_time(ctx->param, t);
 }
 

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -92,11 +92,12 @@ static const X509_CRL_METHOD *default_crl_method = &int_crl_meth;
  * the original encoding the signature wont be affected by reordering of the
  * revoked field.
  */
-static int crl_inf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int crl_inf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                      void *_2)
 {
     X509_CRL_INFO *a = (X509_CRL_INFO *)*pval;
 
+    osslunused2();
     if (!a || !a->revoked)
         return 1;
     switch (operation) {
@@ -197,14 +198,15 @@ static int crl_set_issuers(X509_CRL *crl)
  * The X509_CRL structure needs a bit of customisation. Cache some extensions
  * and hash of the whole CRL.
  */
-static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                  void *_2)
 {
     X509_CRL *crl = (X509_CRL *)*pval;
     STACK_OF(X509_EXTENSION) *exts;
     X509_EXTENSION *ext;
     int idx;
 
+    osslunused2();
     switch (operation) {
     case ASN1_OP_NEW_POST:
         crl->idp = NULL;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -128,10 +128,11 @@ IMPLEMENT_ASN1_FUNCTIONS(X509_NAME)
 
 IMPLEMENT_ASN1_DUP_FUNCTION(X509_NAME)
 
-static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *it)
+static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *_1)
 {
     X509_NAME *ret = OPENSSL_zalloc(sizeof(*ret));
 
+    osslunused1();
     if (ret == NULL)
         goto memerr;
     if ((ret->entries = sk_X509_NAME_ENTRY_new_null()) == NULL)
@@ -151,10 +152,11 @@ static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *it)
     return 0;
 }
 
-static void x509_name_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static void x509_name_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *_1)
 {
     X509_NAME *a;
 
+    osslunused1();
     if (!pval || !*pval)
         return;
     a = (X509_NAME *)*pval;
@@ -168,7 +170,7 @@ static void x509_name_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
 
 static int x509_name_ex_d2i(ASN1_VALUE **val,
                             const unsigned char **in, long len,
-                            const ASN1_ITEM *it, int tag, int aclass,
+                            const ASN1_ITEM *_1, int tag, int aclass,
                             char opt, ASN1_TLC *ctx)
 {
     const unsigned char *p = *in, *q;
@@ -187,6 +189,8 @@ static int x509_name_ex_d2i(ASN1_VALUE **val,
     int i, j, ret;
     STACK_OF(X509_NAME_ENTRY) *entries;
     X509_NAME_ENTRY *entry;
+
+    osslunused1();
     q = p;
 
     /* Get internal representation of Name */
@@ -232,10 +236,12 @@ static int x509_name_ex_d2i(ASN1_VALUE **val,
 }
 
 static int x509_name_ex_i2d(ASN1_VALUE **val, unsigned char **out,
-                            const ASN1_ITEM *it, int tag, int aclass)
+                            const ASN1_ITEM *_1, int _2, int _3)
 {
     int ret;
     X509_NAME *a = (X509_NAME *)*val;
+
+    osslunused3();
     if (a->modified) {
         ret = x509_name_encode(a);
         if (ret < 0)
@@ -311,8 +317,9 @@ static int x509_name_encode(X509_NAME *a)
 
 static int x509_name_ex_print(BIO *out, ASN1_VALUE **pval,
                               int indent,
-                              const char *fname, const ASN1_PCTX *pctx)
+                              const char *_1, const ASN1_PCTX *pctx)
 {
+    osslunused1();
     if (X509_NAME_print_ex(out, (X509_NAME *)*pval,
                            indent, pctx->nm_flags) <= 0)
         return 0;

--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -80,11 +80,12 @@
  *
  */
 
-static int rinf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                   void *exarg)
+static int rinf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                   void *_2)
 {
     X509_REQ_INFO *rinf = (X509_REQ_INFO *)*pval;
 
+    osslunused2();
     if (operation == ASN1_OP_NEW_POST) {
         rinf->attributes = sk_X509_ATTRIBUTE_new_null();
         if (!rinf->attributes)

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -81,11 +81,12 @@ IMPLEMENT_ASN1_FUNCTIONS(X509_CINF)
 
 extern void policy_cache_free(X509_POLICY_CACHE *cache);
 
-static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                   void *exarg)
+static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                   void *_2)
 {
     X509 *ret = (X509 *)*pval;
 
+    osslunused2();
     switch (operation) {
 
     case ASN1_OP_NEW_POST:

--- a/crypto/x509v3/v3_addr.c
+++ b/crypto/x509v3/v3_addr.c
@@ -241,11 +241,13 @@ static int i2r_IPAddressOrRanges(BIO *out,
 /*
  * i2r handler for an IPAddrBlocks extension.
  */
-static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *method,
+static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *_1,
                             void *ext, BIO *out, int indent)
 {
     const IPAddrBlocks *addr = ext;
     int i;
+
+    osslunused1();
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);
         const unsigned int afi = v3_addr_get_afi(f);
@@ -929,8 +931,8 @@ int v3_addr_canonize(IPAddrBlocks *addr)
 /*
  * v2i handler for the IPAddrBlocks extension.
  */
-static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
-                              struct v3_ext_ctx *ctx,
+static void *v2i_IPAddrBlocks(const struct v3_ext_method *_1,
+                              struct v3_ext_ctx *_2,
                               STACK_OF(CONF_VALUE) *values)
 {
     static const char v4addr_chars[] = "0123456789.";
@@ -939,6 +941,7 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
     char *s = NULL, *t;
     int i;
 
+    osslunused2();
     if ((addr = sk_IPAddressFamily_new(IPAddressFamily_cmp)) == NULL) {
         X509V3err(X509V3_F_V2I_IPADDRBLOCKS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_akey.c
+++ b/crypto/x509v3/v3_akey.c
@@ -83,12 +83,14 @@ const X509V3_EXT_METHOD v3_akey_id = {
     NULL
 };
 
-static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *_1,
                                                  AUTHORITY_KEYID *akeyid,
                                                  STACK_OF(CONF_VALUE)
                                                  *extlist)
 {
     char *tmp;
+
+    osslunused1();
     if (akeyid->keyid) {
         tmp = hex_to_string(akeyid->keyid->data, akeyid->keyid->length);
         X509V3_add_value("keyid", tmp, &extlist);
@@ -113,7 +115,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
  * this is always included.
  */
 
-static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *_1,
                                             X509V3_CTX *ctx,
                                             STACK_OF(CONF_VALUE) *values)
 {
@@ -129,6 +131,7 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     X509 *cert;
     AUTHORITY_KEYID *akeyid;
 
+    osslunused1();
     for (i = 0; i < sk_CONF_VALUE_num(values); i++) {
         cnf = sk_CONF_VALUE_value(values, i);
         if (strcmp(cnf->name, "keyid") == 0) {

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -110,13 +110,15 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES(X509V3_EXT_METHOD *method,
     return ret;
 }
 
-STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
+STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *_1,
                                        GENERAL_NAME *gen,
                                        STACK_OF(CONF_VALUE) *ret)
 {
     unsigned char *p;
     char oline[256], htmp[5];
     int i;
+
+    osslunused1();
     switch (gen->type) {
     case GEN_OTHERNAME:
         X509V3_add_value("othername", "<unsupported>", &ret);
@@ -430,13 +432,14 @@ GENERAL_NAME *v2i_GENERAL_NAME(const X509V3_EXT_METHOD *method,
 }
 
 GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
-                               const X509V3_EXT_METHOD *method,
+                               const X509V3_EXT_METHOD *_1,
                                X509V3_CTX *ctx, int gen_type, char *value,
                                int is_nc)
 {
     char is_string = 0;
     GENERAL_NAME *gen = NULL;
 
+    osslunused1();
     if (!value) {
         X509V3err(X509V3_F_A2I_GENERAL_NAME, X509V3_R_MISSING_VALUE);
         return NULL;

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -153,10 +153,12 @@ static int i2r_ASIdentifierChoice(BIO *out,
 /*
  * i2r method for an ASIdentifier extension.
  */
-static int i2r_ASIdentifiers(const X509V3_EXT_METHOD *method,
+static int i2r_ASIdentifiers(const X509V3_EXT_METHOD *_1,
                              void *ext, BIO *out, int indent)
 {
     ASIdentifiers *asid = ext;
+
+    osslunused1();
     return (i2r_ASIdentifierChoice(out, asid->asnum, indent,
                                    "Autonomous System Numbers") &&
             i2r_ASIdentifierChoice(out, asid->rdi, indent,
@@ -541,14 +543,15 @@ int v3_asid_canonize(ASIdentifiers *asid)
 /*
  * v2i method for an ASIdentifier extension.
  */
-static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
-                               struct v3_ext_ctx *ctx,
+static void *v2i_ASIdentifiers(const struct v3_ext_method *_1,
+                               struct v3_ext_ctx *_2,
                                STACK_OF(CONF_VALUE) *values)
 {
     ASN1_INTEGER *min = NULL, *max = NULL;
     ASIdentifiers *asid = NULL;
     int i;
 
+    osslunused2();
     if ((asid = ASIdentifiers_new()) == NULL) {
         X509V3err(X509V3_F_V2I_ASIDENTIFIERS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_bcons.c
+++ b/crypto/x509v3/v3_bcons.c
@@ -90,24 +90,26 @@ ASN1_SEQUENCE(BASIC_CONSTRAINTS) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(BASIC_CONSTRAINTS)
 
-static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
+static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *_1,
                                                    BASIC_CONSTRAINTS *bcons,
                                                    STACK_OF(CONF_VALUE)
                                                    *extlist)
 {
+    osslunused1();
     X509V3_add_value_bool("CA", bcons->ca, &extlist);
     X509V3_add_value_int("pathlen", bcons->pathlen, &extlist);
     return extlist;
 }
 
-static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
-                                                X509V3_CTX *ctx,
+static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *_1,
+                                                X509V3_CTX *_2,
                                                 STACK_OF(CONF_VALUE) *values)
 {
     BASIC_CONSTRAINTS *bcons = NULL;
     CONF_VALUE *val;
     int i;
 
+    osslunused2();
     if ((bcons = BASIC_CONSTRAINTS_new()) == NULL) {
         X509V3err(X509V3_F_V2I_BASIC_CONSTRAINTS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_bitst.c
+++ b/crypto/x509v3/v3_bitst.c
@@ -105,13 +105,15 @@ STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
 }
 
 ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
-                                     X509V3_CTX *ctx,
+                                     X509V3_CTX *_1,
                                      STACK_OF(CONF_VALUE) *nval)
 {
     CONF_VALUE *val;
     ASN1_BIT_STRING *bs;
     int i;
     BIT_STRING_BITNAME *bnam;
+
+    osslunused1();
     if ((bs = ASN1_BIT_STRING_new()) == NULL) {
         X509V3err(X509V3_F_V2I_ASN1_BIT_STRING, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_cpols.c
+++ b/crypto/x509v3/v3_cpols.c
@@ -132,7 +132,7 @@ ASN1_SEQUENCE(NOTICEREF) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(NOTICEREF)
 
-static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
+static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *_1,
                                          X509V3_CTX *ctx, char *value)
 {
     STACK_OF(POLICYINFO) *pols = NULL;
@@ -142,6 +142,8 @@ static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
     STACK_OF(CONF_VALUE) *vals;
     CONF_VALUE *cnf;
     int i, ia5org;
+
+    osslunused1();
     pols = sk_POLICYINFO_new_null();
     if (pols == NULL) {
         X509V3err(X509V3_F_R2I_CERTPOL, ERR_R_MALLOC_FAILURE);
@@ -290,7 +292,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
 
 }
 
-static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
+static POLICYQUALINFO *notice_section(X509V3_CTX *_1,
                                       STACK_OF(CONF_VALUE) *unot, int ia5org)
 {
     int i, ret;
@@ -298,6 +300,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
     USERNOTICE *not;
     POLICYQUALINFO *qual;
 
+    osslunused1();
     if ((qual = POLICYQUALINFO_new()) == NULL)
         goto merr;
     if ((qual->pqualid = OBJ_nid2obj(NID_id_qt_unotice)) == NULL) {
@@ -399,11 +402,13 @@ static int nref_nos(STACK_OF(ASN1_INTEGER) *nnums, STACK_OF(CONF_VALUE) *nos)
     return 0;
 }
 
-static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
+static int i2r_certpol(X509V3_EXT_METHOD *_1, STACK_OF(POLICYINFO) *pol,
                        BIO *out, int indent)
 {
     int i;
     POLICYINFO *pinfo;
+
+    osslunused1();
     /* First print out the policy OIDs */
     for (i = 0; i < sk_POLICYINFO_num(pol); i++) {
         pinfo = sk_POLICYINFO_value(pol, i);

--- a/crypto/x509v3/v3_crld.c
+++ b/crypto/x509v3/v3_crld.c
@@ -342,11 +342,12 @@ static void *v2i_crld(const X509V3_EXT_METHOD *method,
     return NULL;
 }
 
-static int dpn_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int dpn_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *_1,
+                  void *_2)
 {
     DIST_POINT_NAME *dpn = (DIST_POINT_NAME *)*pval;
 
+    osslunused2();
     switch (operation) {
     case ASN1_OP_NEW_POST:
         dpn->dpname = NULL;
@@ -409,13 +410,15 @@ const X509V3_EXT_METHOD v3_idp = {
     NULL
 };
 
-static void *v2i_idp(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
+static void *v2i_idp(const X509V3_EXT_METHOD *_1, X509V3_CTX *ctx,
                      STACK_OF(CONF_VALUE) *nval)
 {
     ISSUING_DIST_POINT *idp = NULL;
     CONF_VALUE *cnf;
     char *name, *val;
     int i, ret;
+
+    osslunused1();
     idp = ISSUING_DIST_POINT_new();
     if (idp == NULL)
         goto merr;
@@ -484,10 +487,12 @@ static int print_distpoint(BIO *out, DIST_POINT_NAME *dpn, int indent)
     return 1;
 }
 
-static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
+static int i2r_idp(const X509V3_EXT_METHOD *_1, void *pidp, BIO *out,
                    int indent)
 {
     ISSUING_DIST_POINT *idp = pidp;
+
+    osslunused1();
     if (idp->distpoint)
         print_distpoint(out, idp->distpoint, indent);
     if (idp->onlyuser > 0)
@@ -508,12 +513,14 @@ static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
     return 1;
 }
 
-static int i2r_crldp(const X509V3_EXT_METHOD *method, void *pcrldp, BIO *out,
+static int i2r_crldp(const X509V3_EXT_METHOD *_1, void *pcrldp, BIO *out,
                      int indent)
 {
     STACK_OF(DIST_POINT) *crld = pcrldp;
     DIST_POINT *point;
     int i;
+
+    osslunused1();
     for (i = 0; i < sk_DIST_POINT_num(crld); i++) {
         BIO_puts(out, "\n");
         point = sk_DIST_POINT_value(crld, i);

--- a/crypto/x509v3/v3_extku.c
+++ b/crypto/x509v3/v3_extku.c
@@ -99,14 +99,16 @@ ASN1_ITEM_TEMPLATE_END(EXTENDED_KEY_USAGE)
 
 IMPLEMENT_ASN1_FUNCTIONS(EXTENDED_KEY_USAGE)
 
-static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD
-                                                    *method, void *a, STACK_OF(CONF_VALUE)
+static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *_1,
+                                                    void *a, STACK_OF(CONF_VALUE)
                                                     *ext_list)
 {
     EXTENDED_KEY_USAGE *eku = a;
     int i;
     ASN1_OBJECT *obj;
     char obj_tmp[80];
+
+    osslunused1();
     for (i = 0; i < sk_ASN1_OBJECT_num(eku); i++) {
         obj = sk_ASN1_OBJECT_value(eku, i);
         i2t_ASN1_OBJECT(obj_tmp, 80, obj);
@@ -115,8 +117,8 @@ static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD
     return ext_list;
 }
 
-static void *v2i_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *method,
-                                    X509V3_CTX *ctx,
+static void *v2i_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *_1,
+                                    X509V3_CTX *_2,
                                     STACK_OF(CONF_VALUE) *nval)
 {
     EXTENDED_KEY_USAGE *extku;
@@ -125,6 +127,7 @@ static void *v2i_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *method,
     CONF_VALUE *val;
     int i;
 
+    osslunused2();
     if ((extku = sk_ASN1_OBJECT_new_null()) == NULL) {
         X509V3err(X509V3_F_V2I_EXTENDED_KEY_USAGE, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_ia5.c
+++ b/crypto/x509v3/v3_ia5.c
@@ -74,10 +74,11 @@ const X509V3_EXT_METHOD v3_ns_ia5_list[] = {
     EXT_END
 };
 
-char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
+char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *_1, ASN1_IA5STRING *ia5)
 {
     char *tmp;
 
+    osslunused1();
     if (!ia5 || !ia5->length)
         return NULL;
     if ((tmp = OPENSSL_malloc(ia5->length + 1)) == NULL) {
@@ -89,10 +90,12 @@ char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
     return tmp;
 }
 
-ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
-                                   X509V3_CTX *ctx, char *str)
+ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *_1,
+                                   X509V3_CTX *_2, char *str)
 {
     ASN1_IA5STRING *ia5;
+
+    osslunused2();
     if (!str) {
         X509V3err(X509V3_F_S2I_ASN1_IA5STRING,
                   X509V3_R_INVALID_NULL_ARGUMENT);

--- a/crypto/x509v3/v3_int.c
+++ b/crypto/x509v3/v3_int.c
@@ -77,9 +77,10 @@ const X509V3_EXT_METHOD v3_delta_crl = {
     0, 0, 0, 0, NULL
 };
 
-static void *s2i_asn1_int(X509V3_EXT_METHOD *meth, X509V3_CTX *ctx,
+static void *s2i_asn1_int(X509V3_EXT_METHOD *meth, X509V3_CTX *_1,
                           char *value)
 {
+    osslunused1();
     return s2i_ASN1_INTEGER(meth, value);
 }
 

--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -169,12 +169,14 @@ static int i2r_NAME_CONSTRAINTS(const X509V3_EXT_METHOD *method, void *a,
     return 1;
 }
 
-static int do_i2r_name_constraints(const X509V3_EXT_METHOD *method,
+static int do_i2r_name_constraints(const X509V3_EXT_METHOD *_1,
                                    STACK_OF(GENERAL_SUBTREE) *trees,
                                    BIO *bp, int ind, char *name)
 {
     GENERAL_SUBTREE *tree;
     int i;
+
+    osslunused1();
     if (sk_GENERAL_SUBTREE_num(trees) > 0)
         BIO_printf(bp, "%*s%s:\n", ind, "", name);
     for (i = 0; i < sk_GENERAL_SUBTREE_num(trees); i++) {

--- a/crypto/x509v3/v3_pci.c
+++ b/crypto/x509v3/v3_pci.c
@@ -55,9 +55,10 @@ const X509V3_EXT_METHOD v3_pci =
     NULL,
 };
 
-static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *pci,
+static int i2r_pci(X509V3_EXT_METHOD *_1, PROXY_CERT_INFO_EXTENSION *pci,
                    BIO *out, int indent)
 {
+    osslunused1();
     BIO_printf(out, "%*sPath Length Constraint: ", indent, "");
     if (pci->pcPathLengthConstraint)
         i2a_ASN1_INTEGER(out, pci->pcPathLengthConstraint);
@@ -233,7 +234,7 @@ static int process_pci_value(CONF_VALUE *val,
     return 0;
 }
 
-static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
+static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *_1,
                                           X509V3_CTX *ctx, char *value)
 {
     PROXY_CERT_INFO_EXTENSION *pci = NULL;
@@ -243,6 +244,7 @@ static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
     ASN1_OCTET_STRING *policy = NULL;
     int i, j;
 
+    osslunused1();
     vals = X509V3_parse_list(value);
     for (i = 0; i < sk_CONF_VALUE_num(vals); i++) {
         CONF_VALUE *cnf = sk_CONF_VALUE_value(vals, i);

--- a/crypto/x509v3/v3_pcons.c
+++ b/crypto/x509v3/v3_pcons.c
@@ -89,11 +89,12 @@ ASN1_SEQUENCE(POLICY_CONSTRAINTS) = {
 
 IMPLEMENT_ASN1_ALLOC_FUNCTIONS(POLICY_CONSTRAINTS)
 
-static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD
-                                                    *method, void *a, STACK_OF(CONF_VALUE)
-                                                    *extlist)
+static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(
+        const X509V3_EXT_METHOD *_1, void *a, STACK_OF(CONF_VALUE) *extlist)
 {
     POLICY_CONSTRAINTS *pcons = a;
+
+    osslunused1();
     X509V3_add_value_int("Require Explicit Policy",
                          pcons->requireExplicitPolicy, &extlist);
     X509V3_add_value_int("Inhibit Policy Mapping",
@@ -101,14 +102,15 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD
     return extlist;
 }
 
-static void *v2i_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD *method,
-                                    X509V3_CTX *ctx,
+static void *v2i_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD *_1,
+                                    X509V3_CTX *_2,
                                     STACK_OF(CONF_VALUE) *values)
 {
     POLICY_CONSTRAINTS *pcons = NULL;
     CONF_VALUE *val;
     int i;
 
+    osslunused2();
     if ((pcons = POLICY_CONSTRAINTS_new()) == NULL) {
         X509V3err(X509V3_F_V2I_POLICY_CONSTRAINTS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_pku.c
+++ b/crypto/x509v3/v3_pku.c
@@ -85,10 +85,11 @@ ASN1_SEQUENCE(PKEY_USAGE_PERIOD) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(PKEY_USAGE_PERIOD)
 
-static int i2r_PKEY_USAGE_PERIOD(X509V3_EXT_METHOD *method,
+static int i2r_PKEY_USAGE_PERIOD(X509V3_EXT_METHOD *_1,
                                  PKEY_USAGE_PERIOD *usage, BIO *out,
                                  int indent)
 {
+    osslunused1();
     BIO_printf(out, "%*s", indent, "");
     if (usage->notBefore) {
         BIO_write(out, "Not Before: ", 12);

--- a/crypto/x509v3/v3_pmaps.c
+++ b/crypto/x509v3/v3_pmaps.c
@@ -92,15 +92,17 @@ ASN1_ITEM_TEMPLATE_END(POLICY_MAPPINGS)
 
 IMPLEMENT_ASN1_ALLOC_FUNCTIONS(POLICY_MAPPING)
 
-static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD
-                                                 *method, void *a, STACK_OF(CONF_VALUE)
-                                                 *ext_list)
+static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD *_1,
+                                                 void *a,
+                                                 STACK_OF(CONF_VALUE) *ext_list)
 {
     POLICY_MAPPINGS *pmaps = a;
     POLICY_MAPPING *pmap;
     int i;
     char obj_tmp1[80];
     char obj_tmp2[80];
+
+    osslunused1();
     for (i = 0; i < sk_POLICY_MAPPING_num(pmaps); i++) {
         pmap = sk_POLICY_MAPPING_value(pmaps, i);
         i2t_ASN1_OBJECT(obj_tmp1, 80, pmap->issuerDomainPolicy);
@@ -110,8 +112,8 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD
     return ext_list;
 }
 
-static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *method,
-                                 X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *nval)
+static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *_1,
+                                 X509V3_CTX *_2, STACK_OF(CONF_VALUE) *nval)
 {
     POLICY_MAPPINGS *pmaps;
     POLICY_MAPPING *pmap;
@@ -119,6 +121,7 @@ static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *method,
     CONF_VALUE *val;
     int i;
 
+    osslunused2();
     if ((pmaps = sk_POLICY_MAPPING_new_null()) == NULL) {
         X509V3err(X509V3_F_V2I_POLICY_MAPPINGS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -598,9 +598,10 @@ static int check_ssl_ca(const X509 *x)
         return 0;
 }
 
-static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_ssl_client(const X509_PURPOSE *_1, const X509 *x,
                                     int ca)
 {
+    osslunused1();
     if (xku_reject(x, XKU_SSL_CLIENT))
         return 0;
     if (ca)
@@ -622,9 +623,10 @@ static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
 #define KU_TLS \
         KU_DIGITAL_SIGNATURE|KU_KEY_ENCIPHERMENT|KU_KEY_AGREEMENT
 
-static int check_purpose_ssl_server(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_ssl_server(const X509_PURPOSE *_1, const X509 *x,
                                     int ca)
 {
+    osslunused1();
     if (xku_reject(x, XKU_SSL_SERVER | XKU_SGC))
         return 0;
     if (ca)
@@ -679,11 +681,12 @@ static int purpose_smime(const X509 *x, int ca)
     return 1;
 }
 
-static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_smime_sign(const X509_PURPOSE *_1, const X509 *x,
                                     int ca)
 {
-    int ret;
-    ret = purpose_smime(x, ca);
+    int ret = purpose_smime(x, ca);
+
+    osslunused1();
     if (!ret || ca)
         return ret;
     if (ku_reject(x, KU_DIGITAL_SIGNATURE | KU_NON_REPUDIATION))
@@ -691,11 +694,12 @@ static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
     return ret;
 }
 
-static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_smime_encrypt(const X509_PURPOSE *_1, const X509 *x,
                                        int ca)
 {
-    int ret;
-    ret = purpose_smime(x, ca);
+    int ret = purpose_smime(x, ca);
+
+    osslunused1();
     if (!ret || ca)
         return ret;
     if (ku_reject(x, KU_KEY_ENCIPHERMENT))
@@ -703,9 +707,10 @@ static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
     return ret;
 }
 
-static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_crl_sign(const X509_PURPOSE *_1, const X509 *x,
                                   int ca)
 {
+    osslunused1();
     if (ca) {
         int ca_ret;
         if ((ca_ret = check_ca(x)) != 2)
@@ -723,8 +728,9 @@ static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
  * is valid. Additional checks must be made on the chain.
  */
 
-static int ocsp_helper(const X509_PURPOSE *xp, const X509 *x, int ca)
+static int ocsp_helper(const X509_PURPOSE *_1, const X509 *x, int ca)
 {
+    osslunused1();
     /*
      * Must be a valid CA.  Should we really support the "I don't know" value
      * (2)?
@@ -735,11 +741,12 @@ static int ocsp_helper(const X509_PURPOSE *xp, const X509 *x, int ca)
     return 1;
 }
 
-static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_timestamp_sign(const X509_PURPOSE *_1, const X509 *x,
                                         int ca)
 {
     int i_ext;
 
+    osslunused1();
     /* If ca is true we must return if this is a valid CA certificate. */
     if (ca)
         return check_ca(x);
@@ -770,8 +777,9 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
     return 1;
 }
 
-static int no_check(const X509_PURPOSE *xp, const X509 *x, int ca)
+static int no_check(const X509_PURPOSE *_1, const X509 *_2, int _3)
 {
+    osslunused3();
     return 1;
 }
 

--- a/crypto/x509v3/v3_scts.c
+++ b/crypto/x509v3/v3_scts.c
@@ -146,7 +146,7 @@ static void SCT_LIST_free(STACK_OF(SCT) *a)
     sk_SCT_pop_free(a, SCT_free);
 }
 
-static STACK_OF(SCT) *d2i_SCT_LIST(STACK_OF(SCT) **a,
+static STACK_OF(SCT) *d2i_SCT_LIST(STACK_OF(SCT) **_1,
                                    const unsigned char **pp, long length)
 {
     ASN1_OCTET_STRING *oct = NULL;
@@ -156,6 +156,7 @@ static STACK_OF(SCT) *d2i_SCT_LIST(STACK_OF(SCT) **a,
     unsigned short listlen, sctlen = 0, fieldlen;
     const unsigned char *q = *pp;
 
+    osslunused1();
     if (d2i_ASN1_OCTET_STRING(&oct, &q, length) == NULL)
         return NULL;
     if (oct->length < 2)
@@ -253,12 +254,13 @@ static STACK_OF(SCT) *d2i_SCT_LIST(STACK_OF(SCT) **a,
     goto done;
 }
 
-static int i2r_SCT_LIST(X509V3_EXT_METHOD *method, STACK_OF(SCT) *sct_list,
+static int i2r_SCT_LIST(X509V3_EXT_METHOD *_1, STACK_OF(SCT) *sct_list,
                         BIO *out, int indent)
 {
     SCT *sct;
     int i;
 
+    osslunused1();
     for (i = 0; i < sk_SCT_num(sct_list);) {
         sct = sk_SCT_value(sct_list, i);
 

--- a/crypto/x509v3/v3_skey.c
+++ b/crypto/x509v3/v3_skey.c
@@ -73,17 +73,19 @@ const X509V3_EXT_METHOD v3_skey_id = {
     NULL
 };
 
-char *i2s_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method, ASN1_OCTET_STRING *oct)
+char *i2s_ASN1_OCTET_STRING(X509V3_EXT_METHOD *_1, ASN1_OCTET_STRING *oct)
 {
+    osslunused1();
     return hex_to_string(oct->data, oct->length);
 }
 
-ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
-                                         X509V3_CTX *ctx, char *str)
+ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *_1,
+                                         X509V3_CTX *_2, char *str)
 {
     ASN1_OCTET_STRING *oct;
     long length;
 
+    osslunused2();
     if ((oct = ASN1_OCTET_STRING_new()) == NULL) {
         X509V3err(X509V3_F_S2I_ASN1_OCTET_STRING, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_sxnet.c
+++ b/crypto/x509v3/v3_sxnet.c
@@ -103,14 +103,15 @@ ASN1_SEQUENCE(SXNET) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(SXNET)
 
-static int sxnet_i2r(X509V3_EXT_METHOD *method, SXNET *sx, BIO *out,
+static int sxnet_i2r(X509V3_EXT_METHOD *_1, SXNET *sx, BIO *out,
                      int indent)
 {
-    long v;
+    long v = ASN1_INTEGER_get(sx->version);
     char *tmp;
     SXNETID *id;
     int i;
-    v = ASN1_INTEGER_get(sx->version);
+
+    osslunused1();
     BIO_printf(out, "%*sVersion: %ld (0x%lX)", indent, "", v + 1, v);
     for (i = 0; i < sk_SXNETID_num(sx->ids); i++) {
         id = sk_SXNETID_value(sx->ids, i);
@@ -130,12 +131,14 @@ static int sxnet_i2r(X509V3_EXT_METHOD *method, SXNET *sx, BIO *out,
  * they should really be separate values for each user.
  */
 
-static SXNET *sxnet_v2i(X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
+static SXNET *sxnet_v2i(X509V3_EXT_METHOD *_1, X509V3_CTX *_2,
                         STACK_OF(CONF_VALUE) *nval)
 {
     CONF_VALUE *cnf;
     SXNET *sx = NULL;
     int i;
+
+    osslunused2();
     for (i = 0; i < sk_CONF_VALUE_num(nval); i++) {
         cnf = sk_CONF_VALUE_value(nval, i);
         if (!SXNET_add_id_asc(&sx, cnf->name, cnf->value, -1))

--- a/crypto/x509v3/v3_tlsf.c
+++ b/crypto/x509v3/v3_tlsf.c
@@ -104,7 +104,7 @@ static TLS_FEATURE_NAME tls_feature_tbl[] = {
  * used by the CONF library to represent a multi-valued extension.  ext_list is
  * returned.
  */
-static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *method,
+static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *_1,
                                              TLS_FEATURE *tls_feature,
                                              STACK_OF(CONF_VALUE) *ext_list)
 {
@@ -112,6 +112,8 @@ static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *method,
     size_t j;
     ASN1_INTEGER *ai;
     long tlsextid;
+
+    osslunused1();
     for (i = 0; i < sk_ASN1_INTEGER_num(tls_feature); i++) {
         ai = sk_ASN1_INTEGER_value(tls_feature, i);
         tlsextid = ASN1_INTEGER_get(ai);
@@ -131,8 +133,8 @@ static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *method,
  * structure, which is returned if the conversion is successful.  In case of
  * error, NULL is returned.
  */
-static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *method,
-                                    X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *nval)
+static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *_1,
+                                    X509V3_CTX *_2, STACK_OF(CONF_VALUE) *nval)
 {
     TLS_FEATURE *tlsf;
     char *extval, *endptr;
@@ -142,6 +144,7 @@ static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *method,
     size_t j;
     long tlsextid;
 
+    osslunused2();
     if ((tlsf = sk_ASN1_INTEGER_new_null()) == NULL) {
         X509V3err(X509V3_F_V2I_TLS_FEATURE, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -141,11 +141,12 @@ int X509V3_add_value_bool_nf(char *name, int asn1_bool,
     return 1;
 }
 
-char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, ASN1_ENUMERATED *a)
+char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *_1, ASN1_ENUMERATED *a)
 {
     BIGNUM *bntmp = NULL;
     char *strtmp = NULL;
 
+    osslunused1();
     if (!a)
         return NULL;
     if ((bntmp = ASN1_ENUMERATED_to_BN(a, NULL)) == NULL
@@ -155,11 +156,12 @@ char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, ASN1_ENUMERATED *a)
     return strtmp;
 }
 
-char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, ASN1_INTEGER *a)
+char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *_1, ASN1_INTEGER *a)
 {
     BIGNUM *bntmp = NULL;
     char *strtmp = NULL;
 
+    osslunused1();
     if (!a)
         return NULL;
     if ((bntmp = ASN1_INTEGER_to_BN(a, NULL)) == NULL
@@ -169,12 +171,14 @@ char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, ASN1_INTEGER *a)
     return strtmp;
 }
 
-ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *method, char *value)
+ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *_1, char *value)
 {
     BIGNUM *bn = NULL;
     ASN1_INTEGER *aint;
     int isneg, ishex;
     int ret;
+
+    osslunused1();
     if (value == NULL) {
         X509V3err(X509V3_F_S2I_ASN1_INTEGER, X509V3_R_INVALID_NULL_VALUE);
         return NULL;
@@ -636,8 +640,7 @@ typedef int (*equal_fn) (const unsigned char *pattern, size_t pattern_len,
 
 /* Skip pattern prefix to match "wildcard" subject */
 static void skip_prefix(const unsigned char **p, size_t *plen,
-                        const unsigned char *subject, size_t subject_len,
-                        unsigned int flags)
+                        size_t subject_len, unsigned int flags)
 {
     const unsigned char *pattern = *p;
     size_t pattern_len = *plen;
@@ -671,7 +674,7 @@ static int equal_nocase(const unsigned char *pattern, size_t pattern_len,
                         const unsigned char *subject, size_t subject_len,
                         unsigned int flags)
 {
-    skip_prefix(&pattern, &pattern_len, subject, subject_len, flags);
+    skip_prefix(&pattern, &pattern_len, subject_len, flags);
     if (pattern_len != subject_len)
         return 0;
     while (pattern_len) {
@@ -700,7 +703,7 @@ static int equal_case(const unsigned char *pattern, size_t pattern_len,
                       const unsigned char *subject, size_t subject_len,
                       unsigned int flags)
 {
-    skip_prefix(&pattern, &pattern_len, subject, subject_len, flags);
+    skip_prefix(&pattern, &pattern_len, subject_len, flags);
     if (pattern_len != subject_len)
         return 0;
     return !memcmp(pattern, subject, pattern_len);
@@ -712,9 +715,11 @@ static int equal_case(const unsigned char *pattern, size_t pattern_len,
  */
 static int equal_email(const unsigned char *a, size_t a_len,
                        const unsigned char *b, size_t b_len,
-                       unsigned int unused_flags)
+                       unsigned int _1)
 {
     size_t i = a_len;
+
+    osslunused1();
     if (a_len != b_len)
         return 0;
     /*

--- a/doc/apps/verify.pod
+++ b/doc/apps/verify.pod
@@ -18,7 +18,6 @@ B<openssl> B<verify>
 [B<-crl_download>]
 [B<-crl_check>]
 [B<-crl_check_all>]
-[B<-engine id>]
 [B<-explicit_policy>]
 [B<-extended_crl>]
 [B<-ignore_critical>]
@@ -97,8 +96,6 @@ because it doesn't add any security.
 The B<file> should contain one or more CRLs in PEM format.
 This option can be specified more than once to include CRLs from multiple
 B<files>.
-If you want to enable an B<engine> via the B<-engine> option, that option has
-to be specified before this one.
 
 =item B<-crl_download>
 
@@ -113,15 +110,6 @@ If a valid CRL cannot be found an error occurs.
 
 Checks the validity of B<all> certificates in the chain by attempting
 to look up valid CRLs.
-
-=item B<-engine id>
-
-Specifying an engine B<id> will cause L<verify(1)> to attempt to load the
-specified engine.
-The engine will then be set as the default for all its supported algorithms.
-If you want to load certificates or CRLs that require engine support via any of
-the B<-trusted>, B<-untrusted> or B<-CRLfile> options, the B<-engine> option
-must be specified before those options.
 
 =item B<-explicit_policy>
 
@@ -206,8 +194,6 @@ to constuct a certificate chain from the subject certificate to a trust-anchor.
 The B<file> should contain one or more certificates in PEM format.
 This option can be specified more than once to include untrusted certiificates
 from multiple B<files>.
-If you want to enable an B<engine> via the B<-engine> option, that option has
-to be specified before this one.
 
 =item B<-trusted file>
 
@@ -222,8 +208,6 @@ from multiple B<files>.
 This option implies the B<-no-CAfile> and B<-no-CApath> options.
 This option cannot be used in combination with either of the B<-CAfile> or
 B<-CApath> options.
-If you want to enable an B<engine> via the B<-engine> option, that option has
-to be specified before this one.
 
 =item B<-use_deltas>
 

--- a/doc/crypto/EC_GROUP_copy.pod
+++ b/doc/crypto/EC_GROUP_copy.pod
@@ -1,4 +1,4 @@
-=pod
+pod
 
 =head1 NAME
 

--- a/e_os.h
+++ b/e_os.h
@@ -93,6 +93,15 @@ extern "C" {
 #  define REF_PRINT_COUNT(a, b)
 # endif
 
+# define osslargused(x)      (void)x
+# define osslunused1()       (void)_1
+# define osslunused2()       (void)_1, (void)_2
+# define osslunused3()       (void)_1, (void)_2, (void)_3
+# define osslunused4()       (void)_1, (void)_2, (void)_3, (void)_4
+# define osslunused5()       (void)_1, (void)_2, (void)_3, (void)_4, (void)_5
+# define osslunused6() \
+    (void)_1, (void)_2, (void)_3, (void)_4, (void)_5, (void)_6
+
 # ifndef DEVRANDOM
 /*
  * set this to a comma-separated list of 'random' device files to try out. My

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -60,6 +60,7 @@
 #include <openssl/async.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
+#include <e_os.h>
 
 #define DASYNC_LIB_NAME "DASYNC"
 #include "e_dasync_err.c"
@@ -221,29 +222,34 @@ void engine_load_dasync_internal(void)
     ERR_clear_error();
 }
 
-static int dasync_init(ENGINE *e)
+static int dasync_init(ENGINE *_1)
 {
+    osslunused1();
     return 1;
 }
 
 
-static int dasync_finish(ENGINE *e)
+static int dasync_finish(ENGINE *_1)
 {
+    osslunused1();
     return 1;
 }
 
 
-static int dasync_destroy(ENGINE *e)
+static int dasync_destroy(ENGINE *_1)
 {
+    osslunused1();
     destroy_digests();
     ERR_unload_DASYNC_strings();
     return 1;
 }
 
-static int dasync_digests(ENGINE *e, const EVP_MD **digest,
+static int dasync_digests(ENGINE *_1, const EVP_MD **digest,
                           const int **nids, int nid)
 {
     int ok = 1;
+
+    osslunused1();
     if (!digest) {
         /* We are returning a list of supported nids */
         return dasync_digest_nids(nids);

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -76,6 +76,7 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/modes.h>
+#include <e_os.h>
 
 #ifndef OPENSSL_NO_HW
 # ifndef OPENSSL_NO_HW_PADLOCK
@@ -206,8 +207,9 @@ static ENGINE *ENGINE_padlock(void)
 #   endif
 
 /* Check availability of the engine */
-static int padlock_init(ENGINE *e)
+static int padlock_init(ENGINE *_1)
 {
+    osslunused1();
     return (padlock_use_rng || padlock_use_ace);
 }
 
@@ -593,9 +595,10 @@ DECLARE_AES_EVP(256, ofb, OFB)
 DECLARE_AES_EVP(256, ctr, CTR)
 
 static int
-padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
+padlock_ciphers(ENGINE *_1, const EVP_CIPHER **cipher, const int **nids,
                 int nid)
 {
+    osslunused1();
     /* No specific cipher => return a list of supported nids ... */
     if (!cipher) {
         *nids = padlock_cipher_nids;
@@ -664,12 +667,13 @@ padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
 /* Prepare the encryption key for PadLock usage */
 static int
 padlock_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                     const unsigned char *iv, int enc)
+                     const unsigned char *_1, int enc)
 {
     struct padlock_cipher_data *cdata;
     int key_len = EVP_CIPHER_CTX_key_length(ctx) * 8;
     unsigned long mode = EVP_CIPHER_CTX_mode(ctx);
 
+    osslunused1();
     if (key == NULL)
         return 0;               /* ERROR */
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -252,7 +252,7 @@ BN_MONT_CTX *EC_GROUP_get_mont_data(const EC_GROUP *group);
 /** Gets the order of a EC_GROUP
  *  \param  group  EC_GROUP object
  *  \param  order  BIGNUM to which the order is copied
- *  \param  ctx    BN_CTX object (optional)
+ *  \param  ctx    unused
  *  \return 1 on success and 0 if an error occurred
  */
 int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, BN_CTX *ctx);
@@ -274,11 +274,10 @@ int EC_GROUP_order_bits(const EC_GROUP *group);
 /** Gets the cofactor of a EC_GROUP
  *  \param  group     EC_GROUP object
  *  \param  cofactor  BIGNUM to which the cofactor is copied
- *  \param  ctx       BN_CTX object (optional)
+ *  \param  ctx       unused
  *  \return 1 on success and 0 if an error occurred
  */
-int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor,
-                          BN_CTX *ctx);
+int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor, BN_CTX *ctx);
 
 /** Gets the cofactor of an EC_GROUP
  *  \param  group  EC_GROUP object

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -403,7 +403,8 @@ int RSA_sign_ASN1_OCTET_STRING(int type,
                                const unsigned char *m, unsigned int m_length,
                                unsigned char *sigret, unsigned int *siglen,
                                RSA *rsa);
-int RSA_verify_ASN1_OCTET_STRING(int type, const unsigned char *m,
+int RSA_verify_ASN1_OCTET_STRING(int type,
+                                 const unsigned char *m,
                                  unsigned int m_length, unsigned char *sigbuf,
                                  unsigned int siglen, RSA *rsa);
 
@@ -448,7 +449,7 @@ int RSA_padding_check_none(unsigned char *to, int tlen,
                            const unsigned char *f, int fl, int rsa_len);
 int RSA_padding_add_X931(unsigned char *to, int tlen, const unsigned char *f,
                          int fl);
-int RSA_padding_check_X931(unsigned char *to, int tlen,
+int RSA_padding_check_X931(unsigned char *to,
                            const unsigned char *f, int fl, int rsa_len);
 int RSA_X931_hash_id(int nid);
 

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -514,8 +514,7 @@ int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
 int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
                                    int purpose, int trust);
 void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags);
-void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
-                             time_t t);
+void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, time_t t, unsigned long flags);
 void X509_STORE_CTX_set_verify_cb(X509_STORE_CTX *ctx,
                                   int (*verify_cb) (int, X509_STORE_CTX *));
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -890,8 +890,7 @@ end:
 
 static int dtls1_set_handshake_header(SSL *s, int htype, unsigned long len)
 {
-    unsigned char *p = (unsigned char *)s->init_buf->data;
-    dtls1_set_message_header(s, p, htype, len, 0, len);
+    dtls1_set_message_header(s, htype, len, 0, len);
     s->init_num = (int)len + DTLS1_HM_HEADER_LENGTH;
     s->init_off = 0;
     /* Buffer the message to handle re-xmits */

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -231,7 +231,7 @@ void DTLS_RECORD_LAYER_set_write_sequence(RECORD_LAYER *rl, unsigned char *seq)
 }
 
 static int have_handshake_fragment(SSL *s, int type, unsigned char *buf,
-                                   int len, int peek);
+                                   int len);
 
 /* copy buffered record into SSL structure */
 static int dtls1_copy_record(SSL *s, pitem *item)
@@ -424,7 +424,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
     /*
      * check whether there's a handshake message (client hello?) waiting
      */
-    if ((ret = have_handshake_fragment(s, type, buf, len, peek)))
+    if ((ret = have_handshake_fragment(s, type, buf, len)))
         return ret;
 
     /*
@@ -986,7 +986,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
          * is started.
          */
 static int have_handshake_fragment(SSL *s, int type, unsigned char *buf,
-                                   int len, int peek)
+                                   int len)
 {
 
     if ((type == SSL3_RT_HANDSHAKE)

--- a/ssl/record/record_locl.h
+++ b/ssl/record/record_locl.h
@@ -198,8 +198,7 @@ __owur int ssl3_do_compress(SSL *ssl);
 __owur int ssl3_do_uncompress(SSL *ssl);
 void ssl3_cbc_copy_mac(unsigned char *out,
                        const SSL3_RECORD *rec, unsigned md_size);
-__owur int ssl3_cbc_remove_padding(const SSL *s,
-                            SSL3_RECORD *rec,
+__owur int ssl3_cbc_remove_padding(SSL3_RECORD *rec,
                             unsigned block_size, unsigned mac_size);
 __owur int tls1_cbc_remove_padding(const SSL *s,
                             SSL3_RECORD *rec,

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -616,7 +616,7 @@ int ssl3_enc(SSL *s, int send)
         if (EVP_MD_CTX_md(s->read_hash) != NULL)
             mac_size = EVP_MD_CTX_size(s->read_hash);
         if ((bs != 1) && !send)
-            return ssl3_cbc_remove_padding(s, rec, bs, mac_size);
+            return ssl3_cbc_remove_padding(rec, bs, mac_size);
     }
     return (1);
 }
@@ -1005,8 +1005,7 @@ int tls1_mac(SSL *ssl, unsigned char *md, int send)
  *   1: if the padding was valid
  *  -1: otherwise.
  */
-int ssl3_cbc_remove_padding(const SSL *s,
-                            SSL3_RECORD *rec,
+int ssl3_cbc_remove_padding(SSL3_RECORD *rec,
                             unsigned block_size, unsigned mac_size)
 {
     unsigned padding_length, good;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3100,8 +3100,9 @@ void ssl3_clear(SSL *s)
 }
 
 #ifndef OPENSSL_NO_SRP
-static char *srp_password_from_info_cb(SSL *s, void *arg)
+static char *srp_password_from_info_cb(SSL *s, void *_1)
 {
+    osslunused1();
     return OPENSSL_strdup(s->srp_ctx.info);
 }
 #endif

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1062,10 +1062,12 @@ int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain, int ref)
 
 static int ssl_security_default_callback(SSL *s, SSL_CTX *ctx, int op,
                                          int bits, int nid, void *other,
-                                         void *ex)
+                                         void *_1)
 {
     int level, minbits;
     static const int minbits_table[5] = { 80, 112, 128, 192, 256 };
+
+    osslunused1();
     if (ctx)
         level = SSL_CTX_get_security_level(ctx);
     else

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2493,7 +2493,7 @@ void SSL_set_cert_cb(SSL *s, int (*cb) (SSL *ssl, void *arg), void *arg)
     ssl_cert_set_cert_cb(s->cert, cb, arg);
 }
 
-void ssl_set_masks(SSL *s, const SSL_CIPHER *cipher)
+void ssl_set_masks(SSL *s, const SSL_CIPHER *_1)
 {
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_GOST)
     CERT_PKEY *cpk;
@@ -2507,6 +2507,8 @@ void ssl_set_masks(SSL *s, const SSL_CIPHER *cipher)
     X509 *x = NULL;
     int pk_nid = 0, md_nid = 0;
 #endif
+
+    osslunused1();
     if (c == NULL)
         return;
 
@@ -2929,8 +2931,9 @@ void SSL_set_connect_state(SSL *s)
     clear_ciphers(s);
 }
 
-int ssl_undefined_function(SSL *s)
+int ssl_undefined_function(SSL *_1)
 {
+    osslunused1();
     SSLerr(SSL_F_SSL_UNDEFINED_FUNCTION, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return (0);
 }
@@ -2942,13 +2945,15 @@ int ssl_undefined_void_function(void)
     return (0);
 }
 
-int ssl_undefined_const_function(const SSL *s)
+int ssl_undefined_const_function(const SSL *_1)
 {
+    osslunused1();
     return (0);
 }
 
-SSL_METHOD *ssl_bad_method(int ver)
+SSL_METHOD *ssl_bad_method(int _1)
 {
+    osslunused1();
     SSLerr(SSL_F_SSL_BAD_METHOD, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return (NULL);
 }
@@ -3425,8 +3430,9 @@ void *SSL_CTX_get_ex_data(const SSL_CTX *s, int idx)
     return (CRYPTO_get_ex_data(&s->ex_data, idx));
 }
 
-int ssl_ok(SSL *s)
+int ssl_ok(SSL *_1)
 {
+    osslunused1();
     return (1);
 }
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1948,7 +1948,7 @@ __owur int ssl_choose_client_version(SSL *s, int version);
 __owur long tls1_default_timeout(void);
 __owur int dtls1_do_write(SSL *s, int type);
 void dtls1_set_message_header(SSL *s,
-                              unsigned char *p, unsigned char mt,
+                              unsigned char mt,
                               unsigned long len,
                               unsigned long frag_off,
                               unsigned long frag_len);
@@ -1957,8 +1957,7 @@ __owur int dtls1_write_app_data_bytes(SSL *s, int type, const void *buf, int len
 
 __owur int dtls1_read_failed(SSL *s, int code);
 __owur int dtls1_buffer_message(SSL *s, int ccs);
-__owur int dtls1_retransmit_message(SSL *s, unsigned short seq,
-                             unsigned long frag_off, int *found);
+__owur int dtls1_retransmit_message(SSL *s, unsigned short seq, int *found);
 __owur int dtls1_get_queue_priority(unsigned short seq, int is_ccs);
 int dtls1_retransmit_buffered_messages(SSL *s);
 void dtls1_clear_record_buffer(SSL *s);

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -82,9 +82,11 @@ struct ssl_conf_cmd {
 static struct ssl_conf_name *ssl_names;
 static size_t ssl_names_count;
 
-static void ssl_module_free(CONF_IMODULE *md)
+static void ssl_module_free(CONF_IMODULE *_1)
 {
     size_t i, j;
+
+    osslunused1();
     if (ssl_names == NULL)
         return;
     for (i = 0; i < ssl_names_count; i++) {

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -792,11 +792,11 @@ static int serverinfo_find_extension(const unsigned char *serverinfo,
     /* Unreachable */
 }
 
-static int serverinfo_srv_parse_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char *in,
-                                   size_t inlen, int *al, void *arg)
+static int serverinfo_srv_parse_cb(SSL *_1, unsigned int _2,
+                                   const unsigned char *_3,
+                                   size_t inlen, int *al, void *_4)
 {
-
+    osslunused4();
     if (inlen != 0) {
         *al = SSL_AD_DECODE_ERROR;
         return 0;
@@ -807,11 +807,12 @@ static int serverinfo_srv_parse_cb(SSL *s, unsigned int ext_type,
 
 static int serverinfo_srv_add_cb(SSL *s, unsigned int ext_type,
                                  const unsigned char **out, size_t *outlen,
-                                 int *al, void *arg)
+                                 int *al, void *_1)
 {
     const unsigned char *serverinfo = NULL;
     size_t serverinfo_length = 0;
 
+    osslunused1();
     /* Is there serverinfo data for the chosen server cert? */
     if ((ssl_get_server_cert_serverinfo(s, &serverinfo,
                                         &serverinfo_length)) != 0) {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -531,10 +531,11 @@ WORK_STATE ossl_statem_client_pre_work(SSL *s, WORK_STATE wst)
  * Perform any work that needs to be done after sending a message from the
  * client to the server.
  */
-WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst)
+WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE _1)
 {
     OSSL_STATEM *st = &s->statem;
 
+    osslunused1();
     s->init_num = 0;
 
     switch(st->hand_state) {
@@ -770,10 +771,11 @@ MSG_PROCESS_RETURN ossl_statem_client_process_message(SSL *s, PACKET *pkt)
  * Perform any further processing required following the receipt of a message
  * from the server
  */
-WORK_STATE ossl_statem_client_post_process_message(SSL *s, WORK_STATE wst)
+WORK_STATE ossl_statem_client_post_process_message(SSL *s, WORK_STATE _1)
 {
     OSSL_STATEM *st = &s->statem;
 
+    osslunused1();
     switch(st->hand_state) {
 #ifndef OPENSSL_NO_SCTP
     case TLS_ST_CR_SRVR_DONE:

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1076,9 +1076,9 @@ int dtls1_retransmit_buffered_messages(SSL *s)
     for (item = pqueue_next(&iter); item != NULL; item = pqueue_next(&iter)) {
         frag = (hm_fragment *)item->data;
         if (dtls1_retransmit_message(s, (unsigned short)
-                                     dtls1_get_queue_priority
-                                     (frag->msg_header.seq,
-                                      frag->msg_header.is_ccs), 0,
+                                     dtls1_get_queue_priority(
+                                         frag->msg_header.seq,
+                                         frag->msg_header.is_ccs),
                                      &found) <= 0 && found) {
             fprintf(stderr, "dtls1_retransmit_message() failed\n");
             return -1;
@@ -1152,8 +1152,7 @@ int dtls1_buffer_message(SSL *s, int is_ccs)
 }
 
 int
-dtls1_retransmit_message(SSL *s, unsigned short seq, unsigned long frag_off,
-                         int *found)
+dtls1_retransmit_message(SSL *s, unsigned short seq, int *found)
 {
     int ret;
     /* XDTLS: for now assuming that read/writes are blocking */
@@ -1242,10 +1241,10 @@ void dtls1_clear_record_buffer(SSL *s)
     }
 }
 
-void dtls1_set_message_header(SSL *s, unsigned char *p,
-                                        unsigned char mt, unsigned long len,
-                                        unsigned long frag_off,
-                                        unsigned long frag_len)
+void dtls1_set_message_header(SSL *s,
+        unsigned char mt, unsigned long len,
+        unsigned long frag_off,
+        unsigned long frag_len)
 {
     if (frag_off == 0) {
         s->d1->handshake_write_seq = s->d1->next_handshake_write_seq;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -369,10 +369,11 @@ unsigned long ssl3_output_cert_chain(SSL *s, CERT_PKEY *cpk)
     return l + SSL_HM_HEADER_LENGTH(s);
 }
 
-WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst)
+WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE _1)
 {
     void (*cb) (const SSL *ssl, int type, int val) = NULL;
 
+    osslunused1();
 #ifndef OPENSSL_NO_SCTP
     if (SSL_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(s))) {
         WORK_STATE ret;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -588,10 +588,11 @@ WORK_STATE ossl_statem_server_pre_work(SSL *s, WORK_STATE wst)
  * Perform any work that needs to be done after sending a message from the
  * server to the client.
  */
-WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
+WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE _1)
 {
     OSSL_STATEM *st = &s->statem;
 
+    osslunused1();
     s->init_num = 0;
 
     switch(st->hand_state) {
@@ -948,7 +949,7 @@ int dtls_construct_hello_verify_request(SSL *s)
     len = dtls_raw_hello_verify_request(&buf[DTLS1_HM_HEADER_LENGTH],
                                          s->d1->cookie, s->d1->cookie_len);
 
-    dtls1_set_message_header(s, buf, DTLS1_MT_HELLO_VERIFY_REQUEST, len, 0,
+    dtls1_set_message_header(s, DTLS1_MT_HELLO_VERIFY_REQUEST, len, 0,
                              len);
     len += DTLS1_HM_HEADER_LENGTH;
 
@@ -2571,8 +2572,9 @@ MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL *s, PACKET *pkt)
     return MSG_PROCESS_ERROR;
 }
 
-WORK_STATE tls_post_process_client_key_exchange(SSL *s, WORK_STATE wst)
+WORK_STATE tls_post_process_client_key_exchange(SSL *s, WORK_STATE _1)
 {
+    osslunused1();
 #ifndef OPENSSL_NO_SCTP
     if (wst == WORK_MORE_A) {
         if (SSL_IS_DTLS(s)) {

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -575,9 +575,10 @@ int tls1_final_finish_mac(SSL *s, const char *str, int slen,
     return TLS1_FINISH_MAC_LENGTH;
 }
 
-int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
+int tls1_generate_master_secret(SSL *s, unsigned char *_1, unsigned char *p,
                                 int len)
 {
+    osslunused1();
     if (s->session->flags & SSL_SESS_FLAG_EXTMS) {
         unsigned char hash[EVP_MAX_MD_SIZE * 2];
         int hashlen;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2613,14 +2613,15 @@ static int ssl_scan_serverhello_tlsext(SSL *s, PACKET *pkt, int *al)
     return 1;
 }
 
-int ssl_prepare_clienthello_tlsext(SSL *s)
+int ssl_prepare_clienthello_tlsext(SSL *_1)
 {
-
+    osslunused1();
     return 1;
 }
 
-int ssl_prepare_serverhello_tlsext(SSL *s)
+int ssl_prepare_serverhello_tlsext(SSL *_1)
 {
+    osslunused1();
     return 1;
 }
 

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -79,15 +79,17 @@
 static int ctr = 0;
 static ASYNC_JOB *currjob = NULL;
 
-static int only_pause(void *args)
+static int only_pause(void *_1)
 {
+    osslunused1();
     ASYNC_pause_job();
 
     return 1;
 }
 
-static int add_two(void *args)
+static int add_two(void *_1)
 {
+    osslunused1();
     ctr++;
     ASYNC_pause_job();
     ctr++;
@@ -95,16 +97,18 @@ static int add_two(void *args)
     return 2;
 }
 
-static int save_current(void *args)
+static int save_current(void *_1)
 {
+    osslunused1();
     currjob = ASYNC_get_current_job();
     ASYNC_pause_job();
 
     return 1;
 }
 
-static int wake(void *args)
+static int wake(void *_1)
 {
+    osslunused1();
     ASYNC_pause_job();
     ASYNC_wake(ASYNC_get_current_job());
     ASYNC_pause_job();
@@ -113,8 +117,9 @@ static int wake(void *args)
     return 1;
 }
 
-static int blockpause(void *args)
+static int blockpause(void *_1)
 {
+    osslunused1();
     ASYNC_block_pause();
     ASYNC_pause_job();
     ASYNC_unblock_pause();
@@ -275,9 +280,8 @@ static int test_ASYNC_block_pause()
 
 #endif
 
-int main(int argc, char **argv)
+int main()
 {
-
 #ifdef ASYNC_NULL
     fprintf(stderr, "NULL implementation - skipping async tests\n");
 #else

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -279,10 +279,12 @@ static unsigned char key_out[KEY_TEST_NUM][8] = {
 
 static int test(void);
 static int print_test_data(void);
+
 int main(int argc, char *argv[])
 {
     int ret;
 
+    osslargused(argv);
     if (argc > 1)
         ret = print_test_data();
     else

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -1112,11 +1112,12 @@ int test_mod_exp_mont_consttime(BIO *bp, BN_CTX *ctx)
  * Test constant-time modular exponentiation with 1024-bit inputs, which on
  * x86_64 cause a different code branch to be taken.
  */
-int test_mod_exp_mont5(BIO *bp, BN_CTX *ctx)
+int test_mod_exp_mont5(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *p, *m, *d, *e;
     BN_MONT_CTX *mont;
 
+    osslunused1();
     a = BN_new();
     p = BN_new();
     m = BN_new();
@@ -1226,11 +1227,12 @@ int test_exp(BIO *bp, BN_CTX *ctx)
 }
 
 #ifndef OPENSSL_NO_EC2M
-int test_gf2m_add(BIO *bp)
+int test_gf2m_add(BIO *_1)
 {
     BIGNUM *a, *b, *c;
     int i, ret = 0;
 
+    osslunused1();
     a = BN_new();
     b = BN_new();
     c = BN_new();
@@ -1262,13 +1264,14 @@ int test_gf2m_add(BIO *bp)
     return ret;
 }
 
-int test_gf2m_mod(BIO *bp)
+int test_gf2m_mod(BIO *_1)
 {
     BIGNUM *a, *b[2], *c, *d, *e;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1303,13 +1306,14 @@ int test_gf2m_mod(BIO *bp)
     return ret;
 }
 
-int test_gf2m_mod_mul(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_mul(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d, *e, *f, *g, *h;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1356,13 +1360,14 @@ int test_gf2m_mod_mul(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_gf2m_mod_sqr(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_sqr(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1396,13 +1401,14 @@ int test_gf2m_mod_sqr(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_gf2m_mod_inv(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_inv(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1434,13 +1440,14 @@ int test_gf2m_mod_inv(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_gf2m_mod_div(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_div(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d, *e, *f;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1478,13 +1485,14 @@ int test_gf2m_mod_div(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_gf2m_mod_exp(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_exp(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d, *e, *f;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1527,13 +1535,14 @@ int test_gf2m_mod_exp(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_gf2m_mod_sqrt(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_sqrt(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d, *e, *f;
     int i, j, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1571,13 +1580,14 @@ int test_gf2m_mod_sqrt(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_gf2m_mod_solve_quad(BIO *bp, BN_CTX *ctx)
+int test_gf2m_mod_solve_quad(BIO *_1, BN_CTX *ctx)
 {
     BIGNUM *a, *b[2], *c, *d, *e;
     int i, j, s = 0, t, ret = 0;
     int p0[] = { 163, 7, 6, 3, 0, -1 };
     int p1[] = { 193, 15, 0, -1 };
 
+    osslunused1();
     a = BN_new();
     b[0] = BN_new();
     b[1] = BN_new();
@@ -1629,10 +1639,11 @@ int test_gf2m_mod_solve_quad(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 #endif
-static int genprime_cb(int p, int n, BN_GENCB *arg)
+static int genprime_cb(int p, int _1, BN_GENCB *_2)
 {
     char c = '*';
 
+    osslunused2();
     if (p == 0)
         c = '.';
     if (p == 1)
@@ -1646,7 +1657,7 @@ static int genprime_cb(int p, int n, BN_GENCB *arg)
     return 1;
 }
 
-int test_kron(BIO *bp, BN_CTX *ctx)
+int test_kron(BIO *_1, BN_CTX *ctx)
 {
     BN_GENCB cb;
     BIGNUM *a, *b, *r, *t;
@@ -1654,6 +1665,7 @@ int test_kron(BIO *bp, BN_CTX *ctx)
     int legendre, kronecker;
     int ret = 0;
 
+    osslunused1();
     a = BN_new();
     b = BN_new();
     r = BN_new();
@@ -1743,13 +1755,14 @@ int test_kron(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_sqrt(BIO *bp, BN_CTX *ctx)
+int test_sqrt(BIO *_1, BN_CTX *ctx)
 {
     BN_GENCB cb;
     BIGNUM *a, *p, *r;
     int i, j;
     int ret = 0;
 
+    osslunused1();
     a = BN_new();
     p = BN_new();
     r = BN_new();
@@ -1833,12 +1846,13 @@ int test_sqrt(BIO *bp, BN_CTX *ctx)
     return ret;
 }
 
-int test_small_prime(BIO *bp, BN_CTX *ctx)
+int test_small_prime(BIO *bp, BN_CTX *_1)
 {
     static const int bits = 10;
     int ret = 0;
     BIGNUM *r;
 
+    osslunused1();
     r = BN_new();
     if (!BN_generate_prime_ex(r, bits, 0, NULL, NULL, NULL))
         goto err;

--- a/test/casttest.c
+++ b/test/casttest.c
@@ -111,7 +111,7 @@ static unsigned char c_b[16] = {
     0x80, 0xAC, 0x05, 0xB8, 0xE8, 0x3D, 0x69, 0x6E
 };
 
-int main(int argc, char *argv[])
+int main()
 {
 # ifdef FULL_TEST
     long l;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -61,6 +61,7 @@
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include "../e_os.h"
 
 
 #define CLIENT_VERSION_LEN      2
@@ -86,7 +87,7 @@
  */
 #define TEST_SET_SESSION_TICK_DATA_VER_NEG      1
 
-int main(int argc, char *argv[])
+int main()
 {
     SSL_CTX *ctx;
     SSL *con;

--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -49,6 +49,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "../e_os.h"
 
 static const unsigned int CONSTTIME_TRUE = (unsigned)(~0);
 static const unsigned int CONSTTIME_FALSE = 0;
@@ -223,12 +224,13 @@ static int signed_test_values[] = { 0, 1, -1, 1024, -1024, 12345, -12345,
     INT_MIN + 1
 };
 
-int main(int argc, char *argv[])
+int main()
 {
     unsigned int a, b, i, j;
     int c, d;
     unsigned char e, f;
     int num_failed = 0, num_all = 0;
+
     fprintf(stdout, "Testing constant time operations...\n");
 
     for (i = 0; i < OSSL_NELEM(test_values); ++i) {

--- a/test/destest.c
+++ b/test/destest.c
@@ -58,6 +58,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "../e_os.h"
 #include <openssl/e_os2.h>
 #if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WINDOWS)
 # ifndef OPENSSL_SYS_MSDOS
@@ -352,7 +353,8 @@ static char *pt(unsigned char *p);
 static int cfb_test(int bits, unsigned char *cfb_cipher);
 static int cfb64_test(unsigned char *cfb_cipher);
 static int ede_cfb64_test(unsigned char *cfb_cipher);
-int main(int argc, char *argv[])
+
+int main()
 {
     int j, err = 0;
     unsigned int i;

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -83,7 +83,7 @@ static const char rnd_seed[] =
 
 static int run_rfc5114_tests(void);
 
-int main(int argc, char *argv[])
+int main()
 {
     BN_GENCB *_cb = NULL;
     DH *a = NULL;
@@ -209,10 +209,11 @@ int main(int argc, char *argv[])
     EXIT(ret);
 }
 
-static int cb(int p, int n, BN_GENCB *arg)
+static int cb(int p, int _1, BN_GENCB *arg)
 {
     char c = '*';
 
+    osslunused1();
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -124,7 +124,7 @@ static const char rnd_seed[] =
 
 static BIO *bio_err = NULL;
 
-int main(int argc, char **argv)
+int main()
 {
     BN_GENCB *cb;
     DSA *dsa = NULL;
@@ -224,11 +224,12 @@ int main(int argc, char **argv)
     EXIT(!ret);
 }
 
-static int dsa_cb(int p, int n, BN_GENCB *arg)
+static int dsa_cb(int p, int _1, BN_GENCB *arg)
 {
-    char c = '*';
     static int ok = 0, num = 0;
+    char c = '*';
 
+    osslunused1();
     if (p == 0) {
         c = '.';
         num++;

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -339,10 +339,11 @@ static struct {
 
 #define COOKIE_LEN  20
 
-static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
+static int cookie_gen(SSL *_1, unsigned char *cookie, unsigned int *cookie_len)
 {
     unsigned int i;
 
+    osslunused1();
     for (i = 0; i < COOKIE_LEN; i++, cookie++) {
         *cookie = i;
     }
@@ -351,11 +352,12 @@ static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
     return 1;
 }
 
-static int cookie_verify(SSL *ssl, const unsigned char *cookie,
+static int cookie_verify(SSL *_1, const unsigned char *cookie,
                          unsigned int cookie_len)
 {
     unsigned int i;
 
+    osslunused1();
     if (cookie_len != COOKIE_LEN)
         return 0;
 

--- a/test/ecdhtest.c
+++ b/test/ecdhtest.c
@@ -462,7 +462,7 @@ static int ecdh_kat(BIO *out, const ecdh_kat_t *kat)
     return rv;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
     BN_CTX *ctx = NULL;
     int nid, ret = 1;

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -127,7 +127,7 @@ static void group_order_tests(EC_GROUP *group)
     order = BN_new();
     fprintf(stdout, "verify group order ...");
     fflush(stdout);
-    if (!EC_GROUP_get_order(group, order, ctx))
+    if (!EC_GROUP_get_order(group, order, NULL))
         ABORT;
     if (!EC_POINT_mul(group, Q, order, NULL, NULL, ctx))
         ABORT;
@@ -782,7 +782,7 @@ static void prime_field_tests(void)
         points[2] = Q;
         points[3] = Q;
 
-        if (!EC_GROUP_get_order(group, z, ctx))
+        if (!EC_GROUP_get_order(group, z, NULL))
             ABORT;
         if (!BN_add(y, z, BN_value_one()))
             ABORT;
@@ -1657,7 +1657,7 @@ static void nistp_tests()
 static const char rnd_seed[] =
     "string to make the random number generator think it has entropy";
 
-int main(int argc, char *argv[])
+int main()
 {
     char *p;
 

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -59,9 +59,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <openssl/e_os2.h>
+#include "../e_os.h"
 
 #ifdef OPENSSL_NO_ENGINE
-int main(int argc, char *argv[])
+int main()
 {
     printf("No ENGINE support\n");
     return (0);
@@ -93,7 +94,7 @@ static void display_engine_list(void)
     ENGINE_free(h);
 }
 
-int main(int argc, char *argv[])
+int main()
 {
     ENGINE *block[512];
     char buf[256];

--- a/test/exptest.c
+++ b/test/exptest.c
@@ -182,7 +182,7 @@ static int test_exp_mod_zero()
     return ret;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
     BN_CTX *ctx;
     BIO *out = NULL;

--- a/test/gmdifftest.c
+++ b/test/gmdifftest.c
@@ -54,6 +54,7 @@
 
 #include <openssl/crypto.h>
 #include <stdio.h>
+#include "../e_os.h"
 
 #define SECS_PER_DAY (24 * 60 * 60)
 
@@ -102,7 +103,7 @@ static int check_time(long offset)
     return 1;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     long offset;
     int fails;

--- a/test/heartbeat_test.c
+++ b/test/heartbeat_test.c
@@ -46,6 +46,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../e_os.h"
 
 #if !defined(OPENSSL_NO_HEARTBEATS) && !defined(OPENSSL_NO_UNIT_TEST)
 
@@ -345,7 +346,7 @@ static int test_dtls1_heartbleed_excessive_plaintext_length()
 # undef EXECUTE_HEARTBEAT_TEST
 # undef SETUP_HEARTBEAT_TEST_FIXTURE
 
-int main(int argc, char *argv[])
+int main()
 {
     int result = 0;
 
@@ -362,7 +363,7 @@ int main(int argc, char *argv[])
 
 #else                           /* OPENSSL_NO_HEARTBEATS */
 
-int main(int argc, char *argv[])
+int main()
 {
     return EXIT_SUCCESS;
 }

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -127,7 +127,7 @@ static struct test_st {
 
 static char *pt(unsigned char *md, unsigned int len);
 
-int main(int argc, char *argv[])
+int main()
 {
 # ifndef OPENSSL_NO_MD5
     int i;

--- a/test/ideatest.c
+++ b/test/ideatest.c
@@ -108,7 +108,8 @@ static const unsigned char cfb_cipher64[CFB_TEST_SIZE] = {
 
 static int cfb64_test(const unsigned char *cfb_cipher);
 static char *pt(unsigned char *p);
-int main(int argc, char *argv[])
+
+int main()
 {
     int i, err = 0;
     IDEA_KEY_SCHEDULE key, dkey;

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -269,7 +269,7 @@ static int run_test_vectors(void)
     return errs;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     unsigned char rkey[16];
     unsigned char rkey2[16];

--- a/test/jpaketest.c
+++ b/test/jpaketest.c
@@ -1,10 +1,11 @@
 #include <openssl/opensslconf.h>
+#include "../e_os.h"
 
 #ifdef OPENSSL_NO_JPAKE
 
 # include <stdio.h>
 
-int main(int argc, char *argv[])
+int main()
 {
     printf("No J-PAKE support\n");
     return (0);
@@ -104,7 +105,7 @@ static int run_jpake(JPAKE_CTX *alice, JPAKE_CTX *bob)
     return 0;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     JPAKE_CTX *alice;
     JPAKE_CTX *bob;

--- a/test/md2test.c
+++ b/test/md2test.c
@@ -97,7 +97,8 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+
+int main()
 {
     int i, err = 0;
     char **P, **R;

--- a/test/md4test.c
+++ b/test/md4test.c
@@ -93,7 +93,8 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+
+int main()
 {
     int i, err = 0;
     char **P, **R;

--- a/test/md5test.c
+++ b/test/md5test.c
@@ -93,7 +93,8 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+
+int main()
 {
     int i, err = 0;
     char **P, **R;

--- a/test/mdc2test.c
+++ b/test/mdc2test.c
@@ -89,7 +89,7 @@ static unsigned char pad2[16] = {
     0x35, 0xD8, 0x7A, 0xFE, 0xAB, 0x33, 0xBE, 0xE2
 };
 
-int main(int argc, char *argv[])
+int main()
 {
     int ret = 0;
     unsigned char md[MDC2_DIGEST_LENGTH];

--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -56,8 +56,9 @@
 #include <string.h>
 #include <openssl/bio.h>
 #include <openssl/crypto.h>
+#include "../e_os.h"
 
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
     char *p;
@@ -75,7 +76,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    if (argv[1] && strcmp(argv[1], "freeit") == 0) {
+    if (argc > 1 && strcmp(argv[1], "freeit") == 0) {
         OPENSSL_free(lost);
         lost = NULL;
     }

--- a/test/p5_crpt2_test.c
+++ b/test/p5_crpt2_test.c
@@ -175,7 +175,7 @@ test_p5_pbkdf2(int i, char *digestname, testdata *test, const char *hex)
     OPENSSL_free(out);
 }
 
-int main(int argc, char **argv)
+int main()
 {
     int i;
     testdata *test = test_cases;

--- a/test/packettest.c
+++ b/test/packettest.c
@@ -57,6 +57,7 @@
 
 
 #include "../ssl/packet_locl.h"
+#include "../e_os.h"
 
 #define BUF_LEN 255
 
@@ -457,7 +458,7 @@ static int test_PACKET_get_length_prefixed_3()
     return 1;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     unsigned char buf[BUF_LEN];
     unsigned int i;

--- a/test/pbelutest.c
+++ b/test/pbelutest.c
@@ -55,18 +55,20 @@
 #include <openssl/evp.h>
 #include <stdio.h>
 #include <string.h>
+#include "../e_os.h"
 
 /*
  * Password based encryption (PBE) table ordering test.
  * Attempt to look up all supported algorithms.
  */
 
-int main(int argc, char **argv)
+int main()
 {
     size_t i;
     int rv = 0;
     int pbe_type, pbe_nid;
     int last_type = -1, last_nid = -1;
+
     for (i = 0; EVP_PBE_get(&pbe_type, &pbe_nid, i) != 0; i++) {
         if (EVP_PBE_find(pbe_type, pbe_nid, NULL, NULL, 0) == 0) {
             rv = 1;

--- a/test/randtest.c
+++ b/test/randtest.c
@@ -64,16 +64,13 @@
 /* some FIPS 140-1 random number test */
 /* some simple tests */
 
-int main(int argc, char **argv)
+int main()
 {
     unsigned char buf[2500];
     int i, j, k, s, sign, nsign, err = 0;
     unsigned long n1;
     unsigned long n2[16];
     unsigned long runs[2][34];
-    /*
-     * double d;
-     */
     long d;
 
     i = RAND_bytes(buf, 2500);

--- a/test/rc2test.c
+++ b/test/rc2test.c
@@ -100,7 +100,7 @@ static unsigned char RC2cipher[4][8] = {
     {0x50, 0xDC, 0x01, 0x62, 0xBD, 0x75, 0x7F, 0x31},
 };
 
-int main(int argc, char *argv[])
+int main()
 {
     int i, n, err = 0;
     RC2_KEY key;

--- a/test/rc4test.c
+++ b/test/rc4test.c
@@ -112,7 +112,7 @@ static unsigned char output[7][30] = {
     {0},
 };
 
-int main(int argc, char *argv[])
+int main(int _1, char *_2[])
 {
     int i, err = 0;
     int j;
@@ -125,6 +125,7 @@ int main(int argc, char *argv[])
 
     OPENSSL_cpuid_setup();
 # endif
+    osslunused2();
 
     for (i = 0; i < 6; i++) {
         RC4_set_key(&key, keys[i][0], &(keys[i][1]));

--- a/test/rc5test.c
+++ b/test/rc5test.c
@@ -235,7 +235,7 @@ static unsigned char rc5_cbc_iv[RC5_CBC_NUM][8] = {
     {0x7c, 0xb3, 0xf1, 0xdf, 0x34, 0xf9, 0x48, 0x11},
 };
 
-int main(int argc, char *argv[])
+int main()
 {
     int i, n, err = 0;
     RC5_32_KEY key;

--- a/test/rmdtest.c
+++ b/test/rmdtest.c
@@ -99,7 +99,8 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+
+int main()
 {
     int i, err = 0;
     char **P, **R;

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -208,7 +208,7 @@ static int pad_unknown(void)
 static const char rnd_seed[] =
     "string to make the random number generator think it has entropy";
 
-int main(int argc, char *argv[])
+int main()
 {
     int err = 0;
     int v;

--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -1,7 +1,8 @@
 
 #include <openssl/crypto.h>
+#include "../e_os.h"
 
-int main(int argc, char **argv)
+int main()
 {
 #if defined(OPENSSL_SYS_LINUX) || defined(OPENSSL_SYS_UNIX)
     char *p = NULL, *q = NULL;

--- a/test/sha1test.c
+++ b/test/sha1test.c
@@ -81,7 +81,8 @@ static char *ret[] = {
 static char *bigret = "34aa973cd4c4daa4f61eeb2bdbad27316534016f";
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+
+int main()
 {
     int i, err = 0;
     char **P, **R;

--- a/test/sha256t.c
+++ b/test/sha256t.c
@@ -8,6 +8,7 @@
 
 #include <openssl/sha.h>
 #include <openssl/evp.h>
+#include "../e_os.h"
 
 static const unsigned char app_b1[SHA256_DIGEST_LENGTH] = {
     0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
@@ -51,7 +52,7 @@ static const unsigned char addenum_3[SHA224_DIGEST_LENGTH] = {
     0x4e, 0xe7, 0xad, 0x67
 };
 
-int main(int argc, char **argv)
+int main()
 {
     unsigned char md[SHA256_DIGEST_LENGTH];
     int i;

--- a/test/sha512t.c
+++ b/test/sha512t.c
@@ -9,6 +9,7 @@
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
+#include "../e_os.h"
 
 static const unsigned char app_c1[SHA512_DIGEST_LENGTH] = {
     0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba,
@@ -70,7 +71,7 @@ static const unsigned char app_d3[SHA384_DIGEST_LENGTH] = {
     0xae, 0x97, 0xdd, 0xd8, 0x7f, 0x3d, 0x89, 0x85
 };
 
-int main(int argc, char **argv)
+int main()
 {
     unsigned char md[SHA512_DIGEST_LENGTH];
     int i;

--- a/test/srptest.c
+++ b/test/srptest.c
@@ -1,4 +1,5 @@
 #include <openssl/opensslconf.h>
+#include "../e_os.h"
 #ifdef OPENSSL_NO_SRP
 
 # include <stdio.h>
@@ -121,7 +122,7 @@ static int run_srp(const char *username, const char *client_pass,
     return ret;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     BIO *bio_err;
     bio_err = BIO_new_fp(stderr, BIO_NOCLOSE | BIO_FP_TEXT);

--- a/test/ssltest.c
+++ b/test/ssltest.c
@@ -249,9 +249,11 @@ typedef struct srp_client_arg_st {
 
 # define PWD_STRLEN 1024
 
-static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
+static char *ssl_give_srp_client_pwd_cb(SSL *_1, void *arg)
 {
     SRP_CLIENT_ARG *srp_client_arg = (SRP_CLIENT_ARG *)arg;
+
+    osslunused1();
     return OPENSSL_strdup((char *)srp_client_arg->srppassin);
 }
 
@@ -288,10 +290,11 @@ static int npn_client = 0;
 static int npn_server = 0;
 static int npn_server_reject = 0;
 
-static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
-                         const unsigned char *in, unsigned int inlen,
-                         void *arg)
+static int cb_client_npn(SSL *_1, unsigned char **out, unsigned char *outlen,
+                         const unsigned char *_2, unsigned int _3,
+                         void *_4)
 {
+    osslunused4();
     /*
      * This callback only returns the protocol string, rather than a length
      * prefixed set. We assume that NEXT_PROTO_STRING is a one element list
@@ -302,17 +305,19 @@ static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
     return SSL_TLSEXT_ERR_OK;
 }
 
-static int cb_server_npn(SSL *s, const unsigned char **data,
-                         unsigned int *len, void *arg)
+static int cb_server_npn(SSL *_1, const unsigned char **data,
+                         unsigned int *len, void *_2)
 {
+    osslunused2();
     *data = (const unsigned char *)NEXT_PROTO_STRING;
     *len = sizeof(NEXT_PROTO_STRING) - 1;
     return SSL_TLSEXT_ERR_OK;
 }
 
-static int cb_server_rejects_npn(SSL *s, const unsigned char **data,
-                                 unsigned int *len, void *arg)
+static int cb_server_rejects_npn(SSL *_1, const unsigned char **_2,
+                                 unsigned int *_3, void *_4)
 {
+    osslunused4();
     return SSL_TLSEXT_ERR_NOACK;
 }
 
@@ -412,14 +417,14 @@ static unsigned char *next_protos_parse(unsigned short *outlen,
     return out;
 }
 
-static int cb_server_alpn(SSL *s, const unsigned char **out,
+static int cb_server_alpn(SSL *_1, const unsigned char **out,
                           unsigned char *outlen, const unsigned char *in,
-                          unsigned int inlen, void *arg)
+                          unsigned int inlen, void *_2)
 {
-    unsigned char *protos;
     unsigned short protos_len;
+    unsigned char *protos = next_protos_parse(&protos_len, alpn_server);
 
-    protos = next_protos_parse(&protos_len, alpn_server);
+    osslunused2();
     if (protos == NULL) {
         fprintf(stderr, "failed to parser ALPN server protocol string: %s\n",
                 alpn_server);
@@ -525,10 +530,11 @@ static int custom_ext = 0;
 /* This set based on extension callbacks */
 static int custom_ext_error = 0;
 
-static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char *in, size_t inlen,
-                                   int *al, void *arg)
+static int serverinfo_cli_parse_cb(SSL *_1, unsigned int ext_type,
+                                   const unsigned char *_2, size_t _3,
+                                   int *_4, void *_5)
 {
+    osslunused5();
     if (ext_type == SCT_EXT_TYPE)
         serverinfo_sct_seen++;
     else if (ext_type == TACK_EXT_TYPE)
@@ -557,26 +563,29 @@ static int verify_serverinfo()
  * 3 - ClientHello with "abc", "defg" response
  */
 
-static int custom_ext_0_cli_add_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+static int custom_ext_0_cli_add_cb(SSL *_1, unsigned int ext_type,
+                                   const unsigned char **_2,
+                                   size_t *_3, int *_4, void *_5)
 {
+    osslunused5();
     if (ext_type != CUSTOM_EXT_TYPE_0)
         custom_ext_error = 1;
     return 0;                   /* Don't send an extension */
 }
 
-static int custom_ext_0_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_0_cli_parse_cb(SSL *_1, unsigned int _2,
+                                     const unsigned char *_3,
+                                     size_t _4, int *_5, void *_6)
 {
+    osslunused6();
     return 1;
 }
 
-static int custom_ext_1_cli_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_1_cli_add_cb(SSL *_1, unsigned int ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_1)
         custom_ext_error = 1;
     *out = (const unsigned char *)custom_ext_cli_string;
@@ -584,17 +593,19 @@ static int custom_ext_1_cli_add_cb(SSL *s, unsigned int ext_type,
     return 1;                   /* Send "abc" */
 }
 
-static int custom_ext_1_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_1_cli_parse_cb(SSL *_1, unsigned int _2,
+                                     const unsigned char *_3,
+                                     size_t _4, int *_5, void *_6)
 {
+    osslunused6();
     return 1;
 }
 
-static int custom_ext_2_cli_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_2_cli_add_cb(SSL *_1, unsigned int ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
     *out = (const unsigned char *)custom_ext_cli_string;
@@ -602,10 +613,11 @@ static int custom_ext_2_cli_add_cb(SSL *s, unsigned int ext_type,
     return 1;                   /* Send "abc" */
 }
 
-static int custom_ext_2_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_2_cli_parse_cb(SSL *_1, unsigned int ext_type,
+                                     const unsigned char *_2,
+                                     size_t inlen, int *_3, void *_4)
 {
+    osslunused4();
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
     if (inlen != 0)
@@ -613,10 +625,11 @@ static int custom_ext_2_cli_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_3_cli_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_cli_add_cb(SSL *_1, unsigned int ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
     *out = (const unsigned char *)custom_ext_cli_string;
@@ -624,10 +637,11 @@ static int custom_ext_3_cli_add_cb(SSL *s, unsigned int ext_type,
     return 1;                   /* Send "abc" */
 }
 
-static int custom_ext_3_cli_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_cli_parse_cb(SSL *_1, unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
     if (inlen != strlen(custom_ext_srv_string))
@@ -641,28 +655,31 @@ static int custom_ext_3_cli_parse_cb(SSL *s, unsigned int ext_type,
  * custom_ext_0_cli_add_cb returns 0 - the server won't receive a callback
  * for this extension
  */
-static int custom_ext_0_srv_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_0_srv_parse_cb(SSL *_1, unsigned int _2,
+                                     const unsigned char *_3,
+                                     size_t _4, int *_5, void *_6)
 {
+    osslunused6();
     custom_ext_error = 1;
     return 1;
 }
 
 /* 'add' callbacks are only called if the 'parse' callback is called */
-static int custom_ext_0_srv_add_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+static int custom_ext_0_srv_add_cb(SSL *_1, unsigned int _2,
+                                   const unsigned char **_3,
+                                   size_t *_4, int *_5, void *_6)
 {
+    osslunused6();
     /* Error: should not have been called */
     custom_ext_error = 1;
     return 0;                   /* Don't send an extension */
 }
 
-static int custom_ext_1_srv_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_1_srv_parse_cb(SSL *_1, unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_1)
         custom_ext_error = 1;
     /* Check for "abc" */
@@ -673,17 +690,19 @@ static int custom_ext_1_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_1_srv_add_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+static int custom_ext_1_srv_add_cb(SSL *_1, unsigned int _2,
+                                   const unsigned char **_3,
+                                   size_t *_4, int *_5, void *_6)
 {
+    osslunused6();
     return 0;                   /* Don't send an extension */
 }
 
-static int custom_ext_2_srv_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_2_srv_parse_cb(SSL *_1, unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
     /* Check for "abc" */
@@ -694,19 +713,21 @@ static int custom_ext_2_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_2_srv_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_2_srv_add_cb(SSL *_1, unsigned int _2,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen, int *_3, void *_4)
 {
+    osslunused4();
     *out = NULL;
     *outlen = 0;
     return 1;                   /* Send empty extension */
 }
 
-static int custom_ext_3_srv_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_srv_parse_cb(SSL *_1, unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen, int *_2, void *_3)
 {
+    osslunused3();
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
     /* Check for "abc" */
@@ -717,10 +738,11 @@ static int custom_ext_3_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_3_srv_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_srv_add_cb(SSL *_1, unsigned int _2,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen, int *_3, void *_4)
 {
+    osslunused4();
     *out = (const unsigned char *)custom_ext_srv_string;
     *outlen = strlen(custom_ext_srv_string);
     return 1;                   /* Send "defg" */
@@ -3436,7 +3458,7 @@ static int psk_key2bn(const char *pskkey, unsigned char *psk,
     return ret;
 }
 
-static unsigned int psk_client_callback(SSL *ssl, const char *hint,
+static unsigned int psk_client_callback(SSL *_1, const char *_2,
                                         char *identity,
                                         unsigned int max_identity_len,
                                         unsigned char *psk,
@@ -3445,6 +3467,7 @@ static unsigned int psk_client_callback(SSL *ssl, const char *hint,
     int ret;
     unsigned int psk_len = 0;
 
+    osslunused2();
     ret = BIO_snprintf(identity, max_identity_len, "Client_identity");
     if (ret < 0)
         goto out_err;
@@ -3459,12 +3482,13 @@ static unsigned int psk_client_callback(SSL *ssl, const char *hint,
     return psk_len;
 }
 
-static unsigned int psk_server_callback(SSL *ssl, const char *identity,
+static unsigned int psk_server_callback(SSL *_1, const char *identity,
                                         unsigned char *psk,
                                         unsigned int max_psk_len)
 {
     unsigned int psk_len = 0;
 
+    osslunused1();
     if (strcmp(identity, "Client_identity") != 0) {
         BIO_printf(bio_err, "server: PSK error: client identity not found\n");
         return 0;

--- a/test/wp_test.c
+++ b/test/wp_test.c
@@ -8,9 +8,10 @@
 
 #include <openssl/whrlpool.h>
 #include <openssl/crypto.h>
+#include "../e_os.h"
 
 #if defined(OPENSSL_NO_WHIRLPOOL)
-int main(int argc, char *argv[])
+int main()
 {
     printf("No Whirlpool support\n");
     return (0);
@@ -117,7 +118,7 @@ static const unsigned char iso_test_9[WHIRLPOOL_DIGEST_LENGTH] = {
     0x69, 0x53, 0xB2, 0x26, 0xE4, 0xED, 0x8B, 0x01
 };
 
-int main(int argc, char *argv[])
+int main()
 {
     unsigned char md[WHIRLPOOL_DIGEST_LENGTH];
     int i;


### PR DESCRIPTION
Unused parameters were removed from various functions, including
the following:
    BN_RECP_CTX_set, DSA_sign, DSA_verify, EC_GROUP_get_order,
    EC_GROUP_get_cofactor, RSA_padding_check_none,
    RSA_sign_ASN1_OCTET_STRING, RSA_verify_ASN1_OCTET_STRING,
    BN_RECP_CTX_set, DSA_sign, DSA_verify
Also the following functions where have not been documented:
    i2a_ASN1_STRING, ASN1_bn_print, X509_CRL_diff,
    X509_ATTRIBUTE_get0_data, X509_STORE_CTX_set_time
And many internal functions.