### PR TITLE
Fix a "defined but not used" warning when enabling ssl-trace

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -527,11 +527,6 @@ static ssl_trace_tbl ssl_sig_tbl[] = {
     {TLSEXT_signature_gostr34102012_512, "gost2012_512"}
 };
 
-static ssl_trace_tbl ssl_hb_tbl[] = {
-    {1, "peer_allowed_to_send"},
-    {2, "peer_not_allowed_to_send"}
-};
-
 static ssl_trace_tbl ssl_ctype_tbl[] = {
     {1, "rsa_sign"},
     {2, "dss_sign"},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

