### PR TITLE
Restore the ERR_FATAL_ERROR() macro

### DIFF
--- a/doc/man3/ERR_GET_LIB.pod
+++ b/doc/man3/ERR_GET_LIB.pod
@@ -15,11 +15,15 @@ reason code
 
  int ERR_GET_REASON(unsigned long e);
 
+ int ERR_FATAL_ERROR(unsigned long e);
+
 =head1 DESCRIPTION
 
 The error code returned by ERR_get_error() consists of a library
 number, function code and reason code. ERR_GET_LIB(), ERR_GET_FUNC()
 and ERR_GET_REASON() can be used to extract these.
+
+ERR_FATAL_ERROR() indicates whether a given error code is a fatal error.
 
 The library number and function code describe where the error
 occurred, the reason code is the information about what went wrong.
@@ -33,11 +37,13 @@ B<ERR_R_...> reason codes such as B<ERR_R_MALLOC_FAILURE> are globally
 unique. However, when checking for sub-library specific reason codes,
 be sure to also compare the library number.
 
-ERR_GET_LIB(), ERR_GET_FUNC() and ERR_GET_REASON() are macros.
+ERR_GET_LIB(), ERR_GET_FUNC(), ERR_GET_REASON(), and ERR_FATAL_ERROR()
+ are macros.
 
 =head1 RETURN VALUES
 
-The library number, function code and reason code respectively.
+The library number, function code, reason code, and whether the error
+is fatal, respectively.
 
 =head1 SEE ALSO
 

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -140,6 +140,7 @@ typedef struct err_state_st {
 # define ERR_GET_LIB(l)          (int)(((l) >> 24L) & 0x0FFL)
 # define ERR_GET_FUNC(l)         (int)(((l) >> 12L) & 0xFFFL)
 # define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)
+# define ERR_FATAL_ERROR(l)      (int)( (l)         & ERR_R_FATAL)
 
 /* OS functions */
 # define SYS_F_FOPEN             1


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] CLA is signed

##### Description of change
Commit 0cd0a820abc6124cf8e176fa92d620a2abf9e419 removed this macro
along with many unused function and reason codes; ERR_FATAL_ERROR()
was not used in the tree, but did have external consumers.

Add it back to restore the API compatibility and avoid breaking
applications for no internal benefit.

We could wrap this in an OPENSSL_API_COMPAT check if we don't want to support it indefinitely.