### PR TITLE
VMS fix of test/recipes/80-test_ssl_new.t

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -24,8 +24,8 @@ $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
 
 my @conf_srcs =  glob(srctop_file("test", "ssl-tests", "*.conf.in"));
 map { s/;.*// } @conf_srcs if $^O eq "VMS";
-my @conf_files = map { basename($_) } @conf_srcs;
-map { s/\.in// } @conf_files;
+my @conf_files = map { basename($_, ".in") } @conf_srcs;
+map { s/\^// } @conf_files if $^O eq "VMS";
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.


### PR DESCRIPTION
On VMS, file names with more than one period get all but the last get
escaped with a ^, so 21-key-update.conf.in becomes 21-key-update^.conf.in
That means that %conf_dependent_tests and %skip become useless unless
we massage the file names that are used as indexes.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
