### PR TITLE
Guard last few debugging printfs in libssl (1.0.2)

### DIFF
--- a/ssl/d1_both.c
+++ b/ssl/d1_both.c
@@ -1075,7 +1075,9 @@ int dtls1_send_change_cipher_spec(SSL *s, int a, int b)
 int dtls1_read_failed(SSL *s, int code)
 {
     if (code > 0) {
+#ifdef TLS_DEBUG
         fprintf(stderr, "invalid state reached %s:%d", __FILE__, __LINE__);
+#endif
         return 1;
     }
 
@@ -1147,7 +1149,9 @@ int dtls1_retransmit_buffered_messages(SSL *s)
                                      (frag->msg_header.seq,
                                       frag->msg_header.is_ccs), 0,
                                      &found) <= 0 && found) {
+#ifdef TLS_DEBUG
             fprintf(stderr, "dtls1_retransmit_message() failed\n");
+#endif
             return -1;
         }
     }
@@ -1247,7 +1251,9 @@ dtls1_retransmit_message(SSL *s, unsigned short seq, unsigned long frag_off,
 
     item = pqueue_find(s->d1->sent_messages, seq64be);
     if (item == NULL) {
+#ifdef TLS_DEBUG
         fprintf(stderr, "retransmit:  message %d non-existant\n", seq);
+#endif
         *found = 0;
         return 0;
     }

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -3168,7 +3168,9 @@ int ssl3_get_cert_verify(SSL *s)
             goto f_err;
         }
         if (i != 64) {
+#ifdef SSL_DEBUG
             fprintf(stderr, "GOST signature length is %d", i);
+#endif
         }
         for (idx = 0; idx < 64; idx++) {
             signature[63 - idx] = p[idx];


### PR DESCRIPTION
Fixes #2542
