### PR TITLE
Trim Travis config part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
     - cd _srcdist
     - make
     - if [ -z "$BUILDONLY" ]; then
-          HARNESS_VERBOSE=yes make test
+          HARNESS_VERBOSE=yes make test;
       fi
     - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ addons:
         packages:
             - clang-3.6
             - gcc-5
-            - binutils-mingw-w64
-            - gcc-mingw-w64
-            - wine
         sources:
             - llvm-toolchain-precise-3.6
             - ubuntu-toolchain-r-test
@@ -21,17 +18,15 @@ compiler:
     - clang-3.6
     - gcc
     - gcc-5
-    - i686-w64-mingw32-gcc
-    - x86_64-w64-mingw32-gcc
 
 env:
     - CONFIG_OPTS=""
     - CONFIG_OPTS="shared"
     - CONFIG_OPTS="no-pic"
     - CONFIG_OPTS="--debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
-    - CONFIG_OPTS="--unified"
-    - CONFIG_OPTS="--unified shared"
-    - CONFIG_OPTS="--unified --debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
+    - CONFIG_OPTS="--unified" BUILDONLY="yes"
+    - CONFIG_OPTS="--unified shared" BUILDONLY="yes"
+    - CONFIG_OPTS="--unified --debug --strict-warnings enable-rc5 enable-md2" BUILDONLY="yes"
 
 matrix:
     include:
@@ -48,14 +43,8 @@ matrix:
           compiler: gcc-5
           env: CONFIG_OPTS="no-asm --strict-warnings -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
         - os: linux
-          compiler: clang-3.6
-          env: CONFIG_OPTS="no-engine"
-        - os: linux
-          compiler: gcc
-          env: CONFIG_OPTS="no-engine"
-        - os: linux
-          compiler: gcc-5
-          env: CONFIG_OPTS="no-engine"
+          compiler: clang
+          env: CONFIG_OPTS="no-engine" BUILDONLY="yes"
     exclude:
         - os: osx
           compiler: clang-3.6
@@ -63,33 +52,6 @@ matrix:
           compiler: gcc
         - os: osx
           compiler: gcc-5
-        - os: osx
-          compiler: i686-w64-mingw32-gcc
-        - os: osx
-          compiler: x86_64-w64-mingw32-gcc
-        - compiler: i686-w64-mingw32-gcc
-          env: CONFIG_OPTS="shared"
-        - compiler: x86_64-w64-mingw32-gcc
-          env: CONFIG_OPTS="shared"
-        - compiler: i686-w64-mingw32-gcc
-          env: CONFIG_OPTS="--unified shared"
-        - compiler: x86_64-w64-mingw32-gcc
-          env: CONFIG_OPTS="--unified shared"
-    allow_failures:
-        - compiler: i686-w64-mingw32-gcc
-          env: CONFIG_OPTS="--debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
-        - compiler: x86_64-w64-mingw32-gcc
-          env: CONFIG_OPTS="--debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
-        - compiler: i686-w64-mingw32-gcc
-          env: CONFIG_OPTS="--unified --debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
-        - compiler: x86_64-w64-mingw32-gcc
-          env: CONFIG_OPTS="--unified --debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
-        - compiler: clang-3.6
-          env: CONFIG_OPTS="no-engine"
-        - compiler: gcc-5
-          env: CONFIG_OPTS="no-engine"
-        - compiler: gcc
-          env: CONFIG_OPTS="no-engine"
 
 before_script:
     - sh .travis-create-release.sh $TRAVIS_OS_NAME
@@ -109,10 +71,9 @@ before_script:
 script:
     - cd _srcdist
     - make
-    - if [ -n "$CROSS_COMPILE" ]; then
-          export EXE_SHELL="wine" WINEPREFIX=`pwd`;
+    - if [ -z "$BUILDONLY" ]; then
+          HARNESS_VERBOSE=yes make test
       fi
-    - HARNESS_VERBOSE=yes make test
     - cd ..
 
 notifications:


### PR DESCRIPTION
- Remove Win builds. They're slow, allowed to fail, and therefore
  useless as they are.
- Make the --unified part of the matrix build-only. (This can be
  swapped if --unified becomes the default)
- Only build 'no-engine' once, don't run any tests, but don't allow it
  to fail.