### PR TITLE
Install applink.c

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -342,6 +342,11 @@ install_dev:
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@echo "*** Installing development files"
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/include/openssl
+	@ : {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
+	@echo "install $(SRCDIR)/ms/applink.c -> $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c"
+	@cp $(SRCDIR)/ms/applink.c $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+	@chmod 644 $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+	@ : {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
 	@set -e; for i in $(SRCDIR)/include/openssl/*.h \
 			  $(BLDDIR)/include/openssl/*.h; do \
 		fn=`basename $$i`; \
@@ -397,6 +402,10 @@ install_dev:
 
 uninstall_dev:
 	@echo "*** Uninstalling development files"
+	@ : {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
+	@echo "$(RM) $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c"
+	@$(RM) $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+	@ : {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
 	@set -e; for i in $(SRCDIR)/include/openssl/*.h \
 			  $(BLDDIR)/include/openssl/*.h; do \
 		fn=`basename $$i`; \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -479,7 +479,7 @@ install_runtime:
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/bin
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(OPENSSLDIR)/misc
 	@echo "*** Installing runtime files"
-	: {- output_off() unless windowsdll(); "" -};
+	@ : {- output_off() unless windowsdll(); "" -}
 	@set -e; for s in dummy $(SHLIBS); do \
 		if [ "$$s" = "dummy" ]; then continue; fi; \
 		fn=`basename $$s`; \
@@ -489,7 +489,7 @@ install_runtime:
 		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
 		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
 	done
-	: {- output_on() unless windowsdll(); "" -};
+	@ : {- output_on() unless windowsdll(); "" -}
 	@set -e; for x in dummy $(PROGRAMS); do \
 		if [ "$$x" = "dummy" ]; then continue; fi; \
 		fn=`basename $$x`; \
@@ -532,14 +532,14 @@ uninstall_runtime:
 		echo "$(RM) $(DESTDIR)$(OPENSSLDIR)/misc/$$fn"; \
 		$(RM) $(DESTDIR)$(OPENSSLDIR)/misc/$$fn; \
 	done
-	: {- output_off() unless windowsdll(); "" -};
+	@ : {- output_off() unless windowsdll(); "" -}
 	@set -e; for s in dummy $(SHLIBS); do \
 		if [ "$$s" = "dummy" ]; then continue; fi; \
 		fn=`basename $$s`; \
 		echo "$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
 		$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
 	done
-	: {- output_on() unless windowsdll(); "" -};
+	@ : {- output_on() unless windowsdll(); "" -}
 	$(RM) $(DESTDIR)$(OPENSSLDIR)/openssl.cnf
 	-$(RMDIR) $(DESTDIR)$(INSTALLTOP)/bin
 	-$(RMDIR) $(DESTDIR)$(OPENSSLDIR)/misc

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -259,6 +259,10 @@ install_dev:
 	@if "$(INSTALLTOP)"=="" ( echo INSTALLTOP should not be empty & exit 1 )
 	@echo *** Installing development files
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\include\openssl"
+	@rem {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
+	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\ms\applink.c" \
+				       "$(INSTALLTOP)\include\openssl"
+	@rem {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\include\openssl\*.h" \
 				       "$(INSTALLTOP)\include\openssl"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(BLDDIR)\include\openssl\*.h \

--- a/doc/crypto/OPENSSL_Applink.pod
+++ b/doc/crypto/OPENSSL_Applink.pod
@@ -16,7 +16,8 @@ Even though it appears at application side, it's essentially OpenSSL
 private interface. For this reason application developers are not
 expected to implement it, but to compile provided module with
 compiler of their choice and link it into the target application.
-The referred module is available as <openssl>/ms/applink.c.
+The referred module is available as F<applink.c>, located alongside
+the public header files (only on the platforms where applicable).
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Install applink.c among the public header files, like in older OpenSSL versions.

This is only done on the platforms where it makes any sense (Windows and mingw).
