### PR TITLE
Fix build with missing X509_set_proxy_flag num

### DIFF
--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4152,3 +4152,4 @@ HMAC_CTX_get_md                         4096	1_1_0	EXIST::FUNCTION:
 NAME_CONSTRAINTS_check_CN               4097	1_1_0	EXIST::FUNCTION:
 OCSP_resp_get0_id                       4098	1_1_0	EXIST::FUNCTION:OCSP
 OCSP_resp_get0_certs                    4099	1_1_0	EXIST::FUNCTION:OCSP
+X509_set_proxy_flag                     4100	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
@levitte After 9961cb77684aa26fe7302e691b7d16e53432a625 my shared build started failing with the following error:

```
Error: X509_set_proxy_flag does not have a number assigned
LD_LIBRARY_PATH=: gcc -DDSO_DLFCN -DHAVE_DLFCN_H -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPOLY1305_ASM -DOPENSSLDIR="/usr/local/ssl" -DENGINESDIR="/usr/local/lib64/engines-1.1" -Wall -O0 -g -pthread -m64 -DL_ENDIAN -Wa,--noexecstack -fPIC -m64 -shared -Wl,-Bsymbolic -Wl,-soname=libcrypto.so.1.1 -o ./libcrypto.so.1.1 -Wl,--whole-archive,--version-script=crypto.map ./libcrypto.a -Wl,--no-whole-archive -ldl
/usr/bin/ld:crypto.map:3360: syntax error in VERSION script
collect2: error: ld returned 1 exit status
Makefile.shared:197: recipe for target 'link_shlib.linux-shared' failed
```

This PR fixes build for me. Please let me know if you want more info or there is anything else that should be done.

Thanks