### PR TITLE
Haiku x86-64 doesn't need RC4_CHAR.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1764,10 +1764,11 @@ sub vms_info {
                                        release => "-fomit-frame-pointer")),
         bn_ops           => "BN_LLONG",
     },
+    # Haiku builds with no-asm
     "haiku-x86_64" => {
         inherit_from     => [ "haiku-common", asm("x86_64_asm") ],
         cflags           => add("-m64"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
     },
 
 


### PR DESCRIPTION
This is a follow-up PR taking account comments on #618 . Thanks for the review.