### PR TITLE
Change req_check_len error message in req.c, it also accepts passphrase of 20 bytes.

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1273,7 +1273,7 @@ static int req_check_len(int len, int n_min, int n_max)
     }
     if ((n_max >= 0) && (len > n_max)) {
         BIO_printf(bio_err,
-                   "string is too long, it needs to be less than  %d bytes long\n",
+                   "string is too long, it needs to be no more than %d bytes long\n",
                    n_max);
         return (0);
     }


### PR DESCRIPTION
##### Description of change
This PR changes the error message that is displayed when trying to use a passphrase longer than 20 bytes.

It is however possible to use a passphrase of exactly 20 bytes long.



