### PR TITLE
Add unused-args warning flags

### DIFF
--- a/Configure
+++ b/Configure
@@ -126,6 +126,7 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
         . " -Wtype-limits"
         . " -Wno-parentheses-equality"
         . " -Werror"
+        . " -Wunused-parameter"
         ;
 
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.
@@ -140,8 +141,8 @@ my $clang_devteam_warn = ""
         . " -Qunused-arguments"
         . " -Wextra"
         . " -Wswitch -Wswitch-default"
-        . " -Wno-unused-parameter"
         . " -Wno-parentheses-equality"
+        . " -Wunused-parameter"
         . " -Wno-missing-field-initializers"
         . " -Wno-language-extension-token"
         . " -Wno-extended-offsetof"

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -118,6 +118,7 @@ int chopup_args(ARGS *arg, char *buf)
 #ifndef APP_INIT
 int app_init(long mesgwin)
 {
+    (void)mesgwin;
     return (1);
 }
 #endif
@@ -1996,6 +1997,7 @@ static STACK_OF(X509_CRL) *crls_http_cb(X509_STORE_CTX *ctx, X509_NAME *nm)
     X509_CRL *crl;
     STACK_OF(DIST_POINT) *crldp;
 
+    (void)nm;
     crls = sk_X509_CRL_new_null();
     if (!crls)
         return NULL;

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -262,6 +262,7 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_tmp)
     PW_CB_DATA *cb_data = (PW_CB_DATA *)cb_tmp;
 
 #ifdef OPENSSL_NO_UI
+    (void)verify;
     if (cb_data != NULL && cb_data->password != NULL) {
         res = strlen(cb_data->password);
         if (res > bufsiz)
@@ -1255,9 +1256,9 @@ static ENGINE *try_load_engine(const char *engine)
 
 ENGINE *setup_engine(const char *engine, int debug)
 {
+#ifndef OPENSSL_NO_ENGINE
     ENGINE *e = NULL;
 
-#ifndef OPENSSL_NO_ENGINE
     if (engine) {
         if (strcmp(engine, "auto") == 0) {
             BIO_printf(bio_err, "enabling auto ENGINE support\n");
@@ -1283,8 +1284,12 @@ ENGINE *setup_engine(const char *engine, int debug)
 
         BIO_printf(bio_err, "engine \"%s\" set.\n", ENGINE_get_id(e));
     }
-#endif
     return e;
+#else
+    (void)engine;
+    (void)debug;
+    return NULL;
+#endif
 }
 
 void release_engine(ENGINE *e)
@@ -1293,6 +1298,8 @@ void release_engine(ENGINE *e)
     if (e != NULL)
         /* Free our "structural" reference. */
         ENGINE_free(e);
+#else
+    (void)e;
 #endif
 }
 

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -65,12 +65,20 @@ static unsigned int dummy_psk(SSL *ssl, const char *hint, char *identity,
                               unsigned char *psk,
                               unsigned int max_psk_len)
 {
+    (void)ssl;
+    (void)hint;
+    (void)identity;
+    (void)max_identity_len;
+    (void)psk;
+    (void)max_psk_len;
     return 0;
 }
 #endif
 #ifndef OPENSSL_NO_SRP
 static char *dummy_srp(SSL *ssl, void *arg)
 {
+    (void)ssl;
+    (void)arg;
     return "";
 }
 #endif

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -365,6 +365,7 @@ static int dh_cb(int p, int n, BN_GENCB *cb)
 {
     char c = '*';
 
+    (void)n;
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -294,6 +294,7 @@ static int dsa_cb(int p, int n, BN_GENCB *cb)
 {
     char c = '*';
 
+    (void)n;
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -224,6 +224,7 @@ static void util_do_cmds(ENGINE *e, STACK_OF(OPENSSL_STRING) *cmds,
 {
     int loop, res, num = sk_OPENSSL_STRING_num(cmds);
 
+    (void)indent;
     if (num < 0) {
         BIO_printf(out, "[Error]: internal stack error\n");
         return;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -177,6 +177,7 @@ static int genrsa_cb(int p, int n, BN_GENCB *cb)
 {
     char c = '*';
 
+    (void)n;
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -992,6 +992,7 @@ static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser)
 static BIO *init_responder(const char *port)
 {
 # ifdef OPENSSL_NO_SOCK
+    (void)port;
     BIO_printf(bio_err,
                "Error setting up accept BIO - sockets not supported.\n");
     return NULL;
@@ -1056,6 +1057,9 @@ static int urldecode(char *p)
 static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio)
 {
 # ifdef OPENSSL_NO_SOCK
+    (void)preq;
+    (void)pcbio;
+    (void)acbio;
     return 0;
 # else
     int len;

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -457,6 +457,8 @@ int help_main(int argc, char **argv)
 
 int exit_main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
     return EXIT_THE_PROGRAM;
 }
 

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -344,6 +344,10 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
     char *passin = NULL;
     int rv = -1;
     X509 *x;
+
+#ifdef OPENSSL_NO_ENGINE
+    (void)engine_impl;
+#endif
     if (((pkey_op == EVP_PKEY_OP_SIGN) || (pkey_op == EVP_PKEY_OP_DECRYPT)
          || (pkey_op == EVP_PKEY_OP_DERIVE))
         && (key_type != KEY_PRIVKEY && kdfalg == NULL)) {

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -416,9 +416,9 @@ int ssl_print_tmp_key(BIO *out, SSL *s)
 long bio_dump_callback(BIO *bio, int cmd, const char *argp,
                        int argi, long argl, long ret)
 {
-    BIO *out;
+    BIO *out = (BIO *)BIO_get_callback_arg(bio);
 
-    out = (BIO *)BIO_get_callback_arg(bio);
+    (void)argl;
     if (out == NULL)
         return (ret);
 
@@ -539,6 +539,7 @@ void msg_cb(int write_p, int version, int content_type, const void *buf,
     const char *str_content_type = "", *str_details1 = "", *str_details2 = "";
     const unsigned char* bp = buf;
 
+    (void)ssl;
     if (version == SSL3_VERSION ||
         version == TLS1_VERSION ||
         version == TLS1_1_VERSION ||
@@ -656,6 +657,7 @@ void tlsext_cb(SSL *s, int client_server, int type,
     BIO *bio = arg;
     const char *extname = lookup(type, tlsext_types, "unknown");
 
+    (void)s;
     BIO_printf(bio, "TLS %s extension \"%s\" (id=%d), len=%d\n",
                client_server ? "server" : "client", extname, type, len);
     BIO_dump(bio, (const char *)data, len);

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1362,6 +1362,7 @@ void ssl_ctx_security_debug(SSL_CTX *ctx, int verbose)
 
 static void keylog_callback(const SSL *ssl, const char *line)
 {
+    (void)ssl;
     if (bio_keylog == NULL) {
         BIO_printf(bio_err, "Keylog callback is invoked without valid file!\n");
         return;

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -416,9 +416,10 @@ int ssl_print_tmp_key(BIO *out, SSL *s)
 long bio_dump_callback(BIO *bio, int cmd, const char *argp,
                        int argi, long argl, long ret)
 {
-    BIO *out = (BIO *)BIO_get_callback_arg(bio);
+    BIO *out;
 
     (void)argl;
+    out = (BIO *)BIO_get_callback_arg(bio);
     if (out == NULL)
         return (ret);
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -149,6 +149,7 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
     long key_len;
     unsigned char *key;
 
+    (void)ssl;
     if (c_debug)
         BIO_printf(bio_c_out, "psk_client_cb\n");
     if (!hint) {
@@ -208,6 +209,8 @@ static int ssl_servername_cb(SSL *s, int *ad, void *arg)
 {
     tlsextctx *p = (tlsextctx *) arg;
     const char *hn = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+
+    (void)ad;
     if (SSL_get_servername_type(s) != -1)
         p->ack = !SSL_session_reused(s) && hn != NULL;
     else
@@ -313,6 +316,7 @@ static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
     PW_CB_DATA cb_tmp;
     int l;
 
+    (void)s;
     cb_tmp.password = (char *)srp_arg->srppassin;
     cb_tmp.prompt_info = "SRP user";
     if ((l = password_callback(pass, PWD_STRLEN, 0, &cb_tmp)) < 0) {
@@ -345,6 +349,7 @@ static int next_proto_cb(SSL *s, unsigned char **out, unsigned char *outlen,
 {
     tlsextnextprotoctx *ctx = arg;
 
+    (void)s;
     if (!c_quiet) {
         /* We can assume that |in| is syntactically valid. */
         unsigned i;
@@ -371,6 +376,9 @@ static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
     char pem_name[100];
     unsigned char ext_buf[4 + 65536];
 
+    (void)s;
+    (void)al;
+    (void)arg;
     /* Reconstruct the type/len fields prior to extension data */
     ext_buf[0] = ext_type >> 8;
     ext_buf[1] = ext_type & 0xFF;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -796,6 +796,7 @@ static int new_session_cb(SSL *S, SSL_SESSION *sess)
 {
     BIO *stmp = BIO_new_file(sess_out, "w");
 
+    (void)S;
     if (stmp == NULL) {
         BIO_printf(bio_err, "Error writing session file %s\n", sess_out);
     } else {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2093,6 +2093,9 @@ static int sv_body(int s, int stype, unsigned char *context)
     struct timeval *timeoutp;
 #endif
 
+#ifdef OPENSSL_NO_DTLS
+    (void)stype;
+#endif
     buf = app_malloc(bufsize, "server buffer");
     if (s_nbio) {
         if (!BIO_socket_nbio(s, 1))
@@ -3276,12 +3279,12 @@ typedef struct simple_ssl_session_st {
 
 static simple_ssl_session *first = NULL;
 
-static int add_session(SSL *s, SSL_SESSION *session)
+static int add_session(SSL *ssl, SSL_SESSION *session)
 {
     simple_ssl_session *sess = app_malloc(sizeof(*sess), "get session");
     unsigned char *p;
 
-    (void)s;
+    (void)ssl;
     SSL_SESSION_get_id(session, &sess->idlen);
     sess->derlen = i2d_SSL_SESSION(session, NULL);
     if (sess->derlen < 0) {
@@ -3316,12 +3319,12 @@ static int add_session(SSL *s, SSL_SESSION *session)
     return 0;
 }
 
-static SSL_SESSION *get_session(SSL *s, const unsigned char *id, int idlen,
+static SSL_SESSION *get_session(SSL *ssl, const unsigned char *id, int idlen,
                                 int *do_copy)
 {
     simple_ssl_session *sess;
 
-    (void)s;
+    (void)ssl;
     *do_copy = 0;
     for (sess = first; sess; sess = sess->next) {
         if (idlen == (int)sess->idlen && !memcmp(sess->id, id, idlen)) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -147,14 +147,14 @@ static int dtlslisten = 0;
 static char *psk_identity = "Client_identity";
 char *psk_key = NULL;           /* by default PSK is not used */
 
-static unsigned int psk_server_cb(SSL *s, const char *identity,
+static unsigned int psk_server_cb(SSL *ssl, const char *identity,
                                   unsigned char *psk,
                                   unsigned int max_psk_len)
 {
     long key_len = 0;
     unsigned char *key;
 
-    (void)s;
+    (void)ssl;
     if (s_debug)
         BIO_printf(bio_s_out, "psk_server_cb\n");
     if (!identity) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -147,13 +147,14 @@ static int dtlslisten = 0;
 static char *psk_identity = "Client_identity";
 char *psk_key = NULL;           /* by default PSK is not used */
 
-static unsigned int psk_server_cb(SSL *ssl, const char *identity,
+static unsigned int psk_server_cb(SSL *s, const char *identity,
                                   unsigned char *psk,
                                   unsigned int max_psk_len)
 {
     long key_len = 0;
     unsigned char *key;
 
+    (void)s;
     if (s_debug)
         BIO_printf(bio_s_out, "psk_server_cb\n");
     if (!identity) {
@@ -430,6 +431,8 @@ static int ssl_servername_cb(SSL *s, int *ad, void *arg)
 {
     tlsextctx *p = (tlsextctx *) arg;
     const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+
+    (void)ad;
     if (servername && p->biodebug)
         BIO_printf(p->biodebug, "Hostname in TLS extension: \"%s\"\n",
                    servername);
@@ -637,6 +640,7 @@ static int next_proto_cb(SSL *s, const unsigned char **data,
 {
     tlsextnextprotoctx *next_proto = arg;
 
+    (void)s;
     *data = next_proto->data;
     *len = next_proto->len;
 
@@ -655,6 +659,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
 {
     tlsextalpnctx *alpn_ctx = arg;
 
+    (void)s;
     if (!s_quiet) {
         /* We can assume that |in| is syntactically valid. */
         unsigned int i;
@@ -685,6 +690,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
 
 static int not_resumable_sess_cb(SSL *s, int is_forward_secure)
 {
+    (void)s;
     /* disable resumption for sessions with forward secure ciphers */
     return is_forward_secure;
 }
@@ -2701,6 +2707,7 @@ static int www_body(int s, int stype, unsigned char *context)
     int width;
     fd_set readfds;
 
+    (void)stype;
     /* Set width for a select call if needed */
     width = s + 1;
 
@@ -3080,6 +3087,7 @@ static int rev_body(int s, int stype, unsigned char *context)
     SSL *con;
     BIO *io, *ssl_bio, *sbio;
 
+    (void)stype;
     buf = app_malloc(bufsize, "server rev buffer");
     io = BIO_new(BIO_f_buffer());
     ssl_bio = BIO_new(BIO_f_ssl());
@@ -3268,11 +3276,12 @@ typedef struct simple_ssl_session_st {
 
 static simple_ssl_session *first = NULL;
 
-static int add_session(SSL *ssl, SSL_SESSION *session)
+static int add_session(SSL *s, SSL_SESSION *session)
 {
     simple_ssl_session *sess = app_malloc(sizeof(*sess), "get session");
     unsigned char *p;
 
+    (void)s;
     SSL_SESSION_get_id(session, &sess->idlen);
     sess->derlen = i2d_SSL_SESSION(session, NULL);
     if (sess->derlen < 0) {
@@ -3307,10 +3316,12 @@ static int add_session(SSL *ssl, SSL_SESSION *session)
     return 0;
 }
 
-static SSL_SESSION *get_session(SSL *ssl, const unsigned char *id, int idlen,
+static SSL_SESSION *get_session(SSL *s, const unsigned char *id, int idlen,
                                 int *do_copy)
 {
     simple_ssl_session *sess;
+
+    (void)s;
     *do_copy = 0;
     for (sess = first; sess; sess = sess->next) {
         if (idlen == (int)sess->idlen && !memcmp(sess->id, id, idlen)) {
@@ -3328,6 +3339,8 @@ static void del_session(SSL_CTX *sctx, SSL_SESSION *session)
     simple_ssl_session *sess, *prev = NULL;
     const unsigned char *id;
     unsigned int idlen;
+
+    (void)sctx;
     id = SSL_SESSION_get_id(session, &idlen);
     for (sess = first; sess; sess = sess->next) {
         if (idlen == sess->idlen && !memcmp(sess->id, id, idlen)) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -275,6 +275,7 @@ static const char rnd_seed[] =
 static SIGRETTYPE sig_done(int sig);
 static SIGRETTYPE sig_done(int sig)
 {
+    (void)sig;
     signal(SIGALRM, sig_done);
     run = 0;
 }
@@ -2895,6 +2896,7 @@ int speed_main(int argc, char **argv)
 
 static void print_message(const char *s, long num, int length)
 {
+    (void)num;
 #ifdef SIGALRM
     BIO_printf(bio_err,
                mr ? "+DT:%s:%d:%d\n"
@@ -2912,6 +2914,7 @@ static void print_message(const char *s, long num, int length)
 static void pkey_print_message(const char *str, const char *str2, long num,
                                int bits, int tm)
 {
+    (void)num;
 #ifdef SIGALRM
     BIO_printf(bio_err,
                mr ? "+DTP:%d:%s:%s:%d\n"

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -987,6 +987,7 @@ static X509_STORE *create_cert_store(const char *CApath, const char *CAfile,
 
 static int verify_cb(int ok, X509_STORE_CTX *ctx)
 {
+    (void)ctx;
     return ok;
 }
 #endif  /* ndef OPENSSL_NO_TS */

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -683,6 +683,10 @@ static TS_RESP *create_response(CONF *conf, const char *section, const char *eng
     BIO *query_bio = NULL;
     TS_RESP_CTX *resp_ctx = NULL;
 
+#ifdef OPENSSL_NO_ENGINE
+    (void)engine;
+#endif
+
     if ((query_bio = BIO_new_file(queryfile, "rb")) == NULL)
         goto end;
     if ((section = TS_CONF_get_tsa_section(conf, section)) == NULL)

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -177,6 +177,7 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
     const unsigned char *iv;
     const unsigned char *iv2;
 
+    (void)key2;
     OPENSSL_assert(in && out && key && ivec);
     OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));
     OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -42,6 +42,7 @@ void *ASN1_d2i_bio(void *(*xnew) (void), d2i_of_void *d2i, BIO *in, void **x)
     void *ret = NULL;
     int len;
 
+    (void)xnew;
     len = asn1_d2i_read_bio(in, &b);
     if (len < 0)
         goto err;

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -248,9 +248,10 @@ static int traverse_string(const unsigned char *p, int len, int inform,
 
 static int in_utf8(unsigned long value, void *arg)
 {
-    int *nchar = arg;
+    int *nchar;
 
     (void)value;
+    nchar = arg;
     (*nchar)++;
     return 1;
 }

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -248,8 +248,9 @@ static int traverse_string(const unsigned char *p, int len, int inform,
 
 static int in_utf8(unsigned long value, void *arg)
 {
-    int *nchar;
-    nchar = arg;
+    int *nchar = arg;
+
+    (void)value;
     (*nchar)++;
     return 1;
 }

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -44,6 +44,7 @@ static int oid_module_init(CONF_IMODULE *md, const CONF *cnf)
 
 static void oid_module_finish(CONF_IMODULE *md)
 {
+    (void)md;
 }
 
 void ASN1_add_oid_module(void)

--- a/crypto/asn1/asn_mstbl.c
+++ b/crypto/asn1/asn_mstbl.c
@@ -42,6 +42,7 @@ static int stbl_module_init(CONF_IMODULE *md, const CONF *cnf)
 
 static void stbl_module_finish(CONF_IMODULE *md)
 {
+    (void)md;
     ASN1_STRING_TABLE_cleanup();
 }
 

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -107,6 +107,7 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     unsigned char *p;
     int derlen;
 
+    (void)b;
     if (!parg)
         return 0;
 
@@ -134,6 +135,7 @@ static int ndef_prefix_free(BIO *b, unsigned char **pbuf, int *plen,
 {
     NDEF_SUPPORT *ndef_aux;
 
+    (void)b;
     if (!parg)
         return 0;
 
@@ -166,6 +168,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     const ASN1_AUX *aux;
     ASN1_STREAM_ARG sarg;
 
+    (void)b;
     if (!parg)
         return 0;
 

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -19,6 +19,7 @@ int i2a_ASN1_STRING(BIO *bp, const ASN1_STRING *a, int type)
     static const char *h = "0123456789ABCDEF";
     char buf[2];
 
+    (void)type;
     if (a == NULL)
         return (0);
 

--- a/crypto/asn1/nsseq.c
+++ b/crypto/asn1/nsseq.c
@@ -16,6 +16,8 @@
 static int nsseq_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                     void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_NEW_POST) {
         NETSCAPE_CERT_SEQUENCE *nsseq;
         nsseq = (NETSCAPE_CERT_SEQUENCE *)*pval;

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -229,6 +229,8 @@ int PKCS5_v2_scrypt_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
     int rv = 0;
     SCRYPT_PARAMS *sparam = NULL;
 
+    (void)c;
+    (void)md;
     if (EVP_CIPHER_CTX_cipher(ctx) == NULL) {
         EVPerr(EVP_F_PKCS5_V2_SCRYPT_KEYIVGEN, EVP_R_NO_CIPHER_SET);
         goto err;

--- a/crypto/asn1/p8_pkey.c
+++ b/crypto/asn1/p8_pkey.c
@@ -17,6 +17,8 @@
 static int pkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                    void *exarg)
 {
+    (void)it;
+    (void)exarg;
     /* Since the structure must still be valid use ASN1_OP_FREE_PRE */
     if (operation == ASN1_OP_FREE_PRE) {
         PKCS8_PRIV_KEY_INFO *key = (PKCS8_PRIV_KEY_INFO *)*pval;

--- a/crypto/asn1/t_pkey.c
+++ b/crypto/asn1/t_pkey.c
@@ -50,6 +50,7 @@ int ASN1_bn_print(BIO *bp, const char *number, const BIGNUM *num,
     unsigned char *buf = NULL, *tmp = NULL;
     int buflen;
 
+    (void)ign;
     if (num == NULL)
         return 1;
     neg = BN_is_negative(num) ? "-" : "";

--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -64,6 +64,7 @@ ASN1_ITEM_end(CBIGNUM)
 
 static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
+    (void)it;
     *pval = (ASN1_VALUE *)BN_new();
     if (*pval != NULL)
         return 1;
@@ -73,6 +74,7 @@ static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
 
 static int bn_secure_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
+    (void)it;
     *pval = (ASN1_VALUE *)BN_secure_new();
     if (*pval != NULL)
         return 1;
@@ -96,6 +98,9 @@ static int bn_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
 {
     BIGNUM *bn;
     int pad;
+
+    (void)putype;
+    (void)it;
     if (!*pval)
         return -1;
     bn = (BIGNUM *)*pval;
@@ -117,6 +122,8 @@ static int bn_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 {
     BIGNUM *bn;
 
+    (void)utype;
+    (void)free_cont;
     if (*pval == NULL && !bn_new(pval, it))
         return 0;
     bn = (BIGNUM *)*pval;
@@ -138,6 +145,9 @@ static int bn_secure_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 static int bn_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *it,
                     int indent, const ASN1_PCTX *pctx)
 {
+    (void)it;
+    (void)indent;
+    (void)pctx;
     if (!BN_print(out, *(BIGNUM **)pval))
         return 0;
     if (BIO_puts(out, "\n") <= 0)

--- a/crypto/asn1/x_long.c
+++ b/crypto/asn1/x_long.c
@@ -65,6 +65,7 @@ static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
     /* this exists to bypass broken gcc optimization */
     char *cp = (char *)pval;
 
+    (void)putype;
     /* use memcpy, because we may not be long aligned */
     memcpy(&ltmp, cp, sizeof(long));
 
@@ -109,6 +110,9 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     long ltmp;
     unsigned long utmp = 0;
     char *cp = (char *)pval;
+
+    (void)utype;
+    (void)free_cont;
     if (len > (int)sizeof(long)) {
         ASN1err(ASN1_F_LONG_C2I, ASN1_R_INTEGER_TOO_LARGE_FOR_LONG);
         return 0;
@@ -142,5 +146,8 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 static int long_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *it,
                       int indent, const ASN1_PCTX *pctx)
 {
+    (void)it;
+    (void)indent;
+    (void)pctx;
     return BIO_printf(out, "%ld\n", *(long *)pval);
 }

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -41,6 +41,7 @@ int BIO_socket(int domain, int socktype, int protocol, int options)
 {
     int sock = -1;
 
+    (void)options;
     if (BIO_sock_init() != 1)
         return INVALID_SOCKET;
 

--- a/crypto/bio/bio_cb.c
+++ b/crypto/bio/bio_cb.c
@@ -24,6 +24,8 @@ long BIO_debug_callback(BIO *bio, int cmd, const char *argp,
     int len;
     size_t p_maxlen;
 
+    (void)argp;
+    (void)argl;
     if (BIO_CB_RETURN & cmd)
         r = ret;
 

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -18,16 +18,20 @@
  */
 BIO *BIO_new_fd(int fd, int close_flag)
 {
+    (void)fd;
+    (void)close_flag;
     return NULL;
 }
 
 int BIO_fd_non_fatal_error(int err)
 {
+    (void)err;
     return 0;
 }
 
 int BIO_fd_should_retry(int i)
 {
+    (void)i;
     return 0;
 }
 

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -368,30 +368,47 @@ static int file_puts(BIO *bp, const char *str)
 
 static int file_write(BIO *b, const char *in, int inl)
 {
+    (void)b;
+    (void)in;
+    (void)inl;
     return -1;
 }
 static int file_read(BIO *b, char *out, int outl)
 {
+    (void)b;
+    (void)out;
+    (void)outl;
     return -1;
 }
 static int file_puts(BIO *bp, const char *str)
 {
+    (void)bp;
+    (void)str;
     return -1;
 }
 static int file_gets(BIO *bp, char *buf, int size)
 {
+    (void)bp;
+    (void)buf;
+    (void)size;
     return 0;
 }
 static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
+    (void)b;
+    (void)cmd;
+    (void)num;
+    (void)ptr;
     return 0;
 }
 static int file_new(BIO *bi)
 {
+    (void)bi;
     return 0;
 }
 static int file_free(BIO *a)
 {
+    (void)a;
     return 0;
 }
 
@@ -419,6 +436,8 @@ const BIO_METHOD *BIO_s_file(void)
 
 BIO *BIO_new_file(const char *filename, const char *mode)
 {
+    (void)filename;
+    (void)mode;
     return NULL;
 }
 

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -387,6 +387,7 @@ static void xcloselog(BIO *bp)
 
 static void xopenlog(BIO *bp, char *name, int level)
 {
+    (void)bp;
 #  ifdef WATT32                 /* djgpp/DOS */
     openlog(name, LOG_PID | LOG_CONS | LOG_NDELAY, level);
 #  else
@@ -396,11 +397,13 @@ static void xopenlog(BIO *bp, char *name, int level)
 
 static void xsyslog(BIO *bp, int priority, const char *string)
 {
+    (void)bp;
     syslog(priority, "%s", string);
 }
 
 static void xcloselog(BIO *bp)
 {
+    (void)bp;
     closelog();
 }
 

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -85,6 +85,7 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_SET_CLOSE:
     case BIO_CTRL_FLUSH:
     case BIO_CTRL_DUP:
+        ret = 1;
         break;
     case BIO_CTRL_GET_CLOSE:
     case BIO_CTRL_INFO:

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -58,11 +58,16 @@ static int null_free(BIO *a)
 
 static int null_read(BIO *b, char *out, int outl)
 {
+    (void)b;
+    (void)out;
+    (void)outl;
     return (0);
 }
 
 static int null_write(BIO *b, const char *in, int inl)
 {
+    (void)b;
+    (void)in;
     return (inl);
 }
 
@@ -70,6 +75,9 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
     long ret = 1;
 
+    (void)b;
+    (void)num;
+    (void)ptr;
     switch (cmd) {
     case BIO_CTRL_RESET:
     case BIO_CTRL_EOF:
@@ -77,7 +85,6 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_SET_CLOSE:
     case BIO_CTRL_FLUSH:
     case BIO_CTRL_DUP:
-        ret = 1;
         break;
     case BIO_CTRL_GET_CLOSE:
     case BIO_CTRL_INFO:
@@ -93,11 +100,15 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 static int null_gets(BIO *bp, char *buf, int size)
 {
+    (void)bp;
+    (void)buf;
+    (void)size;
     return (0);
 }
 
 static int null_puts(BIO *bp, const char *str)
 {
+    (void)bp;
     if (str == NULL)
         return (0);
     return (strlen(str));

--- a/crypto/bn/bn_asm.c
+++ b/crypto/bn/bn_asm.c
@@ -942,6 +942,12 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, int num)
 {
+    (void)rp;
+    (void)ap;
+    (void)bp;
+    (void)np;
+    (void)n0;
+    (void)num;
     return 0;
 }
 #  endif                        /* OPENSSL_BN_ASM_MONT */

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -310,6 +310,7 @@ int bn_probable_prime_dh_retry(BIGNUM *rnd, int bits, BN_CTX *ctx)
     int i;
     int ret = 0;
 
+    (void)ctx;
  loop:
     if (!BN_rand(rnd, bits, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD))
         goto err;

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -43,6 +43,7 @@ void BN_RECP_CTX_free(BN_RECP_CTX *recp)
 
 int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *ctx)
 {
+    (void)ctx;
     if (!BN_copy(&(recp->N), d))
         return 0;
     BN_zero(&(recp->Nr));

--- a/crypto/cmac/cm_ameth.c
+++ b/crypto/cmac/cm_ameth.c
@@ -20,6 +20,7 @@
 
 static int cmac_size(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return EVP_MAX_BLOCK_LENGTH;
 }
 

--- a/crypto/cmac/cm_pmeth.c
+++ b/crypto/cmac/cm_pmeth.c
@@ -64,6 +64,7 @@ static int int_update(EVP_MD_CTX *ctx, const void *data, size_t count)
 
 static int cmac_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
 {
+    (void)ctx;
     EVP_MD_CTX_set_flags(mctx, EVP_MD_CTX_FLAG_NO_INIT);
     EVP_MD_CTX_set_update_fn(mctx, int_update);
     return 1;
@@ -72,6 +73,7 @@ static int cmac_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
 static int cmac_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
                         EVP_MD_CTX *mctx)
 {
+    (void)mctx;
     return CMAC_Final(ctx->data, sig, siglen);
 }
 

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -46,6 +46,8 @@ ASN1_NDEF_SEQUENCE(CMS_EncapsulatedContentInfo) = {
 static int cms_si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                      void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_POST) {
         CMS_SignerInfo *si = (CMS_SignerInfo *)*pval;
         EVP_PKEY_free(si->pkey);
@@ -121,6 +123,8 @@ ASN1_CHOICE(CMS_KeyAgreeRecipientIdentifier) = {
 static int cms_rek_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                       void *exarg)
 {
+    (void)it;
+    (void)exarg;
     CMS_RecipientEncryptedKey *rek = (CMS_RecipientEncryptedKey *)*pval;
     if (operation == ASN1_OP_FREE_POST) {
         EVP_PKEY_free(rek->pkey);
@@ -147,6 +151,8 @@ ASN1_CHOICE(CMS_OriginatorIdentifierOrKey) = {
 static int cms_kari_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                        void *exarg)
 {
+    (void)it;
+    (void)exarg;
     CMS_KeyAgreeRecipientInfo *kari = (CMS_KeyAgreeRecipientInfo *)*pval;
     if (operation == ASN1_OP_NEW_POST) {
         kari->ctx = EVP_CIPHER_CTX_new();
@@ -198,6 +204,8 @@ ASN1_SEQUENCE(CMS_OtherRecipientInfo) = {
 static int cms_ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                      void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_PRE) {
         CMS_RecipientInfo *ri = (CMS_RecipientInfo *)*pval;
         if (ri->type == CMS_RECIPINFO_TRANS) {
@@ -283,10 +291,13 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 {
     ASN1_STREAM_ARG *sarg = exarg;
     CMS_ContentInfo *cms = NULL;
+
+    (void)it;
     if (pval)
         cms = (CMS_ContentInfo *)*pval;
     else
         return 1;
+
     switch (operation) {
 
     case ASN1_OP_STREAM_PRE:

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -810,6 +810,7 @@ int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
 CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
 {
     CMS_ContentInfo *cms;
+
     if (comp_nid <= 0)
         comp_nid = NID_zlib_compression;
     cms = cms_CompressedData_create(comp_nid);
@@ -831,12 +832,19 @@ CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
 int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
                    unsigned int flags)
 {
+    (void)cms;
+    (void)dcont;
+    (void)out;
+    (void)flags;
     CMSerr(CMS_F_CMS_UNCOMPRESS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
     return 0;
 }
 
 CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
 {
+    (void)in;
+    (void)comp_nid;
+    (void)flags;
     CMSerr(CMS_F_CMS_COMPRESS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
     return NULL;
 }

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -48,12 +48,14 @@ static void *zlib_zalloc(void *opaque, unsigned int no, unsigned int size)
 {
     void *p;
 
+    (void)opaque;
     p = OPENSSL_zalloc(no * size);
     return p;
 }
 
 static void zlib_zfree(void *opaque, void *address)
 {
+    (void)opaque;
     OPENSSL_free(address);
 }
 

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -626,5 +626,6 @@ static int def_is_number(const CONF *conf, char c)
 
 static int def_to_int(const CONF *conf, char c)
 {
+    (void)conf;
     return c - '0';
 }

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -280,6 +280,8 @@ void OPENSSL_showfatal(const char *fmta, ...)
     va_start(ap, fmta);
     vfprintf(stderr, fmta, ap);
     va_end(ap);
+#else
+    (void)fmta;
 #endif
 }
 

--- a/crypto/ct/ct_x509v3.c
+++ b/crypto/ct/ct_x509v3.c
@@ -15,17 +15,23 @@
 
 static char *i2s_poison(const X509V3_EXT_METHOD *method, void *val)
 {
+    (void)method;
+    (void)val;
     return OPENSSL_strdup("NULL");
 }
 
 static void *s2i_poison(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx, const char *str)
 {
-   return ASN1_NULL_new();
+    (void)method;
+    (void)ctx;
+    (void)str;
+    return ASN1_NULL_new();
 }
 
 static int i2r_SCT_LIST(X509V3_EXT_METHOD *method, STACK_OF(SCT) *sct_list,
                  BIO *out, int indent)
 {
+    (void)method;
     SCT_LIST_print(sct_list, out, indent, "\n", NULL);
     return 1;
 }

--- a/crypto/des/rpc_enc.c
+++ b/crypto/des/rpc_enc.c
@@ -16,6 +16,7 @@ int _des_crypt(char *buf, int len, struct desparams *desp)
     DES_key_schedule ks;
     int enc;
 
+    (void)buf;
     DES_set_key_unchecked(&desp->des_key, &ks);
     enc = (desp->des_dir == ENCRYPT) ? DES_ENCRYPT : DES_DECRYPT;
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -456,18 +456,21 @@ static int dh_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 static int dh_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                           ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_dh_print(bp, pkey->pkey.dh, indent, 0);
 }
 
 static int dh_public_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                            ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_dh_print(bp, pkey->pkey.dh, indent, 1);
 }
 
 static int dh_private_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                             ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_dh_print(bp, pkey->pkey.dh, indent, 2);
 }
 
@@ -483,6 +486,7 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri);
 
 static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
+    (void)pkey;
     switch (op) {
 #ifndef OPENSSL_NO_CMS
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -487,6 +487,10 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri);
 static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     (void)pkey;
+#ifdef OPENSSL_NO_CMS
+    (void)arg1;
+    (void)arg2;
+#endif
     switch (op) {
 #ifndef OPENSSL_NO_CMS
 

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -18,6 +18,8 @@
 static int dh_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                  void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)DH_new();
         if (*pval != NULL)

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -199,6 +199,7 @@ static int dh_bn_mod_exp(const DH *dh, BIGNUM *r,
                          const BIGNUM *a, const BIGNUM *p,
                          const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *m_ctx)
 {
+    (void)dh;
     return BN_mod_exp_mont(r, a, p, m, ctx, m_ctx);
 }
 

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -56,6 +56,10 @@ DH *DH_new_method(ENGINE *engine)
 {
     DH *ret = OPENSSL_zalloc(sizeof(*ret));
 
+#ifdef OPENSSL_NO_ENGINE
+    (void)engine;
+#endif
+
     if (ret == NULL) {
         DHerr(DH_F_DH_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -388,18 +388,21 @@ static int dsa_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
 static int dsa_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                            ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 0);
 }
 
 static int dsa_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                          ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 1);
 }
 
 static int dsa_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                           ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 2);
 }
 
@@ -427,6 +430,8 @@ static int dsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
     DSA_SIG *dsa_sig;
     const unsigned char *p;
 
+    (void)sigalg;
+    (void)pctx;
     if (!sig) {
         if (BIO_puts(bp, "\n") <= 0)
             return 0;

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -61,6 +61,8 @@ int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 static int dsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                   void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)DSA_new();
         if (*pval != NULL)
@@ -111,6 +113,8 @@ int DSA_sign(int type, const unsigned char *dgst, int dlen,
              unsigned char *sig, unsigned int *siglen, DSA *dsa)
 {
     DSA_SIG *s;
+
+    (void)type; /* FIXME(API) */
     RAND_seed(dgst, dlen);
     s = DSA_do_sign(dgst, dlen, dsa);
     if (s == NULL) {
@@ -138,6 +142,7 @@ int DSA_verify(int type, const unsigned char *dgst, int dgst_len,
     int derlen = -1;
     int ret = -1;
 
+    (void)type;
     s = DSA_SIG_new();
     if (s == NULL)
         return (ret);

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -65,6 +65,10 @@ DSA *DSA_new_method(ENGINE *engine)
 {
     DSA *ret = OPENSSL_zalloc(sizeof(*ret));
 
+#ifdef OPENSSL_NO_ENGINE
+    (void)engine;
+#endif
+
     if (ret == NULL) {
         DSAerr(DSA_F_DSA_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -187,6 +187,7 @@ static char *dlfcn_merger(DSO *dso, const char *filespec1,
 {
     char *merged;
 
+    (void)dso;
     if (!filespec1 && !filespec2) {
         DSOerr(DSO_F_DLFCN_MERGER, ERR_R_PASSED_NULL_PARAMETER);
         return (NULL);

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -15,6 +15,7 @@ static DSO *DSO_new_method(DSO_METHOD *meth)
 {
     DSO *ret;
 
+    (void)meth;
     if (default_DSO_meth == NULL) {
         /*
          * We default to DSO_METH_openssl() which in turn defaults to

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -172,6 +172,7 @@ int ec_GF2m_simple_group_set_curve(EC_GROUP *group,
 {
     int ret = 0, i;
 
+    (void)ctx;
     /* group->field */
     if (!BN_copy(group->field, p))
         goto err;
@@ -211,6 +212,7 @@ int ec_GF2m_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
 {
     int ret = 0;
 
+    (void)ctx;
     if (p != NULL) {
         if (!BN_copy(p, group->field))
             return 0;
@@ -341,6 +343,7 @@ int ec_GF2m_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
 int ec_GF2m_simple_point_set_to_infinity(const EC_GROUP *group,
                                          EC_POINT *point)
 {
+    (void)group;
     point->Z_is_one = 0;
     BN_zero(point->Z);
     return 1;
@@ -356,6 +359,9 @@ int ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *group,
                                                 const BIGNUM *y, BN_CTX *ctx)
 {
     int ret = 0;
+
+    (void)group;
+    (void)ctx;
     if (x == NULL || y == NULL) {
         ECerr(EC_F_EC_GF2M_SIMPLE_POINT_SET_AFFINE_COORDINATES,
               ERR_R_PASSED_NULL_PARAMETER);
@@ -389,6 +395,7 @@ int ec_GF2m_simple_point_get_affine_coordinates(const EC_GROUP *group,
 {
     int ret = 0;
 
+    (void)ctx;
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GF2M_SIMPLE_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);
@@ -556,6 +563,7 @@ int ec_GF2m_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
 int ec_GF2m_simple_is_at_infinity(const EC_GROUP *group,
                                   const EC_POINT *point)
 {
+    (void)group;
     return BN_is_zero(point->Z);
 }
 

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -418,18 +418,21 @@ static int eckey_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
 static int eckey_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                              ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PARAM);
 }
 
 static int eckey_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                            ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PUBLIC);
 }
 
 static int eckey_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                             ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PRIVATE);
 }
 

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -74,6 +74,10 @@ EC_KEY *EC_KEY_new_method(ENGINE *engine)
 {
     EC_KEY *ret = OPENSSL_zalloc(sizeof(*ret));
 
+#ifdef OPENSSL_NO_ENGINE
+    (void)engine;
+#endif
+
     if (ret == NULL) {
         ECerr(EC_F_EC_KEY_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -320,6 +320,7 @@ BN_MONT_CTX *EC_GROUP_get_mont_data(const EC_GROUP *group)
 
 int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, BN_CTX *ctx)
 {
+    (void)ctx;
     if (group->order == NULL)
         return 0;
     if (!BN_copy(order, group->order))
@@ -342,6 +343,7 @@ int EC_GROUP_order_bits(const EC_GROUP *group)
 int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor,
                           BN_CTX *ctx)
 {
+    (void)ctx;
 
     if (group->cofactor == NULL)
         return 0;

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -21,6 +21,8 @@ int ossl_ecdsa_sign(int type, const unsigned char *dgst, int dlen,
 {
     ECDSA_SIG *s;
     RAND_seed(dgst, dlen);
+
+    (void)type;
     s = ECDSA_do_sign_ex(dgst, dlen, kinv, r, eckey);
     if (s == NULL) {
         *siglen = 0;
@@ -325,6 +327,7 @@ int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
     int derlen = -1;
     int ret = -1;
 
+    (void)type;
     s = ECDSA_SIG_new();
     if (s == NULL)
         return (ret);

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -231,6 +231,7 @@ int ec_GFp_mont_field_decode(const EC_GROUP *group, BIGNUM *r,
 int ec_GFp_mont_field_set_to_one(const EC_GROUP *group, BIGNUM *r,
                                  BN_CTX *ctx)
 {
+    (void)ctx;
     if (group->field_data2 == NULL) {
         ECerr(EC_F_EC_GFP_MONT_FIELD_SET_TO_ONE, EC_R_NOT_INITIALIZED);
         return 0;

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1314,6 +1314,7 @@ int ec_GFp_nistp224_point_get_affine_coordinates(const EC_GROUP *group,
                                                  BIGNUM *x, BIGNUM *y,
                                                  BN_CTX *ctx)
 {
+    (void)ctx;
     felem z1, z2, x_in, y_in, x_out, y_out;
     widefelem tmp;
 

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1934,6 +1934,7 @@ int ec_GFp_nistp256_point_get_affine_coordinates(const EC_GROUP *group,
     smallfelem x_out, y_out;
     longfelem tmp;
 
+    (void)ctx;
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GFP_NISTP256_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1762,6 +1762,7 @@ int ec_GFp_nistp521_point_get_affine_coordinates(const EC_GROUP *group,
     felem z1, z2, x_in, y_in, x_out, y_out;
     largefelem tmp;
 
+    (void)ctx;
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_EC_GFP_NISTP521_POINT_GET_AFFINE_COORDINATES,
               EC_R_POINT_AT_INFINITY);

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1413,6 +1413,7 @@ __owur static int ecp_nistz256_get_affine(const EC_GROUP *group,
     BN_ULONG point_x[P256_LIMBS], point_y[P256_LIMBS], point_z[P256_LIMBS];
     BN_ULONG x_ret[P256_LIMBS], y_ret[P256_LIMBS];
 
+    (void)ctx;
     if (EC_POINT_is_at_infinity(group, point)) {
         ECerr(EC_F_ECP_NISTZ256_GET_AFFINE, EC_R_POINT_AT_INFINITY);
         return 0;

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -359,6 +359,7 @@ int ec_GFp_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
 int ec_GFp_simple_point_set_to_infinity(const EC_GROUP *group,
                                         EC_POINT *point)
 {
+    (void)group;
     point->Z_is_one = 0;
     BN_zero(point->Z);
     return 1;
@@ -935,6 +936,7 @@ int ec_GFp_simple_dbl(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a,
 
 int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
 {
+    (void)ctx;
     if (EC_POINT_is_at_infinity(group, point) || BN_is_zero(point->Y))
         /* point is its own inverse */
         return 1;
@@ -944,6 +946,7 @@ int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
 
 int ec_GFp_simple_is_at_infinity(const EC_GROUP *group, const EC_POINT *point)
 {
+    (void)group;
     return BN_is_zero(point->Z);
 }
 

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -194,16 +194,19 @@ static int ecx_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
 
 static int ecx_size(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return X25519_KEYLEN;
 }
 
 static int ecx_bits(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return X25519_BITS;
 }
 
 static int ecx_security_bits(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return X25519_SECURITY_BITS;
 }
 
@@ -219,6 +222,8 @@ static void ecx_free(EVP_PKEY *pkey)
 /* "parameters" are always equal */
 static int ecx_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
 {
+    (void)a;
+    (void)b;
     return 1;
 }
 
@@ -227,6 +232,7 @@ static int ecx_key_print(BIO *bp, const EVP_PKEY *pkey, int indent,
 {
     const X25519_KEY *xkey = pkey->pkey.ptr;
 
+    (void)ctx;
     if (op == X25519_PRIVATE) {
         if (xkey == NULL || xkey->privkey == NULL) {
             if (BIO_printf(bp, "%*s<INVALID PRIVATE KEY>\n", indent, "") <= 0)
@@ -326,6 +332,7 @@ const EVP_PKEY_ASN1_METHOD ecx25519_asn1_meth = {
 
 static int pkey_ecx_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 {
+    (void)ctx;
     return ecx_key_op(pkey, NULL, NULL, 0, X25519_KEYGEN);
 }
 
@@ -356,6 +363,9 @@ static int pkey_ecx_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
 
 static int pkey_ecx_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 {
+    (void)ctx;
+    (void)p1;
+    (void)p2;
     /* Only need to handle peer key for derivation */
     if (type == EVP_PKEY_CTRL_PEER_KEY)
         return 1;

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -179,6 +179,7 @@ static void int_engine_module_finish(CONF_IMODULE *md)
 {
     ENGINE *e;
 
+    (void)md;
     while ((e = sk_ENGINE_pop(initialized_engines)))
         ENGINE_finish(e);
     sk_ENGINE_free(initialized_engines);

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -63,6 +63,8 @@ static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
 {
     int idx;
     char *s = (char *)p;
+
+    (void)f;
     /* Take care of the easy one first (eg. it requires no searches) */
     if (cmd == ENGINE_CTRL_GET_FIRST_CMD_TYPE) {
         if ((e->cmd_defns == NULL) || int_ctrl_cmd_is_null(e->cmd_defns))

--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -135,6 +135,11 @@ static void dynamic_data_ctx_free_func(void *parent, void *ptr,
                                        CRYPTO_EX_DATA *ad, int idx, long argl,
                                        void *argp)
 {
+    (void)parent;
+    (void)ad;
+    (void)idx;
+    (void)argl;
+    (void)argp;
     if (ptr) {
         dynamic_data_ctx *ctx = (dynamic_data_ctx *)ptr;
         DSO_free(ctx->dynamic_dso);
@@ -270,6 +275,7 @@ void engine_load_dynamic_int(void)
 
 static int dynamic_init(ENGINE *e)
 {
+    (void)e;
     /*
      * We always return failure - the "dynamic" engine itself can't be used
      * for anything.
@@ -283,6 +289,7 @@ static int dynamic_finish(ENGINE *e)
      * This should never be called on account of "dynamic_init" always
      * failing.
      */
+    (void)e;
     return 0;
 }
 
@@ -291,6 +298,7 @@ static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
     dynamic_data_ctx *ctx = dynamic_get_data_ctx(e);
     int initialised;
 
+    (void)f;
     if (!ctx) {
         ENGINEerr(ENGINE_F_DYNAMIC_CTRL, ENGINE_R_NOT_LOADED);
         return 0;

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -71,6 +71,7 @@ int engine_free_util(ENGINE *e, int not_locked)
 {
     int i;
 
+    (void)not_locked;
     if (e == NULL)
         return 1;
 #ifdef HAVE_ATOMICS

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -194,6 +194,8 @@ typedef struct {
 static int test_rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                              const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
 # ifdef TEST_ENG_OPENSSL_RC4_P_INIT
     fprintf(stderr, "(TEST_ENG_OPENSSL_RC4) test_init_key() called\n");
 # endif
@@ -284,6 +286,7 @@ static int test_cipher_nids(const int **nids)
 static int openssl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                            const int **nids, int nid)
 {
+    (void)e;
     if (!cipher) {
         /* We are returning a list of supported nids */
         return test_cipher_nids(nids);
@@ -380,6 +383,7 @@ static int test_digest_nids(const int **nids)
 static int openssl_digests(ENGINE *e, const EVP_MD **digest,
                            const int **nids, int nid)
 {
+    (void)e;
     if (!digest) {
         /* We are returning a list of supported nids */
         return test_digest_nids(nids);
@@ -406,6 +410,10 @@ static EVP_PKEY *openssl_load_privkey(ENGINE *eng, const char *key_id,
 {
     BIO *in;
     EVP_PKEY *key;
+
+    (void)eng;
+    (void)ui_method;
+    (void)callback_data;
     fprintf(stderr, "(TEST_ENG_OPENSSL_PKEY)Loading Private key %s\n",
             key_id);
     in = BIO_new_file(key_id, "r");
@@ -642,6 +650,7 @@ static int ossl_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 
 int openssl_destroy(ENGINE *e)
 {
+    (void)e;
     test_sha_md_destroy();
 #ifdef TEST_ENG_OPENSSL_RC4
     test_r4_cipher_destroy();

--- a/crypto/engine/eng_rdrand.c
+++ b/crypto/engine/eng_rdrand.c
@@ -60,6 +60,7 @@ static RAND_METHOD rdrand_meth = {
 
 static int rdrand_init(ENGINE *e)
 {
+    (void)e;
     return 1;
 }
 

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -164,6 +164,8 @@ static void look_str_cb(int nid, STACK_OF(ENGINE) *sk, ENGINE *def, void *arg)
 {
     ENGINE_FIND_STR *lk = arg;
     int i;
+
+    (void)def;
     if (lk->ameth)
         return;
     for (i = 0; i < sk_ENGINE_num(sk); i++) {

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -626,12 +626,14 @@ void err_delete_thread_state(void)
 #if OPENSSL_API_COMPAT < 0x10100000L
 void ERR_remove_thread_state(void *dummy)
 {
+    (void)dummy;
 }
 #endif
 
 #if OPENSSL_API_COMPAT < 0x10000000L
 void ERR_remove_state(unsigned long pid)
 {
+    (void)pid;
 }
 #endif
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -60,6 +60,9 @@ int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type)
 
 int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 {
+#ifdef OPENSSL_NO_ENGINE
+    (void)impl;
+#endif
     EVP_MD_CTX_clear_flags(ctx, EVP_MD_CTX_FLAG_CLEANED);
 #ifndef OPENSSL_NO_ENGINE
     /*

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -254,6 +254,7 @@ static int aesni_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int ret, mode;
     EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
 
+    (void)iv;
     mode = EVP_CIPHER_CTX_mode(ctx);
     if ((mode == EVP_CIPH_ECB_MODE || mode == EVP_CIPH_CBC_MODE)
         && !enc) {
@@ -330,6 +331,8 @@ static int aesni_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                               const unsigned char *iv, int enc)
 {
     EVP_AES_GCM_CTX *gctx = EVP_C_DATA(EVP_AES_GCM_CTX,ctx);
+
+    (void)enc;
     if (!iv && !key)
         return 1;
     if (key) {
@@ -1036,6 +1039,7 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int ret, mode;
     EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
 
+    (void)iv;
     mode = EVP_CIPHER_CTX_mode(ctx);
     if ((mode == EVP_CIPH_ECB_MODE || mode == EVP_CIPH_CBC_MODE)
         && !enc) {
@@ -1435,6 +1439,8 @@ static int aes_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                             const unsigned char *iv, int enc)
 {
     EVP_AES_GCM_CTX *gctx = EVP_C_DATA(EVP_AES_GCM_CTX,ctx);
+
+    (void)enc;
     if (!iv && !key)
         return 1;
     if (key) {
@@ -1778,6 +1784,8 @@ BLOCK_CIPHER_custom(NID_aes, 128, 1, 12, gcm, GCM,
 static int aes_xts_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 {
     EVP_AES_XTS_CTX *xctx = EVP_C_DATA(EVP_AES_XTS_CTX,c);
+
+    (void)arg;
     if (type == EVP_CTRL_COPY) {
         EVP_CIPHER_CTX *out = ptr;
         EVP_AES_XTS_CTX *xctx_out = EVP_C_DATA(EVP_AES_XTS_CTX,out);
@@ -2028,6 +2036,8 @@ static int aes_ccm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                             const unsigned char *iv, int enc)
 {
     EVP_AES_CCM_CTX *cctx = EVP_C_DATA(EVP_AES_CCM_CTX,ctx);
+
+    (void)enc;
     if (!iv && !key)
         return 1;
     if (key)
@@ -2209,6 +2219,8 @@ static int aes_wrap_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                              const unsigned char *iv, int enc)
 {
     EVP_AES_WRAP_CTX *wctx = EVP_C_DATA(EVP_AES_WRAP_CTX,ctx);
+
+    (void)enc;
     if (!iv && !key)
         return 1;
     if (key) {
@@ -2462,6 +2474,8 @@ static int aes_ocb_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                             const unsigned char *iv, int enc)
 {
     EVP_AES_OCB_CTX *octx = EVP_C_DATA(EVP_AES_OCB_CTX,ctx);
+
+    (void)enc;
     if (!iv && !key)
         return 1;
     if (key) {

--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -67,6 +67,7 @@ static int aesni_cbc_hmac_sha1_init_key(EVP_CIPHER_CTX *ctx,
     EVP_AES_HMAC_SHA1 *key = data(ctx);
     int ret;
 
+    (void)iv;
     if (enc)
         ret = aesni_set_encrypt_key(inkey,
                                     EVP_CIPHER_CTX_key_length(ctx) * 8,

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -64,6 +64,7 @@ static int aesni_cbc_hmac_sha256_init_key(EVP_CIPHER_CTX *ctx,
     EVP_AES_HMAC_SHA256 *key = data(ctx);
     int ret;
 
+    (void)iv;
     if (enc)
         ret = aesni_set_encrypt_key(inkey,
                                     EVP_CIPHER_CTX_key_length(ctx) * 8,

--- a/crypto/evp/e_bf.c
+++ b/crypto/evp/e_bf.c
@@ -31,6 +31,8 @@ IMPLEMENT_BLOCK_CIPHER(bf, ks, BF, EVP_BF_KEY, NID_bf, 8, 16, 8, 64,
 static int bf_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                        const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
     BF_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;
 }

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -216,6 +216,7 @@ static int camellia_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int ret, mode;
     EVP_CAMELLIA_KEY *dat = EVP_C_DATA(EVP_CAMELLIA_KEY,ctx);
 
+    (void)iv;
     ret = Camellia_set_key(key, EVP_CIPHER_CTX_key_length(ctx) * 8, &dat->ks);
     if (ret < 0) {
         EVPerr(EVP_F_CAMELLIA_INIT_KEY, EVP_R_CAMELLIA_KEY_SETUP_FAILED);

--- a/crypto/evp/e_cast.c
+++ b/crypto/evp/e_cast.c
@@ -33,6 +33,8 @@ IMPLEMENT_BLOCK_CIPHER(cast5, ks, CAST, EVP_CAST_KEY,
 static int cast_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                          const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
     CAST_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;
 }

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -37,6 +37,7 @@ static int chacha_init_key(EVP_CIPHER_CTX *ctx,
     EVP_CHACHA_KEY *key = data(ctx);
     unsigned int i;
 
+    (void)enc;
     if (user_key)
         for (i = 0; i < CHACHA_KEY_SIZE; i+=4) {
             key->key.d[i/4] = CHACHA_U8TOU32(user_key+i);

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -208,6 +208,8 @@ static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     DES_cblock *deskey = (DES_cblock *)key;
     EVP_DES_KEY *dat = (EVP_DES_KEY *) EVP_CIPHER_CTX_get_cipher_data(ctx);
 
+    (void)iv;
+    (void)enc;
     dat->stream.cbc = NULL;
 # if defined(SPARC_DES_CAPABLE)
     if (SPARC_DES_CAPABLE) {
@@ -226,7 +228,8 @@ static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 
 static int des_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 {
-
+    (void)c;
+    (void)arg;
     switch (type) {
     case EVP_CTRL_RAND_KEY:
         if (RAND_bytes(ptr, 8) <= 0)

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -228,6 +228,8 @@ static int des_ede_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     DES_cblock *deskey = (DES_cblock *)key;
     DES_EDE_KEY *dat = data(ctx);
 
+    (void)iv;
+    (void)enc;
     dat->stream.cbc = NULL;
 # if defined(SPARC_DES_CAPABLE)
     if (SPARC_DES_CAPABLE) {
@@ -255,6 +257,8 @@ static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     DES_cblock *deskey = (DES_cblock *)key;
     DES_EDE_KEY *dat = data(ctx);
 
+    (void)iv;
+    (void)enc;
     dat->stream.cbc = NULL;
 # if defined(SPARC_DES_CAPABLE)
     if (SPARC_DES_CAPABLE) {
@@ -278,9 +282,9 @@ static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 
 static int des3_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
-
     DES_cblock *deskey = ptr;
 
+    (void)arg;
     switch (type) {
     case EVP_CTRL_RAND_KEY:
         if (RAND_bytes(ptr, EVP_CIPHER_CTX_key_length(ctx)) <= 0)

--- a/crypto/evp/e_idea.c
+++ b/crypto/evp/e_idea.c
@@ -49,6 +49,7 @@ BLOCK_CIPHER_defs(idea, IDEA_KEY_SCHEDULE, NID_idea, 8, 16, 8, 64,
 static int idea_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                          const unsigned char *iv, int enc)
 {
+    (void)iv;
     if (!enc) {
         if (EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_OFB_MODE)
             enc = 1;

--- a/crypto/evp/e_null.c
+++ b/crypto/evp/e_null.c
@@ -38,12 +38,17 @@ const EVP_CIPHER *EVP_enc_null(void)
 static int null_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                          const unsigned char *iv, int enc)
 {
+    (void)ctx;
+    (void)key;
+    (void)iv;
+    (void)enc;
     return 1;
 }
 
 static int null_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                        const unsigned char *in, size_t inl)
 {
+    (void)ctx;
     if (in != out)
         memcpy(out, in, inl);
     return 1;

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -83,6 +83,8 @@ const EVP_CIPHER *EVP_rc2_40_cbc(void)
 static int rc2_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                         const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
     RC2_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx),
                 key, data(ctx)->key_bits);
     return 1;

--- a/crypto/evp/e_rc4.c
+++ b/crypto/evp/e_rc4.c
@@ -69,6 +69,8 @@ const EVP_CIPHER *EVP_rc4_40(void)
 static int rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                         const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
     RC4_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;
 }

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -40,6 +40,8 @@ static int rc4_hmac_md5_init_key(EVP_CIPHER_CTX *ctx,
 {
     EVP_RC4_HMAC_MD5 *key = data(ctx);
 
+    (void)iv;
+    (void)enc;
     RC4_set_key(&key->ks, EVP_CIPHER_CTX_key_length(ctx), inkey);
 
     MD5_Init(&key->head);       /* handy when benchmarking */

--- a/crypto/evp/e_rc5.c
+++ b/crypto/evp/e_rc5.c
@@ -66,6 +66,8 @@ static int rc5_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 static int r_32_12_16_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                                const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
     RC5_32_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx),
                    key, data(ctx)->rounds);
     return 1;

--- a/crypto/evp/e_seed.c
+++ b/crypto/evp/e_seed.c
@@ -32,6 +32,8 @@ IMPLEMENT_BLOCK_CIPHER(seed, ks, SEED, EVP_SEED_KEY, NID_seed,
 static int seed_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                          const unsigned char *iv, int enc)
 {
+    (void)iv;
+    (void)enc;
     SEED_set_key(key, &EVP_C_DATA(EVP_SEED_KEY,ctx)->ks);
     return 1;
 }

--- a/crypto/evp/e_xcbc_d.c
+++ b/crypto/evp/e_xcbc_d.c
@@ -54,6 +54,8 @@ static int desx_cbc_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 {
     DES_cblock *deskey = (DES_cblock *)key;
 
+    (void)iv;
+    (void)enc;
     DES_set_key_unchecked(deskey, &data(ctx)->ks);
     memcpy(&data(ctx)->inw[0], &key[8], 8);
     memcpy(&data(ctx)->outw[0], &key[16], 8);

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -58,6 +58,9 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
                       ENGINE *impl, const unsigned char *key,
                       const unsigned char *iv, int enc)
 {
+#ifdef OPENSSL_NO_ENGINE
+    (void)impl;
+#endif
     if (enc == -1)
         enc = ctx->encrypt;
     else {

--- a/crypto/evp/m_null.c
+++ b/crypto/evp/m_null.c
@@ -16,16 +16,22 @@
 
 static int init(EVP_MD_CTX *ctx)
 {
+    (void)ctx;
     return 1;
 }
 
 static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
 {
+    (void)ctx;
+    (void)data;
+    (void)count;
     return 1;
 }
 
 static int final(EVP_MD_CTX *ctx, unsigned char *md)
 {
+    (void)ctx;
+    (void)md;
     return 1;
 }
 

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -142,9 +142,10 @@ int PKCS5_v2_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
     PBE2PARAM *pbe2 = NULL;
     const EVP_CIPHER *cipher;
     EVP_PBE_KEYGEN *kdf;
-
     int rv = 0;
 
+    (void)c;
+    (void)md;
     pbe2 = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), param);
     if (pbe2 == NULL) {
         EVPerr(EVP_F_PKCS5_V2_PBE_KEYIVGEN, EVP_R_DECODE_ERROR);
@@ -195,6 +196,8 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
     PBKDF2PARAM *kdf = NULL;
     const EVP_MD *prfmd;
 
+    (void)c;
+    (void)md;
     if (EVP_CIPHER_CTX_cipher(ctx) == NULL) {
         EVPerr(EVP_F_PKCS5_V2_PBKDF2_KEYIVGEN, EVP_R_NO_CIPHER_SET);
         goto err;

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -113,17 +113,35 @@ void crypto_cleanup_all_ex_data_int(void)
 static void dummy_new(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
                      long argl, void *argp)
 {
+    (void)parent;
+    (void)ptr;
+    (void)ad;
+    (void)idx;
+    (void)argl;
+    (void)argp;
 }
 
 static void dummy_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
                        long argl, void *argp)
 {
+    (void)parent;
+    (void)ptr;
+    (void)ad;
+    (void)idx;
+    (void)argl;
+    (void)argp;
 }
 
 static int dummy_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
                      void *from_d, int idx,
                      long argl, void *argp)
 {
+    (void)to;
+    (void)from;
+    (void)from_d;
+    (void)idx;
+    (void)argl;
+    (void)argp;
     return 0;
 }
 

--- a/crypto/hmac/hm_ameth.c
+++ b/crypto/hmac/hm_ameth.c
@@ -21,6 +21,7 @@
 
 static int hmac_size(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return EVP_MAX_MD_SIZE;
 }
 
@@ -36,6 +37,8 @@ static void hmac_key_free(EVP_PKEY *pkey)
 
 static int hmac_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
+    (void)pkey;
+    (void)arg1;
     switch (op) {
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
         *(int *)arg2 = NID_sha256;

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -176,7 +176,8 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
         ret = malloc(num);
     }
 #else
-    osslargused(file); osslargused(line);
+    (void)file;
+    (void)line;
     ret = malloc(num);
 #endif
 
@@ -217,7 +218,8 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
         return ret;
     }
 #else
-    osslargused(file); osslargused(line);
+    (void)file;
+    (void)line;
 #endif
     return realloc(str, num);
 

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -381,6 +381,8 @@ void CRYPTO_mem_debug_free(void *addr, int before_p,
 {
     MEM m, *mp;
 
+    (void)file;
+    (void)line;
     switch (before_p) {
     case 0:
         if (addr == NULL)

--- a/crypto/modes/cfb128.c
+++ b/crypto/modes/cfb128.c
@@ -178,6 +178,7 @@ void CRYPTO_cfb128_1_encrypt(const unsigned char *in, unsigned char *out,
     size_t n;
     unsigned char c[1], d[1];
 
+    (void)num;
     for (n = 0; n < bits; ++n) {
         c[0] = (in[n / 8] & (1 << (7 - n % 8))) ? 0x80 : 0;
         cfbr_encrypt_block(c, d, 1, key, ivec, enc, block);
@@ -193,6 +194,7 @@ void CRYPTO_cfb128_8_encrypt(const unsigned char *in, unsigned char *out,
 {
     size_t n;
 
+    (void)num;
     for (n = 0; n < length; ++n)
         cfbr_encrypt_block(&in[n], &out[n], 8, key, ivec, enc, block);
 }

--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -97,6 +97,8 @@ FILE *openssl_fopen(const char *filename, const char *mode)
 
 void *openssl_fopen(const char *filename, const char *mode)
 {
+    (void)filename;
+    (void)mode;
     return NULL;
 }
 

--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -111,6 +111,8 @@ static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
                           int ind)
 {
     OCSP_CRLID *a = in;
+
+    (void)method;
     if (a->crlUrl) {
         if (BIO_printf(bp, "%*scrlUrl: ", ind, "") <= 0)
             goto err;
@@ -143,6 +145,7 @@ static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
 static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
                             BIO *bp, int ind)
 {
+    (void)method;
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
     if (!ASN1_GENERALIZEDTIME_print(bp, cutoff))
@@ -153,6 +156,7 @@ static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
 static int i2r_object(const X509V3_EXT_METHOD *method, void *oid, BIO *bp,
                       int ind)
 {
+    (void)method;
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
     if (i2a_ASN1_OBJECT(bp, oid) <= 0)
@@ -215,6 +219,7 @@ static void ocsp_nonce_free(void *a)
 static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
                           BIO *out, int indent)
 {
+    (void)method;
     if (BIO_printf(out, "%*s", indent, "") <= 0)
         return 0;
     if (i2a_ASN1_STRING(out, nonce, V_ASN1_OCTET_STRING) <= 0)
@@ -227,12 +232,19 @@ static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
 static int i2r_ocsp_nocheck(const X509V3_EXT_METHOD *method, void *nocheck,
                             BIO *out, int indent)
 {
+    (void)method;
+    (void)nocheck;
+    (void)out;
+    (void)indent;
     return 1;
 }
 
 static void *s2i_ocsp_nocheck(const X509V3_EXT_METHOD *method,
                               X509V3_CTX *ctx, const char *str)
 {
+    (void)method;
+    (void)ctx;
+    (void)str;
     return ASN1_NULL_new();
 }
 
@@ -243,6 +255,7 @@ static int i2r_ocsp_serviceloc(const X509V3_EXT_METHOD *method, void *in,
     OCSP_SERVICELOC *a = in;
     ACCESS_DESCRIPTION *ad;
 
+    (void)method;
     if (BIO_printf(bp, "%*sIssuer: ", ind, "") <= 0)
         goto err;
     if (X509_NAME_print_ex(bp, a->issuer, 0, XN_FLAG_ONELINE) <= 0)

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -32,6 +32,8 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
 {
 #if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
     int i;
+
+    (void)w;
 #else
     int i, j;
     const char *prompt;

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -35,6 +35,7 @@ static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     ASN1_STREAM_ARG *sarg = exarg;
     PKCS7 **pp7 = (PKCS7 **)pval;
 
+    (void)it;
     switch (operation) {
 
     case ASN1_OP_STREAM_PRE:
@@ -82,6 +83,8 @@ IMPLEMENT_ASN1_FUNCTIONS(PKCS7_SIGNED)
 static int si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                  void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_POST) {
         PKCS7_SIGNER_INFO *si = (PKCS7_SIGNER_INFO *)*pval;
         EVP_PKEY_free(si->pkey);
@@ -125,6 +128,8 @@ IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENVELOPE)
 static int ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                  void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_POST) {
         PKCS7_RECIP_INFO *ri = (PKCS7_RECIP_INFO *)*pval;
         X509_free(ri->cert);

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -16,11 +16,10 @@
 
 long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
 {
-    int nid;
+    int nid = OBJ_obj2nid(p7->type);
     long ret;
 
-    nid = OBJ_obj2nid(p7->type);
-
+    (void)parg;
     switch (cmd) {
     /* NOTE(emilia): does not support detached digested data. */
     case PKCS7_OP_SET_DETACHED_SIGNATURE:

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -16,10 +16,11 @@
 
 long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
 {
-    int nid = OBJ_obj2nid(p7->type);
+    int nid;
     long ret;
 
     (void)parg;
+    nid = OBJ_obj2nid(p7->type);
     switch (cmd) {
     /* NOTE(emilia): does not support detached digested data. */
     case PKCS7_OP_SET_DETACHED_SIGNATURE:

--- a/crypto/poly1305/poly1305_ameth.c
+++ b/crypto/poly1305/poly1305_ameth.c
@@ -21,12 +21,14 @@
 
 static int poly1305_size(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return POLY1305_DIGEST_SIZE;
 }
 
 static void poly1305_key_free(EVP_PKEY *pkey)
 {
     ASN1_OCTET_STRING *os = EVP_PKEY_get0(pkey);
+
     if (os != NULL) {
         if (os->data != NULL)
             OPENSSL_cleanse(os->data, os->length);
@@ -36,6 +38,10 @@ static void poly1305_key_free(EVP_PKEY *pkey)
 
 static int poly1305_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
+    (void)pkey;
+    (void)op;
+    (void)arg1;
+    (void)arg2;
     /* nothing, (including ASN1_PKEY_CTRL_DEFAULT_MD_NID), is supported */
     return -2;
 }

--- a/crypto/poly1305/poly1305_pmeth.c
+++ b/crypto/poly1305/poly1305_pmeth.c
@@ -105,6 +105,7 @@ static int poly1305_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *sigle
 {
     POLY1305_PKEY_CTX *pctx = ctx->data;
 
+    (void)mctx;
     *siglen = POLY1305_DIGEST_SIZE;
     if (sig != NULL)
         Poly1305_Final(&pctx->ctx, sig);

--- a/crypto/rand/md_rand.c
+++ b/crypto/rand/md_rand.c
@@ -660,11 +660,14 @@ void rand_hw_xor(unsigned char *buf, size_t num)
 
 static int rand_hw_seed(EVP_MD_CTX *ctx)
 {
+    (void)ctx;
     return 1;
 }
 
 void rand_hw_xor(unsigned char *buf, size_t num)
 {
+    (void)buf;
+    (void)num;
     return;
 }
 

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -361,12 +361,14 @@ static int pkey_rsa_print(BIO *bp, const EVP_PKEY *pkey, int off, int priv)
 static int rsa_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                          ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return pkey_rsa_print(bp, pkey, indent, 0);
 }
 
 static int rsa_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
                           ASN1_PCTX *ctx)
 {
+    (void)ctx;
     return pkey_rsa_print(bp, pkey, indent, 1);
 }
 
@@ -394,6 +396,7 @@ static RSA_PSS_PARAMS *rsa_pss_decode(const X509_ALGOR *alg)
 static int rsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
                          const ASN1_STRING *sig, int indent, ASN1_PCTX *pctx)
 {
+    (void)pctx;
     if (OBJ_obj2nid(sigalg->algorithm) == EVP_PKEY_RSA_PSS) {
         int rv;
         RSA_PSS_PARAMS *pss = rsa_pss_decode(sigalg);
@@ -712,6 +715,9 @@ static int rsa_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
                            X509_ALGOR *sigalg, ASN1_BIT_STRING *sig,
                            EVP_PKEY *pkey)
 {
+    (void)it;
+    (void)asn;
+    (void)sig;
     /* Sanity check: make sure it is PSS */
     if (OBJ_obj2nid(sigalg->algorithm) != EVP_PKEY_RSA_PSS) {
         RSAerr(RSA_F_RSA_ITEM_VERIFY, RSA_R_UNSUPPORTED_SIGNATURE_TYPE);
@@ -759,6 +765,9 @@ static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
     int pad_mode;
     EVP_PKEY_CTX *pkctx = EVP_MD_CTX_pkey_ctx(ctx);
 
+    (void)it;
+    (void)asn;
+    (void)sig;
     if (EVP_PKEY_CTX_get_rsa_padding(pkctx, &pad_mode) <= 0)
         return 0;
     if (pad_mode == RSA_PKCS1_PADDING)

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -18,6 +18,8 @@
 static int rsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                   void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)RSA_new();
         if (*pval != NULL)
@@ -53,6 +55,8 @@ ASN1_SEQUENCE_cb(RSAPublicKey, rsa_cb) = {
 static int rsa_pss_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                       void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_PRE) {
         RSA_PSS_PARAMS *pss = (RSA_PSS_PARAMS *)*pval;
         X509_ALGOR_free(pss->maskHash);
@@ -73,6 +77,8 @@ IMPLEMENT_ASN1_FUNCTIONS(RSA_PSS_PARAMS)
 static int rsa_oaep_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                        void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_PRE) {
         RSA_OAEP_PARAMS *oaep = (RSA_OAEP_PARAMS *)*pval;
         X509_ALGOR_free(oaep->maskHash);

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -73,6 +73,9 @@ RSA *RSA_new_method(ENGINE *engine)
 {
     RSA *ret = OPENSSL_zalloc(sizeof(*ret));
 
+#ifdef OPENSSL_NO_ENGINE
+    (void)engine;
+#endif
     if (ret == NULL) {
         RSAerr(RSA_F_RSA_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/rsa/rsa_none.c
+++ b/crypto/rsa/rsa_none.c
@@ -31,7 +31,7 @@ int RSA_padding_add_none(unsigned char *to, int tlen,
 int RSA_padding_check_none(unsigned char *to, int tlen,
                            const unsigned char *from, int flen, int num)
 {
-
+    (void)num;
     if (flen > tlen) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_NONE, RSA_R_DATA_TOO_LARGE);
         return (-1);

--- a/crypto/rsa/rsa_null.c
+++ b/crypto/rsa/rsa_null.c
@@ -55,6 +55,11 @@ const RSA_METHOD *RSA_null_method(void)
 static int RSA_null_public_encrypt(int flen, const unsigned char *from,
                                    unsigned char *to, RSA *rsa, int padding)
 {
+    (void)flen;
+    (void)from;
+    (void)to;
+    (void)rsa;
+    (void)padding;
     RSAerr(RSA_F_RSA_NULL_PUBLIC_ENCRYPT, RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
 }
@@ -62,6 +67,11 @@ static int RSA_null_public_encrypt(int flen, const unsigned char *from,
 static int RSA_null_private_encrypt(int flen, const unsigned char *from,
                                     unsigned char *to, RSA *rsa, int padding)
 {
+    (void)flen;
+    (void)from;
+    (void)to;
+    (void)rsa;
+    (void)padding;
     RSAerr(RSA_F_RSA_NULL_PRIVATE_ENCRYPT,
            RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
@@ -70,6 +80,11 @@ static int RSA_null_private_encrypt(int flen, const unsigned char *from,
 static int RSA_null_private_decrypt(int flen, const unsigned char *from,
                                     unsigned char *to, RSA *rsa, int padding)
 {
+    (void)flen;
+    (void)from;
+    (void)to;
+    (void)rsa;
+    (void)padding;
     RSAerr(RSA_F_RSA_NULL_PRIVATE_DECRYPT,
            RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
@@ -78,16 +93,23 @@ static int RSA_null_private_decrypt(int flen, const unsigned char *from,
 static int RSA_null_public_decrypt(int flen, const unsigned char *from,
                                    unsigned char *to, RSA *rsa, int padding)
 {
+    (void)flen;
+    (void)from;
+    (void)to;
+    (void)rsa;
+    (void)padding;
     RSAerr(RSA_F_RSA_NULL_PUBLIC_DECRYPT, RSA_R_RSA_OPERATIONS_NOT_SUPPORTED);
     return -1;
 }
 
 static int RSA_null_init(RSA *rsa)
 {
+    (void)rsa;
     return (1);
 }
 
 static int RSA_null_finish(RSA *rsa)
 {
+    (void)rsa;
     return (1);
 }

--- a/crypto/rsa/rsa_saos.c
+++ b/crypto/rsa/rsa_saos.c
@@ -23,6 +23,7 @@ int RSA_sign_ASN1_OCTET_STRING(int type,
     int i, j, ret = 1;
     unsigned char *p, *s;
 
+    (void)type; /* FIXME(API) */
     sig.type = V_ASN1_OCTET_STRING;
     sig.length = m_len;
     sig.data = (unsigned char *)m;
@@ -61,6 +62,7 @@ int RSA_verify_ASN1_OCTET_STRING(int dtype,
     const unsigned char *p;
     ASN1_OCTET_STRING *sig = NULL;
 
+    (void)dtype; /* FIXME(API) */
     if (siglen != (unsigned int)RSA_size(rsa)) {
         RSAerr(RSA_F_RSA_VERIFY_ASN1_OCTET_STRING,
                RSA_R_WRONG_SIGNATURE_LENGTH);

--- a/crypto/rsa/rsa_x931.c
+++ b/crypto/rsa/rsa_x931.c
@@ -56,6 +56,7 @@ int RSA_padding_check_X931(unsigned char *to, int tlen,
     int i = 0, j;
     const unsigned char *p;
 
+    (void)tlen;
     p = from;
     if ((num != flen) || ((*p != 0x6A) && (*p != 0x6B))) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_X931, RSA_R_INVALID_HEADER);

--- a/crypto/siphash/siphash_ameth.c
+++ b/crypto/siphash/siphash_ameth.c
@@ -21,6 +21,7 @@
 
 static int siphash_size(const EVP_PKEY *pkey)
 {
+    (void)pkey;
     return SIPHASH_MAX_DIGEST_SIZE;
 }
 
@@ -37,6 +38,10 @@ static void siphash_key_free(EVP_PKEY *pkey)
 
 static int siphash_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
+    (void)pkey;
+    (void)op;
+    (void)arg1;
+    (void)arg2;
     /* nothing (including ASN1_PKEY_CTRL_DEFAULT_MD_NID), is supported */
     return -2;
 }

--- a/crypto/siphash/siphash_pmeth.c
+++ b/crypto/siphash/siphash_pmeth.c
@@ -109,6 +109,7 @@ static int siphash_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen
 {
     SIPHASH_PKEY_CTX *pctx = ctx->data;
 
+    (void)mctx;
     *siglen = SipHash_hash_size(&pctx->ctx);
     if (sig != NULL)
         return SipHash_Final(&pctx->ctx, sig, *siglen);

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -69,6 +69,7 @@ int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
     static unsigned int thread_local_key = 0;
 
+    (void)cleanup;
     if (thread_local_key >= OPENSSL_CRYPTO_THREAD_LOCAL_KEY_MAX)
         return 0;
 
@@ -115,6 +116,7 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)
 
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 {
+    (void)lock;
     *val += amount;
     *ret  = *val;
 

--- a/crypto/ts/ts_asn1.c
+++ b/crypto/ts/ts_asn1.c
@@ -160,6 +160,9 @@ static int ts_resp_cb(int op, ASN1_VALUE **pval, const ASN1_ITEM *it,
                       void *exarg)
 {
     TS_RESP *ts_resp = (TS_RESP *)*pval;
+
+    (void)it;
+    (void)exarg;
     if (op == ASN1_OP_NEW_POST) {
         ts_resp->tst_info = NULL;
     } else if (op == ASN1_OP_FREE_POST) {

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -46,6 +46,7 @@ static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, void *data)
 {
     ASN1_INTEGER *serial = ASN1_INTEGER_new();
 
+    (void)data;
     if (serial == NULL)
         goto err;
     if (!ASN1_INTEGER_set(serial, 1))
@@ -65,6 +66,8 @@ static int def_time_cb(struct TS_resp_ctx *ctx, void *data,
                        long *sec, long *usec)
 {
     struct timeval tv;
+
+    (void)data;
     if (gettimeofday(&tv, NULL) != 0) {
         TSerr(TS_F_DEF_TIME_CB, TS_R_TIME_SYSCALL_ERROR);
         TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
@@ -102,6 +105,8 @@ static int def_time_cb(struct TS_resp_ctx *ctx, void *data,
 static int def_extension_cb(struct TS_resp_ctx *ctx, X509_EXTENSION *ext,
                             void *data)
 {
+    (void)ext;
+    (void)data;
     TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
                                 "Unsupported extension.");
     TS_RESP_CTX_add_failure_info(ctx, TS_INFO_UNACCEPTED_EXTENSION);

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -99,6 +99,7 @@ static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
 {
     UI_STRING *ret = NULL;
 
+    (void)ui;
     if (prompt == NULL) {
         UIerr(UI_F_GENERAL_ALLOCATE_PROMPT, ERR_R_PASSED_NULL_PARAMETER);
     } else if ((type == UIT_PROMPT || type == UIT_VERIFY
@@ -415,6 +416,7 @@ static int print_error(const char *str, size_t len, UI *ui)
 {
     UI_STRING uis;
 
+    (void)len;
     memset(&uis, 0, sizeof(uis));
     uis.type = UIT_ERROR;
     uis.out_string = str;
@@ -502,6 +504,8 @@ int UI_process(UI *ui)
 
 int UI_ctrl(UI *ui, int cmd, long i, void *p, void (*f) (void))
 {
+    (void)p;
+    (void)f;
     if (ui == NULL) {
         UIerr(UI_F_UI_CTRL, ERR_R_PASSED_NULL_PARAMETER);
         return -1;

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -214,6 +214,7 @@ UI_METHOD *UI_OpenSSL(void)
  */
 static int write_string(UI *ui, UI_STRING *uis)
 {
+    (void)ui;
     switch (UI_get_string_type(uis)) {
     case UIT_ERROR:
     case UIT_INFO:
@@ -473,6 +474,7 @@ static int open_console(UI *ui)
 
 static int noecho_console(UI *ui)
 {
+    (void)ui;
 #ifdef TTY_FLAGS
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
     tty_new.TTY_FLAGS &= ~ECHO;
@@ -515,6 +517,7 @@ static int noecho_console(UI *ui)
 
 static int echo_console(UI *ui)
 {
+    (void)ui;
 #if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
     tty_new.TTY_FLAGS |= ECHO;

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -67,12 +67,24 @@ static void ui_new_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
      * Do nothing, the data is allocated externally and assigned later with
      * CRYPTO_set_ex_data()
      */
+    (void)parent;
+    (void)ptr;
+    (void)ad;
+    (void)idx;
+    (void)argl;
+    (void)argp;
 }
 
 static int ui_dup_method_data(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
                               void *from_d, int idx, long argl, void *argp)
 {
     void **pptr = (void **)from_d;
+
+    (void)to;
+    (void)from;
+    (void)idx;
+    (void)argl;
+    (void)argp;
     if (*pptr != NULL)
         *pptr = OPENSSL_memdup(*pptr, sizeof(struct pem_password_cb_data));
     return 1;
@@ -81,6 +93,11 @@ static int ui_dup_method_data(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
 static void ui_free_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                                 int idx, long argl, void *argp)
 {
+    (void)parent;
+    (void)ad;
+    (void)idx;
+    (void)argl;
+    (void)argp;
     OPENSSL_free(ptr);
 }
 
@@ -97,6 +114,7 @@ DEFINE_RUN_ONCE_STATIC(ui_method_data_index_init)
 
 static int ui_open(UI *ui)
 {
+    (void)ui;
     return 1;
 }
 static int ui_read(UI *ui, UI_STRING *uis)
@@ -129,10 +147,13 @@ static int ui_read(UI *ui, UI_STRING *uis)
 }
 static int ui_write(UI *ui, UI_STRING *uis)
 {
+    (void)ui;
+    (void)uis;
     return 1;
 }
 static int ui_close(UI *ui)
 {
+    (void)ui;
     return 1;
 }
 

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -72,10 +72,11 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
                     char **retp)
 {
     int ret = 0;
-    BY_DIR *ld = (BY_DIR *)ctx->method_data;
+    BY_DIR *ld;
     char *dir = NULL;
 
     (void)retp;
+    ld = (BY_DIR *)ctx->method_data;
     switch (cmd) {
     case X509_L_ADD_DIR:
         if (argl == X509_FILETYPE_DEFAULT) {

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -72,11 +72,10 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
                     char **retp)
 {
     int ret = 0;
-    BY_DIR *ld;
+    BY_DIR *ld = (BY_DIR *)ctx->method_data;
     char *dir = NULL;
 
-    ld = (BY_DIR *)ctx->method_data;
-
+    (void)retp;
     switch (cmd) {
     case X509_L_ADD_DIR:
         if (argl == X509_FILETYPE_DEFAULT) {

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -44,6 +44,7 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
     int ok = 0;
     char *file;
 
+    (void)ret;
     switch (cmd) {
     case X509_L_FILE_LOAD:
         if (argl == X509_FILETYPE_DEFAULT) {

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -310,8 +310,9 @@ ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,
                                int atrtype, void *data)
 {
-    ASN1_TYPE *ttmp;
-    ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
+    ASN1_TYPE *ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
+
+    (void)data;
     if (!ttmp)
         return NULL;
     if (atrtype != ASN1_TYPE_get(ttmp)) {

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -310,9 +310,11 @@ ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,
                                int atrtype, void *data)
 {
-    ASN1_TYPE *ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
+    ASN1_TYPE *ttmp;
 
     (void)data;
+    ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
+
     if (!ttmp)
         return NULL;
     if (atrtype != ASN1_TYPE_get(ttmp)) {

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -432,11 +432,18 @@ int X509_CRL_check_suiteb(X509_CRL *crl, EVP_PKEY *pk, unsigned long flags)
 int X509_chain_check_suiteb(int *perror_depth, X509 *x, STACK_OF(X509) *chain,
                             unsigned long flags)
 {
+    (void)perror_depth;
+    (void)x;
+    (void)chain;
+    (void)flags;
     return 0;
 }
 
 int X509_CRL_check_suiteb(X509_CRL *crl, EVP_PKEY *pk, unsigned long flags)
 {
+    (void)crl;
+    (void)pk;
+    (void)flags;
     return 0;
 }
 

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -238,6 +238,7 @@ static int trust_1oid(X509_TRUST *trust, X509 *x, int flags)
 
 static int trust_compat(X509_TRUST *trust, X509 *x, int flags)
 {
+    (void)trust;
     /* Call for side-effect of computing hash and caching extensions */
     X509_check_purpose(x, -1, 0);
     if ((flags & X509_TRUST_NO_SS_COMPAT) == 0 && x->ex_flags & EXFLAG_SS)

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -101,6 +101,7 @@ static int internal_verify(X509_STORE_CTX *ctx);
 
 static int null_callback(int ok, X509_STORE_CTX *e)
 {
+    (void)e;
     return ok;
 }
 
@@ -1282,6 +1283,8 @@ static int check_crl_chain(X509_STORE_CTX *ctx,
                            STACK_OF(X509) *crl_path)
 {
     X509 *cert_ta, *crl_ta;
+
+    (void)ctx;
     cert_ta = sk_X509_value(cert_path, sk_X509_num(cert_path) - 1);
     crl_ta = sk_X509_value(crl_path, sk_X509_num(crl_path) - 1);
     if (!X509_cmp(cert_ta, crl_ta))
@@ -1941,6 +1944,8 @@ X509_CRL *X509_CRL_diff(X509_CRL *base, X509_CRL *newer,
     X509_CRL *crl = NULL;
     int i;
     STACK_OF(X509_REVOKED) *revs = NULL;
+
+    (void)flags;
     /* CRLs can't be delta already */
     if (base->base_crl_number || newer->base_crl_number) {
         X509err(X509_F_X509_CRL_DIFF, X509_R_CRL_ALREADY_DELTA);
@@ -2406,6 +2411,7 @@ void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags)
 void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
                              time_t t)
 {
+    (void)flags;
     X509_VERIFY_PARAM_set_time(ctx->param, t);
 }
 

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -49,6 +49,8 @@ static int crl_inf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 {
     X509_CRL_INFO *a = (X509_CRL_INFO *)*pval;
 
+    (void)it;
+    (void)exarg;
     if (!a || !a->revoked)
         return 1;
     switch (operation) {
@@ -157,6 +159,8 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     X509_EXTENSION *ext;
     int idx;
 
+    (void)it;
+    (void)exarg;
     switch (operation) {
     case ASN1_OP_NEW_POST:
         crl->idp = NULL;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -91,6 +91,7 @@ static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *it)
 {
     X509_NAME *ret = OPENSSL_zalloc(sizeof(*ret));
 
+    (void)it;
     if (ret == NULL)
         goto memerr;
     if ((ret->entries = sk_X509_NAME_ENTRY_new_null()) == NULL)
@@ -114,6 +115,7 @@ static void x509_name_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
     X509_NAME *a;
 
+    (void)it;
     if (!pval || !*pval)
         return;
     a = (X509_NAME *)*pval;
@@ -156,6 +158,8 @@ static int x509_name_ex_d2i(ASN1_VALUE **val,
     int i, j, ret;
     STACK_OF(X509_NAME_ENTRY) *entries;
     X509_NAME_ENTRY *entry;
+
+    (void)it;
     if (len > X509_NAME_MAX)
         len = X509_NAME_MAX;
     q = p;
@@ -212,6 +216,10 @@ static int x509_name_ex_i2d(ASN1_VALUE **val, unsigned char **out,
 {
     int ret;
     X509_NAME *a = (X509_NAME *)*val;
+
+    (void)it;
+    (void)tag;
+    (void)aclass;
     if (a->modified) {
         ret = x509_name_encode(a);
         if (ret < 0)
@@ -281,6 +289,7 @@ static int x509_name_ex_print(BIO *out, ASN1_VALUE **pval,
                               int indent,
                               const char *fname, const ASN1_PCTX *pctx)
 {
+    (void)fname;
     if (X509_NAME_print_ex(out, (const X509_NAME *)*pval,
                            indent, pctx->nm_flags) <= 0)
         return 0;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -29,6 +29,8 @@ static int x509_pubkey_decode(EVP_PKEY **pk, X509_PUBKEY *key);
 static int pubkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                      void *exarg)
 {
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_FREE_POST) {
         X509_PUBKEY *pubkey = (X509_PUBKEY *)*pval;
         EVP_PKEY_free(pubkey->pkey);

--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -37,6 +37,8 @@ static int rinf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 {
     X509_REQ_INFO *rinf = (X509_REQ_INFO *)*pval;
 
+    (void)it;
+    (void)exarg;
     if (operation == ASN1_OP_NEW_POST) {
         rinf->attributes = sk_X509_ATTRIBUTE_new_null();
         if (!rinf->attributes)

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -38,6 +38,8 @@ static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 {
     X509 *ret = (X509 *)*pval;
 
+    (void)it;
+    (void)exarg;
     switch (operation) {
 
     case ASN1_OP_NEW_POST:

--- a/crypto/x509v3/v3_addr.c
+++ b/crypto/x509v3/v3_addr.c
@@ -198,6 +198,8 @@ static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *method,
 {
     const IPAddrBlocks *addr = ext;
     int i;
+
+    (void)method;
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);
         const unsigned int afi = X509v3_addr_get_afi(f);
@@ -892,6 +894,8 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
     char *s = NULL, *t;
     int i;
 
+    (void)method;
+    (void)ctx;
     if ((addr = sk_IPAddressFamily_new(IPAddressFamily_cmp)) == NULL) {
         X509V3err(X509V3_F_V2I_IPADDRBLOCKS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_akey.c
+++ b/crypto/x509v3/v3_akey.c
@@ -40,6 +40,8 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
                                                  *extlist)
 {
     char *tmp;
+
+    (void)method;
     if (akeyid->keyid) {
         tmp = OPENSSL_buf2hexstr(akeyid->keyid->data, akeyid->keyid->length);
         X509V3_add_value("keyid", tmp, &extlist);
@@ -80,6 +82,7 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     X509 *cert;
     AUTHORITY_KEYID *akeyid;
 
+    (void)method;
     for (i = 0; i < sk_CONF_VALUE_num(values); i++) {
         cnf = sk_CONF_VALUE_value(values, i);
         if (strcmp(cnf->name, "keyid") == 0) {

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -68,6 +68,8 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
     unsigned char *p;
     char oline[256], htmp[5];
     int i;
+
+    (void)method;
     switch (gen->type) {
     case GEN_OTHERNAME:
         X509V3_add_value("othername", "<unsupported>", &ret);
@@ -389,6 +391,7 @@ GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
     char is_string = 0;
     GENERAL_NAME *gen = NULL;
 
+    (void)method;
     if (!value) {
         X509V3err(X509V3_F_A2I_GENERAL_NAME, X509V3_R_MISSING_VALUE);
         return NULL;

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -109,6 +109,8 @@ static int i2r_ASIdentifiers(const X509V3_EXT_METHOD *method,
                              void *ext, BIO *out, int indent)
 {
     ASIdentifiers *asid = ext;
+
+    (void)method;
     return (i2r_ASIdentifierChoice(out, asid->asnum, indent,
                                    "Autonomous System Numbers") &&
             i2r_ASIdentifierChoice(out, asid->rdi, indent,
@@ -501,6 +503,8 @@ static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
     ASIdentifiers *asid = NULL;
     int i;
 
+    (void)method;
+    (void)ctx;
     if ((asid = ASIdentifiers_new()) == NULL) {
         X509V3err(X509V3_F_V2I_ASIDENTIFIERS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_bcons.c
+++ b/crypto/x509v3/v3_bcons.c
@@ -46,6 +46,7 @@ static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
                                                    STACK_OF(CONF_VALUE)
                                                    *extlist)
 {
+    (void)method;
     X509V3_add_value_bool("CA", bcons->ca, &extlist);
     X509V3_add_value_int("pathlen", bcons->pathlen, &extlist);
     return extlist;
@@ -59,6 +60,8 @@ static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
     CONF_VALUE *val;
     int i;
 
+    (void)method;
+    (void)ctx;
     if ((bcons = BASIC_CONSTRAINTS_new()) == NULL) {
         X509V3err(X509V3_F_V2I_BASIC_CONSTRAINTS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_bitst.c
+++ b/crypto/x509v3/v3_bitst.c
@@ -63,6 +63,8 @@ ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
     ASN1_BIT_STRING *bs;
     int i;
     BIT_STRING_BITNAME *bnam;
+
+    (void)ctx;
     if ((bs = ASN1_BIT_STRING_new()) == NULL) {
         X509V3err(X509V3_F_V2I_ASN1_BIT_STRING, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_cpols.c
+++ b/crypto/x509v3/v3_cpols.c
@@ -93,6 +93,8 @@ static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
     STACK_OF(CONF_VALUE) *vals;
     CONF_VALUE *cnf;
     int i, ia5org;
+
+    (void)method;
     pols = sk_POLICYINFO_new_null();
     if (pols == NULL) {
         X509V3err(X509V3_F_R2I_CERTPOL, ERR_R_MALLOC_FAILURE);
@@ -250,6 +252,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
     USERNOTICE *not;
     POLICYQUALINFO *qual;
 
+    (void)ctx;
     if ((qual = POLICYQUALINFO_new()) == NULL)
         goto merr;
     if ((qual->pqualid = OBJ_nid2obj(NID_id_qt_unotice)) == NULL) {
@@ -357,6 +360,8 @@ static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
 {
     int i;
     POLICYINFO *pinfo;
+
+    (void)method;
     /* First print out the policy OIDs */
     for (i = 0; i < sk_POLICYINFO_num(pol); i++) {
         pinfo = sk_POLICYINFO_value(pol, i);

--- a/crypto/x509v3/v3_crld.c
+++ b/crypto/x509v3/v3_crld.c
@@ -298,6 +298,8 @@ static int dpn_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 {
     DIST_POINT_NAME *dpn = (DIST_POINT_NAME *)*pval;
 
+    (void)it;
+    (void)exarg;
     switch (operation) {
     case ASN1_OP_NEW_POST:
         dpn->dpname = NULL;
@@ -367,6 +369,8 @@ static void *v2i_idp(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
     CONF_VALUE *cnf;
     char *name, *val;
     int i, ret;
+
+    (void)method;
     idp = ISSUING_DIST_POINT_new();
     if (idp == NULL)
         goto merr;
@@ -439,6 +443,8 @@ static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
                    int indent)
 {
     ISSUING_DIST_POINT *idp = pidp;
+
+    (void)method;
     if (idp->distpoint)
         print_distpoint(out, idp->distpoint, indent);
     if (idp->onlyuser > 0)
@@ -465,6 +471,8 @@ static int i2r_crldp(const X509V3_EXT_METHOD *method, void *pcrldp, BIO *out,
     STACK_OF(DIST_POINT) *crld = pcrldp;
     DIST_POINT *point;
     int i;
+
+    (void)method;
     for (i = 0; i < sk_DIST_POINT_num(crld); i++) {
         BIO_puts(out, "\n");
         point = sk_DIST_POINT_value(crld, i);

--- a/crypto/x509v3/v3_extku.c
+++ b/crypto/x509v3/v3_extku.c
@@ -58,6 +58,8 @@ static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD
     int i;
     ASN1_OBJECT *obj;
     char obj_tmp[80];
+
+    (void)method;
     for (i = 0; i < sk_ASN1_OBJECT_num(eku); i++) {
         obj = sk_ASN1_OBJECT_value(eku, i);
         i2t_ASN1_OBJECT(obj_tmp, 80, obj);
@@ -76,6 +78,8 @@ static void *v2i_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *method,
     CONF_VALUE *val;
     int i;
 
+    (void)method;
+    (void)ctx;
     if ((extku = sk_ASN1_OBJECT_new_null()) == NULL) {
         X509V3err(X509V3_F_V2I_EXTENDED_KEY_USAGE, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_ia5.c
+++ b/crypto/x509v3/v3_ia5.c
@@ -29,6 +29,7 @@ char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
 {
     char *tmp;
 
+    (void)method;
     if (!ia5 || !ia5->length)
         return NULL;
     if ((tmp = OPENSSL_malloc(ia5->length + 1)) == NULL) {
@@ -44,6 +45,9 @@ ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
                                    X509V3_CTX *ctx, const char *str)
 {
     ASN1_IA5STRING *ia5;
+
+    (void)method;
+    (void)ctx;
     if (!str) {
         X509V3err(X509V3_F_S2I_ASN1_IA5STRING,
                   X509V3_R_INVALID_NULL_ARGUMENT);

--- a/crypto/x509v3/v3_int.c
+++ b/crypto/x509v3/v3_int.c
@@ -31,6 +31,7 @@ const X509V3_EXT_METHOD v3_delta_crl = {
 static void *s2i_asn1_int(X509V3_EXT_METHOD *meth, X509V3_CTX *ctx,
                           const char *value)
 {
+    (void)ctx;
     return s2i_ASN1_INTEGER(meth, value);
 }
 

--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -127,6 +127,8 @@ static int do_i2r_name_constraints(const X509V3_EXT_METHOD *method,
 {
     GENERAL_SUBTREE *tree;
     int i;
+
+    (void)method;
     if (sk_GENERAL_SUBTREE_num(trees) > 0)
         BIO_printf(bp, "%*s%s:\n", ind, "", name);
     for (i = 0; i < sk_GENERAL_SUBTREE_num(trees); i++) {

--- a/crypto/x509v3/v3_pci.c
+++ b/crypto/x509v3/v3_pci.c
@@ -63,6 +63,7 @@ const X509V3_EXT_METHOD v3_pci =
 static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *pci,
                    BIO *out, int indent)
 {
+    (void)method;
     BIO_printf(out, "%*sPath Length Constraint: ", indent, "");
     if (pci->pcPathLengthConstraint)
         i2a_ASN1_INTEGER(out, pci->pcPathLengthConstraint);
@@ -246,6 +247,7 @@ static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
     ASN1_OCTET_STRING *policy = NULL;
     int i, j;
 
+    (void)method;
     vals = X509V3_parse_list(value);
     for (i = 0; i < sk_CONF_VALUE_num(vals); i++) {
         CONF_VALUE *cnf = sk_CONF_VALUE_value(vals, i);

--- a/crypto/x509v3/v3_pcons.c
+++ b/crypto/x509v3/v3_pcons.c
@@ -45,6 +45,8 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD
                                                     *extlist)
 {
     POLICY_CONSTRAINTS *pcons = a;
+
+    (void)method;
     X509V3_add_value_int("Require Explicit Policy",
                          pcons->requireExplicitPolicy, &extlist);
     X509V3_add_value_int("Inhibit Policy Mapping",
@@ -60,6 +62,8 @@ static void *v2i_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD *method,
     CONF_VALUE *val;
     int i;
 
+    (void)method;
+    (void)ctx;
     if ((pcons = POLICY_CONSTRAINTS_new()) == NULL) {
         X509V3err(X509V3_F_V2I_POLICY_CONSTRAINTS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_pku.c
+++ b/crypto/x509v3/v3_pku.c
@@ -40,6 +40,7 @@ static int i2r_PKEY_USAGE_PERIOD(X509V3_EXT_METHOD *method,
                                  PKEY_USAGE_PERIOD *usage, BIO *out,
                                  int indent)
 {
+    (void)method;
     BIO_printf(out, "%*s", indent, "");
     if (usage->notBefore) {
         BIO_write(out, "Not Before: ", 12);

--- a/crypto/x509v3/v3_pmaps.c
+++ b/crypto/x509v3/v3_pmaps.c
@@ -52,6 +52,8 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD
     int i;
     char obj_tmp1[80];
     char obj_tmp2[80];
+
+    (void)method;
     for (i = 0; i < sk_POLICY_MAPPING_num(pmaps); i++) {
         pmap = sk_POLICY_MAPPING_value(pmaps, i);
         i2t_ASN1_OBJECT(obj_tmp1, 80, pmap->issuerDomainPolicy);
@@ -70,6 +72,8 @@ static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *method,
     CONF_VALUE *val;
     int i;
 
+    (void)method;
+    (void)ctx;
     if ((pmaps = sk_POLICY_MAPPING_new_null()) == NULL) {
         X509V3err(X509V3_F_V2I_POLICY_MAPPINGS, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -566,6 +566,7 @@ static int check_ssl_ca(const X509 *x)
 static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
                                     int ca)
 {
+    (void)xp;
     if (xku_reject(x, XKU_SSL_CLIENT))
         return 0;
     if (ca)
@@ -590,6 +591,7 @@ static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
 static int check_purpose_ssl_server(const X509_PURPOSE *xp, const X509 *x,
                                     int ca)
 {
+    (void)xp;
     if (xku_reject(x, XKU_SSL_SERVER | XKU_SGC))
         return 0;
     if (ca)
@@ -647,8 +649,9 @@ static int purpose_smime(const X509 *x, int ca)
 static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
                                     int ca)
 {
-    int ret;
-    ret = purpose_smime(x, ca);
+    int ret = purpose_smime(x, ca);
+
+    (void)xp;
     if (!ret || ca)
         return ret;
     if (ku_reject(x, KU_DIGITAL_SIGNATURE | KU_NON_REPUDIATION))
@@ -659,8 +662,9 @@ static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
 static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
                                        int ca)
 {
-    int ret;
-    ret = purpose_smime(x, ca);
+    int ret = purpose_smime(x, ca);
+
+    (void)xp;
     if (!ret || ca)
         return ret;
     if (ku_reject(x, KU_KEY_ENCIPHERMENT))
@@ -671,6 +675,7 @@ static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
 static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
                                   int ca)
 {
+    (void)xp;
     if (ca) {
         int ca_ret;
         if ((ca_ret = check_ca(x)) != 2)
@@ -690,6 +695,7 @@ static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
 
 static int ocsp_helper(const X509_PURPOSE *xp, const X509 *x, int ca)
 {
+    (void)xp;
     /*
      * Must be a valid CA.  Should we really support the "I don't know" value
      * (2)?
@@ -705,6 +711,7 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
 {
     int i_ext;
 
+    (void)xp;
     /* If ca is true we must return if this is a valid CA certificate. */
     if (ca)
         return check_ca(x);
@@ -737,6 +744,9 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
 
 static int no_check(const X509_PURPOSE *xp, const X509 *x, int ca)
 {
+    (void)xp;
+    (void)x;
+    (void)ca;
     return 1;
 }
 

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -649,9 +649,10 @@ static int purpose_smime(const X509 *x, int ca)
 static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
                                     int ca)
 {
-    int ret = purpose_smime(x, ca);
+    int ret;
 
     (void)xp;
+    ret = purpose_smime(x, ca);
     if (!ret || ca)
         return ret;
     if (ku_reject(x, KU_DIGITAL_SIGNATURE | KU_NON_REPUDIATION))
@@ -662,9 +663,10 @@ static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
 static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
                                        int ca)
 {
-    int ret = purpose_smime(x, ca);
+    int ret;
 
     (void)xp;
+    ret = purpose_smime(x, ca);
     if (!ret || ca)
         return ret;
     if (ku_reject(x, KU_KEY_ENCIPHERMENT))

--- a/crypto/x509v3/v3_skey.c
+++ b/crypto/x509v3/v3_skey.c
@@ -27,6 +27,7 @@ const X509V3_EXT_METHOD v3_skey_id = {
 char *i2s_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
                             const ASN1_OCTET_STRING *oct)
 {
+    (void)method;
     return OPENSSL_buf2hexstr(oct->data, oct->length);
 }
 
@@ -36,6 +37,8 @@ ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
     ASN1_OCTET_STRING *oct;
     long length;
 
+    (void)method;
+    (void)ctx;
     if ((oct = ASN1_OCTET_STRING_new()) == NULL) {
         X509V3err(X509V3_F_S2I_ASN1_OCTET_STRING, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_sxnet.c
+++ b/crypto/x509v3/v3_sxnet.c
@@ -57,11 +57,12 @@ IMPLEMENT_ASN1_FUNCTIONS(SXNET)
 static int sxnet_i2r(X509V3_EXT_METHOD *method, SXNET *sx, BIO *out,
                      int indent)
 {
-    long v;
+    long v = ASN1_INTEGER_get(sx->version);
     char *tmp;
     SXNETID *id;
     int i;
-    v = ASN1_INTEGER_get(sx->version);
+
+    (void)method;
     BIO_printf(out, "%*sVersion: %ld (0x%lX)", indent, "", v + 1, v);
     for (i = 0; i < sk_SXNETID_num(sx->ids); i++) {
         id = sk_SXNETID_value(sx->ids, i);
@@ -87,6 +88,9 @@ static SXNET *sxnet_v2i(X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
     CONF_VALUE *cnf;
     SXNET *sx = NULL;
     int i;
+
+    (void)method;
+    (void)ctx;
     for (i = 0; i < sk_CONF_VALUE_num(nval); i++) {
         cnf = sk_CONF_VALUE_value(nval, i);
         if (!SXNET_add_id_asc(&sx, cnf->name, cnf->value, -1))

--- a/crypto/x509v3/v3_sxnet.c
+++ b/crypto/x509v3/v3_sxnet.c
@@ -57,12 +57,13 @@ IMPLEMENT_ASN1_FUNCTIONS(SXNET)
 static int sxnet_i2r(X509V3_EXT_METHOD *method, SXNET *sx, BIO *out,
                      int indent)
 {
-    long v = ASN1_INTEGER_get(sx->version);
+    long v;
     char *tmp;
     SXNETID *id;
     int i;
 
     (void)method;
+    v = ASN1_INTEGER_get(sx->version);
     BIO_printf(out, "%*sVersion: %ld (0x%lX)", indent, "", v + 1, v);
     for (i = 0; i < sk_SXNETID_num(sx->ids); i++) {
         id = sk_SXNETID_value(sx->ids, i);

--- a/crypto/x509v3/v3_tlsf.c
+++ b/crypto/x509v3/v3_tlsf.c
@@ -64,6 +64,8 @@ static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *method,
     size_t j;
     ASN1_INTEGER *ai;
     long tlsextid;
+
+    (void)method;
     for (i = 0; i < sk_ASN1_INTEGER_num(tls_feature); i++) {
         ai = sk_ASN1_INTEGER_value(tls_feature, i);
         tlsextid = ASN1_INTEGER_get(ai);
@@ -94,6 +96,8 @@ static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *method,
     size_t j;
     long tlsextid;
 
+    (void)method;
+    (void)ctx;
     if ((tlsf = sk_ASN1_INTEGER_new_null()) == NULL) {
         X509V3err(X509V3_F_V2I_TLS_FEATURE, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -99,6 +99,7 @@ char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, const ASN1_ENUMERATED *a)
     BIGNUM *bntmp = NULL;
     char *strtmp = NULL;
 
+    (void)method;
     if (!a)
         return NULL;
     if ((bntmp = ASN1_ENUMERATED_to_BN(a, NULL)) == NULL
@@ -113,6 +114,7 @@ char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, const ASN1_INTEGER *a)
     BIGNUM *bntmp = NULL;
     char *strtmp = NULL;
 
+    (void)method;
     if (!a)
         return NULL;
     if ((bntmp = ASN1_INTEGER_to_BN(a, NULL)) == NULL
@@ -128,6 +130,8 @@ ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *method, const char *value)
     ASN1_INTEGER *aint;
     int isneg, ishex;
     int ret;
+
+    (void)method;
     if (value == NULL) {
         X509V3err(X509V3_F_S2I_ASN1_INTEGER, X509V3_R_INVALID_NULL_VALUE);
         return NULL;
@@ -567,6 +571,8 @@ static int equal_email(const unsigned char *a, size_t a_len,
                        unsigned int unused_flags)
 {
     size_t i = a_len;
+
+    (void)unused_flags;
     if (a_len != b_len)
         return 0;
     /*

--- a/e_os.h
+++ b/e_os.h
@@ -42,7 +42,6 @@ extern "C" {
 #  define REF_PRINT_COUNT(a, b)
 # endif
 
-# define osslargused(x)      (void)x
 # define OPENSSL_CONF        "openssl.cnf"
 
 # ifndef DEVRANDOM

--- a/engines/e_capi.c
+++ b/engines/e_capi.c
@@ -1903,6 +1903,9 @@ OPENSSL_EXPORT
 OPENSSL_EXPORT
     int bind_engine(ENGINE *e, const char *id, const dynamic_fns *fns)
 {
+    (void)e;
+    (void)id;
+    (void)fns;
     return 0;
 }
 

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -319,18 +319,21 @@ void engine_load_dasync_int(void)
 
 static int dasync_init(ENGINE *e)
 {
+    (void)e;
     return 1;
 }
 
 
 static int dasync_finish(ENGINE *e)
 {
+    (void)e;
     return 1;
 }
 
 
 static int dasync_destroy(ENGINE *e)
 {
+    (void)e;
     destroy_digests();
     destroy_ciphers();
     RSA_meth_free(dasync_rsa_method);
@@ -342,6 +345,8 @@ static int dasync_digests(ENGINE *e, const EVP_MD **digest,
                           const int **nids, int nid)
 {
     int ok = 1;
+
+    (void)e;
     if (!digest) {
         /* We are returning a list of supported nids */
         return dasync_digest_nids(nids);
@@ -363,6 +368,8 @@ static int dasync_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                                    const int **nids, int nid)
 {
     int ok = 1;
+
+    (void)e;
     if (cipher == NULL) {
         /* We are returning a list of supported nids */
         *nids = dasync_cipher_nids;
@@ -389,6 +396,9 @@ static void wait_cleanup(ASYNC_WAIT_CTX *ctx, const void *key,
                          OSSL_ASYNC_FD readfd, void *pvwritefd)
 {
     OSSL_ASYNC_FD *pwritefd = (OSSL_ASYNC_FD *)pvwritefd;
+
+    (void)ctx;
+    (void)key;
 #if defined(ASYNC_WIN)
     CloseHandle(readfd);
     CloseHandle(*pwritefd);

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -399,6 +399,9 @@ static void wait_cleanup(ASYNC_WAIT_CTX *ctx, const void *key,
 
     (void)ctx;
     (void)key;
+#ifndef OPENSSL_THREADS
+    (void)readfd;
+#endif
 #if defined(ASYNC_WIN)
     CloseHandle(readfd);
     CloseHandle(*pwritefd);

--- a/engines/e_dasync_err.c
+++ b/engines/e_dasync_err.c
@@ -96,6 +96,10 @@ static void ERR_unload_DASYNC_strings(void)
 
 static void ERR_DASYNC_error(int function, int reason, char *file, int line)
 {
+#ifdef OPENSSL_NO_ERR
+    (void)file;
+    (void)line;
+#endif
     if (DASYNC_lib_error_code == 0)
         DASYNC_lib_error_code = ERR_get_next_error_library();
     ERR_PUT_error(DASYNC_lib_error_code, function, reason, file, line);

--- a/engines/e_ossltest.c
+++ b/engines/e_ossltest.c
@@ -360,18 +360,21 @@ void ENGINE_load_ossltest(void)
 
 static int ossltest_init(ENGINE *e)
 {
+    (void)e;
     return 1;
 }
 
 
 static int ossltest_finish(ENGINE *e)
 {
+    (void)e;
     return 1;
 }
 
 
 static int ossltest_destroy(ENGINE *e)
 {
+    (void)e;
     destroy_digests();
     destroy_ciphers();
     ERR_unload_OSSLTEST_strings();
@@ -382,6 +385,8 @@ static int ossltest_digests(ENGINE *e, const EVP_MD **digest,
                           const int **nids, int nid)
 {
     int ok = 1;
+
+    (void)e;
     if (!digest) {
         /* We are returning a list of supported nids */
         return ossltest_digest_nids(nids);
@@ -415,6 +420,8 @@ static int ossltest_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                           const int **nids, int nid)
 {
     int ok = 1;
+
+    (void)e;
     if (!cipher) {
         /* We are returning a list of supported nids */
         *nids = ossltest_cipher_nids;

--- a/engines/e_ossltest_err.c
+++ b/engines/e_ossltest_err.c
@@ -83,6 +83,10 @@ static void ERR_unload_OSSLTEST_strings(void)
 
 static void ERR_OSSLTEST_error(int function, int reason, char *file, int line)
 {
+#ifdef OPENSSL_NO_ERR
+    (void)file;
+    (void)line;
+#endif
     if (OSSLTEST_lib_error_code == 0)
         OSSLTEST_lib_error_code = ERR_get_next_error_library();
     ERR_PUT_error(OSSLTEST_lib_error_code, function, reason, file, line);

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -141,6 +141,7 @@ static ENGINE *ENGINE_padlock(void)
 /* Check availability of the engine */
 static int padlock_init(ENGINE *e)
 {
+    (void)e;
     return (padlock_use_rng || padlock_use_ace);
 }
 
@@ -527,6 +528,7 @@ static int
 padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
                 int nid)
 {
+    (void)e;
     /* No specific cipher => return a list of supported nids ... */
     if (!cipher) {
         *nids = padlock_cipher_nids;
@@ -601,6 +603,7 @@ padlock_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int key_len = EVP_CIPHER_CTX_key_length(ctx) * 8;
     unsigned long mode = EVP_CIPHER_CTX_mode(ctx);
 
+    (void)iv;
     if (key == NULL)
         return 0;               /* ERROR */
 

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -742,6 +742,9 @@ OPENSSL_EXPORT
 OPENSSL_EXPORT
     int bind_engine(ENGINE *e, const char *id, const dynamic_fns *fns)
 {
+    (void)e;
+    (void)id;
+    (void)fns;
     return 0;
 }
 

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -188,6 +188,8 @@ static ASN1_PCTX *pctx;
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     pctx = ASN1_PCTX_new();
     ASN1_PCTX_set_flags(pctx, ASN1_PCTX_FLAGS_SHOW_ABSENT |
         ASN1_PCTX_FLAGS_SHOW_SEQUENCE | ASN1_PCTX_FLAGS_SHOW_SSOF |

--- a/fuzz/asn1parse.c
+++ b/fuzz/asn1parse.c
@@ -23,6 +23,8 @@ static BIO *bio_out;
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     bio_out = BIO_new_file("/dev/null", "w");
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();

--- a/fuzz/bignum.c
+++ b/fuzz/bignum.c
@@ -21,6 +21,8 @@
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
 

--- a/fuzz/bndiv.c
+++ b/fuzz/bndiv.c
@@ -27,6 +27,8 @@ static BIGNUM *b5;
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     b1 = BN_new();
     b2 = BN_new();
     b3 = BN_new();

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -27,6 +27,8 @@ static int idx;
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     STACK_OF(SSL_COMP) *comp_methods;
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);

--- a/fuzz/cms.c
+++ b/fuzz/cms.c
@@ -19,6 +19,8 @@
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);

--- a/fuzz/conf.c
+++ b/fuzz/conf.c
@@ -18,6 +18,8 @@
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
     return 1;

--- a/fuzz/crl.c
+++ b/fuzz/crl.c
@@ -15,6 +15,8 @@
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);

--- a/fuzz/ct.c
+++ b/fuzz/ct.c
@@ -19,6 +19,8 @@
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     CRYPTO_free_ex_index(0, -1);
     ERR_get_state();

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -477,6 +477,8 @@ int FuzzerInitialize(int *argc, char ***argv)
 {
     STACK_OF(SSL_COMP) *comp_methods;
 
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
     ERR_get_state();

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -15,6 +15,8 @@
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
+    (void)argc;
+    (void)argv;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -9,6 +9,7 @@
 #ifndef HEADER_INTERNAL_REFCOUNT_H
 # define HEADER_INTERNAL_REFCOUNT_H
 
+
 # if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
 # include <stdatomic.h>
 # define HAVE_C11_ATOMICS
@@ -42,12 +43,14 @@ typedef int CRYPTO_REF_COUNT;
 
 static ossl_inline int CRYPTO_UP_REF(int *val, int *ret, void *lock)
 {
+    (void)lock;
     *ret = __atomic_fetch_add(val, 1, __ATOMIC_RELAXED) + 1;
     return 1;
 }
 
 static ossl_inline int CRYPTO_DOWN_REF(int *val, int *ret, void *lock)
 {
+    (void)lock;
     *ret = __atomic_fetch_sub(val, 1, __ATOMIC_RELEASE) - 1;
     if (*ret == 0)
         __atomic_thread_fence(__ATOMIC_ACQUIRE);

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -454,6 +454,8 @@ BIO *BIO_new_buffer_ssl_connect(SSL_CTX *ctx)
  err:
     BIO_free(buf);
     BIO_free(ssl);
+#else
+    (void)ctx;
 #endif
     return (NULL);
 }
@@ -472,6 +474,8 @@ BIO *BIO_new_ssl_connect(SSL_CTX *ctx)
     return (ret);
  err:
     BIO_free(con);
+#else
+    (void)ctx;
 #endif
     return (NULL);
 }

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -608,6 +608,9 @@ int ssl3_do_uncompress(SSL *ssl, SSL3_RECORD *rr)
     else
         rr->length = i;
     rr->data = rr->comp;
+#else
+    (void)ssl;
+    (void)rr;
 #endif
     return 1;
 }
@@ -627,6 +630,9 @@ int ssl3_do_compress(SSL *ssl, SSL3_RECORD *wr)
         wr->length = i;
 
     wr->input = wr->data;
+#else
+    (void)ssl;
+    (void)wr;
 #endif
     return (1);
 }

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -2854,6 +2854,7 @@ const SSL_CIPHER *ssl3_get_cipher(unsigned int u)
 
 int ssl3_set_handshake_header(SSL *s, WPACKET *pkt, int htype)
 {
+    (void)s;
     /* No header in the event of a CCS */
     if (htype == SSL3_MT_CHANGE_CIPHER_SPEC)
         return 1;
@@ -2953,6 +2954,7 @@ void ssl3_clear(SSL *s)
 #ifndef OPENSSL_NO_SRP
 static char *srp_password_from_info_cb(SSL *s, void *arg)
 {
+    (void)arg;
     return OPENSSL_strdup(s->srp_ctx.info);
 }
 #endif

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -881,8 +881,10 @@ static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
                                          int op, int bits, int nid, void *other,
                                          void *ex)
 {
-    int level, minbits;
     static const int minbits_table[5] = { 80, 112, 128, 192, 256 };
+    int level, minbits;
+
+    (void)ex;
     if (ctx)
         level = SSL_CTX_get_security_level(ctx);
     else

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -881,8 +881,8 @@ static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
                                          int op, int bits, int nid, void *other,
                                          void *ex)
 {
-    static const int minbits_table[5] = { 80, 112, 128, 192, 256 };
     int level, minbits;
+    static const int minbits_table[5] = { 80, 112, 128, 192, 256 };
 
     (void)ex;
     if (ctx)

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1785,11 +1785,14 @@ STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void)
 STACK_OF(SSL_COMP) *SSL_COMP_set0_compression_methods(STACK_OF(SSL_COMP)
                                                       *meths)
 {
+    (void)meths;
     return meths;
 }
 
 int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm)
 {
+    (void)id;
+    (void)cm;
     return 1;
 }
 
@@ -1875,6 +1878,7 @@ const char *SSL_COMP_get_name(const COMP_METHOD *comp)
 #ifndef OPENSSL_NO_COMP
     return comp ? COMP_get_name(comp) : NULL;
 #else
+    (void)comp;
     return NULL;
 #endif
 }
@@ -1884,6 +1888,7 @@ const char *SSL_COMP_get0_name(const SSL_COMP *comp)
 #ifndef OPENSSL_NO_COMP
     return comp->name;
 #else
+    (void)comp;
     return NULL;
 #endif
 }
@@ -1893,6 +1898,7 @@ int SSL_COMP_get_id(const SSL_COMP *comp)
 #ifndef OPENSSL_NO_COMP
     return comp->id;
 #else
+    (void)comp;
     return -1;
 #endif
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3395,6 +3395,7 @@ const COMP_METHOD *SSL_get_current_compression(SSL *s)
 #ifndef OPENSSL_NO_COMP
     return s->compress ? COMP_CTX_get_method(s->compress) : NULL;
 #else
+    (void)s;
     return NULL;
 #endif
 }
@@ -3404,6 +3405,7 @@ const COMP_METHOD *SSL_get_current_expansion(SSL *s)
 #ifndef OPENSSL_NO_COMP
     return s->expand ? COMP_CTX_get_method(s->expand) : NULL;
 #else
+    (void)s;
     return NULL;
 #endif
 }
@@ -4094,6 +4096,7 @@ static int ct_extract_ocsp_response_scts(SSL *s)
     OCSP_RESPONSE_free(rsp);
     return scts_extracted;
 # else
+    (void)s;
     /* Behave as if no OCSP response exists */
     return 0;
 # endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3143,6 +3143,7 @@ void SSL_set_connect_state(SSL *s)
 
 int ssl_undefined_function(SSL *s)
 {
+    (void)s;
     SSLerr(SSL_F_SSL_UNDEFINED_FUNCTION, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return (0);
 }
@@ -3156,11 +3157,13 @@ int ssl_undefined_void_function(void)
 
 int ssl_undefined_const_function(const SSL *s)
 {
+    (void)s;
     return (0);
 }
 
 const SSL_METHOD *ssl_bad_method(int ver)
 {
+    (void)ver;
     SSLerr(SSL_F_SSL_BAD_METHOD, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return (NULL);
 }
@@ -3644,6 +3647,7 @@ void *SSL_CTX_get_ex_data(const SSL_CTX *s, int idx)
 
 int ssl_ok(SSL *s)
 {
+    (void)s;
     return (1);
 }
 
@@ -4141,6 +4145,9 @@ const STACK_OF(SCT) *SSL_get0_peer_scts(SSL *s)
 static int ct_permissive(const CT_POLICY_EVAL_CTX * ctx,
                          const STACK_OF(SCT) *scts, void *unused_arg)
 {
+    (void)ctx;
+    (void)scts;
+    (void)unused_arg;
     return 1;
 }
 
@@ -4150,6 +4157,8 @@ static int ct_strict(const CT_POLICY_EVAL_CTX * ctx,
     int count = scts != NULL ? sk_SCT_num(scts) : 0;
     int i;
 
+    (void)ctx;
+    (void)unused_arg;
     for (i = 0; i < count; ++i) {
         SCT *sct = sk_SCT_value(scts, i);
         int status = SCT_get_validation_status(sct);

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -36,6 +36,8 @@ static size_t ssl_names_count;
 static void ssl_module_free(CONF_IMODULE *md)
 {
     size_t i, j;
+
+    (void)md;
     if (ssl_names == NULL)
         return;
     for (i = 0; i < ssl_names_count; i++) {

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -740,7 +740,10 @@ static int serverinfo_srv_parse_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char *in,
                                    size_t inlen, int *al, void *arg)
 {
-
+    (void)s;
+    (void)ext_type;
+    (void)in;
+    (void)arg;
     if (inlen != 0) {
         *al = SSL_AD_DECODE_ERROR;
         return 0;
@@ -756,6 +759,7 @@ static int serverinfo_srv_add_cb(SSL *s, unsigned int ext_type,
     const unsigned char *serverinfo = NULL;
     size_t serverinfo_length = 0;
 
+    (void)arg;
     /* Is there serverinfo data for the chosen server cert? */
     if ((ssl_get_server_cert_serverinfo(s, &serverinfo,
                                         &serverinfo_length)) != 0) {

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -985,6 +985,7 @@ static int final_sig_algs(SSL *s, unsigned int context, int sent, int *al)
 
 static int final_key_share(SSL *s, unsigned int context, int sent, int *al)
 {
+    (void)context;
     if (!SSL_IS_TLS13(s))
         return 1;
 
@@ -1103,6 +1104,7 @@ static int final_key_share(SSL *s, unsigned int context, int sent, int *al)
 
 static int init_psk_kex_modes(SSL *s, unsigned int context)
 {
+    (void)context;
     s->ext.psk_kex_mode = TLSEXT_KEX_MODE_FLAG_NONE;
     return 1;
 }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -349,6 +349,7 @@ static int verify_extension(SSL *s, unsigned int context, unsigned int type,
 static int extension_is_relevant(SSL *s, unsigned int extctx,
                                  unsigned int thisctx)
 {
+    (void)thisctx;
     if ((SSL_IS_DTLS(s)
                 && (extctx & EXT_TLS_IMPLEMENTATION_ONLY) != 0)
             || (s->version == SSL3_VERSION
@@ -691,6 +692,7 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
 static int final_renegotiate(SSL *s, unsigned int context, int sent,
                                      int *al)
 {
+    (void)context;
     if (!s->server) {
         /*
          * Check if we can connect to a server that doesn't support safe
@@ -724,6 +726,7 @@ static int final_renegotiate(SSL *s, unsigned int context, int sent,
 
 static int init_server_name(SSL *s, unsigned int context)
 {
+    (void)context;
     if (s->server)
         s->servername_done = 0;
 
@@ -736,6 +739,8 @@ static int final_server_name(SSL *s, unsigned int context, int sent,
     int ret = SSL_TLSEXT_ERR_NOACK;
     int altmp = SSL_AD_UNRECOGNIZED_NAME;
 
+    (void)context;
+    (void)sent;
     if (s->ctx != NULL && s->ctx->ext.servername_cb != 0)
         ret = s->ctx->ext.servername_cb(s, &altmp,
                                         s->ctx->ext.servername_arg);
@@ -768,6 +773,9 @@ static int final_ec_pt_formats(SSL *s, unsigned int context, int sent,
 {
     unsigned long alg_k, alg_a;
 
+    (void)context;
+    (void)sent;
+    (void)al;
     if (s->server)
         return 1;
 
@@ -805,6 +813,7 @@ static int final_ec_pt_formats(SSL *s, unsigned int context, int sent,
 
 static int init_session_ticket(SSL *s, unsigned int context)
 {
+    (void)context;
     if (!s->server)
         s->ext.ticket_expected = 0;
 
@@ -814,6 +823,7 @@ static int init_session_ticket(SSL *s, unsigned int context)
 #ifndef OPENSSL_NO_OCSP
 static int init_status_request(SSL *s, unsigned int context)
 {
+    (void)context;
     if (s->server) {
         s->ext.status_type = TLSEXT_STATUSTYPE_nothing;
     } else {
@@ -833,6 +843,7 @@ static int init_status_request(SSL *s, unsigned int context)
 #ifndef OPENSSL_NO_NEXTPROTONEG
 static int init_npn(SSL *s, unsigned int context)
 {
+    (void)context;
     s->s3->npn_seen = 0;
 
     return 1;
@@ -841,6 +852,7 @@ static int init_npn(SSL *s, unsigned int context)
 
 static int init_alpn(SSL *s, unsigned int context)
 {
+    (void)context;
     OPENSSL_free(s->s3->alpn_selected);
     s->s3->alpn_selected = NULL;
     if (s->server) {
@@ -857,6 +869,8 @@ static int final_alpn(SSL *s, unsigned int context, int sent, int *al)
     const unsigned char *selected = NULL;
     unsigned char selected_len = 0;
 
+    (void)context;
+    (void)sent;
     if (!s->server)
         return 1;
 
@@ -889,6 +903,7 @@ static int final_alpn(SSL *s, unsigned int context, int sent, int *al)
 
 static int init_sig_algs(SSL *s, unsigned int context)
 {
+    (void)context;
     /* Clear any signature algorithms extension received */
     OPENSSL_free(s->s3->tmp.peer_sigalgs);
     s->s3->tmp.peer_sigalgs = NULL;
@@ -899,6 +914,7 @@ static int init_sig_algs(SSL *s, unsigned int context)
 #ifndef OPENSSL_NO_SRP
 static int init_srp(SSL *s, unsigned int context)
 {
+    (void)context;
     OPENSSL_free(s->srp_ctx.login);
     s->srp_ctx.login = NULL;
 
@@ -908,6 +924,7 @@ static int init_srp(SSL *s, unsigned int context)
 
 static int init_etm(SSL *s, unsigned int context)
 {
+    (void)context;
     s->s3->flags &= ~TLS1_FLAGS_ENCRYPT_THEN_MAC;
 
     return 1;
@@ -915,6 +932,7 @@ static int init_etm(SSL *s, unsigned int context)
 
 static int init_ems(SSL *s, unsigned int context)
 {
+    (void)context;
     if (!s->server)
         s->s3->flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
 
@@ -923,6 +941,8 @@ static int init_ems(SSL *s, unsigned int context)
 
 static int final_ems(SSL *s, unsigned int context, int sent, int *al)
 {
+    (void)context;
+    (void)sent;
     if (!s->server && s->hit) {
         /*
          * Check extended master secret extension is consistent with
@@ -942,6 +962,7 @@ static int final_ems(SSL *s, unsigned int context, int sent, int *al)
 #ifndef OPENSSL_NO_SRTP
 static int init_srtp(SSL *s, unsigned int context)
 {
+    (void)context;
     if (s->server)
         s->srtp_profile = NULL;
 
@@ -951,6 +972,7 @@ static int init_srtp(SSL *s, unsigned int context)
 
 static int final_sig_algs(SSL *s, unsigned int context, int sent, int *al)
 {
+    (void)context;
     if (!sent && SSL_IS_TLS13(s)) {
         *al = TLS13_AD_MISSING_EXTENSION;
         SSLerr(SSL_F_FINAL_SIG_ALGS, SSL_R_MISSING_SIGALGS_EXTENSION);

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -15,6 +15,9 @@
 int tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     /* Add RI if renegotiating */
     if (!s->renegotiate)
         return 1;
@@ -34,6 +37,9 @@ int tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_ctos_server_name(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (s->ext.hostname == NULL)
         return 1;
 
@@ -59,6 +65,9 @@ int tls_construct_ctos_server_name(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_ctos_srp(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     /* Add SRP username if there is one */
     if (s->srp_ctx.login == NULL)
         return 1;
@@ -114,6 +123,9 @@ int tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt, unsigned int context,
     const unsigned char *pformats;
     size_t num_formats;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!use_ecc(s))
         return 1;
 
@@ -139,6 +151,9 @@ int tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
     const unsigned char *pcurves = NULL, *pcurvestmp;
     size_t num_curves = 0, i;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!use_ecc(s))
         return 1;
 
@@ -189,6 +204,9 @@ int tls_construct_ctos_session_ticket(SSL *s, WPACKET *pkt,
 {
     size_t ticklen;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!tls_use_ticket(s))
         return 1;
 
@@ -231,6 +249,9 @@ int tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt, unsigned int context,
     size_t salglen;
     const uint16_t *salg;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!SSL_CLIENT_USE_SIGALGS(s))
         return 1;
 
@@ -257,6 +278,8 @@ int tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
 {
     int i;
 
+    (void)chainidx;
+    (void)al;
     /* This extension isn't defined for client Certificates */
     if (x != NULL)
         return 1;
@@ -322,6 +345,9 @@ int tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
 int tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (s->ctx->ext.npn_select_cb == NULL || !SSL_IS_FIRST_HANDSHAKE(s))
         return 1;
 
@@ -342,6 +368,9 @@ int tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                             size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     s->s3->alpn_sent = 0;
 
     if (s->ext.alpn == NULL || !SSL_IS_FIRST_HANDSHAKE(s))
@@ -369,6 +398,9 @@ int tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
     STACK_OF(SRTP_PROTECTION_PROFILE) *clnt = SSL_get_srtp_profiles(s);
     int i, end;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (clnt == NULL)
         return 1;
 
@@ -406,6 +438,9 @@ int tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)
         return 1;
 
@@ -422,6 +457,8 @@ int tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)chainidx;
+    (void)al;
     if (s->ct_validation_callback == NULL)
         return 1;
 
@@ -442,6 +479,10 @@ int tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_ctos_ems(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)s;
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_extended_master_secret)
             || !WPACKET_put_bytes_u16(pkt, 0)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CTOS_EMS, ERR_R_INTERNAL_ERROR);
@@ -457,6 +498,9 @@ int tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
 {
     int currv, min_version, max_version, reason;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_supported_versions)
             || !WPACKET_start_sub_packet_u16(pkt)
             || !WPACKET_start_sub_packet_u8(pkt)) {
@@ -631,6 +675,12 @@ int tls_construct_ctos_key_share(SSL *s, WPACKET *pkt, unsigned int context,
         SSLerr(SSL_F_TLS_CONSTRUCT_CTOS_KEY_SHARE, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+#else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;
@@ -645,6 +695,9 @@ int tls_construct_ctos_padding(SSL *s, WPACKET *pkt, unsigned int context,
     unsigned char *padbytes;
     size_t hlen;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if ((s->options & SSL_OP_TLSEXT_PADDING) == 0)
         return 1;
 
@@ -806,6 +859,9 @@ int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
     size_t ilen;
     const unsigned char *data;
 
+    (void)x;
+    (void)chainidx;
+
     /* Check for logic errors */
     assert(expected_len == 0 || s->s3->previous_client_finished_len != 0);
     assert(expected_len == 0 || s->s3->previous_server_finished_len != 0);
@@ -859,6 +915,8 @@ int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_stoc_server_name(SSL *s, PACKET *pkt, unsigned int context,
                                X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
     if (s->ext.hostname == NULL || PACKET_remaining(pkt) > 0) {
         *al = SSL_AD_UNRECOGNIZED_NAME;
         return 0;
@@ -886,6 +944,8 @@ int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
     unsigned int ecpointformats_len;
     PACKET ecptformatlist;
 
+    (void)x;
+    (void)chainidx;
     if (!PACKET_as_length_prefixed_1(pkt, &ecptformatlist)) {
         *al = SSL_AD_DECODE_ERROR;
         return 0;
@@ -918,6 +978,8 @@ int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
     if (s->ext.session_ticket_cb != NULL &&
         !s->ext.session_ticket_cb(s, PACKET_data(pkt),
                               PACKET_remaining(pkt),
@@ -940,6 +1002,7 @@ int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
     /*
      * MUST only be sent if we've requested a status
      * request message. In TLS <= 1.2 it must also be empty.
@@ -971,6 +1034,8 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
     /*
      * Only take it if we asked for it - i.e if there is no CT validation
      * callback set, then a custom extension MAY be processing it, so we
@@ -1029,6 +1094,8 @@ int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     unsigned char selected_len;
     PACKET tmppkt;
 
+    (void)x;
+    (void)chainidx;
     /* Check if we are in a renegotiation. If so ignore this extension */
     if (!SSL_IS_FIRST_HANDSHAKE(s))
         return 1;
@@ -1078,6 +1145,8 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     size_t len;
 
+    (void)x;
+    (void)chainidx;
     /* We must have requested it. */
     if (!s->s3->alpn_sent) {
         *al = SSL_AD_UNSUPPORTED_EXTENSION;
@@ -1119,6 +1188,8 @@ int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     STACK_OF(SRTP_PROTECTION_PROFILE) *clnt;
     SRTP_PROTECTION_PROFILE *prof;
 
+    (void)x;
+    (void)chainidx;
     if (!PACKET_get_net_2(pkt, &ct) || ct != 2
             || !PACKET_get_net_2(pkt, &id)
             || !PACKET_get_1(pkt, &mki)
@@ -1168,6 +1239,10 @@ int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
     /* Ignore if inappropriate ciphersuite */
     if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)
             && s->s3->tmp.new_cipher->algorithm_mac != SSL_AEAD
@@ -1180,6 +1255,10 @@ int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 int tls_parse_stoc_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
     s->s3->flags |= TLS1_FLAGS_RECEIVED_EXTMS;
     if (!s->hit)
         s->session->flags |= SSL_SESS_FLAG_EXTMS;
@@ -1289,6 +1368,12 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 0;
     }
     EVP_PKEY_free(skey);
+#else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -15,6 +15,7 @@
 int tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -37,6 +38,7 @@ int tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_ctos_server_name(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -65,6 +67,7 @@ int tls_construct_ctos_server_name(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_ctos_srp(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -123,6 +126,7 @@ int tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt, unsigned int context,
     const unsigned char *pformats;
     size_t num_formats;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -151,6 +155,7 @@ int tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
     const unsigned char *pcurves = NULL, *pcurvestmp;
     size_t num_curves = 0, i;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -204,6 +209,7 @@ int tls_construct_ctos_session_ticket(SSL *s, WPACKET *pkt,
 {
     size_t ticklen;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -249,6 +255,7 @@ int tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt, unsigned int context,
     size_t salglen;
     const uint16_t *salg;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -278,6 +285,7 @@ int tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
 {
     int i;
 
+    (void)context;
     (void)chainidx;
     (void)al;
     /* This extension isn't defined for client Certificates */
@@ -345,6 +353,7 @@ int tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
 int tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -368,6 +377,7 @@ int tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                             size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -398,6 +408,7 @@ int tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
     STACK_OF(SRTP_PROTECTION_PROFILE) *clnt = SSL_get_srtp_profiles(s);
     int i, end;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -438,6 +449,7 @@ int tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -457,6 +469,7 @@ int tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)chainidx;
     (void)al;
     if (s->ct_validation_callback == NULL)
@@ -479,6 +492,7 @@ int tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_ctos_ems(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)s;
     (void)x;
     (void)chainidx;
@@ -498,6 +512,7 @@ int tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
 {
     int currv, min_version, max_version, reason;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -570,6 +585,7 @@ int tls_construct_ctos_psk_kex_modes(SSL *s, WPACKET *pkt, unsigned int context,
     s->ext.psk_kex_mode = TLSEXT_KEX_MODE_FLAG_KE | TLSEXT_KEX_MODE_FLAG_KE_DHE;
 #else
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -684,6 +700,7 @@ int tls_construct_ctos_key_share(SSL *s, WPACKET *pkt, unsigned int context,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -702,6 +719,7 @@ int tls_construct_ctos_padding(SSL *s, WPACKET *pkt, unsigned int context,
     size_t hlen;
 
     (void)x;
+    (void)context;
     (void)chainidx;
     (void)al;
     if ((s->options & SSL_OP_TLSEXT_PADDING) == 0)
@@ -852,6 +870,7 @@ int tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -871,6 +890,7 @@ int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
     const unsigned char *data;
 
     (void)x;
+    (void)context;
     (void)chainidx;
 
     /* Check for logic errors */
@@ -927,6 +947,7 @@ int tls_parse_stoc_server_name(SSL *s, PACKET *pkt, unsigned int context,
                                X509 *x, size_t chainidx, int *al)
 {
     (void)x;
+    (void)context;
     (void)chainidx;
     if (s->ext.hostname == NULL || PACKET_remaining(pkt) > 0) {
         *al = SSL_AD_UNRECOGNIZED_NAME;
@@ -956,6 +977,7 @@ int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
     PACKET ecptformatlist;
 
     (void)x;
+    (void)context;
     (void)chainidx;
     if (!PACKET_as_length_prefixed_1(pkt, &ecptformatlist)) {
         *al = SSL_AD_DECODE_ERROR;
@@ -990,6 +1012,7 @@ int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
     (void)x;
+    (void)context;
     (void)chainidx;
     if (s->ext.session_ticket_cb != NULL &&
         !s->ext.session_ticket_cb(s, PACKET_data(pkt),
@@ -1013,6 +1036,7 @@ int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     /*
      * MUST only be sent if we've requested a status
@@ -1045,6 +1069,7 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     /*
@@ -1105,6 +1130,7 @@ int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     unsigned char selected_len;
     PACKET tmppkt;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     /* Check if we are in a renegotiation. If so ignore this extension */
@@ -1156,6 +1182,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     size_t len;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     /* We must have requested it. */
@@ -1199,6 +1226,7 @@ int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     STACK_OF(SRTP_PROTECTION_PROFILE) *clnt;
     SRTP_PROTECTION_PROFILE *prof;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     if (!PACKET_get_net_2(pkt, &ct) || ct != 2
@@ -1251,6 +1279,7 @@ int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1267,6 +1296,7 @@ int tls_parse_stoc_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1382,6 +1412,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1412,6 +1443,7 @@ int tls_parse_stoc_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -550,6 +550,7 @@ int tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
 int tls_construct_ctos_psk_kex_modes(SSL *s, WPACKET *pkt, unsigned int context,
                                      X509 *x, size_t chainidx, int *al)
 {
+    (void)s;
 #ifndef OPENSSL_NO_TLS1_3
     /*
      * TODO(TLS1.3): Do we want this list to be configurable? For now we always
@@ -567,6 +568,11 @@ int tls_construct_ctos_psk_kex_modes(SSL *s, WPACKET *pkt, unsigned int context,
     }
 
     s->ext.psk_kex_mode = TLSEXT_KEX_MODE_FLAG_KE | TLSEXT_KEX_MODE_FLAG_KE_DHE;
+#else
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;
@@ -844,6 +850,11 @@ int tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
  err:
     return ret;
 #else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
     return 1;
 #endif
 }
@@ -1398,6 +1409,12 @@ int tls_parse_stoc_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     s->hit = 1;
+#else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -505,6 +505,12 @@ int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
         else if (mode == TLSEXT_KEX_MODE_KE)
             s->ext.psk_kex_mode |= TLSEXT_KEX_MODE_FLAG_KE;
     }
+#else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;
@@ -705,6 +711,8 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     unsigned int id, i;
     const EVP_MD *md = NULL;
 
+    (void)x;
+    (void)chainidx;
     /*
      * If we have no PSK kex mode that we recognise then we can't resume so
      * ignore this extension
@@ -1166,6 +1174,9 @@ int tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_psk(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!s->hit)
         return 1;
 

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -20,6 +20,7 @@ int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
     unsigned int ilen;
     const unsigned char *data;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     /* Parse the length byte */
@@ -81,6 +82,7 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
     unsigned int servname_type;
     PACKET sni, hostname;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     if (!PACKET_as_length_prefixed_2(pkt, &sni)
@@ -147,6 +149,7 @@ int tls_parse_ctos_srp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     PACKET srp_I;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     if (!PACKET_as_length_prefixed_1(pkt, &srp_I)
@@ -174,6 +177,7 @@ int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET ec_point_format_list;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     if (!PACKET_as_length_prefixed_1(pkt, &ec_point_format_list)
@@ -198,6 +202,7 @@ int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     if (s->ext.session_ticket_cb &&
@@ -216,6 +221,7 @@ int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     PACKET supported_sig_algs;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     if (!PACKET_as_length_prefixed_2(pkt, &supported_sig_algs)
@@ -238,6 +244,7 @@ int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET responder_id_list, exts;
 
+    (void)context;
     (void)chainidx;
     /* Not defined if we get one of these in a client Certificate */
     if (x != NULL)
@@ -336,6 +343,7 @@ int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_ctos_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)context;
     (void)pkt;
     (void)x;
     (void)chainidx;
@@ -361,6 +369,7 @@ int tls_parse_ctos_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     PACKET protocol_list, save_protocol_list, protocol;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     if (!SSL_IS_FIRST_HANDSHAKE(s))
@@ -403,6 +412,7 @@ int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     int i, srtp_pref;
     PACKET subpkt;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     /* Ignore this if we have no SRTP profiles */
@@ -472,6 +482,7 @@ int tls_parse_ctos_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -508,6 +519,7 @@ int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -648,6 +660,7 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -662,6 +675,7 @@ int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET supported_groups_list;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     /* Each group is 2 bytes and we must have at least 1. */
@@ -689,6 +703,7 @@ int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     /* The extension must always be empty */
@@ -711,6 +726,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     unsigned int id, i;
     const EVP_MD *md = NULL;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     /*
@@ -809,6 +825,7 @@ err:
 int tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -834,6 +851,7 @@ int tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_server_name(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -861,6 +879,7 @@ int tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt, unsigned int context,
     const unsigned char *plist;
     size_t plistlen;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -884,6 +903,7 @@ int tls_construct_stoc_session_ticket(SSL *s, WPACKET *pkt,
                                       unsigned int context, X509 *x,
                                       size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -906,6 +926,7 @@ int tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
                                       unsigned int context, X509 *x,
                                       size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)al;
     if (!s->ext.status_expected)
@@ -945,6 +966,7 @@ int tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
     int ret;
     int npn_seen = s->s3->npn_seen;
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -971,6 +993,7 @@ int tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
 int tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                             size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -996,6 +1019,7 @@ int tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
                                 X509 *x, size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1019,6 +1043,7 @@ int tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1049,6 +1074,7 @@ int tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_stoc_ems(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1135,6 +1161,7 @@ int tls_construct_stoc_key_share(SSL *s, WPACKET *pkt, unsigned int context,
 #else
     (void)s;
     (void)pkt;
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1155,6 +1182,7 @@ int tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt, unsigned int context,
         0x06, 0x06, 0x2a, 0x85, 0x03, 0x02, 0x02, 0x17
     };
 
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;
@@ -1174,6 +1202,7 @@ int tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_psk(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)context;
     (void)x;
     (void)chainidx;
     (void)al;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -20,6 +20,8 @@ int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
     unsigned int ilen;
     const unsigned char *data;
 
+    (void)x;
+    (void)chainidx;
     /* Parse the length byte */
     if (!PACKET_get_1(pkt, &ilen)
         || !PACKET_get_bytes(pkt, &data, ilen)) {
@@ -79,6 +81,8 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
     unsigned int servname_type;
     PACKET sni, hostname;
 
+    (void)x;
+    (void)chainidx;
     if (!PACKET_as_length_prefixed_2(pkt, &sni)
         /* ServerNameList must be at least 1 byte long. */
         || PACKET_remaining(&sni) == 0) {
@@ -143,6 +147,8 @@ int tls_parse_ctos_srp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     PACKET srp_I;
 
+    (void)x;
+    (void)chainidx;
     if (!PACKET_as_length_prefixed_1(pkt, &srp_I)
             || PACKET_contains_zero_byte(&srp_I)) {
         *al = SSL_AD_DECODE_ERROR;
@@ -168,6 +174,8 @@ int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET ec_point_format_list;
 
+    (void)x;
+    (void)chainidx;
     if (!PACKET_as_length_prefixed_1(pkt, &ec_point_format_list)
         || PACKET_remaining(&ec_point_format_list) == 0) {
         *al = SSL_AD_DECODE_ERROR;
@@ -190,6 +198,8 @@ int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
     if (s->ext.session_ticket_cb &&
             !s->ext.session_ticket_cb(s, PACKET_data(pkt),
                                   PACKET_remaining(pkt),
@@ -206,6 +216,8 @@ int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     PACKET supported_sig_algs;
 
+    (void)x;
+    (void)chainidx;
     if (!PACKET_as_length_prefixed_2(pkt, &supported_sig_algs)
             || PACKET_remaining(&supported_sig_algs) == 0) {
         *al = SSL_AD_DECODE_ERROR;
@@ -226,6 +238,7 @@ int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET responder_id_list, exts;
 
+    (void)chainidx;
     /* Not defined if we get one of these in a client Certificate */
     if (x != NULL)
         return 1;
@@ -323,6 +336,10 @@ int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_ctos_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
     /*
      * We shouldn't accept this extension on a
      * renegotiation.
@@ -344,6 +361,8 @@ int tls_parse_ctos_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     PACKET protocol_list, save_protocol_list, protocol;
 
+    (void)x;
+    (void)chainidx;
     if (!SSL_IS_FIRST_HANDSHAKE(s))
         return 1;
 
@@ -384,6 +403,8 @@ int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     int i, srtp_pref;
     PACKET subpkt;
 
+    (void)x;
+    (void)chainidx;
     /* Ignore this if we have no SRTP profiles */
     if (SSL_get_srtp_profiles(s) == NULL)
         return 1;
@@ -450,6 +471,10 @@ int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 int tls_parse_ctos_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC))
         s->s3->flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC;
 
@@ -614,6 +639,12 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
         found = 1;
     }
+#else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;
@@ -625,6 +656,8 @@ int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET supported_groups_list;
 
+    (void)x;
+    (void)chainidx;
     /* Each group is 2 bytes and we must have at least 1. */
     if (!PACKET_as_length_prefixed_2(pkt, &supported_groups_list)
             || PACKET_remaining(&supported_groups_list) == 0
@@ -650,6 +683,8 @@ int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
 int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
     /* The extension must always be empty */
     if (PACKET_remaining(pkt) != 0) {
         *al = SSL_AD_DECODE_ERROR;
@@ -766,6 +801,9 @@ err:
 int tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!s->s3->send_connection_binding)
         return 1;
 
@@ -788,6 +826,9 @@ int tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_server_name(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (s->hit || s->servername_done != 1
             || s->session->ext.hostname == NULL)
         return 1;
@@ -812,6 +853,9 @@ int tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt, unsigned int context,
     const unsigned char *plist;
     size_t plistlen;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!using_ecc)
         return 1;
 
@@ -832,6 +876,9 @@ int tls_construct_stoc_session_ticket(SSL *s, WPACKET *pkt,
                                       unsigned int context, X509 *x,
                                       size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (!s->ext.ticket_expected || !tls_use_ticket(s)) {
         s->ext.ticket_expected = 0;
         return 1;
@@ -851,6 +898,8 @@ int tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
                                       unsigned int context, X509 *x,
                                       size_t chainidx, int *al)
 {
+    (void)x;
+    (void)al;
     if (!s->ext.status_expected)
         return 1;
 
@@ -888,6 +937,9 @@ int tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
     int ret;
     int npn_seen = s->s3->npn_seen;
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     s->s3->npn_seen = 0;
     if (!npn_seen || s->ctx->ext.npn_advertised_cb == NULL)
         return 1;
@@ -911,6 +963,9 @@ int tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
 int tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                             size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (s->s3->alpn_selected == NULL)
         return 1;
 
@@ -933,6 +988,9 @@ int tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
                                 X509 *x, size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (s->srtp_profile == NULL)
         return 1;
 
@@ -953,6 +1011,9 @@ int tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if ((s->s3->flags & TLS1_FLAGS_ENCRYPT_THEN_MAC) == 0)
         return 1;
 
@@ -980,6 +1041,9 @@ int tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
 int tls_construct_stoc_ems(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
                            size_t chainidx, int *al)
 {
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if ((s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS) == 0)
         return 1;
 
@@ -1060,6 +1124,12 @@ int tls_construct_stoc_key_share(SSL *s, WPACKET *pkt, unsigned int context,
         SSLerr(SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+#else
+    (void)s;
+    (void)pkt;
+    (void)x;
+    (void)chainidx;
+    (void)al;
 #endif
 
     return 1;
@@ -1077,6 +1147,9 @@ int tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt, unsigned int context,
         0x06, 0x06, 0x2a, 0x85, 0x03, 0x02, 0x02, 0x17
     };
 
+    (void)x;
+    (void)chainidx;
+    (void)al;
     if (((s->s3->tmp.new_cipher->id & 0xFFFF) != 0x80
          && (s->s3->tmp.new_cipher->id & 0xFFFF) != 0x81)
             || (SSL_get_options(s) & SSL_OP_CRYPTOPRO_TLSEXT_BUG) == 0)

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1725,6 +1725,8 @@ static int tls_process_ske_psk_preamble(SSL *s, PACKET *pkt, int *al)
 
     return 1;
 #else
+    (void)s;
+    (void)pkt;
     SSLerr(SSL_F_TLS_PROCESS_SKE_PSK_PREAMBLE, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -1775,6 +1777,9 @@ static int tls_process_ske_srp(SSL *s, PACKET *pkt, EVP_PKEY **pkey, int *al)
 
     return 1;
 #else
+    (void)s;
+    (void)pkt;
+    (void)pkey;
     SSLerr(SSL_F_TLS_PROCESS_SKE_SRP, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -1881,6 +1886,10 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey, int *al)
 
     return 0;
 #else
+    (void)s;
+    (void)pkt;
+    (void)pkey;
+    (void)al;
     SSLerr(SSL_F_TLS_PROCESS_SKE_DHE, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -1978,6 +1987,9 @@ static int tls_process_ske_ecdhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey, int *al)
 
     return 1;
 #else
+    (void)s;
+    (void)pkt;
+    (void)pkey;
     SSLerr(SSL_F_TLS_PROCESS_SKE_ECDHE, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -2644,6 +2656,8 @@ static int tls_construct_cke_psk_preamble(SSL *s, WPACKET *pkt, int *al)
 
     return ret;
 #else
+    (void)s;
+    (void)pkt;
     SSLerr(SSL_F_TLS_CONSTRUCT_CKE_PSK_PREAMBLE, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -2734,6 +2748,7 @@ static int tls_construct_cke_rsa(SSL *s, WPACKET *pkt, int *al)
 
     return 0;
 #else
+    (void)pkt;
     SSLerr(SSL_F_TLS_CONSTRUCT_CKE_RSA, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -2772,6 +2787,10 @@ static int tls_construct_cke_dhe(SSL *s, WPACKET *pkt, int *al)
     return 1;
  err:
     EVP_PKEY_free(ckey);
+#else
+    (void)s;
+    (void)pkt;
+    (void)al;
 #endif
     SSLerr(SSL_F_TLS_CONSTRUCT_CKE_DHE, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
@@ -2823,6 +2842,8 @@ static int tls_construct_cke_ecdhe(SSL *s, WPACKET *pkt, int *al)
     EVP_PKEY_free(ckey);
     return ret;
 #else
+    (void)s;
+    (void)pkt;
     SSLerr(SSL_F_TLS_CONSTRUCT_CKE_ECDHE, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -2941,6 +2962,8 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt, int *al)
     EVP_MD_CTX_free(ukm_hash);
     return 0;
 #else
+    (void)s;
+    (void)pkt;
     SSLerr(SSL_F_TLS_CONSTRUCT_CKE_GOST, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;
@@ -2970,6 +2993,8 @@ static int tls_construct_cke_srp(SSL *s, WPACKET *pkt, int *al)
 
     return 1;
 #else
+    (void)s;
+    (void)pkt;
     SSLerr(SSL_F_TLS_CONSTRUCT_CKE_SRP, ERR_R_INTERNAL_ERROR);
     *al = SSL_AD_INTERNAL_ERROR;
     return 0;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -737,6 +737,7 @@ int ossl_statem_client_construct_message(SSL *s, WPACKET *pkt,
 {
     OSSL_STATEM *st = &s->statem;
 
+    (void)pkt;
     switch (st->hand_state) {
     default:
         /* Shouldn't happen */
@@ -2785,6 +2786,7 @@ static int tls_construct_cke_ecdhe(SSL *s, WPACKET *pkt, int *al)
     EVP_PKEY *ckey = NULL, *skey = NULL;
     int ret = 0;
 
+    (void)al;
     skey = s->s3->peer_tmp;
     if (skey == NULL) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CKE_ECDHE, ERR_R_INTERNAL_ERROR);
@@ -2950,6 +2952,7 @@ static int tls_construct_cke_srp(SSL *s, WPACKET *pkt, int *al)
 #ifndef OPENSSL_NO_SRP
     unsigned char *abytes = NULL;
 
+    (void)al;
     if (s->srp_ctx.A == NULL
             || !WPACKET_sub_allocate_bytes_u16(pkt, BN_num_bytes(s->srp_ctx.A),
                                                &abytes)) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -824,6 +824,7 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs)
 {
     void (*cb) (const SSL *ssl, int type, int val) = NULL;
 
+    (void)wst;
 #ifndef OPENSSL_NO_SCTP
     if (SSL_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(s))) {
         WORK_STATE ret;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2474,6 +2474,8 @@ static int tls_process_cke_psk_preamble(SSL *s, PACKET *pkt, int *al)
     return 1;
 #else
     /* Should never happen */
+    (void)s;
+    (void)pkt;
     *al = SSL_AD_INTERNAL_ERROR;
     SSLerr(SSL_F_TLS_PROCESS_CKE_PSK_PREAMBLE, ERR_R_INTERNAL_ERROR);
     return 0;
@@ -2708,6 +2710,8 @@ static int tls_process_cke_dhe(SSL *s, PACKET *pkt, int *al)
     EVP_PKEY_free(ckey);
     return ret;
 #else
+    (void)s;
+    (void)pkt;
     /* Should never happen */
     *al = SSL_AD_INTERNAL_ERROR;
     SSLerr(SSL_F_TLS_PROCESS_CKE_DHE, ERR_R_INTERNAL_ERROR);
@@ -2770,6 +2774,8 @@ static int tls_process_cke_ecdhe(SSL *s, PACKET *pkt, int *al)
     return ret;
 #else
     /* Should never happen */
+    (void)s;
+    (void)pkt;
     *al = SSL_AD_INTERNAL_ERROR;
     SSLerr(SSL_F_TLS_PROCESS_CKE_ECDHE, ERR_R_INTERNAL_ERROR);
     return 0;
@@ -2812,6 +2818,8 @@ static int tls_process_cke_srp(SSL *s, PACKET *pkt, int *al)
     return 1;
 #else
     /* Should never happen */
+    (void)s;
+    (void)pkt;
     *al = SSL_AD_INTERNAL_ERROR;
     SSLerr(SSL_F_TLS_PROCESS_CKE_SRP, ERR_R_INTERNAL_ERROR);
     return 0;
@@ -2913,6 +2921,8 @@ static int tls_process_cke_gost(SSL *s, PACKET *pkt, int *al)
     return ret;
 #else
     /* Should never happen */
+    (void)s;
+    (void)pkt;
     *al = SSL_AD_INTERNAL_ERROR;
     SSLerr(SSL_F_TLS_PROCESS_CKE_GOST, ERR_R_INTERNAL_ERROR);
     return 0;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -695,6 +695,7 @@ WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
 {
     OSSL_STATEM *st = &s->statem;
 
+    (void)wst;
     s->init_num = 0;
 
     switch (st->hand_state) {
@@ -844,6 +845,7 @@ int ossl_statem_server_construct_message(SSL *s, WPACKET *pkt,
 {
     OSSL_STATEM *st = &s->statem;
 
+    (void)pkt;
     switch (st->hand_state) {
     default:
         /* Shouldn't happen */
@@ -1982,6 +1984,7 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
 
 int tls_construct_server_done(SSL *s, WPACKET *pkt)
 {
+    (void)pkt;
     if (!s->s3->tmp.cert_request) {
         if (!ssl3_digest_cached_records(s, 0)) {
             ssl3_send_alert(s, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
@@ -3020,6 +3023,8 @@ WORK_STATE tls_post_process_client_key_exchange(SSL *s, WORK_STATE wst)
     } else {
         ossl_statem_set_sctp_read_sock(s, 0);
     }
+#else
+    (void)wst;
 #endif
 
     if (s->statem.no_cert_verify || !s->session->peer) {

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -474,6 +474,7 @@ size_t tls1_final_finish_mac(SSL *s, const char *str, size_t slen,
 int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
                                 size_t len, size_t *secret_size)
 {
+    (void)out;
     /*
      * TODO(TLS1.3): We haven't implemented TLS1.3 key derivation yet. For now
      * we will just force no use of EMS (which adds complications around the

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -664,6 +664,9 @@ int tls1_check_ec_tmp_key(SSL *s, unsigned long cid)
 
 static int tls1_check_cert_param(SSL *s, X509 *x, int set_ee_md)
 {
+    (void)s;
+    (void)x;
+    (void)set_ee_md;
     return 1;
 }
 

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1370,6 +1370,7 @@ void SSL_trace(int write_p, int version, int content_type,
     const unsigned char *msg = buf;
     BIO *bio = arg;
 
+    (void)version; /* FIXME(API) */
     if (write_p == 2) {
         BIO_puts(bio, "Session ");
         ssl_print_hex(bio, 0,

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -178,6 +178,7 @@ int tls13_generate_master_secret(SSL *s, unsigned char *out,
 {
     const EVP_MD *md = ssl_handshake_md(s);
 
+    (void)prevlen;
     *secret_size = EVP_MD_size(md);
     return tls13_generate_secret(s, md, prev, NULL, 0, out);
 }
@@ -195,6 +196,7 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
     EVP_PKEY *key = NULL;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
+    (void)slen;
     if (!ssl_handshake_hash(s, hash, sizeof(hash), &hashlen))
         goto err;
 

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -42,6 +42,7 @@ int tls13_hkdf_expand(SSL *s, const EVP_MD *md, const unsigned char *secret,
                             + EVP_MAX_MD_SIZE];
     WPACKET pkt;
 
+    (void)s;
     if (pctx == NULL)
         return 0;
 
@@ -124,6 +125,7 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
     int ret;
     EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
 
+    (void)s;
     if (pctx == NULL)
         return 0;
 

--- a/test/aborttest.c
+++ b/test/aborttest.c
@@ -9,7 +9,7 @@
 
 #include <openssl/crypto.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     OPENSSL_die("Voluntary abort", __FILE__, __LINE__);
     return 0;

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -87,7 +87,7 @@ static int test_afalg_aes_128_cbc(ENGINE *e)
     return status;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     ENGINE *e;
 
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
 #else  /* OPENSSL_NO_AFALGENG */
 
-int main(int argc, char **argv)
+int main(void)
 {
     fprintf(stderr, "AFALG not supported - skipping AFALG tests\n");
     printf("PASS\n");

--- a/test/asynciotest.c
+++ b/test/asynciotest.c
@@ -241,6 +241,9 @@ static long async_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
 static int async_gets(BIO *bio, char *buf, int size)
 {
+    (void)bio;
+    (void)buf;
+    (void)size;
     /* We don't support this - not needed anyway */
     return -1;
 }

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -22,6 +22,7 @@ static ASYNC_JOB *currjob = NULL;
 
 static int only_pause(void *args)
 {
+    (void)args;
     ASYNC_pause_job();
 
     return 1;
@@ -29,6 +30,7 @@ static int only_pause(void *args)
 
 static int add_two(void *args)
 {
+    (void)args;
     ctr++;
     ASYNC_pause_job();
     ctr++;
@@ -38,6 +40,7 @@ static int add_two(void *args)
 
 static int save_current(void *args)
 {
+    (void)args;
     currjob = ASYNC_get_current_job();
     ASYNC_pause_job();
 
@@ -49,6 +52,8 @@ static int waitfd(void *args)
 {
     ASYNC_JOB *job;
     ASYNC_WAIT_CTX *waitctx;
+
+    (void)args;
     job = ASYNC_get_current_job();
     if (job == NULL)
         return 0;
@@ -80,6 +85,7 @@ static int waitfd(void *args)
 
 static int blockpause(void *args)
 {
+    (void)args;
     ASYNC_block_pause();
     ASYNC_pause_job();
     ASYNC_unblock_pause();
@@ -270,7 +276,7 @@ static int test_ASYNC_block_pause()
     return 1;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     if (!ASYNC_is_capable()) {
         fprintf(stderr,

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -357,6 +357,7 @@ static int send_finished(SSL *s, BIO *rbio)
     };
     unsigned char handshake_hash[EVP_MAX_MD_SIZE];
 
+    (void)s;
     /* Derive key material */
     do_PRF(TLS_MD_KEY_EXPANSION_CONST, TLS_MD_KEY_EXPANSION_CONST_SIZE,
            server_random, SSL3_RANDOM_SIZE,
@@ -443,7 +444,7 @@ static struct {
     /* The last test should be NODROP, because a DROP wouldn't get tested. */
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     SSL_SESSION *sess;
     SSL_CTX *ctx;

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -235,6 +235,7 @@ int main(int argc, char *argv[])
 {
     int ret;
 
+    (void)argv;
     if (argc > 1)
         ret = print_test_data();
     else

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -20,7 +20,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_BF
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No BF support\n");
     return (0);

--- a/test/bio_enc_test.c
+++ b/test/bio_enc_test.c
@@ -12,7 +12,7 @@
 #include <openssl/bio.h>
 #include <openssl/rand.h>
 
-int main()
+int main(void)
 {
     BIO *b;
     static const unsigned char key[16] = { 0 };

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -33,7 +33,12 @@
  */
 #define bn_expand2 dummy_bn_expand2
 BIGNUM *bn_expand2(BIGNUM *b, int words);
-BIGNUM *bn_expand2(BIGNUM *b, int words) { return NULL; }
+BIGNUM *bn_expand2(BIGNUM *b, int words)
+{
+    (void)b;
+    (void)words;
+    return NULL;
+}
 #include "../crypto/bn/bn_lcl.h"
 
 #define MAXPAIRS        20

--- a/test/casttest.c
+++ b/test/casttest.c
@@ -15,7 +15,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_CAST
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No CAST support\n");
     return (0);

--- a/test/casttest.c
+++ b/test/casttest.c
@@ -63,7 +63,7 @@ static unsigned char c_b[16] = {
     0x80, 0xAC, 0x05, 0xB8, 0xE8, 0x3D, 0x69, 0x6E
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
 # ifdef FULL_TEST
     long l;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -29,7 +29,7 @@
  */
 #define TEST_SET_SESSION_TICK_DATA_VER_NEG      0
 
-int main(int argc, char *argv[])
+int main(void)
 {
     SSL_CTX *ctx;
     SSL *con = NULL;

--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -270,7 +270,7 @@ static size_t test_values_s[] =
     SIZE_MAX
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     unsigned int a, b, i, j;
     int c, d;

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -591,6 +591,8 @@ int test_main(int argc, char *argv[])
 #else
 int test_main(int argc, char *argv[])
 {
+    (void)argc;
+    (void)argv;
     printf("No CT support\n");
     return 0;
 }

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -565,6 +565,7 @@ int test_main(int argc, char *argv[])
     int result = 0;
     char *tmp_env;
 
+    (void)argc;
     tmp_env = getenv("CT_DIR");
     ct_dir = OPENSSL_strdup(tmp_env != NULL ? tmp_env : "ct");
     tmp_env = getenv("CERTS_DIR");

--- a/test/destest.c
+++ b/test/destest.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #ifdef OPENSSL_NO_DES
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No DES support\n");
     return (0);
@@ -302,7 +302,8 @@ static char *pt(unsigned char *p);
 static int cfb_test(int bits, unsigned char *cfb_cipher);
 static int cfb64_test(unsigned char *cfb_cipher);
 static int ede_cfb64_test(unsigned char *cfb_cipher);
-int main(int argc, char *argv[])
+
+int main(void)
 {
     int j, err = 0;
     unsigned int i;

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -20,7 +20,7 @@
 #include <openssl/err.h>
 
 #ifdef OPENSSL_NO_DH
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No DH support\n");
     return (0);
@@ -35,7 +35,7 @@ static const char rnd_seed[] =
 
 static int run_rfc5114_tests(void);
 
-int main(int argc, char *argv[])
+int main(void)
 {
     BN_GENCB *_cb = NULL;
     DH *a = NULL;
@@ -173,6 +173,7 @@ static int cb(int p, int n, BN_GENCB *arg)
 {
     char c = '*';
 
+    (void)n;
     if (p == 0)
         c = '.';
     if (p == 1)

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -22,7 +22,7 @@
 #include <openssl/bn.h>
 
 #ifdef OPENSSL_NO_DSA
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No DSA support\n");
     return (0);
@@ -76,7 +76,7 @@ static const char rnd_seed[] =
 
 static BIO *bio_err = NULL;
 
-int main(int argc, char **argv)
+int main(void)
 {
     BN_GENCB *cb;
     DSA *dsa = NULL;
@@ -172,6 +172,7 @@ static int dsa_cb(int p, int n, BN_GENCB *arg)
     char c = '*';
     static int ok = 0, num = 0;
 
+    (void)n;
     if (p == 0) {
         c = '.';
         num++;

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -26,6 +26,8 @@ static unsigned int clnt_psk_callback(SSL *ssl, const char *hint,
                                       unsigned char *psk,
                                       unsigned int max_psk_len)
 {
+    (void)ssl;
+    (void)hint;
     BIO_snprintf(ident, max_ident_len, "psk");
 
     if (max_psk_len > 20)
@@ -39,6 +41,8 @@ static unsigned int srvr_psk_callback(SSL *ssl, const char *identity,
                                       unsigned char *psk,
                                       unsigned int max_psk_len)
 {
+    (void)ssl;
+    (void)identity;
     if (max_psk_len > 20)
         max_psk_len = 20;
     memset(psk, 0x5a, max_psk_len);

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -299,6 +299,7 @@ static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
 {
     unsigned int i;
 
+    (void)ssl;
     for (i = 0; i < COOKIE_LEN; i++, cookie++) {
         *cookie = i;
     }
@@ -312,6 +313,7 @@ static int cookie_verify(SSL *ssl, const unsigned char *cookie,
 {
     unsigned int i;
 
+    (void)ssl;
     if (cookie_len != COOKIE_LEN)
         return 0;
 

--- a/test/ecdhtest.c
+++ b/test/ecdhtest.c
@@ -38,7 +38,7 @@
 #include <openssl/err.h>
 
 #ifdef OPENSSL_NO_EC
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No ECDH support\n");
     return (0);
@@ -542,7 +542,7 @@ static int ecdh_cavs_kat(BIO *out, const ecdh_cavs_kat_t *kat)
     return rv;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     BN_CTX *ctx = NULL;
     int nid, ret = 1;

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -28,7 +28,7 @@
 #include <openssl/opensslconf.h> /* To see if OPENSSL_NO_EC is defined */
 
 #ifdef OPENSSL_NO_EC
-int main(int argc, char *argv[])
+int main(void)
 {
     puts("Elliptic curves are disabled.");
     return 0;

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -32,7 +32,7 @@
 #include <time.h>
 
 #ifdef OPENSSL_NO_EC
-int main(int argc, char *argv[])
+int main(void)
 {
     puts("Elliptic curves are disabled.");
     return 0;
@@ -1742,7 +1742,7 @@ static void parameter_test(void)
 static const char rnd_seed[] =
     "string to make the random number generator think it has entropy";
 
-int main(int argc, char *argv[])
+int main(void)
 {
     char *p;
 

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -12,7 +12,7 @@
 #include <openssl/e_os2.h>
 
 #ifdef OPENSSL_NO_ENGINE
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No ENGINE support\n");
     return (0);
@@ -44,7 +44,7 @@ static void display_engine_list(void)
     ENGINE_free(h);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     ENGINE *block[512];
     char buf[256];

--- a/test/exdatatest.c
+++ b/test/exdatatest.c
@@ -78,7 +78,7 @@ static void MYOBJ_free(MYOBJ *obj)
     OPENSSL_free(obj);
 }
 
-int main()
+int main(void)
 {
     MYOBJ *t1, *t2;
     const char *cp;

--- a/test/exptest.c
+++ b/test/exptest.c
@@ -134,7 +134,7 @@ static int test_exp_mod_zero()
     return ret;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     BN_CTX *ctx;
     BIO *out = NULL;

--- a/test/generate_buildtest.pl
+++ b/test/generate_buildtest.pl
@@ -27,7 +27,7 @@ print <<"_____";
 # include <openssl/$name.h>
 #endif
 
-int main()
+int main(void)
 {
     return 0;
 }

--- a/test/gmdifftest.c
+++ b/test/gmdifftest.c
@@ -57,7 +57,7 @@ static int check_time(long offset)
     return 1;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     long offset;
     int fails;

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -211,7 +211,7 @@ static int do_not_call_session_ticket_cb(SSL *s, unsigned char *key_name,
                                          HMAC_CTX *hctx, int enc)
 {
     HANDSHAKE_EX_DATA *ex_data =
-        (HANDSHAKE_EX_DATA*)SSL_get_ex_data(s, ex_data_idx);
+        (HANDSHAKE_EX_DATA*)(SSL_get_ex_data(s, ex_data_idx));
 
     (void)key_name;
     (void)iv;

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -136,11 +136,13 @@ static int select_server_ctx(SSL *s, void *arg, int ignore)
  */
 static int servername_ignore_cb(SSL *s, int *ad, void *arg)
 {
+    (void)ad;
     return select_server_ctx(s, arg, 1);
 }
 
 static int servername_reject_cb(SSL *s, int *ad, void *arg)
 {
+    (void)ad;
     return select_server_ctx(s, arg, 0);
 }
 
@@ -169,6 +171,7 @@ static int client_ocsp_cb(SSL *s, void *arg)
     const unsigned char *resp;
     int len;
 
+    (void)arg;
     len = SSL_get_tlsext_status_ocsp_resp(s, &resp);
     if (len != 1 || *resp != dummy_ocsp_resp_good_val)
         return 0;
@@ -176,18 +179,29 @@ static int client_ocsp_cb(SSL *s, void *arg)
     return 1;
 }
 
-static int verify_reject_cb(X509_STORE_CTX *ctx, void *arg) {
+static int verify_reject_cb(X509_STORE_CTX *ctx, void *arg)
+{
+    (void)arg;
     X509_STORE_CTX_set_error(ctx, X509_V_ERR_APPLICATION_VERIFICATION);
     return 0;
 }
 
-static int verify_accept_cb(X509_STORE_CTX *ctx, void *arg) {
+static int verify_accept_cb(X509_STORE_CTX *ctx, void *arg)
+{
+    (void)ctx;
+    (void)arg;
     return 1;
 }
 
 static int broken_session_ticket_cb(SSL *s, unsigned char *key_name, unsigned char *iv,
                                     EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc)
 {
+    (void)s;
+    (void)key_name;
+    (void)iv;
+    (void)ctx;
+    (void)hctx;
+    (void)enc;
     return 0;
 }
 
@@ -197,7 +211,13 @@ static int do_not_call_session_ticket_cb(SSL *s, unsigned char *key_name,
                                          HMAC_CTX *hctx, int enc)
 {
     HANDSHAKE_EX_DATA *ex_data =
-        (HANDSHAKE_EX_DATA*)(SSL_get_ex_data(s, ex_data_idx));
+        (HANDSHAKE_EX_DATA*)SSL_get_ex_data(s, ex_data_idx);
+
+    (void)key_name;
+    (void)iv;
+    (void)ctx;
+    (void)hctx;
+    (void)enc;
     ex_data->session_ticket_do_not_call = 1;
     return 0;
 }
@@ -251,6 +271,7 @@ static int client_npn_cb(SSL *s, unsigned char **out, unsigned char *outlen,
     CTX_DATA *ctx_data = (CTX_DATA*)(arg);
     int ret;
 
+    (void)s;
     ret = SSL_select_next_proto(out, outlen, in, inlen,
                                 ctx_data->npn_protocols,
                                 ctx_data->npn_protocols_len);
@@ -263,6 +284,8 @@ static int server_npn_cb(SSL *s, const unsigned char **data,
                          unsigned int *len, void *arg)
 {
     CTX_DATA *ctx_data = (CTX_DATA*)(arg);
+
+    (void)s;
     *data = ctx_data->npn_protocols;
     *len = ctx_data->npn_protocols_len;
     return SSL_TLSEXT_ERR_OK;
@@ -281,10 +304,10 @@ static int server_alpn_cb(SSL *s, const unsigned char **out,
 {
     CTX_DATA *ctx_data = (CTX_DATA*)(arg);
     int ret;
-
     /* SSL_select_next_proto isn't const-correct... */
     unsigned char *tmp_out;
 
+    (void)s;
     /*
      * The result points either to |in| or to |ctx_data->alpn_protocols|.
      * The callback is allowed to point to |in| or to a long-lived buffer,
@@ -452,6 +475,7 @@ static void configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
 static void configure_handshake_ssl(SSL *server, SSL *client,
                                     const SSL_TEST_EXTRA_CONF *extra)
 {
+    (void)server;
     if (extra->client.servername != SSL_TEST_SERVERNAME_NONE)
         SSL_set_tlsext_host_name(client,
                                  ssl_servername_name(extra->client.servername));

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -338,6 +338,9 @@ static void configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
     unsigned char *ticket_keys;
     size_t ticket_key_len;
 
+#ifdef OPENSSL_NO_NEXTPROTONEG
+    (void)client_ctx_data;
+#endif
     TEST_check(SSL_CTX_set_max_send_fragment(server_ctx,
                                              test->max_fragment_size) == 1);
     if (server2_ctx != NULL) {

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -79,7 +79,7 @@ static struct test_st {
 
 static char *pt(unsigned char *md, unsigned int len);
 
-int main(int argc, char *argv[])
+int main(void)
 {
 # ifndef OPENSSL_NO_MD5
     int i;

--- a/test/ideatest.c
+++ b/test/ideatest.c
@@ -14,7 +14,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_IDEA
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No IDEA support\n");
     return (0);
@@ -60,14 +60,14 @@ static const unsigned char cfb_cipher64[CFB_TEST_SIZE] = {
 
 static int cfb64_test(const unsigned char *cfb_cipher);
 static char *pt(unsigned char *p);
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, err = 0;
     IDEA_KEY_SCHEDULE key, dkey;
     unsigned char iv[8];
-
     IDEA_set_encrypt_key(k, &key);
     IDEA_ecb_encrypt(in, out, &key);
+
     if (memcmp(out, c, 8) != 0) {
         printf("ecb idea error encrypting\n");
         printf("got     :");

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -228,7 +228,7 @@ static int run_test_vectors(void)
     return errs;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     unsigned char rkey[16];
     unsigned char rkey2[16];

--- a/test/md2test.c
+++ b/test/md2test.c
@@ -14,7 +14,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_MD2
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No MD2 support\n");
     return (0);
@@ -49,7 +49,7 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, err = 0;
     char **P, **R;

--- a/test/md4test.c
+++ b/test/md4test.c
@@ -14,7 +14,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_MD4
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No MD4 support\n");
     return (0);
@@ -45,7 +45,7 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, err = 0;
     char **P, **R;

--- a/test/md5test.c
+++ b/test/md5test.c
@@ -14,7 +14,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_MD5
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No MD5 support\n");
     return (0);
@@ -45,7 +45,7 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, err = 0;
     char **P, **R;

--- a/test/mdc2test.c
+++ b/test/mdc2test.c
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef OPENSSL_NO_MDC2
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No MDC2 support\n");
     return (0);
@@ -41,7 +41,7 @@ static unsigned char pad2[16] = {
     0x35, 0xD8, 0x7A, 0xFE, 0xAB, 0x33, 0xBE, 0xE2
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int ret = 1;
     unsigned char md[MDC2_DIGEST_LENGTH];

--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -19,6 +19,7 @@ int main(int argc, char **argv)
     char *lost;
     int noleak;
 
+    (void)argc;
     p = getenv("OPENSSL_DEBUG_MEMORY");
     if (p != NULL && strcmp(p, "on") == 0)
         CRYPTO_set_mem_debug(1);

--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -42,6 +42,8 @@ int main(int argc, char **argv)
         return 1;
     return ((lost != NULL) ^ (noleak == 0));
 #else
+    (void)argc;
+    (void)argv;
     return 0;
 #endif
 }

--- a/test/modes_internal_test.c
+++ b/test/modes_internal_test.c
@@ -960,6 +960,10 @@ static void benchmark_gcm128(const unsigned char *K, size_t Klen,
     }
 # endif
 #else
+    (void)K;
+    (void)Klen;
+    (void)IV;
+    (void)IVlen;
     fprintf(stderr,
             "Benchmarking of modes isn't available on this platform\n");
 #endif

--- a/test/p5_crpt2_test.c
+++ b/test/p5_crpt2_test.c
@@ -132,7 +132,7 @@ test_p5_pbkdf2(int i, char *digestname, testdata *test, const char *hex)
     OPENSSL_free(out);
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     int i;
     testdata *test = test_cases;

--- a/test/packettest.c
+++ b/test/packettest.c
@@ -497,7 +497,7 @@ static int test_PACKET_as_length_prefixed_2()
     return 1;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     unsigned char buf[BUF_LEN];
     unsigned int i;

--- a/test/pbelutest.c
+++ b/test/pbelutest.c
@@ -16,12 +16,13 @@
  * Attempt to look up all supported algorithms.
  */
 
-int main(int argc, char **argv)
+int main(void)
 {
     size_t i;
     int rv = 0;
     int pbe_type, pbe_nid;
     int last_type = -1, last_nid = -1;
+
     for (i = 0; EVP_PBE_get(&pbe_type, &pbe_nid, i) != 0; i++) {
         if (EVP_PBE_find(pbe_type, pbe_nid, NULL, NULL, 0) == 0) {
             rv = 1;

--- a/test/randtest.c
+++ b/test/randtest.c
@@ -16,7 +16,7 @@
 /* some FIPS 140-1 random number test */
 /* some simple tests */
 
-int main(int argc, char **argv)
+int main(void)
 {
     unsigned char buf[2500];
     int i, j, k, s, sign, nsign, err = 0;

--- a/test/rc2test.c
+++ b/test/rc2test.c
@@ -19,7 +19,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_RC2
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No RC2 support\n");
     return (0);
@@ -52,7 +52,7 @@ static unsigned char RC2cipher[4][8] = {
     {0x50, 0xDC, 0x01, 0x62, 0xBD, 0x75, 0x7F, 0x31},
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, n, err = 0;
     RC2_KEY key;

--- a/test/rc4test.c
+++ b/test/rc4test.c
@@ -14,7 +14,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_RC4
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No RC4 support\n");
     return (0);

--- a/test/rc4test.c
+++ b/test/rc4test.c
@@ -64,7 +64,7 @@ static unsigned char output[7][30] = {
     {0},
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, err = 0;
     int j;

--- a/test/rc5test.c
+++ b/test/rc5test.c
@@ -19,7 +19,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_RC5
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No RC5 support\n");
     return (0);

--- a/test/rc5test.c
+++ b/test/rc5test.c
@@ -187,7 +187,7 @@ static unsigned char rc5_cbc_iv[RC5_CBC_NUM][8] = {
     {0x7c, 0xb3, 0xf1, 0xdf, 0x34, 0xf9, 0x48, 0x11},
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i, n, err = 0;
     RC5_32_KEY key;

--- a/test/rmdtest.c
+++ b/test/rmdtest.c
@@ -14,7 +14,7 @@
 #include "../e_os.h"
 
 #ifdef OPENSSL_NO_RMD160
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No ripemd support\n");
     return (0);
@@ -50,7 +50,7 @@ static char *ret[] = {
 };
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+int main(void)
 {
     unsigned int i;
     int err = 0;

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -220,7 +220,7 @@ static int pad_unknown(void)
 static const char rnd_seed[] =
     "string to make the random number generator think it has entropy";
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int err = 0;
     int v;

--- a/test/sanitytest.c
+++ b/test/sanitytest.c
@@ -36,7 +36,7 @@ enum largechoices {
     a10, b10, c10, d10, e10, f10, g10, h10, i10, j10,
     xxx };
 
-int main()
+int main(void)
 {
     char *p;
     char bytes[sizeof(p)];

--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -13,7 +13,7 @@
 #define perror_line1(l)  perror_line2(l)
 #define perror_line2(l)  perror("failed " #l)
 
-int main(int argc, char **argv)
+int main(void)
 {
 #if defined(OPENSSL_SYS_LINUX) || defined(OPENSSL_SYS_UNIX)
     char *p = NULL, *q = NULL, *r = NULL, *s = NULL;

--- a/test/sha1test.c
+++ b/test/sha1test.c
@@ -32,7 +32,7 @@ static char *ret[] = {
 static char *bigret = "34aa973cd4c4daa4f61eeb2bdbad27316534016f";
 
 static char *pt(unsigned char *md);
-int main(int argc, char *argv[])
+int main(void)
 {
     unsigned int i;
     int err = 0;

--- a/test/sha256t.c
+++ b/test/sha256t.c
@@ -56,7 +56,7 @@ static const unsigned char addenum_3[SHA224_DIGEST_LENGTH] = {
     0x4e, 0xe7, 0xad, 0x67
 };
 
-int main(int argc, char **argv)
+int main(void)
 {
     unsigned char md[SHA256_DIGEST_LENGTH];
     int i;

--- a/test/sha512t.c
+++ b/test/sha512t.c
@@ -75,7 +75,7 @@ static const unsigned char app_d3[SHA384_DIGEST_LENGTH] = {
     0xae, 0x97, 0xdd, 0xd8, 0x7f, 0x3d, 0x89, 0x85
 };
 
-int main(int argc, char **argv)
+int main(void)
 {
     unsigned char md[SHA512_DIGEST_LENGTH];
     int i;

--- a/test/srptest.c
+++ b/test/srptest.c
@@ -12,7 +12,7 @@
 
 # include <stdio.h>
 
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No SRP support\n");
     return (0);

--- a/test/srptest.c
+++ b/test/srptest.c
@@ -274,7 +274,7 @@ static int run_srp_kat(void)
     return ret;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     BIO *bio_err;
     bio_err = BIO_new_fp(stderr, BIO_NOCLOSE | BIO_FP_TEXT);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -54,9 +54,11 @@ struct sslapitest_log_counts {
     unsigned int server_application_secret_count;
 };
 
-static void client_keylog_callback(const SSL *ssl, const char *line) {
+static void client_keylog_callback(const SSL *ssl, const char *line)
+{
     int line_length = strlen(line);
 
+    (void)ssl;
     /* If the log doesn't fit, error out. */
     if ((client_log_buffer_index + line_length) > LOG_BUFFER_SIZE) {
         printf("No room in client log\n");
@@ -72,9 +74,11 @@ static void client_keylog_callback(const SSL *ssl, const char *line) {
     return;
 }
 
-static void server_keylog_callback(const SSL *ssl, const char *line) {
+static void server_keylog_callback(const SSL *ssl, const char *line)
+{
     int line_length = strlen(line);
 
+    (void)ssl;
     /* If the log doesn't fit, error out. */
     if ((server_log_buffer_index + line_length) > LOG_BUFFER_SIZE) {
         printf("No room in server log\n");
@@ -850,10 +854,13 @@ ssl_session_set_up(const char *const test_case_name)
 
 static void ssl_session_tear_down(SSL_SESSION_TEST_FIXTURE fixture)
 {
+    (void)fixture;
 }
 
 static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
 {
+    (void)ssl;
+    (void)sess;
     new_called++;
 
     return 1;
@@ -861,6 +868,8 @@ static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
 
 static void remove_session_cb(SSL_CTX *ctx, SSL_SESSION *sess)
 {
+    (void)ctx;
+    (void)sess;
     remove_called++;
 }
 
@@ -1221,6 +1230,7 @@ static SSL_BIO_TEST_FIXTURE ssl_bio_set_up(const char *const test_case_name)
 
 static void ssl_bio_tear_down(SSL_BIO_TEST_FIXTURE fixture)
 {
+    (void)fixture;
 }
 
 static int execute_test_ssl_bio(SSL_BIO_TEST_FIXTURE fix)

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -76,12 +76,17 @@ static long tls_corrupt_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
 static int tls_corrupt_gets(BIO *bio, char *buf, int size)
 {
+    (void)bio;
+    (void)buf;
+    (void)size;
     /* We don't support this - not needed anyway */
     return -1;
 }
 
 static int tls_corrupt_puts(BIO *bio, const char *str)
 {
+    (void)bio;
+    (void)str;
     /* We don't support this - not needed anyway */
     return -1;
 }

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -154,6 +154,8 @@ typedef struct srp_client_arg_st {
 static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
 {
     SRP_CLIENT_ARG *srp_client_arg = (SRP_CLIENT_ARG *)arg;
+
+    (void)s;
     return OPENSSL_strdup((char *)srp_client_arg->srppassin);
 }
 
@@ -194,6 +196,10 @@ static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
                          const unsigned char *in, unsigned int inlen,
                          void *arg)
 {
+    (void)s;
+    (void)in;
+    (void)inlen;
+    (void)arg;
     /*
      * This callback only returns the protocol string, rather than a length
      * prefixed set. We assume that NEXT_PROTO_STRING is a one element list
@@ -207,6 +213,8 @@ static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
 static int cb_server_npn(SSL *s, const unsigned char **data,
                          unsigned int *len, void *arg)
 {
+    (void)s;
+    (void)arg;
     *data = (const unsigned char *)NEXT_PROTO_STRING;
     *len = sizeof(NEXT_PROTO_STRING) - 1;
     return SSL_TLSEXT_ERR_OK;
@@ -215,6 +223,10 @@ static int cb_server_npn(SSL *s, const unsigned char **data,
 static int cb_server_rejects_npn(SSL *s, const unsigned char **data,
                                  unsigned int *len, void *arg)
 {
+    (void)s;
+    (void)data;
+    (void)len;
+    (void)arg;
     return SSL_TLSEXT_ERR_NOACK;
 }
 
@@ -288,6 +300,9 @@ static SSL_SESSION *client_sess;
 static int servername_cb(SSL *s, int *ad, void *arg)
 {
     const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+
+    (void)ad;
+    (void)arg;
     if (sn_server2 == NULL) {
         BIO_printf(bio_stdout, "Servername 2 is NULL\n");
         return SSL_TLSEXT_ERR_NOACK;
@@ -306,6 +321,8 @@ static int verify_servername(SSL *client, SSL *server)
 {
     /* just need to see if sn_context is what we expect */
     SSL_CTX* ctx = SSL_get_SSL_CTX(server);
+
+    (void)client;
     if (sn_expect == 0)
         return 0;
     if (sn_expect == 1 && ctx == s_ctx)
@@ -371,6 +388,7 @@ static int cb_server_alpn(SSL *s, const unsigned char **out,
     size_t protos_len;
     char* alpn_str = arg;
 
+    (void)s;
     protos = next_protos_parse(&protos_len, alpn_str);
     if (protos == NULL) {
         fprintf(stderr, "failed to parser ALPN server protocol string: %s\n",
@@ -486,6 +504,12 @@ static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char *in, size_t inlen,
                                    int *al, void *arg)
 {
+    (void)s;
+    (void)in;
+    (void)inlen;
+    (void)al;
+    (void)arg;
+
     if (ext_type == TLSEXT_TYPE_signed_certificate_timestamp)
         serverinfo_sct_seen++;
     else if (ext_type == TACK_EXT_TYPE)
@@ -495,7 +519,7 @@ static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int verify_serverinfo()
+static int verify_serverinfo(void)
 {
     if (serverinfo_sct != serverinfo_sct_seen)
         return -1;
@@ -518,6 +542,11 @@ static int custom_ext_0_cli_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)out;
+    (void)outlen;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_0)
         custom_ext_error = 1;
     return 0;                   /* Don't send an extension */
@@ -527,6 +556,12 @@ static int custom_ext_0_cli_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)in;
+    (void)inlen;
+    (void)al;
+    (void)arg;
     return 1;
 }
 
@@ -534,6 +569,9 @@ static int custom_ext_1_cli_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_1)
         custom_ext_error = 1;
     *out = (const unsigned char *)custom_ext_cli_string;
@@ -545,6 +583,12 @@ static int custom_ext_1_cli_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)in;
+    (void)inlen;
+    (void)al;
+    (void)arg;
     return 1;
 }
 
@@ -552,6 +596,9 @@ static int custom_ext_2_cli_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
     *out = (const unsigned char *)custom_ext_cli_string;
@@ -563,6 +610,10 @@ static int custom_ext_2_cli_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)in;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
     if (inlen != 0)
@@ -574,6 +625,9 @@ static int custom_ext_3_cli_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
     *out = (const unsigned char *)custom_ext_cli_string;
@@ -585,6 +639,9 @@ static int custom_ext_3_cli_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
     if (inlen != strlen(custom_ext_srv_string))
@@ -602,6 +659,12 @@ static int custom_ext_0_srv_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)in;
+    (void)inlen;
+    (void)al;
+    (void)arg;
     custom_ext_error = 1;
     return 1;
 }
@@ -611,6 +674,12 @@ static int custom_ext_0_srv_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)out;
+    (void)outlen;
+    (void)al;
+    (void)arg;
     /* Error: should not have been called */
     custom_ext_error = 1;
     return 0;                   /* Don't send an extension */
@@ -620,6 +689,9 @@ static int custom_ext_1_srv_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_1)
         custom_ext_error = 1;
     /* Check for "abc" */
@@ -634,6 +706,12 @@ static int custom_ext_1_srv_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)out;
+    (void)outlen;
+    (void)al;
+    (void)arg;
     return 0;                   /* Don't send an extension */
 }
 
@@ -641,6 +719,9 @@ static int custom_ext_2_srv_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
     /* Check for "abc" */
@@ -655,6 +736,10 @@ static int custom_ext_2_srv_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)al;
+    (void)arg;
     *out = NULL;
     *outlen = 0;
     return 1;                   /* Send empty extension */
@@ -664,6 +749,9 @@ static int custom_ext_3_srv_parse_cb(SSL *s, unsigned int ext_type,
                                      const unsigned char *in,
                                      size_t inlen, int *al, void *arg)
 {
+    (void)s;
+    (void)al;
+    (void)arg;
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
     /* Check for "abc" */
@@ -678,6 +766,10 @@ static int custom_ext_3_srv_add_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char **out,
                                    size_t *outlen, int *al, void *arg)
 {
+    (void)s;
+    (void)ext_type;
+    (void)al;
+    (void)arg;
     *out = (const unsigned char *)custom_ext_srv_string;
     *outlen = strlen(custom_ext_srv_string);
     return 1;                   /* Send "defg" */
@@ -3172,6 +3264,8 @@ static unsigned int psk_client_callback(SSL *ssl, const char *hint,
     int ret;
     unsigned int psk_len = 0;
 
+    (void)ssl;
+    (void)hint;
     ret = BIO_snprintf(identity, max_identity_len, "Client_identity");
     if (ret < 0)
         goto out_err;
@@ -3192,6 +3286,7 @@ static unsigned int psk_server_callback(SSL *ssl, const char *identity,
 {
     unsigned int psk_len = 0;
 
+    (void)ssl;
     if (strcmp(identity, "Client_identity") != 0) {
         BIO_printf(bio_err, "server: PSK error: client identity not found\n");
         return 0;

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -221,6 +221,9 @@ static long tls_dump_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
 static int tls_dump_gets(BIO *bio, char *buf, int size)
 {
+    (void)bio;
+    (void)buf;
+    (void)size;
     /* We don't support this - not needed anyway */
     return -1;
 }
@@ -477,6 +480,7 @@ static long mempacket_test_ctrl(BIO *bio, int cmd, long num, void *ptr)
     MEMPACKET_TEST_CTX *ctx = BIO_get_data(bio);
     MEMPACKET *thispkt;
 
+    (void)ptr;
     switch (cmd) {
     case BIO_CTRL_EOF:
         ret = (long)(sk_MEMPACKET_num(ctx->pkts) == 0);
@@ -513,6 +517,9 @@ static long mempacket_test_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
 static int mempacket_test_gets(BIO *bio, char *buf, int size)
 {
+    (void)bio;
+    (void)buf;
+    (void)size;
     /* We don't support this - not needed anyway */
     return -1;
 }

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -230,7 +230,7 @@ static int test_thread_local(void)
     return 1;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     if (!test_lock())
       return 1;

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -21,12 +21,14 @@ typedef unsigned int thread_t;
 
 static int run_thread(thread_t *t, void (*f)(void))
 {
+    (void)t;
     f();
     return 1;
 }
 
 static int wait_for_thread(thread_t thread)
 {
+    (void)thread;
     return 1;
 }
 

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -134,6 +134,8 @@ static unsigned char server_ats_iv[] = {
 /* Mocked out implementations of various functions */
 int ssl3_digest_cached_records(SSL *s, int keep)
 {
+    (void)s;
+    (void)keep;
     return 1;
 }
 
@@ -143,6 +145,7 @@ static int full_hash = 0;
 int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
                        size_t *hashlen)
 {
+    (void)s;
     if (sizeof(hs_start_hash) > outlen
             || sizeof(hs_full_hash) != sizeof(hs_start_hash))
         return 0;
@@ -160,15 +163,18 @@ int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
 
 const EVP_MD *ssl_handshake_md(SSL *s)
 {
+    (void)s;
     return EVP_sha256();
 }
 
 void RECORD_LAYER_reset_read_sequence(RECORD_LAYER *rl)
 {
+    (void)rl;
 }
 
 void RECORD_LAYER_reset_write_sequence(RECORD_LAYER *rl)
 {
+    (void)rl;
 }
 
 int ssl_cipher_get_evp(const SSL_SESSION *s, const EVP_CIPHER **enc,
@@ -176,6 +182,13 @@ int ssl_cipher_get_evp(const SSL_SESSION *s, const EVP_CIPHER **enc,
                        size_t *mac_secret_size, SSL_COMP **comp, int use_etm)
 
 {
+    (void)s;
+    (void)enc;
+    (void)md;
+    (void)mac_pkey_type;
+    (void)mac_secret_size;
+    (void)comp;
+    (void)use_etm;
     return 0;
 }
 

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -202,6 +202,10 @@ int ssl_log_secret(SSL *ssl,
                    const uint8_t *secret,
                    size_t secret_len)
 {
+    (void)ssl;
+    (void)label;
+    (void)secret;
+    (void)secret_len;
     return 1;
 }
 

--- a/test/uitest.c
+++ b/test/uitest.c
@@ -43,6 +43,7 @@ BIO *bio_err = NULL;
 /* Old style PEM password callback */
 static int test_pem_password_cb(char *buf, int size, int rwflag, void *userdata)
 {
+    (void)rwflag;
     OPENSSL_strlcpy(buf, (char *)userdata, (size_t)size);
     return 1;
 }
@@ -125,6 +126,7 @@ int test_main(int argc, char *argv[])
 {
     int ret;
 
+    (void)argc;
     bio_err = dup_bio_err(FORMAT_TEXT);
 
 #ifndef OPENSSL_NO_UI

--- a/test/wp_test.c
+++ b/test/wp_test.c
@@ -122,7 +122,7 @@ static const unsigned char iso_test_9[WHIRLPOOL_DIGEST_LENGTH] = {
     0x69, 0x53, 0xB2, 0x26, 0xE4, 0xED, 0x8B, 0x01
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     unsigned char md[WHIRLPOOL_DIGEST_LENGTH];
     int i;

--- a/test/wp_test.c
+++ b/test/wp_test.c
@@ -15,7 +15,7 @@
 #include <openssl/crypto.h>
 
 #if defined(OPENSSL_NO_WHIRLPOOL)
-int main(int argc, char *argv[])
+int main(void)
 {
     printf("No Whirlpool support\n");
     return (0);

--- a/test/wpackettest.c
+++ b/test/wpackettest.c
@@ -427,6 +427,7 @@ int test_main(int argc, char *argv[])
 {
     int testresult = 0;
 
+    (void)argc;
     buf = BUF_MEM_new();
     if (buf != NULL) {
         ADD_TEST(test_WPACKET_init);


### PR DESCRIPTION
This adds -Wunused-param and fixes many warnings.  Not all; still over 600 to go.

Is this worth doing?  Most of the warnings are because of having to fit into a common API.  But not all, e.g., DSA_sign() could have been changed.

Thoughts?
