### PR TITLE
Add a -subj override to the x509 app its signing capability.

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1714,12 +1714,16 @@ X509_NAME *parse_name(const char *cp, long chtype, int canmulti)
     char *work;
     X509_NAME *n;
 
-    if (*cp++ != '/')
+    if (*cp++ != '/') {
+        ERR_clear_error();
+        BIO_printf(bio_err, "Subject does not start with a '/'\n");
         return NULL;
+    }
 
     n = X509_NAME_new();
     if (n == NULL)
         return NULL;
+
     work = OPENSSL_strdup(cp);
     if (work == NULL)
         goto err;

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -286,6 +286,15 @@ void X509_REQ_get0_signature(const X509_REQ *req, const ASN1_BIT_STRING **psig,
         *palg = &req->sig_alg;
 }
 
+void X509_REQ_set0_signature(X509_REQ *req, ASN1_BIT_STRING *psigOrNull,
+                             X509_ALGOR *palgOrNull)
+{
+    if (psigOrNull != NULL)
+        req->signature = psigOrNull;
+    if (palgOrNull != NULL)
+        req->sig_alg = *palgOrNull;
+}
+
 int X509_REQ_get_signature_nid(const X509_REQ *req)
 {
     return OBJ_obj2nid(req->sig_alg.algorithm);

--- a/doc/apps/x509.pod
+++ b/doc/apps/x509.pod
@@ -47,6 +47,9 @@ B<openssl> B<x509>
 [B<-passin arg>]
 [B<-x509toreq>]
 [B<-req>]
+[B<-subj arg>]
+[B<-utf8>]
+[B<-multivalue-rdn>]
 [B<-CA filename>]
 [B<-CAkey filename>]
 [B<-CAcreateserial>]
@@ -375,6 +378,33 @@ option the serial number file (as specified by the B<-CAserial> or
 B<-CAcreateserial> options) is not used.
 
 The serial number can be decimal or hex (if preceded by B<0x>).
+
+=item B<-subj arg>
+
+supersedes subject name given in the request.
+The arg must be formatted as I</type0=value0/type1=value1/type2=...>,
+characters may be escaped by \ (backslash), no spaces are skipped.
+
+=item B<-utf8>
+
+this option causes field values to be interpreted as UTF8 strings, by
+default they are interpreted as ASCII. This means that the field
+values, whether prompted from a terminal or obtained from a
+configuration file, must be valid UTF8 strings. Applies to the
+value set by the B<-subj> flag.
+
+=item B<-multivalue-rdn>
+
+This option causes the -subj argument to be interpreted with full
+support for multivalued RDNs. Applies to the value set by the 
+B<-subj> flag.
+
+Example:
+
+I</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
+
+If -multi-rdn is not used then the UID value is I<123456+CN=John Doe>.
+
 
 =item B<-CA filename>
 

--- a/doc/crypto/X509_get0_signature.pod
+++ b/doc/crypto/X509_get0_signature.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-X509_get0_signature, X509_get_signature_nid, X509_get0_tbs_sigalg,
+X509_get0_signature, X509_REQ_set0_signature, X509_get_signature_nid, X509_get0_tbs_sigalg,
 X509_REQ_get0_signature, X509_REQ_get_signature_nid, X509_CRL_get0_signature,
 X509_CRL_get_signature_nid - signature information
 
@@ -13,6 +13,8 @@ X509_CRL_get_signature_nid - signature information
  void X509_get0_signature(const ASN1_BIT_STRING **psig,
                           const X509_ALGOR **palg,
                           const X509 *x);
+ void X509_REQ_set0_signature(X509_REQ *req, ASN1_BIT_STRING *psigOrNull,
+                             X509_ALGOR *palgOrNull)
  int X509_get_signature_nid(const X509 *x);
  const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *x);
 
@@ -31,6 +33,14 @@ X509_CRL_get_signature_nid - signature information
 X509_get0_signature() sets B<*psig> to the signature of B<x> and B<*palg>
 to the signature algorithm of B<x>. The values returned are internal
 pointers which B<MUST NOT> be freed up after the call.
+
+X509_set0_signature() is the equivalent setter. If NULL is passed - that
+value is ignored; and the value in B<*req> is not overwritten. The algorithm
+value B<*palgOrNull> is copied into the struct of the B<*req>; but the 
+signature value B<*palgOrNull> is simply a pointer from B<*req>. So calling 
+this function transfers the memory management of that value; and therefore 
+the  B<*palgOrNull> tha has been passed in should not be freed directly after 
+the X509_set0_signature() function has been called. 
 
 X509_get0_tbs_sigalg() returns the signature algorithm in the signed
 portion of B<x>.

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -660,6 +660,8 @@ X509_NAME *X509_REQ_get_subject_name(const X509_REQ *req);
 int X509_REQ_set_subject_name(X509_REQ *req, X509_NAME *name);
 void X509_REQ_get0_signature(const X509_REQ *req, const ASN1_BIT_STRING **psig,
                              const X509_ALGOR **palg);
+void X509_REQ_set0_signature(X509_REQ *req, ASN1_BIT_STRING *psigOrNull,
+                             X509_ALGOR *palgOrNull);
 int X509_REQ_get_signature_nid(const X509_REQ *req);
 int i2d_re_X509_REQ_tbs(X509_REQ *req, unsigned char **pp);
 int X509_REQ_set_pubkey(X509_REQ *x, EVP_PKEY *pkey);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4208,3 +4208,4 @@ OCSP_RESPID_set_by_key                  4158	1_1_0a	EXIST::FUNCTION:OCSP
 OCSP_RESPID_match                       4159	1_1_0a	EXIST::FUNCTION:OCSP
 ASN1_ITEM_lookup                        4160	1_1_1	EXIST::FUNCTION:
 ASN1_ITEM_get                           4161	1_1_1	EXIST::FUNCTION:
+X509_REQ_set0_signature                 4162	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Overrides  the subject from the request. 

Much in line with the functionality found in req(1) and ca(1). Useful when dealing with IoT and ILO devices that are unaware of IPv6/IPv4 and other name mappings and hence generate a
somewhat odd request.

Also makes the error message of parse_name (used by req, CA et.al.) a bit easier to understand.
