### PR TITLE
use OSSLzu instead of lu format for size_t display

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -555,8 +555,8 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
     OPENSSL_strlcat(out_buf, magic, sizeof out_buf);
     OPENSSL_strlcat(out_buf, "$", sizeof out_buf);
     if (rounds_custom) {
-        char tmp_buf[7 + 9 + 1]; /* "rounds=999999999" */
-        sprintf(tmp_buf, "rounds=%lu", rounds);
+        char tmp_buf[80]; /* "rounds=999999999" */
+        sprintf(tmp_buf, "rounds=%"OSSLzu, rounds);
         OPENSSL_strlcat(out_buf, tmp_buf, sizeof out_buf);
         OPENSSL_strlcat(out_buf, "$", sizeof out_buf);
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
