### PR TITLE
Cast to an unsigned type before negating

### DIFF
--- a/crypto/asn1/x_long.c
+++ b/crypto/asn1/x_long.c
@@ -76,7 +76,7 @@ static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
      * set.
      */
     if (ltmp < 0)
-        utmp = -ltmp - 1;
+        utmp = -(unsigned long)ltmp - 1;
     else
         utmp = ltmp;
     clen = BN_num_bits_word(utmp);

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -451,7 +451,7 @@ fmtint(char **sbuffer,
     if (!(flags & DP_F_UNSIGNED)) {
         if (value < 0) {
             signvalue = '-';
-            uvalue = -value;
+            uvalue = -(unsigned LLONG)value;
         } else if (flags & DP_F_PLUS)
             signvalue = '+';
         else if (flags & DP_F_SPACE)


### PR DESCRIPTION
llvm's ubsan reported:
runtime error: negation of -9223372036854775808 cannot be represented in type
'long'; cast to an unsigned type to negate this value to itself

Found using afl