### PR TITLE
Clarify text for acceptable values for stateOrProvinceName

### DIFF
--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -15,7 +15,7 @@ oid_section		= new_oids
 # To use this configuration file with the "-extfile" option of the
 # "openssl x509" utility, name here the section containing the
 # X.509v3 extensions to use:
-# extensions		= 
+# extensions		=
 # (Alternatively, use a configuration file that has only
 # X.509v3 extensions in its main [= default] section.)
 
@@ -113,7 +113,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 # input_password = secret
 # output_password = secret
 
-# This sets a mask for permitted string types. There are several options. 
+# This sets a mask for permitted string types. There are several options.
 # default: PrintableString, T61String, BMPString.
 # pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
 # utf8only: only UTF8Strings (PKIX recommendation after 2004).
@@ -130,7 +130,7 @@ countryName_default		= AU
 countryName_min			= 2
 countryName_max			= 2
 
-stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName		= State (e.g. NY) or Province Name (e.g. Gloucestershire)
 stateOrProvinceName_default	= Some-State
 
 localityName			= Locality Name (eg, city)

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -15,7 +15,7 @@ oid_section		= new_oids
 # To use this configuration file with the "-extfile" option of the
 # "openssl x509" utility, name here the section containing the
 # X.509v3 extensions to use:
-# extensions		= 
+# extensions		=
 # (Alternatively, use a configuration file that has only
 # X.509v3 extensions in its main [= default] section.)
 
@@ -113,7 +113,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 # input_password = secret
 # output_password = secret
 
-# This sets a mask for permitted string types. There are several options. 
+# This sets a mask for permitted string types. There are several options.
 # default: PrintableString, T61String, BMPString.
 # pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
 # utf8only: only UTF8Strings (PKIX recommendation after 2004).
@@ -130,7 +130,7 @@ countryName_default		= AU
 countryName_min			= 2
 countryName_max			= 2
 
-stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName		= State (e.g. NY) or Province Name (e.g. Gloucestershire)
 stateOrProvinceName_default	= Some-State
 
 localityName			= Locality Name (eg, city)


### PR DESCRIPTION
This is a minor change to the text displayed when creating a CSR with openssl. The current text is:

```
$ openssl req -new -newkey rsa:2048 -nodes -keyout foo.key -out foo.csr
Generating a 2048 bit RSA private key
........+++
..........+++
writing new private key to 'foo.key'
-----
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:US
State or Province Name (full name) [Some-State]
```

The `full name` is being interpreted by many users [1] as if this value is validated, thus making a value such as "NY" invalid.

[1] https://en.wikipedia.org/wiki/Certificate_signing_request#Procedure