### PR TITLE
Fix error in the loop of ECDH in speed.c

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2650,20 +2650,20 @@ int speed_main(int argc, char **argv)
                         break;
                     }
                 }
-                if (ecdh_checks != 0) {
-                    pkey_print_message("", "ecdh",
-                            ecdh_c[testnum][0],
-                            test_curves_bits[testnum], ECDH_SECONDS);
-                    Time_F(START);
-                    count = run_benchmark(async_jobs, ECDH_compute_key_loop, loopargs);
-                    d = Time_F(STOP);
-                    BIO_printf(bio_err,
-                            mr ? "+R7:%ld:%d:%.2f\n" :
-                            "%ld %d-bit ECDH ops in %.2fs\n", count,
-                            test_curves_bits[testnum], d);
-                    ecdh_results[testnum][0] = d / (double)count;
-                    rsa_count = count;
-                }
+            }
+            if (ecdh_checks != 0) {
+                pkey_print_message("", "ecdh",
+                        ecdh_c[testnum][0],
+                        test_curves_bits[testnum], ECDH_SECONDS);
+                Time_F(START);
+                count = run_benchmark(async_jobs, ECDH_compute_key_loop, loopargs);
+                d = Time_F(STOP);
+                BIO_printf(bio_err,
+                        mr ? "+R7:%ld:%d:%.2f\n" :
+                        "%ld %d-bit ECDH ops in %.2fs\n", count,
+                        test_curves_bits[testnum], d);
+                ecdh_results[testnum][0] = d / (double)count;
+                rsa_count = count;
             }
         }
 


### PR DESCRIPTION
The tests were incorrectly repeated multiple times when using the option `-async_jobs`

For example, with `async_jobs = 2` all the tests were repeated twice:

```
> apps/openssl speed -engine dasync -elapsed -async_jobs 2 ecd
engine "dasync" set.
You have chosen to measure elapsed time instead of user CPU time.
Doing 160 bit  ecdh's for 1s: 4464 160-bit ECDH ops in 1.00s
Doing 160 bit  ecdh's for 1s: 4464 160-bit ECDH ops in 1.00s
Doing 192 bit  ecdh's for 1s: 3685 192-bit ECDH ops in 1.00s
Doing 192 bit  ecdh's for 1s: 3677 192-bit ECDH ops in 1.00s
Doing 224 bit  ecdh's for 1s: 2712 224-bit ECDH ops in 1.00s
Doing 224 bit  ecdh's for 1s: 2714 224-bit ECDH ops in 1.00s
```

