### PR TITLE
S/MIME CMS SHA1 signing fix.

### DIFF
--- a/crypto/evp/m_md5_sha1.c
+++ b/crypto/evp/m_md5_sha1.c
@@ -52,10 +52,15 @@ static int ctrl(EVP_MD_CTX *ctx, int cmd, int mslen, void *ms)
     unsigned char padtmp[48];
     unsigned char md5tmp[MD5_DIGEST_LENGTH];
     unsigned char sha1tmp[SHA_DIGEST_LENGTH];
-    struct md5_sha1_ctx *mctx = EVP_MD_CTX_md_data(ctx);
+    struct md5_sha1_ctx *mctx;
 
     if (cmd != EVP_CTRL_SSL3_MASTER_SECRET)
+        return -2;
+
+    if (ctx == NULL)
         return 0;
+
+    mctx = EVP_MD_CTX_md_data(ctx);
 
     /* SSLv3 client auth handling: see RFC-6101 5.6.8 */
     if (mslen != 48)

--- a/crypto/evp/m_sha1.c
+++ b/crypto/evp/m_sha1.c
@@ -36,10 +36,15 @@ static int ctrl(EVP_MD_CTX *ctx, int cmd, int mslen, void *ms)
     unsigned char padtmp[40];
     unsigned char sha1tmp[SHA_DIGEST_LENGTH];
 
-    SHA_CTX *sha1 = EVP_MD_CTX_md_data(ctx);
+    SHA_CTX *sha1;
 
     if (cmd != EVP_CTRL_SSL3_MASTER_SECRET)
+        return -2;
+
+    if (ctx == NULL)
         return 0;
+
+    sha1 = EVP_MD_CTX_md_data(ctx);
 
     /* SSLv3 client auth handling: see RFC-6101 5.6.8 */
     if (mslen != 48)

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -107,6 +107,14 @@ my @smime_pkcs7_tests = (
 	"-CAfile", catfile($smdir, "smroot.pem"), "-out", "smtst.txt" ]
     ],
 
+    [ "signed content S/MIME format, RSA key SHA1",
+      [ "-sign", "-in", $smcont, "-md", "sha1",
+	"-certfile", catfile($smdir, "smroot.pem"),
+	"-signer", catfile($smdir, "smrsa1.pem"), "-out", "test.cms" ],
+      [ "-verify", "-in", "test.cms",
+	"-CAfile", catfile($smdir, "smroot.pem"), "-out", "smtst.txt" ]
+    ],
+
     [ "signed content test streaming S/MIME format, 2 DSA and 2 RSA keys",
       [ "-sign", "-in", $smcont, "-nodetach",
 	"-signer", catfile($smdir, "smrsa1.pem"),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] tests are added or updated
- [ x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This makes explicit siging messages using SHA1 work again for cms and smime. Test added.