### PR TITLE
Fix some clang warnings

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -548,12 +548,12 @@ long MS_CALLBACK bio_dump_callback(BIO *bio, int cmd, const char *argp,
 
     if (cmd == (BIO_CB_READ | BIO_CB_RETURN)) {
         BIO_printf(out, "read from %p [%p] (%lu bytes => %ld (0x%lX))\n",
-                   (void *)bio, argp, (unsigned long)argi, ret, ret);
+                   (void *)bio, (void *)argp, (unsigned long)argi, ret, ret);
         BIO_dump(out, argp, (int)ret);
         return (ret);
     } else if (cmd == (BIO_CB_WRITE | BIO_CB_RETURN)) {
         BIO_printf(out, "write to %p [%p] (%lu bytes => %ld (0x%lX))\n",
-                   (void *)bio, argp, (unsigned long)argi, ret, ret);
+                   (void *)bio, (void *)argp, (unsigned long)argi, ret, ret);
         BIO_dump(out, argp, (int)ret);
     }
     return (ret);

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -980,7 +980,7 @@ int ssl3_get_client_hello(SSL *s)
 
         session_length = *(p + SSL3_RANDOM_SIZE);
 
-        if (SSL3_RANDOM_SIZE + session_length + 1 >= (d + n) - p) {
+        if ((int)(SSL3_RANDOM_SIZE + session_length + 1) >= (d + n) - p) {
             al = SSL_AD_DECODE_ERROR;
             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
             goto f_err;
@@ -1061,7 +1061,7 @@ int ssl3_get_client_hello(SSL *s)
         }
         cookie_len = *(p++);
 
-        if ((d + n ) - p < cookie_len) {
+        if ((d + n ) - p < (int)(cookie_len)) {
             al = SSL_AD_DECODE_ERROR;
             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
             goto f_err;


### PR DESCRIPTION
Fixes some issues with clang failing when using --strict-warnings

Travis is failing in 1.0.2. Lets see if this helps. This is for 1.0.2 and 1.0.1.