### PR TITLE
Bug reports and patches for OpenSSL

### DIFF
--- a/apps/ts.c
+++ b/apps/ts.c
@@ -887,9 +887,15 @@ static TS_VERIFY_CTX *create_verify_ctx(const char *data, const char *digest,
             goto err;
         f = TS_VFY_VERSION | TS_VFY_SIGNER;
         if (data != NULL) {
+            BIO *out = NULL;
+
             f |= TS_VFY_DATA;
-            if (TS_VERIFY_CTX_set_data(ctx, BIO_new_file(data, "rb")) == NULL)
+            if ((out = BIO_new_file(data, "rb")) == NULL)
                 goto err;
+            if (TS_VERIFY_CTX_set_data(ctx, out) == NULL) {
+                BIO_free_all(out);
+                goto err;
+            }
         } else if (digest != NULL) {
             long imprint_len;
             unsigned char *hexstr = OPENSSL_hexstr2buf(digest, &imprint_len);

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -254,8 +254,10 @@ static int eckey_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
     }
 
     if (!PKCS8_pkey_set0(p8, OBJ_nid2obj(NID_X9_62_id_ecPublicKey), 0,
-                         ptype, pval, ep, eplen))
+                         ptype, pval, ep, eplen)) {
+        OPENSSL_free(ep);
         return 0;
+    }
 
     return 1;
 }

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1838,7 +1838,7 @@ int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm)
     if (id < 193 || id > 255) {
         SSLerr(SSL_F_SSL_COMP_ADD_COMPRESSION_METHOD,
                SSL_R_COMPRESSION_ID_NOT_WITHIN_PRIVATE_RANGE);
-        return 0;
+        return 1;
     }
 
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE);


### PR DESCRIPTION
Dear OpenSSL developers,

We are software engineering researchers at University of Virginia. As part of a research project, we have built a tool for automatically finding and fixing error handling bugs and are testing it on various cryptographic libraries and applications that use them.

In the most recent version of OpenSSL, we discovered various instances where there may be memory leak on error path, potential error propagation or missing check of function call. And we also give a patch for each potential bug.

Please let us know how you intend to address these issues.

Sincerely,
Baishakhi Ray, Yuchi Tian

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
Fix potential memory leak, error propagation and missing check of function call bugs.