### PR TITLE
Don't call memcpy with NULL as source

### DIFF
--- a/crypto/bn/bn_intern.c
+++ b/crypto/bn/bn_intern.c
@@ -167,7 +167,8 @@ int bn_copy_words(BN_ULONG *out, const BIGNUM *in, int size)
         return 0;
 
     memset(out, 0, sizeof(*out) * size);
-    memcpy(out, in->d, sizeof(*out) * in->top);
+    if (in->d != NULL)
+        memcpy(out, in->d, sizeof(*out) * in->top);
     return 1;
 }
 


### PR DESCRIPTION
Calling it with lenght 0 and NULL as source is undefined behaviour.