### PR TITLE
Fix session ticket and SNI (master)

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1502,6 +1502,9 @@ unsigned char *ssl_add_serverhello_tlsext(SSL *s, unsigned char *buf,
             return NULL;
         s2n(TLSEXT_TYPE_session_ticket, ret);
         s2n(0, ret);
+    } else {
+        /* if we don't add the above TLSEXT, we can't add a session ticket later */
+        s->tlsext_ticket_expected = 0;
     }
 
     if (s->tlsext_status_expected) {

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -64,6 +64,16 @@ The test section supports the following options:
   - AcceptAll - accepts all certificates.
   - RejectAll - rejects all certificates.
 
+* ServerName - the server the client is expected to successfully connect to
+  - server1 - the initial context (default)
+  - server2 - the secondary context
+
+* SessionTicketExpected - whether or not a session ticket is expected
+  - Ignore - do not check for a session ticket (default)
+  - Yes - a session ticket is expected
+  - No - a session ticket is not expected
+  - Broken - a special test case where the session ticket callback does not initialize crypto
+
 ## Configuring the client and server
 
 The client and server configurations can be any valid `SSL_CTX`
@@ -77,6 +87,10 @@ server => {
     "MinProtocol" => "TLSv1",
 }
 ```
+
+A server2 section may optionally be defined to configure a secondary
+context that is selected via the ServerName test option. If the server2
+section is not configured, then the configuration matches server.
 
 ### Default server and client configurations
 

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -43,6 +43,12 @@ sub print_templates {
     # Add the implicit base configuration.
     foreach my $test (@ssltests::tests) {
         $test->{"server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
+	# use server values if server2 is not defined
+	if (defined $test->{"server2"}) {
+	    $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server2"}}) };
+	} else {
+	    $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server"}}) };
+	}
         $test->{"client"} = { (%ssltests::base_client, %{$test->{"client"}}) };
     }
 

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -26,10 +26,19 @@ typedef struct handshake_result {
     /* Negotiated protocol. On success, these should always match. */
     int server_protocol;
     int client_protocol;
+    /* Server connection */
+    int servername;
+    /* Session ticket status */
+    int session_ticket;
+    /* Was this called on the second context? */
+    int session_ticket_do_not_call;
 } HANDSHAKE_RESULT;
 
 /* Do a handshake and report some information about the result. */
 HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx,
                               const SSL_TEST_CTX *test_ctx);
+
+int do_not_call_session_ticket_callback(SSL* s, unsigned char* key_name, unsigned char *iv,
+                                        EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc);
 
 #endif  /* HEADER_HANDSHAKE_HELPER_H */

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -42,7 +42,7 @@ foreach my $conf (@conf_files) {
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 4;  # = scalar @conf_srcs
+plan tests => 6;  # = scalar @conf_srcs
 
 sub test_conf {
     plan tests => 3;

--- a/test/ssl-tests/01-simple.conf
+++ b/test/ssl-tests/01-simple.conf
@@ -11,9 +11,16 @@ ssl_conf = 0-default-ssl
 
 [0-default-ssl]
 server = 0-default-server
+server2 = 0-default-server2
 client = 0-default-client
 
 [0-default-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-default-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -36,9 +43,16 @@ ssl_conf = 1-verify-cert-ssl
 
 [1-verify-cert-ssl]
 server = 1-verify-cert-server
+server2 = 1-verify-cert-server2
 client = 1-verify-cert-client
 
 [1-verify-cert-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-verify-cert-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem

--- a/test/ssl-tests/02-protocol-version.conf
+++ b/test/ssl-tests/02-protocol-version.conf
@@ -370,9 +370,17 @@ ssl_conf = 0-version-negotiation-ssl
 
 [0-version-negotiation-ssl]
 server = 0-version-negotiation-server
+server2 = 0-version-negotiation-server2
 client = 0-version-negotiation-client
 
 [0-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -397,9 +405,17 @@ ssl_conf = 1-version-negotiation-ssl
 
 [1-version-negotiation-ssl]
 server = 1-version-negotiation-server
+server2 = 1-version-negotiation-server2
 client = 1-version-negotiation-client
 
 [1-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -424,9 +440,17 @@ ssl_conf = 2-version-negotiation-ssl
 
 [2-version-negotiation-ssl]
 server = 2-version-negotiation-server
+server2 = 2-version-negotiation-server2
 client = 2-version-negotiation-client
 
 [2-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[2-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -451,9 +475,17 @@ ssl_conf = 3-version-negotiation-ssl
 
 [3-version-negotiation-ssl]
 server = 3-version-negotiation-server
+server2 = 3-version-negotiation-server2
 client = 3-version-negotiation-client
 
 [3-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[3-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -478,9 +510,16 @@ ssl_conf = 4-version-negotiation-ssl
 
 [4-version-negotiation-ssl]
 server = 4-version-negotiation-server
+server2 = 4-version-negotiation-server2
 client = 4-version-negotiation-client
 
 [4-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[4-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -504,9 +543,18 @@ ssl_conf = 5-version-negotiation-ssl
 
 [5-version-negotiation-ssl]
 server = 5-version-negotiation-server
+server2 = 5-version-negotiation-server2
 client = 5-version-negotiation-client
 
 [5-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[5-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -532,9 +580,18 @@ ssl_conf = 6-version-negotiation-ssl
 
 [6-version-negotiation-ssl]
 server = 6-version-negotiation-server
+server2 = 6-version-negotiation-server2
 client = 6-version-negotiation-client
 
 [6-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[6-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -560,9 +617,18 @@ ssl_conf = 7-version-negotiation-ssl
 
 [7-version-negotiation-ssl]
 server = 7-version-negotiation-server
+server2 = 7-version-negotiation-server2
 client = 7-version-negotiation-client
 
 [7-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[7-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -588,9 +654,18 @@ ssl_conf = 8-version-negotiation-ssl
 
 [8-version-negotiation-ssl]
 server = 8-version-negotiation-server
+server2 = 8-version-negotiation-server2
 client = 8-version-negotiation-client
 
 [8-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[8-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -616,9 +691,17 @@ ssl_conf = 9-version-negotiation-ssl
 
 [9-version-negotiation-ssl]
 server = 9-version-negotiation-server
+server2 = 9-version-negotiation-server2
 client = 9-version-negotiation-client
 
 [9-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[9-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -643,9 +726,18 @@ ssl_conf = 10-version-negotiation-ssl
 
 [10-version-negotiation-ssl]
 server = 10-version-negotiation-server
+server2 = 10-version-negotiation-server2
 client = 10-version-negotiation-client
 
 [10-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[10-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -671,9 +763,18 @@ ssl_conf = 11-version-negotiation-ssl
 
 [11-version-negotiation-ssl]
 server = 11-version-negotiation-server
+server2 = 11-version-negotiation-server2
 client = 11-version-negotiation-client
 
 [11-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[11-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -699,9 +800,18 @@ ssl_conf = 12-version-negotiation-ssl
 
 [12-version-negotiation-ssl]
 server = 12-version-negotiation-server
+server2 = 12-version-negotiation-server2
 client = 12-version-negotiation-client
 
 [12-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[12-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -727,9 +837,17 @@ ssl_conf = 13-version-negotiation-ssl
 
 [13-version-negotiation-ssl]
 server = 13-version-negotiation-server
+server2 = 13-version-negotiation-server2
 client = 13-version-negotiation-client
 
 [13-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[13-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -754,9 +872,18 @@ ssl_conf = 14-version-negotiation-ssl
 
 [14-version-negotiation-ssl]
 server = 14-version-negotiation-server
+server2 = 14-version-negotiation-server2
 client = 14-version-negotiation-client
 
 [14-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[14-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -782,9 +909,18 @@ ssl_conf = 15-version-negotiation-ssl
 
 [15-version-negotiation-ssl]
 server = 15-version-negotiation-server
+server2 = 15-version-negotiation-server2
 client = 15-version-negotiation-client
 
 [15-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[15-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -810,9 +946,17 @@ ssl_conf = 16-version-negotiation-ssl
 
 [16-version-negotiation-ssl]
 server = 16-version-negotiation-server
+server2 = 16-version-negotiation-server2
 client = 16-version-negotiation-client
 
 [16-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[16-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -837,9 +981,18 @@ ssl_conf = 17-version-negotiation-ssl
 
 [17-version-negotiation-ssl]
 server = 17-version-negotiation-server
+server2 = 17-version-negotiation-server2
 client = 17-version-negotiation-client
 
 [17-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[17-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -865,9 +1018,17 @@ ssl_conf = 18-version-negotiation-ssl
 
 [18-version-negotiation-ssl]
 server = 18-version-negotiation-server
+server2 = 18-version-negotiation-server2
 client = 18-version-negotiation-client
 
 [18-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[18-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -892,9 +1053,17 @@ ssl_conf = 19-version-negotiation-ssl
 
 [19-version-negotiation-ssl]
 server = 19-version-negotiation-server
+server2 = 19-version-negotiation-server2
 client = 19-version-negotiation-client
 
 [19-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[19-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -919,9 +1088,17 @@ ssl_conf = 20-version-negotiation-ssl
 
 [20-version-negotiation-ssl]
 server = 20-version-negotiation-server
+server2 = 20-version-negotiation-server2
 client = 20-version-negotiation-client
 
 [20-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[20-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -947,9 +1124,17 @@ ssl_conf = 21-version-negotiation-ssl
 
 [21-version-negotiation-ssl]
 server = 21-version-negotiation-server
+server2 = 21-version-negotiation-server2
 client = 21-version-negotiation-client
 
 [21-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[21-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -975,9 +1160,17 @@ ssl_conf = 22-version-negotiation-ssl
 
 [22-version-negotiation-ssl]
 server = 22-version-negotiation-server
+server2 = 22-version-negotiation-server2
 client = 22-version-negotiation-client
 
 [22-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[22-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1003,9 +1196,16 @@ ssl_conf = 23-version-negotiation-ssl
 
 [23-version-negotiation-ssl]
 server = 23-version-negotiation-server
+server2 = 23-version-negotiation-server2
 client = 23-version-negotiation-client
 
 [23-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[23-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -1030,9 +1230,18 @@ ssl_conf = 24-version-negotiation-ssl
 
 [24-version-negotiation-ssl]
 server = 24-version-negotiation-server
+server2 = 24-version-negotiation-server2
 client = 24-version-negotiation-client
 
 [24-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[24-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -1058,9 +1267,18 @@ ssl_conf = 25-version-negotiation-ssl
 
 [25-version-negotiation-ssl]
 server = 25-version-negotiation-server
+server2 = 25-version-negotiation-server2
 client = 25-version-negotiation-client
 
 [25-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[25-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -1087,9 +1305,18 @@ ssl_conf = 26-version-negotiation-ssl
 
 [26-version-negotiation-ssl]
 server = 26-version-negotiation-server
+server2 = 26-version-negotiation-server2
 client = 26-version-negotiation-client
 
 [26-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[26-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1116,9 +1343,18 @@ ssl_conf = 27-version-negotiation-ssl
 
 [27-version-negotiation-ssl]
 server = 27-version-negotiation-server
+server2 = 27-version-negotiation-server2
 client = 27-version-negotiation-client
 
 [27-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[27-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1145,9 +1381,17 @@ ssl_conf = 28-version-negotiation-ssl
 
 [28-version-negotiation-ssl]
 server = 28-version-negotiation-server
+server2 = 28-version-negotiation-server2
 client = 28-version-negotiation-client
 
 [28-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[28-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -1173,9 +1417,18 @@ ssl_conf = 29-version-negotiation-ssl
 
 [29-version-negotiation-ssl]
 server = 29-version-negotiation-server
+server2 = 29-version-negotiation-server2
 client = 29-version-negotiation-client
 
 [29-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[29-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -1202,9 +1455,18 @@ ssl_conf = 30-version-negotiation-ssl
 
 [30-version-negotiation-ssl]
 server = 30-version-negotiation-server
+server2 = 30-version-negotiation-server2
 client = 30-version-negotiation-client
 
 [30-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[30-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1231,9 +1493,18 @@ ssl_conf = 31-version-negotiation-ssl
 
 [31-version-negotiation-ssl]
 server = 31-version-negotiation-server
+server2 = 31-version-negotiation-server2
 client = 31-version-negotiation-client
 
 [31-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[31-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1260,9 +1531,17 @@ ssl_conf = 32-version-negotiation-ssl
 
 [32-version-negotiation-ssl]
 server = 32-version-negotiation-server
+server2 = 32-version-negotiation-server2
 client = 32-version-negotiation-client
 
 [32-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[32-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -1288,9 +1567,18 @@ ssl_conf = 33-version-negotiation-ssl
 
 [33-version-negotiation-ssl]
 server = 33-version-negotiation-server
+server2 = 33-version-negotiation-server2
 client = 33-version-negotiation-client
 
 [33-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[33-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1316,9 +1604,18 @@ ssl_conf = 34-version-negotiation-ssl
 
 [34-version-negotiation-ssl]
 server = 34-version-negotiation-server
+server2 = 34-version-negotiation-server2
 client = 34-version-negotiation-client
 
 [34-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[34-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1344,9 +1641,17 @@ ssl_conf = 35-version-negotiation-ssl
 
 [35-version-negotiation-ssl]
 server = 35-version-negotiation-server
+server2 = 35-version-negotiation-server2
 client = 35-version-negotiation-client
 
 [35-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[35-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -1371,9 +1676,18 @@ ssl_conf = 36-version-negotiation-ssl
 
 [36-version-negotiation-ssl]
 server = 36-version-negotiation-server
+server2 = 36-version-negotiation-server2
 client = 36-version-negotiation-client
 
 [36-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[36-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1399,9 +1713,17 @@ ssl_conf = 37-version-negotiation-ssl
 
 [37-version-negotiation-ssl]
 server = 37-version-negotiation-server
+server2 = 37-version-negotiation-server2
 client = 37-version-negotiation-client
 
 [37-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[37-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -1426,9 +1748,17 @@ ssl_conf = 38-version-negotiation-ssl
 
 [38-version-negotiation-ssl]
 server = 38-version-negotiation-server
+server2 = 38-version-negotiation-server2
 client = 38-version-negotiation-client
 
 [38-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[38-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -1453,9 +1783,17 @@ ssl_conf = 39-version-negotiation-ssl
 
 [39-version-negotiation-ssl]
 server = 39-version-negotiation-server
+server2 = 39-version-negotiation-server2
 client = 39-version-negotiation-client
 
 [39-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[39-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -1481,9 +1819,17 @@ ssl_conf = 40-version-negotiation-ssl
 
 [40-version-negotiation-ssl]
 server = 40-version-negotiation-server
+server2 = 40-version-negotiation-server2
 client = 40-version-negotiation-client
 
 [40-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[40-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1509,9 +1855,17 @@ ssl_conf = 41-version-negotiation-ssl
 
 [41-version-negotiation-ssl]
 server = 41-version-negotiation-server
+server2 = 41-version-negotiation-server2
 client = 41-version-negotiation-client
 
 [41-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[41-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1537,9 +1891,16 @@ ssl_conf = 42-version-negotiation-ssl
 
 [42-version-negotiation-ssl]
 server = 42-version-negotiation-server
+server2 = 42-version-negotiation-server2
 client = 42-version-negotiation-client
 
 [42-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[42-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -1564,9 +1925,18 @@ ssl_conf = 43-version-negotiation-ssl
 
 [43-version-negotiation-ssl]
 server = 43-version-negotiation-server
+server2 = 43-version-negotiation-server2
 client = 43-version-negotiation-client
 
 [43-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[43-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -1592,9 +1962,18 @@ ssl_conf = 44-version-negotiation-ssl
 
 [44-version-negotiation-ssl]
 server = 44-version-negotiation-server
+server2 = 44-version-negotiation-server2
 client = 44-version-negotiation-client
 
 [44-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[44-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -1621,9 +2000,18 @@ ssl_conf = 45-version-negotiation-ssl
 
 [45-version-negotiation-ssl]
 server = 45-version-negotiation-server
+server2 = 45-version-negotiation-server2
 client = 45-version-negotiation-client
 
 [45-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[45-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1650,9 +2038,18 @@ ssl_conf = 46-version-negotiation-ssl
 
 [46-version-negotiation-ssl]
 server = 46-version-negotiation-server
+server2 = 46-version-negotiation-server2
 client = 46-version-negotiation-client
 
 [46-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[46-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1679,9 +2076,17 @@ ssl_conf = 47-version-negotiation-ssl
 
 [47-version-negotiation-ssl]
 server = 47-version-negotiation-server
+server2 = 47-version-negotiation-server2
 client = 47-version-negotiation-client
 
 [47-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[47-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -1707,9 +2112,18 @@ ssl_conf = 48-version-negotiation-ssl
 
 [48-version-negotiation-ssl]
 server = 48-version-negotiation-server
+server2 = 48-version-negotiation-server2
 client = 48-version-negotiation-client
 
 [48-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[48-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -1736,9 +2150,18 @@ ssl_conf = 49-version-negotiation-ssl
 
 [49-version-negotiation-ssl]
 server = 49-version-negotiation-server
+server2 = 49-version-negotiation-server2
 client = 49-version-negotiation-client
 
 [49-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[49-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1765,9 +2188,18 @@ ssl_conf = 50-version-negotiation-ssl
 
 [50-version-negotiation-ssl]
 server = 50-version-negotiation-server
+server2 = 50-version-negotiation-server2
 client = 50-version-negotiation-client
 
 [50-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[50-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1794,9 +2226,17 @@ ssl_conf = 51-version-negotiation-ssl
 
 [51-version-negotiation-ssl]
 server = 51-version-negotiation-server
+server2 = 51-version-negotiation-server2
 client = 51-version-negotiation-client
 
 [51-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[51-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -1822,9 +2262,18 @@ ssl_conf = 52-version-negotiation-ssl
 
 [52-version-negotiation-ssl]
 server = 52-version-negotiation-server
+server2 = 52-version-negotiation-server2
 client = 52-version-negotiation-client
 
 [52-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[52-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -1851,9 +2300,18 @@ ssl_conf = 53-version-negotiation-ssl
 
 [53-version-negotiation-ssl]
 server = 53-version-negotiation-server
+server2 = 53-version-negotiation-server2
 client = 53-version-negotiation-client
 
 [53-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[53-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1880,9 +2338,17 @@ ssl_conf = 54-version-negotiation-ssl
 
 [54-version-negotiation-ssl]
 server = 54-version-negotiation-server
+server2 = 54-version-negotiation-server2
 client = 54-version-negotiation-client
 
 [54-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[54-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -1908,9 +2374,18 @@ ssl_conf = 55-version-negotiation-ssl
 
 [55-version-negotiation-ssl]
 server = 55-version-negotiation-server
+server2 = 55-version-negotiation-server2
 client = 55-version-negotiation-client
 
 [55-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[55-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -1936,9 +2411,17 @@ ssl_conf = 56-version-negotiation-ssl
 
 [56-version-negotiation-ssl]
 server = 56-version-negotiation-server
+server2 = 56-version-negotiation-server2
 client = 56-version-negotiation-client
 
 [56-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[56-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -1963,9 +2446,17 @@ ssl_conf = 57-version-negotiation-ssl
 
 [57-version-negotiation-ssl]
 server = 57-version-negotiation-server
+server2 = 57-version-negotiation-server2
 client = 57-version-negotiation-client
 
 [57-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[57-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -1990,9 +2481,17 @@ ssl_conf = 58-version-negotiation-ssl
 
 [58-version-negotiation-ssl]
 server = 58-version-negotiation-server
+server2 = 58-version-negotiation-server2
 client = 58-version-negotiation-client
 
 [58-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[58-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -2018,9 +2517,17 @@ ssl_conf = 59-version-negotiation-ssl
 
 [59-version-negotiation-ssl]
 server = 59-version-negotiation-server
+server2 = 59-version-negotiation-server2
 client = 59-version-negotiation-client
 
 [59-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[59-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2046,9 +2553,17 @@ ssl_conf = 60-version-negotiation-ssl
 
 [60-version-negotiation-ssl]
 server = 60-version-negotiation-server
+server2 = 60-version-negotiation-server2
 client = 60-version-negotiation-client
 
 [60-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[60-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2074,9 +2589,16 @@ ssl_conf = 61-version-negotiation-ssl
 
 [61-version-negotiation-ssl]
 server = 61-version-negotiation-server
+server2 = 61-version-negotiation-server2
 client = 61-version-negotiation-client
 
 [61-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[61-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -2101,9 +2623,18 @@ ssl_conf = 62-version-negotiation-ssl
 
 [62-version-negotiation-ssl]
 server = 62-version-negotiation-server
+server2 = 62-version-negotiation-server2
 client = 62-version-negotiation-client
 
 [62-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[62-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -2129,9 +2660,18 @@ ssl_conf = 63-version-negotiation-ssl
 
 [63-version-negotiation-ssl]
 server = 63-version-negotiation-server
+server2 = 63-version-negotiation-server2
 client = 63-version-negotiation-client
 
 [63-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[63-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -2158,9 +2698,18 @@ ssl_conf = 64-version-negotiation-ssl
 
 [64-version-negotiation-ssl]
 server = 64-version-negotiation-server
+server2 = 64-version-negotiation-server2
 client = 64-version-negotiation-client
 
 [64-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[64-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2187,9 +2736,18 @@ ssl_conf = 65-version-negotiation-ssl
 
 [65-version-negotiation-ssl]
 server = 65-version-negotiation-server
+server2 = 65-version-negotiation-server2
 client = 65-version-negotiation-client
 
 [65-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[65-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2216,9 +2774,17 @@ ssl_conf = 66-version-negotiation-ssl
 
 [66-version-negotiation-ssl]
 server = 66-version-negotiation-server
+server2 = 66-version-negotiation-server2
 client = 66-version-negotiation-client
 
 [66-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[66-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -2244,9 +2810,18 @@ ssl_conf = 67-version-negotiation-ssl
 
 [67-version-negotiation-ssl]
 server = 67-version-negotiation-server
+server2 = 67-version-negotiation-server2
 client = 67-version-negotiation-client
 
 [67-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[67-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -2273,9 +2848,18 @@ ssl_conf = 68-version-negotiation-ssl
 
 [68-version-negotiation-ssl]
 server = 68-version-negotiation-server
+server2 = 68-version-negotiation-server2
 client = 68-version-negotiation-client
 
 [68-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[68-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2302,9 +2886,18 @@ ssl_conf = 69-version-negotiation-ssl
 
 [69-version-negotiation-ssl]
 server = 69-version-negotiation-server
+server2 = 69-version-negotiation-server2
 client = 69-version-negotiation-client
 
 [69-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[69-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2331,9 +2924,17 @@ ssl_conf = 70-version-negotiation-ssl
 
 [70-version-negotiation-ssl]
 server = 70-version-negotiation-server
+server2 = 70-version-negotiation-server2
 client = 70-version-negotiation-client
 
 [70-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[70-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -2359,9 +2960,18 @@ ssl_conf = 71-version-negotiation-ssl
 
 [71-version-negotiation-ssl]
 server = 71-version-negotiation-server
+server2 = 71-version-negotiation-server2
 client = 71-version-negotiation-client
 
 [71-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[71-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2388,9 +2998,18 @@ ssl_conf = 72-version-negotiation-ssl
 
 [72-version-negotiation-ssl]
 server = 72-version-negotiation-server
+server2 = 72-version-negotiation-server2
 client = 72-version-negotiation-client
 
 [72-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[72-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2417,9 +3036,17 @@ ssl_conf = 73-version-negotiation-ssl
 
 [73-version-negotiation-ssl]
 server = 73-version-negotiation-server
+server2 = 73-version-negotiation-server2
 client = 73-version-negotiation-client
 
 [73-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[73-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -2445,9 +3072,18 @@ ssl_conf = 74-version-negotiation-ssl
 
 [74-version-negotiation-ssl]
 server = 74-version-negotiation-server
+server2 = 74-version-negotiation-server2
 client = 74-version-negotiation-client
 
 [74-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[74-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2474,9 +3110,17 @@ ssl_conf = 75-version-negotiation-ssl
 
 [75-version-negotiation-ssl]
 server = 75-version-negotiation-server
+server2 = 75-version-negotiation-server2
 client = 75-version-negotiation-client
 
 [75-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[75-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -2502,9 +3146,17 @@ ssl_conf = 76-version-negotiation-ssl
 
 [76-version-negotiation-ssl]
 server = 76-version-negotiation-server
+server2 = 76-version-negotiation-server2
 client = 76-version-negotiation-client
 
 [76-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[76-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -2528,9 +3180,17 @@ ssl_conf = 77-version-negotiation-ssl
 
 [77-version-negotiation-ssl]
 server = 77-version-negotiation-server
+server2 = 77-version-negotiation-server2
 client = 77-version-negotiation-client
 
 [77-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[77-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -2555,9 +3215,17 @@ ssl_conf = 78-version-negotiation-ssl
 
 [78-version-negotiation-ssl]
 server = 78-version-negotiation-server
+server2 = 78-version-negotiation-server2
 client = 78-version-negotiation-client
 
 [78-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[78-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2582,9 +3250,17 @@ ssl_conf = 79-version-negotiation-ssl
 
 [79-version-negotiation-ssl]
 server = 79-version-negotiation-server
+server2 = 79-version-negotiation-server2
 client = 79-version-negotiation-client
 
 [79-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[79-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2609,9 +3285,16 @@ ssl_conf = 80-version-negotiation-ssl
 
 [80-version-negotiation-ssl]
 server = 80-version-negotiation-server
+server2 = 80-version-negotiation-server2
 client = 80-version-negotiation-client
 
 [80-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[80-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -2635,9 +3318,18 @@ ssl_conf = 81-version-negotiation-ssl
 
 [81-version-negotiation-ssl]
 server = 81-version-negotiation-server
+server2 = 81-version-negotiation-server2
 client = 81-version-negotiation-client
 
 [81-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[81-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -2662,9 +3354,18 @@ ssl_conf = 82-version-negotiation-ssl
 
 [82-version-negotiation-ssl]
 server = 82-version-negotiation-server
+server2 = 82-version-negotiation-server2
 client = 82-version-negotiation-client
 
 [82-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[82-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -2690,9 +3391,18 @@ ssl_conf = 83-version-negotiation-ssl
 
 [83-version-negotiation-ssl]
 server = 83-version-negotiation-server
+server2 = 83-version-negotiation-server2
 client = 83-version-negotiation-client
 
 [83-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[83-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2718,9 +3428,18 @@ ssl_conf = 84-version-negotiation-ssl
 
 [84-version-negotiation-ssl]
 server = 84-version-negotiation-server
+server2 = 84-version-negotiation-server2
 client = 84-version-negotiation-client
 
 [84-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[84-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2746,9 +3465,17 @@ ssl_conf = 85-version-negotiation-ssl
 
 [85-version-negotiation-ssl]
 server = 85-version-negotiation-server
+server2 = 85-version-negotiation-server2
 client = 85-version-negotiation-client
 
 [85-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[85-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -2773,9 +3500,18 @@ ssl_conf = 86-version-negotiation-ssl
 
 [86-version-negotiation-ssl]
 server = 86-version-negotiation-server
+server2 = 86-version-negotiation-server2
 client = 86-version-negotiation-client
 
 [86-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[86-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -2801,9 +3537,18 @@ ssl_conf = 87-version-negotiation-ssl
 
 [87-version-negotiation-ssl]
 server = 87-version-negotiation-server
+server2 = 87-version-negotiation-server2
 client = 87-version-negotiation-client
 
 [87-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[87-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2829,9 +3574,18 @@ ssl_conf = 88-version-negotiation-ssl
 
 [88-version-negotiation-ssl]
 server = 88-version-negotiation-server
+server2 = 88-version-negotiation-server2
 client = 88-version-negotiation-client
 
 [88-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[88-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2857,9 +3611,17 @@ ssl_conf = 89-version-negotiation-ssl
 
 [89-version-negotiation-ssl]
 server = 89-version-negotiation-server
+server2 = 89-version-negotiation-server2
 client = 89-version-negotiation-client
 
 [89-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[89-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -2884,9 +3646,18 @@ ssl_conf = 90-version-negotiation-ssl
 
 [90-version-negotiation-ssl]
 server = 90-version-negotiation-server
+server2 = 90-version-negotiation-server2
 client = 90-version-negotiation-client
 
 [90-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[90-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -2912,9 +3683,18 @@ ssl_conf = 91-version-negotiation-ssl
 
 [91-version-negotiation-ssl]
 server = 91-version-negotiation-server
+server2 = 91-version-negotiation-server2
 client = 91-version-negotiation-client
 
 [91-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[91-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2940,9 +3720,17 @@ ssl_conf = 92-version-negotiation-ssl
 
 [92-version-negotiation-ssl]
 server = 92-version-negotiation-server
+server2 = 92-version-negotiation-server2
 client = 92-version-negotiation-client
 
 [92-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[92-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -2967,9 +3755,18 @@ ssl_conf = 93-version-negotiation-ssl
 
 [93-version-negotiation-ssl]
 server = 93-version-negotiation-server
+server2 = 93-version-negotiation-server2
 client = 93-version-negotiation-client
 
 [93-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[93-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -2995,9 +3792,17 @@ ssl_conf = 94-version-negotiation-ssl
 
 [94-version-negotiation-ssl]
 server = 94-version-negotiation-server
+server2 = 94-version-negotiation-server2
 client = 94-version-negotiation-client
 
 [94-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[94-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -3022,9 +3827,17 @@ ssl_conf = 95-version-negotiation-ssl
 
 [95-version-negotiation-ssl]
 server = 95-version-negotiation-server
+server2 = 95-version-negotiation-server2
 client = 95-version-negotiation-client
 
 [95-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[95-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -3050,9 +3863,17 @@ ssl_conf = 96-version-negotiation-ssl
 
 [96-version-negotiation-ssl]
 server = 96-version-negotiation-server
+server2 = 96-version-negotiation-server2
 client = 96-version-negotiation-client
 
 [96-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[96-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -3078,9 +3899,17 @@ ssl_conf = 97-version-negotiation-ssl
 
 [97-version-negotiation-ssl]
 server = 97-version-negotiation-server
+server2 = 97-version-negotiation-server2
 client = 97-version-negotiation-client
 
 [97-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[97-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3106,9 +3935,17 @@ ssl_conf = 98-version-negotiation-ssl
 
 [98-version-negotiation-ssl]
 server = 98-version-negotiation-server
+server2 = 98-version-negotiation-server2
 client = 98-version-negotiation-client
 
 [98-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[98-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3134,9 +3971,16 @@ ssl_conf = 99-version-negotiation-ssl
 
 [99-version-negotiation-ssl]
 server = 99-version-negotiation-server
+server2 = 99-version-negotiation-server2
 client = 99-version-negotiation-client
 
 [99-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[99-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -3161,9 +4005,18 @@ ssl_conf = 100-version-negotiation-ssl
 
 [100-version-negotiation-ssl]
 server = 100-version-negotiation-server
+server2 = 100-version-negotiation-server2
 client = 100-version-negotiation-client
 
 [100-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[100-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -3190,9 +4043,18 @@ ssl_conf = 101-version-negotiation-ssl
 
 [101-version-negotiation-ssl]
 server = 101-version-negotiation-server
+server2 = 101-version-negotiation-server2
 client = 101-version-negotiation-client
 
 [101-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[101-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -3219,9 +4081,18 @@ ssl_conf = 102-version-negotiation-ssl
 
 [102-version-negotiation-ssl]
 server = 102-version-negotiation-server
+server2 = 102-version-negotiation-server2
 client = 102-version-negotiation-client
 
 [102-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[102-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3248,9 +4119,18 @@ ssl_conf = 103-version-negotiation-ssl
 
 [103-version-negotiation-ssl]
 server = 103-version-negotiation-server
+server2 = 103-version-negotiation-server2
 client = 103-version-negotiation-client
 
 [103-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[103-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3277,9 +4157,17 @@ ssl_conf = 104-version-negotiation-ssl
 
 [104-version-negotiation-ssl]
 server = 104-version-negotiation-server
+server2 = 104-version-negotiation-server2
 client = 104-version-negotiation-client
 
 [104-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[104-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -3305,9 +4193,18 @@ ssl_conf = 105-version-negotiation-ssl
 
 [105-version-negotiation-ssl]
 server = 105-version-negotiation-server
+server2 = 105-version-negotiation-server2
 client = 105-version-negotiation-client
 
 [105-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[105-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -3334,9 +4231,18 @@ ssl_conf = 106-version-negotiation-ssl
 
 [106-version-negotiation-ssl]
 server = 106-version-negotiation-server
+server2 = 106-version-negotiation-server2
 client = 106-version-negotiation-client
 
 [106-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[106-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3363,9 +4269,18 @@ ssl_conf = 107-version-negotiation-ssl
 
 [107-version-negotiation-ssl]
 server = 107-version-negotiation-server
+server2 = 107-version-negotiation-server2
 client = 107-version-negotiation-client
 
 [107-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[107-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3392,9 +4307,17 @@ ssl_conf = 108-version-negotiation-ssl
 
 [108-version-negotiation-ssl]
 server = 108-version-negotiation-server
+server2 = 108-version-negotiation-server2
 client = 108-version-negotiation-client
 
 [108-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[108-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -3420,9 +4343,18 @@ ssl_conf = 109-version-negotiation-ssl
 
 [109-version-negotiation-ssl]
 server = 109-version-negotiation-server
+server2 = 109-version-negotiation-server2
 client = 109-version-negotiation-client
 
 [109-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[109-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3449,9 +4381,18 @@ ssl_conf = 110-version-negotiation-ssl
 
 [110-version-negotiation-ssl]
 server = 110-version-negotiation-server
+server2 = 110-version-negotiation-server2
 client = 110-version-negotiation-client
 
 [110-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[110-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3478,9 +4419,17 @@ ssl_conf = 111-version-negotiation-ssl
 
 [111-version-negotiation-ssl]
 server = 111-version-negotiation-server
+server2 = 111-version-negotiation-server2
 client = 111-version-negotiation-client
 
 [111-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[111-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -3506,9 +4455,18 @@ ssl_conf = 112-version-negotiation-ssl
 
 [112-version-negotiation-ssl]
 server = 112-version-negotiation-server
+server2 = 112-version-negotiation-server2
 client = 112-version-negotiation-client
 
 [112-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[112-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3535,9 +4493,17 @@ ssl_conf = 113-version-negotiation-ssl
 
 [113-version-negotiation-ssl]
 server = 113-version-negotiation-server
+server2 = 113-version-negotiation-server2
 client = 113-version-negotiation-client
 
 [113-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[113-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -3563,9 +4529,17 @@ ssl_conf = 114-version-negotiation-ssl
 
 [114-version-negotiation-ssl]
 server = 114-version-negotiation-server
+server2 = 114-version-negotiation-server2
 client = 114-version-negotiation-client
 
 [114-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[114-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -3591,9 +4565,17 @@ ssl_conf = 115-version-negotiation-ssl
 
 [115-version-negotiation-ssl]
 server = 115-version-negotiation-server
+server2 = 115-version-negotiation-server2
 client = 115-version-negotiation-client
 
 [115-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[115-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -3620,9 +4602,17 @@ ssl_conf = 116-version-negotiation-ssl
 
 [116-version-negotiation-ssl]
 server = 116-version-negotiation-server
+server2 = 116-version-negotiation-server2
 client = 116-version-negotiation-client
 
 [116-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[116-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3649,9 +4639,17 @@ ssl_conf = 117-version-negotiation-ssl
 
 [117-version-negotiation-ssl]
 server = 117-version-negotiation-server
+server2 = 117-version-negotiation-server2
 client = 117-version-negotiation-client
 
 [117-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[117-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3678,9 +4676,16 @@ ssl_conf = 118-version-negotiation-ssl
 
 [118-version-negotiation-ssl]
 server = 118-version-negotiation-server
+server2 = 118-version-negotiation-server2
 client = 118-version-negotiation-client
 
 [118-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[118-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -3706,9 +4711,18 @@ ssl_conf = 119-version-negotiation-ssl
 
 [119-version-negotiation-ssl]
 server = 119-version-negotiation-server
+server2 = 119-version-negotiation-server2
 client = 119-version-negotiation-client
 
 [119-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[119-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -3735,9 +4749,18 @@ ssl_conf = 120-version-negotiation-ssl
 
 [120-version-negotiation-ssl]
 server = 120-version-negotiation-server
+server2 = 120-version-negotiation-server2
 client = 120-version-negotiation-client
 
 [120-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[120-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -3765,9 +4788,18 @@ ssl_conf = 121-version-negotiation-ssl
 
 [121-version-negotiation-ssl]
 server = 121-version-negotiation-server
+server2 = 121-version-negotiation-server2
 client = 121-version-negotiation-client
 
 [121-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[121-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3795,9 +4827,18 @@ ssl_conf = 122-version-negotiation-ssl
 
 [122-version-negotiation-ssl]
 server = 122-version-negotiation-server
+server2 = 122-version-negotiation-server2
 client = 122-version-negotiation-client
 
 [122-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[122-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3825,9 +4866,17 @@ ssl_conf = 123-version-negotiation-ssl
 
 [123-version-negotiation-ssl]
 server = 123-version-negotiation-server
+server2 = 123-version-negotiation-server2
 client = 123-version-negotiation-client
 
 [123-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[123-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -3854,9 +4903,18 @@ ssl_conf = 124-version-negotiation-ssl
 
 [124-version-negotiation-ssl]
 server = 124-version-negotiation-server
+server2 = 124-version-negotiation-server2
 client = 124-version-negotiation-client
 
 [124-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[124-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -3884,9 +4942,18 @@ ssl_conf = 125-version-negotiation-ssl
 
 [125-version-negotiation-ssl]
 server = 125-version-negotiation-server
+server2 = 125-version-negotiation-server2
 client = 125-version-negotiation-client
 
 [125-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[125-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -3914,9 +4981,18 @@ ssl_conf = 126-version-negotiation-ssl
 
 [126-version-negotiation-ssl]
 server = 126-version-negotiation-server
+server2 = 126-version-negotiation-server2
 client = 126-version-negotiation-client
 
 [126-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[126-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -3944,9 +5020,17 @@ ssl_conf = 127-version-negotiation-ssl
 
 [127-version-negotiation-ssl]
 server = 127-version-negotiation-server
+server2 = 127-version-negotiation-server2
 client = 127-version-negotiation-client
 
 [127-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[127-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -3973,9 +5057,18 @@ ssl_conf = 128-version-negotiation-ssl
 
 [128-version-negotiation-ssl]
 server = 128-version-negotiation-server
+server2 = 128-version-negotiation-server2
 client = 128-version-negotiation-client
 
 [128-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[128-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4002,9 +5095,18 @@ ssl_conf = 129-version-negotiation-ssl
 
 [129-version-negotiation-ssl]
 server = 129-version-negotiation-server
+server2 = 129-version-negotiation-server2
 client = 129-version-negotiation-client
 
 [129-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[129-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4031,9 +5133,17 @@ ssl_conf = 130-version-negotiation-ssl
 
 [130-version-negotiation-ssl]
 server = 130-version-negotiation-server
+server2 = 130-version-negotiation-server2
 client = 130-version-negotiation-client
 
 [130-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[130-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -4059,9 +5169,18 @@ ssl_conf = 131-version-negotiation-ssl
 
 [131-version-negotiation-ssl]
 server = 131-version-negotiation-server
+server2 = 131-version-negotiation-server2
 client = 131-version-negotiation-client
 
 [131-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[131-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4088,9 +5207,17 @@ ssl_conf = 132-version-negotiation-ssl
 
 [132-version-negotiation-ssl]
 server = 132-version-negotiation-server
+server2 = 132-version-negotiation-server2
 client = 132-version-negotiation-client
 
 [132-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[132-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -4116,9 +5243,17 @@ ssl_conf = 133-version-negotiation-ssl
 
 [133-version-negotiation-ssl]
 server = 133-version-negotiation-server
+server2 = 133-version-negotiation-server2
 client = 133-version-negotiation-client
 
 [133-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[133-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -4144,9 +5279,17 @@ ssl_conf = 134-version-negotiation-ssl
 
 [134-version-negotiation-ssl]
 server = 134-version-negotiation-server
+server2 = 134-version-negotiation-server2
 client = 134-version-negotiation-client
 
 [134-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[134-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -4173,9 +5316,17 @@ ssl_conf = 135-version-negotiation-ssl
 
 [135-version-negotiation-ssl]
 server = 135-version-negotiation-server
+server2 = 135-version-negotiation-server2
 client = 135-version-negotiation-client
 
 [135-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[135-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4202,9 +5353,17 @@ ssl_conf = 136-version-negotiation-ssl
 
 [136-version-negotiation-ssl]
 server = 136-version-negotiation-server
+server2 = 136-version-negotiation-server2
 client = 136-version-negotiation-client
 
 [136-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[136-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4231,9 +5390,16 @@ ssl_conf = 137-version-negotiation-ssl
 
 [137-version-negotiation-ssl]
 server = 137-version-negotiation-server
+server2 = 137-version-negotiation-server2
 client = 137-version-negotiation-client
 
 [137-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[137-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -4259,9 +5425,18 @@ ssl_conf = 138-version-negotiation-ssl
 
 [138-version-negotiation-ssl]
 server = 138-version-negotiation-server
+server2 = 138-version-negotiation-server2
 client = 138-version-negotiation-client
 
 [138-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[138-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -4288,9 +5463,18 @@ ssl_conf = 139-version-negotiation-ssl
 
 [139-version-negotiation-ssl]
 server = 139-version-negotiation-server
+server2 = 139-version-negotiation-server2
 client = 139-version-negotiation-client
 
 [139-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[139-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -4318,9 +5502,18 @@ ssl_conf = 140-version-negotiation-ssl
 
 [140-version-negotiation-ssl]
 server = 140-version-negotiation-server
+server2 = 140-version-negotiation-server2
 client = 140-version-negotiation-client
 
 [140-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[140-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4348,9 +5541,18 @@ ssl_conf = 141-version-negotiation-ssl
 
 [141-version-negotiation-ssl]
 server = 141-version-negotiation-server
+server2 = 141-version-negotiation-server2
 client = 141-version-negotiation-client
 
 [141-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[141-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4378,9 +5580,17 @@ ssl_conf = 142-version-negotiation-ssl
 
 [142-version-negotiation-ssl]
 server = 142-version-negotiation-server
+server2 = 142-version-negotiation-server2
 client = 142-version-negotiation-client
 
 [142-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[142-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -4407,9 +5617,18 @@ ssl_conf = 143-version-negotiation-ssl
 
 [143-version-negotiation-ssl]
 server = 143-version-negotiation-server
+server2 = 143-version-negotiation-server2
 client = 143-version-negotiation-client
 
 [143-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[143-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -4437,9 +5656,18 @@ ssl_conf = 144-version-negotiation-ssl
 
 [144-version-negotiation-ssl]
 server = 144-version-negotiation-server
+server2 = 144-version-negotiation-server2
 client = 144-version-negotiation-client
 
 [144-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[144-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4467,9 +5695,18 @@ ssl_conf = 145-version-negotiation-ssl
 
 [145-version-negotiation-ssl]
 server = 145-version-negotiation-server
+server2 = 145-version-negotiation-server2
 client = 145-version-negotiation-client
 
 [145-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[145-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4497,9 +5734,17 @@ ssl_conf = 146-version-negotiation-ssl
 
 [146-version-negotiation-ssl]
 server = 146-version-negotiation-server
+server2 = 146-version-negotiation-server2
 client = 146-version-negotiation-client
 
 [146-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[146-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -4526,9 +5771,18 @@ ssl_conf = 147-version-negotiation-ssl
 
 [147-version-negotiation-ssl]
 server = 147-version-negotiation-server
+server2 = 147-version-negotiation-server2
 client = 147-version-negotiation-client
 
 [147-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[147-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4556,9 +5810,18 @@ ssl_conf = 148-version-negotiation-ssl
 
 [148-version-negotiation-ssl]
 server = 148-version-negotiation-server
+server2 = 148-version-negotiation-server2
 client = 148-version-negotiation-client
 
 [148-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[148-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4586,9 +5849,17 @@ ssl_conf = 149-version-negotiation-ssl
 
 [149-version-negotiation-ssl]
 server = 149-version-negotiation-server
+server2 = 149-version-negotiation-server2
 client = 149-version-negotiation-client
 
 [149-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[149-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -4615,9 +5886,18 @@ ssl_conf = 150-version-negotiation-ssl
 
 [150-version-negotiation-ssl]
 server = 150-version-negotiation-server
+server2 = 150-version-negotiation-server2
 client = 150-version-negotiation-client
 
 [150-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[150-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4644,9 +5924,17 @@ ssl_conf = 151-version-negotiation-ssl
 
 [151-version-negotiation-ssl]
 server = 151-version-negotiation-server
+server2 = 151-version-negotiation-server2
 client = 151-version-negotiation-client
 
 [151-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[151-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -4672,9 +5960,17 @@ ssl_conf = 152-version-negotiation-ssl
 
 [152-version-negotiation-ssl]
 server = 152-version-negotiation-server
+server2 = 152-version-negotiation-server2
 client = 152-version-negotiation-client
 
 [152-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[152-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -4700,9 +5996,17 @@ ssl_conf = 153-version-negotiation-ssl
 
 [153-version-negotiation-ssl]
 server = 153-version-negotiation-server
+server2 = 153-version-negotiation-server2
 client = 153-version-negotiation-client
 
 [153-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[153-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -4729,9 +6033,17 @@ ssl_conf = 154-version-negotiation-ssl
 
 [154-version-negotiation-ssl]
 server = 154-version-negotiation-server
+server2 = 154-version-negotiation-server2
 client = 154-version-negotiation-client
 
 [154-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[154-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4758,9 +6070,17 @@ ssl_conf = 155-version-negotiation-ssl
 
 [155-version-negotiation-ssl]
 server = 155-version-negotiation-server
+server2 = 155-version-negotiation-server2
 client = 155-version-negotiation-client
 
 [155-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[155-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4787,9 +6107,16 @@ ssl_conf = 156-version-negotiation-ssl
 
 [156-version-negotiation-ssl]
 server = 156-version-negotiation-server
+server2 = 156-version-negotiation-server2
 client = 156-version-negotiation-client
 
 [156-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[156-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -4815,9 +6142,18 @@ ssl_conf = 157-version-negotiation-ssl
 
 [157-version-negotiation-ssl]
 server = 157-version-negotiation-server
+server2 = 157-version-negotiation-server2
 client = 157-version-negotiation-client
 
 [157-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[157-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -4844,9 +6180,18 @@ ssl_conf = 158-version-negotiation-ssl
 
 [158-version-negotiation-ssl]
 server = 158-version-negotiation-server
+server2 = 158-version-negotiation-server2
 client = 158-version-negotiation-client
 
 [158-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[158-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -4874,9 +6219,18 @@ ssl_conf = 159-version-negotiation-ssl
 
 [159-version-negotiation-ssl]
 server = 159-version-negotiation-server
+server2 = 159-version-negotiation-server2
 client = 159-version-negotiation-client
 
 [159-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[159-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -4904,9 +6258,18 @@ ssl_conf = 160-version-negotiation-ssl
 
 [160-version-negotiation-ssl]
 server = 160-version-negotiation-server
+server2 = 160-version-negotiation-server2
 client = 160-version-negotiation-client
 
 [160-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[160-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -4934,9 +6297,17 @@ ssl_conf = 161-version-negotiation-ssl
 
 [161-version-negotiation-ssl]
 server = 161-version-negotiation-server
+server2 = 161-version-negotiation-server2
 client = 161-version-negotiation-client
 
 [161-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[161-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -4963,9 +6334,18 @@ ssl_conf = 162-version-negotiation-ssl
 
 [162-version-negotiation-ssl]
 server = 162-version-negotiation-server
+server2 = 162-version-negotiation-server2
 client = 162-version-negotiation-client
 
 [162-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[162-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -4993,9 +6373,18 @@ ssl_conf = 163-version-negotiation-ssl
 
 [163-version-negotiation-ssl]
 server = 163-version-negotiation-server
+server2 = 163-version-negotiation-server2
 client = 163-version-negotiation-client
 
 [163-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[163-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5023,9 +6412,18 @@ ssl_conf = 164-version-negotiation-ssl
 
 [164-version-negotiation-ssl]
 server = 164-version-negotiation-server
+server2 = 164-version-negotiation-server2
 client = 164-version-negotiation-client
 
 [164-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[164-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5053,9 +6451,17 @@ ssl_conf = 165-version-negotiation-ssl
 
 [165-version-negotiation-ssl]
 server = 165-version-negotiation-server
+server2 = 165-version-negotiation-server2
 client = 165-version-negotiation-client
 
 [165-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[165-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -5082,9 +6488,18 @@ ssl_conf = 166-version-negotiation-ssl
 
 [166-version-negotiation-ssl]
 server = 166-version-negotiation-server
+server2 = 166-version-negotiation-server2
 client = 166-version-negotiation-client
 
 [166-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[166-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5112,9 +6527,18 @@ ssl_conf = 167-version-negotiation-ssl
 
 [167-version-negotiation-ssl]
 server = 167-version-negotiation-server
+server2 = 167-version-negotiation-server2
 client = 167-version-negotiation-client
 
 [167-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[167-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5142,9 +6566,17 @@ ssl_conf = 168-version-negotiation-ssl
 
 [168-version-negotiation-ssl]
 server = 168-version-negotiation-server
+server2 = 168-version-negotiation-server2
 client = 168-version-negotiation-client
 
 [168-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[168-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -5171,9 +6603,18 @@ ssl_conf = 169-version-negotiation-ssl
 
 [169-version-negotiation-ssl]
 server = 169-version-negotiation-server
+server2 = 169-version-negotiation-server2
 client = 169-version-negotiation-client
 
 [169-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[169-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5201,9 +6642,17 @@ ssl_conf = 170-version-negotiation-ssl
 
 [170-version-negotiation-ssl]
 server = 170-version-negotiation-server
+server2 = 170-version-negotiation-server2
 client = 170-version-negotiation-client
 
 [170-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[170-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -5230,9 +6679,17 @@ ssl_conf = 171-version-negotiation-ssl
 
 [171-version-negotiation-ssl]
 server = 171-version-negotiation-server
+server2 = 171-version-negotiation-server2
 client = 171-version-negotiation-client
 
 [171-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[171-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -5257,9 +6714,17 @@ ssl_conf = 172-version-negotiation-ssl
 
 [172-version-negotiation-ssl]
 server = 172-version-negotiation-server
+server2 = 172-version-negotiation-server2
 client = 172-version-negotiation-client
 
 [172-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[172-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -5285,9 +6750,17 @@ ssl_conf = 173-version-negotiation-ssl
 
 [173-version-negotiation-ssl]
 server = 173-version-negotiation-server
+server2 = 173-version-negotiation-server2
 client = 173-version-negotiation-client
 
 [173-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[173-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5313,9 +6786,17 @@ ssl_conf = 174-version-negotiation-ssl
 
 [174-version-negotiation-ssl]
 server = 174-version-negotiation-server
+server2 = 174-version-negotiation-server2
 client = 174-version-negotiation-client
 
 [174-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[174-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5341,9 +6822,16 @@ ssl_conf = 175-version-negotiation-ssl
 
 [175-version-negotiation-ssl]
 server = 175-version-negotiation-server
+server2 = 175-version-negotiation-server2
 client = 175-version-negotiation-client
 
 [175-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[175-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -5368,9 +6856,18 @@ ssl_conf = 176-version-negotiation-ssl
 
 [176-version-negotiation-ssl]
 server = 176-version-negotiation-server
+server2 = 176-version-negotiation-server2
 client = 176-version-negotiation-client
 
 [176-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[176-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -5396,9 +6893,18 @@ ssl_conf = 177-version-negotiation-ssl
 
 [177-version-negotiation-ssl]
 server = 177-version-negotiation-server
+server2 = 177-version-negotiation-server2
 client = 177-version-negotiation-client
 
 [177-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[177-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -5425,9 +6931,18 @@ ssl_conf = 178-version-negotiation-ssl
 
 [178-version-negotiation-ssl]
 server = 178-version-negotiation-server
+server2 = 178-version-negotiation-server2
 client = 178-version-negotiation-client
 
 [178-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[178-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5454,9 +6969,18 @@ ssl_conf = 179-version-negotiation-ssl
 
 [179-version-negotiation-ssl]
 server = 179-version-negotiation-server
+server2 = 179-version-negotiation-server2
 client = 179-version-negotiation-client
 
 [179-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[179-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5483,9 +7007,17 @@ ssl_conf = 180-version-negotiation-ssl
 
 [180-version-negotiation-ssl]
 server = 180-version-negotiation-server
+server2 = 180-version-negotiation-server2
 client = 180-version-negotiation-client
 
 [180-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[180-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -5511,9 +7043,18 @@ ssl_conf = 181-version-negotiation-ssl
 
 [181-version-negotiation-ssl]
 server = 181-version-negotiation-server
+server2 = 181-version-negotiation-server2
 client = 181-version-negotiation-client
 
 [181-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[181-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -5540,9 +7081,18 @@ ssl_conf = 182-version-negotiation-ssl
 
 [182-version-negotiation-ssl]
 server = 182-version-negotiation-server
+server2 = 182-version-negotiation-server2
 client = 182-version-negotiation-client
 
 [182-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[182-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5569,9 +7119,18 @@ ssl_conf = 183-version-negotiation-ssl
 
 [183-version-negotiation-ssl]
 server = 183-version-negotiation-server
+server2 = 183-version-negotiation-server2
 client = 183-version-negotiation-client
 
 [183-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[183-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5598,9 +7157,17 @@ ssl_conf = 184-version-negotiation-ssl
 
 [184-version-negotiation-ssl]
 server = 184-version-negotiation-server
+server2 = 184-version-negotiation-server2
 client = 184-version-negotiation-client
 
 [184-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[184-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -5626,9 +7193,18 @@ ssl_conf = 185-version-negotiation-ssl
 
 [185-version-negotiation-ssl]
 server = 185-version-negotiation-server
+server2 = 185-version-negotiation-server2
 client = 185-version-negotiation-client
 
 [185-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[185-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5655,9 +7231,18 @@ ssl_conf = 186-version-negotiation-ssl
 
 [186-version-negotiation-ssl]
 server = 186-version-negotiation-server
+server2 = 186-version-negotiation-server2
 client = 186-version-negotiation-client
 
 [186-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[186-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5684,9 +7269,17 @@ ssl_conf = 187-version-negotiation-ssl
 
 [187-version-negotiation-ssl]
 server = 187-version-negotiation-server
+server2 = 187-version-negotiation-server2
 client = 187-version-negotiation-client
 
 [187-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[187-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -5712,9 +7305,18 @@ ssl_conf = 188-version-negotiation-ssl
 
 [188-version-negotiation-ssl]
 server = 188-version-negotiation-server
+server2 = 188-version-negotiation-server2
 client = 188-version-negotiation-client
 
 [188-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[188-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5741,9 +7343,17 @@ ssl_conf = 189-version-negotiation-ssl
 
 [189-version-negotiation-ssl]
 server = 189-version-negotiation-server
+server2 = 189-version-negotiation-server2
 client = 189-version-negotiation-client
 
 [189-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[189-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -5769,9 +7379,17 @@ ssl_conf = 190-version-negotiation-ssl
 
 [190-version-negotiation-ssl]
 server = 190-version-negotiation-server
+server2 = 190-version-negotiation-server2
 client = 190-version-negotiation-client
 
 [190-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[190-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -5797,9 +7415,17 @@ ssl_conf = 191-version-negotiation-ssl
 
 [191-version-negotiation-ssl]
 server = 191-version-negotiation-server
+server2 = 191-version-negotiation-server2
 client = 191-version-negotiation-client
 
 [191-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[191-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -5826,9 +7452,17 @@ ssl_conf = 192-version-negotiation-ssl
 
 [192-version-negotiation-ssl]
 server = 192-version-negotiation-server
+server2 = 192-version-negotiation-server2
 client = 192-version-negotiation-client
 
 [192-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[192-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -5855,9 +7489,17 @@ ssl_conf = 193-version-negotiation-ssl
 
 [193-version-negotiation-ssl]
 server = 193-version-negotiation-server
+server2 = 193-version-negotiation-server2
 client = 193-version-negotiation-client
 
 [193-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[193-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -5884,9 +7526,16 @@ ssl_conf = 194-version-negotiation-ssl
 
 [194-version-negotiation-ssl]
 server = 194-version-negotiation-server
+server2 = 194-version-negotiation-server2
 client = 194-version-negotiation-client
 
 [194-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[194-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -5912,9 +7561,18 @@ ssl_conf = 195-version-negotiation-ssl
 
 [195-version-negotiation-ssl]
 server = 195-version-negotiation-server
+server2 = 195-version-negotiation-server2
 client = 195-version-negotiation-client
 
 [195-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[195-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -5941,9 +7599,18 @@ ssl_conf = 196-version-negotiation-ssl
 
 [196-version-negotiation-ssl]
 server = 196-version-negotiation-server
+server2 = 196-version-negotiation-server2
 client = 196-version-negotiation-client
 
 [196-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[196-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -5971,9 +7638,18 @@ ssl_conf = 197-version-negotiation-ssl
 
 [197-version-negotiation-ssl]
 server = 197-version-negotiation-server
+server2 = 197-version-negotiation-server2
 client = 197-version-negotiation-client
 
 [197-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[197-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6001,9 +7677,18 @@ ssl_conf = 198-version-negotiation-ssl
 
 [198-version-negotiation-ssl]
 server = 198-version-negotiation-server
+server2 = 198-version-negotiation-server2
 client = 198-version-negotiation-client
 
 [198-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[198-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6031,9 +7716,17 @@ ssl_conf = 199-version-negotiation-ssl
 
 [199-version-negotiation-ssl]
 server = 199-version-negotiation-server
+server2 = 199-version-negotiation-server2
 client = 199-version-negotiation-client
 
 [199-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[199-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -6060,9 +7753,18 @@ ssl_conf = 200-version-negotiation-ssl
 
 [200-version-negotiation-ssl]
 server = 200-version-negotiation-server
+server2 = 200-version-negotiation-server2
 client = 200-version-negotiation-client
 
 [200-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[200-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -6090,9 +7792,18 @@ ssl_conf = 201-version-negotiation-ssl
 
 [201-version-negotiation-ssl]
 server = 201-version-negotiation-server
+server2 = 201-version-negotiation-server2
 client = 201-version-negotiation-client
 
 [201-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[201-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6120,9 +7831,18 @@ ssl_conf = 202-version-negotiation-ssl
 
 [202-version-negotiation-ssl]
 server = 202-version-negotiation-server
+server2 = 202-version-negotiation-server2
 client = 202-version-negotiation-client
 
 [202-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[202-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6150,9 +7870,17 @@ ssl_conf = 203-version-negotiation-ssl
 
 [203-version-negotiation-ssl]
 server = 203-version-negotiation-server
+server2 = 203-version-negotiation-server2
 client = 203-version-negotiation-client
 
 [203-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[203-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -6179,9 +7907,18 @@ ssl_conf = 204-version-negotiation-ssl
 
 [204-version-negotiation-ssl]
 server = 204-version-negotiation-server
+server2 = 204-version-negotiation-server2
 client = 204-version-negotiation-client
 
 [204-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[204-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6208,9 +7945,18 @@ ssl_conf = 205-version-negotiation-ssl
 
 [205-version-negotiation-ssl]
 server = 205-version-negotiation-server
+server2 = 205-version-negotiation-server2
 client = 205-version-negotiation-client
 
 [205-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[205-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6237,9 +7983,17 @@ ssl_conf = 206-version-negotiation-ssl
 
 [206-version-negotiation-ssl]
 server = 206-version-negotiation-server
+server2 = 206-version-negotiation-server2
 client = 206-version-negotiation-client
 
 [206-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[206-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -6265,9 +8019,18 @@ ssl_conf = 207-version-negotiation-ssl
 
 [207-version-negotiation-ssl]
 server = 207-version-negotiation-server
+server2 = 207-version-negotiation-server2
 client = 207-version-negotiation-client
 
 [207-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[207-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6294,9 +8057,17 @@ ssl_conf = 208-version-negotiation-ssl
 
 [208-version-negotiation-ssl]
 server = 208-version-negotiation-server
+server2 = 208-version-negotiation-server2
 client = 208-version-negotiation-client
 
 [208-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[208-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -6322,9 +8093,17 @@ ssl_conf = 209-version-negotiation-ssl
 
 [209-version-negotiation-ssl]
 server = 209-version-negotiation-server
+server2 = 209-version-negotiation-server2
 client = 209-version-negotiation-client
 
 [209-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[209-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -6350,9 +8129,17 @@ ssl_conf = 210-version-negotiation-ssl
 
 [210-version-negotiation-ssl]
 server = 210-version-negotiation-server
+server2 = 210-version-negotiation-server2
 client = 210-version-negotiation-client
 
 [210-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[210-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -6379,9 +8166,17 @@ ssl_conf = 211-version-negotiation-ssl
 
 [211-version-negotiation-ssl]
 server = 211-version-negotiation-server
+server2 = 211-version-negotiation-server2
 client = 211-version-negotiation-client
 
 [211-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[211-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6408,9 +8203,17 @@ ssl_conf = 212-version-negotiation-ssl
 
 [212-version-negotiation-ssl]
 server = 212-version-negotiation-server
+server2 = 212-version-negotiation-server2
 client = 212-version-negotiation-client
 
 [212-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[212-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6437,9 +8240,16 @@ ssl_conf = 213-version-negotiation-ssl
 
 [213-version-negotiation-ssl]
 server = 213-version-negotiation-server
+server2 = 213-version-negotiation-server2
 client = 213-version-negotiation-client
 
 [213-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[213-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -6465,9 +8275,18 @@ ssl_conf = 214-version-negotiation-ssl
 
 [214-version-negotiation-ssl]
 server = 214-version-negotiation-server
+server2 = 214-version-negotiation-server2
 client = 214-version-negotiation-client
 
 [214-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[214-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -6494,9 +8313,18 @@ ssl_conf = 215-version-negotiation-ssl
 
 [215-version-negotiation-ssl]
 server = 215-version-negotiation-server
+server2 = 215-version-negotiation-server2
 client = 215-version-negotiation-client
 
 [215-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[215-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -6524,9 +8352,18 @@ ssl_conf = 216-version-negotiation-ssl
 
 [216-version-negotiation-ssl]
 server = 216-version-negotiation-server
+server2 = 216-version-negotiation-server2
 client = 216-version-negotiation-client
 
 [216-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[216-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6554,9 +8391,18 @@ ssl_conf = 217-version-negotiation-ssl
 
 [217-version-negotiation-ssl]
 server = 217-version-negotiation-server
+server2 = 217-version-negotiation-server2
 client = 217-version-negotiation-client
 
 [217-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[217-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6584,9 +8430,17 @@ ssl_conf = 218-version-negotiation-ssl
 
 [218-version-negotiation-ssl]
 server = 218-version-negotiation-server
+server2 = 218-version-negotiation-server2
 client = 218-version-negotiation-client
 
 [218-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[218-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -6613,9 +8467,18 @@ ssl_conf = 219-version-negotiation-ssl
 
 [219-version-negotiation-ssl]
 server = 219-version-negotiation-server
+server2 = 219-version-negotiation-server2
 client = 219-version-negotiation-client
 
 [219-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[219-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -6643,9 +8506,18 @@ ssl_conf = 220-version-negotiation-ssl
 
 [220-version-negotiation-ssl]
 server = 220-version-negotiation-server
+server2 = 220-version-negotiation-server2
 client = 220-version-negotiation-client
 
 [220-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[220-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6673,9 +8545,18 @@ ssl_conf = 221-version-negotiation-ssl
 
 [221-version-negotiation-ssl]
 server = 221-version-negotiation-server
+server2 = 221-version-negotiation-server2
 client = 221-version-negotiation-client
 
 [221-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[221-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6703,9 +8584,17 @@ ssl_conf = 222-version-negotiation-ssl
 
 [222-version-negotiation-ssl]
 server = 222-version-negotiation-server
+server2 = 222-version-negotiation-server2
 client = 222-version-negotiation-client
 
 [222-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[222-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -6732,9 +8621,18 @@ ssl_conf = 223-version-negotiation-ssl
 
 [223-version-negotiation-ssl]
 server = 223-version-negotiation-server
+server2 = 223-version-negotiation-server2
 client = 223-version-negotiation-client
 
 [223-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[223-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6762,9 +8660,18 @@ ssl_conf = 224-version-negotiation-ssl
 
 [224-version-negotiation-ssl]
 server = 224-version-negotiation-server
+server2 = 224-version-negotiation-server2
 client = 224-version-negotiation-client
 
 [224-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[224-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6792,9 +8699,17 @@ ssl_conf = 225-version-negotiation-ssl
 
 [225-version-negotiation-ssl]
 server = 225-version-negotiation-server
+server2 = 225-version-negotiation-server2
 client = 225-version-negotiation-client
 
 [225-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[225-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -6821,9 +8736,18 @@ ssl_conf = 226-version-negotiation-ssl
 
 [226-version-negotiation-ssl]
 server = 226-version-negotiation-server
+server2 = 226-version-negotiation-server2
 client = 226-version-negotiation-client
 
 [226-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[226-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6850,9 +8774,17 @@ ssl_conf = 227-version-negotiation-ssl
 
 [227-version-negotiation-ssl]
 server = 227-version-negotiation-server
+server2 = 227-version-negotiation-server2
 client = 227-version-negotiation-client
 
 [227-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[227-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -6878,9 +8810,17 @@ ssl_conf = 228-version-negotiation-ssl
 
 [228-version-negotiation-ssl]
 server = 228-version-negotiation-server
+server2 = 228-version-negotiation-server2
 client = 228-version-negotiation-client
 
 [228-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[228-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -6906,9 +8846,17 @@ ssl_conf = 229-version-negotiation-ssl
 
 [229-version-negotiation-ssl]
 server = 229-version-negotiation-server
+server2 = 229-version-negotiation-server2
 client = 229-version-negotiation-client
 
 [229-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[229-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -6935,9 +8883,17 @@ ssl_conf = 230-version-negotiation-ssl
 
 [230-version-negotiation-ssl]
 server = 230-version-negotiation-server
+server2 = 230-version-negotiation-server2
 client = 230-version-negotiation-client
 
 [230-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[230-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -6964,9 +8920,17 @@ ssl_conf = 231-version-negotiation-ssl
 
 [231-version-negotiation-ssl]
 server = 231-version-negotiation-server
+server2 = 231-version-negotiation-server2
 client = 231-version-negotiation-client
 
 [231-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[231-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -6993,9 +8957,16 @@ ssl_conf = 232-version-negotiation-ssl
 
 [232-version-negotiation-ssl]
 server = 232-version-negotiation-server
+server2 = 232-version-negotiation-server2
 client = 232-version-negotiation-client
 
 [232-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[232-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -7021,9 +8992,18 @@ ssl_conf = 233-version-negotiation-ssl
 
 [233-version-negotiation-ssl]
 server = 233-version-negotiation-server
+server2 = 233-version-negotiation-server2
 client = 233-version-negotiation-client
 
 [233-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[233-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -7050,9 +9030,18 @@ ssl_conf = 234-version-negotiation-ssl
 
 [234-version-negotiation-ssl]
 server = 234-version-negotiation-server
+server2 = 234-version-negotiation-server2
 client = 234-version-negotiation-client
 
 [234-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[234-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -7080,9 +9069,18 @@ ssl_conf = 235-version-negotiation-ssl
 
 [235-version-negotiation-ssl]
 server = 235-version-negotiation-server
+server2 = 235-version-negotiation-server2
 client = 235-version-negotiation-client
 
 [235-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[235-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7110,9 +9108,18 @@ ssl_conf = 236-version-negotiation-ssl
 
 [236-version-negotiation-ssl]
 server = 236-version-negotiation-server
+server2 = 236-version-negotiation-server2
 client = 236-version-negotiation-client
 
 [236-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[236-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7140,9 +9147,17 @@ ssl_conf = 237-version-negotiation-ssl
 
 [237-version-negotiation-ssl]
 server = 237-version-negotiation-server
+server2 = 237-version-negotiation-server2
 client = 237-version-negotiation-client
 
 [237-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[237-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -7169,9 +9184,18 @@ ssl_conf = 238-version-negotiation-ssl
 
 [238-version-negotiation-ssl]
 server = 238-version-negotiation-server
+server2 = 238-version-negotiation-server2
 client = 238-version-negotiation-client
 
 [238-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[238-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -7199,9 +9223,18 @@ ssl_conf = 239-version-negotiation-ssl
 
 [239-version-negotiation-ssl]
 server = 239-version-negotiation-server
+server2 = 239-version-negotiation-server2
 client = 239-version-negotiation-client
 
 [239-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[239-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7229,9 +9262,18 @@ ssl_conf = 240-version-negotiation-ssl
 
 [240-version-negotiation-ssl]
 server = 240-version-negotiation-server
+server2 = 240-version-negotiation-server2
 client = 240-version-negotiation-client
 
 [240-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[240-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7259,9 +9301,17 @@ ssl_conf = 241-version-negotiation-ssl
 
 [241-version-negotiation-ssl]
 server = 241-version-negotiation-server
+server2 = 241-version-negotiation-server2
 client = 241-version-negotiation-client
 
 [241-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[241-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -7288,9 +9338,18 @@ ssl_conf = 242-version-negotiation-ssl
 
 [242-version-negotiation-ssl]
 server = 242-version-negotiation-server
+server2 = 242-version-negotiation-server2
 client = 242-version-negotiation-client
 
 [242-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[242-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7318,9 +9377,18 @@ ssl_conf = 243-version-negotiation-ssl
 
 [243-version-negotiation-ssl]
 server = 243-version-negotiation-server
+server2 = 243-version-negotiation-server2
 client = 243-version-negotiation-client
 
 [243-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[243-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7348,9 +9416,17 @@ ssl_conf = 244-version-negotiation-ssl
 
 [244-version-negotiation-ssl]
 server = 244-version-negotiation-server
+server2 = 244-version-negotiation-server2
 client = 244-version-negotiation-client
 
 [244-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[244-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -7377,9 +9453,18 @@ ssl_conf = 245-version-negotiation-ssl
 
 [245-version-negotiation-ssl]
 server = 245-version-negotiation-server
+server2 = 245-version-negotiation-server2
 client = 245-version-negotiation-client
 
 [245-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[245-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7407,9 +9492,17 @@ ssl_conf = 246-version-negotiation-ssl
 
 [246-version-negotiation-ssl]
 server = 246-version-negotiation-server
+server2 = 246-version-negotiation-server2
 client = 246-version-negotiation-client
 
 [246-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[246-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -7436,9 +9529,17 @@ ssl_conf = 247-version-negotiation-ssl
 
 [247-version-negotiation-ssl]
 server = 247-version-negotiation-server
+server2 = 247-version-negotiation-server2
 client = 247-version-negotiation-client
 
 [247-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[247-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -7463,9 +9564,17 @@ ssl_conf = 248-version-negotiation-ssl
 
 [248-version-negotiation-ssl]
 server = 248-version-negotiation-server
+server2 = 248-version-negotiation-server2
 client = 248-version-negotiation-client
 
 [248-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[248-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -7491,9 +9600,17 @@ ssl_conf = 249-version-negotiation-ssl
 
 [249-version-negotiation-ssl]
 server = 249-version-negotiation-server
+server2 = 249-version-negotiation-server2
 client = 249-version-negotiation-client
 
 [249-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[249-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7519,9 +9636,17 @@ ssl_conf = 250-version-negotiation-ssl
 
 [250-version-negotiation-ssl]
 server = 250-version-negotiation-server
+server2 = 250-version-negotiation-server2
 client = 250-version-negotiation-client
 
 [250-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[250-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7547,9 +9672,16 @@ ssl_conf = 251-version-negotiation-ssl
 
 [251-version-negotiation-ssl]
 server = 251-version-negotiation-server
+server2 = 251-version-negotiation-server2
 client = 251-version-negotiation-client
 
 [251-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[251-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -7574,9 +9706,18 @@ ssl_conf = 252-version-negotiation-ssl
 
 [252-version-negotiation-ssl]
 server = 252-version-negotiation-server
+server2 = 252-version-negotiation-server2
 client = 252-version-negotiation-client
 
 [252-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[252-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -7602,9 +9743,18 @@ ssl_conf = 253-version-negotiation-ssl
 
 [253-version-negotiation-ssl]
 server = 253-version-negotiation-server
+server2 = 253-version-negotiation-server2
 client = 253-version-negotiation-client
 
 [253-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[253-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -7631,9 +9781,18 @@ ssl_conf = 254-version-negotiation-ssl
 
 [254-version-negotiation-ssl]
 server = 254-version-negotiation-server
+server2 = 254-version-negotiation-server2
 client = 254-version-negotiation-client
 
 [254-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[254-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7660,9 +9819,18 @@ ssl_conf = 255-version-negotiation-ssl
 
 [255-version-negotiation-ssl]
 server = 255-version-negotiation-server
+server2 = 255-version-negotiation-server2
 client = 255-version-negotiation-client
 
 [255-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[255-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7689,9 +9857,17 @@ ssl_conf = 256-version-negotiation-ssl
 
 [256-version-negotiation-ssl]
 server = 256-version-negotiation-server
+server2 = 256-version-negotiation-server2
 client = 256-version-negotiation-client
 
 [256-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[256-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -7717,9 +9893,18 @@ ssl_conf = 257-version-negotiation-ssl
 
 [257-version-negotiation-ssl]
 server = 257-version-negotiation-server
+server2 = 257-version-negotiation-server2
 client = 257-version-negotiation-client
 
 [257-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[257-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -7746,9 +9931,18 @@ ssl_conf = 258-version-negotiation-ssl
 
 [258-version-negotiation-ssl]
 server = 258-version-negotiation-server
+server2 = 258-version-negotiation-server2
 client = 258-version-negotiation-client
 
 [258-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[258-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7775,9 +9969,18 @@ ssl_conf = 259-version-negotiation-ssl
 
 [259-version-negotiation-ssl]
 server = 259-version-negotiation-server
+server2 = 259-version-negotiation-server2
 client = 259-version-negotiation-client
 
 [259-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[259-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7804,9 +10007,17 @@ ssl_conf = 260-version-negotiation-ssl
 
 [260-version-negotiation-ssl]
 server = 260-version-negotiation-server
+server2 = 260-version-negotiation-server2
 client = 260-version-negotiation-client
 
 [260-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[260-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -7832,9 +10043,18 @@ ssl_conf = 261-version-negotiation-ssl
 
 [261-version-negotiation-ssl]
 server = 261-version-negotiation-server
+server2 = 261-version-negotiation-server2
 client = 261-version-negotiation-client
 
 [261-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[261-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -7861,9 +10081,18 @@ ssl_conf = 262-version-negotiation-ssl
 
 [262-version-negotiation-ssl]
 server = 262-version-negotiation-server
+server2 = 262-version-negotiation-server2
 client = 262-version-negotiation-client
 
 [262-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[262-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7890,9 +10119,17 @@ ssl_conf = 263-version-negotiation-ssl
 
 [263-version-negotiation-ssl]
 server = 263-version-negotiation-server
+server2 = 263-version-negotiation-server2
 client = 263-version-negotiation-client
 
 [263-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[263-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -7918,9 +10155,18 @@ ssl_conf = 264-version-negotiation-ssl
 
 [264-version-negotiation-ssl]
 server = 264-version-negotiation-server
+server2 = 264-version-negotiation-server2
 client = 264-version-negotiation-client
 
 [264-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[264-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -7947,9 +10193,17 @@ ssl_conf = 265-version-negotiation-ssl
 
 [265-version-negotiation-ssl]
 server = 265-version-negotiation-server
+server2 = 265-version-negotiation-server2
 client = 265-version-negotiation-client
 
 [265-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[265-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -7975,9 +10229,17 @@ ssl_conf = 266-version-negotiation-ssl
 
 [266-version-negotiation-ssl]
 server = 266-version-negotiation-server
+server2 = 266-version-negotiation-server2
 client = 266-version-negotiation-client
 
 [266-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[266-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -8003,9 +10265,17 @@ ssl_conf = 267-version-negotiation-ssl
 
 [267-version-negotiation-ssl]
 server = 267-version-negotiation-server
+server2 = 267-version-negotiation-server2
 client = 267-version-negotiation-client
 
 [267-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[267-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -8031,9 +10301,17 @@ ssl_conf = 268-version-negotiation-ssl
 
 [268-version-negotiation-ssl]
 server = 268-version-negotiation-server
+server2 = 268-version-negotiation-server2
 client = 268-version-negotiation-client
 
 [268-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[268-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8060,9 +10338,17 @@ ssl_conf = 269-version-negotiation-ssl
 
 [269-version-negotiation-ssl]
 server = 269-version-negotiation-server
+server2 = 269-version-negotiation-server2
 client = 269-version-negotiation-client
 
 [269-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[269-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8089,9 +10375,16 @@ ssl_conf = 270-version-negotiation-ssl
 
 [270-version-negotiation-ssl]
 server = 270-version-negotiation-server
+server2 = 270-version-negotiation-server2
 client = 270-version-negotiation-client
 
 [270-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[270-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -8117,9 +10410,18 @@ ssl_conf = 271-version-negotiation-ssl
 
 [271-version-negotiation-ssl]
 server = 271-version-negotiation-server
+server2 = 271-version-negotiation-server2
 client = 271-version-negotiation-client
 
 [271-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[271-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -8146,9 +10448,18 @@ ssl_conf = 272-version-negotiation-ssl
 
 [272-version-negotiation-ssl]
 server = 272-version-negotiation-server
+server2 = 272-version-negotiation-server2
 client = 272-version-negotiation-client
 
 [272-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[272-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -8175,9 +10486,18 @@ ssl_conf = 273-version-negotiation-ssl
 
 [273-version-negotiation-ssl]
 server = 273-version-negotiation-server
+server2 = 273-version-negotiation-server2
 client = 273-version-negotiation-client
 
 [273-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[273-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8205,9 +10525,18 @@ ssl_conf = 274-version-negotiation-ssl
 
 [274-version-negotiation-ssl]
 server = 274-version-negotiation-server
+server2 = 274-version-negotiation-server2
 client = 274-version-negotiation-client
 
 [274-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[274-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8235,9 +10564,17 @@ ssl_conf = 275-version-negotiation-ssl
 
 [275-version-negotiation-ssl]
 server = 275-version-negotiation-server
+server2 = 275-version-negotiation-server2
 client = 275-version-negotiation-client
 
 [275-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[275-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -8264,9 +10601,18 @@ ssl_conf = 276-version-negotiation-ssl
 
 [276-version-negotiation-ssl]
 server = 276-version-negotiation-server
+server2 = 276-version-negotiation-server2
 client = 276-version-negotiation-client
 
 [276-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[276-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -8293,9 +10639,18 @@ ssl_conf = 277-version-negotiation-ssl
 
 [277-version-negotiation-ssl]
 server = 277-version-negotiation-server
+server2 = 277-version-negotiation-server2
 client = 277-version-negotiation-client
 
 [277-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[277-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8323,9 +10678,18 @@ ssl_conf = 278-version-negotiation-ssl
 
 [278-version-negotiation-ssl]
 server = 278-version-negotiation-server
+server2 = 278-version-negotiation-server2
 client = 278-version-negotiation-client
 
 [278-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[278-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8353,9 +10717,17 @@ ssl_conf = 279-version-negotiation-ssl
 
 [279-version-negotiation-ssl]
 server = 279-version-negotiation-server
+server2 = 279-version-negotiation-server2
 client = 279-version-negotiation-client
 
 [279-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[279-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -8382,9 +10754,18 @@ ssl_conf = 280-version-negotiation-ssl
 
 [280-version-negotiation-ssl]
 server = 280-version-negotiation-server
+server2 = 280-version-negotiation-server2
 client = 280-version-negotiation-client
 
 [280-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[280-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8412,9 +10793,18 @@ ssl_conf = 281-version-negotiation-ssl
 
 [281-version-negotiation-ssl]
 server = 281-version-negotiation-server
+server2 = 281-version-negotiation-server2
 client = 281-version-negotiation-client
 
 [281-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[281-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8442,9 +10832,17 @@ ssl_conf = 282-version-negotiation-ssl
 
 [282-version-negotiation-ssl]
 server = 282-version-negotiation-server
+server2 = 282-version-negotiation-server2
 client = 282-version-negotiation-client
 
 [282-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[282-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -8471,9 +10869,18 @@ ssl_conf = 283-version-negotiation-ssl
 
 [283-version-negotiation-ssl]
 server = 283-version-negotiation-server
+server2 = 283-version-negotiation-server2
 client = 283-version-negotiation-client
 
 [283-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[283-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8500,9 +10907,17 @@ ssl_conf = 284-version-negotiation-ssl
 
 [284-version-negotiation-ssl]
 server = 284-version-negotiation-server
+server2 = 284-version-negotiation-server2
 client = 284-version-negotiation-client
 
 [284-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[284-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -8528,9 +10943,17 @@ ssl_conf = 285-version-negotiation-ssl
 
 [285-version-negotiation-ssl]
 server = 285-version-negotiation-server
+server2 = 285-version-negotiation-server2
 client = 285-version-negotiation-client
 
 [285-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[285-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -8556,9 +10979,17 @@ ssl_conf = 286-version-negotiation-ssl
 
 [286-version-negotiation-ssl]
 server = 286-version-negotiation-server
+server2 = 286-version-negotiation-server2
 client = 286-version-negotiation-client
 
 [286-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[286-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -8584,9 +11015,17 @@ ssl_conf = 287-version-negotiation-ssl
 
 [287-version-negotiation-ssl]
 server = 287-version-negotiation-server
+server2 = 287-version-negotiation-server2
 client = 287-version-negotiation-client
 
 [287-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[287-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8613,9 +11052,17 @@ ssl_conf = 288-version-negotiation-ssl
 
 [288-version-negotiation-ssl]
 server = 288-version-negotiation-server
+server2 = 288-version-negotiation-server2
 client = 288-version-negotiation-client
 
 [288-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[288-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8642,9 +11089,16 @@ ssl_conf = 289-version-negotiation-ssl
 
 [289-version-negotiation-ssl]
 server = 289-version-negotiation-server
+server2 = 289-version-negotiation-server2
 client = 289-version-negotiation-client
 
 [289-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[289-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -8670,9 +11124,18 @@ ssl_conf = 290-version-negotiation-ssl
 
 [290-version-negotiation-ssl]
 server = 290-version-negotiation-server
+server2 = 290-version-negotiation-server2
 client = 290-version-negotiation-client
 
 [290-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[290-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -8699,9 +11162,18 @@ ssl_conf = 291-version-negotiation-ssl
 
 [291-version-negotiation-ssl]
 server = 291-version-negotiation-server
+server2 = 291-version-negotiation-server2
 client = 291-version-negotiation-client
 
 [291-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[291-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -8728,9 +11200,18 @@ ssl_conf = 292-version-negotiation-ssl
 
 [292-version-negotiation-ssl]
 server = 292-version-negotiation-server
+server2 = 292-version-negotiation-server2
 client = 292-version-negotiation-client
 
 [292-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[292-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8758,9 +11239,18 @@ ssl_conf = 293-version-negotiation-ssl
 
 [293-version-negotiation-ssl]
 server = 293-version-negotiation-server
+server2 = 293-version-negotiation-server2
 client = 293-version-negotiation-client
 
 [293-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[293-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8788,9 +11278,17 @@ ssl_conf = 294-version-negotiation-ssl
 
 [294-version-negotiation-ssl]
 server = 294-version-negotiation-server
+server2 = 294-version-negotiation-server2
 client = 294-version-negotiation-client
 
 [294-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[294-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -8817,9 +11315,18 @@ ssl_conf = 295-version-negotiation-ssl
 
 [295-version-negotiation-ssl]
 server = 295-version-negotiation-server
+server2 = 295-version-negotiation-server2
 client = 295-version-negotiation-client
 
 [295-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[295-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -8846,9 +11353,18 @@ ssl_conf = 296-version-negotiation-ssl
 
 [296-version-negotiation-ssl]
 server = 296-version-negotiation-server
+server2 = 296-version-negotiation-server2
 client = 296-version-negotiation-client
 
 [296-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[296-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8876,9 +11392,18 @@ ssl_conf = 297-version-negotiation-ssl
 
 [297-version-negotiation-ssl]
 server = 297-version-negotiation-server
+server2 = 297-version-negotiation-server2
 client = 297-version-negotiation-client
 
 [297-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[297-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8906,9 +11431,17 @@ ssl_conf = 298-version-negotiation-ssl
 
 [298-version-negotiation-ssl]
 server = 298-version-negotiation-server
+server2 = 298-version-negotiation-server2
 client = 298-version-negotiation-client
 
 [298-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[298-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -8935,9 +11468,18 @@ ssl_conf = 299-version-negotiation-ssl
 
 [299-version-negotiation-ssl]
 server = 299-version-negotiation-server
+server2 = 299-version-negotiation-server2
 client = 299-version-negotiation-client
 
 [299-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[299-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -8965,9 +11507,18 @@ ssl_conf = 300-version-negotiation-ssl
 
 [300-version-negotiation-ssl]
 server = 300-version-negotiation-server
+server2 = 300-version-negotiation-server2
 client = 300-version-negotiation-client
 
 [300-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[300-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -8995,9 +11546,17 @@ ssl_conf = 301-version-negotiation-ssl
 
 [301-version-negotiation-ssl]
 server = 301-version-negotiation-server
+server2 = 301-version-negotiation-server2
 client = 301-version-negotiation-client
 
 [301-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[301-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -9024,9 +11583,18 @@ ssl_conf = 302-version-negotiation-ssl
 
 [302-version-negotiation-ssl]
 server = 302-version-negotiation-server
+server2 = 302-version-negotiation-server2
 client = 302-version-negotiation-client
 
 [302-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[302-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9054,9 +11622,17 @@ ssl_conf = 303-version-negotiation-ssl
 
 [303-version-negotiation-ssl]
 server = 303-version-negotiation-server
+server2 = 303-version-negotiation-server2
 client = 303-version-negotiation-client
 
 [303-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[303-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -9083,9 +11659,17 @@ ssl_conf = 304-version-negotiation-ssl
 
 [304-version-negotiation-ssl]
 server = 304-version-negotiation-server
+server2 = 304-version-negotiation-server2
 client = 304-version-negotiation-client
 
 [304-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[304-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -9110,9 +11694,17 @@ ssl_conf = 305-version-negotiation-ssl
 
 [305-version-negotiation-ssl]
 server = 305-version-negotiation-server
+server2 = 305-version-negotiation-server2
 client = 305-version-negotiation-client
 
 [305-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[305-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -9137,9 +11729,17 @@ ssl_conf = 306-version-negotiation-ssl
 
 [306-version-negotiation-ssl]
 server = 306-version-negotiation-server
+server2 = 306-version-negotiation-server2
 client = 306-version-negotiation-client
 
 [306-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[306-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9165,9 +11765,17 @@ ssl_conf = 307-version-negotiation-ssl
 
 [307-version-negotiation-ssl]
 server = 307-version-negotiation-server
+server2 = 307-version-negotiation-server2
 client = 307-version-negotiation-client
 
 [307-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[307-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9193,9 +11801,16 @@ ssl_conf = 308-version-negotiation-ssl
 
 [308-version-negotiation-ssl]
 server = 308-version-negotiation-server
+server2 = 308-version-negotiation-server2
 client = 308-version-negotiation-client
 
 [308-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[308-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -9220,9 +11835,18 @@ ssl_conf = 309-version-negotiation-ssl
 
 [309-version-negotiation-ssl]
 server = 309-version-negotiation-server
+server2 = 309-version-negotiation-server2
 client = 309-version-negotiation-client
 
 [309-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[309-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -9248,9 +11872,18 @@ ssl_conf = 310-version-negotiation-ssl
 
 [310-version-negotiation-ssl]
 server = 310-version-negotiation-server
+server2 = 310-version-negotiation-server2
 client = 310-version-negotiation-client
 
 [310-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[310-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -9276,9 +11909,18 @@ ssl_conf = 311-version-negotiation-ssl
 
 [311-version-negotiation-ssl]
 server = 311-version-negotiation-server
+server2 = 311-version-negotiation-server2
 client = 311-version-negotiation-client
 
 [311-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[311-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9305,9 +11947,18 @@ ssl_conf = 312-version-negotiation-ssl
 
 [312-version-negotiation-ssl]
 server = 312-version-negotiation-server
+server2 = 312-version-negotiation-server2
 client = 312-version-negotiation-client
 
 [312-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[312-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9334,9 +11985,17 @@ ssl_conf = 313-version-negotiation-ssl
 
 [313-version-negotiation-ssl]
 server = 313-version-negotiation-server
+server2 = 313-version-negotiation-server2
 client = 313-version-negotiation-client
 
 [313-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[313-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -9362,9 +12021,18 @@ ssl_conf = 314-version-negotiation-ssl
 
 [314-version-negotiation-ssl]
 server = 314-version-negotiation-server
+server2 = 314-version-negotiation-server2
 client = 314-version-negotiation-client
 
 [314-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[314-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -9390,9 +12058,18 @@ ssl_conf = 315-version-negotiation-ssl
 
 [315-version-negotiation-ssl]
 server = 315-version-negotiation-server
+server2 = 315-version-negotiation-server2
 client = 315-version-negotiation-client
 
 [315-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[315-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9419,9 +12096,18 @@ ssl_conf = 316-version-negotiation-ssl
 
 [316-version-negotiation-ssl]
 server = 316-version-negotiation-server
+server2 = 316-version-negotiation-server2
 client = 316-version-negotiation-client
 
 [316-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[316-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9448,9 +12134,17 @@ ssl_conf = 317-version-negotiation-ssl
 
 [317-version-negotiation-ssl]
 server = 317-version-negotiation-server
+server2 = 317-version-negotiation-server2
 client = 317-version-negotiation-client
 
 [317-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[317-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -9476,9 +12170,18 @@ ssl_conf = 318-version-negotiation-ssl
 
 [318-version-negotiation-ssl]
 server = 318-version-negotiation-server
+server2 = 318-version-negotiation-server2
 client = 318-version-negotiation-client
 
 [318-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[318-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9505,9 +12208,18 @@ ssl_conf = 319-version-negotiation-ssl
 
 [319-version-negotiation-ssl]
 server = 319-version-negotiation-server
+server2 = 319-version-negotiation-server2
 client = 319-version-negotiation-client
 
 [319-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[319-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9534,9 +12246,17 @@ ssl_conf = 320-version-negotiation-ssl
 
 [320-version-negotiation-ssl]
 server = 320-version-negotiation-server
+server2 = 320-version-negotiation-server2
 client = 320-version-negotiation-client
 
 [320-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[320-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -9562,9 +12282,18 @@ ssl_conf = 321-version-negotiation-ssl
 
 [321-version-negotiation-ssl]
 server = 321-version-negotiation-server
+server2 = 321-version-negotiation-server2
 client = 321-version-negotiation-client
 
 [321-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[321-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9591,9 +12320,17 @@ ssl_conf = 322-version-negotiation-ssl
 
 [322-version-negotiation-ssl]
 server = 322-version-negotiation-server
+server2 = 322-version-negotiation-server2
 client = 322-version-negotiation-client
 
 [322-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[322-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -9619,9 +12356,17 @@ ssl_conf = 323-version-negotiation-ssl
 
 [323-version-negotiation-ssl]
 server = 323-version-negotiation-server
+server2 = 323-version-negotiation-server2
 client = 323-version-negotiation-client
 
 [323-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[323-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -9647,9 +12392,17 @@ ssl_conf = 324-version-negotiation-ssl
 
 [324-version-negotiation-ssl]
 server = 324-version-negotiation-server
+server2 = 324-version-negotiation-server2
 client = 324-version-negotiation-client
 
 [324-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[324-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -9675,9 +12428,17 @@ ssl_conf = 325-version-negotiation-ssl
 
 [325-version-negotiation-ssl]
 server = 325-version-negotiation-server
+server2 = 325-version-negotiation-server2
 client = 325-version-negotiation-client
 
 [325-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[325-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9703,9 +12464,17 @@ ssl_conf = 326-version-negotiation-ssl
 
 [326-version-negotiation-ssl]
 server = 326-version-negotiation-server
+server2 = 326-version-negotiation-server2
 client = 326-version-negotiation-client
 
 [326-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[326-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9732,9 +12501,16 @@ ssl_conf = 327-version-negotiation-ssl
 
 [327-version-negotiation-ssl]
 server = 327-version-negotiation-server
+server2 = 327-version-negotiation-server2
 client = 327-version-negotiation-client
 
 [327-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[327-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -9760,9 +12536,18 @@ ssl_conf = 328-version-negotiation-ssl
 
 [328-version-negotiation-ssl]
 server = 328-version-negotiation-server
+server2 = 328-version-negotiation-server2
 client = 328-version-negotiation-client
 
 [328-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[328-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -9789,9 +12574,18 @@ ssl_conf = 329-version-negotiation-ssl
 
 [329-version-negotiation-ssl]
 server = 329-version-negotiation-server
+server2 = 329-version-negotiation-server2
 client = 329-version-negotiation-client
 
 [329-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[329-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -9818,9 +12612,18 @@ ssl_conf = 330-version-negotiation-ssl
 
 [330-version-negotiation-ssl]
 server = 330-version-negotiation-server
+server2 = 330-version-negotiation-server2
 client = 330-version-negotiation-client
 
 [330-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[330-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9847,9 +12650,18 @@ ssl_conf = 331-version-negotiation-ssl
 
 [331-version-negotiation-ssl]
 server = 331-version-negotiation-server
+server2 = 331-version-negotiation-server2
 client = 331-version-negotiation-client
 
 [331-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[331-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9877,9 +12689,17 @@ ssl_conf = 332-version-negotiation-ssl
 
 [332-version-negotiation-ssl]
 server = 332-version-negotiation-server
+server2 = 332-version-negotiation-server2
 client = 332-version-negotiation-client
 
 [332-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[332-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -9906,9 +12726,18 @@ ssl_conf = 333-version-negotiation-ssl
 
 [333-version-negotiation-ssl]
 server = 333-version-negotiation-server
+server2 = 333-version-negotiation-server2
 client = 333-version-negotiation-client
 
 [333-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[333-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -9935,9 +12764,18 @@ ssl_conf = 334-version-negotiation-ssl
 
 [334-version-negotiation-ssl]
 server = 334-version-negotiation-server
+server2 = 334-version-negotiation-server2
 client = 334-version-negotiation-client
 
 [334-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[334-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -9964,9 +12802,18 @@ ssl_conf = 335-version-negotiation-ssl
 
 [335-version-negotiation-ssl]
 server = 335-version-negotiation-server
+server2 = 335-version-negotiation-server2
 client = 335-version-negotiation-client
 
 [335-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[335-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -9994,9 +12841,17 @@ ssl_conf = 336-version-negotiation-ssl
 
 [336-version-negotiation-ssl]
 server = 336-version-negotiation-server
+server2 = 336-version-negotiation-server2
 client = 336-version-negotiation-client
 
 [336-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[336-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -10023,9 +12878,18 @@ ssl_conf = 337-version-negotiation-ssl
 
 [337-version-negotiation-ssl]
 server = 337-version-negotiation-server
+server2 = 337-version-negotiation-server2
 client = 337-version-negotiation-client
 
 [337-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[337-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -10052,9 +12916,18 @@ ssl_conf = 338-version-negotiation-ssl
 
 [338-version-negotiation-ssl]
 server = 338-version-negotiation-server
+server2 = 338-version-negotiation-server2
 client = 338-version-negotiation-client
 
 [338-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[338-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10082,9 +12955,17 @@ ssl_conf = 339-version-negotiation-ssl
 
 [339-version-negotiation-ssl]
 server = 339-version-negotiation-server
+server2 = 339-version-negotiation-server2
 client = 339-version-negotiation-client
 
 [339-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[339-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -10111,9 +12992,18 @@ ssl_conf = 340-version-negotiation-ssl
 
 [340-version-negotiation-ssl]
 server = 340-version-negotiation-server
+server2 = 340-version-negotiation-server2
 client = 340-version-negotiation-client
 
 [340-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[340-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10141,9 +13031,17 @@ ssl_conf = 341-version-negotiation-ssl
 
 [341-version-negotiation-ssl]
 server = 341-version-negotiation-server
+server2 = 341-version-negotiation-server2
 client = 341-version-negotiation-client
 
 [341-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[341-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
@@ -10170,9 +13068,17 @@ ssl_conf = 342-version-negotiation-ssl
 
 [342-version-negotiation-ssl]
 server = 342-version-negotiation-server
+server2 = 342-version-negotiation-server2
 client = 342-version-negotiation-client
 
 [342-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[342-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -10197,9 +13103,17 @@ ssl_conf = 343-version-negotiation-ssl
 
 [343-version-negotiation-ssl]
 server = 343-version-negotiation-server
+server2 = 343-version-negotiation-server2
 client = 343-version-negotiation-client
 
 [343-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[343-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -10224,9 +13138,17 @@ ssl_conf = 344-version-negotiation-ssl
 
 [344-version-negotiation-ssl]
 server = 344-version-negotiation-server
+server2 = 344-version-negotiation-server2
 client = 344-version-negotiation-client
 
 [344-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[344-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -10251,9 +13173,17 @@ ssl_conf = 345-version-negotiation-ssl
 
 [345-version-negotiation-ssl]
 server = 345-version-negotiation-server
+server2 = 345-version-negotiation-server2
 client = 345-version-negotiation-client
 
 [345-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[345-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10279,9 +13209,16 @@ ssl_conf = 346-version-negotiation-ssl
 
 [346-version-negotiation-ssl]
 server = 346-version-negotiation-server
+server2 = 346-version-negotiation-server2
 client = 346-version-negotiation-client
 
 [346-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[346-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -10306,9 +13243,18 @@ ssl_conf = 347-version-negotiation-ssl
 
 [347-version-negotiation-ssl]
 server = 347-version-negotiation-server
+server2 = 347-version-negotiation-server2
 client = 347-version-negotiation-client
 
 [347-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = SSLv3
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[347-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
@@ -10334,9 +13280,18 @@ ssl_conf = 348-version-negotiation-ssl
 
 [348-version-negotiation-ssl]
 server = 348-version-negotiation-server
+server2 = 348-version-negotiation-server2
 client = 348-version-negotiation-client
 
 [348-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[348-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -10362,9 +13317,18 @@ ssl_conf = 349-version-negotiation-ssl
 
 [349-version-negotiation-ssl]
 server = 349-version-negotiation-server
+server2 = 349-version-negotiation-server2
 client = 349-version-negotiation-client
 
 [349-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[349-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -10390,9 +13354,18 @@ ssl_conf = 350-version-negotiation-ssl
 
 [350-version-negotiation-ssl]
 server = 350-version-negotiation-server
+server2 = 350-version-negotiation-server2
 client = 350-version-negotiation-client
 
 [350-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[350-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10419,9 +13392,17 @@ ssl_conf = 351-version-negotiation-ssl
 
 [351-version-negotiation-ssl]
 server = 351-version-negotiation-server
+server2 = 351-version-negotiation-server2
 client = 351-version-negotiation-client
 
 [351-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = SSLv3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[351-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = SSLv3
@@ -10447,9 +13428,18 @@ ssl_conf = 352-version-negotiation-ssl
 
 [352-version-negotiation-ssl]
 server = 352-version-negotiation-server
+server2 = 352-version-negotiation-server2
 client = 352-version-negotiation-client
 
 [352-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[352-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -10475,9 +13465,18 @@ ssl_conf = 353-version-negotiation-ssl
 
 [353-version-negotiation-ssl]
 server = 353-version-negotiation-server
+server2 = 353-version-negotiation-server2
 client = 353-version-negotiation-client
 
 [353-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[353-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -10503,9 +13502,18 @@ ssl_conf = 354-version-negotiation-ssl
 
 [354-version-negotiation-ssl]
 server = 354-version-negotiation-server
+server2 = 354-version-negotiation-server2
 client = 354-version-negotiation-client
 
 [354-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[354-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10532,9 +13540,17 @@ ssl_conf = 355-version-negotiation-ssl
 
 [355-version-negotiation-ssl]
 server = 355-version-negotiation-server
+server2 = 355-version-negotiation-server2
 client = 355-version-negotiation-client
 
 [355-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[355-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1
@@ -10560,9 +13576,18 @@ ssl_conf = 356-version-negotiation-ssl
 
 [356-version-negotiation-ssl]
 server = 356-version-negotiation-server
+server2 = 356-version-negotiation-server2
 client = 356-version-negotiation-client
 
 [356-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[356-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -10588,9 +13613,18 @@ ssl_conf = 357-version-negotiation-ssl
 
 [357-version-negotiation-ssl]
 server = 357-version-negotiation-server
+server2 = 357-version-negotiation-server2
 client = 357-version-negotiation-client
 
 [357-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[357-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10617,9 +13651,17 @@ ssl_conf = 358-version-negotiation-ssl
 
 [358-version-negotiation-ssl]
 server = 358-version-negotiation-server
+server2 = 358-version-negotiation-server2
 client = 358-version-negotiation-client
 
 [358-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[358-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
@@ -10645,9 +13687,18 @@ ssl_conf = 359-version-negotiation-ssl
 
 [359-version-negotiation-ssl]
 server = 359-version-negotiation-server
+server2 = 359-version-negotiation-server2
 client = 359-version-negotiation-client
 
 [359-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[359-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -10674,9 +13725,17 @@ ssl_conf = 360-version-negotiation-ssl
 
 [360-version-negotiation-ssl]
 server = 360-version-negotiation-server
+server2 = 360-version-negotiation-server2
 client = 360-version-negotiation-client
 
 [360-version-negotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[360-version-negotiation-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MinProtocol = TLSv1.2

--- a/test/ssl-tests/03-custom_verify.conf
+++ b/test/ssl-tests/03-custom_verify.conf
@@ -18,9 +18,16 @@ ssl_conf = 0-verify-success-ssl
 
 [0-verify-success-ssl]
 server = 0-verify-success-server
+server2 = 0-verify-success-server2
 client = 0-verify-success-client
 
 [0-verify-success-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-verify-success-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -43,9 +50,16 @@ ssl_conf = 1-verify-custom-reject-ssl
 
 [1-verify-custom-reject-ssl]
 server = 1-verify-custom-reject-server
+server2 = 1-verify-custom-reject-server2
 client = 1-verify-custom-reject-client
 
 [1-verify-custom-reject-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-verify-custom-reject-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -70,9 +84,16 @@ ssl_conf = 2-verify-custom-allow-ssl
 
 [2-verify-custom-allow-ssl]
 server = 2-verify-custom-allow-server
+server2 = 2-verify-custom-allow-server2
 client = 2-verify-custom-allow-client
 
 [2-verify-custom-allow-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[2-verify-custom-allow-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -96,9 +117,16 @@ ssl_conf = 3-noverify-success-ssl
 
 [3-noverify-success-ssl]
 server = 3-noverify-success-server
+server2 = 3-noverify-success-server2
 client = 3-noverify-success-client
 
 [3-noverify-success-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[3-noverify-success-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -119,9 +147,16 @@ ssl_conf = 4-noverify-ignore-custom-reject-ssl
 
 [4-noverify-ignore-custom-reject-ssl]
 server = 4-noverify-ignore-custom-reject-server
+server2 = 4-noverify-ignore-custom-reject-server2
 client = 4-noverify-ignore-custom-reject-client
 
 [4-noverify-ignore-custom-reject-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[4-noverify-ignore-custom-reject-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -143,9 +178,16 @@ ssl_conf = 5-noverify-accept-custom-allow-ssl
 
 [5-noverify-accept-custom-allow-ssl]
 server = 5-noverify-accept-custom-allow-server
+server2 = 5-noverify-accept-custom-allow-server2
 client = 5-noverify-accept-custom-allow-client
 
 [5-noverify-accept-custom-allow-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[5-noverify-accept-custom-allow-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -167,9 +209,16 @@ ssl_conf = 6-verify-fail-no-root-ssl
 
 [6-verify-fail-no-root-ssl]
 server = 6-verify-fail-no-root-server
+server2 = 6-verify-fail-no-root-server2
 client = 6-verify-fail-no-root-client
 
 [6-verify-fail-no-root-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[6-verify-fail-no-root-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -192,9 +241,16 @@ ssl_conf = 7-verify-custom-success-no-root-ssl
 
 [7-verify-custom-success-no-root-ssl]
 server = 7-verify-custom-success-no-root-server
+server2 = 7-verify-custom-success-no-root-server2
 client = 7-verify-custom-success-no-root-client
 
 [7-verify-custom-success-no-root-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[7-verify-custom-success-no-root-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -217,9 +273,16 @@ ssl_conf = 8-verify-custom-fail-no-root-ssl
 
 [8-verify-custom-fail-no-root-ssl]
 server = 8-verify-custom-fail-no-root-server
+server2 = 8-verify-custom-fail-no-root-server2
 client = 8-verify-custom-fail-no-root-client
 
 [8-verify-custom-fail-no-root-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[8-verify-custom-fail-no-root-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem

--- a/test/ssl-tests/04-client_auth.conf
+++ b/test/ssl-tests/04-client_auth.conf
@@ -29,9 +29,16 @@ ssl_conf = 0-server-auth-flex-ssl
 
 [0-server-auth-flex-ssl]
 server = 0-server-auth-flex-server
+server2 = 0-server-auth-flex-server2
 client = 0-server-auth-flex-client
 
 [0-server-auth-flex-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-server-auth-flex-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -54,9 +61,17 @@ ssl_conf = 1-client-auth-flex-request-ssl
 
 [1-client-auth-flex-request-ssl]
 server = 1-client-auth-flex-request-server
+server2 = 1-client-auth-flex-request-server2
 client = 1-client-auth-flex-request-client
 
 [1-client-auth-flex-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Request
+
+
+[1-client-auth-flex-request-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -80,9 +95,18 @@ ssl_conf = 2-client-auth-flex-require-fail-ssl
 
 [2-client-auth-flex-require-fail-ssl]
 server = 2-client-auth-flex-require-fail-server
+server2 = 2-client-auth-flex-require-fail-server2
 client = 2-client-auth-flex-require-fail-client
 
 [2-client-auth-flex-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+
+[2-client-auth-flex-require-fail-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -108,9 +132,18 @@ ssl_conf = 3-client-auth-flex-require-ssl
 
 [3-client-auth-flex-require-ssl]
 server = 3-client-auth-flex-require-server
+server2 = 3-client-auth-flex-require-server2
 client = 3-client-auth-flex-require-client
 
 [3-client-auth-flex-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+
+[3-client-auth-flex-require-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -137,9 +170,17 @@ ssl_conf = 4-client-auth-flex-noroot-ssl
 
 [4-client-auth-flex-noroot-ssl]
 server = 4-client-auth-flex-noroot-server
+server2 = 4-client-auth-flex-noroot-server2
 client = 4-client-auth-flex-noroot-client
 
 [4-client-auth-flex-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+
+[4-client-auth-flex-noroot-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -166,9 +207,17 @@ ssl_conf = 5-server-auth-TLSv1-ssl
 
 [5-server-auth-TLSv1-ssl]
 server = 5-server-auth-TLSv1-server
+server2 = 5-server-auth-TLSv1-server2
 client = 5-server-auth-TLSv1-client
 
 [5-server-auth-TLSv1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1
+
+
+[5-server-auth-TLSv1-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -193,9 +242,18 @@ ssl_conf = 6-client-auth-TLSv1-request-ssl
 
 [6-client-auth-TLSv1-request-ssl]
 server = 6-client-auth-TLSv1-request-server
+server2 = 6-client-auth-TLSv1-request-server2
 client = 6-client-auth-TLSv1-request-client
 
 [6-client-auth-TLSv1-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1
+VerifyMode = Request
+
+
+[6-client-auth-TLSv1-request-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -221,9 +279,19 @@ ssl_conf = 7-client-auth-TLSv1-require-fail-ssl
 
 [7-client-auth-TLSv1-require-fail-ssl]
 server = 7-client-auth-TLSv1-require-fail-server
+server2 = 7-client-auth-TLSv1-require-fail-server2
 client = 7-client-auth-TLSv1-require-fail-client
 
 [7-client-auth-TLSv1-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+
+[7-client-auth-TLSv1-require-fail-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -251,9 +319,19 @@ ssl_conf = 8-client-auth-TLSv1-require-ssl
 
 [8-client-auth-TLSv1-require-ssl]
 server = 8-client-auth-TLSv1-require-server
+server2 = 8-client-auth-TLSv1-require-server2
 client = 8-client-auth-TLSv1-require-client
 
 [8-client-auth-TLSv1-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+
+[8-client-auth-TLSv1-require-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -282,9 +360,18 @@ ssl_conf = 9-client-auth-TLSv1-noroot-ssl
 
 [9-client-auth-TLSv1-noroot-ssl]
 server = 9-client-auth-TLSv1-noroot-server
+server2 = 9-client-auth-TLSv1-noroot-server2
 client = 9-client-auth-TLSv1-noroot-client
 
 [9-client-auth-TLSv1-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1
+VerifyMode = Require
+
+
+[9-client-auth-TLSv1-noroot-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -313,9 +400,17 @@ ssl_conf = 10-server-auth-TLSv1.1-ssl
 
 [10-server-auth-TLSv1.1-ssl]
 server = 10-server-auth-TLSv1.1-server
+server2 = 10-server-auth-TLSv1.1-server2
 client = 10-server-auth-TLSv1.1-client
 
 [10-server-auth-TLSv1.1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.1
+
+
+[10-server-auth-TLSv1.1-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -340,9 +435,18 @@ ssl_conf = 11-client-auth-TLSv1.1-request-ssl
 
 [11-client-auth-TLSv1.1-request-ssl]
 server = 11-client-auth-TLSv1.1-request-server
+server2 = 11-client-auth-TLSv1.1-request-server2
 client = 11-client-auth-TLSv1.1-request-client
 
 [11-client-auth-TLSv1.1-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.1
+VerifyMode = Request
+
+
+[11-client-auth-TLSv1.1-request-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -368,9 +472,19 @@ ssl_conf = 12-client-auth-TLSv1.1-require-fail-ssl
 
 [12-client-auth-TLSv1.1-require-fail-ssl]
 server = 12-client-auth-TLSv1.1-require-fail-server
+server2 = 12-client-auth-TLSv1.1-require-fail-server2
 client = 12-client-auth-TLSv1.1-require-fail-client
 
 [12-client-auth-TLSv1.1-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+
+[12-client-auth-TLSv1.1-require-fail-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -398,9 +512,19 @@ ssl_conf = 13-client-auth-TLSv1.1-require-ssl
 
 [13-client-auth-TLSv1.1-require-ssl]
 server = 13-client-auth-TLSv1.1-require-server
+server2 = 13-client-auth-TLSv1.1-require-server2
 client = 13-client-auth-TLSv1.1-require-client
 
 [13-client-auth-TLSv1.1-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+
+[13-client-auth-TLSv1.1-require-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -429,9 +553,18 @@ ssl_conf = 14-client-auth-TLSv1.1-noroot-ssl
 
 [14-client-auth-TLSv1.1-noroot-ssl]
 server = 14-client-auth-TLSv1.1-noroot-server
+server2 = 14-client-auth-TLSv1.1-noroot-server2
 client = 14-client-auth-TLSv1.1-noroot-client
 
 [14-client-auth-TLSv1.1-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.1
+VerifyMode = Require
+
+
+[14-client-auth-TLSv1.1-noroot-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -460,9 +593,17 @@ ssl_conf = 15-server-auth-TLSv1.2-ssl
 
 [15-server-auth-TLSv1.2-ssl]
 server = 15-server-auth-TLSv1.2-server
+server2 = 15-server-auth-TLSv1.2-server2
 client = 15-server-auth-TLSv1.2-client
 
 [15-server-auth-TLSv1.2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.2
+
+
+[15-server-auth-TLSv1.2-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -487,9 +628,18 @@ ssl_conf = 16-client-auth-TLSv1.2-request-ssl
 
 [16-client-auth-TLSv1.2-request-ssl]
 server = 16-client-auth-TLSv1.2-request-server
+server2 = 16-client-auth-TLSv1.2-request-server2
 client = 16-client-auth-TLSv1.2-request-client
 
 [16-client-auth-TLSv1.2-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.2
+VerifyMode = Request
+
+
+[16-client-auth-TLSv1.2-request-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -515,9 +665,19 @@ ssl_conf = 17-client-auth-TLSv1.2-require-fail-ssl
 
 [17-client-auth-TLSv1.2-require-fail-ssl]
 server = 17-client-auth-TLSv1.2-require-fail-server
+server2 = 17-client-auth-TLSv1.2-require-fail-server2
 client = 17-client-auth-TLSv1.2-require-fail-client
 
 [17-client-auth-TLSv1.2-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+
+[17-client-auth-TLSv1.2-require-fail-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -545,9 +705,19 @@ ssl_conf = 18-client-auth-TLSv1.2-require-ssl
 
 [18-client-auth-TLSv1.2-require-ssl]
 server = 18-client-auth-TLSv1.2-require-server
+server2 = 18-client-auth-TLSv1.2-require-server2
 client = 18-client-auth-TLSv1.2-require-client
 
 [18-client-auth-TLSv1.2-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+
+[18-client-auth-TLSv1.2-require-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -576,9 +746,18 @@ ssl_conf = 19-client-auth-TLSv1.2-noroot-ssl
 
 [19-client-auth-TLSv1.2-noroot-ssl]
 server = 19-client-auth-TLSv1.2-noroot-server
+server2 = 19-client-auth-TLSv1.2-noroot-server2
 client = 19-client-auth-TLSv1.2-noroot-client
 
 [19-client-auth-TLSv1.2-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+Protocol = TLSv1.2
+VerifyMode = Require
+
+
+[19-client-auth-TLSv1.2-noroot-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem

--- a/test/ssl-tests/05-sni.conf
+++ b/test/ssl-tests/05-sni.conf
@@ -1,0 +1,38 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 1
+
+test-0 = 0-SNI-default
+# ===========================================================
+
+[0-SNI-default]
+ssl_conf = 0-SNI-default-ssl
+
+[0-SNI-default-ssl]
+server = 0-SNI-default-server
+server2 = 0-SNI-default-server2
+client = 0-SNI-default-client
+
+[0-SNI-default-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-SNI-default-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-SNI-default-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-0]
+ExpectedResult = Success
+ServerName = server2
+
+

--- a/test/ssl-tests/05-sni.conf.in
+++ b/test/ssl-tests/05-sni.conf.in
@@ -1,0 +1,25 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## SSL test configurations
+
+use strict;
+use warnings;
+
+package ssltests;
+
+our @tests = (
+    {
+        name => "SNI-default",
+        server => { },
+        client => { },
+        test   => { "ServerName" => "server2",
+		    "ExpectedResult" => "Success" },
+    },
+);

--- a/test/ssl-tests/06-sni-ticket.conf
+++ b/test/ssl-tests/06-sni-ticket.conf
@@ -1,0 +1,650 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 17
+
+test-0 = 0-sni-session-ticket
+test-1 = 1-sni-session-ticket
+test-2 = 2-sni-session-ticket
+test-3 = 3-sni-session-ticket
+test-4 = 4-sni-session-ticket
+test-5 = 5-sni-session-ticket
+test-6 = 6-sni-session-ticket
+test-7 = 7-sni-session-ticket
+test-8 = 8-sni-session-ticket
+test-9 = 9-sni-session-ticket
+test-10 = 10-sni-session-ticket
+test-11 = 11-sni-session-ticket
+test-12 = 12-sni-session-ticket
+test-13 = 13-sni-session-ticket
+test-14 = 14-sni-session-ticket
+test-15 = 15-sni-session-ticket
+test-16 = 16-sni-session-ticket
+# ===========================================================
+
+[0-sni-session-ticket]
+ssl_conf = 0-sni-session-ticket-ssl
+
+[0-sni-session-ticket-ssl]
+server = 0-sni-session-ticket-server
+server2 = 0-sni-session-ticket-server2
+client = 0-sni-session-ticket-client
+
+[0-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[0-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-0]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = Broken
+
+
+# ===========================================================
+
+[1-sni-session-ticket]
+ssl_conf = 1-sni-session-ticket-ssl
+
+[1-sni-session-ticket-ssl]
+server = 1-sni-session-ticket-server
+server2 = 1-sni-session-ticket-server2
+client = 1-sni-session-ticket-client
+
+[1-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[1-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-1]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = Yes
+
+
+# ===========================================================
+
+[2-sni-session-ticket]
+ssl_conf = 2-sni-session-ticket-ssl
+
+[2-sni-session-ticket-ssl]
+server = 2-sni-session-ticket-server
+server2 = 2-sni-session-ticket-server2
+client = 2-sni-session-ticket-client
+
+[2-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[2-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[2-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-2]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = Yes
+
+
+# ===========================================================
+
+[3-sni-session-ticket]
+ssl_conf = 3-sni-session-ticket-ssl
+
+[3-sni-session-ticket-ssl]
+server = 3-sni-session-ticket-server
+server2 = 3-sni-session-ticket-server2
+client = 3-sni-session-ticket-client
+
+[3-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[3-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[3-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-3]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = Yes
+
+
+# ===========================================================
+
+[4-sni-session-ticket]
+ssl_conf = 4-sni-session-ticket-ssl
+
+[4-sni-session-ticket-ssl]
+server = 4-sni-session-ticket-server
+server2 = 4-sni-session-ticket-server2
+client = 4-sni-session-ticket-client
+
+[4-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[4-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[4-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-4]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[5-sni-session-ticket]
+ssl_conf = 5-sni-session-ticket-ssl
+
+[5-sni-session-ticket-ssl]
+server = 5-sni-session-ticket-server
+server2 = 5-sni-session-ticket-server2
+client = 5-sni-session-ticket-client
+
+[5-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[5-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[5-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-5]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[6-sni-session-ticket]
+ssl_conf = 6-sni-session-ticket-ssl
+
+[6-sni-session-ticket-ssl]
+server = 6-sni-session-ticket-server
+server2 = 6-sni-session-ticket-server2
+client = 6-sni-session-ticket-client
+
+[6-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[6-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[6-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-6]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[7-sni-session-ticket]
+ssl_conf = 7-sni-session-ticket-ssl
+
+[7-sni-session-ticket-ssl]
+server = 7-sni-session-ticket-server
+server2 = 7-sni-session-ticket-server2
+client = 7-sni-session-ticket-client
+
+[7-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[7-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[7-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-7]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[8-sni-session-ticket]
+ssl_conf = 8-sni-session-ticket-ssl
+
+[8-sni-session-ticket-ssl]
+server = 8-sni-session-ticket-server
+server2 = 8-sni-session-ticket-server2
+client = 8-sni-session-ticket-client
+
+[8-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[8-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[8-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-8]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[9-sni-session-ticket]
+ssl_conf = 9-sni-session-ticket-ssl
+
+[9-sni-session-ticket-ssl]
+server = 9-sni-session-ticket-server
+server2 = 9-sni-session-ticket-server2
+client = 9-sni-session-ticket-client
+
+[9-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[9-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[9-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-9]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[10-sni-session-ticket]
+ssl_conf = 10-sni-session-ticket-ssl
+
+[10-sni-session-ticket-ssl]
+server = 10-sni-session-ticket-server
+server2 = 10-sni-session-ticket-server2
+client = 10-sni-session-ticket-client
+
+[10-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[10-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[10-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-10]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[11-sni-session-ticket]
+ssl_conf = 11-sni-session-ticket-ssl
+
+[11-sni-session-ticket-ssl]
+server = 11-sni-session-ticket-server
+server2 = 11-sni-session-ticket-server2
+client = 11-sni-session-ticket-client
+
+[11-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[11-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[11-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-11]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[12-sni-session-ticket]
+ssl_conf = 12-sni-session-ticket-ssl
+
+[12-sni-session-ticket-ssl]
+server = 12-sni-session-ticket-server
+server2 = 12-sni-session-ticket-server2
+client = 12-sni-session-ticket-client
+
+[12-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[12-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[12-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-12]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[13-sni-session-ticket]
+ssl_conf = 13-sni-session-ticket-ssl
+
+[13-sni-session-ticket-ssl]
+server = 13-sni-session-ticket-server
+server2 = 13-sni-session-ticket-server2
+client = 13-sni-session-ticket-client
+
+[13-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[13-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[13-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-13]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[14-sni-session-ticket]
+ssl_conf = 14-sni-session-ticket-ssl
+
+[14-sni-session-ticket-ssl]
+server = 14-sni-session-ticket-server
+server2 = 14-sni-session-ticket-server2
+client = 14-sni-session-ticket-client
+
+[14-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[14-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[14-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-14]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[15-sni-session-ticket]
+ssl_conf = 15-sni-session-ticket-ssl
+
+[15-sni-session-ticket-ssl]
+server = 15-sni-session-ticket-server
+server2 = 15-sni-session-ticket-server2
+client = 15-sni-session-ticket-client
+
+[15-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[15-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[15-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-15]
+ExpectedResult = Success
+ServerName = server1
+SessionTicketExpected = No
+
+
+# ===========================================================
+
+[16-sni-session-ticket]
+ssl_conf = 16-sni-session-ticket-ssl
+
+[16-sni-session-ticket-ssl]
+server = 16-sni-session-ticket-server
+server2 = 16-sni-session-ticket-server2
+client = 16-sni-session-ticket-client
+
+[16-sni-session-ticket-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[16-sni-session-ticket-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+
+[16-sni-session-ticket-client]
+CipherString = DEFAULT
+Options = -SessionTicket
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+
+[test-16]
+ExpectedResult = Success
+ServerName = server2
+SessionTicketExpected = No
+
+

--- a/test/ssl-tests/06-sni-ticket.conf.in
+++ b/test/ssl-tests/06-sni-ticket.conf.in
@@ -1,0 +1,83 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## Test version negotiation
+
+use strict;
+use warnings;
+
+package ssltests;
+
+
+our @tests = ();
+
+sub generate_tests() {
+    foreach my $c ("SessionTicket", "-SessionTicket") {
+	foreach my $s1 ("SessionTicket", "-SessionTicket") {
+	    foreach my $s2 ("SessionTicket", "-SessionTicket") {
+		foreach my $n ("server1", "server2") {
+		    my $result = expected_result($c, $s1, $s2, $n);
+                    push @tests, {
+                        "name" => "sni-session-ticket",
+                        "client" => {
+                            "Options" => $c,
+                        },
+                        "server" => {
+                            "Options" => $s1,
+                        },
+			"server2" => {
+			    "Options" => $s2,
+			},
+                        "test" => {
+                            "ServerName" => $n,
+                            "ExpectedResult" => "Success",
+			    "SessionTicketExpected" => $result,
+                        }
+                    };
+                }
+            }
+        }
+    }
+}
+
+# If the client has session tickets disabled, then No support
+# If the server initial_ctx has session tickets disabled, then No support
+# If SNI is in use, then if the "switched-to" context has session tickets disabled,
+#    then No support
+sub expected_result {
+    my ($c, $s1, $s2, $n) = @_;
+
+    return "No" if $c eq "-SessionTicket";
+    return "No" if $s1 eq "-SessionTicket";
+    return "No" if ($s2 eq "-SessionTicket" && $n eq "server2");
+
+    return "Yes";
+
+}
+
+# Add a "Broken" case.
+push @tests, {
+    "name" => "sni-session-ticket",
+    "client" => {
+	"Options" => "SessionTicket",
+    },
+    "server" => {
+	"Options" => "SessionTicket",
+    },
+    "server2" => {
+	"Options" => "SessionTicket",
+    },
+    "test" => {
+	"ServerName" => "server1",
+	"ExpectedResult" => "Success",
+	"SessionTicketExpected" => "Broken",
+    }
+};
+
+generate_tests();

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include <openssl/conf.h>
 #include <openssl/err.h>
@@ -122,6 +123,33 @@ static int check_protocol(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
     return 1;
 }
 
+static int check_servername(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
+{
+    if (result.servername != test_ctx->servername) {
+        fprintf(stderr, "Client ServerName mismatch, expected %s, got %s\n.",
+                ssl_servername_name(test_ctx->servername),
+                ssl_servername_name(result.servername));
+        return 0;
+    }
+    return 1;
+}
+
+static int check_session_ticket_expected(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
+{
+    if (test_ctx->session_ticket_expected == SSL_TEST_SESSION_TICKET_IGNORE)
+        return 1;
+    if (test_ctx->session_ticket_expected == SSL_TEST_SESSION_TICKET_BROKEN &&
+        result.session_ticket == SSL_TEST_SESSION_TICKET_NO)
+        return 1;
+    if (result.session_ticket != test_ctx->session_ticket_expected) {
+        fprintf(stderr, "Client SessionTicketExpected mismatch, expected %s, got %s\n.",
+                ssl_session_ticket_expected_name(test_ctx->session_ticket_expected),
+                ssl_session_ticket_expected_name(result.session_ticket));
+        return 0;
+    }
+    return 1;
+}
+
 /*
  * This could be further simplified by constructing an expected
  * HANDSHAKE_RESULT, and implementing comparison methods for
@@ -132,28 +160,61 @@ static int check_test(HANDSHAKE_RESULT result, SSL_TEST_CTX *test_ctx)
     int ret = 1;
     ret &= check_result(result, test_ctx);
     ret &= check_alerts(result, test_ctx);
-    if (result.result == SSL_TEST_SUCCESS)
+    if (result.result == SSL_TEST_SUCCESS) {
         ret &= check_protocol(result, test_ctx);
+        ret &= check_servername(result, test_ctx);
+        ret &= check_session_ticket_expected(result, test_ctx);
+        ret &= (result.session_ticket_do_not_call == 0);
+    }
     return ret;
+}
+
+static int servername_callback(SSL *s, int *ad, void *arg)
+{
+    const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+    if (servername != NULL && !strcmp(servername, "server2")) {
+        SSL_CTX *new_ctx = (SSL_CTX*)arg;
+        SSL_set_SSL_CTX(s, new_ctx);
+        /*
+         * Copy over all the SSL_CTX options - reasonable behavior
+         * allows testing of cases where the options between two
+         * contexts differ/conflict
+         */
+        SSL_clear_options(s, 0xFFFFFFFFL);
+        SSL_set_options(s, SSL_CTX_get_options(new_ctx));
+    }
+    return SSL_TLSEXT_ERR_OK;
 }
 
 static int execute_test(SSL_TEST_FIXTURE fixture)
 {
     int ret = 0;
-    SSL_CTX *server_ctx = NULL, *client_ctx = NULL;
+    SSL_CTX *server_ctx = NULL, *server2_ctx = NULL, *client_ctx = NULL;
     SSL_TEST_CTX *test_ctx = NULL;
     HANDSHAKE_RESULT result;
 
     server_ctx = SSL_CTX_new(TLS_server_method());
+    server2_ctx = SSL_CTX_new(TLS_server_method());
     client_ctx = SSL_CTX_new(TLS_client_method());
-    OPENSSL_assert(server_ctx != NULL && client_ctx != NULL);
+    OPENSSL_assert(server_ctx != NULL && server2_ctx != NULL && client_ctx != NULL);
 
     OPENSSL_assert(CONF_modules_load(conf, fixture.test_app, 0) > 0);
 
     if (!SSL_CTX_config(server_ctx, "server")
-       || !SSL_CTX_config(client_ctx, "client")) {
+        || !SSL_CTX_config(server2_ctx, "server2")
+        || !SSL_CTX_config(client_ctx, "client")) {
         goto err;
     }
+
+    /* link the two contexts for SNI purposes */
+    SSL_CTX_set_tlsext_servername_callback(server_ctx, servername_callback);
+    SSL_CTX_set_tlsext_servername_arg(server_ctx, server2_ctx);
+    /*
+     * The initial_ctx/session_ctx always handles the encrypt/decrypt of the
+     * session ticket. This ticket_key callback is assigned to the second
+     * session (assigned via SNI), and should never be invoked
+     */
+    SSL_CTX_set_tlsext_ticket_key_cb(server2_ctx, do_not_call_session_ticket_callback);
 
     test_ctx = SSL_TEST_CTX_create(conf, fixture.test_app);
     if (test_ctx == NULL)
@@ -166,6 +227,7 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
 err:
     CONF_modules_unload(0);
     SSL_CTX_free(server_ctx);
+    SSL_CTX_free(server2_ctx);
     SSL_CTX_free(client_ctx);
     SSL_TEST_CTX_free(test_ctx);
     if (ret != 1)

--- a/test/ssl_test.tmpl
+++ b/test/ssl_test.tmpl
@@ -3,12 +3,20 @@ ssl_conf = {-$testname-}-ssl
 
 [{-$testname-}-ssl]
 server = {-$testname-}-server
+server2 = {-$testname-}-server2
 client = {-$testname-}-client
 
 [{-$testname-}-server]
 {-
     foreach my $key (sort keys %server) {
         $OUT .= qq{$key} . " = " . qq{$server{$key}\n} if defined $server{$key};
+    }
+-}
+
+[{-$testname-}-server2]
+{-
+    foreach my $key (sort keys %server2) {
+        $OUT .= qq{$key} . " = " . qq{$server2{$key}\n} if defined $server2{$key};
     }
 -}
 

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -154,6 +154,62 @@ const char *ssl_verify_callback_name(ssl_verify_callback_t callback)
                      callback);
 }
 
+/**************/
+/* ServerName */
+/**************/
+
+static const test_enum ssl_servername[] = {
+    {"server1", SSL_TEST_SERVERNAME_SERVER1},
+    {"server2", SSL_TEST_SERVERNAME_SERVER2},
+};
+
+__owur static int parse_servername(SSL_TEST_CTX *test_ctx,
+                                   const char *value)
+{
+    int ret_value;
+    if (!parse_enum(ssl_servername, OSSL_NELEM(ssl_servername),
+                    &ret_value, value)) {
+        return 0;
+    }
+    test_ctx->servername = ret_value;
+    return 1;
+}
+
+const char *ssl_servername_name(ssl_servername_t server)
+{
+    return enum_name(ssl_servername, OSSL_NELEM(ssl_servername),
+                     server);
+}
+
+/*************************/
+/* SessionTicketExpected */
+/*************************/
+
+static const test_enum ssl_session_ticket_expected[] = {
+    {"Ignore", SSL_TEST_SESSION_TICKET_IGNORE},
+    {"Yes", SSL_TEST_SESSION_TICKET_YES},
+    {"No", SSL_TEST_SESSION_TICKET_NO},
+    {"Broken", SSL_TEST_SESSION_TICKET_BROKEN},
+};
+
+__owur static int parse_session_ticket_expected(SSL_TEST_CTX *test_ctx,
+                                                const char *value)
+{
+    int ret_value;
+    if (!parse_enum(ssl_session_ticket_expected, OSSL_NELEM(ssl_session_ticket_expected),
+                    &ret_value, value)) {
+        return 0;
+    }
+    test_ctx->session_ticket_expected = ret_value;
+    return 1;
+}
+
+const char *ssl_session_ticket_expected_name(ssl_session_ticket_expected_t server)
+{
+    return enum_name(ssl_session_ticket_expected,
+                     OSSL_NELEM(ssl_session_ticket_expected),
+                     server);
+}
 
 /*************************************************************/
 /* Known test options and their corresponding parse methods. */
@@ -170,6 +226,8 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ServerAlert", &parse_server_alert },
     { "Protocol", &parse_protocol },
     { "ClientVerifyCallback", &parse_client_verify_callback },
+    { "ServerName", &parse_servername },
+    { "SessionTicketExpected", &parse_session_ticket_expected },
 };
 
 

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -26,6 +26,18 @@ typedef enum {
     SSL_TEST_VERIFY_REJECT_ALL
 } ssl_verify_callback_t;
 
+typedef enum {
+    SSL_TEST_SERVERNAME_SERVER1 = 0, /* Default */
+    SSL_TEST_SERVERNAME_SERVER2
+} ssl_servername_t;
+
+typedef enum {
+    SSL_TEST_SESSION_TICKET_IGNORE = 0, /* Default */
+    SSL_TEST_SESSION_TICKET_YES,
+    SSL_TEST_SESSION_TICKET_NO,
+    SSL_TEST_SESSION_TICKET_BROKEN, /* Special test */
+} ssl_session_ticket_expected_t;
+
 typedef struct ssl_test_ctx {
     /* Test expectations. */
     /* Defaults to SUCCESS. */
@@ -41,12 +53,17 @@ typedef struct ssl_test_ctx {
     int protocol;
     /* One of a number of predefined custom callbacks. */
     ssl_verify_callback_t client_verify_callback;
+    /* One of a number of predefined server names use by the client */
+    ssl_servername_t servername;
+    ssl_session_ticket_expected_t session_ticket_expected;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);
 const char *ssl_alert_name(int alert);
 const char *ssl_protocol_name(int protocol);
 const char *ssl_verify_callback_name(ssl_verify_callback_t verify_callback);
+const char *ssl_servername_name(ssl_servername_t server);
+const char *ssl_session_ticket_expected_name(ssl_session_ticket_expected_t server);
 
 /*
  * Load the test case context from |conf|.

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -64,6 +64,18 @@ static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
                 ssl_verify_callback_name(ctx2->client_verify_callback));
         return 0;
     }
+    if (ctx->servername != ctx2->servername) {
+        fprintf(stderr, "ServerName mismatch: %s vs %s.\n",
+                ssl_servername_name(ctx->servername),
+                ssl_servername_name(ctx2->servername));
+        return 0;
+    }
+    if (ctx->session_ticket_expected != ctx2->session_ticket_expected) {
+        fprintf(stderr, "SessionTicketExpected mismatch: %s vs %s.\n",
+                ssl_session_ticket_expected_name(ctx->session_ticket_expected),
+                ssl_session_ticket_expected_name(ctx2->session_ticket_expected));
+        return 0;
+    }
 
     return 1;
 }
@@ -141,7 +153,9 @@ static int test_good_configuration()
     fixture.expected_ctx->client_alert = SSL_AD_UNKNOWN_CA;
     fixture.expected_ctx->server_alert = 0;  /* No alert. */
     fixture.expected_ctx->protocol = TLS1_1_VERSION;
-    fixture.expected_ctx->client_verify_callback = SSL_TEST_VERIFY_REJECT_ALL,
+    fixture.expected_ctx->client_verify_callback = SSL_TEST_VERIFY_REJECT_ALL;
+    fixture.expected_ctx->servername = SSL_TEST_SERVERNAME_SERVER2;
+    fixture.expected_ctx->session_ticket_expected = SSL_TEST_SESSION_TICKET_YES;
     EXECUTE_SSL_TEST_CTX_TEST();
 }
 
@@ -151,6 +165,8 @@ static const char *bad_configurations[] = {
     "ssltest_unknown_alert",
     "ssltest_unknown_protocol",
     "ssltest_unknown_verify_callback",
+    "ssltest_unknown_servername",
+    "ssltest_unknown_session_ticket_expected",
 };
 
 static int test_bad_configuration(int idx)

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -5,6 +5,8 @@ ExpectedResult = ServerFail
 ClientAlert = UnknownCA
 Protocol = TLSv1.1
 ClientVerifyCallback = RejectAll
+ServerName = server2
+SessionTicketExpected = Yes
 
 [ssltest_unknown_option]
 UnknownOption = Foo
@@ -20,3 +22,9 @@ Protocol = Foo
 
 [ssltest_unknown_verify_callback]
 ClientVerifyCallback = Foo
+
+[ssltest_unknown_servername]
+ServerName = Foo
+
+[ssltest_unknown_session_ticket_expected]
+SessionTicketExpected = Foo


### PR DESCRIPTION
When session tickets are used, it's possible that SNI might swtich the
SSL_CTX on an SSL. Normally, this is not a problem, because the
initial_ctx/session_ctx are used for all session ticket/id processes.

However, when the SNI callback occurs, it's possible that the callback
may update the options in the SSL from the SSL_CTX, and this could
cause SSL_OP_NO_TICKET to be set. If this occurs, then two bad things
can happen:

1. The session ticket TLSEXT may not be written when the ticket expected
flag is set. The state machine transistions to writing the ticket, and
the client responds with an error as its not expecting a ticket.
2. When creating the session ticket, if the ticket key cb returns 0
the crypto/hmac contexts are not initialized, and the code crashes when
trying to encrypt the session ticket.

To fix 1, if the ticket TLSEXT is not written out, clear the expected
ticket flag.
To fix 2, consider a return of 0 from the ticket key cb a recoverable
error, and write a 0 length ticket and continue. The client-side code
can explicitly handle this case.

Fix these two cases, and add unit test code to validate ticket behavior.