### PR TITLE
modes/ocb128.c: fix misaligned access in ILP32 builds on 64-bit processors.

### DIFF
--- a/crypto/modes/ocb128.c
+++ b/crypto/modes/ocb128.c
@@ -294,7 +294,7 @@ int CRYPTO_ocb128_aad(OCB128_CONTEXT *ctx, const unsigned char *aad,
 
         /* Sum_i = Sum_{i-1} xor ENCIPHER(K, A_i xor Offset_i) */
         aad_block = (OCB_BLOCK *)(aad + ((i - ctx->blocks_hashed - 1) * 16));
-        ocb_block16_xor(&ctx->offset_aad, aad_block, &tmp1);
+        ocb_block16_xor_misaligned(&ctx->offset_aad, aad_block, &tmp1);
         ctx->encrypt(tmp1.c, tmp2.c, ctx->keyenc);
         ocb_block16_xor(&ctx->sum, &tmp2, &ctx->sum);
     }


### PR DESCRIPTION
One could have fixed the problem by arranging 64-bit alignment of
EVP_AES_OCB_CTX.aad_buf in evp/e_aes.c, but CRYPTO_ocb128_aad
prototype doesn't imply alignment and we have to honour it.

Fixes #2985.

I'm adding WIP, because I want to see if it would be appropriate to omit some of the casts. This commit is bare minimum and does fix the problem. So that there either be additional commit or this one alone...