### PR TITLE
Make the SSL_COMP_add_compression_method a no-op instead of fixing it

### DIFF
--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -27,6 +27,7 @@ SSL_COMP_add_compression_method() adds the compression method B<cm> with
 the identifier B<id> to the list of available compression methods. This
 list is globally maintained for all SSL operations within this application.
 It cannot be set for specific SSL_CTX or SSL objects.
+From OpenSSL 1.1.0 calling this function does nothing.
 
 SSL_COMP_get_compression_methods() returns a stack of all of the available
 compression methods or NULL on error.

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1822,51 +1822,7 @@ void ssl_comp_free_compression_methods_int(void)
 
 int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm)
 {
-    SSL_COMP *comp;
-
-    if (cm == NULL || COMP_get_type(cm) == NID_undef)
-        return 1;
-
-    /*-
-     * According to draft-ietf-tls-compression-04.txt, the
-     * compression number ranges should be the following:
-     *
-     *   0 to  63:  methods defined by the IETF
-     *  64 to 192:  external party methods assigned by IANA
-     * 193 to 255:  reserved for private use
-     */
-    if (id < 193 || id > 255) {
-        SSLerr(SSL_F_SSL_COMP_ADD_COMPRESSION_METHOD,
-               SSL_R_COMPRESSION_ID_NOT_WITHIN_PRIVATE_RANGE);
-        return 0;
-    }
-
-    CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE);
-    comp = OPENSSL_malloc(sizeof(*comp));
-    if (comp == NULL) {
-        CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
-        SSLerr(SSL_F_SSL_COMP_ADD_COMPRESSION_METHOD, ERR_R_MALLOC_FAILURE);
-        return (1);
-    }
-
-    comp->id = id;
-    comp->method = cm;
-    load_builtin_compressions();
-    if (ssl_comp_methods && sk_SSL_COMP_find(ssl_comp_methods, comp) >= 0) {
-        OPENSSL_free(comp);
-        CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
-        SSLerr(SSL_F_SSL_COMP_ADD_COMPRESSION_METHOD,
-               SSL_R_DUPLICATE_COMPRESSION_ID);
-        return (1);
-    }
-    if (ssl_comp_methods == NULL || !sk_SSL_COMP_push(ssl_comp_methods, comp)) {
-        OPENSSL_free(comp);
-        CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
-        SSLerr(SSL_F_SSL_COMP_ADD_COMPRESSION_METHOD, ERR_R_MALLOC_FAILURE);
-        return (1);
-    }
-    CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
-    return (0);
+    return 1;
 }
 #endif
 


### PR DESCRIPTION
Note: current implementation is bogus and moreover it is impossible by
design to create custom compression methods in application code,
because the structure type COMP_METHOD is now opaque.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

