### PR TITLE
Fix a couple of uninit variable warnings

### DIFF
--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -290,7 +290,7 @@ int tls13_change_cipher_state(SSL *s, int which)
     unsigned char *finsecret = NULL;
     EVP_CIPHER_CTX *ciph_ctx;
     const EVP_CIPHER *ciph = s->s3->tmp.new_sym_enc;
-    size_t ivlen, keylen, finsecretlen;
+    size_t ivlen, keylen, finsecretlen = 0;
     const unsigned char *label;
     size_t labellen;
     int ret = 0;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
     SSL_CTX *ctx;
-    SSL *con;
+    SSL *con = NULL;
     BIO *rbio;
     BIO *wbio;
     BIO *err;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
One warning is bogus, and one is real - both causing travis failures.