### PR TITLE
Prevent double-free of CTLOG public key

### DIFF
--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -245,10 +245,10 @@ CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name)
         goto err;
     }
 
-    ret->public_key = public_key;
     if (ct_v1_log_id_from_pkey(public_key, ret->log_id) != 1)
         goto err;
 
+    ret->public_key = public_key;
     return ret;
 err:
     CTLOG_free(ret);


### PR DESCRIPTION
Previously, if ct_v1_log_id_from_pkey failed, public_key would be freed by CTLOG_free at the end of the function, and then again by the caller (who would assume ownership was not transferred when CTLOG_new returned NULL).