### PR TITLE
Fix crash in EVP_CIPHER_CTX_cleanup

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1120,6 +1120,8 @@ BLOCK_CIPHER_generic_pack(NID_aes, 128, EVP_CIPH_FLAG_FIPS)
 static int aes_gcm_cleanup(EVP_CIPHER_CTX *c)
 {
     EVP_AES_GCM_CTX *gctx = c->cipher_data;
+    if (gctx == NULL)
+        return 0;
     OPENSSL_cleanse(&gctx->gcm, sizeof(gctx->gcm));
     if (gctx->iv != c->iv)
         OPENSSL_free(gctx->iv);


### PR DESCRIPTION
If EVP_CIPHER_CTX_init fails to allocate cipher_data,
any attempt to use EVP_CIPHER_CTX_ctrl or even
EVP_CIPHER_CTX_cleanup crashes in
case it is an AES cipher.  This was observed with
the enc_read_ctx.  This patch sets cipher = NULL
if allocation of cipher_data fails, or the INIT or COPY
method fails.

```
==26646==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000029c 
==26646==The signal is caused by a WRITE memory access.
==26646==Hint: address points to the zero page.
    #0 0x2324b44 in aes_gcm_ctrl crypto/evp/e_aes.c:1234
    #1 0x231fad7 in EVP_CIPHER_CTX_ctrl crypto/evp/evp_enc.c:619
    #2 0x222930c in tls1_enc ssl/t1_enc.c:843
    #3 0x228961c in ssl3_get_record ssl/s3_pkt.c:446
    #4 0x228961c in ssl3_read_bytes ssl/s3_pkt.c:1234
    #5 0x228f382 in ssl3_get_message ssl/s3_both.c:371
    #6 0x228e095 in ssl3_get_finished ssl/s3_both.c:249
    #7 0x227732b in ssl3_connect ssl/s3_clnt.c:586
    #8 0x228aecf in ssl3_read_bytes ssl/s3_pkt.c:1213
    #9 0x227e97c in ssl3_read_internal ssl/s3_lib.c:4459
    #10 0x227e97c in ssl3_read ssl/s3_lib.c:4483

==17544==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000100
==17544==The signal is caused by a WRITE memory access.
==17544==Hint: address points to the zero page.
    #0 0x7fd33fa5b44a  (/lib/x86_64-linux-gnu/libc.so.6+0x8b44a)
    #1 0x7fd340c96cd1 in __interceptor_memset ../../../../gcc-7-20161218/libsanitizer/asan/asan_interceptors.cc:471
    #2 0x20cbbf1 in aes_gcm_cleanup crypto/evp/e_aes.c:1123
    #3 0x20c5ed7 in EVP_CIPHER_CTX_cleanup crypto/evp/evp_enc.c:559
    #4 0x20c5ed7 in EVP_CIPHER_CTX_free crypto/evp/evp_enc.c:550
```