### PR TITLE
Mark a HelloRequest record as read

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1430,7 +1430,12 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
                         return -1;
                     }
                 }
+            } else {
+                SSL3_RECORD_set_read(rr);
             }
+        } else {
+            /* Does this ever happen? */
+            SSL3_RECORD_set_read(rr);
         }
         /*
          * we either finished a handshake or ignored the request, now try


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Otherwise the client will try to process it again. The second time around
it will try and move the record data into handshake fragment storage and
realise that there is no data left. At that point it marks it as read
anyway. However, it is a bug that we go around the loop a second time, so
we prevent that.