### PR TITLE
Prevents that OPENSSL_gmtime incorrectly signals success if gmtime_r …

### DIFF
--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -56,7 +56,8 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
      * should return &data, but doesn't on some systems, so we don't even
      * look at the return value
      */
-    gmtime_r(timer, result);
+    if (gmtime_r(timer, result) == NULL)
+        return NULL;
     ts = result;
 #elif !defined(OPENSSL_SYS_VMS) || defined(VMS_GMTIME_OK)
     ts = gmtime(timer);

--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -52,10 +52,6 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
     struct tm *ts = NULL;
 
 #if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && (!defined(OPENSSL_SYS_VMS) || defined(gmtime_r)) && !defined(OPENSSL_SYS_MACOSX)
-    /*
-     * should return &data, but doesn't on some systems, so we don't even
-     * look at the return value
-     */
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;


### PR DESCRIPTION
…fails, and that struct\* tm result's possibly uninitialized content is used
