### PR TITLE
Removes CTLOG_new_null from the CT public API

### DIFF
--- a/crypto/ct/ct_err.c
+++ b/crypto/ct/ct_err.c
@@ -22,7 +22,6 @@ static ERR_STRING_DATA CT_str_functs[] = {
     {ERR_FUNC(CT_F_CTLOG_NEW), "CTLOG_new"},
     {ERR_FUNC(CT_F_CTLOG_NEW_FROM_BASE64), "CTLOG_new_from_base64"},
     {ERR_FUNC(CT_F_CTLOG_NEW_FROM_CONF), "ctlog_new_from_conf"},
-    {ERR_FUNC(CT_F_CTLOG_NEW_NULL), "CTLOG_new_null"},
     {ERR_FUNC(CT_F_CTLOG_STORE_LOAD_CTX_NEW), "ctlog_store_load_ctx_new"},
     {ERR_FUNC(CT_F_CTLOG_STORE_LOAD_FILE), "CTLOG_STORE_load_file"},
     {ERR_FUNC(CT_F_CTLOG_STORE_LOAD_LOG), "ctlog_store_load_log"},

--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -234,10 +234,12 @@ end:
  */
 CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name)
 {
-    CTLOG *ret = CTLOG_new_null();
+    CTLOG *ret = OPENSSL_zalloc(sizeof(*ret));
 
-    if (ret == NULL)
+    if (ret == NULL) {
+        CTerr(CT_F_CTLOG_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
 
     ret->name = OPENSSL_strdup(name);
     if (ret->name == NULL) {
@@ -253,16 +255,6 @@ CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name)
 err:
     CTLOG_free(ret);
     return NULL;
-}
-
-CTLOG *CTLOG_new_null(void)
-{
-    CTLOG *ret = OPENSSL_zalloc(sizeof(*ret));
-
-    if (ret == NULL)
-        CTerr(CT_F_CTLOG_NEW_NULL, ERR_R_MALLOC_FAILURE);
-
-    return ret;
 }
 
 /* Frees CT log and associated structures */

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -413,12 +413,6 @@ __owur int o2i_SCT_signature(SCT *sct, const unsigned char **in, size_t len);
 CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
 
 /*
- * Creates a new, blank CT log instance.
- * Should be deleted by the caller using CTLOG_free when no longer needed.
- */
-CTLOG *CTLOG_new_null(void);
-
-/*
  * Creates a new CT |ct_log| instance with the given base64 public_key and |name|.
  * Should be deleted by the caller using CTLOG_free when no longer needed.
  */


### PR DESCRIPTION
This is an entirely useless function, given that CTLOG is publicly immutable.

Therefore, it should be safe to remove - no one could conceivably be using it.