### PR TITLE
Add a test for the UI API

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -252,36 +252,27 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_tmp)
     int res = 0;
 #ifndef OPENSSL_NO_UI
     UI *ui = NULL;
-    const char *prompt_info = NULL;
 #endif
-    const char *password = NULL;
     PW_CB_DATA *cb_data = (PW_CB_DATA *)cb_tmp;
 
-    if (cb_data) {
-        if (cb_data->password)
-            password = cb_data->password;
-#ifndef OPENSSL_NO_UI
-        if (cb_data->prompt_info)
-            prompt_info = cb_data->prompt_info;
-#endif
-    }
-
-    if (password) {
-        res = strlen(password);
+#ifdef OPENSSL_NO_UI
+    if (cb_data != NULL && cb_data->password != NULL) {
+        res = strlen(cb_data->password);
         if (res > bufsiz)
             res = bufsiz;
-        memcpy(buf, password, res);
-        return res;
+        memcpy(buf, cb_data->password, res);
     }
-
-#ifndef OPENSSL_NO_UI
+#else
     ui = UI_new_method(ui_method);
     if (ui) {
         int ok = 0;
         char *buff = NULL;
         int ui_flags = 0;
+        const char *prompt_info = NULL;
         char *prompt;
 
+        if (cb_data != NULL && cb_data->prompt_info != NULL)
+            prompt_info = cb_data->prompt_info;
         prompt = UI_construct_prompt(ui, "pass phrase", prompt_info);
         if (!prompt) {
             BIO_printf(bio_err, "Out of memory\n");
@@ -291,6 +282,9 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_tmp)
 
         ui_flags |= UI_INPUT_FLAG_DEFAULT_PWD;
         UI_ctrl(ui, UI_CTRL_PRINT_ERRORS, 1, 0, 0);
+
+        /* We know that there is no previous user data to return to us */
+        (void)UI_add_user_data(ui, cb_data);
 
         if (ok >= 0)
             ok = UI_add_input_string(ui, prompt, ui_flags, buf,

--- a/test/recipes/03-test_ui.t
+++ b/test/recipes/03-test_ui.t
@@ -1,0 +1,30 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+use OpenSSL::Test;
+
+setup("test_ui");
+
+plan tests => 1;
+
+note <<"EOF";
+The best way to test the UI interface is currently by using an openssl
+command that uses password_callback.  The only one that does this is
+'genrsa'.
+Since password_callback uses a UI method derived from UI_OpenSSL(), it
+ensures that one gets tested well enough as well.
+EOF
+
+my $outfile = "rsa_$$.pem";
+ok(run(app(["openssl", "genrsa", "-passout", "pass:password", "-aes128",
+            "-out", $outfile])),
+   "Checking that genrsa with a password works properly");
+
+unlink $outfile;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

The best way to test the UI interface is currently by using an openssl
command that uses password_callback.  The only one that does this is
'genrsa'.
Since password_callback uses a UI method derived from UI_OpenSSL(), it
ensures that one gets tested well enough as well.