### PR TITLE
fix build failure caused by typo in eng_cryptodev.c

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -939,7 +939,7 @@ static int cryptodev_digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
     if (fstate->mac_len != 0) {
         if (fstate->mac_data != NULL) {
             dstate->mac_data = OPENSSL_malloc(fstate->mac_len);
-            if (dstate->ac_data == NULL) {
+            if (dstate->mac_data == NULL) {
                 printf("cryptodev_digest_init: malloc failed\n");
                 return 0;
             }


### PR DESCRIPTION
This patch fixes a typo introduced in
a03f81f4ead24c234dc26e388d86a352685f3948 (Fix NULL-return checks in 1.0.2)
that becomes apparent when both -DHAVE_CRYPTODEV and -DUSE_CRYPTODEV_DIGESTS
options are used with configure.

Signed-off-by: Cristian Stoica <cristian.stoica@nxp.com>