### PR TITLE
Fix no-tls1_2 and no-dtls1_2

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -59,6 +59,8 @@ my %conf_dependent_tests = (
   "07-dtls-protocol-version.conf" => !$is_default_dtls,
   "10-resumption.conf" => !$is_default_tls,
   "11-dtls_resumption.conf" => !$is_default_dtls,
+  "17-renegotiate.conf" => disabled("tls1_2"),
+  "18-dtls-renegotiate.conf" => disabled("dtls1_2"),
   "19-mac-then-encrypt.conf" => !$is_default_tls,
   "20-cert-select.conf" => !$is_default_tls || $no_dh || $no_dsa,
 );

--- a/test/ssl-tests/17-renegotiate.conf.in
+++ b/test/ssl-tests/17-renegotiate.conf.in
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 
 package ssltests;
+use OpenSSL::Test::Utils;
 
 our @tests = (
     {
@@ -106,7 +107,9 @@ our @tests = (
             "ResumptionExpected" => "No",
             "ExpectedResult" => "Success"
         }
-    },
+    }
+);
+our @tests_tls1_2 = (
     {
         name => "renegotiate-aead-to-non-aead",
         server => {
@@ -182,5 +185,7 @@ our @tests = (
             "ResumptionExpected" => "No",
             "ExpectedResult" => "Success"
         }
-    },
+    }
 );
+
+push @tests, @tests_tls1_2 unless disabled("tls1_2");

--- a/test/ssl-tests/18-dtls-renegotiate.conf.in
+++ b/test/ssl-tests/18-dtls-renegotiate.conf.in
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 
 package ssltests;
+use OpenSSL::Test::Utils;
 
 our @tests = (
     {
@@ -92,7 +93,9 @@ our @tests = (
             "ResumptionExpected" => "No",
             "ExpectedResult" => "Success"
         }
-    },
+    }
+);
+our @tests_dtls1_2 = (
     {
         name => "renegotiate-aead-to-non-aead",
         server => {
@@ -166,3 +169,6 @@ our @tests = (
         }
     },
 );
+
+
+push @tests, @tests_dtls1_2 unless disabled("dtls1_2");

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -477,6 +477,7 @@ end:
 }
 #endif
 
+#ifndef OPENSSL_NO_TLS1_2
 static int full_early_callback(SSL *s, int *al, void *arg)
 {
     int *ctr = arg;
@@ -559,6 +560,7 @@ end:
 
     return testresult;
 }
+#endif
 
 static int execute_test_large_message(const SSL_METHOD *smeth,
                                       const SSL_METHOD *cmeth, int read_ahead)
@@ -1568,7 +1570,9 @@ int test_main(int argc, char *argv[])
 #ifndef OPENSSL_NO_TLS1_3
     ADD_TEST(test_keylog_no_master_key);
 #endif
+#ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_early_cb);
+#endif
 
     testresult = run_tests(argv[0]);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This fixes no-tls1_2 and no-dtls1_2 configurations. The commit changing sslapitest is for master only. The other commit is for both master and 1.1.0.