### PR TITLE
Use default ZLIB1 on Windows

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -80,10 +80,11 @@
             sub {
                 unless ($disabled{zlib}) {
                     if (defined($disabled{"zlib-dynamic"})) {
-                        return $withargs{zlib_lib};
+                        return $withargs{zlib_lib} // "ZLIB1";
                     }
                 }
-                return (); },
+                return ();
+            },
 
         ld              => "link",
         lflags          => "/nologo",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1276,9 +1276,11 @@ sub vms_info {
         cflags           => "-W3 -wd4090 -Gs0 -GF -Gy -nologo -DOPENSSL_SYS_WIN32 -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -D_CRT_SECURE_NO_DEPRECATE",
         defines          => add(sub { my @defs = ();
                                       unless ($disabled{"zlib-dynamic"}) {
+                                          my $zlib =
+                                              $withargs{zlib_lib} // "ZLIB1";
                                           push @defs,
                                               quotify("perl",
-                                                      'LIBZ="' . $withargs{zlib_lib} . '"');
+                                                      'LIBZ="' . $zlib . '"');
                                       }
                                       return [ @defs ];
                                     }),


### PR DESCRIPTION
The treatment of `--with-zlib-lib` was a bit sloppy, if it wasn't given, the VC build ended up with the macro `LIBZ` being set to the empty string.  In all cases where this might be an issue, make sure that the default `ZLIB1` is used explicitely.

Fixes #1772
