### PR TITLE
Replace SSL_PKEY_RSA_SIGN, SSL_PKEY_RSA_ENC with SSL_PKEY_RSA

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -63,7 +63,7 @@ CERT *ssl_cert_new(void)
         return NULL;
     }
 
-    ret->key = &(ret->pkeys[SSL_PKEY_RSA_ENC]);
+    ret->key = &(ret->pkeys[SSL_PKEY_RSA]);
     ret->references = 1;
     ret->sec_cb = ssl_security_default_callback;
     ret->sec_level = OPENSSL_TLS_SECURITY_LEVEL;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1909,7 +1909,7 @@ int ssl_cipher_get_cert_index(const SSL_CIPHER *c)
     else if (alg_a & SSL_aDSS)
         return SSL_PKEY_DSA_SIGN;
     else if (alg_a & SSL_aRSA)
-        return SSL_PKEY_RSA_ENC;
+        return SSL_PKEY_RSA;
     else if (alg_a & SSL_aGOST12)
         return SSL_PKEY_GOST_EC;
     else if (alg_a & SSL_aGOST01)

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -398,14 +398,13 @@
 # define SSL_USE_ETM(s) (s->s3->flags & TLS1_FLAGS_ENCRYPT_THEN_MAC)
 
 /* Mostly for SSLv3 */
-# define SSL_PKEY_RSA_ENC        0
-# define SSL_PKEY_RSA_SIGN       1
-# define SSL_PKEY_DSA_SIGN       2
-# define SSL_PKEY_ECC            3
-# define SSL_PKEY_GOST01         4
-# define SSL_PKEY_GOST12_256     5
-# define SSL_PKEY_GOST12_512     6
-# define SSL_PKEY_NUM            7
+# define SSL_PKEY_RSA            0
+# define SSL_PKEY_DSA_SIGN       1
+# define SSL_PKEY_ECC            2
+# define SSL_PKEY_GOST01         3
+# define SSL_PKEY_GOST12_256     4
+# define SSL_PKEY_GOST12_512     5
+# define SSL_PKEY_NUM            6
 /*
  * Pseudo-constant. GOST cipher suites can use different certs for 1
  * SSL_CIPHER. So let's see which one we have in fact.
@@ -413,10 +412,10 @@
 # define SSL_PKEY_GOST_EC SSL_PKEY_NUM+1
 
 /*
- * TODO(TLS1.3) for now use RSA_SIGN keys for PSS
+ * TODO(TLS1.3) for now use SSL_PKEY_RSA keys for PSS
  */
 
-#define SSL_PKEY_RSA_PSS_SIGN SSL_PKEY_RSA_SIGN
+#define SSL_PKEY_RSA_PSS_SIGN SSL_PKEY_RSA
 
 /*-
  * SSL_kRSA <- RSA_ENC

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1071,7 +1071,7 @@ int ssl_cert_type(const X509 *x, const EVP_PKEY *pk)
     default:
         return -1;
     case EVP_PKEY_RSA:
-        return SSL_PKEY_RSA_ENC;
+        return SSL_PKEY_RSA;
     case EVP_PKEY_DSA:
         return SSL_PKEY_DSA_SIGN;
 #ifndef OPENSSL_NO_EC

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2465,7 +2465,7 @@ static int tls_process_cke_rsa(SSL *s, PACKET *pkt, int *al)
     unsigned char *rsa_decrypt = NULL;
     int ret = 0;
 
-    rsa = EVP_PKEY_get0_RSA(s->cert->pkeys[SSL_PKEY_RSA_ENC].privatekey);
+    rsa = EVP_PKEY_get0_RSA(s->cert->pkeys[SSL_PKEY_RSA].privatekey);
     if (rsa == NULL) {
         *al = SSL_AD_HANDSHAKE_FAILURE;
         SSLerr(SSL_F_TLS_PROCESS_CKE_RSA, SSL_R_MISSING_RSA_CERTIFICATE);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1601,7 +1601,7 @@ int tls1_process_sigalgs(SSL *s)
         if (SSL_IS_TLS13(s) && sigptr->sig == EVP_PKEY_RSA)
             continue;
         idx = tls12_get_pkey_idx(sigptr->sig);
-        if (idx > 0 && pmd[idx] == NULL) {
+        if (idx >= 0 && pmd[idx] == NULL) {
             md = ssl_md(sigptr->hash_idx);
             pmd[idx] = md;
             pvalid[idx] = CERT_PKEY_EXPLICIT_SIGN;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This replaces the SSL_PKEY_RSA_ENC and SSL_PKEY_RSA_SIGN certificate and private key types with SSL_PKEY_RSA instead. This was only ever partly implemented (SSL_PKEY_RSA_SIGN was always NULL): for signing it checked to see if RSA_PKEY_RSA_SIGN was present (which it never would be) and then tried SSL_PKEY_RSA_ENC.