### PR TITLE
Fix renegotiation with Client Auth

### DIFF
--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -355,6 +355,7 @@ static int state_machine(SSL *s, int server)
             s->hit = 0;
 
             s->s3->tmp.cert_request = 0;
+            s->s3->tmp.cert_req = 0;
 
             if (SSL_IS_DTLS(s)) {
                 st->use_timer = 1;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -347,6 +347,8 @@ static int state_machine(SSL *s, int server)
                  */
                 s->ctx->stats.sess_accept_renegotiate++;
             }
+
+            s->s3->tmp.cert_request = 0;
         } else {
             s->ctx->stats.sess_connect++;
 
@@ -354,7 +356,6 @@ static int state_machine(SSL *s, int server)
             memset(s->s3->client_random, 0, sizeof(s->s3->client_random));
             s->hit = 0;
 
-            s->s3->tmp.cert_request = 0;
             s->s3->tmp.cert_req = 0;
 
             if (SSL_IS_DTLS(s)) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -353,7 +353,7 @@ static int send_certificate_request(SSL *s)
             * if SSL_VERIFY_CLIENT_ONCE is set, don't request cert
             * during re-negotiation:
             */
-           && ((s->session->peer == NULL) ||
+           && (s->s3->tmp.finish_md_len == 0 ||
                !(s->verify_mode & SSL_VERIFY_CLIENT_ONCE))
            /*
             * never request cert in anonymous ciphersuites (see

--- a/test/ssl-tests/17-renegotiate.conf
+++ b/test/ssl-tests/17-renegotiate.conf
@@ -1,11 +1,13 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 4
+num_tests = 6
 
 test-0 = 0-renegotiate-client-no-resume
 test-1 = 1-renegotiate-client-resume
 test-2 = 2-renegotiate-server-no-resume
 test-3 = 3-renegotiate-server-resume
+test-4 = 4-renegotiate-client-auth-require
+test-5 = 5-renegotiate-client-auth-once
 # ===========================================================
 
 [0-renegotiate-client-no-resume]
@@ -114,5 +116,69 @@ ExpectedResult = Success
 HandshakeMode = RenegotiateServer
 Method = TLS
 ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[4-renegotiate-client-auth-require]
+ssl_conf = 4-renegotiate-client-auth-require-ssl
+
+[4-renegotiate-client-auth-require-ssl]
+server = 4-renegotiate-client-auth-require-server
+client = 4-renegotiate-client-auth-require-client
+
+[4-renegotiate-client-auth-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+Options = NoResumptionOnRenegotiation
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[4-renegotiate-client-auth-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = TLS
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[5-renegotiate-client-auth-once]
+ssl_conf = 5-renegotiate-client-auth-once-ssl
+
+[5-renegotiate-client-auth-once-ssl]
+server = 5-renegotiate-client-auth-once-server
+client = 5-renegotiate-client-auth-once-client
+
+[5-renegotiate-client-auth-once-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+Options = NoResumptionOnRenegotiation
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Once
+
+[5-renegotiate-client-auth-once-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = TLS
+ResumptionExpected = No
 
 

--- a/test/ssl-tests/17-renegotiate.conf.in
+++ b/test/ssl-tests/17-renegotiate.conf.in
@@ -14,6 +14,7 @@ use warnings;
 
 package ssltests;
 
+my $dir_sep = $^O ne "VMS" ? "/" : "";
 
 our @tests = (
     {
@@ -70,4 +71,42 @@ our @tests = (
             "ExpectedResult" => "Success"
         }
     },
+    {
+        name => "renegotiate-client-auth-require",
+        server => {
+            "Options" => "NoResumptionOnRenegotiation",
+            "MaxProtocol" => "TLSv1.2",
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "TLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "renegotiate-client-auth-once",
+        server => {
+            "Options" => "NoResumptionOnRenegotiation",
+            "MaxProtocol" => "TLSv1.2",
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Once",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "TLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    }
 );

--- a/test/ssl-tests/18-dtls-renegotiate.conf
+++ b/test/ssl-tests/18-dtls-renegotiate.conf
@@ -1,10 +1,12 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 3
+num_tests = 5
 
 test-0 = 0-renegotiate-client-no-resume
 test-1 = 1-renegotiate-client-resume
 test-2 = 2-renegotiate-server-resume
+test-3 = 3-renegotiate-client-auth-require
+test-4 = 4-renegotiate-client-auth-once
 # ===========================================================
 
 [0-renegotiate-client-no-resume]
@@ -78,6 +80,66 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-2]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = DTLS
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[3-renegotiate-client-auth-require]
+ssl_conf = 3-renegotiate-client-auth-require-ssl
+
+[3-renegotiate-client-auth-require-ssl]
+server = 3-renegotiate-client-auth-require-server
+client = 3-renegotiate-client-auth-require-client
+
+[3-renegotiate-client-auth-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[3-renegotiate-client-auth-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = DTLS
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[4-renegotiate-client-auth-once]
+ssl_conf = 4-renegotiate-client-auth-once-ssl
+
+[4-renegotiate-client-auth-once-ssl]
+server = 4-renegotiate-client-auth-once-server
+client = 4-renegotiate-client-auth-once-client
+
+[4-renegotiate-client-auth-once-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Once
+
+[4-renegotiate-client-auth-once-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
 ExpectedResult = Success
 HandshakeMode = RenegotiateServer
 Method = DTLS

--- a/test/ssl-tests/18-dtls-renegotiate.conf.in
+++ b/test/ssl-tests/18-dtls-renegotiate.conf.in
@@ -14,6 +14,7 @@ use warnings;
 
 package ssltests;
 
+my $dir_sep = $^O ne "VMS" ? "/" : "";
 
 our @tests = (
     {
@@ -60,4 +61,38 @@ our @tests = (
             "ExpectedResult" => "Success"
         }
     },
+    {
+        name => "renegotiate-client-auth-require",
+        server => {
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "DTLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "renegotiate-client-auth-once",
+        server => {
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Once",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "DTLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    }
 );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

#1920 describes a problem where a non-client auth reneg handshake that occurs after a client-auth handshake will end up with the client sending a Certificate message when it is not supposed to.

There is another related bug where, in the same situation, the server expects a Certificate message even when it hasn't requested one!

These two bugs together mean that OpenSSL will happily talk to the same version of itself in this scenario, but nothing else.

In adding tests for this I found a third bug in the implementation of SSL_VERIFY_CLIENT_ONCE. The documentation for this flag says:
````
      B<Server mode:> only request a client certificate on the initial TLS/SSL
      handshake. Do not ask for a client certificate again in case of a
      renegotiation. This flag must be used together with SSL_VERIFY_PEER.
    
      B<Client mode:> ignored
````
But the implementation actually did nothing. After the server sends its
ServerKeyExchange message, the code was checking s->session->peer to see if
it is NULL. If it was set then it did not ask for another client
certificate. However s->session->peer will only be set in the event of a
resumption, but a ServerKeyExchange message is only sent in the event of a
full handshake (i.e. no resumption).
    
The documentation suggests that the original intention was for this to
have an effect on renegotiation, and resumption doesn't come into it.
    
The fix is to properly check for renegotiation, not whether there is already
a client certificate in the session.
    
As far as I can tell this has been broken for a *long* time. I actually wondered whether we would be better off just removing it. But as it turns out I need to use it for my tests to work so I fixed it anyway!!

I also fixed a bug in TLSProxy where zero length messages weren't being recorded properly.

This is for master. I will create a separate PR for 1.1.0

Fixes #1920