### PR TITLE
TLSv1.3: Rename the elliptic_curves extension to supported_groups

### DIFF
--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -59,7 +59,7 @@ int set_cert_key_stuff(SSL_CTX *ctx, X509 *cert, EVP_PKEY *key,
                        STACK_OF(X509) *chain, int build_chain);
 int ssl_print_sigalgs(BIO *out, SSL *s);
 int ssl_print_point_formats(BIO *out, SSL *s);
-int ssl_print_curves(BIO *out, SSL *s, int noshared);
+int ssl_print_groups(BIO *out, SSL *s, int noshared);
 #endif
 int ssl_print_tmp_key(BIO *out, SSL *s);
 int init_client(int *sock, const char *host, const char *port,

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2560,7 +2560,7 @@ static int init_ssl_connection(SSL *con)
     ssl_print_sigalgs(bio_s_out, con);
 #ifndef OPENSSL_NO_EC
     ssl_print_point_formats(bio_s_out, con);
-    ssl_print_curves(bio_s_out, con, 0);
+    ssl_print_groups(bio_s_out, con, 0);
 #endif
     BIO_printf(bio_s_out, "CIPHER is %s\n", (str != NULL) ? str : "(NONE)");
 
@@ -2847,7 +2847,7 @@ static int www_body(int s, int stype, unsigned char *context)
             }
             ssl_print_sigalgs(io, con);
 #ifndef OPENSSL_NO_EC
-            ssl_print_curves(io, con, 0);
+            ssl_print_groups(io, con, 0);
 #endif
             BIO_printf(io, (SSL_session_reused(con)
                             ? "---\nReused, " : "---\nNew, "));

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -2,12 +2,24 @@
 
 =head1 NAME
 
+SSL_CTX_set1_groups, SSL_CTX_set1_groups_list, SSL_set1_groups,
+SSL_set1_groups_list, SSL_get1_groups, SSL_get_shared_group,
 SSL_CTX_set1_curves, SSL_CTX_set1_curves_list, SSL_set1_curves,
-SSL_set1_curves_list, SSL_get1_curves, SSL_get_shared_curve - EC supported curve functions
+SSL_set1_curves_list, SSL_get1_curves, SSL_get_shared_curve
+- EC supported curve functions
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
+
+ int SSL_CTX_set1_groups(SSL_CTX *ctx, int *glist, int glistlen);
+ int SSL_CTX_set1_groups_list(SSL_CTX *ctx, char *list);
+
+ int SSL_set1_groups(SSL *ssl, int *glist, int glistlen);
+ int SSL_set1_groups_list(SSL *ssl, char *list);
+
+ int SSL_get1_groups(SSL *ssl, int *groups);
+ int SSL_get_shared_group(SSL *s, int n);
 
  int SSL_CTX_set1_curves(SSL_CTX *ctx, int *clist, int clistlen);
  int SSL_CTX_set1_curves_list(SSL_CTX *ctx, char *list);
@@ -20,35 +32,41 @@ SSL_set1_curves_list, SSL_get1_curves, SSL_get_shared_curve - EC supported curve
 
 =head1 DESCRIPTION
 
-SSL_CTX_set1_curves() sets the supported curves for B<ctx> to B<clistlen>
-curves in the array B<clist>. The array consist of all NIDs of curves in
-preference order. For a TLS client the curves are used directly in the
-supported curves extension. For a TLS server the curves are used to
-determine the set of shared curves.
+SSL_CTX_set1_groups() sets the supported groups for B<ctx> to B<glistlen>
+groups in the array B<glist>. The array consist of all NIDs of groups in
+preference order. For a TLS client the groups are used directly in the
+supported groups extension. For a TLS server the groups are used to
+determine the set of shared groups.
 
-SSL_CTX_set1_curves_list() sets the supported curves for B<ctx> to
-string B<list>. The string is a colon separated list of curve NIDs or
+SSL_CTX_set1_groups_list() sets the supported groups for B<ctx> to
+string B<list>. The string is a colon separated list of group NIDs or
 names, for example "P-521:P-384:P-256".
 
-SSL_set1_curves() and SSL_set1_curves_list() are similar except they set
-supported curves for the SSL structure B<ssl>.
+SSL_set1_groups() and SSL_set1_groups_list() are similar except they set
+supported groups for the SSL structure B<ssl>.
 
-SSL_get1_curves() returns the set of supported curves sent by a client
-in the supported curves extension. It returns the total number of
-supported curves. The B<curves> parameter can be B<NULL> to simply
-return the number of curves for memory allocation purposes. The
-B<curves> array is in the form of a set of curve NIDs in preference
-order. It can return zero if the client did not send a supported curves
+SSL_get1_groups() returns the set of supported groups sent by a client
+in the supported groups extension. It returns the total number of
+supported groups. The B<groups> parameter can be B<NULL> to simply
+return the number of groups for memory allocation purposes. The
+B<groups> array is in the form of a set of group NIDs in preference
+order. It can return zero if the client did not send a supported groups
 extension.
 
-SSL_get_shared_curve() returns shared curve B<n> for a server-side
-SSL B<ssl>. If B<n> is -1 then the total number of shared curves is
+SSL_get_shared_group() returns shared group B<n> for a server-side
+SSL B<ssl>. If B<n> is -1 then the total number of shared groups is
 returned, which may be zero. Other than for diagnostic purposes,
-most applications will only be interested in the first shared curve
+most applications will only be interested in the first shared group
 so B<n> is normally set to zero. If the value B<n> is out of range,
 NID_undef is returned.
 
 All these functions are implemented as macros.
+
+The curve functions are synonyms for the equivalently named group functions and
+are identical in every respect. They exist because, prior to TLS1.3, there was
+only the concept of supported curves. In TLS1.3 this was renamed to supported
+groups, and extended to include Diffie Hellman groups. The group functions
+should be used in preference.
 
 =head1 NOTES
 
@@ -58,16 +76,16 @@ consider using the SSL_CONF interface instead of manually parsing options.
 
 =head1 RETURN VALUES
 
-SSL_CTX_set1_curves(), SSL_CTX_set1_curves_list(), SSL_set1_curves() and
-SSL_set1_curves_list(), return 1 for success and 0 for failure.
+SSL_CTX_set1_groups(), SSL_CTX_set1_groups_list(), SSL_set1_groups() and
+SSL_set1_groups_list(), return 1 for success and 0 for failure.
 
-SSL_get1_curves() returns the number of curves, which may be zero.
+SSL_get1_groups() returns the number of groups, which may be zero.
 
-SSL_get_shared_curve() returns the NID of shared curve B<n> or NID_undef if there
-is no shared curve B<n>; or the total number of shared curves if B<n>
+SSL_get_shared_group() returns the NID of shared group B<n> or NID_undef if there
+is no shared group B<n>; or the total number of shared groups if B<n>
 is -1.
 
-When called on a client B<ssl>, SSL_get_shared_curve() has no meaning and
+When called on a client B<ssl>, SSL_get_shared_group() has no meaning and
 returns -1.
 
 =head1 SEE ALSO
@@ -76,7 +94,8 @@ L<SSL_CTX_add_extra_chain_cert(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2.
+The curve functions were first added to OpenSSL 1.0.2. The equivalent group
+functions were first added to OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1109,10 +1109,10 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS        83
 # define SSL_CTRL_CHAIN                          88
 # define SSL_CTRL_CHAIN_CERT                     89
-# define SSL_CTRL_GET_CURVES                     90
-# define SSL_CTRL_SET_CURVES                     91
-# define SSL_CTRL_SET_CURVES_LIST                92
-# define SSL_CTRL_GET_SHARED_CURVE               93
+# define SSL_CTRL_GET_GROUPS                     90
+# define SSL_CTRL_SET_GROUPS                     91
+# define SSL_CTRL_SET_GROUPS_LIST                92
+# define SSL_CTRL_GET_SHARED_GROUP               93
 # define SSL_CTRL_SET_SIGALGS                    97
 # define SSL_CTRL_SET_SIGALGS_LIST               98
 # define SSL_CTRL_CERT_FLAGS                     99
@@ -1227,18 +1227,30 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_ctrl(s,SSL_CTRL_SET_CHAIN_CERT_STORE,0,(char *)st)
 # define SSL_set1_chain_cert_store(s,st) \
         SSL_ctrl(s,SSL_CTRL_SET_CHAIN_CERT_STORE,1,(char *)st)
+# define SSL_get1_groups(ctx, s) \
+        SSL_ctrl(ctx,SSL_CTRL_GET_GROUPS,0,(char *)s)
 # define SSL_get1_curves(ctx, s) \
-        SSL_ctrl(ctx,SSL_CTRL_GET_CURVES,0,(char *)s)
+        SSL_get1_groups((ctx), (s))
+# define SSL_CTX_set1_groups(ctx, glist, glistlen) \
+        SSL_CTX_ctrl(ctx,SSL_CTRL_SET_GROUPS,glistlen,(char *)glist)
+# define SSL_CTX_set1_groups_list(ctx, s) \
+        SSL_CTX_ctrl(ctx,SSL_CTRL_SET_GROUPS_LIST,0,(char *)s)
 # define SSL_CTX_set1_curves(ctx, clist, clistlen) \
-        SSL_CTX_ctrl(ctx,SSL_CTRL_SET_CURVES,clistlen,(char *)clist)
+        SSL_CTX_set1_groups((ctx), (clist), (clistlen))
 # define SSL_CTX_set1_curves_list(ctx, s) \
-        SSL_CTX_ctrl(ctx,SSL_CTRL_SET_CURVES_LIST,0,(char *)s)
+        SSL_CTX_set1_groups_list((ctx), (s))
+# define SSL_set1_groups(ctx, glist, glistlen) \
+        SSL_ctrl(ctx,SSL_CTRL_SET_GROUPS,glistlen,(char *)glist)
+# define SSL_set1_groups_list(ctx, s) \
+        SSL_ctrl(ctx,SSL_CTRL_SET_GROUPS_LIST,0,(char *)s)
 # define SSL_set1_curves(ctx, clist, clistlen) \
-        SSL_ctrl(ctx,SSL_CTRL_SET_CURVES,clistlen,(char *)clist)
+        SSL_set1_groups((ctx), (clist), (clistlen))
 # define SSL_set1_curves_list(ctx, s) \
-        SSL_ctrl(ctx,SSL_CTRL_SET_CURVES_LIST,0,(char *)s)
+        SSL_set1_groups_list((ctx), (s))
+# define SSL_get_shared_group(s, n) \
+        SSL_ctrl(s,SSL_CTRL_GET_SHARED_GROUP,n,NULL)
 # define SSL_get_shared_curve(s, n) \
-        SSL_ctrl(s,SSL_CTRL_GET_SHARED_CURVE,n,NULL)
+        SSL_get_shared_group((s), (n))
 # define SSL_CTX_set1_sigalgs(ctx, slist, slistlen) \
         SSL_CTX_ctrl(ctx,SSL_CTRL_SET_SIGALGS,slistlen,(int *)slist)
 # define SSL_CTX_set1_sigalgs_list(ctx, s) \

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -124,8 +124,14 @@ extern "C" {
 # define TLSEXT_TYPE_cert_type           9
 
 /* ExtensionType values from RFC4492 */
-# define TLSEXT_TYPE_elliptic_curves             10
+/*
+ * Prior to TLSv1.3 the supported_groups extension was known as
+ * elliptic_curves
+ */
+# define TLSEXT_TYPE_supported_groups            10
+# define TLSEXT_TYPE_elliptic_curves             TLSEXT_TYPE_supported_groups
 # define TLSEXT_TYPE_ec_point_formats            11
+
 
 /* ExtensionType value from RFC5054 */
 # define TLSEXT_TYPE_srp                         12

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -2969,8 +2969,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             nid = EC_GROUP_get_curve_name(group);
             if (nid == NID_undef)
                 return 0;
-            return tls1_set_curves(&s->tlsext_ellipticcurvelist,
-                                   &s->tlsext_ellipticcurvelist_length,
+            return tls1_set_groups(&s->tlsext_supportedgroupslist,
+                                   &s->tlsext_supportedgroupslist_length,
                                    &nid, 1);
         }
         break;
@@ -3112,20 +3112,21 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         return ssl_cert_set_current(s->cert, larg);
 
 #ifndef OPENSSL_NO_EC
-    case SSL_CTRL_GET_CURVES:
+    case SSL_CTRL_GET_GROUPS:
         {
             unsigned char *clist;
             size_t clistlen;
             if (!s->session)
                 return 0;
-            clist = s->session->tlsext_ellipticcurvelist;
-            clistlen = s->session->tlsext_ellipticcurvelist_length / 2;
+            clist = s->session->tlsext_supportedgroupslist;
+            clistlen = s->session->tlsext_supportedgroupslist_length / 2;
             if (parg) {
                 size_t i;
                 int *cptr = parg;
                 unsigned int cid, nid;
                 for (i = 0; i < clistlen; i++) {
                     n2s(clist, cid);
+                    /* TODO(TLS1.3): Handle DH groups here */
                     nid = tls1_ec_curve_id2nid(cid, NULL);
                     if (nid != 0)
                         cptr[i] = nid;
@@ -3136,16 +3137,16 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             return (int)clistlen;
         }
 
-    case SSL_CTRL_SET_CURVES:
-        return tls1_set_curves(&s->tlsext_ellipticcurvelist,
-                               &s->tlsext_ellipticcurvelist_length, parg, larg);
+    case SSL_CTRL_SET_GROUPS:
+        return tls1_set_groups(&s->tlsext_supportedgroupslist,
+                               &s->tlsext_supportedgroupslist_length, parg, larg);
 
-    case SSL_CTRL_SET_CURVES_LIST:
-        return tls1_set_curves_list(&s->tlsext_ellipticcurvelist,
-                                    &s->tlsext_ellipticcurvelist_length, parg);
+    case SSL_CTRL_SET_GROUPS_LIST:
+        return tls1_set_groups_list(&s->tlsext_supportedgroupslist,
+                                    &s->tlsext_supportedgroupslist_length, parg);
 
-    case SSL_CTRL_GET_SHARED_CURVE:
-        return tls1_shared_curve(s, larg);
+    case SSL_CTRL_GET_SHARED_GROUP:
+        return tls1_shared_group(s, larg);
 
 #endif
     case SSL_CTRL_SET_SIGALGS:
@@ -3320,8 +3321,8 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
             nid = EC_GROUP_get_curve_name(group);
             if (nid == NID_undef)
                 return 0;
-            return tls1_set_curves(&ctx->tlsext_ellipticcurvelist,
-                                   &ctx->tlsext_ellipticcurvelist_length,
+            return tls1_set_groups(&ctx->tlsext_supportedgroupslist,
+                                   &ctx->tlsext_supportedgroupslist_length,
                                    &nid, 1);
         }
         /* break; */
@@ -3417,14 +3418,14 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
 #endif
 
 #ifndef OPENSSL_NO_EC
-    case SSL_CTRL_SET_CURVES:
-        return tls1_set_curves(&ctx->tlsext_ellipticcurvelist,
-                               &ctx->tlsext_ellipticcurvelist_length,
+    case SSL_CTRL_SET_GROUPS:
+        return tls1_set_groups(&ctx->tlsext_supportedgroupslist,
+                               &ctx->tlsext_supportedgroupslist_length,
                                parg, larg);
 
-    case SSL_CTRL_SET_CURVES_LIST:
-        return tls1_set_curves_list(&ctx->tlsext_ellipticcurvelist,
-                                    &ctx->tlsext_ellipticcurvelist_length,
+    case SSL_CTRL_SET_GROUPS_LIST:
+        return tls1_set_groups_list(&ctx->tlsext_supportedgroupslist,
+                                    &ctx->tlsext_supportedgroupslist_length,
                                     parg);
 #endif
     case SSL_CTRL_SET_SIGALGS:

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -202,15 +202,21 @@ static int cmd_ClientSignatureAlgorithms(SSL_CONF_CTX *cctx, const char *value)
     return rv > 0;
 }
 
-static int cmd_Curves(SSL_CONF_CTX *cctx, const char *value)
+static int cmd_Groups(SSL_CONF_CTX *cctx, const char *value)
 {
     int rv;
     if (cctx->ssl)
-        rv = SSL_set1_curves_list(cctx->ssl, value);
+        rv = SSL_set1_groups_list(cctx->ssl, value);
     /* NB: ctx == NULL performs syntax checking only */
     else
-        rv = SSL_CTX_set1_curves_list(cctx->ctx, value);
+        rv = SSL_CTX_set1_groups_list(cctx->ctx, value);
     return rv > 0;
+}
+
+/* This is the old name for cmd_Groups - retained for backwards compatibility */
+static int cmd_Curves(SSL_CONF_CTX *cctx, const char *value)
+{
+    return cmd_Groups(cctx, value);
 }
 
 #ifndef OPENSSL_NO_EC
@@ -543,6 +549,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_STRING(SignatureAlgorithms, "sigalgs", 0),
     SSL_CONF_CMD_STRING(ClientSignatureAlgorithms, "client_sigalgs", 0),
     SSL_CONF_CMD_STRING(Curves, "curves", 0),
+    SSL_CONF_CMD_STRING(Groups, "groups", 0),
 #ifndef OPENSSL_NO_EC
     SSL_CONF_CMD_STRING(ECDHParameters, "named_curve", SSL_CONF_FLAG_SERVER),
 #endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -610,14 +610,14 @@ SSL *SSL_new(SSL_CTX *ctx)
         s->tlsext_ecpointformatlist_length =
             ctx->tlsext_ecpointformatlist_length;
     }
-    if (ctx->tlsext_ellipticcurvelist) {
-        s->tlsext_ellipticcurvelist =
-            OPENSSL_memdup(ctx->tlsext_ellipticcurvelist,
-                           ctx->tlsext_ellipticcurvelist_length);
-        if (!s->tlsext_ellipticcurvelist)
+    if (ctx->tlsext_supportedgroupslist) {
+        s->tlsext_supportedgroupslist =
+            OPENSSL_memdup(ctx->tlsext_supportedgroupslist,
+                           ctx->tlsext_supportedgroupslist_length);
+        if (!s->tlsext_supportedgroupslist)
             goto err;
-        s->tlsext_ellipticcurvelist_length =
-            ctx->tlsext_ellipticcurvelist_length;
+        s->tlsext_supportedgroupslist_length =
+            ctx->tlsext_supportedgroupslist_length;
     }
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
@@ -1001,7 +1001,7 @@ void SSL_free(SSL *s)
     SSL_CTX_free(s->initial_ctx);
 #ifndef OPENSSL_NO_EC
     OPENSSL_free(s->tlsext_ecpointformatlist);
-    OPENSSL_free(s->tlsext_ellipticcurvelist);
+    OPENSSL_free(s->tlsext_supportedgroupslist);
 #endif                          /* OPENSSL_NO_EC */
     sk_X509_EXTENSION_pop_free(s->tlsext_ocsp_exts, X509_EXTENSION_free);
 #ifndef OPENSSL_NO_OCSP
@@ -1857,8 +1857,8 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     if (ctx == NULL) {
         switch (cmd) {
 #ifndef OPENSSL_NO_EC
-        case SSL_CTRL_SET_CURVES_LIST:
-            return tls1_set_curves_list(NULL, NULL, parg);
+        case SSL_CTRL_SET_GROUPS_LIST:
+            return tls1_set_groups_list(NULL, NULL, parg);
 #endif
         case SSL_CTRL_SET_SIGALGS_LIST:
         case SSL_CTRL_SET_CLIENT_SIGALGS_LIST:
@@ -2630,7 +2630,7 @@ void SSL_CTX_free(SSL_CTX *a)
 
 #ifndef OPENSSL_NO_EC
     OPENSSL_free(a->tlsext_ecpointformatlist);
-    OPENSSL_free(a->tlsext_ellipticcurvelist);
+    OPENSSL_free(a->tlsext_supportedgroupslist);
 #endif
     OPENSSL_free(a->alpn_client_proto_list);
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -550,8 +550,8 @@ struct ssl_session_st {
 # ifndef OPENSSL_NO_EC
     size_t tlsext_ecpointformatlist_length;
     unsigned char *tlsext_ecpointformatlist; /* peer's list */
-    size_t tlsext_ellipticcurvelist_length;
-    unsigned char *tlsext_ellipticcurvelist; /* peer's list */
+    size_t tlsext_supportedgroupslist_length;
+    unsigned char *tlsext_supportedgroupslist; /* peer's list */
 # endif                         /* OPENSSL_NO_EC */
     /* RFC4507 info */
     unsigned char *tlsext_tick; /* Session ticket */
@@ -864,8 +864,8 @@ struct ssl_ctx_st {
     /* EC extension values inherited by SSL structure */
     size_t tlsext_ecpointformatlist_length;
     unsigned char *tlsext_ecpointformatlist;
-    size_t tlsext_ellipticcurvelist_length;
-    unsigned char *tlsext_ellipticcurvelist;
+    size_t tlsext_supportedgroupslist_length;
+    unsigned char *tlsext_supportedgroupslist;
 # endif                         /* OPENSSL_NO_EC */
 
     /* ext status type used for CSR extension (OCSP Stapling) */
@@ -1074,9 +1074,9 @@ struct ssl_st {
     size_t tlsext_ecpointformatlist_length;
     /* our list */
     unsigned char *tlsext_ecpointformatlist;
-    size_t tlsext_ellipticcurvelist_length;
+    size_t tlsext_supportedgroupslist_length;
     /* our list */
-    unsigned char *tlsext_ellipticcurvelist;
+    unsigned char *tlsext_supportedgroupslist;
 # endif                         /* OPENSSL_NO_EC */
     /* TLS Session Ticket extension override */
     TLS_SESSION_TICKET_EXT *tlsext_session_ticket;
@@ -2049,10 +2049,10 @@ SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 __owur int tls1_ec_curve_id2nid(int curve_id, unsigned int *pflags);
 __owur int tls1_ec_nid2curve_id(int nid);
 __owur int tls1_check_curve(SSL *s, const unsigned char *p, size_t len);
-__owur int tls1_shared_curve(SSL *s, int nmatch);
-__owur int tls1_set_curves(unsigned char **pext, size_t *pextlen,
+__owur int tls1_shared_group(SSL *s, int nmatch);
+__owur int tls1_set_groups(unsigned char **pext, size_t *pextlen,
                            int *curves, size_t ncurves);
-__owur int tls1_set_curves_list(unsigned char **pext, size_t *pextlen,
+__owur int tls1_set_groups_list(unsigned char **pext, size_t *pextlen,
                                 const char *str);
 __owur int tls1_check_ec_tmp_key(SSL *s, unsigned long id);
 __owur EVP_PKEY *ssl_generate_pkey_curve(int id);

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -132,7 +132,7 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
     dest->tlsext_hostname = NULL;
 #ifndef OPENSSL_NO_EC
     dest->tlsext_ecpointformatlist = NULL;
-    dest->tlsext_ellipticcurvelist = NULL;
+    dest->tlsext_supportedgroupslist = NULL;
 #endif
     dest->tlsext_tick = NULL;
 #ifndef OPENSSL_NO_SRP
@@ -198,11 +198,11 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
         if (dest->tlsext_ecpointformatlist == NULL)
             goto err;
     }
-    if (src->tlsext_ellipticcurvelist) {
-        dest->tlsext_ellipticcurvelist =
-            OPENSSL_memdup(src->tlsext_ellipticcurvelist,
-                           src->tlsext_ellipticcurvelist_length);
-        if (dest->tlsext_ellipticcurvelist == NULL)
+    if (src->tlsext_supportedgroupslist) {
+        dest->tlsext_supportedgroupslist =
+            OPENSSL_memdup(src->tlsext_supportedgroupslist,
+                           src->tlsext_supportedgroupslist_length);
+        if (dest->tlsext_supportedgroupslist == NULL)
             goto err;
     }
 #endif
@@ -753,8 +753,8 @@ void SSL_SESSION_free(SSL_SESSION *ss)
 #ifndef OPENSSL_NO_EC
     ss->tlsext_ecpointformatlist_length = 0;
     OPENSSL_free(ss->tlsext_ecpointformatlist);
-    ss->tlsext_ellipticcurvelist_length = 0;
-    OPENSSL_free(ss->tlsext_ellipticcurvelist);
+    ss->tlsext_supportedgroupslist_length = 0;
+    OPENSSL_free(ss->tlsext_supportedgroupslist);
 #endif                          /* OPENSSL_NO_EC */
 #ifndef OPENSSL_NO_PSK
     OPENSSL_free(ss->psk_identity_hint);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1730,7 +1730,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
         }
 
         /* Get NID of appropriate shared curve */
-        nid = tls1_shared_curve(s, -2);
+        nid = tls1_shared_group(s, -2);
         curve_id = tls1_ec_nid2curve_id(nid);
         if (curve_id == 0) {
             SSLerr(SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,

--- a/ssl/t1_ext.c
+++ b/ssl/t1_ext.c
@@ -242,7 +242,7 @@ int SSL_extension_supported(unsigned int ext_type)
         /* Internally supported extensions. */
     case TLSEXT_TYPE_application_layer_protocol_negotiation:
     case TLSEXT_TYPE_ec_point_formats:
-    case TLSEXT_TYPE_elliptic_curves:
+    case TLSEXT_TYPE_supported_groups:
     case TLSEXT_TYPE_heartbeat:
 #ifndef OPENSSL_NO_NEXTPROTONEG
     case TLSEXT_TYPE_next_proto_neg:

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -446,7 +446,7 @@ static ssl_trace_tbl ssl_exts_tbl[] = {
     {TLSEXT_TYPE_client_authz, "client_authz"},
     {TLSEXT_TYPE_server_authz, "server_authz"},
     {TLSEXT_TYPE_cert_type, "cert_type"},
-    {TLSEXT_TYPE_elliptic_curves, "elliptic_curves"},
+    {TLSEXT_TYPE_supported_groups, "supported_groups"},
     {TLSEXT_TYPE_ec_point_formats, "ec_point_formats"},
     {TLSEXT_TYPE_srp, "srp"},
     {TLSEXT_TYPE_signature_algorithms, "signature_algorithms"},
@@ -463,7 +463,7 @@ static ssl_trace_tbl ssl_exts_tbl[] = {
     {TLSEXT_TYPE_extended_master_secret, "extended_master_secret"}
 };
 
-static ssl_trace_tbl ssl_curve_tbl[] = {
+static ssl_trace_tbl ssl_groups_tbl[] = {
     {1, "sect163k1 (K-163)"},
     {2, "sect163r1"},
     {3, "sect163r2 (B-163)"},
@@ -662,13 +662,13 @@ static int ssl_print_extension(BIO *bio, int indent, int server, int extype,
             return 0;
         return ssl_trace_list(bio, indent + 2, ext + 1, xlen, 1, ssl_point_tbl);
 
-    case TLSEXT_TYPE_elliptic_curves:
+    case TLSEXT_TYPE_supported_groups:
         if (extlen < 2)
             return 0;
         xlen = (ext[0] << 8) | ext[1];
         if (extlen != xlen + 2)
             return 0;
-        return ssl_trace_list(bio, indent + 2, ext + 2, xlen, 2, ssl_curve_tbl);
+        return ssl_trace_list(bio, indent + 2, ext + 2, xlen, 2, ssl_groups_tbl);
 
     case TLSEXT_TYPE_signature_algorithms:
 
@@ -997,7 +997,7 @@ static int ssl_print_server_keyex(BIO *bio, int indent, SSL *ssl,
                 return 0;
             curve = (msg[1] << 8) | msg[2];
             BIO_printf(bio, "named_curve: %s (%d)\n",
-                       ssl_trace_str(curve, ssl_curve_tbl), curve);
+                       ssl_trace_str(curve, ssl_groups_tbl), curve);
             msg += 3;
             msglen -= 3;
             if (!ssl_print_hexbuf(bio, indent + 2, "point", 1, &msg, &msglen))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This is a skin deep change, which simply renames most places where we talk about curves in a TLS context to groups. This is because TLS1.3 has renamed the extension, and it can now include DH groups too. We still only support curves, but this rename should pave the way for a future inclusion of DH groups.