### PR TITLE
Minor change in output

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -38,7 +38,7 @@ while ( $ARGV[0] =~ /^-/ ) {
 	    $verbose++;
     }
     else {
-	    print STDERR "Usage error; try -help.\n";
+	    print STDERR "Usage error; try -h for help.\n";
 	    exit 1;
     }
 }


### PR DESCRIPTION
During Parse flags the ARGV is checked for -h, but in the "Usage error" - output, -help was printed.