### PR TITLE
Add $(EX_LIBS) to the LIBDEPS for libgost.so, just as for all other engines

### DIFF
--- a/engines/ccgost/Makefile
+++ b/engines/ccgost/Makefile
@@ -32,7 +32,7 @@ lib: $(LIBOBJ)
 		$(MAKE) -f $(TOP)/Makefile.shared -e \
 			LIBNAME=$(LIBNAME) \
 			LIBEXTRAS='$(LIBOBJ)' \
-			LIBDEPS='-L$(TOP) -lcrypto' \
+			LIBDEPS='-L$(TOP) -lcrypto $(EX_LIBS)' \
 			link_o.$(SHLIB_TARGET); \
 	else \
 		$(AR) $(LIB) $(LIBOBJ); \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed
##### Description of change

<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Without this, any linker flag the user gave when configuring are ignored.

Fixes #1783
