### PR TITLE
Wordsmithing and naming consistency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -806,8 +806,8 @@
                 possible to create your own ".conf" and ".tmpl" files and store
                 them locally, outside the OpenSSL source tree. This environment
                 variable can be set to the directory where these files are held
-                and will have Configure to consider them in addition to the
-                standard ones.
+                and will be considered by Configure before it looks in the
+                standard directories.
 
  PERL
                 The name of the Perl executable to use when building OpenSSL.

--- a/doc/man3/BIO_read.pod
+++ b/doc/man3/BIO_read.pod
@@ -9,21 +9,21 @@ BIO_read_ex, BIO_write_ex, BIO_read, BIO_write, BIO_gets, BIO_puts
 
  #include <openssl/bio.h>
 
- int BIO_read_ex(BIO *b, void *out, size_t outl, size_t *read);
- int BIO_write_ex(BIO *b, const void *in, size_t inl, size_t *written);
+ int BIO_read_ex(BIO *b, void *data, size_t dlen, size_t *readbytes);
+ int BIO_write_ex(BIO *b, const void *data, size_t dlen, size_t *written);
 
- int BIO_read(BIO *b, void *buf, int len);
+ int BIO_read(BIO *b, void *data, int dlen);
  int BIO_gets(BIO *b, char *buf, int size);
- int BIO_write(BIO *b, const void *buf, int len);
+ int BIO_write(BIO *b, const void *data, int dlen);
  int BIO_puts(BIO *b, const char *buf);
 
 =head1 DESCRIPTION
 
-BIO_read_ex() attempts to read B<outl> bytes from BIO B<b> and places the data
-in B<out>. If any bytes were successfully read then the number of bytes read is
-stored in B<*read>.
+BIO_read_ex() attempts to read B<dlen> bytes from BIO B<b> and places the data
+in B<data>. If any bytes were successfully read then the number of bytes read is
+stored in B<*readbytes>.
 
-BIO_write_ex() attempts to write B<inl> bytes from B<in> to BIO B<b>. If
+BIO_write_ex() attempts to write B<dlen> bytes from B<data> to BIO B<b>. If
 successful then the number of bytes written is stored in B<*written>.
 
 BIO_read() attempts to read B<len> bytes from BIO B<b> and places
@@ -31,7 +31,7 @@ the data in B<buf>.
 
 BIO_gets() performs the BIOs "gets" operation and places the data
 in B<buf>. Usually this operation will attempt to read a line of data
-from the BIO of maximum length B<len-1>. There are exceptions to this,
+from the BIO of maximum length B<size-1>. There are exceptions to this,
 however; for example, BIO_gets() on a digest BIO will calculate and
 return the digest and other BIOs may not support BIO_gets() at all.
 The returned string is always NUL-terminated.

--- a/doc/man3/BIO_set_callback.pod
+++ b/doc/man3/BIO_set_callback.pod
@@ -76,7 +76,7 @@ the value of B<oper>, that is the operation being performed.
 =item B<processed>
 
 B<processed> is a pointer to a location which will be updated with the amount of
-data that was actually read or written. Only used for BIO_CB_READ, BIO_CB_WRITE, 
+data that was actually read or written. Only used for BIO_CB_READ, BIO_CB_WRITE,
 BIO_CB_GETS and BIO_CB_PUTS.
 
 =item B<ret>
@@ -111,75 +111,75 @@ or
 
 is called before the free operation.
 
-=item B<BIO_read_ex(b, out, outl, read)>
+=item B<BIO_read_ex(b, data, dlen, readbytes)>
 
- callback_ex(b, BIO_CB_READ, out, outl, 0, 0L, 1L, read)
+ callback_ex(b, BIO_CB_READ, data, dlen, 0, 0L, 1L, readbytes)
 
 or
 
- callback(b, BIO_CB_READ, out, outl, 0L, 1L)
- 
+ callback(b, BIO_CB_READ, data, dlen, 0L, 1L)
+
 is called before the read and
 
- callback_ex(b, BIO_CB_READ | BIO_CB_RETURN, out, outl, 0, 0L, retvalue, read)
+ callback_ex(b, BIO_CB_READ | BIO_CB_RETURN, data, dlen, 0, 0L, retvalue, readbytes)
 
 or
 
- callback(b, BIO_CB_READ|BIO_CB_RETURN, out, outl, 0L, retvalue)
+ callback(b, BIO_CB_READ|BIO_CB_RETURN, data, dlen, 0L, retvalue)
 
 after.
 
-=item B<BIO_write(b, in, inl, written)>
+=item B<BIO_write(b, data, dlen, written)>
 
- callback_ex(b, BIO_CB_WRITE, in, inl, 0, 0L, 1L, written)
+ callback_ex(b, BIO_CB_WRITE, data, dlen, 0, 0L, 1L, written)
 
 or
 
- callback(b, BIO_CB_WRITE, in, inl, 0L, 1L)
+ callback(b, BIO_CB_WRITE, datat, dlen, 0L, 1L)
 
 is called before the write and
 
- callback_ex(b, BIO_CB_WRITE | BIO_CB_RETURN, in, inl, 0, 0L, retvalue, written)
+ callback_ex(b, BIO_CB_WRITE | BIO_CB_RETURN, data, dlen, 0, 0L, retvalue, written)
 
 or
 
- callback(b, BIO_CB_WRITE|BIO_CB_RETURN, in, inl, 0L, retvalue)
+ callback(b, BIO_CB_WRITE|BIO_CB_RETURN, data, dlen, 0L, retvalue)
 
 after.
 
-=item B<BIO_gets(b, out, outl)>
+=item B<BIO_gets(b, buf, size)>
 
- callback_ex(b, BIO_CB_GETS, out, outl, 0, 0L, 1, NULL, NULL)
+ callback_ex(b, BIO_CB_GETS, buf, size, 0, 0L, 1, NULL, NULL)
 
 or
 
- callback(b, BIO_CB_GETS, out, outl, 0L, 1L)
+ callback(b, BIO_CB_GETS, buf, size, 0L, 1L)
 
 is called before the operation and
 
- callback_ex(b, BIO_CB_GETS | BIO_CB_RETURN, out, outl, 0, 0L, retvalue, read)
+ callback_ex(b, BIO_CB_GETS | BIO_CB_RETURN, buf, size, 0, 0L, retvalue, readbytes)
 
 or
 
- callback(b, BIO_CB_GETS|BIO_CB_RETURN, out, outl, 0L, retvalue)
+ callback(b, BIO_CB_GETS|BIO_CB_RETURN, buf, size, 0L, retvalue)
 
 after.
 
-=item B<BIO_puts(b, in)>
+=item B<BIO_puts(b, buf)>
 
- callback_ex(b, BIO_CB_PUTS, in, 0, 0, 0L, 1L, NULL);
+ callback_ex(b, BIO_CB_PUTS, buf, 0, 0, 0L, 1L, NULL);
 
 or
 
- callback(b, BIO_CB_PUTS, in, 0, 0L, 1L)
+ callback(b, BIO_CB_PUTS, buf, 0, 0L, 1L)
 
 is called before the operation and
 
- callback_ex(b, BIO_CB_PUTS | BIO_CB_RETURN, in, 0, 0, 0L, retvalue, written)
+ callback_ex(b, BIO_CB_PUTS | BIO_CB_RETURN, buf, 0, 0, 0L, retvalue, written)
 
 or
 
- callback(b, BIO_CB_WRITE|BIO_CB_RETURN, in, 0, 0L, retvalue)
+ callback(b, BIO_CB_WRITE|BIO_CB_RETURN, buf, 0, 0L, retvalue)
 
 after.
 
@@ -198,7 +198,7 @@ is called before the call and
 or
 
  callback(b, BIO_CB_CTRL|BIO_CB_RETURN, parg, cmd, larg, ret)
- 
+
 after.
 
 =back

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -552,7 +552,7 @@ int BIO_get_shutdown(BIO *a);
 void BIO_vfree(BIO *a);
 int BIO_up_ref(BIO *a);
 int BIO_read(BIO *b, void *data, int dlen);
-int BIO_read_ex(BIO *b, void *data, size_t dlen, size_t *read);
+int BIO_read_ex(BIO *b, void *data, size_t dlen, size_t *readbytes);
 int BIO_gets(BIO *bp, char *buf, int size);
 int BIO_write(BIO *b, const void *data, int dlen);
 int BIO_write_ex(BIO *b, const void *data, size_t dlen, size_t *written);


### PR DESCRIPTION
An old wordsmithing patch I had lying around on this branch name, plus some cleanup for the recent BIO rework.  Try to make BIO_{read,write}{,_ex} and BIO_{puts,gets} parameter names match across implementation, declaration, and documentation.

- [x] documentation is added or updated
- [x] CCLA is signed
