### PR TITLE
Prefer SHA256 to SHA1 in examples

### DIFF
--- a/doc/man3/X509_digest.pod
+++ b/doc/man3/X509_digest.pod
@@ -40,7 +40,7 @@ All other functions described here return a digest of the DER representation
 of their entire B<data> objects.
 
 The B<type> parameter specifies the digest to
-be used, such as EVP_sha1(). The B<md> is a pointer to the buffer where the
+be used, such as EVP_sha256(). The B<md> is a pointer to the buffer where the
 digest will be copied and is assumed to be large enough; the constant
 B<EVP_MAX_MD_SIZE> is suggested. The B<len> parameter, if not NULL, points
 to a place where the digest size will be stored.


### PR DESCRIPTION
SHA1 is gradually being deprecated in favor of SHA256.  Though
examples in our manuals are not always intended to be suggestions
for runtime use, some readers will treat them as such -- we might
as well only mention the modern algorithms when there is a need
to mention a generic algorithm.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

trivial change of example