### PR TITLE
Add memleak checks, and fix one in test apps.

### DIFF
--- a/test/bntest.c
+++ b/test/bntest.c
@@ -154,6 +154,9 @@ int main(int argc, char *argv[])
     BIO *out;
     char *outfile = NULL;
 
+    CRYPTO_set_mem_debug(1);
+    CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
+
     results = 0;
 
     RAND_seed(rnd_seed, sizeof rnd_seed); /* or BN_generate_prime may fail */
@@ -353,12 +356,20 @@ int main(int argc, char *argv[])
     BN_CTX_free(ctx);
     BIO_free(out);
 
+    ERR_print_errors_fp(stderr);
+
+#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+    if (CRYPTO_mem_leaks_fp(stderr) <= 0)
+        EXIT(1);
+#endif
     EXIT(0);
  err:
     BIO_puts(out, "1\n");       /* make sure the Perl script fed by bc
                                  * notices the failure, see test_bn in
                                  * test/Makefile.ssl */
     (void)BIO_flush(out);
+    BN_CTX_free(ctx);
+    BIO_free(out);
 
     ERR_print_errors_fp(stderr);
     EXIT(1);

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -579,6 +579,11 @@ int main(int argc, char *argv[])
     int result = 0;
     char *tmp_env = NULL;
 
+    tmp_env = getenv("OPENSSL_DEBUG_MEMORY");
+    if (tmp_env != NULL && strcmp(tmp_env, "on") == 0)
+        CRYPTO_set_mem_debug(1);
+    CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
+
     tmp_env = getenv("CT_DIR");
     ct_dir = OPENSSL_strdup(tmp_env != NULL ? tmp_env : "ct");
     tmp_env = getenv("CERTS_DIR");
@@ -597,6 +602,11 @@ int main(int argc, char *argv[])
 
     OPENSSL_free(ct_dir);
     OPENSSL_free(certs_dir);
+
+#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+    if (CRYPTO_mem_leaks_fp(stderr) <= 0)
+        result = 1;
+#endif
 
     return result;
 }

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -194,6 +194,7 @@ int main(int argc, char *argv[])
     if (!run_rfc5114_tests())
         ret = 1;
  err:
+    (void)BIO_flush(out);
     ERR_print_errors_fp(stderr);
 
     OPENSSL_free(abuf);
@@ -202,6 +203,12 @@ int main(int argc, char *argv[])
     DH_free(a);
     BN_GENCB_free(_cb);
     BIO_free(out);
+
+#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+    if (CRYPTO_mem_leaks_fp(stderr) <= 0)
+        ret = 1;
+#endif
+
     EXIT(ret);
 }
 


### PR DESCRIPTION
Please take a look at this PR.
It's a issue related to the new locking API used in BIO structures

Previously, a BIO structure could be stack-allocated with no worry.
Now because of the new 'lock' field, it is a memory leak.

IMHO, it's an prioritary hurdle to address .
Various solutions are possible, I let the devteam decide.
