### PR TITLE
Increase the size of the stack buffer to prevent an overflow

### DIFF
--- a/crypto/ec/eck_prn.c
+++ b/crypto/ec/eck_prn.c
@@ -238,7 +238,7 @@ static int print_bin(BIO *fp, const char *name, const unsigned char *buf,
                      size_t len, int off)
 {
     size_t i;
-    char str[128];
+    char str[128 + 1 + 4];
 
     if (buf == NULL)
         return 1;


### PR DESCRIPTION
The maximum value for off is limited to 128 at the start of the function.  Later on, off + 1 + 4 bytes can written into the array on the stack.  This change increases the size of the array to prevent an overflow.

Fixes #2517.
