### PR TITLE
Make getting and setting the RAND default method thread safe

### DIFF
--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -166,11 +166,6 @@ void engine_cleanup_int(void)
                                         engine_cleanup_cb_free);
         cleanup_stack = NULL;
     }
-    /*
-     * FIXME: This should be handled (somehow) through RAND, eg. by it
-     * registering a cleanup callback.
-     */
-    RAND_set_rand_method(NULL);
     CRYPTO_THREAD_lock_free(global_engine_lock);
 }
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -109,6 +109,8 @@ void rand_cleanup_int(void)
     if (meth && meth->cleanup)
         meth->cleanup();
     RAND_set_rand_method(NULL);
+    CRYPTO_THREAD_lock_free(rand_meth_lock);
+    CRYPTO_THREAD_lock_free(rand_engine_lock);
 }
 
 void RAND_seed(const void *buf, int num)

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -12,27 +12,50 @@
 #include "internal/cryptlib.h"
 #include <openssl/opensslconf.h>
 #include "internal/rand.h"
-
 #include <openssl/engine.h>
+#include "internal/thread_once.h"
 
 #ifndef OPENSSL_NO_ENGINE
 /* non-NULL if default_RAND_meth is ENGINE-provided */
 static ENGINE *funct_ref = NULL;
+static CRYPTO_RWLOCK *rand_engine_lock = NULL;
 #endif
 static const RAND_METHOD *default_RAND_meth = NULL;
+static CRYPTO_RWLOCK *rand_meth_lock = NULL;
+static CRYPTO_ONCE rand_lock_init = CRYPTO_ONCE_STATIC_INIT;
+
+DEFINE_RUN_ONCE_STATIC(do_rand_lock_init)
+{
+#ifndef OPENSSL_NO_ENGINE
+    rand_engine_lock = CRYPTO_THREAD_lock_new();
+#endif
+    rand_meth_lock = CRYPTO_THREAD_lock_new();
+    return rand_engine_lock != NULL && rand_meth_lock != NULL;
+}
 
 int RAND_set_rand_method(const RAND_METHOD *meth)
 {
+    if (!RUN_ONCE(&rand_lock_init, do_rand_lock_init))
+        return 0;
+
+    CRYPTO_THREAD_write_lock(rand_meth_lock);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(funct_ref);
     funct_ref = NULL;
 #endif
     default_RAND_meth = meth;
+    CRYPTO_THREAD_unlock(rand_meth_lock);
     return 1;
 }
 
 const RAND_METHOD *RAND_get_rand_method(void)
 {
+    const RAND_METHOD *tmp_meth = NULL;
+
+    if (!RUN_ONCE(&rand_lock_init, do_rand_lock_init))
+        return NULL;
+
+    CRYPTO_THREAD_write_lock(rand_meth_lock);
     if (!default_RAND_meth) {
 #ifndef OPENSSL_NO_ENGINE
         ENGINE *e = ENGINE_get_default_RAND();
@@ -49,13 +72,19 @@ const RAND_METHOD *RAND_get_rand_method(void)
 #endif
             default_RAND_meth = RAND_OpenSSL();
     }
-    return default_RAND_meth;
+    tmp_meth = default_RAND_meth;
+    CRYPTO_THREAD_unlock(rand_meth_lock);
+    return tmp_meth;
 }
 
 #ifndef OPENSSL_NO_ENGINE
 int RAND_set_rand_engine(ENGINE *engine)
 {
     const RAND_METHOD *tmp_meth = NULL;
+
+    if (!RUN_ONCE(&rand_lock_init, do_rand_lock_init))
+        return 0;
+
     if (engine) {
         if (!ENGINE_init(engine))
             return 0;
@@ -65,9 +94,11 @@ int RAND_set_rand_engine(ENGINE *engine)
             return 0;
         }
     }
+    CRYPTO_THREAD_write_lock(rand_engine_lock);
     /* This function releases any prior ENGINE so call it first */
     RAND_set_rand_method(tmp_meth);
     funct_ref = engine;
+    CRYPTO_THREAD_unlock(rand_engine_lock);
     return 1;
 }
 #endif


### PR DESCRIPTION
From a comment in #3136, where it was noticed that `RAND_set_rand_method()` and friends weren't thread safe.