### PR TITLE
tools: c_rehash - stable hash symlink output needed

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -103,7 +103,7 @@ sub hash_dir {
 	print "Doing $_[0]\n";
 	chdir $_[0];
 	opendir(DIR, ".");
-	my @flist = readdir(DIR);
+	my @flist = sort readdir(DIR);
 	closedir DIR;
 	if ( $removelinks ) {
 		# Delete any existing symbolic links


### PR DESCRIPTION
an output of the utility c_rehash depends on the order the readdir
function returns filenames. The order can vary depending on dir-entry
order in the file-system. The different order can be annoying in the case of
version control of CA store (/etc/ssl/certs) or in the case of syncing nodes of
cluster.
The sorting the file-list ensure deterministic output of c_rehash.

BTS: #766214
Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>