### PR TITLE
Fix i2d_SSL_SESSION pp output parameter should point to end of asn1 data

### DIFF
--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -281,8 +281,8 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
         goto err;
     }
 
-    p = as->cipher->data;
-    id = 0x03000000L | ((unsigned long)p[0] << 8L) | (unsigned long)p[1];
+    id = 0x03000000L | ((unsigned long)as->cipher->data[0] << 8L)
+                     | (unsigned long)as->cipher->data[1];
 
     ret->cipher_id = id;
     ret->cipher = ssl3_get_cipher_by_id(id);


### PR DESCRIPTION
The value p is still used on success, for *pp = p;