### PR TITLE
Code health: Unused reference to OPENSSL_BUILD_SHLIBSSL

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -68,11 +68,6 @@
 # include "internal/dane.h"
 # include "internal/refcount.h"
 
-# ifdef OPENSSL_BUILD_SHLIBSSL
-#  undef OPENSSL_EXTERN
-#  define OPENSSL_EXTERN OPENSSL_EXPORT
-# endif
-
 # undef PKCS1_CHECK
 
 # define c2l(c,l)        (l = ((unsigned long)(*((c)++)))     , \


### PR DESCRIPTION
##### Checklist
##### Description of change

This macro doesn't appear to be used, last mention of it in the change log refers to a perl file that no longer exists.