### PR TITLE
Fix docs for X509_CRL_get0_by_serial() and X509_CRL_get0_by_cert()

### DIFF
--- a/doc/man3/X509_CRL_get0_by_serial.pod
+++ b/doc/man3/X509_CRL_get0_by_serial.pod
@@ -70,7 +70,10 @@ in turn using sk_X509_REVOKED_value().
 
 =head1 RETURN VALUES
 
-X509_CRL_get0_by_serial(), X509_CRL_get0_by_cert(),
+X509_CRL_get0_by_serial() and X509_CRL_get0_by_cert() return 0 for failure,
+1 on success except if the revoked entry has the reason C<removeFromCRL> (8),
+in which case 2 is returned.
+
 X509_REVOKED_set_serialNumber(), X509_REVOKED_set_revocationDate(),
 X509_CRL_add0_revoked() and X509_CRL_sort() return 1 for success and 0 for
 failure.


### PR DESCRIPTION
They both return 2 when the revoked entry that's found has the reason
removeFromCRL.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
