### PR TITLE
Stop using and deprecate ENGINE_setup_bsd_cryptodev

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -116,11 +116,6 @@ static void ossl_init_add_all_ciphers(void)
                     "openssl_add_all_ciphers_int()\n");
 # endif
     openssl_add_all_ciphers_int();
-# ifndef OPENSSL_NO_ENGINE
-#  if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV)
-    ENGINE_setup_bsd_cryptodev();
-#  endif
-# endif
 #endif
 }
 
@@ -137,11 +132,6 @@ static void ossl_init_add_all_digests(void)
                     "openssl_add_all_digests()\n");
 # endif
     openssl_add_all_digests_int();
-# ifndef OPENSSL_NO_ENGINE
-#  if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV)
-    ENGINE_setup_bsd_cryptodev();
-#  endif
-# endif
 #endif
 }
 

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -746,7 +746,7 @@ typedef int (*dynamic_bind_engine) (ENGINE *e, const char *id,
 void *ENGINE_get_static_state(void);
 
 # if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV)
-void ENGINE_setup_bsd_cryptodev(void);
+DEPRECATEDIN_1_1_0(void ENGINE_setup_bsd_cryptodev(void))
 # endif
 
 /* BEGIN ERROR CODES */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3307,7 +3307,7 @@ EVP_read_pw_string_min                  3254	1_1_0	EXIST::FUNCTION:UI
 X509_set_notBefore                      3255	1_1_0	EXIST::FUNCTION:
 MD4                                     3256	1_1_0	EXIST::FUNCTION:MD4
 EVP_PKEY_CTX_dup                        3257	1_1_0	EXIST::FUNCTION:
-ENGINE_setup_bsd_cryptodev              3258	1_1_0	EXIST:__FreeBSD__:FUNCTION:ENGINE
+ENGINE_setup_bsd_cryptodev              3258	1_1_0	EXIST:__FreeBSD__:FUNCTION:DEPRECATEDIN_1_1_0,ENGINE
 PEM_read_bio_DHparams                   3259	1_1_0	EXIST::FUNCTION:DH
 CMS_SharedInfo_encode                   3260	1_1_0	EXIST::FUNCTION:CMS
 ASN1_OBJECT_create                      3261	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
The calls we made to it were redundant, as the same initialization is
done later in OPENSSL_init_crypto() anyway.

---

Inspired by #1285
