### PR TITLE
Bugfix for 'no-des' configure option

### DIFF
--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -389,7 +389,13 @@ static int cms_wrap_init(CMS_KeyAgreeRecipientInfo *kari,
      * Pick a cipher based on content encryption cipher. If it is DES3 use
      * DES3 wrap otherwise use AES wrap similar to key size.
      */
+#ifndef OPENSSL_NO_DES
     if (EVP_CIPHER_type(cipher) == NID_des_ede3_cbc)
+        kekcipher = EVP_des_ede3_wrap();
+    else if (keylen <= 16)
+#else
+    if (keylen <= 16)
+#endif
         kekcipher = EVP_des_ede3_wrap();
     else if (keylen <= 16)
         kekcipher = EVP_aes_128_wrap();

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -394,13 +394,14 @@ static int cms_wrap_init(CMS_KeyAgreeRecipientInfo *kari,
         kekcipher = EVP_des_ede3_wrap();
 #endif
 #ifndef OPENSSL_NO_AES
-    if (EVP_CIPHER_type(cipher) != NID_des_ede3_cbc)
+    if (EVP_CIPHER_type(cipher) != NID_des_ede3_cbc) {
       if (keylen <= 16)
           kekcipher = EVP_aes_128_wrap();
       else if (keylen <= 24)
           kekcipher = EVP_aes_192_wrap();
       else
           kekcipher = EVP_aes_256_wrap();
+    }
 #endif
     return EVP_EncryptInit_ex(ctx, kekcipher, NULL, NULL, NULL);
 }

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -392,17 +392,16 @@ static int cms_wrap_init(CMS_KeyAgreeRecipientInfo *kari,
 #ifndef OPENSSL_NO_DES
     if (EVP_CIPHER_type(cipher) == NID_des_ede3_cbc)
         kekcipher = EVP_des_ede3_wrap();
-    else if (keylen <= 16)
-#else
-    if (keylen <= 16)
 #endif
-        kekcipher = EVP_des_ede3_wrap();
-    else if (keylen <= 16)
-        kekcipher = EVP_aes_128_wrap();
-    else if (keylen <= 24)
-        kekcipher = EVP_aes_192_wrap();
-    else
-        kekcipher = EVP_aes_256_wrap();
+#ifndef OPENSSL_NO_AES
+    if (EVP_CIPHER_type(cipher) != NID_des_ede3_cbc)
+      if (keylen <= 16)
+          kekcipher = EVP_aes_128_wrap();
+      else if (keylen <= 24)
+          kekcipher = EVP_aes_192_wrap();
+      else
+          kekcipher = EVP_aes_256_wrap();
+#endif
     return EVP_EncryptInit_ex(ctx, kekcipher, NULL, NULL, NULL);
 }
 


### PR DESCRIPTION
Building with "no-des" fails at crypto/cms/cms_kari.c
```
../libcrypto.a(cms_kari.o): In function `cms_RecipientInfo_kari_encrypt':
cms_kari.c:(.text+0x647): undefined reference to `EVP_des_ede3_wrap'
```


Using:
```
$ uname -s -r -v -m -p -i -o
Linux 2.6.32-573.18.1.el6.x86_64 #1 SMP Wed Jan 6 11:20:49 EST 2016 x86_64 x86_64 x86_64 GNU/Linux
~/sandbox/openssl-1.0.2g
```

The provided commit adds conditional directive and allows the build to complete. 

RT [openssl.org [#4432]](https://rt.openssl.org/Ticket/Display.html?id=4432)