### PR TITLE
Fixup SSL EX_DATA index

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -218,9 +218,8 @@ DEFINE_STACK_OF(void)
 # define CRYPTO_EX_INDEX_ENGINE          10
 # define CRYPTO_EX_INDEX_UI              11
 # define CRYPTO_EX_INDEX_BIO             12
-# define CRYPTO_EX_INDEX_STORE           13
-# define CRYPTO_EX_INDEX_APP             14
-# define CRYPTO_EX_INDEX__COUNT          15
+# define CRYPTO_EX_INDEX_APP             13
+# define CRYPTO_EX_INDEX__COUNT          14
 
 /*
  * This is the default callbacks, but we can have others as well: this is

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1764,15 +1764,15 @@ __owur size_t SSL_SESSION_get_master_key(const SSL_SESSION *ssl,
                                          unsigned char *out, size_t outlen);
 
 #define SSL_get_ex_new_index(l, p, newf, dupf, freef) \
-    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_SESSION, l, p, newf, dupf, freef)
+    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL, l, p, newf, dupf, freef)
 __owur int SSL_set_ex_data(SSL *ssl, int idx, void *data);
 void *SSL_get_ex_data(const SSL *ssl, int idx);
 #define SSL_SESSION_get_ex_new_index(l, p, newf, dupf, freef) \
-    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX, l, p, newf, dupf, freef)
+    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_SESSION, l, p, newf, dupf, freef)
 __owur int SSL_SESSION_set_ex_data(SSL_SESSION *ss, int idx, void *data);
 void *SSL_SESSION_get_ex_data(const SSL_SESSION *ss, int idx);
 #define SSL_CTX_get_ex_new_index(l, p, newf, dupf, freef) \
-    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL, l, p, newf, dupf, freef)
+    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX, l, p, newf, dupf, freef)
 __owur int SSL_CTX_set_ex_data(SSL_CTX *ssl, int idx, void *data);
 void *SSL_CTX_get_ex_data(const SSL_CTX *ssl, int idx);
 


### PR DESCRIPTION
The SSL, SSL_CTX, and SSL_SESSION indices were being referenced
incorrectly in the "_get_ex_new_index" functions.

Remove the STORE EX_DATA index; that functionality is gone.