### PR TITLE
Make -xcert work again.

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -944,6 +944,7 @@ int args_excert(int opt, SSL_EXCERT **pexc)
             BIO_printf(bio_err, "%s: Error adding xcert\n", opt_getprog());
             goto err;
         }
+        *pexc = exc;
         exc->certfile = opt_arg();
         break;
     case OPT_X_KEY:


### PR DESCRIPTION
When a certificate is prepended update the list pointer.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
##### Description of change
<!-- Provide a description of the changes.
If it fixes a github issue, add Fixes #XXXX.
-->

This fixes the -xcert option to s_client/s_server. 