### PR TITLE
Update the location of the pod files

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -50,5 +50,5 @@ acceptance and review process faster:
     test/README for information on the test framework.
 
     6.  New features or changed functionality must include
-    documentation. Please look at the "pod" files in doc/apps, doc/crypto
-    and doc/ssl for examples of our style.
+    documentation. Please look at the "pod" files in doc/man[1357]
+    for examples of our style.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Since 99d63d4 ("Move manpages to man[1357] structure.", 2016-10-26), the location
of the pod files has changed.