### PR TITLE
DJGPP adjustments

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1514,17 +1514,6 @@ sub vms_info {
 	inherit_from     => [ "Cygwin-x86" ]
     },
 
-#### DJGPP
-    "DJGPP" => {
-        inherit_from     => [ asm("x86_asm") ],
-        cc               => "gcc",
-        cflags           => "-I/dev/env/WATT_ROOT/inc -DTERMIO -DL_ENDIAN -fomit-frame-pointer -O2 -Wall",
-        sys_id           => "MSDOS",
-        ex_libs          => add("-L/dev/env/WATT_ROOT/lib -lwatt"),
-        bn_ops           => "BN_LLONG",
-        perlasm_scheme   => "a.out",
-    },
-
 ##### MacOS X (a.k.a. Darwin) setup
     "darwin-common" => {
         inherit_from     => [ "BASE_unix" ],

--- a/Configurations/50-djgpp.conf
+++ b/Configurations/50-djgpp.conf
@@ -1,0 +1,15 @@
+# We can't make any commitment to support the DJGPP platform,
+# and rely entirely on the OpenSSL community to help is fine
+# tune and test.
+
+%targets = (
+    "DJGPP" => {
+        inherit_from     => [ asm("x86_asm") ],
+        cc               => "gcc",
+        cflags           => "-I/dev/env/WATT_ROOT/inc -DTERMIOS -DL_ENDIAN -fomit-frame-pointer -O2 -Wall",
+        sys_id           => "MSDOS",
+        ex_libs          => add("-L/dev/env/WATT_ROOT/lib -lwatt"),
+        bn_ops           => "BN_LLONG",
+        perlasm_scheme   => "a.out",
+    },
+);

--- a/INSTALL.DJGPP
+++ b/INSTALL.DJGPP
@@ -19,7 +19,7 @@
  files to download, see the DJGPP "ZIP PICKER" page at
  "http://www.delorie.com/djgpp/zip-picker.html". You also need to have
  the WATT-32 networking package installed before you try to compile
- OpenSSL. This can be obtained from "http://www.bgnett.no/~giva/".
+ OpenSSL. This can be obtained from "http://www.watt-32.net/".
  The Makefile assumes that the WATT-32 code is in the directory
  specified by the environment variable WATT_ROOT. If you have watt-32
  in directory "watt32" under your main DJGPP directory, specify

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -94,12 +94,6 @@
          ((a)->s6_addr32[2] == htonl(0x0000ffff)))
 # endif
 
-# ifdef WATT32
-#  define sock_write SockWrite  /* Watt-32 uses same names */
-#  define sock_read  SockRead
-#  define sock_puts  SockPuts
-# endif
-
 static int dgram_write(BIO *h, const char *buf, int num);
 static int dgram_read(BIO *h, char *buf, int size);
 static int dgram_puts(BIO *h, const char *str);

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -89,10 +89,10 @@
 
 # if !defined(OPENSSL_NO_STDIO)
 
-#ifdef OPENSSL_SYS_MSDOS
-# include <libc/unconst.h>
+#  if defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_WINDOWS)
+#   include <libc/unconst.h>
 static void dosify_filename(const char *filename);
-#endif
+#  endif
 static int file_write(BIO *h, const char *buf, int num);
 static int file_read(BIO *h, char *buf, int size);
 static int file_puts(BIO *h, const char *str);
@@ -159,7 +159,7 @@ static FILE *file_fopen(const char *filename, const char *mode)
         file = fopen(filename, mode);
     }
 #  else
-#   ifdef OPENSSL_SYS_MSDOS
+#   if defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_WINDOWS)
     dosify_filename(filename);
 #   endif
     file = fopen(filename, mode);
@@ -462,7 +462,7 @@ static int file_puts(BIO *bp, const char *str)
     return (ret);
 }
 
-#ifdef OPENSSL_SYS_MSDOS
+# if defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_WINDOWS)
 static void dosify_filename(const char *filename)
 {
     if (filename && *filename && !HAS_LFN_SUPPORT(filename)) {
@@ -478,7 +478,7 @@ static void dosify_filename(const char *filename)
         } while (*++namestart);
     }
 }
-#endif
+# endif
 #else
 
 static int file_write(BIO *b, const char *in, int inl)

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -177,6 +177,7 @@ static FILE *file_fopen(const char *filename, const char *mode)
                 }
                 lastchar = *filename;
             }
+            *iterator = '\0';
             filename = newname;
         }
         file = fopen(filename, mode);

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -162,7 +162,7 @@ static FILE *file_fopen(const char *filename, const char *mode)
             char *iterator;
             char lastchar;
 
-            newname = OPENSSL_malloc(strlen(filename));
+            newname = OPENSSL_malloc(strlen(filename) + 1);
             if (newname == NULL)
                 return NULL;
 

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -66,7 +66,11 @@
 # include <openssl/bio.h>
 
 # ifdef WATT32
-#  define sock_write SockWrite  /* Watt-32 uses same names */
+/* Watt-32 uses same names */
+#  undef sock_write
+#  undef sock_read
+#  undef sock_puts
+#  define sock_write SockWrite
 #  define sock_read  SockRead
 #  define sock_puts  SockPuts
 # endif

--- a/e_os.h
+++ b/e_os.h
@@ -151,6 +151,7 @@ extern "C" {
 #  define writesocket(s,b,n)      send((s),(b),(n),0)
 # elif defined(__DJGPP__)
 #  define WATT32
+#  define WATT32_NO_OLDIES
 #  define get_last_socket_error() errno
 #  define clear_socket_error()    errno=0
 #  define closesocket(s)          close_s(s)
@@ -185,11 +186,14 @@ extern "C" {
 #   include <unistd.h>
 #   include <sys/stat.h>
 #   include <sys/socket.h>
+#   include <sys/un.h>
 #   include <tcp.h>
 #   include <netdb.h>
 #   define _setmode setmode
 #   define _O_TEXT O_TEXT
 #   define _O_BINARY O_BINARY
+#   define HAS_LFN_SUPPORT(name)  (pathconf((name), _PC_NAME_MAX) > 12)
+#   undef DEVRANDOM_EGD  /*  Neither MS-DOS nor FreeDOS provide 'egd' sockets.  */
 #   undef DEVRANDOM
 #   define DEVRANDOM "/dev/urandom\x24"
 #  endif                        /* __DJGPP__ */


### PR DESCRIPTION
- Configure: Replaced -DTERMIO by -DTERMIOS in CFLAGS.
- crypto/bio/bss_dgram.c [WATT32]: Remove obsolete redefinition of
  function names: sock_write, sock_read and sock_puts.
- crypto/bio/bss_sock.c [WATT32]: For Watt-32 2.2.11 sock_write,
  sock_read and sock_puts are redefined to their private names so
  their names must be undefined first before they can be redefined
  again.
- crypto/bio/bss_file.c (file_fopen) [OPENSSL_SYS_MSDOS]: Call
  dosify_filename to replace leading dot if file system does not
  support it.
  (dosify_filename): Replace leading dot in passed file name if file
  system does not support LFN. Replace all leading dots in the dirname
  part and the basname part of the file name.
- e_os.h [**DJGPP**]: Undefine macro DEVRANDOM_EGD. Neither MS-DOS nor
  FreeDOS provide 'egd' sockets.
  New macro HAS_LFN_SUPPORT checks if underlying file system supports
  long file names or not.
  Include sys/un.h.
  Define WATT32_NO_OLDIES.
- INSTALL.DJGPP: Update URL of WATT-32 library.

Submitted by Juan Manuel Guerrero juan.guerrero@gmx.de

RT#4217
