### PR TITLE
[1.0.2] Add missing error string for SSL_R_TOO_MANY_WARN_ALERTS

### DIFF
--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -753,6 +753,7 @@ static ERR_STRING_DATA SSL_str_reasons[] = {
      "tls illegal exporter label"},
     {ERR_REASON(SSL_R_TLS_INVALID_ECPOINTFORMAT_LIST),
      "tls invalid ecpointformat list"},
+    {ERR_REASON(SSL_R_TOO_MANY_WARN_ALERTS), "too many warn alerts"},
     {ERR_REASON(SSL_R_TLS_PEER_DID_NOT_RESPOND_WITH_CERTIFICATE_LIST),
      "tls peer did not respond with certificate list"},
     {ERR_REASON(SSL_R_TLS_RSA_ENCRYPTED_VALUE_LENGTH_IS_WRONG),


### PR DESCRIPTION
22646a0 left out the error string for SSL_R_TOO_MANY_WARN_ALERTS, this commit adds the 1.1.0 branches version of the error string.