### PR TITLE
Add EC_KEY_get0_engine()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
  Changes between 1.1.0e and 1.1.1 [xx XXX xxxx]
 
+  *) Add EC_KEY_get0_engine(), which does for EC_KEY what RSA_get0_engine()
+     does for RSA, etc.
+     [Richard Levitte]
+
   *) Have 'config' recognise 64-bit mingw and choose 'mingw64' as the target
      platform rather than 'mingw'.
      [Richard Levitte]

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -177,6 +177,11 @@ int EC_KEY_up_ref(EC_KEY *r)
     return ((i > 1) ? 1 : 0);
 }
 
+ENGINE *EC_KEY_get0_engine(const EC_KEY *eckey)
+{
+    return eckey->engine;
+}
+
 int EC_KEY_generate_key(EC_KEY *eckey)
 {
     if (eckey == NULL || eckey->group == NULL) {

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -81,7 +81,7 @@ EC_KEY_up_ref() increments the reference count associated with the EC_KEY
 object.
 
 EC_KEY_get0_engine() returns a handle to the ENGINE that has been set for
-this RSA object.
+this EC_KEY object.
 
 EC_KEY_generate_key() generates a new public and private key for the supplied
 B<eckey> object. B<eckey> must have an EC_GROUP object associated with it

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -5,6 +5,7 @@
 EC_KEY_get_method, EC_KEY_set_method,
 EC_KEY_new, EC_KEY_get_flags, EC_KEY_set_flags, EC_KEY_clear_flags,
 EC_KEY_new_by_curve_name, EC_KEY_free, EC_KEY_copy, EC_KEY_dup, EC_KEY_up_ref,
+EC_KEY_get0_engine,
 EC_KEY_get0_group, EC_KEY_set_group, EC_KEY_get0_private_key,
 EC_KEY_set_private_key, EC_KEY_get0_public_key, EC_KEY_set_public_key,
 EC_KEY_get_conv_form,
@@ -27,6 +28,7 @@ EC_KEY objects
  EC_KEY *EC_KEY_copy(EC_KEY *dst, const EC_KEY *src);
  EC_KEY *EC_KEY_dup(const EC_KEY *src);
  int EC_KEY_up_ref(EC_KEY *key);
+ ENGINE *EC_KEY_get0_engine(const EC_KEY *eckey);
  const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
  int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
  const BIGNUM *EC_KEY_get0_private_key(const EC_KEY *key);
@@ -77,6 +79,9 @@ EC_KEY_dup() creates a new EC_KEY object and copies B<ec_key> into it.
 
 EC_KEY_up_ref() increments the reference count associated with the EC_KEY
 object.
+
+EC_KEY_get0_engine() returns a handle to the ENGINE that has been set for
+this RSA object.
 
 EC_KEY_generate_key() generates a new public and private key for the supplied
 B<eckey> object. B<eckey> must have an EC_GROUP object associated with it
@@ -148,6 +153,8 @@ EC_KEY_get_flags() returns the flags associated with the EC_KEY object as an
 integer.
 
 EC_KEY_copy() returns a pointer to the destination key, or NULL on error.
+
+EC_KEY_get0_engine() returns a pointer to an ENGINE, or NULL if it wasn't set.
 
 EC_KEY_up_ref(), EC_KEY_set_group(), EC_KEY_set_private_key(),
 EC_KEY_set_public_key(), EC_KEY_precompute_mult(), EC_KEY_generate_key(),

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -787,6 +787,12 @@ EC_KEY *EC_KEY_dup(const EC_KEY *src);
  */
 int EC_KEY_up_ref(EC_KEY *key);
 
+/** Returns the ENGINE object of a EC_KEY object
+ *  \param  key  EC_KEY object
+ *  \return the ENGINE object (possibly NULL).
+ */
+ENGINE *EC_KEY_get0_engine(const EC_KEY *eckey);
+
 /** Returns the EC_GROUP object of a EC_KEY object
  *  \param  key  EC_KEY object
  *  \return the EC_GROUP object (possibly NULL).


### PR DESCRIPTION
Just as for DH, DSA and RSA, this gives the engine associated with the
key.

-----

Partially fixes #1779