### PR TITLE
On shared library names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -406,6 +406,12 @@
      template in Configurations, like unix-Makefile.tmpl or
      descrip.mms.tmpl.
 
+     With this change, the library names were also renamed on Windows
+     and on VMS.  They now have names that are closer to the standard
+     on Unix, and include the major version number, and in certain
+     cases, the architecture they are built for.  See "Notes on shared
+     libraries" in INSTALL.
+
      We rely heavily on the perl module Text::Template.
      [Richard Levitte]
 

--- a/INSTALL
+++ b/INSTALL
@@ -947,7 +947,7 @@
  where OpenSSL does not know how to build shared libraries the "no-shared"
  option will be forced and only static libraries will be created.
 
- Shared libraries are named a little different on different platforms.
+ Shared libraries are named a little differently on different platforms.
  One way or another, they all have the major OpenSSL version number as
  part of the file name, i.e. for OpenSSL 1.1.x, 1.1 is somehow part of
  the name.

--- a/INSTALL
+++ b/INSTALL
@@ -937,8 +937,8 @@
  supported. If your platform does not provide pthreads or Windows threads then
  you should Configure with the "no-threads" option.
 
- Note on shared libraries
- ------------------------
+ Notes on shared libraries
+ -------------------------
 
  For most systems the OpenSSL Configure script knows what is needed to
  build shared libraries for libcrypto and libssl. On these systems
@@ -946,6 +946,31 @@
  only static libraries created by using the "no-shared" option. On systems
  where OpenSSL does not know how to build shared libraries the "no-shared"
  option will be forced and only static libraries will be created.
+
+ Shared libraries are named a little different on different platforms.
+ One way or another, they all have the major OpenSSL version number as
+ part of the file name, i.e. for OpenSSL 1.1.x, 1.1 is somehow part of
+ the name.
+
+ On most POSIXly platforms, shared libraries are named libcrypto.so.1.1
+ and libssl.so.1.1.
+
+ on Cygwin, shared libraries are named cygcrypto-1.1.dll and cygssl-1.1.dll
+ with import libraries libcrypto.dll.a and libssl.dll.a.
+
+ On Windows build with MSVC or using MingW, shared libraries are named
+ libcrypto-1_1.dll and libssl-1_1.dll for 32-bit Windows, libcrypto-1_1-x64.dll
+ and libssl-1_1-x64.dll for 64-bit x86_64 Windows, and libcrypto-1_1-ia64.dll
+ and libssl-1_1-ia64.dll for IA64 Windows.  With MSVC, the import libraries
+ are named libcrypto.lib and libssl.lib, while with MingW, they are named
+ libcrypto.dll.a and libddl.dll.a.
+
+ On VMS, shareable images (VMS speak for shared libraries) are named
+ ossl$libcrypto0101_shr.exe and ossl$libssl0101_shr.exe.  However, when
+ OpenSSL is specifically built for 32-bit pointers, the shareable images
+ are named ossl$libcrypto0101_shr32.exe and ossl$libssl0101_shr32.exe
+ instead, and when built for 64-bit pointers, they are named
+ ossl$libcrypto0101_shr64.exe and ossl$libssl0101_shr64.exe.
 
  Note on random number generation
  --------------------------------


### PR DESCRIPTION
@kaduk informed me that there was no information on the new DLL names on Windows...  and except for the git log, he's absolutely correct.  This adds the information in `INSTALL` and adds a not to this effect in the entry in `CHANGES` that announces the unified build, 'cause that's where this should have been notified from the start.
