### PR TITLE
X509_CRL_digest() - ensure precomputed sha1 hash before returning it

### DIFF
--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -377,7 +377,7 @@ int X509_digest(const X509 *data, const EVP_MD *type, unsigned char *md,
 int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
                     unsigned char *md, unsigned int *len)
 {
-    if (type == EVP_sha1()) {
+    if (type == EVP_sha1() && (data->flags & EXFLAG_SET) != 0) {
         /* Asking for SHA1; always computed in CRL d2i. */
         if (len != NULL)
             *len = sizeof(data->sha1_hash);

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -226,6 +226,8 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
             if (crl->meth->crl_init(crl) == 0)
                 return 0;
         }
+
+        crl->flags |= EXFLAG_SET;
         break;
 
     case ASN1_OP_FREE_POST:

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -355,6 +355,7 @@ struct ISSUING_DIST_POINT_st {
 # define EXFLAG_SI               0x20
 # define EXFLAG_V1               0x40
 # define EXFLAG_INVALID          0x80
+/* EXFLAG_SET is set to indicate that some values have been precomputed */
 # define EXFLAG_SET              0x100
 # define EXFLAG_CRITICAL         0x200
 # define EXFLAG_PROXY            0x400

--- a/test/recipes/25-test_crl.t
+++ b/test/recipes/25-test_crl.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_crl");
 
-plan tests => 3;
+plan tests => 5;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -24,3 +24,20 @@ subtest 'crl conversions' => sub {
 };
 
 ok(run(test(['crltest'])));
+
+ok(compare1stline([qw{openssl crl -noout -fingerprint -in},
+                   srctop_file('test', 'testcrl.pem')],
+                  'SHA1 Fingerprint=BA:F4:1B:AD:7A:9B:2F:09:16:BC:60:A7:0E:CE:79:2E:36:00:E7:B2'));
+ok(compare1stline([qw{openssl crl -noout -fingerprint -sha256 -in},
+                   srctop_file('test', 'testcrl.pem')],
+                  'SHA256 Fingerprint=B3:A9:FD:A7:2E:8C:3D:DF:D0:F1:C3:1A:96:60:B5:FD:B0:99:7C:7F:0E:E4:34:F5:DB:87:62:36:BC:F1:BC:1B'));
+
+sub compare1stline {
+    my ($cmdarray, $str) = @_;
+    my @lines = run(app($cmdarray), capture => 1);
+
+    return 1 if $lines[0] =~ m|^\Q${str}\E\R$|;
+    note "Got      ", $lines[0];
+    note "Expected ", $str;
+    return 0;
+}


### PR DESCRIPTION
X509_CRL_digest() didn't check if the precomputed sha1 hash was actually
present.  This also makes sure there's an appropriate flag to check.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

Fixes #2313