### PR TITLE
Make the Boring tests pass

### DIFF
--- a/test/ossl_shim/ossl_config.json
+++ b/test/ossl_shim/ossl_config.json
@@ -1184,7 +1184,20 @@
             "SkipHelloRetryRequest":"Test failure - reason unknown",
             "Peek-Alert":"Test failure - reason unknown",
             "TLS13-TrailingKeyShareData":"Test failure - reason unknown",
-            "Peek-KeyUpdate":"Test failure - reason unknown"
+            "Peek-KeyUpdate":"Test failure - reason unknown",
+            "Resume-Server-SSL3-SSL3":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-SSL3-TLS1":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-SSL3-TLS11":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS1-TLS1":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS1-TLS1-DTLS":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-SSL3-TLS12":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS1-TLS12":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS1-TLS11":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS1-TLS12-DTLS":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS11-TLS11":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS11-TLS12":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS12-TLS12":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement",
+            "Resume-Server-TLS12-TLS12-DTLS":"Test failure - runner using <draft17 TLS1.3 causes failures due to incorrect PSK extension placement"
     },
     "ErrorMap" : {
     }


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

The boring tests are currently failing because they send a PSK extension
which isn't in the last place. This is not allowed in the latest TLS1.3
specs. However the Boring tests we have are based on an old commit that
pre-date when that rule first appeared.

The proper solution is to update the tests to a later commit. But for now
to get travis to go green we disable the failing tests.

I will work on updating the Boring tests today.