### PR TITLE
TLSv1.3: Check the PSK extension is the last one

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -447,10 +447,14 @@ int tls_collect_extensions(SSL *s, PACKET *packet, unsigned int context,
         }
         /*
          * Verify this extension is allowed. We only check duplicates for
-         * extensions that we recognise.
+         * extensions that we recognise. We also have a special case for the
+         * PSK extension, which must be the last one in the ClientHello.
          */
         if (!verify_extension(s, context, type, exts, raw_extensions, &thisex)
-                || (thisex != NULL && thisex->present == 1)) {
+                || (thisex != NULL && thisex->present == 1)
+                || (type == TLSEXT_TYPE_psk
+                    && (context & EXT_CLIENT_HELLO) != 0
+                    && PACKET_remaining(&extensions) != 0)) {
             SSLerr(SSL_F_TLS_COLLECT_EXTENSIONS, SSL_R_BAD_EXTENSION);
             *al = SSL_AD_ILLEGAL_PARAMETER;
             goto err;

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -1,0 +1,73 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file srctop_dir bldtop_dir/;
+use OpenSSL::Test::Utils;
+use File::Temp qw(tempfile);
+use TLSProxy::Proxy;
+
+my $test_name = "test_tls13psk";
+setup($test_name);
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS|MSWin32)$/;
+
+plan skip_all => "$test_name needs the dynamic engine feature enabled"
+    if disabled("engine") || disabled("dynamic-engine");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLSv1.3 enabled"
+    if disabled("tls1_3");
+
+$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
+
+my $proxy = TLSProxy::Proxy->new(
+    undef,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
+);
+
+#Most PSK tests are done in test_ssl_new. This just checks sending a PSK
+#extension when it isn't in the last place in a ClientHello
+
+#Test 1: First get a session
+(undef, my $session) = tempfile();
+$proxy->clientflags("-sess_out ".$session);
+$proxy->sessionfile($session);
+$proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 2;
+ok(TLSProxy::Message->success(), "Initial connection");
+
+#Test 2: Attempt a resume with PSK not in last place. Should fail
+$proxy->clear();
+$proxy->clientflags("-sess_in ".$session);
+$proxy->filter(\&modify_psk_filter);
+$proxy->start();
+ok(TLSProxy::Message->fail(), "PSK not last");
+
+unlink $session;
+
+sub modify_psk_filter
+{
+    my $proxy = shift;
+
+    # We're only interested in the initial ClientHello
+    return if ($proxy->flight != 0);
+
+    foreach my $message (@{$proxy->message_list}) {
+        if ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO) {
+            $message->set_extension(TLSProxy::Message::EXT_FORCE_LAST, "");
+            $message->repack();
+        }
+    }
+}

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -85,7 +85,9 @@ use constant {
     # This extension is an unofficial extension only ever written by OpenSSL
     # (i.e. not read), and even then only when enabled. We use it to test
     # handling of duplicate extensions.
-    EXT_DUPLICATE_EXTENSION => 0xfde8
+    EXT_DUPLICATE_EXTENSION => 0xfde8,
+    #Unknown extension that should appear last
+    EXT_FORCE_LAST => 0xffff
 };
 
 use constant {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
It is a requirement that the PSK extension is the last extension in the ClientHello. We always generate it like that, but were failing to check that a ClientHello we receive obeys the rules.