### PR TITLE
DEFINE_STACK_OF(ASN1_UTF8STRING) replaced from ts_lcl.h to ts.h

### DIFF
--- a/crypto/ts/ts_lcl.h
+++ b/crypto/ts/ts_lcl.h
@@ -144,8 +144,6 @@ struct TS_status_info_st {
     ASN1_BIT_STRING *failure_info;
 };
 
-DEFINE_STACK_OF(ASN1_UTF8STRING)
-
 /*-
  * IssuerSerial ::= SEQUENCE {
  *         issuer                   GeneralNames,

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -473,6 +473,8 @@ DEFINE_STACK_OF(ASN1_INTEGER)
 
 DEFINE_STACK_OF(ASN1_GENERALSTRING)
 
+DEFINE_STACK_OF(ASN1_UTF8STRING)
+
 typedef struct asn1_type_st {
     int type;
     union {


### PR DESCRIPTION
Missing defines for work with ASN1_UTF8STRING.

Public function TS_STATUS_INFO_get0_text returns STACK_OF(ASN1_UTF8STRING)*. STACK_OF(ASN1_UTF8STRING) is defined in ts_lcl.h (internal header), thus applications can not work with the returned value. This patch moves DEFINE_STACK_OF(ASN1_UTF8STRING) to public header file.