### PR TITLE
In rand_cleanup_int(), don't go creating a default method

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -74,7 +74,7 @@ int RAND_set_rand_engine(ENGINE *engine)
 
 void rand_cleanup_int(void)
 {
-    const RAND_METHOD *meth = RAND_get_rand_method();
+    const RAND_METHOD *meth = default_RAND_meth;
     if (meth && meth->cleanup)
         meth->cleanup();
     RAND_set_rand_method(NULL);


### PR DESCRIPTION
If no default method was yet given, RAND_get_rand_method() will set it
up.  Doing so just to clean it away seems pretty silly, so instead,
use the default_RAND_meth variable directly.

This also clears a possible race condition where this will try to init
things, such as ERR or ENGINE when in the middle of a OPENSSL_cleanup.

Fixes #3128