### PR TITLE
Add memory leak detection to d2i_test

### DIFF
--- a/test/d2i_test.c
+++ b/test/d2i_test.c
@@ -142,6 +142,7 @@ int main(int argc, char **argv)
     int result = 0;
     const char *test_type_name;
     const char *expected_error_string;
+    const char *p = getenv("OPENSSL_DEBUG_MEMORY");
 
     size_t i;
 
@@ -152,6 +153,10 @@ int main(int argc, char **argv)
         {"encode", ASN1_ENCODE},
         {"compare", ASN1_COMPARE}
     };
+
+    if (p != NULL && strcmp(p, "on") == 0)
+        CRYPTO_set_mem_debug(1);
+    CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
 
     if (argc != 4) {
         fprintf(stderr,
@@ -193,6 +198,11 @@ int main(int argc, char **argv)
     ADD_TEST(test_bad_asn1);
 
     result = run_tests(argv[0]);
+
+#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+    if (CRYPTO_mem_leaks_fp(stderr) <= 0)
+        result = 1;
+#endif
 
     return result;
 }


### PR DESCRIPTION
This adds leak detection to d2i_test in a similar way to other tests.