### PR TITLE
remove double initialization of cryptodev engine

### DIFF
--- a/crypto/evp/c_all.c
+++ b/crypto/evp/c_all.c
@@ -82,9 +82,4 @@ void OPENSSL_add_all_algorithms_noconf(void)
     OPENSSL_cpuid_setup();
     OpenSSL_add_all_ciphers();
     OpenSSL_add_all_digests();
-#ifndef OPENSSL_NO_ENGINE
-# if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV)
-    ENGINE_setup_bsd_cryptodev();
-# endif
-#endif
 }


### PR DESCRIPTION
cryptodev engine is initialized together with the other engines in
ENGINE_load_builtin_engines. The initialization done through
OpenSSL_add_all_algorithms is redundant.

Signed-off-by: Cristian Stoica <cristian.stoica@nxp.com>