### PR TITLE
initialize the RSA struct to 0.

### DIFF
--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -143,6 +143,7 @@ RSA *RSA_new_method(ENGINE *engine)
         RSAerr(RSA_F_RSA_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
+    memset(ret,0,sizeof(RSA));
 
     ret->meth = RSA_get_default_method();
 #ifndef OPENSSL_NO_ENGINE


### PR DESCRIPTION
This helps with program code linked against static builds accessing a uninitialized ->engine pointer. (like e.g. steam)