### PR TITLE
Code cleanup: remove the VMS specific reimplementation of gmtime

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,11 @@
 
  Changes between 1.1.0e and 1.1.1 [xx XXX xxxx]
 
+  *) Remove the VMS-specific reimplementation of gmtime from crypto/o_times.c.
+     VMS C's RTL has a fully up to date gmtime() and gmtime_r() since V7.1,
+     which is the minimum version we support.
+     [Richard Levitte]
+
   *) Certificate time validation (X509_cmp_time) enforces stricter
      compliance with RFC 5280. Fractional seconds and timezone offsets
      are no longer allowed.

--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -11,207 +11,21 @@
 #include <string.h>
 #include <openssl/crypto.h>
 
-#ifdef OPENSSL_SYS_VMS
-# if __CRTL_VER >= 70000000 && \
-     (defined _POSIX_C_SOURCE || !defined _ANSI_C_SOURCE)
-#  define VMS_GMTIME_OK
-# endif
-# ifndef VMS_GMTIME_OK
-#  include <libdtdef.h>
-#  include <lib$routines.h>
-#  include <lnmdef.h>
-#  include <starlet.h>
-#  include <descrip.h>
-#  include <stdlib.h>
-# endif                         /* ndef VMS_GMTIME_OK */
-
-
-/*
- * Needed to pick up the correct definitions and declarations in some of the
- * DEC C Header Files (*.H).
- */
-# define __NEW_STARLET 1
-
-# if (defined(__alpha) || defined(__ia64))
-#  include <iledef.h>
-# else
-
-/* VAX */
-typedef struct _ile3 {          /* Copied from ILEDEF.H for Alpha   */
-#  pragma __nomember_alignment
-    unsigned short int ile3$w_length;        /* Length of buffer in bytes */
-    unsigned short int ile3$w_code;          /* Item code value */
-    void *ile3$ps_bufaddr;                   /* Buffer address */
-    unsigned short int *ile3$ps_retlen_addr; /* Address of word for returned length */
-} ILE3;
-# endif   /* alpha || ia64    */
-#endif    /* OPENSSL_SYS_VMS  */
-
 struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
 {
     struct tm *ts = NULL;
 
-#if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && (!defined(OPENSSL_SYS_VMS) || defined(gmtime_r)) && !defined(OPENSSL_SYS_MACOSX)
+#if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && !defined(OPENSSL_SYS_MACOSX)
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;
-#elif !defined(OPENSSL_SYS_VMS) || defined(VMS_GMTIME_OK)
+#else
     ts = gmtime(timer);
     if (ts == NULL)
         return NULL;
 
     memcpy(result, ts, sizeof(struct tm));
     ts = result;
-#endif
-#if defined( OPENSSL_SYS_VMS) && !defined( VMS_GMTIME_OK)
-    if (ts == NULL) {
-        static $DESCRIPTOR(tabnam, "LNM$DCL_LOGICAL");
-        static $DESCRIPTOR(lognam, "SYS$TIMEZONE_DIFFERENTIAL");
-        char logvalue[256];
-        unsigned int reslen = 0;
-# if __INITIAL_POINTER_SIZE == 64
-        ILEB_64 itemlist[2], *pitem;
-# else
-        ILE3 itemlist[2], *pitem;
-# endif
-        int status;
-        time_t t;
-
-
-        /*
-         * Setup an itemlist for the call to $TRNLNM - Translate Logical Name.
-         */
-        pitem = itemlist;
-
-# if __INITIAL_POINTER_SIZE == 64
-        pitem->ileb_64$w_mbo = 1;
-        pitem->ileb_64$w_code = LNM$_STRING;
-        pitem->ileb_64$l_mbmo = -1;
-        pitem->ileb_64$q_length = sizeof (logvalue);
-        pitem->ileb_64$pq_bufaddr = logvalue;
-        pitem->ileb_64$pq_retlen_addr = (unsigned __int64 *) &reslen;
-        pitem++;
-        /* Last item of the item list is null terminated */
-        pitem->ileb_64$q_length = pitem->ileb_64$w_code = 0;
-# else
-        pitem->ile3$w_length = sizeof (logvalue);
-        pitem->ile3$w_code = LNM$_STRING;
-        pitem->ile3$ps_bufaddr = logvalue;
-        pitem->ile3$ps_retlen_addr = (unsigned short int *) &reslen;
-        pitem++;
-        /* Last item of the item list is null terminated */
-        pitem->ile3$w_length = pitem->ile3$w_code = 0;
-# endif
-
-
-        /* Get the value for SYS$TIMEZONE_DIFFERENTIAL */
-        status = sys$trnlnm(0, &tabnam, &lognam, 0, itemlist);
-        if (!(status & 1))
-            return NULL;
-        logvalue[reslen] = '\0';
-
-        t = *timer;
-
-        /* The following is extracted from the DEC C header time.h */
-        /*
-         **  Beginning in OpenVMS Version 7.0 mktime, time, ctime, strftime
-         **  have two implementations.  One implementation is provided
-         **  for compatibility and deals with time in terms of local time,
-         **  the other __utc_* deals with time in terms of UTC.
-         */
-        /*
-         * We use the same conditions as in said time.h to check if we should
-         * assume that t contains local time (and should therefore be
-         * adjusted) or UTC (and should therefore be left untouched).
-         */
-# if __CRTL_VER < 70000000 || defined _VMS_V6_SOURCE
-        /* Get the numerical value of the equivalence string */
-        status = atoi(logvalue);
-
-        /* and use it to move time to GMT */
-        t -= status;
-# endif
-
-        /* then convert the result to the time structure */
-
-        /*
-         * Since there was no gmtime_r() to do this stuff for us, we have to
-         * do it the hard way.
-         */
-        {
-            /*-
-             * The VMS epoch is the astronomical Smithsonian date,
-               if I remember correctly, which is November 17, 1858.
-               Furthermore, time is measure in tenths of microseconds
-               and stored in quadwords (64 bit integers).  unix_epoch
-               below is January 1st 1970 expressed as a VMS time.  The
-               following code was used to get this number:
-
-               #include <stdio.h>
-               #include <stdlib.h>
-               #include <lib$routines.h>
-               #include <starlet.h>
-
-               main()
-               {
-                 unsigned long systime[2];
-                 unsigned short epoch_values[7] =
-                   { 1970, 1, 1, 0, 0, 0, 0 };
-
-                 lib$cvt_vectim(epoch_values, systime);
-
-                 printf("%u %u", systime[0], systime[1]);
-               }
-            */
-            unsigned long unix_epoch[2] = { 1273708544, 8164711 };
-            unsigned long deltatime[2];
-            unsigned long systime[2];
-            struct vms_vectime {
-                short year, month, day, hour, minute, second, centi_second;
-            } time_values;
-            long operation;
-
-            /*
-             * Turn the number of seconds since January 1st 1970 to an
-             * internal delta time. Note that lib$cvt_to_internal_time() will
-             * assume that t is signed, and will therefore break on 32-bit
-             * systems some time in 2038.
-             */
-            operation = LIB$K_DELTA_SECONDS;
-            status = lib$cvt_to_internal_time(&operation, &t, deltatime);
-
-            /*
-             * Add the delta time with the Unix epoch and we have the current
-             * UTC time in internal format
-             */
-            status = lib$add_times(unix_epoch, deltatime, systime);
-
-            /* Turn the internal time into a time vector */
-            status = sys$numtim(&time_values, systime);
-
-            /* Fill in the struct tm with the result */
-            result->tm_sec = time_values.second;
-            result->tm_min = time_values.minute;
-            result->tm_hour = time_values.hour;
-            result->tm_mday = time_values.day;
-            result->tm_mon = time_values.month - 1;
-            result->tm_year = time_values.year - 1900;
-
-            operation = LIB$K_DAY_OF_WEEK;
-            status = lib$cvt_from_internal_time(&operation,
-                                                &result->tm_wday, systime);
-            result->tm_wday %= 7;
-
-            operation = LIB$K_DAY_OF_YEAR;
-            status = lib$cvt_from_internal_time(&operation,
-                                                &result->tm_yday, systime);
-            result->tm_yday--;
-
-            result->tm_isdst = 0; /* There's no way to know... */
-
-            ts = result;
-        }
-    }
 #endif
     return ts;
 }


### PR DESCRIPTION
This reimplementation was necessary before VMS C V7.1.  Since that's
the minimum version we support in this OpenSSL version, the
reimplementation is no longer needed.

-----

Thank you @tmshort for the reminder.

To anyone who wants to double check the sanity of this removal, please have a look at the [VMS C release notes](http://h41379.www4.hpe.com/commercial/c/docs/rn_alphavms.html).