### PR TITLE
async_win.c: remove unused variable

### DIFF
--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -109,8 +109,6 @@ void async_global_cleanup(void)
 
 int async_fibre_init_dispatcher(async_fibre *fibre)
 {
-    LPVOID dispatcher;
-
     fibre->fibre = ConvertThreadToFiber(NULL);
     if (fibre->fibre == NULL) {
         fibre->converted = 0;


### PR DESCRIPTION
Silencing this:
```
crypto/async/arch/async_win.c: In function 'async_fibre_init_dispatcher':
crypto/async/arch/async_win.c:112:12: warning: unused variable 'dispatcher' [-Wunused-variable]
     LPVOID dispatcher;
            ^
```