### PR TITLE
TLSv1.3: Use the supported_versions extension for version negotiation

### DIFF
--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -68,6 +68,9 @@ extern "C" {
 # define TLS1_3_VERSION                  0x0304
 # define TLS_MAX_VERSION                 TLS1_3_VERSION
 
+/* TODO(TLS1.3) REMOVE ME: Version indicator for draft -17 */
+# define TLS1_3_VERSION_DRAFT            0x7f11
+
 /* Special value for method supporting multiple versions */
 # define TLS_ANY_VERSION                 0x10000
 
@@ -162,6 +165,9 @@ extern "C" {
 
 /* ExtensionType value from RFC4507 */
 # define TLSEXT_TYPE_session_ticket              35
+
+/* As defined for TLS1.3 */
+# define TLSEXT_TYPE_supported_versions          43
 
 /* Temporary extension type */
 # define TLSEXT_TYPE_renegotiate                 0xff01

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -68,8 +68,8 @@ extern "C" {
 # define TLS1_3_VERSION                  0x0304
 # define TLS_MAX_VERSION                 TLS1_3_VERSION
 
-/* TODO(TLS1.3) REMOVE ME: Version indicator for draft -17 */
-# define TLS1_3_VERSION_DRAFT            0x7f11
+/* TODO(TLS1.3) REMOVE ME: Version indicator for draft -18 */
+# define TLS1_3_VERSION_DRAFT            0x7f12
 
 /* Special value for method supporting multiple versions */
 # define TLS_ANY_VERSION                 0x10000

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -70,6 +70,7 @@ extern "C" {
 
 /* TODO(TLS1.3) REMOVE ME: Version indicator for draft -18 */
 # define TLS1_3_VERSION_DRAFT            0x7f12
+# define TLS1_3_VERSION_DRAFT_TXT        "TLS 1.3 (draft 18)"
 
 /* Special value for method supporting multiple versions */
 # define TLS_ANY_VERSION                 0x10000

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2056,6 +2056,9 @@ __owur int dtls1_process_heartbeat(SSL *s, unsigned char *p,
                                    size_t length);
 #  endif
 
+__owur RAW_EXTENSION *tls_get_extension_by_type(RAW_EXTENSION *exts,
+                                                size_t numexts,
+                                                unsigned int type);
 __owur int tls_get_ticket_from_client(SSL *s, CLIENTHELLO_MSG *hello,
                                       SSL_SESSION **ret);
 __owur int tls_check_client_ems_support(SSL *s, const CLIENTHELLO_MSG *hello);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -349,6 +349,10 @@
 
 /* Check if an SSL structure is using DTLS */
 # define SSL_IS_DTLS(s)  (s->method->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS)
+
+/* Check if we are using TLSv1.3 */
+# define SSL_IS_TLS13(s) (!SSL_IS_DTLS(s) && (s)->version >= TLS1_3_VERSION)
+
 /* See if we need explicit IV */
 # define SSL_USE_EXPLICIT_IV(s)  \
                 (s->method->ssl3_enc->enc_flags & SSL_ENC_FLAG_EXPLICIT_IV)

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -779,8 +779,13 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
      * TLS 1.0 and renegotiating with TLS 1.2. We do this by using
      * client_version in client hello and not resetting it to
      * the negotiated version.
+     *
+     * For TLS 1.3 we always set the ClientHello version to 1.2 and rely on the
+     * supported_versions extension for the reall supported versions.
      */
-    if (!WPACKET_put_bytes_u16(pkt, s->client_version)
+    if (!WPACKET_put_bytes_u16(pkt,
+                (!SSL_IS_DTLS(s) && s->client_version >= TLS1_3_VERSION)
+                ? TLS1_2_VERSION : s->client_version)
             || !WPACKET_memcpy(pkt, s->s3->client_random, SSL3_RANDOM_SIZE)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CLIENT_HELLO, ERR_R_INTERNAL_ERROR);
         return 0;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -781,11 +781,12 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
      * the negotiated version.
      *
      * For TLS 1.3 we always set the ClientHello version to 1.2 and rely on the
-     * supported_versions extension for the reall supported versions.
+     * supported_versions extension for the real supported versions.
      */
     if (!WPACKET_put_bytes_u16(pkt,
-                (!SSL_IS_DTLS(s) && s->client_version >= TLS1_3_VERSION)
-                ? TLS1_2_VERSION : s->client_version)
+                               (!SSL_IS_DTLS(s)
+                                   && s->client_version >= TLS1_3_VERSION)
+                               ? TLS1_2_VERSION : s->client_version)
             || !WPACKET_memcpy(pkt, s->s3->client_random, SSL3_RANDOM_SIZE)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CLIENT_HELLO, ERR_R_INTERNAL_ERROR);
         return 0;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -703,6 +703,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
     SSL_COMP *comp;
 #endif
     SSL_SESSION *sess = s->session;
+    int client_version;
 
     if (!WPACKET_set_max_size(pkt, SSL3_RT_MAX_PLAIN_LENGTH)) {
         /* Should not happen */
@@ -783,10 +784,8 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
      * For TLS 1.3 we always set the ClientHello version to 1.2 and rely on the
      * supported_versions extension for the real supported versions.
      */
-    if (!WPACKET_put_bytes_u16(pkt,
-                               (!SSL_IS_DTLS(s)
-                                   && s->client_version >= TLS1_3_VERSION)
-                               ? TLS1_2_VERSION : s->client_version)
+    client_version = SSL_IS_TLS13(s) ? TLS1_2_VERSION : s->client_version;
+    if (!WPACKET_put_bytes_u16(pkt, client_version)
             || !WPACKET_memcpy(pkt, s->s3->client_random, SSL3_RANDOM_SIZE)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CLIENT_HELLO, ERR_R_INTERNAL_ERROR);
         return 0;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1002,6 +1002,11 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
 
     switch (server_version) {
     default:
+        /*
+         * TODO(TLS1.3): This check will fail if someone attempts to do
+         * renegotiation in TLS1.3 at the moment. We need to ensure we disable
+         * renegotiation for TLS1.3
+         */
         if (version_cmp(s, client_version, s->version) < 0)
             return SSL_R_WRONG_SSL_VERSION;
         /*

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1118,6 +1118,10 @@ int ssl_choose_client_version(SSL *s, int version)
     const version_info *vent;
     const version_info *table;
 
+    /* TODO(TLS1.3): Remove this before release */
+    if (version == TLS1_3_VERSION_DRAFT)
+        version = TLS1_3_VERSION;
+
     switch (s->method->version) {
     default:
         if (version != s->version)

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1044,6 +1044,11 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
             /* TODO(TLS1.3): Remove this before release */
             if (candidate_vers == TLS1_3_VERSION_DRAFT)
                 candidate_vers = TLS1_3_VERSION;
+            /*
+             * TODO(TLS1.3): There is some discussion on the TLS list about
+             * wheter to ignore versions <TLS1.2 in supported_versions. At the
+             * moment we honour them if present. To be reviewed later
+             */
             if ((int)candidate_vers > s->client_version)
                 s->client_version = candidate_vers;
             if (version_cmp(s, candidate_vers, best_vers) <= 0)

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1053,7 +1053,7 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
                  vent->version != 0 && vent->version != (int)candidate_vers;
                  ++vent)
                 ;
-            if (vent->version != 0) {
+            if (vent->version != 0 && vent->smeth != NULL) {
                 const SSL_METHOD *method;
 
                 method = vent->smeth();

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1024,13 +1024,7 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
                                              hello->num_extensions,
                                              TLSEXT_TYPE_supported_versions);
 
-    /*
-     * TODO(TLS1.3): We only look at this if our max protocol version is TLS1.3
-     * or above. Should we allow it for lower versions too?
-     */
-    if (suppversions != NULL && !SSL_IS_DTLS(s)
-            && (s->max_proto_version == 0
-                || TLS1_3_VERSION <= s->max_proto_version)) {
+    if (suppversions != NULL && !SSL_IS_DTLS(s)) {
         unsigned int candidate_vers = 0;
         unsigned int best_vers = 0;
         const SSL_METHOD *best_method = NULL;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1036,8 +1036,7 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
         const SSL_METHOD *best_method = NULL;
         PACKET versionslist;
 
-        if (!PACKET_get_length_prefixed_1(&suppversions->data, &versionslist)
-                || PACKET_remaining(&suppversions->data) != 0) {
+        if (!PACKET_as_length_prefixed_1(&suppversions->data, &versionslist)) {
             /* Trailing or invalid data? */
             return SSL_R_LENGTH_MISMATCH;
         }
@@ -1052,7 +1051,8 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
                 continue;
             for (vent = table;
                  vent->version != 0 && vent->version != (int)candidate_vers;
-                 ++vent);
+                 ++vent)
+                ;
             if (vent->version != 0) {
                 const SSL_METHOD *method;
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1046,7 +1046,7 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello)
             for (vent = table;
                  vent->version != 0 && vent->version != (int)candidate_vers;
                  ++vent)
-                ;
+                continue;
             if (vent->version != 0 && vent->smeth != NULL) {
                 const SSL_METHOD *method;
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1544,7 +1544,9 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
     int compm, al = SSL_AD_INTERNAL_ERROR;
     size_t sl, len;
 
-    if (!WPACKET_put_bytes_u16(pkt, s->version)
+    /* TODO(TLS1.3): Remove the DRAFT conditional before release */
+    if (!WPACKET_put_bytes_u16(pkt, (s->version == TLS1_3_VERSION)
+                                    ? TLS1_3_VERSION_DRAFT : s->version)
                /*
                 * Random stuff. Filling of the server_random takes place in
                 * tls_process_client_hello()

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1543,10 +1543,11 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
 {
     int compm, al = SSL_AD_INTERNAL_ERROR;
     size_t sl, len;
+    int version;
 
     /* TODO(TLS1.3): Remove the DRAFT conditional before release */
-    if (!WPACKET_put_bytes_u16(pkt, (s->version == TLS1_3_VERSION)
-                                    ? TLS1_3_VERSION_DRAFT : s->version)
+    version = SSL_IS_TLS13(s) ? TLS1_3_VERSION_DRAFT : s->version;
+    if (!WPACKET_put_bytes_u16(pkt, version)
                /*
                 * Random stuff. Filling of the server_random takes place in
                 * tls_process_client_hello()

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2826,8 +2826,8 @@ int ssl_parse_serverhello_tlsext(SSL *s, PACKET *pkt)
  *
  * Returns a pointer to the found RAW_EXTENSION data, or NULL if not found.
  */
-static RAW_EXTENSION *get_extension_by_type(RAW_EXTENSION *exts, size_t numexts,
-                                            unsigned int type)
+RAW_EXTENSION *tls_get_extension_by_type(RAW_EXTENSION *exts, size_t numexts,
+                                         unsigned int type)
 {
     size_t loop;
 
@@ -2885,9 +2885,9 @@ int tls_get_ticket_from_client(SSL *s, CLIENTHELLO_MSG *hello,
     if (s->version <= SSL3_VERSION || !tls_use_ticket(s))
         return 0;
 
-    ticketext = get_extension_by_type(hello->pre_proc_exts,
-                                      hello->num_extensions,
-                                      TLSEXT_TYPE_session_ticket);
+    ticketext = tls_get_extension_by_type(hello->pre_proc_exts,
+                                          hello->num_extensions,
+                                          TLSEXT_TYPE_session_ticket);
     if (ticketext == NULL)
         return 0;
 
@@ -2948,8 +2948,9 @@ int tls_check_client_ems_support(SSL *s, const CLIENTHELLO_MSG *hello)
     if (s->version <= SSL3_VERSION)
         return 1;
 
-    emsext = get_extension_by_type(hello->pre_proc_exts, hello->num_extensions,
-                                   TLSEXT_TYPE_extended_master_secret);
+    emsext = tls_get_extension_by_type(hello->pre_proc_exts,
+                                       hello->num_extensions,
+                                       TLSEXT_TYPE_extended_master_secret);
 
     /*
      * No extensions is a success - we have successfully discovered that the

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1371,7 +1371,7 @@ int ssl_add_clienthello_tlsext(SSL *s, WPACKET *pkt, int *al)
         return 0;
     }
 
-    if (!SSL_IS_DTLS(s) && s->version >= TLS1_3_VERSION) {
+    if (SSL_IS_TLS13(s)) {
         int min_version, max_version, reason, currv;
         if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_supported_versions)
                 || !WPACKET_start_sub_packet_u16(pkt)
@@ -1384,6 +1384,11 @@ int ssl_add_clienthello_tlsext(SSL *s, WPACKET *pkt, int *al)
             SSLerr(SSL_F_SSL_ADD_CLIENTHELLO_TLSEXT, reason);
             return 0;
         }
+        /*
+         * TODO(TLS1.3): There is some discussion on the TLS list as to wheter
+         * we should include versions <TLS1.2. For the moment we do. To be
+         * reviewed later.
+         */
         for (currv = max_version; currv >= min_version; currv--) {
             /* TODO(TLS1.3): Remove this first if clause prior to release!! */
             if (currv == TLS1_3_VERSION) {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1371,8 +1371,6 @@ int ssl_add_clienthello_tlsext(SSL *s, WPACKET *pkt, int *al)
         return 0;
     }
 
-
-    /* TODO(TLS1.3): Should we add this extension for versions < TLS1.3? */
     if (!SSL_IS_DTLS(s) && s->version >= TLS1_3_VERSION) {
         int min_version, max_version, reason, currv;
         if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_supported_versions)

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -453,6 +453,7 @@ static ssl_trace_tbl ssl_exts_tbl[] = {
     {TLSEXT_TYPE_use_srtp, "use_srtp"},
     {TLSEXT_TYPE_heartbeat, "heartbeat"},
     {TLSEXT_TYPE_session_ticket, "session_ticket"},
+    {TLSEXT_TYPE_supported_versions, "supported_versions"},
     {TLSEXT_TYPE_renegotiate, "renegotiate"},
 # ifndef OPENSSL_NO_NEXTPROTONEG
     {TLSEXT_TYPE_next_proto_neg, "next_proto_neg"},
@@ -562,6 +563,15 @@ static ssl_trace_tbl ssl_crypto_tbl[] = {
     {TLS1_RT_CRYPTO_IV | TLS1_RT_CRYPTO_READ, "Read IV"},
     {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_WRITE, "Write IV (fixed part)"},
     {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_READ, "Read IV (fixed part)"}
+};
+
+static ssl_trace_tbl ssl_supp_versions_tbl[] = {
+    {SSL3_VERSION, "SSLv3"},
+    {TLS1_VERSION, "TLSv1.0"},
+    {TLS1_1_VERSION, "TLSv1.1"},
+    {TLS1_2_VERSION, "TLSv1.2"},
+    {TLS1_3_VERSION, "TLSv1.3"},
+    {TLS1_3_VERSION_DRAFT, "TLSv1.3 draft 17"}
 };
 
 static void ssl_print_hex(BIO *bio, int indent, const char *name,
@@ -726,6 +736,15 @@ static int ssl_print_extension(BIO *bio, int indent, int server, int extype,
         if (extlen != 0)
             ssl_print_hex(bio, indent + 4, "ticket", ext, extlen);
         break;
+
+    case TLSEXT_TYPE_supported_versions:
+        if (extlen < 1)
+            return 0;
+        xlen = ext[0];
+        if (extlen != xlen + 1)
+            return 0;
+        return ssl_trace_list(bio, indent + 2, ext + 1, xlen, 2,
+                              ssl_supp_versions_tbl);
 
     default:
         BIO_dump_indent(bio, (const char *)ext, extlen, indent + 2);

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -571,7 +571,7 @@ static ssl_trace_tbl ssl_supp_versions_tbl[] = {
     {TLS1_1_VERSION, "TLSv1.1"},
     {TLS1_2_VERSION, "TLSv1.2"},
     {TLS1_3_VERSION, "TLSv1.3"},
-    {TLS1_3_VERSION_DRAFT, "TLSv1.3 draft 17"}
+    {TLS1_3_VERSION_DRAFT, "TLSv1.3 draft 18"}
 };
 
 static void ssl_print_hex(BIO *bio, int indent, const char *name,

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -62,6 +62,8 @@ static ssl_trace_tbl ssl_version_tbl[] = {
     {TLS1_1_VERSION, "TLS 1.1"},
     {TLS1_2_VERSION, "TLS 1.2"},
     {TLS1_3_VERSION, "TLS 1.3"},
+    /* TODO(TLS1.3): Remove this line before release */
+    {TLS1_3_VERSION_DRAFT, TLS1_3_VERSION_DRAFT_TXT},
     {DTLS1_VERSION, "DTLS 1.0"},
     {DTLS1_2_VERSION, "DTLS 1.2"},
     {DTLS1_BAD_VER, "DTLS 1.0 (bad)"}
@@ -571,7 +573,7 @@ static ssl_trace_tbl ssl_supp_versions_tbl[] = {
     {TLS1_1_VERSION, "TLSv1.1"},
     {TLS1_2_VERSION, "TLSv1.2"},
     {TLS1_3_VERSION, "TLSv1.3"},
-    {TLS1_3_VERSION_DRAFT, "TLSv1.3 draft 18"}
+    {TLS1_3_VERSION_DRAFT, TLS1_3_VERSION_DRAFT_TXT}
 };
 
 static void ssl_print_hex(BIO *bio, int indent, const char *name,

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -567,15 +567,6 @@ static ssl_trace_tbl ssl_crypto_tbl[] = {
     {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_READ, "Read IV (fixed part)"}
 };
 
-static ssl_trace_tbl ssl_supp_versions_tbl[] = {
-    {SSL3_VERSION, "SSLv3"},
-    {TLS1_VERSION, "TLSv1.0"},
-    {TLS1_1_VERSION, "TLSv1.1"},
-    {TLS1_2_VERSION, "TLSv1.2"},
-    {TLS1_3_VERSION, "TLSv1.3"},
-    {TLS1_3_VERSION_DRAFT, TLS1_3_VERSION_DRAFT_TXT}
-};
-
 static void ssl_print_hex(BIO *bio, int indent, const char *name,
                           const unsigned char *msg, size_t msglen)
 {
@@ -746,7 +737,7 @@ static int ssl_print_extension(BIO *bio, int indent, int server, int extype,
         if (extlen != xlen + 1)
             return 0;
         return ssl_trace_list(bio, indent + 2, ext + 1, xlen, 2,
-                              ssl_supp_versions_tbl);
+                              ssl_version_tbl);
 
     default:
         BIO_dump_indent(bio, (const char *)ext, extlen, indent + 2);

--- a/test/recipes/70-test_sslversions.t
+++ b/test/recipes/70-test_sslversions.t
@@ -1,0 +1,148 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+use TLSProxy::Proxy;
+use File::Temp qw(tempfile);
+
+use constant {
+    REVERSE_ORDER_VERSIONS => 1,
+    UNRECOGNISED_VERSIONS => 2,
+    NO_EXTENSION => 3,
+    EMPTY_EXTENSION => 4,
+    NO_TLS1_3 => 5
+};
+
+my $testtype;
+
+my $test_name = "test_sslversions";
+setup($test_name);
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS|MSWin32)$/;
+
+plan skip_all => "$test_name needs the dynamic engine feature enabled"
+    if disabled("engine") || disabled("dynamic-engine");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLS1.3, TLS1.2 and TLS1.1 enabled"
+    if disabled("tls1_3") || disabled("tls1_2") || disabled("tls1_1");
+
+$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+
+my $proxy = TLSProxy::Proxy->new(
+    undef,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
+);
+
+#We're just testing various negative and unusual scenarios here. ssltest with
+#02-protocol-version.conf should check all the various combinations of normal
+#version neg
+
+#Test 1: An empty supported_versions extension should not succeed
+$testtype = EMPTY_EXTENSION;
+$proxy->filter(\&modify_supported_versions_filter);
+$proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 6;
+ok(TLSProxy::Message->fail(), "Empty supported versions");
+
+#Test 2: supported_versions extension with no recognised versions should not
+#succeed
+$proxy->clear();
+$testtype = UNRECOGNISED_VERSIONS;
+$proxy->start();
+ok(TLSProxy::Message->fail(), "No recognised versions");
+
+#Test 3: No supported versions extensions should succeed and select TLSv1.2
+$proxy->clear();
+$testtype = NO_EXTENSION;
+$proxy->start();
+my $record = pop @{$proxy->record_list};
+ok(TLSProxy::Message->success()
+   && $record->version() == TLSProxy::Record::VERS_TLS_1_2,
+   "No supported versions extension");
+
+#Test 4: No supported versions extensions should fail if only TLS1.3 available
+$proxy->clear();
+$proxy->serverflags("-tls1_3");
+$proxy->start();
+ok(TLSProxy::Message->fail(), "No supported versions extension (only TLS1.3)");
+
+#Test 5: supported versions extension with best version last should succeed
+#and select TLSv1.3
+$proxy->clear();
+$testtype = REVERSE_ORDER_VERSIONS;
+$proxy->start();
+$record = pop @{$proxy->record_list};
+ok(TLSProxy::Message->success()
+   && $record->version() == TLSProxy::Record::VERS_TLS_1_3,
+   "Reverse order versions");
+
+#Test 6: no TLSv1.3 or TLSv1.2 version in supported versions extension, but
+#TLSv1.1 and TLSv1.0 are present. Should just use TLSv1.1 and succeed
+$proxy->clear();
+$testtype = NO_TLS1_3;
+$proxy->start();
+$record = pop @{$proxy->record_list};
+ok(TLSProxy::Message->success()
+   && $record->version() == TLSProxy::Record::VERS_TLS_1_1,
+   "No TLS1.3 in supported versions extension");
+
+sub modify_supported_versions_filter
+{
+    my $proxy = shift;
+
+    # We're only interested in the initial ClientHello
+    if ($proxy->flight != 0) {
+        return;
+    }
+
+    foreach my $message (@{$proxy->message_list}) {
+        if ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO) {
+            my $ext;
+            if ($testtype == REVERSE_ORDER_VERSIONS) {
+                $ext = pack "C5",
+                    0x04, # Length
+                    0x03, 0x03, #TLSv1.2
+                    0x03, 0x04; #TLSv1.3
+            } elsif ($testtype == UNRECOGNISED_VERSIONS) {
+                $ext = pack "C5",
+                    0x04, # Length
+                    0x04, 0x04, #Some unrecognised version
+                    0x04, 0x03; #Another unrecognised version
+            } elsif ($testtype == NO_TLS1_3) {
+                $ext = pack "C5",
+                    0x04, # Length
+                    0x03, 0x02, #TLSv1.1
+                    0x03, 0x01; #TLSv1.0
+            }
+            if ($testtype == REVERSE_ORDER_VERSIONS
+                    || $testtype == UNRECOGNISED_VERSIONS
+                    || $testtype == NO_TLS1_3) {
+                $message->set_extension(
+                    TLSProxy::Message::EXT_SUPPORTED_VERSIONS, $ext);
+            } elsif ($testtype == EMPTY_EXTENSION) {
+                $message->set_extension(
+                    TLSProxy::Message::EXT_SUPPORTED_VERSIONS, "");
+            } else {
+                $message->delete_extension(
+                    TLSProxy::Message::EXT_SUPPORTED_VERSIONS);
+            }
+
+            $message->repack();
+        }
+    }
+}
+
+

--- a/test/recipes/70-test_sslversions.t
+++ b/test/recipes/70-test_sslversions.t
@@ -17,7 +17,7 @@ use constant {
     UNRECOGNISED_VERSIONS => 2,
     NO_EXTENSION => 3,
     EMPTY_EXTENSION => 4,
-    NO_TLS1_3 => 5,
+    TLS1_1_AND_1_0_ONLY => 5,
     WITH_TLS1_4 => 6
 };
 
@@ -93,12 +93,12 @@ ok(TLSProxy::Message->success()
 #Test 6: no TLSv1.3 or TLSv1.2 version in supported versions extension, but
 #TLSv1.1 and TLSv1.0 are present. Should just use TLSv1.1 and succeed
 $proxy->clear();
-$testtype = NO_TLS1_3;
+$testtype = TLS1_1_AND_1_0_ONLY;
 $proxy->start();
 $record = pop @{$proxy->record_list};
 ok(TLSProxy::Message->success()
    && $record->version() == TLSProxy::Record::VERS_TLS_1_1,
-   "No TLS1.3 in supported versions extension");
+   "TLS1.1 and TLS1.0 in supported versions extension only");
 
 #Test 7: TLS1.4 and TLS1.3 in supported versions. Should succeed and use TLS1.3
 $proxy->clear();
@@ -131,7 +131,7 @@ sub modify_supported_versions_filter
                     0x04, # Length
                     0x04, 0x04, #Some unrecognised version
                     0x04, 0x03; #Another unrecognised version
-            } elsif ($testtype == NO_TLS1_3) {
+            } elsif ($testtype == TLS1_1_AND_1_0_ONLY) {
                 $ext = pack "C5",
                     0x04, # Length
                     0x03, 0x02, #TLSv1.1
@@ -144,7 +144,7 @@ sub modify_supported_versions_filter
             }
             if ($testtype == REVERSE_ORDER_VERSIONS
                     || $testtype == UNRECOGNISED_VERSIONS
-                    || $testtype == NO_TLS1_3
+                    || $testtype == TLS1_1_AND_1_0_ONLY
                     || $testtype == WITH_TLS1_4) {
                 $message->set_extension(
                     TLSProxy::Message::EXT_SUPPORTED_VERSIONS, $ext);

--- a/test/recipes/70-test_sslvertol.t
+++ b/test/recipes/70-test_sslvertol.t
@@ -34,15 +34,18 @@ my $proxy = TLSProxy::Proxy->new(
     (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
 );
 
-#Test 1: Asking for TLS1.3 should pass
-my $client_version = TLSProxy::Record::VERS_TLS_1_3;
+#Test 1: Asking for TLS1.4 should pass
+my $client_version = TLSProxy::Record::VERS_TLS_1_4;
+#We don't want the supported versions extension for this test
+$proxy->clientflags("-no_tls1_3");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 2;
-ok(TLSProxy::Message->success(), "Version tolerance test, TLS 1.3");
+ok(TLSProxy::Message->success(), "Version tolerance test, TLS 1.4");
 
 #Test 2: Testing something below SSLv3 should fail
 $client_version = TLSProxy::Record::VERS_SSL_3_0 - 1;
 $proxy->clear();
+$proxy->clientflags("-no_tls1_3");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Version tolerance test, SSL < 3.0");
 

--- a/test/ssl-tests/17-renegotiate.conf
+++ b/test/ssl-tests/17-renegotiate.conf
@@ -18,6 +18,7 @@ client = 0-renegotiate-client-no-resume-client
 [0-renegotiate-client-no-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -45,6 +46,7 @@ client = 1-renegotiate-client-resume-client
 [1-renegotiate-client-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-renegotiate-client-resume-client]
@@ -71,6 +73,7 @@ client = 2-renegotiate-server-no-resume-client
 [2-renegotiate-server-no-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -98,6 +101,7 @@ client = 3-renegotiate-server-resume-client
 [3-renegotiate-server-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-renegotiate-server-resume-client]

--- a/test/ssl-tests/17-renegotiate.conf.in
+++ b/test/ssl-tests/17-renegotiate.conf.in
@@ -19,7 +19,8 @@ our @tests = (
     {
         name => "renegotiate-client-no-resume",
         server => {
-            "Options" => "NoResumptionOnRenegotiation"
+            "Options" => "NoResumptionOnRenegotiation",
+            "MaxProtocol" => "TLSv1.2"
         },
         client => {},
         test => {
@@ -31,7 +32,9 @@ our @tests = (
     },
     {
         name => "renegotiate-client-resume",
-        server => {},
+        server => {
+            "MaxProtocol" => "TLSv1.2"
+        },
         client => {},
         test => {
             "Method" => "TLS",
@@ -43,7 +46,8 @@ our @tests = (
     {
         name => "renegotiate-server-no-resume",
         server => {
-            "Options" => "NoResumptionOnRenegotiation"
+            "Options" => "NoResumptionOnRenegotiation",
+            "MaxProtocol" => "TLSv1.2"
         },
         client => {},
         test => {
@@ -55,7 +59,9 @@ our @tests = (
     },
     {
         name => "renegotiate-server-resume",
-        server => {},
+        server => {
+            "MaxProtocol" => "TLSv1.2"
+        },
         client => {},
         test => {
             "Method" => "TLS",

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -236,9 +236,10 @@ sub expected_result {
         return ("ServerFail", undef);
     } elsif ($c_min > $s_max) {
         my @prots = @$protocols;
-        if ($prots[$c_min] eq "TLSv1.3") {
-            # Client won't have sent any ciphersuite the server recognises
-                        return ("ServerFail", undef);
+        if ($prots[$c_max] eq "TLSv1.3") {
+            # Client will have sent supported_versions, so server will know
+            # that there are no overlapping versions.
+            return ("ServerFail", undef);
         } else {
             # Server will try with a version that is lower than the lowest
             # supported client version.

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -62,6 +62,7 @@ use constant {
     EXT_ENCRYPT_THEN_MAC => 22,
     EXT_EXTENDED_MASTER_SECRET => 23,
     EXT_SESSION_TICKET => 35,
+    EXT_SUPPORTED_VERSIONS => 43,
     # This extension does not exist and isn't recognised by OpenSSL.
     # We use it to test handling of duplicate extensions.
     EXT_DUPLICATE_EXTENSION => 1234

--- a/util/TLSProxy/Record.pm
+++ b/util/TLSProxy/Record.pm
@@ -35,6 +35,7 @@ my %record_type = (
 );
 
 use constant {
+    VERS_TLS_1_4 => 773,
     VERS_TLS_1_3 => 772,
     VERS_TLS_1_2 => 771,
     VERS_TLS_1_1 => 770,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change

<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

TLSv1.3 does version negotiation differently to <=TL1.2. The ClientHello.version field is now always set to TLSv1.2, and instead we have a new supported_versions extension that lists the version numbers that we are willing to negotiate. This PR adds support for the new extension. We already have some existing test coverage for version neg in test_ssl_new (02-protocol-version.conf). In addition to that I've added some extra tests in the form of a new TLSProxy test.

This builds on all the previous TLSv1.3 PRs, i.e. #1804, #1805 and #1807. Please ignore the first 6 commits in this PR and _only_ review the last 5 commits!!! (I wish we had a way of not showing those...its kind of annoying)
