### PR TITLE
Reuse strndup(), simplify code

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -192,8 +192,7 @@ static void free_dir(X509_LOOKUP *lu)
 
 static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
 {
-    int j, len;
-    const char *s, *ss, *p;
+    const char *s, *p;
 
     if (dir == NULL || !*dir) {
         X509err(X509_F_ADD_CERT_DIR, X509_R_INVALID_DIRECTORY);
@@ -205,15 +204,17 @@ static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
     do {
         if ((*p == LIST_SEPARATOR_CHAR) || (*p == '\0')) {
             BY_DIR_ENTRY *ent;
-            ss = s;
+            int j;
+            size_t len;
+            const char *ss = s;
             s = p + 1;
-            len = (int)(p - ss);
+            len = p - ss;
             if (len == 0)
                 continue;
             for (j = 0; j < sk_BY_DIR_ENTRY_num(ctx->dirs); j++) {
                 ent = sk_BY_DIR_ENTRY_value(ctx->dirs, j);
-                if (strlen(ent->dir) == (size_t)len &&
-                    strncmp(ent->dir, ss, (unsigned int)len) == 0)
+                if (strlen(ent->dir) == len &&
+                    strncmp(ent->dir, ss, len) == 0)
                     break;
             }
             if (j < sk_BY_DIR_ENTRY_num(ctx->dirs))
@@ -230,13 +231,11 @@ static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
                 return 0;
             ent->dir_type = type;
             ent->hashes = sk_BY_DIR_HASH_new(by_dir_hash_cmp);
-            ent->dir = OPENSSL_malloc((unsigned int)len + 1);
+            ent->dir = OPENSSL_strndup(ss, len);
             if (ent->dir == NULL || ent->hashes == NULL) {
                 by_dir_entry_free(ent);
                 return 0;
             }
-            strncpy(ent->dir, ss, (unsigned int)len);
-            ent->dir[len] = '\0';
             if (!sk_BY_DIR_ENTRY_push(ctx->dirs, ent)) {
                 by_dir_entry_free(ent);
                 return 0;


### PR DESCRIPTION
The original code would contain `strndup()` reimplemented, a bunch of unneeded casts and variables with too wide scope which made code harder to analyze.