### PR TITLE
evp_test: when function and reason strings aren't available, just skip

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -372,6 +372,12 @@ static int check_test_error(struct evp_test *t)
     func = ERR_func_error_string(err);
     reason = ERR_reason_error_string(err);
 
+    if (func == NULL && reason == NULL) {
+        fprintf(stderr, "Test line %d: expected error \"%s:%s\", no strings available.  Skipping...\n",
+                t->start_line, t->func, t->reason);
+        return 1;
+    }
+
     if (strcmp(func, t->func) == 0 && strcmp(reason, t->reason) == 0)
         return 1;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

When configuring `no-autoerrinit`, `test/evp_test` segfaults when trying to check error strings.