### PR TITLE
Make ossl_ecdh_compute_key() return a boolean

### DIFF
--- a/crypto/ec/ec_25519.c
+++ b/crypto/ec/ec_25519.c
@@ -253,9 +253,9 @@ static int x25519_compute_key(unsigned char **psec, size_t *pseclen,
                               const EC_POINT *pub_key, const EC_KEY *ecdh)
 {
     unsigned char *key;
-    int ret = -1;
+    int ret = 0;
     if (ecdh->custom_data == NULL)
-        return -1;
+        return 0;
     key = OPENSSL_malloc(EC_X25519_KEYLEN);
     if (key == NULL)
         return 0;

--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -38,7 +38,7 @@ int ossl_ecdh_compute_key(unsigned char **psec, size_t *pseclen,
 {
     if (ecdh->group->meth->ecdh_compute_key == NULL) {
         ECerr(EC_F_OSSL_ECDH_COMPUTE_KEY, EC_R_CURVE_DOES_NOT_SUPPORT_ECDH);
-        return -1;
+        return 0;
     }
 
     return ecdh->group->meth->ecdh_compute_key(psec, pseclen, pub_key, ecdh);


### PR DESCRIPTION
The following code in `ECDH_compute_key()` treats the return value of `compute_key` as a boolean.
```shell
    if (!eckey->meth->compute_key(&sec, &seclen, pub_key, eckey))
        return 0;
```
BTW, there're getter/setter for `EC_KEY_METHOD` in openssl-1.1, so it's better to document the fields of it.