### PR TITLE
Travis: update sanitizer configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,16 @@ matrix:
     include:
         - os: linux
           compiler: clang-3.6
-          env: CONFIG_OPTS="-fsanitize=address no-shared"
+          env: CONFIG_OPTS="no-shared enable-asan"
         - os: linux
           compiler: clang-3.6
-          env: CONFIG_OPTS="no-shared no-asm -fno-sanitize-recover -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2 -fno-sanitize=alignment"
+          env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 -fno-sanitize=alignment"
         - os: linux
           compiler: gcc-5
-          env: CONFIG_OPTS="no-shared -fsanitize=address"
+          env: CONFIG_OPTS="no-shared no-asm enable-asan enable-rc5 enable-md2"
         - os: linux
           compiler: gcc-5
-          env: CONFIG_OPTS="no-shared no-asm -fno-sanitize-recover -DPEDANTIC -fsanitize=address -fsanitize=undefined enable-rc5 enable-md2"
+          env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC"
         - os: linux
           compiler: i686-w64-mingw32-gcc
           env: CONFIG_OPTS="no-pic"


### PR DESCRIPTION
- Use the new enable-ubsan and enable-asan configuration options.
- Separate ubsan and asan runs.
- In addition, run shared *san tests to get more coverage. A shared
  asan build can't easily be set up with clang, so we do those runs with
  the gcc flavour, where shared runtime is the default.

(See https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso for
 clang+asan woes when testing shared libraries.)