### PR TITLE
Fix SSLv3 Client Auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
           env: CONFIG_OPTS="no-shared enable-asan"
         - os: linux
           compiler: clang-3.6
-          env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 -fno-sanitize=alignment"
+          env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method -fno-sanitize=alignment"
         - os: linux
           compiler: clang-3.6
           env: CONFIG_OPTS="no-shared no-asm enable-asan enable-rc5 enable-md2"

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -531,8 +531,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s) {
              * to that state if so
              */
             if(!transition(s, mt)) {
-                ssl3_send_alert(s, SSL3_AL_FATAL, SSL3_AD_UNEXPECTED_MESSAGE);
-                SSLerr(SSL_F_READ_STATE_MACHINE, SSL_R_UNEXPECTED_MESSAGE);
+                ossl_statem_set_error(s);
                 return SUB_STATE_ERROR;
             }
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -90,7 +90,6 @@ static ossl_inline int cert_req_allowed(SSL *s)
  *  Return values are:
  *  1: Yes
  *  0: No
- * -1: Error
  */
 static int key_exchange_expected(SSL *s)
 {
@@ -174,8 +173,6 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
                 }
             } else {
                 ske_expected = key_exchange_expected(s);
-                if (ske_expected < 0)
-                    goto err;
                 /* SKE is optional for some PSK ciphersuites */
                 if (ske_expected
                         || ((s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK)
@@ -209,8 +206,6 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
 
     case TLS_ST_CR_CERT_STATUS:
         ske_expected = key_exchange_expected(s);
-        if (ske_expected < 0)
-            goto err;
         /* SKE is optional for some PSK ciphersuites */
         if (ske_expected
                 || ((s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK)

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -398,9 +398,6 @@ WORK_STATE ossl_statem_client_pre_work(SSL *s, WORK_STATE wst)
         }
         break;
 
-    case TLS_ST_CW_CERT:
-        return tls_prepare_client_certificate(s, wst);
-
     case TLS_ST_CW_CHANGE:
         if (SSL_IS_DTLS(s)) {
             if (s->hit) {
@@ -665,6 +662,9 @@ WORK_STATE ossl_statem_client_post_process_message(SSL *s, WORK_STATE wst)
     OSSL_STATEM *st = &s->statem;
 
     switch(st->hand_state) {
+    case TLS_ST_CR_CERT_REQ:
+        return tls_prepare_client_certificate(s, wst);
+
 #ifndef OPENSSL_NO_SCTP
     case TLS_ST_CR_SRVR_DONE:
         /* We only get here if we are using SCTP and we are renegotiating */
@@ -1799,7 +1799,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
     s->s3->tmp.ca_names = ca_sk;
     ca_sk = NULL;
 
-    ret = MSG_PROCESS_CONTINUE_READING;
+    ret = MSG_PROCESS_CONTINUE_PROCESSING;
     goto done;
  err:
     ossl_statem_set_error(s);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -104,11 +104,12 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
         if (mt == SSL3_MT_CLIENT_KEY_EXCHANGE) {
             if (s->s3->tmp.cert_request) {
                 if (s->version == SSL3_VERSION) {
-                    if ((s->verify_mode & SSL_VERIFY_PEER) &&
-                          (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
+                    if ((s->verify_mode & SSL_VERIFY_PEER)
+                        && (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
                         /*
                          * This isn't an unexpected message as such - we're just
-                         * not going to accept it.
+                         * not going to accept it because we require a client
+                         * cert.
                          */
                         ssl3_send_alert(s, SSL3_AL_FATAL,
                                         SSL3_AD_HANDSHAKE_FAILURE);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -114,6 +114,17 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
                 return 1;
             }
         }
+        if (mt == SSL3_MT_CLIENT_KEY_EXCHANGE && s->s3->tmp.cert_request
+                && s->version == SSL3_VERSION) {
+            /*
+             * This isn't an unexpected message as such - we're just not going
+             * to accept it.
+             */
+            ssl3_send_alert(s, SSL3_AL_FATAL, SSL3_AD_HANDSHAKE_FAILURE);
+            SSLerr(SSL_F_READ_STATE_MACHINE,
+                   SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE);
+            return 0;
+        }
         break;
 
     case TLS_ST_SR_CERT:
@@ -197,6 +208,8 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
     }
 
     /* No valid transition found */
+    ssl3_send_alert(s, SSL3_AL_FATAL, SSL3_AD_UNEXPECTED_MESSAGE);
+    SSLerr(SSL_F_READ_STATE_MACHINE, SSL_R_UNEXPECTED_MESSAGE);
     return 0;
 }
 

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -39,6 +39,7 @@ my $no_dtls = alldisabled(available_protocols("dtls"));
 
 my %conf_dependent_tests = (
   "02-protocol-version.conf" => !$is_default_tls,
+  "04-client_auth.conf" => !$is_default_tls,
   "05-dtls-protocol-version.conf" => !$is_default_dtls,
 );
 

--- a/test/ssl-tests/04-client_auth.conf
+++ b/test/ssl-tests/04-client_auth.conf
@@ -161,12 +161,14 @@ client = 5-server-auth-TLSv1-client
 [5-server-auth-TLSv1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
 
 [5-server-auth-TLSv1-client]
 CipherString = DEFAULT
-Protocol = TLSv1
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -186,13 +188,15 @@ client = 6-client-auth-TLSv1-request-client
 [6-client-auth-TLSv1-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
 VerifyMode = Request
 
 [6-client-auth-TLSv1-request-client]
 CipherString = DEFAULT
-Protocol = TLSv1
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -212,14 +216,16 @@ client = 7-client-auth-TLSv1-require-fail-client
 [7-client-auth-TLSv1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [7-client-auth-TLSv1-require-fail-client]
 CipherString = DEFAULT
-Protocol = TLSv1
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -240,16 +246,18 @@ client = 8-client-auth-TLSv1-require-client
 [8-client-auth-TLSv1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
 [8-client-auth-TLSv1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -269,15 +277,17 @@ client = 9-client-auth-TLSv1-noroot-client
 [9-client-auth-TLSv1-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1
 VerifyMode = Require
 
 [9-client-auth-TLSv1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-Protocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -298,12 +308,14 @@ client = 10-server-auth-TLSv1.1-client
 [10-server-auth-TLSv1.1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
 
 [10-server-auth-TLSv1.1-client]
 CipherString = DEFAULT
-Protocol = TLSv1.1
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -323,13 +335,15 @@ client = 11-client-auth-TLSv1.1-request-client
 [11-client-auth-TLSv1.1-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
 VerifyMode = Request
 
 [11-client-auth-TLSv1.1-request-client]
 CipherString = DEFAULT
-Protocol = TLSv1.1
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -349,14 +363,16 @@ client = 12-client-auth-TLSv1.1-require-fail-client
 [12-client-auth-TLSv1.1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [12-client-auth-TLSv1.1-require-fail-client]
 CipherString = DEFAULT
-Protocol = TLSv1.1
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -377,16 +393,18 @@ client = 13-client-auth-TLSv1.1-require-client
 [13-client-auth-TLSv1.1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
 [13-client-auth-TLSv1.1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -406,15 +424,17 @@ client = 14-client-auth-TLSv1.1-noroot-client
 [14-client-auth-TLSv1.1-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.1
 VerifyMode = Require
 
 [14-client-auth-TLSv1.1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-Protocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -435,12 +455,14 @@ client = 15-server-auth-TLSv1.2-client
 [15-server-auth-TLSv1.2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
 
 [15-server-auth-TLSv1.2-client]
 CipherString = DEFAULT
-Protocol = TLSv1.2
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -460,13 +482,15 @@ client = 16-client-auth-TLSv1.2-request-client
 [16-client-auth-TLSv1.2-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
 VerifyMode = Request
 
 [16-client-auth-TLSv1.2-request-client]
 CipherString = DEFAULT
-Protocol = TLSv1.2
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -486,14 +510,16 @@ client = 17-client-auth-TLSv1.2-require-fail-client
 [17-client-auth-TLSv1.2-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [17-client-auth-TLSv1.2-require-fail-client]
 CipherString = DEFAULT
-Protocol = TLSv1.2
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -514,16 +540,18 @@ client = 18-client-auth-TLSv1.2-require-client
 [18-client-auth-TLSv1.2-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
 [18-client-auth-TLSv1.2-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -543,15 +571,17 @@ client = 19-client-auth-TLSv1.2-noroot-client
 [19-client-auth-TLSv1.2-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-Protocol = TLSv1.2
 VerifyMode = Require
 
 [19-client-auth-TLSv1.2-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-Protocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/04-client_auth.conf.in
+++ b/test/ssl-tests/04-client_auth.conf.in
@@ -26,7 +26,13 @@ sub generate_tests() {
     foreach (0..$#protocols) {
         my $protocol = $protocols[$_];
         my $protocol_name = $protocol || "flex";
+        my $caalert;
         if (!$is_disabled[$_]) {
+            if ($protocol_name eq "SSLv3") {
+                $caalert = "BadCertificate";
+            } else {
+                $caalert = "UnknownCA";
+            }
             # Sanity-check simple handshake.
             push @tests, {
                 name => "server-auth-${protocol_name}",
@@ -109,7 +115,7 @@ sub generate_tests() {
                 },
                 test   => {
                     "ExpectedResult" => "ServerFail",
-                    "ServerAlert" => "UnknownCA",
+                    "ServerAlert" => $caalert,
                 },
             };
         }

--- a/test/ssl-tests/04-client_auth.conf.in
+++ b/test/ssl-tests/04-client_auth.conf.in
@@ -31,10 +31,12 @@ sub generate_tests() {
             push @tests, {
                 name => "server-auth-${protocol_name}",
                 server => {
-                    "Protocol" => $protocol
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol
                 },
                 client => {
-                    "Protocol" => $protocol
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol
                 },
                 test   => { "ExpectedResult" => "Success" },
             };
@@ -43,11 +45,13 @@ sub generate_tests() {
             push @tests, {
                 name => "client-auth-${protocol_name}-request",
                 server => {
-                    "Protocol" => $protocol,
-                    "VerifyMode" => "Request",
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
+                    "VerifyMode" => "Request"
                 },
                 client => {
-                    "Protocol" => $protocol
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol
                 },
                 test   => { "ExpectedResult" => "Success" },
             };
@@ -56,12 +60,14 @@ sub generate_tests() {
             push @tests, {
                 name => "client-auth-${protocol_name}-require-fail",
                 server => {
-                    "Protocol" => $protocol,
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
                     "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
                     "VerifyMode" => "Require",
                 },
                 client => {
-                    "Protocol" => $protocol,
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol
                 },
                 test   => {
                     "ExpectedResult" => "ServerFail",
@@ -73,12 +79,14 @@ sub generate_tests() {
             push @tests, {
                 name => "client-auth-${protocol_name}-require",
                 server => {
-                    "Protocol" => $protocol,
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
                     "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
                     "VerifyMode" => "Request",
                 },
                 client => {
-                    "Protocol" => $protocol,
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
                     "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
                     "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem",
                 },
@@ -89,11 +97,13 @@ sub generate_tests() {
             push @tests, {
                 name => "client-auth-${protocol_name}-noroot",
                 server => {
-                    "Protocol" => $protocol,
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
                     "VerifyMode" => "Require",
                 },
                 client => {
-                    "Protocol" => $protocol,
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
                     "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
                     "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem",
                 },

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -83,6 +83,7 @@ static const test_enum ssl_alerts[] = {
     {"UnknownCA", SSL_AD_UNKNOWN_CA},
     {"HandshakeFailure", SSL_AD_HANDSHAKE_FAILURE},
     {"UnrecognizedName", SSL_AD_UNRECOGNIZED_NAME},
+    {"BadCertificate", SSL_AD_BAD_CERTIFICATE}
 };
 
 __owur static int parse_alert(int *alert, const char *value)


### PR DESCRIPTION
The rec_layer_s3.c changes in this PR aren't really part of this change. They are being reviewed separately as a different standalone bug fix - but they are a pre-requisite for this fix, so they are included here too.

Client Auth for SSLv3 is badly broken. There are a number of fixes in this MR:

* Move the preparation of the client certificate to be post processing work after reading the CertificateRequest message rather than pre processing work prior to writing the Certificate message. As part of preparing the client certificate we may discover that we do not have one available. If we are also talking SSLv3 then we won't send the Certificate message at all. However, if we don't discover this until we are about to send the Certificate message it is too late and we send an empty one anyway. This is wrong for SSLv3.

* Having received a ClientKeyExchange message instead of a Certificate we know that we are not going to receive a CertificateVerify message. This means we can free up the handshake_buffer. However we better call ssl3_digest_cached_records() instead of just freeing it up, otherwise we later try and use it anyway and a core dump results. This could happen, for example, in SSLv3 where we send a CertificateRequest but the client sends no Certificate message at all. This is valid in SSLv3 (in TLS clients are required to send an empty Certificate message).

* In TLS if the server sends a CertificateRequest and the client does not provide one, if the server cannot continue it should send a HandshakeFailure alert. In SSLv3 the same should happen, but instead we were sending an UnexpectedMessage alert. This is incorrect - the message isn't unexpected - it is valid for the client not to send one - its just that we cannot continue without one.
The Client Auth tests were not correctly setting the Protocol, so that this aspect had no effect. It was testing the same thing lots of times for TLSv1.2 every time.

* In TLS during ClientAuth if the CA is not recognised you should get an UnknownCA alert. In SSLv3 this does not exist and you should get a BadCertificate alert. The tests didn't take account of this.
If configuring for anything other than the default TLS protocols then test failures were occurring.

The core dump issue noted above was found using the BoringSSL test suite, and is what started me on this odyssey. We'd have found it using our own client-auth tests if it wasn't for the fact that:

* We don't build sslv3 by default
* The tests were broken for sslv3 anyway
* Even if the obvious test problems were fixed it still would have been hidden because the tests weren't actually testing different protocol versions even though they appeared to be.
