### PR TITLE
Add parentheses around macro argument of OSSL_NELEM

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -511,7 +511,7 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
-#define OSSL_NELEM(x)    (sizeof(x)/sizeof(x[0]))
+#define OSSL_NELEM(x)    (sizeof(x)/sizeof((x)[0]))
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 # define CRYPTO_memcmp memcmp


### PR DESCRIPTION
This fixes potential problems with OSSL_NELEM if it is called with some
expression that can be evaluated in a surprising way if [0] is added in the
macro expansion.