### PR TITLE
Handle Visual C warning about non-standard function names.

### DIFF
--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -15,6 +15,7 @@
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
 #include <openssl/lhash.h>
+#include "e_os.h"
 
 static CONF_METHOD *default_CONF_method = NULL;
 

--- a/e_os.h
+++ b/e_os.h
@@ -469,6 +469,13 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 # if defined(OPENSSL_SYS_WINDOWS)
 #  define strcasecmp _stricmp
 #  define strncasecmp _strnicmp
+#  if (_MSC_VER >= 1310)
+#   define open _open
+#   define fdopen _fdopen
+#   define close _close
+#   define strdup _strdup
+#   define unlink _unlink
+#  endif
 # elif defined(OPENSSL_SYS_VMS)
 /* VMS below version 7.0 doesn't have strcasecmp() */
 #  include "internal/o_str.h"


### PR DESCRIPTION
Visual C version from version 2003 complain about certain function
names, for example:

```
apps\apps.c(2572) : warning C4996: 'open': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _open. See online help for details.
```

This adds preprocessor aliases for them in e_os.h.

Additionally, crypto/conf/conf_lib.c needs to include e_os.h to catch
those aliases.

RT#4488
RT#4489
