### PR TITLE
Use TLSEXT_KEYNAME_LENGTH in tls_decrypt_ticket.

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1252,8 +1252,8 @@ TICKET_RETURN tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     }
     /* Attempt to decrypt session data */
     /* Move p after IV to start of encrypted ticket, update length */
-    p = etick + 16 + EVP_CIPHER_CTX_iv_length(ctx);
-    eticklen -= 16 + EVP_CIPHER_CTX_iv_length(ctx);
+    p = etick + TLSEXT_KEYNAME_LENGTH + EVP_CIPHER_CTX_iv_length(ctx);
+    eticklen -= TLSEXT_KEYNAME_LENGTH + EVP_CIPHER_CTX_iv_length(ctx);
     sdec = OPENSSL_malloc(eticklen);
     if (sdec == NULL || EVP_DecryptUpdate(ctx, sdec, &slen, p,
                                           (int)eticklen) <= 0) {


### PR DESCRIPTION
Just use a define instead of a constant.
Should work at least for 1.1.0 & master.