### PR TITLE
Move the building of test/buildtest_*. to be done unconditionally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,23 @@ matrix:
           compiler: clang-3.6
           env: CONFIG_OPTS="no-shared no-asm enable-asan enable-rc5 enable-md2"
         - os: linux
+          compiler: clang-3.6
+          env: CONFIG_OPTS="no-stdio"
+        - os: linux
           compiler: gcc-5
           env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC"
         - os: linux
           compiler: i686-w64-mingw32-gcc
           env: CONFIG_OPTS="no-pic"
         - os: linux
+          compiler: i686-w64-mingw32-gcc
+          env: CONFIG_OPTS="no-stdio"
+        - os: linux
           compiler: x86_64-w64-mingw32-gcc
           env: CONFIG_OPTS="no-pic"
+        - os: linux
+          compiler: x86_64-w64-mingw32-gcc
+          env: CONFIG_OPTS="no-stdio"
     exclude:
         - os: linux
           compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - CONFIG_OPTS="--strict-warnings no-shared" BUILDONLY="yes"
     - CONFIG_OPTS="no-pic --strict-warnings" BUILDONLY="yes"
     - CONFIG_OPTS="no-engine no-shared --strict-warnings" BUILDONLY="yes"
+    - CONFIG_OPTS="no-stdio --strict-warnings" BUILDONLY="yes"
 
 matrix:
     include:

--- a/test/build.info
+++ b/test/build.info
@@ -262,7 +262,13 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bioprinttest]=bioprinttest.c
   INCLUDE[bioprinttest]=../include
   DEPEND[bioprinttest]=../libcrypto
-  {-
+
+  SOURCE[sslapitest]=sslapitest.c ssltestlib.c testutil.c
+  INCLUDE[sslapitest]=../include
+  DEPEND[sslapitest]=../libcrypto ../libssl
+ENDIF
+
+{-
    use File::Spec::Functions;
    use File::Basename;
    use if $^O ne "VMS", 'File::Glob' => qw/glob/;
@@ -286,9 +292,4 @@ IF[{- !$disabled{tests} -}]
   DEPEND[buildtest_$name]=../libssl ../libcrypto
 _____
    }
-  -}
-
-  SOURCE[sslapitest]=sslapitest.c ssltestlib.c testutil.c
-  INCLUDE[sslapitest]=../include
-  DEPEND[sslapitest]=../libcrypto ../libssl
-ENDIF
+-}

--- a/test/generate_buildtest.pl
+++ b/test/generate_buildtest.pl
@@ -11,6 +11,7 @@ use warnings;
 
 # First argument is name;
 my $name = shift @ARGV;
+my $name_uc = uc $name;
 # All other arguments are ignored for now
 
 print <<"_____";
@@ -18,7 +19,13 @@ print <<"_____";
  * Generated with test/generate_buildtest.pl, to check that such a simple
  * program builds.
  */
-#include <openssl/$name.h>
+#include <openssl/opensslconf.h>
+#ifndef OPENSSL_NO_STDIO
+# include <stdio.h>
+#endif
+#ifndef OPENSSL_NO_${name_uc}
+# include <openssl/$name.h>
+#endif
 
 int main()
 {


### PR DESCRIPTION
These were guarded by $disabled{tests}.  However, 'tests' is disabled
if we configure 'no-stdio', which means that we don't detect the lack
of OPENSSL_NO_STDIO guards in our public header files.  So we move the
generation and build of test/buildtest_*.c to be unconditional.
