### PR TITLE
Use memcmp() instead of CRYPTO_memcmp() when fuzzing

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -313,26 +313,15 @@ void OPENSSL_die(const char *message, const char *file, int line)
 }
 
 #if !defined(OPENSSL_CPUID_OBJ)
-/* volatile unsigned char* pointers are there because
- * 1. Accessing a variable declared volatile via a pointer
- *    that lacks a volatile qualifier causes undefined behavior.
- * 2. When the variable itself is not volatile the compiler is
- *    not required to keep all those reads and can convert
- *    this into canonical memcmp() which doesn't read the whole block.
- * Pointers to volatile resolve the first problem fully. The second
- * problem cannot be resolved in any Standard-compliant way but this
- * works the problem around. Compilers typically react to
- * pointers to volatile by preserving the reads and writes through them.
- * The latter is not required by the Standard if the memory pointed to
- * is not volatile.
- * Pointers themselves are volatile in the function signature to work
- * around a subtle bug in gcc 4.6+ which causes writes through
- * pointers to volatile to not be emitted in some rare,
- * never needed in real life, pieces of code.
+/*
+ * The volatile is used to to ensure that the compiler generates code that reads
+ * all values from the array and doesn't try to optimize this away. The standard
+ * doesn't actually require this behavior if the original data pointed to is
+ * not volatile, but compilers do this in practice anyway.
+ *
+ * There are also assembler versions of this function.
  */
-int CRYPTO_memcmp(const volatile void * volatile in_a,
-                  const volatile void * volatile in_b,
-                  size_t len)
+int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len)
 {
     size_t i;
     const volatile unsigned char *a = in_a;

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -321,6 +321,7 @@ void OPENSSL_die(const char *message, const char *file, int line)
  *
  * There are also assembler versions of this function.
  */
+# undef CRYPTO_memcmp
 int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len)
 {
     size_t i;

--- a/e_os.h
+++ b/e_os.h
@@ -513,6 +513,10 @@ struct servent *getservbyname(const char *name, const char *proto);
 
 #define OSSL_NELEM(x)    (sizeof(x)/sizeof(x[0]))
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+# define CRYPTO_memcmp memcmp
+#endif
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -347,9 +347,7 @@ int OPENSSL_gmtime_diff(int *pday, int *psec,
  * into a defined order as the return value when a != b is undefined, other
  * than to be non-zero.
  */
-int CRYPTO_memcmp(const volatile void * volatile in_a,
-                  const volatile void * volatile in_b,
-                  size_t len);
+int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 
 /* Standard initialisation options */
 # define OPENSSL_INIT_NO_LOAD_CRYPTO_STRINGS 0x00000001L


### PR DESCRIPTION
I've been running the client and server fuzzer with this patch for a while and it's giving very good results, together with the patch that just landed in libfuzzer.

But I don't really like this patch, since it changed the public header. Does someone have a better idea how to do this? Note that we have assembler versions of CRYPTO_memcmp(), and I guess I prefer to have assembler enabled.