### PR TITLE
Configure: use 5.10.0, don't require...

### DIFF
--- a/Configure
+++ b/Configure
@@ -9,7 +9,7 @@
 
 ##  Configure -- OpenSSL source tree configuration script
 
-require 5.10.0;
+use 5.10.0;
 use strict;
 use Config;
 use File::Basename;


### PR DESCRIPTION
Configure starts with 'require 5.10.0', but if executed by older perl
it fails with "might be runaway multi-line // string" instead of
naturally expected "Perl v5.10.0 required--this is only v5.x.y".
