### PR TITLE
Trivial if(1) simplification

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -240,23 +240,21 @@ int passwd_main(int argc, char **argv)
     }
 
     if ((in == NULL) && (passwds == NULL)) {
-        if (1) {
 #ifndef OPENSSL_NO_UI
-            /* build a null-terminated list */
-            static char *passwds_static[2] = { NULL, NULL };
+        /* build a null-terminated list */
+        static char *passwds_static[2] = { NULL, NULL };
 
-            passwds = passwds_static;
-            if (in == NULL)
-                if (EVP_read_pw_string
-                    (passwd_malloc, passwd_malloc_size, "Password: ",
-                     !(passed_salt || in_noverify)) != 0)
-                    goto end;
-            passwds[0] = passwd_malloc;
-        } else {
-#endif
+        passwds = passwds_static;
+        if (in == NULL)
+            if (EVP_read_pw_string
+                (passwd_malloc, passwd_malloc_size, "Password: ",
+                 !(passed_salt || in_noverify)) != 0)
+                goto end;
+        passwds[0] = passwd_malloc;
+#else
             BIO_printf(bio_err, "password required\n");
             goto end;
-        }
+#endif
     }
 
 


### PR DESCRIPTION
##### Checklist

- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change

The original file has a weird "if(1)" construct, which combines with a preprocessor macro. I believe that removing it makes the code more readable (and 2 lines smaller).

I think this change is trivial enough to not require me to sign the licensing agreement (let me know otherwise, I will gladly comply).