### PR TITLE
TLSv1.3: Fix missing SSL_IS_TLS13(s) usage

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -205,7 +205,7 @@ int ssl3_get_record(SSL *s)
                 n2s(p, rr[num_recs].length);
 
                 /* Lets check version. In TLSv1.3 we ignore this field */
-                if (!s->first_packet && s->version != TLS1_3_VERSION
+                if (!s->first_packet && !SSL_IS_TLS13(s)
                         && version != s->version) {
                     SSLerr(SSL_F_SSL3_GET_RECORD, SSL_R_WRONG_VERSION_NUMBER);
                     if ((s->version & 0xFF00) == (version & 0xFF00)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1445,7 +1445,7 @@ MSG_PROCESS_RETURN tls_process_client_hello(SSL *s, PACKET *pkt)
     }
 
     /* Check we've got a key_share for TLSv1.3 */
-    if (s->version == TLS1_3_VERSION && s->s3->peer_tmp == NULL && !s->hit) {
+    if (SSL_IS_TLS13(s) && s->s3->peer_tmp == NULL && !s->hit) {
         /* No suitable share */
         /* TODO(TLS1.3): Send a HelloRetryRequest */
         al = SSL_AD_HANDSHAKE_FAILURE;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

We should use the macro for testing if we are using TLSv1.3 rather than checking s->version directly.