### PR TITLE
Fix typo in SSL_CTX_set_msg_callback docs

### DIFF
--- a/doc/ssl/SSL_CTX_set_msg_callback.pod
+++ b/doc/ssl/SSL_CTX_set_msg_callback.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-SSL_CTX_set_msg_callback, SSL_CTX_set_msg_callback_arg, SSL_set_msg_callback, SSL_get_msg_callback_arg - install callback for observing protocol messages
+SSL_CTX_set_msg_callback, SSL_CTX_set_msg_callback_arg, SSL_set_msg_callback, SSL_set_msg_callback_arg - install callback for observing protocol messages
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Change `SSL_get_msg_callback_arg` to `SSL_set_msg_callback_arg`