### PR TITLE
Typo in the BUF_reverse manual

### DIFF
--- a/doc/man3/BUF_MEM_new.pod
+++ b/doc/man3/BUF_MEM_new.pod
@@ -44,7 +44,7 @@ size.
 BUF_MEM_grow_clean() is similar to BUF_MEM_grow() but it sets any free'd
 or additionally-allocated memory to zero.
 
-BUF_reverse() reverses B<size> bytes at B<in> into B<out>.  If B<out>
+BUF_reverse() reverses B<size> bytes at B<in> into B<out>.  If B<in>
 is NULL, the array is reversed in-place.
 
 =head1 RETURN VALUES


### PR DESCRIPTION
##### Checklist
- [x] documentation is added or updated

##### Description of change
The typo in the BUF_reverse's manual is fixed. There was a wrong description of conditions when BUF_reverse does in-place reverse.
