### PR TITLE
Fix TLS1_get_version and TLS1_get_client_version macros

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1741,6 +1741,7 @@ __owur int SSL_get_quiet_shutdown(const SSL *ssl);
 void SSL_set_shutdown(SSL *ssl, int mode);
 __owur int SSL_get_shutdown(const SSL *ssl);
 __owur int SSL_version(const SSL *ssl);
+__owur int SSL_client_version(const SSL *s);
 __owur int SSL_CTX_set_default_verify_paths(SSL_CTX *ctx);
 __owur int SSL_CTX_set_default_verify_dir(SSL_CTX *ctx);
 __owur int SSL_CTX_set_default_verify_file(SSL_CTX *ctx);

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -179,10 +179,10 @@ extern "C" {
 # define TLS1_2_VERSION_MINOR            0x03
 
 # define TLS1_get_version(s) \
-                ((s->version >> 8) == TLS1_VERSION_MAJOR ? s->version : 0)
+                ((SSL_version(s) >> 8) == TLS1_VERSION_MAJOR ? SSL_version(s) : 0)
 
 # define TLS1_get_client_version(s) \
-                ((s->client_version >> 8) == TLS1_VERSION_MAJOR ? s->client_version : 0)
+                ((SSL_client_version(s) >> 8) == TLS1_VERSION_MAJOR ? SSL_client_version(s) : 0)
 
 # define TLS1_AD_DECRYPTION_FAILED       21
 # define TLS1_AD_RECORD_OVERFLOW         22

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3381,17 +3381,22 @@ void SSL_set_shutdown(SSL *s, int mode)
 
 int SSL_get_shutdown(const SSL *s)
 {
-    return (s->shutdown);
+    return s->shutdown;
 }
 
 int SSL_version(const SSL *s)
 {
-    return (s->version);
+    return s->version;
+}
+
+int SSL_client_version(const SSL *s)
+{
+    return s->client_version;
 }
 
 SSL_CTX *SSL_get_SSL_CTX(const SSL *ssl)
 {
-    return (ssl->ctx);
+    return ssl->ctx;
 }
 
 SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -394,3 +394,4 @@ SSL_enable_ct                           393	1_1_0	EXIST::FUNCTION:CT
 SSL_CTX_enable_ct                       394	1_1_0	EXIST::FUNCTION:CT
 SSL_CTX_get_ciphers                     395	1_1_0	EXIST::FUNCTION:
 SSL_SESSION_get0_hostname               396	1_1_0	EXIST::FUNCTION:
+SSL_client_version                      397	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Causes build failure in e.g. OpenResty https://github.com/openresty/lua-nginx-module/issues/757.