### PR TITLE
Remove tls1.3 references from the man pages

### DIFF
--- a/doc/apps/ciphers.pod
+++ b/doc/apps/ciphers.pod
@@ -15,7 +15,6 @@ B<openssl> B<ciphers>
 [B<-tls1>]
 [B<-tls1_1>]
 [B<-tls1_2>]
-[B<-tls1_3>]
 [B<-s>]
 [B<-psk>]
 [B<-srp>]
@@ -69,11 +68,6 @@ L<SSL_CIPHER_description(3)>.
 =item B<-V>
 
 Like B<-v>, but include the official cipher suite values in hex.
-
-=item B<-tls1_3>
-
-In combination with the B<-s> option, list the ciphers which would be used if
-TLSv1.3 were negotiated.
 
 =item B<-tls1_2>
 

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -71,12 +71,10 @@ B<openssl> B<s_client>
 [B<-tls1>]
 [B<-tls1_1>]
 [B<-tls1_2>]
-[B<-tls1_3>]
 [B<-no_ssl3>]
 [B<-no_tls1>]
 [B<-no_tls1_1>]
 [B<-no_tls1_2>]
-[B<-no_tls1_3>]
 [B<-dtls>]
 [B<-dtls1>]
 [B<-dtls1_2>]
@@ -355,7 +353,7 @@ Use the PSK key B<key> when using a PSK cipher suite. The key is
 given as a hexadecimal number without leading 0x, for example -psk
 1a2b3c4d.
 
-=item B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
+=item B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>
 
 These options require or disable the use of the specified SSL or TLS protocols.
 By default B<s_client> will negotiate the highest mutually supported protocol

--- a/doc/apps/s_server.pod
+++ b/doc/apps/s_server.pod
@@ -78,7 +78,6 @@ B<openssl> B<s_server>
 [B<-tls1>]
 [B<-tls1_1>]
 [B<-tls1_2>]
-[B<-tls1_3>]
 [B<-dtls>]
 [B<-dtls1>]
 [B<-dtls1_2>]
@@ -91,7 +90,6 @@ B<openssl> B<s_server>
 [B<-no_tls1>]
 [B<-no_tls1_1>]
 [B<-no_tls1_2>]
-[B<-no_tls1_3>]
 [B<-no_dhe>]
 [B<-bugs>]
 [B<-comp>]
@@ -326,7 +324,7 @@ Use the PSK key B<key> when using a PSK cipher suite. The key is
 given as a hexadecimal number without leading 0x, for example -psk
 1a2b3c4d.
 
-=item B<-ssl2>, B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>, B<-no_ssl2>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
+=item B<-ssl2>, B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-no_ssl2>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>
 
 These options require or disable the use of the specified SSL or TLS protocols.
 By default B<s_server> will negotiate the highest mutually supported protocol


### PR DESCRIPTION
The man pages for ciphers, s_client and s_server mention the tls1_3
option but it is not implemented in the 1.1.0 branch. Thus remove it to
avoid confusion.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>