### PR TITLE
Fix the crash due to inconsistent enc_write_ctx on the 1.1.0 branch

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -61,10 +61,10 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
     EVP_MD_CTX_set_flags(m5, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
     for (i = 0; (int)i < num; i += MD5_DIGEST_LENGTH) {
         k++;
-        if (k > sizeof buf) {
+        if (k > sizeof(buf)) {
             /* bug: 'buf' is too small for this ciphersuite */
             SSLerr(SSL_F_SSL3_GENERATE_KEY_BLOCK, ERR_R_INTERNAL_ERROR);
-            return 0;
+            goto err;
         }
 
         for (j = 0; j < k; j++)
@@ -225,7 +225,8 @@ int ssl3_change_cipher_state(SSL *s, int which)
 
     memcpy(mac_secret, ms, i);
 
-    EVP_CipherInit_ex(dd, c, NULL, key, iv, (which & SSL3_CC_WRITE));
+    if (!EVP_CipherInit_ex(dd, c, NULL, key, iv, (which & SSL3_CC_WRITE)))
+        goto err2;
 
 #ifdef OPENSSL_SSL_TRACE_CRYPTO
     if (s->msg_callback) {


### PR DESCRIPTION
fix the error handling in ssl3_change_cipher_state

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
This pull request is for trunk and 1.1.0 branch.

It fixes #2114 by checking the error code of EVP_CipherInit_ex and returning
it to the application, which has to avoid calling SSL_shutdown in this case.
I have noticed a memory leak in ssl3_generate_key_block that was not
there in the 1.0.2 branch.
