### PR TITLE
Remove -xtarget=ultra from solaris(64)-sparcv9-cc builds.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -294,11 +294,11 @@ sub vms_info {
     },
     "solaris-sparcv9-cc" => {
         inherit_from     => [ "solaris-sparcv7-cc", asm("sparcv9_asm") ],
-        cflags           => add_before("-xarch=v8plus -xtarget=ultra"),
+        cflags           => add_before("-xarch=v8plus"),
     },
     "solaris64-sparcv9-cc" => {
         inherit_from     => [ "solaris-sparcv7-cc", asm("sparcv9_asm") ],
-        cflags           => add_before("-xarch=v9 -xtarget=ultra"),
+        cflags           => add_before("-xarch=v9"),
         lflags           => add_before("-xarch=v9"),
         bn_ops           => "BN_LLONG RC4_CHAR",
         shared_ldflag    => "-xarch=v9 -G -dy -z text",


### PR DESCRIPTION
solaris64-sparcv9-cc was accidentally building 32-bit files because of the way -xtarget=ultra was being used. This patch removes -xtarget=ultra from both the 32-bit and the 64-bit Sparc builds. Details below.

The -xtarget=ultra flag was silently overriding the value of -xarch=v9 (and -xarch=v8plus) by causing the compiler to choose the best value for Ultra CPUs, which happens to be -xarch=v8plusa, a 32-bit mode. You can check the compiler behavior by using -xdryrun:
```
> cc -xdryrun -xarch=v9 -xtarget=ultra /dev/null
### -xarch=v8plusa -xcache=16/32/1:512/64/1 -xchip=ultra /dev/null
```
Swapping the order so that -xarch=v9 overrides the target default is one solution:
```
> cc -xdryrun -xtarget=ultra -xarch=v9 /dev/null
### -xarch=v9 -xcache=16/32/1:512/64/1 -xchip=ultra /dev/null
```
as is removing -xtarget=ultra completely.
```
> cc -xdryrun -xarch=v9 /dev/null
### -xarch=v9 /dev/null
```
There may be a good reason -xtarget=ultra is used here, but I can't think of a reason why ultra would be preferred over any of the other 20+ target CPU choices. If -xtarget is kept, please add a comment warning future devs to be careful when changing the ordering of these command-line flags.  The 1.0.2 branch had these values in the correct order, by the way (-xtarget=ultra -xarch=v9).

We use a fairly old compiler version (Sun C 5.8 2005/10/13), but as far as I can tell, these flags still work the same in later versions. The manual for this version is at https://docs.oracle.com/cd/E19422-01/819-3688-10/819-3688-10.pdf and these flags are documented in sections B.2.66 and B.2.138.
