### PR TITLE
Fail if an unrecognised record type is received

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,11 @@
 
  Changes between 1.1.0a and 1.1.1 [xx XXX xxxx]
 
-  *)
+  *) OpenSSL now fails if it receives an unrecognised record type in TLS1.0
+     or TLS1.1. Previously this only happened in SSLv3 and TLS1.2. This is to
+     prevent issues where no progress is being made and the peer continually
+     sends unrecognised record types, using up resources processing them.
+     [Matt Caswell]
 
   *) 'openssl passwd' can now produce SHA256 and SHA512 based output,
      using the algorithm defined in

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1463,14 +1463,12 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
     switch (SSL3_RECORD_get_type(rr)) {
     default:
         /*
-         * TLS up to v1.1 just ignores unknown message types: TLS v1.2 give
-         * an unexpected message alert.
+         * TLS 1.0 and 1.1 say you SHOULD ignore unrecognised record types, but
+         * TLS 1.2 says you MUST send an unexpected message alert. We use the
+         * TLS 1.2 behaviour for all protocol versions to prevent issues where
+         * no progress is being made and the peer continually sends unrecognised
+         * record types, using up resources processing them.
          */
-        if (s->version >= TLS1_VERSION && s->version <= TLS1_1_VERSION) {
-            SSL3_RECORD_set_length(rr, 0);
-            SSL3_RECORD_set_read(rr);
-            goto start;
-        }
         al = SSL_AD_UNEXPECTED_MESSAGE;
         SSLerr(SSL_F_SSL3_READ_BYTES, SSL_R_UNEXPECTED_RECORD);
         goto f_err;

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -38,7 +38,11 @@ my $proxy = TLSProxy::Proxy->new(
 my $content_type = TLSProxy::Record::RT_APPLICATION_DATA;
 my $inject_recs_num = 1;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 9;
+my $num_tests = 10;
+if (!disabled("tls1_1")) {
+    $num_tests++;
+}
+plan tests => $num_tests;
 ok(TLSProxy::Message->fail(), "Out of context empty records test");
 
 #Test 2: Injecting in context empty records should succeed
@@ -107,6 +111,23 @@ $sslv2testtype = ALERT_BEFORE_SSLV2;
 $proxy->clear();
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Alert before SSLv2 ClientHello test");
+
+#Unregcognised record type tests
+
+#Test 10: Sending an unrecognised record type in TLS1.2 should fail
+$proxy->clear();
+$proxy->filter(\&add_unknown_record_type);
+$proxy->start();
+ok(TLSProxy::Message->fail(), "Unrecognised record type in TLS1.2");
+
+#Test 11: Sending an unrecognised record type in TLS1.1 should fail
+if (!disabled("tls1_1")) {
+    $proxy->clear();
+    $proxy->clientflags("-tls1_1");
+    $proxy->start();
+    ok(TLSProxy::Message->fail(), "Unrecognised record type in TLS1.1");
+}
+
 sub add_empty_recs_filter
 {
     my $proxy = shift;
@@ -332,4 +353,29 @@ sub add_sslv2_filter
         push @{$proxy->record_list}, $record;
     }
 
+}
+
+sub add_unknown_record_type
+{
+    my $proxy = shift;
+
+    # We'll change a record after the initial version neg has taken place
+    if ($proxy->flight != 2) {
+        return;
+    }
+
+    my $lastrec = ${$proxy->record_list}[-1];
+    my $record = TLSProxy::Record->new(
+        2,
+        TLSProxy::Record::RT_UNKNOWN,
+        $lastrec->version(),
+        1,
+        0,
+        1,
+        1,
+        "X",
+        "X"
+    );
+
+    unshift @{$proxy->record_list}, $record;
 }

--- a/util/TLSProxy/Record.pm
+++ b/util/TLSProxy/Record.pm
@@ -22,14 +22,16 @@ use constant {
     RT_APPLICATION_DATA => 23,
     RT_HANDSHAKE => 22,
     RT_ALERT => 21,
-    RT_CCS => 20
+    RT_CCS => 20,
+    RT_UNKNOWN => 100
 };
 
 my %record_type = (
     RT_APPLICATION_DATA, "APPLICATION DATA",
     RT_HANDSHAKE, "HANDSHAKE",
     RT_ALERT, "ALERT",
-    RT_CCS, "CCS"
+    RT_CCS, "CCS",
+    RT_UNKNOWN, "UNKNOWN"
 );
 
 use constant {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
TLS1.0 and TLS1.1 say you SHOULD ignore unrecognised record types, but TLS 1.2 says you MUST send an unexpected message alert. We swap to the TLS 1.2 behaviour for all protocol versions to prevent issues where no progress is being made and the peer continually sends unrecognised record types, using up resources processing them.