### PR TITLE
Fix build with no-nextprotoneg

### DIFF
--- a/ssl/t1_ext.c
+++ b/ssl/t1_ext.c
@@ -275,7 +275,9 @@ int SSL_extension_supported(unsigned int ext_type)
     case TLSEXT_TYPE_ec_point_formats:
     case TLSEXT_TYPE_elliptic_curves:
     case TLSEXT_TYPE_heartbeat:
+# ifndef OPENSSL_NO_NEXTPROTONEG
     case TLSEXT_TYPE_next_proto_neg:
+# endif
     case TLSEXT_TYPE_padding:
     case TLSEXT_TYPE_renegotiate:
     case TLSEXT_TYPE_server_name:


### PR DESCRIPTION
Add a missing ifdef. Same change is already present in master.
Would be nice if 1.0.2 can also be built with no-nextprotoneg.