### PR TITLE
Fix no-ct hangups

### DIFF
--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -265,19 +265,23 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
                | checkhandshake::ALPN_SRV_EXTENSION,
                "ALPN handshake test");
 
-#Test 14: SCT handshake (client request only)
-$proxy->clear();
-#Note: -ct also sends status_request
-$proxy->clientflags("-no_tls1_3 -ct");
-$proxy->serverflags("-status_file "
-                    .srctop_file("test", "recipes", "ocsp-response.der"));
-$proxy->start();
-checkhandshake($proxy, checkhandshake::OCSP_HANDSHAKE,
-               checkhandshake::DEFAULT_EXTENSIONS
-               | checkhandshake::SCT_CLI_EXTENSION
-               | checkhandshake::STATUS_REQUEST_CLI_EXTENSION
-               | checkhandshake::STATUS_REQUEST_SRV_EXTENSION,
-               "SCT handshake test (client)");
+SKIP: {
+    skip "No CT support in this OpenSSL build", 1 if disabled("ct");
+
+    #Test 14: SCT handshake (client request only)
+    $proxy->clear();
+    #Note: -ct also sends status_request
+    $proxy->clientflags("-no_tls1_3 -ct");
+    $proxy->serverflags("-status_file "
+                        .srctop_file("test", "recipes", "ocsp-response.der"));
+    $proxy->start();
+    checkhandshake($proxy, checkhandshake::OCSP_HANDSHAKE,
+                   checkhandshake::DEFAULT_EXTENSIONS
+                   | checkhandshake::SCT_CLI_EXTENSION
+                   | checkhandshake::STATUS_REQUEST_CLI_EXTENSION
+                   | checkhandshake::STATUS_REQUEST_SRV_EXTENSION,
+                   "SCT handshake test (client)");
+}
 
 #Test 15: SCT handshake (server support only)
 $proxy->clear();
@@ -290,23 +294,27 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
                checkhandshake::DEFAULT_EXTENSIONS,
                "SCT handshake test (server)");
 
-#Test 16: SCT handshake (client and server)
-#There is no built-in server side support for this so we are actually also
-#testing custom extensions here
-$proxy->clear();
-#Note: -ct also sends status_request
-$proxy->clientflags("-no_tls1_3 -ct");
-$proxy->serverflags("-status_file "
-                    .srctop_file("test", "recipes", "ocsp-response.der")
-                    ." -serverinfo ".srctop_file("test", "serverinfo.pem"));
-$proxy->start();
-checkhandshake($proxy, checkhandshake::OCSP_HANDSHAKE,
-               checkhandshake::DEFAULT_EXTENSIONS
-               | checkhandshake::SCT_CLI_EXTENSION
-               | checkhandshake::SCT_SRV_EXTENSION
-               | checkhandshake::STATUS_REQUEST_CLI_EXTENSION
-               | checkhandshake::STATUS_REQUEST_SRV_EXTENSION,
-               "SCT handshake test");
+SKIP: {
+    skip "No CT support in this OpenSSL build", 1 if disabled("ct");
+
+    #Test 16: SCT handshake (client and server)
+    #There is no built-in server side support for this so we are actually also
+    #testing custom extensions here
+    $proxy->clear();
+    #Note: -ct also sends status_request
+    $proxy->clientflags("-no_tls1_3 -ct");
+    $proxy->serverflags("-status_file "
+                        .srctop_file("test", "recipes", "ocsp-response.der")
+                        ." -serverinfo ".srctop_file("test", "serverinfo.pem"));
+    $proxy->start();
+    checkhandshake($proxy, checkhandshake::OCSP_HANDSHAKE,
+                   checkhandshake::DEFAULT_EXTENSIONS
+                   | checkhandshake::SCT_CLI_EXTENSION
+                   | checkhandshake::SCT_SRV_EXTENSION
+                   | checkhandshake::STATUS_REQUEST_CLI_EXTENSION
+                   | checkhandshake::STATUS_REQUEST_SRV_EXTENSION,
+                   "SCT handshake test");
+}
 
 
 #Test 17: NPN handshake (client request only)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

When configured `no-ct`, some tests would simply hang.  One test because `s_client` doesn't understand `-ct` in tha configuration, and the other because both the client and server end of the test would end up in `SSL_ERROR_WANT_READ`.  These commits fix both issues.
