### PR TITLE
GOST: rearrange code so it's more like C rather than C++

### DIFF
--- a/engines/ccgost/gost2001.c
+++ b/engines/ccgost/gost2001.c
@@ -434,14 +434,16 @@ int gost2001_compute_public(EC_KEY *ec)
 int gost2001_keygen(EC_KEY *ec)
 {
     BIGNUM *order = BN_new(), *d = BN_new();
+    const EC_GROUP *group = NULL;
+
     if (order == NULL || d == NULL) {
         GOSTerr(GOST_F_GOST2001_KEYGEN, ERR_R_MALLOC_FAILURE);
         BN_free(d);
         BN_free(order);
         return 0;
     }
-    const EC_GROUP *group = EC_KEY_get0_group(ec);
 
+    group = EC_KEY_get0_group(ec);
     if(!group || !EC_GROUP_get_order(group, order, NULL)) {
         GOSTerr(GOST_F_GOST2001_KEYGEN, ERR_R_INTERNAL_ERROR);
         BN_free(d);


### PR DESCRIPTION
Some builds fail otherwise.
