### PR TITLE
Build fixups, mainly allowing the definition of program or object file specific macros

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -66,6 +66,8 @@
                              deps => $unified_info{depends}->{$src},
                              incs => [ @{$unified_info{includes}->{$bin}},
                                        @{$unified_info{includes}->{$obj}} ],
+                             defs => [ @{$unified_info{defines}->{$bin}},
+                                       @{$unified_info{defines}->{$obj}} ],
                              %opts);
          foreach (@{$unified_info{depends}->{$src}}) {
              dogenerate($_, $obj, $bin, %opts);
@@ -89,6 +91,8 @@
                          deps => $unified_info{depends}->{$obj},
                          incs => [ @{$unified_info{includes}->{$bin}},
                                    @{$unified_info{includes}->{$obj}} ],
+                         defs => [ @{$unified_info{defines}->{$bin}},
+                                   @{$unified_info{defines}->{$obj}} ],
                          %opts);
          foreach ((@{$unified_info{sources}->{$obj}},
                    @{$unified_info{depends}->{$obj}})) {

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -160,7 +160,9 @@ OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover.$target{pointer_size} -}:
 
 CC= {- $target{cc} -}
-CFLAGS= /DEFINE=({- join(",", @{$target{defines}}, @{$config{defines}},"OPENSSLDIR=\"\"\"\$(OPENSSLDIR_C)\"\"\"","ENGINESDIR=\"\"\"\$(ENGINESDIR_C)\"\"\"") -}) {- $target{cflags} -} {- $config{cflags} -}
+DEFINES= {- join(",", @{$target{defines}}, @{$config{defines}},"OPENSSLDIR=\"\"\"\$(OPENSSLDIR_C)\"\"\"","ENGINESDIR=\"\"\"\$(ENGINESDIR_C)\"\"\"") -}
+CFLAGS_NODEF= {- $target{cflags} -} {- $config{cflags} -}
+CFLAGS= /DEFINE=($(DEFINES)) $(CFLAGS_NODEF)
 CFLAGS_Q=$(CFLAGS)
 DEPFLAG= /DEFINE=({- join(",", @{$config{depdefines}}) -})
 LDFLAGS= {- $target{lflags} -}
@@ -591,6 +593,7 @@ EOF
       my $incs = "";
       my @incs = ();
       push @incs, @{$args{incs}} if @{$args{incs}};
+      my $defs = join("", map { ",".$_ } @{$args{defs}});
       unless ($disabled{zlib}) {
           # GNV$ZLIB_INCLUDE is the standard logical name for later zlib
           # incarnations.
@@ -616,7 +619,7 @@ $obj.OBJ : $deps
         ${before}
         SET DEFAULT $forward
         $incs_on
-        \$(CC) \$(CFLAGS)${ecflags}${incs}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
+        \$(CC) /DEFINE=(\$(DEFINES)$defs) \$(CFLAGS_NODEF)${ecflags}${incs}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
         $incs_off
         SET DEFAULT $backward
         ${after}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -863,6 +863,7 @@ configdata.pm: $(SRCDIR)/Configure $(SRCDIR)/config {- join(" ", @{$config{build
       my $generator = join(" ", @{$args{generator}});
       my $generator_incs = join("", map { " -I".$_ } @{$args{generator_incs}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
+      my $defs = join("", map { " -D".$_ } @{$args{defs}});
       my $deps = join(" ", @{$args{generator_deps}}, @{$args{deps}});
 
       if ($args{src} !~ /\.[sS]$/) {
@@ -901,7 +902,7 @@ EOF
 $target: $args{generator}->[0] $deps
 	( trap "rm -f \$@.*" INT 0; \\
 	  $generator \$@.S; \\
-	  \$(CC) $incs \$(CFLAGS) -E \$@.S | \\
+	  \$(CC) $incs \$(CFLAGS) $defs -E \$@.S | \\
 	  \$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@.i && \\
 	  mv -f \$@.i \$@ )
 EOF
@@ -914,7 +915,7 @@ EOF
           }
           return <<"EOF";
 $args{src}: $args{generator}->[0] $deps
-	\$(CC) $incs \$(CFLAGS) -E \$< | \\
+	\$(CC) $incs \$(CFLAGS) $defs -E \$< | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
 EOF
       }
@@ -935,6 +936,7 @@ EOF
       my $srcs = join(" ",  @srcs);
       my $deps = join(" ", @srcs, @{$args{deps}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
+      my $defs = join("", map { " -D".$_ } @{$args{defs}});
       unless ($disabled{zlib}) {
           if ($withargs{zlib_include}) {
               $incs .= " -I".$withargs{zlib_include};
@@ -959,7 +961,7 @@ $obj$objext: $deps
 EOF
       if (!$disabled{makedepend} && $makedepprog !~ /\/makedepend/) {
           $recipe .= <<"EOF";
-	$cc $incs $cflags -MMD -MF $obj$depext.tmp -MT \$\@ -c -o \$\@ $srcs
+	$cc $incs $cflags $defs -MMD -MF $obj$depext.tmp -MT \$\@ -c -o \$\@ $srcs
 	\@touch $obj$depext.tmp
 	\@if cmp $obj$depext.tmp $obj$depext > /dev/null 2> /dev/null; then \\
 		rm -f $obj$depext.tmp; \\
@@ -969,7 +971,7 @@ EOF
 EOF
       } else {
           $recipe .= <<"EOF";
-	$cc $incs $cflags -c -o \$\@ $srcs
+	$cc $incs $cflags $defs -c -o \$\@ $srcs
 EOF
           if (!$disabled{makedepend} && $makedepprog =~ /\/makedepend/) {
               $recipe .= <<"EOF";

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -357,6 +357,7 @@ configdata.pm: "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{b
       my $generator = '"'.join('" "', @{$args{generator}}).'"';
       my $generator_incs = join("", map { " -I \"$_\"" } @{$args{generator_incs}});
       my $incs = join("", map { " /I \"$_\"" } @{$args{incs}});
+      my $defs = join("", map { " /D".$_ } @{$args{defs}});
       my $deps = @{$args{deps}} ?
           '"'.join('" "', @{$args{generator_deps}}, @{$args{deps}}).'"' : '';
 
@@ -393,7 +394,7 @@ EOF
 $target: "$args{generator}->[0]" $deps
 	set ASM=\$(AS)
 	$generator \$@.S
-	\$(CC) $incs \$(CFLAGS) /EP /C \$@.S > \$@.i && move /Y \$@.i \$@
+	\$(CC) $incs \$(CFLAGS) $defs /EP /C \$@.S > \$@.i && move /Y \$@.i \$@
         del /Q \$@.S
 EOF
               }
@@ -406,7 +407,7 @@ EOF
           }
           return <<"EOF";
 $target: "$args{generator}->[0]" $deps
-	\$(CC) $incs \$(CFLAGS) /EP /C "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
+	\$(CC) $incs \$(CFLAGS) $defs /EP /C "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
 EOF
       }
   }
@@ -419,6 +420,7 @@ EOF
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
+     my $defs = join("", map { " /D".$_ } @{$args{defs}});
      unless ($disabled{zlib}) {
          if ($withargs{zlib_include}) {
              $incs .= ' /I "'.$withargs{zlib_include}.'"';
@@ -436,7 +438,7 @@ EOF
      }
      return <<"EOF"	if (!$disabled{makedepend});
 $obj$depext: $deps
-	\$(CC) \$(CFLAGS) $ecflags$inc /Zs /showIncludes $srcs 2>&1 | \\
+	\$(CC) $incs \$(CFLAGS) $ecflags $defs /Zs /showIncludes $srcs 2>&1 | \\
 	    "\$(PERL)" -n << > $obj$depext
 chomp;
 s/^Note: including file: *//;
@@ -444,13 +446,13 @@ s/^Note: including file: *//;
 END { print '$obj$objext: ',join(" ", sort keys \%collect),"\\n" }
 <<
 $obj$objext: $obj$depext
-	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ @<<
+	\$(CC) $incs \$(CFLAGS) $ecflags $defs -c \$(COUTFLAG)\$\@ @<<
 $srcs
 <<
 EOF
     return <<"EOF"	if ($disabled{makedepend});
 $obj$objext: $deps
-	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ $srcs
+	\$(CC) $incs \$(CFLAGS) $ecflags $defs -c \$(COUTFLAG)\$\@ $srcs
 EOF
  }
 

--- a/Configure
+++ b/Configure
@@ -1451,6 +1451,7 @@ if ($builder eq "unified") {
         my %sources = ();
         my %shared_sources = ();
         my %includes = ();
+        my %defines = ();
         my %depends = ();
         my %renames = ();
         my %sharednames = ();
@@ -1559,6 +1560,9 @@ if ($builder eq "unified") {
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*INCLUDE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
             => sub { push @{$includes{$1}}, tokenize($2)
+                         if !@skip || $skip[$#skip] > 0 },
+            qr/^\s*MACRO\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
+            => sub { push @{$defines{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*DEPEND\[((?:\\.|[^\\\]])*)\]\s*=\s*(.*)\s*$/
             => sub { push @{$depends{$1}}, tokenize($2)
@@ -1880,6 +1884,27 @@ EOF
                     unless grep { $_ eq $ib } @{$unified_info{includes}->{$ddest}->{build}};
             }
         }
+
+        foreach (keys %defines) {
+            my $dest = $_;
+            my $ddest = cleanfile($sourced, $_, $blddir);
+
+            # If the destination doesn't exist in source, it can only be
+            # a generated file in the build tree.
+            if (! -f $ddest) {
+                $ddest = cleanfile($buildd, $_, $blddir);
+                if ($unified_info{rename}->{$ddest}) {
+                    $ddest = $unified_info{rename}->{$ddest};
+                }
+            }
+            foreach (@{$defines{$dest}}) {
+                m|^([^=]*)(=.*)?$|;
+                die "0 length macro name not permitted\n" if $1 eq "";
+                die "$1 defined more than once\n"
+                    if defined $unified_info{defines}->{$ddest}->{$1};
+                $unified_info{defines}->{$ddest}->{$1} = $2;
+            }
+        }
     }
 
     ### Make unified_info a bit more efficient
@@ -1893,6 +1918,12 @@ EOF
             $unified_info{$l1}->{$l2} =
                 [ sort keys %{$unified_info{$l1}->{$l2}} ];
         }
+    }
+    # Defines
+    foreach my $dest (sort keys %{$unified_info{defines}}) {
+        $unified_info{defines}->{$dest}
+            = [ map { $_.$unified_info{defines}->{$dest}->{$_} }
+                sort keys %{$unified_info{defines}->{$dest}} ];
     }
     # Includes
     foreach my $dest (sort keys %{$unified_info{includes}}) {

--- a/Configure
+++ b/Configure
@@ -1767,7 +1767,9 @@ EOF
                     $s = cleanfile($buildd, $_, $blddir);
                 }
                 # We recognise C++, C and asm files
-                if ($s =~ /\.(cc|cpp|c|s|S)$/) {
+                # However, no transformation should be made if the destination
+                # is an object file
+                if ($dest !~ /\.o$/ && $s =~ /\.(cc|cpp|c|s|S)$/) {
                     my $o = $_;
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++


### PR DESCRIPTION
The idea is primarly to be able to have a `build.info` construction like this:

```
PROGRAMS_NO_INST=foo
SOURCE[foo]=foo.c
MACRO[foo]=FOO
```

In addition to this, it may be valuable to have programs depend on specific compilations of certain sources, allowing a construct like this:

```
PROGRAMS_NO_INST=special_foo
SOURCE[special_foo]=special_foo.o bar.c
SOURCE[special_foo.o]=../crypto/foo/foo.c
MACRO[special_foo.o]=SPECIAL=1
```

---

This was inspired by #1698, where there's a C source file that contains a self test guarded by a SELFTEST macro.  With the changes in this PR, building a self test program is just a few lines in, for example, `test/build.info`:

```
PROGRAMS_NO_INST=selftest_keccak1600
SOURCE[selftest_keccak1600]=selftest_keccak1600.o
SOURCE[selftest_keccak1600.o]=../crypto/sha/keccak1600.c
MACRO[selftest_keccak1600.o]=SELFTEST
```
