### PR TITLE
Free the compression methods in s_server and s_client

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2132,6 +2132,7 @@ int MAIN(int argc, char **argv)
         BIO_free(bio_c_msg);
         bio_c_msg = NULL;
     }
+    SSL_COMP_free_compression_methods();
     apps_shutdown();
     OPENSSL_EXIT(ret);
 }

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2132,6 +2132,7 @@ int MAIN(int argc, char *argv[])
         BIO_free(bio_s_msg);
         bio_s_msg = NULL;
     }
+    SSL_COMP_free_compression_methods();
     apps_shutdown();
     OPENSSL_EXIT(ret);
 }


### PR DESCRIPTION
This causes a minor (64 bytes on my machine) mem leak in s_server/s_client.

1.0.2 only.
