### PR TITLE
Fix regression in header analysis, simplify pointer manipulation

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -489,7 +489,6 @@ int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher)
 {
     const EVP_CIPHER *enc = NULL;
     char *dekinfostart, c;
-    char **header_pp = &header;
 
     cipher->cipher = NULL;
     if ((header == NULL) || (*header == '\0') || (*header == '\n'))
@@ -537,12 +536,13 @@ int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher)
     *header = '\0';
     cipher->cipher = enc = EVP_get_cipherbyname(dekinfostart);
     *header = c;
+    header++;
 
     if (enc == NULL) {
         PEMerr(PEM_F_PEM_GET_EVP_CIPHER_INFO, PEM_R_UNSUPPORTED_ENCRYPTION);
         return (0);
     }
-    if (!load_iv(header_pp, &(cipher->iv[0]), EVP_CIPHER_iv_length(enc)))
+    if (!load_iv(&header, &(cipher->iv[0]), EVP_CIPHER_iv_length(enc)))
         return (0);
 
     return (1);


### PR DESCRIPTION
Fixes regression introduced in https://github.com/openssl/openssl/pull/643 and simplifies the code to make it more maintainable.