### PR TITLE
Add a null UI method

### DIFF
--- a/crypto/ui/build.info
+++ b/crypto/ui/build.info
@@ -1,3 +1,3 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
-        ui_err.c ui_lib.c ui_openssl.c ui_util.c
+        ui_err.c ui_lib.c ui_openssl.c ui_null.c ui_util.c

--- a/crypto/ui/ui_null.c
+++ b/crypto/ui/ui_null.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "ui_locl.h"
+
+static const UI_METHOD ui_null = {
+    "OpenSSL NULL UI",
+    NULL,                        /* opener */
+    NULL,                        /* writer */
+    NULL,                        /* flusher */
+    NULL,                        /* reader */
+    NULL,                        /* closer */
+    NULL
+};
+
+/* The method with all the built-in thingies */
+const UI_METHOD *UI_null(void)
+{
+    return &ui_null;
+}

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -9,7 +9,7 @@ UI_dup_input_boolean, UI_add_info_string, UI_dup_info_string,
 UI_add_error_string, UI_dup_error_string, UI_construct_prompt,
 UI_add_user_data, UI_get0_user_data, UI_get0_result, UI_process,
 UI_ctrl, UI_set_default_method, UI_get_default_method, UI_get_method,
-UI_set_method, UI_OpenSSL, - user interface
+UI_set_method, UI_OpenSSL, UI_null - user interface
 
 =head1 SYNOPSIS
 
@@ -59,6 +59,7 @@ UI_set_method, UI_OpenSSL, - user interface
  const UI_METHOD *UI_set_method(UI *ui, const UI_METHOD *meth);
 
  UI_METHOD *UI_OpenSSL(void);
+ const UI_METHOD *UI_null(void);
 
 =head1 DESCRIPTION
 
@@ -176,6 +177,9 @@ UI_set_method() changes the UI method associated with a given UI.
 
 UI_OpenSSL() is the default OpenSSL UI method for prompting
 passphrases on the command line.
+
+UI_null() is a UI method that does nothing.  Its use is to avoid
+getting internal defaults for passed UI_METHOD pointers.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -206,6 +206,12 @@ const UI_METHOD *UI_set_method(UI *ui, const UI_METHOD *meth);
 /* The method with all the built-in thingies */
 UI_METHOD *UI_OpenSSL(void);
 
+/*
+ * NULL method.  Literarily does nothing, but may serve as a placeholder
+ * to avoid internal default.
+ */
+const UI_METHOD *UI_null(void);
+
 /* ---------- For method writers ---------- */
 /*-
    A method contains a number of functions that implement the low level

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4252,3 +4252,4 @@ EVP_aria_256_ecb                        4202	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_256_ctr                        4203	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_128_ctr                        4204	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_192_ctr                        4205	1_1_1	EXIST::FUNCTION:ARIA
+UI_null                                 4206	1_1_1	EXIST::FUNCTION:UI


### PR DESCRIPTION
There are cases when, if you pass a NULL UI_METHOD, the called
function will use an internal default.  This is well and good, but
there may be cases when this is undesirable and one would rather send
in a UI that does absolutely nothing (sort of a /dev/null).  UI_null()
is the UI_METHOD for this purpose.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
