### PR TITLE
Fix overflow check in BN_bn2dec()

### DIFF
--- a/crypto/bn/bn_print.c
+++ b/crypto/bn/bn_print.c
@@ -92,14 +92,13 @@ char *BN_bn2dec(const BIGNUM *a)
         if (BN_is_negative(t))
             *p++ = '-';
 
-        i = 0;
         while (!BN_is_zero(t)) {
+            if (lp - bn_data >= bn_data_num)
+                goto err;
             *lp = BN_div_word(t, BN_DEC_CONV);
             if (*lp == (BN_ULONG)-1)
                 goto err;
             lp++;
-            if (lp - bn_data >= bn_data_num)
-                goto err;
         }
         lp--;
         /*


### PR DESCRIPTION
Fix an off by one error in the overflow check added by 07bed46f332fc ("Check for errors in BN_bn2dec()").

This causes, for example BN_bn2dec(BN_value_one()) to fail.