### PR TITLE
Fix EC_KEY_set_private_key() to call key->group->meth->set_private()

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -483,8 +483,8 @@ int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *priv_key)
 {
     if (key->group == NULL || key->group->meth == NULL)
         return 0;
-    if (key->group->meth->set_private
-        && key->meth->set_private(key, priv_key) == 0)
+    if (key->group->meth->set_private != NULL
+        && key->group->meth->set_private(key, priv_key) == 0)
         return 0;
     if (key->meth->set_private != NULL
         && key->meth->set_private(key, priv_key) == 0)


### PR DESCRIPTION
Fix a bug introduced by 6903e2e7e9a4 (Extended EC_METHOD customisation support., 2016-02-01).
key->meth->set_private() is wrongly called where it should call key->group->meth->set_private().