### PR TITLE
Better variable name

### DIFF
--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -205,14 +205,14 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
             for (i = 0; i < sk_X509_EXTENSION_num(exts); i++) {
                 ASN1_OBJECT *obj;
                 X509_EXTENSION *ex;
-                int j;
+                int critical;
                 ex = sk_X509_EXTENSION_value(exts, i);
                 if (BIO_printf(bp, "%12s", "") <= 0)
                     goto err;
                 obj = X509_EXTENSION_get_object(ex);
                 i2a_ASN1_OBJECT(bp, obj);
-                j = X509_EXTENSION_get_critical(ex);
-                if (BIO_printf(bp, ": %s\n", j ? "critical" : "") <= 0)
+                critical = X509_EXTENSION_get_critical(ex);
+                if (BIO_printf(bp, ": %s\n", critical ? "critical" : "") <= 0)
                     goto err;
                 if (!X509V3_EXT_print(bp, ex, cflag, 16)) {
                     BIO_printf(bp, "%16s", "");


### PR DESCRIPTION
The variable name in the original code is unnecessarily useless.