### PR TITLE
Use AES256 for the default encryption algorithm for TLS session tickets.

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3819,20 +3819,33 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_TLSEXT_TICKET_KEYS:
         {
             unsigned char *keys = parg;
+            long tlsext_tick_keylen = (sizeof(ctx->tlsext_tick_key_name) +
+                sizeof(ctx->tlsext_tick_hmac_key) +
+                sizeof(ctx->tlsext_tick_aes_key));
             if (!keys)
-                return 48;
-            if (larg != 48) {
+                return tlsext_tick_keylen;
+            if (larg != tlsext_tick_keylen) {
                 SSLerr(SSL_F_SSL3_CTX_CTRL, SSL_R_INVALID_TICKET_KEYS_LENGTH);
                 return 0;
             }
             if (cmd == SSL_CTRL_SET_TLSEXT_TICKET_KEYS) {
-                memcpy(ctx->tlsext_tick_key_name, keys, 16);
-                memcpy(ctx->tlsext_tick_hmac_key, keys + 16, 16);
-                memcpy(ctx->tlsext_tick_aes_key, keys + 32, 16);
+                memcpy(ctx->tlsext_tick_key_name, keys,
+                       sizeof(ctx->tlsext_tick_key_name));
+                memcpy(ctx->tlsext_tick_hmac_key,
+                       keys + sizeof(ctx->tlsext_tick_key_name),
+                       sizeof(ctx->tlsext_tick_hmac_key));
+                memcpy(ctx->tlsext_tick_aes_key,
+                       keys + sizeof(ctx->tlsext_tick_key_name) + sizeof(ctx->tlsext_tick_hmac_key),
+                       sizeof(ctx->tlsext_tick_aes_key));
             } else {
-                memcpy(keys, ctx->tlsext_tick_key_name, 16);
-                memcpy(keys + 16, ctx->tlsext_tick_hmac_key, 16);
-                memcpy(keys + 32, ctx->tlsext_tick_aes_key, 16);
+                memcpy(keys, ctx->tlsext_tick_key_name,
+                       sizeof(ctx->tlsext_tick_key_name));
+                memcpy(keys + sizeof(ctx->tlsext_tick_key_name),
+                       ctx->tlsext_tick_hmac_key,
+                       sizeof(ctx->tlsext_tick_hmac_key));
+                memcpy(keys + sizeof(ctx->tlsext_tick_key_name) + sizeof(ctx->tlsext_tick_hmac_key),
+                       ctx->tlsext_tick_aes_key,
+                       sizeof(ctx->tlsext_tick_aes_key));
             }
             return 1;
         }

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -3429,13 +3429,15 @@ int ssl3_send_newsession_ticket(SSL *s)
         } else {
             if (RAND_bytes(iv, 16) <= 0)
                 goto err;
-            if (!EVP_EncryptInit_ex(&ctx, EVP_aes_128_cbc(), NULL,
+            if (!EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL,
                                     tctx->tlsext_tick_aes_key, iv))
                 goto err;
-            if (!HMAC_Init_ex(&hctx, tctx->tlsext_tick_hmac_key, 16,
+            if (!HMAC_Init_ex(&hctx, tctx->tlsext_tick_hmac_key,
+                              sizeof(tctx->tlsext_tick_hmac_key),
                               tlsext_tick_md(), NULL))
                 goto err;
-            memcpy(key_name, tctx->tlsext_tick_key_name, 16);
+            memcpy(key_name, tctx->tlsext_tick_key_name,
+                   sizeof(tctx->tlsext_tick_key_name));
         }
 
         /*

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -1077,8 +1077,8 @@ struct ssl_ctx_st {
     void *tlsext_servername_arg;
     /* RFC 4507 session ticket keys */
     unsigned char tlsext_tick_key_name[16];
-    unsigned char tlsext_tick_hmac_key[16];
-    unsigned char tlsext_tick_aes_key[16];
+    unsigned char tlsext_tick_hmac_key[32];
+    unsigned char tlsext_tick_aes_key[32];
     /* Callback to support customisation of ticket key setting */
     int (*tlsext_ticket_key_cb) (SSL *ssl,
                                  unsigned char *name, unsigned char *iv,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2000,9 +2000,9 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
     ret->tlsext_servername_callback = 0;
     ret->tlsext_servername_arg = NULL;
     /* Setup RFC4507 ticket keys */
-    if ((RAND_pseudo_bytes(ret->tlsext_tick_key_name, 16) <= 0)
-        || (RAND_bytes(ret->tlsext_tick_hmac_key, 16) <= 0)
-        || (RAND_bytes(ret->tlsext_tick_aes_key, 16) <= 0))
+    if ((RAND_pseudo_bytes(ret->tlsext_tick_key_name, sizeof(ret->tlsext_tick_key_name)) <= 0)
+        || (RAND_bytes(ret->tlsext_tick_hmac_key, sizeof(ret->tlsext_tick_hmac_key)) <= 0)
+        || (RAND_bytes(ret->tlsext_tick_aes_key, sizeof(ret->tlsext_tick_aes_key)) <= 0))
         ret->options |= SSL_OP_NO_TICKET;
 
     ret->tlsext_status_cb = 0;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3415,13 +3415,15 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
             renew_ticket = 1;
     } else {
         /* Check key name matches */
-        if (memcmp(etick, tctx->tlsext_tick_key_name, 16))
+        if (memcmp(etick, tctx->tlsext_tick_key_name,
+                   sizeof(tctx->tlsext_tick_key_name)) != 0)
             return 2;
-        if (HMAC_Init_ex(&hctx, tctx->tlsext_tick_hmac_key, 16,
+        if (HMAC_Init_ex(&hctx, tctx->tlsext_tick_hmac_key,
+                         sizeof(tctx->tlsext_tick_hmac_key),
                          tlsext_tick_md(), NULL) <= 0
-                || EVP_DecryptInit_ex(&ctx, EVP_aes_128_cbc(), NULL,
+                || EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL,
                                       tctx->tlsext_tick_aes_key,
-                                      etick + 16) <= 0) {
+                                      etick + sizeof(tctx->tlsext_tick_key_name)) <= 0) {
             goto err;
        }
     }


### PR DESCRIPTION
rather than AES128.

Addresses Issue #514; backported to the 1.0.2 branch.