### PR TITLE
Fix potential memory leak in ASN1_TIME_to_generalizedtime()

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -62,7 +62,7 @@ int ASN1_TIME_check(const ASN1_TIME *t)
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *t,
                                                    ASN1_GENERALIZEDTIME **out)
 {
-    ASN1_GENERALIZEDTIME *ret;
+    ASN1_GENERALIZEDTIME *ret = NULL;
     char *str;
     int newlen;
 
@@ -71,22 +71,20 @@ ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *t,
 
     if (out == NULL || *out == NULL) {
         if ((ret = ASN1_GENERALIZEDTIME_new()) == NULL)
-            return NULL;
-        if (out)
-            *out = ret;
+            goto err;
     } else
         ret = *out;
 
     /* If already GeneralizedTime just copy across */
     if (t->type == V_ASN1_GENERALIZEDTIME) {
         if (!ASN1_STRING_set(ret, t->data, t->length))
-            return NULL;
-        return ret;
+            goto err;
+        goto done;
     }
 
     /* grow the string */
     if (!ASN1_STRING_set(ret, NULL, t->length + 2))
-        return NULL;
+        goto err;
     /* ASN1_STRING_set() allocated 'len + 1' bytes. */
     newlen = t->length + 2 + 1;
     str = (char *)ret->data;
@@ -96,10 +94,19 @@ ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *t,
     else
         OPENSSL_strlcpy(str, "20", newlen);
 
-    OPENSSL_strlcat(str, (char *)t->data, newlen);
+    OPENSSL_strlcat(str, (const char *)t->data, newlen);
 
-    return ret;
+ done:
+   if (out != NULL && *out == NULL)
+       *out = ret;
+   return ret;
+
+ err:
+    if (out == NULL || *out != ret)
+        ASN1_GENERALIZEDTIME_free(ret);
+    return NULL;
 }
+
 
 int ASN1_TIME_set_string(ASN1_TIME *s, const char *str)
 {


### PR DESCRIPTION
If ret is allocated, it may be leaked on error.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
