### PR TITLE
Have the directory reader use the Unix API on VMS

### DIFF
--- a/crypto/o_dir.c
+++ b/crypto/o_dir.c
@@ -23,7 +23,8 @@
 #include "internal/o_dir.h"
 
 #define LPDIR_H
-#if defined OPENSSL_SYS_UNIX || defined DJGPP
+#if defined OPENSSL_SYS_UNIX || defined DJGPP \
+    (defined __VMS_VER && __VMS_VER >= 70000000)
 # include "LPdir_unix.c"
 #elif defined OPENSSL_SYS_VMS
 # include "LPdir_vms.c"


### PR DESCRIPTION
opendir(), readdir() and closedir() have been available on VMS since
version 7.0.
