### PR TITLE
VMS UI_OpenSSL fixups

### DIFF
--- a/crypto/ui/ui_err.c
+++ b/crypto/ui/ui_err.c
@@ -19,8 +19,11 @@
 # define ERR_REASON(reason) ERR_PACK(ERR_LIB_UI,0,reason)
 
 static ERR_STRING_DATA UI_str_functs[] = {
+    {ERR_FUNC(UI_F_CLOSE_CONSOLE), "close_console"},
+    {ERR_FUNC(UI_F_ECHO_CONSOLE), "echo_console"},
     {ERR_FUNC(UI_F_GENERAL_ALLOCATE_BOOLEAN), "general_allocate_boolean"},
     {ERR_FUNC(UI_F_GENERAL_ALLOCATE_PROMPT), "general_allocate_prompt"},
+    {ERR_FUNC(UI_F_NOECHO_CONSOLE), "noecho_console"},
     {ERR_FUNC(UI_F_OPEN_CONSOLE), "open_console"},
     {ERR_FUNC(UI_F_UI_CREATE_METHOD), "UI_create_method"},
     {ERR_FUNC(UI_F_UI_CTRL), "UI_ctrl"},
@@ -45,6 +48,9 @@ static ERR_STRING_DATA UI_str_reasons[] = {
     {ERR_REASON(UI_R_PROCESSING_ERROR), "processing error"},
     {ERR_REASON(UI_R_RESULT_TOO_LARGE), "result too large"},
     {ERR_REASON(UI_R_RESULT_TOO_SMALL), "result too small"},
+    {ERR_REASON(UI_R_SYSASSIGN_ERROR), "sys$assign error"},
+    {ERR_REASON(UI_R_SYSDASSGN_ERROR), "sys$dassgn error"},
+    {ERR_REASON(UI_R_SYSQIOW_ERROR), "sys$qiow error"},
     {ERR_REASON(UI_R_UNKNOWN_CONTROL_COMMAND), "unknown control command"},
     {ERR_REASON(UI_R_UNKNOWN_TTYGET_ERRNO_VALUE),
      "unknown ttyget errno value"},

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -452,8 +452,14 @@ static int open_console(UI *ui)
     status = sys$assign(&terminal, &channel, 0, 0);
 
     /* if there isn't a TT device, something is very wrong */
-    if (status != SS$_NORMAL)
+    if (status != SS$_NORMAL) {
+        char tmp_num[12];
+
+        BIO_snprintf(tmp_num, sizeof(tmp_num) - 1, "%%X%08X", status);
+        UIerr(UI_F_OPEN_CONSOLE, UI_R_SYSASSIGN_ERROR);
+        ERR_add_error_data(2, "status=", tmp_num);
         return 0;
+    }
 
     status = sys$qiow(0, channel, IO$_SENSEMODE, &iosb, 0, 0, tty_orig, 12,
                       0, 0, 0, 0);
@@ -483,8 +489,18 @@ static int noecho_console(UI *ui)
         tty_new[2] = tty_orig[2];
         status = sys$qiow(0, channel, IO$_SETMODE, &iosb, 0, 0, tty_new, 12,
                           0, 0, 0, 0);
-        if ((status != SS$_NORMAL) || (iosb.iosb$w_value != SS$_NORMAL))
+        if ((status != SS$_NORMAL) || (iosb.iosb$w_value != SS$_NORMAL)) {
+            char tmp_num[2][12];
+
+            BIO_snprintf(tmp_num[0], sizeof(tmp_num[0]) - 1, "%%X%08X",
+                         status);
+            BIO_snprintf(tmp_num[1], sizeof(tmp_num[1]) - 1, "%%X%08X",
+                         iosb.iosb$w_value);
+            UIerr(UI_F_NOECHO_CONSOLE, UI_R_SYSQIOW_ERROR);
+            ERR_add_error_data(5, "status=", tmp_num[0],
+                               ",", "iosb.iosb$w_value=", tmp_num[1]);
             return 0;
+        }
     }
 #endif
 #if defined(_WIN32) && !defined(_WIN32_WCE)
@@ -515,8 +531,18 @@ static int echo_console(UI *ui)
         tty_new[2] = tty_orig[2];
         status = sys$qiow(0, channel, IO$_SETMODE, &iosb, 0, 0, tty_new, 12,
                           0, 0, 0, 0);
-        if ((status != SS$_NORMAL) || (iosb.iosb$w_value != SS$_NORMAL))
+        if ((status != SS$_NORMAL) || (iosb.iosb$w_value != SS$_NORMAL)) {
+            char tmp_num[2][12];
+
+            BIO_snprintf(tmp_num[0], sizeof(tmp_num[0]) - 1, "%%X%08X",
+                         status);
+            BIO_snprintf(tmp_num[1], sizeof(tmp_num[1]) - 1, "%%X%08X",
+                         iosb.iosb$w_value);
+            UIerr(UI_F_ECHO_CONSOLE, UI_R_SYSQIOW_ERROR);
+            ERR_add_error_data(5, "status=", tmp_num[0],
+                               ",", "iosb.iosb$w_value=", tmp_num[1]);
             return 0;
+        }
     }
 #endif
 #if defined(_WIN32) && !defined(_WIN32_WCE)
@@ -537,8 +563,14 @@ static int close_console(UI *ui)
         fclose(tty_out);
 #ifdef OPENSSL_SYS_VMS
     status = sys$dassgn(channel);
-    if (status != SS$_NORMAL)
+    if (status != SS$_NORMAL) {
+        char tmp_num[12];
+
+        BIO_snprintf(tmp_num, sizeof(tmp_num) - 1, "%%X%08X", status);
+        UIerr(UI_F_CLOSE_CONSOLE, UI_R_SYSDASSGN_ERROR);
+        ERR_add_error_data(2, "status=", tmp_num);
         return 0;
+    }
 #endif
     CRYPTO_THREAD_unlock(ui->lock);
 

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -339,8 +339,11 @@ int ERR_load_UI_strings(void);
 /* Error codes for the UI functions. */
 
 /* Function codes. */
+# define UI_F_CLOSE_CONSOLE                               115
+# define UI_F_ECHO_CONSOLE                                116
 # define UI_F_GENERAL_ALLOCATE_BOOLEAN                    108
 # define UI_F_GENERAL_ALLOCATE_PROMPT                     109
+# define UI_F_NOECHO_CONSOLE                              117
 # define UI_F_OPEN_CONSOLE                                114
 # define UI_F_UI_CREATE_METHOD                            112
 # define UI_F_UI_CTRL                                     111
@@ -362,6 +365,9 @@ int ERR_load_UI_strings(void);
 # define UI_R_PROCESSING_ERROR                            107
 # define UI_R_RESULT_TOO_LARGE                            100
 # define UI_R_RESULT_TOO_SMALL                            101
+# define UI_R_SYSASSIGN_ERROR                             109
+# define UI_R_SYSDASSGN_ERROR                             110
+# define UI_R_SYSQIOW_ERROR                               111
 # define UI_R_UNKNOWN_CONTROL_COMMAND                     106
 # define UI_R_UNKNOWN_TTYGET_ERRNO_VALUE                  108
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This includes two changes:

```
    VMS UI_OpenSSL: if the TT device isn't a tty, flag instead of error
    
    On all platforms, if the controlling tty isn't an actual tty, this is
    flagged by setting is_a_tty to zero...  except on VMS, where this was
    treated as an error.  Change this to behave like the other platforms.
```

and

```
    VMS UI_OpenSSL: generate OpenSSL errors when things go wrong.
```
