### PR TITLE
TLS 1.3 signature algorithm updates.

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -243,6 +243,8 @@ static int do_print_sigalgs(BIO *out, SSL *s, int shared)
             BIO_puts(out, ":");
         if (sign_nid == EVP_PKEY_RSA)
             sstr = "RSA";
+        else if (sign_nid == EVP_PKEY_RSA_PSS)
+            sstr = "RSA-PSS";
         else if (sign_nid == EVP_PKEY_DSA)
             sstr = "DSA";
         else if (sign_nid == EVP_PKEY_EC)

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -261,7 +261,7 @@ static int do_print_sigalgs(BIO *out, SSL *s, int shared)
             SSL_get_sigalgs(s, i, &sign_nid, &hash_nid, NULL, &rsign, &rhash);
         if (i)
             BIO_puts(out, ":");
-        sstr= get_sigtype(sign_nid);
+        sstr = get_sigtype(sign_nid);
         if (sstr)
             BIO_printf(out, "%s+", sstr);
         else

--- a/doc/man3/SSL_CTX_set1_sigalgs.pod
+++ b/doc/man3/SSL_CTX_set1_sigalgs.pod
@@ -70,11 +70,14 @@ prohibits them (for example SHA1 if the security level is 4 or more).
 
 Currently the NID_md5, NID_sha1, NID_sha224, NID_sha256, NID_sha384 and
 NID_sha512 digest NIDs are supported and the public key algorithm NIDs
-EVP_PKEY_RSA, EVP_PKEY_DSA and EVP_PKEY_EC.
+EVP_PKEY_RSA, EVP_PKEY_RSA_PSS, EVP_PKEY_DSA and EVP_PKEY_EC.
 
 The short or long name values for digests can be used in a string (for
 example "MD5", "SHA1", "SHA224", "SHA256", "SHA384", "SHA512") and
-the public key algorithm strings "RSA", "DSA" or "ECDSA".
+the public key algorithm strings "RSA", "RSA-PSS", "DSA" or "ECDSA".
+
+The TLS 1.3 signature scheme names (such as "rsa_pss_sha256") can also
+be used.
 
 The use of MD5 as a digest is strongly discouraged due to security weaknesses.
 

--- a/doc/man3/SSL_get_peer_signature_nid.pod
+++ b/doc/man3/SSL_get_peer_signature_nid.pod
@@ -1,0 +1,45 @@
+=pod
+
+=head1 NAME
+
+SSL_get_peer_signature_nid, SSL_get_peer_signature_type_nid - get TLS
+message signing types
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ int SSL_get_peer_signature_nid(SSL *ssl, int *psig_nid);
+ int SSL_get_peer_signature_type_nid(const SSL *ssl, int *psigtype_nid);
+
+=head1 DESCRIPTION
+
+SSL_get_peer_signature_nid() sets B<*psig_nid> to the NID of the digest used
+by the peer to sign TLS messages. It is implemented as a macro.
+
+SSL_get_peer_signature_type_nid() sets B<*psigtype_nid> to the signature
+type used by the peer to sign TLS messages. Currently the signature type
+is the NID of the public key type used for signing except for PSS signing
+where it is B<EVP_PKEY_RSA_PSS>.
+
+=head1 RETURN VALUES
+
+These functions return 1 for success and 0 for failure. There are several
+possible reasons for failure: the ciphersuite has no signature (e.g. it
+uses RSA key exchange or is anonymous), the TLS version is below 1.2 or
+the functions were called before the peer signed a message.
+
+=head1 SEE ALSO
+
+L<ssl(7)>, L<SSL_get_peer_certificate(3)>,
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -250,6 +250,8 @@ __owur int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
                                const unsigned char *p, size_t plen,
                                int use_context);
 
+int SSL_get_peer_signature_type_nid(const SSL *s, int *pnid);
+
 int SSL_get_sigalgs(SSL *s, int idx,
                     int *psign, int *phash, int *psignandhash,
                     unsigned char *rsig, unsigned char *rhash);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1493,6 +1493,25 @@ typedef struct {
     size_t meths_count;
 } custom_ext_methods;
 
+/*
+ * Structure containing table entry of values associated with the signature
+ * algorithms (signature scheme) extension
+*/
+typedef struct sigalg_lookup_st {
+    /* TLS 1.3 signature scheme name */
+    const char *name;
+    /* Raw value used in extension */
+    uint16_t sigalg;
+    /* NID of hash algorithm */
+    int hash;
+    /* NID of signature algorithm */
+    int sig;
+    /* Combined hash and signature NID, if any */
+    int sigandhash;
+    /* Required public key curve (ECDSA only) */
+    int curve;
+} SIGALG_LOOKUP;
+
 typedef struct cert_st {
     /* Current active set */
     /*
@@ -1538,7 +1557,7 @@ typedef struct cert_st {
      * Signature algorithms shared by client and server: cached because these
      * are used most often.
      */
-    TLS_SIGALGS *shared_sigalgs;
+    const SIGALG_LOOKUP **shared_sigalgs;
     size_t shared_sigalgslen;
     /*
      * Certificate setup callback: if set is called whenever a certificate
@@ -1571,18 +1590,6 @@ typedef struct cert_st {
     CRYPTO_REF_COUNT references;             /* >1 only if SSL_copy_session_id is used */
     CRYPTO_RWLOCK *lock;
 } CERT;
-
-/* Structure containing decoded values of signature algorithms extension */
-struct tls_sigalgs_st {
-    /* NID of hash algorithm */
-    int hash_nid;
-    /* NID of signature algorithm */
-    int sign_nid;
-    /* Combined hash and signature NID */
-    int signandhash_nid;
-    /* Raw value used in extension */
-    uint16_t rsigalg;
-};
 
 # define FP_ICC  (int (*)(const void *,const void *))
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1250,7 +1250,7 @@ typedef struct ssl3_state_st {
          * algorithms extension for server or as part of a certificate
          * request for client.
          */
-        unsigned int *peer_sigalgs;
+        uint16_t *peer_sigalgs;
         /* Size of above array */
         size_t peer_sigalgslen;
         /* Digest peer uses for signing */
@@ -1519,7 +1519,7 @@ typedef struct cert_st {
      * the client hello as the supported signature algorithms extension. For
      * servers it represents the signature algorithms we are willing to use.
      */
-    unsigned int *conf_sigalgs;
+    uint16_t *conf_sigalgs;
     /* Size of above array */
     size_t conf_sigalgslen;
     /*
@@ -1529,7 +1529,7 @@ typedef struct cert_st {
      * represents the signature algorithms we are willing to use for client
      * authentication.
      */
-    unsigned int *client_sigalgs;
+    uint16_t *client_sigalgs;
     /* Size of above array */
     size_t client_sigalgslen;
     /*
@@ -1579,7 +1579,7 @@ struct tls_sigalgs_st {
     /* Combined hash and signature NID */
     int signandhash_nid;
     /* Raw value used in extension */
-    unsigned int rsigalg;
+    uint16_t rsigalg;
 };
 
 # define FP_ICC  (int (*)(const void *,const void *))
@@ -2185,10 +2185,10 @@ __owur EVP_MD_CTX *ssl_replace_hash(EVP_MD_CTX **hash, const EVP_MD *md);
 void ssl_clear_hash_ctx(EVP_MD_CTX **hash);
 __owur long ssl_get_algorithm2(SSL *s);
 __owur int tls12_copy_sigalgs(SSL *s, WPACKET *pkt,
-                              const unsigned int *psig, size_t psiglen);
+                              const uint16_t *psig, size_t psiglen);
 __owur int tls1_save_sigalgs(SSL *s, PACKET *pkt);
 __owur int tls1_process_sigalgs(SSL *s);
-__owur size_t tls12_get_psigalgs(SSL *s, int sent, const unsigned int **psigs);
+__owur size_t tls12_get_psigalgs(SSL *s, int sent, const uint16_t **psigs);
 __owur int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
                                    EVP_PKEY *pkey);
 void ssl_set_client_disabled(SSL *s);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1255,6 +1255,8 @@ typedef struct ssl3_state_st {
         size_t peer_sigalgslen;
         /* Digest peer uses for signing */
         const EVP_MD *peer_md;
+        /* Signature type: public key type or EVP_PKEY_RSA_PSS for PSS */
+        int peer_sigtype;
         /* Array of digests used for signing */
         const EVP_MD *md[SSL_PKEY_NUM];
         /*
@@ -1709,10 +1711,7 @@ typedef enum tlsext_index_en {
 #define TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512       0xefef
 #define TLSEXT_SIGALG_gostr34102001_gostr3411                   0xeded
 
-#define SIGID_IS_PSS(sigid) ((sigid) == TLSEXT_SIGALG_rsa_pss_sha256 \
-                             || (sigid) == TLSEXT_SIGALG_rsa_pss_sha384 \
-                             || (sigid) == TLSEXT_SIGALG_rsa_pss_sha512)
-
+#define SSL_USE_PSS(s) (s->s3->tmp.peer_sigtype == EVP_PKEY_RSA_PSS)
 
 /* A dummy signature value not valid for TLSv1.2 signature algs */
 #define TLSEXT_signature_rsa_pss                                0x0101
@@ -2189,8 +2188,7 @@ __owur int tls12_copy_sigalgs(SSL *s, WPACKET *pkt,
 __owur int tls1_save_sigalgs(SSL *s, PACKET *pkt);
 __owur int tls1_process_sigalgs(SSL *s);
 __owur size_t tls12_get_psigalgs(SSL *s, int sent, const uint16_t **psigs);
-__owur int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
-                                   EVP_PKEY *pkey);
+__owur int tls12_check_peer_sigalg(SSL *s, unsigned int sig, EVP_PKEY *pkey);
 void ssl_set_client_disabled(SSL *s);
 __owur int ssl_cipher_disabled(SSL *s, const SSL_CIPHER *c, int op);
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -226,7 +226,7 @@ int tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt, X509 *x, size_t chainidx,
                                 int *al)
 {
     size_t salglen;
-    const unsigned int *salg;
+    const uint16_t *salg;
 
     if (!SSL_CLIENT_USE_SIGALGS(s))
         return 1;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1957,8 +1957,7 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
         }
         if (SSL_USE_PSS(s)) {
             if (EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING) <= 0
-                       /* -1 here means set saltlen to the digest len */
-                    || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx,
+                || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx,
                                                 RSA_PSS_SALTLEN_DIGEST) <= 0) {
                 al = SSL_AD_INTERNAL_ERROR;
                 SSLerr(SSL_F_TLS_PROCESS_KEY_EXCHANGE, ERR_R_EVP_LIB);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1958,7 +1958,8 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
         if (ispss) {
             if (EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING) <= 0
                        /* -1 here means set saltlen to the digest len */
-                    || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, -1) <= 0) {
+                    || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx,
+                                                RSA_PSS_SALTLEN_DIGEST) <= 0) {
                 al = SSL_AD_INTERNAL_ERROR;
                 SSLerr(SSL_F_TLS_PROCESS_KEY_EXCHANGE, ERR_R_EVP_LIB);
                 goto err;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -188,8 +188,8 @@ int tls_construct_cert_verify(SSL *s, WPACKET *pkt)
 
     if (ispss) {
         if (EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING) <= 0
-                   /* -1 here means set saltlen to the digest len */
-                || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, -1) <= 0) {
+            || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx,
+                                                RSA_PSS_SALTLEN_DIGEST) <= 0) {
             SSLerr(SSL_F_TLS_CONSTRUCT_CERT_VERIFY, ERR_R_EVP_LIB);
             goto err;
         }
@@ -361,8 +361,8 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
 
     if (ispss) {
         if (EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING) <= 0
-                   /* -1 here means set saltlen to the digest len */
-                || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, -1) <= 0) {
+            || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx,
+                                                RSA_PSS_SALTLEN_DIGEST) <= 0) {
             SSLerr(SSL_F_TLS_PROCESS_CERT_VERIFY, ERR_R_EVP_LIB);
             goto f_err;
         }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -243,7 +243,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
     unsigned char *gost_data = NULL;
 #endif
     int al = SSL_AD_INTERNAL_ERROR, ret = MSG_PROCESS_ERROR;
-    int type = 0, j, pktype, ispss = 0;
+    int type = 0, j, pktype;
     unsigned int len;
     X509 *peer;
     const EVP_MD *md = NULL;
@@ -290,14 +290,14 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
                 al = SSL_AD_DECODE_ERROR;
                 goto f_err;
             }
-            rv = tls12_check_peer_sigalg(&md, s, sigalg, pkey);
+            rv = tls12_check_peer_sigalg(s, sigalg, pkey);
             if (rv == -1) {
                 goto f_err;
             } else if (rv == 0) {
                 al = SSL_AD_DECODE_ERROR;
                 goto f_err;
             }
-            ispss = SIGID_IS_PSS(sigalg);
+            md = s->s3->tmp.peer_md;
 #ifdef SSL_DEBUG
             fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
 #endif
@@ -359,7 +359,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
     }
 #endif
 
-    if (ispss) {
+    if (SSL_USE_PSS(s)) {
         if (EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING) <= 0
             || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx,
                                                 RSA_PSS_SALTLEN_DIGEST) <= 0) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2308,7 +2308,7 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
     }
 
     if (SSL_USE_SIGALGS(s)) {
-        const unsigned int *psigs;
+        const uint16_t *psigs;
         size_t nl = tls12_get_psigalgs(s, 1, &psigs);
 
         if (!WPACKET_start_sub_packet_u16(pkt)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2250,8 +2250,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
             if (ispss) {
                 if (EVP_PKEY_CTX_set_rsa_padding(pctx,
                                                  RSA_PKCS1_PSS_PADDING) <= 0
-                           /* -1 here means set saltlen to the digest len */
-                        || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, -1) <= 0) {
+                    || EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, RSA_PSS_SALTLEN_DIGEST) <= 0) {
                     SSLerr(SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,
                            ERR_R_EVP_LIB);
                     goto f_err;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -722,13 +722,9 @@ static const SIGALG_LOOKUP sigalg_lookup_tbl[] = {
     {TLSEXT_SIGALG_ecdsa_secp521r1_sha512, NID_sha512, EVP_PKEY_EC},
     {TLSEXT_SIGALG_ecdsa_sha1, NID_sha1, EVP_PKEY_EC},
 #endif
-    /*
-     * PSS must appear before PKCS1 so that we prefer that when signing where
-     * possible
-     */
-    {TLSEXT_SIGALG_rsa_pss_sha256, NID_sha256, EVP_PKEY_RSA},
-    {TLSEXT_SIGALG_rsa_pss_sha384, NID_sha384, EVP_PKEY_RSA},
-    {TLSEXT_SIGALG_rsa_pss_sha512, NID_sha512, EVP_PKEY_RSA},
+    {TLSEXT_SIGALG_rsa_pss_sha256, NID_sha256, EVP_PKEY_RSA_PSS},
+    {TLSEXT_SIGALG_rsa_pss_sha384, NID_sha384, EVP_PKEY_RSA_PSS},
+    {TLSEXT_SIGALG_rsa_pss_sha512, NID_sha512, EVP_PKEY_RSA_PSS},
     {TLSEXT_SIGALG_rsa_pkcs1_sha256, NID_sha256, EVP_PKEY_RSA},
     {TLSEXT_SIGALG_rsa_pkcs1_sha384, NID_sha384, EVP_PKEY_RSA},
     {TLSEXT_SIGALG_rsa_pkcs1_sha512, NID_sha512, EVP_PKEY_RSA},
@@ -814,7 +810,8 @@ size_t tls12_get_psigalgs(SSL *s, int sent, const uint16_t **psigs)
 
 /*
  * Check signature algorithm is consistent with sent supported signature
- * algorithms and if so return relevant digest.
+ * algorithms and if so set relevant digest and signature scheme in
+ * s.
  */
 int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
                             EVP_PKEY *pkey)
@@ -823,11 +820,15 @@ int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
     char sigalgstr[2];
     size_t sent_sigslen, i;
     int pkeyid = EVP_PKEY_id(pkey);
+    int peer_pkeyid;
     /* Should never happen */
     if (pkeyid == -1)
         return -1;
     /* Check key type is consistent with signature */
-    if (pkeyid != tls_sigalg_get_sig(sig)) {
+    peer_pkeyid = tls_sigalg_get_sig(sig);
+    /* RSA keys can be used for RSA-PSS */
+    if (pkeyid != peer_pkeyid
+        && (peer_pkeyid != EVP_PKEY_RSA_PSS || pkeyid != EVP_PKEY_RSA)) {
         SSLerr(SSL_F_TLS12_CHECK_PEER_SIGALG, SSL_R_WRONG_SIGNATURE_TYPE);
         return 0;
     }
@@ -1261,7 +1262,7 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
 int tls12_get_sigandhash(SSL *s, WPACKET *pkt, const EVP_PKEY *pk,
                          const EVP_MD *md, int *ispss)
 {
-    int md_id, sig_id, tmpispss = 0;
+    int md_id, sig_id;
     size_t i;
     const SIGALG_LOOKUP *curr;
 
@@ -1271,30 +1272,18 @@ int tls12_get_sigandhash(SSL *s, WPACKET *pkt, const EVP_PKEY *pk,
     sig_id = EVP_PKEY_id(pk);
     if (md_id == NID_undef)
         return 0;
+    /* For TLS 1.3 only allow RSA-PSS */
+    if (SSL_IS_TLS13(s) && sig_id == EVP_PKEY_RSA)
+        sig_id = EVP_PKEY_RSA_PSS;
 
     for (i = 0, curr = sigalg_lookup_tbl; i < OSSL_NELEM(sigalg_lookup_tbl);
          i++, curr++) {
-        if (curr->hash == md_id && curr->sig == sig_id) {
-            if (sig_id == EVP_PKEY_RSA) {
-                tmpispss = SIGID_IS_PSS(curr->sigalg);
-                if (!SSL_IS_TLS13(s) && tmpispss) {
-                    size_t j;
-
-                    /*
-                     * Check peer actually sent a PSS sig id - it could have
-                     * been a PKCS1 sig id instead.
-                     */
-                    for (j = 0; j < s->cert->shared_sigalgslen; j++)
-                        if (s->cert->shared_sigalgs[j].rsigalg == curr->sigalg)
-                            break;
-
-                    if (j == s->cert->shared_sigalgslen)
-                        continue;
-                }
-            }
+        /* If key type is RSA also match PSS signature type */
+        if (curr->hash == md_id && (curr->sig == sig_id
+            || (sig_id == EVP_PKEY_RSA && curr->sig == EVP_PKEY_RSA_PSS))) {
             if (!WPACKET_put_bytes_u16(pkt, curr->sigalg))
                 return 0;
-            *ispss = tmpispss;
+            *ispss = curr->sig == EVP_PKEY_RSA_PSS;
             return 1;
         }
     }
@@ -1350,6 +1339,12 @@ static int tls12_get_pkey_idx(int sig_nid)
     switch (sig_nid) {
 #ifndef OPENSSL_NO_RSA
     case EVP_PKEY_RSA:
+        return SSL_PKEY_RSA_SIGN;
+    /*
+     * For now return RSA key for PSS. When we support PSS only keys
+     * this will need to be updated.
+     */
+    case EVP_PKEY_RSA_PSS:
         return SSL_PKEY_RSA_SIGN;
 #endif
 #ifndef OPENSSL_NO_DSA
@@ -1437,6 +1432,8 @@ void ssl_set_sig_mask(uint32_t *pmask_a, SSL *s, int op)
     for (i = 0; i < sigalgslen; i ++, sigalgs++) {
         switch (tls_sigalg_get_sig(*sigalgs)) {
 #ifndef OPENSSL_NO_RSA
+        /* Any RSA-PSS signature algorithms also mean we allow RSA */
+        case EVP_PKEY_RSA_PSS:
         case EVP_PKEY_RSA:
             if (!have_rsa && tls12_sigalg_allowed(s, op, *sigalgs))
                 have_rsa = 1;
@@ -1606,11 +1603,7 @@ int tls1_process_sigalgs(SSL *s)
     for (i = 0, sigptr = c->shared_sigalgs;
          i < c->shared_sigalgslen; i++, sigptr++) {
         /* Ignore PKCS1 based sig algs in TLSv1.3 */
-        if (SSL_IS_TLS13(s)
-                && (sigptr->rsigalg == TLSEXT_SIGALG_rsa_pkcs1_sha1
-                    || sigptr->rsigalg == TLSEXT_SIGALG_rsa_pkcs1_sha256
-                    || sigptr->rsigalg == TLSEXT_SIGALG_rsa_pkcs1_sha384
-                    || sigptr->rsigalg == TLSEXT_SIGALG_rsa_pkcs1_sha512))
+        if (SSL_IS_TLS13(s) && sigptr->sign_nid == EVP_PKEY_RSA)
             continue;
         idx = tls12_get_pkey_idx(sigptr->sign_nid);
         if (idx > 0 && pmd[idx] == NULL) {
@@ -1716,6 +1709,8 @@ static void get_sigorhash(int *psig, int *phash, const char *str)
 {
     if (strcmp(str, "RSA") == 0) {
         *psig = EVP_PKEY_RSA;
+    } else if (strcmp(str, "RSA-PSS") == 0 || strcmp(str, "PSS") == 0) {
+        *psig = EVP_PKEY_RSA_PSS;
     } else if (strcmp(str, "DSA") == 0) {
         *psig = EVP_PKEY_DSA;
     } else if (strcmp(str, "ECDSA") == 0) {
@@ -1779,7 +1774,6 @@ int tls1_set_sigalgs_list(CERT *c, const char *str, int client)
     return tls1_set_sigalgs(c, sig.sigalgs, sig.sigalgcnt, client);
 }
 
-/* TODO(TLS1.3): Needs updating to allow setting of TLS1.3 sig algs */
 int tls1_set_sigalgs(CERT *c, const int *psig_nids, size_t salglen, int client)
 {
     uint16_t *sigalgs, *sptr;
@@ -1790,10 +1784,6 @@ int tls1_set_sigalgs(CERT *c, const int *psig_nids, size_t salglen, int client)
     sigalgs = OPENSSL_malloc((salglen / 2) * sizeof(*sigalgs));
     if (sigalgs == NULL)
         return 0;
-    /*
-     * TODO(TLS1.3): Somehow we need to be able to set RSA-PSS as well as
-     * RSA-PKCS1. For now we only allow setting of RSA-PKCS1
-     */
     for (i = 0, sptr = sigalgs; i < salglen; i += 2) {
         size_t j;
         const SIGALG_LOOKUP *curr;
@@ -1802,9 +1792,6 @@ int tls1_set_sigalgs(CERT *c, const int *psig_nids, size_t salglen, int client)
 
         for (j = 0, curr = sigalg_lookup_tbl; j < OSSL_NELEM(sigalg_lookup_tbl);
              j++, curr++) {
-            /* Skip setting PSS so we get PKCS1 by default */
-            if (SIGID_IS_PSS(curr->sigalg))
-                continue;
             if (curr->hash == md_id && curr->sig == sig_id) {
                 *sptr++ = curr->sigalg;
                 break;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -710,35 +710,58 @@ static const uint16_t suiteb_sigalgs[] = {
 #endif
 
 typedef struct sigalg_lookup_st {
+    const char *name;
     uint16_t sigalg;
     int hash;
     int sig;
+    int sigandhash;
+    int curve;
 } SIGALG_LOOKUP;
 
 static const SIGALG_LOOKUP sigalg_lookup_tbl[] = {
 #ifndef OPENSSL_NO_EC
-    {TLSEXT_SIGALG_ecdsa_secp256r1_sha256, NID_sha256, EVP_PKEY_EC},
-    {TLSEXT_SIGALG_ecdsa_secp384r1_sha384, NID_sha384, EVP_PKEY_EC},
-    {TLSEXT_SIGALG_ecdsa_secp521r1_sha512, NID_sha512, EVP_PKEY_EC},
-    {TLSEXT_SIGALG_ecdsa_sha1, NID_sha1, EVP_PKEY_EC},
+    {"ecdsa_secp256r1_sha256", TLSEXT_SIGALG_ecdsa_secp256r1_sha256,
+     NID_sha256, EVP_PKEY_EC, NID_ecdsa_with_SHA256, NID_X9_62_prime256v1},
+    {"ecdsa_secp384r1_sha384", TLSEXT_SIGALG_ecdsa_secp384r1_sha384,
+     NID_sha384, EVP_PKEY_EC, NID_ecdsa_with_SHA384, NID_secp384r1},
+    {"ecdsa_secp521r1_sha512", TLSEXT_SIGALG_ecdsa_secp521r1_sha512,
+     NID_sha512, EVP_PKEY_EC, NID_ecdsa_with_SHA512, NID_secp521r1},
+    {NULL, TLSEXT_SIGALG_ecdsa_sha1,
+     NID_sha1, EVP_PKEY_EC, NID_ecdsa_with_SHA1, NID_undef},
 #endif
-    {TLSEXT_SIGALG_rsa_pss_sha256, NID_sha256, EVP_PKEY_RSA_PSS},
-    {TLSEXT_SIGALG_rsa_pss_sha384, NID_sha384, EVP_PKEY_RSA_PSS},
-    {TLSEXT_SIGALG_rsa_pss_sha512, NID_sha512, EVP_PKEY_RSA_PSS},
-    {TLSEXT_SIGALG_rsa_pkcs1_sha256, NID_sha256, EVP_PKEY_RSA},
-    {TLSEXT_SIGALG_rsa_pkcs1_sha384, NID_sha384, EVP_PKEY_RSA},
-    {TLSEXT_SIGALG_rsa_pkcs1_sha512, NID_sha512, EVP_PKEY_RSA},
-    {TLSEXT_SIGALG_rsa_pkcs1_sha1, NID_sha1, EVP_PKEY_RSA},
+    {"rsa_pss_sha256", TLSEXT_SIGALG_rsa_pss_sha256,
+     NID_sha256, EVP_PKEY_RSA_PSS, NID_undef, NID_undef},
+    {"rsa_pss_sha384", TLSEXT_SIGALG_rsa_pss_sha384,
+     NID_sha384, EVP_PKEY_RSA_PSS, NID_undef, NID_undef},
+    {"rsa_pss_sha512", TLSEXT_SIGALG_rsa_pss_sha512,
+     NID_sha512, EVP_PKEY_RSA_PSS, NID_undef, NID_undef},
+    {"rsa_pkcs1_sha256", TLSEXT_SIGALG_rsa_pkcs1_sha256,
+     NID_sha256, EVP_PKEY_RSA, NID_sha256WithRSAEncryption, NID_undef},
+    {"rsa_pkcs1_sha384", TLSEXT_SIGALG_rsa_pkcs1_sha384,
+     NID_sha384, EVP_PKEY_RSA, NID_sha384WithRSAEncryption, NID_undef},
+    {"rsa_pkcs1_sha512", TLSEXT_SIGALG_rsa_pkcs1_sha512,
+     NID_sha512, EVP_PKEY_RSA, NID_sha512WithRSAEncryption, NID_undef},
+    {"rsa_pkcs1_sha1", TLSEXT_SIGALG_rsa_pkcs1_sha1,
+     NID_sha1, EVP_PKEY_RSA, NID_sha1WithRSAEncryption, NID_undef},
 #ifndef OPENSSL_NO_DSA
-    {TLSEXT_SIGALG_dsa_sha256, NID_sha256, EVP_PKEY_DSA},
-    {TLSEXT_SIGALG_dsa_sha384, NID_sha384, EVP_PKEY_DSA},
-    {TLSEXT_SIGALG_dsa_sha512, NID_sha512, EVP_PKEY_DSA},
-    {TLSEXT_SIGALG_dsa_sha1, NID_sha1, EVP_PKEY_DSA},
+    {NULL, TLSEXT_SIGALG_dsa_sha256,
+     NID_sha256, EVP_PKEY_DSA, NID_dsa_with_SHA256, NID_undef},
+    {NULL, TLSEXT_SIGALG_dsa_sha384,
+     NID_sha384, EVP_PKEY_DSA, NID_undef, NID_undef},
+    {NULL, TLSEXT_SIGALG_dsa_sha512,
+     NID_sha512, EVP_PKEY_DSA, NID_undef, NID_undef},
+    {NULL, TLSEXT_SIGALG_dsa_sha1,
+     NID_sha1, EVP_PKEY_DSA, NID_dsaWithSHA1, NID_undef},
 #endif
 #ifndef OPENSSL_NO_GOST
-    {TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256, NID_id_GostR3411_2012_256, NID_id_GostR3410_2012_256},
-    {TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512, NID_id_GostR3411_2012_512, NID_id_GostR3410_2012_512},
-    {TLSEXT_SIGALG_gostr34102001_gostr3411, NID_id_GostR3411_94, NID_id_GostR3410_2001}
+    {NULL, TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256,
+     NID_id_GostR3411_2012_256, NID_id_GostR3410_2012_256, NID_undef,
+     NID_undef},
+    {NULL, TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512,
+     NID_id_GostR3411_2012_512, NID_id_GostR3410_2012_512, NID_undef,
+     NID_undef},
+    {NULL, TLSEXT_SIGALG_gostr34102001_gostr3411,
+     NID_id_GostR3411_94, NID_id_GostR3410_2001, NID_undef, NID_undef}
 #endif
 };
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1725,11 +1725,12 @@ int SSL_get_shared_sigalgs(SSL *s, int idx,
     return (int)s->cert->shared_sigalgslen;
 }
 
-#define MAX_SIGALGLEN   (TLSEXT_hash_num * TLSEXT_signature_num * 2)
+/* Maximum possible number of unique entries in sigalgs array */
+#define TLS_MAX_SIGALGCNT (OSSL_NELEM(sigalg_lookup_tbl) * 2)
 
 typedef struct {
     size_t sigalgcnt;
-    int sigalgs[MAX_SIGALGLEN];
+    int sigalgs[TLS_MAX_SIGALGCNT];
 } sig_cb_st;
 
 static void get_sigorhash(int *psig, int *phash, const char *str)
@@ -1748,16 +1749,18 @@ static void get_sigorhash(int *psig, int *phash, const char *str)
             *phash = OBJ_ln2nid(str);
     }
 }
+/* Maximum length of a signature algorithm string component */
+#define TLS_MAX_SIGSTRING_LEN   40
 
 static int sig_cb(const char *elem, int len, void *arg)
 {
     sig_cb_st *sarg = arg;
     size_t i;
-    char etmp[40], *p;
+    char etmp[TLS_MAX_SIGSTRING_LEN], *p;
     int sig_alg = NID_undef, hash_alg = NID_undef;
     if (elem == NULL)
         return 0;
-    if (sarg->sigalgcnt == MAX_SIGALGLEN)
+    if (sarg->sigalgcnt == TLS_MAX_SIGALGCNT)
         return 0;
     if (len > (int)(sizeof(etmp) - 1))
         return 0;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -813,22 +813,22 @@ size_t tls12_get_psigalgs(SSL *s, int sent, const uint16_t **psigs)
  * algorithms and if so set relevant digest and signature scheme in
  * s.
  */
-int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
-                            EVP_PKEY *pkey)
+int tls12_check_peer_sigalg(SSL *s, unsigned int sig, EVP_PKEY *pkey)
 {
     const uint16_t *sent_sigs;
+    const EVP_MD *md = NULL;
     char sigalgstr[2];
     size_t sent_sigslen, i;
     int pkeyid = EVP_PKEY_id(pkey);
-    int peer_pkeyid;
+    int peer_sigtype;
     /* Should never happen */
     if (pkeyid == -1)
         return -1;
     /* Check key type is consistent with signature */
-    peer_pkeyid = tls_sigalg_get_sig(sig);
+    peer_sigtype = tls_sigalg_get_sig(sig);
     /* RSA keys can be used for RSA-PSS */
-    if (pkeyid != peer_pkeyid
-        && (peer_pkeyid != EVP_PKEY_RSA_PSS || pkeyid != EVP_PKEY_RSA)) {
+    if (pkeyid != peer_sigtype
+        && (peer_sigtype != EVP_PKEY_RSA_PSS || pkeyid != EVP_PKEY_RSA)) {
         SSLerr(SSL_F_TLS12_CHECK_PEER_SIGALG, SSL_R_WRONG_SIGNATURE_TYPE);
         return 0;
     }
@@ -878,8 +878,8 @@ int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
         SSLerr(SSL_F_TLS12_CHECK_PEER_SIGALG, SSL_R_WRONG_SIGNATURE_TYPE);
         return 0;
     }
-    *pmd = tls12_get_hash(tls_sigalg_get_hash(sig));
-    if (*pmd == NULL) {
+    md = tls12_get_hash(tls_sigalg_get_hash(sig));
+    if (md == NULL) {
         SSLerr(SSL_F_TLS12_CHECK_PEER_SIGALG, SSL_R_UNKNOWN_DIGEST);
         return 0;
     }
@@ -890,7 +890,7 @@ int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
     sigalgstr[0] = (sig >> 8) & 0xff;
     sigalgstr[1] = sig & 0xff;
     if (!ssl_security(s, SSL_SECOP_SIGALG_CHECK,
-                      EVP_MD_size(*pmd) * 4, EVP_MD_type(*pmd),
+                      EVP_MD_size(md) * 4, EVP_MD_type(md),
                       (void *)sigalgstr)) {
         SSLerr(SSL_F_TLS12_CHECK_PEER_SIGALG, SSL_R_WRONG_SIGNATURE_TYPE);
         return 0;
@@ -898,7 +898,8 @@ int tls12_check_peer_sigalg(const EVP_MD **pmd, SSL *s, unsigned int sig,
     /*
      * Store the digest used so applications can retrieve it if they wish.
      */
-    s->s3->tmp.peer_md = *pmd;
+    s->s3->tmp.peer_md = md;
+    s->s3->tmp.peer_sigtype = peer_sigtype;
     return 1;
 }
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1288,6 +1288,7 @@ int tls12_get_sigandhash(SSL *s, WPACKET *pkt, const EVP_PKEY *pk,
 {
     int md_id, sig_id;
     size_t i;
+    const SIGALG_LOOKUP *curr;
 
     if (md == NULL)
         return 0;
@@ -1299,8 +1300,25 @@ int tls12_get_sigandhash(SSL *s, WPACKET *pkt, const EVP_PKEY *pk,
     if (SSL_IS_TLS13(s) && sig_id == EVP_PKEY_RSA)
         sig_id = EVP_PKEY_RSA_PSS;
 
+    if (s->s3->tmp.peer_sigalgs == NULL) {
+        /* Should never happen: we abort if no sigalgs extension and TLS 1.3 */
+        if (SSL_IS_TLS13(s))
+            return 0;
+        /* For TLS 1.2 and no sigalgs lookup using complete table */
+        for (i = 0, curr = sigalg_lookup_tbl; i < OSSL_NELEM(sigalg_lookup_tbl);
+             i++, curr++) {
+            if (curr->hash == md_id && curr->sig == sig_id) {
+                if (!WPACKET_put_bytes_u16(pkt, curr->sigalg))
+                    return 0;
+                *ispss = curr->sig == EVP_PKEY_RSA_PSS;
+                return 1;
+            }
+        }
+        return 0;
+    }
+
     for (i = 0; i < s->cert->shared_sigalgslen; i++) {
-        const SIGALG_LOOKUP *curr = s->cert->shared_sigalgs[i];
+        curr = s->cert->shared_sigalgs[i];
 
         /*
          * Look for matching key and hash. If key type is RSA also match PSS

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -903,6 +903,14 @@ int tls12_check_peer_sigalg(SSL *s, unsigned int sig, EVP_PKEY *pkey)
     return 1;
 }
 
+int SSL_get_peer_signature_type_nid(const SSL *s, int *pnid)
+{
+    if (s->s3->tmp.peer_sigtype == NID_undef)
+        return 0;
+    *pnid = s->s3->tmp.peer_sigtype;
+    return 1;
+}
+
 /*
  * Set a mask of disabled algorithms: an algorithm is disabled if it isn't
  * supported, doesn't appear in supported signature algorithms, isn't supported

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -92,8 +92,11 @@ handshake.
 * ExpectedServerCertType, ExpectedClientCertType - the expected algorithm or
   curve of server or client certificate
 
-* ExpectedServerSignatureHash, ExpectedClientSignatureHash - the expected
+* ExpectedServerSignHash, ExpectedClientSignHash - the expected
   signing hash used by server or client certificate
+
+* ExpectedServerSignType, ExpectedClientSignType - the expected
+  signature type used by server or client when signing messages
 
 ## Configuring the client and server
 

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1073,6 +1073,9 @@ static HANDSHAKE_RESULT *do_handshake_internal(
     SSL_get_peer_signature_nid(client.ssl, &ret->server_sign_hash);
     SSL_get_peer_signature_nid(server.ssl, &ret->client_sign_hash);
 
+    SSL_get_peer_signature_type_nid(client.ssl, &ret->server_sign_type);
+    SSL_get_peer_signature_type_nid(server.ssl, &ret->client_sign_type);
+
     ret->server_cert_type = peer_pkey_type(client.ssl);
     ret->client_cert_type = peer_pkey_type(server.ssl);
 

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -49,10 +49,14 @@ typedef struct handshake_result {
     int server_cert_type;
     /* server signing hash */
     int server_sign_hash;
+    /* server signature type */
+    int server_sign_type;
     /* client certificate key type */
     int client_cert_type;
     /* client signing hash */
     int client_sign_hash;
+    /* client signature type */
+    int client_sign_type;
 } HANDSHAKE_RESULT;
 
 HANDSHAKE_RESULT *HANDSHAKE_RESULT_new(void);

--- a/test/ssl-tests/01-simple.conf
+++ b/test/ssl-tests/01-simple.conf
@@ -40,12 +40,12 @@ client = 1-Server signature algorithms bug-client
 [1-Server signature algorithms bug-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = ECDSA+SHA256
+ClientSignatureAlgorithms = PSS+SHA512:RSA+SHA512
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-Server signature algorithms bug-client]
 CipherString = DEFAULT
-SignatureAlgorithms = RSA+SHA256
+SignatureAlgorithms = PSS+SHA256:RSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/01-simple.conf.in
+++ b/test/ssl-tests/01-simple.conf.in
@@ -22,8 +22,8 @@ our @tests = (
     {
         name => "Server signature algorithms bug",
         # Should have no effect as we aren't doing client auth
-        server => { "ClientSignatureAlgorithms" => "ECDSA+SHA256" },
-        client => { "SignatureAlgorithms" => "RSA+SHA256" },
+        server => { "ClientSignatureAlgorithms" => "PSS+SHA512:RSA+SHA512" },
+        client => { "SignatureAlgorithms" => "PSS+SHA256:RSA+SHA256" },
         test   => { "ExpectedResult" => "Success" },
     },
 

--- a/test/ssl-tests/04-client_auth.conf
+++ b/test/ssl-tests/04-client_auth.conf
@@ -562,6 +562,7 @@ VerifyMode = Peer
 [test-18]
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
+ExpectedClientSignType = RSA
 ExpectedResult = Success
 
 

--- a/test/ssl-tests/04-client_auth.conf.in
+++ b/test/ssl-tests/04-client_auth.conf.in
@@ -34,10 +34,12 @@ sub generate_tests() {
                 $caalert = "UnknownCA";
             }
             my $clihash;
+            my $clisigtype;
             my $clisigalgs;
-            # TODO add TLSv1.3 versions
+            # TODO(TLS1.3) add TLSv1.3 versions
             if ($protocol_name eq "TLSv1.2") {
                 $clihash = "SHA256";
+                $clisigtype = "RSA";
                 $clisigalgs = "SHA256+RSA";
             }
             # Sanity-check simple handshake.
@@ -106,6 +108,7 @@ sub generate_tests() {
                 },
                 test   => { "ExpectedResult" => "Success",
                             "ExpectedClientCertType" => "RSA",
+                            "ExpectedClientSignType" => $clisigtype,
                             "ExpectedClientSignHash" => $clihash,
                 },
             };

--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 6
+num_tests = 7
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-RSA CipherString Selection
@@ -8,6 +8,7 @@ test-2 = 2-ECDSA CipherString Selection, no ECDSA certificate
 test-3 = 3-ECDSA Signature Algorithm Selection
 test-4 = 4-ECDSA Signature Algorithm Selection, no ECDSA certificate
 test-5 = 5-RSA Signature Algorithm Selection
+test-6 = 6-RSA-PSS Signature Algorithm Selection
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -33,6 +34,7 @@ VerifyMode = Peer
 [test-0]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
+ExpectedServerSignType = EC
 
 
 # ===========================================================
@@ -60,6 +62,7 @@ VerifyMode = Peer
 [test-1]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
@@ -112,6 +115,7 @@ VerifyMode = Peer
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
 
 
 # ===========================================================
@@ -165,5 +169,36 @@ VerifyMode = Peer
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA
+
+
+# ===========================================================
+
+[6-RSA-PSS Signature Algorithm Selection]
+ssl_conf = 6-RSA-PSS Signature Algorithm Selection-ssl
+
+[6-RSA-PSS Signature Algorithm Selection-ssl]
+server = 6-RSA-PSS Signature Algorithm Selection-server
+client = 6-RSA-PSS Signature Algorithm Selection-client
+
+[6-RSA-PSS Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-RSA-PSS Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = RSA-PSS+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+ExpectedResult = Success
+ExpectedServerCertType = RSA
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
 
 

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -15,7 +15,7 @@ my $dir_sep = $^O ne "VMS" ? "/" : "";
 my $server = {
     "ECDSA.Certificate" => "\${ENV::TEST_CERTS_DIR}${dir_sep}server-ecdsa-cert.pem",
     "ECDSA.PrivateKey" => "\${ENV::TEST_CERTS_DIR}${dir_sep}server-ecdsa-key.pem",
-    # TODO: add test cases for TLSv1.3
+    # TODO(TLS1.3): add test cases for TLSv1.3
     "MaxProtocol" => "TLSv1.2"
 };
 
@@ -28,6 +28,7 @@ our @tests = (
         },
         test   => {
             "ExpectedServerCertType" =>, "P-256",
+            "ExpectedServerSignType" =>, "EC",
             "ExpectedResult" => "Success"
         },
     },
@@ -39,6 +40,7 @@ our @tests = (
         },
         test   => {
             "ExpectedServerCertType" =>, "RSA",
+            "ExpectedServerSignType" =>, "RSA-PSS",
             "ExpectedResult" => "Success"
         },
     },
@@ -61,6 +63,7 @@ our @tests = (
         test   => {
             "ExpectedServerCertType" => "P-256",
             "ExpectedServerSignHash" => "SHA256",
+            "ExpectedServerSignType" => "EC",
             "ExpectedResult" => "Success"
         },
     },
@@ -83,6 +86,20 @@ our @tests = (
         test   => {
             "ExpectedServerCertType" => "RSA",
             "ExpectedServerSignHash" => "SHA256",
+            "ExpectedServerSignType" => "RSA",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "RSA-PSS Signature Algorithm Selection",
+        server => $server,
+        client => {
+            "SignatureAlgorithms" => "RSA-PSS+SHA256",
+        },
+        test   => {
+            "ExpectedServerCertType" => "RSA",
+            "ExpectedServerSignHash" => "SHA256",
+            "ExpectedServerSignType" => "RSA-PSS",
             "ExpectedResult" => "Success"
         },
     }

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -217,6 +217,13 @@ static int check_server_sign_hash(HANDSHAKE_RESULT *result,
                      result->server_sign_hash);
 }
 
+static int check_server_sign_type(HANDSHAKE_RESULT *result,
+                                  SSL_TEST_CTX *test_ctx)
+{
+    return check_nid("Server signing", test_ctx->expected_server_sign_type,
+                     result->server_sign_type);
+}
+
 static int check_client_cert_type(HANDSHAKE_RESULT *result,
                                   SSL_TEST_CTX *test_ctx)
 {
@@ -229,6 +236,13 @@ static int check_client_sign_hash(HANDSHAKE_RESULT *result,
 {
     return check_nid("Client signing hash", test_ctx->expected_client_sign_hash,
                      result->client_sign_hash);
+}
+
+static int check_client_sign_type(HANDSHAKE_RESULT *result,
+                                  SSL_TEST_CTX *test_ctx)
+{
+    return check_nid("Client signing", test_ctx->expected_client_sign_type,
+                     result->client_sign_type);
 }
 
 /*
@@ -254,8 +268,10 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
         ret &= check_tmp_key(result, test_ctx);
         ret &= check_server_cert_type(result, test_ctx);
         ret &= check_server_sign_hash(result, test_ctx);
+        ret &= check_server_sign_type(result, test_ctx);
         ret &= check_client_cert_type(result, test_ctx);
         ret &= check_client_sign_hash(result, test_ctx);
+        ret &= check_client_sign_type(result, test_ctx);
     }
     return ret;
 }

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -432,9 +432,9 @@ IMPLEMENT_SSL_TEST_INT_OPTION(SSL_TEST_CTX, test, app_data_size)
 
 IMPLEMENT_SSL_TEST_INT_OPTION(SSL_TEST_CTX, test, max_fragment_size)
 
-/***********************/
-/* Expected key types  */
-/***********************/
+/*************************************/
+/* Expected key and signature types  */
+/*************************************/
 
 __owur static int parse_expected_key_type(int *ptype, const char *value)
 {
@@ -473,10 +473,24 @@ __owur static int parse_expected_server_cert_type(SSL_TEST_CTX *test_ctx,
                                    value);
 }
 
+__owur static int parse_expected_server_sign_type(SSL_TEST_CTX *test_ctx,
+                                                 const char *value)
+{
+    return parse_expected_key_type(&test_ctx->expected_server_sign_type,
+                                   value);
+}
+
 __owur static int parse_expected_client_cert_type(SSL_TEST_CTX *test_ctx,
                                                   const char *value)
 {
     return parse_expected_key_type(&test_ctx->expected_client_cert_type,
+                                   value);
+}
+
+__owur static int parse_expected_client_sign_type(SSL_TEST_CTX *test_ctx,
+                                                 const char *value)
+{
+    return parse_expected_key_type(&test_ctx->expected_client_sign_type,
                                    value);
 }
 
@@ -540,8 +554,10 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedTmpKeyType", &parse_expected_tmp_key_type },
     { "ExpectedServerCertType", &parse_expected_server_cert_type },
     { "ExpectedServerSignHash", &parse_expected_server_sign_hash },
+    { "ExpectedServerSignType", &parse_expected_server_sign_type },
     { "ExpectedClientCertType", &parse_expected_client_cert_type },
     { "ExpectedClientSignHash", &parse_expected_client_sign_hash },
+    { "ExpectedClientSignType", &parse_expected_client_sign_type },
 };
 
 /* Nested client options. */

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -165,10 +165,14 @@ typedef struct {
     int expected_server_cert_type;
     /* Expected server signing hash */
     int expected_server_sign_hash;
+    /* Expected server signature type */
+    int expected_server_sign_type;
     /* Expected client certificate key type */
     int expected_client_cert_type;
     /* Expected client signing hash */
     int expected_client_sign_hash;
+    /* Expected client signature type */
+    int expected_client_sign_type;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -412,3 +412,4 @@ SSL_COMP_get_id                         412	1_1_0d	EXIST::FUNCTION:
 SSL_COMP_get0_name                      413	1_1_0d	EXIST::FUNCTION:
 SSL_CTX_set_keylog_callback             414	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get_keylog_callback             415	1_1_1	EXIST::FUNCTION:
+SSL_get_peer_signature_type_nid         416	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This PR revises the signature algorithms (signature scheme) extension handling. 

The new EVP_PKEY_RSA_PSS constant is used to mark which signature algorithms use RSA-PSS. The "RSA-PSS" string can be used to include PSS schemes as well as the new TLS 1.3 names.

The schemes are 16bit values so the code has been updated to use uint16_t, though I maye have missed the odd reference.

For shared signature algorithms the old TLS_SIGALGS structure has been replaced by SIGALG_LOOKUP as all shared signatures will now have an entry in the table.

SIGALG_LOOKUP has been extended to include TLS 1.3 scheme names, signature NIDs and the required curve: the latter is not currently used but will be referenced when the certificate selection code is added (this is the next step).

WIP because the documentation needs updating and tests could be added e.g. to check the signature type is correct for RSA or RSA-PSS.