### PR TITLE
Don't use deprecated EVP_CIPHER_CTX_cleanup() internally

### DIFF
--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -60,7 +60,7 @@ CMAC_CTX *CMAC_CTX_new(void)
 
 void CMAC_CTX_cleanup(CMAC_CTX *ctx)
 {
-    EVP_CIPHER_CTX_cleanup(ctx->cctx);
+    EVP_CIPHER_CTX_reset(ctx->cctx);
     OPENSSL_cleanse(ctx->tbl, EVP_MAX_BLOCK_LENGTH);
     OPENSSL_cleanse(ctx->k1, EVP_MAX_BLOCK_LENGTH);
     OPENSSL_cleanse(ctx->k2, EVP_MAX_BLOCK_LENGTH);


### PR DESCRIPTION
Use EVP_CIPHER_CTX_reset() instead

-----

Fixes #2808