### PR TITLE
Fix no-tls1_2

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -80,7 +80,7 @@ my %skip = (
   "16-dtls-certstatus.conf" => $no_dtls || $no_ocsp,
   "18-dtls-renegotiate.conf" => $no_dtls,
   "19-mac-then-encrypt.conf" => $no_pre_tls1_3,
-  "20-cert-select.conf" => $no_ec,
+  "20-cert-select.conf" => disabled("tls1_2") || $no_ec,
 );
 
 foreach my $conf (@conf_files) {


### PR DESCRIPTION
It seems that the ssl test 20-cert-select.conf dislikes the lack of TLSv1.2

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
