### PR TITLE
Removal of old VMS cruft

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -28,11 +28,7 @@
 
 #ifndef W_OK
 # ifdef OPENSSL_SYS_VMS
-#  if defined(__DECC)
-#   include <unistd.h>
-#  else
-#   include <unixlib.h>
-#  endif
+#  include <unistd.h>
 # elif !defined(OPENSSL_SYS_VXWORKS) && !defined(OPENSSL_SYS_WINDOWS)
 #  include <sys/file.h>
 # endif

--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -17,31 +17,6 @@
 # define _kbhit kbhit
 #endif
 
-#if defined(OPENSSL_SYS_VMS) && !defined(FD_SET)
-/*
- * VAX C does not defined fd_set and friends, but it's actually quite simple
- */
-/* These definitions are borrowed from SOCKETSHR.       /Richard Levitte */
-# define MAX_NOFILE      32
-# define NBBY             8     /* number of bits in a byte */
-
-# ifndef FD_SETSIZE
-#  define FD_SETSIZE      MAX_NOFILE
-# endif                         /* FD_SETSIZE */
-
-/* How many things we'll allow select to use. 0 if unlimited */
-# define MAXSELFD        MAX_NOFILE
-typedef int fd_mask;            /* int here! VMS prototypes int, not long */
-# define NFDBITS (sizeof(fd_mask) * NBBY)/* bits per mask (power of 2!) */
-# define NFDSHIFT 5             /* Shift based on above */
-
-typedef fd_mask fd_set;
-# define FD_SET(n, p)    (*(p) |= (1 << ((n) % NFDBITS)))
-# define FD_CLR(n, p)    (*(p) &= ~(1 << ((n) % NFDBITS)))
-# define FD_ISSET(n, p)  (*(p) & (1 << ((n) % NFDBITS)))
-# define FD_ZERO(p)      memset((p), 0, sizeof(*(p)))
-#endif
-
 #define PORT            "4433"
 #define PROTOCOL        "tcp"
 

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -13,11 +13,8 @@
 #include "bio_lcl.h"
 #ifndef OPENSSL_NO_DGRAM
 
-# if !(defined(_WIN32) || defined(OPENSSL_SYS_VMS))
+# if !defined(_WIN32)
 #  include <sys/time.h>
-# endif
-# if defined(OPENSSL_SYS_VMS)
-#  include <sys/timeb.h>
 # endif
 
 # ifndef OPENSSL_NO_SCTP
@@ -1939,11 +1936,6 @@ static void get_current_time(struct timeval *t)
 #  endif
     t->tv_sec = (long)(now.ul / 10000000);
     t->tv_usec = ((int)(now.ul % 10000000)) / 10;
-# elif defined(OPENSSL_SYS_VMS)
-    struct timeb tb;
-    ftime(&tb);
-    t->tv_sec = (long)tb.time;
-    t->tv_usec = (long)tb.millitm * 1000;
 # else
     gettimeofday(t, NULL);
 # endif

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -13,9 +13,7 @@
 #include <openssl/rand.h>
 #include "ssl_locl.h"
 
-#if defined(OPENSSL_SYS_VMS)
-# include <sys/timeb.h>
-#elif defined(OPENSSL_SYS_VXWORKS)
+#if defined(OPENSSL_SYS_VXWORKS)
 # include <sys/times.h>
 #elif !defined(OPENSSL_SYS_WIN32)
 # include <sys/time.h>
@@ -404,11 +402,6 @@ static void get_current_time(struct timeval *t)
 # endif
     t->tv_sec = (long)(now.ul / 10000000);
     t->tv_usec = ((int)(now.ul % 10000000)) / 10;
-#elif defined(OPENSSL_SYS_VMS)
-    struct timeb tb;
-    ftime(&tb);
-    t->tv_sec = (long)tb.time;
-    t->tv_usec = (long)tb.millitm * 1000;
 #else
     gettimeofday(t, NULL);
 #endif


### PR DESCRIPTION
This is code to fixup deficiencies in VAX C and older DEC C RTLs.  Since we only support DEC C V7.1 and up, thsi old cruft isn't useful any more.