### PR TITLE
Fix some missing OBJ_dup failure checks.

### DIFF
--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -288,7 +288,7 @@ int X509_ATTRIBUTE_set1_object(X509_ATTRIBUTE *attr, const ASN1_OBJECT *obj)
         return (0);
     ASN1_OBJECT_free(attr->object);
     attr->object = OBJ_dup(obj);
-    return (1);
+    return attr->object != NULL;
 }
 
 int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -235,7 +235,7 @@ int X509_EXTENSION_set_object(X509_EXTENSION *ex, ASN1_OBJECT *obj)
         return (0);
     ASN1_OBJECT_free(ex->object);
     ex->object = OBJ_dup(obj);
-    return (1);
+    return ex->object != NULL;
 }
 
 int X509_EXTENSION_set_critical(X509_EXTENSION *ex, int crit)


### PR DESCRIPTION
Fix some missing OBJ_dup failure checks.
Merged from
https://boringssl.googlesource.com/boringssl/+/0ce78a757d815c0dde9ed5884229f3a5b2cb3e9c%5E!

---
It's a quick and short change.