### PR TITLE
Add a make distclean rule in the OpenSSL_1_0_2 branch

### DIFF
--- a/Makefile.org
+++ b/Makefile.org
@@ -424,6 +424,14 @@ clean:	libclean
 	rm -fr $$i/*; \
 	done
 
+distclean: clean
+	-$(RM) `find . -name .git -prune -o -type l -print`
+	$(RM) apps/CA.pl
+	$(RM) test/evptests.txt test/newkey.pem test/testkey.pem test/testreq.pem
+	$(RM) tools/c_rehash
+	$(RM) crypto/opensslconf.h
+	$(RM) Makefile Makefile.bak
+
 makefile.one: files
 	$(PERL) util/mk1mf.pl >makefile.one; \
 	sh util/do_ms.sh


### PR DESCRIPTION
This adds a make distclean rule that works like the distclean rule in the master branch,
that is useful if you often switch between 1_1_0 and 1_0_2 branches, as I do.
There is also a dclean target but I am not sure if it is really working, so I left it as is.