### PR TITLE
.travis.yml: switch to trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: c
 cache: ccache
 
@@ -42,7 +44,7 @@ matrix:
                   packages:
                       - clang-3.6
                   sources:
-                      - llvm-toolchain-precise-3.6
+                      - llvm-toolchain-trusty-3.6
                       - ubuntu-toolchain-r-test
           compiler: clang-3.6
           env: CONFIG_OPTS="--strict-warnings no-deprecated" BUILDONLY="yes"
@@ -70,7 +72,7 @@ matrix:
                   packages:
                       - clang-3.6
                   sources:
-                      - llvm-toolchain-precise-3.6
+                      - llvm-toolchain-trusty-3.6
                       - ubuntu-toolchain-r-test
           compiler: clang-3.6
           env: EXTENDED_TEST="yes" CONFIG_OPTS="enable-msan"
@@ -80,7 +82,7 @@ matrix:
                   packages:
                       - clang-3.6
                   sources:
-                      - llvm-toolchain-precise-3.6
+                      - llvm-toolchain-trusty-3.6
                       - ubuntu-toolchain-r-test
           compiler: clang-3.6
           env:  EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg -fno-sanitize=alignment no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
@@ -90,7 +92,7 @@ matrix:
                   packages:
                       - clang-3.6
                   sources:
-                      - llvm-toolchain-precise-3.6
+                      - llvm-toolchain-trusty-3.6
                       - ubuntu-toolchain-r-test
           compiler: clang-3.6
           env: EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2 no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"


### PR DESCRIPTION
Wine-based tests in #2735 seem to run faster, see if it has anything to with dist and if trusty works in master...