### PR TITLE
Don't use the ! command

### DIFF
--- a/util/domd
+++ b/util/domd
@@ -34,11 +34,11 @@ else
     ${PERL} $TOP/util/clean-depend.pl < Makefile > Makefile.new
     RC=$?
 fi
-if ! cmp -s Makefile.save Makefile.new; then
-    mv Makefile.new Makefile
-else
+if cmp -s Makefile.save Makefile.new; then
     mv Makefile.save Makefile
     rm -f Makefile.new
+else
+    mv Makefile.new Makefile
 fi
 # unfake the presence of Kerberos
 rm $TOP/krb5.h


### PR DESCRIPTION
The ! command doesn't exist on all Unix family operating systems, so
don't use it.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] CLA is signed

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Fixes #2302