### PR TITLE
dsa/dsa_gen: add error message for seed_len < 0

### DIFF
--- a/crypto/dsa/dsa_err.c
+++ b/crypto/dsa/dsa_err.c
@@ -21,7 +21,7 @@
 static ERR_STRING_DATA DSA_str_functs[] = {
     {ERR_FUNC(DSA_F_DSAPARAMS_PRINT), "DSAparams_print"},
     {ERR_FUNC(DSA_F_DSAPARAMS_PRINT_FP), "DSAparams_print_fp"},
-    {ERR_FUNC(DSA_F_DSA_BUILTIN_PARAMGEN), "DSA_BUILTIN_PARAMGEN"},
+    {ERR_FUNC(DSA_F_DSA_BUILTIN_PARAMGEN), "dsa_builtin_paramgen"},
     {ERR_FUNC(DSA_F_DSA_BUILTIN_PARAMGEN2), "dsa_builtin_paramgen2"},
     {ERR_FUNC(DSA_F_DSA_DO_SIGN), "DSA_do_sign"},
     {ERR_FUNC(DSA_F_DSA_DO_VERIFY), "DSA_do_verify"},
@@ -56,6 +56,8 @@ static ERR_STRING_DATA DSA_str_reasons[] = {
     {ERR_REASON(DSA_R_NO_PARAMETERS_SET), "no parameters set"},
     {ERR_REASON(DSA_R_PARAMETER_ENCODING_ERROR), "parameter encoding error"},
     {ERR_REASON(DSA_R_Q_NOT_PRIME), "q not prime"},
+    {ERR_REASON(DSA_R_SEED_LEN_SMALL),
+     "seed_len is less than the length of q"},
     {0, NULL}
 };
 

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -74,8 +74,10 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
     bits = (bits + 63) / 64 * 64;
 
     if (seed_in != NULL) {
-        if (seed_len < (size_t)qsize)
+        if (seed_len < (size_t)qsize) {
+            DSAerr(DSA_F_DSA_BUILTIN_PARAMGEN, DSA_R_SEED_LEN_SMALL);
             return 0;
+        }
         if (seed_len > (size_t)qsize) {
             /* Only consume as much seed as is expected. */
             seed_len = qsize;

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -274,6 +274,7 @@ int ERR_load_DSA_strings(void);
 # define DSA_R_NO_PARAMETERS_SET                          107
 # define DSA_R_PARAMETER_ENCODING_ERROR                   105
 # define DSA_R_Q_NOT_PRIME                                113
+# define DSA_R_SEED_LEN_SMALL                             110
 
 #  ifdef  __cplusplus
 }


### PR DESCRIPTION
prio openssl 1.1.0 seed_len < q was accepted and the seed argument was
then ignored. Now DSA_generate_parameters_ex() returns an error in such
a case but no error string.

Signed-off-by: Sebastian Andrzej Siewior sebastian@breakpoint.cc
