### PR TITLE
Documentation fix: -no_check_time for verify, etc.

### DIFF
--- a/doc/apps/cms.pod
+++ b/doc/apps/cms.pod
@@ -47,6 +47,7 @@ B<openssl> B<cms>
 [B<-ignore_critical>]
 [B<-inhibit_any>]
 [B<-inhibit_map>]
+[B<-no_check_time>]
 [B<-partial_chain>]
 [B<-policy arg>]
 [B<-policy_check>]
@@ -472,7 +473,7 @@ address matches that specified in the From: address.
 
 =item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
 B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
-B<-inhibit_map>, B<-no_alt_chains>, B<-partial_chain>, B<-policy>,
+B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
 B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,
 B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,
 B<-verify_depth>, B<-verify_email>, B<-verify_hostname>, B<-verify_ip>,

--- a/doc/apps/ocsp.pod
+++ b/doc/apps/ocsp.pod
@@ -42,6 +42,7 @@ B<openssl> B<ocsp>
 [B<-ignore_critical>]
 [B<-inhibit_any>]
 [B<-inhibit_map>]
+[B<-no_check_time>]
 [B<-partial_chain>]
 [B<-policy arg>]
 [B<-policy_check>]
@@ -194,7 +195,7 @@ Do not load the trusted CA certificates from the default directory location
 
 =item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
 B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
-B<-inhibit_map>, B<-no_alt_chains>, B<-partial_chain>, B<-policy>,
+B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
 B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,
 B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,
 B<-verify_depth>, B<-verify_email>, B<-verify_hostname>, B<-verify_ip>,

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -34,6 +34,7 @@ B<openssl> B<s_client>
 [B<-ignore_critical>]
 [B<-inhibit_any>]
 [B<-inhibit_map>]
+[B<-no_check_time>]
 [B<-partial_chain>]
 [B<-policy arg>]
 [B<-policy_check>]
@@ -226,7 +227,7 @@ whitespace is ignored in the associated data field.  For example:
 
 =item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
 B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
-B<-inhibit_map>, B<-no_alt_chains>, B<-partial_chain>, B<-policy>,
+B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
 B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,
 B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,
 B<-verify_depth>, B<-verify_email>, B<-verify_hostname>, B<-verify_ip>,

--- a/doc/apps/s_server.pod
+++ b/doc/apps/s_server.pod
@@ -44,6 +44,7 @@ B<openssl> B<s_server>
 [B<-ignore_critical>]
 [B<-inhibit_any>]
 [B<-inhibit_map>]
+[B<-no_check_time>]
 [B<-partial_chain>]
 [B<-policy arg>]
 [B<-policy_check>]
@@ -231,7 +232,7 @@ anonymous ciphersuite or PSK) this option has no effect.
 
 =item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
 B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
-B<-inhibit_map>, B<-no_alt_chains>, B<-partial_chain>, B<-policy>,
+B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
 B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,
 B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,
 B<-verify_depth>, B<-verify_email>, B<-verify_hostname>, B<-verify_ip>,

--- a/doc/apps/verify.pod
+++ b/doc/apps/verify.pod
@@ -24,6 +24,7 @@ B<openssl> B<verify>
 [B<-ignore_critical>]
 [B<-inhibit_any>]
 [B<-inhibit_map>]
+[B<-no_check_time>]
 [B<-partial_chain>]
 [B<-policy arg>]
 [B<-policy_check>]
@@ -143,6 +144,12 @@ Set policy variable inhibit-any-policy (see RFC5280).
 =item B<-inhibit_map>
 
 Set policy variable inhibit-policy-mapping (see RFC5280).
+
+=item B<-no_check_time>
+
+This option suppresses checking the validity period of certificates and CRLs 
+against the current time. If option B<-attime timestamp> is used to specify 
+a verification time, the check is not suppressed.
 
 =item B<-partial_chain>
 


### PR DESCRIPTION
This commit updates the documentation of cms, ocsp, s_client,
s_server, and verify to reflect the new "-no_check_time" option
introduced in commit d35ff2c0ade0a12e84aaa2e9841b4983a2f3cf45
on 2015-07-31.