### PR TITLE
Raise an Err when CRYPTO_THREAD_lock_new fails

### DIFF
--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -50,6 +50,7 @@ int asn1_set_choice_selector(ASN1_VALUE **pval, int value,
  * then the count is incremented. If op is 0 count is set to 1. If op is -1
  * count is decremented and the return value is the current reference count
  * or 0 if no reference count exists.
+ * FIXME: return and manage any error from inside this method
  */
 
 int asn1_do_lock(ASN1_VALUE **pval, int op, const ASN1_ITEM *it)
@@ -68,8 +69,10 @@ int asn1_do_lock(ASN1_VALUE **pval, int op, const ASN1_ITEM *it)
     if (op == 0) {
         *lck = 1;
         *lock = CRYPTO_THREAD_lock_new();
-        if (*lock == NULL)
+        if (*lock == NULL) {
+            /* FIXME: should report an error (-1) at this point */
             return 0;
+        }
         return 1;
     }
     CRYPTO_atomic_add(lck, op, &ret, *lock);

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -64,6 +64,7 @@ DH *DH_new_method(ENGINE *engine)
     ret->references = 1;
     ret->lock = CRYPTO_THREAD_lock_new();
     if (ret->lock == NULL) {
+        DHerr(DH_F_DH_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(ret);
         return NULL;
     }

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -73,6 +73,7 @@ DSA *DSA_new_method(ENGINE *engine)
     ret->references = 1;
     ret->lock = CRYPTO_THREAD_lock_new();
     if (ret->lock == NULL) {
+        DSAerr(DSA_F_DSA_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(ret);
         return NULL;
     }

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -39,6 +39,7 @@ static DSO *DSO_new_method(DSO_METHOD *meth)
     ret->references = 1;
     ret->lock = CRYPTO_THREAD_lock_new();
     if (ret->lock == NULL) {
+        DSOerr(DSO_F_DSO_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         sk_void_free(ret->meth_data);
         OPENSSL_free(ret);
         return NULL;

--- a/engines/e_chil.c
+++ b/engines/e_chil.c
@@ -309,8 +309,10 @@ static int bind_helper(ENGINE *e)
 #  endif
 
     chil_lock = CRYPTO_THREAD_lock_new();
-    if (chil_lock == NULL)
+    if (chil_lock == NULL) {
+        HWCRHKerr(HWCRHK_F_BIND_HELPER, ERR_R_MALLOC_FAILURE);
         return 0;
+    }
 
     if (!ENGINE_set_id(e, engine_hwcrhk_id) ||
         !ENGINE_set_name(e, engine_hwcrhk_name) ||
@@ -1092,8 +1094,10 @@ static int hwcrhk_mutex_init(HWCryptoHook_Mutex * mt,
                              HWCryptoHook_CallerContext * cactx)
 {
     mt->lock = CRYPTO_THREAD_lock_new();
-    if (mt->lock == NULL)
+    if (mt->lock == NULL) {
+        HWCRHKerr(HWCRHK_F_HWCRHK_MUTEX_INIT, ERR_R_MALLOC_FAILURE);
         return 1;               /* failure */
+    }
     return 0;                   /* success */
 }
 

--- a/engines/e_chil_err.h
+++ b/engines/e_chil_err.h
@@ -39,6 +39,8 @@ static void ERR_HWCRHK_error(int function, int reason, char *file, int line);
 # define HWCRHK_F_HWCRHK_MOD_EXP                          107
 # define HWCRHK_F_HWCRHK_RAND_BYTES                       108
 # define HWCRHK_F_HWCRHK_RSA_MOD_EXP                      109
+# define HWCRHK_F_BIND_HELPER                             110
+# define HWCRHK_F_HWCRHK_MUTEX_INIT                       111
 
 /* Reason codes. */
 # define HWCRHK_R_ALREADY_LOADED                          100


### PR DESCRIPTION
Add missing error raise call, as it is done everyxhere else.