### PR TITLE
Add -Wundef to --strict-warnings options for 1.0.2

### DIFF
--- a/Configure
+++ b/Configure
@@ -109,7 +109,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [experimenta
 # Minimum warning options... any contributions to OpenSSL should at least get
 # past these. 
 
-my $gcc_devteam_warn = "-Wall -pedantic -DPEDANTIC -Wno-long-long -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Werror -DCRYPTO_MDEBUG_ALL -DCRYPTO_MDEBUG_ABORT -DREF_CHECK -DOPENSSL_NO_DEPRECATED";
+my $gcc_devteam_warn = "-Wall -pedantic -DPEDANTIC -Wno-long-long -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wundef -Werror -DCRYPTO_MDEBUG_ALL -DCRYPTO_MDEBUG_ABORT -DREF_CHECK -DOPENSSL_NO_DEPRECATED";
 
 # TODO(openssl-team): fix problems and investigate if (at least) the following
 # warnings can also be enabled:

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -103,7 +103,7 @@
  * TEST_CASE_NAME is defined as the name of the test case function where
  * possible; otherwise we get by with the file name and line number.
  */
-# if __STDC_VERSION__ < 199901L
+# if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L
 #  if defined(_MSC_VER)
 #   define TEST_CASE_NAME __FUNCTION__
 #  else


### PR DESCRIPTION
Add -Wundef to --strict-warnings options for gcc & clang.
This PR is against 1.0.2