### PR TITLE
Port remaining old DTLS tests

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -55,7 +55,7 @@ my $no_ocsp = disabled("ocsp");
 # expectations dynamically based on the OpenSSL compile-time config.
 my %conf_dependent_tests = (
   "02-protocol-version.conf" => !$is_default_tls,
-  "04-client_auth.conf" => !$is_default_tls,
+  "04-client_auth.conf" => !$is_default_tls || !$is_default_dtls,
   "05-sni.conf" => disabled("tls1_1"),
   "07-dtls-protocol-version.conf" => !$is_default_dtls,
   "10-resumption.conf" => !$is_default_tls,

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -331,7 +331,7 @@ sub testssl {
 
     subtest 'standard SSL tests' => sub {
 	######################################################################
-      plan tests => 21;
+      plan tests => 13;
 
       SKIP: {
 	  skip "SSLv3 is not supported by this OpenSSL build", 4
@@ -353,34 +353,6 @@ sub testssl {
 
 	  ok(run(test([@ssltest, "-bio_pair"])),
 	     'test sslv2/sslv3 via BIO pair');
-	}
-
-      SKIP: {
-	  skip "DTLSv1 is not supported by this OpenSSL build", 4
-	      if disabled("dtls1");
-
-	  ok(run(test([@ssltest, "-dtls1"])),
-	     'test dtlsv1');
-	  ok(run(test([@ssltest, "-dtls1", "-server_auth", @CA])),
-	   'test dtlsv1 with server authentication');
-	  ok(run(test([@ssltest, "-dtls1", "-client_auth", @CA])),
-	     'test dtlsv1 with client authentication');
-	  ok(run(test([@ssltest, "-dtls1", "-server_auth", "-client_auth", @CA])),
-	     'test dtlsv1 with both server and client authentication');
-	}
-
-      SKIP: {
-	  skip "DTLSv1.2 is not supported by this OpenSSL build", 4
-	      if disabled("dtls1_2");
-
-	  ok(run(test([@ssltest, "-dtls12"])),
-	     'test dtlsv1.2');
-	  ok(run(test([@ssltest, "-dtls12", "-server_auth", @CA])),
-	     'test dtlsv1.2 with server authentication');
-	  ok(run(test([@ssltest, "-dtls12", "-client_auth", @CA])),
-	     'test dtlsv1.2 with client authentication');
-	  ok(run(test([@ssltest, "-dtls12", "-server_auth", "-client_auth", @CA])),
-	     'test dtlsv1.2 with both server and client authentication');
 	}
 
       SKIP: {

--- a/test/ssl-tests/04-client_auth.conf
+++ b/test/ssl-tests/04-client_auth.conf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 20
+num_tests = 30
 
 test-0 = 0-server-auth-flex
 test-1 = 1-client-auth-flex-request
@@ -22,6 +22,16 @@ test-16 = 16-client-auth-TLSv1.2-request
 test-17 = 17-client-auth-TLSv1.2-require-fail
 test-18 = 18-client-auth-TLSv1.2-require
 test-19 = 19-client-auth-TLSv1.2-noroot
+test-20 = 20-server-auth-DTLSv1
+test-21 = 21-client-auth-DTLSv1-request
+test-22 = 22-client-auth-DTLSv1-require-fail
+test-23 = 23-client-auth-DTLSv1-require
+test-24 = 24-client-auth-DTLSv1-noroot
+test-25 = 25-server-auth-DTLSv1.2
+test-26 = 26-client-auth-DTLSv1.2-request
+test-27 = 27-client-auth-DTLSv1.2-require-fail
+test-28 = 28-client-auth-DTLSv1.2-require
+test-29 = 29-client-auth-DTLSv1.2-noroot
 # ===========================================================
 
 [0-server-auth-flex]
@@ -595,5 +605,311 @@ VerifyMode = Peer
 [test-19]
 ExpectedResult = ServerFail
 ExpectedServerAlert = UnknownCA
+
+
+# ===========================================================
+
+[20-server-auth-DTLSv1]
+ssl_conf = 20-server-auth-DTLSv1-ssl
+
+[20-server-auth-DTLSv1-ssl]
+server = 20-server-auth-DTLSv1-server
+client = 20-server-auth-DTLSv1-client
+
+[20-server-auth-DTLSv1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[20-server-auth-DTLSv1-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-20]
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[21-client-auth-DTLSv1-request]
+ssl_conf = 21-client-auth-DTLSv1-request-ssl
+
+[21-client-auth-DTLSv1-request-ssl]
+server = 21-client-auth-DTLSv1-request-server
+client = 21-client-auth-DTLSv1-request-client
+
+[21-client-auth-DTLSv1-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Request
+
+[21-client-auth-DTLSv1-request-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-21]
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[22-client-auth-DTLSv1-require-fail]
+ssl_conf = 22-client-auth-DTLSv1-require-fail-ssl
+
+[22-client-auth-DTLSv1-require-fail-ssl]
+server = 22-client-auth-DTLSv1-require-fail-server
+client = 22-client-auth-DTLSv1-require-fail-client
+
+[22-client-auth-DTLSv1-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[22-client-auth-DTLSv1-require-fail-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-22]
+ExpectedResult = ServerFail
+ExpectedServerAlert = HandshakeFailure
+Method = DTLS
+
+
+# ===========================================================
+
+[23-client-auth-DTLSv1-require]
+ssl_conf = 23-client-auth-DTLSv1-require-ssl
+
+[23-client-auth-DTLSv1-require-ssl]
+server = 23-client-auth-DTLSv1-require-server
+client = 23-client-auth-DTLSv1-require-client
+
+[23-client-auth-DTLSv1-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+[23-client-auth-DTLSv1-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-23]
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[24-client-auth-DTLSv1-noroot]
+ssl_conf = 24-client-auth-DTLSv1-noroot-ssl
+
+[24-client-auth-DTLSv1-noroot-ssl]
+server = 24-client-auth-DTLSv1-noroot-server
+client = 24-client-auth-DTLSv1-noroot-client
+
+[24-client-auth-DTLSv1-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[24-client-auth-DTLSv1-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-24]
+ExpectedResult = ServerFail
+ExpectedServerAlert = UnknownCA
+Method = DTLS
+
+
+# ===========================================================
+
+[25-server-auth-DTLSv1.2]
+ssl_conf = 25-server-auth-DTLSv1.2-ssl
+
+[25-server-auth-DTLSv1.2-ssl]
+server = 25-server-auth-DTLSv1.2-server
+client = 25-server-auth-DTLSv1.2-client
+
+[25-server-auth-DTLSv1.2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[25-server-auth-DTLSv1.2-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-25]
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[26-client-auth-DTLSv1.2-request]
+ssl_conf = 26-client-auth-DTLSv1.2-request-ssl
+
+[26-client-auth-DTLSv1.2-request-ssl]
+server = 26-client-auth-DTLSv1.2-request-server
+client = 26-client-auth-DTLSv1.2-request-client
+
+[26-client-auth-DTLSv1.2-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Request
+
+[26-client-auth-DTLSv1.2-request-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-26]
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[27-client-auth-DTLSv1.2-require-fail]
+ssl_conf = 27-client-auth-DTLSv1.2-require-fail-ssl
+
+[27-client-auth-DTLSv1.2-require-fail-ssl]
+server = 27-client-auth-DTLSv1.2-require-fail-server
+client = 27-client-auth-DTLSv1.2-require-fail-client
+
+[27-client-auth-DTLSv1.2-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[27-client-auth-DTLSv1.2-require-fail-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-27]
+ExpectedResult = ServerFail
+ExpectedServerAlert = HandshakeFailure
+Method = DTLS
+
+
+# ===========================================================
+
+[28-client-auth-DTLSv1.2-require]
+ssl_conf = 28-client-auth-DTLSv1.2-require-ssl
+
+[28-client-auth-DTLSv1.2-require-ssl]
+server = 28-client-auth-DTLSv1.2-require-server
+client = 28-client-auth-DTLSv1.2-require-client
+
+[28-client-auth-DTLSv1.2-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+[28-client-auth-DTLSv1.2-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-28]
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[29-client-auth-DTLSv1.2-noroot]
+ssl_conf = 29-client-auth-DTLSv1.2-noroot-ssl
+
+[29-client-auth-DTLSv1.2-noroot-ssl]
+server = 29-client-auth-DTLSv1.2-noroot-server
+client = 29-client-auth-DTLSv1.2-noroot-client
+
+[29-client-auth-DTLSv1.2-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[29-client-auth-DTLSv1.2-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-29]
+ExpectedResult = ServerFail
+ExpectedServerAlert = UnknownCA
+Method = DTLS
 
 

--- a/test/ssl-tests/04-client_auth.conf.in
+++ b/test/ssl-tests/04-client_auth.conf.in
@@ -12,24 +12,27 @@ use OpenSSL::Test::Utils qw(anydisabled);
 setup("no_test_here");
 
 # We test version-flexible negotiation (undef) and each protocol version.
-my @protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2");
+my @protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLSv1", "DTLSv1.2");
 
 my @is_disabled = (0);
-push @is_disabled, anydisabled("ssl3", "tls1", "tls1_1", "tls1_2");
+push @is_disabled, anydisabled("ssl3", "tls1", "tls1_1", "tls1_2", "dtls1", "dtls1_2");
 
 our @tests = ();
 
 sub generate_tests() {
-
     foreach (0..$#protocols) {
         my $protocol = $protocols[$_];
         my $protocol_name = $protocol || "flex";
         my $caalert;
+        my $method;
         if (!$is_disabled[$_]) {
             if ($protocol_name eq "SSLv3") {
                 $caalert = "BadCertificate";
             } else {
                 $caalert = "UnknownCA";
+            }
+            if ($protocol_name =~ m/^DTLS/) {
+                $method = "DTLS";
             }
             my $clihash;
             my $clisigtype;
@@ -51,7 +54,10 @@ sub generate_tests() {
                     "MinProtocol" => $protocol,
                     "MaxProtocol" => $protocol
                 },
-                test   => { "ExpectedResult" => "Success" },
+                test   => {
+                    "ExpectedResult" => "Success",
+                    "Method" => $method,
+                },
             };
 
             # Handshake with client cert requested but not required or received.
@@ -66,7 +72,10 @@ sub generate_tests() {
                     "MinProtocol" => $protocol,
                     "MaxProtocol" => $protocol
                 },
-                test   => { "ExpectedResult" => "Success" },
+                test   => {
+                    "ExpectedResult" => "Success",
+                    "Method" => $method,
+                },
             };
 
             # Handshake with client cert required but not present.
@@ -85,6 +94,7 @@ sub generate_tests() {
                 test   => {
                     "ExpectedResult" => "ServerFail",
                     "ExpectedServerAlert" => "HandshakeFailure",
+                    "Method" => $method,
                 },
             };
 
@@ -104,10 +114,12 @@ sub generate_tests() {
                     "Certificate" => test_pem("ee-client-chain.pem"),
                     "PrivateKey"  => test_pem("ee-key.pem"),
                 },
-                test   => { "ExpectedResult" => "Success",
-                            "ExpectedClientCertType" => "RSA",
-                            "ExpectedClientSignType" => $clisigtype,
-                            "ExpectedClientSignHash" => $clihash,
+                test   => {
+                    "ExpectedResult" => "Success",
+                    "ExpectedClientCertType" => "RSA",
+                    "ExpectedClientSignType" => $clisigtype,
+                    "ExpectedClientSignHash" => $clihash,
+                    "Method" => $method,
                 },
             };
 
@@ -128,10 +140,11 @@ sub generate_tests() {
                 test   => {
                     "ExpectedResult" => "ServerFail",
                     "ExpectedServerAlert" => $caalert,
+                    "Method" => $method,
                 },
             };
         }
     }
 }
- 
+
 generate_tests();


### PR DESCRIPTION
We already test DTLS protocol versions. For good measure, add some
DTLS tests with client auth to the new test framework, so that we can
remove the old tests without losing coverage.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
