### PR TITLE
Fix broken loading of client CAs

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -605,8 +605,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file)
             X509_NAME_free(xn);
             xn = NULL;
         } else {
-            if (!lh_X509_NAME_insert(name_hash, xn))
-                goto err;
+            lh_X509_NAME_insert(name_hash, xn);
             if (!sk_X509_NAME_push(ret, xn))
                 goto err;
         }


### PR DESCRIPTION
The SSL_load_client_CA_file() failed to load any CAs due to an
inccorrect assumption about the return value of lh_*_insert(). The
return value when inserting into a hash is the old value of the key.

The bug was introduced in 3c82e437bb3af822ea13cd5a24bab0745c556246.