### PR TITLE
Add EVP_ENCODE_CTX_length

### DIFF
--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -110,6 +110,11 @@ int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx)
     return 1;
 }
 
+int EVP_ENCODE_CTX_length(EVP_ENCODE_CTX *ctx)
+{
+    return ctx->length;
+}
+
 int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx)
 {
     return ctx->num;

--- a/doc/crypto/EVP_EncodeInit.pod
+++ b/doc/crypto/EVP_EncodeInit.pod
@@ -14,6 +14,7 @@ EVP_DecodeBlock - EVP base 64 encode/decode routines
  EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
  void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
  int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx);
+ int EVP_ENCODE_CTX_length(EVP_ENCODE_CTX *ctx);
  int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx);
  void EVP_EncodeInit(EVP_ENCODE_CTX *ctx);
  int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
@@ -80,6 +81,8 @@ sufficiently large to accommodate the output data which will never be more than
 EVP_ENCODE_CTX_copy() can be used to copy a context B<sctx> to a context
 B<dctx>. B<dctx> must be initialized before calling this function.
 
+EVP_ENCODE_CTX_length() will return the block length.
+
 EVP_ENCODE_CTX_num() will return the number of as yet unprocessed bytes still to
 be encoded or decoded that are pending in the B<ctx> object.
 
@@ -130,6 +133,8 @@ the data decoded or -1 on error.
 
 EVP_ENCODE_CTX_new() returns a pointer to the newly allocated EVP_ENCODE_CTX
 object or NULL on error.
+
+EVP_ENCODE_CTX_length() returns the block length.
 
 EVP_ENCODE_CTX_num() returns the number of bytes pending encoding or decoding in
 B<ctx>.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -609,6 +609,7 @@ __owur int EVP_SealFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
 EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
 void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
 int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx);
+int EVP_ENCODE_CTX_length(EVP_ENCODE_CTX *ctx);
 int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx);
 void EVP_EncodeInit(EVP_ENCODE_CTX *ctx);
 int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4189,3 +4189,4 @@ X509_STORE_unlock                       4133	1_1_0	EXIST::FUNCTION:
 X509_STORE_lock                         4134	1_1_0	EXIST::FUNCTION:
 X509_set_proxy_pathlen                  4135	1_1_0	EXIST::FUNCTION:
 X509_get_proxy_pathlen                  4136	1_1_0	EXIST::FUNCTION:
+EVP_ENCODE_CTX_length                   4137	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is one more function for `EVP_ENCODE_CTX` that I would love to see added. I use it currently to get the real base64 size that needs to be allocated for string in my PHP crypto extension where I define this macro ( EVP_ENCODE_CTX_length is redefined in my ext atm. but would be great to have in OpenSSL):

```
#define PHP_CRYPTO_BASE64_ENCODING_SIZE_REAL(data_len, b64ctx) \
	(((data_len) + 2) * 4 / 3 + data_len / EVP_ENCODE_CTX_length(b64ctx) + 1)
```

I know that the returned value will be always 48 for encoding atm. but I think it's better to have it as a function in case it got changed in the future and it's a very simple function.