### PR TITLE
Run 'make' with 5 threads instead of an infinite amount

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -46,7 +46,7 @@ Configure for fuzzing:
             enable-ssl3 enable-ssl3-method enable-nextprotoneg \
             --debug
     $ sudo apt-get install make
-    $ LDCMD=clang++ make -j
+    $ LDCMD=clang++ make -j5
     $ fuzz/helper.py $FUZZER
 
 Where $FUZZER is one of the executables in `fuzz/`.


### PR DESCRIPTION
##### Checklist

##### Description of change
In the instructions on how to build the fuzzers, limit the amount of threads spawned by ```make``` to 5.