### PR TITLE
Fix ec point formats

### DIFF
--- a/Configure
+++ b/Configure
@@ -507,7 +507,8 @@ my @disable_cascades = (
 
     "stdio"             => [ "apps", "capieng" ],
     "apps"              => [ "tests" ],
-    "comp"		=> [ "zlib" ],
+    "comp"              => [ "zlib" ],
+    "ec"                => [ "tls1_3" ],
     sub { !$disabled{"unit-test"} } => [ "heartbeats" ],
 
     sub { !$disabled{"msan"} } => [ "asm" ],

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -92,6 +92,7 @@ typedef struct extensions_definition_st {
  *
  * TODO(TLS1.3): Make sure we have a test to check the consistency of these
  */
+#define INVALID_EXTENSION { 0x10000, 0, NULL, NULL, NULL, NULL, NULL, NULL }
 static const EXTENSION_DEFINITION ext_defs[] = {
     {
         TLSEXT_TYPE_renegotiate,
@@ -116,6 +117,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         EXT_CLIENT_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
         init_srp, tls_parse_ctos_srp, NULL, NULL, tls_construct_ctos_srp, NULL
     },
+#else
+    INVALID_EXTENSION,
 #endif
 #ifndef OPENSSL_NO_EC
     {
@@ -132,6 +135,9 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         NULL /* TODO(TLS1.3): Need to add this */,
         tls_construct_ctos_supported_groups, NULL
     },
+#else
+    INVALID_EXTENSION,
+    INVALID_EXTENSION,
 #endif
     {
         TLSEXT_TYPE_session_ticket,
@@ -155,6 +161,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_parse_stoc_status_request, tls_construct_stoc_status_request,
         tls_construct_ctos_status_request, final_status_request
     },
+#else
+    INVALID_EXTENSION,
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
     {
@@ -163,6 +171,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         init_npn, tls_parse_ctos_npn, tls_parse_stoc_npn,
         tls_construct_stoc_next_proto_neg, tls_construct_ctos_npn, NULL
     },
+#else
+    INVALID_EXTENSION,
 #endif
     {
         /*
@@ -183,6 +193,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         init_srtp, tls_parse_ctos_use_srtp, tls_parse_stoc_use_srtp,
         tls_construct_stoc_use_srtp, tls_construct_ctos_use_srtp, NULL
     },
+#else
+    INVALID_EXTENSION,
 #endif
     {
         TLSEXT_TYPE_encrypt_then_mac,
@@ -203,6 +215,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
          */
         NULL, tls_parse_stoc_sct, NULL, tls_construct_ctos_sct,  NULL
     },
+#else
+    INVALID_EXTENSION,
 #endif
     {
         TLSEXT_TYPE_extended_master_secret,

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -120,7 +120,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #ifndef OPENSSL_NO_EC
     {
         TLSEXT_TYPE_ec_point_formats,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
         NULL, tls_parse_ctos_ec_pt_formats, tls_parse_stoc_ec_pt_formats,
         tls_construct_stoc_ec_pt_formats, tls_construct_ctos_ec_pt_formats,
         final_ec_pt_formats

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -480,6 +480,7 @@ int tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt, int *al)
 
 int tls_construct_ctos_key_share(SSL *s, WPACKET *pkt, int *al)
 {
+#ifndef OPENSSL_NO_TLS1_3
     size_t i, sharessent = 0, num_curves = 0;
     const unsigned char *pcurves = NULL;
 
@@ -559,6 +560,7 @@ int tls_construct_ctos_key_share(SSL *s, WPACKET *pkt, int *al)
         SSLerr(SSL_F_TLS_CONSTRUCT_CTOS_KEY_SHARE, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+#endif
 
     return 1;
 }
@@ -983,6 +985,7 @@ int tls_parse_stoc_ems(SSL *s, PACKET *pkt, int *al)
 
 int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, int *al)
 {
+#ifndef OPENSSL_NO_TLS1_3
     unsigned int group_id;
     PACKET encoded_pt;
     EVP_PKEY *ckey = s->s3->tmp.pkey, *skey = NULL;
@@ -1038,6 +1041,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, int *al)
         return 0;
     }
     EVP_PKEY_free(skey);
+#endif
 
     return 1;
 }

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -457,6 +457,7 @@ int tls_parse_ctos_etm(SSL *s, PACKET *pkt, int *al)
  * used. Returns 1 if the group is in the list (and allowed if |checkallow| is
  * 1) or 0 otherwise.
  */
+#ifndef OPENSSL_NO_TLS1_3
 static int check_in_list(SSL *s, unsigned int group_id,
                          const unsigned char *groups, size_t num_groups,
                          int checkallow)
@@ -479,6 +480,7 @@ static int check_in_list(SSL *s, unsigned int group_id,
     /* If i == num_groups then not in the list */
     return i < num_groups;
 }
+#endif
 
 /*
  * Process a key_share extension received in the ClientHello. |pkt| contains
@@ -487,6 +489,7 @@ static int check_in_list(SSL *s, unsigned int group_id,
  */
 int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, int *al)
 {
+#ifndef OPENSSL_NO_TLS1_3
     unsigned int group_id;
     PACKET key_share_list, encoded_pt;
     const unsigned char *clntcurves, *srvrcurves;
@@ -607,6 +610,7 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, int *al)
 
         found = 1;
     }
+#endif
 
     return 1;
 }
@@ -857,6 +861,7 @@ int tls_construct_stoc_ems(SSL *s, WPACKET *pkt, int *al)
 
 int tls_construct_stoc_key_share(SSL *s, WPACKET *pkt, int *al)
 {
+#ifndef OPENSSL_NO_TLS1_3
     unsigned char *encodedPoint;
     size_t encoded_pt_len = 0;
     EVP_PKEY *ckey = s->s3->peer_tmp, *skey = NULL;
@@ -905,6 +910,7 @@ int tls_construct_stoc_key_share(SSL *s, WPACKET *pkt, int *al)
         SSLerr(SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+#endif
 
     return 1;
 }

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -275,7 +275,8 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
                "ALPN handshake test");
 
 SKIP: {
-    skip "No CT support in this OpenSSL build", 1 if disabled("ct");
+    skip "No CT and/or EC support in this OpenSSL build", 1
+        if disabled("ct") || disabled("ec");
 
     #Test 14: SCT handshake (client request only)
     $proxy->clear();
@@ -304,7 +305,8 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
                "SCT handshake test (server)");
 
 SKIP: {
-    skip "No CT support in this OpenSSL build", 1 if disabled("ct");
+    skip "No CT and/or EC support in this OpenSSL build", 1
+        if disabled("ct") || disabled("ec");
 
     #Test 16: SCT handshake (client and server)
     #There is no built-in server side support for this so we are actually also

--- a/test/testlib/checkhandshake.pm
+++ b/test/testlib/checkhandshake.pm
@@ -23,8 +23,9 @@ use constant {
     CLIENT_AUTH_HANDSHAKE => 8,
     RENEG_HANDSHAKE => 16,
     NPN_HANDSHAKE => 32,
+    EC_HANDSHAKE => 64,
 
-    ALL_HANDSHAKES => 63
+    ALL_HANDSHAKES => 127
 };
 
 use constant {
@@ -43,6 +44,8 @@ use constant {
     NPN_CLI_EXTENSION => 0x00000800,
     NPN_SRV_EXTENSION => 0x00001000,
     SRP_CLI_EXTENSION => 0x00002000,
+    #Client side for ec point formats is a default extension
+    EC_POINT_FORMAT_SRV_EXTENSION => 0x00004000,
 };
 
 our @handmessages = ();

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -83,6 +83,10 @@ use constant {
     EXT_DUPLICATE_EXTENSION => 0xfde8
 };
 
+use constant {
+    CIPHER_ADH_AES_128_SHA => 0x03000034
+};
+
 my $payload = "";
 my $messlen = -1;
 my $mt;

--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -25,6 +25,7 @@ my $have_IPv6 = 0;
 my $IP_factory;
 
 my $is_tls13 = 0;
+my $ciphersuite = undef;
 
 sub new
 {
@@ -108,6 +109,7 @@ sub clearClient
     $self->{message_list} = [];
     $self->{clientflags} = "";
     $is_tls13 = 0;
+    $ciphersuite = undef;
 
     TLSProxy::Message->clear();
     TLSProxy::Record->clear();
@@ -533,6 +535,15 @@ sub reneg
         $self->{reneg} = shift;
     }
     return $self->{reneg};
+}
+
+sub ciphersuite
+{
+    my $class = shift;
+    if (@_) {
+        $ciphersuite = shift;
+    }
+    return $ciphersuite;
 }
 
 1;

--- a/util/TLSProxy/ServerHello.pm
+++ b/util/TLSProxy/ServerHello.pm
@@ -103,6 +103,7 @@ sub parse
     $self->session_id_len($session_id_len);
     $self->session($session);
     $self->ciphersuite($ciphersuite);
+    TLSProxy::Proxy->ciphersuite($ciphersuite);
     $self->comp_meth($comp_meth);
     $self->extension_data(\%extensions);
 

--- a/util/TLSProxy/ServerKeyExchange.pm
+++ b/util/TLSProxy/ServerKeyExchange.pm
@@ -42,9 +42,9 @@ sub parse
 {
     my $self = shift;
 
-    #Minimal SKE parsing. Only supports DHE at the moment (if its not DHE
-    #the parsing data will be trash...which is ok as long as we don't try to
-    #use it)
+    #Minimal SKE parsing. Only supports one known DHE ciphersuite at the moment
+    return if (TLSProxy::Proxy->ciphersuite()
+               != TLSProxy::Message::CIPHER_ADH_AES_128_SHA);
 
     my $p_len = unpack('n', $self->data);
     my $ptr = 2;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
Fix the EC point formats extension. This should be sent in the ServerHello if an EC based ciphersuite is
negotiated (<= TLS1.2). The relevant flag to do this was missed off in the recent extensions refactor. This bug should have been caught by `70-test_sslmessages` but that test never tries an EC ciphersuite, so we also update the test to do that.

Fixes #2133