### PR TITLE
Rather use -out parameter than redirect stdout

### DIFF
--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -21,8 +21,8 @@ plan tests => 5;
 #using test/testrsa.pem which happens to be a 512 bit RSA
 ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha1',
             '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
-            '-sigopt', 'rsa_mgf1_md:sha512', srctop_file('test', 'testrsa.pem')],
-           stdout => 'testrsapss.sig')),
+            '-sigopt', 'rsa_mgf1_md:sha512', '-out', 'testrsapss.sig',
+            srctop_file('test', 'testrsa.pem')])),
    "openssl dgst -sign");
 
 with({ exit_checker => sub { return shift == 1; } },


### PR DESCRIPTION
On some platforms, setting stdout to binary mode isn't quite enough,
which makes the result unusable.  With -out, we have better control.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
