### PR TITLE
Remove pointless free loop in X509_PURPOSE_cleanup()

### DIFF
--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -194,9 +194,6 @@ static void trtable_free(X509_TRUST *p)
 
 void X509_TRUST_cleanup(void)
 {
-    unsigned int i;
-    for (i = 0; i < X509_TRUST_COUNT; i++)
-        trtable_free(trstandard + i);
     sk_X509_TRUST_pop_free(trtable, trtable_free);
     trtable = NULL;
 }

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -229,10 +229,7 @@ static void xptable_free(X509_PURPOSE *p)
 
 void X509_PURPOSE_cleanup(void)
 {
-    unsigned int i;
     sk_X509_PURPOSE_pop_free(xptable, xptable_free);
-    for (i = 0; i < X509_PURPOSE_COUNT; i++)
-        xptable_free(xstandard + i);
     xptable = NULL;
 }
 


### PR DESCRIPTION
X509_PURPOSE_cleanup() iterates through xstandard which can only contain non-heap allocated X509_PURPOSE's so this change removes the loop as it's pointless.