### PR TITLE
Fix various doc nits.

### DIFF
--- a/doc/man1/CA.pl.pod
+++ b/doc/man1/CA.pl.pod
@@ -29,28 +29,14 @@ B<CA.pl> B<-verify> [B<-extra-verify> extra-params] B<certfile>...
 
 B<CA.pl> B<-revoke> [B<-extra-ca> extra-params] B<certfile> [B<reason>]
 
+=head1 DESCRIPTION
+
 The B<CA.pl> script is a perl script that supplies the relevant command line
 arguments to the B<openssl> command for some common certificate operations.
 It is intended to simplify the process of certificate creation and management
 by the use of some simple options.
 
-=head1 COMMON OPTIONS
-
-=over 4
-
-=item B<-extra-req> | B<-extra-ca> | B<-extra-pkcs12> | B<-extra-x509> | B<-extra-verify> <extra-params>
-
-The purpose of these parameters is to allow optional parameters to be supplied
-to B<openssl> that this command executes. The B<-extra-cmd> are specific to the
-option being used and the B<openssl> command getting invoked. For example
-when this command invokes B<openssl req> extra parameters can be passed on
-with the B<-extra-req> parameter. The
-B<openssl> commands being invoked per option are documented below.
-Users should consult B<openssl> command documentation for more information.
-
-=back
-
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 
@@ -133,6 +119,16 @@ Leverages B<openssl ca> command.
 verifies certificates against the CA certificate for "demoCA". If no certificates
 are specified on the command line it tries to verify the file "newcert.pem".
 Invokes B<openssl verify> command.
+
+=item B<-extra-req> | B<-extra-ca> | B<-extra-pkcs12> | B<-extra-x509> | B<-extra-verify> <extra-params>
+
+The purpose of these parameters is to allow optional parameters to be supplied
+to B<openssl> that this command executes. The B<-extra-cmd> are specific to the
+option being used and the B<openssl> command getting invoked. For example
+when this command invokes B<openssl req> extra parameters can be passed on
+with the B<-extra-req> parameter. The
+B<openssl> commands being invoked per option are documented below.
+Users should consult B<openssl> command documentation for more information.
 
 =back
 

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -62,7 +62,7 @@ and their status.
 
 The options descriptions will be divided into each purpose.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -28,7 +28,7 @@ The B<ciphers> command converts textual OpenSSL cipher lists into ordered
 SSL cipher preference lists. It can be used as a test tool to determine
 the appropriate cipherlist.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -104,7 +104,7 @@ B<openssl> B<cms>
 The B<cms> command handles S/MIME v3.1 mail. It can encrypt, decrypt, sign and
 verify, compress and uncompress S/MIME messages.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 There are fourteen operation options that set the type of operation to be
 performed. The meaning of the other options varies according to the operation

--- a/doc/man1/crl.pod
+++ b/doc/man1/crl.pod
@@ -26,7 +26,7 @@ B<openssl> B<crl>
 
 The B<crl> command processes CRL files in DER or PEM format.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/crl2pkcs7.pod
+++ b/doc/man1/crl2pkcs7.pod
@@ -21,7 +21,7 @@ The B<crl2pkcs7> command takes an optional CRL and one or more
 certificates and converts them into a PKCS#7 degenerate "certificates
 only" structure.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/dsa.pod
+++ b/doc/man1/dsa.pod
@@ -37,7 +37,7 @@ forms and their components printed out. B<Note> This command uses the
 traditional SSLeay compatible format for private key encryption: newer
 applications should use the more secure PKCS#8 format using the B<pkcs8>
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -36,7 +36,7 @@ private key format specified in 'SEC 1: Elliptic Curve Cryptography'
 (http://www.secg.org/). To convert an OpenSSL EC private key into the
 PKCS#8 private key format use the B<pkcs8> command.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/errstr.pod
+++ b/doc/man1/errstr.pod
@@ -15,7 +15,7 @@ numerical forms will be available. The B<errstr> utility can be used to
 display the meaning of the hex code. The hex code is the hex digits after the
 second colon.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 None.
 

--- a/doc/man1/nseq.pod
+++ b/doc/man1/nseq.pod
@@ -19,7 +19,7 @@ sequence and prints out the certificates contained in it or takes a
 file of certificates and converts it into a Netscape certificate
 sequence.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/ocsp.pod
+++ b/doc/man1/ocsp.pod
@@ -95,7 +95,7 @@ The B<ocsp> command performs many common OCSP tasks. It can be used
 to print out requests and responses, create requests and send queries
 to an OCSP responder and behave like a mini OCSP server itself.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 This command operates as either a client or a server.
 The options are described below, divided into those two modes.

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -350,7 +350,7 @@ RC5 Cipher
 
 =back
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 Details of which options are available depend on the specific command.
 This section describes some common options with common behavior.

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -49,7 +49,7 @@ The B<pkcs12> command allows PKCS#12 files (sometimes referred to as
 PFX files) to be created and parsed. PKCS#12 files are used by several
 programs including Netscape, MSIE and MS Outlook.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 There are a lot of options the meaning of some depends of whether a PKCS#12 file
 is being created or parsed. By default a PKCS#12 file is parsed. A PKCS#12

--- a/doc/man1/pkcs7.pod
+++ b/doc/man1/pkcs7.pod
@@ -21,7 +21,7 @@ B<openssl> B<pkcs7>
 
 The B<pkcs7> command processes PKCS#7 files in DER or PEM format.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -34,7 +34,7 @@ The B<pkcs8> command processes private keys in PKCS#8 format. It can handle
 both unencrypted PKCS#8 PrivateKeyInfo format and EncryptedPrivateKeyInfo
 format with a variety of PKCS#5 (v1.5 and v2.0) and PKCS#12 algorithms.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/pkey.pod
+++ b/doc/man1/pkey.pod
@@ -28,7 +28,7 @@ B<openssl> B<pkey>
 The B<pkey> command processes public or private keys. They can be converted
 between various forms and their components printed out.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/pkeyparam.pod
+++ b/doc/man1/pkeyparam.pod
@@ -19,7 +19,7 @@ B<openssl> B<pkeyparam>
 The B<pkey> command processes public or private keys. They can be converted
 between various forms and their components printed out.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -38,7 +38,7 @@ B<openssl> B<pkeyutl>
 The B<pkeyutl> command can be used to perform public key operations using
 any supported algorithm.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -52,7 +52,7 @@ The B<req> command primarily creates and processes certificate requests
 in PKCS#10 format. It can additionally create self signed certificates
 for use as root CAs for example.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/rsa.pod
+++ b/doc/man1/rsa.pod
@@ -41,7 +41,7 @@ traditional SSLeay compatible format for private key encryption: newer
 applications should use the more secure PKCS#8 format using the B<pkcs8>
 utility.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/rsautl.pod
+++ b/doc/man1/rsautl.pod
@@ -29,7 +29,7 @@ B<openssl> B<rsautl>
 The B<rsautl> command can be used to sign, verify, encrypt and decrypt
 data using the RSA algorithm.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/sess_id.pod
+++ b/doc/man1/sess_id.pod
@@ -24,7 +24,7 @@ master key) in human readable format. Since this is a diagnostic tool that
 needs some knowledge of the SSL protocol to use properly, most users will
 not need to use it.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -74,7 +74,7 @@ B<openssl> B<smime>
 The B<smime> command handles S/MIME mail. It can encrypt, decrypt, sign and
 verify S/MIME messages.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 There are six operation options that set the type of operation to be performed.
 The meaning of the other options varies according to the operation type.

--- a/doc/man1/spkac.pod
+++ b/doc/man1/spkac.pod
@@ -26,7 +26,7 @@ The B<spkac> command processes Netscape signed public key and challenge
 (SPKAC) files. It can print out their contents, verify the signature and
 produce its own SPKACs from a supplied private key.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man1/verify.pod
+++ b/doc/man1/verify.pod
@@ -55,7 +55,7 @@ B<openssl> B<verify>
 
 The B<verify> command verifies certificate chains.
 
-=head1 COMMAND OPTIONS
+=head1 OPTIONS
 
 =over 4
 

--- a/doc/man3/ERR_GET_LIB.pod
+++ b/doc/man3/ERR_GET_LIB.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-ERR_GET_LIB, ERR_GET_FUNC, ERR_GET_REASON - get library, function and
-reason code
+ERR_GET_LIB, ERR_GET_FUNC, ERR_GET_REASON, ERR_FATAL_ERROR
+- get information from error codes
 
 =head1 SYNOPSIS
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -409,8 +409,8 @@ The ChaCha20 stream cipher. The key length is 256 bits, the IV is 96 bits long.
 
 Authenticated encryption with ChaCha20-Poly1305. Like EVP_chacha20() the key is
 256 bits and the IV is 96 bits. This supports additional authenticated
-data (AAD) and produces a 128 bit authentication tag. The L</GCM and OCB modes>
-section below applies.
+data (AAD) and produces a 128 bit authentication tag. See the
+L</GCM and OCB Modes> section for more information.
 
 =back
 

--- a/doc/man3/SSL_set_bio.pod
+++ b/doc/man3/SSL_set_bio.pod
@@ -39,41 +39,41 @@ used in preference. The ownership rules are as follows:
 
 =over 4
 
-=item
+=item *
 
 If neither the rbio or wbio have changed from their previous values then nothing
 is done.
 
-=item
+=item *
 
 If the rbio and wbio parameters are different and both are different to their
 previously set values then one reference is consumed for the rbio and one
 reference is consumed for the wbio.
 
-=item
+=item *
 
 If the rbio and wbio parameters are the same and the rbio is not the same as the
 previously set value then one reference is consumed.
 
-=item
+=item *
 
 If the rbio and wbio parameters are the same and the rbio is the same as the
 previously set value, then no additional references are consumed.
 
-=item
+=item *
 
 If the rbio and wbio parameters are different and the rbio is the same as the
 previously set value then one reference is consumbed for the wbio and no
 references are consumed for the rbio.
 
-=item
+=item *
 
 If the rbio and wbio parameters are different and the wbio is the same as the
 previously set value and the old rbio and wbio values were the same as each
 other then one reference is consumed for the rbio and no references are consumed
 for the wbio.
 
-=item
+=item *
 
 If the rbio and wbio parameters are different and the wbio is the same as the
 previously set value and the old rbio and wbio values were different to each

--- a/util/find-doc-nits.pl
+++ b/util/find-doc-nits.pl
@@ -41,8 +41,8 @@ my $OUT;
 
 my %mandatory_sections =
     ( '*'    => [ 'NAME', 'DESCRIPTION', 'COPYRIGHT' ],
-      1      => [ 'SYNOPSIS', '(COMMAND\s+)?OPTIONS' ],
-      3      => [ 'SYNOPSIS', 'RETURN\s+VALUES' ],
+      1      => [ 'SYNOPSIS', 'OPTIONS' ],
+      3      => [ 'SYNOPSIS', 'RETURN VALUES' ],
       5      => [ ],
       7      => [ ] );
 
@@ -174,7 +174,7 @@ sub check()
     $section = $1 if $dirname =~ /man([1-9])/;
 
     foreach ((@{$mandatory_sections{'*'}}, @{$mandatory_sections{$section}})) {
-        print "$id doesn't have a head1 section matching $_\n"
+        print "$id: missing $_ head1 section\n"
             if $contents !~ /^=head1\s+${_}\s*$/m;
     }
 
@@ -256,6 +256,9 @@ sub printem()
 getopts('nshu');
 
 &help() if ( $opt_h );
+
+die "Need one of -n -s or -u flags.\n"
+    unless $opt_n or $opt_s or $opt_u;
 
 if ( $opt_n or $opt_s ) {
     foreach (@ARGV ? @ARGV : glob('doc/*/*.pod')) {


### PR DESCRIPTION
find-doc-nits warns if you don't give a "what to do flag"
Don't use regexps for section names, just strings:  More consistency.
Rename "COMMAND OPTIONS" to OPTIONS.
Fix a couple of other nit-level things.