### PR TITLE
Fix engine use-after-free in apps/openssl

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -692,10 +692,7 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
             BIO_printf(bio_err, "no engine specified\n");
         else {
 #ifndef OPENSSL_NO_ENGINE
-            if (ENGINE_init(e)) {
-                pkey = ENGINE_load_private_key(e, file, ui_method, &cb_data);
-                ENGINE_finish(e);
-            }
+            pkey = ENGINE_load_private_key(e, file, ui_method, &cb_data);
             if (pkey == NULL) {
                 BIO_printf(bio_err, "cannot load %s from engine\n", key_descrip);
                 ERR_print_errors(bio_err);
@@ -1264,7 +1261,7 @@ ENGINE *setup_engine(const char *engine, int debug)
             ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
         }
         ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0, ui_method, 0, 1);
-        if (!ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
+        if (!ENGINE_init(e) || !ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
             BIO_printf(bio_err, "can't use that engine\n");
             ERR_print_errors(bio_err);
             ENGINE_free(e);

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1236,6 +1236,7 @@ end_of_options:
     X509_CRL_free(crl);
     NCONF_free(conf);
     NCONF_free(extconf);
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1114,6 +1114,7 @@ int cms_main(int argc, char **argv)
     BIO_free(indata);
     BIO_free_all(out);
     OPENSSL_free(passin);
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -398,6 +398,7 @@ int dgst_main(int argc, char **argv)
     sk_OPENSSL_STRING_free(macopts);
     OPENSSL_free(sigbuf);
     BIO_free(bmd);
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -104,7 +104,7 @@ int dhparam_main(int argc, char **argv)
             outfile = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         case OPT_CHECK:
             check = 1;

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -251,6 +251,7 @@ int dsa_main(int argc, char **argv)
     DSA_free(dsa);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
+    ENGINE_finish(e);
     return (ret);
 }
 #endif

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -105,7 +105,7 @@ int dsaparam_main(int argc, char **argv)
             outfile = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         case OPT_TIMEBOMB:
 # ifdef GENCB_TEST

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -275,6 +275,7 @@ int ec_main(int argc, char **argv)
     EC_KEY_free(eckey);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
+    ENGINE_finish(e);
     return (ret);
 }
 #endif

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -168,7 +168,7 @@ int ecparam_main(int argc, char **argv)
             need_rand = 1;
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         }
     }

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -151,7 +151,7 @@ int enc_main(int argc, char **argv)
             passarg = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         case OPT_D:
             enc = 0;

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -74,7 +74,7 @@ int gendsa_main(int argc, char **argv)
             passoutarg = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         case OPT_RAND:
             inrand = opt_arg();

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -194,6 +194,7 @@ int genpkey_main(int argc, char **argv)
     BIO_free_all(out);
     BIO_free(in);
     OPENSSL_free(pass);
+    ENGINE_finish(e);
 
     return ret;
 }

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -169,6 +169,7 @@ int genrsa_main(int argc, char **argv)
     OPENSSL_free(passout);
     if (ret != 0)
         ERR_print_errors(bio_err);
+    ENGINE_finish(eng);
     return (ret);
 }
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -580,6 +580,7 @@ int pkcs12_main(int argc, char **argv)
     OPENSSL_free(badpass);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -90,7 +90,7 @@ int pkcs7_main(int argc, char **argv)
             print_certs = 1;
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         }
     }

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -347,6 +347,7 @@ int pkcs8_main(int argc, char **argv)
     BIO_free(in);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
+    ENGINE_finish(e);
 
     return ret;
 }

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -184,6 +184,7 @@ int pkey_main(int argc, char **argv)
     BIO_free(in);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
+    ENGINE_finish(e);
 
     return ret;
 }

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -58,7 +58,7 @@ int pkeyparam_main(int argc, char **argv)
             outfile = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         case OPT_TEXT:
             text = 1;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -329,6 +329,7 @@ int pkeyutl_main(int argc, char **argv)
     OPENSSL_free(buf_out);
     OPENSSL_free(sig);
     sk_OPENSSL_STRING_free(pkeyopts);
+    ENGINE_finish(e);
     return ret;
 }
 

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -60,7 +60,7 @@ int rand_main(int argc, char **argv)
             outfile = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         case OPT_RAND:
             inrand = opt_arg();

--- a/apps/req.c
+++ b/apps/req.c
@@ -824,6 +824,7 @@ int req_main(int argc, char **argv)
         OPENSSL_free(passin);
     if (passout != nofree_passout)
         OPENSSL_free(passout);
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -298,6 +298,7 @@ int rsa_main(int argc, char **argv)
     RSA_free(rsa);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
+    ENGINE_finish(e);
     return (ret);
 }
 #endif

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -272,6 +272,7 @@ int rsautl_main(int argc, char **argv)
     OPENSSL_free(rsa_in);
     OPENSSL_free(rsa_out);
     OPENSSL_free(passin);
+    ENGINE_finish(e);
     return ret;
 }
 #endif

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2488,6 +2488,7 @@ int s_client_main(int argc, char **argv)
     bio_c_out = NULL;
     BIO_free(bio_c_msg);
     bio_c_msg = NULL;
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1970,6 +1970,7 @@ int s_server_main(int argc, char *argv[])
 #ifdef CHARSET_EBCDIC
     BIO_meth_free(methods_ebcdic);
 #endif
+    ENGINE_finish(engine);
     return (ret);
 }
 

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -618,6 +618,7 @@ int smime_main(int argc, char **argv)
     BIO_free(indata);
     BIO_free_all(out);
     OPENSSL_free(passin);
+    ENGINE_finish(e);
     return (ret);
 }
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1566,7 +1566,7 @@ int speed_main(int argc, char **argv)
 #endif
 
     /* Initialize the engine after the fork */
-    (void)setup_engine(engine_id, 0);
+    ENGINE_finish(setup_engine(engine_id, 0));
 
     /* No parameters; turn on everything. */
     if ((argc == 0) && !doit[D_EVP]) {

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -188,5 +188,6 @@ int spkac_main(int argc, char **argv)
     BIO_free_all(out);
     EVP_PKEY_free(pkey);
     OPENSSL_free(passin);
+    ENGINE_finish(e);
     return (ret);
 }

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -269,7 +269,7 @@ int srp_main(int argc, char **argv)
             passoutarg = opt_arg();
             break;
         case OPT_ENGINE:
-            (void)setup_engine(opt_arg(), 0);
+            ENGINE_finish(setup_engine(opt_arg(), 0));
             break;
         }
     }

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -68,6 +68,7 @@ int verify_main(int argc, char **argv)
     int noCApath = 0, noCAfile = 0;
     int vpmtouched = 0, crl_download = 0, show_chain = 0, i = 0, ret = 1;
     OPTION_CHOICE o;
+    ENGINE *e;
 
     if ((vpm = X509_VERIFY_PARAM_new()) == NULL)
         goto end;
@@ -140,10 +141,11 @@ int verify_main(int argc, char **argv)
             crl_download = 1;
             break;
         case OPT_ENGINE:
-            if (setup_engine(opt_arg(), 0) == NULL) {
+            e = setup_engine(opt_arg(), 0);
+	    if (e == NULL)
                 /* Failure message already displayed */
                 goto end;
-            }
+            ENGINE_finish(e);
             break;
         case OPT_SHOW_CHAIN:
             show_chain = 1;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -894,6 +894,7 @@ int x509_main(int argc, char **argv)
     sk_ASN1_OBJECT_pop_free(reject, ASN1_OBJECT_free);
     ASN1_OBJECT_free(objtmp);
     OPENSSL_free(passin);
+    ENGINE_finish(e);
     return (ret);
 }
 


### PR DESCRIPTION
In `setup_engine()` we load an engine with ENGINE_by_id() and then we deliberately drop our reference to it while (naughtily) keeping the pointer to it. Then (since #1639) we try to call `ENGINE_init()` with that no-longer-valid pointer.

```
==81236== Invalid read of size 4
==81236==    at 0x514B12: engine_unlocked_init (eng_init.c:20)
==81236==    by 0x514D24: ENGINE_init (eng_init.c:88)
==81236==    by 0x405E1D: load_key (apps.c:695)
==81236==    by 0x42EDA4: rsautl_main (rsautl.c:177)
==81236==    by 0x421427: do_cmd (openssl.c:471)
==81236==    by 0x420BD8: main (openssl.c:177)
==81236==  Address 0x5653ab0 is 160 bytes inside a block of size 192 free'd
==81236==    at 0x4C2CD5A: free (vg_replace_malloc.c:530)
==81236==    by 0x53EB15: CRYPTO_free (mem.c:179)
==81236==    by 0x51514B: engine_free_util (eng_lib.c:93)
==81236==    by 0x51516F: ENGINE_free (eng_lib.c:99)
==81236==    by 0x40716D: setup_engine (apps.c:1277)
==81236==    by 0x42EC2E: rsautl_main (rsautl.c:104)
==81236==    by 0x421427: do_cmd (openssl.c:471)
==81236==    by 0x420BD8: main (openssl.c:177)
==81236==  Block was alloc'd at
==81236==    at 0x4C2BBAD: malloc (vg_replace_malloc.c:299)
==81236==    by 0x53E8C2: CRYPTO_malloc (mem.c:92)
==81236==    by 0x53E8F5: CRYPTO_zalloc (mem.c:100)
==81236==    by 0x514EE4: ENGINE_new (eng_lib.c:31)
==81236==    by 0x515F49: ENGINE_by_id (eng_list.c:306)
==81236==    by 0x406F6C: try_load_engine (apps.c:1236)
==81236==    by 0x407050: setup_engine (apps.c:1258)
==81236==    by 0x42EC2E: rsautl_main (rsautl.c:104)
==81236==    by 0x421427: do_cmd (openssl.c:471)
==81236==    by 0x420BD8: main (openssl.c:177)
```

I chose to hold a functional refcount instead of a structural refcount and thus revert commit a1b791225f29 because otherwise, we have compatibility issues with existing engines. This may be an engine_pkcs11 bug but if you call `ENGINE_finish()` from `load_key()` while still holding the `EVP_PKEY` it gave you, you end up with a *different* use-after-free:

```
==98405== Invalid read of size 8
==98405==    at 0x5A546A1: check_key_fork (p11_front.c:150)
==98405==    by 0x5A550BD: PKCS11_private_encrypt (p11_front.c:432)
==98405==    by 0x56E592: RSA_private_encrypt (rsa_crpt.c:37)
==98405==    by 0x42F12D: rsautl_main (rsautl.c:240)
==98405==    by 0x4214A3: do_cmd (openssl.c:471)
==98405==    by 0x420C54: main (openssl.c:177)
==98405==  Address 0x57611f8 is 40 bytes inside a block of size 48 free'd
==98405==    at 0x4C2CD5A: free (vg_replace_malloc.c:530)
==98405==    by 0x53EC95: CRYPTO_free (mem.c:179)
==98405==    by 0x5A7F77D: CRYPTO_free (mem.c:166)
==98405==    by 0x5A51911: pkcs11_destroy_keys (p11_key.c:551)
==98405==    by 0x5A5340D: pkcs11_destroy_token (p11_slot.c:519)
==98405==    by 0x5A54100: pkcs11_release_slot (p11_slot.c:451)
==98405==    by 0x5A544E6: pkcs11_release_all_slots (p11_slot.c:431)
==98405==    by 0x5A4E78D: pkcs11_finish (eng_back.c:269)
==98405==    by 0x514D66: engine_unlocked_finish (eng_init.c:60)
==98405==    by 0x514F02: ENGINE_finish (eng_init.c:101)
==98405==    by 0x405E4C: load_key (apps.c:697)
```