### PR TITLE
Raise an alloc error on any alloc failure

### DIFF
--- a/crypto/dh/dh_meth.c
+++ b/crypto/dh/dh_meth.c
@@ -13,19 +13,20 @@
 
 DH_METHOD *DH_meth_new(const char *name, int flags)
 {
-    DH_METHOD *dhm = OPENSSL_zalloc(sizeof(DH_METHOD));
+    DH_METHOD *dhm = OPENSSL_zalloc(sizeof(*dhm));
 
     if (dhm != NULL) {
-        dhm->name = OPENSSL_strdup(name);
-        if (dhm->name == NULL) {
-            OPENSSL_free(dhm);
-            DHerr(DH_F_DH_METH_NEW, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
         dhm->flags = flags;
+
+        dhm->name = OPENSSL_strdup(name);
+        if (dhm->name != NULL)
+            return dhm;
+
+        OPENSSL_free(dhm);
     }
 
-    return dhm;
+    DHerr(DH_F_DH_METH_NEW, ERR_R_MALLOC_FAILURE);
+    return NULL;
 }
 
 void DH_meth_free(DH_METHOD *dhm)
@@ -38,21 +39,20 @@ void DH_meth_free(DH_METHOD *dhm)
 
 DH_METHOD *DH_meth_dup(const DH_METHOD *dhm)
 {
-    DH_METHOD *ret;
-
-    ret = OPENSSL_malloc(sizeof(DH_METHOD));
+    DH_METHOD *ret = OPENSSL_malloc(sizeof(*ret));
 
     if (ret != NULL) {
         memcpy(ret, dhm, sizeof(*dhm));
+
         ret->name = OPENSSL_strdup(dhm->name);
-        if (ret->name == NULL) {
-            OPENSSL_free(ret);
-            DHerr(DH_F_DH_METH_DUP, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
+        if (ret->name != NULL)
+            return ret;
+
+        OPENSSL_free(ret);
     }
 
-    return ret;
+    DHerr(DH_F_DH_METH_DUP, ERR_R_MALLOC_FAILURE);
+    return NULL;
 }
 
 const char *DH_meth_get0_name(const DH_METHOD *dhm)
@@ -62,9 +62,8 @@ const char *DH_meth_get0_name(const DH_METHOD *dhm)
 
 int DH_meth_set1_name(DH_METHOD *dhm, const char *name)
 {
-    char *tmpname;
+    char *tmpname = OPENSSL_strdup(name);
 
-    tmpname = OPENSSL_strdup(name);
     if (tmpname == NULL) {
         DHerr(DH_F_DH_METH_SET1_NAME, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/dsa/dsa_meth.c
+++ b/crypto/dsa/dsa_meth.c
@@ -21,19 +21,20 @@
 
 DSA_METHOD *DSA_meth_new(const char *name, int flags)
 {
-    DSA_METHOD *dsam = OPENSSL_zalloc(sizeof(DSA_METHOD));
+    DSA_METHOD *dsam = OPENSSL_zalloc(sizeof(*dsam));
 
     if (dsam != NULL) {
-        dsam->name = OPENSSL_strdup(name);
-        if (dsam->name == NULL) {
-            OPENSSL_free(dsam);
-            DSAerr(DSA_F_DSA_METH_NEW, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
         dsam->flags = flags;
+
+        dsam->name = OPENSSL_strdup(name);
+        if (dsam->name != NULL)
+            return dsam;
+
+        OPENSSL_free(dsam);
     }
 
-    return dsam;
+    DSAerr(DSA_F_DSA_METH_NEW, ERR_R_MALLOC_FAILURE);
+    return NULL;
 }
 
 void DSA_meth_free(DSA_METHOD *dsam)
@@ -46,21 +47,20 @@ void DSA_meth_free(DSA_METHOD *dsam)
 
 DSA_METHOD *DSA_meth_dup(const DSA_METHOD *dsam)
 {
-    DSA_METHOD *ret;
-
-    ret = OPENSSL_malloc(sizeof(DSA_METHOD));
+    DSA_METHOD *ret = OPENSSL_malloc(sizeof(*ret));
 
     if (ret != NULL) {
         memcpy(ret, dsam, sizeof(*dsam));
+
         ret->name = OPENSSL_strdup(dsam->name);
-        if (ret->name == NULL) {
-            OPENSSL_free(ret);
-            DSAerr(DSA_F_DSA_METH_DUP, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
+        if (ret->name != NULL)
+            return ret;
+
+        OPENSSL_free(ret);
     }
 
-    return ret;
+    DSAerr(DSA_F_DSA_METH_DUP, ERR_R_MALLOC_FAILURE);
+    return NULL;
 }
 
 const char *DSA_meth_get0_name(const DSA_METHOD *dsam)
@@ -70,9 +70,8 @@ const char *DSA_meth_get0_name(const DSA_METHOD *dsam)
 
 int DSA_meth_set1_name(DSA_METHOD *dsam, const char *name)
 {
-    char *tmpname;
+    char *tmpname = OPENSSL_strdup(name);
 
-    tmpname = OPENSSL_strdup(name);
     if (tmpname == NULL) {
         DSAerr(DSA_F_DSA_METH_SET1_NAME, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/rsa/rsa_meth.c
+++ b/crypto/rsa/rsa_meth.c
@@ -13,19 +13,20 @@
 
 RSA_METHOD *RSA_meth_new(const char *name, int flags)
 {
-    RSA_METHOD *meth = OPENSSL_zalloc(sizeof(RSA_METHOD));
+    RSA_METHOD *meth = OPENSSL_zalloc(sizeof(*meth));
 
     if (meth != NULL) {
-        meth->name = OPENSSL_strdup(name);
-        if (meth->name == NULL) {
-            OPENSSL_free(meth);
-            RSAerr(RSA_F_RSA_METH_NEW, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
         meth->flags = flags;
+
+        meth->name = OPENSSL_strdup(name);
+        if (meth->name != NULL)
+            return meth;
+
+        OPENSSL_free(meth);
     }
 
-    return meth;
+    RSAerr(RSA_F_RSA_METH_NEW, ERR_R_MALLOC_FAILURE);
+    return NULL;
 }
 
 void RSA_meth_free(RSA_METHOD *meth)
@@ -38,21 +39,20 @@ void RSA_meth_free(RSA_METHOD *meth)
 
 RSA_METHOD *RSA_meth_dup(const RSA_METHOD *meth)
 {
-    RSA_METHOD *ret;
-
-    ret = OPENSSL_malloc(sizeof(RSA_METHOD));
+    RSA_METHOD *ret = OPENSSL_malloc(sizeof(*ret));
 
     if (ret != NULL) {
         memcpy(ret, meth, sizeof(*meth));
+
         ret->name = OPENSSL_strdup(meth->name);
-        if (ret->name == NULL) {
-            OPENSSL_free(ret);
-            RSAerr(RSA_F_RSA_METH_DUP, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
+        if (ret->name != NULL)
+            return ret;
+
+        OPENSSL_free(ret);
     }
 
-    return ret;
+    RSAerr(RSA_F_RSA_METH_DUP, ERR_R_MALLOC_FAILURE);
+    return NULL;
 }
 
 const char *RSA_meth_get0_name(const RSA_METHOD *meth)
@@ -62,9 +62,8 @@ const char *RSA_meth_get0_name(const RSA_METHOD *meth)
 
 int RSA_meth_set1_name(RSA_METHOD *meth, const char *name)
 {
-    char *tmpname;
+    char *tmpname = OPENSSL_strdup(name);
 
-    tmpname = OPENSSL_strdup(name);
     if (tmpname == NULL) {
         RSAerr(RSA_F_RSA_METH_SET1_NAME, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -469,6 +469,7 @@ static int append_ia5(STACK_OF(OPENSSL_STRING) **sk, const ASN1_IA5STRING *email
         return 1;
     emtmp = OPENSSL_strdup((char *)email->data);
     if (emtmp == NULL || !sk_OPENSSL_STRING_push(*sk, emtmp)) {
+        OPENSSL_free(emtmp);    /* free on push failure */
         X509_email_free(*sk);
         *sk = NULL;
         return 0;


### PR DESCRIPTION
##### Description of change
Current code was using OPENSSL_zalloc/OPENSSL_malloc and OPENSSL_strdup, 
but only the failure of last one was raising an error.

Targets:
- [X] master
- [X] branch 1.1.0
