### PR TITLE
Fix memory leak in library deinit

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -161,17 +161,6 @@ static EX_CALLBACKS *get_and_lock(int class_index)
 
     ip = &ex_data[class_index];
     CRYPTO_THREAD_write_lock(ex_data_lock);
-    if (ip->meth == NULL) {
-        ip->meth = sk_EX_CALLBACK_new_null();
-        /* We push an initial value on the stack because the SSL
-         * "app_data" routines use ex_data index zero.  See RT 3710. */
-        if (ip->meth == NULL
-            || !sk_EX_CALLBACK_push(ip->meth, NULL)) {
-            CRYPTOerr(CRYPTO_F_GET_AND_LOCK, ERR_R_MALLOC_FAILURE);
-            CRYPTO_THREAD_unlock(ex_data_lock);
-            return NULL;
-        }
-    }
     return ip;
 }
 
@@ -255,6 +244,18 @@ int CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
 
     if (ip == NULL)
         return -1;
+
+    if (ip->meth == NULL) {
+        ip->meth = sk_EX_CALLBACK_new_null();
+        /* We push an initial value on the stack because the SSL
+         * "app_data" routines use ex_data index zero.  See RT 3710. */
+        if (ip->meth == NULL
+            || !sk_EX_CALLBACK_push(ip->meth, NULL)) {
+            CRYPTOerr(CRYPTO_F_GET_AND_LOCK, ERR_R_MALLOC_FAILURE);
+            goto err;
+        }
+    }
+
     a = (EX_CALLBACK *)OPENSSL_malloc(sizeof(*a));
     if (a == NULL) {
         CRYPTOerr(CRYPTO_F_CRYPTO_GET_EX_NEW_INDEX, ERR_R_MALLOC_FAILURE);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -474,12 +474,12 @@ void OPENSSL_cleanup(void)
                     "RAND_cleanup()\n");
 
 #endif
-    CRYPTO_cleanup_all_ex_data();
-    EVP_cleanup();
-    CONF_modules_free();
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_cleanup();
 #endif
+    CRYPTO_cleanup_all_ex_data();
+    EVP_cleanup();
+    CONF_modules_free();
     RAND_cleanup();
     base_inited = 0;
 }
@@ -628,5 +628,3 @@ int OPENSSL_atexit(void (*handler)(void))
 
     return 1;
 }
-
-


### PR DESCRIPTION
ENGINE_cleanup calls CRYPTO_free_ex_data and therefore,
CRYPTO_cleanup_all_ex_data - which cleans up the method pointers - must
run after ENGINE_cleanup.

Additionally, don't needlessly initialize the EX_CALLBACKS stack during
e.g. CRYPTO_free_ex_data. The only time this is actually needed is when
reserving the first ex data index. Specifically, since sk_num returns -1
on NULL input, the rest of the code already handles a NULL method stack
correctly.