### PR TITLE
Fix ALPN

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
  Changes between 1.0.2g and 1.1.0  [xx XXX xxxx]
 
+  *) Modify behavior of ALPN to invoke callback after SNI/servername
+     callback, such that updates to the SSL_CTX affect ALPN.
+     [Todd Short]
+
   *) Changes to the DEFAULT cipherlist:
        - Prefer (EC)DHE handshakes over plain RSA.
        - Prefer AEAD ciphers over legacy ciphers.

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1960,7 +1960,7 @@ void policies_print(X509_STORE_CTX *ctx)
  *
  *   returns: a malloced buffer or NULL on failure.
  */
-unsigned char *next_protos_parse(unsigned short *outlen, const char *in)
+unsigned char *next_protos_parse(size_t *outlen, const char *in)
 {
     size_t len;
     unsigned char *out;

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -565,7 +565,7 @@ int do_X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md,
 extern char *psk_key;
 # endif
 
-unsigned char *next_protos_parse(unsigned short *outlen, const char *in);
+unsigned char *next_protos_parse(size_t *outlen, const char *in);
 
 void print_cert_checks(BIO *bio, X509 *x,
                        const char *checkhost,

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -443,7 +443,7 @@ static char *srtp_profiles = NULL;
 /* This the context that we pass to next_proto_cb */
 typedef struct tlsextnextprotoctx_st {
     unsigned char *data;
-    unsigned short len;
+    size_t len;
     int status;
 } tlsextnextprotoctx;
 
@@ -1589,7 +1589,7 @@ int s_client_main(int argc, char **argv)
         SSL_CTX_set_next_proto_select_cb(ctx, next_proto_cb, &next_proto);
 #endif
     if (alpn_in) {
-        unsigned short alpn_len;
+        size_t alpn_len;
         unsigned char *alpn = next_protos_parse(&alpn_len, alpn_in);
 
         if (alpn == NULL) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -739,7 +739,7 @@ static int next_proto_cb(SSL *s, const unsigned char **data,
 /* This the context that we pass to alpn_cb */
 typedef struct tlsextalpnctx_st {
     unsigned char *data;
-    unsigned short len;
+    size_t len;
 } tlsextalpnctx;
 
 static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
@@ -749,7 +749,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
 
     if (!s_quiet) {
         /* We can assume that |in| is syntactically valid. */
-        unsigned i;
+        unsigned int i;
         BIO_printf(bio_s_out, "ALPN protocols advertised by the client: ");
         for (i = 0; i < inlen;) {
             if (i)
@@ -1582,7 +1582,7 @@ int s_server_main(int argc, char *argv[])
     }
 #if !defined(OPENSSL_NO_NEXTPROTONEG)
     if (next_proto_neg_in) {
-        unsigned short len;
+        size_t len;
         next_proto.data = next_protos_parse(&len, next_proto_neg_in);
         if (next_proto.data == NULL)
             goto end;
@@ -1593,7 +1593,7 @@ int s_server_main(int argc, char *argv[])
 #endif
     alpn_ctx.data = NULL;
     if (alpn_in) {
-        unsigned short len;
+        size_t len;
         alpn_ctx.data = next_protos_parse(&len, alpn_in);
         if (alpn_ctx.data == NULL)
             goto end;

--- a/doc/ssl/SSL_CTX_set_alpn_select_cb.pod
+++ b/doc/ssl/SSL_CTX_set_alpn_select_cb.pod
@@ -1,0 +1,126 @@
+=pod
+
+=head1 NAME
+
+SSL_CTX_set_alpn_select_cb, SSL_CTX_set_alpn_protos, SSL_set_alpn_protos,
+SSL_get0_alpn_selected, SSL_select_next_proto - handle application layer
+protocol negotiation (ALPN)
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
+                             unsigned int protos_len);
+ int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
+                         unsigned int protos_len);
+ void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
+                                 int (*cb) (SSL *ssl,
+                                            const unsigned char **out,
+                                            unsigned char *outlen,
+                                            const unsigned char *in,
+                                            unsigned int inlen,
+                                            void *arg), void *arg);
+ int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
+                           const unsigned char *server,
+                           unsigned int server_len,
+                           const unsigned char *client,
+                           unsigned int client_len)
+ void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
+                             unsigned int *len);
+
+=head1 DESCRIPTION
+
+SSL_CTX_set_alpn_protos() and SSL_set_alpn_protos() are used by the client to
+set the list of protocols available to be negotiated. The B<protos> must be in
+protocol-list format, described below. The length of B<protos> is specified in
+B<protos_len>.
+
+SSL_CTX_set_alpn_select_cb() sets the application callback B<cb> used by a
+server to select which protocol to use for the incoming connection. When B<cb>
+is NULL, no ALPN is not used. The B<arg> value is pointer which is passed to
+the application callback.
+
+B<cb> is the application defined callback. The B<in>, B<inlen> parameters are a
+vector in protocol-list format. The value of the B<out>, B<outlen> vector
+should be set to the value of a single protocol contained with in the B<in>,
+B<inlen> vector. The B<arg> parameter is the pointer set via
+SSL_CTX_set_alpn_select_cb().
+
+SSL_select_next_proto() is a helper function used to select protocols. It
+implements the standard protocol selection. It is expected that this function
+is called from the application callback B<cb>. The protocol data in B<server>,
+B<server_len> and B<client>, B<client_len> must be in protocol-list format
+described below. The first item in the B<server>, B<server_len> list that
+matches an item in the B<client>, B<client_len> list is selected, and returned
+in B<out>, B<outlen>. The B<out> value will point into either B<server> or
+B<client>, so it should be copied immediately. If no match is found, the first
+item in B<client>, B<client_len> is returned in B<out>, B<outlen>. This
+function can also be used in the NPN callback.
+
+SSL_get0_alpn_selected() returns a pointer to the selected protocol in B<data>
+with length B<len>. It is not NUL-terminated. B<data> is set to NULL and B<len>
+is set to 0 if no protocol has been selected. B<data> value must not be freed.
+
+=head1 NOTES
+
+The protocol-lists must be in wire-format, which is defined as a vector of
+non-empty, 8-bit length-prefixed, byte strings. The length-prefix byte is not
+included in the length. Each string is limited to 255 bytes. A byte-string
+length of 0 is invalid. A truncated byte-string is invalid. The length of the
+vector is not in the vector itself, but in a separate variable.
+
+Example:
+
+ unsigned char vector[] = {
+     6, 's', 'p', 'd', 'y', '/', '1',
+     8, 'h', 't', 't', 'p', '/', '1', '.', '1'
+ };
+ unsigned int length = sizeof(vector);
+
+The ALPN callback is executed after the servername callback; as that servername
+callback may update the SSL_CTX, and subsequently, the ALPN callback.
+
+If there is no ALPN proposed in the ClientHello, the ALPN callback is not
+invoked.
+
+=head1 RETURN VALUES
+
+SSL_CTX_set_alpn_protos() and SSL_set_alpn_protos() return 0 on success, and
+non-0 on failure. WARNING: these functions reverse the return value convention.
+
+SSL_select_next_proto() returns one of the following:
+
+=over 4
+
+=item OPENSSL_NPN_NEGOTIATED
+
+A match was found and is returned in B<out>, B<outlen>.
+
+=item OPENSSL_NPN_NO_OVERLAP
+
+No match was found. The first item in B<client>, B<client_len> is returned in
+B<out>, B<outlen>.
+
+=back
+
+The ALPN select callback B<cb>, must return one of the following:
+
+=over 4
+
+=item SSL_TLSEXT_ERR_OK
+
+ALPN protocol selected.
+
+=item SSL_TLSEXT_ERR_NOACK
+
+ALPN protocol not selected.
+
+=back
+
+=head1 SEE ALSO
+
+L<ssl(3)>, L<SSL_CTX_set_tlsext_servername_callback(3)>,
+L<SSL_CTX_set_tlsext_servername_arg(3)>
+
+=cut

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -779,9 +779,9 @@ __owur int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
 # define OPENSSL_NPN_NO_OVERLAP  2
 
 __owur int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
-                            unsigned protos_len);
+                                   unsigned int protos_len);
 __owur int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
-                        unsigned protos_len);
+                               unsigned int protos_len);
 void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
                                 int (*cb) (SSL *ssl,
                                            const unsigned char **out,
@@ -790,7 +790,7 @@ void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
                                            unsigned int inlen,
                                            void *arg), void *arg);
 void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
-                            unsigned *len);
+                            unsigned int *len);
 
 # ifndef OPENSSL_NO_PSK
 /*

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3047,6 +3047,7 @@ void ssl3_free(SSL *s)
     OPENSSL_free(s->s3->tmp.peer_sigalgs);
     ssl3_free_digest_list(s);
     OPENSSL_free(s->s3->alpn_selected);
+    OPENSSL_free(s->s3->alpn_proposed);
 
 #ifndef OPENSSL_NO_SRP
     SSL_SRP_CTX_free(s);
@@ -3060,37 +3061,24 @@ void ssl3_clear(SSL *s)
     ssl3_cleanup_key_block(s);
     sk_X509_NAME_pop_free(s->s3->tmp.ca_names, X509_NAME_free);
     OPENSSL_free(s->s3->tmp.ciphers_raw);
-    s->s3->tmp.ciphers_raw = NULL;
     OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
-    s->s3->tmp.pms = NULL;
     OPENSSL_free(s->s3->tmp.peer_sigalgs);
-    s->s3->tmp.peer_sigalgs = NULL;
 
-#ifndef OPENSSL_NO_EC
-    s->s3->is_probably_safari = 0;
-#endif
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
     EVP_PKEY_free(s->s3->tmp.pkey);
-    s->s3->tmp.pkey = NULL;
     EVP_PKEY_free(s->s3->peer_tmp);
-    s->s3->peer_tmp = NULL;
 #endif                         /* !OPENSSL_NO_EC */
 
     ssl3_free_digest_list(s);
 
-    if (s->s3->alpn_selected) {
-        OPENSSL_free(s->s3->alpn_selected);
-        s->s3->alpn_selected = NULL;
-    }
+    OPENSSL_free(s->s3->alpn_selected);
+    OPENSSL_free(s->s3->alpn_proposed);
 
+    /* NULL/zero-out everything in the s3 struct */
     memset(s->s3, 0, sizeof(*s->s3));
 
     ssl_free_wbio_buffer(s);
 
-    s->s3->renegotiate = 0;
-    s->s3->total_renegotiations = 0;
-    s->s3->num_renegotiations = 0;
-    s->s3->in_read_app_data = 0;
     s->version = SSL3_VERSION;
 
 #if !defined(OPENSSL_NO_NEXTPROTONEG)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2172,15 +2172,14 @@ void SSL_CTX_set_next_proto_select_cb(SSL_CTX *ctx,
  * length-prefixed strings). Returns 0 on success.
  */
 int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
-                            unsigned protos_len)
+                            unsigned int protos_len)
 {
     OPENSSL_free(ctx->alpn_client_proto_list);
-    ctx->alpn_client_proto_list = OPENSSL_malloc(protos_len);
+    ctx->alpn_client_proto_list = OPENSSL_memdup(protos, protos_len);
     if (ctx->alpn_client_proto_list == NULL) {
         SSLerr(SSL_F_SSL_CTX_SET_ALPN_PROTOS, ERR_R_MALLOC_FAILURE);
         return 1;
     }
-    memcpy(ctx->alpn_client_proto_list, protos, protos_len);
     ctx->alpn_client_proto_list_len = protos_len;
 
     return 0;
@@ -2192,15 +2191,14 @@ int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
  * length-prefixed strings). Returns 0 on success.
  */
 int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
-                        unsigned protos_len)
+                        unsigned int protos_len)
 {
     OPENSSL_free(ssl->alpn_client_proto_list);
-    ssl->alpn_client_proto_list = OPENSSL_malloc(protos_len);
+    ssl->alpn_client_proto_list = OPENSSL_memdup(protos, protos_len);
     if (ssl->alpn_client_proto_list == NULL) {
         SSLerr(SSL_F_SSL_SET_ALPN_PROTOS, ERR_R_MALLOC_FAILURE);
         return 1;
     }
-    memcpy(ssl->alpn_client_proto_list, protos, protos_len);
     ssl->alpn_client_proto_list_len = protos_len;
 
     return 0;
@@ -2230,7 +2228,7 @@ void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
  * respond with a negotiated protocol then |*len| will be zero.
  */
 void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
-                            unsigned *len)
+                            unsigned int *len)
 {
     *data = NULL;
     if (ssl->s3)

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1348,7 +1348,12 @@ typedef struct ssl3_state_st {
      * that the server selected once the ServerHello has been processed.
      */
     unsigned char *alpn_selected;
-    unsigned alpn_selected_len;
+    size_t alpn_selected_len;
+    /* used by the server to know what options were proposed */
+    unsigned char *alpn_proposed;
+    size_t alpn_proposed_len;
+    /* used by the client to know if it actually sent alpn */
+    int alpn_sent;
 
 #   ifndef OPENSSL_NO_EC
     /*

--- a/test/recipes/80-test_ssl.t
+++ b/test/recipes/80-test_ssl.t
@@ -64,7 +64,7 @@ my $P2intermediate="tmp_intP2.ss";
 plan tests =>
     1				# For testss
     + 1				# For ssltest -test_cipherlist
-    + 11			# For the first testssl
+    + 13			# For the first testssl
     + 16			# For the first testsslproxy
     + 16			# For the second testsslproxy
     ;
@@ -603,10 +603,29 @@ sub testssl {
 	}
     };
 
+    subtest 'SNI tests' => sub {
+
+	plan tests => 7;
+
+      SKIP: {
+	  skip "TLSv1.x is not supported by this OpenSSL build", 7
+	      if $no_tls1 && $no_tls1_1 && $no_tls1_2;
+
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo"])));
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_server1", "foo"])));
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo", "-sn_server1", "foo", "-sn_expect1"])));
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo", "-sn_server1", "bar", "-sn_expect1"])));
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo", "-sn_server1", "foo", "-sn_server2", "bar", "-sn_expect1"])));
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "bar", "-sn_server1", "foo", "-sn_server2", "bar", "-sn_expect2"])));
+	  # Negative test - make sure it doesn't crash, and doesn't switch contexts
+	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foobar", "-sn_server1", "foo", "-sn_server2", "bar", "-sn_expect1"])));
+	}
+    };
+
     subtest 'ALPN tests' => sub {
 	######################################################################
 
-	plan tests => 14;
+	plan tests => 12;
 
       SKIP: {
 	  skip "TLSv1.0 is not supported by this OpenSSL build", 12
@@ -626,22 +645,39 @@ sub testssl {
 	  is(run(test([@ssltest, "-bio_pair", "-tls1", "-alpn_client", "baz", "-alpn_server", "bar,foo"])), 0,
              "Testing ALPN with protocol mismatch, expecting failure");
 
-	SKIP: {
-	    skip "skipping SRP tests", 4
-		if $no_srp;
+	  # ALPN + SNI
+	  ok(run(test([@ssltest, "-bio_pair",
+		       "-alpn_client", "foo,bar", "-sn_client", "alice",
+		       "-alpn_server1", "foo,123", "-sn_server1", "alice",
+		       "-alpn_server2", "bar,456", "-sn_server2", "bob",
+		       "-alpn_expected", "foo"])));
+	  ok(run(test([@ssltest, "-bio_pair",
+		       "-alpn_client", "foo,bar", "-sn_client", "bob",
+		       "-alpn_server1", "foo,123", "-sn_server1", "alice",
+		       "-alpn_server2", "bar,456", "-sn_server2", "bob",
+		       "-alpn_expected", "bar"])));
+	}
+    };
 
-	    ok(run(test([@ssltest, "-tls1", "-cipher", "SRP", "-srpuser", "test", "-srppass", "abc123"])),
-	       'test tls1 with SRP');
+    subtest 'SRP tests' => sub {
 
-	    ok(run(test([@ssltest, "-bio_pair", "-tls1", "-cipher", "SRP", "-srpuser", "test", "-srppass", "abc123"])),
-	       'test tls1 with SRP via BIO pair');
+	plan tests => 4;
 
-	    ok(run(test([@ssltest, "-tls1", "-cipher", "aSRP", "-srpuser", "test", "-srppass", "abc123"])),
-		 'test tls1 with SRP auth');
+      SKIP: {
+	  skip "skipping SRP tests", 4
+	      if $no_srp;
 
-	    ok(run(test([@ssltest, "-bio_pair", "-tls1", "-cipher", "aSRP", "-srpuser", "test", "-srppass", "abc123"])),
-	       'test tls1 with SRP auth via BIO pair');
-	  }
+	  ok(run(test([@ssltest, "-tls1", "-cipher", "SRP", "-srpuser", "test", "-srppass", "abc123"])),
+	     'test tls1 with SRP');
+
+	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-cipher", "SRP", "-srpuser", "test", "-srppass", "abc123"])),
+	     'test tls1 with SRP via BIO pair');
+
+	  ok(run(test([@ssltest, "-tls1", "-cipher", "aSRP", "-srpuser", "test", "-srppass", "abc123"])),
+	     'test tls1 with SRP auth');
+
+	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-cipher", "aSRP", "-srpuser", "test", "-srppass", "abc123"])),
+	     'test tls1 with SRP auth via BIO pair');
 	}
     };
 

--- a/test/ssltest.c
+++ b/test/ssltest.c
@@ -207,6 +207,9 @@
 # include OPENSSL_UNISTD
 #endif
 
+SSL_CTX *s_ctx = NULL;
+SSL_CTX *s_ctx2 = NULL;
+
 /*
  * There is really no standard for this, so let's assign something
  * only for this test
@@ -366,7 +369,8 @@ static int verify_npn(SSL *client, SSL *server)
 #endif
 
 static const char *alpn_client;
-static const char *alpn_server;
+static char *alpn_server;
+static char *alpn_server2;
 static const char *alpn_expected;
 static unsigned char *alpn_selected;
 static const char *server_min_proto;
@@ -374,6 +378,48 @@ static const char *server_max_proto;
 static const char *client_min_proto;
 static const char *client_max_proto;
 static const char *should_negotiate;
+static const char *sn_client;
+static const char *sn_server1;
+static const char *sn_server2;
+static int sn_expect = 0;
+
+static int servername_cb(SSL *s, int *ad, void *arg)
+{
+    const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+    if (sn_server2 == NULL) {
+        BIO_printf(bio_stdout, "Servername 2 is NULL\n");
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    if (servername) {
+        if (s_ctx2 != NULL && sn_server2 != NULL &&
+            !strcasecmp(servername, sn_server2)) {
+            BIO_printf(bio_stdout, "Switching server context.\n");
+            SSL_set_SSL_CTX(s, s_ctx2);
+        }
+    }
+    return SSL_TLSEXT_ERR_OK;
+}
+static int verify_servername(SSL *client, SSL *server)
+{
+    /* just need to see if sn_context is what we expect */
+    SSL_CTX* ctx = SSL_get_SSL_CTX(server);
+    if (sn_expect == 0)
+        return 0;
+    if (sn_expect == 1 && ctx == s_ctx)
+        return 0;
+    if (sn_expect == 2 && ctx == s_ctx2)
+        return 0;
+    BIO_printf(bio_stdout, "Servername: expected context %d\n", sn_expect);
+    if (ctx == s_ctx2)
+        BIO_printf(bio_stdout, "Servername: context is 2\n");
+    else if (ctx == s_ctx)
+        BIO_printf(bio_stdout, "Servername: context is 1\n");
+    else
+        BIO_printf(bio_stdout, "Servername: context is unknown\n");
+    return -1;
+}
+
 
 /*-
  * next_protos_parse parses a comma separated list of strings into a string
@@ -384,7 +430,7 @@ static const char *should_negotiate;
  *
  *   returns: a malloced buffer or NULL on failure.
  */
-static unsigned char *next_protos_parse(unsigned short *outlen,
+static unsigned char *next_protos_parse(size_t *outlen,
                                         const char *in)
 {
     size_t len;
@@ -420,12 +466,13 @@ static int cb_server_alpn(SSL *s, const unsigned char **out,
                           unsigned int inlen, void *arg)
 {
     unsigned char *protos;
-    unsigned short protos_len;
+    size_t protos_len;
+    char* alpn_str = arg;
 
-    protos = next_protos_parse(&protos_len, alpn_server);
+    protos = next_protos_parse(&protos_len, alpn_str);
     if (protos == NULL) {
         fprintf(stderr, "failed to parser ALPN server protocol string: %s\n",
-                alpn_server);
+                alpn_str);
         abort();
     }
 
@@ -491,8 +538,15 @@ static int verify_alpn(SSL *client, SSL *server)
     BIO_printf(bio_stdout, "', server: '");
     BIO_write(bio_stdout, server_proto, server_proto_len);
     BIO_printf(bio_stdout, "'\n");
-    BIO_printf(bio_stdout, "ALPN configured: client: '%s', server: '%s'\n",
-               alpn_client, alpn_server);
+    BIO_printf(bio_stdout, "ALPN configured: client: '%s', server: '",
+                   alpn_client);
+    if (SSL_get_SSL_CTX(server) == s_ctx2) {
+        BIO_printf(bio_stdout, "%s'\n",
+                   alpn_server2);
+    } else {
+        BIO_printf(bio_stdout, "%s'\n",
+                   alpn_server);
+    }
     return -1;
 }
 
@@ -769,7 +823,7 @@ static void sv_usage(void)
     fprintf(stderr, " -no_dhe       - disable DHE\n");
 #endif
 #ifndef OPENSSL_NO_EC
-    fprintf(stderr, " -no_ecdhe     - disable ECDHE\n");
+    fprintf(stderr, " -no_ecdhe     - disable ECDHE\nTODO(openssl-team): no_ecdhe was broken by auto ecdh. Make this work again.\n");
 #endif
 #ifndef OPENSSL_NO_PSK
     fprintf(stderr, " -psk arg      - PSK in hex (without 0x)\n");
@@ -809,12 +863,6 @@ static void sv_usage(void)
     fprintf(stderr,
             " -time         - measure processor time used by client and server\n");
     fprintf(stderr, " -zlib         - use zlib compression\n");
-#ifndef OPENSSL_NO_EC
-    fprintf(stderr,
-            " -named_curve arg  - Elliptic curve name to use for ephemeral ECDH keys.\n"
-            "                 Use \"openssl ecparam -list_curves\" for all names\n"
-            "                 (default is sect163r2).\n");
-#endif
     fprintf(stderr,
             " -test_cipherlist - Verifies the order of the ssl cipher lists.\n"
             "                    When this option is requested, the cipherlist\n"
@@ -832,6 +880,8 @@ static void sv_usage(void)
             " -custom_ext - try various custom extension callbacks\n");
     fprintf(stderr, " -alpn_client <string> - have client side offer ALPN\n");
     fprintf(stderr, " -alpn_server <string> - have server side offer ALPN\n");
+    fprintf(stderr, " -alpn_server1 <string> - alias for -alpn_server\n");
+    fprintf(stderr, " -alpn_server2 <string> - have server side context 2 offer ALPN\n");
     fprintf(stderr,
             " -alpn_expected <string> - the ALPN protocol that should be negotiated\n");
     fprintf(stderr, " -server_min_proto <string> - Minimum version the server should support\n");
@@ -844,6 +894,11 @@ static void sv_usage(void)
     fprintf(stderr, " -requestct    - request certificate transparency\n");
     fprintf(stderr, " -requirect    - require certificate transparency\n");
 #endif
+    fprintf(stderr, " -sn_client <string>  - have client request this servername\n");
+    fprintf(stderr, " -sn_server1 <string> - have server context 1 respond to this servername\n");
+    fprintf(stderr, " -sn_server2 <string> - have server context 2 respond to this servername\n");
+    fprintf(stderr, " -sn_expect1          - expected server 1\n");
+    fprintf(stderr, " -sn_expect2          - expected server 2\n");
 }
 
 static void print_key_details(BIO *out, EVP_PKEY *key)
@@ -1025,10 +1080,6 @@ int main(int argc, char *argv[])
     struct app_verify_arg app_verify_arg =
         { APP_CALLBACK_STRING, 0, 0, NULL, NULL };
     char *p;
-#ifndef OPENSSL_NO_EC
-    char *named_curve = NULL;
-#endif
-    SSL_CTX *s_ctx = NULL;
     SSL_CTX *c_ctx = NULL;
     const SSL_METHOD *meth = NULL;
     SSL *c_ssl, *s_ssl;
@@ -1038,9 +1089,6 @@ int main(int argc, char *argv[])
     DH *dh;
     int dhe512 = 0, dhe1024dsa = 0;
 #endif
-#ifndef OPENSSL_NO_EC
-    EC_KEY *ecdh = NULL;
-#endif
 #ifndef OPENSSL_NO_SRP
     /* client */
     SRP_CLIENT_ARG srp_client_arg = { NULL, NULL };
@@ -1048,7 +1096,6 @@ int main(int argc, char *argv[])
     SRP_SERVER_ARG srp_server_arg = { NULL, NULL };
 #endif
     int no_dhe = 0;
-    int no_ecdhe = 0;
     int no_psk = 0;
     int print_time = 0;
     clock_t s_time = 0, c_time = 0;
@@ -1071,7 +1118,7 @@ int main(int argc, char *argv[])
     ct_validation_cb ct_validation = NULL;
 #endif
 
-    SSL_CONF_CTX *s_cctx = NULL, *c_cctx = NULL;
+    SSL_CONF_CTX *s_cctx = NULL, *c_cctx = NULL, *s_cctx2 = NULL;
     STACK_OF(OPENSSL_STRING) *conf_args = NULL;
     char *arg = NULL, *argn = NULL;
 
@@ -1093,9 +1140,10 @@ int main(int argc, char *argv[])
     bio_stdout = BIO_new_fp(stdout, BIO_NOCLOSE | BIO_FP_TEXT);
 
     s_cctx = SSL_CONF_CTX_new();
+    s_cctx2 = SSL_CONF_CTX_new();
     c_cctx = SSL_CONF_CTX_new();
 
-    if (!s_cctx || !c_cctx) {
+    if (!s_cctx || !c_cctx || !s_cctx2) {
         ERR_print_errors(bio_err);
         goto end;
     }
@@ -1104,7 +1152,15 @@ int main(int argc, char *argv[])
                            SSL_CONF_FLAG_CMDLINE | SSL_CONF_FLAG_SERVER |
                            SSL_CONF_FLAG_CERTIFICATE |
                            SSL_CONF_FLAG_REQUIRE_PRIVATE);
+    SSL_CONF_CTX_set_flags(s_cctx2,
+                           SSL_CONF_FLAG_CMDLINE | SSL_CONF_FLAG_SERVER |
+                           SSL_CONF_FLAG_CERTIFICATE |
+                           SSL_CONF_FLAG_REQUIRE_PRIVATE);
     if (!SSL_CONF_CTX_set1_prefix(s_cctx, "-s_")) {
+        ERR_print_errors(bio_err);
+        goto end;
+    }
+    if (!SSL_CONF_CTX_set1_prefix(s_cctx2, "-s_")) {
         ERR_print_errors(bio_err);
         goto end;
     }
@@ -1165,7 +1221,7 @@ int main(int argc, char *argv[])
         } else if (strcmp(*argv, "-no_dhe") == 0)
             no_dhe = 1;
         else if (strcmp(*argv, "-no_ecdhe") == 0)
-            no_ecdhe = 1;
+            /* obsolete */;
         else if (strcmp(*argv, "-psk") == 0) {
             if (--argc < 1)
                 goto bad;
@@ -1259,17 +1315,7 @@ int main(int argc, char *argv[])
             comp = COMP_ZLIB;
         }
 #endif
-        else if (strcmp(*argv, "-named_curve") == 0) {
-            if (--argc < 1)
-                goto bad;
-#ifndef OPENSSL_NO_EC
-            named_curve = *(++argv);
-#else
-            fprintf(stderr,
-                    "ignoring -named_curve, since I'm compiled without ECDH\n");
-            ++argv;
-#endif
-        } else if (strcmp(*argv, "-app_verify") == 0) {
+        else if (strcmp(*argv, "-app_verify") == 0) {
             app_verify_arg.app_verify = 1;
         } else if (strcmp(*argv, "-proxy") == 0) {
             app_verify_arg.allow_proxy_certs = 1;
@@ -1299,10 +1345,15 @@ int main(int argc, char *argv[])
             if (--argc < 1)
                 goto bad;
             alpn_client = *(++argv);
-        } else if (strcmp(*argv, "-alpn_server") == 0) {
+        } else if (strcmp(*argv, "-alpn_server") == 0 ||
+                   strcmp(*argv, "-alpn_server1") == 0) {
             if (--argc < 1)
                 goto bad;
             alpn_server = *(++argv);
+        } else if (strcmp(*argv, "-alpn_server2") == 0) {
+            if (--argc < 1)
+                goto bad;
+            alpn_server2 = *(++argv);
         } else if (strcmp(*argv, "-alpn_expected") == 0) {
             if (--argc < 1)
                 goto bad;
@@ -1327,6 +1378,22 @@ int main(int argc, char *argv[])
             if (--argc < 1)
                 goto bad;
             should_negotiate = *(++argv);
+        } else if (strcmp(*argv, "-sn_client") == 0) {
+            if (--argc < 1)
+                goto bad;
+            sn_client = *(++argv);
+        } else if (strcmp(*argv, "-sn_server1") == 0) {
+            if (--argc < 1)
+                goto bad;
+            sn_server1 = *(++argv);
+        } else if (strcmp(*argv, "-sn_server2") == 0) {
+            if (--argc < 1)
+                goto bad;
+            sn_server2 = *(++argv);
+        } else if (strcmp(*argv, "-sn_expect1") == 0) {
+            sn_expect = 1;
+        } else if (strcmp(*argv, "-sn_expect2") == 0) {
+            sn_expect = 2;
         } else {
             int rv;
             arg = argv[0];
@@ -1517,7 +1584,8 @@ int main(int argc, char *argv[])
 
     c_ctx = SSL_CTX_new(meth);
     s_ctx = SSL_CTX_new(meth);
-    if ((c_ctx == NULL) || (s_ctx == NULL)) {
+    s_ctx2 = SSL_CTX_new(meth); /* no SSL_CTX_dup! */
+    if ((c_ctx == NULL) || (s_ctx == NULL) || (s_ctx2 == NULL)) {
         ERR_print_errors(bio_err);
         goto end;
     }
@@ -1528,10 +1596,12 @@ int main(int argc, char *argv[])
      */
     SSL_CTX_set_security_level(c_ctx, 0);
     SSL_CTX_set_security_level(s_ctx, 0);
+    SSL_CTX_set_security_level(s_ctx2, 0);
 
     if (cipher != NULL) {
         if (!SSL_CTX_set_cipher_list(c_ctx, cipher)
-           || !SSL_CTX_set_cipher_list(s_ctx, cipher)) {
+            || !SSL_CTX_set_cipher_list(s_ctx, cipher)
+            || !SSL_CTX_set_cipher_list(s_ctx2, cipher)) {
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -1547,6 +1617,7 @@ int main(int argc, char *argv[])
     /* Process SSL_CONF arguments */
     SSL_CONF_CTX_set_ssl_ctx(c_cctx, c_ctx);
     SSL_CONF_CTX_set_ssl_ctx(s_cctx, s_ctx);
+    SSL_CONF_CTX_set_ssl_ctx(s_cctx2, s_ctx2);
 
     for (i = 0; i < sk_OPENSSL_STRING_num(conf_args); i += 2) {
         int rv;
@@ -1554,8 +1625,10 @@ int main(int argc, char *argv[])
         argn = sk_OPENSSL_STRING_value(conf_args, i + 1);
         rv = SSL_CONF_cmd(c_cctx, arg, argn);
         /* If not recognised use server context */
-        if (rv == -2)
+        if (rv == -2) {
+            SSL_CONF_cmd(s_cctx2, arg, argn);
             rv = SSL_CONF_cmd(s_cctx, arg, argn);
+        }
         if (rv <= 0) {
             BIO_printf(bio_err, "Error processing %s %s\n",
                        arg, argn ? argn : "");
@@ -1564,7 +1637,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (!SSL_CONF_CTX_finish(s_cctx) || !SSL_CONF_CTX_finish(c_cctx)) {
+    if (!SSL_CONF_CTX_finish(s_cctx) || !SSL_CONF_CTX_finish(c_cctx) || !SSL_CONF_CTX_finish(s_cctx2)) {
         BIO_puts(bio_err, "Error finishing context\n");
         ERR_print_errors(bio_err);
         goto end;
@@ -1572,52 +1645,23 @@ int main(int argc, char *argv[])
 #ifndef OPENSSL_NO_DH
     if (!no_dhe) {
         if (dhe1024dsa) {
-            /*
-             * use SSL_OP_SINGLE_DH_USE to avoid small subgroup attacks
-             */
-            SSL_CTX_set_options(s_ctx, SSL_OP_SINGLE_DH_USE);
             dh = get_dh1024dsa();
         } else if (dhe512)
             dh = get_dh512();
         else
             dh = get_dh1024();
         SSL_CTX_set_tmp_dh(s_ctx, dh);
+        SSL_CTX_set_tmp_dh(s_ctx2, dh);
         DH_free(dh);
     }
 #else
     (void)no_dhe;
 #endif
 
-#ifndef OPENSSL_NO_EC
-    if (!no_ecdhe) {
-        int nid;
-
-        if (named_curve != NULL) {
-            nid = OBJ_sn2nid(named_curve);
-            if (nid == 0) {
-                BIO_printf(bio_err, "unknown curve name (%s)\n", named_curve);
-                goto end;
-            }
-        } else {
-            nid = NID_X9_62_prime256v1;
-        }
-
-        ecdh = EC_KEY_new_by_curve_name(nid);
-        if (ecdh == NULL) {
-            BIO_printf(bio_err, "unable to create curve\n");
-            goto end;
-        }
-
-        SSL_CTX_set_tmp_ecdh(s_ctx, ecdh);
-        SSL_CTX_set_options(s_ctx, SSL_OP_SINGLE_ECDH_USE);
-        EC_KEY_free(ecdh);
-    }
-#else
-    (void)no_ecdhe;
-#endif
-
     if ((!SSL_CTX_load_verify_locations(s_ctx, CAfile, CApath)) ||
         (!SSL_CTX_set_default_verify_paths(s_ctx)) ||
+        (!SSL_CTX_load_verify_locations(s_ctx2, CAfile, CApath)) ||
+        (!SSL_CTX_set_default_verify_paths(s_ctx2)) ||
         (!SSL_CTX_load_verify_locations(c_ctx, CAfile, CApath)) ||
         (!SSL_CTX_set_default_verify_paths(c_ctx))) {
         /* fprintf(stderr,"SSL_load_verify_locations\n"); */
@@ -1626,6 +1670,7 @@ int main(int argc, char *argv[])
     }
 
     if (!SSL_CTX_set_default_ctlog_list_file(s_ctx) ||
+        !SSL_CTX_set_default_ctlog_list_file(s_ctx2) ||
         !SSL_CTX_set_default_ctlog_list_file(c_ctx)) {
         ERR_print_errors(bio_err);
     }
@@ -1635,7 +1680,12 @@ int main(int argc, char *argv[])
         SSL_CTX_set_verify(s_ctx,
                            SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                            verify_callback);
+        SSL_CTX_set_verify(s_ctx2,
+                           SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           verify_callback);
         SSL_CTX_set_cert_verify_callback(s_ctx, app_verify_callback,
+                                         &app_verify_arg);
+        SSL_CTX_set_cert_verify_callback(s_ctx2, app_verify_callback,
                                          &app_verify_arg);
     }
     if (server_auth) {
@@ -1648,7 +1698,9 @@ int main(int argc, char *argv[])
     {
         int session_id_context = 0;
         if (!SSL_CTX_set_session_id_context(s_ctx, (void *)&session_id_context,
-                                       sizeof session_id_context)) {
+                                            sizeof session_id_context) ||
+            !SSL_CTX_set_session_id_context(s_ctx2, (void *)&session_id_context,
+                                            sizeof session_id_context)) {
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -1670,9 +1722,11 @@ int main(int argc, char *argv[])
 #ifndef OPENSSL_NO_PSK
         SSL_CTX_set_psk_client_callback(c_ctx, psk_client_callback);
         SSL_CTX_set_psk_server_callback(s_ctx, psk_server_callback);
+        SSL_CTX_set_psk_server_callback(s_ctx2, psk_server_callback);
         if (debug)
             BIO_printf(bio_err, "setting PSK identity hint to s_ctx\n");
-        if (!SSL_CTX_use_psk_identity_hint(s_ctx, "ctx server identity_hint")) {
+        if (!SSL_CTX_use_psk_identity_hint(s_ctx, "ctx server identity_hint") ||
+            !SSL_CTX_use_psk_identity_hint(s_ctx2, "ctx server identity_hint")) {
             BIO_printf(bio_err, "error setting PSK identity hint to s_ctx\n");
             ERR_print_errors(bio_err);
             goto end;
@@ -1695,8 +1749,11 @@ int main(int argc, char *argv[])
 
     if (srp_server_arg.expected_user != NULL) {
         SSL_CTX_set_verify(s_ctx, SSL_VERIFY_NONE, verify_callback);
+        SSL_CTX_set_verify(s_ctx2, SSL_VERIFY_NONE, verify_callback);
         SSL_CTX_set_srp_cb_arg(s_ctx, &srp_server_arg);
+        SSL_CTX_set_srp_cb_arg(s_ctx2, &srp_server_arg);
         SSL_CTX_set_srp_username_callback(s_ctx, ssl_srp_server_param_cb);
+        SSL_CTX_set_srp_username_callback(s_ctx2, ssl_srp_server_param_cb);
     }
 #endif
 
@@ -1711,9 +1768,12 @@ int main(int argc, char *argv[])
             goto end;
         }
         SSL_CTX_set_next_protos_advertised_cb(s_ctx, cb_server_npn, NULL);
+        SSL_CTX_set_next_protos_advertised_cb(s_ctx2, cb_server_npn, NULL);
     }
     if (npn_server_reject) {
         SSL_CTX_set_next_protos_advertised_cb(s_ctx, cb_server_rejects_npn,
+                                              NULL);
+        SSL_CTX_set_next_protos_advertised_cb(s_ctx2, cb_server_rejects_npn,
                                               NULL);
     }
 #endif
@@ -1736,7 +1796,8 @@ int main(int argc, char *argv[])
         }
     }
     if (serverinfo_file)
-        if (!SSL_CTX_use_serverinfo_file(s_ctx, serverinfo_file)) {
+        if (!SSL_CTX_use_serverinfo_file(s_ctx, serverinfo_file) ||
+            !SSL_CTX_use_serverinfo_file(s_ctx2, serverinfo_file)) {
             BIO_printf(bio_err, "missing serverinfo file\n");
             goto end;
         }
@@ -1762,7 +1823,15 @@ int main(int argc, char *argv[])
                                       custom_ext_0_srv_add_cb,
                                       NULL, NULL,
                                       custom_ext_0_srv_parse_cb, NULL)
+            || !SSL_CTX_add_server_custom_ext(s_ctx2, CUSTOM_EXT_TYPE_0,
+                                      custom_ext_0_srv_add_cb,
+                                      NULL, NULL,
+                                      custom_ext_0_srv_parse_cb, NULL)
             || !SSL_CTX_add_server_custom_ext(s_ctx, CUSTOM_EXT_TYPE_1,
+                                      custom_ext_1_srv_add_cb,
+                                      NULL, NULL,
+                                      custom_ext_1_srv_parse_cb, NULL)
+            || !SSL_CTX_add_server_custom_ext(s_ctx2, CUSTOM_EXT_TYPE_1,
                                       custom_ext_1_srv_add_cb,
                                       NULL, NULL,
                                       custom_ext_1_srv_parse_cb, NULL)
@@ -1770,7 +1839,15 @@ int main(int argc, char *argv[])
                                       custom_ext_2_srv_add_cb,
                                       NULL, NULL,
                                       custom_ext_2_srv_parse_cb, NULL)
+            || !SSL_CTX_add_server_custom_ext(s_ctx2, CUSTOM_EXT_TYPE_2,
+                                      custom_ext_2_srv_add_cb,
+                                      NULL, NULL,
+                                      custom_ext_2_srv_parse_cb, NULL)
             || !SSL_CTX_add_server_custom_ext(s_ctx, CUSTOM_EXT_TYPE_3,
+                                      custom_ext_3_srv_add_cb,
+                                      NULL, NULL,
+                                      custom_ext_3_srv_parse_cb, NULL)
+            || !SSL_CTX_add_server_custom_ext(s_ctx2, CUSTOM_EXT_TYPE_3,
                                       custom_ext_3_srv_add_cb,
                                       NULL, NULL,
                                       custom_ext_3_srv_parse_cb, NULL)) {
@@ -1780,10 +1857,12 @@ int main(int argc, char *argv[])
     }
 
     if (alpn_server)
-        SSL_CTX_set_alpn_select_cb(s_ctx, cb_server_alpn, NULL);
+        SSL_CTX_set_alpn_select_cb(s_ctx, cb_server_alpn, alpn_server);
+    if (alpn_server2)
+        SSL_CTX_set_alpn_select_cb(s_ctx2, cb_server_alpn, alpn_server2);
 
     if (alpn_client) {
-        unsigned short alpn_len;
+        size_t alpn_len;
         unsigned char *alpn = next_protos_parse(&alpn_len, alpn_client);
 
         if (alpn == NULL) {
@@ -1799,8 +1878,14 @@ int main(int argc, char *argv[])
         OPENSSL_free(alpn);
     }
 
+    if (sn_server1 != NULL || sn_server2 != NULL)
+        SSL_CTX_set_tlsext_servername_callback(s_ctx, servername_cb);
+
     c_ssl = SSL_new(c_ctx);
     s_ssl = SSL_new(s_ctx);
+
+    if (sn_client)
+        SSL_set_tlsext_host_name(c_ssl, sn_client);
 
     if (!set_protocol_version(server_min_proto, s_ssl, SSL_CTRL_SET_MIN_PROTO_VERSION))
         goto end;
@@ -1883,8 +1968,10 @@ int main(int argc, char *argv[])
 
  end:
     SSL_CTX_free(s_ctx);
+    SSL_CTX_free(s_ctx2);
     SSL_CTX_free(c_ctx);
     SSL_CONF_CTX_free(s_cctx);
+    SSL_CONF_CTX_free(s_cctx2);
     SSL_CONF_CTX_free(c_cctx);
     sk_OPENSSL_STRING_free(conf_args);
 
@@ -2149,6 +2236,10 @@ int doit_localhost(SSL *s_ssl, SSL *c_ssl, int family, long count,
         goto err;
     }
     if (verify_alpn(c_ssl, s_ssl) < 0) {
+        ret = 1;
+        goto err;
+    }
+    if (verify_servername(c_ssl, s_ssl) < 0) {
         ret = 1;
         goto err;
     }
@@ -2525,6 +2616,10 @@ int doit_biopair(SSL *s_ssl, SSL *c_ssl, long count,
         goto err;
     }
     if (verify_alpn(c_ssl, s_ssl) < 0) {
+        ret = 1;
+        goto err;
+    }
+    if (verify_servername(c_ssl, s_ssl) < 0) {
         ret = 1;
         goto err;
     }


### PR DESCRIPTION
* Perform ALPN after the SNI callback; the SSL_CTX may change due to
  that processing
* Add flags to indicate that we actually sent ALPN, to properly error
  out if unexpectedly received.
* clean up ssl3_free() no need to explicitly clear when doing memset
* size_t-ify ALPN/NPN code
* document ALPN functions