### PR TITLE
Make SSL_CTX_set_cert_store increase the reference counter

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3550,6 +3550,8 @@ X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx)
 void SSL_CTX_set_cert_store(SSL_CTX *ctx, X509_STORE *store)
 {
     X509_STORE_free(ctx->cert_store);
+    if (store != NULL)
+        X509_STORE_up_ref(store);
     ctx->cert_store = store;
 }
 


### PR DESCRIPTION
I'm not sure if we covered something like this in our discussion about the style guide. But I think since it's freeing the old one, it should increase reference counter for the new one.

This came up in https://github.com/nodejs/node/pull/8491#pullrequestreview-5976947