### PR TITLE
Change the md in random number generator to SHA-256

### DIFF
--- a/crypto/rand/md_rand.c
+++ b/crypto/rand/md_rand.c
@@ -390,10 +390,11 @@ static int rand_bytes(unsigned char *buf, int num, int pseudo)
 
         int n = STATE_SIZE;     /* so that the complete pool gets accessed */
         while (n > 0) {
-#if MD_DIGEST_LENGTH > 20
-# error "Please adjust DUMMY_SEED."
-#endif
-#define DUMMY_SEED "...................." /* at least MD_DIGEST_LENGTH */
+#if defined(USE_SHA256_RAND)
+# define DUMMY_SEED "................................" /* at least MD_DIGEST_LENGTH */
+#else
+# define DUMMY_SEED "...................."
+#endif     
             /*
              * Note that the seed does not matter, it's just that
              * rand_add expects to have something to hash.

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -12,33 +12,25 @@
 
 # define ENTROPY_NEEDED 32      /* require 256 bits = 32 bytes of randomness */
 
-# if !defined(USE_MD5_RAND) && !defined(USE_SHA1_RAND) && !defined(USE_MDC2_RAND) && !defined(USE_MD2_RAND)
+# if !defined(USE_SHA256_RAND) && !defined(OPENSSL_NO_SHA256)
+#  define USE_SHA256_RAND
+# elif !defined(USE_SHA1_RAND)
 #  define USE_SHA1_RAND
 # endif
 
 # include <openssl/evp.h>
 # define MD_Update(a,b,c)        EVP_DigestUpdate(a,b,c)
 # define MD_Final(a,b)           EVP_DigestFinal_ex(a,b,NULL)
-# if defined(USE_MD5_RAND)
-#  include <openssl/md5.h>
-#  define MD_DIGEST_LENGTH        MD5_DIGEST_LENGTH
-#  define MD_Init(a)              EVP_DigestInit_ex(a,EVP_md5(), NULL)
-#  define MD(a,b,c)               EVP_Digest(a,b,c,NULL,EVP_md5(), NULL)
+# if defined(USE_SHA256_RAND)
+#  include <openssl/sha.h>
+#  define MD_DIGEST_LENGTH        SHA_DIGEST_LENGTH
+#  define MD_Init(a)              EVP_DigestInit_ex(a,EVP_sha256(), NULL)
+#  define MD(a,b,c)               EVP_Digest(a,b,c,NULL,EVP_sha256(), NULL)
 # elif defined(USE_SHA1_RAND)
 #  include <openssl/sha.h>
 #  define MD_DIGEST_LENGTH        SHA_DIGEST_LENGTH
 #  define MD_Init(a)              EVP_DigestInit_ex(a,EVP_sha1(), NULL)
 #  define MD(a,b,c)               EVP_Digest(a,b,c,NULL,EVP_sha1(), NULL)
-# elif defined(USE_MDC2_RAND)
-#  include <openssl/mdc2.h>
-#  define MD_DIGEST_LENGTH        MDC2_DIGEST_LENGTH
-#  define MD_Init(a)              EVP_DigestInit_ex(a,EVP_mdc2(), NULL)
-#  define MD(a,b,c)               EVP_Digest(a,b,c,NULL,EVP_mdc2(), NULL)
-# elif defined(USE_MD2_RAND)
-#  include <openssl/md2.h>
-#  define MD_DIGEST_LENGTH        MD2_DIGEST_LENGTH
-#  define MD_Init(a)              EVP_DigestInit_ex(a,EVP_md2(), NULL)
-#  define MD(a,b,c)               EVP_Digest(a,b,c,NULL,EVP_md2(), NULL)
 # endif
 
 void rand_hw_xor(unsigned char *buf, size_t num);

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -23,7 +23,7 @@
 # define MD_Final(a,b)           EVP_DigestFinal_ex(a,b,NULL)
 # if defined(USE_SHA256_RAND)
 #  include <openssl/sha.h>
-#  define MD_DIGEST_LENGTH        SHA_DIGEST_LENGTH
+#  define MD_DIGEST_LENGTH        SHA256_DIGEST_LENGTH
 #  define MD_Init(a)              EVP_DigestInit_ex(a,EVP_sha256(), NULL)
 #  define MD(a,b,c)               EVP_Digest(a,b,c,NULL,EVP_sha256(), NULL)
 # elif defined(USE_SHA1_RAND)


### PR DESCRIPTION
According to the paper published in EUROCRYPT'16, I think that if we can change the digest algorithm in the random number generator from sha-1 to sha-256, at least when we use a seed with full entropy of 256bits, after stirring operation, we can produce all random number with 256 bit entropy(in the paper, the author pointed out that in some circumstances, the entropy of a 32 bytes random number is only 240bits, although a 256bit full-entropy seed has been added). I also removed the MD5/MD2 digest which will never be used in openssl's PRNG. 
