### PR TITLE
Test CA names

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -506,15 +506,15 @@ STACK_OF(X509_NAME) *SSL_CTX_get_client_CA_list(const SSL_CTX *ctx)
 STACK_OF(X509_NAME) *SSL_get_client_CA_list(const SSL *s)
 {
     if (!s->server) {           /* we are in the client */
-        if (((s->version >> 8) == SSL3_VERSION_MAJOR) && (s->s3 != NULL))
-            return (s->s3->tmp.ca_names);
+        if (s->s3 != NULL)
+            return s->s3->tmp.ca_names;
         else
-            return (NULL);
+            return NULL;
     } else {
         if (s->client_CA != NULL)
-            return (s->client_CA);
+            return s->client_CA;
         else
-            return (s->ctx->client_CA);
+            return s->ctx->client_CA;
     }
 }
 

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -98,6 +98,10 @@ handshake.
 * ExpectedServerSignType, ExpectedClientSignType - the expected
   signature type used by server or client when signing messages
 
+* ExpectedClientCANames - for client auth list of CA names the server must
+  send. If this is "empty" the list is expected to be empty otherwise it
+  is a file of certificates whose subject names form the list.
+
 ## Configuring the client and server
 
 The client and server configurations can be any valid `SSL_CTX`

--- a/test/build.info
+++ b/test/build.info
@@ -236,7 +236,7 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[ssl_test_ctx_test]=ssl_test_ctx_test.c ssl_test_ctx.c testutil.c test_main_custom.c
   INCLUDE[ssl_test_ctx_test]=.. ../include
-  DEPEND[ssl_test_ctx_test]=../libcrypto
+  DEPEND[ssl_test_ctx_test]=../libcrypto ../libssl
 
   SOURCE[ssl_test]=ssl_test.c ssl_test_ctx.c testutil.c handshake_helper.c test_main_custom.c
   INCLUDE[ssl_test]=.. ../include

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -34,6 +34,7 @@ void HANDSHAKE_RESULT_free(HANDSHAKE_RESULT *result)
     OPENSSL_free(result->server_npn_negotiated);
     OPENSSL_free(result->client_alpn_negotiated);
     OPENSSL_free(result->server_alpn_negotiated);
+    sk_X509_NAME_pop_free(result->client_ca_names, X509_NAME_free);
     OPENSSL_free(result);
 }
 
@@ -1122,6 +1123,7 @@ static HANDSHAKE_RESULT *do_handshake_internal(
     /* API dictates unsigned int rather than size_t. */
     unsigned int proto_len = 0;
     EVP_PKEY *tmp_key;
+    STACK_OF(X509_NAME) *names;
 
     memset(&server_ctx_data, 0, sizeof(server_ctx_data));
     memset(&server2_ctx_data, 0, sizeof(server2_ctx_data));
@@ -1294,6 +1296,12 @@ static HANDSHAKE_RESULT *do_handshake_internal(
 
     SSL_get_peer_signature_type_nid(client.ssl, &ret->server_sign_type);
     SSL_get_peer_signature_type_nid(server.ssl, &ret->client_sign_type);
+
+    names = SSL_get_client_CA_list(client.ssl);
+    if (names == NULL)
+        ret->client_ca_names = NULL;
+    else
+        ret->client_ca_names = SSL_dup_CA_list(names);
 
     ret->server_cert_type = peer_pkey_type(client.ssl);
     ret->client_cert_type = peer_pkey_type(server.ssl);

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -58,6 +58,8 @@ typedef struct handshake_result {
     int client_sign_hash;
     /* client signature type */
     int client_sign_type;
+    /* Client CA names */
+    STACK_OF(X509_NAME) *client_ca_names;
 } HANDSHAKE_RESULT;
 
 HANDSHAKE_RESULT *HANDSHAKE_RESULT_new(void);

--- a/test/ssl-tests/04-client_auth.conf
+++ b/test/ssl-tests/04-client_auth.conf
@@ -1,37 +1,43 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 30
+num_tests = 36
 
 test-0 = 0-server-auth-flex
 test-1 = 1-client-auth-flex-request
 test-2 = 2-client-auth-flex-require-fail
 test-3 = 3-client-auth-flex-require
-test-4 = 4-client-auth-flex-noroot
-test-5 = 5-server-auth-TLSv1
-test-6 = 6-client-auth-TLSv1-request
-test-7 = 7-client-auth-TLSv1-require-fail
-test-8 = 8-client-auth-TLSv1-require
-test-9 = 9-client-auth-TLSv1-noroot
-test-10 = 10-server-auth-TLSv1.1
-test-11 = 11-client-auth-TLSv1.1-request
-test-12 = 12-client-auth-TLSv1.1-require-fail
-test-13 = 13-client-auth-TLSv1.1-require
-test-14 = 14-client-auth-TLSv1.1-noroot
-test-15 = 15-server-auth-TLSv1.2
-test-16 = 16-client-auth-TLSv1.2-request
-test-17 = 17-client-auth-TLSv1.2-require-fail
-test-18 = 18-client-auth-TLSv1.2-require
-test-19 = 19-client-auth-TLSv1.2-noroot
-test-20 = 20-server-auth-DTLSv1
-test-21 = 21-client-auth-DTLSv1-request
-test-22 = 22-client-auth-DTLSv1-require-fail
-test-23 = 23-client-auth-DTLSv1-require
-test-24 = 24-client-auth-DTLSv1-noroot
-test-25 = 25-server-auth-DTLSv1.2
-test-26 = 26-client-auth-DTLSv1.2-request
-test-27 = 27-client-auth-DTLSv1.2-require-fail
-test-28 = 28-client-auth-DTLSv1.2-require
-test-29 = 29-client-auth-DTLSv1.2-noroot
+test-4 = 4-client-auth-flex-require-non-empty-names
+test-5 = 5-client-auth-flex-noroot
+test-6 = 6-server-auth-TLSv1
+test-7 = 7-client-auth-TLSv1-request
+test-8 = 8-client-auth-TLSv1-require-fail
+test-9 = 9-client-auth-TLSv1-require
+test-10 = 10-client-auth-TLSv1-require-non-empty-names
+test-11 = 11-client-auth-TLSv1-noroot
+test-12 = 12-server-auth-TLSv1.1
+test-13 = 13-client-auth-TLSv1.1-request
+test-14 = 14-client-auth-TLSv1.1-require-fail
+test-15 = 15-client-auth-TLSv1.1-require
+test-16 = 16-client-auth-TLSv1.1-require-non-empty-names
+test-17 = 17-client-auth-TLSv1.1-noroot
+test-18 = 18-server-auth-TLSv1.2
+test-19 = 19-client-auth-TLSv1.2-request
+test-20 = 20-client-auth-TLSv1.2-require-fail
+test-21 = 21-client-auth-TLSv1.2-require
+test-22 = 22-client-auth-TLSv1.2-require-non-empty-names
+test-23 = 23-client-auth-TLSv1.2-noroot
+test-24 = 24-server-auth-DTLSv1
+test-25 = 25-client-auth-DTLSv1-request
+test-26 = 26-client-auth-DTLSv1-require-fail
+test-27 = 27-client-auth-DTLSv1-require
+test-28 = 28-client-auth-DTLSv1-require-non-empty-names
+test-29 = 29-client-auth-DTLSv1-noroot
+test-30 = 30-server-auth-DTLSv1.2
+test-31 = 31-client-auth-DTLSv1.2-request
+test-32 = 32-client-auth-DTLSv1.2-require-fail
+test-33 = 33-client-auth-DTLSv1.2-require
+test-34 = 34-client-auth-DTLSv1.2-require-non-empty-names
+test-35 = 35-client-auth-DTLSv1.2-noroot
 # ===========================================================
 
 [0-server-auth-flex]
@@ -129,26 +135,29 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-3]
+ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[4-client-auth-flex-noroot]
-ssl_conf = 4-client-auth-flex-noroot-ssl
+[4-client-auth-flex-require-non-empty-names]
+ssl_conf = 4-client-auth-flex-require-non-empty-names-ssl
 
-[4-client-auth-flex-noroot-ssl]
-server = 4-client-auth-flex-noroot-server
-client = 4-client-auth-flex-noroot-client
+[4-client-auth-flex-require-non-empty-names-ssl]
+server = 4-client-auth-flex-require-non-empty-names-server
+client = 4-client-auth-flex-require-non-empty-names-client
 
-[4-client-auth-flex-noroot-server]
+[4-client-auth-flex-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
 
-[4-client-auth-flex-noroot-client]
+[4-client-auth-flex-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -156,55 +165,55 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-4]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[5-client-auth-flex-noroot]
+ssl_conf = 5-client-auth-flex-noroot-ssl
+
+[5-client-auth-flex-noroot-ssl]
+server = 5-client-auth-flex-noroot-server
+client = 5-client-auth-flex-noroot-client
+
+[5-client-auth-flex-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[5-client-auth-flex-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
 ExpectedResult = ServerFail
 ExpectedServerAlert = UnknownCA
 
 
 # ===========================================================
 
-[5-server-auth-TLSv1]
-ssl_conf = 5-server-auth-TLSv1-ssl
+[6-server-auth-TLSv1]
+ssl_conf = 6-server-auth-TLSv1-ssl
 
-[5-server-auth-TLSv1-ssl]
-server = 5-server-auth-TLSv1-server
-client = 5-server-auth-TLSv1-client
+[6-server-auth-TLSv1-ssl]
+server = 6-server-auth-TLSv1-server
+client = 6-server-auth-TLSv1-client
 
-[5-server-auth-TLSv1-server]
+[6-server-auth-TLSv1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[5-server-auth-TLSv1-client]
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-5]
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[6-client-auth-TLSv1-request]
-ssl_conf = 6-client-auth-TLSv1-request-ssl
-
-[6-client-auth-TLSv1-request-ssl]
-server = 6-client-auth-TLSv1-request-server
-client = 6-client-auth-TLSv1-request-client
-
-[6-client-auth-TLSv1-request-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Request
-
-[6-client-auth-TLSv1-request-client]
+[6-server-auth-TLSv1-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
@@ -217,14 +226,42 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[7-client-auth-TLSv1-require-fail]
-ssl_conf = 7-client-auth-TLSv1-require-fail-ssl
+[7-client-auth-TLSv1-request]
+ssl_conf = 7-client-auth-TLSv1-request-ssl
 
-[7-client-auth-TLSv1-require-fail-ssl]
-server = 7-client-auth-TLSv1-require-fail-server
-client = 7-client-auth-TLSv1-require-fail-client
+[7-client-auth-TLSv1-request-ssl]
+server = 7-client-auth-TLSv1-request-server
+client = 7-client-auth-TLSv1-request-client
 
-[7-client-auth-TLSv1-require-fail-server]
+[7-client-auth-TLSv1-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Request
+
+[7-client-auth-TLSv1-request-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-7]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[8-client-auth-TLSv1-require-fail]
+ssl_conf = 8-client-auth-TLSv1-require-fail-ssl
+
+[8-client-auth-TLSv1-require-fail-ssl]
+server = 8-client-auth-TLSv1-require-fail-server
+client = 8-client-auth-TLSv1-require-fail-client
+
+[8-client-auth-TLSv1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -233,28 +270,28 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[7-client-auth-TLSv1-require-fail-client]
+[8-client-auth-TLSv1-require-fail-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-7]
+[test-8]
 ExpectedResult = ServerFail
 ExpectedServerAlert = HandshakeFailure
 
 
 # ===========================================================
 
-[8-client-auth-TLSv1-require]
-ssl_conf = 8-client-auth-TLSv1-require-ssl
+[9-client-auth-TLSv1-require]
+ssl_conf = 9-client-auth-TLSv1-require-ssl
 
-[8-client-auth-TLSv1-require-ssl]
-server = 8-client-auth-TLSv1-require-server
-client = 8-client-auth-TLSv1-require-client
+[9-client-auth-TLSv1-require-ssl]
+server = 9-client-auth-TLSv1-require-server
+client = 9-client-auth-TLSv1-require-client
 
-[8-client-auth-TLSv1-require-server]
+[9-client-auth-TLSv1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -263,38 +300,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[8-client-auth-TLSv1-require-client]
-Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-8]
-ExpectedClientCertType = RSA
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[9-client-auth-TLSv1-noroot]
-ssl_conf = 9-client-auth-TLSv1-noroot-ssl
-
-[9-client-auth-TLSv1-noroot-ssl]
-server = 9-client-auth-TLSv1-noroot-server
-client = 9-client-auth-TLSv1-noroot-client
-
-[9-client-auth-TLSv1-noroot-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1
-MinProtocol = TLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
-
-[9-client-auth-TLSv1-noroot-client]
+[9-client-auth-TLSv1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
@@ -304,84 +310,93 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-9]
+ExpectedClientCANames = empty
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[10-client-auth-TLSv1-require-non-empty-names]
+ssl_conf = 10-client-auth-TLSv1-require-non-empty-names-ssl
+
+[10-client-auth-TLSv1-require-non-empty-names-ssl]
+server = 10-client-auth-TLSv1-require-non-empty-names-server
+client = 10-client-auth-TLSv1-require-non-empty-names-client
+
+[10-client-auth-TLSv1-require-non-empty-names-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+[10-client-auth-TLSv1-require-non-empty-names-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-10]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[11-client-auth-TLSv1-noroot]
+ssl_conf = 11-client-auth-TLSv1-noroot-ssl
+
+[11-client-auth-TLSv1-noroot-ssl]
+server = 11-client-auth-TLSv1-noroot-server
+client = 11-client-auth-TLSv1-noroot-client
+
+[11-client-auth-TLSv1-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[11-client-auth-TLSv1-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1
+MinProtocol = TLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-11]
 ExpectedResult = ServerFail
 ExpectedServerAlert = UnknownCA
 
 
 # ===========================================================
 
-[10-server-auth-TLSv1.1]
-ssl_conf = 10-server-auth-TLSv1.1-ssl
+[12-server-auth-TLSv1.1]
+ssl_conf = 12-server-auth-TLSv1.1-ssl
 
-[10-server-auth-TLSv1.1-ssl]
-server = 10-server-auth-TLSv1.1-server
-client = 10-server-auth-TLSv1.1-client
+[12-server-auth-TLSv1.1-ssl]
+server = 12-server-auth-TLSv1.1-server
+client = 12-server-auth-TLSv1.1-client
 
-[10-server-auth-TLSv1.1-server]
+[12-server-auth-TLSv1.1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[10-server-auth-TLSv1.1-client]
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-10]
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[11-client-auth-TLSv1.1-request]
-ssl_conf = 11-client-auth-TLSv1.1-request-ssl
-
-[11-client-auth-TLSv1.1-request-ssl]
-server = 11-client-auth-TLSv1.1-request-server
-client = 11-client-auth-TLSv1.1-request-client
-
-[11-client-auth-TLSv1.1-request-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Request
-
-[11-client-auth-TLSv1.1-request-client]
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-11]
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[12-client-auth-TLSv1.1-require-fail]
-ssl_conf = 12-client-auth-TLSv1.1-require-fail-ssl
-
-[12-client-auth-TLSv1.1-require-fail-ssl]
-server = 12-client-auth-TLSv1.1-require-fail-server
-client = 12-client-auth-TLSv1.1-require-fail-client
-
-[12-client-auth-TLSv1.1-require-fail-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-MinProtocol = TLSv1.1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-[12-client-auth-TLSv1.1-require-fail-client]
+[12-server-auth-TLSv1.1-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
@@ -389,20 +404,77 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-12]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[13-client-auth-TLSv1.1-request]
+ssl_conf = 13-client-auth-TLSv1.1-request-ssl
+
+[13-client-auth-TLSv1.1-request-ssl]
+server = 13-client-auth-TLSv1.1-request-server
+client = 13-client-auth-TLSv1.1-request-client
+
+[13-client-auth-TLSv1.1-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Request
+
+[13-client-auth-TLSv1.1-request-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-13]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[14-client-auth-TLSv1.1-require-fail]
+ssl_conf = 14-client-auth-TLSv1.1-require-fail-ssl
+
+[14-client-auth-TLSv1.1-require-fail-ssl]
+server = 14-client-auth-TLSv1.1-require-fail-server
+client = 14-client-auth-TLSv1.1-require-fail-client
+
+[14-client-auth-TLSv1.1-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[14-client-auth-TLSv1.1-require-fail-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-14]
 ExpectedResult = ServerFail
 ExpectedServerAlert = HandshakeFailure
 
 
 # ===========================================================
 
-[13-client-auth-TLSv1.1-require]
-ssl_conf = 13-client-auth-TLSv1.1-require-ssl
+[15-client-auth-TLSv1.1-require]
+ssl_conf = 15-client-auth-TLSv1.1-require-ssl
 
-[13-client-auth-TLSv1.1-require-ssl]
-server = 13-client-auth-TLSv1.1-require-server
-client = 13-client-auth-TLSv1.1-require-client
+[15-client-auth-TLSv1.1-require-ssl]
+server = 15-client-auth-TLSv1.1-require-server
+client = 15-client-auth-TLSv1.1-require-client
 
-[13-client-auth-TLSv1.1-require-server]
+[15-client-auth-TLSv1.1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -411,7 +483,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[13-client-auth-TLSv1.1-require-client]
+[15-client-auth-TLSv1.1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -420,29 +492,32 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-13]
+[test-15]
+ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[14-client-auth-TLSv1.1-noroot]
-ssl_conf = 14-client-auth-TLSv1.1-noroot-ssl
+[16-client-auth-TLSv1.1-require-non-empty-names]
+ssl_conf = 16-client-auth-TLSv1.1-require-non-empty-names-ssl
 
-[14-client-auth-TLSv1.1-noroot-ssl]
-server = 14-client-auth-TLSv1.1-noroot-server
-client = 14-client-auth-TLSv1.1-noroot-client
+[16-client-auth-TLSv1.1-require-non-empty-names-ssl]
+server = 16-client-auth-TLSv1.1-require-non-empty-names-server
+client = 16-client-auth-TLSv1.1-require-non-empty-names-client
 
-[14-client-auth-TLSv1.1-noroot-server]
+[16-client-auth-TLSv1.1-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
 
-[14-client-auth-TLSv1.1-noroot-client]
+[16-client-auth-TLSv1.1-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
@@ -451,48 +526,80 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-14]
+[test-16]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[17-client-auth-TLSv1.1-noroot]
+ssl_conf = 17-client-auth-TLSv1.1-noroot-ssl
+
+[17-client-auth-TLSv1.1-noroot-ssl]
+server = 17-client-auth-TLSv1.1-noroot-server
+client = 17-client-auth-TLSv1.1-noroot-client
+
+[17-client-auth-TLSv1.1-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[17-client-auth-TLSv1.1-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+MinProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-17]
 ExpectedResult = ServerFail
 ExpectedServerAlert = UnknownCA
 
 
 # ===========================================================
 
-[15-server-auth-TLSv1.2]
-ssl_conf = 15-server-auth-TLSv1.2-ssl
+[18-server-auth-TLSv1.2]
+ssl_conf = 18-server-auth-TLSv1.2-ssl
 
-[15-server-auth-TLSv1.2-ssl]
-server = 15-server-auth-TLSv1.2-server
-client = 15-server-auth-TLSv1.2-client
+[18-server-auth-TLSv1.2-ssl]
+server = 18-server-auth-TLSv1.2-server
+client = 18-server-auth-TLSv1.2-client
 
-[15-server-auth-TLSv1.2-server]
+[18-server-auth-TLSv1.2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[15-server-auth-TLSv1.2-client]
+[18-server-auth-TLSv1.2-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-15]
+[test-18]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[16-client-auth-TLSv1.2-request]
-ssl_conf = 16-client-auth-TLSv1.2-request-ssl
+[19-client-auth-TLSv1.2-request]
+ssl_conf = 19-client-auth-TLSv1.2-request-ssl
 
-[16-client-auth-TLSv1.2-request-ssl]
-server = 16-client-auth-TLSv1.2-request-server
-client = 16-client-auth-TLSv1.2-request-client
+[19-client-auth-TLSv1.2-request-ssl]
+server = 19-client-auth-TLSv1.2-request-server
+client = 19-client-auth-TLSv1.2-request-client
 
-[16-client-auth-TLSv1.2-request-server]
+[19-client-auth-TLSv1.2-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -500,27 +607,27 @@ MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
-[16-client-auth-TLSv1.2-request-client]
+[19-client-auth-TLSv1.2-request-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-16]
+[test-19]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[17-client-auth-TLSv1.2-require-fail]
-ssl_conf = 17-client-auth-TLSv1.2-require-fail-ssl
+[20-client-auth-TLSv1.2-require-fail]
+ssl_conf = 20-client-auth-TLSv1.2-require-fail-ssl
 
-[17-client-auth-TLSv1.2-require-fail-ssl]
-server = 17-client-auth-TLSv1.2-require-fail-server
-client = 17-client-auth-TLSv1.2-require-fail-client
+[20-client-auth-TLSv1.2-require-fail-ssl]
+server = 20-client-auth-TLSv1.2-require-fail-server
+client = 20-client-auth-TLSv1.2-require-fail-client
 
-[17-client-auth-TLSv1.2-require-fail-server]
+[20-client-auth-TLSv1.2-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -529,28 +636,28 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[17-client-auth-TLSv1.2-require-fail-client]
+[20-client-auth-TLSv1.2-require-fail-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-17]
+[test-20]
 ExpectedResult = ServerFail
 ExpectedServerAlert = HandshakeFailure
 
 
 # ===========================================================
 
-[18-client-auth-TLSv1.2-require]
-ssl_conf = 18-client-auth-TLSv1.2-require-ssl
+[21-client-auth-TLSv1.2-require]
+ssl_conf = 21-client-auth-TLSv1.2-require-ssl
 
-[18-client-auth-TLSv1.2-require-ssl]
-server = 18-client-auth-TLSv1.2-require-server
-client = 18-client-auth-TLSv1.2-require-client
+[21-client-auth-TLSv1.2-require-ssl]
+server = 21-client-auth-TLSv1.2-require-server
+client = 21-client-auth-TLSv1.2-require-client
 
-[18-client-auth-TLSv1.2-require-server]
+[21-client-auth-TLSv1.2-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = SHA256+RSA
@@ -560,7 +667,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[18-client-auth-TLSv1.2-require-client]
+[21-client-auth-TLSv1.2-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -569,7 +676,8 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-18]
+[test-21]
+ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
 ExpectedClientSignType = RSA
@@ -578,22 +686,25 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[19-client-auth-TLSv1.2-noroot]
-ssl_conf = 19-client-auth-TLSv1.2-noroot-ssl
+[22-client-auth-TLSv1.2-require-non-empty-names]
+ssl_conf = 22-client-auth-TLSv1.2-require-non-empty-names-ssl
 
-[19-client-auth-TLSv1.2-noroot-ssl]
-server = 19-client-auth-TLSv1.2-noroot-server
-client = 19-client-auth-TLSv1.2-noroot-client
+[22-client-auth-TLSv1.2-require-non-empty-names-ssl]
+server = 22-client-auth-TLSv1.2-require-non-empty-names-server
+client = 22-client-auth-TLSv1.2-require-non-empty-names-client
 
-[19-client-auth-TLSv1.2-noroot-server]
+[22-client-auth-TLSv1.2-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ClientSignatureAlgorithms = SHA256+RSA
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
 
-[19-client-auth-TLSv1.2-noroot-client]
+[22-client-auth-TLSv1.2-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
@@ -602,184 +713,94 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-19]
-ExpectedResult = ServerFail
-ExpectedServerAlert = UnknownCA
-
-
-# ===========================================================
-
-[20-server-auth-DTLSv1]
-ssl_conf = 20-server-auth-DTLSv1-ssl
-
-[20-server-auth-DTLSv1-ssl]
-server = 20-server-auth-DTLSv1-server
-client = 20-server-auth-DTLSv1-client
-
-[20-server-auth-DTLSv1-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[20-server-auth-DTLSv1-client]
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-20]
+[test-22]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedClientSignHash = SHA256
+ExpectedClientSignType = RSA
 ExpectedResult = Success
-Method = DTLS
 
 
 # ===========================================================
 
-[21-client-auth-DTLSv1-request]
-ssl_conf = 21-client-auth-DTLSv1-request-ssl
+[23-client-auth-TLSv1.2-noroot]
+ssl_conf = 23-client-auth-TLSv1.2-noroot-ssl
 
-[21-client-auth-DTLSv1-request-ssl]
-server = 21-client-auth-DTLSv1-request-server
-client = 21-client-auth-DTLSv1-request-client
+[23-client-auth-TLSv1.2-noroot-ssl]
+server = 23-client-auth-TLSv1.2-noroot-server
+client = 23-client-auth-TLSv1.2-noroot-client
 
-[21-client-auth-DTLSv1-request-server]
+[23-client-auth-TLSv1.2-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Request
-
-[21-client-auth-DTLSv1-request-client]
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-21]
-ExpectedResult = Success
-Method = DTLS
-
-
-# ===========================================================
-
-[22-client-auth-DTLSv1-require-fail]
-ssl_conf = 22-client-auth-DTLSv1-require-fail-ssl
-
-[22-client-auth-DTLSv1-require-fail-ssl]
-server = 22-client-auth-DTLSv1-require-fail-server
-client = 22-client-auth-DTLSv1-require-fail-client
-
-[22-client-auth-DTLSv1-require-fail-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[22-client-auth-DTLSv1-require-fail-client]
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-22]
-ExpectedResult = ServerFail
-ExpectedServerAlert = HandshakeFailure
-Method = DTLS
-
-
-# ===========================================================
-
-[23-client-auth-DTLSv1-require]
-ssl_conf = 23-client-auth-DTLSv1-require-ssl
-
-[23-client-auth-DTLSv1-require-ssl]
-server = 23-client-auth-DTLSv1-require-server
-client = 23-client-auth-DTLSv1-require-client
-
-[23-client-auth-DTLSv1-require-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Request
-
-[23-client-auth-DTLSv1-require-client]
+[23-client-auth-TLSv1.2-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
-MaxProtocol = DTLSv1
-MinProtocol = DTLSv1
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-23]
-ExpectedClientCertType = RSA
+ExpectedResult = ServerFail
+ExpectedServerAlert = UnknownCA
+
+
+# ===========================================================
+
+[24-server-auth-DTLSv1]
+ssl_conf = 24-server-auth-DTLSv1-ssl
+
+[24-server-auth-DTLSv1-ssl]
+server = 24-server-auth-DTLSv1-server
+client = 24-server-auth-DTLSv1-client
+
+[24-server-auth-DTLSv1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[24-server-auth-DTLSv1-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-24]
 ExpectedResult = Success
 Method = DTLS
 
 
 # ===========================================================
 
-[24-client-auth-DTLSv1-noroot]
-ssl_conf = 24-client-auth-DTLSv1-noroot-ssl
+[25-client-auth-DTLSv1-request]
+ssl_conf = 25-client-auth-DTLSv1-request-ssl
 
-[24-client-auth-DTLSv1-noroot-ssl]
-server = 24-client-auth-DTLSv1-noroot-server
-client = 24-client-auth-DTLSv1-noroot-client
+[25-client-auth-DTLSv1-request-ssl]
+server = 25-client-auth-DTLSv1-request-server
+client = 25-client-auth-DTLSv1-request-client
 
-[24-client-auth-DTLSv1-noroot-server]
+[25-client-auth-DTLSv1-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
+VerifyMode = Request
 
-[24-client-auth-DTLSv1-noroot-client]
-Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+[25-client-auth-DTLSv1-request-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-24]
-ExpectedResult = ServerFail
-ExpectedServerAlert = UnknownCA
-Method = DTLS
-
-
-# ===========================================================
-
-[25-server-auth-DTLSv1.2]
-ssl_conf = 25-server-auth-DTLSv1.2-ssl
-
-[25-server-auth-DTLSv1.2-ssl]
-server = 25-server-auth-DTLSv1.2-server
-client = 25-server-auth-DTLSv1.2-client
-
-[25-server-auth-DTLSv1.2-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[25-server-auth-DTLSv1.2-client]
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -790,59 +811,30 @@ Method = DTLS
 
 # ===========================================================
 
-[26-client-auth-DTLSv1.2-request]
-ssl_conf = 26-client-auth-DTLSv1.2-request-ssl
+[26-client-auth-DTLSv1-require-fail]
+ssl_conf = 26-client-auth-DTLSv1-require-fail-ssl
 
-[26-client-auth-DTLSv1.2-request-ssl]
-server = 26-client-auth-DTLSv1.2-request-server
-client = 26-client-auth-DTLSv1.2-request-client
+[26-client-auth-DTLSv1-require-fail-ssl]
+server = 26-client-auth-DTLSv1-require-fail-server
+client = 26-client-auth-DTLSv1-require-fail-client
 
-[26-client-auth-DTLSv1.2-request-server]
+[26-client-auth-DTLSv1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Request
-
-[26-client-auth-DTLSv1.2-request-client]
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-26]
-ExpectedResult = Success
-Method = DTLS
-
-
-# ===========================================================
-
-[27-client-auth-DTLSv1.2-require-fail]
-ssl_conf = 27-client-auth-DTLSv1.2-require-fail-ssl
-
-[27-client-auth-DTLSv1.2-require-fail-ssl]
-server = 27-client-auth-DTLSv1.2-require-fail-server
-client = 27-client-auth-DTLSv1.2-require-fail-client
-
-[27-client-auth-DTLSv1.2-require-fail-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[27-client-auth-DTLSv1.2-require-fail-client]
+[26-client-auth-DTLSv1-require-fail-client]
 CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
-MinProtocol = DTLSv1.2
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-27]
+[test-26]
 ExpectedResult = ServerFail
 ExpectedServerAlert = HandshakeFailure
 Method = DTLS
@@ -850,14 +842,203 @@ Method = DTLS
 
 # ===========================================================
 
-[28-client-auth-DTLSv1.2-require]
-ssl_conf = 28-client-auth-DTLSv1.2-require-ssl
+[27-client-auth-DTLSv1-require]
+ssl_conf = 27-client-auth-DTLSv1-require-ssl
 
-[28-client-auth-DTLSv1.2-require-ssl]
-server = 28-client-auth-DTLSv1.2-require-server
-client = 28-client-auth-DTLSv1.2-require-client
+[27-client-auth-DTLSv1-require-ssl]
+server = 27-client-auth-DTLSv1-require-server
+client = 27-client-auth-DTLSv1-require-client
 
-[28-client-auth-DTLSv1.2-require-server]
+[27-client-auth-DTLSv1-require-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+[27-client-auth-DTLSv1-require-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-27]
+ExpectedClientCANames = empty
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[28-client-auth-DTLSv1-require-non-empty-names]
+ssl_conf = 28-client-auth-DTLSv1-require-non-empty-names-ssl
+
+[28-client-auth-DTLSv1-require-non-empty-names-ssl]
+server = 28-client-auth-DTLSv1-require-non-empty-names-server
+client = 28-client-auth-DTLSv1-require-non-empty-names-client
+
+[28-client-auth-DTLSv1-require-non-empty-names-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
+
+[28-client-auth-DTLSv1-require-non-empty-names-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-28]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[29-client-auth-DTLSv1-noroot]
+ssl_conf = 29-client-auth-DTLSv1-noroot-ssl
+
+[29-client-auth-DTLSv1-noroot-ssl]
+server = 29-client-auth-DTLSv1-noroot-server
+client = 29-client-auth-DTLSv1-noroot-client
+
+[29-client-auth-DTLSv1-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[29-client-auth-DTLSv1-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1
+MinProtocol = DTLSv1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-29]
+ExpectedResult = ServerFail
+ExpectedServerAlert = UnknownCA
+Method = DTLS
+
+
+# ===========================================================
+
+[30-server-auth-DTLSv1.2]
+ssl_conf = 30-server-auth-DTLSv1.2-ssl
+
+[30-server-auth-DTLSv1.2-ssl]
+server = 30-server-auth-DTLSv1.2-server
+client = 30-server-auth-DTLSv1.2-client
+
+[30-server-auth-DTLSv1.2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[30-server-auth-DTLSv1.2-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-30]
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[31-client-auth-DTLSv1.2-request]
+ssl_conf = 31-client-auth-DTLSv1.2-request-ssl
+
+[31-client-auth-DTLSv1.2-request-ssl]
+server = 31-client-auth-DTLSv1.2-request-server
+client = 31-client-auth-DTLSv1.2-request-client
+
+[31-client-auth-DTLSv1.2-request-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Request
+
+[31-client-auth-DTLSv1.2-request-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-31]
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[32-client-auth-DTLSv1.2-require-fail]
+ssl_conf = 32-client-auth-DTLSv1.2-require-fail-ssl
+
+[32-client-auth-DTLSv1.2-require-fail-ssl]
+server = 32-client-auth-DTLSv1.2-require-fail-server
+client = 32-client-auth-DTLSv1.2-require-fail-client
+
+[32-client-auth-DTLSv1.2-require-fail-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[32-client-auth-DTLSv1.2-require-fail-client]
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-32]
+ExpectedResult = ServerFail
+ExpectedServerAlert = HandshakeFailure
+Method = DTLS
+
+
+# ===========================================================
+
+[33-client-auth-DTLSv1.2-require]
+ssl_conf = 33-client-auth-DTLSv1.2-require-ssl
+
+[33-client-auth-DTLSv1.2-require-ssl]
+server = 33-client-auth-DTLSv1.2-require-server
+client = 33-client-auth-DTLSv1.2-require-client
+
+[33-client-auth-DTLSv1.2-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
@@ -866,7 +1047,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[28-client-auth-DTLSv1.2-require-client]
+[33-client-auth-DTLSv1.2-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
@@ -875,7 +1056,8 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-28]
+[test-33]
+ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedResult = Success
 Method = DTLS
@@ -883,22 +1065,24 @@ Method = DTLS
 
 # ===========================================================
 
-[29-client-auth-DTLSv1.2-noroot]
-ssl_conf = 29-client-auth-DTLSv1.2-noroot-ssl
+[34-client-auth-DTLSv1.2-require-non-empty-names]
+ssl_conf = 34-client-auth-DTLSv1.2-require-non-empty-names-ssl
 
-[29-client-auth-DTLSv1.2-noroot-ssl]
-server = 29-client-auth-DTLSv1.2-noroot-server
-client = 29-client-auth-DTLSv1.2-noroot-client
+[34-client-auth-DTLSv1.2-require-non-empty-names-ssl]
+server = 34-client-auth-DTLSv1.2-require-non-empty-names-server
+client = 34-client-auth-DTLSv1.2-require-non-empty-names-client
 
-[29-client-auth-DTLSv1.2-noroot-server]
+[34-client-auth-DTLSv1.2-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyMode = Require
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Request
 
-[29-client-auth-DTLSv1.2-noroot-client]
+[34-client-auth-DTLSv1.2-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
@@ -907,7 +1091,40 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-29]
+[test-34]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedResult = Success
+Method = DTLS
+
+
+# ===========================================================
+
+[35-client-auth-DTLSv1.2-noroot]
+ssl_conf = 35-client-auth-DTLSv1.2-noroot-ssl
+
+[35-client-auth-DTLSv1.2-noroot-ssl]
+server = 35-client-auth-DTLSv1.2-noroot-server
+client = 35-client-auth-DTLSv1.2-noroot-client
+
+[35-client-auth-DTLSv1.2-noroot-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyMode = Require
+
+[35-client-auth-DTLSv1.2-noroot-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-35]
 ExpectedResult = ServerFail
 ExpectedServerAlert = UnknownCA
 Method = DTLS

--- a/test/ssl-tests/04-client_auth.conf.in
+++ b/test/ssl-tests/04-client_auth.conf.in
@@ -119,6 +119,34 @@ sub generate_tests() {
                     "ExpectedClientCertType" => "RSA",
                     "ExpectedClientSignType" => $clisigtype,
                     "ExpectedClientSignHash" => $clihash,
+                    "ExpectedClientCANames" => "empty",
+                    "Method" => $method,
+                },
+            };
+
+            # Successful handshake with client authentication non-empty names
+            push @tests, {
+                name => "client-auth-${protocol_name}-require-non-empty-names",
+                server => {
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
+                    "ClientSignatureAlgorithms" => $clisigalgs,
+                    "ClientCAFile" => test_pem("root-cert.pem"),
+                    "VerifyCAFile" => test_pem("root-cert.pem"),
+                    "VerifyMode" => "Request",
+                },
+                client => {
+                    "MinProtocol" => $protocol,
+                    "MaxProtocol" => $protocol,
+                    "Certificate" => test_pem("ee-client-chain.pem"),
+                    "PrivateKey"  => test_pem("ee-key.pem"),
+                },
+                test   => {
+                    "ExpectedResult" => "Success",
+                    "ExpectedClientCertType" => "RSA",
+                    "ExpectedClientSignType" => $clisigtype,
+                    "ExpectedClientSignHash" => $clihash,
+                    "ExpectedClientCANames" => test_pem("root-cert.pem"),
                     "Method" => $method,
                 },
             };

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -316,6 +316,24 @@ my @tests_tls_1_3 = (
             "ExpectedClientCertType" => "RSA",
             "ExpectedClientSignHash" => "SHA256",
             "ExpectedClientSignType" => "RSA-PSS",
+            "ExpectedClientCANames" => "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names",
+        server => {
+            "ClientSignatureAlgorithms" => "PSS+SHA256",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "ClientCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => $client_tls_1_3,
+        test   => {
+            "ExpectedClientCertType" => "RSA",
+            "ExpectedClientSignHash" => "SHA256",
+            "ExpectedClientSignType" => "RSA-PSS",
+            "ExpectedClientCANames" => test_pem("root-cert.pem"),
             "ExpectedResult" => "Success"
         },
     },

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -255,6 +255,62 @@ static int check_client_sign_type(HANDSHAKE_RESULT *result,
                      result->client_sign_type);
 }
 
+static void print_ca_names(STACK_OF(X509_NAME) *names)
+{
+    BIO *err;
+    int i;
+
+    if (names == NULL || sk_X509_NAME_num(names) == 0) {
+        fprintf(stderr, "    <empty>\n");
+        return;
+    }
+    err = BIO_new_fp(stderr, BIO_NOCLOSE);
+    for (i = 0; i < sk_X509_NAME_num(names); i++) {
+        X509_NAME_print_ex(err, sk_X509_NAME_value(names, i), 4,
+                           XN_FLAG_ONELINE);
+        BIO_puts(err, "\n");
+    }
+    BIO_free(err);
+}
+
+static int check_ca_names(const char *name,
+                          STACK_OF(X509_NAME) *expected_names,
+                          STACK_OF(X509_NAME) *names)
+{
+    int i;
+
+    if (expected_names == NULL)
+        return 1;
+    if (names == NULL || sk_X509_NAME_num(names) == 0) {
+        if (sk_X509_NAME_num(expected_names) == 0)
+            return 1;
+        goto err;
+    }
+    if (sk_X509_NAME_num(names) != sk_X509_NAME_num(expected_names))
+        goto err;
+    for (i = 0; i < sk_X509_NAME_num(names); i++) {
+        if (X509_NAME_cmp(sk_X509_NAME_value(names, i),
+                          sk_X509_NAME_value(expected_names, i)) != 0) {
+            goto err;
+        }
+    }
+    return 1;
+    err:
+    fprintf(stderr, "%s: list mismatch\nExpected Names:\n", name);
+    print_ca_names(expected_names);
+    fprintf(stderr, "Received Names:\n");
+    print_ca_names(names);
+    return 0;
+}
+
+static int check_client_ca_names(HANDSHAKE_RESULT *result,
+                                 SSL_TEST_CTX *test_ctx)
+{
+    return check_ca_names("Client CA names",
+                          test_ctx->expected_client_ca_names,
+                          result->client_ca_names);
+}
+
 /*
  * This could be further simplified by constructing an expected
  * HANDSHAKE_RESULT, and implementing comparison methods for
@@ -283,6 +339,7 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
         ret &= check_client_cert_type(result, test_ctx);
         ret &= check_client_sign_hash(result, test_ctx);
         ret &= check_client_sign_type(result, test_ctx);
+        ret &= check_client_ca_names(result, test_ctx);
     }
     return ret;
 }

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -535,6 +535,22 @@ __owur static int parse_expected_client_sign_hash(SSL_TEST_CTX *test_ctx,
                                     value);
 }
 
+__owur static int parse_expected_ca_names(STACK_OF(X509_NAME) **pnames,
+                                          const char *value)
+{
+    if (value == NULL)
+        return 0;
+    if (!strcmp(value, "empty"))
+        *pnames = sk_X509_NAME_new_null();
+    else
+        *pnames = SSL_load_client_CA_file(value);
+    return *pnames != NULL;
+}
+__owur static int parse_expected_client_ca_names(SSL_TEST_CTX *test_ctx,
+                                                 const char *value)
+{
+    return parse_expected_ca_names(&test_ctx->expected_client_ca_names, value);
+}
 
 /* Known test options and their corresponding parse methods. */
 
@@ -567,6 +583,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedClientCertType", &parse_expected_client_cert_type },
     { "ExpectedClientSignHash", &parse_expected_client_sign_hash },
     { "ExpectedClientSignType", &parse_expected_client_sign_type },
+    { "ExpectedClientCANames", &parse_expected_client_ca_names },
 };
 
 /* Nested client options. */
@@ -644,6 +661,7 @@ void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx)
     ssl_test_ctx_free_extra_data(ctx);
     OPENSSL_free(ctx->expected_npn_protocol);
     OPENSSL_free(ctx->expected_alpn_protocol);
+    sk_X509_NAME_pop_free(ctx->expected_client_ca_names, X509_NAME_free);
     OPENSSL_free(ctx);
 }
 

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -194,6 +194,8 @@ typedef struct {
     int expected_client_sign_hash;
     /* Expected client signature type */
     int expected_client_sign_type;
+    /* Expected CA names for client auth */
+    STACK_OF(X509_NAME) *expected_client_ca_names;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This checks the value of the CA names sent during a certificate request matches the expected value.

The code is a little more general purpose because it will need to be extended for the TLS 1.3 draft-19 and #2918 where CA names can be sent during ClientHello.