### PR TITLE
Fix help option in c_rehash error text and man page

### DIFF
--- a/doc/apps/rehash.pod
+++ b/doc/apps/rehash.pod
@@ -11,7 +11,7 @@ c_rehash, rehash - Create symbolic links to files named by the hash values
 
 B<openssl>
 B<rehash>
-B<[-help]>
+B<[-h]>
 B<[-old]>
 B<[-n]>
 B<[-v]>
@@ -82,7 +82,7 @@ optionally prefixed with some text and an equals sign.
 
 =over 4
 
-=item B<-help>
+=item B<-h>
 
 Display a brief usage message.
 

--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -38,7 +38,7 @@ while ( $ARGV[0] =~ /^-/ ) {
 	    $verbose++;
     }
     else {
-	    print STDERR "Usage error; try -help.\n";
+	    print STDERR "Usage error; try -h.\n";
 	    exit 1;
     }
 }


### PR DESCRIPTION
The c_rehash tool does not accept the _-help_ option but works with _-h_. Updated the error text and the man page to reflect the status quo.