### PR TITLE
Fix 'openssl s_client -engine' support

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1261,7 +1261,7 @@ ENGINE *setup_engine(const char *engine, int debug)
             ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
         }
         ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0, ui_method, 0, 1);
-        if (!ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
+        if (!ENGINE_init(e) || !ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
             BIO_printf(bio_err, "can't use that engine\n");
             ERR_print_errors(bio_err);
             ENGINE_free(e);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -577,8 +577,8 @@ OPTIONS s_client_options[] = {
     {"cert", OPT_CERT, '<', "Certificate file to use, PEM format assumed"},
     {"certform", OPT_CERTFORM, 'F',
      "Certificate format (PEM or DER) PEM default"},
-    {"key", OPT_KEY, '<', "Private key file to use, if not in -cert file"},
-    {"keyform", OPT_KEYFORM, 'F', "Key format (PEM or DER) PEM default"},
+    {"key", OPT_KEY, 's', "Private key file to use, if not in -cert file"},
+    {"keyform", OPT_KEYFORM, 'E', "Key format (PEM, DER or engine) PEM default"},
     {"pass", OPT_PASS, 's', "Private key file pass phrase source"},
     {"CApath", OPT_CAPATH, '/', "PEM format directory of CA's"},
     {"CAfile", OPT_CAFILE, '<', "PEM format file of CA's"},
@@ -1202,7 +1202,7 @@ int s_client_main(int argc, char **argv)
             fallback_scsv = 1;
             break;
         case OPT_KEYFORM:
-            if (!opt_format(opt_arg(), OPT_FMT_PEMDER, &key_format))
+            if (!opt_format(opt_arg(), OPT_FMT_PDE, &key_format))
                 goto opthelp;
             break;
         case OPT_PASS:


### PR DESCRIPTION
The support for '-keyform engine' in s_client got lost between 1.0.2 and 1.1.

Also, we don't actually call `ENGINE_init()` before we try to use a key from the engine, which is moderately suboptimal. This only ever worked for engine_pkcs11 because of a bug in engine_pkcs11 which I have now fixed in https://github.com/OpenSC/libp11/pull/108 — it registered its hardware-specific methods as generic RSA/EC methods for OpenSSL to use instead of just installing them on any EVP_PKEY it handed out. So when we used `ENGINE_set_default()` with engine_pkcs11, [bad things](https://github.com/OpenSC/libp11/issues/107) happen.

But historically this *did* result in an implicit initialisation of the engine, as its methods were erroneously installed as our defaults.