### PR TITLE
Add padding spaces before printing signature algorithm.

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -111,6 +111,8 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
 
     if (!(cflag & X509_FLAG_NO_SIGNAME)) {
         const X509_ALGOR *tsig_alg = X509_get0_tbs_sigalg(x);
+        if (BIO_puts(bp, "    ") <= 0)
+            goto err;
         if (X509_signature_print(bp, tsig_alg, NULL) <= 0)
             goto err;
     }


### PR DESCRIPTION
When printing x509 certificates like

```
openssl x509 -in ca.crt -noout -text
```

It has two `Signature Algorithm` lines. In `CHANGES:7466` it introduces a function `X509_signature_print` to deduplicate the print routine. But it would result in one of the lines having incorrect indentation.

This PR manually added the indentation back.
