### PR TITLE
RT4339: Fix handling of <internal/bn_conf.h> in UEFI build

### DIFF
--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -111,7 +111,17 @@
 #ifndef HEADER_BN_LCL_H
 # define HEADER_BN_LCL_H
 
-# include "internal/bn_conf.h"
+/*
+ * The EDK2 build doesn't use bn_conf.h; it sets THIRTY_TWO_BIT or
+ * SIXTY_FOUR_BIT in its own environment since it doesn't re-run our
+ * Configure script and needs to support both 32-bit and 64-bit.
+ */
+# include <openssl/opensslconf.h>
+
+# if !defined(OPENSSL_SYS_UEFI)
+#  include "internal/bn_conf.h"
+# endif
+
 # include "internal/bn_int.h"
 
 #ifdef  __cplusplus

--- a/crypto/include/internal/bn_conf.h.in
+++ b/crypto/include/internal/bn_conf.h.in
@@ -56,7 +56,11 @@
 #ifndef HEADER_BN_CONF_H
 # define HEADER_BN_CONF_H
 
-# if !defined(OPENSSL_SYS_UEFI)
+/*
+ * The contents of this file are not used in the UEFI build, as
+ * both 32-bit and 64-bit builds are supported from a single run
+ * of the Configure script.
+ */
 
 /* Should we define BN_DIV2W here? */
 
@@ -64,6 +68,5 @@
 {- $config{b64l} ? "#define" : "#undef" -} SIXTY_FOUR_BIT_LONG
 {- $config{b64}  ? "#define" : "#undef" -} SIXTY_FOUR_BIT
 {- $config{b32}  ? "#define" : "#undef" -} THIRTY_TWO_BIT
-# endif
 
 #endif


### PR DESCRIPTION
The entire contents of <internal/bn_conf.h> are unwanted in the UEFI
build because we have to do it differently there. To support building
for both 32-bit and 64-bit platforms without re-running the OpenSSL
Configure script, the EDK2 environment defines THIRTY_TWO_BIT or
SIXTY_FOUR_BIT for itself according to the target platform.

The current setup is broken, though. It checks for OPENSSL_SYS_UEFI but
before it's actually defined, since opensslconf.h hasn't yet been
included.

Let's fix that by including opensslconf.h. And also let's move the
bn_conf.h doesn't even need to *exist* in the UEFI build environment.