### PR TITLE
Improved cryptodev support

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -184,7 +184,6 @@ static struct {
     {
         CRYPTO_AES_CBC, NID_aes_256_cbc, 16, 32,
     },
-# ifdef CRYPTO_AES_CTR
     {
         CRYPTO_AES_CTR, NID_aes_128_ctr, 14, 16,
     },
@@ -194,7 +193,6 @@ static struct {
     {
         CRYPTO_AES_CTR, NID_aes_256_ctr, 14, 32,
     },
-# endif
     {
         CRYPTO_BLF_CBC, NID_bf_cbc, 8, 16,
     },
@@ -812,7 +810,6 @@ static const EVP_CIPHER *cryptodev_aes_256_cbc(void)
     return aes_256_cbc_cipher;
 }
 
-# ifdef CRYPTO_AES_CTR
 static EVP_CIPHER *aes_ctr_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_ctr(void)
 {
@@ -912,7 +909,6 @@ static const EVP_CIPHER *cryptodev_aes_ecb(void)
         }
         aes_ecb_cipher = cipher;
     }
-# endif
     return aes_ecb_cipher;
 }
 
@@ -1010,7 +1006,6 @@ cryptodev_engine_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
     case NID_aes_256_cbc:
         *cipher = cryptodev_aes_256_cbc();
         break;
-# ifdef CRYPTO_AES_CTR
     case NID_aes_128_ctr:
         *cipher = cryptodev_aes_ctr();
         break;
@@ -1029,7 +1024,6 @@ cryptodev_engine_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
     case NID_aes_256_ecb:
         *cipher = cryptodev_aes_256_ecb();
         break;
-# endif
     default:
         *cipher = NULL;
         break;
@@ -1447,7 +1441,6 @@ static int cryptodev_engine_destroy(ENGINE *e)
     aes_192_cbc_cipher = NULL;
     EVP_CIPHER_meth_free(aes_256_cbc_cipher);
     aes_256_cbc_cipher = NULL;
-# ifdef CRYPTO_AES_CTR
     EVP_CIPHER_meth_free(aes_ctr_cipher);
     aes_ctr_cipher = NULL;
     EVP_CIPHER_meth_free(aes_192_ctr_cipher);
@@ -1460,7 +1453,6 @@ static int cryptodev_engine_destroy(ENGINE *e)
     aes_192_ecb_cipher = NULL;
     EVP_CIPHER_meth_free(aes_256_ecb_cipher);
     aes_256_ecb_cipher = NULL;
-# endif
 # ifdef USE_CRYPTODEV_DIGESTS
     EVP_MD_meth_free(sha1_md);
     sha1_md = NULL;

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -534,12 +534,13 @@ static int cryptodev_cleanup(EVP_CIPHER_CTX *ctx)
 
 static int cryptodev_cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void *p2)
 {
-    struct dev_crypto_state *state = ctx->cipher_data;
+    struct dev_crypto_state *state = EVP_CIPHER_CTX_get_cipher_data(ctx);
     struct session_op *sess = &state->d_sess;
 
     if (type == EVP_CTRL_COPY) {
         EVP_CIPHER_CTX *out = p2;
-        return cryptodev_init_key(out, sess->key, ctx->iv, 0);
+        return cryptodev_init_key(out, (unsigned char *)sess->key,
+                                 EVP_CIPHER_CTX_iv(ctx), 0);
     }
 
     return 0;

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -191,11 +191,6 @@ static struct {
     int nid;
     int digestlen;
 } digests[] = {
-#  if 0
-        /* HMAC is not supported */
-    {CRYPTO_MD5_HMAC, NID_hmacWithMD5, 16},
-    {CRYPTO_SHA1_HMAC, NID_hmacWithSHA1, 20},
-#  endif
     {CRYPTO_MD5, NID_md5, 16},
     {CRYPTO_SHA1, NID_sha1, 20},
     {CRYPTO_SHA2_256, NID_sha256, 32},

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -204,9 +204,11 @@ static struct {
     {
         CRYPTO_SKIPJACK_CBC, NID_undef, 0, 0,
     },
-    {
-        0, NID_undef, 0, 0,
-    },
+    {CRYPTO_3DES_ECB, NID_des_ede3_ecb, 0, 24},
+    {CRYPTO_AES_ECB, NID_aes_128_ecb, 0, 16},
+    {CRYPTO_AES_ECB, NID_aes_192_ecb, 0, 24},
+    {CRYPTO_AES_ECB, NID_aes_256_ecb, 0, 32},
+    {0, NID_undef, 0, 0},
 };
 
 # ifdef USE_CRYPTODEV_DIGESTS
@@ -661,6 +663,30 @@ static const EVP_CIPHER *cryptodev_3des_cbc(void)
     return des3_cbc_cipher;
 }
 
+/* 3DES ECB EVP */
+static EVP_CIPHER *des3_ecb_cipher = NULL;
+static const EVP_CIPHER *cryptodev_3des_ecb(void)
+{
+    if (des3_ecb_cipher == NULL) {
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_des_ede3_ecb, 8, 24);
+
+        if (cipher == NULL
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_ECB_MODE)
+            || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
+            || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
+            || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))) {
+            EVP_CIPHER_meth_free(cipher);
+            cipher = NULL;
+        }
+        des3_ecb_cipher = cipher;
+    }
+    return des3_ecb_cipher;
+}
+
 static EVP_CIPHER *bf_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_bf_cbc(void)
 {
@@ -861,7 +887,89 @@ static const EVP_CIPHER *cryptodev_aes_256_ctr(void)
     }
     return aes_256_ctr_cipher;
 }
+
+static EVP_CIPHER *aes_ecb_cipher = NULL;
+static const EVP_CIPHER *cryptodev_aes_ecb(void)
+{
+    if (aes_ecb_cipher == NULL) {
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_128_ecb, 16, 16);
+
+        if (cipher == NULL
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_ECB_MODE)
+            || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
+            || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
+            || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
+            EVP_CIPHER_meth_free(cipher);
+            cipher = NULL;
+        }
+        aes_ecb_cipher = cipher;
+    }
 # endif
+    return aes_ecb_cipher;
+}
+
+static EVP_CIPHER *aes_192_ecb_cipher = NULL;
+static const EVP_CIPHER *cryptodev_aes_192_ecb(void)
+{
+    if (aes_192_ecb_cipher == NULL) {
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_192_ecb, 16, 24);
+
+        if (cipher == NULL
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_ECB_MODE)
+            || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
+            || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
+            || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
+            EVP_CIPHER_meth_free(cipher);
+            cipher = NULL;
+        }
+        aes_192_ecb_cipher = cipher;
+    }
+    return aes_192_ecb_cipher;
+}
+
+static EVP_CIPHER *aes_256_ecb_cipher = NULL;
+static const EVP_CIPHER *cryptodev_aes_256_ecb(void)
+{
+    if (aes_256_ecb_cipher == NULL) {
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_256_ecb, 16, 32);
+
+        if (cipher == NULL
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_ECB_MODE)
+            || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
+            || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
+            || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
+            EVP_CIPHER_meth_free(cipher);
+            cipher = NULL;
+        }
+        aes_256_ecb_cipher = cipher;
+    }
+    return aes_256_ecb_cipher;
+}
+
 /*
  * Registered by the ENGINE when used to find out how to deal with
  * a particular NID in the ENGINE. this says what we'll do at the
@@ -880,6 +988,9 @@ cryptodev_engine_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
         break;
     case NID_des_ede3_cbc:
         *cipher = cryptodev_3des_cbc();
+        break;
+    case NID_des_ede3_ecb:
+        *cipher = cryptodev_3des_ecb();
         break;
     case NID_des_cbc:
         *cipher = cryptodev_des_cbc();
@@ -908,6 +1019,15 @@ cryptodev_engine_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
         break;
     case NID_aes_256_ctr:
         *cipher = cryptodev_aes_256_ctr();
+        break;
+    case NID_aes_128_ecb:
+        *cipher = cryptodev_aes_ecb();
+        break;
+    case NID_aes_192_ecb:
+        *cipher = cryptodev_aes_192_ecb();
+        break;
+    case NID_aes_256_ecb:
+        *cipher = cryptodev_aes_256_ecb();
         break;
 # endif
     default:
@@ -1315,6 +1435,8 @@ static int cryptodev_engine_destroy(ENGINE *e)
     des_cbc_cipher = NULL;
     EVP_CIPHER_meth_free(des3_cbc_cipher);
     des3_cbc_cipher = NULL;
+    EVP_CIPHER_meth_free(des3_ecb_cipher);
+    des3_ecb_cipher = NULL;
     EVP_CIPHER_meth_free(bf_cbc_cipher);
     bf_cbc_cipher = NULL;
     EVP_CIPHER_meth_free(cast_cbc_cipher);
@@ -1332,6 +1454,12 @@ static int cryptodev_engine_destroy(ENGINE *e)
     aes_192_ctr_cipher = NULL;
     EVP_CIPHER_meth_free(aes_256_ctr_cipher);
     aes_256_ctr_cipher = NULL;
+    EVP_CIPHER_meth_free(aes_ecb_cipher);
+    aes_ecb_cipher = NULL;
+    EVP_CIPHER_meth_free(aes_192_ecb_cipher);
+    aes_192_ecb_cipher = NULL;
+    EVP_CIPHER_meth_free(aes_256_ecb_cipher);
+    aes_256_ecb_cipher = NULL;
 # endif
 # ifdef USE_CRYPTODEV_DIGESTS
     EVP_MD_meth_free(sha1_md);

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -81,6 +81,14 @@ void engine_load_cryptodev_int(void)
 
 #else
 
+/* Available on cryptodev-linux but not on FreeBSD 8.4 */
+# ifndef CRYPTO_HMAC_MAX_KEY_LEN
+#  define CRYPTO_HMAC_MAX_KEY_LEN 512
+# endif
+# ifndef CRYPTO_CIPHER_MAX_KEY_LEN
+#  define CRYPTO_CIPHER_MAX_KEY_LEN 64
+# endif
+
 struct dev_crypto_state {
     struct session_op d_sess;
     int d_fd;
@@ -169,16 +177,22 @@ static struct {
     {CRYPTO_ARC4, NID_rc4, 0, 16},
     {CRYPTO_DES_CBC, NID_des_cbc, 8, 8},
     {CRYPTO_3DES_CBC, NID_des_ede3_cbc, 8, 24},
+# if !defined(CRYPTO_ALGORITHM_MIN) || defined(CRYPTO_3DES_ECB)
     {CRYPTO_3DES_ECB, NID_des_ede3_ecb, 0, 24},
+# endif
     {CRYPTO_AES_CBC, NID_aes_128_cbc, 16, 16},
     {CRYPTO_AES_CBC, NID_aes_192_cbc, 16, 24},
     {CRYPTO_AES_CBC, NID_aes_256_cbc, 16, 32},
+# if !defined(CRYPTO_ALGORITHM_MIN) || defined(CRYPTO_AES_CTR)
     {CRYPTO_AES_CTR, NID_aes_128_ctr, 14, 16},
     {CRYPTO_AES_CTR, NID_aes_192_ctr, 14, 24},
     {CRYPTO_AES_CTR, NID_aes_256_ctr, 14, 32},
+# endif
+# if !defined(CRYPTO_ALGORITHM_MIN) || defined(CRYPTO_AES_ECB)
     {CRYPTO_AES_ECB, NID_aes_128_ecb, 0, 16},
     {CRYPTO_AES_ECB, NID_aes_192_ecb, 0, 24},
     {CRYPTO_AES_ECB, NID_aes_256_ecb, 0, 32},
+# endif
     {CRYPTO_BLF_CBC, NID_bf_cbc, 8, 16},
     {CRYPTO_CAST_CBC, NID_cast5_cbc, 8, 16},
     {CRYPTO_SKIPJACK_CBC, NID_undef, 0, 0},

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2002 Bob Beck <beck@openbsd.org>
  * Copyright (c) 2002 Theo de Raadt
  * Copyright (c) 2002 Markus Friedl
+ * Copyright (c) 2012 Nikos Mavrogiannopoulos
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,7 +85,6 @@ struct dev_crypto_state {
     struct session_op d_sess;
     int d_fd;
 # ifdef USE_CRYPTODEV_DIGESTS
-    char dummy_mac_key[HASH_MAX_LEN];
     unsigned char digest_res[HASH_MAX_LEN];
     char *mac_data;
     int mac_len;
@@ -94,12 +94,12 @@ struct dev_crypto_state {
 static u_int32_t cryptodev_asymfeat = 0;
 
 static RSA_METHOD *cryptodev_rsa;
-#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_DSA
 static DSA_METHOD *cryptodev_dsa = NULL;
-#endif
-#ifndef OPENSSL_NO_DH
+# endif
+# ifndef OPENSSL_NO_DH
 static DH_METHOD *cryptodev_dh;
-#endif
+# endif
 
 static int get_asym_dev_crypto(void);
 static int open_dev_crypto(void);
@@ -132,7 +132,7 @@ static int cryptodev_rsa_nocrt_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa,
                                        BN_CTX *ctx);
 static int cryptodev_rsa_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa,
                                  BN_CTX *ctx);
-#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_DSA
 static int cryptodev_dsa_bn_mod_exp(DSA *dsa, BIGNUM *r, const BIGNUM *a,
                                     const BIGNUM *p, const BIGNUM *m,
                                     BN_CTX *ctx, BN_MONT_CTX *m_ctx);
@@ -144,14 +144,14 @@ static DSA_SIG *cryptodev_dsa_do_sign(const unsigned char *dgst, int dlen,
                                       DSA *dsa);
 static int cryptodev_dsa_verify(const unsigned char *dgst, int dgst_len,
                                 DSA_SIG *sig, DSA *dsa);
-#endif
-#ifndef OPENSSL_NO_DH
+# endif
+# ifndef OPENSSL_NO_DH
 static int cryptodev_mod_exp_dh(const DH *dh, BIGNUM *r, const BIGNUM *a,
                                 const BIGNUM *p, const BIGNUM *m, BN_CTX *ctx,
                                 BN_MONT_CTX *m_ctx);
 static int cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key,
                                     DH *dh);
-#endif
+# endif
 static int cryptodev_ctrl(ENGINE *e, int cmd, long i, void *p,
                           void (*f) (void));
 void engine_load_cryptodev_int(void);
@@ -213,8 +213,10 @@ static struct {
 static struct {
     int id;
     int nid;
-    int keylen;
+    int  digestlen;
 } digests[] = {
+#  if 0
+    /* HMAC is not supported */
     {
         CRYPTO_MD5_HMAC, NID_hmacWithMD5, 16
     },
@@ -222,20 +224,29 @@ static struct {
         CRYPTO_SHA1_HMAC, NID_hmacWithSHA1, 20
     },
     {
-        CRYPTO_RIPEMD160_HMAC, NID_ripemd160, 16
-        /* ? */
+        CRYPTO_SHA2_256_HMAC, NID_hmacWithSHA256, 32
     },
     {
-        CRYPTO_MD5_KPDK, NID_undef, 0
+        CRYPTO_SHA2_384_HMAC, NID_hmacWithSHA384, 48
     },
     {
-        CRYPTO_SHA1_KPDK, NID_undef, 0
+        CRYPTO_SHA2_512_HMAC, NID_hmacWithSHA512, 64
     },
+#  endif
     {
         CRYPTO_MD5, NID_md5, 16
     },
     {
         CRYPTO_SHA1, NID_sha1, 20
+    },
+    {
+        CRYPTO_SHA2_256, NID_sha256, 32
+    },
+    {
+        CRYPTO_SHA2_384, NID_sha384, 48
+    },
+    {
+        CRYPTO_SHA2_512, NID_sha512, 64
     },
     {
         0, NID_undef, 0
@@ -312,13 +323,14 @@ static int get_cryptodev_ciphers(const int **cnids)
     static int nids[CRYPTO_ALGORITHM_MAX];
     struct session_op sess;
     int fd, i, count = 0;
+    unsigned char fake_key[CRYPTO_CIPHER_MAX_KEY_LEN];
 
     if ((fd = get_dev_crypto()) < 0) {
         *cnids = NULL;
         return (0);
     }
     memset(&sess, 0, sizeof(sess));
-    sess.key = (caddr_t) "123456789abcdefghijklmno";
+    sess.key = (void *)fake_key;
 
     for (i = 0; ciphers[i].id && count < CRYPTO_ALGORITHM_MAX; i++) {
         if (ciphers[i].nid == NID_undef)
@@ -349,6 +361,7 @@ static int get_cryptodev_ciphers(const int **cnids)
 static int get_cryptodev_digests(const int **cnids)
 {
     static int nids[CRYPTO_ALGORITHM_MAX];
+    unsigned char fake_key[CRYPTO_CIPHER_MAX_KEY_LEN];
     struct session_op sess;
     int fd, i, count = 0;
 
@@ -357,12 +370,12 @@ static int get_cryptodev_digests(const int **cnids)
         return (0);
     }
     memset(&sess, 0, sizeof(sess));
-    sess.mackey = (caddr_t) "123456789abcdefghijklmno";
+    sess.mackey = (void *)fake_key;
     for (i = 0; digests[i].id && count < CRYPTO_ALGORITHM_MAX; i++) {
         if (digests[i].nid == NID_undef)
             continue;
         sess.mac = digests[i].id;
-        sess.mackeylen = digests[i].keylen;
+        sess.mackeylen = digests[i].digestlen;
         sess.cipher = 0;
         if (ioctl(fd, CIOCGSESSION, &sess) != -1 &&
             ioctl(fd, CIOCFSESSION, &sess.ses) != -1)
@@ -448,14 +461,14 @@ cryptodev_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     cryp.ses = sess->ses;
     cryp.flags = 0;
     cryp.len = inl;
-    cryp.src = (caddr_t) in;
-    cryp.dst = (caddr_t) out;
+    cryp.src = (void *) in;
+    cryp.dst = (void *) out;
     cryp.mac = 0;
 
     cryp.op = EVP_CIPHER_CTX_encrypting(ctx) ? COP_ENCRYPT : COP_DECRYPT;
 
     if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
-        cryp.iv = (caddr_t) EVP_CIPHER_CTX_iv(ctx);
+        cryp.iv = (void *) EVP_CIPHER_CTX_iv(ctx);
         if (!EVP_CIPHER_CTX_encrypting(ctx)) {
             iiv = in + inl - EVP_CIPHER_CTX_iv_length(ctx);
             memcpy(save_iv, iiv, EVP_CIPHER_CTX_iv_length(ctx));
@@ -508,7 +521,7 @@ cryptodev_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if ((state->d_fd = get_dev_crypto()) < 0)
         return (0);
 
-    sess->key = (caddr_t) key;
+    sess->key = (void *) key;
     sess->keylen = EVP_CIPHER_CTX_key_length(ctx);
     sess->cipher = cipher;
 
@@ -882,16 +895,6 @@ static int digest_nid_to_cryptodev(int nid)
     return (0);
 }
 
-static int digest_key_length(int nid)
-{
-    int i;
-
-    for (i = 0; digests[i].id; i++)
-        if (digests[i].nid == nid)
-            return digests[i].keylen;
-    return (0);
-}
-
 static int cryptodev_digest_init(EVP_MD_CTX *ctx)
 {
     struct dev_crypto_state *state = EVP_MD_CTX_md_data(ctx);
@@ -910,8 +913,8 @@ static int cryptodev_digest_init(EVP_MD_CTX *ctx)
         return (0);
     }
 
-    sess->mackey = state->dummy_mac_key;
-    sess->mackeylen = digest_key_length(EVP_MD_CTX_type(ctx));
+    sess->mackey = NULL;
+    sess->mackeylen = 0;
     sess->mac = digest;
 
     if (ioctl(state->d_fd, CIOCGSESSION, sess) < 0) {
@@ -963,9 +966,9 @@ static int cryptodev_digest_update(EVP_MD_CTX *ctx, const void *data,
     cryp.ses = sess->ses;
     cryp.flags = 0;
     cryp.len = count;
-    cryp.src = (caddr_t) data;
+    cryp.src = (void *) data;
     cryp.dst = NULL;
-    cryp.mac = (caddr_t) state->digest_res;
+    cryp.mac = (void *) state->digest_res;
     if (ioctl(state->d_fd, CIOCCRYPT, &cryp) < 0) {
         printf("cryptodev_digest_update: digest failed\n");
         return (0);
@@ -994,7 +997,7 @@ static int cryptodev_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
         cryp.len = state->mac_len;
         cryp.src = state->mac_data;
         cryp.dst = NULL;
-        cryp.mac = (caddr_t) md;
+        cryp.mac = (void *) md;
         if (ioctl(state->d_fd, CIOCCRYPT, &cryp) < 0) {
             printf("cryptodev_digest_final: digest failed\n");
             return (0);
@@ -1054,8 +1057,8 @@ static int cryptodev_digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 
     digest = digest_nid_to_cryptodev(EVP_MD_CTX_type(to));
 
-    sess->mackey = dstate->dummy_mac_key;
-    sess->mackeylen = digest_key_length(EVP_MD_CTX_type(to));
+    sess->mackey = NULL;
+    sess->mackeylen = 0;
     sess->mac = digest;
 
     dstate->d_fd = get_dev_crypto();
@@ -1107,6 +1110,106 @@ static const EVP_MD *cryptodev_sha1(void)
     return sha1_md;
 }
 
+static EVP_MD *sha256_md = NULL;
+static const EVP_MD *cryptodev_sha256(void)
+{
+    if (sha256_md == NULL) {
+        EVP_MD *md;
+
+        if ((md = EVP_MD_meth_new(NID_sha256, NID_undef)) == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_app_datasize(md,
+                                             sizeof(struct dev_crypto_state))
+            || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
+            || !EVP_MD_meth_set_update(md, cryptodev_digest_update)
+            || !EVP_MD_meth_set_final(md, cryptodev_digest_final)
+            || !EVP_MD_meth_set_copy(md, cryptodev_digest_copy)
+            || !EVP_MD_meth_set_cleanup(md, cryptodev_digest_cleanup)) {
+            EVP_MD_meth_free(md);
+            md = NULL;
+        }
+        sha256_md = md;
+    }
+    return sha256_md;
+}
+
+static EVP_MD *sha224_md = NULL;
+static const EVP_MD *cryptodev_sha224(void)
+{
+    if (sha224_md == NULL) {
+        EVP_MD *md;
+
+        if ((md = EVP_MD_meth_new(NID_sha224, NID_undef)) == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_app_datasize(md,
+                                             sizeof(struct dev_crypto_state))
+            || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
+            || !EVP_MD_meth_set_update(md, cryptodev_digest_update)
+            || !EVP_MD_meth_set_final(md, cryptodev_digest_final)
+            || !EVP_MD_meth_set_copy(md, cryptodev_digest_copy)
+            || !EVP_MD_meth_set_cleanup(md, cryptodev_digest_cleanup)) {
+            EVP_MD_meth_free(md);
+            md = NULL;
+        }
+        sha224_md = md;
+    }
+    return sha224_md;
+}
+
+static EVP_MD *sha384_md = NULL;
+static const EVP_MD *cryptodev_sha384(void)
+{
+    if (sha384_md == NULL) {
+        EVP_MD *md;
+
+        if ((md = EVP_MD_meth_new(NID_sha384, NID_undef)) == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_app_datasize(md,
+                                             sizeof(struct dev_crypto_state))
+            || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
+            || !EVP_MD_meth_set_update(md, cryptodev_digest_update)
+            || !EVP_MD_meth_set_final(md, cryptodev_digest_final)
+            || !EVP_MD_meth_set_copy(md, cryptodev_digest_copy)
+            || !EVP_MD_meth_set_cleanup(md, cryptodev_digest_cleanup)) {
+            EVP_MD_meth_free(md);
+            md = NULL;
+        }
+        sha384_md = md;
+    }
+    return sha384_md;
+}
+
+static EVP_MD *sha512_md = NULL;
+static const EVP_MD *cryptodev_sha512(void)
+{
+    if (sha512_md == NULL) {
+        EVP_MD *md;
+
+        if ((md = EVP_MD_meth_new(NID_sha512, NID_undef)) == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_app_datasize(md,
+                                             sizeof(struct dev_crypto_state))
+            || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
+            || !EVP_MD_meth_set_update(md, cryptodev_digest_update)
+            || !EVP_MD_meth_set_final(md, cryptodev_digest_final)
+            || !EVP_MD_meth_set_copy(md, cryptodev_digest_copy)
+            || !EVP_MD_meth_set_cleanup(md, cryptodev_digest_cleanup)) {
+            EVP_MD_meth_free(md);
+            md = NULL;
+        }
+        sha512_md = md;
+    }
+    return sha512_md;
+}
+
 static EVP_MD *md5_md = NULL;
 static const EVP_MD *cryptodev_md5(void)
 {
@@ -1149,6 +1252,18 @@ cryptodev_engine_digests(ENGINE *e, const EVP_MD **digest,
     case NID_sha1:
         *digest = cryptodev_sha1();
         break;
+    case NID_sha256:
+        *digest = cryptodev_sha256();
+        break;
+    case NID_sha224:
+        *digest = cryptodev_sha224();
+        break;
+    case NID_sha384:
+        *digest = cryptodev_sha384();
+        break;
+    case NID_sha512:
+        *digest = cryptodev_sha512();
+        break;
     default:
 # endif                         /* USE_CRYPTODEV_DIGESTS */
         *digest = NULL;
@@ -1186,19 +1301,27 @@ static int cryptodev_engine_destroy(ENGINE *e)
 # ifdef USE_CRYPTODEV_DIGESTS
     EVP_MD_meth_free(sha1_md);
     sha1_md = NULL;
+    EVP_MD_meth_free(sha256_md);
+    sha256_md = NULL;
+    EVP_MD_meth_free(sha224_md);
+    sha224_md = NULL;
+    EVP_MD_meth_free(sha384_md);
+    sha384_md = NULL;
+    EVP_MD_meth_free(sha512_md);
+    sha512_md = NULL;
     EVP_MD_meth_free(md5_md);
     md5_md = NULL;
 # endif
     RSA_meth_free(cryptodev_rsa);
     cryptodev_rsa = NULL;
-#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_DSA
     DSA_meth_free(cryptodev_dsa);
     cryptodev_dsa = NULL;
-#endif
-#ifndef OPENSSL_NO_DH
+# endif
+# ifndef OPENSSL_NO_DH
     DH_meth_free(cryptodev_dh);
     cryptodev_dh = NULL;
-#endif
+# endif
     return 1;
 }
 
@@ -1222,7 +1345,7 @@ static int bn2crparam(const BIGNUM *a, struct crparam *crp)
     if (b == NULL)
         return (1);
 
-    crp->crp_p = (caddr_t) b;
+    crp->crp_p = (void *) b;
     crp->crp_nbits = bits;
 
     BN_bn2bin(a, b);
@@ -1418,7 +1541,7 @@ cryptodev_rsa_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
     return (ret);
 }
 
-#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_DSA
 static int
 cryptodev_dsa_bn_mod_exp(DSA *dsa, BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
                          const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *m_ctx)
@@ -1490,7 +1613,7 @@ static DSA_SIG *cryptodev_dsa_do_sign(const unsigned char *dgst, int dlen,
     kop.crk_op = CRK_DSA_SIGN;
 
     /* inputs: dgst dsa->p dsa->q dsa->g dsa->priv_key */
-    kop.crk_param[0].crp_p = (caddr_t) dgst;
+    kop.crk_param[0].crp_p = (void *) dgst;
     kop.crk_param[0].crp_nbits = dlen * 8;
     DSA_get0_pqg(dsa, &dsap, &dsaq, &dsag);
     DSA_get0_key(dsa, NULL, &priv_key);
@@ -1537,7 +1660,7 @@ cryptodev_dsa_verify(const unsigned char *dgst, int dlen,
     kop.crk_op = CRK_DSA_VERIFY;
 
     /* inputs: dgst dsa->p dsa->q dsa->g dsa->pub_key sig->r sig->s */
-    kop.crk_param[0].crp_p = (caddr_t) dgst;
+    kop.crk_param[0].crp_p = (void *) dgst;
     kop.crk_param[0].crp_nbits = dlen * 8;
     DSA_get0_pqg(dsa, &p, &q, &g);
     if (bn2crparam(p, &kop.crk_param[1]))
@@ -1570,9 +1693,9 @@ cryptodev_dsa_verify(const unsigned char *dgst, int dlen,
     zapparams(&kop);
     return (dsaret);
 }
-#endif
+# endif
 
-#ifndef OPENSSL_NO_DH
+# ifndef OPENSSL_NO_DH
 static int
 cryptodev_mod_exp_dh(const DH *dh, BIGNUM *r, const BIGNUM *a,
                      const BIGNUM *p, const BIGNUM *m, BN_CTX *ctx,
@@ -1613,7 +1736,7 @@ cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
         goto err;
     kop.crk_iparams = 3;
 
-    kop.crk_param[3].crp_p = (caddr_t) key;
+    kop.crk_param[3].crp_p = (void *) key;
     kop.crk_param[3].crp_nbits = keylen * 8;
     kop.crk_oparams = 1;
 
@@ -1628,7 +1751,7 @@ cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
     return (dhret);
 }
 
-#endif /* ndef OPENSSL_NO_DH */
+# endif /* ndef OPENSSL_NO_DH */
 
 /*
  * ctrl right now is just a wrapper that doesn't do much
@@ -1676,7 +1799,7 @@ void engine_load_cryptodev_int(void)
     put_dev_crypto(fd);
 
     if (!ENGINE_set_id(engine, "cryptodev") ||
-        !ENGINE_set_name(engine, "BSD cryptodev engine") ||
+        !ENGINE_set_name(engine, "cryptodev engine") ||
         !ENGINE_set_destroy_function(engine, cryptodev_engine_destroy) ||
         !ENGINE_set_ciphers(engine, cryptodev_engine_ciphers) ||
         !ENGINE_set_digests(engine, cryptodev_engine_digests) ||
@@ -1705,7 +1828,7 @@ void engine_load_cryptodev_int(void)
         return;
     }
 
-#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_DSA
     cryptodev_dsa = DSA_meth_dup(DSA_OpenSSL());
     if (cryptodev_dsa != NULL) {
         DSA_meth_set1_name(cryptodev_dsa, "cryptodev DSA method");
@@ -1725,9 +1848,9 @@ void engine_load_cryptodev_int(void)
         ENGINE_free(engine);
         return;
     }
-#endif
+# endif
 
-#ifndef OPENSSL_NO_DH
+# ifndef OPENSSL_NO_DH
     cryptodev_dh = DH_meth_dup(DH_OpenSSL());
     if (cryptodev_dh != NULL) {
         DH_meth_set1_name(cryptodev_dh, "cryptodev DH method");
@@ -1744,7 +1867,7 @@ void engine_load_cryptodev_int(void)
         ENGINE_free(engine);
         return;
     }
-#endif
+# endif
 
     ENGINE_add(engine);
     ENGINE_free(engine);

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -166,46 +166,22 @@ static struct {
     int ivmax;
     int keylen;
 } ciphers[] = {
-    {
-        CRYPTO_ARC4, NID_rc4, 0, 16,
-    },
-    {
-        CRYPTO_DES_CBC, NID_des_cbc, 8, 8,
-    },
-    {
-        CRYPTO_3DES_CBC, NID_des_ede3_cbc, 8, 24,
-    },
-    {
-        CRYPTO_AES_CBC, NID_aes_128_cbc, 16, 16,
-    },
-    {
-        CRYPTO_AES_CBC, NID_aes_192_cbc, 16, 24,
-    },
-    {
-        CRYPTO_AES_CBC, NID_aes_256_cbc, 16, 32,
-    },
-    {
-        CRYPTO_AES_CTR, NID_aes_128_ctr, 14, 16,
-    },
-    {
-        CRYPTO_AES_CTR, NID_aes_192_ctr, 14, 24,
-    },
-    {
-        CRYPTO_AES_CTR, NID_aes_256_ctr, 14, 32,
-    },
-    {
-        CRYPTO_BLF_CBC, NID_bf_cbc, 8, 16,
-    },
-    {
-        CRYPTO_CAST_CBC, NID_cast5_cbc, 8, 16,
-    },
-    {
-        CRYPTO_SKIPJACK_CBC, NID_undef, 0, 0,
-    },
+    {CRYPTO_ARC4, NID_rc4, 0, 16},
+    {CRYPTO_DES_CBC, NID_des_cbc, 8, 8},
+    {CRYPTO_3DES_CBC, NID_des_ede3_cbc, 8, 24},
     {CRYPTO_3DES_ECB, NID_des_ede3_ecb, 0, 24},
+    {CRYPTO_AES_CBC, NID_aes_128_cbc, 16, 16},
+    {CRYPTO_AES_CBC, NID_aes_192_cbc, 16, 24},
+    {CRYPTO_AES_CBC, NID_aes_256_cbc, 16, 32},
+    {CRYPTO_AES_CTR, NID_aes_128_ctr, 14, 16},
+    {CRYPTO_AES_CTR, NID_aes_192_ctr, 14, 24},
+    {CRYPTO_AES_CTR, NID_aes_256_ctr, 14, 32},
     {CRYPTO_AES_ECB, NID_aes_128_ecb, 0, 16},
     {CRYPTO_AES_ECB, NID_aes_192_ecb, 0, 24},
     {CRYPTO_AES_ECB, NID_aes_256_ecb, 0, 32},
+    {CRYPTO_BLF_CBC, NID_bf_cbc, 8, 16},
+    {CRYPTO_CAST_CBC, NID_cast5_cbc, 8, 16},
+    {CRYPTO_SKIPJACK_CBC, NID_undef, 0, 0},
     {0, NID_undef, 0, 0},
 };
 
@@ -213,44 +189,19 @@ static struct {
 static struct {
     int id;
     int nid;
-    int  digestlen;
+    int digestlen;
 } digests[] = {
 #  if 0
-    /* HMAC is not supported */
-    {
-        CRYPTO_MD5_HMAC, NID_hmacWithMD5, 16
-    },
-    {
-        CRYPTO_SHA1_HMAC, NID_hmacWithSHA1, 20
-    },
-    {
-        CRYPTO_SHA2_256_HMAC, NID_hmacWithSHA256, 32
-    },
-    {
-        CRYPTO_SHA2_384_HMAC, NID_hmacWithSHA384, 48
-    },
-    {
-        CRYPTO_SHA2_512_HMAC, NID_hmacWithSHA512, 64
-    },
+        /* HMAC is not supported */
+    {CRYPTO_MD5_HMAC, NID_hmacWithMD5, 16},
+    {CRYPTO_SHA1_HMAC, NID_hmacWithSHA1, 20},
 #  endif
-    {
-        CRYPTO_MD5, NID_md5, 16
-    },
-    {
-        CRYPTO_SHA1, NID_sha1, 20
-    },
-    {
-        CRYPTO_SHA2_256, NID_sha256, 32
-    },
-    {
-        CRYPTO_SHA2_384, NID_sha384, 48
-    },
-    {
-        CRYPTO_SHA2_512, NID_sha512, 64
-    },
-    {
-        0, NID_undef, 0
-    },
+    {CRYPTO_MD5, NID_md5, 16},
+    {CRYPTO_SHA1, NID_sha1, 20},
+    {CRYPTO_SHA2_256, NID_sha256, 32},
+    {CRYPTO_SHA2_384, NID_sha384, 48},
+    {CRYPTO_SHA2_512, NID_sha512, 64},
+    {0, NID_undef, 0},
 };
 # endif
 
@@ -370,12 +321,12 @@ static int get_cryptodev_digests(const int **cnids)
         return (0);
     }
     memset(&sess, 0, sizeof(sess));
-    sess.mackey = (void *)fake_key;
+    sess.mackey = fake_key;
     for (i = 0; digests[i].id && count < CRYPTO_ALGORITHM_MAX; i++) {
         if (digests[i].nid == NID_undef)
             continue;
         sess.mac = digests[i].id;
-        sess.mackeylen = digests[i].digestlen;
+        sess.mackeylen = 8;
         sess.cipher = 0;
         if (ioctl(fd, CIOCGSESSION, &sess) != -1 &&
             ioctl(fd, CIOCFSESSION, &sess.ses) != -1)
@@ -461,14 +412,14 @@ cryptodev_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     cryp.ses = sess->ses;
     cryp.flags = 0;
     cryp.len = inl;
-    cryp.src = (void *) in;
-    cryp.dst = (void *) out;
+    cryp.src = (void *)in;
+    cryp.dst = (void *)out;
     cryp.mac = 0;
 
     cryp.op = EVP_CIPHER_CTX_encrypting(ctx) ? COP_ENCRYPT : COP_DECRYPT;
 
     if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
-        cryp.iv = (void *) EVP_CIPHER_CTX_iv(ctx);
+        cryp.iv = (void *)EVP_CIPHER_CTX_iv(ctx);
         if (!EVP_CIPHER_CTX_encrypting(ctx)) {
             iiv = in + inl - EVP_CIPHER_CTX_iv_length(ctx);
             memcpy(save_iv, iiv, EVP_CIPHER_CTX_iv_length(ctx));
@@ -521,7 +472,7 @@ cryptodev_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if ((state->d_fd = get_dev_crypto()) < 0)
         return (0);
 
-    sess->key = (void *) key;
+    sess->key = (void *)key;
     sess->keylen = EVP_CIPHER_CTX_key_length(ctx);
     sess->cipher = cipher;
 
@@ -590,9 +541,9 @@ static EVP_CIPHER *rc4_cipher = NULL;
 static const EVP_CIPHER *cryptodev_rc4(void)
 {
     if (rc4_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_rc4, 1, 16);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_rc4, 1, 16)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 0)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_VARIABLE_LENGTH
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -600,7 +551,9 @@ static const EVP_CIPHER *cryptodev_rc4(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -614,9 +567,9 @@ static EVP_CIPHER *des_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_des_cbc(void)
 {
     if (des_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_des_cbc, 8, 8);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_des_cbc, 8, 8)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -624,9 +577,13 @@ static const EVP_CIPHER *cryptodev_des_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -640,9 +597,9 @@ static EVP_CIPHER *des3_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_3des_cbc(void)
 {
     if (des3_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_des_ede3_cbc, 8, 24);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_des_ede3_cbc, 8, 24)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -650,9 +607,13 @@ static const EVP_CIPHER *cryptodev_3des_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -689,9 +650,9 @@ static EVP_CIPHER *bf_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_bf_cbc(void)
 {
     if (bf_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_bf_cbc, 8, 16);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_bf_cbc, 8, 16)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -699,9 +660,13 @@ static const EVP_CIPHER *cryptodev_bf_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -714,9 +679,9 @@ static EVP_CIPHER *cast_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_cast_cbc(void)
 {
     if (cast_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_cast5_cbc, 8, 16);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_cast5_cbc, 8, 16)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -724,9 +689,13 @@ static const EVP_CIPHER *cryptodev_cast_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -739,9 +708,9 @@ static EVP_CIPHER *aes_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_cbc(void)
 {
     if (aes_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_128_cbc, 16, 16);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_aes_128_cbc, 16, 16)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 16)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -749,9 +718,13 @@ static const EVP_CIPHER *cryptodev_aes_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -764,9 +737,9 @@ static EVP_CIPHER *aes_192_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_192_cbc(void)
 {
     if (aes_192_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_192_cbc, 16, 24);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_aes_192_cbc, 16, 24)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 16)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -774,9 +747,13 @@ static const EVP_CIPHER *cryptodev_aes_192_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -789,9 +766,9 @@ static EVP_CIPHER *aes_256_cbc_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_256_cbc(void)
 {
     if (aes_256_cbc_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_256_cbc, 16, 32);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_aes_256_cbc, 16, 32)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 16)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -799,9 +776,13 @@ static const EVP_CIPHER *cryptodev_aes_256_cbc(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -814,9 +795,9 @@ static EVP_CIPHER *aes_ctr_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_ctr(void)
 {
     if (aes_ctr_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_128_ctr, 16, 16);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_aes_128_ctr, 16, 16)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 14)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -824,9 +805,13 @@ static const EVP_CIPHER *cryptodev_aes_ctr(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -839,9 +824,9 @@ static EVP_CIPHER *aes_192_ctr_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_192_ctr(void)
 {
     if (aes_192_ctr_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_192_ctr, 16, 24);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_aes_192_ctr, 16, 24)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 14)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -849,9 +834,13 @@ static const EVP_CIPHER *cryptodev_aes_192_ctr(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -864,9 +853,9 @@ static EVP_CIPHER *aes_256_ctr_cipher = NULL;
 static const EVP_CIPHER *cryptodev_aes_256_ctr(void)
 {
     if (aes_256_ctr_cipher == NULL) {
-        EVP_CIPHER *cipher;
+        EVP_CIPHER *cipher = EVP_CIPHER_meth_new(NID_aes_256_ctr, 16, 32);
 
-        if ((cipher = EVP_CIPHER_meth_new(NID_aes_256_ctr, 16, 32)) == NULL
+        if (cipher == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 14)
             || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE
                                           | EVP_CIPH_CUSTOM_COPY)
@@ -874,9 +863,13 @@ static const EVP_CIPHER *cryptodev_aes_256_ctr(void)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
             || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
-            || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
-            || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
+            || !EVP_CIPHER_meth_set_impl_ctx_size(cipher,
+                                                  sizeof(struct
+                                                         dev_crypto_state))
+            || !EVP_CIPHER_meth_set_set_asn1_params(cipher,
+                                                    EVP_CIPHER_set_asn1_iv)
+            || !EVP_CIPHER_meth_set_get_asn1_params(cipher,
+                                                    EVP_CIPHER_get_asn1_iv)) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
         }
@@ -1095,8 +1088,7 @@ static int cryptodev_digest_update(EVP_MD_CTX *ctx, const void *data,
 
     if (!EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
         /* if application doesn't support one buffer */
-        new_mac_data =
-            OPENSSL_realloc(state->mac_data, state->mac_len + count);
+        new_mac_data = OPENSSL_realloc(state->mac_data, state->mac_len + count);
 
         if (!new_mac_data) {
             printf("cryptodev_digest_update: realloc failed\n");
@@ -1115,9 +1107,9 @@ static int cryptodev_digest_update(EVP_MD_CTX *ctx, const void *data,
     cryp.ses = sess->ses;
     cryp.flags = 0;
     cryp.len = count;
-    cryp.src = (void *) data;
+    cryp.src = (void *)data;
     cryp.dst = NULL;
-    cryp.mac = (void *) state->digest_res;
+    cryp.mac = (void *)state->digest_res;
     if (ioctl(state->d_fd, CIOCCRYPT, &cryp) < 0) {
         printf("cryptodev_digest_update: digest failed\n");
         return (0);
@@ -1144,7 +1136,7 @@ static int cryptodev_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
         cryp.len = state->mac_len;
         cryp.src = state->mac_data;
         cryp.dst = NULL;
-        cryp.mac = (void *) md;
+        cryp.mac = (void *)md;
         if (ioctl(state->d_fd, CIOCCRYPT, &cryp) < 0) {
             printf("cryptodev_digest_final: digest failed\n");
             return (0);
@@ -1236,9 +1228,9 @@ static EVP_MD *sha1_md = NULL;
 static const EVP_MD *cryptodev_sha1(void)
 {
     if (sha1_md == NULL) {
-        EVP_MD *md;
+        EVP_MD *md = EVP_MD_meth_new(NID_sha1, NID_undef);
 
-        if ((md = EVP_MD_meth_new(NID_sha1, NID_undef)) == NULL
+        if (md == NULL
             || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
             || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
@@ -1261,12 +1253,12 @@ static EVP_MD *sha256_md = NULL;
 static const EVP_MD *cryptodev_sha256(void)
 {
     if (sha256_md == NULL) {
-        EVP_MD *md;
+        EVP_MD *md = EVP_MD_meth_new(NID_sha256, NID_undef);
 
-        if ((md = EVP_MD_meth_new(NID_sha256, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+        if (md == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA256_DIGEST_LENGTH)
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA256_CBLOCK)
             || !EVP_MD_meth_set_app_datasize(md,
                                              sizeof(struct dev_crypto_state))
             || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
@@ -1286,12 +1278,12 @@ static EVP_MD *sha224_md = NULL;
 static const EVP_MD *cryptodev_sha224(void)
 {
     if (sha224_md == NULL) {
-        EVP_MD *md;
+        EVP_MD *md = EVP_MD_meth_new(NID_sha224, NID_undef);
 
-        if ((md = EVP_MD_meth_new(NID_sha224, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+        if (md == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA224_DIGEST_LENGTH)
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA256_CBLOCK)
             || !EVP_MD_meth_set_app_datasize(md,
                                              sizeof(struct dev_crypto_state))
             || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
@@ -1311,12 +1303,12 @@ static EVP_MD *sha384_md = NULL;
 static const EVP_MD *cryptodev_sha384(void)
 {
     if (sha384_md == NULL) {
-        EVP_MD *md;
+        EVP_MD *md = EVP_MD_meth_new(NID_sha384, NID_undef);
 
-        if ((md = EVP_MD_meth_new(NID_sha384, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+        if (md == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA384_DIGEST_LENGTH)
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA512_CBLOCK)
             || !EVP_MD_meth_set_app_datasize(md,
                                              sizeof(struct dev_crypto_state))
             || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
@@ -1336,12 +1328,12 @@ static EVP_MD *sha512_md = NULL;
 static const EVP_MD *cryptodev_sha512(void)
 {
     if (sha512_md == NULL) {
-        EVP_MD *md;
+        EVP_MD *md = EVP_MD_meth_new(NID_sha512, NID_undef);
 
-        if ((md = EVP_MD_meth_new(NID_sha512, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
+        if (md == NULL
+            || !EVP_MD_meth_set_result_size(md, SHA512_DIGEST_LENGTH)
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
+            || !EVP_MD_meth_set_input_blocksize(md, SHA512_CBLOCK)
             || !EVP_MD_meth_set_app_datasize(md,
                                              sizeof(struct dev_crypto_state))
             || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
@@ -1361,12 +1353,12 @@ static EVP_MD *md5_md = NULL;
 static const EVP_MD *cryptodev_md5(void)
 {
     if (md5_md == NULL) {
-        EVP_MD *md;
+        EVP_MD *md = EVP_MD_meth_new(NID_md5, NID_undef);
 
-        if ((md = EVP_MD_meth_new(NID_md5, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 16 /* MD5_DIGEST_LENGTH */)
+        if (md == NULL
+            || !EVP_MD_meth_set_result_size(md, 16 /* MD5_DIGEST_LENGTH */ )
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_ONESHOT)
-            || !EVP_MD_meth_set_input_blocksize(md, 64 /* MD5_CBLOCK */)
+            || !EVP_MD_meth_set_input_blocksize(md, 64 /* MD5_CBLOCK */ )
             || !EVP_MD_meth_set_app_datasize(md,
                                              sizeof(struct dev_crypto_state))
             || !EVP_MD_meth_set_init(md, cryptodev_digest_init)
@@ -1498,7 +1490,7 @@ static int bn2crparam(const BIGNUM *a, struct crparam *crp)
     if (b == NULL)
         return (1);
 
-    crp->crp_p = (void *) b;
+    crp->crp_p = (void *)b;
     crp->crp_nbits = bits;
 
     BN_bn2bin(a, b);
@@ -1540,8 +1532,7 @@ static void zapparams(struct crypt_kop *kop)
 }
 
 static int
-cryptodev_asym(struct crypt_kop *kop, int rlen, BIGNUM *r, int slen,
-               BIGNUM *s)
+cryptodev_asym(struct crypt_kop *kop, int rlen, BIGNUM *r, int slen, BIGNUM *s)
 {
     int fd, ret = -1;
 
@@ -1556,13 +1547,12 @@ cryptodev_asym(struct crypt_kop *kop, int rlen, BIGNUM *r, int slen,
         kop->crk_oparams++;
     }
     if (s) {
-        kop->crk_param[kop->crk_iparams + 1].crp_p =
-            OPENSSL_zalloc(slen);
+        kop->crk_param[kop->crk_iparams + 1].crp_p = OPENSSL_zalloc(slen);
         /* No need to free the kop->crk_iparams parameter if it was allocated,
          * callers of this routine have to free allocated parameters through
          * zapparams both in case of success and failure
          */
-        if (kop->crk_param[kop->crk_iparams+1].crp_p == NULL)
+        if (kop->crk_param[kop->crk_iparams + 1].crp_p == NULL)
             return ret;
         kop->crk_param[kop->crk_iparams + 1].crp_nbits = slen * 8;
         kop->crk_oparams++;
@@ -1610,12 +1600,12 @@ cryptodev_bn_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     if (cryptodev_asym(&kop, BN_num_bytes(m), r, 0, NULL)) {
         const RSA_METHOD *meth = RSA_PKCS1_OpenSSL();
         printf("OCF asym process failed, Running in software\n");
-        ret = RSA_meth_get_bn_mod_exp(meth)(r, a, p, m, ctx, in_mont);
+        ret = RSA_meth_get_bn_mod_exp(meth) (r, a, p, m, ctx, in_mont);
 
     } else if (ECANCELED == kop.crk_status) {
         const RSA_METHOD *meth = RSA_PKCS1_OpenSSL();
         printf("OCF hardware operation cancelled. Running in Software\n");
-        ret = RSA_meth_get_bn_mod_exp(meth)(r, a, p, m, ctx, in_mont);
+        ret = RSA_meth_get_bn_mod_exp(meth) (r, a, p, m, ctx, in_mont);
     }
     /* else cryptodev operation worked ok ==> ret = 1 */
 
@@ -1625,8 +1615,7 @@ cryptodev_bn_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
 }
 
 static int
-cryptodev_rsa_nocrt_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa,
-                            BN_CTX *ctx)
+cryptodev_rsa_nocrt_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
 {
     int r;
     const BIGNUM *n = NULL;
@@ -1680,12 +1669,12 @@ cryptodev_rsa_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
     if (cryptodev_asym(&kop, BN_num_bytes(n), r0, 0, NULL)) {
         const RSA_METHOD *meth = RSA_PKCS1_OpenSSL();
         printf("OCF asym process failed, running in Software\n");
-        ret = RSA_meth_get_mod_exp(meth)(r0, I, rsa, ctx);
+        ret = RSA_meth_get_mod_exp(meth) (r0, I, rsa, ctx);
 
     } else if (ECANCELED == kop.crk_status) {
         const RSA_METHOD *meth = RSA_PKCS1_OpenSSL();
         printf("OCF hardware operation cancelled. Running in Software\n");
-        ret = RSA_meth_get_mod_exp(meth)(r0, I, rsa, ctx);
+        ret = RSA_meth_get_mod_exp(meth) (r0, I, rsa, ctx);
     }
     /* else cryptodev operation worked ok ==> ret = 1 */
 
@@ -1712,8 +1701,8 @@ cryptodev_dsa_dsa_mod_exp(DSA *dsa, BIGNUM *t1, const BIGNUM *g,
     BIGNUM *t2;
     int ret = 0;
     const DSA_METHOD *meth;
-    int (*bn_mod_exp)(DSA *, BIGNUM *, const BIGNUM *, const BIGNUM *, const BIGNUM *,
-                      BN_CTX *, BN_MONT_CTX *);
+    int (*bn_mod_exp) (DSA *, BIGNUM *, const BIGNUM *, const BIGNUM *,
+                       const BIGNUM *, BN_CTX *, BN_MONT_CTX *);
 
     t2 = BN_new();
     if (t2 == NULL)
@@ -1766,7 +1755,7 @@ static DSA_SIG *cryptodev_dsa_do_sign(const unsigned char *dgst, int dlen,
     kop.crk_op = CRK_DSA_SIGN;
 
     /* inputs: dgst dsa->p dsa->q dsa->g dsa->priv_key */
-    kop.crk_param[0].crp_p = (void *) dgst;
+    kop.crk_param[0].crp_p = (void *)dgst;
     kop.crk_param[0].crp_nbits = dlen * 8;
     DSA_get0_pqg(dsa, &dsap, &dsaq, &dsag);
     DSA_get0_key(dsa, NULL, &priv_key);
@@ -1786,8 +1775,7 @@ static DSA_SIG *cryptodev_dsa_do_sign(const unsigned char *dgst, int dlen,
     s = BN_new();
     if (s == NULL)
         goto err;
-    if (cryptodev_asym(&kop, BN_num_bytes(dsaq), r,
-                       BN_num_bytes(dsaq), s) == 0) {
+    if (cryptodev_asym(&kop, BN_num_bytes(dsaq), r, BN_num_bytes(dsaq), s) == 0) {
         DSA_SIG_set0(dsasig, r, s);
         dsaret = dsasig;
     } else {
@@ -1813,7 +1801,7 @@ cryptodev_dsa_verify(const unsigned char *dgst, int dlen,
     kop.crk_op = CRK_DSA_VERIFY;
 
     /* inputs: dgst dsa->p dsa->q dsa->g dsa->pub_key sig->r sig->s */
-    kop.crk_param[0].crp_p = (void *) dgst;
+    kop.crk_param[0].crp_p = (void *)dgst;
     kop.crk_param[0].crp_nbits = dlen * 8;
     DSA_get0_pqg(dsa, &p, &q, &g);
     if (bn2crparam(p, &kop.crk_param[1]))
@@ -1869,7 +1857,7 @@ cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
     if ((fd = get_asym_dev_crypto()) < 0) {
         const DH_METHOD *meth = DH_OpenSSL();
 
-        return DH_meth_get_compute_key(meth)(key, pub_key, dh);
+        return DH_meth_get_compute_key(meth) (key, pub_key, dh);
     }
 
     DH_get0_pqg(dh, &p, NULL, NULL);
@@ -1889,14 +1877,14 @@ cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
         goto err;
     kop.crk_iparams = 3;
 
-    kop.crk_param[3].crp_p = (void *) key;
-    kop.crk_param[3].crp_nbits = keylen * 8;
+    kop.crk_param[3].crp_p = (void *)key;
+    kop.crk_param[3].crp_nbits = keylen;
     kop.crk_oparams = 1;
 
     if (ioctl(fd, CIOCKEY, &kop) == -1) {
         const DH_METHOD *meth = DH_OpenSSL();
 
-        dhret = DH_meth_get_compute_key(meth)(key, pub_key, dh);
+        dhret = DH_meth_get_compute_key(meth) (key, pub_key, dh);
     }
  err:
     kop.crk_param[3].crp_p = NULL;
@@ -1904,14 +1892,13 @@ cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
     return (dhret);
 }
 
-# endif /* ndef OPENSSL_NO_DH */
+# endif                         /* ndef OPENSSL_NO_DH */
 
 /*
  * ctrl right now is just a wrapper that doesn't do much
  * but I expect we'll want some options soon.
  */
-static int
-cryptodev_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+static int cryptodev_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
 {
 # ifdef HAVE_SYSLOG_R
     struct syslog_data sd = SYSLOG_DATA_INIT;

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -1131,8 +1131,6 @@ static int cryptodev_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     struct dev_crypto_state *state = EVP_MD_CTX_md_data(ctx);
     struct session_op *sess = &state->d_sess;
 
-    int ret = 1;
-
     if (!md || state->d_fd < 0) {
         printf("cryptodev_digest_final: illegal input\n");
         return (0);
@@ -1157,7 +1155,7 @@ static int cryptodev_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
 
     memcpy(md, state->digest_res, EVP_MD_CTX_size(ctx));
 
-    return (ret);
+    return 1;
 }
 
 static int cryptodev_digest_cleanup(EVP_MD_CTX *ctx)

--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -572,6 +572,19 @@ static int cryptodev_cleanup(EVP_CIPHER_CTX *ctx)
  * gets called when libcrypto requests a cipher NID.
  */
 
+static int cryptodev_cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void *p2)
+{
+    struct dev_crypto_state *state = ctx->cipher_data;
+    struct session_op *sess = &state->d_sess;
+
+    if (type == EVP_CTRL_COPY) {
+        EVP_CIPHER_CTX *out = p2;
+        return cryptodev_init_key(out, sess->key, ctx->iv, 0);
+    }
+
+    return 0;
+}
+
 /* RC4 */
 static EVP_CIPHER *rc4_cipher = NULL;
 static const EVP_CIPHER *cryptodev_rc4(void)
@@ -581,10 +594,12 @@ static const EVP_CIPHER *cryptodev_rc4(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_rc4, 1, 16)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 0)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_VARIABLE_LENGTH)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_VARIABLE_LENGTH
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))) {
             EVP_CIPHER_meth_free(cipher);
             cipher = NULL;
@@ -603,10 +618,12 @@ static const EVP_CIPHER *cryptodev_des_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_des_cbc, 8, 8)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -627,10 +644,12 @@ static const EVP_CIPHER *cryptodev_3des_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_des_ede3_cbc, 8, 24)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -650,10 +669,12 @@ static const EVP_CIPHER *cryptodev_bf_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_bf_cbc, 8, 16)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -673,10 +694,12 @@ static const EVP_CIPHER *cryptodev_cast_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_cast5_cbc, 8, 16)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 8)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -696,10 +719,12 @@ static const EVP_CIPHER *cryptodev_aes_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_aes_128_cbc, 16, 16)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 16)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -719,10 +744,12 @@ static const EVP_CIPHER *cryptodev_aes_192_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_aes_192_cbc, 16, 24)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 16)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -742,10 +769,12 @@ static const EVP_CIPHER *cryptodev_aes_256_cbc(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_aes_256_cbc, 16, 32)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 16)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CBC_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -766,10 +795,12 @@ static const EVP_CIPHER *cryptodev_aes_ctr(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_aes_128_ctr, 16, 16)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 14)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -789,10 +820,12 @@ static const EVP_CIPHER *cryptodev_aes_192_ctr(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_aes_192_ctr, 16, 24)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 14)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {
@@ -812,10 +845,12 @@ static const EVP_CIPHER *cryptodev_aes_256_ctr(void)
 
         if ((cipher = EVP_CIPHER_meth_new(NID_aes_256_ctr, 16, 32)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(cipher, 14)
-            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE)
+            || !EVP_CIPHER_meth_set_flags(cipher, EVP_CIPH_CTR_MODE
+                                          | EVP_CIPH_CUSTOM_COPY)
             || !EVP_CIPHER_meth_set_init(cipher, cryptodev_init_key)
             || !EVP_CIPHER_meth_set_do_cipher(cipher, cryptodev_cipher)
             || !EVP_CIPHER_meth_set_cleanup(cipher, cryptodev_cleanup)
+            || !EVP_CIPHER_meth_set_ctrl(cipher, cryptodev_cipher_ctrl)
             || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(struct dev_crypto_state))
             || !EVP_CIPHER_meth_set_set_asn1_params(cipher, EVP_CIPHER_set_asn1_iv)
             || !EVP_CIPHER_meth_set_get_asn1_params(cipher, EVP_CIPHER_get_asn1_iv)) {


### PR DESCRIPTION
##### Description of change

This is updated version of cryptodev patches by nmav https://github.com/openssl/openssl/pull/191

I also removed bogus ifdef for CRYPTO_AES_CTR (it's enum not constant so ifdef does not really work on it), added more supported algorithms and styled the code.
