### PR TITLE
Add LDAP support (RFC 4511) to s_client ("-starttls ldap")

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -445,7 +445,7 @@ command for more information.
 send the protocol-specific message(s) to switch to TLS for communication.
 B<protocol> is a keyword for the intended protocol.  Currently, the only
 supported keywords are "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server",
-"irc", "postgres", "lmtp", "nntp" and "sieve".
+"irc", "postgres", "lmtp", "nntp", "sieve" and "ldap".
 
 =item B<-xmpphost hostname>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
Add LDAP support (RFC 4511) to s_client ("-starttls ldap"), fixes #1955 

_Note: I'm neither an OpenSSL nor an LDAP expert, but I definitely would like to see "-starttls ldap"; my inspiration for the implementation came from OpenSSL (existing "-starttls postgres"), PRADS, GnuTLS and hydra._