### PR TITLE
Correctly find all critical CRL extensions

### DIFF
--- a/crypto/asn1/x_crl.c
+++ b/crypto/asn1/x_crl.c
@@ -254,6 +254,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 
         for (idx = 0; idx < sk_X509_EXTENSION_num(exts); idx++) {
             int nid;
+
             ext = sk_X509_EXTENSION_value(exts, idx);
             nid = OBJ_obj2nid(ext->object);
             if (nid == NID_freshest_crl)
@@ -263,7 +264,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                 if ((nid == NID_issuing_distribution_point)
                     || (nid == NID_authority_key_identifier)
                     || (nid == NID_delta_crl))
-                    break;;
+                    continue;
                 crl->flags |= EXFLAG_CRITICAL;
                 break;
             }


### PR DESCRIPTION
Unhandled critical CRL extensions were not detected if they appeared
after the handled ones.  (GitHub issue 1757).  Thanks to John Chuah
for reporting this.