### PR TITLE
Fix zlib BIO_METHOD for latest BIO_METHOD structure changes

### DIFF
--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -297,7 +297,11 @@ static long bio_zlib_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp);
 static const BIO_METHOD bio_meth_zlib = {
     BIO_TYPE_COMP,
     "zlib",
+    /* TODO: Convert to new style write function */
+    bwrite_conv,
     bio_zlib_write,
+    /* TODO: Convert to new style read function */
+    bread_conv,
     bio_zlib_read,
     NULL,
     NULL,


### PR DESCRIPTION
Fixes a compilation failure in master when compiling with zlib-dynamic

