### PR TITLE
Set object to null after free for good practise & memory leak

### DIFF
--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -102,5 +102,6 @@ static int do_create(const char *value, const char *name)
     }
 
     OPENSSL_free(lntmp);
+    oid->ln = NULL;
     return 1;
 }

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -99,8 +99,12 @@ static int do_create(const char *value, const char *name)
         lntmp[p - ln] = 0;
         oid = OBJ_nid2obj(nid);
         oid->ln = lntmp;
+        goto fin;
     }
-
+    
+    return 1;
+    
+fin:    
     OPENSSL_free(lntmp);
     oid->ln = NULL;
     return 1;

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -101,5 +101,6 @@ static int do_create(const char *value, const char *name)
         oid->ln = lntmp;
     }
 
+    OPENSSL_free(lntmp);
     return 1;
 }

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -143,8 +143,10 @@ int X509_TRUST_add(int id, int flags, int (*ck) (X509_TRUST *, X509 *, int),
         trtmp = X509_TRUST_get0(idx);
 
     /* OPENSSL_free existing name if dynamic */
-    if (trtmp->flags & X509_TRUST_DYNAMIC_NAME)
+    if (trtmp->flags & X509_TRUST_DYNAMIC_NAME){
         OPENSSL_free(trtmp->name);
+        trtmp->name = NULL;
+    }
     /* dup supplied name */
     if ((trtmp->name = OPENSSL_strdup(name)) == NULL) {
         X509err(X509_F_X509_TRUST_ADD, ERR_R_MALLOC_FAILURE);


### PR DESCRIPTION
Good practise to set object to NULL after free