### PR TITLE
Don't use h constraints for MIPS64 on clang

### DIFF
--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -428,7 +428,7 @@ unsigned __int64 _umul128(unsigned __int64 a, unsigned __int64 b,
 #   endif
 #  elif defined(__mips) && (defined(SIXTY_FOUR_BIT) || defined(SIXTY_FOUR_BIT_LONG))
 #   if defined(__GNUC__) && __GNUC__>=2
-#    if __GNUC__>4 || (__GNUC__>=4 && __GNUC_MINOR__>=4)
+#    if __GNUC__>4 || (__GNUC__>=4 && __GNUC_MINOR__>=4) || defined(__clang__)
                                      /* "h" constraint is no more since 4.4 */
 #     define BN_UMULT_HIGH(a,b)          (((__uint128_t)(a)*(b))>>64)
 #     define BN_UMULT_LOHI(low,high,a,b) ({     \


### PR DESCRIPTION
clang always reports as GCC 4.2 compatible:
```
$ echo "__GNUC__ __GNUC_MINOR__" | /opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/clang -E -
# 1 "<stdin>"
# 1 "<built-in>" 1
# 1 "<built-in>" 3
# 317 "<built-in>" 3
# 1 "<command line>" 1
# 1 "<built-in>" 2
# 1 "<stdin>" 2
4 2
```
And it does not support "h constraints", causing the following compile error:
```
/home/yen/Projects/python3-android/clang-bin/cc  -I. -Icrypto/include -Iinclude -DDSO_DLFCN -DHAVE_DLFCN_H -DNDEBUG -DOPENSSL_THREADS -DOPENSSL_NO_DYNAMIC_ENGINE -DOPENSSL_PIC -DOPENSSL_BN_ASM_MONT -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DAES_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/home/yen/Projects/python3-android/build/21-mips64el-linux-android-4.9/share\"" -DENGINESDIR="\"/home/yen/Projects/python3-android/build/21-mips64el-linux-android-4.9/lib/engines-1.1\"" -Wall -O3 -pthread -fPIE  -fno-integrated-as -fPIC -Wa,--noexecstack  -fPIC -MMD -MF crypto/bn/bn_div.d.tmp -MT crypto/bn/bn_div.o -c -o crypto/bn/bn_div.o crypto/bn/bn_div.c
crypto/bn/bn_div.c:347:13: error: invalid output constraint '=h' in asm
            BN_UMULT_LOHI(t2l, t2h, d1, q);
            ^
crypto/bn/bn_lcl.h:446:26: note: expanded from macro 'BN_UMULT_LOHI'
             : "=l"(low),"=h"(high)     \
                         ^
1 error generated.
```
To tell the truth I don't know what "h constraints" are. This patch just fixes the build.