### PR TITLE
Fix small typo

### DIFF
--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -509,7 +509,7 @@ __owur static int parse_expected_server_sign_hash(SSL_TEST_CTX *test_ctx,
 __owur static int parse_expected_client_sign_hash(SSL_TEST_CTX *test_ctx,
                                                   const char *value)
 {
-    return parse_expected_sign_hash(&test_ctx->expected_server_sign_hash,
+    return parse_expected_sign_hash(&test_ctx->expected_client_sign_hash,
                                     value);
 }
 


### PR DESCRIPTION
In test/ssl_test, parsing ExpectedClientSignHash ended up in the
expected_server_sign_hash field.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
- [x] CLA is signed
