### PR TITLE
RT4318: Fix OSSL_SSIZE_MAX for UEFI build

### DIFF
--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -269,7 +269,7 @@ extern "C" {
 #  endif
 # endif
 
-# if defined(__ultrix) && !defined(ssize_t)
+# if (defined(__ultrix) || defined(OPENSSL_SYS_UEFI)) && !defined(ssize_t)
 #  define ossl_ssize_t int
 #  define OSSL_SSIZE_MAX INT_MAX
 # endif


### PR DESCRIPTION
Commit e634b448c ("Defines OSSL_SSIZE_MAX") introduced a definition of
OSSL_SSIZE_MAX which broke the UEFI build. Fix that by making UEFI take
the same definition as Ultrix (ssize_t == int).