### PR TITLE
Fix a leak in SSL_clear()

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -39,8 +39,6 @@ void RECORD_LAYER_init(RECORD_LAYER *rl, SSL *s)
 
 void RECORD_LAYER_clear(RECORD_LAYER *rl)
 {
-    unsigned int pipes;
-
     rl->rstate = SSL_ST_READ_HEADER;
 
     /*
@@ -62,9 +60,7 @@ void RECORD_LAYER_clear(RECORD_LAYER *rl)
     rl->wpend_buf = NULL;
 
     SSL3_BUFFER_clear(&rl->rbuf);
-    for (pipes = 0; pipes < rl->numwpipes; pipes++)
-        SSL3_BUFFER_clear(&rl->wbuf[pipes]);
-    rl->numwpipes = 0;
+    ssl3_release_write_buffer(rl->s);
     rl->numrpipes = 0;
     SSL3_RECORD_clear(rl->rrec, SSL_MAX_PIPELINES);
 

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -105,13 +105,17 @@ int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len)
 
     wb = RECORD_LAYER_get_wbuf(&s->rlayer);
     for (currpipe = 0; currpipe < numwpipes; currpipe++) {
-        if (wb[currpipe].buf == NULL) {
-            if ((p = OPENSSL_malloc(len)) == NULL) {
+        SSL3_BUFFER *thiswb = &wb[currpipe];
+
+        if (thiswb->buf == NULL) {
+            p = OPENSSL_malloc(len);
+            if (p == NULL) {
                 s->rlayer.numwpipes = currpipe;
                 goto err;
             }
-            wb[currpipe].buf = p;
-            wb[currpipe].len = len;
+            memset(thiswb, 0, sizeof(SSL3_BUFFER));
+            thiswb->buf = p;
+            thiswb->len = len;
         }
     }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -100,8 +100,16 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
         goto end;
     }
 
-    testresult = 1;
+    /*
+     * Calling SSL_clear() first is not required but this tests that SSL_clear()
+     * doesn't leak (when using enable-crypto-mdebug).
+     */
+    if (!SSL_clear(serverssl)) {
+        printf("Unexpected failure from SSL_clear()\n");
+        goto end;
+    }
 
+    testresult = 1;
  end:
     X509_free(chaincert);
     SSL_free(serverssl);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

SSL_clear() was resetting numwpipes to 0, but not freeing any allocated
memory for existing write buffers.

Fixes #2026