### PR TITLE
Fix a crash or unbounded allocation in RSA_padding_add_PKCS1_PSS_mgf1

### DIFF
--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -1,0 +1,49 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use File::Spec;
+use OpenSSL::Test qw/:DEFAULT with srctop_file/;
+use OpenSSL::Test::Utils;
+
+setup("test_rsapss");
+
+plan tests => 5;
+
+#using test/testrsa.pem which happens to be a 512 bit RSA
+ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha1',
+            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+            '-sigopt', 'rsa_mgf1_md:sha512', srctop_file('test', 'testrsa.pem')],
+           stdout => 'testrsapss.sig')),
+   "openssl dgst -sign");
+
+with({ exit_checker => sub { return shift == 1; } },
+     sub { ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha512',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+                       '-sigopt', 'rsa_mgf1_md:sha512', srctop_file('test', 'testrsa.pem')])),
+              "openssl dgst -sign, expect to fail gracefully");
+           ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha512',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:2147483647',
+                       '-sigopt', 'rsa_mgf1_md:sha1', srctop_file('test', 'testrsa.pem')])),
+              "openssl dgst -sign, expect to fail gracefully");
+           ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), '-sha512',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+                       '-sigopt', 'rsa_mgf1_md:sha512', '-signature', 'testrsapss.sig',
+                       srctop_file('test', 'testrsa.pem')])),
+              "openssl dgst -prverify, expect to fail gracefully");
+         });
+
+ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), '-sha1',
+            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+            '-sigopt', 'rsa_mgf1_md:sha512', '-signature', 'testrsapss.sig',
+            srctop_file('test', 'testrsa.pem')])),
+   "openssl dgst -prverify");
+unlink 'testrsapss.sig';


### PR DESCRIPTION
and RSA_verify_PKCS1_PSS_mgf1 with 512-bit RSA vs. sha-512.

@guidovranken: here is how I would like to fix the pss signature functions.
I hope this makes it clear what I meant with the comments on #2699.

I have test cases but don't know how to integrate that in the test framework.

```
openssl genrsa -out rsa.pem 512
openssl dgst -sign rsa.pem -sha512  -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-3 -sigopt rsa_mgf1_md:sha512 < /dev/null  > sig
=>crash
openssl dgst -sign rsa.pem -sha512  -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:2147483647 -sigopt rsa_mgf1_md:sha1 < /dev/null  > sig
=>allocates 2GB and crashes if that succeeds
```

for the problem in RSA_padding_verify I need first a data block
that can be decrypted by the RSA key and clear text ends with 0xBC.

```
openssl dgst -sign rsa.pem -sha1  -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-3 -sigopt rsa_mgf1_md:sha512 < /dev/null  > sig
=> prepares test data, does not crash
openssl dgst -prverify rsa.pem -sha512  -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-3 -sigopt rsa_mgf1_md:sha512 < /dev/null  -signature sig
=> tries to allocate -1, which fails silently but is flagged by asan
```