### PR TITLE
Fix support for DragonFly BSD (follow-up from Issue #1546)

### DIFF
--- a/config
+++ b/config
@@ -187,6 +187,10 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
         echo "${MACH}-${ARCH}-freebsd${VERS}"; exit 0
         ;;
 
+    DragonFly:*)
+	echo "${MACHINE}-whatever-dragonfly"; exit 0
+	;;
+
     FreeBSD:*)
 	echo "${MACHINE}-whatever-freebsd"; exit 0
 	;;
@@ -697,6 +701,7 @@ case "$GUESSOS" in
   powerpc64-*-*bsd*)	OUT="BSD-generic64"; options="$options -DB_ENDIAN" ;;
   sparc64-*-*bsd*)	OUT="BSD-sparc64" ;;
   ia64-*-*bsd*)		OUT="BSD-ia64" ;;
+  x86_64-*-dragonfly*)  OUT="BSD-x86_64" ;;
   amd64-*-*bsd*)	OUT="BSD-x86_64" ;;
   *86*-*-*bsd*)		# mimic ld behaviour when it's looking for libc...
 			if [ -L /usr/lib/libc.so ]; then	# [Free|Net]BSD

--- a/crypto/engine/eng_all.c
+++ b/crypto/engine/eng_all.c
@@ -18,7 +18,7 @@ void ENGINE_load_builtin_engines(void)
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
 }
 
-#if (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV)) && !defined(OPENSSL_NO_DEPRECATED)
+#if (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(HAVE_CRYPTODEV)) && !defined(OPENSSL_NO_DEPRECATED)
 void ENGINE_setup_bsd_cryptodev(void)
 {
     static int bsd_cryptodev_default_loaded = 0;

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -42,9 +42,9 @@
 #include <openssl/crypto.h>
 
 #if (defined(__unix__) || defined(unix)) && !defined(USG) && \
-        (defined(OpenBSD) || defined(__FreeBSD__))
+        (defined(OpenBSD) || defined(__FreeBSD__) || defined(__DragonFly__))
 # include <sys/param.h>
-# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || __FreeBSD_version >= 500041)
+# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || __FreeBSD_version >= 500041) || defined(__DragonFly__)
 #  define HAVE_CRYPTODEV
 # endif
 # if (OpenBSD >= 200110)

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -198,7 +198,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
     return 1;
 }
 # if !defined(OPENSSL_NO_HW) && \
-    (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV))
+    (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(HAVE_CRYPTODEV))
 static CRYPTO_ONCE engine_cryptodev = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(ossl_init_engine_cryptodev)
 {
@@ -525,7 +525,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             && !RUN_ONCE(&engine_openssl, ossl_init_engine_openssl))
         return 0;
 # if !defined(OPENSSL_NO_HW) && \
-    (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV))
+    (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(HAVE_CRYPTODEV))
     if ((opts & OPENSSL_INIT_ENGINE_CRYPTODEV)
             && !RUN_ONCE(&engine_cryptodev, ossl_init_engine_cryptodev))
         return 0;

--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -10,7 +10,7 @@
 #include <openssl/crypto.h>
 #include <openssl/opensslconf.h>
 
-#if defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2)
+#if defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__)
 
 # include OPENSSL_UNISTD
 

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -745,7 +745,7 @@ typedef int (*dynamic_bind_engine) (ENGINE *e, const char *id,
  */
 void *ENGINE_get_static_state(void);
 
-# if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(HAVE_CRYPTODEV)
+# if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(HAVE_CRYPTODEV)
 DEPRECATEDIN_1_1_0(void ENGINE_setup_bsd_cryptodev(void))
 # endif
 


### PR DESCRIPTION
The `__DragonFly__` macros were introduced in issue #1546 along with a
function naming fix, but it was decided they should be handled
separately.