### PR TITLE
Workaround for false -Warray-bounds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,6 @@ before_script:
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
       else
-          # No ccache for clang.
-          # Workaround for https://llvm.org/bugs/show_bug.cgi?id=20144
           if which ccache >/dev/null && [ "$CC" != clang-3.6 ]; then
               CC="ccache $CC";
           fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,9 @@ before_script:
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
       else
-          if which ccache >/dev/null; then
+          # No ccache for clang.
+          # Workaround for https://llvm.org/bugs/show_bug.cgi?id=20144
+          if which ccache >/dev/null && [ "$CC" != clang-3.6 ]; then
               CC="ccache $CC";
           fi;
           $srcdir/config $CONFIG_OPTS;


### PR DESCRIPTION
ccache + clang produces a false strcmp warning, see
https://llvm.org/bugs/show_bug.cgi?id=20144

Since this only happens with ccache and --strict-warnings, and
only with certain versions of glibc / clang, disabling
ccache is a reasonable short-term workaround.