### PR TITLE
Fix some undefined behaviour in stack test

### DIFF
--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -57,6 +57,7 @@ static int int_compare(const int *const *a, const int *const *b)
 static int test_int_stack(void)
 {
     static int v[] = { 1, 2, -4, 16, 999, 1, -173, 1, 9 };
+    static int notpresent = -1;
     const int n = OSSL_NELEM(v);
     static struct {
         int value;
@@ -108,18 +109,26 @@ static int test_int_stack(void)
         }
 
     /* find unsorted -- the pointers are compared */
-    for (i = 0; i < n_finds; i++)
-        if (sk_sint_find(s, v + finds[i].unsorted) != finds[i].unsorted) {
+    for (i = 0; i < n_finds; i++) {
+        int *val = (finds[i].unsorted == -1) ? &notpresent
+                                             : v + finds[i].unsorted;
+
+        if (sk_sint_find(s, val) != finds[i].unsorted) {
             fprintf(stderr, "test int unsorted find %d\n", i);
             goto end;
         }
+    }
 
     /* find_ex unsorted */
-    for (i = 0; i < n_finds; i++)
-        if (sk_sint_find_ex(s, v + finds[i].unsorted) != finds[i].unsorted) {
+    for (i = 0; i < n_finds; i++) {
+        int *val = (finds[i].unsorted == -1) ? &notpresent
+                                             : v + finds[i].unsorted;
+
+        if (sk_sint_find_ex(s, val) != finds[i].unsorted) {
             fprintf(stderr, "test int unsorted find_ex %d\n", i);
             goto end;
         }
+    }
 
     /* sorting */
     if (sk_sint_is_sorted(s)) {


### PR DESCRIPTION
At one point the stack was passing a pointer of the element *before* an
array which is undefined.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
