### PR TITLE
Fixed deadlock in CRYPTO_THREAD_run_once for Windows platform.

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -78,8 +78,8 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
     do {
         result = InterlockedCompareExchange(lock, ONCE_ININIT, ONCE_UNINITED);
         if (result == ONCE_UNINITED) {
-            init();
             *lock = ONCE_DONE;
+            init();
             return 1;
         }
     } while (result == ONCE_ININIT);


### PR DESCRIPTION
Fixed deadlock in CRYPTO_THREAD_run_once() if call to init() is causing a recursive call to CRYPTO_THREAD_run_once() again that is causing a hot deadloop inside do { } while (result == ONCE_ININIT); section.

Example of such call stack:
test.exe!CRYPTO_THREAD_run_once(long * once, void(*)() init) Line 79	C
test.exe!OPENSSL_init_crypto(unsigned __int64 opts, const ossl_init_settings_st * settings) Line 506	C
test.exe!ERR_get_state() Line 662	C
test.exe!ERR_put_error(int lib, int func, int reason, const char * file, int line) Line 358	C
test.exe!DSO_pathbyaddr(void * addr, char * path, int sz) Line 315	C
test.exe!DSO_dsobyaddr(void * addr, int flags) Line 325	C
test.exe!ossl_init_base() Line 105	C
test.exe!ossl_init_base_ossl_() Line 66	C
test.exe!CRYPTO_THREAD_run_once(long * once, void(*)() init) Line 82	C
test.exe!OPENSSL_init_crypto(unsigned __int64 opts, const ossl_init_settings_st * settings) Line 506	C
test.exe!ENGINE_load_builtin_engines() Line 18	C

Here DSO_pathbyaddr() caused an error log message via ERR_put_error() which called OPENSSL_init_crypto() recursively via ERR_get_state().

Setting *lock = ONCE_DONE before init() effectively fixes this issue by causing true for if (*lock == ONCE_DONE) condition on recursive re-entry during init() call.