### PR TITLE
Correct internal tests sources

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -1,3 +1,11 @@
+{-
+     use File::Spec::Functions;
+     sub rebase_files
+     {
+         my ($base, $files) = @_;
+         return join(" ", map { "$base/$_" } split(/\s+/, $files));
+     }
+-}
 IF[{- !$disabled{tests} -}]
   PROGRAMS_NO_INST=\
           aborttest \
@@ -325,8 +333,8 @@ IF[{- !$disabled{tests} -}]
   SOURCE[poly1305_internal_test]=poly1305_internal_test.c testutil.c
   IF[{- !$disabled{shared} -}]
     SOURCE[poly1305_internal_test]= ../crypto/poly1305/poly1305.c \
-        {- $target{poly1305_asm_src} ? "../crypto/poly1305/".$target{poly1305_asm_src} : "" -} \
-        {- $target{cpuid_asm_src} ? "../crypto/".$target{cpuid_asm_src} : "" -} \
+        {- rebase_files("../crypto/poly1305", $target{poly1305_asm_src}) -} \
+        {- rebase_files("../crypto", $target{cpuid_asm_src}) -} \
         ../crypto/cryptlib.c
   ENDIF
   INCLUDE[poly1305_internal_test]=.. ../include ../crypto/include
@@ -345,9 +353,8 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[modes_internal_test]=modes_internal_test.c testutil.c
   IF[{- !$disabled{shared} -}]
-    SOURCE[modes_internal_test]= {- $target{cpuid_asm_src}
-                                    ? "../crypto/".$target{cpuid_asm_src}
-                                    : "" -} \
+    SOURCE[modes_internal_test]= \
+        {- rebase_files("../crypto", $target{cpuid_asm_src}); -} \
         ../crypto/cryptlib.c
   ENDIF
   INCLUDE[modes_internal_test]=.. ../include


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

The sources for internal tests were sometimes badly formed, assuming
perl variables such as $target{cpuid_asm_src} contains only one file
name.  This change correctly massages all file names in such a
variable.