### PR TITLE
perlasm/x86_64-xlate.pl: recognise .cfi_[start|end]proc directives.

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -633,7 +633,7 @@ my %globals;
 	my	$self = {};
 	my	$ret;
 
-	if ($$line =~ s/^\s*\.cfi_(\w+)\s+//) {
+	if ($$line =~ s/^\s*\.cfi_(\w+)\s*//) {
 	    bless $self,$class;
 	    $ret = $self;
 	    undef $self->{value};


### PR DESCRIPTION
The regexp for matching CFI directives required whitespace after the
directive. However, `.cfi_startproc` and `.cfi_endproc` don't have a
following argument and thus probably don't have trailing whitespace and
so weren't being recognised. This meant that `$cfi_rsp` wasn't being set
and so the offsets from `.cfi_push` were wrong.