### PR TITLE
Make 'openssl req -x509' more equivalent to 'openssl req -new' (1.0.2)

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -332,9 +332,10 @@ int MAIN(int argc, char **argv)
             subject = 1;
         else if (strcmp(*argv, "-text") == 0)
             text = 1;
-        else if (strcmp(*argv, "-x509") == 0)
+        else if (strcmp(*argv, "-x509") == 0) {
+            newreq = 1;
             x509 = 1;
-        else if (strcmp(*argv, "-asn1-kludge") == 0)
+        } else if (strcmp(*argv, "-asn1-kludge") == 0)
             kludge = 1;
         else if (strcmp(*argv, "-no-asn1-kludge") == 0)
             kludge = 0;
@@ -756,7 +757,7 @@ int MAIN(int argc, char **argv)
         }
     }
 
-    if (newreq || x509) {
+    if (newreq) {
         if (pkey == NULL) {
             BIO_printf(bio_err, "you need to specify a private key\n");
             goto end;


### PR DESCRIPTION
The following would fail, or rather, freeze:

```
openssl genrsa -out rsa2048.pem 2048
openssl req -x509 -key rsa2048.pem -keyform PEM -out cert.pem
```

In that case, the second command wants to read a certificate request
from stdin, because -x509 wasn't fully flagged as being for creating
something new.  This changes makes it fully flagged.

RT#4655
