### PR TITLE
Issue #719:

### DIFF
--- a/doc/ssl/SSL_CTX_use_serverinfo.pod
+++ b/doc/ssl/SSL_CTX_use_serverinfo.pod
@@ -30,6 +30,14 @@ must consist of a 2-byte Extension Type, a 2-byte length, and then length
 bytes of extension_data.  Each PEM extension name must begin with the phrase
 "BEGIN SERVERINFO FOR ".
 
+If more than one certificate (RSA/DSA) is installed using
+SSL_CTX_use_certificate(), the serverinfo extension will be loaded into the
+last certificate installed.  If e.g. the last item was a RSA certificate, the
+loaded serverinfo extension data will be loaded for that certificate.  To
+use the serverinfo extension for multiple certificates,
+SSL_CTX_use_serverinfo() needs to be called multiple times, once B<after>
+each time a certificate is loaded.
+
 =head1 NOTES
 
 =head1 RETURN VALUES

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -841,7 +841,7 @@ static int serverinfo_srv_add_cb(SSL *s, unsigned int ext_type,
             return 0;           /* No extension found, don't send extension */
         return 1;               /* Send extension */
     }
-    return -1;                  /* No serverinfo data found, don't send
+    return 0;                   /* No serverinfo data found, don't send
                                  * extension */
 }
 
@@ -870,12 +870,27 @@ static int serverinfo_process_buffer(const unsigned char *serverinfo,
 
         /* Register callbacks for extensions */
         ext_type = (serverinfo[0] << 8) + serverinfo[1];
-        if (ctx && !SSL_CTX_add_server_custom_ext(ctx, ext_type,
-                                                  serverinfo_srv_add_cb,
-                                                  NULL, NULL,
-                                                  serverinfo_srv_parse_cb,
-                                                  NULL))
-            return 0;
+        if (ctx) {
+            int have_ext_cbs = 0;
+            size_t i;
+            custom_ext_methods *exts = &ctx->cert->srv_ext;
+            custom_ext_method *meth = exts->meths;
+
+            /* check for existing callbacks for this extension */
+            for (i = 0; i < exts->meths_count; i++, meth++) {
+                if (ext_type == meth->ext_type) {
+                    have_ext_cbs = 1;
+                    break;
+                }
+            }
+
+            if (!have_ext_cbs && !SSL_CTX_add_server_custom_ext(ctx, ext_type,
+                                                                serverinfo_srv_add_cb,
+                                                                NULL, NULL,
+                                                                serverinfo_srv_parse_cb,
+                                                                NULL))
+                return 0;
+        }
 
         serverinfo += 2;
         serverinfo_length -= 2;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -876,7 +876,6 @@ static int serverinfo_process_buffer(const unsigned char *serverinfo,
             custom_ext_methods *exts = &ctx->cert->srv_ext;
             custom_ext_method *meth = exts->meths;
 
-            /* check for existing callbacks for this extension */
             for (i = 0; i < exts->meths_count; i++, meth++) {
                 if (ext_type == meth->ext_type) {
                     have_ext_cbs = 1;


### PR DESCRIPTION
If no serverinfo extension is found in some cases, do not abort the handshake,
but simply omit/skip that extension.

Check for already-registered serverinfo callbacks during serverinfo
registration.

Update SSL_CTX_use_serverinfo() documentation to mention the need to reload the
same serverinfo per certificate, for servers with multiple server certificates.