### PR TITLE
SSL test framework: port resumption tests

### DIFF
--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -82,7 +82,20 @@ The test section supports the following options:
   - Ignore - do not check for a session ticket (default)
   - Yes - a session ticket is expected
   - No - a session ticket is not expected
-  - Broken - a special test case where the session ticket callback does not initialize crypto
+  - Broken - a special test case where the session ticket callback does not
+    initialize crypto
+
+* HandshakeMode - which handshake flavour to test:
+  - Simple - plain handshake (default)
+  - Resume - test resumption
+  - (Renegotiate - test renegotiation, not yet implemented)
+
+* ResumptionExpected - whether or not resumption is expected (Resume mode only)
+  - Yes - resumed handshake
+  - No - full handshake (default)
+
+When HandshakeMode is Resume or Renegotiate, the original handshake is expected
+to succeed. All configured test expectations are verified against the second handshake.
 
 * ServerNPNProtocols, Server2NPNProtocols, ClientNPNProtocols, ExpectedNPNProtocol,
   ServerALPNProtocols, Server2ALPNProtocols, ClientALPNProtocols, ExpectedALPNProtocol -
@@ -103,9 +116,16 @@ server => {
 }
 ```
 
-A server2 section may optionally be defined to configure a secondary
-context that is selected via the ServerName test option. If the server2
-section is not configured, then the configuration matches server.
+The following sections may optionally be defined:
+
+* server2 - this section configures a secondary context that is selected via the
+  ServerName test option. This context is used whenever a ServerNameCallback is
+  specified. If the server2 section is not present, then the configuration
+  matches server.
+* resume_server - this section configures the client to resume its session
+  against a different server. This context is used whenever HandshakeMode is
+  Resume. If the resume-server section is not present, then the configuration
+  matches server.
 
 ### Default server and client configurations
 

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -43,11 +43,24 @@ sub print_templates {
     # Add the implicit base configuration.
     foreach my $test (@ssltests::tests) {
         $test->{"server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
-	# Do not emit an empty "server2" section.
-	if (defined $test->{"server2"}) {
+        if (defined $test->{"server2"}) {
             $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server2"}}) };
+        } elsif (defined $test->{"test"}->{"ServerNameCallback"}) {
+            # Default is the same as server.
+            $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server"}}) };
         } else {
+            # Do not emit an empty "server2" section.
             $test->{"server2"} = { };
+        }
+        if (defined $test->{"resume_server"}) {
+            $test->{"resume_server"} = { (%ssltests::base_server, %{$test->{"resume_server"}}) };
+        } elsif (defined $test->{"test"}->{"HandshakeMode"} &&
+                 $test->{"test"}->{"HandshakeMode"} eq "Resume") {
+            # Default is the same as server.
+            $test->{"resume_server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
+        } else {
+            # Do not emit an empty "resume-server" section.
+            $test->{"resume_server"} = { };
         }
         $test->{"client"} = { (%ssltests::base_client, %{$test->{"client"}}) };
     }

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -36,6 +36,9 @@ typedef struct handshake_result {
     char *server_npn_negotiated;
     char *client_alpn_negotiated;
     char *server_alpn_negotiated;
+    /* Was the handshake resumed? */
+    int client_resumed;
+    int server_resumed;
 } HANDSHAKE_RESULT;
 
 HANDSHAKE_RESULT *HANDSHAKE_RESULT_new(void);
@@ -43,6 +46,7 @@ void HANDSHAKE_RESULT_free(HANDSHAKE_RESULT *result);
 
 /* Do a handshake and report some information about the result. */
 HANDSHAKE_RESULT *do_handshake(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
-                               SSL_CTX *client_ctx, const SSL_TEST_CTX *test_ctx);
+                               SSL_CTX *client_ctx, SSL_CTX *resume_server_ctx,
+                               const SSL_TEST_CTX *test_ctx);
 
 #endif  /* HEADER_HANDSHAKE_HELPER_H */

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -42,12 +42,15 @@ my %conf_dependent_tests = (
   "02-protocol-version.conf" => !$is_default_tls,
   "04-client_auth.conf" => !$is_default_tls,
   "05-dtls-protocol-version.conf" => !$is_default_dtls,
+  "10-resumption.conf" => !$is_default_tls,
+  "11-dtls_resumption.conf" => !$is_default_dtls,
 );
 
 # Default is $no_tls but some tests have different skip conditions.
 my %skip = (
   "05-dtls-protocol-version.conf" => $no_dtls,
   "08-npn.conf" => $no_tls || $no_npn,
+  "11-dtls_resumption.conf" => $no_dtls,
 );
 
 foreach my $conf (@conf_files) {
@@ -60,7 +63,7 @@ foreach my $conf (@conf_files) {
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 9;  # = scalar @conf_srcs
+plan tests => 11;  # = scalar @conf_srcs
 
 sub test_conf {
     plan tests => 3;

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -79,7 +79,7 @@ my $client_sess="client.ss";
 # new format in ssl_test.c and add recipes to 80-test_ssl_new.t instead.
 plan tests =>
     1				# For testss
-    + 11			# For the first testssl
+    +9  			# For the first testssl
     ;
 
 subtest 'test_ss' => sub {
@@ -615,52 +615,6 @@ sub testssl {
 	      if $no_tls1_2;
 
 	  ok(run(test([@ssltest, "-cipher", "AES128-SHA256", "-bytes", "8m"])));
-	}
-    };
-
-    subtest 'TLS session reuse' => sub {
-        plan tests => 12;
-
-        SKIP: {
-            skip "TLS1.1 or TLS1.2 disabled", 12 if $no_tls1_1 || $no_tls1_2;
-            ok(run(test([@ssltest, "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-            ok(run(test([@ssltest, "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "tls1.2"])));
-            ok(run(test([@ssltest, "-server_max_proto", "tls1.1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "tls1.1"])));
-
-            ok(run(test([@ssltest, "-server_max_proto", "tls1.1", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-            ok(run(test([@ssltest, "-server_max_proto", "tls1.1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "tls1.1"])));
-            ok(run(test([@ssltest, "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "tls1.2"])));
-
-            ok(run(test([@ssltest, "-no_ticket", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-            ok(run(test([@ssltest, "-no_ticket", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "tls1.2"])));
-            ok(run(test([@ssltest, "-no_ticket", "-server_max_proto", "tls1.1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "tls1.1"])));
-
-            ok(run(test([@ssltest, "-no_ticket", "-server_max_proto", "tls1.1", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-            ok(run(test([@ssltest, "-no_ticket", "-server_max_proto", "tls1.1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "tls1.1"])));
-            ok(run(test([@ssltest, "-no_ticket", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "tls1.2"])));
-        }
-    };
-
-    subtest 'DTLS session reuse' => sub {
-        plan tests => 12;
-      SKIP: {
-        skip "DTLS1.0 or DTLS1.2 disabled", 12 if $no_dtls1 || $no_dtls1_2;
-
-        ok(run(test([@ssltest, "-dtls", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-        ok(run(test([@ssltest, "-dtls", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "dtls1.2"])));
-        ok(run(test([@ssltest, "-dtls", "-server_max_proto", "dtls1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "dtls1"])));
-
-        ok(run(test([@ssltest, "-dtls", "-server_max_proto", "dtls1", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-        ok(run(test([@ssltest, "-dtls", "-server_max_proto", "dtls1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "dtls1"])));
-        ok(run(test([@ssltest, "-dtls", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "dtls1.2"])));
-
-        ok(run(test([@ssltest, "-dtls", "-no_ticket", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-        ok(run(test([@ssltest, "-dtls", "-no_ticket", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "dtls1.2"])));
-        ok(run(test([@ssltest, "-dtls", "-no_ticket", "-server_max_proto", "dtls1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "dtls1"])));
-
-        ok(run(test([@ssltest, "-dtls", "-no_ticket", "-server_max_proto", "dtls1", "-server_sess_out", $server_sess, "-client_sess_out", $client_sess])));
-        ok(run(test([@ssltest, "-dtls", "-no_ticket", "-server_max_proto", "dtls1", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "1", "-should_negotiate", "dtls1"])));
-        ok(run(test([@ssltest, "-dtls", "-no_ticket", "-server_sess_in", $server_sess, "-client_sess_in", $client_sess, "-should_reuse", "0", "-should_negotiate", "dtls1.2"])));
 	}
     };
 

--- a/test/ssl-tests/05-sni.conf.in
+++ b/test/ssl-tests/05-sni.conf.in
@@ -18,7 +18,6 @@ our @tests = (
     {
         name => "SNI-switch-context",
         server => { },
-        server2 => { },
         client => { },
         test   => { "ServerName" => "server2",
                     "ExpectedServerName" => "server2",
@@ -28,7 +27,6 @@ our @tests = (
     {
         name => "SNI-keep-context",
         server => { },
-        server2 => { },
         client => { },
         test   => { "ServerName" => "server1",
                     "ExpectedServerName" => "server1",
@@ -45,7 +43,6 @@ our @tests = (
     {
         name => "SNI-no-client-support",
         server => { },
-        server2 => { },
         client => { },
         test   => {
             # We expect that the callback is still called
@@ -59,7 +56,6 @@ our @tests = (
     {
         name => "SNI-bad-sni-ignore-mismatch",
         server => { },
-        server2 => { },
         client => { },
         test   => { "ServerName" => "invalid",
                     "ExpectedServerName" => "server1",
@@ -69,7 +65,6 @@ our @tests = (
     {
         name => "SNI-bad-sni-reject-mismatch",
         server => { },
-        server2 => { },
         client => { },
         test   => { "ServerName" => "invalid",
                     "ServerNameCallback" => "RejectMismatch",

--- a/test/ssl-tests/07-dtls-protocol-version.conf.in
+++ b/test/ssl-tests/07-dtls-protocol-version.conf.in
@@ -16,4 +16,4 @@ use warnings;
 
 use protocol_version;
 
-our @tests = generate_tests("DTLS");
+our @tests = generate_version_tests("DTLS");

--- a/test/ssl-tests/10-resumption.conf
+++ b/test/ssl-tests/10-resumption.conf
@@ -1,0 +1,652 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 18
+
+test-0 = 0-resumption
+test-1 = 1-resumption
+test-2 = 2-resumption
+test-3 = 3-resumption
+test-4 = 4-resumption
+test-5 = 5-resumption
+test-6 = 6-resumption
+test-7 = 7-resumption
+test-8 = 8-resumption
+test-9 = 9-resumption
+test-10 = 10-resumption
+test-11 = 11-resumption
+test-12 = 12-resumption
+test-13 = 13-resumption
+test-14 = 14-resumption
+test-15 = 15-resumption
+test-16 = 16-resumption
+test-17 = 17-resumption
+# ===========================================================
+
+[0-resumption]
+ssl_conf = 0-resumption-ssl
+
+[0-resumption-ssl]
+server = 0-resumption-server
+resume-server = 0-resumption-resume-server
+client = 0-resumption-client
+
+[0-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+HandshakeMode = Resume
+Protocol = TLSv1
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[1-resumption]
+ssl_conf = 1-resumption-ssl
+
+[1-resumption-ssl]
+server = 1-resumption-server
+resume-server = 1-resumption-resume-server
+client = 1-resumption-client
+
+[1-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+HandshakeMode = Resume
+Protocol = TLSv1
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[2-resumption]
+ssl_conf = 2-resumption-ssl
+
+[2-resumption-ssl]
+server = 2-resumption-server
+resume-server = 2-resumption-resume-server
+client = 2-resumption-client
+
+[2-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+HandshakeMode = Resume
+Protocol = TLSv1.1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[3-resumption]
+ssl_conf = 3-resumption-ssl
+
+[3-resumption-ssl]
+server = 3-resumption-server
+resume-server = 3-resumption-resume-server
+client = 3-resumption-client
+
+[3-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+HandshakeMode = Resume
+Protocol = TLSv1.1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[4-resumption]
+ssl_conf = 4-resumption-ssl
+
+[4-resumption-ssl]
+server = 4-resumption-server
+resume-server = 4-resumption-resume-server
+client = 4-resumption-client
+
+[4-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+HandshakeMode = Resume
+Protocol = TLSv1.2
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[5-resumption]
+ssl_conf = 5-resumption-ssl
+
+[5-resumption-ssl]
+server = 5-resumption-server
+resume-server = 5-resumption-resume-server
+client = 5-resumption-client
+
+[5-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+HandshakeMode = Resume
+Protocol = TLSv1.2
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[6-resumption]
+ssl_conf = 6-resumption-ssl
+
+[6-resumption-ssl]
+server = 6-resumption-server
+resume-server = 6-resumption-resume-server
+client = 6-resumption-client
+
+[6-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+HandshakeMode = Resume
+Protocol = TLSv1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[7-resumption]
+ssl_conf = 7-resumption-ssl
+
+[7-resumption-ssl]
+server = 7-resumption-server
+resume-server = 7-resumption-resume-server
+client = 7-resumption-client
+
+[7-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-7]
+HandshakeMode = Resume
+Protocol = TLSv1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[8-resumption]
+ssl_conf = 8-resumption-ssl
+
+[8-resumption-ssl]
+server = 8-resumption-server
+resume-server = 8-resumption-resume-server
+client = 8-resumption-client
+
+[8-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[8-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[8-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-8]
+HandshakeMode = Resume
+Protocol = TLSv1.1
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[9-resumption]
+ssl_conf = 9-resumption-ssl
+
+[9-resumption-ssl]
+server = 9-resumption-server
+resume-server = 9-resumption-resume-server
+client = 9-resumption-client
+
+[9-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[9-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[9-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-9]
+HandshakeMode = Resume
+Protocol = TLSv1.1
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[10-resumption]
+ssl_conf = 10-resumption-ssl
+
+[10-resumption-ssl]
+server = 10-resumption-server
+resume-server = 10-resumption-resume-server
+client = 10-resumption-client
+
+[10-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[10-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[10-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-10]
+HandshakeMode = Resume
+Protocol = TLSv1.2
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[11-resumption]
+ssl_conf = 11-resumption-ssl
+
+[11-resumption-ssl]
+server = 11-resumption-server
+resume-server = 11-resumption-resume-server
+client = 11-resumption-client
+
+[11-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[11-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[11-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-11]
+HandshakeMode = Resume
+Protocol = TLSv1.2
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[12-resumption]
+ssl_conf = 12-resumption-ssl
+
+[12-resumption-ssl]
+server = 12-resumption-server
+resume-server = 12-resumption-resume-server
+client = 12-resumption-client
+
+[12-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[12-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[12-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-12]
+HandshakeMode = Resume
+Protocol = TLSv1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[13-resumption]
+ssl_conf = 13-resumption-ssl
+
+[13-resumption-ssl]
+server = 13-resumption-server
+resume-server = 13-resumption-resume-server
+client = 13-resumption-client
+
+[13-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[13-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[13-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-13]
+HandshakeMode = Resume
+Protocol = TLSv1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[14-resumption]
+ssl_conf = 14-resumption-ssl
+
+[14-resumption-ssl]
+server = 14-resumption-server
+resume-server = 14-resumption-resume-server
+client = 14-resumption-client
+
+[14-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[14-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[14-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-14]
+HandshakeMode = Resume
+Protocol = TLSv1.1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[15-resumption]
+ssl_conf = 15-resumption-ssl
+
+[15-resumption-ssl]
+server = 15-resumption-server
+resume-server = 15-resumption-resume-server
+client = 15-resumption-client
+
+[15-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[15-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[15-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-15]
+HandshakeMode = Resume
+Protocol = TLSv1.1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[16-resumption]
+ssl_conf = 16-resumption-ssl
+
+[16-resumption-ssl]
+server = 16-resumption-server
+resume-server = 16-resumption-resume-server
+client = 16-resumption-client
+
+[16-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[16-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[16-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-16]
+HandshakeMode = Resume
+Protocol = TLSv1.2
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[17-resumption]
+ssl_conf = 17-resumption-ssl
+
+[17-resumption-ssl]
+server = 17-resumption-server
+resume-server = 17-resumption-resume-server
+client = 17-resumption-client
+
+[17-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[17-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[17-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-17]
+HandshakeMode = Resume
+Protocol = TLSv1.2
+ResumptionExpected = Yes
+
+

--- a/test/ssl-tests/10-resumption.conf.in
+++ b/test/ssl-tests/10-resumption.conf.in
@@ -7,13 +7,13 @@
 # https://www.openssl.org/source/license.html
 
 
-## Test TLS version negotiation
-
-package ssltests;
+## Test version negotiation upon resumption.
 
 use strict;
 use warnings;
 
+package ssltests;
+
 use protocol_version;
 
-our @tests = generate_version_tests("TLS");
+our @tests = generate_resumption_tests("TLS");

--- a/test/ssl-tests/11-dtls_resumption.conf
+++ b/test/ssl-tests/11-dtls_resumption.conf
@@ -1,0 +1,300 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 8
+
+test-0 = 0-resumption
+test-1 = 1-resumption
+test-2 = 2-resumption
+test-3 = 3-resumption
+test-4 = 4-resumption
+test-5 = 5-resumption
+test-6 = 6-resumption
+test-7 = 7-resumption
+# ===========================================================
+
+[0-resumption]
+ssl_conf = 0-resumption-ssl
+
+[0-resumption-ssl]
+server = 0-resumption-server
+resume-server = 0-resumption-resume-server
+client = 0-resumption-client
+
+[0-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[1-resumption]
+ssl_conf = 1-resumption-ssl
+
+[1-resumption-ssl]
+server = 1-resumption-server
+resume-server = 1-resumption-resume-server
+client = 1-resumption-client
+
+[1-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[2-resumption]
+ssl_conf = 2-resumption-ssl
+
+[2-resumption-ssl]
+server = 2-resumption-server
+resume-server = 2-resumption-resume-server
+client = 2-resumption-client
+
+[2-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1.2
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[3-resumption]
+ssl_conf = 3-resumption-ssl
+
+[3-resumption-ssl]
+server = 3-resumption-server
+resume-server = 3-resumption-resume-server
+client = 3-resumption-client
+
+[3-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1.2
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[4-resumption]
+ssl_conf = 4-resumption-ssl
+
+[4-resumption-ssl]
+server = 4-resumption-server
+resume-server = 4-resumption-resume-server
+client = 4-resumption-client
+
+[4-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[5-resumption]
+ssl_conf = 5-resumption-ssl
+
+[5-resumption-ssl]
+server = 5-resumption-server
+resume-server = 5-resumption-resume-server
+client = 5-resumption-client
+
+[5-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[6-resumption]
+ssl_conf = 6-resumption-ssl
+
+[6-resumption-ssl]
+server = 6-resumption-server
+resume-server = 6-resumption-resume-server
+client = 6-resumption-client
+
+[6-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+Options = SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1.2
+ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[7-resumption]
+ssl_conf = 7-resumption-ssl
+
+[7-resumption-ssl]
+server = 7-resumption-server
+resume-server = 7-resumption-resume-server
+client = 7-resumption-client
+
+[7-resumption-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+Options = -SessionTicket
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-resumption-resume-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-resumption-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-7]
+HandshakeMode = Resume
+Method = DTLS
+Protocol = DTLSv1.2
+ResumptionExpected = Yes
+
+

--- a/test/ssl-tests/11-dtls_resumption.conf.in
+++ b/test/ssl-tests/11-dtls_resumption.conf.in
@@ -7,13 +7,13 @@
 # https://www.openssl.org/source/license.html
 
 
-## Test TLS version negotiation
-
-package ssltests;
+## Test version negotiation upon resumption.
 
 use strict;
 use warnings;
 
+package ssltests;
+
 use protocol_version;
 
-our @tests = generate_version_tests("TLS");
+our @tests = generate_resumption_tests("DTLS");

--- a/test/ssl_test.tmpl
+++ b/test/ssl_test.tmpl
@@ -3,10 +3,13 @@ ssl_conf = {-$testname-}-ssl
 
 [{-$testname-}-ssl]
 server = {-$testname-}-server{-
-    # The server2 section is optional.
+    # The following sections are optional.
     $OUT = "";
     if (%server2) {
         $OUT .= "\nserver2 = $testname-server2";
+    }
+    if (%resume_server) {
+        $OUT .= "\nresume-server = $testname-resume-server";
     }
 -}
 client = {-$testname-}-client
@@ -20,6 +23,12 @@ client = {-$testname-}-client
         $OUT .= "\n[$testname-server2]\n";
         foreach my $key (sort keys %server2) {
             $OUT .= qq{$key} . " = " . qq{$server2{$key}\n} if defined $server2{$key};
+        }
+    }
+    if (%resume_server) {
+        $OUT .= "\n[$testname-resume-server]\n";
+        foreach my $key (sort keys %resume_server) {
+            $OUT .= qq{$key} . " = " . qq{$resume_server{$key}\n} if defined $resume_server{$key};
         }
     }
 -}

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -17,7 +17,9 @@ typedef enum {
     SSL_TEST_SUCCESS = 0,  /* Default */
     SSL_TEST_SERVER_FAIL,
     SSL_TEST_CLIENT_FAIL,
-    SSL_TEST_INTERNAL_ERROR
+    SSL_TEST_INTERNAL_ERROR,
+    /* Couldn't test resumption/renegotiation: original handshake failed. */
+    SSL_TEST_FIRST_HANDSHAKE_FAILED
 } ssl_test_result_t;
 
 typedef enum {
@@ -39,7 +41,6 @@ typedef enum {
     SSL_TEST_SERVERNAME_REJECT_MISMATCH
 } ssl_servername_callback_t;
 
-
 typedef enum {
     SSL_TEST_SESSION_TICKET_IGNORE = 0, /* Default */
     SSL_TEST_SESSION_TICKET_YES,
@@ -51,6 +52,13 @@ typedef enum {
     SSL_TEST_METHOD_TLS = 0, /* Default */
     SSL_TEST_METHOD_DTLS
 } ssl_test_method_t;
+
+typedef enum {
+    SSL_TEST_HANDSHAKE_SIMPLE = 0, /* Default */
+    SSL_TEST_HANDSHAKE_RESUME,
+    /* Not yet implemented */
+    SSL_TEST_HANDSHAKE_RENEGOTIATE
+} ssl_handshake_mode_t;
 
 typedef struct ssl_test_ctx {
     /* Test expectations. */
@@ -96,6 +104,10 @@ typedef struct ssl_test_ctx {
     char *server_alpn_protocols;
     char *server2_alpn_protocols;
     char *expected_alpn_protocol;
+    /* Whether to test a resumed/renegotiated handshake. */
+    ssl_handshake_mode_t handshake_mode;
+    /* Whether the second handshake is resumed or a full handshake (boolean). */
+    int resumption_expected;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);
@@ -107,6 +119,7 @@ const char *ssl_servername_callback_name(ssl_servername_callback_t
                                          servername_callback);
 const char *ssl_session_ticket_name(ssl_session_ticket_t server);
 const char *ssl_test_method_name(ssl_test_method_t method);
+const char *ssl_handshake_mode_name(ssl_handshake_mode_t mode);
 
 /*
  * Load the test case context from |conf|.

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -12,6 +12,8 @@ SessionTicketExpected = Yes
 Method = DTLS
 ClientNPNProtocols = foo,bar
 Server2ALPNProtocols = baz
+HandshakeMode = Resume
+ResumptionExpected = Yes
 
 [ssltest_unknown_option]
 UnknownOption = Foo
@@ -39,3 +41,9 @@ SessionTicketExpected = Foo
 
 [ssltest_unknown_method]
 Method = TLS2
+
+[ssltest_unknown_handshake_mode]
+HandshakeMode = Foo
+
+[ssltest_unknown_resumption_expected]
+ResumptionExpected = Foo


### PR DESCRIPTION
Systematically test every server-side version downgrade or upgrade.

Client version upgrade or downgrade could be tested analogously but will
be done in a later change.