### PR TITLE
Resume reading from randfile when interrupted by a signal.

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -104,6 +104,12 @@ static __FILE_ptr32 (*const vms_fopen)(const char *, const char *, ...) =
 
 #define RFILE ".rnd"
 
+#ifdef EINTR
+# define INTERRUPTED(in) (ferror(in) && errno == EINTR)
+#else
+# define INTERRUPTED (0)
+#endif
+
 /*
  * Note that these functions are intended for seed files only. Entropy
  * devices and EGD sockets are handled in rand_unix.c
@@ -162,9 +168,16 @@ int RAND_load_file(const char *file, long bytes)
             n = (bytes < BUFSIZE) ? (int)bytes : BUFSIZE;
         else
             n = BUFSIZE;
+
         i = fread(buf, 1, n, in);
-        if (i <= 0)
+        if (i <= 0) {
+            if (INTERRUPTED(in)) {
+                /* Interrupted by a signal, resume reading */
+                clearerr(in);
+                continue;
+            }
             break;
+        }
 
         RAND_add(buf, i, (double)i);
         ret += i;


### PR DESCRIPTION
##### Checklist
- [x] CLA is signed

##### Description of change
Our users regularly observe this problem with ssh connections:
sshd: fatal: cannot read from /dev/urandom, Interrupted system call
The cause of this is that RAND_load_file() doesn't resume reading from randfile, when it's interrupted by a signal before it managed to read anything.