### PR TITLE
Draft 19 certificate request format support.

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2336,6 +2336,7 @@ int ERR_load_SSL_strings(void);
 # define SSL_F_TLS_CHOOSE_SIGALG                          513
 # define SSL_F_TLS_CLIENT_KEY_EXCHANGE_POST_WORK          354
 # define SSL_F_TLS_COLLECT_EXTENSIONS                     435
+# define SSL_F_TLS_CONSTRUCT_CERTIFICATE_AUTHORITIES      542
 # define SSL_F_TLS_CONSTRUCT_CERTIFICATE_REQUEST          372
 # define SSL_F_TLS_CONSTRUCT_CERT_STATUS                  429
 # define SSL_F_TLS_CONSTRUCT_CERT_STATUS_BODY             494

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2174,6 +2174,7 @@ int ERR_load_SSL_strings(void);
 # define SSL_F_OSSL_STATEM_SERVER13_READ_TRANSITION       437
 # define SSL_F_OSSL_STATEM_SERVER_CONSTRUCT_MESSAGE       431
 # define SSL_F_OSSL_STATEM_SERVER_READ_TRANSITION         418
+# define SSL_F_PARSE_CA_NAMES                             541
 # define SSL_F_PROCESS_KEY_SHARE_EXT                      439
 # define SSL_F_READ_STATE_MACHINE                         352
 # define SSL_F_SET_CLIENT_CIPHERSUITE                     540

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -184,6 +184,7 @@ extern "C" {
 # define TLSEXT_TYPE_supported_versions          43
 # define TLSEXT_TYPE_cookie                      44
 # define TLSEXT_TYPE_psk_kex_modes               45
+# define TLSEXT_TYPE_certificate_authorities     47
 
 /* Temporary extension type */
 # define TLSEXT_TYPE_renegotiate                 0xff01

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -74,6 +74,7 @@ static ERR_STRING_DATA SSL_str_functs[] = {
      "ossl_statem_server_construct_message"},
     {ERR_FUNC(SSL_F_OSSL_STATEM_SERVER_READ_TRANSITION),
      "ossl_statem_server_read_transition"},
+    {ERR_FUNC(SSL_F_PARSE_CA_NAMES), "parse_ca_names"},
     {ERR_FUNC(SSL_F_PROCESS_KEY_SHARE_EXT), "process_key_share_ext"},
     {ERR_FUNC(SSL_F_READ_STATE_MACHINE), "read_state_machine"},
     {ERR_FUNC(SSL_F_SET_CLIENT_CIPHERSUITE), "set_client_ciphersuite"},

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -282,6 +282,8 @@ static ERR_STRING_DATA SSL_str_functs[] = {
     {ERR_FUNC(SSL_F_TLS_CLIENT_KEY_EXCHANGE_POST_WORK),
      "tls_client_key_exchange_post_work"},
     {ERR_FUNC(SSL_F_TLS_COLLECT_EXTENSIONS), "tls_collect_extensions"},
+    {ERR_FUNC(SSL_F_TLS_CONSTRUCT_CERTIFICATE_AUTHORITIES),
+     "tls_construct_certificate_authorities"},
     {ERR_FUNC(SSL_F_TLS_CONSTRUCT_CERTIFICATE_REQUEST),
      "tls_construct_certificate_request"},
     {ERR_FUNC(SSL_F_TLS_CONSTRUCT_CERT_STATUS), "tls_construct_cert_status"},

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1808,6 +1808,7 @@ typedef enum tlsext_index_en {
     TLSEXT_IDX_cookie,
     TLSEXT_IDX_cryptopro_bug,
     TLSEXT_IDX_early_data,
+    TLSEXT_IDX_certificate_authorities,
     TLSEXT_IDX_padding,
     TLSEXT_IDX_psk
 } TLSEXT_INDEX;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -159,8 +159,9 @@ static const EXTENSION_DEFINITION ext_defs[] = {
     },
     {
         TLSEXT_TYPE_signature_algorithms,
-        EXT_CLIENT_HELLO,
-        init_sig_algs, tls_parse_ctos_sig_algs, NULL, NULL,
+        EXT_CLIENT_HELLO | EXT_TLS1_3_CERTIFICATE_REQUEST,
+        init_sig_algs, tls_parse_ctos_sig_algs,
+        tls_parse_ctos_sig_algs, tls_construct_ctos_sig_algs,
         tls_construct_ctos_sig_algs, final_sig_algs
     },
 #ifndef OPENSSL_NO_OCSP

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2351,7 +2351,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
         }
 
         if (!PACKET_get_length_prefixed_2(pkt, &extensions)) {
-                SSLerr(SSL_F_TLS_PROCESS_CLIENT_CERTIFICATE, SSL_R_BAD_LENGTH);
+                SSLerr(SSL_F_TLS_PROCESS_CERTIFICATE_REQUEST, SSL_R_BAD_LENGTH);
                 goto err;
         }
         if (!tls_collect_extensions(s, &extensions,

--- a/ssl/statem/statem_locl.h
+++ b/ssl/statem/statem_locl.h
@@ -80,6 +80,9 @@ typedef int (*confunc_f) (SSL *s, WPACKET *pkt);
 int check_in_list(SSL *s, unsigned int group_id, const unsigned char *groups,
                   size_t num_groups, int checkallow);
 int create_synthetic_message_hash(SSL *s);
+int parse_ca_names(SSL *s, PACKET *pkt, int *al);
+int construct_ca_names(SSL *s, WPACKET *pkt);
+
 /*
  * TLS/DTLS client state machine functions
  */

--- a/ssl/statem/statem_locl.h
+++ b/ssl/statem/statem_locl.h
@@ -53,6 +53,7 @@
 #define EXT_TLS1_3_HELLO_RETRY_REQUEST      0x0400
 #define EXT_TLS1_3_CERTIFICATE              0x0800
 #define EXT_TLS1_3_NEW_SESSION_TICKET       0x1000
+#define EXT_TLS1_3_CERTIFICATE_REQUEST      0x2000
 
 /* Dummy message type */
 #define SSL3_MT_DUMMY   -1


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

Add support for the TLS 1.3 draft-19 certificate request format.

It passes 'make test' but no other interop testing has been done: there aren't many implementations about yet ;-)

This adds support for the certificate_authorities extension which can be used by client and server.

The signature algorithms extension can now be generated/parsed by both client and server.

Still todo:

Check new extension code is correct. Maybe rename/move the signature algorithms functions: e.g. tls_construct_ctos_sig_algs can now also construct signature algorithms from server to client too.

Add functions to allow setting of CA list client side and retrieval server side and appropriate options to s_client, s_server and SSL_CONF.

Document new functions.

Add tests: the certificate request distinguished names is currently untested too: DONE in #2969
