### PR TITLE
allow the creation of a nextUpdate-less CRL (rebased).

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1088,11 +1088,9 @@ end_of_options:
                 crlhours = 0;
             ERR_clear_error();
         }
-        if ((crldays == 0) && (crlhours == 0) && (crlsec == 0)) {
+        if ((crldays == 0) && (crlhours == 0) && (crlsec == 0) && verbose)
             BIO_printf(bio_err,
-                       "cannot lookup how long until the next CRL is issued\n");
-            goto end;
-        }
+                       "creating a CRL without a nextUpdate\n");
 
         if (verbose)
             BIO_printf(bio_err, "making CRL\n");
@@ -1105,13 +1103,15 @@ end_of_options:
         if (tmptm == NULL)
             goto end;
         X509_gmtime_adj(tmptm, 0);
-        X509_CRL_set1_lastUpdate(crl, tmptm);
-        if (!X509_time_adj_ex(tmptm, crldays, crlhours * 60 * 60 + crlsec,
-                              NULL)) {
-            BIO_puts(bio_err, "error setting CRL nextUpdate\n");
-            goto end;
+        X509_CRL_set_lastUpdate(crl, tmptm);
+        if (crldays || crlhours || crlsec) {
+            if (!X509_time_adj_ex(tmptm, crldays, crlhours * 60 * 60 + crlsec,
+                                  NULL)) {
+                BIO_puts(bio_err, "error setting CRL nextUpdate\n");
+                goto end;
+            }
+            X509_CRL_set_nextUpdate(crl, tmptm);
         }
-        X509_CRL_set1_nextUpdate(crl, tmptm);
 
         ASN1_TIME_free(tmptm);
 

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -284,6 +284,10 @@ now to place in the CRL nextUpdate field.
 
 the number of hours before the next CRL is due.
 
+=item B<-crlsec num>
+
+the number of seconds before the next CRL is due.
+
 =item B<-revoke filename>
 
 a filename containing a certificate to revoke.
@@ -418,8 +422,9 @@ present.
 =item B<default_crl_hours default_crl_days>
 
 the same as the B<-crlhours> and the B<-crldays> options. These
-will only be used if neither command line option is present. At
-least one of these must be present to generate a CRL.
+will only be used if neither command line option is present. If
+neither the command line options nor the configuration file elements
+are present, the CRL won't have a nextUpdate field.
 
 =item B<default_md>
 


### PR DESCRIPTION
iCLA has been sent today.
This pull request is a rebased version of the previous one (that I didn't do correctly).

##### Checklist
- [x] documentation is added or updated
- [x] CLA is signed

##### Description of change
When using "openssl ca -gencrl" without any of the "-crldays"/"-crlhours"/"-crlsec" command line options, and without any "default_crl_days"/"default_crl_hours" configuration file options, the generated CRL has no nextUpdate element.
