### PR TITLE
Fix man3 reference to CRYPTO_secure_used

### DIFF
--- a/doc/man3/OPENSSL_secure_malloc.pod
+++ b/doc/man3/OPENSSL_secure_malloc.pod
@@ -6,7 +6,7 @@ CRYPTO_secure_malloc_init, CRYPTO_secure_malloc_initialized,
 CRYPTO_secure_malloc_done, OPENSSL_secure_malloc, CRYPTO_secure_malloc,
 OPENSSL_secure_zalloc, CRYPTO_secure_zalloc, OPENSSL_secure_free,
 CRYPTO_secure_free, OPENSSL_secure_actual_size, OPENSSL_secure_allocated,
-CYRPTO_secure_used - secure heap storage
+CRYPTO_secure_used - secure heap storage
 
 =head1 SYNOPSIS
 
@@ -30,7 +30,7 @@ CYRPTO_secure_used - secure heap storage
  size_t OPENSSL_secure_actual_size(const void *ptr);
  int OPENSSL_secure_allocated(const void *ptr);
 
- size_t CYRPTO_secure_used();
+ size_t CRYPTO_secure_used();
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
Discovered a mismatch in man pages as part of helping someone. This change fixes the spelling in doc/man3 to match the symbol defined in include/openssl/crypto.h.