### PR TITLE
Secure heap segmentation fault

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -351,6 +351,9 @@ static int sh_init(size_t size, int minsize)
         goto err;
     if (minsize <= 0 || (minsize & (minsize - 1)) != 0)
         goto err;
+
+    while (minsize < sizeof(SH_LIST))
+        minsize *= 2;
 
     sh.arena_size = size;
     sh.minsize = minsize;


### PR DESCRIPTION
The problem occurs when the minsize is less than sizeof(SH_LIST).

The sh_add_to_list function will overwrite subsequent slots in the free list for small allocations.  This causes a segmentation fault if the writes goes off the end of the secure memory.  I've not investigated if this problem can overwrite memory without the segmentation fault, but it seems likely.

This fix limits the minsize to the sizeof of the SH_LIST structure (which also has a side effect of properly aligning the pointers).  The alternative would be to return an error if minsize is too small.

Fixes #2630.
