### PR TITLE
Cast to an unsigned type before negating

### DIFF
--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -289,7 +289,7 @@ static int asn1_get_int64(int64_t *pr, const unsigned char *b, size_t blen,
             ASN1err(ASN1_F_ASN1_GET_INT64, ASN1_R_TOO_SMALL);
             return 0;
         }
-        *pr = -(int64_t)r;
+        *pr = -(uint64_t)r;
     } else {
         if (r > INT64_MAX) {
             ASN1err(ASN1_F_ASN1_GET_INT64, ASN1_R_TOO_LARGE);


### PR DESCRIPTION
llvm's ubsan reported:
runtime error: negation of -9223372036854775808 cannot be represented in
type 'int64_t' (aka 'long'); cast to an unsigned type to negate this
value to itself

Found using libfuzzer