### PR TITLE
SSL test: only write out server2 when testing SNI

### DIFF
--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -43,12 +43,12 @@ sub print_templates {
     # Add the implicit base configuration.
     foreach my $test (@ssltests::tests) {
         $test->{"server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
-	# use server values if server2 is not defined
+	# Do not emit an empty "server2" section.
 	if (defined $test->{"server2"}) {
 	    $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server2"}}) };
 	} else {
-	    $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server"}}) };
-	}
+            $test->{"server2"} = { };
+        }
         $test->{"client"} = { (%ssltests::base_client, %{$test->{"client"}}) };
     }
 

--- a/test/ssl-tests/01-simple.conf
+++ b/test/ssl-tests/01-simple.conf
@@ -11,7 +11,6 @@ ssl_conf = 0-default-ssl
 
 [0-default-ssl]
 server = 0-default-server
-server2 = 0-default-server2
 client = 0-default-client
 
 [0-default-server]
@@ -19,18 +18,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[0-default-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [0-default-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = Success
@@ -43,7 +34,6 @@ ssl_conf = 1-verify-cert-ssl
 
 [1-verify-cert-ssl]
 server = 1-verify-cert-server
-server2 = 1-verify-cert-server2
 client = 1-verify-cert-client
 
 [1-verify-cert-server]
@@ -51,17 +41,9 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[1-verify-cert-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [1-verify-cert-client]
 CipherString = DEFAULT
 VerifyMode = Peer
-
 
 [test-1]
 ClientAlert = UnknownCA

--- a/test/ssl-tests/02-protocol-version.conf
+++ b/test/ssl-tests/02-protocol-version.conf
@@ -370,7 +370,6 @@ ssl_conf = 0-version-negotiation-ssl
 
 [0-version-negotiation-ssl]
 server = 0-version-negotiation-server
-server2 = 0-version-negotiation-server2
 client = 0-version-negotiation-client
 
 [0-version-negotiation-server]
@@ -379,20 +378,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[0-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [0-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = InternalError
@@ -405,7 +395,6 @@ ssl_conf = 1-version-negotiation-ssl
 
 [1-version-negotiation-ssl]
 server = 1-version-negotiation-server
-server2 = 1-version-negotiation-server2
 client = 1-version-negotiation-client
 
 [1-version-negotiation-server]
@@ -414,20 +403,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[1-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [1-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-1]
 ExpectedResult = InternalError
@@ -440,7 +420,6 @@ ssl_conf = 2-version-negotiation-ssl
 
 [2-version-negotiation-ssl]
 server = 2-version-negotiation-server
-server2 = 2-version-negotiation-server2
 client = 2-version-negotiation-client
 
 [2-version-negotiation-server]
@@ -449,20 +428,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[2-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [2-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-2]
 ExpectedResult = InternalError
@@ -475,7 +445,6 @@ ssl_conf = 3-version-negotiation-ssl
 
 [3-version-negotiation-ssl]
 server = 3-version-negotiation-server
-server2 = 3-version-negotiation-server2
 client = 3-version-negotiation-client
 
 [3-version-negotiation-server]
@@ -484,20 +453,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[3-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [3-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-3]
 ExpectedResult = InternalError
@@ -510,7 +470,6 @@ ssl_conf = 4-version-negotiation-ssl
 
 [4-version-negotiation-ssl]
 server = 4-version-negotiation-server
-server2 = 4-version-negotiation-server2
 client = 4-version-negotiation-client
 
 [4-version-negotiation-server]
@@ -518,19 +477,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[4-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [4-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-4]
 ExpectedResult = InternalError
@@ -543,7 +494,6 @@ ssl_conf = 5-version-negotiation-ssl
 
 [5-version-negotiation-ssl]
 server = 5-version-negotiation-server
-server2 = 5-version-negotiation-server2
 client = 5-version-negotiation-client
 
 [5-version-negotiation-server]
@@ -553,21 +503,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[5-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [5-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-5]
 ExpectedResult = InternalError
@@ -580,7 +520,6 @@ ssl_conf = 6-version-negotiation-ssl
 
 [6-version-negotiation-ssl]
 server = 6-version-negotiation-server
-server2 = 6-version-negotiation-server2
 client = 6-version-negotiation-client
 
 [6-version-negotiation-server]
@@ -590,21 +529,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[6-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [6-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-6]
 ExpectedResult = InternalError
@@ -617,7 +546,6 @@ ssl_conf = 7-version-negotiation-ssl
 
 [7-version-negotiation-ssl]
 server = 7-version-negotiation-server
-server2 = 7-version-negotiation-server2
 client = 7-version-negotiation-client
 
 [7-version-negotiation-server]
@@ -627,21 +555,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[7-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [7-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-7]
 ExpectedResult = InternalError
@@ -654,7 +572,6 @@ ssl_conf = 8-version-negotiation-ssl
 
 [8-version-negotiation-ssl]
 server = 8-version-negotiation-server
-server2 = 8-version-negotiation-server2
 client = 8-version-negotiation-client
 
 [8-version-negotiation-server]
@@ -664,21 +581,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[8-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [8-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-8]
 ExpectedResult = InternalError
@@ -691,7 +598,6 @@ ssl_conf = 9-version-negotiation-ssl
 
 [9-version-negotiation-ssl]
 server = 9-version-negotiation-server
-server2 = 9-version-negotiation-server2
 client = 9-version-negotiation-client
 
 [9-version-negotiation-server]
@@ -700,20 +606,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[9-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [9-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-9]
 ExpectedResult = InternalError
@@ -726,7 +623,6 @@ ssl_conf = 10-version-negotiation-ssl
 
 [10-version-negotiation-ssl]
 server = 10-version-negotiation-server
-server2 = 10-version-negotiation-server2
 client = 10-version-negotiation-client
 
 [10-version-negotiation-server]
@@ -736,21 +632,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[10-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [10-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-10]
 ExpectedResult = InternalError
@@ -763,7 +649,6 @@ ssl_conf = 11-version-negotiation-ssl
 
 [11-version-negotiation-ssl]
 server = 11-version-negotiation-server
-server2 = 11-version-negotiation-server2
 client = 11-version-negotiation-client
 
 [11-version-negotiation-server]
@@ -773,21 +658,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[11-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [11-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-11]
 ExpectedResult = InternalError
@@ -800,7 +675,6 @@ ssl_conf = 12-version-negotiation-ssl
 
 [12-version-negotiation-ssl]
 server = 12-version-negotiation-server
-server2 = 12-version-negotiation-server2
 client = 12-version-negotiation-client
 
 [12-version-negotiation-server]
@@ -810,21 +684,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[12-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [12-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-12]
 ExpectedResult = InternalError
@@ -837,7 +701,6 @@ ssl_conf = 13-version-negotiation-ssl
 
 [13-version-negotiation-ssl]
 server = 13-version-negotiation-server
-server2 = 13-version-negotiation-server2
 client = 13-version-negotiation-client
 
 [13-version-negotiation-server]
@@ -846,20 +709,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[13-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [13-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-13]
 ExpectedResult = InternalError
@@ -872,7 +726,6 @@ ssl_conf = 14-version-negotiation-ssl
 
 [14-version-negotiation-ssl]
 server = 14-version-negotiation-server
-server2 = 14-version-negotiation-server2
 client = 14-version-negotiation-client
 
 [14-version-negotiation-server]
@@ -882,21 +735,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[14-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [14-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-14]
 ExpectedResult = InternalError
@@ -909,7 +752,6 @@ ssl_conf = 15-version-negotiation-ssl
 
 [15-version-negotiation-ssl]
 server = 15-version-negotiation-server
-server2 = 15-version-negotiation-server2
 client = 15-version-negotiation-client
 
 [15-version-negotiation-server]
@@ -919,21 +761,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[15-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [15-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-15]
 ExpectedResult = InternalError
@@ -946,7 +778,6 @@ ssl_conf = 16-version-negotiation-ssl
 
 [16-version-negotiation-ssl]
 server = 16-version-negotiation-server
-server2 = 16-version-negotiation-server2
 client = 16-version-negotiation-client
 
 [16-version-negotiation-server]
@@ -955,20 +786,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[16-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [16-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-16]
 ExpectedResult = InternalError
@@ -981,7 +803,6 @@ ssl_conf = 17-version-negotiation-ssl
 
 [17-version-negotiation-ssl]
 server = 17-version-negotiation-server
-server2 = 17-version-negotiation-server2
 client = 17-version-negotiation-client
 
 [17-version-negotiation-server]
@@ -991,21 +812,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[17-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [17-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-17]
 ExpectedResult = InternalError
@@ -1018,7 +829,6 @@ ssl_conf = 18-version-negotiation-ssl
 
 [18-version-negotiation-ssl]
 server = 18-version-negotiation-server
-server2 = 18-version-negotiation-server2
 client = 18-version-negotiation-client
 
 [18-version-negotiation-server]
@@ -1027,20 +837,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[18-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [18-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-18]
 ExpectedResult = InternalError
@@ -1053,7 +854,6 @@ ssl_conf = 19-version-negotiation-ssl
 
 [19-version-negotiation-ssl]
 server = 19-version-negotiation-server
-server2 = 19-version-negotiation-server2
 client = 19-version-negotiation-client
 
 [19-version-negotiation-server]
@@ -1062,20 +862,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[19-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [19-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-19]
 ExpectedResult = ServerFail
@@ -1088,7 +879,6 @@ ssl_conf = 20-version-negotiation-ssl
 
 [20-version-negotiation-ssl]
 server = 20-version-negotiation-server
-server2 = 20-version-negotiation-server2
 client = 20-version-negotiation-client
 
 [20-version-negotiation-server]
@@ -1097,20 +887,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[20-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [20-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-20]
 ExpectedResult = Success
@@ -1124,7 +905,6 @@ ssl_conf = 21-version-negotiation-ssl
 
 [21-version-negotiation-ssl]
 server = 21-version-negotiation-server
-server2 = 21-version-negotiation-server2
 client = 21-version-negotiation-client
 
 [21-version-negotiation-server]
@@ -1133,20 +913,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[21-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [21-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-21]
 ExpectedResult = Success
@@ -1160,7 +931,6 @@ ssl_conf = 22-version-negotiation-ssl
 
 [22-version-negotiation-ssl]
 server = 22-version-negotiation-server
-server2 = 22-version-negotiation-server2
 client = 22-version-negotiation-client
 
 [22-version-negotiation-server]
@@ -1169,20 +939,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[22-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [22-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-22]
 ExpectedResult = Success
@@ -1196,7 +957,6 @@ ssl_conf = 23-version-negotiation-ssl
 
 [23-version-negotiation-ssl]
 server = 23-version-negotiation-server
-server2 = 23-version-negotiation-server2
 client = 23-version-negotiation-client
 
 [23-version-negotiation-server]
@@ -1204,19 +964,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[23-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [23-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-23]
 ExpectedResult = Success
@@ -1230,7 +982,6 @@ ssl_conf = 24-version-negotiation-ssl
 
 [24-version-negotiation-ssl]
 server = 24-version-negotiation-server
-server2 = 24-version-negotiation-server2
 client = 24-version-negotiation-client
 
 [24-version-negotiation-server]
@@ -1240,21 +991,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[24-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [24-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-24]
 ExpectedResult = ServerFail
@@ -1267,7 +1008,6 @@ ssl_conf = 25-version-negotiation-ssl
 
 [25-version-negotiation-ssl]
 server = 25-version-negotiation-server
-server2 = 25-version-negotiation-server2
 client = 25-version-negotiation-client
 
 [25-version-negotiation-server]
@@ -1277,21 +1017,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[25-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [25-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-25]
 ExpectedResult = Success
@@ -1305,7 +1035,6 @@ ssl_conf = 26-version-negotiation-ssl
 
 [26-version-negotiation-ssl]
 server = 26-version-negotiation-server
-server2 = 26-version-negotiation-server2
 client = 26-version-negotiation-client
 
 [26-version-negotiation-server]
@@ -1315,21 +1044,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[26-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [26-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-26]
 ExpectedResult = Success
@@ -1343,7 +1062,6 @@ ssl_conf = 27-version-negotiation-ssl
 
 [27-version-negotiation-ssl]
 server = 27-version-negotiation-server
-server2 = 27-version-negotiation-server2
 client = 27-version-negotiation-client
 
 [27-version-negotiation-server]
@@ -1353,21 +1071,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[27-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [27-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-27]
 ExpectedResult = Success
@@ -1381,7 +1089,6 @@ ssl_conf = 28-version-negotiation-ssl
 
 [28-version-negotiation-ssl]
 server = 28-version-negotiation-server
-server2 = 28-version-negotiation-server2
 client = 28-version-negotiation-client
 
 [28-version-negotiation-server]
@@ -1390,20 +1097,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[28-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [28-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-28]
 ExpectedResult = Success
@@ -1417,7 +1115,6 @@ ssl_conf = 29-version-negotiation-ssl
 
 [29-version-negotiation-ssl]
 server = 29-version-negotiation-server
-server2 = 29-version-negotiation-server2
 client = 29-version-negotiation-client
 
 [29-version-negotiation-server]
@@ -1427,21 +1124,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[29-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [29-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-29]
 ExpectedResult = Success
@@ -1455,7 +1142,6 @@ ssl_conf = 30-version-negotiation-ssl
 
 [30-version-negotiation-ssl]
 server = 30-version-negotiation-server
-server2 = 30-version-negotiation-server2
 client = 30-version-negotiation-client
 
 [30-version-negotiation-server]
@@ -1465,21 +1151,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[30-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [30-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-30]
 ExpectedResult = Success
@@ -1493,7 +1169,6 @@ ssl_conf = 31-version-negotiation-ssl
 
 [31-version-negotiation-ssl]
 server = 31-version-negotiation-server
-server2 = 31-version-negotiation-server2
 client = 31-version-negotiation-client
 
 [31-version-negotiation-server]
@@ -1503,21 +1178,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[31-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [31-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-31]
 ExpectedResult = Success
@@ -1531,7 +1196,6 @@ ssl_conf = 32-version-negotiation-ssl
 
 [32-version-negotiation-ssl]
 server = 32-version-negotiation-server
-server2 = 32-version-negotiation-server2
 client = 32-version-negotiation-client
 
 [32-version-negotiation-server]
@@ -1540,20 +1204,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[32-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [32-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-32]
 ExpectedResult = Success
@@ -1567,7 +1222,6 @@ ssl_conf = 33-version-negotiation-ssl
 
 [33-version-negotiation-ssl]
 server = 33-version-negotiation-server
-server2 = 33-version-negotiation-server2
 client = 33-version-negotiation-client
 
 [33-version-negotiation-server]
@@ -1577,21 +1231,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[33-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [33-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-33]
 ExpectedResult = ServerFail
@@ -1604,7 +1248,6 @@ ssl_conf = 34-version-negotiation-ssl
 
 [34-version-negotiation-ssl]
 server = 34-version-negotiation-server
-server2 = 34-version-negotiation-server2
 client = 34-version-negotiation-client
 
 [34-version-negotiation-server]
@@ -1614,21 +1257,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[34-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [34-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-34]
 ExpectedResult = ServerFail
@@ -1641,7 +1274,6 @@ ssl_conf = 35-version-negotiation-ssl
 
 [35-version-negotiation-ssl]
 server = 35-version-negotiation-server
-server2 = 35-version-negotiation-server2
 client = 35-version-negotiation-client
 
 [35-version-negotiation-server]
@@ -1650,20 +1282,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[35-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [35-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-35]
 ExpectedResult = ServerFail
@@ -1676,7 +1299,6 @@ ssl_conf = 36-version-negotiation-ssl
 
 [36-version-negotiation-ssl]
 server = 36-version-negotiation-server
-server2 = 36-version-negotiation-server2
 client = 36-version-negotiation-client
 
 [36-version-negotiation-server]
@@ -1686,21 +1308,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[36-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [36-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-36]
 ExpectedResult = ServerFail
@@ -1713,7 +1325,6 @@ ssl_conf = 37-version-negotiation-ssl
 
 [37-version-negotiation-ssl]
 server = 37-version-negotiation-server
-server2 = 37-version-negotiation-server2
 client = 37-version-negotiation-client
 
 [37-version-negotiation-server]
@@ -1722,20 +1333,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[37-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [37-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-37]
 ExpectedResult = ServerFail
@@ -1748,7 +1350,6 @@ ssl_conf = 38-version-negotiation-ssl
 
 [38-version-negotiation-ssl]
 server = 38-version-negotiation-server
-server2 = 38-version-negotiation-server2
 client = 38-version-negotiation-client
 
 [38-version-negotiation-server]
@@ -1757,20 +1358,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[38-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [38-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-38]
 ExpectedResult = ServerFail
@@ -1783,7 +1375,6 @@ ssl_conf = 39-version-negotiation-ssl
 
 [39-version-negotiation-ssl]
 server = 39-version-negotiation-server
-server2 = 39-version-negotiation-server2
 client = 39-version-negotiation-client
 
 [39-version-negotiation-server]
@@ -1792,20 +1383,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[39-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [39-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-39]
 ExpectedResult = Success
@@ -1819,7 +1401,6 @@ ssl_conf = 40-version-negotiation-ssl
 
 [40-version-negotiation-ssl]
 server = 40-version-negotiation-server
-server2 = 40-version-negotiation-server2
 client = 40-version-negotiation-client
 
 [40-version-negotiation-server]
@@ -1828,20 +1409,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[40-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [40-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-40]
 ExpectedResult = Success
@@ -1855,7 +1427,6 @@ ssl_conf = 41-version-negotiation-ssl
 
 [41-version-negotiation-ssl]
 server = 41-version-negotiation-server
-server2 = 41-version-negotiation-server2
 client = 41-version-negotiation-client
 
 [41-version-negotiation-server]
@@ -1864,20 +1435,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[41-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [41-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-41]
 ExpectedResult = Success
@@ -1891,7 +1453,6 @@ ssl_conf = 42-version-negotiation-ssl
 
 [42-version-negotiation-ssl]
 server = 42-version-negotiation-server
-server2 = 42-version-negotiation-server2
 client = 42-version-negotiation-client
 
 [42-version-negotiation-server]
@@ -1899,19 +1460,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[42-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [42-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-42]
 ExpectedResult = Success
@@ -1925,7 +1478,6 @@ ssl_conf = 43-version-negotiation-ssl
 
 [43-version-negotiation-ssl]
 server = 43-version-negotiation-server
-server2 = 43-version-negotiation-server2
 client = 43-version-negotiation-client
 
 [43-version-negotiation-server]
@@ -1935,21 +1487,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[43-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [43-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-43]
 ExpectedResult = ServerFail
@@ -1962,7 +1504,6 @@ ssl_conf = 44-version-negotiation-ssl
 
 [44-version-negotiation-ssl]
 server = 44-version-negotiation-server
-server2 = 44-version-negotiation-server2
 client = 44-version-negotiation-client
 
 [44-version-negotiation-server]
@@ -1972,21 +1513,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[44-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [44-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-44]
 ExpectedResult = Success
@@ -2000,7 +1531,6 @@ ssl_conf = 45-version-negotiation-ssl
 
 [45-version-negotiation-ssl]
 server = 45-version-negotiation-server
-server2 = 45-version-negotiation-server2
 client = 45-version-negotiation-client
 
 [45-version-negotiation-server]
@@ -2010,21 +1540,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[45-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [45-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-45]
 ExpectedResult = Success
@@ -2038,7 +1558,6 @@ ssl_conf = 46-version-negotiation-ssl
 
 [46-version-negotiation-ssl]
 server = 46-version-negotiation-server
-server2 = 46-version-negotiation-server2
 client = 46-version-negotiation-client
 
 [46-version-negotiation-server]
@@ -2048,21 +1567,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[46-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [46-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-46]
 ExpectedResult = Success
@@ -2076,7 +1585,6 @@ ssl_conf = 47-version-negotiation-ssl
 
 [47-version-negotiation-ssl]
 server = 47-version-negotiation-server
-server2 = 47-version-negotiation-server2
 client = 47-version-negotiation-client
 
 [47-version-negotiation-server]
@@ -2085,20 +1593,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[47-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [47-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-47]
 ExpectedResult = Success
@@ -2112,7 +1611,6 @@ ssl_conf = 48-version-negotiation-ssl
 
 [48-version-negotiation-ssl]
 server = 48-version-negotiation-server
-server2 = 48-version-negotiation-server2
 client = 48-version-negotiation-client
 
 [48-version-negotiation-server]
@@ -2122,21 +1620,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[48-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [48-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-48]
 ExpectedResult = Success
@@ -2150,7 +1638,6 @@ ssl_conf = 49-version-negotiation-ssl
 
 [49-version-negotiation-ssl]
 server = 49-version-negotiation-server
-server2 = 49-version-negotiation-server2
 client = 49-version-negotiation-client
 
 [49-version-negotiation-server]
@@ -2160,21 +1647,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[49-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [49-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-49]
 ExpectedResult = Success
@@ -2188,7 +1665,6 @@ ssl_conf = 50-version-negotiation-ssl
 
 [50-version-negotiation-ssl]
 server = 50-version-negotiation-server
-server2 = 50-version-negotiation-server2
 client = 50-version-negotiation-client
 
 [50-version-negotiation-server]
@@ -2198,21 +1674,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[50-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [50-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-50]
 ExpectedResult = Success
@@ -2226,7 +1692,6 @@ ssl_conf = 51-version-negotiation-ssl
 
 [51-version-negotiation-ssl]
 server = 51-version-negotiation-server
-server2 = 51-version-negotiation-server2
 client = 51-version-negotiation-client
 
 [51-version-negotiation-server]
@@ -2235,20 +1700,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[51-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [51-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-51]
 ExpectedResult = Success
@@ -2262,7 +1718,6 @@ ssl_conf = 52-version-negotiation-ssl
 
 [52-version-negotiation-ssl]
 server = 52-version-negotiation-server
-server2 = 52-version-negotiation-server2
 client = 52-version-negotiation-client
 
 [52-version-negotiation-server]
@@ -2272,21 +1727,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[52-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [52-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-52]
 ExpectedResult = Success
@@ -2300,7 +1745,6 @@ ssl_conf = 53-version-negotiation-ssl
 
 [53-version-negotiation-ssl]
 server = 53-version-negotiation-server
-server2 = 53-version-negotiation-server2
 client = 53-version-negotiation-client
 
 [53-version-negotiation-server]
@@ -2310,21 +1754,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[53-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [53-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-53]
 ExpectedResult = Success
@@ -2338,7 +1772,6 @@ ssl_conf = 54-version-negotiation-ssl
 
 [54-version-negotiation-ssl]
 server = 54-version-negotiation-server
-server2 = 54-version-negotiation-server2
 client = 54-version-negotiation-client
 
 [54-version-negotiation-server]
@@ -2347,20 +1780,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[54-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [54-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-54]
 ExpectedResult = Success
@@ -2374,7 +1798,6 @@ ssl_conf = 55-version-negotiation-ssl
 
 [55-version-negotiation-ssl]
 server = 55-version-negotiation-server
-server2 = 55-version-negotiation-server2
 client = 55-version-negotiation-client
 
 [55-version-negotiation-server]
@@ -2384,21 +1807,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[55-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [55-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-55]
 ExpectedResult = ServerFail
@@ -2411,7 +1824,6 @@ ssl_conf = 56-version-negotiation-ssl
 
 [56-version-negotiation-ssl]
 server = 56-version-negotiation-server
-server2 = 56-version-negotiation-server2
 client = 56-version-negotiation-client
 
 [56-version-negotiation-server]
@@ -2420,20 +1832,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[56-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [56-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-56]
 ExpectedResult = ServerFail
@@ -2446,7 +1849,6 @@ ssl_conf = 57-version-negotiation-ssl
 
 [57-version-negotiation-ssl]
 server = 57-version-negotiation-server
-server2 = 57-version-negotiation-server2
 client = 57-version-negotiation-client
 
 [57-version-negotiation-server]
@@ -2455,20 +1857,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[57-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [57-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-57]
 ExpectedResult = ServerFail
@@ -2481,7 +1874,6 @@ ssl_conf = 58-version-negotiation-ssl
 
 [58-version-negotiation-ssl]
 server = 58-version-negotiation-server
-server2 = 58-version-negotiation-server2
 client = 58-version-negotiation-client
 
 [58-version-negotiation-server]
@@ -2490,20 +1882,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[58-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [58-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-58]
 ExpectedResult = Success
@@ -2517,7 +1900,6 @@ ssl_conf = 59-version-negotiation-ssl
 
 [59-version-negotiation-ssl]
 server = 59-version-negotiation-server
-server2 = 59-version-negotiation-server2
 client = 59-version-negotiation-client
 
 [59-version-negotiation-server]
@@ -2526,20 +1908,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[59-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [59-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-59]
 ExpectedResult = Success
@@ -2553,7 +1926,6 @@ ssl_conf = 60-version-negotiation-ssl
 
 [60-version-negotiation-ssl]
 server = 60-version-negotiation-server
-server2 = 60-version-negotiation-server2
 client = 60-version-negotiation-client
 
 [60-version-negotiation-server]
@@ -2562,20 +1934,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[60-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [60-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-60]
 ExpectedResult = Success
@@ -2589,7 +1952,6 @@ ssl_conf = 61-version-negotiation-ssl
 
 [61-version-negotiation-ssl]
 server = 61-version-negotiation-server
-server2 = 61-version-negotiation-server2
 client = 61-version-negotiation-client
 
 [61-version-negotiation-server]
@@ -2597,19 +1959,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[61-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [61-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-61]
 ExpectedResult = Success
@@ -2623,7 +1977,6 @@ ssl_conf = 62-version-negotiation-ssl
 
 [62-version-negotiation-ssl]
 server = 62-version-negotiation-server
-server2 = 62-version-negotiation-server2
 client = 62-version-negotiation-client
 
 [62-version-negotiation-server]
@@ -2633,21 +1986,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[62-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [62-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-62]
 ExpectedResult = ServerFail
@@ -2660,7 +2003,6 @@ ssl_conf = 63-version-negotiation-ssl
 
 [63-version-negotiation-ssl]
 server = 63-version-negotiation-server
-server2 = 63-version-negotiation-server2
 client = 63-version-negotiation-client
 
 [63-version-negotiation-server]
@@ -2670,21 +2012,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[63-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [63-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-63]
 ExpectedResult = Success
@@ -2698,7 +2030,6 @@ ssl_conf = 64-version-negotiation-ssl
 
 [64-version-negotiation-ssl]
 server = 64-version-negotiation-server
-server2 = 64-version-negotiation-server2
 client = 64-version-negotiation-client
 
 [64-version-negotiation-server]
@@ -2708,21 +2039,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[64-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [64-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-64]
 ExpectedResult = Success
@@ -2736,7 +2057,6 @@ ssl_conf = 65-version-negotiation-ssl
 
 [65-version-negotiation-ssl]
 server = 65-version-negotiation-server
-server2 = 65-version-negotiation-server2
 client = 65-version-negotiation-client
 
 [65-version-negotiation-server]
@@ -2746,21 +2066,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[65-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [65-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-65]
 ExpectedResult = Success
@@ -2774,7 +2084,6 @@ ssl_conf = 66-version-negotiation-ssl
 
 [66-version-negotiation-ssl]
 server = 66-version-negotiation-server
-server2 = 66-version-negotiation-server2
 client = 66-version-negotiation-client
 
 [66-version-negotiation-server]
@@ -2783,20 +2092,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[66-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [66-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-66]
 ExpectedResult = Success
@@ -2810,7 +2110,6 @@ ssl_conf = 67-version-negotiation-ssl
 
 [67-version-negotiation-ssl]
 server = 67-version-negotiation-server
-server2 = 67-version-negotiation-server2
 client = 67-version-negotiation-client
 
 [67-version-negotiation-server]
@@ -2820,21 +2119,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[67-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [67-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-67]
 ExpectedResult = Success
@@ -2848,7 +2137,6 @@ ssl_conf = 68-version-negotiation-ssl
 
 [68-version-negotiation-ssl]
 server = 68-version-negotiation-server
-server2 = 68-version-negotiation-server2
 client = 68-version-negotiation-client
 
 [68-version-negotiation-server]
@@ -2858,21 +2146,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[68-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [68-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-68]
 ExpectedResult = Success
@@ -2886,7 +2164,6 @@ ssl_conf = 69-version-negotiation-ssl
 
 [69-version-negotiation-ssl]
 server = 69-version-negotiation-server
-server2 = 69-version-negotiation-server2
 client = 69-version-negotiation-client
 
 [69-version-negotiation-server]
@@ -2896,21 +2173,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[69-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [69-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-69]
 ExpectedResult = Success
@@ -2924,7 +2191,6 @@ ssl_conf = 70-version-negotiation-ssl
 
 [70-version-negotiation-ssl]
 server = 70-version-negotiation-server
-server2 = 70-version-negotiation-server2
 client = 70-version-negotiation-client
 
 [70-version-negotiation-server]
@@ -2933,20 +2199,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[70-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [70-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-70]
 ExpectedResult = Success
@@ -2960,7 +2217,6 @@ ssl_conf = 71-version-negotiation-ssl
 
 [71-version-negotiation-ssl]
 server = 71-version-negotiation-server
-server2 = 71-version-negotiation-server2
 client = 71-version-negotiation-client
 
 [71-version-negotiation-server]
@@ -2970,21 +2226,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[71-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [71-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-71]
 ExpectedResult = Success
@@ -2998,7 +2244,6 @@ ssl_conf = 72-version-negotiation-ssl
 
 [72-version-negotiation-ssl]
 server = 72-version-negotiation-server
-server2 = 72-version-negotiation-server2
 client = 72-version-negotiation-client
 
 [72-version-negotiation-server]
@@ -3008,21 +2253,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[72-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [72-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-72]
 ExpectedResult = Success
@@ -3036,7 +2271,6 @@ ssl_conf = 73-version-negotiation-ssl
 
 [73-version-negotiation-ssl]
 server = 73-version-negotiation-server
-server2 = 73-version-negotiation-server2
 client = 73-version-negotiation-client
 
 [73-version-negotiation-server]
@@ -3045,20 +2279,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[73-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [73-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-73]
 ExpectedResult = Success
@@ -3072,7 +2297,6 @@ ssl_conf = 74-version-negotiation-ssl
 
 [74-version-negotiation-ssl]
 server = 74-version-negotiation-server
-server2 = 74-version-negotiation-server2
 client = 74-version-negotiation-client
 
 [74-version-negotiation-server]
@@ -3082,21 +2306,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[74-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [74-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-74]
 ExpectedResult = Success
@@ -3110,7 +2324,6 @@ ssl_conf = 75-version-negotiation-ssl
 
 [75-version-negotiation-ssl]
 server = 75-version-negotiation-server
-server2 = 75-version-negotiation-server2
 client = 75-version-negotiation-client
 
 [75-version-negotiation-server]
@@ -3119,20 +2332,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[75-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [75-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-75]
 ExpectedResult = Success
@@ -3146,7 +2350,6 @@ ssl_conf = 76-version-negotiation-ssl
 
 [76-version-negotiation-ssl]
 server = 76-version-negotiation-server
-server2 = 76-version-negotiation-server2
 client = 76-version-negotiation-client
 
 [76-version-negotiation-server]
@@ -3155,19 +2358,10 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[76-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [76-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-76]
 ExpectedResult = ServerFail
@@ -3180,7 +2374,6 @@ ssl_conf = 77-version-negotiation-ssl
 
 [77-version-negotiation-ssl]
 server = 77-version-negotiation-server
-server2 = 77-version-negotiation-server2
 client = 77-version-negotiation-client
 
 [77-version-negotiation-server]
@@ -3189,19 +2382,10 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[77-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [77-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-77]
 ExpectedResult = Success
@@ -3215,7 +2399,6 @@ ssl_conf = 78-version-negotiation-ssl
 
 [78-version-negotiation-ssl]
 server = 78-version-negotiation-server
-server2 = 78-version-negotiation-server2
 client = 78-version-negotiation-client
 
 [78-version-negotiation-server]
@@ -3224,19 +2407,10 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[78-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [78-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-78]
 ExpectedResult = Success
@@ -3250,7 +2424,6 @@ ssl_conf = 79-version-negotiation-ssl
 
 [79-version-negotiation-ssl]
 server = 79-version-negotiation-server
-server2 = 79-version-negotiation-server2
 client = 79-version-negotiation-client
 
 [79-version-negotiation-server]
@@ -3259,19 +2432,10 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[79-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [79-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-79]
 ExpectedResult = Success
@@ -3285,7 +2449,6 @@ ssl_conf = 80-version-negotiation-ssl
 
 [80-version-negotiation-ssl]
 server = 80-version-negotiation-server
-server2 = 80-version-negotiation-server2
 client = 80-version-negotiation-client
 
 [80-version-negotiation-server]
@@ -3293,18 +2456,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[80-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [80-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-80]
 ExpectedResult = Success
@@ -3318,7 +2473,6 @@ ssl_conf = 81-version-negotiation-ssl
 
 [81-version-negotiation-ssl]
 server = 81-version-negotiation-server
-server2 = 81-version-negotiation-server2
 client = 81-version-negotiation-client
 
 [81-version-negotiation-server]
@@ -3328,20 +2482,10 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[81-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [81-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-81]
 ExpectedResult = ServerFail
@@ -3354,7 +2498,6 @@ ssl_conf = 82-version-negotiation-ssl
 
 [82-version-negotiation-ssl]
 server = 82-version-negotiation-server
-server2 = 82-version-negotiation-server2
 client = 82-version-negotiation-client
 
 [82-version-negotiation-server]
@@ -3364,20 +2507,10 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[82-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [82-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-82]
 ExpectedResult = Success
@@ -3391,7 +2524,6 @@ ssl_conf = 83-version-negotiation-ssl
 
 [83-version-negotiation-ssl]
 server = 83-version-negotiation-server
-server2 = 83-version-negotiation-server2
 client = 83-version-negotiation-client
 
 [83-version-negotiation-server]
@@ -3401,20 +2533,10 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[83-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [83-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-83]
 ExpectedResult = Success
@@ -3428,7 +2550,6 @@ ssl_conf = 84-version-negotiation-ssl
 
 [84-version-negotiation-ssl]
 server = 84-version-negotiation-server
-server2 = 84-version-negotiation-server2
 client = 84-version-negotiation-client
 
 [84-version-negotiation-server]
@@ -3438,20 +2559,10 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[84-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [84-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-84]
 ExpectedResult = Success
@@ -3465,7 +2576,6 @@ ssl_conf = 85-version-negotiation-ssl
 
 [85-version-negotiation-ssl]
 server = 85-version-negotiation-server
-server2 = 85-version-negotiation-server2
 client = 85-version-negotiation-client
 
 [85-version-negotiation-server]
@@ -3474,19 +2584,10 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[85-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [85-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-85]
 ExpectedResult = Success
@@ -3500,7 +2601,6 @@ ssl_conf = 86-version-negotiation-ssl
 
 [86-version-negotiation-ssl]
 server = 86-version-negotiation-server
-server2 = 86-version-negotiation-server2
 client = 86-version-negotiation-client
 
 [86-version-negotiation-server]
@@ -3510,20 +2610,10 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[86-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [86-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-86]
 ExpectedResult = Success
@@ -3537,7 +2627,6 @@ ssl_conf = 87-version-negotiation-ssl
 
 [87-version-negotiation-ssl]
 server = 87-version-negotiation-server
-server2 = 87-version-negotiation-server2
 client = 87-version-negotiation-client
 
 [87-version-negotiation-server]
@@ -3547,20 +2636,10 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[87-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [87-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-87]
 ExpectedResult = Success
@@ -3574,7 +2653,6 @@ ssl_conf = 88-version-negotiation-ssl
 
 [88-version-negotiation-ssl]
 server = 88-version-negotiation-server
-server2 = 88-version-negotiation-server2
 client = 88-version-negotiation-client
 
 [88-version-negotiation-server]
@@ -3584,20 +2662,10 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[88-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [88-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-88]
 ExpectedResult = Success
@@ -3611,7 +2679,6 @@ ssl_conf = 89-version-negotiation-ssl
 
 [89-version-negotiation-ssl]
 server = 89-version-negotiation-server
-server2 = 89-version-negotiation-server2
 client = 89-version-negotiation-client
 
 [89-version-negotiation-server]
@@ -3620,19 +2687,10 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[89-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [89-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-89]
 ExpectedResult = Success
@@ -3646,7 +2704,6 @@ ssl_conf = 90-version-negotiation-ssl
 
 [90-version-negotiation-ssl]
 server = 90-version-negotiation-server
-server2 = 90-version-negotiation-server2
 client = 90-version-negotiation-client
 
 [90-version-negotiation-server]
@@ -3656,20 +2713,10 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[90-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [90-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-90]
 ExpectedResult = Success
@@ -3683,7 +2730,6 @@ ssl_conf = 91-version-negotiation-ssl
 
 [91-version-negotiation-ssl]
 server = 91-version-negotiation-server
-server2 = 91-version-negotiation-server2
 client = 91-version-negotiation-client
 
 [91-version-negotiation-server]
@@ -3693,20 +2739,10 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[91-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [91-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-91]
 ExpectedResult = Success
@@ -3720,7 +2756,6 @@ ssl_conf = 92-version-negotiation-ssl
 
 [92-version-negotiation-ssl]
 server = 92-version-negotiation-server
-server2 = 92-version-negotiation-server2
 client = 92-version-negotiation-client
 
 [92-version-negotiation-server]
@@ -3729,19 +2764,10 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[92-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [92-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-92]
 ExpectedResult = Success
@@ -3755,7 +2781,6 @@ ssl_conf = 93-version-negotiation-ssl
 
 [93-version-negotiation-ssl]
 server = 93-version-negotiation-server
-server2 = 93-version-negotiation-server2
 client = 93-version-negotiation-client
 
 [93-version-negotiation-server]
@@ -3765,20 +2790,10 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[93-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [93-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-93]
 ExpectedResult = Success
@@ -3792,7 +2807,6 @@ ssl_conf = 94-version-negotiation-ssl
 
 [94-version-negotiation-ssl]
 server = 94-version-negotiation-server
-server2 = 94-version-negotiation-server2
 client = 94-version-negotiation-client
 
 [94-version-negotiation-server]
@@ -3801,19 +2815,10 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[94-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [94-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-94]
 ExpectedResult = Success
@@ -3827,7 +2832,6 @@ ssl_conf = 95-version-negotiation-ssl
 
 [95-version-negotiation-ssl]
 server = 95-version-negotiation-server
-server2 = 95-version-negotiation-server2
 client = 95-version-negotiation-client
 
 [95-version-negotiation-server]
@@ -3836,21 +2840,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[95-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [95-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-95]
 ExpectedResult = InternalError
@@ -3863,7 +2858,6 @@ ssl_conf = 96-version-negotiation-ssl
 
 [96-version-negotiation-ssl]
 server = 96-version-negotiation-server
-server2 = 96-version-negotiation-server2
 client = 96-version-negotiation-client
 
 [96-version-negotiation-server]
@@ -3872,21 +2866,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[96-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [96-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-96]
 ExpectedResult = InternalError
@@ -3899,7 +2884,6 @@ ssl_conf = 97-version-negotiation-ssl
 
 [97-version-negotiation-ssl]
 server = 97-version-negotiation-server
-server2 = 97-version-negotiation-server2
 client = 97-version-negotiation-client
 
 [97-version-negotiation-server]
@@ -3908,21 +2892,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[97-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [97-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-97]
 ExpectedResult = InternalError
@@ -3935,7 +2910,6 @@ ssl_conf = 98-version-negotiation-ssl
 
 [98-version-negotiation-ssl]
 server = 98-version-negotiation-server
-server2 = 98-version-negotiation-server2
 client = 98-version-negotiation-client
 
 [98-version-negotiation-server]
@@ -3944,21 +2918,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[98-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [98-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-98]
 ExpectedResult = InternalError
@@ -3971,7 +2936,6 @@ ssl_conf = 99-version-negotiation-ssl
 
 [99-version-negotiation-ssl]
 server = 99-version-negotiation-server
-server2 = 99-version-negotiation-server2
 client = 99-version-negotiation-client
 
 [99-version-negotiation-server]
@@ -3979,20 +2943,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[99-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [99-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-99]
 ExpectedResult = InternalError
@@ -4005,7 +2961,6 @@ ssl_conf = 100-version-negotiation-ssl
 
 [100-version-negotiation-ssl]
 server = 100-version-negotiation-server
-server2 = 100-version-negotiation-server2
 client = 100-version-negotiation-client
 
 [100-version-negotiation-server]
@@ -4015,22 +2970,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[100-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [100-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-100]
 ExpectedResult = InternalError
@@ -4043,7 +2988,6 @@ ssl_conf = 101-version-negotiation-ssl
 
 [101-version-negotiation-ssl]
 server = 101-version-negotiation-server
-server2 = 101-version-negotiation-server2
 client = 101-version-negotiation-client
 
 [101-version-negotiation-server]
@@ -4053,22 +2997,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[101-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [101-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-101]
 ExpectedResult = InternalError
@@ -4081,7 +3015,6 @@ ssl_conf = 102-version-negotiation-ssl
 
 [102-version-negotiation-ssl]
 server = 102-version-negotiation-server
-server2 = 102-version-negotiation-server2
 client = 102-version-negotiation-client
 
 [102-version-negotiation-server]
@@ -4091,22 +3024,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[102-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [102-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-102]
 ExpectedResult = InternalError
@@ -4119,7 +3042,6 @@ ssl_conf = 103-version-negotiation-ssl
 
 [103-version-negotiation-ssl]
 server = 103-version-negotiation-server
-server2 = 103-version-negotiation-server2
 client = 103-version-negotiation-client
 
 [103-version-negotiation-server]
@@ -4129,22 +3051,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[103-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [103-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-103]
 ExpectedResult = InternalError
@@ -4157,7 +3069,6 @@ ssl_conf = 104-version-negotiation-ssl
 
 [104-version-negotiation-ssl]
 server = 104-version-negotiation-server
-server2 = 104-version-negotiation-server2
 client = 104-version-negotiation-client
 
 [104-version-negotiation-server]
@@ -4166,21 +3077,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[104-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [104-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-104]
 ExpectedResult = InternalError
@@ -4193,7 +3095,6 @@ ssl_conf = 105-version-negotiation-ssl
 
 [105-version-negotiation-ssl]
 server = 105-version-negotiation-server
-server2 = 105-version-negotiation-server2
 client = 105-version-negotiation-client
 
 [105-version-negotiation-server]
@@ -4203,22 +3104,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[105-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [105-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-105]
 ExpectedResult = InternalError
@@ -4231,7 +3122,6 @@ ssl_conf = 106-version-negotiation-ssl
 
 [106-version-negotiation-ssl]
 server = 106-version-negotiation-server
-server2 = 106-version-negotiation-server2
 client = 106-version-negotiation-client
 
 [106-version-negotiation-server]
@@ -4241,22 +3131,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[106-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [106-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-106]
 ExpectedResult = InternalError
@@ -4269,7 +3149,6 @@ ssl_conf = 107-version-negotiation-ssl
 
 [107-version-negotiation-ssl]
 server = 107-version-negotiation-server
-server2 = 107-version-negotiation-server2
 client = 107-version-negotiation-client
 
 [107-version-negotiation-server]
@@ -4279,22 +3158,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[107-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [107-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-107]
 ExpectedResult = InternalError
@@ -4307,7 +3176,6 @@ ssl_conf = 108-version-negotiation-ssl
 
 [108-version-negotiation-ssl]
 server = 108-version-negotiation-server
-server2 = 108-version-negotiation-server2
 client = 108-version-negotiation-client
 
 [108-version-negotiation-server]
@@ -4316,21 +3184,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[108-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [108-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-108]
 ExpectedResult = InternalError
@@ -4343,7 +3202,6 @@ ssl_conf = 109-version-negotiation-ssl
 
 [109-version-negotiation-ssl]
 server = 109-version-negotiation-server
-server2 = 109-version-negotiation-server2
 client = 109-version-negotiation-client
 
 [109-version-negotiation-server]
@@ -4353,22 +3211,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[109-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [109-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-109]
 ExpectedResult = InternalError
@@ -4381,7 +3229,6 @@ ssl_conf = 110-version-negotiation-ssl
 
 [110-version-negotiation-ssl]
 server = 110-version-negotiation-server
-server2 = 110-version-negotiation-server2
 client = 110-version-negotiation-client
 
 [110-version-negotiation-server]
@@ -4391,22 +3238,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[110-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [110-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-110]
 ExpectedResult = InternalError
@@ -4419,7 +3256,6 @@ ssl_conf = 111-version-negotiation-ssl
 
 [111-version-negotiation-ssl]
 server = 111-version-negotiation-server
-server2 = 111-version-negotiation-server2
 client = 111-version-negotiation-client
 
 [111-version-negotiation-server]
@@ -4428,21 +3264,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[111-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [111-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-111]
 ExpectedResult = InternalError
@@ -4455,7 +3282,6 @@ ssl_conf = 112-version-negotiation-ssl
 
 [112-version-negotiation-ssl]
 server = 112-version-negotiation-server
-server2 = 112-version-negotiation-server2
 client = 112-version-negotiation-client
 
 [112-version-negotiation-server]
@@ -4465,22 +3291,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[112-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [112-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-112]
 ExpectedResult = InternalError
@@ -4493,7 +3309,6 @@ ssl_conf = 113-version-negotiation-ssl
 
 [113-version-negotiation-ssl]
 server = 113-version-negotiation-server
-server2 = 113-version-negotiation-server2
 client = 113-version-negotiation-client
 
 [113-version-negotiation-server]
@@ -4502,21 +3317,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[113-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [113-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-113]
 ExpectedResult = InternalError
@@ -4529,7 +3335,6 @@ ssl_conf = 114-version-negotiation-ssl
 
 [114-version-negotiation-ssl]
 server = 114-version-negotiation-server
-server2 = 114-version-negotiation-server2
 client = 114-version-negotiation-client
 
 [114-version-negotiation-server]
@@ -4538,21 +3343,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[114-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [114-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-114]
 ExpectedResult = ServerFail
@@ -4565,7 +3361,6 @@ ssl_conf = 115-version-negotiation-ssl
 
 [115-version-negotiation-ssl]
 server = 115-version-negotiation-server
-server2 = 115-version-negotiation-server2
 client = 115-version-negotiation-client
 
 [115-version-negotiation-server]
@@ -4574,21 +3369,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[115-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [115-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-115]
 ExpectedResult = Success
@@ -4602,7 +3388,6 @@ ssl_conf = 116-version-negotiation-ssl
 
 [116-version-negotiation-ssl]
 server = 116-version-negotiation-server
-server2 = 116-version-negotiation-server2
 client = 116-version-negotiation-client
 
 [116-version-negotiation-server]
@@ -4611,21 +3396,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[116-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [116-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-116]
 ExpectedResult = Success
@@ -4639,7 +3415,6 @@ ssl_conf = 117-version-negotiation-ssl
 
 [117-version-negotiation-ssl]
 server = 117-version-negotiation-server
-server2 = 117-version-negotiation-server2
 client = 117-version-negotiation-client
 
 [117-version-negotiation-server]
@@ -4648,21 +3423,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[117-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [117-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-117]
 ExpectedResult = Success
@@ -4676,7 +3442,6 @@ ssl_conf = 118-version-negotiation-ssl
 
 [118-version-negotiation-ssl]
 server = 118-version-negotiation-server
-server2 = 118-version-negotiation-server2
 client = 118-version-negotiation-client
 
 [118-version-negotiation-server]
@@ -4684,20 +3449,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[118-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [118-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-118]
 ExpectedResult = Success
@@ -4711,7 +3468,6 @@ ssl_conf = 119-version-negotiation-ssl
 
 [119-version-negotiation-ssl]
 server = 119-version-negotiation-server
-server2 = 119-version-negotiation-server2
 client = 119-version-negotiation-client
 
 [119-version-negotiation-server]
@@ -4721,22 +3477,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[119-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [119-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-119]
 ExpectedResult = ServerFail
@@ -4749,7 +3495,6 @@ ssl_conf = 120-version-negotiation-ssl
 
 [120-version-negotiation-ssl]
 server = 120-version-negotiation-server
-server2 = 120-version-negotiation-server2
 client = 120-version-negotiation-client
 
 [120-version-negotiation-server]
@@ -4759,22 +3504,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[120-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [120-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-120]
 ExpectedResult = Success
@@ -4788,7 +3523,6 @@ ssl_conf = 121-version-negotiation-ssl
 
 [121-version-negotiation-ssl]
 server = 121-version-negotiation-server
-server2 = 121-version-negotiation-server2
 client = 121-version-negotiation-client
 
 [121-version-negotiation-server]
@@ -4798,22 +3532,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[121-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [121-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-121]
 ExpectedResult = Success
@@ -4827,7 +3551,6 @@ ssl_conf = 122-version-negotiation-ssl
 
 [122-version-negotiation-ssl]
 server = 122-version-negotiation-server
-server2 = 122-version-negotiation-server2
 client = 122-version-negotiation-client
 
 [122-version-negotiation-server]
@@ -4837,22 +3560,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[122-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [122-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-122]
 ExpectedResult = Success
@@ -4866,7 +3579,6 @@ ssl_conf = 123-version-negotiation-ssl
 
 [123-version-negotiation-ssl]
 server = 123-version-negotiation-server
-server2 = 123-version-negotiation-server2
 client = 123-version-negotiation-client
 
 [123-version-negotiation-server]
@@ -4875,21 +3587,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[123-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [123-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-123]
 ExpectedResult = Success
@@ -4903,7 +3606,6 @@ ssl_conf = 124-version-negotiation-ssl
 
 [124-version-negotiation-ssl]
 server = 124-version-negotiation-server
-server2 = 124-version-negotiation-server2
 client = 124-version-negotiation-client
 
 [124-version-negotiation-server]
@@ -4913,22 +3615,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[124-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [124-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-124]
 ExpectedResult = Success
@@ -4942,7 +3634,6 @@ ssl_conf = 125-version-negotiation-ssl
 
 [125-version-negotiation-ssl]
 server = 125-version-negotiation-server
-server2 = 125-version-negotiation-server2
 client = 125-version-negotiation-client
 
 [125-version-negotiation-server]
@@ -4952,22 +3643,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[125-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [125-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-125]
 ExpectedResult = Success
@@ -4981,7 +3662,6 @@ ssl_conf = 126-version-negotiation-ssl
 
 [126-version-negotiation-ssl]
 server = 126-version-negotiation-server
-server2 = 126-version-negotiation-server2
 client = 126-version-negotiation-client
 
 [126-version-negotiation-server]
@@ -4991,22 +3671,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[126-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [126-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-126]
 ExpectedResult = Success
@@ -5020,7 +3690,6 @@ ssl_conf = 127-version-negotiation-ssl
 
 [127-version-negotiation-ssl]
 server = 127-version-negotiation-server
-server2 = 127-version-negotiation-server2
 client = 127-version-negotiation-client
 
 [127-version-negotiation-server]
@@ -5029,21 +3698,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[127-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [127-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-127]
 ExpectedResult = Success
@@ -5057,7 +3717,6 @@ ssl_conf = 128-version-negotiation-ssl
 
 [128-version-negotiation-ssl]
 server = 128-version-negotiation-server
-server2 = 128-version-negotiation-server2
 client = 128-version-negotiation-client
 
 [128-version-negotiation-server]
@@ -5067,22 +3726,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[128-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [128-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-128]
 ExpectedResult = ServerFail
@@ -5095,7 +3744,6 @@ ssl_conf = 129-version-negotiation-ssl
 
 [129-version-negotiation-ssl]
 server = 129-version-negotiation-server
-server2 = 129-version-negotiation-server2
 client = 129-version-negotiation-client
 
 [129-version-negotiation-server]
@@ -5105,22 +3753,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[129-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [129-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-129]
 ExpectedResult = ServerFail
@@ -5133,7 +3771,6 @@ ssl_conf = 130-version-negotiation-ssl
 
 [130-version-negotiation-ssl]
 server = 130-version-negotiation-server
-server2 = 130-version-negotiation-server2
 client = 130-version-negotiation-client
 
 [130-version-negotiation-server]
@@ -5142,21 +3779,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[130-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [130-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-130]
 ExpectedResult = ServerFail
@@ -5169,7 +3797,6 @@ ssl_conf = 131-version-negotiation-ssl
 
 [131-version-negotiation-ssl]
 server = 131-version-negotiation-server
-server2 = 131-version-negotiation-server2
 client = 131-version-negotiation-client
 
 [131-version-negotiation-server]
@@ -5179,22 +3806,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[131-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [131-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-131]
 ExpectedResult = ServerFail
@@ -5207,7 +3824,6 @@ ssl_conf = 132-version-negotiation-ssl
 
 [132-version-negotiation-ssl]
 server = 132-version-negotiation-server
-server2 = 132-version-negotiation-server2
 client = 132-version-negotiation-client
 
 [132-version-negotiation-server]
@@ -5216,21 +3832,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[132-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [132-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-132]
 ExpectedResult = ServerFail
@@ -5243,7 +3850,6 @@ ssl_conf = 133-version-negotiation-ssl
 
 [133-version-negotiation-ssl]
 server = 133-version-negotiation-server
-server2 = 133-version-negotiation-server2
 client = 133-version-negotiation-client
 
 [133-version-negotiation-server]
@@ -5252,21 +3858,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[133-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [133-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-133]
 ExpectedResult = ServerFail
@@ -5279,7 +3876,6 @@ ssl_conf = 134-version-negotiation-ssl
 
 [134-version-negotiation-ssl]
 server = 134-version-negotiation-server
-server2 = 134-version-negotiation-server2
 client = 134-version-negotiation-client
 
 [134-version-negotiation-server]
@@ -5288,21 +3884,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[134-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [134-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-134]
 ExpectedResult = Success
@@ -5316,7 +3903,6 @@ ssl_conf = 135-version-negotiation-ssl
 
 [135-version-negotiation-ssl]
 server = 135-version-negotiation-server
-server2 = 135-version-negotiation-server2
 client = 135-version-negotiation-client
 
 [135-version-negotiation-server]
@@ -5325,21 +3911,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[135-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [135-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-135]
 ExpectedResult = Success
@@ -5353,7 +3930,6 @@ ssl_conf = 136-version-negotiation-ssl
 
 [136-version-negotiation-ssl]
 server = 136-version-negotiation-server
-server2 = 136-version-negotiation-server2
 client = 136-version-negotiation-client
 
 [136-version-negotiation-server]
@@ -5362,21 +3938,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[136-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [136-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-136]
 ExpectedResult = Success
@@ -5390,7 +3957,6 @@ ssl_conf = 137-version-negotiation-ssl
 
 [137-version-negotiation-ssl]
 server = 137-version-negotiation-server
-server2 = 137-version-negotiation-server2
 client = 137-version-negotiation-client
 
 [137-version-negotiation-server]
@@ -5398,20 +3964,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[137-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [137-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-137]
 ExpectedResult = Success
@@ -5425,7 +3983,6 @@ ssl_conf = 138-version-negotiation-ssl
 
 [138-version-negotiation-ssl]
 server = 138-version-negotiation-server
-server2 = 138-version-negotiation-server2
 client = 138-version-negotiation-client
 
 [138-version-negotiation-server]
@@ -5435,22 +3992,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[138-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [138-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-138]
 ExpectedResult = ServerFail
@@ -5463,7 +4010,6 @@ ssl_conf = 139-version-negotiation-ssl
 
 [139-version-negotiation-ssl]
 server = 139-version-negotiation-server
-server2 = 139-version-negotiation-server2
 client = 139-version-negotiation-client
 
 [139-version-negotiation-server]
@@ -5473,22 +4019,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[139-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [139-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-139]
 ExpectedResult = Success
@@ -5502,7 +4038,6 @@ ssl_conf = 140-version-negotiation-ssl
 
 [140-version-negotiation-ssl]
 server = 140-version-negotiation-server
-server2 = 140-version-negotiation-server2
 client = 140-version-negotiation-client
 
 [140-version-negotiation-server]
@@ -5512,22 +4047,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[140-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [140-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-140]
 ExpectedResult = Success
@@ -5541,7 +4066,6 @@ ssl_conf = 141-version-negotiation-ssl
 
 [141-version-negotiation-ssl]
 server = 141-version-negotiation-server
-server2 = 141-version-negotiation-server2
 client = 141-version-negotiation-client
 
 [141-version-negotiation-server]
@@ -5551,22 +4075,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[141-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [141-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-141]
 ExpectedResult = Success
@@ -5580,7 +4094,6 @@ ssl_conf = 142-version-negotiation-ssl
 
 [142-version-negotiation-ssl]
 server = 142-version-negotiation-server
-server2 = 142-version-negotiation-server2
 client = 142-version-negotiation-client
 
 [142-version-negotiation-server]
@@ -5589,21 +4102,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[142-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [142-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-142]
 ExpectedResult = Success
@@ -5617,7 +4121,6 @@ ssl_conf = 143-version-negotiation-ssl
 
 [143-version-negotiation-ssl]
 server = 143-version-negotiation-server
-server2 = 143-version-negotiation-server2
 client = 143-version-negotiation-client
 
 [143-version-negotiation-server]
@@ -5627,22 +4130,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[143-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [143-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-143]
 ExpectedResult = Success
@@ -5656,7 +4149,6 @@ ssl_conf = 144-version-negotiation-ssl
 
 [144-version-negotiation-ssl]
 server = 144-version-negotiation-server
-server2 = 144-version-negotiation-server2
 client = 144-version-negotiation-client
 
 [144-version-negotiation-server]
@@ -5666,22 +4158,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[144-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [144-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-144]
 ExpectedResult = Success
@@ -5695,7 +4177,6 @@ ssl_conf = 145-version-negotiation-ssl
 
 [145-version-negotiation-ssl]
 server = 145-version-negotiation-server
-server2 = 145-version-negotiation-server2
 client = 145-version-negotiation-client
 
 [145-version-negotiation-server]
@@ -5705,22 +4186,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[145-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [145-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-145]
 ExpectedResult = Success
@@ -5734,7 +4205,6 @@ ssl_conf = 146-version-negotiation-ssl
 
 [146-version-negotiation-ssl]
 server = 146-version-negotiation-server
-server2 = 146-version-negotiation-server2
 client = 146-version-negotiation-client
 
 [146-version-negotiation-server]
@@ -5743,21 +4213,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[146-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [146-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-146]
 ExpectedResult = Success
@@ -5771,7 +4232,6 @@ ssl_conf = 147-version-negotiation-ssl
 
 [147-version-negotiation-ssl]
 server = 147-version-negotiation-server
-server2 = 147-version-negotiation-server2
 client = 147-version-negotiation-client
 
 [147-version-negotiation-server]
@@ -5781,22 +4241,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[147-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [147-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-147]
 ExpectedResult = Success
@@ -5810,7 +4260,6 @@ ssl_conf = 148-version-negotiation-ssl
 
 [148-version-negotiation-ssl]
 server = 148-version-negotiation-server
-server2 = 148-version-negotiation-server2
 client = 148-version-negotiation-client
 
 [148-version-negotiation-server]
@@ -5820,22 +4269,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[148-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [148-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-148]
 ExpectedResult = Success
@@ -5849,7 +4288,6 @@ ssl_conf = 149-version-negotiation-ssl
 
 [149-version-negotiation-ssl]
 server = 149-version-negotiation-server
-server2 = 149-version-negotiation-server2
 client = 149-version-negotiation-client
 
 [149-version-negotiation-server]
@@ -5858,21 +4296,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[149-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [149-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-149]
 ExpectedResult = Success
@@ -5886,7 +4315,6 @@ ssl_conf = 150-version-negotiation-ssl
 
 [150-version-negotiation-ssl]
 server = 150-version-negotiation-server
-server2 = 150-version-negotiation-server2
 client = 150-version-negotiation-client
 
 [150-version-negotiation-server]
@@ -5896,22 +4324,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[150-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [150-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-150]
 ExpectedResult = ServerFail
@@ -5924,7 +4342,6 @@ ssl_conf = 151-version-negotiation-ssl
 
 [151-version-negotiation-ssl]
 server = 151-version-negotiation-server
-server2 = 151-version-negotiation-server2
 client = 151-version-negotiation-client
 
 [151-version-negotiation-server]
@@ -5933,21 +4350,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[151-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [151-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-151]
 ExpectedResult = ServerFail
@@ -5960,7 +4368,6 @@ ssl_conf = 152-version-negotiation-ssl
 
 [152-version-negotiation-ssl]
 server = 152-version-negotiation-server
-server2 = 152-version-negotiation-server2
 client = 152-version-negotiation-client
 
 [152-version-negotiation-server]
@@ -5969,21 +4376,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[152-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [152-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-152]
 ExpectedResult = ServerFail
@@ -5996,7 +4394,6 @@ ssl_conf = 153-version-negotiation-ssl
 
 [153-version-negotiation-ssl]
 server = 153-version-negotiation-server
-server2 = 153-version-negotiation-server2
 client = 153-version-negotiation-client
 
 [153-version-negotiation-server]
@@ -6005,21 +4402,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[153-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [153-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-153]
 ExpectedResult = Success
@@ -6033,7 +4421,6 @@ ssl_conf = 154-version-negotiation-ssl
 
 [154-version-negotiation-ssl]
 server = 154-version-negotiation-server
-server2 = 154-version-negotiation-server2
 client = 154-version-negotiation-client
 
 [154-version-negotiation-server]
@@ -6042,21 +4429,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[154-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [154-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-154]
 ExpectedResult = Success
@@ -6070,7 +4448,6 @@ ssl_conf = 155-version-negotiation-ssl
 
 [155-version-negotiation-ssl]
 server = 155-version-negotiation-server
-server2 = 155-version-negotiation-server2
 client = 155-version-negotiation-client
 
 [155-version-negotiation-server]
@@ -6079,21 +4456,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[155-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [155-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-155]
 ExpectedResult = Success
@@ -6107,7 +4475,6 @@ ssl_conf = 156-version-negotiation-ssl
 
 [156-version-negotiation-ssl]
 server = 156-version-negotiation-server
-server2 = 156-version-negotiation-server2
 client = 156-version-negotiation-client
 
 [156-version-negotiation-server]
@@ -6115,20 +4482,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[156-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [156-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-156]
 ExpectedResult = Success
@@ -6142,7 +4501,6 @@ ssl_conf = 157-version-negotiation-ssl
 
 [157-version-negotiation-ssl]
 server = 157-version-negotiation-server
-server2 = 157-version-negotiation-server2
 client = 157-version-negotiation-client
 
 [157-version-negotiation-server]
@@ -6152,22 +4510,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[157-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [157-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-157]
 ExpectedResult = ServerFail
@@ -6180,7 +4528,6 @@ ssl_conf = 158-version-negotiation-ssl
 
 [158-version-negotiation-ssl]
 server = 158-version-negotiation-server
-server2 = 158-version-negotiation-server2
 client = 158-version-negotiation-client
 
 [158-version-negotiation-server]
@@ -6190,22 +4537,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[158-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [158-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-158]
 ExpectedResult = Success
@@ -6219,7 +4556,6 @@ ssl_conf = 159-version-negotiation-ssl
 
 [159-version-negotiation-ssl]
 server = 159-version-negotiation-server
-server2 = 159-version-negotiation-server2
 client = 159-version-negotiation-client
 
 [159-version-negotiation-server]
@@ -6229,22 +4565,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[159-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [159-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-159]
 ExpectedResult = Success
@@ -6258,7 +4584,6 @@ ssl_conf = 160-version-negotiation-ssl
 
 [160-version-negotiation-ssl]
 server = 160-version-negotiation-server
-server2 = 160-version-negotiation-server2
 client = 160-version-negotiation-client
 
 [160-version-negotiation-server]
@@ -6268,22 +4593,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[160-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [160-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-160]
 ExpectedResult = Success
@@ -6297,7 +4612,6 @@ ssl_conf = 161-version-negotiation-ssl
 
 [161-version-negotiation-ssl]
 server = 161-version-negotiation-server
-server2 = 161-version-negotiation-server2
 client = 161-version-negotiation-client
 
 [161-version-negotiation-server]
@@ -6306,21 +4620,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[161-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [161-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-161]
 ExpectedResult = Success
@@ -6334,7 +4639,6 @@ ssl_conf = 162-version-negotiation-ssl
 
 [162-version-negotiation-ssl]
 server = 162-version-negotiation-server
-server2 = 162-version-negotiation-server2
 client = 162-version-negotiation-client
 
 [162-version-negotiation-server]
@@ -6344,22 +4648,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[162-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [162-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-162]
 ExpectedResult = Success
@@ -6373,7 +4667,6 @@ ssl_conf = 163-version-negotiation-ssl
 
 [163-version-negotiation-ssl]
 server = 163-version-negotiation-server
-server2 = 163-version-negotiation-server2
 client = 163-version-negotiation-client
 
 [163-version-negotiation-server]
@@ -6383,22 +4676,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[163-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [163-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-163]
 ExpectedResult = Success
@@ -6412,7 +4695,6 @@ ssl_conf = 164-version-negotiation-ssl
 
 [164-version-negotiation-ssl]
 server = 164-version-negotiation-server
-server2 = 164-version-negotiation-server2
 client = 164-version-negotiation-client
 
 [164-version-negotiation-server]
@@ -6422,22 +4704,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[164-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [164-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-164]
 ExpectedResult = Success
@@ -6451,7 +4723,6 @@ ssl_conf = 165-version-negotiation-ssl
 
 [165-version-negotiation-ssl]
 server = 165-version-negotiation-server
-server2 = 165-version-negotiation-server2
 client = 165-version-negotiation-client
 
 [165-version-negotiation-server]
@@ -6460,21 +4731,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[165-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [165-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-165]
 ExpectedResult = Success
@@ -6488,7 +4750,6 @@ ssl_conf = 166-version-negotiation-ssl
 
 [166-version-negotiation-ssl]
 server = 166-version-negotiation-server
-server2 = 166-version-negotiation-server2
 client = 166-version-negotiation-client
 
 [166-version-negotiation-server]
@@ -6498,22 +4759,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[166-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [166-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-166]
 ExpectedResult = Success
@@ -6527,7 +4778,6 @@ ssl_conf = 167-version-negotiation-ssl
 
 [167-version-negotiation-ssl]
 server = 167-version-negotiation-server
-server2 = 167-version-negotiation-server2
 client = 167-version-negotiation-client
 
 [167-version-negotiation-server]
@@ -6537,22 +4787,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[167-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [167-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-167]
 ExpectedResult = Success
@@ -6566,7 +4806,6 @@ ssl_conf = 168-version-negotiation-ssl
 
 [168-version-negotiation-ssl]
 server = 168-version-negotiation-server
-server2 = 168-version-negotiation-server2
 client = 168-version-negotiation-client
 
 [168-version-negotiation-server]
@@ -6575,21 +4814,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[168-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [168-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-168]
 ExpectedResult = Success
@@ -6603,7 +4833,6 @@ ssl_conf = 169-version-negotiation-ssl
 
 [169-version-negotiation-ssl]
 server = 169-version-negotiation-server
-server2 = 169-version-negotiation-server2
 client = 169-version-negotiation-client
 
 [169-version-negotiation-server]
@@ -6613,22 +4842,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[169-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [169-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-169]
 ExpectedResult = Success
@@ -6642,7 +4861,6 @@ ssl_conf = 170-version-negotiation-ssl
 
 [170-version-negotiation-ssl]
 server = 170-version-negotiation-server
-server2 = 170-version-negotiation-server2
 client = 170-version-negotiation-client
 
 [170-version-negotiation-server]
@@ -6651,21 +4869,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[170-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [170-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-170]
 ExpectedResult = Success
@@ -6679,7 +4888,6 @@ ssl_conf = 171-version-negotiation-ssl
 
 [171-version-negotiation-ssl]
 server = 171-version-negotiation-server
-server2 = 171-version-negotiation-server2
 client = 171-version-negotiation-client
 
 [171-version-negotiation-server]
@@ -6688,20 +4896,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[171-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [171-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-171]
 ExpectedResult = ServerFail
@@ -6714,7 +4913,6 @@ ssl_conf = 172-version-negotiation-ssl
 
 [172-version-negotiation-ssl]
 server = 172-version-negotiation-server
-server2 = 172-version-negotiation-server2
 client = 172-version-negotiation-client
 
 [172-version-negotiation-server]
@@ -6723,20 +4921,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[172-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [172-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-172]
 ExpectedResult = Success
@@ -6750,7 +4939,6 @@ ssl_conf = 173-version-negotiation-ssl
 
 [173-version-negotiation-ssl]
 server = 173-version-negotiation-server
-server2 = 173-version-negotiation-server2
 client = 173-version-negotiation-client
 
 [173-version-negotiation-server]
@@ -6759,20 +4947,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[173-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [173-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-173]
 ExpectedResult = Success
@@ -6786,7 +4965,6 @@ ssl_conf = 174-version-negotiation-ssl
 
 [174-version-negotiation-ssl]
 server = 174-version-negotiation-server
-server2 = 174-version-negotiation-server2
 client = 174-version-negotiation-client
 
 [174-version-negotiation-server]
@@ -6795,20 +4973,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[174-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [174-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-174]
 ExpectedResult = Success
@@ -6822,7 +4991,6 @@ ssl_conf = 175-version-negotiation-ssl
 
 [175-version-negotiation-ssl]
 server = 175-version-negotiation-server
-server2 = 175-version-negotiation-server2
 client = 175-version-negotiation-client
 
 [175-version-negotiation-server]
@@ -6830,19 +4998,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[175-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [175-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-175]
 ExpectedResult = Success
@@ -6856,7 +5016,6 @@ ssl_conf = 176-version-negotiation-ssl
 
 [176-version-negotiation-ssl]
 server = 176-version-negotiation-server
-server2 = 176-version-negotiation-server2
 client = 176-version-negotiation-client
 
 [176-version-negotiation-server]
@@ -6866,21 +5025,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[176-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [176-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-176]
 ExpectedResult = ServerFail
@@ -6893,7 +5042,6 @@ ssl_conf = 177-version-negotiation-ssl
 
 [177-version-negotiation-ssl]
 server = 177-version-negotiation-server
-server2 = 177-version-negotiation-server2
 client = 177-version-negotiation-client
 
 [177-version-negotiation-server]
@@ -6903,21 +5051,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[177-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [177-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-177]
 ExpectedResult = Success
@@ -6931,7 +5069,6 @@ ssl_conf = 178-version-negotiation-ssl
 
 [178-version-negotiation-ssl]
 server = 178-version-negotiation-server
-server2 = 178-version-negotiation-server2
 client = 178-version-negotiation-client
 
 [178-version-negotiation-server]
@@ -6941,21 +5078,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[178-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [178-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-178]
 ExpectedResult = Success
@@ -6969,7 +5096,6 @@ ssl_conf = 179-version-negotiation-ssl
 
 [179-version-negotiation-ssl]
 server = 179-version-negotiation-server
-server2 = 179-version-negotiation-server2
 client = 179-version-negotiation-client
 
 [179-version-negotiation-server]
@@ -6979,21 +5105,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[179-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [179-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-179]
 ExpectedResult = Success
@@ -7007,7 +5123,6 @@ ssl_conf = 180-version-negotiation-ssl
 
 [180-version-negotiation-ssl]
 server = 180-version-negotiation-server
-server2 = 180-version-negotiation-server2
 client = 180-version-negotiation-client
 
 [180-version-negotiation-server]
@@ -7016,20 +5131,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[180-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [180-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-180]
 ExpectedResult = Success
@@ -7043,7 +5149,6 @@ ssl_conf = 181-version-negotiation-ssl
 
 [181-version-negotiation-ssl]
 server = 181-version-negotiation-server
-server2 = 181-version-negotiation-server2
 client = 181-version-negotiation-client
 
 [181-version-negotiation-server]
@@ -7053,21 +5158,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[181-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [181-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-181]
 ExpectedResult = Success
@@ -7081,7 +5176,6 @@ ssl_conf = 182-version-negotiation-ssl
 
 [182-version-negotiation-ssl]
 server = 182-version-negotiation-server
-server2 = 182-version-negotiation-server2
 client = 182-version-negotiation-client
 
 [182-version-negotiation-server]
@@ -7091,21 +5185,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[182-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [182-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-182]
 ExpectedResult = Success
@@ -7119,7 +5203,6 @@ ssl_conf = 183-version-negotiation-ssl
 
 [183-version-negotiation-ssl]
 server = 183-version-negotiation-server
-server2 = 183-version-negotiation-server2
 client = 183-version-negotiation-client
 
 [183-version-negotiation-server]
@@ -7129,21 +5212,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[183-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [183-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-183]
 ExpectedResult = Success
@@ -7157,7 +5230,6 @@ ssl_conf = 184-version-negotiation-ssl
 
 [184-version-negotiation-ssl]
 server = 184-version-negotiation-server
-server2 = 184-version-negotiation-server2
 client = 184-version-negotiation-client
 
 [184-version-negotiation-server]
@@ -7166,20 +5238,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[184-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [184-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-184]
 ExpectedResult = Success
@@ -7193,7 +5256,6 @@ ssl_conf = 185-version-negotiation-ssl
 
 [185-version-negotiation-ssl]
 server = 185-version-negotiation-server
-server2 = 185-version-negotiation-server2
 client = 185-version-negotiation-client
 
 [185-version-negotiation-server]
@@ -7203,21 +5265,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[185-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [185-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-185]
 ExpectedResult = Success
@@ -7231,7 +5283,6 @@ ssl_conf = 186-version-negotiation-ssl
 
 [186-version-negotiation-ssl]
 server = 186-version-negotiation-server
-server2 = 186-version-negotiation-server2
 client = 186-version-negotiation-client
 
 [186-version-negotiation-server]
@@ -7241,21 +5292,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[186-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [186-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-186]
 ExpectedResult = Success
@@ -7269,7 +5310,6 @@ ssl_conf = 187-version-negotiation-ssl
 
 [187-version-negotiation-ssl]
 server = 187-version-negotiation-server
-server2 = 187-version-negotiation-server2
 client = 187-version-negotiation-client
 
 [187-version-negotiation-server]
@@ -7278,20 +5318,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[187-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [187-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-187]
 ExpectedResult = Success
@@ -7305,7 +5336,6 @@ ssl_conf = 188-version-negotiation-ssl
 
 [188-version-negotiation-ssl]
 server = 188-version-negotiation-server
-server2 = 188-version-negotiation-server2
 client = 188-version-negotiation-client
 
 [188-version-negotiation-server]
@@ -7315,21 +5345,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[188-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [188-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-188]
 ExpectedResult = Success
@@ -7343,7 +5363,6 @@ ssl_conf = 189-version-negotiation-ssl
 
 [189-version-negotiation-ssl]
 server = 189-version-negotiation-server
-server2 = 189-version-negotiation-server2
 client = 189-version-negotiation-client
 
 [189-version-negotiation-server]
@@ -7352,20 +5371,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[189-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [189-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-189]
 ExpectedResult = Success
@@ -7379,7 +5389,6 @@ ssl_conf = 190-version-negotiation-ssl
 
 [190-version-negotiation-ssl]
 server = 190-version-negotiation-server
-server2 = 190-version-negotiation-server2
 client = 190-version-negotiation-client
 
 [190-version-negotiation-server]
@@ -7388,21 +5397,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[190-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [190-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-190]
 ExpectedResult = ServerFail
@@ -7415,7 +5415,6 @@ ssl_conf = 191-version-negotiation-ssl
 
 [191-version-negotiation-ssl]
 server = 191-version-negotiation-server
-server2 = 191-version-negotiation-server2
 client = 191-version-negotiation-client
 
 [191-version-negotiation-server]
@@ -7424,21 +5423,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[191-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [191-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-191]
 ExpectedResult = Success
@@ -7452,7 +5442,6 @@ ssl_conf = 192-version-negotiation-ssl
 
 [192-version-negotiation-ssl]
 server = 192-version-negotiation-server
-server2 = 192-version-negotiation-server2
 client = 192-version-negotiation-client
 
 [192-version-negotiation-server]
@@ -7461,21 +5450,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[192-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [192-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-192]
 ExpectedResult = Success
@@ -7489,7 +5469,6 @@ ssl_conf = 193-version-negotiation-ssl
 
 [193-version-negotiation-ssl]
 server = 193-version-negotiation-server
-server2 = 193-version-negotiation-server2
 client = 193-version-negotiation-client
 
 [193-version-negotiation-server]
@@ -7498,21 +5477,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[193-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [193-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-193]
 ExpectedResult = Success
@@ -7526,7 +5496,6 @@ ssl_conf = 194-version-negotiation-ssl
 
 [194-version-negotiation-ssl]
 server = 194-version-negotiation-server
-server2 = 194-version-negotiation-server2
 client = 194-version-negotiation-client
 
 [194-version-negotiation-server]
@@ -7534,20 +5503,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[194-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [194-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-194]
 ExpectedResult = Success
@@ -7561,7 +5522,6 @@ ssl_conf = 195-version-negotiation-ssl
 
 [195-version-negotiation-ssl]
 server = 195-version-negotiation-server
-server2 = 195-version-negotiation-server2
 client = 195-version-negotiation-client
 
 [195-version-negotiation-server]
@@ -7571,22 +5531,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[195-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [195-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-195]
 ExpectedResult = ServerFail
@@ -7599,7 +5549,6 @@ ssl_conf = 196-version-negotiation-ssl
 
 [196-version-negotiation-ssl]
 server = 196-version-negotiation-server
-server2 = 196-version-negotiation-server2
 client = 196-version-negotiation-client
 
 [196-version-negotiation-server]
@@ -7609,22 +5558,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[196-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [196-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-196]
 ExpectedResult = Success
@@ -7638,7 +5577,6 @@ ssl_conf = 197-version-negotiation-ssl
 
 [197-version-negotiation-ssl]
 server = 197-version-negotiation-server
-server2 = 197-version-negotiation-server2
 client = 197-version-negotiation-client
 
 [197-version-negotiation-server]
@@ -7648,22 +5586,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[197-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [197-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-197]
 ExpectedResult = Success
@@ -7677,7 +5605,6 @@ ssl_conf = 198-version-negotiation-ssl
 
 [198-version-negotiation-ssl]
 server = 198-version-negotiation-server
-server2 = 198-version-negotiation-server2
 client = 198-version-negotiation-client
 
 [198-version-negotiation-server]
@@ -7687,22 +5614,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[198-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [198-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-198]
 ExpectedResult = Success
@@ -7716,7 +5633,6 @@ ssl_conf = 199-version-negotiation-ssl
 
 [199-version-negotiation-ssl]
 server = 199-version-negotiation-server
-server2 = 199-version-negotiation-server2
 client = 199-version-negotiation-client
 
 [199-version-negotiation-server]
@@ -7725,21 +5641,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[199-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [199-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-199]
 ExpectedResult = Success
@@ -7753,7 +5660,6 @@ ssl_conf = 200-version-negotiation-ssl
 
 [200-version-negotiation-ssl]
 server = 200-version-negotiation-server
-server2 = 200-version-negotiation-server2
 client = 200-version-negotiation-client
 
 [200-version-negotiation-server]
@@ -7763,22 +5669,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[200-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [200-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-200]
 ExpectedResult = Success
@@ -7792,7 +5688,6 @@ ssl_conf = 201-version-negotiation-ssl
 
 [201-version-negotiation-ssl]
 server = 201-version-negotiation-server
-server2 = 201-version-negotiation-server2
 client = 201-version-negotiation-client
 
 [201-version-negotiation-server]
@@ -7802,22 +5697,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[201-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [201-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-201]
 ExpectedResult = Success
@@ -7831,7 +5716,6 @@ ssl_conf = 202-version-negotiation-ssl
 
 [202-version-negotiation-ssl]
 server = 202-version-negotiation-server
-server2 = 202-version-negotiation-server2
 client = 202-version-negotiation-client
 
 [202-version-negotiation-server]
@@ -7841,22 +5725,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[202-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [202-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-202]
 ExpectedResult = Success
@@ -7870,7 +5744,6 @@ ssl_conf = 203-version-negotiation-ssl
 
 [203-version-negotiation-ssl]
 server = 203-version-negotiation-server
-server2 = 203-version-negotiation-server2
 client = 203-version-negotiation-client
 
 [203-version-negotiation-server]
@@ -7879,21 +5752,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[203-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [203-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-203]
 ExpectedResult = Success
@@ -7907,7 +5771,6 @@ ssl_conf = 204-version-negotiation-ssl
 
 [204-version-negotiation-ssl]
 server = 204-version-negotiation-server
-server2 = 204-version-negotiation-server2
 client = 204-version-negotiation-client
 
 [204-version-negotiation-server]
@@ -7917,22 +5780,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[204-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [204-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-204]
 ExpectedResult = ServerFail
@@ -7945,7 +5798,6 @@ ssl_conf = 205-version-negotiation-ssl
 
 [205-version-negotiation-ssl]
 server = 205-version-negotiation-server
-server2 = 205-version-negotiation-server2
 client = 205-version-negotiation-client
 
 [205-version-negotiation-server]
@@ -7955,22 +5807,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[205-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [205-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-205]
 ExpectedResult = ServerFail
@@ -7983,7 +5825,6 @@ ssl_conf = 206-version-negotiation-ssl
 
 [206-version-negotiation-ssl]
 server = 206-version-negotiation-server
-server2 = 206-version-negotiation-server2
 client = 206-version-negotiation-client
 
 [206-version-negotiation-server]
@@ -7992,21 +5833,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[206-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [206-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-206]
 ExpectedResult = ServerFail
@@ -8019,7 +5851,6 @@ ssl_conf = 207-version-negotiation-ssl
 
 [207-version-negotiation-ssl]
 server = 207-version-negotiation-server
-server2 = 207-version-negotiation-server2
 client = 207-version-negotiation-client
 
 [207-version-negotiation-server]
@@ -8029,22 +5860,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[207-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [207-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-207]
 ExpectedResult = ServerFail
@@ -8057,7 +5878,6 @@ ssl_conf = 208-version-negotiation-ssl
 
 [208-version-negotiation-ssl]
 server = 208-version-negotiation-server
-server2 = 208-version-negotiation-server2
 client = 208-version-negotiation-client
 
 [208-version-negotiation-server]
@@ -8066,21 +5886,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[208-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [208-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-208]
 ExpectedResult = ServerFail
@@ -8093,7 +5904,6 @@ ssl_conf = 209-version-negotiation-ssl
 
 [209-version-negotiation-ssl]
 server = 209-version-negotiation-server
-server2 = 209-version-negotiation-server2
 client = 209-version-negotiation-client
 
 [209-version-negotiation-server]
@@ -8102,21 +5912,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[209-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [209-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-209]
 ExpectedResult = ServerFail
@@ -8129,7 +5930,6 @@ ssl_conf = 210-version-negotiation-ssl
 
 [210-version-negotiation-ssl]
 server = 210-version-negotiation-server
-server2 = 210-version-negotiation-server2
 client = 210-version-negotiation-client
 
 [210-version-negotiation-server]
@@ -8138,21 +5938,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[210-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [210-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-210]
 ExpectedResult = Success
@@ -8166,7 +5957,6 @@ ssl_conf = 211-version-negotiation-ssl
 
 [211-version-negotiation-ssl]
 server = 211-version-negotiation-server
-server2 = 211-version-negotiation-server2
 client = 211-version-negotiation-client
 
 [211-version-negotiation-server]
@@ -8175,21 +5965,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[211-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [211-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-211]
 ExpectedResult = Success
@@ -8203,7 +5984,6 @@ ssl_conf = 212-version-negotiation-ssl
 
 [212-version-negotiation-ssl]
 server = 212-version-negotiation-server
-server2 = 212-version-negotiation-server2
 client = 212-version-negotiation-client
 
 [212-version-negotiation-server]
@@ -8212,21 +5992,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[212-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [212-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-212]
 ExpectedResult = Success
@@ -8240,7 +6011,6 @@ ssl_conf = 213-version-negotiation-ssl
 
 [213-version-negotiation-ssl]
 server = 213-version-negotiation-server
-server2 = 213-version-negotiation-server2
 client = 213-version-negotiation-client
 
 [213-version-negotiation-server]
@@ -8248,20 +6018,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[213-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [213-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-213]
 ExpectedResult = Success
@@ -8275,7 +6037,6 @@ ssl_conf = 214-version-negotiation-ssl
 
 [214-version-negotiation-ssl]
 server = 214-version-negotiation-server
-server2 = 214-version-negotiation-server2
 client = 214-version-negotiation-client
 
 [214-version-negotiation-server]
@@ -8285,22 +6046,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[214-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [214-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-214]
 ExpectedResult = ServerFail
@@ -8313,7 +6064,6 @@ ssl_conf = 215-version-negotiation-ssl
 
 [215-version-negotiation-ssl]
 server = 215-version-negotiation-server
-server2 = 215-version-negotiation-server2
 client = 215-version-negotiation-client
 
 [215-version-negotiation-server]
@@ -8323,22 +6073,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[215-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [215-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-215]
 ExpectedResult = Success
@@ -8352,7 +6092,6 @@ ssl_conf = 216-version-negotiation-ssl
 
 [216-version-negotiation-ssl]
 server = 216-version-negotiation-server
-server2 = 216-version-negotiation-server2
 client = 216-version-negotiation-client
 
 [216-version-negotiation-server]
@@ -8362,22 +6101,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[216-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [216-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-216]
 ExpectedResult = Success
@@ -8391,7 +6120,6 @@ ssl_conf = 217-version-negotiation-ssl
 
 [217-version-negotiation-ssl]
 server = 217-version-negotiation-server
-server2 = 217-version-negotiation-server2
 client = 217-version-negotiation-client
 
 [217-version-negotiation-server]
@@ -8401,22 +6129,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[217-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [217-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-217]
 ExpectedResult = Success
@@ -8430,7 +6148,6 @@ ssl_conf = 218-version-negotiation-ssl
 
 [218-version-negotiation-ssl]
 server = 218-version-negotiation-server
-server2 = 218-version-negotiation-server2
 client = 218-version-negotiation-client
 
 [218-version-negotiation-server]
@@ -8439,21 +6156,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[218-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [218-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-218]
 ExpectedResult = Success
@@ -8467,7 +6175,6 @@ ssl_conf = 219-version-negotiation-ssl
 
 [219-version-negotiation-ssl]
 server = 219-version-negotiation-server
-server2 = 219-version-negotiation-server2
 client = 219-version-negotiation-client
 
 [219-version-negotiation-server]
@@ -8477,22 +6184,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[219-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [219-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-219]
 ExpectedResult = Success
@@ -8506,7 +6203,6 @@ ssl_conf = 220-version-negotiation-ssl
 
 [220-version-negotiation-ssl]
 server = 220-version-negotiation-server
-server2 = 220-version-negotiation-server2
 client = 220-version-negotiation-client
 
 [220-version-negotiation-server]
@@ -8516,22 +6212,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[220-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [220-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-220]
 ExpectedResult = Success
@@ -8545,7 +6231,6 @@ ssl_conf = 221-version-negotiation-ssl
 
 [221-version-negotiation-ssl]
 server = 221-version-negotiation-server
-server2 = 221-version-negotiation-server2
 client = 221-version-negotiation-client
 
 [221-version-negotiation-server]
@@ -8555,22 +6240,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[221-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [221-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-221]
 ExpectedResult = Success
@@ -8584,7 +6259,6 @@ ssl_conf = 222-version-negotiation-ssl
 
 [222-version-negotiation-ssl]
 server = 222-version-negotiation-server
-server2 = 222-version-negotiation-server2
 client = 222-version-negotiation-client
 
 [222-version-negotiation-server]
@@ -8593,21 +6267,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[222-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [222-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-222]
 ExpectedResult = Success
@@ -8621,7 +6286,6 @@ ssl_conf = 223-version-negotiation-ssl
 
 [223-version-negotiation-ssl]
 server = 223-version-negotiation-server
-server2 = 223-version-negotiation-server2
 client = 223-version-negotiation-client
 
 [223-version-negotiation-server]
@@ -8631,22 +6295,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[223-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [223-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-223]
 ExpectedResult = Success
@@ -8660,7 +6314,6 @@ ssl_conf = 224-version-negotiation-ssl
 
 [224-version-negotiation-ssl]
 server = 224-version-negotiation-server
-server2 = 224-version-negotiation-server2
 client = 224-version-negotiation-client
 
 [224-version-negotiation-server]
@@ -8670,22 +6323,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[224-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [224-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-224]
 ExpectedResult = Success
@@ -8699,7 +6342,6 @@ ssl_conf = 225-version-negotiation-ssl
 
 [225-version-negotiation-ssl]
 server = 225-version-negotiation-server
-server2 = 225-version-negotiation-server2
 client = 225-version-negotiation-client
 
 [225-version-negotiation-server]
@@ -8708,21 +6350,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[225-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [225-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-225]
 ExpectedResult = Success
@@ -8736,7 +6369,6 @@ ssl_conf = 226-version-negotiation-ssl
 
 [226-version-negotiation-ssl]
 server = 226-version-negotiation-server
-server2 = 226-version-negotiation-server2
 client = 226-version-negotiation-client
 
 [226-version-negotiation-server]
@@ -8746,22 +6378,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[226-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [226-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-226]
 ExpectedResult = ServerFail
@@ -8774,7 +6396,6 @@ ssl_conf = 227-version-negotiation-ssl
 
 [227-version-negotiation-ssl]
 server = 227-version-negotiation-server
-server2 = 227-version-negotiation-server2
 client = 227-version-negotiation-client
 
 [227-version-negotiation-server]
@@ -8783,21 +6404,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[227-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [227-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-227]
 ExpectedResult = ServerFail
@@ -8810,7 +6422,6 @@ ssl_conf = 228-version-negotiation-ssl
 
 [228-version-negotiation-ssl]
 server = 228-version-negotiation-server
-server2 = 228-version-negotiation-server2
 client = 228-version-negotiation-client
 
 [228-version-negotiation-server]
@@ -8819,21 +6430,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[228-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [228-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-228]
 ExpectedResult = ServerFail
@@ -8846,7 +6448,6 @@ ssl_conf = 229-version-negotiation-ssl
 
 [229-version-negotiation-ssl]
 server = 229-version-negotiation-server
-server2 = 229-version-negotiation-server2
 client = 229-version-negotiation-client
 
 [229-version-negotiation-server]
@@ -8855,21 +6456,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[229-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [229-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-229]
 ExpectedResult = Success
@@ -8883,7 +6475,6 @@ ssl_conf = 230-version-negotiation-ssl
 
 [230-version-negotiation-ssl]
 server = 230-version-negotiation-server
-server2 = 230-version-negotiation-server2
 client = 230-version-negotiation-client
 
 [230-version-negotiation-server]
@@ -8892,21 +6483,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[230-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [230-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-230]
 ExpectedResult = Success
@@ -8920,7 +6502,6 @@ ssl_conf = 231-version-negotiation-ssl
 
 [231-version-negotiation-ssl]
 server = 231-version-negotiation-server
-server2 = 231-version-negotiation-server2
 client = 231-version-negotiation-client
 
 [231-version-negotiation-server]
@@ -8929,21 +6510,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[231-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [231-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-231]
 ExpectedResult = Success
@@ -8957,7 +6529,6 @@ ssl_conf = 232-version-negotiation-ssl
 
 [232-version-negotiation-ssl]
 server = 232-version-negotiation-server
-server2 = 232-version-negotiation-server2
 client = 232-version-negotiation-client
 
 [232-version-negotiation-server]
@@ -8965,20 +6536,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[232-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [232-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-232]
 ExpectedResult = Success
@@ -8992,7 +6555,6 @@ ssl_conf = 233-version-negotiation-ssl
 
 [233-version-negotiation-ssl]
 server = 233-version-negotiation-server
-server2 = 233-version-negotiation-server2
 client = 233-version-negotiation-client
 
 [233-version-negotiation-server]
@@ -9002,22 +6564,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[233-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [233-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-233]
 ExpectedResult = ServerFail
@@ -9030,7 +6582,6 @@ ssl_conf = 234-version-negotiation-ssl
 
 [234-version-negotiation-ssl]
 server = 234-version-negotiation-server
-server2 = 234-version-negotiation-server2
 client = 234-version-negotiation-client
 
 [234-version-negotiation-server]
@@ -9040,22 +6591,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[234-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [234-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-234]
 ExpectedResult = Success
@@ -9069,7 +6610,6 @@ ssl_conf = 235-version-negotiation-ssl
 
 [235-version-negotiation-ssl]
 server = 235-version-negotiation-server
-server2 = 235-version-negotiation-server2
 client = 235-version-negotiation-client
 
 [235-version-negotiation-server]
@@ -9079,22 +6619,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[235-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [235-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-235]
 ExpectedResult = Success
@@ -9108,7 +6638,6 @@ ssl_conf = 236-version-negotiation-ssl
 
 [236-version-negotiation-ssl]
 server = 236-version-negotiation-server
-server2 = 236-version-negotiation-server2
 client = 236-version-negotiation-client
 
 [236-version-negotiation-server]
@@ -9118,22 +6647,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[236-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [236-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-236]
 ExpectedResult = Success
@@ -9147,7 +6666,6 @@ ssl_conf = 237-version-negotiation-ssl
 
 [237-version-negotiation-ssl]
 server = 237-version-negotiation-server
-server2 = 237-version-negotiation-server2
 client = 237-version-negotiation-client
 
 [237-version-negotiation-server]
@@ -9156,21 +6674,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[237-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [237-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-237]
 ExpectedResult = Success
@@ -9184,7 +6693,6 @@ ssl_conf = 238-version-negotiation-ssl
 
 [238-version-negotiation-ssl]
 server = 238-version-negotiation-server
-server2 = 238-version-negotiation-server2
 client = 238-version-negotiation-client
 
 [238-version-negotiation-server]
@@ -9194,22 +6702,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[238-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [238-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-238]
 ExpectedResult = Success
@@ -9223,7 +6721,6 @@ ssl_conf = 239-version-negotiation-ssl
 
 [239-version-negotiation-ssl]
 server = 239-version-negotiation-server
-server2 = 239-version-negotiation-server2
 client = 239-version-negotiation-client
 
 [239-version-negotiation-server]
@@ -9233,22 +6730,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[239-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [239-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-239]
 ExpectedResult = Success
@@ -9262,7 +6749,6 @@ ssl_conf = 240-version-negotiation-ssl
 
 [240-version-negotiation-ssl]
 server = 240-version-negotiation-server
-server2 = 240-version-negotiation-server2
 client = 240-version-negotiation-client
 
 [240-version-negotiation-server]
@@ -9272,22 +6758,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[240-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [240-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-240]
 ExpectedResult = Success
@@ -9301,7 +6777,6 @@ ssl_conf = 241-version-negotiation-ssl
 
 [241-version-negotiation-ssl]
 server = 241-version-negotiation-server
-server2 = 241-version-negotiation-server2
 client = 241-version-negotiation-client
 
 [241-version-negotiation-server]
@@ -9310,21 +6785,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[241-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [241-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-241]
 ExpectedResult = Success
@@ -9338,7 +6804,6 @@ ssl_conf = 242-version-negotiation-ssl
 
 [242-version-negotiation-ssl]
 server = 242-version-negotiation-server
-server2 = 242-version-negotiation-server2
 client = 242-version-negotiation-client
 
 [242-version-negotiation-server]
@@ -9348,22 +6813,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[242-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [242-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-242]
 ExpectedResult = Success
@@ -9377,7 +6832,6 @@ ssl_conf = 243-version-negotiation-ssl
 
 [243-version-negotiation-ssl]
 server = 243-version-negotiation-server
-server2 = 243-version-negotiation-server2
 client = 243-version-negotiation-client
 
 [243-version-negotiation-server]
@@ -9387,22 +6841,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[243-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [243-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-243]
 ExpectedResult = Success
@@ -9416,7 +6860,6 @@ ssl_conf = 244-version-negotiation-ssl
 
 [244-version-negotiation-ssl]
 server = 244-version-negotiation-server
-server2 = 244-version-negotiation-server2
 client = 244-version-negotiation-client
 
 [244-version-negotiation-server]
@@ -9425,21 +6868,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[244-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [244-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-244]
 ExpectedResult = Success
@@ -9453,7 +6887,6 @@ ssl_conf = 245-version-negotiation-ssl
 
 [245-version-negotiation-ssl]
 server = 245-version-negotiation-server
-server2 = 245-version-negotiation-server2
 client = 245-version-negotiation-client
 
 [245-version-negotiation-server]
@@ -9463,22 +6896,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[245-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [245-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-245]
 ExpectedResult = Success
@@ -9492,7 +6915,6 @@ ssl_conf = 246-version-negotiation-ssl
 
 [246-version-negotiation-ssl]
 server = 246-version-negotiation-server
-server2 = 246-version-negotiation-server2
 client = 246-version-negotiation-client
 
 [246-version-negotiation-server]
@@ -9501,21 +6923,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[246-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [246-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-246]
 ExpectedResult = Success
@@ -9529,7 +6942,6 @@ ssl_conf = 247-version-negotiation-ssl
 
 [247-version-negotiation-ssl]
 server = 247-version-negotiation-server
-server2 = 247-version-negotiation-server2
 client = 247-version-negotiation-client
 
 [247-version-negotiation-server]
@@ -9538,20 +6950,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[247-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [247-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-247]
 ExpectedResult = ServerFail
@@ -9564,7 +6967,6 @@ ssl_conf = 248-version-negotiation-ssl
 
 [248-version-negotiation-ssl]
 server = 248-version-negotiation-server
-server2 = 248-version-negotiation-server2
 client = 248-version-negotiation-client
 
 [248-version-negotiation-server]
@@ -9573,20 +6975,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[248-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [248-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-248]
 ExpectedResult = Success
@@ -9600,7 +6993,6 @@ ssl_conf = 249-version-negotiation-ssl
 
 [249-version-negotiation-ssl]
 server = 249-version-negotiation-server
-server2 = 249-version-negotiation-server2
 client = 249-version-negotiation-client
 
 [249-version-negotiation-server]
@@ -9609,20 +7001,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[249-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [249-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-249]
 ExpectedResult = Success
@@ -9636,7 +7019,6 @@ ssl_conf = 250-version-negotiation-ssl
 
 [250-version-negotiation-ssl]
 server = 250-version-negotiation-server
-server2 = 250-version-negotiation-server2
 client = 250-version-negotiation-client
 
 [250-version-negotiation-server]
@@ -9645,20 +7027,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[250-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [250-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-250]
 ExpectedResult = Success
@@ -9672,7 +7045,6 @@ ssl_conf = 251-version-negotiation-ssl
 
 [251-version-negotiation-ssl]
 server = 251-version-negotiation-server
-server2 = 251-version-negotiation-server2
 client = 251-version-negotiation-client
 
 [251-version-negotiation-server]
@@ -9680,19 +7052,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[251-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [251-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-251]
 ExpectedResult = Success
@@ -9706,7 +7070,6 @@ ssl_conf = 252-version-negotiation-ssl
 
 [252-version-negotiation-ssl]
 server = 252-version-negotiation-server
-server2 = 252-version-negotiation-server2
 client = 252-version-negotiation-client
 
 [252-version-negotiation-server]
@@ -9716,21 +7079,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[252-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [252-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-252]
 ExpectedResult = ServerFail
@@ -9743,7 +7096,6 @@ ssl_conf = 253-version-negotiation-ssl
 
 [253-version-negotiation-ssl]
 server = 253-version-negotiation-server
-server2 = 253-version-negotiation-server2
 client = 253-version-negotiation-client
 
 [253-version-negotiation-server]
@@ -9753,21 +7105,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[253-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [253-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-253]
 ExpectedResult = Success
@@ -9781,7 +7123,6 @@ ssl_conf = 254-version-negotiation-ssl
 
 [254-version-negotiation-ssl]
 server = 254-version-negotiation-server
-server2 = 254-version-negotiation-server2
 client = 254-version-negotiation-client
 
 [254-version-negotiation-server]
@@ -9791,21 +7132,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[254-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [254-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-254]
 ExpectedResult = Success
@@ -9819,7 +7150,6 @@ ssl_conf = 255-version-negotiation-ssl
 
 [255-version-negotiation-ssl]
 server = 255-version-negotiation-server
-server2 = 255-version-negotiation-server2
 client = 255-version-negotiation-client
 
 [255-version-negotiation-server]
@@ -9829,21 +7159,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[255-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [255-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-255]
 ExpectedResult = Success
@@ -9857,7 +7177,6 @@ ssl_conf = 256-version-negotiation-ssl
 
 [256-version-negotiation-ssl]
 server = 256-version-negotiation-server
-server2 = 256-version-negotiation-server2
 client = 256-version-negotiation-client
 
 [256-version-negotiation-server]
@@ -9866,20 +7185,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[256-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [256-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-256]
 ExpectedResult = Success
@@ -9893,7 +7203,6 @@ ssl_conf = 257-version-negotiation-ssl
 
 [257-version-negotiation-ssl]
 server = 257-version-negotiation-server
-server2 = 257-version-negotiation-server2
 client = 257-version-negotiation-client
 
 [257-version-negotiation-server]
@@ -9903,21 +7212,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[257-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [257-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-257]
 ExpectedResult = Success
@@ -9931,7 +7230,6 @@ ssl_conf = 258-version-negotiation-ssl
 
 [258-version-negotiation-ssl]
 server = 258-version-negotiation-server
-server2 = 258-version-negotiation-server2
 client = 258-version-negotiation-client
 
 [258-version-negotiation-server]
@@ -9941,21 +7239,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[258-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [258-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-258]
 ExpectedResult = Success
@@ -9969,7 +7257,6 @@ ssl_conf = 259-version-negotiation-ssl
 
 [259-version-negotiation-ssl]
 server = 259-version-negotiation-server
-server2 = 259-version-negotiation-server2
 client = 259-version-negotiation-client
 
 [259-version-negotiation-server]
@@ -9979,21 +7266,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[259-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [259-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-259]
 ExpectedResult = Success
@@ -10007,7 +7284,6 @@ ssl_conf = 260-version-negotiation-ssl
 
 [260-version-negotiation-ssl]
 server = 260-version-negotiation-server
-server2 = 260-version-negotiation-server2
 client = 260-version-negotiation-client
 
 [260-version-negotiation-server]
@@ -10016,20 +7292,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[260-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [260-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-260]
 ExpectedResult = Success
@@ -10043,7 +7310,6 @@ ssl_conf = 261-version-negotiation-ssl
 
 [261-version-negotiation-ssl]
 server = 261-version-negotiation-server
-server2 = 261-version-negotiation-server2
 client = 261-version-negotiation-client
 
 [261-version-negotiation-server]
@@ -10053,21 +7319,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[261-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [261-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-261]
 ExpectedResult = Success
@@ -10081,7 +7337,6 @@ ssl_conf = 262-version-negotiation-ssl
 
 [262-version-negotiation-ssl]
 server = 262-version-negotiation-server
-server2 = 262-version-negotiation-server2
 client = 262-version-negotiation-client
 
 [262-version-negotiation-server]
@@ -10091,21 +7346,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[262-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [262-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-262]
 ExpectedResult = Success
@@ -10119,7 +7364,6 @@ ssl_conf = 263-version-negotiation-ssl
 
 [263-version-negotiation-ssl]
 server = 263-version-negotiation-server
-server2 = 263-version-negotiation-server2
 client = 263-version-negotiation-client
 
 [263-version-negotiation-server]
@@ -10128,20 +7372,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[263-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [263-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-263]
 ExpectedResult = Success
@@ -10155,7 +7390,6 @@ ssl_conf = 264-version-negotiation-ssl
 
 [264-version-negotiation-ssl]
 server = 264-version-negotiation-server
-server2 = 264-version-negotiation-server2
 client = 264-version-negotiation-client
 
 [264-version-negotiation-server]
@@ -10165,21 +7399,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[264-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [264-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-264]
 ExpectedResult = Success
@@ -10193,7 +7417,6 @@ ssl_conf = 265-version-negotiation-ssl
 
 [265-version-negotiation-ssl]
 server = 265-version-negotiation-server
-server2 = 265-version-negotiation-server2
 client = 265-version-negotiation-client
 
 [265-version-negotiation-server]
@@ -10202,20 +7425,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[265-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [265-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-265]
 ExpectedResult = Success
@@ -10229,7 +7443,6 @@ ssl_conf = 266-version-negotiation-ssl
 
 [266-version-negotiation-ssl]
 server = 266-version-negotiation-server
-server2 = 266-version-negotiation-server2
 client = 266-version-negotiation-client
 
 [266-version-negotiation-server]
@@ -10238,21 +7451,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[266-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [266-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-266]
 ExpectedResult = ServerFail
@@ -10265,7 +7469,6 @@ ssl_conf = 267-version-negotiation-ssl
 
 [267-version-negotiation-ssl]
 server = 267-version-negotiation-server
-server2 = 267-version-negotiation-server2
 client = 267-version-negotiation-client
 
 [267-version-negotiation-server]
@@ -10274,21 +7477,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[267-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [267-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-267]
 ExpectedResult = ClientFail
@@ -10301,7 +7495,6 @@ ssl_conf = 268-version-negotiation-ssl
 
 [268-version-negotiation-ssl]
 server = 268-version-negotiation-server
-server2 = 268-version-negotiation-server2
 client = 268-version-negotiation-client
 
 [268-version-negotiation-server]
@@ -10310,21 +7503,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[268-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [268-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-268]
 ExpectedResult = Success
@@ -10338,7 +7522,6 @@ ssl_conf = 269-version-negotiation-ssl
 
 [269-version-negotiation-ssl]
 server = 269-version-negotiation-server
-server2 = 269-version-negotiation-server2
 client = 269-version-negotiation-client
 
 [269-version-negotiation-server]
@@ -10347,21 +7530,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[269-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [269-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-269]
 ExpectedResult = Success
@@ -10375,7 +7549,6 @@ ssl_conf = 270-version-negotiation-ssl
 
 [270-version-negotiation-ssl]
 server = 270-version-negotiation-server
-server2 = 270-version-negotiation-server2
 client = 270-version-negotiation-client
 
 [270-version-negotiation-server]
@@ -10383,20 +7556,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[270-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [270-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-270]
 ExpectedResult = Success
@@ -10410,7 +7575,6 @@ ssl_conf = 271-version-negotiation-ssl
 
 [271-version-negotiation-ssl]
 server = 271-version-negotiation-server
-server2 = 271-version-negotiation-server2
 client = 271-version-negotiation-client
 
 [271-version-negotiation-server]
@@ -10420,22 +7584,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[271-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [271-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-271]
 ExpectedResult = ServerFail
@@ -10448,7 +7602,6 @@ ssl_conf = 272-version-negotiation-ssl
 
 [272-version-negotiation-ssl]
 server = 272-version-negotiation-server
-server2 = 272-version-negotiation-server2
 client = 272-version-negotiation-client
 
 [272-version-negotiation-server]
@@ -10458,22 +7611,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[272-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [272-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-272]
 ExpectedResult = ClientFail
@@ -10486,7 +7629,6 @@ ssl_conf = 273-version-negotiation-ssl
 
 [273-version-negotiation-ssl]
 server = 273-version-negotiation-server
-server2 = 273-version-negotiation-server2
 client = 273-version-negotiation-client
 
 [273-version-negotiation-server]
@@ -10496,22 +7638,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[273-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [273-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-273]
 ExpectedResult = Success
@@ -10525,7 +7657,6 @@ ssl_conf = 274-version-negotiation-ssl
 
 [274-version-negotiation-ssl]
 server = 274-version-negotiation-server
-server2 = 274-version-negotiation-server2
 client = 274-version-negotiation-client
 
 [274-version-negotiation-server]
@@ -10535,22 +7666,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[274-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [274-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-274]
 ExpectedResult = Success
@@ -10564,7 +7685,6 @@ ssl_conf = 275-version-negotiation-ssl
 
 [275-version-negotiation-ssl]
 server = 275-version-negotiation-server
-server2 = 275-version-negotiation-server2
 client = 275-version-negotiation-client
 
 [275-version-negotiation-server]
@@ -10573,21 +7693,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[275-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [275-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-275]
 ExpectedResult = Success
@@ -10601,7 +7712,6 @@ ssl_conf = 276-version-negotiation-ssl
 
 [276-version-negotiation-ssl]
 server = 276-version-negotiation-server
-server2 = 276-version-negotiation-server2
 client = 276-version-negotiation-client
 
 [276-version-negotiation-server]
@@ -10611,22 +7721,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[276-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [276-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-276]
 ExpectedResult = ClientFail
@@ -10639,7 +7739,6 @@ ssl_conf = 277-version-negotiation-ssl
 
 [277-version-negotiation-ssl]
 server = 277-version-negotiation-server
-server2 = 277-version-negotiation-server2
 client = 277-version-negotiation-client
 
 [277-version-negotiation-server]
@@ -10649,22 +7748,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[277-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [277-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-277]
 ExpectedResult = Success
@@ -10678,7 +7767,6 @@ ssl_conf = 278-version-negotiation-ssl
 
 [278-version-negotiation-ssl]
 server = 278-version-negotiation-server
-server2 = 278-version-negotiation-server2
 client = 278-version-negotiation-client
 
 [278-version-negotiation-server]
@@ -10688,22 +7776,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[278-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [278-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-278]
 ExpectedResult = Success
@@ -10717,7 +7795,6 @@ ssl_conf = 279-version-negotiation-ssl
 
 [279-version-negotiation-ssl]
 server = 279-version-negotiation-server
-server2 = 279-version-negotiation-server2
 client = 279-version-negotiation-client
 
 [279-version-negotiation-server]
@@ -10726,21 +7803,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[279-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [279-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-279]
 ExpectedResult = Success
@@ -10754,7 +7822,6 @@ ssl_conf = 280-version-negotiation-ssl
 
 [280-version-negotiation-ssl]
 server = 280-version-negotiation-server
-server2 = 280-version-negotiation-server2
 client = 280-version-negotiation-client
 
 [280-version-negotiation-server]
@@ -10764,22 +7831,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[280-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [280-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-280]
 ExpectedResult = Success
@@ -10793,7 +7850,6 @@ ssl_conf = 281-version-negotiation-ssl
 
 [281-version-negotiation-ssl]
 server = 281-version-negotiation-server
-server2 = 281-version-negotiation-server2
 client = 281-version-negotiation-client
 
 [281-version-negotiation-server]
@@ -10803,22 +7859,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[281-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [281-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-281]
 ExpectedResult = Success
@@ -10832,7 +7878,6 @@ ssl_conf = 282-version-negotiation-ssl
 
 [282-version-negotiation-ssl]
 server = 282-version-negotiation-server
-server2 = 282-version-negotiation-server2
 client = 282-version-negotiation-client
 
 [282-version-negotiation-server]
@@ -10841,21 +7886,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[282-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [282-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-282]
 ExpectedResult = Success
@@ -10869,7 +7905,6 @@ ssl_conf = 283-version-negotiation-ssl
 
 [283-version-negotiation-ssl]
 server = 283-version-negotiation-server
-server2 = 283-version-negotiation-server2
 client = 283-version-negotiation-client
 
 [283-version-negotiation-server]
@@ -10879,22 +7914,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[283-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [283-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-283]
 ExpectedResult = ServerFail
@@ -10907,7 +7932,6 @@ ssl_conf = 284-version-negotiation-ssl
 
 [284-version-negotiation-ssl]
 server = 284-version-negotiation-server
-server2 = 284-version-negotiation-server2
 client = 284-version-negotiation-client
 
 [284-version-negotiation-server]
@@ -10916,21 +7940,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[284-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [284-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-284]
 ExpectedResult = ServerFail
@@ -10943,7 +7958,6 @@ ssl_conf = 285-version-negotiation-ssl
 
 [285-version-negotiation-ssl]
 server = 285-version-negotiation-server
-server2 = 285-version-negotiation-server2
 client = 285-version-negotiation-client
 
 [285-version-negotiation-server]
@@ -10952,21 +7966,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[285-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [285-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-285]
 ExpectedResult = ServerFail
@@ -10979,7 +7984,6 @@ ssl_conf = 286-version-negotiation-ssl
 
 [286-version-negotiation-ssl]
 server = 286-version-negotiation-server
-server2 = 286-version-negotiation-server2
 client = 286-version-negotiation-client
 
 [286-version-negotiation-server]
@@ -10988,21 +7992,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[286-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [286-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-286]
 ExpectedResult = ClientFail
@@ -11015,7 +8010,6 @@ ssl_conf = 287-version-negotiation-ssl
 
 [287-version-negotiation-ssl]
 server = 287-version-negotiation-server
-server2 = 287-version-negotiation-server2
 client = 287-version-negotiation-client
 
 [287-version-negotiation-server]
@@ -11024,21 +8018,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[287-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [287-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-287]
 ExpectedResult = Success
@@ -11052,7 +8037,6 @@ ssl_conf = 288-version-negotiation-ssl
 
 [288-version-negotiation-ssl]
 server = 288-version-negotiation-server
-server2 = 288-version-negotiation-server2
 client = 288-version-negotiation-client
 
 [288-version-negotiation-server]
@@ -11061,21 +8045,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[288-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [288-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-288]
 ExpectedResult = Success
@@ -11089,7 +8064,6 @@ ssl_conf = 289-version-negotiation-ssl
 
 [289-version-negotiation-ssl]
 server = 289-version-negotiation-server
-server2 = 289-version-negotiation-server2
 client = 289-version-negotiation-client
 
 [289-version-negotiation-server]
@@ -11097,20 +8071,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[289-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [289-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-289]
 ExpectedResult = Success
@@ -11124,7 +8090,6 @@ ssl_conf = 290-version-negotiation-ssl
 
 [290-version-negotiation-ssl]
 server = 290-version-negotiation-server
-server2 = 290-version-negotiation-server2
 client = 290-version-negotiation-client
 
 [290-version-negotiation-server]
@@ -11134,22 +8099,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[290-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [290-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-290]
 ExpectedResult = ServerFail
@@ -11162,7 +8117,6 @@ ssl_conf = 291-version-negotiation-ssl
 
 [291-version-negotiation-ssl]
 server = 291-version-negotiation-server
-server2 = 291-version-negotiation-server2
 client = 291-version-negotiation-client
 
 [291-version-negotiation-server]
@@ -11172,22 +8126,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[291-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [291-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-291]
 ExpectedResult = ClientFail
@@ -11200,7 +8144,6 @@ ssl_conf = 292-version-negotiation-ssl
 
 [292-version-negotiation-ssl]
 server = 292-version-negotiation-server
-server2 = 292-version-negotiation-server2
 client = 292-version-negotiation-client
 
 [292-version-negotiation-server]
@@ -11210,22 +8153,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[292-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [292-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-292]
 ExpectedResult = Success
@@ -11239,7 +8172,6 @@ ssl_conf = 293-version-negotiation-ssl
 
 [293-version-negotiation-ssl]
 server = 293-version-negotiation-server
-server2 = 293-version-negotiation-server2
 client = 293-version-negotiation-client
 
 [293-version-negotiation-server]
@@ -11249,22 +8181,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[293-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [293-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-293]
 ExpectedResult = Success
@@ -11278,7 +8200,6 @@ ssl_conf = 294-version-negotiation-ssl
 
 [294-version-negotiation-ssl]
 server = 294-version-negotiation-server
-server2 = 294-version-negotiation-server2
 client = 294-version-negotiation-client
 
 [294-version-negotiation-server]
@@ -11287,21 +8208,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[294-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [294-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-294]
 ExpectedResult = Success
@@ -11315,7 +8227,6 @@ ssl_conf = 295-version-negotiation-ssl
 
 [295-version-negotiation-ssl]
 server = 295-version-negotiation-server
-server2 = 295-version-negotiation-server2
 client = 295-version-negotiation-client
 
 [295-version-negotiation-server]
@@ -11325,22 +8236,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[295-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [295-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-295]
 ExpectedResult = ClientFail
@@ -11353,7 +8254,6 @@ ssl_conf = 296-version-negotiation-ssl
 
 [296-version-negotiation-ssl]
 server = 296-version-negotiation-server
-server2 = 296-version-negotiation-server2
 client = 296-version-negotiation-client
 
 [296-version-negotiation-server]
@@ -11363,22 +8263,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[296-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [296-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-296]
 ExpectedResult = Success
@@ -11392,7 +8282,6 @@ ssl_conf = 297-version-negotiation-ssl
 
 [297-version-negotiation-ssl]
 server = 297-version-negotiation-server
-server2 = 297-version-negotiation-server2
 client = 297-version-negotiation-client
 
 [297-version-negotiation-server]
@@ -11402,22 +8291,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[297-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [297-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-297]
 ExpectedResult = Success
@@ -11431,7 +8310,6 @@ ssl_conf = 298-version-negotiation-ssl
 
 [298-version-negotiation-ssl]
 server = 298-version-negotiation-server
-server2 = 298-version-negotiation-server2
 client = 298-version-negotiation-client
 
 [298-version-negotiation-server]
@@ -11440,21 +8318,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[298-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [298-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-298]
 ExpectedResult = Success
@@ -11468,7 +8337,6 @@ ssl_conf = 299-version-negotiation-ssl
 
 [299-version-negotiation-ssl]
 server = 299-version-negotiation-server
-server2 = 299-version-negotiation-server2
 client = 299-version-negotiation-client
 
 [299-version-negotiation-server]
@@ -11478,22 +8346,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[299-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [299-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-299]
 ExpectedResult = Success
@@ -11507,7 +8365,6 @@ ssl_conf = 300-version-negotiation-ssl
 
 [300-version-negotiation-ssl]
 server = 300-version-negotiation-server
-server2 = 300-version-negotiation-server2
 client = 300-version-negotiation-client
 
 [300-version-negotiation-server]
@@ -11517,22 +8374,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[300-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [300-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-300]
 ExpectedResult = Success
@@ -11546,7 +8393,6 @@ ssl_conf = 301-version-negotiation-ssl
 
 [301-version-negotiation-ssl]
 server = 301-version-negotiation-server
-server2 = 301-version-negotiation-server2
 client = 301-version-negotiation-client
 
 [301-version-negotiation-server]
@@ -11555,21 +8401,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[301-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [301-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-301]
 ExpectedResult = Success
@@ -11583,7 +8420,6 @@ ssl_conf = 302-version-negotiation-ssl
 
 [302-version-negotiation-ssl]
 server = 302-version-negotiation-server
-server2 = 302-version-negotiation-server2
 client = 302-version-negotiation-client
 
 [302-version-negotiation-server]
@@ -11593,22 +8429,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[302-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [302-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-302]
 ExpectedResult = Success
@@ -11622,7 +8448,6 @@ ssl_conf = 303-version-negotiation-ssl
 
 [303-version-negotiation-ssl]
 server = 303-version-negotiation-server
-server2 = 303-version-negotiation-server2
 client = 303-version-negotiation-client
 
 [303-version-negotiation-server]
@@ -11631,21 +8456,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[303-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [303-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-303]
 ExpectedResult = Success
@@ -11659,7 +8475,6 @@ ssl_conf = 304-version-negotiation-ssl
 
 [304-version-negotiation-ssl]
 server = 304-version-negotiation-server
-server2 = 304-version-negotiation-server2
 client = 304-version-negotiation-client
 
 [304-version-negotiation-server]
@@ -11668,20 +8483,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[304-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [304-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-304]
 ExpectedResult = ServerFail
@@ -11694,7 +8500,6 @@ ssl_conf = 305-version-negotiation-ssl
 
 [305-version-negotiation-ssl]
 server = 305-version-negotiation-server
-server2 = 305-version-negotiation-server2
 client = 305-version-negotiation-client
 
 [305-version-negotiation-server]
@@ -11703,20 +8508,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[305-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [305-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-305]
 ExpectedResult = ClientFail
@@ -11729,7 +8525,6 @@ ssl_conf = 306-version-negotiation-ssl
 
 [306-version-negotiation-ssl]
 server = 306-version-negotiation-server
-server2 = 306-version-negotiation-server2
 client = 306-version-negotiation-client
 
 [306-version-negotiation-server]
@@ -11738,20 +8533,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[306-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [306-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-306]
 ExpectedResult = Success
@@ -11765,7 +8551,6 @@ ssl_conf = 307-version-negotiation-ssl
 
 [307-version-negotiation-ssl]
 server = 307-version-negotiation-server
-server2 = 307-version-negotiation-server2
 client = 307-version-negotiation-client
 
 [307-version-negotiation-server]
@@ -11774,20 +8559,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[307-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [307-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-307]
 ExpectedResult = Success
@@ -11801,7 +8577,6 @@ ssl_conf = 308-version-negotiation-ssl
 
 [308-version-negotiation-ssl]
 server = 308-version-negotiation-server
-server2 = 308-version-negotiation-server2
 client = 308-version-negotiation-client
 
 [308-version-negotiation-server]
@@ -11809,19 +8584,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[308-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [308-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-308]
 ExpectedResult = Success
@@ -11835,7 +8602,6 @@ ssl_conf = 309-version-negotiation-ssl
 
 [309-version-negotiation-ssl]
 server = 309-version-negotiation-server
-server2 = 309-version-negotiation-server2
 client = 309-version-negotiation-client
 
 [309-version-negotiation-server]
@@ -11845,21 +8611,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[309-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [309-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-309]
 ExpectedResult = ServerFail
@@ -11872,7 +8628,6 @@ ssl_conf = 310-version-negotiation-ssl
 
 [310-version-negotiation-ssl]
 server = 310-version-negotiation-server
-server2 = 310-version-negotiation-server2
 client = 310-version-negotiation-client
 
 [310-version-negotiation-server]
@@ -11882,21 +8637,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[310-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [310-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-310]
 ExpectedResult = ClientFail
@@ -11909,7 +8654,6 @@ ssl_conf = 311-version-negotiation-ssl
 
 [311-version-negotiation-ssl]
 server = 311-version-negotiation-server
-server2 = 311-version-negotiation-server2
 client = 311-version-negotiation-client
 
 [311-version-negotiation-server]
@@ -11919,21 +8663,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[311-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [311-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-311]
 ExpectedResult = Success
@@ -11947,7 +8681,6 @@ ssl_conf = 312-version-negotiation-ssl
 
 [312-version-negotiation-ssl]
 server = 312-version-negotiation-server
-server2 = 312-version-negotiation-server2
 client = 312-version-negotiation-client
 
 [312-version-negotiation-server]
@@ -11957,21 +8690,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[312-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [312-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-312]
 ExpectedResult = Success
@@ -11985,7 +8708,6 @@ ssl_conf = 313-version-negotiation-ssl
 
 [313-version-negotiation-ssl]
 server = 313-version-negotiation-server
-server2 = 313-version-negotiation-server2
 client = 313-version-negotiation-client
 
 [313-version-negotiation-server]
@@ -11994,20 +8716,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[313-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [313-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-313]
 ExpectedResult = Success
@@ -12021,7 +8734,6 @@ ssl_conf = 314-version-negotiation-ssl
 
 [314-version-negotiation-ssl]
 server = 314-version-negotiation-server
-server2 = 314-version-negotiation-server2
 client = 314-version-negotiation-client
 
 [314-version-negotiation-server]
@@ -12031,21 +8743,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[314-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [314-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-314]
 ExpectedResult = ClientFail
@@ -12058,7 +8760,6 @@ ssl_conf = 315-version-negotiation-ssl
 
 [315-version-negotiation-ssl]
 server = 315-version-negotiation-server
-server2 = 315-version-negotiation-server2
 client = 315-version-negotiation-client
 
 [315-version-negotiation-server]
@@ -12068,21 +8769,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[315-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [315-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-315]
 ExpectedResult = Success
@@ -12096,7 +8787,6 @@ ssl_conf = 316-version-negotiation-ssl
 
 [316-version-negotiation-ssl]
 server = 316-version-negotiation-server
-server2 = 316-version-negotiation-server2
 client = 316-version-negotiation-client
 
 [316-version-negotiation-server]
@@ -12106,21 +8796,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[316-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [316-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-316]
 ExpectedResult = Success
@@ -12134,7 +8814,6 @@ ssl_conf = 317-version-negotiation-ssl
 
 [317-version-negotiation-ssl]
 server = 317-version-negotiation-server
-server2 = 317-version-negotiation-server2
 client = 317-version-negotiation-client
 
 [317-version-negotiation-server]
@@ -12143,20 +8822,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[317-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [317-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-317]
 ExpectedResult = Success
@@ -12170,7 +8840,6 @@ ssl_conf = 318-version-negotiation-ssl
 
 [318-version-negotiation-ssl]
 server = 318-version-negotiation-server
-server2 = 318-version-negotiation-server2
 client = 318-version-negotiation-client
 
 [318-version-negotiation-server]
@@ -12180,21 +8849,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[318-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [318-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-318]
 ExpectedResult = Success
@@ -12208,7 +8867,6 @@ ssl_conf = 319-version-negotiation-ssl
 
 [319-version-negotiation-ssl]
 server = 319-version-negotiation-server
-server2 = 319-version-negotiation-server2
 client = 319-version-negotiation-client
 
 [319-version-negotiation-server]
@@ -12218,21 +8876,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[319-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [319-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-319]
 ExpectedResult = Success
@@ -12246,7 +8894,6 @@ ssl_conf = 320-version-negotiation-ssl
 
 [320-version-negotiation-ssl]
 server = 320-version-negotiation-server
-server2 = 320-version-negotiation-server2
 client = 320-version-negotiation-client
 
 [320-version-negotiation-server]
@@ -12255,20 +8902,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[320-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [320-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-320]
 ExpectedResult = Success
@@ -12282,7 +8920,6 @@ ssl_conf = 321-version-negotiation-ssl
 
 [321-version-negotiation-ssl]
 server = 321-version-negotiation-server
-server2 = 321-version-negotiation-server2
 client = 321-version-negotiation-client
 
 [321-version-negotiation-server]
@@ -12292,21 +8929,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[321-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [321-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-321]
 ExpectedResult = Success
@@ -12320,7 +8947,6 @@ ssl_conf = 322-version-negotiation-ssl
 
 [322-version-negotiation-ssl]
 server = 322-version-negotiation-server
-server2 = 322-version-negotiation-server2
 client = 322-version-negotiation-client
 
 [322-version-negotiation-server]
@@ -12329,20 +8955,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[322-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [322-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-322]
 ExpectedResult = Success
@@ -12356,7 +8973,6 @@ ssl_conf = 323-version-negotiation-ssl
 
 [323-version-negotiation-ssl]
 server = 323-version-negotiation-server
-server2 = 323-version-negotiation-server2
 client = 323-version-negotiation-client
 
 [323-version-negotiation-server]
@@ -12365,21 +8981,12 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[323-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [323-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-323]
 ExpectedResult = ServerFail
@@ -12392,7 +8999,6 @@ ssl_conf = 324-version-negotiation-ssl
 
 [324-version-negotiation-ssl]
 server = 324-version-negotiation-server
-server2 = 324-version-negotiation-server2
 client = 324-version-negotiation-client
 
 [324-version-negotiation-server]
@@ -12401,21 +9007,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[324-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [324-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-324]
 ExpectedResult = ClientFail
@@ -12428,7 +9025,6 @@ ssl_conf = 325-version-negotiation-ssl
 
 [325-version-negotiation-ssl]
 server = 325-version-negotiation-server
-server2 = 325-version-negotiation-server2
 client = 325-version-negotiation-client
 
 [325-version-negotiation-server]
@@ -12437,21 +9033,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[325-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [325-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-325]
 ExpectedResult = ClientFail
@@ -12464,7 +9051,6 @@ ssl_conf = 326-version-negotiation-ssl
 
 [326-version-negotiation-ssl]
 server = 326-version-negotiation-server
-server2 = 326-version-negotiation-server2
 client = 326-version-negotiation-client
 
 [326-version-negotiation-server]
@@ -12473,21 +9059,12 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[326-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [326-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-326]
 ExpectedResult = Success
@@ -12501,7 +9078,6 @@ ssl_conf = 327-version-negotiation-ssl
 
 [327-version-negotiation-ssl]
 server = 327-version-negotiation-server
-server2 = 327-version-negotiation-server2
 client = 327-version-negotiation-client
 
 [327-version-negotiation-server]
@@ -12509,20 +9085,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[327-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [327-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-327]
 ExpectedResult = Success
@@ -12536,7 +9104,6 @@ ssl_conf = 328-version-negotiation-ssl
 
 [328-version-negotiation-ssl]
 server = 328-version-negotiation-server
-server2 = 328-version-negotiation-server2
 client = 328-version-negotiation-client
 
 [328-version-negotiation-server]
@@ -12546,22 +9113,12 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[328-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [328-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-328]
 ExpectedResult = ServerFail
@@ -12574,7 +9131,6 @@ ssl_conf = 329-version-negotiation-ssl
 
 [329-version-negotiation-ssl]
 server = 329-version-negotiation-server
-server2 = 329-version-negotiation-server2
 client = 329-version-negotiation-client
 
 [329-version-negotiation-server]
@@ -12584,22 +9140,12 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[329-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [329-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-329]
 ExpectedResult = ClientFail
@@ -12612,7 +9158,6 @@ ssl_conf = 330-version-negotiation-ssl
 
 [330-version-negotiation-ssl]
 server = 330-version-negotiation-server
-server2 = 330-version-negotiation-server2
 client = 330-version-negotiation-client
 
 [330-version-negotiation-server]
@@ -12622,22 +9167,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[330-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [330-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-330]
 ExpectedResult = ClientFail
@@ -12650,7 +9185,6 @@ ssl_conf = 331-version-negotiation-ssl
 
 [331-version-negotiation-ssl]
 server = 331-version-negotiation-server
-server2 = 331-version-negotiation-server2
 client = 331-version-negotiation-client
 
 [331-version-negotiation-server]
@@ -12660,22 +9194,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[331-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [331-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-331]
 ExpectedResult = Success
@@ -12689,7 +9213,6 @@ ssl_conf = 332-version-negotiation-ssl
 
 [332-version-negotiation-ssl]
 server = 332-version-negotiation-server
-server2 = 332-version-negotiation-server2
 client = 332-version-negotiation-client
 
 [332-version-negotiation-server]
@@ -12698,21 +9221,12 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[332-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [332-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-332]
 ExpectedResult = Success
@@ -12726,7 +9240,6 @@ ssl_conf = 333-version-negotiation-ssl
 
 [333-version-negotiation-ssl]
 server = 333-version-negotiation-server
-server2 = 333-version-negotiation-server2
 client = 333-version-negotiation-client
 
 [333-version-negotiation-server]
@@ -12736,22 +9249,12 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[333-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [333-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-333]
 ExpectedResult = ClientFail
@@ -12764,7 +9267,6 @@ ssl_conf = 334-version-negotiation-ssl
 
 [334-version-negotiation-ssl]
 server = 334-version-negotiation-server
-server2 = 334-version-negotiation-server2
 client = 334-version-negotiation-client
 
 [334-version-negotiation-server]
@@ -12774,22 +9276,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[334-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [334-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-334]
 ExpectedResult = ClientFail
@@ -12802,7 +9294,6 @@ ssl_conf = 335-version-negotiation-ssl
 
 [335-version-negotiation-ssl]
 server = 335-version-negotiation-server
-server2 = 335-version-negotiation-server2
 client = 335-version-negotiation-client
 
 [335-version-negotiation-server]
@@ -12812,22 +9303,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[335-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [335-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-335]
 ExpectedResult = Success
@@ -12841,7 +9322,6 @@ ssl_conf = 336-version-negotiation-ssl
 
 [336-version-negotiation-ssl]
 server = 336-version-negotiation-server
-server2 = 336-version-negotiation-server2
 client = 336-version-negotiation-client
 
 [336-version-negotiation-server]
@@ -12850,21 +9330,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[336-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [336-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-336]
 ExpectedResult = Success
@@ -12878,7 +9349,6 @@ ssl_conf = 337-version-negotiation-ssl
 
 [337-version-negotiation-ssl]
 server = 337-version-negotiation-server
-server2 = 337-version-negotiation-server2
 client = 337-version-negotiation-client
 
 [337-version-negotiation-server]
@@ -12888,22 +9358,12 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[337-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [337-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-337]
 ExpectedResult = ClientFail
@@ -12916,7 +9376,6 @@ ssl_conf = 338-version-negotiation-ssl
 
 [338-version-negotiation-ssl]
 server = 338-version-negotiation-server
-server2 = 338-version-negotiation-server2
 client = 338-version-negotiation-client
 
 [338-version-negotiation-server]
@@ -12926,22 +9385,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[338-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [338-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-338]
 ExpectedResult = Success
@@ -12955,7 +9404,6 @@ ssl_conf = 339-version-negotiation-ssl
 
 [339-version-negotiation-ssl]
 server = 339-version-negotiation-server
-server2 = 339-version-negotiation-server2
 client = 339-version-negotiation-client
 
 [339-version-negotiation-server]
@@ -12964,21 +9412,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[339-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [339-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-339]
 ExpectedResult = Success
@@ -12992,7 +9431,6 @@ ssl_conf = 340-version-negotiation-ssl
 
 [340-version-negotiation-ssl]
 server = 340-version-negotiation-server
-server2 = 340-version-negotiation-server2
 client = 340-version-negotiation-client
 
 [340-version-negotiation-server]
@@ -13002,22 +9440,12 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[340-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [340-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-340]
 ExpectedResult = Success
@@ -13031,7 +9459,6 @@ ssl_conf = 341-version-negotiation-ssl
 
 [341-version-negotiation-ssl]
 server = 341-version-negotiation-server
-server2 = 341-version-negotiation-server2
 client = 341-version-negotiation-client
 
 [341-version-negotiation-server]
@@ -13040,21 +9467,12 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[341-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [341-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-341]
 ExpectedResult = Success
@@ -13068,7 +9486,6 @@ ssl_conf = 342-version-negotiation-ssl
 
 [342-version-negotiation-ssl]
 server = 342-version-negotiation-server
-server2 = 342-version-negotiation-server2
 client = 342-version-negotiation-client
 
 [342-version-negotiation-server]
@@ -13077,20 +9494,11 @@ CipherString = DEFAULT
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[342-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [342-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-342]
 ExpectedResult = ServerFail
@@ -13103,7 +9511,6 @@ ssl_conf = 343-version-negotiation-ssl
 
 [343-version-negotiation-ssl]
 server = 343-version-negotiation-server
-server2 = 343-version-negotiation-server2
 client = 343-version-negotiation-client
 
 [343-version-negotiation-server]
@@ -13112,20 +9519,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[343-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [343-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-343]
 ExpectedResult = ClientFail
@@ -13138,7 +9536,6 @@ ssl_conf = 344-version-negotiation-ssl
 
 [344-version-negotiation-ssl]
 server = 344-version-negotiation-server
-server2 = 344-version-negotiation-server2
 client = 344-version-negotiation-client
 
 [344-version-negotiation-server]
@@ -13147,20 +9544,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[344-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [344-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-344]
 ExpectedResult = ClientFail
@@ -13173,7 +9561,6 @@ ssl_conf = 345-version-negotiation-ssl
 
 [345-version-negotiation-ssl]
 server = 345-version-negotiation-server
-server2 = 345-version-negotiation-server2
 client = 345-version-negotiation-client
 
 [345-version-negotiation-server]
@@ -13182,20 +9569,11 @@ CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[345-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [345-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-345]
 ExpectedResult = Success
@@ -13209,7 +9587,6 @@ ssl_conf = 346-version-negotiation-ssl
 
 [346-version-negotiation-ssl]
 server = 346-version-negotiation-server
-server2 = 346-version-negotiation-server2
 client = 346-version-negotiation-client
 
 [346-version-negotiation-server]
@@ -13217,19 +9594,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[346-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [346-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-346]
 ExpectedResult = Success
@@ -13243,7 +9612,6 @@ ssl_conf = 347-version-negotiation-ssl
 
 [347-version-negotiation-ssl]
 server = 347-version-negotiation-server
-server2 = 347-version-negotiation-server2
 client = 347-version-negotiation-client
 
 [347-version-negotiation-server]
@@ -13253,21 +9621,11 @@ MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[347-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = SSLv3
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [347-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-347]
 ExpectedResult = ServerFail
@@ -13280,7 +9638,6 @@ ssl_conf = 348-version-negotiation-ssl
 
 [348-version-negotiation-ssl]
 server = 348-version-negotiation-server
-server2 = 348-version-negotiation-server2
 client = 348-version-negotiation-client
 
 [348-version-negotiation-server]
@@ -13290,21 +9647,11 @@ MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[348-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [348-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-348]
 ExpectedResult = ClientFail
@@ -13317,7 +9664,6 @@ ssl_conf = 349-version-negotiation-ssl
 
 [349-version-negotiation-ssl]
 server = 349-version-negotiation-server
-server2 = 349-version-negotiation-server2
 client = 349-version-negotiation-client
 
 [349-version-negotiation-server]
@@ -13327,21 +9673,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[349-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [349-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-349]
 ExpectedResult = ClientFail
@@ -13354,7 +9690,6 @@ ssl_conf = 350-version-negotiation-ssl
 
 [350-version-negotiation-ssl]
 server = 350-version-negotiation-server
-server2 = 350-version-negotiation-server2
 client = 350-version-negotiation-client
 
 [350-version-negotiation-server]
@@ -13364,21 +9699,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[350-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [350-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-350]
 ExpectedResult = Success
@@ -13392,7 +9717,6 @@ ssl_conf = 351-version-negotiation-ssl
 
 [351-version-negotiation-ssl]
 server = 351-version-negotiation-server
-server2 = 351-version-negotiation-server2
 client = 351-version-negotiation-client
 
 [351-version-negotiation-server]
@@ -13401,20 +9725,11 @@ CipherString = DEFAULT
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[351-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = SSLv3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [351-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-351]
 ExpectedResult = Success
@@ -13428,7 +9743,6 @@ ssl_conf = 352-version-negotiation-ssl
 
 [352-version-negotiation-ssl]
 server = 352-version-negotiation-server
-server2 = 352-version-negotiation-server2
 client = 352-version-negotiation-client
 
 [352-version-negotiation-server]
@@ -13438,21 +9752,11 @@ MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[352-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [352-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-352]
 ExpectedResult = ClientFail
@@ -13465,7 +9769,6 @@ ssl_conf = 353-version-negotiation-ssl
 
 [353-version-negotiation-ssl]
 server = 353-version-negotiation-server
-server2 = 353-version-negotiation-server2
 client = 353-version-negotiation-client
 
 [353-version-negotiation-server]
@@ -13475,21 +9778,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[353-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [353-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-353]
 ExpectedResult = ClientFail
@@ -13502,7 +9795,6 @@ ssl_conf = 354-version-negotiation-ssl
 
 [354-version-negotiation-ssl]
 server = 354-version-negotiation-server
-server2 = 354-version-negotiation-server2
 client = 354-version-negotiation-client
 
 [354-version-negotiation-server]
@@ -13512,21 +9804,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[354-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [354-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-354]
 ExpectedResult = Success
@@ -13540,7 +9822,6 @@ ssl_conf = 355-version-negotiation-ssl
 
 [355-version-negotiation-ssl]
 server = 355-version-negotiation-server
-server2 = 355-version-negotiation-server2
 client = 355-version-negotiation-client
 
 [355-version-negotiation-server]
@@ -13549,20 +9830,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[355-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [355-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-355]
 ExpectedResult = Success
@@ -13576,7 +9848,6 @@ ssl_conf = 356-version-negotiation-ssl
 
 [356-version-negotiation-ssl]
 server = 356-version-negotiation-server
-server2 = 356-version-negotiation-server2
 client = 356-version-negotiation-client
 
 [356-version-negotiation-server]
@@ -13586,21 +9857,11 @@ MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[356-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [356-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-356]
 ExpectedResult = ClientFail
@@ -13613,7 +9874,6 @@ ssl_conf = 357-version-negotiation-ssl
 
 [357-version-negotiation-ssl]
 server = 357-version-negotiation-server
-server2 = 357-version-negotiation-server2
 client = 357-version-negotiation-client
 
 [357-version-negotiation-server]
@@ -13623,21 +9883,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[357-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [357-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-357]
 ExpectedResult = Success
@@ -13651,7 +9901,6 @@ ssl_conf = 358-version-negotiation-ssl
 
 [358-version-negotiation-ssl]
 server = 358-version-negotiation-server
-server2 = 358-version-negotiation-server2
 client = 358-version-negotiation-client
 
 [358-version-negotiation-server]
@@ -13660,20 +9909,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[358-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [358-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-358]
 ExpectedResult = Success
@@ -13687,7 +9927,6 @@ ssl_conf = 359-version-negotiation-ssl
 
 [359-version-negotiation-ssl]
 server = 359-version-negotiation-server
-server2 = 359-version-negotiation-server2
 client = 359-version-negotiation-client
 
 [359-version-negotiation-server]
@@ -13697,21 +9936,11 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[359-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [359-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-359]
 ExpectedResult = Success
@@ -13725,7 +9954,6 @@ ssl_conf = 360-version-negotiation-ssl
 
 [360-version-negotiation-ssl]
 server = 360-version-negotiation-server
-server2 = 360-version-negotiation-server2
 client = 360-version-negotiation-client
 
 [360-version-negotiation-server]
@@ -13734,20 +9962,11 @@ CipherString = DEFAULT
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[360-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [360-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-360]
 ExpectedResult = Success

--- a/test/ssl-tests/03-custom_verify.conf
+++ b/test/ssl-tests/03-custom_verify.conf
@@ -18,7 +18,6 @@ ssl_conf = 0-verify-success-ssl
 
 [0-verify-success-ssl]
 server = 0-verify-success-server
-server2 = 0-verify-success-server2
 client = 0-verify-success-client
 
 [0-verify-success-server]
@@ -26,18 +25,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[0-verify-success-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [0-verify-success-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = Success
@@ -50,7 +41,6 @@ ssl_conf = 1-verify-custom-reject-ssl
 
 [1-verify-custom-reject-ssl]
 server = 1-verify-custom-reject-server
-server2 = 1-verify-custom-reject-server2
 client = 1-verify-custom-reject-client
 
 [1-verify-custom-reject-server]
@@ -58,18 +48,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[1-verify-custom-reject-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [1-verify-custom-reject-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-1]
 ClientAlert = HandshakeFailure
@@ -84,7 +66,6 @@ ssl_conf = 2-verify-custom-allow-ssl
 
 [2-verify-custom-allow-ssl]
 server = 2-verify-custom-allow-server
-server2 = 2-verify-custom-allow-server2
 client = 2-verify-custom-allow-client
 
 [2-verify-custom-allow-server]
@@ -92,18 +73,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[2-verify-custom-allow-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [2-verify-custom-allow-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-2]
 ClientVerifyCallback = AcceptAll
@@ -117,7 +90,6 @@ ssl_conf = 3-noverify-success-ssl
 
 [3-noverify-success-ssl]
 server = 3-noverify-success-server
-server2 = 3-noverify-success-server2
 client = 3-noverify-success-client
 
 [3-noverify-success-server]
@@ -125,16 +97,8 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[3-noverify-success-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [3-noverify-success-client]
 CipherString = DEFAULT
-
 
 [test-3]
 ExpectedResult = Success
@@ -147,7 +111,6 @@ ssl_conf = 4-noverify-ignore-custom-reject-ssl
 
 [4-noverify-ignore-custom-reject-ssl]
 server = 4-noverify-ignore-custom-reject-server
-server2 = 4-noverify-ignore-custom-reject-server2
 client = 4-noverify-ignore-custom-reject-client
 
 [4-noverify-ignore-custom-reject-server]
@@ -155,16 +118,8 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[4-noverify-ignore-custom-reject-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [4-noverify-ignore-custom-reject-client]
 CipherString = DEFAULT
-
 
 [test-4]
 ClientVerifyCallback = RejectAll
@@ -178,7 +133,6 @@ ssl_conf = 5-noverify-accept-custom-allow-ssl
 
 [5-noverify-accept-custom-allow-ssl]
 server = 5-noverify-accept-custom-allow-server
-server2 = 5-noverify-accept-custom-allow-server2
 client = 5-noverify-accept-custom-allow-client
 
 [5-noverify-accept-custom-allow-server]
@@ -186,16 +140,8 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[5-noverify-accept-custom-allow-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [5-noverify-accept-custom-allow-client]
 CipherString = DEFAULT
-
 
 [test-5]
 ClientVerifyCallback = AcceptAll
@@ -209,7 +155,6 @@ ssl_conf = 6-verify-fail-no-root-ssl
 
 [6-verify-fail-no-root-ssl]
 server = 6-verify-fail-no-root-server
-server2 = 6-verify-fail-no-root-server2
 client = 6-verify-fail-no-root-client
 
 [6-verify-fail-no-root-server]
@@ -217,17 +162,9 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[6-verify-fail-no-root-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [6-verify-fail-no-root-client]
 CipherString = DEFAULT
 VerifyMode = Peer
-
 
 [test-6]
 ClientAlert = UnknownCA
@@ -241,7 +178,6 @@ ssl_conf = 7-verify-custom-success-no-root-ssl
 
 [7-verify-custom-success-no-root-ssl]
 server = 7-verify-custom-success-no-root-server
-server2 = 7-verify-custom-success-no-root-server2
 client = 7-verify-custom-success-no-root-client
 
 [7-verify-custom-success-no-root-server]
@@ -249,17 +185,9 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[7-verify-custom-success-no-root-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [7-verify-custom-success-no-root-client]
 CipherString = DEFAULT
 VerifyMode = Peer
-
 
 [test-7]
 ClientVerifyCallback = AcceptAll
@@ -273,7 +201,6 @@ ssl_conf = 8-verify-custom-fail-no-root-ssl
 
 [8-verify-custom-fail-no-root-ssl]
 server = 8-verify-custom-fail-no-root-server
-server2 = 8-verify-custom-fail-no-root-server2
 client = 8-verify-custom-fail-no-root-client
 
 [8-verify-custom-fail-no-root-server]
@@ -281,17 +208,9 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[8-verify-custom-fail-no-root-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [8-verify-custom-fail-no-root-client]
 CipherString = DEFAULT
 VerifyMode = Peer
-
 
 [test-8]
 ClientAlert = HandshakeFailure

--- a/test/ssl-tests/04-client_auth.conf
+++ b/test/ssl-tests/04-client_auth.conf
@@ -29,7 +29,6 @@ ssl_conf = 0-server-auth-flex-ssl
 
 [0-server-auth-flex-ssl]
 server = 0-server-auth-flex-server
-server2 = 0-server-auth-flex-server2
 client = 0-server-auth-flex-client
 
 [0-server-auth-flex-server]
@@ -37,18 +36,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[0-server-auth-flex-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [0-server-auth-flex-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = Success
@@ -61,7 +52,6 @@ ssl_conf = 1-client-auth-flex-request-ssl
 
 [1-client-auth-flex-request-ssl]
 server = 1-client-auth-flex-request-server
-server2 = 1-client-auth-flex-request-server2
 client = 1-client-auth-flex-request-client
 
 [1-client-auth-flex-request-server]
@@ -70,19 +60,10 @@ CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
-
-[1-client-auth-flex-request-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Request
-
-
 [1-client-auth-flex-request-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-1]
 ExpectedResult = Success
@@ -95,7 +76,6 @@ ssl_conf = 2-client-auth-flex-require-fail-ssl
 
 [2-client-auth-flex-require-fail-ssl]
 server = 2-client-auth-flex-require-fail-server
-server2 = 2-client-auth-flex-require-fail-server2
 client = 2-client-auth-flex-require-fail-client
 
 [2-client-auth-flex-require-fail-server]
@@ -105,20 +85,10 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-
-[2-client-auth-flex-require-fail-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-
 [2-client-auth-flex-require-fail-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-2]
 ExpectedResult = ServerFail
@@ -132,7 +102,6 @@ ssl_conf = 3-client-auth-flex-require-ssl
 
 [3-client-auth-flex-require-ssl]
 server = 3-client-auth-flex-require-server
-server2 = 3-client-auth-flex-require-server2
 client = 3-client-auth-flex-require-client
 
 [3-client-auth-flex-require-server]
@@ -142,22 +111,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-
-[3-client-auth-flex-require-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Request
-
-
 [3-client-auth-flex-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-3]
 ExpectedResult = Success
@@ -170,7 +129,6 @@ ssl_conf = 4-client-auth-flex-noroot-ssl
 
 [4-client-auth-flex-noroot-ssl]
 server = 4-client-auth-flex-noroot-server
-server2 = 4-client-auth-flex-noroot-server2
 client = 4-client-auth-flex-noroot-client
 
 [4-client-auth-flex-noroot-server]
@@ -179,21 +137,12 @@ CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Require
 
-
-[4-client-auth-flex-noroot-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
-
-
 [4-client-auth-flex-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-4]
 ExpectedResult = ServerFail
@@ -207,7 +156,6 @@ ssl_conf = 5-server-auth-TLSv1-ssl
 
 [5-server-auth-TLSv1-ssl]
 server = 5-server-auth-TLSv1-server
-server2 = 5-server-auth-TLSv1-server2
 client = 5-server-auth-TLSv1-client
 
 [5-server-auth-TLSv1-server]
@@ -216,20 +164,11 @@ CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1
 
-
-[5-server-auth-TLSv1-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
-
-
 [5-server-auth-TLSv1-client]
 CipherString = DEFAULT
 Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-5]
 ExpectedResult = Success
@@ -242,7 +181,6 @@ ssl_conf = 6-client-auth-TLSv1-request-ssl
 
 [6-client-auth-TLSv1-request-ssl]
 server = 6-client-auth-TLSv1-request-server
-server2 = 6-client-auth-TLSv1-request-server2
 client = 6-client-auth-TLSv1-request-client
 
 [6-client-auth-TLSv1-request-server]
@@ -252,21 +190,11 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1
 VerifyMode = Request
 
-
-[6-client-auth-TLSv1-request-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
-VerifyMode = Request
-
-
 [6-client-auth-TLSv1-request-client]
 CipherString = DEFAULT
 Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-6]
 ExpectedResult = Success
@@ -279,7 +207,6 @@ ssl_conf = 7-client-auth-TLSv1-require-fail-ssl
 
 [7-client-auth-TLSv1-require-fail-ssl]
 server = 7-client-auth-TLSv1-require-fail-server
-server2 = 7-client-auth-TLSv1-require-fail-server2
 client = 7-client-auth-TLSv1-require-fail-client
 
 [7-client-auth-TLSv1-require-fail-server]
@@ -290,22 +217,11 @@ Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-
-[7-client-auth-TLSv1-require-fail-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-
 [7-client-auth-TLSv1-require-fail-client]
 CipherString = DEFAULT
 Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-7]
 ExpectedResult = ServerFail
@@ -319,7 +235,6 @@ ssl_conf = 8-client-auth-TLSv1-require-ssl
 
 [8-client-auth-TLSv1-require-ssl]
 server = 8-client-auth-TLSv1-require-server
-server2 = 8-client-auth-TLSv1-require-server2
 client = 8-client-auth-TLSv1-require-client
 
 [8-client-auth-TLSv1-require-server]
@@ -330,16 +245,6 @@ Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-
-[8-client-auth-TLSv1-require-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Request
-
-
 [8-client-auth-TLSv1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
@@ -347,7 +252,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-8]
 ExpectedResult = Success
@@ -360,7 +264,6 @@ ssl_conf = 9-client-auth-TLSv1-noroot-ssl
 
 [9-client-auth-TLSv1-noroot-ssl]
 server = 9-client-auth-TLSv1-noroot-server
-server2 = 9-client-auth-TLSv1-noroot-server2
 client = 9-client-auth-TLSv1-noroot-client
 
 [9-client-auth-TLSv1-noroot-server]
@@ -370,15 +273,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1
 VerifyMode = Require
 
-
-[9-client-auth-TLSv1-noroot-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
-VerifyMode = Require
-
-
 [9-client-auth-TLSv1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
@@ -386,7 +280,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-9]
 ExpectedResult = ServerFail
@@ -400,7 +293,6 @@ ssl_conf = 10-server-auth-TLSv1.1-ssl
 
 [10-server-auth-TLSv1.1-ssl]
 server = 10-server-auth-TLSv1.1-server
-server2 = 10-server-auth-TLSv1.1-server2
 client = 10-server-auth-TLSv1.1-client
 
 [10-server-auth-TLSv1.1-server]
@@ -409,20 +301,11 @@ CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1.1
 
-
-[10-server-auth-TLSv1.1-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
-
-
 [10-server-auth-TLSv1.1-client]
 CipherString = DEFAULT
 Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-10]
 ExpectedResult = Success
@@ -435,7 +318,6 @@ ssl_conf = 11-client-auth-TLSv1.1-request-ssl
 
 [11-client-auth-TLSv1.1-request-ssl]
 server = 11-client-auth-TLSv1.1-request-server
-server2 = 11-client-auth-TLSv1.1-request-server2
 client = 11-client-auth-TLSv1.1-request-client
 
 [11-client-auth-TLSv1.1-request-server]
@@ -445,21 +327,11 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1.1
 VerifyMode = Request
 
-
-[11-client-auth-TLSv1.1-request-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
-VerifyMode = Request
-
-
 [11-client-auth-TLSv1.1-request-client]
 CipherString = DEFAULT
 Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-11]
 ExpectedResult = Success
@@ -472,7 +344,6 @@ ssl_conf = 12-client-auth-TLSv1.1-require-fail-ssl
 
 [12-client-auth-TLSv1.1-require-fail-ssl]
 server = 12-client-auth-TLSv1.1-require-fail-server
-server2 = 12-client-auth-TLSv1.1-require-fail-server2
 client = 12-client-auth-TLSv1.1-require-fail-client
 
 [12-client-auth-TLSv1.1-require-fail-server]
@@ -483,22 +354,11 @@ Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-
-[12-client-auth-TLSv1.1-require-fail-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-
 [12-client-auth-TLSv1.1-require-fail-client]
 CipherString = DEFAULT
 Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-12]
 ExpectedResult = ServerFail
@@ -512,7 +372,6 @@ ssl_conf = 13-client-auth-TLSv1.1-require-ssl
 
 [13-client-auth-TLSv1.1-require-ssl]
 server = 13-client-auth-TLSv1.1-require-server
-server2 = 13-client-auth-TLSv1.1-require-server2
 client = 13-client-auth-TLSv1.1-require-client
 
 [13-client-auth-TLSv1.1-require-server]
@@ -523,16 +382,6 @@ Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-
-[13-client-auth-TLSv1.1-require-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Request
-
-
 [13-client-auth-TLSv1.1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
@@ -540,7 +389,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-13]
 ExpectedResult = Success
@@ -553,7 +401,6 @@ ssl_conf = 14-client-auth-TLSv1.1-noroot-ssl
 
 [14-client-auth-TLSv1.1-noroot-ssl]
 server = 14-client-auth-TLSv1.1-noroot-server
-server2 = 14-client-auth-TLSv1.1-noroot-server2
 client = 14-client-auth-TLSv1.1-noroot-client
 
 [14-client-auth-TLSv1.1-noroot-server]
@@ -563,15 +410,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1.1
 VerifyMode = Require
 
-
-[14-client-auth-TLSv1.1-noroot-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
-VerifyMode = Require
-
-
 [14-client-auth-TLSv1.1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
@@ -579,7 +417,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-14]
 ExpectedResult = ServerFail
@@ -593,7 +430,6 @@ ssl_conf = 15-server-auth-TLSv1.2-ssl
 
 [15-server-auth-TLSv1.2-ssl]
 server = 15-server-auth-TLSv1.2-server
-server2 = 15-server-auth-TLSv1.2-server2
 client = 15-server-auth-TLSv1.2-client
 
 [15-server-auth-TLSv1.2-server]
@@ -602,20 +438,11 @@ CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1.2
 
-
-[15-server-auth-TLSv1.2-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
-
-
 [15-server-auth-TLSv1.2-client]
 CipherString = DEFAULT
 Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-15]
 ExpectedResult = Success
@@ -628,7 +455,6 @@ ssl_conf = 16-client-auth-TLSv1.2-request-ssl
 
 [16-client-auth-TLSv1.2-request-ssl]
 server = 16-client-auth-TLSv1.2-request-server
-server2 = 16-client-auth-TLSv1.2-request-server2
 client = 16-client-auth-TLSv1.2-request-client
 
 [16-client-auth-TLSv1.2-request-server]
@@ -638,21 +464,11 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1.2
 VerifyMode = Request
 
-
-[16-client-auth-TLSv1.2-request-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
-VerifyMode = Request
-
-
 [16-client-auth-TLSv1.2-request-client]
 CipherString = DEFAULT
 Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-16]
 ExpectedResult = Success
@@ -665,7 +481,6 @@ ssl_conf = 17-client-auth-TLSv1.2-require-fail-ssl
 
 [17-client-auth-TLSv1.2-require-fail-ssl]
 server = 17-client-auth-TLSv1.2-require-fail-server
-server2 = 17-client-auth-TLSv1.2-require-fail-server2
 client = 17-client-auth-TLSv1.2-require-fail-client
 
 [17-client-auth-TLSv1.2-require-fail-server]
@@ -676,22 +491,11 @@ Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-
-[17-client-auth-TLSv1.2-require-fail-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-
 [17-client-auth-TLSv1.2-require-fail-client]
 CipherString = DEFAULT
 Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-17]
 ExpectedResult = ServerFail
@@ -705,7 +509,6 @@ ssl_conf = 18-client-auth-TLSv1.2-require-ssl
 
 [18-client-auth-TLSv1.2-require-ssl]
 server = 18-client-auth-TLSv1.2-require-server
-server2 = 18-client-auth-TLSv1.2-require-server2
 client = 18-client-auth-TLSv1.2-require-client
 
 [18-client-auth-TLSv1.2-require-server]
@@ -716,16 +519,6 @@ Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-
-[18-client-auth-TLSv1.2-require-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Request
-
-
 [18-client-auth-TLSv1.2-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
@@ -733,7 +526,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-18]
 ExpectedResult = Success
@@ -746,7 +538,6 @@ ssl_conf = 19-client-auth-TLSv1.2-noroot-ssl
 
 [19-client-auth-TLSv1.2-noroot-ssl]
 server = 19-client-auth-TLSv1.2-noroot-server
-server2 = 19-client-auth-TLSv1.2-noroot-server2
 client = 19-client-auth-TLSv1.2-noroot-client
 
 [19-client-auth-TLSv1.2-noroot-server]
@@ -756,15 +547,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Protocol = TLSv1.2
 VerifyMode = Require
 
-
-[19-client-auth-TLSv1.2-noroot-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
-VerifyMode = Require
-
-
 [19-client-auth-TLSv1.2-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
@@ -772,7 +554,6 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-19]
 ExpectedResult = ServerFail

--- a/test/ssl-tests/05-sni.conf
+++ b/test/ssl-tests/05-sni.conf
@@ -18,18 +18,15 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [0-SNI-default-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [0-SNI-default-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = Success

--- a/test/ssl-tests/05-sni.conf.in
+++ b/test/ssl-tests/05-sni.conf.in
@@ -18,6 +18,7 @@ our @tests = (
     {
         name => "SNI-default",
         server => { },
+        server2 => { },
         client => { },
         test   => { "ServerName" => "server2",
 		    "ExpectedResult" => "Success" },

--- a/test/ssl-tests/06-sni-ticket.conf
+++ b/test/ssl-tests/06-sni-ticket.conf
@@ -35,20 +35,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [0-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [0-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = Success
@@ -72,20 +69,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [1-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [1-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-1]
 ExpectedResult = Success
@@ -109,20 +103,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [2-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [2-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-2]
 ExpectedResult = Success
@@ -146,20 +137,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [3-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [3-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-3]
 ExpectedResult = Success
@@ -183,20 +171,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [4-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [4-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-4]
 ExpectedResult = Success
@@ -220,20 +205,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [5-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [5-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-5]
 ExpectedResult = Success
@@ -257,20 +239,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [6-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [6-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-6]
 ExpectedResult = Success
@@ -294,20 +273,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [7-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [7-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-7]
 ExpectedResult = Success
@@ -331,20 +307,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [8-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [8-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-8]
 ExpectedResult = Success
@@ -368,20 +341,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [9-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [9-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-9]
 ExpectedResult = Success
@@ -405,20 +375,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [10-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [10-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-10]
 ExpectedResult = Success
@@ -442,20 +409,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [11-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [11-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-11]
 ExpectedResult = Success
@@ -479,20 +443,17 @@ CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [12-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [12-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-12]
 ExpectedResult = Success
@@ -516,20 +477,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [13-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [13-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-13]
 ExpectedResult = Success
@@ -553,20 +511,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [14-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [14-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-14]
 ExpectedResult = Success
@@ -590,20 +545,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [15-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [15-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-15]
 ExpectedResult = Success
@@ -627,20 +579,17 @@ CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [16-sni-session-ticket-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
 [16-sni-session-ticket-client]
 CipherString = DEFAULT
 Options = -SessionTicket
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-16]
 ExpectedResult = Success

--- a/test/ssl-tests/07-dtls-protocol-version.conf
+++ b/test/ssl-tests/07-dtls-protocol-version.conf
@@ -73,7 +73,6 @@ ssl_conf = 0-version-negotiation-ssl
 
 [0-version-negotiation-ssl]
 server = 0-version-negotiation-server
-server2 = 0-version-negotiation-server2
 client = 0-version-negotiation-client
 
 [0-version-negotiation-server]
@@ -82,20 +81,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[0-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [0-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-0]
 ExpectedResult = Success
@@ -110,7 +100,6 @@ ssl_conf = 1-version-negotiation-ssl
 
 [1-version-negotiation-ssl]
 server = 1-version-negotiation-server
-server2 = 1-version-negotiation-server2
 client = 1-version-negotiation-client
 
 [1-version-negotiation-server]
@@ -119,20 +108,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[1-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [1-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-1]
 ExpectedResult = Success
@@ -147,7 +127,6 @@ ssl_conf = 2-version-negotiation-ssl
 
 [2-version-negotiation-ssl]
 server = 2-version-negotiation-server
-server2 = 2-version-negotiation-server2
 client = 2-version-negotiation-client
 
 [2-version-negotiation-server]
@@ -155,19 +134,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[2-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [2-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-2]
 ExpectedResult = Success
@@ -182,7 +153,6 @@ ssl_conf = 3-version-negotiation-ssl
 
 [3-version-negotiation-ssl]
 server = 3-version-negotiation-server
-server2 = 3-version-negotiation-server2
 client = 3-version-negotiation-client
 
 [3-version-negotiation-server]
@@ -192,21 +162,11 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[3-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [3-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-3]
 ExpectedResult = Success
@@ -221,7 +181,6 @@ ssl_conf = 4-version-negotiation-ssl
 
 [4-version-negotiation-ssl]
 server = 4-version-negotiation-server
-server2 = 4-version-negotiation-server2
 client = 4-version-negotiation-client
 
 [4-version-negotiation-server]
@@ -231,21 +190,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[4-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [4-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-4]
 ExpectedResult = Success
@@ -260,7 +209,6 @@ ssl_conf = 5-version-negotiation-ssl
 
 [5-version-negotiation-ssl]
 server = 5-version-negotiation-server
-server2 = 5-version-negotiation-server2
 client = 5-version-negotiation-client
 
 [5-version-negotiation-server]
@@ -269,20 +217,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[5-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [5-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-5]
 ExpectedResult = Success
@@ -297,7 +236,6 @@ ssl_conf = 6-version-negotiation-ssl
 
 [6-version-negotiation-ssl]
 server = 6-version-negotiation-server
-server2 = 6-version-negotiation-server2
 client = 6-version-negotiation-client
 
 [6-version-negotiation-server]
@@ -307,21 +245,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[6-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [6-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-6]
 ExpectedResult = ServerFail
@@ -335,7 +263,6 @@ ssl_conf = 7-version-negotiation-ssl
 
 [7-version-negotiation-ssl]
 server = 7-version-negotiation-server
-server2 = 7-version-negotiation-server2
 client = 7-version-negotiation-client
 
 [7-version-negotiation-server]
@@ -344,20 +271,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[7-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [7-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-7]
 ExpectedResult = ServerFail
@@ -371,7 +289,6 @@ ssl_conf = 8-version-negotiation-ssl
 
 [8-version-negotiation-ssl]
 server = 8-version-negotiation-server
-server2 = 8-version-negotiation-server2
 client = 8-version-negotiation-client
 
 [8-version-negotiation-server]
@@ -380,20 +297,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[8-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [8-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-8]
 ExpectedResult = Success
@@ -408,7 +316,6 @@ ssl_conf = 9-version-negotiation-ssl
 
 [9-version-negotiation-ssl]
 server = 9-version-negotiation-server
-server2 = 9-version-negotiation-server2
 client = 9-version-negotiation-client
 
 [9-version-negotiation-server]
@@ -417,20 +324,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[9-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [9-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-9]
 ExpectedResult = Success
@@ -445,7 +343,6 @@ ssl_conf = 10-version-negotiation-ssl
 
 [10-version-negotiation-ssl]
 server = 10-version-negotiation-server
-server2 = 10-version-negotiation-server2
 client = 10-version-negotiation-client
 
 [10-version-negotiation-server]
@@ -453,19 +350,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[10-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [10-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-10]
 ExpectedResult = Success
@@ -480,7 +369,6 @@ ssl_conf = 11-version-negotiation-ssl
 
 [11-version-negotiation-ssl]
 server = 11-version-negotiation-server
-server2 = 11-version-negotiation-server2
 client = 11-version-negotiation-client
 
 [11-version-negotiation-server]
@@ -490,21 +378,11 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[11-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [11-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-11]
 ExpectedResult = Success
@@ -519,7 +397,6 @@ ssl_conf = 12-version-negotiation-ssl
 
 [12-version-negotiation-ssl]
 server = 12-version-negotiation-server
-server2 = 12-version-negotiation-server2
 client = 12-version-negotiation-client
 
 [12-version-negotiation-server]
@@ -529,21 +406,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[12-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [12-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-12]
 ExpectedResult = Success
@@ -558,7 +425,6 @@ ssl_conf = 13-version-negotiation-ssl
 
 [13-version-negotiation-ssl]
 server = 13-version-negotiation-server
-server2 = 13-version-negotiation-server2
 client = 13-version-negotiation-client
 
 [13-version-negotiation-server]
@@ -567,20 +433,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[13-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [13-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-13]
 ExpectedResult = Success
@@ -595,7 +452,6 @@ ssl_conf = 14-version-negotiation-ssl
 
 [14-version-negotiation-ssl]
 server = 14-version-negotiation-server
-server2 = 14-version-negotiation-server2
 client = 14-version-negotiation-client
 
 [14-version-negotiation-server]
@@ -605,21 +461,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[14-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [14-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-14]
 ExpectedResult = Success
@@ -634,7 +480,6 @@ ssl_conf = 15-version-negotiation-ssl
 
 [15-version-negotiation-ssl]
 server = 15-version-negotiation-server
-server2 = 15-version-negotiation-server2
 client = 15-version-negotiation-client
 
 [15-version-negotiation-server]
@@ -643,20 +488,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[15-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [15-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-15]
 ExpectedResult = Success
@@ -671,7 +507,6 @@ ssl_conf = 16-version-negotiation-ssl
 
 [16-version-negotiation-ssl]
 server = 16-version-negotiation-server
-server2 = 16-version-negotiation-server2
 client = 16-version-negotiation-client
 
 [16-version-negotiation-server]
@@ -680,19 +515,10 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[16-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [16-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-16]
 ExpectedResult = Success
@@ -707,7 +533,6 @@ ssl_conf = 17-version-negotiation-ssl
 
 [17-version-negotiation-ssl]
 server = 17-version-negotiation-server
-server2 = 17-version-negotiation-server2
 client = 17-version-negotiation-client
 
 [17-version-negotiation-server]
@@ -716,19 +541,10 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[17-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [17-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-17]
 ExpectedResult = Success
@@ -743,7 +559,6 @@ ssl_conf = 18-version-negotiation-ssl
 
 [18-version-negotiation-ssl]
 server = 18-version-negotiation-server
-server2 = 18-version-negotiation-server2
 client = 18-version-negotiation-client
 
 [18-version-negotiation-server]
@@ -751,18 +566,10 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[18-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [18-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-18]
 ExpectedResult = Success
@@ -777,7 +584,6 @@ ssl_conf = 19-version-negotiation-ssl
 
 [19-version-negotiation-ssl]
 server = 19-version-negotiation-server
-server2 = 19-version-negotiation-server2
 client = 19-version-negotiation-client
 
 [19-version-negotiation-server]
@@ -787,20 +593,10 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[19-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [19-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-19]
 ExpectedResult = Success
@@ -815,7 +611,6 @@ ssl_conf = 20-version-negotiation-ssl
 
 [20-version-negotiation-ssl]
 server = 20-version-negotiation-server
-server2 = 20-version-negotiation-server2
 client = 20-version-negotiation-client
 
 [20-version-negotiation-server]
@@ -825,20 +620,10 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[20-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [20-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-20]
 ExpectedResult = Success
@@ -853,7 +638,6 @@ ssl_conf = 21-version-negotiation-ssl
 
 [21-version-negotiation-ssl]
 server = 21-version-negotiation-server
-server2 = 21-version-negotiation-server2
 client = 21-version-negotiation-client
 
 [21-version-negotiation-server]
@@ -862,19 +646,10 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[21-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [21-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-21]
 ExpectedResult = Success
@@ -889,7 +664,6 @@ ssl_conf = 22-version-negotiation-ssl
 
 [22-version-negotiation-ssl]
 server = 22-version-negotiation-server
-server2 = 22-version-negotiation-server2
 client = 22-version-negotiation-client
 
 [22-version-negotiation-server]
@@ -899,20 +673,10 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[22-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [22-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-22]
 ExpectedResult = Success
@@ -927,7 +691,6 @@ ssl_conf = 23-version-negotiation-ssl
 
 [23-version-negotiation-ssl]
 server = 23-version-negotiation-server
-server2 = 23-version-negotiation-server2
 client = 23-version-negotiation-client
 
 [23-version-negotiation-server]
@@ -936,19 +699,10 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[23-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [23-version-negotiation-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-23]
 ExpectedResult = Success
@@ -963,7 +717,6 @@ ssl_conf = 24-version-negotiation-ssl
 
 [24-version-negotiation-ssl]
 server = 24-version-negotiation-server
-server2 = 24-version-negotiation-server2
 client = 24-version-negotiation-client
 
 [24-version-negotiation-server]
@@ -972,21 +725,12 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[24-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [24-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-24]
 ExpectedResult = Success
@@ -1001,7 +745,6 @@ ssl_conf = 25-version-negotiation-ssl
 
 [25-version-negotiation-ssl]
 server = 25-version-negotiation-server
-server2 = 25-version-negotiation-server2
 client = 25-version-negotiation-client
 
 [25-version-negotiation-server]
@@ -1010,21 +753,12 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[25-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [25-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-25]
 ExpectedResult = Success
@@ -1039,7 +773,6 @@ ssl_conf = 26-version-negotiation-ssl
 
 [26-version-negotiation-ssl]
 server = 26-version-negotiation-server
-server2 = 26-version-negotiation-server2
 client = 26-version-negotiation-client
 
 [26-version-negotiation-server]
@@ -1047,20 +780,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[26-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [26-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-26]
 ExpectedResult = Success
@@ -1075,7 +800,6 @@ ssl_conf = 27-version-negotiation-ssl
 
 [27-version-negotiation-ssl]
 server = 27-version-negotiation-server
-server2 = 27-version-negotiation-server2
 client = 27-version-negotiation-client
 
 [27-version-negotiation-server]
@@ -1085,22 +809,12 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[27-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [27-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-27]
 ExpectedResult = Success
@@ -1115,7 +829,6 @@ ssl_conf = 28-version-negotiation-ssl
 
 [28-version-negotiation-ssl]
 server = 28-version-negotiation-server
-server2 = 28-version-negotiation-server2
 client = 28-version-negotiation-client
 
 [28-version-negotiation-server]
@@ -1125,22 +838,12 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[28-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [28-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-28]
 ExpectedResult = Success
@@ -1155,7 +858,6 @@ ssl_conf = 29-version-negotiation-ssl
 
 [29-version-negotiation-ssl]
 server = 29-version-negotiation-server
-server2 = 29-version-negotiation-server2
 client = 29-version-negotiation-client
 
 [29-version-negotiation-server]
@@ -1164,21 +866,12 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[29-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [29-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-29]
 ExpectedResult = Success
@@ -1193,7 +886,6 @@ ssl_conf = 30-version-negotiation-ssl
 
 [30-version-negotiation-ssl]
 server = 30-version-negotiation-server
-server2 = 30-version-negotiation-server2
 client = 30-version-negotiation-client
 
 [30-version-negotiation-server]
@@ -1203,22 +895,12 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[30-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [30-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-30]
 ExpectedResult = ServerFail
@@ -1232,7 +914,6 @@ ssl_conf = 31-version-negotiation-ssl
 
 [31-version-negotiation-ssl]
 server = 31-version-negotiation-server
-server2 = 31-version-negotiation-server2
 client = 31-version-negotiation-client
 
 [31-version-negotiation-server]
@@ -1241,21 +922,12 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[31-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [31-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-31]
 ExpectedResult = ServerFail
@@ -1269,7 +941,6 @@ ssl_conf = 32-version-negotiation-ssl
 
 [32-version-negotiation-ssl]
 server = 32-version-negotiation-server
-server2 = 32-version-negotiation-server2
 client = 32-version-negotiation-client
 
 [32-version-negotiation-server]
@@ -1278,21 +949,12 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[32-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [32-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-32]
 ExpectedResult = Success
@@ -1307,7 +969,6 @@ ssl_conf = 33-version-negotiation-ssl
 
 [33-version-negotiation-ssl]
 server = 33-version-negotiation-server
-server2 = 33-version-negotiation-server2
 client = 33-version-negotiation-client
 
 [33-version-negotiation-server]
@@ -1316,21 +977,12 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[33-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [33-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-33]
 ExpectedResult = Success
@@ -1345,7 +997,6 @@ ssl_conf = 34-version-negotiation-ssl
 
 [34-version-negotiation-ssl]
 server = 34-version-negotiation-server
-server2 = 34-version-negotiation-server2
 client = 34-version-negotiation-client
 
 [34-version-negotiation-server]
@@ -1353,20 +1004,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[34-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [34-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-34]
 ExpectedResult = Success
@@ -1381,7 +1024,6 @@ ssl_conf = 35-version-negotiation-ssl
 
 [35-version-negotiation-ssl]
 server = 35-version-negotiation-server
-server2 = 35-version-negotiation-server2
 client = 35-version-negotiation-client
 
 [35-version-negotiation-server]
@@ -1391,22 +1033,12 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[35-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [35-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-35]
 ExpectedResult = Success
@@ -1421,7 +1053,6 @@ ssl_conf = 36-version-negotiation-ssl
 
 [36-version-negotiation-ssl]
 server = 36-version-negotiation-server
-server2 = 36-version-negotiation-server2
 client = 36-version-negotiation-client
 
 [36-version-negotiation-server]
@@ -1431,22 +1062,12 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[36-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [36-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-36]
 ExpectedResult = Success
@@ -1461,7 +1082,6 @@ ssl_conf = 37-version-negotiation-ssl
 
 [37-version-negotiation-ssl]
 server = 37-version-negotiation-server
-server2 = 37-version-negotiation-server2
 client = 37-version-negotiation-client
 
 [37-version-negotiation-server]
@@ -1470,21 +1090,12 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[37-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [37-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-37]
 ExpectedResult = Success
@@ -1499,7 +1110,6 @@ ssl_conf = 38-version-negotiation-ssl
 
 [38-version-negotiation-ssl]
 server = 38-version-negotiation-server
-server2 = 38-version-negotiation-server2
 client = 38-version-negotiation-client
 
 [38-version-negotiation-server]
@@ -1509,22 +1119,12 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[38-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [38-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-38]
 ExpectedResult = Success
@@ -1539,7 +1139,6 @@ ssl_conf = 39-version-negotiation-ssl
 
 [39-version-negotiation-ssl]
 server = 39-version-negotiation-server
-server2 = 39-version-negotiation-server2
 client = 39-version-negotiation-client
 
 [39-version-negotiation-server]
@@ -1548,21 +1147,12 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[39-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [39-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-39]
 ExpectedResult = Success
@@ -1577,7 +1167,6 @@ ssl_conf = 40-version-negotiation-ssl
 
 [40-version-negotiation-ssl]
 server = 40-version-negotiation-server
-server2 = 40-version-negotiation-server2
 client = 40-version-negotiation-client
 
 [40-version-negotiation-server]
@@ -1586,20 +1175,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[40-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [40-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-40]
 ExpectedResult = Success
@@ -1614,7 +1194,6 @@ ssl_conf = 41-version-negotiation-ssl
 
 [41-version-negotiation-ssl]
 server = 41-version-negotiation-server
-server2 = 41-version-negotiation-server2
 client = 41-version-negotiation-client
 
 [41-version-negotiation-server]
@@ -1623,20 +1202,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[41-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [41-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-41]
 ExpectedResult = Success
@@ -1651,7 +1221,6 @@ ssl_conf = 42-version-negotiation-ssl
 
 [42-version-negotiation-ssl]
 server = 42-version-negotiation-server
-server2 = 42-version-negotiation-server2
 client = 42-version-negotiation-client
 
 [42-version-negotiation-server]
@@ -1659,19 +1228,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[42-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [42-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-42]
 ExpectedResult = Success
@@ -1686,7 +1247,6 @@ ssl_conf = 43-version-negotiation-ssl
 
 [43-version-negotiation-ssl]
 server = 43-version-negotiation-server
-server2 = 43-version-negotiation-server2
 client = 43-version-negotiation-client
 
 [43-version-negotiation-server]
@@ -1696,21 +1256,11 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[43-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [43-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-43]
 ExpectedResult = Success
@@ -1725,7 +1275,6 @@ ssl_conf = 44-version-negotiation-ssl
 
 [44-version-negotiation-ssl]
 server = 44-version-negotiation-server
-server2 = 44-version-negotiation-server2
 client = 44-version-negotiation-client
 
 [44-version-negotiation-server]
@@ -1735,21 +1284,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[44-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [44-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-44]
 ExpectedResult = Success
@@ -1764,7 +1303,6 @@ ssl_conf = 45-version-negotiation-ssl
 
 [45-version-negotiation-ssl]
 server = 45-version-negotiation-server
-server2 = 45-version-negotiation-server2
 client = 45-version-negotiation-client
 
 [45-version-negotiation-server]
@@ -1773,20 +1311,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[45-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [45-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-45]
 ExpectedResult = Success
@@ -1801,7 +1330,6 @@ ssl_conf = 46-version-negotiation-ssl
 
 [46-version-negotiation-ssl]
 server = 46-version-negotiation-server
-server2 = 46-version-negotiation-server2
 client = 46-version-negotiation-client
 
 [46-version-negotiation-server]
@@ -1811,21 +1339,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[46-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [46-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-46]
 ExpectedResult = Success
@@ -1840,7 +1358,6 @@ ssl_conf = 47-version-negotiation-ssl
 
 [47-version-negotiation-ssl]
 server = 47-version-negotiation-server
-server2 = 47-version-negotiation-server2
 client = 47-version-negotiation-client
 
 [47-version-negotiation-server]
@@ -1849,20 +1366,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[47-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [47-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-47]
 ExpectedResult = Success
@@ -1877,7 +1385,6 @@ ssl_conf = 48-version-negotiation-ssl
 
 [48-version-negotiation-ssl]
 server = 48-version-negotiation-server
-server2 = 48-version-negotiation-server2
 client = 48-version-negotiation-client
 
 [48-version-negotiation-server]
@@ -1886,21 +1393,12 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[48-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [48-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-48]
 ExpectedResult = ClientFail
@@ -1914,7 +1412,6 @@ ssl_conf = 49-version-negotiation-ssl
 
 [49-version-negotiation-ssl]
 server = 49-version-negotiation-server
-server2 = 49-version-negotiation-server2
 client = 49-version-negotiation-client
 
 [49-version-negotiation-server]
@@ -1923,21 +1420,12 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[49-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [49-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-49]
 ExpectedResult = Success
@@ -1952,7 +1440,6 @@ ssl_conf = 50-version-negotiation-ssl
 
 [50-version-negotiation-ssl]
 server = 50-version-negotiation-server
-server2 = 50-version-negotiation-server2
 client = 50-version-negotiation-client
 
 [50-version-negotiation-server]
@@ -1960,20 +1447,12 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[50-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [50-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-50]
 ExpectedResult = Success
@@ -1988,7 +1467,6 @@ ssl_conf = 51-version-negotiation-ssl
 
 [51-version-negotiation-ssl]
 server = 51-version-negotiation-server
-server2 = 51-version-negotiation-server2
 client = 51-version-negotiation-client
 
 [51-version-negotiation-server]
@@ -1998,22 +1476,12 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[51-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [51-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-51]
 ExpectedResult = ClientFail
@@ -2027,7 +1495,6 @@ ssl_conf = 52-version-negotiation-ssl
 
 [52-version-negotiation-ssl]
 server = 52-version-negotiation-server
-server2 = 52-version-negotiation-server2
 client = 52-version-negotiation-client
 
 [52-version-negotiation-server]
@@ -2037,22 +1504,12 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[52-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [52-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-52]
 ExpectedResult = Success
@@ -2067,7 +1524,6 @@ ssl_conf = 53-version-negotiation-ssl
 
 [53-version-negotiation-ssl]
 server = 53-version-negotiation-server
-server2 = 53-version-negotiation-server2
 client = 53-version-negotiation-client
 
 [53-version-negotiation-server]
@@ -2076,21 +1532,12 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[53-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [53-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-53]
 ExpectedResult = Success
@@ -2105,7 +1552,6 @@ ssl_conf = 54-version-negotiation-ssl
 
 [54-version-negotiation-ssl]
 server = 54-version-negotiation-server
-server2 = 54-version-negotiation-server2
 client = 54-version-negotiation-client
 
 [54-version-negotiation-server]
@@ -2115,22 +1561,12 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[54-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [54-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-54]
 ExpectedResult = Success
@@ -2145,7 +1581,6 @@ ssl_conf = 55-version-negotiation-ssl
 
 [55-version-negotiation-ssl]
 server = 55-version-negotiation-server
-server2 = 55-version-negotiation-server2
 client = 55-version-negotiation-client
 
 [55-version-negotiation-server]
@@ -2154,21 +1589,12 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[55-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [55-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-55]
 ExpectedResult = Success
@@ -2183,7 +1609,6 @@ ssl_conf = 56-version-negotiation-ssl
 
 [56-version-negotiation-ssl]
 server = 56-version-negotiation-server
-server2 = 56-version-negotiation-server2
 client = 56-version-negotiation-client
 
 [56-version-negotiation-server]
@@ -2192,20 +1617,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[56-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [56-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-56]
 ExpectedResult = ClientFail
@@ -2219,7 +1635,6 @@ ssl_conf = 57-version-negotiation-ssl
 
 [57-version-negotiation-ssl]
 server = 57-version-negotiation-server
-server2 = 57-version-negotiation-server2
 client = 57-version-negotiation-client
 
 [57-version-negotiation-server]
@@ -2228,20 +1643,11 @@ CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[57-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [57-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-57]
 ExpectedResult = Success
@@ -2256,7 +1662,6 @@ ssl_conf = 58-version-negotiation-ssl
 
 [58-version-negotiation-ssl]
 server = 58-version-negotiation-server
-server2 = 58-version-negotiation-server2
 client = 58-version-negotiation-client
 
 [58-version-negotiation-server]
@@ -2264,19 +1669,11 @@ Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[58-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [58-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-58]
 ExpectedResult = Success
@@ -2291,7 +1688,6 @@ ssl_conf = 59-version-negotiation-ssl
 
 [59-version-negotiation-ssl]
 server = 59-version-negotiation-server
-server2 = 59-version-negotiation-server2
 client = 59-version-negotiation-client
 
 [59-version-negotiation-server]
@@ -2301,21 +1697,11 @@ MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[59-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [59-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-59]
 ExpectedResult = ClientFail
@@ -2329,7 +1715,6 @@ ssl_conf = 60-version-negotiation-ssl
 
 [60-version-negotiation-ssl]
 server = 60-version-negotiation-server
-server2 = 60-version-negotiation-server2
 client = 60-version-negotiation-client
 
 [60-version-negotiation-server]
@@ -2339,21 +1724,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[60-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [60-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-60]
 ExpectedResult = Success
@@ -2368,7 +1743,6 @@ ssl_conf = 61-version-negotiation-ssl
 
 [61-version-negotiation-ssl]
 server = 61-version-negotiation-server
-server2 = 61-version-negotiation-server2
 client = 61-version-negotiation-client
 
 [61-version-negotiation-server]
@@ -2377,20 +1751,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[61-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [61-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-61]
 ExpectedResult = Success
@@ -2405,7 +1770,6 @@ ssl_conf = 62-version-negotiation-ssl
 
 [62-version-negotiation-ssl]
 server = 62-version-negotiation-server
-server2 = 62-version-negotiation-server2
 client = 62-version-negotiation-client
 
 [62-version-negotiation-server]
@@ -2415,21 +1779,11 @@ MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[62-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [62-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-62]
 ExpectedResult = Success
@@ -2444,7 +1798,6 @@ ssl_conf = 63-version-negotiation-ssl
 
 [63-version-negotiation-ssl]
 server = 63-version-negotiation-server
-server2 = 63-version-negotiation-server2
 client = 63-version-negotiation-client
 
 [63-version-negotiation-server]
@@ -2453,20 +1806,11 @@ CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-
-[63-version-negotiation-server2]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-
 [63-version-negotiation-client]
 CipherString = DEFAULT
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
-
 
 [test-63]
 ExpectedResult = Success

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -176,10 +176,15 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
     SSL_CTX *server_ctx = NULL, *server2_ctx = NULL, *client_ctx = NULL;
     SSL_TEST_CTX *test_ctx = NULL;
     HANDSHAKE_RESULT result;
+    const char *server2;
 
     test_ctx = SSL_TEST_CTX_create(conf, fixture.test_app);
     if (test_ctx == NULL)
         goto err;
+
+    /* Use ServerName to detect if we're testing SNI. */
+    server2 = (test_ctx->servername != SSL_TEST_SERVERNAME_NONE) ? "server2"
+        : "server";
 
 #ifndef OPENSSL_NO_DTLS
     if (test_ctx->method == SSL_TEST_METHOD_DTLS) {
@@ -200,14 +205,10 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
     OPENSSL_assert(CONF_modules_load(conf, fixture.test_app, 0) > 0);
 
     if (!SSL_CTX_config(server_ctx, "server")
-        || !SSL_CTX_config(server2_ctx, "server2")
+        || !SSL_CTX_config(server2_ctx, server2)
         || !SSL_CTX_config(client_ctx, "client")) {
         goto err;
     }
-
-    test_ctx = SSL_TEST_CTX_create(conf, fixture.test_app);
-    if (test_ctx == NULL)
-        goto err;
 
     result = do_handshake(server_ctx, server2_ctx, client_ctx, test_ctx);
 

--- a/test/ssl_test.tmpl
+++ b/test/ssl_test.tmpl
@@ -2,8 +2,13 @@
 ssl_conf = {-$testname-}-ssl
 
 [{-$testname-}-ssl]
-server = {-$testname-}-server
-server2 = {-$testname-}-server2
+server = {-$testname-}-server{-
+    # The server2 section is optional.
+    $OUT = "";
+    if (%server2) {
+        $OUT .= "\nserver2 = $testname-server2";
+    }
+-}
 client = {-$testname-}-client
 
 [{-$testname-}-server]
@@ -11,22 +16,19 @@ client = {-$testname-}-client
     foreach my $key (sort keys %server) {
         $OUT .= qq{$key} . " = " . qq{$server{$key}\n} if defined $server{$key};
     }
--}
-
-[{-$testname-}-server2]
-{-
-    foreach my $key (sort keys %server2) {
-        $OUT .= qq{$key} . " = " . qq{$server2{$key}\n} if defined $server2{$key};
+    if (%server2) {
+        $OUT .= "\n[$testname-server2]\n";
+        foreach my $key (sort keys %server2) {
+            $OUT .= qq{$key} . " = " . qq{$server2{$key}\n} if defined $server2{$key};
+        }
     }
 -}
-
 [{-$testname-}-client]
 {-
     foreach my $key (sort keys %client) {
         $OUT .= qq{$key} . " = " . qq{$client{$key}\n} if defined $client{$key};
     }
 -}
-
 [test-{-$idx-}]
 {-
     foreach my $key (sort keys %test) {


### PR DESCRIPTION
The SNI tests introduced a redundant "server2" section into every test
configuration. Copy this automatically from "server" unless testing SNI,
to reduce noise in the generated confs.

Also remove duplicate SSL_TEST_CTX_create (merge conflict error).