### PR TITLE
add OCSP_resp_get1_id() accessor

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <time.h>
 #include "internal/cryptlib.h"
+#include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>
@@ -199,9 +200,9 @@ const STACK_OF(X509) *OCSP_resp_get0_certs(const OCSP_BASICRESP *bs)
 int OCSP_resp_get0_id(const OCSP_BASICRESP *bs,
                       const ASN1_OCTET_STRING **pid,
                       const X509_NAME **pname)
-
 {
     const OCSP_RESPID *rid = &bs->tbsResponseData.responderId;
+
     if (rid->type == V_OCSP_RESPID_NAME) {
         *pname = rid->value.byName;
         *pid = NULL;
@@ -211,6 +212,26 @@ int OCSP_resp_get0_id(const OCSP_BASICRESP *bs,
     } else {
         return 0;
     }
+    return 1;
+}
+
+int OCSP_resp_get1_id(const OCSP_BASICRESP *bs,
+                      ASN1_OCTET_STRING **pid,
+                      X509_NAME **pname)
+{
+    const OCSP_RESPID *rid = &bs->tbsResponseData.responderId;
+
+    if (rid->type == V_OCSP_RESPID_NAME) {
+        *pname = X509_NAME_dup(rid->value.byName);
+        *pid = NULL;
+    } else if (rid->type == V_OCSP_RESPID_KEY) {
+        *pid = ASN1_OCTET_STRING_dup(rid->value.byKey);
+        *pname = NULL;
+    } else {
+        return 0;
+    }
+    if (!pname && !pid)
+        return -1;
     return 1;
 }
 

--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -230,8 +230,8 @@ int OCSP_resp_get1_id(const OCSP_BASICRESP *bs,
     } else {
         return 0;
     }
-    if (!pname && !pid)
-        return -1;
+    if (pname == NULL && pid == NULL)
+        return 0;
     return 1;
 }
 

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -4,6 +4,7 @@
 
 OCSP_resp_get0_certs,
 OCSP_resp_get0_id,
+OCSP_resp_get1_id,
 OCSP_resp_get0_produced_at,
 OCSP_resp_find_status, OCSP_resp_count, OCSP_resp_get0, OCSP_resp_find,
 OCSP_single_get0_status, OCSP_check_validity
@@ -35,6 +36,9 @@ OCSP_single_get0_status, OCSP_check_validity
  int OCSP_resp_get0_id(const OCSP_BASICRESP *bs,
                        const ASN1_OCTET_STRING **pid,
                        const X509_NAME **pname);
+ int OCSP_resp_get1_id(const OCSP_BASICRESP *bs,
+                       ASN1_OCTET_STRING **pid,
+                       X509_NAME **pname);
 
  int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
                          ASN1_GENERALIZEDTIME *nextupd,
@@ -75,7 +79,8 @@ OCSP_resp_get0_certs() returns any certificates included in B<bs>.
 OCSP_resp_get0_id() gets the responder id of <bs>. If the responder ID is
 a name then <*pname> is set to the name and B<*pid> is set to NULL. If the
 responder ID is by key ID then B<*pid> is set to the key ID and B<*pname>
-is set to NULL.
+is set to NULL. OCSP_resp_get1_id() leaves ownership of B<*pid> and B<*pname>
+with the caller, who is responsible for freeing them.
 
 OCSP_check_validity() checks the validity of B<thisupd> and B<nextupd> values
 which will be typically obtained from OCSP_resp_find_status() or

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -80,7 +80,9 @@ OCSP_resp_get0_id() gets the responder id of <bs>. If the responder ID is
 a name then <*pname> is set to the name and B<*pid> is set to NULL. If the
 responder ID is by key ID then B<*pid> is set to the key ID and B<*pname>
 is set to NULL. OCSP_resp_get1_id() leaves ownership of B<*pid> and B<*pname>
-with the caller, who is responsible for freeing them.
+with the caller, who is responsible for freeing them. Both functions return 1
+in case of success and 0 in case of failure. If OCSP_resp_get1_id() returns 0,
+no freeing of the results is necessary.
 
 OCSP_check_validity() checks the validity of B<thisupd> and B<nextupd> values
 which will be typically obtained from OCSP_resp_find_status() or

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -218,6 +218,9 @@ const STACK_OF(X509) *OCSP_resp_get0_certs(const OCSP_BASICRESP *bs);
 int OCSP_resp_get0_id(const OCSP_BASICRESP *bs,
                       const ASN1_OCTET_STRING **pid,
                       const X509_NAME **pname);
+int OCSP_resp_get1_id(const OCSP_BASICRESP *bs,
+                      ASN1_OCTET_STRING **pid,
+                      X509_NAME **pname);
 
 int OCSP_resp_find(OCSP_BASICRESP *bs, OCSP_CERTID *id, int last);
 int OCSP_single_get0_status(OCSP_SINGLERESP *single, int *reason,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4270,3 +4270,4 @@ UINT32_it                               4214	1_1_0f	EXIST:!EXPORT_VAR_AS_FUNCTIO
 UINT32_it                               4214	1_1_0f	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 ZINT64_it                               4215	1_1_0f	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 ZINT64_it                               4215	1_1_0f	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
+OCSP_resp_get1_id                       4216	1_1_0f	EXIST::FUNCTION:OCSP


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated -> no tests for `get0` variant present in the first place, would be keen on adding tests if someone could provide some pointers to how to get test data
- [x] CLA is signed -> sent via email before PR was filed

##### Description of change
As brought up in https://mta.openssl.org/pipermail/openssl-users/2016-November/004796.html and https://mta.openssl.org/pipermail/openssl-dev/2016-November/008696.html, this PR adds a `get1` style getter for OCSP response info, in particular to facilitate interoperability with downstream functions like `X509_find_by_subject()`, which do not accept `const` arguments.