### PR TITLE
Fix a sig algs bug and add some tests

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1258,7 +1258,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTX_set1_sigalgs_list(ctx, s) \
         SSL_CTX_ctrl(ctx,SSL_CTRL_SET_SIGALGS_LIST,0,(char *)s)
 # define SSL_set1_sigalgs(ctx, slist, slistlen) \
-        SSL_ctrl(ctx,SSL_CTRL_SET_SIGALGS,clistlen,(int *)slist)
+        SSL_ctrl(ctx,SSL_CTRL_SET_SIGALGS,slistlen,(int *)slist)
 # define SSL_set1_sigalgs_list(ctx, s) \
         SSL_ctrl(ctx,SSL_CTRL_SET_SIGALGS_LIST,0,(char *)s)
 # define SSL_CTX_set1_client_sigalgs(ctx, slist, slistlen) \

--- a/test/build.info
+++ b/test/build.info
@@ -273,7 +273,7 @@ IF[{- !$disabled{tests} -}]
   DEPEND[bioprinttest]=../libcrypto
 
   SOURCE[sslapitest]=sslapitest.c ssltestlib.c testutil.c test_main_custom.c
-  INCLUDE[sslapitest]=../include
+  INCLUDE[sslapitest]=../include ..
   DEPEND[sslapitest]=../libcrypto ../libssl
 
   SOURCE[dtlstest]=dtlstest.c ssltestlib.c testutil.c test_main_custom.c

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -937,6 +937,12 @@ static int test_set_sigalgs(int idx)
         return 0;
     }
 
+    /*
+     * TODO(TLS1.3): These APIs cannot set TLSv1.3 sig algs so we just test it
+     * for TLSv1.2 for now until we add a new API.
+     */
+    SSL_CTX_set_max_proto_version(cctx, TLS1_2_VERSION);
+
     if (testctx) {
         int ret;
         if (curr->list != NULL)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
This PR fixes a bug in the SSL_set1_sigalgs() macro. Prior to this fix, use of the macro results in a compilation failure. The bug was actually already fixed once in commit 75fdee0, but the fix was only applied to the 1.0.2 branch for some reason.

I've also added some tests for this.

The first 2 commits are for 1.1.0 and master. The third commit is only for master as it is TLSv1.3 specific.