### PR TITLE
Unix: take control of CFLAGS and LDFLAGS / SHARED_LDFLAGS combinations

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -55,6 +55,14 @@
         inherit_from    => [ "BASE_common" ],
         template        => 1,
 
+        # These two flags are hacks that tells if $(CFLAGS) and $(LDFLAGS)
+        # should be combined or if $(CFLAGS) and $(SHARED_LDFLAGS) should be
+        # combined when linking programs or shared objects.
+        # These work as defaults, and there may be similar variables prefixed
+        # with lib_, dso_ or bin_ to specify exactly when each rule applies.
+        combine_cflags_lflags => 1,
+        combine_cflags_shared_ldflags => 1,
+
         ex_libs         =>
             sub {
                 unless ($disabled{zlib}) {

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1176,13 +1176,21 @@ sub vms_info {
     },
 
 #### IBM's AIX.
+    "aix-common" => {
+        inherit_from     => [ "BASE_unix" ],
+        # When building shared libraries on AIX, a middle step where the
+        # contents of the .a archive is linked together on one object file
+        # that is then used to build the shared library.  In this middle
+        # step, $(CFLAGS) must NOT be used.
+        lib_combine_cflags_lflags => 0,
+    },
     # Below targets assume AIX >=5. Caveat lector. If you are accustomed
     # to control compilation "bitness" by setting $OBJECT_MODE environment
     # variable, then you should know that in OpenSSL case it's considered
     # only in ./config. Once configured, build procedure remains "deaf" to
     # current value of $OBJECT_MODE.
     "aix-gcc" => {
-        inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
+        inherit_from     => [ "aix-common", asm("ppc32_asm") ],
         cc               => "gcc",
         cflags           => combine(picker(default => "-DB_ENDIAN",
                                            debug   => "-O0 -g",
@@ -1199,7 +1207,7 @@ sub vms_info {
         arflags          => "-X32",
     },
     "aix64-gcc" => {
-        inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
+        inherit_from     => [ "aix-common", asm("ppc64_asm") ],
         cc               => "gcc",
         cflags           => combine(picker(default => "-maix64 -DB_ENDIAN",
                                            debug   => "-O0 -g",
@@ -1216,7 +1224,7 @@ sub vms_info {
         arflags          => "-X64",
     },
     "aix-cc" => {
-        inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
+        inherit_from     => [ "aix-common", asm("ppc32_asm") ],
         cc               => "cc",
         cflags           => combine(picker(default => "-q32 -DB_ENDIAN -qmaxmem=16384 -qro -qroconst",
                                            debug   => "-O0 -g",
@@ -1234,7 +1242,7 @@ sub vms_info {
         arflags          => "-X 32",
     },
     "aix64-cc" => {
-        inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
+        inherit_from     => [ "aix-common", asm("ppc64_asm") ],
         cc               => "cc",
         cflags           => combine(picker(default => "-q64 -DB_ENDIAN -qmaxmem=16384 -qro -qroconst",
                                            debug   => "-O0 -g",

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1003,6 +1003,13 @@ EOF
       my $shlib_target = $target{shared_target};
       my $ordinalsfile = defined($args{ordinals}) ? $args{ordinals}->[1] : "";
       my $target = shlib_simple($lib);
+      my $ldflags =
+          $target{lib_combine_cflags_lflags} // $target{combine_cflags_lflags}
+          ? '$(CFLAGS) $(LDFLAGS)' : '$(LDFLAGS)';
+      my $shared_ldflags =
+          $target{lib_combine_cflags_shared_ldflags}
+          // $target{combine_cflags_shared_ldflags}
+          ? '$(CFLAGS) $(LIB_LDFLAGS)' : '$(LIB_LDFLAGS)';
       return <<"EOF"
 # With a build on a Windows POSIX layer (Cygwin or Mingw), we know for a fact
 # that two files get produced, {shlibname}.dll and {libname}.dll.a.
@@ -1020,8 +1027,8 @@ $target: $lib$libext $deps $ordinalsfile
 		LIBNAME=$libname LIBVERSION=\$(SHLIB_MAJOR).\$(SHLIB_MINOR) \\
 		LIBCOMPATVERSIONS=';\$(SHLIB_VERSION_HISTORY)' \\
 		CC='\$(CC)' CFLAGS='\$(CFLAGS) \$(LIB_CFLAGS)' \\
-		LDFLAGS='\$(LDFLAGS)' \\
-		SHARED_LDFLAGS='\$(LIB_LDFLAGS)' SHLIB_EXT=$shlibext \\
+		LDFLAGS='$ldflags' \\
+		SHARED_LDFLAGS='$shared_ldflags' SHLIB_EXT=$shlibext \\
 		RC='\$(RC)' SHARED_RCFLAGS='\$(RCFLAGS)' \\
 		link_shlib.$shlib_target
 EOF
@@ -1046,15 +1053,22 @@ EOF
       my $shlib_target = $target{shared_target};
       my $objs = join(" ", map { $_.$objext } @{$args{objs}});
       my $target = dso($lib);
+      my $ldflags =
+          $target{dso_combine_cflags_lflags} // $target{combine_cflags_lflags}
+          ? '$(CFLAGS) $(LDFLAGS)' : '$(LDFLAGS)';
+      my $shared_ldflags =
+          $target{dso_combine_cflags_shared_ldflags}
+          // $target{combine_cflags_shared_ldflags}
+          ? '$(CFLAGS) $(DSO_LDFLAGS)' : '$(DSO_LDFLAGS)';
       return <<"EOF";
 $target: $objs $deps
 	\$(MAKE) -f \$(SRCDIR)/Makefile.shared -e \\
 		PLATFORM=\$(PLATFORM) \\
 		PERL="\$(PERL)" SRCDIR='\$(SRCDIR)' DSTDIR="$libd" \\
 		LIBDEPS='\$(PLIB_LDFLAGS) '"$shlibdeps"' \$(EX_LIBS)' \\
-		LIBNAME=$libname LDFLAGS='\$(LDFLAGS)' \\
+		LIBNAME=$libname LDFLAGS='$ldflags' \\
 		CC='\$(CC)' CFLAGS='\$(CFLAGS) \$(DSO_CFLAGS)' \\
-		SHARED_LDFLAGS='\$(DSO_LDFLAGS)' \\
+		SHARED_LDFLAGS='$shared_ldflags' \\
 		SHLIB_EXT=$dsoext \\
 		LIBEXTRAS="$objs" \\
 		link_dso.$shlib_target
@@ -1094,6 +1108,9 @@ EOF
           $cc = '$(CXX)';
           $cflags = '$(CXXFLAGS) $(BIN_CXXFLAGS)';
       }
+      my $ldflags =
+          $target{bin_combine_cflags_lflags} // $target{combine_cflags_lflags}
+          ? '$(CFLAGS) $(LDFLAGS)' : '$(LDFLAGS)';
       return <<"EOF";
 $bin$exeext: $objs $deps
 	\$(RM) $bin$exeext
@@ -1102,7 +1119,7 @@ $bin$exeext: $objs $deps
 		APPNAME=$bin$exeext OBJECTS="$objs" \\
 		LIBDEPS='\$(PLIB_LDFLAGS) '"$linklibs"' \$(EX_LIBS)' \\
 		CC='$cc' CFLAGS='$cflags' \\
-		LDFLAGS='\$(LDFLAGS)' \\
+		LDFLAGS='$ldflags' \\
 		link_app.$shlib_target
 EOF
   }

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -103,7 +103,7 @@ CALC_VERSIONS=	\
 LINK_APP=	\
   ( $(SET_X);   \
     LIBDEPS="$${LIBDEPS:-$(LIBDEPS)}"; \
-    LDCMD="$${LDCMD:-$(CC)}"; LDFLAGS="$${LDFLAGS:-$(CFLAGS) $(LDFLAGS)}"; \
+    LDCMD="$${LDCMD:-$(CC)}"; LDFLAGS="$${LDFLAGS:-$(LDFLAGS)}"; \
     LIBPATH=`for x in $$LIBDEPS; do echo $$x; done | sed -e 's/^ *-L//;t' -e d | uniq`; \
     LIBPATH=`echo $$LIBPATH | sed -e 's/ /:/g'`; \
     echo LD_LIBRARY_PATH=$$LIBPATH:$$LD_LIBRARY_PATH \
@@ -115,7 +115,7 @@ LINK_SO=	\
   ( $(SET_X);   \
     LIBDEPS="$${LIBDEPS:-$(LIBDEPS)}"; \
     SHAREDCMD="$${SHAREDCMD:-$(CC)}"; \
-    SHAREDFLAGS="$${SHAREDFLAGS:-$(CFLAGS) $(SHARED_LDFLAGS)}"; \
+    SHAREDFLAGS="$${SHAREDFLAGS:-$(SHARED_LDFLAGS)}"; \
     LIBPATH=`for x in $$LIBDEPS; do echo $$x; done | sed -e 's/^ *-L//;t' -e d | uniq`; \
     LIBPATH=`echo $$LIBPATH | sed -e 's/ /:/g'`; \
     echo LD_LIBRARY_PATH=$$LIBPATH:$$LD_LIBRARY_PATH \
@@ -164,7 +164,7 @@ LINK_SO_SHLIB_UNPACKED=	\
 DETECT_GNU_LD=($(CC) -Wl,-V /dev/null 2>&1 | grep '^GNU ld' )>/dev/null
 
 DO_GNU_SO_COMMON=\
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX"
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX"
 DO_GNU_DSO=\
 	SHLIB=$(LIBNAME).so; \
 	SHLIB_SOVER=; \
@@ -176,7 +176,7 @@ DO_GNU_SO=\
 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
 	$(DO_GNU_SO_COMMON)
-DO_GNU_APP=LDFLAGS="$(CFLAGS) $(LDFLAGS)"
+DO_GNU_APP=LDFLAGS="$(LDFLAGS)"
 
 #This is rather special.  It's a special target with which one can link
 #applications without bothering with any features that have anything to
@@ -206,7 +206,7 @@ link_dso.bsd:
 	LIBDEPS=" "; \
 	ALLSYMSFLAGS=; \
 	NOALLSYMSFLAGS=; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -nostdlib"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -nostdlib"; \
 	fi; $(LINK_SO_DSO)
 link_shlib.bsd:
 	@if $(DETECT_GNU_LD); then $(DO_GNU_SO); else \
@@ -216,11 +216,11 @@ link_shlib.bsd:
 	LIBDEPS=" "; \
 	ALLSYMSFLAGS="-Wl,-Bforcearchive"; \
 	NOALLSYMSFLAGS=; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -nostdlib"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -nostdlib"; \
 	fi; $(LINK_SO_SHLIB)
 link_app.bsd:
 	@if $(DETECT_GNU_LD); then $(DO_GNU_APP); else \
-	LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
+	LDFLAGS="$(LDFLAGS)"; \
 	fi; $(LINK_APP)
 
 # For Darwin AKA Mac OS/X (dyld)
@@ -245,7 +245,7 @@ link_dso.darwin:
 	SHLIB_SUFFIX=.dylib; \
 	ALLSYMSFLAGS=''; \
 	NOALLSYMSFLAGS=''; \
-	SHAREDFLAGS="$(CFLAGS) `echo $(SHARED_LDFLAGS) | sed s/dynamiclib/bundle/`"; \
+	SHAREDFLAGS="`echo $(SHARED_LDFLAGS) | sed s/dynamiclib/bundle/`"; \
 	$(LINK_SO_DSO)
 link_shlib.darwin:
 	@ $(CALC_VERSIONS); \
@@ -253,7 +253,7 @@ link_shlib.darwin:
 	SHLIB_SUFFIX=.dylib; \
 	ALLSYMSFLAGS='-all_load'; \
 	NOALLSYMSFLAGS=''; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS)"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS)"; \
 	if [ -n "$(LIBVERSION)" ]; then \
 		SHAREDFLAGS="$$SHAREDFLAGS -current_version $(LIBVERSION)"; \
 	fi; \
@@ -271,7 +271,7 @@ link_dso.cygwin:
 	ALLSYMSFLAGS=''; \
 	NOALLSYMSFLAGS=''; \
 	base=-Wl,--enable-auto-image-base; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared $$base -Wl,-Bsymbolic"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -shared $$base -Wl,-Bsymbolic"; \
 	$(LINK_SO_DSO)
 link_shlib.cygwin:
 	@ $(CALC_VERSIONS); \
@@ -284,7 +284,7 @@ link_shlib.cygwin:
 		$(RC) $(SHARED_RCFLAGS) -o rc.o; \
 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,--enable-auto-image-base -Wl,-Bsymbolic -Wl,--out-implib,lib$(LIBNAME).dll.a rc.o"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -Wl,--enable-auto-image-base -Wl,-Bsymbolic -Wl,--out-implib,lib$(LIBNAME).dll.a rc.o"; \
 	$(LINK_SO_SHLIB) || exit 1; \
 	rm rc.o
 link_app.cygwin:
@@ -312,7 +312,7 @@ link_shlib.mingw:
 		$(RC) $(SHARED_RCFLAGS) -o rc.o; \
 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared $$base -Wl,-Bsymbolic -Wl,--out-implib,lib$(LIBNAME).dll.a $(LIBNAME).def rc.o"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -shared $$base -Wl,-Bsymbolic -Wl,--out-implib,lib$(LIBNAME).dll.a $(LIBNAME).def rc.o"; \
 	$(LINK_SO_SHLIB) || exit 1; \
 	rm $(LIBNAME).def rc.o
 
@@ -324,7 +324,7 @@ link_dso.alpha-osf1:
 		SHLIB_SUFFIX=; \
 		ALLSYMSFLAGS=''; \
 		NOALLSYMSFLAGS=''; \
-		SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-B,symbolic"; \
+		SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -Wl,-B,symbolic"; \
 	fi; \
 	$(LINK_SO_DSO)
 link_shlib.alpha-osf1:
@@ -342,7 +342,7 @@ link_shlib.alpha-osf1:
 		SHLIB_SOVER=; \
 		ALLSYMSFLAGS='-all'; \
 		NOALLSYMSFLAGS='-none'; \
-		SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-B,symbolic"; \
+		SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -Wl,-B,symbolic"; \
 		if [ -n "$$SHLIB_HIST" ]; then \
 			SHAREDFLAGS="$$SHAREDFLAGS -set_version $$SHLIB_HIST"; \
 		fi; \
@@ -352,7 +352,7 @@ link_app.alpha-osf1:
 	@if $(DETECT_GNU_LD); then \
 		$(DO_GNU_APP); \
 	else \
-		LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
+		LDFLAGS="$(LDFLAGS)"; \
 	fi; \
 	$(LINK_APP)
 
@@ -365,7 +365,7 @@ link_dso.solaris:
 		SHLIB_SUFFIX=; \
 		ALLSYMSFLAGS=""; \
 		NOALLSYMSFLAGS=""; \
-		SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -h $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX -Wl,-Bsymbolic"; \
+		SHAREDFLAGS="$(SHARED_LDFLAGS) -h $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX -Wl,-Bsymbolic"; \
 	fi; \
 	$(LINK_SO_DSO)
 link_shlib.solaris:
@@ -378,14 +378,14 @@ link_shlib.solaris:
 		$(PERL) $(SRCDIR)/util/mkdef.pl $(LIBNAME) linux >$(LIBNAME).map; \
 		ALLSYMSFLAGS="-Wl,-z,allextract,-M,$(LIBNAME).map"; \
 		NOALLSYMSFLAGS="-Wl,-z,defaultextract"; \
-		SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -h $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX -Wl,-Bsymbolic"; \
+		SHAREDFLAGS="$(SHARED_LDFLAGS) -h $$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX -Wl,-Bsymbolic"; \
 	fi; \
 	$(LINK_SO_SHLIB)
 link_app.solaris:
 	@ if $(DETECT_GNU_LD); then \
 		$(DO_GNU_APP); \
 	else \
-		LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
+		LDFLAGS="$(LDFLAGS)"; \
 	fi; \
 	$(LINK_APP)
 
@@ -458,7 +458,7 @@ link_dso.irix:
 		SHLIB_SUFFIX=; \
 		ALLSYMSFLAGS=""; \
 		NOALLSYMSFLAGS=""; \
-		SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-soname,$$SHLIB$$SHLIB_SUFFIX,-B,symbolic"; \
+		SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -Wl,-soname,$$SHLIB$$SHLIB_SUFFIX,-B,symbolic"; \
 	fi; \
 	$(LINK_SO_DSO)
 link_shlib.irix:
@@ -472,11 +472,11 @@ link_shlib.irix:
 		($(CC) -v 2>&1 | grep gcc) > /dev/null && MINUSWL="-Wl,"; \
 		ALLSYMSFLAGS="$${MINUSWL}-all"; \
 		NOALLSYMSFLAGS="$${MINUSWL}-none"; \
-		SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-soname,$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX,-B,symbolic"; \
+		SHAREDFLAGS="$(SHARED_LDFLAGS) -shared -Wl,-soname,$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX,-B,symbolic"; \
 	fi; \
 	$(LINK_SO_SHLIB)
 link_app.irix:
-	@LDFLAGS="$(CFLAGS) $(LDFLAGS)"; \
+	@LDFLAGS="$(LDFLAGS)"; \
 	$(LINK_APP)
 
 # 32-bit PA-RISC HP-UX embeds the -L pathname of libs we link with, so
@@ -495,7 +495,7 @@ link_dso.hpux:
 	ALLSYMSFLAGS=''; \
 	NOALLSYMSFLAGS=''; \
 	expr $(PLATFORM) : 'hpux64' > /dev/null && ALLSYMSFLAGS='-Wl,+forceload'; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -Wl,-B,symbolic,+vnocompatwarnings,-z,+s,+h,$$SHLIB$$SHLIB_SUFFIX,+cdp,../:,+cdp,./:"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -Wl,-B,symbolic,+vnocompatwarnings,-z,+s,+h,$$SHLIB$$SHLIB_SUFFIX,+cdp,../:,+cdp,./:"; \
 	fi; \
 	rm -f $(DSTDIR)/$$SHLIB$$SHLIB_SUFFIX || :; \
 	$(LINK_SO_DSO) && chmod a=rx $(DSTDIR)/$$SHLIB$$SHLIB_SUFFIX
@@ -508,13 +508,13 @@ link_shlib.hpux:
 	ALLSYMSFLAGS='-Wl,-Fl'; \
 	NOALLSYMSFLAGS=''; \
 	expr $(PLATFORM) : 'hpux64' > /dev/null && ALLSYMSFLAGS='-Wl,+forceload'; \
-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -Wl,-B,symbolic,+vnocompatwarnings,-z,+s,+h,$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX,+cdp,../:,+cdp,./:"; \
+	SHAREDFLAGS="$(SHARED_LDFLAGS) -Wl,-B,symbolic,+vnocompatwarnings,-z,+s,+h,$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX,+cdp,../:,+cdp,./:"; \
 	fi; \
 	rm -f $(DSTDIR)/$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX || :; \
 	$(LINK_SO_SHLIB) && chmod a=rx $(DSTDIR)/$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX
 link_app.hpux:
 	@if $(DETECT_GNU_LD); then $(DO_GNU_APP); else \
-	LDFLAGS="$(CFLAGS) $(LDFLAGS) -Wl,+s,+cdp,../:,+cdp,./:"; \
+	LDFLAGS="$(LDFLAGS) -Wl,+s,+cdp,../:,+cdp,./:"; \
 	fi; \
 	$(LINK_APP)
 
@@ -525,7 +525,7 @@ link_dso.aix:
 	SHLIB_SUFFIX=; \
 	ALLSYMSFLAGS=''; \
 	NOALLSYMSFLAGS=''; \
-	SHAREDFLAGS='$(CFLAGS) $(SHARED_LDFLAGS) -Wl,-bexpall,-bnolibpath,-bM:SRE'; \
+	SHAREDFLAGS='$(SHARED_LDFLAGS) -Wl,-bexpall,-bnolibpath,-bM:SRE'; \
 	rm -f $(DSTDIR)/$$SHLIB$$SHLIB_SOVER 2>&1 > /dev/null ; \
 	$(LINK_SO_DSO);
 link_shlib.aix:
@@ -536,11 +536,11 @@ link_shlib.aix:
 	SHLIB_SUFFIX=; \
 	ALLSYMSFLAGS='-bnogc'; \
 	NOALLSYMSFLAGS=''; \
-	SHAREDFLAGS='$(CFLAGS) $(SHARED_LDFLAGS) -Wl,-bexpall,-bnolibpath,-bM:SRE'; \
+	SHAREDFLAGS='$(SHARED_LDFLAGS) -Wl,-bexpall,-bnolibpath,-bM:SRE'; \
 	rm -f $(DSTDIR)/$$SHLIB$$SHLIB_SOVER 2>&1 > /dev/null ; \
 	$(LINK_SO_SHLIB_VIA_O)
 link_app.aix:
-	LDFLAGS="$(CFLAGS) -Wl,-bsvr4 $(LDFLAGS)"; \
+	LDFLAGS="-Wl,-bsvr4 $(LDFLAGS)"; \
 	$(LINK_APP)
 
 


### PR DESCRIPTION
Makefile.shared has so far been entirely in control how CFLAGS is
combined with LDFLAGS and SHARED_LDFLAGS.  This is practical but
can also be a stumbling block.

The solution is to move the control over these combinations to the
config targets and the build file templates.

Note: this is a hack, a future (and not as compatible) solution will
come in a future major release.

This should hopefully help #2148