### PR TITLE
Updates CT log list

### DIFF
--- a/apps/ct_log_list.cnf
+++ b/apps/ct_log_list.cnf
@@ -1,34 +1,49 @@
-enabled_logs=pilot,aviator,rocketeer,digicert,certly,izempe,symantec,venafi
+enabled_logs = ct.googleapis.com/pilot, ct.googleapis.com/aviator, ct1.digicert-ct.com/log, ct.googleapis.com/rocketeer, log.certly.io, ct.izenpe.com, ct.ws.symantec.com, ctlog.api.venafi.com, vega.ws.symantec.com, ctserver.cnnic.cn, ctlog.wosign.com, ct.startssl.com
 
-[pilot]
-description = Google Pilot Log
+[ct.googleapis.com/pilot]
+description = Google 'Pilot' log
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCzWE0J5APC2em4JlvR8EEEFMoA==
 
-[aviator]
-description = Google Aviator log
+[ct.googleapis.com/aviator]
+description = Google 'Aviator' log
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1/TMabLkDpCjiupacAlP7xNi0I1JYP8bQFAHDG1xhtolSY1l4QgNRzRrvSe8liE+NPWHdjGxfx3JhTsN9x8/6Q==
 
-[rocketeer]
-description = Google Rocketeer log
-key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIFsYyDzBi7MxCAC/oJBXK7dHjG+1aLCOkHjpoHPqTyghLpzA9BYbqvnV16mAw04vUjyYASVGJCUoI3ctBcJAeg==
-
-[digicert]
+[ct1.digicert-ct.com/log]
 description = DigiCert Log Server
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAkbFvhu7gkAW6MHSrBlpE1n4+HCFRkC5OLAjgqhkTH+/uzSfSl8ois8ZxAD2NgaTZe1M9akhYlrYkes4JECs6A==
 
-[certly]
+[ct.googleapis.com/rocketeer]
+description = Google 'Rocketeer' log
+key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIFsYyDzBi7MxCAC/oJBXK7dHjG+1aLCOkHjpoHPqTyghLpzA9BYbqvnV16mAw04vUjyYASVGJCUoI3ctBcJAeg==
+
+[log.certly.io]
 description = Certly.IO log
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECyPLhWKYYUgEc+tUXfPQB4wtGS2MNvXrjwFCCnyYJifBtd2Sk7Cu+Js9DNhMTh35FftHaHu6ZrclnNBKwmbbSA==
 
-[izempe]
-description = Izempe log
+[ct.izenpe.com]
+description = Izenpe log
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJ2Q5DC3cUBj4IQCiDu0s6j51up+TZAkAEcQRF6tczw90rLWXkJMAW7jr9yc92bIKgV8vDXU4lDeZHvYHduDuvg==
 
-[symantec]
+[ct.ws.symantec.com]
 description = Symantec log
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEluqsHEYMG1XcDfy1lCdGV0JwOmkY4r87xNuroPS2bMBTP01CEDPwWJePa75y9CrsHEKqAy8afig1dpkIPSEUhg==
 
-[venafi]
+[ctlog.api.venafi.com]
 description = Venafi log
 key = MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAolpIHxdSlTXLo1s6H1OCdpSj/4DyHDc8wLG9wVmLqy1lk9fz4ATVmm+/1iN2Nk8jmctUKK2MFUtlWXZBSpym97M7frGlSaQXUWyA3CqQUEuIJOmlEjKTBEiQAvpfDjCHjlV2Be4qTM6jamkJbiWtgnYPhJL6ONaGTiSPm7Byy57iaz/hbckldSOIoRhYBiMzeNoA0DiRZ9KmfSeXZ1rB8y8X5urSW+iBzf2SaOfzBvDpcoTuAaWx2DPazoOl28fP1hZ+kHUYvxbcMjttjauCFx+JII0dmuZNIwjfeG/GBb9frpSX219k1O4Wi6OEbHEr8at/XQ0y7gTikOxBn/s5wQIDAQAB
 
+[vega.ws.symantec.com]
+description = Symantec 'Vega' log
+key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6pWeAv/u8TNtS4e8zf0ZF2L/lNPQWQc/Ai0ckP7IRzA78d0NuBEMXR2G3avTK0Zm+25ltzv9WWis36b4ztIYTQ==
+
+[ctserver.cnnic.cn]
+description = CNNIC CT log
+key = MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv7UIYZopMgTTJWPp2IXhhuAf1l6a9zM7gBvntj5fLaFm9pVKhKYhVnno94XuXeN8EsDgiSIJIj66FpUGvai5samyetZhLocRuXhAiXXbDNyQ4KR51tVebtEq2zT0mT9liTtGwiksFQccyUsaVPhsHq9gJ2IKZdWauVA2Fm5x9h8B9xKn/L/2IaMpkIYtd967TNTP/dLPgixN1PLCLaypvurDGSVDsuWabA3FHKWL9z8wr7kBkbdpEhLlg2H+NAC+9nGKx+tQkuhZ/hWR65aX+CNUPy2OB9/u2rNPyDydb988LENXoUcMkQT0dU3aiYGkFAY0uZjD2vH97TM20xYtNQIDAQAB
+
+[ctlog.wosign.com]
+description = WoSign log
+key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzBGIey1my66PTTBmJxklIpMhRrQvAdPG+SvVyLpzmwai8IoCnNBrRhgwhbrpJIsO0VtwKAx+8TpFf1rzgkJgMQ==
+
+[ct.startssl.com]
+description = StartCom log
+key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESPNZ8/YFGNPbsu1Gfs/IEbVXsajWTOaft0oaFIZDqUiwy1o/PErK38SCFFWa+PeOQFXc9NKv6nV0+05/YIYuUQ==


### PR DESCRIPTION
Latest list of Certificate Transparency logs that have completed at least 90 days of Google's compliance monitoring successfully.

Generated by https://github.com/RJPercival/certificate-transparency/blob/0a753fb4487bbf33de7b202133aac95cd0bf21b2/python/utilities/log_list/openssl_generator.py from the log list found at https://sites.google.com/site/certificatetransparency/known-logs.