### PR TITLE
General verify options to openssl ts

### DIFF
--- a/doc/apps/ts.pod
+++ b/doc/apps/ts.pod
@@ -8,13 +8,12 @@ ts - Time Stamping Authority tool (client/server)
 
 B<openssl> B<ts>
 B<-query>
-[B<-help>]
 [B<-rand> file:file...]
 [B<-config> configfile]
 [B<-data> file_to_hash]
 [B<-digest> digest_bytes]
 [B<-[digest]>]
-[B<-policy> object_id]
+[B<-tspolicy> object_id]
 [B<-no_nonce>]
 [B<-cert>]
 [B<-in> request.tsq]
@@ -31,7 +30,7 @@ B<-reply>
 [B<-inkey> private.pem]
 [B<-sha1|-sha224|-sha256|-sha384|-sha512>]
 [B<-chain> certs_file.pem]
-[B<-policy> object_id]
+[B<-tspolicy> object_id]
 [B<-in> response.tsr]
 [B<-token_in>]
 [B<-out> response.tsr]
@@ -49,6 +48,37 @@ B<-verify>
 [B<-CApath> trusted_cert_path]
 [B<-CAfile> trusted_certs.pem]
 [B<-untrusted> cert_file.pem]
+[I<verify options>]
+
+I<verify options:>
+[-attime timestamp]
+[-check_ss_sig]
+[-crl_check]
+[-crl_check_all]
+[-explicit_policy]
+[-extended_crl]
+[-ignore_critical]
+[-inhibit_any]
+[-inhibit_map]
+[-issuer_checks]
+[-no_alt_chains]
+[-no_check_time]
+[-partial_chain]
+[-policy arg]
+[-policy_check]
+[-policy_print]
+[-purpose purpose]
+[-suiteB_128]
+[-suiteB_128_only]
+[-suiteB_192]
+[-trusted_first]
+[-use_deltas]
+[-verify_depth num]
+[-verify_email email]
+[-verify_hostname hostname]
+[-verify_ip ip]
+[-verify_name name]
+[-x509_strict]
 
 =head1 DESCRIPTION
 
@@ -100,10 +130,6 @@ request with the following options:
 
 =over 4
 
-=item B<-help>
-
-Print out a usage message.
-
 =item B<-rand> file:file...
 
 The files containing random data for seeding the random number
@@ -136,7 +162,7 @@ The message digest to apply to the data file.
 Any digest supported by the OpenSSL B<dgst> command can be used.
 The default is SHA-1. (Optional)
 
-=item B<-policy> object_id
+=item B<-tspolicy> object_id
 
 The policy that the client expects the TSA to use for creating the
 time stamp token. Either the dotted OID notation or OID names defined
@@ -235,7 +261,7 @@ contain the certificate chain for the signer certificate from its
 issuer upwards. The B<-reply> command does not build a certificate
 chain automatically. (Optional)
 
-=item B<-policy> object_id
+=item B<-tspolicy> object_id
 
 The default policy to use for the response unless the client
 explicitly requires a particular TSA policy. The OID can be specified
@@ -343,6 +369,20 @@ certificate. This file must contain the TSA signing certificate and
 all intermediate CA certificates unless the response includes them.
 (Optional)
 
+=item I<verify options>
+
+The options [-attime timestamp], [-check_ss_sig], [-crl_check],
+[-crl_check_all], [-explicit_policy], [-extended_crl],
+[-ignore_critical], [-inhibit_any], [-inhibit_map],
+[-issuer_checks], [-no_alt_chains], [-no_check_time],
+[-partial_chain], [-policy arg], [-policy_check],
+[-policy_print], [-purpose purpose], [-suiteB_128],
+[-suiteB_128_only], [-suiteB_192], [-trusted_first],
+[-use_deltas], [-verify_depth num], [-verify_email email],
+[-verify_hostname hostname], [-verify_ip ip], [-verify_name name], 
+and [-x509_strict] can be used to control timestamp verification. 
+See L<verify(1)>.
+
 =back
 
 =head1 CONFIGURATION FILE OPTIONS
@@ -415,7 +455,7 @@ B<-sha1|-sha224|-sha256|-sha384|-sha512> command line option. (Optional)
 =item B<default_policy>
 
 The default policy to use when the request does not mandate any
-policy. The same as the B<-policy> command line option. (Optional)
+policy. The same as the B<-tspolicy> command line option. (Optional)
 
 =item B<other_policies>
 
@@ -501,7 +541,7 @@ specifies a policy id (assuming the tsa_policy1 name is defined in the
 OID section of the config file):
 
   openssl ts -query -data design2.txt -md5 \
-	-policy tsa_policy1 -cert -out design2.tsq
+	-tspolicy tsa_policy1 -cert -out design2.tsq
 
 =head2 Time Stamp Response
 

--- a/test/recipes/80-test_tsa.t
+++ b/test/recipes/80-test_tsa.t
@@ -98,7 +98,7 @@ indir "tsa" => sub
 
      skip "failed", 16
          unless ok(run(app([@RUN, "-query", "-data", $testtsa,
-                            "-policy", "tsa_policy1", "-cert",
+                            "-tspolicy", "tsa_policy1", "-cert",
                             "-out", "req1.tsq"])),
                    'creating req1.req time stamp request for file testtsa');
 
@@ -132,7 +132,7 @@ indir "tsa" => sub
 
      skip "failed", 10
          unless ok(run(app([@RUN, "-query", "-data", $testtsa,
-                            "-policy", "tsa_policy2", "-no_nonce",
+                            "-tspolicy", "tsa_policy2", "-no_nonce",
                             "-out", "req2.tsq"])),
                    'creating req2.req time stamp request for file testtsa');
 


### PR DESCRIPTION
This commit adds the general verify options of ocsp, verify,
cms, etc. to the openssl timestamping app as suggested by
Stephen N. Henson in [openssl.org #4287]. The conflicting
"-policy" option of "openssl ts" has been renamed to
"-tspolicy". Documentation and tests have been updated.

CAVE: This will break code, which currently uses the "-policy"
option.

See also: Pull request #610 and https://rt.openssl.org/Ticket/Display.html?id=4287 