### PR TITLE
Ensure we handle len == 0 in ERR_err_string_n

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -500,6 +500,9 @@ void ERR_error_string_n(unsigned long e, char *buf, size_t len)
     const char *ls, *fs, *rs;
     unsigned long l, f, r;
 
+    if (len == 0)
+        return;
+
     l = ERR_GET_LIB(e);
     f = ERR_GET_FUNC(e);
     r = ERR_GET_REASON(e);


### PR DESCRIPTION
If len == 0 in a call to ERR_error_string_n() then we can read beyond the
end of the buffer. Really applications should not be calling this function
with len == 0, but we shouldn't be letting it through either!

Thanks to Agostino Sarubbo for reporting this issue.