### PR TITLE
Discard support of some deprecated ns extensions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Discard support of some obsolete X509.v3 Netscape (NS) extensions.
+     Except nsComment who is still present in openssl.cfg files and co.
+     See the list of these old extensions in doc/man5/x509v3_config.pod 
+     [FDaSilvaYY]
+
   *) Change the default RSA, DSA and DH size to 2048 bit instead of 1024.
      This changes the size when using the genpkey app when no size is given. It
      fixes an omission in earlier changes that changed all RSA, DSA and DH

--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -189,7 +189,7 @@ basicConstraints=CA:FALSE
 # This is typical in keyUsage for a client certificate.
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
@@ -290,7 +290,7 @@ basicConstraints=CA:FALSE
 # This is typical in keyUsage for a client certificate.
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -189,7 +189,7 @@ basicConstraints=CA:FALSE
 # This is typical in keyUsage for a client certificate.
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
@@ -290,7 +290,7 @@ basicConstraints=CA:FALSE
 # This is typical in keyUsage for a client certificate.
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -839,6 +839,7 @@ id-ce 56		: noRevAvail		: X509v3 No Revocation Available
 ext-key-usage 0		: anyExtendedKeyUsage	: Any Extended Key Usage
 
 
+# Older and deprecated Netscape extensions
 !Cname netscape
 2 16 840 1 113730	: Netscape		: Netscape Communications Corp.
 !Cname netscape-cert-extension

--- a/crypto/x509v3/ext_dat.h
+++ b/crypto/x509v3/ext_dat.h
@@ -11,7 +11,7 @@ int name_cmp(const char *name, const char *cmp);
 
 extern const X509V3_EXT_METHOD v3_bcons, v3_nscert, v3_key_usage, v3_ext_ku;
 extern const X509V3_EXT_METHOD v3_pkey_usage_period, v3_sxnet, v3_info, v3_sinfo;
-extern const X509V3_EXT_METHOD v3_ns_ia5_list[8], v3_alt[3], v3_skey_id, v3_akey_id;
+extern const X509V3_EXT_METHOD v3_ns_comment, v3_alt[3], v3_skey_id, v3_akey_id;
 extern const X509V3_EXT_METHOD v3_crl_num, v3_crl_reason, v3_crl_invdate;
 extern const X509V3_EXT_METHOD v3_delta_crl, v3_cpols, v3_crld, v3_freshest_crl;
 extern const X509V3_EXT_METHOD v3_ocsp_nonce, v3_ocsp_accresp, v3_ocsp_acutoff;

--- a/crypto/x509v3/standard_exts.h
+++ b/crypto/x509v3/standard_exts.h
@@ -14,13 +14,7 @@
 
 static const X509V3_EXT_METHOD *standard_exts[] = {
     &v3_nscert,
-    &v3_ns_ia5_list[0],
-    &v3_ns_ia5_list[1],
-    &v3_ns_ia5_list[2],
-    &v3_ns_ia5_list[3],
-    &v3_ns_ia5_list[4],
-    &v3_ns_ia5_list[5],
-    &v3_ns_ia5_list[6],
+    &v3_ns_comment,
     &v3_skey_id,
     &v3_key_usage,
     &v3_pkey_usage_period,

--- a/crypto/x509v3/v3_ia5.c
+++ b/crypto/x509v3/v3_ia5.c
@@ -14,15 +14,18 @@
 #include <openssl/x509v3.h>
 #include "ext_dat.h"
 
-const X509V3_EXT_METHOD v3_ns_ia5_list[8] = {
-    EXT_IA5STRING(NID_netscape_base_url),
-    EXT_IA5STRING(NID_netscape_revocation_url),
-    EXT_IA5STRING(NID_netscape_ca_revocation_url),
-    EXT_IA5STRING(NID_netscape_renewal_url),
-    EXT_IA5STRING(NID_netscape_ca_policy_url),
-    EXT_IA5STRING(NID_netscape_ssl_server_name),
-    EXT_IA5STRING(NID_netscape_comment),
-    EXT_END
+/*
+ * TODO(1.2.0): clean and sweep config files reference to nsComment
+ * so #v3_ns_comment can be removed
+ */
+const X509V3_EXT_METHOD v3_ns_comment = {
+    NID_netscape_comment, 0, ASN1_ITEM_ref(ASN1_IA5STRING),
+    0, 0,
+    0, 0,
+    (X509V3_EXT_I2S) i2s_ASN1_IA5STRING,
+    (X509V3_EXT_S2I) s2i_ASN1_IA5STRING,
+    0, 0, 0, 0,
+    NULL
 };
 
 char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
@@ -44,6 +47,7 @@ ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
                                    X509V3_CTX *ctx, const char *str)
 {
     ASN1_IA5STRING *ia5;
+
     if (!str) {
         X509V3err(X509V3_F_S2I_ASN1_IA5STRING,
                   X509V3_R_INVALID_NULL_ARGUMENT);

--- a/demos/certs/apps/apps.cnf
+++ b/demos/certs/apps/apps.cnf
@@ -36,7 +36,7 @@ commonName			= $ENV::CN
 basicConstraints=critical, CA:FALSE
 keyUsage=critical, nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 [ ec_cert ]
@@ -47,7 +47,7 @@ nsComment			= "OpenSSL Generated Certificate"
 basicConstraints=critical, CA:FALSE
 keyUsage=critical, nonRepudiation, digitalSignature, keyAgreement
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.

--- a/demos/certs/ca.cnf
+++ b/demos/certs/ca.cnf
@@ -36,7 +36,7 @@ commonName			= $ENV::CN
 basicConstraints=critical, CA:FALSE
 keyUsage=critical, nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
@@ -48,7 +48,7 @@ authorityKeyIdentifier=keyid
 basicConstraints=critical, CA:FALSE
 keyUsage=critical, nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
+# TODO(1.2.0): old and deprecated extension to be removed
 nsComment			= "OpenSSL Generated Certificate"
 
 # PKIX recommendations harmless if included in all certificates.

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -336,15 +336,6 @@ struct ISSUING_DIST_POINT_st {
                         NULL, NULL, \
                         table}
 
-# define EXT_IA5STRING(nid) { nid, 0, ASN1_ITEM_ref(ASN1_IA5STRING), \
-                        0,0,0,0, \
-                        (X509V3_EXT_I2S)i2s_ASN1_IA5STRING, \
-                        (X509V3_EXT_S2I)s2i_ASN1_IA5STRING, \
-                        0,0,0,0, \
-                        NULL}
-
-# define EXT_END { -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-
 /* X509_PURPOSE stuff */
 
 # define EXFLAG_BCONS            0x1


### PR DESCRIPTION
Only  &v3_ns_ia5_list[ 0...6 ] are used.
