### PR TITLE
Stop init loops

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -79,6 +79,13 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
     if ((init_lock = CRYPTO_THREAD_lock_new()) == NULL)
         return 0;
     OPENSSL_cpuid_setup();
+
+    /*
+     * BIG FAT WARNING!
+     * Everything needed to be initialized in this function before threads
+     * come along MUST happen before base_inited is set to 1, or we will
+     * see race conditions.
+     */
     base_inited = 1;
 
 #if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -503,7 +503,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
     }
 
-    if (!RUN_ONCE(&base, ossl_init_base))
+    if (!base_inited && !RUN_ONCE(&base, ossl_init_base))
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_LOAD_CRYPTO_STRINGS)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Under certain circumstances, the libcrypto init code would loop,
causing a deadlock.  This would typically happen if something in
ossl_init_base() caused an OpenSSL error, and the error stack routines
would recurse into the init code before the flag that ossl_init_base()
had been run was checked.

This change makes sure ossl_init_base isn't run once more of the base
is initiated.

Thanks to Dmitry Kostjuchenko for the idea.

Fixes #1899