### PR TITLE
Fix CT base64 decoding

### DIFF
--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -45,6 +45,11 @@ static int ct_base64_decode(const char *in, unsigned char **out)
         goto err;
     }
 
+    /* Subtract padding bytes from |outlen| */
+    while (in[--inlen] == '=') {
+        --outlen;
+    }
+
     *out = outbuf;
     return outlen;
 err:

--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -64,6 +64,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 {
     SCT *sct = SCT_new();
     unsigned char *dec = NULL;
+    const unsigned char* p = NULL;
     int declen;
 
     if (sct == NULL) {
@@ -102,7 +103,9 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
         CTerr(CT_F_SCT_NEW_FROM_BASE64, X509_R_BASE64_DECODE_ERROR);
         goto err;
     }
-    if (o2i_SCT_signature(sct, (const unsigned char **)&dec, declen) <= 0)
+
+    p = dec;
+    if (o2i_SCT_signature(sct, &p, declen) <= 0)
         goto err;
     OPENSSL_free(dec);
     dec = NULL;

--- a/crypto/ct/ct_oct.c
+++ b/crypto/ct/ct_oct.c
@@ -254,11 +254,6 @@ err:
     return -1;
 }
 
-void SCT_LIST_free(STACK_OF(SCT) *a)
-{
-    sk_SCT_pop_free(a, SCT_free);
-}
-
 STACK_OF(SCT) *o2i_SCT_LIST(STACK_OF(SCT) **a, const unsigned char **pp,
                             size_t len)
 {

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -45,6 +45,11 @@ void SCT_free(SCT *sct)
     OPENSSL_free(sct);
 }
 
+void SCT_LIST_free(STACK_OF(SCT) *a)
+{
+    sk_SCT_pop_free(a, SCT_free);
+}
+
 int SCT_set_version(SCT *sct, sct_version_t version)
 {
     if (version != SCT_VERSION_V1) {

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -512,39 +512,25 @@ static int test_decode_tls_sct()
 
 static int test_encode_tls_sct()
 {
-    const unsigned char log_id[] = "\xDF\x1C\x2E\xC1\x15\x00\x94\x52\x47\xA9"
-            "\x61\x68\x32\x5D\xDC\x5C\x79\x59\xE8\xF7\xC6\xD3\x88\xFC\x00\x2E"
-            "\x0B\xBD\x3F\x74\xD7\x64";
-
-    const unsigned char signature[] = "\x45\x02\x20\x48\x2F\x67\x51\xAF\x35"
-            "\xDB\xA6\x54\x36\xBE\x1F\xD6\x64\x0F\x3D\xBF\x9A\x41\x42\x94\x95"
-            "\x92\x45\x30\x28\x8F\xA3\xE5\xE2\x3E\x06\x02\x21\x00\xE4\xED\xC0"
-            "\xDB\x3A\xC5\x72\xB1\xE2\xF5\xE8\xAB\x6A\x68\x06\x53\x98\x7D\xCF"
-            "\x41\x02\x7D\xFE\xFF\xA1\x05\x51\x9D\x89\xED\xBF\x08";
+    const char log_id[] = "3xwuwRUAlFJHqWFoMl3cXHlZ6PfG04j8AC4LvT9012Q=";
+    const uint64_t timestamp = 1;
+    const char extensions[] = "";
+    const char signature[] = "RQIgSC9nUa8126ZUNr4f1mQPPb+aQUKUlZJFMCiPo+XiPgY"
+        "CIQDk7cDbOsVyseL16KtqaAZTmH3PQQJ9/v+hBVGdie2/CA==";
 
     SETUP_CT_TEST_FIXTURE();
 
     STACK_OF(SCT) *sct_list = sk_SCT_new_null();
-    SCT *sct = SCT_new();
-    if (!SCT_set_version(sct, SCT_VERSION_V1)) {
-        fprintf(stderr, "Failed to set SCT version\n");
-        return 0;
-    }
-    if (!SCT_set1_log_id(sct, log_id, 32)) {
-        fprintf(stderr, "Failed to set SCT log ID\n");
-        return 0;
-    }
-    SCT_set_timestamp(sct, 1);
-    if (!SCT_set_signature_nid(sct, NID_ecdsa_with_SHA256)) {
-        fprintf(stderr, "Failed to set SCT signature NID\n");
-        return 0;
-    }
-    if (!SCT_set1_signature(sct, signature, 71)) {
-        fprintf(stderr, "Failed to set SCT signature\n");
-        return 0;
-    }
-    sk_SCT_push(sct_list, sct);
+    SCT *sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
+                                   CT_LOG_ENTRY_TYPE_X509, timestamp,
+                                   extensions, signature);
 
+    if (sct == NULL) {
+        fprintf(stderr, "Failed to create SCT from base64-encoded test data\n");
+        return 0;
+    }
+
+    sk_SCT_push(sct_list, sct);
     fixture.sct_list = sct_list;
     fixture.sct_dir = ct_dir;
     fixture.sct_text_file = "tls1.sct";

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -515,8 +515,8 @@ static int test_encode_tls_sct()
     const char log_id[] = "3xwuwRUAlFJHqWFoMl3cXHlZ6PfG04j8AC4LvT9012Q=";
     const uint64_t timestamp = 1;
     const char extensions[] = "";
-    const char signature[] = "RQIgSC9nUa8126ZUNr4f1mQPPb+aQUKUlZJFMCiPo+XiPgY"
-        "CIQDk7cDbOsVyseL16KtqaAZTmH3PQQJ9/v+hBVGdie2/CA==";
+    const char signature[] = "BAMARzBAMiBIL2dRrzXbplQ2vh/WZA89v5pBQpSVkkUwKI+j5"
+            "eI+BgIhAOTtwNs6xXKx4vXoq2poBlOYfc9BAn3+/6EFUZ2J7b8I";
 
     SETUP_CT_TEST_FIXTURE();
 

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -61,30 +61,28 @@ static CT_TEST_FIXTURE set_up(const char *const test_case_name)
 {
     CT_TEST_FIXTURE fixture;
     int setup_ok = 1;
-    CTLOG_STORE *ctlog_store;
 
     memset(&fixture, 0, sizeof(fixture));
 
-    ctlog_store = CTLOG_STORE_new();
+    fixture.test_case_name = test_case_name;
+    fixture.epoch_time_in_ms = 1473269626000; /* Sep 7 17:33:46 2016 GMT */
+    fixture.ctlog_store = CTLOG_STORE_new();
 
-    if (ctlog_store == NULL) {
+    if (fixture.ctlog_store == NULL) {
         setup_ok = 0;
         fprintf(stderr, "Failed to create a new CT log store\n");
         goto end;
     }
 
-    if (CTLOG_STORE_load_default_file(ctlog_store) != 1) {
+    if (CTLOG_STORE_load_default_file(fixture.ctlog_store) != 1) {
         setup_ok = 0;
         fprintf(stderr, "Failed to load CT log list\n");
         goto end;
     }
 
-    fixture.test_case_name = test_case_name;
-    fixture.epoch_time_in_ms = 1473269626000; /* Sep 7 17:33:46 2016 GMT */
-    fixture.ctlog_store = ctlog_store;
-
 end:
     if (!setup_ok) {
+        CTLOG_STORE_free(fixture.ctlog_store);
         exit(EXIT_FAILURE);
     }
     return fixture;
@@ -517,21 +515,22 @@ static int test_encode_tls_sct()
     const char extensions[] = "";
     const char signature[] = "BAMARzBAMiBIL2dRrzXbplQ2vh/WZA89v5pBQpSVkkUwKI+j5"
             "eI+BgIhAOTtwNs6xXKx4vXoq2poBlOYfc9BAn3+/6EFUZ2J7b8I";
+    SCT *sct = NULL;
 
     SETUP_CT_TEST_FIXTURE();
 
-    STACK_OF(SCT) *sct_list = sk_SCT_new_null();
-    SCT *sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
-                                   CT_LOG_ENTRY_TYPE_X509, timestamp,
-                                   extensions, signature);
+    fixture.sct_list = sk_SCT_new_null();
+    sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
+                              CT_LOG_ENTRY_TYPE_X509, timestamp,
+                              extensions, signature);
 
     if (sct == NULL) {
+        tear_down(fixture);
         fprintf(stderr, "Failed to create SCT from base64-encoded test data\n");
         return 0;
     }
 
-    sk_SCT_push(sct_list, sct);
-    fixture.sct_list = sct_list;
+    sk_SCT_push(fixture.sct_list, sct);
     fixture.sct_dir = ct_dir;
     fixture.sct_text_file = "tls1.sct";
     EXECUTE_CT_TEST();


### PR DESCRIPTION
This gives better code coverage and is more representative of how a user would likely construct an SCT (using the base64 returned by a CT log).
