### PR TITLE
Do not set load_crypto_strings_inited when OPENSSL_NO_ERR is defined

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -103,8 +103,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_strings)
                     "err_load_crypto_strings_int()\n");
 # endif
     ret = err_load_crypto_strings_int();
-#endif
     load_crypto_strings_inited = 1;
+#endif    
     return ret;
 }
 


### PR DESCRIPTION
Only set the load_crypto_strings_inited to 1 when err_load_crypto_strings_int was called.

This solves the following issue:
- openssl is built with no-err
- load_crypto_strings_inited is set to 1 during the OPENSSL_init_crypto call
- During the cleanup: OPENSSL_cleanup, err_free_strings_int is called because load_crypto_strings_inited == 1
- err_free_strings_int calls do_err_strings_init because it has never been called
- Now do_err_strings_init calls OPENSSL_init_crypto
- But since we are in the cleanup (stopped == 1) this results in an error:
  CRYPTOerr(CRYPTO_F_OPENSSL_INIT_CRYPTO, ERR_R_INIT_FAIL);
- which then tries to initialize everything we are trying to clean up: ERR_get_state, ossl_init_thread_start, etc