### PR TITLE
Better way to recognise mingw64 in config script

### DIFF
--- a/config
+++ b/config
@@ -320,6 +320,15 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
 	echo "${MACHINE}-v11-${SYSTEM}"; exit 0;
 	;;
 
+    # The following combinations are supported
+    # MINGW64* on x86_64 => mingw64
+    # MINGW32* on x86_64 => mingw
+    # MINGW32* on i?86 => mingw
+    #
+    # MINGW64* on i?86 isn't expected to work...
+    MINGW64*:*:*:x86_64)
+	echo "${MACHINE}-whatever-mingw64"; exit 0;
+	;;
     MINGW*)
 	echo "${MACHINE}-whatever-mingw"; exit 0;
 	;;
@@ -801,8 +810,6 @@ case "$GUESSOS" in
 	    options="$options no-asm"
 	fi
 	;;
-  i[3456]86-*-mingw) OUT="mingw" ;;
-  x86_64-*-mingw) OUT="mingw64" ;;
   # these are all covered by the catchall below
   i[3456]86-*-cygwin) OUT="Cygwin-x86" ;;
   *-*-cygwin) OUT="Cygwin-${MACHINE}" ;;


### PR DESCRIPTION
This is an amendment of #2914