### PR TITLE
Provide getters for default_passwd_cb and userdata

### DIFF
--- a/doc/ssl/SSL_CTX_set_default_passwd_cb.pod
+++ b/doc/ssl/SSL_CTX_set_default_passwd_cb.pod
@@ -3,8 +3,10 @@
 =head1 NAME
 
 SSL_CTX_set_default_passwd_cb, SSL_CTX_set_default_passwd_cb_userdata,
-SSL_set_default_passwd_cb, SSL_set_default_passwd_cb_userdata - set passwd
-callback for encrypted PEM file handling
+SSL_CTX_get_default_passwd_cb, SSL_CTX_get_default_passwd_cb_userdata,
+SSL_set_default_passwd_cb, SSL_set_default_passwd_cb_userdata,
+SSL_get_default_passwd_cb, SSL_get_default_passwd_cb_userdata - set or
+get passwd callback for encrypted PEM file handling
 
 =head1 SYNOPSIS
 
@@ -12,8 +14,13 @@ callback for encrypted PEM file handling
 
  void SSL_CTX_set_default_passwd_cb(SSL_CTX *ctx, pem_password_cb *cb);
  void SSL_CTX_set_default_passwd_cb_userdata(SSL_CTX *ctx, void *u);
+ pem_password_cb *SSL_CTX_get_default_passwd_cb(SSL_CTX *ctx);
+ void *SSL_CTX_get_default_passwd_cb_userdata(SSL_CTX *ctx);
+
  void SSL_set_default_passwd_cb(SSL *s, pem_password_cb *cb);
  void SSL_set_default_passwd_cb_userdata(SSL *s, void *u);
+ pem_password_cb *SSL_get_default_passwd_cb(SSL *s);
+ void *SSL_get_default_passwd_cb_userdata(SSL *s);
 
  int pem_passwd_cb(char *buf, int size, int rwflag, void *userdata);
 
@@ -25,8 +32,17 @@ when loading/storing a PEM certificate with encryption.
 SSL_CTX_set_default_passwd_cb_userdata() sets a pointer to B<userdata> which
 will be provided to the password callback on invocation.
 
-SSL_set_default_passwd_cb() and SSL_set_default_passwd_cb_userdata() perform the
-same function as their SSL_CTX counterparts, but using an SSL object.
+SSL_CTX_get_default_passwd_cb() returns a function pointer to the password
+callback currently set in B<ctx>. If no callback was explicitly set, the
+NULL pointer is returned.
+
+SSL_CTX_get_default_passwd_cb_userdata() returns a pointer to B<userdata>
+currently set in B<ctx>. If no userdata was explicitly set, the NULL pointer
+is returned.
+
+SSL_set_default_passwd_cb(), SSL_set_default_passwd_cb_userdata(),
+SSL_get_default_passwd_cb() and SSL_get_default_passwd_cb_userdata() perform
+the same function as their SSL_CTX counterparts, but using an SSL object.
 
 The pem_passwd_cb(), which must be provided by the application, hands back the
 password to be used during decryption. On invocation a pointer to B<userdata>
@@ -73,6 +89,12 @@ truncated.
   buf[size - 1] = '\0';
   return(strlen(buf));
  }
+
+=head1 HISTORY
+
+SSL_CTX_get_default_passwd_cb(), SSL_CTX_get_default_passwd_cb_userdata(),
+SSL_set_default_passwd_cb() and SSL_set_default_passwd_cb_userdata() were
+first added to OpenSSL 1.1.0
 
 =head1 SEE ALSO
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1527,8 +1527,12 @@ __owur int SSL_CTX_use_certificate_ASN1(SSL_CTX *ctx, int len,
 
 void SSL_CTX_set_default_passwd_cb(SSL_CTX *ctx, pem_password_cb *cb);
 void SSL_CTX_set_default_passwd_cb_userdata(SSL_CTX *ctx, void *u);
+pem_password_cb *SSL_CTX_get_default_passwd_cb(SSL_CTX *ctx);
+void *SSL_CTX_get_default_passwd_cb_userdata(SSL_CTX *ctx);
 void SSL_set_default_passwd_cb(SSL *s, pem_password_cb *cb);
 void SSL_set_default_passwd_cb_userdata(SSL *s, void *u);
+pem_password_cb *SSL_get_default_passwd_cb(SSL *s);
+void *SSL_get_default_passwd_cb_userdata(SSL *s);
 
 __owur int SSL_CTX_check_private_key(const SSL_CTX *ctx);
 __owur int SSL_check_private_key(const SSL *ctx);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2474,6 +2474,16 @@ void SSL_CTX_set_default_passwd_cb_userdata(SSL_CTX *ctx, void *u)
     ctx->default_passwd_callback_userdata = u;
 }
 
+pem_password_cb *SSL_CTX_get_default_passwd_cb(SSL_CTX *ctx)
+{
+    return ctx->default_passwd_callback;
+}
+
+void *SSL_CTX_get_default_passwd_cb_userdata(SSL_CTX *ctx)
+{
+    return ctx->default_passwd_callback_userdata;
+}
+
 void SSL_set_default_passwd_cb(SSL *s, pem_password_cb *cb)
 {
     s->default_passwd_callback = cb;
@@ -2482,6 +2492,16 @@ void SSL_set_default_passwd_cb(SSL *s, pem_password_cb *cb)
 void SSL_set_default_passwd_cb_userdata(SSL *s, void *u)
 {
     s->default_passwd_callback_userdata = u;
+}
+
+pem_password_cb *SSL_get_default_passwd_cb(SSL *s)
+{
+    return s->default_passwd_callback;
+}
+
+void *SSL_get_default_passwd_cb_userdata(SSL *s)
+{
+    return s->default_passwd_callback_userdata;
 }
 
 void SSL_CTX_set_cert_verify_callback(SSL_CTX *ctx,

--- a/util/ssleay.num
+++ b/util/ssleay.num
@@ -418,3 +418,7 @@ DTLSv1_listen                           473	1_1_0	EXIST::FUNCTION:
 SSL_get0_verified_chain                 474	1_1_0	EXIST::FUNCTION:
 OPENSSL_init_ssl                        475	1_1_0	EXIST::FUNCTION:
 SSL_get_changed_async_fds               476	1_1_0	EXIST::FUNCTION:
+SSL_get_default_passwd_cb_userdata      477	1_1_0	EXIST::FUNCTION:
+SSL_get_default_passwd_cb               478	1_1_0	EXIST::FUNCTION:
+SSL_CTX_get_default_passwd_cb_userdata  479	1_1_0	EXIST::FUNCTION:
+SSL_CTX_get_default_passwd_cb           480	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This patch provides getters for default_passwd_cb and userdata for SSL
and SSL_CTX. The getter functions are required to port Python's ssl module
to OpenSSL 1.2.