### PR TITLE
Fix waitctx fds

### DIFF
--- a/crypto/async/async_wait.c
+++ b/crypto/async/async_wait.c
@@ -113,22 +113,25 @@ int ASYNC_WAIT_CTX_get_changed_fds(ASYNC_WAIT_CTX *ctx, OSSL_ASYNC_FD *addfd,
 {
     struct fd_lookup_st *curr;
 
-    *numaddfds = ctx->numadd;
-    *numdelfds = ctx->numdel;
-    if (addfd == NULL && delfd == NULL)
-        return 1;
-
+    *numaddfds = 0;
+    *numdelfds = 0;
     curr = ctx->fds;
 
     while (curr != NULL) {
         /* We ignore fds that have been marked as both added and deleted */
-        if (curr->del && !curr->add && (delfd != NULL)) {
-            *delfd = curr->fd;
-            delfd++;
+        if (curr->del && !curr->add) {
+            if (delfd != NULL) {
+                *delfd = curr->fd;
+                delfd++;
+            }
+            (*numdelfds)++;
         }
-        if (curr->add && !curr->del && (addfd != NULL)) {
-            *addfd = curr->fd;
-            addfd++;
+        if (curr->add && !curr->del) {
+            if (addfd != NULL) {
+                *addfd = curr->fd;
+                addfd++;
+            }
+            (*numaddfds)++;
         }
         curr = curr->next;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
- [x] CLA is signed

##### Description of change

There are cases where the engine calls `ASYNC_WAIT_CTX_set_wait_fd()` followed by `ASYNC_WAIT_CTX_clear_fd()` before pausing the async job.
This happens for example when the submission to the HW accelerator fails and there is no operation in flight (no fd should be added in the epoll set of the application).

In this case, the application will get inconsistent results from `ASYNC_WAIT_CTX_get_changed_fds()`

Both `numdelfds` and `numaddfds` will be set to 1 (they have been increased with the previous call to set_wait_fd and clear_fd)
However in the while loop we explicitly ignore the fds that have been marked as both added and deleted.
This means that the array of fds returned to the application won’t contain any meaningful data, which results in unpredictable behavior.

This pull request changes `ASYNC_WAIT_CTX_get_changed_fds()` to make sure that the numbers of file descriptors returned to the application are always correct.

The changes applies to **master** and **1.1.0**
