### PR TITLE
Support building with cygwin perl

### DIFF
--- a/ms/uplink-x86_64.pl
+++ b/ms/uplink-x86_64.pl
@@ -2,7 +2,7 @@
 
 $output=shift;
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
-open OUT,"| \"$^X\" ${dir}../crypto/perlasm/x86_64-xlate.pl $output";
+open OUT,"| \"$^X\" ${dir}/../crypto/perlasm/x86_64-xlate.pl $output";
 *STDOUT=*OUT;
 push(@INC,"${dir}.");
 


### PR DESCRIPTION
The match on the line just above the open, when using cygwin perl, does
not end with a / character. The result of that is that we try to find a
file "ms../crypto/perlasm/x86_64-xlate.pl", which obviously does not
exist.

Fix by adding an explicit / character

Signed-off-by: Wouter Verhelst w@uter.be
