### PR TITLE
sha/asm/sha512-armv8.pl: fix big-endian support in __KERNEL__ case.

### DIFF
--- a/crypto/sha/asm/sha512-armv8.pl
+++ b/crypto/sha/asm/sha512-armv8.pl
@@ -102,7 +102,7 @@ my ($T0,$T1,$T2)=(@X[($i-8)&15],@X[($i-9)&15],@X[($i-10)&15]);
    $T0=@X[$i+3] if ($i<11);
 
 $code.=<<___	if ($i<16);
-#ifndef	__ARMEB__
+#ifndef	__AARCH64EB__
 	rev	@X[$i],@X[$i]			// $i
 #endif
 ___


### PR DESCRIPTION
In non-__KERNEL__ context 32-bit-style __ARMEB__/__ARMEL__ macros were
set in arm_arch.h, which is shared between 32- and 64-bit builds. Since
it's not included in __KERNEL__ case, we have to adhere to official
64-bit pre-defines, __AARCH64EB__/__AARCH64_EL__.

[If we are to share more code, it would need similar adjustment.]