### PR TITLE
New SSL test framework

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -711,7 +711,8 @@ dist:
 
 # Helper targets #####################################################
 
-link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/shlib_wrap.sh
+link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/shlib_wrap.sh \
+	    $(BLDDIR)/test/generate_ssl_tests.pl
 
 $(BLDDIR)/util/opensslwrap.sh: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
@@ -723,7 +724,11 @@ $(BLDDIR)/util/shlib_wrap.sh: configdata.pm
 	    mkdir -p "$(BLDDIR)/util"; \
 	    ln -sf "../$(SRCDIR)/util/shlib_wrap.sh" "$(BLDDIR)/util"; \
 	fi
-
+$(BLDDIR)/test/generate_ssl_tests.pl: configdata.pm
+	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
+	    mkdir -p "$(BLDDIR)/test"; \
+	    ln -sf "../$(SRCDIR)/test/generate_ssl_tests.pl" "$(BLDDIR)/test"; \
+	fi
 FORCE:
 
 # Building targets ###################################################

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -594,8 +594,8 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
 #endif
     SSL_CONF_CMD_STRING(CipherString, "cipher", 0),
     SSL_CONF_CMD_STRING(Protocol, NULL, 0),
-    SSL_CONF_CMD_STRING(MinProtocol, "min_protocol", SSL_CONF_FLAG_SERVER | SSL_CONF_FLAG_CLIENT),
-    SSL_CONF_CMD_STRING(MaxProtocol, "max_protocol", SSL_CONF_FLAG_SERVER | SSL_CONF_FLAG_CLIENT),
+    SSL_CONF_CMD_STRING(MinProtocol, "min_protocol", 0),
+    SSL_CONF_CMD_STRING(MaxProtocol, "max_protocol", 0),
     SSL_CONF_CMD_STRING(Options, NULL, 0),
     SSL_CONF_CMD_STRING(VerifyMode, NULL, 0),
     SSL_CONF_CMD(Certificate, "cert", SSL_CONF_FLAG_CERTIFICATE,

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -397,8 +397,14 @@ $(D2ITEST)$(EXE_EXT): $(D2ITEST).o $(DLIBCRYPTO) testutil.o
 $(SSLTESTCTXTEST)$(EXE_EXT): $(SSLTESTCTXTEST).o testutil.o $(DLIBCRYPTO)
 	@target=$(SSLTESTCTXTEST); $(BUILD_CMD)
 
+$(SSLTESTCTXTEST)$(EXE_EXT): $(SSLTESTCTXTEST).o testutil.o ssl_test_ctx.o \
+	$(DLIBCRYPTO)
+	@target=$(SSLTESTCTXTEST) testutil="testutil.o ssl_test_ctx.o"; \
+	$(BUILD_CMD)
+
 $(NEWSSLTEST)$(EXE_EXT): $(NEWSSLTEST).o testutil.o ssl_test_ctx.o \
 	handshake_helper.o $(DLIBSSL) $(DLIBCRYPTO)
-	@target=$(NEWSSLTEST); $(BUILD_CMD)
+	@target=$(NEWSSLTEST) testutil="testutil.o ssl_test_ctx.o \
+	handshake_helper.o"; $(BUILD_CMD)
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -85,6 +85,8 @@ CTTEST=	ct_test
 THREADSTEST=	threadstest
 AFALGTEST= afalgtest
 D2ITEST = d2i_test
+SSLTESTCTXTEST = ssl_test_ctx_test
+NEWSSLTEST = ssl_test
 
 TESTS=		alltests
 
@@ -107,7 +109,8 @@ EXE=	$(NPTEST)$(EXE_EXT) $(MEMLEAKTEST)$(EXE_EXT) \
 	$(CONSTTIMETEST)$(EXE_EXT) $(VERIFYEXTRATEST)$(EXE_EXT) \
 	$(CLIENTHELLOTEST)$(EXE_EXT) $(PACKETTEST)$(EXE_EXT) $(ASYNCTEST)$(EXE_EXT) \
 	$(DTLSV1LISTENTEST)$(EXE_EXT) $(CTTEST)$(EXE_EXT) $(THREADSTEST)$(EXE_EXT) \
-	$(AFALGTEST)$(EXE_EXT) $(D2ITEST)$(EXE_EXT)
+	$(AFALGTEST)$(EXE_EXT) $(D2ITEST)$(EXE_EXT) $(SSLTESTCTXTEST)$(EXE_EXT) \
+	$(NEWSSLTEST)$(EXE_EXT)
 
 # $(METHTEST)$(EXE_EXT)
 
@@ -125,7 +128,8 @@ OBJ=	$(NPTEST).o $(MEMLEAKTEST).o \
 	$(HEARTBEATTEST).o $(P5_CRPT2_TEST).o \
 	$(CONSTTIMETEST).o $(VERIFYEXTRATEST).o $(CLIENTHELLOTEST).o \
 	$(PACKETTEST).o $(ASYNCTEST).o $(DTLSV1LISTENTEST).o $(CTTEST).o \
-	$(THREADSTEST).o testutil.o $(AFALGTEST).o $(D2ITEST).o
+	$(THREADSTEST).o testutil.o $(AFALGTEST).o $(D2ITEST).o ssl_test_ctx.o \
+	$(SSLTESTCTXTEST).o $(NEWSSLTEST).o handshake_helper.o
 
 SRC=	$(NPTEST).c $(MEMLEAKTEST).c \
 	$(BNTEST).c $(ECTEST).c \
@@ -140,9 +144,10 @@ SRC=	$(NPTEST).c $(MEMLEAKTEST).c \
 	$(HEARTBEATTEST).c $(P5_CRPT2_TEST).c \
 	$(CONSTTIMETEST).c $(VERIFYEXTRATEST).c $(CLIENTHELLOTEST).c \
 	$(PACKETTEST).c $(ASYNCTEST).c $(DTLSV1LISTENTEST).c $(CTTEST).c \
-	$(THREADSTEST).c testutil.c $(AFALGTEST).c $(D2ITEST).c
+	$(THREADSTEST).c testutil.c $(AFALGTEST).c $(D2ITEST).c ssl_test_ctx.c \
+	$(SSLTESTCTXTEST).c $(NEWSSLTEST).c handshake_helper.c
 
-HEADER=	testutil.h
+HEADER=	testutil.h ssl_test_ctx.h handshake_helper.h
 
 ALL=	$(GENERAL) $(SRC) $(HEADER)
 
@@ -388,5 +393,12 @@ $(AFALGTEST)$(EXE_EXT): $(AFALGTEST).o $(DLIBCRYPTO)
 
 $(D2ITEST)$(EXE_EXT): $(D2ITEST).o $(DLIBCRYPTO) testutil.o
 	@target=$(D2ITEST) testutil=testutil.o; $(BUILD_CMD)
+
+$(SSLTESTCTXTEST)$(EXE_EXT): $(SSLTESTCTXTEST).o testutil.o $(DLIBCRYPTO)
+	@target=$(SSLTESTCTXTEST); $(BUILD_CMD)
+
+$(NEWSSLTEST)$(EXE_EXT): $(NEWSSLTEST).o testutil.o ssl_test_ctx.o \
+	handshake_helper.o $(DLIBSSL) $(DLIBCRYPTO)
+	@target=$(NEWSSLTEST); $(BUILD_CMD)
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -16,7 +16,8 @@ generated test, you should run
 ```
 $ ./config
 $ cd test
-$ TOP=.. perl generate_ssl_tests.pl ssl-tests/my.conf.in > ssl-tests/my.conf
+$ TOP=.. perl -I testlib/ generate_ssl_tests.pl ssl-tests/my.conf.in \
+  > ssl-tests/my.conf
 ```
 
 where `my.conf.in` is your test input file.

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -1,0 +1,117 @@
+# SSL tests
+
+SSL testcases are configured in the `ssl-tests` directory.
+
+Each `ssl_*.conf.in` file contains a number of test configurations. These files
+are used to generate testcases in the OpenSSL CONF format.
+
+The precise test output can be dependent on the library configuration. The test
+harness generates the output files on the fly.
+
+However, for verification, we also include checked-in configuration outputs
+corresponding to the default configuration. These testcases live in
+`test/ssl-tests/*.conf` files. Therefore, whenever you're adding or updating a
+generated test, you should run
+
+```
+$ ./config
+$ cd test
+$ TOP=.. perl generate_ssl_tests.pl ssl-tests/my.conf.in > ssl-tests/my.conf
+```
+
+where `my.conf.in` is your test input file.
+
+For example, to generate the test cases in `ssl-tests/01-simple.conf.in`, do
+
+```
+$ TOP=.. perl generate_ssl_tests.pl ssl-tests/01-simple.conf.in > ssl-tests/01-simple.conf
+```
+
+For more details, see `ssl-tests/01-simple.conf.in` for an example.
+
+## Configuring the test
+
+First, give your test a name. The names do not have to be unique.
+
+An example test input looks like this:
+
+```
+    {
+        name => "test-default",
+        server => { "CipherString" => "DEFAULT" },
+        client => { "CipherString" => "DEFAULT" },
+        test   => { "ExpectedResult" => "Success" },
+    }
+```
+
+The test section supports the following options:
+
+* ExpectedResult - expected handshake outcome. One of
+  - Success - handshake success
+  - ServerFail - serverside handshake failure
+  - ClientFail - clientside handshake failure
+  - InternalError - some other error
+  
+* ClientAlert, ServerAlert - expected alert. One of
+  - UnknownCA
+
+* Protocol - expected negotiated protocol. One of
+  SSLv3, TLSv1, TLSv1.1, TLSv1.2.
+
+## Configuring the client and server
+
+The client and server configurations can be any valid `SSL_CTX`
+configurations. For details, see the manpages for `SSL_CONF_cmd`.
+
+Give your configurations as a dictionary of CONF commands, e.g.
+
+```
+server => {
+    "CipherString = DEFAULT",
+    "MinProtocol = TLSv1",
+}
+```
+
+### Default server and client configurations
+
+The default server certificate and CA files are added to the configurations
+automatically. Server certificate verification is requested by default.
+
+You can override these options by redefining them:
+
+```
+client => {
+    "VerifyCAFile" => "/path/to/custom/file"
+}
+```
+
+or by deleting them
+
+```
+client => {
+    "VerifyCAFile" => undef
+}
+```
+
+## Adding a test to the test harness
+
+Add your configuration file to `test/recipes/80-test_ssl_new.t`.
+
+## Running the tests with the test harness
+
+```
+HARNESS_VERBOSE=yes make TESTS=test_ssl_new test
+```
+
+## Running a test manually
+
+Set the `TEST_CERTS_DIR` environment variable to point to the location of the
+certs. E.g., from the root OpenSSL directory, do
+
+```
+$ TEST_CERTS_DIR=test/certs test/ssl_test test/ssl-tests/01-simple.conf
+```
+
+Note that the `test/ssl-tests/*.conf` files correspond to expected outputs in
+the default configuration. To run tests manually in a different configuration,
+you may need to generate the right file from the `*.conf.in` input first.

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -52,9 +52,9 @@ The test section supports the following options:
   - ServerFail - serverside handshake failure
   - ClientFail - clientside handshake failure
   - InternalError - some other error
-  
-* ClientAlert, ServerAlert - expected alert. One of
-  - UnknownCA
+
+* ClientAlert, ServerAlert - expected alert. See `ssl_test_ctx.c` for known
+  values.
 
 * Protocol - expected negotiated protocol. One of
   SSLv3, TLSv1, TLSv1.1, TLSv1.2.
@@ -68,8 +68,8 @@ Give your configurations as a dictionary of CONF commands, e.g.
 
 ```
 server => {
-    "CipherString = DEFAULT",
-    "MinProtocol = TLSv1",
+    "CipherString" => "DEFAULT",
+    "MinProtocol" => "TLSv1",
 }
 ```
 
@@ -106,13 +106,34 @@ HARNESS_VERBOSE=yes make TESTS=test_ssl_new test
 
 ## Running a test manually
 
-Set the `TEST_CERTS_DIR` environment variable to point to the location of the
-certs. E.g., from the root OpenSSL directory, do
+These steps are only needed during development. End users should run `make test`
+or follow the instructions above to run the SSL test suite.
+
+To run an SSL test manually from the command line, the `TEST_CERTS_DIR`
+environment variable to point to the location of the certs. E.g., from the root
+OpenSSL directory, do
 
 ```
 $ TEST_CERTS_DIR=test/certs test/ssl_test test/ssl-tests/01-simple.conf
 ```
 
-Note that the `test/ssl-tests/*.conf` files correspond to expected outputs in
-the default configuration. To run tests manually in a different configuration,
-you may need to generate the right file from the `*.conf.in` input first.
+or for shared builds
+
+```
+$ TEST_CERTS_DIR=test/certs util/shlib_wrap.sh test/ssl_test \
+  test/ssl-tests/01-simple.conf
+```
+
+Note that the test expectations sometimes depend on the Configure settings. For
+example, the negotiated protocol depends on the set of available (enabled)
+protocols: a build with `enable-ssl3` has different test expectations than a
+build with `no-ssl3`.
+
+The Perl test harness automatically generates expected outputs, so users who
+just run `make test` do not need any extra steps.
+
+However, when running a test manually, keep in mind that the repository version
+of the generated `test/ssl-tests/*.conf` correspond to expected outputs in with
+the default Configure options. To run `ssl_test` manually from the command line
+in a build with a different configuration, you may need to generate the right
+`*.conf` file from the `*.conf.in` input first.

--- a/test/build.info
+++ b/test/build.info
@@ -14,7 +14,8 @@ PROGRAMS=\
         danetest heartbeat_test p5_crpt2_test \
         constant_time_test verify_extra_test clienthellotest \
         packettest asynctest secmemtest srptest memleaktest \
-        dtlsv1listentest ct_test threadstest afalgtest d2i_test
+        dtlsv1listentest ct_test threadstest afalgtest d2i_test \
+        ssl_test_ctx_test ssl_test
 
 SOURCE[aborttest]=aborttest.c
 INCLUDE[aborttest]={- rel2abs(catdir($builddir,"../include")) -} ../include
@@ -224,4 +225,14 @@ SOURCE[d2i_test]=d2i_test.c testutil.c
 INCLUDE[d2i_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
 DEPEND[d2i_test]=../libcrypto
 
+SOURCE[ssl_test_ctx_test]=ssl_test_ctx_test.c ssl_test_ctx.c testutil.c
+INCLUDE[ssl_test_ctx_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+DEPEND[ssl_test_ctx_test]=../libcrypto
+
+SOURCE[ssl_test]=ssl_test.c ssl_test_ctx.c testutil.c handshake_helper.c
+INCLUDE[ssl_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+DEPEND[ssl_test]=../libcrypto ../libssl
+
 INCLUDE[testutil.o]=..
+INCLUDE[ssl_test_ctx.o]={- rel2abs(catdir($builddir,"../include")) -} ../include
+INCLUDE[handshake_helper.o]={- rel2abs(catdir($builddir,"../include")) -} ../include

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -9,8 +9,16 @@ use warnings;
 use File::Basename;
 use File::Spec::Functions;
 
-use lib catdir(dirname(__FILE__),"../util");  # for with_fallback
-use lib catdir(dirname(__FILE__),"ssl-tests");  # for ssltests_base
+use OpenSSL::Test qw/srctop_dir srctop_file/;
+use OpenSSL::Test::Utils;
+
+# This block needs to run before 'use lib srctop_dir' directives.
+BEGIN {
+OpenSSL::Test::setup("no_test_here");
+}
+
+use lib srctop_dir("util");  # for with_fallback
+use lib srctop_dir("test", "ssl-tests");  # for ssltests_base
 
 use with_fallback qw(Text::Template);
 
@@ -20,7 +28,8 @@ push (@ISA, qw/Text::Template/);
 use ssltests_base;
 
 sub print_templates {
-    my $template = Text::Template->new(TYPE => 'FILE', SOURCE => "ssl_test.tmpl");
+    my $source = srctop_file("test", "ssl_test.tmpl");
+    my $template = Text::Template->new(TYPE => 'FILE', SOURCE => $source);
 
     print "# Generated with generate_ssl_tests.pl\n\n";
 

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -1,0 +1,97 @@
+#! /usr/bin/perl
+# -*- mode: perl; -*-
+
+## SSL testcase generator
+
+use strict;
+use warnings;
+
+use File::Basename;
+use File::Spec::Functions;
+
+use lib catdir(dirname(__FILE__),"../util");  # for with_fallback
+use lib catdir(dirname(__FILE__),"ssl-tests");  # for ssltests_base
+
+use with_fallback qw(Text::Template);
+
+use vars qw/@ISA/;
+push (@ISA, qw/Text::Template/);
+
+use ssltests_base;
+
+sub print_templates {
+    my $template = Text::Template->new(TYPE => 'FILE', SOURCE => "ssl_test.tmpl");
+
+    print "# Generated with generate_ssl_tests.pl\n\n";
+
+    my $num = scalar @ssltests::tests;
+
+    # Add the implicit base configuration.
+    foreach my $test (@ssltests::tests) {
+        $test->{"server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
+        $test->{"client"} = { (%ssltests::base_client, %{$test->{"client"}}) };
+    }
+
+    # ssl_test expects to find a
+    #
+    # num_tests = n
+    #
+    # directive in the file. It'll then look for configuration directives
+    # for n tests, that each look like this:
+    #
+    # test-n = test-section
+    #
+    # [test-section]
+    # (SSL modules for client and server configuration go here.)
+    #
+    # [test-n]
+    # (Test configuration goes here.)
+    print "num_tests = $num\n\n";
+
+    # The conf module locations must come before everything else, because
+    # they look like
+    #
+    # test-n = test-section
+    #
+    # and you can't mix and match them with sections.
+    my $idx = 0;
+
+    foreach my $test (@ssltests::tests) {
+        my $testname = "${idx}-" . $test->{'name'};
+        print "test-$idx = $testname\n";
+        $idx++;
+    }
+
+    $idx = 0;
+
+    foreach my $test (@ssltests::tests) {
+        my $testname = "${idx}-" . $test->{'name'};
+        my $text = $template->fill_in(
+            HASH => [{ idx => $idx, testname => $testname } , $test],
+            DELIMITERS => [ "{-", "-}" ]);
+        print "# ===========================================================\n\n";
+        print "$text\n";
+        $idx++;
+    }
+}
+
+# Shamelessly copied from Configure.
+sub read_config {
+    my $fname = shift;
+    open(INPUT, "< $fname")
+	or die "Can't open input file '$fname'!\n";
+    my $x = $/;
+    undef $/;
+    my $content = <INPUT>;
+    $/ = $x;
+    close(INPUT);
+    eval $content;
+    warn $@ if $@;
+}
+
+my $input_file = shift;
+# Reads the tests into ssltests::tests.
+read_config($input_file);
+print_templates();
+
+1;

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -14,7 +14,7 @@ use OpenSSL::Test::Utils;
 
 # This block needs to run before 'use lib srctop_dir' directives.
 BEGIN {
-OpenSSL::Test::setup("no_test_here");
+    OpenSSL::Test::setup("no_test_here");
 }
 
 use lib srctop_dir("util");  # for with_fallback
@@ -89,10 +89,8 @@ sub read_config {
     my $fname = shift;
     open(INPUT, "< $fname")
 	or die "Can't open input file '$fname'!\n";
-    my $x = $/;
-    undef $/;
+    local $/ = undef;
     my $content = <INPUT>;
-    $/ = $x;
     close(INPUT);
     eval $content;
     warn $@ if $@;

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL licenses, (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+
+#include "handshake_helper.h"
+
+/*
+ * Since there appears to be no way to extract the sent/received alert
+ * from the SSL object directly, we use the info callback and stash
+ * the result in ex_data.
+ */
+typedef struct handshake_ex_data {
+    int alert_sent;
+    int alert_received;
+} HANDSHAKE_EX_DATA;
+
+static int ex_data_idx;
+
+static void info_callback(const SSL *s, int where, int ret)
+{
+    if (where & SSL_CB_ALERT) {
+        HANDSHAKE_EX_DATA *ex_data =
+            (HANDSHAKE_EX_DATA*)(SSL_get_ex_data(s, ex_data_idx));
+        if (where & SSL_CB_WRITE) {
+            ex_data->alert_sent = ret;
+        } else {
+            ex_data->alert_received = ret;
+        }
+    }
+        /* Else do nothing. */
+}
+
+typedef enum {
+    SUCCESS,
+    RETRY,
+    ERROR
+} peer_status_t;
+
+static peer_status_t do_handshake_step(SSL *ssl)
+{
+    int ret;
+
+    ret = SSL_do_handshake(ssl);
+
+    if (ret == 1) {
+        return SUCCESS;
+    } else if (ret == 0) {
+        return ERROR;
+    } else {
+        int error = SSL_get_error(ssl, ret);
+        if (error == SSL_ERROR_WANT_READ)
+            return RETRY;
+        else
+            return ERROR;
+    }
+}
+
+typedef enum {
+    /* Both parties succeeded. */
+    HANDSHAKE_SUCCESS,
+    /* Client errored. */
+    CLIENT_ERROR,
+    /* Server errored. */
+    SERVER_ERROR,
+    /* Peers are in inconsistent state. */
+    INTERNAL_ERROR,
+    /* One or both peers not done. */
+    HANDSHAKE_RETRY
+} handshake_status_t;
+
+/*
+ * Determine the handshake outcome.
+ * last_status: the status of the peer to have acted last.
+ * previous_status: the status of the peer that didn't act last.
+ * client_went_last: 1 if the client went last.
+ */
+static handshake_status_t handshake_status(peer_status_t last_status,
+                                           peer_status_t previous_status,
+                                           int client_went_last)
+{
+    switch (last_status) {
+    case SUCCESS:
+        switch (previous_status) {
+        case SUCCESS:
+            /* Both succeeded. */
+            return HANDSHAKE_SUCCESS;
+            break;
+        case RETRY:
+            /* Let the first peer finish. */
+            return HANDSHAKE_RETRY;
+        case ERROR:
+            /*
+             * Second peer succeeded despite the fact that the first peer
+             * already errored. This shouldn't happen.
+             */
+            return INTERNAL_ERROR;
+        }
+
+    case RETRY:
+        if (previous_status == RETRY) {
+            /* Neither peer is done. */
+            return HANDSHAKE_RETRY;
+        } else {
+            /*
+             * Deadlock: second peer is waiting for more input while first
+             * peer thinks they're done (no more input is coming).
+             */
+            return INTERNAL_ERROR;
+        }
+    case ERROR:
+        switch (previous_status) {
+        case SUCCESS:
+            /*
+             * First peer succeeded but second peer errored.
+             * TODO(emilia): we should be able to continue here (with some
+             * application data?) to ensure the first peer receives the
+             * alert / close_notify.
+             */
+            return client_went_last ? CLIENT_ERROR : SERVER_ERROR;
+        case RETRY:
+            /* We errored; let the peer finish. */
+            return HANDSHAKE_RETRY;
+        case ERROR:
+            /* Both peers errored. Return the one that errored first. */
+            return client_went_last ? SERVER_ERROR : CLIENT_ERROR;
+        }
+    }
+    /* Control should never reach here. */
+    return INTERNAL_ERROR;
+}
+
+HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx)
+{
+    SSL *server, *client;
+    BIO *client_to_server, *server_to_client;
+    HANDSHAKE_EX_DATA server_ex_data, client_ex_data;
+    HANDSHAKE_RESULT ret;
+    int client_turn = 1;
+    peer_status_t client_status = RETRY, server_status = RETRY;
+    handshake_status_t status = HANDSHAKE_RETRY;
+
+    server = SSL_new(server_ctx);
+    client = SSL_new(client_ctx);
+    OPENSSL_assert(server != NULL && client != NULL);
+
+    memset(&server_ex_data, 0, sizeof(server_ex_data));
+    memset(&client_ex_data, 0, sizeof(client_ex_data));
+    memset(&ret, 0, sizeof(ret));
+    ret.result = SSL_TEST_INTERNAL_ERROR;
+
+    client_to_server = BIO_new(BIO_s_mem());
+    server_to_client = BIO_new(BIO_s_mem());
+
+    OPENSSL_assert(client_to_server != NULL && server_to_client != NULL);
+
+    /* Non-blocking bio. */
+    BIO_set_nbio(client_to_server, 1);
+    BIO_set_nbio(server_to_client, 1);
+
+    SSL_set_connect_state(client);
+    SSL_set_accept_state(server);
+
+    /* The bios are now owned by the SSL object. */
+    SSL_set_bio(client, server_to_client, client_to_server);
+    OPENSSL_assert(BIO_up_ref(server_to_client) > 0);
+    OPENSSL_assert(BIO_up_ref(client_to_server) > 0);
+    SSL_set_bio(server, client_to_server, server_to_client);
+
+    ex_data_idx = SSL_get_ex_new_index(0, "ex data", NULL, NULL, NULL);
+    OPENSSL_assert(ex_data_idx >= 0);
+
+    OPENSSL_assert(SSL_set_ex_data(server, ex_data_idx,
+                                   &server_ex_data) == 1);
+    OPENSSL_assert(SSL_set_ex_data(client, ex_data_idx,
+                                   &client_ex_data) == 1);
+
+    SSL_set_info_callback(server, &info_callback);
+    SSL_set_info_callback(client, &info_callback);
+
+    for(;;) {
+        if (client_turn) {
+            client_status = do_handshake_step(client);
+            status = handshake_status(client_status, server_status,
+                                      1 /* client went last */);
+        } else {
+            server_status = do_handshake_step(server);
+            status = handshake_status(server_status, client_status,
+                                      0 /* server went last */);
+        }
+
+        switch (status) {
+        case HANDSHAKE_SUCCESS:
+            ret.result = SSL_TEST_SUCCESS;
+            goto err;
+        case CLIENT_ERROR:
+            ret.result = SSL_TEST_CLIENT_FAIL;
+            goto err;
+        case SERVER_ERROR:
+            ret.result = SSL_TEST_SERVER_FAIL;
+            goto err;
+        case INTERNAL_ERROR:
+            ret.result = SSL_TEST_INTERNAL_ERROR;
+            goto err;
+        case HANDSHAKE_RETRY:
+            /* Continue. */
+            client_turn ^= 1;
+            break;
+        }
+    }
+ err:
+    ret.server_alert_sent = server_ex_data.alert_sent;
+    ret.server_alert_received = client_ex_data.alert_received;
+    ret.client_alert_sent = client_ex_data.alert_sent;
+    ret.client_alert_received = server_ex_data.alert_received;
+    ret.server_protocol = SSL_version(server);
+    ret.client_protocol = SSL_version(client);
+
+    SSL_free(server);
+    SSL_free(client);
+    return ret;
+}

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL licenses, (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#include "ssl_test_ctx.h"
+
+typedef struct handshake_result {
+    ssl_test_result_t result;
+    /* These alerts are in the 2-byte format returned by the info_callback. */
+    /* Alert sent by the client; 0 if no alert. */
+    int client_alert_sent;
+    /* Alert received by the server; 0 if no alert. */
+    int client_alert_received;
+    /* Alert sent by the server; 0 if no alert. */
+    int server_alert_sent;
+    /* Alert received by the client; 0 if no alert. */
+    int server_alert_received;
+    /* Negotiated protocol. On success, these should always match. */
+    int server_protocol;
+    int client_protocol;
+} HANDSHAKE_RESULT;
+
+/* Do a handshake and report some information about the result. */
+HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx);

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -8,6 +8,9 @@
  * or in the file LICENSE in the source distribution.
  */
 
+#ifndef HEADER_HANDSHAKE_HELPER_H
+#define HEADER_HANDSHAKE_HELPER_H
+
 #include "ssl_test_ctx.h"
 
 typedef struct handshake_result {
@@ -28,3 +31,5 @@ typedef struct handshake_result {
 
 /* Do a handshake and report some information about the result. */
 HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx);
+
+#endif  /* HEADER_HANDSHAKE_HELPER_H */

--- a/test/recipes/80-test_ssl.t
+++ b/test/recipes/80-test_ssl.t
@@ -66,6 +66,9 @@ my $P2intermediate="tmp_intP2.ss";
 my $server_sess="server.ss";
 my $client_sess="client.ss";
 
+# ssltest.c is deprecated in favour of the new framework in ssl_test.c
+# If you're adding tests here, you probably want to convert them to the
+# new format in ssl_test.c and add recipes to 80-test_ssl_new.t instead.
 plan tests =>
     1				# For testss
     + 1				# For ssltest -test_cipherlist

--- a/test/recipes/80-test_ssl.t
+++ b/test/recipes/80-test_ssl.t
@@ -69,7 +69,7 @@ my $client_sess="client.ss";
 plan tests =>
     1				# For testss
     + 1				# For ssltest -test_cipherlist
-    + 15			# For the first testssl
+    + 14			# For the first testssl
     + 16			# For the first testsslproxy
     + 16			# For the second testsslproxy
     ;
@@ -710,55 +710,6 @@ sub testssl {
 
 	  ok(run(test([@ssltest, "-cipher", "AES128-SHA256", "-bytes", "8m"])));
 	}
-    };
-
-    subtest 'TLS Version min/max tests' => sub {
-        my @protos;
-        push(@protos, "ssl3") unless $no_ssl3;
-        push(@protos, "tls1") unless $no_tls1;
-        push(@protos, "tls1.1") unless $no_tls1_1;
-        push(@protos, "tls1.2") unless $no_tls1_2;
-        my @minprotos = (undef, @protos);
-        my @maxprotos = (@protos, undef);
-        my @shdprotos = (@protos, $protos[$#protos]);
-        my $n = ((@protos+2) * (@protos+3))/2 - 2;
-        my $ntests = $n * $n;
-	plan tests => $ntests;
-      SKIP: {
-        skip "TLS disabled", 1 if $ntests == 1;
-
-        my $should;
-        for (my $smin = 0; $smin < @minprotos; ++$smin) {
-        for (my $smax = $smin ? $smin - 1 : 0; $smax < @maxprotos; ++$smax) {
-        for (my $cmin = 0; $cmin < @minprotos; ++$cmin) {
-        for (my $cmax = $cmin ? $cmin - 1 : 0; $cmax < @maxprotos; ++$cmax) {
-            if ($cmax < $smin-1) {
-                $should = "fail-server";
-            } elsif ($smax < $cmin-1) {
-                $should = "fail-client";
-            } elsif ($cmax > $smax) {
-                $should = $shdprotos[$smax];
-            } else {
-                $should = $shdprotos[$cmax];
-            }
-
-            my @args = @ssltest;
-            push(@args, "-should_negotiate", $should);
-            push(@args, "-server_min_proto", $minprotos[$smin])
-                if (defined($minprotos[$smin]));
-            push(@args, "-server_max_proto", $maxprotos[$smax])
-                if (defined($maxprotos[$smax]));
-            push(@args, "-client_min_proto", $minprotos[$cmin])
-                if (defined($minprotos[$cmin]));
-            push(@args, "-client_max_proto", $maxprotos[$cmax])
-                if (defined($maxprotos[$cmax]));
-            my $ok = run(test[@args]);
-            if (! $ok) {
-                print STDERR "\nsmin=$smin, smax=$smax, cmin=$cmin, cmax=$cmax\n";
-                print STDERR "\nFailed: @args\n";
-            }
-            ok($ok);
-        }}}}}
     };
 
     subtest 'DTLS Version min/max tests' => sub {

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -1,0 +1,76 @@
+#! /usr/bin/perl
+
+use strict;
+use warnings;
+
+use File::Compare qw/compare_text/;
+
+use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file/;
+use OpenSSL::Test::Utils qw/disabled alldisabled available_protocols/;
+
+setup("test_ssl_new");
+
+$ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
+
+plan tests => 2;
+
+# 02-protocol-version.conf test results depend on the configuration of enabled
+# protocols. We only verify generated sources in the default configuration.
+my $is_default = (disabled("ssl3") && !disabled("tls1") &&
+                  !disabled("tls1_1") && !disabled("tls1_2"));
+
+# [file, check_source]
+my @conf_files = (["01-simple.conf", 1],
+                  ["02-protocol-version.conf", $is_default]);
+
+foreach my $conf (@conf_files) {
+    subtest "Test configuration $conf->[0]" => sub {
+        test_conf(@$conf);
+    }
+}
+
+sub test_conf {
+    plan tests => 3;
+
+    my ($conf, $check_source) = @_;
+
+    my $conf_file = srctop_file("test", "ssl-tests", $conf);
+    my $tmp_file = srctop_file("test", "ssl-tests", "${conf}.tmp");
+    my $run_test = 1;
+
+  SKIP: {
+      # "Test" 1. Generate the source.
+      my $input_file = $conf_file . ".in";
+
+      skip 'failure', 2 unless
+        ok(run(perltest(["generate_ssl_tests.pl", $input_file],
+                        stdout => $tmp_file)),
+           "Getting output from generate_ssl_tests.pl.");
+
+    SKIP: {
+        # Test 2. Compare against existing output in test/ssl_tests.conf.
+        skip "Skipping generated source test for $conf", 1
+          if !$check_source;
+
+        $run_test = is(cmp_text($tmp_file, $conf_file), 0,
+                       "Comparing generated sources.");
+      }
+
+      # Test 3. Run the test.
+      my $no_tls = alldisabled(available_protocols("tls"));
+      skip "No TLS tests available; skipping tests", 1 if $no_tls;
+      skip "Stale sources; skipping tests", 1 if !$run_test;
+      
+      ok(run(test(["ssl_test", $tmp_file])), "running ssl_test $conf");
+    }
+
+    unlink glob $tmp_file;
+}
+
+sub cmp_text {
+    return compare_text(@_, sub {
+        $_[0] =~ s/\R//g;
+        $_[1] =~ s/\R//g;
+        return $_[0] ne $_[1];
+    });
+}

--- a/test/recipes/80-test_ssl_test_ctx.t
+++ b/test/recipes/80-test_ssl_test_ctx.t
@@ -1,0 +1,12 @@
+#! /usr/bin/perl
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_ssl_test_ctx");
+
+plan tests => 1;
+ok(run(test(["ssl_test_ctx_test", srctop_file("test", "ssl_test_ctx_test.conf")])),
+   "running ssl_test_ctx_test ssl_test_ctx_test.conf");

--- a/test/ssl-tests/01-simple.conf
+++ b/test/ssl-tests/01-simple.conf
@@ -1,0 +1,56 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 2
+
+test-0 = 0-default
+test-1 = 1-verify-cert
+# ===========================================================
+
+[0-default]
+ssl_conf = 0-default-ssl
+
+[0-default-ssl]
+server = 0-default-server
+client = 0-default-client
+
+[0-default-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-default-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-0]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[1-verify-cert]
+ssl_conf = 1-verify-cert-ssl
+
+[1-verify-cert-ssl]
+server = 1-verify-cert-server
+client = 1-verify-cert-client
+
+[1-verify-cert-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-verify-cert-client]
+CipherString = DEFAULT
+VerifyMode = Peer
+
+
+[test-1]
+ClientAlert = UnknownCA
+ExpectedResult = ClientFail
+
+

--- a/test/ssl-tests/01-simple.conf.in
+++ b/test/ssl-tests/01-simple.conf.in
@@ -1,0 +1,27 @@
+# -*- mode: perl; -*-
+
+## SSL test configurations
+
+package ssltests;
+
+our @tests = (
+    {
+        name => "default",
+        server => { },
+        client => { },
+        test   => { "ExpectedResult" => "Success" },
+    },
+
+    {
+        name => "verify-cert",
+        server => { },
+        client => {
+            # Don't set up the client root file.
+            "VerifyCAFile" => undef,
+        },
+        test   => {
+          "ExpectedResult" => "ClientFail",
+          "ClientAlert" => "UnknownCA",
+        },
+    },
+);

--- a/test/ssl-tests/02-protocol-version.conf
+++ b/test/ssl-tests/02-protocol-version.conf
@@ -1,0 +1,10697 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 361
+
+test-0 = 0-version-negotiation
+test-1 = 1-version-negotiation
+test-2 = 2-version-negotiation
+test-3 = 3-version-negotiation
+test-4 = 4-version-negotiation
+test-5 = 5-version-negotiation
+test-6 = 6-version-negotiation
+test-7 = 7-version-negotiation
+test-8 = 8-version-negotiation
+test-9 = 9-version-negotiation
+test-10 = 10-version-negotiation
+test-11 = 11-version-negotiation
+test-12 = 12-version-negotiation
+test-13 = 13-version-negotiation
+test-14 = 14-version-negotiation
+test-15 = 15-version-negotiation
+test-16 = 16-version-negotiation
+test-17 = 17-version-negotiation
+test-18 = 18-version-negotiation
+test-19 = 19-version-negotiation
+test-20 = 20-version-negotiation
+test-21 = 21-version-negotiation
+test-22 = 22-version-negotiation
+test-23 = 23-version-negotiation
+test-24 = 24-version-negotiation
+test-25 = 25-version-negotiation
+test-26 = 26-version-negotiation
+test-27 = 27-version-negotiation
+test-28 = 28-version-negotiation
+test-29 = 29-version-negotiation
+test-30 = 30-version-negotiation
+test-31 = 31-version-negotiation
+test-32 = 32-version-negotiation
+test-33 = 33-version-negotiation
+test-34 = 34-version-negotiation
+test-35 = 35-version-negotiation
+test-36 = 36-version-negotiation
+test-37 = 37-version-negotiation
+test-38 = 38-version-negotiation
+test-39 = 39-version-negotiation
+test-40 = 40-version-negotiation
+test-41 = 41-version-negotiation
+test-42 = 42-version-negotiation
+test-43 = 43-version-negotiation
+test-44 = 44-version-negotiation
+test-45 = 45-version-negotiation
+test-46 = 46-version-negotiation
+test-47 = 47-version-negotiation
+test-48 = 48-version-negotiation
+test-49 = 49-version-negotiation
+test-50 = 50-version-negotiation
+test-51 = 51-version-negotiation
+test-52 = 52-version-negotiation
+test-53 = 53-version-negotiation
+test-54 = 54-version-negotiation
+test-55 = 55-version-negotiation
+test-56 = 56-version-negotiation
+test-57 = 57-version-negotiation
+test-58 = 58-version-negotiation
+test-59 = 59-version-negotiation
+test-60 = 60-version-negotiation
+test-61 = 61-version-negotiation
+test-62 = 62-version-negotiation
+test-63 = 63-version-negotiation
+test-64 = 64-version-negotiation
+test-65 = 65-version-negotiation
+test-66 = 66-version-negotiation
+test-67 = 67-version-negotiation
+test-68 = 68-version-negotiation
+test-69 = 69-version-negotiation
+test-70 = 70-version-negotiation
+test-71 = 71-version-negotiation
+test-72 = 72-version-negotiation
+test-73 = 73-version-negotiation
+test-74 = 74-version-negotiation
+test-75 = 75-version-negotiation
+test-76 = 76-version-negotiation
+test-77 = 77-version-negotiation
+test-78 = 78-version-negotiation
+test-79 = 79-version-negotiation
+test-80 = 80-version-negotiation
+test-81 = 81-version-negotiation
+test-82 = 82-version-negotiation
+test-83 = 83-version-negotiation
+test-84 = 84-version-negotiation
+test-85 = 85-version-negotiation
+test-86 = 86-version-negotiation
+test-87 = 87-version-negotiation
+test-88 = 88-version-negotiation
+test-89 = 89-version-negotiation
+test-90 = 90-version-negotiation
+test-91 = 91-version-negotiation
+test-92 = 92-version-negotiation
+test-93 = 93-version-negotiation
+test-94 = 94-version-negotiation
+test-95 = 95-version-negotiation
+test-96 = 96-version-negotiation
+test-97 = 97-version-negotiation
+test-98 = 98-version-negotiation
+test-99 = 99-version-negotiation
+test-100 = 100-version-negotiation
+test-101 = 101-version-negotiation
+test-102 = 102-version-negotiation
+test-103 = 103-version-negotiation
+test-104 = 104-version-negotiation
+test-105 = 105-version-negotiation
+test-106 = 106-version-negotiation
+test-107 = 107-version-negotiation
+test-108 = 108-version-negotiation
+test-109 = 109-version-negotiation
+test-110 = 110-version-negotiation
+test-111 = 111-version-negotiation
+test-112 = 112-version-negotiation
+test-113 = 113-version-negotiation
+test-114 = 114-version-negotiation
+test-115 = 115-version-negotiation
+test-116 = 116-version-negotiation
+test-117 = 117-version-negotiation
+test-118 = 118-version-negotiation
+test-119 = 119-version-negotiation
+test-120 = 120-version-negotiation
+test-121 = 121-version-negotiation
+test-122 = 122-version-negotiation
+test-123 = 123-version-negotiation
+test-124 = 124-version-negotiation
+test-125 = 125-version-negotiation
+test-126 = 126-version-negotiation
+test-127 = 127-version-negotiation
+test-128 = 128-version-negotiation
+test-129 = 129-version-negotiation
+test-130 = 130-version-negotiation
+test-131 = 131-version-negotiation
+test-132 = 132-version-negotiation
+test-133 = 133-version-negotiation
+test-134 = 134-version-negotiation
+test-135 = 135-version-negotiation
+test-136 = 136-version-negotiation
+test-137 = 137-version-negotiation
+test-138 = 138-version-negotiation
+test-139 = 139-version-negotiation
+test-140 = 140-version-negotiation
+test-141 = 141-version-negotiation
+test-142 = 142-version-negotiation
+test-143 = 143-version-negotiation
+test-144 = 144-version-negotiation
+test-145 = 145-version-negotiation
+test-146 = 146-version-negotiation
+test-147 = 147-version-negotiation
+test-148 = 148-version-negotiation
+test-149 = 149-version-negotiation
+test-150 = 150-version-negotiation
+test-151 = 151-version-negotiation
+test-152 = 152-version-negotiation
+test-153 = 153-version-negotiation
+test-154 = 154-version-negotiation
+test-155 = 155-version-negotiation
+test-156 = 156-version-negotiation
+test-157 = 157-version-negotiation
+test-158 = 158-version-negotiation
+test-159 = 159-version-negotiation
+test-160 = 160-version-negotiation
+test-161 = 161-version-negotiation
+test-162 = 162-version-negotiation
+test-163 = 163-version-negotiation
+test-164 = 164-version-negotiation
+test-165 = 165-version-negotiation
+test-166 = 166-version-negotiation
+test-167 = 167-version-negotiation
+test-168 = 168-version-negotiation
+test-169 = 169-version-negotiation
+test-170 = 170-version-negotiation
+test-171 = 171-version-negotiation
+test-172 = 172-version-negotiation
+test-173 = 173-version-negotiation
+test-174 = 174-version-negotiation
+test-175 = 175-version-negotiation
+test-176 = 176-version-negotiation
+test-177 = 177-version-negotiation
+test-178 = 178-version-negotiation
+test-179 = 179-version-negotiation
+test-180 = 180-version-negotiation
+test-181 = 181-version-negotiation
+test-182 = 182-version-negotiation
+test-183 = 183-version-negotiation
+test-184 = 184-version-negotiation
+test-185 = 185-version-negotiation
+test-186 = 186-version-negotiation
+test-187 = 187-version-negotiation
+test-188 = 188-version-negotiation
+test-189 = 189-version-negotiation
+test-190 = 190-version-negotiation
+test-191 = 191-version-negotiation
+test-192 = 192-version-negotiation
+test-193 = 193-version-negotiation
+test-194 = 194-version-negotiation
+test-195 = 195-version-negotiation
+test-196 = 196-version-negotiation
+test-197 = 197-version-negotiation
+test-198 = 198-version-negotiation
+test-199 = 199-version-negotiation
+test-200 = 200-version-negotiation
+test-201 = 201-version-negotiation
+test-202 = 202-version-negotiation
+test-203 = 203-version-negotiation
+test-204 = 204-version-negotiation
+test-205 = 205-version-negotiation
+test-206 = 206-version-negotiation
+test-207 = 207-version-negotiation
+test-208 = 208-version-negotiation
+test-209 = 209-version-negotiation
+test-210 = 210-version-negotiation
+test-211 = 211-version-negotiation
+test-212 = 212-version-negotiation
+test-213 = 213-version-negotiation
+test-214 = 214-version-negotiation
+test-215 = 215-version-negotiation
+test-216 = 216-version-negotiation
+test-217 = 217-version-negotiation
+test-218 = 218-version-negotiation
+test-219 = 219-version-negotiation
+test-220 = 220-version-negotiation
+test-221 = 221-version-negotiation
+test-222 = 222-version-negotiation
+test-223 = 223-version-negotiation
+test-224 = 224-version-negotiation
+test-225 = 225-version-negotiation
+test-226 = 226-version-negotiation
+test-227 = 227-version-negotiation
+test-228 = 228-version-negotiation
+test-229 = 229-version-negotiation
+test-230 = 230-version-negotiation
+test-231 = 231-version-negotiation
+test-232 = 232-version-negotiation
+test-233 = 233-version-negotiation
+test-234 = 234-version-negotiation
+test-235 = 235-version-negotiation
+test-236 = 236-version-negotiation
+test-237 = 237-version-negotiation
+test-238 = 238-version-negotiation
+test-239 = 239-version-negotiation
+test-240 = 240-version-negotiation
+test-241 = 241-version-negotiation
+test-242 = 242-version-negotiation
+test-243 = 243-version-negotiation
+test-244 = 244-version-negotiation
+test-245 = 245-version-negotiation
+test-246 = 246-version-negotiation
+test-247 = 247-version-negotiation
+test-248 = 248-version-negotiation
+test-249 = 249-version-negotiation
+test-250 = 250-version-negotiation
+test-251 = 251-version-negotiation
+test-252 = 252-version-negotiation
+test-253 = 253-version-negotiation
+test-254 = 254-version-negotiation
+test-255 = 255-version-negotiation
+test-256 = 256-version-negotiation
+test-257 = 257-version-negotiation
+test-258 = 258-version-negotiation
+test-259 = 259-version-negotiation
+test-260 = 260-version-negotiation
+test-261 = 261-version-negotiation
+test-262 = 262-version-negotiation
+test-263 = 263-version-negotiation
+test-264 = 264-version-negotiation
+test-265 = 265-version-negotiation
+test-266 = 266-version-negotiation
+test-267 = 267-version-negotiation
+test-268 = 268-version-negotiation
+test-269 = 269-version-negotiation
+test-270 = 270-version-negotiation
+test-271 = 271-version-negotiation
+test-272 = 272-version-negotiation
+test-273 = 273-version-negotiation
+test-274 = 274-version-negotiation
+test-275 = 275-version-negotiation
+test-276 = 276-version-negotiation
+test-277 = 277-version-negotiation
+test-278 = 278-version-negotiation
+test-279 = 279-version-negotiation
+test-280 = 280-version-negotiation
+test-281 = 281-version-negotiation
+test-282 = 282-version-negotiation
+test-283 = 283-version-negotiation
+test-284 = 284-version-negotiation
+test-285 = 285-version-negotiation
+test-286 = 286-version-negotiation
+test-287 = 287-version-negotiation
+test-288 = 288-version-negotiation
+test-289 = 289-version-negotiation
+test-290 = 290-version-negotiation
+test-291 = 291-version-negotiation
+test-292 = 292-version-negotiation
+test-293 = 293-version-negotiation
+test-294 = 294-version-negotiation
+test-295 = 295-version-negotiation
+test-296 = 296-version-negotiation
+test-297 = 297-version-negotiation
+test-298 = 298-version-negotiation
+test-299 = 299-version-negotiation
+test-300 = 300-version-negotiation
+test-301 = 301-version-negotiation
+test-302 = 302-version-negotiation
+test-303 = 303-version-negotiation
+test-304 = 304-version-negotiation
+test-305 = 305-version-negotiation
+test-306 = 306-version-negotiation
+test-307 = 307-version-negotiation
+test-308 = 308-version-negotiation
+test-309 = 309-version-negotiation
+test-310 = 310-version-negotiation
+test-311 = 311-version-negotiation
+test-312 = 312-version-negotiation
+test-313 = 313-version-negotiation
+test-314 = 314-version-negotiation
+test-315 = 315-version-negotiation
+test-316 = 316-version-negotiation
+test-317 = 317-version-negotiation
+test-318 = 318-version-negotiation
+test-319 = 319-version-negotiation
+test-320 = 320-version-negotiation
+test-321 = 321-version-negotiation
+test-322 = 322-version-negotiation
+test-323 = 323-version-negotiation
+test-324 = 324-version-negotiation
+test-325 = 325-version-negotiation
+test-326 = 326-version-negotiation
+test-327 = 327-version-negotiation
+test-328 = 328-version-negotiation
+test-329 = 329-version-negotiation
+test-330 = 330-version-negotiation
+test-331 = 331-version-negotiation
+test-332 = 332-version-negotiation
+test-333 = 333-version-negotiation
+test-334 = 334-version-negotiation
+test-335 = 335-version-negotiation
+test-336 = 336-version-negotiation
+test-337 = 337-version-negotiation
+test-338 = 338-version-negotiation
+test-339 = 339-version-negotiation
+test-340 = 340-version-negotiation
+test-341 = 341-version-negotiation
+test-342 = 342-version-negotiation
+test-343 = 343-version-negotiation
+test-344 = 344-version-negotiation
+test-345 = 345-version-negotiation
+test-346 = 346-version-negotiation
+test-347 = 347-version-negotiation
+test-348 = 348-version-negotiation
+test-349 = 349-version-negotiation
+test-350 = 350-version-negotiation
+test-351 = 351-version-negotiation
+test-352 = 352-version-negotiation
+test-353 = 353-version-negotiation
+test-354 = 354-version-negotiation
+test-355 = 355-version-negotiation
+test-356 = 356-version-negotiation
+test-357 = 357-version-negotiation
+test-358 = 358-version-negotiation
+test-359 = 359-version-negotiation
+test-360 = 360-version-negotiation
+# ===========================================================
+
+[0-version-negotiation]
+ssl_conf = 0-version-negotiation-ssl
+
+[0-version-negotiation-ssl]
+server = 0-version-negotiation-server
+client = 0-version-negotiation-client
+
+[0-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-0]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[1-version-negotiation]
+ssl_conf = 1-version-negotiation-ssl
+
+[1-version-negotiation-ssl]
+server = 1-version-negotiation-server
+client = 1-version-negotiation-client
+
+[1-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-1]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[2-version-negotiation]
+ssl_conf = 2-version-negotiation-ssl
+
+[2-version-negotiation-ssl]
+server = 2-version-negotiation-server
+client = 2-version-negotiation-client
+
+[2-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[2-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-2]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[3-version-negotiation]
+ssl_conf = 3-version-negotiation-ssl
+
+[3-version-negotiation-ssl]
+server = 3-version-negotiation-server
+client = 3-version-negotiation-client
+
+[3-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[3-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-3]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[4-version-negotiation]
+ssl_conf = 4-version-negotiation-ssl
+
+[4-version-negotiation-ssl]
+server = 4-version-negotiation-server
+client = 4-version-negotiation-client
+
+[4-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[4-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-4]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[5-version-negotiation]
+ssl_conf = 5-version-negotiation-ssl
+
+[5-version-negotiation-ssl]
+server = 5-version-negotiation-server
+client = 5-version-negotiation-client
+
+[5-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[5-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-5]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[6-version-negotiation]
+ssl_conf = 6-version-negotiation-ssl
+
+[6-version-negotiation-ssl]
+server = 6-version-negotiation-server
+client = 6-version-negotiation-client
+
+[6-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[6-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-6]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[7-version-negotiation]
+ssl_conf = 7-version-negotiation-ssl
+
+[7-version-negotiation-ssl]
+server = 7-version-negotiation-server
+client = 7-version-negotiation-client
+
+[7-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[7-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-7]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[8-version-negotiation]
+ssl_conf = 8-version-negotiation-ssl
+
+[8-version-negotiation-ssl]
+server = 8-version-negotiation-server
+client = 8-version-negotiation-client
+
+[8-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[8-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-8]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[9-version-negotiation]
+ssl_conf = 9-version-negotiation-ssl
+
+[9-version-negotiation-ssl]
+server = 9-version-negotiation-server
+client = 9-version-negotiation-client
+
+[9-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[9-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-9]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[10-version-negotiation]
+ssl_conf = 10-version-negotiation-ssl
+
+[10-version-negotiation-ssl]
+server = 10-version-negotiation-server
+client = 10-version-negotiation-client
+
+[10-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[10-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-10]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[11-version-negotiation]
+ssl_conf = 11-version-negotiation-ssl
+
+[11-version-negotiation-ssl]
+server = 11-version-negotiation-server
+client = 11-version-negotiation-client
+
+[11-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[11-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-11]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[12-version-negotiation]
+ssl_conf = 12-version-negotiation-ssl
+
+[12-version-negotiation-ssl]
+server = 12-version-negotiation-server
+client = 12-version-negotiation-client
+
+[12-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[12-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-12]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[13-version-negotiation]
+ssl_conf = 13-version-negotiation-ssl
+
+[13-version-negotiation-ssl]
+server = 13-version-negotiation-server
+client = 13-version-negotiation-client
+
+[13-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[13-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-13]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[14-version-negotiation]
+ssl_conf = 14-version-negotiation-ssl
+
+[14-version-negotiation-ssl]
+server = 14-version-negotiation-server
+client = 14-version-negotiation-client
+
+[14-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[14-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-14]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[15-version-negotiation]
+ssl_conf = 15-version-negotiation-ssl
+
+[15-version-negotiation-ssl]
+server = 15-version-negotiation-server
+client = 15-version-negotiation-client
+
+[15-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[15-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-15]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[16-version-negotiation]
+ssl_conf = 16-version-negotiation-ssl
+
+[16-version-negotiation-ssl]
+server = 16-version-negotiation-server
+client = 16-version-negotiation-client
+
+[16-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[16-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-16]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[17-version-negotiation]
+ssl_conf = 17-version-negotiation-ssl
+
+[17-version-negotiation-ssl]
+server = 17-version-negotiation-server
+client = 17-version-negotiation-client
+
+[17-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[17-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-17]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[18-version-negotiation]
+ssl_conf = 18-version-negotiation-ssl
+
+[18-version-negotiation-ssl]
+server = 18-version-negotiation-server
+client = 18-version-negotiation-client
+
+[18-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[18-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-18]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[19-version-negotiation]
+ssl_conf = 19-version-negotiation-ssl
+
+[19-version-negotiation-ssl]
+server = 19-version-negotiation-server
+client = 19-version-negotiation-client
+
+[19-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[19-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-19]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[20-version-negotiation]
+ssl_conf = 20-version-negotiation-ssl
+
+[20-version-negotiation-ssl]
+server = 20-version-negotiation-server
+client = 20-version-negotiation-client
+
+[20-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[20-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-20]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[21-version-negotiation]
+ssl_conf = 21-version-negotiation-ssl
+
+[21-version-negotiation-ssl]
+server = 21-version-negotiation-server
+client = 21-version-negotiation-client
+
+[21-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[21-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-21]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[22-version-negotiation]
+ssl_conf = 22-version-negotiation-ssl
+
+[22-version-negotiation-ssl]
+server = 22-version-negotiation-server
+client = 22-version-negotiation-client
+
+[22-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[22-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-22]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[23-version-negotiation]
+ssl_conf = 23-version-negotiation-ssl
+
+[23-version-negotiation-ssl]
+server = 23-version-negotiation-server
+client = 23-version-negotiation-client
+
+[23-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[23-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-23]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[24-version-negotiation]
+ssl_conf = 24-version-negotiation-ssl
+
+[24-version-negotiation-ssl]
+server = 24-version-negotiation-server
+client = 24-version-negotiation-client
+
+[24-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[24-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-24]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[25-version-negotiation]
+ssl_conf = 25-version-negotiation-ssl
+
+[25-version-negotiation-ssl]
+server = 25-version-negotiation-server
+client = 25-version-negotiation-client
+
+[25-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[25-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-25]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[26-version-negotiation]
+ssl_conf = 26-version-negotiation-ssl
+
+[26-version-negotiation-ssl]
+server = 26-version-negotiation-server
+client = 26-version-negotiation-client
+
+[26-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[26-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-26]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[27-version-negotiation]
+ssl_conf = 27-version-negotiation-ssl
+
+[27-version-negotiation-ssl]
+server = 27-version-negotiation-server
+client = 27-version-negotiation-client
+
+[27-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[27-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-27]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[28-version-negotiation]
+ssl_conf = 28-version-negotiation-ssl
+
+[28-version-negotiation-ssl]
+server = 28-version-negotiation-server
+client = 28-version-negotiation-client
+
+[28-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[28-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-28]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[29-version-negotiation]
+ssl_conf = 29-version-negotiation-ssl
+
+[29-version-negotiation-ssl]
+server = 29-version-negotiation-server
+client = 29-version-negotiation-client
+
+[29-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[29-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-29]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[30-version-negotiation]
+ssl_conf = 30-version-negotiation-ssl
+
+[30-version-negotiation-ssl]
+server = 30-version-negotiation-server
+client = 30-version-negotiation-client
+
+[30-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[30-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-30]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[31-version-negotiation]
+ssl_conf = 31-version-negotiation-ssl
+
+[31-version-negotiation-ssl]
+server = 31-version-negotiation-server
+client = 31-version-negotiation-client
+
+[31-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[31-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-31]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[32-version-negotiation]
+ssl_conf = 32-version-negotiation-ssl
+
+[32-version-negotiation-ssl]
+server = 32-version-negotiation-server
+client = 32-version-negotiation-client
+
+[32-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[32-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-32]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[33-version-negotiation]
+ssl_conf = 33-version-negotiation-ssl
+
+[33-version-negotiation-ssl]
+server = 33-version-negotiation-server
+client = 33-version-negotiation-client
+
+[33-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[33-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-33]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[34-version-negotiation]
+ssl_conf = 34-version-negotiation-ssl
+
+[34-version-negotiation-ssl]
+server = 34-version-negotiation-server
+client = 34-version-negotiation-client
+
+[34-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[34-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-34]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[35-version-negotiation]
+ssl_conf = 35-version-negotiation-ssl
+
+[35-version-negotiation-ssl]
+server = 35-version-negotiation-server
+client = 35-version-negotiation-client
+
+[35-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[35-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-35]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[36-version-negotiation]
+ssl_conf = 36-version-negotiation-ssl
+
+[36-version-negotiation-ssl]
+server = 36-version-negotiation-server
+client = 36-version-negotiation-client
+
+[36-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[36-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-36]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[37-version-negotiation]
+ssl_conf = 37-version-negotiation-ssl
+
+[37-version-negotiation-ssl]
+server = 37-version-negotiation-server
+client = 37-version-negotiation-client
+
+[37-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[37-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-37]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[38-version-negotiation]
+ssl_conf = 38-version-negotiation-ssl
+
+[38-version-negotiation-ssl]
+server = 38-version-negotiation-server
+client = 38-version-negotiation-client
+
+[38-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[38-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-38]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[39-version-negotiation]
+ssl_conf = 39-version-negotiation-ssl
+
+[39-version-negotiation-ssl]
+server = 39-version-negotiation-server
+client = 39-version-negotiation-client
+
+[39-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[39-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-39]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[40-version-negotiation]
+ssl_conf = 40-version-negotiation-ssl
+
+[40-version-negotiation-ssl]
+server = 40-version-negotiation-server
+client = 40-version-negotiation-client
+
+[40-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[40-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-40]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[41-version-negotiation]
+ssl_conf = 41-version-negotiation-ssl
+
+[41-version-negotiation-ssl]
+server = 41-version-negotiation-server
+client = 41-version-negotiation-client
+
+[41-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[41-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-41]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[42-version-negotiation]
+ssl_conf = 42-version-negotiation-ssl
+
+[42-version-negotiation-ssl]
+server = 42-version-negotiation-server
+client = 42-version-negotiation-client
+
+[42-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[42-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-42]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[43-version-negotiation]
+ssl_conf = 43-version-negotiation-ssl
+
+[43-version-negotiation-ssl]
+server = 43-version-negotiation-server
+client = 43-version-negotiation-client
+
+[43-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[43-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-43]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[44-version-negotiation]
+ssl_conf = 44-version-negotiation-ssl
+
+[44-version-negotiation-ssl]
+server = 44-version-negotiation-server
+client = 44-version-negotiation-client
+
+[44-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[44-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-44]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[45-version-negotiation]
+ssl_conf = 45-version-negotiation-ssl
+
+[45-version-negotiation-ssl]
+server = 45-version-negotiation-server
+client = 45-version-negotiation-client
+
+[45-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[45-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-45]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[46-version-negotiation]
+ssl_conf = 46-version-negotiation-ssl
+
+[46-version-negotiation-ssl]
+server = 46-version-negotiation-server
+client = 46-version-negotiation-client
+
+[46-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[46-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-46]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[47-version-negotiation]
+ssl_conf = 47-version-negotiation-ssl
+
+[47-version-negotiation-ssl]
+server = 47-version-negotiation-server
+client = 47-version-negotiation-client
+
+[47-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[47-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-47]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[48-version-negotiation]
+ssl_conf = 48-version-negotiation-ssl
+
+[48-version-negotiation-ssl]
+server = 48-version-negotiation-server
+client = 48-version-negotiation-client
+
+[48-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[48-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-48]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[49-version-negotiation]
+ssl_conf = 49-version-negotiation-ssl
+
+[49-version-negotiation-ssl]
+server = 49-version-negotiation-server
+client = 49-version-negotiation-client
+
+[49-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[49-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-49]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[50-version-negotiation]
+ssl_conf = 50-version-negotiation-ssl
+
+[50-version-negotiation-ssl]
+server = 50-version-negotiation-server
+client = 50-version-negotiation-client
+
+[50-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[50-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-50]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[51-version-negotiation]
+ssl_conf = 51-version-negotiation-ssl
+
+[51-version-negotiation-ssl]
+server = 51-version-negotiation-server
+client = 51-version-negotiation-client
+
+[51-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[51-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-51]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[52-version-negotiation]
+ssl_conf = 52-version-negotiation-ssl
+
+[52-version-negotiation-ssl]
+server = 52-version-negotiation-server
+client = 52-version-negotiation-client
+
+[52-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[52-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-52]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[53-version-negotiation]
+ssl_conf = 53-version-negotiation-ssl
+
+[53-version-negotiation-ssl]
+server = 53-version-negotiation-server
+client = 53-version-negotiation-client
+
+[53-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[53-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-53]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[54-version-negotiation]
+ssl_conf = 54-version-negotiation-ssl
+
+[54-version-negotiation-ssl]
+server = 54-version-negotiation-server
+client = 54-version-negotiation-client
+
+[54-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[54-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-54]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[55-version-negotiation]
+ssl_conf = 55-version-negotiation-ssl
+
+[55-version-negotiation-ssl]
+server = 55-version-negotiation-server
+client = 55-version-negotiation-client
+
+[55-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[55-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-55]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[56-version-negotiation]
+ssl_conf = 56-version-negotiation-ssl
+
+[56-version-negotiation-ssl]
+server = 56-version-negotiation-server
+client = 56-version-negotiation-client
+
+[56-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[56-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-56]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[57-version-negotiation]
+ssl_conf = 57-version-negotiation-ssl
+
+[57-version-negotiation-ssl]
+server = 57-version-negotiation-server
+client = 57-version-negotiation-client
+
+[57-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[57-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-57]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[58-version-negotiation]
+ssl_conf = 58-version-negotiation-ssl
+
+[58-version-negotiation-ssl]
+server = 58-version-negotiation-server
+client = 58-version-negotiation-client
+
+[58-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[58-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-58]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[59-version-negotiation]
+ssl_conf = 59-version-negotiation-ssl
+
+[59-version-negotiation-ssl]
+server = 59-version-negotiation-server
+client = 59-version-negotiation-client
+
+[59-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[59-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-59]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[60-version-negotiation]
+ssl_conf = 60-version-negotiation-ssl
+
+[60-version-negotiation-ssl]
+server = 60-version-negotiation-server
+client = 60-version-negotiation-client
+
+[60-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[60-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-60]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[61-version-negotiation]
+ssl_conf = 61-version-negotiation-ssl
+
+[61-version-negotiation-ssl]
+server = 61-version-negotiation-server
+client = 61-version-negotiation-client
+
+[61-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[61-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-61]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[62-version-negotiation]
+ssl_conf = 62-version-negotiation-ssl
+
+[62-version-negotiation-ssl]
+server = 62-version-negotiation-server
+client = 62-version-negotiation-client
+
+[62-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[62-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-62]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[63-version-negotiation]
+ssl_conf = 63-version-negotiation-ssl
+
+[63-version-negotiation-ssl]
+server = 63-version-negotiation-server
+client = 63-version-negotiation-client
+
+[63-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[63-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-63]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[64-version-negotiation]
+ssl_conf = 64-version-negotiation-ssl
+
+[64-version-negotiation-ssl]
+server = 64-version-negotiation-server
+client = 64-version-negotiation-client
+
+[64-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[64-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-64]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[65-version-negotiation]
+ssl_conf = 65-version-negotiation-ssl
+
+[65-version-negotiation-ssl]
+server = 65-version-negotiation-server
+client = 65-version-negotiation-client
+
+[65-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[65-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-65]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[66-version-negotiation]
+ssl_conf = 66-version-negotiation-ssl
+
+[66-version-negotiation-ssl]
+server = 66-version-negotiation-server
+client = 66-version-negotiation-client
+
+[66-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[66-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-66]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[67-version-negotiation]
+ssl_conf = 67-version-negotiation-ssl
+
+[67-version-negotiation-ssl]
+server = 67-version-negotiation-server
+client = 67-version-negotiation-client
+
+[67-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[67-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-67]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[68-version-negotiation]
+ssl_conf = 68-version-negotiation-ssl
+
+[68-version-negotiation-ssl]
+server = 68-version-negotiation-server
+client = 68-version-negotiation-client
+
+[68-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[68-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-68]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[69-version-negotiation]
+ssl_conf = 69-version-negotiation-ssl
+
+[69-version-negotiation-ssl]
+server = 69-version-negotiation-server
+client = 69-version-negotiation-client
+
+[69-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[69-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-69]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[70-version-negotiation]
+ssl_conf = 70-version-negotiation-ssl
+
+[70-version-negotiation-ssl]
+server = 70-version-negotiation-server
+client = 70-version-negotiation-client
+
+[70-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[70-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-70]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[71-version-negotiation]
+ssl_conf = 71-version-negotiation-ssl
+
+[71-version-negotiation-ssl]
+server = 71-version-negotiation-server
+client = 71-version-negotiation-client
+
+[71-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[71-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-71]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[72-version-negotiation]
+ssl_conf = 72-version-negotiation-ssl
+
+[72-version-negotiation-ssl]
+server = 72-version-negotiation-server
+client = 72-version-negotiation-client
+
+[72-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[72-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-72]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[73-version-negotiation]
+ssl_conf = 73-version-negotiation-ssl
+
+[73-version-negotiation-ssl]
+server = 73-version-negotiation-server
+client = 73-version-negotiation-client
+
+[73-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[73-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-73]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[74-version-negotiation]
+ssl_conf = 74-version-negotiation-ssl
+
+[74-version-negotiation-ssl]
+server = 74-version-negotiation-server
+client = 74-version-negotiation-client
+
+[74-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[74-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-74]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[75-version-negotiation]
+ssl_conf = 75-version-negotiation-ssl
+
+[75-version-negotiation-ssl]
+server = 75-version-negotiation-server
+client = 75-version-negotiation-client
+
+[75-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[75-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-75]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[76-version-negotiation]
+ssl_conf = 76-version-negotiation-ssl
+
+[76-version-negotiation-ssl]
+server = 76-version-negotiation-server
+client = 76-version-negotiation-client
+
+[76-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[76-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-76]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[77-version-negotiation]
+ssl_conf = 77-version-negotiation-ssl
+
+[77-version-negotiation-ssl]
+server = 77-version-negotiation-server
+client = 77-version-negotiation-client
+
+[77-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[77-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-77]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[78-version-negotiation]
+ssl_conf = 78-version-negotiation-ssl
+
+[78-version-negotiation-ssl]
+server = 78-version-negotiation-server
+client = 78-version-negotiation-client
+
+[78-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[78-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-78]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[79-version-negotiation]
+ssl_conf = 79-version-negotiation-ssl
+
+[79-version-negotiation-ssl]
+server = 79-version-negotiation-server
+client = 79-version-negotiation-client
+
+[79-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[79-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-79]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[80-version-negotiation]
+ssl_conf = 80-version-negotiation-ssl
+
+[80-version-negotiation-ssl]
+server = 80-version-negotiation-server
+client = 80-version-negotiation-client
+
+[80-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[80-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-80]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[81-version-negotiation]
+ssl_conf = 81-version-negotiation-ssl
+
+[81-version-negotiation-ssl]
+server = 81-version-negotiation-server
+client = 81-version-negotiation-client
+
+[81-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[81-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-81]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[82-version-negotiation]
+ssl_conf = 82-version-negotiation-ssl
+
+[82-version-negotiation-ssl]
+server = 82-version-negotiation-server
+client = 82-version-negotiation-client
+
+[82-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[82-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-82]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[83-version-negotiation]
+ssl_conf = 83-version-negotiation-ssl
+
+[83-version-negotiation-ssl]
+server = 83-version-negotiation-server
+client = 83-version-negotiation-client
+
+[83-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[83-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-83]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[84-version-negotiation]
+ssl_conf = 84-version-negotiation-ssl
+
+[84-version-negotiation-ssl]
+server = 84-version-negotiation-server
+client = 84-version-negotiation-client
+
+[84-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[84-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-84]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[85-version-negotiation]
+ssl_conf = 85-version-negotiation-ssl
+
+[85-version-negotiation-ssl]
+server = 85-version-negotiation-server
+client = 85-version-negotiation-client
+
+[85-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[85-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-85]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[86-version-negotiation]
+ssl_conf = 86-version-negotiation-ssl
+
+[86-version-negotiation-ssl]
+server = 86-version-negotiation-server
+client = 86-version-negotiation-client
+
+[86-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[86-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-86]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[87-version-negotiation]
+ssl_conf = 87-version-negotiation-ssl
+
+[87-version-negotiation-ssl]
+server = 87-version-negotiation-server
+client = 87-version-negotiation-client
+
+[87-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[87-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-87]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[88-version-negotiation]
+ssl_conf = 88-version-negotiation-ssl
+
+[88-version-negotiation-ssl]
+server = 88-version-negotiation-server
+client = 88-version-negotiation-client
+
+[88-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[88-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-88]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[89-version-negotiation]
+ssl_conf = 89-version-negotiation-ssl
+
+[89-version-negotiation-ssl]
+server = 89-version-negotiation-server
+client = 89-version-negotiation-client
+
+[89-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[89-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-89]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[90-version-negotiation]
+ssl_conf = 90-version-negotiation-ssl
+
+[90-version-negotiation-ssl]
+server = 90-version-negotiation-server
+client = 90-version-negotiation-client
+
+[90-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[90-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-90]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[91-version-negotiation]
+ssl_conf = 91-version-negotiation-ssl
+
+[91-version-negotiation-ssl]
+server = 91-version-negotiation-server
+client = 91-version-negotiation-client
+
+[91-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[91-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-91]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[92-version-negotiation]
+ssl_conf = 92-version-negotiation-ssl
+
+[92-version-negotiation-ssl]
+server = 92-version-negotiation-server
+client = 92-version-negotiation-client
+
+[92-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[92-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-92]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[93-version-negotiation]
+ssl_conf = 93-version-negotiation-ssl
+
+[93-version-negotiation-ssl]
+server = 93-version-negotiation-server
+client = 93-version-negotiation-client
+
+[93-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[93-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-93]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[94-version-negotiation]
+ssl_conf = 94-version-negotiation-ssl
+
+[94-version-negotiation-ssl]
+server = 94-version-negotiation-server
+client = 94-version-negotiation-client
+
+[94-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[94-version-negotiation-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-94]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[95-version-negotiation]
+ssl_conf = 95-version-negotiation-ssl
+
+[95-version-negotiation-ssl]
+server = 95-version-negotiation-server
+client = 95-version-negotiation-client
+
+[95-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[95-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-95]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[96-version-negotiation]
+ssl_conf = 96-version-negotiation-ssl
+
+[96-version-negotiation-ssl]
+server = 96-version-negotiation-server
+client = 96-version-negotiation-client
+
+[96-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[96-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-96]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[97-version-negotiation]
+ssl_conf = 97-version-negotiation-ssl
+
+[97-version-negotiation-ssl]
+server = 97-version-negotiation-server
+client = 97-version-negotiation-client
+
+[97-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[97-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-97]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[98-version-negotiation]
+ssl_conf = 98-version-negotiation-ssl
+
+[98-version-negotiation-ssl]
+server = 98-version-negotiation-server
+client = 98-version-negotiation-client
+
+[98-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[98-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-98]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[99-version-negotiation]
+ssl_conf = 99-version-negotiation-ssl
+
+[99-version-negotiation-ssl]
+server = 99-version-negotiation-server
+client = 99-version-negotiation-client
+
+[99-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[99-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-99]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[100-version-negotiation]
+ssl_conf = 100-version-negotiation-ssl
+
+[100-version-negotiation-ssl]
+server = 100-version-negotiation-server
+client = 100-version-negotiation-client
+
+[100-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[100-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-100]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[101-version-negotiation]
+ssl_conf = 101-version-negotiation-ssl
+
+[101-version-negotiation-ssl]
+server = 101-version-negotiation-server
+client = 101-version-negotiation-client
+
+[101-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[101-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-101]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[102-version-negotiation]
+ssl_conf = 102-version-negotiation-ssl
+
+[102-version-negotiation-ssl]
+server = 102-version-negotiation-server
+client = 102-version-negotiation-client
+
+[102-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[102-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-102]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[103-version-negotiation]
+ssl_conf = 103-version-negotiation-ssl
+
+[103-version-negotiation-ssl]
+server = 103-version-negotiation-server
+client = 103-version-negotiation-client
+
+[103-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[103-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-103]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[104-version-negotiation]
+ssl_conf = 104-version-negotiation-ssl
+
+[104-version-negotiation-ssl]
+server = 104-version-negotiation-server
+client = 104-version-negotiation-client
+
+[104-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[104-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-104]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[105-version-negotiation]
+ssl_conf = 105-version-negotiation-ssl
+
+[105-version-negotiation-ssl]
+server = 105-version-negotiation-server
+client = 105-version-negotiation-client
+
+[105-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[105-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-105]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[106-version-negotiation]
+ssl_conf = 106-version-negotiation-ssl
+
+[106-version-negotiation-ssl]
+server = 106-version-negotiation-server
+client = 106-version-negotiation-client
+
+[106-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[106-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-106]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[107-version-negotiation]
+ssl_conf = 107-version-negotiation-ssl
+
+[107-version-negotiation-ssl]
+server = 107-version-negotiation-server
+client = 107-version-negotiation-client
+
+[107-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[107-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-107]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[108-version-negotiation]
+ssl_conf = 108-version-negotiation-ssl
+
+[108-version-negotiation-ssl]
+server = 108-version-negotiation-server
+client = 108-version-negotiation-client
+
+[108-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[108-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-108]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[109-version-negotiation]
+ssl_conf = 109-version-negotiation-ssl
+
+[109-version-negotiation-ssl]
+server = 109-version-negotiation-server
+client = 109-version-negotiation-client
+
+[109-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[109-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-109]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[110-version-negotiation]
+ssl_conf = 110-version-negotiation-ssl
+
+[110-version-negotiation-ssl]
+server = 110-version-negotiation-server
+client = 110-version-negotiation-client
+
+[110-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[110-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-110]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[111-version-negotiation]
+ssl_conf = 111-version-negotiation-ssl
+
+[111-version-negotiation-ssl]
+server = 111-version-negotiation-server
+client = 111-version-negotiation-client
+
+[111-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[111-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-111]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[112-version-negotiation]
+ssl_conf = 112-version-negotiation-ssl
+
+[112-version-negotiation-ssl]
+server = 112-version-negotiation-server
+client = 112-version-negotiation-client
+
+[112-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[112-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-112]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[113-version-negotiation]
+ssl_conf = 113-version-negotiation-ssl
+
+[113-version-negotiation-ssl]
+server = 113-version-negotiation-server
+client = 113-version-negotiation-client
+
+[113-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[113-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-113]
+ExpectedResult = InternalError
+
+
+# ===========================================================
+
+[114-version-negotiation]
+ssl_conf = 114-version-negotiation-ssl
+
+[114-version-negotiation-ssl]
+server = 114-version-negotiation-server
+client = 114-version-negotiation-client
+
+[114-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[114-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-114]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[115-version-negotiation]
+ssl_conf = 115-version-negotiation-ssl
+
+[115-version-negotiation-ssl]
+server = 115-version-negotiation-server
+client = 115-version-negotiation-client
+
+[115-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[115-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-115]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[116-version-negotiation]
+ssl_conf = 116-version-negotiation-ssl
+
+[116-version-negotiation-ssl]
+server = 116-version-negotiation-server
+client = 116-version-negotiation-client
+
+[116-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[116-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-116]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[117-version-negotiation]
+ssl_conf = 117-version-negotiation-ssl
+
+[117-version-negotiation-ssl]
+server = 117-version-negotiation-server
+client = 117-version-negotiation-client
+
+[117-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[117-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-117]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[118-version-negotiation]
+ssl_conf = 118-version-negotiation-ssl
+
+[118-version-negotiation-ssl]
+server = 118-version-negotiation-server
+client = 118-version-negotiation-client
+
+[118-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[118-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-118]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[119-version-negotiation]
+ssl_conf = 119-version-negotiation-ssl
+
+[119-version-negotiation-ssl]
+server = 119-version-negotiation-server
+client = 119-version-negotiation-client
+
+[119-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[119-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-119]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[120-version-negotiation]
+ssl_conf = 120-version-negotiation-ssl
+
+[120-version-negotiation-ssl]
+server = 120-version-negotiation-server
+client = 120-version-negotiation-client
+
+[120-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[120-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-120]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[121-version-negotiation]
+ssl_conf = 121-version-negotiation-ssl
+
+[121-version-negotiation-ssl]
+server = 121-version-negotiation-server
+client = 121-version-negotiation-client
+
+[121-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[121-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-121]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[122-version-negotiation]
+ssl_conf = 122-version-negotiation-ssl
+
+[122-version-negotiation-ssl]
+server = 122-version-negotiation-server
+client = 122-version-negotiation-client
+
+[122-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[122-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-122]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[123-version-negotiation]
+ssl_conf = 123-version-negotiation-ssl
+
+[123-version-negotiation-ssl]
+server = 123-version-negotiation-server
+client = 123-version-negotiation-client
+
+[123-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[123-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-123]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[124-version-negotiation]
+ssl_conf = 124-version-negotiation-ssl
+
+[124-version-negotiation-ssl]
+server = 124-version-negotiation-server
+client = 124-version-negotiation-client
+
+[124-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[124-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-124]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[125-version-negotiation]
+ssl_conf = 125-version-negotiation-ssl
+
+[125-version-negotiation-ssl]
+server = 125-version-negotiation-server
+client = 125-version-negotiation-client
+
+[125-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[125-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-125]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[126-version-negotiation]
+ssl_conf = 126-version-negotiation-ssl
+
+[126-version-negotiation-ssl]
+server = 126-version-negotiation-server
+client = 126-version-negotiation-client
+
+[126-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[126-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-126]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[127-version-negotiation]
+ssl_conf = 127-version-negotiation-ssl
+
+[127-version-negotiation-ssl]
+server = 127-version-negotiation-server
+client = 127-version-negotiation-client
+
+[127-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[127-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-127]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[128-version-negotiation]
+ssl_conf = 128-version-negotiation-ssl
+
+[128-version-negotiation-ssl]
+server = 128-version-negotiation-server
+client = 128-version-negotiation-client
+
+[128-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[128-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-128]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[129-version-negotiation]
+ssl_conf = 129-version-negotiation-ssl
+
+[129-version-negotiation-ssl]
+server = 129-version-negotiation-server
+client = 129-version-negotiation-client
+
+[129-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[129-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-129]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[130-version-negotiation]
+ssl_conf = 130-version-negotiation-ssl
+
+[130-version-negotiation-ssl]
+server = 130-version-negotiation-server
+client = 130-version-negotiation-client
+
+[130-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[130-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-130]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[131-version-negotiation]
+ssl_conf = 131-version-negotiation-ssl
+
+[131-version-negotiation-ssl]
+server = 131-version-negotiation-server
+client = 131-version-negotiation-client
+
+[131-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[131-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-131]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[132-version-negotiation]
+ssl_conf = 132-version-negotiation-ssl
+
+[132-version-negotiation-ssl]
+server = 132-version-negotiation-server
+client = 132-version-negotiation-client
+
+[132-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[132-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-132]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[133-version-negotiation]
+ssl_conf = 133-version-negotiation-ssl
+
+[133-version-negotiation-ssl]
+server = 133-version-negotiation-server
+client = 133-version-negotiation-client
+
+[133-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[133-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-133]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[134-version-negotiation]
+ssl_conf = 134-version-negotiation-ssl
+
+[134-version-negotiation-ssl]
+server = 134-version-negotiation-server
+client = 134-version-negotiation-client
+
+[134-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[134-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-134]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[135-version-negotiation]
+ssl_conf = 135-version-negotiation-ssl
+
+[135-version-negotiation-ssl]
+server = 135-version-negotiation-server
+client = 135-version-negotiation-client
+
+[135-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[135-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-135]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[136-version-negotiation]
+ssl_conf = 136-version-negotiation-ssl
+
+[136-version-negotiation-ssl]
+server = 136-version-negotiation-server
+client = 136-version-negotiation-client
+
+[136-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[136-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-136]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[137-version-negotiation]
+ssl_conf = 137-version-negotiation-ssl
+
+[137-version-negotiation-ssl]
+server = 137-version-negotiation-server
+client = 137-version-negotiation-client
+
+[137-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[137-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-137]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[138-version-negotiation]
+ssl_conf = 138-version-negotiation-ssl
+
+[138-version-negotiation-ssl]
+server = 138-version-negotiation-server
+client = 138-version-negotiation-client
+
+[138-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[138-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-138]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[139-version-negotiation]
+ssl_conf = 139-version-negotiation-ssl
+
+[139-version-negotiation-ssl]
+server = 139-version-negotiation-server
+client = 139-version-negotiation-client
+
+[139-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[139-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-139]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[140-version-negotiation]
+ssl_conf = 140-version-negotiation-ssl
+
+[140-version-negotiation-ssl]
+server = 140-version-negotiation-server
+client = 140-version-negotiation-client
+
+[140-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[140-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-140]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[141-version-negotiation]
+ssl_conf = 141-version-negotiation-ssl
+
+[141-version-negotiation-ssl]
+server = 141-version-negotiation-server
+client = 141-version-negotiation-client
+
+[141-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[141-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-141]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[142-version-negotiation]
+ssl_conf = 142-version-negotiation-ssl
+
+[142-version-negotiation-ssl]
+server = 142-version-negotiation-server
+client = 142-version-negotiation-client
+
+[142-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[142-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-142]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[143-version-negotiation]
+ssl_conf = 143-version-negotiation-ssl
+
+[143-version-negotiation-ssl]
+server = 143-version-negotiation-server
+client = 143-version-negotiation-client
+
+[143-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[143-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-143]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[144-version-negotiation]
+ssl_conf = 144-version-negotiation-ssl
+
+[144-version-negotiation-ssl]
+server = 144-version-negotiation-server
+client = 144-version-negotiation-client
+
+[144-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[144-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-144]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[145-version-negotiation]
+ssl_conf = 145-version-negotiation-ssl
+
+[145-version-negotiation-ssl]
+server = 145-version-negotiation-server
+client = 145-version-negotiation-client
+
+[145-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[145-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-145]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[146-version-negotiation]
+ssl_conf = 146-version-negotiation-ssl
+
+[146-version-negotiation-ssl]
+server = 146-version-negotiation-server
+client = 146-version-negotiation-client
+
+[146-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[146-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-146]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[147-version-negotiation]
+ssl_conf = 147-version-negotiation-ssl
+
+[147-version-negotiation-ssl]
+server = 147-version-negotiation-server
+client = 147-version-negotiation-client
+
+[147-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[147-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-147]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[148-version-negotiation]
+ssl_conf = 148-version-negotiation-ssl
+
+[148-version-negotiation-ssl]
+server = 148-version-negotiation-server
+client = 148-version-negotiation-client
+
+[148-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[148-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-148]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[149-version-negotiation]
+ssl_conf = 149-version-negotiation-ssl
+
+[149-version-negotiation-ssl]
+server = 149-version-negotiation-server
+client = 149-version-negotiation-client
+
+[149-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[149-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-149]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[150-version-negotiation]
+ssl_conf = 150-version-negotiation-ssl
+
+[150-version-negotiation-ssl]
+server = 150-version-negotiation-server
+client = 150-version-negotiation-client
+
+[150-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[150-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-150]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[151-version-negotiation]
+ssl_conf = 151-version-negotiation-ssl
+
+[151-version-negotiation-ssl]
+server = 151-version-negotiation-server
+client = 151-version-negotiation-client
+
+[151-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[151-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-151]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[152-version-negotiation]
+ssl_conf = 152-version-negotiation-ssl
+
+[152-version-negotiation-ssl]
+server = 152-version-negotiation-server
+client = 152-version-negotiation-client
+
+[152-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[152-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-152]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[153-version-negotiation]
+ssl_conf = 153-version-negotiation-ssl
+
+[153-version-negotiation-ssl]
+server = 153-version-negotiation-server
+client = 153-version-negotiation-client
+
+[153-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[153-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-153]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[154-version-negotiation]
+ssl_conf = 154-version-negotiation-ssl
+
+[154-version-negotiation-ssl]
+server = 154-version-negotiation-server
+client = 154-version-negotiation-client
+
+[154-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[154-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-154]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[155-version-negotiation]
+ssl_conf = 155-version-negotiation-ssl
+
+[155-version-negotiation-ssl]
+server = 155-version-negotiation-server
+client = 155-version-negotiation-client
+
+[155-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[155-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-155]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[156-version-negotiation]
+ssl_conf = 156-version-negotiation-ssl
+
+[156-version-negotiation-ssl]
+server = 156-version-negotiation-server
+client = 156-version-negotiation-client
+
+[156-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[156-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-156]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[157-version-negotiation]
+ssl_conf = 157-version-negotiation-ssl
+
+[157-version-negotiation-ssl]
+server = 157-version-negotiation-server
+client = 157-version-negotiation-client
+
+[157-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[157-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-157]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[158-version-negotiation]
+ssl_conf = 158-version-negotiation-ssl
+
+[158-version-negotiation-ssl]
+server = 158-version-negotiation-server
+client = 158-version-negotiation-client
+
+[158-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[158-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-158]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[159-version-negotiation]
+ssl_conf = 159-version-negotiation-ssl
+
+[159-version-negotiation-ssl]
+server = 159-version-negotiation-server
+client = 159-version-negotiation-client
+
+[159-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[159-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-159]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[160-version-negotiation]
+ssl_conf = 160-version-negotiation-ssl
+
+[160-version-negotiation-ssl]
+server = 160-version-negotiation-server
+client = 160-version-negotiation-client
+
+[160-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[160-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-160]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[161-version-negotiation]
+ssl_conf = 161-version-negotiation-ssl
+
+[161-version-negotiation-ssl]
+server = 161-version-negotiation-server
+client = 161-version-negotiation-client
+
+[161-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[161-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-161]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[162-version-negotiation]
+ssl_conf = 162-version-negotiation-ssl
+
+[162-version-negotiation-ssl]
+server = 162-version-negotiation-server
+client = 162-version-negotiation-client
+
+[162-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[162-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-162]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[163-version-negotiation]
+ssl_conf = 163-version-negotiation-ssl
+
+[163-version-negotiation-ssl]
+server = 163-version-negotiation-server
+client = 163-version-negotiation-client
+
+[163-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[163-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-163]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[164-version-negotiation]
+ssl_conf = 164-version-negotiation-ssl
+
+[164-version-negotiation-ssl]
+server = 164-version-negotiation-server
+client = 164-version-negotiation-client
+
+[164-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[164-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-164]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[165-version-negotiation]
+ssl_conf = 165-version-negotiation-ssl
+
+[165-version-negotiation-ssl]
+server = 165-version-negotiation-server
+client = 165-version-negotiation-client
+
+[165-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[165-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-165]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[166-version-negotiation]
+ssl_conf = 166-version-negotiation-ssl
+
+[166-version-negotiation-ssl]
+server = 166-version-negotiation-server
+client = 166-version-negotiation-client
+
+[166-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[166-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-166]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[167-version-negotiation]
+ssl_conf = 167-version-negotiation-ssl
+
+[167-version-negotiation-ssl]
+server = 167-version-negotiation-server
+client = 167-version-negotiation-client
+
+[167-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[167-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-167]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[168-version-negotiation]
+ssl_conf = 168-version-negotiation-ssl
+
+[168-version-negotiation-ssl]
+server = 168-version-negotiation-server
+client = 168-version-negotiation-client
+
+[168-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[168-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-168]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[169-version-negotiation]
+ssl_conf = 169-version-negotiation-ssl
+
+[169-version-negotiation-ssl]
+server = 169-version-negotiation-server
+client = 169-version-negotiation-client
+
+[169-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[169-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-169]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[170-version-negotiation]
+ssl_conf = 170-version-negotiation-ssl
+
+[170-version-negotiation-ssl]
+server = 170-version-negotiation-server
+client = 170-version-negotiation-client
+
+[170-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[170-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-170]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[171-version-negotiation]
+ssl_conf = 171-version-negotiation-ssl
+
+[171-version-negotiation-ssl]
+server = 171-version-negotiation-server
+client = 171-version-negotiation-client
+
+[171-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[171-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-171]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[172-version-negotiation]
+ssl_conf = 172-version-negotiation-ssl
+
+[172-version-negotiation-ssl]
+server = 172-version-negotiation-server
+client = 172-version-negotiation-client
+
+[172-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[172-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-172]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[173-version-negotiation]
+ssl_conf = 173-version-negotiation-ssl
+
+[173-version-negotiation-ssl]
+server = 173-version-negotiation-server
+client = 173-version-negotiation-client
+
+[173-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[173-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-173]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[174-version-negotiation]
+ssl_conf = 174-version-negotiation-ssl
+
+[174-version-negotiation-ssl]
+server = 174-version-negotiation-server
+client = 174-version-negotiation-client
+
+[174-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[174-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-174]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[175-version-negotiation]
+ssl_conf = 175-version-negotiation-ssl
+
+[175-version-negotiation-ssl]
+server = 175-version-negotiation-server
+client = 175-version-negotiation-client
+
+[175-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[175-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-175]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[176-version-negotiation]
+ssl_conf = 176-version-negotiation-ssl
+
+[176-version-negotiation-ssl]
+server = 176-version-negotiation-server
+client = 176-version-negotiation-client
+
+[176-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[176-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-176]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[177-version-negotiation]
+ssl_conf = 177-version-negotiation-ssl
+
+[177-version-negotiation-ssl]
+server = 177-version-negotiation-server
+client = 177-version-negotiation-client
+
+[177-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[177-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-177]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[178-version-negotiation]
+ssl_conf = 178-version-negotiation-ssl
+
+[178-version-negotiation-ssl]
+server = 178-version-negotiation-server
+client = 178-version-negotiation-client
+
+[178-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[178-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-178]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[179-version-negotiation]
+ssl_conf = 179-version-negotiation-ssl
+
+[179-version-negotiation-ssl]
+server = 179-version-negotiation-server
+client = 179-version-negotiation-client
+
+[179-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[179-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-179]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[180-version-negotiation]
+ssl_conf = 180-version-negotiation-ssl
+
+[180-version-negotiation-ssl]
+server = 180-version-negotiation-server
+client = 180-version-negotiation-client
+
+[180-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[180-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-180]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[181-version-negotiation]
+ssl_conf = 181-version-negotiation-ssl
+
+[181-version-negotiation-ssl]
+server = 181-version-negotiation-server
+client = 181-version-negotiation-client
+
+[181-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[181-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-181]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[182-version-negotiation]
+ssl_conf = 182-version-negotiation-ssl
+
+[182-version-negotiation-ssl]
+server = 182-version-negotiation-server
+client = 182-version-negotiation-client
+
+[182-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[182-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-182]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[183-version-negotiation]
+ssl_conf = 183-version-negotiation-ssl
+
+[183-version-negotiation-ssl]
+server = 183-version-negotiation-server
+client = 183-version-negotiation-client
+
+[183-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[183-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-183]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[184-version-negotiation]
+ssl_conf = 184-version-negotiation-ssl
+
+[184-version-negotiation-ssl]
+server = 184-version-negotiation-server
+client = 184-version-negotiation-client
+
+[184-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[184-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-184]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[185-version-negotiation]
+ssl_conf = 185-version-negotiation-ssl
+
+[185-version-negotiation-ssl]
+server = 185-version-negotiation-server
+client = 185-version-negotiation-client
+
+[185-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[185-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-185]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[186-version-negotiation]
+ssl_conf = 186-version-negotiation-ssl
+
+[186-version-negotiation-ssl]
+server = 186-version-negotiation-server
+client = 186-version-negotiation-client
+
+[186-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[186-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-186]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[187-version-negotiation]
+ssl_conf = 187-version-negotiation-ssl
+
+[187-version-negotiation-ssl]
+server = 187-version-negotiation-server
+client = 187-version-negotiation-client
+
+[187-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[187-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-187]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[188-version-negotiation]
+ssl_conf = 188-version-negotiation-ssl
+
+[188-version-negotiation-ssl]
+server = 188-version-negotiation-server
+client = 188-version-negotiation-client
+
+[188-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[188-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-188]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[189-version-negotiation]
+ssl_conf = 189-version-negotiation-ssl
+
+[189-version-negotiation-ssl]
+server = 189-version-negotiation-server
+client = 189-version-negotiation-client
+
+[189-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[189-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = SSLv3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-189]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[190-version-negotiation]
+ssl_conf = 190-version-negotiation-ssl
+
+[190-version-negotiation-ssl]
+server = 190-version-negotiation-server
+client = 190-version-negotiation-client
+
+[190-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[190-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-190]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[191-version-negotiation]
+ssl_conf = 191-version-negotiation-ssl
+
+[191-version-negotiation-ssl]
+server = 191-version-negotiation-server
+client = 191-version-negotiation-client
+
+[191-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[191-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-191]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[192-version-negotiation]
+ssl_conf = 192-version-negotiation-ssl
+
+[192-version-negotiation-ssl]
+server = 192-version-negotiation-server
+client = 192-version-negotiation-client
+
+[192-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[192-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-192]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[193-version-negotiation]
+ssl_conf = 193-version-negotiation-ssl
+
+[193-version-negotiation-ssl]
+server = 193-version-negotiation-server
+client = 193-version-negotiation-client
+
+[193-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[193-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-193]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[194-version-negotiation]
+ssl_conf = 194-version-negotiation-ssl
+
+[194-version-negotiation-ssl]
+server = 194-version-negotiation-server
+client = 194-version-negotiation-client
+
+[194-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[194-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-194]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[195-version-negotiation]
+ssl_conf = 195-version-negotiation-ssl
+
+[195-version-negotiation-ssl]
+server = 195-version-negotiation-server
+client = 195-version-negotiation-client
+
+[195-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[195-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-195]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[196-version-negotiation]
+ssl_conf = 196-version-negotiation-ssl
+
+[196-version-negotiation-ssl]
+server = 196-version-negotiation-server
+client = 196-version-negotiation-client
+
+[196-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[196-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-196]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[197-version-negotiation]
+ssl_conf = 197-version-negotiation-ssl
+
+[197-version-negotiation-ssl]
+server = 197-version-negotiation-server
+client = 197-version-negotiation-client
+
+[197-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[197-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-197]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[198-version-negotiation]
+ssl_conf = 198-version-negotiation-ssl
+
+[198-version-negotiation-ssl]
+server = 198-version-negotiation-server
+client = 198-version-negotiation-client
+
+[198-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[198-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-198]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[199-version-negotiation]
+ssl_conf = 199-version-negotiation-ssl
+
+[199-version-negotiation-ssl]
+server = 199-version-negotiation-server
+client = 199-version-negotiation-client
+
+[199-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[199-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-199]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[200-version-negotiation]
+ssl_conf = 200-version-negotiation-ssl
+
+[200-version-negotiation-ssl]
+server = 200-version-negotiation-server
+client = 200-version-negotiation-client
+
+[200-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[200-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-200]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[201-version-negotiation]
+ssl_conf = 201-version-negotiation-ssl
+
+[201-version-negotiation-ssl]
+server = 201-version-negotiation-server
+client = 201-version-negotiation-client
+
+[201-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[201-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-201]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[202-version-negotiation]
+ssl_conf = 202-version-negotiation-ssl
+
+[202-version-negotiation-ssl]
+server = 202-version-negotiation-server
+client = 202-version-negotiation-client
+
+[202-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[202-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-202]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[203-version-negotiation]
+ssl_conf = 203-version-negotiation-ssl
+
+[203-version-negotiation-ssl]
+server = 203-version-negotiation-server
+client = 203-version-negotiation-client
+
+[203-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[203-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-203]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[204-version-negotiation]
+ssl_conf = 204-version-negotiation-ssl
+
+[204-version-negotiation-ssl]
+server = 204-version-negotiation-server
+client = 204-version-negotiation-client
+
+[204-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[204-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-204]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[205-version-negotiation]
+ssl_conf = 205-version-negotiation-ssl
+
+[205-version-negotiation-ssl]
+server = 205-version-negotiation-server
+client = 205-version-negotiation-client
+
+[205-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[205-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-205]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[206-version-negotiation]
+ssl_conf = 206-version-negotiation-ssl
+
+[206-version-negotiation-ssl]
+server = 206-version-negotiation-server
+client = 206-version-negotiation-client
+
+[206-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[206-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-206]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[207-version-negotiation]
+ssl_conf = 207-version-negotiation-ssl
+
+[207-version-negotiation-ssl]
+server = 207-version-negotiation-server
+client = 207-version-negotiation-client
+
+[207-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[207-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-207]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[208-version-negotiation]
+ssl_conf = 208-version-negotiation-ssl
+
+[208-version-negotiation-ssl]
+server = 208-version-negotiation-server
+client = 208-version-negotiation-client
+
+[208-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[208-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-208]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[209-version-negotiation]
+ssl_conf = 209-version-negotiation-ssl
+
+[209-version-negotiation-ssl]
+server = 209-version-negotiation-server
+client = 209-version-negotiation-client
+
+[209-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[209-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-209]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[210-version-negotiation]
+ssl_conf = 210-version-negotiation-ssl
+
+[210-version-negotiation-ssl]
+server = 210-version-negotiation-server
+client = 210-version-negotiation-client
+
+[210-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[210-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-210]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[211-version-negotiation]
+ssl_conf = 211-version-negotiation-ssl
+
+[211-version-negotiation-ssl]
+server = 211-version-negotiation-server
+client = 211-version-negotiation-client
+
+[211-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[211-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-211]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[212-version-negotiation]
+ssl_conf = 212-version-negotiation-ssl
+
+[212-version-negotiation-ssl]
+server = 212-version-negotiation-server
+client = 212-version-negotiation-client
+
+[212-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[212-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-212]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[213-version-negotiation]
+ssl_conf = 213-version-negotiation-ssl
+
+[213-version-negotiation-ssl]
+server = 213-version-negotiation-server
+client = 213-version-negotiation-client
+
+[213-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[213-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-213]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[214-version-negotiation]
+ssl_conf = 214-version-negotiation-ssl
+
+[214-version-negotiation-ssl]
+server = 214-version-negotiation-server
+client = 214-version-negotiation-client
+
+[214-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[214-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-214]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[215-version-negotiation]
+ssl_conf = 215-version-negotiation-ssl
+
+[215-version-negotiation-ssl]
+server = 215-version-negotiation-server
+client = 215-version-negotiation-client
+
+[215-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[215-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-215]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[216-version-negotiation]
+ssl_conf = 216-version-negotiation-ssl
+
+[216-version-negotiation-ssl]
+server = 216-version-negotiation-server
+client = 216-version-negotiation-client
+
+[216-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[216-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-216]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[217-version-negotiation]
+ssl_conf = 217-version-negotiation-ssl
+
+[217-version-negotiation-ssl]
+server = 217-version-negotiation-server
+client = 217-version-negotiation-client
+
+[217-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[217-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-217]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[218-version-negotiation]
+ssl_conf = 218-version-negotiation-ssl
+
+[218-version-negotiation-ssl]
+server = 218-version-negotiation-server
+client = 218-version-negotiation-client
+
+[218-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[218-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-218]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[219-version-negotiation]
+ssl_conf = 219-version-negotiation-ssl
+
+[219-version-negotiation-ssl]
+server = 219-version-negotiation-server
+client = 219-version-negotiation-client
+
+[219-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[219-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-219]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[220-version-negotiation]
+ssl_conf = 220-version-negotiation-ssl
+
+[220-version-negotiation-ssl]
+server = 220-version-negotiation-server
+client = 220-version-negotiation-client
+
+[220-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[220-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-220]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[221-version-negotiation]
+ssl_conf = 221-version-negotiation-ssl
+
+[221-version-negotiation-ssl]
+server = 221-version-negotiation-server
+client = 221-version-negotiation-client
+
+[221-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[221-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-221]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[222-version-negotiation]
+ssl_conf = 222-version-negotiation-ssl
+
+[222-version-negotiation-ssl]
+server = 222-version-negotiation-server
+client = 222-version-negotiation-client
+
+[222-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[222-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-222]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[223-version-negotiation]
+ssl_conf = 223-version-negotiation-ssl
+
+[223-version-negotiation-ssl]
+server = 223-version-negotiation-server
+client = 223-version-negotiation-client
+
+[223-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[223-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-223]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[224-version-negotiation]
+ssl_conf = 224-version-negotiation-ssl
+
+[224-version-negotiation-ssl]
+server = 224-version-negotiation-server
+client = 224-version-negotiation-client
+
+[224-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[224-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-224]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[225-version-negotiation]
+ssl_conf = 225-version-negotiation-ssl
+
+[225-version-negotiation-ssl]
+server = 225-version-negotiation-server
+client = 225-version-negotiation-client
+
+[225-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[225-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-225]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[226-version-negotiation]
+ssl_conf = 226-version-negotiation-ssl
+
+[226-version-negotiation-ssl]
+server = 226-version-negotiation-server
+client = 226-version-negotiation-client
+
+[226-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[226-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-226]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[227-version-negotiation]
+ssl_conf = 227-version-negotiation-ssl
+
+[227-version-negotiation-ssl]
+server = 227-version-negotiation-server
+client = 227-version-negotiation-client
+
+[227-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[227-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-227]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[228-version-negotiation]
+ssl_conf = 228-version-negotiation-ssl
+
+[228-version-negotiation-ssl]
+server = 228-version-negotiation-server
+client = 228-version-negotiation-client
+
+[228-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[228-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-228]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[229-version-negotiation]
+ssl_conf = 229-version-negotiation-ssl
+
+[229-version-negotiation-ssl]
+server = 229-version-negotiation-server
+client = 229-version-negotiation-client
+
+[229-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[229-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-229]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[230-version-negotiation]
+ssl_conf = 230-version-negotiation-ssl
+
+[230-version-negotiation-ssl]
+server = 230-version-negotiation-server
+client = 230-version-negotiation-client
+
+[230-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[230-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-230]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[231-version-negotiation]
+ssl_conf = 231-version-negotiation-ssl
+
+[231-version-negotiation-ssl]
+server = 231-version-negotiation-server
+client = 231-version-negotiation-client
+
+[231-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[231-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-231]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[232-version-negotiation]
+ssl_conf = 232-version-negotiation-ssl
+
+[232-version-negotiation-ssl]
+server = 232-version-negotiation-server
+client = 232-version-negotiation-client
+
+[232-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[232-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-232]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[233-version-negotiation]
+ssl_conf = 233-version-negotiation-ssl
+
+[233-version-negotiation-ssl]
+server = 233-version-negotiation-server
+client = 233-version-negotiation-client
+
+[233-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[233-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-233]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[234-version-negotiation]
+ssl_conf = 234-version-negotiation-ssl
+
+[234-version-negotiation-ssl]
+server = 234-version-negotiation-server
+client = 234-version-negotiation-client
+
+[234-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[234-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-234]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[235-version-negotiation]
+ssl_conf = 235-version-negotiation-ssl
+
+[235-version-negotiation-ssl]
+server = 235-version-negotiation-server
+client = 235-version-negotiation-client
+
+[235-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[235-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-235]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[236-version-negotiation]
+ssl_conf = 236-version-negotiation-ssl
+
+[236-version-negotiation-ssl]
+server = 236-version-negotiation-server
+client = 236-version-negotiation-client
+
+[236-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[236-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-236]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[237-version-negotiation]
+ssl_conf = 237-version-negotiation-ssl
+
+[237-version-negotiation-ssl]
+server = 237-version-negotiation-server
+client = 237-version-negotiation-client
+
+[237-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[237-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-237]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[238-version-negotiation]
+ssl_conf = 238-version-negotiation-ssl
+
+[238-version-negotiation-ssl]
+server = 238-version-negotiation-server
+client = 238-version-negotiation-client
+
+[238-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[238-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-238]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[239-version-negotiation]
+ssl_conf = 239-version-negotiation-ssl
+
+[239-version-negotiation-ssl]
+server = 239-version-negotiation-server
+client = 239-version-negotiation-client
+
+[239-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[239-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-239]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[240-version-negotiation]
+ssl_conf = 240-version-negotiation-ssl
+
+[240-version-negotiation-ssl]
+server = 240-version-negotiation-server
+client = 240-version-negotiation-client
+
+[240-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[240-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-240]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[241-version-negotiation]
+ssl_conf = 241-version-negotiation-ssl
+
+[241-version-negotiation-ssl]
+server = 241-version-negotiation-server
+client = 241-version-negotiation-client
+
+[241-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[241-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-241]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[242-version-negotiation]
+ssl_conf = 242-version-negotiation-ssl
+
+[242-version-negotiation-ssl]
+server = 242-version-negotiation-server
+client = 242-version-negotiation-client
+
+[242-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[242-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-242]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[243-version-negotiation]
+ssl_conf = 243-version-negotiation-ssl
+
+[243-version-negotiation-ssl]
+server = 243-version-negotiation-server
+client = 243-version-negotiation-client
+
+[243-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[243-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-243]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[244-version-negotiation]
+ssl_conf = 244-version-negotiation-ssl
+
+[244-version-negotiation-ssl]
+server = 244-version-negotiation-server
+client = 244-version-negotiation-client
+
+[244-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[244-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-244]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[245-version-negotiation]
+ssl_conf = 245-version-negotiation-ssl
+
+[245-version-negotiation-ssl]
+server = 245-version-negotiation-server
+client = 245-version-negotiation-client
+
+[245-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[245-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-245]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[246-version-negotiation]
+ssl_conf = 246-version-negotiation-ssl
+
+[246-version-negotiation-ssl]
+server = 246-version-negotiation-server
+client = 246-version-negotiation-client
+
+[246-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[246-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-246]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[247-version-negotiation]
+ssl_conf = 247-version-negotiation-ssl
+
+[247-version-negotiation-ssl]
+server = 247-version-negotiation-server
+client = 247-version-negotiation-client
+
+[247-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[247-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-247]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[248-version-negotiation]
+ssl_conf = 248-version-negotiation-ssl
+
+[248-version-negotiation-ssl]
+server = 248-version-negotiation-server
+client = 248-version-negotiation-client
+
+[248-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[248-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-248]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[249-version-negotiation]
+ssl_conf = 249-version-negotiation-ssl
+
+[249-version-negotiation-ssl]
+server = 249-version-negotiation-server
+client = 249-version-negotiation-client
+
+[249-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[249-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-249]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[250-version-negotiation]
+ssl_conf = 250-version-negotiation-ssl
+
+[250-version-negotiation-ssl]
+server = 250-version-negotiation-server
+client = 250-version-negotiation-client
+
+[250-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[250-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-250]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[251-version-negotiation]
+ssl_conf = 251-version-negotiation-ssl
+
+[251-version-negotiation-ssl]
+server = 251-version-negotiation-server
+client = 251-version-negotiation-client
+
+[251-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[251-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-251]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[252-version-negotiation]
+ssl_conf = 252-version-negotiation-ssl
+
+[252-version-negotiation-ssl]
+server = 252-version-negotiation-server
+client = 252-version-negotiation-client
+
+[252-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[252-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-252]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[253-version-negotiation]
+ssl_conf = 253-version-negotiation-ssl
+
+[253-version-negotiation-ssl]
+server = 253-version-negotiation-server
+client = 253-version-negotiation-client
+
+[253-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[253-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-253]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[254-version-negotiation]
+ssl_conf = 254-version-negotiation-ssl
+
+[254-version-negotiation-ssl]
+server = 254-version-negotiation-server
+client = 254-version-negotiation-client
+
+[254-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[254-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-254]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[255-version-negotiation]
+ssl_conf = 255-version-negotiation-ssl
+
+[255-version-negotiation-ssl]
+server = 255-version-negotiation-server
+client = 255-version-negotiation-client
+
+[255-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[255-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-255]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[256-version-negotiation]
+ssl_conf = 256-version-negotiation-ssl
+
+[256-version-negotiation-ssl]
+server = 256-version-negotiation-server
+client = 256-version-negotiation-client
+
+[256-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[256-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-256]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[257-version-negotiation]
+ssl_conf = 257-version-negotiation-ssl
+
+[257-version-negotiation-ssl]
+server = 257-version-negotiation-server
+client = 257-version-negotiation-client
+
+[257-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[257-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-257]
+ExpectedResult = Success
+Protocol = TLSv1
+
+
+# ===========================================================
+
+[258-version-negotiation]
+ssl_conf = 258-version-negotiation-ssl
+
+[258-version-negotiation-ssl]
+server = 258-version-negotiation-server
+client = 258-version-negotiation-client
+
+[258-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[258-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-258]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[259-version-negotiation]
+ssl_conf = 259-version-negotiation-ssl
+
+[259-version-negotiation-ssl]
+server = 259-version-negotiation-server
+client = 259-version-negotiation-client
+
+[259-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[259-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-259]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[260-version-negotiation]
+ssl_conf = 260-version-negotiation-ssl
+
+[260-version-negotiation-ssl]
+server = 260-version-negotiation-server
+client = 260-version-negotiation-client
+
+[260-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[260-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-260]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[261-version-negotiation]
+ssl_conf = 261-version-negotiation-ssl
+
+[261-version-negotiation-ssl]
+server = 261-version-negotiation-server
+client = 261-version-negotiation-client
+
+[261-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[261-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-261]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[262-version-negotiation]
+ssl_conf = 262-version-negotiation-ssl
+
+[262-version-negotiation-ssl]
+server = 262-version-negotiation-server
+client = 262-version-negotiation-client
+
+[262-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[262-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-262]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[263-version-negotiation]
+ssl_conf = 263-version-negotiation-ssl
+
+[263-version-negotiation-ssl]
+server = 263-version-negotiation-server
+client = 263-version-negotiation-client
+
+[263-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[263-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-263]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[264-version-negotiation]
+ssl_conf = 264-version-negotiation-ssl
+
+[264-version-negotiation-ssl]
+server = 264-version-negotiation-server
+client = 264-version-negotiation-client
+
+[264-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[264-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-264]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[265-version-negotiation]
+ssl_conf = 265-version-negotiation-ssl
+
+[265-version-negotiation-ssl]
+server = 265-version-negotiation-server
+client = 265-version-negotiation-client
+
+[265-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[265-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-265]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[266-version-negotiation]
+ssl_conf = 266-version-negotiation-ssl
+
+[266-version-negotiation-ssl]
+server = 266-version-negotiation-server
+client = 266-version-negotiation-client
+
+[266-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[266-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-266]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[267-version-negotiation]
+ssl_conf = 267-version-negotiation-ssl
+
+[267-version-negotiation-ssl]
+server = 267-version-negotiation-server
+client = 267-version-negotiation-client
+
+[267-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[267-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-267]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[268-version-negotiation]
+ssl_conf = 268-version-negotiation-ssl
+
+[268-version-negotiation-ssl]
+server = 268-version-negotiation-server
+client = 268-version-negotiation-client
+
+[268-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[268-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-268]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[269-version-negotiation]
+ssl_conf = 269-version-negotiation-ssl
+
+[269-version-negotiation-ssl]
+server = 269-version-negotiation-server
+client = 269-version-negotiation-client
+
+[269-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[269-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-269]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[270-version-negotiation]
+ssl_conf = 270-version-negotiation-ssl
+
+[270-version-negotiation-ssl]
+server = 270-version-negotiation-server
+client = 270-version-negotiation-client
+
+[270-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[270-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-270]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[271-version-negotiation]
+ssl_conf = 271-version-negotiation-ssl
+
+[271-version-negotiation-ssl]
+server = 271-version-negotiation-server
+client = 271-version-negotiation-client
+
+[271-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[271-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-271]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[272-version-negotiation]
+ssl_conf = 272-version-negotiation-ssl
+
+[272-version-negotiation-ssl]
+server = 272-version-negotiation-server
+client = 272-version-negotiation-client
+
+[272-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[272-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-272]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[273-version-negotiation]
+ssl_conf = 273-version-negotiation-ssl
+
+[273-version-negotiation-ssl]
+server = 273-version-negotiation-server
+client = 273-version-negotiation-client
+
+[273-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[273-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-273]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[274-version-negotiation]
+ssl_conf = 274-version-negotiation-ssl
+
+[274-version-negotiation-ssl]
+server = 274-version-negotiation-server
+client = 274-version-negotiation-client
+
+[274-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[274-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-274]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[275-version-negotiation]
+ssl_conf = 275-version-negotiation-ssl
+
+[275-version-negotiation-ssl]
+server = 275-version-negotiation-server
+client = 275-version-negotiation-client
+
+[275-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[275-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-275]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[276-version-negotiation]
+ssl_conf = 276-version-negotiation-ssl
+
+[276-version-negotiation-ssl]
+server = 276-version-negotiation-server
+client = 276-version-negotiation-client
+
+[276-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[276-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-276]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[277-version-negotiation]
+ssl_conf = 277-version-negotiation-ssl
+
+[277-version-negotiation-ssl]
+server = 277-version-negotiation-server
+client = 277-version-negotiation-client
+
+[277-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[277-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-277]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[278-version-negotiation]
+ssl_conf = 278-version-negotiation-ssl
+
+[278-version-negotiation-ssl]
+server = 278-version-negotiation-server
+client = 278-version-negotiation-client
+
+[278-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[278-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-278]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[279-version-negotiation]
+ssl_conf = 279-version-negotiation-ssl
+
+[279-version-negotiation-ssl]
+server = 279-version-negotiation-server
+client = 279-version-negotiation-client
+
+[279-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[279-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-279]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[280-version-negotiation]
+ssl_conf = 280-version-negotiation-ssl
+
+[280-version-negotiation-ssl]
+server = 280-version-negotiation-server
+client = 280-version-negotiation-client
+
+[280-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[280-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-280]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[281-version-negotiation]
+ssl_conf = 281-version-negotiation-ssl
+
+[281-version-negotiation-ssl]
+server = 281-version-negotiation-server
+client = 281-version-negotiation-client
+
+[281-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[281-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-281]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[282-version-negotiation]
+ssl_conf = 282-version-negotiation-ssl
+
+[282-version-negotiation-ssl]
+server = 282-version-negotiation-server
+client = 282-version-negotiation-client
+
+[282-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[282-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-282]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[283-version-negotiation]
+ssl_conf = 283-version-negotiation-ssl
+
+[283-version-negotiation-ssl]
+server = 283-version-negotiation-server
+client = 283-version-negotiation-client
+
+[283-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[283-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-283]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[284-version-negotiation]
+ssl_conf = 284-version-negotiation-ssl
+
+[284-version-negotiation-ssl]
+server = 284-version-negotiation-server
+client = 284-version-negotiation-client
+
+[284-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[284-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-284]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[285-version-negotiation]
+ssl_conf = 285-version-negotiation-ssl
+
+[285-version-negotiation-ssl]
+server = 285-version-negotiation-server
+client = 285-version-negotiation-client
+
+[285-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[285-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-285]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[286-version-negotiation]
+ssl_conf = 286-version-negotiation-ssl
+
+[286-version-negotiation-ssl]
+server = 286-version-negotiation-server
+client = 286-version-negotiation-client
+
+[286-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[286-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-286]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[287-version-negotiation]
+ssl_conf = 287-version-negotiation-ssl
+
+[287-version-negotiation-ssl]
+server = 287-version-negotiation-server
+client = 287-version-negotiation-client
+
+[287-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[287-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-287]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[288-version-negotiation]
+ssl_conf = 288-version-negotiation-ssl
+
+[288-version-negotiation-ssl]
+server = 288-version-negotiation-server
+client = 288-version-negotiation-client
+
+[288-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[288-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-288]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[289-version-negotiation]
+ssl_conf = 289-version-negotiation-ssl
+
+[289-version-negotiation-ssl]
+server = 289-version-negotiation-server
+client = 289-version-negotiation-client
+
+[289-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[289-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-289]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[290-version-negotiation]
+ssl_conf = 290-version-negotiation-ssl
+
+[290-version-negotiation-ssl]
+server = 290-version-negotiation-server
+client = 290-version-negotiation-client
+
+[290-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[290-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-290]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[291-version-negotiation]
+ssl_conf = 291-version-negotiation-ssl
+
+[291-version-negotiation-ssl]
+server = 291-version-negotiation-server
+client = 291-version-negotiation-client
+
+[291-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[291-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-291]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[292-version-negotiation]
+ssl_conf = 292-version-negotiation-ssl
+
+[292-version-negotiation-ssl]
+server = 292-version-negotiation-server
+client = 292-version-negotiation-client
+
+[292-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[292-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-292]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[293-version-negotiation]
+ssl_conf = 293-version-negotiation-ssl
+
+[293-version-negotiation-ssl]
+server = 293-version-negotiation-server
+client = 293-version-negotiation-client
+
+[293-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[293-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-293]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[294-version-negotiation]
+ssl_conf = 294-version-negotiation-ssl
+
+[294-version-negotiation-ssl]
+server = 294-version-negotiation-server
+client = 294-version-negotiation-client
+
+[294-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[294-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-294]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[295-version-negotiation]
+ssl_conf = 295-version-negotiation-ssl
+
+[295-version-negotiation-ssl]
+server = 295-version-negotiation-server
+client = 295-version-negotiation-client
+
+[295-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[295-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-295]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[296-version-negotiation]
+ssl_conf = 296-version-negotiation-ssl
+
+[296-version-negotiation-ssl]
+server = 296-version-negotiation-server
+client = 296-version-negotiation-client
+
+[296-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[296-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-296]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[297-version-negotiation]
+ssl_conf = 297-version-negotiation-ssl
+
+[297-version-negotiation-ssl]
+server = 297-version-negotiation-server
+client = 297-version-negotiation-client
+
+[297-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[297-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-297]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[298-version-negotiation]
+ssl_conf = 298-version-negotiation-ssl
+
+[298-version-negotiation-ssl]
+server = 298-version-negotiation-server
+client = 298-version-negotiation-client
+
+[298-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[298-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-298]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[299-version-negotiation]
+ssl_conf = 299-version-negotiation-ssl
+
+[299-version-negotiation-ssl]
+server = 299-version-negotiation-server
+client = 299-version-negotiation-client
+
+[299-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[299-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-299]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[300-version-negotiation]
+ssl_conf = 300-version-negotiation-ssl
+
+[300-version-negotiation-ssl]
+server = 300-version-negotiation-server
+client = 300-version-negotiation-client
+
+[300-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[300-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-300]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[301-version-negotiation]
+ssl_conf = 301-version-negotiation-ssl
+
+[301-version-negotiation-ssl]
+server = 301-version-negotiation-server
+client = 301-version-negotiation-client
+
+[301-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[301-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-301]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[302-version-negotiation]
+ssl_conf = 302-version-negotiation-ssl
+
+[302-version-negotiation-ssl]
+server = 302-version-negotiation-server
+client = 302-version-negotiation-client
+
+[302-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[302-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-302]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[303-version-negotiation]
+ssl_conf = 303-version-negotiation-ssl
+
+[303-version-negotiation-ssl]
+server = 303-version-negotiation-server
+client = 303-version-negotiation-client
+
+[303-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[303-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-303]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[304-version-negotiation]
+ssl_conf = 304-version-negotiation-ssl
+
+[304-version-negotiation-ssl]
+server = 304-version-negotiation-server
+client = 304-version-negotiation-client
+
+[304-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[304-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-304]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[305-version-negotiation]
+ssl_conf = 305-version-negotiation-ssl
+
+[305-version-negotiation-ssl]
+server = 305-version-negotiation-server
+client = 305-version-negotiation-client
+
+[305-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[305-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-305]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[306-version-negotiation]
+ssl_conf = 306-version-negotiation-ssl
+
+[306-version-negotiation-ssl]
+server = 306-version-negotiation-server
+client = 306-version-negotiation-client
+
+[306-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[306-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-306]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[307-version-negotiation]
+ssl_conf = 307-version-negotiation-ssl
+
+[307-version-negotiation-ssl]
+server = 307-version-negotiation-server
+client = 307-version-negotiation-client
+
+[307-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[307-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-307]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[308-version-negotiation]
+ssl_conf = 308-version-negotiation-ssl
+
+[308-version-negotiation-ssl]
+server = 308-version-negotiation-server
+client = 308-version-negotiation-client
+
+[308-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[308-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-308]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[309-version-negotiation]
+ssl_conf = 309-version-negotiation-ssl
+
+[309-version-negotiation-ssl]
+server = 309-version-negotiation-server
+client = 309-version-negotiation-client
+
+[309-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[309-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-309]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[310-version-negotiation]
+ssl_conf = 310-version-negotiation-ssl
+
+[310-version-negotiation-ssl]
+server = 310-version-negotiation-server
+client = 310-version-negotiation-client
+
+[310-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[310-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-310]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[311-version-negotiation]
+ssl_conf = 311-version-negotiation-ssl
+
+[311-version-negotiation-ssl]
+server = 311-version-negotiation-server
+client = 311-version-negotiation-client
+
+[311-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[311-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-311]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[312-version-negotiation]
+ssl_conf = 312-version-negotiation-ssl
+
+[312-version-negotiation-ssl]
+server = 312-version-negotiation-server
+client = 312-version-negotiation-client
+
+[312-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[312-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-312]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[313-version-negotiation]
+ssl_conf = 313-version-negotiation-ssl
+
+[313-version-negotiation-ssl]
+server = 313-version-negotiation-server
+client = 313-version-negotiation-client
+
+[313-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[313-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-313]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[314-version-negotiation]
+ssl_conf = 314-version-negotiation-ssl
+
+[314-version-negotiation-ssl]
+server = 314-version-negotiation-server
+client = 314-version-negotiation-client
+
+[314-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[314-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-314]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[315-version-negotiation]
+ssl_conf = 315-version-negotiation-ssl
+
+[315-version-negotiation-ssl]
+server = 315-version-negotiation-server
+client = 315-version-negotiation-client
+
+[315-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[315-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-315]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[316-version-negotiation]
+ssl_conf = 316-version-negotiation-ssl
+
+[316-version-negotiation-ssl]
+server = 316-version-negotiation-server
+client = 316-version-negotiation-client
+
+[316-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[316-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-316]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[317-version-negotiation]
+ssl_conf = 317-version-negotiation-ssl
+
+[317-version-negotiation-ssl]
+server = 317-version-negotiation-server
+client = 317-version-negotiation-client
+
+[317-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[317-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-317]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[318-version-negotiation]
+ssl_conf = 318-version-negotiation-ssl
+
+[318-version-negotiation-ssl]
+server = 318-version-negotiation-server
+client = 318-version-negotiation-client
+
+[318-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[318-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-318]
+ExpectedResult = Success
+Protocol = TLSv1.1
+
+
+# ===========================================================
+
+[319-version-negotiation]
+ssl_conf = 319-version-negotiation-ssl
+
+[319-version-negotiation-ssl]
+server = 319-version-negotiation-server
+client = 319-version-negotiation-client
+
+[319-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[319-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-319]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[320-version-negotiation]
+ssl_conf = 320-version-negotiation-ssl
+
+[320-version-negotiation-ssl]
+server = 320-version-negotiation-server
+client = 320-version-negotiation-client
+
+[320-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[320-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-320]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[321-version-negotiation]
+ssl_conf = 321-version-negotiation-ssl
+
+[321-version-negotiation-ssl]
+server = 321-version-negotiation-server
+client = 321-version-negotiation-client
+
+[321-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[321-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-321]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[322-version-negotiation]
+ssl_conf = 322-version-negotiation-ssl
+
+[322-version-negotiation-ssl]
+server = 322-version-negotiation-server
+client = 322-version-negotiation-client
+
+[322-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[322-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-322]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[323-version-negotiation]
+ssl_conf = 323-version-negotiation-ssl
+
+[323-version-negotiation-ssl]
+server = 323-version-negotiation-server
+client = 323-version-negotiation-client
+
+[323-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[323-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-323]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[324-version-negotiation]
+ssl_conf = 324-version-negotiation-ssl
+
+[324-version-negotiation-ssl]
+server = 324-version-negotiation-server
+client = 324-version-negotiation-client
+
+[324-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[324-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-324]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[325-version-negotiation]
+ssl_conf = 325-version-negotiation-ssl
+
+[325-version-negotiation-ssl]
+server = 325-version-negotiation-server
+client = 325-version-negotiation-client
+
+[325-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[325-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-325]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[326-version-negotiation]
+ssl_conf = 326-version-negotiation-ssl
+
+[326-version-negotiation-ssl]
+server = 326-version-negotiation-server
+client = 326-version-negotiation-client
+
+[326-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[326-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-326]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[327-version-negotiation]
+ssl_conf = 327-version-negotiation-ssl
+
+[327-version-negotiation-ssl]
+server = 327-version-negotiation-server
+client = 327-version-negotiation-client
+
+[327-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[327-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-327]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[328-version-negotiation]
+ssl_conf = 328-version-negotiation-ssl
+
+[328-version-negotiation-ssl]
+server = 328-version-negotiation-server
+client = 328-version-negotiation-client
+
+[328-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[328-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-328]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[329-version-negotiation]
+ssl_conf = 329-version-negotiation-ssl
+
+[329-version-negotiation-ssl]
+server = 329-version-negotiation-server
+client = 329-version-negotiation-client
+
+[329-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[329-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-329]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[330-version-negotiation]
+ssl_conf = 330-version-negotiation-ssl
+
+[330-version-negotiation-ssl]
+server = 330-version-negotiation-server
+client = 330-version-negotiation-client
+
+[330-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[330-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-330]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[331-version-negotiation]
+ssl_conf = 331-version-negotiation-ssl
+
+[331-version-negotiation-ssl]
+server = 331-version-negotiation-server
+client = 331-version-negotiation-client
+
+[331-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[331-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-331]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[332-version-negotiation]
+ssl_conf = 332-version-negotiation-ssl
+
+[332-version-negotiation-ssl]
+server = 332-version-negotiation-server
+client = 332-version-negotiation-client
+
+[332-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[332-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-332]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[333-version-negotiation]
+ssl_conf = 333-version-negotiation-ssl
+
+[333-version-negotiation-ssl]
+server = 333-version-negotiation-server
+client = 333-version-negotiation-client
+
+[333-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[333-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-333]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[334-version-negotiation]
+ssl_conf = 334-version-negotiation-ssl
+
+[334-version-negotiation-ssl]
+server = 334-version-negotiation-server
+client = 334-version-negotiation-client
+
+[334-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[334-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-334]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[335-version-negotiation]
+ssl_conf = 335-version-negotiation-ssl
+
+[335-version-negotiation-ssl]
+server = 335-version-negotiation-server
+client = 335-version-negotiation-client
+
+[335-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[335-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-335]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[336-version-negotiation]
+ssl_conf = 336-version-negotiation-ssl
+
+[336-version-negotiation-ssl]
+server = 336-version-negotiation-server
+client = 336-version-negotiation-client
+
+[336-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[336-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-336]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[337-version-negotiation]
+ssl_conf = 337-version-negotiation-ssl
+
+[337-version-negotiation-ssl]
+server = 337-version-negotiation-server
+client = 337-version-negotiation-client
+
+[337-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[337-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-337]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[338-version-negotiation]
+ssl_conf = 338-version-negotiation-ssl
+
+[338-version-negotiation-ssl]
+server = 338-version-negotiation-server
+client = 338-version-negotiation-client
+
+[338-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[338-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-338]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[339-version-negotiation]
+ssl_conf = 339-version-negotiation-ssl
+
+[339-version-negotiation-ssl]
+server = 339-version-negotiation-server
+client = 339-version-negotiation-client
+
+[339-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[339-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-339]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[340-version-negotiation]
+ssl_conf = 340-version-negotiation-ssl
+
+[340-version-negotiation-ssl]
+server = 340-version-negotiation-server
+client = 340-version-negotiation-client
+
+[340-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[340-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-340]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[341-version-negotiation]
+ssl_conf = 341-version-negotiation-ssl
+
+[341-version-negotiation-ssl]
+server = 341-version-negotiation-server
+client = 341-version-negotiation-client
+
+[341-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[341-version-negotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-341]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[342-version-negotiation]
+ssl_conf = 342-version-negotiation-ssl
+
+[342-version-negotiation-ssl]
+server = 342-version-negotiation-server
+client = 342-version-negotiation-client
+
+[342-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[342-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-342]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[343-version-negotiation]
+ssl_conf = 343-version-negotiation-ssl
+
+[343-version-negotiation-ssl]
+server = 343-version-negotiation-server
+client = 343-version-negotiation-client
+
+[343-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[343-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-343]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[344-version-negotiation]
+ssl_conf = 344-version-negotiation-ssl
+
+[344-version-negotiation-ssl]
+server = 344-version-negotiation-server
+client = 344-version-negotiation-client
+
+[344-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[344-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-344]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[345-version-negotiation]
+ssl_conf = 345-version-negotiation-ssl
+
+[345-version-negotiation-ssl]
+server = 345-version-negotiation-server
+client = 345-version-negotiation-client
+
+[345-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[345-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-345]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[346-version-negotiation]
+ssl_conf = 346-version-negotiation-ssl
+
+[346-version-negotiation-ssl]
+server = 346-version-negotiation-server
+client = 346-version-negotiation-client
+
+[346-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[346-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-346]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[347-version-negotiation]
+ssl_conf = 347-version-negotiation-ssl
+
+[347-version-negotiation-ssl]
+server = 347-version-negotiation-server
+client = 347-version-negotiation-client
+
+[347-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[347-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-347]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[348-version-negotiation]
+ssl_conf = 348-version-negotiation-ssl
+
+[348-version-negotiation-ssl]
+server = 348-version-negotiation-server
+client = 348-version-negotiation-client
+
+[348-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[348-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-348]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[349-version-negotiation]
+ssl_conf = 349-version-negotiation-ssl
+
+[349-version-negotiation-ssl]
+server = 349-version-negotiation-server
+client = 349-version-negotiation-client
+
+[349-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[349-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-349]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[350-version-negotiation]
+ssl_conf = 350-version-negotiation-ssl
+
+[350-version-negotiation-ssl]
+server = 350-version-negotiation-server
+client = 350-version-negotiation-client
+
+[350-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[350-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-350]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[351-version-negotiation]
+ssl_conf = 351-version-negotiation-ssl
+
+[351-version-negotiation-ssl]
+server = 351-version-negotiation-server
+client = 351-version-negotiation-client
+
+[351-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[351-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-351]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[352-version-negotiation]
+ssl_conf = 352-version-negotiation-ssl
+
+[352-version-negotiation-ssl]
+server = 352-version-negotiation-server
+client = 352-version-negotiation-client
+
+[352-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[352-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-352]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[353-version-negotiation]
+ssl_conf = 353-version-negotiation-ssl
+
+[353-version-negotiation-ssl]
+server = 353-version-negotiation-server
+client = 353-version-negotiation-client
+
+[353-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[353-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-353]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[354-version-negotiation]
+ssl_conf = 354-version-negotiation-ssl
+
+[354-version-negotiation-ssl]
+server = 354-version-negotiation-server
+client = 354-version-negotiation-client
+
+[354-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[354-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-354]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[355-version-negotiation]
+ssl_conf = 355-version-negotiation-ssl
+
+[355-version-negotiation-ssl]
+server = 355-version-negotiation-server
+client = 355-version-negotiation-client
+
+[355-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[355-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-355]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[356-version-negotiation]
+ssl_conf = 356-version-negotiation-ssl
+
+[356-version-negotiation-ssl]
+server = 356-version-negotiation-server
+client = 356-version-negotiation-client
+
+[356-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[356-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-356]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[357-version-negotiation]
+ssl_conf = 357-version-negotiation-ssl
+
+[357-version-negotiation-ssl]
+server = 357-version-negotiation-server
+client = 357-version-negotiation-client
+
+[357-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[357-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-357]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[358-version-negotiation]
+ssl_conf = 358-version-negotiation-ssl
+
+[358-version-negotiation-ssl]
+server = 358-version-negotiation-server
+client = 358-version-negotiation-client
+
+[358-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[358-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-358]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[359-version-negotiation]
+ssl_conf = 359-version-negotiation-ssl
+
+[359-version-negotiation-ssl]
+server = 359-version-negotiation-server
+client = 359-version-negotiation-client
+
+[359-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[359-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-359]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+
+# ===========================================================
+
+[360-version-negotiation]
+ssl_conf = 360-version-negotiation-ssl
+
+[360-version-negotiation-ssl]
+server = 360-version-negotiation-server
+client = 360-version-negotiation-client
+
+[360-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[360-version-negotiation-client]
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-360]
+ExpectedResult = Success
+Protocol = TLSv1.2
+
+

--- a/test/ssl-tests/02-protocol-version.conf.in
+++ b/test/ssl-tests/02-protocol-version.conf.in
@@ -6,10 +6,6 @@ package ssltests;
 
 use List::Util qw/max min/;
 
-use lib 'testlib';
-
-# TODO(emilia, levitte): there must be a better way to call test utilities
-# without pretending to run a test?
 use OpenSSL::Test;
 use OpenSSL::Test::Utils qw/anydisabled alldisabled/;
 setup("no_test_here");

--- a/test/ssl-tests/02-protocol-version.conf.in
+++ b/test/ssl-tests/02-protocol-version.conf.in
@@ -1,0 +1,115 @@
+# -*- mode: perl; -*-
+
+## Test version negotiation
+
+package ssltests;
+
+use List::Util qw/max min/;
+
+use lib 'testlib';
+
+# TODO(emilia, levitte): there must be a better way to call test utilities
+# without pretending to run a test?
+use OpenSSL::Test;
+use OpenSSL::Test::Utils qw/anydisabled alldisabled/;
+setup("no_test_here");
+
+my @protocols = ("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2");
+# undef stands for "no limit".
+my @min_protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2");
+my @max_protocols = ("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", undef);
+
+my @is_disabled = anydisabled("ssl3", "tls1", "tls1_1", "tls1_2");
+
+# Protocol configuration works in cascades, i.e.,
+# $no_tls1_1 disables TLSv1.1 and below.
+# We now have at least one protocol enabled.
+my $min_enabled; my $max_enabled;
+
+foreach my $i (0..$#protocols) {
+    if (!$is_disabled[$i]) {
+        $min_enabled = $i;
+        last;
+    }
+}
+
+foreach my $i (0..$#protocols) {
+    if (!$is_disabled[$i]) {
+        $max_enabled = $i;
+    }
+}
+
+our @tests = ();
+
+sub generate_tests() {
+    foreach my $c_min (0..$#min_protocols) {
+        my $c_max_min = $c_min == 0 ? 0 : $c_min - 1;
+        foreach my $c_max ($c_max_min..$#max_protocols) {
+            foreach my $s_min (0..$#min_protocols) {
+                my $s_max_min = $s_min == 0 ? 0 : $s_min - 1;
+                foreach my $s_max ($s_max_min..$#max_protocols) {
+                    my ($result, $protocol) =
+                        expected_result($c_min, $c_max, $s_min, $s_max);
+                    push @tests, {
+                        "name" => "version-negotiation",
+                        "client" => {
+                            "MinProtocol" => $min_protocols[$c_min],
+                            "MaxProtocol" => $max_protocols[$c_max],
+                        },
+                        "server" => {
+                            "MinProtocol" => $min_protocols[$s_min],
+                            "MaxProtocol" => $max_protocols[$s_max],
+                        },
+                        "test" => {
+                            "ExpectedResult" => $result,
+                            "Protocol" => $protocol
+                        }
+                    };
+                }
+            }
+        }
+    }
+}
+
+sub expected_result {
+    my $no_tls = alldisabled("ssl3", "tls1", "tls1_1", "tls1_2");
+    if ($no_tls) {
+        return ("InternalError", undef);
+    }
+
+    my ($c_min, $c_max, $s_min, $s_max) = @_;
+
+    # Adjust for "undef" (no limit).
+    $c_min = $c_min == 0 ? 0 : $c_min - 1;
+    $c_max = $c_max == scalar(@max_protocols) - 1 ? $c_max - 1 : $c_max;
+    $s_min = $s_min == 0 ? 0 : $s_min - 1;
+    $s_max = $s_max == scalar(@max_protocols) - 1 ? $s_max - 1 : $s_max;
+
+    $c_min = max $c_min, $min_enabled;
+    $s_min = max $s_min, $min_enabled;
+    $c_max = min $c_max, $max_enabled;
+    $s_max = min $s_max, $max_enabled;
+
+    if ($c_min > $c_max) {
+        # Client should fail to even send a hello.
+        # This results in an internal error since the server will be
+        # waiting for input that never arrives.
+        return ("InternalError", undef);
+    } elsif ($s_min > $s_max) {
+        # Server has no protocols, should always fail.
+        return ("ServerFail", undef);
+    } elsif ($s_min > $c_max) {
+        # Server doesn't support the client range.
+        return ("ServerFail", undef);
+    } elsif ($c_min > $s_max) {
+        # Server will try with a version that is lower than the lowest
+        # supported client version.
+        return ("ClientFail", undef);
+    } else {
+        # Server and client ranges overlap.
+        my $max_common = $s_max < $c_max ? $s_max : $c_max;
+        return ("Success", $protocols[$max_common]);
+    }        
+}
+
+generate_tests();

--- a/test/ssl-tests/02-protocol-version.conf.in
+++ b/test/ssl-tests/02-protocol-version.conf.in
@@ -17,11 +17,13 @@ my @max_protocols = ("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", undef);
 
 my @is_disabled = anydisabled("ssl3", "tls1", "tls1_1", "tls1_2");
 
-# Protocol configuration works in cascades, i.e.,
-# $no_tls1_1 disables TLSv1.1 and below.
-# We now have at least one protocol enabled.
 my $min_enabled; my $max_enabled;
 
+# Protocol configuration works in cascades, i.e.,
+# $no_tls1_1 disables TLSv1.1 and below.
+#
+# $min_enabled and $max_enabled will be correct if there is at least one
+# protocol enabled.
 foreach my $i (0..$#protocols) {
     if (!$is_disabled[$i]) {
         $min_enabled = $i;
@@ -81,6 +83,8 @@ sub expected_result {
     $s_min = $s_min == 0 ? 0 : $s_min - 1;
     $s_max = $s_max == scalar(@max_protocols) - 1 ? $s_max - 1 : $s_max;
 
+    # We now have at least one protocol enabled, so $min_enabled and
+    # $max_enabled are well-defined.
     $c_min = max $c_min, $min_enabled;
     $s_min = max $s_min, $min_enabled;
     $c_max = min $c_max, $max_enabled;
@@ -105,7 +109,7 @@ sub expected_result {
         # Server and client ranges overlap.
         my $max_common = $s_max < $c_max ? $s_max : $c_max;
         return ("Success", $protocols[$max_common]);
-    }        
+    }
 }
 
 generate_tests();

--- a/test/ssl-tests/ssltests_base.pm
+++ b/test/ssl-tests/ssltests_base.pm
@@ -1,0 +1,17 @@
+# -*- mode: perl; -*-
+
+## SSL test configurations
+
+package ssltests;
+
+our %base_server = (
+    "Certificate" => "\${ENV::TEST_CERTS_DIR}/servercert.pem",
+    "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}/serverkey.pem",
+    "CipherString" => "DEFAULT",
+);
+
+our %base_client = (
+    "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}/rootcert.pem",
+    "VerifyMode" => "Peer",
+    "CipherString" => "DEFAULT",
+);

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -20,9 +20,12 @@
 
 static CONF *conf = NULL;
 
+/* Currently the section names are of the form test-<number>, e.g. test-15. */
+#define MAX_TESTCASE_NAME_LENGTH 100
+
 typedef struct ssl_test_ctx_test_fixture {
     const char *test_case_name;
-    char test_app[100];
+    char test_app[MAX_TESTCASE_NAME_LENGTH];
 } SSL_TEST_FIXTURE;
 
 static SSL_TEST_FIXTURE set_up(const char *const test_case_name)
@@ -149,9 +152,9 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
 
     OPENSSL_assert(CONF_modules_load(conf, fixture.test_app, 0) > 0);
 
-    if(!SSL_CTX_config(server_ctx, "server")
+    if (!SSL_CTX_config(server_ctx, "server")
        || !SSL_CTX_config(client_ctx, "client")) {
-           goto err;
+        goto err;
     }
 
     test_ctx = SSL_TEST_CTX_create(conf, fixture.test_app);

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL licenses, (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#include <stdio.h>
+
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+#include "handshake_helper.h"
+#include "ssl_test_ctx.h"
+#include "testutil.h"
+
+static CONF *conf = NULL;
+
+typedef struct ssl_test_ctx_test_fixture {
+    const char *test_case_name;
+    char test_app[100];
+} SSL_TEST_FIXTURE;
+
+static SSL_TEST_FIXTURE set_up(const char *const test_case_name)
+{
+    SSL_TEST_FIXTURE fixture;
+    fixture.test_case_name = test_case_name;
+    return fixture;
+}
+
+static const char *print_alert(int alert)
+{
+    return alert ? SSL_alert_desc_string_long(alert) : "no alert";
+}
+
+static int check_result(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
+{
+    if (result.result != test_ctx->expected_result) {
+        fprintf(stderr, "ExpectedResult mismatch: expected %s, got %s.\n",
+                ssl_test_result_t_name(test_ctx->expected_result),
+                ssl_test_result_t_name(result.result));
+        return 0;
+    }
+    return 1;
+}
+
+static int check_alerts(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
+{
+    if (result.client_alert_sent != result.client_alert_received) {
+        fprintf(stderr, "Client sent alert %s but server received %s\n.",
+                print_alert(result.client_alert_sent),
+                print_alert(result.client_alert_received));
+        /*
+         * We can't bail here because the peer doesn't always get far enough
+         * to process a received alert. Specifically, in protocol version
+         * negotiation tests, we have the following scenario.
+         * Client supports TLS v1.2 only; Server supports TLS v1.1.
+         * Client proposes TLS v1.2; server responds with 1.1;
+         * Client now sends a protocol alert, using TLS v1.2 in the header.
+         * The server, however, rejects the alert because of version mismatch
+         * in the record layer; therefore, the server appears to never
+         * receive the alert.
+         */
+        /* return 0; */
+    }
+
+    if (result.server_alert_sent != result.server_alert_received) {
+        fprintf(stderr, "Server sent alert %s but client received %s\n.",
+                print_alert(result.server_alert_sent),
+                print_alert(result.server_alert_received));
+        /* return 0; */
+    }
+
+    /* Tolerate an alert if one wasn't explicitly specified in the test. */
+    if (test_ctx->client_alert
+        /*
+         * The info callback alert value is computed as
+         * (s->s3->send_alert[0] << 8) | s->s3->send_alert[1]
+         * where the low byte is the alert code and the high byte is other stuff.
+         */
+        && (result.client_alert_sent & 0xff) != test_ctx->client_alert) {
+        fprintf(stderr, "ClientAlert mismatch: expected %s, got %s.\n",
+                print_alert(test_ctx->client_alert),
+                print_alert(result.client_alert_sent));
+        return 0;
+    }
+
+    if (test_ctx->server_alert
+        && (result.server_alert_sent & 0xff) != test_ctx->server_alert) {
+        fprintf(stderr, "ServerAlert mismatch: expected %s, got %s.\n",
+                print_alert(test_ctx->server_alert),
+                print_alert(result.server_alert_sent));
+        return 0;
+    }
+
+    return 1;
+}
+
+static int check_protocol(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
+{
+    if (result.client_protocol != result.server_protocol) {
+        fprintf(stderr, "Client has protocol %s but server has %s\n.",
+                ssl_protocol_name(result.client_protocol),
+                ssl_protocol_name(result.server_protocol));
+        return 0;
+    }
+
+    if (test_ctx->protocol) {
+        if (result.client_protocol != test_ctx->protocol) {
+            fprintf(stderr, "Protocol mismatch: expected %s, got %s.\n",
+                    ssl_protocol_name(test_ctx->protocol),
+                    ssl_protocol_name(result.client_protocol));
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/*
+ * This could be further simplified by constructing an expected
+ * HANDSHAKE_RESULT, and implementing comparison methods for
+ * its fields.
+ */
+static int check_test(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
+{
+    int ret = 1;
+    ret &= check_result(result, test_ctx);
+    ret &= check_alerts(result, test_ctx);
+    if (result.result == SSL_TEST_SUCCESS)
+        ret &= check_protocol(result, test_ctx);
+    return ret;
+}
+
+static int execute_test(SSL_TEST_FIXTURE fixture)
+{
+    /* TODO(emilia): this is confusing. Flip to return 1 on success. */
+    int ret = 1;
+    SSL_CTX *server_ctx = NULL, *client_ctx = NULL;
+    SSL_TEST_CTX *test_ctx = NULL;
+    HANDSHAKE_RESULT result;
+
+    server_ctx = SSL_CTX_new(TLS_server_method());
+    client_ctx = SSL_CTX_new(TLS_client_method());
+    OPENSSL_assert(server_ctx != NULL && client_ctx != NULL);
+
+    OPENSSL_assert(CONF_modules_load(conf, fixture.test_app, 0) > 0);
+
+    if(!SSL_CTX_config(server_ctx, "server")
+       || !SSL_CTX_config(client_ctx, "client")) {
+           goto err;
+    }
+
+    test_ctx = SSL_TEST_CTX_create(conf, fixture.test_app);
+    if (test_ctx == NULL)
+        goto err;
+
+    result = do_handshake(server_ctx, client_ctx);
+
+    if (check_test(result, test_ctx))
+        ret = 0;
+
+err:
+    CONF_modules_unload(0);
+    SSL_CTX_free(server_ctx);
+    SSL_CTX_free(client_ctx);
+    SSL_TEST_CTX_free(test_ctx);
+    if (ret != 0)
+        ERR_print_errors_fp(stderr);
+    return ret;
+}
+
+static void tear_down(SSL_TEST_FIXTURE fixture)
+{
+}
+
+#define SETUP_SSL_TEST_FIXTURE()                        \
+    SETUP_TEST_FIXTURE(SSL_TEST_FIXTURE, set_up)
+#define EXECUTE_SSL_TEST()             \
+    EXECUTE_TEST(execute_test, tear_down)
+
+static int test_handshake(int idx)
+{
+    SETUP_SSL_TEST_FIXTURE();
+    snprintf(fixture.test_app, sizeof(fixture.test_app),
+             "test-%d", idx);
+    EXECUTE_SSL_TEST();
+}
+
+int main(int argc, char **argv)
+{
+    int result = 0;
+    long num_tests;
+
+    if (argc != 2)
+        return 1;
+
+    conf = NCONF_new(NULL);
+    OPENSSL_assert(conf != NULL);
+
+    /* argv[1] should point to the test conf file */
+    OPENSSL_assert(NCONF_load(conf, argv[1], NULL) > 0);
+
+    OPENSSL_assert(NCONF_get_number_e(conf, NULL, "num_tests", &num_tests));
+
+    ADD_ALL_TESTS(test_handshake, (int)(num_tests));
+    result = run_tests(argv[0]);
+
+    CONF_modules_free();
+    return result;
+}

--- a/test/ssl_test.tmpl
+++ b/test/ssl_test.tmpl
@@ -1,0 +1,27 @@
+[{-$testname-}]
+ssl_conf = {-$testname-}-ssl
+
+[{-$testname-}-ssl]
+server = {-$testname-}-server
+client = {-$testname-}-client
+
+[{-$testname-}-server]
+{-
+    foreach my $key (sort keys %server) {
+        $OUT .= qq{$key} . " = " . qq{$server{$key}\n} if defined $server{$key};
+    }
+-}
+
+[{-$testname-}-client]
+{-
+    foreach my $key (sort keys %client) {
+        $OUT .= qq{$key} . " = " . qq{$client{$key}\n} if defined $client{$key};
+    }
+-}
+
+[test-{-$idx-}]
+{-
+    foreach my $key (sort keys %test) {
+        $OUT .= qq{$key} ." = " . qq{$test{$key}\n} if defined $test{$key};
+    }
+-}

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL licenses, (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#include <string.h>
+
+#include <openssl/e_os2.h>
+#include <openssl/crypto.h>
+
+#include "e_os.h"
+#include "ssl_test_ctx.h"
+
+/* True enums and other test configuration values that map to an int. */
+typedef struct {
+    const char *name;
+    int value;
+} test_enum;
+
+
+__owur static int parse_enum(const test_enum *enums, size_t num_enums,
+                             int *value, const char *name)
+{
+    size_t i;
+    for (i = 0; i < num_enums; i++) {
+        if (strcmp(enums[i].name, name) == 0) {
+            *value = enums[i].value;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static const char *enum_name(const test_enum *enums, size_t num_enums,
+                             int value)
+{
+    size_t i;
+    for (i = 0; i < num_enums; i++) {
+        if (enums[i].value == value) {
+            return enums[i].name;
+        }
+    }
+    return "InvalidValue";
+}
+
+
+/*******************/
+/* ExpectedResult. */
+/*******************/
+
+static const test_enum ssl_test_results[] = {
+    {"Success", SSL_TEST_SUCCESS},
+    {"ServerFail", SSL_TEST_SERVER_FAIL},
+    {"ClientFail", SSL_TEST_CLIENT_FAIL},
+    {"InternalError", SSL_TEST_INTERNAL_ERROR},
+};
+
+__owur static int parse_expected_result(SSL_TEST_CTX *test_ctx, const char *value)
+{
+    int ret_value;
+    if (!parse_enum(ssl_test_results, OSSL_NELEM(ssl_test_results),
+                    &ret_value, value)) {
+        return 0;
+    }
+    test_ctx->expected_result = ret_value;
+    return 1;
+}
+
+const char *ssl_test_result_t_name(ssl_test_result_t result)
+{
+    return enum_name(ssl_test_results, OSSL_NELEM(ssl_test_results), result);
+}
+
+/******************************/
+/* ClientAlert / ServerAlert. */
+/******************************/
+
+static const test_enum ssl_alerts[] = {
+    {"UnknownCA", SSL_AD_UNKNOWN_CA},
+};
+
+__owur static int parse_alert(int *alert, const char *value)
+{
+    return parse_enum(ssl_alerts, OSSL_NELEM(ssl_alerts), alert, value);
+}
+
+__owur static int parse_client_alert(SSL_TEST_CTX *test_ctx, const char *value)
+{
+    return parse_alert(&test_ctx->client_alert, value);
+}
+
+__owur static int parse_server_alert(SSL_TEST_CTX *test_ctx, const char *value)
+{
+    return parse_alert(&test_ctx->server_alert, value);
+}
+
+const char *ssl_alert_name(int alert)
+{
+    return enum_name(ssl_alerts, OSSL_NELEM(ssl_alerts), alert);
+}
+
+/************/
+/* Protocol */
+/************/
+
+static const test_enum ssl_protocols[] = {
+     {"TLSv1.2", TLS1_2_VERSION},
+     {"TLSv1.1", TLS1_1_VERSION},
+     {"TLSv1", TLS1_VERSION},
+     {"SSLv3", SSL3_VERSION},
+};
+
+__owur static int parse_protocol(SSL_TEST_CTX *test_ctx, const char *value)
+{
+    return parse_enum(ssl_protocols, OSSL_NELEM(ssl_protocols),
+                      &test_ctx->protocol, value);
+}
+
+const char *ssl_protocol_name(int protocol)
+{
+    return enum_name(ssl_protocols, OSSL_NELEM(ssl_protocols), protocol);
+}
+
+
+/*************************************************************/
+/* Known test options and their corresponding parse methods. */
+/*************************************************************/
+
+typedef struct {
+    const char *name;
+    int (*parse)(SSL_TEST_CTX *test_ctx, const char *value);
+} ssl_test_ctx_option;
+
+static const ssl_test_ctx_option ssl_test_ctx_options[] = {
+    { "ExpectedResult", &parse_expected_result },
+    { "ClientAlert", &parse_client_alert },
+    { "ServerAlert", &parse_server_alert },
+    { "Protocol", &parse_protocol },
+};
+
+
+/*
+ * Since these methods are used to create tests, we use OPENSSL_assert liberally
+ * for malloc failures and other internal errors.
+ */
+SSL_TEST_CTX *SSL_TEST_CTX_new()
+{
+    SSL_TEST_CTX *ret;
+    ret = OPENSSL_zalloc(sizeof(*ret));
+    OPENSSL_assert(ret != NULL);
+    ret->expected_result = SSL_TEST_SUCCESS;
+    return ret;
+}
+
+void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx)
+{
+    OPENSSL_free(ctx);
+}
+
+SSL_TEST_CTX *SSL_TEST_CTX_create(const CONF *conf, const char *test_section)
+{
+    STACK_OF(CONF_VALUE) *sk_conf;
+    SSL_TEST_CTX *ctx;
+    int i;
+    size_t j;
+
+    sk_conf = NCONF_get_section(conf, test_section);
+    OPENSSL_assert(sk_conf != NULL);
+
+    ctx = SSL_TEST_CTX_new();
+    OPENSSL_assert(ctx != NULL);
+
+    for (i = 0; i < sk_CONF_VALUE_num(sk_conf); i++) {
+        int found = 0;
+        const CONF_VALUE *option = sk_CONF_VALUE_value(sk_conf, i);
+        for (j = 0; j < OSSL_NELEM(ssl_test_ctx_options); j++) {
+            if (strcmp(option->name, ssl_test_ctx_options[j].name) == 0) {
+                if (!ssl_test_ctx_options[j].parse(ctx, option->value)) {
+                    fprintf(stderr, "Bad value %s for option %s\n",
+                            option->value, option->name);
+                    goto err;
+                }
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            fprintf(stderr, "Unknown test option: %s\n", option->name);
+            goto err;
+        }
+    }
+
+    goto done;
+
+ err:
+    SSL_TEST_CTX_free(ctx);
+    ctx = NULL;
+ done:
+    return ctx;
+}

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL licenses, (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#ifndef HEADER_SSL_TEST_CONF_H
+#define HEADER_SSL_TEST_CONF_H
+
+#include <openssl/conf.h>
+#include <openssl/ssl.h>
+
+typedef enum {
+    SSL_TEST_SUCCESS,  /* Default */
+    SSL_TEST_SERVER_FAIL,
+    SSL_TEST_CLIENT_FAIL,
+    SSL_TEST_INTERNAL_ERROR
+} ssl_test_result_t;
+
+typedef struct ssl_test_ctx {
+    /* Test expectations. */
+    /* Defaults to SUCCESS. */
+    ssl_test_result_t expected_result;
+    /* Alerts. 0 if no expectation. */
+    /* See ssl.h for alert codes. */
+    /* Alert sent by the client / received by the server. */
+    int client_alert;
+    /* Alert sent by the server / received by the client. */
+    int server_alert;
+    /* Negotiated protocol version. 0 if no expectation. */
+    /* See ssl.h for protocol versions. */
+    int protocol;
+} SSL_TEST_CTX;
+
+const char *ssl_test_result_t_name(ssl_test_result_t result);
+const char *ssl_alert_name(int alert);
+const char *ssl_protocol_name(int protocol);
+
+/*
+ * Load the test case context from |conf|.
+ * See test/README.ssl_test for details on the conf file format.
+ */
+SSL_TEST_CTX *SSL_TEST_CTX_create(const CONF *conf, const char *test_section);
+
+SSL_TEST_CTX *SSL_TEST_CTX_new(void);
+
+void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx);
+#endif

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -8,8 +8,8 @@
  * or in the file LICENSE in the source distribution.
  */
 
-#ifndef HEADER_SSL_TEST_CONF_H
-#define HEADER_SSL_TEST_CONF_H
+#ifndef HEADER_SSL_TEST_CTX_H
+#define HEADER_SSL_TEST_CTX_H
 
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
@@ -49,4 +49,5 @@ SSL_TEST_CTX *SSL_TEST_CTX_create(const CONF *conf, const char *test_section);
 SSL_TEST_CTX *SSL_TEST_CTX_new(void);
 
 void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx);
-#endif
+
+#endif  /* HEADER_SSL_TEST_CTX_H */

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL licenses, (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+/*
+ * Ideally, CONF should offer standard parsing methods and cover them
+ * in tests. But since we have no CONF tests, we use a custom test for now.
+ */
+
+#include <stdio.h>
+
+#include "e_os.h"
+#include "ssl_test_ctx.h"
+#include "testutil.h"
+#include <openssl/e_os2.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/ssl.h>
+
+static CONF *conf = NULL;
+
+typedef struct ssl_test_ctx_test_fixture {
+    const char *test_case_name;
+    const char *test_section;
+    /* Expected parsed configuration. */
+    SSL_TEST_CTX *expected_ctx;
+} SSL_TEST_CTX_TEST_FIXTURE;
+
+/* Returns 1 if the contexts are equal, 0 otherwise. */
+static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
+{
+    if (ctx->expected_result != ctx2->expected_result) {
+        fprintf(stderr, "ExpectedResult mismatch: %s vs %s.\n",
+                ssl_test_result_t_name(ctx->expected_result),
+                ssl_test_result_t_name(ctx2->expected_result));
+        return 0;
+    }
+    if (ctx->client_alert != ctx2->client_alert) {
+        fprintf(stderr, "ClientAlert mismatch: %s vs %s.\n",
+                ssl_alert_name(ctx->expected_result),
+                ssl_alert_name(ctx2->expected_result));
+        return 0;
+    }
+    if (ctx->server_alert != ctx2->server_alert) {
+        fprintf(stderr, "ServerAlert mismatch: %s vs %s.\n",
+                ssl_alert_name(ctx->expected_result),
+                ssl_alert_name(ctx2->expected_result));
+        return 0;
+    }
+    if (ctx->protocol != ctx2->protocol) {
+        fprintf(stderr, "ClientAlert mismatch: %s vs %s.\n",
+                ssl_protocol_name(ctx->expected_result),
+                ssl_protocol_name(ctx2->expected_result));
+        return 0;
+    }
+
+    return 1;
+}
+
+static SSL_TEST_CTX_TEST_FIXTURE set_up(const char *const test_case_name)
+{
+    SSL_TEST_CTX_TEST_FIXTURE fixture;
+    fixture.test_case_name = test_case_name;
+    fixture.expected_ctx = SSL_TEST_CTX_new();
+    OPENSSL_assert(fixture.expected_ctx != NULL);
+    return fixture;
+}
+
+static int execute_test(SSL_TEST_CTX_TEST_FIXTURE fixture)
+{
+    int ret = 1;
+
+    SSL_TEST_CTX *ctx = SSL_TEST_CTX_create(conf, fixture.test_section);
+
+    if (ctx == NULL) {
+        fprintf(stderr, "Failed to parse good configuration %s.\n",
+                fixture.test_section);
+        goto err;
+    }
+
+    if (!SSL_TEST_CTX_equal(ctx, fixture.expected_ctx))
+        goto err;
+
+    ret = 0;
+ err:
+    SSL_TEST_CTX_free(ctx);
+    return ret;
+}
+
+static int execute_failure_test(SSL_TEST_CTX_TEST_FIXTURE fixture)
+{
+    SSL_TEST_CTX *ctx = SSL_TEST_CTX_create(conf, fixture.test_section);
+
+    if (ctx != NULL) {
+        fprintf(stderr, "Parsing bad configuration %s succeeded.\n",
+                fixture.test_section);
+        SSL_TEST_CTX_free(ctx);
+        return 1;
+    }
+
+    return 0;
+}
+
+static void tear_down(SSL_TEST_CTX_TEST_FIXTURE fixture)
+{
+    SSL_TEST_CTX_free(fixture.expected_ctx);
+    ERR_print_errors_fp(stderr);
+}
+
+#define SETUP_SSL_TEST_CTX_TEST_FIXTURE()                       \
+    SETUP_TEST_FIXTURE(SSL_TEST_CTX_TEST_FIXTURE, set_up)
+#define EXECUTE_SSL_TEST_CTX_TEST()             \
+    EXECUTE_TEST(execute_test, tear_down)
+#define EXECUTE_SSL_TEST_CTX_FAILURE_TEST()             \
+    EXECUTE_TEST(execute_failure_test, tear_down)
+
+static int test_empty_configuration()
+{
+    SETUP_SSL_TEST_CTX_TEST_FIXTURE();
+    fixture.test_section = "ssltest_default";
+    fixture.expected_ctx->expected_result = SSL_TEST_SUCCESS;
+    EXECUTE_SSL_TEST_CTX_TEST();
+}
+
+static int test_good_configuration()
+{
+    SETUP_SSL_TEST_CTX_TEST_FIXTURE();
+    fixture.test_section = "ssltest_good";
+    fixture.expected_ctx->expected_result = SSL_TEST_SERVER_FAIL;
+    fixture.expected_ctx->client_alert = SSL_AD_UNKNOWN_CA;
+    fixture.expected_ctx->server_alert = 0;  /* No alert. */
+    fixture.expected_ctx->protocol = TLS1_1_VERSION;
+    EXECUTE_SSL_TEST_CTX_TEST();
+}
+
+static const char *bad_configurations[] = {
+    "ssltest_unknown_option",
+    "ssltest_unknown_expected_result",
+    "ssltest_unknown_alert",
+    "ssltest_unknown_protocol",
+};
+
+static int test_bad_configuration(int idx)
+{
+        SETUP_SSL_TEST_CTX_TEST_FIXTURE();
+        fixture.test_section = bad_configurations[idx];
+        EXECUTE_SSL_TEST_CTX_FAILURE_TEST();
+}
+
+int main(int argc, char **argv)
+{
+    int result = 0;
+
+    if (argc != 2)
+        return 1;
+
+    conf = NCONF_new(NULL);
+    OPENSSL_assert(conf != NULL);
+
+    /* argv[1] should point to test/ssl_test_ctx_test.conf */
+    OPENSSL_assert(NCONF_load(conf, argv[1], NULL) > 0);
+
+
+    ADD_TEST(test_empty_configuration);
+    ADD_TEST(test_good_configuration);
+    ADD_ALL_TESTS(test_bad_configuration, OSSL_NELEM(bad_configurations));
+
+    result = run_tests(argv[0]);
+
+    NCONF_free(conf);
+
+    return result;
+}

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -1,0 +1,18 @@
+[ssltest_default]
+
+[ssltest_good]
+ExpectedResult = ServerFail
+ClientAlert = UnknownCA
+Protocol = TLSv1.1
+
+[ssltest_unknown_option]
+UnknownOption = Foo
+
+[ssltest_unknown_expected_result]
+ExpectedResult = Foo
+
+[ssltest_unknown_alert]
+ServerAlert = Foo
+
+[ssltest_unknown_protocol]
+Protocol = Foo

--- a/test/testutil.c
+++ b/test/testutil.c
@@ -68,37 +68,70 @@
 typedef struct test_info {
     const char *test_case_name;
     int (*test_fn) ();
+    int (*param_test_fn)(int idx);
+    int num;
 } TEST_INFO;
 
 static TEST_INFO all_tests[1024];
 static int num_tests = 0;
+/*
+ * A parameterised tests runs a loop of test cases.
+ * |num_test_cases| counts the total number of test cases
+ * across all tests.
+ */
+static int num_test_cases = 0;
 
 void add_test(const char *test_case_name, int (*test_fn) ())
 {
     assert(num_tests != OSSL_NELEM(all_tests));
     all_tests[num_tests].test_case_name = test_case_name;
     all_tests[num_tests].test_fn = test_fn;
+    all_tests[num_tests].num = -1;
+    ++num_test_cases;
     ++num_tests;
+}
+
+void add_all_tests(const char *test_case_name, int(*test_fn)(int idx),
+                   int num)
+{
+    assert(num_tests != OSSL_NELEM(all_tests));
+    all_tests[num_tests].test_case_name = test_case_name;
+    all_tests[num_tests].param_test_fn = test_fn;
+    all_tests[num_tests].num = num;
+    ++num_tests;
+    num_test_cases += num;
 }
 
 int run_tests(const char *test_prog_name)
 {
     int num_failed = 0;
-    int i = 0;
 
-    printf("%s: %d test case%s\n", test_prog_name, num_tests,
-           num_tests == 1 ? "" : "s");
+    int i, j;
+
+    printf("%s: %d test case%s\n", test_prog_name, num_test_cases,
+           num_test_cases == 1 ? "" : "s");
+
     for (i = 0; i != num_tests; ++i) {
-        if (all_tests[i].test_fn()) {
-            printf("** %s failed **\n--------\n",
-                   all_tests[i].test_case_name);
-            ++num_failed;
+        if (all_tests[i].num == -1) {
+            if (all_tests[i].test_fn()) {
+                printf("** %s failed **\n--------\n",
+                       all_tests[i].test_case_name);
+                ++num_failed;
+            }
+        } else {
+            for (j = 0; j < all_tests[i].num; j++) {
+                if (all_tests[i].param_test_fn(j)) {
+                    printf("** %s failed test %d\n--------\n",
+                           all_tests[i].test_case_name, j);
+                    ++num_failed;
+                }
+            }
         }
     }
 
     if (num_failed != 0) {
         printf("%s: %d test%s failed (out of %d)\n", test_prog_name,
-               num_failed, num_failed != 1 ? "s" : "", num_tests);
+               num_failed, num_failed != 1 ? "s" : "", num_test_cases);
         return EXIT_FAILURE;
     }
     printf("  All tests passed.\n");

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -90,8 +90,8 @@
  *      }
  */
 # define SETUP_TEST_FIXTURE(TEST_FIXTURE_TYPE, set_up)\
-        TEST_FIXTURE_TYPE fixture = set_up(TEST_CASE_NAME);\
-        int result = 0
+    TEST_FIXTURE_TYPE fixture = set_up(TEST_CASE_NAME); \
+    int result = 0
 
 # define EXECUTE_TEST(execute_func, tear_down)\
         if (execute_func(fixture) != 0) result = 1;\
@@ -120,7 +120,16 @@
  * returned from run_tests() should be used as the return value for main().
  */
 # define ADD_TEST(test_function) add_test(#test_function, test_function)
+
+/*
+ * Simple parameterized tests. Adds a test_function(idx) test for each
+ * 0 <= idx < num.
+ */
+# define ADD_ALL_TESTS(test_function, num) \
+  add_all_tests(#test_function, test_function, num)
+
 void add_test(const char *test_case_name, int (*test_fn) ());
+void add_all_tests(const char *test_case_name, int (*test_fn)(int idx), int num);
 int run_tests(const char *test_prog_name);
 
 #endif                          /* HEADER_TESTUTIL_H */


### PR DESCRIPTION
Currently, SSL tests are configured via command-line switches to
ssltest.c. This results in a lot of duplication between ssltest.c and
apps, and a complex setup. ssltest.c is also simply old and needs
maintenance.

Instead, we already have a way to configure SSL servers and clients, so
we leverage that. SSL tests can now be configured from a configuration
file. Test servers and clients are configured using the standard
ssl_conf module. Additional test settings are configured via a test
configuration.

Moreover, since the CONF language involves unnecessary boilerplate, the
test conf itself is generated from a shorter Perl syntax.

The generated testcase files are checked in to the repo to make
it easier to verify that the intended test cases are in fact run; and to
simplify debugging failures.

To demonstrate the approach, min/max protocol tests are converted to the
new format. This change also fixes MinProtocol and MaxProtocol
handling. It was previously requested that an SSL_CTX have both the
server and client flags set for these commands; this clearly can never work.

Guide to this PR:
 - test/ssl_test.c - test framework
 - test/ssl_test_ctx.* - test configuration structure
 - test/handshake_helper.* - new SSL test handshaking code
 - test/ssl-tests/ - test configurations
 - test/generate_ssl_tests.pl - script for generating CONF-style test
   configurations from perl inputs