### PR TITLE
Extra closing bracket in crypto\rand\randfile.c

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -209,7 +209,7 @@ int RAND_write_file(const char *file)
             return 1;
         }
     }
-#endif
+# endif
 #endif
 
 #if defined(O_CREAT) && !defined(OPENSSL_NO_POSIX_IO) && \

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -208,8 +208,8 @@ int RAND_write_file(const char *file)
              */
             return 1;
         }
-# endif
     }
+#endif
 #endif
 
 #if defined(O_CREAT) && !defined(OPENSSL_NO_POSIX_IO) && \


### PR DESCRIPTION
Issue was noticed in CPPCheck:

CryptoPkg\Library\OpensslLib\openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: 'OPENSSL_SYS_VMS'.

openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: 'OPENSSL_SYS_VMS;__INITIAL_POINTER_SIZE=64'.

openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: 'S_IFBLK'.

openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: 'S_IFCHR'.

openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: '_S_IFBLK'.

openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: '_S_IFCHR'.

openssl-1.1.0b\crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: '_WIN32'.

crypto\rand\randfile.c 280 Invalid number of character '{' when these macros are defined: '__OpenBSD__'.


This change was introduced in this commit:  https://github.com/openssl/openssl/commit/fc6076ca272f74eb1364c29e6974ad5da5ef9777?diff=split#diff-1014acebaa2c13d44ca196b9a433ef2eR184

When OPENSSL_NO_POSIX_IO is not defined and S_ISBLK or S_ISCHR is not defined, then there is an extra closing bracket on line 212 of randfile.c .  This pull request fixes the issue, as verified by CPPCheck.  Logic seems to be as originally intended.