### PR TITLE
X25519 doc

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -21,6 +21,7 @@ man5/
 
 man7/
         Overviews; start with crypto.pod and ssl.pod, for example
+        Algorithm specific EVP_PKEY documentation.
 
 Formatted versions of the manpages (apps,ssl,crypto) can be found at
         https://www.openssl.org/docs/manpages.html

--- a/doc/man3/EVP_PKEY_CTX_set_tls1_prf_md.pod
+++ b/doc/man3/EVP_PKEY_CTX_set_tls1_prf_md.pod
@@ -50,7 +50,7 @@ All these functions are implemented as macros.
 
 A context for the TLS PRF can be obtained by calling:
 
- EVP_PKEY_CTX *pctx = EVP_PKEY_new_id(EVP_PKEY_TLS1_PRF, NULL);
+ EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_TLS1_PRF, NULL);
 
 The digest, secret value and seed must be set before a key is derived or an
 error occurs.

--- a/doc/man7/X25519.pod
+++ b/doc/man7/X25519.pod
@@ -1,0 +1,58 @@
+=pod
+
+=head1 NAME
+
+X25519 - EVP_PKEY X25519 support
+
+=head1 DESCRIPTION
+
+The B<X25519> EVP_PKEY implementation supports key generation and key
+derivation using B<X25519>. It has associated private and public key formats
+compatible with draft-ietf-curdle-pkix-03.
+
+No additional parameters can be set during key generation.
+
+The peer public key must be set using EVP_PKEY_derive_set_peer() when
+performing key derivation.
+
+=head1 NOTES
+
+A context for the B<X25519> algorithm can be obtained by calling:
+
+ EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(NID_X25519, NULL);
+
+=head1 EXAMPLE
+
+This example generates an B<X25519> private key and writes it to standard
+output in PEM format:
+
+ #include <openssl/evp.h>
+ #include <openssl/pem.h>
+ ...
+ EVP_PKEY *pkey = NULL;
+ EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(NID_X25519, NULL);
+ EVP_PKEY_keygen_init(pctx);
+ EVP_PKEY_keygen(pctx, &pkey);
+ EVP_PKEY_CTX_free(pctx);
+ PEM_write_PrivateKey(stdout, pkey, NULL, NULL, 0, NULL, NULL);
+
+The key derviation example in L<EVP_PKEY_derive(3)> can be used with
+B<X25519>.
+
+=head1 SEE ALSO
+
+L<EVP_PKEY_CTX_new(3)>,
+L<EVP_PKEY_keygen(3)>,
+L<EVP_PKEY_derive(3)>,
+L<EVP_PKEY_derive_set_peer(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

This adds documentation for the X25519 algorithm. This is straight forward and just uses the EVP_PKEY functionality for key derivation and key generation with no algorithm specific operations.

This has been added as a new "man4" manual page. There will be others to follow for other algorithms and engines. Some of them will have algorithm specific operations which should create appropriate links in man3: that will need to be checked/implemented when the need arises.

Someone check I didn't miss anything out when adding man4