### PR TITLE
Define OPENSSL_NO_ASM when building on solaris-x86-cc

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -213,7 +213,7 @@ sub vms_info {
     "solaris-x86-cc" => {
         inherit_from     => [ "solaris-common" ],
         cc               => "cc",
-        cflags           => add_before(picker(default => "-xarch=generic -xstrconst -Xa -DL_ENDIAN",
+        cflags           => add_before(picker(default => "-xarch=generic -xstrconst -Xa -DL_ENDIAN -DOPENSSL_NO_ASM",
                                               debug   => "-g",
                                               release => "-xO5 -xregs=frameptr -xdepend -xbuiltin"),
                                        threads("-D_REENTRANT")),

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -245,7 +245,8 @@ typedef UINT64 uint64_t;
 #  define PRIu64 "%Lu"
 # elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
      defined(__osf__) || defined(__sgi) || defined(__hpux) || \
-     defined(OPENSSL_SYS_VMS) || defined (__OpenBSD__)
+     defined(OPENSSL_SYS_VMS) || defined (__OpenBSD__) || \
+     (defined(__SUNPRO_C) && __SUNPRO_C < 0x590)
 #  include <inttypes.h>
 # elif defined(_MSC_VER) && _MSC_VER<=1500
 /*


### PR DESCRIPTION
This platform already lacks an asm definition, but the build will still try to erroneously build the padlock engine. In addition to this fix, the padlock code probably needs to better detect if asm is available.

For reference I am using the following compiler:
`cc: Sun C 5.10 SunOS_i386 2009/06/03`

Here is the failure output when the linker can't find any of the asm functions:

```
Undefined			first referenced
 symbol  			    in file
padlock_xstore                      ./libcrypto.a(e_padlock.o)
padlock_capability                  ./libcrypto.a(e_padlock.o)
padlock_reload_key                  ./libcrypto.a(e_padlock.o)
padlock_ctr32_encrypt               ./libcrypto.a(e_padlock.o)
padlock_key_bswap                   ./libcrypto.a(e_padlock.o)
padlock_cbc_encrypt                 ./libcrypto.a(e_padlock.o)
padlock_cfb_encrypt                 ./libcrypto.a(e_padlock.o)
padlock_ecb_encrypt                 ./libcrypto.a(e_padlock.o)
padlock_ofb_encrypt                 ./libcrypto.a(e_padlock.o)
padlock_aes_block                   ./libcrypto.a(e_padlock.o)
ld: fatal: Symbol referencing errors. No output written to apps/openssl
```