### PR TITLE
Update Windows build notes

### DIFF
--- a/NOTES.WIN
+++ b/NOTES.WIN
@@ -106,8 +106,8 @@
 
  If you link with static OpenSSL libraries then you're expected to
  additionally link your application with WS2_32.LIB, ADVAPI32.LIB,
- GDI32.LIB and USER32.LIB. Those developing non-interactive service
- applications might feel concerned about linking with the latter two,
+ CRYPT32.LIB, GDI32.LIB and USER32.LIB. Those developing non-interactive
+ service applications might feel concerned about linking with the latter two,
  as they are justly associated with interactive desktop, which is not
  available to service processes. The toolkit is designed to detect in
  which context it's currently executed, GUI, console app or service,


### PR DESCRIPTION
Just adding CRYPT32.LIB as a required lib when linking statically on Windows (new requirement since OpenSSL 1.1).

This resolves #1061.