### PR TITLE
Degrade 3DES to MEDIUM in SSL2

### DIFF
--- a/ssl/s2_lib.c
+++ b/ssl/s2_lib.c
@@ -254,7 +254,7 @@ OPENSSL_GLOBAL const SSL_CIPHER ssl2_ciphers[] = {
      SSL_3DES,
      SSL_MD5,
      SSL_SSLV2,
-     SSL_NOT_DEFAULT | SSL_NOT_EXP | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_NOT_EXP | SSL_MEDIUM,
      0,
      112,
      168,


### PR DESCRIPTION
The SWEET32 fix moved 3DES from HIGH to MEDIUM, but omitted SSL2.