### PR TITLE
Remove redundant check

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -127,7 +127,7 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
      * reinitialisation, when it may all be unnecessary.
      */
     if (ctx->engine && ctx->cipher
-        && (!cipher || (cipher && (cipher->nid == ctx->cipher->nid))))
+        && (!cipher || (cipher->nid == ctx->cipher->nid)))
         goto skip_to_init;
 #endif
     if (cipher) {


### PR DESCRIPTION
This was found with Cppcheck. C language uses "short circuiting" so no need for the second `cipher` check - just makes the reader think more than needed.