### PR TITLE
Fix SSL_VERIFY_CLIENT_ONCE (1.0.2)

### DIFF
--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -506,7 +506,7 @@ int ssl3_accept(SSL *s)
                     * if SSL_VERIFY_CLIENT_ONCE is set, don't request cert
                     * during re-negotiation:
                     */
-                   ((s->session->peer != NULL) &&
+                   (s->s3->tmp.finish_md_len != 0 &&
                     (s->verify_mode & SSL_VERIFY_CLIENT_ONCE)) ||
                    /*
                     * never request cert in anonymous ciphersuites (see


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
- [ ] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

The flag SSL_VERIFY_CLIENT_ONCE is documented as follows:
````
  B<Server mode:> only request a client certificate on the initial TLS/SSL
  handshake. Do not ask for a client certificate again in case of a
  renegotiation. This flag must be used together with SSL_VERIFY_PEER.

  B<Client mode:> ignored
````
But the implementation actually did nothing. After the server sends its
ServerKeyExchange message, the code was checking s->session->peer to see if
it is NULL. If it was set then it did not ask for another client
certificate. However s->session->peer will only be set in the event of a
resumption, but a ServerKeyExchange message is only sent in the event of a
full handshake (i.e. no resumption).

The documentation suggests that the original intention was for this to
have an effect on renegotiation, and resumption doesn't come into it.

The fix is to properly check for renegotiation, not whether there is already
a client certificate in the session.

As far as I can tell this has been broken for a *long* time.

This is the one bug fixed in #1982 and #1983 which also impacts 1.0.2