### PR TITLE
Remove sessions from external cache, even if internal cache not used

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -708,16 +708,16 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck)
             r = lh_SSL_SESSION_delete(ctx->sessions, c);
             SSL_SESSION_list_remove(ctx, c);
         }
+        c->not_resumable = 1;
 
         if (lck)
             CRYPTO_THREAD_unlock(ctx->lock);
 
-        if (ret) {
-            r->not_resumable = 1;
-            if (ctx->remove_session_cb != NULL)
-                ctx->remove_session_cb(ctx, r);
+        if (ret)
             SSL_SESSION_free(r);
-        }
+
+        if (ctx->remove_session_cb != NULL)
+            ctx->remove_session_cb(ctx, c);
     } else
         ret = 0;
     return (ret);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1839,16 +1839,9 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL *s, PACKET *pkt)
          */
         if (i & SSL_SESS_CACHE_CLIENT) {
             /*
-             * Remove the old session from the cache
+             * Remove the old session from the cache. We carry on if this fails
              */
-            if (i & SSL_SESS_CACHE_NO_INTERNAL_STORE) {
-                if (s->session_ctx->remove_session_cb != NULL)
-                    s->session_ctx->remove_session_cb(s->session_ctx,
-                                                      s->session);
-            } else {
-                /* We carry on if this fails */
-                SSL_CTX_remove_session(s->session_ctx, s->session);
-            }
+            SSL_CTX_remove_session(s->session_ctx, s->session);
         }
 
         if ((new_sess = ssl_session_dup(s->session, 0)) == 0) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -79,11 +79,50 @@ static int test_tlsext_status_type(void)
     return testresult;
 }
 
-static int test_session(void)
+typedef struct ssl_session_test_fixture {
+    const char *test_case_name;
+    int use_ext_cache;
+    int use_int_cache;
+} SSL_SESSION_TEST_FIXTURE;
+
+static int new_called = 0, remove_called = 0;
+
+static SSL_SESSION_TEST_FIXTURE
+ssl_session_set_up(const char *const test_case_name)
+{
+    SSL_SESSION_TEST_FIXTURE fixture;
+
+    fixture.test_case_name = test_case_name;
+    fixture.use_ext_cache = 1;
+    fixture.use_int_cache = 1;
+
+    new_called = remove_called = 0;
+
+    return fixture;
+}
+
+static void ssl_session_tear_down(SSL_SESSION_TEST_FIXTURE fixture)
+{
+}
+
+static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
+{
+    new_called++;
+
+    return 1;
+}
+
+static void remove_session_cb(SSL_CTX *ctx, SSL_SESSION *sess)
+{
+    remove_called++;
+}
+
+static int execute_test_session(SSL_SESSION_TEST_FIXTURE fix)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl1 = NULL, *clientssl1 = NULL;
     SSL *serverssl2 = NULL, *clientssl2 = NULL;
+    SSL *serverssl3 = NULL, *clientssl3 = NULL;
     SSL_SESSION *sess1 = NULL, *sess2 = NULL;
     int testresult = 0;
 
@@ -93,24 +132,44 @@ static int test_session(void)
         return 0;
     }
 
-    /* Turn on client session cache */
-    SSL_CTX_set_session_cache_mode(cctx, SSL_SESS_CACHE_CLIENT);
+#ifndef OPENSSL_NO_TLS1_2
+    /* Only allow TLS1.2 so we can force a connection failure later */
+    SSL_CTX_set_min_proto_version(cctx, TLS1_2_VERSION);
+#endif
+
+    /* Set up session cache */
+    if (fix.use_ext_cache) {
+        SSL_CTX_sess_set_new_cb(cctx, new_session_cb);
+        SSL_CTX_sess_set_remove_cb(cctx, remove_session_cb);
+    }
+    if (fix.use_int_cache) {
+        /* Also covers instance where both are set */
+        SSL_CTX_set_session_cache_mode(cctx, SSL_SESS_CACHE_CLIENT);
+    } else {
+        SSL_CTX_set_session_cache_mode(cctx,
+                                       SSL_SESS_CACHE_CLIENT
+                                       | SSL_SESS_CACHE_NO_INTERNAL_STORE);
+    }
 
     if (!create_ssl_connection(sctx, cctx, &serverssl1, &clientssl1, NULL,
                                NULL)) {
         printf("Unable to create SSL connection\n");
         goto end;
     }
-
     sess1 = SSL_get1_session(clientssl1);
     if (sess1 == NULL) {
         printf("Unexpected NULL session\n");
         goto end;
     }
 
-    if (SSL_CTX_add_session(cctx, sess1)) {
+    if (fix.use_int_cache && SSL_CTX_add_session(cctx, sess1)) {
         /* Should have failed because it should already be in the cache */
         printf("Unexpected success adding session to cache\n");
+        goto end;
+    }
+
+    if (fix.use_ext_cache && (new_called != 1 || remove_called != 0)) {
+        printf("Session not added to cache\n");
         goto end;
     }
 
@@ -126,6 +185,11 @@ static int test_session(void)
         goto end;
     }
 
+    if (fix.use_ext_cache && (new_called != 2 || remove_called != 0)) {
+        printf("Remove session callback unexpectedly called\n");
+        goto end;
+    }
+
     /*
      * This should clear sess2 from the cache because it is a "bad" session. See
      * SSL_set_session() documentation.
@@ -135,41 +199,128 @@ static int test_session(void)
         goto end;
     }
 
+    if (fix.use_ext_cache && (new_called != 2 || remove_called != 1)) {
+        printf("Failed to call callback to remove session\n");
+        goto end;
+    }
+
+
     if (SSL_get_session(clientssl2) != sess1) {
         printf("Unexpected session found\n");
         goto end;
     }
 
-    if (!SSL_CTX_add_session(cctx, sess2)) {
-        /*
-         * Should have succeeded because it should not already be in the cache
+    if (fix.use_int_cache) {
+        if (!SSL_CTX_add_session(cctx, sess2)) {
+            /*
+             * Should have succeeded because it should not already be in the cache
+             */
+            printf("Unexpected failure adding session to cache\n");
+            goto end;
+        }
+
+        if (!SSL_CTX_remove_session(cctx, sess2)) {
+            printf("Unexpected failure removing session from cache\n");
+            goto end;
+        }
+
+        /* This is for the purposes of internal cache testing...ignore the
+         * counter for external cache
          */
-        printf("Unexpected failure adding session to cache\n");
-        goto end;
+        if (fix.use_ext_cache)
+            remove_called--;
     }
 
-    if (!SSL_CTX_remove_session(cctx, sess2)) {
-        printf("Unexpected failure removing session from cache\n");
-        goto end;
-    }
-
+    /* This shouldn't be in the cache so should fail */
     if (SSL_CTX_remove_session(cctx, sess2)) {
         printf("Unexpected success removing session from cache\n");
         goto end;
     }
 
+    if (fix.use_ext_cache && (new_called != 2 || remove_called != 2)) {
+        printf("Failed to call callback to remove session #2\n");
+        goto end;
+    }
+
+#ifndef OPENSSL_NO_TLS1_1
+    /* Force a connection failure */
+    SSL_CTX_set_max_proto_version(sctx, TLS1_1_VERSION);
+    clientssl3 = SSL_new(cctx);
+    if (clientssl3 == NULL) {
+        printf("Malloc failure\n");
+        goto end;
+    }
+    if (!SSL_set_session(clientssl3, sess1)) {
+        printf("Unable to set session for third connection\n");
+        goto end;
+    }
+
+    /* This should fail because of the mismatched protocol versions */
+    if (create_ssl_connection(sctx, cctx, &serverssl3, &clientssl3, NULL,
+                               NULL)) {
+        printf("Unexpected success creating SSL connection\n");
+        goto end;
+    }
+
+    /* We should have automatically removed the session from the cache */
+    if (fix.use_ext_cache && (new_called != 2 || remove_called != 3)) {
+        printf("Failed to call callback to remove session #2\n");
+        goto end;
+    }
+
+    if (fix.use_int_cache && !SSL_CTX_add_session(cctx, sess2)) {
+        /*
+         * Should have succeeded because it should not already be in the cache
+         */
+        printf("Unexpected failure adding session to cache #2\n");
+        goto end;
+    }
+#endif
+
     testresult = 1;
+
  end:
     SSL_free(serverssl1);
     SSL_free(clientssl1);
     SSL_free(serverssl2);
     SSL_free(clientssl2);
+    SSL_free(serverssl3);
+    SSL_free(clientssl3);
     SSL_SESSION_free(sess1);
     SSL_SESSION_free(sess2);
+    /*
+     * Check if we need to remove any sessions up-refed for the external cache
+     */
+    if (new_called >= 1)
+        SSL_SESSION_free(sess1);
+    if (new_called >= 2)
+        SSL_SESSION_free(sess2);
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
 
     return testresult;
+}
+
+static int test_session_with_only_int_cache(void) {
+    SETUP_TEST_FIXTURE(SSL_SESSION_TEST_FIXTURE, ssl_session_set_up);
+
+    fixture.use_ext_cache = 0;
+
+    EXECUTE_TEST(execute_test_session, ssl_session_tear_down);
+}
+
+static int test_session_with_only_ext_cache(void) {
+    SETUP_TEST_FIXTURE(SSL_SESSION_TEST_FIXTURE, ssl_session_set_up);
+
+    fixture.use_int_cache = 0;
+
+    EXECUTE_TEST(execute_test_session, ssl_session_tear_down);
+}
+
+static int test_session_with_both_cache(void) {
+    SETUP_TEST_FIXTURE(SSL_SESSION_TEST_FIXTURE, ssl_session_set_up);
+
+    EXECUTE_TEST(execute_test_session, ssl_session_tear_down);
 }
 
 int main(int argc, char *argv[])
@@ -191,7 +342,9 @@ int main(int argc, char *argv[])
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
 
     ADD_TEST(test_tlsext_status_type);
-    ADD_TEST(test_session);
+    ADD_TEST(test_session_with_only_int_cache);
+    ADD_TEST(test_session_with_only_ext_cache);
+    ADD_TEST(test_session_with_both_cache);
 
     testresult = run_tests(argv[0]);
 


### PR DESCRIPTION
If the SSL_SESS_CACHE_NO_INTERNAL_STORE cache mode is used then we weren't
removing sessions from the external cache, e.g. if an alert occurs the
session is supposed to be automatically removed.

This PR fixes the issue and adds some additional testing.

Replaces #1069.
