### PR TITLE
EVP docs: chacha20, chacha20-poly1305

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -29,7 +29,8 @@ EVP_aes_128_cbc, EVP_aes_128_ecb, EVP_aes_128_cfb, EVP_aes_128_ofb,
 EVP_aes_192_cbc, EVP_aes_192_ecb, EVP_aes_192_cfb, EVP_aes_192_ofb,
 EVP_aes_256_cbc, EVP_aes_256_ecb, EVP_aes_256_cfb, EVP_aes_256_ofb,
 EVP_aes_128_gcm, EVP_aes_192_gcm, EVP_aes_256_gcm,
-EVP_aes_128_ccm, EVP_aes_192_ccm, EVP_aes_256_ccm - EVP cipher routines
+EVP_aes_128_ccm, EVP_aes_192_ccm, EVP_aes_256_ccm,
+EVP_chacha20, EVP_chacha20_poly1305 - EVP cipher routines
 
 =head1 SYNOPSIS
 
@@ -399,6 +400,17 @@ the L</GCM and OCB Modes> section below for details.
 AES Counter with CBC-MAC Mode (CCM) for 128, 192 and 256 bit keys respectively.
 These ciphers require additional control operations to function correctly: see
 CCM mode section below for details.
+
+=item EVP_chacha20()
+
+The ChaCha20 stream cipher. The key length is 256 bits, the IV is 96 bits long.
+
+=item EVP_chacha20_poly1305()
+
+Authenticated encryption with ChaCha20-Poly1305. Like EVP_chacha20() the key is
+256 bits and the IV is 96 bits. This supports additional authenticated
+data (AAD) and produces a 128 bit authentication tag. The L</GCM and OCB modes>
+section below applies.
 
 =back
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- This change is trivial, no CLA needed.

##### Description of change

This documents the availability of chacha20 and chacha20-poly1305 in the EVP docs where all the other ciphers hang out as well.

