### PR TITLE
fix "info" spelling

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -508,7 +508,7 @@ debug_logicals :
 
 # Building targets ###################################################
 
-configdata.pm : {- join(" ", sourcefile("Configurations", "descrip.mms.tmpl"), sourcefile("Configurations", "common.tmpl")) -} $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{build_infos}}) -}
+configdata.pm : {- join(" ", sourcefile("Configurations", "descrip.mms.tmpl"), sourcefile("Configurations", "common.tmpl")) -} $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{build_info}}) -}
         @ WRITE SYS$OUTPUT "Reconfiguring..."
         perl $(SRCDIR)Configure reconf
         @ WRITE SYS$OUTPUT "*************************************************"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -830,7 +830,7 @@ openssl.pc:
 	    echo 'Version: '$(VERSION); \
 	    echo 'Requires: libssl libcrypto' ) > openssl.pc
 
-configdata.pm: {- $config{build_file_template} -} $(SRCDIR)/Configurations/common.tmpl $(SRCDIR)/Configure $(SRCDIR)/config {- join(" ", @{$config{build_infos}}) -}
+configdata.pm: {- $config{build_file_template} -} $(SRCDIR)/Configurations/common.tmpl $(SRCDIR)/Configure $(SRCDIR)/config {- join(" ", @{$config{build_info}}) -}
 	@echo "Detected changed: $?"
 	@echo "Reconfiguring..."
 	$(SRCDIR)/Configure reconf

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -322,7 +322,7 @@ uninstall_html_docs:
 
 # Building targets ###################################################
 
-configdata.pm: "{- $config{build_file_template} -}" "$(SRCDIR)\Configurations\common.tmpl" "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{build_infos}}) -}
+configdata.pm: "{- $config{build_file_template} -}" "$(SRCDIR)\Configurations\common.tmpl" "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{build_info}}) -}
 	@echo "Detected changed: $?"
 	@echo "Reconfiguring..."
 	"$(PERL)" "$(SRCDIR)\Configure" reconf

--- a/Configure
+++ b/Configure
@@ -1343,23 +1343,23 @@ if ($builder eq "unified") {
         return $res;
     }
 
-    my @build_infos = ( [ ".", "build.info" ] );
+    my @build_info = ( [ ".", "build.info" ] );
     foreach (@{$config{dirs}}) {
-        push @build_infos, [ $_, "build.info" ]
+        push @build_info, [ $_, "build.info" ]
             if (-f catfile($srcdir, $_, "build.info"));
     }
     foreach (@{$config{sdirs}}) {
-        push @build_infos, [ catdir("crypto", $_), "build.info" ]
+        push @build_info, [ catdir("crypto", $_), "build.info" ]
             if (-f catfile($srcdir, "crypto", $_, "build.info"));
     }
     foreach (@{$config{engdirs}}) {
-        push @build_infos, [ catdir("engines", $_), "build.info" ]
+        push @build_info, [ catdir("engines", $_), "build.info" ]
             if (-f catfile($srcdir, "engines", $_, "build.info"));
     }
 
-    $config{build_infos} = [ ];
+    $config{build_info} = [ ];
 
-    foreach (@build_infos) {
+    foreach (@build_info) {
         my $sourced = catdir($srcdir, $_->[0]);
         my $buildd = catdir($blddir, $_->[0]);
 
@@ -1389,7 +1389,7 @@ if ($builder eq "unified") {
         my %sharednames = ();
         my %generate = ();
 
-        push @{$config{build_infos}}, catfile(abs2rel($sourced, $blddir), $f);
+        push @{$config{build_info}}, catfile(abs2rel($sourced, $blddir), $f);
         my $template = Text::Template->new(TYPE => 'FILE',
                                            SOURCE => catfile($sourced, $f));
         die "Something went wrong with $sourced/$f: $!\n" unless $template;


### PR DESCRIPTION
fix typical spelling error of uncountable words like information

more reading:
http://dictionary.cambridge.org/grammar/british-grammar/nouns-countable-and-uncountable

patch produced with:
$ grep -r build_infos . -l|xargs sed -i s/build_infos/build_info/g
