### PR TITLE
Allow older versions in the *.num files

### DIFF
--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -1630,8 +1630,7 @@ sub check_version_lte()
 	if ($cvnums ne $tvnums) {
 		die "Invalid version number: $testversion "
 			."for current version $currversion\n"
-			if (substr($cvnums, -1) < substr($tvnums, -1)
-				|| substr($cvnums, 0, 4) ne substr($tvnums, 0, 4));
+			if (substr($cvnums, 0, 4) ne substr($tvnums, 0, 4));
 		return;
 	}
 	#If we get here then the base version (i.e. the numbers) are the same - they


### PR DESCRIPTION
In 1.1.0 we only allowed a strictly increasing version number in the *.num
files, i.e. you could never introduce a symbol at the end of the *.num file
with a lower version number than the one preceding it. This made sense for
1.1.0. However in master we may be introducing symbols for backport to
1.1.0. Therefore it is ok in master to have a symbol for version 1.1.0c
coming after a symbol for version 1.1.1.

This commit fixes the check in mkdef.pl to be a bit looser to allow this.