### PR TITLE
remove unused macros in list -disabled

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -817,14 +817,8 @@ static void list_disabled(void)
 #ifdef OPENSSL_NO_SRTP
     BIO_puts(bio_out, "SRTP\n");
 #endif
-#ifdef OPENSSL_NO_SSL
-    BIO_puts(bio_out, "SSL\n");
-#endif
 #ifdef OPENSSL_NO_SSL3
     BIO_puts(bio_out, "SSL3\n");
-#endif
-#if defined(OPENSSL_NO_TLS)
-    BIO_puts(bio_out, "TLS\n");
 #endif
 #ifdef OPENSSL_NO_TLS1
     BIO_puts(bio_out, "TLS1\n");


### PR DESCRIPTION
list -disabled was checking for macros OPENSSL_NO_SSL/OPENSSL_NO_TLS, which are
not used in the code to disable SSL/TLS respectively.
Building with these macros, wrongly show (list -disabled) as SSL/TLS disabled independent of whether SSL/TLS is really disabled in the library or not. 
Hence removing this code.