### PR TITLE
RT4310(again): Elide EVP_read_pw_string() and friends for no-ui build

### DIFF
--- a/crypto/evp/evp_key.c
+++ b/crypto/evp/evp_key.c
@@ -62,6 +62,7 @@
 #include <openssl/evp.h>
 #include <openssl/ui.h>
 
+#ifndef OPENSSL_NO_UI
 /* should be init to zeros. */
 static char prompt_string[80];
 
@@ -116,6 +117,7 @@ int EVP_read_pw_string_min(char *buf, int min, int len, const char *prompt,
     OPENSSL_cleanse(buff, BUFSIZ);
     return ret;
 }
+#endif /* OPENSSL_NO_UI */
 
 int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
                    const unsigned char *salt, const unsigned char *data,

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -81,7 +81,7 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 int PEM_def_callback(char *buf, int num, int w, void *key)
 {
-#ifdef OPENSSL_NO_STDIO
+#if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
     /*
      * We should not ever call the default callback routine from windows.
      */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -556,11 +556,13 @@ int EVP_MD_CTX_test_flags(const EVP_MD_CTX *ctx, int flags);
 __owur int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md,
                            unsigned int *s);
 
+#ifndef OPENSSL_NO_UI
 int EVP_read_pw_string(char *buf, int length, const char *prompt, int verify);
 int EVP_read_pw_string_min(char *buf, int minlen, int maxlen,
                            const char *prompt, int verify);
 void EVP_set_pw_prompt(const char *prompt);
 char *EVP_get_pw_prompt(void);
+#endif
 
 __owur int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
                           const unsigned char *salt,


### PR DESCRIPTION
This was already reviewed by @richsalz as part of https://github.com/openssl/openssl/pull/729 but I'm separating it out into its own request as suggested there.

It has the distinction of being the *last* thing I need in OpenSSL HEAD before I can say that all the UEFI patches against 1.0.2 are backports from upstream — which is an important milestone. There's more to be done in HEAD (all in pull requests already), but it would be excellent to be able to reach this milestone for our 1.0.2 patches by merging this one.

Then I can get most of my cleanups and build system improvement (generating opensslconf.h and the file list from OpenSSL's Configure script automatically instead of manually maintaining them), into the upstream UEFI build tree.