### PR TITLE
Test x509 store api

### DIFF
--- a/test/README
+++ b/test/README
@@ -19,15 +19,17 @@ digit number and {name} is a unique name of your choice.
 
 The number {nn} is (somewhat loosely) grouped as follows:
 
-05  individual symmetric cipher algorithms
-10  math (bignum)
-15  individual asymmetric cipher algorithms
-20  openssl commands (some otherwise not tested)
-25  certificate forms, generation and verification
-30  engine and evp
-70  PACKET layer
-80  "larger" protocols (CA, CMS, OCSP, SSL, TSA)
-90  misc
+00-04  sanity, internal and essential API tests
+05-09  individual symmetric cipher algorithms
+10-14  math (bignum)
+15-19  individual asymmetric cipher algorithms
+20-24  openssl commands (some otherwise not tested)
+25-29  certificate forms, generation and verification
+30-35  engine and evp
+60-79  APIs
+   70  PACKET layer
+80-89  "larger" protocols (CA, CMS, OCSP, SSL, TSA)
+90-99  misc
 
 
 A recipe that just runs a test executable

--- a/test/recipes/60-test_x509_store.t
+++ b/test/recipes/60-test_x509_store.t
@@ -1,0 +1,48 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use File::Copy;
+use File::Spec::Functions qw/:DEFAULT canonpath/;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_x509_store");
+
+# We use 'openssl verify' for these tests, as it contains everything
+# we need to conduct these tests.  The tests here are a subset of the
+# ones found in 25-test_verify.t
+
+sub verify {
+    my ($cert, $purpose, $trustedpath, $untrusted, @opts) = @_;
+    my @args = qw(openssl verify -auth_level 1 -purpose);
+    my @path = qw(test certs);
+    push(@args, "$purpose", @opts);
+    push(@args, "-CApath", $trustedpath);
+    for (@$untrusted) { push(@args, "-untrusted", srctop_file(@path, "$_.pem")) }
+    push(@args, srctop_file(@path, "$cert.pem"));
+    run(app([@args]));
+}
+
+plan tests => 3;
+
+indir "60-test_x509_store" => sub {
+    for (("root-cert")) {
+        copy(srctop_file("test", "certs", "$_.pem"), curdir());
+    }
+    ok(run(app([qw(openssl rehash), curdir()])), "Rehashing");
+
+    # Canonical success
+    ok(verify("ee-cert", "sslserver", curdir(), ["ca-cert"], "-show_chain"),
+       "verify ee-cert");
+
+    # Failure because root cert not present in CApath
+    ok(!verify("ca-root2", "any", curdir(), [], "-show_chain"));
+}, create => 1, cleanup => 1;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

It turns out that we don't have any test of the `X509_STORE` / `X509_LOOKUP` API.  `openssl verify` uses that API when given `-CApath` and `-CAfile`, so this is a fairly simple test based on that command.