### PR TITLE
Fix 1.0.2 heartbeat test

### DIFF
--- a/ssl/heartbeat_test.c
+++ b/ssl/heartbeat_test.c
@@ -278,7 +278,7 @@ static int test_dtls1_not_bleeding()
 
     fixture.payload = &payload_buf[0];
     fixture.sent_payload_len = payload_buf_len;
-    fixture.expected_return_value = 0;
+    fixture.expected_return_value = -1;
     fixture.expected_payload_len = payload_buf_len;
     fixture.expected_return_payload =
         "Not bleeding, sixteen spaces of padding";
@@ -301,7 +301,7 @@ static int test_dtls1_not_bleeding_empty_payload()
 
     fixture.payload = &payload_buf[0];
     fixture.sent_payload_len = payload_buf_len;
-    fixture.expected_return_value = 0;
+    fixture.expected_return_value = -1;
     fixture.expected_payload_len = payload_buf_len;
     fixture.expected_return_payload = "";
     EXECUTE_HEARTBEAT_TEST();
@@ -370,7 +370,7 @@ static int test_tls1_not_bleeding()
 
     fixture.payload = &payload_buf[0];
     fixture.sent_payload_len = payload_buf_len;
-    fixture.expected_return_value = 0;
+    fixture.expected_return_value = -1;
     fixture.expected_payload_len = payload_buf_len;
     fixture.expected_return_payload =
         "Not bleeding, sixteen spaces of padding";
@@ -393,7 +393,7 @@ static int test_tls1_not_bleeding_empty_payload()
 
     fixture.payload = &payload_buf[0];
     fixture.sent_payload_len = payload_buf_len;
-    fixture.expected_return_value = 0;
+    fixture.expected_return_value = -1;
     fixture.expected_payload_len = payload_buf_len;
     fixture.expected_return_payload = "";
     EXECUTE_HEARTBEAT_TEST();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
The heartbeat_test reaches into the internals of libssl and calls some internal functions. It then checks the return value to check its what it expected. However commit fa4c374 changed the return value of these internal functions, and now the test is failing.

The solution is to update the test to look for the new return value.