### PR TITLE
Remove sessions from external cache, even if internal cache is not used

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -815,6 +815,9 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck)
             if (ctx->remove_session_cb != NULL)
                 ctx->remove_session_cb(ctx, r);
             SSL_SESSION_free(r);
+        } else {
+            if (ctx->remove_session_cb != NULL)
+                ctx->remove_session_cb(ctx, c);
         }
     } else
         ret = 0;


### PR DESCRIPTION
Section 7.2 of RFC5246 requires sessions to be invalidated after a fatal
alert.  OpenSSL calls SSL_CTX_remove_session() after a fatal alert to
invalidate the session.  SSL_CTX_remove_session() calls
remove_session_lock().

Prior to this commit, remove_session_lock() would only remove a session
from the external session cache if the session was found in the internal
session cache.  Therefore, when using an external session cache with the
SSL_SESS_CACHE_NO_INTERNAL_STORE cache modifier, sessions would not be
invalidated after fatal alerts.

This commit ensures that sessions are removed from the external cache
even if they are not present in the internal cache.