### PR TITLE
Add EVP_ENCODE_CTX_copy

### DIFF
--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -102,6 +102,14 @@ void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx)
 {
     OPENSSL_free(ctx);
 }
+
+int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx)
+{
+    memcpy(dctx, sctx, sizeof(EVP_ENCODE_CTX));
+
+    return 1;
+}
+
 int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx)
 {
     return ctx->num;

--- a/doc/crypto/EVP_EncodeInit.pod
+++ b/doc/crypto/EVP_EncodeInit.pod
@@ -2,10 +2,10 @@
 
 =head1 NAME
 
-EVP_ENCODE_CTX_new, EVP_ENCODE_CTX_free, EVP_ENCODE_CTX_num, EVP_EncodeInit,
-EVP_EncodeUpdate, EVP_EncodeFinal, EVP_EncodeBlock, EVP_DecodeInit,
-EVP_DecodeUpdate, EVP_DecodeFinal, EVP_DecodeBlock - EVP base 64 encode/decode
-routines
+EVP_ENCODE_CTX_new, EVP_ENCODE_CTX_free, EVP_ENCODE_CTX_copy,
+EVP_ENCODE_CTX_num, EVP_EncodeInit, EVP_EncodeUpdate, EVP_EncodeFinal,
+EVP_EncodeBlock, EVP_DecodeInit, EVP_DecodeUpdate, EVP_DecodeFinal,
+EVP_DecodeBlock - EVP base 64 encode/decode routines
 
 =head1 SYNOPSIS
 
@@ -13,6 +13,7 @@ routines
 
  EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
  void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
+ int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx);
  int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx);
  void EVP_EncodeInit(EVP_ENCODE_CTX *ctx);
  int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
@@ -75,6 +76,9 @@ data will be stored in B<out> and the length of the data written will be stored
 in B<*outl>. It is the caller's responsibility to ensure that B<out> is
 sufficiently large to accommodate the output data which will never be more than
 65 bytes plus an additional NUL terminator (i.e. 66 bytes in total).
+
+EVP_ENCODE_CTX_copy() can be used to copy a context B<sctx> to a context
+B<dctx>. B<dctx> must be initialized before calling this function.
 
 EVP_ENCODE_CTX_num() will return the number of as yet unprocessed bytes still to
 be encoded or decoded that are pending in the B<ctx> object.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -608,6 +608,7 @@ __owur int EVP_SealFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
 
 EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
 void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
+int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx);
 int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx);
 void EVP_EncodeInit(EVP_ENCODE_CTX *ctx);
 int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4153,3 +4153,4 @@ NAME_CONSTRAINTS_check_CN               4097	1_1_0	EXIST::FUNCTION:
 OCSP_resp_get0_id                       4098	1_1_0	EXIST::FUNCTION:OCSP
 OCSP_resp_get0_certs                    4099	1_1_0	EXIST::FUNCTION:OCSP
 X509_set_proxy_flag                     4100	1_1_0	EXIST::FUNCTION:
+EVP_ENCODE_CTX_copy                     4101	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Currently there is no way how to copy `EVP_ENCODE_CTX` in 1.1 which causes issue to my [PHP crypto extension](https://github.com/bukka/php-crypto/tree/next) that wraps `EVP_ENCODE_CTX` to the PHP class `Crypto\Base64`. The problem is that each class instance in PHP should be clonable and a script like [this](https://github.com/bukka/php-crypto/blob/next/tests/Base64___clone_basic.phpt) will be quite tricky (read messy) to make work without this addition.

I think it will also make it more consistent with other contexts like `CIPHER_CTX` or `HMAC_CTX` where copy exists.

If that would be possible to add it before 1.1 as a missing thing, that would be great. I noticed that similar functions are still added so I hope it's not too late.