### PR TITLE
perl: Separate compile-time environment from runtime environment

### DIFF
--- a/Configure
+++ b/Configure
@@ -913,7 +913,11 @@ $config{cross_compile_prefix} = $ENV{'CROSS_COMPILE'}
     if $config{cross_compile_prefix} eq "";
 
 # Allow overriding the names of some tools.  USE WITH CARE
+# Note: only Unix cares about HASHBANGPERL...  that explains
+# the default string.
 $config{perl} =    $ENV{'PERL'}    || ($^O ne "VMS" ? $^X : "perl");
+$config{hashbangperl} =
+    $ENV{'HASHBANGPERL'}           || $ENV{'PERL'}     || "/usr/bin/env perl";
 $target{cc} =      $ENV{'CC'}      || $target{cc}      || "cc";
 $target{ranlib} =  $ENV{'RANLIB'}  || $target{ranlib}  ||
                    (which("$config{cross_compile_prefix}ranlib") ?

--- a/INSTALL
+++ b/INSTALL
@@ -722,7 +722,14 @@
                 variable can be set to the directory where these files are held.
 
  PERL
-                The name of the Perl executable to use.
+                The name of the Perl executable to use when building OpenSSL.
+
+ HASHBANGPERL
+                The command string for the Perl executable to insert in the
+                #! line of perl scripts that will be publically installed.
+                Default: /usr/bin/env perl
+                Note: the value of this variable is added to the same scripts
+                on all platforms, but it's only relevant on Unix-like platforms.
 
  RC
                 The name of the rc executable to use. The default will be as

--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -1,4 +1,4 @@
-#!{- $config{perl} -}
+#!{- $config{hashbangperl} -}
 # Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use

--- a/apps/tsget.in
+++ b/apps/tsget.in
@@ -1,4 +1,4 @@
-#!{- $config{perl} -}
+#!{- $config{hashbangperl} -}
 # Copyright (c) 2002 The OpenTSA Project. All rights reserved.
 # Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
 #

--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -1,4 +1,4 @@
-#!{- $config{perl} -}
+#!{- $config{hashbangperl} -}
 
 # {- join("\n# ", @autowarntext) -}
 # Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.


### PR DESCRIPTION
Make it possible to have a separate and different perl command string
for installable scripts than we use when building, with the
environment variable HASHBANGPERL.  Its value default to the same as
the environment PERL if it's defined, otherwise '/usr/bin/env perl'.

Note: this is only relevant for Unix-like environments.
