### PR TITLE
Make enc -ciphers only output modes that are usable

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -563,8 +563,16 @@ static void show_ciphers(const OBJ_NAME *name, void *bio_)
 {
     BIO *bio = bio_;
     static int n;
+    const EVP_CIPHER *cipher;
 
     if (!islower((unsigned char)*name->name))
+        return;
+
+    /* Filter out ciphers that we cannot use */
+    cipher = EVP_get_cipherbyname(name->name);
+    if (cipher == NULL ||
+            (EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0 ||
+            EVP_CIPHER_mode(cipher) == EVP_CIPH_XTS_MODE)
         return;
 
     BIO_printf(bio, "-%-25s", name->name);

--- a/test/recipes/20-test_enc_more.t
+++ b/test/recipes/20-test_enc_more.t
@@ -29,7 +29,7 @@ my $fail = "";
 my $cmd = "openssl";
 
 my @ciphers =
-    grep(! /wrap|hmac|poly|ocb|xts|^$|^[^-]|(?i)[cg]cm/,
+    grep(! /wrap|^$|^[^-]/,
          (map { split /\s+/ }
               run(app([$cmd, "enc", "-ciphers"]), capture => 1)));
 


### PR DESCRIPTION
- [x] tests are added or updated

Limit the output of the `enc -ciphers` command to just the ciphers enc can process.  Currently, this means no AEAD ciphers and no XTS mode.  Without this change `enc -ciphers` will output cipher modes that produce an error when an attempt is made to use them.

Update the test script that uses this output, to exhaustively test the ciphers, to not filter out the now missing cipher modes.
