### PR TITLE
Implement DSA_SIG_set0() and ECDSA_SIG_set0(), for setting signature …

### DIFF
--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -34,6 +34,8 @@ void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig)
 
 int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
+    if (r == NULL || s == NULL)
+        return 0;
     BN_clear_free(sig->r);
     BN_clear_free(sig->s);
     sig->r = r;

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -32,7 +32,7 @@ void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig)
     *ps = sig->s;
 }
 
-int DSA_SIG_set0(BIGNUM *r, BIGNUM *s, DSA_SIG *sig)
+int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
     BN_clear_free(sig->r);
     BN_clear_free(sig->s);

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -32,6 +32,15 @@ void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig)
     *ps = sig->s;
 }
 
+int DSA_SIG_set0(BIGNUM *r, BIGNUM *s, DSA_SIG *sig)
+{
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+    sig->r = r;
+    sig->s = s;
+    return 1;
+}
+
 /* Override the default free and new methods */
 static int dsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                   void *exarg)

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1180,7 +1180,7 @@ void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig)
         *ps = sig->s;
 }
 
-int ECDSA_SIG_set0(BIGNUM *r, BIGNUM *s, ECDSA_SIG *sig)
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
     BN_clear_free(sig->r);
     BN_clear_free(sig->s);

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1182,6 +1182,8 @@ void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig)
 
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
+    if (r == NULL || s == NULL)
+        return 0;
     BN_clear_free(sig->r);
     BN_clear_free(sig->s);
     sig->r = r;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1180,6 +1180,15 @@ void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig)
         *ps = sig->s;
 }
 
+int ECDSA_SIG_set0(BIGNUM *r, BIGNUM *s, ECDSA_SIG *sig)
+{
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+    sig->r = r;
+    sig->s = s;
+    return 1;
+}
+
 int ECDSA_size(const EC_KEY *r)
 {
     int ret, i;

--- a/doc/crypto/DSA_SIG_new.pod
+++ b/doc/crypto/DSA_SIG_new.pod
@@ -11,7 +11,7 @@ DSA_SIG_new, DSA_SIG_free - allocate and free DSA signature objects
  DSA_SIG *DSA_SIG_new(void);
  void DSA_SIG_free(DSA_SIG *a);
  void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig);
- int DSA_SIG_set0(BIGNUM *r, BIGNUM *s, DSA_SIG *sig);
+ int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 
 =head1 DESCRIPTION
 

--- a/doc/crypto/DSA_SIG_new.pod
+++ b/doc/crypto/DSA_SIG_new.pod
@@ -11,6 +11,7 @@ DSA_SIG_new, DSA_SIG_free - allocate and free DSA signature objects
  DSA_SIG *DSA_SIG_new(void);
  void DSA_SIG_free(DSA_SIG *a);
  void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig);
+ int DSA_SIG_set0(BIGNUM *r, BIGNUM *s, DSA_SIG *sig);
 
 =head1 DESCRIPTION
 
@@ -22,6 +23,12 @@ values are erased before the memory is returned to the system.
 DSA_SIG_get0() returns internal pointers the B<r> and B<s> values contained
 in B<sig>. The values can then be examined or initialised.
 
+The B<r> and B<s> values can be set by calling DSA_SIG_set0() and passing the
+new values for B<r> and B<s> as parameters to the function. Calling this
+function transfers the memory management of the values to the DSA_SIG object,
+and therefore the values that have been passed in should not be freed directly
+after this function has been called.
+
 =head1 RETURN VALUES
 
 If the allocation fails, DSA_SIG_new() returns B<NULL> and sets an
@@ -30,6 +37,8 @@ L<ERR_get_error(3)>. Otherwise it returns a pointer
 to the newly allocated structure.
 
 DSA_SIG_free() returns no value.
+
+DSA_SIG_set0() returns 1 on success or 0 on failure.
 
 =head1 SEE ALSO
 

--- a/doc/crypto/ecdsa.pod
+++ b/doc/crypto/ecdsa.pod
@@ -14,6 +14,7 @@ algorithm (ECDSA) functions
  ECDSA_SIG *ECDSA_SIG_new(void);
  void ECDSA_SIG_free(ECDSA_SIG *sig);
  void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig);
+ int ECDSA_SIG_set0(BIGNUM *r, BIGNUM *s, ECDSA_SIG *sig);
  int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
  ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
  int ECDSA_size(const EC_KEY *eckey);
@@ -52,6 +53,12 @@ ECDSA_SIG_free() frees the B<ECDSA_SIG> structure B<sig>.
 
 ECDSA_SIG_get0() returns internal pointers the B<r> and B<s> values contained
 in B<sig>. The values can then be examined or initialised.
+
+The B<r> and B<s> values can be set by calling ECDSA_SIG_set0() and passing the
+new values for B<r> and B<s> as parameters to the function. Calling this
+function transfers the memory management of the values to the ECDSA_SIG object,
+and therefore the values that have been passed in should not be freed directly
+after this function has been called.
 
 i2d_ECDSA_SIG() creates the DER encoding of the ECDSA signature B<sig> and
 writes the encoded signature to B<*pp> (note: if B<pp> is NULL i2d_ECDSA_SIG()
@@ -105,6 +112,8 @@ ECDSA_do_sign_ex() is similar to ECDSA_sign_ex() except the signature is
 returned as a newly allocated B<ECDSA_SIG> structure (or NULL on error).
 
 =head1 RETURN VALUES
+
+ECDSA_SIG_set0() returns 1 on success or 0 on failure.
 
 ECDSA_size() returns the maximum length signature or 0 on error.
 

--- a/doc/crypto/ecdsa.pod
+++ b/doc/crypto/ecdsa.pod
@@ -14,7 +14,7 @@ algorithm (ECDSA) functions
  ECDSA_SIG *ECDSA_SIG_new(void);
  void ECDSA_SIG_free(ECDSA_SIG *sig);
  void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig);
- int ECDSA_SIG_set0(BIGNUM *r, BIGNUM *s, ECDSA_SIG *sig);
+ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
  int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
  ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
  int ECDSA_size(const EC_KEY *eckey);

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -82,7 +82,7 @@ void DSA_SIG_free(DSA_SIG *a);
 int i2d_DSA_SIG(const DSA_SIG *a, unsigned char **pp);
 DSA_SIG *d2i_DSA_SIG(DSA_SIG **v, const unsigned char **pp, long length);
 void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig);
-int DSA_SIG_set0(BIGNUM *r, BIGNUM *s, DSA_SIG *sig);
+int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 
 DSA_SIG *DSA_do_sign(const unsigned char *dgst, int dlen, DSA *dsa);
 int DSA_do_verify(const unsigned char *dgst, int dgst_len,

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -82,6 +82,7 @@ void DSA_SIG_free(DSA_SIG *a);
 int i2d_DSA_SIG(const DSA_SIG *a, unsigned char **pp);
 DSA_SIG *d2i_DSA_SIG(DSA_SIG **v, const unsigned char **pp, long length);
 void DSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const DSA_SIG *sig);
+int DSA_SIG_set0(BIGNUM *r, BIGNUM *s, DSA_SIG *sig);
 
 DSA_SIG *DSA_do_sign(const unsigned char *dgst, int dlen, DSA *dsa);
 int DSA_do_verify(const unsigned char *dgst, int dgst_len,

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1080,6 +1080,13 @@ ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
  */
 void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig);
 
+/** Setter for r and s fields of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG pointer
+ *  \param  r    pointer to BIGNUM for r (may be NULL)
+ *  \param  s    pointer to BIGNUM for s (may be NULL)
+ */
+int ECDSA_SIG_set0(BIGNUM *r, BIGNUM *s, ECDSA_SIG *sig);
+
 /** Computes the ECDSA signature of the given hash value using
  *  the supplied private key and returns the created signature.
  *  \param  dgst      pointer to the hash value

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1085,7 +1085,7 @@ void ECDSA_SIG_get0(BIGNUM **pr, BIGNUM **ps, const ECDSA_SIG *sig);
  *  \param  r    pointer to BIGNUM for r (may be NULL)
  *  \param  s    pointer to BIGNUM for s (may be NULL)
  */
-int ECDSA_SIG_set0(BIGNUM *r, BIGNUM *s, ECDSA_SIG *sig);
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 
 /** Computes the ECDSA signature of the given hash value using
  *  the supplied private key and returns the created signature.


### PR DESCRIPTION
…values.

SSH2 implementations which use DSA_do_verify() and ECDSA_do_verify() are given
the R and S values, and the data to be signed, by the client.  Thus in order
to validate these signatures, SSH2 implementations will digest and sign
the data -- and then pass in properly provisioned DSA_SIG and ECDSA_SIG objects.

Unfortunately, the existing OpenSSL-1.1.0 APIs do not allow for directly setting
those R and S values in these objects, which makes using OpenSSL for such
SSH2 implementations much more difficult.