### PR TITLE
update secmemtest.c for heap manipulator implementions

### DIFF
--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -20,8 +20,8 @@ int main(int argc, char **argv)
         perror("failed 1");
         return 1;
     }
-    CRYPTO_secure_free(p);
-    CRYPTO_free(q);
+    OPENSSL_secure_free(p);
+    OPENSSL_free(q);
     CRYPTO_secure_malloc_done();
 #else
     /* Should fail. */


### PR DESCRIPTION
`CRYPTO_free()`, `CRYPTO_clear_free()` and `CRYPTO_secure_free()` now receive
`__FILE__` and `__LINE__`, see https://github.com/openssl/openssl/commit/05c7b1631b4f6884b9ef5f0943a3d16d36383f52