### PR TITLE
rand/randfile.c: fix fallback to HOME, reject empty filenames.

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -318,14 +318,15 @@ const char *RAND_file_name(char *buf, size_t size)
 #else
     if (OPENSSL_issetugid() == 0) {
         s = getenv("RANDFILE");
-    } else {
+    }
+    if (s == NULL || !*s) {
         use_randfile = 0;
         if (OPENSSL_issetugid() == 0)
             s = getenv("HOME");
     }
 #endif
 #ifdef DEFAULT_HOME
-    if (!use_randfile && s == NULL) {
+    if (!use_randfile && (s == NULL || !*s)) {
         s = DEFAULT_HOME;
     }
 #endif
@@ -364,5 +365,8 @@ const char *RAND_file_name(char *buf, size_t size)
             return NULL;
         }
 #endif
+    if (!buf[0]) {
+        return NULL;
+    }
     return buf;
 }


### PR DESCRIPTION
Restore the fallback to $HOME for non-setuid programs when RANDFILE is
unset, broken since "rand/randfile.c: make it non-ASCII-savvy".

While at it, try harder to find a non-empty path and treat empty
paths as error. This fixes "unable to write 'random state'" errors on
Linux when running tools like genrsa.
___
Tested by running `strace -e open openssl genrsa`. Before the patch on OpenSSL 1.1.0 an empty path was observed and the above warning was produced. After the patch, no empty path is being read and the warning is gone.

If approved, could this be backported to 1.1.0?