### PR TITLE
Do not overallocate for tmp.ciphers_raw

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3470,7 +3470,8 @@ STACK_OF(SSL_CIPHER) *ssl_bytes_to_cipher_list(SSL *s,
          * slightly over allocate because we won't store those. But that isn't a
          * problem.
          */
-        raw = s->s3->tmp.ciphers_raw = OPENSSL_malloc(numciphers * n);
+        raw = OPENSSL_malloc(numciphers * TLS_CIPHER_LEN);
+        s->s3->tmp.ciphers_raw = raw;
         if (raw == NULL) {
             *al = SSL_AD_INTERNAL_ERROR;
             goto err;


### PR DESCRIPTION
Well, not as much, at least.

Commit 07afdf3c3ac97af4f2b4eec22a97f7230f8227e0 changed things so
that for SSLv2 format ClientHellos we store the cipher list in the
TLS format, i.e., with two bytes per cipher, to be consistent with
historical behavior.

However, the space allocated for the array still performed the computation
with three bytes per cipher, a needless over-allocation (though a relatively
small one, all things considered).

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

For 1.1.0 as well, it looks like.  @mattcaswell did the original; please take a look.

This would have been a one-line change but for that "TLS_CIPHER_LEN" is a lot longer than "n" and made the line too long.