### PR TITLE
s_client.c: avoid compiler warning on Windows/MS-DOS systems

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -812,7 +812,9 @@ int s_client_main(int argc, char **argv)
     int socket_family = AF_UNSPEC, socket_type = SOCK_STREAM;
     int starttls_proto = PROTO_OFF, crl_format = FORMAT_PEM, crl_download = 0;
     int write_tty, read_tty, write_ssl, read_ssl, tty_on, ssl_pending;
+#if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MSDOS)
     int at_eof = 0;
+#endif
     int read_buf_len = 0;
     int fallback_scsv = 0;
     long randamt = 0;
@@ -2393,8 +2395,10 @@ int s_client_main(int argc, char **argv)
             } else
                 i = raw_read_stdin(cbuf, BUFSIZZ);
 
+#if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MSDOS)
             if (i == 0)
                 at_eof = 1;
+#endif
 
             if ((!c_ign_eof) && ((i <= 0) || (cbuf[0] == 'Q' && cmdletters))) {
                 BIO_printf(bio_err, "DONE\n");


### PR DESCRIPTION
it appears when using gcc/mingw:
```
apps/s_client.c:815:9: warning: variable 'at_eof' set but not used [-Wunused-but-set-variable]
     int at_eof = 0;
         ^~~~~~
```