### PR TITLE
Make 'openssl req -x509' more equivalent to 'openssl req -new'

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -289,6 +289,7 @@ int req_main(int argc, char **argv)
             break;
         case OPT_X509:
             x509 = 1;
+            newreq = 1;
             break;
         case OPT_DAYS:
             days = atoi(opt_arg());
@@ -578,7 +579,7 @@ int req_main(int argc, char **argv)
         }
     }
 
-    if (newreq || x509) {
+    if (newreq) {
         if (pkey == NULL) {
             BIO_printf(bio_err, "you need to specify a private key\n");
             goto end;


### PR DESCRIPTION
The following would fail, or rather, freeze:

```
openssl genrsa -out rsa2048.pem 2048
openssl req -x509 -key rsa2048.pem -keyform PEM -out cert.pem
```

In that case, the second command wants to read a certificate request
from stdin, because -x509 wasn't fully flagged as being for creating
something new.  This changes makes it fully flagged.

[RT#4655](https://rt.openssl.org/Ticket/Display.html?id=4655)
(log in with username _guest_ and password _guest_ if you don't have a registered user)
