### PR TITLE
Fix a crash or unbounded allocation in RSA_padding_add_PKCS1_PSS_mgf1 for 1.1.0 & 1.0.2

### DIFF
--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -76,7 +76,11 @@ int RSA_verify_PKCS1_PSS_mgf1(RSA *rsa, const unsigned char *mHash,
         EM++;
         emLen--;
     }
-    if (emLen < (hLen + sLen + 2)) { /* sLen can be small negative */
+    if (emLen < hLen + 2) {
+        RSAerr(RSA_F_RSA_VERIFY_PKCS1_PSS_MGF1, RSA_R_DATA_TOO_LARGE);
+        goto err;
+    }
+    if (sLen > emLen - hLen - 2) { /* sLen can be small negative */
         RSAerr(RSA_F_RSA_VERIFY_PKCS1_PSS_MGF1, RSA_R_DATA_TOO_LARGE);
         goto err;
     }
@@ -175,9 +179,14 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
         *EM++ = 0;
         emLen--;
     }
+    if (emLen < hLen + 2) {
+        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_PSS_MGF1,
+               RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
+        goto err;
+    }
     if (sLen == -2) {
         sLen = emLen - hLen - 2;
-    } else if (emLen < (hLen + sLen + 2)) {
+    } else if (sLen > emLen - hLen - 2) {
         RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_PSS_MGF1,
                RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
         goto err;

--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -1,0 +1,49 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use File::Spec;
+use OpenSSL::Test qw/:DEFAULT with srctop_file/;
+use OpenSSL::Test::Utils;
+
+setup("test_rsapss");
+
+plan tests => 5;
+
+#using test/testrsa.pem which happens to be a 512 bit RSA
+ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha1',
+            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-2',
+            '-sigopt', 'rsa_mgf1_md:sha512', srctop_file('test', 'testrsa.pem')],
+           stdout => 'testrsapss.sig')),
+   "openssl dgst -sign");
+
+with({ exit_checker => sub { return shift == 1; } },
+     sub { ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha512',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-2',
+                       '-sigopt', 'rsa_mgf1_md:sha512', srctop_file('test', 'testrsa.pem')])),
+              "openssl dgst -sign, expect to fail gracefully");
+           ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha512',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:2147483647',
+                       '-sigopt', 'rsa_mgf1_md:sha1', srctop_file('test', 'testrsa.pem')])),
+              "openssl dgst -sign, expect to fail gracefully");
+           ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), '-sha512',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-2',
+                       '-sigopt', 'rsa_mgf1_md:sha512', '-signature', 'testrsapss.sig',
+                       srctop_file('test', 'testrsa.pem')])),
+              "openssl dgst -prverify, expect to fail gracefully");
+         });
+
+ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), '-sha1',
+            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-2',
+            '-sigopt', 'rsa_mgf1_md:sha512', '-signature', 'testrsapss.sig',
+            srctop_file('test', 'testrsa.pem')])),
+   "openssl dgst -prverify");
+unlink 'testrsapss.sig';


### PR DESCRIPTION
This is the back-port of #2801:
The first commit is usable for 1.1.0 & 1.0.2,
while the test case works only for 1.1.0