### PR TITLE
Fix BAD CCS alert in DTLS

### DIFF
--- a/ssl/d1_pkt.c
+++ b/ssl/d1_pkt.c
@@ -1323,9 +1323,9 @@ int dtls1_read_bytes(SSL *s, int type, unsigned char *buf, int len, int peek)
         /* XDTLS: check that epoch is consistent */
         if ((rr->length != ccs_hdr_len) ||
             (rr->off != 0) || (rr->data[0] != SSL3_MT_CCS)) {
-            i = SSL_AD_ILLEGAL_PARAMETER;
+            al = SSL_AD_ILLEGAL_PARAMETER;
             SSLerr(SSL_F_DTLS1_READ_BYTES, SSL_R_BAD_CHANGE_CIPHER_SPEC);
-            goto err;
+            goto f_err;
         }
 
         rr->length = 0;


### PR DESCRIPTION
Set the correct variable, and then actually send the alert!

This only applies to 1.0.2
