### PR TITLE
Use sk_CONF_VALUE_pop_free in do_ext_nconf error path.

### DIFF
--- a/crypto/x509v3/v3_conf.c
+++ b/crypto/x509v3/v3_conf.c
@@ -94,7 +94,7 @@ static X509_EXTENSION *do_ext_nconf(CONF *conf, X509V3_CTX *ctx, int ext_nid,
             ERR_add_error_data(4, "name=", OBJ_nid2sn(ext_nid), ",section=",
                                value);
             if (*value != '@')
-                sk_CONF_VALUE_free(nval);
+                sk_CONF_VALUE_pop_free(nval, X509V3_conf_free);
             return NULL;
         }
         ext_struc = method->v2i(method, ctx, nval);


### PR DESCRIPTION
8605abf13523579ecab8b1f2a4bcb8354d94af79 fixed the nval leak, but it
used free instead of pop_free. nval owns its contents, so it should be
freed with pop_free. See the pop_free call a few lines down.

This is a no-op as, in this codepath, we must have nval == NULL or
sk_CONF_VALUE_num(nval) == 0. In those cases, free and pop_free are
identical. However, variables should be freed consistently.