### PR TITLE
Remove dead-code infinite loop

### DIFF
--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -176,7 +176,6 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
     if (bs->certs && certs)
         sk_X509_free(untrusted);
     return ret;
-    goto end;
 
  err:
     ret = 0;


### PR DESCRIPTION
Commit d32f5d8733df9938727710d4194e92813c421ef1 added a 'goto end;' statement
at the end of the code block for the 'end' label.  Fortunately, it was after a
return statement, so no infinite loop occurred, but it is still dead code.

Remove the extra goto statement as cleanup.