### PR TITLE
Memory leaks / Static analysis

### DIFF
--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -178,6 +178,7 @@ int ec_GFp_mont_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     }
 
  err:
+    BN_free(one);
     BN_CTX_free(new_ctx);
     BN_MONT_CTX_free(mont);
     return ret;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -110,6 +110,7 @@ int SSL_use_RSAPrivateKey(SSL *ssl, RSA *rsa)
     RSA_up_ref(rsa);
     if (EVP_PKEY_assign_RSA(pkey, rsa) <= 0) {
         RSA_free(rsa);
+        EVP_PKEY_free(pkey);
         return 0;
     }
 
@@ -452,6 +453,7 @@ int SSL_CTX_use_RSAPrivateKey(SSL_CTX *ctx, RSA *rsa)
     RSA_up_ref(rsa);
     if (EVP_PKEY_assign_RSA(pkey, rsa) <= 0) {
         RSA_free(rsa);
+        EVP_PKEY_free(pkey);
         return 0;
     }
 


### PR DESCRIPTION
My colleagues have run static analysis on openssl code base.

It seems there are three memory leaks.  In function crypto/ec/ecp_mont.c:ec_GFp_mont_group_set_curve variable "one" is not freed in case of last  goto to label "err" and in functions ssl/ssl_rsa.c:SSL_use_RSAPrivateKey and ssl/ssl_rsa.c:SSL_CTX_use_RSAPrivateKey variable "pkey" is not freed  at last return of zero.