### PR TITLE
Revert "Useless allocation"

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1547,6 +1547,7 @@ int speed_main(int argc, char **argv)
         loopargs[i].buf = loopargs[i].buf_malloc + misalign;
         loopargs[i].buf2 = loopargs[i].buf2_malloc + misalign;
         loopargs[i].siglen = app_malloc(sizeof(unsigned int), "signature length");
+        *(loopargs[i].siglen) = 0;
 #ifndef OPENSSL_NO_EC
         loopargs[i].secret_a = app_malloc(MAX_ECDH_SIZE, "ECDH secret a");
         loopargs[i].secret_b = app_malloc(MAX_ECDH_SIZE, "ECDH secret b");

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -154,7 +154,7 @@ typedef struct loopargs_st {
     unsigned char *buf2;
     unsigned char *buf_malloc;
     unsigned char *buf2_malloc;
-    unsigned int siglen;
+    unsigned int *siglen;
 #ifndef OPENSSL_NO_RSA
     RSA *rsa_key[RSA_NUM];
 #endif
@@ -914,7 +914,7 @@ static int RSA_sign_loop(void *args)
     loopargs_t *tempargs = (loopargs_t *)args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
-    unsigned int *rsa_num = &tempargs->siglen;
+    unsigned int *rsa_num = tempargs->siglen;
     RSA **rsa_key = tempargs->rsa_key;
     int ret, count;
     for (count = 0; COND(rsa_c[testnum][0]); count++) {
@@ -934,7 +934,7 @@ static int RSA_verify_loop(void *args)
     loopargs_t *tempargs = (loopargs_t *)args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
-    unsigned int rsa_num = tempargs->siglen;
+    unsigned int rsa_num = *(tempargs->siglen);
     RSA **rsa_key = tempargs->rsa_key;
     int ret, count;
     for (count = 0; COND(rsa_c[testnum][1]); count++) {
@@ -958,7 +958,7 @@ static int DSA_sign_loop(void *args)
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     DSA **dsa_key = tempargs->dsa_key;
-    unsigned int *siglen = &tempargs->siglen;
+    unsigned int *siglen = tempargs->siglen;
     int ret, count;
     for (count = 0; COND(dsa_c[testnum][0]); count++) {
         ret = DSA_sign(0, buf, 20, buf2, siglen, dsa_key[testnum]);
@@ -978,7 +978,7 @@ static int DSA_verify_loop(void *args)
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     DSA **dsa_key = tempargs->dsa_key;
-    unsigned int siglen = tempargs->siglen;
+    unsigned int siglen = *(tempargs->siglen);
     int ret, count;
     for (count = 0; COND(dsa_c[testnum][1]); count++) {
         ret = DSA_verify(0, buf, 20, buf2, siglen, dsa_key[testnum]);
@@ -1001,7 +1001,7 @@ static int ECDSA_sign_loop(void *args)
     unsigned char *buf = tempargs->buf;
     EC_KEY **ecdsa = tempargs->ecdsa;
     unsigned char *ecdsasig = tempargs->buf2;
-    unsigned int *ecdsasiglen = &tempargs->siglen;
+    unsigned int *ecdsasiglen = tempargs->siglen;
     int ret, count;
     for (count = 0; COND(ecdsa_c[testnum][0]); count++) {
         ret = ECDSA_sign(0, buf, 20,
@@ -1022,7 +1022,7 @@ static int ECDSA_verify_loop(void *args)
     unsigned char *buf = tempargs->buf;
     EC_KEY **ecdsa = tempargs->ecdsa;
     unsigned char *ecdsasig = tempargs->buf2;
-    unsigned int ecdsasiglen = tempargs->siglen;
+    unsigned int ecdsasiglen = *(tempargs->siglen);
     int ret, count;
     for (count = 0; COND(ecdsa_c[testnum][1]); count++) {
         ret = ECDSA_verify(0, buf, 20, ecdsasig, ecdsasiglen,
@@ -1546,6 +1546,7 @@ int speed_main(int argc, char **argv)
         /* Align the start of buffers on a 64 byte boundary */
         loopargs[i].buf = loopargs[i].buf_malloc + misalign;
         loopargs[i].buf2 = loopargs[i].buf2_malloc + misalign;
+        loopargs[i].siglen = app_malloc(sizeof(unsigned int), "signature length");
 #ifndef OPENSSL_NO_EC
         loopargs[i].secret_a = app_malloc(MAX_ECDH_SIZE, "ECDH secret a");
         loopargs[i].secret_b = app_malloc(MAX_ECDH_SIZE, "ECDH secret b");
@@ -2312,7 +2313,7 @@ int speed_main(int argc, char **argv)
             continue;
         for (i = 0; i < loopargs_len; i++) {
             st = RSA_sign(NID_md5_sha1, loopargs[i].buf, 36, loopargs[i].buf2,
-                          &loopargs[i].siglen, loopargs[i].rsa_key[testnum]);
+                          loopargs[i].siglen, loopargs[i].rsa_key[testnum]);
             if (st == 0)
                 break;
         }
@@ -2338,7 +2339,7 @@ int speed_main(int argc, char **argv)
 
         for (i = 0; i < loopargs_len; i++) {
             st = RSA_verify(NID_md5_sha1, loopargs[i].buf, 36, loopargs[i].buf2,
-                            loopargs[i].siglen, loopargs[i].rsa_key[testnum]);
+                            *(loopargs[i].siglen), loopargs[i].rsa_key[testnum]);
             if (st <= 0)
                 break;
         }
@@ -2384,7 +2385,7 @@ int speed_main(int argc, char **argv)
         /* DSA_sign_setup(dsa_key[testnum],NULL); */
         for (i = 0; i < loopargs_len; i++) {
             st = DSA_sign(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                          &loopargs[i].siglen, loopargs[i].dsa_key[testnum]);
+                          loopargs[i].siglen, loopargs[i].dsa_key[testnum]);
             if (st == 0)
                 break;
         }
@@ -2409,7 +2410,7 @@ int speed_main(int argc, char **argv)
 
         for (i = 0; i < loopargs_len; i++) {
             st = DSA_verify(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                            loopargs[i].siglen, loopargs[i].dsa_key[testnum]);
+                            *(loopargs[i].siglen), loopargs[i].dsa_key[testnum]);
             if (st <= 0)
                 break;
         }
@@ -2465,7 +2466,7 @@ int speed_main(int argc, char **argv)
                 /* Perform ECDSA signature test */
                 EC_KEY_generate_key(loopargs[i].ecdsa[testnum]);
                 st = ECDSA_sign(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                                &loopargs[i].siglen, loopargs[i].ecdsa[testnum]);
+                                loopargs[i].siglen, loopargs[i].ecdsa[testnum]);
                 if (st == 0)
                     break;
             }
@@ -2493,7 +2494,7 @@ int speed_main(int argc, char **argv)
             /* Perform ECDSA verification test */
             for (i = 0; i < loopargs_len; i++) {
                 st = ECDSA_verify(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                                  loopargs[i].siglen, loopargs[i].ecdsa[testnum]);
+                                  *(loopargs[i].siglen), loopargs[i].ecdsa[testnum]);
                 if (st != 1)
                     break;
             }
@@ -2761,6 +2762,7 @@ int speed_main(int argc, char **argv)
     for (i = 0; i < loopargs_len; i++) {
         OPENSSL_free(loopargs[i].buf_malloc);
         OPENSSL_free(loopargs[i].buf2_malloc);
+        OPENSSL_free(loopargs[i].siglen);
 
 #ifndef OPENSSL_NO_RSA
         for (k = 0; k < RSA_NUM; k++)


### PR DESCRIPTION
The memory allocation of siglen in a separate buffer is actually
required to run speed in async mode.

Removing the allocation causes failures with DSA and ECDSA

This reverts commit 0930e07d1eb522e663abe543ee865a508749946e.


## More info

We observed a failure when running speed with async jobs in the latest beta release.

```
> openssl speed -elapsed -async_jobs 1 dsa512
You have chosen to measure elapsed time instead of user CPU time.
Doing 512 bit sign dsa's for 10s: 70486 512 bit DSA signs in 10.00s
DSA verify failure.  No DSA verify will be done.
OpenSSL 1.1.0-pre6 (beta) 4 Aug 2016
built on: reproducible build, date unspecified
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr)
compiler: gcc -DDSO_DLFCN -DHAVE_DLFCN_H -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib64/engines-1.1\""  -Wa,--noexecstack
```

I believe that this is caused by the following commit: https://github.com/openssl/openssl/commit/0930e07d1eb522e663abe543ee865a508749946e

The changes were not necessary and the allocation of `siglen` in a separate buffer is actually required for the async jobs to work correctly.

After this commit the `siglen` is stored directly in `tempargs`.
When we start the `ASYNC_JOB` the struct is copied into the new execution context and all the changes done to siglen are visible only inside the `ASYNC_JOB`.

When the `ASYNC_JOB` finishes the async infrastructure does not copy the struct back in speed.
This is a design decision and not a bug in the async code.

In order to solve the error we need to pass siglen as a pointer so that the correct value is visible also from the caller (i.e. speed) and the verify operation can complete successfully.

Reverting the commit solves the problem:

git revert 0930e07d1eb522e663abe543ee865a508749946e

```
> openssl speed -elapsed -async_jobs 1 dsa512
You have chosen to measure elapsed time instead of user CPU time.
Doing 512 bit sign dsa's for 10s: 70485 512 bit DSA signs in 9.99s
Doing 512 bit verify dsa's for 10s: 119001 512 bit DSA verify in 10.00s
OpenSSL 1.1.0-pre6 (beta) 4 Aug 2016
built on: reproducible build, date unspecified
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr)
compiler: gcc -DDSO_DLFCN -DHAVE_DLFCN_H -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib64/engines-1.1\""  -Wa,--noexecstack
                  sign    verify    sign/s verify/s
dsa  512 bits 0.000142s 0.000084s   7055.6  11900.1
```
