### PR TITLE
Check that async_jobs is not negative to avoid a warning

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1214,7 +1214,7 @@ int speed_main(int argc, char **argv)
 #ifndef NO_FORK
     int multi = 0;
 #endif
-    int async_jobs = 0;
+    unsigned int async_jobs = 0;
 #if !defined(OPENSSL_NO_RSA) || !defined(OPENSSL_NO_DSA) \
     || !defined(OPENSSL_NO_EC)
     long rsa_count = 1;
@@ -1390,6 +1390,12 @@ int speed_main(int argc, char **argv)
             if (!ASYNC_is_capable()) {
                 BIO_printf(bio_err,
                            "%s: async_jobs specified but async not supported\n",
+                           prog);
+                goto opterr;
+            }
+            if (async_jobs > 99999) {
+                BIO_printf(bio_err,
+                           "%s: too many async_jobs\n",
                            prog);
                 goto opterr;
             }


### PR DESCRIPTION
Hi gcc7 produces a warning in --strict-warnings mode:

apps/speed.c: In function 'speed_main':
apps/speed.c:1516:5: error: 'memset': specified size between 18446742819579101184 and 18446744073709551032 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
     memset(loopargs, 0, loopargs_len * sizeof(loopargs_t));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
apps/speed.c: At top level:
cc1: error: unrecognized command line option '-Wno-parentheses-equality' [-Werror]
cc1: all warnings being treated as errors
make[1]: *** [apps/speed.o] Error 1

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79647 for details
so gcc will not change, but Martin Sebor suggested a patch
which avoids negative job numbers.

It may be possible that the job numbers should be more restricted, though.