### PR TITLE
More zalloc: fix default initialisation of some allocated objects

### DIFF
--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -199,7 +199,7 @@ static ASN1_STRING_TABLE *stable_get(int nid)
     tmp = ASN1_STRING_TABLE_get(nid);
     if (tmp && tmp->flags & STABLE_FLAGS_MALLOC)
         return tmp;
-    rv = OPENSSL_malloc(sizeof(*rv));
+    rv = OPENSSL_zalloc(sizeof(*rv));
     if (rv == NULL)
         return NULL;
     if (!sk_ASN1_STRING_TABLE_push(stable, rv)) {
@@ -213,10 +213,8 @@ static ASN1_STRING_TABLE *stable_get(int nid)
         rv->mask = tmp->mask;
         rv->flags = tmp->flags | STABLE_FLAGS_MALLOC;
     } else {
-        rv->nid = NID_undef;
         rv->minsize = -1;
         rv->maxsize = -1;
-        rv->mask = 0;
         rv->flags = STABLE_FLAGS_MALLOC;
     }
     return rv;

--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -213,6 +213,7 @@ static ASN1_STRING_TABLE *stable_get(int nid)
         rv->mask = tmp->mask;
         rv->flags = tmp->flags | STABLE_FLAGS_MALLOC;
     } else {
+        rv->nid = NID_undef;
         rv->minsize = -1;
         rv->maxsize = -1;
         rv->mask = 0;

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -95,9 +95,8 @@ const BIO_METHOD *BIO_f_asn1(void)
 
 static int asn1_bio_new(BIO *b)
 {
-    BIO_ASN1_BUF_CTX *ctx;
+    BIO_ASN1_BUF_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 
-    ctx = OPENSSL_malloc(sizeof(*ctx));
     if (ctx == NULL)
         return 0;
     if (!asn1_bio_init(ctx, DEFAULT_ASN1_BUF_SIZE)) {
@@ -116,17 +115,9 @@ static int asn1_bio_init(BIO_ASN1_BUF_CTX *ctx, int size)
     if (ctx->buf == NULL)
         return 0;
     ctx->bufsize = size;
-    ctx->bufpos = 0;
-    ctx->buflen = 0;
-    ctx->copylen = 0;
     ctx->asn1_class = V_ASN1_UNIVERSAL;
     ctx->asn1_tag = V_ASN1_OCTET_STRING;
-    ctx->ex_buf = NULL;
-    ctx->ex_len = 0;
-    ctx->ex_pos = 0;
     ctx->state = ASN1_STATE_START;
-    ctx->prefix = ctx->prefix_free = ctx->suffix = ctx->suffix_free = NULL;
-    ctx->ex_arg = NULL;
     return 1;
 }
 

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -96,6 +96,7 @@ const BIO_METHOD *BIO_f_asn1(void)
 static int asn1_bio_new(BIO *b)
 {
     BIO_ASN1_BUF_CTX *ctx;
+
     ctx = OPENSSL_malloc(sizeof(*ctx));
     if (ctx == NULL)
         return 0;
@@ -120,10 +121,12 @@ static int asn1_bio_init(BIO_ASN1_BUF_CTX *ctx, int size)
     ctx->copylen = 0;
     ctx->asn1_class = V_ASN1_UNIVERSAL;
     ctx->asn1_tag = V_ASN1_OCTET_STRING;
-    ctx->ex_buf = 0;
-    ctx->ex_pos = 0;
+    ctx->ex_buf = NULL;
     ctx->ex_len = 0;
+    ctx->ex_pos = 0;
     ctx->state = ASN1_STATE_START;
+    ctx->prefix = ctx->prefix_free = ctx->suffix = ctx->suffix_free = NULL;
+    ctx->ex_arg = NULL;
     return 1;
 }
 

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -90,6 +90,7 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     ndef_aux->ndef_bio = sarg.ndef_bio;
     ndef_aux->boundary = sarg.boundary;
     ndef_aux->out = out;
+    ndef_aux->derbuf = NULL;
 
     BIO_ctrl(asn_bio, BIO_C_SET_EX_ARG, 0, ndef_aux);
 

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -60,14 +60,14 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
         ASN1err(ASN1_F_BIO_NEW_NDEF, ASN1_R_STREAMING_NOT_SUPPORTED);
         return NULL;
     }
-    ndef_aux = OPENSSL_malloc(sizeof(*ndef_aux));
+    ndef_aux = OPENSSL_zalloc(sizeof(*ndef_aux));
     asn_bio = BIO_new(BIO_f_asn1());
+    if (ndef_aux == NULL || asn_bio == NULL)
+        goto err;
 
     /* ASN1 bio needs to be next to output BIO */
-
     out = BIO_push(asn_bio, out);
-
-    if (ndef_aux == NULL || asn_bio == NULL || !out)
+    if (out == NULL)
         goto err;
 
     BIO_asn1_set_prefix(asn_bio, ndef_prefix, ndef_prefix_free);
@@ -90,7 +90,6 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     ndef_aux->ndef_bio = sarg.ndef_bio;
     ndef_aux->boundary = sarg.boundary;
     ndef_aux->out = out;
-    ndef_aux->derbuf = NULL;
 
     BIO_ctrl(asn_bio, BIO_C_SET_EX_ARG, 0, ndef_aux);
 

--- a/crypto/asn1/tasn_scn.c
+++ b/crypto/asn1/tasn_scn.c
@@ -25,12 +25,20 @@
 ASN1_SCTX *ASN1_SCTX_new(int (*scan_cb) (ASN1_SCTX *ctx))
 {
     ASN1_SCTX *ret;
+
     ret = OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1err(ASN1_F_ASN1_SCTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
+    ret->it = ret->tt = NULL;
+    ret->flags = 0;
+    ret->skidx = ret->depth = 0;
+    ret->sname = ret->fname = NULL;
+    ret->prim_type = 0;
+    ret->field = NULL;
     ret->scan_cb = scan_cb;
+    ret->app_data = NULL;
     return ret;
 }
 

--- a/crypto/asn1/tasn_scn.c
+++ b/crypto/asn1/tasn_scn.c
@@ -24,21 +24,13 @@
 
 ASN1_SCTX *ASN1_SCTX_new(int (*scan_cb) (ASN1_SCTX *ctx))
 {
-    ASN1_SCTX *ret;
+    ASN1_SCTX *ret = OPENSSL_zalloc(sizeof(*ret));
 
-    ret = OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1err(ASN1_F_ASN1_SCTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    ret->it = ret->tt = NULL;
-    ret->flags = 0;
-    ret->skidx = ret->depth = 0;
-    ret->sname = ret->fname = NULL;
-    ret->prim_type = 0;
-    ret->field = NULL;
     ret->scan_cb = scan_cb;
-    ret->app_data = NULL;
     return ret;
 }
 

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -74,20 +74,13 @@ struct bio_bio_st {
 
 static int bio_new(BIO *bio)
 {
-    struct bio_bio_st *b;
+    struct bio_bio_st *b = OPENSSL_zalloc(sizeof(*b));
 
-    b = OPENSSL_malloc(sizeof(*b));
     if (b == NULL)
         return 0;
 
-    b->peer = NULL;
-    b->closed = 0;
-    b->len = 0;
-    b->offset = 0;
     /* enough for one TLS record (just a default) */
     b->size = 17 * 1024;
-    b->buf = NULL;
-    b->request = 0;
 
     bio->ptr = b;
     return 1;

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -81,9 +81,13 @@ static int bio_new(BIO *bio)
         return 0;
 
     b->peer = NULL;
+    b->closed = 0;
+    b->len = 0;
+    b->offset = 0;
     /* enough for one TLS record (just a default) */
     b->size = 17 * 1024;
     b->buf = NULL;
+    b->request = 0;
 
     bio->ptr = b;
     return 1;


### PR DESCRIPTION
1st commit is intended to be back-ported.
So, I revert some of his changes in the second commit directly.