### PR TITLE
Fix build on illumos with gcc 5.3

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -58,7 +58,7 @@
 #include "e_os.h"
 
 /* We need to define this to get macros like S_IFBLK and S_IFCHR */
-#if !defined(OPENSSL_SYS_VXWORKS)
+#if !defined(OPENSSL_SYS_VXWORKS) && !defined(__sun__)
 # define _XOPEN_SOURCE 500
 #endif
 


### PR DESCRIPTION
gcc 5.3 defines STDC_VERSION to 201112L (c99), together with _XOPEN_SOURCE 500 this leads to compilation error in feature-tests.h ("Compiler or options invalid for pre-UNIX 03 X/Open applications and pre-2001 POSIX applications").