### PR TITLE
Fix fmtstr for BIO_printf() et al

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -386,8 +386,6 @@ fmtstr(char **sbuffer,
         value = "<NULL>";
 
     strln = OPENSSL_strnlen(value, max < 0 ? SIZE_MAX : (size_t)max);
-    if (max >= 0 && strln > (size_t)max)
-        strln = (size_t)max;
 
     padlen = min - strln;
     if (min < 0 || padlen < 0)

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -385,11 +385,9 @@ fmtstr(char **sbuffer,
     if (value == 0)
         value = "<NULL>";
 
-    strln = OPENSSL_strnlen(value, max < 0 ? SIZE_MAX : max);
-    if (strln > INT_MAX)
-        strln = INT_MAX;
-    if (max >= 0 && strln > max)
-        strln = max;
+    strln = OPENSSL_strnlen(value, max < 0 ? SIZE_MAX : (size_t)max);
+    if (max >= 0 && strln > (size_t)max)
+        strln = (size_t)max;
 
     padlen = min - strln;
     if (min < 0 || padlen < 0)

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <limits.h>
+#include "internal/numbers.h"
 #include "internal/cryptlib.h"
 #ifndef NO_SYS_TYPES_H
 # include <sys/types.h>
@@ -385,7 +385,7 @@ fmtstr(char **sbuffer,
     if (value == 0)
         value = "<NULL>";
 
-    strln = strlen(value);
+    strln = OPENSSL_strnlen(value, max < 0 ? SIZE_MAX : max);
     if (strln > INT_MAX)
         strln = INT_MAX;
     if (max >= 0 && strln > max)

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -388,25 +388,29 @@ fmtstr(char **sbuffer,
     strln = strlen(value);
     if (strln > INT_MAX)
         strln = INT_MAX;
+    if (max >= 0 && strln > max)
+        strln = max;
 
     padlen = min - strln;
     if (min < 0 || padlen < 0)
         padlen = 0;
+    if (max >= 0)
+        max += padlen;      /* The maximum output including padding */
     if (flags & DP_F_MINUS)
         padlen = -padlen;
 
-    while ((padlen > 0) && (cnt < max)) {
+    while ((padlen > 0) && (max < 0 || cnt < max)) {
         if(!doapr_outch(sbuffer, buffer, currlen, maxlen, ' '))
             return 0;
         --padlen;
         ++cnt;
     }
-    while (*value && (cnt < max)) {
+    while (*value && (max < 0 || cnt < max)) {
         if(!doapr_outch(sbuffer, buffer, currlen, maxlen, *value++))
             return 0;
         ++cnt;
     }
-    while ((padlen < 0) && (cnt < max)) {
+    while ((padlen < 0) && (max < 0 || cnt < max)) {
         if(!doapr_outch(sbuffer, buffer, currlen, maxlen, ' '))
             return 0;
         ++padlen;

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -405,9 +405,10 @@ fmtstr(char **sbuffer,
         --padlen;
         ++cnt;
     }
-    while (*value && (max < 0 || cnt < max)) {
+    while (strln > 0 && (max < 0 || cnt < max)) {
         if(!doapr_outch(sbuffer, buffer, currlen, maxlen, *value++))
             return 0;
+        --strln;
         ++cnt;
     }
     while ((padlen < 0) && (max < 0 || cnt < max)) {


### PR DESCRIPTION
-   If we have a maximum amount of characters permitted to be printed
  (for example "%.2s", which allows for a maximum of 2 chars), we
  minimize the number of characters from the string to printed to
  that size.
-   If there is space for padding and there is a maximum amount of
  characters to print (for example "%3.2s", which shall give at
  least a 1 space padding), the amount of characters to pad with
  gets added to the maximum so the minimum field size (3 in this
  example) gets filled out.
