### PR TITLE
Fix the evp_test Ctrl keyword processing

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1246,7 +1246,8 @@ static void pkey_test_cleanup(struct evp_test *t)
     EVP_PKEY_CTX_free(kdata->ctx);
 }
 
-static int pkey_test_ctrl(EVP_PKEY_CTX *pctx, const char *value)
+static int pkey_test_ctrl(struct evp_test *t, EVP_PKEY_CTX *pctx,
+                          const char *value)
 {
     int rv;
     char *p, *tmpval;
@@ -1258,6 +1259,13 @@ static int pkey_test_ctrl(EVP_PKEY_CTX *pctx, const char *value)
     if (p != NULL)
         *p++ = 0;
     rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
+    if (p != NULL && rv <= 0 && rv != -2) {
+        /* If p has an OID assume disabled algorithm */
+        if (OBJ_sn2nid(p) != NID_undef || OBJ_ln2nid(p) != NID_undef) {
+            t->skip = 1;
+            rv = 1;
+        }
+    }
     OPENSSL_free(tmpval);
     return rv > 0;
 }
@@ -1271,7 +1279,7 @@ static int pkey_test_parse(struct evp_test *t,
     if (strcmp(keyword, "Output") == 0)
         return test_bin(value, &kdata->output, &kdata->output_len);
     if (strcmp(keyword, "Ctrl") == 0)
-        return pkey_test_ctrl(kdata->ctx, value);
+        return pkey_test_ctrl(t, kdata->ctx, value);
     return 0;
 }
 
@@ -1391,7 +1399,7 @@ static int pderive_test_parse(struct evp_test *t,
     if (strcmp(keyword, "SharedSecret") == 0)
         return test_bin(value, &kdata->output, &kdata->output_len);
     if (strcmp(keyword, "Ctrl") == 0)
-        return pkey_test_ctrl(kdata->ctx, value);
+        return pkey_test_ctrl(t, kdata->ctx, value);
     return 0;
 }
 
@@ -1812,7 +1820,7 @@ static int kdf_test_parse(struct evp_test *t,
     if (strcmp(keyword, "Output") == 0)
         return test_bin(value, &kdata->output, &kdata->output_len);
     if (strncmp(keyword, "Ctrl", 4) == 0)
-        return pkey_test_ctrl(kdata->ctx, value);
+        return pkey_test_ctrl(t, kdata->ctx, value);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Skip the test if the value after ":" is a disabled algorithm, rather
than failing it