### PR TITLE
Encourage having external tests in multiple test recipes

### DIFF
--- a/test/README.external
+++ b/test/README.external
@@ -1,12 +1,16 @@
-Running the BoringSSL test suite with OpenSSL
-=============================================
+Running external test suites with OpenSSL
+=========================================
 
-It is possible to integrate external test suites into OpenSSL's "make test". At
-the current time the only supported external suite is the one used by
-BoringSSL.
-
+It is possible to integrate external test suites into OpenSSL's "make test".
 This capability is considered a developer option and may not work on all
 platforms.
+
+At the current time the only supported external suite is the one used by
+BoringSSL.
+
+
+The BoringSSL test suite
+========================
 
 In order to run the BoringSSL tests with OpenSSL, first checkout the BoringSSL
 source code into an appropriate directory:
@@ -40,11 +44,11 @@ To see more detailed output you can run just the BoringSSL tests with the
 verbose option:
 
 $ VERBOSE=1 BORING_RUNNER_DIR=/path/to/boringssl/ssl/test/runner make \
-  TESTS="test_external" test
+  TESTS="test_external_boringssl" test
 
 
 Test failures and suppressions
-==============================
+------------------------------
 
 A large number of the BoringSSL tests are known to fail. A test could fail
 because of many possible reasons. For example:

--- a/test/recipes/95-test_external_boringssl.t
+++ b/test/recipes/95-test_external_boringssl.t
@@ -11,24 +11,23 @@ use OpenSSL::Test;
 use OpenSSL::Test::Utils;
 use OpenSSL::Test qw/:DEFAULT bldtop_file srctop_file cmdstr/;
 
-setup("test_external");
+setup("test_external_boringssl");
 
 plan skip_all => "No external tests in this configuration"
     if disabled("external-tests");
 
-if (!$ENV{BORING_RUNNER_DIR}) {
-    plan skip_all => "No external tests have been detected";
-}
+plan skip_all => "BoringSSL runner not detected"
+    if !$ENV{BORING_RUNNER_DIR};
 
 plan tests => 1;
 
 indir $ENV{BORING_RUNNER_DIR} => sub {
     ok(filter_run(cmd(["go", "test", "-shim-path",
-                      bldtop_file("test", "ossl_shim", "ossl_shim"),
-                      "-shim-config",
-                      srctop_file("test", "ossl_shim", "ossl_config.json"),
-                      "-pipe", "-allow-unimplemented"])),
-        "running external tests");
+                       bldtop_file("test", "ossl_shim", "ossl_shim"),
+                       "-shim-config",
+                       srctop_file("test", "ossl_shim", "ossl_config.json"),
+                       "-pipe", "-allow-unimplemented"])),
+       "running BoringSSL tests");
 }, create => 0, cleanup => 0;
 
 # Filter the output so that the "ok" printed by go test doesn't confuse


### PR DESCRIPTION
This will make the individual external tests more easily selectable /
deselectable through the usual test selection mechanism.

This also moves external tests to group 95.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
