### PR TITLE
Test more cipher modes

### DIFF
--- a/test/recipes/20-test_enc_more.t
+++ b/test/recipes/20-test_enc_more.t
@@ -1,0 +1,58 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+# ======================================================================
+# Copyright (c) 2017 Oracle and/or its affiliates.  All rights reserved.
+
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw/catfile/;
+use File::Copy;
+use File::Compare qw/compare_text/;
+use File::Basename;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_evp_more");
+
+my $testsrc = srctop_file("test", "recipes", basename($0));
+
+my $cipherlist = undef;
+my $plaintext = catfile(".", "testdatafile");
+my $fail = "";
+my $cmd = "openssl";
+
+my @ciphers =
+    grep(! /wrap|hmac|poly|ocb|xts|^$|^[^-]|(?i)[cg]cm/,
+         (map { split /\s+/ }
+              run(app([$cmd, "enc", "-ciphers"]), capture => 1)));
+
+plan tests => 1 + scalar @ciphers;
+
+my $init = ok(copy($testsrc, $plaintext));
+
+SKIP: {
+    skip "Not initialized, skipping...", (scalar @ciphers) unless $init;
+
+    foreach my $cipher (@ciphers) {
+        my $ciphername = substr $cipher, 1;
+        my $cipherfile = "$plaintext.$ciphername.cipher";
+        my $clearfile = "$plaintext.$ciphername.clear";
+        my @common = ( $cmd, "enc", "$cipher", "-k", "test" );
+
+        ok(run(app([@common, "-e", "-in", $plaintext, "-out", $cipherfile]))
+           && compare_text($plaintext, $cipherfile) != 0
+           && run(app([@common, "-d", "-in", $cipherfile, "-out", $clearfile]))
+           && compare_text($plaintext, $clearfile) == 0
+           , $ciphername);
+        unlink $cipherfile, $clearfile;
+    }
+}
+
+unlink $plaintext;


### PR DESCRIPTION
- [x] tests are added or updated

Add a test case that uses the evp cipher list to validate successful encryption and decryption of all cipher modes accepted by the enc command (i.e. not AEAD, XTS and wrappers).

The nearest existing test case to this is `test_enc` that uses the _list -cipher-commands_ to get a list of ciphers to validate.  This omits about half of the available cipher modes.  This test, instead uses _enc -ciphers_ for the list.

Unlike `test_enc`, this test makes no attempt to validate both binary and base64 encoded output.
