### PR TITLE
Fix a mem leak in ssl_test_ctx.c

### DIFF
--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -585,6 +585,7 @@ static void ssl_test_extra_conf_free_data(SSL_TEST_EXTRA_CONF *conf)
     OPENSSL_free(conf->client.alpn_protocols);
     OPENSSL_free(conf->server.alpn_protocols);
     OPENSSL_free(conf->server2.alpn_protocols);
+    OPENSSL_free(conf->client.reneg_ciphers);
 }
 
 static void ssl_test_ctx_free_extra_data(SSL_TEST_CTX *ctx)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
