### PR TITLE
Fixed the return code of RAND_query_egd_bytes when connect fails.

### DIFF
--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -228,10 +228,10 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
 
 int RAND_egd_bytes(const char *path, int bytes)
 {
-    int num, ret = 0;
+    int num, ret = -1;
 
     num = RAND_query_egd_bytes(path, NULL, bytes);
-    if (num < 1 || RAND_status() == 1)
+    if (RAND_status() == 1)
         ret = num;
  err:
     return (ret);

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -231,6 +231,8 @@ int RAND_egd_bytes(const char *path, int bytes)
     int num, ret = -1;
 
     num = RAND_query_egd_bytes(path, NULL, bytes);
+    if (num < 0)
+        goto err;
     if (RAND_status() == 1)
         ret = num;
  err:

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -133,6 +133,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
                 break;
 #  endif
             default:
+                ret = -1;
                 goto err;       /* failure */
             }
         }
@@ -230,9 +231,7 @@ int RAND_egd_bytes(const char *path, int bytes)
     int num, ret = 0;
 
     num = RAND_query_egd_bytes(path, NULL, bytes);
-    if (num < 1)
-        goto err;
-    if (RAND_status() == 1)
+    if (num < 1 || RAND_status() == 1)
         ret = num;
  err:
     return (ret);


### PR DESCRIPTION
According to the documentation of RAND_query_egd_bytes and RAND_egd_bytes, they should return -1 when an error occurs during connection or communication. But if **connect** fails, RAND_query_egd_bytes returns 0. The correct return code should be -1.