### PR TITLE
Fix t_fromb64 (srp_vfy.c) memory corruption

### DIFF
--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -36,10 +36,13 @@ static int t_fromb64(unsigned char *a, size_t alen, const char *src)
     int i, j;
     int size;
 
+    if (alen == 0 || alen > INT_MAX)
+        return -1;
+
     while (*src && (*src == ' ' || *src == '\t' || *src == '\n'))
         ++src;
     size = strlen(src);
-    if (alen > INT_MAX || size > (int)alen)
+    if (size > (int)alen)
         return -1;
 
     i = 0;

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -42,7 +42,7 @@ static int t_fromb64(unsigned char *a, size_t alen, const char *src)
     while (*src && (*src == ' ' || *src == '\t' || *src == '\n'))
         ++src;
     size = strlen(src);
-    if (size > (int)alen)
+    if (size < 0 || size > (int)alen)
         return -1;
 
     i = 0;

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -80,7 +80,7 @@ static int t_fromb64(unsigned char *a, size_t alen, const char *src)
         if (--i < 0)
             break;
     }
-    while (a[j] == 0 && j <= size)
+    while (j <= size && a[j] == 0)
         ++j;
     i = 0;
     while (j <= size)

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -42,7 +42,7 @@ static int t_fromb64(unsigned char *a, size_t alen, const char *src)
     while (*src && (*src == ' ' || *src == '\t' || *src == '\n'))
         ++src;
     size = strlen(src);
-    if (size < 0 || size > (int)alen)
+    if (size < 0 || size >= (int)alen)
         return -1;
 
     i = 0;


### PR DESCRIPTION
##### Checklist

##### Description of change

Input to the the SRP code's internal base64 decoding function, ```t_fromb64```, is prone to memory corruption if the size of the input string is equal to the size of the output buffer.

Proof of concept (this should trigger AddressSanitizer):

```c
    unsigned char tmp[MAX_LEN];
    char* v;
    v = malloc(MAX_LEN + 1);
    memset(v, 'A', MAX_LEN);
    v[MAX_LEN] = 0x00;
    t_fromb64(tmp, sizeof(tmp), v);
```

Unfortunately, since ```t_fromb64``` is a static function and thus not part of the API, this code cannot be added directly to the tests.