### PR TITLE
Fix linking of internal tests

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -339,6 +339,17 @@ source as well.  However, the files given through SOURCE are expected
 to be located in the source tree while files given through DEPEND are
 expected to be located in the build tree)
 
+It's also possible to depend on static libraries explicitely:
+
+    DEPEND[foo]=libsomething.a
+    DEPEND[libbar]=libsomethingelse.a
+
+This should be rarely used, and care should be taken to make sure it's
+only used when supported.  For example, native Windows build doesn't
+support build static libraries and DLLs at the same time, so using
+static libraries on Windows can only be done when configured
+'no-shared'.
+
 For some libraries, we maintain files with public symbols and their
 slot in a transfer vector (important on some platforms).  It can be
 declared like this:

--- a/Configurations/README.design
+++ b/Configurations/README.design
@@ -133,7 +133,7 @@ library 'libssl' is built from the source file 'ssl/tls.c'.
 
     ENGINES_NO_INST=ossltest
     SOURCE[ossltest]=e_ossltest.c
-    DEPEND[ossltest]=../libcrypto
+    DEPEND[ossltest]=../libcrypto.a
     INCLUDE[ossltest]=../include
 
 This is the build.info file in 'engines/', telling us that two engines
@@ -142,8 +142,9 @@ dasync's source is 'engines/e_dasync.c' and ossltest's source is
 'engines/e_ossltest.c' and that the include directory 'include/' may
 be used when building anything that will be part of these engines.
 Also, both engines depend on the library 'libcrypto' to function
-properly.  Finally, only dasync is being installed, as ossltest is
-only for internal testing.
+properly.  ossltest is explicitely linked with the static variant of
+the library 'libcrypto'.  Finally, only dasync is being installed, as
+ossltest is only for internal testing.
 
 When Configure digests these build.info files, the accumulated
 information comes down to this:
@@ -170,7 +171,7 @@ information comes down to this:
 
     ENGINES_NO_INST=engines/ossltest
     SOURCE[engines/ossltest]=engines/e_ossltest.c
-    DEPEND[engines/ossltest]=libcrypto
+    DEPEND[engines/ossltest]=libcrypto.a
     INCLUDE[engines/ossltest]=include
     
     GENERATE[crypto/buildinf.h]=util/mkbuildinf.pl "$(CC) $(CFLAGS)" "$(PLATFORM)"
@@ -281,9 +282,13 @@ section above would be digested into a %unified_info table:
                     [
                         "crypto/buildinf.h",
                     ],
-                "engines/ossltest" =>
+                "engines/dasync" =>
                     [
                         "libcrypto",
+                    ],
+                "engines/ossltest" =>
+                    [
+                        "libcrypto.a",
                     ],
                 "libssl" =>
                     [
@@ -395,6 +400,14 @@ section above would be digested into a %unified_info table:
                 "crypto/evp.o" =>
                     [
                         "crypto/evp.c",
+                    ],
+                "engines/e_dasync.o" =>
+                    [
+                        "engines/e_dasync.c",
+                    ],
+                "engines/dasync" =>
+                    [
+                        "engines/e_dasync.o",
                     ],
                 "engines/e_ossltest.o" =>
                     [

--- a/Configurations/README.design
+++ b/Configurations/README.design
@@ -142,7 +142,7 @@ dasync's source is 'engines/e_dasync.c' and ossltest's source is
 'engines/e_ossltest.c' and that the include directory 'include/' may
 be used when building anything that will be part of these engines.
 Also, both engines depend on the library 'libcrypto' to function
-properly.  ossltest is explicitely linked with the static variant of
+properly.  ossltest is explicitly linked with the static variant of
 the library 'libcrypto'.  Finally, only dasync is being installed, as
 ossltest is only for internal testing.
 

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -9,15 +9,22 @@
  # there are no duplicate dependencies and that they are in the
  # right order.  This is especially used to sort the list of
  # libraries that a build depends on.
+ sub extensionlesslib {
+     my @result = map { $_ =~ /(\.a)?$/; $` } @_;
+     return @result if wantarray;
+     return $result[0];
+ }
  sub resolvedepends {
      my $thing = shift;
+     my $extensionlessthing = extensionlesslib($thing);
      my @listsofar = @_;    # to check if we're looping
-     my @list = @{$unified_info{depends}->{$thing}};
+     my @list = @{$unified_info{depends}->{$extensionlessthing}};
      my @newlist = ();
      if (scalar @list) {
          foreach my $item (@list) {
+             my $extensionlessitem = extensionlesslib($item);
              # It's time to break off when the dependency list starts looping
-             next if grep { $_ eq $item } @listsofar;
+             next if grep { extensionlesslib($_) eq $extensionlessitem } @listsofar;
              push @newlist, $item, resolvedepends($item, @listsofar, $item);
          }
      }
@@ -28,8 +35,9 @@
      my @newlist = ();
      while (@list) {
          my $item = shift @list;
+         my $extensionlessitem = extensionlesslib($item);
          push @newlist, $item
-             unless grep { $item eq $_ } @list;
+             unless grep { $extensionlessitem eq extensionlesslib($_) } @list;
      }
      @newlist;
  }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -529,6 +529,17 @@ configdata.pm : $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{bu
   use File::Basename;
   use File::Spec::Functions qw/abs2rel rel2abs catfile catdir/;
 
+  # Helper function to figure out dependencies on libraries
+  # It takes a list of library names and outputs a list of dependencies
+  sub compute_lib_depends {
+      if ($disabled{shared}) {
+          return map { $_ =~ /\.a$/ ? $`.".OLB" : $_.".OLB" } @_;
+      }
+      return map { $_ =~ /\.a$/
+                   ? $`.".OLB"
+                   : $unified_info{sharednames}->{$_}.".EXE" } @_;
+  }
+
   sub generatesrc {
       my %args = @_;
       my $generator = join(" ", @{$args{generator}});
@@ -631,9 +642,7 @@ EOF
       my $libd = dirname($lib);
       my $libn = basename($lib);
       (my $mkdef_key = $libn) =~ s/^${osslprefix_q}lib([^0-9]*)\d*/$1/i;
-      my @deps = map {
-          $disabled{shared} ? $_.".OLB"
-              : $unified_info{sharednames}->{$_}.".EXE"; } @{$args{deps}};
+      my @deps = compute_lib_depends(@{$args{deps}});
       my $deps = join(", -\n\t\t", @deps);
       my $shlib_target = $disabled{shared} ? "" : $target{shared_target};
       my $ordinalsfile = defined($args{ordinals}) ? $args{ordinals}->[1] : "";
@@ -679,9 +688,7 @@ EOF
       my $libn = basename($lib);
       (my $libn_nolib = $libn) =~ s/^lib//;
       my @objs = map { "$_.OBJ" } @{$args{objs}};
-      my @deps = map {
-          $disabled{shared} ? $_.".OLB"
-              : $unified_info{sharednames}->{$_}.".EXE"; } @{$args{deps}};
+      my @deps = compute_lib_depends(@{$args{deps}});
       my $deps = join(", -\n\t\t", @objs, @deps);
       my $shlib_target = $disabled{shared} ? "" : $target{shared_target};
       my $engine_opt = abs2rel(rel2abs(catfile($config{sourcedir},
@@ -731,9 +738,7 @@ EOF
       my $bind = dirname($bin);
       my $binn = basename($bin);
       my @objs = map { "$_.OBJ" } @{$args{objs}};
-      my @deps = map {
-          $disabled{shared} ? $_.".OLB"
-              : $unified_info{sharednames}->{$_}.".EXE"; } @{$args{deps}};
+      my @deps = compute_lib_depends(@{$args{deps}});
       my $deps = join(", -\n\t\t", @objs, @deps);
       # The "[]" hack is because in .OPT files, each line inherits the
       # previous line's file spec as default, so if no directory spec

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -63,12 +63,8 @@
   }
   my $sd1 = sourcedir("ssl","record");
   my $sd2 = sourcedir("ssl","statem");
-  my @ssl_locl_users =
-      ( "[.test]cipher_overhead_test.o",
-        "[.test]dtls_mtu_test.o",
-        "[.test]heartbeat_test.o",
-        "[.test]ssltest_old.o",
-        grep /^\[\.ssl\.(?:record|statem)\].*\.o$/, keys %{$unified_info{sources}} );
+  my @ssl_locl_users = grep(/^\[\.(?:ssl\.(?:record|statem)|test)\].*\.o$/,
+                            keys %{$unified_info{sources}});
   foreach (@ssl_locl_users) {
       (my $x = $_) =~ s|\.o$|.OBJ|;
       $unified_info{before}->{$x}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -844,13 +844,13 @@ configdata.pm: $(SRCDIR)/Configure $(SRCDIR)/config {- join(" ", @{$config{build
   # It takes a list of library names and outputs a list of dependencies
   sub compute_lib_depends {
       if ($disabled{shared}) {
-          return map { $_.$libext } @_;
+          return map { $_ =~ /\.a$/ ? $`.$libext : $_.$libext } @_;
       }
 
       # Depending on shared libraries:
       # On Windows POSIX layers, we depend on {libname}.dll.a
       # On Unix platforms, we depend on {shlibname}.so
-      return map { shlib_simple($_) } @_;
+      return map { $_ =~ /\.a$/ ? $`.$libext : shlib_simple($_) } @_;
   }
 
   sub generatesrc {
@@ -1073,11 +1073,16 @@ EOF
       my $binn = basename($bin);
       my $objs = join(" ", map { $_.$objext } @{$args{objs}});
       my $deps = join(" ",compute_lib_depends(@{$args{deps}}));
-      my $linklibs = join("", map { my $d = dirname($_);
-                                    my $f = basename($_);
-                                    $d = "." if $d eq $f;
-                                    (my $l = $f) =~ s/^lib//;
-                                    " -L$d -l$l" } @{$args{deps}});
+      my $linklibs = join("", map { if ($_ =~ /\.a$/) {
+                                        " $_";
+                                    } else {
+                                        my $d = dirname($_);
+                                        my $f = basename($_);
+                                        $d = "." if $d eq $f;
+                                        (my $l = $f) =~ s/^lib//;
+                                        " -L$d -l$l"
+                                    }
+                                  } @{$args{deps}});
       my $shlib_target = $disabled{shared} ? "" : $target{shared_target};
       my $cc = '$(CC)';
       my $cflags = '$(CFLAGS) $(BIN_CFLAGS)';

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -347,8 +347,10 @@ configdata.pm: "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{b
  # It takes a list of library names and outputs a list of dependencies
  sub compute_lib_depends {
      if ($disabled{shared}) {
-	 return map { $_.$libext } @_;
+	 return map { $_ =~ /\.a$/ ? $`.$libext : $_.$libext } @_;
      }
+     die "Linking with static OpenSSL libraries is not supported in this configuration\n"
+         if grep /\.a$/, @_;
      return map { shlib_import($_) } @_;
  }
 

--- a/Configure
+++ b/Configure
@@ -1856,9 +1856,16 @@ EOF
                     $d = cleanfile($buildd, $_, $blddir);
                 }
                 # Take note if the file to depend on is being renamed
+                # Take extra care with files ending with .a, they should
+                # be treated without that extension, and the extension
+                # should be added back after treatment.
+                $d =~ /(\.a)?$/;
+                my $e = $1 // "";
+                $d = $`;
                 if ($unified_info{rename}->{$d}) {
                     $d = $unified_info{rename}->{$d};
                 }
+                $d .= $e;
                 $unified_info{depends}->{$ddest}->{$d} = 1;
                 # If we depend on a header file or a perl module, let's make
                 # sure it can get included

--- a/test/build.info
+++ b/test/build.info
@@ -308,79 +308,39 @@ IF[{- !$disabled{tests} -}]
   ENDIF
 
   # Internal test programs.  These are essentially a collection of internal
-  # test routines.  Because they sometimes need to reach internal symbols that
-  # aren't available through the shared library (at least on Linux, Solaris,
-  # Windows and VMS, where the exported symbols are those listed in util/*.num),
-  # these programs may be built on files directly picked from inside crypto/
-  # or ssl/, to test using symbols that exist in those specific files.  These
-  # programs will also be linked with libcrypto / libssl, so we don't pick
-  # out more specific files than necessary.
-  # This might mean we have multiply defined symbols, but since linking is
-  # ordered with object files first and libraries after, the symbols from the
-  # object files will be chosen before those in the libraries.  This is handled
-  # properly by all linkers.
-  # Note that when building with static libraries, none of those extra files
-  # are needed, since all symbols are available anyway, regardless of what's
-  # listed in util/*.num.
-  PROGRAMS_NO_INST=asn1_internal_test modes_internal_test x509_internal_test
+  # test routines.  Some of them need to reach internal symbols that aren't
+  # available through the shared library (at least on Linux, Solaris, Windows
+  # and VMS, where the exported symbols are those listed in util/*.num), these
+  # programs are forcebly linked with the static libraries, where all symbols
+  # are always available.  This excludes linking these programs natively on
+  # Windows when building shared libraries, since the static libraries share
+  # names with the DLL import libraries.
+  IF[{- $disabled{shared} || $target{build_scheme}->[1] ne 'windows' -}]
+    PROGRAMS_NO_INST=asn1_internal_test modes_internal_test x509_internal_test
+    IF[{- !$disabled{poly1305} -}]
+      PROGRAMS_NO_INST=poly1305_internal_test
+    ENDIF
+
+    SOURCE[poly1305_internal_test]=poly1305_internal_test.c testutil.c test_main_custom.c
+    INCLUDE[poly1305_internal_test]=.. ../include ../crypto/include
+    DEPEND[poly1305_internal_test]=../libcrypto.a
+
+    SOURCE[asn1_internal_test]=asn1_internal_test.c testutil.c test_main.c
+    INCLUDE[asn1_internal_test]=.. ../include ../crypto/include
+    DEPEND[asn1_internal_test]=../libcrypto.a
+
+    SOURCE[modes_internal_test]=modes_internal_test.c testutil.c test_main_custom.c
+    INCLUDE[modes_internal_test]=.. ../include
+    DEPEND[modes_internal_test]=../libcrypto.a
+
+    SOURCE[x509_internal_test]=x509_internal_test.c testutil.c test_main.c
+    INCLUDE[x509_internal_test]=.. ../include
+    DEPEND[x509_internal_test]=../libcrypto.a
+  ENDIF
+
   IF[{- !$disabled{mdc2} -}]
     PROGRAMS_NO_INST=mdc2_internal_test
   ENDIF
-  IF[{- !$disabled{poly1305} -}]
-    PROGRAMS_NO_INST=poly1305_internal_test
-  ENDIF
-
-  SOURCE[poly1305_internal_test]=poly1305_internal_test.c testutil.c test_main_custom.c
-  IF[{- !$disabled{shared} -}]
-    SOURCE[poly1305_internal_test]= ../crypto/poly1305/poly1305.c \
-        {- rebase_files("../crypto/poly1305", $target{poly1305_asm_src}) -} \
-        {- rebase_files("../crypto", $target{cpuid_asm_src}) -} \
-        ../crypto/cryptlib.c
-  ENDIF
-  INCLUDE[poly1305_internal_test]=.. ../include ../crypto/include
-  DEPEND[poly1305_internal_test]=../libcrypto
-
-  SOURCE[asn1_internal_test]=asn1_internal_test.c testutil.c test_main.c
-  IF[{- !$disabled{shared} -}]
-    SOURCE[asn1_internal_test]= ../crypto/asn1/a_strnid.c \
-        ../crypto/rsa/rsa_ameth.c ../crypto/dsa/dsa_ameth.c \
-        ../crypto/dh/dh_ameth.c ../crypto/ec/ec_ameth.c \
-        ../crypto/hmac/hm_ameth.c ../crypto/cmac/cm_ameth.c \
-        ../crypto/ec/ecx_meth.c ../crypto/ec/curve25519.c
-  ENDIF
-  INCLUDE[asn1_internal_test]=.. ../include ../crypto/include
-  DEPEND[asn1_internal_test]=../libcrypto
-
-  SOURCE[modes_internal_test]=modes_internal_test.c testutil.c test_main_custom.c
-  IF[{- !$disabled{shared} -}]
-    SOURCE[modes_internal_test]= \
-        {- rebase_files("../crypto", $target{cpuid_asm_src}); -} \
-        ../crypto/cryptlib.c
-  ENDIF
-  INCLUDE[modes_internal_test]=.. ../include
-  DEPEND[modes_internal_test]=../libcrypto
-
-  # The reason for the huge amount of directly included x509v3 files
-  # is that a table that is checked by x509_internal_test refers to
-  # structures that are spread all over those files.
-  SOURCE[x509_internal_test]=x509_internal_test.c testutil.c test_main.c
-  IF[{- !$disabled{shared} -}]
-    SOURCE[x509_internal_test]= ../crypto/x509v3/v3_bitst.c \
-        ../crypto/x509v3/v3_ia5.c ../crypto/x509v3/v3_skey.c \
-        ../crypto/x509v3/v3_pku.c ../crypto/x509v3/v3_alt.c \
-        ../crypto/x509v3/v3_bcons.c ../crypto/x509v3/v3_int.c \
-        ../crypto/x509v3/v3_cpols.c ../crypto/x509v3/v3_akey.c \
-        ../crypto/x509v3/v3_crld.c ../crypto/x509v3/v3_utl.c \
-        ../crypto/x509v3/v3_extku.c ../crypto/x509v3/v3_enum.c \
-        ../crypto/x509v3/v3_sxnet.c ../crypto/x509v3/v3_info.c \
-        ../crypto/x509v3/v3_addr.c ../crypto/x509v3/v3_asid.c \
-        ../crypto/x509v3/v3_pcons.c ../crypto/x509v3/v3_pmaps.c \
-        ../crypto/x509v3/v3_pci.c ../crypto/x509v3/v3_ncons.c \
-        ../crypto/x509v3/v3_tlsf.c ../crypto/ocsp/v3_ocsp.c \
-        ../crypto/ct/ct_x509v3.c ../crypto/asn1/a_strex.c
-  ENDIF
-  INCLUDE[x509_internal_test]=.. ../include
-  DEPEND[x509_internal_test]=../libcrypto
 
   SOURCE[mdc2_internal_test]=mdc2_internal_test.c testutil.c test_main.c
   INCLUDE[mdc2_internal_test]=.. ../include

--- a/test/recipes/03-test_internal.t
+++ b/test/recipes/03-test_internal.t
@@ -12,12 +12,14 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal");
 
+my $shared_windows = $^O eq 'MSWin32' && !disabled("shared");
+
 my %known_internal_tests =
   ( mdc2_internal_test => !disabled("mdc2"),
-    poly1305_internal_test => !disabled("poly1305"),
-    modes_internal_test => 1,
-    asn1_internal_test => 1,
-    x509_internal_test => 1 );
+    poly1305_internal_test => !disabled("poly1305") && !$shared_windows,
+    modes_internal_test => !$shared_windows,
+    asn1_internal_test => !$shared_windows,
+    x509_internal_test => !$shared_windows );
 
 plan tests => scalar keys %known_internal_tests;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Internal tests were a bit of a pain with all the object files to depend on explicitely.  Another much easier way is to explicitely link them with the static libcrypto.  This only needed a little bit of extra support in Configure and associated files.