### PR TITLE
Add missing flags for EVP_chacha20()

### DIFF
--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -127,7 +127,7 @@ static const EVP_CIPHER chacha20 = {
     1,                      /* block_size */
     CHACHA_KEY_SIZE,        /* key_len */
     CHACHA_CTR_SIZE,        /* iv_len, 128-bit counter in the context */
-    0,                      /* flags */
+    EVP_CIPH_CUSTOM_IV | EVP_CIPH_ALWAYS_CALL_INIT,
     chacha_init_key,
     chacha_cipher,
     NULL,


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
<!-- - [ ] documentation is added or updated
- [ ] tests are added or updated -->
- [x] CLA is signed

##### Description of change

ChaCha20 code uses its own custom cipher_data. Add EVP_CIPH_CUSTOM_IV
and EVP_CIPH_ALWAYS_CALL_INIT so that the key and the iv can be set by
different calls of EVP_CipherInit_ex().
