### PR TITLE
bio/b_addr.c: omit private hstrerror.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -179,7 +179,7 @@ sub vms_info {
         inherit_from     => [ "BASE_unix" ],
         template         => 1,
         cflags           => "-DFILIO_H",
-        ex_libs          => add("-lresolv -lsocket -lnsl -ldl"),
+        ex_libs          => add("-lsocket -lnsl -ldl"),
         dso_scheme       => "dlfcn",
         thread_scheme    => "pthreads",
         shared_target    => "solaris-shared",

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -18,30 +18,6 @@
 #include <internal/thread_once.h>
 #include <ctype.h>
 
-#ifdef _HPUX_SOURCE
-static const char *ossl_hstrerror(int herr)
-{
-    switch (herr) {
-    case -1:
-        return strerror(errno);
-    case 0:
-        return "No error";
-    case HOST_NOT_FOUND:
-        return "Host not found";
-    case NO_DATA:                /* NO_ADDRESS is a synonym */
-        return "No data";
-    case NO_RECOVERY:
-        return "Non recoverable error";
-    case TRY_AGAIN:
-        return "Try again";
-    default:
-        break;
-    }
-    return "unknown error";
-}
-# define hstrerror(e) ossl_hstrerror(e)
-#endif
-
 CRYPTO_RWLOCK *bio_lookup_lock;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
 
@@ -688,9 +664,10 @@ int BIO_lookup(const char *host, const char *service,
         return 0;
 
     if (1) {
-        int gai_ret = 0;
 #ifdef AI_PASSIVE
+        int gai_ret = 0;
         struct addrinfo hints;
+
         memset(&hints, 0, sizeof hints);
 
         hints.ai_family = family;
@@ -780,8 +757,18 @@ int BIO_lookup(const char *host, const char *service,
 
             if (he == NULL) {
 #ifndef OPENSSL_SYS_WINDOWS
-                BIOerr(BIO_F_BIO_LOOKUP, ERR_R_SYS_LIB);
-                ERR_add_error_data(1, hstrerror(h_errno));
+                /*
+                 * This might be misleading, because h_errno is used as if
+                 * it was errno. To minimize mixup add 1000. Underlying
+                 * reason for this is that hstrerror is declared obsolete,
+                 * not to mention that a) h_errno is not always guaranteed
+                 * to be meanigless; b) hstrerror can reside in yet another
+                 * library, linking for sake of hstrerror is an overkill;
+                 * c) this path is not executed on contemporary systems
+                 * anyway [above getaddrinfo/gai_strerror is]. We just let
+                 * system administrator figure this out...
+                 */
+                SYSerr(SYS_F_GETHOSTBYNAME, 1000 + h_errno);
 #else
                 SYSerr(SYS_F_GETHOSTBYNAME, WSAGetLastError());
 #endif
@@ -830,8 +817,7 @@ int BIO_lookup(const char *host, const char *service,
 
                 if (se == NULL) {
 #ifndef OPENSSL_SYS_WINDOWS
-                    BIOerr(BIO_F_BIO_LOOKUP, ERR_R_SYS_LIB);
-                    ERR_add_error_data(1, hstrerror(h_errno));
+                    SYSerr(SYS_F_GETSERVBYNAME, errno);
 #else
                     SYSerr(SYS_F_GETSERVBYNAME, WSAGetLastError());
 #endif


### PR DESCRIPTION
The issue was discussed in #2091. This partially reverts #2092 and fixes pair of minor bugs.