### PR TITLE
SSL_get_shared_sigalgs: handle negative idx parameter

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -239,7 +239,7 @@ static int do_print_sigalgs(BIO *out, SSL *s, int shared)
     int i, nsig, client;
     client = SSL_is_server(s) ? 0 : 1;
     if (shared)
-        nsig = SSL_get_shared_sigalgs(s, -1, NULL, NULL, NULL, NULL, NULL);
+        nsig = SSL_get_shared_sigalgs(s, 0, NULL, NULL, NULL, NULL, NULL);
     else
         nsig = SSL_get_sigalgs(s, -1, NULL, NULL, NULL, NULL, NULL);
     if (nsig == 0)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1684,6 +1684,7 @@ int SSL_get_shared_sigalgs(SSL *s, int idx,
 {
     const SIGALG_LOOKUP *shsigalgs;
     if (s->cert->shared_sigalgs == NULL
+        || idx < 0
         || idx >= (int)s->cert->shared_sigalgslen
         || s->cert->shared_sigalgslen > INT_MAX)
         return 0;


### PR DESCRIPTION
When idx is negative (as is the case with do_print_sigalgs in
apps/s_cb.c), AddressSanitizer complains about a buffer overflow (read).
Though since the pointer is not dereferenced, normally this is harmless.

Tested with `openssl s_server` and `curl -k https://localhost:4433`.
