### PR TITLE
Fix compilation when using MASM on x86

### DIFF
--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -89,7 +89,7 @@ TITLE	$_[0].asm
 IF \@Version LT 800
 ECHO MASM version 8.00 or later is strongly recommended.
 ENDIF
-.486
+.686
 .MODEL	FLAT
 OPTION	DOTNAME
 IF \@Version LT 800


### PR DESCRIPTION
The generated asm code from x86cpuid.pl contains CMOVE instructions
which are only available on i686 and later CPUs.

Without this patch, ml.exe fails when compiling that file.