### PR TITLE
VMS: tell the C compiler to use the ISO C94 standard

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1761,7 +1761,7 @@ sub vms_info {
         inherit_from     => [ "BASE_VMS" ],
         template         => 1,
         cc               => "CC/DECC",
-        cflags           => picker(default => "/STANDARD=RELAXED/NOLIST/PREFIX=ALL",
+        cflags           => picker(default => "/STANDARD=(ISOC94,RELAXED)/NOLIST/PREFIX=ALL",
                                    debug   => "/NOOPTIMIZE/DEBUG",
                                    release => "/OPTIMIZE/NODEBUG"),
         lflags           => picker(default => "/MAP",


### PR DESCRIPTION
The current version of the VMS compiler provides C99 features,
strictly language wise.  Unfortunately, even the most recent standard
library isn't fully updated for that standard, so we need to use an
earlier standard that the compiler supports.

Most importantly, this affects the `__STDC_VERSION__` value, which the
compiler unfortunately currently defaults to 199901L.  With this
change we won't have to give VMS special treatment when looking for
features based on that macro.
