### PR TITLE
Travis: Use 2 cores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ script:
           top=.;
       fi
     - $make update
-    - $make
+    - $make -j2
     - if [ -z "$BUILDONLY" ]; then
           if [ -n "$CROSS_COMPILE" ]; then
               export EXE_SHELL="wine" WINEPREFIX=`pwd`;


### PR DESCRIPTION
According to the documentation, we have 2 cores. It seems to be non-obvious how
to detect this at runtime in the container, so use a fixed value.