### PR TITLE
Fix a double free in ca command line

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1912,7 +1912,6 @@ static int certify_spkac(X509 **xret, const char *infile, EVP_PKEY *pkey,
     sk = CONF_get_section(parms, "default");
     if (sk_CONF_VALUE_num(sk) == 0) {
         BIO_printf(bio_err, "no name/value pairs found in %s\n", infile);
-        CONF_free(parms);
         goto end;
     }
 


### PR DESCRIPTION
Providing a spkac file with no default section causes a double free.

Thanks to Brian Carpenter for reporting this issue.