### PR TITLE
Missing checks of bn_wexpand and BN_copy return value

### DIFF
--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -78,8 +78,9 @@ int BN_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
                 goto err;
         }
     }
-    if (r != rr)
-        BN_copy(r, rr);
+    if (r != rr && BN_copy(r, rr) == NULL)
+        goto err;
+
     ret = 1;
  err:
     BN_CTX_end(ctx);

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -970,8 +970,9 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
  end:
 #endif
     bn_correct_top(rr);
-    if (r != rr)
-        BN_copy(r, rr);
+    if (r != rr && BN_copy(r, rr) == NULL)
+        goto err;
+
     ret = 1;
  err:
     bn_check_top(r);

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -240,7 +240,8 @@ int BN_is_prime_fasttest_ex(const BIGNUM *a, int checks, BN_CTX *ctx_passed,
         BIGNUM *t;
         if ((t = BN_CTX_get(ctx)) == NULL)
             goto err;
-        BN_copy(t, a);
+        if (BN_copy(t, a) == NULL)
+            goto err;
         t->neg = 0;
         A = t;
     } else

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -90,8 +90,9 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
         rr->top = max - 1;
     else
         rr->top = max;
-    if (rr != r)
-        BN_copy(r, rr);
+    if (r != rr && BN_copy(r, rr) == NULL)
+        goto err;
+
     ret = 1;
  err:
     bn_check_top(rr);

--- a/crypto/ec/ec2_mult.c
+++ b/crypto/ec/ec2_mult.c
@@ -223,7 +223,7 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
                                              BN_CTX *ctx)
 {
     BIGNUM *x1, *x2, *z1, *z2;
-    int ret = 0, i;
+    int ret = 0, i, group_top;
     BN_ULONG mask, word;
 
     if (r == point) {
@@ -253,10 +253,11 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
     x2 = r->X;
     z2 = r->Y;
 
-    if (bn_wexpand(x1, bn_get_top(group->field)) == NULL
-        || bn_wexpand(z1, bn_get_top(group->field)) == NULL
-        || bn_wexpand(x2, bn_get_top(group->field)) == NULL
-        || bn_wexpand(z2, bn_get_top(group->field)) == NULL)
+    group_top = bn_get_top(group->field);
+    if (bn_wexpand(x1, group_top) == NULL
+        || bn_wexpand(z1, group_top) == NULL
+        || bn_wexpand(x2, group_top) == NULL
+        || bn_wexpand(z2, group_top) == NULL)
         goto err;
 
     if (!BN_GF2m_mod_arr(x1, point->X, group->poly))
@@ -286,14 +287,14 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
     for (; i >= 0; i--) {
         word = bn_get_words(scalar)[i];
         while (mask) {
-            BN_consttime_swap(word & mask, x1, x2, bn_get_top(group->field));
-            BN_consttime_swap(word & mask, z1, z2, bn_get_top(group->field));
+            BN_consttime_swap(word & mask, x1, x2, group_top);
+            BN_consttime_swap(word & mask, z1, z2, group_top);
             if (!gf2m_Madd(group, point->X, x2, z2, x1, z1, ctx))
                 goto err;
             if (!gf2m_Mdouble(group, x1, z1, ctx))
                 goto err;
-            BN_consttime_swap(word & mask, x1, x2, bn_get_top(group->field));
-            BN_consttime_swap(word & mask, z1, z2, bn_get_top(group->field));
+            BN_consttime_swap(word & mask, x1, x2, group_top);
+            BN_consttime_swap(word & mask, z1, z2, group_top);
             mask >>= 1;
         }
         mask = BN_TBIT;

--- a/crypto/ec/ec2_mult.c
+++ b/crypto/ec/ec2_mult.c
@@ -253,10 +253,11 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
     x2 = r->X;
     z2 = r->Y;
 
-    bn_wexpand(x1, bn_get_top(group->field));
-    bn_wexpand(z1, bn_get_top(group->field));
-    bn_wexpand(x2, bn_get_top(group->field));
-    bn_wexpand(z2, bn_get_top(group->field));
+    if (bn_wexpand(x1, bn_get_top(group->field)) == NULL
+        || bn_wexpand(z1, bn_get_top(group->field)) == NULL
+        || bn_wexpand(x2, bn_get_top(group->field)) == NULL
+        || bn_wexpand(z2, bn_get_top(group->field)) == NULL)
+        goto err;
 
     if (!BN_GF2m_mod_arr(x1, point->X, group->poly))
         goto err;               /* x1 = x */

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -75,7 +75,8 @@ static int rsa_builtin_keygen(RSA *rsa, int bits, BIGNUM *e_value,
     if (!rsa->iqmp && ((rsa->iqmp = BN_secure_new()) == NULL))
         goto err;
 
-    BN_copy(rsa->e, e_value);
+    if (BN_copy(rsa->e, e_value) == NULL)
+        goto err;
 
     /* generate p and q */
     for (;;) {


### PR DESCRIPTION
Could be back-port to 1.1.0, for sure.
These changes are also valid for 1.0.2, but the fix is incomplete in this case.
