### PR TITLE
Removes {i2o,o2i}_SCT_signature from the CT public API

### DIFF
--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -164,6 +164,29 @@ __owur int SCT_is_complete(const SCT *sct);
  */
 __owur int SCT_signature_is_complete(const SCT *sct);
 
+/*
+ * TODO(RJPercival): Create an SCT_signature struct and make i2o_SCT_signature
+ * and o2i_SCT_signature conform to the i2d/d2i conventions.
+ */
+
+/*
+* Serialize (to TLS format) an |sct| signature and write it to |out|.
+* If |out| is null, no signature will be output but the length will be returned.
+* If |out| points to a null pointer, a string will be allocated to hold the
+* TLS-format signature. It is the responsibility of the caller to free it.
+* If |out| points to an allocated string, the signature will be written to it.
+* The length of the signature in TLS format will be returned.
+*/
+__owur int i2o_SCT_signature(const SCT *sct, unsigned char **out);
+
+/*
+* Parses an SCT signature in TLS format and populates the |sct| with it.
+* |in| should be a pointer to a string containing the TLS-format signature.
+* |in| will be advanced to the end of the signature if parsing succeeds.
+* |len| should be the length of the signature in |in|.
+* Returns the number of bytes parsed, or a negative integer if an error occurs.
+*/
+__owur int o2i_SCT_signature(SCT *sct, const unsigned char **in, size_t len);
 
 /*
  * Handlers for Certificate Transparency X509v3/OCSP extensions

--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -185,6 +185,8 @@ __owur int i2o_SCT_signature(const SCT *sct, unsigned char **out);
 * |in| will be advanced to the end of the signature if parsing succeeds.
 * |len| should be the length of the signature in |in|.
 * Returns the number of bytes parsed, or a negative integer if an error occurs.
+* If an error occurs, the SCT's signature NID may be updated whilst the
+* signature field itself remains unset.
 */
 __owur int o2i_SCT_signature(SCT *sct, const unsigned char **in, size_t len);
 

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -391,25 +391,6 @@ __owur int i2o_SCT(const SCT *sct, unsigned char **out);
  */
 SCT *o2i_SCT(SCT **psct, const unsigned char **in, size_t len);
 
-/*
-* Serialize (to TLS format) an |sct| signature and write it to |out|.
-* If |out| is null, no signature will be output but the length will be returned.
-* If |out| points to a null pointer, a string will be allocated to hold the
-* TLS-format signature. It is the responsibility of the caller to free it.
-* If |out| points to an allocated string, the signature will be written to it.
-* The length of the signature in TLS format will be returned.
-*/
-__owur int i2o_SCT_signature(const SCT *sct, unsigned char **out);
-
-/*
-* Parses an SCT signature in TLS format and populates the |sct| with it.
-* |in| should be a pointer to a string containing the TLS-format signature.
-* |in| will be advanced to the end of the signature if parsing succeeds.
-* |len| should be the length of the signature in |in|.
-* Returns the number of bytes parsed, or a negative integer if an error occurs.
-*/
-__owur int o2i_SCT_signature(SCT *sct, const unsigned char **in, size_t len);
-
 /********************
  * CT log functions *
  ********************/

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2538,7 +2538,6 @@ d2i_ECPKParameters                      2501	1_1_0	EXIST::FUNCTION:EC
 IDEA_ofb64_encrypt                      2502	1_1_0	EXIST::FUNCTION:IDEA
 CAST_decrypt                            2503	1_1_0	EXIST::FUNCTION:CAST
 TS_STATUS_INFO_get0_failure_info        2504	1_1_0	EXIST::FUNCTION:TS
-o2i_SCT_signature                       2505	1_1_0	EXIST::FUNCTION:CT
 ENGINE_unregister_pkey_meths            2506	1_1_0	EXIST::FUNCTION:ENGINE
 DISPLAYTEXT_new                         2507	1_1_0	EXIST::FUNCTION:
 CMS_final                               2508	1_1_0	EXIST::FUNCTION:CMS
@@ -3590,7 +3589,6 @@ d2i_BASIC_CONSTRAINTS                   3539	1_1_0	EXIST::FUNCTION:
 X509_CERT_AUX_new                       3540	1_1_0	EXIST::FUNCTION:
 ENGINE_register_pkey_asn1_meths         3541	1_1_0	EXIST::FUNCTION:ENGINE
 CRYPTO_ocb128_tag                       3542	1_1_0	EXIST::FUNCTION:OCB
-i2o_SCT_signature                       3543	1_1_0	EXIST::FUNCTION:CT
 ERR_load_OBJ_strings                    3544	1_1_0	EXIST::FUNCTION:
 BIO_ctrl_get_read_request               3545	1_1_0	EXIST::FUNCTION:
 BN_from_montgomery                      3546	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
They have surprising semantics, and so may be error prone to use. They may return to the public API in the future if an SCT_signature struct is added that allows them to be refactored to conform to the i2d/d2i function signature conventions.

Also updates the documentation of o2i_SCT_signature to highlight that, if an error occurs, the SCT's signature NID may be updated whilst the signature field itself remains unset.