### PR TITLE
Remove redundant redeclaration of ‘X509_STORE_set_flags’

### DIFF
--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -272,7 +272,6 @@ int X509_STORE_set_purpose(X509_STORE *ctx, int purpose);
 int X509_STORE_set_trust(X509_STORE *ctx, int trust);
 int X509_STORE_set1_param(X509_STORE *ctx, X509_VERIFY_PARAM *pm);
 X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *ctx);
-int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
 
 void X509_STORE_set_verify(X509_STORE *ctx, X509_STORE_CTX_verify_fn verify);
 #define X509_STORE_set_verify_func(ctx, func) \


### PR DESCRIPTION
a47bc283 accidentally adds another define for X509_STORE_set_flags
It is already defined 5 lines prior