### PR TITLE
test_rehash does nothing, have it do something

### DIFF
--- a/test/recipes/40-test_rehash.t
+++ b/test/recipes/40-test_rehash.t
@@ -14,7 +14,7 @@ use File::Spec::Functions;
 use File::Copy;
 use File::Basename;
 use if $^O ne "VMS", 'File::Glob' => qw/glob/;
-use OpenSSL::Test qw/:DEFAULT bldtop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_rehash");
 
@@ -58,16 +58,39 @@ indir "rehash.$$" => sub {
 }, create => 1, cleanup => 1;
 
 sub prepare {
-    my @sourcefiles =
-        sort map { glob(bldtop_file('certs', 'demo', "*.$_")) } ('pem',
-                                                                 'crt',
-                                                                 'cer',
-                                                                 'crl');
+    my @pemsourcefiles = sort glob(srctop_file('test', "*.pem"));
     my @destfiles = ();
-    foreach (@sourcefiles) {
-        copy($_, curdir());
-        push @destfiles, catfile(curdir(), basename($_));
+
+    die "There are no source files\n" if scalar @pemsourcefiles == 0;
+
+    my $cnt = 0;
+    foreach (@pemsourcefiles) {
+        my $basename = basename($_, ".pem");
+        my $writing = 0;
+
+        open PEM, $_ or die "Can't read $_: $!\n";
+        while (my $line = <PEM>) {
+            if ($line =~ m{^-----BEGIN (?:CERTIFICATE|X509 CRL)-----}) {
+                die "New start in a PEM blob?\n" if $writing;
+                $cnt++;
+                my $destfile =
+                    catfile(curdir(),
+                            $basename . sprintf("-%02d", $cnt) . ".pem");
+                push @destfiles, $destfile;
+                open OUT, '>', $destfile
+                    or die "Can't write $destfile\n";
+                $writing = 1;
+            }
+            print OUT $line if $writing;
+            if ($line =~ m|^-----END |) {
+                close OUT if $writing;
+                $writing = 0;
+            }
+        }
+        die "No end marker in $basename\n" if $writing;
     }
+    die "No test PEM files produced\n" if $cnt == 0;
+
     foreach (@_) {
         die "Internal error, argument is not CODE"
             unless (ref($_) eq 'CODE');


### PR DESCRIPTION
test/recipes/40-test_rehash.t uses test files from certs/demo, which
doesn't exist any longer.  Have it use PEM files from test/ instead.

Because rehash wants only one certificate or CRL per file, we must
also filter those PEM files to produce test files with a single object
each.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Fixes #2593