### PR TITLE
Allow parallell make in Configure

### DIFF
--- a/Configure
+++ b/Configure
@@ -2041,12 +2041,13 @@ EOF
 	close(OUT);
 } else {
 	my $make_command = "$make PERL=\'$perl\'";
-	my $make_targets = "";
-	$make_targets .= " links" if $symlink;
-	$make_targets .= " depend" if $depflags ne $default_depflags && $make_depend;
-	$make_targets .= " gentests" if $symlink;
-	(system $make_command.$make_targets) == 0 or exit $?
-		if $make_targets ne "";
+	my @make_targets = ();
+	push @make_targets, "links" if $symlink;
+	push @make_targets, "depend" if $depflags ne $default_depflags && $make_depend;
+	push @make_targets, "gentests" if $symlink;
+	foreach my $make_target (@make_targets) {
+	    (system "$make_command $make_target") == 0 or exit $?;
+	}
 	if ( $perl =~ m@^/@) {
 	    &dofile("tools/c_rehash",$perl,'^#!/', '#!%s','^my \$dir;$', 'my $dir = "' . $openssldir . '";', '^my \$prefix;$', 'my $prefix = "' . $prefix . '";');
 	    &dofile("apps/CA.pl",$perl,'^#!/', '#!%s');
@@ -2056,8 +2057,8 @@ EOF
 	    &dofile("apps/CA.pl",'/usr/local/bin/perl','^#!/', '#!%s');
 	}
 	if ($depflags ne $default_depflags && !$make_depend) {
-            $warn_make_depend++;
-        }
+	    $warn_make_depend++;
+	}
 }
 
 # create the ms/version32.rc file if needed


### PR DESCRIPTION
If someone tries this:

    MAKE='make -j8' ./config

then Configure ends up doing this:

    make -j8 links depend gentests

Doing those three in parallell leads to a race condition that may very well
cause issue such as tests not being run (because they all get linked to a
dummy that does nothing instead of the real test).

To mitigate this, execute the three targets in one make call each.

Fixes #2331