### PR TITLE
Fix bntest to check for possible negative zero

### DIFF
--- a/test/bntest.c
+++ b/test/bntest.c
@@ -2195,7 +2195,7 @@ static int file_test_run(STANZA *s)
 static int file_tests()
 {
     STANZA s;
-    int linesread = 0, result = 0;
+    int linesread = 0, errcnt = 0;
 
     /* Read test file. */
     memset(&s, 0, sizeof(s));
@@ -2203,17 +2203,14 @@ static int file_tests()
         if (s.numpairs == 0)
             continue;
         if (!file_test_run(&s)) {
-            if (result == 0)
-                fprintf(stderr, "Test at %d failed\n", s.start);
-            goto err;
+            fprintf(stderr, "Test at %d failed\n", s.start);
+            errcnt++;
         }
         clearstanza(&s);
         s.start = linesread;
     }
-    result = 1;
 
-err:
-    return result;
+    return errcnt == 0;
 }
 
 int test_main(int argc, char *argv[])

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -146,8 +146,14 @@ static int equalBN(const char *op, const BIGNUM *expected, const BIGNUM *actual)
     if (BN_cmp(expected, actual) == 0)
         return 1;
 
-    exstr = BN_bn2hex(expected);
-    actstr = BN_bn2hex(actual);
+    if (BN_is_zero(expected) && BN_is_negative(expected))
+        exstr = OPENSSL_strdup("-0");
+    else
+        exstr = BN_bn2hex(expected);
+    if (BN_is_zero(actual) && BN_is_negative(actual))
+        actstr = OPENSSL_strdup("-0");
+    else
+        actstr = BN_bn2hex(actual);
     if (exstr == NULL || actstr == NULL)
         goto err;
 

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -1155,21 +1155,28 @@ static int file_rshift(STANZA *s)
     BIGNUM *rshift = getBN(s, "RShift");
     BIGNUM *ret = BN_new();
     int n = 0;
-    int st = 0;
+    int errcnt = 1;
 
     if (a == NULL || rshift == NULL || ret == NULL || !getint(s, &n, "N"))
         goto err;
 
+    errcnt = 0;
     if (!BN_rshift(ret, a, n)
             || !equalBN("A >> N", rshift, ret))
-        goto err;
+        errcnt++;
 
-    st = 1;
+    /* If N == 1, try with rshift1 as well */
+    if (n == 1) {
+        if (!BN_rshift1(ret, a)
+                || !equalBN("A >> 1 (rshift1)", rshift, ret))
+            errcnt++;
+    }
+
 err:
     BN_free(a);
     BN_free(rshift);
     BN_free(ret);
-    return st;
+    return errcnt == 0;
 }
 
 static int file_square(STANZA *s)

--- a/test/bntests.txt
+++ b/test/bntests.txt
@@ -4643,6 +4643,10 @@ N = 64
 #
 # These test vectors satisfy A / 2^N = RShift, rounding towards zero.
 
+Rshift = 0
+A = -1
+N = 1
+
 RShift = 6ce746ffa7979ce10b751cd2308402a95d00d596cd97b36380
 A = d9ce8dff4f2f39c216ea39a461080552ba01ab2d9b2f66c701
 N = 1
@@ -5966,6 +5970,11 @@ B = -542fb814f45924aa09a16f2a6
 #
 # These test vectors satisfy Quotient = A / B, rounded towards zero, and
 # Remainder = A - B * Quotient.
+
+Quotient = 0
+Remainder = -1
+A = -1
+B = 2
 
 Quotient = 1
 Remainder = 0


### PR DESCRIPTION
This is related to #1672, where the possibility of negative zero is discussed.  The impemented checks are inspired from https://github.com/google/boringssl/commit/4008c7a80d59cb8dd7606abca12ec23870470c7f, which is mentioned in #1672.

##### Checklist
- [x] tests are added or updated
