### PR TITLE
Fix: PEM_read_bio_PrivateKey with no-ui / no-stdio

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -77,21 +77,23 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 int PEM_def_callback(char *buf, int num, int w, void *key)
 {
+#if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
+    int i;
+#else
     int i, j;
     const char *prompt;
+#endif
+
     if (key) {
         i = strlen(key);
         i = (i > num) ? num : i;
         memcpy(buf, key, i);
-        return (i);
+        return i;
     }
 
 #if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
-    /*
-     * We should not ever call the default callback routine from windows.
-     */
     PEMerr(PEM_F_PEM_DEF_CALLBACK, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-    return (-1);
+    return -1;
 #else
     prompt = EVP_get_pw_prompt();
     if (prompt == NULL)
@@ -102,7 +104,7 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
         if (i != 0) {
             PEMerr(PEM_F_PEM_DEF_CALLBACK, PEM_R_PROBLEMS_GETTING_PASSWORD);
             memset(buf, 0, (unsigned int)num);
-            return (-1);
+            return -1;
         }
         j = strlen(buf);
         if (j < MIN_LENGTH) {
@@ -112,7 +114,7 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
         } else
             break;
     }
-    return (j);
+    return j;
 #endif
 }
 

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -77,13 +77,6 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 int PEM_def_callback(char *buf, int num, int w, void *key)
 {
-#if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
-    /*
-     * We should not ever call the default callback routine from windows.
-     */
-    PEMerr(PEM_F_PEM_DEF_CALLBACK, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-    return (-1);
-#else
     int i, j;
     const char *prompt;
     if (key) {
@@ -93,6 +86,13 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
         return (i);
     }
 
+#if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
+    /*
+     * We should not ever call the default callback routine from windows.
+     */
+    PEMerr(PEM_F_PEM_DEF_CALLBACK, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+    return (-1);
+#else
     prompt = EVP_get_pw_prompt();
     if (prompt == NULL)
         prompt = "Enter PEM pass phrase:";


### PR DESCRIPTION
If openssl is compiled with no-ui or no-stdio, then PEM_read_bio_PrivateKey fails if a password but no callback is provided.

The reason is that the premature return in the PEM_def_callback implementation comes too early when OPENSSL_NO_STDIO or OPENSSL_NO_UI is defined.

This patch moves the ifdef block to the correct place.