### PR TITLE
Fix bug when there is a pause between EoED and CF

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1829,6 +1829,7 @@ int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
         s->early_data_state = SSL_EARLY_DATA_WRITE_RETRY;
         return ret;
 
+    case SSL_EARLY_DATA_FINISHED_READING:
     case SSL_EARLY_DATA_READ_RETRY:
         /* We are a server writing to an unauthenticated client */
         s->early_data_state = SSL_EARLY_DATA_UNAUTH_WRITING;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
If the server received EoED then SSL_read_early_data() will return
SSL_READ_EARLY_DATA_FINISH. However if the CF has not yet been processed
then SSL_is_init_finished() will still return 0. Therefore we should still
be able to write early data.

Fixes #3041