### PR TITLE
Limit the length of the encrypted premaster key.

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4418,10 +4418,11 @@ int ssl_log_rsa_client_key_exchange(SSL *ssl,
         return 0;
     }
 
+    /* We only want the first 8 bytes of the encrypted premaster as a tag. */
     return nss_keylog_int("RSA",
                           ssl,
                           encrypted_premaster,
-                          encrypted_premaster_len,
+                          8,
                           premaster,
                           premaster_len);
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -198,6 +198,7 @@ static int test_keylog(void) {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
+    int rc;
 
     /* Clean up logging space */
     memset(client_log_buffer, 0, LOG_BUFFER_SIZE + 1);
@@ -215,6 +216,13 @@ static int test_keylog(void) {
     /* We cannot log the master secret for TLSv1.3, so we should forbid it. */
     SSL_CTX_set_options(cctx, SSL_OP_NO_TLSv1_3);
     SSL_CTX_set_options(sctx, SSL_OP_NO_TLSv1_3);
+
+    /* We also want to ensure that we use RSA-based key exchange. */
+    rc = SSL_CTX_set_cipher_list(cctx, "RSA");
+    if (rc == 0) {
+        printf("Unable to restrict to RSA key exchange.\n");
+        goto end;
+    }
 
     if (SSL_CTX_get_keylog_callback(cctx)) {
         printf("Unexpected initial value for client "


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] tests are added or updated
- [X] CLA is signed

##### Description of change

This change also fixes a bug from #1646 where we would log out the *entire* encrypted premaster secret. The SSLKEYLOGFILE format only expects the first 8 bytes so that a given premaster secret can be located. This patch updates the test to correctly exercise that code, and then fixes the underlying bug as well.

Some additional enhancements to the testing harness will be made in #2287.