### PR TITLE
Fix error handling in SSL_CTX_new

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2030,10 +2030,8 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
     ret->rbuf_freelist->len = 0;
     ret->rbuf_freelist->head = NULL;
     ret->wbuf_freelist = OPENSSL_malloc(sizeof(SSL3_BUF_FREELIST));
-    if (!ret->wbuf_freelist) {
-        OPENSSL_free(ret->rbuf_freelist);
+    if (!ret->wbuf_freelist)
         goto err;
-    }
     ret->wbuf_freelist->chunklen = 0;
     ret->wbuf_freelist->len = 0;
     ret->wbuf_freelist->head = NULL;


### PR DESCRIPTION
I encountered the following crash, in SSL_CTX_new.
There is no need to free rbuf_freelist here, SSL_CTX_free will do that.

```
==2566==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030012fff80
READ of size 8 at 0x6030012fff80 thread T28
    #0 0x222fb65 in ssl_buf_freelist_free ssl/ssl_lib.c:2093
    #1 0x222fb65 in SSL_CTX_free ssl/ssl_lib.c:2182
    #2 0x22374a9 in SSL_CTX_free ssl/ssl_lib.c:2079
    #3 0x22374a9 in SSL_CTX_new ssl/ssl_lib.c:2078

```