### PR TITLE
Fix DTLSv1_listen() sequence numbers

### DIFF
--- a/ssl/d1_srvr.c
+++ b/ssl/d1_srvr.c
@@ -355,15 +355,6 @@ int dtls1_accept(SSL *s)
 
             s->init_num = 0;
 
-            /*
-             * Reflect ClientHello sequence to remain stateless while
-             * listening
-             */
-            if (listen) {
-                memcpy(s->s3->write_sequence, s->s3->read_sequence,
-                       sizeof(s->s3->write_sequence));
-            }
-
             /* If we're just listening, stop here */
             if (listen && s->state == SSL3_ST_SW_SRVR_HELLO_A) {
                 ret = 2;


### PR DESCRIPTION
This fixes a bug in 1.0.2. This issue does not impact 1.1.0 due to the rewrite of DTLSv1_listen().

DTLSv1_listen() is stateless. We never increment the record read sequence while listening, and we reflect the incoming record's sequence number in our write sequence.
    
The logic for doing the write sequence reflection was *after* we had finished processing the incoming ClientHello and before we write the ServerHello. In the normal course of events this is fine. However if we
need to write an early alert during ClientHello processing (e.g. no shared cipher), then we haven't done the write sequence reflection yet. This means the alert gets written with the wrong sequence number (it will just be set to whatever value we left it in the last time we wrote something). If the sequence number is less than expected then the client will believe that the incoming alert is a retransmit and will therefore drop it, causing the client to hang waiting for a response from the server.
    
Fixes #2886
