### PR TITLE
WIP: Add EC_FLAG_EXT_PKEY

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -482,3 +482,24 @@ size_t EVP_PKEY_get1_tls_encodedpoint(EVP_PKEY *pkey, unsigned char **ppt)
         return 0;
     return rv;
 }
+
+int EVP_PKEY_external_private_key(EVP_PKEY *pkey)
+{
+    /*
+     * Don't check the public/private key, this is mostly for smart
+     * cards, TPMs and other cases where the private key is in a
+     * different process space.
+     */
+#ifndef OPENSSL_NO_RSA
+    if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA
+        && (RSA_default_flags(EVP_PKEY_get0_RSA(pkey)) & RSA_METHOD_FLAG_NO_CHECK
+            || RSA_get_flags(EVP_PKEY_get0_RSA(pkey)) & RSA_FLAG_EXT_PKEY))
+        return 1;
+#endif
+#ifndef OPENSSL_NO_EC
+    if (EVP_PKEY_id(pkey) == EVP_PKEY_EC
+        && EC_KEY_get_flags(EVP_PKEY_get0_EC_KEY(pkey)) & EC_FLAG_EXT_PKEY)
+        return 1;
+#endif
+    return 0;
+}

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -302,6 +302,11 @@ int RSA_test_flags(const RSA *r, int flags)
     return r->flags & flags;
 }
 
+int RSA_get_flags(const RSA *r)
+{
+    return r->flags;
+}
+
 void RSA_set_flags(RSA *r, int flags)
 {
     r->flags |= flags;

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -1,3 +1,4 @@
+
 =pod
 
 =head1 NAME
@@ -105,11 +106,17 @@ point_conversion_forms please see L<EC_POINT_new(3)>.
 
 EC_KEY_set_flags() sets the flags in the B<flags> parameter on the EC_KEY
 object. Any flags that are already set are left set. The flags currently
-defined are EC_FLAG_NON_FIPS_ALLOW and EC_FLAG_FIPS_CHECKED. In
-addition there is the flag EC_FLAG_COFACTOR_ECDH which is specific to ECDH.
+defined are EC_FLAG_NON_FIPS_ALLOW, EC_FLAG_FIPS_CHECKED and EC_FLAG_NO_CHECK.
+In addition there is the flag EC_FLAG_COFACTOR_ECDH which is specific to ECDH.
 EC_KEY_get_flags() returns the current flags that are set for this EC_KEY.
 EC_KEY_clear_flags() clears the flags indicated by the B<flags> parameter; all
 other flags are left in their existing state.
+
+The EC_FLAG_NON_FIPS_ALLOW and EC_FLAG_FIPS_CHECKED flags are obsolete with the
+removal of FIPS support from  OpenSSL 1.1.0. The EC_FLAG_NO_CHECK prevents
+checking the private/public key parts against each other, and is intended to
+be used by ENGINEs that keep private keys in TPMs or other secure memory areas,
+similar to RSA_METHOD_FLAG_NO_CHECK.
 
 EC_KEY_set_asn1_flag() sets the asn1_flag on the underlying EC_GROUP object
 (if set). Refer to L<EC_GROUP_copy(3)> for further information on the

--- a/doc/man3/EVP_PKEY_cmp.pod
+++ b/doc/man3/EVP_PKEY_cmp.pod
@@ -15,6 +15,8 @@ EVP_PKEY_cmp - public key parameter and comparison functions
  int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b);
  int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b);
 
+ int EVP_PKEY_external_private_key(const EVP_PKEY *pkey);
+
 =head1 DESCRIPTION
 
 The function EVP_PKEY_missing_parameters() returns 1 if the public key
@@ -31,6 +33,9 @@ B<a> and B<b>.
 
 The function EVP_PKEY_cmp() compares the public key components and parameters
 (if present) of keys B<a> and B<b>.
+
+The function EVP_PKEY_external_private_key() is used to indicate whether or
+not the private key is stored externally.
 
 =head1 NOTES
 
@@ -55,6 +60,11 @@ failure.
 The function EVP_PKEY_cmp_parameters() and EVP_PKEY_cmp() return 1 if the
 keys match, 0 if they don't match, -1 if the key types are different and
 -2 if the operation is not supported.
+
+The function EVP_PKEY_external_private_key() returns 1 if the flags on the
+b<pkey> indicate the private key is stored externally. Otherwise, 0 is
+returned. The flags checked are B<EC_FLAG_EXT_PKEY>, B<RSA_FLAG_EXT_PKEY> and
+B<RSA_METHOD_FLAG_NO_CHECK>.
 
 =head1 SEE ALSO
 

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -4,8 +4,8 @@
 
 RSA_set0_key, RSA_set0_factors, RSA_set0_crt_params, RSA_get0_key,
 RSA_get0_factors, RSA_get0_crt_params, RSA_clear_flags,
-RSA_test_flags, RSA_set_flags, RSA_get0_engine - Routines for getting
-and setting data in an RSA object
+RSA_test_flags, RSA_get_flags, RSA_set_flags, RSA_get0_engine -
+Routines for getting and setting data in an RSA object
 
 =head1 SYNOPSIS
 
@@ -22,6 +22,7 @@ and setting data in an RSA object
                           const BIGNUM **iqmp);
  void RSA_clear_flags(RSA *r, int flags);
  int RSA_test_flags(const RSA *r, int flags);
+ int RSA_get_flags(const RSA *r);
  void RSA_set_flags(RSA *r, int flags);
  ENGINE *RSA_get0_engine(RSA *r);
 
@@ -60,7 +61,8 @@ RSA_get0_crt_params() and RSA_set0_crt_params().
 
 RSA_set_flags() sets the flags in the B<flags> parameter on the RSA
 object. Multiple flags can be passed in one go (bitwise ORed together).
-Any flags that are already set are left set. RSA_test_flags() tests to
+Any flags that are already set are left set. RSA_get_flags() returns
+all flags that are currently set. RSA_test_flags() tests to
 see whether the flags passed in the B<flags> parameter are currently
 set in the RSA object. Multiple flags can be tested in one go. All
 flags that are currently set are returned, or zero if none of the

--- a/doc/man3/RSA_set_method.pod
+++ b/doc/man3/RSA_set_method.pod
@@ -4,7 +4,7 @@
 
 RSA_set_default_method, RSA_get_default_method, RSA_set_method,
 RSA_get_method, RSA_PKCS1_OpenSSL, RSA_null_method, RSA_flags,
-RSA_new_method - select RSA method
+RSA_default_flags, RSA_new_method - select RSA method
 
 =head1 SYNOPSIS
 
@@ -23,6 +23,8 @@ RSA_new_method - select RSA method
  RSA_METHOD *RSA_null_method(void);
 
  int RSA_flags(const RSA *rsa);
+
+ int RSA_default_flags(const RSA *rsa);
 
  RSA *RSA_new_method(ENGINE *engine);
 
@@ -62,7 +64,8 @@ RSA key itself is valid and does not have its implementation changed by
 RSA_set_method().
 
 RSA_flags() returns the B<flags> that are set for B<rsa>'s current
-RSA_METHOD. See the BUGS section.
+RSA_METHOD. RSA_default_flags() is an alias of this function. See the
+BUGS section.
 
 RSA_new_method() allocates and initializes an RSA structure so that
 B<engine> will be used for the RSA operations. If B<engine> is NULL, the
@@ -161,8 +164,10 @@ itself, not by the B<flags> value in the RSA_METHOD attached to the RSA key
 (which is what this function returns). If the flags element of an RSA key
 is changed, the changes will be honoured by RSA functionality but will not
 be reflected in the return value of the RSA_flags() function - in effect
-RSA_flags() behaves more like an RSA_default_flags() function (which does
-not currently exist).
+RSA_flags() behaves more like an RSA_default_flags() function (which is
+defined as an alias of RSA_flags).
+
+Use RSA_get_flags() to get the flags from the RSA object.
 
 =head1 SEE ALSO
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -743,6 +743,7 @@ int ECPKParameters_print_fp(FILE *fp, const EC_GROUP *x, int off);
 /* some values for the flags field */
 # define EC_FLAG_NON_FIPS_ALLOW  0x1
 # define EC_FLAG_FIPS_CHECKED    0x2
+# define EC_FLAG_EXT_PKEY        0x4
 # define EC_FLAG_COFACTOR_ECDH   0x1000
 
 /** Creates a new EC_KEY object.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -963,6 +963,7 @@ int EVP_PKEY_get_default_digest_nid(EVP_PKEY *pkey, int *pnid);
 int EVP_PKEY_set1_tls_encodedpoint(EVP_PKEY *pkey,
                                    const unsigned char *pt, size_t ptlen);
 size_t EVP_PKEY_get1_tls_encodedpoint(EVP_PKEY *pkey, unsigned char **ppt);
+int EVP_PKEY_external_private_key(EVP_PKEY *pkey);
 
 int EVP_CIPHER_type(const EVP_CIPHER *ctx);
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -56,6 +56,7 @@ extern "C" {
  * and that they do not depend on the private key components being present:
  * for example a key stored in external hardware. Without this flag
  * bn_mod_exp gets called when private key components are absent.
+ * This flag works with RSA_METHOD_FLAG_NO_CHECK
  */
 # define RSA_FLAG_EXT_PKEY               0x0020
 
@@ -224,7 +225,12 @@ void RSA_free(RSA *r);
 /* "up" the RSA object's reference count */
 int RSA_up_ref(RSA *r);
 
+/* This gets the flags from the RSA_METHOD */
 int RSA_flags(const RSA *r);
+/* A more meaningful name - as a macro for ABI compat */
+#define RSA_default_flags RSA_flags
+/* This gets the flags from the RSA */
+int RSA_get_flags(const RSA *r);
 
 void RSA_set_default_method(const RSA_METHOD *meth);
 const RSA_METHOD *RSA_get_default_method(void);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4224,3 +4224,5 @@ X509_VERIFY_PARAM_set_inh_flags         4174	1_1_0d	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_inh_flags         4175	1_1_0d	EXIST::FUNCTION:
 EVP_PKEY_CTX_md                         4176	1_1_1	EXIST::FUNCTION:
 RSA_pkey_ctx_ctrl                       4177	1_1_1	EXIST::FUNCTION:RSA
+RSA_get_flags                           4178	1_1_1	EXIST::FUNCTION:RSA
+EVP_PKEY_external_private_key           4179	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
RSA has the RSA_FLAG_EXT_PKEY and RSA_METHOD_FLAG_NO_CHECK that
are used to indicate whether a key should be checked because it
is stored externally. These flags are somewhat redundant in the
case of RSA, but are missing documentation, and are missing from
the EC code. So, add EC_FLAG_EXT_PKEY to allow an ENGINE
implementation of EC to store private EC keys external to OpenSSL.

This also adds some missing RSA functionality (i.e. flag retreival).

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
- [X] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
