### PR TITLE
TLSv1.3 session updates

### DIFF
--- a/doc/man3/SSL_CTX_add_session.pod
+++ b/doc/man3/SSL_CTX_add_session.pod
@@ -21,8 +21,8 @@ reference count for session B<c> is incremented by 1. If a session with
 the same session id already exists, the old session is removed by calling
 L<SSL_SESSION_free(3)>.
 
-SSL_CTX_remove_session() removes the session B<c> from the context B<ctx>.
-L<SSL_SESSION_free(3)> is called once for B<c>.
+SSL_CTX_remove_session() removes the session B<c> from the context B<ctx> and
+marks it as non-resumable. L<SSL_SESSION_free(3)> is called once for B<c>.
 
 SSL_add_session() and SSL_remove_session() are synonyms for their
 SSL_CTX_*() counterparts.

--- a/doc/man3/SSL_CTX_sess_set_get_cb.pod
+++ b/doc/man3/SSL_CTX_sess_set_get_cb.pod
@@ -57,7 +57,7 @@ and session caching is enabled (see
 L<SSL_CTX_set_session_cache_mode(3)>).
 The new_session_cb() is passed the B<ssl> connection and the ssl session
 B<sess>. If the callback returns B<0>, the session will be immediately
-removed again. Note that in TLSv1.3 sessions are established after the main
+removed again. Note that in TLSv1.3, sessions are established after the main
 handshake has completed. The server decides when to send the client the session
 information and this may occur some time after the end of the handshake (or not
 at all). This means that applications should expect the new_session_cb()

--- a/doc/man3/SSL_CTX_sess_set_get_cb.pod
+++ b/doc/man3/SSL_CTX_sess_set_get_cb.pod
@@ -57,7 +57,17 @@ and session caching is enabled (see
 L<SSL_CTX_set_session_cache_mode(3)>).
 The new_session_cb() is passed the B<ssl> connection and the ssl session
 B<sess>. If the callback returns B<0>, the session will be immediately
-removed again.
+removed again. Note that in TLSv1.3 sessions are established after the main
+handshake has completed. The server decides when to send the client the session
+information and this may occur some time after the end of the handshake (or not
+at all). This means that applications should expect the new_session_cb()
+function to be invoked during the handshake (for <= TLSv1.2) or after the
+handshake (for TLSv1.3). It is also possible in TLSv1.3 for multiple sessions to
+be established with a single connection. In these case the new_session_cb()
+function will be invoked multiple times.
+
+In TLSv1.3 it is recommended that each SSL_SESSION object is only used for
+resumption once.
 
 The remove_session_cb() is called, whenever the SSL engine removes a session
 from the internal cache. This happens when the session is removed because

--- a/doc/man3/SSL_CTX_sess_set_get_cb.pod
+++ b/doc/man3/SSL_CTX_sess_set_get_cb.pod
@@ -67,7 +67,8 @@ be established with a single connection. In these case the new_session_cb()
 function will be invoked multiple times.
 
 In TLSv1.3 it is recommended that each SSL_SESSION object is only used for
-resumption once.
+resumption once. One way of enforcing that is for applications to call
+L<SSL_CTX_remove_session(3)> after a session has been used.
 
 The remove_session_cb() is called, whenever the SSL engine removes a session
 from the internal cache. This happens when the session is removed because

--- a/doc/man3/SSL_SESSION_is_resumable.pod
+++ b/doc/man3/SSL_SESSION_is_resumable.pod
@@ -1,0 +1,40 @@
+=pod
+
+=head1 NAME
+
+SSL_SESSION_is_resumable
+- determine whether an SSL_SESSION object can be used for resumption
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ const SSL_CIPHER *SSL_SESSION_is_resumable(const SSL_SESSSION *s);
+
+=head1 DESCRIPTION
+
+SSL_SESSION_is_resumable() determines whether an SSL_SESSION object can be used
+to resume a session or not. Returns 1 if it can or 0 if not. Note that
+attempting to resume with a non-resumable session will result in OpenSSL
+performing a full handshake.
+
+=head1 SEE ALSO
+
+L<ssl(7)>,
+L<SSL_get_session(3)>,
+L<SSL_CTX_sess_set_new_cb(3)>
+
+=head1 HISTORY
+
+SSL_SESSION_is_resumable() was first added to OpenSSL 1.1.1
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_SESSION_is_resumable.pod
+++ b/doc/man3/SSL_SESSION_is_resumable.pod
@@ -15,8 +15,8 @@ SSL_SESSION_is_resumable
 
 SSL_SESSION_is_resumable() determines whether an SSL_SESSION object can be used
 to resume a session or not. Returns 1 if it can or 0 if not. Note that
-attempting to resume with a non-resumable session will result in OpenSSL
-performing a full handshake.
+attempting to resume with a non-resumable session will result in a full
+handshake.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_get_session.pod
+++ b/doc/man3/SSL_get_session.pod
@@ -26,7 +26,30 @@ count of the B<SSL_SESSION> is incremented by one.
 =head1 NOTES
 
 The ssl session contains all information required to re-establish the
-connection without a new handshake.
+connection without a full handshake for SSL versions <= TLSv1.2. In TLSv1.3 the
+same is true, but sessions are established after the main handshake has occurred.
+The server will send the session information to the client at a time of its
+choosing which may be some while after the initial connection is established (or
+not at all). Calling these functions on the client side in TLSv1.3 before the
+session has been established will still return an SSL_SESSION object but it
+cannot be used for resuming the session. See L<SSL_SESSION_is_resumable(3)> for
+information on how to determine whether an SSL_SESSION object can be used for
+resumption or not.
+
+Additionally, in TLSv1.3, a server can send multiple session messages for a
+single connection. In that case the above functions will only return information
+on the last session that was received.
+
+The preferred way for applications to obtain a resumable SSL_SESSION object is
+to use a new session callback as described in L<SSL_CTX_sess_set_new_cb(3)>.
+The new session callback is only invoked when a session is actually established,
+so this avoids the problem described above where an application obtains an
+SSL_SESSION object that cannot be used for resumption in TLSv1.3. It also
+enables applications to obtain information about all sessions sent by the
+server.
+
+In TLSv1.3 it is recommended that each SSL_SESSION object is only used for
+resumption once.
 
 SSL_get0_session() returns a pointer to the actual session. As the
 reference counter is not incremented, the pointer is only valid while

--- a/doc/man3/SSL_get_session.pod
+++ b/doc/man3/SSL_get_session.pod
@@ -29,16 +29,16 @@ The ssl session contains all information required to re-establish the
 connection without a full handshake for SSL versions <= TLSv1.2. In TLSv1.3 the
 same is true, but sessions are established after the main handshake has occurred.
 The server will send the session information to the client at a time of its
-choosing which may be some while after the initial connection is established (or
-not at all). Calling these functions on the client side in TLSv1.3 before the
-session has been established will still return an SSL_SESSION object but it
-cannot be used for resuming the session. See L<SSL_SESSION_is_resumable(3)> for
-information on how to determine whether an SSL_SESSION object can be used for
-resumption or not.
+choosing, which may be some while after the initial connection is established
+(or never). Calling these functions on the client side in TLSv1.3 before the
+session has been established will still return an SSL_SESSION object but that
+object cannot be used for resuming the session. See
+L<SSL_SESSION_is_resumable(3)> for information on how to determine whether an
+SSL_SESSION object can be used for resumption or not.
 
-Additionally, in TLSv1.3, a server can send multiple session messages for a
-single connection. In that case the above functions will only return information
-on the last session that was received.
+Additionally, in TLSv1.3, a server can send multiple messages that establish a
+session for a single connection. In that case the above functions will only
+return information on the last session that was received.
 
 The preferred way for applications to obtain a resumable SSL_SESSION object is
 to use a new session callback as described in L<SSL_CTX_sess_set_new_cb(3)>.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1502,6 +1502,7 @@ __owur int SSL_SESSION_set1_id_context(SSL_SESSION *s, const unsigned char *sid_
                                 unsigned int sid_ctx_len);
 __owur int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
                                unsigned int sid_len);
+__owur int SSL_SESSION_is_resumable(const SSL_SESSION *s);
 
 __owur SSL_SESSION *SSL_SESSION_new(void);
 const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s,

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2442,7 +2442,6 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL *s, PACKET *pkt)
     if (ticklen == 0)
         return MSG_PROCESS_CONTINUE_READING;
 
-    /* TODO(TLS1.3): Is this a suitable test for TLS1.3? */
     if (s->session->session_id_length > 0) {
         int i = s->session_ctx->session_cache_mode;
         SSL_SESSION *new_sess;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1049,13 +1049,9 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
         return 0;
     }
 
-    if ((sess == NULL) || !ssl_version_supported(s, sess->ssl_version) ||
-        /*
-         * In the case of EAP-FAST, we can have a pre-shared
-         * "ticket" without a session ID.
-         */
-        (!sess->session_id_length && !sess->ext.tick) ||
-        (sess->not_resumable)) {
+    if (sess == NULL
+            || !ssl_version_supported(s, sess->ssl_version)
+            || !SSL_SESSION_is_resumable(sess)) {
         if (!ssl_get_new_session(s, 0))
             return 0;
     }

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -440,3 +440,4 @@ SSL_get0_peer_CA_list                   440	1_1_1	EXIST::FUNCTION:
 SSL_CTX_add1_CA_list                    441	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get0_CA_list                    442	1_1_1	EXIST::FUNCTION:
 SSL_CTX_add_custom_ext                  443	1_1_1	EXIST::FUNCTION:
+SSL_SESSION_is_resumable                444	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Sessions work differently in TLSv1.3. The session is established post-handshake at a time chosen by the server (or not at all if the server decides). Additionally a server can send multiple session tickets for a single connection. This causes problems for SSL_get_session() et al because an application could end up with a session object that is not useful for resumption if called too early. Also it can only handle the last session information sent.

We already have a suitable mechanism for handling this: SSL_CTX_sess_set_new_cb(). This provides
a way of setting a callback to be informed every time we get session information. Applications will have to expect that to be called post-handshake now.

This PR provides various documentation updates to describe the way things work now. It also adds a new function SSL_SESSION_is_resumable() which can be used to test whether a session object can be used for resumption or not. Attempting to use an SSL_SESSION for resumption which isn't capable of it is not fatal though...you just get a full handshake instead.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
