### PR TITLE
crypto/ppccap.c: SIGILL-free processor capabilities detection on MacOS X

### DIFF
--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -7,6 +7,10 @@
 #if defined(__linux) || defined(_AIX)
 # include <sys/utsname.h>
 #endif
+#if defined(__APPLE__) && defined(__MACH__)
+# include <sys/types.h>
+# include <sys/sysctl.h>
+#endif
 #include <openssl/crypto.h>
 #include <openssl/bn.h>
 
@@ -120,6 +124,28 @@ void OPENSSL_cpuid_setup(void)
 # endif
         if (uname(&uts) != 0 || atoi(uts.version) < 6)
             return;
+    }
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+    OPENSSL_ppccap_P |= PPC_FPU;
+
+    {
+        int val;
+        size_t len = sizeof(val);
+
+        if (sysctlbyname("hw.optional.64bitops", &val, &len, NULL, 0) == 0) {
+            if (val)
+                OPENSSL_ppccap_P |= PPC_FPU64;
+        }
+
+        len = sizeof(val);
+        if (sysctlbyname("hw.optional.altivec", &val, &len, NULL, 0) == 0) {
+            if (val)
+                OPENSSL_ppccap_P |= PPC_ALTIVEC;
+        }
+
+        return;
     }
 #endif
 

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -128,8 +128,6 @@ void OPENSSL_cpuid_setup(void)
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__)
-    OPENSSL_ppccap_P |= PPC_FPU;
-
     {
         int val;
         size_t len = sizeof(val);


### PR DESCRIPTION
It seems to be problematic to probe processor capabilities with SIGILL
on MacOS X. The problem should be limited to cases when application code
is debugged, but crashes were reported even during normal execution...

[backport of 0bd93bbe4ae60e5f318b298bfe617e468a7b71d0] a.k.a #3101

