### PR TITLE
Remove some unused options from 10-main.conf

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1755,7 +1755,7 @@ sub vms_info {
         #as               => "???",
         #debug_aflags     => "/NOOPTIMIZE/DEBUG",
         #release_aflags   => "/OPTIMIZE/NODEBUG",
-        bn_opts          => "SIXTY_FOUR_BIT RC4_INT RC4_CHUNK_LL DES_PTR BF_PTR",
+        bn_opts          => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-alpha-p32" => {
         inherit_from     => [ "vms-generic" ],
@@ -1807,7 +1807,7 @@ sub vms_info {
         #as               => "I4S",
         #debug_aflags     => "/NOOPTIMIZE/DEBUG",
         #release_aflags   => "/OPTIMIZE/NODEBUG",
-        bn_opts          => "SIXTY_FOUR_BIT RC4_INT RC4_CHUNK_LL DES_PTR BF_PTR",
+        bn_opts          => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-ia64-p32" => {
         inherit_from     => [ "vms-generic" ],


### PR DESCRIPTION
The options RC4_CHUNK_LL, DES_PTR, and BF_PTR were removed by Rich
in commit 3e9e810f2e047effb1056211794d2d12ec2b04e7 but were still
sticking around in a coupule configuration entries.

Since they're unused, remove them.