### PR TITLE
Make 'err' lable in ssl_cert_dup unconditional

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -315,7 +315,7 @@ CERT *ssl_cert_dup(CERT *cert)
                 OPENSSL_malloc(cert->pkeys[i].serverinfo_length);
             if (ret->pkeys[i].serverinfo == NULL) {
                 SSLerr(SSL_F_SSL_CERT_DUP, ERR_R_MALLOC_FAILURE);
-                return NULL;
+                goto err;
             }
             ret->pkeys[i].serverinfo_length =
                 cert->pkeys[i].serverinfo_length;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -392,9 +392,7 @@ CERT *ssl_cert_dup(CERT *cert)
 
     return (ret);
 
-#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_ECDH)
  err:
-#endif
 #ifndef OPENSSL_NO_RSA
     if (ret->rsa_tmp != NULL)
         RSA_free(ret->rsa_tmp);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Fixes #2080