### PR TITLE
#4337: SEGV Fault in the DES_fcrypt

### DIFF
--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -70,7 +70,6 @@ char *DES_crypt(const char *buf, const char *salt)
     char e_buf[32 + 1];         /* replace 32 by 8 ? */
     char *ret;
 
-    if (sizeof(salt) < 2) return NULL;
     if (salt[0] == '\0' || salt[1] == '\0') return NULL;
 
     /* Copy at most 2 chars of salt */
@@ -110,7 +109,6 @@ char *DES_fcrypt(const char *buf, const char *salt, char *ret)
     unsigned char *b = bb;
     unsigned char c, u;
 
-    if (sizeof(salt) < 2) return NULL;
     if (salt[0] == '\0' || salt[1] == '\0') return NULL;
 
     /*

--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -70,9 +70,12 @@ char *DES_crypt(const char *buf, const char *salt)
     char e_buf[32 + 1];         /* replace 32 by 8 ? */
     char *ret;
 
+    if (sizeof(salt) < 2) return NULL;
+    if (salt[0] == '\0' || salt[1] == '\0') return NULL;
+
     /* Copy at most 2 chars of salt */
-    if ((e_salt[0] = salt[0]) != '\0')
-        e_salt[1] = salt[1];
+    e_salt[0] = salt[0];
+    e_salt[1] = salt[1];
 
     /* Copy at most 32 chars of password */
     strncpy(e_buf, buf, sizeof(e_buf));

--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -107,6 +107,9 @@ char *DES_fcrypt(const char *buf, const char *salt, char *ret)
     unsigned char *b = bb;
     unsigned char c, u;
 
+    if (sizeof(salt) < 2) return NULL;
+    if (salt[0] == '\0' || salt[1] == '\0') return NULL;
+
     /*
      * eay 25/08/92 If you call crypt("pwd","*") as often happens when you
      * have * as the pwd field in /etc/passwd, the function returns
@@ -115,17 +118,14 @@ char *DES_fcrypt(const char *buf, const char *salt, char *ret)
      * libraries.  People found that the disabled accounts effectively had no
      * passwd :-(.
      */
-#ifndef CHARSET_EBCDIC
-    x = ret[0] = ((salt[0] == '\0') ? 'A' : salt[0]);
+
+    x = ret[0] = salt[0];
+    if (x >= sizeof(con_salt)) return NULL;
     Eswap0 = con_salt[x] << 2;
-    x = ret[1] = ((salt[1] == '\0') ? 'A' : salt[1]);
+
+    x = ret[1] = salt[1];
+    if (x >= sizeof(con_salt)) return NULL;
     Eswap1 = con_salt[x] << 6;
-#else
-    x = ret[0] = ((salt[0] == '\0') ? os_toascii['A'] : salt[0]);
-    Eswap0 = con_salt[x] << 2;
-    x = ret[1] = ((salt[1] == '\0') ? os_toascii['A'] : salt[1]);
-    Eswap1 = con_salt[x] << 6;
-#endif
 
     /*
      * EAY r=strlen(buf); r=(r+7)/8;

--- a/test/destest.c
+++ b/test/destest.c
@@ -719,27 +719,27 @@ int main(int argc, char *argv[])
         err = 1;
     }
     str = crypt("testing", "y€");
-    if (str != 0) {
+    if (str != NULL) {
         printf("salt error only usascii are accepted, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "‰A");
-    if (str != 0) {
+    if (str != NULL) {
         printf("salt error only usascii are accepted, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "\0A");
-    if (str != 0) {
+    if (str != NULL) {
         printf("salt error cannot contain null terminator, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "A\0");
-    if (str != 0) {
+    if (str != NULL) {
         printf("salt error cannot contain null terminator, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "A");
-    if (str != 0) {
+    if (str != NULL) {
         printf("salt error size have to be at least 2, returned value should be 0\n");
         err = 1;
     }

--- a/test/destest.c
+++ b/test/destest.c
@@ -720,27 +720,27 @@ int main(int argc, char *argv[])
     }
     str = crypt("testing", "y€");
     if (str != 0) {
-        printf("salt error, returned value should be 0\n");
+        printf("salt error only usascii are accepted, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "‰A");
     if (str != 0) {
-        printf("salt error, returned value should be 0\n");
+        printf("salt error only usascii are accepted, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "\0A");
     if (str != 0) {
-        printf("salt error, returned value should be 0\n");
+        printf("salt error cannot contain null terminator, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "A\0");
     if (str != 0) {
-        printf("salt error, returned value should be 0\n");
+        printf("salt error cannot contain null terminator, returned value should be 0\n");
         err = 1;
     }
     str = crypt("testing", "A");
     if (str != 0) {
-        printf("salt error, returned value should be 0\n");
+        printf("salt error size have to be at least 2, returned value should be 0\n");
         err = 1;
     }
 # ifdef OPENSSL_SYS_NETWARE

--- a/test/destest.c
+++ b/test/destest.c
@@ -718,6 +718,31 @@ int main(int argc, char *argv[])
         printf("fast crypt error, %s should be yA1Rp/1hZXIJk\n", str);
         err = 1;
     }
+    str = crypt("testing", "y€");
+    if (str != 0) {
+        printf("salt error, returned value should be 0\n");
+        err = 1;
+    }
+    str = crypt("testing", "‰A");
+    if (str != 0) {
+        printf("salt error, returned value should be 0\n");
+        err = 1;
+    }
+    str = crypt("testing", "\0A");
+    if (str != 0) {
+        printf("salt error, returned value should be 0\n");
+        err = 1;
+    }
+    str = crypt("testing", "A\0");
+    if (str != 0) {
+        printf("salt error, returned value should be 0\n");
+        err = 1;
+    }
+    str = crypt("testing", "A");
+    if (str != 0) {
+        printf("salt error, returned value should be 0\n");
+        err = 1;
+    }
 # ifdef OPENSSL_SYS_NETWARE
     if (err)
         printf("ERROR: %d\n", err);


### PR DESCRIPTION
If these functions has to be compilant with crypt(), then \0 is also not allowed as a salt when salt contains \0 returned is NULL.

Changes in the line 74, 75. So when, there was salt[0] == \0, then value of the e_salt[1] was undefined, end then it was send to the ebcdic2ascii. (Hashtag Pure Evilness)