### PR TITLE
Fix running tests on Android by tweaking interpreter paths

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -187,7 +187,7 @@ DSO_LDFLAGS=$(LIB_LDFLAGS)
 BIN_CFLAGS={- $target{bin_cflags} -}
 BIN_CXXFLAGS={- $target{bin_cxxflag} || "" -}
 
-PERL={- $config{perl} -}
+PERL?={- $config{perl} -}
 
 ARFLAGS= {- $target{arflags} -}
 AR=$(CROSS_COMPILE){- $target{ar} || "ar" -} $(ARFLAGS) r

--- a/Configure
+++ b/Configure
@@ -970,6 +970,8 @@ $config{cross_compile_prefix} = $ENV{'CROSS_COMPILE'}
 $config{perl} =    ($^O ne "VMS" ? $^X : "perl");
 $config{hashbangperl} =
     $ENV{'HASHBANGPERL'}           || $ENV{'PERL'}     || "/usr/bin/env perl";
+$config{hashbangsh}   =
+    $ENV{'HASHBANGSH'}             || "/bin/sh";
 $target{cc} =      $ENV{'CC'}      || $target{cc}      || "cc";
 $target{cxx} =     $ENV{'CXX'}     || $target{cxx}     || "c++";
 $target{ranlib} =  $ENV{'RANLIB'}  || $target{ranlib}  ||

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!{- $config{hashbangsh} -}
 
 [ $# -ne 0 ] || set -x		# debug mode without arguments:-)
 


### PR DESCRIPTION
##### Checklist
- [ ] documentation is added or updated
  Currently Android support is incomplete, especially for the ./Configure step. I'd like to postpone documentation until everything is set.
- [x] tests are added or updated
- [ ] CLA is signed (I don't remember whether I've signed or not, sorry)

##### Description of change

My patch fixes two issues relating to running tests on Android devices.

1. On the device perl may not be installed in the same path as the building host, so I allow PERL to be overridden. For example, I use the following command to run tests on Android:
```
PERL=$(which perl) make test
```
The hashbangperl approach does not always work as perl, unlike sh, is not built-in in Android. It's likely that path to third-party perl builds are unknown during the build time, while some tests require an absolute path in $PERL.

2. Android put the default shell at /system/bin/sh instead of /bin/sh. I create a variable so that packagers can choose a different interpreter path for sh, or tests may fail. An example usage can be:
```
export HASHBANGSH=/system/bin/sh
./Configure android-xxx
```
I don't include ```$ENV{SHELL}``` in candidates as it might points to /bin/bash or even /bin/zsh, which may break tests. I don't use ```/usr/bin/env sh``` either as on Android there's no /usr/bin/env but only /system/bin/env.

An example run for tests on Android can be found at https://github.com/openssl/openssl/issues/1531#issuecomment-255370578