### PR TITLE
Fix af_alg engine failure on 32 bit architectures.

### DIFF
--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -230,7 +230,7 @@ int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
     memset(cb, '\0', sizeof(*cb));
     cb->aio_fildes = sfd;
     cb->aio_lio_opcode = IOCB_CMD_PREAD;
-    cb->aio_buf = (uint64_t)buf;
+    cb->aio_buf = (uint64_t)(unsigned long)buf;
     cb->aio_offset = 0;
     cb->aio_data = 0;
     cb->aio_nbytes = len;

--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -230,6 +230,10 @@ int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
     memset(cb, '\0', sizeof(*cb));
     cb->aio_fildes = sfd;
     cb->aio_lio_opcode = IOCB_CMD_PREAD;
+    /*
+     * The pointer has to be converted to unsigned value first to avoid
+     * sign extension on cast to 64 bit value
+     */
     cb->aio_buf = (uint64_t)(unsigned long)buf;
     cb->aio_offset = 0;
     cb->aio_data = 0;

--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -230,11 +230,15 @@ int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
     memset(cb, '\0', sizeof(*cb));
     cb->aio_fildes = sfd;
     cb->aio_lio_opcode = IOCB_CMD_PREAD;
-    /*
-     * The pointer has to be converted to unsigned value first to avoid
-     * sign extension on cast to 64 bit value
-     */
-    cb->aio_buf = (uint64_t)(unsigned long)buf;
+    if (sizeof(buf) != sizeof(cb->aio_buf)) {
+        /*
+         * The pointer has to be converted to 32 bit unsigned value first
+         * to avoid sign extension on cast to 64 bit value
+         */
+        cb->aio_buf = (uint64_t)(unsigned long)buf;
+    } else {
+        cb->aio_buf = (uint64_t)buf;
+    }
     cb->aio_offset = 0;
     cb->aio_data = 0;
     cb->aio_nbytes = len;


### PR DESCRIPTION
Add extra cast to unsigned long to avoid sign extension when
converting pointer to 64 bit data.