### PR TITLE
Add ARIA to the change log

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,9 @@
      are no longer allowed.
      [Emilia Käsper]
 
+  *) Add support for ARIA
+     [Paul Dale]
+
   *) Add support for SipHash
      [Todd Short]
 


### PR DESCRIPTION
The CHANGES file was not updated as part of #2337 to indicate the presence of the ARIA cipher.
This PR rectifies this.

