### PR TITLE
Allow CA.pl script user to pass extra arguments to openssl command

### DIFF
--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -46,7 +46,24 @@ my $NEWCERT = "newcert.pem";
 my $NEWP12 = "newcert.p12";
 my $RET = 0;
 my $WHAT = shift @ARGV || "";
+my @OPENSSL_CMDS = ("req", "ca", "pkcs12", "x509", "verify");
+my %EXTRA = extra_args(\@ARGV, "-extra-");
 my $FILE;
+
+sub extra_args {
+    my ($args_ref, $arg_prefix) = @_;
+    my %eargs = map {
+	if ($_ < $#$args_ref) {
+	    my ($arg, $value) = splice(@$args_ref, $_, 2);
+	    $arg =~ s/$arg_prefix//;
+	    ($arg, $value);
+	} else {
+	    ();
+	}
+    } reverse grep($$args_ref[$_] =~ /$arg_prefix/, 0..$#$args_ref);
+    my %empty = map { ($_, "") } @OPENSSL_CMDS;
+    return (%empty, %eargs);
+}
 
 # See if reason for a CRL entry is valid; exit if not.
 sub crl_reason_ok
@@ -96,22 +113,23 @@ sub run
 
 
 if ( $WHAT =~ /^(-\?|-h|-help)$/ ) {
-    print STDERR "usage: CA -newcert|-newreq|-newreq-nodes|-newca|-sign|-signcert|-verify\n";
-    print STDERR "       CA -pkcs12 [certname]\n";
-    print STDERR "       CA -crl|-revoke cert-filename [reason]\n";
+    print STDERR "usage: CA.pl -newcert | -newreq | -newreq-nodes | -xsign | -sign | -signCA | -signcert | -crl | -newca [-extra-cmd extra-params]\n";
+    print STDERR "       CA.pl -pkcs12 [-extra-pkcs12 extra-params] [certname]\n";
+    print STDERR "       CA.pl -verify [-extra-verify extra-params] certfile ...\n";
+    print STDERR "       CA.pl -revoke [-extra-ca extra-params] certfile [reason]\n";
     exit 0;
 }
 if ($WHAT eq '-newcert' ) {
     # create a certificate
-    $RET = run("$REQ -new -x509 -keyout $NEWKEY -out $NEWCERT $DAYS");
+    $RET = run("$REQ -new -x509 -keyout $NEWKEY -out $NEWCERT $DAYS $EXTRA{req}");
     print "Cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-newreq' ) {
     # create a certificate request
-    $RET = run("$REQ -new -keyout $NEWKEY -out $NEWREQ $DAYS");
+    $RET = run("$REQ -new -keyout $NEWKEY -out $NEWREQ $DAYS $EXTRA{req}");
     print "Request is in $NEWREQ, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-newreq-nodes' ) {
     # create a certificate request
-    $RET = run("$REQ -new -nodes -keyout $NEWKEY -out $NEWREQ $DAYS");
+    $RET = run("$REQ -new -nodes -keyout $NEWKEY -out $NEWREQ $DAYS $EXTRA{req}");
     print "Request is in $NEWREQ, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-newca' ) {
     # create the directory hierarchy
@@ -136,11 +154,11 @@ if ($WHAT eq '-newcert' ) {
         print "Making CA certificate ...\n";
         $RET = run("$REQ -new -keyout"
                 . " ${CATOP}/private/$CAKEY"
-                . " -out ${CATOP}/$CAREQ");
+                . " -out ${CATOP}/$CAREQ $EXTRA{req}");
         $RET = run("$CA -create_serial"
                 . " -out ${CATOP}/$CACERT $CADAYS -batch"
                 . " -keyfile ${CATOP}/private/$CAKEY -selfsign"
-                . " -extensions v3_ca"
+                . " -extensions v3_ca $EXTRA{ca}"
                 . " -infiles ${CATOP}/$CAREQ") if $RET == 0;
         print "CA certificate is in ${CATOP}/$CACERT\n" if $RET == 0;
     }
@@ -150,32 +168,32 @@ if ($WHAT eq '-newcert' ) {
     $RET = run("$PKCS12 -in $NEWCERT -inkey $NEWKEY"
             . " -certfile ${CATOP}/$CACERT"
             . " -out $NEWP12"
-            . " -export -name \"$cname\"");
+            . " -export -name \"$cname\" $EXTRA{pkcs12}");
     print "PKCS #12 file is in $NEWP12\n" if $RET == 0;
 } elsif ($WHAT eq '-xsign' ) {
-    $RET = run("$CA -policy policy_anything -infiles $NEWREQ");
+    $RET = run("$CA -policy policy_anything $EXTRA{ca} -infiles $NEWREQ");
 } elsif ($WHAT eq '-sign' ) {
-    $RET = run("$CA -policy policy_anything -out $NEWCERT -infiles $NEWREQ");
+    $RET = run("$CA -policy policy_anything -out $NEWCERT $EXTRA{ca} -infiles $NEWREQ");
     print "Signed certificate is in $NEWCERT\n" if $RET == 0;
 } elsif ($WHAT eq '-signCA' ) {
     $RET = run("$CA -policy policy_anything -out $NEWCERT"
-            . " -extensions v3_ca -infiles $NEWREQ");
+            . " -extensions v3_ca $EXTRA{ca} -infiles $NEWREQ");
     print "Signed CA certificate is in $NEWCERT\n" if $RET == 0;
 } elsif ($WHAT eq '-signcert' ) {
     $RET = run("$X509 -x509toreq -in $NEWREQ -signkey $NEWREQ"
-            . " -out tmp.pem");
+            . " -out tmp.pem $EXTRA{x509}");
     $RET = run("$CA -policy policy_anything -out $NEWCERT"
-            . " -infiles tmp.pem") if $RET == 0;
+            . "$EXTRA{ca} -infiles tmp.pem") if $RET == 0;
     print "Signed certificate is in $NEWCERT\n" if $RET == 0;
 } elsif ($WHAT eq '-verify' ) {
     my @files = @ARGV ? @ARGV : ( $NEWCERT );
     my $file;
     foreach $file (@files) {
-        my $status = run("$VERIFY \"-CAfile\" ${CATOP}/$CACERT $file");
+        my $status = run("$VERIFY \"-CAfile\" ${CATOP}/$CACERT $file $EXTRA{verify}");
         $RET = $status if $status != 0;
     }
 } elsif ($WHAT eq '-crl' ) {
-    $RET = run("$CA -gencrl -out ${CATOP}/crl/$CACRL");
+    $RET = run("$CA -gencrl -out ${CATOP}/crl/$CACRL $EXTRA{ca}");
     print "Generated CRL is in ${CATOP}/crl/$CACRL\n" if $RET == 0;
 } elsif ($WHAT eq '-revoke' ) {
     my $cname = $ARGV[1];
@@ -186,7 +204,7 @@ if ($WHAT eq '-newcert' ) {
     my $reason = $ARGV[2];
     $reason = " -crl_reason $reason"
         if defined $reason && crl_reason_ok($reason);
-    $RET = run("$CA -revoke \"$cname\"" . $reason);
+    $RET = run("$CA -revoke \"$cname\"" . $reason . $EXTRA{ca});
 } else {
     print STDERR "Unknown arg \"$WHAT\"\n";
     print STDERR "Use -help for help.\n";

--- a/doc/man1/CA.pl.pod
+++ b/doc/man1/CA.pl.pod
@@ -7,26 +7,48 @@ CA.pl - friendlier interface for OpenSSL certificate programs
 =head1 SYNOPSIS
 
 B<CA.pl>
-[B<-?>]
-[B<-h>]
-[B<-help>]
-[B<-newcert>]
-[B<-newreq>]
-[B<-newreq-nodes>]
-[B<-newca>]
-[B<-xsign>]
-[B<-sign>]
-[B<-signreq>]
-[B<-signcert>]
-[B<-verify>]
-[B<files>]
+B<-?> |
+B<-h> |
+B<-help>
 
-=head1 DESCRIPTION
+B<CA.pl>
+B<-newcert> |
+B<-newreq> |
+B<-newreq-nodes> |
+B<-xsign> |
+B<-sign> |
+B<-signCA> |
+B<-signcert> |
+B<-crl> |
+B<-newca>
+[B<-extra-cmd> extra-params]
+
+B<CA.pl> B<-pkcs12> [B<-extra-pkcs12> extra-params] [B<certname>]
+
+B<CA.pl> B<-verify> [B<-extra-verify> extra-params] B<certfile>...
+
+B<CA.pl> B<-revoke> [B<-extra-ca> extra-params] B<certfile> [B<reason>]
 
 The B<CA.pl> script is a perl script that supplies the relevant command line
 arguments to the B<openssl> command for some common certificate operations.
 It is intended to simplify the process of certificate creation and management
 by the use of some simple options.
+
+=head1 COMMON OPTIONS
+
+=over 4
+
+=item B<-extra-req> | B<-extra-ca> | B<-extra-pkcs12> | B<-extra-x509> | B<-extra-verify> <extra-params>
+
+The purpose of these parameters is to allow optional parameters to be supplied
+to B<openssl> that this command executes. The B<-extra-cmd> are specific to the
+option being used and the B<openssl> command getting invoked. For example
+when this command invokes B<openssl req> extra parameters can be passed on
+with the B<-extra-req> parameter. The
+B<openssl> commands being invoked per option are documented below.
+Users should consult B<openssl> command documentation for more information.
+
+=back
 
 =head1 COMMAND OPTIONS
 
@@ -40,15 +62,18 @@ prints a usage message.
 
 creates a new self signed certificate. The private key is written to the file
 "newkey.pem" and the request written to the file "newreq.pem".
+This argument invokes B<openssl req> command.
 
 =item B<-newreq>
 
 creates a new certificate request. The private key is written to the file
 "newkey.pem" and the request written to the file "newreq.pem".
+Executes B<openssl req> command below the hood.
 
 =item B<-newreq-nodes>
 
 is like B<-newreq> except that the private key will not be encrypted.
+Uses B<openssl req> command.
 
 =item B<-newca>
 
@@ -57,6 +82,7 @@ and B<-xsign> options). The user is prompted to enter the filename of the CA
 certificates (which should also contain the private key) or by hitting ENTER
 details of the CA will be prompted for. The relevant files and directories
 are created in a directory called "demoCA" in the current directory.
+B<openssl req> and B<openssl ca> commands are get invoked.
 
 =item B<-pkcs12>
 
@@ -68,29 +94,31 @@ B<-sign> option. The PKCS#12 file can be imported directly into a browser.
 If there is an additional argument on the command line it will be used as the
 "friendly name" for the certificate (which is typically displayed in the browser
 list box), otherwise the name "My Certificate" is used.
+Delegates work to B<openssl pkcs12> command.
 
-=item B<-sign>, B<-signreq>, B<-xsign>
+=item B<-sign>, B<-signcert>, B<-xsign>
 
 calls the B<ca> program to sign a certificate request. It expects the request
 to be in the file "newreq.pem". The new certificate is written to the file
 "newcert.pem" except in the case of the B<-xsign> option when it is written
-to standard output.
-
+to standard output. Leverages B<openssl ca> command.
 
 =item B<-signCA>
 
 this option is the same as the B<-signreq> option except it uses the configuration
 file section B<v3_ca> and so makes the signed request a valid CA certificate. This
 is useful when creating intermediate CA from a root CA.
+Extra params are passed on to B<openssl ca> command.
 
 =item B<-signcert>
 
 this option is the same as B<-sign> except it expects a self signed certificate
 to be present in the file "newreq.pem".
+Extra params are passed on to B<openssl x509> and B<openssl ca> commands.
 
 =item B<-crl>
 
-generate a CRL
+generate a CRL. Executes B<openssl ca> command.
 
 =item B<-revoke certfile [reason]>
 
@@ -98,15 +126,13 @@ revoke the certificate contained in the specified B<certfile>. An optional
 reason may be specified, and must be one of: B<unspecified>,
 B<keyCompromise>, B<CACompromise>, B<affiliationChanged>, B<superseded>,
 B<cessationOfOperation>, B<certificateHold>, or B<removeFromCRL>.
+Leverages B<openssl ca> command.
 
 =item B<-verify>
 
 verifies certificates against the CA certificate for "demoCA". If no certificates
 are specified on the command line it tries to verify the file "newcert.pem".
-
-=item B<files>
-
-one or more optional certificate file names for use with the B<-verify> command.
+Invokes B<openssl verify> command.
 
 =back
 


### PR DESCRIPTION
This change is useful e.g. to fully script CA commands e.g. like the following:

```
OPENSSL=/my/latest/openssl CA_REQ='-passout pass:foobar -subj "/C=FI/L=Helsinki/O=Practicing techie/CN=demo.practicingtechie.com/emailAddress=info@practicingtechie.com"' ./opt/openssl/ssl/misc/CA.pl -newreq

OPENSSL=/my/latest/openssl CA_CA='-passin file:capassphrase.txt -batch' ./opt/openssl/ssl/misc/CA.pl -sign
```
