### PR TITLE
Free any existing SRTP connection profile

### DIFF
--- a/ssl/d1_srtp.c
+++ b/ssl/d1_srtp.c
@@ -197,6 +197,8 @@ static int ssl_ctx_make_profiles(const char *profiles_string,
             ptr = col + 1;
     } while (col);
 
+    sk_SRTP_PROTECTION_PROFILE_free(*out);
+
     *out = profiles;
 
     return 0;


### PR DESCRIPTION
When setting a new SRTP connection profile using
SSL_CTX_set_tlsext_use_srtp() or SSL_set_tlsext_use_srtp() we should
free any existing profile first to avoid a memory leak.