### PR TITLE
S390x assmebly on pre z10

### DIFF
--- a/crypto/chacha/asm/chacha-s390x.pl
+++ b/crypto/chacha/asm/chacha-s390x.pl
@@ -147,7 +147,8 @@ $code.=<<___;
 .type	ChaCha20_ctr32,\@function
 .align	32
 ChaCha20_ctr32:
-	cl${g}ije	$len,0,.Lno_data	# $len==0?
+	ltgr	$len,$len	# $len==0?
+	bzr	%r14
 	a${g}hi	$len,-64
 	l${g}hi	%r1,-$frame
 	stm${g}	%r6,%r15,`6*$SIZE_T`($sp)
@@ -279,7 +280,6 @@ $code.=<<___;
 	stmg	%r0,%r3,$stdframe+4*12($sp)
 
 	lm${g}	%r6,%r15,`$frame+6*$SIZE_T`($sp)
-.Lno_data:
 	br	%r14
 
 .align	16

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -129,27 +129,51 @@ OPENSSL_cleanse:
 .type	CRYPTO_memcmp,@function
 .align	16
 CRYPTO_memcmp:
-#if !defined(__s390x__) && !defined(__s390x)
-	llgfr	%r4,%r4
-#endif
-	lghi	%r5,0
-	clgr	%r4,%r5
-	je	.Lno_data
-
+#if defined(__s390x__) || defined(__s390x)
+	stg     %r12,96(%r15)
+	ltgr    %r4,%r4
+	je      .Lno_data
+	lhi     %r5,0
+	lghi    %r1,0
 .Loop_cmp:
-	llc	%r0,0(%r2)
-	la	%r2,1(%r2)
-	llc	%r1,0(%r3)
-	la	%r3,1(%r3)
-	xr	%r1,%r0
-	or	%r5,%r1
-	brctg	%r4,.Loop_cmp
-
-	lnr	%r5,%r5
-	srl	%r5,31
+	llgc    %r0,0(%r1,%r3)
+	llgc    %r12,0(%r1,%r2)
+	xr      %r0,%r12
+	or      %r5,%r0
+	aghi    %r1,1
+	brctg   %r4,.Loop_cmp
+	lhi     %r2,255
+	nr      %r2,%r5
+.Lexit:
+	lgfr    %r2,%r2
+	lg      %r12,96(%r15)
+	br      %r14
 .Lno_data:
-	lgr	%r2,%r5
-	br	%r14
+	lhi     %r2,0
+	j       .Lexit
+
+#else
+        st      %r12,48(%r15)
+        ltr     %r4,%r4
+        je      .Lno_data
+        lhi     %r5,0
+        lhi     %r1,0
+.Loop_cmp:
+        ic      %r0,0(%r1,%r3)
+        ic      %r12,0(%r1,%r2)
+        xr      %r0,%r12
+        or      %r5,%r0
+        ahi     %r1,1
+        brct    %r4,.Loop_cmp
+        lhi     %r2,255
+        nr      %r2,%r5
+.Lexit:
+        l       %r12,48(%r15)
+        br      %r14
+.Lno_data:
+        lhi     %r2,0
+        j       .Lexit
+#endif
 .size	CRYPTO_memcmp,.-CRYPTO_memcmp
 
 .globl	OPENSSL_instrument_bus


### PR DESCRIPTION
The Debian port currently supports pre z10 machines in their s390x port so instead of adding -march=z10 to CPU flags I tried to avoid the opcodes.
It builds & the testsuite passes. I am not sure if the 31bit part is relevant these days.