### PR TITLE
Make ssl_test_new work on non-Unix.

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -711,8 +711,7 @@ dist:
 
 # Helper targets #####################################################
 
-link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/shlib_wrap.sh \
-	    $(BLDDIR)/test/generate_ssl_tests.pl
+link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/shlib_wrap.sh
 
 $(BLDDIR)/util/opensslwrap.sh: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
@@ -723,11 +722,6 @@ $(BLDDIR)/util/shlib_wrap.sh: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/util"; \
 	    ln -sf "../$(SRCDIR)/util/shlib_wrap.sh" "$(BLDDIR)/util"; \
-	fi
-$(BLDDIR)/test/generate_ssl_tests.pl: configdata.pm
-	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
-	    mkdir -p "$(BLDDIR)/test"; \
-	    ln -sf "../$(SRCDIR)/test/generate_ssl_tests.pl" "$(BLDDIR)/test"; \
 	fi
 FORCE:
 

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -48,6 +48,7 @@ sub test_conf {
 
       skip 'failure', 2 unless
         ok(run(perltest(["generate_ssl_tests.pl", $input_file],
+                        interpreter_args => [ "-I", srctop_dir("test", "testlib")],
                         stdout => $tmp_file)),
            "Getting output from generate_ssl_tests.pl.");
 


### PR DESCRIPTION
Add interpreter_args to the generate_ssl_tests perltest so that it can
locate testlib.

Also remove a symlink of generate_ssl_tests.pl to the build directory.
Now that the build scripts look for sources in both directories, this
is no longer necessary (see commit fbd361eaf84446e8d6860ab2b7ecf9d04585f2ef).