### PR TITLE
Add buf-freelists to deprecated options

### DIFF
--- a/Configure
+++ b/Configure
@@ -356,6 +356,7 @@ foreach my $proto ((@tls, @dtls))
 
 my @deprecated_disablables = (
     "ssl2",
+    "buf-freelists",
     );
 
 # All of the following is disabled by default (RC5 was enabled before 0.9.8):


### PR DESCRIPTION
The buf-freelists option was removed in master. There may be some
things that try to disable it, so don't error out.