### PR TITLE
Ignore windows generated manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Ignore editor artefacts
+# Ignore editor artifacts
 /.dir-locals.el
 
 # Top level excludes
@@ -169,3 +169,7 @@ Makefile.save
 *.bak
 cscope.*
 *.d
+pod2htmd.tmp
+
+# Windows manifest files
+*.manifest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Ignore editor artifacts
+# Ignore editor artefacts
 /.dir-locals.el
 
 # Top level excludes


### PR DESCRIPTION
- Commit a95ce7f builds *.manifest files on windows -- added them to
  .gitignore.

- ignore pod -> html temp file

- fixed typo