### PR TITLE
[code-health] Remove dead code in e_aes_cbc_hmac_{sha1,sha256}.c

### DIFF
--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -552,7 +552,6 @@ static int aesni_cbc_hmac_sha256_cipher(EVP_CIPHER_CTX *ctx,
             key->md = key->head;
             SHA256_Update(&key->md, key->aux.tls_aad, plen);
 
-# if 1
             len -= SHA256_DIGEST_LENGTH; /* amend mac */
             if (len >= (256 + SHA256_CBLOCK)) {
                 j = (len - (256 + SHA256_CBLOCK)) & (0 - SHA256_CBLOCK);
@@ -661,26 +660,7 @@ static int aesni_cbc_hmac_sha256_cipher(EVP_CIPHER_CTX *ctx,
             }
 #  endif
             len += SHA256_DIGEST_LENGTH;
-# else
-            SHA256_Update(&key->md, out, inp_len);
-            res = key->md.num;
-            SHA256_Final(pmac->c, &key->md);
 
-            {
-                unsigned int inp_blocks, pad_blocks;
-
-                /* but pretend as if we hashed padded payload */
-                inp_blocks =
-                    1 + ((SHA256_CBLOCK - 9 - res) >> (sizeof(res) * 8 - 1));
-                res += (unsigned int)(len - inp_len);
-                pad_blocks = res / SHA256_CBLOCK;
-                res %= SHA256_CBLOCK;
-                pad_blocks +=
-                    1 + ((SHA256_CBLOCK - 9 - res) >> (sizeof(res) * 8 - 1));
-                for (; inp_blocks < pad_blocks; inp_blocks++)
-                    sha1_block_data_order(&key->md, data, 1);
-            }
-# endif
             key->md = key->tail;
             SHA256_Update(&key->md, pmac->c, SHA256_DIGEST_LENGTH);
             SHA256_Final(pmac->c, &key->md);
@@ -688,7 +668,7 @@ static int aesni_cbc_hmac_sha256_cipher(EVP_CIPHER_CTX *ctx,
             /* verify HMAC */
             out += inp_len;
             len -= inp_len;
-# if 1
+
             {
                 unsigned char *p =
                     out + len - 1 - maxpad - SHA256_DIGEST_LENGTH;
@@ -711,21 +691,7 @@ static int aesni_cbc_hmac_sha256_cipher(EVP_CIPHER_CTX *ctx,
                 res = 0 - ((0 - res) >> (sizeof(res) * 8 - 1));
                 ret &= (int)~res;
             }
-# else
-            for (res = 0, i = 0; i < SHA256_DIGEST_LENGTH; i++)
-                res |= out[i] ^ pmac->c[i];
-            res = 0 - ((0 - res) >> (sizeof(res) * 8 - 1));
-            ret &= (int)~res;
 
-            /* verify padding */
-            pad = (pad & ~res) | (maxpad & res);
-            out = out + len - 1 - pad;
-            for (res = 0, i = 0; i < pad; i++)
-                res |= out[i] ^ pad;
-
-            res = (0 - res) >> (sizeof(res) * 8 - 1);
-            ret &= (int)~res;
-# endif
             return ret;
         } else {
             SHA256_Update(&key->md, out, len);


### PR DESCRIPTION
A few `#if 1` macro branches contained an unreachable `#else` block.
Removing these might help improve readability.

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Removes some dead code to help make the stitched functions more readable.
