### PR TITLE
Fix strdup macro redefinition

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -473,7 +473,9 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #   define open _open
 #   define fdopen _fdopen
 #   define close _close
-#   define strdup _strdup
+#   ifndef strdup
+#    define strdup _strdup
+#   endif
 #   define unlink _unlink
 #  endif
 # elif defined(OPENSSL_SYS_VMS)


### PR DESCRIPTION
This fixes the following warning when the CRT debug heap (crtdbg.h) is used:
e_os.h(476): warning C4005: 'strdup': macro redefinition
C:\Program Files (x86)\Windows Kits\10\Include\10.0.10586.0\ucrt\crtdbg.h(319): note: see previous definition of 'strdup'