### PR TITLE
Disable 15-test_ecparam.t when configured no-ec2m

### DIFF
--- a/test/recipes/15-test_ecparam.t
+++ b/test/recipes/15-test_ecparam.t
@@ -18,7 +18,7 @@ use OpenSSL::Test::Utils;
 setup("test_ecparam");
 
 plan skip_all => "EC isn't supported in this build"
-    if disabled("ec");
+    if disabled("ec") || disabled("ec2m");
 
 my @valid = glob(data_file("valid", "*.pem"));
 my @invalid = glob(data_file("invalid", "*.pem"));


### PR DESCRIPTION
This test doesn't actually fail completely, but there's no real pattern to distinguish which data files should be omitted when no-ec2m is configured and which should not.


##### Checklist
- [x] tests are added or updated
