### PR TITLE
Replace binary asm literals with hexadecimal

### DIFF
--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -1707,8 +1707,8 @@ $code.=<<___;
 	movups	16($key),$rndkey[0]		# forward reference
 	lea	112($key),$key			# size optimization
 
-	pshufd	\$0b00011011,$ABCD,$ABCD	# flip word order
-	pshufd	\$0b00011011,$E,$E		# flip word order
+	pshufd	\$0x1b,$ABCD,$ABCD		# flip word order
+	pshufd	\$0x1b,$E,$E			# flip word order
 	jmp	.Loop_shaext
 
 .align	16
@@ -1808,8 +1808,8 @@ $code.=<<___;
 	lea		64($in0),$in0
 	jnz		.Loop_shaext
 
-	pshufd	\$0b00011011,$ABCD,$ABCD
-	pshufd	\$0b00011011,$E,$E
+	pshufd	\$0x1b,$ABCD,$ABCD
+	pshufd	\$0x1b,$E,$E
 	movups	$iv,($ivp)			# write IV
 	movdqu	$ABCD,($ctx)
 	movd	$E,16($ctx)

--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -4558,11 +4558,11 @@ __aesni_set_encrypt_key:
 	$movkey	%xmm0,(%rax)
 	lea	16(%rax),%rax
 .Lkey_expansion_128_cold:
-	shufps	\$0b00010000,%xmm0,%xmm4
+	shufps	\$0x10,%xmm0,%xmm4
 	xorps	%xmm4, %xmm0
-	shufps	\$0b10001100,%xmm0,%xmm4
+	shufps	\$0x8c,%xmm0,%xmm4
 	xorps	%xmm4, %xmm0
-	shufps	\$0b11111111,%xmm1,%xmm1	# critical path
+	shufps	\$0xff,%xmm1,%xmm1	# critical path
 	xorps	%xmm1,%xmm0
 	ret
 
@@ -4573,25 +4573,25 @@ __aesni_set_encrypt_key:
 .Lkey_expansion_192a_cold:
 	movaps	%xmm2, %xmm5
 .Lkey_expansion_192b_warm:
-	shufps	\$0b00010000,%xmm0,%xmm4
+	shufps	\$0x10,%xmm0,%xmm4
 	movdqa	%xmm2,%xmm3
 	xorps	%xmm4,%xmm0
-	shufps	\$0b10001100,%xmm0,%xmm4
+	shufps	\$0x8c,%xmm0,%xmm4
 	pslldq	\$4,%xmm3
 	xorps	%xmm4,%xmm0
-	pshufd	\$0b01010101,%xmm1,%xmm1	# critical path
+	pshufd	\$0x55,%xmm1,%xmm1	# critical path
 	pxor	%xmm3,%xmm2
 	pxor	%xmm1,%xmm0
-	pshufd	\$0b11111111,%xmm0,%xmm3
+	pshufd	\$0xff,%xmm0,%xmm3
 	pxor	%xmm3,%xmm2
 	ret
 
 .align 16
 .Lkey_expansion_192b:
 	movaps	%xmm0,%xmm3
-	shufps	\$0b01000100,%xmm0,%xmm5
+	shufps	\$0x44,%xmm0,%xmm5
 	$movkey	%xmm5,(%rax)
-	shufps	\$0b01001110,%xmm2,%xmm3
+	shufps	\$0x4e,%xmm2,%xmm3
 	$movkey	%xmm3,16(%rax)
 	lea	32(%rax),%rax
 	jmp	.Lkey_expansion_192b_warm
@@ -4601,11 +4601,11 @@ __aesni_set_encrypt_key:
 	$movkey	%xmm2,(%rax)
 	lea	16(%rax),%rax
 .Lkey_expansion_256a_cold:
-	shufps	\$0b00010000,%xmm0,%xmm4
+	shufps	\$0x10,%xmm0,%xmm4
 	xorps	%xmm4,%xmm0
-	shufps	\$0b10001100,%xmm0,%xmm4
+	shufps	\$0x8c,%xmm0,%xmm4
 	xorps	%xmm4,%xmm0
-	shufps	\$0b11111111,%xmm1,%xmm1	# critical path
+	shufps	\$0xff,%xmm1,%xmm1	# critical path
 	xorps	%xmm1,%xmm0
 	ret
 
@@ -4614,11 +4614,11 @@ __aesni_set_encrypt_key:
 	$movkey	%xmm0,(%rax)
 	lea	16(%rax),%rax
 
-	shufps	\$0b00010000,%xmm2,%xmm4
+	shufps	\$0x10,%xmm2,%xmm4
 	xorps	%xmm4,%xmm2
-	shufps	\$0b10001100,%xmm2,%xmm4
+	shufps	\$0x8c,%xmm2,%xmm4
 	xorps	%xmm4,%xmm2
-	shufps	\$0b10101010,%xmm1,%xmm1	# critical path
+	shufps	\$0xaa,%xmm1,%xmm1	# critical path
 	xorps	%xmm1,%xmm2
 	ret
 .size	${PREFIX}_set_encrypt_key,.-${PREFIX}_set_encrypt_key

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -420,15 +420,15 @@ my ($Xhi,$Xi,$Hkey,$HK)=@_;
 if (!defined($HK)) {	$HK = $T2;
 $code.=<<___;
 	movdqa		$Xi,$Xhi		#
-	pshufd		\$0b01001110,$Xi,$T1
-	pshufd		\$0b01001110,$Hkey,$T2
+	pshufd		\$0x4e,$Xi,$T1
+	pshufd		\$0x4e,$Hkey,$T2
 	pxor		$Xi,$T1			#
 	pxor		$Hkey,$T2
 ___
 } else {
 $code.=<<___;
 	movdqa		$Xi,$Xhi		#
-	pshufd		\$0b01001110,$Xi,$T1
+	pshufd		\$0x4e,$Xi,$T1
 	pxor		$Xi,$T1			#
 ___
 }
@@ -495,10 +495,10 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	movdqu		($Xip),$Hkey
-	pshufd		\$0b01001110,$Hkey,$Hkey	# dword swap
+	pshufd		\$0x4e,$Hkey,$Hkey	# dword swap
 
 	# <<1 twist
-	pshufd		\$0b11111111,$Hkey,$T2	# broadcast uppermost dword
+	pshufd		\$0xff,$Hkey,$T2	# broadcast uppermost dword
 	movdqa		$Hkey,$T1
 	psllq		\$1,$Hkey
 	pxor		$T3,$T3			#
@@ -512,15 +512,15 @@ $code.=<<___;
 	pxor		$T3,$Hkey		# if(carry) H^=0x1c2_polynomial
 
 	# calculate H^2
-	pshufd		\$0b01001110,$Hkey,$HK
+	pshufd		\$0x4e,$Hkey,$HK
 	movdqa		$Hkey,$Xi
 	pxor		$Hkey,$HK
 ___
 	&clmul64x64_T2	($Xhi,$Xi,$Hkey,$HK);
 	&reduction_alg9	($Xhi,$Xi);
 $code.=<<___;
-	pshufd		\$0b01001110,$Hkey,$T1
-	pshufd		\$0b01001110,$Xi,$T2
+	pshufd		\$0x4e,$Hkey,$T1
+	pshufd		\$0x4e,$Xi,$T2
 	pxor		$Hkey,$T1		# Karatsuba pre-processing
 	movdqu		$Hkey,0x00($Htbl)	# save H
 	pxor		$Xi,$T2			# Karatsuba pre-processing
@@ -537,8 +537,8 @@ ___
 	&clmul64x64_T2	($Xhi,$Xi,$Hkey,$HK);	# H^4
 	&reduction_alg9	($Xhi,$Xi);
 $code.=<<___;
-	pshufd		\$0b01001110,$T3,$T1
-	pshufd		\$0b01001110,$Xi,$T2
+	pshufd		\$0x4e,$T3,$T1
+	pshufd		\$0x4e,$Xi,$T2
 	pxor		$T3,$T1			# Karatsuba pre-processing
 	movdqu		$T3,0x30($Htbl)		# save H^3
 	pxor		$Xi,$T2			# Karatsuba pre-processing
@@ -670,14 +670,14 @@ $code.=<<___;
 	pshufb		$T3,$Xln
 	 pshufb		$T3,$Xl
 	movdqa		$Xln,$Xhn
-	pshufd		\$0b01001110,$Xln,$Xmn
+	pshufd		\$0x4e,$Xln,$Xmn
 	pxor		$Xln,$Xmn
 	pclmulqdq	\$0x00,$Hkey,$Xln
 	pclmulqdq	\$0x11,$Hkey,$Xhn
 	pclmulqdq	\$0x00,$HK,$Xmn
 
 	movdqa		$Xl,$Xh
-	pshufd		\$0b01001110,$Xl,$Xm
+	pshufd		\$0x4e,$Xl,$Xm
 	pxor		$Xl,$Xm
 	pclmulqdq	\$0x00,$Hkey2,$Xl
 	pclmulqdq	\$0x11,$Hkey2,$Xh
@@ -692,12 +692,12 @@ $code.=<<___;
 	pshufb		$T3,$Xl
 	 pshufb		$T3,$T1
 	movdqa		$Xl,$Xh
-	pshufd		\$0b01001110,$Xl,$Xm
+	pshufd		\$0x4e,$Xl,$Xm
 	 pxor		$T1,$Xi
 	pxor		$Xl,$Xm
 	pclmulqdq	\$0x00,$Hkey3,$Xl
 	 movdqa		$Xi,$Xhi
-	 pshufd		\$0b01001110,$Xi,$T1
+	 pshufd		\$0x4e,$Xi,$T1
 	 pxor		$Xi,$T1
 	pclmulqdq	\$0x11,$Hkey3,$Xh
 	pclmulqdq	\$0x00,$HK,$Xm
@@ -720,14 +720,14 @@ $code.=<<___;
 	 movdqu		0x20($inp),$Xln
 	 movdqa		$Xl,$Xh
 	pclmulqdq	\$0x10,$HK,$T1
-	 pshufd		\$0b01001110,$Xl,$Xm
+	 pshufd		\$0x4e,$Xl,$Xm
 	xorps		$Xhn,$Xhi
 	 pxor		$Xl,$Xm
 	 pshufb		$T3,$Xln
 	movups		0x20($Htbl),$HK
 	xorps		$Xmn,$T1
 	 pclmulqdq	\$0x00,$Hkey,$Xl
-	 pshufd		\$0b01001110,$Xln,$Xmn
+	 pshufd		\$0x4e,$Xln,$Xmn
 
 	pxor		$Xi,$T1			# aggregated Karatsuba post-processing
 	 movdqa		$Xln,$Xhn
@@ -771,7 +771,7 @@ $code.=<<___;
 
 	 movdqa		$Xl,$Xh
 	 pxor		$Xm,$Xmn
-	 pshufd		\$0b01001110,$Xl,$Xm
+	 pshufd		\$0x4e,$Xl,$Xm
 	pxor		$T2,$Xi			#
 	pxor		$T1,$Xhi
 	 pxor		$Xl,$Xm
@@ -781,7 +781,7 @@ $code.=<<___;
 	movdqa		$Xi,$Xhi
 	 pclmulqdq	\$0x11,$Hkey3,$Xh
 	 xorps		$Xl,$Xln
-	pshufd		\$0b01001110,$Xi,$T1
+	pshufd		\$0x4e,$Xi,$T1
 	pxor		$Xi,$T1
 
 	 pclmulqdq	\$0x00,$HK,$Xm
@@ -833,7 +833,7 @@ $code.=<<___;
 	pxor		$T1,$Xi			# Ii+Xi
 
 	movdqa		$Xln,$Xhn
-	pshufd		\$0b01001110,$Xln,$Xmn
+	pshufd		\$0x4e,$Xln,$Xmn
 	pxor		$Xln,$Xmn
 	pclmulqdq	\$0x00,$Hkey,$Xln
 	pclmulqdq	\$0x11,$Hkey,$Xhn
@@ -850,7 +850,7 @@ $code.=<<___;
 .Lmod_loop:
 	movdqa		$Xi,$Xhi
 	movdqa		$Xmn,$T1
-	pshufd		\$0b01001110,$Xi,$Xmn	#
+	pshufd		\$0x4e,$Xi,$Xmn	#
 	pxor		$Xi,$Xmn		#
 
 	pclmulqdq	\$0x00,$Hkey2,$Xi
@@ -888,7 +888,7 @@ $code.=<<___;
 	  pslldq	\$8,$Xi
 	  psrldq	\$8,$T1			#	
 	  pxor		$T2,$Xi
-	pshufd		\$0b01001110,$Xhn,$Xmn
+	pshufd		\$0x4e,$Xhn,$Xmn
 	  pxor		$T1,$Xhi		#
 	pxor		$Xhn,$Xmn		#
 
@@ -910,7 +910,7 @@ $code.=<<___;
 .Leven_tail:
 	 movdqa		$Xi,$Xhi
 	 movdqa		$Xmn,$T1
-	 pshufd		\$0b01001110,$Xi,$Xmn	#
+	 pshufd		\$0x4e,$Xi,$Xmn	#
 	 pxor		$Xi,$Xmn		#
 
 	pclmulqdq	\$0x00,$Hkey2,$Xi
@@ -985,10 +985,10 @@ $code.=<<___;
 	vzeroupper
 
 	vmovdqu		($Xip),$Hkey
-	vpshufd		\$0b01001110,$Hkey,$Hkey	# dword swap
+	vpshufd		\$0x4e,$Hkey,$Hkey	# dword swap
 
 	# <<1 twist
-	vpshufd		\$0b11111111,$Hkey,$T2	# broadcast uppermost dword
+	vpshufd		\$0xff,$Hkey,$T2	# broadcast uppermost dword
 	vpsrlq		\$63,$Hkey,$T1
 	vpsllq		\$1,$Hkey,$Hkey
 	vpxor		$T3,$T3,$T3		#
@@ -1076,8 +1076,8 @@ ___
 	&clmul64x64_avx	($Xhi,$Xi,$Hkey,$HK);	# calculate H^2,4,6,8
 	&reduction_avx	($Xhi,$Xi);
 $code.=<<___;
-	vpshufd		\$0b01001110,$T3,$T1
-	vpshufd		\$0b01001110,$Xi,$T2
+	vpshufd		\$0x4e,$T3,$T1
+	vpshufd		\$0x4e,$Xi,$T2
 	vpxor		$T3,$T1,$T1		# Karatsuba pre-processing
 	vmovdqu		$T3,0x00($Htbl)		# save H^1,3,5,7
 	vpxor		$Xi,$T2,$T2		# Karatsuba pre-processing

--- a/crypto/sha/asm/sha1-mb-x86_64.pl
+++ b/crypto/sha/asm/sha1-mb-x86_64.pl
@@ -570,10 +570,10 @@ $code.=<<___;
 	punpcklqdq	@MSG0[1],$ABCD0		# d0.c0.b0.a0
 	punpckhqdq	@MSG0[1],$ABCD1		# d1.c1.b1.a1
 
-	pshufd		\$0b00111111,@MSG0[3],$E0
-	pshufd		\$0b01111111,@MSG0[3],$E1
-	pshufd		\$0b00011011,$ABCD0,$ABCD0
-	pshufd		\$0b00011011,$ABCD1,$ABCD1
+	pshufd		\$0x3f,@MSG0[3],$E0
+	pshufd		\$0x7f,@MSG0[3],$E1
+	pshufd		\$0x1b,$ABCD0,$ABCD0
+	pshufd		\$0x1b,$ABCD1,$ABCD1
 	jmp		.Loop_shaext
 
 .align	32
@@ -711,8 +711,8 @@ $code.=<<___;
 
 	mov		`$REG_SZ*17+8`(%rsp),$num
 
-	pshufd		\$0b00011011,$ABCD0,$ABCD0
-	pshufd		\$0b00011011,$ABCD1,$ABCD1
+	pshufd		\$0x1b,$ABCD0,$ABCD0
+	pshufd		\$0x1b,$ABCD1,$ABCD1
 
 	movdqa		$ABCD0,@MSG0[0]
 	punpckldq	$ABCD1,$ABCD0		# b1.b0.a1.a0

--- a/crypto/sha/asm/sha1-x86_64.pl
+++ b/crypto/sha/asm/sha1-x86_64.pl
@@ -358,9 +358,9 @@ $code.=<<___;
 	movdqa	K_XX_XX+0xa0(%rip),$BSWAP	# byte-n-word swap
 
 	movdqu	($inp),@MSG[0]
-	pshufd	\$0b00011011,$ABCD,$ABCD	# flip word order
+	pshufd	\$0x1b,$ABCD,$ABCD		# flip word order
 	movdqu	0x10($inp),@MSG[1]
-	pshufd	\$0b00011011,$E,$E		# flip word order
+	pshufd	\$0x1b,$E,$E			# flip word order
 	movdqu	0x20($inp),@MSG[2]
 	pshufb	$BSWAP,@MSG[0]
 	movdqu	0x30($inp),@MSG[3]
@@ -426,8 +426,8 @@ $code.=<<___;
 
 	jnz		.Loop_shaext
 
-	pshufd	\$0b00011011,$ABCD,$ABCD
-	pshufd	\$0b00011011,$E,$E
+	pshufd	\$0x1b,$ABCD,$ABCD
+	pshufd	\$0x1b,$E,$E
 	movdqu	$ABCD,($ctx)
 	movd	$E,16($ctx)
 ___

--- a/crypto/sha/asm/sha256-mb-x86_64.pl
+++ b/crypto/sha/asm/sha256-mb-x86_64.pl
@@ -483,10 +483,10 @@ $code.=<<___;
 	punpckhqdq	@MSG1[0],$ABEF1			# F1.E1.B1.A1
 	punpckhqdq	@MSG1[2],$CDGH1			# H1.G1.D1.C1
 
-	pshufd		\$0b00011011,$ABEF0,$ABEF0
-	pshufd		\$0b00011011,$CDGH0,$CDGH0
-	pshufd		\$0b00011011,$ABEF1,$ABEF1
-	pshufd		\$0b00011011,$CDGH1,$CDGH1
+	pshufd		\$0x1b,$ABEF0,$ABEF0
+	pshufd		\$0x1b,$CDGH0,$CDGH0
+	pshufd		\$0x1b,$ABEF1,$ABEF1
+	pshufd		\$0x1b,$CDGH1,$CDGH1
 	jmp		.Loop_shaext
 
 .align	32
@@ -703,10 +703,10 @@ $code.=<<___;
 
 	mov		`$REG_SZ*17+8`(%rsp),$num
 
-	pshufd		\$0b00011011,$ABEF0,$ABEF0
-	pshufd		\$0b00011011,$CDGH0,$CDGH0
-	pshufd		\$0b00011011,$ABEF1,$ABEF1
-	pshufd		\$0b00011011,$CDGH1,$CDGH1
+	pshufd		\$0x1b,$ABEF0,$ABEF0
+	pshufd		\$0x1b,$CDGH0,$CDGH0
+	pshufd		\$0x1b,$ABEF1,$ABEF1
+	pshufd		\$0x1b,$CDGH1,$CDGH1
 
 	movdqa		$ABEF0,@MSG0[0]
 	movdqa		$CDGH0,@MSG0[1]


### PR DESCRIPTION
Older OS X systems use an old version of the GNU assembler that does not
support binary literals, which then causes the build to fail because the
immediate expression is treated as 0:

sha1-x86_64.s:1243:missing or invalid immediate expression `0b00011011' taken as 0
sha1-x86_64.s:1243:suffix or operands invalid for `pshufd'
sha1-x86_64.s:1245:missing or invalid immediate expression `0b00011011' taken as 0
sha1-x86_64.s:1245:suffix or operands invalid for `pshufd'
sha1-x86_64.s:1395:missing or invalid immediate expression `0b00011011' taken as 0
sha1-x86_64.s:1395:suffix or operands invalid for `pshufd'
sha1-x86_64.s:1396:missing or invalid immediate expression `0b00011011' taken as 0
sha1-x86_64.s:1396:suffix or operands invalid for `pshufd'
make[2]: *** [sha1-x86_64.o] Error 1

This affects OS X 10.6.8 "Snow Leopard", and possibly below. See
https://trac.macports.org/ticket/50771 for more details.

Signed-off-by: Clemens Lang <cal@macports.org>