### PR TITLE
VMS build file template: assign 'arch' to local symbol table

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -222,7 +222,7 @@ NODEBUG=@
         $(NODEBUG) !
         $(NODEBUG) ! Figure out the architecture
         $(NODEBUG) !
-        $(NODEBUG) arch == f$edit( f$getsyi( "arch_name"), "upcase")
+        $(NODEBUG) arch = f$edit( f$getsyi( "arch_name"), "upcase")
         $(NODEBUG) !
         $(NODEBUG) ! Set up logical names for the libraries, so LINK and
         $(NODEBUG) ! running programs can use them.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Since the local symbol table is looked up before the global symbol
table, 'arch' assigned in the local symbol table of the DCL where MMS
is called would be seen before the 'arch' defined in descrip.mms.
Assigning it to the local symbol table in descrip.mms removes that
issue.