### PR TITLE
Travis: run on Trusty with clang 3.9 (1.1.0 branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: required
+
 language: c
 cache: ccache
 
@@ -8,13 +11,12 @@ addons:
     apt:
         packages:
             - ccache
-            - clang-3.6
+            - clang-3.9
             - gcc-5
             - binutils-mingw-w64
             - gcc-mingw-w64
-            - wine
         sources:
-            - llvm-toolchain-precise-3.6
+            - llvm-toolchain-trusty-3.9
             - ubuntu-toolchain-r-test
 
 os:
@@ -35,25 +37,25 @@ env:
 matrix:
     include:
         - os: linux
-          compiler: clang-3.6
+          compiler: clang-3.9
           env: CONFIG_OPTS="--strict-warnings no-deprecated" BUILDONLY="yes"
         - os: linux
           compiler: gcc
           env: CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers" COVERALLS="yes"
         - os: linux
-          compiler: clang-3.6
+          compiler: clang-3.9
           env: CONFIG_OPTS="enable-asan"
         - os: linux
-          compiler: clang-3.6
+          compiler: clang-3.9
           env: CONFIG_OPTS="enable-msan"
         - os: linux
-          compiler: clang-3.6
+          compiler: clang-3.9
           env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method -fno-sanitize=alignment"
         - os: linux
-          compiler: clang-3.6
+          compiler: clang-3.9
           env: CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2"
         - os: linux
-          compiler: clang-3.6
+          compiler: clang-3.9
           env: CONFIG_OPTS="no-stdio"
         - os: linux
           compiler: gcc-5
@@ -95,10 +97,19 @@ before_script:
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
       else
-          if which ccache >/dev/null && [ "$CC" != clang-3.6 ]; then
+          if which ccache >/dev/null && [ "$CC" != clang-3.9 ]; then
               CC="ccache $CC";
           fi;
           $srcdir/config -v $CONFIG_OPTS;
+      fi
+    - if [ -z "$BUILDONLY" ]; then
+          if [ -n "$CROSS_COMPILE" ]; then
+              if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+                  sudo dpkg --add-architecture i386;
+                  sudo apt-get update;
+                  sudo apt-get -yq install wine;
+              fi;
+          fi;
       fi
     - cd $top
 


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/6460 for context on the changes to wine install.

A green presubmit is at https://travis-ci.org/ekasper/openssl/builds/195489750