### PR TITLE
Use directly OPENSSL_zalloc in OPENSSL_sk_dup and OPENSSL_sk_deep_copy

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -39,25 +39,20 @@ OPENSSL_sk_compfunc OPENSSL_sk_set_cmp_func(OPENSSL_STACK *sk, OPENSSL_sk_compfu
 OPENSSL_STACK *OPENSSL_sk_dup(OPENSSL_STACK *sk)
 {
     OPENSSL_STACK *ret;
-    char **s;
 
-    if ((ret = OPENSSL_sk_new(sk->comp)) == NULL)
-        goto err;
-    s = OPENSSL_realloc((char *)ret->data,
-                        (unsigned int)sizeof(char *) * sk->num_alloc);
-    if (s == NULL)
-        goto err;
-    ret->data = s;
+    if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL)
+        return NULL;
 
-    ret->num = sk->num;
+    /* direct structure assignment */
+    *ret = *sk;
+
+    if ((ret->data = OPENSSL_malloc(sizeof(*ret->data) * sk->num_alloc)) == NULL)
+        goto err;
     memcpy(ret->data, sk->data, sizeof(char *) * sk->num);
-    ret->sorted = sk->sorted;
-    ret->num_alloc = sk->num_alloc;
-    ret->comp = sk->comp;
-    return (ret);
+    return ret;
  err:
     OPENSSL_sk_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 OPENSSL_STACK *OPENSSL_sk_deep_copy(OPENSSL_STACK *sk, OPENSSL_sk_copyfunc copy_func,
@@ -67,18 +62,17 @@ OPENSSL_STACK *OPENSSL_sk_deep_copy(OPENSSL_STACK *sk, OPENSSL_sk_copyfunc copy_
     int i;
 
     if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL)
-        return ret;
-    ret->comp = sk->comp;
-    ret->sorted = sk->sorted;
-    ret->num = sk->num;
+        return NULL;
+
+    /* direct structure assignment */
+    *ret = *sk;
+
     ret->num_alloc = sk->num > MIN_NODES ? sk->num : MIN_NODES;
-    ret->data = OPENSSL_malloc(sizeof(*ret->data) * ret->num_alloc);
+    ret->data = OPENSSL_zalloc(sizeof(*ret->data) * ret->num_alloc);
     if (ret->data == NULL) {
         OPENSSL_free(ret);
         return NULL;
     }
-    for (i = 0; i < ret->num_alloc; i++)
-        ret->data[i] = NULL;
 
     for (i = 0; i < ret->num; ++i) {
         if (sk->data[i] == NULL)

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -36,7 +36,7 @@ OPENSSL_sk_compfunc OPENSSL_sk_set_cmp_func(OPENSSL_STACK *sk, OPENSSL_sk_compfu
     return old;
 }
 
-OPENSSL_STACK *OPENSSL_sk_dup(OPENSSL_STACK *sk)
+OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *sk)
 {
     OPENSSL_STACK *ret;
 
@@ -55,7 +55,8 @@ OPENSSL_STACK *OPENSSL_sk_dup(OPENSSL_STACK *sk)
     return NULL;
 }
 
-OPENSSL_STACK *OPENSSL_sk_deep_copy(OPENSSL_STACK *sk, OPENSSL_sk_copyfunc copy_func,
+OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *sk,
+                             OPENSSL_sk_copyfunc copy_func,
                              OPENSSL_sk_freefunc free_func)
 {
     OPENSSL_STACK *ret;

--- a/doc/crypto/DEFINE_STACK_OF.pod
+++ b/doc/crypto/DEFINE_STACK_OF.pod
@@ -50,8 +50,8 @@ stack container
  int sk_TYPE_find_ex(STACK_OF(TYPE) *sk, TYPE *ptr);
  void sk_TYPE_sort(const STACK_OF(TYPE) *sk);
  int sk_TYPE_is_sorted(const STACK_OF(TYPE) *sk);
- STACK_OF(TYPE) *sk_TYPE_dup(STACK_OF(TYPE) *sk);
- STACK_OF(TYPE) *sk_TYPE_deep_copy(STACK_OF(TYPE) *sk,
+ STACK_OF(TYPE) *sk_TYPE_dup(const STACK_OF(TYPE) *sk);
+ STACK_OF(TYPE) *sk_TYPE_deep_copy(const STACK_OF(TYPE) *sk,
                                    sk_TYPE_copyfunc copyfunc,
                                    sk_TYPE_freefunc freefunc);
  sk_TYPE_compfunc (*sk_TYPE_set_cmp_func(STACK_OF(TYPE) *sk, sk_TYPE_compfunc compare);

--- a/include/openssl/safestack.h
+++ b/include/openssl/safestack.h
@@ -101,11 +101,11 @@ extern "C" {
     { \
         return OPENSSL_sk_is_sorted((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline STACK_OF(t1) * sk_##t1##_dup(STACK_OF(t1) *sk) \
+    static ossl_inline STACK_OF(t1) * sk_##t1##_dup(const STACK_OF(t1) *sk) \
     { \
-        return (STACK_OF(t1) *)OPENSSL_sk_dup((OPENSSL_STACK *)sk); \
+        return (STACK_OF(t1) *)OPENSSL_sk_dup((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline STACK_OF(t1) *sk_##t1##_deep_copy(STACK_OF(t1) *sk, \
+    static ossl_inline STACK_OF(t1) *sk_##t1##_deep_copy(const STACK_OF(t1) *sk, \
                                                     sk_##t1##_copyfunc copyfunc, \
                                                     sk_##t1##_freefunc freefunc) \
     { \

--- a/include/openssl/stack.h
+++ b/include/openssl/stack.h
@@ -29,7 +29,7 @@ OPENSSL_STACK *OPENSSL_sk_new(OPENSSL_sk_compfunc cmp);
 OPENSSL_STACK *OPENSSL_sk_new_null(void);
 void OPENSSL_sk_free(OPENSSL_STACK *);
 void OPENSSL_sk_pop_free(OPENSSL_STACK *st, void (*func) (void *));
-OPENSSL_STACK *OPENSSL_sk_deep_copy(OPENSSL_STACK *, OPENSSL_sk_copyfunc c, OPENSSL_sk_freefunc f);
+OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *, OPENSSL_sk_copyfunc c, OPENSSL_sk_freefunc f);
 int OPENSSL_sk_insert(OPENSSL_STACK *sk, void *data, int where);
 void *OPENSSL_sk_delete(OPENSSL_STACK *st, int loc);
 void *OPENSSL_sk_delete_ptr(OPENSSL_STACK *st, const void *p);
@@ -41,7 +41,7 @@ void *OPENSSL_sk_shift(OPENSSL_STACK *st);
 void *OPENSSL_sk_pop(OPENSSL_STACK *st);
 void OPENSSL_sk_zero(OPENSSL_STACK *st);
 OPENSSL_sk_compfunc OPENSSL_sk_set_cmp_func(OPENSSL_STACK *sk, OPENSSL_sk_compfunc cmp);
-OPENSSL_STACK *OPENSSL_sk_dup(OPENSSL_STACK *st);
+OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *st);
 void OPENSSL_sk_sort(OPENSSL_STACK *st);
 int OPENSSL_sk_is_sorted(const OPENSSL_STACK *st);
 


### PR DESCRIPTION
Directly allocate sk_TYPE_ stack  while duplicating them.
Same as #1228 , I delete the source branch by error.