### PR TITLE
VSI submission: redirect terminal input through socket

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1774,7 +1774,7 @@ sub vms_info {
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",
 
-        apps_aux_src     => "vms_decc_init.c",
+        apps_aux_src     => "vms_decc_init.c vms_term_sock.c",
     },
 
     "vms-alpha" => {

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2300,6 +2300,32 @@ int app_isdir(const char *name)
 #endif
 
 /* raw_read|write section */
+#if defined(__VMS)
+# include "vms_term_sock.h"
+static int stdin_sock = -1;
+static void close_stdin_sock(void)
+{
+    TerminalSocket (TERM_SOCK_DELETE, &stdin_sock);
+}
+int fileno_stdin()
+{
+    if (stdin_sock == -1) {
+        TerminalSocket(TERM_SOCK_CREATE, &stdin_sock);
+        atexit(close_stdin_sock);
+
+    return stdin_sock;
+}
+#else
+int fileno_stdin()
+{
+    return fileno(stdin);
+}
+#endif
+int fileno_stdout()
+{
+    return fileno(stdout);
+}
+
 #if defined(_WIN32) && defined(STD_INPUT_HANDLE)
 int raw_read_stdin(void *buf, int siz)
 {
@@ -2309,10 +2335,15 @@ int raw_read_stdin(void *buf, int siz)
     else
         return (-1);
 }
+#elif defined(__VMS)
+int raw_read_stdin(void *buf, int siz)
+{
+    return recv(fileno_stdin(), buf, siz, 0);
+}
 #else
 int raw_read_stdin(void *buf, int siz)
 {
-    return read(fileno(stdin), buf, siz);
+    return read(fileno_stdin(), buf, siz);
 }
 #endif
 
@@ -2328,7 +2359,7 @@ int raw_write_stdout(const void *buf, int siz)
 #else
 int raw_write_stdout(const void *buf, int siz)
 {
-    return write(fileno(stdout), buf, siz);
+    return write(fileno_stdout(), buf, siz);
 }
 #endif
 

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2303,15 +2303,18 @@ int app_isdir(const char *name)
 #if defined(__VMS)
 # include "vms_term_sock.h"
 static int stdin_sock = -1;
+
 static void close_stdin_sock(void)
 {
     TerminalSocket (TERM_SOCK_DELETE, &stdin_sock);
 }
+
 int fileno_stdin()
 {
     if (stdin_sock == -1) {
         TerminalSocket(TERM_SOCK_CREATE, &stdin_sock);
         atexit(close_stdin_sock);
+    }
 
     return stdin_sock;
 }
@@ -2321,6 +2324,7 @@ int fileno_stdin()
     return fileno(stdin);
 }
 #endif
+
 int fileno_stdout()
 {
     return fileno(stdout);

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2309,7 +2309,7 @@ static void close_stdin_sock(void)
     TerminalSocket (TERM_SOCK_DELETE, &stdin_sock);
 }
 
-int fileno_stdin()
+int fileno_stdin(void)
 {
     if (stdin_sock == -1) {
         TerminalSocket(TERM_SOCK_CREATE, &stdin_sock);
@@ -2319,13 +2319,13 @@ int fileno_stdin()
     return stdin_sock;
 }
 #else
-int fileno_stdin()
+int fileno_stdin(void)
 {
     return fileno(stdin);
 }
 #endif
 
-int fileno_stdout()
+int fileno_stdout(void)
 {
     return fileno(stdout);
 }

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -549,8 +549,8 @@ void store_setup_crl_download(X509_STORE *st);
 
 int app_isdir(const char *);
 int app_access(const char *, int flag);
-int fileno_stdin();
-int fileno_stdout();
+int fileno_stdin(void);
+int fileno_stdout(void);
 int raw_read_stdin(void *, int);
 int raw_write_stdout(const void *, int);
 

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -549,6 +549,8 @@ void store_setup_crl_download(X509_STORE *st);
 
 int app_isdir(const char *);
 int app_access(const char *, int flag);
+int fileno_stdin();
+int fileno_stdout();
 int raw_read_stdin(void *, int);
 int raw_write_stdout(const void *, int);
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -43,6 +43,9 @@
 
 #ifndef OPENSSL_NO_SOCK
 
+#ifdef OPENSSL_SYS_VMS
+# include "vms_term_sock.h"
+#endif
 /*
  * With IPv6, it looks like Digital has mixed up the proper order of
  * recursive header file inclusion, resulting in the compiler complaining
@@ -858,6 +861,10 @@ int s_client_main(int argc, char **argv)
     int c_nbio = 0, c_msg = 0, c_ign_eof = 0, c_brief = 0;
     int c_tlsextdebug = 0, c_status_req = 0;
     BIO *bio_c_msg = NULL;
+#if defined(OPENSSL_SYS_VMS)  
+    int stdin_sock;
+    TerminalSocket(TERM_SOCK_CREATE, &stdin_sock);
+#endif 
 
     FD_ZERO(&readfds);
     FD_ZERO(&writefds);
@@ -1821,8 +1828,14 @@ int s_client_main(int argc, char **argv)
     SSL_set_connect_state(con);
 
     /* ok, lets connect */
+#if defined(OPENSSL_SYS_VMS)  
+    if (stdin_sock > SSL_get_fd(con))
+        width = stdin_sock + 1;
+    else
+        width = SSL_get_fd(con) + 1;
+#else  
     width = SSL_get_fd(con) + 1;
-
+#endif
     read_tty = 1;
     write_tty = 0;
     tty_on = 0;
@@ -2149,10 +2162,15 @@ int s_client_main(int argc, char **argv)
                  * and EOF satisfies that.  To avoid a CPU-hogging loop,
                  * set the flag so we exit.
                  */
+#if defined(OPENSSL_SYS_VMS)
+                if (read_tty && !at_eof)
+                    openssl_fdset(stdin_sock, &readfds);
+#else
                 if (read_tty && !at_eof)
                     openssl_fdset(fileno(stdin), &readfds);
                 if (write_tty)
                     openssl_fdset(fileno(stdout), &writefds);
+#endif
             }
             if (read_ssl)
                 openssl_fdset(SSL_get_fd(con), &readfds);
@@ -2278,7 +2296,7 @@ int s_client_main(int argc, char **argv)
                 goto shut;
             }
         }
-#if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
+#if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VMS) 
         /* Assume Windows/DOS/BeOS can always write */
         else if (!ssl_pending && write_tty)
 #else
@@ -2371,13 +2389,25 @@ int s_client_main(int argc, char **argv)
 #if defined(OPENSSL_SYS_MSDOS)
         else if (has_stdin_waiting())
 #else
-        else if (FD_ISSET(fileno(stdin), &readfds))
+
+#if defined(OPENSSL_SYS_VMS)  
+	   else if (FD_ISSET(stdin_sock,&readfds))  
+#else  
+ 	   else if (FD_ISSET(fileno(stdin),&readfds))  
+#endif 
+
 #endif
         {
             if (crlf) {
                 int j, lf_num;
 
                 i = raw_read_stdin(cbuf, BUFSIZZ / 2);
+		#if defined(OPENSSL_SYS_VMS)
+                    i = recv(stdin_sock, cbuf, BUFSIZZ/2, 0);
+                #else
+                    i = raw_read_stdin(cbuf, BUFSIZZ/2);
+                #endif
+
                 lf_num = 0;
                 /* both loops are skipped when i <= 0 */
                 for (j = 0; j < i; j++)
@@ -2393,8 +2423,13 @@ int s_client_main(int argc, char **argv)
                 }
                 assert(lf_num == 0);
             } else
-                i = raw_read_stdin(cbuf, BUFSIZZ);
-
+		{
+			#if defined(OPENSSL_SYS_VMS) 
+	                i = recv(stdin_sock, cbuf, BUFSIZZ, 0);
+			#else
+	                i = raw_read_stdin(cbuf, BUFSIZZ);
+			#endif
+		}
 #if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MSDOS)
             if (i == 0)
                 at_eof = 1;
@@ -2479,6 +2514,9 @@ int s_client_main(int argc, char **argv)
     bio_c_out = NULL;
     BIO_free(bio_c_msg);
     bio_c_msg = NULL;
+#if defined(OPENSSL_SYS_VMS) 
+    TerminalSocket(TERM_SOCK_DELETE, &stdin_sock);
+#endif
     return (ret);
 }
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -861,10 +861,10 @@ int s_client_main(int argc, char **argv)
     int c_nbio = 0, c_msg = 0, c_ign_eof = 0, c_brief = 0;
     int c_tlsextdebug = 0, c_status_req = 0;
     BIO *bio_c_msg = NULL;
-#if defined(OPENSSL_SYS_VMS)  
+#if defined(OPENSSL_SYS_VMS)
     int stdin_sock;
     TerminalSocket(TERM_SOCK_CREATE, &stdin_sock);
-#endif 
+#endif
 
     FD_ZERO(&readfds);
     FD_ZERO(&writefds);
@@ -1828,12 +1828,12 @@ int s_client_main(int argc, char **argv)
     SSL_set_connect_state(con);
 
     /* ok, lets connect */
-#if defined(OPENSSL_SYS_VMS)  
+#if defined(OPENSSL_SYS_VMS)
     if (stdin_sock > SSL_get_fd(con))
         width = stdin_sock + 1;
     else
         width = SSL_get_fd(con) + 1;
-#else  
+#else
     width = SSL_get_fd(con) + 1;
 #endif
     read_tty = 1;
@@ -2296,7 +2296,7 @@ int s_client_main(int argc, char **argv)
                 goto shut;
             }
         }
-#if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VMS) 
+#if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VMS)
         /* Assume Windows/DOS/BeOS can always write */
         else if (!ssl_pending && write_tty)
 #else
@@ -2388,25 +2388,20 @@ int s_client_main(int argc, char **argv)
 /* OPENSSL_SYS_MSDOS includes OPENSSL_SYS_WINDOWS */
 #if defined(OPENSSL_SYS_MSDOS)
         else if (has_stdin_waiting())
+#elif defined(OPENSSL_SYS_VMS)
+        else if (FD_ISSET(stdin_sock, &readfds))
 #else
-
-#if defined(OPENSSL_SYS_VMS)  
-	   else if (FD_ISSET(stdin_sock,&readfds))  
-#else  
- 	   else if (FD_ISSET(fileno(stdin),&readfds))  
-#endif 
-
+        else if (FD_ISSET(fileno(stdin), &readfds))
 #endif
         {
             if (crlf) {
                 int j, lf_num;
 
+#if defined(OPENSSL_SYS_VMS)
+                i = recv(stdin_sock, cbuf, BUFSIZZ / 2, 0);
+#else
                 i = raw_read_stdin(cbuf, BUFSIZZ / 2);
-		#if defined(OPENSSL_SYS_VMS)
-                    i = recv(stdin_sock, cbuf, BUFSIZZ/2, 0);
-                #else
-                    i = raw_read_stdin(cbuf, BUFSIZZ/2);
-                #endif
+#endif
 
                 lf_num = 0;
                 /* both loops are skipped when i <= 0 */
@@ -2422,14 +2417,13 @@ int s_client_main(int argc, char **argv)
                     }
                 }
                 assert(lf_num == 0);
-            } else
-		{
-			#if defined(OPENSSL_SYS_VMS) 
-	                i = recv(stdin_sock, cbuf, BUFSIZZ, 0);
-			#else
-	                i = raw_read_stdin(cbuf, BUFSIZZ);
-			#endif
-		}
+            } else {
+#if defined(OPENSSL_SYS_VMS)
+                i = recv(stdin_sock, cbuf, BUFSIZZ, 0);
+#else
+                i = raw_read_stdin(cbuf, BUFSIZZ);
+#endif
+            }
 #if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MSDOS)
             if (i == 0)
                 at_eof = 1;
@@ -2514,7 +2508,7 @@ int s_client_main(int argc, char **argv)
     bio_c_out = NULL;
     BIO_free(bio_c_msg);
     bio_c_msg = NULL;
-#if defined(OPENSSL_SYS_VMS) 
+#if defined(OPENSSL_SYS_VMS)
     TerminalSocket(TERM_SOCK_DELETE, &stdin_sock);
 #endif
     return (ret);

--- a/apps/vms_term_sock.c
+++ b/apps/vms_term_sock.c
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2016 VMS Software, Inc. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
 #ifdef __VMS 
 #define OPENSSL_SYS_VMS
 #pragma message disable DOLLARID

--- a/apps/vms_term_sock.c
+++ b/apps/vms_term_sock.c
@@ -1,0 +1,597 @@
+#ifdef __VMS 
+#define OPENSSL_SYS_VMS
+#pragma message disable DOLLARID
+
+
+#include <openssl/OPENSSLCONF.H>
+
+#if !defined(_POSIX_C_SOURCE) && defined(OPENSSL_SYS_VMS)
+/*
+ * On VMS, you need to define this to get the declaration of fileno().  The
+ * value 2 is to make sure no function defined in POSIX-2 is left undefined.
+ */
+# define _POSIX_C_SOURCE 2
+#endif
+
+#include <stdio.h>
+
+#undef _POSIX_C_SOURCE
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <starlet.h>
+#include <iodef.h>
+#ifdef __alpha
+#include <iosbdef.h>
+#else
+typedef struct _iosb {			/* Copied from IOSBDEF.H for Alpha  */
+#pragma __nomember_alignment
+    __union  {
+        __struct  {
+            unsigned short int iosb$w_status; /* Final I/O status           */
+            __union  {
+                __struct  {             /* 16-bit byte count variant        */
+                    unsigned short int iosb$w_bcnt; /* 16-bit byte count    */
+                    __union  {
+                        unsigned int iosb$l_dev_depend; /* 32-bit device dependent info */
+                        unsigned int iosb$l_pid; /* 32-bit pid              */
+                        } iosb$r_l;
+                    } iosb$r_bcnt_16;
+                __struct  {             /* 32-bit byte count variant        */
+                    unsigned int iosb$l_bcnt; /* 32-bit byte count (unaligned) */
+                    unsigned short int iosb$w_dev_depend_high; /* 16-bit device dependent info */
+                    } iosb$r_bcnt_32;
+                } iosb$r_devdepend;
+            } iosb$r_io_64;
+        __struct  {
+            __union  {
+                unsigned int iosb$l_getxxi_status; /* Final GETxxI status   */
+                unsigned int iosb$l_reg_status; /* Final $Registry status   */
+                } iosb$r_l_status;
+            unsigned int iosb$l_reserved; /* Reserved field                 */
+            } iosb$r_get_64;
+        } iosb$r_io_get;
+    } IOSB;
+
+#if !defined(__VAXC)
+#define iosb$w_status iosb$r_io_get.iosb$r_io_64.iosb$w_status
+#define iosb$w_bcnt iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_16.iosb$w_bcnt
+#define iosb$r_l        iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_16.iosb$r_l
+#define iosb$l_dev_depend iosb$r_l.iosb$l_dev_depend
+#define iosb$l_pid iosb$r_l.iosb$l_pid
+#define iosb$l_bcnt iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_32.iosb$l_bcnt
+#define iosb$w_dev_depend_high iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_32.iosb$w_dev_depend_high
+#define iosb$l_getxxi_status iosb$r_io_get.iosb$r_get_64.iosb$r_l_status.iosb$l_getxxi_status
+#define iosb$l_reg_status iosb$r_io_get.iosb$r_get_64.iosb$r_l_status.iosb$l_reg_status
+#endif          /* #if !defined(__VAXC) */
+
+#endif					/* End of IOSBDEF */
+
+#include <efndef.h>
+#include <stdlib.h>
+#include <ssdef.h>
+#include <time.h>
+#include <stdarg.h>
+#include <descrip.h>
+
+#include "term_sock.h"
+
+#ifdef __alpha
+static struct _iosb TerminalDeviceIosb;
+#else
+IOSB TerminalDeviceIosb;
+#endif
+
+static char TerminalDeviceBuff[255 + 2];
+static int TerminalSocketPair[2] = {0, 0};
+static unsigned short TerminalDeviceChan = 0;
+
+static int CreateSocketPair (int, int, int, int *);
+static void SocketPairTimeoutAst (int);
+static int TerminalDeviceAst (int);
+static void LogMessage (char *, ...);
+
+/*
+** Socket Pair Timeout Value (must be 0-59 seconds)
+*/
+#define SOCKET_PAIR_TIMEOUT_VALUE 20
+
+/*
+** Socket Pair Timeout Block which is passed to timeout AST
+*/
+typedef struct _SocketPairTimeoutBlock {
+    unsigned short SockChan1;
+    unsigned short SockChan2;
+    } SPTB;
+
+#ifdef TERM_SOCK_TEST
+
+/*----------------------------------------------------------------------------*/
+/*                                                                            */
+/*----------------------------------------------------------------------------*/
+int main (int argc, char *argv[], char *envp[])
+{
+char TermBuff[80];
+int TermSock,
+    status,
+    len;
+
+LogMessage ("Enter 'q' or 'Q' to quit ...");
+while (strcasecmp (TermBuff, "Q"))
+    {
+    /*
+    ** Create the terminal socket
+    */
+    status = TerminalSocket (TERM_SOCK_CREATE, &TermSock);
+    if (status != TERM_SOCK_SUCCESS)
+	exit (1);
+
+    /*
+    ** Process the terminal input
+    */
+    LogMessage ("Waiting on terminal I/O ...\n");
+    len = recv (TermSock, TermBuff, sizeof (TermBuff), 0) ;
+    TermBuff[len] = '\0';
+    LogMessage ("Received terminal I/O [%s]", TermBuff);
+
+    /*
+    ** Delete the terminal socket
+    */
+    status = TerminalSocket (TERM_SOCK_DELETE, &TermSock);
+    if (status != TERM_SOCK_SUCCESS)
+	exit (1);
+    }
+
+return 1;
+
+}
+#endif 
+
+/*----------------------------------------------------------------------------*/
+/*                                                                            */
+/*----------------------------------------------------------------------------*/
+int TerminalSocket (int FunctionCode, int *ReturnSocket)
+{
+int status;
+$DESCRIPTOR (TerminalDeviceDesc, "SYS$COMMAND");
+
+/*
+** Process the requested function code
+*/
+switch (FunctionCode)
+   {
+   case TERM_SOCK_CREATE:
+	/*
+	** Create a socket pair
+	*/
+	status = CreateSocketPair (AF_INET, SOCK_STREAM, 0, TerminalSocketPair);
+	if (status == -1)
+	    {
+	    LogMessage ("TerminalSocket: CreateSocketPair () - %08X", status);
+	    if (TerminalSocketPair[0])
+		close (TerminalSocketPair[0]);
+	    if (TerminalSocketPair[1])
+		close (TerminalSocketPair[1]);
+	    return (TERM_SOCK_FAILURE);
+	    }
+
+	/*
+	** Assign a channel to the terminal device
+	*/
+	status = sys$assign (&TerminalDeviceDesc,
+			     &TerminalDeviceChan, 
+			     0, 0, 0);
+	if (! (status & 1))
+	    {
+	    LogMessage ("TerminalSocket: SYS$ASSIGN () - %08X", status);
+	    close (TerminalSocketPair[0]);
+	    close (TerminalSocketPair[1]);
+	    return (TERM_SOCK_FAILURE);
+	    }
+
+	/*
+	** Queue an async IO to the terminal device
+	*/
+	status = sys$qio (EFN$C_ENF,
+			  TerminalDeviceChan,
+	                  IO$_READVBLK,
+	                  &TerminalDeviceIosb, 
+			  TerminalDeviceAst, 
+			  0, 
+	                  TerminalDeviceBuff,
+	                  sizeof (TerminalDeviceBuff) - 2,
+	                  0, 0, 0, 0);
+	if (! (status & 1))
+	    {
+	    LogMessage ("TerminalSocket: SYS$QIO () - %08X", status);
+	    close (TerminalSocketPair[0]);
+	    close (TerminalSocketPair[1]);
+	    return (TERM_SOCK_FAILURE);
+	    }
+
+	/*
+	** Return the input side of the socket pair
+	*/
+	*ReturnSocket = TerminalSocketPair[1];
+        break;
+
+   case TERM_SOCK_DELETE:
+	/*
+	** Cancel any pending IO on the terminal channel
+	*/
+	status = sys$cancel (TerminalDeviceChan);
+	if (! (status & 1))
+	    {
+	    LogMessage ("TerminalSocket: SYS$CANCEL () - %08X", status);
+	    close (TerminalSocketPair[0]);
+	    close (TerminalSocketPair[1]);
+	    return (TERM_SOCK_FAILURE);
+	    }
+
+	/*
+	** Deassign the terminal channel
+	*/
+	status = sys$dassgn (TerminalDeviceChan);
+	if (! (status & 1))
+	    {
+	    LogMessage ("TerminalSocket: SYS$DASSGN () - %08X", status);
+	    close (TerminalSocketPair[0]);
+	    close (TerminalSocketPair[1]);
+	    return (TERM_SOCK_FAILURE);
+	    }
+
+	/*
+	** Close the terminal socket pair
+	*/
+	close (TerminalSocketPair[0]);
+	close (TerminalSocketPair[1]);
+
+	/*
+	** Return the initialized socket
+	*/
+	*ReturnSocket = 0;
+	break;
+
+    default:
+	/*
+	** Invalid function code
+	*/
+	LogMessage ("TerminalSocket: Invalid Function Code - %d", FunctionCode);
+	return (TERM_SOCK_FAILURE);
+	break;
+    }	
+
+/*
+** Return success
+*/
+return (TERM_SOCK_SUCCESS);
+
+}
+
+/*----------------------------------------------------------------------------*/
+/*                                                                            */
+/*----------------------------------------------------------------------------*/
+static int CreateSocketPair (
+    int		SocketFamily,
+    int		SocketType,
+    int		SocketProtocol,
+    int		*SocketPair)
+{
+struct dsc$descriptor AscTimeDesc = {0, DSC$K_DTYPE_T, DSC$K_CLASS_S, NULL};
+static const char* LocalHostAddr = {"127.0.0.1"};
+unsigned short TcpAcceptChan = 0,
+	       TcpDeviceChan = 0;
+unsigned long BinTimeBuff[2];
+struct sockaddr_in sin;
+char AscTimeBuff[32];
+short LocalHostPort;
+int status; 
+unsigned int slen;
+
+#ifdef __alpha
+struct _iosb iosb;
+#else
+IOSB iosb;
+#endif
+
+int SockDesc1 = 0,
+    SockDesc2 = 0;
+SPTB sptb;
+$DESCRIPTOR (TcpDeviceDesc, "TCPIP$DEVICE");
+
+/*
+** Create a socket
+*/
+SockDesc1 = socket (SocketFamily, SocketType, 0);
+if (SockDesc1 < 0)
+    {
+    LogMessage ("CreateSocketPair: socket () - %d", errno);
+    return (-1);
+    }
+
+/*
+** Initialize the socket information
+*/
+slen = sizeof (sin);
+memset ((char *) &sin, 0, slen);
+sin.sin_family = SocketFamily;
+sin.sin_addr.s_addr = inet_addr (LocalHostAddr);
+sin.sin_port = 0;
+
+/*
+** Bind the socket to the local IP
+*/
+status = bind (SockDesc1, (struct sockaddr *) &sin, slen);
+if (status < 0)
+    {
+    LogMessage ("CreateSocketPair: bind () - %d", errno);
+    close (SockDesc1);   
+    return (-1);
+    }
+
+/*
+** Get the socket name so we can save the port number
+*/
+status = getsockname (SockDesc1, (struct sockaddr *) &sin, &slen);
+if (status < 0)
+    {
+    LogMessage ("CreateSocketPair: getsockname () - %d", errno);
+    close (SockDesc1); 
+    return (-1);
+    }
+else
+    LocalHostPort = sin.sin_port;			
+
+/*
+** Setup a listen for the socket
+*/
+listen (SockDesc1, 5);
+
+/*
+** Get the binary (64-bit) time of the specified timeout value
+*/
+sprintf (AscTimeBuff, "0 0:0:%02d.00", SOCKET_PAIR_TIMEOUT_VALUE);
+AscTimeDesc.dsc$w_length = strlen (AscTimeBuff);
+AscTimeDesc.dsc$a_pointer = AscTimeBuff;
+status = sys$bintim (&AscTimeDesc, BinTimeBuff);
+if (! (status & 1))
+    {
+    LogMessage ("CreateSocketPair: SYS$BINTIM () - %08X", status);
+    close (SockDesc1);
+    return (-1);
+    }
+
+/*
+** Assign another channel to the TCP/IP device for the accept.
+** This is the channel that ends up being connected to.
+*/
+status = sys$assign (&TcpDeviceDesc, &TcpDeviceChan, 0, 0, 0);
+if (! (status & 1))
+    {
+    LogMessage ("CreateSocketPair: SYS$ASSIGN () - %08X", status);
+    close (SockDesc1);
+    return (-1);
+    }
+
+/*
+** Get the channel of the first socket for the accept
+*/
+TcpAcceptChan = decc$get_sdc (SockDesc1);		
+
+/*
+** Perform the accept using $QIO so we can do this asynchronously
+*/
+status = sys$qio (EFN$C_ENF, 
+		  TcpAcceptChan,
+                  IO$_ACCESS | IO$M_ACCEPT,
+                  &iosb,
+		  0, 0, 0, 0, 0,
+                  &TcpDeviceChan,
+                  0, 0);
+if (! (status & 1))
+    {
+    LogMessage ("CreateSocketPair: SYS$QIO () - %08X", status);
+    close (SockDesc1);
+    sys$dassgn (TcpDeviceChan);
+    return (-1);
+    }
+
+/*
+** Create the second socket to do the connect
+*/
+SockDesc2 = socket (SocketFamily, SocketType, 0);
+if (SockDesc2 < 0)
+    {
+    LogMessage ("CreateSocketPair: socket () - %d", errno);
+    sys$cancel (TcpAcceptChan);
+    close (SockDesc1);
+    sys$dassgn (TcpDeviceChan);
+    return (-1) ;
+    } 
+
+/*
+** Setup the Socket Pair Timeout Block
+*/
+sptb.SockChan1 = TcpAcceptChan;
+sptb.SockChan2 = decc$get_sdc (SockDesc2);
+
+/*
+** Before we block on the connect, set a timer that can cancel I/O on our two 
+** sockets if it never connects.
+*/
+status = sys$setimr (EFN$C_ENF, 
+		     BinTimeBuff, 
+		     SocketPairTimeoutAst, 
+		     &sptb, 
+		     0);
+if (! (status & 1))
+    {
+    LogMessage ("CreateSocketPair: SYS$SETIMR () - %08X", status);
+    sys$cancel (TcpAcceptChan);
+    close (SockDesc1);
+    close (SockDesc2);
+    sys$dassgn (TcpDeviceChan);
+    return (-1);
+    }
+
+/*
+** Now issue the connect
+*/
+memset ((char *) &sin, 0, sizeof (sin)) ;
+sin.sin_family = SocketFamily;
+sin.sin_addr.s_addr = inet_addr (LocalHostAddr) ;
+sin.sin_port = LocalHostPort ;
+
+status = connect (SockDesc2, (struct sockaddr *) &sin, sizeof (sin));
+if (status < 0 )
+    {
+    LogMessage ("CreateSocketPair: connect () - %d", errno);
+    sys$cantim (&sptb, 0);
+    sys$cancel (TcpAcceptChan);
+    close (SockDesc1);
+    close (SockDesc2);
+    sys$dassgn (TcpDeviceChan);
+    return (-1);
+    }
+
+/*
+** Wait for the asynch $QIO to finish.  Note that if the I/O was aborted 
+** (SS$_ABORT), then we probably canceled it from the AST routine - so log a 
+** timeout.
+*/
+status = sys$synch (EFN$C_ENF, &iosb);
+if (! (iosb.iosb$w_status & 1))
+    {
+    if (iosb.iosb$w_status == SS$_ABORT)
+	LogMessage ("CreateSocketPair: SYS$QIO(iosb) timeout");
+    else 
+	{
+        LogMessage ("CreateSocketPair: SYS$QIO(iosb) - %d", iosb.iosb$w_status);
+        sys$cantim (&sptb, 0);
+        }
+    close (SockDesc1);
+    close (SockDesc2);
+    sys$dassgn (TcpDeviceChan);
+    return (-1);
+    }
+
+/*
+** Here we're successfully connected, so cancel the timer, convert the I/O 
+** channel to a socket fd, close the listener socket and return the connected 
+** pair.
+*/
+sys$cantim (&sptb, 0);
+
+close (SockDesc1) ;
+SocketPair[0] = SockDesc2 ;
+SocketPair[1] = socket_fd (TcpDeviceChan);
+
+return (0) ;
+
+}
+
+/*----------------------------------------------------------------------------*/
+/*                                                                            */
+/*----------------------------------------------------------------------------*/
+static void SocketPairTimeoutAst (int astparm)
+{
+SPTB *sptb = (SPTB *) astparm;
+
+sys$cancel (sptb->SockChan2);			/* Cancel the connect() */
+sys$cancel (sptb->SockChan1);			/* Cancel the accept() 	*/
+
+return;
+
+}
+
+/*----------------------------------------------------------------------------*/
+/*                                                                            */
+/*----------------------------------------------------------------------------*/
+static int TerminalDeviceAst (int astparm)
+{
+int status;
+
+/*
+** Terminate the terminal buffer
+*/
+TerminalDeviceBuff[TerminalDeviceIosb.iosb$w_bcnt] = '\0';
+strcat (TerminalDeviceBuff, "\n");
+
+/*
+** Send the data read from the terminal device throught the socket pair
+*/
+send (TerminalSocketPair[0], TerminalDeviceBuff, TerminalDeviceIosb.iosb$w_bcnt + 1, 0);
+
+/*
+** Queue another async IO to the terminal device
+*/
+status = sys$qio (EFN$C_ENF,
+         	  TerminalDeviceChan,
+         	  IO$_READVBLK,
+         	  &TerminalDeviceIosb, 
+	 	  TerminalDeviceAst, 
+	 	  0, 
+         	  TerminalDeviceBuff,
+         	  sizeof (TerminalDeviceBuff) - 1,
+         	  0, 0, 0, 0);
+
+/*
+** Return status
+*/
+return status;
+
+}
+
+/*----------------------------------------------------------------------------*/
+/*                                                                            */
+/*----------------------------------------------------------------------------*/
+static void LogMessage (char *msg, ...)
+{
+char *Month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", 
+                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+static unsigned int pid = 0;
+va_list args;
+time_t CurTime;
+struct tm *LocTime;
+char MsgBuff[256];
+
+/*
+** Get the process pid
+*/
+if (pid == 0)
+    pid = getpid ();
+
+/*
+** Convert the current time into local time
+*/
+CurTime = time (NULL);
+LocTime = localtime (&CurTime);
+
+/*
+** Format the message buffer
+*/
+sprintf (MsgBuff, "%02d-%s-%04d %02d:%02d:%02d [%08X] %s\n",
+         LocTime->tm_mday, Month[LocTime->tm_mon], (LocTime->tm_year + 1900),
+         LocTime->tm_hour, LocTime->tm_min, LocTime->tm_sec, pid, msg);
+
+/*
+** Get any variable arguments and add them to the print of the message buffer 
+*/
+va_start (args, msg);
+vfprintf (stderr, MsgBuff, args);
+va_end (args);
+
+/*
+** Flush standard error output
+*/
+fsync (fileno (stderr));
+
+return;
+
+}
+#endif

--- a/apps/vms_term_sock.c
+++ b/apps/vms_term_sock.c
@@ -88,7 +88,7 @@ typedef struct _iosb {           /* Copied from IOSBDEF.H for Alpha  */
 # include <stdarg.h>
 # include <descrip.h>
 
-# include "term_sock.h"
+# include "vms_term_sock.h"
 
 # ifdef __alpha
 static struct _iosb TerminalDeviceIosb;

--- a/apps/vms_term_sock.c
+++ b/apps/vms_term_sock.c
@@ -7,39 +7,39 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifdef __VMS 
-#define OPENSSL_SYS_VMS
-#pragma message disable DOLLARID
+#ifdef __VMS
+# define OPENSSL_SYS_VMS
+# pragma message disable DOLLARID
 
 
-#include <openssl/OPENSSLCONF.H>
+# include <openssl/opensslconf.h>
 
-#if !defined(_POSIX_C_SOURCE) && defined(OPENSSL_SYS_VMS)
+# if !defined(_POSIX_C_SOURCE) && defined(OPENSSL_SYS_VMS)
 /*
  * On VMS, you need to define this to get the declaration of fileno().  The
  * value 2 is to make sure no function defined in POSIX-2 is left undefined.
  */
-# define _POSIX_C_SOURCE 2
-#endif
+#  define _POSIX_C_SOURCE 2
+# endif
 
-#include <stdio.h>
+# include <stdio.h>
 
-#undef _POSIX_C_SOURCE
+# undef _POSIX_C_SOURCE
 
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <inet.h>
-#include <unistd.h>
-#include <string.h>
-#include <errno.h>
-#include <starlet.h>
-#include <iodef.h>
-#ifdef __alpha
-#include <iosbdef.h>
-#else
-typedef struct _iosb {			/* Copied from IOSBDEF.H for Alpha  */
-#pragma __nomember_alignment
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+# include <inet.h>
+# include <unistd.h>
+# include <string.h>
+# include <errno.h>
+# include <starlet.h>
+# include <iodef.h>
+# ifdef __alpha
+#  include <iosbdef.h>
+# else
+typedef struct _iosb {           /* Copied from IOSBDEF.H for Alpha  */
+#  pragma __nomember_alignment
     __union  {
         __struct  {
             unsigned short int iosb$w_status; /* Final I/O status           */
@@ -49,52 +49,52 @@ typedef struct _iosb {			/* Copied from IOSBDEF.H for Alpha  */
                     __union  {
                         unsigned int iosb$l_dev_depend; /* 32-bit device dependent info */
                         unsigned int iosb$l_pid; /* 32-bit pid              */
-                        } iosb$r_l;
-                    } iosb$r_bcnt_16;
+                    } iosb$r_l;
+                } iosb$r_bcnt_16;
                 __struct  {             /* 32-bit byte count variant        */
                     unsigned int iosb$l_bcnt; /* 32-bit byte count (unaligned) */
                     unsigned short int iosb$w_dev_depend_high; /* 16-bit device dependent info */
-                    } iosb$r_bcnt_32;
-                } iosb$r_devdepend;
-            } iosb$r_io_64;
+                } iosb$r_bcnt_32;
+            } iosb$r_devdepend;
+        } iosb$r_io_64;
         __struct  {
             __union  {
                 unsigned int iosb$l_getxxi_status; /* Final GETxxI status   */
                 unsigned int iosb$l_reg_status; /* Final $Registry status   */
-                } iosb$r_l_status;
+            } iosb$r_l_status;
             unsigned int iosb$l_reserved; /* Reserved field                 */
-            } iosb$r_get_64;
-        } iosb$r_io_get;
-    } IOSB;
+        } iosb$r_get_64;
+    } iosb$r_io_get;
+} IOSB;
 
-#if !defined(__VAXC)
-#define iosb$w_status iosb$r_io_get.iosb$r_io_64.iosb$w_status
-#define iosb$w_bcnt iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_16.iosb$w_bcnt
-#define iosb$r_l        iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_16.iosb$r_l
-#define iosb$l_dev_depend iosb$r_l.iosb$l_dev_depend
-#define iosb$l_pid iosb$r_l.iosb$l_pid
-#define iosb$l_bcnt iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_32.iosb$l_bcnt
-#define iosb$w_dev_depend_high iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_32.iosb$w_dev_depend_high
-#define iosb$l_getxxi_status iosb$r_io_get.iosb$r_get_64.iosb$r_l_status.iosb$l_getxxi_status
-#define iosb$l_reg_status iosb$r_io_get.iosb$r_get_64.iosb$r_l_status.iosb$l_reg_status
-#endif          /* #if !defined(__VAXC) */
+#  if !defined(__VAXC)
+#   define iosb$w_status iosb$r_io_get.iosb$r_io_64.iosb$w_status
+#   define iosb$w_bcnt iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_16.iosb$w_bcnt
+#   define iosb$r_l        iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_16.iosb$r_l
+#   define iosb$l_dev_depend iosb$r_l.iosb$l_dev_depend
+#   define iosb$l_pid iosb$r_l.iosb$l_pid
+#   define iosb$l_bcnt iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_32.iosb$l_bcnt
+#   define iosb$w_dev_depend_high iosb$r_io_get.iosb$r_io_64.iosb$r_devdepend.iosb$r_bcnt_32.iosb$w_dev_depend_high
+#   define iosb$l_getxxi_status iosb$r_io_get.iosb$r_get_64.iosb$r_l_status.iosb$l_getxxi_status
+#   define iosb$l_reg_status iosb$r_io_get.iosb$r_get_64.iosb$r_l_status.iosb$l_reg_status
+#  endif          /* #if !defined(__VAXC) */
 
-#endif					/* End of IOSBDEF */
+# endif  /* End of IOSBDEF */
 
-#include <efndef.h>
-#include <stdlib.h>
-#include <ssdef.h>
-#include <time.h>
-#include <stdarg.h>
-#include <descrip.h>
+# include <efndef.h>
+# include <stdlib.h>
+# include <ssdef.h>
+# include <time.h>
+# include <stdarg.h>
+# include <descrip.h>
 
-#include "term_sock.h"
+# include "term_sock.h"
 
-#ifdef __alpha
+# ifdef __alpha
 static struct _iosb TerminalDeviceIosb;
-#else
+# else
 IOSB TerminalDeviceIosb;
-#endif
+# endif
 
 static char TerminalDeviceBuff[255 + 2];
 static int TerminalSocketPair[2] = {0, 0};
@@ -108,7 +108,7 @@ static void LogMessage (char *, ...);
 /*
 ** Socket Pair Timeout Value (must be 0-59 seconds)
 */
-#define SOCKET_PAIR_TIMEOUT_VALUE 20
+# define SOCKET_PAIR_TIMEOUT_VALUE 20
 
 /*
 ** Socket Pair Timeout Block which is passed to timeout AST
@@ -116,391 +116,372 @@ static void LogMessage (char *, ...);
 typedef struct _SocketPairTimeoutBlock {
     unsigned short SockChan1;
     unsigned short SockChan2;
-    } SPTB;
+} SPTB;
 
-#ifdef TERM_SOCK_TEST
+# ifdef TERM_SOCK_TEST
 
 /*----------------------------------------------------------------------------*/
 /*                                                                            */
 /*----------------------------------------------------------------------------*/
 int main (int argc, char *argv[], char *envp[])
 {
-char TermBuff[80];
-int TermSock,
-    status,
-    len;
+    char TermBuff[80];
+    int TermSock,
+        status,
+        len;
 
-LogMessage ("Enter 'q' or 'Q' to quit ...");
-while (strcasecmp (TermBuff, "Q"))
-    {
-    /*
-    ** Create the terminal socket
-    */
-    status = TerminalSocket (TERM_SOCK_CREATE, &TermSock);
-    if (status != TERM_SOCK_SUCCESS)
-	exit (1);
+    LogMessage ("Enter 'q' or 'Q' to quit ...");
+    while (strcasecmp (TermBuff, "Q")) {
+        /*
+        ** Create the terminal socket
+        */
+        status = TerminalSocket (TERM_SOCK_CREATE, &TermSock);
+        if (status != TERM_SOCK_SUCCESS)
+            exit (1);
 
-    /*
-    ** Process the terminal input
-    */
-    LogMessage ("Waiting on terminal I/O ...\n");
-    len = recv (TermSock, TermBuff, sizeof (TermBuff), 0) ;
-    TermBuff[len] = '\0';
-    LogMessage ("Received terminal I/O [%s]", TermBuff);
+        /*
+        ** Process the terminal input
+        */
+        LogMessage ("Waiting on terminal I/O ...\n");
+        len = recv (TermSock, TermBuff, sizeof (TermBuff), 0) ;
+        TermBuff[len] = '\0';
+        LogMessage ("Received terminal I/O [%s]", TermBuff);
 
-    /*
-    ** Delete the terminal socket
-    */
-    status = TerminalSocket (TERM_SOCK_DELETE, &TermSock);
-    if (status != TERM_SOCK_SUCCESS)
-	exit (1);
+        /*
+        ** Delete the terminal socket
+        */
+        status = TerminalSocket (TERM_SOCK_DELETE, &TermSock);
+        if (status != TERM_SOCK_SUCCESS)
+            exit (1);
     }
 
-return 1;
+    return 1;
 
 }
-#endif 
+# endif
 
 /*----------------------------------------------------------------------------*/
 /*                                                                            */
 /*----------------------------------------------------------------------------*/
 int TerminalSocket (int FunctionCode, int *ReturnSocket)
 {
-int status;
-$DESCRIPTOR (TerminalDeviceDesc, "SYS$COMMAND");
+    int status;
+    $DESCRIPTOR (TerminalDeviceDesc, "SYS$COMMAND");
 
-/*
-** Process the requested function code
-*/
-switch (FunctionCode)
-   {
-   case TERM_SOCK_CREATE:
-	/*
-	** Create a socket pair
-	*/
-	status = CreateSocketPair (AF_INET, SOCK_STREAM, 0, TerminalSocketPair);
-	if (status == -1)
-	    {
-	    LogMessage ("TerminalSocket: CreateSocketPair () - %08X", status);
-	    if (TerminalSocketPair[0])
-		close (TerminalSocketPair[0]);
-	    if (TerminalSocketPair[1])
-		close (TerminalSocketPair[1]);
-	    return (TERM_SOCK_FAILURE);
-	    }
+    /*
+    ** Process the requested function code
+    */
+    switch (FunctionCode) {
+    case TERM_SOCK_CREATE:
+        /*
+        ** Create a socket pair
+        */
+        status = CreateSocketPair (AF_INET, SOCK_STREAM, 0, TerminalSocketPair);
+        if (status == -1) {
+            LogMessage ("TerminalSocket: CreateSocketPair () - %08X", status);
+            if (TerminalSocketPair[0])
+                close (TerminalSocketPair[0]);
+            if (TerminalSocketPair[1])
+                close (TerminalSocketPair[1]);
+            return (TERM_SOCK_FAILURE);
+        }
 
-	/*
-	** Assign a channel to the terminal device
-	*/
-	status = sys$assign (&TerminalDeviceDesc,
-			     &TerminalDeviceChan, 
-			     0, 0, 0);
-	if (! (status & 1))
-	    {
-	    LogMessage ("TerminalSocket: SYS$ASSIGN () - %08X", status);
-	    close (TerminalSocketPair[0]);
-	    close (TerminalSocketPair[1]);
-	    return (TERM_SOCK_FAILURE);
-	    }
+        /*
+        ** Assign a channel to the terminal device
+        */
+        status = sys$assign (&TerminalDeviceDesc,
+                             &TerminalDeviceChan,
+                             0, 0, 0);
+        if (! (status & 1)) {
+            LogMessage ("TerminalSocket: SYS$ASSIGN () - %08X", status);
+            close (TerminalSocketPair[0]);
+            close (TerminalSocketPair[1]);
+            return (TERM_SOCK_FAILURE);
+        }
 
-	/*
-	** Queue an async IO to the terminal device
-	*/
-	status = sys$qio (EFN$C_ENF,
-			  TerminalDeviceChan,
-	                  IO$_READVBLK,
-	                  &TerminalDeviceIosb, 
-			  TerminalDeviceAst, 
-			  0, 
-	                  TerminalDeviceBuff,
-	                  sizeof (TerminalDeviceBuff) - 2,
-	                  0, 0, 0, 0);
-	if (! (status & 1))
-	    {
-	    LogMessage ("TerminalSocket: SYS$QIO () - %08X", status);
-	    close (TerminalSocketPair[0]);
-	    close (TerminalSocketPair[1]);
-	    return (TERM_SOCK_FAILURE);
-	    }
+        /*
+        ** Queue an async IO to the terminal device
+        */
+        status = sys$qio (EFN$C_ENF,
+                          TerminalDeviceChan,
+                          IO$_READVBLK,
+                          &TerminalDeviceIosb,
+                          TerminalDeviceAst,
+                          0,
+                          TerminalDeviceBuff,
+                          sizeof (TerminalDeviceBuff) - 2,
+                          0, 0, 0, 0);
+        if (! (status & 1)) {
+            LogMessage ("TerminalSocket: SYS$QIO () - %08X", status);
+            close (TerminalSocketPair[0]);
+            close (TerminalSocketPair[1]);
+            return (TERM_SOCK_FAILURE);
+        }
 
-	/*
-	** Return the input side of the socket pair
-	*/
-	*ReturnSocket = TerminalSocketPair[1];
+        /*
+        ** Return the input side of the socket pair
+        */
+        *ReturnSocket = TerminalSocketPair[1];
         break;
 
-   case TERM_SOCK_DELETE:
-	/*
-	** Cancel any pending IO on the terminal channel
-	*/
-	status = sys$cancel (TerminalDeviceChan);
-	if (! (status & 1))
-	    {
-	    LogMessage ("TerminalSocket: SYS$CANCEL () - %08X", status);
-	    close (TerminalSocketPair[0]);
-	    close (TerminalSocketPair[1]);
-	    return (TERM_SOCK_FAILURE);
-	    }
+    case TERM_SOCK_DELETE:
+        /*
+        ** Cancel any pending IO on the terminal channel
+        */
+        status = sys$cancel (TerminalDeviceChan);
+        if (! (status & 1)) {
+            LogMessage ("TerminalSocket: SYS$CANCEL () - %08X", status);
+            close (TerminalSocketPair[0]);
+            close (TerminalSocketPair[1]);
+            return (TERM_SOCK_FAILURE);
+        }
 
-	/*
+        /*
 	** Deassign the terminal channel
 	*/
-	status = sys$dassgn (TerminalDeviceChan);
-	if (! (status & 1))
-	    {
-	    LogMessage ("TerminalSocket: SYS$DASSGN () - %08X", status);
-	    close (TerminalSocketPair[0]);
-	    close (TerminalSocketPair[1]);
-	    return (TERM_SOCK_FAILURE);
-	    }
+        status = sys$dassgn (TerminalDeviceChan);
+        if (! (status & 1)) {
+            LogMessage ("TerminalSocket: SYS$DASSGN () - %08X", status);
+            close (TerminalSocketPair[0]);
+            close (TerminalSocketPair[1]);
+            return (TERM_SOCK_FAILURE);
+        }
 
-	/*
-	** Close the terminal socket pair
-	*/
-	close (TerminalSocketPair[0]);
-	close (TerminalSocketPair[1]);
+        /*
+        ** Close the terminal socket pair
+        */
+        close (TerminalSocketPair[0]);
+        close (TerminalSocketPair[1]);
 
-	/*
+        /*
 	** Return the initialized socket
 	*/
-	*ReturnSocket = 0;
-	break;
+        *ReturnSocket = 0;
+        break;
 
     default:
-	/*
+        /*
 	** Invalid function code
 	*/
-	LogMessage ("TerminalSocket: Invalid Function Code - %d", FunctionCode);
-	return (TERM_SOCK_FAILURE);
-	break;
-    }	
+        LogMessage ("TerminalSocket: Invalid Function Code - %d", FunctionCode);
+        return (TERM_SOCK_FAILURE);
+        break;
+    }
 
-/*
-** Return success
-*/
-return (TERM_SOCK_SUCCESS);
+    /*
+    ** Return success
+    */
+    return (TERM_SOCK_SUCCESS);
 
 }
 
 /*----------------------------------------------------------------------------*/
 /*                                                                            */
 /*----------------------------------------------------------------------------*/
-static int CreateSocketPair (
-    int		SocketFamily,
-    int		SocketType,
-    int		SocketProtocol,
-    int		*SocketPair)
+static int CreateSocketPair (int SocketFamily,
+                             int SocketType,
+                             int SocketProtocol,
+                             int *SocketPair)
 {
-struct dsc$descriptor AscTimeDesc = {0, DSC$K_DTYPE_T, DSC$K_CLASS_S, NULL};
-static const char* LocalHostAddr = {"127.0.0.1"};
-unsigned short TcpAcceptChan = 0,
-	       TcpDeviceChan = 0;
-unsigned long BinTimeBuff[2];
-struct sockaddr_in sin;
-char AscTimeBuff[32];
-short LocalHostPort;
-int status; 
-unsigned int slen;
+    struct dsc$descriptor AscTimeDesc = {0, DSC$K_DTYPE_T, DSC$K_CLASS_S, NULL};
+    static const char* LocalHostAddr = {"127.0.0.1"};
+    unsigned short TcpAcceptChan = 0,
+        TcpDeviceChan = 0;
+    unsigned long BinTimeBuff[2];
+    struct sockaddr_in sin;
+    char AscTimeBuff[32];
+    short LocalHostPort;
+    int status;
+    unsigned int slen;
 
-#ifdef __alpha
-struct _iosb iosb;
-#else
-IOSB iosb;
-#endif
+# ifdef __alpha
+    struct _iosb iosb;
+# else
+    IOSB iosb;
+# endif
 
-int SockDesc1 = 0,
-    SockDesc2 = 0;
-SPTB sptb;
-$DESCRIPTOR (TcpDeviceDesc, "TCPIP$DEVICE");
+    int SockDesc1 = 0,
+        SockDesc2 = 0;
+    SPTB sptb;
+    $DESCRIPTOR (TcpDeviceDesc, "TCPIP$DEVICE");
 
-/*
-** Create a socket
-*/
-SockDesc1 = socket (SocketFamily, SocketType, 0);
-if (SockDesc1 < 0)
-    {
-    LogMessage ("CreateSocketPair: socket () - %d", errno);
-    return (-1);
+    /*
+    ** Create a socket
+    */
+    SockDesc1 = socket (SocketFamily, SocketType, 0);
+    if (SockDesc1 < 0) {
+        LogMessage ("CreateSocketPair: socket () - %d", errno);
+        return (-1);
     }
 
-/*
-** Initialize the socket information
-*/
-slen = sizeof (sin);
-memset ((char *) &sin, 0, slen);
-sin.sin_family = SocketFamily;
-sin.sin_addr.s_addr = inet_addr (LocalHostAddr);
-sin.sin_port = 0;
+    /*
+    ** Initialize the socket information
+    */
+    slen = sizeof (sin);
+    memset ((char *) &sin, 0, slen);
+    sin.sin_family = SocketFamily;
+    sin.sin_addr.s_addr = inet_addr (LocalHostAddr);
+    sin.sin_port = 0;
 
-/*
-** Bind the socket to the local IP
-*/
-status = bind (SockDesc1, (struct sockaddr *) &sin, slen);
-if (status < 0)
-    {
-    LogMessage ("CreateSocketPair: bind () - %d", errno);
-    close (SockDesc1);   
-    return (-1);
+    /*
+    ** Bind the socket to the local IP
+    */
+    status = bind (SockDesc1, (struct sockaddr *) &sin, slen);
+    if (status < 0) {
+        LogMessage ("CreateSocketPair: bind () - %d", errno);
+        close (SockDesc1);
+        return (-1);
     }
 
-/*
-** Get the socket name so we can save the port number
-*/
-status = getsockname (SockDesc1, (struct sockaddr *) &sin, &slen);
-if (status < 0)
-    {
-    LogMessage ("CreateSocketPair: getsockname () - %d", errno);
-    close (SockDesc1); 
-    return (-1);
-    }
-else
-    LocalHostPort = sin.sin_port;			
+    /*
+    ** Get the socket name so we can save the port number
+    */
+    status = getsockname (SockDesc1, (struct sockaddr *) &sin, &slen);
+    if (status < 0) {
+        LogMessage ("CreateSocketPair: getsockname () - %d", errno);
+        close (SockDesc1);
+        return (-1);
+    } else
+        LocalHostPort = sin.sin_port;
 
-/*
-** Setup a listen for the socket
-*/
-listen (SockDesc1, 5);
+    /*
+    ** Setup a listen for the socket
+    */
+    listen (SockDesc1, 5);
 
-/*
-** Get the binary (64-bit) time of the specified timeout value
-*/
-sprintf (AscTimeBuff, "0 0:0:%02d.00", SOCKET_PAIR_TIMEOUT_VALUE);
-AscTimeDesc.dsc$w_length = strlen (AscTimeBuff);
-AscTimeDesc.dsc$a_pointer = AscTimeBuff;
-status = sys$bintim (&AscTimeDesc, BinTimeBuff);
-if (! (status & 1))
-    {
-    LogMessage ("CreateSocketPair: SYS$BINTIM () - %08X", status);
-    close (SockDesc1);
-    return (-1);
+    /*
+    ** Get the binary (64-bit) time of the specified timeout value
+    */
+    sprintf (AscTimeBuff, "0 0:0:%02d.00", SOCKET_PAIR_TIMEOUT_VALUE);
+    AscTimeDesc.dsc$w_length = strlen (AscTimeBuff);
+    AscTimeDesc.dsc$a_pointer = AscTimeBuff;
+    status = sys$bintim (&AscTimeDesc, BinTimeBuff);
+    if (! (status & 1)) {
+        LogMessage ("CreateSocketPair: SYS$BINTIM () - %08X", status);
+        close (SockDesc1);
+        return (-1);
     }
 
-/*
-** Assign another channel to the TCP/IP device for the accept.
-** This is the channel that ends up being connected to.
-*/
-status = sys$assign (&TcpDeviceDesc, &TcpDeviceChan, 0, 0, 0);
-if (! (status & 1))
-    {
-    LogMessage ("CreateSocketPair: SYS$ASSIGN () - %08X", status);
-    close (SockDesc1);
-    return (-1);
+    /*
+    ** Assign another channel to the TCP/IP device for the accept.
+    ** This is the channel that ends up being connected to.
+    */
+    status = sys$assign (&TcpDeviceDesc, &TcpDeviceChan, 0, 0, 0);
+    if (! (status & 1)) {
+        LogMessage ("CreateSocketPair: SYS$ASSIGN () - %08X", status);
+        close (SockDesc1);
+        return (-1);
     }
 
-/*
-** Get the channel of the first socket for the accept
-*/
-TcpAcceptChan = decc$get_sdc (SockDesc1);		
+    /*
+    ** Get the channel of the first socket for the accept
+    */
+    TcpAcceptChan = decc$get_sdc (SockDesc1);
 
-/*
-** Perform the accept using $QIO so we can do this asynchronously
-*/
-status = sys$qio (EFN$C_ENF, 
-		  TcpAcceptChan,
-                  IO$_ACCESS | IO$M_ACCEPT,
-                  &iosb,
-		  0, 0, 0, 0, 0,
-                  &TcpDeviceChan,
-                  0, 0);
-if (! (status & 1))
-    {
-    LogMessage ("CreateSocketPair: SYS$QIO () - %08X", status);
-    close (SockDesc1);
-    sys$dassgn (TcpDeviceChan);
-    return (-1);
+    /*
+    ** Perform the accept using $QIO so we can do this asynchronously
+    */
+    status = sys$qio (EFN$C_ENF,
+                      TcpAcceptChan,
+                      IO$_ACCESS | IO$M_ACCEPT,
+                      &iosb,
+                      0, 0, 0, 0, 0,
+                      &TcpDeviceChan,
+                      0, 0);
+    if (! (status & 1)) {
+        LogMessage ("CreateSocketPair: SYS$QIO () - %08X", status);
+        close (SockDesc1);
+        sys$dassgn (TcpDeviceChan);
+        return (-1);
     }
 
-/*
-** Create the second socket to do the connect
-*/
-SockDesc2 = socket (SocketFamily, SocketType, 0);
-if (SockDesc2 < 0)
-    {
-    LogMessage ("CreateSocketPair: socket () - %d", errno);
-    sys$cancel (TcpAcceptChan);
-    close (SockDesc1);
-    sys$dassgn (TcpDeviceChan);
-    return (-1) ;
-    } 
-
-/*
-** Setup the Socket Pair Timeout Block
-*/
-sptb.SockChan1 = TcpAcceptChan;
-sptb.SockChan2 = decc$get_sdc (SockDesc2);
-
-/*
-** Before we block on the connect, set a timer that can cancel I/O on our two 
-** sockets if it never connects.
-*/
-status = sys$setimr (EFN$C_ENF, 
-		     BinTimeBuff, 
-		     SocketPairTimeoutAst, 
-		     &sptb, 
-		     0);
-if (! (status & 1))
-    {
-    LogMessage ("CreateSocketPair: SYS$SETIMR () - %08X", status);
-    sys$cancel (TcpAcceptChan);
-    close (SockDesc1);
-    close (SockDesc2);
-    sys$dassgn (TcpDeviceChan);
-    return (-1);
+    /*
+    ** Create the second socket to do the connect
+    */
+    SockDesc2 = socket (SocketFamily, SocketType, 0);
+    if (SockDesc2 < 0) {
+        LogMessage ("CreateSocketPair: socket () - %d", errno);
+        sys$cancel (TcpAcceptChan);
+        close (SockDesc1);
+        sys$dassgn (TcpDeviceChan);
+        return (-1) ;
     }
 
-/*
-** Now issue the connect
-*/
-memset ((char *) &sin, 0, sizeof (sin)) ;
-sin.sin_family = SocketFamily;
-sin.sin_addr.s_addr = inet_addr (LocalHostAddr) ;
-sin.sin_port = LocalHostPort ;
+    /*
+    ** Setup the Socket Pair Timeout Block
+    */
+    sptb.SockChan1 = TcpAcceptChan;
+    sptb.SockChan2 = decc$get_sdc (SockDesc2);
 
-status = connect (SockDesc2, (struct sockaddr *) &sin, sizeof (sin));
-if (status < 0 )
-    {
-    LogMessage ("CreateSocketPair: connect () - %d", errno);
-    sys$cantim (&sptb, 0);
-    sys$cancel (TcpAcceptChan);
-    close (SockDesc1);
-    close (SockDesc2);
-    sys$dassgn (TcpDeviceChan);
-    return (-1);
+    /*
+    ** Before we block on the connect, set a timer that can cancel I/O on our
+    ** two sockets if it never connects.
+    */
+    status = sys$setimr (EFN$C_ENF,
+                         BinTimeBuff,
+                         SocketPairTimeoutAst,
+                         &sptb,
+                         0);
+    if (! (status & 1)) {
+        LogMessage ("CreateSocketPair: SYS$SETIMR () - %08X", status);
+        sys$cancel (TcpAcceptChan);
+        close (SockDesc1);
+        close (SockDesc2);
+        sys$dassgn (TcpDeviceChan);
+        return (-1);
     }
 
-/*
-** Wait for the asynch $QIO to finish.  Note that if the I/O was aborted 
-** (SS$_ABORT), then we probably canceled it from the AST routine - so log a 
-** timeout.
-*/
-status = sys$synch (EFN$C_ENF, &iosb);
-if (! (iosb.iosb$w_status & 1))
-    {
-    if (iosb.iosb$w_status == SS$_ABORT)
-	LogMessage ("CreateSocketPair: SYS$QIO(iosb) timeout");
-    else 
-	{
-        LogMessage ("CreateSocketPair: SYS$QIO(iosb) - %d", iosb.iosb$w_status);
+    /*
+    ** Now issue the connect
+    */
+    memset ((char *) &sin, 0, sizeof (sin)) ;
+    sin.sin_family = SocketFamily;
+    sin.sin_addr.s_addr = inet_addr (LocalHostAddr) ;
+    sin.sin_port = LocalHostPort ;
+
+    status = connect (SockDesc2, (struct sockaddr *) &sin, sizeof (sin));
+    if (status < 0 ) {
+        LogMessage ("CreateSocketPair: connect () - %d", errno);
         sys$cantim (&sptb, 0);
-        }
-    close (SockDesc1);
-    close (SockDesc2);
-    sys$dassgn (TcpDeviceChan);
-    return (-1);
+        sys$cancel (TcpAcceptChan);
+        close (SockDesc1);
+        close (SockDesc2);
+        sys$dassgn (TcpDeviceChan);
+        return (-1);
     }
 
-/*
-** Here we're successfully connected, so cancel the timer, convert the I/O 
-** channel to a socket fd, close the listener socket and return the connected 
-** pair.
-*/
-sys$cantim (&sptb, 0);
+    /*
+    ** Wait for the asynch $QIO to finish.  Note that if the I/O was aborted
+    ** (SS$_ABORT), then we probably canceled it from the AST routine - so log
+    ** a timeout.
+    */
+    status = sys$synch (EFN$C_ENF, &iosb);
+    if (! (iosb.iosb$w_status & 1)) {
+        if (iosb.iosb$w_status == SS$_ABORT)
+            LogMessage ("CreateSocketPair: SYS$QIO(iosb) timeout");
+        else {
+            LogMessage ("CreateSocketPair: SYS$QIO(iosb) - %d",
+                        iosb.iosb$w_status);
+            sys$cantim (&sptb, 0);
+        }
+        close (SockDesc1);
+        close (SockDesc2);
+        sys$dassgn (TcpDeviceChan);
+        return (-1);
+    }
 
-close (SockDesc1) ;
-SocketPair[0] = SockDesc2 ;
-SocketPair[1] = socket_fd (TcpDeviceChan);
+    /*
+    ** Here we're successfully connected, so cancel the timer, convert the
+    ** I/O channel to a socket fd, close the listener socket and return the
+    ** connected pair.
+    */
+    sys$cantim (&sptb, 0);
 
-return (0) ;
+    close (SockDesc1) ;
+    SocketPair[0] = SockDesc2 ;
+    SocketPair[1] = socket_fd (TcpDeviceChan);
+
+    return (0) ;
 
 }
 
@@ -509,12 +490,12 @@ return (0) ;
 /*----------------------------------------------------------------------------*/
 static void SocketPairTimeoutAst (int astparm)
 {
-SPTB *sptb = (SPTB *) astparm;
+    SPTB *sptb = (SPTB *) astparm;
 
-sys$cancel (sptb->SockChan2);			/* Cancel the connect() */
-sys$cancel (sptb->SockChan1);			/* Cancel the accept() 	*/
+    sys$cancel (sptb->SockChan2); /* Cancel the connect() */
+    sys$cancel (sptb->SockChan1); /* Cancel the accept() */
 
-return;
+    return;
 
 }
 
@@ -523,36 +504,37 @@ return;
 /*----------------------------------------------------------------------------*/
 static int TerminalDeviceAst (int astparm)
 {
-int status;
+    int status;
 
-/*
-** Terminate the terminal buffer
-*/
-TerminalDeviceBuff[TerminalDeviceIosb.iosb$w_bcnt] = '\0';
-strcat (TerminalDeviceBuff, "\n");
+    /*
+    ** Terminate the terminal buffer
+    */
+    TerminalDeviceBuff[TerminalDeviceIosb.iosb$w_bcnt] = '\0';
+    strcat (TerminalDeviceBuff, "\n");
 
-/*
-** Send the data read from the terminal device throught the socket pair
-*/
-send (TerminalSocketPair[0], TerminalDeviceBuff, TerminalDeviceIosb.iosb$w_bcnt + 1, 0);
+    /*
+    ** Send the data read from the terminal device throught the socket pair
+    */
+    send (TerminalSocketPair[0], TerminalDeviceBuff,
+          TerminalDeviceIosb.iosb$w_bcnt + 1, 0);
 
-/*
-** Queue another async IO to the terminal device
-*/
-status = sys$qio (EFN$C_ENF,
-         	  TerminalDeviceChan,
-         	  IO$_READVBLK,
-         	  &TerminalDeviceIosb, 
-	 	  TerminalDeviceAst, 
-	 	  0, 
-         	  TerminalDeviceBuff,
-         	  sizeof (TerminalDeviceBuff) - 1,
-         	  0, 0, 0, 0);
+    /*
+    ** Queue another async IO to the terminal device
+    */
+    status = sys$qio (EFN$C_ENF,
+                      TerminalDeviceChan,
+                      IO$_READVBLK,
+                      &TerminalDeviceIosb,
+                      TerminalDeviceAst,
+                      0,
+                      TerminalDeviceBuff,
+                      sizeof (TerminalDeviceBuff) - 1,
+                      0, 0, 0, 0);
 
-/*
-** Return status
-*/
-return status;
+    /*
+    ** Return status
+    */
+    return status;
 
 }
 
@@ -561,46 +543,48 @@ return status;
 /*----------------------------------------------------------------------------*/
 static void LogMessage (char *msg, ...)
 {
-char *Month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", 
-                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-static unsigned int pid = 0;
-va_list args;
-time_t CurTime;
-struct tm *LocTime;
-char MsgBuff[256];
+    char *Month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+    static unsigned int pid = 0;
+    va_list args;
+    time_t CurTime;
+    struct tm *LocTime;
+    char MsgBuff[256];
 
-/*
-** Get the process pid
-*/
-if (pid == 0)
-    pid = getpid ();
+    /*
+    ** Get the process pid
+    */
+    if (pid == 0)
+        pid = getpid ();
 
-/*
-** Convert the current time into local time
-*/
-CurTime = time (NULL);
-LocTime = localtime (&CurTime);
+    /*
+    ** Convert the current time into local time
+    */
+    CurTime = time (NULL);
+    LocTime = localtime (&CurTime);
 
-/*
-** Format the message buffer
-*/
-sprintf (MsgBuff, "%02d-%s-%04d %02d:%02d:%02d [%08X] %s\n",
-         LocTime->tm_mday, Month[LocTime->tm_mon], (LocTime->tm_year + 1900),
-         LocTime->tm_hour, LocTime->tm_min, LocTime->tm_sec, pid, msg);
+    /*
+    ** Format the message buffer
+    */
+    sprintf (MsgBuff, "%02d-%s-%04d %02d:%02d:%02d [%08X] %s\n",
+             LocTime->tm_mday, Month[LocTime->tm_mon],
+             (LocTime->tm_year + 1900), LocTime->tm_hour, LocTime->tm_min,
+             LocTime->tm_sec, pid, msg);
 
-/*
-** Get any variable arguments and add them to the print of the message buffer 
-*/
-va_start (args, msg);
-vfprintf (stderr, MsgBuff, args);
-va_end (args);
+    /*
+    ** Get any variable arguments and add them to the print of the message
+    ** buffer
+    */
+    va_start (args, msg);
+    vfprintf (stderr, MsgBuff, args);
+    va_end (args);
 
-/*
-** Flush standard error output
-*/
-fsync (fileno (stderr));
+    /*
+    ** Flush standard error output
+    */
+    fsync (fileno (stderr));
 
-return;
+    return;
 
 }
 #endif

--- a/apps/vms_term_sock.h
+++ b/apps/vms_term_sock.h
@@ -1,0 +1,21 @@
+#ifndef TERM_SOCK_H
+#define TERM_SOCK_H
+
+/*
+** Terminal Socket Function Codes
+*/
+#define TERM_SOCK_CREATE	1
+#define TERM_SOCK_DELETE	2
+
+/*
+** Terminal Socket Status Codes
+*/
+#define TERM_SOCK_FAILURE	0
+#define TERM_SOCK_SUCCESS	1
+
+/*
+** Terminal Socket Prototype
+*/
+int TerminalSocket (int FunctionCode, int *ReturnSocket);
+
+#endif

--- a/apps/vms_term_sock.h
+++ b/apps/vms_term_sock.h
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2016 VMS Software, Inc. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
 #ifndef TERM_SOCK_H
 #define TERM_SOCK_H
 

--- a/apps/vms_term_sock.h
+++ b/apps/vms_term_sock.h
@@ -8,19 +8,19 @@
  */
 
 #ifndef TERM_SOCK_H
-#define TERM_SOCK_H
+# define TERM_SOCK_H
 
 /*
 ** Terminal Socket Function Codes
 */
-#define TERM_SOCK_CREATE	1
-#define TERM_SOCK_DELETE	2
+# define TERM_SOCK_CREATE       1
+# define TERM_SOCK_DELETE       2
 
 /*
 ** Terminal Socket Status Codes
 */
-#define TERM_SOCK_FAILURE	0
-#define TERM_SOCK_SUCCESS	1
+# define TERM_SOCK_FAILURE      0
+# define TERM_SOCK_SUCCESS      1
 
 /*
 ** Terminal Socket Prototype


### PR DESCRIPTION
This is needed, because on VMS, select() can only be used on sockets.  being
able to use select() on all kinds of file descriptors is unique to Unix.

So, the solution for VMS is to create a layer that translates input from
standard input to socket communication.
