### PR TITLE
Add external krb5 test support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "pyca.cryptography"]
 	path = pyca-cryptography
 	url = https://github.com/pyca/cryptography.git
+
+[submodule "krb5"]
+	path = krb5
+	url = https://github.com/krb5/krb5

--- a/.travis.yml
+++ b/.travis.yml
@@ -196,6 +196,9 @@ script:
               sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install wine;
               export EXE_SHELL="wine" WINEPREFIX=`pwd`;
           fi;
+          if [ -e krb5/src ]; then
+              sudo apt-get -yq install bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python-cjson python-paste python-pyrad slapd tcl-dev tcsh;
+          fi;
           HARNESS_VERBOSE=yes BORING_RUNNER_DIR=$top/boringssl/ssl/test/runner make test;
       else
           $make build_tests;

--- a/test/README.external
+++ b/test/README.external
@@ -98,3 +98,37 @@ Test failures and suppressions
 Some tests target older (<=1.0.2) versions so will not run. Other tests target
 other crypto implementations so are not relevant. Currently no tests fail.
 
+
+krb5 test suite
+===============
+
+Much like the PYCA/Cryptography test suite, this builds and runs the krb5
+tests against the local OpenSSL build.
+
+You will need a git checkout of krb5 at the top level:
+
+$ git clone https://github.com/krb5/krb5
+
+krb5's master has to pass this same CI, but a known-good version is
+krb5-1.15.1-final if you want to be sure.
+
+$ cd krb5
+$ git checkout krb5-1.15.1-final
+$ cd ..
+
+OpenSSL must be built with external tests enabled:
+
+$ ./config enable-external-tests
+$ make
+
+krb5's tests will then be run as part of the rest of the suite, or can be
+explicitly run (with more debugging):
+
+$ VERBOSE=1 make TESTS=test_external_krb5 test
+
+Test failures supressions
+-------------------------
+
+krb5 will automatically adapt its test suite to account for the configuration
+of your system.  Certain tests may require more installed packages to run.  No
+tests are expected to fail.

--- a/test/README.external
+++ b/test/README.external
@@ -93,7 +93,7 @@ to be installed.
 $ make test VERBOSE=1 TESTS=test_external_pyca
 
 Test failures and suppressions
-==============================
+------------------------------
 
 Some tests target older (<=1.0.2) versions so will not run. Other tests target
 other crypto implementations so are not relevant. Currently no tests fail.

--- a/test/recipes/95-test_external_krb5.t
+++ b/test/recipes/95-test_external_krb5.t
@@ -1,0 +1,25 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT data_file srctop_file/;
+
+setup("test_external_krb5");
+
+plan tests => 1;
+
+SKIP: {
+    skip "No external tests in this configuration"
+        if disabled("external-tests");
+    skip "krb5 not available", 1
+        if ! -f srctop_file("krb5", "README");
+
+    ok(run(cmd([data_file("krb5.sh")])), "running krb5 tests");
+}

--- a/test/recipes/95-test_external_krb5_data/krb5.sh
+++ b/test/recipes/95-test_external_krb5_data/krb5.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -ex
+#
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# krb5's test suite clears LD_LIBRARY_PATH
+LDFLAGS="-L`pwd`/$BLDTOP -Wl,-rpath,`pwd`/$BLDTOP"
+CFLAGS="-I`pwd`/$BLDTOP/include -I`pwd`/$SRCTOP/include"
+
+cd $SRCTOP/krb5/src
+autoreconf
+./configure --with-ldap --with-prng-alg=os --enable-pkinit \
+            --with-crypto-impl=openssl --with-tls-impl=openssl \
+            CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
+
+# quiet make so that Travis doesn't overflow
+make -s
+
+make check


### PR DESCRIPTION
##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed ~(I think this change is trivial)~

##### Description of change
As suggested by @mattcaswell and @tiran in https://github.com/openssl/openssl/issues/1903, this PR augments the external tests with [krb5](https://github.com/krb5/krb5)'s test suite (built against openssl).  I am a krb5, not an OpenSSL, developer, so mistakes are expected on my part.  In particular, I do not know Perl, and as such am not wedded to this design in any particular way.

Thanks!