### PR TITLE
VMS: pretend to use -znodelete

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1767,6 +1767,7 @@ sub vms_info {
         cflags           => picker(default => "/STANDARD=(ISOC94,RELAXED)/NOLIST/PREFIX=ALL",
                                    debug   => "/NOOPTIMIZE/DEBUG",
                                    release => "/OPTIMIZE/NODEBUG"),
+        defines          => add("OPENSSL_USE_NODELETE"),
         lflags           => picker(default => "/MAP",
                                    debug   => "/DEBUG/TRACEBACK",
                                    release => "/NODEBUG/NOTRACEBACK"),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

VMS only unloads shared libraries at process rundown, so tell the
OpenSSL code so by pretending we linked with -znodelete.