### PR TITLE
Fix for #2730. Add CRLDP extension to list of supported extensions

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -277,6 +277,7 @@ int X509_supported_extension(X509_EXTENSION *ex)
         NID_subject_alt_name,   /* 85 */
         NID_basic_constraints,  /* 87 */
         NID_certificate_policies, /* 89 */
+        NID_crl_distribution_points, /* 103 */
         NID_ext_key_usage,      /* 126 */
 #ifndef OPENSSL_NO_RFC3779
         NID_sbgp_ipAddrBlock,   /* 290 */


### PR DESCRIPTION
##### Checklist

##### Description of change
Fixes #2730. Tracked it down to the extension missing from the list in X509_supported_extension().

I've not added a test, as this would require an always-accessible http address for the CRL download. I have manually tested using generated PKI and a CRL on an internal web server.