### PR TITLE
Remove -Wno-parentheses-equality from gcc --strict-warnings options

### DIFF
--- a/Configure
+++ b/Configure
@@ -124,7 +124,6 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
         . " -Wshadow"
         . " -Wformat"
         . " -Wtype-limits"
-        . " -Wno-parentheses-equality"
         . " -Werror"
         ;
 


### PR DESCRIPTION
This is no gcc option, previously gcc never complained about -Wno-xxx
but that is probably broken, for instance gcc-7 occasionally complains about:

apps/speed.c: At top level:
cc1: error: unrecognized command line option '-Wno-parentheses-equality' [-Werror]
cc1: all warnings being treated as errors
make[1]: *** [apps/speed.o] Error 1

