### PR TITLE
remove test/.rnd on make clean

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -290,6 +290,7 @@ clean: libclean
 	-$(RM) `find . -name '*{- $objext -}' -a \! -path "./.git/*"`
 	$(RM) core
 	$(RM) tags TAGS
+	$(RM) test/.rnd
 	$(RM) openssl.pc libcrypto.pc libssl.pc
 	-$(RM) `find . -type l -a \! -path "./.git/*"`
 	$(RM) $(TARFILE)


### PR DESCRIPTION
Neither "make clean" nor "make distclean" removes the file "test/.rnd".
This patch removes this temporary file on make clean.
This patch should work on master/OpenSSL_1_1_0-stable.