### PR TITLE
Add SSL_get_tlsext_status_type() method

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1233,6 +1233,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_SET_MAX_PROTO_VERSION          124
 # define SSL_CTRL_SET_SPLIT_SEND_FRAGMENT        125
 # define SSL_CTRL_SET_MAX_PIPELINES              126
+# define SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE     127
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -351,6 +351,9 @@ SSL_callback_ctrl(ssl,SSL_CTRL_SET_TLSEXT_DEBUG_CB,(void (*)(void))cb)
 # define SSL_set_tlsext_debug_arg(ssl, arg) \
 SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_DEBUG_ARG,0, (void *)arg)
 
+# define SSL_get_tlsext_status_type(ssl, arg) \
+SSL_ctrl(ssl,SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE,0, (void *)arg)
+
 # define SSL_set_tlsext_status_type(ssl, type) \
 SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE,type, NULL)
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3071,6 +3071,11 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         ret = 1;
         break;
 
+    case SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE:
+        *(int *)parg = s->tlsext_status_type;
+        ret = 1;
+        break;
+
     case SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE:
         s->tlsext_status_type = larg;
         ret = 1;


### PR DESCRIPTION
The tlsext_status_type field in SSL is used by e.g. OpenResty to determine
if the client requested the certificate status, but SSL is now opaque.

(Btw, any alternative suggestion to accomplish the same would be appreciated).