### PR TITLE
Disable SNI tests for no-tls builds

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -56,6 +56,7 @@ my $no_ocsp = disabled("ocsp");
 my %conf_dependent_tests = (
   "02-protocol-version.conf" => !$is_default_tls,
   "04-client_auth.conf" => !$is_default_tls,
+  "05-sni.conf" => $no_tls || disabled("tls1_1"),
   "07-dtls-protocol-version.conf" => !$is_default_dtls,
   "10-resumption.conf" => !$is_default_tls,
   "11-dtls_resumption.conf" => !$is_default_dtls,

--- a/test/ssl-tests/05-sni.conf.in
+++ b/test/ssl-tests/05-sni.conf.in
@@ -15,7 +15,9 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
-our @tests = (
+our @tests = ();
+
+our @tests_tls = (
     {
         name => "SNI-switch-context",
         server => {
@@ -145,6 +147,8 @@ our @tests = (
         },
     },
 );
+
+push @tests, @tests_tls unless disabled("tls");
 
 our @tests_tls_1_1 = (
     {


### PR DESCRIPTION
##### Description of change
Fixes #1723
Re-generate tests based on *tls flags. Tested using a standard build and a './config no-tls' build.