### PR TITLE
Add a coverage target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c
 cache: ccache
 
+before_install:
+    - pip install --user cpp-coveralls
+
 addons:
     apt:
         packages:
@@ -25,12 +28,14 @@ compiler:
 env:
     - CONFIG_OPTS="" DESTDIR="_install"
     - CONFIG_OPTS="--debug no-shared enable-crypto-mdebug enable-rc5 enable-md2"
-    - CONFIG_OPTS="--strict-warnings no-shared" BUILDONLY="yes"
     - CONFIG_OPTS="no-pic --strict-warnings" BUILDONLY="yes"
     - CONFIG_OPTS="no-engine no-shared --strict-warnings" BUILDONLY="yes"
 
 matrix:
     include:
+        - os: linux
+          compiler: gcc
+          env: CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers" COVERALLS="yes"
         - os: linux
           compiler: clang-3.6
           env: CONFIG_OPTS="no-shared enable-asan"
@@ -106,6 +111,11 @@ script:
           make install install_docs DESTDIR="../$DESTDIR";
       fi
     - cd $top
+
+after_success:
+    - if [ -n "$COVERALLS" ]; then
+          coveralls -b .;
+      fi;
 
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
 
 after_success:
     - if [ -n "$COVERALLS" ]; then
-          coveralls -b .;
+          coveralls -b . --gcov-options '\-lp';
       fi;
 
 notifications:


### PR DESCRIPTION
Run tests with coverage and report to coveralls.io

For simplicity, this currently only adds a single target in a
configuration that attempts to maximize coverage. The true CI coverage
from all the various builds may be a little larger.

The coverage run has the following configuration:
- no-asm: since we can't track asm coverage anyway, might as well measure the
  non-asm code coverage.
- Enable various disabled-by-default options:
  - rc5
  - md2
  - ec_nistp_64_gcc_128
  - ssl3
  - ssl3-method
  - weak-ssl-ciphers

Finally, observe that no-pic implies no-shared, and therefore running
both builds in the matrix is redundant.