### PR TITLE
Travis: When testing installation, build in separate dir, otherwise in checkout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,15 +60,15 @@ matrix:
 
 before_script:
     - if [ -n "$DESTDIR" ]; then
-          srcdir=../_srcdist;
-          top=..;
           sh .travis-create-release.sh $TRAVIS_OS_NAME;
           tar -xvzf _srcdist.tar.gz;
           mkdir _build;
           cd _build;
+          srcdir=../_srcdist;
+          top=..;
       else
-          srcdir=.
-          top=.
+          srcdir=.;
+          top=.;
       fi
     - if [ "$CC" == i686-w64-mingw32-gcc ]; then
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
@@ -86,12 +86,10 @@ before_script:
 
 script:
     - if [ -n "$DESTDIR" ]; then
-          srcdir=../_srcdist;
-          top=..;
           cd _build;
+          top=..;
       else
-          srcdir=.
-          top=.
+          top=.;
       fi
     - make update
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,26 +59,40 @@ matrix:
           compiler: gcc
 
 before_script:
-    - sh .travis-create-release.sh $TRAVIS_OS_NAME
-    - tar -xvzf _srcdist.tar.gz
-    - mkdir _build;
-    - cd _build;
+    - if [ -n "$DESTDIR" ]; then
+          srcdir=../_srcdist;
+          top=..;
+          sh .travis-create-release.sh $TRAVIS_OS_NAME;
+          tar -xvzf _srcdist.tar.gz;
+          mkdir _build;
+          cd _build;
+      else
+          srcdir=.
+          top=.
+      fi
     - if [ "$CC" == i686-w64-mingw32-gcc ]; then
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
-          ../_srcdist/Configure mingw $CONFIG_OPTS -Wno-pedantic-ms-format;
+          $srcdir/Configure mingw $CONFIG_OPTS -Wno-pedantic-ms-format;
       elif [ "$CC" == x86_64-w64-mingw32-gcc ]; then
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
-          ../_srcdist/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
+          $srcdir/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
       else
           if which ccache >/dev/null && [ "$CC" != clang-3.6 ]; then
               CC="ccache $CC";
           fi;
-          ../_srcdist/config $CONFIG_OPTS;
+          $srcdir/config $CONFIG_OPTS;
       fi
-    - cd ..
+    - cd $top
 
 script:
-    - cd _build;
+    - if [ -n "$DESTDIR" ]; then
+          srcdir=../_srcdist;
+          top=..;
+          cd _build;
+      else
+          srcdir=.
+          top=.
+      fi
     - make update
     - make
     - if [ -z "$BUILDONLY" ]; then
@@ -93,7 +107,7 @@ script:
           mkdir "../$DESTDIR";
           make install install_docs DESTDIR="../$DESTDIR";
       fi
-    - cd ..
+    - cd $top
 
 notifications:
     email:


### PR DESCRIPTION
The rationale is that installation from a tarball is a common task
that everyone performs.  For all other builds, we do specialised
tests, and might as well build them directly in the checkout, which
also gives us fuzz corpora.
