### PR TITLE
Remove proxy tests. Add verify callback tests.

### DIFF
--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -59,6 +59,11 @@ The test section supports the following options:
 * Protocol - expected negotiated protocol. One of
   SSLv3, TLSv1, TLSv1.1, TLSv1.2.
 
+* ClientVerifyCallback - the client's custom certificate verify callback.
+  Used to test callback behaviour. One of
+  - AcceptAll - accepts all certificates.
+  - RejectAll - rejects all certificates.
+
 ## Configuring the client and server
 
 The client and server configurations can be any valid `SSL_CTX`

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -30,6 +30,7 @@ typedef struct handshake_result {
 } HANDSHAKE_RESULT;
 
 /* Do a handshake and report some information about the result. */
-HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx);
+HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx,
+                              const SSL_TEST_CTX *test_ctx);
 
 #endif  /* HEADER_HANDSHAKE_HELPER_H */

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -20,8 +20,9 @@ setup("test_ssl_new");
 
 $ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
 
-my @conf_srcs =  glob(srctop_file("test", "ssl-tests", "*.conf"));
-my @conf_files = map {basename($_)} @conf_srcs;
+my @conf_srcs =  glob(srctop_file("test", "ssl-tests", "*.conf.in"));
+my @conf_files = map { basename($_) } @conf_srcs;
+map { s/\.in// } @conf_files;
 
 # 02-protocol-version.conf test results depend on the configuration of enabled
 # protocols. We only verify generated sources in the default configuration.
@@ -39,7 +40,7 @@ foreach my $conf (@conf_files) {
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 2;  # = scalar @conf_files
+plan tests => 3;  # = scalar @conf_srcs
 
 sub test_conf {
     plan tests => 3;

--- a/test/ssl-tests/03-custom_verify.conf
+++ b/test/ssl-tests/03-custom_verify.conf
@@ -1,0 +1,238 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 9
+
+test-0 = 0-verify-success
+test-1 = 1-verify-custom-reject
+test-2 = 2-verify-custom-allow
+test-3 = 3-noverify-success
+test-4 = 4-noverify-ignore-custom-reject
+test-5 = 5-noverify-accept-custom-allow
+test-6 = 6-verify-fail-no-root
+test-7 = 7-verify-custom-success-no-root
+test-8 = 8-verify-custom-fail-no-root
+# ===========================================================
+
+[0-verify-success]
+ssl_conf = 0-verify-success-ssl
+
+[0-verify-success-ssl]
+server = 0-verify-success-server
+client = 0-verify-success-client
+
+[0-verify-success-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-verify-success-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-0]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[1-verify-custom-reject]
+ssl_conf = 1-verify-custom-reject-ssl
+
+[1-verify-custom-reject-ssl]
+server = 1-verify-custom-reject-server
+client = 1-verify-custom-reject-client
+
+[1-verify-custom-reject-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-verify-custom-reject-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-1]
+ClientAlert = HandshakeFailure
+ClientVerifyCallback = RejectAll
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[2-verify-custom-allow]
+ssl_conf = 2-verify-custom-allow-ssl
+
+[2-verify-custom-allow-ssl]
+server = 2-verify-custom-allow-server
+client = 2-verify-custom-allow-client
+
+[2-verify-custom-allow-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[2-verify-custom-allow-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-2]
+ClientVerifyCallback = AcceptAll
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[3-noverify-success]
+ssl_conf = 3-noverify-success-ssl
+
+[3-noverify-success-ssl]
+server = 3-noverify-success-server
+client = 3-noverify-success-client
+
+[3-noverify-success-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[3-noverify-success-client]
+CipherString = DEFAULT
+
+
+[test-3]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[4-noverify-ignore-custom-reject]
+ssl_conf = 4-noverify-ignore-custom-reject-ssl
+
+[4-noverify-ignore-custom-reject-ssl]
+server = 4-noverify-ignore-custom-reject-server
+client = 4-noverify-ignore-custom-reject-client
+
+[4-noverify-ignore-custom-reject-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[4-noverify-ignore-custom-reject-client]
+CipherString = DEFAULT
+
+
+[test-4]
+ClientVerifyCallback = RejectAll
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[5-noverify-accept-custom-allow]
+ssl_conf = 5-noverify-accept-custom-allow-ssl
+
+[5-noverify-accept-custom-allow-ssl]
+server = 5-noverify-accept-custom-allow-server
+client = 5-noverify-accept-custom-allow-client
+
+[5-noverify-accept-custom-allow-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[5-noverify-accept-custom-allow-client]
+CipherString = DEFAULT
+
+
+[test-5]
+ClientVerifyCallback = AcceptAll
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[6-verify-fail-no-root]
+ssl_conf = 6-verify-fail-no-root-ssl
+
+[6-verify-fail-no-root-ssl]
+server = 6-verify-fail-no-root-server
+client = 6-verify-fail-no-root-client
+
+[6-verify-fail-no-root-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[6-verify-fail-no-root-client]
+CipherString = DEFAULT
+VerifyMode = Peer
+
+
+[test-6]
+ClientAlert = UnknownCA
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[7-verify-custom-success-no-root]
+ssl_conf = 7-verify-custom-success-no-root-ssl
+
+[7-verify-custom-success-no-root-ssl]
+server = 7-verify-custom-success-no-root-server
+client = 7-verify-custom-success-no-root-client
+
+[7-verify-custom-success-no-root-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[7-verify-custom-success-no-root-client]
+CipherString = DEFAULT
+VerifyMode = Peer
+
+
+[test-7]
+ClientVerifyCallback = AcceptAll
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[8-verify-custom-fail-no-root]
+ssl_conf = 8-verify-custom-fail-no-root-ssl
+
+[8-verify-custom-fail-no-root-ssl]
+server = 8-verify-custom-fail-no-root-server
+client = 8-verify-custom-fail-no-root-client
+
+[8-verify-custom-fail-no-root-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[8-verify-custom-fail-no-root-client]
+CipherString = DEFAULT
+VerifyMode = Peer
+
+
+[test-8]
+ClientAlert = HandshakeFailure
+ClientVerifyCallback = RejectAll
+ExpectedResult = ClientFail
+
+

--- a/test/ssl-tests/03-custom_verify.conf.in
+++ b/test/ssl-tests/03-custom_verify.conf.in
@@ -1,0 +1,127 @@
+# -*- mode: perl; -*-
+
+## SSL test configurations
+
+package ssltests;
+
+our @tests = (
+
+    # Sanity-check that verification indeed succeeds without the
+    # restrictive callback.
+    {
+        name => "verify-success",
+        server => { },
+        client => { },
+        test   => { "ExpectedResult" => "Success" },
+    },
+
+    # Same test as above but with a custom callback that always fails.
+    {
+        name => "verify-custom-reject",
+        server => { },
+        client => { },
+        test   => {
+            "ClientVerifyCallback" => "RejectAll",
+            "ExpectedResult" => "ClientFail",
+            "ClientAlert" => "HandshakeFailure",
+        },
+    },
+
+    # Same test as above but with a custom callback that always succeeds.
+    {
+        name => "verify-custom-allow",
+        server => { },
+        client => { },
+        test   => {
+            "ClientVerifyCallback" => "AcceptAll",
+            "ExpectedResult" => "Success",
+        },
+    },
+
+    # Sanity-check that verification indeed succeeds if peer verification
+    # is not requested.
+    {
+        name => "noverify-success",
+        server => { },
+        client => {
+            "VerifyMode" => undef,
+            "VerifyCAFile" => undef,
+        },
+        test   => { "ExpectedResult" => "Success" },
+    },
+
+    # Same test as above but with a custom callback that always fails.
+    # The callback return has no impact on handshake success in this mode.
+    {
+        name => "noverify-ignore-custom-reject",
+        server => { },
+        client => {
+            "VerifyMode" => undef,
+            "VerifyCAFile" => undef,
+        },
+        test   => {
+            "ClientVerifyCallback" => "RejectAll",
+            "ExpectedResult" => "Success",
+        },
+    },
+
+    # Same test as above but with a custom callback that always succeeds.
+    # The callback return has no impact on handshake success in this mode.
+    {
+        name => "noverify-accept-custom-allow",
+        server => { },
+        client => {
+            "VerifyMode" => undef,
+            "VerifyCAFile" => undef,
+        },
+        test   => {
+            "ClientVerifyCallback" => "AcceptAll",
+            "ExpectedResult" => "Success",
+        },
+    },
+
+    # Sanity-check that verification indeed fails without the
+    # permissive callback.
+    {
+        name => "verify-fail-no-root",
+        server => { },
+        client => {
+            # Don't set up the client root file.
+            "VerifyCAFile" => undef,
+        },
+        test   => {
+          "ExpectedResult" => "ClientFail",
+          "ClientAlert" => "UnknownCA",
+        },
+    },
+
+    # Same test as above but with a custom callback that always succeeds.
+    {
+        name => "verify-custom-success-no-root",
+        server => { },
+        client => {
+            "VerifyCAFile" => undef,
+        },
+        test   => {
+            "ClientVerifyCallback" => "AcceptAll",
+            "ExpectedResult" => "Success"
+        },
+    },
+
+    # Same test as above but with a custom callback that always fails.
+    {
+        name => "verify-custom-fail-no-root",
+        server => { },
+        client => {
+            "VerifyCAFile" => undef,
+        },
+        test   => {
+            "ClientVerifyCallback" => "RejectAll",
+            "ExpectedResult" => "ClientFail",
+            "ClientAlert" => "HandshakeFailure",
+        },
+    },
+
+
+
+);

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -44,8 +44,8 @@ static int check_result(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
 {
     if (result.result != test_ctx->expected_result) {
         fprintf(stderr, "ExpectedResult mismatch: expected %s, got %s.\n",
-                ssl_test_result_t_name(test_ctx->expected_result),
-                ssl_test_result_t_name(result.result));
+                ssl_test_result_name(test_ctx->expected_result),
+                ssl_test_result_name(result.result));
         return 0;
     }
     return 1;
@@ -160,7 +160,7 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
     if (test_ctx == NULL)
         goto err;
 
-    result = do_handshake(server_ctx, client_ctx);
+    result = do_handshake(server_ctx, client_ctx, test_ctx);
 
     ret = check_test(result, test_ctx);
 

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -71,7 +71,7 @@ __owur static int parse_expected_result(SSL_TEST_CTX *test_ctx, const char *valu
     return 1;
 }
 
-const char *ssl_test_result_t_name(ssl_test_result_t result)
+const char *ssl_test_result_name(ssl_test_result_t result)
 {
     return enum_name(ssl_test_results, OSSL_NELEM(ssl_test_results), result);
 }
@@ -82,6 +82,7 @@ const char *ssl_test_result_t_name(ssl_test_result_t result)
 
 static const test_enum ssl_alerts[] = {
     {"UnknownCA", SSL_AD_UNKNOWN_CA},
+    {"HandshakeFailure", SSL_AD_HANDSHAKE_FAILURE},
 };
 
 __owur static int parse_alert(int *alert, const char *value)
@@ -126,6 +127,34 @@ const char *ssl_protocol_name(int protocol)
     return enum_name(ssl_protocols, OSSL_NELEM(ssl_protocols), protocol);
 }
 
+/***********************/
+/* CertVerifyCallback. */
+/***********************/
+
+static const test_enum ssl_verify_callbacks[] = {
+    {"None", SSL_TEST_VERIFY_NONE},
+    {"AcceptAll", SSL_TEST_VERIFY_ACCEPT_ALL},
+    {"RejectAll", SSL_TEST_VERIFY_REJECT_ALL},
+};
+
+__owur static int parse_client_verify_callback(SSL_TEST_CTX *test_ctx,
+                                              const char *value)
+{
+    int ret_value;
+    if (!parse_enum(ssl_verify_callbacks, OSSL_NELEM(ssl_verify_callbacks),
+                    &ret_value, value)) {
+        return 0;
+    }
+    test_ctx->client_verify_callback = ret_value;
+    return 1;
+}
+
+const char *ssl_verify_callback_name(ssl_verify_callback_t callback)
+{
+    return enum_name(ssl_verify_callbacks, OSSL_NELEM(ssl_verify_callbacks),
+                     callback);
+}
+
 
 /*************************************************************/
 /* Known test options and their corresponding parse methods. */
@@ -141,6 +170,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ClientAlert", &parse_client_alert },
     { "ServerAlert", &parse_server_alert },
     { "Protocol", &parse_protocol },
+    { "ClientVerifyCallback", &parse_client_verify_callback },
 };
 
 
@@ -153,7 +183,6 @@ SSL_TEST_CTX *SSL_TEST_CTX_new()
     SSL_TEST_CTX *ret;
     ret = OPENSSL_zalloc(sizeof(*ret));
     OPENSSL_assert(ret != NULL);
-    ret->expected_result = SSL_TEST_SUCCESS;
     return ret;
 }
 

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -15,11 +15,17 @@
 #include <openssl/ssl.h>
 
 typedef enum {
-    SSL_TEST_SUCCESS,  /* Default */
+    SSL_TEST_SUCCESS = 0,  /* Default */
     SSL_TEST_SERVER_FAIL,
     SSL_TEST_CLIENT_FAIL,
     SSL_TEST_INTERNAL_ERROR
 } ssl_test_result_t;
+
+typedef enum {
+    SSL_TEST_VERIFY_NONE = 0, /* Default */
+    SSL_TEST_VERIFY_ACCEPT_ALL,
+    SSL_TEST_VERIFY_REJECT_ALL
+} ssl_verify_callback_t;
 
 typedef struct ssl_test_ctx {
     /* Test expectations. */
@@ -34,11 +40,14 @@ typedef struct ssl_test_ctx {
     /* Negotiated protocol version. 0 if no expectation. */
     /* See ssl.h for protocol versions. */
     int protocol;
+    /* One of a number of predefined custom callbacks. */
+    ssl_verify_callback_t client_verify_callback;
 } SSL_TEST_CTX;
 
-const char *ssl_test_result_t_name(ssl_test_result_t result);
+const char *ssl_test_result_name(ssl_test_result_t result);
 const char *ssl_alert_name(int alert);
 const char *ssl_protocol_name(int protocol);
+const char *ssl_verify_callback_name(ssl_verify_callback_t verify_callback);
 
 /*
  * Load the test case context from |conf|.

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -37,26 +37,32 @@ static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
 {
     if (ctx->expected_result != ctx2->expected_result) {
         fprintf(stderr, "ExpectedResult mismatch: %s vs %s.\n",
-                ssl_test_result_t_name(ctx->expected_result),
-                ssl_test_result_t_name(ctx2->expected_result));
+                ssl_test_result_name(ctx->expected_result),
+                ssl_test_result_name(ctx2->expected_result));
         return 0;
     }
     if (ctx->client_alert != ctx2->client_alert) {
         fprintf(stderr, "ClientAlert mismatch: %s vs %s.\n",
-                ssl_alert_name(ctx->expected_result),
-                ssl_alert_name(ctx2->expected_result));
+                ssl_alert_name(ctx->client_alert),
+                ssl_alert_name(ctx2->client_alert));
         return 0;
     }
     if (ctx->server_alert != ctx2->server_alert) {
         fprintf(stderr, "ServerAlert mismatch: %s vs %s.\n",
-                ssl_alert_name(ctx->expected_result),
-                ssl_alert_name(ctx2->expected_result));
+                ssl_alert_name(ctx->server_alert),
+                ssl_alert_name(ctx2->server_alert));
         return 0;
     }
     if (ctx->protocol != ctx2->protocol) {
         fprintf(stderr, "ClientAlert mismatch: %s vs %s.\n",
-                ssl_protocol_name(ctx->expected_result),
-                ssl_protocol_name(ctx2->expected_result));
+                ssl_protocol_name(ctx->protocol),
+                ssl_protocol_name(ctx2->protocol));
+        return 0;
+    }
+    if (ctx->client_verify_callback != ctx2->client_verify_callback) {
+        fprintf(stderr, "ClientVerifyCallback mismatch: %s vs %s.\n",
+                ssl_verify_callback_name(ctx->client_verify_callback),
+                ssl_verify_callback_name(ctx2->client_verify_callback));
         return 0;
     }
 
@@ -136,6 +142,7 @@ static int test_good_configuration()
     fixture.expected_ctx->client_alert = SSL_AD_UNKNOWN_CA;
     fixture.expected_ctx->server_alert = 0;  /* No alert. */
     fixture.expected_ctx->protocol = TLS1_1_VERSION;
+    fixture.expected_ctx->client_verify_callback = SSL_TEST_VERIFY_REJECT_ALL,
     EXECUTE_SSL_TEST_CTX_TEST();
 }
 
@@ -144,6 +151,7 @@ static const char *bad_configurations[] = {
     "ssltest_unknown_expected_result",
     "ssltest_unknown_alert",
     "ssltest_unknown_protocol",
+    "ssltest_unknown_verify_callback",
 };
 
 static int test_bad_configuration(int idx)

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -4,6 +4,7 @@
 ExpectedResult = ServerFail
 ClientAlert = UnknownCA
 Protocol = TLSv1.1
+ClientVerifyCallback = RejectAll
 
 [ssltest_unknown_option]
 UnknownOption = Foo
@@ -16,3 +17,6 @@ ServerAlert = Foo
 
 [ssltest_unknown_protocol]
 Protocol = Foo
+
+[ssltest_unknown_verify_callback]
+ClientVerifyCallback = Foo


### PR DESCRIPTION
The old proxy tests test the implementation of an application proxy
policy callback defined in the test itself, which is not particularly
useful.

It is, however, useful to test cert verify overrides in
general. Therefore, replace these tests with tests for cert verify
callback behaviour.

Also glob the ssl test inputs on the .in files to catch missing
generated files.