### PR TITLE
Add missing ifdef compat block

### DIFF
--- a/crypto/include/internal/cryptlib.h
+++ b/crypto/include/internal/cryptlib.h
@@ -82,7 +82,9 @@ typedef struct ex_callback_st EX_CALLBACK;
 
 DEFINE_STACK_OF(EX_CALLBACK)
 
+# if OPENSSL_API_COMPAT < 0x10100000L
 DEFINE_STACK_OF(CRYPTO_dynlock)
+#endif
 
 typedef struct app_mem_info_st APP_INFO;
 DEFINE_LHASH_OF(APP_INFO);

--- a/crypto/include/internal/cryptlib.h
+++ b/crypto/include/internal/cryptlib.h
@@ -84,7 +84,7 @@ DEFINE_STACK_OF(EX_CALLBACK)
 
 # if OPENSSL_API_COMPAT < 0x10100000L
 DEFINE_STACK_OF(CRYPTO_dynlock)
-#endif
+# endif
 
 typedef struct app_mem_info_st APP_INFO;
 DEFINE_LHASH_OF(APP_INFO);


### PR DESCRIPTION
CRYPTO_dynlock struct is only available for compat < 0x10100000L. See crypto.h