### PR TITLE
Fix the signature of CRYPT_EX_dup

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -96,7 +96,7 @@ static void dummy_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
 }
 
 static int dummy_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                     void *from_d, int idx,
+                     void **from_d, int idx,
                      long argl, void *argp)
 {
     return 1;

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -71,9 +71,8 @@ static void ui_new_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 }
 
 static int ui_dup_method_data(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                              void *from_d, int idx, long argl, void *argp)
+                              void **pptr, int idx, long argl, void *argp)
 {
-    void **pptr = (void **)from_d;
     if (*pptr != NULL)
         *pptr = OPENSSL_memdup(*pptr, sizeof(struct pem_password_cb_data));
     return 1;

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -23,7 +23,7 @@ CRYPTO_free_ex_data, CRYPTO_new_ex_data
  typedef void CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                              int idx, long argl, void *argp);
  typedef int CRYPTO_EX_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                           void *from_d, int idx, long argl, void *argp);
+                           void **from_d, int idx, long argl, void *argp);
 
  int CRYPTO_new_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
 
@@ -140,10 +140,8 @@ dup_func() is called when a structure is being copied.  This is only done
 for B<SSL>, B<SSL_SESSION>, B<EC_KEY> objects and B<BIO> chains via
 BIO_dup_chain().  The B<to> and B<from> parameters
 are pointers to the destination and source B<CRYPTO_EX_DATA> structures,
-respectively.  The B<from_d> parameter needs to be cast to a B<void **pptr>
-as the API has currently the wrong signature; that will be changed in a
-future version.  The B<*pptr> is a pointer to the source exdata.
-When the dup_func() returns, the value in B<*pptr> is copied to the
+respectively.  The B<*from_d> parameter is a pointer to the source exdata.
+When the dup_func() returns, the value in B<*from_d> is copied to the
 destination ex_data.  If the pointer contained in B<*pptr> is not modified
 by the dup_func(), then both B<to> and B<from> will point to the same data.
 The B<idx>, B<argl> and B<argp> parameters are as described for the other

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -163,6 +163,8 @@ dup_func() should return 0 for failure and 1 for success.
 =head1 HISTORY
 
 CRYPTO_alloc_ex_data() was added in OpenSSL 3.0.
+The signature of the dup_func() callback was changed in OpenSSL 3.0 to use the
+type B<void **> for B<from_d>.  Previously this parameter was of type B<void *>.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -201,7 +201,7 @@ typedef void CRYPTO_EX_new (void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 typedef void CRYPTO_EX_free (void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                              int idx, long argl, void *argp);
 typedef int CRYPTO_EX_dup (CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                           void *from_d, int idx, long argl, void *argp);
+                           void **from_d, int idx, long argl, void *argp);
 __owur int CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
                                    CRYPTO_EX_new *new_func,
                                    CRYPTO_EX_dup *dup_func,

--- a/test/exdatatest.c
+++ b/test/exdatatest.c
@@ -37,7 +37,7 @@ static void exnew(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 }
 
 static int exdup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-          void *from_d, int idx, long argl, void *argp)
+          void **from_d, int idx, long argl, void *argp)
 {
     if (!TEST_int_eq(idx, saved_idx)
         || !TEST_long_eq(argl, saved_argl)
@@ -87,7 +87,7 @@ static void exnew2(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 }
 
 static int exdup2(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-          void *from_d, int idx, long argl, void *argp)
+          void **from_d, int idx, long argl, void *argp)
 {
     MYOBJ_EX_DATA **update_ex_data = (MYOBJ_EX_DATA**)from_d;
     MYOBJ_EX_DATA *ex_data = NULL;


### PR DESCRIPTION
This fixes a strict aliasing issue in ui_dup_method_data.

And fix the error handling in CRYPTO_dup_ex_data.

I have split the error handling fix in an extra commit,
as the function signature can probably only be changed
in the master branch, while the error handling should
be fixed in 1.1.0 as well.  I will need another PR for 1.0.2.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
