### PR TITLE
Fix possible memory leak in cryptodev_digest_update.

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -810,14 +810,15 @@ static int cryptodev_digest_update(EVP_MD_CTX *ctx, const void *data,
 
     if (!(ctx->flags & EVP_MD_CTX_FLAG_ONESHOT)) {
         /* if application doesn't support one buffer */
-        state->mac_data =
+        char *mac_data =
             OPENSSL_realloc(state->mac_data, state->mac_len + count);
 
-        if (!state->mac_data) {
+        if (mac_data == NULL) {
             printf("cryptodev_digest_update: realloc failed\n");
             return (0);
         }
 
+        state->mac_data = mac_data;
         memcpy(state->mac_data + state->mac_len, data, count);
         state->mac_len += count;
 


### PR DESCRIPTION
This completely untested patch should fix the remaining issues from #2496,
Note: I have no OpenBSD, but the code in question is only compiled on some kind of BSD.
This is against OpenSSL_1_0_2-stable.