### PR TITLE
"any" instead of "and" in x509v3 docs

### DIFF
--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -165,7 +165,7 @@ registered ID: OBJECT IDENTIFIER), B<IP> (an IP address), B<dirName>
 (a distinguished name) and otherName.
 
 The email option include a special 'copy' value. This will automatically
-include and email addresses contained in the certificate subject name in
+include any email addresses contained in the certificate subject name in
 the extension.
 
 The IP address used in the B<IP> options can be in either IPv4 or IPv6 format.


### PR DESCRIPTION
##### Checklist
- [x] documentation is added or updated

##### Description of change

Very minor documentation fix - this "and" should be an "any".

Fixed in LibreSSL's docs: http://man.openbsd.org/man5/x509v3.cnf.5#Subject_alternative_name

I assume this is so tiny I don't need to sign a CLA.
CLA: trivial