### PR TITLE
Add getters for X509_OBJECT

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -436,6 +436,11 @@ X509 *X509_OBJECT_get0_X509(X509_OBJECT *a)
     return a->data.x509;
 }
 
+int X509_OBJECT_get_type(X509_OBJECT *a)
+{
+    return a->type;
+}
+
 void X509_OBJECT_free(X509_OBJECT *a)
 {
     if (a == NULL)
@@ -513,6 +518,11 @@ X509_OBJECT *X509_OBJECT_retrieve_by_subject(STACK_OF(X509_OBJECT) *h,
     if (idx == -1)
         return NULL;
     return sk_X509_OBJECT_value(h, idx);
+}
+
+STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(X509_STORE *v)
+{
+    return v->objs;
 }
 
 STACK_OF(X509) *X509_STORE_get1_certs(X509_STORE_CTX *ctx, X509_NAME *nm)
@@ -727,6 +737,11 @@ int X509_STORE_set_trust(X509_STORE *ctx, int trust)
 int X509_STORE_set1_param(X509_STORE *ctx, X509_VERIFY_PARAM *param)
 {
     return X509_VERIFY_PARAM_set1(ctx->param, param);
+}
+
+X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *ctx)
+{
+    return ctx->param;
 }
 
 void X509_STORE_set_verify_cb(X509_STORE *ctx,

--- a/doc/crypto/X509_STORE_get0_param.pod
+++ b/doc/crypto/X509_STORE_get0_param.pod
@@ -1,0 +1,48 @@
+=pod
+
+=head1 NAME
+
+X509_STORE_get0_param, X509_STORE_set1_param,
+X509_STORE_get0_objects - X509_STORE setter and getter functions
+
+=head1 SYNOPSIS
+
+ #include <openssl/x509_vfy.h>
+
+ X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *ctx);
+ int X509_STORE_set1_param(X509_STORE *ctx, X509_VERIFY_PARAM *pm);
+ STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(X509_STORE *ctx);
+
+=head1 DESCRIPTION
+
+X509_STORE_set1_param() sets the verification parameters
+to B<pm> for B<ctx>.
+
+X509_STORE_get0_param() retrieves an internal pointer to the verification
+parameters for B<ctx>. The returned pointer must not be freed by the
+calling application
+
+X509_STORE_get0_objects() retrieve an internal pointer to the store's
+X509 object cache. The cache contains B<X509> and B<X509_CRL> objects. The
+returned pointer must not be freed by the calling application.
+
+
+=head1 RETURN VALUES
+
+X509_STORE_get0_param() returns a pointer to an
+B<X509_VERIFY_PARAM> structure.
+
+X509_STORE_set1_param() returns 1 for success and 0 for failure.
+
+X509_STORE_get0_objects() returns a pointer to a stack of B<X509_OBJECT>.
+
+=head1 SEE ALSO
+
+L<X509_STORE_new(3)>
+
+=head1 HISTORY
+
+B<X509_STORE_get0_param> and B<X509_STORE_get0_objects> were added in
+OpenSSL version 1.1.0.
+
+=cut

--- a/doc/crypto/X509_STORE_new.pod
+++ b/doc/crypto/X509_STORE_new.pod
@@ -32,5 +32,10 @@ X509_STORE_free() does not return values.
 =head1 SEE ALSO
 
 L<X509_STORE_set_verify_cb_func(3)>
+L<X509_STORE_get0_param(3)>
+
+=head1 HISTORY
+
+The B<X509_STORE_up_ref> function was added in OpenSSL 1.1.0
 
 =cut

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -272,11 +272,13 @@ X509_OBJECT *X509_OBJECT_retrieve_match(STACK_OF(X509_OBJECT) *h,
                                         X509_OBJECT *x);
 void X509_OBJECT_up_ref_count(X509_OBJECT *a);
 void X509_OBJECT_free(X509_OBJECT *a);
+int X509_OBJECT_get_type(X509_OBJECT *a);
 X509 *X509_OBJECT_get0_X509(X509_OBJECT *a);
 void X509_OBJECT_free_contents(X509_OBJECT *a);
 X509_STORE *X509_STORE_new(void);
 void X509_STORE_free(X509_STORE *v);
 int X509_STORE_up_ref(X509_STORE *v);
+STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(X509_STORE *v);
 
 STACK_OF(X509) *X509_STORE_get1_certs(X509_STORE_CTX *st, X509_NAME *nm);
 STACK_OF(X509_CRL) *X509_STORE_get1_crls(X509_STORE_CTX *st, X509_NAME *nm);
@@ -284,6 +286,7 @@ int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
 int X509_STORE_set_purpose(X509_STORE *ctx, int purpose);
 int X509_STORE_set_trust(X509_STORE *ctx, int trust);
 int X509_STORE_set1_param(X509_STORE *ctx, X509_VERIFY_PARAM *pm);
+X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *ctx);
 
 void X509_STORE_set_verify_cb(X509_STORE *ctx,
                               int (*verify_cb) (int, X509_STORE_CTX *));

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4208,3 +4208,6 @@ X509_STORE_CTX_set0_untrusted           4082	1_1_0	EXIST::FUNCTION:
 OPENSSL_hexchar2int                     4083	1_1_0	EXIST::FUNCTION:
 X509_STORE_set_ex_data                  4084	1_1_0	EXIST::FUNCTION:
 X509_STORE_get_ex_data                  4085	1_1_0	EXIST::FUNCTION:
+X509_STORE_get0_objects                 4086	1_1_0	EXIST::FUNCTION:
+X509_STORE_get0_param                   4087	1_1_0	EXIST::FUNCTION:
+X509_OBJECT_get_type                    4088	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
OpenSSL 1.1.0-pre5 breaks Python's SSL module again. In two functions
Python's ssl module gets all X509_OBJECT from the context's X509_STORE
and iterates over them.

https://hg.python.org/cpython/file/tip/Modules/_ssl.c#l3420
https://hg.python.org/cpython/file/tip/Modules/_ssl.c#l3467

OpenSSL 1.1.0 lacks two functions to implement the same feature.
X509_OBJECT_get0_X509() is already defined.

STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(X509_STORE*);
int X509_OBJECT_get_type(X509_OBJECT*);

Signed-off-by: Christian Heimes <cheimes@redhat.com>