### PR TITLE
95-test_external_pyca_data/cryptography.py: only install for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,17 @@ matrix:
                   sources:
                       - ubuntu-toolchain-r-test
           compiler: gcc-5
-          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers enable-external-tests no-shared -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" COVERALLS="yes" BORINGSSL_TESTS="yes" CXX="g++-5"
+          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers no-shared -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" COVERALLS="yes" BORINGSSL_TESTS="yes" CXX="g++-5"
+        - os: linux
+          addons:
+              apt:
+                  packages:
+                      - gcc-5
+                      - g++-5
+                  sources:
+                      - ubuntu-toolchain-r-test
+          compiler: gcc-5
+          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-external-tests" BORINGSSL_TESTS="yes" CXX="g++-5" TESTS=95
         - os: linux
           addons:
               apt:

--- a/test/recipes/95-test_external_pyca.t
+++ b/test/recipes/95-test_external_pyca.t
@@ -23,6 +23,8 @@ SKIP: {
         if ! -f srctop_file("pyca-cryptography", "setup.py");
     skip "PYCA tests not available on Windows or VMS", 1
         if $^O =~ /^(VMS|MSWin32)$/;
+    skip "PYCA tests only available in a shared build", 1
+        if disabled("shared");
 
     ok(run(cmd(["sh", data_file("cryptography.sh")])),
         "running Python Cryptography tests");

--- a/test/recipes/95-test_external_pyca_data/cryptography.sh
+++ b/test/recipes/95-test_external_pyca_data/cryptography.sh
@@ -44,7 +44,7 @@ virtualenv venv-pycrypto
 
 cd pyca-cryptography
 
-pip install -q --requirement dev-requirements.txt
+pip install .[test]
 
 echo "------------------------------------------------------------------"
 echo "Building cryptography"


### PR DESCRIPTION
Also, be less silent when installing, so possible errors are shown.

[extended tests]

Fixes #3005
