### PR TITLE
x86_64cpuid.pl generate OPENSSL_cleanse that SEGFAULT (1.0.2g)

### DIFF
--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -209,7 +209,7 @@ OPENSSL_cleanse:
 .align	16
 .Lot:
 	test	\$7,$arg1
-	jz	.Laligned
+	jz	.Lret
 	mov	%al,($arg1)
 	lea	-1($arg2),$arg2
 	lea	1($arg1),$arg1


### PR DESCRIPTION
 - there is a segfault in OPENSSL_cleanse x86_64 generated assembly version
   when a NULL pointer is provided as parameter.
   Detected with following command line:
   touch passwd.srpv ; src/openssl/apps/openssl srp -srpvfile passwd.srpv -add -gn 1536 user

