### PR TITLE
satsub64be() fixes

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -105,6 +105,16 @@
                          l|=((unsigned long)(*((c)++)))<< 8, \
                          l|=((unsigned long)(*((c)++))))
 
+# define n2l8(c,l)       (l =((uint64_t)(*((c)++)))<<56, \
+                         l|=((uint64_t)(*((c)++)))<<48, \
+                         l|=((uint64_t)(*((c)++)))<<40, \
+                         l|=((uint64_t)(*((c)++)))<<32, \
+                         l|=((uint64_t)(*((c)++)))<<24, \
+                         l|=((uint64_t)(*((c)++)))<<16, \
+                         l|=((uint64_t)(*((c)++)))<< 8, \
+                         l|=((uint64_t)(*((c)++))))
+
+
 # define l2n(l,c)        (*((c)++)=(unsigned char)(((l)>>24)&0xff), \
                          *((c)++)=(unsigned char)(((l)>>16)&0xff), \
                          *((c)++)=(unsigned char)(((l)>> 8)&0xff), \


### PR DESCRIPTION
In PR #1296 I added a minimal fix for `satsub64be()` since it was already fairly much outside the scope of what I was trying to do — it was broken even for standard DTLS.

It warrants closer attention though. Here's a cleanup for both the special-case 64-bit version, and the fallback. The former can work for little-endian too and the latter doesn't need to be bytewise; we can do it as two 32-bit values instead.

I checked with GCC 6.1.1 on Fedora, and at least for x86_64 the compiler is clever enough to spot the pattern of bytewise loads-and-shifts in `n2l8()` and emit a single `movbe` instruction.

