### PR TITLE
RT4130: Add enginesdir to pkg-config file

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -797,6 +797,7 @@ libcrypto.pc:
 	    echo 'exec_prefix=$${prefix}'; \
 	    echo 'libdir=$${exec_prefix}/$(LIBDIR)'; \
 	    echo 'includedir=$${prefix}/include'; \
+	    echo 'enginesdir=$${libdir}/engines-{- $sover -}'; \
 	    echo ''; \
 	    echo 'Name: OpenSSL-libcrypto'; \
 	    echo 'Description: OpenSSL cryptography library'; \


### PR DESCRIPTION
Please make the openssl.pc pkg-config file *tell* where the engines directory is.

Currently, engines which need to install into the correct directory need to jump through hoops and apply various distribution-specific knowledge to try to find it.

See https://github.com/OpenSC/libp11/blob/master/configure.ac#L100 and weep.