### PR TITLE
asynctest: don't depend on apps

### DIFF
--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <openssl/async.h>
 #include <openssl/crypto.h>
-#include <../apps/apps.h>
 
 static int ctr = 0;
 static ASYNC_JOB *currjob = NULL;


### PR DESCRIPTION
Remove unnecessary include of apps.h. Tests shouldn't take a
dependency on apps. In this case, there is no dependency, the include
is unnecessary.
