### PR TITLE
Fixed default value of the private key size in the man page

### DIFF
--- a/doc/man1/genrsa.pod
+++ b/doc/man1/genrsa.pod
@@ -79,7 +79,7 @@ for all available algorithms.
 =item B<numbits>
 
 the size of the private key to generate in bits. This must be the last option
-specified. The default is 512.
+specified. The default is 2048.
 
 =back
 


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.
-->

When you generate an RSA key, the default private key size is actually 2048 bits, as is defined in `apps/genrsa.c` on line 29. The man page still says 512.