### PR TITLE
Revert "Add Haiku support."

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1763,36 +1763,6 @@ sub vms_info {
         shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
         ranlib           => "$ENV{'RANLIB'}",
     },
-    "haiku-common" => {
-        template         => 1,
-        cc               => "cc",
-        cflags           => add_before(picker(default => "-DL_ENDIAN -Wall",
-                                              debug   => "-g -O0",
-                                              release => "-O2"),
-                                       threads("-D_REENTRANT")),
-        sys_id           => "HAIKU",
-        lflags           => "-lnetwork",
-        perlasm_scheme   => "elf",
-        thread_scheme    => "pthreads",
-        dso_scheme       => "dlfcn",
-        shared_target    => "haiku-shared",
-        shared_cflag     => "-fPIC",
-        shared_ldflag    => "-shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
-    },
-    "haiku-x86" => {
-        inherit_from     => [ "haiku-common", asm("x86_elf_asm") ],
-        cflags           => add(picker(default => "",
-                                       release => "-fomit-frame-pointer")),
-        bn_ops           => "BN_LLONG",
-    },
-    # Haiku builds with no-asm
-    "haiku-x86_64" => {
-        inherit_from     => [ "haiku-common", asm("x86_64_asm") ],
-        cflags           => add("-m64"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-    },
-
 
     ##### VMS
     "vms-generic" => {

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -561,11 +561,11 @@ symlink.hpux:
 symlink.cygwin symlink.alpha-osf1 symlink.tru64 symlink.tru64-rpath:
 
 # Compatibility targets
-link_dso.bsd-gcc-shared link_dso.linux-shared link_dso.gnu-shared link_dso.haiku-shared: link_dso.gnu
+link_dso.bsd-gcc-shared link_dso.linux-shared link_dso.gnu-shared: link_dso.gnu
 link_shlib.bsd-gcc-shared: link_shlib.linux-shared
-link_shlib.gnu-shared link_shlib.haiku-shared: link_shlib.gnu
-link_app.bsd-gcc-shared link_app.linux-shared link_app.gnu-shared link_app.haiku-shared: link_app.gnu
-symlink.bsd-gcc-shared symlink.bsd-shared symlink.linux-shared symlink.gnu-shared symlink.haiku-shared: symlink.gnu
+link_shlib.gnu-shared: link_shlib.gnu
+link_app.bsd-gcc-shared link_app.linux-shared link_app.gnu-shared: link_app.gnu
+symlink.bsd-gcc-shared symlink.bsd-shared symlink.linux-shared symlink.gnu-shared: symlink.gnu
 link_dso.bsd-shared: link_dso.bsd
 link_shlib.bsd-shared: link_shlib.bsd
 link_app.bsd-shared: link_app.bsd

--- a/config
+++ b/config
@@ -202,10 +202,6 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
 	echo "${MACHINE}-whatever-freebsd"; exit 0
 	;;
 
-    Haiku:*)
-	echo "${MACHINE}-whatever-haiku"; exit 0
-	;;
-
     NetBSD:*:*:*386*)
         echo "`(/usr/sbin/sysctl -n hw.model || /sbin/sysctl -n hw.model) | sed 's,.*\(.\)86-class.*,i\186,'`-whatever-netbsd"; exit 0
 	;;
@@ -728,8 +724,6 @@ case "$GUESSOS" in
 			*ELF*)	OUT="BSD-x86-elf" ;;
 			*)	OUT="BSD-x86"; options="$options no-sse2" ;;
 			esac ;;
-  x86_64-*-haiku)	OUT="haiku-x86_64" ;;
-  *-*-haiku)		OUT="haiku-x86" ;;
   *-*-*bsd*)		OUT="BSD-generic32" ;;
 
   *-*-osf)		OUT="osf1-alpha-cc" ;;

--- a/e_os.h
+++ b/e_os.h
@@ -548,13 +548,6 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
-/* haiku */
-# if defined(OPENSSL_SYS_HAIKU)
-#  include <sys/select.h>
-#  include <sys/time.h>
-# endif
-/* end haiku */
-
 #define OSSL_NELEM(x)    (sizeof(x)/sizeof(x[0]))
 
 #ifdef  __cplusplus


### PR DESCRIPTION
This reverts commit 6e08e9e7ccf00aba847351adc3b46b9dae1f114d.
Commit 2ca1e22b2acdacb0a879dded91bdd5b2b6040ad3 needn't be reverted
since the configuration stanza is gone.