### PR TITLE
PBKDF2 computation speedup (15-40%)

### DIFF
--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -88,7 +88,6 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
             HMAC_CTX_free(hctx_tpl);
             return 0;
         }
-        HMAC_CTX_reset(hctx);
         memcpy(p, digtmp, cplen);
         for (j = 1; j < iter; j++) {
             if (!HMAC_CTX_copy(hctx, hctx_tpl)) {
@@ -102,7 +101,6 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
                 HMAC_CTX_free(hctx_tpl);
                 return 0;
             }
-            HMAC_CTX_reset(hctx);
             for (k = 0; k < cplen; k++)
                 p[k] ^= digtmp[k];
         }

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -157,31 +157,36 @@ void HMAC_CTX_free(HMAC_CTX *ctx)
     }
 }
 
-int HMAC_CTX_reset(HMAC_CTX *ctx)
+static int hmac_ctx_alloc_mds(HMAC_CTX *ctx)
 {
-    hmac_ctx_cleanup(ctx);
     if (ctx->i_ctx == NULL)
         ctx->i_ctx = EVP_MD_CTX_new();
     if (ctx->i_ctx == NULL)
-        goto err;
+        return 0;
     if (ctx->o_ctx == NULL)
         ctx->o_ctx = EVP_MD_CTX_new();
     if (ctx->o_ctx == NULL)
-        goto err;
+        return 0;
     if (ctx->md_ctx == NULL)
         ctx->md_ctx = EVP_MD_CTX_new();
     if (ctx->md_ctx == NULL)
-        goto err;
-    ctx->md = NULL;
+        return 0;
     return 1;
- err:
+}
+
+int HMAC_CTX_reset(HMAC_CTX *ctx)
+{
     hmac_ctx_cleanup(ctx);
-    return 0;
+    if (!hmac_ctx_alloc_mds(ctx)) {
+        hmac_ctx_cleanup(ctx);
+        return 0;
+    }
+    return 1;
 }
 
 int HMAC_CTX_copy(HMAC_CTX *dctx, HMAC_CTX *sctx)
 {
-    if (!HMAC_CTX_reset(dctx))
+    if (!hmac_ctx_alloc_mds(dctx))
         goto err;
     if (!EVP_MD_CTX_copy_ex(dctx->i_ctx, sctx->i_ctx))
         goto err;


### PR DESCRIPTION
This commit contains some optimizations in PKCS5_PBKDF2_HMAC() and
HMAC_CTX_copy() functions which together makes PBKDF2 computations
faster by 15-40% according to my measurements made on x64 Linux with
both asm optimized and no-asm versions of SHA1, SHA256 and SHA512.

**Proof of correctness:**

Let's assume that HMAC_CTX_copy() is unchanged.
The removed HMAC_CTX_reset() calls were unnecessary because they are
followed by HMAC_CTX_copy() or HMAC_CTX_free() calls in every possible
code flows. Calling reset is unnecessary before calling free and the copy
function started with calling reset again. So if we can prove that the copy
function is doing the same as before then calling reset is still unnecessary.

Now we have to prove that HMAC_CTX_copy() is doing the same as before.
In the error cases it always calls hmac_ctx_cleanup() that will clear everything
securely, we only need to care about the success case.

dctx->key_length and dctx->md were set to zero and then to
sctx->key_length and dctx->md respectively, we can safely remove setting
them to zero.

dctx->key was first cleansed and then fully overwritten with sctx->key, we do
not need to call OPENSSL_cleanse().

dctx->i_ctx, dctx->o_ctx and dctx->md_ctx were first reset by calling
EVP_MD_CTX_reset(), then they were allocated if they were not previously
and finally EVP_MD_CTX_copy_ex() was called to fill them. The optional
allocation is still there in the new code. EVP_MD_CTX_reset() is called
inside EVP_MD_CTX_copy_ex() in every successful code path, but their
inner md_data is now kept and reused. It is safe to do that because the
whole kept md_data is overwritten with the contents of in->md_data inside
the copy function, so we do not need to cleanse its contents.

This concludes the proof.

**Why is the speedup?**

Now we do not cleanse, free and reallocate the inner md_data of the
message digest contexts, which were previously called ate least once for
every iteration (and even much more if the desired ouput length was long).

**Why are the EVP_MD_CTX_new() calls necessary in HMAC_CTX_copy?**

I do not know. If they would not be needed then the change would be much smaller.
(No need for the hmac_ctx_alloc_mds function). If I remove them then all the tests
are still running successfully, but I didn't want to do that because that would change
the observable behavior of HMAC_CTX_copy(). I can not think of a case where
it would be called with NULL contexts in it because HMAC_CTX_new() initializes them
and those are never set back to NULL later. If they are not necessary, then I would like
to revert the modifications in hmac.c and only remove the call of HMAC_CTX_reset()
inside HMAC_CTX_copy().
See example commit with that change (tests are still ok): https://github.com/tresorit/openssl/commit/831d67ab7a5a
