### PR TITLE
Fix a few leaks in X509_REQ_to_X509 (1.0.2 backport)

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -2305,6 +2305,7 @@ static int certify_spkac(X509 **xret, char *infile, EVP_PKEY *pkey,
 
     j = NETSCAPE_SPKI_verify(spki, pktmp);
     if (j <= 0) {
+        EVP_PKEY_free(pktmp);
         BIO_printf(bio_err,
                    "signature verification failed on SPKAC public key\n");
         goto err;

--- a/crypto/x509/x509_r2x.c
+++ b/crypto/x509/x509_r2x.c
@@ -70,10 +70,12 @@ X509 *X509_REQ_to_X509(X509_REQ *r, int days, EVP_PKEY *pkey)
     X509 *ret = NULL;
     X509_CINF *xi = NULL;
     X509_NAME *xn;
+    EVP_PKEY *pubkey = NULL;
+    int res;
 
     if ((ret = X509_new()) == NULL) {
         X509err(X509_F_X509_REQ_TO_X509, ERR_R_MALLOC_FAILURE);
-        goto err;
+        return NULL;
     }
 
     /* duplicate the request */
@@ -89,9 +91,9 @@ X509 *X509_REQ_to_X509(X509_REQ *r, int days, EVP_PKEY *pkey)
     }
 
     xn = X509_REQ_get_subject_name(r);
-    if (X509_set_subject_name(ret, X509_NAME_dup(xn)) == 0)
+    if (X509_set_subject_name(ret, xn) == 0)
         goto err;
-    if (X509_set_issuer_name(ret, X509_NAME_dup(xn)) == 0)
+    if (X509_set_issuer_name(ret, xn) == 0)
         goto err;
 
     if (X509_gmtime_adj(xi->validity->notBefore, 0) == NULL)
@@ -100,9 +102,11 @@ X509 *X509_REQ_to_X509(X509_REQ *r, int days, EVP_PKEY *pkey)
         NULL)
         goto err;
 
-    X509_set_pubkey(ret, X509_REQ_get_pubkey(r));
+    pubkey = X509_REQ_get_pubkey(r);
+    res = X509_set_pubkey(ret, pubkey);
+    EVP_PKEY_free(pubkey);
 
-    if (!X509_sign(ret, pkey, EVP_md5()))
+    if (!res || !X509_sign(ret, pkey, EVP_md5()))
         goto err;
     if (0) {
  err:


### PR DESCRIPTION
Backport of 0517538d1a39bc  "Fix a few leaks in X509_REQ_to_X509 "
Backport of f6c006ea76304a  "Fix a possible leak on NETSCAPE_SPKI_verify failure "

Backport of PR #933 to 1.0.2 branch