### PR TITLE
Avoid calling memcpy with lenght of 0

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -66,10 +66,11 @@ int i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
 
     *(p++) = (unsigned char)bits;
     d = a->data;
-    memcpy(p, d, len);
-    p += len;
-    if (len > 0)
+    if (len > 0) {
+        memcpy(p, d, len);
+        p += len;
         p[-1] &= (0xff << bits);
+    }
     *pp = p;
     return (ret);
 }


### PR DESCRIPTION
We can call memcpy() with a pointer 1 past the last allocated byte and length
of 0 and you can argue that that's undefined behaviour.

Reported by tis-interpreter