### PR TITLE
Additional CMS content types from RFC 4073, RFC 5083, and RFC 5084.

### DIFF
--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -257,7 +257,10 @@ id-smime-ct 6		: id-smime-ct-contentInfo
 id-smime-ct 7		: id-smime-ct-DVCSRequestData
 id-smime-ct 8		: id-smime-ct-DVCSResponseData
 id-smime-ct 9		: id-smime-ct-compressedData
+id-smime-ct 19		: id-smime-ct-contentCollection
+id-smime-ct 23		: id-smime-ct-authEnvelopedData
 id-smime-ct 27		: id-ct-asciiTextWithCRLF
+id-smime-ct 28		: id-ct-xml
 
 # S/MIME Attributes
 id-smime-aa 1		: id-smime-aa-receiptRequest


### PR DESCRIPTION
For readability's sake, this doesn't include the changes made to other files by `make generate_crypto_objects`.