### PR TITLE
perlasm/x86_64-xlate.pl: fix typos.

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -279,7 +279,7 @@ my %globals;
 	}
 
 	# if base register is %rbp or %r13, see if it's possible to
-	# flip base and ingex registers [for better performance]
+	# flip base and index registers [for better performance]
 	if (!$self->{label} && $self->{index} && $self->{scale}==1 &&
 	    $self->{base} =~ /(rbp|r13)/) {
 		$self->{base} = $self->{index}; $self->{index} = $1;

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -633,7 +633,7 @@ my %globals;
 	my	$self = {};
 	my	$ret;
 
-	if ($$line =~ s/^\s*\.cfi_(\w+)\s+//) {
+	if ($$line =~ s/^\s*\.cfi_(\w+)\s*//) {
 	    bless $self,$class;
 	    $ret = $self;
 	    undef $self->{value};
@@ -656,7 +656,7 @@ my %globals;
 			&& do {	$cfa_rsp -= 1*eval($$line) if ($cfa_reg eq "%rsp");
 				last;
 			      };
-	    /def_cfa/	&& do {	if ($$line =~ /(%r\w+)\s*,\s*(\.+)/) {
+	    /def_cfa/	&& do {	if ($$line =~ /(%r\w+)\s*,\s*(.+)/) {
 				    $cfa_reg = $1;
 				    $cfa_rsp = -1*eval($2) if ($cfa_reg eq "%rsp");
 				}


### PR DESCRIPTION
Fix spelling typo in commentary and pair of typo-bugs in the new
cfi_directive package.
