### PR TITLE
RT4309: Define PRIu64 for UEFI build

### DIFF
--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -299,6 +299,7 @@ typedef INT32 int32_t;
 typedef UINT32 uint32_t;
 typedef INT64 int64_t;
 typedef UINT64 uint64_t;
+#define PRIu64 "%Lu"
 # elif defined(_MSC_VER) && _MSC_VER<=1500
 /*
  * minimally required typdefs for systems not supporting inttypes.h or


### PR DESCRIPTION
Provide an appropriate definition of PRIu64 for the EDK2 build, since
we don't have <inttypes.h> there.