### PR TITLE
bn: fix BN_DEBUG + BN_DEBUG_RAND support

### DIFF
--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -146,13 +146,10 @@ extern "C" {
 
 # ifdef BN_DEBUG
 
-/* We only need assert() when debugging */
-#  include <assert.h>
-
 #  ifdef BN_DEBUG_RAND
 /* To avoid "make update" cvs wars due to BN_DEBUG, use some tricks */
-#   ifndef RAND_pseudo_bytes
-int RAND_pseudo_bytes(unsigned char *buf, int num);
+#   ifndef RAND_bytes
+int RAND_bytes(unsigned char *buf, int num);
 #    define BN_DEBUG_TRIX
 #   endif
 #   define bn_pollute(a) \
@@ -171,7 +168,7 @@ int RAND_pseudo_bytes(unsigned char *buf, int num);
             } \
         } while(0)
 #   ifdef BN_DEBUG_TRIX
-#    undef RAND_pseudo_bytes
+#    undef RAND_bytes
 #   endif
 #  else
 #   define bn_pollute(a)
@@ -180,7 +177,7 @@ int RAND_pseudo_bytes(unsigned char *buf, int num);
         do { \
                 const BIGNUM *_bnum2 = (a); \
                 if (_bnum2 != NULL) { \
-                        assert((_bnum2->top == 0) || \
+                        OPENSSL_assert((_bnum2->top == 0) || \
                                 (_bnum2->d[_bnum2->top - 1] != 0)); \
                         bn_pollute(_bnum2); \
                 } \
@@ -192,7 +189,8 @@ int RAND_pseudo_bytes(unsigned char *buf, int num);
 #  define bn_wcheck_size(bn, words) \
         do { \
                 const BIGNUM *_bnum2 = (bn); \
-                assert((words) <= (_bnum2)->dmax && (words) >= (_bnum2)->top); \
+                OPENSSL_assert((words) <= (_bnum2)->dmax && \
+                        (words) >= (_bnum2)->top); \
                 /* avoid unused variable warning with NDEBUG */ \
                 (void)(_bnum2); \
         } while(0)


### PR DESCRIPTION
Couple of updates to make this code work properly again;
- use OPENSSL_assert() instead of assert() (and #include <assert.h>)
- the circular-dependency-avoidance uses RAND_bytes() (not pseudo)

Change-Id: Iefb5a9dd73f71fd81c1268495c54a64378955354
Signed-off-by: Geoff Thorpe geoff@openssl.org
