### PR TITLE
Offer PBE key streching via command line app

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -6,10 +6,10 @@ IF[{- !$disabled{apps} -}]
           openssl.c \
           asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c dhparam.c \
           dsa.c dsaparam.c ec.c ecparam.c enc.c engine.c errstr.c gendsa.c \
-          genpkey.c genrsa.c nseq.c ocsp.c passwd.c pkcs12.c pkcs7.c pkcs8.c \
-          pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c rsa.c rsautl.c \
-          s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c \
-          srp.c ts.c verify.c version.c x509.c rehash.c \
+          genpkey.c genrsa.c nseq.c ocsp.c passwd.c pbe.c pkcs12.c pkcs7.c \
+          pkcs8.c pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c rsa.c \
+          rsautl.c s_client.c s_server.c s_time.c sess_id.c smime.c speed.c \
+          spkac.c srp.c ts.c verify.c version.c x509.c rehash.c \
           apps.c opt.c s_cb.c s_socket.c \
           app_rand.c \
           {- $target{apps_aux_src} -}

--- a/apps/pbe.c
+++ b/apps/pbe.c
@@ -91,7 +91,7 @@ typedef enum OPTION_choice {
     OPT_ITERCNT,
 #ifndef OPENSSL_NO_SCRYPT
     OPT_PARAM_N, OPT_PARAM_R, OPT_PARAM_P,
-    OPT_MEMSIZE,
+    OPT_MAXALLOC,
 #endif
     OPT_DKLEN, OPT_DIGEST
 } OPTION_CHOICE;
@@ -107,7 +107,7 @@ OPTIONS pbe_options[] = {
     {"N", OPT_PARAM_N, 'p', "CPU/memory cost parameter for scrypt"},
     {"r", OPT_PARAM_R, 'p', "Block size parameter for scrypt"},
     {"p", OPT_PARAM_P, 'p', "Parallelization parameter for scrypt"},
-    {"memsize", OPT_MEMSIZE, 'p', "Maximum memory allocation in MiB (default is 128 MiB)"},
+    {"maxalloc", OPT_MAXALLOC, 'p', "Maximum memory allocation in MiB (default is 128 MiB)"},
 #endif
     {"dklen", OPT_DKLEN, 'p', "Key derivation output key length"},
     {"", OPT_DIGEST, '-', "Any supported digest"},
@@ -129,7 +129,7 @@ int pbe_main(int argc, char **argv)
     unsigned int itercnt = 0, dklen = 0;
 #ifndef OPENSSL_NO_SCRYPT
     unsigned int par_n = 0, par_r = 0, par_p = 0;
-    unsigned int memsize_mib = 128;
+    unsigned int maxalloc_mib = 128;
 #endif
     unsigned char *dkey = NULL;
 
@@ -179,8 +179,8 @@ int pbe_main(int argc, char **argv)
             md = m;
             break;
 #ifndef OPENSSL_NO_SCRYPT
-        case OPT_MEMSIZE:
-            memsize_mib = atoi(opt_arg());
+        case OPT_MAXALLOC:
+            maxalloc_mib = atoi(opt_arg());
             break;
 #endif
         }
@@ -291,7 +291,7 @@ int pbe_main(int argc, char **argv)
         result = PKCS5_PBKDF2_HMAC(password, passlen, (unsigned char*)salt, saltlen, itercnt, md, dklen, dkey);
 #ifndef OPENSSL_NO_SCRYPT
     } else if (kdf == PBE_KDF_SCRYPT) {
-        result = EVP_PBE_scrypt(password, passlen, (unsigned char*)salt, saltlen, par_n, par_r, par_p, memsize_mib * 1024 * 1024, dkey, dklen);
+        result = EVP_PBE_scrypt(password, passlen, (unsigned char*)salt, saltlen, par_n, par_r, par_p, maxalloc_mib * 1024 * 1024, dkey, dklen);
 #endif
     }
 

--- a/apps/pbe.c
+++ b/apps/pbe.c
@@ -1,0 +1,332 @@
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ *
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ *
+ * Copyright remains Eric Young's, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    "This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)"
+ *    The word 'cryptographic' can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.]
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include "apps.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+typedef enum pbe_kdf {
+    PBE_KDF_INVALID,
+    PBE_KDF_PBKDF2,
+    PBE_KDF_SCRYPT
+} PBE_KDF;
+
+#define PASSWORD_BUFSIZE        (8 * 1024)
+static OPT_PAIR pbe_kdfs[] = {
+    {"pbkdf2", PBE_KDF_PBKDF2},
+#ifndef OPENSSL_NO_SCRYPT
+    {"scrypt", PBE_KDF_SCRYPT},
+#endif
+    {NULL}
+};
+
+static int hex_parse(char *hexbuffer);
+static int is_power_of_two(unsigned int value);
+
+typedef enum OPTION_choice {
+    OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
+    OPT_HEXSALT,
+    OPT_KDF, OPT_SALT,
+    OPT_ITERCNT,
+#ifndef OPENSSL_NO_SCRYPT
+    OPT_PARAM_N, OPT_PARAM_R, OPT_PARAM_P,
+#endif
+    OPT_DKLEN, OPT_DIGEST
+} OPTION_CHOICE;
+
+OPTIONS pbe_options[] = {
+    {OPT_HELP_STR, 1, '-', "Usage: %s [options]\n"},
+    {"help", OPT_HELP, '-', "Display this summary"},
+    {"kdf", OPT_KDF, 's', "Specify the key derivation function"},
+    {"salt", OPT_SALT, 's', "Salt for key derivation"},
+    {"hexsalt", OPT_HEXSALT, '-', "Interpret the given salt as hex string"},
+    {"itercnt", OPT_ITERCNT, 'p', "Iteration count for key derivation with PBKDF2"},
+#ifndef OPENSSL_NO_SCRYPT
+    {"N", OPT_PARAM_N, 'p', "CPU/memory cost parameter for scrypt"},
+    {"r", OPT_PARAM_R, 'p', "Block size parameter for scrypt"},
+    {"p", OPT_PARAM_P, 'p', "Parallelization parameter for scrypt"},
+#endif
+    {"dklen", OPT_DKLEN, 'p', "Key derivation output key length"},
+    {"", OPT_DIGEST, '-', "Any supported digest"},
+    {NULL}
+};
+
+int pbe_main(int argc, char **argv)
+{
+    BIO *in = NULL;
+    int kdf = PBE_KDF_INVALID;
+    const EVP_MD *md = NULL, *m = NULL;
+    char *salt = NULL, *password = NULL;
+    int saltlen = 0, passlen = 0;
+    OPTION_CHOICE o;
+    int i = 0;
+    int result = 0;
+    const char *prog = NULL;
+    int hexsalt = 0;
+    unsigned int itercnt = 0, dklen = 0;
+#ifndef OPENSSL_NO_SCRYPT
+    unsigned int par_n = 0, par_r = 0, par_p = 0;
+#endif
+    unsigned char *dkey = NULL;
+
+    prog = opt_progname(argv[0]);
+    md = EVP_get_digestbyname(prog);
+
+    prog = opt_init(argc, argv, pbe_options);
+    while ((o = opt_next()) != OPT_EOF) {
+        switch (o) {
+        case OPT_EOF:
+        case OPT_ERR:
+ opthelp:
+            BIO_printf(bio_err, "%s: Use -help for summary.\n", prog);
+            goto end;
+        case OPT_HELP:
+            opt_help(pbe_options);
+            goto end;
+        case OPT_HEXSALT:
+            hexsalt = 1;
+            break;
+        case OPT_KDF:
+            if (!opt_pair(opt_arg(), pbe_kdfs, &kdf)) {
+                opt_help(pbe_options);
+                goto end;
+            }
+            break;
+        case OPT_SALT:
+            salt = opt_arg();
+            break;
+        case OPT_ITERCNT:
+            itercnt = atoi(opt_arg());
+            break;
+#ifndef OPENSSL_NO_SCRYPT
+        case OPT_PARAM_N:
+            par_n = atoi(opt_arg());
+            break;
+        case OPT_PARAM_R:
+            par_r = atoi(opt_arg());
+            break;
+        case OPT_PARAM_P:
+            par_p = atoi(opt_arg());
+            break;
+#endif
+        case OPT_DKLEN:
+            dklen = atoi(opt_arg());
+            break;
+        case OPT_DIGEST:
+            if (!opt_md(opt_unknown(), &m))
+                goto opthelp;
+            md = m;
+            break;
+        }
+    }
+    argc = opt_num_rest();
+    argv = opt_rest();
+
+    if (kdf == PBE_KDF_INVALID) {
+        OPT_PAIR *next_kdf = pbe_kdfs;
+        BIO_puts(bio_err,
+                 "No key derivation function given: use the -kdf option\n");
+        BIO_puts(bio_err, "Known KDF: ");
+        while (next_kdf->name) {
+            BIO_puts(bio_err, next_kdf->name);
+            BIO_puts(bio_err, " ");
+            next_kdf++;
+        }
+        BIO_puts(bio_err, "\n");
+        goto end;
+    }
+
+    if (!salt) {
+        BIO_puts(bio_err,
+                 "No salt given: use the -salt option\n");
+        goto end;
+    }
+
+    if (!dklen) {
+        BIO_puts(bio_err,
+                 "No derivative key length given: use the -dklen option\n");
+        goto end;
+    }
+
+    if (!app_load_modules(NULL))
+        goto end;
+
+    dkey = app_malloc(dklen, "derived key buffer");
+    password = app_malloc(PASSWORD_BUFSIZE, "password buffer");
+
+    /* perform KDF-specific sanity checks before reading in the password */
+    if (kdf == PBE_KDF_PBKDF2) {
+        if (par_n || par_r || par_p) {
+            BIO_puts(bio_err,
+                     "For PBKDF2, the N, r and p parameters do not make sense. Omit them.\n");
+            goto end;
+        }
+        if (!itercnt) {
+            BIO_puts(bio_err,
+                     "No iteration count given: use the -itercnt option\n");
+            goto end;
+        }
+#ifndef OPENSSL_NO_SCRYPT
+    } else if (kdf == PBE_KDF_SCRYPT) {
+        if (itercnt) {
+            BIO_puts(bio_err,
+                     "For scrypt, the itercnt parameter does not make sense. Omit it.\n");
+            goto end;
+        }
+        if (!par_n || !par_r || !par_p) {
+            BIO_puts(bio_err,
+                     "Either N, r or p parameter missing: use the -N, -r or -p option\n");
+            goto end;
+        }
+        if (par_n < 2) {
+            BIO_puts(bio_err,
+                     "Parameter \"N\" must be at least 2\n");
+            goto end;
+        }
+        if (!is_power_of_two(par_n)) {
+            BIO_puts(bio_err,
+                     "Parameter \"N\" must be a power of two\n");
+            goto end;
+        }
+#endif
+    }
+
+    in = BIO_new(BIO_s_file());
+    if (in == NULL) {
+        ERR_print_errors(bio_err);
+        goto end;
+    }
+    BIO_set_fp(in, stdin, BIO_NOCLOSE);
+
+    passlen = BIO_read(in, password, PASSWORD_BUFSIZE);
+    if (passlen == PASSWORD_BUFSIZE) {
+        /* password was probably incompletely read, do not do any derivation on
+         * truncated passwords */
+        BIO_printf(bio_err,
+                 "Given password exceeds allocated buffer of %d bytes.\n", PASSWORD_BUFSIZE);
+        goto end;
+    }
+
+    saltlen = strlen(salt);
+    if (hexsalt) {
+        saltlen = hex_parse(salt);
+        if (saltlen == 0) {
+            BIO_puts(bio_err, "Could not parse salt as hex value\n");
+            goto end;
+        }
+    }
+
+    result = 0;
+    if (kdf == PBE_KDF_PBKDF2) {
+        if (!md)
+            md = EVP_sha1();
+        result = PKCS5_PBKDF2_HMAC(password, passlen, (unsigned char*)salt, saltlen, itercnt, md, dklen, dkey);
+#ifndef OPENSSL_NO_SCRYPT
+    } else if (kdf == PBE_KDF_SCRYPT) {
+        result = EVP_PBE_scrypt(password, passlen, (unsigned char*)salt, saltlen, par_n, par_r, par_p, 128 * 1024 * 1024, dkey, dklen);
+#endif
+    }
+
+    if (result != 1) {
+        BIO_printf(bio_err, "Key derivation failed: result %d\n", result);
+        ERR_print_errors(bio_err);
+        goto end;
+    }
+
+    for (i = 0; i < dklen; i++) {
+        BIO_printf(bio_out, "%02x", dkey[i] & 0xff);
+    }
+    BIO_printf(bio_out, "\n");
+
+end:
+    OPENSSL_clear_free(password, PASSWORD_BUFSIZE);
+    OPENSSL_free(dkey);
+    BIO_free(in);
+    return 0;
+}
+
+static int hex_parse(char *hexbuffer) {
+    int i, l;
+    l = strlen(hexbuffer);
+    if ((l % 2) != 0) {
+        BIO_puts(bio_err, "Hex string is not of even length\n");
+        return 0;
+    }
+    for (i = 0; i < l; i += 2) {
+        if ((!isxdigit(hexbuffer[i])) || (!isxdigit(hexbuffer[i + 1]))) {
+            BIO_printf(bio_err, "Invalid hex character at position %d\n", i / 2);
+            return 0;
+        }
+        hexbuffer[i / 2] = (OPENSSL_hexchar2int(hexbuffer[i + 0]) << 4) | (OPENSSL_hexchar2int(hexbuffer[i + 1]));
+    }
+    return l / 2;
+}
+
+static int is_power_of_two(unsigned int value) {
+    int bits_set = 0;
+    while (value) {
+        if (value & 1) bits_set++;
+        value >>= 1;
+    }
+    return bits_set == 1;
+}
+

--- a/apps/pbe.c
+++ b/apps/pbe.c
@@ -118,7 +118,7 @@ int pbe_main(int argc, char **argv)
     char *salt = NULL, *password = NULL;
     int saltlen = 0, passlen = 0;
     OPTION_CHOICE o;
-    int i = 0;
+    unsigned int i = 0;
     int result = 0;
     const char *prog = NULL;
     int hexsalt = 0;

--- a/apps/pbe.c
+++ b/apps/pbe.c
@@ -128,9 +128,6 @@ int pbe_main(int argc, char **argv)
 #endif
     unsigned char *dkey = NULL;
 
-    prog = opt_progname(argv[0]);
-    md = EVP_get_digestbyname(prog);
-
     prog = opt_init(argc, argv, pbe_options);
     while ((o = opt_next()) != OPT_EOF) {
         switch (o) {
@@ -227,9 +224,9 @@ int pbe_main(int argc, char **argv)
         }
 #ifndef OPENSSL_NO_SCRYPT
     } else if (kdf == PBE_KDF_SCRYPT) {
-        if (itercnt) {
+        if (itercnt || md) {
             BIO_puts(bio_err,
-                     "For scrypt, the itercnt parameter does not make sense. Omit it.\n");
+                     "For scrypt, the itercnt and digest parameters do not make sense. Omit them.\n");
             goto end;
         }
         if (!par_n || !par_r || !par_p) {

--- a/apps/progs.h
+++ b/apps/progs.h
@@ -72,6 +72,7 @@ extern int ts_main(int argc, char *argv[]);
 extern int verify_main(int argc, char *argv[]);
 extern int version_main(int argc, char *argv[]);
 extern int x509_main(int argc, char *argv[]);
+extern int pbe_main(int argc, char *argv[]);
 
 extern OPTIONS asn1parse_options[];
 extern OPTIONS ca_options[];
@@ -121,6 +122,7 @@ extern OPTIONS ts_options[];
 extern OPTIONS verify_options[];
 extern OPTIONS version_options[];
 extern OPTIONS x509_options[];
+extern OPTIONS pbe_options[];
 
 #ifdef INCLUDE_FUNCTION_TABLE
 static FUNCTION functions[] = {
@@ -208,6 +210,7 @@ static FUNCTION functions[] = {
     { FT_general, "verify", verify_main, verify_options },
     { FT_general, "version", version_main, version_options },
     { FT_general, "x509", x509_main, x509_options },
+    { FT_general, "pbe", pbe_main, pbe_options },
 #ifndef OPENSSL_NO_MD2
     { FT_md, "md2", dgst_main},
 #endif

--- a/apps/progs.h
+++ b/apps/progs.h
@@ -48,6 +48,7 @@ extern int list_main(int argc, char *argv[]);
 extern int nseq_main(int argc, char *argv[]);
 extern int ocsp_main(int argc, char *argv[]);
 extern int passwd_main(int argc, char *argv[]);
+extern int pbe_main(int argc, char *argv[]);
 extern int pkcs12_main(int argc, char *argv[]);
 extern int pkcs7_main(int argc, char *argv[]);
 extern int pkcs8_main(int argc, char *argv[]);
@@ -72,7 +73,6 @@ extern int ts_main(int argc, char *argv[]);
 extern int verify_main(int argc, char *argv[]);
 extern int version_main(int argc, char *argv[]);
 extern int x509_main(int argc, char *argv[]);
-extern int pbe_main(int argc, char *argv[]);
 
 extern OPTIONS asn1parse_options[];
 extern OPTIONS ca_options[];
@@ -98,6 +98,7 @@ extern OPTIONS list_options[];
 extern OPTIONS nseq_options[];
 extern OPTIONS ocsp_options[];
 extern OPTIONS passwd_options[];
+extern OPTIONS pbe_options[];
 extern OPTIONS pkcs12_options[];
 extern OPTIONS pkcs7_options[];
 extern OPTIONS pkcs8_options[];
@@ -122,7 +123,6 @@ extern OPTIONS ts_options[];
 extern OPTIONS verify_options[];
 extern OPTIONS version_options[];
 extern OPTIONS x509_options[];
-extern OPTIONS pbe_options[];
 
 #ifdef INCLUDE_FUNCTION_TABLE
 static FUNCTION functions[] = {
@@ -172,6 +172,7 @@ static FUNCTION functions[] = {
     { FT_general, "ocsp", ocsp_main, ocsp_options },
 #endif
     { FT_general, "passwd", passwd_main, passwd_options },
+    { FT_general, "pbe", pbe_main, pbe_options },
 #ifndef OPENSSL_NO_DES
     { FT_general, "pkcs12", pkcs12_main, pkcs12_options },
 #endif
@@ -210,7 +211,6 @@ static FUNCTION functions[] = {
     { FT_general, "verify", verify_main, verify_options },
     { FT_general, "version", version_main, version_options },
     { FT_general, "x509", x509_main, x509_options },
-    { FT_general, "pbe", pbe_main, pbe_options },
 #ifndef OPENSSL_NO_MD2
     { FT_md, "md2", dgst_main},
 #endif

--- a/doc/apps/pbe.pod
+++ b/doc/apps/pbe.pod
@@ -1,0 +1,118 @@
+=pod
+
+=head1 NAME
+
+pbe - Handles key derivation using password-based encryption functions
+
+=head1 SYNOPSIS
+
+B<openssl> B<pbe>
+[B<-help>]
+[B<-kdf kdf_function>]
+[B<-salt string>]
+[B<-hexsalt>]
+[B<-itercnt iterations>]
+[B<-N cost_param>]
+[B<-r block_param>]
+[B<-p parallel_param>]
+[B<-dklen bytes>]
+[B<-* hash_fnc>]
+
+=head1 DESCRIPTION
+
+The B<pbe> command derives a secret key from a given password using a
+password-based encryption (PBE) key stretching function. These functions work
+similar to hash functions but offer customizable load parameterizations in
+order to deliberately slow down the derivation process. This is useful to
+increase the difficulty of dictionary attacks. Currently, two PBE functions are
+supported: PBKDF2 and scrypt.
+
+=head1 COMMAND OPTIONS
+
+=over 4
+
+=item B<-help>
+
+Print out a usage message.
+
+=item B<-kdf kdf_function>
+
+Specifies the key derivation function that B<pbe> uses. Permissible values are
+pbkdf2 or scrypt.
+
+=item B<-salt string>
+
+Gives the salt value used for key derivation. The passed string is by default
+interpreted as the literal salt.
+
+=item B<-hexsalt>
+
+Tells B<pbe> to interpret the passed salt string as a hex string (i.e., it is
+Base16 decoded first before it is used).
+
+=item B<-itercnt iterations>
+
+For PBKDF2, internally an HMAC function is iterated. This parameter defines how
+many iterations should be taken. A greater value increases the time for
+derivation in a linear manner.
+
+=item B<-N cost_param>
+
+For scrypt, N gives the cost and memory load factor. It needs to be a power of
+two.
+
+=item B<-r block_param>
+
+For scrypt, r is the block size parameter.
+
+=item B<-p parallel_param>
+
+For scrypt, p gives the parallelization parameter.
+
+=item B<-dklen bytes>
+
+Gives the length in bytes which the derived password shall have.
+
+=item B<-* hash_fnc>
+
+Internally the PBE derivation functions rely on cryptographic hash functions.
+In the case that this hash function is parametrizable, it can be specified on
+the command line. Note that scrypt will, by definition, always use
+PBKDF2-HMAC-SHA256 internally and thus B<pbe> will reject any other given hash
+when scrypt is requested. For PBKDF2, internally HMAC is used for the
+computation. If the message digest function is not given on the command line,
+B<pbe> will default to PBKDF2-HMAC-SHA1.
+
+=back
+
+=head1 CONSIDERATIONS
+
+The derivation time of PBKDF2 scales linearly with the given iteration count.
+It is not a memory-hard derivation function and thus the memory requirements
+will not scale up with increased derivation time.
+
+In contrast, scrypt will consume approximately 128 * r * N bytes of memory for
+the internal computation. The derivation time scales linearly with all of N, r,
+and p. Colin Percival, the author of scrypt, suggested in its initial
+publication the values N = 16384, r = 8, p = 1 for interactive logins and N =
+1048576, r = 8, p = 1 for generating keys to encrypt or decrypt sensitive
+files.
+
+=head1 SEE ALSO
+
+L<dgst(1)>
+
+=head1 HISTORY
+
+The B<pbe> command was first added to OpenSSL 1.1.0.
+
+=head1 COPYRIGHT
+
+Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/apps/pbe.pod
+++ b/doc/apps/pbe.pod
@@ -15,6 +15,7 @@ B<openssl> B<pbe>
 [B<-N cost_param>]
 [B<-r block_param>]
 [B<-p parallel_param>]
+[B<-memsize size_mib>]
 [B<-dklen bytes>]
 [B<-* hash_fnc>]
 
@@ -68,6 +69,12 @@ For scrypt, r is the block size parameter.
 =item B<-p parallel_param>
 
 For scrypt, p gives the parallelization parameter.
+
+=item B<-memsize size_mib>
+
+For derivation functions which are memory hard, this parameter defines the
+maximum amount of memory in megabytes (MiB) which OpenSSL will allocate in the
+computation of the key. The default is 128 MiB.
 
 =item B<-dklen bytes>
 

--- a/doc/apps/pbe.pod
+++ b/doc/apps/pbe.pod
@@ -15,7 +15,7 @@ B<openssl> B<pbe>
 [B<-N cost_param>]
 [B<-r block_param>]
 [B<-p parallel_param>]
-[B<-memsize size_mib>]
+[B<-maxalloc size_mib>]
 [B<-dklen bytes>]
 [B<-* hash_fnc>]
 
@@ -70,10 +70,10 @@ For scrypt, r is the block size parameter.
 
 For scrypt, p gives the parallelization parameter.
 
-=item B<-memsize size_mib>
+=item B<-maxalloc size_mib>
 
 For derivation functions which are memory hard, this parameter defines the
-maximum amount of memory in megabytes (MiB) which OpenSSL will allocate in the
+maximum amount of memory in Megabytes (MiB) which OpenSSL will allocate in the
 computation of the key. The default is 128 MiB.
 
 =item B<-dklen bytes>


### PR DESCRIPTION
The key streching functions PBKDF2 and scrypt currently do not have any way of performing key derivation via the command line interface. This patch adds an app called "pbe" which offers this functionality.

It is a rebased version of PR #318, but I accidentally messed up the merge, so this starts fresh and removes all the commit noise.

Modifications from PR #318 are that OPT_PAIR is now used to parse the -kdf parameter and OPENSSL_NO_SCRYPT is honored.
