### PR TITLE
Remove automatic RPATH

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,12 @@
      https://www.akkadia.org/drepper/SHA-crypt.txt
      [Richard Levitte]
 
+ Changes between 1.1.0b and 1.1.0c [xx XXX xxxx]
+
+  *) Removed automatic addition of RPATH in shared libraries and executables,
+     as this was a remainder from OpenSSL 1.0.x and isn't needed any more.
+     [Richard Levitte]
+
  Changes between 1.1.0a and 1.1.0b [26 Sep 2016]
 
   *) Fix Use After Free for large message sizes

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -176,20 +176,7 @@ PLIB_LDFLAGS= {- $target{plib_lflags} -}
 EX_LIBS= {- $target{ex_libs} -} {- $config{ex_libs} -}
 LIB_CFLAGS={- $target{shared_cflag} || "" -}
 LIB_CXXFLAGS={- $target{shared_cxxflag} || "" -}
-LIB_LDFLAGS={- $target{shared_ldflag}." ".$config{shared_ldflag}
-               # Unlike other OSes (like Solaris, Linux, Tru64,
-               # IRIX) BSD run-time linkers (tested OpenBSD, NetBSD
-               # and FreeBSD) "demand" RPATH set on .so objects.
-               # Apparently application RPATH is not global and
-               # does not apply to .so linked with other .so.
-               # Problem manifests itself when libssl.so fails to
-               # load libcrypto.so. One can argue that we should
-               # engrave this into Makefile.shared rules or into
-               # BSD-* config lines above. Meanwhile let's try to
-               # be cautious and pass -rpath to linker only when
-               # $prefix is not /usr.
-               . ($config{target} =~ m|^BSD-| && $prefix !~ m|^/usr/.*$|
-                  ? " -Wl,-rpath,\$\$(LIBRPATH)" : "") -}
+LIB_LDFLAGS={- $target{shared_ldflag}." ".$config{shared_ldflag} -}
 DSO_CFLAGS={- $target{shared_cflag} || "" -}
 DSO_CXXFLAGS={- $target{shared_cxxflag} || "" -}
 DSO_LDFLAGS=$(LIB_LDFLAGS)

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -153,6 +153,10 @@ LIBDIR={- #
 ENGINESDIR={- use File::Spec::Functions;
               catdir($prefix,$libdir,"engines-$sover") -}
 
+# Convenience variable for those who want to set the rpath in shared
+# libraries and applications
+LIBRPATH=$(INSTALLTOP)/$(LIBDIR)
+
 MANDIR=$(INSTALLTOP)/share/man
 DOCDIR=$(INSTALLTOP)/share/doc/$(BASENAME)
 HTMLDIR=$(DOCDIR)/html
@@ -1094,7 +1098,7 @@ $bin$exeext: $objs $deps
 		APPNAME=$bin$exeext OBJECTS="$objs" \\
 		LIBDEPS='\$(PLIB_LDFLAGS) '"$linklibs"' \$(EX_LIBS)' \\
 		CC='$cc' CFLAGS='$cflags' \\
-		LDFLAGS='\$(LDFLAGS)' LIBRPATH='\$(INSTALLTOP)/\$(LIBDIR)' \\
+		LDFLAGS='\$(LDFLAGS)' \\
 		link_app.$shlib_target
 EOF
   }

--- a/Configure
+++ b/Configure
@@ -545,8 +545,9 @@ $config{build_type} = "release";
 
 my %unsupported_options = ();
 my %deprecated_options = ();
-foreach (@argvcopy)
+while (@argvcopy)
 	{
+	$_ = shift @argvcopy;
 	# VMS is a case insensitive environment, and depending on settings
 	# out of our control, we may receive options uppercased.  Let's
 	# downcase at least the part before any equal sign.
@@ -732,6 +733,14 @@ foreach (@argvcopy)
 		elsif (/^-[lL](.*)$/ or /^-Wl,/)
 			{
 			$libs.=$_." ";
+			}
+		elsif (/^-rpath$/ or /^-R$/)
+			# -rpath is the OSF1 rpath flag
+			# -R is the old Solaris rpath flag
+			{
+			my $rpath = shift(@argvcopy) || "";
+			$rpath .= " " if $rpath ne "";
+			$libs.=$_." ".$rpath;
 			}
 		elsif (/^-static$/)
 			{

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -176,7 +176,7 @@ DO_GNU_SO=\
 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
 	$(DO_GNU_SO_COMMON)
-DO_GNU_APP=LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,-rpath,$(LIBRPATH)"
+DO_GNU_APP=LDFLAGS="$(CFLAGS) $(LDFLAGS)"
 
 #This is rather special.  It's a special target with which one can link
 #applications without bothering with any features that have anything to
@@ -220,7 +220,7 @@ link_shlib.bsd:
 	fi; $(LINK_SO_SHLIB)
 link_app.bsd:
 	@if $(DETECT_GNU_LD); then $(DO_GNU_APP); else \
-	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,-rpath,$(LIBPATH)"; \
+	LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
 	fi; $(LINK_APP)
 
 # For Darwin AKA Mac OS/X (dyld)
@@ -352,7 +352,7 @@ link_app.alpha-osf1:
 	@if $(DETECT_GNU_LD); then \
 		$(DO_GNU_APP); \
 	else \
-		LDFLAGS="$(CFLAGS) $(LDFLAGS) -rpath $(LIBRPATH)"; \
+		LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
 	fi; \
 	$(LINK_APP)
 
@@ -385,7 +385,7 @@ link_app.solaris:
 	@ if $(DETECT_GNU_LD); then \
 		$(DO_GNU_APP); \
 	else \
-		LDFLAGS="$(CFLAGS) $(LDFLAGS) -R $(LIBRPATH)"; \
+		LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
 	fi; \
 	$(LINK_APP)
 
@@ -476,7 +476,7 @@ link_shlib.irix:
 	fi; \
 	$(LINK_SO_SHLIB)
 link_app.irix:
-	@LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,-rpath,$(LIBRPATH)"; \
+	@LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
 	$(LINK_APP)
 
 # 32-bit PA-RISC HP-UX embeds the -L pathname of libs we link with, so
@@ -514,7 +514,7 @@ link_shlib.hpux:
 	$(LINK_SO_SHLIB) && chmod a=rx $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX
 link_app.hpux:
 	@if $(DETECT_GNU_LD); then $(DO_GNU_APP); else \
-	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,+s,+cdp,../:,+cdp,./:,+b,$(LIBRPATH)"; \
+	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,+s,+cdp,../:,+cdp,./:"; \
 	fi; \
 	$(LINK_APP)
 
@@ -540,7 +540,7 @@ link_shlib.aix:
 	rm -f $(DSTDIR)/$$SHLIB$$SHLIB_SOVER 2>&1 > /dev/null ; \
 	$(LINK_SO_SHLIB_VIA_O)
 link_app.aix:
-	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,-brtl,-blibpath:$(LIBRPATH):$${LIBPATH:-/usr/lib:/lib}"; \
+	LDFLAGS="$(CFLAGS) -Wl,-bsvr4 $(LDFLAGS)"; \
 	$(LINK_APP)
 
 

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -81,7 +81,7 @@ SunOS|IRIX*)
 	;;
 esac
 
-{- output_off() if $config{ex_libs} !~ /(^|\s)-Wl,-rpath,/; ""; -}
+{- output_off() if $config{ex_libs} !~ /,-rpath,/; ""; -}
 if [ -f "$LIBCRYPTOSO" -a -z "$preload_var" ]; then
 	# Following three lines are major excuse for isolating them into
 	# this wrapper script. Original reason for setting LD_PRELOAD
@@ -97,7 +97,7 @@ if [ -f "$LIBCRYPTOSO" -a -z "$preload_var" ]; then
 	DYLD_INSERT_LIBRARIES="$LIBCRYPTOSO:$LIBSSLSO"	# MacOS X
 	export LD_PRELOAD _RLD_LIST DYLD_INSERT_LIBRARIES
 fi
-{- output_on() if $config{ex_libs} !~ /(^|\s)-Wl,-rpath,/; ""; -}
+{- output_on() if $config{ex_libs} !~ /,-rpath,/; ""; -}
 
 cmd="$1"; [ -x "$cmd" ] || cmd="$cmd${EXE_EXT}"
 shift


### PR DESCRIPTION
Before OpenSSL 1.1.0, binaries were installed in a non-standard
location by default, and runpath directories were therefore added in
those binaries, to make sure the executables would be able to find the
shared libraries they were linked with.

With OpenSSL 1.1.0 and on, binaries are installed in standard
directories by default, and the addition of runpath directories is
therefore not needed any more.

Make Configure recognise -rpath and -R to support user added rpaths
for OSF1 and Solaris.  For convenience, add a variable LIBRPATH in the
Unix Makefile, which the users can use as follows:

```
./config [options] -Wl,-rpath,\$(LIBRPATH)
```

---

Fixes #1635 and is an alternative to #1688
