### PR TITLE
Clean up following new SNI tests

### DIFF
--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -64,8 +64,9 @@ The test section supports the following options:
   - AcceptAll - accepts all certificates.
   - RejectAll - rejects all certificates.
 
-* ServerName - the server the client is expected to successfully connect to
-  - server1 - the initial context (default)
+* ServerName - the server the client should attempt to connect to. One of
+  - None - do not use SNI (default)
+  - server1 - the initial context
   - server2 - the secondary context
 
 * SessionTicketExpected - whether or not a session ticket is expected

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -27,18 +27,15 @@ typedef struct handshake_result {
     int server_protocol;
     int client_protocol;
     /* Server connection */
-    int servername;
+    ssl_servername_t servername;
     /* Session ticket status */
-    int session_ticket;
+    ssl_session_ticket_t session_ticket;
     /* Was this called on the second context? */
     int session_ticket_do_not_call;
 } HANDSHAKE_RESULT;
 
 /* Do a handshake and report some information about the result. */
-HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *client_ctx,
-                              const SSL_TEST_CTX *test_ctx);
-
-int do_not_call_session_ticket_callback(SSL* s, unsigned char* key_name, unsigned char *iv,
-                                        EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc);
+HANDSHAKE_RESULT do_handshake(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
+                              SSL_CTX *client_ctx, const SSL_TEST_CTX *test_ctx);
 
 #endif  /* HEADER_HANDSHAKE_HELPER_H */

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -159,6 +159,7 @@ const char *ssl_verify_callback_name(ssl_verify_callback_t callback)
 /**************/
 
 static const test_enum ssl_servername[] = {
+    {"None", SSL_TEST_SERVERNAME_NONE},
     {"server1", SSL_TEST_SERVERNAME_SERVER1},
     {"server2", SSL_TEST_SERVERNAME_SERVER2},
 };
@@ -185,18 +186,17 @@ const char *ssl_servername_name(ssl_servername_t server)
 /* SessionTicketExpected */
 /*************************/
 
-static const test_enum ssl_session_ticket_expected[] = {
+static const test_enum ssl_session_ticket[] = {
     {"Ignore", SSL_TEST_SESSION_TICKET_IGNORE},
     {"Yes", SSL_TEST_SESSION_TICKET_YES},
     {"No", SSL_TEST_SESSION_TICKET_NO},
     {"Broken", SSL_TEST_SESSION_TICKET_BROKEN},
 };
 
-__owur static int parse_session_ticket_expected(SSL_TEST_CTX *test_ctx,
-                                                const char *value)
+__owur static int parse_session_ticket(SSL_TEST_CTX *test_ctx, const char *value)
 {
     int ret_value;
-    if (!parse_enum(ssl_session_ticket_expected, OSSL_NELEM(ssl_session_ticket_expected),
+    if (!parse_enum(ssl_session_ticket, OSSL_NELEM(ssl_session_ticket),
                     &ret_value, value)) {
         return 0;
     }
@@ -204,10 +204,10 @@ __owur static int parse_session_ticket_expected(SSL_TEST_CTX *test_ctx,
     return 1;
 }
 
-const char *ssl_session_ticket_expected_name(ssl_session_ticket_expected_t server)
+const char *ssl_session_ticket_name(ssl_session_ticket_t server)
 {
-    return enum_name(ssl_session_ticket_expected,
-                     OSSL_NELEM(ssl_session_ticket_expected),
+    return enum_name(ssl_session_ticket,
+                     OSSL_NELEM(ssl_session_ticket),
                      server);
 }
 
@@ -227,7 +227,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "Protocol", &parse_protocol },
     { "ClientVerifyCallback", &parse_client_verify_callback },
     { "ServerName", &parse_servername },
-    { "SessionTicketExpected", &parse_session_ticket_expected },
+    { "SessionTicketExpected", &parse_session_ticket },
 };
 
 

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -27,7 +27,8 @@ typedef enum {
 } ssl_verify_callback_t;
 
 typedef enum {
-    SSL_TEST_SERVERNAME_SERVER1 = 0, /* Default */
+    SSL_TEST_SERVERNAME_NONE = 0, /* Default */
+    SSL_TEST_SERVERNAME_SERVER1,
     SSL_TEST_SERVERNAME_SERVER2
 } ssl_servername_t;
 
@@ -36,7 +37,7 @@ typedef enum {
     SSL_TEST_SESSION_TICKET_YES,
     SSL_TEST_SESSION_TICKET_NO,
     SSL_TEST_SESSION_TICKET_BROKEN, /* Special test */
-} ssl_session_ticket_expected_t;
+} ssl_session_ticket_t;
 
 typedef struct ssl_test_ctx {
     /* Test expectations. */
@@ -55,7 +56,7 @@ typedef struct ssl_test_ctx {
     ssl_verify_callback_t client_verify_callback;
     /* One of a number of predefined server names use by the client */
     ssl_servername_t servername;
-    ssl_session_ticket_expected_t session_ticket_expected;
+    ssl_session_ticket_t session_ticket_expected;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);
@@ -63,7 +64,7 @@ const char *ssl_alert_name(int alert);
 const char *ssl_protocol_name(int protocol);
 const char *ssl_verify_callback_name(ssl_verify_callback_t verify_callback);
 const char *ssl_servername_name(ssl_servername_t server);
-const char *ssl_session_ticket_expected_name(ssl_session_ticket_expected_t server);
+const char *ssl_session_ticket_name(ssl_session_ticket_t server);
 
 /*
  * Load the test case context from |conf|.

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -72,8 +72,8 @@ static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
     }
     if (ctx->session_ticket_expected != ctx2->session_ticket_expected) {
         fprintf(stderr, "SessionTicketExpected mismatch: %s vs %s.\n",
-                ssl_session_ticket_expected_name(ctx->session_ticket_expected),
-                ssl_session_ticket_expected_name(ctx2->session_ticket_expected));
+                ssl_session_ticket_name(ctx->session_ticket_expected),
+                ssl_session_ticket_name(ctx2->session_ticket_expected));
         return 0;
     }
 


### PR DESCRIPTION
- Only send SNI in SNI tests. This allows us to test handshakes without
  the SNI extension as well.
- Move all handshake-specific machinery to handshake_helper.c
- Use enum types to represent the enum everywhere
  (Resorting to plain ints can end in sign mismatch when the enum is
  represented by an unsigned type.)