### PR TITLE
Fix memory leak in pkcs12 -export

### DIFF
--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -204,6 +204,9 @@ int PKCS12_setup_mac(PKCS12 *p12, int iter, unsigned char *salt, int saltlen,
 {
     X509_ALGOR *macalg;
 
+    PKCS12_MAC_DATA_free(p12->mac);
+    p12->mac = NULL;
+
     if ((p12->mac = PKCS12_MAC_DATA_new()) == NULL)
         return PKCS12_ERROR;
     if (iter > 1) {


### PR DESCRIPTION
##### Description of change

Fixes memory leak in pkcs12 -export
Example of command to reproduce is (with gost engine):
openssl pkcs12 -export -inkey 2512/seckey.pem -in 2512/cert.pem -out 2512/pkcs12.p12 -password pass:12345 -keypbe gost89 -certpbe gost89 -macalg md_gost94