### PR TITLE
Fix: openssl req command reports incorrect EC key size

### DIFF
--- a/Configurations/90-team.conf
+++ b/Configurations/90-team.conf
@@ -14,6 +14,14 @@
         thread_scheme    => "(unknown)",
         ex_libs          => add(" ","-lefence"),
     },
+    "debug-linux-x86_64" => {
+        inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
+        cflags           => add("-DBN_DEBUG -DREF_DEBUG -DCONF_DEBUG -m64 -DL_ENDIAN -g -Wall -Werror"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "elf",
+        shared_ldflag    => "-m64",
+        multilib         => "64",
+    },
     "debug-erbridge" => {
         inherit_from     => [ "x86_64_asm" ],
         cc               => "gcc",

--- a/Configurations/90-team.conf
+++ b/Configurations/90-team.conf
@@ -14,14 +14,6 @@
         thread_scheme    => "(unknown)",
         ex_libs          => add(" ","-lefence"),
     },
-    "debug-linux-x86_64" => {
-        inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
-        cflags           => add("-DBN_DEBUG -DREF_DEBUG -DCONF_DEBUG -m64 -DL_ENDIAN -g -Wall -Werror"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        perlasm_scheme   => "elf",
-        shared_ldflag    => "-m64",
-        multilib         => "64",
-    },
     "debug-erbridge" => {
         inherit_from     => [ "x86_64_asm" ],
         cc               => "gcc",

--- a/apps/req.c
+++ b/apps/req.c
@@ -545,7 +545,16 @@ int req_main(int argc, char **argv)
                     goto end;
                 }
             }
+
+#ifndef OPENSSL_NO_EC
+            if (pkey_type == EVP_PKEY_EC
+                    && EVP_PKEY_CTX_get_ec_keygen_bits(genctx, &newkey) <= 0) {
+                BIO_printf(bio_err, "Error setting EC keysize\n");
+                ERR_print_errors(bio_err);
+                goto end;
+			}
         }
+#endif
 
         BIO_printf(bio_err, "Generating a %ld bit %s private key\n",
                    newkey, keyalgstr);

--- a/apps/req.c
+++ b/apps/req.c
@@ -553,8 +553,8 @@ int req_main(int argc, char **argv)
                 ERR_print_errors(bio_err);
                 goto end;
 			}
-        }
 #endif
+        }
 
         BIO_printf(bio_err, "Generating a %ld bit %s private key\n",
                    newkey, keyalgstr);

--- a/apps/req.c
+++ b/apps/req.c
@@ -552,7 +552,7 @@ int req_main(int argc, char **argv)
                 BIO_printf(bio_err, "Error getting EC key generator key size\n");
                 ERR_print_errors(bio_err);
                 goto end;
-			}
+            }
 #endif
         }
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -549,7 +549,7 @@ int req_main(int argc, char **argv)
 #ifndef OPENSSL_NO_EC
             if (pkey_type == EVP_PKEY_EC
                     && EVP_PKEY_CTX_get_ec_keygen_bits(genctx, &newkey) <= 0) {
-                BIO_printf(bio_err, "Error setting EC keysize\n");
+                BIO_printf(bio_err, "Error getting EC key generator key size\n");
                 ERR_print_errors(bio_err);
                 goto end;
 			}

--- a/crypto/ec/ec_pmeth.c
+++ b/crypto/ec/ec_pmeth.c
@@ -320,6 +320,15 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             dctx->co_key = NULL;
         }
         return 1;
+
+    case EVP_PKEY_CTRL_GET_EC_KEYGEN_BITS:
+        if (!dctx->gen_group) {
+            ECerr(EC_F_PKEY_EC_CTRL, EC_R_NO_PARAMETERS_SET);
+            return 0;
+        }
+        *((int*)p2) = EC_GROUP_order_bits(dctx->gen_group);
+        return 1;
+
 #endif
 
     case EVP_PKEY_CTRL_EC_KDF_TYPE:

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1385,6 +1385,11 @@ void EC_KEY_METHOD_get_verify(EC_KEY_METHOD *meth,
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_GET_EC_KDF_UKM, 0, (void *)p)
 
+# define EVP_PKEY_CTX_get_ec_keygen_bits(ctx, bits) \
+        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
+                                EVP_PKEY_OP_KEYGEN, \
+                                EVP_PKEY_CTRL_GET_EC_KEYGEN_BITS, 0, bits)
+
 # define EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID             (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_EC_PARAM_ENC                      (EVP_PKEY_ALG_CTRL + 2)
 # define EVP_PKEY_CTRL_EC_ECDH_COFACTOR                  (EVP_PKEY_ALG_CTRL + 3)
@@ -1395,6 +1400,7 @@ void EC_KEY_METHOD_get_verify(EC_KEY_METHOD *meth,
 # define EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN                 (EVP_PKEY_ALG_CTRL + 8)
 # define EVP_PKEY_CTRL_EC_KDF_UKM                        (EVP_PKEY_ALG_CTRL + 9)
 # define EVP_PKEY_CTRL_GET_EC_KDF_UKM                    (EVP_PKEY_ALG_CTRL + 10)
+# define EVP_PKEY_CTRL_GET_EC_KEYGEN_BITS                (EVP_PKEY_ALG_CTRL + 11)
 /* KDF types */
 # define EVP_PKEY_ECDH_KDF_NONE                          1
 # define EVP_PKEY_ECDH_KDF_X9_62                         2


### PR DESCRIPTION
An email bug report to rt@openssl.org describing this pull request will follow shortly after submission.