### PR TITLE
s_server: -trace option falls through

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1332,9 +1332,8 @@ int s_server_main(int argc, char *argv[])
         case OPT_TRACE:
 #ifndef OPENSSL_NO_SSL_TRACE
             s_msg = 2;
-#else
-            break;
 #endif
+            break;
         case OPT_SECURITY_DEBUG:
             sdebug = 1;
             break;


### PR DESCRIPTION
in s_server cmd:
specifying -trace option, falls through and turn-on security_debug