### PR TITLE
Add some more consistency checks in tls_decrypt_ticket

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1318,7 +1318,7 @@ TICKET_RETURN tls_decrypt_ticket(SSL *s, const unsigned char *etick,
         /* Some additional consistency checks */
         if (p != sdec + slen || sess->session_id_length != 0) {
             SSL_SESSION_free(sess);
-            return 2;
+            return TICKET_NO_DECRYPT;
         }
         /*
          * The session ID, if non-empty, is used by some clients to detect


### PR DESCRIPTION
This adds some additional consistency checks in tls_decrypt_ticket.
The PR works for master.  If you think it is a good idea, I can
back-port that to 1.1.0 & 1.0.2 as well.