### PR TITLE
Fix potential memory leaks

### DIFF
--- a/crypto/x509v3/v3_conf.c
+++ b/crypto/x509v3/v3_conf.c
@@ -166,7 +166,6 @@ static X509_EXTENSION *do_ext_i2d(const X509V3_EXT_METHOD *method,
 
  merr:
     X509V3err(X509V3_F_DO_EXT_I2D, ERR_R_MALLOC_FAILURE);
-    OPENSSL_free(ext_der);
     ASN1_OCTET_STRING_free(ext_oct);
     return NULL;
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2873,7 +2873,9 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
     ossl_statem_set_error(s);
  done:
     X509_free(x);
-    sk_X509_pop_free(sk, X509_free);
+    if (sk != NULL){
+      sk_X509_pop_free(sk, X509_free);
+    }
     return ret;
 }
 


### PR DESCRIPTION
Memory leak due to null sk object being freed again in tls_process_client_certificate() function using sk_X509_pop_free()