### PR TITLE
TLSv1.3: Don't check the record version

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -204,8 +204,9 @@ int ssl3_get_record(SSL *s)
                 rr[num_recs].rec_version = version;
                 n2s(p, rr[num_recs].length);
 
-                /* Lets check version */
-                if (!s->first_packet && version != s->version) {
+                /* Lets check version. In TLSv1.3 we ignore this field */
+                if (!s->first_packet && s->version != TLS1_3_VERSION
+                        && version != s->version) {
                     SSLerr(SSL_F_SSL3_GET_RECORD, SSL_R_WRONG_VERSION_NUMBER);
                     if ((s->version & 0xFF00) == (version & 0xFF00)
                         && !s->enc_write_ctx && !s->write_hash) {

--- a/test/recipes/70-test_sslcbcpadding.t
+++ b/test/recipes/70-test_sslcbcpadding.t
@@ -48,6 +48,7 @@ ok(TLSProxy::Message->success(), "Maximally-padded record test");
 # Test that invalid padding is rejected.
 foreach my $offset (@test_offsets) {
     $proxy->clear();
+    $proxy->serverflags("-tls1_2");
     $bad_padding_offset = $offset;
     $proxy->start();
     ok(TLSProxy::Message->fail(), "Invalid padding byte $bad_padding_offset");

--- a/util/TLSProxy/Record.pm
+++ b/util/TLSProxy/Record.pm
@@ -278,11 +278,6 @@ sub content_type
     my $self = shift;
     return $self->{content_type};
 }
-sub version
-{
-    my $self = shift;
-    return $self->{version};
-}
 sub sslv2
 {
     my $self = shift;
@@ -331,5 +326,13 @@ sub len
       $self->{len} = shift;
     }
     return $self->{len};
+}
+sub version
+{
+    my $self = shift;
+    if (@_) {
+      $self->{version} = shift;
+    }
+    return $self->{version};
 }
 1;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
The record layer version field must be ignored in TLSv1.3, so we remove the check when using that version.