### PR TITLE
Have the configuration options 'no-err' and 'no-async' work again

### DIFF
--- a/Configure
+++ b/Configure
@@ -886,7 +886,8 @@ foreach (sort (keys %disabled))
 		$what = "ripemd" if $what eq "rmd160";
 		$what = "whrlpool" if $what eq "whirlpool";
 
-		if (grep { $_ eq $what } @{$config{sdirs}})
+		if ($what ne "async" && $what ne "err"
+		    && grep { $_ eq $what } @{$config{sdirs}})
 			{
 			push @{$config{openssl_algorithm_defines}}, "OPENSSL_NO_$WHAT";
 			@{$config{sdirs}} = grep { $_ ne $what} @{$config{sdirs}};


### PR DESCRIPTION
In an earlier attempt to simplify the processing of disabled options,
'no-err' and 'no-async' stopped working properly.  'err' and 'async'
are directories under 'crypto/', but they are special insofar that
they can't be simply skipped, like all the algorithm directories can,
so they need special treatment among the disablable things.
