### PR TITLE
UI docs: Rephrase the UI method function return value description

### DIFF
--- a/doc/man3/UI_create_method.pod
+++ b/doc/man3/UI_create_method.pod
@@ -85,27 +85,12 @@ by closing the channel to the tty, maybe by destroying a dialog box.
 
 =back
 
-All of these functions are expected to return one of these values:
-
-=over 4
-
-=item 0
-
-on error.
-
-=item 1
-
-on success.
-
-=item -1
-
-on out-off-band events, for example if some prompting has been
-cancelled (by pressing Ctrl-C, for example).
-This is only expected to be returned by the flusher or the reader.
+All of these functions are expected to return 0 on error, 1 on
+success, or -1 on out-off-band events, for example if some prompting
+has been cancelled (by pressing Ctrl-C, for example).
+Only the flusher or the reader are expected to return -1.
 If returned by another of the functions, it's treated as if 0 was
 returned.
-
-=back
 
 Regarding the writer and the reader, don't assume the former should
 only write and don't assume the latter should only read.


### PR DESCRIPTION
It seems the =item isn't supposed to have pure numbers, or so tells me
perldoc.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
