### PR TITLE
Configure: recognize -framewrok as linker option [on Apple OSes].

### DIFF
--- a/Configure
+++ b/Configure
@@ -743,6 +743,10 @@ while (@argvcopy)
 			{
 			$libs.=$_." ";
 			}
+		elsif (/^-framework$/)
+			{
+			$libs.=$_." ".shift(@argvcopy)." ";
+			}
 		elsif (/^-rpath$/ or /^-R$/)
 			# -rpath is the OSF1 rpath flag
 			# -R is the old Solaris rpath flag


### PR DESCRIPTION
This is handy for internal iOS tests, when you have to make it work
in sandbox.
