### PR TITLE
Test mac-then-encrypt

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,9 @@
   *) Heartbeat support has been removed; the ABI is changed for now.
      [Richard Levitte, Rich Salz]
 
+  *) Support for SSL_OP_NO_ENCRYPT_THEN_MAC in SSL_CONF_cmd.
+     [Emilia Käsper]
+
  Changes between 1.1.0b and 1.1.0c [xx XXX xxxx]
 
   *) ChaCha20/Poly1305 heap-buffer-overflow

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -353,6 +353,10 @@ B<UnsafeLegacyServerConnect> permits the use of unsafe legacy renegotiation
 for OpenSSL clients only. Equivalent to B<SSL_OP_LEGACY_SERVER_CONNECT>.
 Set by default.
 
+B<EncryptThenMac>: use encrypt-then-mac extension, enabled by
+default. Inverse of B<SSL_OP_NO_ENCRYPT_THEN_MAC>: that is,
+B<-EncryptThenMac> is the same as setting B<SSL_OP_NO_ENCRYPT_THEN_MAC>.
+
 =item B<VerifyMode>
 
 The B<value> argument is a comma separated list of flags to set.

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -357,6 +357,7 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_SRV("ECDHSingle", SSL_OP_SINGLE_ECDH_USE),
         SSL_FLAG_TBL("UnsafeLegacyRenegotiation",
                      SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION),
+        SSL_FLAG_TBL_INV("EncryptThenMac", SSL_OP_NO_ENCRYPT_THEN_MAC),
     };
     if (value == NULL)
         return -3;

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -29,7 +29,7 @@ map { s/\.in// } @conf_files;
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 18;  # = scalar @conf_srcs
+plan tests => 19;  # = scalar @conf_srcs
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.

--- a/test/ssl-tests/19-mac-then-encrypt.conf
+++ b/test/ssl-tests/19-mac-then-encrypt.conf
@@ -1,0 +1,156 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 6
+
+test-0 = 0-disable-encrypt-then-mac-server-sha
+test-1 = 1-disable-encrypt-then-mac-client-sha
+test-2 = 2-disable-encrypt-then-mac-both-sha
+test-3 = 3-disable-encrypt-then-mac-server-sha2
+test-4 = 4-disable-encrypt-then-mac-client-sha2
+test-5 = 5-disable-encrypt-then-mac-both-sha2
+# ===========================================================
+
+[0-disable-encrypt-then-mac-server-sha]
+ssl_conf = 0-disable-encrypt-then-mac-server-sha-ssl
+
+[0-disable-encrypt-then-mac-server-sha-ssl]
+server = 0-disable-encrypt-then-mac-server-sha-server
+client = 0-disable-encrypt-then-mac-server-sha-client
+
+[0-disable-encrypt-then-mac-server-sha-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-disable-encrypt-then-mac-server-sha-client]
+CipherString = AES128-SHA
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[1-disable-encrypt-then-mac-client-sha]
+ssl_conf = 1-disable-encrypt-then-mac-client-sha-ssl
+
+[1-disable-encrypt-then-mac-client-sha-ssl]
+server = 1-disable-encrypt-then-mac-client-sha-server
+client = 1-disable-encrypt-then-mac-client-sha-client
+
+[1-disable-encrypt-then-mac-client-sha-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-disable-encrypt-then-mac-client-sha-client]
+CipherString = AES128-SHA
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[2-disable-encrypt-then-mac-both-sha]
+ssl_conf = 2-disable-encrypt-then-mac-both-sha-ssl
+
+[2-disable-encrypt-then-mac-both-sha-ssl]
+server = 2-disable-encrypt-then-mac-both-sha-server
+client = 2-disable-encrypt-then-mac-both-sha-client
+
+[2-disable-encrypt-then-mac-both-sha-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-disable-encrypt-then-mac-both-sha-client]
+CipherString = AES128-SHA
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[3-disable-encrypt-then-mac-server-sha2]
+ssl_conf = 3-disable-encrypt-then-mac-server-sha2-ssl
+
+[3-disable-encrypt-then-mac-server-sha2-ssl]
+server = 3-disable-encrypt-then-mac-server-sha2-server
+client = 3-disable-encrypt-then-mac-server-sha2-client
+
+[3-disable-encrypt-then-mac-server-sha2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-disable-encrypt-then-mac-server-sha2-client]
+CipherString = AES128-SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[4-disable-encrypt-then-mac-client-sha2]
+ssl_conf = 4-disable-encrypt-then-mac-client-sha2-ssl
+
+[4-disable-encrypt-then-mac-client-sha2-ssl]
+server = 4-disable-encrypt-then-mac-client-sha2-server
+client = 4-disable-encrypt-then-mac-client-sha2-client
+
+[4-disable-encrypt-then-mac-client-sha2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-disable-encrypt-then-mac-client-sha2-client]
+CipherString = AES128-SHA256
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[5-disable-encrypt-then-mac-both-sha2]
+ssl_conf = 5-disable-encrypt-then-mac-both-sha2-ssl
+
+[5-disable-encrypt-then-mac-both-sha2-ssl]
+server = 5-disable-encrypt-then-mac-both-sha2-server
+client = 5-disable-encrypt-then-mac-both-sha2-client
+
+[5-disable-encrypt-then-mac-both-sha2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-disable-encrypt-then-mac-both-sha2-client]
+CipherString = AES128-SHA256
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = Success
+
+

--- a/test/ssl-tests/19-mac-then-encrypt.conf.in
+++ b/test/ssl-tests/19-mac-then-encrypt.conf.in
@@ -1,0 +1,89 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## SSL test configurations
+
+package ssltests;
+
+our @tests = (
+    {
+        name => "disable-encrypt-then-mac-server-sha",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-client-sha",
+        server => {
+        },
+        client => {
+          "CipherString" => "AES128-SHA",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-both-sha",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-server-sha2",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA256",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-client-sha2",
+        server => {
+        },
+        client => {
+          "CipherString" => "AES128-SHA256",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-both-sha2",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA256",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Verify that the encrypt-then-mac negotiation is handled
correctly. Additionally, when compiled with no-asm, this test ensures
coverage for the constant-time MAC copying code in
ssl3_cbc_copy_mac. The proxy-based CBC padding test covers that as
well but it's nevertheless better to have an explicit handshake test
for mac-then-encrypt.