### PR TITLE
e_os2.h: Refine OSSL_SSIZE definition under UEFI environment

### DIFF
--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -207,12 +207,8 @@ extern "C" {
 # endif
 
 # if defined(OPENSSL_SYS_UEFI) && !defined(ossl_ssize_t)
-#  if !defined(ssize_t)
-#   define ossl_ssize_t int
-#  else
-#   define ossl_ssize_t ssize_t
-#  endif
-#  define OSSL_SSIZE_MAX INT_MAX
+#  define ossl_ssize_t INTN
+#  define OSSL_SSIZE_MAX MAX_INTN
 # endif
 
 # ifndef ossl_ssize_t

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -206,8 +206,12 @@ extern "C" {
 #  endif
 # endif
 
-# if defined(OPENSSL_SYS_UEFI) && !defined(ssize_t)
-#  define ossl_ssize_t int
+# if defined(OPENSSL_SYS_UEFI) && !defined(ossl_ssize_t)
+#  if !defined(ssize_t)
+#   define ossl_ssize_t int
+#  else
+#   define ossl_ssize_t ssize_t
+#  endif
 #  define OSSL_SSIZE_MAX INT_MAX
 # endif
 


### PR DESCRIPTION
Under UEFI build environment, we may encounter the OSSL_SSIZE macro
re-definition error in e_os2.h if any module call OpenSSL API directly
by including "openssl/xxxx.h" (caused by the predefined _WIN32/_WIN64
macro, which should have been un-defined under OPENSSL_SYS_UEFI).

Though it's not one recommended usage, this patch could still eliminate
the possible build issue by refining the OSSL_SSIZE definition under
OPENSSL_SYS_UEFI.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
