### PR TITLE
On VMS, massage the fetch file names to remove the generation number

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -281,6 +281,24 @@ static int ends_with_dirsep(const char *path)
     return *path == '/';
 }
 
+static int massage_filename(char *name)
+{
+# ifdef __VMS
+    char *p = strchr(name, ';');
+    char *q = p;
+
+    if (q != NULL) {
+        for (q++; *q != '\0'; q++) {
+            if (!isdigit(*q))
+                return 1;
+        }
+    }
+
+    *p = '\0';
+# endif
+    return 1;
+}
+
 /*
  * Process a directory; return number of errors found.
  */
@@ -316,6 +334,7 @@ static int do_dir(const char *dirname, enum Hash h)
     }
     while ((filename = OPENSSL_DIR_read(&d, dirname)) != NULL) {
         if ((copy = strdup(filename)) == NULL
+                || !massage_filename(copy)
                 || sk_OPENSSL_STRING_push(files, copy) == 0) {
             BIO_puts(bio_err, "out of memory\n");
             exit(1);


### PR DESCRIPTION
The generation number is ';nnn' at the end of the file name fetched
with readdir().  Because rehash checks for specific extensions and
doesn't expect an additional generation number, the easiest is to
massage the received file name early by simply removing the generation
number.
