### PR TITLE
Fix no-dtls builds

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -138,8 +138,13 @@ static const char *session_id_prefix = NULL;
 #ifndef OPENSSL_NO_DTLS
 static int enable_timeouts = 0;
 static long socket_mtu;
-static int dtlslisten = 0;
 #endif
+
+/*
+ * We define this but make it always be 0 in no-dtls builds to simplify the
+ * code.
+ */
+static int dtlslisten = 0;
 
 static int early_data = 0;
 


### PR DESCRIPTION
Commits f2ff1432f in master and 14d4d7eda in 1.1.0 broke the no-dtls build
by moving the position of a "#endif" for OPENSSL_NO_DTLS in a change
which is otherwise unrelated to DTLS. This puts it back to where it was.

