### PR TITLE
Handle the case when file names in build.info files may have spaces

### DIFF
--- a/Configure
+++ b/Configure
@@ -1418,47 +1418,47 @@ if ($builder eq "unified") {
             => sub { die "ENDIF out of scope" if ! @skip;
                      pop @skip; },
             qr/^\s*PROGRAMS\s*=\s*(.*)\s*$/
-            => sub { push @programs, split(/\s+/, $1)
+            => sub { push @programs, tokenize($1)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*LIBS\s*=\s*(.*)\s*$/
-            => sub { push @libraries, split(/\s+/, $1)
+            => sub { push @libraries, tokenize($1)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*ENGINES\s*=\s*(.*)\s*$/
-            => sub { push @engines, split(/\s+/, $1)
+            => sub { push @engines, tokenize($1)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SCRIPTS\s*=\s*(.*)\s*$/
-            => sub { push @scripts, split(/\s+/, $1)
+            => sub { push @scripts, tokenize($1)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*EXTRA\s*=\s*(.*)\s*$/
-            => sub { push @extra, split(/\s+/, $1)
+            => sub { push @extra, tokenize($1)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*OVERRIDES\s*=\s*(.*)\s*$/
-            => sub { push @overrides, split(/\s+/, $1)
+            => sub { push @overrides, tokenize($1)
                          if !@skip || $skip[$#skip] > 0 },
 
             qr/^\s*ORDINALS\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/,
-            => sub { push @{$ordinals{$1}}, split(/\s+/, $2)
+            => sub { push @{$ordinals{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SOURCE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$sources{$1}}, split(/\s+/, $2)
+            => sub { push @{$sources{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SHARED_SOURCE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$shared_sources{$1}}, split(/\s+/, $2)
+            => sub { push @{$shared_sources{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*INCLUDE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$includes{$1}}, split(/\s+/, $2)
+            => sub { push @{$includes{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*DEPEND\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$depends{$1}}, split(/\s+/, $2)
+            => sub { push @{$depends{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*GENERATE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
             => sub { push @{$generate{$1}}, $2
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*RENAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$renames{$1}}, split(/\s+/, $2)
+            => sub { push @{$renames{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SHARED_NAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$sharednames{$1}}, split(/\s+/, $2)
+            => sub { push @{$sharednames{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*BEGINRAW\[((?:\\.|[^\\\]])+)\]\s*$/
             => sub {
@@ -2568,4 +2568,42 @@ sub collect_information {
             $collectors{"AFTER"}->($_);
         }
     }
+}
+
+# tokenize($line)
+# $line is a line of text to split up into tokens
+# returns a list of tokens
+#
+# Tokens are divided by spaces.  If the tokens include spaces, they
+# have to be quoted with single or double quotes.  Double quotes
+# inside a double quoted token must be escaped.  Escaping is done
+# with backslash.
+# Basically, the same quoting rules apply for " and ' as in any
+# Unix shell.
+sub tokenize {
+    my $line = my $debug_line = shift;
+    my @result = ();
+
+    while ($line =~ s|^\s+||, $line ne "") {
+        my $token = "";
+        while ($line ne "" && $line !~ m|^\s|) {
+            if ($line =~ m/^"((?:[^"\\]+|\\.)*)"/) {
+                $token .= $1;
+                $line = $';
+            } elsif ($line =~ m/^'([^']*)'/) {
+                $token .= $1;
+                $line = $';
+            } elsif ($line =~ m/^(\S+)/) {
+                $token .= $1;
+                $line = $';
+            }
+        }
+        push @result, $token;
+    }
+
+    if ($ENV{CONFIGURE_DEBUG_TOKENIZE}) {
+	print STDERR "DEBUG[tokenize]: Parsed '$debug_line' into:\n";
+	print STDERR "DEBUG[tokenize]: ('", join("', '", @result), "')\n";
+    }
+    return @result;
 }

--- a/apps/build.info
+++ b/apps/build.info
@@ -14,7 +14,7 @@ IF[{- !$disabled{apps} -}]
           apps.c opt.c s_cb.c s_socket.c \
           app_rand.c \
           {- $target{apps_aux_src} -}
-  INCLUDE[openssl]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[openssl]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[openssl]=../libssl
 
   SCRIPTS=CA.pl {- $tsget_name -}

--- a/build.info
+++ b/build.info
@@ -2,8 +2,8 @@
 LIBS=libcrypto libssl
 ORDINALS[libcrypto]=crypto
 ORDINALS[libssl]=ssl
-INCLUDE[libcrypto]={- rel2abs(catdir($builddir,"include")) -} . crypto/include include
-INCLUDE[libssl]={- rel2abs(catdir($builddir,"include")) -} . include
+INCLUDE[libcrypto]="{- rel2abs(catdir($builddir,"include")) -}" . crypto/include include
+INCLUDE[libssl]="{- rel2abs(catdir($builddir,"include")) -}" . include
 DEPEND[libssl]=libcrypto
 
 IF[{- $config{target} =~ /^Cygwin/ -}]

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -7,7 +7,7 @@ SOURCE[../../libcrypto]=\
         {- $target{bn_asm_src} -} \
         bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c \
         bn_depr.c bn_const.c bn_x931p.c bn_intern.c bn_dh.c bn_srp.c
-INCLUDE[../../libcrypto]={- rel2abs(catdir($builddir,"..","..","crypto","include")) -}
+INCLUDE[../../libcrypto]="{- rel2abs(catdir($builddir,"..","..","crypto","include")) -}"
 
 INCLUDE[bn_exp.o]=..
 

--- a/engines/afalg/build.info
+++ b/engines/afalg/build.info
@@ -9,7 +9,7 @@ IF[{- !$disabled{"engine"} -}]
       ENGINES=afalg
       SOURCE[afalg]=e_afalg.c e_afalg_err.c
       DEPEND[afalg]=../../libcrypto
-      INCLUDE[afalg]= {- rel2abs(catdir($builddir,"../../include")) -} ../../include
+      INCLUDE[afalg]= "{- rel2abs(catdir($builddir,"../../include")) -}" ../../include
     ENDIF
   ENDIF
 ENDIF

--- a/engines/build.info
+++ b/engines/build.info
@@ -12,19 +12,19 @@ IF[{- !$disabled{"engine"} -}]
     ENGINES=padlock dasync ossltest
     SOURCE[padlock]=e_padlock.c {- $target{padlock_asm_src} -}
     DEPEND[padlock]=../libcrypto
-    INCLUDE[padlock]={- rel2abs(catdir($builddir,"../include")) -} ../include
+    INCLUDE[padlock]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
     IF[{- !$disabled{capieng} -}]
       ENGINES=capi
       SOURCE[capi]=e_capi.c
       DEPEND[capi]=../libcrypto
-      INCLUDE[capi]={- rel2abs(catdir($builddir,"../include")) -} ../include
+      INCLUDE[capi]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
     ENDIF
     SOURCE[dasync]=e_dasync.c
     DEPEND[dasync]=../libcrypto
-    INCLUDE[dasync]={- rel2abs(catdir($builddir,"../include")) -} ../include
+    INCLUDE[dasync]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
     SOURCE[ossltest]=e_ossltest.c
     DEPEND[ossltest]=../libcrypto
-    INCLUDE[ossltest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+    INCLUDE[ossltest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   ENDIF
 
   GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)

--- a/test/build.info
+++ b/test/build.info
@@ -19,234 +19,234 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest
 
   SOURCE[aborttest]=aborttest.c
-  INCLUDE[aborttest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[aborttest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[aborttest]=../libcrypto
 
   SOURCE[nptest]=nptest.c
-  INCLUDE[nptest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[nptest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[nptest]=../libcrypto
 
   SOURCE[bntest]=bntest.c
-  INCLUDE[bntest]={- rel2abs(catdir($builddir,"../crypto/include")) -} {- rel2abs(catdir($builddir,"../include")) -} .. ../crypto/include ../include
+  INCLUDE[bntest]="{- rel2abs(catdir($builddir,"../crypto/include")) -}" "{- rel2abs(catdir($builddir,"../include")) -}" .. ../crypto/include ../include
   DEPEND[bntest]=../libcrypto
 
   SOURCE[ectest]=ectest.c
-  INCLUDE[ectest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[ectest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[ectest]=../libcrypto
 
   SOURCE[ecdsatest]=ecdsatest.c
-  INCLUDE[ecdsatest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[ecdsatest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[ecdsatest]=../libcrypto
 
   SOURCE[ecdhtest]=ecdhtest.c
-  INCLUDE[ecdhtest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[ecdhtest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[ecdhtest]=../libcrypto
 
   SOURCE[gmdifftest]=gmdifftest.c
-  INCLUDE[gmdifftest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[gmdifftest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[gmdifftest]=../libcrypto
 
   SOURCE[pbelutest]=pbelutest.c
-  INCLUDE[pbelutest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[pbelutest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[pbelutest]=../libcrypto
 
   SOURCE[ideatest]=ideatest.c
-  INCLUDE[ideatest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[ideatest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[ideatest]=../libcrypto
 
   SOURCE[md2test]=md2test.c
-  INCLUDE[md2test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[md2test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[md2test]=../libcrypto
 
   SOURCE[md4test]=md4test.c
-  INCLUDE[md4test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[md4test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[md4test]=../libcrypto
 
   SOURCE[md5test]=md5test.c
-  INCLUDE[md5test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[md5test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[md5test]=../libcrypto
 
   SOURCE[hmactest]=hmactest.c
-  INCLUDE[hmactest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[hmactest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[hmactest]=../libcrypto
 
   SOURCE[wp_test]=wp_test.c
-  INCLUDE[wp_test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[wp_test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[wp_test]=../libcrypto
 
   SOURCE[rc2test]=rc2test.c
-  INCLUDE[rc2test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[rc2test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[rc2test]=../libcrypto
 
   SOURCE[rc4test]=rc4test.c
-  INCLUDE[rc4test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[rc4test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[rc4test]=../libcrypto
 
   SOURCE[rc5test]=rc5test.c
-  INCLUDE[rc5test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[rc5test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[rc5test]=../libcrypto
 
   SOURCE[destest]=destest.c
-  INCLUDE[destest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[destest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[destest]=../libcrypto
 
   SOURCE[sha1test]=sha1test.c
-  INCLUDE[sha1test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[sha1test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[sha1test]=../libcrypto
 
   SOURCE[sha256t]=sha256t.c
-  INCLUDE[sha256t]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[sha256t]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[sha256t]=../libcrypto
 
   SOURCE[sha512t]=sha512t.c
-  INCLUDE[sha512t]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[sha512t]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[sha512t]=../libcrypto
 
   SOURCE[mdc2test]=mdc2test.c
-  INCLUDE[mdc2test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[mdc2test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[mdc2test]=../libcrypto
 
   SOURCE[rmdtest]=rmdtest.c
-  INCLUDE[rmdtest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[rmdtest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[rmdtest]=../libcrypto
 
   SOURCE[randtest]=randtest.c
-  INCLUDE[randtest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[randtest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[randtest]=../libcrypto
 
   SOURCE[dhtest]=dhtest.c
-  INCLUDE[dhtest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[dhtest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[dhtest]=../libcrypto
 
   SOURCE[enginetest]=enginetest.c
-  INCLUDE[enginetest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[enginetest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[enginetest]=../libcrypto
 
   SOURCE[casttest]=casttest.c
-  INCLUDE[casttest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[casttest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[casttest]=../libcrypto
 
   SOURCE[bftest]=bftest.c
-  INCLUDE[bftest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[bftest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[bftest]=../libcrypto
 
   SOURCE[ssltest_old]=ssltest_old.c
-  INCLUDE[ssltest_old]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[ssltest_old]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[ssltest_old]=../libcrypto ../libssl
 
   SOURCE[dsatest]=dsatest.c
-  INCLUDE[dsatest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[dsatest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[dsatest]=../libcrypto
 
   SOURCE[exptest]=exptest.c
-  INCLUDE[exptest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[exptest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[exptest]=../libcrypto
 
   SOURCE[rsa_test]=rsa_test.c
-  INCLUDE[rsa_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[rsa_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[rsa_test]=../libcrypto
 
   SOURCE[evp_test]=evp_test.c
-  INCLUDE[evp_test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[evp_test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[evp_test]=../libcrypto
 
   SOURCE[evp_extra_test]=evp_extra_test.c
-  INCLUDE[evp_extra_test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[evp_extra_test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[evp_extra_test]=../libcrypto
 
   SOURCE[igetest]=igetest.c
-  INCLUDE[igetest]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[igetest]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[igetest]=../libcrypto
 
   SOURCE[v3nametest]=v3nametest.c
-  INCLUDE[v3nametest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[v3nametest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[v3nametest]=../libcrypto
 
   SOURCE[danetest]=danetest.c
-  INCLUDE[danetest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[danetest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[danetest]=../libcrypto ../libssl
 
   SOURCE[heartbeat_test]=heartbeat_test.c testutil.c
-  INCLUDE[heartbeat_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[heartbeat_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[heartbeat_test]=../libcrypto ../libssl
 
   SOURCE[p5_crpt2_test]=p5_crpt2_test.c
-  INCLUDE[p5_crpt2_test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[p5_crpt2_test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[p5_crpt2_test]=../libcrypto
 
   SOURCE[constant_time_test]=constant_time_test.c
-  INCLUDE[constant_time_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[constant_time_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[constant_time_test]=../libcrypto
 
   SOURCE[verify_extra_test]=verify_extra_test.c
-  INCLUDE[verify_extra_test]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[verify_extra_test]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[verify_extra_test]=../libcrypto
 
   SOURCE[clienthellotest]=clienthellotest.c
-  INCLUDE[clienthellotest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[clienthellotest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[clienthellotest]=../libcrypto ../libssl
 
   SOURCE[packettest]=packettest.c
-  INCLUDE[packettest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[packettest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[packettest]=../libcrypto
 
   SOURCE[asynctest]=asynctest.c
-  INCLUDE[asynctest]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[asynctest]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[asynctest]=../libcrypto
 
   SOURCE[secmemtest]=secmemtest.c
-  INCLUDE[secmemtest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[secmemtest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[secmemtest]=../libcrypto
 
   SOURCE[srptest]=srptest.c
-  INCLUDE[srptest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[srptest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[srptest]=../libcrypto
 
   SOURCE[memleaktest]=memleaktest.c
-  INCLUDE[memleaktest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[memleaktest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[memleaktest]=../libcrypto
 
   SOURCE[dtlsv1listentest]=dtlsv1listentest.c
-  INCLUDE[dtlsv1listentest]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[dtlsv1listentest]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[dtlsv1listentest]=../libssl
 
   SOURCE[ct_test]=ct_test.c testutil.c
-  INCLUDE[ct_test]={- rel2abs(catdir($builddir,"../include")) -} ../crypto/include ../include
+  INCLUDE[ct_test]="{- rel2abs(catdir($builddir,"../include")) -}" ../crypto/include ../include
   DEPEND[ct_test]=../libcrypto
 
   SOURCE[threadstest]=threadstest.c
-  INCLUDE[threadstest]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[threadstest]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[threadstest]=../libcrypto
 
   SOURCE[afalgtest]=afalgtest.c
-  INCLUDE[afalgtest]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[afalgtest]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[afalgtest]=../libcrypto
 
   SOURCE[d2i_test]=d2i_test.c testutil.c
-  INCLUDE[d2i_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[d2i_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[d2i_test]=../libcrypto
 
   SOURCE[ssl_test_ctx_test]=ssl_test_ctx_test.c ssl_test_ctx.c testutil.c
-  INCLUDE[ssl_test_ctx_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[ssl_test_ctx_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[ssl_test_ctx_test]=../libcrypto
 
   SOURCE[ssl_test]=ssl_test.c ssl_test_ctx.c testutil.c handshake_helper.c
-  INCLUDE[ssl_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[ssl_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[ssl_test]=../libcrypto ../libssl
 
   SOURCE[cipherlist_test]=cipherlist_test.c testutil.c
-  INCLUDE[cipherlist_test]={- rel2abs(catdir($builddir,"../include")) -} .. ../include
+  INCLUDE[cipherlist_test]="{- rel2abs(catdir($builddir,"../include")) -}" .. ../include
   DEPEND[cipherlist_test]=../libcrypto ../libssl
 
   INCLUDE[testutil.o]=..
-  INCLUDE[ssl_test_ctx.o]={- rel2abs(catdir($builddir,"../include")) -} ../include
-  INCLUDE[handshake_helper.o]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[ssl_test_ctx.o]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
+  INCLUDE[handshake_helper.o]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
 
   SOURCE[x509aux]=x509aux.c
-  INCLUDE[x509aux]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[x509aux]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[x509aux]=../libcrypto
 
   SOURCE[asynciotest]=asynciotest.c
-  INCLUDE[asynciotest]={- rel2abs(catdir($builddir,"../include")) -} ../include
+  INCLUDE[asynciotest]="{- rel2abs(catdir($builddir,"../include")) -}" ../include
   DEPEND[asynciotest]=../libcrypto ../libssl
 ENDIF


### PR DESCRIPTION
This adds a tokenizer that treats " and ' much in the same way as a Unix shell.

This should solve [RT#4492](https://rt.openssl.org/Ticket/Display.html?id=4492)
