### PR TITLE
Use EVP interface for ECDH in apps/speed.c

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2653,11 +2653,11 @@ int speed_main(int argc, char **argv)
                 rsa_count = 1;
                 break;
             }
-            for (k = 0; (unsigned int)k < test_outlen && ecdh_checks == 1; k++) {
-                if (loopargs[i].secret_a[k] != loopargs[i].secret_b[k])
-                    ecdh_checks = 0;
-            }
-            if (ecdh_checks == 0) {
+
+            /* Compare the computation results: CRYPTO_memcmp() returns 0 if equal */
+            if (CRYPTO_memcmp(loopargs[i].secret_a,
+                              loopargs[i].secret_b, outlen)) {
+                ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH computations don't match.\n");
                 ERR_print_errors(bio_err);
                 rsa_count = 1;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2587,8 +2587,10 @@ int speed_main(int argc, char **argv)
             continue;
 
         for (i = 0; i < loopargs_len; i++) {
-            EVP_PKEY_CTX *kctx = NULL, *ctx = NULL;
-            EVP_PKEY *key_A = NULL, *key_B = NULL;
+            EVP_PKEY_CTX *kctx = NULL;
+            EVP_PKEY_CTX *ctx = NULL;
+            EVP_PKEY *key_A = NULL;
+            EVP_PKEY *key_B = NULL;
             size_t outlen;
 
             if (testnum == R_EC_X25519) {
@@ -2606,7 +2608,7 @@ int speed_main(int argc, char **argv)
                                                                test_curves
                                                                [testnum]) ||
                        /* Create the parameter object params */
-                       !EVP_PKEY_paramgen(pctx, &params) || 0) {
+                       !EVP_PKEY_paramgen(pctx, &params)) {
                     ecdh_checks = 0;
                     BIO_printf(bio_err, "ECDH init failure.\n");
                     ERR_print_errors(bio_err);
@@ -2622,8 +2624,7 @@ int speed_main(int argc, char **argv)
                 pctx = NULL;
             }
             if (!kctx ||        /* keygen ctx is not null */
-                !EVP_PKEY_keygen_init(kctx) || /* init keygen ctx */
-                0) {
+                !EVP_PKEY_keygen_init(kctx) /* init keygen ctx */ ) {
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH keygen failure.\n");
                 ERR_print_errors(bio_err);
@@ -2637,8 +2638,7 @@ int speed_main(int argc, char **argv)
                 !EVP_PKEY_derive_init(ctx) || /* init derivation ctx */
                 !EVP_PKEY_derive_set_peer(ctx, key_B) || /* set peer pubkey in ctx */
                 !EVP_PKEY_derive(ctx, NULL, &outlen) || /* determine max length */
-                outlen > MAX_ECDH_SIZE || /* avoid buffer overflow */
-                0) {
+                outlen > MAX_ECDH_SIZE /* avoid buffer overflow */ ) {
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH key generation failure.\n");
                 ERR_print_errors(bio_err);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -144,9 +144,6 @@ static volatile int run = 0;
 static int mr = 0;
 static int usertime = 1;
 
-typedef void *(*kdf_fn) (const void *in, size_t inlen, void *out,
-                         size_t *xoutlen);
-
 typedef struct loopargs_st {
     ASYNC_JOB *inprogress_job;
     ASYNC_WAIT_CTX *wait_ctx;
@@ -167,7 +164,6 @@ typedef struct loopargs_st {
     unsigned char *secret_a;
     unsigned char *secret_b;
     size_t outlen[EC_NUM];
-    kdf_fn kdf;
 #endif
     EVP_CIPHER_CTX *ctx;
     HMAC_CTX *hctx;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1031,18 +1031,6 @@ static int ECDSA_verify_loop(void *args)
 /* ******************************************************************** */
 static long ecdh_c[EC_NUM][1];
 
-static int ECDH_EVP_derive_key(unsigned char *derived_secret,
-                               size_t *outlen, EVP_PKEY_CTX *ctx)
-{
-    int rt = 1;
-    if ((rt = EVP_PKEY_derive(ctx, derived_secret, outlen)) <= 0) {
-        BIO_printf(bio_err, "ECDH EVP_PKEY_derive failure: returned %d\n", rt);
-        ERR_print_errors(bio_err);
-        return rt;
-    }
-    return rt;
-}
-
 static int ECDH_EVP_derive_key_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -1051,10 +1039,12 @@ static int ECDH_EVP_derive_key_loop(void *args)
     int count;
     size_t *outlen = &(tempargs->outlen[testnum]);
 
-    for (count = 0; COND(ecdh_c[testnum][0]); count++) {
-        if (!ECDH_EVP_derive_key(derived_secret, outlen, ctx))
+    for (count = 0; COND(ecdh_c[testnum][0]); count++)
+        if (EVP_PKEY_derive(ctx, derived_secret, outlen) <= 0) {
+            BIO_printf(bio_err, "ECDH EVP_PKEY_derive failure\n");
+            ERR_print_errors(bio_err);
             break;
-    }
+        }
     return count;
 }
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -144,8 +144,8 @@ static volatile int run = 0;
 static int mr = 0;
 static int usertime = 1;
 
-typedef void *(*kdf_fn) (
-        const void *in, size_t inlen, void *out, size_t *xoutlen);
+typedef void *(*kdf_fn) (const void *in, size_t inlen, void *out,
+                         size_t *xoutlen);
 
 typedef struct loopargs_st {
     ASYNC_JOB *inprogress_job;
@@ -166,8 +166,8 @@ typedef struct loopargs_st {
     EVP_PKEY_CTX *ecdh_ctx[EC_NUM];
     unsigned char *secret_a;
     unsigned char *secret_b;
-    size_t      outlen[EC_NUM];
-    kdf_fn      kdf;
+    size_t outlen[EC_NUM];
+    kdf_fn kdf;
 #endif
     EVP_CIPHER_CTX *ctx;
     HMAC_CTX *hctx;
@@ -225,7 +225,8 @@ static int DSA_verify_loop(void *args);
 static int ECDSA_sign_loop(void *args);
 static int ECDSA_verify_loop(void *args);
 #endif
-static int run_benchmark(int async_jobs, int (*loop_function)(void *), loopargs_t *loopargs);
+static int run_benchmark(int async_jobs, int (*loop_function) (void *),
+                         loopargs_t * loopargs);
 
 static double Time_F(int s);
 static void print_message(const char *s, long num, int length);
@@ -581,7 +582,7 @@ static OPT_PAIR ecdh_choices[] = {
 #else
 # define COND(unused_cond) (run && count<0x7fffffff)
 # define COUNT(d) (count)
-#endif                         /* SIGALRM */
+#endif                          /* SIGALRM */
 
 static int testnum;
 
@@ -591,14 +592,14 @@ static long c[ALGOR_NUM][SIZE_NUM];
 #ifndef OPENSSL_NO_MD2
 static int EVP_Digest_MD2_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char md2[MD2_DIGEST_LENGTH];
     int count;
 
     for (count = 0; COND(c[D_MD2][testnum]); count++) {
         if (!EVP_Digest(buf, (size_t)lengths[testnum], md2, NULL, EVP_md2(),
-                NULL))
+                        NULL))
             return -1;
     }
     return count;
@@ -608,14 +609,14 @@ static int EVP_Digest_MD2_loop(void *args)
 #ifndef OPENSSL_NO_MDC2
 static int EVP_Digest_MDC2_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char mdc2[MDC2_DIGEST_LENGTH];
     int count;
 
     for (count = 0; COND(c[D_MDC2][testnum]); count++) {
         if (!EVP_Digest(buf, (size_t)lengths[testnum], mdc2, NULL, EVP_mdc2(),
-                NULL))
+                        NULL))
             return -1;
     }
     return count;
@@ -625,14 +626,14 @@ static int EVP_Digest_MDC2_loop(void *args)
 #ifndef OPENSSL_NO_MD4
 static int EVP_Digest_MD4_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char md4[MD4_DIGEST_LENGTH];
     int count;
 
     for (count = 0; COND(c[D_MD4][testnum]); count++) {
         if (!EVP_Digest(buf, (size_t)lengths[testnum], md4, NULL, EVP_md4(),
-                NULL))
+                        NULL))
             return -1;
     }
     return count;
@@ -642,7 +643,7 @@ static int EVP_Digest_MD4_loop(void *args)
 #ifndef OPENSSL_NO_MD5
 static int MD5_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char md5[MD5_DIGEST_LENGTH];
     int count;
@@ -653,7 +654,7 @@ static int MD5_loop(void *args)
 
 static int HMAC_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     HMAC_CTX *hctx = tempargs->hctx;
     unsigned char hmac[MD5_DIGEST_LENGTH];
@@ -670,7 +671,7 @@ static int HMAC_loop(void *args)
 
 static int SHA1_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char sha[SHA_DIGEST_LENGTH];
     int count;
@@ -681,7 +682,7 @@ static int SHA1_loop(void *args)
 
 static int SHA256_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char sha256[SHA256_DIGEST_LENGTH];
     int count;
@@ -692,7 +693,7 @@ static int SHA256_loop(void *args)
 
 static int SHA512_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char sha512[SHA512_DIGEST_LENGTH];
     int count;
@@ -704,7 +705,7 @@ static int SHA512_loop(void *args)
 #ifndef OPENSSL_NO_WHIRLPOOL
 static int WHIRLPOOL_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char whirlpool[WHIRLPOOL_DIGEST_LENGTH];
     int count;
@@ -717,13 +718,13 @@ static int WHIRLPOOL_loop(void *args)
 #ifndef OPENSSL_NO_RMD160
 static int EVP_Digest_RMD160_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char rmd160[RIPEMD160_DIGEST_LENGTH];
     int count;
     for (count = 0; COND(c[D_RMD160][testnum]); count++) {
         if (!EVP_Digest(buf, (size_t)lengths[testnum], &(rmd160[0]),
-                NULL, EVP_ripemd160(), NULL))
+                        NULL, EVP_ripemd160(), NULL))
             return -1;
     }
     return count;
@@ -734,7 +735,7 @@ static int EVP_Digest_RMD160_loop(void *args)
 static RC4_KEY rc4_ks;
 static int RC4_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
     for (count = 0; COND(c[D_RC4][testnum]); count++)
@@ -750,24 +751,23 @@ static DES_key_schedule sch2;
 static DES_key_schedule sch3;
 static int DES_ncbc_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
     for (count = 0; COND(c[D_CBC_DES][testnum]); count++)
         DES_ncbc_encrypt(buf, buf, lengths[testnum], &sch,
-                &DES_iv, DES_ENCRYPT);
+                         &DES_iv, DES_ENCRYPT);
     return count;
 }
 
 static int DES_ede3_cbc_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
     for (count = 0; COND(c[D_EDE3_DES][testnum]); count++)
         DES_ede3_cbc_encrypt(buf, buf, lengths[testnum],
-                &sch, &sch2, &sch3,
-                &DES_iv, DES_ENCRYPT);
+                             &sch, &sch2, &sch3, &DES_iv, DES_ENCRYPT);
     return count;
 }
 #endif
@@ -778,82 +778,76 @@ static unsigned char iv[2 * MAX_BLOCK_SIZE / 8];
 static AES_KEY aes_ks1, aes_ks2, aes_ks3;
 static int AES_cbc_128_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
     for (count = 0; COND(c[D_CBC_128_AES][testnum]); count++)
         AES_cbc_encrypt(buf, buf,
-                (size_t)lengths[testnum], &aes_ks1,
-                iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks1, iv, AES_ENCRYPT);
     return count;
 }
 
 static int AES_cbc_192_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
     for (count = 0; COND(c[D_CBC_192_AES][testnum]); count++)
         AES_cbc_encrypt(buf, buf,
-                (size_t)lengths[testnum], &aes_ks2,
-                iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks2, iv, AES_ENCRYPT);
     return count;
 }
 
 static int AES_cbc_256_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
     for (count = 0; COND(c[D_CBC_256_AES][testnum]); count++)
         AES_cbc_encrypt(buf, buf,
-                (size_t)lengths[testnum], &aes_ks3,
-                iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
     return count;
 }
 
 static int AES_ige_128_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     int count;
     for (count = 0; COND(c[D_IGE_128_AES][testnum]); count++)
         AES_ige_encrypt(buf, buf2,
-                (size_t)lengths[testnum], &aes_ks1,
-                iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks1, iv, AES_ENCRYPT);
     return count;
 }
 
 static int AES_ige_192_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     int count;
     for (count = 0; COND(c[D_IGE_192_AES][testnum]); count++)
         AES_ige_encrypt(buf, buf2,
-                (size_t)lengths[testnum], &aes_ks2,
-                iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks2, iv, AES_ENCRYPT);
     return count;
 }
 
 static int AES_ige_256_encrypt_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     int count;
     for (count = 0; COND(c[D_IGE_256_AES][testnum]); count++)
         AES_ige_encrypt(buf, buf2,
-                (size_t)lengths[testnum], &aes_ks3,
-                iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
     return count;
 }
 
 static int CRYPTO_gcm128_aad_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     GCM128_CONTEXT *gcm_ctx = tempargs->gcm_ctx;
     int count;
@@ -866,7 +860,7 @@ static long save_count = 0;
 static int decrypt = 0;
 static int EVP_Update_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     EVP_CIPHER_CTX *ctx = tempargs->ctx;
     int outl, count;
@@ -889,7 +883,7 @@ static int EVP_Update_loop(void *args)
 static const EVP_MD *evp_md = NULL;
 static int EVP_Digest_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char md[EVP_MAX_MD_SIZE];
     int count;
@@ -909,7 +903,7 @@ static long rsa_c[RSA_NUM][2];  /* # RSA iteration test */
 
 static int RSA_sign_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     unsigned int *rsa_num = &tempargs->siglen;
@@ -929,14 +923,15 @@ static int RSA_sign_loop(void *args)
 
 static int RSA_verify_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     unsigned int rsa_num = tempargs->siglen;
     RSA **rsa_key = tempargs->rsa_key;
     int ret, count;
     for (count = 0; COND(rsa_c[testnum][1]); count++) {
-        ret = RSA_verify(NID_md5_sha1, buf, 36, buf2, rsa_num, rsa_key[testnum]);
+        ret =
+            RSA_verify(NID_md5_sha1, buf, 36, buf2, rsa_num, rsa_key[testnum]);
         if (ret <= 0) {
             BIO_printf(bio_err, "RSA verify failure\n");
             ERR_print_errors(bio_err);
@@ -952,7 +947,7 @@ static int RSA_verify_loop(void *args)
 static long dsa_c[DSA_NUM][2];
 static int DSA_sign_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     DSA **dsa_key = tempargs->dsa_key;
@@ -972,7 +967,7 @@ static int DSA_sign_loop(void *args)
 
 static int DSA_verify_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
     DSA **dsa_key = tempargs->dsa_key;
@@ -995,15 +990,14 @@ static int DSA_verify_loop(void *args)
 static long ecdsa_c[EC_NUM][2];
 static int ECDSA_sign_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     EC_KEY **ecdsa = tempargs->ecdsa;
     unsigned char *ecdsasig = tempargs->buf2;
     unsigned int *ecdsasiglen = &tempargs->siglen;
     int ret, count;
     for (count = 0; COND(ecdsa_c[testnum][0]); count++) {
-        ret = ECDSA_sign(0, buf, 20,
-                ecdsasig, ecdsasiglen, ecdsa[testnum]);
+        ret = ECDSA_sign(0, buf, 20, ecdsasig, ecdsasiglen, ecdsa[testnum]);
         if (ret == 0) {
             BIO_printf(bio_err, "ECDSA sign failure\n");
             ERR_print_errors(bio_err);
@@ -1016,15 +1010,14 @@ static int ECDSA_sign_loop(void *args)
 
 static int ECDSA_verify_loop(void *args)
 {
-    loopargs_t *tempargs = *(loopargs_t **)args;
+    loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     EC_KEY **ecdsa = tempargs->ecdsa;
     unsigned char *ecdsasig = tempargs->buf2;
     unsigned int ecdsasiglen = tempargs->siglen;
     int ret, count;
     for (count = 0; COND(ecdsa_c[testnum][1]); count++) {
-        ret = ECDSA_verify(0, buf, 20, ecdsasig, ecdsasiglen,
-                ecdsa[testnum]);
+        ret = ECDSA_verify(0, buf, 20, ecdsasig, ecdsasiglen, ecdsa[testnum]);
         if (ret != 1) {
             BIO_printf(bio_err, "ECDSA verify failure\n");
             ERR_print_errors(bio_err);
@@ -1039,11 +1032,10 @@ static int ECDSA_verify_loop(void *args)
 static long ecdh_c[EC_NUM][1];
 
 static int ECDH_EVP_derive_key(unsigned char *derived_secret,
-                            size_t *outlen,
-                            EVP_PKEY_CTX *ctx)
+                               size_t *outlen, EVP_PKEY_CTX *ctx)
 {
-    int rt=1;
-    if ( (rt=EVP_PKEY_derive(ctx, derived_secret, outlen)) <= 0 ) {
+    int rt = 1;
+    if ((rt = EVP_PKEY_derive(ctx, derived_secret, outlen)) <= 0) {
         BIO_printf(bio_err, "ECDH EVP_PKEY_derive failure: returned %d\n", rt);
         ERR_print_errors(bio_err);
         return rt;
@@ -1060,7 +1052,7 @@ static int ECDH_EVP_derive_key_loop(void *args)
     size_t *outlen = &(tempargs->outlen[testnum]);
 
     for (count = 0; COND(ecdh_c[testnum][0]); count++) {
-        if ( !ECDH_EVP_derive_key(derived_secret, outlen, ctx) )
+        if (!ECDH_EVP_derive_key(derived_secret, outlen, ctx))
             break;
     }
     return count;
@@ -1069,7 +1061,7 @@ static int ECDH_EVP_derive_key_loop(void *args)
 #endif                          /* OPENSSL_NO_EC */
 
 static int run_benchmark(int async_jobs,
-                         int (*loop_function)(void *), loopargs_t *loopargs)
+                         int (*loop_function) (void *), loopargs_t * loopargs)
 {
     int job_op_count = 0;
     int total_op_count = 0;
@@ -1125,14 +1117,16 @@ static int run_benchmark(int async_jobs,
             if (loopargs[i].inprogress_job == NULL)
                 continue;
 
-            if (!ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, NULL, &num_job_fds)
-                    || num_job_fds > 1) {
+            if (!ASYNC_WAIT_CTX_get_all_fds
+                (loopargs[i].wait_ctx, NULL, &num_job_fds)
+                || num_job_fds > 1) {
                 BIO_printf(bio_err, "Too many fds in ASYNC_WAIT_CTX\n");
                 ERR_print_errors(bio_err);
                 error = 1;
                 break;
             }
-            ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, &job_fd, &num_job_fds);
+            ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, &job_fd,
+                                       &num_job_fds);
             FD_SET(job_fd, &waitfdset);
             if (job_fd > max_fd)
                 max_fd = job_fd;
@@ -1140,9 +1134,9 @@ static int run_benchmark(int async_jobs,
 
         if (max_fd >= (OSSL_ASYNC_FD)FD_SETSIZE) {
             BIO_printf(bio_err,
-                    "Error: max_fd (%d) must be smaller than FD_SETSIZE (%d). "
-                    "Decrease the value of async_jobs\n",
-                    max_fd, FD_SETSIZE);
+                       "Error: max_fd (%d) must be smaller than FD_SETSIZE (%d). "
+                       "Decrease the value of async_jobs\n",
+                       max_fd, FD_SETSIZE);
             ERR_print_errors(bio_err);
             error = 1;
             break;
@@ -1167,14 +1161,16 @@ static int run_benchmark(int async_jobs,
             if (loopargs[i].inprogress_job == NULL)
                 continue;
 
-            if (!ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, NULL, &num_job_fds)
-                    || num_job_fds > 1) {
+            if (!ASYNC_WAIT_CTX_get_all_fds
+                (loopargs[i].wait_ctx, NULL, &num_job_fds)
+                || num_job_fds > 1) {
                 BIO_printf(bio_err, "Too many fds in ASYNC_WAIT_CTX\n");
                 ERR_print_errors(bio_err);
                 error = 1;
                 break;
             }
-            ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, &job_fd, &num_job_fds);
+            ASYNC_WAIT_CTX_get_all_fds(loopargs[i].wait_ctx, &job_fd,
+                                       &num_job_fds);
 
 #if defined(OPENSSL_SYS_UNIX)
             if (num_job_fds == 1 && !FD_ISSET(job_fd, &waitfdset))
@@ -1187,8 +1183,9 @@ static int run_benchmark(int async_jobs,
 #endif
 
             ret = ASYNC_start_job(&loopargs[i].inprogress_job,
-                    loopargs[i].wait_ctx, &job_op_count, loop_function,
-                    (void *)(loopargs + i), sizeof(loopargs_t));
+                                  loopargs[i].wait_ctx, &job_op_count,
+                                  loop_function, (void *)(loopargs + i),
+                                  sizeof(loopargs_t));
             switch (ret) {
             case ASYNC_PAUSE:
                 break;
@@ -1354,7 +1351,7 @@ int speed_main(int argc, char **argv)
         163, 233, 283,
         409, 571, 163,
         233, 283, 409,
-        571, 253 /* X25519 */
+        571, 253                /* X25519 */
     };
 
     int ecdsa_doit[EC_NUM] = { 0 };
@@ -1442,7 +1439,7 @@ int speed_main(int argc, char **argv)
     argv = opt_rest();
 
     /* Remaining arguments are algorithms. */
-    for ( ; *argv; argv++) {
+    for (; *argv; argv++) {
         if (found(*argv, doit_choices, &i)) {
             doit[i] = 1;
             continue;
@@ -1488,14 +1485,12 @@ int speed_main(int argc, char **argv)
         }
 #endif
         if (strcmp(*argv, "aes") == 0) {
-            doit[D_CBC_128_AES] = doit[D_CBC_192_AES] =
-                doit[D_CBC_256_AES] = 1;
+            doit[D_CBC_128_AES] = doit[D_CBC_192_AES] = doit[D_CBC_256_AES] = 1;
             continue;
         }
 #ifndef OPENSSL_NO_CAMELLIA
         if (strcmp(*argv, "camellia") == 0) {
-            doit[D_CBC_128_CML] = doit[D_CBC_192_CML] =
-                doit[D_CBC_256_CML] = 1;
+            doit[D_CBC_128_CML] = doit[D_CBC_192_CML] = doit[D_CBC_256_CML] = 1;
             continue;
         }
 #endif
@@ -1533,7 +1528,8 @@ int speed_main(int argc, char **argv)
     }
 
     loopargs_len = (async_jobs == 0 ? 1 : async_jobs);
-    loopargs = app_malloc(loopargs_len * sizeof(loopargs_t), "array of loopargs");
+    loopargs =
+        app_malloc(loopargs_len * sizeof(loopargs_t), "array of loopargs");
     memset(loopargs, 0, loopargs_len * sizeof(loopargs_t));
 
     for (i = 0; i < loopargs_len; i++) {
@@ -1545,8 +1541,10 @@ int speed_main(int argc, char **argv)
             }
         }
 
-        loopargs[i].buf_malloc = app_malloc((int)BUFSIZE + MAX_MISALIGNMENT + 1, "input buffer");
-        loopargs[i].buf2_malloc = app_malloc((int)BUFSIZE + MAX_MISALIGNMENT + 1, "input buffer");
+        loopargs[i].buf_malloc =
+            app_malloc((int)BUFSIZE + MAX_MISALIGNMENT + 1, "input buffer");
+        loopargs[i].buf2_malloc =
+            app_malloc((int)BUFSIZE + MAX_MISALIGNMENT + 1, "input buffer");
         /* Align the start of buffers on a 64 byte boundary */
         loopargs[i].buf = loopargs[i].buf_malloc + misalign;
         loopargs[i].buf2 = loopargs[i].buf2_malloc + misalign;
@@ -1599,10 +1597,11 @@ int speed_main(int argc, char **argv)
             const unsigned char *p;
 
             p = rsa_data[k];
-            loopargs[i].rsa_key[k] = d2i_RSAPrivateKey(NULL, &p, rsa_data_length[k]);
+            loopargs[i].rsa_key[k] =
+                d2i_RSAPrivateKey(NULL, &p, rsa_data_length[k]);
             if (loopargs[i].rsa_key[k] == NULL) {
-                BIO_printf(bio_err, "internal error loading RSA key number %d\n",
-                        k);
+                BIO_printf(bio_err,
+                           "internal error loading RSA key number %d\n", k);
                 goto end;
             }
         }
@@ -1743,7 +1742,7 @@ int speed_main(int argc, char **argv)
             rsa_doit[i] = 0;
         else {
             if (rsa_c[i][0] == 0) {
-                rsa_c[i][0] = 1;            /* Set minimum iteration Nb to 1. */
+                rsa_c[i][0] = 1; /* Set minimum iteration Nb to 1. */
                 rsa_c[i][1] = 20;
             }
         }
@@ -1760,7 +1759,7 @@ int speed_main(int argc, char **argv)
             dsa_doit[i] = 0;
         else {
             if (dsa_c[i][0] == 0) {
-                dsa_c[i][0] = 1;            /* Set minimum iteration Nb to 1. */
+                dsa_c[i][0] = 1; /* Set minimum iteration Nb to 1. */
                 dsa_c[i][1] = 1;
             }
         }
@@ -1849,12 +1848,12 @@ int speed_main(int argc, char **argv)
 # else
 /* not worth fixing */
 #  error "You cannot disable DES on systems without SIGALRM."
-# endif                        /* OPENSSL_NO_DES */
+# endif                         /* OPENSSL_NO_DES */
 #else
 # ifndef _WIN32
     signal(SIGALRM, sig_done);
 # endif
-#endif                         /* SIGALRM */
+#endif                          /* SIGALRM */
 
 #ifndef OPENSSL_NO_MD2
     if (doit[D_MD2]) {
@@ -1938,7 +1937,8 @@ int speed_main(int argc, char **argv)
     }
     if (doit[D_SHA256]) {
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_SHA256], c[D_SHA256][testnum], lengths[testnum]);
+            print_message(names[D_SHA256], c[D_SHA256][testnum],
+                          lengths[testnum]);
             Time_F(START);
             count = run_benchmark(async_jobs, SHA256_loop, loopargs);
             d = Time_F(STOP);
@@ -1947,18 +1947,19 @@ int speed_main(int argc, char **argv)
     }
     if (doit[D_SHA512]) {
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_SHA512], c[D_SHA512][testnum], lengths[testnum]);
+            print_message(names[D_SHA512], c[D_SHA512][testnum],
+                          lengths[testnum]);
             Time_F(START);
             count = run_benchmark(async_jobs, SHA512_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_SHA512, testnum, count, d);
         }
     }
-
 #ifndef OPENSSL_NO_WHIRLPOOL
     if (doit[D_WHIRLPOOL]) {
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_WHIRLPOOL], c[D_WHIRLPOOL][testnum], lengths[testnum]);
+            print_message(names[D_WHIRLPOOL], c[D_WHIRLPOOL][testnum],
+                          lengths[testnum]);
             Time_F(START);
             count = run_benchmark(async_jobs, WHIRLPOOL_loop, loopargs);
             d = Time_F(STOP);
@@ -1970,7 +1971,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_RMD160
     if (doit[D_RMD160]) {
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_RMD160], c[D_RMD160][testnum], lengths[testnum]);
+            print_message(names[D_RMD160], c[D_RMD160][testnum],
+                          lengths[testnum]);
             Time_F(START);
             count = run_benchmark(async_jobs, EVP_Digest_RMD160_loop, loopargs);
             d = Time_F(STOP);
@@ -1992,7 +1994,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DES
     if (doit[D_CBC_DES]) {
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_CBC_DES], c[D_CBC_DES][testnum], lengths[testnum]);
+            print_message(names[D_CBC_DES], c[D_CBC_DES][testnum],
+                          lengths[testnum]);
             Time_F(START);
             count = run_benchmark(async_jobs, DES_ncbc_encrypt_loop, loopargs);
             d = Time_F(STOP);
@@ -2002,9 +2005,11 @@ int speed_main(int argc, char **argv)
 
     if (doit[D_EDE3_DES]) {
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_EDE3_DES], c[D_EDE3_DES][testnum], lengths[testnum]);
+            print_message(names[D_EDE3_DES], c[D_EDE3_DES][testnum],
+                          lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, DES_ede3_cbc_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, DES_ede3_cbc_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_EDE3_DES, testnum, count, d);
         }
@@ -2016,7 +2021,8 @@ int speed_main(int argc, char **argv)
             print_message(names[D_CBC_128_AES], c[D_CBC_128_AES][testnum],
                           lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, AES_cbc_128_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, AES_cbc_128_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_CBC_128_AES, testnum, count, d);
         }
@@ -2026,7 +2032,8 @@ int speed_main(int argc, char **argv)
             print_message(names[D_CBC_192_AES], c[D_CBC_192_AES][testnum],
                           lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, AES_cbc_192_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, AES_cbc_192_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_CBC_192_AES, testnum, count, d);
         }
@@ -2036,7 +2043,8 @@ int speed_main(int argc, char **argv)
             print_message(names[D_CBC_256_AES], c[D_CBC_256_AES][testnum],
                           lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, AES_cbc_256_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, AES_cbc_256_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_CBC_256_AES, testnum, count, d);
         }
@@ -2047,7 +2055,8 @@ int speed_main(int argc, char **argv)
             print_message(names[D_IGE_128_AES], c[D_IGE_128_AES][testnum],
                           lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, AES_ige_128_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, AES_ige_128_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_IGE_128_AES, testnum, count, d);
         }
@@ -2057,7 +2066,8 @@ int speed_main(int argc, char **argv)
             print_message(names[D_IGE_192_AES], c[D_IGE_192_AES][testnum],
                           lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, AES_ige_192_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, AES_ige_192_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_IGE_192_AES, testnum, count, d);
         }
@@ -2067,19 +2077,23 @@ int speed_main(int argc, char **argv)
             print_message(names[D_IGE_256_AES], c[D_IGE_256_AES][testnum],
                           lengths[testnum]);
             Time_F(START);
-            count = run_benchmark(async_jobs, AES_ige_256_encrypt_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, AES_ige_256_encrypt_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_IGE_256_AES, testnum, count, d);
         }
     }
     if (doit[D_GHASH]) {
         for (i = 0; i < loopargs_len; i++) {
-            loopargs[i].gcm_ctx = CRYPTO_gcm128_new(&aes_ks1, (block128_f) AES_encrypt);
-            CRYPTO_gcm128_setiv(loopargs[i].gcm_ctx, (unsigned char *)"0123456789ab", 12);
+            loopargs[i].gcm_ctx =
+                CRYPTO_gcm128_new(&aes_ks1, (block128_f) AES_encrypt);
+            CRYPTO_gcm128_setiv(loopargs[i].gcm_ctx,
+                                (unsigned char *)"0123456789ab", 12);
         }
 
         for (testnum = 0; testnum < SIZE_NUM; testnum++) {
-            print_message(names[D_GHASH], c[D_GHASH][testnum], lengths[testnum]);
+            print_message(names[D_GHASH], c[D_GHASH][testnum],
+                          lengths[testnum]);
             Time_F(START);
             count = run_benchmark(async_jobs, CRYPTO_gcm128_aad_loop, loopargs);
             d = Time_F(STOP);
@@ -2088,7 +2102,6 @@ int speed_main(int argc, char **argv)
         for (i = 0; i < loopargs_len; i++)
             CRYPTO_gcm128_release(loopargs[i].gcm_ctx);
     }
-
 #ifndef OPENSSL_NO_CAMELLIA
     if (doit[D_CBC_128_CML]) {
         if (async_jobs > 0) {
@@ -2157,7 +2170,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_IDEA] = 0;
         }
         for (testnum = 0; testnum < SIZE_NUM && async_init == 0; testnum++) {
-            print_message(names[D_CBC_IDEA], c[D_CBC_IDEA][testnum], lengths[testnum]);
+            print_message(names[D_CBC_IDEA], c[D_CBC_IDEA][testnum],
+                          lengths[testnum]);
             Time_F(START);
             for (count = 0, run = 1; COND(c[D_CBC_IDEA][testnum]); count++)
                 IDEA_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
@@ -2176,7 +2190,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_SEED] = 0;
         }
         for (testnum = 0; testnum < SIZE_NUM && async_init == 0; testnum++) {
-            print_message(names[D_CBC_SEED], c[D_CBC_SEED][testnum], lengths[testnum]);
+            print_message(names[D_CBC_SEED], c[D_CBC_SEED][testnum],
+                          lengths[testnum]);
             Time_F(START);
             for (count = 0, run = 1; COND(c[D_CBC_SEED][testnum]); count++)
                 SEED_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
@@ -2194,7 +2209,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_RC2] = 0;
         }
         for (testnum = 0; testnum < SIZE_NUM && async_init == 0; testnum++) {
-            print_message(names[D_CBC_RC2], c[D_CBC_RC2][testnum], lengths[testnum]);
+            print_message(names[D_CBC_RC2], c[D_CBC_RC2][testnum],
+                          lengths[testnum]);
             if (async_jobs > 0) {
                 BIO_printf(bio_err, "Async mode is not supported, exiting...");
                 exit(1);
@@ -2217,7 +2233,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_RC5] = 0;
         }
         for (testnum = 0; testnum < SIZE_NUM && async_init == 0; testnum++) {
-            print_message(names[D_CBC_RC5], c[D_CBC_RC5][testnum], lengths[testnum]);
+            print_message(names[D_CBC_RC5], c[D_CBC_RC5][testnum],
+                          lengths[testnum]);
             if (async_jobs > 0) {
                 BIO_printf(bio_err, "Async mode is not supported, exiting...");
                 exit(1);
@@ -2240,7 +2257,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_BF] = 0;
         }
         for (testnum = 0; testnum < SIZE_NUM && async_init == 0; testnum++) {
-            print_message(names[D_CBC_BF], c[D_CBC_BF][testnum], lengths[testnum]);
+            print_message(names[D_CBC_BF], c[D_CBC_BF][testnum],
+                          lengths[testnum]);
             Time_F(START);
             for (count = 0, run = 1; COND(c[D_CBC_BF][testnum]); count++)
                 BF_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
@@ -2259,7 +2277,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_CAST] = 0;
         }
         for (testnum = 0; testnum < SIZE_NUM && async_init == 0; testnum++) {
-            print_message(names[D_CBC_CAST], c[D_CBC_CAST][testnum], lengths[testnum]);
+            print_message(names[D_CBC_CAST], c[D_CBC_CAST][testnum],
+                          lengths[testnum]);
             Time_F(START);
             for (count = 0, run = 1; COND(c[D_CBC_CAST][testnum]); count++)
                 CAST_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
@@ -2303,9 +2322,11 @@ int speed_main(int argc, char **argv)
                 for (k = 0; k < loopargs_len; k++) {
                     loopargs[k].ctx = EVP_CIPHER_CTX_new();
                     if (decrypt)
-                        EVP_DecryptInit_ex(loopargs[k].ctx, evp_cipher, NULL, key16, iv);
+                        EVP_DecryptInit_ex(loopargs[k].ctx, evp_cipher, NULL,
+                                           key16, iv);
                     else
-                        EVP_EncryptInit_ex(loopargs[k].ctx, evp_cipher, NULL, key16, iv);
+                        EVP_EncryptInit_ex(loopargs[k].ctx, evp_cipher, NULL,
+                                           key16, iv);
                     EVP_CIPHER_CTX_set_padding(loopargs[k].ctx, 0);
                 }
 
@@ -2348,7 +2369,8 @@ int speed_main(int argc, char **argv)
             rsa_count = 1;
         } else {
             pkey_print_message("private", "rsa",
-                               rsa_c[testnum][0], rsa_bits[testnum], RSA_SECONDS);
+                               rsa_c[testnum][0], rsa_bits[testnum],
+                               RSA_SECONDS);
             /* RSA_blinding_on(rsa_key[testnum],NULL); */
             Time_F(START);
             count = run_benchmark(async_jobs, RSA_sign_loop, loopargs);
@@ -2374,7 +2396,8 @@ int speed_main(int argc, char **argv)
             rsa_doit[testnum] = 0;
         } else {
             pkey_print_message("public", "rsa",
-                               rsa_c[testnum][1], rsa_bits[testnum], RSA_SECONDS);
+                               rsa_c[testnum][1], rsa_bits[testnum],
+                               RSA_SECONDS);
             Time_F(START);
             count = run_benchmark(async_jobs, RSA_verify_loop, loopargs);
             d = Time_F(STOP);
@@ -2420,7 +2443,8 @@ int speed_main(int argc, char **argv)
             rsa_count = 1;
         } else {
             pkey_print_message("sign", "dsa",
-                               dsa_c[testnum][0], dsa_bits[testnum], DSA_SECONDS);
+                               dsa_c[testnum][0], dsa_bits[testnum],
+                               DSA_SECONDS);
             Time_F(START);
             count = run_benchmark(async_jobs, DSA_sign_loop, loopargs);
             d = Time_F(STOP);
@@ -2445,7 +2469,8 @@ int speed_main(int argc, char **argv)
             dsa_doit[testnum] = 0;
         } else {
             pkey_print_message("verify", "dsa",
-                               dsa_c[testnum][1], dsa_bits[testnum], DSA_SECONDS);
+                               dsa_c[testnum][1], dsa_bits[testnum],
+                               DSA_SECONDS);
             Time_F(START);
             count = run_benchmark(async_jobs, DSA_verify_loop, loopargs);
             d = Time_F(STOP);
@@ -2474,7 +2499,8 @@ int speed_main(int argc, char **argv)
         if (!ecdsa_doit[testnum])
             continue;           /* Ignore Curve */
         for (i = 0; i < loopargs_len; i++) {
-            loopargs[i].ecdsa[testnum] = EC_KEY_new_by_curve_name(test_curves[testnum]);
+            loopargs[i].ecdsa[testnum] =
+                EC_KEY_new_by_curve_name(test_curves[testnum]);
             if (loopargs[i].ecdsa[testnum] == NULL) {
                 st = 0;
                 break;
@@ -2490,7 +2516,8 @@ int speed_main(int argc, char **argv)
                 /* Perform ECDSA signature test */
                 EC_KEY_generate_key(loopargs[i].ecdsa[testnum]);
                 st = ECDSA_sign(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                                &loopargs[i].siglen, loopargs[i].ecdsa[testnum]);
+                                &loopargs[i].siglen,
+                                loopargs[i].ecdsa[testnum]);
                 if (st == 0)
                     break;
             }
@@ -2518,7 +2545,8 @@ int speed_main(int argc, char **argv)
             /* Perform ECDSA verification test */
             for (i = 0; i < loopargs_len; i++) {
                 st = ECDSA_verify(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                                  loopargs[i].siglen, loopargs[i].ecdsa[testnum]);
+                                  loopargs[i].siglen,
+                                  loopargs[i].ecdsa[testnum]);
                 if (st != 1)
                     break;
             }
@@ -2569,15 +2597,16 @@ int speed_main(int argc, char **argv)
                 EVP_PKEY_CTX *pctx = NULL;
                 EVP_PKEY *params = NULL;
 
-                if (    /* Create the context for parameter generation */
-                        !(pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) ||
-                        /* Initialise the parameter generation */
-                        !EVP_PKEY_paramgen_init(pctx) ||
-                        /* Set the curve by NID */
-                        !EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, test_curves[testnum]) ||
-                        /* Create the parameter object params */
-                        !EVP_PKEY_paramgen(pctx, &params) ||
-                        0) {
+                if (            /* Create the context for parameter generation */
+                       !(pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) ||
+                       /* Initialise the parameter generation */
+                       !EVP_PKEY_paramgen_init(pctx) ||
+                       /* Set the curve by NID */
+                       !EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx,
+                                                               test_curves
+                                                               [testnum]) ||
+                       /* Create the parameter object params */
+                       !EVP_PKEY_paramgen(pctx, &params) || 0) {
                     ecdh_checks = 0;
                     BIO_printf(bio_err, "ECDH init failure.\n");
                     ERR_print_errors(bio_err);
@@ -2587,12 +2616,14 @@ int speed_main(int argc, char **argv)
                 /* Create the context for the key generation */
                 kctx = EVP_PKEY_CTX_new(params, NULL);
 
-                EVP_PKEY_free(params); params = NULL;
-                EVP_PKEY_CTX_free(pctx); pctx = NULL;
+                EVP_PKEY_free(params);
+                params = NULL;
+                EVP_PKEY_CTX_free(pctx);
+                pctx = NULL;
             }
-            if (    !kctx || /* keygen ctx is not null */
-                    !EVP_PKEY_keygen_init(kctx) || /* init keygen ctx */
-                    0) {
+            if (!kctx ||        /* keygen ctx is not null */
+                !EVP_PKEY_keygen_init(kctx) || /* init keygen ctx */
+                0) {
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH keygen failure.\n");
                 ERR_print_errors(bio_err);
@@ -2600,14 +2631,14 @@ int speed_main(int argc, char **argv)
                 break;
             }
 
-            if (    !EVP_PKEY_keygen(kctx, &key_A) || /* generate secret key A */
-                    !EVP_PKEY_keygen(kctx, &key_B) || /* generate secret key B */
-                    !(ctx = EVP_PKEY_CTX_new(key_A, NULL)) || /* derivation ctx from skeyA */
-                    !EVP_PKEY_derive_init(ctx) || /* init derivation ctx */
-                    !EVP_PKEY_derive_set_peer(ctx, key_B) || /* set peer pubkey in ctx */
-                    !EVP_PKEY_derive(ctx, NULL, &outlen) || /* determine max length */
-                    outlen > MAX_ECDH_SIZE || /* avoid buffer overflow */
-                    0) {
+            if (!EVP_PKEY_keygen(kctx, &key_A) || /* generate secret key A */
+                !EVP_PKEY_keygen(kctx, &key_B) || /* generate secret key B */
+                !(ctx = EVP_PKEY_CTX_new(key_A, NULL)) || /* derivation ctx from skeyA */
+                !EVP_PKEY_derive_init(ctx) || /* init derivation ctx */
+                !EVP_PKEY_derive_set_peer(ctx, key_B) || /* set peer pubkey in ctx */
+                !EVP_PKEY_derive(ctx, NULL, &outlen) || /* determine max length */
+                outlen > MAX_ECDH_SIZE || /* avoid buffer overflow */
+                0) {
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH key generation failure.\n");
                 ERR_print_errors(bio_err);
@@ -2618,19 +2649,21 @@ int speed_main(int argc, char **argv)
             loopargs[i].ecdh_ctx[testnum] = ctx;
             loopargs[i].outlen[testnum] = outlen;
 
-            EVP_PKEY_CTX_free(kctx); kctx = NULL;
+            EVP_PKEY_CTX_free(kctx);
+            kctx = NULL;
         }
         if (ecdh_checks != 0) {
             pkey_print_message("", "ecdh",
-                    ecdh_c[testnum][0],
-                    test_curves_bits[testnum], ECDH_SECONDS);
+                               ecdh_c[testnum][0],
+                               test_curves_bits[testnum], ECDH_SECONDS);
             Time_F(START);
-            count = run_benchmark(async_jobs, ECDH_EVP_derive_key_loop, loopargs);
+            count =
+                run_benchmark(async_jobs, ECDH_EVP_derive_key_loop, loopargs);
             d = Time_F(STOP);
             BIO_printf(bio_err,
-                    mr ? "+R7:%ld:%d:%.2f\n" :
-                    "%ld %d-bit ECDH ops in %.2fs\n", count,
-                    test_curves_bits[testnum], d);
+                       mr ? "+R7:%ld:%d:%.2f\n" :
+                       "%ld %d-bit ECDH ops in %.2fs\n", count,
+                       test_curves_bits[testnum], d);
             ecdh_results[testnum][0] = d / (double)count;
             rsa_count = count;
         }
@@ -2935,8 +2968,9 @@ static int do_multi(int multi)
             if (p)
                 *p = '\0';
             if (buf[0] != '+') {
-                BIO_printf(bio_err, "Don't understand line '%s' from child %d\n",
-                        buf, n);
+                BIO_printf(bio_err,
+                           "Don't understand line '%s' from child %d\n", buf,
+                           n);
                 continue;
             }
             printf("Got: %s from %d\n", buf, n);
@@ -3002,15 +3036,13 @@ static int do_multi(int multi)
 
                 d = atof(sstrsep(&p, sep));
                 if (n)
-                    ecdsa_results[k][0] =
-                        1 / (1 / ecdsa_results[k][0] + 1 / d);
+                    ecdsa_results[k][0] = 1 / (1 / ecdsa_results[k][0] + 1 / d);
                 else
                     ecdsa_results[k][0] = d;
 
                 d = atof(sstrsep(&p, sep));
                 if (n)
-                    ecdsa_results[k][1] =
-                        1 / (1 / ecdsa_results[k][1] + 1 / d);
+                    ecdsa_results[k][1] = 1 / (1 / ecdsa_results[k][1] + 1 / d);
                 else
                     ecdsa_results[k][1] = d;
             } else if (strncmp(buf, "+F5:", 4) == 0) {
@@ -3033,7 +3065,8 @@ static int do_multi(int multi)
             else if (strncmp(buf, "+H:", 3) == 0) {
                 ;
             } else
-                BIO_printf(bio_err, "Unknown type '%s' from child %d\n", buf, n);
+                BIO_printf(bio_err, "Unknown type '%s' from child %d\n", buf,
+                           n);
         }
 
         fclose(f);
@@ -3057,8 +3090,7 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher)
     out = app_malloc(mblengths[num - 1] + 1024, "multiblock output buffer");
     ctx = EVP_CIPHER_CTX_new();
     EVP_EncryptInit_ex(ctx, evp_cipher, NULL, no_key, no_iv);
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_MAC_KEY, sizeof(no_key),
-                        no_key);
+    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_MAC_KEY, sizeof(no_key), no_key);
     alg_name = OBJ_nid2ln(EVP_CIPHER_nid(evp_cipher));
 
     for (j = 0; j < num; j++) {


### PR DESCRIPTION
Noticed [this thread in the openssl-dev ML](https://mta.openssl.org/pipermail/openssl-dev/2016-October/008582.html).

I was already working on option number 3 for a side project where I had the need to compare benchmarks of ECDH with different curves, including X25519, so here is a pull request to start from if we want to revise which interface to use to access EC crypto in apps/speed.

This commit only affects ECDH benchmarking, ECDSA still uses the low-level API. 
