### PR TITLE
Do not display an error message if the default CT log list is not found

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -238,11 +238,7 @@ int ctx_set_verify_locations(SSL_CTX *ctx, const char *CAfile,
 int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path)
 {
     if (path == NULL) {
-        if (SSL_CTX_set_default_ctlog_list_file(ctx) <= 0) {
-            BIO_puts(bio_err, "Failed to load default Certificate Transparency "
-                     "log list\n");
-        }
-        return 1; /* Do not treat failure to load the default as an error */
+        return SSL_CTX_set_default_ctlog_list_file(ctx);
     }
 
     return SSL_CTX_set_ctlog_list_file(ctx, path);

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -490,6 +490,12 @@ X509_STORE *setup_verify(char *CAfile, char *CApath,
 __owur int ctx_set_verify_locations(SSL_CTX *ctx, const char *CAfile,
                                     const char *CApath, int noCAfile,
                                     int noCApath);
+
+/*
+ * Sets the file to load the Certificate Transparency log list from.
+ * If path is NULL, loads from the default file path.
+ * Returns 1 on success, 0 otherwise.
+ */
 __owur int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
 
 # ifdef OPENSSL_NO_ENGINE

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2613,13 +2613,18 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 
 #ifndef OPENSSL_NO_CT
         scts = SSL_get0_peer_scts(s);
-        BIO_printf(bio, "---\nSCTs present (%i)\n---\n",
-                   scts ? sk_SCT_num(scts) : 0);
-        SCT_LIST_print(scts, bio, 0, "\n---\n");
-        BIO_printf(bio, "\n");
+        BIO_printf(bio, "---\nSCTs present (%i)\n",
+                   scts != NULL ? sk_SCT_num(scts) : 0);
+
         if (SSL_get_ct_validation_callback(s) == NULL) {
-          BIO_printf(bio, "---\nWarning: CT validation is disabled, so not all "
+          BIO_printf(bio, "Warning: CT validation is disabled, so not all "
                      "SCTs may be displayed. Re-run with \"-requestct\".\n");
+        }
+
+        if (scts != NULL && sk_SCT_num(scts) > 0) {
+            BIO_printf(bio, "---\n");
+            SCT_LIST_print(scts, bio, 0, "\n---\n");
+            BIO_printf(bio, "\n");
         }
 #endif
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1670,8 +1670,18 @@ int s_client_main(int argc, char **argv)
     }
 
     if (!ctx_set_ctlog_list_file(ctx, ctlog_file)) {
-        ERR_print_errors(bio_err);
-        goto end;
+        if (ct_validation != NULL) {
+            ERR_print_errors(bio_err);
+            goto end;
+        }
+
+        /*
+         * If CT validation is not enabled, the log list isn't needed so don't
+         * show errors or abort. We try to load it regardless because then we
+         * can show the names of the logs any SCTs came from (SCTs may be seen
+         * even with validation disabled).
+         */
+        ERR_clear_error();
     }
 #endif
 

--- a/doc/ssl/SSL_CTX_set_ctlog_list_file.pod
+++ b/doc/ssl/SSL_CTX_set_ctlog_list_file.pod
@@ -37,9 +37,6 @@ The expected format of the log list file is:
 These functions will not clear the existing CT log list - it will be appended
 to.
 
-SSL_CTX_set_default_ctlog_list_file() will not report errors if it fails for
-any reason. Use SSL_CTX_set_ctlog_list_file() if you want errors to be reported.
-
 If an error occurs whilst parsing a particular log entry in the file, that log
 entry will be skipped.
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4143,11 +4143,7 @@ end:
 
 int SSL_CTX_set_default_ctlog_list_file(SSL_CTX *ctx)
 {
-    int ret = CTLOG_STORE_load_default_file(ctx->ctlog_store);
-
-    /* Clear any errors if the default file does not exist */
-    ERR_clear_error();
-    return ret;
+    return CTLOG_STORE_load_default_file(ctx->ctlog_store);
 }
 
 int SSL_CTX_set_ctlog_list_file(SSL_CTX *ctx, const char *path)


### PR DESCRIPTION
This saves users getting concerned if they see "Failed to load default Certificate Transparency log list" when using s_client. An error will still be displayed if they explicitly provide a CT log list using --ctlogfile and loading fails.