### PR TITLE
Don't check for malloc failure twice.

### DIFF
--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -154,11 +154,6 @@ int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     if (*ppkey == NULL)
         return -1;
 
-    if (*ppkey == NULL) {
-        EVPerr(EVP_F_EVP_PKEY_KEYGEN, ERR_R_MALLOC_FAILURE);
-        return -1;
-    }
-
     ret = ctx->pmeth->keygen(ctx, *ppkey);
     if (ret <= 0) {
         EVP_PKEY_free(*ppkey);


### PR DESCRIPTION
a03f81f4ead24c234dc26e388d86a352685f3948 added a malloc failure check to `EVP_PKEY_keygen`, but there already was one.

Wasn't sure whether you all preferred the one with or without the `EVPerr`. The original code was without. `EVP_PKEY_new` already pushes `ERR_R_MALLOC_FAILURE` on error.