### PR TITLE
Add -Wundef to gcc's --strict-warnings options

### DIFF
--- a/Configure
+++ b/Configure
@@ -144,6 +144,7 @@ my $clang_devteam_warn = ""
         . " -Wconditional-uninitialized"
         . " -Wincompatible-pointer-types-discards-qualifiers"
         . " -Wmissing-variable-declarations"
+        . " -Wundef"
         ;
 
 # This adds backtrace information to the memory leak info.  Is only used

--- a/Configure
+++ b/Configure
@@ -121,6 +121,7 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
         . " -Wshadow"
         . " -Wformat"
         . " -Wtype-limits"
+        . " -Wundef"
         . " -Werror"
         ;
 

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -227,7 +227,8 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
     return !strerror_s(buf, buflen, errnum);
 #elif defined(_GNU_SOURCE)
     return strerror_r(errnum, buf, buflen) != NULL;
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600)
+#elif (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || \
+      (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600)
     /*
      * We can use "real" strerror_r. The OpenSSL version differs in that it
      * gives 1 on success and 0 on failure for consistency with other OpenSSL

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -8,8 +8,8 @@
  */
 
 #include <stdio.h>
-#include <openssl/stack.h>
 #include "internal/cryptlib.h"
+#include <openssl/stack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509_ext.c
+++ b/crypto/x509/x509_ext.c
@@ -8,8 +8,8 @@
  */
 
 #include <stdio.h>
-#include <openssl/stack.h>
 #include "internal/cryptlib.h"
+#include <openssl/stack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -8,8 +8,8 @@
  */
 
 #include <stdio.h>
-#include <openssl/stack.h>
 #include "internal/cryptlib.h"
+#include <openssl/stack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -8,8 +8,8 @@
  */
 
 #include <stdio.h>
-#include <openssl/stack.h>
 #include "internal/cryptlib.h"
+#include <openssl/stack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -8,8 +8,8 @@
  */
 
 #include <stdio.h>
-#include <openssl/stack.h>
 #include "internal/cryptlib.h"
+#include <openssl/stack.h>
 #include <openssl/buffer.h>
 #include <openssl/asn1.h>
 #include <openssl/evp.h>

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -56,7 +56,7 @@
  * TEST_CASE_NAME is defined as the name of the test case function where
  * possible; otherwise we get by with the file name and line number.
  */
-# if __STDC_VERSION__ < 199901L
+# if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L
 #  if defined(_MSC_VER)
 #   define TEST_CASE_NAME __FUNCTION__
 #  else


### PR DESCRIPTION
This PR adds -Wundef to --strict-warnings for gcc.
This warns on #if with undefined macros.

For 1.1.0-stable only.
I will do another PR for master once #2705 is merged. 