### PR TITLE
Ability to debug memory leaks under Visual Studio 2003 and higher.

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -14,14 +14,16 @@
 #include "internal/cryptlib.h"
 
 /*
-* allow Visual Studio 2003 and higher dump possible memory leaks with _CrtDumpMemoryLeaks() API
-* if OPENSSL_NO_CRYPTO_MDEBUG is defined and library local memory debugging functionality is disabled
+* allow Visual Studio 2003 and higher dump possible memory leaks with
+* _CrtDumpMemoryLeaks() API if OPENSSL_NO_CRYPTO_MDEBUG is defined and library
+* local memory debugging functionality is disabled
 */
-#if defined(OPENSSL_NO_CRYPTO_MDEBUG) && defined(_DEBUG) && defined(_MSC_VER) && (_MSC_VER >= 1310)
-#include <crtdbg.h>
-#ifdef _NORMAL_BLOCK
-    #define MSVC_MEM_DEBUG
-#endif
+#if defined(OPENSSL_NO_CRYPTO_MDEBUG) && defined(_DEBUG) && \
+    defined(_MSC_VER) && (_MSC_VER >= 1310)
+# include <crtdbg.h>
+# ifdef _NORMAL_BLOCK
+   #define MSVC_MEM_DEBUG
+# endif
 #endif
 
 /*
@@ -100,10 +102,10 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
     }
 #else
     #ifndef MSVC_MEM_DEBUG
-        osslargused(file); osslargused(line);
-        ret = malloc(num);
+    osslargused(file); osslargused(line);
+    ret = malloc(num);
     #else
-        ret = _malloc_dbg(num, _NORMAL_BLOCK, file, line);
+    ret = _malloc_dbg(num, _NORMAL_BLOCK, file, line);
     #endif
 #endif
 
@@ -144,10 +146,10 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
     return realloc(str, num);
 #else
     #ifndef MSVC_MEM_DEBUG
-        osslargused(file); osslargused(line);
-        return realloc(str, num);
+    osslargused(file); osslargused(line);
+    return realloc(str, num);
     #else
-        return _realloc_dbg(str, num, _NORMAL_BLOCK, file, line);
+    return _realloc_dbg(str, num, _NORMAL_BLOCK, file, line);
     #endif
 #endif
 }
@@ -196,9 +198,9 @@ void CRYPTO_free(void *str, const char *file, int line)
     }
 #else
     #ifndef MSVC_MEM_DEBUG
-        free(str);
+    free(str);
     #else
-        _free_dbg(str, _NORMAL_BLOCK);
+    _free_dbg(str, _NORMAL_BLOCK);
     #endif
 #endif
 }

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -22,7 +22,7 @@
     defined(_MSC_VER) && (_MSC_VER >= 1310)
 # include <crtdbg.h>
 # ifdef _NORMAL_BLOCK
-   #define MSVC_MEM_DEBUG
+   #define MSVC_MDEBUG
 # endif
 #endif
 
@@ -101,12 +101,12 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
         ret = malloc(num);
     }
 #else
-    #ifndef MSVC_MEM_DEBUG
+# ifndef MSVC_MDEBUG
     osslargused(file); osslargused(line);
     ret = malloc(num);
-    #else
+# else
     ret = _malloc_dbg(num, _NORMAL_BLOCK, file, line);
-    #endif
+# endif
 #endif
 
     return ret;
@@ -145,12 +145,12 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
     }
     return realloc(str, num);
 #else
-    #ifndef MSVC_MEM_DEBUG
+# ifndef MSVC_MDEBUG
     osslargused(file); osslargused(line);
     return realloc(str, num);
-    #else
+# else
     return _realloc_dbg(str, num, _NORMAL_BLOCK, file, line);
-    #endif
+# endif
 #endif
 }
 
@@ -197,11 +197,11 @@ void CRYPTO_free(void *str, const char *file, int line)
         free(str);
     }
 #else
-    #ifndef MSVC_MEM_DEBUG
+# ifndef MSVC_MDEBUG
     free(str);
-    #else
+# else
     _free_dbg(str, _NORMAL_BLOCK);
-    #endif
+# endif
 #endif
 }
 


### PR DESCRIPTION
Add possibility to debug memory leaks under Visual Studio 2003 and higher by using its _CrtDumpMemoryLeaks() API which is described in detail on MSDN - [Interpreting the Memory-Leak Report](http://msdn.microsoft.com/en-us/library/x98tx3cf(v=vs.140).aspx#Interpreting%20the%20Memory-Leak%20Report).

This functionality becomes automatically available in OpenSSL if library local memory debugging is switched off by defining OPENSSL_NO_CRYPTO_MDEBUG.

Visual Studio will then give useful log if such leaks occurred in the application:

Detected memory leaks!
Dumping objects ->
crypto\init.c(45) : {166973} normal block at 0x06371C68, 8 bytes long.
 Data: <        > 00 00 00 00 01 00 00 00
crypto\err\err.c(652) : {166972} normal block at 0x0BC915F0, 392 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
crypto\init.c(45) : {161936} normal block at 0x09131470, 8 bytes long.
 Data: <        > 00 00 00 00 01 00 00 00
crypto\err\err.c(652) : {161935} normal block at 0x0BC91280, 392 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
crypto\init.c(45) : {99666} normal block at 0x06369250, 8 bytes long.
 Data: <        > 00 00 00 00 01 00 00 00
crypto\err\err.c(652) : {99665} normal block at 0x061D8928, 392 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Object dump complete.
The program '[9604] test.exe' has exited with code 0 (0x0).