### PR TITLE
TLSv1.3: Disallow compression

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -791,7 +791,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
 
         maxcomplen = pipelens[j];
         if (s->compress != NULL)
-            pipelens[j] += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
+            maxcomplen += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
 
         /* write the header */
         if (!WPACKET_put_bytes_u8(thispkt, rectype)

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1105,7 +1105,9 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
         return 0;
     }
 #ifndef OPENSSL_NO_COMP
-    if (ssl_allow_compression(s) && s->ctx->comp_methods) {
+    if (ssl_allow_compression(s)
+            && s->ctx->comp_methods
+            && (SSL_IS_DTLS(s) || s->s3->tmp.max_ver < TLS1_3_VERSION)) {
         int compnum = sk_SSL_COMP_num(s->ctx->comp_methods);
         for (i = 0; i < compnum; i++) {
             comp = sk_SSL_COMP_value(s->ctx->comp_methods, i);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1736,7 +1736,7 @@ static int tls_early_post_process_client_hello(SSL *s, int *al)
     s->s3->tmp.new_compression = NULL;
 #ifndef OPENSSL_NO_COMP
     /* This only happens if we have a cache hit */
-    if (s->session->compress_meth != 0) {
+    if (s->session->compress_meth != 0 && !SSL_IS_TLS13(s)) {
         int m, comp_id = s->session->compress_meth;
         unsigned int k;
         /* Perform sanity checks on resumed compression algorithm */
@@ -1770,9 +1770,10 @@ static int tls_early_post_process_client_hello(SSL *s, int *al)
                    SSL_R_REQUIRED_COMPRESSION_ALGORITHM_MISSING);
             goto err;
         }
-    } else if (s->hit)
+    } else if (s->hit) {
         comp = NULL;
-    else if (ssl_allow_compression(s) && s->ctx->comp_methods) {
+    } else if (ssl_allow_compression(s) && s->ctx->comp_methods
+                   && !SSL_IS_TLS13(s)) {
         /* See if we have a match */
         int m, nn, v, done = 0;
         unsigned int o;

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1207,6 +1207,9 @@ static HANDSHAKE_RESULT *do_handshake_internal(
         ret->session_ticket = SSL_TEST_SESSION_TICKET_NO;
     else
         ret->session_ticket = SSL_TEST_SESSION_TICKET_YES;
+    ret->compression = (SSL_get_current_compression(client.ssl) == NULL)
+                       ? SSL_TEST_COMPRESSION_NO
+                       : SSL_TEST_COMPRESSION_YES;
     ret->session_ticket_do_not_call = server_ex_data.session_ticket_do_not_call;
 
 #ifndef OPENSSL_NO_NEXTPROTONEG

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -34,6 +34,7 @@ typedef struct handshake_result {
     ssl_servername_t servername;
     /* Session ticket status */
     ssl_session_ticket_t session_ticket;
+    ssl_compression_t compression;
     /* Was this called on the second context? */
     int session_ticket_do_not_call;
     char *client_npn_negotiated;

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -34,7 +34,7 @@ typedef struct handshake_result {
     ssl_servername_t servername;
     /* Session ticket status */
     ssl_session_ticket_t session_ticket;
-    ssl_compression_t compression;
+    int compression;
     /* Was this called on the second context? */
     int session_ticket_do_not_call;
     char *client_npn_negotiated;

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -29,7 +29,7 @@ map { s/\^// } @conf_files if $^O eq "VMS";
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 21;  # = scalar @conf_srcs
+plan tests => 22;  # = scalar @conf_srcs
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.
@@ -63,6 +63,7 @@ my %conf_dependent_tests = (
   "18-dtls-renegotiate.conf" => disabled("dtls1_2"),
   "19-mac-then-encrypt.conf" => !$is_default_tls,
   "20-cert-select.conf" => !$is_default_tls || $no_dh || $no_dsa,
+  "22-compression.conf" => !$is_default_tls,
 );
 
 # Add your test here if it should be skipped for some compile-time
@@ -87,6 +88,7 @@ my %skip = (
   "19-mac-then-encrypt.conf" => $no_pre_tls1_3,
   "20-cert-select.conf" => disabled("tls1_2") || $no_ec,
   "21-key-update.conf" => disabled("tls1_3"),
+  "22-compression.conf" => disabled("zlib") || $no_tls,
 );
 
 foreach my $conf (@conf_files) {

--- a/test/ssl-tests/22-compression.conf
+++ b/test/ssl-tests/22-compression.conf
@@ -1,0 +1,112 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 4
+
+test-0 = 0-tlsv1_2-both-compress
+test-1 = 1-tlsv1_2-client-compress
+test-2 = 2-tlsv1_2-server-compress
+test-3 = 3-tlsv1_2-neither-compress
+# ===========================================================
+
+[0-tlsv1_2-both-compress]
+ssl_conf = 0-tlsv1_2-both-compress-ssl
+
+[0-tlsv1_2-both-compress-ssl]
+server = 0-tlsv1_2-both-compress-server
+client = 0-tlsv1_2-both-compress-client
+
+[0-tlsv1_2-both-compress-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = Compression
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-tlsv1_2-both-compress-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+Options = Compression
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+CompressionExpected = Yes
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[1-tlsv1_2-client-compress]
+ssl_conf = 1-tlsv1_2-client-compress-ssl
+
+[1-tlsv1_2-client-compress-ssl]
+server = 1-tlsv1_2-client-compress-server
+client = 1-tlsv1_2-client-compress-client
+
+[1-tlsv1_2-client-compress-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-tlsv1_2-client-compress-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+Options = Compression
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+CompressionExpected = No
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[2-tlsv1_2-server-compress]
+ssl_conf = 2-tlsv1_2-server-compress-ssl
+
+[2-tlsv1_2-server-compress-ssl]
+server = 2-tlsv1_2-server-compress-server
+client = 2-tlsv1_2-server-compress-client
+
+[2-tlsv1_2-server-compress-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = Compression
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-tlsv1_2-server-compress-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+CompressionExpected = No
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[3-tlsv1_2-neither-compress]
+ssl_conf = 3-tlsv1_2-neither-compress-ssl
+
+[3-tlsv1_2-neither-compress-ssl]
+server = 3-tlsv1_2-neither-compress-server
+client = 3-tlsv1_2-neither-compress-client
+
+[3-tlsv1_2-neither-compress-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-tlsv1_2-neither-compress-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+CompressionExpected = No
+ExpectedResult = Success
+
+

--- a/test/ssl-tests/22-compression.conf.in
+++ b/test/ssl-tests/22-compression.conf.in
@@ -1,0 +1,127 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## Test Compression
+
+use strict;
+use warnings;
+
+package ssltests;
+use OpenSSL::Test::Utils;
+
+our @tests = ();
+
+our @tests_tls1_3 = (
+    {
+        name => "tlsv1_3-both-compress",
+        server => {
+            "Options" => "Compression"
+        },
+        client => {
+            "Options" => "Compression"
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "tlsv1_3-client-compress",
+        server => {
+        },
+        client => {
+            "Options" => "Compression"
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "tlsv1_3-server-compress",
+        server => {
+            "Options" => "Compression"
+        },
+        client => {
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "tlsv1_3-neither-compress",
+        server => {
+        },
+        client => {
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+);
+our @tests_tls1_2 = (
+    {
+        name => "tlsv1_2-both-compress",
+        server => {
+            "Options" => "Compression"
+        },
+        client => {
+            "Options" => "Compression",
+            "MaxProtocol" => "TLSv1.2"
+        },
+        test => {
+            "CompressionExpected" => "Yes",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "tlsv1_2-client-compress",
+        server => {
+        },
+        client => {
+            "Options" => "Compression",
+            "MaxProtocol" => "TLSv1.2"
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "tlsv1_2-server-compress",
+        server => {
+            "Options" => "Compression"
+        },
+        client => {
+            "MaxProtocol" => "TLSv1.2"
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+    {
+        name => "tlsv1_2-neither-compress",
+        server => {
+        },
+        client => {
+            "MaxProtocol" => "TLSv1.2"
+        },
+        test => {
+            "CompressionExpected" => "No",
+            "ExpectedResult" => "Success"
+        }
+    },
+);
+
+push @tests, @tests_tls1_3 unless disabled("tls1_3");
+push @tests, @tests_tls1_2 unless alldisabled(("tls1_2", "tls1_1", "tls1",
+                                               "ssl3"));

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -149,9 +149,9 @@ static int check_session_ticket(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx
 static int check_compression(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
 {
     if (result->compression != test_ctx->compression_expected) {
-        fprintf(stderr, "Client CompressionExpected mismatch, expected %s, got %s\n.",
-                ssl_compression_name(test_ctx->compression_expected),
-                ssl_compression_name(result->compression));
+        fprintf(stderr, "Client CompressionExpected mismatch, expected %d, got %d\n.",
+                test_ctx->compression_expected,
+                result->compression);
         return 0;
     }
     return 1;

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -146,6 +146,16 @@ static int check_session_ticket(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx
     return 1;
 }
 
+static int check_compression(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
+{
+    if (result->compression != test_ctx->compression_expected) {
+        fprintf(stderr, "Client CompressionExpected mismatch, expected %s, got %s\n.",
+                ssl_compression_name(test_ctx->compression_expected),
+                ssl_compression_name(result->compression));
+        return 0;
+    }
+    return 1;
+}
 #ifndef OPENSSL_NO_NEXTPROTONEG
 static int check_npn(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
 {
@@ -259,6 +269,7 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
         ret &= check_protocol(result, test_ctx);
         ret &= check_servername(result, test_ctx);
         ret &= check_session_ticket(result, test_ctx);
+        ret &= check_compression(result, test_ctx);
         ret &= (result->session_ticket_do_not_call == 0);
 #ifndef OPENSSL_NO_NEXTPROTONEG
         ret &= check_npn(result, test_ctx);

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -288,26 +288,7 @@ const char *ssl_session_ticket_name(ssl_session_ticket_t server)
 
 /* CompressionExpected */
 
-static const test_enum ssl_compression[] = {
-    {"Yes", SSL_TEST_COMPRESSION_YES},
-    {"No", SSL_TEST_COMPRESSION_NO},
-};
-
-__owur static int parse_compression(SSL_TEST_CTX *test_ctx, const char *value)
-{
-    int ret_value;
-    if (!parse_enum(ssl_compression, OSSL_NELEM(ssl_compression),
-                    &ret_value, value)) {
-        return 0;
-    }
-    test_ctx->compression_expected = ret_value;
-    return 1;
-}
-
-const char *ssl_compression_name(ssl_compression_t comp)
-{
-    return enum_name(ssl_compression, OSSL_NELEM(ssl_compression), comp);
-}
+IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_CTX, test, compression_expected)
 
 /* Method */
 
@@ -564,7 +545,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedProtocol", &parse_protocol },
     { "ExpectedServerName", &parse_expected_servername },
     { "SessionTicketExpected", &parse_session_ticket },
-    { "CompressionExpected", &parse_compression },
+    { "CompressionExpected", &parse_test_compression_expected },
     { "Method", &parse_test_method },
     { "ExpectedNPNProtocol", &parse_test_expected_npn_protocol },
     { "ExpectedALPNProtocol", &parse_test_expected_alpn_protocol },

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -286,6 +286,29 @@ const char *ssl_session_ticket_name(ssl_session_ticket_t server)
                      server);
 }
 
+/* CompressionExpected */
+
+static const test_enum ssl_compression[] = {
+    {"Yes", SSL_TEST_COMPRESSION_YES},
+    {"No", SSL_TEST_COMPRESSION_NO},
+};
+
+__owur static int parse_compression(SSL_TEST_CTX *test_ctx, const char *value)
+{
+    int ret_value;
+    if (!parse_enum(ssl_compression, OSSL_NELEM(ssl_compression),
+                    &ret_value, value)) {
+        return 0;
+    }
+    test_ctx->compression_expected = ret_value;
+    return 1;
+}
+
+const char *ssl_compression_name(ssl_compression_t comp)
+{
+    return enum_name(ssl_compression, OSSL_NELEM(ssl_compression), comp);
+}
+
 /* Method */
 
 static const test_enum ssl_test_methods[] = {
@@ -541,6 +564,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedProtocol", &parse_protocol },
     { "ExpectedServerName", &parse_expected_servername },
     { "SessionTicketExpected", &parse_session_ticket },
+    { "CompressionExpected", &parse_compression },
     { "Method", &parse_test_method },
     { "ExpectedNPNProtocol", &parse_test_expected_npn_protocol },
     { "ExpectedALPNProtocol", &parse_test_expected_alpn_protocol },

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -52,6 +52,11 @@ typedef enum {
 } ssl_session_ticket_t;
 
 typedef enum {
+    SSL_TEST_COMPRESSION_NO = 0, /* Default */
+    SSL_TEST_COMPRESSION_YES
+} ssl_compression_t;
+
+typedef enum {
     SSL_TEST_METHOD_TLS = 0, /* Default */
     SSL_TEST_METHOD_DTLS
 } ssl_test_method_t;
@@ -163,6 +168,7 @@ typedef struct {
      */
     ssl_servername_t expected_servername;
     ssl_session_ticket_t session_ticket_expected;
+    ssl_compression_t compression_expected;
     /* The expected NPN/ALPN protocol to negotiate. */
     char *expected_npn_protocol;
     char *expected_alpn_protocol;
@@ -192,6 +198,7 @@ const char *ssl_servername_name(ssl_servername_t server);
 const char *ssl_servername_callback_name(ssl_servername_callback_t
                                          servername_callback);
 const char *ssl_session_ticket_name(ssl_session_ticket_t server);
+const char *ssl_compression_name(ssl_compression_t server);
 const char *ssl_test_method_name(ssl_test_method_t method);
 const char *ssl_handshake_mode_name(ssl_handshake_mode_t mode);
 const char *ssl_ct_validation_name(ssl_ct_validation_t mode);

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -168,7 +168,7 @@ typedef struct {
      */
     ssl_servername_t expected_servername;
     ssl_session_ticket_t session_ticket_expected;
-    ssl_compression_t compression_expected;
+    int compression_expected;
     /* The expected NPN/ALPN protocol to negotiate. */
     char *expected_npn_protocol;
     char *expected_alpn_protocol;
@@ -198,7 +198,6 @@ const char *ssl_servername_name(ssl_servername_t server);
 const char *ssl_servername_callback_name(ssl_servername_callback_t
                                          servername_callback);
 const char *ssl_session_ticket_name(ssl_session_ticket_t server);
-const char *ssl_compression_name(ssl_compression_t server);
 const char *ssl_test_method_name(ssl_test_method_t method);
 const char *ssl_handshake_mode_name(ssl_handshake_mode_t mode);
 const char *ssl_ct_validation_name(ssl_ct_validation_t mode);

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -173,6 +173,12 @@ static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
                 ssl_session_ticket_name(ctx2->session_ticket_expected));
         return 0;
     }
+    if (ctx->compression_expected != ctx2->compression_expected) {
+        fprintf(stderr, "ComrpessionExpected mismatch: %s vs %s.\n",
+                ssl_compression_name(ctx->compression_expected),
+                ssl_compression_name(ctx2->compression_expected));
+        return 0;
+    }
     if (!strings_equal("ExpectedNPNProtocol", ctx->expected_npn_protocol,
                        ctx2->expected_npn_protocol))
         return 0;
@@ -250,6 +256,7 @@ static int test_good_configuration()
     fixture.expected_ctx->expected_protocol = TLS1_1_VERSION;
     fixture.expected_ctx->expected_servername = SSL_TEST_SERVERNAME_SERVER2;
     fixture.expected_ctx->session_ticket_expected = SSL_TEST_SESSION_TICKET_YES;
+    fixture.expected_ctx->compression_expected = SSL_TEST_COMPRESSION_NO;
     fixture.expected_ctx->resumption_expected = 1;
 
     fixture.expected_ctx->extra.client.verify_callback =
@@ -284,6 +291,7 @@ static const char *bad_configurations[] = {
     "ssltest_unknown_servername",
     "ssltest_unknown_servername_callback",
     "ssltest_unknown_session_ticket_expected",
+    "ssltest_unknown_compression_expected",
     "ssltest_unknown_method",
     "ssltest_unknown_handshake_mode",
     "ssltest_unknown_resumption_expected",

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -174,9 +174,9 @@ static int SSL_TEST_CTX_equal(SSL_TEST_CTX *ctx, SSL_TEST_CTX *ctx2)
         return 0;
     }
     if (ctx->compression_expected != ctx2->compression_expected) {
-        fprintf(stderr, "ComrpessionExpected mismatch: %s vs %s.\n",
-                ssl_compression_name(ctx->compression_expected),
-                ssl_compression_name(ctx2->compression_expected));
+        fprintf(stderr, "ComrpessionExpected mismatch: %d vs %d.\n",
+                ctx->compression_expected,
+                ctx2->compression_expected);
         return 0;
     }
     if (!strings_equal("ExpectedNPNProtocol", ctx->expected_npn_protocol,

--- a/test/ssl_test_ctx_test.conf
+++ b/test/ssl_test_ctx_test.conf
@@ -72,6 +72,9 @@ ServerNameCallback = Foo
 [ssltest_unknown_session_ticket_expected]
 SessionTicketExpected = Foo
 
+[ssltest_unknown_compression_expected]
+CompressionExpected = Foo
+
 [ssltest_unknown_method]
 Method = TLS2
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Make sure that we can never negotiate compression in TLSv1.3. As per the spec this means that even if the server only support TLSv1.2, the client will never negotiate compression if it issues a TLSv1.3 compliant ClientHello.

I added tests for this but they will only run in an "enable-zlib" build. This means they won't get run by travis, but any problems should be picked up by run-checker.