### PR TITLE
Disable AFALG when cross-compiling

### DIFF
--- a/Configure
+++ b/Configure
@@ -1208,6 +1208,8 @@ unless ($disabled{afalgeng}) {
             } else {
                 push @{$config{engdirs}}, "afalg";
             }
+        } else {
+            $disabled{afalgeng} = "cross-compiling";
         }
     } else {
         $disabled{afalgeng}  = "not-linux";


### PR DESCRIPTION
We don't currently support cross-compiling of the afalg engine. However
we were failing to explicitly mark it as disabled during Configure leading
to a failed build.