### PR TITLE
Fix i2d_X509_AUX.

### DIFF
--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -184,16 +184,13 @@ X509 *d2i_X509_AUX(X509 **a, const unsigned char **pp, long length)
 int i2d_X509_AUX(X509 *a, unsigned char **pp)
 {
     int length, tmplen;
-    unsigned char *start = *pp;
     length = i2d_X509(a, pp);
     if (length < 0 || a == NULL)
         return length;
 
     tmplen = i2d_X509_CERT_AUX(a->aux, pp);
-    if (tmplen < 0) {
-        *pp = start;
+    if (tmplen < 0)
         return tmplen;
-    }
     length += tmplen;
 
     return length;


### PR DESCRIPTION
446ba8de9af9aa4fa3debc7c76a38f4efed47a62 add some missing failure checks, but the logic to reset *pp doesn't work if pp is NULL. Simply remove the checks as the template-based i2d functions can modify *pp in error paths already.

You'll want to cherry-pick this into 1.0.1 and 1.0.2 as well.