### PR TITLE
Adds a "-precert" flag to "openssl req" for creating pre-certificates

### DIFF
--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -125,7 +125,7 @@ if ($WHAT eq '-newcert' ) {
     print "Cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-precert' ) {
     # create a pre-certificate
-    $RET = run("$REQ -new -x509 -precert -keyout $NEWKEY -out $NEWCERT $DAYS");
+    $RET = run("$REQ -x509 -precert -keyout $NEWKEY -out $NEWCERT $DAYS");
     print "Pre-cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-newreq' ) {
     # create a certificate request

--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -123,6 +123,10 @@ if ($WHAT eq '-newcert' ) {
     # create a certificate
     $RET = run("$REQ -new -x509 -keyout $NEWKEY -out $NEWCERT $DAYS $EXTRA{req}");
     print "Cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
+} elsif ($WHAT eq '-newprecert' ) {
+    # create a pre-certificate
+    $RET = run("$REQ -new -x509 -precert -keyout $NEWKEY -out $NEWCERT $DAYS");
+    print "Pre-cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-newreq' ) {
     # create a certificate request
     $RET = run("$REQ -new -keyout $NEWKEY -out $NEWREQ $DAYS $EXTRA{req}");

--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -123,7 +123,7 @@ if ($WHAT eq '-newcert' ) {
     # create a certificate
     $RET = run("$REQ -new -x509 -keyout $NEWKEY -out $NEWCERT $DAYS $EXTRA{req}");
     print "Cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
-} elsif ($WHAT eq '-newprecert' ) {
+} elsif ($WHAT eq '-precert' ) {
     # create a pre-certificate
     $RET = run("$REQ -new -x509 -precert -keyout $NEWKEY -out $NEWCERT $DAYS");
     print "Pre-cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;

--- a/apps/req.c
+++ b/apps/req.c
@@ -126,7 +126,7 @@ const OPTIONS req_options[] = {
      "Cert extension section (override value in config file)"},
     {"reqexts", OPT_REQEXTS, 's',
      "Request extension section (override value in config file)"},
-    {"precert", OPT_PRECERT, '-', "Add a poison extension"},
+    {"precert", OPT_PRECERT, '-', "Add a poison extension (implies -new)"},
     {"", OPT_MD, '-', "Any supported digest"},
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
@@ -161,8 +161,7 @@ int req_main(int argc, char **argv)
     int pkey_type = -1, private = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, keyform = FORMAT_PEM;
     int modulus = 0, multirdn = 0, verify = 0, noout = 0, text = 0;
-    int nodes = 0, newhdr = 0, subject = 0, pubkey = 0;
-    int precert = 0;
+    int nodes = 0, newhdr = 0, subject = 0, pubkey = 0, precert = 0;
     long newkey = -1;
     unsigned long chtype = MBSTRING_ASC, nmflag = 0, reqflag = 0;
     char nmflag_set = 0;
@@ -321,7 +320,7 @@ int req_main(int argc, char **argv)
             req_exts = opt_arg();
             break;
         case OPT_PRECERT:
-            precert = 1;
+            newreq = precert = 1;
             break;
         case OPT_MD:
             if (!opt_md(opt_unknown(), &md_alg))

--- a/apps/req.c
+++ b/apps/req.c
@@ -79,7 +79,7 @@ typedef enum OPTION_choice {
     OPT_VERIFY, OPT_NODES, OPT_NOOUT, OPT_VERBOSE, OPT_UTF8,
     OPT_NAMEOPT, OPT_REQOPT, OPT_SUBJ, OPT_SUBJECT, OPT_TEXT, OPT_X509,
     OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_EXTENSIONS,
-    OPT_REQEXTS, OPT_MD
+    OPT_REQEXTS, OPT_PRECERT, OPT_MD
 } OPTION_CHOICE;
 
 const OPTIONS req_options[] = {
@@ -126,6 +126,7 @@ const OPTIONS req_options[] = {
      "Cert extension section (override value in config file)"},
     {"reqexts", OPT_REQEXTS, 's',
      "Request extension section (override value in config file)"},
+    {"precert", OPT_PRECERT, '-', "Add a poison extension"},
     {"", OPT_MD, '-', "Any supported digest"},
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
@@ -161,6 +162,7 @@ int req_main(int argc, char **argv)
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, keyform = FORMAT_PEM;
     int modulus = 0, multirdn = 0, verify = 0, noout = 0, text = 0;
     int nodes = 0, newhdr = 0, subject = 0, pubkey = 0;
+    int precert = 0;
     long newkey = -1;
     unsigned long chtype = MBSTRING_ASC, nmflag = 0, reqflag = 0;
     char nmflag_set = 0;
@@ -317,6 +319,9 @@ int req_main(int argc, char **argv)
             break;
         case OPT_REQEXTS:
             req_exts = opt_arg();
+            break;
+        case OPT_PRECERT:
+            precert = 1;
             break;
         case OPT_MD:
             if (!opt_md(opt_unknown(), &md_alg))
@@ -642,6 +647,15 @@ int req_main(int argc, char **argv)
                 BIO_printf(bio_err, "Error Loading extension section %s\n",
                            extensions);
                 goto end;
+            }
+
+            /* If a pre-cert was requested, we need to add a poison extension */
+            if (precert) {
+                if (X509_add1_ext_i2d(x509ss, NID_ct_precert_poison, NULL, 1, 0)
+                    != 1) {
+                    BIO_printf(bio_err, "Error adding poison extension\n");
+                    goto end;
+                }
             }
 
             i = do_X509_sign(x509ss, pkey, digest, sigopts);

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -263,6 +263,8 @@ Transparency logs in order to obtain signed certificate timestamps (SCTs).
 These SCTs can then be embedded into the pre-certificate as an extension, before
 removing the poison and signing the certificate.
 
+This implies the B<-new> flag.
+
 =item B<-utf8>
 
 this option causes field values to be interpreted as UTF8 strings, by

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -37,6 +37,7 @@ B<openssl> B<req>
 [B<-newhdr>]
 [B<-extensions section>]
 [B<-reqexts section>]
+[B<-precert>]
 [B<-utf8>]
 [B<-nameopt>]
 [B<-reqopt>]
@@ -253,6 +254,14 @@ extensions (if the B<-x509> option is present) or certificate
 request extensions. This allows several different sections to
 be used in the same configuration file to specify requests for
 a variety of purposes.
+
+=item B<-precert>
+
+a poison extension will be added to the certificate, making it a
+"pre-certificate" (see RFC6962). This can be submitted to Certificate
+Transparency logs in order to obtain signed certificate timestamps (SCTs).
+These SCTs can then be embedded into the pre-certificate as an extension, before
+removing the poison and signing the certificate.
 
 =item B<-utf8>
 

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -43,7 +43,7 @@ plan tests => 5;
         'verifying new certificate');
 
      $ENV{OPENSSL_CONFIG} = "-config ".srctop_file("test", "Uss.cnf");
-     ok(run(perlapp(["CA.pl", "-newprecert"], stderr => undef)),
+     ok(run(perlapp(["CA.pl", "-precert"], stderr => undef)),
         'creating new pre-certificate');
 }
 

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -22,7 +22,7 @@ my $std_openssl_cnf =
 
 rmtree("demoCA", { safe => 0 });
 
-plan tests => 4;
+plan tests => 5;
  SKIP: {
      $ENV{OPENSSL_CONFIG} = '-config "'.srctop_file("test", "CAss.cnf").'"';
      skip "failed creating CA structure", 3
@@ -41,6 +41,10 @@ plan tests => 4;
 
      ok(run(perlapp(["CA.pl", "-verify", "newcert.pem"])),
         'verifying new certificate');
+
+     $ENV{OPENSSL_CONFIG} = "-config ".srctop_file("test", "Uss.cnf");
+     ok(run(perlapp(["CA.pl", "-newprecert"], stderr => undef)),
+        'creating new pre-certificate');
 }
 
 


### PR DESCRIPTION
This makes it a little easier to create a pre-certificate.

I'm not sure if this is worthwhile having as a flag, given the ease of adding the poison extension through other means, but it saves a user having to lookup RFC 6962 and learn how to properly add this extension themselves.
