### PR TITLE
Add missing usage hints how to generate primes

### DIFF
--- a/apps/prime.c
+++ b/apps/prime.c
@@ -155,5 +155,8 @@ int MAIN(int argc, char **argv)
     BIO_printf(bio_err, "options are\n");
     BIO_printf(bio_err, "%-14s hex\n", "-hex");
     BIO_printf(bio_err, "%-14s number of checks\n", "-checks <n>");
+    BIO_printf(bio_err, "%-14s generate prime\n", "-generate");
+    BIO_printf(bio_err, "%-14s number of bits\n", "-bits <n>");
+    BIO_printf(bio_err, "%-14s safe prime\n", "-safe");
     return 1;
 }


### PR DESCRIPTION
For 1.0.2 additional options of prime command are implemented
but the usage help does not advertise them.