### PR TITLE
Simplify tests part 2

### DIFF
--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -507,20 +507,20 @@ static int test_encode_tls_sct()
     SCT *sct = SCT_new();
     if (!SCT_set_version(sct, SCT_VERSION_V1)) {
         fprintf(stderr, "Failed to set SCT version\n");
-        return 1;
+        return 0;
     }
     if (!SCT_set1_log_id(sct, log_id, 32)) {
         fprintf(stderr, "Failed to set SCT log ID\n");
-        return 1;
+        return 0;
     }
     SCT_set_timestamp(sct, 1);
     if (!SCT_set_signature_nid(sct, NID_ecdsa_with_SHA256)) {
         fprintf(stderr, "Failed to set SCT signature NID\n");
-        return 1;
+        return 0;
     }
     if (!SCT_set1_signature(sct, signature, 71)) {
         fprintf(stderr, "Failed to set SCT signature\n");
-        return 1;
+        return 0;
     }
     sk_SCT_push(sct_list, sct);
 

--- a/test/mdc2_internal_test.c
+++ b/test/mdc2_internal_test.c
@@ -21,46 +21,6 @@ typedef struct {
     const unsigned char expected[MDC2_DIGEST_LENGTH];
 } TESTDATA;
 
-typedef struct {
-    const char *case_name;
-    int num;
-    const TESTDATA *data;
-} SIMPLE_FIXTURE;
-
-/**********************************************************************
- *
- * Test of mdc2 internal functions
- *
- ***/
-
-static SIMPLE_FIXTURE setup_mdc2(const char *const test_case_name)
-{
-    SIMPLE_FIXTURE fixture;
-    fixture.case_name = test_case_name;
-    return fixture;
-}
-
-static int execute_mdc2(SIMPLE_FIXTURE fixture)
-{
-    unsigned char md[MDC2_DIGEST_LENGTH];
-    MDC2_CTX c;
-
-    MDC2_Init(&c);
-    MDC2_Update(&c, (const unsigned char *)fixture.data->input,
-                strlen(fixture.data->input));
-    MDC2_Final(&(md[0]), &c);
-
-    if (memcmp(fixture.data->expected, md, MDC2_DIGEST_LENGTH)) {
-        fprintf(stderr, "mdc2 test %d: unexpected output\n", fixture.num);
-        return 0;
-    }
-
-    return 1;
-}
-
-static void teardown_mdc2(SIMPLE_FIXTURE fixture)
-{
-}
 
 /**********************************************************************
  *
@@ -78,17 +38,34 @@ static TESTDATA tests[] = {
     }
 };
 
-static int drive_tests(int idx)
+/**********************************************************************
+ *
+ * Test of mdc2 internal functions
+ *
+ ***/
+
+static int test_mdc2(int idx)
 {
-    SETUP_TEST_FIXTURE(SIMPLE_FIXTURE, setup_mdc2);
-    fixture.num = idx;
-    fixture.data = &tests[idx];
-    EXECUTE_TEST(execute_mdc2, teardown_mdc2);
+    unsigned char md[MDC2_DIGEST_LENGTH];
+    MDC2_CTX c;
+    const TESTDATA testdata = tests[idx];
+
+    MDC2_Init(&c);
+    MDC2_Update(&c, (const unsigned char *)testdata.input,
+                strlen(testdata.input));
+    MDC2_Final(&(md[0]), &c);
+
+    if (memcmp(testdata.expected, md, MDC2_DIGEST_LENGTH)) {
+        fprintf(stderr, "mdc2 test %d: unexpected output\n", idx);
+        return 0;
+    }
+
+    return 1;
 }
 
 int main(int argc, char **argv)
 {
-    ADD_ALL_TESTS(drive_tests, OSSL_NELEM(tests));
+    ADD_ALL_TESTS(test_mdc2, OSSL_NELEM(tests));
 
     return run_tests(argv[0]);
 }

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -216,20 +216,6 @@ static int execute_test(SSL_TEST_CTX_TEST_FIXTURE fixture)
     return success;
 }
 
-static int execute_failure_test(SSL_TEST_CTX_TEST_FIXTURE fixture)
-{
-    SSL_TEST_CTX *ctx = SSL_TEST_CTX_create(conf, fixture.test_section);
-
-    if (ctx != NULL) {
-        fprintf(stderr, "Parsing bad configuration %s succeeded.\n",
-                fixture.test_section);
-        SSL_TEST_CTX_free(ctx);
-        return 0;
-    }
-
-    return 1;
-}
-
 static void tear_down(SSL_TEST_CTX_TEST_FIXTURE fixture)
 {
     SSL_TEST_CTX_free(fixture.expected_ctx);
@@ -239,8 +225,6 @@ static void tear_down(SSL_TEST_CTX_TEST_FIXTURE fixture)
     SETUP_TEST_FIXTURE(SSL_TEST_CTX_TEST_FIXTURE, set_up)
 #define EXECUTE_SSL_TEST_CTX_TEST()             \
     EXECUTE_TEST(execute_test, tear_down)
-#define EXECUTE_SSL_TEST_CTX_FAILURE_TEST()             \
-    EXECUTE_TEST(execute_failure_test, tear_down)
 
 static int test_empty_configuration()
 {
@@ -307,9 +291,16 @@ static const char *bad_configurations[] = {
 
 static int test_bad_configuration(int idx)
 {
-        SETUP_SSL_TEST_CTX_TEST_FIXTURE();
-        fixture.test_section = bad_configurations[idx];
-        EXECUTE_SSL_TEST_CTX_FAILURE_TEST();
+    SSL_TEST_CTX *ctx = SSL_TEST_CTX_create(conf, bad_configurations[idx]);
+
+    if (ctx != NULL) {
+        fprintf(stderr, "Parsing bad configuration %s succeeded.\n",
+                bad_configurations[idx]);
+        SSL_TEST_CTX_free(ctx);
+        return 0;
+    }
+
+    return 1;
 }
 
 int main(int argc, char **argv)

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -60,6 +60,11 @@
         tear_down(fixture);\
         return result
 
+/* Shorthand if tear_down does nothing. */
+# define EXECUTE_TEST_NO_TEARDOWN(execute_func)\
+        result = execute_func(fixture);\
+        return result
+
 /*
  * TEST_CASE_NAME is defined as the name of the test case function where
  * possible; otherwise we get by with the file name and line number.


### PR DESCRIPTION
1) Remove some unnecessary fixtures
2) Add EXECUTE_TEST_NO_TEARDOWN shorthand when a fixture exists but has
no teardown.
3) Fix return values in ct_test.c (introduced by an earlier refactoring,
oops)

Note that for parameterized tests, the index (test vector) usually holds all the
customization, and there should be no need for a separate test
fixture. The CTS test is an exception: it demonstrates how to combine
customization with parameterization.