### PR TITLE
Add -Wswitch-enum

### DIFF
--- a/Configure
+++ b/Configure
@@ -114,6 +114,7 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
         # it grew impossible to resolve this without sizeable additional
         # code, so we just tell compiler to be pedantic about everything
         # but 'long long' type.
+        . " -Wswitch"
         . " -DPEDANTIC -pedantic -Wno-long-long"
         . " -Wall"
         . " -Wsign-compare"
@@ -127,7 +128,6 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.
 # TODO(openssl-team): fix problems and investigate if (at least) the
 # following warnings can also be enabled:
-#       -Wswitch-enum
 #       -Wcast-align
 #       -Wunreachable-code
 #       -Wlanguage-extension-token -- no, we use asm()
@@ -136,6 +136,7 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 my $clang_devteam_warn = ""
         . " -Qunused-arguments"
         . " -Wextra"
+        . " -Wswitch -Wswitch-default"
         . " -Wno-unused-parameter"
         . " -Wno-missing-field-initializers"
         . " -Wno-language-extension-token"

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -188,7 +188,11 @@ static int ui_read(UI *ui, UI_STRING *uis)
                     return 1;
                 }
             }
-        default:
+            break;
+        case UIT_NONE:
+        case UIT_BOOLEAN:
+        case UIT_INFO:
+        case UIT_ERROR:
             break;
         }
     }
@@ -208,7 +212,11 @@ static int ui_write(UI *ui, UI_STRING *uis)
                 if (password && password[0] != '\0')
                     return 1;
             }
-        default:
+            break;
+        case UIT_NONE:
+        case UIT_BOOLEAN:
+        case UIT_INFO:
+        case UIT_ERROR:
             break;
         }
     }

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -393,10 +393,15 @@ int list_main(int argc, char **argv)
     return 0;
 }
 
+typedef enum HELP_CHOICE {
+    OPT_hERR = -1, OPT_hEOF = 0, OPT_hHELP
+} HELP_CHOICE;
+
 OPTIONS help_options[] = {
-    {"help", OPT_HELP, '-', "Display this summary"},
+    {"help", OPT_hHELP, '-', "Display this summary"},
     {NULL}
 };
+
 
 int help_main(int argc, char **argv)
 {
@@ -404,15 +409,16 @@ int help_main(int argc, char **argv)
     int i, nl;
     FUNC_TYPE tp;
     char *prog;
-    HELPLIST_CHOICE o;
+    HELP_CHOICE o;
 
     prog = opt_init(argc, argv, help_options);
-    while ((o = opt_next()) != OPT_EOF) {
+    while ((o = opt_next()) != OPT_hEOF) {
         switch (o) {
-        default:
+        case OPT_hERR:
+        case OPT_hEOF:
             BIO_printf(bio_err, "%s: Use -help for summary.\n", prog);
             return 1;
-        case OPT_HELP:
+        case OPT_hHELP:
             opt_help(help_options);
             return 0;
         }

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -296,19 +296,14 @@ int ts_main(int argc, char **argv)
         goto end;
 
     /* Check parameter consistency and execute the appropriate function. */
-    switch (mode) {
-    default:
-    case OPT_ERR:
-        goto opthelp;
-    case OPT_QUERY:
+    if (mode == OPT_QUERY) {
         if (vpmtouched)
             goto opthelp;
         if ((data != NULL) && (digest != NULL))
             goto opthelp;
         ret = !query_command(data, digest, md, policy, no_nonce, cert,
                              in, out, text);
-        break;
-    case OPT_REPLY:
+    } else if (mode == OPT_REPLY) {
         if (vpmtouched)
             goto opthelp;
         if ((in != NULL) && (queryfile != NULL))
@@ -320,13 +315,15 @@ int ts_main(int argc, char **argv)
         ret = !reply_command(conf, section, engine, queryfile,
                              password, inkey, md, signer, chain, policy,
                              in, token_in, out, token_out, text);
-        break;
-    case OPT_VERIFY:
+
+    } else if (mode == OPT_VERIFY) {
         if ((in == NULL) || !EXACTLY_ONE(queryfile, data, digest))
             goto opthelp;
         ret = !verify_command(data, digest, queryfile, in, token_in,
                               CApath, CAfile, untrusted,
                               vpmtouched ? vpm : NULL);
+    } else {
+        goto opthelp;
     }
 
  end:

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -157,7 +157,6 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
 
     for (;;) {
         switch (ctx->state) {
-
             /* Setup prefix data, call it */
         case ASN1_STATE_START:
             if (!asn1_bio_setup_ex(b, ctx, ctx->prefix,
@@ -223,7 +222,8 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
 
             break;
 
-        default:
+        case ASN1_STATE_POST_COPY:
+        case ASN1_STATE_DONE:
             BIO_clear_retry_flags(b);
             return 0;
 

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -65,10 +65,11 @@ int SCT_set_log_entry_type(SCT *sct, ct_log_entry_type_t entry_type)
     case CT_LOG_ENTRY_TYPE_PRECERT:
         sct->entry_type = entry_type;
         return 1;
-    default:
-        CTerr(CT_F_SCT_SET_LOG_ENTRY_TYPE, CT_R_UNSUPPORTED_ENTRY_TYPE);
-        return 0;
+    case CT_LOG_ENTRY_TYPE_NOT_SET:
+        break;
     }
+    CTerr(CT_F_SCT_SET_LOG_ENTRY_TYPE, CT_R_UNSUPPORTED_ENTRY_TYPE);
+    return 0;
 }
 
 int SCT_set0_log_id(SCT *sct, unsigned char *log_id, size_t log_id_len)
@@ -269,9 +270,11 @@ int SCT_set_source(SCT *sct, sct_source_t source)
         return SCT_set_log_entry_type(sct, CT_LOG_ENTRY_TYPE_X509);
     case SCT_SOURCE_X509V3_EXTENSION:
         return SCT_set_log_entry_type(sct, CT_LOG_ENTRY_TYPE_PRECERT);
-    default: /* if we aren't sure, leave the log entry type alone */
-        return 1;
+    case SCT_SOURCE_UNKNOWN:
+        break;
     }
+    /* if we aren't sure, leave the log entry type alone */
+    return 1;
 }
 
 sct_validation_status_t SCT_get_validation_status(const SCT *sct)

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -66,13 +66,13 @@ EC_GROUP *EC_GROUP_new(const EC_METHOD *meth)
 void EC_pre_comp_free(EC_GROUP *group)
 {
     switch (group->pre_comp_type) {
-    default:
+    case PCT_none:
         break;
-#ifdef ECP_NISTZ256_REFERENCE_IMPLEMENTATION
     case PCT_nistz256:
+#ifdef ECP_NISTZ256_ASM
         EC_nistz256_pre_comp_free(group->pre_comp.nistz256);
-        break;
 #endif
+        break;
 #ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
     case PCT_nistp224:
         EC_nistp224_pre_comp_free(group->pre_comp.nistp224);
@@ -82,6 +82,11 @@ void EC_pre_comp_free(EC_GROUP *group)
         break;
     case PCT_nistp521:
         EC_nistp521_pre_comp_free(group->pre_comp.nistp521);
+        break;
+#else
+    case PCT_nistp224:
+    case PCT_nistp256:
+    case PCT_nistp521:
         break;
 #endif
     case PCT_ec:
@@ -143,14 +148,14 @@ int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
     /* Copy precomputed */
     dest->pre_comp_type = src->pre_comp_type;
     switch (src->pre_comp_type) {
-    default:
+    case PCT_none:
         dest->pre_comp.ec = NULL;
         break;
-#ifdef ECP_NISTZ256_REFERENCE_IMPLEMENTATION
     case PCT_nistz256:
+#ifdef ECP_NISTZ256_ASM
         dest->pre_comp.nistz256 = EC_nistz256_pre_comp_dup(src->pre_comp.nistz256);
-        break;
 #endif
+        break;
 #ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
     case PCT_nistp224:
         dest->pre_comp.nistp224 = EC_nistp224_pre_comp_dup(src->pre_comp.nistp224);
@@ -160,6 +165,11 @@ int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
         break;
     case PCT_nistp521:
         dest->pre_comp.nistp521 = EC_nistp521_pre_comp_dup(src->pre_comp.nistp521);
+        break;
+#else
+    case PCT_nistp224:
+    case PCT_nistp256:
+    case PCT_nistp521:
         break;
 #endif
     case PCT_ec:

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -254,6 +254,16 @@ static BN_ULONG is_one(const BIGNUM *z)
     return res;
 }
 
+/*
+ * For reference, this macro is used only when new ecp_nistz256 assembly
+ * module is being developed.  For example, configure with
+ * -DECP_NISTZ256_REFERENCE_IMPLEMENTATION and implement only functions
+ * performing simplest arithmetic operations on 256-bit vectors. Then
+ * work on implementation of higher-level functions performing point
+ * operations. Then remove ECP_NISTZ256_REFERENCE_IMPLEMENTATION
+ * and never define it again. (The correct macro denoting presence of
+ * ecp_nistz256 module is ECP_NISTZ256_ASM.)
+ */
 #ifndef ECP_NISTZ256_REFERENCE_IMPLEMENTATION
 void ecp_nistz256_point_double(P256_POINT *r, const P256_POINT *a);
 void ecp_nistz256_point_add(P256_POINT *r,

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -60,7 +60,11 @@ static void free_string(UI_STRING *uis)
             OPENSSL_free((char *)uis->_.boolean_data.ok_chars);
             OPENSSL_free((char *)uis->_.boolean_data.cancel_chars);
             break;
-        default:
+        case UIT_NONE:
+        case UIT_PROMPT:
+        case UIT_VERIFY:
+        case UIT_ERROR:
+        case UIT_INFO:
             break;
         }
     }
@@ -689,9 +693,13 @@ const char *UI_get0_action_string(UI_STRING *uis)
     case UIT_PROMPT:
     case UIT_BOOLEAN:
         return uis->_.boolean_data.action_desc;
-    default:
-        return NULL;
+    case UIT_NONE:
+    case UIT_VERIFY:
+    case UIT_INFO:
+    case UIT_ERROR:
+        break;
     }
+    return NULL;
 }
 
 const char *UI_get0_result_string(UI_STRING *uis)
@@ -700,9 +708,13 @@ const char *UI_get0_result_string(UI_STRING *uis)
     case UIT_PROMPT:
     case UIT_VERIFY:
         return uis->result_buf;
-    default:
-        return NULL;
+    case UIT_NONE:
+    case UIT_BOOLEAN:
+    case UIT_INFO:
+    case UIT_ERROR:
+        break;
     }
+    return NULL;
 }
 
 const char *UI_get0_test_string(UI_STRING *uis)
@@ -710,9 +722,14 @@ const char *UI_get0_test_string(UI_STRING *uis)
     switch (uis->type) {
     case UIT_VERIFY:
         return uis->_.string_data.test_buf;
-    default:
-        return NULL;
+    case UIT_NONE:
+    case UIT_BOOLEAN:
+    case UIT_INFO:
+    case UIT_ERROR:
+    case UIT_PROMPT:
+        break;
     }
+    return NULL;
 }
 
 int UI_get_result_minsize(UI_STRING *uis)
@@ -721,9 +738,13 @@ int UI_get_result_minsize(UI_STRING *uis)
     case UIT_PROMPT:
     case UIT_VERIFY:
         return uis->_.string_data.result_minsize;
-    default:
-        return -1;
+    case UIT_NONE:
+    case UIT_INFO:
+    case UIT_ERROR:
+    case UIT_BOOLEAN:
+        break;
     }
+    return -1;
 }
 
 int UI_get_result_maxsize(UI_STRING *uis)
@@ -732,9 +753,13 @@ int UI_get_result_maxsize(UI_STRING *uis)
     case UIT_PROMPT:
     case UIT_VERIFY:
         return uis->_.string_data.result_maxsize;
-    default:
-        return -1;
+    case UIT_NONE:
+    case UIT_INFO:
+    case UIT_ERROR:
+    case UIT_BOOLEAN:
+        break;
     }
+    return -1;
 }
 
 int UI_set_result(UI *ui, UI_STRING *uis, const char *result)
@@ -800,7 +825,9 @@ int UI_set_result(UI *ui, UI_STRING *uis, const char *result)
                 }
             }
         }
-    default:
+    case UIT_NONE:
+    case UIT_INFO:
+    case UIT_ERROR:
         break;
     }
     return 0;

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -219,7 +219,10 @@ static int write_string(UI *ui, UI_STRING *uis)
         fputs(UI_get0_output_string(uis), tty_out);
         fflush(tty_out);
         break;
-    default:
+    case UIT_NONE:
+    case UIT_PROMPT:
+    case UIT_VERIFY:
+    case UIT_BOOLEAN:
         break;
     }
     return 1;
@@ -256,7 +259,9 @@ static int read_string(UI *ui, UI_STRING *uis)
             return 0;
         }
         break;
-    default:
+    case UIT_NONE:
+    case UIT_INFO:
+    case UIT_ERROR:
         break;
     }
     return 1;

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -132,7 +132,7 @@ static int x509_object_cmp(const X509_OBJECT *const *a,
     case X509_LU_CRL:
         ret = X509_CRL_cmp((*a)->data.crl, (*b)->data.crl);
         break;
-    default:
+    case X509_LU_NONE:
         /* abort(); */
         return 0;
     }
@@ -377,7 +377,7 @@ int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x)
 int X509_OBJECT_up_ref_count(X509_OBJECT *a)
 {
     switch (a->type) {
-    default:
+    case X509_LU_NONE:
         break;
     case X509_LU_X509:
         return X509_up_ref(a->data.x509);
@@ -424,7 +424,7 @@ void X509_OBJECT_free(X509_OBJECT *a)
     if (a == NULL)
         return;
     switch (a->type) {
-    default:
+    case X509_LU_NONE:
         break;
     case X509_LU_X509:
         X509_free(a->data.x509);
@@ -454,7 +454,7 @@ static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, X509_LOOKUP_TYPE type,
         stmp.data.crl = &crl_s;
         crl_s.crl.issuer = name;
         break;
-    default:
+    case X509_LU_NONE:
         /* abort(); */
         return -1;
     }

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -590,7 +590,9 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
         case READ_STATE_POST_PROCESS:
             st->read_state_work = post_process_message(s, st->read_state_work);
             switch (st->read_state_work) {
-            default:
+            case WORK_ERROR:
+            case WORK_MORE_A:
+            case WORK_MORE_B:
                 return SUB_STATE_ERROR;
 
             case WORK_FINISHED_CONTINUE:
@@ -718,14 +720,16 @@ static SUB_STATE_RETURN write_state_machine(SSL *s)
                 return SUB_STATE_FINISHED;
                 break;
 
-            default:
+            case WRITE_TRAN_ERROR:
                 return SUB_STATE_ERROR;
             }
             break;
 
         case WRITE_STATE_PRE_WORK:
             switch (st->write_state_work = pre_work(s, st->write_state_work)) {
-            default:
+            case WORK_ERROR:
+            case WORK_MORE_A:
+            case WORK_MORE_B:
                 return SUB_STATE_ERROR;
 
             case WORK_FINISHED_CONTINUE:
@@ -754,7 +758,9 @@ static SUB_STATE_RETURN write_state_machine(SSL *s)
 
         case WRITE_STATE_POST_WORK:
             switch (st->write_state_work = post_work(s, st->write_state_work)) {
-            default:
+            case WORK_ERROR:
+            case WORK_MORE_A:
+            case WORK_MORE_B:
                 return SUB_STATE_ERROR;
 
             case WORK_FINISHED_CONTINUE:

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -122,6 +122,9 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
     int ske_expected;
 
     switch (st->hand_state) {
+    default:
+        break;
+
     case TLS_ST_CW_CLNT_HELLO:
         if (mt == SSL3_MT_SERVER_HELLO) {
             st->hand_state = TLS_ST_CR_SRVR_HELLO;
@@ -258,9 +261,6 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
             return 1;
         }
         break;
-
-    default:
-        break;
     }
 
  err:
@@ -279,6 +279,10 @@ WRITE_TRAN ossl_statem_client_write_transition(SSL *s)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return WRITE_TRAN_ERROR;
+
     case TLS_ST_OK:
         /* Renegotiation - fall through */
     case TLS_ST_BEFORE:
@@ -367,10 +371,6 @@ WRITE_TRAN ossl_statem_client_write_transition(SSL *s)
             ossl_statem_set_in_init(s, 0);
             return WRITE_TRAN_CONTINUE;
         }
-
-    default:
-        /* Shouldn't happen */
-        return WRITE_TRAN_ERROR;
     }
 }
 
@@ -383,6 +383,10 @@ WORK_STATE ossl_statem_client_pre_work(SSL *s, WORK_STATE wst)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* No pre work to be done */
+        break;
+
     case TLS_ST_CW_CLNT_HELLO:
         s->shutdown = 0;
         if (SSL_IS_DTLS(s)) {
@@ -408,14 +412,10 @@ WORK_STATE ossl_statem_client_pre_work(SSL *s, WORK_STATE wst)
                 return dtls_wait_for_dry(s);
 #endif
         }
-        return WORK_FINISHED_CONTINUE;
+        break;
 
     case TLS_ST_OK:
         return tls_finish_handshake(s, wst);
-
-    default:
-        /* No pre work to be done */
-        break;
     }
 
     return WORK_FINISHED_CONTINUE;
@@ -432,6 +432,10 @@ WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst)
     s->init_num = 0;
 
     switch (st->hand_state) {
+    default:
+        /* No post work to be done */
+        break;
+
     case TLS_ST_CW_CLNT_HELLO:
         if (wst == WORK_MORE_A && statem_flush(s) != 1)
             return WORK_MORE_A;
@@ -494,10 +498,6 @@ WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst)
         if (statem_flush(s) != 1)
             return WORK_MORE_B;
         break;
-
-    default:
-        /* No post work to be done */
-        break;
     }
 
     return WORK_FINISHED_CONTINUE;
@@ -515,6 +515,10 @@ int ossl_statem_client_construct_message(SSL *s)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return 0;
+
     case TLS_ST_CW_CLNT_HELLO:
         return tls_construct_client_hello(s);
 
@@ -543,13 +547,7 @@ int ossl_statem_client_construct_message(SSL *s)
                                       ssl3_enc->client_finished_label,
                                       s->method->
                                       ssl3_enc->client_finished_label_len);
-
-    default:
-        /* Shouldn't happen */
-        break;
     }
-
-    return 0;
 }
 
 /*
@@ -561,6 +559,10 @@ unsigned long ossl_statem_client_max_message_size(SSL *s)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return 0;
+
     case TLS_ST_CR_SRVR_HELLO:
         return SERVER_HELLO_MAX_LENGTH;
 
@@ -597,13 +599,7 @@ unsigned long ossl_statem_client_max_message_size(SSL *s)
 
     case TLS_ST_CR_FINISHED:
         return FINISHED_MAX_LENGTH;
-
-    default:
-        /* Shouldn't happen */
-        break;
     }
-
-    return 0;
 }
 
 /*
@@ -614,6 +610,10 @@ MSG_PROCESS_RETURN ossl_statem_client_process_message(SSL *s, PACKET *pkt)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return MSG_PROCESS_ERROR;
+
     case TLS_ST_CR_SRVR_HELLO:
         return tls_process_server_hello(s, pkt);
 
@@ -643,13 +643,7 @@ MSG_PROCESS_RETURN ossl_statem_client_process_message(SSL *s, PACKET *pkt)
 
     case TLS_ST_CR_FINISHED:
         return tls_process_finished(s, pkt);
-
-    default:
-        /* Shouldn't happen */
-        break;
     }
-
-    return MSG_PROCESS_ERROR;
 }
 
 /*
@@ -661,6 +655,10 @@ WORK_STATE ossl_statem_client_post_process_message(SSL *s, WORK_STATE wst)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return WORK_ERROR;
+
     case TLS_ST_CR_CERT_REQ:
         return tls_prepare_client_certificate(s, wst);
 
@@ -678,13 +676,7 @@ WORK_STATE ossl_statem_client_post_process_message(SSL *s, WORK_STATE wst)
         ossl_statem_set_sctp_read_sock(s, 0);
         return WORK_FINISHED_STOP;
 #endif
-
-    default:
-        break;
     }
-
-    /* Shouldn't happen */
-    return WORK_ERROR;
 }
 
 int tls_construct_client_hello(SSL *s)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -82,6 +82,9 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        break;
+
     case TLS_ST_BEFORE:
     case DTLS_ST_SW_HELLO_VERIFY_REQUEST:
         if (mt == SSL3_MT_CLIENT_HELLO) {
@@ -207,9 +210,6 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
             return 1;
         }
         break;
-
-    default:
-        break;
     }
 
     /* No valid transition found */
@@ -312,6 +312,10 @@ WRITE_TRAN ossl_statem_server_write_transition(SSL *s)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return WRITE_TRAN_ERROR;
+
     case TLS_ST_BEFORE:
         /* Just go straight to trying to read from the client */
         return WRITE_TRAN_FINISHED;
@@ -414,10 +418,6 @@ WRITE_TRAN ossl_statem_server_write_transition(SSL *s)
         st->hand_state = TLS_ST_OK;
         ossl_statem_set_in_init(s, 0);
         return WRITE_TRAN_CONTINUE;
-
-    default:
-        /* Shouldn't happen */
-        return WRITE_TRAN_ERROR;
     }
 }
 
@@ -430,6 +430,10 @@ WORK_STATE ossl_statem_server_pre_work(SSL *s, WORK_STATE wst)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* No pre work to be done */
+        break;
+
     case TLS_ST_SW_HELLO_REQ:
         s->shutdown = 0;
         if (SSL_IS_DTLS(s))
@@ -491,10 +495,6 @@ WORK_STATE ossl_statem_server_pre_work(SSL *s, WORK_STATE wst)
 
     case TLS_ST_OK:
         return tls_finish_handshake(s, wst);
-
-    default:
-        /* No pre work to be done */
-        break;
     }
 
     return WORK_FINISHED_CONTINUE;
@@ -511,6 +511,10 @@ WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
     s->init_num = 0;
 
     switch (st->hand_state) {
+    default:
+        /* No post work to be done */
+        break;
+
     case TLS_ST_SW_HELLO_REQ:
         if (statem_flush(s) != 1)
             return WORK_MORE_A;
@@ -603,10 +607,6 @@ WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
         }
 #endif
         break;
-
-    default:
-        /* No post work to be done */
-        break;
     }
 
     return WORK_FINISHED_CONTINUE;
@@ -624,6 +624,10 @@ int ossl_statem_server_construct_message(SSL *s)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return 0;
+
     case DTLS_ST_SW_HELLO_VERIFY_REQUEST:
         return dtls_construct_hello_verify_request(s);
 
@@ -663,13 +667,7 @@ int ossl_statem_server_construct_message(SSL *s)
                                       ssl3_enc->server_finished_label,
                                       s->method->
                                       ssl3_enc->server_finished_label_len);
-
-    default:
-        /* Shouldn't happen */
-        break;
     }
-
-    return 0;
 }
 
 /*
@@ -701,6 +699,10 @@ unsigned long ossl_statem_server_max_message_size(SSL *s)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return 0;
+
     case TLS_ST_SR_CLNT_HELLO:
         return CLIENT_HELLO_MAX_LENGTH;
 
@@ -723,13 +725,7 @@ unsigned long ossl_statem_server_max_message_size(SSL *s)
 
     case TLS_ST_SR_FINISHED:
         return FINISHED_MAX_LENGTH;
-
-    default:
-        /* Shouldn't happen */
-        break;
     }
-
-    return 0;
 }
 
 /*
@@ -740,6 +736,10 @@ MSG_PROCESS_RETURN ossl_statem_server_process_message(SSL *s, PACKET *pkt)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return MSG_PROCESS_ERROR;
+
     case TLS_ST_SR_CLNT_HELLO:
         return tls_process_client_hello(s, pkt);
 
@@ -762,13 +762,7 @@ MSG_PROCESS_RETURN ossl_statem_server_process_message(SSL *s, PACKET *pkt)
 
     case TLS_ST_SR_FINISHED:
         return tls_process_finished(s, pkt);
-
-    default:
-        /* Shouldn't happen */
-        break;
     }
-
-    return MSG_PROCESS_ERROR;
 }
 
 /*
@@ -780,6 +774,10 @@ WORK_STATE ossl_statem_server_post_process_message(SSL *s, WORK_STATE wst)
     OSSL_STATEM *st = &s->statem;
 
     switch (st->hand_state) {
+    default:
+        /* Shouldn't happen */
+        return WORK_ERROR;
+
     case TLS_ST_SR_CLNT_HELLO:
         return tls_post_process_client_hello(s, wst);
 
@@ -803,13 +801,8 @@ WORK_STATE ossl_statem_server_post_process_message(SSL *s, WORK_STATE wst)
         }
 #endif
         return WORK_FINISHED_CONTINUE;
-
-    default:
-        break;
     }
 
-    /* Shouldn't happen */
-    return WORK_ERROR;
 }
 
 #ifndef OPENSSL_NO_SRP

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -244,7 +244,10 @@ static int assert_validity(CT_TEST_FIXTURE fixture,
         case SCT_VALIDATION_STATUS_INVALID:
             ++invalid_sct_count;
             break;
-        default:
+        case SCT_VALIDATION_STATUS_NOT_SET:
+        case SCT_VALIDATION_STATUS_UNKNOWN_LOG:
+        case SCT_VALIDATION_STATUS_UNVERIFIED:
+        case SCT_VALIDATION_STATUS_UNKNOWN_VERSION:
             /* Ignore other validation statuses. */
             break;
         }

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -333,7 +333,7 @@ static void configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         SSL_CTX_set_cert_verify_callback(client_ctx, &verify_reject_cb,
                                          NULL);
         break;
-    default:
+    case SSL_TEST_VERIFY_NONE:
         break;
     }
 
@@ -347,7 +347,7 @@ static void configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         SSL_CTX_set_tlsext_servername_callback(server_ctx, servername_reject_cb);
         SSL_CTX_set_tlsext_servername_arg(server_ctx, server2_ctx);
         break;
-    default:
+    case SSL_TEST_SERVERNAME_CB_NONE:
         break;
     }
 
@@ -631,9 +631,11 @@ static connect_phase_t next_phase(connect_phase_t phase)
         return SHUTDOWN;
     case SHUTDOWN:
         return CONNECTION_DONE;
-    default:
-        TEST_check(0); /* Should never call next_phase when done. */
+    case CONNECTION_DONE:
+        TEST_check(0);
+        break;
     }
+    return -1;
 }
 
 static void do_connect_step(PEER *peer, connect_phase_t phase)
@@ -648,8 +650,9 @@ static void do_connect_step(PEER *peer, connect_phase_t phase)
     case SHUTDOWN:
         do_shutdown_step(peer);
         break;
-    default:
+    case CONNECTION_DONE:
         TEST_check(0);
+        break;
     }
 }
 


### PR DESCRIPTION
Change code so when switching on an enumeration, have case's for all
enumeration values.

Only used on clang and gcc when configured with strict warning builds.
