### PR TITLE
Fix leak of secrecy in ecdh_compute_key()

### DIFF
--- a/crypto/ecdh/ech_ossl.c
+++ b/crypto/ecdh/ech_ossl.c
@@ -212,7 +212,9 @@ static int ecdh_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
         BN_CTX_end(ctx);
     if (ctx)
         BN_CTX_free(ctx);
-    if (buf)
+    if (buf) {
+        OPENSSL_cleanse(buf, buflen);
         OPENSSL_free(buf);
+    }
     return (ret);
 }


### PR DESCRIPTION
Our test framework scans the process memory of our product for unerased key material.
This test detected large fragments of the (intermediate) shared Diffie-Hellman secret
after the completion of the key exchange, although the secret had already been wiped
by our program.

I was able to track down the leak and verify that it was caused by a temporary buffer in
ecdh_compute_key(). The buffer was not wiped on exit and partially overwritten afterwards.

This patch adds an OPENSSL_cleanse() call to wipe the buffer.

(This problem does not affect master, since ECDH_compute_key() has been reworked since
and a lot of attention has been payed to securely erase intermediate results.)
