### PR TITLE
Pointer should be checked to avoid null dereferencing later.

### DIFF
--- a/crypto/include/internal/md32_common.h
+++ b/crypto/include/internal/md32_common.h
@@ -253,7 +253,7 @@ int HASH_UPDATE(HASH_CTX *c, const void *data_, size_t len)
     HASH_LONG l;
     size_t n;
 
-    if (len == 0)
+    if (data == NULL || len == 0)
         return 1;
 
     l = (c->Nl + (((HASH_LONG) len) << 3)) & 0xffffffffUL;


### PR DESCRIPTION
As an example a call to PKCS5_PBKDF2_HMAC( str, str_len, salt, sizeof(salt), ... ) results in  application crashes in memcpy() line 306 when no salt is used.

- [x] CLA is signed