### PR TITLE
Server sigalgs fix

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2188,7 +2188,7 @@ __owur int tls12_copy_sigalgs(SSL *s, WPACKET *pkt,
                               const unsigned int *psig, size_t psiglen);
 __owur int tls1_save_sigalgs(SSL *s, PACKET *pkt);
 __owur int tls1_process_sigalgs(SSL *s);
-__owur size_t tls12_get_psigalgs(SSL *s, const unsigned int **psigs);
+__owur size_t tls12_get_psigalgs(SSL *s, int sent, const unsigned int **psigs);
 __owur int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
                                    EVP_PKEY *pkey);
 void ssl_set_client_disabled(SSL *s);

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -231,7 +231,7 @@ int tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt, X509 *x, size_t chainidx,
     if (!SSL_CLIENT_USE_SIGALGS(s))
         return 1;
 
-    salglen = tls12_get_psigalgs(s, &salg);
+    salglen = tls12_get_psigalgs(s, 1, &salg);
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_signature_algorithms)
                /* Sub-packet for sig-algs extension */
             || !WPACKET_start_sub_packet_u16(pkt)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2310,7 +2310,7 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
 
     if (SSL_USE_SIGALGS(s)) {
         const unsigned int *psigs;
-        size_t nl = tls12_get_psigalgs(s, &psigs);
+        size_t nl = tls12_get_psigalgs(s, 1, &psigs);
 
         if (!WPACKET_start_sub_packet_u16(pkt)
                 || !tls12_copy_sigalgs(s, pkt, psigs, nl)

--- a/test/ssl-tests/01-simple.conf
+++ b/test/ssl-tests/01-simple.conf
@@ -1,9 +1,10 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 2
+num_tests = 3
 
 test-0 = 0-default
-test-1 = 1-verify-cert
+test-1 = 1-Server signature algorithms bug
+test-2 = 2-verify-cert
 # ===========================================================
 
 [0-default]
@@ -29,23 +30,48 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[1-verify-cert]
-ssl_conf = 1-verify-cert-ssl
+[1-Server signature algorithms bug]
+ssl_conf = 1-Server signature algorithms bug-ssl
 
-[1-verify-cert-ssl]
-server = 1-verify-cert-server
-client = 1-verify-cert-client
+[1-Server signature algorithms bug-ssl]
+server = 1-Server signature algorithms bug-server
+client = 1-Server signature algorithms bug-client
 
-[1-verify-cert-server]
+[1-Server signature algorithms bug-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ClientSignatureAlgorithms = ECDSA+SHA256
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-Server signature algorithms bug-client]
+CipherString = DEFAULT
+SignatureAlgorithms = RSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[2-verify-cert]
+ssl_conf = 2-verify-cert-ssl
+
+[2-verify-cert-ssl]
+server = 2-verify-cert-server
+client = 2-verify-cert-client
+
+[2-verify-cert-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[1-verify-cert-client]
+[2-verify-cert-client]
 CipherString = DEFAULT
 VerifyMode = Peer
 
-[test-1]
+[test-2]
 ExpectedClientAlert = UnknownCA
 ExpectedResult = ClientFail
 

--- a/test/ssl-tests/01-simple.conf.in
+++ b/test/ssl-tests/01-simple.conf.in
@@ -20,6 +20,14 @@ our @tests = (
     },
 
     {
+        name => "Server signature algorithms bug",
+        # Should have no effect as we aren't doing client auth
+        server => { "ClientSignatureAlgorithms" => "ECDSA+SHA256" },
+        client => { "SignatureAlgorithms" => "RSA+SHA256" },
+        test   => { "ExpectedResult" => "Success" },
+    },
+
+    {
         name => "verify-cert",
         server => { },
         client => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This fixes a bug where if we configured client authentication signature algorithms on a server it would wrongly use them when deciding which signing algorithm to use. This affects master, 1.1.0 and 1.0.2 which will need a separate PR as the code is significantly different.

You can reproduce this with:

```
openssl s_server -client_sigalgs ECDSA+SHA256 
openssl s_client -sigalgs RSA+SHA256
```
the handshake will fail.