### PR TITLE
TLS check temp key type

### DIFF
--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -87,6 +87,8 @@ handshake.
 
 * ExpectedNPNProtocol, ExpectedALPNProtocol - NPN and ALPN expectations.
 
+* ExpectedTmpKeyType - the expected algorithm or curve of server temp key
+
 ## Configuring the client and server
 
 The client and server configurations can be any valid `SSL_CTX`

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -879,6 +879,7 @@ static HANDSHAKE_RESULT *do_handshake_internal(
     const unsigned char *proto = NULL;
     /* API dictates unsigned int rather than size_t. */
     unsigned int proto_len = 0;
+    EVP_PKEY *tmp_key;
 
     memset(&server_ctx_data, 0, sizeof(server_ctx_data));
     memset(&server2_ctx_data, 0, sizeof(server2_ctx_data));
@@ -1037,6 +1038,19 @@ static HANDSHAKE_RESULT *do_handshake_internal(
 
     if (session_out != NULL)
         *session_out = SSL_get1_session(client.ssl);
+
+    if (SSL_get_server_tmp_key(client.ssl, &tmp_key)) {
+        int nid;
+        nid = EVP_PKEY_id(tmp_key);
+#ifndef OPENSSL_NO_EC
+        if (nid == EVP_PKEY_EC) {
+            EC_KEY *ec = EVP_PKEY_get0_EC_KEY(tmp_key);
+            nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
+        }
+#endif
+        EVP_PKEY_free(tmp_key);
+        ret->tmp_key_type = nid;
+    }
 
     ctx_data_free_data(&server_ctx_data);
     ctx_data_free_data(&server2_ctx_data);

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1040,8 +1040,7 @@ static HANDSHAKE_RESULT *do_handshake_internal(
         *session_out = SSL_get1_session(client.ssl);
 
     if (SSL_get_server_tmp_key(client.ssl, &tmp_key)) {
-        int nid;
-        nid = EVP_PKEY_id(tmp_key);
+        int nid = EVP_PKEY_id(tmp_key);
 #ifndef OPENSSL_NO_EC
         if (nid == EVP_PKEY_EC) {
             EC_KEY *ec = EVP_PKEY_get0_EC_KEY(tmp_key);

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -43,6 +43,8 @@ typedef struct handshake_result {
     /* Was the handshake resumed? */
     int client_resumed;
     int server_resumed;
+    /* Temporary key type */
+    int tmp_key_type;
 } HANDSHAKE_RESULT;
 
 HANDSHAKE_RESULT *HANDSHAKE_RESULT_new(void);

--- a/test/ssl-tests/14-curves.conf
+++ b/test/ssl-tests/14-curves.conf
@@ -55,6 +55,7 @@ VerifyMode = Peer
 
 [test-0]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect163k1
 
 
 # ===========================================================
@@ -81,6 +82,7 @@ VerifyMode = Peer
 
 [test-1]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect163r1
 
 
 # ===========================================================
@@ -107,6 +109,7 @@ VerifyMode = Peer
 
 [test-2]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect163r2
 
 
 # ===========================================================
@@ -133,6 +136,7 @@ VerifyMode = Peer
 
 [test-3]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect193r1
 
 
 # ===========================================================
@@ -159,6 +163,7 @@ VerifyMode = Peer
 
 [test-4]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect193r2
 
 
 # ===========================================================
@@ -185,6 +190,7 @@ VerifyMode = Peer
 
 [test-5]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect233k1
 
 
 # ===========================================================
@@ -211,6 +217,7 @@ VerifyMode = Peer
 
 [test-6]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect233r1
 
 
 # ===========================================================
@@ -237,6 +244,7 @@ VerifyMode = Peer
 
 [test-7]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect239k1
 
 
 # ===========================================================
@@ -263,6 +271,7 @@ VerifyMode = Peer
 
 [test-8]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect283k1
 
 
 # ===========================================================
@@ -289,6 +298,7 @@ VerifyMode = Peer
 
 [test-9]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect283r1
 
 
 # ===========================================================
@@ -315,6 +325,7 @@ VerifyMode = Peer
 
 [test-10]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect409k1
 
 
 # ===========================================================
@@ -341,6 +352,7 @@ VerifyMode = Peer
 
 [test-11]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect409r1
 
 
 # ===========================================================
@@ -367,6 +379,7 @@ VerifyMode = Peer
 
 [test-12]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect571k1
 
 
 # ===========================================================
@@ -393,6 +406,7 @@ VerifyMode = Peer
 
 [test-13]
 ExpectedResult = Success
+ExpectedTmpKeyType = sect571r1
 
 
 # ===========================================================
@@ -419,6 +433,7 @@ VerifyMode = Peer
 
 [test-14]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp160k1
 
 
 # ===========================================================
@@ -445,6 +460,7 @@ VerifyMode = Peer
 
 [test-15]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp160r1
 
 
 # ===========================================================
@@ -471,6 +487,7 @@ VerifyMode = Peer
 
 [test-16]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp160r2
 
 
 # ===========================================================
@@ -497,6 +514,7 @@ VerifyMode = Peer
 
 [test-17]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp192k1
 
 
 # ===========================================================
@@ -523,6 +541,7 @@ VerifyMode = Peer
 
 [test-18]
 ExpectedResult = Success
+ExpectedTmpKeyType = prime192v1
 
 
 # ===========================================================
@@ -549,6 +568,7 @@ VerifyMode = Peer
 
 [test-19]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp224k1
 
 
 # ===========================================================
@@ -575,6 +595,7 @@ VerifyMode = Peer
 
 [test-20]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp224r1
 
 
 # ===========================================================
@@ -601,6 +622,7 @@ VerifyMode = Peer
 
 [test-21]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp256k1
 
 
 # ===========================================================
@@ -627,6 +649,7 @@ VerifyMode = Peer
 
 [test-22]
 ExpectedResult = Success
+ExpectedTmpKeyType = prime256v1
 
 
 # ===========================================================
@@ -653,6 +676,7 @@ VerifyMode = Peer
 
 [test-23]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp384r1
 
 
 # ===========================================================
@@ -679,6 +703,7 @@ VerifyMode = Peer
 
 [test-24]
 ExpectedResult = Success
+ExpectedTmpKeyType = secp521r1
 
 
 # ===========================================================
@@ -705,6 +730,7 @@ VerifyMode = Peer
 
 [test-25]
 ExpectedResult = Success
+ExpectedTmpKeyType = brainpoolP256r1
 
 
 # ===========================================================
@@ -731,6 +757,7 @@ VerifyMode = Peer
 
 [test-26]
 ExpectedResult = Success
+ExpectedTmpKeyType = brainpoolP384r1
 
 
 # ===========================================================
@@ -757,6 +784,7 @@ VerifyMode = Peer
 
 [test-27]
 ExpectedResult = Success
+ExpectedTmpKeyType = brainpoolP512r1
 
 
 # ===========================================================
@@ -783,5 +811,6 @@ VerifyMode = Peer
 
 [test-28]
 ExpectedResult = Success
+ExpectedTmpKeyType = X25519
 
 

--- a/test/ssl-tests/14-curves.conf.in
+++ b/test/ssl-tests/14-curves.conf.in
@@ -35,7 +35,10 @@ sub generate_tests() {
 		"CipherString" => "ECDHE",
                 "Curves" => $curve
             },
-            test   => { "ExpectedResult" => "Success" },
+            test   => {
+                "ExpectedTmpKeyType" => $curve,
+                "ExpectedResult" => "Success"
+            },
         };
     }
 }

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -187,6 +187,17 @@ static int check_resumption(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
     return 1;
 }
 
+static int check_tmp_key(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
+{
+    if (test_ctx->expected_tmp_key_type == 0
+        || test_ctx->expected_tmp_key_type == result->tmp_key_type)
+        return 1;
+    fprintf(stderr, "Tmp key type mismatch, %s vs %s\n",
+            OBJ_nid2ln(test_ctx->expected_tmp_key_type),
+            OBJ_nid2ln(result->tmp_key_type));
+    return 0;
+}
+
 /*
  * This could be further simplified by constructing an expected
  * HANDSHAKE_RESULT, and implementing comparison methods for
@@ -207,6 +218,7 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
 #endif
         ret &= check_alpn(result, test_ctx);
         ret &= check_resumption(result, test_ctx);
+        ret &= check_tmp_key(result, test_ctx);
     }
     return ret;
 }

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -440,6 +440,7 @@ __owur static int parse_expected_tmp_key_type(SSL_TEST_CTX *test_ctx,
                                               const char *value)
 {
     int nid;
+
     if (value == NULL)
         return 0;
     nid = OBJ_sn2nid(value);

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -432,6 +432,29 @@ IMPLEMENT_SSL_TEST_INT_OPTION(SSL_TEST_CTX, test, app_data_size)
 
 IMPLEMENT_SSL_TEST_INT_OPTION(SSL_TEST_CTX, test, max_fragment_size)
 
+/***********************/
+/* ExpectedTmpKeyType  */
+/***********************/
+
+__owur static int parse_expected_tmp_key_type(SSL_TEST_CTX *test_ctx,
+                                              const char *value)
+{
+    int nid;
+    if (value == NULL)
+        return 0;
+    nid = OBJ_sn2nid(value);
+    if (nid == NID_undef)
+        nid = OBJ_ln2nid(value);
+#ifndef OPENSSL_NO_EC
+    if (nid == NID_undef)
+        nid = EC_curve_nist2nid(value);
+#endif
+    if (nid == NID_undef)
+        return 0;
+    test_ctx->expected_tmp_key_type = nid;
+    return 1;
+}
+
 /*************************************************************/
 /* Known test options and their corresponding parse methods. */
 /*************************************************************/
@@ -456,6 +479,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ResumptionExpected", &parse_test_resumption_expected },
     { "ApplicationData", &parse_test_app_data_size },
     { "MaxFragmentSize", &parse_test_max_fragment_size },
+    { "ExpectedTmpKeyType", &parse_expected_tmp_key_type },
 };
 
 /* Nested client options. */

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -159,6 +159,8 @@ typedef struct {
     char *expected_alpn_protocol;
     /* Whether the second handshake is resumed or a full handshake (boolean). */
     int resumption_expected;
+    /* Expected temporary key type */
+    int expected_tmp_key_type;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This adds a new test option so we can check the server temp key is of the expected type. It also extends the existing curve selection test to check the curve the server uses.