### PR TITLE
Address feedback on SSLv2 ClientHello processing

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -33,7 +33,7 @@
 void RECORD_LAYER_init(RECORD_LAYER *rl, SSL *s)
 {
     rl->s = s;
-    RECORD_LAYER_set_first_record(&s->rlayer, 1);
+    RECORD_LAYER_set_first_record(&s->rlayer);
     SSL3_RECORD_clear(rl->rrec, SSL_MAX_PIPELINES);
 }
 

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -33,6 +33,7 @@
 void RECORD_LAYER_init(RECORD_LAYER *rl, SSL *s)
 {
     rl->s = s;
+    RECORD_LAYER_set_first_record(&s->rlayer, 1);
     SSL3_RECORD_clear(rl->rrec, SSL_MAX_PIPELINES);
 }
 

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -199,6 +199,9 @@ typedef struct record_layer_st {
     unsigned char read_sequence[SEQ_NUM_SIZE];
     unsigned char write_sequence[SEQ_NUM_SIZE];
 
+    /* Set to true if this is the first record in a connection */
+    unsigned int is_first_record;
+
     DTLS_RECORD_LAYER *d;
 } RECORD_LAYER;
 

--- a/ssl/record/record_locl.h
+++ b/ssl/record/record_locl.h
@@ -31,6 +31,8 @@
 #define RECORD_LAYER_reset_empty_record_count(rl) \
                                                 ((rl)->empty_record_count = 0)
 #define RECORD_LAYER_get_empty_record_count(rl) ((rl)->empty_record_count)
+#define RECORD_LAYER_is_first_record(rl)        ((rl)->is_first_record)
+#define RECORD_LAYER_set_first_record(rl, val)  ((rl)->is_first_record = (val))
 #define DTLS_RECORD_LAYER_get_r_epoch(rl)       ((rl)->d->r_epoch)
 
 __owur int ssl3_read_n(SSL *s, int n, int max, int extend, int clearold);

--- a/ssl/record/record_locl.h
+++ b/ssl/record/record_locl.h
@@ -32,7 +32,8 @@
                                                 ((rl)->empty_record_count = 0)
 #define RECORD_LAYER_get_empty_record_count(rl) ((rl)->empty_record_count)
 #define RECORD_LAYER_is_first_record(rl)        ((rl)->is_first_record)
-#define RECORD_LAYER_set_first_record(rl, val)  ((rl)->is_first_record = (val))
+#define RECORD_LAYER_set_first_record(rl)       ((rl)->is_first_record = 1)
+#define RECORD_LAYER_clear_first_record(rl)     ((rl)->is_first_record = 0)
 #define DTLS_RECORD_LAYER_get_r_epoch(rl)       ((rl)->d->r_epoch)
 
 __owur int ssl3_read_n(SSL *s, int n, int max, int extend, int clearold);

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -159,18 +159,9 @@ int ssl3_get_record(SSL *s)
             p = RECORD_LAYER_get_packet(&s->rlayer);
 
             /*
-             * Check whether this is a regular record or an SSLv2 style record.
-             * The latter can only be used in the first record of an initial
-             * ClientHello for old clients. Initial ClientHello means
-             * s->first_packet is set and s->server is true.  The first record
-             * means s->rlayer.is_first_record is true. Probably this is
-             * sufficient in itself instead of s->first_packet, but I am
-             * cautious. We check s->read_hash and s->enc_read_ctx to ensure
-             * this does not apply during renegotiation.
+             * The first record received by the server may be a V2ClientHello.
              */
-            if (s->first_packet && s->server
-                    && RECORD_LAYER_is_first_record(&s->rlayer)
-                    && s->read_hash == NULL && s->enc_read_ctx == NULL
+            if (s->server && RECORD_LAYER_is_first_record(&s->rlayer)
                     && (p[0] & 0x80) && (p[2] == SSL2_MT_CLIENT_HELLO)) {
                 /*
                  *  SSLv2 style record
@@ -342,7 +333,7 @@ int ssl3_get_record(SSL *s)
 
         /* we have pulled in a full packet so zero things */
         RECORD_LAYER_reset_packet_length(&s->rlayer);
-        RECORD_LAYER_set_first_record(&s->rlayer, 0);
+        RECORD_LAYER_clear_first_record(&s->rlayer);
     } while (num_recs < max_recs
              && rr[num_recs-1].type == SSL3_RT_APPLICATION_DATA
              && SSL_USE_EXPLICIT_IV(s)

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -162,15 +162,14 @@ int ssl3_get_record(SSL *s)
              * Check whether this is a regular record or an SSLv2 style record.
              * The latter can only be used in the first record of an initial
              * ClientHello for old clients. Initial ClientHello means
-             * s->first_packet is set and s->server is true. The first record
-             * means we've not received any data so far (s->init_num == 0) and
-             * have had no empty records. We check s->read_hash and
-             * s->enc_read_ctx to ensure this does not apply during
-             * renegotiation.
+             * s->first_packet is set and s->server is true.  The first record
+             * means s->rlayer.is_first_record is true. Probably this is
+             * sufficient in itself instead of s->first_packet, but I am
+             * cautious. We check s->read_hash and s->enc_read_ctx to ensure
+             * this does not apply during renegotiation.
              */
             if (s->first_packet && s->server
-                    && s->init_num == 0
-                    && RECORD_LAYER_get_empty_record_count(&s->rlayer) == 0
+                    && RECORD_LAYER_is_first_record(&s->rlayer)
                     && s->read_hash == NULL && s->enc_read_ctx == NULL
                     && (p[0] & 0x80) && (p[2] == SSL2_MT_CLIENT_HELLO)) {
                 /*
@@ -335,6 +334,7 @@ int ssl3_get_record(SSL *s)
 
         /* we have pulled in a full packet so zero things */
         RECORD_LAYER_reset_packet_length(&s->rlayer);
+        RECORD_LAYER_set_first_record(&s->rlayer, 0);
     } while (num_recs < max_recs
              && rr[num_recs-1].type == SSL3_RT_APPLICATION_DATA
              && SSL_USE_EXPLICIT_IV(s)

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -72,7 +72,6 @@ use constant {
     ALERT_BEFORE_SSLV2 => 4
 };
 #Test 5: Inject an SSLv2 style record format for a TLSv1.2 ClientHello
-#my $sslv2testtype = TLSV1_2_IN_SSLV2;
 my $sslv2testtype = TLSV1_2_IN_SSLV2;
 $proxy->clear();
 $proxy->filter(\&add_sslv2_filter);

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -37,7 +37,8 @@ use constant {
 #Alert descriptions
 use constant {
     AL_DESC_CLOSE_NOTIFY => 0,
-    AL_DESC_UNEXPECTED_MESSAGE => 10
+    AL_DESC_UNEXPECTED_MESSAGE => 10,
+    AL_DESC_NO_RENEGOTIATION => 100
 };
 
 my %message_type = (

--- a/util/TLSProxy/Record.pm
+++ b/util/TLSProxy/Record.pm
@@ -98,6 +98,7 @@ sub get_records
                 $content_type,
                 $version,
                 $len,
+                0,
                 $len_real,
                 $decrypt_len,
                 substr($packet, TLS_RECORD_HEADER_LENGTH, $len_real),
@@ -167,6 +168,7 @@ sub new
         $content_type,
         $version,
         $len,
+        $sslv2,
         $len_real,
         $decrypt_len,
         $data,
@@ -177,6 +179,7 @@ sub new
         content_type => $content_type,
         version => $version,
         len => $len,
+        sslv2 => $sslv2,
         len_real => $len_real,
         decrypt_len => $decrypt_len,
         data => $data,
@@ -247,7 +250,11 @@ sub reconstruct_record
     my $self = shift;
     my $data;
 
-    $data = pack('Cnn', $self->content_type, $self->version, $self->len);
+    if ($self->sslv2) {
+        $data = pack('n', $self->len | 0x8000);
+    } else {
+        $data = pack('Cnn', $self->content_type, $self->version, $self->len);
+    }
     $data .= $self->data;
 
     return $data;
@@ -268,6 +275,11 @@ sub version
 {
     my $self = shift;
     return $self->{version};
+}
+sub sslv2
+{
+    my $self = shift;
+    return $self->{sslv2};
 }
 sub len_real
 {

--- a/util/TLSProxy/ServerHello.pm
+++ b/util/TLSProxy/ServerHello.pm
@@ -56,13 +56,25 @@ sub parse
     my $comp_meth = unpack('C', substr($self->data, $ptr));
     $ptr++;
     my $extensions_len = unpack('n', substr($self->data, $ptr));
-    $ptr += 2;
+    if (!defined $extensions_len) {
+        $extensions_len = 0;
+    } else {
+        $ptr += 2;
+    }
     #For now we just deal with this as a block of data. In the future we will
     #want to parse this
-    my $extension_data = substr($self->data, $ptr);
+    my $extension_data;
+    if ($extensions_len != 0) {
+        $extension_data = substr($self->data, $ptr);
     
-    if (length($extension_data) != $extensions_len) {
-        die "Invalid extension length\n";
+        if (length($extension_data) != $extensions_len) {
+            die "Invalid extension length\n";
+        }
+    } else {
+        if (length($self->data) != $ptr) {
+            die "Invalid extension length\n";
+        }
+        $extension_data = "";
     }
     my %extensions = ();
     while (length($extension_data) >= 4) {


### PR DESCRIPTION
Feedback on the previous SSLv2 ClientHello processing fix was that it
breaks layering by reading init_num in the record layer. It also does not
detect if there was a previous non-fatal warning.

This is an alternative approach that directly tracks in the record layer
whether this is the first record.

GitHub Issue #1298