### PR TITLE
Majority rules, use session_ctx vs initial_ctx

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -600,7 +600,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     s->tlsext_ocsp_resp = NULL;
     s->tlsext_ocsp_resplen = -1;
     SSL_CTX_up_ref(ctx);
-    s->initial_ctx = ctx;
+    s->session_ctx = ctx;
 #ifndef OPENSSL_NO_EC
     if (ctx->tlsext_ecpointformatlist) {
         s->tlsext_ecpointformatlist =
@@ -999,7 +999,7 @@ void SSL_free(SSL *s)
     /* Free up if allocated */
 
     OPENSSL_free(s->tlsext_hostname);
-    SSL_CTX_free(s->initial_ctx);
+    SSL_CTX_free(s->session_ctx);
 #ifndef OPENSSL_NO_EC
     OPENSSL_free(s->tlsext_ecpointformatlist);
     OPENSSL_free(s->tlsext_ellipticcurvelist);
@@ -3380,7 +3380,7 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
     if (ssl->ctx == ctx)
         return ssl->ctx;
     if (ctx == NULL)
-        ctx = ssl->initial_ctx;
+        ctx = ssl->session_ctx;
     new_cert = ssl_cert_dup(ctx->cert);
     if (new_cert == NULL) {
         return NULL;

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1077,7 +1077,7 @@ struct ssl_st {
     /* TLS pre-shared secret session resumption */
     tls_session_secret_cb_fn tls_session_secret_cb;
     void *tls_session_secret_cb_arg;
-    SSL_CTX *initial_ctx;       /* initial ctx, used to store sessions */
+    SSL_CTX *session_ctx;       /* initial ctx, used to store sessions */
 # ifndef OPENSSL_NO_NEXTPROTONEG
     /*
      * Next protocol negotiation. For the client, this is the protocol that
@@ -1089,7 +1089,6 @@ struct ssl_st {
     unsigned char *next_proto_negotiated;
     unsigned char next_proto_negotiated_len;
 # endif
-# define session_ctx initial_ctx
     /* What we'll do */
     STACK_OF(SRTP_PROTECTION_PROFILE) *srtp_profiles;
     /* What's been chosen */

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2992,7 +2992,7 @@ int tls_construct_new_session_ticket(SSL *s)
     int len, slen_full, slen;
     SSL_SESSION *sess;
     unsigned int hlen;
-    SSL_CTX *tctx = s->initial_ctx;
+    SSL_CTX *tctx = s->session_ctx;
     unsigned char iv[EVP_MAX_IV_LENGTH];
     unsigned char key_name[TLSEXT_KEYNAME_LENGTH];
     int iv_len;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2684,12 +2684,12 @@ static int ssl_check_clienthello_tlsext_early(SSL *s)
         ret =
             s->ctx->tlsext_servername_callback(s, &al,
                                                s->ctx->tlsext_servername_arg);
-    else if (s->initial_ctx != NULL
-             && s->initial_ctx->tlsext_servername_callback != 0)
+    else if (s->session_ctx != NULL
+             && s->session_ctx->tlsext_servername_callback != 0)
         ret =
-            s->initial_ctx->tlsext_servername_callback(s, &al,
+            s->session_ctx->tlsext_servername_callback(s, &al,
                                                        s->
-                                                       initial_ctx->tlsext_servername_arg);
+                                                       session_ctx->tlsext_servername_arg);
 
     switch (ret) {
     case SSL_TLSEXT_ERR_ALERT_FATAL:
@@ -2863,12 +2863,12 @@ int ssl_check_serverhello_tlsext(SSL *s)
         ret =
             s->ctx->tlsext_servername_callback(s, &al,
                                                s->ctx->tlsext_servername_arg);
-    else if (s->initial_ctx != NULL
-             && s->initial_ctx->tlsext_servername_callback != 0)
+    else if (s->session_ctx != NULL
+             && s->session_ctx->tlsext_servername_callback != 0)
         ret =
-            s->initial_ctx->tlsext_servername_callback(s, &al,
+            s->session_ctx->tlsext_servername_callback(s, &al,
                                                        s->
-                                                       initial_ctx->tlsext_servername_arg);
+                                                       session_ctx->tlsext_servername_arg);
 
     /*
      * Ensure we get sensible values passed to tlsext_status_cb in the event
@@ -3084,7 +3084,7 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     unsigned char tick_hmac[EVP_MAX_MD_SIZE];
     HMAC_CTX *hctx = NULL;
     EVP_CIPHER_CTX *ctx;
-    SSL_CTX *tctx = s->initial_ctx;
+    SSL_CTX *tctx = s->session_ctx;
 
     /* Initialize session ticket encryption and HMAC contexts */
     hctx = HMAC_CTX_new();


### PR DESCRIPTION
session_ctx and initial_ctx are aliases of each other, and with the
opaque data structures, there's no need to keep both around. Since
there were more references of session_ctx, replace all instances of
initial_ctx with session_ctx.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
These don't really apply.
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
