### PR TITLE
Add PKCS7_DUAL_CONTENT flag for UEFI, Authenticode

### DIFF
--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -279,10 +279,18 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
         return 0;
     }
 
-    /* Check for data and content: two sets of data */
-    if (!PKCS7_get_detached(p7) && indata) {
-        PKCS7err(PKCS7_F_PKCS7_VERIFY, PKCS7_R_CONTENT_AND_DATA_PRESENT);
-        return 0;
+    if (flags & PKCS7_NO_DUAL_CONTENT) {
+        /*
+         * This was originally "#if 0" because we thought that only old broken
+         * Netscape did this.  It turns out that Authenticode uses this kind
+         * of "extended" PKCS7 format, and things like UEFI secure boot and
+         * tools like osslsigncode need it.  In Authenticode the verification
+         * process is different, but the existing PKCs7 verification works.
+         */
+        if (!PKCS7_get_detached(p7) && indata) {
+            PKCS7err(PKCS7_F_PKCS7_VERIFY, PKCS7_R_CONTENT_AND_DATA_PRESENT);
+            return 0;
+        }
     }
 
     sinfos = PKCS7_get_signer_info(p7);

--- a/doc/crypto/PKCS7_verify.pod
+++ b/doc/crypto/PKCS7_verify.pod
@@ -8,6 +8,8 @@ PKCS7_verify, PKCS7_get0_signers - verify a PKCS#7 signedData structure
 
  #include <openssl/pkcs7.h>
 
+ #define PKCS7_NO_DUAL_CONTENT
+
  int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store, BIO *indata, BIO *out, int flags);
 
  STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, STACK_OF(X509) *certs, int flags);
@@ -34,7 +36,12 @@ Normally the verify process proceeds as follows.
 
 Initially some sanity checks are performed on B<p7>. The type of B<p7> must
 be signedData. There must be at least one signature on the data and if
-the content is detached B<indata> cannot be B<NULL>.
+the content is detached B<indata> cannot be B<NULL>.  If the content is
+not detached and B<indata> is not B<NULL>, then the structure has both
+embedded and external content. To treat this as an error, use the flag
+B<PKCS7_NO_DUAL_CONTENT>.
+The default behavior allows this, for compatibility with older
+versions of OpenSSL.
 
 An attempt is made to locate all the signer's certificates, first looking in
 the B<certs> parameter (if it is not B<NULL>) and then looking in any certificates

--- a/include/openssl/pkcs7.h
+++ b/include/openssl/pkcs7.h
@@ -237,6 +237,7 @@ DEFINE_STACK_OF(PKCS7)
 # define PKCS7_NOCRL             0x2000
 # define PKCS7_PARTIAL           0x4000
 # define PKCS7_REUSE_DIGEST      0x8000
+# define PKCS7_NO_DUAL_CONTENT   0x10000
 
 /* Flags: for compatibility with older code */
 


### PR DESCRIPTION
Alternative way to address #694 and #695 .  Adds a runtime flag, and extensive comment.  And doc.
Looking for @t-j-h and @dwmw2 to review this.