### PR TITLE
Make sure to set DT_RUNPATH rather than DT_RPATH with the GNU toolchain

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1015,7 +1015,7 @@ $target: $lib$libext $deps $ordinalsfile
 		LIBNAME=$libname LIBVERSION=\$(SHLIB_MAJOR).\$(SHLIB_MINOR) \\
 		LIBCOMPATVERSIONS=';\$(SHLIB_VERSION_HISTORY)' \\
 		CC='\$(CC)' CFLAGS='\$(CFLAGS) \$(LIB_CFLAGS)' \\
-		LDFLAGS='\$(LDFLAGS)' \\
+		LDFLAGS='\$(LDFLAGS)' LIBRPATH='\$(INSTALLTOP)/\$(LIBDIR)' \\
 		SHARED_LDFLAGS='\$(LIB_LDFLAGS)' SHLIB_EXT=$shlibext \\
 		RC='\$(RC)' SHARED_RCFLAGS='\$(RCFLAGS)' \\
 		link_shlib.$shlib_target

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -186,7 +186,7 @@ LIB_LDFLAGS={- $target{shared_ldflag}." ".$config{shared_ldflag}
                # be cautious and pass -rpath to linker only when
                # $prefix is not /usr.
                . ($config{target} =~ m|^BSD-| && $prefix !~ m|^/usr/.*$|
-                  ? " -Wl,-rpath,\$\$(LIBRPATH)" : "") -}
+                  ? " -Wl,--enable-new-dtags,-rpath,\$\$(LIBRPATH)" : "") -}
 DSO_CFLAGS={- $target{shared_cflag} || "" -}
 DSO_LDFLAGS=$(LIB_LDFLAGS)
 BIN_CFLAGS={- $target{bin_cflags} -}

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -220,7 +220,7 @@ link_shlib.bsd:
 	fi; $(LINK_SO_SHLIB)
 link_app.bsd:
 	@if $(DETECT_GNU_LD); then $(DO_GNU_APP); else \
-	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,-rpath,$(LIBPATH)"; \
+	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,--enable-new-dtags,-rpath,$(LIBPATH)"; \
 	fi; $(LINK_APP)
 
 # For Darwin AKA Mac OS/X (dyld)

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -176,7 +176,7 @@ DO_GNU_SO=\
 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
 	$(DO_GNU_SO_COMMON)
-DO_GNU_APP=LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,-rpath,$(LIBRPATH)"
+DO_GNU_APP=LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,--enable-new-dtags,-rpath,$(LIBRPATH)"
 
 #This is rather special.  It's a special target with which one can link
 #applications without bothering with any features that have anything to


### PR DESCRIPTION
With the GNU toolchain, directories set with -rpath are searched
before LD_LIBRARY_PATH is considered.  If you're building OpenSSL
1.1.1-dev with a prefix where OpenSSL 1.1.0 is already installed, you
get into trouble no matter what you set LD_LIBRARY_PATH.  That can be
fixed by using LD_PRELOAD, but that comes with its own problems.

A better way is to tell the linker to store the -rpath directories
with DT_RUNPATH tags rather than DT_RPATH ones.  DT_RUNPATH
directories are considered after LD_LIBRARY_PATH.

Other platforms that use ELF may have the same issue.

---

Fixes #1635 
