### PR TITLE
Rewrite base64 code.

### DIFF
--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -47,19 +47,19 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int en_de);
 
 struct evp_Encode_Ctx_st {
-    /* number saved in a partial encode/decode */
-    int num;
-    /*
-     * The length is either the output line length (in input bytes) or the
-     * shortest input line length that is ok.  Once decoding begins, the
-     * length is adjusted up each time a longer line is decoded
-     */
-    int length;
-    /* data to encode */
-    unsigned char enc_data[80];
-    /* number read on current line */
-    int line_num;
-    int expect_nl;
+    /* data_used indicates the number of bytes of |data| that are valid. When
+     * encoding, |data| will be filled and encoded as a lump. When decoding,
+     * only the first four bytes of |data| will be used. */
+    unsigned data_used;
+    uint8_t data[48];
+
+    /* eof_seen indicates that the end of the base64 data has been seen when
+     * decoding. Only whitespace can follow. */
+    char eof_seen;
+
+    /* error_encountered indicates that invalid base64 data was found. This will
+     * cause all future calls to fail. */
+    char error_encountered;
 };
 
 typedef struct evp_pbe_st EVP_PBE_CTL;

--- a/doc/crypto/EVP_EncodeInit.pod
+++ b/doc/crypto/EVP_EncodeInit.pod
@@ -15,17 +15,18 @@ routines
  void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
  int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx);
  void EVP_EncodeInit(EVP_ENCODE_CTX *ctx);
- void EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
-                       const unsigned char *in, int inl);
- void EVP_EncodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl);
- int EVP_EncodeBlock(unsigned char *t, const unsigned char *f, int n);
+ void EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *out_len,
+                       const unsigned char *in, size_t in_len);
+ void EVP_EncodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *out_len);
+ size_t EVP_EncodeBlock(unsigned char *dst, const unsigned char *src,
+                        size_t src_len);
 
  void EVP_DecodeInit(EVP_ENCODE_CTX *ctx);
- int EVP_DecodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
-                      const unsigned char *in, int inl);
- int EVP_DecodeFinal(EVP_ENCODE_CTX *ctx, unsigned
-                     char *out, int *outl);
- int EVP_DecodeBlock(unsigned char *t, const unsigned char *f, int n);
+ int EVP_DecodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *out_len,
+                      const unsigned char *in, size_t in_len);
+ int EVP_DecodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *out_len);
+ int EVP_DecodeBlock(unsigned char *dst, const unsigned char *src,
+                     size_t src_len);
 
 =head1 DESCRIPTION
 
@@ -53,73 +54,75 @@ will also be output.
 
 EVP_EncodeInit() initialises B<ctx> for the start of a new encoding operation.
 
-EVP_EncodeUpdate() encode B<inl> bytes of data found in the buffer pointed to by
-B<in>. The output is stored in the buffer B<out> and the number of bytes output
-is stored in B<*outl>. It is the caller's responsibility to ensure that the
-buffer at B<out> is sufficiently large to accommodate the output data. Only full
-blocks of data (48 bytes) will be immediately processed and output by this
-function. Any remainder is held in the B<ctx> object and will be processed by a
-subsequent call to EVP_EncodeUpdate() or EVP_EncodeFinal(). To calculate the
-required size of the output buffer add together the value of B<inl> with the
-amount of unprocessed data held in B<ctx> and divide the result by 48 (ignore
-any remainder). This gives the number of blocks of data that will be processed.
-Ensure the output buffer contains 65 bytes of storage for each block, plus an
-additional byte for a NUL terminator. EVP_EncodeUpdate() may be called
-repeatedly to process large amounts of input data. In the event of an error
-EVP_EncodeUpdate() will set B<*outl> to 0.
+EVP_EncodeUpdate() encode B<in_len> bytes of data found in the buffer pointed
+to by B<in>. The output is stored in the buffer B<out> and the number of bytes
+output is stored in B<*out_len>. It is the caller's responsibility to ensure
+that the buffer at B<out> is sufficiently large to accommodate the output data.
+Only full blocks of data (48 bytes) will be immediately processed and output by
+this function. Any remainder is held in the B<ctx> object and will be processed
+by a subsequent call to EVP_EncodeUpdate() or EVP_EncodeFinal(). To calculate
+the required size of the output buffer add together the value of B<in_len> with
+the amount of unprocessed data held in B<ctx> and divide the result by 48
+(ignore any remainder). This gives the number of blocks of data that will be
+processed. Ensure the output buffer contains 65 bytes of storage for each
+block, plus an additional byte for a NUL terminator. EVP_EncodeUpdate() may be
+called repeatedly to process large amounts of input data. In the event of an
+error EVP_EncodeUpdate() will set B<*out_len> to 0.
 
 EVP_EncodeFinal() must be called at the end of an encoding operation. It will
 process any partial block of data remaining in the B<ctx> object. The output
 data will be stored in B<out> and the length of the data written will be stored
-in B<*outl>. It is the caller's responsibility to ensure that B<out> is
+in B<*out_len>. It is the caller's responsibility to ensure that B<out> is
 sufficiently large to accommodate the output data which will never be more than
 65 bytes plus an additional NUL terminator (i.e. 66 bytes in total).
 
 EVP_ENCODE_CTX_num() will return the number of as yet unprocessed bytes still to
 be encoded or decoded that are pending in the B<ctx> object.
 
-EVP_EncodeBlock() encodes a full block of input data in B<f> and of length
-B<dlen> and stores it in B<t>. For every 3 bytes of input provided 4 bytes of
-output data will be produced. If B<dlen> is not divisible by 3 then the block is
-encoded as a final block of data and the output is padded such that it is always
-divisible by 4. Additionally a NUL terminator character will be added. For
-example if 16 bytes of input data is provided then 24 bytes of encoded data is
-created plus 1 byte for a NUL terminator (i.e. 25 bytes in total). The length of
-the data generated I<without> the NUL terminator is returned from the function.
+EVP_EncodeBlock() encodes a full block of input data in B<src> and of length
+B<src_len> and stores it in B<t>. For every 3 bytes of input provided 4 bytes of
+output data will be produced. If B<src_len> is not divisible by 3 then the
+block is encoded as a final block of data and the output is padded such that it
+is always divisible by 4. Additionally a NUL terminator character will be
+added. For example if 16 bytes of input data is provided then 24 bytes of
+encoded data is created plus 1 byte for a NUL terminator (i.e. 25 bytes in
+total). The length of the data generated I<without> the NUL terminator is
+returned from the function.
 
 EVP_DecodeInit() initialises B<ctx> for the start of a new decoding operation.
 
-EVP_DecodeUpdate() decodes B<inl> characters of data found in the buffer pointed
-to by B<in>. The output is stored in the buffer B<out> and the number of bytes
-output is stored in B<*outl>. It is the caller's responsibility to ensure that
-the buffer at B<out> is sufficiently large to accommodate the output data. This
-function will attempt to decode as much data as possible in 4 byte chunks. Any
-whitespace, newline or carriage return characters are ignored. Any partial chunk
-of unprocessed data (1, 2 or 3 bytes) that remains at the end will be held in
-the B<ctx> object and processed by a subsequent call to EVP_DecodeUpdate(). If
-any illegal base 64 characters are encountered or if the base 64 padding
-character "=" is encountered in the middle of the data then the function returns
--1 to indicate an error. A return value of 0 or 1 indicates successful
-processing of the data. A return value of 0 additionally indicates that the last
-input data characters processed included the base 64 padding character "=" and
-therefore no more non-padding character data is expected to be processed. For
-every 4 valid base 64 bytes processed (ignoring whitespace, carriage returns and
-line feeds), 3 bytes of binary output data will be produced (or less at the end
-of the data where the padding character "=" has been used).
+EVP_DecodeUpdate() decodes B<in_len> characters of data found in the buffer
+pointed to by B<in>. The output is stored in the buffer B<out> and the number
+of bytes output is stored in B<*out_len>. It is the caller's responsibility to
+ensure that the buffer at B<out> is sufficiently large to accommodate the
+output data. This function will attempt to decode as much data as possible in 4
+byte chunks. Any whitespace, newline or carriage return characters are ignored.
+Any partial chunk of unprocessed data (1, 2 or 3 bytes) that remains at the end
+will be held in the B<ctx> object and processed by a subsequent call to
+EVP_DecodeUpdate(). If any illegal base 64 characters are encountered or if the
+base 64 padding character "=" is encountered in the middle of the data then the
+function returns -1 to indicate an error. A return value of 0 or 1 indicates
+successful processing of the data. A return value of 0 additionally indicates
+that the last input data characters processed included the base 64 padding
+character "=" and therefore no more non-padding character data is expected to
+be processed. For every 4 valid base 64 bytes processed (ignoring whitespace,
+carriage returns and line feeds), 3 bytes of binary output data will be
+produced (or less at the end of the data where the padding character "=" has
+been used).
 
 EVP_DecodeFinal() must be called at the end of a decoding operation. If there
 is any unprocessed data still in B<ctx> then the input data must not have been
 a multiple of 4 and therefore an error has occurred. The function will return -1
 in this case. Otherwise the function returns 1 on success.
 
-EVP_DecodeBlock() will decode the block of B<n> characters of base 64 data
-contained in B<f> and store the result in B<t>. Any leading whitespace will be
-trimmed as will any trailing whitespace, newlines, carriage returns or EOF
-characters. After such trimming the length of the data in B<f> must be divisbile
-by 4. For every 4 input bytes exactly 3 output bytes will be produced. The
-output will be padded with 0 bits if necessary to ensure that the output is
-always 3 bytes for every 4 input bytes. This function will return the length of
-the data decoded or -1 on error.
+EVP_DecodeBlock() will decode the block of B<src_len> characters of base 64
+data contained in B<src> and store the result in B<dst>. Any leading whitespace
+will be trimmed as will any trailing whitespace, newlines or carriage returns.
+After such trimming the length of the data in B<src> must be divisbile by 4.
+For every 4 input bytes exactly 3 output bytes will be produced. The output
+will be padded with 0 bits if necessary to ensure that the output is always 3
+bytes for every 4 input bytes. This function will return the length of the data
+decoded or -1 on error.
 
 =head1 RETURN VALUES
 

--- a/test/evptests.txt
+++ b/test/evptests.txt
@@ -2934,13 +2934,11 @@ Output = "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eA==\neHh4
 Encoding = invalid
 Output = "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\neA==eHh4eHh4eHh4eHh4eHh4\n"
 
-# B64_EOF ('-') terminates input and trailing bytes are ignored
-Encoding = valid
-Input = "OpenSSLOpenSSL\n"
+# B64_EOF ('-') used to signal the end of input, but is now an error.
+Encoding = invalid
 Output = "T3BlblNTTE9wZW5TU0wK\n-abcd"
 
-Encoding = valid
-Input = "OpenSSLOpenSSL\n"
+Encoding = invalid
 Output = "T3BlblNTTE9wZW5TU0wK-abcd"
 
 Cipher = chacha20


### PR DESCRIPTION
While Emilia's reworking in 3cdd1e94 certainly helped, the code for
decoding, at least, was still a little complex for something that really
shouldn't be.

This change achieves some of its reduction in complexity by dropping
support for '-' in base64 data. Previously, this acted like a comment
marker (see below). We have deployed this change at Google and have not
found any ill effects: this appears to be completely unused in reality.

This is a “port” of BoringSSL's base64 code to OpenSSL. The stdint.h
types have been changed to C89 types, the code has been reformatted and
variable declarations have been changed to C89 style.

Here's an example of a PEM blob that was previously accepted but would
be rejected with this change:

```
-----BEGIN RSA PRIVATE KEY-----
MIICXQIBAAKBgQC+qeXl4ZUfQZFmcGAPwdt7Mza4NQ6mJHehc4V/hVYc6eepvL/5
uyyflzuhVy5ufctdi92FlXcIct5nNPdqK0PPdWH5Uzw0t/OjI5y/SJh8ur20krqw
j/N1IOs63AcGLIVSkwx89iQbxj+2tV+YxFpGunUYyR/bJJWczuDMA/CujQIDAQAB
AoGBAKA6IRRdzbbVoD5JI8E6NZtEP7DwDZ57uPk6Hq86u1JTEzcmguJ4dJitPBRr
Mn7yQgwcNQ5EvCKifdqXvXBAaZuiiPFuCS/gfUw04jVHXWvG8ZvBQC3dutUYnFW7
hdun8QU/Z6a1BethvESi1J1vgY2+XC4cBIvbutTc9HhMhbQ1AkEA8YTKGsVEYoKE
d7sSx4qjeN4bgzeVgIwRt01wJ1EJN62LhwO+pYSXvTt14aHxiascejJqUhtuWvzR
nuwydqiDpwJBAMoYgUoWdgW4O/C5ZXjiSia54jzrt7upxSq88njTRo/MCQfuJVbc
3GUD+15V0zNhx9D7lcI+1uxhfcD7jWbJEqsCQBrE/SG6e7nvfX9H3O0BEN10wNfq
cUeuPshybNvuv3bMZYqxf5AZAjiXPpmjuYHo1V8191Lid3jeTN2wkGdWhkECQQCI
Rj3oV3z+Hl1M1bc27GBT/MQxkEE0qiXpy780+kJ6dHsifdNv3z4+X5EA656e5zB2
Gy/A697BRnwlxXpz9OJBAkAUe7Ap0yU8aO6g5g+gsH+18bF0MftWh81VLOo09rRp
SOHxNGGJLE5As5XkCGUZVIass1r8Q4N22Wip0QzeSWDi
-
-          .   *   ..  . *  *
-        *  * @()Ooc()*   o  .
-            (Q@*0CG*O()  ___
-           |\_________/|/ _ \
-           |  |  |  |  | / | |
-           |  |  |  |  | | | |
-           |  |  |  |  | | | |
-           |  |  |  |  | | | |
-           |  |  |  |  | | | |
-           |  |  |  |  | \_| |
-           |  |  |  |  |\___/
-           |\_|__|__|_/|
-            \_________/
-
-----END RSA PRIVATE KEY-----
```
