### PR TITLE
Never return -1 from BN_exp

### DIFF
--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -46,7 +46,7 @@ int BN_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
     if (BN_get_flags(p, BN_FLG_CONSTTIME) != 0) {
         /* BN_FLG_CONSTTIME only supported by BN_mod_exp_mont() */
         BNerr(BN_F_BN_EXP, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-        return -1;
+        return 0;
     }
 
     BN_CTX_start(ctx);
@@ -177,7 +177,7 @@ int BN_mod_exp_recp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     if (BN_get_flags(p, BN_FLG_CONSTTIME) != 0) {
         /* BN_FLG_CONSTTIME only supported by BN_mod_exp_mont() */
         BNerr(BN_F_BN_MOD_EXP_RECP, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-        return -1;
+        return 0;
     }
 
     bits = BN_num_bits(p);
@@ -1123,7 +1123,7 @@ int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,
     if (BN_get_flags(p, BN_FLG_CONSTTIME) != 0) {
         /* BN_FLG_CONSTTIME only supported by BN_mod_exp_mont() */
         BNerr(BN_F_BN_MOD_EXP_MONT_WORD, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-        return -1;
+        return 0;
     }
 
     bn_check_top(p);
@@ -1254,7 +1254,7 @@ int BN_mod_exp_simple(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     if (BN_get_flags(p, BN_FLG_CONSTTIME) != 0) {
         /* BN_FLG_CONSTTIME only supported by BN_mod_exp_mont() */
         BNerr(BN_F_BN_MOD_EXP_SIMPLE, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-        return -1;
+        return 0;
     }
 
     bits = BN_num_bits(p);


### PR DESCRIPTION
The return code of `BN_exp`, `BN_mod_exp` is documented as 0. However it might return -1 in the cases below which can happen if BN is not correct. This is an issue for example in ` DSA_generate_key` that relies on that return value.

This is actually not a theoretical issue as it happened when I was playing with DSA in PHP openssl ext:

https://github.com/php/php-src/blob/c3c90abb17017af83133f57ec5d7663c0b33fdff/ext/openssl/tests/bug72336.phpt

The problem was that we expect binary value - BN_bin2bn is used on the string (meaning user forgot to call hex2bin). What happened is that `DSA_generate_key` returned 1 (success) but in fact priv key wasn't generated. Currently I have to do this after porting to 1.1 which is a bit messy.

https://github.com/php/php-src/blob/c3c90abb17017af83133f57ec5d7663c0b33fdff/ext/openssl/openssl.c#L4077-L4082

I understand that it might not be good to fix it in 1.0.2 due to BC break but 1.1 would be good IMHO.