### PR TITLE
poly1305/asm/poly1305-armv8.pl: ilp32-specific poly1305_init fix.

### DIFF
--- a/crypto/poly1305/asm/poly1305-armv8.pl
+++ b/crypto/poly1305/asm/poly1305-armv8.pl
@@ -100,7 +100,11 @@ poly1305_init:
 	csel	$d0,$d0,$r0,eq
 	csel	$d1,$d1,$r1,eq
 
+#ifdef	__ILP32__
+	stp	w12,w13,[$len]
+#else
 	stp	$d0,$d1,[$len]
+#endif
 
 	mov	x0,#1
 .Lno_key:


### PR DESCRIPTION
[skip ci]
