### PR TITLE
Fix renegotiation with Client Auth (1.1.0)

### DIFF
--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -369,6 +369,7 @@ static int state_machine(SSL *s, int server)
             s->hit = 0;
 
             s->s3->tmp.cert_request = 0;
+            s->s3->tmp.cert_req = 0;
 
             if (SSL_IS_DTLS(s)) {
                 st->use_timer = 1;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -361,6 +361,8 @@ static int state_machine(SSL *s, int server)
                  */
                 s->ctx->stats.sess_accept_renegotiate++;
             }
+
+            s->s3->tmp.cert_request = 0;
         } else {
             s->ctx->stats.sess_connect++;
 
@@ -368,7 +370,6 @@ static int state_machine(SSL *s, int server)
             memset(s->s3->client_random, 0, sizeof(s->s3->client_random));
             s->hit = 0;
 
-            s->s3->tmp.cert_request = 0;
             s->s3->tmp.cert_req = 0;
 
             if (SSL_IS_DTLS(s)) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -276,7 +276,7 @@ static int send_certificate_request(SSL *s)
             * if SSL_VERIFY_CLIENT_ONCE is set, don't request cert
             * during re-negotiation:
             */
-           && ((s->session->peer == NULL) ||
+           && (s->s3->tmp.finish_md_len == 0 ||
                !(s->verify_mode & SSL_VERIFY_CLIENT_ONCE))
            /*
             * never request cert in anonymous ciphersuites (see

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -1,0 +1,147 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+use File::Temp qw(tempfile);
+use TLSProxy::Proxy;
+my $test_name = "test_tls13messages";
+setup($test_name);
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS|MSWin32)$/;
+
+plan skip_all => "$test_name needs the dynamic engine feature enabled"
+    if disabled("engine") || disabled("dynamic-engine");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLS enabled"
+    if alldisabled(available_protocols("tls"));
+
+$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+
+use constant {
+    DEFAULT_HANDSHAKE => 1,
+    OCSP_HANDSHAKE => 2,
+    RESUME_HANDSHAKE => 4,
+    CLIENT_AUTH_HANDSHAKE => 8,
+    RENEG_HANDSHAKE => 16,
+
+    ALL_HANDSHAKES => 31
+};
+
+my @handmessages = (
+    [TLSProxy::Message::MT_CLIENT_HELLO, ALL_HANDSHAKES],
+    [TLSProxy::Message::MT_SERVER_HELLO, ALL_HANDSHAKES],
+    [TLSProxy::Message::MT_CERTIFICATE, ALL_HANDSHAKES & ~RESUME_HANDSHAKE],
+    [TLSProxy::Message::MT_CERTIFICATE_STATUS, OCSP_HANDSHAKE],
+    #ServerKeyExchange handshakes not currently supported by TLSProxy
+    [TLSProxy::Message::MT_CERTIFICATE_REQUEST, CLIENT_AUTH_HANDSHAKE],
+    [TLSProxy::Message::MT_SERVER_HELLO_DONE, ALL_HANDSHAKES & ~RESUME_HANDSHAKE],
+    [TLSProxy::Message::MT_CERTIFICATE, CLIENT_AUTH_HANDSHAKE],
+    [TLSProxy::Message::MT_CLIENT_KEY_EXCHANGE, ALL_HANDSHAKES & ~RESUME_HANDSHAKE],
+    [TLSProxy::Message::MT_CERTIFICATE_VERIFY, CLIENT_AUTH_HANDSHAKE],
+    [TLSProxy::Message::MT_FINISHED, ALL_HANDSHAKES],
+    [TLSProxy::Message::MT_NEW_SESSION_TICKET, ALL_HANDSHAKES & ~RESUME_HANDSHAKE],
+    [TLSProxy::Message::MT_FINISHED, ALL_HANDSHAKES],
+    [TLSProxy::Message::MT_CLIENT_HELLO, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_SERVER_HELLO, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_CERTIFICATE, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_SERVER_HELLO_DONE, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_CLIENT_KEY_EXCHANGE, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_FINISHED, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_NEW_SESSION_TICKET, RENEG_HANDSHAKE],
+    [TLSProxy::Message::MT_FINISHED, RENEG_HANDSHAKE],
+    [0, 0]
+);
+
+my $proxy = TLSProxy::Proxy->new(
+    undef,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
+);
+
+sub checkmessages($$);
+
+#Test 1: Check we get all the right messages for a default handshake
+(undef, my $session) = tempfile();
+$proxy->serverconnects(2);
+$proxy->clientflags("-sess_out ".$session);
+$proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 5;
+checkmessages(DEFAULT_HANDSHAKE, "Default handshake test");
+
+#Test 2: Resumption handshake
+$proxy->clearClient();
+$proxy->clientflags("-sess_in ".$session);
+$proxy->clientstart();
+checkmessages(RESUME_HANDSHAKE, "Resumption handshake test");
+unlink $session;
+
+#Test 3: A client auth handshake
+$proxy->clear();
+$proxy->clientflags("-cert ".srctop_file("apps", "server.pem"));
+$proxy->serverflags("-Verify 5");
+$proxy->start();
+checkmessages(CLIENT_AUTH_HANDSHAKE, "Client auth handshake test");
+
+#Test 4: A handshake with a renegotiation
+$proxy->clear();
+$proxy->reneg(1);
+$proxy->start();
+checkmessages(RENEG_HANDSHAKE, "Rengotiation handshake test");
+
+#Test 5: A handshake with a renegotiation and client auth
+$proxy->clear();
+$proxy->clientflags("-cert ".srctop_file("apps", "server.pem"));
+$proxy->serverflags("-Verify 5");
+$proxy->reneg(1);
+$proxy->start();
+checkmessages(RENEG_HANDSHAKE | CLIENT_AUTH_HANDSHAKE,
+              "Renogitation and client auth handshake test");
+
+sub checkmessages($$)
+{
+    my ($handtype, $testname) = @_;
+
+    subtest $testname => sub {
+        my $loop = 0;
+        my $numtests;
+
+        #First count the number of tests
+        for ($numtests = 0; $handmessages[$loop][1] != 0; $loop++) {
+            $numtests++ if (($handmessages[$loop][1] & $handtype) != 0);
+        }
+
+        plan tests => $numtests;
+
+        my $nextmess = 0;
+        my $message = undef;
+        for ($loop = 0; $handmessages[$loop][1] != 0; $loop++) {
+            next if (($handmessages[$loop][1] & $handtype) == 0);
+            if (scalar @{$proxy->message_list} > $nextmess) {
+                $message = ${$proxy->message_list}[$nextmess];
+                $nextmess++;
+            } else {
+                $message = undef;
+            }
+            if (!defined $message) {
+                fail("Message type check. Got nothing, expected "
+                     .$handmessages[$loop][0]);
+            } else {
+                ok($message->mt == $handmessages[$loop][0],
+                   "Message type check. Got ".$message->mt
+                   .", expected ".$handmessages[$loop][0]);
+            }
+        }
+    }
+}

--- a/test/ssl-tests/17-renegotiate.conf
+++ b/test/ssl-tests/17-renegotiate.conf
@@ -1,11 +1,13 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 4
+num_tests = 6
 
 test-0 = 0-renegotiate-client-no-resume
 test-1 = 1-renegotiate-client-resume
 test-2 = 2-renegotiate-server-no-resume
 test-3 = 3-renegotiate-server-resume
+test-4 = 4-renegotiate-client-auth-require
+test-5 = 5-renegotiate-client-auth-once
 # ===========================================================
 
 [0-renegotiate-client-no-resume]
@@ -110,5 +112,69 @@ ExpectedResult = Success
 HandshakeMode = RenegotiateServer
 Method = TLS
 ResumptionExpected = Yes
+
+
+# ===========================================================
+
+[4-renegotiate-client-auth-require]
+ssl_conf = 4-renegotiate-client-auth-require-ssl
+
+[4-renegotiate-client-auth-require-ssl]
+server = 4-renegotiate-client-auth-require-server
+client = 4-renegotiate-client-auth-require-client
+
+[4-renegotiate-client-auth-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+Options = NoResumptionOnRenegotiation
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[4-renegotiate-client-auth-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = TLS
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[5-renegotiate-client-auth-once]
+ssl_conf = 5-renegotiate-client-auth-once-ssl
+
+[5-renegotiate-client-auth-once-ssl]
+server = 5-renegotiate-client-auth-once-server
+client = 5-renegotiate-client-auth-once-client
+
+[5-renegotiate-client-auth-once-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+Options = NoResumptionOnRenegotiation
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Once
+
+[5-renegotiate-client-auth-once-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = TLS
+ResumptionExpected = No
 
 

--- a/test/ssl-tests/17-renegotiate.conf.in
+++ b/test/ssl-tests/17-renegotiate.conf.in
@@ -14,6 +14,7 @@ use warnings;
 
 package ssltests;
 
+my $dir_sep = $^O ne "VMS" ? "/" : "";
 
 our @tests = (
     {
@@ -64,4 +65,42 @@ our @tests = (
             "ExpectedResult" => "Success"
         }
     },
+    {
+        name => "renegotiate-client-auth-require",
+        server => {
+            "Options" => "NoResumptionOnRenegotiation",
+            "MaxProtocol" => "TLSv1.2",
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "TLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "renegotiate-client-auth-once",
+        server => {
+            "Options" => "NoResumptionOnRenegotiation",
+            "MaxProtocol" => "TLSv1.2",
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Once",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "TLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    }
 );

--- a/test/ssl-tests/18-dtls-renegotiate.conf
+++ b/test/ssl-tests/18-dtls-renegotiate.conf
@@ -1,10 +1,12 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 3
+num_tests = 5
 
 test-0 = 0-renegotiate-client-no-resume
 test-1 = 1-renegotiate-client-resume
 test-2 = 2-renegotiate-server-resume
+test-3 = 3-renegotiate-client-auth-require
+test-4 = 4-renegotiate-client-auth-once
 # ===========================================================
 
 [0-renegotiate-client-no-resume]
@@ -78,6 +80,66 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-2]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = DTLS
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[3-renegotiate-client-auth-require]
+ssl_conf = 3-renegotiate-client-auth-require-ssl
+
+[3-renegotiate-client-auth-require-ssl]
+server = 3-renegotiate-client-auth-require-server
+client = 3-renegotiate-client-auth-require-client
+
+[3-renegotiate-client-auth-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[3-renegotiate-client-auth-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+ExpectedResult = Success
+HandshakeMode = RenegotiateServer
+Method = DTLS
+ResumptionExpected = No
+
+
+# ===========================================================
+
+[4-renegotiate-client-auth-once]
+ssl_conf = 4-renegotiate-client-auth-once-ssl
+
+[4-renegotiate-client-auth-once-ssl]
+server = 4-renegotiate-client-auth-once-server
+client = 4-renegotiate-client-auth-once-client
+
+[4-renegotiate-client-auth-once-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Once
+
+[4-renegotiate-client-auth-once-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
 ExpectedResult = Success
 HandshakeMode = RenegotiateServer
 Method = DTLS

--- a/test/ssl-tests/18-dtls-renegotiate.conf.in
+++ b/test/ssl-tests/18-dtls-renegotiate.conf.in
@@ -14,6 +14,7 @@ use warnings;
 
 package ssltests;
 
+my $dir_sep = $^O ne "VMS" ? "/" : "";
 
 our @tests = (
     {
@@ -60,4 +61,38 @@ our @tests = (
             "ExpectedResult" => "Success"
         }
     },
+    {
+        name => "renegotiate-client-auth-require",
+        server => {
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "DTLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "renegotiate-client-auth-once",
+        server => {
+            "VerifyCAFile" => "\${ENV::TEST_CERTS_DIR}${dir_sep}root-cert.pem",
+            "VerifyMode" => "Once",
+        },
+        client => {
+            "Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-client-chain.pem",
+            "PrivateKey"  => "\${ENV::TEST_CERTS_DIR}${dir_sep}ee-key.pem"
+        },
+        test => {
+            "Method" => "DTLS",
+            "HandshakeMode" => "RenegotiateServer",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    }
 );

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -171,7 +171,7 @@ sub get_messages
                 $recoffset += 4;
                 $payload = "";
                 
-                if ($recoffset < $record->decrypt_len) {
+                if ($recoffset <= $record->decrypt_len) {
                     #Some payload data is present in this record
                     if ($record->decrypt_len - $recoffset >= $messlen) {
                         #We can complete the message with this record

--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -42,6 +42,7 @@ sub new
         clientflags => "",
         serverconnects => 1,
         serverpid => 0,
+        reneg => 0,
 
         #Public read
         execute => $execute,
@@ -117,6 +118,7 @@ sub clear
     $self->{serverflags} = "";
     $self->{serverconnects} = 1;
     $self->{serverpid} = 0;
+    $self->{reneg} = 0;
 }
 
 sub restart
@@ -200,7 +202,13 @@ sub clientstart
                     or die "Failed to redirect stdout: $!";
                 open(STDERR, ">&STDOUT");
             }
-            my $execcmd = "echo test | ".$self->execute
+            my $echostr;
+            if ($self->reneg()) {
+                $echostr = "R";
+            } else {
+                $echostr = "test";
+            }
+            my $execcmd = "echo ".$echostr." | ".$self->execute
                  ." s_client -engine ossltest -connect "
                  .($self->proxy_addr).":".($self->proxy_port);
             if ($self->cipherc ne "") {
@@ -502,6 +510,15 @@ sub fill_known_data
         $ret .= chr($i);
     }
     return $ret;
+}
+
+sub reneg
+{
+    my $self = shift;
+    if (@_) {
+      $self->{reneg} = shift;
+    }
+    return $self->{reneg};
 }
 
 1;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

#1920 describes a problem where a non-client auth reneg handshake that occurs after a client-auth handshake will end up with the client sending a Certificate message when it is not supposed to.

There is another related bug where, in the same situation, the server expects a Certificate message even when it hasn't requested one!

These two bugs together mean that OpenSSL will happily talk to the same version of itself in this scenario, but nothing else.

In adding tests for this I found a third bug in the implementation of SSL_VERIFY_CLIENT_ONCE. The documentation for this flag says:
````
      B<Server mode:> only request a client certificate on the initial TLS/SSL
      handshake. Do not ask for a client certificate again in case of a
      renegotiation. This flag must be used together with SSL_VERIFY_PEER.
    
      B<Client mode:> ignored
````
But the implementation actually did nothing. After the server sends its
ServerKeyExchange message, the code was checking s->session->peer to see if
it is NULL. If it was set then it did not ask for another client
certificate. However s->session->peer will only be set in the event of a
resumption, but a ServerKeyExchange message is only sent in the event of a
full handshake (i.e. no resumption).
    
The documentation suggests that the original intention was for this to
have an effect on renegotiation, and resumption doesn't come into it.
    
The fix is to properly check for renegotiation, not whether there is already
a client certificate in the session.
    
As far as I can tell this has been broken for a *long* time. I actually wondered whether we would be better off just removing it. But as it turns out I need to use it for my tests to work so I fixed it anyway!!

I also fixed a bug in TLSProxy where zero length messages weren't being recorded properly.

This is the 1.1.0 version of #1982

Fixes #1920