### PR TITLE
SSL test ctx: fix tests

### DIFF
--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -264,6 +264,7 @@ static int test_good_configuration()
 
 static const char *bad_configurations[] = {
     "ssltest_unknown_option",
+    "ssltest_wrong_section",
     "ssltest_unknown_expected_result",
     "ssltest_unknown_alert",
     "ssltest_unknown_protocol",

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -30,22 +30,37 @@ ALPNProtocols = baz
 [ssltest_unknown_option]
 UnknownOption = Foo
 
+[ssltest_wrong_section]
+server = ssltest_wrong_section_server
+
+[ssltest_wrong_section_server]
+VerifyCallback = RejectAll
+
 [ssltest_unknown_expected_result]
 ExpectedResult = Foo
 
 [ssltest_unknown_alert]
-ServerAlert = Foo
+ExpectedServerAlert = Foo
 
 [ssltest_unknown_protocol]
 Protocol = Foo
 
 [ssltest_unknown_verify_callback]
-ClientVerifyCallback = Foo
+client = ssltest_unknown_verify_callback_client
+
+[ssltest_unknown_verify_callback_client]
+VerifyCallback = Foo
 
 [ssltest_unknown_servername]
+client = ssltest_unknown_servername_client
+
+[ssltest_unknown_servername_client]
 ServerName = Foo
 
 [ssltest_unknown_servername_callback]
+server = ssltest_unknown_servername_server
+
+[ssltest_unknown_servername_server]
 ServerNameCallback = Foo
 
 [ssltest_unknown_session_ticket_expected]


### PR DESCRIPTION
Some failure tests were failing for the wrong reason after the CTX
refactoring. Update those tests.