### PR TITLE
do not remove links found in .git directory

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -259,7 +259,7 @@ clean: libclean
 	rm -f core
 	rm -f tags TAGS
 	rm -f openssl.pc libcrypto.pc libssl.pc
-	-rm -f `find . -type l`
+	-rm -f `find . -type l -a \! -path "./.git/*"`
 	rm -f $(TARFILE)
 
 # This exists solely for those who still type 'make depend'


### PR DESCRIPTION
Some setups use links inside .git directory and make clean should not
remove them to avoid breaking git meta-information.

Signed-off-by: Cristian Stoica <cristian.stoica@nxp.com>