### PR TITLE
SSL test framework: port SNI tests

### DIFF
--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -61,6 +61,7 @@ The test section supports the following options:
 
 * ClientVerifyCallback - the client's custom certificate verify callback.
   Used to test callback behaviour. One of
+  - None - no custom callback (default)
   - AcceptAll - accepts all certificates.
   - RejectAll - rejects all certificates.
 
@@ -70,6 +71,12 @@ The test section supports the following options:
   - None - do not use SNI (default)
   - server1 - the initial context
   - server2 - the secondary context
+  - invalid - an unknown context
+
+* ServerNameCallback - the SNI switching callback to use
+  - None - no callback (default)
+  - IgnoreMismatch - continue the handshake on SNI mismatch
+  - RejectMismatch - abort the handshake on SNI mismatch
 
 * SessionTicketExpected - whether or not a session ticket is expected
   - Ignore - do not check for a session ticket (default)

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -79,7 +79,7 @@ my $client_sess="client.ss";
 # new format in ssl_test.c and add recipes to 80-test_ssl_new.t instead.
 plan tests =>
     1				# For testss
-    + 13			# For the first testssl
+    + 12			# For the first testssl
     ;
 
 subtest 'test_ss' => sub {
@@ -576,25 +576,6 @@ sub testssl {
 	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-serverinfo_file", $serverinfo, "-serverinfo_tack"])));
 	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-serverinfo_file", $serverinfo, "-serverinfo_sct", "-serverinfo_tack"])));
 	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-custom_ext", "-serverinfo_file", $serverinfo, "-serverinfo_sct", "-serverinfo_tack"])));
-	}
-    };
-
-    subtest 'SNI tests' => sub {
-
-	plan tests => 7;
-
-      SKIP: {
-	  skip "TLSv1.x is not supported by this OpenSSL build", 7
-	      if $no_tls1 && $no_tls1_1 && $no_tls1_2;
-
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo"])));
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_server1", "foo"])));
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo", "-sn_server1", "foo", "-sn_expect1"])));
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo", "-sn_server1", "bar", "-sn_expect1"])));
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foo", "-sn_server1", "foo", "-sn_server2", "bar", "-sn_expect1"])));
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "bar", "-sn_server1", "foo", "-sn_server2", "bar", "-sn_expect2"])));
-	  # Negative test - make sure it doesn't crash, and doesn't switch contexts
-	  ok(run(test([@ssltest, "-bio_pair", "-sn_client", "foobar", "-sn_server1", "foo", "-sn_server2", "bar", "-sn_expect1"])));
 	}
     };
 

--- a/test/ssl-tests/05-sni.conf
+++ b/test/ssl-tests/05-sni.conf
@@ -1,35 +1,193 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 1
+num_tests = 6
 
-test-0 = 0-SNI-default
+test-0 = 0-SNI-switch-context
+test-1 = 1-SNI-keep-context
+test-2 = 2-SNI-no-server-support
+test-3 = 3-SNI-no-client-support
+test-4 = 4-SNI-bad-sni-ignore-mismatch
+test-5 = 5-SNI-bad-sni-reject-mismatch
 # ===========================================================
 
-[0-SNI-default]
-ssl_conf = 0-SNI-default-ssl
+[0-SNI-switch-context]
+ssl_conf = 0-SNI-switch-context-ssl
 
-[0-SNI-default-ssl]
-server = 0-SNI-default-server
-server2 = 0-SNI-default-server2
-client = 0-SNI-default-client
+[0-SNI-switch-context-ssl]
+server = 0-SNI-switch-context-server
+server2 = 0-SNI-switch-context-server2
+client = 0-SNI-switch-context-client
 
-[0-SNI-default-server]
+[0-SNI-switch-context-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[0-SNI-default-server2]
+[0-SNI-switch-context-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[0-SNI-default-client]
+[0-SNI-switch-context-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-0]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
+
+
+# ===========================================================
+
+[1-SNI-keep-context]
+ssl_conf = 1-SNI-keep-context-ssl
+
+[1-SNI-keep-context-ssl]
+server = 1-SNI-keep-context-server
+server2 = 1-SNI-keep-context-server2
+client = 1-SNI-keep-context-client
+
+[1-SNI-keep-context-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-SNI-keep-context-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-SNI-keep-context-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+ExpectedResult = Success
+ExpectedServerName = server1
+ServerName = server1
+ServerNameCallback = IgnoreMismatch
+
+
+# ===========================================================
+
+[2-SNI-no-server-support]
+ssl_conf = 2-SNI-no-server-support-ssl
+
+[2-SNI-no-server-support-ssl]
+server = 2-SNI-no-server-support-server
+client = 2-SNI-no-server-support-client
+
+[2-SNI-no-server-support-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-SNI-no-server-support-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+ExpectedResult = Success
+ServerName = server1
+
+
+# ===========================================================
+
+[3-SNI-no-client-support]
+ssl_conf = 3-SNI-no-client-support-ssl
+
+[3-SNI-no-client-support-ssl]
+server = 3-SNI-no-client-support-server
+server2 = 3-SNI-no-client-support-server2
+client = 3-SNI-no-client-support-client
+
+[3-SNI-no-client-support-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-SNI-no-client-support-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-SNI-no-client-support-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+ExpectedResult = Success
+ExpectedServerName = server1
+ServerNameCallback = IgnoreMismatch
+
+
+# ===========================================================
+
+[4-SNI-bad-sni-ignore-mismatch]
+ssl_conf = 4-SNI-bad-sni-ignore-mismatch-ssl
+
+[4-SNI-bad-sni-ignore-mismatch-ssl]
+server = 4-SNI-bad-sni-ignore-mismatch-server
+server2 = 4-SNI-bad-sni-ignore-mismatch-server2
+client = 4-SNI-bad-sni-ignore-mismatch-client
+
+[4-SNI-bad-sni-ignore-mismatch-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-SNI-bad-sni-ignore-mismatch-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-SNI-bad-sni-ignore-mismatch-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ExpectedResult = Success
+ExpectedServerName = server1
+ServerName = invalid
+ServerNameCallback = IgnoreMismatch
+
+
+# ===========================================================
+
+[5-SNI-bad-sni-reject-mismatch]
+ssl_conf = 5-SNI-bad-sni-reject-mismatch-ssl
+
+[5-SNI-bad-sni-reject-mismatch-ssl]
+server = 5-SNI-bad-sni-reject-mismatch-server
+server2 = 5-SNI-bad-sni-reject-mismatch-server2
+client = 5-SNI-bad-sni-reject-mismatch-client
+
+[5-SNI-bad-sni-reject-mismatch-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-SNI-bad-sni-reject-mismatch-server2]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-SNI-bad-sni-reject-mismatch-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = ServerFail
+ServerAlert = UnrecognizedName
+ServerName = invalid
+ServerNameCallback = RejectMismatch
 
 

--- a/test/ssl-tests/05-sni.conf.in
+++ b/test/ssl-tests/05-sni.conf.in
@@ -16,11 +16,64 @@ package ssltests;
 
 our @tests = (
     {
-        name => "SNI-default",
+        name => "SNI-switch-context",
         server => { },
         server2 => { },
         client => { },
         test   => { "ServerName" => "server2",
-		    "ExpectedResult" => "Success" },
+                    "ExpectedServerName" => "server2",
+                    "ServerNameCallback" => "IgnoreMismatch",
+                    "ExpectedResult" => "Success" },
+    },
+    {
+        name => "SNI-keep-context",
+        server => { },
+        server2 => { },
+        client => { },
+        test   => { "ServerName" => "server1",
+                    "ExpectedServerName" => "server1",
+                    "ServerNameCallback" => "IgnoreMismatch",
+                    "ExpectedResult" => "Success" },
+    },
+    {
+        name => "SNI-no-server-support",
+        server => { },
+        client => { },
+        test   => { "ServerName" => "server1",
+                    "ExpectedResult" => "Success" },
+    },
+    {
+        name => "SNI-no-client-support",
+        server => { },
+        server2 => { },
+        client => { },
+        test   => {
+            # We expect that the callback is still called
+            # to let the application decide whether they tolerate
+            # missing SNI (as our test callback does).
+            "ExpectedServerName" => "server1",
+            "ServerNameCallback" => "IgnoreMismatch",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "SNI-bad-sni-ignore-mismatch",
+        server => { },
+        server2 => { },
+        client => { },
+        test   => { "ServerName" => "invalid",
+                    "ExpectedServerName" => "server1",
+                    "ServerNameCallback" => "IgnoreMismatch",
+                    "ExpectedResult" => "Success" },
+    },
+    {
+        name => "SNI-bad-sni-reject-mismatch",
+        server => { },
+        server2 => { },
+        client => { },
+        test   => { "ServerName" => "invalid",
+                    "ServerNameCallback" => "RejectMismatch",
+                    "ExpectedResult" => "ServerFail",
+                    "ServerAlert" => "UnrecognizedName"},
     },
 );

--- a/test/ssl-tests/06-sni-ticket.conf
+++ b/test/ssl-tests/06-sni-ticket.conf
@@ -83,7 +83,9 @@ VerifyMode = Peer
 
 [test-1]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = Yes
 
 
@@ -117,7 +119,9 @@ VerifyMode = Peer
 
 [test-2]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = Yes
 
 
@@ -151,7 +155,9 @@ VerifyMode = Peer
 
 [test-3]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = Yes
 
 
@@ -185,7 +191,9 @@ VerifyMode = Peer
 
 [test-4]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -219,7 +227,9 @@ VerifyMode = Peer
 
 [test-5]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -253,7 +263,9 @@ VerifyMode = Peer
 
 [test-6]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -287,7 +299,9 @@ VerifyMode = Peer
 
 [test-7]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -321,7 +335,9 @@ VerifyMode = Peer
 
 [test-8]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -355,7 +371,9 @@ VerifyMode = Peer
 
 [test-9]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -389,7 +407,9 @@ VerifyMode = Peer
 
 [test-10]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -423,7 +443,9 @@ VerifyMode = Peer
 
 [test-11]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -457,7 +479,9 @@ VerifyMode = Peer
 
 [test-12]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -491,7 +515,9 @@ VerifyMode = Peer
 
 [test-13]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -525,7 +551,9 @@ VerifyMode = Peer
 
 [test-14]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -559,7 +587,9 @@ VerifyMode = Peer
 
 [test-15]
 ExpectedResult = Success
+ExpectedServerName = server1
 ServerName = server1
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 
@@ -593,7 +623,9 @@ VerifyMode = Peer
 
 [test-16]
 ExpectedResult = Success
+ExpectedServerName = server2
 ServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = No
 
 

--- a/test/ssl-tests/06-sni-ticket.conf.in
+++ b/test/ssl-tests/06-sni-ticket.conf.in
@@ -36,6 +36,9 @@ sub generate_tests() {
 			},
                         "test" => {
                             "ServerName" => $n,
+                            "ExpectedServerName" => $n,
+                            # We don't test mismatch here.
+                            "ServerNameCallback" => "IgnoreMismatch",
                             "ExpectedResult" => "Success",
 			    "SessionTicketExpected" => $result,
                         }

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -29,8 +29,16 @@ typedef enum {
 typedef enum {
     SSL_TEST_SERVERNAME_NONE = 0, /* Default */
     SSL_TEST_SERVERNAME_SERVER1,
-    SSL_TEST_SERVERNAME_SERVER2
+    SSL_TEST_SERVERNAME_SERVER2,
+    SSL_TEST_SERVERNAME_INVALID
 } ssl_servername_t;
+
+typedef enum {
+    SSL_TEST_SERVERNAME_CB_NONE = 0,  /* Default */
+    SSL_TEST_SERVERNAME_IGNORE_MISMATCH,
+    SSL_TEST_SERVERNAME_REJECT_MISMATCH
+} ssl_servername_callback_t;
+
 
 typedef enum {
     SSL_TEST_SESSION_TICKET_IGNORE = 0, /* Default */
@@ -61,6 +69,18 @@ typedef struct ssl_test_ctx {
     ssl_verify_callback_t client_verify_callback;
     /* One of a number of predefined server names use by the client */
     ssl_servername_t servername;
+    /*
+     * The expected SNI context to use.
+     * We test server-side that the server switched to the expected context.
+     * Set by the callback upon success, so if the callback wasn't called or
+     * terminated with an alert, the servername will match with
+     * SSL_TEST_SERVERNAME_NONE.
+     * Note: in the event that the servername was accepted, the client should
+     * also receive an empty SNI extension back but we have no way of probing
+     * client-side via the API that this was the case.
+     */
+    ssl_servername_t expected_servername;
+    ssl_servername_callback_t servername_callback;
     ssl_session_ticket_t session_ticket_expected;
     /* Whether the server/client CTX should use DTLS or TLS. */
     ssl_test_method_t method;
@@ -71,6 +91,8 @@ const char *ssl_alert_name(int alert);
 const char *ssl_protocol_name(int protocol);
 const char *ssl_verify_callback_name(ssl_verify_callback_t verify_callback);
 const char *ssl_servername_name(ssl_servername_t server);
+const char *ssl_servername_callback_name(ssl_servername_callback_t
+                                         servername_callback);
 const char *ssl_session_ticket_name(ssl_session_ticket_t server);
 const char *ssl_test_method_name(ssl_test_method_t method);
 

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -70,6 +70,18 @@ static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
                 ssl_servername_name(ctx2->servername));
         return 0;
     }
+    if (ctx->expected_servername != ctx2->expected_servername) {
+        fprintf(stderr, "ExpectedServerName mismatch: %s vs %s.\n",
+                ssl_servername_name(ctx->expected_servername),
+                ssl_servername_name(ctx2->expected_servername));
+        return 0;
+    }
+    if (ctx->servername_callback != ctx2->servername_callback) {
+        fprintf(stderr, "ServerNameCallback mismatch: %s vs %s.\n",
+                ssl_servername_callback_name(ctx->servername_callback),
+                ssl_servername_callback_name(ctx2->servername_callback));
+        return 0;
+    }
     if (ctx->session_ticket_expected != ctx2->session_ticket_expected) {
         fprintf(stderr, "SessionTicketExpected mismatch: %s vs %s.\n",
                 ssl_session_ticket_name(ctx->session_ticket_expected),
@@ -155,6 +167,9 @@ static int test_good_configuration()
     fixture.expected_ctx->protocol = TLS1_1_VERSION;
     fixture.expected_ctx->client_verify_callback = SSL_TEST_VERIFY_REJECT_ALL;
     fixture.expected_ctx->servername = SSL_TEST_SERVERNAME_SERVER2;
+    fixture.expected_ctx->expected_servername = SSL_TEST_SERVERNAME_SERVER2;
+    fixture.expected_ctx->servername_callback =
+        SSL_TEST_SERVERNAME_IGNORE_MISMATCH;
     fixture.expected_ctx->session_ticket_expected = SSL_TEST_SESSION_TICKET_YES;
     fixture.expected_ctx->method = SSL_TEST_METHOD_DTLS;
     EXECUTE_SSL_TEST_CTX_TEST();
@@ -167,6 +182,7 @@ static const char *bad_configurations[] = {
     "ssltest_unknown_protocol",
     "ssltest_unknown_verify_callback",
     "ssltest_unknown_servername",
+    "ssltest_unknown_servername_callback",
     "ssltest_unknown_session_ticket_expected",
     "ssltest_unknown_method",
 };

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -6,6 +6,8 @@ ClientAlert = UnknownCA
 Protocol = TLSv1.1
 ClientVerifyCallback = RejectAll
 ServerName = server2
+ExpectedServerName = server2
+ServerNameCallback = IgnoreMismatch
 SessionTicketExpected = Yes
 Method = DTLS
 
@@ -27,9 +29,11 @@ ClientVerifyCallback = Foo
 [ssltest_unknown_servername]
 ServerName = Foo
 
+[ssltest_unknown_servername_callback]
+ServerNameCallback = Foo
+
 [ssltest_unknown_session_ticket_expected]
 SessionTicketExpected = Foo
 
 [ssltest_unknown_method]
 Method = TLS2
-


### PR DESCRIPTION
Observe that the old tests were partly ill-defined:
setting sn_server1 but not sn_server2 in ssltest_old.c does not enable
the SNI callback.

Fix this, and also explicitly test both flavours of SNI mismatch (ignore
/ fatal alert). Tests still pass.