### PR TITLE
Don't handle handshake messages when writing early data on server

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -367,7 +367,13 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
 
     s->rlayer.wnum = 0;
 
-    if (SSL_in_init(s) && !ossl_statem_get_in_handshake(s)) {
+    /*
+     * When writing early data on the server side we could be "in_init" in
+     * between receiving the EoED and the CF - but we don't want to handle those
+     * messages yet.
+     */
+    if (SSL_in_init(s) && !ossl_statem_get_in_handshake(s)
+            && s->early_data_state != SSL_EARLY_DATA_UNAUTH_WRITING) {
         i = s->handshake_func(s);
         if (i < 0)
             return i;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1830,12 +1830,14 @@ int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
         return ret;
 
     case SSL_EARLY_DATA_FINISHED_READING:
-    case SSL_EARLY_DATA_READ_RETRY:
+    case SSL_EARLY_DATA_READ_RETRY: {
+        int early_data_state = s->early_data_state;
         /* We are a server writing to an unauthenticated client */
         s->early_data_state = SSL_EARLY_DATA_UNAUTH_WRITING;
         ret = SSL_write_ex(s, buf, num, written);
-        s->early_data_state = SSL_EARLY_DATA_READ_RETRY;
+        s->early_data_state = early_data_state;
         return ret;
+    }
 
     default:
         SSLerr(SSL_F_SSL_WRITE_EARLY_DATA, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1799,7 +1799,7 @@ int SSL_write_ex(SSL *s, const void *buf, size_t num, size_t *written)
 
 int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
 {
-    int ret;
+    int ret, early_data_state;
 
     switch (s->early_data_state) {
     case SSL_EARLY_DATA_NONE:
@@ -1830,14 +1830,13 @@ int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
         return ret;
 
     case SSL_EARLY_DATA_FINISHED_READING:
-    case SSL_EARLY_DATA_READ_RETRY: {
-        int early_data_state = s->early_data_state;
+    case SSL_EARLY_DATA_READ_RETRY:
+        early_data_state = s->early_data_state;
         /* We are a server writing to an unauthenticated client */
         s->early_data_state = SSL_EARLY_DATA_UNAUTH_WRITING;
         ret = SSL_write_ex(s, buf, num, written);
         s->early_data_state = early_data_state;
         return ret;
-    }
 
     default:
         SSLerr(SSL_F_SSL_WRITE_EARLY_DATA, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1544,7 +1544,8 @@ static int test_set_sigalgs(int idx)
 #define MSG3    "This"
 #define MSG4    "is"
 #define MSG5    "a"
-#define MSG6    "test."
+#define MSG6    "test"
+#define MSG7    "message."
 
 /*
  * Helper method to setup objects for early data test. Caller frees objects on
@@ -1772,6 +1773,19 @@ static int test_early_data_read_write(int idx)
      */
     if (SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes)) {
         printf("Unexpected success doing final client read\n");
+        goto end;
+    }
+
+    /* Server should be able to write normal data */
+    if (!SSL_write_ex(serverssl, MSG7, strlen(MSG7), &written)
+            || written != strlen(MSG7)) {
+        printf("Failed writing normal data message 7\n");
+        goto end;
+    }
+    if (!SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes)
+            || readbytes != strlen(MSG7)
+            || memcmp(MSG7, buf, strlen(MSG7))) {
+        printf("Failed reading message 7\n");
         goto end;
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
If we have received the EoED message but not yet had the CF then we are
"in init". Despite that we still want to write application data, so suppress
the "in init" check in ssl3_write_bytes() in that scenario.

The earlier commit (9b5c865d) testing for delayed arrival of CF didn't quite push back the arrival late enough to demonstrate this second problem

Fixes #3041