### PR TITLE
Call EC_GROUP_order_bits in priv2opt.

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -607,7 +607,7 @@ size_t ec_key_simple_priv2oct(const EC_KEY *eckey,
 {
     size_t buf_len;
 
-    buf_len = (EC_GROUP_get_degree(eckey->group) + 7) / 8;
+    buf_len = (EC_GROUP_order_bits(eckey->group) + 7) / 8;
     if (eckey->priv_key == NULL)
         return 0;
     if (buf == NULL)


### PR DESCRIPTION
The private key is a scalar and should be sized by the order, not the
degree.
