### PR TITLE
Change default directory for the .rnd file on Windows and VMS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,8 +6,8 @@
 
   *) The method for finding the storage location for the Windows RAND seed file
      has changed. First we check %RANDFILE%. If that is not set then we check
-     the directories %TMP%, %TEMP%, %USERPROFILE%, %SYSTEMROOT% and %HOME% in
-     that order. If all else fails we fall back to "C:".
+     the directories %HOME%, %USERPROFILE% and %SYSTEMROOT% in that order. If
+     all else fails we fall back to C:\.
      [Matt Caswell]
 
   *) The EVP_EncryptUpdate() function has had its return type changed from void

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -292,11 +292,9 @@ const char *RAND_file_name(char *buf, size_t size)
          * uses TCHARs, but getenv() gives us chars so its easier to do it this
          * way
          */
-        if ((s = getenv("TMP")) == NULL
-            && (s = getenv("TEMP")) == NULL
-            && (s = getenv("USERPROFILE")) == NULL
-            && (s = getenv("SYSTEMROOT")) == NULL) {
-            s = getenv("HOME");
+        if ((s = getenv("HOME")) == NULL
+            && (s = getenv("USERPROFILE")) == NULL) {
+            s = getenv("SYSTEMROOT");
         }
 #else
         if (OPENSSL_issetugid() == 0)

--- a/doc/crypto/RAND_load_file.pod
+++ b/doc/crypto/RAND_load_file.pod
@@ -20,15 +20,29 @@ RAND_file_name() generates a default path for the random seed
 file. B<buf> points to a buffer of size B<num> in which to store the
 filename.
 
-On Windows the seed file is %RANDFILE% if that environment variable is set.
-Otherwise the file is called ".rnd" in one of the following locations (in order
-of preference): %TMP%, %TEMP%, %USERPROFILE%, %SYSTEMROOT%, %HOME%, "C:".
+On all systems, if the environment variable B<RANDFILE> is set, its
+value will be used as the seed file name.
 
-On all other systems the seed file is $RANDFILE if that environment variable is
-set, $HOME/.rnd otherwise.
+Otherwise, the file is called ".rnd", found in platform dependent locations:
 
-If $HOME (on non Windows systems) is not set either, or B<num> is
-too small for the path name, an error occurs.
+=over 4
+
+=item On Windows (in order of preference)
+
+%HOME%, %USERPROFILE%, %SYSTEMROOT%, C:\
+
+=item On VMS
+
+SYS$LOGIN:
+
+=item On all other systems
+
+$HOME
+
+=back
+
+If C<$HOME> (on non-Windows and non-VMS system) is not set either, or
+B<num> is too small for the path name, an error occurs.
 
 RAND_load_file() reads a number of bytes from file B<filename> and
 adds them to the PRNG. If B<max_bytes> is non-negative,

--- a/e_os.h
+++ b/e_os.h
@@ -325,6 +325,8 @@ extern FILE *_imp___iob;
 #   define NO_SYS_PARAM_H
 #   define NO_SYS_UN_H
 
+#   define DEFAULT_HOME "SYS$LOGIN:"
+
 #  else
      /* !defined VMS */
 #   ifdef OPENSSL_UNISTD


### PR DESCRIPTION
The previous change for Windows wasn't quite right.  Corrected to use
%HOME%, %USERPROFILE% and %SYSTEMPROFILE%, in that order.

Also adding the default home for VMS, SYS$LOGIN:
