### PR TITLE
SSL tests: compress generated output a little

### DIFF
--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -45,32 +45,35 @@ sub print_templates {
         $test->{"server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
         if (defined $test->{"server2"}) {
             $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server2"}}) };
-        } elsif (defined $test->{"test"}->{"ServerNameCallback"}) {
-            # Default is the same as server.
-            $test->{"server2"} = { (%ssltests::base_server, %{$test->{"server"}}) };
         } else {
-            # Do not emit an empty "server2" section.
+            if (defined $test->{"test"}->{"ServerNameCallback"}) {
+                # Default is the same as server.
+                $test->{"reuse_server2"} = 1;
+            }
+            # Do not emit an empty/duplicate "server2" section.
             $test->{"server2"} = { };
         }
         if (defined $test->{"resume_server"}) {
             $test->{"resume_server"} = { (%ssltests::base_server, %{$test->{"resume_server"}}) };
-        } elsif (defined $test->{"test"}->{"HandshakeMode"} &&
-                 $test->{"test"}->{"HandshakeMode"} eq "Resume") {
-            # Default is the same as server.
-            $test->{"resume_server"} = { (%ssltests::base_server, %{$test->{"server"}}) };
         } else {
-            # Do not emit an empty "resume-server" section.
+            if (defined $test->{"test"}->{"HandshakeMode"} &&
+                 $test->{"test"}->{"HandshakeMode"} eq "Resume") {
+                # Default is the same as server.
+                $test->{"reuse_resume_server"} = 1;
+            }
+            # Do not emit an empty/duplicate "resume-server" section.
             $test->{"resume_server"} = { };
         }
         $test->{"client"} = { (%ssltests::base_client, %{$test->{"client"}}) };
         if (defined $test->{"resume_client"}) {
             $test->{"resume_client"} = { (%ssltests::base_client, %{$test->{"resume_client"}}) };
-        } elsif (defined $test->{"test"}->{"HandshakeMode"} &&
-                 $test->{"test"}->{"HandshakeMode"} eq "Resume") {
-            # Default is the same as client.
-            $test->{"resume_client"} = { (%ssltests::base_client, %{$test->{"client"}}) };
         } else {
-            # Do not emit an empty "resume-client" section.
+            if (defined $test->{"test"}->{"HandshakeMode"} &&
+                 $test->{"test"}->{"HandshakeMode"} eq "Resume") {
+                # Default is the same as client.
+                $test->{"reuse_resume_client"} = 1;
+            }
+            # Do not emit an empty/duplicate "resume-client" section.
             $test->{"resume_client"} = { };
         }
     }

--- a/test/ssl-tests/05-sni.conf
+++ b/test/ssl-tests/05-sni.conf
@@ -15,15 +15,10 @@ ssl_conf = 0-SNI-switch-context-ssl
 
 [0-SNI-switch-context-ssl]
 server = 0-SNI-switch-context-server
-server2 = 0-SNI-switch-context-server2
 client = 0-SNI-switch-context-client
+server2 = 0-SNI-switch-context-server
 
 [0-SNI-switch-context-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[0-SNI-switch-context-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -47,15 +42,10 @@ ssl_conf = 1-SNI-keep-context-ssl
 
 [1-SNI-keep-context-ssl]
 server = 1-SNI-keep-context-server
-server2 = 1-SNI-keep-context-server2
 client = 1-SNI-keep-context-client
+server2 = 1-SNI-keep-context-server
 
 [1-SNI-keep-context-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[1-SNI-keep-context-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -103,15 +93,10 @@ ssl_conf = 3-SNI-no-client-support-ssl
 
 [3-SNI-no-client-support-ssl]
 server = 3-SNI-no-client-support-server
-server2 = 3-SNI-no-client-support-server2
 client = 3-SNI-no-client-support-client
+server2 = 3-SNI-no-client-support-server
 
 [3-SNI-no-client-support-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[3-SNI-no-client-support-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -134,15 +119,10 @@ ssl_conf = 4-SNI-bad-sni-ignore-mismatch-ssl
 
 [4-SNI-bad-sni-ignore-mismatch-ssl]
 server = 4-SNI-bad-sni-ignore-mismatch-server
-server2 = 4-SNI-bad-sni-ignore-mismatch-server2
 client = 4-SNI-bad-sni-ignore-mismatch-client
+server2 = 4-SNI-bad-sni-ignore-mismatch-server
 
 [4-SNI-bad-sni-ignore-mismatch-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[4-SNI-bad-sni-ignore-mismatch-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -166,15 +146,10 @@ ssl_conf = 5-SNI-bad-sni-reject-mismatch-ssl
 
 [5-SNI-bad-sni-reject-mismatch-ssl]
 server = 5-SNI-bad-sni-reject-mismatch-server
-server2 = 5-SNI-bad-sni-reject-mismatch-server2
 client = 5-SNI-bad-sni-reject-mismatch-client
+server2 = 5-SNI-bad-sni-reject-mismatch-server
 
 [5-SNI-bad-sni-reject-mismatch-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[5-SNI-bad-sni-reject-mismatch-server2]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem

--- a/test/ssl-tests/06-sni-ticket.conf
+++ b/test/ssl-tests/06-sni-ticket.conf
@@ -26,8 +26,8 @@ ssl_conf = 0-sni-session-ticket-ssl
 
 [0-sni-session-ticket-ssl]
 server = 0-sni-session-ticket-server
-server2 = 0-sni-session-ticket-server2
 client = 0-sni-session-ticket-client
+server2 = 0-sni-session-ticket-server2
 
 [0-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -60,8 +60,8 @@ ssl_conf = 1-sni-session-ticket-ssl
 
 [1-sni-session-ticket-ssl]
 server = 1-sni-session-ticket-server
-server2 = 1-sni-session-ticket-server2
 client = 1-sni-session-ticket-client
+server2 = 1-sni-session-ticket-server2
 
 [1-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -96,8 +96,8 @@ ssl_conf = 2-sni-session-ticket-ssl
 
 [2-sni-session-ticket-ssl]
 server = 2-sni-session-ticket-server
-server2 = 2-sni-session-ticket-server2
 client = 2-sni-session-ticket-client
+server2 = 2-sni-session-ticket-server2
 
 [2-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -132,8 +132,8 @@ ssl_conf = 3-sni-session-ticket-ssl
 
 [3-sni-session-ticket-ssl]
 server = 3-sni-session-ticket-server
-server2 = 3-sni-session-ticket-server2
 client = 3-sni-session-ticket-client
+server2 = 3-sni-session-ticket-server2
 
 [3-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -168,8 +168,8 @@ ssl_conf = 4-sni-session-ticket-ssl
 
 [4-sni-session-ticket-ssl]
 server = 4-sni-session-ticket-server
-server2 = 4-sni-session-ticket-server2
 client = 4-sni-session-ticket-client
+server2 = 4-sni-session-ticket-server2
 
 [4-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -204,8 +204,8 @@ ssl_conf = 5-sni-session-ticket-ssl
 
 [5-sni-session-ticket-ssl]
 server = 5-sni-session-ticket-server
-server2 = 5-sni-session-ticket-server2
 client = 5-sni-session-ticket-client
+server2 = 5-sni-session-ticket-server2
 
 [5-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -240,8 +240,8 @@ ssl_conf = 6-sni-session-ticket-ssl
 
 [6-sni-session-ticket-ssl]
 server = 6-sni-session-ticket-server
-server2 = 6-sni-session-ticket-server2
 client = 6-sni-session-ticket-client
+server2 = 6-sni-session-ticket-server2
 
 [6-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -276,8 +276,8 @@ ssl_conf = 7-sni-session-ticket-ssl
 
 [7-sni-session-ticket-ssl]
 server = 7-sni-session-ticket-server
-server2 = 7-sni-session-ticket-server2
 client = 7-sni-session-ticket-client
+server2 = 7-sni-session-ticket-server2
 
 [7-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -312,8 +312,8 @@ ssl_conf = 8-sni-session-ticket-ssl
 
 [8-sni-session-ticket-ssl]
 server = 8-sni-session-ticket-server
-server2 = 8-sni-session-ticket-server2
 client = 8-sni-session-ticket-client
+server2 = 8-sni-session-ticket-server2
 
 [8-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -348,8 +348,8 @@ ssl_conf = 9-sni-session-ticket-ssl
 
 [9-sni-session-ticket-ssl]
 server = 9-sni-session-ticket-server
-server2 = 9-sni-session-ticket-server2
 client = 9-sni-session-ticket-client
+server2 = 9-sni-session-ticket-server2
 
 [9-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -384,8 +384,8 @@ ssl_conf = 10-sni-session-ticket-ssl
 
 [10-sni-session-ticket-ssl]
 server = 10-sni-session-ticket-server
-server2 = 10-sni-session-ticket-server2
 client = 10-sni-session-ticket-client
+server2 = 10-sni-session-ticket-server2
 
 [10-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -420,8 +420,8 @@ ssl_conf = 11-sni-session-ticket-ssl
 
 [11-sni-session-ticket-ssl]
 server = 11-sni-session-ticket-server
-server2 = 11-sni-session-ticket-server2
 client = 11-sni-session-ticket-client
+server2 = 11-sni-session-ticket-server2
 
 [11-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -456,8 +456,8 @@ ssl_conf = 12-sni-session-ticket-ssl
 
 [12-sni-session-ticket-ssl]
 server = 12-sni-session-ticket-server
-server2 = 12-sni-session-ticket-server2
 client = 12-sni-session-ticket-client
+server2 = 12-sni-session-ticket-server2
 
 [12-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -492,8 +492,8 @@ ssl_conf = 13-sni-session-ticket-ssl
 
 [13-sni-session-ticket-ssl]
 server = 13-sni-session-ticket-server
-server2 = 13-sni-session-ticket-server2
 client = 13-sni-session-ticket-client
+server2 = 13-sni-session-ticket-server2
 
 [13-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -528,8 +528,8 @@ ssl_conf = 14-sni-session-ticket-ssl
 
 [14-sni-session-ticket-ssl]
 server = 14-sni-session-ticket-server
-server2 = 14-sni-session-ticket-server2
 client = 14-sni-session-ticket-client
+server2 = 14-sni-session-ticket-server2
 
 [14-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -564,8 +564,8 @@ ssl_conf = 15-sni-session-ticket-ssl
 
 [15-sni-session-ticket-ssl]
 server = 15-sni-session-ticket-server
-server2 = 15-sni-session-ticket-server2
 client = 15-sni-session-ticket-client
+server2 = 15-sni-session-ticket-server2
 
 [15-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -600,8 +600,8 @@ ssl_conf = 16-sni-session-ticket-ssl
 
 [16-sni-session-ticket-ssl]
 server = 16-sni-session-ticket-server
-server2 = 16-sni-session-ticket-server2
 client = 16-sni-session-ticket-client
+server2 = 16-sni-session-ticket-server2
 
 [16-sni-session-ticket-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem

--- a/test/ssl-tests/08-npn.conf
+++ b/test/ssl-tests/08-npn.conf
@@ -167,8 +167,8 @@ ssl_conf = 6-npn-with-sni-no-context-switch-ssl
 
 [6-npn-with-sni-no-context-switch-ssl]
 server = 6-npn-with-sni-no-context-switch-server
-server2 = 6-npn-with-sni-no-context-switch-server2
 client = 6-npn-with-sni-no-context-switch-client
+server2 = 6-npn-with-sni-no-context-switch-server2
 
 [6-npn-with-sni-no-context-switch-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -202,8 +202,8 @@ ssl_conf = 7-npn-with-sni-context-switch-ssl
 
 [7-npn-with-sni-context-switch-ssl]
 server = 7-npn-with-sni-context-switch-server
-server2 = 7-npn-with-sni-context-switch-server2
 client = 7-npn-with-sni-context-switch-client
+server2 = 7-npn-with-sni-context-switch-server2
 
 [7-npn-with-sni-context-switch-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -237,8 +237,8 @@ ssl_conf = 8-npn-selected-sni-server-supports-npn-ssl
 
 [8-npn-selected-sni-server-supports-npn-ssl]
 server = 8-npn-selected-sni-server-supports-npn-server
-server2 = 8-npn-selected-sni-server-supports-npn-server2
 client = 8-npn-selected-sni-server-supports-npn-client
+server2 = 8-npn-selected-sni-server-supports-npn-server2
 
 [8-npn-selected-sni-server-supports-npn-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -271,8 +271,8 @@ ssl_conf = 9-npn-selected-sni-server-does-not-support-npn-ssl
 
 [9-npn-selected-sni-server-does-not-support-npn-ssl]
 server = 9-npn-selected-sni-server-does-not-support-npn-server
-server2 = 9-npn-selected-sni-server-does-not-support-npn-server2
 client = 9-npn-selected-sni-server-does-not-support-npn-client
+server2 = 9-npn-selected-sni-server-does-not-support-npn-server2
 
 [9-npn-selected-sni-server-does-not-support-npn-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -331,8 +331,8 @@ ssl_conf = 11-sni-npn-preferred-over-alpn-ssl
 
 [11-sni-npn-preferred-over-alpn-ssl]
 server = 11-sni-npn-preferred-over-alpn-server
-server2 = 11-sni-npn-preferred-over-alpn-server2
 client = 11-sni-npn-preferred-over-alpn-client
+server2 = 11-sni-npn-preferred-over-alpn-server2
 
 [11-sni-npn-preferred-over-alpn-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem

--- a/test/ssl-tests/09-alpn.conf
+++ b/test/ssl-tests/09-alpn.conf
@@ -166,8 +166,8 @@ ssl_conf = 6-alpn-with-sni-no-context-switch-ssl
 
 [6-alpn-with-sni-no-context-switch-ssl]
 server = 6-alpn-with-sni-no-context-switch-server
-server2 = 6-alpn-with-sni-no-context-switch-server2
 client = 6-alpn-with-sni-no-context-switch-client
+server2 = 6-alpn-with-sni-no-context-switch-server2
 
 [6-alpn-with-sni-no-context-switch-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -201,8 +201,8 @@ ssl_conf = 7-alpn-with-sni-context-switch-ssl
 
 [7-alpn-with-sni-context-switch-ssl]
 server = 7-alpn-with-sni-context-switch-server
-server2 = 7-alpn-with-sni-context-switch-server2
 client = 7-alpn-with-sni-context-switch-client
+server2 = 7-alpn-with-sni-context-switch-server2
 
 [7-alpn-with-sni-context-switch-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -236,8 +236,8 @@ ssl_conf = 8-alpn-selected-sni-server-supports-alpn-ssl
 
 [8-alpn-selected-sni-server-supports-alpn-ssl]
 server = 8-alpn-selected-sni-server-supports-alpn-server
-server2 = 8-alpn-selected-sni-server-supports-alpn-server2
 client = 8-alpn-selected-sni-server-supports-alpn-client
+server2 = 8-alpn-selected-sni-server-supports-alpn-server2
 
 [8-alpn-selected-sni-server-supports-alpn-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -270,8 +270,8 @@ ssl_conf = 9-alpn-selected-sni-server-does-not-support-alpn-ssl
 
 [9-alpn-selected-sni-server-does-not-support-alpn-ssl]
 server = 9-alpn-selected-sni-server-does-not-support-alpn-server
-server2 = 9-alpn-selected-sni-server-does-not-support-alpn-server2
 client = 9-alpn-selected-sni-server-does-not-support-alpn-client
+server2 = 9-alpn-selected-sni-server-does-not-support-alpn-server2
 
 [9-alpn-selected-sni-server-does-not-support-alpn-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem

--- a/test/ssl-tests/10-resumption.conf
+++ b/test/ssl-tests/10-resumption.conf
@@ -45,9 +45,9 @@ ssl_conf = 0-resumption-ssl
 
 [0-resumption-ssl]
 server = 0-resumption-server
-resume-server = 0-resumption-resume-server
-resume-client = 0-resumption-resume-client
 client = 0-resumption-client
+resume-server = 0-resumption-resume-server
+resume-client = 0-resumption-client
 
 [0-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -68,11 +68,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[0-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-0]
 HandshakeMode = Resume
 Protocol = TLSv1
@@ -86,9 +81,9 @@ ssl_conf = 1-resumption-ssl
 
 [1-resumption-ssl]
 server = 1-resumption-server
-resume-server = 1-resumption-resume-server
-resume-client = 1-resumption-resume-client
 client = 1-resumption-client
+resume-server = 1-resumption-resume-server
+resume-client = 1-resumption-client
 
 [1-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -109,11 +104,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[1-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-1]
 HandshakeMode = Resume
 Protocol = TLSv1
@@ -127,9 +117,9 @@ ssl_conf = 2-resumption-ssl
 
 [2-resumption-ssl]
 server = 2-resumption-server
-resume-server = 2-resumption-resume-server
-resume-client = 2-resumption-resume-client
 client = 2-resumption-client
+resume-server = 2-resumption-resume-server
+resume-client = 2-resumption-client
 
 [2-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -150,11 +140,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[2-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-2]
 HandshakeMode = Resume
 Protocol = TLSv1.1
@@ -168,9 +153,9 @@ ssl_conf = 3-resumption-ssl
 
 [3-resumption-ssl]
 server = 3-resumption-server
-resume-server = 3-resumption-resume-server
-resume-client = 3-resumption-resume-client
 client = 3-resumption-client
+resume-server = 3-resumption-resume-server
+resume-client = 3-resumption-client
 
 [3-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -191,11 +176,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[3-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-3]
 HandshakeMode = Resume
 Protocol = TLSv1.1
@@ -209,9 +189,9 @@ ssl_conf = 4-resumption-ssl
 
 [4-resumption-ssl]
 server = 4-resumption-server
-resume-server = 4-resumption-resume-server
-resume-client = 4-resumption-resume-client
 client = 4-resumption-client
+resume-server = 4-resumption-resume-server
+resume-client = 4-resumption-client
 
 [4-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -232,11 +212,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[4-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-4]
 HandshakeMode = Resume
 Protocol = TLSv1.2
@@ -250,9 +225,9 @@ ssl_conf = 5-resumption-ssl
 
 [5-resumption-ssl]
 server = 5-resumption-server
-resume-server = 5-resumption-resume-server
-resume-client = 5-resumption-resume-client
 client = 5-resumption-client
+resume-server = 5-resumption-resume-server
+resume-client = 5-resumption-client
 
 [5-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -273,11 +248,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[5-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-5]
 HandshakeMode = Resume
 Protocol = TLSv1.2
@@ -291,9 +261,9 @@ ssl_conf = 6-resumption-ssl
 
 [6-resumption-ssl]
 server = 6-resumption-server
-resume-server = 6-resumption-resume-server
-resume-client = 6-resumption-resume-client
 client = 6-resumption-client
+resume-server = 6-resumption-resume-server
+resume-client = 6-resumption-client
 
 [6-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -314,11 +284,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[6-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-6]
 HandshakeMode = Resume
 Protocol = TLSv1
@@ -332,9 +297,9 @@ ssl_conf = 7-resumption-ssl
 
 [7-resumption-ssl]
 server = 7-resumption-server
-resume-server = 7-resumption-resume-server
-resume-client = 7-resumption-resume-client
 client = 7-resumption-client
+resume-server = 7-resumption-resume-server
+resume-client = 7-resumption-client
 
 [7-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -355,11 +320,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[7-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-7]
 HandshakeMode = Resume
 Protocol = TLSv1
@@ -373,9 +333,9 @@ ssl_conf = 8-resumption-ssl
 
 [8-resumption-ssl]
 server = 8-resumption-server
-resume-server = 8-resumption-resume-server
-resume-client = 8-resumption-resume-client
 client = 8-resumption-client
+resume-server = 8-resumption-resume-server
+resume-client = 8-resumption-client
 
 [8-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -396,11 +356,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[8-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-8]
 HandshakeMode = Resume
 Protocol = TLSv1.1
@@ -414,9 +369,9 @@ ssl_conf = 9-resumption-ssl
 
 [9-resumption-ssl]
 server = 9-resumption-server
-resume-server = 9-resumption-resume-server
-resume-client = 9-resumption-resume-client
 client = 9-resumption-client
+resume-server = 9-resumption-resume-server
+resume-client = 9-resumption-client
 
 [9-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -437,11 +392,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[9-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-9]
 HandshakeMode = Resume
 Protocol = TLSv1.1
@@ -455,9 +405,9 @@ ssl_conf = 10-resumption-ssl
 
 [10-resumption-ssl]
 server = 10-resumption-server
-resume-server = 10-resumption-resume-server
-resume-client = 10-resumption-resume-client
 client = 10-resumption-client
+resume-server = 10-resumption-resume-server
+resume-client = 10-resumption-client
 
 [10-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -478,11 +428,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[10-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-10]
 HandshakeMode = Resume
 Protocol = TLSv1.2
@@ -496,9 +441,9 @@ ssl_conf = 11-resumption-ssl
 
 [11-resumption-ssl]
 server = 11-resumption-server
-resume-server = 11-resumption-resume-server
-resume-client = 11-resumption-resume-client
 client = 11-resumption-client
+resume-server = 11-resumption-resume-server
+resume-client = 11-resumption-client
 
 [11-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -519,11 +464,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[11-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-11]
 HandshakeMode = Resume
 Protocol = TLSv1.2
@@ -537,9 +477,9 @@ ssl_conf = 12-resumption-ssl
 
 [12-resumption-ssl]
 server = 12-resumption-server
-resume-server = 12-resumption-resume-server
-resume-client = 12-resumption-resume-client
 client = 12-resumption-client
+resume-server = 12-resumption-resume-server
+resume-client = 12-resumption-client
 
 [12-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -560,11 +500,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[12-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-12]
 HandshakeMode = Resume
 Protocol = TLSv1
@@ -578,9 +513,9 @@ ssl_conf = 13-resumption-ssl
 
 [13-resumption-ssl]
 server = 13-resumption-server
-resume-server = 13-resumption-resume-server
-resume-client = 13-resumption-resume-client
 client = 13-resumption-client
+resume-server = 13-resumption-resume-server
+resume-client = 13-resumption-client
 
 [13-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -601,11 +536,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[13-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-13]
 HandshakeMode = Resume
 Protocol = TLSv1
@@ -619,9 +549,9 @@ ssl_conf = 14-resumption-ssl
 
 [14-resumption-ssl]
 server = 14-resumption-server
-resume-server = 14-resumption-resume-server
-resume-client = 14-resumption-resume-client
 client = 14-resumption-client
+resume-server = 14-resumption-resume-server
+resume-client = 14-resumption-client
 
 [14-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -642,11 +572,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[14-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-14]
 HandshakeMode = Resume
 Protocol = TLSv1.1
@@ -660,9 +585,9 @@ ssl_conf = 15-resumption-ssl
 
 [15-resumption-ssl]
 server = 15-resumption-server
-resume-server = 15-resumption-resume-server
-resume-client = 15-resumption-resume-client
 client = 15-resumption-client
+resume-server = 15-resumption-resume-server
+resume-client = 15-resumption-client
 
 [15-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -683,11 +608,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[15-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-15]
 HandshakeMode = Resume
 Protocol = TLSv1.1
@@ -701,9 +621,9 @@ ssl_conf = 16-resumption-ssl
 
 [16-resumption-ssl]
 server = 16-resumption-server
-resume-server = 16-resumption-resume-server
-resume-client = 16-resumption-resume-client
 client = 16-resumption-client
+resume-server = 16-resumption-resume-server
+resume-client = 16-resumption-client
 
 [16-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -724,11 +644,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[16-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-16]
 HandshakeMode = Resume
 Protocol = TLSv1.2
@@ -742,9 +657,9 @@ ssl_conf = 17-resumption-ssl
 
 [17-resumption-ssl]
 server = 17-resumption-server
-resume-server = 17-resumption-resume-server
-resume-client = 17-resumption-resume-client
 client = 17-resumption-client
+resume-server = 17-resumption-resume-server
+resume-client = 17-resumption-client
 
 [17-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -765,11 +680,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[17-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-17]
 HandshakeMode = Resume
 Protocol = TLSv1.2
@@ -783,17 +693,11 @@ ssl_conf = 18-resumption-ssl
 
 [18-resumption-ssl]
 server = 18-resumption-server
-resume-server = 18-resumption-resume-server
-resume-client = 18-resumption-resume-client
 client = 18-resumption-client
+resume-server = 18-resumption-server
+resume-client = 18-resumption-resume-client
 
 [18-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[18-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -825,17 +729,11 @@ ssl_conf = 19-resumption-ssl
 
 [19-resumption-ssl]
 server = 19-resumption-server
-resume-server = 19-resumption-resume-server
-resume-client = 19-resumption-resume-client
 client = 19-resumption-client
+resume-server = 19-resumption-server
+resume-client = 19-resumption-resume-client
 
 [19-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[19-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -867,17 +765,11 @@ ssl_conf = 20-resumption-ssl
 
 [20-resumption-ssl]
 server = 20-resumption-server
-resume-server = 20-resumption-resume-server
-resume-client = 20-resumption-resume-client
 client = 20-resumption-client
+resume-server = 20-resumption-server
+resume-client = 20-resumption-resume-client
 
 [20-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[20-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -909,17 +801,11 @@ ssl_conf = 21-resumption-ssl
 
 [21-resumption-ssl]
 server = 21-resumption-server
-resume-server = 21-resumption-resume-server
-resume-client = 21-resumption-resume-client
 client = 21-resumption-client
+resume-server = 21-resumption-server
+resume-client = 21-resumption-resume-client
 
 [21-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[21-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -951,17 +837,11 @@ ssl_conf = 22-resumption-ssl
 
 [22-resumption-ssl]
 server = 22-resumption-server
-resume-server = 22-resumption-resume-server
-resume-client = 22-resumption-resume-client
 client = 22-resumption-client
+resume-server = 22-resumption-server
+resume-client = 22-resumption-resume-client
 
 [22-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[22-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -993,17 +873,11 @@ ssl_conf = 23-resumption-ssl
 
 [23-resumption-ssl]
 server = 23-resumption-server
-resume-server = 23-resumption-resume-server
-resume-client = 23-resumption-resume-client
 client = 23-resumption-client
+resume-server = 23-resumption-server
+resume-client = 23-resumption-resume-client
 
 [23-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[23-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -1035,17 +909,11 @@ ssl_conf = 24-resumption-ssl
 
 [24-resumption-ssl]
 server = 24-resumption-server
-resume-server = 24-resumption-resume-server
-resume-client = 24-resumption-resume-client
 client = 24-resumption-client
+resume-server = 24-resumption-server
+resume-client = 24-resumption-resume-client
 
 [24-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[24-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -1077,17 +945,11 @@ ssl_conf = 25-resumption-ssl
 
 [25-resumption-ssl]
 server = 25-resumption-server
-resume-server = 25-resumption-resume-server
-resume-client = 25-resumption-resume-client
 client = 25-resumption-client
+resume-server = 25-resumption-server
+resume-client = 25-resumption-resume-client
 
 [25-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[25-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -1119,17 +981,11 @@ ssl_conf = 26-resumption-ssl
 
 [26-resumption-ssl]
 server = 26-resumption-server
-resume-server = 26-resumption-resume-server
-resume-client = 26-resumption-resume-client
 client = 26-resumption-client
+resume-server = 26-resumption-server
+resume-client = 26-resumption-resume-client
 
 [26-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[26-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -1161,17 +1017,11 @@ ssl_conf = 27-resumption-ssl
 
 [27-resumption-ssl]
 server = 27-resumption-server
-resume-server = 27-resumption-resume-server
-resume-client = 27-resumption-resume-client
 client = 27-resumption-client
+resume-server = 27-resumption-server
+resume-client = 27-resumption-resume-client
 
 [27-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[27-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -1203,17 +1053,11 @@ ssl_conf = 28-resumption-ssl
 
 [28-resumption-ssl]
 server = 28-resumption-server
-resume-server = 28-resumption-resume-server
-resume-client = 28-resumption-resume-client
 client = 28-resumption-client
+resume-server = 28-resumption-server
+resume-client = 28-resumption-resume-client
 
 [28-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[28-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -1245,17 +1089,11 @@ ssl_conf = 29-resumption-ssl
 
 [29-resumption-ssl]
 server = 29-resumption-server
-resume-server = 29-resumption-resume-server
-resume-client = 29-resumption-resume-client
 client = 29-resumption-client
+resume-server = 29-resumption-server
+resume-client = 29-resumption-resume-client
 
 [29-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[29-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -1287,17 +1125,11 @@ ssl_conf = 30-resumption-ssl
 
 [30-resumption-ssl]
 server = 30-resumption-server
-resume-server = 30-resumption-resume-server
-resume-client = 30-resumption-resume-client
 client = 30-resumption-client
+resume-server = 30-resumption-server
+resume-client = 30-resumption-resume-client
 
 [30-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[30-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -1329,17 +1161,11 @@ ssl_conf = 31-resumption-ssl
 
 [31-resumption-ssl]
 server = 31-resumption-server
-resume-server = 31-resumption-resume-server
-resume-client = 31-resumption-resume-client
 client = 31-resumption-client
+resume-server = 31-resumption-server
+resume-client = 31-resumption-resume-client
 
 [31-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[31-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -1371,17 +1197,11 @@ ssl_conf = 32-resumption-ssl
 
 [32-resumption-ssl]
 server = 32-resumption-server
-resume-server = 32-resumption-resume-server
-resume-client = 32-resumption-resume-client
 client = 32-resumption-client
+resume-server = 32-resumption-server
+resume-client = 32-resumption-resume-client
 
 [32-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[32-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -1413,17 +1233,11 @@ ssl_conf = 33-resumption-ssl
 
 [33-resumption-ssl]
 server = 33-resumption-server
-resume-server = 33-resumption-resume-server
-resume-client = 33-resumption-resume-client
 client = 33-resumption-client
+resume-server = 33-resumption-server
+resume-client = 33-resumption-resume-client
 
 [33-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[33-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -1455,17 +1269,11 @@ ssl_conf = 34-resumption-ssl
 
 [34-resumption-ssl]
 server = 34-resumption-server
-resume-server = 34-resumption-resume-server
-resume-client = 34-resumption-resume-client
 client = 34-resumption-client
+resume-server = 34-resumption-server
+resume-client = 34-resumption-resume-client
 
 [34-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[34-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -1497,17 +1305,11 @@ ssl_conf = 35-resumption-ssl
 
 [35-resumption-ssl]
 server = 35-resumption-server
-resume-server = 35-resumption-resume-server
-resume-client = 35-resumption-resume-client
 client = 35-resumption-client
+resume-server = 35-resumption-server
+resume-client = 35-resumption-resume-client
 
 [35-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[35-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket

--- a/test/ssl-tests/11-dtls_resumption.conf
+++ b/test/ssl-tests/11-dtls_resumption.conf
@@ -25,9 +25,9 @@ ssl_conf = 0-resumption-ssl
 
 [0-resumption-ssl]
 server = 0-resumption-server
-resume-server = 0-resumption-resume-server
-resume-client = 0-resumption-resume-client
 client = 0-resumption-client
+resume-server = 0-resumption-resume-server
+resume-client = 0-resumption-client
 
 [0-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -48,11 +48,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[0-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-0]
 HandshakeMode = Resume
 Method = DTLS
@@ -67,9 +62,9 @@ ssl_conf = 1-resumption-ssl
 
 [1-resumption-ssl]
 server = 1-resumption-server
-resume-server = 1-resumption-resume-server
-resume-client = 1-resumption-resume-client
 client = 1-resumption-client
+resume-server = 1-resumption-resume-server
+resume-client = 1-resumption-client
 
 [1-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -90,11 +85,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[1-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-1]
 HandshakeMode = Resume
 Method = DTLS
@@ -109,9 +99,9 @@ ssl_conf = 2-resumption-ssl
 
 [2-resumption-ssl]
 server = 2-resumption-server
-resume-server = 2-resumption-resume-server
-resume-client = 2-resumption-resume-client
 client = 2-resumption-client
+resume-server = 2-resumption-resume-server
+resume-client = 2-resumption-client
 
 [2-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -132,11 +122,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[2-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-2]
 HandshakeMode = Resume
 Method = DTLS
@@ -151,9 +136,9 @@ ssl_conf = 3-resumption-ssl
 
 [3-resumption-ssl]
 server = 3-resumption-server
-resume-server = 3-resumption-resume-server
-resume-client = 3-resumption-resume-client
 client = 3-resumption-client
+resume-server = 3-resumption-resume-server
+resume-client = 3-resumption-client
 
 [3-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -174,11 +159,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[3-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-3]
 HandshakeMode = Resume
 Method = DTLS
@@ -193,9 +173,9 @@ ssl_conf = 4-resumption-ssl
 
 [4-resumption-ssl]
 server = 4-resumption-server
-resume-server = 4-resumption-resume-server
-resume-client = 4-resumption-resume-client
 client = 4-resumption-client
+resume-server = 4-resumption-resume-server
+resume-client = 4-resumption-client
 
 [4-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -216,11 +196,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[4-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-4]
 HandshakeMode = Resume
 Method = DTLS
@@ -235,9 +210,9 @@ ssl_conf = 5-resumption-ssl
 
 [5-resumption-ssl]
 server = 5-resumption-server
-resume-server = 5-resumption-resume-server
-resume-client = 5-resumption-resume-client
 client = 5-resumption-client
+resume-server = 5-resumption-resume-server
+resume-client = 5-resumption-client
 
 [5-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -258,11 +233,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[5-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-5]
 HandshakeMode = Resume
 Method = DTLS
@@ -277,9 +247,9 @@ ssl_conf = 6-resumption-ssl
 
 [6-resumption-ssl]
 server = 6-resumption-server
-resume-server = 6-resumption-resume-server
-resume-client = 6-resumption-resume-client
 client = 6-resumption-client
+resume-server = 6-resumption-resume-server
+resume-client = 6-resumption-client
 
 [6-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -300,11 +270,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[6-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-6]
 HandshakeMode = Resume
 Method = DTLS
@@ -319,9 +284,9 @@ ssl_conf = 7-resumption-ssl
 
 [7-resumption-ssl]
 server = 7-resumption-server
-resume-server = 7-resumption-resume-server
-resume-client = 7-resumption-resume-client
 client = 7-resumption-client
+resume-server = 7-resumption-resume-server
+resume-client = 7-resumption-client
 
 [7-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
@@ -342,11 +307,6 @@ CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[7-resumption-resume-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
 [test-7]
 HandshakeMode = Resume
 Method = DTLS
@@ -361,17 +321,11 @@ ssl_conf = 8-resumption-ssl
 
 [8-resumption-ssl]
 server = 8-resumption-server
-resume-server = 8-resumption-resume-server
-resume-client = 8-resumption-resume-client
 client = 8-resumption-client
+resume-server = 8-resumption-server
+resume-client = 8-resumption-resume-client
 
 [8-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[8-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -404,17 +358,11 @@ ssl_conf = 9-resumption-ssl
 
 [9-resumption-ssl]
 server = 9-resumption-server
-resume-server = 9-resumption-resume-server
-resume-client = 9-resumption-resume-client
 client = 9-resumption-client
+resume-server = 9-resumption-server
+resume-client = 9-resumption-resume-client
 
 [9-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[9-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -447,17 +395,11 @@ ssl_conf = 10-resumption-ssl
 
 [10-resumption-ssl]
 server = 10-resumption-server
-resume-server = 10-resumption-resume-server
-resume-client = 10-resumption-resume-client
 client = 10-resumption-client
+resume-server = 10-resumption-server
+resume-client = 10-resumption-resume-client
 
 [10-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[10-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -490,17 +432,11 @@ ssl_conf = 11-resumption-ssl
 
 [11-resumption-ssl]
 server = 11-resumption-server
-resume-server = 11-resumption-resume-server
-resume-client = 11-resumption-resume-client
 client = 11-resumption-client
+resume-server = 11-resumption-server
+resume-client = 11-resumption-resume-client
 
 [11-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[11-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -533,17 +469,11 @@ ssl_conf = 12-resumption-ssl
 
 [12-resumption-ssl]
 server = 12-resumption-server
-resume-server = 12-resumption-resume-server
-resume-client = 12-resumption-resume-client
 client = 12-resumption-client
+resume-server = 12-resumption-server
+resume-client = 12-resumption-resume-client
 
 [12-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[12-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -576,17 +506,11 @@ ssl_conf = 13-resumption-ssl
 
 [13-resumption-ssl]
 server = 13-resumption-server
-resume-server = 13-resumption-resume-server
-resume-client = 13-resumption-resume-client
 client = 13-resumption-client
+resume-server = 13-resumption-server
+resume-client = 13-resumption-resume-client
 
 [13-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[13-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket
@@ -619,17 +543,11 @@ ssl_conf = 14-resumption-ssl
 
 [14-resumption-ssl]
 server = 14-resumption-server
-resume-server = 14-resumption-resume-server
-resume-client = 14-resumption-resume-client
 client = 14-resumption-client
+resume-server = 14-resumption-server
+resume-client = 14-resumption-resume-client
 
 [14-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[14-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = SessionTicket
@@ -662,17 +580,11 @@ ssl_conf = 15-resumption-ssl
 
 [15-resumption-ssl]
 server = 15-resumption-server
-resume-server = 15-resumption-resume-server
-resume-client = 15-resumption-resume-client
 client = 15-resumption-client
+resume-server = 15-resumption-server
+resume-client = 15-resumption-resume-client
 
 [15-resumption-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Options = -SessionTicket
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[15-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Options = -SessionTicket

--- a/test/ssl_test.tmpl
+++ b/test/ssl_test.tmpl
@@ -2,20 +2,26 @@
 ssl_conf = {-$testname-}-ssl
 
 [{-$testname-}-ssl]
-server = {-$testname-}-server{-
+server = {-$testname-}-server
+client = {-$testname-}-client{-
     # The following sections are optional.
     $OUT = "";
     if (%server2) {
         $OUT .= "\nserver2 = $testname-server2";
+    } elsif ($reuse_server2) {
+        $OUT .= "\nserver2 = $testname-server";
     }
     if (%resume_server) {
         $OUT .= "\nresume-server = $testname-resume-server";
+    } elsif ($reuse_resume_server) {
+        $OUT .= "\nresume-server = $testname-server";
     }
     if (%resume_client) {
         $OUT .= "\nresume-client = $testname-resume-client";
+    } elsif ($reuse_resume_client) {
+        $OUT .= "\nresume-client = $testname-client";
     }
 -}
-client = {-$testname-}-client
 
 [{-$testname-}-server]
 {-


### PR DESCRIPTION
Don't emit duplicate server/client sections when they are
identical. Instead, just point to the same section.