### PR TITLE
Restore last-resort expired untrusted intermediate issuers

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -305,19 +305,21 @@ int X509_verify_cert(X509_STORE_CTX *ctx)
 /*
  * Given a STACK_OF(X509) find the issuer of cert (if any)
  */
+
 static X509 *find_issuer(X509_STORE_CTX *ctx, STACK_OF(X509) *sk, X509 *x)
 {
     int i;
+    X509 *issuer, *rv = NULL;
 
     for (i = 0; i < sk_X509_num(sk); i++) {
-        X509 *issuer = sk_X509_value(sk, i);
-
-        if (!ctx->check_issued(ctx, x, issuer))
-            continue;
-        if (x509_check_cert_time(ctx, issuer, -1))
-            return issuer;
+        issuer = sk_X509_value(sk, i);
+        if (ctx->check_issued(ctx, x, issuer)) {
+            rv = issuer;
+            if (x509_check_cert_time(ctx, rv, -1))
+                break;
+        }
     }
-    return NULL;
+    return rv;
 }
 
 /* Given a possible certificate and issuer check them */


### PR DESCRIPTION
Fixes #1997

Clone of #2004 for the `master` branch.

