### PR TITLE
Fix config option 'no-deprecated'

### DIFF
--- a/crypto/asn1/asn1_item_list.c
+++ b/crypto/asn1/asn1_item_list.c
@@ -12,9 +12,11 @@
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/cms.h>
+#include <openssl/dh.h>
 #include <openssl/ocsp.h>
 #include <openssl/pkcs7.h>
 #include <openssl/pkcs12.h>
+#include <openssl/rsa.h>
 #include <openssl/x509v3.h>
 
 #include "asn1_item_list.h"


### PR DESCRIPTION
crypto/asn1/asn1_item_list.c needed including dh.h and rsa.h directly.
The reason is that they are not included by x509.h when configured
'no-deprecated'