### PR TITLE
Don't attempt to load the CT log list with no-ec

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -376,7 +376,8 @@ static void configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
                                               ticket_key_len) == 1);
     OPENSSL_free(ticket_keys);
 
-#ifndef OPENSSL_NO_CT
+    /* The default log list includes EC keys, so CT can't work without EC. */
+#if !defined(OPENSSL_NO_CT) && !defined(OPENSSL_NO_EC)
     TEST_check(SSL_CTX_set_default_ctlog_list_file(client_ctx));
     switch (extra->client.ct_validation) {
     case SSL_TEST_CT_VALIDATION_PERMISSIVE:

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -42,6 +42,7 @@ my $no_tls = alldisabled(available_protocols("tls"));
 my $no_dtls = alldisabled(available_protocols("dtls"));
 my $no_npn = disabled("nextprotoneg");
 my $no_ct = disabled("ct");
+my $no_ec = disabled("ec");
 
 my %conf_dependent_tests = (
   "02-protocol-version.conf" => !$is_default_tls,
@@ -57,7 +58,7 @@ my %skip = (
   "08-npn.conf" => $no_tls || $no_npn,
   "10-resumption.conf" => disabled("tls1_1") || disabled("tls1_2"),
   "11-dtls_resumption.conf" => disabled("dtls1") || disabled("dtls1_2"),
-  "12-ct.conf" => $no_tls || $no_ct,
+  "12-ct.conf" => $no_tls || $no_ct || $no_ec,
 );
 
 foreach my $conf (@conf_files) {


### PR DESCRIPTION
In practice, CT isn't really functional without EC anyway, as most logs
use EC keys. So, skip loading the log list with no-ec, and skip CT tests
completely in that conf.