### PR TITLE
Server cert tidy

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2256,6 +2256,7 @@ int ERR_load_SSL_strings(void);
 # define SSL_F_TLS1_PRF                                   284
 # define SSL_F_TLS1_SETUP_KEY_BLOCK                       211
 # define SSL_F_TLS1_SET_SERVER_SIGALGS                    335
+# define SSL_F_TLS_CHOOSE_SIGALG                          510
 # define SSL_F_TLS_CLIENT_KEY_EXCHANGE_POST_WORK          354
 # define SSL_F_TLS_COLLECT_EXTENSIONS                     435
 # define SSL_F_TLS_CONSTRUCT_CERTIFICATE_REQUEST          372

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3137,12 +3137,11 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 
     case SSL_CTRL_SET_CURRENT_CERT:
         if (larg == SSL_CERT_SET_SERVER) {
-            CERT_PKEY *cpk;
             const SSL_CIPHER *cipher;
             if (!s->server)
                 return 0;
             cipher = s->s3->tmp.new_cipher;
-            if (!cipher)
+            if (cipher == NULL)
                 return 0;
             /*
              * No certificate for unauthenticated ciphersuites or using SRP
@@ -3150,10 +3149,9 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
              */
             if (cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
                 return 2;
-            cpk = ssl_get_server_send_pkey(s);
-            if (!cpk)
+            if (s->s3->tmp.cert_idx == -1)
                 return 0;
-            s->cert->key = cpk;
+            s->cert->key = &s->cert->pkeys[s->s3->tmp.cert_idx];
             return 1;
         }
         return ssl_cert_set_current(s->cert, larg);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3149,9 +3149,9 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
              */
             if (cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
                 return 2;
-            if (s->s3->tmp.cert_idx == -1)
+            if (s->s3->tmp.cert == NULL)
                 return 0;
-            s->cert->key = &s->cert->pkeys[s->s3->tmp.cert_idx];
+            s->cert->key = s->s3->tmp.cert;
             return 1;
         }
         return ssl_cert_set_current(s->cert, larg);

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -260,6 +260,7 @@ static ERR_STRING_DATA SSL_str_functs[] = {
     {ERR_FUNC(SSL_F_TLS1_PRF), "tls1_PRF"},
     {ERR_FUNC(SSL_F_TLS1_SETUP_KEY_BLOCK), "tls1_setup_key_block"},
     {ERR_FUNC(SSL_F_TLS1_SET_SERVER_SIGALGS), "tls1_set_server_sigalgs"},
+    {ERR_FUNC(SSL_F_TLS_CHOOSE_SIGALG), "tls_choose_sigalg"},
     {ERR_FUNC(SSL_F_TLS_CLIENT_KEY_EXCHANGE_POST_WORK),
      "tls_client_key_exchange_post_work"},
     {ERR_FUNC(SSL_F_TLS_COLLECT_EXTENSIONS), "tls_collect_extensions"},

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2836,20 +2836,14 @@ int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL *s)
 int ssl_get_server_cert_serverinfo(SSL *s, const unsigned char **serverinfo,
                                    size_t *serverinfo_length)
 {
-    CERT *c = NULL;
-    int i = 0;
+    CERT_PKEY *cpk = s->s3->tmp.cert;
     *serverinfo_length = 0;
 
-    c = s->cert;
-    i = s->s3->tmp.cert_idx;
-
-    if (i == -1)
-        return 0;
-    if (c->pkeys[i].serverinfo == NULL)
+    if (cpk == NULL || cpk->serverinfo == NULL)
         return 0;
 
-    *serverinfo = c->pkeys[i].serverinfo;
-    *serverinfo_length = c->pkeys[i].serverinfo_length;
+    *serverinfo = cpk->serverinfo;
+    *serverinfo_length = cpk->serverinfo_length;
     return 1;
 }
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1947,6 +1947,15 @@ struct openssl_ssl_test_functions {
 
 const char *ssl_protocol_to_string(int version);
 
+/* Returns true if certificate and private key for 'idx' are present */
+static ossl_inline int ssl_has_cert(const SSL *s, int idx)
+{
+    if (idx < 0 || idx >= SSL_PKEY_NUM)
+        return 0;
+    return s->cert->pkeys[idx].x509 != NULL
+        && s->cert->pkeys[idx].privatekey != NULL;
+}
+
 # ifndef OPENSSL_UNIT_TEST
 
 void ssl_clear_cipher_ctx(SSL *s);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2274,7 +2274,7 @@ __owur int ssl_security_cert(SSL *s, SSL_CTX *ctx, X509 *x, int vfy, int is_ee);
 __owur int ssl_security_cert_chain(SSL *s, STACK_OF(X509) *sk, X509 *ex,
                                    int vfy);
 
-int tls_choose_sigalg(SSL *s);
+int tls_choose_sigalg(SSL *s, int *al);
 
 __owur EVP_MD_CTX *ssl_replace_hash(EVP_MD_CTX **hash, const EVP_MD *md);
 void ssl_clear_hash_ctx(EVP_MD_CTX **hash);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2009,12 +2009,9 @@ __owur int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid,
 int ssl_undefined_function(SSL *s);
 __owur int ssl_undefined_void_function(void);
 __owur int ssl_undefined_const_function(const SSL *s);
-__owur CERT_PKEY *ssl_get_server_send_pkey(SSL *s);
 __owur int ssl_get_server_cert_serverinfo(SSL *s,
                                           const unsigned char **serverinfo,
                                           size_t *serverinfo_length);
-__owur EVP_PKEY *ssl_get_sign_pkey(SSL *s, const SSL_CIPHER *c,
-                                   const EVP_MD **pmd);
 __owur int ssl_cert_type(const X509 *x, const EVP_PKEY *pkey);
 void ssl_set_masks(SSL *s);
 __owur STACK_OF(SSL_CIPHER) *ssl_get_ciphers_by_id(SSL *s);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2283,6 +2283,7 @@ __owur int tls12_copy_sigalgs(SSL *s, WPACKET *pkt,
                               const uint16_t *psig, size_t psiglen);
 __owur int tls1_save_sigalgs(SSL *s, PACKET *pkt);
 __owur int tls1_process_sigalgs(SSL *s);
+__owur int tls1_set_peer_legacy_sigalg(SSL *s, const EVP_PKEY *pkey);
 __owur size_t tls12_get_psigalgs(SSL *s, int sent, const uint16_t **psigs);
 __owur int tls12_check_peer_sigalg(SSL *s, uint16_t, EVP_PKEY *pkey);
 void ssl_set_client_disabled(SSL *s);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1210,6 +1210,8 @@ typedef struct sigalg_lookup_st {
     int curve;
 } SIGALG_LOOKUP;
 
+typedef struct cert_pkey_st CERT_PKEY;
+
 typedef struct ssl3_state_st {
     long flags;
     size_t read_mac_secret_size;
@@ -1293,8 +1295,8 @@ typedef struct ssl3_state_st {
 # endif
         /* Signature algorithm we actually use */
         const SIGALG_LOOKUP *sigalg;
-        /* Index of certificate we use */
-        int cert_idx;
+        /* Pointer to certificate we use */
+        CERT_PKEY *cert;
         /*
          * signature algorithms peer reports: e.g. supported signature
          * algorithms extension for server or as part of a certificate
@@ -1488,7 +1490,7 @@ typedef struct dtls1_state_st {
 #  define NAMED_CURVE_TYPE           3
 # endif                         /* OPENSSL_NO_EC */
 
-typedef struct cert_pkey_st {
+struct cert_pkey_st {
     X509 *x509;
     EVP_PKEY *privatekey;
     /* Chain for this certificate */
@@ -1502,7 +1504,7 @@ typedef struct cert_pkey_st {
      */
     unsigned char *serverinfo;
     size_t serverinfo_length;
-} CERT_PKEY;
+};
 /* Retrieve Suite B flags */
 # define tls1_suiteb(s)  (s->cert->cert_flags & SSL_CERT_FLAG_SUITEB_128_LOS)
 /* Uses to check strict mode: suite B modes are always strict */

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1981,15 +1981,15 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
                 al = SSL_AD_DECODE_ERROR;
                 goto err;
             }
-            md = ssl_md(s->s3->tmp.peer_sigalg->hash_idx);
 #ifdef SSL_DEBUG
             fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
 #endif
-        } else if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA) {
-            md = EVP_md5_sha1();
-        } else {
-            md = EVP_sha1();
+        } else if (!tls1_set_peer_legacy_sigalg(s, pkey)) {
+            al = SSL_AD_INTERNAL_ERROR;
+            goto err;
         }
+
+        md = ssl_md(s->s3->tmp.peer_sigalg->hash_idx);
 
         if (!PACKET_get_length_prefixed_2(pkt, &signature)
             || PACKET_remaining(pkt) != 0) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -331,20 +331,15 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
                 al = SSL_AD_DECODE_ERROR;
                 goto f_err;
             }
-            md = ssl_md(s->s3->tmp.peer_sigalg->hash_idx);
 #ifdef SSL_DEBUG
             fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
 #endif
-        } else {
-            /* Use default digest for this key type */
-            int idx = ssl_cert_type(NULL, pkey);
-            if (idx >= 0)
-                md = s->s3->tmp.md[idx];
-            if (md == NULL) {
+        } else if (!tls1_set_peer_legacy_sigalg(s, pkey)) {
                 al = SSL_AD_INTERNAL_ERROR;
                 goto f_err;
-            }
         }
+
+        md = ssl_md(s->s3->tmp.peer_sigalg->hash_idx);
 
         if (!PACKET_get_net_2(pkt, &len)) {
             SSLerr(SSL_F_TLS_PROCESS_CERT_VERIFY, SSL_R_LENGTH_MISMATCH);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1736,12 +1736,12 @@ static int tls_handle_status_request(SSL *s, int *al)
         int ret;
 
         /* If no certificate can't return certificate status */
-        if (s->s3->tmp.cert_idx != -1) {
+        if (s->s3->tmp.cert != NULL) {
             /*
              * Set current certificate to one we will use so SSL_get_certificate
              * et al can pick it up.
              */
-            s->cert->key = &s->cert->pkeys[s->s3->tmp.cert_idx];
+            s->cert->key = s->s3->tmp.cert;
             ret = s->ctx->ext.status_cb(s, s->ctx->ext.status_arg);
             switch (ret) {
                 /* We don't want to send a status request response */
@@ -2225,7 +2225,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
 
     /* not anonymous */
     if (lu != NULL) {
-        EVP_PKEY *pkey = s->cert->pkeys[s->s3->tmp.cert_idx].privatekey;
+        EVP_PKEY *pkey = s->s3->tmp.cert->privatekey;
         const EVP_MD *md = ssl_md(lu->hash_idx);
         unsigned char *sigbytes1, *sigbytes2;
         size_t siglen;
@@ -3173,14 +3173,13 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
 
 int tls_construct_server_certificate(SSL *s, WPACKET *pkt)
 {
-    CERT_PKEY *cpk;
+    CERT_PKEY *cpk = s->s3->tmp.cert;
     int al = SSL_AD_INTERNAL_ERROR;
 
-    if (s->s3->tmp.cert_idx == -1) {
+    if (cpk == NULL) {
         SSLerr(SSL_F_TLS_CONSTRUCT_SERVER_CERTIFICATE, ERR_R_INTERNAL_ERROR);
         return 0;
     }
-    cpk = &s->cert->pkeys[s->s3->tmp.cert_idx];
 
     /*
      * In TLSv1.3 the certificate chain is always preceded by a 0 length context

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1797,12 +1797,8 @@ WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst)
                 goto f_err;
             }
             s->s3->tmp.new_cipher = cipher;
-            if (!tls_choose_sigalg(s)) {
-                al = SSL_AD_HANDSHAKE_FAILURE;
-                SSLerr(SSL_F_TLS_POST_PROCESS_CLIENT_HELLO,
-                       SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM);
+            if (!tls_choose_sigalg(s, &al))
                 goto f_err;
-            }
             /* check whether we should disable session resumption */
             if (s->not_resumable_session_cb != NULL)
                 s->session->not_resumable =

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1734,15 +1734,14 @@ static int tls_handle_status_request(SSL *s, int *al)
     if (s->ext.status_type != TLSEXT_STATUSTYPE_nothing && s->ctx != NULL
             && s->ctx->ext.status_cb != NULL) {
         int ret;
-        CERT_PKEY *certpkey = ssl_get_server_send_pkey(s);
 
         /* If no certificate can't return certificate status */
-        if (certpkey != NULL) {
+        if (s->s3->tmp.cert_idx != -1) {
             /*
              * Set current certificate to one we will use so SSL_get_certificate
              * et al can pick it up.
              */
-            s->cert->key = certpkey;
+            s->cert->key = &s->cert->pkeys[s->s3->tmp.cert_idx];
             ret = s->ctx->ext.status_cb(s, s->ctx->ext.status_arg);
             switch (ret) {
                 /* We don't want to send a status request response */
@@ -2133,11 +2132,12 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
 
     if (!(s->s3->tmp.new_cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
         && !(s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK)) {
-        if ((pkey = ssl_get_sign_pkey(s, s->s3->tmp.new_cipher, &md))
-            == NULL) {
+        if (s->s3->tmp.cert_idx == -1 || s->s3->tmp.sigalg == NULL) {
             al = SSL_AD_DECODE_ERROR;
             goto f_err;
         }
+        pkey = s->cert->pkeys[s->s3->tmp.cert_idx].privatekey;
+        md = ssl_md(s->s3->tmp.sigalg->hash_idx);
     } else {
         pkey = NULL;
     }
@@ -3190,11 +3190,11 @@ int tls_construct_server_certificate(SSL *s, WPACKET *pkt)
     CERT_PKEY *cpk;
     int al = SSL_AD_INTERNAL_ERROR;
 
-    cpk = ssl_get_server_send_pkey(s);
-    if (cpk == NULL) {
+    if (s->s3->tmp.cert_idx == -1) {
         SSLerr(SSL_F_TLS_CONSTRUCT_SERVER_CERTIFICATE, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+    cpk = &s->cert->pkeys[s->s3->tmp.cert_idx];
 
     /*
      * In TLSv1.3 the certificate chain is always preceded by a 0 length context

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2201,11 +2201,9 @@ DH *ssl_get_auto_dh(SSL *s)
         else
             dh_secbits = 80;
     } else {
-        CERT_PKEY *cpk;
-        if (s->s3->tmp.cert_idx == -1)
+        if (s->s3->tmp.cert == NULL)
             return NULL;
-        cpk = &s->cert->pkeys[s->s3->tmp.cert_idx];
-        dh_secbits = EVP_PKEY_security_bits(cpk->privatekey);
+        dh_secbits = EVP_PKEY_security_bits(s->s3->tmp.cert->privatekey);
     }
 
     if (dh_secbits >= 128) {
@@ -2369,7 +2367,7 @@ int tls_choose_sigalg(SSL *s, int *al)
         idx = ssl_cipher_get_cert_index(s->s3->tmp.new_cipher);
         /* If no certificate for ciphersuite return */
         if (idx == -1) {
-            s->s3->tmp.cert_idx = -1;
+            s->s3->tmp.cert = NULL;
             s->s3->tmp.sigalg = NULL;
             return 1;
         }
@@ -2445,7 +2443,7 @@ int tls_choose_sigalg(SSL *s, int *al)
             }
         }
     }
-    s->s3->tmp.cert_idx = idx;
+    s->s3->tmp.cert = &s->cert->pkeys[idx];
     s->s3->tmp.sigalg = lu;
     return 1;
 }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2268,7 +2268,7 @@ int ssl_security_cert_chain(SSL *s, STACK_OF(X509) *sk, X509 *x, int vfy)
  * Choose an appropriate signature algorithm based on available certificates
  * Set current certificate and digest to match chosen algorithm.
  */
-int tls_choose_sigalg(SSL *s)
+int tls_choose_sigalg(SSL *s, int *al)
 {
     if (SSL_IS_TLS13(s)) {
         size_t i;
@@ -2312,6 +2312,8 @@ int tls_choose_sigalg(SSL *s)
             s->cert->key = s->cert->pkeys + idx;
             return 1;
         }
+        *al = SSL_AD_HANDSHAKE_FAILURE;
+        SSLerr(SSL_F_TLS_CHOOSE_SIGALG, SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM);
         return 0;
     }
     /*

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2201,7 +2201,10 @@ DH *ssl_get_auto_dh(SSL *s)
         else
             dh_secbits = 80;
     } else {
-        CERT_PKEY *cpk = ssl_get_server_send_pkey(s);
+        CERT_PKEY *cpk;
+        if (s->s3->tmp.cert_idx == -1)
+            return NULL;
+        cpk = &s->cert->pkeys[s->s3->tmp.cert_idx];
         dh_secbits = EVP_PKEY_security_bits(cpk->privatekey);
     }
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -917,7 +917,7 @@ int tls12_check_peer_sigalg(SSL *s, uint16_t sig, EVP_PKEY *pkey)
         if (SSL_IS_TLS13(s)) {
             /* For TLS 1.3 check curve matches signature algorithm */
 
-            if (curve != lu->curve) {
+            if (lu->curve != NID_undef && curve != lu->curve) {
                 SSLerr(SSL_F_TLS12_CHECK_PEER_SIGALG, SSL_R_WRONG_CURVE);
                 return 0;
             }
@@ -2348,7 +2348,7 @@ int tls_choose_sigalg(SSL *s, int *al)
 
                     curve = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
                 }
-                if (curve != lu->curve)
+                if (lu->curve != NID_undef && curve != lu->curve)
                     continue;
 #else
                 continue;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This PR simplifies server certificate signature algorithm and certificate handling. The function tls_choose_sigalg() is extended to choose the appropriate signature algorithm and certificate for all versions of TLS. For TLS 1.1 and below the signature algorithm is fixed by the ciphersuite.

The corresponding TLS code is updated to use the set signature algorithm instead of having special cases for each version/algorithm.

Some additional simplification will be possible when something similar is done for client auth but that's for another PR.