### PR TITLE
Additional check to handle BAD SSL_write retry, in 1.0.2 version

### DIFF
--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -670,7 +670,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, int len)
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if (len < tot) {
+    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wnum)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return (-1);
     }

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -670,7 +670,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, int len)
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wnum)))) {
+    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wpend_tot)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return (-1);
     }

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -670,7 +670,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, int len)
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wpend_tot)))) {
+    if ((len < tot) || ((wb->left != 0) && (len < (tot + s->s3->wpend_tot)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return (-1);
     }


### PR DESCRIPTION
New check is added in in ssl3_write_bytes, to handle ssl3_write_bytes failure.

If SSL_write is called after failure with smaller buffer length (smaller than overall length, but bigger than tot), then after ssl3_write_pending we are doing "n = (len - tot)". This will give a value close to 2^32 to n. Then this will cause ABR to application buffer.
 