### PR TITLE
Fixed macro redefinition errors

### DIFF
--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -11,7 +11,8 @@
 #include "../async_locl.h"
 
 #ifdef ASYNC_WIN
-#define _WINSOCKAPI_  
+	
+# define _WINSOCKAPI_  
 # include <windows.h>
 # include "internal/cryptlib.h"
 

--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -11,7 +11,7 @@
 #include "../async_locl.h"
 
 #ifdef ASYNC_WIN
-
+#define _WINSOCKAPI_    // stops windows.h including winsock.h
 # include <windows.h>
 # include "internal/cryptlib.h"
 

--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -11,7 +11,7 @@
 #include "../async_locl.h"
 
 #ifdef ASYNC_WIN
-#define _WINSOCKAPI_    // stops windows.h including winsock.h
+#define _WINSOCKAPI_  
 # include <windows.h>
 # include "internal/cryptlib.h"
 

--- a/crypto/async/async_locl.h
+++ b/crypto/async/async_locl.h
@@ -17,7 +17,7 @@
 #endif
 
 #if defined(_WIN32)
-#define _WINSOCKAPI_  
+# define _WINSOCKAPI_  
 # include <windows.h>
 #endif
 

--- a/crypto/async/async_locl.h
+++ b/crypto/async/async_locl.h
@@ -17,6 +17,7 @@
 #endif
 
 #if defined(_WIN32)
+#define _WINSOCKAPI_    // stops windows.h including winsock.h
 # include <windows.h>
 #endif
 

--- a/crypto/async/async_locl.h
+++ b/crypto/async/async_locl.h
@@ -17,7 +17,7 @@
 #endif
 
 #if defined(_WIN32)
-#define _WINSOCKAPI_    // stops windows.h including winsock.h
+#define _WINSOCKAPI_  
 # include <windows.h>
 #endif
 

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -74,7 +74,7 @@ static COMP_METHOD zlib_stateful_method = {
  * and we do not link to a .LIB file when ZLIB_SHARED is set.
  */
 # if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
-#define _WINSOCKAPI_    // stops windows.h including winsock.h
+#define _WINSOCKAPI_   
 #  include <windows.h>
 # endif                         /* !(OPENSSL_SYS_WINDOWS ||
                                  * OPENSSL_SYS_WIN32) */

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -74,6 +74,7 @@ static COMP_METHOD zlib_stateful_method = {
  * and we do not link to a .LIB file when ZLIB_SHARED is set.
  */
 # if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
+#define _WINSOCKAPI_    // stops windows.h including winsock.h
 #  include <windows.h>
 # endif                         /* !(OPENSSL_SYS_WINDOWS ||
                                  * OPENSSL_SYS_WIN32) */

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -74,7 +74,7 @@ static COMP_METHOD zlib_stateful_method = {
  * and we do not link to a .LIB file when ZLIB_SHARED is set.
  */
 # if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
-#define _WINSOCKAPI_   
+# define _WINSOCKAPI_   
 #  include <windows.h>
 # endif                         /* !(OPENSSL_SYS_WINDOWS ||
                                  * OPENSSL_SYS_WIN32) */

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -12,6 +12,7 @@
 #include "rand_lcl.h"
 
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
+#define _WINSOCKAPI_    // stops windows.h including winsock.h
 # include <windows.h>
 /* On Windows 7 or higher use BCrypt instead of the legacy CryptoAPI */
 # if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT>=0x0601

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -12,7 +12,7 @@
 #include "rand_lcl.h"
 
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
-#define _WINSOCKAPI_    // stops windows.h including winsock.h
+#define _WINSOCKAPI_   
 # include <windows.h>
 /* On Windows 7 or higher use BCrypt instead of the legacy CryptoAPI */
 # if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT>=0x0601

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -12,7 +12,7 @@
 #include "rand_lcl.h"
 
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
-#define _WINSOCKAPI_   
+# define _WINSOCKAPI_   
 # include <windows.h>
 /* On Windows 7 or higher use BCrypt instead of the legacy CryptoAPI */
 # if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT>=0x0601

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -8,6 +8,7 @@
  */
 
 #if defined(_WIN32)
+#define _WINSOCKAPI_    // stops windows.h including winsock.h
 # include <windows.h>
 #endif
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -8,7 +8,7 @@
  */
 
 #if defined(_WIN32)
-#define _WINSOCKAPI_    // stops windows.h including winsock.h
+#define _WINSOCKAPI_  
 # include <windows.h>
 #endif
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -8,7 +8,7 @@
  */
 
 #if defined(_WIN32)
-#define _WINSOCKAPI_  
+# define _WINSOCKAPI_  
 # include <windows.h>
 #endif
 

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -61,6 +61,7 @@
 #endif
 
 #ifdef WIN_CONSOLE_BUG
+#define _WINSOCKAPI_    // stops windows.h including winsock.h
 # include <windows.h>
 # ifndef OPENSSL_SYS_WINCE
 #  include <wincon.h>

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -61,7 +61,7 @@
 #endif
 
 #ifdef WIN_CONSOLE_BUG
-#define _WINSOCKAPI_   
+# define _WINSOCKAPI_   
 # include <windows.h>
 # ifndef OPENSSL_SYS_WINCE
 #  include <wincon.h>

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -61,7 +61,7 @@
 #endif
 
 #ifdef WIN_CONSOLE_BUG
-#define _WINSOCKAPI_    // stops windows.h including winsock.h
+#define _WINSOCKAPI_   
 # include <windows.h>
 # ifndef OPENSSL_SYS_WINCE
 #  include <wincon.h>


### PR DESCRIPTION
When including windows in different files, the macro _WINSOCKAPI_ should
be defined before to prevent the inclusion of the winsock.h file. 