### PR TITLE
Fix tests with enable-dtls no-dtls1 no-dtls1_2

### DIFF
--- a/Configure
+++ b/Configure
@@ -838,6 +838,18 @@ while (@tocheckfor) {
     @tocheckfor = (keys %new_tocheckfor);
 }
 
+# Disable protocols with no supported versions
+my $present = 0;
+foreach (@tls) {
+    $present = 1 if (!$disabled{$_});
+}
+$disabled{"tls"} = "no versions enabled" if (!$present);
+$present = 0;
+foreach (@dtls) {
+    $present = 1 if (!$disabled{$_});
+}
+$disabled{"dtls"} = "no versions enabled" if (!$present);
+
 our $die = sub { die @_; };
 if ($target eq "TABLE") {
     local $die = sub { warn @_; };


### PR DESCRIPTION
In this (admittedly silly) configuration, we end up thinking that
we have DTLS enabled but there is nothing useful to do with it.
Most of the tests already do the right thing, e.g., in 80-test_ssl_new.t
we check for:
my $no_dtls = alldisabled(available_protocols("dtls"));
which is easy due to some nice perl tooling we have available.

However, in sslapitest, we don't easily have that fine granularity of
control, and in the aforementioned configuration, sslapitest will happily
attempt to run test_large_message_dtls(), which will go into the handshake
and call ssl_get_client_min_max_version() only to discover that there are
no versions available.

Instead of implementing a local fix, take a more abstract approach and
claim at a high level that the entire protocol family is disabled if
none of the available protocol versions are enabled.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
