### PR TITLE
Add ex_data functions for X509_STORE

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -743,6 +743,16 @@ void X509_STORE_set_lookup_crls_cb(X509_STORE *ctx,
     ctx->lookup_crls = cb;
 }
 
+int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data)
+{
+    return CRYPTO_set_ex_data(&ctx->ex_data, idx, data);
+}
+
+void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx)
+{
+    return CRYPTO_get_ex_data(&ctx->ex_data, idx);
+}
+
 X509_STORE *X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx)
 {
     return ctx->ctx;

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -292,6 +292,10 @@ void X509_STORE_set_lookup_crls_cb(X509_STORE *ctx,
                                    STACK_OF(X509_CRL) *(*cb) (X509_STORE_CTX
                                                               *ctx,
                                                               X509_NAME *nm));
+#define X509_STORE_get_ex_new_index(l, p, newf, dupf, freef) \
+    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE, l, p, newf, dupf, freef)
+int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data);
+void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx);
 
 X509_STORE_CTX *X509_STORE_CTX_new(void);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4207,3 +4207,5 @@ X509_STORE_CTX_get_cert                 4081	1_1_0	NOEXIST::FUNCTION:
 X509_STORE_CTX_set0_verified_chain      4082	1_1_0	EXIST::FUNCTION:
 X509_STORE_CTX_set0_untrusted           4083	1_1_0	EXIST::FUNCTION:
 OPENSSL_hexchar2int                     4084	1_1_0	EXIST::FUNCTION:
+X509_STORE_set_ex_data                  4085	1_1_0	EXIST::FUNCTION:
+X509_STORE_get_ex_data                  4086	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add missing X509_STORE_{set,get}_ex_data() function and X509_STORE_get_ex_new_index() macro.

X509_STORE has ex_data and the documentation[1] also mentions the functions/macro but they are not actually implemented.

[1] https://github.com/openssl/openssl/blob/e6390acac925f952cfd06ccdbba0b273b8f71551/doc/crypto/BIO_get_ex_new_index.pod