### PR TITLE
Fix a few internals tests

### DIFF
--- a/test/recipes/03-test_internal_chacha.t
+++ b/test/recipes/03-test_internal_chacha.t
@@ -16,4 +16,4 @@ setup("test_internal_chacha");
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 
-simple_test("test_internal_chacha", "chacha_internal_test", "mdc2");
+simple_test("test_internal_chacha", "chacha_internal_test", "chacha");

--- a/test/recipes/03-test_internal_poly1305.t
+++ b/test/recipes/03-test_internal_poly1305.t
@@ -16,4 +16,4 @@ setup("test_internal_poly1305");
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 
-simple_test("test_internal_poly1305", "poly1305_internal_test", "mdc2");
+simple_test("test_internal_poly1305", "poly1305_internal_test", "poly1305");

--- a/test/recipes/03-test_internal_siphash.t
+++ b/test/recipes/03-test_internal_siphash.t
@@ -16,4 +16,4 @@ setup("test_internal_siphash");
 plan skip_all => "This test is unsupported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 
-simple_test("test_internal_siphash", "siphash_internal_test", "mdc2");
+simple_test("test_internal_siphash", "siphash_internal_test", "siphash");


### PR DESCRIPTION
The internals tests for chacha, poly1305 and siphash were erroneously
made conditional on if mdc2 was enabled.  Corrected to depend on the
correct algorithms being enabled instead.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

