### PR TITLE
Fix typo

### DIFF
--- a/NOTES.WIN
+++ b/NOTES.WIN
@@ -36,7 +36,7 @@
      PREFIX:      %ProgramFiles(86)%\OpenSSL
      OPENSSLDIR:  %CommonProgramFiles(86)%\SSL
 
- For VC-WIN32, the following defaults are use:
+ For VC-WIN64, the following defaults are use:
 
      PREFIX:      %ProgramW6432%\OpenSSL
      OPENSSLDIR:  %CommonProgramW6432%\SSL


### PR DESCRIPTION
I think the second "VC-WIN32" should be "VC-WIN64", according to the commit message of 8c16829.