### PR TITLE
WIP: Access OPENSSL_ia32cap_P via 32-bit words

### DIFF
--- a/crypto/bn/asm/x86_64-gf2m.pl
+++ b/crypto/bn/asm/x86_64-gf2m.pl
@@ -174,8 +174,8 @@ $code.=<<___;
 .type	bn_GF2m_mul_2x2,\@abi-omnipotent
 .align	16
 bn_GF2m_mul_2x2:
-	mov	OPENSSL_ia32cap_P(%rip),%rax
-	bt	\$33,%rax
+	mov	OPENSSL_ia32cap_P+4(%rip),%eax
+	bt	\$1,%eax
 	jnc	.Lvanilla_mul_2x2
 
 	movq		$a1,%xmm0


### PR DESCRIPTION
The OPENSSL_ia32cap_P bit vector is an array of 4 32-bit words.
Its declaration in crypto/cryptlib.c is not explicitly 64-bit
aligned, and 64-bit access may incur a performance penalty.

This commit addresses one case in which 64-bit access is used,
and if deemed acceptable, we should identify and fix the rest.

Reported by Christos Zoulas of NetBSD.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
- [ ] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
