### PR TITLE
e_afalg: Don't warn about kernel version when pedantic

### DIFF
--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -26,8 +26,10 @@
 #define K_MIN2  0
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(K_MAJ, K_MIN1, K_MIN2) || \
     !defined(AF_ALG)
-# warning "AFALG ENGINE requires Kernel Headers >= 4.1.0"
-# warning "Skipping Compilation of AFALG engine"
+# ifndef PEDANTIC
+#  warning "AFALG ENGINE requires Kernel Headers >= 4.1.0"
+#  warning "Skipping Compilation of AFALG engine"
+# endif
 void engine_load_afalg_int(void);
 void engine_load_afalg_int(void)
 {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

When built with --strict-warnings and the Linux kernel headers don't
match the kernel version, the preprocessor warnings in
engines/afalg/e_afalg.c cause compilation errors.  Use the macro
PEDANTIC to avoid those warnings in that case.