### PR TITLE
sk_TYPE_dup and sk_TYPE_deep_copy: Avoid potential crash.

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -41,7 +41,7 @@ OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *sk)
 {
     OPENSSL_STACK *ret;
 
-    if (sk->num < 0)
+    if (sk == NULL || sk->num < 0)
         return NULL;
 
     if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL)
@@ -66,7 +66,7 @@ OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *sk,
     OPENSSL_STACK *ret;
     int i;
 
-    if (sk->num < 0)
+    if (sk == NULL || sk->num < 0)
         return NULL;
 
     if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL)


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CLA: Trivial.

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
These functions are now safe to use also when the given stack is NULL,
in analogy to the other functions that are perfectly safe in this case.
