### PR TITLE
RSA, DSA, DH: Allow some given input to be NULL on already initialised key

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -245,10 +245,15 @@ void DH_get0_pqg(const DH *dh, BIGNUM **p, BIGNUM **q, BIGNUM **g)
 
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
-    /* q is optional */
-    if ((p == NULL && dh->p == NULL)
-        || (g == NULL && dh->g == NULL))
+    /* If the fields p and g in d are NULL, the corresponding input
+     * parameters MUST be non-NULL.  q may remain NULL.
+     *
+     * It is an error to give the results from get0 on d
+     * as input parameters.
+     */
+    if (p == dh->p || (dh->q != NULL && q == dh->q) || g == dh->g)
         return 0;
+
     if (p != NULL) {
         BN_free(dh->p);
         dh->p = p;
@@ -290,8 +295,15 @@ void DH_get0_key(const DH *dh, BIGNUM **pub_key, BIGNUM **priv_key)
 
 int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
 {
-    /* Note that it is valid for priv_key to be NULL */
-    if (dh->pub_key == NULL && pub_key == NULL)
+    /* If the pub_key in dh is NULL, the corresponding input
+     * parameters MUST be non-NULL.  The priv_key field may
+     * be left NULL.
+     *
+     * It is an error to give the results from get0 on dh
+     * as input parameters.
+     */
+    if (dh->pub_key == pub_key
+        || (dh->priv_key != NULL && priv_key != dh->priv_key))
         return 0;
 
     if (pub_key != NULL) {

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -246,14 +246,21 @@ void DH_get0_pqg(const DH *dh, BIGNUM **p, BIGNUM **q, BIGNUM **g)
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
     /* q is optional */
-    if (p == NULL || g == NULL)
+    if ((p == NULL && dh->p == NULL)
+        || (g == NULL && dh->g == NULL))
         return 0;
-    BN_free(dh->p);
-    BN_free(dh->q);
-    BN_free(dh->g);
-    dh->p = p;
-    dh->q = q;
-    dh->g = g;
+    if (p != NULL) {
+        BN_free(dh->p);
+        dh->p = p;
+    }
+    if (q != NULL) {
+        BN_free(dh->q);
+        dh->q = q;
+    }
+    if (g != NULL) {
+        BN_free(dh->g);
+        dh->g = g;
+    }
 
     if (q != NULL) {
         dh->length = BN_num_bits(q);
@@ -284,13 +291,17 @@ void DH_get0_key(const DH *dh, BIGNUM **pub_key, BIGNUM **priv_key)
 int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
 {
     /* Note that it is valid for priv_key to be NULL */
-    if (pub_key == NULL)
+    if (dh->pub_key == NULL && pub_key == NULL)
         return 0;
 
-    BN_free(dh->pub_key);
-    BN_free(dh->priv_key);
-    dh->pub_key = pub_key;
-    dh->priv_key = priv_key;
+    if (pub_key != NULL) {
+        BN_free(dh->pub_key);
+        dh->pub_key = pub_key;
+    }
+    if (priv_key != NULL) {
+        BN_free(dh->priv_key);
+        dh->priv_key = priv_key;
+    }
 
     return 1;
 }

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -315,14 +315,22 @@ void DSA_get0_pqg(const DSA *d, BIGNUM **p, BIGNUM **q, BIGNUM **g)
 
 int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
-    if (p == NULL || q == NULL || g == NULL)
+    if ((p == NULL && d->p == NULL)
+        || (q == NULL && d->q == NULL)
+        || (g == NULL && d->g == NULL))
         return 0;
-    BN_free(d->p);
-    BN_free(d->q);
-    BN_free(d->g);
-    d->p = p;
-    d->q = q;
-    d->g = g;
+    if (p != NULL) {
+        BN_free(d->p);
+        d->p = p;
+    }
+    if (q != NULL) {
+        BN_free(d->q);
+        d->q = q;
+    }
+    if (g != NULL) {
+        BN_free(d->g);
+        d->g = g;
+    }
 
     return 1;
 }
@@ -338,13 +346,17 @@ void DSA_get0_key(const DSA *d, BIGNUM **pub_key, BIGNUM **priv_key)
 int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
 {
     /* Note that it is valid for priv_key to be NULL */
-    if (pub_key == NULL)
+    if (d->pub_key == NULL && pub_key == NULL)
         return 0;
 
-    BN_free(d->pub_key);
-    BN_free(d->priv_key);
-    d->pub_key = pub_key;
-    d->priv_key = priv_key;
+    if (pub_key != NULL) {
+        BN_free(d->pub_key);
+        d->pub_key = pub_key;
+    }
+    if (priv_key != NULL) {
+        BN_free(d->priv_key);
+        d->priv_key = priv_key;
+    }
 
     return 1;
 }

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -315,10 +315,15 @@ void DSA_get0_pqg(const DSA *d, BIGNUM **p, BIGNUM **q, BIGNUM **g)
 
 int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
-    if ((p == NULL && d->p == NULL)
-        || (q == NULL && d->q == NULL)
-        || (g == NULL && d->g == NULL))
+    /* If the fields in d are NULL, the corresponding input
+     * parameters MUST be non-NULL.
+     *
+     * It is an error to give the results from get0 on d
+     * as input parameters.
+     */
+    if (p == d->p || q == d->q || g == d->g)
         return 0;
+
     if (p != NULL) {
         BN_free(d->p);
         d->p = p;
@@ -345,8 +350,15 @@ void DSA_get0_key(const DSA *d, BIGNUM **pub_key, BIGNUM **priv_key)
 
 int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
 {
-    /* Note that it is valid for priv_key to be NULL */
-    if (d->pub_key == NULL && pub_key == NULL)
+    /* If the pub_key in d is NULL, the corresponding input
+     * parameters MUST be non-NULL.  The priv_key field may
+     * be left NULL.
+     *
+     * It is an error to give the results from get0 on d
+     * as input parameters.
+     */
+    if (d->pub_key == pub_key
+        || (d->priv_key != NULL && priv_key != d->priv_key))
         return 0;
 
     if (pub_key != NULL) {

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -286,9 +286,15 @@ int RSA_security_bits(const RSA *rsa)
 
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 {
-    /* d is the private component and may be NULL */
-    if ((n == NULL && r->n == NULL)
-        || (e == NULL && r->e == NULL))
+    /* If the fields in r are NULL, the corresponding input
+     * parameters MUST be non-NULL for n and e.  d may be
+     * left NULL (in case only the public key is used).
+     *
+     * It is an error to give the results from get0 on r
+     * as input parameters.
+     */
+    if (n == r->n || e == r->e
+        || (r->d != NULL && d == r->d))
         return 0;
 
     if (n != NULL) {
@@ -309,8 +315,13 @@ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 
 int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
 {
-    if ((p == NULL && r->p == NULL)
-        || (q == NULL && r->q == NULL))
+    /* If the fields in r are NULL, the corresponding input
+     * parameters MUST be non-NULL.
+     *
+     * It is an error to give the results from get0 on r
+     * as input parameters.
+     */
+    if (p == r->p || q == r->q)
         return 0;
 
     if (p != NULL) {
@@ -327,9 +338,13 @@ int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
 
 int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp)
 {
-    if ((dmp1 == NULL && r->dmp1 == NULL)
-        || (dmq1 == NULL && r->dmq1 == NULL)
-        || (iqmp == NULL && r->iqmp == NULL))
+    /* If the fields in r are NULL, the corresponding input
+     * parameters MUST be non-NULL.
+     *
+     * It is an error to give the results from get0 on r
+     * as input parameters.
+     */
+    if (dmp1 == r->dmp1 || dmq1 == r->dmq1 || iqmp == r->iqmp)
         return 0;
 
     if (dmp1 != NULL) {

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -287,43 +287,63 @@ int RSA_security_bits(const RSA *rsa)
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 {
     /* d is the private component and may be NULL */
-    if (n == NULL || e == NULL)
+    if ((n == NULL && r->n == NULL)
+        || (e == NULL && r->e == NULL))
         return 0;
 
-    BN_free(r->n);
-    BN_free(r->e);
-    BN_free(r->d);
-    r->n = n;
-    r->e = e;
-    r->d = d;
+    if (n != NULL) {
+        BN_free(r->n);
+        r->n = n;
+    }
+    if (e != NULL) {
+        BN_free(r->e);
+        r->e = e;
+    }
+    if (d != NULL) {
+        BN_free(r->d);
+        r->d = d;
+    }
 
     return 1;
 }
 
 int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
 {
-    if (p == NULL || q == NULL)
+    if ((p == NULL && r->p == NULL)
+        || (q == NULL && r->q == NULL))
         return 0;
 
-    BN_free(r->p);
-    BN_free(r->q);
-    r->p = p;
-    r->q = q;
+    if (p != NULL) {
+        BN_free(r->p);
+        r->p = p;
+    }
+    if (q != NULL) {
+        BN_free(r->q);
+        r->q = q;
+    }
 
     return 1;
 }
 
 int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp)
 {
-    if (dmp1 == NULL || dmq1 == NULL || iqmp == NULL)
+    if ((dmp1 == NULL && r->dmp1 == NULL)
+        || (dmq1 == NULL && r->dmq1 == NULL)
+        || (iqmp == NULL && r->iqmp == NULL))
         return 0;
 
-    BN_free(r->dmp1);
-    BN_free(r->dmq1);
-    BN_free(r->iqmp);
-    r->dmp1 = dmp1;
-    r->dmq1 = dmq1;
-    r->iqmp = iqmp;
+    if (dmp1 != NULL) {
+        BN_free(r->dmp1);
+        r->dmp1 = dmp1;
+    }
+    if (dmq1 != NULL) {
+        BN_free(r->dmq1);
+        r->dmq1 = dmq1;
+    }
+    if (iqmp != NULL) {
+        BN_free(r->iqmp);
+        r->iqmp = iqmp;
+    }
 
     return 1;
 }

--- a/doc/crypto/DH_get0_pqg.pod
+++ b/doc/crypto/DH_get0_pqg.pod
@@ -49,7 +49,7 @@ private key values. This memory should not be freed directly.
 The public and private key values can be set using DH_set0_key(). The public
 key must be non-NULL the first time this function is called on a given DH
 object. The private key may be NULL.  On subsequent calls, either may be NULL,
-which means the correspond DH field is left untouched. As for DH_set0_pqg()
+which means the corresponding DH field is left untouched. As for DH_set0_pqg()
 this function transfers the memory management of the key values to the DH
 object, and therefore they should not be freed directly after this function has
 been called.

--- a/doc/crypto/DH_get0_pqg.pod
+++ b/doc/crypto/DH_get0_pqg.pod
@@ -47,7 +47,9 @@ be. The values point to the internal representation of the public key and
 private key values. This memory should not be freed directly.
 
 The public and private key values can be set using DH_set0_key(). The public
-key must always be non-NULL. The private key may be NULL. As for DH_set0_pqg()
+key must be non-NULL the first time this function is called on a given DH
+object. The private key may be NULL.  On subsequent calls, either may be NULL,
+which means the correspond DH field is left untouched. As for DH_set0_pqg()
 this function transfers the memory management of the key values to the DH
 object, and therefore they should not be freed directly after this function has
 been called.

--- a/doc/crypto/DH_get0_pqg.pod
+++ b/doc/crypto/DH_get0_pqg.pod
@@ -70,6 +70,13 @@ length parameter associated with this DH object. If the length is non-zero then
 it is used, otherwise it is ignored. The B<length> parameter indicates the
 length of the secret exponent (private key) in bits.
 
+=head1 NOTES
+
+Values retrieved with DH_get0_key() are owned by the DH object used
+in the call and may therefore I<not> be passed to DH_set0_key().  If
+needed, duplicate the received value using BN_dup() and pass the
+duplicate.  The same applies to DH_get0_pqg() and DH_set0_pqg().
+
 =head1 RETURN VALUES
 
 DH_set0_pqg() and DH_set0_key() return 1 on success or 0 on failure.

--- a/doc/crypto/DSA_get0_pqg.pod
+++ b/doc/crypto/DSA_get0_pqg.pod
@@ -62,6 +62,13 @@ within the DSA object.
 DSA_get0_engine() returns a handle to the ENGINE that has been set for this DSA
 object, or NULL if no such ENGINE has been set.
 
+=head1 NOTES
+
+Values retrieved with DSA_get0_key() are owned by the DSA object used
+in the call and may therefore I<not> be passed to DSA_set0_key().  If
+needed, duplicate the received value using BN_dup() and pass the
+duplicate.  The same applies to DSA_get0_pqg() and DSA_set0_pqg().
+
 =head1 RETURN VALUES
 
 DSA_set0_pqg() and DSA_set0_key() return 1 on success or 0 on failure.

--- a/doc/crypto/DSA_get0_pqg.pod
+++ b/doc/crypto/DSA_get0_pqg.pod
@@ -46,7 +46,7 @@ private key values. This memory should not be freed directly.
 The public and private key values can be set using DSA_set0_key(). The public
 key must be non-NULL the first time this function is called on a given DSA
 object. The private key may be NULL.  On subsequent calls, either may be NULL,
-which means the correspond DSA field is left untouched. As for DSA_set0_pqg()
+which means the corresponding DSA field is left untouched. As for DSA_set0_pqg()
 this function transfers the memory management of the key values to the DSA
 object, and therefore they should not be freed directly after this function has
 been called.

--- a/doc/crypto/DSA_get0_pqg.pod
+++ b/doc/crypto/DSA_get0_pqg.pod
@@ -44,7 +44,9 @@ be. The values point to the internal representation of the public key and
 private key values. This memory should not be freed directly.
 
 The public and private key values can be set using DSA_set0_key(). The public
-key must always be non-NULL. The private key may be NULL. As for DSA_set0_pqg()
+key must be non-NULL the first time this function is called on a given DSA
+object. The private key may be NULL.  On subsequent calls, either may be NULL,
+which means the correspond DSA field is left untouched. As for DSA_set0_pqg()
 this function transfers the memory management of the key values to the DSA
 object, and therefore they should not be freed directly after this function has
 been called.

--- a/doc/crypto/RSA_get0_key.pod
+++ b/doc/crypto/RSA_get0_key.pod
@@ -73,7 +73,8 @@ this RSA object, or NULL if no such ENGINE has been set.
 Values retrieved with RSA_get0_key() are owned by the RSA object used
 in the call and may therefore I<not> be passed to RSA_set0_key().  If
 needed, duplicate the received value using BN_dup() and pass the
-duplicate.
+duplicate.  The same applies to RSA_get0_factors() and RSA_set0_factors()
+as well as RSA_get0_crt_params() and RSA_set0_crt_params().
 
 =head1 RETURN VALUES
 

--- a/doc/crypto/RSA_get0_key.pod
+++ b/doc/crypto/RSA_get0_key.pod
@@ -46,7 +46,10 @@ RSA_set0_key() and passing the new values for B<n>, B<e> and B<d> as
 parameters to the function. Calling this function transfers the memory
 management of the values to the RSA object, and therefore the values
 that have been passed in should not be freed by the caller after this
-function has been called.
+function has been called.  The first time this function is called for
+a specific RSA object, B<n> and B<e> must be non-C<NULL>; however,
+this function may be called again with B<n> or B<e> being NULL to
+complete or set of values, typically to add a value for B<d>.
 
 In a similar fashion, the B<p> and B<q> parameters can be obtained and
 set with RSA_get0_factors() and RSA_set0_factors(), and the B<dmp1>,

--- a/doc/crypto/RSA_get0_key.pod
+++ b/doc/crypto/RSA_get0_key.pod
@@ -43,13 +43,13 @@ by the caller.
 
 The B<n>, B<e> and B<d> parameter values can be set by calling
 RSA_set0_key() and passing the new values for B<n>, B<e> and B<d> as
-parameters to the function. Calling this function transfers the memory
-management of the values to the RSA object, and therefore the values
-that have been passed in should not be freed by the caller after this
-function has been called.  The first time this function is called for
-a specific RSA object, B<n> and B<e> must be non-C<NULL>; however,
-this function may be called again with B<n> or B<e> being NULL to
-complete or set of values, typically to add a value for B<d>.
+parameters to the function.  The values B<n> and B<e> must be non-NULL
+the first time this function is called on a given RSA object. The
+value B<d> may be NULL. On subsequent calls any of these values may be
+NULL which means the corresponding RSA field is left untouched.
+Calling this function transfers the memory management of the values to
+the RSA object, and therefore the values that have been passed in
+should not be freed by the caller after this function has been called.
 
 In a similar fashion, the B<p> and B<q> parameters can be obtained and
 set with RSA_get0_factors() and RSA_set0_factors(), and the B<dmp1>,
@@ -67,6 +67,13 @@ RSA object.
 
 RSA_get0_engine() returns a handle to the ENGINE that has been set for
 this RSA object, or NULL if no such ENGINE has been set.
+
+=head1 NOTES
+
+Values retrieved with RSA_get0_key() are owned by the RSA object used
+in the call and may therefore I<not> be passed to RSA_set0_key().  If
+needed, duplicate the received value using BN_dup() and pass the
+duplicate.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
The diverse {RSA,DSA,DH}_set0_\* functions are made to allow some
parameters to be NULL IF the corresponding numbers in the given key
structure have already been previously initialised.  Specifically,
this allows the addition of private components to be added to a key
that already has the public half, approximately like this:

```
RSA_get0_key(rsa, NULL, &e, NULL);
RSA_get0_factors(rsa, &p, &q);
/* calculate new d */
RSA_set0_key(rsa, NULL, NULL, d);
```

---

**NOTE** This is an alternative to #994, and might prove to be the better choice.
