### PR TITLE
Make OpenSSL::Test a bit more flexible

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ build_script:
 
 test_script:
     - cd _build
-    - nmake test
+    - nmake test V=1
     - cd ..
 
 # Fake deploy script to test installation

--- a/test/testlib/OpenSSL/Test.pm
+++ b/test/testlib/OpenSSL/Test.pm
@@ -94,21 +94,6 @@ my %hooks = (
 # Debug flag, to be set manually when needed
 my $debug = 0;
 
-# Declare some utility functions that are defined at the end
-sub bldtop_file;
-sub bldtop_dir;
-sub srctop_file;
-sub srctop_dir;
-sub quotify;
-
-# Declare some private functions that are defined at the end
-sub __env;
-sub __cwd;
-sub __apps_file;
-sub __results_file;
-sub __fixup_cmd;
-sub __build_cmd;
-
 =head2 Main functions
 
 The following functions are exported by default when using C<OpenSSL::Test>.

--- a/test/testlib/OpenSSL/Test.pm
+++ b/test/testlib/OpenSSL/Test.pm
@@ -301,68 +301,76 @@ calculated before we moved into the directory "foo".
 sub cmd {
     my $cmd = shift;
     my %opts = @_;
-    return sub { my $num = shift;
-                 # Make a copy to not destroy the caller's array
-                 my @cmdargs = ( @$cmd );
-                 my @prog = __wrap_cmd(shift @cmdargs,
-                                       $opts{exe_shell} // ());
+    return sub {
+        my $num = shift;
+        # Make a copy to not destroy the caller's array
+        my @cmdargs = ( @$cmd );
+        my @prog = __wrap_cmd(shift @cmdargs, $opts{exe_shell} // ());
 
-                 return __decorate_cmd($num, [ @prog, quotify(@cmdargs) ],
-                                       %opts); }
+        return __decorate_cmd($num, [ @prog, quotify(@cmdargs) ],
+                              %opts);
+    }
 }
 
 sub app {
     my $cmd = shift;
     my %opts = @_;
-    return sub { my @cmdargs = ( @{$cmd} );
-                 my @prog = __fixup_prg(__apps_file(shift @cmdargs,
-                                                    __exeext()));
-                 return cmd([ @prog, @cmdargs ],
-                            exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift); }
+    return sub {
+        my @cmdargs = ( @{$cmd} );
+        my @prog = __fixup_prg(__apps_file(shift @cmdargs, __exeext()));
+        return cmd([ @prog, @cmdargs ],
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+    }
 }
 
 sub fuzz {
     my $cmd = shift;
     my %opts = @_;
-    return sub { my @cmdargs = ( @{$cmd} );
-                 my @prog = __fixup_prg(__fuzz_file(shift @cmdargs,
-                                                    __exeext()));
-                 return cmd([ @prog, @cmdargs ],
-                            exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift); }
+    return sub {
+        my @cmdargs = ( @{$cmd} );
+        my @prog = __fixup_prg(__fuzz_file(shift @cmdargs, __exeext()));
+        return cmd([ @prog, @cmdargs ],
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+    }
 }
 
 sub test {
     my $cmd = shift;
     my %opts = @_;
-    return sub { my @cmdargs = ( @{$cmd} );
-                 my @prog = __fixup_prg(__test_file(shift @cmdargs,
-                                                    __exeext()));
-                 return cmd([ @prog, @cmdargs ],
-                            exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift); }
+    return sub {
+        my @cmdargs = ( @{$cmd} );
+        my @prog = __fixup_prg(__test_file(shift @cmdargs, __exeext()));
+        return cmd([ @prog, @cmdargs ],
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+    }
 }
 
 sub perlapp {
     my $cmd = shift;
     my %opts = @_;
-    return sub { my @interpreter_args = defined $opts{interpreter_args} ?
-                     @{$opts{interpreter_args}} : ();
-                 my @interpreter = __fixup_prg($^X);
-                 my @cmdargs = ( @{$cmd} );
-                 my @prog = __apps_file(shift @cmdargs, undef);
-                 return cmd([ @interpreter, @interpreter_args,
-                              @prog, @cmdargs ], %opts) -> (shift); }
+    return sub {
+        my @interpreter_args = defined $opts{interpreter_args} ?
+            @{$opts{interpreter_args}} : ();
+        my @interpreter = __fixup_prg($^X);
+        my @cmdargs = ( @{$cmd} );
+        my @prog = __apps_file(shift @cmdargs, undef);
+        return cmd([ @interpreter, @interpreter_args,
+                     @prog, @cmdargs ], %opts) -> (shift);
+    }
 }
 
 sub perltest {
     my $cmd = shift;
     my %opts = @_;
-    return sub { my @interpreter_args = defined $opts{interpreter_args} ?
-                     @{$opts{interpreter_args}} : ();
-                 my @interpreter = __fixup_prg($^X);
-                 my @cmdargs = ( @{$cmd} );
-                 my @prog = __test_file(shift @cmdargs, undef);
-                 return cmd([ @interpreter, @interpreter_args,
-                              @prog, @cmdargs ], %opts) -> (shift); }
+    return sub {
+        my @interpreter_args = defined $opts{interpreter_args} ?
+            @{$opts{interpreter_args}} : ();
+        my @interpreter = __fixup_prg($^X);
+        my @cmdargs = ( @{$cmd} );
+        my @prog = __test_file(shift @cmdargs, undef);
+        return cmd([ @interpreter, @interpreter_args,
+                     @prog, @cmdargs ], %opts) -> (shift);
+    }
 }
 
 =over 4

--- a/test/testlib/OpenSSL/Test.pm
+++ b/test/testlib/OpenSSL/Test.pm
@@ -1008,14 +1008,9 @@ sub __fixup_prg {
 	$prefix = ($prog =~ /^(?:[\$a-z0-9_]+:)?[<\[]/i ? "mcr " : "mcr []");
     }
 
-    # We test both with and without extension.  The reason
-    # is that we might be passed a complete file spec, with
-    # extension.
+    # We test if the program to use exists.
     if ( ! -x $prog ) {
-	my $prog = "$prog";
-	if ( ! -x $prog ) {
-	    $prog = undef;
-	}
+	$prog = undef;
     }
 
     if (defined($prog)) {


### PR DESCRIPTION
So far, apps and test programs, were a bit rigidely accessible as
executables or perl scripts.  But what about scripts in some other
language?  The answer is certainly not to add new functions to access
scripts for each language!

Instead, this adds two functions, executable() and script(), which are
useful to access executables and scripts in a more generalised manner.
app(), test(), fuzz(), perlapp() and perltest() are rewritten in terms
of executable() or script(), and serve as examples how to do something
similar for other scripting languages, or constrain the programs to
certain directories.

---

This is one answer to the request for help in #1682
