### PR TITLE
Only build the body of e_padlock when there are lower level routines

### DIFF
--- a/Configure
+++ b/Configure
@@ -1160,6 +1160,9 @@ unless ($disabled{asm}) {
     if ($target{ec_asm_src} =~ /ecp_nistz256/) {
 	push @{$config{defines}}, "ECP_NISTZ256_ASM";
     }
+    if ($target{padlock_asm_src} ne $table{DEFAULTS}->{padlock_asm_src}) {
+	push @{$config{defines}}, "PADLOCK_ASM";
+    }
     if ($target{poly1305_asm_src} ne "") {
 	push @{$config{defines}}, "POLY1305_ASM";
     }

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -41,14 +41,10 @@
  */
 
 #  undef COMPILE_HW_PADLOCK
-#  if !defined(I386_ONLY) && !defined(OPENSSL_NO_ASM)
-#   if    defined(__i386__) || defined(__i386) ||    \
-        defined(__x86_64__) || defined(__x86_64) || \
-        defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64)
-#    define COMPILE_HW_PADLOCK
-#    ifdef OPENSSL_NO_DYNAMIC_ENGINE
+#  if !defined(I386_ONLY) && defined(PADLOCK_ASM)
+#   define COMPILE_HW_PADLOCK
+#   ifdef OPENSSL_NO_DYNAMIC_ENGINE
 static ENGINE *ENGINE_padlock(void);
-#    endif
 #   endif
 #  endif
 


### PR DESCRIPTION
engines/e_padlock.c assumes that for all x86 and x86_64 platforms, the
lower level routines will be present.  However, that's not always
true, for example for solaris-x86-cc, and that leads to build errors.

The better solution is to have configure detect if the lower level
padlock routines are being built, and define the macro PADLOCK_ASM if
they are, and use that macro in our C code.

---

This goes to _master_ and _1.1.0_ branches
