### PR TITLE
Fix crash in ssl3_finish_mac

### DIFF
--- a/ssl/d1_clnt.c
+++ b/ssl/d1_clnt.c
@@ -320,8 +320,13 @@ int dtls1_connect(SSL *s)
             s->shutdown = 0;
 
             /* every DTLS ClientHello resets Finished MAC */
-            ssl3_init_finished_mac(s);
+            if (!ssl3_init_finished_mac(s)) {
+                ret = -1;
+                s->state = SSL_ST_ERR;
+                goto end;
+            }
 
+            /* fall thru */
         case SSL3_ST_CW_CLNT_HELLO_B:
             dtls1_start_timer(s);
             ret = ssl3_client_hello(s);

--- a/ssl/d1_srvr.c
+++ b/ssl/d1_srvr.c
@@ -282,7 +282,12 @@ int dtls1_accept(SSL *s)
                         goto end;
                     }
 
-                ssl3_init_finished_mac(s);
+                if (!ssl3_init_finished_mac(s)) {
+                    ret = -1;
+                    s->state = SSL_ST_ERR;
+                    goto end;
+                }
+
                 s->state = SSL3_ST_SR_CLNT_HELLO_A;
                 s->ctx->stats.sess_accept++;
             } else if (!s->s3->send_connection_binding &&
@@ -322,7 +327,11 @@ int dtls1_accept(SSL *s)
             s->state = SSL3_ST_SW_FLUSH;
             s->init_num = 0;
 
-            ssl3_init_finished_mac(s);
+            if (!ssl3_init_finished_mac(s)) {
+                ret = -1;
+                s->state = SSL_ST_ERR;
+                goto end;
+            }
             break;
 
         case SSL3_ST_SW_HELLO_REQ_C:
@@ -381,7 +390,11 @@ int dtls1_accept(SSL *s)
 
             /* HelloVerifyRequest resets Finished MAC */
             if (s->version != DTLS1_BAD_VER)
-                ssl3_init_finished_mac(s);
+                if (!ssl3_init_finished_mac(s)) {
+                    ret = -1;
+                    s->state = SSL_ST_ERR;
+                    goto end;
+                }
             break;
 
 #ifndef OPENSSL_NO_SCTP

--- a/ssl/s23_clnt.c
+++ b/ssl/s23_clnt.c
@@ -204,7 +204,10 @@ int ssl23_connect(SSL *s)
                 goto end;
             }
 
-            ssl3_init_finished_mac(s);
+            if (!ssl3_init_finished_mac(s)) {
+                ret = -1;
+                goto end;
+            }
 
             s->state = SSL23_ST_CW_CLNT_HELLO_A;
             s->ctx->stats.sess_connect++;

--- a/ssl/s23_srvr.c
+++ b/ssl/s23_srvr.c
@@ -195,7 +195,10 @@ int ssl23_accept(SSL *s)
                 s->init_buf = buf;
             }
 
-            ssl3_init_finished_mac(s);
+            if (!ssl3_init_finished_mac(s)) {
+                ret = -1;
+                goto end;
+            }
 
             s->state = SSL23_ST_SR_CLNT_HELLO_A;
             s->ctx->stats.sess_accept++;

--- a/ssl/s3_clnt.c
+++ b/ssl/s3_clnt.c
@@ -263,6 +263,7 @@ int ssl3_connect(SSL *s)
 
             if (!ssl3_setup_buffers(s)) {
                 ret = -1;
+                s->state = SSL_ST_ERR;
                 goto end;
             }
 
@@ -275,7 +276,11 @@ int ssl3_connect(SSL *s)
 
             /* don't push the buffering BIO quite yet */
 
-            ssl3_init_finished_mac(s);
+            if (!ssl3_init_finished_mac(s)) {
+                ret = -1;
+                s->state = SSL_ST_ERR;
+                goto end;
+            }
 
             s->state = SSL3_ST_CW_CLNT_HELLO_A;
             s->ctx->stats.sess_connect++;

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -555,17 +555,20 @@ int ssl3_enc(SSL *s, int send)
         if ((bs != 1) && !send)
             return ssl3_cbc_remove_padding(s, rec, bs, mac_size);
     }
-    return (1);
+    return 1;
 }
 
-void ssl3_init_finished_mac(SSL *s)
+int ssl3_init_finished_mac(SSL *s)
 {
     if (s->s3->handshake_buffer)
         BIO_free(s->s3->handshake_buffer);
     if (s->s3->handshake_dgst)
         ssl3_free_digest_list(s);
     s->s3->handshake_buffer = BIO_new(BIO_s_mem());
+    if (s->s3->handshake_buffer == NULL)
+        return 0;
     (void)BIO_set_close(s->s3->handshake_buffer, BIO_CLOSE);
+    return 1;
 }
 
 void ssl3_free_digest_list(SSL *s)
@@ -622,6 +625,10 @@ int ssl3_digest_cached_records(SSL *s)
     for (i = 0; ssl_get_handshake_digest(i, &mask, &md); i++) {
         if ((mask & ssl_get_algorithm2(s)) && md) {
             s->s3->handshake_dgst[i] = EVP_MD_CTX_create();
+            if (s->s3->handshake_dgst[i] == NULL) {
+                SSLerr(SSL_F_SSL3_DIGEST_CACHED_RECORDS, ERR_R_MALLOC_FAILURE);
+                return 0;
+            }
 #ifdef OPENSSL_FIPS
             if (EVP_MD_nid(md) == NID_md5) {
                 EVP_MD_CTX_set_flags(s->s3->handshake_dgst[i],

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -311,7 +311,12 @@ int ssl3_accept(SSL *s)
                     goto end;
                 }
 
-                ssl3_init_finished_mac(s);
+                if (!ssl3_init_finished_mac(s)) {
+                    ret = -1;
+                    s->state = SSL_ST_ERR;
+                    goto end;
+                }
+
                 s->state = SSL3_ST_SR_CLNT_HELLO_A;
                 s->ctx->stats.sess_accept++;
             } else if (!s->s3->send_connection_binding &&
@@ -348,7 +353,11 @@ int ssl3_accept(SSL *s)
             s->state = SSL3_ST_SW_FLUSH;
             s->init_num = 0;
 
-            ssl3_init_finished_mac(s);
+            if (!ssl3_init_finished_mac(s)) {
+                ret = -1;
+                s->state = SSL_ST_ERR;
+                goto end;
+            }
             break;
 
         case SSL3_ST_SW_HELLO_REQ_C:

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1158,7 +1158,7 @@ long ssl2_default_timeout(void);
 
 const SSL_CIPHER *ssl3_get_cipher_by_char(const unsigned char *p);
 int ssl3_put_cipher_by_char(const SSL_CIPHER *c, unsigned char *p);
-void ssl3_init_finished_mac(SSL *s);
+int ssl3_init_finished_mac(SSL *s);
 int ssl3_send_server_certificate(SSL *s);
 int ssl3_send_newsession_ticket(SSL *s);
 int ssl3_send_cert_status(SSL *s);


### PR DESCRIPTION
This should fix issue #2113 
I think not having a return code for ssl3_init_finished_mac
is the root cause of the problem, together with the fact
that s->s3->handshake_buffer is used as a status flag
everywhere.