### PR TITLE
Fix strict-warnings build

### DIFF
--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1575,8 +1575,8 @@ ___
 }
 
 ########################################################################
-# void AES_xts_encrypt(const char *inp,char *out,size_t len,
-#	const AES_KEY *key1, const AES_KEY *key2,
+# void AES_xts_encrypt(const unsigned char *inp, unsigned char *out,
+#	size_t len, const AES_KEY *key1, const AES_KEY *key2,
 #	const unsigned char iv[16]);
 #
 {
@@ -1944,8 +1944,8 @@ $code.=<<___;
 	br	$ra
 .size	AES_xts_encrypt,.-AES_xts_encrypt
 ___
-# void AES_xts_decrypt(const char *inp,char *out,size_t len,
-#	const AES_KEY *key1, const AES_KEY *key2,
+# void AES_xts_decrypt(const unsigned char *inp, unsigned char *out,
+#	size_t len, const AES_KEY *key1, const AES_KEY *key2,
 #	const unsigned char iv[16]);
 #
 $code.=<<___;

--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -601,7 +601,7 @@ int asn1_valid_host(const ASN1_STRING *host)
     const unsigned char *hostptr = host->data;
     int type = host->type;
     int i;
-    char width = -1;
+    signed char width = -1;
     unsigned short chflags = 0, prevchflags;
 
     if (type > 0 && type < 31)

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -135,10 +135,10 @@ void AES_ctr32_encrypt(const unsigned char *in, unsigned char *out,
                        const unsigned char ivec[AES_BLOCK_SIZE]);
 #endif
 #ifdef AES_XTS_ASM
-void AES_xts_encrypt(const char *inp, char *out, size_t len,
+void AES_xts_encrypt(const unsigned char *inp, unsigned char *out, size_t len,
                      const AES_KEY *key1, const AES_KEY *key2,
                      const unsigned char iv[16]);
-void AES_xts_decrypt(const char *inp, char *out, size_t len,
+void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
                      const AES_KEY *key1, const AES_KEY *key2,
                      const unsigned char iv[16]);
 #endif

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include <signal.h>
+#include "internal/cryptlib.h"
 
 extern unsigned long OPENSSL_s390xcap_P[];
 


### PR DESCRIPTION
This is a trivial fix for strict-warnings build errors on s390x.

./config --strict-warnings
Operating system: s390x-whatever-linux2
Configuring OpenSSL version 1.1.1-dev (0x10101000L)
    no-asan         [default]  OPENSSL_NO_ASAN
    no-crypto-mdebug [default]  OPENSSL_NO_CRYPTO_MDEBUG
    no-crypto-mdebug-backtrace [default]  OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE
    no-ec_nistp_64_gcc_128 [default]  OPENSSL_NO_EC_NISTP_64_GCC_128
    no-egd          [default]  OPENSSL_NO_EGD
    no-fuzz-afl     [default]  OPENSSL_NO_FUZZ_AFL
    no-fuzz-libfuzzer [default]  OPENSSL_NO_FUZZ_LIBFUZZER
    no-heartbeats   [default]  OPENSSL_NO_HEARTBEATS
    no-md2          [default]  OPENSSL_NO_MD2 (skip dir)
    no-msan         [default]  OPENSSL_NO_MSAN
    no-rc5          [default]  OPENSSL_NO_RC5 (skip dir)
    no-sctp         [default]  OPENSSL_NO_SCTP
    no-ssl-trace    [default]  OPENSSL_NO_SSL_TRACE
    no-ssl3         [default]  OPENSSL_NO_SSL3
    no-ssl3-method  [default]  OPENSSL_NO_SSL3_METHOD
    no-ubsan        [default]  OPENSSL_NO_UBSAN
    no-unit-test    [default]  OPENSSL_NO_UNIT_TEST
    no-weak-ssl-ciphers [default]  OPENSSL_NO_WEAK_SSL_CIPHERS
    no-zlib         [default] 
    no-zlib-dynamic [default] 
Configuring for linux64-s390x

PERL          =/usr/bin/perl
PERLVERSION   =5.22.2 for s390x-linux-thread-multi
HASHBANGPERL  =/usr/bin/env perl
CC            =gcc
CFLAG         =-Wall -O3 -pthread -m64 -DB_ENDIAN  -DDEBUG_UNUSED -Wswitch -DPEDANTIC -pedantic -Wno-long-long -Wall -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wtype-limits -Werror -Wa,--noexecstack
CXX           =g++
CXXFLAG       =-Wall -O3 -pthread -m64 -DB_ENDIAN 
DEFINES       =DSO_DLFCN HAVE_DLFCN_H NDEBUG OPENSSL_THREADS OPENSSL_NO_STATIC_ENGINE OPENSSL_PIC OPENSSL_BN_ASM_MONT OPENSSL_BN_ASM_GF2m SHA1_ASM SHA256_ASM SHA512_ASM RC4_ASM AES_ASM AES_CTR_ASM AES_XTS_ASM GHASH_ASM POLY1305_ASM
EX_LIBS       =-ldl 

crypto/asn1/a_strex.c: In function 'asn1_valid_host':
crypto/asn1/a_strex.c:609:15: error: comparison is always false due to limited range of data type [-Werror=type-limits]
     if (width == -1 || hostlen == 0)
               ^~

crypto/evp/e_aes.c: In function 'aes_xts_init_key':
crypto/evp/e_aes.c:1805:26: error: assignment from incompatible pointer type [-Werror=incompatible-pointer-types]
             xctx->stream = enc ? AES_xts_encrypt : AES_xts_decrypt;
                          ^

crypto/s390xcap.c:26:6: error: no previous prototype for 'OPENSSL_cpuid_setup' [-Werror=missing-prototypes]
 void OPENSSL_cpuid_setup(void)

