### PR TITLE
Majority rules, use session_ctx vs initial_ctx

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -599,7 +599,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     s->ext.ocsp.resp = NULL;
     s->ext.ocsp.resp_len = 0;
     SSL_CTX_up_ref(ctx);
-    s->initial_ctx = ctx;
+    s->session_ctx = ctx;
 #ifndef OPENSSL_NO_EC
     if (ctx->ext.ecpointformats) {
         s->ext.ecpointformats =
@@ -995,7 +995,7 @@ void SSL_free(SSL *s)
     /* Free up if allocated */
 
     OPENSSL_free(s->ext.hostname);
-    SSL_CTX_free(s->initial_ctx);
+    SSL_CTX_free(s->session_ctx);
 #ifndef OPENSSL_NO_EC
     OPENSSL_free(s->ext.ecpointformats);
     OPENSSL_free(s->ext.supportedgroups);
@@ -3483,7 +3483,7 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
     if (ssl->ctx == ctx)
         return ssl->ctx;
     if (ctx == NULL)
-        ctx = ssl->initial_ctx;
+        ctx = ssl->session_ctx;
     new_cert = ssl_cert_dup(ctx->cert);
     if (new_cert == NULL) {
         return NULL;

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1150,10 +1150,7 @@ struct ssl_st {
     /* Have we attempted to find/parse SCTs yet? */
     int scts_parsed;
 # endif
-    SSL_CTX *initial_ctx;       /* initial ctx, used to store sessions */
-# ifndef OPENSSL_NO_NEXTPROTONEG
-# endif
-# define session_ctx initial_ctx
+    SSL_CTX *session_ctx;       /* initial ctx, used to store sessions */
     /* What we'll do */
     STACK_OF(SRTP_PROTECTION_PROFILE) *srtp_profiles;
     /* What's been chosen */

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -736,10 +736,10 @@ static int final_server_name(SSL *s, unsigned int context, int sent,
     if (s->ctx != NULL && s->ctx->ext.servername_cb != 0)
         ret = s->ctx->ext.servername_cb(s, &altmp,
                                         s->ctx->ext.servername_arg);
-    else if (s->initial_ctx != NULL
-             && s->initial_ctx->ext.servername_cb != 0)
-        ret = s->initial_ctx->ext.servername_cb(s, &altmp,
-                                       s->initial_ctx->ext.servername_arg);
+    else if (s->session_ctx != NULL
+             && s->session_ctx->ext.servername_cb != 0)
+        ret = s->session_ctx->ext.servername_cb(s, &altmp,
+                                       s->session_ctx->ext.servername_arg);
 
     switch (ret) {
     case SSL_TLSEXT_ERR_ALERT_FATAL:

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3221,7 +3221,7 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
     int len, slen_full, slen, lenfinal;
     SSL_SESSION *sess;
     unsigned int hlen;
-    SSL_CTX *tctx = s->initial_ctx;
+    SSL_CTX *tctx = s->session_ctx;
     unsigned char iv[EVP_MAX_IV_LENGTH];
     unsigned char key_name[TLSEXT_KEYNAME_LENGTH];
     int iv_len, al = SSL_AD_INTERNAL_ERROR;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1186,7 +1186,7 @@ TICKET_RETURN tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     unsigned char tick_hmac[EVP_MAX_MD_SIZE];
     HMAC_CTX *hctx = NULL;
     EVP_CIPHER_CTX *ctx;
-    SSL_CTX *tctx = s->initial_ctx;
+    SSL_CTX *tctx = s->session_ctx;
 
     /* Initialize session ticket encryption and HMAC contexts */
     hctx = HMAC_CTX_new();


### PR DESCRIPTION
session_ctx and initial_ctx are aliases of each other, and with the
opaque data structures, there's no need to keep both around. Since
there were more references of session_ctx, replace all instances of
initial_ctx with session_ctx.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
These don't really apply:
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
