### PR TITLE
Use consistent variable names in example

### DIFF
--- a/doc/man3/X509_NAME_get_index_by_NID.pod
+++ b/doc/man3/X509_NAME_get_index_by_NID.pod
@@ -83,10 +83,9 @@ Process all entries:
 
 Process all commonName entries:
 
- int loc;
+ int lastpos = -1;
  X509_NAME_ENTRY *e;
 
- loc = -1;
  for (;;)
         {
         lastpos = X509_NAME_get_index_by_NID(nm, NID_commonName, lastpos);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

In the X509_NAME_get_index_by_NID.pod example, the initialized variable is called
"loc", but the one used in the for loop is called "lastpos". Make the names match.