### PR TITLE
Add a platform specific configuration checker

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -1,3 +1,20 @@
+Intro
+=====
+
+This directory contains a few sets of files that are used for
+configuration in diverse ways:
+
+    *.conf      Target platform configurations, please read
+                'Configurations of OpenSSL target platforms' for more
+                information.
+    *.tmpl      Build file templates, please read 'Build-file
+                programming with the "unified" build system' as well
+                as 'Build info files' for more information.
+    *.pm        Helper scripts / modules for the main `Configure`
+                script.  See 'Configure helper scripts for more
+                information.
+
+
 Configurations of OpenSSL target platforms
 ==========================================
 
@@ -672,3 +689,23 @@ else, end it like this:
 
       "";       # Make sure no lingering values end up in the Makefile
     -}
+
+
+Configure helper scripts
+========================
+
+Configure uses helper scripts in this directory:
+
+Checker scripts
+---------------
+
+These scripts are per platform family, to check the integrity of the
+tools used for configuration and building.  The checker script used is
+either {build_platform}-{build_file}-checker.pm or
+{build_platform}-checker.pm, where {build_platform} is the second
+'build_scheme' list element from the configuration target data, and
+{build_file} is 'build_file' from the same target data.
+
+If the check succeeds, the script is expected to end with a non-zero
+expression.  If the check fails, the script can end with a zero, or
+with a `die`.

--- a/Configurations/unix-checker.pm
+++ b/Configurations/unix-checker.pm
@@ -10,8 +10,9 @@ if (rel2abs('.') !~ m|/|) {
     die <<EOF;
 
 ******************************************************************************
-This perl version doesn't produce Unix like paths (with forward slash
-directory separators).  Please use an implementation that does.
+This perl implementation doesn't produce Unix like paths (with forward slash
+directory separators).  Please use an implementation that matches your
+building platform.
 
 This Perl version: $Config{version} for $Config{archname}
 ******************************************************************************

--- a/Configurations/unix-checker.pm
+++ b/Configurations/unix-checker.pm
@@ -1,0 +1,21 @@
+#! /usr/bin/perl
+
+use Config;
+
+# Check that the perl implementation file modules generate paths that
+# we expect for the platform
+use File::Spec::Functions qw(:DEFAULT rel2abs);
+
+if (rel2abs('.') !~ m|/|) {
+    die <<EOF;
+
+******************************************************************************
+This perl version doesn't produce Unix like paths (with forward slash
+directory separators).  Please use an implementation that does.
+
+This Perl version: $Config{version} for $Config{archname}
+******************************************************************************
+EOF
+}
+
+1;

--- a/Configurations/windows-checker.pm
+++ b/Configurations/windows-checker.pm
@@ -1,0 +1,21 @@
+#! /usr/bin/perl
+
+use Config;
+
+# Check that the perl implementation file modules generate paths that
+# we expect for the platform
+use File::Spec::Functions qw(:DEFAULT rel2abs);
+
+if (rel2abs('.') !~ m|\\|) {
+    die <<EOF;
+
+******************************************************************************
+This perl version doesn't produce Windows like paths (with backward slash
+directory separators).  Please use an implementation that does.
+
+This Perl version: $Config{version} for $Config{archname}
+******************************************************************************
+EOF
+}
+
+1;

--- a/Configurations/windows-checker.pm
+++ b/Configurations/windows-checker.pm
@@ -10,8 +10,9 @@ if (rel2abs('.') !~ m|\\|) {
     die <<EOF;
 
 ******************************************************************************
-This perl version doesn't produce Windows like paths (with backward slash
-directory separators).  Please use an implementation that does.
+This perl implementation doesn't produce Windows like paths (with backward
+slash directory separators).  Please use an implementation that matches your
+building platform.
 
 This Perl version: $Config{version} for $Config{archname}
 ******************************************************************************

--- a/Configure
+++ b/Configure
@@ -993,6 +993,25 @@ $target{build_scheme} = [ $target{build_scheme} ]
 my ($builder, $builder_platform, @builder_opts) =
     @{$target{build_scheme}};
 
+foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
+                      $builder_platform."-checker.pm")) {
+    my $checker_path = catfile($srcdir, "Configurations", $checker);
+    if (-f $checker_path) {
+        my $fn = $ENV{CONFIGURE_CHECKER_WARN}
+            ? sub { warn $@; } : sub { die $@; };
+        if (! do $checker_path) {
+            if ($@) {
+                $fn->($@);
+            } elsif ($!) {
+                $fn->($!);
+            } else {
+                $fn->("The detected tools didn't match the platform\n");
+            }
+        }
+        last;
+    }
+}
+
 push @{$config{defines}}, "NDEBUG"    if $config{build_type} eq "release";
 
 if ($target =~ /^mingw/ && `$target{cc} --target-help 2>&1` =~ m/-mno-cygwin/m)


### PR DESCRIPTION
For each platform, we may need to perform some basic checks to see
that available tools perform as we expect them.

For the moment, the added checkers test that Perl gives the expected
path format.  This should help MingW users to see if they run an
appropriate Perl implementation, for example.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated

-----

Fixes #2846