### PR TITLE
avoid double-free in callers to OCSP_parse_url

### DIFF
--- a/crypto/ocsp/ocsp_lib.c
+++ b/crypto/ocsp/ocsp_lib.c
@@ -266,8 +266,11 @@ int OCSP_parse_url(const char *url, char **phost, char **pport, char **ppath,
  err:
     OPENSSL_free(buf);
     OPENSSL_free(*ppath);
+    *ppath = NULL;
     OPENSSL_free(*pport);
+    *pport = NULL;
     OPENSSL_free(*phost);
+    *phost = NULL;
     return 0;
 
 }


### PR DESCRIPTION
It appears to be common for callers of OCSP_parse_url to later call OPENSSL_free on the path, port, and host parameters even in the event of failure. This can result in a double-free error, because on failure, OCSP_parse_url returns the old pointers to the caller after freeing them. For example:

```
$ openssl version
OpenSSL 1.0.2e 3 Dec 2015
$ openssl ocsp -url https://[
Error parsing URL
140735167492176:error:27072079:OCSP routines:OCSP_parse_url:error parsing url:ocsp_lib.c:269:
openssl(1689,0x7fff75aa7000) malloc: *** error for object 0x7fde01514870: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
$ openssl crl -inform http -in http://[
openssl(52971,0x7fff75aa7000) malloc: *** error for object 0x7fd1ebc1d580: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

This patch sets the path, port, and host parameters to NULL after they are freed in OCSP_parse_url, before they are returned to the caller, so the caller won't try to free them again.

Credit to @guidovranken to showing me this problem.