### PR TITLE
Make it possible for external code to set the certificate proxy path length

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -533,6 +533,11 @@ void X509_set_proxy_flag(X509 *x)
     x->ex_flags |= EXFLAG_PROXY;
 }
 
+void X509_set_proxy_pathlen(X509 *x, long l)
+{
+    x->ex_pcpathlen = l;
+}
+
 int X509_check_ca(X509 *x)
 {
     if (!(x->ex_flags & EXFLAG_SET)) {
@@ -848,4 +853,13 @@ long X509_get_pathlen(X509 *x)
             || (x->ex_flags & EXFLAG_BCONS) == 0)
         return -1;
     return x->ex_pathlen;
+}
+
+long X509_get_proxy_pathlen(X509 *x)
+{
+    /* Called for side effect of caching extensions */
+    if (X509_check_purpose(x, -1, -1) != 1
+            || (x->ex_flags & EXFLAG_PROXY) == 0)
+        return -1;
+    return x->ex_pcpathlen;
 }

--- a/doc/crypto/X509_get_extension_flags.pod
+++ b/doc/crypto/X509_get_extension_flags.pod
@@ -4,8 +4,12 @@
 
 X509_get0_subject_key_id,
 X509_get_pathlen,
-X509_get_extension_flags, X509_get_key_usage, X509_get_extended_key_usage,
-X509_set_proxy_flag - retrieve certificate extension data
+X509_get_extension_flags,
+X509_get_key_usage,
+X509_get_extended_key_usage,
+X509_set_proxy_flag,
+X509_set_proxy_pathlen,
+X509_get_proxy_pathlen - retrieve certificate extension data
 
 =head1 SYNOPSIS
 
@@ -17,6 +21,8 @@ X509_set_proxy_flag - retrieve certificate extension data
    uint32_t X509_get_extended_key_usage(X509 *x);
    const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
    void X509_set_proxy_flag(X509 *x);
+   void X509_set_proxy_path_length(int l);
+   long X509_get_proxy_pathlen(X509 *x);
 
 =head1 DESCRIPTION
 
@@ -107,6 +113,13 @@ X509_set_proxy_flag() marks the certificate with the B<EXFLAG_PROXY> flag.
 This is for the users who need to mark non-RFC3820 proxy certificates as
 such, as OpenSSL only detects RFC3820 compliant ones.
 
+X509_set_proxy_pathlen() sets the proxy certificate path length for the given
+certificate B<x>.  This is for the users who need to mark non-RFC3820 proxy
+certificates as such, as OpenSSL only detects RFC3820 compliant ones.
+
+X509_get_proxy_pathlen() returns the proxy certificate path length for the
+given certificate B<x> if it is a proxy certicate.
+
 =head1 NOTES
 
 The value of the flags correspond to extension values which are cached
@@ -138,13 +151,17 @@ X509_get0_subject_key_id() returns the subject key identifier as a
 pointer to an B<ASN1_OCTET_STRING> structure or B<NULL> if the extension
 is absent or an error occurred during parsing.
 
+X509_get_proxy_pathlen() returns the path length value if the given
+certificate is a proxy one and has a path length set, and -1 otherwise.
+
 =head1 SEE ALSO
 
 L<X509_check_purpose(3)>
 
 =head1 HISTORY
 
-X509_get_pathlen() and X509_set_proxy_flag() were added in OpenSSL 1.1.0.
+X509_get_pathlen(), X509_set_proxy_flag(), X509_set_proxy_pathlen() and
+X509_get_proxy_pathlen() were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -650,6 +650,8 @@ int X509_PURPOSE_set(int *p, int purpose);
 int X509_check_issued(X509 *issuer, X509 *subject);
 int X509_check_akid(X509 *issuer, AUTHORITY_KEYID *akid);
 void X509_set_proxy_flag(X509 *x);
+void X509_set_proxy_pathlen(X509 *x, long l);
+long X509_get_proxy_pathlen(X509 *x);
 
 uint32_t X509_get_extension_flags(X509 *x);
 uint32_t X509_get_key_usage(X509 *x);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4154,3 +4154,5 @@ OCSP_resp_get0_id                       4098	1_1_0	EXIST::FUNCTION:OCSP
 OCSP_resp_get0_certs                    4099	1_1_0	EXIST::FUNCTION:OCSP
 X509_set_proxy_flag                     4100	1_1_0	EXIST::FUNCTION:
 EVP_ENCODE_CTX_copy                     4101	1_1_0	EXIST::FUNCTION:
+X509_set_proxy_pathlen                  4102	1_1_0	EXIST::FUNCTION:
+X509_get_proxy_pathlen                  4103	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This adds the functions X509_set_proxy_pathlen(), which sets the
internal pc path length cache for a given X509 structure, along with
X509_get_proxy_pathlen(), which retrieves it.

Along with the previously added X509_set_proxy_flag(), this provides
the tools needed to manipulate all the information cached on proxy
certificates, allowing external code to do what's necessary to have
them verified correctly by the libcrypto code.
