### PR TITLE
Make header signature of CRYPTO_mem_leaks BIO instead of struct bio_st

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -409,7 +409,7 @@ void CRYPTO_mem_debug_free(void *addr, int flag,
 #  ifndef OPENSSL_NO_STDIO
 int CRYPTO_mem_leaks_fp(FILE *);
 #  endif
-int CRYPTO_mem_leaks(struct bio_st *bio);
+int CRYPTO_mem_leaks(BIO *bio);
 # endif
 
 /* die if we have to */


### PR DESCRIPTION
With this struct being opaque now and the actual function definition using `BIO` it potentially makes sense to switch this. (Unless there are some declaration order issues that I am unaware of)