### PR TITLE
Clarify a line in asm code

### DIFF
--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -251,7 +251,7 @@ $code.=<<___	if ($avx>2);
 	jc	.LChaCha20_avx512
 ___
 $code.=<<___;
-	test	\$`1<<(41-32)`,%r10d
+	test	\$`1<<9`,%r10d		# check for SSSE3
 	jnz	.LChaCha20_ssse3
 
 	push	%rbx


### PR DESCRIPTION
41-32 is 9, and that's the bit for SSSE3, so add a comment clarifying that that's what we're testing.
Don't need to believe me. crypto/sha/asm/sha1-x86_64.pl:263 performs the same check, and has a comment.