### PR TITLE
Add test to check EVP_PKEY method ordering.

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -24,7 +24,8 @@ IF[{- !$disabled{tests} -}]
           packettest asynctest secmemtest srptest memleaktest \
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
-          bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test
+          bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
+          pkey_meth_test
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include
@@ -282,6 +283,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bio_enc_test]=bio_enc_test.c
   INCLUDE[bio_enc_test]=../include
   DEPEND[bio_enc_test]=../libcrypto
+
+  SOURCE[pkey_meth_test]=pkey_meth_test.c testutil.c test_main.c
+  INCLUDE[pkey_meth_test]=../include
+  DEPEND[pkey_meth_test]=../libcrypto
 
   IF[{- !$disabled{psk} -}]
     PROGRAMS_NO_INST=dtls_mtu_test

--- a/test/pkey_meth_test.c
+++ b/test/pkey_meth_test.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Internal tests for EVP_PKEY method ordering */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+#include "testutil.h"
+#include "test_main.h"
+
+/**********************************************************************
+ *
+ * Test of EVP_PKEY_ASN1 method ordering
+ *
+ ***/
+
+static int test_asn1_meths()
+{
+    int i;
+    int prev = -1;
+    int good = 1;
+    int pkey_id;
+    const EVP_PKEY_ASN1_METHOD *ameth;
+
+    for (i = 0; i < EVP_PKEY_asn1_get_count(); i++) {
+        ameth = EVP_PKEY_asn1_get0(i);
+        EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, NULL, NULL, ameth);
+        if (pkey_id < prev)
+            good = 0;
+        prev = pkey_id;
+
+    }
+    if (!good) {
+        fprintf(stderr, "EVP_PKEY_ASN1_METHOD table out of order!\n");
+        for (i = 0; i < EVP_PKEY_asn1_get_count(); i++) {
+            const char *info;
+
+            ameth = EVP_PKEY_asn1_get0(i);
+            EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, &info, NULL, ameth);
+            if (info == NULL)
+                info = "<NO NAME>";
+            fprintf(stderr, "%d : %s : %s\n", pkey_id, OBJ_nid2ln(pkey_id),
+                    info);
+        }
+    } else {
+        fprintf(stderr, "Order OK\n");
+    }
+
+    return good;
+}
+
+void register_tests()
+{
+    ADD_TEST(test_asn1_meths);
+}

--- a/test/recipes/30-test_pkey_meth.t
+++ b/test/recipes/30-test_pkey_meth.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_pkey_meth", "pkey_meth_test");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This adds a simple test to check the EVP_PKEY_ASN1_METHOD internal table is correctly ordered.