### PR TITLE
bio/b_print.c: fix %z failure in 32-bit build.

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -267,10 +267,10 @@ _dopr(char **sbuffer,
                     value = va_arg(args, unsigned LLONG);
                     break;
                 case DP_C_SIZE:
-                    value = (ossl_ssize_t)va_arg(args, size_t);
+                    value = va_arg(args, size_t);
                     break;
                 default:
-                    value = (LLONG) va_arg(args, unsigned int);
+                    value = (LLONG)va_arg(args, unsigned int);
                     break;
                 }
                 if (!fmtint(sbuffer, buffer, &currlen, maxlen, value,


### PR DESCRIPTION
Fixes #3064.

[As implied at the end of #3064 I probably wasn't completely impartial there and might have rushed it and didn't pay enough attention to note failure in 32-bit build.]
