### PR TITLE
Add cipher suite tests to ssl_test_old for DTLS

### DIFF
--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -21,6 +21,8 @@ typedef enum OPTION_choice {
     OPT_TLS1,
     OPT_TLS1_1,
     OPT_TLS1_2,
+    OPT_DTLS1,
+    OPT_DTLS1_2,
     OPT_PSK,
     OPT_SRP,
     OPT_V, OPT_UPPER_V, OPT_S
@@ -42,6 +44,12 @@ OPTIONS ciphers_options[] = {
 #endif
 #ifndef OPENSSL_NO_TLS1_2
     {"tls1_2", OPT_TLS1_2, '-', "TLS1.2 mode"},
+#endif
+#ifndef OPENSSL_NO_DTLS1
+    {"dtls1", OPT_DTLS1, '-', "DTLS1 mode"},
+#endif
+#ifndef OPENSSL_NO_DTLS1_2
+    {"dtls1_2", OPT_DTLS1_2, '-', "DTLS1.2 mode"},
 #endif
 #ifndef OPENSSL_NO_SSL_TRACE
     {"stdname", OPT_STDNAME, '-', "Show standard cipher names"},
@@ -135,6 +143,20 @@ int ciphers_main(int argc, char **argv)
             min_version = TLS1_2_VERSION;
             max_version = TLS1_2_VERSION;
             break;
+#ifndef OPENSSL_NO_DTLS1
+        case OPT_DTLS1:
+            min_version = DTLS1_VERSION;
+            max_version = DTLS1_VERSION;
+            meth = DTLS_server_method();
+            break;
+#endif
+#ifndef OPENSSL_NO_DTLS1_2
+        case OPT_DTLS1_2:
+            min_version = DTLS1_2_VERSION;
+            max_version = DTLS1_2_VERSION;
+            meth = DTLS_server_method();
+            break;
+#endif
         case OPT_PSK:
 #ifndef OPENSSL_NO_PSK
             psk = 1;

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -170,6 +170,8 @@ extern "C" {
 # define SSL_TXT_TLSV1           "TLSv1"
 # define SSL_TXT_TLSV1_1         "TLSv1.1"
 # define SSL_TXT_TLSV1_2         "TLSv1.2"
+# define SSL_TXT_DTLSV1          "DTLSv1"
+# define SSL_TXT_DTLSV1_2        "DTLSv1.2"
 
 # define SSL_TXT_ALL             "ALL"
 

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -448,6 +448,8 @@ sub testssl {
 	# FIXME: I feel unsure about the following line, is that really just TLSv1.2, or is it all of the SSLv3/TLS protocols?
         push(@protocols, "TLSv1.2") unless $no_tls1_2;
         push(@protocols, "SSLv3") unless $no_ssl3;
+        push(@protocols, "DTLSv1") unless $no_dtls1;
+        push(@protocols, "DTLSv1.2") unless $no_dtls1_2;
 	my $protocolciphersuitcount = 0;
 	my %ciphersuites =
 	    map { my @c =
@@ -466,10 +468,15 @@ sub testssl {
 	plan tests => $protocolciphersuitcount + scalar(@protocols);
 
 	foreach my $protocol (@protocols) {
+	    my @protoarg = ();
+	    @protoarg = ("-ssl3") if $protocol eq "SSLv3";
+	    @protoarg = ("-dtls1") if $protocol eq "DTLSv1";
+	    @protoarg = ("-dtls12") if $protocol eq "DTLSv1.2";
+
 	    note "Testing ciphersuites for $protocol";
 	    foreach my $cipher (@{$ciphersuites{$protocol}}) {
 		ok(run(test([@ssltest, @exkeys, "-cipher", $cipher,
-			     $protocol eq "SSLv3" ? ("-ssl3") : ()])),
+			     (@protoarg)])),
 		   "Testing $cipher");
 	    }
             is(run(test([@ssltest,


### PR DESCRIPTION
As [discussed](https://github.com/openssl/openssl/pull/1666#issuecomment-252048193), `ssl_test_old` iterates over all ciphersuites for TLS protocols but doesn't do DTLS.

I am no longer too bothered about that addition, since in #1666 I've since added a separate MTU test which will iterate over all DTLS ciphersuites anyway. But in order to get `ssl_test_old` doing it, I also had to fix `SSL_CTX_set_cipher_list()` to accept "`DTLSv1`" and "`DTLSv1.2`" as arguments. That might be worth having, so I'm submitting it separately for posterity.
