### PR TITLE
Fix build errors and warnings with no-cms, no-dh and no-ec (1.0.2)

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1087,11 +1087,14 @@ int MAIN(int argc, char *argv[])
     char *chCApath = NULL, *chCAfile = NULL;
     char *vfyCApath = NULL, *vfyCAfile = NULL;
     unsigned char *context = NULL;
+#ifndef OPENSSL_NO_DH
     char *dhfile = NULL;
+    int no_dhe = 0;
+#endif
     int badop = 0;
     int ret = 1;
     int build_chain = 0;
-    int no_tmp_rsa = 0, no_dhe = 0, no_ecdhe = 0, nocert = 0;
+    int no_tmp_rsa = 0, no_ecdhe = 0, nocert = 0;
     int state = 0;
     const SSL_METHOD *meth = NULL;
     int socket_type = SOCK_STREAM;
@@ -1239,11 +1242,15 @@ int MAIN(int argc, char *argv[])
             if (--argc < 1)
                 goto bad;
             s_chain_file = *(++argv);
-        } else if (strcmp(*argv, "-dhparam") == 0) {
+        }
+#ifndef OPENSSL_NO_DH
+        else if (strcmp(*argv, "-dhparam") == 0) {
             if (--argc < 1)
                 goto bad;
             dhfile = *(++argv);
-        } else if (strcmp(*argv, "-dcertform") == 0) {
+        }
+#endif
+        else if (strcmp(*argv, "-dcertform") == 0) {
             if (--argc < 1)
                 goto bad;
             s_dcert_format = str2fmt(*(++argv));
@@ -1390,9 +1397,13 @@ int MAIN(int argc, char *argv[])
             verify_quiet = 1;
         } else if (strcmp(*argv, "-no_tmp_rsa") == 0) {
             no_tmp_rsa = 1;
-        } else if (strcmp(*argv, "-no_dhe") == 0) {
+        }
+#ifndef OPENSSL_NO_DH
+        else if (strcmp(*argv, "-no_dhe") == 0) {
             no_dhe = 1;
-        } else if (strcmp(*argv, "-no_ecdhe") == 0) {
+        }
+#endif
+        else if (strcmp(*argv, "-no_ecdhe") == 0) {
             no_ecdhe = 1;
         } else if (strcmp(*argv, "-no_resume_ephemeral") == 0) {
             no_resume_ephemeral = 1;

--- a/crypto/dh/dh.h
+++ b/crypto/dh/dh.h
@@ -356,7 +356,9 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
 
 /* KDF types */
 # define EVP_PKEY_DH_KDF_NONE                            1
+# ifndef OPENSSL_NO_CMS
 # define EVP_PKEY_DH_KDF_X9_42                           2
+# endif
 
 /* BEGIN ERROR CODES */
 /*

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -61,6 +61,7 @@
 #include <openssl/cms.h>
 
 /* Key derivation from X9.42/RFC2631 */
+/* Uses CMS functions, hence the #ifdef wrapper. */
 
 #define DH_KDF_MAX      (1L << 30)
 

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -457,6 +457,7 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
     else if (dctx->kdf_type == EVP_PKEY_DH_KDF_X9_42) {
         unsigned char *Z = NULL;
         size_t Zlen = 0;
+
         if (!dctx->kdf_outlen || !dctx->kdf_oid)
             return 0;
         if (key == NULL) {
@@ -486,7 +487,7 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
         return ret;
     }
 #endif
-    return 1;
+    return 0;
 }
 
 const EVP_PKEY_METHOD dh_pkey_meth = {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4231,7 +4231,10 @@ int ssl3_get_req_cert_type(SSL *s, unsigned char *p)
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_ECDH)
     int nostrict = 1;
 #endif
+#if !defined(OPENSSL_NO_GOST) || !defined(OPENSSL_NO_DH) || \
+    !defined(OPENSSL_NO_ECDH)
     unsigned long alg_k;
+#endif
 
     /* If we have custom certificate types set, use them */
     if (s->cert->ctypes) {
@@ -4261,7 +4264,10 @@ int ssl3_get_req_cert_type(SSL *s, unsigned char *p)
         }
     }
 
+#if !defined(OPENSSL_NO_GOST) || !defined(OPENSSL_NO_DH) || \
+    !defined(OPENSSL_NO_ECDH)
     alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+#endif
 
 #ifndef OPENSSL_NO_GOST
     if (s->version >= TLS1_VERSION) {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4228,7 +4228,9 @@ int ssl3_get_req_cert_type(SSL *s, unsigned char *p)
 #ifndef OPENSSL_NO_ECDSA
     int have_ecdsa_sign = 0;
 #endif
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_ECDH)
     int nostrict = 1;
+#endif
     unsigned long alg_k;
 
     /* If we have custom certificate types set, use them */
@@ -4238,8 +4240,10 @@ int ssl3_get_req_cert_type(SSL *s, unsigned char *p)
     }
     /* get configured sigalgs */
     siglen = tls12_get_psigalgs(s, 1, &sig);
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_ECDH)
     if (s->cert->cert_flags & SSL_CERT_FLAGS_CHECK_TLS_STRICT)
         nostrict = 0;
+#endif
     for (i = 0; i < siglen; i += 2, sig += 2) {
         switch (sig[1]) {
         case TLSEXT_signature_rsa:

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -392,7 +392,10 @@ CERT *ssl_cert_dup(CERT *cert)
 
     return (ret);
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_ECDH) || \
+    !defined(OPENSSL_NO_TLSEXT)
  err:
+#endif
 #ifndef OPENSSL_NO_RSA
     if (ret->rsa_tmp != NULL)
         RSA_free(ret->rsa_tmp);

--- a/test/cms-test.pl
+++ b/test/cms-test.pl
@@ -100,6 +100,13 @@ my $no_ec2m;
 my $no_ecdh;
 my $ossl8 = `$ossl_path version -v` =~ /0\.9\.8/;
 
+system ("$ossl_path no-cms > $null_path");
+if ($? == 0)
+        {
+        print "CMS disabled\n";
+        exit 0;
+        }
+
 system ("$ossl_path no-ec > $null_path");
 if ($? == 0)
 	{


### PR DESCRIPTION
Four patches for build errors and warnings when Openssl is configured with no-dh and no-ec

Plus another patch to fix no-cms cherry-picked from master
