### PR TITLE
Tidy up certificate type handling.

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -2903,6 +2903,7 @@ void ssl3_free(SSL *s)
     s->s3->tmp.pkey = NULL;
 #endif
 
+    OPENSSL_free(s->s3->tmp.ctype);
     sk_X509_NAME_pop_free(s->s3->tmp.ca_names, X509_NAME_free);
     OPENSSL_free(s->s3->tmp.ciphers_raw);
     OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
@@ -2921,6 +2922,7 @@ void ssl3_free(SSL *s)
 void ssl3_clear(SSL *s)
 {
     ssl3_cleanup_key_block(s);
+    OPENSSL_free(s->s3->tmp.ctype);
     sk_X509_NAME_pop_free(s->s3->tmp.ca_names, X509_NAME_free);
     OPENSSL_free(s->s3->tmp.ciphers_raw);
     OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
@@ -3212,14 +3214,9 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             const unsigned char **pctype = parg;
             if (s->server || !s->s3->tmp.cert_req)
                 return 0;
-            if (s->cert->ctypes) {
-                if (pctype)
-                    *pctype = s->cert->ctypes;
-                return (int)s->cert->ctype_num;
-            }
             if (pctype)
-                *pctype = (unsigned char *)s->s3->tmp.ctype;
-            return s->s3->tmp.ctype_num;
+                *pctype = s->s3->tmp.ctype;
+            return s->s3->tmp.ctype_len;
         }
 
     case SSL_CTRL_SET_CLIENT_CERT_TYPES:
@@ -3761,9 +3758,8 @@ int ssl3_get_req_cert_type(SSL *s, WPACKET *pkt)
     uint32_t alg_k, alg_a = 0;
 
     /* If we have custom certificate types set, use them */
-    if (s->cert->ctypes) {
-        return WPACKET_memcpy(pkt, s->cert->ctypes, s->cert->ctype_num);
-    }
+    if (s->cert->ctype)
+        return WPACKET_memcpy(pkt, s->cert->ctype, s->cert->ctype_len);
     /* Get mask of algorithms disabled by signature list */
     ssl_set_sig_mask(&alg_a, s, SSL_SECOP_SIGALG_MASK);
 
@@ -3811,17 +3807,17 @@ int ssl3_get_req_cert_type(SSL *s, WPACKET *pkt)
 
 static int ssl3_set_req_cert_type(CERT *c, const unsigned char *p, size_t len)
 {
-    OPENSSL_free(c->ctypes);
-    c->ctypes = NULL;
-    if (!p || !len)
+    OPENSSL_free(c->ctype);
+    c->ctype = NULL;
+    c->ctype_len = 0;
+    if (p == NULL || len == 0)
         return 1;
     if (len > 0xff)
         return 0;
-    c->ctypes = OPENSSL_malloc(len);
-    if (c->ctypes == NULL)
+    c->ctype = OPENSSL_memdup(p, len);
+    if (c->ctype == NULL)
         return 0;
-    memcpy(c->ctypes, p, len);
-    c->ctype_num = len;
+    c->ctype_len = len;
     return 1;
 }
 

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -164,12 +164,11 @@ CERT *ssl_cert_dup(CERT *cert)
     /* Shared sigalgs also NULL */
     ret->shared_sigalgs = NULL;
     /* Copy any custom client certificate types */
-    if (cert->ctypes) {
-        ret->ctypes = OPENSSL_malloc(cert->ctype_num);
-        if (ret->ctypes == NULL)
+    if (cert->ctype) {
+        ret->ctype = OPENSSL_memdup(cert->ctype, cert->ctype_len);
+        if (ret->ctype == NULL)
             goto err;
-        memcpy(ret->ctypes, cert->ctypes, cert->ctype_num);
-        ret->ctype_num = cert->ctype_num;
+        ret->ctype_len = cert->ctype_len;
     }
 
     ret->cert_flags = cert->cert_flags;
@@ -252,7 +251,7 @@ void ssl_cert_free(CERT *c)
     OPENSSL_free(c->conf_sigalgs);
     OPENSSL_free(c->client_sigalgs);
     OPENSSL_free(c->shared_sigalgs);
-    OPENSSL_free(c->ctypes);
+    OPENSSL_free(c->ctype);
     X509_STORE_free(c->verify_store);
     X509_STORE_free(c->chain_store);
     custom_exts_free(&c->cli_ext);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1280,8 +1280,9 @@ typedef struct ssl3_state_st {
 # endif
         /* used for certificate requests */
         int cert_req;
-        int ctype_num;
-        char ctype[SSL3_CT_NUMBER];
+        /* Certificate types in certificate request message. */
+        uint8_t *ctype;
+        size_t ctype_len;
         STACK_OF(X509_NAME) *ca_names;
         size_t key_block_length;
         unsigned char *key_block;
@@ -1570,13 +1571,9 @@ typedef struct cert_st {
     /* Flags related to certificates */
     uint32_t cert_flags;
     CERT_PKEY pkeys[SSL_PKEY_NUM];
-    /*
-     * Certificate types (received or sent) in certificate request message.
-     * On receive this is only set if number of certificate types exceeds
-     * SSL3_CT_NUMBER.
-     */
-    unsigned char *ctypes;
-    size_t ctype_num;
+    /* Custom certificate types sent in certificate request message. */
+    uint8_t *ctype;
+    size_t ctype_len;
     /*
      * supported signature algorithms. When set on a client this is sent in
      * the client hello as the supported signature algorithms extension. For

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2009,25 +2009,20 @@ int tls1_check_chain(SSL *s, X509 *x, EVP_PKEY *pk, STACK_OF(X509) *chain,
             break;
         }
         if (check_type) {
-            const unsigned char *ctypes;
-            int ctypelen;
-            if (c->ctypes) {
-                ctypes = c->ctypes;
-                ctypelen = (int)c->ctype_num;
-            } else {
-                ctypes = (unsigned char *)s->s3->tmp.ctype;
-                ctypelen = s->s3->tmp.ctype_num;
-            }
-            for (i = 0; i < ctypelen; i++) {
-                if (ctypes[i] == check_type) {
+            const uint8_t *ctypes = s->s3->tmp.ctype;
+            size_t j;
+
+            for (j = 0; j < s->s3->tmp.ctype_len; j++, ctypes++) {
+                if (*ctypes == check_type) {
                     rv |= CERT_PKEY_CERT_TYPE;
                     break;
                 }
             }
             if (!(rv & CERT_PKEY_CERT_TYPE) && !check_flags)
                 goto end;
-        } else
+        } else {
             rv |= CERT_PKEY_CERT_TYPE;
+        }
 
         ca_dn = s->s3->tmp.ca_names;
 


### PR DESCRIPTION
The certificate types used to be held in a fixed length array or (if
it was too long) a malloced buffer. This was done to retain binary
compatibility. The code can be simplified now SSL is opaque by always
using a malloced buffer.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
