### PR TITLE
Fix manual generation on Unix

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -563,109 +563,29 @@ uninstall_runtime:
 	@ : {- output_on() unless windowsdll(); "" -}
 	-$(RMDIR) $(DESTDIR)$(INSTALLTOP)/bin
 
-# A method to extract all names from a .pod file
-# The first sed extracts everything between "=head1 NAME" and the next =head1
-# The perl command joins all the lines into one
-# The second sed removes the description and turns all commas into spaces
-# Voilà, you have a space separated list of names!
-EXTRACT_NAMES=sed -e '1,/^=head1  *NAME *$$/d;/^=head1/,$$d' | \
-              $(PERL) -p -0 -e 's/\n/ /g; END {print "\n"}' | \
-              sed -e 's/ - .*$$//;s/,/ /g'
-PROCESS_PODS=\
-	set -e; \
-	here=`cd $(SRCDIR); pwd`; \
-	point=$$here/util/point.sh; \
-	for ds in man1 man3 man5 man7 ; do \
-	    SEC=`echo $$ds | sed -e s/man//`; \
-	    for p in $(SRCDIR)/doc/$$ds/*.pod; do \
-		fn=`basename $$p .pod`; \
-		Name=$$fn; \
-		NAME=`echo $$fn | tr '[a-z]' '[A-Z]'`; \
-		suf=`eval "echo $$OUTSUFFIX"`; \
-		top=`eval "echo $$OUTTOP"`; \
-		$(PERL) $(SRCDIR)/util/mkdir-p.pl $$top/man$$SEC; \
-		echo "install $$p -> $$top/man$$SEC/$$fn$$suf"; \
-		cat $$p | eval "$$GENERATE" \
-			>  $$top/man$$SEC/$$fn$$suf; \
-		names=`cat $$p | $(EXTRACT_NAMES)`; \
-		( cd $$top/man$$SEC; \
-		  for n in $$names; do \
-		      comp_n="$$n"; \
-		      comp_fn="$$fn"; \
-		      case "$(PLATFORM)" in DJGPP|Cygwin*|mingw*|darwin*-*-cc) \
-			  comp_n=`echo "$$n" | tr '[A-Z]' '[a-z]'`; \
-			  comp_fn=`echo "$$fn" | tr '[A-Z]' '[a-z]'`; \
-			  ;; \
-		      esac; \
-		      if [ "$$comp_n" != "$$comp_fn" ]; then \
-			  echo "link $$top/man$$SEC/$$n$$suf -> $$top/man$$SEC/$$fn$$suf"; \
-			  PLATFORM=$(PLATFORM) $$point $$fn$$suf $$n$$suf; \
-		      fi; \
-		  done ); \
-	    done; \
-	done
-UNINSTALL_DOCS=\
-	set -e; \
-	here=`cd $(SRCDIR); pwd`; \
-	for ds in man1 man3 man5 man7 ; do \
-	    SEC=`echo $$ds | sed -e s/man//`; \
-	    for p in $(SRCDIR)/doc/$$ds/*.pod; do \
-		fn=`basename $$p .pod`; \
-		suf=`eval "echo $$OUTSUFFIX"`; \
-		top=`eval "echo $$OUTTOP"`; \
-		echo "$(RM) $$top/man$$SEC/$$fn$$suf"; \
-	        $(RM) $$top/man$$SEC/$$fn$$suf; \
-		names=`cat $$p | $(EXTRACT_NAMES)`; \
-		for n in $$names; do \
-		    comp_n="$$n"; \
-		    comp_fn="$$fn"; \
-		    case "$(PLATFORM)" in DJGPP|Cygwin*|mingw*|darwin*-*-cc) \
-			comp_n=`echo "$$n" | tr '[A-Z]' '[a-z]'`; \
-			comp_fn=`echo "$$fn" | tr '[A-Z]' '[a-z]'`; \
-			;; \
-		    esac; \
-		    if [ "$$comp_n" != "$$comp_fn" ]; then \
-			echo "$(RM) $$top/man$$SEC/$$n$$suf"; \
-			$(RM) $$top/man$$SEC/$$n$$suf; \
-		    fi; \
-		done; \
-		( $(RMDIR) $$top/man$$SEC 2>/dev/null || exit 0 ); \
-	    done; \
-	done
 
 install_man_docs:
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@echo "*** Installing manpages"
-	@\
-	OUTSUFFIX='.$${SEC}$(MANSUFFIX)'; \
-	OUTTOP="$(DESTDIR)$(MANDIR)"; \
-	GENERATE='pod2man --name=$$NAME --section=$$SEC --center=OpenSSL --release=$(VERSION)'; \
-	$(PROCESS_PODS)
+	$(PERL) $(SRCDIR)/util/process_docs.pl \
+		--destdir=$(DESTDIR)$(MANDIR) --type=man --suffix=$(MANSUFFIX)
 
 uninstall_man_docs:
 	@echo "*** Uninstalling manpages"
-	@\
-	OUTSUFFIX='.$${SEC}$(MANSUFFIX)'; \
-	OUTTOP="$(DESTDIR)$(MANDIR)"; \
-	$(UNINSTALL_DOCS)
+	$(PERL) $(SRCDIR)/util/process_docs.pl \
+		--destdir=$(DESTDIR)$(MANDIR) --type=man --suffix=$(MANSUFFIX) \
+		--remove
 
 install_html_docs:
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@echo "*** Installing HTML manpages"
-	@\
-	OUTSUFFIX='.$(HTMLSUFFIX)'; \
-	OUTTOP="$(DESTDIR)$(HTMLDIR)"; \
-	GENERATE="pod2html --podroot=$(SRCDIR)/doc --htmldir=.. \
-			   --podpath=apps:crypto:ssl --title=\$$Name \
-		  | perl -pe 's|href=\"http://man.he.net/man|href=\"../man|g; s|href=\"(.*/man.*)(?<!\.html)\">|href=\"\$$1.html\">|g;'"; \
-	$(PROCESS_PODS)
+	$(PERL) $(SRCDIR)/util/process_docs.pl \
+		--destdir=$(DESTDIR)$(HTMLDIR) --type=html
 
 uninstall_html_docs:
 	@echo "*** Uninstalling manpages"
-	@\
-	OUTSUFFIX='.$(HTMLSUFFIX)'; \
-	OUTTOP="$(DESTDIR)$(HTMLDIR)"; \
-	$(UNINSTALL_DOCS)
+	$(PERL) $(SRCDIR)/util/process_docs.pl \
+		--destdir=$(DESTDIR)$(HTMLDIR) --type=html --remove
 
 
 # Developer targets (note: these are only available on Unix) #########

--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -33,6 +33,8 @@ GetOptions(\%options,
            'destdir=s',         # Destination directory
            #'in=s@',             # Explicit files to process (ignores sourcedir)
            'type=s',            # The result type, 'man' or 'html'
+           'suffix:s',          # Suffix to add to the extension.
+                                # Only used with type=man
            'remove',            # To remove files rather than writing them
            'dry-run|n',         # Only output file names on STDOUT
            'debug|D+',
@@ -50,6 +52,8 @@ pod2usage(1) unless ( defined $options{section}
                       && defined $options{type}
                       && ($options{type} eq 'man'
                           || $options{type} eq 'html') );
+pod2usage(1) if ( $options{type} eq 'html'
+                  && defined $options{suffix} );
 
 if ($options{debug}) {
     print STDERR "DEBUG: options:\n";
@@ -59,6 +63,8 @@ if ($options{debug}) {
         if defined $options{destdir};
     print STDERR "DEBUG:   --type      = $options{type}\n"
         if defined $options{type};
+    print STDERR "DEBUG:   --suffix    = $options{suffix}\n"
+        if defined $options{suffix};
     foreach (sort @{$options{section}}) {
         print STDERR "DEBUG:   --section   = $_\n";
     }
@@ -87,7 +93,7 @@ foreach my $section (sort @{$options{section}}) {
 
         my $updir = updir();
         my $name = uc $podname;
-        my $suffix = { man  => ".$podinfo{section}",
+        my $suffix = { man  => ".$podinfo{section}".($options{suffix} // ""),
                        html => ".html" } -> {$options{type}};
         my $generate = { man  => "pod2man --name=$name --section=$podinfo{section} --center=OpenSSL --release=$config{version} \"$podpath\"",
                          html => "pod2html \"--podroot=$options{sourcedir}\" --htmldir=$updir --podpath=man1:man3:man5:man7 \"--infile=$podpath\" \"--title=$podname\""
@@ -174,6 +180,7 @@ B<process_docs.pl>
 [B<--sourcedir>=I<dir>]
 B<--destdir>=I<dir>
 B<--type>=B<man>|B<html>
+[B<--suffix>=I<suffix>]
 [B<--remove>]
 [B<--dry-run>|B<-n>]
 [B<--debug>|B<-D>]
@@ -205,6 +212,10 @@ Top directory where the resulting files should end up
 =item B<--type>=B<man>|B<html>
 
 Type of output to produce.  Currently supported are man pages and HTML files.
+
+=item B<--suffix>=I<suffix>
+
+A suffix added to the extension.  Only valid with B<--type>=B<man>
 
 =item B<--remove>
 


### PR DESCRIPTION
Manual generation on Unix hasn't caught up with the directoory layout change.  Also, we have a well working script that does the work on other platforms, there's no point in making Unix a special case (i.e. double the maintainance burden).
