### PR TITLE
Fix: failed to open config file if not specified when using CA commands

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -305,11 +305,6 @@ int ca_main(int argc, char **argv)
     X509_REVOKED *r = NULL;
     OPTION_CHOICE o;
 
-    conf = NULL;
-    section = NULL;
-    preserve = 0;
-    msie_hack = 0;
-
     prog = opt_init(argc, argv, ca_options);
     while ((o = opt_next()) != OPT_EOF) {
         switch (o) {
@@ -482,13 +477,11 @@ end_of_options:
     argv = opt_rest();
 
     BIO_printf(bio_err, "Using configuration from %s\n", configfile);
-    /* We already loaded the default config file */
-    if (configfile != default_config_file) {
-        if ((conf = app_load_config(configfile)) == NULL)
-            goto end;
-        if (!app_load_modules(conf))
-            goto end;
-    }
+    
+    if ((conf = app_load_config(configfile)) == NULL)
+        goto end;
+    if (!app_load_modules(conf))
+        goto end;
 
     /* Lets get the config section we are using */
     if (section == NULL) {


### PR DESCRIPTION
Issue was introduced in
https://github.com/openssl/openssl/commit/a0a82324f965bbcc4faed4e1ee3fcaf81ea52166

This patch fixes an issue which causes the 'openssl ca' commands to
fail if '-config' is not specified even if it says so otherwise.
Problem is that the default config is not loaded and the conf variable
is NULL which causes an exception.