### PR TITLE
Small MSVC build fixes

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1267,7 +1267,7 @@ sub vms_info {
                                        release =>
                                        sub {
                                            ($disabled{shared} ? "" : "/MD")
-                                               ." /Ox /O2 /Ob2";
+                                               ." /O2";
                                        })),
         lib_cflags       => add(sub { $disabled{shared} ? "/MT /Zl" : () }),
         # Following might/should appears controversial, i.e. defining

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -168,7 +168,7 @@ uninstall: uninstall_docs uninstall_sw
 libclean:
 	$(PERL) -e "map { m/(.*)\.dll$$/; unlink glob """$$1.*"""; } @ARGV" $(SHLIBS)
 	-del /Q /F $(LIBS)
-	-del ossl_static.pdb
+	-del /Q ossl_static.pdb
 
 clean: libclean
 	-del /Q /F $(PROGRAMS) $(TESTPROGS) $(ENGINES) $(SCRIPTS)
@@ -195,6 +195,8 @@ uninstall_docs:
 install_ssldirs:
 	@$(PERL) $(SRCDIR)\util\mkdir-p.pl "$(DESTDIR)$(OPENSSLDIR)\certs"
 	@$(PERL) $(SRCDIR)\util\mkdir-p.pl "$(DESTDIR)$(OPENSSLDIR)\private"
+	@$(PERL) $(SRCDIR)\util\copy.pl $(SRCDIR)\apps\openssl.cnf \
+                                       "$(DESTDIR)$(OPENSSLDIR)"
 
 install_dev:
 	@if "$(INSTALLTOP)"=="" ( echo INSTALLTOP should not be empty & exit 1 )
@@ -390,8 +392,8 @@ $target: $deps $ordinalsfile $mkdef_pl
 		/implib:\$@ \$(LDOUTFLAG)$shlib$shlibext /def:$shlib.def @<< || (DEL /Q \$(\@B).* $shlib.* && EXIT 1)
 $objs $shlib.res$linklibs \$(EX_LIBS)
 <<
-	DEL /F apps\\$shlib$shlibext
-	DEL /F test\\$shlib$shlibext
+	DEL /Q /F apps\\$shlib$shlibext
+	DEL /Q /F test\\$shlib$shlibext
 	COPY $shlib$shlibext apps
 	COPY $shlib$shlibext test
 EOF


### PR DESCRIPTION
- "/Ox /O2 /Ob2" get's reduced to "/O2", the reason being:
  
  /Ox = /Ob2 /Og /Oi /Ot /Oy /Gs
  /O2 = /Ob2 /Og /Oi /Ot /Oy /Gs /GF /Gy
- apps/openssl.cnf gets installed.
