### PR TITLE
Reduce Travis impact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ compiler:
     - gcc
 
 env:
-    - CONFIG_OPTS="" DESTDIR="_install"
-    - CONFIG_OPTS="--debug no-shared enable-crypto-mdebug enable-rc5 enable-md2"
+    - CONFIG_OPTS="" DESTDIR="_install" TESTS="-test_fuzz"
+    - CONFIG_OPTS="--debug no-shared enable-crypto-mdebug enable-rc5 enable-md2" TESTS="-test_fuzz"
     - CONFIG_OPTS="no-ec" BUILDONLY="yes"
 
 matrix:
@@ -43,7 +43,7 @@ matrix:
           env: CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers enable-external-tests no-shared -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" COVERALLS="yes" BORINGSSL_TESTS="yes" CXX="g++-5"
         - os: linux
           compiler: clang-3.6
-          env: CONFIG_OPTS="enable-msan"
+          env: CONFIG_OPTS="enable-msan" TESTS="-test_fuzz"
         - os: linux
           compiler: clang-3.6
           env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg -fno-sanitize=alignment no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
@@ -52,19 +52,19 @@ matrix:
           env: CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2 no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
         - os: linux
           compiler: gcc-5
-          env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC"
+          env: CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC" TESTS="-test_fuzz"
         - os: linux
           compiler: gcc-5
-          env: CONFIG_OPTS="--strict-warnings enable-tls1_3" COMMENT="Move to the BORINGTEST build when interoperable"
+          env: CONFIG_OPTS="--strict-warnings enable-tls1_3" COMMENT="Move to the BORINGTEST build when interoperable" TESTS="-test_fuzz"
         - os: linux
           compiler: i686-w64-mingw32-gcc
           env: CONFIG_OPTS="no-stdio" BUILDONLY="yes"
         - os: linux
           compiler: i686-w64-mingw32-gcc
-          env: CONFIG_OPTS="no-pic"
+          env: CONFIG_OPTS="no-pic" TESTS="-test_fuzz"
         - os: linux
           compiler: x86_64-w64-mingw32-gcc
-          env: CONFIG_OPTS="no-pic"
+          env: CONFIG_OPTS="no-pic" TESTS="-test_fuzz"
     exclude:
         - os: linux
           compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ compiler:
 
 env:
     - CONFIG_OPTS="" DESTDIR="_install" TESTS="-test_fuzz"
-    - CONFIG_OPTS="--debug no-shared enable-crypto-mdebug enable-rc5 enable-md2" TESTS="-test_fuzz"
+    - CONFIG_OPTS="--debug --strict-warnings no-shared enable-crypto-mdebug enable-rc5 enable-md2" TESTS="-test_fuzz"
     - CONFIG_OPTS="no-ec" BUILDONLY="yes"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ compiler:
 env:
     - CONFIG_OPTS="" DESTDIR="_install"
     - CONFIG_OPTS="--debug no-shared enable-crypto-mdebug enable-rc5 enable-md2"
-    - CONFIG_OPTS="no-pic --strict-warnings" BUILDONLY="yes" CHECKDOCS="yes"
-    - CONFIG_OPTS="no-engine no-shared --strict-warnings" BUILDONLY="yes"
-    - CONFIG_OPTS="no-stdio --strict-warnings" BUILDONLY="yes"
     - CONFIG_OPTS="no-ec" BUILDONLY="yes"
 
 matrix:


### PR DESCRIPTION

We have a machine running daily builds with a number of `no-` options.  There is no need to have them run in Travis as well.  Also, there is no need to run the fuzz corpus tests in *every* build.