### PR TITLE
Use _WIN32 over WIN32 for preprocessor conditional

### DIFF
--- a/crypto/seed/seed.c
+++ b/crypto/seed/seed.c
@@ -37,7 +37,7 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
-# ifdef WIN32
+# ifdef _WIN32
 #  include <memory.h>
 # endif
 


### PR DESCRIPTION
The intent seems to be that the WIN32 symbol is for things that are a direct
byproduct of being a windows-variant configuration and should be used for
feature en/disablement on windows systems.  Use of the _WIN32 symbol is more
widespread, being used to implement platform portability of more generic code.

We do define WIN32 in some situations in e_os.h, but that is not included
universally.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

