### PR TITLE
Add support for rsaesOaep keys

### DIFF
--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -38,6 +38,9 @@ static const EVP_PKEY_ASN1_METHOD *standard_methods[] = {
 #ifndef OPENSSL_NO_CMAC
     &cmac_asn1_meth,
 #endif
+#ifndef OPENSSL_NO_RSA
+    &rsa_asn1_meths[2],
+#endif
 #ifndef OPENSSL_NO_DH
     &dhx_asn1_meth
 #endif

--- a/crypto/include/internal/asn1_int.h
+++ b/crypto/include/internal/asn1_int.h
@@ -62,7 +62,7 @@ extern const EVP_PKEY_ASN1_METHOD dhx_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD dsa_asn1_meths[5];
 extern const EVP_PKEY_ASN1_METHOD eckey_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD hmac_asn1_meth;
-extern const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[2];
+extern const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[3];
 
 /*
  * These are used internally in the ASN1_OBJECT to keep track of whether the

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -827,7 +827,7 @@ static int rsa_cms_encrypt(CMS_RecipientInfo *ri)
 }
 #endif
 
-const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[2] = {
+const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[3] = {
     {
      EVP_PKEY_RSA,
      EVP_PKEY_RSA,
@@ -861,6 +861,11 @@ const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[2] = {
 
     {
      EVP_PKEY_RSA2,
+     EVP_PKEY_RSA,
+     ASN1_PKEY_ALIAS},
+
+    {
+     EVP_PKEY_RSA3,
      EVP_PKEY_RSA,
      ASN1_PKEY_ALIAS}
 };

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -40,6 +40,7 @@
 # define EVP_PKEY_NONE   NID_undef
 # define EVP_PKEY_RSA    NID_rsaEncryption
 # define EVP_PKEY_RSA2   NID_rsa
+# define EVP_PKEY_RSA3   NID_rsaesOaep
 # define EVP_PKEY_DSA    NID_dsa
 # define EVP_PKEY_DSA1   NID_dsa_2
 # define EVP_PKEY_DSA2   NID_dsaWithSHA

--- a/test/build.info
+++ b/test/build.info
@@ -16,7 +16,7 @@ IF[{- !$disabled{tests} -}]
           packettest asynctest secmemtest srptest memleaktest \
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
-          bioprinttest sslapitest
+          bioprinttest sslapitest pkey_asn1_test
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include
@@ -266,6 +266,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[sslapitest]=sslapitest.c ssltestlib.c testutil.c
   INCLUDE[sslapitest]=../include
   DEPEND[sslapitest]=../libcrypto ../libssl
+
+  SOURCE[pkey_asn1_test]=pkey_asn1_test.c
+  INCLUDE[pkey_asn1_test]=../crypto/include ../include
+  DEPEND[pkey_asn1_test]=../libcrypto
 ENDIF
 
 {-

--- a/test/pkey_asn1_test.c
+++ b/test/pkey_asn1_test.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Check ordering in standard_methods array */
+
+#include <stdio.h>
+#include <openssl/asn1t.h>
+#include <openssl/x509.h>
+#include <internal/asn1_int.h>
+
+int
+main(int argc, char *argv[])
+{
+	int num = EVP_PKEY_asn1_get_count();
+	int i;
+	const EVP_PKEY_ASN1_METHOD *prev = NULL;
+	int result = 0;
+
+	for (i = 0; i < num; i++) {
+		const EVP_PKEY_ASN1_METHOD *cur = EVP_PKEY_asn1_get0(i);
+		if (prev && prev->pkey_id > cur->pkey_id) {
+			printf("standard_methods[%d] method %s is out of order\n",
+			       i - 1, OBJ_nid2sn(prev->pkey_id));
+			result = 1;
+		}
+		prev = cur;
+	}
+
+	if (result)
+		printf("bsearch ordering test of standard_methods array failed\n");
+
+	return result;
+}


### PR DESCRIPTION
rsaesOaep keys are identical to standard rsa keys except they have a few extra algorithm parameters, so we should be able to import and parse them.  The standard_methods array (in which all key support is added) mujst be in sort order, so add a test to check for that as well.

Signed-off-by: James Bottomley jejb@linux.vnet.ibm.com
