### PR TITLE
Add a modern linux-x86 config target

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -731,6 +731,8 @@ sub vms_info {
     },
 
     #### IA-32 targets...
+    #### These targets are a bit aged and are to be used on older Linux
+    #### machines where gcc doesn't understand -m32 and -m64
     "linux-elf" => {
         inherit_from     => [ "linux-generic32", asm("x86_elf_asm") ],
         cflags           => add(picker(default => "-DL_ENDIAN",
@@ -748,6 +750,21 @@ sub vms_info {
         perlasm_scheme   => "a.out",
     },
 
+    #### X86 / X86_64 targets
+    "linux-x86" => {
+        inherit_from     => [ "linux-generic32", asm("x86_asm") ],
+        cflags           => add(picker(default => "-m32 -DL_ENDIAN",
+                                       release => "-fomit-frame-pointer")),
+        bn_ops           => "BN_LLONG",
+        perlasm_scheme   => "elf",
+        shared_ldflag    => add("-m32"),
+    },
+    "linux-x86-clang" => {
+        inherit_from     => [ "linux-x86" ],
+        cc               => "clang",
+        cxx              => "clang++",
+        cflags           => add("-Wextra -Qunused-arguments"),
+    },
     "linux-x86_64" => {
         inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
         cflags           => add("-m64 -DL_ENDIAN"),

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -731,7 +731,7 @@ sub vms_info {
     },
 
     #### IA-32 targets...
-    #### These targets are a bit aged and are to be used on older Linux
+    #### These two targets are a bit aged and are to be used on older Linux
     #### machines where gcc doesn't understand -m32 and -m64
     "linux-elf" => {
         inherit_from     => [ "linux-generic32", asm("x86_elf_asm") ],

--- a/config
+++ b/config
@@ -640,7 +640,14 @@ case "$GUESSOS" in
 	else
 	    OUT="linux-x86_64"
 	fi ;;
-  *86-*-linux2) OUT="linux-elf" ;;
+  *86-*-linux2)
+        # On machines where the compiler understands -m32, prefer a
+        # config target that uses it
+        if $CC -m32 -E -x c /dev/null > /dev/null 2>&1; then
+            OUT="linux-x86"
+        else
+            OUT="linux-elf"
+        fi ;;
   *86-*-linux1) OUT="linux-aout" ;;
   *-*-linux?) OUT="linux-generic32" ;;
   sun4[uv]*-*-solaris2)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

'linux-x86' is similar to 'linux-x86_64' but uses -m32 rather than -m64.

'linux-elf' is kept as a legacy target for Linux machines where the compiler doesn't understand -m32.

`config` is updated to check what the compiler understands and choose 'linux-x86' or 'linux-elf' accordingly.
