### PR TITLE
fix BN_hex2bn()/BN_dec2bn() memory leak

### DIFF
--- a/crypto/bn/bn_print.c
+++ b/crypto/bn/bn_print.c
@@ -187,7 +187,7 @@ int BN_hex2bn(BIGNUM **bn, const char *a)
     for (i = 0; i <= (INT_MAX/4) && isxdigit((unsigned char)a[i]); i++)
         continue;
 
-    if (i > INT_MAX/4)
+    if (i == 0 || i > INT_MAX/4)
         goto err;
 
     num = i + neg;
@@ -262,7 +262,7 @@ int BN_dec2bn(BIGNUM **bn, const char *a)
     for (i = 0; i <= (INT_MAX/4) && isdigit((unsigned char)a[i]); i++)
         continue;
 
-    if (i > INT_MAX/4)
+    if (i == 0 || i > INT_MAX/4)
         goto err;
 
     num = i + neg;

--- a/doc/crypto/BN_bn2bin.pod
+++ b/doc/crypto/BN_bn2bin.pod
@@ -51,11 +51,12 @@ hexadecimal and decimal encoding of B<a> respectively. For negative
 numbers, the string is prefaced with a leading '-'. The string must be
 freed later using OPENSSL_free().
 
-BN_hex2bn() converts the string B<str> containing a hexadecimal number
-to a B<BIGNUM> and stores it in **B<bn>. If *B<bn> is NULL, a new
-B<BIGNUM> is created. If B<bn> is NULL, it only computes the number's
-length in hexadecimal digits. If the string starts with '-', the
-number is negative. BN_dec2bn() is the same using the decimal system.
+BN_hex2bn()takes as many characters as possible from the string B<str>, 
+including the leading character '-' which means negative, to form a valid 
+hexadecimal number representation and converts them to a B<BIGNUM> and 
+stores it in **B<bn>. If *B<bn> is NULL, a new B<BIGNUM> is created. If 
+B<bn> is NULL, it only computes the length of valid representation.
+BN_dec2bn() is the same using the decimal system.
 
 BN_print() and BN_print_fp() write the hexadecimal encoding of B<a>,
 with a leading '-' for negative numbers, to the B<BIO> or B<FILE>
@@ -84,8 +85,9 @@ BN_bn2binpad() returns the number of bytes written or -1 if the supplied
 buffer is too small.
 
 BN_bn2hex() and BN_bn2dec() return a null-terminated string, or NULL
-on error. BN_hex2bn() and BN_dec2bn() return the number's length in
-hexadecimal or decimal digits, and 0 on error.
+on error. BN_hex2bn() and BN_dec2bn() return the the length of valid 
+representation in hexadecimal or decimal digits, and 0 on error, in which
+case no new B<BIGNUM> will be created.
 
 BN_print_fp() and BN_print() return 1 on success, 0 on write errors.
 


### PR DESCRIPTION
```c
BIGNUM* n = NULL;
if (BN_hex2bn(&n, "g")){
    ...
    BN_free(n);
}
else{
     // error handling
}
```
  According to returned error code(0), we need to handle the error and generally expect that n is still NULL so that we don't need call to BN_free(), but we are disappointed and may cause potential memory leak. In additionI, "-g" isn't a valid hex string but `BN_hex2bn(&n, "-g")` returns 1 and eats the char '-'.

  This fix may be a breaking change for someone?!