### PR TITLE
WIP: Fix BN_GF2m issues

### DIFF
--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -1211,10 +1211,9 @@ int BN_GF2m_poly2arr(const BIGNUM *a, int p[], int max)
         }
     }
 
-    if (k < max) {
+    if (k < max)
         p[k] = -1;
-        k++;
-    }
+    k++;
 
     return k;
 }

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -336,7 +336,7 @@ int BN_GF2m_mod_arr(BIGNUM *r, const BIGNUM *a, const int p[])
         z[j] = 0;
 
         for (k = 1; p[k] != 0; k++) {
-            if (p[k] < 0)
+            if (p[k] < 0 || p[k] >= p[k - 1])
                 return 0;
             /* reducing component t^p[k] */
             n = p[0] - p[k];
@@ -376,7 +376,7 @@ int BN_GF2m_mod_arr(BIGNUM *r, const BIGNUM *a, const int p[])
         for (k = 1; p[k] != 0; k++) {
             BN_ULONG tmp_ulong;
 
-            if (p[k] < 0)
+            if (p[k] < 0 || p[k] >= p[k - 1])
                 return 0;
 
             /* reducing component t^p[k] */

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -403,16 +403,28 @@ int BN_GF2m_mod_arr(BIGNUM *r, const BIGNUM *a, const int p[])
 int BN_GF2m_mod(BIGNUM *r, const BIGNUM *a, const BIGNUM *p)
 {
     int ret = 0;
-    int arr[6];
+    const size_t max = BN_num_bits(p) + 1;
+    int *arr = NULL;
+
+    arr = OPENSSL_malloc(sizeof(*arr) * max);
+    if (arr == NULL) {
+        BNerr(BN_F_BN_GF2M_MOD, ERR_R_MALLOC_FAILURE);
+        goto err;
+    }
+
     bn_check_top(a);
     bn_check_top(p);
-    ret = BN_GF2m_poly2arr(p, arr, OSSL_NELEM(arr));
-    if (!ret || ret > (int)OSSL_NELEM(arr)) {
+    ret = BN_GF2m_poly2arr(p, arr, max);
+    if (ret == 0 || ret > (int)max) {
         BNerr(BN_F_BN_GF2M_MOD, BN_R_INVALID_LENGTH);
-        return 0;
+        ret = 0;
+        goto err;
     }
     ret = BN_GF2m_mod_arr(r, a, arr);
     bn_check_top(r);
+
+ err:
+    OPENSSL_free(arr);
     return ret;
 }
 

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -336,6 +336,8 @@ int BN_GF2m_mod_arr(BIGNUM *r, const BIGNUM *a, const int p[])
         z[j] = 0;
 
         for (k = 1; p[k] != 0; k++) {
+            if (p[k] < 0)
+                return 0;
             /* reducing component t^p[k] */
             n = p[0] - p[k];
             d0 = n % BN_BITS2;
@@ -373,6 +375,9 @@ int BN_GF2m_mod_arr(BIGNUM *r, const BIGNUM *a, const int p[])
 
         for (k = 1; p[k] != 0; k++) {
             BN_ULONG tmp_ulong;
+
+            if (p[k] < 0)
+                return 0;
 
             /* reducing component t^p[k] */
             n = p[k] / BN_BITS2;


### PR DESCRIPTION
Some of the `BN_GF2M_*` functions don't handle invalid input very well - and crash as a result. OpenSSL only support an irreducible polynomial in the trinomial or pentanomial forms - with a trailing "+1" in both cases. One of parameters to `BN_GF2M_mod_arr` is an array of integers which correspond to the bit position of the coefficients in that polynomial. This array is expected to be terminated by a -1 value. The final coefficient is always expected to be 0 to correspond to the final "+1" in the polynomial. This means that for all valid curves the array is actually terminated by 0 followed by -1. However invalid polynomials might only be terminated by -1. The existing code will crash if the 0 is not there.

This issue does not seem to be remotely exploitable because an invalid curve cannot be encoded in ASN.1, so this doesn't seem to represent a security issue.

The issue was discovered thanks to a POC written by @guidovranken. This PR also fixes a couple of other issues discovered along the way.