### PR TITLE
Internalizes SCT_verify and removes SCT_verify_v1

### DIFF
--- a/crypto/ct/ct_err.c
+++ b/crypto/ct/ct_err.c
@@ -45,8 +45,7 @@ static ERR_STRING_DATA CT_str_functs[] = {
     {ERR_FUNC(CT_F_SCT_SET_LOG_ENTRY_TYPE), "SCT_set_log_entry_type"},
     {ERR_FUNC(CT_F_SCT_SET_SIGNATURE_NID), "SCT_set_signature_nid"},
     {ERR_FUNC(CT_F_SCT_SET_VERSION), "SCT_set_version"},
-    {ERR_FUNC(CT_F_SCT_VERIFY), "SCT_verify"},
-    {ERR_FUNC(CT_F_SCT_VERIFY_V1), "SCT_verify_v1"},
+    {ERR_FUNC(CT_F_SCT_CTX_VERIFY), "SCT_CTX_verify"},
     {0, NULL}
 };
 

--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -151,6 +151,13 @@ __owur int SCT_CTX_set1_issuer_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey);
 __owur int SCT_CTX_set1_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey);
 
 /*
+ * Verifies an SCT with the given context.
+ * Returns 1 if the SCT verifies successfully; any other value indicates
+ * failure. See EVP_DigestVerifyFinal() for the meaning of those values.
+ */
+__owur int SCT_CTX_verify(const SCT_CTX *sctx, const SCT *sct);
+
+/*
  * Does this SCT have the minimum fields populated to be usable?
  * Returns 1 if so, 0 otherwise.
  */

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -349,7 +349,7 @@ int SCT_validate(SCT *sct, const CT_POLICY_EVAL_CTX *ctx)
     if (SCT_CTX_set1_cert(sctx, ctx->cert, NULL) != 1)
         sct->validation_status = SCT_VALIDATION_STATUS_UNVERIFIED;
     else
-        sct->validation_status = SCT_verify(sctx, sct) == 1 ?
+        sct->validation_status = SCT_CTX_verify(sctx, sct) == 1 ?
             SCT_VALIDATION_STATUS_VALID : SCT_VALIDATION_STATUS_INVALID;
 
 end:

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -271,19 +271,6 @@ void SCT_LIST_print(const STACK_OF(SCT) *sct_list, BIO *out, int indent,
                     const char *separator, const CTLOG_STORE *logs);
 
 /*
- * Verifies an SCT with the given context.
- * Returns 1 if the SCT verifies successfully, 0 otherwise.
- */
-__owur int SCT_verify(const SCT_CTX *sctx, const SCT *sct);
-
-/*
- * Verifies an SCT against the provided data.
- * Returns 1 if the SCT verifies successfully, 0 otherwise.
- */
-__owur int SCT_verify_v1(SCT *sct, X509 *cert, X509 *preissuer,
-                  X509_PUBKEY *log_pubkey, X509 *issuer_cert);
-
-/*
  * Gets the last result of validating this SCT.
  * If it has not been validated yet, returns SCT_VALIDATION_STATUS_NOT_SET.
  */
@@ -518,8 +505,7 @@ int ERR_load_CT_strings(void);
 # define CT_F_SCT_SET_LOG_ENTRY_TYPE                      102
 # define CT_F_SCT_SET_SIGNATURE_NID                       103
 # define CT_F_SCT_SET_VERSION                             104
-# define CT_F_SCT_VERIFY                                  128
-# define CT_F_SCT_VERIFY_V1                               129
+# define CT_F_SCT_CTX_VERIFY                              128
 
 /* Reason codes. */
 # define CT_R_BASE64_DECODE_ERROR                         108

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -570,7 +570,6 @@ CRYPTO_cts128_encrypt_block             569	1_1_0	EXIST::FUNCTION:
 ASN1_digest                             570	1_1_0	EXIST::FUNCTION:
 ERR_load_X509V3_strings                 571	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_cleanup               572	1_1_0	EXIST::FUNCTION:
-SCT_verify                              573	1_1_0	EXIST::FUNCTION:CT
 d2i_X509                                574	1_1_0	EXIST::FUNCTION:
 a2i_ASN1_STRING                         575	1_1_0	EXIST::FUNCTION:
 EC_GROUP_get_mont_data                  576	1_1_0	EXIST::FUNCTION:EC
@@ -596,7 +595,6 @@ RAND_query_egd_bytes                    596	1_1_0	EXIST::FUNCTION:EGD
 i2d_ASN1_PRINTABLE                      597	1_1_0	EXIST::FUNCTION:
 ENGINE_cmd_is_executable                598	1_1_0	EXIST::FUNCTION:ENGINE
 BIO_puts                                599	1_1_0	EXIST::FUNCTION:
-SCT_verify_v1                           600	1_1_0	EXIST::FUNCTION:CT
 RSAPublicKey_it                         601	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:RSA
 RSAPublicKey_it                         601	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:RSA
 ISSUING_DIST_POINT_new                  602	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
SCT_verify is impossible to call through the public API (SCT_CTX_new() is not part of the public API), so this renames it to SCT_CTX_verify and moves it out of the public API.

SCT_verify_v1 is redundant, since SCT_validate does the same verification (by calling SCT_verify) and more. The API is less confusing with a single verification function (SCT_validate).

This also corrects the comment for SCT_verify that omits the fact that it may return values other than 0 and 1.