### PR TITLE
TLSv1.3: Downgrade Protection mechanism

### DIFF
--- a/Configure
+++ b/Configure
@@ -407,6 +407,7 @@ my @disablables = (
     "tests",
     "threads",
     "tls",
+    "tls13downgrade",
     "ts",
     "ubsan",
     "ui",
@@ -451,6 +452,7 @@ our %disabled = ( # "what"         => "comment"
                   "ubsan"		=> "default",
           #TODO(TLS1.3): Temporarily disabled while this is a WIP
 		  "tls1_3"              => "default",
+		  "tls13downgrade"      => "default",
 		  "unit-test"           => "default",
 		  "weak-ssl-ciphers"    => "default",
 		  "zlib"                => "default",

--- a/INSTALL
+++ b/INSTALL
@@ -427,6 +427,16 @@
                    require additional system-dependent options! See "Note on
                    multi-threading" below.
 
+  enable-tls13downgrade
+                   TODO(TLS1.3): Make this enabled by default and remove the
+                   option when TLSv1.3 is out of draft
+                   TLSv1.3 offers a downgrade protection mechanism. This is
+                   implemented but disabled by default. It should not typically
+                   be enabled except for testing purposes. Otherwise this could
+                   cause problems if a pre-RFC version of OpenSSL talks to an
+                   RFC implementation (it will erroneously be detected as a
+                   downgrade).
+
   no-ts
                    Don't build Time Stamping Authority support.
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -58,6 +58,14 @@
 #define SSL3_NUM_CIPHERS        OSSL_NELEM(ssl3_ciphers)
 #define SSL3_NUM_SCSVS          OSSL_NELEM(ssl3_scsvs)
 
+/* TLSv1.3 downgrade protection sentinel values */
+const unsigned char tls11downgrade[] = {
+    0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x00
+};
+const unsigned char tls12downgrade[] = {
+    0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01
+};
+
 /*
  * The list of available ciphers, mostly organized into the following
  * groups:
@@ -4030,13 +4038,6 @@ int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
     }
 #ifndef OPENSSL_NO_TLS13DOWNGRADE
     if (ret) {
-        static const unsigned char tls11downgrade[] = {
-            0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x00
-        };
-        static const unsigned char tls12downgrade[] = {
-            0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01
-        };
-
         assert(sizeof(tls11downgrade) < len && sizeof(tls12downgrade) < len);
         if (dgrd == DOWNGRADE_TO_1_2)
             memcpy(result + len - sizeof(tls12downgrade), tls12downgrade,

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2175,7 +2175,8 @@ __owur int ssl_check_version_downgrade(SSL *s);
 __owur int ssl_set_version_bound(int method_version, int version, int *bound);
 __owur int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello,
                                      DOWNGRADE *dgrd);
-__owur int ssl_choose_client_version(SSL *s, int version);
+__owur int ssl_choose_client_version(SSL *s, int version, int checkdgrd,
+                                     int *al);
 int ssl_get_client_min_max_version(const SSL *s, int *min_version,
                                    int *max_version);
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1865,6 +1865,9 @@ typedef enum tlsext_index_en {
 /* A dummy signature value not valid for TLSv1.2 signature algs */
 #define TLSEXT_signature_rsa_pss                                0x0101
 
+/* TLSv1.3 downgrade protection sentinel values */
+extern const unsigned char tls11downgrade[8];
+extern const unsigned char tls12downgrade[8];
 
 extern SSL3_ENC_METHOD ssl3_undef_enc_method;
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1783,6 +1783,12 @@ typedef struct ssl3_comp_st {
 } SSL3_COMP;
 # endif
 
+typedef enum downgrade_en {
+    DOWNGRADE_NONE,
+    DOWNGRADE_TO_1_2,
+    DOWNGRADE_TO_1_1
+} DOWNGRADE;
+
 /*
  * Extension index values NOTE: Any updates to these defines should be mirrored
  * with equivalent updates to ext_defs in extensions.c
@@ -2101,7 +2107,7 @@ __owur int ssl_verify_alarm_type(long type);
 void ssl_sort_cipher_list(void);
 void ssl_load_ciphers(void);
 __owur int ssl_fill_hello_random(SSL *s, int server, unsigned char *field,
-                                 size_t len);
+                                 size_t len, DOWNGRADE dgrd);
 __owur int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
                                       int free_pms);
 __owur EVP_PKEY *ssl_generate_pkey(EVP_PKEY *pm);
@@ -2167,7 +2173,8 @@ __owur int ssl_version_supported(const SSL *s, int version);
 __owur int ssl_set_client_hello_version(SSL *s);
 __owur int ssl_check_version_downgrade(SSL *s);
 __owur int ssl_set_version_bound(int method_version, int version, int *bound);
-__owur int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello);
+__owur int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello,
+                                     DOWNGRADE *dgrd);
 __owur int ssl_choose_client_version(SSL *s, int version);
 int ssl_get_client_min_max_version(const SSL *s, int *min_version,
                                    int *max_version);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1094,7 +1094,8 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
     } else
         i = 1;
 
-    if (i && ssl_fill_hello_random(s, 0, p, sizeof(s->s3->client_random)) <= 0)
+    if (i && ssl_fill_hello_random(s, 0, p, sizeof(s->s3->client_random),
+                                   DOWNGRADE_NONE) <= 0)
         return 0;
 
     /*-

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1681,22 +1681,32 @@ int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello, DOWNGRADE *dgrd)
  *
  * @s: client SSL handle.
  * @version: The proposed version from the server's HELLO.
+ * @checkdgrd: Whether to check the downgrade sentinels in the server_random
+ * @al: Where to store any alert value that may be generated
  *
  * Returns 0 on success or an SSL error reason number on failure.
  */
-int ssl_choose_client_version(SSL *s, int version)
+int ssl_choose_client_version(SSL *s, int version, int checkdgrd, int *al)
 {
     const version_info *vent;
     const version_info *table;
+    int highver = 0;
 
     /* TODO(TLS1.3): Remove this before release */
     if (version == TLS1_3_VERSION_DRAFT)
         version = TLS1_3_VERSION;
 
+    if (s->hello_retry_request && version != TLS1_3_VERSION) {
+        *al = SSL_AD_PROTOCOL_VERSION;
+        return SSL_R_WRONG_SSL_VERSION;
+    }
+
     switch (s->method->version) {
     default:
-        if (version != s->version)
+        if (version != s->version) {
+            *al = SSL_AD_PROTOCOL_VERSION;
             return SSL_R_WRONG_SSL_VERSION;
+        }
         /*
          * If this SSL handle is not from a version flexible method we don't
          * (and never did) check min/max, FIPS or Suite B constraints.  Hope
@@ -1716,23 +1726,68 @@ int ssl_choose_client_version(SSL *s, int version)
     for (vent = table; vent->version != 0; ++vent) {
         const SSL_METHOD *method;
         int err;
+#ifndef OPENSSL_NO_TLS13DOWNGRADE
+        static const unsigned char tls11downgrade[] = {
+            0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x00
+        };
+        static const unsigned char tls12downgrade[] = {
+            0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01
+        };
+#endif
 
-        if (version != vent->version)
-            continue;
         if (vent->cmeth == NULL)
-            break;
-        if (s->hello_retry_request && version != TLS1_3_VERSION)
-            return SSL_R_WRONG_SSL_VERSION;
+            continue;
+
+        if (highver != 0 && version != vent->version)
+            continue;
 
         method = vent->cmeth();
         err = ssl_method_error(s, method);
-        if (err != 0)
-            return err;
+        if (err != 0) {
+            if (version == vent->version) {
+                *al = SSL_AD_PROTOCOL_VERSION;
+                return err;
+            }
+
+            continue;
+        }
+        if (highver == 0)
+            highver = vent->version;
+
+        if (version != vent->version)
+            continue;
+
+#ifndef OPENSSL_NO_TLS13DOWNGRADE
+        /* Check for downgrades */
+        if (checkdgrd) {
+            if (version == TLS1_2_VERSION && highver > version) {
+                if (memcmp(tls12downgrade,
+                           s->s3->server_random + SSL3_RANDOM_SIZE
+                                                - sizeof(tls12downgrade),
+                           sizeof(tls12downgrade)) == 0) {
+                    *al = SSL_AD_ILLEGAL_PARAMETER;
+                    return SSL_R_INAPPROPRIATE_FALLBACK;
+                }
+            } else if (!SSL_IS_DTLS(s)
+                       && version < TLS1_2_VERSION
+                       && highver > version) {
+                if (memcmp(tls11downgrade,
+                           s->s3->server_random + SSL3_RANDOM_SIZE
+                                                - sizeof(tls11downgrade),
+                           sizeof(tls11downgrade)) == 0) {
+                    *al = SSL_AD_ILLEGAL_PARAMETER;
+                    return SSL_R_INAPPROPRIATE_FALLBACK;
+                }
+            }
+        }
+#endif
+
         s->method = method;
         s->version = version;
         return 0;
     }
 
+    *al = SSL_AD_PROTOCOL_VERSION;
     return SSL_R_UNSUPPORTED_PROTOCOL;
 }
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1726,14 +1726,6 @@ int ssl_choose_client_version(SSL *s, int version, int checkdgrd, int *al)
     for (vent = table; vent->version != 0; ++vent) {
         const SSL_METHOD *method;
         int err;
-#ifndef OPENSSL_NO_TLS13DOWNGRADE
-        static const unsigned char tls11downgrade[] = {
-            0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x00
-        };
-        static const unsigned char tls12downgrade[] = {
-            0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01
-        };
-#endif
 
         if (vent->cmeth == NULL)
             continue;

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -43,6 +43,15 @@ sub extension_filter
 {
     my $proxy = shift;
 
+    if ($proxy->flight == 1) {
+        # Change the ServerRandom so that the downgrade sentinel doesn't cause
+        # the connection to fail
+        my $message = ${$proxy->message_list}[1];
+        $message->random("\0"x32);
+        $message->repack();
+        return;
+    }
+
     # We're only interested in the initial ClientHello
     if ($proxy->flight != 0) {
         return;

--- a/test/recipes/70-test_sslversions.t
+++ b/test/recipes/70-test_sslversions.t
@@ -115,6 +115,17 @@ sub modify_supported_versions_filter
 {
     my $proxy = shift;
 
+    if ($proxy->flight == 1) {
+        # Change the ServerRandom so that the downgrade sentinel doesn't cause
+        # the connection to fail
+        my $message = ${$proxy->message_list}[1];
+        return if (!defined $message);
+
+        $message->random("\0"x32);
+        $message->repack();
+        return;
+    }
+
     # We're only interested in the initial ClientHello
     if ($proxy->flight != 0) {
         return;

--- a/test/recipes/70-test_tls13downgrade.t
+++ b/test/recipes/70-test_tls13downgrade.t
@@ -1,0 +1,93 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+use TLSProxy::Proxy;
+
+my $test_name = "test_tls13downgrade";
+setup($test_name);
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS|MSWin32)$/;
+
+plan skip_all => "$test_name needs the dynamic engine feature enabled"
+    if disabled("engine") || disabled("dynamic-engine");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLS1.3 and TLS1.2 enabled"
+    if disabled("tls1_3") || disabled("tls1_2");
+
+# TODO(TLS1.3): Enable this when TLSv1.3 comes out of draft
+plan skip_all => "$test_name not run in pre TLSv1.3 RFC implementation"
+    if disabled("tls13downgrade");
+
+$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+
+my $proxy = TLSProxy::Proxy->new(
+    undef,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
+);
+
+use constant {
+    DOWNGRADE_TO_TLS_1_2 => 0,
+    DOWNGRADE_TO_TLS_1_1 => 1
+};
+
+#Test 1: Downgrade from TLSv1.3 to TLSv1.2
+$proxy->filter(\&downgrade_filter);
+my $testtype = DOWNGRADE_TO_TLS_1_2;
+$proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 3;
+ok(TLSProxy::Message->fail(), "Downgrade TLSv1.3 to TLSv1.2");
+
+#Test 2: Downgrade from TLSv1.3 to TLSv1.1
+$proxy->clear();
+$testtype = DOWNGRADE_TO_TLS_1_1;
+$proxy->start();
+ok(TLSProxy::Message->fail(), "Downgrade TLSv1.3 to TLSv1.1");
+
+#Test 3: Downgrade from TLSv1.2 to TLSv1.1
+$proxy->clear();
+$proxy->clientflags("-no_tls1_3");
+$proxy->serverflags("-no_tls1_3");
+$proxy->start();
+ok(TLSProxy::Message->fail(), "Downgrade TLSv1.2 to TLSv1.1");
+
+sub downgrade_filter
+{
+    my $proxy = shift;
+
+    # We're only interested in the initial ClientHello
+    if ($proxy->flight != 0) {
+        return;
+    }
+
+    my $message = ${$proxy->message_list}[0];
+
+    my $ext;
+    if ($testtype == DOWNGRADE_TO_TLS_1_2) {
+        $ext = pack "C3",
+            0x02, # Length
+            0x03, 0x03; #TLSv1.2
+    } else {
+        $ext = pack "C3",
+            0x02, # Length
+            0x03, 0x02; #TLSv1.1
+    }
+
+    $message->set_extension(TLSProxy::Message::EXT_SUPPORTED_VERSIONS, $ext);
+
+    $message->repack();
+}
+


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
This PR implements the TLSv1.3 downgrade protection mechanism.

For now it is switched off by default (enabled via "enable-tls13downgrade"). This is because the current draft says pre-RFC implementations SHOULD NOT implement it (if a pre-RFC implementation connects to an RFC implementation it will mistakenly detect a downgrade and abort the connection).

As soon as the draft becomes an RFC we can enable it by default and remove the "enable-tls13downgrade" option completely.