### PR TITLE
bio/b_print.c: recognize even 'j' format modifier.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@
 
   *) Add the 'z' and 'j' modifiers to BIO_printf() et al formatting string,
      'z' is to be used for [s]size_t, and 'j' - with [u]int64_t.
-     [Richard Levitte, Andt Polyakov]
+     [Richard Levitte, Andy Polyakov]
 
   *) Add EC_KEY_get0_engine(), which does for EC_KEY what RSA_get0_engine()
      does for RSA, etc.

--- a/CHANGES
+++ b/CHANGES
@@ -4,9 +4,9 @@
 
  Changes between 1.1.0e and 1.1.1 [xx XXX xxxx]
 
-  *) Add the z modifier parsing to BIO_printf() et al formatting string,
-     to be used for size_t and ssize_t (ossl_ssize_t).
-     [Richard Levitte]
+  *) Add the 'z' and 'j' modifiers to BIO_printf() et al formatting string,
+     'z' is to be used for [s]size_t, and 'j' - with [u]int64_t.
+     [Richard Levitte, Andt Polyakov]
 
   *) Add EC_KEY_get0_engine(), which does for EC_KEY what RSA_get0_engine()
      does for RSA, etc.

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -548,8 +548,8 @@ int enc_main(int argc, char **argv)
 
     ret = 0;
     if (verbose) {
-        BIO_printf(bio_err, "bytes read   :%8"PRIu64"\n", BIO_number_read(in));
-        BIO_printf(bio_err, "bytes written:%8"PRIu64"\n", BIO_number_written(out));
+        BIO_printf(bio_err, "bytes read   :%8ju\n", BIO_number_read(in));
+        BIO_printf(bio_err, "bytes written:%8ju\n", BIO_number_written(out));
     }
  end:
     ERR_print_errors(bio_err);

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1042,8 +1042,8 @@ static char *hexencode(const unsigned char *data, size_t len)
     int ilen = (int) outlen;
 
     if (outlen < len || ilen < 0 || outlen != (size_t)ilen) {
-        BIO_printf(bio_err, "%s: %" PRIu64 "-byte buffer too large to hexencode\n",
-                   opt_getprog(), (uint64_t)len);
+        BIO_printf(bio_err, "%s: %zu-byte buffer too large to hexencode\n",
+                   opt_getprog(), len);
         exit(1);
     }
     cp = out = app_malloc(ilen, "TLSA hex data buffer");

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2901,8 +2901,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 #endif
 
         BIO_printf(bio,
-                   "---\nSSL handshake has read %" PRIu64
-                   " bytes and written %" PRIu64 " bytes\n",
+                   "---\nSSL handshake has read %ju bytes "
+                   "and written %ju bytes\n",
                    BIO_number_read(SSL_get_rbio(s)),
                    BIO_number_written(SSL_get_wbio(s)));
     }

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -208,6 +208,7 @@ _dopr(char **sbuffer,
                 ch = *format++;
                 break;
             case 'q':
+            case 'j':
                 cflags = DP_C_LLONG;
                 ch = *format++;
                 break;

--- a/e_os.h
+++ b/e_os.h
@@ -42,6 +42,10 @@ extern "C" {
                              * non-compliant MSVCRT.DLL... */
 # elif defined(_WIN32)
 #  define OSSLzu  "u"
+# elif defined(__VMS)
+#  define OSSLzu  "u"       /* VMS suffers from similar problem as MinGW,
+                             * i.e. C RTL falling behind compiler. Recall
+			     * that sizeof(size_t)==4 even in LP64 VMS. */
 # elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define OSSLzu  "zu"
 # elif defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__==4

--- a/e_os.h
+++ b/e_os.h
@@ -30,29 +30,26 @@ extern "C" {
 # endif
 
 /*
- * We need a format operator for some client tools for uint64_t.  If inttypes.h
- * isn't available or did not define it, just go with hard-coded.
+ * Format specifier for printing size_t. Original conundrum was to
+ * get it working with -Wformat [-Werror], which can be considered
+ * overzelaous, especially in multi-platform context, but it's
+ * conscious choice...
  */
-# if defined(OPENSSL_SYS_UEFI)
-#  define PRIu64 "Lu"
-# endif
-# ifndef PRIu64
-#  ifdef SIXTY_FOUR_BIT_LONG
-#   define PRIu64 "lu"
-#  else
-#   define PRIu64 "llu"
-#  endif
-# endif
-
-/* Format specifier for printing size_t */
-# if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
+# if defined(_WIN64)
+#  define OSSLzu  "I64u"    /* One would expect _WIN{64|32} cases after
+                             * __STDC_VERSION__, but there are corner
+                             * cases of MinGW compilers that link with
+                             * non-compliant MSVCRT.DLL... */
+# elif defined(_WIN32)
+#  define OSSLzu  "u"
+# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define OSSLzu  "zu"
+# elif defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__==4
+#  define OSSLzu  "u"       /* 'lu' should have worked, but when generating
+                             * 32-bit code gcc still complains :-( */
 # else
-#  ifdef THIRTY_TWO_BIT
-#   define OSSLzu "u"
-#  else
-#   define OSSLzu PRIu64
-#  endif
+#  define OSSLzu  "lu"      /* To see that is works recall what does L
+                             * stand for in ILP32 and LP64 */
 # endif
 
 # if !defined(NDEBUG) && !defined(OPENSSL_NO_STDIO)

--- a/e_os.h
+++ b/e_os.h
@@ -45,7 +45,7 @@ extern "C" {
 # elif defined(__VMS)
 #  define OSSLzu  "u"       /* VMS suffers from similar problem as MinGW,
                              * i.e. C RTL falling behind compiler. Recall
-			     * that sizeof(size_t)==4 even in LP64 VMS. */
+                             * that sizeof(size_t)==4 even in LP64 case. */
 # elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define OSSLzu  "zu"
 # elif defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__==4

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -236,7 +236,6 @@ typedef INT32 int32_t;
 typedef UINT32 uint32_t;
 typedef INT64 int64_t;
 typedef UINT64 uint64_t;
-#  define PRIu64 "%Lu"
 # elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
      defined(__osf__) || defined(__sgi) || defined(__hpux) || \
      defined(OPENSSL_SYS_VMS) || defined (__OpenBSD__)


### PR DESCRIPTION
This takes further steps in #3060 context, up to point of dropping PRIu64...