### PR TITLE
Surround ctx_set_ctlog_list_file() with #ifndef OPENSSL_NO_CT

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -235,6 +235,8 @@ int ctx_set_verify_locations(SSL_CTX *ctx, const char *CAfile,
     return SSL_CTX_load_verify_locations(ctx, CAfile, CApath);
 }
 
+#ifndef OPENSSL_NO_CT
+
 int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path)
 {
     if (path == NULL) {
@@ -243,6 +245,8 @@ int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path)
 
     return SSL_CTX_set_ctlog_list_file(ctx, path);
 }
+
+#endif
 
 int dump_cert_text(BIO *out, X509 *x)
 {

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -491,12 +491,16 @@ __owur int ctx_set_verify_locations(SSL_CTX *ctx, const char *CAfile,
                                     const char *CApath, int noCAfile,
                                     int noCApath);
 
+#ifndef OPENSSL_NO_CT
+
 /*
  * Sets the file to load the Certificate Transparency log list from.
  * If path is NULL, loads from the default file path.
  * Returns 1 on success, 0 otherwise.
  */
 __owur int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
+
+#endif
 
 # ifdef OPENSSL_NO_ENGINE
 #  define setup_engine(engine, debug) NULL

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2569,8 +2569,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
     unsigned char *exportedkeymat;
 #ifndef OPENSSL_NO_CT
     const STACK_OF(SCT) *scts;
-#endif
     const SSL_CTX *ctx = SSL_get_SSL_CTX(s);
+#endif
 
     if (full) {
         int got_a_chain = 0;

--- a/test/ssltest.c
+++ b/test/ssltest.c
@@ -1615,11 +1615,13 @@ int main(int argc, char *argv[])
         /* goto end; */
     }
 
+#ifndef OPENSSL_NO_CT
     if (!SSL_CTX_set_default_ctlog_list_file(s_ctx) ||
         !SSL_CTX_set_default_ctlog_list_file(s_ctx2) ||
         !SSL_CTX_set_default_ctlog_list_file(c_ctx)) {
         ERR_print_errors(bio_err);
     }
+#endif
 
     if (client_auth) {
         printf("client authentication\n");


### PR DESCRIPTION
Fixes builds configured with CT disabled.