### PR TITLE
Avoid the call to OPENSSL_malloc with a negative value

### DIFF
--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -324,6 +324,9 @@ DSO *DSO_dsobyaddr(void *addr, int flags)
     char *filename = NULL;
     int len = DSO_pathbyaddr(addr, NULL, 0);
 
+    if (len < 0)
+        return NULL;
+
     filename = OPENSSL_malloc(len);
     if (filename != NULL
             && DSO_pathbyaddr(addr, filename, len) == len)


### PR DESCRIPTION
##### Description of change

`DSO_dsobyaddr()` function contains a call to `DSO_pathbyaddr()` and the result is assigned to a signed integer.  

`len = DSO_pathbyaddr()`

`DSO_pathbyaddr` returns `-1` on error.

Immediatelly follows a call to `OPENSSL_malloc(len)` thus -1 is eventually casted to `size_t`.
Indeed calling `malloc(0xFF..FF)`. This can, in some situations, lead to some unwanted results and problems. 

E.g. (pretty unusual but...) if an implementation define `size_t` to be a 32 bit value on a 64 bit machine then 4G are allocated.
