### PR TITLE
Fix incomplete no-nextprotoneg build option

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1311,9 +1311,11 @@ int s_client_main(int argc, char **argv)
                 goto end;
             }
             break;
+#ifndef OPENSSL_NO_NEXTPROTONEG
         case OPT_NEXTPROTONEG:
             next_proto_neg_in = opt_arg();
             break;
+#endif
         case OPT_ALPN:
             alpn_in = opt_arg();
             break;

--- a/ssl/t1_ext.c
+++ b/ssl/t1_ext.c
@@ -272,7 +272,9 @@ int SSL_extension_supported(unsigned int ext_type)
     case TLSEXT_TYPE_ec_point_formats:
     case TLSEXT_TYPE_elliptic_curves:
     case TLSEXT_TYPE_heartbeat:
+#ifndef OPENSSL_NO_NEXTPROTONEG
     case TLSEXT_TYPE_next_proto_neg:
+#endif
     case TLSEXT_TYPE_padding:
     case TLSEXT_TYPE_renegotiate:
     case TLSEXT_TYPE_server_name:

--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -304,6 +304,7 @@ $cflags.=" -DOPENSSL_NO_HW"   if $no_hw;
 $cflags.=" -DOPENSSL_NO_ASYNC" if $no_async;
 $cflags.=" -DOPENSSL_NO_AUTOALGINIT" if $no_autoalginit;
 $cflags.=" -DOPENSSL_NO_AUTOERRINIT" if $no_autoerrinit;
+$cflags.=" -DOPENSSL_NO_NEXTPROTONEG" if $no_nextprotoneg;
 $cflags.=" -DOPENSSL_FIPS"    if $fips;
 $cflags.=" -DOPENSSL_NO_EC2M"    if $no_ec2m;
 $cflags.= " -DZLIB" if $zlib_opt;


### PR DESCRIPTION
When building -pre3 configured with no-nextprotoneg, I ran into issues with build errors.

1.` -DOPENSSL_NO_NEXTPROTONEG` is not added to the CFLAGS, fixed in `util/mk1mf.pl`
2. ssl/t1_ext.c build fails, added missing #ifndef OPENSSL_NO_NEXTPROTONEG guard
3. apps/s_client build fails, added missing #ifndef OPENSSL_NO_NEXTPROTONEG guard

With these patches, I can build without NPN on FreeBSD 10.2 amd64