### PR TITLE
Restore the test coverage of COMP_rle and SSL_COMP_add_compression_me…

### DIFF
--- a/ssl/ssltest.c
+++ b/ssl/ssltest.c
@@ -1239,13 +1239,21 @@ int main(int argc, char *argv[])
         } else if (strcmp(*argv, "-time") == 0) {
             print_time = 1;
         }
-#ifndef OPENSSL_NO_COMP
         else if (strcmp(*argv, "-zlib") == 0) {
+#ifndef OPENSSL_NO_COMP
             comp = COMP_ZLIB;
-        } else if (strcmp(*argv, "-rle") == 0) {
-            comp = COMP_RLE;
-        }
+#else
+            fprintf(stderr,
+                    "ignoring -zlib, since I'm compiled without COMP\n");
 #endif
+        } else if (strcmp(*argv, "-rle") == 0) {
+#ifndef OPENSSL_NO_COMP
+            comp = COMP_RLE;
+#else
+            fprintf(stderr,
+                    "ignoring -rle, since I'm compiled without COMP\n");
+#endif
+        }
         else if (strcmp(*argv, "-named_curve") == 0) {
             if (--argc < 1)
                 goto bad;


### PR DESCRIPTION
This PR restores test coverage for the COMP_rle and SSL_COMP_add_compression_method.

It turned out that also the simplistic COMP_rle stuff was actually not working,
because it was unable to compress/decompress zero byte messages.

I did this for the 1.0.2-branch only at this time.

I have the impression, that it is impossible to write a test case for the SSL_COMP_add_compression_method in the 1.1.0 branch, because the
you cannot create an object of type COMP_METHOD any more, because
the structure type is now opaque.

I think it would be better to make the SSL_COMP_add_compression_method
return 1 (error) unconditionally in trunk and 1.1.0 branch.