### PR TITLE
Move extension data into sub-structs

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -653,25 +653,30 @@ void SSL_CTX_set_cookie_verify_cb(SSL_CTX *ctx,
                                                                unsigned int
                                                                cookie_len));
 # ifndef OPENSSL_NO_NEXTPROTONEG
-#  define SSL_CTX_set_npn_select_cb SSL_CTX_set_next_proto_select_cb
-#  define SSL_CTX_set_npn_advertised_cb SSL_CTX_set_next_protos_advertised_cb
-#  define SSL_get0_npn_negotiated SSL_get0_next_proto_negotiated
+
+typedef int (*SSL_CTX_npn_advertised_cb_func)(SSL *ssl,
+                                              const unsigned char **out,
+                                              unsigned int *outlen,
+                                              void *arg);
 void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *s,
-                                           int (*cb) (SSL *ssl,
-                                                      const unsigned char **out,
-                                                      unsigned int *outlen,
-                                                      void *arg),
-                                           void *arg);
+                                   SSL_CTX_npn_advertised_cb_func cb,
+                                   void *arg);
+#  define SSL_CTX_set_npn_advertised_cb SSL_CTX_set_next_protos_advertised_cb
+
+typedef int (*SSL_CTX_npn_select_cb_func)(SSL *s,
+                                          unsigned char **out,
+                                          unsigned char *outlen,
+                                          const unsigned char *in,
+                                          unsigned int inlen,
+                                          void *arg);
 void SSL_CTX_set_next_proto_select_cb(SSL_CTX *s,
-                                      int (*cb) (SSL *ssl,
-                                                 unsigned char **out,
-                                                 unsigned char *outlen,
-                                                 const unsigned char *in,
-                                                 unsigned int inlen,
-                                                 void *arg),
+                                      SSL_CTX_npn_select_cb_func cb,
                                       void *arg);
+#  define SSL_CTX_set_npn_select_cb SSL_CTX_set_next_proto_select_cb
+
 void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
                                     unsigned *len);
+#  define SSL_get0_npn_negotiated SSL_get0_next_proto_negotiated
 # endif
 
 __owur int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
@@ -687,13 +692,15 @@ __owur int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
                                    unsigned int protos_len);
 __owur int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
                                unsigned int protos_len);
-void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
-                                int (*cb) (SSL *ssl,
+typedef int (*SSL_CTX_alpn_select_cb_func)(SSL *ssl,
                                            const unsigned char **out,
                                            unsigned char *outlen,
                                            const unsigned char *in,
                                            unsigned int inlen,
-                                           void *arg), void *arg);
+                                           void *arg);
+void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
+                                SSL_CTX_alpn_select_cb_func cb,
+                                void *arg);
 void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
                             unsigned int *len);
 
@@ -704,64 +711,22 @@ void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
  */
 #  define PSK_MAX_IDENTITY_LEN 128
 #  define PSK_MAX_PSK_LEN 256
-void SSL_CTX_set_psk_client_callback(SSL_CTX *ctx,
-                                     unsigned int (*psk_client_callback) (SSL
-                                                                          *ssl,
-                                                                          const
-                                                                          char
-                                                                          *hint,
-                                                                          char
-                                                                          *identity,
-                                                                          unsigned
-                                                                          int
-                                                                          max_identity_len,
-                                                                          unsigned
-                                                                          char
-                                                                          *psk,
-                                                                          unsigned
-                                                                          int
-                                                                          max_psk_len));
-void SSL_set_psk_client_callback(SSL *ssl,
-                                 unsigned int (*psk_client_callback) (SSL
-                                                                      *ssl,
-                                                                      const
-                                                                      char
-                                                                      *hint,
-                                                                      char
-                                                                      *identity,
-                                                                      unsigned
-                                                                      int
-                                                                      max_identity_len,
-                                                                      unsigned
-                                                                      char
-                                                                      *psk,
-                                                                      unsigned
-                                                                      int
-                                                                      max_psk_len));
-void SSL_CTX_set_psk_server_callback(SSL_CTX *ctx,
-                                     unsigned int (*psk_server_callback) (SSL
-                                                                          *ssl,
-                                                                          const
-                                                                          char
-                                                                          *identity,
-                                                                          unsigned
-                                                                          char
-                                                                          *psk,
-                                                                          unsigned
-                                                                          int
-                                                                          max_psk_len));
-void SSL_set_psk_server_callback(SSL *ssl,
-                                 unsigned int (*psk_server_callback) (SSL
-                                                                      *ssl,
-                                                                      const
-                                                                      char
-                                                                      *identity,
-                                                                      unsigned
-                                                                      char
-                                                                      *psk,
-                                                                      unsigned
-                                                                      int
-                                                                      max_psk_len));
+typedef unsigned int (*SSL_psk_client_cb_func)(SSL *ssl,
+                                               const char *hint,
+                                               char *identity,
+                                               unsigned int max_identity_len,
+                                               unsigned char *psk,
+                                               unsigned int max_psk_len);
+void SSL_CTX_set_psk_client_callback(SSL_CTX *ctx, SSL_psk_client_cb_func cb);
+void SSL_set_psk_client_callback(SSL *ssl, SSL_psk_client_cb_func cb);
+
+typedef unsigned int (*SSL_psk_server_cb_func)(SSL *ssl,
+                                               const char *identity,
+                                               unsigned char *psk,
+                                               unsigned int max_psk_len);
+void SSL_CTX_set_psk_server_callback(SSL_CTX *ctx, SSL_psk_server_cb_func cb);
+void SSL_set_psk_server_callback(SSL *ssl, SSL_psk_server_cb_func cb);
+
 __owur int SSL_CTX_use_psk_identity_hint(SSL_CTX *ctx, const char *identity_hint);
 __owur int SSL_use_psk_identity_hint(SSL *s, const char *identity_hint);
 const char *SSL_get_psk_identity_hint(const SSL *s);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -653,19 +653,23 @@ void SSL_CTX_set_cookie_verify_cb(SSL_CTX *ctx,
                                                                unsigned int
                                                                cookie_len));
 # ifndef OPENSSL_NO_NEXTPROTONEG
+#  define SSL_CTX_set_npn_select_cb SSL_CTX_set_next_proto_select_cb
+#  define SSL_CTX_set_npn_advertised_cb SSL_CTX_set_next_protos_advertised_cb
+#  define SSL_get0_npn_negotiated SSL_get0_next_proto_negotiated
 void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *s,
                                            int (*cb) (SSL *ssl,
-                                                      const unsigned char
-                                                      **out,
+                                                      const unsigned char **out,
                                                       unsigned int *outlen,
-                                                      void *arg), void *arg);
+                                                      void *arg),
+                                           void *arg);
 void SSL_CTX_set_next_proto_select_cb(SSL_CTX *s,
                                       int (*cb) (SSL *ssl,
                                                  unsigned char **out,
                                                  unsigned char *outlen,
                                                  const unsigned char *in,
                                                  unsigned int inlen,
-                                                 void *arg), void *arg);
+                                                 void *arg),
+                                      void *arg);
 void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
                                     unsigned *len);
 # endif

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3237,7 +3237,7 @@ long ssl3_callback_ctrl(SSL *s, int cmd, void (*fp) (void))
 #endif
     case SSL_CTRL_SET_TLSEXT_DEBUG_CB:
         s->ext.debug_cb = (void (*)(SSL *, int, int,
-                                       const unsigned char *, int, void *))fp;
+                                    const unsigned char *, int, void *))fp;
         break;
 
     case SSL_CTRL_SET_NOT_RESUMABLE_SESS_CB:

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -183,13 +183,13 @@ int i2d_SSL_SESSION(SSL_SESSION *in, unsigned char **pp)
     as.peer = in->peer;
 
     ssl_session_sinit(&as.tlsext_hostname, &tlsext_hostname,
-                      in->tlsext_hostname);
-    if (in->tlsext_tick) {
+                      in->ext.hostname);
+    if (in->ext.tick) {
         ssl_session_oinit(&as.tlsext_tick, &tlsext_tick,
-                          in->tlsext_tick, in->tlsext_ticklen);
+                          in->ext.tick, in->ext.ticklen);
     }
-    if (in->tlsext_tick_lifetime_hint > 0)
-        as.tlsext_tick_lifetime_hint = in->tlsext_tick_lifetime_hint;
+    if (in->ext.tick_lifetime_hint > 0)
+        as.tlsext_tick_lifetime_hint = in->ext.tick_lifetime_hint;
 #ifndef OPENSSL_NO_PSK
     ssl_session_sinit(&as.psk_identity_hint, &psk_identity_hint,
                       in->psk_identity_hint);
@@ -315,7 +315,7 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
     /* NB: this defaults to zero which is X509_V_OK */
     ret->verify_result = as->verify_result;
 
-    if (!ssl_session_strndup(&ret->tlsext_hostname, as->tlsext_hostname))
+    if (!ssl_session_strndup(&ret->ext.hostname, as->tlsext_hostname))
         goto err;
 
 #ifndef OPENSSL_NO_PSK
@@ -325,13 +325,13 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
         goto err;
 #endif
 
-    ret->tlsext_tick_lifetime_hint = as->tlsext_tick_lifetime_hint;
+    ret->ext.tick_lifetime_hint = as->tlsext_tick_lifetime_hint;
     if (as->tlsext_tick) {
-        ret->tlsext_tick = as->tlsext_tick->data;
-        ret->tlsext_ticklen = as->tlsext_tick->length;
+        ret->ext.tick = as->tlsext_tick->data;
+        ret->ext.ticklen = as->tlsext_tick->length;
         as->tlsext_tick->data = NULL;
     } else {
-        ret->tlsext_tick = NULL;
+        ret->ext.tick = NULL;
     }
 #ifndef OPENSSL_NO_COMP
     if (as->comp_id) {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2267,10 +2267,7 @@ void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
  * ServerHello.
  */
 void SSL_CTX_set_npn_advertised_cb(SSL_CTX *ctx,
-                                   int (*cb) (SSL *ssl,
-                                              const unsigned char **out,
-                                              unsigned int *outlen,
-                                              void *arg),
+                                   SSL_CTX_npn_advertised_cb_func cb,
                                    void *arg)
 {
     ctx->ext.npn_advertised_cb = cb;
@@ -2288,11 +2285,7 @@ void SSL_CTX_set_npn_advertised_cb(SSL_CTX *ctx,
  * a value other than SSL_TLSEXT_ERR_OK.
  */
 void SSL_CTX_set_npn_select_cb(SSL_CTX *ctx,
-                               int (*cb) (SSL *s, unsigned char **out,
-                                          unsigned char *outlen,
-                                          const unsigned char *in,
-                                          unsigned int inlen,
-                                          void *arg),
+                               SSL_CTX_npn_select_cb_func cb,
                                void *arg)
 {
     ctx->ext.npn_select_cb = cb;
@@ -2344,12 +2337,8 @@ int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
  * from the client's list of offered protocols.
  */
 void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
-                                int (*cb) (SSL *ssl,
-                                           const unsigned char **out,
-                                           unsigned char *outlen,
-                                           const unsigned char *in,
-                                           unsigned int inlen,
-                                           void *arg), void *arg)
+                                SSL_CTX_alpn_select_cb_func cb,
+                                void *arg)
 {
     ctx->ext.alpn_select_cb = cb;
     ctx->ext.alpn_select_cb_arg = arg;
@@ -3726,46 +3715,22 @@ const char *SSL_get_psk_identity(const SSL *s)
     return (s->session->psk_identity);
 }
 
-void SSL_set_psk_client_callback(SSL *s,
-                                 unsigned int (*cb) (SSL *ssl,
-                                                     const char *hint,
-                                                     char *identity,
-                                                     unsigned int
-                                                     max_identity_len,
-                                                     unsigned char *psk,
-                                                     unsigned int max_psk_len))
+void SSL_set_psk_client_callback(SSL *s, SSL_psk_client_cb_func cb)
 {
     s->psk_client_callback = cb;
 }
 
-void SSL_CTX_set_psk_client_callback(SSL_CTX *ctx,
-                                     unsigned int (*cb) (SSL *ssl,
-                                                         const char *hint,
-                                                         char *identity,
-                                                         unsigned int
-                                                         max_identity_len,
-                                                         unsigned char *psk,
-                                                         unsigned int
-                                                         max_psk_len))
+void SSL_CTX_set_psk_client_callback(SSL_CTX *ctx, SSL_psk_client_cb_func cb)
 {
     ctx->psk_client_callback = cb;
 }
 
-void SSL_set_psk_server_callback(SSL *s,
-                                 unsigned int (*cb) (SSL *ssl,
-                                                     const char *identity,
-                                                     unsigned char *psk,
-                                                     unsigned int max_psk_len))
+void SSL_set_psk_server_callback(SSL *s, SSL_psk_server_cb_func cb)
 {
     s->psk_server_callback = cb;
 }
 
-void SSL_CTX_set_psk_server_callback(SSL_CTX *ctx,
-                                     unsigned int (*cb) (SSL *ssl,
-                                                         const char *identity,
-                                                         unsigned char *psk,
-                                                         unsigned int
-                                                         max_psk_len))
+void SSL_CTX_set_psk_server_callback(SSL_CTX *ctx, SSL_psk_server_cb_func cb)
 {
     ctx->psk_server_callback = cb;
 }

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -843,30 +843,20 @@ struct ssl_ctx_st {
          * For a server, this contains a callback function by which the set of
          * advertised protocols can be provided.
          */
-        int (*npn_advertised_cb) (SSL *s, const unsigned char **buf,
-                                          unsigned int *len, void *arg);
+        SSL_CTX_npn_advertised_cb_func npn_advertised_cb;
         void *npn_advertised_cb_arg;
         /*
          * For a client, this contains a callback function that selects the next
          * protocol from the list provided by the server.
          */
-        int (*npn_select_cb) (SSL *s, unsigned char **out,
-                                     unsigned char *outlen,
-                                     const unsigned char *in,
-                                     unsigned int inlen, void *arg);
+        SSL_CTX_npn_select_cb_func npn_select_cb;
         void *npn_select_cb_arg;
 # endif
     } ext;
 
 # ifndef OPENSSL_NO_PSK
-    unsigned int (*psk_client_callback) (SSL *ssl, const char *hint,
-                                         char *identity,
-                                         unsigned int max_identity_len,
-                                         unsigned char *psk,
-                                         unsigned int max_psk_len);
-    unsigned int (*psk_server_callback) (SSL *ssl, const char *identity,
-                                         unsigned char *psk,
-                                         unsigned int max_psk_len);
+    SSL_psk_client_cb_func psk_client_callback;
+    SSL_psk_server_cb_func psk_server_callback;
 # endif
 
 # ifndef OPENSSL_NO_SRP
@@ -1002,14 +992,8 @@ struct ssl_st {
     /* actual code */
     int error_code;
 # ifndef OPENSSL_NO_PSK
-    unsigned int (*psk_client_callback) (SSL *ssl, const char *hint,
-                                         char *identity,
-                                         unsigned int max_identity_len,
-                                         unsigned char *psk,
-                                         unsigned int max_psk_len);
-    unsigned int (*psk_server_callback) (SSL *ssl, const char *identity,
-                                         unsigned char *psk,
-                                         unsigned int max_psk_len);
+    SSL_psk_client_cb_func psk_client_callback;
+    SSL_psk_server_cb_func psk_server_callback;
 # endif
     SSL_CTX *ctx;
     /* Verified chain of peer */

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1032,8 +1032,8 @@ struct ssl_st {
 
     struct {
         /* TLS extension debug callback */
-        void (*debug_cb) (SSL *s, int client_server, int type,
-                                 const unsigned char *data, int len, void *arg);
+        void (*debug_cb)(SSL *s, int client_server, int type,
+                         const unsigned char *data, int len, void *arg);
         void *debug_arg;
         char *hostname;
         /* certificate status request info */

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -961,7 +961,7 @@ int SSL_set_session_ticket_ext(SSL *s, void *ext_data, int ext_len)
             return 0;
         }
 
-        if (ext_data) {
+        if (ext_data != NULL) {
             s->ext.session_ticket->length = ext_len;
             s->ext.session_ticket->data = s->ext.session_ticket + 1;
             memcpy(s->ext.session_ticket->data, ext_data, ext_len);

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -119,18 +119,18 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
     if (BIO_printf(bp, "%s", x->srp_username ? x->srp_username : "None") <= 0)
         goto err;
 #endif
-    if (x->tlsext_tick_lifetime_hint) {
+    if (x->ext.tick_lifetime_hint) {
         if (BIO_printf(bp,
                        "\n    TLS session ticket lifetime hint: %ld (seconds)",
-                       x->tlsext_tick_lifetime_hint) <= 0)
+                       x->ext.tick_lifetime_hint) <= 0)
             goto err;
     }
-    if (x->tlsext_tick) {
+    if (x->ext.tick) {
         if (BIO_puts(bp, "\n    TLS session ticket:\n") <= 0)
             goto err;
         /* TODO(size_t): Convert this call */
         if (BIO_dump_indent
-            (bp, (const char *)x->tlsext_tick, (int)x->tlsext_ticklen, 4)
+            (bp, (const char *)x->ext.tick, (int)x->ext.ticklen, 4)
             <= 0)
             goto err;
     }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -799,28 +799,10 @@ static int init_status_request(SSL *s, unsigned int context)
          * Ensure we get sensible values passed to tlsext_status_cb in the event
          * that we don't receive a status message
          */
-        OPENSSL_free(s->tlsext_ocsp_resp);
-        s->ext.ocsp_resp = NULL;
-        s->ext.ocsp_resplen = 0;
+        OPENSSL_free(s->ext.ocsp.resp);
+        s->ext.ocsp.resp = NULL;
+        s->ext.ocsp.resp_len = 0;
     }
-
-    return 1;
-}
-
-static int final_status_request(SSL *s, unsigned int context, int sent,
-                                        int *al)
-{
-    if (s->server)
-        return 1;
-
-    /*
-     * Ensure we get sensible values passed to ext.status_cb in the event
-     * that we don't receive a status message
-     */
-    OPENSSL_free(s->ext.ocsp.resp);
-    s->ext.ocsp.resp = NULL;
-    s->ext.ocsp.resp_len = 0;
->>>>>>> Move extension data into sub-structs
 
     return 1;
 }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2204,18 +2204,18 @@ int tls_process_cert_status_body(SSL *s, PACKET *pkt, int *al)
         SSLerr(SSL_F_TLS_PROCESS_CERT_STATUS_BODY, SSL_R_LENGTH_MISMATCH);
         return 0;
     }
-    s->tlsext_ocsp_resp = OPENSSL_malloc(resplen);
-    if (s->ext.ocsp_resp == NULL) {
+    s->ext.ocsp.resp = OPENSSL_malloc(resplen);
+    if (s->ext.ocsp.resp == NULL) {
         *al = SSL_AD_INTERNAL_ERROR;
         SSLerr(SSL_F_TLS_PROCESS_CERT_STATUS_BODY, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    if (!PACKET_copy_bytes(pkt, s->ext.ocsp_resp, resplen)) {
+    if (!PACKET_copy_bytes(pkt, s->ext.ocsp.resp, resplen)) {
         *al = SSL_AD_DECODE_ERROR;
         SSLerr(SSL_F_TLS_PROCESS_CERT_STATUS_BODY, SSL_R_LENGTH_MISMATCH);
         return 0;
     }
-    s->ext.ocsp_resplen = resplen;
+    s->ext.ocsp.resp_len = resplen;
 
     return 1;
 }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3465,10 +3465,9 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
  */
 int tls_construct_cert_status_body(SSL *s, WPACKET *pkt)
 {
-<<<<<<< 3b72dcd5fb4d2c756a830dba1fc34f4a7ae61b73
-    if (!WPACKET_put_bytes_u8(pkt, s->tlsext_status_type)
-            || !WPACKET_sub_memcpy_u24(pkt, s->tlsext_ocsp_resp,
-                                       s->tlsext_ocsp_resplen)) {
+    if (!WPACKET_put_bytes_u8(pkt, s->ext.status_type)
+            || !WPACKET_sub_memcpy_u24(pkt, s->ext.ocsp.resp,
+                                       s->ext.ocsp.resp_len)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CERT_STATUS_BODY, ERR_R_INTERNAL_ERROR);
         return 0;
     }
@@ -3479,12 +3478,6 @@ int tls_construct_cert_status_body(SSL *s, WPACKET *pkt)
 int tls_construct_cert_status(SSL *s, WPACKET *pkt)
 {
     if (!tls_construct_cert_status_body(s, pkt)) {
-=======
-    if (!WPACKET_put_bytes_u8(pkt, s->ext.status_type)
-            || !WPACKET_sub_memcpy_u24(pkt, s->ext.ocsp.resp,
-                                       s->ext.ocsp.resp_len)) {
-        SSLerr(SSL_F_TLS_CONSTRUCT_CERT_STATUS, ERR_R_INTERNAL_ERROR);
->>>>>>> Move extension data into sub-structs
         ssl3_send_alert(s, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
         return 0;
     }

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -87,6 +87,8 @@ handshake.
 
 * ExpectedNPNProtocol, ExpectedALPNProtocol - NPN and ALPN expectations.
 
+* ExpectedTmpKeyType - the expected algorithm or curve of server temp key
+
 ## Configuring the client and server
 
 The client and server configurations can be any valid `SSL_CTX`

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -378,16 +378,16 @@ static void configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         parse_protos(extra->server.npn_protocols,
                      &server_ctx_data->npn_protocols,
                      &server_ctx_data->npn_protocols_len);
-        SSL_CTX_set_next_protos_advertised_cb(server_ctx, server_npn_cb,
-                                              server_ctx_data);
+        SSL_CTX_set_npn_advertised_cb(server_ctx, server_npn_cb,
+                                      server_ctx_data);
     }
     if (extra->server2.npn_protocols != NULL) {
         parse_protos(extra->server2.npn_protocols,
                      &server2_ctx_data->npn_protocols,
                      &server2_ctx_data->npn_protocols_len);
         TEST_check(server2_ctx != NULL);
-        SSL_CTX_set_next_protos_advertised_cb(server2_ctx, server_npn_cb,
-                                              server2_ctx_data);
+        SSL_CTX_set_npn_advertised_cb(server2_ctx, server_npn_cb,
+                                      server2_ctx_data);
     }
     if (extra->client.npn_protocols != NULL) {
         parse_protos(extra->client.npn_protocols,

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -43,6 +43,8 @@ typedef struct handshake_result {
     /* Was the handshake resumed? */
     int client_resumed;
     int server_resumed;
+    /* Temporary key type */
+    int tmp_key_type;
 } HANDSHAKE_RESULT;
 
 HANDSHAKE_RESULT *HANDSHAKE_RESULT_new(void);

--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -589,7 +589,7 @@ static bssl::UniquePtr<SSL_CTX> SetupCtx(const TestConfig *config) {
     SSL_CTX_set_client_cert_cb(ssl_ctx.get(), ClientCertCallback);
   }
 
-  SSL_CTX_set_next_protos_advertised_cb(
+  SSL_CTX_set_npn_advertised_cb(
       ssl_ctx.get(), NextProtosAdvertisedCallback, NULL);
   if (!config->select_next_proto.empty()) {
     SSL_CTX_set_next_proto_select_cb(ssl_ctx.get(), NextProtoSelectCallback,

--- a/test/ssl-tests/14-curves.conf
+++ b/test/ssl-tests/14-curves.conf
@@ -55,6 +55,7 @@ VerifyMode = Peer
 
 [test-0]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect163k1
 
 
 # ===========================================================
@@ -81,6 +82,7 @@ VerifyMode = Peer
 
 [test-1]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect163r1
 
 
 # ===========================================================
@@ -107,6 +109,7 @@ VerifyMode = Peer
 
 [test-2]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect163r2
 
 
 # ===========================================================
@@ -133,6 +136,7 @@ VerifyMode = Peer
 
 [test-3]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect193r1
 
 
 # ===========================================================
@@ -159,6 +163,7 @@ VerifyMode = Peer
 
 [test-4]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect193r2
 
 
 # ===========================================================
@@ -185,6 +190,7 @@ VerifyMode = Peer
 
 [test-5]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect233k1
 
 
 # ===========================================================
@@ -211,6 +217,7 @@ VerifyMode = Peer
 
 [test-6]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect233r1
 
 
 # ===========================================================
@@ -237,6 +244,7 @@ VerifyMode = Peer
 
 [test-7]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect239k1
 
 
 # ===========================================================
@@ -263,6 +271,7 @@ VerifyMode = Peer
 
 [test-8]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect283k1
 
 
 # ===========================================================
@@ -289,6 +298,7 @@ VerifyMode = Peer
 
 [test-9]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect283r1
 
 
 # ===========================================================
@@ -315,6 +325,7 @@ VerifyMode = Peer
 
 [test-10]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect409k1
 
 
 # ===========================================================
@@ -341,6 +352,7 @@ VerifyMode = Peer
 
 [test-11]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect409r1
 
 
 # ===========================================================
@@ -367,6 +379,7 @@ VerifyMode = Peer
 
 [test-12]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect571k1
 
 
 # ===========================================================
@@ -393,6 +406,7 @@ VerifyMode = Peer
 
 [test-13]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect571r1
 
 
 # ===========================================================
@@ -419,6 +433,7 @@ VerifyMode = Peer
 
 [test-14]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp160k1
 
 
 # ===========================================================
@@ -445,6 +460,7 @@ VerifyMode = Peer
 
 [test-15]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp160r1
 
 
 # ===========================================================
@@ -471,6 +487,7 @@ VerifyMode = Peer
 
 [test-16]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp160r2
 
 
 # ===========================================================
@@ -497,6 +514,7 @@ VerifyMode = Peer
 
 [test-17]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp192k1
 
 
 # ===========================================================
@@ -523,6 +541,7 @@ VerifyMode = Peer
 
 [test-18]
 ExpectedResult = Success
+ExpectedTmpKeyType = prime192v1
 
 
 # ===========================================================
@@ -549,6 +568,7 @@ VerifyMode = Peer
 
 [test-19]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp224k1
 
 
 # ===========================================================
@@ -575,6 +595,7 @@ VerifyMode = Peer
 
 [test-20]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp224r1
 
 
 # ===========================================================
@@ -601,6 +622,7 @@ VerifyMode = Peer
 
 [test-21]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp256k1
 
 
 # ===========================================================
@@ -627,6 +649,7 @@ VerifyMode = Peer
 
 [test-22]
 ExpectedResult = Success
+ExpectedTmpKeyType = prime256v1
 
 
 # ===========================================================
@@ -653,6 +676,7 @@ VerifyMode = Peer
 
 [test-23]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp384r1
 
 
 # ===========================================================
@@ -679,6 +703,7 @@ VerifyMode = Peer
 
 [test-24]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp521r1
 
 
 # ===========================================================
@@ -705,6 +730,7 @@ VerifyMode = Peer
 
 [test-25]
 ExpectedResult = Success
+ExpectedTmpKeyType = brainpoolP256r1
 
 
 # ===========================================================
@@ -731,6 +757,7 @@ VerifyMode = Peer
 
 [test-26]
 ExpectedResult = Success
+ExpectedTmpKeyType = brainpoolP384r1
 
 
 # ===========================================================
@@ -757,6 +784,7 @@ VerifyMode = Peer
 
 [test-27]
 ExpectedResult = Success
+ExpectedTmpKeyType = brainpoolP512r1
 
 
 # ===========================================================
@@ -783,5 +811,6 @@ VerifyMode = Peer
 
 [test-28]
 ExpectedResult = Success
+ExpectedTmpKeyType = X25519
 
 

--- a/test/ssl-tests/14-curves.conf.in
+++ b/test/ssl-tests/14-curves.conf.in
@@ -35,7 +35,10 @@ sub generate_tests() {
 		"CipherString" => "ECDHE",
                 "Curves" => $curve
             },
-            test   => { "ExpectedResult" => "Success" },
+            test   => {
+                "ExpectedTmpKeyType" => $curve,
+                "ExpectedResult" => "Success"
+            },
         };
     }
 }

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -187,6 +187,17 @@ static int check_resumption(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
     return 1;
 }
 
+static int check_tmp_key(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
+{
+    if (test_ctx->expected_tmp_key_type == 0
+        || test_ctx->expected_tmp_key_type == result->tmp_key_type)
+        return 1;
+    fprintf(stderr, "Tmp key type mismatch, %s vs %s\n",
+            OBJ_nid2ln(test_ctx->expected_tmp_key_type),
+            OBJ_nid2ln(result->tmp_key_type));
+    return 0;
+}
+
 /*
  * This could be further simplified by constructing an expected
  * HANDSHAKE_RESULT, and implementing comparison methods for
@@ -207,6 +218,7 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
 #endif
         ret &= check_alpn(result, test_ctx);
         ret &= check_resumption(result, test_ctx);
+        ret &= check_tmp_key(result, test_ctx);
     }
     return ret;
 }

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -432,6 +432,30 @@ IMPLEMENT_SSL_TEST_INT_OPTION(SSL_TEST_CTX, test, app_data_size)
 
 IMPLEMENT_SSL_TEST_INT_OPTION(SSL_TEST_CTX, test, max_fragment_size)
 
+/***********************/
+/* ExpectedTmpKeyType  */
+/***********************/
+
+__owur static int parse_expected_tmp_key_type(SSL_TEST_CTX *test_ctx,
+                                              const char *value)
+{
+    int nid;
+
+    if (value == NULL)
+        return 0;
+    nid = OBJ_sn2nid(value);
+    if (nid == NID_undef)
+        nid = OBJ_ln2nid(value);
+#ifndef OPENSSL_NO_EC
+    if (nid == NID_undef)
+        nid = EC_curve_nist2nid(value);
+#endif
+    if (nid == NID_undef)
+        return 0;
+    test_ctx->expected_tmp_key_type = nid;
+    return 1;
+}
+
 /*************************************************************/
 /* Known test options and their corresponding parse methods. */
 /*************************************************************/
@@ -456,6 +480,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ResumptionExpected", &parse_test_resumption_expected },
     { "ApplicationData", &parse_test_app_data_size },
     { "MaxFragmentSize", &parse_test_max_fragment_size },
+    { "ExpectedTmpKeyType", &parse_expected_tmp_key_type },
 };
 
 /* Nested client options. */

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -159,6 +159,8 @@ typedef struct {
     char *expected_alpn_protocol;
     /* Whether the second handshake is resumed or a full handshake (boolean). */
     int resumption_expected;
+    /* Expected temporary key type */
+    int expected_tmp_key_type;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -1662,14 +1662,12 @@ int main(int argc, char *argv[])
                        "Can't have both -npn_server and -npn_server_reject\n");
             goto end;
         }
-        SSL_CTX_set_next_protos_advertised_cb(s_ctx, cb_server_npn, NULL);
-        SSL_CTX_set_next_protos_advertised_cb(s_ctx2, cb_server_npn, NULL);
+        SSL_CTX_set_npn_advertised_cb(s_ctx, cb_server_npn, NULL);
+        SSL_CTX_set_npn_advertised_cb(s_ctx2, cb_server_npn, NULL);
     }
     if (npn_server_reject) {
-        SSL_CTX_set_next_protos_advertised_cb(s_ctx, cb_server_rejects_npn,
-                                              NULL);
-        SSL_CTX_set_next_protos_advertised_cb(s_ctx2, cb_server_rejects_npn,
-                                              NULL);
+        SSL_CTX_set_npn_advertised_cb(s_ctx, cb_server_rejects_npn, NULL);
+        SSL_CTX_set_npn_advertised_cb(s_ctx2, cb_server_rejects_npn, NULL);
     }
 #endif
 


### PR DESCRIPTION
So instead of tlsext_hostname, for example, you have ext.hostname.  It ensures that all extension stuff is at least grouped together.  And shorter more consistent names for some things.  Lists end in plural and have a matching ```_len``` element.  ALPN and NPN are spelled with four or three letters, not next_proto and next_protos, inconsistently.  And so on.