### PR TITLE
Fix math in BN_bn2dec comment.

### DIFF
--- a/crypto/bn/bn_print.c
+++ b/crypto/bn/bn_print.c
@@ -67,8 +67,8 @@ char *BN_bn2dec(const BIGNUM *a)
     /*-
      * get an upper bound for the length of the decimal integer
      * num <= (BN_num_bits(a) + 1) * log(2)
-     *     <= 3 * BN_num_bits(a) * 0.1001 + log(2) + 1     (rounding error)
-     *     <= BN_num_bits(a)/10 + BN_num_bits/1000 + 1 + 1
+     *     <= 3 * BN_num_bits(a) * 0.101 + log(2) + 1     (rounding error)
+     *     <= 3 * BN_num_bits(a) / 10 + 3 * BN_num_bits / 1000 + 1 + 1
      */
     i = BN_num_bits(a) * 3;
     num = (i / 10 + i / 1000 + 1) + 1;


### PR DESCRIPTION
The bound on log(2)/3 on the second line is incorrect and has an extra
zero compared to the divisions in the third line. log(2)/3 = 0.10034...
which is bounded by 0.101 and not 0.1001. The divisions actually
correspond to 0.101 which is fine. The third line also dropped a factor
of three.

The actual code appears to be fine. Just the comments are wrong.