### PR TITLE
HP-UX doesn't have hstrerror(), so make our own for that platform

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -18,6 +18,30 @@
 #include <internal/thread_once.h>
 #include <ctype.h>
 
+#ifdef _HPUX_SOURCE
+static const char *ossl_hstrerror(int herr)
+{
+    switch (herr) {
+    case -1:
+        return strerror(errno);
+    case 0:
+        return "No error";
+    case HOST_NOT_FOUND:
+        return "Host not found";
+    case NO_DATA:                /* NO_ADDRESS is a synonym */
+        return "No data";
+    case NO_RECOVERY:
+        return "Non recoverable error";
+    case TRY_AGAIN:
+        return "Try again";
+    default:
+        break;
+    }
+    return "unknown error";
+}
+# define hstrerror(e) ossl_hstrerror(e)
+#endif
+
 CRYPTO_RWLOCK *bio_lookup_lock;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Fixes #2091 (I hope)