### PR TITLE
utils/mkdir-p: check if dir exists also after mkdir failed

### DIFF
--- a/util/mkdir-p.pl
+++ b/util/mkdir-p.pl
@@ -33,6 +33,12 @@ sub do_mkdir_p {
     do_mkdir_p($parent);
   }
 
-  mkdir($dir, 0777) || die "Cannot create directory $dir: $!\n";
+  unless (mkdir($dir, 0777)) {
+    if (-d $dir) {
+      # We raced against another instance doing the same thing.
+      return;
+    }
+    die "Cannot create directory $dir: $!\n";
+  }
   print "created directory `$dir'\n";
 }


### PR DESCRIPTION
with "make install -j8" it happens very often that two or more make
instances are creating the same directory in parallel. As a result one
instace creates the directory and second mkdir fails because the
directory exists already (but it did not while testing for it earlier).

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>