### PR TITLE
Configure: remove superfluous 0x

### DIFF
--- a/Configure
+++ b/Configure
@@ -287,7 +287,7 @@ if (defined $ENV{$local_config_envname}) {
 }
 
 
-print "Configuring OpenSSL version $config{version} (0x$config{version_num})\n";
+print "Configuring OpenSSL version $config{version} ($config{version_num})\n";
 
 $config{prefix}="";
 $config{openssldir}="";


### PR DESCRIPTION
The number is taken from the OPENSSL_VERSION_NUMBER which is already
in the hex form.