### PR TITLE
Add SSL_CTX_get_ciphers()

### DIFF
--- a/doc/ssl/SSL_get_ciphers.pod
+++ b/doc/ssl/SSL_get_ciphers.pod
@@ -2,13 +2,14 @@
 
 =head1 NAME
 
-SSL_get_ciphers, SSL_get_cipher_list - get list of available SSL_CIPHERs
+SSL_get_ciphers, SSL_CTX_get_ciphers, SSL_get_cipher_list - get list of available SSL_CIPHERs
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
  STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
+ STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx);
  STACK_OF(SSL_CIPHER) *SSL_get1_supported_ciphers(SSL *s);
  STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
  const char *SSL_get_cipher_list(const SSL *ssl, int priority);
@@ -18,6 +19,8 @@ SSL_get_ciphers, SSL_get_cipher_list - get list of available SSL_CIPHERs
 SSL_get_ciphers() returns the stack of available SSL_CIPHERs for B<ssl>,
 sorted by preference. If B<ssl> is NULL or no ciphers are available, NULL
 is returned.
+
+SSL_CTX_get_ciphers() returns the stack of available SSL_CIPHERs for B<ctx>.
 
 SSL_get1_supported_ciphers() returns the stack of enabled SSL_CIPHERs for
 B<ssl>, sorted by preference.
@@ -43,17 +46,17 @@ is returned.
 
 =head1 NOTES
 
-The details of the ciphers obtained by SSL_get_ciphers(),
+The details of the ciphers obtained by SSL_get_ciphers(), SSL_CTX_get_ciphers()
 SSL_get1_supported_ciphers() and SSL_get_client_ciphers() can be obtained using
 the L<SSL_CIPHER_get_name(3)> family of functions.
 
 Call SSL_get_cipher_list() with B<priority> starting from 0 to obtain the
 sorted list of available ciphers, until NULL is returned.
 
-Note: SSL_get_ciphers() and SSL_get_client_ciphers() return a pointer
-to an internal cipher stack, which will be freed later on when the SSL
-or SSL_SESSION object is freed.  Therefore, the calling code B<MUST
-NOT> free the return value itself.
+Note: SSL_get_ciphers(), SSL_CTX_get_ciphers() and SSL_get_client_ciphers()
+return a pointer to an internal cipher stack, which will be freed later on when
+the SSL or SSL_SESSION object is freed.  Therefore, the calling code B<MUST NOT>
+free the return value itself.
 
 The stack returned by SSL_get1_supported_ciphers() should be freed using
 sk_SSL_CIPHER_free().

--- a/doc/ssl/ssl.pod
+++ b/doc/ssl/ssl.pod
@@ -239,6 +239,8 @@ protocol context defined in the B<SSL_CTX> structure.
 
 =item X509_STORE *B<SSL_CTX_get_cert_store>(SSL_CTX *ctx);
 
+=item STACK *B<SSL_CTX_get_ciphers>(const SSL_CTX *ctx);
+
 =item STACK *B<SSL_CTX_get_client_CA_list>(const SSL_CTX *ctx);
 
 =item int (*B<SSL_CTX_get_client_cert_cb>(SSL_CTX *ctx))(SSL *ssl, X509 **x509, EVP_PKEY **pkey);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1683,6 +1683,7 @@ __owur const SSL_METHOD *DTLS_server_method(void); /* DTLS 1.0 and 1.2 */
 __owur const SSL_METHOD *DTLS_client_method(void); /* DTLS 1.0 and 1.2 */
 
 __owur STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *s);
+__owur STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx);
 __owur STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *s);
 __owur STACK_OF(SSL_CIPHER) *SSL_get1_supported_ciphers(SSL *s);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1999,6 +1999,15 @@ const char *SSL_get_cipher_list(const SSL *s, int n)
     return (c->name);
 }
 
+/** return a STACK of the ciphers available for the SSL_CTX and in order of
+ * preference */
+STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx)
+{
+    if (ctx != NULL)
+        return ctx->cipher_list;
+    return NULL;
+}
+
 /** specify the ciphers to be used by default by the SSL_CTX */
 int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
 {

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -392,3 +392,4 @@ SSL_CTX_set0_ctlog_store                391	1_1_0	EXIST::FUNCTION:CT
 SSL_CTX_get0_ctlog_store                392	1_1_0	EXIST::FUNCTION:CT
 SSL_enable_ct                           393	1_1_0	EXIST::FUNCTION:CT
 SSL_CTX_enable_ct                       394	1_1_0	EXIST::FUNCTION:CT
+SSL_CTX_get_ciphers                     395	1_1_0	EXIST::FUNCTION


### PR DESCRIPTION
There are both set/get functions for SSL:

    int SSL_set_cipher_list(SSL *s, const char *str);
    STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *s);

But for SSL_CTX, there is only set function:

    int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);

and currently no get function:

    STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx);


Since libssl was made opaque, there is no way for users to access SSL_CTX.cipher_list, so I think it should be implemented.

Thanks,
