### PR TITLE
WIP: Enable control of atexit()

### DIFF
--- a/Configure
+++ b/Configure
@@ -327,6 +327,7 @@ my @disablables = (
     "asan",
     "asm",
     "async",
+    "atexit-control",
     "autoalginit",
     "autoerrinit",
     "bf",
@@ -422,6 +423,7 @@ my %deprecated_disablables = (
 
 our %disabled = ( # "what"         => "comment"
                   "asan"		=> "default",
+		  "atexit-control"	=> "default",
 		  "crypto-mdebug"       => "default",
 		  "crypto-mdebug-backtrace" => "default",
 		  "ec_nistp_64_gcc_128" => "default",

--- a/INSTALL
+++ b/INSTALL
@@ -223,6 +223,17 @@
                    Do not use assembler code. On some platforms a small amount
                    of assembler code may still be used.
 
+  enable-atexit-control
+                   By default OpenSSL will clean itself up via an atexit()
+                   handler. Most platforms will call the atexit() handler on
+                   dlclose() if OpenSSL has been dynamically loaded at runtime.
+                   However, some platforms only attempt to call the atexit()
+                   handler on process termination which may cause crashes if
+                   OpenSSL has been dynamically loaded. This option enables the
+                   ability to switch off the atexit() handler - see the
+                   OPENSSL_init_crypto() man page. It should *only* be used on
+                   platforms that do not call atexit() handlers on dlclose().
+
   no-async
                    Do not build support for async operations.
 

--- a/doc/crypto/OPENSSL_init_crypto.pod
+++ b/doc/crypto/OPENSSL_init_crypto.pod
@@ -12,6 +12,7 @@ initialisation and deinitialisation functions
  #include <openssl/crypto.h>
 
  void OPENSSL_cleanup(void);
+ void OPENSSL_cond_cleanup(void);
  int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
  int OPENSSL_atexit(void (*handler)(void));
  void OPENSSL_thread_stop(void);
@@ -150,6 +151,17 @@ With this option the library will automatically load and initialise all the
 built in engines listed above with the exception of the openssl and dasync
 engines. This not a default option.
 
+=item OPENSSL_INIT_NO_ATEXIT
+
+By default OpenSSL will clean itself up via an atexit() handler. Most platforms
+will call the atexit() handler on dlclose() if OpenSSL has been dynamically
+loaded at runtime. However, some less common platforms only attempt to call the
+atexit() handler on process termination which may cause crashes if OpenSSL has
+been dynamically loaded. This option switches off the atexit() handler. It only
+has an effect if OpenSSL has been built using the "enable-atexit-control" option
+(which is off by default) - otherwise it is ignored. If this is used then
+OpenSSL must be cleaned up manually (see OPENSSL_cond_cleanup() below).
+
 =back
 
 Multiple options may be combined together in a single call to
@@ -169,6 +181,13 @@ are discouraged from calling this function and should instead, typically, rely
 on auto-deinitialisation. This is to avoid error conditions where both an
 application and a library it depends on both use OpenSSL, and the library
 deinitialises it before the application has finished using it.
+
+If the OPENSSL_INIT_NO_ATEXIT option has been used then OPENSSL_cond_cleanup()
+should be called when OpenSSL is no longer needed. This has the effect of
+conditionally calling OPENSSL_cleanup() if and only if the library has been
+built with the "enable-atexit-control" option. Care should be taken to avoid
+cleaning up OpenSSL if other libraries or the main application may still be
+using it.
 
 Once OPENSSL_cleanup() has been called the library cannot be reinitialised.
 Attempts to call OPENSSL_init_crypto() will fail and an ERR_R_INIT_FAIL error

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -368,6 +368,7 @@ int CRYPTO_memcmp(const volatile void * volatile in_a,
 # define OPENSSL_INIT_ENGINE_PADLOCK         0x00004000L
 # define OPENSSL_INIT_ENGINE_AFALG           0x00008000L
 /* OPENSSL_INIT flag 0x00010000 reserved for internal use */
+# define OPENSSL_INIT_NO_ATEXIT              0x00020000L
 /* OPENSSL_INIT flag range 0xfff00000 reserved for OPENSSL_init_ssl() */
 /* Max OPENSSL_INIT flag value is 0x80000000 */
 
@@ -379,6 +380,7 @@ int CRYPTO_memcmp(const volatile void * volatile in_a,
 
 
 /* Library initialisation functions */
+void OPENSSL_cond_cleanup(void);
 void OPENSSL_cleanup(void);
 int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
 int OPENSSL_atexit(void (*handler)(void));

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4208,3 +4208,4 @@ OCSP_RESPID_set_by_key                  4158	1_1_0a	EXIST::FUNCTION:OCSP
 OCSP_RESPID_match                       4159	1_1_0a	EXIST::FUNCTION:OCSP
 ASN1_ITEM_lookup                        4160	1_1_1	EXIST::FUNCTION:
 ASN1_ITEM_get                           4161	1_1_1	EXIST::FUNCTION:
+OPENSSL_cond_cleanup                    4162	1_1_0a	EXIST::FUNCTION:


### PR DESCRIPTION
By default OpenSSL will clean itself up via an atexit() handler. Most platforms will call the atexit() handler on dlclose() if OpenSSL has been dynamically loaded at runtime. However, some platforms only attempt to call the atexit() handler on process termination which may cause crashes if OpenSSL has been dynamically loaded. This option enables the ability to switch off the atexit() handler - see the OPENSSL_init_crypto() man page.  It should *only* be used on platforms that do not call atexit() handlers on dlclose().
    
This commit also adds the option OPENSSL_INIT_NO_ATEXIT to switch off the  atexit() handler at run time. It only has an effect if built with enable-atexit-control.
    
It also implements OPENSSL_cond_cleanup() which conditionally calls OPENSSL_cleanup() only if OpenSSL has been built with enable-atexit-control.
    
Finally this commit fixes an atexit() issue on Windows. The Windows implementation of atexit() does not get called on FreeLibrary() (the equivalent of dlclose()). However the MS function _onexit() does. Therefore we use that instead. This means that use of enable-atexit-control should not be necessary on Windows platforms.

This address the issue described here:
https://github.com/curl/curl/issues/1055

There is also a mkdef.pl commit in this MR. It's included here only because it is necessary to get this to build. We were sanity checking that the symbols in *.num were always in version number order. However it is actually valid for this not to be the case where we are adding symbols for backport to a previous version.

I have marked this as WIP because there is no test for this yet. Also, I wanted to get feedback on the approach as its a fairly significant change. This is intended for backport to 1.1.0, even though it does add new functions/option (because it addresses a bug).