### PR TITLE
Make OPENSSL_assert debugger friendly

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -84,9 +84,9 @@ void OPENSSL_cpuid_setup(void)
 }
 #endif
 
+#include <signal.h>
 #if defined(_WIN32) && !defined(__CYGWIN__)
 # include <tchar.h>
-# include <signal.h>
 # ifdef __WATCOMC__
 #  if defined(_UNICODE) || defined(__UNICODE__)
 #   define _vsntprintf _vsnwprintf
@@ -303,6 +303,20 @@ void OPENSSL_die(const char *message, const char *file, int line)
     raise(SIGABRT);
 # endif
     _exit(3);
+#endif
+}
+
+void OPENSSL_trap(const char *message, const char *file, int line)
+{
+    OPENSSL_showfatal("%s:%d: OpenSSL trap: %s\n", file, line, message);
+#ifdef _MSC_VER
+    /* __debugbreak() is a compiler intrinsic, DebugBreak() is a function
+     * that essentially calles __debugbreak().  We might as well use the
+     * intrinsic directly.
+     */
+    __debugbreak();
+#else
+    raise(SIGTRAP);
 #endif
 }
 

--- a/e_os.h
+++ b/e_os.h
@@ -31,7 +31,7 @@ extern "C" {
 
 # if !defined(NDEBUG) && !defined(OPENSSL_NO_STDIO)
 #  define REF_ASSERT_ISNT(test) \
-    (void)((test) ? (OPENSSL_die("refcount error", __FILE__, __LINE__), 1) : 0)
+    (void)((test) ? (OPENSSL_trap("refcount error", __FILE__, __LINE__), 1) : 0)
 # else
 #  define REF_ASSERT_ISNT(i)
 # endif

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -321,11 +321,12 @@ int CRYPTO_mem_leaks(BIO *bio);
 
 /* die if we have to */
 ossl_noreturn void OPENSSL_die(const char *assertion, const char *file, int line);
+void OPENSSL_trap(const char *assertion, const char *file, int line);
 # if OPENSSL_API_COMPAT < 0x10100000L
 #  define OpenSSLDie(f,l,a) OPENSSL_die((a),(f),(l))
 # endif
 # define OPENSSL_assert(e) \
-    (void)((e) ? 0 : (OPENSSL_die("assertion failed: " #e, OPENSSL_FILE, OPENSSL_LINE), 1))
+    (void)((e) ? 0 : (OPENSSL_trap("assertion failed: " #e, OPENSSL_FILE, OPENSSL_LINE), 1))
 
 int OPENSSL_isservice(void);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4208,3 +4208,4 @@ OCSP_RESPID_set_by_key                  4158	1_1_0a	EXIST::FUNCTION:OCSP
 OCSP_RESPID_match                       4159	1_1_0a	EXIST::FUNCTION:OCSP
 ASN1_ITEM_lookup                        4160	1_1_1	EXIST::FUNCTION:
 ASN1_ITEM_get                           4161	1_1_1	EXIST::FUNCTION:
+OPENSSL_trap                            4162	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
OPENSSL_assert(), just like assert(), would simply abort when the
assertion failed.  This isn't very friendly to those who want to run
with a debugger and be able to easily check the conditions around the
failed assertion, since abort() and friends simply terminate the
program.

This implements a new function OPENSSL_trap(), which is somewhat like
OPENSSL_die() but signals a debug break (SIGTRAP on Unix family
platforms) instead of aborting, and has OPENSSL_assert use it rather
than OPENSSL_die().
