### PR TITLE
crypto/x509/x509_vpm.c: Simplify int_x509_param_set1()

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -259,12 +259,11 @@ static int int_x509_param_set1(char **pdest, size_t *pdestlen,
 {
     void *tmp;
     if (src) {
-        if (srclen == 0) {
-            tmp = OPENSSL_strdup(src);
+        if (srclen == 0)
             srclen = strlen(src);
-        } else
-            tmp = OPENSSL_memdup(src, srclen);
-        if (!tmp)
+
+        tmp = OPENSSL_memdup(src, srclen);
+        if (tmp == NULL)
             return 0;
     } else {
         tmp = NULL;
@@ -272,7 +271,7 @@ static int int_x509_param_set1(char **pdest, size_t *pdestlen,
     }
     OPENSSL_free(*pdest);
     *pdest = tmp;
-    if (pdestlen)
+    if (pdestlen != NULL)
         *pdestlen = srclen;
     return 1;
 }


### PR DESCRIPTION
This patch simplifies int_x509_param_set1() and also makes it not call strlen twice when srclen is 0 (strdup calls strlen).