### PR TITLE
0075 simple test

### DIFF
--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -66,7 +66,6 @@ static int execute_tbl_standard(SIMPLE_FIXTURE fixture)
 
 static void teardown_tbl_standard(SIMPLE_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 /**********************************************************************
@@ -116,7 +115,6 @@ static int execute_standard_methods(SIMPLE_FIXTURE fixture)
 
 static void teardown_standard_methods(SIMPLE_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 /**********************************************************************

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -18,27 +18,15 @@
 #include "testutil.h"
 #include "e_os.h"
 
-typedef struct {
-    const char *test_case_name;
-    const char *test_section;
-} SIMPLE_FIXTURE;
-
 /**********************************************************************
  *
  * Test of a_strnid's tbl_standard
  *
  ***/
 
-static SIMPLE_FIXTURE setup_tbl_standard(const char *const test_case_name)
-{
-    SIMPLE_FIXTURE fixture;
-    fixture.test_case_name = test_case_name;
-    return fixture;
-}
-
 #include "../crypto/asn1/tbl_standard.h"
 
-static int execute_tbl_standard(SIMPLE_FIXTURE fixture)
+static int test_tbl_standard()
 {
     const ASN1_STRING_TABLE *tmp;
     int last_nid = -1;
@@ -53,19 +41,15 @@ static int execute_tbl_standard(SIMPLE_FIXTURE fixture)
     }
 
     if (last_nid != 0) {
-        fprintf(stderr, "%s: Table order OK\n", fixture.test_section);
+        fprintf(stderr, "asn1 tbl_standard: Table order OK\n");
         return 1;
     }
 
     for (tmp = tbl_standard, i = 0; i < OSSL_NELEM(tbl_standard); i++, tmp++)
-        fprintf(stderr, "%s: Index %" OSSLzu ", NID %d, Name=%s\n",
-               fixture.test_section, i, tmp->nid, OBJ_nid2ln(tmp->nid));
+        fprintf(stderr, "asn1 tbl_standard: Index %" OSSLzu ", NID %d, Name=%s\n",
+                i, tmp->nid, OBJ_nid2ln(tmp->nid));
 
     return 0;
-}
-
-static void teardown_tbl_standard(SIMPLE_FIXTURE fixture)
-{
 }
 
 /**********************************************************************
@@ -74,17 +58,10 @@ static void teardown_tbl_standard(SIMPLE_FIXTURE fixture)
  *
  ***/
 
-static SIMPLE_FIXTURE setup_standard_methods(const char *const test_case_name)
-{
-    SIMPLE_FIXTURE fixture;
-    fixture.test_case_name = test_case_name;
-    return fixture;
-}
-
 #include "internal/asn1_int.h"
 #include "../crypto/asn1/standard_methods.h"
 
-static int execute_standard_methods(SIMPLE_FIXTURE fixture)
+static int test_standard_methods()
 {
     const EVP_PKEY_ASN1_METHOD **tmp;
     int last_pkey_id = -1;
@@ -100,51 +77,23 @@ static int execute_standard_methods(SIMPLE_FIXTURE fixture)
     }
 
     if (last_pkey_id != 0) {
-        fprintf(stderr, "%s: Table order OK\n", fixture.test_section);
+        fprintf(stderr, "asn1 standard methods: Table order OK\n");
         return 1;
     }
 
     for (tmp = standard_methods, i = 0; i < OSSL_NELEM(standard_methods);
          i++, tmp++)
-        fprintf(stderr, "%s: Index %" OSSLzu ", pkey ID %d, Name=%s\n",
-               fixture.test_section, i, (*tmp)->pkey_id,
-               OBJ_nid2sn((*tmp)->pkey_id));
+        fprintf(stderr, "asn1 standard methods: Index %" OSSLzu
+                ", pkey ID %d, Name=%s\n", i, (*tmp)->pkey_id,
+                OBJ_nid2sn((*tmp)->pkey_id));
 
     return 0;
 }
 
-static void teardown_standard_methods(SIMPLE_FIXTURE fixture)
-{
-}
-
-/**********************************************************************
- *
- * Test driver
- *
- ***/
-
-static struct {
-    const char *section;
-    SIMPLE_FIXTURE (*setup)(const char *const test_case_name);
-    int (*execute)(SIMPLE_FIXTURE);
-    void (*teardown)(SIMPLE_FIXTURE);
-} tests[] = {
-    {"asn1 tlb_standard", setup_tbl_standard, execute_tbl_standard,
-     teardown_tbl_standard},
-    {"asn1 standard_methods", setup_standard_methods, execute_standard_methods,
-     teardown_standard_methods}
-};
-
-static int drive_tests(int idx)
-{
-    SETUP_TEST_FIXTURE(SIMPLE_FIXTURE, tests[idx].setup);
-    fixture.test_section = tests[idx].section;
-    EXECUTE_TEST(tests[idx].execute, tests[idx].teardown);
-}
-
 int main(int argc, char **argv)
 {
-    ADD_ALL_TESTS(drive_tests, OSSL_NELEM(tests));
+    ADD_TEST(test_tbl_standard);
+    ADD_TEST(test_standard_methods);
 
     return run_tests(argv[0]);
 }

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -167,7 +167,6 @@ static void tear_down(CIPHERLIST_TEST_FIXTURE fixture)
 {
     SSL_CTX_free(fixture.server);
     SSL_CTX_free(fixture.client);
-    ERR_print_errors_fp(stderr);
 }
 
 #define SETUP_CIPHERLIST_TEST_FIXTURE() \

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -88,7 +88,6 @@ static void tear_down(CT_TEST_FIXTURE fixture)
 {
     CTLOG_STORE_free(fixture.ctlog_store);
     SCT_LIST_free(fixture.sct_list);
-    ERR_print_errors_fp(stderr);
 }
 
 static char *mk_file_path(const char *dir, const char *file)

--- a/test/d2i_test.c
+++ b/test/d2i_test.c
@@ -118,7 +118,6 @@ static int execute_test(D2I_TEST_FIXTURE fixture)
 
 static void tear_down(D2I_TEST_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 #define SETUP_D2I_TEST_FIXTURE() \

--- a/test/d2i_test.c
+++ b/test/d2i_test.c
@@ -41,18 +41,7 @@ typedef struct {
 
 static expected_error_t expected_error = ASN1_UNKNOWN;
 
-typedef struct d2i_test_fixture {
-    const char *test_case_name;
-} D2I_TEST_FIXTURE;
-
-static D2I_TEST_FIXTURE set_up(const char *const test_case_name)
-{
-    D2I_TEST_FIXTURE fixture;
-    fixture.test_case_name = test_case_name;
-    return fixture;
-}
-
-static int execute_test(D2I_TEST_FIXTURE fixture)
+static int test_bad_asn1()
 {
     BIO *bio = NULL;
     ASN1_VALUE *value = NULL;
@@ -114,22 +103,6 @@ static int execute_test(D2I_TEST_FIXTURE fixture)
     OPENSSL_free(der);
     ASN1_item_free(value, item_type);
     return ret;
-}
-
-static void tear_down(D2I_TEST_FIXTURE fixture)
-{
-}
-
-#define SETUP_D2I_TEST_FIXTURE() \
-    SETUP_TEST_FIXTURE(D2I_TEST_FIXTURE, set_up)
-
-#define EXECUTE_D2I_TEST() \
-    EXECUTE_TEST(execute_test, tear_down)
-
-static int test_bad_asn1()
-{
-    SETUP_D2I_TEST_FIXTURE();
-    EXECUTE_D2I_TEST();
 }
 
 /*

--- a/test/heartbeat_test.c
+++ b/test/heartbeat_test.c
@@ -155,7 +155,6 @@ static int dummy_handshake(SSL *s)
 
 static void tear_down(HEARTBEAT_TEST_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
     SSL_free(fixture.s);
     SSL_CTX_free(fixture.ctx);
 }
@@ -365,7 +364,6 @@ int main(int argc, char *argv[])
     ADD_TEST(test_dtls1_heartbleed_excessive_plaintext_length);
 
     result = run_tests(argv[0]);
-    ERR_print_errors_fp(stderr);
     return result;
 }
 

--- a/test/mdc2_internal_test.c
+++ b/test/mdc2_internal_test.c
@@ -60,7 +60,6 @@ static int execute_mdc2(SIMPLE_FIXTURE fixture)
 
 static void teardown_mdc2(SIMPLE_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 /**********************************************************************

--- a/test/modes_internal_test.c
+++ b/test/modes_internal_test.c
@@ -210,7 +210,6 @@ static int execute_cts128_nist(CTS128_FIXTURE fixture)
 
 static void teardown_cts128(CTS128_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 /**********************************************************************
@@ -279,7 +278,6 @@ static int execute_gcm128(GCM128_FIXTURE fixture)
 
 static void teardown_gcm128(GCM128_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 static void benchmark_gcm128(const unsigned char *K, size_t Klen,

--- a/test/poly1305_internal_test.c
+++ b/test/poly1305_internal_test.c
@@ -144,7 +144,6 @@ static int execute_poly1305(SIMPLE_FIXTURE fixture)
 
 static void teardown_poly1305(SIMPLE_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 static void benchmark_poly1305()

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -301,8 +301,6 @@ err:
     SSL_CTX_free(resume_server_ctx);
     SSL_CTX_free(resume_client_ctx);
     SSL_TEST_CTX_free(test_ctx);
-    if (ret != 1)
-        ERR_print_errors_fp(stderr);
     HANDSHAKE_RESULT_free(result);
     return ret;
 }

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -233,7 +233,6 @@ static int execute_failure_test(SSL_TEST_CTX_TEST_FIXTURE fixture)
 static void tear_down(SSL_TEST_CTX_TEST_FIXTURE fixture)
 {
     SSL_TEST_CTX_free(fixture.expected_ctx);
-    ERR_print_errors_fp(stderr);
 }
 
 #define SETUP_SSL_TEST_CTX_TEST_FIXTURE()                       \

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -12,7 +12,15 @@
 
 #include <openssl/err.h>
 
+/*
+ * In main(), call ADD_TEST to register each test case function, then call
+ * run_tests() to execute all tests and report the results. The result
+ * returned from run_tests() should be used as the return value for main().
+ */
+# define ADD_TEST(test_function) add_test(#test_function, test_function)
+
 /*-
+ * Test cases that share common setup should use the helper
  * SETUP_TEST_FIXTURE and EXECUTE_TEST macros for test case functions.
  *
  * SETUP_TEST_FIXTURE will call set_up() to create a new TEST_FIXTURE_TYPE
@@ -67,13 +75,6 @@
 # else
 #  define TEST_CASE_NAME __func__
 # endif                         /* __STDC_VERSION__ */
-
-/*
- * In main(), call ADD_TEST to register each test case function, then call
- * run_tests() to execute all tests and report the results. The result
- * returned from run_tests() should be used as the return value for main().
- */
-# define ADD_TEST(test_function) add_test(#test_function, test_function)
 
 /*
  * Simple parameterized tests. Adds a test_function(idx) test for each

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -17,28 +17,16 @@
 #include "testutil.h"
 #include "e_os.h"
 
-typedef struct {
-    const char *test_case_name;
-    const char *test_section;
-} SIMPLE_FIXTURE;
-
 /**********************************************************************
  *
  * Test of x509v3
  *
  ***/
 
-static SIMPLE_FIXTURE setup_standard_exts(const char *const test_case_name)
-{
-    SIMPLE_FIXTURE fixture;
-    fixture.test_case_name = test_case_name;
-    return fixture;
-}
-
 #include "../crypto/x509v3/ext_dat.h"
 #include "../crypto/x509v3/standard_exts.h"
 
-static int execute_standard_exts(SIMPLE_FIXTURE fixture)
+static int test_standard_exts()
 {
     size_t i;
     int prev = -1, good = 1;
@@ -64,36 +52,9 @@ static int execute_standard_exts(SIMPLE_FIXTURE fixture)
     return good;
 }
 
-static void teardown_standard_exts(SIMPLE_FIXTURE fixture)
-{
-}
-
-/**********************************************************************
- *
- * Test driver
- *
- ***/
-
-static struct {
-    const char *section;
-    SIMPLE_FIXTURE (*setup)(const char *const test_case_name);
-    int (*execute)(SIMPLE_FIXTURE);
-    void (*teardown)(SIMPLE_FIXTURE);
-} tests[] = {
-    {"standard_exts", setup_standard_exts, execute_standard_exts,
-     teardown_standard_exts},
-};
-
-static int drive_tests(int idx)
-{
-    SETUP_TEST_FIXTURE(SIMPLE_FIXTURE, tests[idx].setup);
-    fixture.test_section = tests[idx].section;
-    EXECUTE_TEST(tests[idx].execute, tests[idx].teardown);
-}
-
 int main(int argc, char **argv)
 {
-    ADD_ALL_TESTS(drive_tests, OSSL_NELEM(tests));
+    ADD_TEST(test_standard_exts);
 
     return run_tests(argv[0]);
 }

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -66,7 +66,6 @@ static int execute_standard_exts(SIMPLE_FIXTURE fixture)
 
 static void teardown_standard_exts(SIMPLE_FIXTURE fixture)
 {
-    ERR_print_errors_fp(stderr);
 }
 
 /**********************************************************************


### PR DESCRIPTION
    Don't create fixtures for simple tests
    
    The test fixtures are (meant to be) useful for sharing common
    setup. Don't bother when we don't have any setup/teardown.
    
    This only addresses simple tests. Parameterized tests (ADD_ALL_TESTS)
    will be made more user-friendly in a follow-up.

Based on https://github.com/openssl/openssl/pull/1835/ (only top commit for this PR).
