### PR TITLE
Use BCryptGenRandom on Windows 7 or higher

### DIFF
--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -37,7 +37,7 @@ int RAND_poll(void)
 {
     MEMORYSTATUS mst;
 # ifndef USE_BCRYPT
-    HCRYPTPROV hProvider = 0;
+    HCRYPTPROV hProvider;
 # endif
     DWORD w;
     BYTE buf[64];
@@ -50,7 +50,7 @@ int RAND_poll(void)
     /* poll the CryptoAPI PRNG */
     /* The CryptoAPI returns sizeof(buf) bytes of randomness */
     if (CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
-        if (CryptGenRandom(hProvider, sizeof(buf), buf) != 0) {
+        if (CryptGenRandom(hProvider, (DWORD)sizeof(buf), buf) != 0) {
             RAND_add(buf, sizeof(buf), sizeof(buf));
         }
         CryptReleaseContext(hProvider, 0);
@@ -58,7 +58,7 @@ int RAND_poll(void)
 
     /* poll the Pentium PRG with CryptoAPI */
     if (CryptAcquireContextW(&hProvider, NULL, INTEL_DEF_PROV, PROV_INTEL_SEC, CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
-        if (CryptGenRandom(hProvider, sizeof(buf), buf) != 0) {
+        if (CryptGenRandom(hProvider, (DWORD)sizeof(buf), buf) != 0) {
             RAND_add(buf, sizeof(buf), sizeof(buf));
         }
         CryptReleaseContext(hProvider, 0);

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -15,12 +15,15 @@
 # include <windows.h>
 /* On Windows 7 or higher use BCrypt instead of the legacy CryptoAPI */
 # if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT>=0x0601
-#  define USE_BCRYPT 1
+#  define RAND_WINDOWS_USE_BCRYPT
 # endif
 
-# ifdef USE_BCRYPT
+# ifdef RAND_WINDOWS_USE_BCRYPT
 #  include <bcrypt.h>
 #  pragma comment(lib, "bcrypt.lib")
+#  ifndef STATUS_SUCCESS
+#   define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
+#  endif
 # else
 #  include <wincrypt.h>
 /*
@@ -36,14 +39,14 @@ static void readtimer(void);
 int RAND_poll(void)
 {
     MEMORYSTATUS mst;
-# ifndef USE_BCRYPT
+# ifndef RAND_WINDOWS_USE_BCRYPT
     HCRYPTPROV hProvider;
 # endif
     DWORD w;
     BYTE buf[64];
 
-# ifdef USE_BCRYPT
-    if (BCryptGenRandom(NULL, buf, (ULONG)sizeof(buf), BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0) {
+# ifdef RAND_WINDOWS_USE_BCRYPT
+    if (BCryptGenRandom(NULL, buf, (ULONG)sizeof(buf), BCRYPT_USE_SYSTEM_PREFERRED_RNG) == STATUS_SUCCESS) {
         RAND_add(buf, sizeof(buf), sizeof(buf));
     }
 # else


### PR DESCRIPTION
When openssl is compiled with MSVC and _WIN32_WINNT>=0x0601 (Windows 7), BCryptGenRandom is used instead of the legacy CryptoAPI.

This change brings the following benefits:
- Removes dependency on CryptoAPI (legacy API) respectively advapi32.dll
- CryptoAPI Cryptographic Service Providers (rsa full) are not dynamically loaded.
- Prefer the Windows API which Microsoft uses and recommends.
- Allows Universal Windows Platform (UWP) apps to use openssl (CryptGenRandom is not available for Windows store apps)