### PR TITLE
Remove ENGINE_load_dasync() (no OPENSSL_INIT_ENGINE_DASYNC already)

### DIFF
--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -334,8 +334,6 @@ ENGINE *ENGINE_by_id(const char *id);
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_PADLOCK, NULL)
 #  define ENGINE_load_capi() \
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_CAPI, NULL)
-#  define ENGINE_load_dasync() \
-    OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_DASYNC, NULL)
 #  define ENGINE_load_afalg() \
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_AFALG, NULL)
 # endif


### PR DESCRIPTION
Fixes: 8d00e30f96fb86b20bc992f626b188c3548fc58c ("Don't try to init dasync internally")