### PR TITLE
Fix typo in ASYNC_WAIT_CTX_new.pod doc

### DIFF
--- a/doc/man3/ASYNC_WAIT_CTX_new.pod
+++ b/doc/man3/ASYNC_WAIT_CTX_new.pod
@@ -57,7 +57,7 @@ asynchronous engine is being used then normally this call will only ever return
 one fd. If multiple asynchronous engines are being used then more could be
 returned.
 
-The function ASYNC_WAIT_CTX_fds_have_changed() can be used to detect if any fds
+The function ASYNC_WAIT_CTX_get_changed_fds() can be used to detect if any fds
 have changed since the last call time ASYNC_start_job() returned an ASYNC_PAUSE
 result (or since the ASYNC_WAIT_CTX was created if no ASYNC_PAUSE result has
 been received). The B<numaddfds> and B<numdelfds> parameters will be populated


### PR DESCRIPTION
For the function that get the changed fds, it should be
'ASYNC_WAIT_CTX_get_changed_fds()' instead of 'ASYNC_WAIT_CTX_fds_have_changed()'.

Signed-off-by: Paul Yang <paulyang.inf@gmail.com>

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
