### PR TITLE
Avoid buffer underflow in evp_test

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -23,17 +23,17 @@
 
 static void remove_space(char **pval)
 {
-    unsigned char *p = (unsigned char *)*pval;
+    unsigned char *p = (unsigned char *)*pval, *beginning;
 
     while (isspace(*p))
         p++;
 
-    *pval = (char *)p;
+    *pval = (char *)(beginning = p);
 
     p = p + strlen(*pval) - 1;
 
     /* Remove trailing space */
-    while (isspace(*p))
+    while (p >= beginning && isspace(*p))
         *p-- = 0;
 }
 


### PR DESCRIPTION
The second loop in the remove_space function doesn't check for walking
back off of the start of the string while setting white space to 0.

This fix exits this loop once the pointer is before the (updated) beginning
of the string.

Fixes #1454

