### PR TITLE
Extended support for the -nameopt flag

### DIFF
--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -69,6 +69,8 @@ int should_retry(int i);
 long bio_dump_callback(BIO *bio, int cmd, const char *argp,
                        int argi, long argl, long ret);
 
+int set_nameopt(const char *arg);
+
 #ifdef HEADER_SSL_H
 void apps_ssl_info_callback(const SSL *s, int where, int ret);
 void msg_cb(int write_p, int version, int content_type, const void *buf,

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -33,6 +33,12 @@ static unsigned char cookie_secret[COOKIE_SECRET_LENGTH];
 static int cookie_initialized = 0;
 #endif
 static BIO *bio_keylog = NULL;
+static unsigned long nmflag = XN_FLAG_ONELINE;
+
+int set_nameopt(const char *arg)
+{
+  return set_name_ex(&nmflag, arg);
+}
 
 static const char *lookup(int val, const STRINT_PAIR* list, const char* def)
 {
@@ -56,7 +62,7 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
         if (err_cert) {
             X509_NAME_print_ex(bio_err,
                                X509_get_subject_name(err_cert),
-                               0, XN_FLAG_ONELINE);
+                               0, nmflag);
             BIO_puts(bio_err, "\n");
         } else
             BIO_puts(bio_err, "<no cert>\n");
@@ -77,7 +83,7 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
         BIO_puts(bio_err, "issuer= ");
         X509_NAME_print_ex(bio_err, X509_get_issuer_name(err_cert),
-                           0, XN_FLAG_ONELINE);
+                           0, nmflag);
         BIO_puts(bio_err, "\n");
         break;
     case X509_V_ERR_CERT_NOT_YET_VALID:
@@ -813,7 +819,7 @@ static int set_cert_cb(SSL *ssl, void *arg)
         rv = SSL_check_chain(ssl, exc->cert, exc->key, exc->chain);
         BIO_printf(bio_err, "Checking cert chain %d:\nSubject: ", i);
         X509_NAME_print_ex(bio_err, X509_get_subject_name(exc->cert), 0,
-                           XN_FLAG_ONELINE);
+                           nmflag);
         BIO_puts(bio_err, "\n");
         print_chain_flags(ssl, rv);
         if (rv & CERT_PKEY_VALID) {
@@ -1103,7 +1109,7 @@ void print_ssl_summary(SSL *s)
 
         BIO_puts(bio_err, "Peer certificate: ");
         X509_NAME_print_ex(bio_err, X509_get_subject_name(peer),
-                           0, XN_FLAG_ONELINE);
+                           0, nmflag);
         BIO_puts(bio_err, "\n");
         if (SSL_get_peer_signature_nid(s, &nid))
             BIO_printf(bio_err, "Hash used: %s\n", OBJ_nid2sn(nid));

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -524,7 +524,7 @@ static int tlsa_import_rrset(SSL *con, STACK_OF(OPENSSL_STRING) *rrset)
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_4, OPT_6, OPT_HOST, OPT_PORT, OPT_CONNECT, OPT_UNIX,
-    OPT_XMPPHOST, OPT_VERIFY,
+    OPT_XMPPHOST, OPT_VERIFY, OPT_NAMEOPT,
     OPT_CERT, OPT_CRL, OPT_CRL_DOWNLOAD, OPT_SESS_OUT, OPT_SESS_IN,
     OPT_CERTFORM, OPT_CRLFORM, OPT_VERIFY_RET_ERROR, OPT_VERIFY_QUIET,
     OPT_BRIEF, OPT_PREXIT, OPT_CRLF, OPT_QUIET, OPT_NBIO,
@@ -579,6 +579,7 @@ const OPTIONS s_client_options[] = {
     {"cert", OPT_CERT, '<', "Certificate file to use, PEM format assumed"},
     {"certform", OPT_CERTFORM, 'F',
      "Certificate format (PEM or DER) PEM default"},
+    {"nameopt", OPT_NAMEOPT, 's', "Various certificate name options"},
     {"key", OPT_KEY, 's', "Private key file to use, if not in -cert file"},
     {"keyform", OPT_KEYFORM, 'E', "Key format (PEM, DER or engine) PEM default"},
     {"pass", OPT_PASS, 's', "Private key file pass phrase source"},
@@ -1012,6 +1013,10 @@ int s_client_main(int argc, char **argv)
             break;
         case OPT_CERT:
             cert_file = opt_arg();
+            break;
+        case OPT_NAMEOPT:
+            if (!set_nameopt(opt_arg()))
+                goto end;
             break;
         case OPT_CRL:
             crl_file = opt_arg();

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -699,7 +699,7 @@ static char *srtp_profiles = NULL;
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP, OPT_ENGINE,
     OPT_4, OPT_6, OPT_ACCEPT, OPT_PORT, OPT_UNIX, OPT_UNLINK, OPT_NACCEPT,
-    OPT_VERIFY, OPT_UPPER_V_VERIFY, OPT_CONTEXT, OPT_CERT, OPT_CRL,
+    OPT_VERIFY, OPT_NAMEOPT, OPT_UPPER_V_VERIFY, OPT_CONTEXT, OPT_CERT, OPT_CRL,
     OPT_CRL_DOWNLOAD, OPT_SERVERINFO, OPT_CERTFORM, OPT_KEY, OPT_KEYFORM,
     OPT_PASS, OPT_CERT_CHAIN, OPT_DHPARAM, OPT_DCERTFORM, OPT_DCERT,
     OPT_DKEYFORM, OPT_DPASS, OPT_DKEY, OPT_DCERT_CHAIN, OPT_NOCERT,
@@ -744,6 +744,7 @@ const OPTIONS s_server_options[] = {
     {"Verify", OPT_UPPER_V_VERIFY, 'n',
      "Turn on peer certificate verification, must have a cert"},
     {"cert", OPT_CERT, '<', "Certificate file to use; default is " TEST_CERT},
+    {"nameopt", OPT_NAMEOPT, 's', "Various certificate name options"},
     {"naccept", OPT_NACCEPT, 'p', "Terminate after #num connections"},
     {"serverinfo", OPT_SERVERINFO, 's',
      "PEM serverinfo file for certificate"},
@@ -1126,6 +1127,10 @@ int s_server_main(int argc, char *argv[])
             break;
         case OPT_CERT:
             s_cert_file = opt_arg();
+            break;
+        case OPT_NAMEOPT:
+            if (!set_nameopt(opt_arg()))
+                goto end;
             break;
         case OPT_CRL:
             crl_file = opt_arg();

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -53,7 +53,7 @@ static const char fmt_http_get_cmd[] = "GET %s HTTP/1.0\r\n\r\n";
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_CONNECT, OPT_CIPHER, OPT_CERT, OPT_KEY, OPT_CAPATH,
+    OPT_CONNECT, OPT_CIPHER, OPT_CERT, OPT_NAMEOPT, OPT_KEY, OPT_CAPATH,
     OPT_CAFILE, OPT_NOCAPATH, OPT_NOCAFILE, OPT_NEW, OPT_REUSE, OPT_BUGS,
     OPT_VERIFY, OPT_TIME, OPT_SSL3,
     OPT_WWW
@@ -65,6 +65,7 @@ const OPTIONS s_time_options[] = {
      "Where to connect as post:port (default is " SSL_CONNECT_NAME ")"},
     {"cipher", OPT_CIPHER, 's', "Cipher to use, see 'openssl ciphers'"},
     {"cert", OPT_CERT, '<', "Cert file to use, PEM format assumed"},
+    {"nameopt", OPT_NAMEOPT, 's', "Various certificate name options"},
     {"key", OPT_KEY, '<', "File with key, PEM; default is -cert file"},
     {"CApath", OPT_CAPATH, '/', "PEM format directory of CA's"},
     {"cafile", OPT_CAFILE, '<', "PEM format file of CA's"},
@@ -140,6 +141,10 @@ int s_time_main(int argc, char **argv)
             break;
         case OPT_CERT:
             certfile = opt_arg();
+            break;
+        case OPT_NAMEOPT:
+            if (!set_nameopt(opt_arg()))
+                goto end;
             break;
         case OPT_KEY:
             keyfile = opt_arg();

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -50,6 +50,7 @@ B<openssl> B<s_client>
 [B<-no_alt_chains>]
 [B<-use_deltas>]
 [B<-auth_level num>]
+[B<-nameopt option>]
 [B<-verify_depth num>]
 [B<-verify_email email>]
 [B<-verify_hostname hostname>]
@@ -186,6 +187,13 @@ will never fail due to a server certificate verify failure.
 
 Return verification errors instead of continuing. This will typically
 abort the handshake with a fatal error.
+
+=item B<-nameopt option>
+
+option which determines how the subject or issuer names are displayed. The
+B<option> argument can be a single option or multiple options separated by
+commas.  Alternatively the B<-nameopt> switch may be used more than once to
+set multiple options. See the L<x509(1)> manual page for details.
 
 =item B<-CApath directory>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -61,6 +61,7 @@ B<openssl> B<s_server>
 [B<-no_alt_chains>]
 [B<-use_deltas>]
 [B<-auth_level num>]
+[B<-nameopt option>]
 [B<-verify_depth num>]
 [B<-verify_return_error>]
 [B<-verify_email email>]
@@ -260,6 +261,13 @@ must supply a certificate or an error occurs.
 
 If the ciphersuite cannot request a client certificate (for example an
 anonymous ciphersuite or PSK) this option has no effect.
+
+=item B<-nameopt option>
+
+option which determines how the subject or issuer names are displayed. The
+B<option> argument can be a single option or multiple options separated by
+commas.  Alternatively the B<-nameopt> switch may be used more than once to
+set multiple options. See the L<x509(1)> manual page for details.
 
 =item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
 B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,

--- a/doc/man1/s_time.pod
+++ b/doc/man1/s_time.pod
@@ -19,6 +19,7 @@ B<openssl> B<s_time>
 [B<-reuse>]
 [B<-new>]
 [B<-verify depth>]
+[B<-nameopt option>]
 [B<-nbio>]
 [B<-time seconds>]
 [B<-ssl3>]
@@ -69,6 +70,13 @@ server certificate chain and turns on server certificate verification.
 Currently the verify operation continues after errors so all the problems
 with a certificate chain can be seen. As a side effect the connection
 will never fail due to a server certificate verify failure.
+
+=item B<-nameopt option>
+
+option which determines how the subject or issuer names are displayed. The
+B<option> argument can be a single option or multiple options separated by
+commas.  Alternatively the B<-nameopt> switch may be used more than once to
+set multiple options. See the L<x509(1)> manual page for details.
 
 =item B<-CApath directory>
 


### PR DESCRIPTION
Provided support for the -nameopt flag 
in s_client, s_server and s_time commands. 
They were the last cmdline utils without nameopt management.

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
Provided support for the -nameopt flag 
in s_client, s_server and s_time commands.

