### PR TITLE
Add DTLS_get_data_mtu()

### DIFF
--- a/doc/man3/DTLS_get_data_mtu.pod
+++ b/doc/man3/DTLS_get_data_mtu.pod
@@ -1,0 +1,36 @@
+=pod
+
+=head1 NAME
+
+DTLS_get_data_mtu - Get maximum data payload size
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ size_t DTLS_get_data_mtu(const SSL *ssl);
+
+=head1 DESCRIPTION
+
+This function obtains the maximum data payload size for the established
+DTLS connection B<ssl>, based on the DTLS record MTU and the overhead
+of the DTLS record header, encryption and authentication currently in use.
+
+=head1 RETURN VALUES
+
+Returns the maximum data payload size on success, or 0 on failure.
+
+=head1 HISTORY
+
+This function was added in OpenSSL 1.1.1
+
+=head1 COPYRIGHT
+
+Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1628,6 +1628,8 @@ __owur const SSL_METHOD *DTLS_method(void); /* DTLS 1.0 and 1.2 */
 __owur const SSL_METHOD *DTLS_server_method(void); /* DTLS 1.0 and 1.2 */
 __owur const SSL_METHOD *DTLS_client_method(void); /* DTLS 1.0 and 1.2 */
 
+__owur size_t DTLS_get_data_mtu(const SSL *s);
+
 __owur STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *s);
 __owur STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx);
 __owur STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *s);

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -1088,3 +1088,39 @@ unsigned int dtls1_min_mtu(SSL *s)
 {
     return dtls1_link_min_mtu() - BIO_dgram_get_mtu_overhead(SSL_get_wbio(s));
 }
+
+size_t DTLS_get_data_mtu(const SSL *s)
+{
+    size_t mac_overhead, int_overhead, blocksize, ext_overhead;
+    const SSL_CIPHER *ciph = SSL_get_current_cipher(s);
+    size_t mtu = s->d1->mtu;
+
+    if (ciph == NULL)
+        return 0;
+
+    if (!ssl_cipher_get_overhead(ciph, &mac_overhead, &int_overhead,
+                                 &blocksize, &ext_overhead))
+        return 0;
+
+    if (SSL_USE_ETM(s))
+        ext_overhead += mac_overhead;
+    else
+        int_overhead += mac_overhead;
+
+    /* Subtract external overhead (e.g. IV/nonce, separate MAC) */
+    if (ext_overhead + DTLS1_RT_HEADER_LENGTH >= mtu)
+        return 0;
+    mtu -= ext_overhead + DTLS1_RT_HEADER_LENGTH;
+
+    /* Round encrypted payload down to cipher block size (for CBC etc.)
+     * No check for overflow since 'mtu % blocksize' cannot exceed mtu. */
+    if (blocksize)
+        mtu -= (mtu % blocksize);
+
+    /* Subtract internal overhead (e.g. CBC padding len byte) */
+    if (int_overhead >= mtu)
+        return 0;
+    mtu -= int_overhead;
+
+    return mtu;
+}

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1813,6 +1813,9 @@ __owur int ssl_cipher_get_evp(const SSL_SESSION *s, const EVP_CIPHER **enc,
                               const EVP_MD **md, int *mac_pkey_type,
                               int *mac_secret_size, SSL_COMP **comp,
                               int use_etm);
+__owur int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
+                                   size_t *int_overhead, size_t *blocksize,
+                                   size_t *ext_overhead);
 __owur int ssl_cipher_get_cert_index(const SSL_CIPHER *c);
 __owur const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl,
                                                 const unsigned char *ptr);

--- a/test/build.info
+++ b/test/build.info
@@ -276,10 +276,14 @@ IF[{- !$disabled{tests} -}]
   DEPEND[bio_enc_test]=../libcrypto
 
   IF[{- $disabled{shared} -}]
-    PROGRAMS_NO_INST=wpackettest
+    PROGRAMS_NO_INST=wpackettest cipher_overhead_test
     SOURCE[wpackettest]=wpackettest.c testutil.c
     INCLUDE[wpackettest]=../include
     DEPEND[wpackettest]=../libcrypto ../libssl
+
+    SOURCE[cipher_overhead_test]=cipher_overhead_test.c
+    INCLUDE[cipher_overhead_test]=.. ../include
+    DEPEND[cipher_overhead_test]=../libcrypto ../libssl
   ENDIF
 ENDIF
 

--- a/test/build.info
+++ b/test/build.info
@@ -275,6 +275,13 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[bio_enc_test]=../include
   DEPEND[bio_enc_test]=../libcrypto
 
+  IF[{- !$disabled{psk} -}]
+    PROGRAMS_NO_INST=dtls_mtu_test
+    SOURCE[dtls_mtu_test]=dtls_mtu_test.c ssltestlib.c
+    INCLUDE[dtls_mtu_test]=.. ../include
+    DEPEND[dtls_mtu_test]=../libcrypto ../libssl
+  ENDIF
+
   IF[{- $disabled{shared} -}]
     PROGRAMS_NO_INST=wpackettest cipher_overhead_test
     SOURCE[wpackettest]=wpackettest.c testutil.c

--- a/test/cipher_overhead_test.c
+++ b/test/cipher_overhead_test.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+
+#include "../ssl/ssl_locl.h"
+
+int main(void)
+{
+    int i, n = ssl3_num_ciphers();
+    const SSL_CIPHER *ciph;
+    size_t mac, in, blk, ex;
+
+    for (i = 0; i < n; i++) {
+        ciph = ssl3_get_cipher(i);
+        if (!ciph->min_dtls)
+            continue;
+        if (!ssl_cipher_get_overhead(ciph, &mac, &in, &blk, &ex)) {
+            printf("Error getting overhead for %s\n", ciph->name);
+            exit(1);
+        } else {
+            printf("Cipher %s: %"OSSLzu" %"OSSLzu" %"OSSLzu" %"OSSLzu"\n",
+                   ciph->name, mac, in, blk, ex);
+        }
+    }
+    exit(0);
+}

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/dtls1.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#include "ssltestlib.h"
+
+/* for SSL_USE_ETM() */
+#include "../ssl/ssl_locl.h"
+
+static int debug = 0;
+
+static unsigned int clnt_psk_callback(SSL *ssl, const char *hint,
+                                      char *ident, unsigned int max_ident_len,
+                                      unsigned char *psk,
+                                      unsigned int max_psk_len)
+{
+    snprintf(ident, max_ident_len, "psk");
+
+    if (max_psk_len > 20)
+        max_psk_len = 20;
+    memset(psk, 0x5a, max_psk_len);
+
+    return max_psk_len;
+}
+
+static unsigned int srvr_psk_callback(SSL *ssl, const char *identity,
+                                      unsigned char *psk,
+                                      unsigned int max_psk_len)
+{
+    if (max_psk_len > 20)
+        max_psk_len = 20;
+    memset(psk, 0x5a, max_psk_len);
+    return max_psk_len;
+}
+
+static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
+{
+    SSL *srvr_ssl = NULL, *clnt_ssl = NULL;
+    BIO *sc_bio = NULL;
+    int i;
+    size_t s;
+    size_t mtus[30];
+    unsigned char buf[600];
+    int rv = 0;
+
+    memset(buf, 0x5a, sizeof(buf));
+
+    if (create_ssl_objects(ctx, ctx, &srvr_ssl, &clnt_ssl, NULL, NULL) != 1)
+        goto out;
+
+    if (no_etm)
+        SSL_set_options(srvr_ssl, SSL_OP_NO_ENCRYPT_THEN_MAC);
+
+    if (SSL_set_cipher_list(srvr_ssl, cs) != 1 ||
+        SSL_set_cipher_list(clnt_ssl, cs) != 1) {
+        ERR_print_errors_fp(stdout);
+        goto out;
+    }
+    sc_bio = SSL_get_rbio(srvr_ssl);
+
+    if (create_ssl_connection(clnt_ssl, srvr_ssl) != 1)
+        goto out;
+
+    if (debug)
+        printf("Channel established\n");
+
+    /* For record MTU values between 500 and 539, call DTLS_get_data_mtu()
+     * to query the payload MTU which will fit. */
+    for (i = 0; i < 30; i++) {
+        SSL_set_mtu(clnt_ssl, 500 + i);
+        mtus[i] = DTLS_get_data_mtu(clnt_ssl);
+        if (debug)
+            printf("%s%s payload MTU for record mtu %d = %"OSSLzu"\n",
+                   cs, no_etm ? "-noEtM":"", 500 + i, mtus[i]);
+        if (mtus[i] == 0) {
+            fprintf(stderr,
+                    "payload MTU failed with record MTU %d for %s\n",
+                    500 + i, cs);
+            goto out;
+        }
+    }
+
+    /* Now get out of the way */
+    SSL_set_mtu(clnt_ssl, 1000);
+
+    /* Now for all values in the range of payload MTUs, send
+     * a payload of that size and see what actual record size
+     * we end up with. */
+    for (s = mtus[0]; s <= mtus[29]; s++) {
+        size_t reclen;
+        if (SSL_write(clnt_ssl, buf, s) != (int)s) {
+            ERR_print_errors_fp(stdout);
+            goto out;
+        }
+        reclen = BIO_read(sc_bio, buf, sizeof(buf));
+        if (debug)
+            printf("record %"OSSLzu" for payload %"OSSLzu"\n", reclen, s);
+
+        for (i = 0; i < 30; i++) {
+            /* DTLS_get_data_mtu() with record MTU 500+i returned mtus[i] ... */
+
+            if (s <= mtus[i] && reclen > (size_t)(500 + i)) {
+                /* We sent a packet smaller than or equal to mtus[j] and
+                 * that made a record *larger* than the record MTU 500+j! */
+                fprintf(stderr,
+                        "%s: Payload MTU %"OSSLzu" reported for record MTU %d\n"
+                        "but sending a payload of %"OSSLzu" made a record of %"OSSLzu"(too large)\n",
+                        cs, mtus[i], 500 + i, s, reclen);
+                goto out;
+            }
+            if (s > mtus[i] && reclen <= (size_t)(500 + i)) {
+                /* We sent a *larger* packet than mtus[i] and that *still*
+                 * fits within the record MTU 500+i, so DTLS_get_data_mtu()
+                 * was overly pessimistic. */
+                fprintf(stderr,
+                        "%s: Payload MTU %"OSSLzu" reported for record MTU %d\n"
+                        "but sending a payload of %"OSSLzu" made a record of %"OSSLzu" (too small)\n",
+                        cs, mtus[i], 500 + i, s, reclen);
+                goto out;
+            }
+        }
+    }
+    rv = 1;
+    if (SSL_USE_ETM(clnt_ssl))
+        rv = 2;
+ out:
+    SSL_free(clnt_ssl);
+    SSL_free(srvr_ssl);
+    return rv;
+}
+
+int main(void)
+{
+    SSL_CTX *ctx = SSL_CTX_new(DTLS_method());
+    STACK_OF(SSL_CIPHER) *ciphers;
+    int i, rv = 0;
+
+    SSL_CTX_set_psk_server_callback(ctx, srvr_psk_callback);
+    SSL_CTX_set_psk_client_callback(ctx, clnt_psk_callback);
+    SSL_CTX_set_security_level(ctx, 0);
+
+    /* We only care about iterating over each enc/mac; we don't
+     * want to repeat the test for each auth/kx variant.
+     * So keep life simple and only do (non-DH) PSK. */
+    if (!SSL_CTX_set_cipher_list(ctx, "PSK")) {
+        fprintf(stderr, "Failed to set PSK cipher list\n");
+        goto out;
+    }
+
+    ciphers = SSL_CTX_get_ciphers(ctx);
+    for (i = 0; i < sk_SSL_CIPHER_num(ciphers); i++) {
+        const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
+        const char *cipher_name = SSL_CIPHER_get_name(cipher);
+
+        /* As noted above, only one test for each enc/mac variant. */
+        if (strncmp(cipher_name, "PSK-", 4))
+            continue;
+
+        rv = mtu_test(ctx, cipher_name, 0);
+        if (!rv)
+            break;
+
+        printf("DTLS MTU test OK for %s\n", cipher_name);
+        if (rv == 1)
+            continue;
+
+        /* mtu_test() returns 2 if it used Encrypt-then-MAC */
+        rv = mtu_test(ctx, cipher_name, 1);
+        if (!rv)
+            break;
+
+        printf("DTLS MTU test OK for %s without Encrypt-then-MAC\n", cipher_name);
+    }
+ out:
+    SSL_CTX_free(ctx);
+
+    return !rv;
+}

--- a/test/recipes/80-test_dtls_mtu.t
+++ b/test/recipes/80-test_dtls_mtu.t
@@ -1,0 +1,21 @@
+#! /usr/bin/env perl
+# Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+my $test_name = "test_dtls_mtu";
+setup($test_name);
+
+plan skip_all => "$test_name needs DTLS and PSK support enabled"
+    if disabled("dtls1_2") || disabled("psk");
+
+plan tests => 1;
+
+ok(run(test(["dtls_mtu_test"])), "running dtls_mtu_test");

--- a/test/recipes/90-test_overhead.t
+++ b/test/recipes/90-test_overhead.t
@@ -1,0 +1,20 @@
+#! /usr/bin/env perl
+# Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_overhead");
+
+plan skip_all => "Only supported in no-shared builds"
+    if !disabled("shared");
+
+plan tests => 1;
+
+ok(run(test(["cipher_overhead_test"])), "running cipher_overhead_test");

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -403,3 +403,4 @@ SSL_dane_clear_flags                    403	1_1_0	EXIST::FUNCTION:
 SSL_SESSION_get0_cipher                 404	1_1_0	EXIST::FUNCTION:
 SSL_SESSION_get0_id_context             405	1_1_0	EXIST::FUNCTION:
 SSL_SESSION_set1_id                     406	1_1_0	EXIST::FUNCTION:
+DTLS_get_data_mtu                       407	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Best case, this is all relatively sane and I just need some help finishing `SSL_CIPHER_get_overhead()` for non-AEAD, non-CBC modes, and perhaps actually report errors instead of just returning zero if something goes wrong.

The idea is that `SSL_CIPHER_get_overhead()` really does just describe the cipher, in isolation — which requires three values: the external overhead, the block size that it's rounded up to, and the internal overhead before that rounding.

Then we have `DTLS_get_data_mtu()` which actually does that, as well as subtracting  `DTLS1_RT_HEADER_LENGTH`, from `s->d1->mtu`.
