### PR TITLE
Backport of ccae4a1582efcad311d095a8e6832b2b67d5ed05

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -750,6 +750,8 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
+#define OSSL_NELEM(x)    (sizeof(x)/sizeof(x[0]))
+
 /* beos */
 # if defined(OPENSSL_SYS_BEOS_R5)
 #  define SO_ERROR 0

--- a/ssl/s23_lib.c
+++ b/ssl/s23_lib.c
@@ -76,7 +76,9 @@ long ssl23_default_timeout(void)
  */
 int ssl23_version_supported(const SSL *s, int version)
 {
-    if (s->method == SSLv23_method()) {
+    if (s->method == SSLv23_method() ||
+        s->method == SSLv23_client_method() ||
+        s->method == SSLv23_server_method()) {
 #ifndef OPENSSL_NO_SSL3
         if ((s->options & SSL_OP_NO_SSLv3) == 0 && version == SSL3_VERSION)
             return 1;

--- a/ssl/s23_lib.c
+++ b/ssl/s23_lib.c
@@ -65,6 +65,42 @@ long ssl23_default_timeout(void)
     return (300);
 }
 
+ /*
+ * ssl23_version_supported - Check that the specified `version` is supported by
+ * `SSL *` instance
+ *
+ * @s: The SSL handle for the candidate method
+ * @version: Protocol version to test against
+ *
+ * Returns 1 when supported, otherwise 0
+ */
+int ssl23_version_supported(const SSL *s, int version)
+{
+    if (s->method == SSLv23_method()) {
+#ifndef OPENSSL_NO_SSL3
+        if ((s->options & SSL_OP_NO_SSLv3) == 0 && version == SSL3_VERSION)
+            return 1;
+#endif
+        if ((s->options & SSL_OP_NO_TLSv1) == 0 && version == TLS1_VERSION)
+            return 1;
+        if ((s->options & SSL_OP_NO_TLSv1_1) == 0 && version == TLS1_1_VERSION)
+            return 1;
+        if ((s->options & SSL_OP_NO_TLSv1_2) == 0 && version == TLS1_2_VERSION)
+            return 1;
+    } else if (s->version == DTLS_ANY_VERSION) {
+        if ((s->options & SSL_OP_NO_DTLSv1) == 0 && version == DTLS1_VERSION)
+            return 1;
+        if ((s->options & SSL_OP_NO_DTLSv1_2) == 0 &&
+            version == DTLS1_2_VERSION) {
+            return 1;
+        }
+    } else {
+        return s->version == version;
+    }
+
+    return 0;
+}
+
 int ssl23_num_ciphers(void)
 {
     return (ssl3_num_ciphers()

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -3089,6 +3089,7 @@ void ERR_load_SSL_strings(void);
 # define SSL_R_SSL_SESSION_ID_CONTEXT_TOO_LONG            273
 # define SSL_R_SSL_SESSION_ID_HAS_BAD_LENGTH              303
 # define SSL_R_SSL_SESSION_ID_IS_DIFFERENT                231
+# define SSL_R_SSL_SESSION_VERSION_MISMATCH               394
 # define SSL_R_TLSV1_ALERT_ACCESS_DENIED                  1049
 # define SSL_R_TLSV1_ALERT_DECODE_ERROR                   1050
 # define SSL_R_TLSV1_ALERT_DECRYPTION_FAILED              1021

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -1,6 +1,6 @@
 /* ssl/ssl_err.c */
 /* ====================================================================
- * Copyright (c) 1999-2015 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2016 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -708,6 +708,8 @@ static ERR_STRING_DATA SSL_str_reasons[] = {
      "ssl session id has bad length"},
     {ERR_REASON(SSL_R_SSL_SESSION_ID_IS_DIFFERENT),
      "ssl session id is different"},
+    {ERR_REASON(SSL_R_SSL_SESSION_VERSION_MISMATCH),
+     "ssl session version mismatch"},
     {ERR_REASON(SSL_R_TLSV1_ALERT_ACCESS_DENIED),
      "tlsv1 alert access denied"},
     {ERR_REASON(SSL_R_TLSV1_ALERT_DECODE_ERROR), "tlsv1 alert decode error"},

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1205,6 +1205,8 @@ long ssl3_default_timeout(void);
 void ssl3_set_handshake_header(SSL *s, int htype, unsigned long len);
 int ssl3_handshake_write(SSL *s);
 
+int ssl23_version_supported(const SSL *s, int version);
+
 int ssl23_num_ciphers(void);
 const SSL_CIPHER *ssl23_get_cipher(unsigned int u);
 int ssl23_read(SSL *s, void *buf, int len);

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -899,19 +899,9 @@ void SSL_SESSION_free(SSL_SESSION *ss)
 int SSL_set_session(SSL *s, SSL_SESSION *session)
 {
     int ret = 0;
-    const SSL_METHOD *meth;
-
     if (session != NULL) {
-        meth = s->ctx->method->get_ssl_method(session->ssl_version);
-        if (meth == NULL)
-            meth = s->method->get_ssl_method(session->ssl_version);
-        if (meth == NULL) {
-            SSLerr(SSL_F_SSL_SET_SESSION, SSL_R_UNABLE_TO_FIND_SSL_METHOD);
-            return (0);
-        }
-
-        if (meth != s->method) {
-            if (!SSL_set_ssl_method(s, meth))
+        if (s->ctx->method != s->method) {
+            if (!SSL_set_ssl_method(s, s->ctx->method))
                 return (0);
         }
 #ifndef OPENSSL_NO_KRB5
@@ -934,14 +924,10 @@ int SSL_set_session(SSL *s, SSL_SESSION *session)
         /* CRYPTO_w_unlock(CRYPTO_LOCK_SSL); */
         ret = 1;
     } else {
-        if (s->session != NULL) {
-            SSL_SESSION_free(s->session);
-            s->session = NULL;
-        }
-
-        meth = s->ctx->method;
-        if (meth != s->method) {
-            if (!SSL_set_ssl_method(s, meth))
+        SSL_SESSION_free(s->session);
+        s->session = NULL;
+        if (s->ctx->method != s->method) {
+            if (!SSL_set_ssl_method(s, s->ctx->method))
                 return (0);
         }
         ret = 1;

--- a/test/testssl
+++ b/test/testssl
@@ -31,6 +31,8 @@ else
 fi
 
 serverinfo="./serverinfo.pem"
+server_sess="server.ss"
+client_sess="client.ss"
 
 #############################################################################
 
@@ -272,5 +274,43 @@ if [ -z "$extra" -a `uname -m` = "x86_64" ]; then
   $ssltest -cipher AES128-SHA    -bytes 8m	|| exit 1
   $ssltest -cipher AES128-SHA256 -bytes 8m	|| exit 1
 fi
+
+#############################################################################
+# TLS session reuse
+
+$ssltest -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate tls1.2 || exit 1
+$ssltest -no-srv-tls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate tls1.1 || exit 1
+
+$ssltest -no-srv-tls1_2 -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -no-srv-tls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate tls1.1 || exit 1
+$ssltest -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate tls1.2 || exit 1
+
+$ssltest -no_ticket -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -no_ticket -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate tls1.2 || exit 1
+$ssltest -no_ticket -no-srv-tls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate tls1.1 || exit 1
+
+$ssltest -no_ticket -no-srv-tls1_2 -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -no_ticket -no-srv-tls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate tls1.1 || exit 1
+$ssltest -no_ticket -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate tls1.2 || exit 1
+
+#############################################################################
+# DTLS session reuse
+
+$ssltest -dtls -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -dtls -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate dtls1.2 || exit 1
+$ssltest -dtls1 -no-srv-dtls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate dtls1 || exit 1
+
+$ssltest -dtls1 -no-srv-dtls1_2 -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -dtls1 -no-srv-dtls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate dtls1 || exit 1
+$ssltest -dtls -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate dtls1.2 || exit 1
+
+$ssltest -dtls -no_ticket -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -dtls -no_ticket -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate dtls1.2 || exit 1
+$ssltest -dtls1 -no_ticket -no-srv-dtls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate dtls1 || exit 1
+
+$ssltest -dtls1 -no_ticket -no-srv-dtls1_2 -server_sess_out $server_sess -client_sess_out $client_sess || exit 1
+$ssltest -dtls1 -no_ticket -no-srv-dtls1_2 -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 1 -should_negotiate dtls1 || exit 1
+$ssltest -dtls -no_ticket -server_sess_in $server_sess -client_sess_in $client_sess -should_reuse 0 -should_negotiate dtls1.2 || exit 1
 
 exit 0


### PR DESCRIPTION
This is a backport of two commits:
- ccae4a1582efcad311d095a8e6832b2b67d5ed05
- b7dffce017aa045272c42eeb5da40804015a759a
### Main differences between ccae4a1582efcad311d095a8e6832b2b67d5ed05 and approach here:

1.0.2 has two clients: s23 and s3. `s->method` was set early on `SSL_set_session` call to make `SSL_connect` call `s3_client_hello`, which is capable of generating client hello with session. So the logical step was to introduce session field to `s23_client_hello`. Additionally, some copy-pasted code was added in `s3_clnt` to handle session resumption and version support.

NULL and deprecate `ssl_get_method` instead of removing it from the structure. Needed for ABI-compatbility.

`ssl23_version_supported` is slightly different, as there are no method tables in 1.0.2. Hopefully it is ok.
### Notes

I took some courage to include some other changes from master into ssltest to allow running tests from b7dffce017aa045272c42eeb5da40804015a759a. However `dtls` tests are in quite odd shape here, since there are no `-dtls` flag (will probably add it later, if the rest looks ok).

cc @kroeckx @mattcaswell @davidben PTAL, I will be glad to answer any questions or incorporate any suggested changes. Tests appears to be passing locally.
