### PR TITLE
Add Postgres support to s_client -starttls

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -814,7 +814,8 @@ typedef enum PROTOCOL_choice {
     PROTO_XMPP,
     PROTO_XMPP_SERVER,
     PROTO_CONNECT,
-    PROTO_IRC
+    PROTO_IRC,
+    PROTO_POSTGRES
 } PROTOCOL_CHOICE;
 
 static OPT_PAIR services[] = {
@@ -826,6 +827,7 @@ static OPT_PAIR services[] = {
     {"xmpp-server", PROTO_XMPP_SERVER},
     {"telnet", PROTO_TELNET},
     {"irc", PROTO_IRC},
+    {"postgres", PROTO_POSTGRES},
     {NULL}
 };
 
@@ -2038,6 +2040,25 @@ int s_client_main(int argc, char **argv)
                 goto shut;
             }
         }
+        break;
+    case PROTO_POSTGRES:
+        {
+            static const unsigned char ssl_request[] = {
+                /* Length        SSLRequest */
+                   0, 0, 0, 8,   4, 210, 22, 47
+            };
+            int bytes;
+
+            /* Send SSLRequest packet */
+            BIO_write(sbio, ssl_request, 8);
+            (void)BIO_flush(sbio);
+
+            /* Reply will be a single S if SSL is enabled */
+            bytes = BIO_read(sbio, sbuf, BUFSIZZ);
+            if (bytes != 1 || sbuf[0] != 'S')
+                goto shut;
+        }
+        break;
     }
 
     for (;;) {

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -361,7 +361,7 @@ command for more information.
 send the protocol-specific message(s) to switch to TLS for communication.
 B<protocol> is a keyword for the intended protocol.  Currently, the only
 supported keywords are "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server",
-and "irc."
+"irc" and "postgres."
 
 =item B<-xmpphost hostname>
 


### PR DESCRIPTION
The patch sends a SSLRequest packet and checks for a S in response.
Useful for checking certificate validity of a PostgreSQL server.