### PR TITLE
Fix s_client early data indicator

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2403,7 +2403,7 @@ int s_client_main(int argc, char **argv)
         else
             timeoutp = NULL;
 
-        if (SSL_in_init(con) && !SSL_total_renegotiations(con)
+        if (!SSL_is_init_finished(con) && SSL_total_renegotiations(con) == 0
                 && SSL_get_key_update_type(con) == SSL_KEY_UPDATE_NONE) {
             in_init = 1;
             tty_on = 0;


### PR DESCRIPTION
s_client was always saying that early_data was rejected even when it was
accepted. This was because it was using the wrong test to detect the end
of the handshake. It was using SSL_in_init() which only tells you whether
it is currently processing/sending/expecting handshake messages. It should
use SSL_is_init_finished() which tells you that no handshake messages are
being processed/sent/expected AND we have completed the handshake. In the
early data case we are not processing/sending handshake messages and we
are expecting early data (not a handshake message) - but the handshake has
not yet completed.

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
