### PR TITLE
Replace enum's in API with int's

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -489,7 +489,7 @@ void BIO_ADDRINFO_free(BIO_ADDRINFO *bai)
  *
  */
 int BIO_parse_hostserv(const char *hostserv, char **host, char **service,
-                       enum BIO_hostserv_priorities hostserv_prio)
+                       int hostserv_prio)
 {
     const char *h = NULL; size_t hl = 0;
     const char *p = NULL; size_t pl = 0;
@@ -652,7 +652,7 @@ DEFINE_RUN_ONCE_STATIC(do_bio_lookup_init)
  * The return value is 1 on success or 0 in case of error.
  */
 int BIO_lookup(const char *host, const char *service,
-               enum BIO_lookup_type lookup_type,
+               int lookup_type,
                int family, int socktype, BIO_ADDRINFO **res)
 {
     int ret = 0;                 /* Assume failure */

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -350,7 +350,7 @@ int BIO_socket_nbio(int s, int mode)
 }
 
 int BIO_sock_info(int sock,
-                  enum BIO_sock_info_type type, union BIO_sock_info_u *info)
+                  int type, union BIO_sock_info_u *info)
 {
     switch (type) {
     case BIO_SOCK_INFO_ADDRESS:

--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -58,7 +58,7 @@ err:
 }
 
 SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
-                         ct_log_entry_type_t entry_type, uint64_t timestamp,
+                         int entry_type, uint64_t timestamp,
                          const char *extensions_base64,
                          const char *signature_base64)
 {

--- a/crypto/ct/ct_locl.h
+++ b/crypto/ct/ct_locl.h
@@ -55,7 +55,7 @@
 
 /* Signed Certificate Timestamp */
 struct sct_st {
-    sct_version_t version;
+    int version;
     /* If version is not SCT_VERSION_V1, this contains the encoded SCT */
     unsigned char *sct;
     size_t sct_len;
@@ -75,11 +75,11 @@ struct sct_st {
     unsigned char *sig;
     size_t sig_len;
     /* Log entry type */
-    ct_log_entry_type_t entry_type;
+    int entry_type;
     /* Where this SCT was found, e.g. certificate, OCSP response, etc. */
-    sct_source_t source;
+    int source;
     /* The result of the last attempt to validate this SCT. */
-    sct_validation_status_t validation_status;
+    int validation_status;
 };
 
 /* Miscellaneous data that is useful when verifying an SCT  */

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -50,7 +50,7 @@ void SCT_LIST_free(STACK_OF(SCT) *a)
     sk_SCT_pop_free(a, SCT_free);
 }
 
-int SCT_set_version(SCT *sct, sct_version_t version)
+int SCT_set_version(SCT *sct, int version)
 {
     if (version != SCT_VERSION_V1) {
         CTerr(CT_F_SCT_SET_VERSION, CT_R_UNSUPPORTED_VERSION);
@@ -61,7 +61,7 @@ int SCT_set_version(SCT *sct, sct_version_t version)
     return 1;
 }
 
-int SCT_set_log_entry_type(SCT *sct, ct_log_entry_type_t entry_type)
+int SCT_set_log_entry_type(SCT *sct, int entry_type)
 {
     sct->validation_status = SCT_VALIDATION_STATUS_NOT_SET;
 
@@ -192,12 +192,12 @@ int SCT_set1_signature(SCT *sct, const unsigned char *sig, size_t sig_len)
     return 1;
 }
 
-sct_version_t SCT_get_version(const SCT *sct)
+int SCT_get_version(const SCT *sct)
 {
     return sct->version;
 }
 
-ct_log_entry_type_t SCT_get_log_entry_type(const SCT *sct)
+int SCT_get_log_entry_type(const SCT *sct)
 {
     return sct->entry_type;
 }
@@ -260,12 +260,12 @@ int SCT_signature_is_complete(const SCT *sct)
         sct->sig != NULL && sct->sig_len > 0;
 }
 
-sct_source_t SCT_get_source(const SCT *sct)
+int SCT_get_source(const SCT *sct)
 {
     return sct->source;
 }
 
-int SCT_set_source(SCT *sct, sct_source_t source)
+int SCT_set_source(SCT *sct, int source)
 {
     sct->source = source;
     sct->validation_status = SCT_VALIDATION_STATUS_NOT_SET;
@@ -282,7 +282,7 @@ int SCT_set_source(SCT *sct, sct_source_t source)
     return 1;
 }
 
-sct_validation_status_t SCT_get_validation_status(const SCT *sct)
+int SCT_get_validation_status(const SCT *sct)
 {
     return sct->validation_status;
 }

--- a/crypto/include/internal/x509_int.h
+++ b/crypto/include/internal/x509_int.h
@@ -256,7 +256,7 @@ struct X509_sig_st {
 
 struct x509_object_st {
     /* one of the above types */
-    X509_LOOKUP_TYPE type;
+    int type;
     union {
         char *ptr;
         X509 *x509;

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -94,7 +94,7 @@ static int allocate_string_stack(UI *ui)
 
 static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
                                           int prompt_freeable,
-                                          enum UI_string_types type,
+                                          int type,
                                           int input_flags, char *result_buf)
 {
     UI_STRING *ret = NULL;
@@ -116,7 +116,7 @@ static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
 
 static int general_allocate_string(UI *ui, const char *prompt,
                                    int prompt_freeable,
-                                   enum UI_string_types type, int input_flags,
+                                   int type, int input_flags,
                                    char *result_buf, int minsize, int maxsize,
                                    const char *test_buf)
 {
@@ -147,7 +147,7 @@ static int general_allocate_boolean(UI *ui,
                                     const char *ok_chars,
                                     const char *cancel_chars,
                                     int prompt_freeable,
-                                    enum UI_string_types type,
+                                    int type,
                                     int input_flags, char *result_buf)
 {
     int ret = -1;
@@ -706,7 +706,7 @@ const void *UI_method_get_ex_data(const UI_METHOD *method, int idx)
     return CRYPTO_get_ex_data(&method->ex_data, idx);
 }
 
-enum UI_string_types UI_get_string_type(UI_STRING *uis)
+int UI_get_string_type(UI_STRING *uis)
 {
     return uis->type;
 }

--- a/crypto/ui/ui_locl.h
+++ b/crypto/ui/ui_locl.h
@@ -53,7 +53,7 @@ struct ui_method_st {
 };
 
 struct ui_string_st {
-    enum UI_string_types type;  /* Input */
+    int type;  /* Input */
     const char *out_string;     /* Input */
     int input_flags;            /* Flags from the user */
     /*

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -48,7 +48,7 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
 static int new_dir(X509_LOOKUP *lu);
 static void free_dir(X509_LOOKUP *lu);
 static int add_cert_dir(BY_DIR *ctx, const char *dir, int type);
-static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
+static int get_cert_by_subject(X509_LOOKUP *xl, int type,
                                X509_NAME *name, X509_OBJECT *ret);
 static X509_LOOKUP_METHOD x509_dir_lookup = {
     "Load certs from files in a directory",
@@ -205,7 +205,7 @@ static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
     return 1;
 }
 
-static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
+static int get_cert_by_subject(X509_LOOKUP *xl, int type,
                                X509_NAME *name, X509_OBJECT *ret)
 {
     BY_DIR *ctx;

--- a/crypto/x509/x509_lcl.h
+++ b/crypto/x509/x509_lcl.h
@@ -76,15 +76,15 @@ struct x509_lookup_method_st {
     int (*shutdown) (X509_LOOKUP *ctx);
     int (*ctrl) (X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
                  char **ret);
-    int (*get_by_subject) (X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+    int (*get_by_subject) (X509_LOOKUP *ctx, int type,
                            X509_NAME *name, X509_OBJECT *ret);
-    int (*get_by_issuer_serial) (X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+    int (*get_by_issuer_serial) (X509_LOOKUP *ctx, int type,
                                  X509_NAME *name, ASN1_INTEGER *serial,
                                  X509_OBJECT *ret);
-    int (*get_by_fingerprint) (X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+    int (*get_by_fingerprint) (X509_LOOKUP *ctx, int type,
                                const unsigned char *bytes, int len,
                                X509_OBJECT *ret);
-    int (*get_by_alias) (X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+    int (*get_by_alias) (X509_LOOKUP *ctx, int type,
                          const char *str, int len, X509_OBJECT *ret);
 };
 

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -81,7 +81,7 @@ int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
         return 1;
 }
 
-int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, int type,
                            X509_NAME *name, X509_OBJECT *ret)
 {
     if ((ctx->method == NULL) || (ctx->method->get_by_subject == NULL))
@@ -91,7 +91,7 @@ int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
     return ctx->method->get_by_subject(ctx, type, name, ret);
 }
 
-int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, int type,
                                  X509_NAME *name, ASN1_INTEGER *serial,
                                  X509_OBJECT *ret)
 {
@@ -100,7 +100,7 @@ int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
     return ctx->method->get_by_issuer_serial(ctx, type, name, serial, ret);
 }
 
-int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, int type,
                                const unsigned char *bytes, int len,
                                X509_OBJECT *ret)
 {
@@ -109,7 +109,7 @@ int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
     return ctx->method->get_by_fingerprint(ctx, type, bytes, len, ret);
 }
 
-int X509_LOOKUP_by_alias(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_alias(X509_LOOKUP *ctx, int type,
                          const char *str, int len, X509_OBJECT *ret)
 {
     if ((ctx->method == NULL) || (ctx->method->get_by_alias == NULL))
@@ -258,7 +258,7 @@ X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *v, X509_LOOKUP_METHOD *m)
 }
 
 X509_OBJECT *X509_STORE_CTX_get_obj_by_subject(X509_STORE_CTX *vs,
-                                               X509_LOOKUP_TYPE type,
+                                               int type,
                                                X509_NAME *name)
 {
     X509_OBJECT *ret = X509_OBJECT_new();
@@ -272,7 +272,7 @@ X509_OBJECT *X509_STORE_CTX_get_obj_by_subject(X509_STORE_CTX *vs,
     return ret;
 }
 
-int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, X509_LOOKUP_TYPE type,
+int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, int type,
                                   X509_NAME *name, X509_OBJECT *ret)
 {
     X509_STORE *ctx = vs->ctx;
@@ -401,7 +401,7 @@ X509_CRL *X509_OBJECT_get0_X509_CRL(X509_OBJECT *a)
     return a->data.crl;
 }
 
-X509_LOOKUP_TYPE X509_OBJECT_get_type(const X509_OBJECT *a)
+int X509_OBJECT_get_type(const X509_OBJECT *a)
 {
     return a->type;
 }
@@ -436,7 +436,7 @@ void X509_OBJECT_free(X509_OBJECT *a)
     OPENSSL_free(a);
 }
 
-static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, X509_LOOKUP_TYPE type,
+static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, int type,
                                X509_NAME *name, int *pnmatch)
 {
     X509_OBJECT stmp;
@@ -475,14 +475,14 @@ static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, X509_LOOKUP_TYPE type,
     return idx;
 }
 
-int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h, X509_LOOKUP_TYPE type,
+int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h, int type,
                                X509_NAME *name)
 {
     return x509_object_idx_cnt(h, type, name, NULL);
 }
 
 X509_OBJECT *X509_OBJECT_retrieve_by_subject(STACK_OF(X509_OBJECT) *h,
-                                             X509_LOOKUP_TYPE type,
+                                             int type,
                                              X509_NAME *name)
 {
     int idx;

--- a/doc/man3/SCT_new.pod
+++ b/doc/man3/SCT_new.pod
@@ -17,28 +17,10 @@ SCT_get_source, SCT_set_source
 
  #include <openssl/ct.h>
 
- typedef enum {
-  CT_LOG_ENTRY_TYPE_NOT_SET = -1,
-  CT_LOG_ENTRY_TYPE_X509 = 0,
-  CT_LOG_ENTRY_TYPE_PRECERT = 1
- } ct_log_entry_type_t;
-
- typedef enum {
-  SCT_VERSION_NOT_SET = -1,
-  SCT_VERSION_V1 = 0
- } sct_version_t;
-
- typedef enum {
-  SCT_SOURCE_UNKNOWN,
-  SCT_SOURCE_TLS_EXTENSION,
-  SCT_SOURCE_X509V3_EXTENSION,
-  SCT_SOURCE_OCSP_STAPLED_RESPONSE
- } sct_source_t;
-
  SCT *SCT_new(void);
  SCT *SCT_new_from_base64(unsigned char version,
                           const char *logid_base64,
-                          ct_log_entry_type_t entry_type,
+                          int entry_type,
                           uint64_t timestamp,
                           const char *extensions_base64,
                           const char *signature_base64);
@@ -46,11 +28,11 @@ SCT_get_source, SCT_set_source
  void SCT_free(SCT *sct);
  void SCT_LIST_free(STACK_OF(SCT) *a);
 
- sct_version_t SCT_get_version(const SCT *sct);
- int SCT_set_version(SCT *sct, sct_version_t version);
+ int SCT_get_version(const SCT *sct);
+ int SCT_set_version(SCT *sct, int version);
 
- ct_log_entry_type_t SCT_get_log_entry_type(const SCT *sct);
- int SCT_set_log_entry_type(SCT *sct, ct_log_entry_type_t entry_type);
+ int SCT_get_log_entry_type(const SCT *sct);
+ int SCT_set_log_entry_type(SCT *sct, int entry_type);
 
  size_t SCT_get0_log_id(const SCT *sct, unsigned char **log_id);
  int SCT_set0_log_id(SCT *sct, unsigned char *log_id, size_t log_id_len);
@@ -70,8 +52,8 @@ SCT_get_source, SCT_set_source
  void SCT_set0_extensions(SCT *sct, unsigned char *ext, size_t ext_len);
  int SCT_set1_extensions(SCT *sct, const unsigned char *ext, size_t ext_len);
 
- sct_source_t SCT_get_source(const SCT *sct);
- int SCT_set_source(SCT *sct, sct_source_t source);
+ int SCT_get_source(const SCT *sct);
+ int SCT_set_source(SCT *sct, int source);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SCT_validate.pod
+++ b/doc/man3/SCT_validate.pod
@@ -9,18 +9,9 @@ checks Signed Certificate Timestamps (SCTs) are valid
 
  #include <openssl/ct.h>
 
- typedef enum {
-  SCT_VALIDATION_STATUS_NOT_SET,
-  SCT_VALIDATION_STATUS_UNKNOWN_LOG,
-  SCT_VALIDATION_STATUS_VALID,
-  SCT_VALIDATION_STATUS_INVALID,
-  SCT_VALIDATION_STATUS_UNVERIFIED,
-  SCT_VALIDATION_STATUS_UNKNOWN_VERSION
- } sct_validation_status_t;
-
  int SCT_validate(SCT *sct, const CT_POLICY_EVAL_CTX *ctx);
  int SCT_LIST_validate(const STACK_OF(SCT) *scts, CT_POLICY_EVAL_CTX *ctx);
- sct_validation_status_t SCT_get_validation_status(const SCT *sct);
+ int SCT_get_validation_status(const SCT *sct);
 
 =head1 DESCRIPTION
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -656,17 +656,14 @@ int BIO_ADDRINFO_protocol(const BIO_ADDRINFO *bai);
 const BIO_ADDR *BIO_ADDRINFO_address(const BIO_ADDRINFO *bai);
 void BIO_ADDRINFO_free(BIO_ADDRINFO *bai);
 
-enum BIO_hostserv_priorities {
-    BIO_PARSE_PRIO_HOST, BIO_PARSE_PRIO_SERV
-};
+# define BIO_PARSE_PRIO_HOST 0
+# define BIO_PARSE_PRIO_SERV 1
 int BIO_parse_hostserv(const char *hostserv, char **host, char **service,
-                       enum BIO_hostserv_priorities hostserv_prio);
-enum BIO_lookup_type {
-    BIO_LOOKUP_CLIENT, BIO_LOOKUP_SERVER
-};
+                       int hostserv_prio);
+# define BIO_LOOKUP_CLIENT 0
+# define BIO_LOOKUP_SERVER 1
 int BIO_lookup(const char *host, const char *service,
-               enum BIO_lookup_type lookup_type,
-               int family, int socktype, BIO_ADDRINFO **res);
+               int lookup_type, int family, int socktype, BIO_ADDRINFO **res);
 int BIO_sock_error(int sock);
 int BIO_socket_ioctl(int fd, long type, void *arg);
 int BIO_socket_nbio(int fd, int mode);
@@ -685,11 +682,8 @@ DEPRECATEDIN_1_1_0(int BIO_accept(int sock, char **ip_port))
 union BIO_sock_info_u {
     BIO_ADDR *addr;
 };
-enum BIO_sock_info_type {
-    BIO_SOCK_INFO_ADDRESS
-};
-int BIO_sock_info(int sock,
-                  enum BIO_sock_info_type type, union BIO_sock_info_u *info);
+# define BIO_SOCK_INFO_ADDRESS 0
+int BIO_sock_info(int sock, int type, union BIO_sock_info_u *info);
 
 #  define BIO_SOCK_REUSEADDR    0x01
 #  define BIO_SOCK_V6_ONLY      0x02

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -27,32 +27,24 @@ extern "C" {
 /* All hashes are SHA256 in v1 of Certificate Transparency */
 # define CT_V1_HASHLEN SHA256_DIGEST_LENGTH
 
-typedef enum {
-    CT_LOG_ENTRY_TYPE_NOT_SET = -1,
-    CT_LOG_ENTRY_TYPE_X509 = 0,
-    CT_LOG_ENTRY_TYPE_PRECERT = 1
-} ct_log_entry_type_t;
+# define CT_LOG_ENTRY_TYPE_NOT_SET -1
+# define CT_LOG_ENTRY_TYPE_X509 0
+# define CT_LOG_ENTRY_TYPE_PRECERT 1
 
-typedef enum {
-    SCT_VERSION_NOT_SET = -1,
-    SCT_VERSION_V1 = 0
-} sct_version_t;
+# define SCT_VERSION_NOT_SET -1
+# define SCT_VERSION_V1 0
 
-typedef enum {
-    SCT_SOURCE_UNKNOWN,
-    SCT_SOURCE_TLS_EXTENSION,
-    SCT_SOURCE_X509V3_EXTENSION,
-    SCT_SOURCE_OCSP_STAPLED_RESPONSE
-} sct_source_t;
+# define SCT_SOURCE_UNKNOWN 0
+# define SCT_SOURCE_TLS_EXTENSION 1
+# define SCT_SOURCE_X509V3_EXTENSION 2
+# define SCT_SOURCE_OCSP_STAPLED_RESPONSE 3
 
-typedef enum {
-    SCT_VALIDATION_STATUS_NOT_SET,
-    SCT_VALIDATION_STATUS_UNKNOWN_LOG,
-    SCT_VALIDATION_STATUS_VALID,
-    SCT_VALIDATION_STATUS_INVALID,
-    SCT_VALIDATION_STATUS_UNVERIFIED,
-    SCT_VALIDATION_STATUS_UNKNOWN_VERSION
-} sct_validation_status_t;
+# define SCT_VALIDATION_STATUS_NOT_SET 0
+# define SCT_VALIDATION_STATUS_UNKNOWN_LOG 1
+# define SCT_VALIDATION_STATUS_VALID 2
+# define SCT_VALIDATION_STATUS_INVALID 3
+# define SCT_VALIDATION_STATUS_UNVERIFIED 4
+# define SCT_VALIDATION_STATUS_UNKNOWN_VERSION 5
 
 DEFINE_STACK_OF(SCT)
 DEFINE_STACK_OF(CTLOG)
@@ -129,7 +121,7 @@ SCT *SCT_new(void);
  */
 SCT *SCT_new_from_base64(unsigned char version,
                          const char *logid_base64,
-                         ct_log_entry_type_t entry_type,
+                         int entry_type,
                          uint64_t timestamp,
                          const char *extensions_base64,
                          const char *signature_base64);
@@ -148,24 +140,24 @@ void SCT_LIST_free(STACK_OF(SCT) *a);
 /*
  * Returns the version of the SCT.
  */
-sct_version_t SCT_get_version(const SCT *sct);
+int SCT_get_version(const SCT *sct);
 
 /*
  * Set the version of an SCT.
  * Returns 1 on success, 0 if the version is unrecognized.
  */
-__owur int SCT_set_version(SCT *sct, sct_version_t version);
+__owur int SCT_set_version(SCT *sct, int version);
 
 /*
  * Returns the log entry type of the SCT.
  */
-ct_log_entry_type_t SCT_get_log_entry_type(const SCT *sct);
+int SCT_get_log_entry_type(const SCT *sct);
 
 /*
  * Set the log entry type of an SCT.
  * Returns 1 on success, 0 otherwise.
  */
-__owur int SCT_set_log_entry_type(SCT *sct, ct_log_entry_type_t entry_type);
+__owur int SCT_set_log_entry_type(SCT *sct, int entry_type);
 
 /*
  * Gets the ID of the log that an SCT came from.
@@ -258,13 +250,13 @@ __owur int SCT_set1_signature(SCT *sct, const unsigned char *sig,
 /*
  * The origin of this SCT, e.g. TLS extension, OCSP response, etc.
  */
-sct_source_t SCT_get_source(const SCT *sct);
+int SCT_get_source(const SCT *sct);
 
 /*
  * Set the origin of this SCT, e.g. TLS extension, OCSP response, etc.
  * Returns 1 on success, 0 otherwise.
  */
-__owur int SCT_set_source(SCT *sct, sct_source_t source);
+__owur int SCT_set_source(SCT *sct, int source);
 
 /*
  * Returns a text string describing the validation status of |sct|.
@@ -293,7 +285,7 @@ void SCT_LIST_print(const STACK_OF(SCT) *sct_list, BIO *out, int indent,
  * Gets the last result of validating this SCT.
  * If it has not been validated yet, returns SCT_VALIDATION_STATUS_NOT_SET.
  */
-sct_validation_status_t SCT_get_validation_status(const SCT *sct);
+int SCT_get_validation_status(const SCT *sct);
 
 /*
  * Validates the given SCT with the provided context.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -846,56 +846,54 @@ DEPRECATEDIN_1_1_0(void SSL_set_debug(SSL *s, int debug))
  * TLS_ST_BEFORE = No handshake has been initiated yet
  * TLS_ST_OK = A handshake has been successfully completed
  */
-typedef enum {
-    TLS_ST_BEFORE,
-    TLS_ST_OK,
-    DTLS_ST_CR_HELLO_VERIFY_REQUEST,
-    TLS_ST_CR_SRVR_HELLO,
-    TLS_ST_CR_CERT,
-    TLS_ST_CR_CERT_STATUS,
-    TLS_ST_CR_KEY_EXCH,
-    TLS_ST_CR_CERT_REQ,
-    TLS_ST_CR_SRVR_DONE,
-    TLS_ST_CR_SESSION_TICKET,
-    TLS_ST_CR_CHANGE,
-    TLS_ST_CR_FINISHED,
-    TLS_ST_CW_CLNT_HELLO,
-    TLS_ST_CW_CERT,
-    TLS_ST_CW_KEY_EXCH,
-    TLS_ST_CW_CERT_VRFY,
-    TLS_ST_CW_CHANGE,
-    TLS_ST_CW_NEXT_PROTO,
-    TLS_ST_CW_FINISHED,
-    TLS_ST_SW_HELLO_REQ,
-    TLS_ST_SR_CLNT_HELLO,
-    DTLS_ST_SW_HELLO_VERIFY_REQUEST,
-    TLS_ST_SW_SRVR_HELLO,
-    TLS_ST_SW_CERT,
-    TLS_ST_SW_KEY_EXCH,
-    TLS_ST_SW_CERT_REQ,
-    TLS_ST_SW_SRVR_DONE,
-    TLS_ST_SR_CERT,
-    TLS_ST_SR_KEY_EXCH,
-    TLS_ST_SR_CERT_VRFY,
-    TLS_ST_SR_NEXT_PROTO,
-    TLS_ST_SR_CHANGE,
-    TLS_ST_SR_FINISHED,
-    TLS_ST_SW_SESSION_TICKET,
-    TLS_ST_SW_CERT_STATUS,
-    TLS_ST_SW_CHANGE,
-    TLS_ST_SW_FINISHED,
-    TLS_ST_SW_ENCRYPTED_EXTENSIONS,
-    TLS_ST_CR_ENCRYPTED_EXTENSIONS,
-    TLS_ST_CR_CERT_VRFY,
-    TLS_ST_SW_CERT_VRFY,
-    TLS_ST_CR_HELLO_REQ,
-    TLS_ST_SW_HELLO_RETRY_REQUEST,
-    TLS_ST_CR_HELLO_RETRY_REQUEST,
-    TLS_ST_SW_KEY_UPDATE,
-    TLS_ST_CW_KEY_UPDATE,
-    TLS_ST_SR_KEY_UPDATE,
-    TLS_ST_CR_KEY_UPDATE
-} OSSL_HANDSHAKE_STATE;
+#define TLS_ST_BEFORE                           0
+#define TLS_ST_OK                               1
+#define DTLS_ST_CR_HELLO_VERIFY_REQUEST         2
+#define TLS_ST_CR_SRVR_HELLO                    3
+#define TLS_ST_CR_CERT                          4
+#define TLS_ST_CR_CERT_STATUS                   5
+#define TLS_ST_CR_KEY_EXCH                      6
+#define TLS_ST_CR_CERT_REQ                      7
+#define TLS_ST_CR_SRVR_DONE                     8
+#define TLS_ST_CR_SESSION_TICKET                9
+#define TLS_ST_CR_CHANGE                       10
+#define TLS_ST_CR_FINISHED                     11
+#define TLS_ST_CW_CLNT_HELLO                   12
+#define TLS_ST_CW_CERT                         13
+#define TLS_ST_CW_KEY_EXCH                     14
+#define TLS_ST_CW_CERT_VRFY                    15
+#define TLS_ST_CW_CHANGE                       16
+#define TLS_ST_CW_NEXT_PROTO                   17
+#define TLS_ST_CW_FINISHED                     18
+#define TLS_ST_SW_HELLO_REQ                    19
+#define TLS_ST_SR_CLNT_HELLO                   20
+#define DTLS_ST_SW_HELLO_VERIFY_REQUEST        21
+#define TLS_ST_SW_SRVR_HELLO                   22
+#define TLS_ST_SW_CERT                         23
+#define TLS_ST_SW_KEY_EXCH                     24
+#define TLS_ST_SW_CERT_REQ                     25
+#define TLS_ST_SW_SRVR_DONE                    26
+#define TLS_ST_SR_CERT                         27
+#define TLS_ST_SR_KEY_EXCH                     28
+#define TLS_ST_SR_CERT_VRFY                    29
+#define TLS_ST_SR_NEXT_PROTO                   30
+#define TLS_ST_SR_CHANGE                       31
+#define TLS_ST_SR_FINISHED                     32
+#define TLS_ST_SW_SESSION_TICKET               33
+#define TLS_ST_SW_CERT_STATUS                  34
+#define TLS_ST_SW_CHANGE                       35
+#define TLS_ST_SW_FINISHED                     36
+#define TLS_ST_SW_ENCRYPTED_EXTENSIONS         37
+#define TLS_ST_CR_ENCRYPTED_EXTENSIONS         38
+#define TLS_ST_CR_CERT_VRFY                    39
+#define TLS_ST_SW_CERT_VRFY                    40
+#define TLS_ST_CR_HELLO_REQ                    41
+#define TLS_ST_SW_HELLO_RETRY_REQUEST          42
+#define TLS_ST_CR_HELLO_RETRY_REQUEST          43
+#define TLS_ST_SW_KEY_UPDATE                   44
+#define TLS_ST_CW_KEY_UPDATE                   45
+#define TLS_ST_SR_KEY_UPDATE                   46
+#define TLS_ST_CR_KEY_UPDATE                   47
 
 /*
  * Most of the following state values are no longer used and are defined to be
@@ -1743,7 +1741,7 @@ void SSL_set_info_callback(SSL *ssl,
                            void (*cb) (const SSL *ssl, int type, int val));
 void (*SSL_get_info_callback(const SSL *ssl)) (const SSL *ssl, int type,
                                                int val);
-__owur OSSL_HANDSHAKE_STATE SSL_get_state(const SSL *ssl);
+__owur int SSL_get_state(const SSL *ssl);
 
 void SSL_set_verify_result(SSL *ssl, long v);
 __owur long SSL_get_verify_result(const SSL *ssl);
@@ -1934,10 +1932,8 @@ int SSL_CTX_set_ct_validation_callback(SSL_CTX *ctx,
  * CT validation callback selected via SSL_enable_ct() and SSL_CTX_enable_ct().
  * The underlying callback is a static function in libssl.
  */
-enum {
-    SSL_CT_VALIDATION_PERMISSIVE = 0,
-    SSL_CT_VALIDATION_STRICT
-};
+#define SSL_CT_VALIDATION_PERMISSIVE 0
+#define SSL_CT_VALIDATION_STRICT 1
 
 /*
  * Enable CT by setting up a callback that implements one of the built-in

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -266,14 +266,12 @@ DEFINE_STACK_OF(UI_STRING)
  * The different types of strings that are currently supported. This is only
  * needed by method authors.
  */
-enum UI_string_types {
-    UIT_NONE = 0,
-    UIT_PROMPT,                 /* Prompt for a string */
-    UIT_VERIFY,                 /* Prompt for a string and verify */
-    UIT_BOOLEAN,                /* Prompt for a yes/no response */
-    UIT_INFO,                   /* Send info to the user */
-    UIT_ERROR                   /* Send an error message to the user */
-};
+# define UIT_NONE 0
+# define UIT_PROMPT 1                 /* Prompt for a string */
+# define UIT_VERIFY 2                 /* Prompt for a string and verify */
+# define UIT_BOOLEAN 3                /* Prompt for a yes/no response */
+# define UIT_INFO 4                   /* Send info to the user */
+# define UIT_ERROR 5                  /* Send an error message to the user */
 
 /* Create and manipulate methods */
 UI_METHOD *UI_create_method(const char *name);
@@ -307,7 +305,7 @@ const void *UI_method_get_ex_data(const UI_METHOD *method, int idx);
  */
 
 /* Return type of the UI_STRING */
-enum UI_string_types UI_get_string_type(UI_STRING *uis);
+int UI_get_string_type(UI_STRING *uis);
 /* Return input flags of the UI_STRING */
 int UI_get_input_flags(UI_STRING *uis);
 /* Return the actual string to output (the prompt, info or error) */

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -44,10 +44,9 @@ The X509_STORE then calls a function to actually verify the
 certificate chain.
 */
 
-typedef enum {
-    X509_LU_NONE = 0,
-    X509_LU_X509, X509_LU_CRL
-} X509_LOOKUP_TYPE;
+#define X509_LU_NONE 0
+#define X509_LU_X509 1
+#define X509_LU_CRL 2
 
 #if OPENSSL_API_COMPAT < 0x10100000L
 #define X509_LU_RETRY   -1
@@ -245,17 +244,17 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
                                 | X509_V_FLAG_INHIBIT_ANY \
                                 | X509_V_FLAG_INHIBIT_MAP)
 
-int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h, X509_LOOKUP_TYPE type,
+int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h, int type,
                                X509_NAME *name);
 X509_OBJECT *X509_OBJECT_retrieve_by_subject(STACK_OF(X509_OBJECT) *h,
-                                             X509_LOOKUP_TYPE type,
+                                             int type,
                                              X509_NAME *name);
 X509_OBJECT *X509_OBJECT_retrieve_match(STACK_OF(X509_OBJECT) *h,
                                         X509_OBJECT *x);
 int X509_OBJECT_up_ref_count(X509_OBJECT *a);
 X509_OBJECT *X509_OBJECT_new(void);
 void X509_OBJECT_free(X509_OBJECT *a);
-X509_LOOKUP_TYPE X509_OBJECT_get_type(const X509_OBJECT *a);
+int X509_OBJECT_get_type(const X509_OBJECT *a);
 X509 *X509_OBJECT_get0_X509(const X509_OBJECT *a);
 X509_CRL *X509_OBJECT_get0_X509_CRL(X509_OBJECT *a);
 X509_STORE *X509_STORE_new(void);
@@ -368,10 +367,10 @@ X509_LOOKUP_METHOD *X509_LOOKUP_file(void);
 int X509_STORE_add_cert(X509_STORE *ctx, X509 *x);
 int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x);
 
-int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, X509_LOOKUP_TYPE type,
+int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, int type,
                                   X509_NAME *name, X509_OBJECT *ret);
 X509_OBJECT *X509_STORE_CTX_get_obj_by_subject(X509_STORE_CTX *vs,
-                                               X509_LOOKUP_TYPE type,
+                                               int type,
                                                X509_NAME *name);
 
 int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc,
@@ -384,15 +383,15 @@ int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type);
 X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method);
 void X509_LOOKUP_free(X509_LOOKUP *ctx);
 int X509_LOOKUP_init(X509_LOOKUP *ctx);
-int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, int type,
                            X509_NAME *name, X509_OBJECT *ret);
-int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, int type,
                                  X509_NAME *name, ASN1_INTEGER *serial,
                                  X509_OBJECT *ret);
-int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, int type,
                                const unsigned char *bytes, int len,
                                X509_OBJECT *ret);
-int X509_LOOKUP_by_alias(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
+int X509_LOOKUP_by_alias(X509_LOOKUP *ctx, int type,
                          const char *str, int len, X509_OBJECT *ret);
 int X509_LOOKUP_shutdown(X509_LOOKUP *ctx);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3952,7 +3952,7 @@ IMPLEMENT_OBJ_BSEARCH_GLOBAL_CMP_FN(SSL_CIPHER, SSL_CIPHER, ssl_cipher_id);
  * Returns the number of SCTs moved, or a negative integer if an error occurs.
  */
 static int ct_move_scts(STACK_OF(SCT) **dst, STACK_OF(SCT) *src,
-                        sct_source_t origin)
+                        int origin)
 {
     int scts_moved = 0;
     SCT *sct = NULL;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -61,7 +61,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s);
 static void init_write_state_machine(SSL *s);
 static SUB_STATE_RETURN write_state_machine(SSL *s);
 
-OSSL_HANDSHAKE_STATE SSL_get_state(const SSL *ssl)
+int SSL_get_state(const SSL *ssl)
 {
     return ssl->statem.hand_state;
 }

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -85,9 +85,9 @@ struct ossl_statem_st {
     WORK_STATE write_state_work;
     READ_STATE read_state;
     WORK_STATE read_state_work;
-    OSSL_HANDSHAKE_STATE hand_state;
+    int hand_state;
     /* The handshake state requested by an API call (e.g. HelloRequest) */
-    OSSL_HANDSHAKE_STATE request_state;
+    int request_state;
     int in_init;
     int read_state_first_init;
     /* true when we are actually in SSL_accept() or SSL_connect() */


### PR DESCRIPTION
sanitytest ensures that this PR is both API and ABI compatible.
