### PR TITLE
Print the X509 version signed, and convert to unsgined for the hex vesion

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -71,8 +71,13 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
     }
     if (!(cflag & X509_FLAG_NO_VERSION)) {
         l = X509_get_version(x);
-        if (BIO_printf(bp, "%8sVersion: %lu (0x%lx)\n", "", l + 1, l) <= 0)
-            goto err;
+        if (l >= 0 && l <= 2) {
+            if (BIO_printf(bp, "%8sVersion: %ld (0x%lx)\n", "", l + 1, (unsigned long)l) <= 0)
+                goto err;
+        } else {
+            if (BIO_printf(bp, "%8sVersion: Unknown (%ld)\n", "", l) <= 0)
+                goto err;
+        }
     }
     if (!(cflag & X509_FLAG_NO_SERIAL)) {
 


### PR DESCRIPTION
Not sure if I need to add 1 for the negative number.

It can be be reproduces using fuzz/corpora/x509/bda67e7c9c61bd575005afe4d723783a9fbf9e73
