### PR TITLE
Fix test that fails with no-ec

### DIFF
--- a/test/ssl-tests/01-simple.conf
+++ b/test/ssl-tests/01-simple.conf
@@ -40,7 +40,7 @@ client = 1-Server signature algorithms bug-client
 [1-Server signature algorithms bug-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = ECDSA+SHA256
+ClientSignatureAlgorithms = RSA+SHA1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-Server signature algorithms bug-client]

--- a/test/ssl-tests/01-simple.conf.in
+++ b/test/ssl-tests/01-simple.conf.in
@@ -22,7 +22,7 @@ our @tests = (
     {
         name => "Server signature algorithms bug",
         # Should have no effect as we aren't doing client auth
-        server => { "ClientSignatureAlgorithms" => "ECDSA+SHA256" },
+        server => { "ClientSignatureAlgorithms" => "RSA+SHA1" },
         client => { "SignatureAlgorithms" => "RSA+SHA256" },
         test   => { "ExpectedResult" => "Success" },
     },


### PR DESCRIPTION
In 01-simple.conf, test 1, all we need is to test this properly is a
server's client signature algo that differs from the client's
signature algorithm.  Unfortunately, ECDSA may be undefined, so we
play it safe by using RSA everywhere (since it can't be disabled) and
use two different SHA digests (they can't be disabled either).

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
