### PR TITLE
crypto/x86_64cpuid.pl: move extended feature detection upwards.

### DIFF
--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -72,6 +72,16 @@ OPENSSL_ia32_cpuid:
 	cpuid
 	mov	%eax,%r11d		# max value for standard query level
 
+	cmp	\$7,%eax
+	jb	.Lno_extended_info
+
+	mov	\$7,%eax
+	xor	%ecx,%ecx
+	cpuid
+	mov	%ebx,8(%rdi)
+
+.Lno_extended_info:
+
 	xor	%eax,%eax
 	cmp	\$0x756e6547,%ebx	# "Genu"
 	setne	%al
@@ -135,14 +145,6 @@ OPENSSL_ia32_cpuid:
 	mov	%eax,%r10d
 	shr	\$14,%r10d
 	and	\$0xfff,%r10d		# number of cores -1 per L1D
-
-	cmp	\$7,%r11d
-	jb	.Lnocacheinfo
-
-	mov	\$7,%eax
-	xor	%ecx,%ecx
-	cpuid
-	mov	%ebx,8(%rdi)
 
 .Lnocacheinfo:
 	mov	\$1,%eax


### PR DESCRIPTION
Extenede feature flags was not pulled on AMD processors, as result a number
of extensions were effectively masked on Ryzen. It should been reported for
Excavator since it implements AVX2 extension, but apparently nobody noticed
or cared...

Should fix #2848.