### PR TITLE
Remove 'log' field from SCT and related accessors

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -204,7 +204,7 @@ static int c_quiet = 0;
 static int c_ign_eof = 0;
 static int c_brief = 0;
 
-static void print_stuff(BIO *berr, SSL *con, int full);
+static void print_stuff(BIO *berr, const SSL_CTX *ctx, SSL *con, int full);
 static int ocsp_resp_cb(SSL *s, void *arg);
 
 static int saved_errno;
@@ -2184,7 +2184,7 @@ int s_client_main(int argc, char **argv)
                     print_ssl_summary(con);
                 }
 
-                print_stuff(bio_c_out, con, full_log);
+                print_stuff(bio_c_out, ctx, con, full_log);
                 if (full_log > 0)
                     full_log--;
 
@@ -2516,13 +2516,13 @@ int s_client_main(int argc, char **argv)
     ret = 0;
  shut:
     if (in_init)
-        print_stuff(bio_c_out, con, full_log);
+        print_stuff(bio_c_out, ctx, con, full_log);
     do_ssl_shutdown(con);
     BIO_closesocket(SSL_get_fd(con));
  end:
     if (con != NULL) {
         if (prexit != 0)
-            print_stuff(bio_c_out, con, 1);
+            print_stuff(bio_c_out, ctx, con, 1);
         SSL_free(con);
     }
 #if !defined(OPENSSL_NO_NEXTPROTONEG)
@@ -2554,7 +2554,7 @@ int s_client_main(int argc, char **argv)
     return (ret);
 }
 
-static void print_stuff(BIO *bio, SSL *s, int full)
+static void print_stuff(BIO *bio, const SSL_CTX *ctx, SSL *s, int full)
 {
     X509 *peer = NULL;
     char buf[BUFSIZ];
@@ -2634,7 +2634,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 
         if (scts != NULL && sk_SCT_num(scts) > 0) {
             BIO_printf(bio, "---\n");
-            SCT_LIST_print(scts, bio, 0, "\n---\n");
+            SCT_LIST_print(scts, bio, 0, "\n---\n", SSL_CTX_get0_ctlog_store(ctx));
             BIO_printf(bio, "\n");
         }
 #endif

--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -125,8 +125,6 @@ struct sct_st {
     ct_log_entry_type_t entry_type;
     /* Where this SCT was found, e.g. certificate, OCSP response, etc. */
     sct_source_t source;
-    /* The CT log that produced this SCT. */
-    const CTLOG *log;
     /* The result of the last attempt to validate this SCT. */
     sct_validation_status_t validation_status;
 };

--- a/crypto/ct/ct_prn.c
+++ b/crypto/ct/ct_prn.c
@@ -96,8 +96,16 @@ static void timestamp_print(uint64_t timestamp, BIO *out)
     ASN1_GENERALIZEDTIME_free(gen);
 }
 
-void SCT_print(const SCT *sct, BIO *out, int indent, const CTLOG *log)
+void SCT_print(const SCT *sct, BIO *out, int indent,
+               const CTLOG_STORE *log_store)
 {
+    const CTLOG *log = NULL;
+
+    if (log_store != NULL) {
+        log = CTLOG_STORE_get0_log_by_id(log_store, sct->log_id,
+                                         sct->log_id_len);
+    }
+
     BIO_printf(out, "%*sSigned Certificate Timestamp:", indent, "");
     BIO_printf(out, "\n%*sVersion   : ", indent + 4, "");
 
@@ -139,14 +147,8 @@ void SCT_LIST_print(const STACK_OF(SCT) *sct_list, BIO *out, int indent,
 
     for (i = 0; i < sk_SCT_num(sct_list); ++i) {
         SCT *sct = sk_SCT_value(sct_list, i);
-        const CTLOG *log = NULL;
 
-        if (log_store != NULL) {
-            log = CTLOG_STORE_get0_log_by_id(log_store, sct->log_id,
-                                             sct->log_id_len);
-        }
-
-        SCT_print(sct, out, indent, log);
+        SCT_print(sct, out, indent, log_store);
         if (i < sk_SCT_num(sct_list) - 1)
             BIO_printf(out, "%s", separator);
     }

--- a/crypto/ct/ct_x509v3.c
+++ b/crypto/ct/ct_x509v3.c
@@ -75,7 +75,7 @@ static char *i2s_poison(const X509V3_EXT_METHOD *method, void *val)
 static int i2r_SCT_LIST(X509V3_EXT_METHOD *method, STACK_OF(SCT) *sct_list,
                  BIO *out, int indent)
 {
-    SCT_LIST_print(sct_list, out, indent, "\n");
+    SCT_LIST_print(sct_list, out, indent, "\n", NULL);
     return 1;
 }
 

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -223,13 +223,6 @@ __owur int SCT_set1_log_id(SCT *sct, const unsigned char *log_id,
                            size_t log_id_len);
 
 /*
- * Gets the name of the log that an SCT came from.
- * Ownership of the log name remains with the SCT.
- * Returns the log name, or NULL if it is not known.
- */
-const char *SCT_get0_log_name(const SCT *sct);
-
-/*
  * Returns the timestamp for the SCT (epoch time in milliseconds).
  */
 uint64_t SCT_get_timestamp(const SCT *sct);
@@ -307,32 +300,23 @@ sct_source_t SCT_get_source(const SCT *sct);
 __owur int SCT_set_source(SCT *sct, sct_source_t source);
 
 /*
- * Gets information about the log the SCT came from, if set.
- */
-const CTLOG *SCT_get0_log(const SCT *sct);
-
-/*
- * Looks up information about the log the SCT came from using a CT log store.
- * The CTLOG_STORE must outlive the SCT, as ownership of the CTLOG remains with
- * the CTLOG_STORE.
- * Returns 1 if information about the log is found, 0 otherwise.
- * The information can be accessed via SCT_get0_log.
- */
-int SCT_set0_log(SCT *sct, const CTLOG_STORE* ct_logs);
-
-/*
  * Pretty-prints an |sct| to |out|.
  * It will be indented by the number of spaces specified by |indent|.
+ * If |log| is not NULL:
+ * - it should be the CT log that the SCT came from.
+ * - its name will be printed.
  */
-void SCT_print(const SCT *sct, BIO *out, int indent);
+void SCT_print(const SCT *sct, BIO *out, int indent, const CTLOG *log);
 
 /*
  * Pretty-prints an |sct_list| to |out|.
  * It will be indented by the number of spaces specified by |indent|.
  * SCTs will be delimited by |separator|.
+ * If |logs| is not NULL, it will be used to lookup the CT log that each SCT
+ * came from, so that the log names can be printed.
  */
 void SCT_LIST_print(const STACK_OF(SCT) *sct_list, BIO *out, int indent,
-                    const char *separator);
+                    const char *separator, const CTLOG_STORE *logs);
 
 /*
  * Verifies an SCT with the given context.

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -302,11 +302,10 @@ __owur int SCT_set_source(SCT *sct, sct_source_t source);
 /*
  * Pretty-prints an |sct| to |out|.
  * It will be indented by the number of spaces specified by |indent|.
- * If |log| is not NULL:
- * - it should be the CT log that the SCT came from.
- * - its name will be printed.
+ * If |logs| is not NULL, it will be used to lookup the CT log that the SCT came
+ * from, so that the log name can be printed.
  */
-void SCT_print(const SCT *sct, BIO *out, int indent, const CTLOG *log);
+void SCT_print(const SCT *sct, BIO *out, int indent, const CTLOG_STORE *logs);
 
 /*
  * Pretty-prints an |sct_list| to |out|.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1932,10 +1932,38 @@ __owur ct_validation_cb SSL_CTX_get_ct_validation_callback(const SSL_CTX *ctx);
 /* Gets the SCTs received from a connection */
 const STACK_OF(SCT) *SSL_get0_peer_scts(SSL *s);
 
-/* Load the CT log list from the default location */
+/*
+ * Loads the CT log list from the default location.
+ * If a CTLOG_STORE has previously been set using SSL_CTX_set_ctlog_store,
+ * the log information loaded from this file will be appended to the
+ * CTLOG_STORE.
+ * Returns 1 on success, 0 otherwise.
+ */
 int SSL_CTX_set_default_ctlog_list_file(SSL_CTX *ctx);
-/* Load the CT log list from the specified file path */
+
+/*
+ * Loads the CT log list from the specified file path.
+ * If a CTLOG_STORE has previously been set using SSL_CTX_set_ctlog_store,
+ * the log information loaded from this file will be appended to the
+ * CTLOG_STORE.
+ * Returns 1 on success, 0 otherwise.
+ */
 int SSL_CTX_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
+
+/*
+ * Sets the CT log list used by all SSL connections created from this SSL_CTX.
+ * Ownership of the CTLOG_STORE is transferred to the SSL_CTX.
+ */
+void SSL_CTX_set0_ctlog_store(SSL_CTX *ctx, CTLOG_STORE *logs);
+
+/*
+ * Gets the CT log list used by all SSL connections created from this SSL_CTX.
+ * This will be NULL unless one of the following functions has been called:
+ * - SSL_CTX_set_default_ctlog_list_file
+ * - SSL_CTX_set_ctlog_list_file
+ * - SSL_CTX_set_ctlog_store
+ */
+const CTLOG_STORE *SSL_CTX_get0_ctlog_store(const SSL_CTX *ctx);
 
 # endif /* OPENSSL_NO_CT */
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4156,4 +4156,15 @@ int SSL_CTX_set_ctlog_list_file(SSL_CTX *ctx, const char *path)
     return CTLOG_STORE_load_file(ctx->ctlog_store, path);
 }
 
+void SSL_CTX_set0_ctlog_store(SSL_CTX *ctx, CTLOG_STORE *logs)
+{
+    CTLOG_STORE_free(ctx->ctlog_store);
+    ctx->ctlog_store = logs;
+}
+
+const CTLOG_STORE *SSL_CTX_get0_ctlog_store(const SSL_CTX *ctx)
+{
+    return ctx->ctlog_store;
+}
+
 #endif

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -202,7 +202,7 @@ static int compare_sct_printout(SCT *sct,
         goto end;
     }
 
-    SCT_print(sct, text_buffer, 0);
+    SCT_print(sct, text_buffer, 0, NULL);
 
     /* Append null terminator because we're about to use the buffer contents
     * as a string. */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1240,7 +1240,6 @@ OBJ_obj2nid                             1202	1_1_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_free                     1203	1_1_0	EXIST::FUNCTION:
 EVP_cast5_cfb64                         1204	1_1_0	EXIST::FUNCTION:CAST
 OPENSSL_uni2asc                         1205	1_1_0	EXIST::FUNCTION:
-SCT_set0_log                            1206	1_1_0	EXIST::FUNCTION:
 PKCS7_add_attribute                     1207	1_1_0	EXIST::FUNCTION:
 ENGINE_register_DSA                     1208	1_1_0	EXIST::FUNCTION:ENGINE
 lh_node_stats                           1209	1_1_0	EXIST::FUNCTION:STDIO
@@ -1953,7 +1952,6 @@ idea_cbc_encrypt                        1890	1_1_0	EXIST::FUNCTION:IDEA
 BN_CTX_secure_new                       1891	1_1_0	EXIST::FUNCTION:
 OCSP_ONEREQ_add_ext                     1892	1_1_0	EXIST::FUNCTION:
 CMS_uncompress                          1893	1_1_0	EXIST::FUNCTION:CMS
-SCT_get0_log                            1894	1_1_0	EXIST::FUNCTION:
 CRYPTO_mem_debug_pop                    1895	1_1_0	EXIST::FUNCTION:CRYPTO_MDEBUG
 EVP_aes_192_cfb128                      1896	1_1_0	EXIST::FUNCTION:AES
 OCSP_REQ_CTX_nbio                       1897	1_1_0	EXIST::FUNCTION:
@@ -3651,7 +3649,6 @@ ENGINE_set_default_string               3532	1_1_0	EXIST::FUNCTION:ENGINE
 BIO_number_read                         3533	1_1_0	EXIST::FUNCTION:
 CRYPTO_zalloc                           3534	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_cmp_parameters                 3535	1_1_0	EXIST::FUNCTION:
-SCT_get0_log_name                       3536	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_new_id                     3537	1_1_0	EXIST::FUNCTION:
 TLS_FEATURE_free                        3538	1_1_0	EXIST::FUNCTION:
 d2i_BASIC_CONSTRAINTS                   3539	1_1_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -388,3 +388,5 @@ SSL_CIPHER_get_auth_nid                 387	1_1_0	EXIST::FUNCTION:
 SSL_CIPHER_get_kx_nid                   388	1_1_0	EXIST::FUNCTION:
 SSL_CIPHER_is_aead                      389	1_1_0	EXIST::FUNCTION:
 SSL_SESSION_up_ref                      390	1_1_0	EXIST::FUNCTION:
+SSL_CTX_set0_ctlog_store                391	1_1_0	EXIST::FUNCTION:CT
+SSL_CTX_get0_ctlog_store                392	1_1_0	EXIST::FUNCTION:CT


### PR DESCRIPTION
See PR #835 for context.

In order to still have access to an SCT's CTLOG when calling SCT_print,
SSL_CTX_get0_ctlog_store has been added.

Improved documentation for some CT functions in openssl/ssl.h.