### PR TITLE
apps/passwd.c: 32 bits is sufficient to hold ROUNDS_MAX.

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -502,7 +502,7 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
     EVP_MD_CTX *md = NULL, *md2 = NULL;
     const EVP_MD *sha = NULL;
     size_t passwd_len, salt_len, magic_len;
-    size_t rounds = 5000;        /* Default */
+    unsigned int rounds = 5000;        /* Default */
     char rounds_custom = 0;
     char *p_bytes = NULL;
     char *s_bytes = NULL;
@@ -539,7 +539,7 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
             else if (srounds < ROUNDS_MIN)
                 rounds = ROUNDS_MIN;
             else
-                rounds = srounds;
+                rounds = (unsigned int)srounds;
             rounds_custom = 1;
         } else {
             return NULL;
@@ -556,7 +556,7 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
     OPENSSL_strlcat(out_buf, "$", sizeof out_buf);
     if (rounds_custom) {
         char tmp_buf[80]; /* "rounds=999999999" */
-        sprintf(tmp_buf, "rounds=%"OSSLzu, rounds);
+        sprintf(tmp_buf, "rounds=%u", rounds);
         OPENSSL_strlcat(out_buf, tmp_buf, sizeof out_buf);
         OPENSSL_strlcat(out_buf, "$", sizeof out_buf);
     }


### PR DESCRIPTION
Even though C standard defines 'z' modifier, recent mingw compilers break
the contract by defining __STDC_VERSION__ with non-compliant MSVCRT.DLL.

make test is failing test_passwd with recent mingw Linux compilers for above reason. Goal was to remove dependency on OSSLzu. I'd actually go as far as arguing that OSSLzu in its current shape is unsuitable. And not only for above reasons. For starters why is it in public header? Does it apply to any of interfaces provided by OpenSSL? No. Most notably BIO_printf doesn't implement it. [Which by the way means that BIO_printf in test/siphash_internal_test.c is wrong.] It's used mainly in tests, but does it qualify for public header? I'd argue no. Secondly [in context of public vs. [test-]private header] dependency on THIRTY_TWO_BIT is not reliable. Counter-examples are SPARC Solaris, VMS, linux-x32 and similar to last one, i.e. ILP32 builds on 64-bit processors...