### PR TITLE
X509 time: tighten validation per RFC 5280

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1754,119 +1754,70 @@ int X509_cmp_current_time(const ASN1_TIME *ctm)
 
 int X509_cmp_time(const ASN1_TIME *ctm, time_t *cmp_time)
 {
-    char *str;
-    ASN1_TIME atm;
-    long offset;
-    char buff1[24], buff2[24], *p;
-    int i, j, remaining;
+    static const size_t utctime_length = sizeof("YYMMDDHHMMSSZ") - 1;
+    static const size_t generalizedtime_length = sizeof("YYYYMMDDHHMMSSZ") - 1;
 
-    p = buff1;
-    remaining = ctm->length;
-    str = (char *)ctm->data;
+    ASN1_TIME atm;
+    unsigned char time1[24], time2[24];
+    int year, result;
+
     /*
-     * Note that the following (historical) code allows much more slack in the
-     * time format than RFC5280. In RFC5280, the representation is fixed:
+     * Note that ASN.1 allows much more slack in the time format than RFC5280.
+     * In RFC5280, the representation is fixed:
      * UTCTime: YYMMDDHHMMSSZ
      * GeneralizedTime: YYYYMMDDHHMMSSZ
+     *
+     * We do NOT currently enforce the following RFC 5280 requirement:
+     *
+     * CAs conforming to this profile MUST always encode certificate
+     * validity dates through the year 2049 as UTCTime; certificate validity
+     * dates in 2050 or later MUST be encoded as GeneralizedTime.
      */
-    if (ctm->type == V_ASN1_UTCTIME) {
-        /* YYMMDDHHMM[SS]Z or YYMMDDHHMM[SS](+-)hhmm */
-        int min_length = sizeof("YYMMDDHHMMZ") - 1;
-        int max_length = sizeof("YYMMDDHHMMSS+hhmm") - 1;
-        if (remaining < min_length || remaining > max_length)
+    switch (ctm->type) {
+    case V_ASN1_UTCTIME:
+        if (ctm->length != utctime_length)
             return 0;
-        memcpy(p, str, 10);
-        p += 10;
-        str += 10;
-        remaining -= 10;
-    } else {
-        /* YYYYMMDDHHMM[SS[.fff]]Z or YYYYMMDDHHMM[SS[.f[f[f]]]](+-)hhmm */
-        int min_length = sizeof("YYYYMMDDHHMMZ") - 1;
-        int max_length = sizeof("YYYYMMDDHHMMSS.fff+hhmm") - 1;
-        if (remaining < min_length || remaining > max_length)
-            return 0;
-        memcpy(p, str, 12);
-        p += 12;
-        str += 12;
-        remaining -= 12;
-    }
-
-    if ((*str == 'Z') || (*str == '-') || (*str == '+')) {
-        *(p++) = '0';
-        *(p++) = '0';
-    } else {
-        /* SS (seconds) */
-        if (remaining < 2)
-            return 0;
-        *(p++) = *(str++);
-        *(p++) = *(str++);
-        remaining -= 2;
         /*
-         * Skip any (up to three) fractional seconds...
-         * TODO(emilia): in RFC5280, fractional seconds are forbidden.
-         * Can we just kill them altogether?
+         * Years >= 50 are 19YY, years < 50 are 20YY.
+         * We verify all digits later; for now we assume they're in valid range.
          */
-        if (remaining && *str == '.') {
-            str++;
-            remaining--;
-            for (i = 0; i < 3 && remaining; i++, str++, remaining--) {
-                if (*str < '0' || *str > '9')
-                    break;
-            }
-        }
-
-    }
-    *(p++) = 'Z';
-    *(p++) = '\0';
-
-    /* We now need either a terminating 'Z' or an offset. */
-    if (!remaining)
+        year = (ctm->data[0] - '0') * 10 + ctm->data[1] - '0';
+        memcpy(time1, year >= 50 ? "19" : "20", 2);
+        memcpy(time1 + 2, ctm->data, ctm->length);
+        break;
+    case V_ASN1_GENERALIZEDTIME:
+        if (ctm->length != generalizedtime_length)
+            return 0;
+        memcpy(time1, ctm->data, ctm->length);
+        break;
+    default:
         return 0;
-    if (*str == 'Z') {
-        if (remaining != 1)
-            return 0;
-        offset = 0;
-    } else {
-        /* (+-)HHMM */
-        if ((*str != '+') && (*str != '-'))
-            return 0;
-        /* Historical behaviour: the (+-)hhmm offset is forbidden in RFC5280. */
-        if (remaining != 5)
-            return 0;
-        if (str[1] < '0' || str[1] > '9' || str[2] < '0' || str[2] > '9' ||
-            str[3] < '0' || str[3] > '9' || str[4] < '0' || str[4] > '9')
-            return 0;
-        offset = ((str[1] - '0') * 10 + (str[2] - '0')) * 60;
-        offset += (str[3] - '0') * 10 + (str[4] - '0');
-        if (*str == '-')
-            offset = -offset;
     }
-    atm.type = ctm->type;
-    atm.flags = 0;
-    atm.length = sizeof(buff2);
-    atm.data = (unsigned char *)buff2;
 
-    if (X509_time_adj(&atm, offset * 60, cmp_time) == NULL)
+    /**
+     * Now everything is in GeneralizedTime. We verify that the digits
+     * are in valid range; we don't verify that the date is valid.
+     */
+    for (size_t i = 0; i < generalizedtime_length - 1; i++) {
+        if (time1[i] < '0' || time1[i] > '9')
+            return 0;
+    }
+    if (time1[generalizedtime_length - 1] != 'Z')
         return 0;
 
-    if (ctm->type == V_ASN1_UTCTIME) {
-        i = (buff1[0] - '0') * 10 + (buff1[1] - '0');
-        if (i < 50)
-            i += 100;           /* cf. RFC 2459 */
-        j = (buff2[0] - '0') * 10 + (buff2[1] - '0');
-        if (j < 50)
-            j += 100;
+    memset(&atm, 0, sizeof(atm));
+    atm.type = V_ASN1_GENERALIZEDTIME;
+    atm.length = sizeof(time2);
+    atm.data = time2;
 
-        if (i < j)
-            return -1;
-        if (i > j)
-            return 1;
-    }
-    i = strcmp(buff1, buff2);
-    if (i == 0)                 /* wait a second then return younger :-) */
+    if (X509_time_adj(&atm, 0, cmp_time) == NULL)
+        return 0;
+
+    result = memcmp(time1, time2, generalizedtime_length);
+    if (result == 0)                 /* wait a second then return younger :-) */
         return -1;
     else
-        return i;
+        return result;
 }
 
 ASN1_TIME *X509_gmtime_adj(ASN1_TIME *s, long adj)

--- a/test/build.info
+++ b/test/build.info
@@ -28,7 +28,7 @@ IF[{- !$disabled{tests} -}]
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
-          pkey_meth_test uitest
+          pkey_meth_test uitest x509_time_test
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include
@@ -294,6 +294,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[pkey_meth_test]=pkey_meth_test.c testutil.c test_main.c
   INCLUDE[pkey_meth_test]=../include
   DEPEND[pkey_meth_test]=../libcrypto
+
+  SOURCE[x509_time_test]=x509_time_test.c testutil.c test_main.c
+  INCLUDE[x509_time_test]=.. ../include
+  DEPEND[x509_time_test]=../libcrypto
 
   IF[{- !$disabled{psk} -}]
     PROGRAMS_NO_INST=dtls_mtu_test

--- a/test/recipes/60-test_x509_time.t
+++ b/test/recipes/60-test_x509_time.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_x509_time", "x509_time_test");

--- a/test/x509_time_test.c
+++ b/test/x509_time_test.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Tests for X509 time functions */
+
+#include <string.h>
+#include <time.h>
+
+#include <openssl/asn1.h>
+#include <openssl/x509.h>
+#include "testutil.h"
+#include "test_main.h"
+#include "e_os.h"
+
+typedef struct {
+    const char *data;
+    int type;
+    time_t cmp_time;
+    /* -1 if asn1_time <= cmp_time, 1 if asn1_time > cmp_time, 0 if error. */
+    int expected;
+} TESTDATA;
+
+static TESTDATA x509_cmp_tests[] = {
+    {
+        "20170217180154Z", V_ASN1_GENERALIZEDTIME,
+        /* The same in seconds since epoch. */
+        1487354514, -1,
+    },
+    {
+        "20170217180154Z", V_ASN1_GENERALIZEDTIME,
+        /* One second more. */
+        1487354515, -1,
+    },
+    {
+        "20170217180154Z", V_ASN1_GENERALIZEDTIME,
+        /* One second less. */
+        1487354513, 1,
+    },
+    /* Same as UTC time. */
+    {
+        "170217180154Z", V_ASN1_UTCTIME,
+        /* The same in seconds since epoch. */
+        1487354514, -1,
+    },
+    {
+        "170217180154Z", V_ASN1_UTCTIME,
+        /* One second more. */
+        1487354515, -1,
+    },
+    {
+        "170217180154Z", V_ASN1_UTCTIME,
+        /* One second less. */
+        1487354513, 1,
+    },
+    /* UTCTime from the 20th century. */
+    {
+        "990217180154Z", V_ASN1_UTCTIME,
+        /* The same in seconds since epoch. */
+        919274514, -1,
+    },
+    {
+        "990217180154Z", V_ASN1_UTCTIME,
+        /* One second more. */
+        919274515, -1,
+    },
+    {
+        "990217180154Z", V_ASN1_UTCTIME,
+        /* One second less. */
+        919274513, 1,
+    },
+    /* Various invalid formats. */
+    {
+        /* No trailing Z. */
+        "20170217180154", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* No trailing Z, UTCTime. */
+        "170217180154", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* No seconds. */
+        "201702171801Z", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* No seconds, UTCTime. */
+        "1702171801Z", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* Fractional seconds. */
+        "20170217180154.001Z", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* Fractional seconds, UTCTime. */
+        "170217180154.001Z", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* Timezone offset. */
+        "20170217180154+0100", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* Timezone offset, UTCTime. */
+        "170217180154+0100", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* Extra digits. */
+        "2017021718015400Z", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* Extra digits, UTCTime. */
+        "17021718015400Z", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* Non-digits. */
+        "2017021718015aZ", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* Non-digits, UTCTime. */
+        "17021718015aZ", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* Trailing garbage. */
+        "20170217180154Zlongtrailinggarbage", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* Trailing garbage, UTCTime. */
+        "170217180154Zlongtrailinggarbage", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+         /* Swapped type. */
+        "20170217180154Z", V_ASN1_UTCTIME, 0, 0,
+    },
+    {
+        /* Swapped type. */
+        "170217180154Z", V_ASN1_GENERALIZEDTIME, 0, 0,
+    },
+    {
+        /* Bad type. */
+        "20170217180154Z", V_ASN1_OCTET_STRING, 0, 0,
+    },
+};
+
+static int test_x509_cmp_time(int idx)
+{
+    ASN1_TIME t;
+    TESTDATA tv = x509_cmp_tests[idx];
+    int result;
+
+    memset(&t, 0, sizeof(t));
+    t.type = tv.type;
+    t.data = (unsigned char*)(tv.data);
+    t.length = strlen(tv.data);
+
+    result = X509_cmp_time(&t, &tv.cmp_time);
+    if (result != tv.expected) {
+        fprintf(stderr, "test_x509_cmp_time(%d) failed: expected %d, got %d\n",
+                idx, tv.expected, result);
+        return 0;
+    }
+    return 1;
+}
+
+void register_tests()
+{
+    ADD_ALL_TESTS(test_x509_cmp_time, OSSL_NELEM(x509_cmp_tests));
+}


### PR DESCRIPTION
- Reject fractional seconds
- Reject offsets
- Check that the time digits are in valid range.

GH issue 2620

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

