### PR TITLE
Call ENGINE_init() before trying to use keys from engine

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1553,7 +1553,7 @@ ENGINE *setup_engine(BIO *err, const char *engine, int debug)
             ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, err, 0);
         }
         ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0, ui_method, 0, 1);
-        if (!ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
+        if (!ENGINE_init(e) || !ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
             BIO_printf(err, "can't use that engine\n");
             ERR_print_errors(err);
             ENGINE_free(e);


### PR DESCRIPTION
Things like 'openssl s_client' only ever worked with keys from an engine
which provided a default generic method for some key type — because it
called ENGINE_set_default() and that ended up being an implicit
initialisation and functional refcount.

But an engine which doesn't provide generic methods doesn't get
initialised, and then when you try to use it you get an error:

cannot load client certificate private key file from engine
140688147056384:error:26096075:engine routines:ENGINE_load_private_key:not initialised:crypto/engine/eng_pkey.c:66:
unable to load client certificate private key file

cf. https://github.com/OpenSC/libp11/issues/107 (in which we discover
that engine_pkcs11 *used* to provide generic methods that OpenSSL would
try to use for ephemeral DH keys when negotiating ECDHE cipher suites in
TLS, and that didn't work out very well.)

(1.0.2 version of #1639)