### PR TITLE
bn/asm/ppc-mont.pl: signal no-op in 32-bit bit build.

### DIFF
--- a/crypto/bn/asm/ppc-mont.pl
+++ b/crypto/bn/asm/ppc-mont.pl
@@ -135,6 +135,7 @@ $code=<<___;
 .align	5
 .bn_mul_mont_int:
 	mr	$rp,r3		; $rp is reassigned
+	li	r3,0
 ___
 $code.=<<___ if ($BNSZ==4);
 	cmpwi	$num,32		; longer key performance is not better


### PR DESCRIPTION
The bug was introduced in 80d27cdb84985c697f8fabb7649abf1f54714d13,
one too many instructions was removed. It went unnoticed, because
new subroutine introduced in previous commit is called in real-life
RSA/DSA/DH cases, while original code is called only in rare tests.
The bug was caught in test_fuzz.