### PR TITLE
Prevent potential OOB read in EC_GROUP_get_basis_type

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -15,15 +15,17 @@
 
 int EC_GROUP_get_basis_type(const EC_GROUP *group)
 {
-    int i = 0;
+    int i;
 
     if (EC_METHOD_get_field_type(EC_GROUP_method_of(group)) !=
         NID_X9_62_characteristic_two_field)
         /* everything else is currently not supported */
         return 0;
 
-    while (group->poly[i] != 0)
-        i++;
+    /* Find the last non-zero element of group->poly[] */
+    for (i = 0;
+        i < sizeof(group->poly)/sizeof(group->poly[0]) && group->poly[i] != 0;
+        i++) ;
 
     if (i == 4)
         return NID_X9_62_ppBasis;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -24,8 +24,9 @@ int EC_GROUP_get_basis_type(const EC_GROUP *group)
 
     /* Find the last non-zero element of group->poly[] */
     for (i = 0;
-        i < OSSL_NELEM(group->poly) & group->poly[i] != 0;
-        i++) ;
+         i < OSSL_NELEM(group->poly) & group->poly[i] != 0;
+         i++)
+        continue;
 
     if (i == 4)
         return NID_X9_62_ppBasis;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -24,7 +24,7 @@ int EC_GROUP_get_basis_type(const EC_GROUP *group)
 
     /* Find the last non-zero element of group->poly[] */
     for (i = 0;
-        i < sizeof(group->poly)/sizeof(group->poly[0]) && group->poly[i] != 0;
+        i < OSSL_NELEM(group->poly) & group->poly[i] != 0;
         i++) ;
 
     if (i == 4)


### PR DESCRIPTION
##### Description of change

When checking the elements of a fixed-size array (EC_GROUP's int poly[6]), do not continue iterating after its last element has been reached; instead, check up to the last element, and break out of the loop once this position is reached. This will prevent out-of-bounds access in case each element of the poly[] array is non-zero.