### PR TITLE
test/recipes/03-test_internal_*: call setup() first.

### DIFF
--- a/test/recipes/03-test_internal_asn1.t
+++ b/test/recipes/03-test_internal_asn1.t
@@ -11,6 +11,8 @@ use OpenSSL::Test;              # get 'plan'
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
+setup("test_internal_asn1");
+
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 

--- a/test/recipes/03-test_internal_chacha.t
+++ b/test/recipes/03-test_internal_chacha.t
@@ -11,6 +11,8 @@ use OpenSSL::Test;              # get 'plan'
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
+setup("test_internal_chacha");
+
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 

--- a/test/recipes/03-test_internal_modes.t
+++ b/test/recipes/03-test_internal_modes.t
@@ -11,6 +11,8 @@ use OpenSSL::Test;              # get 'plan'
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
+setup("test_internal_modes");
+
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 

--- a/test/recipes/03-test_internal_poly1305.t
+++ b/test/recipes/03-test_internal_poly1305.t
@@ -11,6 +11,8 @@ use OpenSSL::Test;              # get 'plan'
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
+setup("test_internal_poly1305");
+
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 

--- a/test/recipes/03-test_internal_siphash.t
+++ b/test/recipes/03-test_internal_siphash.t
@@ -11,6 +11,8 @@ use OpenSSL::Test;              # get 'plan'
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
+setup("test_internal_siphash");
+
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 

--- a/test/recipes/03-test_internal_x509.t
+++ b/test/recipes/03-test_internal_x509.t
@@ -11,6 +11,8 @@ use OpenSSL::Test;              # get 'plan'
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
+setup("test_internal_x509");
+
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 


### PR DESCRIPTION
Strawberry Perl bailed out running test\run_tests.pl insisting on
setup() being called explicitly.
