### PR TITLE
Fix the effect of no-dso in crypto/init.c

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -81,7 +81,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
     OPENSSL_cpuid_setup();
     base_inited = 1;
 
-#ifndef OPENSSL_USE_NODELETE
+#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
 # ifdef DSO_WIN32
     {
         HMODULE handle = NULL;
@@ -604,7 +604,7 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#ifndef OPENSSL_USE_NODELETE
+#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
     {
         union {
             void *sym;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

When configured no-dso, there are no DSO_{whatever} macros defined.
Therefore, before checking those, you have to check if OPENSSL_NO_DSO
is defined.

Fixes #1899