### PR TITLE
Doc nits: callback function typedefs

### DIFF
--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -5,7 +5,8 @@
 BIO_ctrl, BIO_callback_ctrl, BIO_ptr_ctrl, BIO_int_ctrl, BIO_reset,
 BIO_seek, BIO_tell, BIO_flush, BIO_eof, BIO_set_close, BIO_get_close,
 BIO_pending, BIO_wpending, BIO_ctrl_pending, BIO_ctrl_wpending,
-BIO_get_info_callback, BIO_set_info_callback - BIO control operations
+BIO_get_info_callback, BIO_set_info_callback, bio_info_cb
+- BIO control operations
 
 =head1 SYNOPSIS
 

--- a/doc/man3/BIO_set_callback.pod
+++ b/doc/man3/BIO_set_callback.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 BIO_set_callback_ex, BIO_get_callback_ex, BIO_set_callback, BIO_get_callback,
-BIO_set_callback_arg, BIO_get_callback_arg, BIO_debug_callback
+BIO_set_callback_arg, BIO_get_callback_arg, BIO_debug_callback,
+BIO_callback_fn_ex, BIO_callback_fn
 - BIO callback functions
 
 =head1 SYNOPSIS

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -5,7 +5,9 @@
 EVP_PKEY_keygen_init, EVP_PKEY_keygen, EVP_PKEY_paramgen_init,
 EVP_PKEY_paramgen, EVP_PKEY_CTX_set_cb, EVP_PKEY_CTX_get_cb,
 EVP_PKEY_CTX_get_keygen_info, EVP_PKEY_CTX_set_app_data,
-EVP_PKEY_CTX_get_app_data - key and parameter generation functions
+EVP_PKEY_CTX_get_app_data,
+EVP_PKEY_gen_cb
+- key and parameter generation functions
 
 =head1 SYNOPSIS
 
@@ -16,7 +18,7 @@ EVP_PKEY_CTX_get_app_data - key and parameter generation functions
  int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 
- typedef int EVP_PKEY_gen_cb(EVP_PKEY_CTX *ctx);
+ typedef int (*EVP_PKEY_gen_cb)(EVP_PKEY_CTX *ctx);
 
  void EVP_PKEY_CTX_set_cb(EVP_PKEY_CTX *ctx, EVP_PKEY_gen_cb *cb);
  EVP_PKEY_gen_cb *EVP_PKEY_CTX_get_cb(EVP_PKEY_CTX *ctx);

--- a/doc/man3/SSL_CTX_set_generate_session_id.pod
+++ b/doc/man3/SSL_CTX_set_generate_session_id.pod
@@ -2,7 +2,9 @@
 
 =head1 NAME
 
-SSL_CTX_set_generate_session_id, SSL_set_generate_session_id, SSL_has_matching_session_id - manipulate generation of SSL session IDs (server only)
+SSL_CTX_set_generate_session_id, SSL_set_generate_session_id,
+SSL_has_matching_session_id, GEN_SESSION_CB
+- manipulate generation of SSL session IDs (server only)
 
 =head1 SYNOPSIS
 

--- a/doc/man3/SSL_CTX_set_verify.pod
+++ b/doc/man3/SSL_CTX_set_verify.pod
@@ -4,19 +4,19 @@
 
 SSL_CTX_set_verify, SSL_set_verify,
 SSL_CTX_set_verify_depth, SSL_set_verify_depth,
-verify_cb
+SSL_verify_cb
 - set peer certificate verification parameters
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
- void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, verify_cb verify_callback);
- void SSL_set_verify(SSL *s, int mode, verify_cb verify_callback);
+ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, SSL_verify_cb verify_callback);
+ void SSL_set_verify(SSL *s, int mode, SSL_verify_cb verify_callback);
  void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
  void SSL_set_verify_depth(SSL *s, int depth);
 
- typedef int (*verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
+ typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_CTX_set_verify.pod
+++ b/doc/man3/SSL_CTX_set_verify.pod
@@ -2,20 +2,21 @@
 
 =head1 NAME
 
-SSL_CTX_set_verify, SSL_set_verify, SSL_CTX_set_verify_depth, SSL_set_verify_depth - set peer certificate verification parameters
+SSL_CTX_set_verify, SSL_set_verify,
+SSL_CTX_set_verify_depth, SSL_set_verify_depth,
+verify_cb
+- set peer certificate verification parameters
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
- void SSL_CTX_set_verify(SSL_CTX *ctx, int mode,
-                         int (*verify_callback)(int, X509_STORE_CTX *));
- void SSL_set_verify(SSL *s, int mode,
-                     int (*verify_callback)(int, X509_STORE_CTX *));
+ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, verify_cb verify_callback);
+ void SSL_set_verify(SSL *s, int mode, verify_cb verify_callback);
  void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
  void SSL_set_verify_depth(SSL *s, int depth);
 
- int verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx);
+ typedef int (*verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_extension_supported.pod
+++ b/doc/man3/SSL_extension_supported.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 SSL_extension_supported,
-SSL_CTX_add_client_custom_ext, SSL_CTX_add_server_custom_ext
+SSL_CTX_add_client_custom_ext, SSL_CTX_add_server_custom_ext,
+custom_ext_add_cb, custom_ext_free_cb, custom_ext_parse_cb
 - custom TLS extension handling
 
 =head1 SYNOPSIS

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -10,7 +10,8 @@ X509_STORE_CTX_get0_param, X509_STORE_CTX_set0_param,
 X509_STORE_CTX_get0_untrusted, X509_STORE_CTX_set0_untrusted,
 X509_STORE_CTX_get_num_untrusted,
 X509_STORE_CTX_set_default,
-X509_STORE_CTX_set_verify
+X509_STORE_CTX_set_verify,
+X509_STORE_CTX_verify_fn
 - X509_STORE_CTX initialisation
 
 =head1 SYNOPSIS

--- a/doc/man3/X509_STORE_CTX_set_verify_cb.pod
+++ b/doc/man3/X509_STORE_CTX_set_verify_cb.pod
@@ -13,7 +13,9 @@ X509_STORE_CTX_get_check_revocation,
 X509_STORE_CTX_get_check_issued,
 X509_STORE_CTX_get_get_issuer,
 X509_STORE_CTX_get_verify_cb,
-X509_STORE_CTX_set_verify_cb - get and set verification callback
+X509_STORE_CTX_set_verify_cb,
+X509_STORE_CTX_verify_cb
+- get and set verification callback
 
 =head1 SYNOPSIS
 

--- a/doc/man3/X509_STORE_set_verify_cb_func.pod
+++ b/doc/man3/X509_STORE_set_verify_cb_func.pod
@@ -27,7 +27,13 @@ X509_STORE_set_get_issuer,
 X509_STORE_CTX_get_verify,
 X509_STORE_set_verify,
 X509_STORE_get_verify_cb,
-X509_STORE_set_verify_cb_func, X509_STORE_set_verify_cb
+X509_STORE_set_verify_cb_func, X509_STORE_set_verify_cb,
+X509_STORE_CTX_cert_crl_fn, X509_STORE_CTX_check_crl_fn,
+X509_STORE_CTX_check_issued_fn, X509_STORE_CTX_check_policy_fn,
+X509_STORE_CTX_check_revocation_fn, X509_STORE_CTX_cleanup_fn
+X509_STORE_CTX_get_crl_fn, X509_STORE_CTX_get_issuer_fn,
+X509_STORE_CTX_lookup_certs_fn, X509_STORE_CTX_lookup_crls_fn,
+X509_STORE_CTX_verify_cb, X509_STORE_CTX_verify_fn,
 - set verification callback
 
 =head1 SYNOPSIS

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -263,7 +263,7 @@ typedef int (*custom_ext_parse_cb) (SSL *s, unsigned int ext_type,
                                     size_t inlen, int *al, void *parse_arg);
 
 /* Typedef for verification callback */
-typedef int (*verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
+typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U
@@ -1363,8 +1363,8 @@ __owur int SSL_set_cipher_list(SSL *s, const char *str);
 void SSL_set_read_ahead(SSL *s, int yes);
 __owur int SSL_get_verify_mode(const SSL *s);
 __owur int SSL_get_verify_depth(const SSL *s);
-__owur verify_cb SSL_get_verify_callback(const SSL *s);
-void SSL_set_verify(SSL *s, int mode, verify_cb callback);
+__owur SSL_verify_cb SSL_get_verify_callback(const SSL *s);
+void SSL_set_verify(SSL *s, int mode, SSL_verify_cb callback);
 void SSL_set_verify_depth(SSL *s, int depth);
 void SSL_set_cert_cb(SSL *s, int (*cb) (SSL *ssl, void *arg), void *arg);
 # ifndef OPENSSL_NO_RSA
@@ -1463,8 +1463,8 @@ __owur STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *s);
 
 __owur int SSL_CTX_get_verify_mode(const SSL_CTX *ctx);
 __owur int SSL_CTX_get_verify_depth(const SSL_CTX *ctx);
-__owur verify_cb SSL_CTX_get_verify_callback(const SSL_CTX *ctx);
-void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, verify_cb callback);
+__owur SSL_verify_cb SSL_CTX_get_verify_callback(const SSL_CTX *ctx);
+void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, SSL_verify_cb callback);
 void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
 void SSL_CTX_set_cert_verify_callback(SSL_CTX *ctx,
                                       int (*cb) (X509_STORE_CTX *, void *),

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -262,6 +262,9 @@ typedef int (*custom_ext_parse_cb) (SSL *s, unsigned int ext_type,
                                     const unsigned char *in,
                                     size_t inlen, int *al, void *parse_arg);
 
+/* Typedef for verification callback */
+typedef int (*verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
+
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U
 /* Removed from OpenSSL 0.9.8q and 1.0.0c */
@@ -1360,9 +1363,8 @@ __owur int SSL_set_cipher_list(SSL *s, const char *str);
 void SSL_set_read_ahead(SSL *s, int yes);
 __owur int SSL_get_verify_mode(const SSL *s);
 __owur int SSL_get_verify_depth(const SSL *s);
-__owur int (*SSL_get_verify_callback(const SSL *s)) (int, X509_STORE_CTX *);
-void SSL_set_verify(SSL *s, int mode,
-                    int (*callback) (int ok, X509_STORE_CTX *ctx));
+__owur verify_cb SSL_get_verify_callback(const SSL *s);
+void SSL_set_verify(SSL *s, int mode, verify_cb callback);
 void SSL_set_verify_depth(SSL *s, int depth);
 void SSL_set_cert_cb(SSL *s, int (*cb) (SSL *ssl, void *arg), void *arg);
 # ifndef OPENSSL_NO_RSA
@@ -1461,10 +1463,8 @@ __owur STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *s);
 
 __owur int SSL_CTX_get_verify_mode(const SSL_CTX *ctx);
 __owur int SSL_CTX_get_verify_depth(const SSL_CTX *ctx);
-__owur int (*SSL_CTX_get_verify_callback(const SSL_CTX *ctx)) (int,
-                                                        X509_STORE_CTX *);
-void SSL_CTX_set_verify(SSL_CTX *ctx, int mode,
-                        int (*callback) (int, X509_STORE_CTX *));
+__owur verify_cb SSL_CTX_get_verify_callback(const SSL_CTX *ctx);
+void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, verify_cb callback);
 void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
 void SSL_CTX_set_cert_verify_callback(SSL_CTX *ctx,
                                       int (*cb) (X509_STORE_CTX *, void *),

--- a/util/find-doc-nits.pl
+++ b/util/find-doc-nits.pl
@@ -85,7 +85,14 @@ sub name_synopsis()
         my $sym;
         $line =~ s/STACK_OF\([^)]+\)/int/g;
         $line =~ s/__declspec\([^)]+\)//;
-        if ( $line =~ /typedef.* (\S+);/ ) {
+        if ( $line =~ /env (\S*)=/ ) {
+            # environment variable env NAME=...
+            $sym = $1;
+        } elsif ( $line =~ /typedef.*\(\*(\S+)\)\(.*/ ) {
+            # a callback function: typedef ... (*NAME)(...
+            $sym = $1;
+        } elsif ( $line =~ /typedef.* (\S+);/ ) {
+            # a simple typedef: typedef ... NAME;
             $sym = $1;
         } elsif ( $line =~ /#define ([A-Za-z0-9_]+)/ ) {
             $sym = $1;


### PR DESCRIPTION
Enhance find-doc-nits to be better about finding typedefs for
callback functions.  Fix all nits it now finds.  Added some new
typedef names to ssl.h some of which were documented but did not
exist.

Once this is merged, I'd like to see it as part of one of our travis builds.
