### PR TITLE
Prevent potential OOB memory access in secure heap implementation if a custom allocator is used

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -356,6 +356,10 @@ static int sh_init(size_t size, int minsize)
     sh.minsize = minsize;
     sh.bittable_size = (sh.arena_size / sh.minsize) * 2;
 
+    /* Prevent allocations of size 0 later on */
+    if (sh.bittable_size >> 3 == 0)
+        goto err;
+
     sh.freelist_size = -1;
     for (i = sh.bittable_size; i; i >>= 1)
         sh.freelist_size++;


### PR DESCRIPTION
Prevent allocations of size 0 in sh_init, which are not possible with the default ```OPENSSL_zalloc```, but are possible if the user has installed their own allocator using ```CRYPTO_set_mem_functions```. If the 0-allocations succeeds, the secure heap code will later access (at least) the first byte of that space, which is technically an OOB access. This could lead to problems with some custom allocators that only return a valid pointer for subsequent free()-ing, and do not expect that the pointer is actually dereferenced.

An allocation of 0 is attempted if ```size``` is twice the value of ```minsize```, for example:

```c
CRYPTO_secure_malloc_init(4096, 2048)
```
