### PR TITLE
Use go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     apt:
         packages:
             - ccache
-            - golang
+            - golang-1.6
 
 os:
     - linux


### PR DESCRIPTION
The Boring runner needs TagSequence et al from encoding/asn1 which did not
appear until go 1.6.

[extended tests]

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
