### PR TITLE
improved s390x support

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -208,6 +208,7 @@ static int AES_ige_192_encrypt_loop(void *args);
 static int AES_ige_256_encrypt_loop(void *args);
 static int CRYPTO_gcm128_aad_loop(void *args);
 static int EVP_Update_loop(void *args);
+static int EVP_Update_loop_ccm(void *args);
 static int EVP_Digest_loop(void *args);
 #ifndef OPENSSL_NO_RSA
 static int RSA_sign_loop(void *args);
@@ -875,6 +876,39 @@ static int EVP_Update_loop(void *args)
         EVP_EncryptFinal_ex(ctx, buf, &outl);
     return count;
 }
+/*
+ * CCM does not support streaming. For the purpose of performance measurement,
+ * each block is encrypted here individually, using the same (key,iv)-pair.
+ * Please do not use this code in you application.
+ */
+static int EVP_Update_loop_ccm(void *args)
+{
+    loopargs_t *tempargs = *(loopargs_t **) args;
+    unsigned char *buf = tempargs->buf;
+    EVP_CIPHER_CTX *ctx = tempargs->ctx;
+    int outl, count;
+    unsigned char tag[12];
+#ifndef SIGALRM
+    int nb_iter = save_count * 4 * lengths[0] / lengths[testnum];
+#endif
+    if (decrypt) {
+        for (count = 0; COND(nb_iter); count++) {
+            EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv);
+            EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, sizeof(tag), tag);
+            EVP_DecryptUpdate(ctx, NULL, &outl, NULL, lengths[testnum]);
+            EVP_DecryptUpdate(ctx, buf, &outl, buf, lengths[testnum]);
+            EVP_DecryptFinal_ex(ctx, buf, &outl);
+        }
+    } else {
+        for (count = 0; COND(nb_iter); count++) {
+            EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv);
+            EVP_EncryptUpdate(ctx, NULL, &outl, NULL, lengths[testnum]);
+            EVP_EncryptUpdate(ctx, buf, &outl, buf, lengths[testnum]);
+            EVP_EncryptFinal_ex(ctx, buf, &outl);
+        }
+    }
+    return count;
+}
 
 static const EVP_MD *evp_md = NULL;
 static int EVP_Digest_loop(void *args)
@@ -1199,6 +1233,7 @@ static int run_benchmark(int async_jobs,
 int speed_main(int argc, char **argv)
 {
     ENGINE *e = NULL;
+    int (*loopfunc)(void *args);
     loopargs_t *loopargs = NULL;
     int async_init = 0;
     int loopargs_len = 0;
@@ -2312,9 +2347,18 @@ int speed_main(int argc, char **argv)
                                            key16, iv);
                     EVP_CIPHER_CTX_set_padding(loopargs[k].ctx, 0);
                 }
+                switch (EVP_CIPHER_nid(evp_cipher)) {
+                case NID_aes_128_ccm:
+                case NID_aes_192_ccm:
+                case NID_aes_256_ccm:
+                    loopfunc = EVP_Update_loop_ccm;
+                    break;
+                default:
+                    loopfunc = EVP_Update_loop;
+                }
 
                 Time_F(START);
-                count = run_benchmark(async_jobs, EVP_Update_loop, loopargs);
+                count = run_benchmark(async_jobs, loopfunc, loopargs);
                 d = Time_F(STOP);
                 for (k = 0; k < loopargs_len; k++) {
                     EVP_CIPHER_CTX_free(loopargs[k].ctx);

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1439,7 +1439,7 @@ $code.=<<___ if (!$softonly);
 
 .Lctr32_hw_switch:
 ___
-$code.=<<___ if (0);	######### kmctr code was measured to be ~12% slower
+$code.=<<___ if (!$softonly && 0);# kmctr code was measured to be ~12% slower
 	larl	$s0,OPENSSL_s390xcap_P
 	lg	$s0,8($s0)
 	tmhh	$s0,0x0004	# check for message_security-assist-4
@@ -1488,7 +1488,7 @@ $code.=<<___ if (0);	######### kmctr code was measured to be ~12% slower
 	br	$ra
 .align	16
 ___
-$code.=<<___;
+$code.=<<___ if (!$softonly);
 .Lctr32_km_loop:
 	la	$s2,16($sp)
 	lgr	$s3,$fp

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -823,8 +823,8 @@ $code.=<<___ if (!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000
 	srlg	%r0,%r0,0(%r5)
-	ng	%r0,32(%r1)	# check km capability vector
-	ng	%r0,48(%r1)	# check kmc capability vector
+	ng	%r0,40(%r1)	# check km capability vector
+	ng	%r0,56(%r1)	# check kmc capability vector
 	jz	.Lekey_internal
 
 	lmg	%r0,%r1,0($inp)	# just copy 128 bits...
@@ -1442,7 +1442,7 @@ $code.=<<___ if (!$softonly && 0);# kmctr code was measured to be ~12% slower
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kmctr supports the function code
 	srlg	%r0,%r0,0($s0)
-	ng	%r0,64(%r1)	# check kmctr capability vector
+	ng	%r0,72(%r1)	# check kmctr capability vector
 	lgr	%r0,$s0
 	lgr	%r1,$s1
 	jz	.Lctr32_km_loop
@@ -1592,7 +1592,7 @@ $code.=<<___ if(1);
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000
 	srlg	%r0,%r0,32($s1)		# check for 32+function code
-	ng	%r0,32(%r1)		# check km capability vector
+	ng	%r0,40(%r1)		# check km capability vector
 	lgr	%r0,$s0			# restore the function code
 	la	%r1,0($key1)		# restore $key1
 	jz	.Lxts_km_vanilla
@@ -2219,7 +2219,7 @@ ___
 }
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,80,8
+.comm	OPENSSL_s390xcap_P,88,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1413,7 +1413,7 @@ $code.=<<___ if (!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kma supports the function code
 	srlg	%r0,%r0,0($s2)
-	ng	%r0,136(%r1)	# check kma capability vector
+	ng	%r0,152(%r1)	# check kma capability vector
 	lgr	%r0,$s2
 	jz	.Lctr32_nokma
 
@@ -2463,7 +2463,7 @@ ___
 
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,152,8
+.comm	OPENSSL_s390xcap_P,168,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1411,7 +1411,7 @@ $code.=<<___ if (!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kma supports the function code
 	srlg	%r0,%r0,0($s2)
-	ng	%r0,88(%r1)	# check kma capability vector
+	ng	%r0,104(%r1)	# check kma capability vector
 	lgr	%r0,$s2
 	jz	.Lctr32_nokma
 
@@ -1481,7 +1481,7 @@ $code.=<<___ if (!$softonly && 0);# kmctr code was measured to be ~12% slower
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kmctr supports the function code
 	srlg	%r0,%r0,0($s0)
-	ng	%r0,72(%r1)	# check kmctr capability vector
+	ng	%r0,88(%r1)	# check kmctr capability vector
 	lgr	%r0,$s0
 	lgr	%r1,$s1
 	jz	.Lctr32_km_loop
@@ -2321,7 +2321,7 @@ ___
 
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,104,8
+.comm	OPENSSL_s390xcap_P,120,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2219,7 +2219,7 @@ ___
 }
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,88,8
+.comm	OPENSSL_s390xcap_P,104,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -821,12 +821,9 @@ $code.=<<___ if (!$softonly);
 	ar	%r5,%r0
 
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,0(%r1)
-	tmhl	%r0,0x4000	# check for message-security assist
-	jz	.Lekey_internal
-
 	llihh	%r0,0x8000
 	srlg	%r0,%r0,0(%r5)
+	ng	%r0,32(%r1)	# check km capability vector
 	ng	%r0,48(%r1)	# check kmc capability vector
 	jz	.Lekey_internal
 
@@ -1440,11 +1437,6 @@ $code.=<<___ if (!$softonly);
 .Lctr32_hw_switch:
 ___
 $code.=<<___ if (!$softonly && 0);# kmctr code was measured to be ~12% slower
-	larl	$s0,OPENSSL_s390xcap_P
-	lg	$s0,8($s0)
-	tmhh	$s0,0x0004	# check for message_security-assist-4
-	jz	.Lctr32_km_loop
-
 	llgfr	$s0,%r0
 	lgr	$s1,%r1
 	larl	%r1,OPENSSL_s390xcap_P

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2334,7 +2334,9 @@ $code.=<<___ if (!$softonly);
 .type	s390x_aes_ofb_blocks,\@function
 .align	16
 s390x_aes_ofb_blocks:
+.cfi_startproc
 	aghi	$sp,-48
+	.cfi_adjust_cfa_offset 48
 	l	%r0,240($key)	# kmo capability vector checked by caller
 
 	mvc	0(16,$sp),0($iv)
@@ -2347,7 +2349,9 @@ s390x_aes_ofb_blocks:
 	mvc	0(16,$iv),0($sp)
 	xc	0(48,$sp),0($sp)	# wipe iv,key
 	la	$sp,48($sp)
+	.cfi_adjust_cfa_offset -48
 	br	$ra
+.cfi_endproc
 .size	s390x_aes_ofb_blocks,.-s390x_aes_ofb_blocks
 ___
 }

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1413,7 +1413,7 @@ $code.=<<___ if (!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kma supports the function code
 	srlg	%r0,%r0,0($s2)
-	ng	%r0,120(%r1)	# check kma capability vector
+	ng	%r0,136(%r1)	# check kma capability vector
 	lgr	%r0,$s2
 	jz	.Lctr32_nokma
 
@@ -2380,7 +2380,7 @@ ___
 
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,136,8
+.comm	OPENSSL_s390xcap_P,152,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2270,10 +2270,15 @@ $code.=<<___ if (!$softonly);
 .type	s390x_aes_gcm_blocks,\@function
 .align	16
 s390x_aes_gcm_blocks:
+.cfi_startproc
 	stm$g	$alen,$enc,7*$SIZE_T($sp)
+	.cfi_rel_offset $alen,7*$SIZE_T
+	.cfi_rel_offset $key,8*$SIZE_T
+	.cfi_rel_offset $enc,9*$SIZE_T
 	lm$g	$alen,$enc,$stdframe($sp)
 
 	aghi	$sp,-112
+	.cfi_adjust_cfa_offset 112
 
 	lmg	%r0,%r1,0($ctx)
 	ahi	%r1,-1
@@ -2300,11 +2305,16 @@ s390x_aes_gcm_blocks:
 	xc	0(112,$sp),0($sp)	# wipe stack
 
 	la	$sp,112($sp)
+	.cfi_adjust_cfa_offset -112
 	ahi	%r0,1
 	st	%r0,12($ctx)
 
 	lm$g	$alen,$enc,7*$SIZE_T($sp)
+	.cfi_restore $alen
+	.cfi_restore $key
+	.cfi_restore $enc
 	br	$ra
+.cfi_endproc
 .size	s390x_aes_gcm_blocks,.-s390x_aes_gcm_blocks
 ___
 }

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1411,7 +1411,7 @@ $code.=<<___ if (!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kma supports the function code
 	srlg	%r0,%r0,0($s2)
-	ng	%r0,104(%r1)	# check kma capability vector
+	ng	%r0,120(%r1)	# check kma capability vector
 	lgr	%r0,$s2
 	jz	.Lctr32_nokma
 
@@ -2321,7 +2321,7 @@ ___
 
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,120,8
+.comm	OPENSSL_s390xcap_P,136,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2390,9 +2390,13 @@ $code.=<<___ if (!$softonly);
 .type	s390x_aes_cfb_blocks,\@function
 .align	16
 s390x_aes_cfb_blocks:
+.cfi_startproc
 	stm$g	$s,$enc,7*$SIZE_T($sp)
+	.cfi_rel_offset $s,7*$SIZE_T
+	.cfi_rel_offset $enc,8*$SIZE_T
 	lm$g	$s,$enc,$stdframe($sp)
 	aghi	$sp,-48
+	.cfi_adjust_cfa_offset 48
 	lhi	%r1,128
 
 	sllg	%r0,$s,24
@@ -2412,8 +2416,12 @@ s390x_aes_cfb_blocks:
 	xc	0(48,$sp),0($sp)	# wipe iv,key
 
 	la	$sp,48($sp)
+	.cfi_adjust_cfa_offset -48
 	lm$g	$s,$enc,7*$SIZE_T($sp)
+	.cfi_restore $s
+	.cfi_restore $enc
 	br	$ra
+.cfi_endproc
 .size	s390x_aes_cfb_blocks,.-s390x_aes_cfb_blocks
 ___
 }

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1392,6 +1392,7 @@ $code.=<<___;
 .type	AES_ctr32_encrypt,\@function
 .align	16
 AES_ctr32_encrypt:
+.cfi_startproc
 	xgr	%r3,%r4		# flip %r3 and %r4, $out and $len
 	xgr	%r4,%r3
 	xgr	%r3,%r4
@@ -1404,6 +1405,8 @@ $code.=<<___ if (!$softonly);
 	jl	.Lctr32_software
 
 	stm${g}	$s2,$s3,10*$SIZE_T($sp)
+	.cfi_rel_offset $s2,10*$SIZE_T
+	.cfi_rel_offset $s3,11*$SIZE_T
 	llgfr	$s2,%r0
 	larl	%r1,OPENSSL_s390xcap_P
 	llihh	%r0,0x8000	# check if kma supports the function code
@@ -1413,6 +1416,7 @@ $code.=<<___ if (!$softonly);
 	jz	.Lctr32_nokma
 
 	aghi	$sp,-112
+	.cfi_adjust_cfa_offset 112
 	lhi	%r1,0x0600
 	sllg	$len,$len,4
 	or	%r0,%r1		# set HS and LAAD flags
@@ -1429,7 +1433,10 @@ $code.=<<___ if (!$softonly);
 
 	xc	80(32,$sp),80($sp)	# wipe key copy
 	la	$sp,112($sp)
+	.cfi_adjust_cfa_offset -112
 	lm${g}	$s2,$s3,10*$SIZE_T($sp)
+	.cfi_restore $s2
+	.cfi_restore $s3
 	br	$ra
 
 .align	16
@@ -1594,6 +1601,7 @@ $code.=<<___;
 
 	lm${g}	%r6,$ra,6*$SIZE_T($sp)
 	br	$ra
+.cfi_endproc
 .size	AES_ctr32_encrypt,.-AES_ctr32_encrypt
 ___
 }

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2437,7 +2437,9 @@ $code.=<<___ if (!$softonly);
 .type	s390x_aes_cbc_mac_blocks,\@function
 .align	16
 s390x_aes_cbc_mac_blocks:
+.cfi_startproc
 	aghi	$sp,-48
+	.cfi_adjust_cfa_offset 48
 	l	%r0,240($key)	# kmac capability vector checked by caller
 	nill	%r0,0xff7f	# clear "decrypt" bit
 
@@ -2452,7 +2454,9 @@ s390x_aes_cbc_mac_blocks:
 	xc	0(48,$sp),0($sp)	# wipe mac,key
 
 	la	$sp,48($sp)
+	.cfi_adjust_cfa_offset -48
 	br	$ra
+.cfi_endproc
 .size	s390x_aes_cbc_mac_blocks,.-s390x_aes_cbc_mac_blocks
 ___
 }

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2356,6 +2356,28 @@ s390x_aes_ofb_blocks:
 ___
 }
 
+################
+# void s390x_aes_ecb_blocks(unsigned char *out, const AES_KEY *key,
+#                           const unsigned char *in, size_t len)
+{
+my ($out,$key,$in,$len) = map("%r$_",(2..5));
+
+$code.=<<___ if (!$softonly);
+.globl	s390x_aes_ecb_blocks
+.type	s390x_aes_ecb_blocks,\@function
+.align	16
+s390x_aes_ecb_blocks:
+	l	%r0,240($key)	# km capability vector checked by caller
+	la	%r1,0($key)
+
+	.long	0xb92e0024	# km $out,$in
+	brc	1,.-4		# pay attention to "partial completion"
+
+	br	$ra
+.size	s390x_aes_ecb_blocks,.-s390x_aes_ecb_blocks
+___
+}
+
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
 .comm	OPENSSL_s390xcap_P,136,8

--- a/crypto/chacha/asm/chacha-s390x.pl
+++ b/crypto/chacha/asm/chacha-s390x.pl
@@ -596,6 +596,6 @@ LONG	(0x0b0a0908,0x0f0e0d0c,0x1b1a1918,0x1f1e1d1c);	# vperm serialization
 ASCIZ	("\"ChaCha20 for s390x, CRYPTOGAMS by <appro\@openssl.org>\"");
 ALIGN	(4);
 
-COMM	("OPENSSL_s390xcap_P",152,8);
+COMM	("OPENSSL_s390xcap_P",168,8);
 
 PERLASM_END();

--- a/crypto/chacha/asm/chacha-s390x.pl
+++ b/crypto/chacha/asm/chacha-s390x.pl
@@ -20,23 +20,21 @@
 #
 # 3 times faster than compiler-generated code.
 
+use FindBin qw($Bin);
+use lib "$Bin/../..";
+use perlasm::s390x qw(:DEFAULT AUTOLOAD LABEL);
+
 $flavour = shift;
 
 if ($flavour =~ /3[12]/) {
+	$z=0;	# S/390 ABI
 	$SIZE_T=4;
-	$g="";
 } else {
+	$z=1;	# zSeries ABI
 	$SIZE_T=8;
-	$g="g";
 }
 
 while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
-open STDOUT,">$output";
-
-sub AUTOLOAD()		# thunk [simplified] x86-style perlasm
-{ my $opcode = $AUTOLOAD; $opcode =~ s/.*:://;
-    $code .= "\t$opcode\t".join(',',@_)."\n";
-}
 
 my $sp="%r15";
 
@@ -53,8 +51,7 @@ my ($a0,$b0,$c0,$d0)=@_;
 my ($a1,$b1,$c1,$d1)=map(($_&~3)+(($_+1)&3),($a0,$b0,$c0,$d0));
 my ($a2,$b2,$c2,$d2)=map(($_&~3)+(($_+1)&3),($a1,$b1,$c1,$d1));
 my ($a3,$b3,$c3,$d3)=map(($_&~3)+(($_+1)&3),($a2,$b2,$c2,$d2));
-my ($xc,$xc_)=map("\"$_\"",@t);
-my @x=map("\"$_\"",@x);
+my ($xc,$xc_)=map("$_",@t);
 
 	# Consider order in which variables are addressed by their
 	# index:
@@ -78,249 +75,240 @@ my @x=map("\"$_\"",@x);
 	# 'c' stores and loads in the middle, but none in the beginning
 	# or end.
 
-	(
-	"&alr	(@x[$a0],@x[$b0])",	# Q1
-	 "&alr	(@x[$a1],@x[$b1])",	# Q2
-	"&xr	(@x[$d0],@x[$a0])",
-	 "&xr	(@x[$d1],@x[$a1])",
-	"&rll	(@x[$d0],@x[$d0],16)",
-	 "&rll	(@x[$d1],@x[$d1],16)",
+	alr	(@x[$a0],@x[$b0]);	# Q1
+	 alr	(@x[$a1],@x[$b1]);	# Q2
+	xr	(@x[$d0],@x[$a0]);
+	 xr	(@x[$d1],@x[$a1]);
+	rll	(@x[$d0],@x[$d0],16);
+	 rll	(@x[$d1],@x[$d1],16);
 
-	"&alr	($xc,@x[$d0])",
-	 "&alr	($xc_,@x[$d1])",
-	"&xr	(@x[$b0],$xc)",
-	 "&xr	(@x[$b1],$xc_)",
-	"&rll	(@x[$b0],@x[$b0],12)",
-	 "&rll	(@x[$b1],@x[$b1],12)",
+	alr	($xc,@x[$d0]);
+	 alr	($xc_,@x[$d1]);
+	xr	(@x[$b0],$xc);
+	 xr	(@x[$b1],$xc_);
+	rll	(@x[$b0],@x[$b0],12);
+	 rll	(@x[$b1],@x[$b1],12);
 
-	"&alr	(@x[$a0],@x[$b0])",
-	 "&alr	(@x[$a1],@x[$b1])",
-	"&xr	(@x[$d0],@x[$a0])",
-	 "&xr	(@x[$d1],@x[$a1])",
-	"&rll	(@x[$d0],@x[$d0],8)",
-	 "&rll	(@x[$d1],@x[$d1],8)",
+	alr	(@x[$a0],@x[$b0]);
+	 alr	(@x[$a1],@x[$b1]);
+	xr	(@x[$d0],@x[$a0]);
+	 xr	(@x[$d1],@x[$a1]);
+	rll	(@x[$d0],@x[$d0],8);
+	 rll	(@x[$d1],@x[$d1],8);
 
-	"&alr	($xc,@x[$d0])",
-	 "&alr	($xc_,@x[$d1])",
-	"&xr	(@x[$b0],$xc)",
-	 "&xr	(@x[$b1],$xc_)",
-	"&rll	(@x[$b0],@x[$b0],7)",
-	 "&rll	(@x[$b1],@x[$b1],7)",
+	alr	($xc,@x[$d0]);
+	 alr	($xc_,@x[$d1]);
+	xr	(@x[$b0],$xc);
+	 xr	(@x[$b1],$xc_);
+	rll	(@x[$b0],@x[$b0],7);
+	 rll	(@x[$b1],@x[$b1],7);
 
-	"&stm	($xc,$xc_,'$stdframe+4*8+4*$c0($sp)')",	# reload pair of 'c's
-	"&lm	($xc,$xc_,'$stdframe+4*8+4*$c2($sp)')",
+	stm	($xc,$xc_,"$stdframe+4*8+4*$c0($sp)");	# reload pair of 'c's
+	lm	($xc,$xc_,"$stdframe+4*8+4*$c2($sp)");
 
-	"&alr	(@x[$a2],@x[$b2])",	# Q3
-	 "&alr	(@x[$a3],@x[$b3])",	# Q4
-	"&xr	(@x[$d2],@x[$a2])",
-	 "&xr	(@x[$d3],@x[$a3])",
-	"&rll	(@x[$d2],@x[$d2],16)",
-	 "&rll	(@x[$d3],@x[$d3],16)",
+	alr	(@x[$a2],@x[$b2]);	# Q3
+	 alr	(@x[$a3],@x[$b3]);	# Q4
+	xr	(@x[$d2],@x[$a2]);
+	 xr	(@x[$d3],@x[$a3]);
+	rll	(@x[$d2],@x[$d2],16);
+	 rll	(@x[$d3],@x[$d3],16);
 
-	"&alr	($xc,@x[$d2])",
-	 "&alr	($xc_,@x[$d3])",
-	"&xr	(@x[$b2],$xc)",
-	 "&xr	(@x[$b3],$xc_)",
-	"&rll	(@x[$b2],@x[$b2],12)",
-	 "&rll	(@x[$b3],@x[$b3],12)",
+	alr	($xc,@x[$d2]);
+	 alr	($xc_,@x[$d3]);
+	xr	(@x[$b2],$xc);
+	 xr	(@x[$b3],$xc_);
+	rll	(@x[$b2],@x[$b2],12);
+	 rll	(@x[$b3],@x[$b3],12);
 
-	"&alr	(@x[$a2],@x[$b2])",
-	 "&alr	(@x[$a3],@x[$b3])",
-	"&xr	(@x[$d2],@x[$a2])",
-	 "&xr	(@x[$d3],@x[$a3])",
-	"&rll	(@x[$d2],@x[$d2],8)",
-	 "&rll	(@x[$d3],@x[$d3],8)",
+	alr	(@x[$a2],@x[$b2]);
+	 alr	(@x[$a3],@x[$b3]);
+	xr	(@x[$d2],@x[$a2]);
+	 xr	(@x[$d3],@x[$a3]);
+	rll	(@x[$d2],@x[$d2],8);
+	 rll	(@x[$d3],@x[$d3],8);
 
-	"&alr	($xc,@x[$d2])",
-	 "&alr	($xc_,@x[$d3])",
-	"&xr	(@x[$b2],$xc)",
-	 "&xr	(@x[$b3],$xc_)",
-	"&rll	(@x[$b2],@x[$b2],7)",
-	 "&rll	(@x[$b3],@x[$b3],7)"
-	);
+	alr	($xc,@x[$d2]);
+	 alr	($xc_,@x[$d3]);
+	xr	(@x[$b2],$xc);
+	 xr	(@x[$b3],$xc_);
+	rll	(@x[$b2],@x[$b2],7);
+	 rll	(@x[$b3],@x[$b3],7);
 }
 
-$code.=<<___;
-.text
+PERLASM_BEGIN($output);
 
-.globl	ChaCha20_ctr32
-.type	ChaCha20_ctr32,\@function
-.align	32
-ChaCha20_ctr32:
-	lt${g}r	$len,$len			# $len==0?
-	bzr	%r14
-	a${g}hi	$len,-64
-	l${g}hi	%r1,-$frame
-	stm${g}	%r6,%r15,`6*$SIZE_T`($sp)
-	sl${g}r	$out,$inp			# difference
-	la	$len,0($inp,$len)		# end of input minus 64
-	larl	%r7,.Lsigma
-	lgr	%r0,$sp
-	la	$sp,0(%r1,$sp)
-	st${g}	%r0,0($sp)
+TEXT	();
 
-	lmg	%r8,%r11,0($key)		# load key
-	lmg	%r12,%r13,0($counter)		# load counter
-	lmg	%r6,%r7,0(%r7)			# load sigma constant
+GLOBL	("ChaCha20_ctr32");
+TYPE	("ChaCha20_ctr32","\@function");
+ALIGN	(32);
+LABEL	("ChaCha20_ctr32");
+&{$z?	\&ltgr:\&ltr}	($len,$len);	# $len==0?
+	bzr	("%r14");
+&{$z?	\&aghi:\&ahi}	($len,-64);
+&{$z?	\&lghi:\&lhi}	("%r1",-$frame);
+&{$z?	\&stmg:\&stm}	("%r6","%r15","6*$SIZE_T($sp)");
+&{$z?	\&slgr:\&slr}	($out,$inp);	# difference
+	la	($len,"0($inp,$len)");	# end of input minus 64
+	larl	("%r7",".Lsigma");
+	lgr	("%r0",$sp);
+	la	($sp,"0(%r1,$sp)");
+&{$z?	\&stg:\&st}	("%r0","0($sp)");
 
-	la	%r14,0($inp)
-	st${g}	$out,$frame+3*$SIZE_T($sp)
-	st${g}	$len,$frame+4*$SIZE_T($sp)
-	stmg	%r6,%r13,$stdframe($sp)		# copy key schedule to stack
-	srlg	@x[12],%r12,32			# 32-bit counter value
-	j	.Loop_outer
+	lmg	("%r8","%r11","0($key)");	# load key
+	lmg	("%r12","%r13","0($counter)");	# load counter
+	lmg	("%r6","%r7","0(%r7)");	# load sigma constant
 
-.align	16
-.Loop_outer:
-	lm	@x[0],@x[7],$stdframe+4*0($sp)		# load x[0]-x[7]
-	lm	@t[0],@t[1],$stdframe+4*10($sp)		# load x[10]-x[11]
-	lm	@x[13],@x[15],$stdframe+4*13($sp)	# load x[13]-x[15]
-	stm	@t[0],@t[1],$stdframe+4*8+4*10($sp)	# offload x[10]-x[11]
-	lm	@t[0],@t[1],$stdframe+4*8($sp)		# load x[8]-x[9]
-	st	@x[12],$stdframe+4*12($sp)		# save counter
-	st${g}	%r14,$frame+2*$SIZE_T($sp)		# save input pointer
-	lhi	%r14,10
-	j	.Loop
+	la	("%r14","0($inp)");
+&{$z?	\&stg:\&st}	($out,"$frame+3*$SIZE_T($sp)");
+&{$z?	\&stg:\&st}	($len,"$frame+4*$SIZE_T($sp)");
+	stmg	("%r6","%r13","$stdframe($sp)");# copy key schedule to stack
+	srlg	(@x[12],"%r12",32);	# 32-bit counter value
+	j	(".Loop_outer");
 
-.align	4
-.Loop:
-___
-	foreach (&ROUND(0, 4, 8,12)) { eval; }
-	foreach (&ROUND(0, 5,10,15)) { eval; }
-$code.=<<___;
-	brct	%r14,.Loop
+ALIGN	(16);
+LABEL	(".Loop_outer");
+	lm	(@x[0],@x[7],"$stdframe+4*0($sp)");	# load x[0]-x[7]
+	lm	(@t[0],@t[1],"$stdframe+4*10($sp)");	# load x[10]-x[11]
+	lm	(@x[13],@x[15],"$stdframe+4*13($sp)");	# load x[13]-x[15]
+	stm	(@t[0],@t[1],"$stdframe+4*8+4*10($sp)");# offload x[10]-x[11]
+	lm	(@t[0],@t[1],"$stdframe+4*8($sp)");	# load x[8]-x[9]
+	st	(@x[12],"$stdframe+4*12($sp)");	# save counter
+&{$z?	\&stg:\&st}	("%r14","$frame+2*$SIZE_T($sp)");# save input pointer
+	lhi	("%r14",10);
+	j	(".Loop");
 
-	l${g}	%r14,$frame+2*$SIZE_T($sp)		# pull input pointer
-	stm	@t[0],@t[1],$stdframe+4*8+4*8($sp)	# offload x[8]-x[9]
-	lm${g}	@t[0],@t[1],$frame+3*$SIZE_T($sp)
+ALIGN	(4);
+LABEL	(".Loop");
+	ROUND	(0, 4, 8,12);
+	ROUND	(0, 5,10,15);
+	brct	("%r14",".Loop");
 
-	al	@x[0],$stdframe+4*0($sp)	# accumulate key schedule
-	al	@x[1],$stdframe+4*1($sp)
-	al	@x[2],$stdframe+4*2($sp)
-	al	@x[3],$stdframe+4*3($sp)
-	al	@x[4],$stdframe+4*4($sp)
-	al	@x[5],$stdframe+4*5($sp)
-	al	@x[6],$stdframe+4*6($sp)
-	al	@x[7],$stdframe+4*7($sp)
-	lrvr	@x[0],@x[0]
-	lrvr	@x[1],@x[1]
-	lrvr	@x[2],@x[2]
-	lrvr	@x[3],@x[3]
-	lrvr	@x[4],@x[4]
-	lrvr	@x[5],@x[5]
-	lrvr	@x[6],@x[6]
-	lrvr	@x[7],@x[7]
-	al	@x[12],$stdframe+4*12($sp)
-	al	@x[13],$stdframe+4*13($sp)
-	al	@x[14],$stdframe+4*14($sp)
-	al	@x[15],$stdframe+4*15($sp)
-	lrvr	@x[12],@x[12]
-	lrvr	@x[13],@x[13]
-	lrvr	@x[14],@x[14]
-	lrvr	@x[15],@x[15]
+&{$z?	\&lg:\&l}	("%r14","$frame+2*$SIZE_T($sp)");# pull input pointer
+	stm	(@t[0],@t[1],"$stdframe+4*8+4*8($sp)");	# offload x[8]-x[9]
+&{$z?	\&lmg:\&lm}	(@t[0],@t[1],"$frame+3*$SIZE_T($sp)");
 
-	la	@t[0],0(@t[0],%r14)		# reconstruct output pointer
-	cl${g}r	%r14,@t[1]
-	jh	.Ltail
+	al	(@x[0],"$stdframe+4*0($sp)");	# accumulate key schedule
+	al	(@x[1],"$stdframe+4*1($sp)");
+	al	(@x[2],"$stdframe+4*2($sp)");
+	al	(@x[3],"$stdframe+4*3($sp)");
+	al	(@x[4],"$stdframe+4*4($sp)");
+	al	(@x[5],"$stdframe+4*5($sp)");
+	al	(@x[6],"$stdframe+4*6($sp)");
+	al	(@x[7],"$stdframe+4*7($sp)");
+	lrvr	(@x[0],@x[0]);
+	lrvr	(@x[1],@x[1]);
+	lrvr	(@x[2],@x[2]);
+	lrvr	(@x[3],@x[3]);
+	lrvr	(@x[4],@x[4]);
+	lrvr	(@x[5],@x[5]);
+	lrvr	(@x[6],@x[6]);
+	lrvr	(@x[7],@x[7]);
+	al	(@x[12],"$stdframe+4*12($sp)");
+	al	(@x[13],"$stdframe+4*13($sp)");
+	al	(@x[14],"$stdframe+4*14($sp)");
+	al	(@x[15],"$stdframe+4*15($sp)");
+	lrvr	(@x[12],@x[12]);
+	lrvr	(@x[13],@x[13]);
+	lrvr	(@x[14],@x[14]);
+	lrvr	(@x[15],@x[15]);
 
-	x	@x[0],4*0(%r14)			# xor with input
-	x	@x[1],4*1(%r14)
-	st	@x[0],4*0(@t[0])		# store output
-	x	@x[2],4*2(%r14)
-	st	@x[1],4*1(@t[0])
-	x	@x[3],4*3(%r14)
-	st	@x[2],4*2(@t[0])
-	x	@x[4],4*4(%r14)
-	st	@x[3],4*3(@t[0])
-	 lm	@x[0],@x[3],$stdframe+4*8+4*8($sp)	# load x[8]-x[11]
-	x	@x[5],4*5(%r14)
-	st	@x[4],4*4(@t[0])
-	x	@x[6],4*6(%r14)
-	 al	@x[0],$stdframe+4*8($sp)
-	st	@x[5],4*5(@t[0])
-	x	@x[7],4*7(%r14)
-	 al	@x[1],$stdframe+4*9($sp)
-	st	@x[6],4*6(@t[0])
-	x	@x[12],4*12(%r14)
-	 al	@x[2],$stdframe+4*10($sp)
-	st	@x[7],4*7(@t[0])
-	x	@x[13],4*13(%r14)
-	 al	@x[3],$stdframe+4*11($sp)
-	st	@x[12],4*12(@t[0])
-	x	@x[14],4*14(%r14)
-	st	@x[13],4*13(@t[0])
-	x	@x[15],4*15(%r14)
-	st	@x[14],4*14(@t[0])
-	 lrvr	@x[0],@x[0]
-	st	@x[15],4*15(@t[0])
-	 lrvr	@x[1],@x[1]
-	 lrvr	@x[2],@x[2]
-	 lrvr	@x[3],@x[3]
-	lhi	@x[12],1
-	 x	@x[0],4*8(%r14)
-	al	@x[12],$stdframe+4*12($sp)	# increment counter
-	 x	@x[1],4*9(%r14)
-	 st	@x[0],4*8(@t[0])
-	 x	@x[2],4*10(%r14)
-	 st	@x[1],4*9(@t[0])
-	 x	@x[3],4*11(%r14)
-	 st	@x[2],4*10(@t[0])
-	 st	@x[3],4*11(@t[0])
+	la	(@t[0],"0(@t[0],%r14)");	# reconstruct output pointer
+&{$z?	\&clgr:\&clr}	("%r14",@t[1]);
+	jh	(".Ltail");
 
-	cl${g}r	%r14,@t[1]			# done yet?
-	la	%r14,64(%r14)
-	jl	.Loop_outer
+	x	(@x[0],"4*0(%r14)");	# xor with input
+	x	(@x[1],"4*1(%r14)");
+	st	(@x[0],"4*0(@t[0])");	# store output
+	x	(@x[2],"4*2(%r14)");
+	st	(@x[1],"4*1(@t[0])");
+	x	(@x[3],"4*3(%r14)");
+	st	(@x[2],"4*2(@t[0])");
+	x	(@x[4],"4*4(%r14)");
+	st	(@x[3],"4*3(@t[0])");
+	 lm	(@x[0],@x[3],"$stdframe+4*8+4*8($sp)");	# load x[8]-x[11]
+	x	(@x[5],"4*5(%r14)");
+	st	(@x[4],"4*4(@t[0])");
+	x	(@x[6],"4*6(%r14)");
+	 al	(@x[0],"$stdframe+4*8($sp)");
+	st	(@x[5],"4*5(@t[0])");
+	x	(@x[7],"4*7(%r14)");
+	 al	(@x[1],"$stdframe+4*9($sp)");
+	st	(@x[6],"4*6(@t[0])");
+	x	(@x[12],"4*12(%r14)");
+	 al	(@x[2],"$stdframe+4*10($sp)");
+	st	(@x[7],"4*7(@t[0])");
+	x	(@x[13],"4*13(%r14)");
+	 al	(@x[3],"$stdframe+4*11($sp)");
+	st	(@x[12],"4*12(@t[0])");
+	x	(@x[14],"4*14(%r14)");
+	st	(@x[13],"4*13(@t[0])");
+	x	(@x[15],"4*15(%r14)");
+	st	(@x[14],"4*14(@t[0])");
+	 lrvr	(@x[0],@x[0]);
+	st	(@x[15],"4*15(@t[0])");
+	 lrvr	(@x[1],@x[1]);
+	 lrvr	(@x[2],@x[2]);
+	 lrvr	(@x[3],@x[3]);
+	lhi	(@x[12],1);
+	 x	(@x[0],"4*8(%r14)");
+	al	(@x[12],"$stdframe+4*12($sp)");	# increment counter
+	 x	(@x[1],"4*9(%r14)");
+	 st	(@x[0],"4*8(@t[0])");
+	 x	(@x[2],"4*10(%r14)");
+	 st	(@x[1],"4*9(@t[0])");
+	 x	(@x[3],"4*11(%r14)");
+	 st	(@x[2],"4*10(@t[0])");
+	 st	(@x[3],"4*11(@t[0])");
 
-.Ldone:
-	xgr	%r0,%r0
-	xgr	%r1,%r1
-	xgr	%r2,%r2
-	xgr	%r3,%r3
-	stmg	%r0,%r3,$stdframe+4*4($sp)	# wipe key copy
-	stmg	%r0,%r3,$stdframe+4*12($sp)
+&{$z?	\&clgr:\&clr}	("%r14",@t[1]);	# done yet?
+	la	("%r14","64(%r14)");
+	jl	(".Loop_outer");
 
-	lm${g}	%r6,%r15,`$frame+6*$SIZE_T`($sp)
-	br	%r14
+LABEL	(".Ldone");
+	xgr	("%r0","%r0");
+	xgr	("%r1","%r1");
+	xgr	("%r2","%r2");
+	xgr	("%r3","%r3");
+	stmg	("%r0","%r3","$stdframe+4*4($sp)");	# wipe key copy
+	stmg	("%r0","%r3","$stdframe+4*12($sp)");
 
-.align	16
-.Ltail:
-	la	@t[1],64($t[1])
-	stm	@x[0],@x[7],$stdframe+4*0($sp)
-	sl${g}r	@t[1],%r14
-	lm	@x[0],@x[3],$stdframe+4*8+4*8($sp)
-	l${g}hi	@x[6],0
-	stm	@x[12],@x[15],$stdframe+4*12($sp)
-	al	@x[0],$stdframe+4*8($sp)
-	al	@x[1],$stdframe+4*9($sp)
-	al	@x[2],$stdframe+4*10($sp)
-	al	@x[3],$stdframe+4*11($sp)
-	lrvr	@x[0],@x[0]
-	lrvr	@x[1],@x[1]
-	lrvr	@x[2],@x[2]
-	lrvr	@x[3],@x[3]
-	stm	@x[0],@x[3],$stdframe+4*8($sp)
+&{$z?	\&lmg:\&lm}	("%r6","%r15","$frame+6*$SIZE_T($sp)");
+	br	("%r14");
 
-.Loop_tail:
-	llgc	@x[4],0(@x[6],%r14)
-	llgc	@x[5],$stdframe(@x[6],$sp)
-	xr	@x[5],@x[4]
-	stc	@x[5],0(@x[6],@t[0])
-	la	@x[6],1(@x[6])
-	brct	@t[1],.Loop_tail
+ALIGN	(16);
+LABEL	(".Ltail");
+	la	(@t[1],"64($t[1])");
+	stm	(@x[0],@x[7],"$stdframe+4*0($sp)");
+&{$z?	\&slgr:\&slr}	(@t[1],"%r14");
+	lm	(@x[0],@x[3],"$stdframe+4*8+4*8($sp)");
+&{$z?	\&lghi:\&lhi}	(@x[6],0);
+	stm	(@x[12],@x[15],"$stdframe+4*12($sp)");
+	al	(@x[0],"$stdframe+4*8($sp)");
+	al	(@x[1],"$stdframe+4*9($sp)");
+	al	(@x[2],"$stdframe+4*10($sp)");
+	al	(@x[3],"$stdframe+4*11($sp)");
+	lrvr	(@x[0],@x[0]);
+	lrvr	(@x[1],@x[1]);
+	lrvr	(@x[2],@x[2]);
+	lrvr	(@x[3],@x[3]);
+	stm	(@x[0],@x[3],"$stdframe+4*8($sp)");
 
-	j	.Ldone
-.size	ChaCha20_ctr32,.-ChaCha20_ctr32
+LABEL	(".Loop_tail");
+	llgc	(@x[4],"0(@x[6],%r14)");
+	llgc	(@x[5],"$stdframe(@x[6],$sp)");
+	xr	(@x[5],@x[4]);
+	stc	(@x[5],"0(@x[6],@t[0])");
+	la	(@x[6],"1(@x[6])");
+	brct	(@t[1],".Loop_tail");
 
-.align	32
-.Lsigma:
-.long	0x61707865,0x3320646e,0x79622d32,0x6b206574	# endian-neutral
-.asciz	"ChaCha20 for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.align	4
-___
+	j	(".Ldone");
+SIZE	("ChaCha20_ctr32",".-ChaCha20_ctr32");
 
-foreach (split("\n",$code)) {
-	s/\`([^\`]*)\`/eval $1/ge;
+ALIGN	(32);
+LABEL	(".Lsigma");
+LONG	(0x61707865,0x3320646e,0x79622d32,0x6b206574);	# endian-neutral
+ASCIZ	("\"ChaCha20 for s390x, CRYPTOGAMS by <appro\@openssl.org>\"");
+ALIGN	(4);
 
-	print $_,"\n";
-}
-close STDOUT;
+PERLASM_END();

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1143,13 +1143,13 @@ static int s390x_aes_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t len);
 
 # define S390X_aes_128_gcm_CAPABLE (S390X_aes_128_CAPABLE&&\
-                                    OPENSSL_s390xcap_P[17]\
+                                    OPENSSL_s390xcap_P[19]\
                                     &S390X_KMA_GCM_AES_128)
 # define S390X_aes_192_gcm_CAPABLE (S390X_aes_192_CAPABLE&&\
-                                    OPENSSL_s390xcap_P[17]\
+                                    OPENSSL_s390xcap_P[19]\
                                     &S390X_KMA_GCM_AES_192)
 # define S390X_aes_256_gcm_CAPABLE (S390X_aes_256_CAPABLE&&\
-                                    OPENSSL_s390xcap_P[17]\
+                                    OPENSSL_s390xcap_P[19]\
                                     &S390X_KMA_GCM_AES_256)
 
 static int s390x_aes_gcm(GCM128_CONTEXT *ctx, const unsigned char *in,

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -950,6 +950,181 @@ static const EVP_CIPHER aes_##keylen##_##mode = { \
 const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
 { return SPARC_AES_CAPABLE?&aes_t4_##keylen##_##mode:&aes_##keylen##_##mode; }
 
+#elif defined(OPENSSL_CPUID_OBJ) && defined(__s390__) && !defined(AES_SOFTONLY)
+/*
+ * IBM S390X support
+ */
+# include "s390x_arch.h"
+
+/*-
+ * If KM and KMC support the function code, AES_KEY structure holds
+ * key/function code (instead of key schedule/number of rounds).
+ */
+# define S390X_AES_FC (((AES_KEY *)(key))->rounds)
+
+# define S390X_aes_128_CAPABLE ((OPENSSL_s390xcap_P[5]&S390X_KM_AES_128)&&\
+                                (OPENSSL_s390xcap_P[7]&S390X_KMC_AES_128))
+# define S390X_aes_192_CAPABLE ((OPENSSL_s390xcap_P[5]&S390X_KM_AES_192)&&\
+                                (OPENSSL_s390xcap_P[7]&S390X_KMC_AES_192))
+# define S390X_aes_256_CAPABLE ((OPENSSL_s390xcap_P[5]&S390X_KM_AES_256)&&\
+                                (OPENSSL_s390xcap_P[7]&S390X_KMC_AES_256))
+
+# define s390x_aes_init_key aes_init_key
+static int s390x_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                              const unsigned char *iv, int enc);
+
+# define S390X_aes_128_cbc_CAPABLE	1	/* checked by callee */
+# define S390X_aes_192_cbc_CAPABLE	1
+# define S390X_aes_256_cbc_CAPABLE	1
+
+# define s390x_aes_cbc_cipher aes_cbc_cipher
+static int s390x_aes_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_ecb_CAPABLE	0
+# define S390X_aes_192_ecb_CAPABLE	0
+# define S390X_aes_256_ecb_CAPABLE	0
+
+# define s390x_aes_ecb_cipher aes_ecb_cipher
+static int s390x_aes_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_ofb_CAPABLE	0
+# define S390X_aes_192_ofb_CAPABLE	0
+# define S390X_aes_256_ofb_CAPABLE	0
+
+# define s390x_aes_ofb_cipher aes_ofb_cipher
+static int s390x_aes_ofb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_cfb_CAPABLE	0
+# define S390X_aes_192_cfb_CAPABLE	0
+# define S390X_aes_256_cfb_CAPABLE	0
+
+# define s390x_aes_cfb_cipher aes_cfb_cipher
+static int s390x_aes_cfb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_cfb8_CAPABLE	0
+# define S390X_aes_192_cfb8_CAPABLE	0
+# define S390X_aes_256_cfb8_CAPABLE	0
+
+# define s390x_aes_cfb8_cipher aes_cfb8_cipher
+static int s390x_aes_cfb8_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                 const unsigned char *in, size_t len);
+
+# define S390X_aes_128_cfb1_CAPABLE	0
+# define S390X_aes_192_cfb1_CAPABLE	0
+# define S390X_aes_256_cfb1_CAPABLE	0
+
+# define s390x_aes_cfb1_cipher aes_cfb1_cipher
+static int s390x_aes_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                 const unsigned char *in, size_t len);
+
+# define S390X_aes_128_ctr_CAPABLE	1	/* checked by callee */
+# define S390X_aes_192_ctr_CAPABLE	1
+# define S390X_aes_256_ctr_CAPABLE	1
+
+# define s390x_aes_ctr_cipher aes_ctr_cipher
+static int s390x_aes_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_gcm_CAPABLE	0
+# define S390X_aes_192_gcm_CAPABLE	0
+# define S390X_aes_256_gcm_CAPABLE	0
+
+# define s390x_aes_gcm_init_key aes_gcm_init_key
+static int s390x_aes_gcm_init_key(EVP_CIPHER_CTX *ctx,
+                                  const unsigned char *key,
+                                  const unsigned char *iv, int enc);
+
+# define s390x_aes_gcm_cipher aes_gcm_cipher
+static int s390x_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_xts_CAPABLE	1	/* checked by callee */
+# define S390X_aes_256_xts_CAPABLE	1
+
+# define s390x_aes_xts_init_key aes_xts_init_key
+static int s390x_aes_xts_init_key(EVP_CIPHER_CTX *ctx,
+                                  const unsigned char *key,
+                                  const unsigned char *iv, int enc);
+
+# define s390x_aes_xts_cipher aes_xts_cipher
+static int s390x_aes_xts_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# define S390X_aes_128_ccm_CAPABLE	0
+# define S390X_aes_192_ccm_CAPABLE	0
+# define S390X_aes_256_ccm_CAPABLE	0
+
+# define s390x_aes_ccm_init_key aes_ccm_init_key
+static int s390x_aes_ccm_init_key(EVP_CIPHER_CTX *ctx,
+                                  const unsigned char *key,
+                                  const unsigned char *iv, int enc);
+
+# define s390x_aes_ccm_cipher aes_ccm_cipher
+static int s390x_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+
+# ifndef OPENSSL_NO_OCB
+#  define S390X_aes_128_ocb_CAPABLE	0
+#  define S390X_aes_192_ocb_CAPABLE	0
+#  define S390X_aes_256_ocb_CAPABLE	0
+
+#  define s390x_aes_ocb_init_key aes_ocb_init_key
+static int s390x_aes_ocb_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                                  const unsigned char *iv, int enc);
+#  define s390x_aes_ocb_cipher aes_ocb_cipher
+static int s390x_aes_ocb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                const unsigned char *in, size_t len);
+# endif
+
+# define BLOCK_CIPHER_generic(nid,keylen,blocksize,ivlen,nmode,mode,MODE,flags)	\
+static const EVP_CIPHER s390x_aes_##keylen##_##mode = { \
+        nid##_##keylen##_##nmode,blocksize,keylen/8,ivlen, \
+        flags|EVP_CIPH_##MODE##_MODE,   \
+        s390x_aes_init_key,             \
+        s390x_aes_##mode##_cipher,      \
+        NULL,                           \
+        sizeof(EVP_AES_KEY),            \
+        NULL,NULL,NULL,NULL }; \
+static const EVP_CIPHER aes_##keylen##_##mode = { \
+        nid##_##keylen##_##nmode,blocksize,     \
+        keylen/8,ivlen, \
+        flags|EVP_CIPH_##MODE##_MODE,   \
+        aes_init_key,                   \
+        aes_##mode##_cipher,            \
+        NULL,                           \
+        sizeof(EVP_AES_KEY),            \
+        NULL,NULL,NULL,NULL }; \
+const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
+{ return S390X_aes_##keylen##_##mode##_CAPABLE?&s390x_aes_##keylen##_##mode: \
+                                               &aes_##keylen##_##mode; }
+
+# define BLOCK_CIPHER_custom(nid,keylen,blocksize,ivlen,mode,MODE,flags) \
+static const EVP_CIPHER s390x_aes_##keylen##_##mode = { \
+        nid##_##keylen##_##mode,blocksize, \
+        (EVP_CIPH_##MODE##_MODE==EVP_CIPH_XTS_MODE?2:1)*keylen/8, ivlen, \
+        flags|EVP_CIPH_##MODE##_MODE,   \
+        s390x_aes_##mode##_init_key,    \
+        s390x_aes_##mode##_cipher,      \
+        aes_##mode##_cleanup,           \
+        sizeof(EVP_AES_##MODE##_CTX),   \
+        NULL,NULL,aes_##mode##_ctrl,NULL }; \
+static const EVP_CIPHER aes_##keylen##_##mode = { \
+        nid##_##keylen##_##mode,blocksize, \
+        (EVP_CIPH_##MODE##_MODE==EVP_CIPH_XTS_MODE?2:1)*keylen/8, ivlen, \
+        flags|EVP_CIPH_##MODE##_MODE,   \
+        aes_##mode##_init_key,          \
+        aes_##mode##_cipher,            \
+        aes_##mode##_cleanup,           \
+        sizeof(EVP_AES_##MODE##_CTX),   \
+        NULL,NULL,aes_##mode##_ctrl,NULL }; \
+const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
+{ return S390X_aes_##keylen##_##mode##_CAPABLE?&s390x_aes_##keylen##_##mode: \
+                                               &aes_##keylen##_##mode; }
+
 #else
 
 # define BLOCK_CIPHER_generic(nid,keylen,blocksize,ivlen,nmode,mode,MODE,flags) \

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -984,6 +984,10 @@ void s390x_aes_gcm_blocks(unsigned char *out, GCM128_CONTEXT *ctx,
                           const unsigned char *aad, size_t alen,
                           const AES_KEY *key, int enc);
 
+void s390x_aes_cbc_mac_blocks(unsigned char mac[AES_BLOCK_SIZE],
+                              const AES_KEY *key, const unsigned char *in,
+                              size_t len);
+
 # define s390x_aes_init_key aes_init_key
 static int s390x_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                               const unsigned char *iv, int enc);
@@ -1342,18 +1346,301 @@ static int s390x_aes_xts_init_key(EVP_CIPHER_CTX *ctx,
 static int s390x_aes_xts_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t len);
 
-# define S390X_aes_128_ccm_CAPABLE	0
-# define S390X_aes_192_ccm_CAPABLE	0
-# define S390X_aes_256_ccm_CAPABLE	0
+# define S390X_aes_128_ccm_CAPABLE	S390X_aes_128_CAPABLE
+# define S390X_aes_192_ccm_CAPABLE	S390X_aes_192_CAPABLE
+# define S390X_aes_256_ccm_CAPABLE	S390X_aes_256_CAPABLE
 
-# define s390x_aes_ccm_init_key aes_ccm_init_key
+static void s390x_aes_ccm_encrypt_blocks(const unsigned char *in,
+                                         unsigned char *out, size_t blocks,
+                                         const AES_KEY *key,
+                                         const unsigned char
+                                           ivec[AES_BLOCK_SIZE],
+                                         unsigned char mac[AES_BLOCK_SIZE])
+{
+    block128_f block = (block128_f)AES_encrypt;
+    u32 *ctr64 = ((u32 *)ivec + 2);
+    size_t blk;
+
+    if (OPENSSL_s390xcap_P[9] & (1ULL << (63 - S390X_AES_FC(key)))) {
+        s390x_aes_cbc_mac_blocks(mac, key, in, blocks * AES_BLOCK_SIZE);
+    } else {
+        blk = blocks;
+
+        while (blk) {
+            ((u64 *)mac)[0] ^= ((u64 *)in)[0];
+            ((u64 *)mac)[1] ^= ((u64 *)in)[1];
+            (*block)(mac, mac, key);
+            in += AES_BLOCK_SIZE;
+            --blk;
+        }
+        in -= AES_BLOCK_SIZE * blocks;
+    }
+
+    while ((blk = UINT32_MAX - ctr64[1]) < blocks) {
+        AES_ctr32_encrypt(in, out, blk, key, ivec);
+        ctr64[1] = 0;
+        ++ctr64[0];
+        in += blk * AES_BLOCK_SIZE;
+        out += blk * AES_BLOCK_SIZE;
+        blocks -= blk;
+    }
+    AES_ctr32_encrypt(in, out, blocks, key, ivec);
+}
+
+static void s390x_aes_ccm_decrypt_blocks(const unsigned char *in,
+                                         unsigned char *out, size_t blocks,
+                                         const AES_KEY *key,
+                                         const unsigned char
+                                           ivec[AES_BLOCK_SIZE],
+                                         unsigned char mac[AES_BLOCK_SIZE])
+{
+    block128_f block = (block128_f)AES_encrypt;
+    u32 *ctr64 = ((u32 *)ivec + 2);
+    size_t blk;
+
+    while ((blk = UINT32_MAX - ctr64[1]) < blocks) {
+        AES_ctr32_encrypt(in, out, blk, key, ivec);
+        ctr64[1] = 0;
+        ++ctr64[0];
+        in += blk * AES_BLOCK_SIZE;
+        out += blk * AES_BLOCK_SIZE;
+        blocks -= blk;
+    }
+    AES_ctr32_encrypt(in, out, blocks, key, ivec);
+
+    if (OPENSSL_s390xcap_P[9] & (1ULL << (63 - S390X_AES_FC(key)))) {
+        s390x_aes_cbc_mac_blocks(mac, key, out, blocks * AES_BLOCK_SIZE);
+    } else {
+        blk = blocks;
+
+        while (blk) {
+            ((u64 *)mac)[0] ^= ((u64 *)out)[0];
+            ((u64 *)mac)[1] ^= ((u64 *)out)[1];
+            (*block)(mac, mac, key);
+            out += AES_BLOCK_SIZE;
+            --blk;
+        }
+    }
+}
+
 static int s390x_aes_ccm_init_key(EVP_CIPHER_CTX *ctx,
                                   const unsigned char *key,
-                                  const unsigned char *iv, int enc);
+                                  const unsigned char *iv, int enc)
+{
+    EVP_AES_CCM_CTX *cctx = EVP_C_DATA(EVP_AES_CCM_CTX,ctx);
+    unsigned char *ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
+    const int keybitlen = EVP_CIPHER_CTX_key_length(ctx) * 8;
 
-# define s390x_aes_ccm_cipher aes_ccm_cipher
+    if (!iv && !key)
+        return 1;
+
+    if (key) {
+        AES_set_encrypt_key(key, keybitlen, &cctx->ks.ks);
+        CRYPTO_ccm128_init(&cctx->ccm, cctx->M, cctx->L, &cctx->ks,
+                           (block128_f) AES_encrypt);
+        cctx->str = enc ? (ccm128_f)s390x_aes_ccm_encrypt_blocks :
+                          (ccm128_f)s390x_aes_ccm_decrypt_blocks;
+        cctx->key_set = 1;
+    }
+
+    if (iv) {
+        memcpy(ivec, iv, 15 - cctx->L);
+        cctx->iv_set = 1;
+    }
+
+    return 1;
+}
+
+static void s390x_aes_ccm_aad(CCM128_CONTEXT *ctx, const unsigned char *aad,
+                              size_t alen)
+{
+    block128_f block = ctx->block;
+    size_t rem;
+    unsigned int i;
+
+    if (alen == 0)
+        return;
+
+    ctx->nonce.c[0] |= 0x40;
+    (*block) (ctx->nonce.c, ctx->cmac.c, ctx->key);
+    ctx->blocks++;
+
+    if (alen < (0x10000 - 0x100)) {
+        ctx->cmac.c[0] ^= (u8)(alen >> 8);
+        ctx->cmac.c[1] ^= (u8)alen;
+        i = 2;
+    } else if (sizeof(alen) == 8
+               && alen >= (size_t)1 << (32 % (sizeof(alen) * 8))) {
+        ctx->cmac.c[0] ^= 0xFF;
+        ctx->cmac.c[1] ^= 0xFF;
+        ctx->cmac.c[2] ^= (u8)(alen >> (56 % (sizeof(alen) * 8)));
+        ctx->cmac.c[3] ^= (u8)(alen >> (48 % (sizeof(alen) * 8)));
+        ctx->cmac.c[4] ^= (u8)(alen >> (40 % (sizeof(alen) * 8)));
+        ctx->cmac.c[5] ^= (u8)(alen >> (32 % (sizeof(alen) * 8)));
+        ctx->cmac.c[6] ^= (u8)(alen >> 24);
+        ctx->cmac.c[7] ^= (u8)(alen >> 16);
+        ctx->cmac.c[8] ^= (u8)(alen >> 8);
+        ctx->cmac.c[9] ^= (u8)alen;
+        i = 10;
+    } else {
+        ctx->cmac.c[0] ^= 0xFF;
+        ctx->cmac.c[1] ^= 0xFE;
+        ctx->cmac.c[2] ^= (u8)(alen >> 24);
+        ctx->cmac.c[3] ^= (u8)(alen >> 16);
+        ctx->cmac.c[4] ^= (u8)(alen >> 8);
+        ctx->cmac.c[5] ^= (u8)alen;
+        i = 6;
+    }
+
+    for (; i < 16 && alen; ++i, ++aad, --alen)
+        ctx->cmac.c[i] ^= *aad;
+
+    (*block) (ctx->cmac.c, ctx->cmac.c, ctx->key);
+    ctx->blocks++;
+
+    if (OPENSSL_s390xcap_P[9] & (1ULL << (63 - S390X_AES_FC(ctx->key)))) {
+        rem = alen % AES_BLOCK_SIZE;
+        alen -= rem;
+
+        s390x_aes_cbc_mac_blocks(ctx->cmac.c, ctx->key, aad, alen);
+        ctx->blocks += alen / AES_BLOCK_SIZE;
+
+        if (rem) {
+            aad += alen;
+
+            for (i = 0; rem; ++i, ++aad, --rem)
+                ctx->cmac.c[i] ^= *aad;
+
+            (*block) (ctx->cmac.c, ctx->cmac.c, ctx->key);
+            ctx->blocks++;
+        }
+    } else {
+        while (alen) {
+            for (i = 0; i < 16 && alen; ++i, ++aad, --alen)
+                ctx->cmac.c[i] ^= *aad;
+
+            (*block) (ctx->cmac.c, ctx->cmac.c, ctx->key);
+            ctx->blocks++;
+        }
+    }
+}
+
+static int s390x_aes_ccm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                    const unsigned char *in, size_t len)
+{
+    EVP_AES_CCM_CTX *cctx = EVP_C_DATA(EVP_AES_CCM_CTX,ctx);
+    CCM128_CONTEXT *ccm = &cctx->ccm;
+    int enc = EVP_CIPHER_CTX_encrypting(ctx);
+    unsigned char *ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
+    unsigned char *buf = EVP_CIPHER_CTX_buf_noconst(ctx);
+    unsigned char tag[16];
+
+    if (out != in || len < (EVP_CCM_TLS_EXPLICIT_IV_LEN + (size_t)cctx->M))
+        return -1;
+
+    if (enc)
+        memcpy(out, buf, EVP_CCM_TLS_EXPLICIT_IV_LEN);
+
+    memcpy(ivec + EVP_CCM_TLS_FIXED_IV_LEN, in, EVP_CCM_TLS_EXPLICIT_IV_LEN);
+    len -= EVP_CCM_TLS_EXPLICIT_IV_LEN + cctx->M;
+
+    if (CRYPTO_ccm128_setiv(ccm, ivec, 15 - cctx->L, len))
+            return -1;
+
+    s390x_aes_ccm_aad(ccm, buf, cctx->tls_aad_len);
+    in += EVP_CCM_TLS_EXPLICIT_IV_LEN;
+    out += EVP_CCM_TLS_EXPLICIT_IV_LEN;
+
+    if (enc) {
+        if (CRYPTO_ccm128_encrypt_ccm64(ccm, in, out, len, cctx->str))
+            return -1;
+
+        if (!CRYPTO_ccm128_tag(ccm, out + len, cctx->M))
+            return -1;
+
+        return len + EVP_CCM_TLS_EXPLICIT_IV_LEN + cctx->M;
+    } else {
+        if (!CRYPTO_ccm128_decrypt_ccm64(ccm, in, out, len, cctx->str)) {
+            if (CRYPTO_ccm128_tag(ccm, tag, cctx->M)) {
+                if (!CRYPTO_memcmp(tag, in + len, cctx->M))
+                    return len;
+            }
+        }
+        OPENSSL_cleanse(out, len);
+        return -1;
+    }
+}
+
 static int s390x_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                const unsigned char *in, size_t len);
+                                const unsigned char *in, size_t len)
+{
+    EVP_AES_CCM_CTX *cctx = EVP_C_DATA(EVP_AES_CCM_CTX,ctx);
+    CCM128_CONTEXT *ccm = &cctx->ccm;
+    int enc = EVP_CIPHER_CTX_encrypting(ctx);
+    unsigned char *ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
+    unsigned char *buf = EVP_CIPHER_CTX_buf_noconst(ctx);
+    unsigned char tag[16];
+    int rv = -1;
+
+    if (!cctx->key_set)
+        return -1;
+
+    if (cctx->tls_aad_len >= 0)
+        return s390x_aes_ccm_tls_cipher(ctx, out, in, len);
+
+    if (in == NULL && out != NULL)
+        return 0;
+
+    if (!cctx->iv_set)
+        return -1;
+
+    if (!enc && !cctx->tag_set)
+        return -1;
+
+    if (!out) {
+        if (!in) {
+            if (CRYPTO_ccm128_setiv(ccm, ivec, 15 - cctx->L, len))
+                return -1;
+
+            cctx->len_set = 1;
+            return len;
+        }
+
+        if (!cctx->len_set && len)
+            return -1;
+
+        s390x_aes_ccm_aad(ccm, in, len);
+        return len;
+    }
+    if (!cctx->len_set) {
+        if (CRYPTO_ccm128_setiv(ccm, ivec, 15 - cctx->L, len))
+            return -1;
+
+        cctx->len_set = 1;
+    }
+    if (enc) {
+        if (CRYPTO_ccm128_encrypt_ccm64(ccm, in, out, len, cctx->str))
+            return -1;
+
+        cctx->tag_set = 1;
+        return len;
+    } else {
+        if (!CRYPTO_ccm128_decrypt_ccm64(ccm, in, out, len, cctx->str)) {
+            if (CRYPTO_ccm128_tag(ccm, tag, cctx->M)) {
+                if (!CRYPTO_memcmp(tag, buf, cctx->M))
+                    rv = len;
+            }
+        }
+
+        if (rv == -1)
+            OPENSSL_cleanse(out, len);
+
+        cctx->iv_set = 0;
+        cctx->tag_set = 0;
+        cctx->len_set = 0;
+        return rv;
+    }
+}
 
 # ifndef OPENSSL_NO_OCB
 #  define S390X_aes_128_ocb_CAPABLE	0

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -969,6 +969,8 @@ const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
 # define S390X_aes_256_CAPABLE ((OPENSSL_s390xcap_P[5]&S390X_KM_AES_256)&&\
                                 (OPENSSL_s390xcap_P[7]&S390X_KMC_AES_256))
 
+void s390x_aes_ecb_blocks(unsigned char *out, const AES_KEY *key,
+                          const unsigned char *in, size_t len);
 void s390x_aes_ofb_blocks(unsigned char *out, unsigned char iv[AES_BLOCK_SIZE],
                           const unsigned char *in, size_t len,
                           const AES_KEY *key);
@@ -994,13 +996,22 @@ static int s390x_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 static int s390x_aes_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t len);
 
-# define S390X_aes_128_ecb_CAPABLE	0
-# define S390X_aes_192_ecb_CAPABLE	0
-# define S390X_aes_256_ecb_CAPABLE	0
+# define S390X_aes_128_ecb_CAPABLE (S390X_aes_128_CAPABLE&&\
+                                    OPENSSL_s390xcap_P[5]&S390X_KM_AES_128)
+# define S390X_aes_192_ecb_CAPABLE (S390X_aes_192_CAPABLE&&\
+                                    OPENSSL_s390xcap_P[5]&S390X_KM_AES_192)
+# define S390X_aes_256_ecb_CAPABLE (S390X_aes_256_CAPABLE&&\
+                                    OPENSSL_s390xcap_P[5]&S390X_KM_AES_256)
 
-# define s390x_aes_ecb_cipher aes_ecb_cipher
 static int s390x_aes_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                const unsigned char *in, size_t len);
+                                const unsigned char *in, size_t len)
+{
+    EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
+
+    s390x_aes_ecb_blocks(out, &dat->ks.ks, in, len);
+
+    return 1;
+}
 
 # define S390X_aes_128_ofb_CAPABLE (S390X_aes_128_CAPABLE&&\
                                     OPENSSL_s390xcap_P[13]&S390X_KMO_AES_128)

--- a/crypto/modes/asm/ghash-s390x.pl
+++ b/crypto/modes/asm/ghash-s390x.pl
@@ -95,14 +95,23 @@ $code.=<<___ if(!$softonly && 0);	# hardware is slow for single block...
 	lg	%r1,24(%r1)	# load second word of kimd capabilities vector
 	tmhh	%r1,0x4000	# check for function 65
 	jz	.Lsoft_gmult
+	lghi	%r1,-16
 	stg	%r0,16($sp)	# arrange 16 bytes of zero input
 	stg	%r0,24($sp)
+	la	$Htbl,0(%r1,$Htbl)	# H lies right before Htable
+
 	lghi	%r0,65		# function 65
-	la	%r1,0($Xi)	# H lies right after Xi in gcm128_context
+	la	%r1,32($sp)
+	mvc	32(16,$sp),0($Xi)	# copy Xi/Yi
+	mvc	48(16,$sp),0($Htbl)	# copy H
 	la	$inp,16($sp)
 	lghi	$len,16
 	.long	0xb93e0004	# kimd %r0,$inp
 	brc	1,.-4		# pay attention to "partial completion"
+
+	mvc	0(16,$Xi),32($sp)
+	xc	32(32,$sp),32($sp)	# wipe stack
+
 	br	%r14
 .align	32
 .Lsoft_gmult:

--- a/crypto/modes/asm/ghash-s390x.pl
+++ b/crypto/modes/asm/ghash-s390x.pl
@@ -88,9 +88,6 @@ gcm_gmult_4bit:
 ___
 $code.=<<___ if(!$softonly && 0);	# hardware is slow for single block...
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,0(%r1)
-	tmhl	%r0,0x4000	# check for message-security-assist
-	jz	.Lsoft_gmult
 	lghi	%r0,0
 	lg	%r1,24(%r1)	# load second word of kimd capabilities vector
 	tmhh	%r1,0x4000	# check for function 65
@@ -135,14 +132,8 @@ gcm_ghash_4bit:
 ___
 $code.=<<___ if(!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,0(%r1)
-	tmhl	%r0,0x4000	# check for message-security-assist
-	jz	.Lsoft_ghash
-	lghi	%r0,0
-	la	%r1,16($sp)
-	.long	0xb93e0004	# kimd %r0,%r4
-	lg	%r1,24($sp)
-	tmhh	%r1,0x4000	# check for function 65
+	lg	%r0,24(%r1)	# load second word of kimd capabilities vector
+	tmhh	%r0,0x4000	# check for function 65
 	jz	.Lsoft_ghash
 	lghi	%r0,65		# function 65
 	la	%r1,0($Xi)	# H lies right after Xi in gcm128_context

--- a/crypto/modes/asm/ghash-s390x.pl
+++ b/crypto/modes/asm/ghash-s390x.pl
@@ -89,7 +89,7 @@ ___
 $code.=<<___ if(!$softonly && 0);	# hardware is slow for single block...
 	larl	%r1,OPENSSL_s390xcap_P
 	lghi	%r0,0
-	lg	%r1,24(%r1)	# load second word of kimd capabilities vector
+	lg	%r1,32(%r1)	# load second word of kimd capabilities vector
 	tmhh	%r1,0x4000	# check for function 65
 	jz	.Lsoft_gmult
 	lghi	%r1,-16
@@ -132,7 +132,7 @@ gcm_ghash_4bit:
 ___
 $code.=<<___ if(!$softonly);
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,24(%r1)	# load second word of kimd capabilities vector
+	lg	%r0,32(%r1)	# load second word of kimd capabilities vector
 	tmhh	%r0,0x4000	# check for function 65
 	jz	.Lsoft_ghash
 	lghi	%r0,65		# function 65

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -818,6 +818,10 @@ void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)
         ctx->gmult = gcm_gmult_4bit;
         CTX__GHASH(gcm_ghash_4bit);
     }
+# elif defined(GHASH_ASM)
+    gcm_init_4bit(ctx->Htable, ctx->H.u);
+    ctx->gmult = gcm_gmult_4bit;
+    CTX__GHASH(gcm_ghash_4bit);
 # else
     gcm_init_4bit(ctx->Htable, ctx->H.u);
 # endif

--- a/crypto/perlasm/s390x.pm
+++ b/crypto/perlasm/s390x.pm
@@ -1,0 +1,2969 @@
+#!/usr/bin/env perl
+# Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# Copyright IBM Corp. 2016
+# Author: Patrick Steuer <patrick.steuer@de.ibm.com>
+
+package perlasm::s390x;
+
+use strict;
+use warnings;
+use Carp qw(confess);
+use Exporter qw(import);
+
+our @EXPORT=qw(PERLASM_BEGIN PERLASM_END);
+our @EXPORT_OK=qw(AUTOLOAD LABEL stfle);
+our %EXPORT_TAGS=(
+	MSA => [qw(kmac km kmc kimd klmd)],
+	MSA4 => [qw(kmf kmo pcc kmctr)],
+	MSA5 => [qw(ppno prno)],
+	MSA8 => [qw(kma)],
+	VX => [qw(vgef vgeg vgbm vzero vone vgm vgmb vgmh vgmf vgmg
+	    vl vlr vlrep vlrepb vlreph vlrepf vlrepg vleb vleh vlef vleg vleib
+	    vleih vleif vleig vlgv vlgvb vlgvh vlgvf vlgvg vllez vllezb vllezh
+	    vllezf vllezg vlm vlbb vlvg vlvgb vlvgh vlvgf vlvgg vlvgp
+	    vll vmrh vmrhb vmrhh vmrhf vmrhg vmrl vmrlb vmrlh vmrlf vmrlg vpk
+	    vpkh vpkf vpkg vpks vpksh vpksf vpksg vpkshs vpksfs vpksgs vpkls
+	    vpklsh vpklsf vpklsg vpklshs vpklsfs vpklsgs vperm vpdi vrep vrepb
+	    vreph vrepf vrepg vrepi vrepib vrepih vrepif vrepig vscef vsceg
+	    vsel vseg vsegb vsegh vsegf vst vsteb vsteh vstef vsteg vstm vstl
+	    vuph vuphb vuphh vuphf vuplh vuplhb vuplhh vuplhf vupl vuplb vuplhw
+	    vuplf vupll vupllb vupllh vupllf va vab vah vaf vag vaq vacc vaccb
+	    vacch vaccf vaccg vaccq vac vacq vaccc vacccq vn vnc vavg vavgb
+	    vavgh vavgf vavgg vavgl vavglb vavglh vavglf vavglg vcksm vec_ vecb
+	    vech vecf vecg vecl veclb veclh veclf veclg vceq vceqb vceqh vceqf
+	    vceqg vceqbs vceqhs vceqfs vceqgs vch vchb vchh vchf vchg vchbs
+	    vchhs vchfs vchgs vchl vchlb vchlh vchlf vchlg vchlbs vchlhs vchlfs
+	    vchlgs vclz vclzb vclzh vclzf vclzg vctz vctzb vctzh vctzf vctzg
+	    vx vgfm vgfmb vgfmh vgfmf vgfmg vgfma vgfmab vgfmah vgfmaf vgfmag
+	    vlc vlcb vlch vlcf vlcg vlp vlpb vlph vlpf vlpg vmx vmxb vmxh vmxf
+	    vmxg vmxl vmxlb vmxlh vmxlf vmxlg vmn vmnb vmnh vmnf vmng vmnl
+	    vmnlb vmnlh vmnlf vmnlg vmal vmalb vmalhw vmalf vmah vmahb vmahh
+	    vmahf vmalh vmalhb vmalhh vmalhf vmae vmaeb vmaeh vmaef vmale
+	    vmaleb vmaleh vmalef vmao vmaob vmaoh vmaof vmalo vmalob vmaloh
+	    vmalof vmh vmhb vmhh vmhf vmlh vmlhb vmlhh vmlhf vml vmlb vmlhw
+	    vmlf vme vmeb vmeh vmef vmle vmleb vmleh vmlef vmo vmob vmoh vmof
+	    vmlo vmlob vmloh vmlof vno vnot vo vpopct verllv verllvb verllvh
+	    verllvf verllvg verll verllb verllh verllf verllg verim verimb
+	    verimh verimf verimg veslv veslvb veslvh veslvf veslvg vesl veslb
+	    veslh veslf veslg vesrav vesravb vesravh vesravf vesravg vesra
+	    vesrab vesrah vesraf vesrag vesrlv vesrlvb vesrlvh vesrlvf vesrlvg
+	    vesrl vesrlb vesrlh vesrlf vesrlg vsl vslb vsldb vsra vsrab vsrl
+	    vsrlb vs vsb vsh vsf vsg vsq vscbi vscbib vscbih vscbif vscbig
+	    vscbiq vsbi vsbiq vsbcbi vsbcbiq vsumg vsumgh vsumgf vsumq vsumqf
+	    vsumqg vsum vsumb vsumh vtm vfae vfaeb vfaeh vfaef vfaebs vfaehs
+	    vfaefs vfaezb vfaezh vfaezf vfaezbs vfaezhs vfaezfs vfee vfeeb
+	    vfeeh vfeef vfeebs vfeehs vfeefs vfeezb vfeezh vfeezf vfeezbs
+	    vfeezhs vfeezfs vfene vfeneb vfeneh vfenef vfenebs vfenehs vfenefs
+	    vfenezb vfenezh vfenezf vfenezbs vfenezhs vfenezfs vistr vistrb
+	    vistrh vistrf vistrbs vistrhs vistrfs vstrc vstrcb vstrch vstrcf
+	    vstrcbs vstrchs vstrcfs vstrczb vstrczh vstrczf vstrczbs vstrczhs
+	    vstrczfs vfa vfadb wfadb wfc wfcdb wfk wfkdb vfce vfcedb wfcedb
+	    vfcedbs wfcedbs vfch vfchdb wfchdb vfchdbs wfchdbs vfche vfchedb
+	    wfchedb vfchedbs wfchedbs vcdg vcdgb wcdgb vcdlg vcdlgb wcdlgb vcgd
+	    vcgdb wcgdb vclgd vclgdb wclgdb vfd vfddb wfddb vfi vfidb wfidb
+	    vlde vldeb wldeb vled vledb wledb vfm vfmdb wfmdb vfma vfmadb
+	    wfmadb vfms vfmsdb wfmsdb vfpso vfpsodb wfpsodb vflcdb wflcdb
+	    vflndb wflndb vflpdb wflpdb vfsq vfsqdb wfsqdb vfs vfsdb wfsdb
+	    vftci vftcidb wftcidb)],
+	VXE => [qw(vbperm vllezlf vmsl vmslg vnx vnn voc vpopctb vpopcth
+	    vpopctf vpopctg vfasb wfasb wfaxb wfcsb wfcxb wfksb wfkxb vfcesb
+	    vfcesbs wfcesb wfcesbs wfcexb wfcexbs vfchsb vfchsbs wfchsb wfchsbs
+	    wfchxb wfchxbs vfchesb vfchesbs wfchesb wfchesbs wfchexb wfchexbs
+	    vfdsb wfdsb wfdxb vfisb wfisb wfixb vfll vflls wflls wflld vflr
+	    vflrd wflrd wflrx vfmax vfmaxsb vfmaxdb wfmaxsb wfmaxdb wfmaxxb
+	    vfmin vfminsb vfmindb wfminsb wfmindb wfminxb vfmsb wfmsb wfmxb
+	    vfnma vfnms vfmasb wfmasb wfmaxb vfmssb wfmssb wfmsxb vfnmasb
+	    vfnmadb wfnmasb wfnmadb wfnmaxb vfnmssb vfnmsdb wfnmssb wfnmsdb
+	    wfnmsxb vfpsosb wfpsosb vflcsb wflcsb vflnsb wflnsb vflpsb wflpsb
+	    vfpsoxb wfpsoxb vflcxb wflcxb vflnxb wflnxb vflpxb wflpxb vfsqsb
+	    wfsqsb wfsqxb vfssb wfssb wfsxb vftcisb wftcisb wftcixb)],
+	VXD => [qw(vlrlr vlrl vstrlr vstrl vap vcp vcvb vcvbg vcvd vcvdg vdp
+	    vlip vmp vmsp vpkz vpsop vrp vsdp vsrp vsp vtp vupkz)],
+);
+Exporter::export_ok_tags(qw(MSA MSA4 MSA5 MSA8 VX VXE VXD));
+
+our $AUTOLOAD;
+
+my $GR='(?:%r)?([0-9]|1[0-5])';
+my $VR='(?:%v)?([0-9]|1[0-9]|2[0-9]|3[0-1])';
+
+my ($file,$out);
+
+sub PERLASM_BEGIN
+{
+	($file,$out)=(shift,"");
+}
+sub PERLASM_END
+{
+	if (defined($file)) {
+		open(my $fd,'>',$file)||die("can't open $file: $!");
+		print({$fd}$out);
+		close($fd);
+	} else {
+		print($out);
+	}
+}
+
+sub AUTOLOAD {
+	confess(err("PARSE")) if (grep(!defined($_),@_));
+	my $token;
+	for ($AUTOLOAD) {
+		$token=".$1" if (/^.*::([A-Z_]+)$/);	# uppercase: directive
+		$token="\t$1" if (/^.*::([a-z]+)$/);	# lowercase: mnemonic
+		confess(err("PARSE")) if (!defined($token));
+	}
+	$token.="\t" if ($#_>=0);
+	$out.=$token.join(',',@_)."\n";
+}
+
+sub LABEL {						# label directive
+	confess(err("ARGNUM")) if ($#_!=0);
+	my ($label)=@_;
+	$out.="$label:\n";
+}
+
+#
+# Mnemonics
+#
+
+sub stfle {
+	confess(err("ARGNUM")) if ($#_!=0);
+	S(0xb2b0,@_);
+}
+
+# MSA
+
+sub kmac {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb91e,@_);
+}
+
+sub km {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb92e,@_);
+}
+
+sub kmc {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb92f,@_);
+}
+
+sub kimd {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb93e,@_);
+}
+
+sub klmd {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb93f,@_);
+}
+
+# MSA4
+
+sub kmf {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb92a,@_);
+}
+
+sub kmo {
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb92b,@_);
+}
+
+sub pcc {
+	confess(err("ARGNUM")) if ($#_!=-1);
+	RRE(0xb92c,@_);
+}
+
+sub kmctr {
+	confess(err("ARGNUM")) if ($#_!=2);
+	RRFb(0xb92d,@_);
+}
+
+# MSA5
+
+sub prno {
+	ppno(@_);
+}
+
+sub ppno {						# deprecated, use prno
+	confess(err("ARGNUM")) if ($#_!=1);
+	RRE(0xb93c,@_);
+}
+
+# MSA8
+
+sub kma {
+	confess(err("ARGNUM")) if ($#_!=2);
+	RRFb(0xb929,@_);
+}
+
+# VX - Support Instructions
+
+sub vgef {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRV(0xe713,@_);
+}
+sub vgeg {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRV(0xe712,@_);
+}
+
+sub vgbm {
+	confess(err("ARGNUM")) if ($#_!=1);
+	VRIa(0xe744,@_);
+}
+sub vzero {
+	vgbm(@_,0);
+}
+sub vone {
+	vgbm(@_,0xffff);
+}
+
+sub vgm {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRIb(0xe746,@_);
+}
+sub vgmb {
+	vgm(@_,0);
+}
+sub vgmh {
+	vgm(@_,1);
+}
+sub vgmf {
+	vgm(@_,2);
+}
+sub vgmg {
+	vgm(@_,3);
+}
+
+sub vl {
+	confess(err("ARGNUM")) if ($#_!=1);
+	VRX(0xe706,@_);
+}
+
+sub vlr {
+	confess(err("ARGNUM")) if ($#_!=1);
+	VRRa(0xe756,@_);
+}
+
+sub vlrep {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe705,@_);
+}
+sub vlrepb {
+	vlrep(@_,0);
+}
+sub vlreph {
+	vlrep(@_,1);
+}
+sub vlrepf {
+	vlrep(@_,2);
+}
+sub vlrepg {
+	vlrep(@_,3);
+}
+
+sub vleb {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe700,@_);
+}
+sub vleh {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe701,@_);
+}
+sub vlef {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe703,@_);
+}
+sub vleg {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe702,@_);
+}
+
+sub vleib {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRIa(0xe740,@_);
+}
+sub vleih {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRIa(0xe741,@_);
+}
+sub vleif {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRIa(0xe743,@_);
+}
+sub vleig {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRIa(0xe742,@_);
+}
+
+sub vlgv {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRSc(0xe721,@_);
+}
+sub vlgvb {
+	vlgv(@_,0);
+}
+sub vlgvh {
+	vlgv(@_,1);
+}
+sub vlgvf {
+	vlgv(@_,2);
+}
+sub vlgvg {
+	vlgv(@_,3);
+}
+
+sub vllez {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe704,@_);
+}
+sub vllezb {
+	vllez(@_,0);
+}
+sub vllezh {
+	vllez(@_,1);
+}
+sub vllezf {
+	vllez(@_,2);
+}
+sub vllezg {
+	vllez(@_,3);
+}
+
+sub vlm {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRSa(0xe736,@_);
+}
+
+sub vlbb {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe707,@_);
+}
+
+sub vlvg {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRSb(0xe722,@_);
+}
+sub vlvgb {
+	vlvg(@_,0);
+}
+sub vlvgh {
+	vlvg(@_,1);
+}
+sub vlvgf {
+	vlvg(@_,2);
+}
+sub vlvgg {
+	vlvg(@_,3);
+}
+
+sub vlvgp {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRf(0xe762,@_);
+}
+
+sub vll {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRSb(0xe737,@_);
+}
+
+sub vmrh {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe761,@_);
+}
+sub vmrhb {
+	vmrh(@_,0);
+}
+sub vmrhh {
+	vmrh(@_,1);
+}
+sub vmrhf {
+	vmrh(@_,2);
+}
+sub vmrhg {
+	vmrh(@_,3);
+}
+
+sub vmrl {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe760,@_);
+}
+sub vmrlb {
+	vmrl(@_,0);
+}
+sub vmrlh {
+	vmrl(@_,1);
+}
+sub vmrlf {
+	vmrl(@_,2);
+}
+sub vmrlg {
+	vmrl(@_,3);
+}
+
+sub vpk {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe794,@_);
+}
+sub vpkh {
+	vpk(@_,1);
+}
+sub vpkf {
+	vpk(@_,2);
+}
+sub vpkg {
+	vpk(@_,3);
+}
+
+sub vpks {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRb(0xe797,@_);
+}
+sub vpksh {
+	vpks(@_,1,0);
+}
+sub vpksf {
+	vpks(@_,2,0);
+}
+sub vpksg {
+	vpks(@_,3,0);
+}
+sub vpkshs {
+	vpks(@_,1,1);
+}
+sub vpksfs {
+	vpks(@_,2,1);
+}
+sub vpksgs {
+	vpks(@_,3,1);
+}
+
+sub vpkls {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRb(0xe795,@_);
+}
+sub vpklsh {
+	vpkls(@_,1,0);
+}
+sub vpklsf {
+	vpkls(@_,2,0);
+}
+sub vpklsg {
+	vpkls(@_,3,0);
+}
+sub vpklshs {
+	vpkls(@_,1,1);
+}
+sub vpklsfs {
+	vpkls(@_,2,1);
+}
+sub vpklsgs {
+	vpkls(@_,3,1);
+}
+
+sub vperm {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRe(0xe78c,@_);
+}
+
+sub vpdi {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe784,@_);
+}
+
+sub vrep {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRIc(0xe74d,@_);
+}
+sub vrepb {
+	vrep(@_,0);
+}
+sub vreph {
+	vrep(@_,1);
+}
+sub vrepf {
+	vrep(@_,2);
+}
+sub vrepg {
+	vrep(@_,3);
+}
+
+sub vrepi {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRIa(0xe745,@_);
+}
+sub vrepib {
+	vrepi(@_,0);
+}
+sub vrepih {
+	vrepi(@_,1);
+}
+sub vrepif {
+	vrepi(@_,2);
+}
+sub vrepig {
+	vrepi(@_,3);
+}
+
+sub vscef {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRV(0xe71b,@_);
+}
+sub vsceg {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRV(0xe71a,@_);
+}
+
+sub vsel {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRe(0xe78d,@_);
+}
+
+sub vseg {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe75f,@_);
+}
+sub vsegb {
+	vseg(@_,0);
+}
+sub vsegh {
+	vseg(@_,1);
+}
+sub vsegf {
+	vseg(@_,2);
+}
+
+sub vst {
+	confess(err("ARGNUM")) if ($#_!=1);
+	VRX(0xe70e,@_);
+}
+
+sub vsteb {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe708,@_);
+}
+sub vsteh {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe709,@_);
+}
+sub vstef {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe70b,@_);
+}
+sub vsteg {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRX(0xe70a,@_);
+}
+
+sub vstm {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRSa(0xe73e,@_);
+}
+
+sub vstl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRSb(0xe73f,@_);
+}
+
+sub vuph {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7d7,@_);
+}
+sub vuphb {
+	vuph(@_,0);
+}
+sub vuphh {
+	vuph(@_,1);
+}
+sub vuphf {
+	vuph(@_,2);
+}
+
+sub vuplh {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7d5,@_);
+}
+sub vuplhb {
+	vuplh(@_,0);
+}
+sub vuplhh {
+	vuplh(@_,1);
+}
+sub vuplhf {
+	vuplh(@_,2);
+}
+
+sub vupl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7d6,@_);
+}
+sub vuplb {
+	vupl(@_,0);
+}
+sub vuplhw {
+	vupl(@_,1);
+}
+sub vuplf {
+	vupl(@_,2);
+}
+
+sub vupll {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7d4,@_);
+}
+sub vupllb {
+	vupll(@_,0);
+}
+sub vupllh {
+	vupll(@_,1);
+}
+sub vupllf {
+	vupll(@_,2);
+}
+
+# VX - Integer Instructions
+
+sub va {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7f3,@_);
+}
+sub vab {
+	va(@_,0);
+}
+sub vah {
+	va(@_,1);
+}
+sub vaf {
+	va(@_,2);
+}
+sub vag {
+	va(@_,3);
+}
+sub vaq {
+	va(@_,4);
+}
+
+sub vacc {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7f1,@_);
+}
+sub vaccb {
+	vacc(@_,0);
+}
+sub vacch {
+	vacc(@_,1);
+}
+sub vaccf {
+	vacc(@_,2);
+}
+sub vaccg {
+	vacc(@_,3);
+}
+sub vaccq {
+	vacc(@_,4);
+}
+
+sub vac {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7bb,@_);
+}
+sub vacq {
+	vac(@_,4);
+}
+
+sub vaccc {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7b9,@_);
+}
+sub vacccq {
+	vaccc(@_,4);
+}
+
+sub vn {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe768,@_);
+}
+
+sub vnc {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe769,@_);
+}
+
+sub vavg {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7f2,@_);
+}
+sub vavgb {
+	vavg(@_,0);
+}
+sub vavgh {
+	vavg(@_,1);
+}
+sub vavgf {
+	vavg(@_,2);
+}
+sub vavgg {
+	vavg(@_,3);
+}
+
+sub vavgl {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7f0,@_);
+}
+sub vavglb {
+	vavgl(@_,0);
+}
+sub vavglh {
+	vavgl(@_,1);
+}
+sub vavglf {
+	vavgl(@_,2);
+}
+sub vavglg {
+	vavgl(@_,3);
+}
+
+sub vcksm {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe766,@_);
+}
+
+sub vec_ {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7db,@_);
+}
+sub vecb {
+	vec_(@_,0);
+}
+sub vech {
+	vec_(@_,1);
+}
+sub vecf {
+	vec_(@_,2);
+}
+sub vecg {
+	vec_(@_,3);
+}
+
+sub vecl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7d9,@_);
+}
+sub veclb {
+	vecl(@_,0);
+}
+sub veclh {
+	vecl(@_,1);
+}
+sub veclf {
+	vecl(@_,2);
+}
+sub veclg {
+	vecl(@_,3);
+}
+
+sub vceq {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRb(0xe7f8,@_);
+}
+sub vceqb {
+	vceq(@_,0,0);
+}
+sub vceqh {
+	vceq(@_,1,0);
+}
+sub vceqf {
+	vceq(@_,2,0);
+}
+sub vceqg {
+	vceq(@_,3,0);
+}
+sub vceqbs {
+	vceq(@_,0,1);
+}
+sub vceqhs {
+	vceq(@_,1,1);
+}
+sub vceqfs {
+	vceq(@_,2,1);
+}
+sub vceqgs {
+	vceq(@_,3,1);
+}
+
+sub vch {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRb(0xe7fb,@_);
+}
+sub vchb {
+	vch(@_,0,0);
+}
+sub vchh {
+	vch(@_,1,0);
+}
+sub vchf {
+	vch(@_,2,0);
+}
+sub vchg {
+	vch(@_,3,0);
+}
+sub vchbs {
+	vch(@_,0,1);
+}
+sub vchhs {
+	vch(@_,1,1);
+}
+sub vchfs {
+	vch(@_,2,1);
+}
+sub vchgs {
+	vch(@_,3,1);
+}
+
+sub vchl {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRb(0xe7f9,@_);
+}
+sub vchlb {
+	vchl(@_,0,0);
+}
+sub vchlh {
+	vchl(@_,1,0);
+}
+sub vchlf {
+	vchl(@_,2,0);
+}
+sub vchlg {
+	vchl(@_,3,0);
+}
+sub vchlbs {
+	vchl(@_,0,1);
+}
+sub vchlhs {
+	vchl(@_,1,1);
+}
+sub vchlfs {
+	vchl(@_,2,1);
+}
+sub vchlgs {
+	vchl(@_,3,1);
+}
+
+sub vclz {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe753,@_);
+}
+sub vclzb {
+	vclz(@_,0);
+}
+sub vclzh {
+	vclz(@_,1);
+}
+sub vclzf {
+	vclz(@_,2);
+}
+sub vclzg {
+	vclz(@_,3);
+}
+
+sub vctz {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe752,@_);
+}
+sub vctzb {
+	vctz(@_,0);
+}
+sub vctzh {
+	vctz(@_,1);
+}
+sub vctzf {
+	vctz(@_,2);
+}
+sub vctzg {
+	vctz(@_,3);
+}
+
+sub vx {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe76d,@_);
+}
+
+sub vgfm {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7b4,@_);
+}
+sub vgfmb {
+	vgfm(@_,0);
+}
+sub vgfmh {
+	vgfm(@_,1);
+}
+sub vgfmf {
+	vgfm(@_,2);
+}
+sub vgfmg {
+	vgfm(@_,3);
+}
+
+sub vgfma {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7bc,@_);
+}
+sub vgfmab {
+	vgfma(@_,0);
+}
+sub vgfmah {
+	vgfma(@_,1);
+}
+sub vgfmaf {
+	vgfma(@_,2);
+}
+sub vgfmag {
+	vgfma(@_,3);
+}
+
+sub vlc {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7de,@_);
+}
+sub vlcb {
+	vlc(@_,0);
+}
+sub vlch {
+	vlc(@_,1);
+}
+sub vlcf {
+	vlc(@_,2);
+}
+sub vlcg {
+	vlc(@_,3);
+}
+
+sub vlp {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe7df,@_);
+}
+sub vlpb {
+	vlp(@_,0);
+}
+sub vlph {
+	vlp(@_,1);
+}
+sub vlpf {
+	vlp(@_,2);
+}
+sub vlpg {
+	vlp(@_,3);
+}
+
+sub vmx {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7ff,@_);
+}
+sub vmxb {
+	vmx(@_,0);
+}
+sub vmxh {
+	vmx(@_,1);
+}
+sub vmxf {
+	vmx(@_,2);
+}
+sub vmxg {
+	vmx(@_,3);
+}
+
+sub vmxl {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7fd,@_);
+}
+sub vmxlb {
+	vmxl(@_,0);
+}
+sub vmxlh {
+	vmxl(@_,1);
+}
+sub vmxlf {
+	vmxl(@_,2);
+}
+sub vmxlg {
+	vmxl(@_,3);
+}
+
+sub vmn {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7fe,@_);
+}
+sub vmnb {
+	vmn(@_,0);
+}
+sub vmnh {
+	vmn(@_,1);
+}
+sub vmnf {
+	vmn(@_,2);
+}
+sub vmng {
+	vmn(@_,3);
+}
+
+sub vmnl {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7fc,@_);
+}
+sub vmnlb {
+	vmnl(@_,0);
+}
+sub vmnlh {
+	vmnl(@_,1);
+}
+sub vmnlf {
+	vmnl(@_,2);
+}
+sub vmnlg {
+	vmnl(@_,3);
+}
+
+sub vmal {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7aa,@_);
+}
+sub vmalb {
+	vmal(@_,0);
+}
+sub vmalhw {
+	vmal(@_,1);
+}
+sub vmalf {
+	vmal(@_,2);
+}
+
+sub vmah {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7ab,@_);
+}
+sub vmahb {
+	vmah(@_,0);
+}
+sub vmahh {
+	vmah(@_,1);
+}
+sub vmahf {
+	vmah(@_,2);
+}
+
+sub vmalh {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7a9,@_);
+}
+sub vmalhb {
+	vmalh(@_,0);
+}
+sub vmalhh {
+	vmalh(@_,1);
+}
+sub vmalhf {
+	vmalh(@_,2);
+}
+
+sub vmae {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7ae,@_);
+}
+sub vmaeb {
+	vmae(@_,0);
+}
+sub vmaeh {
+	vmae(@_,1);
+}
+sub vmaef {
+	vmae(@_,2);
+}
+
+sub vmale {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7ac,@_);
+}
+sub vmaleb {
+	vmale(@_,0);
+}
+sub vmaleh {
+	vmale(@_,1);
+}
+sub vmalef {
+	vmale(@_,2);
+}
+
+sub vmao {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7af,@_);
+}
+sub vmaob {
+	vmao(@_,0);
+}
+sub vmaoh {
+	vmao(@_,1);
+}
+sub vmaof {
+	vmao(@_,2);
+}
+
+sub vmalo {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7ad,@_);
+}
+sub vmalob {
+	vmalo(@_,0);
+}
+sub vmaloh {
+	vmalo(@_,1);
+}
+sub vmalof {
+	vmalo(@_,2);
+}
+
+sub vmh {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a3,@_);
+}
+sub vmhb {
+	vmh(@_,0);
+}
+sub vmhh {
+	vmh(@_,1);
+}
+sub vmhf {
+	vmh(@_,2);
+}
+
+sub vmlh {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a1,@_);
+}
+sub vmlhb {
+	vmlh(@_,0);
+}
+sub vmlhh {
+	vmlh(@_,1);
+}
+sub vmlhf {
+	vmlh(@_,2);
+}
+
+sub vml {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a2,@_);
+}
+sub vmlb {
+	vml(@_,0);
+}
+sub vmlhw {
+	vml(@_,1);
+}
+sub vmlf {
+	vml(@_,2);
+}
+
+sub vme {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a6,@_);
+}
+sub vmeb {
+	vme(@_,0);
+}
+sub vmeh {
+	vme(@_,1);
+}
+sub vmef {
+	vme(@_,2);
+}
+
+sub vmle {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a4,@_);
+}
+sub vmleb {
+	vmle(@_,0);
+}
+sub vmleh {
+	vmle(@_,1);
+}
+sub vmlef {
+	vmle(@_,2);
+}
+
+sub vmo {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a7,@_);
+}
+sub vmob {
+	vmo(@_,0);
+}
+sub vmoh {
+	vmo(@_,1);
+}
+sub vmof {
+	vmo(@_,2);
+}
+
+sub vmlo {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7a5,@_);
+}
+sub vmlob {
+	vmlo(@_,0);
+}
+sub vmloh {
+	vmlo(@_,1);
+}
+sub vmlof {
+	vmlo(@_,2);
+}
+
+sub vno {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe76b,@_);
+}
+sub vnot {
+	vno(@_,$_[1]);
+}
+
+sub vo {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe76a,@_);
+}
+
+sub vpopct {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRa(0xe750,@_);
+}
+
+sub verllv {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe773,@_);
+}
+sub verllvb {
+	verllv(@_,0);
+}
+sub verllvh {
+	verllv(@_,1);
+}
+sub verllvf {
+	verllv(@_,2);
+}
+sub verllvg {
+	verllv(@_,3);
+}
+
+sub verll {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRSa(0xe733,@_);
+}
+sub verllb {
+	verll(@_,0);
+}
+sub verllh {
+	verll(@_,1);
+}
+sub verllf {
+	verll(@_,2);
+}
+sub verllg {
+	verll(@_,3);
+}
+
+sub verim {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRId(0xe772,@_);
+}
+sub verimb {
+	verim(@_,0);
+}
+sub verimh {
+	verim(@_,1);
+}
+sub verimf {
+	verim(@_,2);
+}
+sub verimg {
+	verim(@_,3);
+}
+
+sub veslv {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe770,@_);
+}
+sub veslvb {
+	veslv(@_,0);
+}
+sub veslvh {
+	veslv(@_,1);
+}
+sub veslvf {
+	veslv(@_,2);
+}
+sub veslvg {
+	veslv(@_,3);
+}
+
+sub vesl {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRSa(0xe730,@_);
+}
+sub veslb {
+	vesl(@_,0);
+}
+sub veslh {
+	vesl(@_,1);
+}
+sub veslf {
+	vesl(@_,2);
+}
+sub veslg {
+	vesl(@_,3);
+}
+
+sub vesrav {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe77a,@_);
+}
+sub vesravb {
+	vesrav(@_,0);
+}
+sub vesravh {
+	vesrav(@_,1);
+}
+sub vesravf {
+	vesrav(@_,2);
+}
+sub vesravg {
+	vesrav(@_,3);
+}
+
+sub vesra {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRSa(0xe73a,@_);
+}
+sub vesrab {
+	vesra(@_,0);
+}
+sub vesrah {
+	vesra(@_,1);
+}
+sub vesraf {
+	vesra(@_,2);
+}
+sub vesrag {
+	vesra(@_,3);
+}
+
+sub vesrlv {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe778,@_);
+}
+sub vesrlvb {
+	vesrlv(@_,0);
+}
+sub vesrlvh {
+	vesrlv(@_,1);
+}
+sub vesrlvf {
+	vesrlv(@_,2);
+}
+sub vesrlvg {
+	vesrlv(@_,3);
+}
+
+sub vesrl {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRSa(0xe738,@_);
+}
+sub vesrlb {
+	vesrl(@_,0);
+}
+sub vesrlh {
+	vesrl(@_,1);
+}
+sub vesrlf {
+	vesrl(@_,2);
+}
+sub vesrlg {
+	vesrl(@_,3);
+}
+
+sub vsl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe774,@_);
+}
+
+sub vslb {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe775,@_);
+}
+
+sub vsldb {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRId(0xe777,@_);
+}
+
+sub vsra {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe77e,@_);
+}
+
+sub vsrab {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe77f,@_);
+}
+
+sub vsrl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe77c,@_);
+}
+
+sub vsrlb {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe77d,@_);
+}
+
+sub vs {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7f7,@_);
+}
+sub vsb {
+	vs(@_,0);
+}
+sub vsh {
+	vs(@_,1);
+}
+sub vsf {
+	vs(@_,2);
+}
+sub vsg {
+	vs(@_,3);
+}
+sub vsq {
+	vs(@_,4);
+}
+
+sub vscbi {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe7f5,@_);
+}
+sub vscbib {
+	vscbi(@_,0);
+}
+sub vscbih {
+	vscbi(@_,1);
+}
+sub vscbif {
+	vscbi(@_,2);
+}
+sub vscbig {
+	vscbi(@_,3);
+}
+sub vscbiq {
+	vscbi(@_,4);
+}
+
+sub vsbi {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7bf,@_);
+}
+sub vsbiq {
+	vsbi(@_,4);
+}
+
+sub vsbcbi {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRd(0xe7bd,@_);
+}
+sub vsbcbiq {
+	vsbcbi(@_,4);
+}
+
+sub vsumg {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe765,@_);
+}
+sub vsumgh {
+	vsumg(@_,1);
+}
+sub vsumgf {
+	vsumg(@_,2);
+}
+
+sub vsumq {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe767,@_);
+}
+sub vsumqf {
+	vsumq(@_,2);
+}
+sub vsumqg {
+	vsumq(@_,3);
+}
+
+sub vsum {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRc(0xe764,@_);
+}
+sub vsumb {
+	vsum(@_,0);
+}
+sub vsumh {
+	vsum(@_,1);
+}
+
+sub vtm {
+	confess(err("ARGNUM")) if ($#_!=1);
+	VRRa(0xe7d8,@_);
+}
+
+# VX - String Instructions
+
+sub vfae {
+	confess(err("ARGNUM")) if ($#_<3||$#_>4);
+	VRRb(0xe782,@_);
+}
+sub vfaeb {
+	vfae(@_[0..2],0,$_[3]);
+}
+sub vfaeh {
+	vfae(@_[0..2],1,$_[3]);
+}
+sub vfaef {
+	vfae(@_[0..2],2,$_[3]);
+}
+sub vfaebs {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],0,0x1|$_[3]);
+}
+sub vfaehs {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],1,0x1|$_[3]);
+}
+sub vfaefs {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],2,0x1|$_[3]);
+}
+sub vfaezb {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],0,0x2|$_[3]);
+}
+sub vfaezh {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],1,0x2|$_[3]);
+}
+sub vfaezf {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],2,0x2|$_[3]);
+}
+sub vfaezbs {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],0,0x3|$_[3]);
+}
+sub vfaezhs {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],1,0x3|$_[3]);
+}
+sub vfaezfs {
+	$_[3]=0 if (!defined($_[3]));
+	vfae(@_[0..2],2,0x3|$_[3]);
+}
+
+sub vfee {
+	confess(err("ARGNUM")) if ($#_<3||$#_>4);
+	VRRb(0xe780,@_);
+}
+sub vfeeb {
+	vfee(@_[0..2],0,$_[3]);
+}
+sub vfeeh {
+	vfee(@_[0..2],1,$_[3]);
+}
+sub vfeef {
+	vfee(@_[0..2],2,$_[3]);
+}
+sub vfeebs {
+	vfee(@_,0,1);
+}
+sub vfeehs {
+	vfee(@_,1,1);
+}
+sub vfeefs {
+	vfee(@_,2,1);
+}
+sub vfeezb {
+	vfee(@_,0,2);
+}
+sub vfeezh {
+	vfee(@_,1,2);
+}
+sub vfeezf {
+	vfee(@_,2,2);
+}
+sub vfeezbs {
+	vfee(@_,0,3);
+}
+sub vfeezhs {
+	vfee(@_,1,3);
+}
+sub vfeezfs {
+	vfee(@_,2,3);
+}
+
+sub vfene {
+	confess(err("ARGNUM")) if ($#_<3||$#_>4);
+	VRRb(0xe781,@_);
+}
+sub vfeneb {
+	vfene(@_[0..2],0,$_[3]);
+}
+sub vfeneh {
+	vfene(@_[0..2],1,$_[3]);
+}
+sub vfenef {
+	vfene(@_[0..2],2,$_[3]);
+}
+sub vfenebs {
+	vfene(@_,0,1);
+}
+sub vfenehs {
+	vfene(@_,1,1);
+}
+sub vfenefs {
+	vfene(@_,2,1);
+}
+sub vfenezb {
+	vfene(@_,0,2);
+}
+sub vfenezh {
+	vfene(@_,1,2);
+}
+sub vfenezf {
+	vfene(@_,2,2);
+}
+sub vfenezbs {
+	vfene(@_,0,3);
+}
+sub vfenezhs {
+	vfene(@_,1,3);
+}
+sub vfenezfs {
+	vfene(@_,2,3);
+}
+
+sub vistr {
+	confess(err("ARGNUM")) if ($#_<2||$#_>3);
+	VRRa(0xe75c,@_[0..2],0,$_[3]);
+}
+sub vistrb {
+	vistr(@_[0..1],0,$_[2]);
+}
+sub vistrh {
+	vistr(@_[0..1],1,$_[2]);
+}
+sub vistrf {
+	vistr(@_[0..1],2,$_[2]);
+}
+sub vistrbs {
+	vistr(@_,0,1);
+}
+sub vistrhs {
+	vistr(@_,1,1);
+}
+sub vistrfs {
+	vistr(@_,2,1);
+}
+
+sub vstrc {
+	confess(err("ARGNUM")) if ($#_<4||$#_>5);
+	VRRd(0xe78a,@_);
+}
+sub vstrcb {
+	vstrc(@_[0..3],0,$_[4]);
+}
+sub vstrch {
+	vstrc(@_[0..3],1,$_[4]);
+}
+sub vstrcf {
+	vstrc(@_[0..3],2,$_[4]);
+}
+sub vstrcbs {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],0,0x1|$_[4]);
+}
+sub vstrchs {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],1,0x1|$_[4]);
+}
+sub vstrcfs {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],2,0x1|$_[4]);
+}
+sub vstrczb {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],0,0x2|$_[4]);
+}
+sub vstrczh {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],1,0x2|$_[4]);
+}
+sub vstrczf {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],2,0x2|$_[4]);
+}
+sub vstrczbs {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],0,0x3|$_[4]);
+}
+sub vstrczhs {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],1,0x3|$_[4]);
+}
+sub vstrczfs {
+	$_[4]=0 if (!defined($_[4]));
+	vstrc(@_[0..3],2,0x3|$_[4]);
+}
+
+# VX - Floating-point Instructions
+
+sub vfa {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRc(0xe7e3,@_);
+}
+sub vfadb {
+	vfa(@_,3,0);
+}
+sub wfadb {
+	vfa(@_,3,8);
+}
+
+sub wfc {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRa(0xe7cb,@_);
+}
+sub wfcdb {
+	wfc(@_,3,0);
+}
+
+sub wfk {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRa(0xe7ca,@_);
+}
+sub wfksb {
+	wfk(@_,2,0);
+}
+sub wfkdb {
+	wfk(@_,3,0);
+}
+sub wfkxb {
+	wfk(@_,4,0);
+}
+
+sub vfce {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRc(0xe7e8,@_);
+}
+sub vfcedb {
+	vfce(@_,3,0,0);
+}
+sub vfcedbs {
+	vfce(@_,3,0,1);
+}
+sub wfcedb {
+	vfce(@_,3,8,0);
+}
+sub wfcedbs {
+	vfce(@_,3,8,1);
+}
+
+sub vfch {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRc(0xe7eb,@_);
+}
+sub vfchdb {
+	vfch(@_,3,0,0);
+}
+sub vfchdbs {
+	vfch(@_,3,0,1);
+}
+sub wfchdb {
+	vfch(@_,3,8,0);
+}
+sub wfchdbs {
+	vfch(@_,3,8,1);
+}
+
+sub vfche {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRc(0xe7ea,@_);
+}
+sub vfchedb {
+	vfche(@_,3,0,0);
+}
+sub vfchedbs {
+	vfche(@_,3,0,1);
+}
+sub wfchedb {
+	vfche(@_,3,8,0);
+}
+sub wfchedbs {
+	vfche(@_,3,8,1);
+}
+
+sub vcdg {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7c3,@_);
+}
+sub vcdgb {
+	vcdg(@_[0..1],3,@_[2..3]);
+}
+sub wcdgb {
+	vcdg(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+
+sub vcdlg {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7c1,@_);
+}
+sub vcdlgb {
+	vcdlg(@_[0..1],3,@_[2..3]);
+}
+sub wcdlgb {
+	vcdlg(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+
+sub vcgd {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7c2,@_);
+}
+sub vcgdb {
+	vcgd(@_[0..1],3,@_[2..3]);
+}
+sub wcgdb {
+	vcgd(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+
+sub vclgd {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7c0,@_);
+}
+sub vclgdb {
+	vclgd(@_[0..1],3,@_[2..3]);
+}
+sub wclgdb {
+	vclgd(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+
+sub vfd {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRc(0xe7e5,@_);
+}
+sub vfddb {
+	vfd(@_,3,0);
+}
+sub wfddb {
+	vfd(@_,3,8);
+}
+
+sub vfi {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7c7,@_);
+}
+sub vfidb {
+	vfi(@_[0..1],3,@_[2..3]);
+}
+sub wfidb {
+	vfi(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+
+sub vlde {	# deprecated, use vfll
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRa(0xe7c4,@_);
+}
+sub vldeb {	# deprecated, use vflls
+	vlde(@_,2,0);
+}
+sub wldeb {	# deprecated, use wflls
+	vlde(@_,2,8);
+}
+
+sub vled {	# deprecated, use vflr
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7c5,@_);
+}
+sub vledb {	# deprecated, use vflrd
+	vled(@_[0..1],3,@_[2..3]);
+}
+sub wledb {	# deprecated, use wflrd
+	vled(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+
+sub vfm {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRc(0xe7e7,@_);
+}
+sub vfmdb {
+	vfm(@_,3,0);
+}
+sub wfmdb {
+	vfm(@_,3,8);
+}
+
+sub vfma {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRe(0xe78f,@_);
+}
+sub vfmadb {
+	vfma(@_,0,3);
+}
+sub wfmadb {
+	vfma(@_,8,3);
+}
+
+sub vfms {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRe(0xe78e,@_);
+}
+sub vfmsdb {
+	vfms(@_,0,3);
+}
+sub wfmsdb {
+	vfms(@_,8,3);
+}
+
+sub vfpso {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRa(0xe7cc,@_);
+}
+sub vfpsodb {
+	vfpso(@_[0..1],3,0,$_[2]);
+}
+sub wfpsodb {
+	vfpso(@_[0..1],3,8,$_[2]);
+}
+sub vflcdb {
+	vfpso(@_,3,0,0);
+}
+sub wflcdb {
+	vfpso(@_,3,8,0);
+}
+sub vflndb {
+	vfpso(@_,3,0,1);
+}
+sub wflndb {
+	vfpso(@_,3,8,1);
+}
+sub vflpdb {
+	vfpso(@_,3,0,2);
+}
+sub wflpdb {
+	vfpso(@_,3,8,2);
+}
+
+sub vfsq {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRRa(0xe7ce,@_);
+}
+sub vfsqdb {
+	vfsq(@_,3,0);
+}
+sub wfsqdb {
+	vfsq(@_,3,8);
+}
+
+sub vfs {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRRc(0xe7e2,@_);
+}
+sub vfsdb {
+	vfs(@_,3,0);
+}
+sub wfsdb {
+	vfs(@_,3,8);
+}
+
+sub vftci {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIe(0xe74a,@_);
+}
+sub vftcidb {
+	vftci(@_,3,0);
+}
+sub wftcidb {
+	vftci(@_,3,8);
+}
+
+# VXE - Support Instructions
+
+sub vbperm {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe785,@_);
+}
+
+sub vllezlf {
+	vllez(@_,6);
+}
+
+# VXE - Integer Instructions
+
+sub vmsl {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRd(0xe7b8,@_);
+}
+sub vmslg {
+	vmsl(@_[0..3],3,$_[4]);
+}
+
+sub vnx {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe76c,@_);
+}
+
+sub vnn {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe76e,@_);
+}
+
+sub voc {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRc(0xe76f,@_);
+}
+
+sub vpopctb {
+	vpopct(@_,0);
+}
+sub vpopcth {
+	vpopct(@_,1);
+}
+sub vpopctf {
+	vpopct(@_,2);
+}
+sub vpopctg {
+	vpopct(@_,3);
+}
+
+# VXE - Floating-Point Instructions
+
+sub vfasb {
+	vfa(@_,2,0);
+}
+sub wfasb {
+	vfa(@_,2,8);
+}
+sub wfaxb {
+	vfa(@_,4,8);
+}
+
+sub wfcsb {
+	wfc(@_,2,0);
+}
+sub wfcxb {
+	wfc(@_,4,0);
+}
+
+sub vfcesb {
+	vfce(@_,2,0,0);
+}
+sub vfcesbs {
+	vfce(@_,2,0,1);
+}
+sub wfcesb {
+	vfce(@_,2,8,0);
+}
+sub wfcesbs {
+	vfce(@_,2,8,1);
+}
+sub wfcexb {
+	vfce(@_,4,8,0);
+}
+sub wfcexbs {
+	vfce(@_,4,8,1);
+}
+
+sub vfchsb {
+	vfch(@_,2,0,0);
+}
+sub vfchsbs {
+	vfch(@_,2,0,1);
+}
+sub wfchsb {
+	vfch(@_,2,8,0);
+}
+sub wfchsbs {
+	vfch(@_,2,8,1);
+}
+sub wfchxb {
+	vfch(@_,4,8,0);
+}
+sub wfchxbs {
+	vfch(@_,4,8,1);
+}
+
+sub vfchesb {
+	vfche(@_,2,0,0);
+}
+sub vfchesbs {
+	vfche(@_,2,0,1);
+}
+sub wfchesb {
+	vfche(@_,2,8,0);
+}
+sub wfchesbs {
+	vfche(@_,2,8,1);
+}
+sub wfchexb {
+	vfche(@_,4,8,0);
+}
+sub wfchexbs {
+	vfche(@_,4,8,1);
+}
+
+sub vfdsb {
+	vfd(@_,2,0);
+}
+sub wfdsb {
+	vfd(@_,2,8);
+}
+sub wfdxb {
+	vfd(@_,4,8);
+}
+
+sub vfisb {
+	vfi(@_[0..1],2,@_[2..3]);
+}
+sub wfisb {
+	vfi(@_[0..1],2,0x8|$_[2],$_[3]);
+}
+sub wfixb {
+	vfi(@_[0..1],4,0x8|$_[2],$_[3]);
+}
+
+sub vfll {
+	vlde(@_);
+}
+sub vflls {
+	vfll(@_,2,0);
+}
+sub wflls {
+	vfll(@_,2,8);
+}
+sub wflld {
+	vfll(@_,3,8);
+}
+
+sub vflr {
+	vled(@_);
+}
+sub vflrd {
+	vflr(@_[0..1],3,@_[2..3]);
+}
+sub wflrd {
+	vflr(@_[0..1],3,0x8|$_[2],$_[3]);
+}
+sub wflrx {
+	vflr(@_[0..1],4,0x8|$_[2],$_[3]);
+}
+
+sub vfmax {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRc(0xe7ef,@_);
+}
+sub vfmaxsb {
+	vfmax(@_[0..2],2,0,$_[3]);
+}
+sub vfmaxdb {
+	vfmax(@_[0..2],3,0,$_[3]);
+}
+sub wfmaxsb {
+	vfmax(@_[0..2],2,8,$_[3]);
+}
+sub wfmaxdb {
+	vfmax(@_[0..2],3,8,$_[3]);
+}
+sub wfmaxxb {
+	vfmax(@_[0..2],4,8,$_[3]);
+}
+
+sub vfmin {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRc(0xe7ee,@_);
+}
+sub vfminsb {
+	vfmin(@_[0..2],2,0,$_[5]);
+}
+sub vfmindb {
+	vfmin(@_[0..2],3,0,$_[5]);
+}
+sub wfminsb {
+	vfmin(@_[0..2],2,8,$_[5]);
+}
+sub wfmindb {
+	vfmin(@_[0..2],3,8,$_[5]);
+}
+sub wfminxb {
+	vfmin(@_[0..2],4,8,$_[5]);
+}
+
+sub vfmsb {
+	vfm(@_,2,0);
+}
+sub wfmsb {
+	vfm(@_,2,8);
+}
+sub wfmxb {
+	vfm(@_,4,8);
+}
+
+sub vfmasb {
+	vfma(@_,0,2);
+}
+sub wfmasb {
+	vfma(@_,8,2);
+}
+sub wfmaxb {
+	vfma(@_,8,4);
+}
+
+sub vfmssb {
+	vfms(@_,0,2);
+}
+sub wfmssb {
+	vfms(@_,8,2);
+}
+sub wfmsxb {
+	vfms(@_,8,4);
+}
+
+sub vfnma {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRe(0xe79f,@_);
+}
+sub vfnmasb {
+	vfnma(@_,0,2);
+}
+sub vfnmadb {
+	vfnma(@_,0,3);
+}
+sub wfnmasb {
+	vfnma(@_,8,2);
+}
+sub wfnmadb {
+	vfnma(@_,8,3);
+}
+sub wfnmaxb {
+	vfnma(@_,8,4);
+}
+
+sub vfnms {
+	confess(err("ARGNUM")) if ($#_!=5);
+	VRRe(0xe79e,@_);
+}
+sub vfnmssb {
+	vfnms(@_,0,2);
+}
+sub vfnmsdb {
+	vfnms(@_,0,3);
+}
+sub wfnmssb {
+	vfnms(@_,8,2);
+}
+sub wfnmsdb {
+	vfnms(@_,8,3);
+}
+sub wfnmsxb {
+	vfnms(@_,8,4);
+}
+
+sub vfpsosb {
+	vfpso(@_[0..1],2,0,$_[2]);
+}
+sub wfpsosb {
+	vfpso(@_[0..1],2,8,$_[2]);
+}
+sub vflcsb {
+	vfpso(@_,2,0,0);
+}
+sub wflcsb {
+	vfpso(@_,2,8,0);
+}
+sub vflnsb {
+	vfpso(@_,2,0,1);
+}
+sub wflnsb {
+	vfpso(@_,2,8,1);
+}
+sub vflpsb {
+	vfpso(@_,2,0,2);
+}
+sub wflpsb {
+	vfpso(@_,2,8,2);
+}
+sub vfpsoxb {
+	vfpso(@_[0..1],4,0,$_[2]);
+}
+sub wfpsoxb {
+	vfpso(@_[0..1],4,8,$_[2]);
+}
+sub vflcxb {
+	vfpso(@_,4,0,0);
+}
+sub wflcxb {
+	vfpso(@_,4,8,0);
+}
+sub vflnxb {
+	vfpso(@_,4,0,1);
+}
+sub wflnxb {
+	vfpso(@_,4,8,1);
+}
+sub vflpxb {
+	vfpso(@_,4,0,2);
+}
+sub wflpxb {
+	vfpso(@_,4,8,2);
+}
+
+sub vfsqsb {
+	vfsq(@_,2,0);
+}
+sub wfsqsb {
+	vfsq(@_,2,8);
+}
+sub wfsqxb {
+	vfsq(@_,4,8);
+}
+
+sub vfssb {
+	vfs(@_,2,0);
+}
+sub wfssb {
+	vfs(@_,2,8);
+}
+sub wfsxb {
+	vfs(@_,4,8);
+}
+
+sub vftcisb {
+	vftci(@_,2,0);
+}
+sub wftcisb {
+	vftci(@_,2,8);
+}
+sub wftcixb {
+	vftci(@_,4,8);
+}
+
+# VXD - Support Instructions
+
+sub vlrlr {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRSd(0xe637,@_);
+}
+
+sub vlrl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VSI(0xe635,@_);
+}
+
+sub vstrlr {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRSd(0xe63f,@_);
+}
+
+sub vstrl {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VSI(0xe63d,@_);
+}
+
+sub vap {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe671,@_);
+}
+
+sub vcp {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRh(0xe677,@_);
+}
+
+sub vcvb {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRi(0xe650,@_);
+}
+
+sub vcvbg {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRRi(0xe652,@_);
+}
+
+sub vcvd {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRIi(0xe658,@_);
+}
+
+sub vcvdg {
+	confess(err("ARGNUM")) if ($#_!=3);
+	VRIi(0xe65a,@_);
+}
+
+sub vdp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe67a,@_);
+}
+
+sub vlip {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VRIh(0xe649,@_);
+}
+
+sub vmp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe678,@_);
+}
+
+sub vmsp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe679,@_);
+}
+
+sub vpkz {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VSI(0xe634,@_);
+}
+
+sub vpsop {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIg(0xe65b,@_);
+}
+
+sub vrp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe67b,@_);
+}
+
+sub vsdp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe67e,@_);
+}
+
+sub vsrp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIg(0xe659,@_);
+}
+
+sub vsp {
+	confess(err("ARGNUM")) if ($#_!=4);
+	VRIf(0xe673,@_);
+}
+
+sub vtp {
+	confess(err("ARGNUM")) if ($#_!=0);
+	VRRg(0xe65f,@_);
+}
+
+sub vupkz {
+	confess(err("ARGNUM")) if ($#_!=2);
+	VSI(0xe63c,@_);
+}
+
+#
+# Instruction Formats
+#
+
+sub RRE {
+	confess(err("ARGNUM")) if ($#_<0||2<$#_);
+	my ($opcode,$r1,$r2)=(shift,get_R(shift),get_R(shift));
+
+	$out.="\t.long\t".sprintf("%#010x",($opcode<<16|$r1<<4|$r2))."\n";
+}
+
+sub RRFb {
+	confess(err("ARGNUM")) if ($#_<3||4<$#_);
+	my ($opcode,$r1,$r3,$r2,$m4)=(shift,get_R(shift),get_R(shift)
+	    ,get_R(shift),get_M(shift));
+
+	$out.="\t.long\t"
+	    .sprintf("%#010x",($opcode<<16|$r3<<12|$m4<<8|$r1<<4|$r2))."\n";
+}
+
+sub S {
+	confess(err("ARGNUM")) if ($#_<0||1<$#_);
+	my ($opcode,$d2,$b2)=(shift,get_DB(shift));
+
+	$out.="\t.long\t".sprintf("%#010x",($opcode<<16|$b2<<12|$d2))."\n";
+}
+
+sub VRIa {
+	confess(err("ARGNUM")) if ($#_<2||3<$#_);
+	my ($opcode,$v1,$i2,$m3)=(shift,get_V(shift),get_I(shift,16),
+	    get_M(shift));
+
+	$out.="\t.word\t".sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4))."\n";
+	$out.="\t.word\t".sprintf("%#06x",$i2)."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m3<<12|RXB($v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VRIb {
+	confess(err("ARGNUM")) if ($#_!=4);
+	my ($opcode,$v1,$i2,$i3,$m4)=(shift,get_V(shift),get_I(shift,8),
+	    ,get_I(shift,8),get_M(shift));
+
+	$out.="\t.word\t".sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($i2<<8|$i3))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VRIc {
+	confess(err("ARGNUM")) if ($#_!=4);
+	my ($opcode,$v1,$v3,$i2,$m4)=(shift,get_V(shift),get_V(shift),
+	    ,get_I(shift,16),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4)|($v3&0xf))."\n";
+	$out.="\t.word\t".sprintf("%#06x",$i2)."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1,$v3)<<8|$opcode&0xff))."\n";
+}
+
+sub VRId {
+	confess(err("ARGNUM")) if ($#_<4||$#_>5);
+	my ($opcode,$v1,$v2,$v3,$i4,$m5)=(shift,get_V(shift),get_V(shift),
+	    ,get_V(shift),get_I(shift,8),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4)|($v2&0xf))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v3&0xf)<<12|$i4))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m5<<12|RXB($v1,$v2,$v3)<<8|$opcode&0xff))."\n";
+}
+
+sub VRIe {
+	confess(err("ARGNUM")) if ($#_!=5);
+	my ($opcode,$v1,$v2,$i3,$m4,$m5)=(shift,get_V(shift),get_V(shift),
+	    ,get_I(shift,12),get_M(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4)|($v2&0xf))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($i3<<4|$m5))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1,$v2)<<8|$opcode&0xff))."\n";
+}
+
+sub VRIf {
+	confess(err("ARGNUM")) if ($#_!=5);
+	my ($opcode,$v1,$v2,$v3,$i4,$m5)=(shift,get_V(shift),get_V(shift),
+	    ,get_V(shift),get_I(shift,8),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4)|($v2&0xf))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v3&0xf)<<12|$m5<<4)|$i4>>4)."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",(($i4&0xf)<<12|RXB($v1,$v2,$v3)<<8|$opcode&0xff))
+	    ."\n";
+}
+
+sub VRIg {
+	confess(err("ARGNUM")) if ($#_!=5);
+	my ($opcode,$v1,$v2,$i3,$i4,$m5)=(shift,get_V(shift),get_V(shift),
+	    ,get_I(shift,8),get_I(shift,8),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4)|($v2&0xf))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($i4<<8|$m5<<4|$i3>>4))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",(($i3&0xf)<<12|RXB($v1,$v2)<<8|$opcode&0xff))
+	    ."\n";
+}
+
+sub VRIh {
+	confess(err("ARGNUM")) if ($#_!=3);
+	my ($opcode,$v1,$i2,$i3)=(shift,get_V(shift),get_I(shift,16),
+	    get_I(shift,4));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4))."\n";
+	$out.="\t.word\t".sprintf("%#06x",$i2)."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($i3<<12|RXB($v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VRIi {
+	confess(err("ARGNUM")) if ($#_!=4);
+	my ($opcode,$v1,$r2,$i3,$m4)=(shift,get_V(shift),get_R(shift),
+	    ,get_I(shift,8),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4)|$r2)."\n";
+	$out.="\t.word\t".sprintf("%#06x",($m4<<4|$i3>>4))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",(($i3&0xf)<<12|RXB($v1)<<8|$opcode&0xff))
+	    ."\n";
+}
+
+sub VRRa {
+	confess(err("ARGNUM")) if ($#_<2||5<$#_);
+	my ($opcode,$v1,$v2,$m3,$m4,$m5)=(shift,get_V(shift),get_V(shift),
+	    get_M(shift),get_M(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($m5<<4|$m4))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m3<<12|RXB($v1,$v2)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRb {
+	confess(err("ARGNUM")) if ($#_<3||5<$#_);
+	my ($opcode,$v1,$v2,$v3,$m4,$m5)=(shift,get_V(shift),get_V(shift),
+	    get_V(shift),get_M(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v3&0xf)<<12|$m5<<4))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1,$v2,$v3)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRc {
+	confess(err("ARGNUM")) if ($#_<3||6<$#_);
+	my ($opcode,$v1,$v2,$v3,$m4,$m5,$m6)=(shift,get_V(shift),get_V(shift),
+	    get_V(shift),get_M(shift),get_M(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v3&0xf)<<12|$m6<<4|$m5))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1,$v2,$v3)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRd {
+	confess(err("ARGNUM")) if ($#_<4||6<$#_);
+	my ($opcode,$v1,$v2,$v3,$v4,$m5,$m6)=(shift,get_V(shift),get_V(shift),
+	    get_V(shift),get_V(shift),get_M(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v3&0xf)<<12|$m5<<8|$m6<<4))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",
+	    (($v4&0xf)<<12|RXB($v1,$v2,$v3,$v4)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRe {
+	confess(err("ARGNUM")) if ($#_<4||6<$#_);
+	my ($opcode,$v1,$v2,$v3,$v4,$m5,$m6)=(shift,get_V(shift),get_V(shift),
+	    get_V(shift),get_V(shift),get_M(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v3&0xf)<<12|$m6<<8|$m5))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",
+	    (($v4&0xf)<<12|RXB($v1,$v2,$v3,$v4)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRf {
+	confess(err("ARGNUM")) if ($#_!=3);
+	my ($opcode,$v1,$r2,$r3)=(shift,get_V(shift),get_R(shift),
+	    get_R(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|$r2))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($r3<<12))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(RXB($v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRg {
+	confess(err("ARGNUM")) if ($#_!=1);
+	my ($opcode,$v1)=(shift,get_V(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",0x0000)."\n";
+	$out.="\t.word\t".sprintf("%#06x",(RXB(0,$v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VRRh {
+	confess(err("ARGNUM")) if ($#_<2||$#_>3);
+	my ($opcode,$v1,$v2,$m3)=(shift,get_V(shift),get_V(shift),
+	    get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(($v2&0xf)<<12|$m3<<4))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(RXB(0,$v1,$v2)<<8|$opcode&0xff))
+	    ."\n";
+}
+
+sub VRRi {
+	confess(err("ARGNUM")) if ($#_!=3);
+	my ($opcode,$r1,$v2,$m3)=(shift,get_R(shift),get_V(shift),
+	    get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|$r1<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($m3<<4))."\n";
+	$out.="\t.word\t".sprintf("%#06x",(RXB(0,$v2)<<8|$opcode&0xff))."\n";
+}
+
+sub VRSa {
+	confess(err("ARGNUM")) if ($#_<3||$#_>4);
+	my ($opcode,$v1,$v3,$d2,$b2,$m4)=(shift,get_V(shift),get_V(shift),
+	    get_DB(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v3&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1,$v3)<<8|$opcode&0xff))."\n";
+}
+
+sub VRSb {
+	confess(err("ARGNUM")) if ($#_<3||$#_>4);
+	my ($opcode,$v1,$r3,$d2,$b2,$m4)=(shift,get_V(shift),get_R(shift),
+	    get_DB(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|$r3))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB($v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VRSc {
+	confess(err("ARGNUM")) if ($#_!=4);
+	my ($opcode,$r1,$v3,$d2,$b2,$m4)=(shift,get_R(shift),get_V(shift),
+	    get_DB(shift),get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|$r1<<4|($v3&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m4<<12|RXB(0,$v3)<<8|$opcode&0xff))."\n";
+}
+
+sub VRSd {
+	confess(err("ARGNUM")) if ($#_!=3);
+	my ($opcode,$v1,$r3,$d2,$b2)=(shift,get_V(shift),get_R(shift),
+	    get_DB(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|$r3))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",(($v1&0xf)<<12|RXB(0,0,0,$v1)<<8|$opcode&0xff))
+	    ."\n";
+}
+
+sub VRV {
+	confess(err("ARGNUM")) if ($#_<2||$#_>3);
+	my ($opcode,$v1,$d2,$v2,$b2,$m3)=(shift,get_V(shift),get_DVB(shift),
+	    get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($v2&0xf)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m3<<12|RXB($v1,$v2)<<8|$opcode&0xff))."\n";
+}
+
+sub VRX {
+	confess(err("ARGNUM")) if ($#_<2||$#_>3);
+	my ($opcode,$v1,$d2,$x2,$b2,$m3)=(shift,get_V(shift),get_DXB(shift),
+	    get_M(shift));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|($v1&0xf)<<4|($x2)))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($m3<<12|RXB($v1)<<8|$opcode&0xff))."\n";
+}
+
+sub VSI {
+	confess(err("ARGNUM")) if ($#_!=3);
+	my ($opcode,$v1,$d2,$b2,$i3)=(shift,get_V(shift),get_DB(shift),
+	    get_I(shift,8));
+
+	$out.="\t.word\t"
+	    .sprintf("%#06x",($opcode&0xff00|$i3))."\n";
+	$out.="\t.word\t".sprintf("%#06x",($b2<<12|$d2))."\n";
+	$out.="\t.word\t"
+	    .sprintf("%#06x",(($v1&0xf)<<12|RXB(0,0,0,$v1)<<8|$opcode&0xff))
+	    ."\n";
+}
+
+#
+# Internal
+#
+
+sub get_R {
+	confess(err("ARGNUM")) if ($#_!=0);
+	my $r;
+
+	for (shift) {
+		if (!defined) {
+			$r=0;
+		} elsif (/^$GR$/) {
+			$r=$1;
+		} else {
+			confess(err("PARSE"));
+		}
+	}
+	confess(err("ARGRANGE")) if ($r&~0xf);
+
+	return $r;
+}
+
+sub get_V {
+	confess(err("ARGNUM")) if ($#_!=0);
+	my $v;
+
+	for (shift) {
+		if (!defined) {
+			$v=0;
+		} elsif (/^$VR$/) {
+			$v=$1;
+		} else {
+			confess(err("PARSE"));
+		}
+	}
+	confess(err("ARGRANGE")) if ($v&~0x1f);
+
+	return $v;
+}
+
+sub get_I {
+	confess(err("ARGNUM")) if ($#_!=1);
+	my ($i,$bits)=(shift,shift);
+
+	$i=defined($i)?(eval($i)):(0);
+	confess(err("PARSE")) if (!defined($i));
+	confess(err("ARGRANGE")) if (abs($i)&~(2**$bits-1));
+
+	return $i&(2**$bits-1);
+}
+
+sub get_M {
+	confess(err("ARGNUM")) if ($#_!=0);
+	my $m=shift;
+
+	$m=defined($m)?(eval($m)):(0);
+	confess(err("PARSE")) if (!defined($m));
+	confess(err("ARGRANGE")) if ($m&~0xf);
+
+	return $m;
+}
+
+sub get_DB
+{
+	confess(err("ARGNUM")) if ($#_!=0);
+	my ($d,$b);
+
+	for (shift) {
+		if (!defined) {
+			($d,$b)=(0,0);
+		} elsif (/^(.+)\($GR\)$/) {
+			($d,$b)=(eval($1),$2);
+			confess(err("PARSE")) if (!defined($d));
+		} elsif (/^(.+)$/) {
+			($d,$b)=(eval($1),0);
+			confess(err("PARSE")) if (!defined($d));
+		} else {
+			confess(err("PARSE"));
+		}
+	}
+	confess(err("ARGRANGE")) if ($d&~0xfff||$b&~0xf);
+
+	return ($d,$b);
+}
+
+sub get_DVB
+{
+	confess(err("ARGNUM")) if ($#_!=0);
+	my ($d,$v,$b);
+
+	for (shift) {
+		if (!defined) {
+			($d,$v,$b)=(0,0,0);
+		} elsif (/^(.+)\($VR,$GR\)$/) {
+			($d,$v,$b)=(eval($1),$2,$3);
+			confess(err("PARSE")) if (!defined($d));
+		} elsif (/^(.+)\($GR\)$/) {
+			($d,$v,$b)=(eval($1),0,$2);
+			confess(err("PARSE")) if (!defined($d));
+		} elsif (/^(.+)$/) {
+			($d,$v,$b)=(eval($1),0,0);
+			confess(err("PARSE")) if (!defined($d));
+		} else {
+			confess(err("PARSE"));
+		}
+	}
+	confess(err("ARGRANGE")) if ($d&~0xfff||$v&~0x1f||$b&~0xf);
+
+	return ($d,$v,$b);
+}
+
+sub get_DXB
+{
+	confess(err("ARGNUM")) if ($#_!=0);
+	my ($d,$x,$b);
+
+	for (shift) {
+		if (!defined) {
+			($d,$x,$b)=(0,0,0);
+		} elsif (/^(.+)\($GR,$GR\)$/) {
+			($d,$x,$b)=(eval($1),$2,$3);
+			confess(err("PARSE")) if (!defined($d));
+		} elsif (/^(.+)\($GR\)$/) {
+			($d,$x,$b)=(eval($1),0,$2);
+			confess(err("PARSE")) if (!defined($d));
+		} elsif (/^(.+)$/) {
+			($d,$x,$b)=(eval($1),0,0);
+			confess(err("PARSE")) if (!defined($d));
+		} else {
+			confess(err("PARSE"));
+		}
+	}
+	confess(err("ARGRANGE")) if ($d&~0xfff||$x&~0xf||$b&~0xf);
+
+	return ($d,$x,$b);
+}
+
+sub RXB
+{
+	confess(err("ARGNUM")) if ($#_<0||3<$#_);
+	my $rxb=0;
+
+	$rxb|=0x08 if (defined($_[0])&&($_[0]&0x10));
+	$rxb|=0x04 if (defined($_[1])&&($_[1]&0x10));
+	$rxb|=0x02 if (defined($_[2])&&($_[2]&0x10));
+	$rxb|=0x01 if (defined($_[3])&&($_[3]&0x10));
+
+	return $rxb;
+}
+
+sub err {
+	my %ERR		=
+	(
+		ARGNUM	=>	'Wrong number of arguments',
+		ARGRANGE=>	'Argument out of range',
+		PARSE	=>	'Parse error',
+	);
+	confess($ERR{ARGNUM}) if ($#_!=0);
+
+	return $ERR{$_[0]};
+}
+
+1;

--- a/crypto/poly1305/asm/poly1305-s390x.pl
+++ b/crypto/poly1305/asm/poly1305-s390x.pl
@@ -24,12 +24,22 @@
 #
 # On side note, z13 enables vector base 2^26 implementation...
 
+#
+# February 2017
+#
+# Add vx code path (base 2^26).
+#
+# Copyright IBM Corp. 2017
+# Author: Patrick Steuer <patrick.steuer@de.ibm.com>
+
+use strict;
 use FindBin qw($Bin);
 use lib "$Bin/../..";
-use perlasm::s390x qw(:DEFAULT AUTOLOAD LABEL);
+use perlasm::s390x qw(:DEFAULT :VX AUTOLOAD LABEL);
 
-$flavour = shift;
+my $flavour = shift;
 
+my ($z,$SIZE_T);
 if ($flavour =~ /3[12]/) {
 	$z=0;	# S/390 ABI
 	$SIZE_T=4;
@@ -38,15 +48,122 @@ if ($flavour =~ /3[12]/) {
 	$SIZE_T=8;
 }
 
+my $output;
 while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
 
-$sp="%r15";
+my $sp="%r15";
 
-my ($ctx,$inp,$len,$padbit) = map("%r$_",(2..5));
+# novx code path ctx layout
+# ---------------------------------
+# var		value	base	off
+# ---------------------------------
+# u64 h[3]	hash	2^64	  0
+# u32 pad[2]
+# u64 r[2]	key	2^64	 32
+
+# vx code path ctx layout
+# ---------------------------------
+# var		value	base	off
+# ---------------------------------
+# u32 acc1[5]	r^2-acc	2^26	  0
+# u32 pad
+# u32 acc2[5]	r-acc	2^26	 24
+# u32 pad
+# u32 r1[5]	r	2^26	 48
+# u32 r15[5]	5*r	2^26	 68
+# u32 r2[5]	r^2	2^26	 88
+# u32 r25[5]	5*r^2	2^26	108
+# u32 r4[5]	r^4	2^26	128
+# u32 r45[5]	5*r^4	2^26	148
 
 PERLASM_BEGIN($output);
 
 TEXT	();
+
+################
+# static void poly1305_init(void *ctx, const unsigned char key[16])
+{
+my ($ctx,$key)=map("%r$_",(2..3));
+my ($r0,$r1,$r2)=map("%r$_",(9,11,13));
+
+sub MUL_RKEY {	# r*=key
+my ($d0hi,$d0lo,$d1hi,$d1lo)=map("%r$_",(4..7));
+my ($t0,$t1,$s1)=map("%r$_",(8,10,12));
+
+	lg	("%r0","32($ctx)");
+	lg	("%r1","40($ctx)");
+
+	srlg	($s1,"%r1",2);
+	algr	($s1,"%r1");
+
+	lgr	($d0lo,$r0);
+	lgr	($d1lo,$r1);
+
+	mlgr	($d0hi,"%r0");
+	lgr	($r1,$d1lo);
+	mlgr	($d1hi,$s1);
+
+	mlgr	($t0,"%r1");
+	mlgr	($t1,"%r0");
+
+	algr	($d0lo,$d1lo);
+	lgr	($d1lo,$r2);
+	alcgr	($d0hi,$d1hi);
+	lghi	($d1hi,0);
+
+	algr	($r1,$r0);
+	alcgr	($t1,$t0);
+
+	msgr	($d1lo,$s1);
+	msgr	($r2,"%r0");
+
+	algr	($r1,$d1lo);
+	alcgr	($t1,$d1hi);
+
+	algr	($r1,$d0hi);
+	alcgr	($r2,$t1);
+
+	lghi	($r0,-4);
+	ngr	($r0,$r2);
+	srlg	($t0,$r2,2);
+	algr	($r0,$t0);
+	lghi	($t1,3);
+	ngr	($r2,$t1);
+
+	algr	($r0,$d0lo);
+	alcgr	($r1,$d1hi);
+	alcgr	($r2,$d1hi);
+}
+
+sub ST_R5R {	# store r,5*r -> base 2^26
+my @d=map("%r$_",(4..8));
+my @off=@_;
+
+	lgr	(@d[2],$r0);
+	lr	("%r1",@d[2]);
+	nilh	("%r1",1023);
+	lgr	(@d[3],$r1);
+	lr	(@d[0],"%r1");
+	srlg	("%r1",@d[2],52);
+	lgr	(@d[4],$r2);
+	srlg	("%r0",@d[2],26);
+	sll	(@d[4],24);
+	lr	(@d[2],@d[3]);
+	nilh	("%r0",1023);
+	sll	(@d[2],12);
+	lr	(@d[1],"%r0");
+	&or	(@d[2],"%r1");
+	srlg	("%r1",@d[3],40);
+	nilh	(@d[2],1023);
+	&or	(@d[4],"%r1");
+	srlg	(@d[3],@d[3],14);
+	nilh	(@d[4],1023);
+	nilh	(@d[3],1023);
+
+	stm	(@d[0],@d[4],"@off[0]($ctx)");
+	mhi	(@d[$_],5) for (0..4);
+	stm	(@d[0],@d[4],"@off[1]($ctx)");
+}
 
 GLOBL	("poly1305_init");
 TYPE	("poly1305_init","\@function");
@@ -54,15 +171,15 @@ ALIGN	(16);
 LABEL	("poly1305_init");
 	lghi	("%r0",0);
 	lghi	("%r1",-1);
-	stg	("%r0","0($ctx)");	# zero hash value
+	stg	("%r0","0($ctx)");	# zero hash value / acc1
 	stg	("%r0","8($ctx)");
 	stg	("%r0","16($ctx)");
 
-&{$z?	\&clgr:\&clr}	($inp,"%r0");
-	je	(".Lno_key");
+&{$z?	\&clgr:\&clr}	($key,"%r0");
+	je	(".Ldone");
 
-	lrvg	("%r4","0($inp)");	# load little-endian key
-	lrvg	("%r5","8($inp)");
+	lrvg	("%r4","0($key)");	# load little-endian key
+	lrvg	("%r5","8($key)");
 
 	nihl	("%r1",0xffc0);		# 0xffffffc0ffffffff
 	srlg	("%r0","%r1",4);	# 0x0ffffffc0fffffff
@@ -75,15 +192,505 @@ LABEL	("poly1305_init");
 	stg	("%r4","32($ctx)");
 	stg	("%r5","40($ctx)");
 
-LABEL	(".Lno_key");
+	larl	("%r1","OPENSSL_s390xcap_P");
+	lg	("%r0","16(%r1)");
+	tmhh	("%r0",0x4000);		# check for vector facility
+	jz	(".Ldone");
+
+	larl	("%r4","poly1305_blocks_vx");
+	larl	("%r5","poly1305_emit_vx");
+
+&{$z?	\&stmg:\&stm}	("%r6","%r13","6*$SIZE_T($sp)");
+&{$z?	\&stmg:\&stm}	("%r4","%r5","4*$z+228($ctx)");
+
+	lg	($r0,"32($ctx)");
+	lg	($r1,"40($ctx)");
+	lghi	($r2,0);
+
+	ST_R5R	(48,68);	# store r,5*r
+
+	MUL_RKEY();
+	ST_R5R	(88,108);	# store r^2,5*r^2
+
+	MUL_RKEY();
+	MUL_RKEY();
+	ST_R5R	(128,148);	# store r^4,5*r^4
+
+	lghi	("%r0",0);
+	stg	("%r0","24($ctx)");	# zero acc2
+	stg	("%r0","32($ctx)");
+	stg	("%r0","40($ctx)");
+
+&{$z?	\&lmg:\&lm}	("%r6","%r13","6*$SIZE_T($sp)");
+	lghi	("%r2",1);
+	br	("%r14");
+
+LABEL	(".Ldone");
 	lghi	("%r2",0);
 	br	("%r14");
 SIZE	("poly1305_init",".-poly1305_init");
+}
 
+# VX CODE PATH
 {
+my $frame=8*16;
+my @m01=map("%v$_",(0..4));
+my @m23=map("%v$_",(5..9));
+my @tmp=@m23;
+my @acc=map("%v$_",(10..14));
+my @r=map("%v$_",(15..19));
+my @r5=map("%v$_",(20..24));
+my $padvec="%v26";
+my $mask4="%v27";
+my @vperm=map("%v$_",(28..30));
+my $mask="%v31";
+
+sub REDUCE {
+	vesrlg	(@tmp[0],@acc[0],26);
+	vesrlg	(@tmp[3],@acc[3],26);
+	vn	(@acc[0],@acc[0],$mask);
+	vn	(@acc[3],@acc[3],$mask);
+	vag	(@acc[1],@acc[1],@tmp[0]);	# carry 0->1
+	vag	(@acc[4],@acc[4],@tmp[3]);	# carry 3->4
+
+	vesrlg	(@tmp[1],@acc[1],26);
+	vesrlg	(@tmp[4],@acc[4],26);
+	vn	(@acc[1],@acc[1],$mask);
+	vn	(@acc[4],@acc[4],$mask);
+	veslg	(@tmp[0],@tmp[4],2);
+	vag	(@tmp[4],@tmp[4],@tmp[0]);	# h[4]*=5
+	vag	(@acc[2],@acc[2],@tmp[1]);	# carry 1->2
+	vag	(@acc[0],@acc[0],@tmp[4]);	# carry 4->0
+
+	vesrlg	(@tmp[2],@acc[2],26);
+	vesrlg	(@tmp[0],@acc[0],26);
+	vn	(@acc[2],@acc[2],$mask);
+	vn	(@acc[0],@acc[0],$mask);
+	vag	(@acc[3],@acc[3],@tmp[2]);	# carry 2->3
+	vag	(@acc[1],@acc[1],@tmp[0]);	# carry 0->1
+
+	vesrlg	(@tmp[3],@acc[3],26);
+	vn	(@acc[3],@acc[3],$mask);
+	vag	(@acc[4],@acc[4],@tmp[3]);	# carry 3->4
+}
+
+################
+# static void poly1305_blocks_vx(void *ctx, const unsigned char *inp,
+#                                size_t len, u32 padbit)
+{
+my ($ctx,$inp,$len) = map("%r$_",(2..4));
+my $padbit="%r0";
+
+GLOBL	("poly1305_blocks_vx");
+TYPE	("poly1305_blocks_vx","\@function");
+ALIGN	(16);
+LABEL	("poly1305_blocks_vx");
+if ($z) {
+	aghi	($sp,-$frame);
+	vstm	("%v8","%v15","0($sp)");
+} else {
+	std	("%f4","16*$SIZE_T+2*8($sp)");
+	std	("%f6","16*$SIZE_T+3*8($sp)");
+	llgfr	($len,$len);
+}
+	llgfr	($padbit,"%r5");
+	vlef	(@acc[$_],"4*$_($ctx)",1) for (0..4);	# load acc1
+	larl	("%r5",".Lconst");
+	vlef	(@acc[$_],"24+4*$_($ctx)",3) for (0..4);	# load acc2
+	sllg	($padbit,$padbit,24);
+	vlm	(@vperm[0],$mask,"0(%r5)");	# load vperm ops, mask
+	vgbm	($mask4,0x0707);
+	vlvgp	($padvec,$padbit,$padbit);
+
+	srlg	("%r1",$len,6);
+	ltgr	("%r1","%r1");
+	jz	(".Lvx_4x_done");
+
+ALIGN	(16);
+LABEL	(".Lvx_4x");
+	vlm	("%v20","%v23","0($inp)");	# load m0,m1,m2,m3
+
+	# m01,m23 -> base 2^26
+
+	vperm	(@m01[0],"%v20","%v21",@vperm[0]);
+	vperm	(@m23[0],"%v22","%v23",@vperm[0]);
+	vperm	(@m01[2],"%v20","%v21",@vperm[1]);
+	vperm	(@m23[2],"%v22","%v23",@vperm[1]);
+	vperm	(@m01[4],"%v20","%v21",@vperm[2]);
+	vperm	(@m23[4],"%v22","%v23",@vperm[2]);
+
+	vesrlg	(@m01[1],@m01[0],26);
+	vesrlg	(@m23[1],@m23[0],26);
+	vesrlg	(@m01[3],@m01[2],30);
+	vesrlg	(@m23[3],@m23[2],30);
+	vesrlg	(@m01[2],@m01[2],4);
+	vesrlg	(@m23[2],@m23[2],4);
+
+	vn	(@m01[4],@m01[4],$mask4);
+	vn	(@m23[4],@m23[4],$mask4);
+for (0..3) {
+	vn	(@m01[$_],@m01[$_],$mask);
+	vn	(@m23[$_],@m23[$_],$mask);
+}
+	vaf	(@m01[4],@m01[4],$padvec);	# pad m01
+	vaf	(@m23[4],@m23[4],$padvec);	# pad m23
+
+	# acc = acc * r^4 + m01 * r^2 + m23
+
+	vlrepf	(@r5[$_],"4*$_+108($ctx)") for (0..4);	# load 5*r^2
+	vlrepf	(@r[$_],"4*$_+88($ctx)") for (0..4);	# load r^2
+
+	vmalof	(@tmp[0],@m01[4],@r5[1],@m23[0]);
+	vmalof	(@tmp[1],@m01[4],@r5[2],@m23[1]);
+	vmalof	(@tmp[2],@m01[4],@r5[3],@m23[2]);
+	vmalof	(@tmp[3],@m01[4],@r5[4],@m23[3]);
+	vmalof	(@tmp[4],@m01[4],@r[0],@m23[4]);
+
+	vmalof	(@tmp[0],@m01[3],@r5[2],@tmp[0]);
+	vmalof	(@tmp[1],@m01[3],@r5[3],@tmp[1]);
+	vmalof	(@tmp[2],@m01[3],@r5[4],@tmp[2]);
+	vmalof	(@tmp[3],@m01[3],@r[0],@tmp[3]);
+	vmalof	(@tmp[4],@m01[3],@r[1],@tmp[4]);
+
+	vmalof	(@tmp[0],@m01[2],@r5[3],@tmp[0]);
+	vmalof	(@tmp[1],@m01[2],@r5[4],@tmp[1]);
+	vmalof	(@tmp[2],@m01[2],@r[0],@tmp[2]);
+	vmalof	(@tmp[3],@m01[2],@r[1],@tmp[3]);
+	vmalof	(@tmp[4],@m01[2],@r[2],@tmp[4]);
+
+	vmalof	(@tmp[0],@m01[1],@r5[4],@tmp[0]);
+	vmalof	(@tmp[1],@m01[1],@r[0],@tmp[1]);
+	vmalof	(@tmp[2],@m01[1],@r[1],@tmp[2]);
+	vmalof	(@tmp[3],@m01[1],@r[2],@tmp[3]);
+	vmalof	(@tmp[4],@m01[1],@r[3],@tmp[4]);
+
+	vmalof	(@tmp[0],@m01[0],@r[0],@tmp[0]);
+	vmalof	(@tmp[1],@m01[0],@r[1],@tmp[1]);
+	vmalof	(@tmp[2],@m01[0],@r[2],@tmp[2]);
+	vmalof	(@tmp[3],@m01[0],@r[3],@tmp[3]);
+	vmalof	(@tmp[4],@m01[0],@r[4],@tmp[4]);
+
+	vlrepf	(@r5[$_],"4*$_+148($ctx)") for (0..4);	# load 5*r^4
+	vlrepf	(@r[$_],"4*$_+128($ctx)") for (0..4);	# load r^4
+
+	vmalof	(@tmp[0],@acc[4],@r5[1],@tmp[0]);
+	vmalof	(@tmp[1],@acc[4],@r5[2],@tmp[1]);
+	vmalof	(@tmp[2],@acc[4],@r5[3],@tmp[2]);
+	vmalof	(@tmp[3],@acc[4],@r5[4],@tmp[3]);
+	vmalof	(@tmp[4],@acc[4],@r[0],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[3],@r5[2],@tmp[0]);
+	vmalof	(@tmp[1],@acc[3],@r5[3],@tmp[1]);
+	vmalof	(@tmp[2],@acc[3],@r5[4],@tmp[2]);
+	vmalof	(@tmp[3],@acc[3],@r[0],@tmp[3]);
+	vmalof	(@tmp[4],@acc[3],@r[1],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[2],@r5[3],@tmp[0]);
+	vmalof	(@tmp[1],@acc[2],@r5[4],@tmp[1]);
+	vmalof	(@tmp[2],@acc[2],@r[0],@tmp[2]);
+	vmalof	(@tmp[3],@acc[2],@r[1],@tmp[3]);
+	vmalof	(@tmp[4],@acc[2],@r[2],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[1],@r5[4],@tmp[0]);
+	vmalof	(@tmp[1],@acc[1],@r[0],@tmp[1]);
+	vmalof	(@tmp[2],@acc[1],@r[1],@tmp[2]);
+	vmalof	(@tmp[3],@acc[1],@r[2],@tmp[3]);
+	vmalof	(@tmp[4],@acc[1],@r[3],@tmp[4]);
+
+	vmalof	(@acc[1],@acc[0],@r[1],@tmp[1]);
+	vmalof	(@acc[2],@acc[0],@r[2],@tmp[2]);
+	vmalof	(@acc[3],@acc[0],@r[3],@tmp[3]);
+	vmalof	(@acc[4],@acc[0],@r[4],@tmp[4]);
+	vmalof	(@acc[0],@acc[0],@r[0],@tmp[0]);
+
+	REDUCE	();
+
+	la	($inp,"64($inp)");
+	brctg	("%r1",".Lvx_4x");
+
+ALIGN	(16);
+LABEL	(".Lvx_4x_done");
+	tml	($len,32);
+	jz	(".Lvx_2x_done");
+
+	vlm	("%v20","%v21","0($inp)");	# load m0,m1
+
+	# m01 -> base 2^26
+
+	vperm	(@m01[0],"%v20","%v21",@vperm[0]);
+	vperm	(@m01[2],"%v20","%v21",@vperm[1]);
+	vperm	(@m01[4],"%v20","%v21",@vperm[2]);
+
+	vesrlg	(@m01[1],@m01[0],26);
+	vesrlg	(@m01[3],@m01[2],30);
+	vesrlg	(@m01[2],@m01[2],4);
+
+	vn	(@m01[4],@m01[4],$mask4);
+	vn	(@m01[$_],@m01[$_],$mask) for (0..3);
+
+	vaf	(@m01[4],@m01[4],$padvec);	# pad m01
+
+	# acc = acc * r^2+ m01
+
+	vlrepf	(@r5[$_],"4*$_+108($ctx)") for (0..4);	# load 5*r^2
+	vlrepf	(@r[$_],"4*$_+88($ctx)") for (0..4);	# load r^2
+
+	vmalof	(@tmp[0],@acc[4],@r5[1],@m01[0]);
+	vmalof	(@tmp[1],@acc[4],@r5[2],@m01[1]);
+	vmalof	(@tmp[2],@acc[4],@r5[3],@m01[2]);
+	vmalof	(@tmp[3],@acc[4],@r5[4],@m01[3]);
+	vmalof	(@tmp[4],@acc[4],@r[0],@m01[4]);
+
+	vmalof	(@tmp[0],@acc[3],@r5[2],@tmp[0]);
+	vmalof	(@tmp[1],@acc[3],@r5[3],@tmp[1]);
+	vmalof	(@tmp[2],@acc[3],@r5[4],@tmp[2]);
+	vmalof	(@tmp[3],@acc[3],@r[0],@tmp[3]);
+	vmalof	(@tmp[4],@acc[3],@r[1],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[2],@r5[3],@tmp[0]);
+	vmalof	(@tmp[1],@acc[2],@r5[4],@tmp[1]);
+	vmalof	(@tmp[2],@acc[2],@r[0],@tmp[2]);
+	vmalof	(@tmp[3],@acc[2],@r[1],@tmp[3]);
+	vmalof	(@tmp[4],@acc[2],@r[2],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[1],@r5[4],@tmp[0]);
+	vmalof	(@tmp[1],@acc[1],@r[0],@tmp[1]);
+	vmalof	(@tmp[2],@acc[1],@r[1],@tmp[2]);
+	vmalof	(@tmp[3],@acc[1],@r[2],@tmp[3]);
+	vmalof	(@tmp[4],@acc[1],@r[3],@tmp[4]);
+
+	vmalof	(@acc[1],@acc[0],@r[1],@tmp[1]);
+	vmalof	(@acc[2],@acc[0],@r[2],@tmp[2]);
+	vmalof	(@acc[3],@acc[0],@r[3],@tmp[3]);
+	vmalof	(@acc[4],@acc[0],@r[4],@tmp[4]);
+	vmalof	(@acc[0],@acc[0],@r[0],@tmp[0]);
+
+	REDUCE	();
+
+	la	($inp,"32($inp)");
+
+ALIGN	(16);
+LABEL	(".Lvx_2x_done");
+	tml	($len,16);
+	jz	(".Lvx_done");
+
+	vleig	($padvec,0,0);
+
+	vzero	("%v20");
+	vl	("%v21","0($inp)");	# load m0
+
+	# m0 -> base 2^26
+
+	vperm	(@m01[0],"%v20","%v21",@vperm[0]);
+	vperm	(@m01[2],"%v20","%v21",@vperm[1]);
+	vperm	(@m01[4],"%v20","%v21",@vperm[2]);
+
+	vesrlg	(@m01[1],@m01[0],26);
+	vesrlg	(@m01[3],@m01[2],30);
+	vesrlg	(@m01[2],@m01[2],4);
+
+	vn	(@m01[4],@m01[4],$mask4);
+	vn	(@m01[$_],@m01[$_],$mask) for (0..3);
+
+	vaf	(@m01[4],@m01[4],$padvec);	# pad m0
+
+	# acc = acc * r + m01
+
+	vlrepf	(@r5[$_],"4*$_+68($ctx)") for (0..4);	# load 5*r
+	vlrepf	(@r[$_],"4*$_+48($ctx)") for (0..4);	# load r
+
+	vmalof	(@tmp[0],@acc[4],@r5[1],@m01[0]);
+	vmalof	(@tmp[1],@acc[4],@r5[2],@m01[1]);
+	vmalof	(@tmp[2],@acc[4],@r5[3],@m01[2]);
+	vmalof	(@tmp[3],@acc[4],@r5[4],@m01[3]);
+	vmalof	(@tmp[4],@acc[4],@r[0],@m01[4]);
+
+	vmalof	(@tmp[0],@acc[3],@r5[2],@tmp[0]);
+	vmalof	(@tmp[1],@acc[3],@r5[3],@tmp[1]);
+	vmalof	(@tmp[2],@acc[3],@r5[4],@tmp[2]);
+	vmalof	(@tmp[3],@acc[3],@r[0],@tmp[3]);
+	vmalof	(@tmp[4],@acc[3],@r[1],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[2],@r5[3],@tmp[0]);
+	vmalof	(@tmp[1],@acc[2],@r5[4],@tmp[1]);
+	vmalof	(@tmp[2],@acc[2],@r[0],@tmp[2]);
+	vmalof	(@tmp[3],@acc[2],@r[1],@tmp[3]);
+	vmalof	(@tmp[4],@acc[2],@r[2],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[1],@r5[4],@tmp[0]);
+	vmalof	(@tmp[1],@acc[1],@r[0],@tmp[1]);
+	vmalof	(@tmp[2],@acc[1],@r[1],@tmp[2]);
+	vmalof	(@tmp[3],@acc[1],@r[2],@tmp[3]);
+	vmalof	(@tmp[4],@acc[1],@r[3],@tmp[4]);
+
+	vmalof	(@acc[1],@acc[0],@r[1],@tmp[1]);
+	vmalof	(@acc[2],@acc[0],@r[2],@tmp[2]);
+	vmalof	(@acc[3],@acc[0],@r[3],@tmp[3]);
+	vmalof	(@acc[4],@acc[0],@r[4],@tmp[4]);
+	vmalof	(@acc[0],@acc[0],@r[0],@tmp[0]);
+
+	REDUCE	();
+
+ALIGN	(16);
+LABEL	(".Lvx_done");
+	vstef	(@acc[$_],"4*$_($ctx)",1) for (0..4);	# store acc
+	vstef	(@acc[$_],"24+4*$_($ctx)",3) for (0..4);
+
+if ($z) {
+	vlm	("%v8","%v15","0($sp)");
+	la	($sp,"$frame($sp)");
+} else {
+	ld	("%f4","16*$SIZE_T+2*8($sp)");
+	ld	("%f6","16*$SIZE_T+3*8($sp)");
+}
+	br	("%r14");
+SIZE	("poly1305_blocks_vx",".-poly1305_blocks_vx");
+}
+
+################
+# static void poly1305_emit_vx(void *ctx, unsigned char mac[16],
+#                              const u32 nonce[4])
+{
+my ($ctx,$mac,$nonce) = map("%r$_",(2..4));
+
+GLOBL	("poly1305_emit_vx");
+TYPE	("poly1305_emit_vx","\@function");
+ALIGN	(16);
+LABEL	("poly1305_emit_vx");
+if ($z) {
+	aghi	($sp,-$frame);
+	vstm	("%v8","%v15","0($sp)");
+} else {
+	std	("%f4","16*$SIZE_T+2*8($sp)");
+	std	("%f6","16*$SIZE_T+3*8($sp)");
+}
+	larl	("%r5",".Lconst");
+
+	vlef	(@acc[$_],"4*$_($ctx)",1) for (0..4);	# load acc1
+	vlef	(@acc[$_],"24+4*$_($ctx)",3) for (0..4);	# load acc2
+	vlef	(@r5[$_],"108+4*$_($ctx)",1) for (0..4);	# load 5*r^2
+	vlef	(@r[$_],"88+4*$_($ctx)",1) for (0..4);	# load r^2
+	vlef	(@r5[$_],"68+4*$_($ctx)",3) for (0..4);	# load 5*r
+	vlef	(@r[$_],"48+4*$_($ctx)",3) for (0..4);	# load r
+	vl	($mask,"48(%r5)");	# load mask
+
+	# acc = acc1 * r^2 + acc2 * r
+
+	vmlof	(@tmp[0],@acc[4],@r5[1]);
+	vmlof	(@tmp[1],@acc[4],@r5[2]);
+	vmlof	(@tmp[2],@acc[4],@r5[3]);
+	vmlof	(@tmp[3],@acc[4],@r5[4]);
+	vmlof	(@tmp[4],@acc[4],@r[0]);
+
+	vmalof	(@tmp[0],@acc[3],@r5[2],@tmp[0]);
+	vmalof	(@tmp[1],@acc[3],@r5[3],@tmp[1]);
+	vmalof	(@tmp[2],@acc[3],@r5[4],@tmp[2]);
+	vmalof	(@tmp[3],@acc[3],@r[0],@tmp[3]);
+	vmalof	(@tmp[4],@acc[3],@r[1],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[2],@r5[3],@tmp[0]);
+	vmalof	(@tmp[1],@acc[2],@r5[4],@tmp[1]);
+	vmalof	(@tmp[2],@acc[2],@r[0],@tmp[2]);
+	vmalof	(@tmp[3],@acc[2],@r[1],@tmp[3]);
+	vmalof	(@tmp[4],@acc[2],@r[2],@tmp[4]);
+
+	vmalof	(@tmp[0],@acc[1],@r5[4],@tmp[0]);
+	vmalof	(@tmp[1],@acc[1],@r[0],@tmp[1]);
+	vmalof	(@tmp[2],@acc[1],@r[1],@tmp[2]);
+	vmalof	(@tmp[3],@acc[1],@r[2],@tmp[3]);
+	vmalof	(@tmp[4],@acc[1],@r[3],@tmp[4]);
+
+	vmalof	(@acc[1],@acc[0],@r[1],@tmp[1]);
+	vmalof	(@acc[2],@acc[0],@r[2],@tmp[2]);
+	vmalof	(@acc[3],@acc[0],@r[3],@tmp[3]);
+	vmalof	(@acc[4],@acc[0],@r[4],@tmp[4]);
+	vmalof	(@acc[0],@acc[0],@r[0],@tmp[0]);
+
+	vzero	("%v27");
+	vsumqg	(@acc[$_],@acc[$_],"%v27") for (0..4);
+
+	REDUCE	();
+
+	vesrlg	(@tmp[1],@acc[1],26);
+	vn	(@acc[1],@acc[1],$mask);
+	vag	(@acc[2],@acc[2],@tmp[1]);	# carry 1->2
+
+	vesrlg	(@tmp[2],@acc[2],26);
+	vn	(@acc[2],@acc[2],$mask);
+	vag	(@acc[3],@acc[3],@tmp[2]);	# carry 2->3
+
+	vesrlg	(@tmp[3],@acc[3],26);
+	vn	(@acc[3],@acc[3],$mask);
+	vag	(@acc[4],@acc[4],@tmp[3]);	# carry 3->4
+
+	# acc -> base 2^64
+	vleib	("%v30",6*8,7);
+	vleib	("%v29",13*8,7);
+	vleib	("%v28",3*8,7);
+
+	veslg	(@acc[1],@acc[1],26);
+	veslg	(@acc[3],@acc[3],26);
+	vo	(@acc[0],@acc[0],@acc[1]);
+	vo	(@acc[2],@acc[2],@acc[3]);
+
+	veslg	(@acc[2],@acc[2],4);
+	vslb	(@acc[2],@acc[2],"%v30");	# <<52
+	vo	(@acc[0],@acc[0],@acc[2]);
+
+	vslb	(@tmp[4],@acc[4],"%v29");	# <<104
+	vo	(@acc[0],@acc[0],@tmp[4]);
+
+	vsrlb	(@acc[1],@acc[4],"%v28");	# >>24
+
+	# acc %= 2^130-5
+	vone	("%v26");
+	vleig	("%v27",5,1);
+	vone	("%v29");
+	vleig	("%v26",-4,1);
+
+	vaq	(@tmp[0],@acc[0],"%v27");
+	vaccq	(@tmp[1],@acc[0],"%v27");
+
+	vaq	(@tmp[1],@tmp[1],"%v26");
+	vaccq	(@tmp[1],@tmp[1],@acc[1]);
+
+	vaq	(@tmp[1],@tmp[1],"%v29");
+
+	vn	(@tmp[2],@tmp[1],@acc[0]);
+	vnc	(@tmp[3],@tmp[0],@tmp[1]);
+	vo	(@acc[0],@tmp[2],@tmp[3]);
+
+	# acc += nonce
+	vl	(@vperm[0],"64(%r5)");
+	vlef	(@tmp[0],"4*$_($nonce)",3-$_) for (0..3);
+
+	vaq	(@acc[0],@acc[0],@tmp[0]);
+
+	vperm	(@acc[0],@acc[0],@acc[0],@vperm[0]);
+	vst	(@acc[0],"0($mac)");	# store mac
+
+if ($z) {
+	vlm	("%v8","%v15","0($sp)");
+	la	($sp,"$frame($sp)");
+} else {
+	ld	("%f4","16*$SIZE_T+2*8($sp)");
+	ld	("%f6","16*$SIZE_T+3*8($sp)");
+}
+	br	("%r14");
+SIZE	("poly1305_emit_vx",".-poly1305_emit_vx");
+}
+}
+
+# NOVX CODE PATH
+{
+################
+# static void poly1305_blocks(void *ctx, const unsigned char *inp, size_t len,
+#                             u32 padbit)
+{
+my ($ctx,$inp,$len,$padbit) = map("%r$_",(2..5));
+
 my ($d0hi,$d0lo,$d1hi,$d1lo,$t0,$h0,$t1,$h1,$h2) = map("%r$_",(6..14));
 my ($r0,$r1,$s1) = map("%r$_",(0..2));
-
 GLOBL	("poly1305_blocks");
 TYPE	("poly1305_blocks","\@function");
 ALIGN	(16);
@@ -168,8 +775,12 @@ LABEL	(".Lno_data");
 	br	("%r14");
 SIZE	("poly1305_blocks",".-poly1305_blocks");
 }
+
+################
+# static void poly1305_emit(void *ctx, unsigned char mac[16],
+#                           const u32 nonce[4])
 {
-my ($mac,$nonce)=($inp,$len);
+my ($ctx,$mac,$nonce) = map("%r$_",(2..4));
 my ($h0,$h1,$h2,$d0,$d1)=map("%r$_",(5..9));
 
 GLOBL	("poly1305_emit");
@@ -216,8 +827,19 @@ LABEL	("poly1305_emit");
 &{$z?	\&lmg:\&lm}	("%r6","%r9","6*$SIZE_T($sp)");
 	br	("%r14");
 SIZE	("poly1305_emit",".-poly1305_emit");
-
-STRING	("\"Poly1305 for s390x, CRYPTOGAMS by <appro\@openssl.org>\"");
 }
+}
+################
+
+ALIGN	(128);
+LABEL	(".Lconst");
+LONG	(0x00060504,0x03020100,0x00161514,0x13121110);	# vperm op[m[1],m[0]]
+LONG	(0x000c0b0a,0x09080706,0x001c1b1a,0x19181716);	# vperm op[m[3],m[2]]
+LONG	(0x00000000,0x000f0e0d,0x00000000,0x001f1e1d);	# vperm op[  - ,m[4]]
+LONG	(0x00000000,0x03ffffff,0x00000000,0x03ffffff);	# [0,2^26-1,0,2^26-1]
+LONG	(0x0f0e0d0c,0x0b0a0908,0x07060504,0x03020100);	# vperm op endian
+STRING	("\"Poly1305 for s390x, CRYPTOGAMS by <appro\@openssl.org>\"");
+
+COMM	("OPENSSL_s390xcap_P",168,8);
 
 PERLASM_END();

--- a/crypto/poly1305/asm/poly1305-s390x.pl
+++ b/crypto/poly1305/asm/poly1305-s390x.pl
@@ -169,6 +169,7 @@ GLOBL	("poly1305_init");
 TYPE	("poly1305_init","\@function");
 ALIGN	(16);
 LABEL	("poly1305_init");
+	CFI_STARTPROC	();
 	lghi	("%r0",0);
 	lghi	("%r1",-1);
 	stg	("%r0","0($ctx)");	# zero hash value / acc1
@@ -201,6 +202,7 @@ LABEL	("poly1305_init");
 	larl	("%r5","poly1305_emit_vx");
 
 &{$z?	\&stmg:\&stm}	("%r6","%r13","6*$SIZE_T($sp)");
+	CFI_REL_OFFSET	("%r$_",$_*$SIZE_T) for (6..13);
 &{$z?	\&stmg:\&stm}	("%r4","%r5","4*$z+228($ctx)");
 
 	lg	($r0,"32($ctx)");
@@ -222,12 +224,14 @@ LABEL	("poly1305_init");
 	stg	("%r0","40($ctx)");
 
 &{$z?	\&lmg:\&lm}	("%r6","%r13","6*$SIZE_T($sp)");
+	CFI_RESTORE	("%r$_") for (6..13);
 	lghi	("%r2",1);
 	br	("%r14");
 
 LABEL	(".Ldone");
 	lghi	("%r2",0);
 	br	("%r14");
+	CFI_ENDPROC	();
 SIZE	("poly1305_init",".-poly1305_init");
 }
 
@@ -285,8 +289,10 @@ GLOBL	("poly1305_blocks_vx");
 TYPE	("poly1305_blocks_vx","\@function");
 ALIGN	(16);
 LABEL	("poly1305_blocks_vx");
+	CFI_STARTPROC	();
 if ($z) {
 	aghi	($sp,-$frame);
+	CFI_ADJUST_CFA_OFFSET	($frame);
 	vstm	("%v8","%v15","0($sp)");
 } else {
 	std	("%f4","16*$SIZE_T+2*8($sp)");
@@ -539,11 +545,13 @@ LABEL	(".Lvx_done");
 if ($z) {
 	vlm	("%v8","%v15","0($sp)");
 	la	($sp,"$frame($sp)");
+	CFI_ADJUST_CFA_OFFSET	(-$frame);
 } else {
 	ld	("%f4","16*$SIZE_T+2*8($sp)");
 	ld	("%f6","16*$SIZE_T+3*8($sp)");
 }
 	br	("%r14");
+	CFI_ENDPROC	();
 SIZE	("poly1305_blocks_vx",".-poly1305_blocks_vx");
 }
 
@@ -557,8 +565,10 @@ GLOBL	("poly1305_emit_vx");
 TYPE	("poly1305_emit_vx","\@function");
 ALIGN	(16);
 LABEL	("poly1305_emit_vx");
+	CFI_STARTPROC	();
 if ($z) {
 	aghi	($sp,-$frame);
+	CFI_ADJUST_CFA_OFFSET	($frame);
 	vstm	("%v8","%v15","0($sp)");
 } else {
 	std	("%f4","16*$SIZE_T+2*8($sp)");
@@ -672,11 +682,13 @@ if ($z) {
 if ($z) {
 	vlm	("%v8","%v15","0($sp)");
 	la	($sp,"$frame($sp)");
+	CFI_ADJUST_CFA_OFFSET	(-$frame);
 } else {
 	ld	("%f4","16*$SIZE_T+2*8($sp)");
 	ld	("%f6","16*$SIZE_T+3*8($sp)");
 }
 	br	("%r14");
+	CFI_ENDPROC	();
 SIZE	("poly1305_emit_vx",".-poly1305_emit_vx");
 }
 }
@@ -695,12 +707,14 @@ GLOBL	("poly1305_blocks");
 TYPE	("poly1305_blocks","\@function");
 ALIGN	(16);
 LABEL	("poly1305_blocks");
+	CFI_STARTPROC	();
 $z?	srlg	($len,$len,4)	:srl	($len,4);
 	lghi	("%r0",0);
 &{$z?	\&clgr:\&clr}	($len,"%r0");
 	je	(".Lno_data");
 
 &{$z?	\&stmg:\&stm}	("%r6","%r14","6*$SIZE_T($sp)");
+	CFI_REL_OFFSET	("%r$_",$_*$SIZE_T) for (6..14);
 
 	llgfr	($padbit,$padbit);	# clear upper half, much needed with
 					# non-64-bit ABI
@@ -771,8 +785,10 @@ LABEL	(".Loop");
 	stg	($h2,"16($ctx)");
 
 &{$z?	\&lmg:\&lm}	("%r6","%r14","6*$SIZE_T($sp)");
+	CFI_RESTORE	("%r$_") for (6..14);
 LABEL	(".Lno_data");
 	br	("%r14");
+	CFI_ENDPROC	();
 SIZE	("poly1305_blocks",".-poly1305_blocks");
 }
 
@@ -787,7 +803,9 @@ GLOBL	("poly1305_emit");
 TYPE	("poly1305_emit","\@function");
 ALIGN	(16);
 LABEL	("poly1305_emit");
+	CFI_STARTPROC	();
 &{$z?	\&stmg:\&stm}	("%r6","%r9","6*$SIZE_T($sp)");
+	CFI_REL_OFFSET	("%r$_",$_*$SIZE_T) for (6..9);
 
 	lg	($h0,"0($ctx)");
 	lg	($h1,"8($ctx)");
@@ -825,7 +843,9 @@ LABEL	("poly1305_emit");
 	strvg	($h1,"8($mac)");
 
 &{$z?	\&lmg:\&lm}	("%r6","%r9","6*$SIZE_T($sp)");
+	CFI_RESTORE	("%r$_") for (6..9);
 	br	("%r14");
+	CFI_ENDPROC	();
 SIZE	("poly1305_emit",".-poly1305_emit");
 }
 }

--- a/crypto/poly1305/asm/poly1305-s390x.pl
+++ b/crypto/poly1305/asm/poly1305-s390x.pl
@@ -24,204 +24,200 @@
 #
 # On side note, z13 enables vector base 2^26 implementation...
 
+use FindBin qw($Bin);
+use lib "$Bin/../..";
+use perlasm::s390x qw(:DEFAULT AUTOLOAD LABEL);
+
 $flavour = shift;
 
 if ($flavour =~ /3[12]/) {
+	$z=0;	# S/390 ABI
 	$SIZE_T=4;
-	$g="";
 } else {
+	$z=1;	# zSeries ABI
 	$SIZE_T=8;
-	$g="g";
 }
 
 while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
-open STDOUT,">$output";
 
 $sp="%r15";
 
 my ($ctx,$inp,$len,$padbit) = map("%r$_",(2..5));
 
-$code.=<<___;
-.text
+PERLASM_BEGIN($output);
 
-.globl	poly1305_init
-.type	poly1305_init,\@function
-.align	16
-poly1305_init:
-	lghi	%r0,0
-	lghi	%r1,-1
-	stg	%r0,0($ctx)		# zero hash value
-	stg	%r0,8($ctx)
-	stg	%r0,16($ctx)
+TEXT	();
 
-	cl${g}r	$inp,%r0
-	je	.Lno_key
+GLOBL	("poly1305_init");
+TYPE	("poly1305_init","\@function");
+ALIGN	(16);
+LABEL	("poly1305_init");
+	lghi	("%r0",0);
+	lghi	("%r1",-1);
+	stg	("%r0","0($ctx)");	# zero hash value
+	stg	("%r0","8($ctx)");
+	stg	("%r0","16($ctx)");
 
-	lrvg	%r4,0($inp)		# load little-endian key
-	lrvg	%r5,8($inp)
+&{$z?	\&clgr:\&clr}	($inp,"%r0");
+	je	(".Lno_key");
 
-	nihl	%r1,0xffc0		# 0xffffffc0ffffffff
-	srlg	%r0,%r1,4		# 0x0ffffffc0fffffff
-	srlg	%r1,%r1,4
-	nill	%r1,0xfffc		# 0x0ffffffc0ffffffc
+	lrvg	("%r4","0($inp)");	# load little-endian key
+	lrvg	("%r5","8($inp)");
 
-	ngr	%r4,%r0
-	ngr	%r5,%r1
+	nihl	("%r1",0xffc0);		# 0xffffffc0ffffffff
+	srlg	("%r0","%r1",4);	# 0x0ffffffc0fffffff
+	srlg	("%r1","%r1",4);
+	nill	("%r1",0xfffc);		# 0x0ffffffc0ffffffc
 
-	stg	%r4,32($ctx)
-	stg	%r5,40($ctx)
+	ngr	("%r4","%r0");
+	ngr	("%r5","%r1");
 
-.Lno_key:
-	lghi	%r2,0
-	br	%r14
-.size	poly1305_init,.-poly1305_init
-___
+	stg	("%r4","32($ctx)");
+	stg	("%r5","40($ctx)");
+
+LABEL	(".Lno_key");
+	lghi	("%r2",0);
+	br	("%r14");
+SIZE	("poly1305_init",".-poly1305_init");
+
 {
 my ($d0hi,$d0lo,$d1hi,$d1lo,$t0,$h0,$t1,$h1,$h2) = map("%r$_",(6..14));
 my ($r0,$r1,$s1) = map("%r$_",(0..2));
 
-$code.=<<___;
-.globl	poly1305_blocks
-.type	poly1305_blocks,\@function
-.align	16
-poly1305_blocks:
-	srl${g}	$len,4			# fixed-up in 64-bit build
-	lghi	%r0,0
-	cl${g}r	$len,%r0
-	je	.Lno_data
+GLOBL	("poly1305_blocks");
+TYPE	("poly1305_blocks","\@function");
+ALIGN	(16);
+LABEL	("poly1305_blocks");
+$z?	srlg	($len,$len,4)	:srl	($len,4);
+	lghi	("%r0",0);
+&{$z?	\&clgr:\&clr}	($len,"%r0");
+	je	(".Lno_data");
 
-	stm${g}	%r6,%r14,`6*$SIZE_T`($sp)
+&{$z?	\&stmg:\&stm}	("%r6","%r14","6*$SIZE_T($sp)");
 
-	llgfr   $padbit,$padbit		# clear upper half, much needed with
+	llgfr	($padbit,$padbit);	# clear upper half, much needed with
 					# non-64-bit ABI
-	lg	$r0,32($ctx)		# load key
-	lg	$r1,40($ctx)
+	lg	($r0,"32($ctx)");	# load key
+	lg	($r1,"40($ctx)");
 
-	lg	$h0,0($ctx)		# load hash value
-	lg	$h1,8($ctx)
-	lg	$h2,16($ctx)
+	lg	($h0,"0($ctx)");	# load hash value
+	lg	($h1,"8($ctx)");
+	lg	($h2,"16($ctx)");
 
-	st$g	$ctx,`2*$SIZE_T`($sp)	# off-load $ctx
-	srlg	$s1,$r1,2
-	algr	$s1,$r1			# s1 = r1 + r1>>2
-	j	.Loop
+&{$z?	\&stg:\&st}	($ctx,"2*$SIZE_T($sp)");	# off-load $ctx
+	srlg	($s1,$r1,2);
+	algr	($s1,$r1);			# s1 = r1 + r1>>2
+	j	(".Loop");
 
-.align	16
-.Loop:
-	lrvg	$d0lo,0($inp)		# load little-endian input
-	lrvg	$d1lo,8($inp)
-	la	$inp,16($inp)
+ALIGN	(16);
+LABEL	(".Loop");
+	lrvg	($d0lo,"0($inp)");	# load little-endian input
+	lrvg	($d1lo,"8($inp)");
+	la	($inp,"16($inp)");
 
-	algr	$d0lo,$h0		# accumulate input
-	alcgr	$d1lo,$h1
+	algr	($d0lo,$h0);		# accumulate input
+	alcgr	($d1lo,$h1);
 
-	lgr	$h0,$d0lo
-	mlgr	$d0hi,$r0		# h0*r0	  -> $d0hi:$d0lo
-	lgr	$h1,$d1lo
-	mlgr	$d1hi,$s1		# h1*5*r1 -> $d1hi:$d1lo
+	lgr	($h0,$d0lo);
+	mlgr	($d0hi,$r0);		# h0*r0	  -> $d0hi:$d0lo
+	lgr	($h1,$d1lo);
+	mlgr	($d1hi,$s1);		# h1*5*r1 -> $d1hi:$d1lo
 
-	mlgr	$t0,$r1			# h0*r1   -> $t0:$h0
-	mlgr	$t1,$r0			# h1*r0   -> $t1:$h1
-	alcgr	$h2,$padbit
+	mlgr	($t0,$r1);		# h0*r1   -> $t0:$h0
+	mlgr	($t1,$r0);		# h1*r0   -> $t1:$h1
+	alcgr	($h2,$padbit);
 
-	algr	$d0lo,$d1lo
-	lgr	$d1lo,$h2
-	alcgr	$d0hi,$d1hi
-	lghi	$d1hi,0
+	algr	($d0lo,$d1lo);
+	lgr	($d1lo,$h2);
+	alcgr	($d0hi,$d1hi);
+	lghi	($d1hi,0);
 
-	algr	$h1,$h0
-	alcgr	$t1,$t0
+	algr	($h1,$h0);
+	alcgr	($t1,$t0);
 
-	msgr	$d1lo,$s1		# h2*s1
-	msgr	$h2,$r0			# h2*r0
+	msgr	($d1lo,$s1);		# h2*s1
+	msgr	($h2,$r0);		# h2*r0
 
-	algr	$h1,$d1lo
-	alcgr	$t1,$d1hi		# $d1hi is zero
+	algr	($h1,$d1lo);
+	alcgr	($t1,$d1hi);		# $d1hi is zero
 
-	algr	$h1,$d0hi
-	alcgr	$h2,$t1
+	algr	($h1,$d0hi);
+	alcgr	($h2,$t1);
 
-	lghi	$h0,-4			# final reduction step
-	ngr	$h0,$h2
-	srlg	$t0,$h2,2
-	algr	$h0,$t0
-	lghi	$t1,3
-	ngr	$h2,$t1
+	lghi	($h0,-4);		# final reduction step
+	ngr	($h0,$h2);
+	srlg	($t0,$h2,2);
+	algr	($h0,$t0);
+	lghi	($t1,3);
+	ngr	($h2,$t1);
 
-	algr	$h0,$d0lo
-	alcgr	$h1,$d1hi		# $d1hi is still zero
-	alcgr	$h2,$d1hi		# $d1hi is still zero
+	algr	($h0,$d0lo);
+	alcgr	($h1,$d1hi);		# $d1hi is still zero
+	alcgr	($h2,$d1hi);		# $d1hi is still zero
 
-	brct$g	$len,.Loop
+&{$z?	\&brctg:\&brct}	($len,".Loop");
 
-	l$g	$ctx,`2*$SIZE_T`($sp)	# restore $ctx
+&{$z?	\&lg:\&l}	($ctx,"2*$SIZE_T($sp)");# restore $ctx
 
-	stg	$h0,0($ctx)		# store hash value
-	stg	$h1,8($ctx)
-	stg	$h2,16($ctx)
+	stg	($h0,"0($ctx)");	# store hash value
+	stg	($h1,"8($ctx)");
+	stg	($h2,"16($ctx)");
 
-	lm${g}	%r6,%r14,`6*$SIZE_T`($sp)
-.Lno_data:
-	br	%r14
-.size	poly1305_blocks,.-poly1305_blocks
-___
+&{$z?	\&lmg:\&lm}	("%r6","%r14","6*$SIZE_T($sp)");
+LABEL	(".Lno_data");
+	br	("%r14");
+SIZE	("poly1305_blocks",".-poly1305_blocks");
 }
 {
 my ($mac,$nonce)=($inp,$len);
 my ($h0,$h1,$h2,$d0,$d1)=map("%r$_",(5..9));
 
-$code.=<<___;
-.globl	poly1305_emit
-.type	poly1305_emit,\@function
-.align	16
-poly1305_emit:
-	stm${g}	%r6,%r9,`6*$SIZE_T`($sp)
+GLOBL	("poly1305_emit");
+TYPE	("poly1305_emit","\@function");
+ALIGN	(16);
+LABEL	("poly1305_emit");
+&{$z?	\&stmg:\&stm}	("%r6","%r9","6*$SIZE_T($sp)");
 
-	lg	$h0,0($ctx)
-	lg	$h1,8($ctx)
-	lg	$h2,16($ctx)
+	lg	($h0,"0($ctx)");
+	lg	($h1,"8($ctx)");
+	lg	($h2,"16($ctx)");
 
-	lghi	%r0,5
-	lghi	%r1,0
-	lgr	$d0,$h0
-	lgr	$d1,$h1
+	lghi	("%r0",5);
+	lghi	("%r1",0);
+	lgr	($d0,$h0);
+	lgr	($d1,$h1);
 
-	algr	$h0,%r0			# compare to modulus
-	alcgr	$h1,%r1
-	alcgr	$h2,%r1
+	algr	($h0,"%r0");		# compare to modulus
+	alcgr	($h1,"%r1");
+	alcgr	($h2,"%r1");
 
-	srlg	$h2,$h2,2		# did it borrow/carry?
-	slgr	%r1,$h2			# 0-$h2>>2
-	lg	$h2,0($nonce)		# load nonce
-	lghi	%r0,-1
-	lg	$ctx,8($nonce)
-	xgr	%r0,%r1			# ~%r1
+	srlg	($h2,$h2,2);		# did it borrow/carry?
+	slgr	("%r1",$h2);		# 0-$h2>>2
+	lg	($h2,"0($nonce)");	# load nonce
+	lghi	("%r0",-1);
+	lg	($ctx,"8($nonce)");
+	xgr	("%r0","%r1");		# ~%r1
 
-	ngr	$h0,%r1
-	ngr	$d0,%r0
-	ngr	$h1,%r1
-	ngr	$d1,%r0
-	ogr	$h0,$d0
-	rllg	$d0,$h2,32		# flip nonce words
-	ogr	$h1,$d1
-	rllg	$d1,$ctx,32
+	ngr	($h0,"%r1");
+	ngr	($d0,"%r0");
+	ngr	($h1,"%r1");
+	ngr	($d1,"%r0");
+	ogr	($h0,$d0);
+	rllg	($d0,$h2,32);		# flip nonce words
+	ogr	($h1,$d1);
+	rllg	($d1,$ctx,32);
 
-	algr	$h0,$d0			# accumulate nonce
-	alcgr	$h1,$d1
+	algr	($h0,$d0);		# accumulate nonce
+	alcgr	($h1,$d1);
 
-	strvg	$h0,0($mac)		# write little-endian result
-	strvg	$h1,8($mac)
+	strvg	($h0,"0($mac)");	# write little-endian result
+	strvg	($h1,"8($mac)");
 
-	lm${g}	%r6,%r9,`6*$SIZE_T`($sp)
-	br	%r14
-.size	poly1305_emit,.-poly1305_emit
+&{$z?	\&lmg:\&lm}	("%r6","%r9","6*$SIZE_T($sp)");
+	br	("%r14");
+SIZE	("poly1305_emit",".-poly1305_emit");
 
-.string	"Poly1305 for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-___
+STRING	("\"Poly1305 for s390x, CRYPTOGAMS by <appro\@openssl.org>\"");
 }
 
-$code =~ s/\`([^\`]*)\`/eval $1/gem;
-$code =~ s/\b(srlg\s+)(%r[0-9]+\s*,)\s*([0-9]+)/$1$2$2$3/gm;
-
-print $code;
-close STDOUT;
+PERLASM_END();

--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -2,3 +2,5 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         md_rand.c randfile.c rand_lib.c rand_err.c rand_egd.c \
         rand_win.c rand_unix.c rand_vms.c
+
+INCLUDE[md_rand.o]=..

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -18,10 +18,10 @@
  * functions. If STFLE returns fewer doublewords or an instruction is not
  * supported, the corresponding element is zero. The order is as follows:
  *
- * STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMCTR:KMCTR:KMA:KMA
+ * STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMA:KMA
  */
 # define S390X_STFLE_DWORDS	3
-# define S390X_QUERY_DWORDS	10
+# define S390X_QUERY_DWORDS	12
 # define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
 extern uint64_t OPENSSL_s390xcap_P[];
 
@@ -40,7 +40,12 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMC_AES_192	(1ULL << 44)
 # define S390X_KMC_AES_128	(1ULL << 45)
 
-/* OPENSSL_s390xcap_P[11] flags */
+/* OPENSSL_s390xcap_P[9] flags */
+# define S390X_KMAC_AES_256	(1ULL << 43)
+# define S390X_KMAC_AES_192	(1ULL << 44)
+# define S390X_KMAC_AES_128	(1ULL << 45)
+
+/* OPENSSL_s390xcap_P[13] flags */
 # define S390X_KMA_GCM_AES_256	(1ULL << 43)
 # define S390X_KMA_GCM_AES_192	(1ULL << 44)
 # define S390X_KMA_GCM_AES_128	(1ULL << 45)

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -18,11 +18,16 @@
  * functions. If STFLE returns fewer doublewords or an instruction is not
  * supported, the corresponding element is zero. The order is as follows:
  *
- * STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMCTR:KMCTR
+ * STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMCTR:KMCTR
  */
-# define S390X_STFLE_DWORDS	2
+# define S390X_STFLE_DWORDS	3
 # define S390X_QUERY_DWORDS	8
 # define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
 extern uint64_t OPENSSL_s390xcap_P[];
+
+/* OPENSSL_s390xcap_P[2] flags */
+# define S390X_STFLE_VXE	(1ULL << 56)
+# define S390X_STFLE_VXD	(1ULL << 57)
+# define S390X_STFLE_VX		(1ULL << 62)
 
 #endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -19,10 +19,11 @@
  * supported, the corresponding element is zero. The order is as follows:
  *
  * STFLE:STFLE:STFLE.
- * KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMO:KMO:KMF:KMF:KMA:KMA
+ * KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMO:KMO:KMF:KMF:PPNO:PPNO:
+ * KMA:KMA
  */
 # define S390X_STFLE_DWORDS	3
-# define S390X_QUERY_DWORDS	16
+# define S390X_QUERY_DWORDS	18
 # define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
 extern uint64_t OPENSSL_s390xcap_P[];
 
@@ -57,11 +58,18 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMF_AES_128	(1ULL << 45)
 
 /* OPENSSL_s390xcap_P[17] flags */
+# define S390X_PRNO_SHA_512_DRNG	(1ULL << 60)
+
+/* OPENSSL_s390xcap_P[18] flags */
+# define S390X_PRNO_TRNG	(1ULL << 13)
+
+/* OPENSSL_s390xcap_P[19] flags */
 # define S390X_KMA_GCM_AES_256	(1ULL << 43)
 # define S390X_KMA_GCM_AES_192	(1ULL << 44)
 # define S390X_KMA_GCM_AES_128	(1ULL << 45)
 
 /* %r0 flags */
+# define S390X_PRNO_SEED	(1ULL <<  7)
 # define S390X_KMA_LPC		(1ULL <<  8)
 # define S390X_KMA_LAAD		(1ULL <<  9)
 # define S390X_KMA_HS		(1ULL << 10)

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -19,10 +19,10 @@
  * supported, the corresponding element is zero. The order is as follows:
  *
  * STFLE:STFLE:STFLE.
- * KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMO:KMO:KMA:KMA
+ * KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMO:KMO:KMF:KMF:KMA:KMA
  */
 # define S390X_STFLE_DWORDS	3
-# define S390X_QUERY_DWORDS	14
+# define S390X_QUERY_DWORDS	16
 # define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
 extern uint64_t OPENSSL_s390xcap_P[];
 
@@ -52,6 +52,11 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMO_AES_128	(1ULL << 45)
 
 /* OPENSSL_s390xcap_P[15] flags */
+# define S390X_KMF_AES_256	(1ULL << 43)
+# define S390X_KMF_AES_192	(1ULL << 44)
+# define S390X_KMF_AES_128	(1ULL << 45)
+
+/* OPENSSL_s390xcap_P[17] flags */
 # define S390X_KMA_GCM_AES_256	(1ULL << 43)
 # define S390X_KMA_GCM_AES_192	(1ULL << 44)
 # define S390X_KMA_GCM_AES_128	(1ULL << 45)

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -30,4 +30,14 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_STFLE_VXD	(1ULL << 57)
 # define S390X_STFLE_VX		(1ULL << 62)
 
+/* OPENSSL_s390xcap_P[5] flags */
+# define S390X_KM_AES_256	(1ULL << 43)
+# define S390X_KM_AES_192	(1ULL << 44)
+# define S390X_KM_AES_128	(1ULL << 45)
+
+/* OPENSSL_s390xcap_P[7] flags */
+# define S390X_KMC_AES_256	(1ULL << 43)
+# define S390X_KMC_AES_192	(1ULL << 44)
+# define S390X_KMC_AES_128	(1ULL << 45)
+
 #endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -18,10 +18,11 @@
  * functions. If STFLE returns fewer doublewords or an instruction is not
  * supported, the corresponding element is zero. The order is as follows:
  *
- * STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMA:KMA
+ * STFLE:STFLE:STFLE.
+ * KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMO:KMO:KMA:KMA
  */
 # define S390X_STFLE_DWORDS	3
-# define S390X_QUERY_DWORDS	12
+# define S390X_QUERY_DWORDS	14
 # define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
 extern uint64_t OPENSSL_s390xcap_P[];
 
@@ -46,6 +47,11 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMAC_AES_128	(1ULL << 45)
 
 /* OPENSSL_s390xcap_P[13] flags */
+# define S390X_KMO_AES_256	(1ULL << 43)
+# define S390X_KMO_AES_192	(1ULL << 44)
+# define S390X_KMO_AES_128	(1ULL << 45)
+
+/* OPENSSL_s390xcap_P[15] flags */
 # define S390X_KMA_GCM_AES_256	(1ULL << 43)
 # define S390X_KMA_GCM_AES_192	(1ULL << 44)
 # define S390X_KMA_GCM_AES_128	(1ULL << 45)

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef S390X_ARCH_H
+# define S390X_ARCH_H
+
+# include <stdint.h>
+
+/*
+ * The elements of OPENSSL_s390xcap_P are the doublewords returned by the STFLE
+ * instruction followed by the doubleword pairs returned by instructions' QUERY
+ * functions. If STFLE returns fewer doublewords or an instruction is not
+ * supported, the corresponding element is zero. The order is as follows:
+ *
+ * STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMCTR:KMCTR
+ */
+# define S390X_STFLE_DWORDS	2
+# define S390X_QUERY_DWORDS	8
+# define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
+extern uint64_t OPENSSL_s390xcap_P[];
+
+#endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -18,10 +18,10 @@
  * functions. If STFLE returns fewer doublewords or an instruction is not
  * supported, the corresponding element is zero. The order is as follows:
  *
- * STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMCTR:KMCTR
+ * STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMCTR:KMCTR:KMA:KMA
  */
 # define S390X_STFLE_DWORDS	3
-# define S390X_QUERY_DWORDS	8
+# define S390X_QUERY_DWORDS	10
 # define S390X_CAP_DWORDS	(S390X_STFLE_DWORDS + S390X_QUERY_DWORDS)
 extern uint64_t OPENSSL_s390xcap_P[];
 
@@ -39,5 +39,10 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMC_AES_256	(1ULL << 43)
 # define S390X_KMC_AES_192	(1ULL << 44)
 # define S390X_KMC_AES_128	(1ULL << 45)
+
+/* OPENSSL_s390xcap_P[11] flags */
+# define S390X_KMA_GCM_AES_256	(1ULL << 43)
+# define S390X_KMA_GCM_AES_192	(1ULL << 44)
+# define S390X_KMA_GCM_AES_128	(1ULL << 45)
 
 #endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -45,4 +45,9 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMA_GCM_AES_192	(1ULL << 44)
 # define S390X_KMA_GCM_AES_128	(1ULL << 45)
 
+/* %r0 flags */
+# define S390X_KMA_LPC		(1ULL <<  8)
+# define S390X_KMA_LAAD		(1ULL <<  9)
+# define S390X_KMA_HS		(1ULL << 10)
+
 #endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -74,4 +74,7 @@ extern uint64_t OPENSSL_s390xcap_P[];
 # define S390X_KMA_LAAD		(1ULL <<  9)
 # define S390X_KMA_HS		(1ULL << 10)
 
+/* %r0 function codes */
+# define S390X_PRNO_SHA_512_DRNG_FC	3
+
 #endif

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -13,8 +13,7 @@
 #include <setjmp.h>
 #include <signal.h>
 #include "internal/cryptlib.h"
-
-extern unsigned long OPENSSL_s390xcap_P[];
+#include "s390x_arch.h"
 
 static sigjmp_buf ill_jmp;
 static void ill_handler(int sig)
@@ -22,17 +21,21 @@ static void ill_handler(int sig)
     siglongjmp(ill_jmp, sig);
 }
 
-unsigned long OPENSSL_s390x_facilities(void);
+void OPENSSL_s390x_facilities(void);
 
 void OPENSSL_cpuid_setup(void)
 {
     sigset_t oset;
     struct sigaction ill_act, oact;
+    uint64_t vec;
+    char *env;
+    int off;
+    int i;
 
     if (OPENSSL_s390xcap_P[0])
         return;
 
-    OPENSSL_s390xcap_P[0] = 1UL << (8 * sizeof(unsigned long) - 1);
+    OPENSSL_s390xcap_P[0] = 1ULL << (8 * sizeof(uint64_t) - 1);
 
     memset(&ill_act, 0, sizeof(ill_act));
     ill_act.sa_handler = ill_handler;
@@ -48,4 +51,26 @@ void OPENSSL_cpuid_setup(void)
 
     sigaction(SIGILL, &oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);
+
+    if ((env = getenv("OPENSSL_s390xcap")) != NULL) {
+        for (i = 0; i < S390X_CAP_DWORDS; i++) {
+            off = (env[0] == '~') ? 1 : 0;
+
+            if (sscanf(env + off, "%llx", (unsigned long long *)&vec) == 1)
+                OPENSSL_s390xcap_P[i] &= off ? ~vec : vec;
+
+            if (i == S390X_STFLE_DWORDS - 1)
+                env = strchr(env, '.');
+            else
+                env = strpbrk(env, ":.");
+
+            if (env == NULL)
+                break;
+
+            if (env[0] == '.')
+                i = S390X_STFLE_DWORDS - 1;
+
+            env++;
+        }
+    }
 }

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -46,6 +46,7 @@ static int vx_enabled(void)
 #endif
 }
 
+
 void OPENSSL_s390x_facilities(void);
 
 void OPENSSL_cpuid_setup(void)

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -30,6 +30,8 @@ OPENSSL_s390x_facilities:
 	stg	%r0,128(%r4)
 	stg	%r0,136(%r4)
 	stg	%r0,144(%r4)
+	stg	%r0,152(%r4)
+	stg	%r0,160(%r4)
 
 	.long	0xb2b04000	# stfle	0(%r4)
 	brc	8,.Ldone
@@ -74,12 +76,19 @@ OPENSSL_s390x_facilities:
 	la	%r1,120(%r4)
 	.long	0xb92a0042	# kmf %r4,%r2
 
+	tml	%r2,0x40	# check for message-security-assist-5
+	jz	.Lret
+
+	lghi	%r0,0		# query prno capability vector
+	la	%r1,136(%r4)
+	.long	0xb93c0042	# prno %r4,%r2
+
 	lg	%r2,16(%r4)
 	tmhl	%r2,0x2000	# check for message-security-assist-8
 	jz	.Lret
 
 	lghi	%r0,0		# query kma capability vector
-	la	%r1,136(%r4)
+	la	%r1,152(%r4)
 	.long	0xb9294022	# kma %r2,%r4,%r2
 
 .Lret:
@@ -209,4 +218,4 @@ OPENSSL_instrument_bus2:
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 
-.comm	OPENSSL_s390xcap_P,152,8
+.comm	OPENSSL_s390xcap_P,168,8

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -21,10 +21,14 @@ OPENSSL_s390x_facilities:
 	stg	%r0,56(%r4)
 	stg	%r0,64(%r4)
 	stg	%r0,72(%r4)
+	stg	%r0,80(%r4)
 
 	.long	0xb2b04000	# stfle	0(%r4)
 	brc	8,.Ldone
 	lghi	%r0,1
+	.long	0xb2b04000	# stfle 0(%r4)
+	brc	8,.Ldone
+	lghi	%r0,2
 	.long	0xb2b04000	# stfle 0(%r4)
 .Ldone:
 	lmg	%r2,%r3,0(%r4)
@@ -32,22 +36,22 @@ OPENSSL_s390x_facilities:
 	jz	.Lret
 
 	lghi	%r0,0		# query kimd capabilities
-	la	%r1,16(%r4)
+	la	%r1,24(%r4)
 	.long	0xb93e0002	# kimd %r0,%r2
 
 	lghi	%r0,0		# query km capability vector
-	la	%r1,32(%r4)
+	la	%r1,40(%r4)
 	.long	0xb92e0042	# km %r4,%r2
 
 	lghi	%r0,0		# query kmc capability vector
-	la	%r1,48(%r4)
+	la	%r1,56(%r4)
 	.long	0xb92f0042	# kmc %r4,%r2
 
 	tmhh	%r3,0x0004	# check for message-security-assist-4
 	jz	.Lret
 
 	lghi	%r0,0		# query kmctr capability vector
-	la	%r1,64(%r4)
+	la	%r1,72(%r4)
 	.long	0xb92d2042	# kmctr %r4,%r2,%r2
 
 .Lret:
@@ -177,4 +181,4 @@ OPENSSL_instrument_bus2:
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 
-.comm	OPENSSL_s390xcap_P,80,8
+.comm	OPENSSL_s390xcap_P,88,8

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -24,6 +24,8 @@ OPENSSL_s390x_facilities:
 	stg	%r0,80(%r4)
 	stg	%r0,88(%r4)
 	stg	%r0,96(%r4)
+	stg	%r0,104(%r4)
+	stg	%r0,112(%r4)
 
 	.long	0xb2b04000	# stfle	0(%r4)
 	brc	8,.Ldone
@@ -49,11 +51,15 @@ OPENSSL_s390x_facilities:
 	la	%r1,56(%r4)
 	.long	0xb92f0042	# kmc %r4,%r2
 
+	lghi	%r0,0		# query kmac capability vector
+	la	%r1,72(%r4)
+	.long	0xb91e0042	# kmac %r4,%r2
+
 	tmhh	%r3,0x0004	# check for message-security-assist-4
 	jz	.Lret
 
 	lghi	%r0,0		# query kmctr capability vector
-	la	%r1,72(%r4)
+	la	%r1,88(%r4)
 	.long	0xb92d2042	# kmctr %r4,%r2,%r2
 
 	lg	%r2,16(%r4)
@@ -61,7 +67,7 @@ OPENSSL_s390x_facilities:
 	jz	.Lret
 
 	lghi	%r0,0		# query kma capability vector
-	la	%r1,88(%r4)
+	la	%r1,104(%r4)
 	.long	0xb9294022	# kma %r2,%r4,%r2
 
 .Lret:
@@ -191,4 +197,4 @@ OPENSSL_instrument_bus2:
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 
-.comm	OPENSSL_s390xcap_P,104,8
+.comm	OPENSSL_s390xcap_P,120,8

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -26,6 +26,8 @@ OPENSSL_s390x_facilities:
 	stg	%r0,96(%r4)
 	stg	%r0,104(%r4)
 	stg	%r0,112(%r4)
+	stg	%r0,120(%r4)
+	stg	%r0,128(%r4)
 
 	.long	0xb2b04000	# stfle	0(%r4)
 	brc	8,.Ldone
@@ -62,12 +64,16 @@ OPENSSL_s390x_facilities:
 	la	%r1,88(%r4)
 	.long	0xb92d2042	# kmctr %r4,%r2,%r2
 
+	lghi	%r0,0		# query kmo capability vector
+	la	%r1,104(%r4)
+	.long	0xb92b0042	# kmo %r4,%r2
+
 	lg	%r2,16(%r4)
 	tmhl	%r2,0x2000	# check for message-security-assist-8
 	jz	.Lret
 
 	lghi	%r0,0		# query kma capability vector
-	la	%r1,104(%r4)
+	la	%r1,120(%r4)
 	.long	0xb9294022	# kma %r2,%r4,%r2
 
 .Lret:
@@ -197,4 +203,4 @@ OPENSSL_instrument_bus2:
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 
-.comm	OPENSSL_s390xcap_P,120,8
+.comm	OPENSSL_s390xcap_P,136,8

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -22,6 +22,8 @@ OPENSSL_s390x_facilities:
 	stg	%r0,64(%r4)
 	stg	%r0,72(%r4)
 	stg	%r0,80(%r4)
+	stg	%r0,88(%r4)
+	stg	%r0,96(%r4)
 
 	.long	0xb2b04000	# stfle	0(%r4)
 	brc	8,.Ldone
@@ -53,6 +55,14 @@ OPENSSL_s390x_facilities:
 	lghi	%r0,0		# query kmctr capability vector
 	la	%r1,72(%r4)
 	.long	0xb92d2042	# kmctr %r4,%r2,%r2
+
+	lg	%r2,16(%r4)
+	tmhl	%r2,0x2000	# check for message-security-assist-8
+	jz	.Lret
+
+	lghi	%r0,0		# query kma capability vector
+	la	%r1,88(%r4)
+	.long	0xb9294022	# kma %r2,%r4,%r2
 
 .Lret:
 	br	%r14
@@ -181,4 +191,4 @@ OPENSSL_instrument_bus2:
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 
-.comm	OPENSSL_s390xcap_P,88,8
+.comm	OPENSSL_s390xcap_P,104,8

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -28,6 +28,8 @@ OPENSSL_s390x_facilities:
 	stg	%r0,112(%r4)
 	stg	%r0,120(%r4)
 	stg	%r0,128(%r4)
+	stg	%r0,136(%r4)
+	stg	%r0,144(%r4)
 
 	.long	0xb2b04000	# stfle	0(%r4)
 	brc	8,.Ldone
@@ -68,12 +70,16 @@ OPENSSL_s390x_facilities:
 	la	%r1,104(%r4)
 	.long	0xb92b0042	# kmo %r4,%r2
 
+	lghi	%r0,0		# query kmf capability vector
+	la	%r1,120(%r4)
+	.long	0xb92a0042	# kmf %r4,%r2
+
 	lg	%r2,16(%r4)
 	tmhl	%r2,0x2000	# check for message-security-assist-8
 	jz	.Lret
 
 	lghi	%r0,0		# query kma capability vector
-	la	%r1,120(%r4)
+	la	%r1,136(%r4)
 	.long	0xb9294022	# kma %r2,%r4,%r2
 
 .Lret:
@@ -203,4 +209,4 @@ OPENSSL_instrument_bus2:
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 
-.comm	OPENSSL_s390xcap_P,136,8
+.comm	OPENSSL_s390xcap_P,152,8

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -215,6 +215,32 @@ OPENSSL_instrument_bus2:
 	br	%r14
 .size	OPENSSL_instrument_bus2,.-OPENSSL_instrument_bus2
 
+.globl	s390x_trng
+.type	s390x_trng,@function
+.align	16
+s390x_trng:
+	lghi	%r5,0
+	lghi	%r0,114		# prno capability vector checked by caller
+	.long	0xb93c0042	# prno %r4,%r2
+	brc	1,.-4		# pay attention to "partial completion"
+	br	%r14
+.size	s390x_trng,.-s390x_trng
+
+.globl	s390x_drng
+.type	s390x_drng,@function
+.align	16
+s390x_drng:
+#if !defined(__s390x__) && !defined(__s390x)
+	l	%r1,96(%r15)
+#else
+	lg	%r1,160(%r15)
+#endif
+	lr	%r0,%r6		# prno capability vector checked by caller
+	.long	0xb93c0024	# prno %r2,%r4
+	brc	1,.-4		# pay attention to "partial completion"
+	br	%r14
+.size	s390x_drng,.-s390x_drng
+
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
 

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -172,9 +172,6 @@ sha1_block_data_order:
 ___
 $code.=<<___ if ($kimdfunc);
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,0(%r1)
-	tmhl	%r0,0x4000	# check for message-security assist
-	jz	.Lsoftware
 	lg	%r0,16(%r1)	# check kimd capabilities
 	tmhh	%r0,`0x8000>>$kimdfunc`
 	jz	.Lsoftware

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -239,7 +239,7 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,120,8
+.comm	OPENSSL_s390xcap_P,136,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -239,7 +239,7 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,88,8
+.comm	OPENSSL_s390xcap_P,104,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -172,7 +172,7 @@ sha1_block_data_order:
 ___
 $code.=<<___ if ($kimdfunc);
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,16(%r1)	# check kimd capabilities
+	lg	%r0,24(%r1)	# check kimd capabilities
 	tmhh	%r0,`0x8000>>$kimdfunc`
 	jz	.Lsoftware
 	lghi	%r0,$kimdfunc
@@ -239,7 +239,7 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,80,8
+.comm	OPENSSL_s390xcap_P,88,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -239,7 +239,7 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,104,8
+.comm	OPENSSL_s390xcap_P,120,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -239,7 +239,7 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,152,8
+.comm	OPENSSL_s390xcap_P,168,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -239,7 +239,7 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,136,8
+.comm	OPENSSL_s390xcap_P,152,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -244,9 +244,6 @@ $Func:
 ___
 $code.=<<___ if ($kimdfunc);
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,0(%r1)
-	tmhl	%r0,0x4000	# check for message-security assist
-	jz	.Lsoftware
 	lg	%r0,16(%r1)	# check kimd capabilities
 	tmhh	%r0,`0x8000>>$kimdfunc`
 	jz	.Lsoftware

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -312,7 +312,7 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,152,8
+.comm	OPENSSL_s390xcap_P,168,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -312,7 +312,7 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,88,8
+.comm	OPENSSL_s390xcap_P,104,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -312,7 +312,7 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,136,8
+.comm	OPENSSL_s390xcap_P,152,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -312,7 +312,7 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,104,8
+.comm	OPENSSL_s390xcap_P,120,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -312,7 +312,7 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,120,8
+.comm	OPENSSL_s390xcap_P,136,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -244,7 +244,7 @@ $Func:
 ___
 $code.=<<___ if ($kimdfunc);
 	larl	%r1,OPENSSL_s390xcap_P
-	lg	%r0,16(%r1)	# check kimd capabilities
+	lg	%r0,24(%r1)	# check kimd capabilities
 	tmhh	%r0,`0x8000>>$kimdfunc`
 	jz	.Lsoftware
 	lghi	%r0,$kimdfunc
@@ -312,7 +312,7 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,80,8
+.comm	OPENSSL_s390xcap_P,88,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -80,6 +80,8 @@ The following bits are significant:
 :
 :
 :
+:
+:
 
 =over
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -128,6 +128,8 @@ The following bits are significant:
 
 :
 :
+:
+:
 
 =over
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -128,7 +128,21 @@ The following bits are significant:
 
 :
 :
+
+=over
+
+=item #60 PRNO-SHA-512-DRNG
+
+=back
+
 :
+
+=over
+
+=item #13 PRNO-TRNG
+
+=back
+
 :
 
 =over

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -76,6 +76,21 @@ The following bits are significant:
 
 =back
 
+:
+:
+:
+:
+
+=over
+
+=item #43 KMA-GCM-AES-256
+
+=item #44 KMA-GCM-AES-192
+
+=item #45 KMA-GCM-AES-128
+
+=back
+
 =head1 EXAMPLES
 
 OPENSSL_s390xcap=.0:0 disables KIMD.

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -15,15 +15,20 @@ extensions are denoted by individual bits in the capability vector.
 When libcrypto is initialized, the bits returned by the STFLE instruction
 and by the QUERY functions are stored in the vector.
 
-The OPENSSL_s390xcap environment variable can be set before starting an
-application to affect capability detection. It is specified by a
-colon-separated list of 64-bit values in hexadecimal notation, the 0x
-prefix being optional. The ~ prefix means bitwise NOT and a point
-indicates the end of the STFLE bits respectively the beginning of the
-QUERY bits.
+To change the set of instructions available to an application, you can
+set the OPENSSL_s390xcap environment variable before you start the
+application. After initialization, the capability vector is ANDed bitwise
+with the corresponding parts of the environment variable.
 
-After initialization, the capability vector is ANDed bitwise with the
-corresponding parts of the environment variable.
+OPENSSL_s390xcap is a colon-separated list of 64-bit values in
+hexadecimal notation. The 0x prefix is optional. Prefix a value with a
+tilde (~) to denote a bitwise NOT operation. A point indicates the end
+of the STFLE bits and the beginning of the QUERY bits, respectively.
+
+The environment variable has the following structure:
+
+STFLE:STFLE:STFLE.KIMD:KIMD:KM:KM:KMC:KMC:KMAC:KMAC:KMCTR:KMCTR:KMO:KMO
+:KMF:KMF:PRNO:PRNO:KMA:KMA
 
 The following bits are significant:
 
@@ -155,9 +160,11 @@ The following bits are significant:
 
 =back
 
+Bits which are not significant need not be specified.
+
 =head1 EXAMPLES
 
-OPENSSL_s390xcap=0:0:~0x4000000000000000 disables the vector facility.
+OPENSSL_s390xcap=::~0x4000000000000000 disables the vector facility.
 
 OPENSSL_s390xcap=.0:0 disables KIMD.
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -95,6 +95,17 @@ The following bits are significant:
 
 :
 :
+
+=over
+
+=item #43 KMF-AES-256
+
+=item #44 KMF-AES-192
+
+=item #45 KMF-AES-128
+
+=back
+
 :
 :
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -1,0 +1,94 @@
+=pod
+
+=head1 NAME
+
+OPENSSL_s390xcap - the z processor capabilities vector
+
+=head1 SYNOPSIS
+
+ env OPENSSL_s390xcap=... <application>
+
+=head1 DESCRIPTION
+
+libcrypto supports z architecture instruction set extensions. These
+extensions are denoted by individual bits in the capability vector.
+When libcrypto is initialized, the bits returned by the STFLE instruction
+and by the QUERY functions are stored in the vector.
+
+The OPENSSL_s390xcap environment variable can be set before starting an
+application to affect capability detection. It is specified by a
+colon-separated list of 64-bit values in hexadecimal notation, the 0x
+prefix being optional. The ~ prefix means bitwise NOT and a point
+indicates the end of the STFLE bits respectively the beginning of the
+QUERY bits.
+
+After initialization, the capability vector is ANDed bitwise with the
+corresponding parts of the environment variable.
+
+The following bits are significant:
+
+.
+
+=over
+
+=item #60 KIMD-SHA-512
+
+=item #61 KIMD-SHA-256
+
+=item #62 KIMD-SHA-1
+
+=back
+
+:
+
+=over
+
+=item #62 KIMD-GHASH
+
+=back
+
+:
+
+=over
+
+=item #11 KM-XTS-AES-256
+
+=item #13 KM-XTS-AES-128
+
+=item #43 KM-AES-256
+
+=item #44 KM-AES-192
+
+=item #45 KM-AES-128
+
+=back
+
+:
+:
+
+=over
+
+=item #43 KMC-AES-256
+
+=item #44 KMC-AES-192
+
+=item #45 KMC-AES-128
+
+=back
+
+=head1 EXAMPLES
+
+OPENSSL_s390xcap=.0:0 disables KIMD.
+
+OPENSSL_s390xcap=.::~0x2800 disables KM-XTS-AES.
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -35,7 +35,7 @@ The following bits are significant:
 :
 :
 
-=over
+=over 4
 
 =item #62 vector facility
 
@@ -43,7 +43,7 @@ The following bits are significant:
 
 .
 
-=over
+=over 4
 
 =item #60 KIMD-SHA-512
 
@@ -55,7 +55,7 @@ The following bits are significant:
 
 :
 
-=over
+=over 4
 
 =item #62 KIMD-GHASH
 
@@ -63,7 +63,7 @@ The following bits are significant:
 
 :
 
-=over
+=over 4
 
 =item #11 KM-XTS-AES-256
 
@@ -80,7 +80,7 @@ The following bits are significant:
 :
 :
 
-=over
+=over 4
 
 =item #43 KMC-AES-256
 
@@ -93,7 +93,7 @@ The following bits are significant:
 :
 :
 
-=over
+=over 4
 
 =item #43 KMAC-AES-256
 
@@ -108,7 +108,7 @@ The following bits are significant:
 :
 :
 
-=over
+=over 4
 
 =item #43 KMO-AES-256
 
@@ -121,7 +121,7 @@ The following bits are significant:
 :
 :
 
-=over
+=over 4
 
 =item #43 KMF-AES-256
 
@@ -134,7 +134,7 @@ The following bits are significant:
 :
 :
 
-=over
+=over 4
 
 =item #60 PRNO-SHA-512-DRNG
 
@@ -142,7 +142,7 @@ The following bits are significant:
 
 :
 
-=over
+=over 4
 
 =item #13 PRNO-TRNG
 
@@ -150,7 +150,7 @@ The following bits are significant:
 
 :
 
-=over
+=over 4
 
 =item #43 KMA-GCM-AES-256
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -95,6 +95,8 @@ The following bits are significant:
 
 :
 :
+:
+:
 
 =over
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -27,6 +27,15 @@ corresponding parts of the environment variable.
 
 The following bits are significant:
 
+:
+:
+
+=over
+
+=item #62 vector facility
+
+=back
+
 .
 
 =over
@@ -131,6 +140,8 @@ The following bits are significant:
 =back
 
 =head1 EXAMPLES
+
+OPENSSL_s390xcap=0:0:~0x4000000000000000 disables the vector facility.
 
 OPENSSL_s390xcap=.0:0 disables KIMD.
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -82,6 +82,8 @@ The following bits are significant:
 :
 :
 :
+:
+:
 
 =over
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -82,6 +82,17 @@ The following bits are significant:
 :
 :
 :
+
+=over
+
+=item #43 KMO-AES-256
+
+=item #44 KMO-AES-192
+
+=item #45 KMO-AES-128
+
+=back
+
 :
 :
 

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -78,6 +78,17 @@ The following bits are significant:
 
 :
 :
+
+=over
+
+=item #43 KMAC-AES-256
+
+=item #44 KMAC-AES-192
+
+=item #45 KMAC-AES-128
+
+=back
+
 :
 :
 :

--- a/doc/man3/RAND_set_rand_method.pod
+++ b/doc/man3/RAND_set_rand_method.pod
@@ -37,10 +37,10 @@ API is being used, so this function is no longer recommended.
 
  typedef struct rand_meth_st
  {
-        void (*seed)(const void *buf, int num);
+        int (*seed)(const void *buf, int num);
         int (*bytes)(unsigned char *buf, int num);
         void (*cleanup)(void);
-        void (*add)(const void *buf, int num, int entropy);
+        int (*add)(const void *buf, int num, double entropy);
         int (*pseudorand)(unsigned char *buf, int num);
         int (*status)(void);
  } RAND_METHOD;

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -29,6 +29,7 @@ plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3");
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+$ENV{OPENSSL_s390xcap} = '.::::::::::::::0:0';
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
 
 

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -29,6 +29,7 @@ plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3");
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+$ENV{OPENSSL_s390xcap} = '.::::::::::::::0:0';
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
 
 


### PR DESCRIPTION
improved s390x support

- fix minor s390x assembly pack issues.
- add OPENSSL_s390xcap environment variable and corresponding man page. 
- add/improve s390x hardware support for aes-ecb, aes-ofb, aes-cfb, aes-cfb8, aes-ctr, aes-ccm, aes-gcm.
- add s390x perlasm module.
- add vectorized chacha20 s390x assembler implementation.
- add vectorized poly1305 s390x assembler implementation.
- add CFI annotations for new s390x assembler code.
- add hardware supported sha512-based DRNG (NIST SP 800-90A), seeded by TRNG

All s390x assembler code paths tested on z13 and zEC12 with 64 and 32-bit abi and on zNEXT with 64-bit abi.

icla and ccla sent to legal@opensslfoundation.org.