### PR TITLE
Add support for PBKDF2 for enc command

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -265,8 +265,8 @@ int enc_main(int argc, char **argv)
             break;
         case OPT_PBKDF2:
             pbkdf2 = 1;
-            if (iter == 0)    /* do not overwrite a choosen value */
-                iter = 10000; /* update to a better default value ? */
+            if (iter == 0)    /* do not overwrite a chosen value */
+                iter = 10000;
             break;
         case OPT_NONE:
             cipher = NULL;
@@ -459,8 +459,10 @@ int enc_main(int argc, char **argv)
             }
 
             if (pbkdf2 == 1) {
-                /* generate key and default iv
-                concatenated into a temporary buffer */
+                /*
+                * generate key and default iv
+                * concatenated into a temporary buffer
+                */
                 unsigned char tmpkeyiv[EVP_MAX_KEY_LENGTH + EVP_MAX_IV_LENGTH];
                 int iklen = EVP_CIPHER_key_length(cipher);
                 int ivlen = EVP_CIPHER_iv_length(cipher);
@@ -475,7 +477,8 @@ int enc_main(int argc, char **argv)
                 memcpy(key, tmpkeyiv, iklen);
                 memcpy(iv, tmpkeyiv+iklen, ivlen);
             } else {
-                BIO_printf(bio_err, "*** WARNING : legacy KDF used. "
+                BIO_printf(bio_err, "*** WARNING : "
+                                    "deprecated key generation used.\n"
                                     "Using -iter or -pbkdf2 would be better.\n");
                 if (!EVP_BytesToKey(cipher, dgst, sptr,
                                     (unsigned char *)str, str_len,

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -450,24 +450,25 @@ int enc_main(int argc, char **argv)
             }
 
             if (pbkdf2 == 1) {
-                /* generate key and default iv concatenated in a temporary buffer */
+                /* generate key and default iv
+                concatenated into a temporary buffer */
                 unsigned char tmpkeyiv[EVP_MAX_KEY_LENGTH + EVP_MAX_IV_LENGTH];
-                int iKlen = EVP_CIPHER_key_length(cipher);
-                int iVlen = EVP_CIPHER_iv_length(cipher);
-                int iSlen = sptr ? sizeof(salt) : 0;  /* not needed if HASH_UPDATE() is fixed */
-                if (!PKCS5_PBKDF2_HMAC(str, str_len, sptr, iSlen, iter,
-                                       dgst,
-                                       iKlen+iVlen, tmpkeyiv)) {
+                int iklen = EVP_CIPHER_key_length(cipher);
+                int ivlen = EVP_CIPHER_iv_length(cipher);
+                /* not needed if HASH_UPDATE() is fixed : */
+                int islen = (sptr != NULL ? sizeof(salt) : 0);
+                if (!PKCS5_PBKDF2_HMAC(str, str_len, sptr, islen,
+                                       iter, dgst, iklen+ivlen, tmpkeyiv)) {
                     BIO_printf(bio_err, "PKCS5_PBKDF2_HMAC failed\n");
                     goto end;
                 }
                 /* split and move data back to global buffer */
-                memcpy(key, tmpkeyiv, iKlen);
-                memcpy(iv, tmpkeyiv+iKlen, iVlen);
+                memcpy(key, tmpkeyiv, iklen);
+                memcpy(iv, tmpkeyiv+iklen, ivlen);
             } else {
                 if (!EVP_BytesToKey(cipher, dgst, sptr,
-                                    (unsigned char *)str,
-                                    str_len, 1, key, iv)) {
+                                    (unsigned char *)str, str_len,
+                                    1, key, iv)) {
                     BIO_printf(bio_err, "EVP_BytesToKey failed\n");
                     goto end;
                 }

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -109,7 +109,7 @@ int enc_main(int argc, char **argv)
     unsigned char key[EVP_MAX_KEY_LENGTH], iv[EVP_MAX_IV_LENGTH];
     unsigned char *buff = NULL, salt[PKCS5_SALT_LEN];
     int pbkdf2 = 0;
-    int iter = 1;
+    int iter = 0;
     long n;
     struct doall_enc_ciphers dec;
 #ifdef ZLIB
@@ -265,7 +265,7 @@ int enc_main(int argc, char **argv)
             break;
         case OPT_PBKDF2:
             pbkdf2 = 1;
-            if (iter == 1)    /* do not overwrite a choosen value */
+            if (iter == 0)    /* do not overwrite a choosen value */
                 iter = 10000; /* update to a better default value ? */
             break;
         case OPT_NONE:
@@ -294,6 +294,9 @@ int enc_main(int argc, char **argv)
 
     if (dgst == NULL)
         dgst = EVP_sha256();
+
+    if (iter == 0)
+        iter = 1;
 
     /* It must be large enough for a base64 encoded line */
     if (base64 && bsize < 80)

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -460,7 +460,7 @@ int enc_main(int argc, char **argv)
 
             if (pbkdf2 == 1) {
                 /*
-                * generate key and default iv
+                * derive key and default iv
                 * concatenated into a temporary buffer
                 */
                 unsigned char tmpkeyiv[EVP_MAX_KEY_LENGTH + EVP_MAX_IV_LENGTH];
@@ -478,7 +478,7 @@ int enc_main(int argc, char **argv)
                 memcpy(iv, tmpkeyiv+iklen, ivlen);
             } else {
                 BIO_printf(bio_err, "*** WARNING : "
-                                    "deprecated key generation used.\n"
+                                    "deprecated key derivation used.\n"
                                     "Using -iter or -pbkdf2 would be better.\n");
                 if (!EVP_BytesToKey(cipher, dgst, sptr,
                                     (unsigned char *)str, str_len,

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -27,6 +27,7 @@ B<openssl enc -I<cipher>>
 [B<-nosalt>]
 [B<-z>]
 [B<-md digest>]
+[B<-iter count>]
 [B<-p>]
 [B<-P>]
 [B<-bufsize number>]
@@ -108,6 +109,12 @@ the B<-pass> argument.
 
 Use the specified digest to create the key from the passphrase.
 The default algorithm is sha-256.
+
+=item B<-iter count>
+
+Use a given number of iterations on the password in deriving the encryption key.
+High values increase the time required to brute-force the resulting file.
+This option enables the use of PBKDF2 algorithm to derive the key.
 
 =item B<-nosalt>
 
@@ -374,8 +381,6 @@ Decrypt some data using a supplied 40 bit RC4 key:
 =head1 BUGS
 
 The B<-A> option when used with large files doesn't work properly.
-
-There should be an option to allow an iteration count to be included.
 
 The B<enc> program only supports a fixed number of algorithms with
 certain parameters. So if, for example, you want to use RC2 with a

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -28,6 +28,7 @@ B<openssl enc -I<cipher>>
 [B<-z>]
 [B<-md digest>]
 [B<-iter count>]
+[B<-pbkdf2>]
 [B<-p>]
 [B<-P>]
 [B<-bufsize number>]
@@ -115,6 +116,10 @@ The default algorithm is sha-256.
 Use a given number of iterations on the password in deriving the encryption key.
 High values increase the time required to brute-force the resulting file.
 This option enables the use of PBKDF2 algorithm to derive the key.
+
+=item B<-pbkdf2>
+
+Use PBKDF2 algorithm with default iteration count unless otherwise specified.
 
 =item B<-nosalt>
 


### PR DESCRIPTION
- [x] documentation is updated
- [x] CLA is signed

iteration count used only for PBKDF2 as per Matt request ( PR #1860 )
