### PR TITLE
Fixed a gcc-7-strict-warnings issue.

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -114,10 +114,11 @@ int i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
 
     *(p++) = (unsigned char)bits;
     d = a->data;
-    memcpy(p, d, len);
-    p += len;
-    if (len > 0)
+    if (len > 0) {
+        memcpy(p, d, len);
+        p += len;
         p[-1] &= (0xff << bits);
+    }
     *pp = p;
     return (ret);
 }


### PR DESCRIPTION
GCC-7 assumes len can be negative, and emits a warning here.
It can be fixed by moving the memcpy in to the if block.
This is the same as this function works on master.