### PR TITLE
RT3720 Increment session miss counter properly

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1122,6 +1122,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
          * overwritten if the server refuses resumption.
          */
         if (s->session->session_id_length > 0) {
+            s->ctx->stats.sess_miss++;
             if (!ssl_get_new_session(s, 0)) {
                 goto f_err;
             }


### PR DESCRIPTION
Updated version of the patch linked from RT 3720, after the state machine rewrite.