### PR TITLE
OCSP_request_add0_id() inconsistent error return

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -35,8 +35,10 @@ OCSP_ONEREQ *OCSP_request_add0_id(OCSP_REQUEST *req, OCSP_CERTID *cid)
         goto err;
     OCSP_CERTID_free(one->reqCert);
     one->reqCert = cid;
-    if (req && !sk_OCSP_ONEREQ_push(req->tbsRequest.requestList, one))
+    if (req && !sk_OCSP_ONEREQ_push(req->tbsRequest.requestList, one)) {
+        one->reqCert = NULL; /* do not free on error */
         goto err;
+    }
     return one;
  err:
     OCSP_ONEREQ_free(one);


### PR DESCRIPTION
There are two failure cases for OCSP_request_add_id():
1. OCSP_ONEREQ_new() failure, where |cid| is not freed
2. sk_OCSP_ONEREQ_push() failure, where |cid| is freed

This changes makes the error behavior consistent, such that |cid| is
not freed when sk_OCSP_ONEREQ_push() fails. OpenSSL only takes
ownership of |cid| when the function succeeds.