### PR TITLE
make it good looking

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -285,10 +285,11 @@ int CRYPTO_dup_ex_data(int class_index, CRYPTO_EX_DATA *to,
     }
 
     for (i = 0; i < mx; i++) {
-        ptr = CRYPTO_get_ex_data(from, i);
-        if (storage[i] && storage[i]->dup_func)
+        if (storage[i] && storage[i]->dup_func) {
+            ptr = CRYPTO_get_ex_data(from, i);
             storage[i]->dup_func(to, from, &ptr, i,
                                  storage[i]->argl, storage[i]->argp);
+        }
         CRYPTO_set_ex_data(to, i, ptr);
     }
     if (storage != stack)


### PR DESCRIPTION
Same as CRYPTO_free_ex_data and CRYPTO_new_ex_data.
Also, why we need storage[10]  to store the item in 'ip->meth'?
Can't we just code like this:

EX_CALLBACK *storage = NULL;
if ((ip = get_and_lock(class_index)) == NULL)
        return;
for (i = 0; i < sk_EX_CALLBACK_num(ip->meth); i++) {
    storage = sk_EX_CALLBACK_value(ip->meth, i);
    /*new or dup or free*/
}
CRYPTO_THREAD_unlock(ex_data_lock);

