### PR TITLE
Fixup the github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,12 @@
 <!--
-Thank you for your pull request. Please review below requirements.
+Thank you for your pull request. Please review these requirements:
 
 Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
+
+Other than that, provide a description above this comment if there isn't one already, and if it fixes a github issue, add 'Fixes #XXXX' (without quotes) as well.
 -->
 
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 - [ ] documentation is added or updated
 - [ ] tests are added or updated
-
-##### Description of change
-<!-- Provide a description of the changes.
-
-If it fixes a github issue, add Fixes #XXXX.
--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,9 @@ Thank you for your pull request. Please review these requirements:
 
 Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
 
-Other than that, provide a description above this comment if there isn't one already, and if it fixes a github issue, add 'Fixes #XXXX' (without quotes) as well.
+Other than that, provide a description above this comment if there isn't one already
+
+If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
 -->
 
 ##### Checklist


### PR DESCRIPTION
When creating a single commit PR, github will now automatically include the commit comment first in the pull request description, and add the template content last.  That makes the description section at the end useless.

This also tries to encourage people to include `Fixes #XXXX` in their commit message when fixing github issues, as that provides better automation (automatic closing of issues).