### PR TITLE
Fix compilation on QNX platform.

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -47,7 +47,7 @@
 # include <errno.h>
 
 # include "e_os.h"
-# if defined(__unix) || defined(__unix__)
+# if defined(__unix) || defined(__unix__) || defined(__QNXNTO__)
 #  include <sys/time.h>         /* struct timeval for DTLS */
 # endif
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -47,7 +47,7 @@
 # include <errno.h>
 
 # include "e_os.h"
-# if defined(__unix) || defined(__unix__) || defined(__QNXNTO__)
+# if defined(__unix) || defined(__unix__) || defined(__QNX__)
 #  include <sys/time.h>         /* struct timeval for DTLS */
 # endif
 


### PR DESCRIPTION
Fixed compilation on QNX platforms such as BlackBerry 10 OS and PlayBook OS due to missing timeval declaration. Added platform definition __QNXNTO__ in order to include sys/time.h header to resolve the error.