### PR TITLE
[openssl.org #4513] BIO socket connect failure was not handled correctly

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -198,7 +198,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             ret = BIO_connect(b->num, BIO_ADDRINFO_address(c->addr_iter),
                               BIO_SOCK_KEEPALIVE | c->connect_mode);
             b->retry_reason = 0;
-            if (ret < 0) {
+            if (ret == 0) {
                 if (BIO_sock_should_retry(ret)) {
                     BIO_set_retry_special(b);
                     c->state = BIO_CONN_S_BLOCKED_CONNECT;


### PR DESCRIPTION
Given that BIO_connect  (crypto/bio/b_sock2.c) returns 1 on success or 0 on failure. 
 
This call can produces the wrong result (openssl/crypto/bio/bss_conn.c)

```
case BIO_CONN_S_CONNECT:
	BIO_clear_retry_flags(b);
	ret = BIO_connect(b->num, BIO_ADDRINFO_address(c->addr_iter),
					  BIO_SOCK_KEEPALIVE | c->connect_mode);
	b->retry_reason = 0;
	if (ret < 0) {    // <-------------------- corrected to ret == 0
            // handle connect error, but was never executed
        }
```

Regards,
Davide