### PR TITLE
ARMv4 assembly pack: harmonize Thumb-ification of iOS build.

### DIFF
--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -59,9 +59,12 @@ $code=<<___;
 .text
 ___
 $code.=".arch	armv8-a+crypto\n"			if ($flavour =~ /64/);
-$code.=".arch	armv7-a\n.fpu	neon\n.code	32\n"	if ($flavour !~ /64/);
-		#^^^^^^ this is done to simplify adoption by not depending
-		#	on latest binutils.
+$code.=<<___						if ($flavour !~ /64/);
+.arch	armv7-a	// don't confuse not-so-latest binutils with argv8 :-)
+.fpu	neon
+.code	32
+#undef	__thumb2__
+___
 
 # Assembler mnemonics are an eclectic mix of 32- and 64-bit syntax,
 # NEON is mostly 32-bit mnemonics, integer - mostly 64. Goal is to

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -111,6 +111,24 @@ void OPENSSL_cpuid_setup(void)
         return;
     }
 
+# if defined(__APPLE__) && !defined(__aarch64__)
+    /*
+     * Capability probing by catching SIGILL appears to be problematic
+     * on iOS. But since Apple universe is "monocultural", it's actually
+     * possible to simply set pre-defined processor capability mask.
+     */
+    if (1) {
+        OPENSSL_armcap_P = ARMV7_NEON;
+        return;
+    }
+    /*
+     * One could do same even for __aarch64__ iOS builds. It's not done
+     * exclusively for reasons of keeping code unified across platforms.
+     * Unified code works because it never triggers SIGILL on Apple
+     * devices...
+     */
+# endif
+
     sigfillset(&all_masked);
     sigdelset(&all_masked, SIGILL);
     sigdelset(&all_masked, SIGTRAP);

--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -27,6 +27,7 @@ $code.=<<___;
 .thumb
 #else
 .code	32
+#undef	__thumb2__
 #endif
 
 .align	5

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -67,7 +67,11 @@ $code=<<___;
 .text
 ___
 $code.=".arch	armv8-a+crypto\n"	if ($flavour =~ /64/);
-$code.=".fpu	neon\n.code	32\n"	if ($flavour !~ /64/);
+$code.=<<___				if ($flavour !~ /64/);
+.fpu	neon
+.code	32
+#undef	__thumb2__
+___
 
 ################################################################################
 # void gcm_init_v8(u128 Htable[16],const u64 H[2]);


### PR DESCRIPTION
Three modules were left behind in a285992763f3961f69a8d86bf7dfff020a08cef9.

[skip ci]

Should fix #2601.
