### PR TITLE
Fix resume after HRR

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1242,11 +1242,18 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
          * ClientHello - which we don't want - so we need to take that bit off.
          */
         if (s->server) {
-            if (hdatalen < s->init_num + SSL3_HM_HEADER_LENGTH) {
+            PACKET hashprefix, msg;
+
+            /* Find how many bytes are left after the first two messages */
+            if (!PACKET_buf_init(&hashprefix, hdata, hdatalen)
+                    || !PACKET_forward(&hashprefix, 1)
+                    || !PACKET_get_length_prefixed_3(&hashprefix, &msg)
+                    || !PACKET_forward(&hashprefix, 1)
+                    || !PACKET_get_length_prefixed_3(&hashprefix, &msg)) {
                 SSLerr(SSL_F_TLS_PSK_DO_BINDER, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
-            hdatalen -= s->init_num + SSL3_HM_HEADER_LENGTH;
+            hdatalen -= PACKET_remaining(&hashprefix);
         }
 
         if (EVP_DigestUpdate(mctx, hdata, hdatalen) <= 0) {

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -17,7 +17,7 @@ use warnings;
 use List::Util qw/max min/;
 
 use OpenSSL::Test;
-use OpenSSL::Test::Utils qw/anydisabled alldisabled/;
+use OpenSSL::Test::Utils qw/anydisabled alldisabled disabled/;
 setup("no_test_here");
 
 my @tls_protocols = ("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3");
@@ -201,6 +201,25 @@ sub generate_resumption_tests {
                 };
             }
         }
+    }
+
+    if (!disabled("tls1_3") && !$dtls) {
+        push @client_tests, {
+            "name" => "resumption-with-hrr",
+            "client" => {
+            },
+            "server" => {
+                "Curves" => "P-256"
+            },
+            "resume_client" => {
+            },
+            "test" => {
+                "ExpectedProtocol" => "TLSv1.3",
+                "Method" => "TLS",
+                "HandshakeMode" => "Resume",
+                "ResumptionExpected" => "Yes",
+            }
+        };
     }
 
     return (@server_tests, @client_tests);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
Commit 6b1bb98 moved the processing of ClientHello extensions into the
state machine post-processing stage. After processing s->init_num is reset
to 0, so by post-processing we cannot rely on its value. Unfortunately we
were using it to handle the PSK extension. This causes the handshake to
fail.

We were using init_num to figure out the length of ClientHello2 so we can
remove it from the handshake_buffer. The handshake_buffer holds the
transcript of all the messages sent so far. For PSK processing though we
only want to add in a partial ClientHello2. This commit changes things so
we just work out where ClientHello2 starts, working forward from the
beginning of handshake_buffer.

Fixes #2983

NOTE: This is for master and the tls1.3-draft-18 branch