### PR TITLE
[code-healthy] Let --strict-warnings work on more compilers

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -174,7 +174,7 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
                    psk_key);
         return 0;
     }
-    if (key_len > max_psk_len) {
+    if (max_psk_len > INT_MAX || key_len > (long)max_psk_len) {
         BIO_printf(bio_err,
                    "psk buffer of callback is too small (%d) for key (%ld)\n",
                    max_psk_len, key_len);

--- a/test/danetest.c
+++ b/test/danetest.c
@@ -317,7 +317,7 @@ static int allws(const char *cp)
     return 1;
 }
 
-static int test_tlsafile(SSL_CTX *ctx, const char *basename,
+static int test_tlsafile(SSL_CTX *ctx, const char *base_name,
                          BIO *f, const char *path)
 {
     char *line;
@@ -353,7 +353,7 @@ static int test_tlsafile(SSL_CTX *ctx, const char *basename,
         if ((ssl = SSL_new(ctx)) == NULL)
             return -1;
         SSL_set_connect_state(ssl);
-        if (SSL_dane_enable(ssl, basename) <= 0) {
+        if (SSL_dane_enable(ssl, base_name) <= 0) {
             SSL_free(ssl);
             return -1;
         }


### PR DESCRIPTION
I tried out a strict-warnings build on an array of compilers I had sitting around, which found a couple things.

Feel free to bikeshed the names and such; I did not put much thought into them.