### PR TITLE
Always ensure that init_msg is initialised for a CCS

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -391,6 +391,7 @@ int tls_get_message_header(SSL *s, int *mt)
                 }
                 s->s3->tmp.message_type = *mt = SSL3_MT_CHANGE_CIPHER_SPEC;
                 s->init_num = readbytes - 1;
+                s->init_msg = s->init_buf->data;
                 s->s3->tmp.message_size = readbytes;
                 return 1;
             } else if (recvd_type != SSL3_RT_HANDSHAKE) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

We don't initialise init_msg for a CCS, but we read it later in grow_init_buf(). If CCS is the first thing received in a flight, then it will use the init_msg from the last flight we received. If the init_buf has been grown in the meantime then it will point to some arbitrary other memory location. This is likely to result in grow_init_buf() attempting to grow to some excessively large amount which is likely to fail. In practice this should never happen because the only time we receive a CCS as the first thing in a flight is in an abbreviated handshake. None of the preceding messages from the server flight would be large enough to trigger this. However this bug is causing a problem for the TLS1.3 work and should be fixed anyway.