### PR TITLE
Silence some clang warnings

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -148,7 +148,7 @@ static int dtlslisten = 0;
 static char *psk_identity = "Client_identity";
 char *psk_key = NULL;           /* by default PSK is not used */
 
-int early_data = 0;
+static int early_data = 0;
 
 static unsigned int psk_server_cb(SSL *ssl, const char *identity,
                                   unsigned char *psk,

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -681,7 +681,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     SSL_SESSION *sess = NULL;
     unsigned int id, i;
     const EVP_MD *md = NULL;
-    uint32_t ticket_age, now, agesec, agems;
+    uint32_t ticket_age = 0, now, agesec, agems;
 
     /*
      * If we have no PSK kex mode that we recognise then we can't resume so


### PR DESCRIPTION
The build fails when built with clang. This fixes it.
