### PR TITLE
const correctness: make HMAC_size() take a const *

### DIFF
--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -164,7 +164,7 @@ int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len)
     return 0;
 }
 
-size_t HMAC_size(HMAC_CTX *ctx)
+size_t HMAC_size(const HMAC_CTX *ctx)
 {
     return EVP_MD_size((ctx)->md);
 }

--- a/include/openssl/hmac.h
+++ b/include/openssl/hmac.h
@@ -67,7 +67,7 @@
 extern "C" {
 #endif
 
-size_t HMAC_size(HMAC_CTX *e);
+size_t HMAC_size(const HMAC_CTX *e);
 HMAC_CTX *HMAC_CTX_new(void);
 int HMAC_CTX_reset(HMAC_CTX *ctx);
 void HMAC_CTX_free(HMAC_CTX *ctx);


### PR DESCRIPTION
This function can take a const *, so it should.

Ran into this when building OpenVPN against the master branch, and the
compiler complained about discarding the const qualifier.

(I hope this is trivial enough to not do the CLA dance).

Signed-off-by: Steffan Karger <steffan@karger.me>