### PR TITLE
RSA, DSA, DH: Do not free pointers if the same is reassigned

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -248,9 +248,12 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
     /* q is optional */
     if (p == NULL || g == NULL)
         return 0;
-    BN_free(dh->p);
-    BN_free(dh->q);
-    BN_free(dh->g);
+    if (dh->p != p)
+        BN_free(dh->p);
+    if (dh->q != q)
+        BN_free(dh->q);
+    if (dh->g != g)
+        BN_free(dh->g);
     dh->p = p;
     dh->q = q;
     dh->g = g;
@@ -287,8 +290,10 @@ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
     if (pub_key == NULL)
         return 0;
 
-    BN_free(dh->pub_key);
-    BN_free(dh->priv_key);
+    if (dh->pub_key != pub_key)
+        BN_free(dh->pub_key);
+    if (dh->priv_key != priv_key)
+        BN_free(dh->priv_key);
     dh->pub_key = pub_key;
     dh->priv_key = priv_key;
 

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -317,9 +317,12 @@ int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
     if (p == NULL || q == NULL || g == NULL)
         return 0;
-    BN_free(d->p);
-    BN_free(d->q);
-    BN_free(d->g);
+    if (d->p != p)
+        BN_free(d->p);
+    if (d->q != q)
+        BN_free(d->q);
+    if (d->g != g)
+        BN_free(d->g);
     d->p = p;
     d->q = q;
     d->g = g;
@@ -341,8 +344,10 @@ int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
     if (pub_key == NULL)
         return 0;
 
-    BN_free(d->pub_key);
-    BN_free(d->priv_key);
+    if (d->pub_key != pub_key)
+        BN_free(d->pub_key);
+    if (d->priv_key != priv_key)
+        BN_free(d->priv_key);
     d->pub_key = pub_key;
     d->priv_key = priv_key;
 

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -290,9 +290,12 @@ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
     if (n == NULL || e == NULL)
         return 0;
 
-    BN_free(r->n);
-    BN_free(r->e);
-    BN_free(r->d);
+    if (r->n != n)
+        BN_free(r->n);
+    if (r->e != e)
+        BN_free(r->e);
+    if (r->d != d)
+        BN_free(r->d);
     r->n = n;
     r->e = e;
     r->d = d;
@@ -305,8 +308,10 @@ int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
     if (p == NULL || q == NULL)
         return 0;
 
-    BN_free(r->p);
-    BN_free(r->q);
+    if (r->p != p)
+        BN_free(r->p);
+    if (r->q != q)
+        BN_free(r->q);
     r->p = p;
     r->q = q;
 
@@ -318,9 +323,12 @@ int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp)
     if (dmp1 == NULL || dmq1 == NULL || iqmp == NULL)
         return 0;
 
-    BN_free(r->dmp1);
-    BN_free(r->dmq1);
-    BN_free(r->iqmp);
+    if (r->dmp1 != dmp1)
+        BN_free(r->dmp1);
+    if (r->dmq1 != dmq1)
+        BN_free(r->dmq1);
+    if (r->iqmp != iqmp)
+        BN_free(r->iqmp);
     r->dmp1 = dmp1;
     r->dmq1 = dmq1;
     r->iqmp = iqmp;


### PR DESCRIPTION
The diverse RSA_set0_\* functions to set key numbers were freeing the
previous numbers unconditionally.  However, if someone has reason to
do something like this, the resulting RSA will have pointers into
freed space:

```
RSA_get0_key(rsa, &n, &e, NULL);
RSA_get0_factors(rsa, &p, &q);
/* calculate new d */
RSA_set0_key(rsa, n, e, d);
```

This changes allows such operation without fault.
