### PR TITLE
Misuse of 64-bit instruction causes segfault in 32-bit application

### DIFF
--- a/crypto/des/asm/dest4-sparcv9.pl
+++ b/crypto/des/asm/dest4-sparcv9.pl
@@ -120,7 +120,7 @@ des_t4_cbc_encrypt:
 	and		$out, 7, %g4
 	alignaddrl	$out, %g0, $out
 	srl		$omask, %g4, $omask
-	srlx		$len, 3, $len
+	srln		$len, 3, $len
 	movrz		%g4, 0, $omask
 	prefetch	[$out], 22
 
@@ -221,7 +221,7 @@ des_t4_cbc_decrypt:
 	and		$out, 7, %g4
 	alignaddrl	$out, %g0, $out
 	srl		$omask, %g4, $omask
-	srlx		$len, 3, $len
+	srln		$len, 3, $len
 	movrz		%g4, 0, $omask
 	prefetch	[$out], 22
 
@@ -329,7 +329,7 @@ des_t4_ede3_cbc_encrypt:
 	and		$out, 7, %g4
 	alignaddrl	$out, %g0, $out
 	srl		$omask, %g4, $omask
-	srlx		$len, 3, $len
+	srln		$len, 3, $len
 	movrz		%g4, 0, $omask
 	prefetch	[$out], 22
 
@@ -481,7 +481,7 @@ des_t4_ede3_cbc_decrypt:
 	and		$out, 7, %g4
 	alignaddrl	$out, %g0, $out
 	srl		$omask, %g4, $omask
-	srlx		$len, 3, $len
+	srln		$len, 3, $len
 	movrz		%g4, 0, $omask
 	prefetch	[$out], 22
 

--- a/crypto/perlasm/sparcv9_modes.pl
+++ b/crypto/perlasm/sparcv9_modes.pl
@@ -86,7 +86,7 @@ $::code.=<<___;
 	srl		$omask, $ooff, $omask
 
 	alignaddrl	$out, %g0, $out
-	srlx		$len, 4, $len
+	srln		$len, 4, $len
 	prefetch	[$out], 22
 
 .L${bits}_cbc_enc_loop:
@@ -196,7 +196,7 @@ $::code.=<<___;
 	and	$blk_init, 63, $blk_init	! tail
 	sub	$len, $blk_init, $len
 	add	$blk_init, 15, $blk_init	! round up to 16n
-	srlx	$len, 4, $len
+	srln	$len, 4, $len
 	srl	$blk_init, 4, $blk_init
 
 .L${bits}_cbc_enc_blk_loop:
@@ -303,7 +303,7 @@ $::code.=<<___;
 	srl		$omask, $ooff, $omask
 
 	andcc		$len, 16, %g0		! is number of blocks even?
-	srlx		$len, 4, $len
+	srln		$len, 4, $len
 	alignaddrl	$out, %g0, $out
 	bz		%icc, .L${bits}_cbc_dec_loop2x
 	prefetch	[$out], 22
@@ -528,7 +528,7 @@ $::code.=<<___;
 	and	$blk_init, 63, $blk_init	! tail
 	sub	$len, $blk_init, $len
 	add	$blk_init, 15, $blk_init	! round up to 16n
-	srlx	$len, 4, $len
+	srln	$len, 4, $len
 	srl	$blk_init, 4, $blk_init
 	sub	$len, 1, $len
 	add	$blk_init, 1, $blk_init
@@ -659,7 +659,7 @@ ${alg}${bits}_t4_ctr32_encrypt:
 	andcc		$len, 16, %g0		! is number of blocks even?
 	alignaddrl	$out, %g0, $out
 	bz		%icc, .L${bits}_ctr32_loop2x
-	srlx		$len, 4, $len
+	srln		$len, 4, $len
 .L${bits}_ctr32_loop:
 	ldx		[$inp + 0], %o0
 	brz,pt		$ileft, 4f
@@ -830,7 +830,7 @@ $::code.=<<___;
 	and	$blk_init, 63, $blk_init	! tail
 	sub	$len, $blk_init, $len
 	add	$blk_init, 15, $blk_init	! round up to 16n
-	srlx	$len, 4, $len
+	srln	$len, 4, $len
 	srl	$blk_init, 4, $blk_init
 	sub	$len, 1, $len
 	add	$blk_init, 1, $blk_init
@@ -977,7 +977,7 @@ ___
 $code.=<<___;
 	alignaddrl	$out, %g0, $out
 	bz		%icc, .L${bits}_xts_${dir}loop2x
-	srlx		$len, 4, $len
+	srln		$len, 4, $len
 .L${bits}_xts_${dir}loop:
 	ldx		[$inp + 0], %o0
 	brz,pt		$ileft, 4f
@@ -1183,7 +1183,7 @@ $code.=<<___;
 	and	$blk_init, 63, $blk_init	! tail
 	sub	$len, $blk_init, $len
 	add	$blk_init, 15, $blk_init	! round up to 16n
-	srlx	$len, 4, $len
+	srln	$len, 4, $len
 	srl	$blk_init, 4, $blk_init
 	sub	$len, 1, $len
 	add	$blk_init, 1, $blk_init


### PR DESCRIPTION
The following assembly code shift-right 64-bit register, but there is no guarantee that the upper 32-bit is zeros for 32-bit applications.

srlx $len, 4, $len 

'srln' should be used in place so that 'srln' gets compiled into 'srlx' for 64-bit application and 'srl' for 32-bit application. 

The change was tested with gcc and Solaris Studio compiler.