### PR TITLE
Fix braces in e_aes.c: aes_init_key

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1027,7 +1027,7 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 
     mode = EVP_CIPHER_CTX_mode(ctx);
     if ((mode == EVP_CIPH_ECB_MODE || mode == EVP_CIPH_CBC_MODE)
-        && !enc)
+        && !enc) {
 #ifdef HWAES_CAPABLE
         if (HWAES_CAPABLE) {
             ret = HWAES_set_decrypt_key(key,
@@ -1066,6 +1066,7 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             dat->block = (block128_f) AES_decrypt;
             dat->stream.cbc = mode == EVP_CIPH_CBC_MODE ?
                 (cbc128_f) AES_cbc_encrypt : NULL;
+        }
     } else
 #ifdef HWAES_CAPABLE
     if (HWAES_CAPABLE) {


### PR DESCRIPTION
This compiled correctly, but depending on what may be defined, it's
possible that this could fail compilation. The braces are mismatched,
and it's possible to end up with an else followed by another else.

This presumes the indentation is mostly correct and indicative of
intent. Found via static analysis.