### PR TITLE
Fix mac-then-encrypt test with enable-tls1_3

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -39,7 +39,9 @@ my $is_default_tls = (disabled("ssl3") && !disabled("tls1") &&
 
 my $is_default_dtls = (!disabled("dtls1") && !disabled("dtls1_2"));
 
+my @all_pre_tls1_3 = ("ssl3", "tls1", "tls1_1", "tls1_2");
 my $no_tls = alldisabled(available_protocols("tls"));
+my $no_pre_tls1_3 = alldisabled(@all_pre_tls1_3);
 my $no_dtls = alldisabled(available_protocols("dtls"));
 my $no_npn = disabled("nextprotoneg");
 my $no_ct = disabled("ct");
@@ -76,6 +78,7 @@ my %skip = (
   "15-certstatus.conf" => $no_tls || $no_ocsp,
   "16-dtls-certstatus.conf" => $no_dtls || $no_ocsp,
   "18-dtls-renegotiate.conf" => $no_dtls,
+  "19-mac-then-encrypt.conf" => $no_pre_tls1_3
 );
 
 foreach my $conf (@conf_files) {

--- a/test/ssl-tests/19-mac-then-encrypt.conf
+++ b/test/ssl-tests/19-mac-then-encrypt.conf
@@ -25,6 +25,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-disable-encrypt-then-mac-server-sha-client]
 CipherString = AES128-SHA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -48,6 +49,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-disable-encrypt-then-mac-client-sha-client]
 CipherString = AES128-SHA
+MaxProtocol = TLSv1.2
 Options = -EncryptThenMac
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -73,6 +75,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-disable-encrypt-then-mac-both-sha-client]
 CipherString = AES128-SHA
+MaxProtocol = TLSv1.2
 Options = -EncryptThenMac
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -93,6 +96,7 @@ client = 3-disable-encrypt-then-mac-server-sha2-client
 [3-disable-encrypt-then-mac-server-sha2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MaxProtocol = TLSv1.2
 Options = -EncryptThenMac
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -121,6 +125,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-disable-encrypt-then-mac-client-sha2-client]
 CipherString = AES128-SHA256
+MaxProtocol = TLSv1.2
 Options = -EncryptThenMac
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -146,6 +151,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-disable-encrypt-then-mac-both-sha2-client]
 CipherString = AES128-SHA256
+MaxProtocol = TLSv1.2
 Options = -EncryptThenMac
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/19-mac-then-encrypt.conf.in
+++ b/test/ssl-tests/19-mac-then-encrypt.conf.in
@@ -19,6 +19,7 @@ our @tests = (
         },
         client => {
           "CipherString" => "AES128-SHA",
+          "MaxProtocol" => "TLSv1.2"
         },
         test   => {
           "ExpectedResult" => "Success",
@@ -31,6 +32,7 @@ our @tests = (
         client => {
           "CipherString" => "AES128-SHA",
           "Options" => "-EncryptThenMac",
+          "MaxProtocol" => "TLSv1.2"
         },
         test   => {
           "ExpectedResult" => "Success",
@@ -44,6 +46,7 @@ our @tests = (
         client => {
           "CipherString" => "AES128-SHA",
           "Options" => "-EncryptThenMac",
+          "MaxProtocol" => "TLSv1.2"
         },
         test   => {
           "ExpectedResult" => "Success",
@@ -53,6 +56,7 @@ our @tests = (
         name => "disable-encrypt-then-mac-server-sha2",
         server => {
           "Options" => "-EncryptThenMac",
+          "MaxProtocol" => "TLSv1.2"
         },
         client => {
           "CipherString" => "AES128-SHA256",
@@ -68,6 +72,7 @@ our @tests = (
         client => {
           "CipherString" => "AES128-SHA256",
           "Options" => "-EncryptThenMac",
+          "MaxProtocol" => "TLSv1.2"
         },
         test   => {
           "ExpectedResult" => "Success",
@@ -81,6 +86,7 @@ our @tests = (
         client => {
           "CipherString" => "AES128-SHA256",
           "Options" => "-EncryptThenMac",
+          "MaxProtocol" => "TLSv1.2"
         },
         test   => {
           "ExpectedResult" => "Success",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Commit b3618f44 added a test for mac-then-encrypt. However the test fails
when running with "enable-tls1_3". The problem is that the test creates a
connection, which ends up being TLSv1.3. However it also restricts the
ciphers to a single mac-then-encrypt ciphersuite that is not TLSv1.3
compatible so the connection aborts and the test fails. Mac-then-encrypt
is not relevant to TLSv1.3, so the test should disable that protocol
version.