### PR TITLE
If idx < 0 only return number of shared siglgs

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1682,22 +1682,23 @@ int SSL_get_shared_sigalgs(SSL *s, int idx,
                            int *psign, int *phash, int *psignhash,
                            unsigned char *rsig, unsigned char *rhash)
 {
-    const SIGALG_LOOKUP *shsigalgs;
     if (s->cert->shared_sigalgs == NULL
         || idx >= (int)s->cert->shared_sigalgslen
         || s->cert->shared_sigalgslen > INT_MAX)
         return 0;
-    shsigalgs = s->cert->shared_sigalgs[idx];
-    if (phash != NULL)
-        *phash = shsigalgs->hash;
-    if (psign != NULL)
-        *psign = shsigalgs->sig;
-    if (psignhash != NULL)
-        *psignhash = shsigalgs->sigandhash;
-    if (rsig != NULL)
-        *rsig = (unsigned char)(shsigalgs->sigalg & 0xff);
-    if (rhash != NULL)
-        *rhash = (unsigned char)((shsigalgs->sigalg >> 8) & 0xff);
+    if (idx >= 0) {
+        const SIGALG_LOOKUP *shsigalgs = s->cert->shared_sigalgs[idx];
+        if (phash != NULL)
+            *phash = shsigalgs->hash;
+        if (psign != NULL)
+            *psign = shsigalgs->sig;
+        if (psignhash != NULL)
+            *psignhash = shsigalgs->sigandhash;
+        if (rsig != NULL)
+            *rsig = (unsigned char)(shsigalgs->sigalg & 0xff);
+        if (rhash != NULL)
+            *rhash = (unsigned char)((shsigalgs->sigalg >> 8) & 0xff);
+    }
     return (int)s->cert->shared_sigalgslen;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This fixes a bug SSL_get_sigalgs() where there would be an OOB read if idx < 0.