### PR TITLE
prevents undefined behavior in SSL_SESS_set1_id and SSL_SESS_set1_id_context

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -835,7 +835,8 @@ int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
       return 0;
     }
     s->session_id_length = sid_len;
-    memcpy(s->session_id, sid, sid_len);
+    if (sid != s->session_id)
+        memcpy(s->session_id, sid, sid_len);
     return 1;
 }
 
@@ -916,7 +917,8 @@ int SSL_SESSION_set1_id_context(SSL_SESSION *s, const unsigned char *sid_ctx,
         return 0;
     }
     s->sid_ctx_length = sid_ctx_len;
-    memcpy(s->sid_ctx, sid_ctx, sid_ctx_len);
+    if (sid_ctx != s->sid_ctx)
+        memcpy(s->sid_ctx, sid_ctx, sid_ctx_len);
 
     return 1;
 }


### PR DESCRIPTION
prevents undefined behavior in SSL_SESS_set1_id and SSL_SESS_set1_id_context calls when src and dst are equal (memcpy), effectively allowing exclusively setting length in both functions.

an alternative approach (to this change) would be to explicitly say that pointers must be different in the documentation.