### PR TITLE
Fix regression in tls1_alpn_handle_client_hello_late

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1805,6 +1805,8 @@ static int tls1_alpn_handle_client_hello_late(SSL *s, int *ret, int *al)
                 return 0;
             }
             s->s3->alpn_selected_len = selected_len;
+        } else if (r == SSL_TLSEXT_ERR_NOACK) {
+            *al = SSL_AD_NO_APPLICATION_PROTOCOL;
         } else {
             *al = SSL_AD_NO_APPLICATION_PROTOCOL;
             *ret = SSL_TLSEXT_ERR_ALERT_FATAL;


### PR DESCRIPTION
817cd0d52f0462039d1fe60462150be7f59d2002 introduced a regression in the
server-side ALPN handler. The handler treats the callback's return
value SSL_TLSEXT_ERR_NOACK as a fatal protocol error and aborts the
handshake. A ALPN callback returns SSL_TLSEXT_ERR_NOACK when both client
and server advertise ALPN but cannot agree on a mutual protocol.