### PR TITLE
RT4340: Check method before access and release ctx in error paths

### DIFF
--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -243,12 +243,12 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
     type = EVP_MD_CTX_md(ctx);
     pkey = EVP_PKEY_CTX_get0_pkey(EVP_MD_CTX_pkey_ctx(ctx));
 
-    if (NULL == type || NULL == pkey) {
+    if (type == NULL || pkey == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ASN1_R_CONTEXT_NOT_INITIALISED);
         goto err;
     }
 
-    if (NULL == pkey->ameth) {
+    if (pkey->ameth == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED);
         goto err;
     }

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -245,7 +245,12 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
 
     if (!type || !pkey) {
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ASN1_R_CONTEXT_NOT_INITIALISED);
-        return 0;
+        goto err;
+    }
+
+    if (!pkey->ameth) {
+        ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED);
+        goto err;
     }
 
     if (pkey->ameth->item_sign) {
@@ -267,13 +272,12 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
         rv = 2;
 
     if (rv == 2) {
-        if (!pkey->ameth ||
-            !OBJ_find_sigid_by_algs(&signid,
+        if (!OBJ_find_sigid_by_algs(&signid,
                                     EVP_MD_nid(type),
                                     pkey->ameth->pkey_id)) {
             ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX,
                     ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED);
-            return 0;
+            goto err;
         }
 
         if (pkey->ameth->pkey_flags & ASN1_PKEY_SIGPARAM_NULL)

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -243,12 +243,12 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
     type = EVP_MD_CTX_md(ctx);
     pkey = EVP_PKEY_CTX_get0_pkey(EVP_MD_CTX_pkey_ctx(ctx));
 
-    if (!type || !pkey) {
+    if (NULL == type || NULL == pkey) {
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ASN1_R_CONTEXT_NOT_INITIALISED);
         goto err;
     }
 
-    if (!pkey->ameth) {
+    if (NULL == pkey->ameth) {
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED);
         goto err;
     }


### PR DESCRIPTION
- In error paths, EVP_MD_CTX allocated by the callee is not released.
- Checking method before accessing