### PR TITLE
Fix installed scripts as well as their installation

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -439,9 +439,7 @@ check_INSTALLTOP :
 # Developer targets ##################################################
 
 debug_logicals :
-        SH LOGICAL/PROC openssl,internal,ossl_installroot
-        IF "$(DESTDIR)" .EQS. "" THEN -
-                SH LOGICAL/PROC ossl_dataroot
+        SH LOGICAL/PROC openssl,internal,ossl_installroot,ossl_dataroot
 
 # Building targets ###################################################
 

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -348,7 +348,8 @@ install_runtime : check_INSTALLTOP
         @ ! Install scripts
         - CREATE/DIR ossl_installroot:[EXE]
         COPY/PROT=W:RE [.APPS]CA.pl ossl_installroot:[EXE]
-        COPY/PROT=W:RE [.TOOLS]c_rehash. ossl_installroot:[EXE]c_rehash.pl
+        COPY/PROT=W:RE [.APPS]tsget.pl ossl_installroot:[EXE]
+        COPY/PROT=W:RE [.TOOLS]c_rehash.pl ossl_installroot:[EXE]
         @ ! {- output_on() if $disabled{apps}; "" -}
         @ ! Install configuration file
         - CREATE/DIR ossl_dataroot:[000000]

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -113,6 +113,10 @@ DEPS={- our @deps = map { (my $x = $_) =~ s|\.o$|\$(DEP_EXT)|; $x; }
                     keys %{$unified_info{sources}};
         join(", ", map { "-\n\t".$_ } @deps); -}
 {- output_on() if $disabled{makedepend}; "" -}
+{- output_off() if $disabled{apps}; "" -}
+BIN_SCRIPTS=[.tools]c_rehash.pl
+MISC_SCRIPTS=[.apps]CA.pl, [.apps]tsget.pl
+{- output_on() if $disabled{apps}; "" -}
 
 # DESTDIR is for package builders so that they can configure for, say,
 # SYS$COMMON:[OPENSSL] and yet have everything installed in STAGING:[USER].
@@ -347,9 +351,7 @@ install_runtime : check_INSTALLTOP
         COPY/PROT=W:RE [.APPS]openssl.EXE ossl_installroot:[EXE.'arch']
         @ ! Install scripts
         - CREATE/DIR ossl_installroot:[EXE]
-        COPY/PROT=W:RE [.APPS]CA.pl ossl_installroot:[EXE]
-        COPY/PROT=W:RE [.APPS]tsget.pl ossl_installroot:[EXE]
-        COPY/PROT=W:RE [.TOOLS]c_rehash.pl ossl_installroot:[EXE]
+        COPY/PROT=W:RE $(BIN_SCRIPTS) ossl_installroot:[EXE]
         @ ! {- output_on() if $disabled{apps}; "" -}
         @ ! Install configuration file
         - CREATE/DIR ossl_dataroot:[000000]
@@ -371,6 +373,8 @@ install_config : [.VMS]openssl_startup.com [.VMS]openssl_shutdown.com -
                 CREATE/DIR/PROT=(S:RWED,O:RWE,G:RE,W:RE) OSSL_DATAROOT:[CERTS]
         IF F$SEARCH("OSSL_DATAROOT:[000000]PRIVATE.DIR;1") .EQS. "" THEN -
                 CREATE/DIR/PROT=(S:RWED,O:RWE,G,W) OSSL_DATAROOT:[PRIVATE]
+        IF F$SEARCH("OSSL_DATAROOT:[000000]MISC.DIR;1") .EQS. "" THEN -
+                CREATE/DIR/PROT=(S:RWED,O:RWE,G,W) OSSL_DATAROOT:[MISC]
         - CREATE/DIR ossl_installroot:[SYS$STARTUP]
         COPY/PROT=W:RE -
                 [.VMS]openssl_startup.com,openssl_shutdown.com -
@@ -378,6 +382,7 @@ install_config : [.VMS]openssl_startup.com [.VMS]openssl_shutdown.com -
         COPY/PROT=W:RE -
                 {- sourcefile("VMS", "openssl_utils.com") -} -
                 ossl_installroot:[SYS$STARTUP]
+        COPY/PROT=W:RE $(MISC_SCRIPTS) OSSL_DATAROOT:[MISC]
 
 [.VMS]openssl_startup.com : vmsconfig.pm {- sourcefile("VMS", "openssl_startup.com.in") -}
         - CREATE/DIR [.VMS]

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -67,6 +67,10 @@ PROGRAMS={- join(" ", map { $_.$exeext } grep { !m|^test\\| } @{$unified_info{pr
 PROGRAMPDBS={- join(" ", map { $_.".pdb" } grep { !m|^test\\| } @{$unified_info{programs}}) -}
 TESTPROGS={- join(" ", map { $_.$exeext } grep { m|^test\\| } @{$unified_info{programs}}) -}
 SCRIPTS={- join(" ", @{$unified_info{scripts}}) -}
+{- output_off() if $disabled{apps}; "" -}
+BIN_SCRIPTS=$(BLDDIR)\tools\c_rehash.pl
+MISC_SCRIPTS=$(BLDDIR)\apps\CA.pl $(BLDDIR)\apps\tsget.pl
+{- output_on() if $disabled{apps}; "" -}
 
 {- output_off() if $disabled{makedepend}; "" -}
 DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
@@ -197,8 +201,11 @@ uninstall_docs:
 install_ssldirs:
 	@$(PERL) $(SRCDIR)\util\mkdir-p.pl "$(DESTDIR)$(OPENSSLDIR)\certs"
 	@$(PERL) $(SRCDIR)\util\mkdir-p.pl "$(DESTDIR)$(OPENSSLDIR)\private"
+	@$(PERL) $(SRCDIR)\util\mkdir-p.pl "$(DESTDIR)$(OPENSSLDIR)\misc"
 	@$(PERL) $(SRCDIR)\util\copy.pl $(SRCDIR)\apps\openssl.cnf \
                                        "$(DESTDIR)$(OPENSSLDIR)"
+	@$(PERL) $(SRCDIR)\util\copy.pl $(MISC_SCRIPTS) \
+                                        "$(DESTDIR)$(OPENSSLDIR)\misc"
 
 install_dev:
 	@if "$(INSTALLTOP)"=="" ( echo INSTALLTOP should not be empty & exit 1 )
@@ -241,9 +248,7 @@ install_runtime:
                                         "$(DESTDIR)$(INSTALLTOP)\bin"
 	@$(PERL) $(SRCDIR)\util\copy.pl $(PROGRAMPDBS) \
                                         "$(DESTDIR)$(INSTALLTOP)\bin"
-	@$(PERL) $(SRCDIR)\util\copy.pl $(SCRIPTS) \
-                                        "$(DESTDIR)$(INSTALLTOP)\bin"
-	@$(PERL) $(SRCDIR)\util\copy.pl tools\c_rehash.pl \
+	@$(PERL) $(SRCDIR)\util\copy.pl $(BIN_SCRIPTS) \
                                         "$(DESTDIR)$(INSTALLTOP)\bin"
 
 uninstall_runtime:

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -241,6 +241,10 @@ install_runtime:
                                         "$(DESTDIR)$(INSTALLTOP)\bin"
 	@$(PERL) $(SRCDIR)\util\copy.pl $(PROGRAMPDBS) \
                                         "$(DESTDIR)$(INSTALLTOP)\bin"
+	@$(PERL) $(SRCDIR)\util\copy.pl $(SCRIPTS) \
+                                        "$(DESTDIR)$(INSTALLTOP)\bin"
+	@$(PERL) $(SRCDIR)\util\copy.pl tools\c_rehash.pl \
+                                        "$(DESTDIR)$(INSTALLTOP)\bin"
 
 uninstall_runtime:
 

--- a/VMS/openssl_utils.com
+++ b/VMS/openssl_utils.com
@@ -5,8 +5,7 @@ $	OPENSSL		:== $OSSL$EXE:OPENSSL
 $
 $	IF F$SYMBOL(PERL) .EQS. "STRING"
 $	THEN
-$	    OSSLCA	:== 'PERL' OSSL$EXE:CA.pl
-$	    OSSLREHASH	:== 'PERL' OSSL$EXE:c_rehash.pl
+$	    C_REHASH	:== 'PERL' OSSL$EXE:c_rehash.pl
 $	ELSE
-$	    WRITE SYS$ERROR "NOTE: no perl => no OSSLCA or OSSLREHASH"
+$	    WRITE SYS$ERROR "NOTE: no perl => no C_REHASH"
 $	ENDIF

--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -23,7 +23,7 @@ if(defined $ENV{'OPENSSL'}) {
 
 my $verbose = 1;
 
-my $OPENSSL_CONFIG = $ENV{"OPENSSL_CONFIG"};
+my $OPENSSL_CONFIG = $ENV{"OPENSSL_CONFIG"} || "";
 my $DAYS = "-days 365";
 my $CADAYS = "-days 1095";	# 3 years
 my $REQ = "$openssl req $OPENSSL_CONFIG";
@@ -45,7 +45,7 @@ my $NEWREQ = "newreq.pem";
 my $NEWCERT = "newcert.pem";
 my $NEWP12 = "newcert.p12";
 my $RET = 0;
-my $WHAT = shift @ARGV;
+my $WHAT = shift @ARGV || "";
 my $FILE;
 
 # See if reason for a CRL entry is valid; exit if not.

--- a/apps/build.info
+++ b/apps/build.info
@@ -1,4 +1,6 @@
-{- use File::Spec::Functions qw/catdir rel2abs/; -}
+{- use File::Spec::Functions qw/catdir rel2abs/;
+   our $tsget_name = $config{target} =~ /^(VC|vms)-/ ? "tsget.pl" : "tsget";
+   "" -}
 IF[{- !$disabled{apps} -}]
   PROGRAMS=openssl
   SOURCE[openssl]=\
@@ -15,7 +17,7 @@ IF[{- !$disabled{apps} -}]
   INCLUDE[openssl]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
   DEPEND[openssl]=../libssl
 
-  SCRIPTS=CA.pl tsget
+  SCRIPTS=CA.pl {- $tsget_name -}
   SOURCE[CA.pl]=CA.pl.in
-  SOURCE[tsget]=tsget.in
+  SOURCE[{- $tsget_name -}]=tsget.in
 ENDIF

--- a/tools/build.info
+++ b/tools/build.info
@@ -1,4 +1,7 @@
+{- our $c_rehash_name =
+       $config{target} =~ /^(VC|vms)-/ ? "c_rehash.pl" : "c_rehash";
+   "" -}
 IF[{- !$disabled{apps} -}]
-  SCRIPTS=c_rehash
-  SOURCE[c_rehash]=c_rehash.in
+  SCRIPTS={- $c_rehash_name -}
+  SOURCE[{- $c_rehash_name -}]=c_rehash.in
 ENDIF


### PR DESCRIPTION
The c_rehash script and a few others were installed differently on VMS and Windows compared to Unix.  This change rectifies that as well as correcting CA.pl slightly and some surrounding support scripts

This stems from issue #1105 
