### PR TITLE
cipherbytes_test: remove unused includes

### DIFF
--- a/test/cipherbytes_test.c
+++ b/test/cipherbytes_test.c
@@ -19,8 +19,6 @@
 #include <openssl/tls1.h>
 
 #include "e_os.h"
-#include "test_main.h"
-#include "testutil.h"
 
 static int test_empty(SSL *s)
 {


### PR DESCRIPTION
cipherbytes_test does not use the testutil / test_main test framework.


