### PR TITLE
do not fail the fuzzer with empty input

### DIFF
--- a/fuzz/conf.c
+++ b/fuzz/conf.c
@@ -20,10 +20,15 @@ int FuzzerInitialize(int *argc, char ***argv) {
 }
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len) {
-    CONF *conf = NCONF_new(NULL);
-    BIO *in = BIO_new(BIO_s_mem());
+    CONF *conf;
+    BIO *in;
     long eline;
+    if (!len) {
+        return 0;
+    }
 
+    conf = NCONF_new(NULL);
+    in = BIO_new(BIO_s_mem());
     OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
     NCONF_load_bio(conf, in, &eline);
     NCONF_free(conf);


### PR DESCRIPTION
BIO_write fails when len==0