### PR TITLE
WIP: ssl/ssl_locl.c: switch to time_t time.

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -551,7 +551,7 @@ struct ssl_session_st {
     long verify_result;         /* only for servers */
     CRYPTO_REF_COUNT references;
     long timeout;
-    long time;
+    time_t time;
     unsigned int compress_meth; /* Need to lookup the method */
     const SSL_CIPHER *cipher;
     unsigned long cipher_id;    /* when ASN.1 loaded, this needs to be used to

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -103,7 +103,7 @@ SSL_SESSION *SSL_SESSION_new(void)
     ss->verify_result = 1;      /* avoid 0 (= X509_V_OK) just in case */
     ss->references = 1;
     ss->timeout = 60 * 5 + 4;   /* 5 minute timeout by default */
-    ss->time = (unsigned long)time(NULL);
+    ss->time = time(NULL);
     ss->lock = CRYPTO_THREAD_lock_new();
     if (ss->lock == NULL) {
         SSLerr(SSL_F_SSL_SESSION_NEW, ERR_R_MALLOC_FAILURE);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -681,7 +681,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     SSL_SESSION *sess = NULL;
     unsigned int id, i;
     const EVP_MD *md = NULL;
-    uint32_t ticket_age = 0, now, agesec, agems;
+    uint32_t ticket_age = 0, agesec, agems;
 
     /*
      * If we have no PSK kex mode that we recognise then we can't resume so
@@ -767,8 +767,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     sess->ext.tick_identity = id;
 
-    now = (uint32_t)time(NULL);
-    agesec = now - (uint32_t)sess->time;
+    agesec = (uint32_t)(time(NULL) - sess->time);
     agems = agesec * (uint32_t)1000;
     ticket_age -= sess->ext.tick_age_add;
 
@@ -780,7 +779,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
      * client's due to the network latency). Therefore we add 1000ms to our age
      * calculation to adjust for rounding errors.
      */
-    if (sess->timeout >= agesec
+    if (sess->timeout >= (long)agesec
             && agems / (uint32_t)1000 == agesec
             && ticket_age <= agems + 1000
             && ticket_age + TICKET_AGE_ALLOWANCE >= agems + 1000) {


### PR DESCRIPTION
This is rather a conversation starter than WIP. Well, it is also a WIP, but it touches too little of the problem. I've ran into this when looking at 32-bit --strict-warning build. What's wrong with `long time` in ssl_session_st (as well as else-/anywhere). Problem is that there are platforms where sizeof(long) < sizeof(time_t). [No, not *cough*-dows alone.] Note that it's kind of loose-loose situation. Currently it's problematic to assign ssl_session_st.time, because of possible truncate, but if it's declared time_t, it becomes problematic to return it with SSL_SESSION_get_time. Also note that it might be undesirable to return time_t from SSL_SESSION_get_time, because there is platform, *cough*-dows,  where sizeof(time_t) depends on compiler flags. Trouble is that while we have control over flags OpenSSL itself gets compiled with, we don't have control over flags for application that includes our public header. With this in mind you kind of start pondering over  [64-bit] ossl_time_t. But how about this? If we take this path, why not as well choose other units, such as milliseconds...