### PR TITLE
appveyor.yml: call upon cmd to redirect stderr.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build_script:
     - ps: >-
         If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
             cd _build
-            &nmake
+            nmake /nologo
             cd ..
         }
 
@@ -50,11 +50,11 @@ test_script:
         If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
             cd _build
             if ($env:EXTENDED_TESTS) {
-                &nmake test V=1
+                nmake /nologo test V=1
                 mkdir ..\_install
-                &nmake install install_docs DESTDIR=..\_install
+                nmake /nologo install install_docs DESTDIR=..\_install
             } Else {
-                &nmake test V=1 TESTS=-test_fuzz
+                nmake /nologo test V=1 TESTS=-test_fuzz
             }
             cd ..
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,8 @@ before_build:
     - perl ..\Configure %TARGET% %SHARED%
     - cd ..
     - ps: >-
-        if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER -or (&git log -2 | Select-String "\[extended tests\]") ) {
+        if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`
+            -or (&git log -2 | Select-String "\[extended tests\]") ) {
             $env:EXTENDED_TESTS="yes"
         }
 
@@ -41,7 +42,7 @@ build_script:
     - ps: >-
         If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
             cd _build
-            nmake /nologo
+            cmd /c "nmake 2>&1"
             cd ..
         }
 
@@ -50,11 +51,11 @@ test_script:
         If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
             cd _build
             if ($env:EXTENDED_TESTS) {
-                nmake /nologo test V=1
+                cmd /c "nmake test V=1 2>&1"
                 mkdir ..\_install
-                nmake /nologo install install_docs DESTDIR=..\_install
+                cmd /c "nmake install install_docs DESTDIR=..\_install 2>&1"
             } Else {
-                nmake /nologo test V=1 TESTS=-test_fuzz
+                cmd /c "nmake test V=1 TESTS=-test_fuzz 2>&1"
             }
             cd ..
         }


### PR DESCRIPTION
Ignored exception in #2810 seems to be bug in powershell. At least it's not present in latest-n-greatest. Problem seems to be that it's "allergic" to output at stderr... It might turn out that it's allergic to first output at stderr, in which case exception will just move elsewhere...
