### PR TITLE
Fix a memory leak on an error path

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -796,6 +796,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     s->session = sess;
     return 1;
 err:
+    SSL_SESSION_free(sess);
     return 0;
 }
 


### PR DESCRIPTION
A leak of an SSL_SESSION object can occur when decoding a psk extension on
an error path when using TLSv1.3
