### PR TITLE
Clean up RAND_bytes() calls

### DIFF
--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -44,13 +44,8 @@ static int bnrand(int pseudorand, BIGNUM *rnd, int bits, int top, int bottom)
     time(&tim);
     RAND_add(&tim, sizeof(tim), 0.0);
 
-    if (pseudorand) {
-        if (RAND_bytes(buf, bytes) <= 0)
-            goto err;
-    } else {
-        if (RAND_bytes(buf, bytes) <= 0)
-            goto err;
-    }
+    if (RAND_bytes(buf, bytes) <= 0)
+        goto err;
 
     if (pseudorand == 2) {
         /*


### PR DESCRIPTION
When RAND_pseudo_bytes() was replaced with RAND_bytes(), this case
was not reduced to a simple RAND_bytes() call.