### PR TITLE
Fixed directory bug for uplink-x86_64.pl

### DIFF
--- a/ms/uplink-x86_64.pl
+++ b/ms/uplink-x86_64.pl
@@ -8,7 +8,7 @@
 
 $output=pop;
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
-open OUT,"| \"$^X\" \"${dir}../crypto/perlasm/x86_64-xlate.pl\" \"$output\"";
+open OUT,"| \"$^X\" \"${dir}/../crypto/perlasm/x86_64-xlate.pl\" \"$output\"";
 *STDOUT=*OUT;
 push(@INC,"${dir}.");
 


### PR DESCRIPTION
I tried to compile latest version for Win64 and it failed, I have fixed it by editing that line.
I was using ActivePerl.