### PR TITLE
Fix a slightly confusing if condition in a2i_ASN1_INTEGER

### DIFF
--- a/crypto/asn1/f_int.c
+++ b/crypto/asn1/f_int.c
@@ -103,7 +103,7 @@ int a2i_ASN1_INTEGER(BIO *bp, ASN1_INTEGER *bs, char *buf, int size)
         bufp = (unsigned char *)buf;
         if (first) {
             first = 0;
-            if ((bufp[0] == '0') && (buf[1] == '0')) {
+            if ((bufp[0] == '0') && (bufp[1] == '0')) {
                 bufp += 2;
                 i -= 2;
             }


### PR DESCRIPTION
Note: buf and bufp are identical here, but the test looks odd to say the least.
This PR applies to all active branches.