### PR TITLE
Place ticket keys into secure memory

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3798,8 +3798,8 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         {
             unsigned char *keys = parg;
             long tick_keylen = (sizeof(ctx->ext.tick_key_name) +
-                                sizeof(ctx->ext.tick_hmac_key) +
-                                sizeof(ctx->ext.tick_aes_key));
+                                sizeof(ctx->ext.secure->tick_hmac_key) +
+                                sizeof(ctx->ext.secure->tick_aes_key));
             if (keys == NULL)
                 return tick_keylen;
             if (larg != tick_keylen) {
@@ -3809,23 +3809,23 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
             if (cmd == SSL_CTRL_SET_TLSEXT_TICKET_KEYS) {
                 memcpy(ctx->ext.tick_key_name, keys,
                        sizeof(ctx->ext.tick_key_name));
-                memcpy(ctx->ext.tick_hmac_key,
+                memcpy(ctx->ext.secure->tick_hmac_key,
                        keys + sizeof(ctx->ext.tick_key_name),
-                       sizeof(ctx->ext.tick_hmac_key));
-                memcpy(ctx->ext.tick_aes_key,
+                       sizeof(ctx->ext.secure->tick_hmac_key));
+                memcpy(ctx->ext.secure->tick_aes_key,
                        keys + sizeof(ctx->ext.tick_key_name) +
-                       sizeof(ctx->ext.tick_hmac_key),
-                       sizeof(ctx->ext.tick_aes_key));
+                       sizeof(ctx->ext.secure->tick_hmac_key),
+                       sizeof(ctx->ext.secure->tick_aes_key));
             } else {
                 memcpy(keys, ctx->ext.tick_key_name,
                        sizeof(ctx->ext.tick_key_name));
                 memcpy(keys + sizeof(ctx->ext.tick_key_name),
-                       ctx->ext.tick_hmac_key,
-                       sizeof(ctx->ext.tick_hmac_key));
+                       ctx->ext.secure->tick_hmac_key,
+                       sizeof(ctx->ext.secure->tick_hmac_key));
                 memcpy(keys + sizeof(ctx->ext.tick_key_name) +
-                       sizeof(ctx->ext.tick_hmac_key),
-                       ctx->ext.tick_aes_key,
-                       sizeof(ctx->ext.tick_aes_key));
+                       sizeof(ctx->ext.secure->tick_hmac_key),
+                       ctx->ext.secure->tick_aes_key,
+                       sizeof(ctx->ext.secure->tick_aes_key));
             }
             return 1;
         }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3050,6 +3050,9 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_SSL_CTX, ret, &ret->ex_data))
         goto err;
 
+    if ((ret->ext.secure = OPENSSL_secure_zalloc(sizeof(*ret->ext.secure))) == NULL)
+        goto err;
+
     /* No compression for DTLS */
     if (!(meth->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS))
         ret->comp_methods = SSL_COMP_get_compression_methods();
@@ -3060,10 +3063,10 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
     /* Setup RFC5077 ticket keys */
     if ((RAND_bytes(ret->ext.tick_key_name,
                     sizeof(ret->ext.tick_key_name)) <= 0)
-        || (RAND_bytes(ret->ext.tick_hmac_key,
-                       sizeof(ret->ext.tick_hmac_key)) <= 0)
-        || (RAND_bytes(ret->ext.tick_aes_key,
-                       sizeof(ret->ext.tick_aes_key)) <= 0))
+        || (RAND_bytes(ret->ext.secure->tick_hmac_key,
+                       sizeof(ret->ext.secure->tick_hmac_key)) <= 0)
+        || (RAND_bytes(ret->ext.secure->tick_aes_key,
+                       sizeof(ret->ext.secure->tick_aes_key)) <= 0))
         ret->options |= SSL_OP_NO_TICKET;
 
     if (RAND_bytes(ret->ext.cookie_hmac_key,
@@ -3203,6 +3206,7 @@ void SSL_CTX_free(SSL_CTX *a)
     OPENSSL_free(a->ext.supportedgroups);
 #endif
     OPENSSL_free(a->ext.alpn);
+    OPENSSL_secure_free(a->ext.secure);
 
     CRYPTO_THREAD_lock_free(a->lock);
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -733,7 +733,13 @@ DEFINE_LHASH_OF(SSL_SESSION);
 /* Needed in ssl_cert.c */
 DEFINE_LHASH_OF(X509_NAME);
 
-# define TLSEXT_KEYNAME_LENGTH 16
+# define TLSEXT_KEYNAME_LENGTH  16
+# define TLSEXT_TICK_KEY_LENGTH 32
+
+typedef struct ssl_ctx_ext_secure_st {
+    unsigned char tick_hmac_key[TLSEXT_TICK_KEY_LENGTH];
+    unsigned char tick_aes_key[TLSEXT_TICK_KEY_LENGTH];
+} SSL_CTX_EXT_SECURE;
 
 struct ssl_ctx_st {
     const SSL_METHOD *method;
@@ -927,8 +933,7 @@ struct ssl_ctx_st {
         void *servername_arg;
         /* RFC 4507 session ticket keys */
         unsigned char tick_key_name[TLSEXT_KEYNAME_LENGTH];
-        unsigned char tick_hmac_key[32];
-        unsigned char tick_aes_key[32];
+        SSL_CTX_EXT_SECURE *secure;
         /* Callback to support customisation of ticket key setting */
         int (*ticket_key_cb) (SSL *ssl,
                               unsigned char *name, unsigned char *iv,

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3832,9 +3832,9 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
         iv_len = EVP_CIPHER_iv_length(cipher);
         if (ssl_randbytes(s, iv, iv_len) <= 0
                 || !EVP_EncryptInit_ex(ctx, cipher, NULL,
-                                       tctx->ext.tick_aes_key, iv)
-                || !HMAC_Init_ex(hctx, tctx->ext.tick_hmac_key,
-                                 sizeof(tctx->ext.tick_hmac_key),
+                                       tctx->ext.secure->tick_aes_key, iv)
+                || !HMAC_Init_ex(hctx, tctx->ext.secure->tick_hmac_key,
+                                 sizeof(tctx->ext.secure->tick_hmac_key),
                                  EVP_sha256(), NULL)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_NEW_SESSION_TICKET,

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1349,11 +1349,11 @@ SSL_TICKET_RETURN tls_decrypt_ticket(SSL *s, const unsigned char *etick,
             ret = SSL_TICKET_NO_DECRYPT;
             goto err;
         }
-        if (HMAC_Init_ex(hctx, tctx->ext.tick_hmac_key,
-                         sizeof(tctx->ext.tick_hmac_key),
+        if (HMAC_Init_ex(hctx, tctx->ext.secure->tick_hmac_key,
+                         sizeof(tctx->ext.secure->tick_hmac_key),
                          EVP_sha256(), NULL) <= 0
             || EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL,
-                                  tctx->ext.tick_aes_key,
+                                  tctx->ext.secure->tick_aes_key,
                                   etick + TLSEXT_KEYNAME_LENGTH) <= 0) {
             goto err;
         }


### PR DESCRIPTION
Place the session ticket AES and HMAC keys into secure memory.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
Below items, don't apply. Existing unit tests pass.
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
