### PR TITLE
OCSP Updates: error codes and multiple certificates

### DIFF
--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -169,6 +169,12 @@ const char *X509_verify_cert_error_string(long n)
         return ("Certificate Transparency required, but no valid SCTs found");
     case X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION:
         return ("proxy subject name violation");
+    case X509_V_ERR_OCSP_VERIFY_NEEDED:
+        return("OCSP verification needed");
+    case X509_V_ERR_OCSP_VERIFY_FAILED:
+        return("OCSP verification failed");
+    case X509_V_ERR_OCSP_CERT_UNKNOWN:
+        return("OCSP unknown cert");
 
     default:
         /* Printing an error number into a static buffer is not thread-safe */

--- a/doc/man1/verify.pod
+++ b/doc/man1/verify.pod
@@ -692,6 +692,47 @@ DANE TLSA authentication is enabled, but no TLSA records matched the
 certificate chain.
 This error is only possible in L<s_client(1)>.
 
+=item B<X509_V_ERR_EE_KEY_TOO_SMALL>
+
+EE certificate key too weak.
+
+=item B<X509_ERR_CA_KEY_TOO_SMALL>
+
+CA certificate key too weak.
+
+=item B<X509_ERR_CA_MD_TOO_WEAK>
+
+CA signature digest algorithm too weak.
+
+=item B<X509_V_ERR_INVALID_CALL>
+
+nvalid certificate verification context.
+
+=item B<X509_V_ERR_STORE_LOOKUP>
+
+Issuer certificate lookup error.
+
+=item B<X509_V_ERR_NO_VALID_SCTS>
+
+Certificate Transparency required, but no valid SCTs found.
+
+=item B<X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION>
+
+Proxy subject name violation.
+
+=item B<X509_V_ERR_OCSP_VERIFY_NEEDED>
+
+Returned by the verify callback to indicate an OCSP verification is needed.
+
+=item B<X509_V_ERR_OCSP_VERIFY_FAILED>
+
+Returned by the verify callback to indicate OCSP verification failed.
+
+=item B<X509_V_ERR_OCSP_CERT_UNKNOWN>
+
+Returned by the verify callback to indicate that the certificate is not recognized
+by the OCSP responder.
+
 =back
 
 =head1 BUGS

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -180,6 +180,10 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 # define         X509_V_ERR_NO_VALID_SCTS                        71
 
 # define         X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION         72
+/* OCSP status errors */
+# define         X509_V_ERR_OCSP_VERIFY_NEEDED                   73  /* Need OCSP verification */
+# define         X509_V_ERR_OCSP_VERIFY_FAILED                   74  /* Couldn't verify cert through OCSP */
+# define         X509_V_ERR_OCSP_CERT_UNKNOWN                    75  /* Certificate wasn't recognized by the OCSP responder */
 
 /* Certificate verify flags */
 


### PR DESCRIPTION
RT3877: Add X509 OCSP error codes and messages
Add additional OCSP error codes for X509 verify usage

RT3867: Support Multiple CA certs in ocsp app
Add the ability to read multiple CA certs from a single file in the
ocsp app.
