### PR TITLE
Additional check to handle BAD SSL_write retry, in master branch

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -356,7 +356,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if (len < s->rlayer.wnum) {
+    if ((len < s->rlayer.wnum) || ((tot != 0) && (len < (tot + s->rlayer.wnum)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return -1;
     }

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -356,7 +356,8 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if ((len < s->rlayer.wnum) || ((tot != 0) && (len < (tot + s->rlayer.wpend_tot)))) {
+    if ((len < s->rlayer.wnum) 
+        || ((wb->left != 0) && (len < (s->rlayer.wnum + s->rlayer.wpend_tot)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return -1;
     }

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -356,7 +356,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if ((len < s->rlayer.wnum) || ((tot != 0) && (len < (tot + s->rlayer.wnum)))) {
+    if ((len < s->rlayer.wnum) || ((tot != 0) && (len < (tot + s->rlayer.wpend_tot)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return -1;
     }


### PR DESCRIPTION
New check is added in in ssl3_write_bytes, to handle ssl3_write_bytes failure.

If SSL_write is called after failure with smaller buffer length (smaller than overall length, but bigger than tot), then after ssl3_write_pending we are doing "n = (len - tot)". This will give a value close to 2^32 to n. Then this will cause ABR to application buffer.