### PR TITLE
Prevent undefined behavior in CRYPTO_cbc128_encrypt

### DIFF
--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -41,6 +41,9 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
     size_t n;
     size_t len = length;
 
+    if (length == 0)
+        return;
+
     OPENSSL_assert(in && out && key && ivec);
     OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));
     OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);

--- a/crypto/modes/cbc128.c
+++ b/crypto/modes/cbc128.c
@@ -22,6 +22,9 @@ void CRYPTO_cbc128_encrypt(const unsigned char *in, unsigned char *out,
     size_t n;
     const unsigned char *iv = ivec;
 
+    if (len == 0)
+        return;
+
 #if !defined(OPENSSL_SMALL_FOOTPRINT)
     if (STRICT_ALIGNMENT &&
         ((size_t)in | (size_t)out | (size_t)ivec) % sizeof(size_t) != 0) {

--- a/crypto/modes/cbc128.c
+++ b/crypto/modes/cbc128.c
@@ -76,6 +76,9 @@ void CRYPTO_cbc128_decrypt(const unsigned char *in, unsigned char *out,
         unsigned char c[16];
     } tmp;
 
+    if (len == 0)
+        return;
+
 #if !defined(OPENSSL_SMALL_FOOTPRINT)
     if (in != out) {
         const unsigned char *iv = ivec;


### PR DESCRIPTION
Prevents that if ```CRYPTO_cbc128_encrypt``` is called with the ```len``` argument being 0 (if any such instance exists currently or will be added in the future), ```memcpy``` (last line of the function) will be called with identical source and destination arguments, which is undefined behavior. (```iv``` is initialized to ```ivec```, but is never updated to point to ```out``` is ```len``` is 0).