### PR TITLE
e_afalg.[ch]: fix --strict-warnings with gcc 4.x and 32-bit build.

### DIFF
--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -236,15 +236,11 @@ int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
     memset(cb, '\0', sizeof(*cb));
     cb->aio_fildes = sfd;
     cb->aio_lio_opcode = IOCB_CMD_PREAD;
-    if (sizeof(buf) != sizeof(cb->aio_buf)) {
-        /*
-         * The pointer has to be converted to 32 bit unsigned value first
-         * to avoid sign extension on cast to 64 bit value
-         */
-        cb->aio_buf = (uint64_t)(unsigned long)buf;
-    } else {
-        cb->aio_buf = (uint64_t)buf;
-    }
+    /*
+     * The pointer has to be converted to unsigned value first to avoid
+     * sign extension on cast to 64 bit value in 32-bit builds
+     */
+    cb->aio_buf = (size_t)buf;
     cb->aio_offset = 0;
     cb->aio_data = 0;
     cb->aio_nbytes = len;
@@ -364,9 +360,9 @@ static int afalg_create_sk(afalg_ctx *actx, const char *ciphertype,
                                 const char *ciphername)
 {
     struct sockaddr_alg sa;
+    int r = -1;
 
     actx->bfd = actx->sfd = -1;
-    int r = -1;
 
     memset(&sa, 0, sizeof(sa));
     sa.salg_family = AF_ALG;

--- a/engines/afalg/e_afalg.h
+++ b/engines/afalg/e_afalg.h
@@ -10,6 +10,11 @@
 #ifndef HEADER_AFALG_H
 # define HEADER_AFALG_H
 
+# if defined(__GNUC__) && __GNUC__ >= 4 && \
+     (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+#  pragma GCC diagnostic ignored "-Wvariadic-macros"
+# endif
+
 # ifdef ALG_DEBUG
 #  define ALG_DGB(x, ...) fprintf(stderr, "ALG_DBG: " x, __VA_ARGS__)
 #  define ALG_INFO(x, ...) fprintf(stderr, "ALG_INFO: " x, __VA_ARGS__)


### PR DESCRIPTION
There is another 32-bit --strict-warning problem in ssl/statem/extensions_srvr.c, but it needs closer consideration...