### PR TITLE
OpenSSL::Test: add a statusvar option for run with capture => 1

### DIFF
--- a/test/recipes/20-test_enc.t
+++ b/test/recipes/20-test_enc.t
@@ -27,20 +27,21 @@ my $test = catfile(".", "p");
 
 my $cmd = "openssl";
 
+my $ciphersstatus = undef;
 my @ciphers =
     map { s/^\s+//; s/\s+$//; split /\s+/ }
-    run(app([$cmd, "list", "-cipher-commands"]), capture => 1);
+    run(app([$cmd, "list", "-cipher-commands"]),
+        capture => 1, statusvar => \$ciphersstatus);
 
-plan tests => 1 + (scalar @ciphers)*2;
-
-my $init = ok(copy($testsrc,$test));
-
-if (!$init) {
-    diag("Trying to copy $testsrc to $test : $!");
-}
+plan tests => 2 + (scalar @ciphers)*2;
 
  SKIP: {
-     skip "Not initialized, skipping...", 11 unless $init;
+     skip "Problems getting ciphers...", 1 + scalar(@ciphers)
+         unless ok($ciphersstatus, "Running 'openssl list -cipher-commands'");
+     unless (ok(copy($testsrc, $test), "Copying $testsrc to $test")) {
+         diag($!);
+         skip "Not initialized, skipping...", scalar(@ciphers);
+     }
 
      foreach my $c (@ciphers) {
 	 my %variant = ("$c" => [],


### PR DESCRIPTION
When using run() with capture => 1, there was no way to find out if
the command was successful or not.  This change adds a statusvar
option, that must refer to a scalar variable, for example:

    my $status = undef;
    my @line = run(["whatever"], capture => 1, statusvar => \$status);

$status will be 1 if the command "whatever" was successful, 0
otherwise.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
