### PR TITLE
Fail if an unrecognised record type is received (1.0.2)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,11 @@
 
  Changes between 1.0.2j and 1.0.2k [xx XXX xxxx]
 
-  *)
+  *) OpenSSL now fails if it receives an unrecognised record type in TLS1.0
+     or TLS1.1. Previously this only happened in SSLv3 and TLS1.2. This is to
+     prevent issues where no progress is being made and the peer continually
+     sends unrecognised record types, using up resources processing them.
+     [Matt Caswell]
 
  Changes between 1.0.2i and 1.0.2j [26 Sep 2016]
 

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -1605,16 +1605,13 @@ int ssl3_read_bytes(SSL *s, int type, unsigned char *buf, int len, int peek)
 
     switch (rr->type) {
     default:
-#ifndef OPENSSL_NO_TLS
         /*
-         * TLS up to v1.1 just ignores unknown message types: TLS v1.2 give
-         * an unexpected message alert.
+         * TLS 1.0 and 1.1 say you SHOULD ignore unrecognised record types, but
+         * TLS 1.2 says you MUST send an unexpected message alert. We use the
+         * TLS 1.2 behaviour for all protocol versions to prevent issues where
+         * no progress is being made and the peer continually sends unrecognised
+         * record types, using up resources processing them.
          */
-        if (s->version >= TLS1_VERSION && s->version <= TLS1_1_VERSION) {
-            rr->length = 0;
-            goto start;
-        }
-#endif
         al = SSL_AD_UNEXPECTED_MESSAGE;
         SSLerr(SSL_F_SSL3_READ_BYTES, SSL_R_UNEXPECTED_RECORD);
         goto f_err;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
TLS1.0 and TLS1.1 say you SHOULD ignore unrecognised record types, but TLS 1.2 says you MUST send an unexpected message alert. We swap to the TLS 1.2 behaviour for all protocol versions to prevent issues where no progress is being made and the peer continually sends unrecognised record types, using up resources processing them.

This is the 1.0.2 version of #1822 