### PR TITLE
.travis.yml: remove osx from build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
 
 os:
     - linux
-    - osx
 
 compiler:
     - clang


### PR DESCRIPTION
Travis OS X utilization and backlog statistics suggest that it became
bottleneck for our integration builds with requests piling up for days
during working days of the week. Suggestion is to remove osx till
capacity is lesser issue.
