### PR TITLE
crypto/evp/e_aes_cbc_hmac_sha256.c: Remove spurious memset

### DIFF
--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -81,10 +81,9 @@ static int aesni_cbc_hmac_sha256_init_key(EVP_CIPHER_CTX *ctx,
     int ret;
 
     if (enc)
-        memset(&key->ks, 0, sizeof(key->ks.rd_key)),
-            ret = aesni_set_encrypt_key(inkey,
-                                        EVP_CIPHER_CTX_key_length(ctx) * 8,
-                                        &key->ks);
+        ret = aesni_set_encrypt_key(inkey,
+                                    EVP_CIPHER_CTX_key_length(ctx) * 8,
+                                    &key->ks);
     else
         ret = aesni_set_decrypt_key(inkey,
                                     EVP_CIPHER_CTX_key_length(ctx) * 8,


### PR DESCRIPTION
In aesni_cbc_hmac_sha256_init_key() there is a memset call that is pointless (and appears unintentionally added as the statement is terminated with a comma) this pull request removes it. The equivalent functions in e_aes.c and e_aes_cbc_hmac_sha1.c do not call memset.