### PR TITLE
Fix a typo in the SSL_get_max_early_data() declarations

### DIFF
--- a/doc/man3/SSL_read_early_data.pod
+++ b/doc/man3/SSL_read_early_data.pod
@@ -19,7 +19,7 @@ SSL_get_early_data_status
  int SSL_CTX_set_max_early_data(SSL_CTX *ctx, uint32_t max_early_data);
  uint32_t SSL_CTX_get_max_early_data(const SSL_CTX *ctx);
  int SSL_set_max_early_data(SSL *s, uint32_t max_early_data);
- uint32_t SSL_get_max_early_data(const SSL_CTX *s);
+ uint32_t SSL_get_max_early_data(const SSL *s);
  uint32_t SSL_SESSION_get_max_early_data(const SSL_SESSION *s);
 
  int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -800,7 +800,7 @@ SSL_CTX_keylog_cb_func SSL_CTX_get_keylog_callback(const SSL_CTX *ctx);
 int SSL_CTX_set_max_early_data(SSL_CTX *ctx, uint32_t max_early_data);
 uint32_t SSL_CTX_get_max_early_data(const SSL_CTX *ctx);
 int SSL_set_max_early_data(SSL *s, uint32_t max_early_data);
-uint32_t SSL_get_max_early_data(const SSL_CTX *s);
+uint32_t SSL_get_max_early_data(const SSL *s);
 
 #ifdef __cplusplus
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4810,7 +4810,7 @@ int SSL_set_max_early_data(SSL *s, uint32_t max_early_data)
     return 1;
 }
 
-uint32_t SSL_get_max_early_data(const SSL_CTX *s)
+uint32_t SSL_get_max_early_data(const SSL *s)
 {
     return s->max_early_data;
 }


### PR DESCRIPTION
##### Checklist

##### Description of change
SSL_get_max_early_data() recently added by 3fc8d856105e ("Construct the
ticket_early_data_info extension", 2017-02-17, #2737) is supposed to take an
SSL, but it doesn't.

