### PR TITLE
Fix symbol version numbers

### DIFF
--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4218,5 +4218,5 @@ BIO_meth_get_write_ex                   4168	1_1_1	EXIST::FUNCTION:
 BIO_meth_set_write_ex                   4169	1_1_1	EXIST::FUNCTION:
 DSO_pathbyaddr                          4170	1_1_0c	EXIST::FUNCTION:
 DSO_dsobyaddr                           4171	1_1_0c	EXIST::FUNCTION:
-CT_POLICY_EVAL_CTX_get_time             4172	1_1_1	EXIST::FUNCTION:CT
-CT_POLICY_EVAL_CTX_set_time             4173	1_1_1	EXIST::FUNCTION:CT
+CT_POLICY_EVAL_CTX_get_time             4172	1_1_0d	EXIST::FUNCTION:CT
+CT_POLICY_EVAL_CTX_set_time             4173	1_1_0d	EXIST::FUNCTION:CT


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

The symbols CT_POLICY_EVAL_CTX_get_time() and
CT_POLICY_EVAL_CTX_set_time() were recently added in master (1fa9ffd93)
and backported to 1.1.0. Commit 18ad46297 in 1.1.0 then corrected the
symbol version to 1_1_0d but did not make the same change in master.

This commit aligns the symbol versions in order to retain ABI
compatibility.