### PR TITLE
Separate --strict-warnings and --debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ compiler:
 
 env:
     - CONFIG_OPTS="shared"
-    - CONFIG_OPTS="--debug --strict-warnings enable-crypto-mdebug enable-rc5 enable-md2"
-    - CONFIG_OPTS="" BUILDONLY="yes"
+    - CONFIG_OPTS="--debug enable-crypto-mdebug enable-rc5 enable-md2"
+    - CONFIG_OPTS="--strict-warnings" BUILDONLY="yes"
     - CONFIG_OPTS="--classic" BUILDONLY="yes"
     - CONFIG_OPTS="--classic shared" BUILDONLY="yes"
-    - CONFIG_OPTS="no-pic" BUILDONLY="yes"
-    - CONFIG_OPTS="no-engine" BUILDONLY="yes"
+    - CONFIG_OPTS="no-pic --strict-warnings" BUILDONLY="yes"
+    - CONFIG_OPTS="no-engine --strict-warnings" BUILDONLY="yes"
 
 matrix:
     include:
@@ -38,13 +38,13 @@ matrix:
           env: CONFIG_OPTS="-fsanitize=address"
         - os: linux
           compiler: clang-3.6
-          env: CONFIG_OPTS="no-asm --strict-warnings -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
+          env: CONFIG_OPTS="no-asm -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
         - os: linux
           compiler: gcc-5
           env: CONFIG_OPTS="-fsanitize=address"
         - os: linux
           compiler: gcc-5
-          env: CONFIG_OPTS="no-asm --strict-warnings -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
+          env: CONFIG_OPTS="no-asm -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
         - os: linux
           compiler: i686-w64-mingw32-gcc
           env: CONFIG_OPTS="no-pic"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ matrix:
           env: CONFIG_OPTS="-fsanitize=address"
         - os: linux
           compiler: clang-3.6
-          env: CONFIG_OPTS="no-asm -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
+          env: CONFIG_OPTS="no-asm -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2 -fno-sanitize=alignment"
         - os: linux
           compiler: gcc-5
           env: CONFIG_OPTS="-fsanitize=address"
         - os: linux
           compiler: gcc-5
-          env: CONFIG_OPTS="no-asm -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
+          env: CONFIG_OPTS="no-asm -fno-sanitize-recover -DPEDANTIC -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
         - os: linux
           compiler: i686-w64-mingw32-gcc
           env: CONFIG_OPTS="no-pic"

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,11 @@
 
  Changes between 1.0.2g and 1.1.0  [xx XXX xxxx]
 
+  *) --strict-warnings no longer enables runtime debugging options
+     such as REF_DEBUG. Instead, debug options are automatically
+     enabled with '--debug' builds.
+     [Andy Polyakov, Emilia Käsper]
+
   *) Made RSA and RSA_METHOD opaque. The structures for managing RSA
      objects have been moved out of the public header files. New
      functions for managing these have been added.

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -507,12 +507,12 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp,
 
     if (cmd == (BIO_CB_READ | BIO_CB_RETURN)) {
         BIO_printf(out, "read from %p [%p] (%lu bytes => %ld (0x%lX))\n",
-                   (void *)bio, argp, (unsigned long)argi, ret, ret);
+                   (void *)bio, (void *)argp, (unsigned long)argi, ret, ret);
         BIO_dump(out, argp, (int)ret);
         return (ret);
     } else if (cmd == (BIO_CB_WRITE | BIO_CB_RETURN)) {
         BIO_printf(out, "write to %p [%p] (%lu bytes => %ld (0x%lX))\n",
-                   (void *)bio, argp, (unsigned long)argi, ret, ret);
+                   (void *)bio, (void *)argp, (unsigned long)argi, ret, ret);
         BIO_dump(out, argp, (int)ret);
     }
     return (ret);

--- a/crypto/cast/cast_lcl.h
+++ b/crypto/cast/cast_lcl.h
@@ -151,10 +151,8 @@
 
 #if defined(OPENSSL_SYS_WIN32) && defined(_MSC_VER)
 # define ROTL(a,n)     (_lrotl(a,n))
-#elif defined(PEDANTIC)
-# define ROTL(a,n)     ((((a)<<(n))&0xffffffffL)|((a)>>((32-(n))&31)))
 #else
-# define ROTL(a,n)     ((((a)<<(n))&0xffffffffL)|((a)>>(32-(n))))
+# define ROTL(a,n)     ((((a)<<(n))&0xffffffffL)|((a)>>((32-(n))&31)))
 #endif
 
 #define C_M    0x3fc

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -101,7 +101,11 @@ static CT_TEST_FIXTURE set_up(const char *const test_case_name)
 {
     CT_TEST_FIXTURE fixture;
     int setup_ok = 1;
-    CTLOG_STORE *ctlog_store = CTLOG_STORE_new();
+    CTLOG_STORE *ctlog_store;
+
+    memset(&fixture, 0, sizeof(fixture));
+
+    ctlog_store = CTLOG_STORE_new();
 
     if (ctlog_store == NULL) {
         setup_ok = 0;
@@ -115,7 +119,6 @@ static CT_TEST_FIXTURE set_up(const char *const test_case_name)
         goto end;
     }
 
-    memset(&fixture, 0, sizeof(fixture));
     fixture.test_case_name = test_case_name;
     fixture.ctlog_store = ctlog_store;
 


### PR DESCRIPTION
Use the former for compile-time errors (with the caveat that it also
enables PEDANTIC codepaths), and the latter for runtime debugging.

Remove individual NDEBUG guards now that NDEBUG is always defined in
release builds.

In Travis, do --strict-warnings on BUILDONLY configurations. This
ensures that the tests run even if --strict-warnings fail, and avoids
hiding unrelated test failures.

Also fix a couple of warnings with clang 3.8 (one of them false positive).