### PR TITLE
RT4175: Fix regression using PKCS7_verify() with Authenticode

### DIFF
--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -279,12 +279,6 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
         return 0;
     }
 
-    /* Check for data and content: two sets of data */
-    if (!PKCS7_get_detached(p7) && indata) {
-        PKCS7err(PKCS7_F_PKCS7_VERIFY, PKCS7_R_CONTENT_AND_DATA_PRESENT);
-        return 0;
-    }
-
     sinfos = PKCS7_get_signer_info(p7);
 
     if (!sinfos || !sk_PKCS7_SIGNER_INFO_num(sinfos)) {


### PR DESCRIPTION
Authenticode uses an extended PKCS#7 format, where the embedded data are
not directly the data to be verified; instead an Authenticode-specific
data structure (SpcIndirectDataContent) is embedded, which describes
the various files covered by the Authenticode signature.

In this case, we need to allow PKCS7_verify() to be called with external
data even though PKCS7_get_detached() is not true.

This always used to work; there was a "sanity" check for external data
being passed to PKCS7_verify() with a non-detached PKCS#7 signature, but
it was always #ifdef'd out.

It was broken in HEAD by commit 55500ea7c ("GH354: Memory leak fixes") and
in 1.0.2 by cherry-picking that same commit to become c8491de39.