### PR TITLE
Use RPMBUILD macros rather than hard coded paths in openssl.spec

### DIFF
--- a/openssl.spec
+++ b/openssl.spec
@@ -1,4 +1,5 @@
 %define _unpackaged_files_terminate_build 0
+%define debug_package %{nil}
 
 Release: 1
 
@@ -80,7 +81,7 @@ documentation and POD files from which the man pages were produced.
 
 %build 
 
-%define CONFIG_FLAGS -DSSL_ALLOW_ADH --prefix=/usr --openssldir=%{openssldir}
+%define CONFIG_FLAGS -DSSL_ALLOW_ADH --prefix=%{_exec_prefix} --openssldir=%{openssldir}
 
 perl util/perlpath.pl /usr/bin/perl
 
@@ -102,7 +103,7 @@ LD_LIBRARY_PATH=`pwd` make test
 
 %install
 rm -rf $RPM_BUILD_ROOT
-make MANDIR=/usr/man MANSUFFIX=ssl INSTALL_PREFIX="$RPM_BUILD_ROOT" install
+make MANDIR=%{_mandir} MANSUFFIX=ssl INSTALL_PREFIX="$RPM_BUILD_ROOT" install
 
 # Make backwards-compatibility symlink to ssleay
 ln -sf /usr/bin/openssl $RPM_BUILD_ROOT/usr/bin/ssleay
@@ -114,10 +115,12 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(0644,root,root,0755)
 %doc CHANGES CHANGES.SSLeay LICENSE NEWS README
 
-%attr(0755,root,root) /usr/bin/*
-%attr(0755,root,root) /usr/lib/*.so*
+%attr(0755,root,root) %{_bindir}/*
+%attr(0755,root,root) %{_libdir}/*.so*
+%attr(0755,root,root) %{_libdir}/engines/*.so*
+%attr(0755,root,root) %{_libdir}/pkgconfig/*
 %attr(0755,root,root) %{openssldir}/misc/*
-%attr(0644,root,root) /usr/man/man[157]/*
+%attr(0644,root,root) %{_mandir}/man[157]/*
 
 %config %attr(0644,root,root) %{openssldir}/openssl.cnf 
 %dir %attr(0755,root,root) %{openssldir}/certs
@@ -128,10 +131,10 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(0644,root,root,0755)
 %doc CHANGES CHANGES.SSLeay LICENSE NEWS README
 
-%attr(0644,root,root) /usr/lib/*.a
-%attr(0644,root,root) /usr/lib/pkgconfig/openssl.pc
-%attr(0644,root,root) /usr/include/openssl/*
-%attr(0644,root,root) /usr/man/man[3]/*
+%attr(0644,root,root) %{_libdir}/*.a
+%attr(0644,root,root) %{_libdir}/pkgconfig/openssl.pc
+%attr(0644,root,root) %{_includedir}/openssl/*
+%attr(0644,root,root) %{_mandir}/man[3]/*
 
 %files doc
 %defattr(0644,root,root,0755)


### PR DESCRIPTION
RT#4522

*note: 1.0.2 only*