### PR TITLE
[code health] doc: Add missing options in s_{server,client}

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -89,6 +89,8 @@ B<openssl> B<s_client>
 [B<-bugs>]
 [B<-comp>]
 [B<-no_comp>]
+[B<-sigalgs sigalglist>]
+[B<-curves curvelist>]
 [B<-cipher cipherlist>]
 [B<-serverpref>]
 [B<-starttls protocol>]
@@ -434,6 +436,19 @@ OpenSSL 1.1.0.
 
 only provide a brief summary of connection parameters instead of the
 normal verbose output.
+
+=item B<-sigalgs sigalglist>
+
+Specifies the list of signature algorithms that are sent by the client.
+The server selects one entry in the list based on its preferences.
+For example strings, see L<SSL_CTX_set1_sigalgs(3)>
+
+=item B<-curves curvelist>
+
+Specifies the list of supported curves to be sent by the client. The curve is
+is ultimately selected by the server. For a list of all curves, use:
+
+    $ openssl ecparam -list_curves
 
 =item B<-cipher cipherlist>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -70,6 +70,8 @@ B<openssl> B<s_server>
 [B<-verify_name name>]
 [B<-x509_strict>]
 [B<-nocert>]
+[B<-client_sigalgs sigalglist>]
+[B<-named_curve curve>]
 [B<-cipher cipherlist>]
 [B<-serverpref>]
 [B<-quiet>]
@@ -412,6 +414,18 @@ OpenSSL 1.1.0.
 
 Provide a brief summary of connection parameters instead of the normal verbose
 output.
+
+=item B<-client_sigalgs sigalglist>
+
+Signature algorithms to support for client certificate authentication
+(colon-separated list)
+
+=item B<-named_curve curve>
+
+Specifies the elliptic curve to use. NOTE: this is single curve, not a list.
+For a list of all possible curves, use:
+
+    $ openssl ecparam -list_curves
 
 =item B<-cipher cipherlist>
 


### PR DESCRIPTION
These were added to the help in ad775e04f6dab but not the pods.

- [x] documentation is added or updated
