### PR TITLE
Remove reduntant X509_STORE_CTX_set_verify_cb declaration

### DIFF
--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -360,8 +360,6 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
 void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags);
 void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
                              time_t t);
-void X509_STORE_CTX_set_verify_cb(X509_STORE_CTX *ctx,
-                                  int (*verify_cb) (int, X509_STORE_CTX *));
 
 X509_POLICY_TREE *X509_STORE_CTX_get0_policy_tree(X509_STORE_CTX *ctx);
 int X509_STORE_CTX_get_explicit_policy(X509_STORE_CTX *ctx);


### PR DESCRIPTION
f0e0fd51fd8307f6eae64862ad9aaea113f1177a added X509_STORE_CTX_set_verify_cb
with a typedef'd argument, making the original one redundant.

Fixes `-Wredundant-decls` warning:
```
In file included from /.../include/openssl/x509.h:363:0,                             
                 from /.../include/openssl/ssl.h:150,                                
                 ...                                                                 
/.../include/openssl/x509_vfy.h:379:6: warning: redundant redeclaration of 'X509_STORE_CTX_set_verify_cb' [-Wredundant-decls]
 void X509_STORE_CTX_set_verify_cb(X509_STORE_CTX *ctx,                              
      ^                                                                              
/.../include/openssl/x509_vfy.h:312:6: note: previous declaration of 'X509_STORE_CTX_set_verify_cb' was here
 void X509_STORE_CTX_set_verify_cb(X509_STORE_CTX *ctx,                              
```