### PR TITLE
Makes CTLOG_new_from_base64 always return 0 on failure

### DIFF
--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -149,7 +149,7 @@ int CTLOG_new_from_base64(CTLOG **ct_log, const char *pkey_base64, const char *n
     *ct_log = CTLOG_new(pkey, name);
     if (*ct_log == NULL) {
         EVP_PKEY_free(pkey);
-        return -1;
+        return 0;
     }
 
     return 1;

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -408,6 +408,7 @@ __owur int o2i_SCT_signature(SCT *sct, const unsigned char **in, size_t len);
 
 /*
  * Creates a new CT log instance with the given |public_key| and |name|.
+ * Returns NULL if malloc fails or if |public_key| cannot be converted to DER.
  * Should be deleted by the caller using CTLOG_free when no longer needed.
  */
 CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
@@ -419,7 +420,9 @@ CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
 CTLOG *CTLOG_new_null(void);
 
 /*
- * Creates a new CT |ct_log| instance with the given base64 public_key and |name|.
+ * Creates a new CTLOG instance with the base64-encoded SubjectPublicKeyInfo DER
+ * in |pkey_base64|. The |name| is a string to help users identify this log.
+ * Returns 1 on success, 0 on failure.
  * Should be deleted by the caller using CTLOG_free when no longer needed.
  */
 int CTLOG_new_from_base64(CTLOG ** ct_log,


### PR DESCRIPTION
In one failure case, it used to return -1. That failure case (CTLOG_new() returning NULL) was not usefully distinct from all of the other failure cases.