### PR TITLE
The Perl interpreter might be in a path with spaces, so maybe quote it

### DIFF
--- a/Configure
+++ b/Configure
@@ -2561,7 +2561,12 @@ sub quotify {
 			 return '"'.$x.'"'; },
 	maybeshell => sub { my $x = shift;
 			    (my $y = $x) =~ s/([\\\"])/\\$1/g;
-			    return $x ne $y ? '"'.$y.'"' : $x; },
+			    if ($x ne $y || $x =~ m|\s|) {
+				return '"'.$y.'"';
+			    } else {
+				return $x;
+			    }
+			},
 	);
     my $for = shift;
     my $processor =

--- a/Configure
+++ b/Configure
@@ -2398,7 +2398,8 @@ sub run_dofile
     foreach (@templates) {
         die "Can't open $_, $!" unless -f $_;
     }
-    my $cmd = "$config{perl} \"-I.\" \"-Mconfigdata\" \"$dofile\" -o\"Configure\" \"".join("\" \"",@templates)."\" > \"$out.new\"";
+    my $perlcmd = (quotify("maybeshell", $config{perl}))[0];
+    my $cmd = "$perlcmd \"-I.\" \"-Mconfigdata\" \"$dofile\" -o\"Configure\" \"".join("\" \"",@templates)."\" > \"$out.new\"";
     #print STDERR "DEBUG[run_dofile]: \$cmd = $cmd\n";
     system($cmd);
     exit 1 if $? != 0;
@@ -2558,6 +2559,9 @@ sub quotify {
 	perl    => sub { my $x = shift;
 			 $x =~ s/([\\\$\@"])/\\$1/g;
 			 return '"'.$x.'"'; },
+	maybeshell => sub { my $x = shift;
+			    (my $y = $x) =~ s/([\\\"])/\\$1/g;
+			    return $x ne $y ? '"'.$y.'"' : $x; },
 	);
     my $for = shift;
     my $processor =


### PR DESCRIPTION
Note: some shells do not like the command verb to be quoted, so we avoid
it unless it's actually necessary.

RT#4665

---

For both _master_ and _1.1.0_ branches
