### PR TITLE
Remove a hack from ssl_test_old

### DIFF
--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -2,13 +2,18 @@
 
 =head1 NAME
 
-SSL_COMP_add_compression_method, SSL_COMP_free_compression_methods - handle SSL/TLS integrated compression methods
+SSL_COMP_add_compression_method, SSL_COMP_get_compression_methods,
+SSL_COMP_get0_name, SSL_COMP_get_id, SSL_COMP_free_compression_methods
+- handle SSL/TLS integrated compression methods
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
  int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
+ STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
+ const char *SSL_COMP_get0_name(const SSL_COMP *comp);
+ int SSL_COMP_get_id(const SSL_COMP *comp);
 
 Deprecated:
 
@@ -22,6 +27,13 @@ SSL_COMP_add_compression_method() adds the compression method B<cm> with
 the identifier B<id> to the list of available compression methods. This
 list is globally maintained for all SSL operations within this application.
 It cannot be set for specific SSL_CTX or SSL objects.
+
+SSL_COMP_get_compression_methods() returns a stack of all of the available
+compression methods or NULL on error.
+
+SSL_COMP_get0_name() returns the name of the compression method B<comp>.
+
+SSL_COMP_get_id() returns the id of the compression method B<comp>.
 
 In versions of OpenSSL prior to 1.1.0 SSL_COMP_free_compression_methods() freed
 the internal table of compression methods that were built internally, and
@@ -76,6 +88,13 @@ The operation failed. Check the error queue to find out the reason.
 
 =back
 
+SSL_COMP_get_compression_methods() returns the stack of compressions methods or
+NULL on error.
+
+SSL_COMP_get0_name() returns the name of the compression method or NULL on error.
+
+SSL_COMP_get_id() returns the name of the compression method or -1 on error.
+
 =head1 SEE ALSO
 
 L<ssl(7)>
@@ -83,6 +102,7 @@ L<ssl(7)>
 =head1 HISTORY
 
 SSL_COMP_free_compression_methods() was deprecated in OpenSSL 1.1.0.
+SSL_COMP_get0_name() and SSL_comp_get_id() were added in OpenSSL 1.1.0d.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1798,6 +1798,8 @@ void SSL_set_tmp_dh_callback(SSL *ssl,
 __owur const COMP_METHOD *SSL_get_current_compression(SSL *s);
 __owur const COMP_METHOD *SSL_get_current_expansion(SSL *s);
 __owur const char *SSL_COMP_get_name(const COMP_METHOD *comp);
+__owur const char *SSL_COMP_get0_name(const SSL_COMP *comp);
+__owur int SSL_COMP_get_id(const SSL_COMP *comp);
 STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
 __owur STACK_OF(SSL_COMP) *SSL_COMP_set0_compression_methods(STACK_OF(SSL_COMP)
                                                       *meths);

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1871,6 +1871,24 @@ const char *SSL_COMP_get_name(const COMP_METHOD *comp)
 #endif
 }
 
+const char *SSL_COMP_get0_name(const SSL_COMP *comp)
+{
+#ifndef OPENSSL_NO_COMP
+    return comp->name;
+#else
+    return -1;
+#endif
+}
+
+int SSL_COMP_get_id(const SSL_COMP *comp)
+{
+#ifndef OPENSSL_NO_COMP
+    return comp->id;
+#else
+    return -1;
+#endif
+}
+
 /* For a cipher return the index corresponding to the certificate type */
 int ssl_cipher_get_cert_index(const SSL_CIPHER *c)
 {

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -92,8 +92,6 @@
 # include <openssl/ct.h>
 #endif
 
-#include "../ssl/ssl_locl.h"
-
 /*
  * Or gethostname won't be declared properly
  * on Compaq platforms (at least with DEC C).
@@ -1430,7 +1428,7 @@ int main(int argc, char *argv[])
         printf("Available compression methods:");
         for (j = 0; j < n; j++) {
             SSL_COMP *c = sk_SSL_COMP_value(ssl_comp_methods, j);
-            printf("  %s:%d", c->name, c->id);
+            printf("  %s:%d", SSL_COMP_get0_name(c), SSL_COMP_get_id(c));
         }
         printf("\n");
     }
@@ -2676,8 +2674,29 @@ int doit(SSL *s_ssl, SSL *c_ssl, long count)
     SSL_set_max_send_fragment(c_ssl, max_frag);
     BIO_set_ssl(c_bio, c_ssl, BIO_NOCLOSE);
 
+    /*
+     * We've just given our ref to these BIOs to c_ssl. We need another one to
+     * give to s_ssl
+     */
+    if (!BIO_up_ref(c_to_s)) {
+        /* c_to_s and s_to_c will get freed when we free c_ssl */
+        c_to_s = NULL;
+        s_to_c = NULL;
+        goto err;
+    }
+    if (!BIO_up_ref(s_to_c)) {
+        /* s_to_c will get freed when we free c_ssl */
+        s_to_c = NULL;
+        goto err;
+    }
+
     SSL_set_accept_state(s_ssl);
     SSL_set_bio(s_ssl, c_to_s, s_to_c);
+
+    /* We've used up all our refs to these now */
+    c_to_s = NULL;
+    s_to_c = NULL;
+
     SSL_set_max_send_fragment(s_ssl, max_frag);
     BIO_set_ssl(s_bio, s_ssl, BIO_NOCLOSE);
 
@@ -2890,23 +2909,6 @@ int doit(SSL *s_ssl, SSL *c_ssl, long count)
     }
     ret = 0;
  err:
-    /*
-     * We have to set the BIO's to NULL otherwise they will be
-     * OPENSSL_free()ed twice.  Once when th s_ssl is SSL_free()ed and again
-     * when c_ssl is SSL_free()ed. This is a hack required because s_ssl and
-     * c_ssl are sharing the same BIO structure and SSL_set_bio() and
-     * SSL_free() automatically BIO_free non NULL entries. You should not
-     * normally do this or be required to do this
-     */
-    if (s_ssl != NULL) {
-        s_ssl->rbio = NULL;
-        s_ssl->wbio = NULL;
-    }
-    if (c_ssl != NULL) {
-        c_ssl->rbio = NULL;
-        c_ssl->wbio = NULL;
-    }
-
     BIO_free(c_to_s);
     BIO_free(s_to_c);
     BIO_free_all(c_bio);

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -408,3 +408,5 @@ DTLS_get_data_mtu                       408	1_1_1	EXIST::FUNCTION:
 SSL_read_ex                             409	1_1_1	EXIST::FUNCTION:
 SSL_peek_ex                             410	1_1_1	EXIST::FUNCTION:
 SSL_write_ex                            411	1_1_1	EXIST::FUNCTION:
+SSL_COMP_get_id                         412	1_1_0d	EXIST::FUNCTION:
+SSL_COMP_get0_name                      413	1_1_0d	EXIST::FUNCTION:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

ssl_test_old was reaching inside the SSL structure and changing the internal
BIO values. This is completely unneccessary, and was causing an abort in the
test when enabling TLSv1.3.

I also removed the need for ssl_test_old to include ssl_locl.h. This
required the addition of some missing accessors for SSL_COMP name and id
fields.

This is for master and 1.1.0