### PR TITLE
Discard BIO_set() method

### DIFF
--- a/crypto/bio/bio_err.c
+++ b/crypto/bio/bio_err.c
@@ -43,7 +43,6 @@ static ERR_STRING_DATA BIO_str_functs[] = {
     {ERR_FUNC(BIO_F_BIO_PARSE_HOSTSERV), "BIO_parse_hostserv"},
     {ERR_FUNC(BIO_F_BIO_PUTS), "BIO_puts"},
     {ERR_FUNC(BIO_F_BIO_READ), "BIO_read"},
-    {ERR_FUNC(BIO_F_BIO_SET), "BIO_set"},
     {ERR_FUNC(BIO_F_BIO_SOCKET), "BIO_socket"},
     {ERR_FUNC(BIO_F_BIO_SOCKET_NBIO), "BIO_socket_nbio"},
     {ERR_FUNC(BIO_F_BIO_SOCK_INFO), "BIO_sock_info"},

--- a/doc/crypto/BIO_meth_new.pod
+++ b/doc/crypto/BIO_meth_new.pod
@@ -88,7 +88,7 @@ BIO_ctrl().
 
 BIO_meth_get_create() and BIO_meth_set_create() get and set the function used
 for creating a new instance of the BIO respectively. This function will be
-called in response to the application calling BIO_new() or BIO_set() and passing
+called in response to the application calling BIO_new() and passing
 in a pointer to the current BIO_METHOD. The BIO_new() function will allocate the
 memory for the new BIO, and a pointer to this newly allocated structure will
 be passed as a parameter to the function.

--- a/doc/crypto/BIO_new.pod
+++ b/doc/crypto/BIO_new.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-BIO_new, BIO_set, BIO_up_ref, BIO_free, BIO_vfree, BIO_free_all - BIO allocation and freeing functions
+BIO_new, BIO_up_ref, BIO_free, BIO_vfree, BIO_free_all,
+BIO_set - BIO allocation and freeing functions
 
 =head1 SYNOPSIS
 
@@ -18,8 +19,6 @@ BIO_new, BIO_set, BIO_up_ref, BIO_free, BIO_vfree, BIO_free_all - BIO allocation
 =head1 DESCRIPTION
 
 The BIO_new() function returns a new BIO using method B<type>.
-
-BIO_set() sets the method of an already existing BIO.
 
 BIO_up_ref() increments the reference count associated with the BIO object.
 
@@ -50,6 +49,10 @@ in a memory leak.
 
 Calling BIO_free_all() on a single BIO has the same effect as calling BIO_free()
 on it other than the discarded return value.
+
+=head1 HISTORY
+
+BIO_set() was removed in OpenSSL 1.1.0 as BIO type is now opaque.
 
 =head1 EXAMPLE
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -533,7 +533,6 @@ BIO *BIO_new_file(const char *filename, const char *mode);
 BIO *BIO_new_fp(FILE *stream, int close_flag);
 # endif
 BIO *BIO_new(const BIO_METHOD *type);
-int BIO_set(BIO *a, const BIO_METHOD *type);
 int BIO_free(BIO *a);
 void BIO_set_data(BIO *a, void *ptr);
 void *BIO_get_data(BIO *a);
@@ -792,7 +791,6 @@ int ERR_load_BIO_strings(void);
 # define BIO_F_BIO_PARSE_HOSTSERV                         136
 # define BIO_F_BIO_PUTS                                   110
 # define BIO_F_BIO_READ                                   111
-# define BIO_F_BIO_SET                                    143
 # define BIO_F_BIO_SOCKET                                 140
 # define BIO_F_BIO_SOCKET_NBIO                            142
 # define BIO_F_BIO_SOCK_INFO                              141

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2805,7 +2805,7 @@ OPENSSL_init                            2761	1_1_0	EXIST::FUNCTION:
 TS_RESP_get_tst_info                    2762	1_1_0	EXIST::FUNCTION:TS
 X509_VERIFY_PARAM_get_depth             2763	1_1_0	EXIST::FUNCTION:
 EVP_SealFinal                           2764	1_1_0	EXIST::FUNCTION:RSA
-BIO_set                                 2765	1_1_0	EXIST::FUNCTION:
+BIO_set                                 2765	1_1_0	NOEXIST::FUNCTION:
 CONF_imodule_set_flags                  2766	1_1_0	EXIST::FUNCTION:
 i2d_ASN1_SET_ANY                        2767	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_decrypt                        2768	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
It is now deprecated as :
- BIO type is now opaque, so no more stack-allocable.
- the new locking API is locking now each BIO object individually.