### PR TITLE
Fix SSL_get_server_tmp_key() in TLSv1.3

### DIFF
--- a/doc/man3/SSL_get_server_tmp_key.pod
+++ b/doc/man3/SSL_get_server_tmp_key.pod
@@ -1,0 +1,43 @@
+=pod
+
+=head1 NAME
+
+SSL_get_server_tmp_key - get information about the server's temporary key used
+during a handshake
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ long SSL_get_server_tmp_key(SSL *ssl, EVP_PKEY **key);
+
+=head1 DESCRIPTION
+
+SSL_get_server_tmp_key() returns the temporary key provided by the server and
+used during key exchange. For example, if ECDHE is in use, then this represents
+the server's public ECDHE key. On success a pointer to the key is stored in
+B<*key>. It is the caller's responsibility to free this key after use using
+L<EVP_PKEY_free(3)>. This function may only be called by the client.
+
+=head1 RETURN VALUES
+
+SSL_get_server_tmp_key() returns 1 on success or 0 otherwise.
+
+=head1 NOTES
+
+This function is implemented as a macro.
+
+=head1 SEE ALSO
+
+L<ssl(7)>, L<EVP_PKEY_free(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1295,7 +1295,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     EVP_PKEY *ckey = s->s3->tmp.pkey, *skey = NULL;
 
     /* Sanity check */
-    if (ckey == NULL) {
+    if (ckey == NULL || s->s3->peer_tmp != NULL) {
         *al = SSL_AD_INTERNAL_ERROR;
         SSLerr(SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
         return 0;
@@ -1386,7 +1386,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         EVP_PKEY_free(skey);
         return 0;
     }
-    EVP_PKEY_free(skey);
+    s->s3->peer_tmp = skey;
 #endif
 
     return 1;


### PR DESCRIPTION
The macro SSL_get_server_tmp_key() returns information about the temp key
used by the server during a handshake. This was returning NULL for TLSv1.3
and causing s_client to omit this information in its connection summary.

This PR also adds some documentation for this macro.

Fixes #3081
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
