### PR TITLE
In apps/rehash.c, decorate the inclusion of internal/o_dir.h for VMS

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -25,7 +25,23 @@
 # include <ctype.h>
 # include <sys/stat.h>
 
+/*
+ * Make sure that the processing of symbol names is treated the same as when
+ * libcrypto is built.  This is done automatically for public headers (see
+ * include/openssl/__DECC_INCLUDE_PROLOGUE.H and __DECC_INCLUDE_EPILOGUE.H),
+ * but not for internal headers.
+ */
+# ifdef __VMS
+#  pragma names save
+#  pragma names as_is,shortened
+# endif
+
 # include "internal/o_dir.h"
+
+# ifdef __VMS
+#  pragma names restore
+# endif
+
 # include <openssl/evp.h>
 # include <openssl/pem.h>
 # include <openssl/x509.h>


### PR DESCRIPTION
The library files are built with symbol names as is, while the
application is built with the default uppercase-all-symbols mode.
That's fine for public APIs, because we have __DECC_INCLUDE_PROLOGUE.H
and __DECC_INCLUDE_EPILOGUE.H automatically telling the compiler how
to treat the public header files.  However, we don't have the same
setup for internal library APIs, since they are usually only used by
the libraries.

Because apps/rehash.c uses a library internal header file, we have to
surround that inclusion with the same kind of pragmas found in
__DECC_INCLUDE_PROLOGUE.H and __DECC_INCLUDE_EPILOGUE.H, or we get
unresolved symbols when building no-shared.
