### PR TITLE
Add a no-libssl configure option

### DIFF
--- a/Configure
+++ b/Configure
@@ -332,6 +332,7 @@ my @disablables = (
     "afalgeng",
     "asan",
     "asm",
+    "apps",
     "async",
     "autoalginit",
     "autoerrinit",
@@ -371,6 +372,7 @@ my @disablables = (
     "heartbeats",
     "hw(-.+)?",
     "idea",
+    "libssl",
     "makedepend",
     "md2",
     "md4",
@@ -508,6 +510,7 @@ my @disable_cascades = (
     "stdio"             => [ "apps", "capieng" ],
     "apps"              => [ "tests" ],
     "comp"		=> [ "zlib" ],
+    "libssl"            => [ "apps" ],
     sub { !$disabled{"unit-test"} } => [ "heartbeats" ],
 
     sub { !$disabled{"msan"} } => [ "asm" ],
@@ -894,6 +897,12 @@ foreach (sort (keys %disabled))
 		push @{$config{openssl_other_defines}}, "OPENSSL_NO_ENGINE";
 		print " OPENSSL_NO_ENGINE (skip engines)";
 		}
+        elsif (/^libssl$/)
+                {
+                @{$config{dirs}} = grep !/^ssl$/, @{$config{dirs}};
+                @{$config{dirs}} = grep !/^fuzz$/, @{$config{dirs}};
+                @{$config{dirs}} = grep !/^test$/, @{$config{dirs}};
+                }
 	else
 		{
 		my ($WHAT, $what);

--- a/build.info
+++ b/build.info
@@ -1,4 +1,8 @@
+IF[{- $config{options} =~ /no-libssl/ -}]
+LIBS=libcrypto
+ELSE
 LIBS=libcrypto libssl
+ENDIF
 ORDINALS[libcrypto]=crypto
 ORDINALS[libssl]=ssl
 INCLUDE[libcrypto]=. crypto/include include


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
- [x] CCLA is signed

Hmm, do we document the disableables anywhere other than in the source of Configure?

##### Description of change

In 1.0.2, there was a top-level 'build_crypto' make target, which could be
used in situations when only libcrypto was desired and libssl was not needed.

For 1.1.0, the build system was revamped to a unified system that does not
have separate levels of Makefile; however, this removed the option to
not build libssl.

To regain some similar functionality, create a "libssl" disableable entity
in Configure, so that passing no-libssl causes the build process to skip over
the ssl/ directory.  The top-level build.info still lists entries for the
library, so it ends up being an empty static archive or a nearly-empty
shared object, according to the configuration.

The 'fuzz', 'apps', and 'test' directories are also skipped in the no-libssl
case, as some tools within them require libssl.  It is in theory possible
to only build the parts that do not require libssl, but that would be a
much more invasive change, and it is unclear that there is a need for
such functionality.

Also list 'apps' as a disableable in Configure (it was already
treated as disableable via autoalginit disabling apps (and it disabling
tests).