### PR TITLE
Removed ugly size_t less than zero check

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -162,7 +162,7 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
     if (malloc_impl != NULL && malloc_impl != CRYPTO_malloc)
         return malloc_impl(num, file, line);
 
-    if (num <= 0)
+    if (num == 0)
         return NULL;
 
     FAILTEST();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Description of change

Removed an ugly size_t less than zero check from the CRYPTO_malloc
