### PR TITLE
Check the exit code from the server process

### DIFF
--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -315,6 +315,7 @@ sub clientstart
         print "Waiting for server process to close: "
               .$self->serverpid."\n";
         waitpid( $self->serverpid, 0);
+        die "exit code $? from server process\n" if $? != 0;
     }
     return 1;
 }


### PR DESCRIPTION
Check the exit code from the server, and make the test suite fail if non-zero.

Should work for master and 1_1_0-stable