### PR TITLE
Fix potential access of null pointer (pp)

### DIFF
--- a/crypto/ct/ct_oct.c
+++ b/crypto/ct/ct_oct.c
@@ -365,9 +365,9 @@ int i2o_SCT_LIST(const STACK_OF(SCT) *a, unsigned char **pp)
     if (pp != NULL) {
         p = *pp;
         s2n(len2 - 2, p);
+        if (!is_pp_new)
+            *pp += len2;
     }
-    if (!is_pp_new)
-        *pp += len2;
     return len2;
 
  err:


### PR DESCRIPTION
Fixes #1001. If |pp| is NULL, a segfault would occur on line 370.