### PR TITLE
Rework error handling of custom_ext_meth_add towards strong exception safety

### DIFF
--- a/ssl/t1_ext.c
+++ b/ssl/t1_ext.c
@@ -179,12 +179,8 @@ static int custom_ext_meth_add(custom_ext_methods *exts,
     tmp = OPENSSL_realloc(exts->meths,
                           (exts->meths_count + 1) * sizeof(custom_ext_method));
 
-    if (tmp == NULL) {
-        OPENSSL_free(exts->meths);
-        exts->meths = NULL;
-        exts->meths_count = 0;
+    if (tmp == NULL)
         return 0;
-    }
 
     exts->meths = tmp;
     meth = exts->meths + exts->meths_count;


### PR DESCRIPTION
As discussed at PR #2625 the error handling here is surprising, and should be changed to
keep the current state intact on all errors.

This PR is for master and 1.1.0 branch.