### PR TITLE
Remove unnecessary memset after PR #2583

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -501,7 +501,6 @@ int ssl_get_prev_session(SSL *s, CLIENTHELLO_MSG *hello, int *al)
         SSL_SESSION data;
 
         data.ssl_version = s->version;
-        memset(data.session_id, 0, sizeof(data.session_id));
         memcpy(data.session_id, hello->session_id, hello->session_id_len);
         data.session_id_length = hello->session_id_len;
 


### PR DESCRIPTION
Remove unnecessary memset after PR #2583 avoids accessing the uninitialized
data after the session_id_length now.

This seems to be a previous attempt to fix the uninitialized session_id.