### PR TITLE
Reject SCTs with timestamps in the future

### DIFF
--- a/crypto/ct/ct_err.c
+++ b/crypto/ct/ct_err.c
@@ -36,6 +36,7 @@ static ERR_STRING_DATA CT_str_functs[] = {
     {ERR_FUNC(CT_F_O2I_SCT_LIST), "o2i_SCT_LIST"},
     {ERR_FUNC(CT_F_O2I_SCT_SIGNATURE), "o2i_SCT_signature"},
     {ERR_FUNC(CT_F_SCT_CTX_NEW), "SCT_CTX_new"},
+    {ERR_FUNC(CT_F_SCT_CTX_VERIFY), "SCT_CTX_verify"},
     {ERR_FUNC(CT_F_SCT_NEW), "SCT_new"},
     {ERR_FUNC(CT_F_SCT_NEW_FROM_BASE64), "SCT_new_from_base64"},
     {ERR_FUNC(CT_F_SCT_SET0_LOG_ID), "SCT_set0_log_id"},
@@ -45,7 +46,6 @@ static ERR_STRING_DATA CT_str_functs[] = {
     {ERR_FUNC(CT_F_SCT_SET_LOG_ENTRY_TYPE), "SCT_set_log_entry_type"},
     {ERR_FUNC(CT_F_SCT_SET_SIGNATURE_NID), "SCT_set_signature_nid"},
     {ERR_FUNC(CT_F_SCT_SET_VERSION), "SCT_set_version"},
-    {ERR_FUNC(CT_F_SCT_CTX_VERIFY), "SCT_CTX_verify"},
     {0, NULL}
 };
 
@@ -58,6 +58,7 @@ static ERR_STRING_DATA CT_str_reasons[] = {
      "log conf missing description"},
     {ERR_REASON(CT_R_LOG_CONF_MISSING_KEY), "log conf missing key"},
     {ERR_REASON(CT_R_LOG_KEY_INVALID), "log key invalid"},
+    {ERR_REASON(CT_R_SCT_FUTURE_TIMESTAMP), "sct future timestamp"},
     {ERR_REASON(CT_R_SCT_INVALID), "sct invalid"},
     {ERR_REASON(CT_R_SCT_INVALID_SIGNATURE), "sct invalid signature"},
     {ERR_REASON(CT_R_SCT_LIST_INVALID), "sct list invalid"},

--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -155,10 +155,11 @@ __owur int SCT_CTX_set1_issuer_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey);
 __owur int SCT_CTX_set1_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey);
 
 /*
- * Sets the current time, in milliseconds since the Unix epoch.
- * The timestamp of the SCT will be compared to this, to check that it was not
- * issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
- * timestamp is in the future", so SCT verification will fail in this case.
+ * Sets the time to evaluate the SCT against, in milliseconds since the Unix
+ * epoch. If the SCT's timestamp is after this time, it will be interpreted as
+ * having been issued in the future. RFC6962 states that "TLS clients MUST
+ * reject SCTs whose timestamp is in the future", so an SCT will not validate
+ * in this case.
  */
 void SCT_CTX_set_time(SCT_CTX *sctx, uint64_t time_in_ms);
 

--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -98,6 +98,8 @@ struct sct_ctx_st {
     /* pre-certificate encoding */
     unsigned char *preder;
     size_t prederlen;
+    /* milliseconds since epoch (to check that the SCT isn't from the future) */
+    uint64_t epoch_time_in_ms;
 };
 
 /* Context when evaluating whether a Certificate Transparency policy is met */
@@ -105,6 +107,8 @@ struct ct_policy_eval_ctx_st {
     X509 *cert;
     X509 *issuer;
     CTLOG_STORE *log_store;
+    /* milliseconds since epoch (to check that SCTs aren't from the future) */
+    uint64_t epoch_time_in_ms;
 };
 
 /*
@@ -149,6 +153,14 @@ __owur int SCT_CTX_set1_issuer_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey);
  * Returns 1 on success, 0 on failure.
  */
 __owur int SCT_CTX_set1_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey);
+
+/*
+ * Sets the current time, in milliseconds since the Unix epoch.
+ * The timestamp of the SCT will be compared to this, to check that it was not
+ * issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
+ * timestamp is in the future", so SCT verification will fail in this case.
+ */
+void SCT_CTX_set_time(SCT_CTX *sctx, uint64_t time_in_ms);
 
 /*
  * Verifies an SCT with the given context.

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -33,7 +33,9 @@ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
     }
 
     // time(NULL) shouldn't ever fail, so don't bother checking for -1.
-    ctx->epoch_time_in_ms = (time(NULL) + SCT_CLOCK_DRIFT_TOLERANCE) * 1000;
+    ctx->epoch_time_in_ms = (uint64_t)(time(NULL) + SCT_CLOCK_DRIFT_TOLERANCE) *
+            1000;
+
     return ctx;
 }
 

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -13,17 +13,24 @@
 
 #include <openssl/ct.h>
 #include <openssl/err.h>
+#include <time.h>
 
 #include "ct_locl.h"
 
 CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
 {
     CT_POLICY_EVAL_CTX *ctx = OPENSSL_zalloc(sizeof(CT_POLICY_EVAL_CTX));
+    time_t epoch_time_in_s;
 
     if (ctx == NULL) {
         CTerr(CT_F_CT_POLICY_EVAL_CTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
+
+    // Use the current time if available.
+    time(&epoch_time_in_s);
+    if (epoch_time_in_s != -1)
+        ctx->epoch_time_in_ms = epoch_time_in_s * 1000;
 
     return ctx;
 }

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -17,6 +17,12 @@
 
 #include "ct_locl.h"
 
+// Number of seconds in the future that an SCT timestamp can be, by default,
+// without being considered invalid. This is added to time() when setting a
+// default value for CT_POLICY_EVAL_CTX.epoch_time_in_ms.
+// It can be overridden by calling CT_POLICY_EVAL_CTX_set_time().
+static const time_t SCT_CLOCK_DRIFT_TOLERANCE = 300;
+
 CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
 {
     CT_POLICY_EVAL_CTX *ctx = OPENSSL_zalloc(sizeof(CT_POLICY_EVAL_CTX));
@@ -27,7 +33,7 @@ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
     }
 
     // time(NULL) shouldn't ever fail, so don't bother checking for -1.
-    ctx->epoch_time_in_ms = time(NULL) * 1000;
+    ctx->epoch_time_in_ms = (time(NULL) + SCT_CLOCK_DRIFT_TOLERANCE) * 1000;
     return ctx;
 }
 

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -20,18 +20,14 @@
 CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
 {
     CT_POLICY_EVAL_CTX *ctx = OPENSSL_zalloc(sizeof(CT_POLICY_EVAL_CTX));
-    time_t epoch_time_in_s;
 
     if (ctx == NULL) {
         CTerr(CT_F_CT_POLICY_EVAL_CTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
-    // Use the current time if available.
-    time(&epoch_time_in_s);
-    if (epoch_time_in_s != -1)
-        ctx->epoch_time_in_ms = epoch_time_in_s * 1000;
-
+    // time(NULL) shouldn't ever fail, so don't bother checking for -1.
+    ctx->epoch_time_in_ms = time(NULL) * 1000;
     return ctx;
 }
 

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -59,6 +59,11 @@ void CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE(CT_POLICY_EVAL_CTX *ctx,
     ctx->log_store = log_store;
 }
 
+void CT_POLICY_EVAL_CTX_set_time(CT_POLICY_EVAL_CTX *ctx, uint64_t time_in_ms)
+{
+    ctx->epoch_time_in_ms = time_in_ms;
+}
+
 X509* CT_POLICY_EVAL_CTX_get0_cert(const CT_POLICY_EVAL_CTX *ctx)
 {
     return ctx->cert;
@@ -74,3 +79,7 @@ const CTLOG_STORE *CT_POLICY_EVAL_CTX_get0_log_store(const CT_POLICY_EVAL_CTX *c
     return ctx->log_store;
 }
 
+uint64_t CT_POLICY_EVAL_CTX_get_time(const CT_POLICY_EVAL_CTX *ctx)
+{
+    return ctx->epoch_time_in_ms;
+}

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -17,10 +17,12 @@
 
 #include "ct_locl.h"
 
-// Number of seconds in the future that an SCT timestamp can be, by default,
-// without being considered invalid. This is added to time() when setting a
-// default value for CT_POLICY_EVAL_CTX.epoch_time_in_ms.
-// It can be overridden by calling CT_POLICY_EVAL_CTX_set_time().
+/*
+ * Number of seconds in the future that an SCT timestamp can be, by default,
+ * without being considered invalid. This is added to time() when setting a
+ * default value for CT_POLICY_EVAL_CTX.epoch_time_in_ms.
+ * It can be overridden by calling CT_POLICY_EVAL_CTX_set_time().
+ */
 static const time_t SCT_CLOCK_DRIFT_TOLERANCE = 300;
 
 CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
@@ -32,7 +34,7 @@ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
         return NULL;
     }
 
-    // time(NULL) shouldn't ever fail, so don't bother checking for -1.
+    /* time(NULL) shouldn't ever fail, so don't bother checking for -1. */
     ctx->epoch_time_in_ms = (uint64_t)(time(NULL) + SCT_CLOCK_DRIFT_TOLERANCE) *
             1000;
 

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -332,6 +332,8 @@ int SCT_validate(SCT *sct, const CT_POLICY_EVAL_CTX *ctx)
             goto err;
     }
 
+    SCT_CTX_set_time(sctx, ctx->epoch_time_in_ms);
+
     /*
      * XXX: Potential for optimization.  This repeats some idempotent heavy
      * lifting on the certificate for each candidate SCT, and appears to not

--- a/crypto/ct/ct_sct_ctx.c
+++ b/crypto/ct/ct_sct_ctx.c
@@ -256,3 +256,8 @@ int SCT_CTX_set1_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey)
     sctx->pkey = pkey;
     return 1;
 }
+
+void SCT_CTX_set_time(SCT_CTX *sctx, uint64_t time_in_ms)
+{
+    sctx->epoch_time_in_ms = time_in_ms;
+}

--- a/crypto/ct/ct_vfy.c
+++ b/crypto/ct/ct_vfy.c
@@ -113,6 +113,10 @@ int SCT_CTX_verify(const SCT_CTX *sctx, const SCT *sct)
         CTerr(CT_F_SCT_CTX_VERIFY, CT_R_SCT_LOG_ID_MISMATCH);
         return 0;
     }
+    if (sct->timestamp > sctx->epoch_time_in_ms) {
+        CTerr(CT_F_SCT_CTX_VERIFY, CT_R_SCT_FUTURE_TIMESTAMP);
+        return 0;
+    }
 
     ctx = EVP_MD_CTX_new();
     if (ctx == NULL)

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -5,7 +5,8 @@
 CT_POLICY_EVAL_CTX_new, CT_POLICY_EVAL_CTX_free,
 CT_POLICY_EVAL_CTX_get0_cert, CT_POLICY_EVAL_CTX_set1_cert,
 CT_POLICY_EVAL_CTX_get0_issuer, CT_POLICY_EVAL_CTX_set1_issuer,
-CT_POLICY_EVAL_CTX_get0_log_store, CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE -
+CT_POLICY_EVAL_CTX_get0_log_store, CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE,
+CT_POLICY_EVAL_CTX_get_time, CT_POLICY_EVAL_CTX_set_time -
 Encapsulates the data required to evaluate whether SCTs meet a Certificate Transparency policy
 
 =head1 SYNOPSIS
@@ -20,13 +21,16 @@ Encapsulates the data required to evaluate whether SCTs meet a Certificate Trans
  int CT_POLICY_EVAL_CTX_set1_issuer(CT_POLICY_EVAL_CTX *ctx, X509 *issuer);
  const CTLOG_STORE *CT_POLICY_EVAL_CTX_get0_log_store(const CT_POLICY_EVAL_CTX *ctx);
  void CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE(CT_POLICY_EVAL_CTX *ctx, CTLOG_STORE *log_store);
+ uint64_t CT_POLICY_EVAL_CTX_get_time(const CT_POLICY_EVAL_CTX *ctx);
+ void CT_POLICY_EVAL_CTX_set_time(CT_POLICY_EVAL_CTX *ctx, uint64_t time_in_ms);
 
 =head1 DESCRIPTION
 
 A B<CT_POLICY_EVAL_CTX> is used by functions that evaluate whether Signed
 Certificate Timestamps (SCTs) fulfil a Certificate Transparency (CT) policy.
 This policy may be, for example, that at least one valid SCT is available. To
-determine this, an SCT's signature must be verified. This requires:
+determine this, an SCT's timestamp and signature must be verified.
+This requires:
 
 =over
 
@@ -35,6 +39,8 @@ determine this, an SCT's signature must be verified. This requires:
 =item * the certificate that the SCT was issued for
 
 =item * the issuer certificate (if the SCT was issued for a pre-certificate)
+
+=item * the current time
 
 =back
 
@@ -57,6 +63,12 @@ Increments the reference count of the certificate.
 
 Holds a pointer to the CTLOG_STORE, so the CTLOG_STORE must outlive the
 CT_POLICY_EVAL_CTX.
+
+=item * CT_POLICY_EVAL_CTX_set_time() to provide the current time
+
+The SCT timestamp will be compared to this time to check whether the SCT was
+supposedly issued in the future. RFC6962 states that "TLS clients MUST reject
+SCTs whose timestamp is in the future".
 
 =back
 

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -68,8 +68,8 @@ CT_POLICY_EVAL_CTX.
 
 The SCT timestamp will be compared to this time to check whether the SCT was
 issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
-timestamp is in the future". By default, this will be set to the
-current time (obtained by calling time()) if possible.
+timestamp is in the future". By default, this will be set to 5 minutes in the
+future (e.g. (time() + 300) * 1000), to allow for clock drift.
 
 The time should be in milliseconds since the Unix epoch.
 

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -68,8 +68,8 @@ CT_POLICY_EVAL_CTX.
 
 The SCT timestamp will be compared to this time to check whether the SCT was
 issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
-timestamp is in the future". Typically, the time provided to this function will
-be the current time.
+timestamp is in the future". By default, this will be set to the
+current time (obtained by calling time()) if possible.
 
 The time should be in milliseconds since the Unix epoch.
 

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -64,11 +64,14 @@ Increments the reference count of the certificate.
 Holds a pointer to the CTLOG_STORE, so the CTLOG_STORE must outlive the
 CT_POLICY_EVAL_CTX.
 
-=item * CT_POLICY_EVAL_CTX_set_time() to provide the current time
+=item * CT_POLICY_EVAL_CTX_set_time() to set the time SCTs should be compared with to determine if they are valid
 
 The SCT timestamp will be compared to this time to check whether the SCT was
-supposedly issued in the future. RFC6962 states that "TLS clients MUST reject
-SCTs whose timestamp is in the future".
+issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
+timestamp is in the future". Typically, the time provided to this function will
+be the current time.
+
+The time should be in milliseconds since the Unix epoch.
 
 =back
 

--- a/doc/man3/SCT_validate.pod
+++ b/doc/man3/SCT_validate.pod
@@ -54,9 +54,11 @@ status will be SCT_VALIDATION_STATUS_UNKNOWN_LOG.
 If the SCT is of an unsupported version (only v1 is currently supported), the
 validation status will be SCT_VALIDATION_STATUS_UNKNOWN_VERSION.
 
-If the SCT's signature is incorrect, the validation status will be
-SCT_VALIDATION_STATUS_INVALID. Otherwise, if all checks have passed, the
-validation status will be SCT_VALIDATION_STATUS_VALID.
+If the SCT's signature is incorrect, its timestamp is in the future (relative to
+the time in CT_POLICY_EVAL_CTX), or if it is otherwise invalid, the validation
+status will be SCT_VALIDATION_STATUS_INVALID.
+
+If all checks pass, the validation status will be SCT_VALIDATION_STATUS_VALID.
 
 =head1 NOTES
 

--- a/doc/man3/SSL_CTX_set_ct_validation_callback.pod
+++ b/doc/man3/SSL_CTX_set_ct_validation_callback.pod
@@ -97,6 +97,9 @@ otherwise.
 When SCT processing is enabled, OCSP stapling will be enabled. This is because
 one possible source of SCTs is the OCSP response from a server.
 
+The time returned by SSL_SESSION_get_time() will be used to evaluate whether any
+presented SCTs have timestamps that are in the future (and therefore invalid).
+
 =head1 RESTRICTIONS
 
 Certificate Transparency validation cannot be enabled and so a callback cannot
@@ -124,7 +127,8 @@ L<ssl(7)>,
 L<SSL_session_reused(3)>,
 L<SSL_set_verify(3)>,
 L<SSL_CTX_set_verify(3)>,
-L<ssl_ct_validation_cb(3)>
+L<ssl_ct_validation_cb(3)>,
+L<SSL_SESSION_get_time(3)>
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -482,7 +482,6 @@ int ERR_load_CT_strings(void);
 # define CT_F_CTLOG_NEW                                   117
 # define CT_F_CTLOG_NEW_FROM_BASE64                       118
 # define CT_F_CTLOG_NEW_FROM_CONF                         119
-# define CT_F_CTLOG_NEW_NULL                              120
 # define CT_F_CTLOG_STORE_LOAD_CTX_NEW                    122
 # define CT_F_CTLOG_STORE_LOAD_FILE                       123
 # define CT_F_CTLOG_STORE_LOAD_LOG                        130

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -106,9 +106,9 @@ void CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE(CT_POLICY_EVAL_CTX *ctx,
 uint64_t CT_POLICY_EVAL_CTX_get_time(const CT_POLICY_EVAL_CTX *ctx);
 
 /*
- * Sets the current time, in milliseconds since the Unix epoch.
- * The timestamps of the SCTs will be compared to this, to check that they were
- * not issued in the future. RFC6962 states that "TLS clients MUST reject SCTs
+ * Sets the time to evaluate SCTs against, in milliseconds since the Unix epoch.
+ * If an SCT's timestamp is after this time, it will be interpreted as having
+ * been issued in the future. RFC6962 states that "TLS clients MUST reject SCTs
  * whose timestamp is in the future", so an SCT will not validate in this case.
  */
 void CT_POLICY_EVAL_CTX_set_time(CT_POLICY_EVAL_CTX *ctx, uint64_t time_in_ms);

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -98,6 +98,21 @@ const CTLOG_STORE *CT_POLICY_EVAL_CTX_get0_log_store(const CT_POLICY_EVAL_CTX *c
 void CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE(CT_POLICY_EVAL_CTX *ctx,
                                                CTLOG_STORE *log_store);
 
+/*
+ * Gets the time, in milliseconds since the Unix epoch, that will be used as the
+ * current time when checking whether an SCT was issued in the future.
+ * Such SCTs will fail validation, as required by RFC6962.
+ */
+uint64_t CT_POLICY_EVAL_CTX_get_time(const CT_POLICY_EVAL_CTX *ctx);
+
+/*
+ * Sets the current time, in milliseconds since the Unix epoch.
+ * The timestamps of the SCTs will be compared to this, to check that they were
+ * not issued in the future. RFC6962 states that "TLS clients MUST reject SCTs
+ * whose timestamp is in the future", so an SCT will not validate in this case.
+ */
+void CT_POLICY_EVAL_CTX_set_time(CT_POLICY_EVAL_CTX *ctx, uint64_t time_in_ms);
+
 /*****************
  * SCT functions *
  *****************/
@@ -482,6 +497,7 @@ int ERR_load_CT_strings(void);
 # define CT_F_O2I_SCT_LIST                                111
 # define CT_F_O2I_SCT_SIGNATURE                           112
 # define CT_F_SCT_CTX_NEW                                 126
+# define CT_F_SCT_CTX_VERIFY                              128
 # define CT_F_SCT_NEW                                     100
 # define CT_F_SCT_NEW_FROM_BASE64                         127
 # define CT_F_SCT_SET0_LOG_ID                             101
@@ -491,7 +507,6 @@ int ERR_load_CT_strings(void);
 # define CT_F_SCT_SET_LOG_ENTRY_TYPE                      102
 # define CT_F_SCT_SET_SIGNATURE_NID                       103
 # define CT_F_SCT_SET_VERSION                             104
-# define CT_F_SCT_CTX_VERIFY                              128
 
 /* Reason codes. */
 # define CT_R_BASE64_DECODE_ERROR                         108
@@ -501,6 +516,7 @@ int ERR_load_CT_strings(void);
 # define CT_R_LOG_CONF_MISSING_DESCRIPTION                111
 # define CT_R_LOG_CONF_MISSING_KEY                        112
 # define CT_R_LOG_KEY_INVALID                             113
+# define CT_R_SCT_FUTURE_TIMESTAMP                        116
 # define CT_R_SCT_INVALID                                 104
 # define CT_R_SCT_INVALID_SIGNATURE                       107
 # define CT_R_SCT_LIST_INVALID                            105

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4279,6 +4279,7 @@ int ssl_validate_ct(SSL *s)
     CT_POLICY_EVAL_CTX_set1_cert(ctx, cert);
     CT_POLICY_EVAL_CTX_set1_issuer(ctx, issuer);
     CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE(ctx, s->ctx->ctlog_store);
+    CT_POLICY_EVAL_CTX_set_time(ctx, SSL_SESSION_get_time(SSL_get0_session(s)));
 
     scts = SSL_get0_peer_scts(s);
 

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -8,6 +8,7 @@
  */
 
 #include <ctype.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -550,6 +551,30 @@ static int test_encode_tls_sct()
     EXECUTE_CT_TEST();
 }
 
+/*
+ * Tests that the CT_POLICY_EVAL_CTX default time is approximately now.
+ * Allow +-10 minutes, as it may compensate for clock skew.
+ */
+static int test_default_ct_policy_eval_ctx_time_is_now()
+{
+    int success = 0;
+    CT_POLICY_EVAL_CTX *ct_policy_ctx = CT_POLICY_EVAL_CTX_new();
+    const time_t default_time = CT_POLICY_EVAL_CTX_get_time(ct_policy_ctx) /
+            1000;
+    const time_t time_tolerance = 600;  /* 10 minutes */
+
+    if (fabs(difftime(time(NULL), default_time)) > time_tolerance) {
+        fprintf(stderr,
+                "Default CT_POLICY_EVAL_CTX time is not approximately now.\n");
+        goto end;
+    }
+
+    success = 1;
+end:
+    CT_POLICY_EVAL_CTX_free(ct_policy_ctx);
+    return success;
+}
+
 int test_main(int argc, char *argv[])
 {
     int result = 0;
@@ -568,6 +593,7 @@ int test_main(int argc, char *argv[])
     ADD_TEST(test_verify_fails_for_future_sct);
     ADD_TEST(test_decode_tls_sct);
     ADD_TEST(test_encode_tls_sct);
+    ADD_TEST(test_default_ct_policy_eval_ctx_time_is_now);
 
     result = run_tests(argv[0]);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4218,3 +4218,5 @@ BIO_meth_get_write_ex                   4168	1_1_1	EXIST::FUNCTION:
 BIO_meth_set_write_ex                   4169	1_1_1	EXIST::FUNCTION:
 DSO_pathbyaddr                          4170	1_1_0c	EXIST::FUNCTION:
 DSO_dsobyaddr                           4171	1_1_0c	EXIST::FUNCTION:
+CT_POLICY_EVAL_CTX_get_time             4172	1_1_1	EXIST::FUNCTION:CT
+CT_POLICY_EVAL_CTX_set_time             4173	1_1_1	EXIST::FUNCTION:CT


### PR DESCRIPTION
As per [RFC6962](https://tools.ietf.org/html/rfc6962#section-5.2), "TLS clients MUST reject SCTs whose timestamp is in the future.".
