### PR TITLE
Resolve over command syntax error which causes 'make install' to fail

### DIFF
--- a/doc/crypto/BIO_set_callback.pod
+++ b/doc/crypto/BIO_set_callback.pod
@@ -40,14 +40,23 @@ BIO_callback_fn() is the type of the callback function. The meaning of each
 argument is described below:
 
 =over
+
+=item B<b>
+
 The BIO the callback is attached to is passed in B<b>.
+
+=item B<oper>
 
 B<oper> is set to the operation being performed. For some operations
 the callback is called twice, once before and once after the actual
 operation, the latter case has B<oper> or'ed with BIO_CB_RETURN.
 
+=item B<argp> B<argi> B<argl>
+
 The meaning of the arguments B<argp>, B<argi> and B<argl> depends on
 the value of B<oper>, that is the operation being performed.
+
+=item B<ret>
 
 B<ret> is the return value that would be returned to the
 application if no callback were present. The actual value returned


### PR DESCRIPTION
There is a syntax error that is causing my `make install` to fail on my local builds. I knew nothing about POD when I started looking at this, but the man pages for pod2man helped me propose this fix (it works for me locally :)). I'm not sure how far the original author intended to indent, nor if the items are correct, but I did what made sense to me based on the function's signature (and surrounding context):

~~~
typedef long (*BIO_callback_fn)(BIO *b, int oper, const char *argp, int argi,
                                 long argl, long ret);
~~~

Also, I noticed that the outcome of the syntax (which exactly matches the callback operations heading) didn't quite work (the indention looks a bit odd), so hopefully someone with a bit more experience can address that.

Anyway, please take a look and provide feedback/modify as needed.

Thanks!