### PR TITLE
Document that RSA == kRSA for cipher strings

### DIFF
--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -219,7 +219,8 @@ When in doubt, include B<!aNULL> in your cipherlist.
 
 =item B<kRSA>, B<aRSA>, B<RSA>
 
-Cipher suites using RSA key exchange, authentication or either respectively.
+Cipher suites using RSA key exchange or authentication. B<RSA> is an alias for
+B<kRSA>.
 
 =item B<kDHr>, B<kDHd>, B<kDH>
 


### PR DESCRIPTION

- [x ] documentation is added or updated

Update the cipher(1) documentation to indicate that the RSA cipher string is the same as the kRSA one.

Fixes #2141.
