### PR TITLE
Fix: error when trying to read an encrypted ec key file

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -537,6 +537,7 @@ int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher)
     *header = '\0';
     cipher->cipher = enc = EVP_get_cipherbyname(dekinfostart);
     *header = c;
+    header++;
 
     if (enc == NULL) {
         PEMerr(PEM_F_PEM_GET_EVP_CIPHER_INFO, PEM_R_UNSUPPORTED_ENCRYPTION);


### PR DESCRIPTION
Issue introduced in
https://github.com/openssl/openssl/commit/33a6d5a0e565e08758bcb6af456ec657c3a7a76a

This patch fixes and issue where a key cannot be read after it has been
encrypted using the 'openssl ec' command. Because the header is not
incremented the load_iv method will always fail.