### PR TITLE
TLSv1.3: Upgrade ossltest and TLSProxy

### DIFF
--- a/engines/e_ossltest.c
+++ b/engines/e_ossltest.c
@@ -226,7 +226,7 @@ static int ossltest_ciphers(ENGINE *, const EVP_CIPHER **,
                             const int **, int);
 
 static int ossltest_cipher_nids[] = {
-    NID_aes_128_cbc, 0
+    NID_aes_128_cbc, NID_aes_128_gcm, 0
 };
 
 /* AES128 */
@@ -235,6 +235,12 @@ int ossltest_aes128_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                              const unsigned char *iv, int enc);
 int ossltest_aes128_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                const unsigned char *in, size_t inl);
+int ossltest_aes128_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                             const unsigned char *iv, int enc);
+int ossltest_aes128_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                               const unsigned char *in, size_t inl);
+static int ossltest_aes128_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
+                                    void *ptr);
 
 static EVP_CIPHER *_hidden_aes_128_cbc = NULL;
 static const EVP_CIPHER *ossltest_aes_128_cbc(void)
@@ -258,9 +264,38 @@ static const EVP_CIPHER *ossltest_aes_128_cbc(void)
     }
     return _hidden_aes_128_cbc;
 }
+static EVP_CIPHER *_hidden_aes_128_gcm = NULL;
+#define AES_GCM_FLAGS   (EVP_CIPH_FLAG_DEFAULT_ASN1 \
+                | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER \
+                | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT \
+                | EVP_CIPH_CUSTOM_COPY |EVP_CIPH_FLAG_AEAD_CIPHER \
+                | EVP_CIPH_GCM_MODE)
+static const EVP_CIPHER *ossltest_aes_128_gcm(void)
+{
+    if (_hidden_aes_128_gcm == NULL
+        && ((_hidden_aes_128_gcm = EVP_CIPHER_meth_new(NID_aes_128_gcm,
+                                                       1 /* block size */,
+                                                       16 /* key len */)) == NULL
+            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_gcm,12)
+            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_gcm, AES_GCM_FLAGS)
+            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_gcm,
+                                         ossltest_aes128_gcm_init_key)
+            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_gcm,
+                                              ossltest_aes128_gcm_cipher)
+            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_gcm,
+                                              ossltest_aes128_gcm_ctrl)
+            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_gcm,
+                              EVP_CIPHER_impl_ctx_size(EVP_aes_128_gcm())))) {
+        EVP_CIPHER_meth_free(_hidden_aes_128_gcm);
+        _hidden_aes_128_gcm = NULL;
+    }
+    return _hidden_aes_128_gcm;
+}
+
 static void destroy_ciphers(void)
 {
     EVP_CIPHER_meth_free(_hidden_aes_128_cbc);
+    EVP_CIPHER_meth_free(_hidden_aes_128_gcm);
     _hidden_aes_128_cbc = NULL;
 }
 
@@ -388,6 +423,9 @@ static int ossltest_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
     switch (nid) {
     case NID_aes_128_cbc:
         *cipher = ossltest_aes_128_cbc();
+        break;
+    case NID_aes_128_gcm:
+        *cipher = ossltest_aes_128_gcm();
         break;
     default:
         ok = 0;
@@ -563,6 +601,52 @@ int ossltest_aes128_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     /* Throw it all away and just use the plaintext as the output */
     memcpy(out, tmpbuf, inl);
     OPENSSL_free(tmpbuf);
+
+    return ret;
+}
+
+int ossltest_aes128_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                             const unsigned char *iv, int enc)
+{
+    return EVP_CIPHER_meth_get_init(EVP_aes_128_gcm()) (ctx, key, iv, enc);
+}
+
+
+int ossltest_aes128_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                               const unsigned char *in, size_t inl)
+{
+    unsigned char *tmpbuf;
+    const size_t datalen = inl - EVP_GCM_TLS_EXPLICIT_IV_LEN
+                           - EVP_GCM_TLS_TAG_LEN;
+
+    tmpbuf = OPENSSL_malloc(datalen);
+    if (tmpbuf == NULL)
+        return -1;
+
+    /* Remember what we were asked to encrypt */
+    memcpy(tmpbuf, in + EVP_GCM_TLS_EXPLICIT_IV_LEN, datalen);
+
+    /* Go through the motions of encrypting it */
+    EVP_CIPHER_meth_get_do_cipher(EVP_aes_128_gcm())(ctx, out, in, inl);
+
+    /*
+     * Throw it all away and just use the plaintext as the output with empty
+     * IV and tag
+     */
+    memset(out, 0, inl);
+    memcpy(out + EVP_GCM_TLS_EXPLICIT_IV_LEN, tmpbuf, datalen);
+    OPENSSL_free(tmpbuf);
+
+    return 1;
+}
+
+static int ossltest_aes128_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
+                                    void *ptr)
+{
+    int ret;
+
+    /* Pass the ctrl down */
+    ret = EVP_CIPHER_meth_get_ctrl(EVP_aes_128_gcm())(ctx, type, arg, ptr);
 
     return ret;
 }

--- a/engines/e_ossltest.c
+++ b/engines/e_ossltest.c
@@ -265,11 +265,13 @@ static const EVP_CIPHER *ossltest_aes_128_cbc(void)
     return _hidden_aes_128_cbc;
 }
 static EVP_CIPHER *_hidden_aes_128_gcm = NULL;
+
 #define AES_GCM_FLAGS   (EVP_CIPH_FLAG_DEFAULT_ASN1 \
                 | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER \
                 | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT \
                 | EVP_CIPH_CUSTOM_COPY |EVP_CIPH_FLAG_AEAD_CIPHER \
                 | EVP_CIPH_GCM_MODE)
+
 static const EVP_CIPHER *ossltest_aes_128_gcm(void)
 {
     if (_hidden_aes_128_gcm == NULL
@@ -615,11 +617,10 @@ int ossltest_aes128_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 int ossltest_aes128_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                const unsigned char *in, size_t inl)
 {
-    unsigned char *tmpbuf;
     const size_t datalen = inl - EVP_GCM_TLS_EXPLICIT_IV_LEN
                            - EVP_GCM_TLS_TAG_LEN;
+    unsigned char *tmpbuf = OPENSSL_malloc(datalen);
 
-    tmpbuf = OPENSSL_malloc(datalen);
     if (tmpbuf == NULL)
         return -1;
 
@@ -643,10 +644,6 @@ int ossltest_aes128_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 static int ossltest_aes128_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                                     void *ptr)
 {
-    int ret;
-
     /* Pass the ctrl down */
-    ret = EVP_CIPHER_meth_get_ctrl(EVP_aes_128_gcm())(ctx, type, arg, ptr);
-
-    return ret;
+    return EVP_CIPHER_meth_get_ctrl(EVP_aes_128_gcm())(ctx, type, arg, ptr);
 }

--- a/test/recipes/70-test_sslcbcpadding.t
+++ b/test/recipes/70-test_sslcbcpadding.t
@@ -40,6 +40,7 @@ my @test_offsets = (0, 128, 254, 255);
 
 # Test that maximally-padded records are accepted.
 my $bad_padding_offset = -1;
+$proxy->serverflags("-tls1_2");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 1 + scalar(@test_offsets);
 ok(TLSProxy::Message->success(), "Maximally-padded record test");

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -37,6 +37,7 @@ my $proxy = TLSProxy::Proxy->new(
 #Test 1: Injecting out of context empty records should fail
 my $content_type = TLSProxy::Record::RT_APPLICATION_DATA;
 my $inject_recs_num = 1;
+$proxy->serverflags("-tls1_2");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 9;
 ok(TLSProxy::Message->fail(), "Out of context empty records test");
@@ -44,6 +45,7 @@ ok(TLSProxy::Message->fail(), "Out of context empty records test");
 #Test 2: Injecting in context empty records should succeed
 $proxy->clear();
 $content_type = TLSProxy::Record::RT_HANDSHAKE;
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(TLSProxy::Message->success(), "In context empty records test");
 
@@ -51,6 +53,7 @@ ok(TLSProxy::Message->success(), "In context empty records test");
 $proxy->clear();
 #We allow 32 consecutive in context empty records
 $inject_recs_num = 33;
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Too many in context empty records test");
 
@@ -59,6 +62,7 @@ ok(TLSProxy::Message->fail(), "Too many in context empty records test");
 #        alert, i.e. this will look like a disorderly close
 $proxy->clear();
 $proxy->filter(\&add_frag_alert_filter);
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(!TLSProxy::Message->end(), "Fragmented alert records test");
 
@@ -75,6 +79,7 @@ use constant {
 my $sslv2testtype = TLSV1_2_IN_SSLV2;
 $proxy->clear();
 $proxy->filter(\&add_sslv2_filter);
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(TLSProxy::Message->success(), "TLSv1.2 in SSLv2 ClientHello test");
 
@@ -83,6 +88,7 @@ ok(TLSProxy::Message->success(), "TLSv1.2 in SSLv2 ClientHello test");
 #        protocol so we don't even send an alert in this case.
 $sslv2testtype = SSLV2_IN_SSLV2;
 $proxy->clear();
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(!TLSProxy::Message->end(), "SSLv2 in SSLv2 ClientHello test");
 
@@ -91,6 +97,7 @@ ok(!TLSProxy::Message->end(), "SSLv2 in SSLv2 ClientHello test");
 #        reasons
 $sslv2testtype = FRAGMENTED_IN_TLSV1_2;
 $proxy->clear();
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(TLSProxy::Message->success(), "Fragmented ClientHello in TLSv1.2 test");
 
@@ -98,6 +105,7 @@ ok(TLSProxy::Message->success(), "Fragmented ClientHello in TLSv1.2 test");
 #        record; and another TLS1.2 record. This isn't allowed so should fail
 $sslv2testtype = FRAGMENTED_IN_SSLV2;
 $proxy->clear();
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Fragmented ClientHello in TLSv1.2/SSLv2 test");
 
@@ -105,6 +113,7 @@ ok(TLSProxy::Message->fail(), "Fragmented ClientHello in TLSv1.2/SSLv2 test");
 #        fail because an SSLv2 ClientHello must be the first record.
 $sslv2testtype = ALERT_BEFORE_SSLV2;
 $proxy->clear();
+$proxy->serverflags("-tls1_2");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Alert before SSLv2 ClientHello test");
 sub add_empty_recs_filter

--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -48,7 +48,7 @@ sub new
         cert => $cert,
         debug => $debug,
         cipherc => "",
-        ciphers => "AES128-SHA",
+        ciphers => "AES128-SHA:TLS13-AES-128-GCM-SHA256",
         flight => 0,
         record_list => [],
         message_list => [],
@@ -113,7 +113,7 @@ sub clear
     my $self = shift;
 
     $self->clearClient;
-    $self->{ciphers} = "AES128-SHA";
+    $self->{ciphers} = "AES128-SHA:TLS13-AES-128-GCM-SHA256";
     $self->{serverflags} = "";
     $self->{serverconnects} = 1;
     $self->{serverpid} = 0;
@@ -147,10 +147,8 @@ sub start
                 or die "Failed to redirect stdout: $!";
             open(STDERR, ">&STDOUT");
         }
-        # TODO(TLS1.3): Temporarily disabled for TLS1.3...no shared cipher
-        # because the TLS1.3 ciphersuites are not compatible with ossltest
         my $execcmd = $self->execute
-            ." s_server -no_tls1_3 -no_comp -rev -engine ossltest -accept "
+            ." s_server -no_comp -rev -engine ossltest -accept "
             .($self->server_port)
             ." -cert ".$self->cert." -naccept ".$self->serverconnects;
         if ($self->ciphers ne "") {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change

<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This builds on #1804. Please ignore the changes from the first 4 commits that are also in that PR.

This upgrades the ossltest engine so that it knows how to deal with a GCM based ciphersuite. It also upgrades TLSProxy so that it will use it where TLSv1.3 has been negotiated, and fixes some tests to work where TLSv1.3 is being used. This will enable us to write tests for the forthcoming TLSv1.3 implementation.
