### PR TITLE
TLSv1.3: Update the custom extensions API

### DIFF
--- a/doc/man3/SSL_extension_supported.pod
+++ b/doc/man3/SSL_extension_supported.pod
@@ -12,29 +12,32 @@ custom_ext_add_cb, custom_ext_free_cb, custom_ext_parse_cb
 
  #include <openssl/ssl.h>
 
- typedef int (*custom_ext_add_cb_ex) (SSL *s, unsigned int ext_type,
-                                      unsigned int context,
-                                      const unsigned char **out,
-                                      size_t *outlen, X509 *x, size_t chainidx,
-                                      int *al, void *add_arg);
+ typedef int (*SSL_custom_ext_add_cb_ex) (SSL *s, unsigned int ext_type,
+                                          unsigned int context,
+                                          const unsigned char **out,
+                                          size_t *outlen, X509 *x,
+                                          size_t chainidx, int *al,
+                                          void *add_arg);
 
- typedef void (*custom_ext_free_cb_ex) (SSL *s, unsigned int ext_type,
-                                        unsigned int context,
-                                        const unsigned char *out,
-                                        void *add_arg);
+ typedef void (*SSL_custom_ext_free_cb_ex) (SSL *s, unsigned int ext_type,
+                                            unsigned int context,
+                                            const unsigned char *out,
+                                            void *add_arg);
 
- typedef int (*custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
-                                        unsigned int context,
-                                        const unsigned char *in,
-                                        size_t inlen, X509 *x, size_t chainidx,
-                                        int *al, void *parse_arg);
+ typedef int (*SSL_custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
+                                            unsigned int context,
+                                            const unsigned char *in,
+                                            size_t inlen, X509 *x,
+                                            size_t chainidx, int *al,
+                                            void *parse_arg);
 
  int SSL_CTX_add_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
                             unsigned int context,
-                            custom_ext_add_cb_ex add_cb,
-                            custom_ext_free_cb_ex free_cb,
+                            SSL_custom_ext_add_cb_ex add_cb,
+                            SSL_custom_ext_free_cb_ex free_cb,
                             void *add_arg,
-                            custom_ext_parse_cb_ex parse_cb, void *parse_arg);
+                            SSL_custom_ext_parse_cb_ex parse_cb,
+                            void *parse_arg);
 
  typedef int (*custom_ext_add_cb)(SSL *s, unsigned int ext_type,
                                   const unsigned char **out,

--- a/doc/man3/SSL_extension_supported.pod
+++ b/doc/man3/SSL_extension_supported.pod
@@ -66,30 +66,31 @@ custom_ext_add_cb, custom_ext_free_cb, custom_ext_parse_cb
 
 =head1 DESCRIPTION
 
-SSL_CTX_add_custom_ext() adds a custom extension for a (D)TLS client or server
+SSL_CTX_add_custom_ext() adds a custom extension for a TLS/DTLS client or server
 for all supported protocol versions with extension type B<ext_type> and
 callbacks B<add_cb>, B<free_cb> and B<parse_cb> (see the
 L</EXTENSION CALLBACKS> section below). The B<context> value determines
 which messages and under what conditions the extension will be added/parsed (see
 the L</EXTENSION CONTEXTS> section below).
 
-SSL_CTX_add_client_custom_ext() adds a custom extension for a (D)TLS client with
-extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and B<parse_cb>.
-This function is similar to SSL_CTX_add_custom_ext() except it only applies
-to clients, uses the older style of callbacks, and implicitly sets the
+SSL_CTX_add_client_custom_ext() adds a custom extension for a TLS/DTLS client
+with extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and
+B<parse_cb>. This function is similar to SSL_CTX_add_custom_ext() except it only
+applies to clients, uses the older style of callbacks, and implicitly sets the
 B<context> value to:
 
  SSL_EXT_TLS1_2_AND_BELOW_ONLY | SSL_EXT_CLIENT_HELLO
  | SSL_EXT_TLS1_2_SERVER_HELLO | SSL_EXT_IGNORE_ON_RESUMPTION
 
-SSL_CTX_add_server_custom_ext() adds a custom extension for a (D)TLS server with
-extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and
+SSL_CTX_add_server_custom_ext() adds a custom extension for a TLS/DTLS server
+with extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and
 B<parse_cb>. This function is similar to SSL_CTX_add_custom_ext() except it
 only applies to servers, uses the older style of callbacks, and implicitly sets
 the B<context> value to the same as for SSL_CTX_add_client_custom_ext() above.
 
-In all cases the extension type must not be handled by OpenSSL internally
-or an error occurs.
+The B<ext_type> parameter corresponds to the B<extension_type> field of
+RFC5246 et al. It is B<not> a NID. In all cases the extension type must not be
+handled by OpenSSL internally or an error occurs.
 
 SSL_extension_supported() returns 1 if the extension B<ext_type> is handled
 internally by OpenSSL and 0 otherwise.
@@ -112,7 +113,7 @@ If the B<add_cb> does not wish to include the extension it must return 0.
 If B<add_cb> returns -1 a fatal handshake error occurs using the TLS
 alert value specified in B<*al>.
 
-When constructing the ClientHello if B<add_cb> is set to NULL a zero length
+When constructing the ClientHello, if B<add_cb> is set to NULL a zero length
 extension is added for B<ext_type>. For all other messages if B<add_cb> is set
 to NULL then no extension is added.
 
@@ -188,8 +189,9 @@ the extension in SSLv3. Applications will not typically need to use this.
 
 =item SSL_EXT_TLS1_2_AND_BELOW_ONLY
 
-The extension is only defined for (D)TLSv1.2 and below. Servers will ignore this
-extension if it is present in the ClientHello and TLSv1.3 is negotiated.
+The extension is only defined for TLSv1.2/DTLSv1.2 and below. Servers will
+ignore this extension if it is present in the ClientHello and TLSv1.3 is
+negotiated.
 
 =item SSL_EXT_TLS1_3_ONLY
 
@@ -246,9 +248,6 @@ The B<add_arg> and B<parse_arg> parameters can be set to arbitrary values
 which will be passed to the corresponding callbacks. They can, for example,
 be used to store the extension data received in a convenient structure or
 pass the extension data to be added or freed when adding extensions.
-
-The B<ext_type> parameter corresponds to the B<extension_type> field of
-RFC5246 et al. It is B<not> a NID.
 
 If the same custom extension type is received multiple times a fatal
 B<decode_error> alert is sent and the handshake aborts. If a custom extension

--- a/doc/man3/SSL_extension_supported.pod
+++ b/doc/man3/SSL_extension_supported.pod
@@ -3,6 +3,7 @@
 =head1 NAME
 
 SSL_extension_supported,
+SSL_CTX_add_custom_ext,
 SSL_CTX_add_client_custom_ext, SSL_CTX_add_server_custom_ext,
 custom_ext_add_cb, custom_ext_free_cb, custom_ext_parse_cb
 - custom TLS extension handling
@@ -11,19 +12,29 @@ custom_ext_add_cb, custom_ext_free_cb, custom_ext_parse_cb
 
  #include <openssl/ssl.h>
 
- int SSL_CTX_add_client_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
-                                   custom_ext_add_cb add_cb,
-                                   custom_ext_free_cb free_cb, void *add_arg,
-                                   custom_ext_parse_cb parse_cb,
-                                   void *parse_arg);
+ typedef int (*custom_ext_add_cb_ex) (SSL *s, unsigned int ext_type,
+                                      unsigned int context,
+                                      const unsigned char **out,
+                                      size_t *outlen, X509 *x, size_t chainidx,
+                                      int *al, void *add_arg);
 
- int SSL_CTX_add_server_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
-                                   custom_ext_add_cb add_cb,
-                                   custom_ext_free_cb free_cb, void *add_arg,
-                                   custom_ext_parse_cb parse_cb,
-                                   void *parse_arg);
+ typedef void (*custom_ext_free_cb_ex) (SSL *s, unsigned int ext_type,
+                                        unsigned int context,
+                                        const unsigned char *out,
+                                        void *add_arg);
 
- int SSL_extension_supported(unsigned int ext_type);
+ typedef int (*custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
+                                        unsigned int context,
+                                        const unsigned char *in,
+                                        size_t inlen, X509 *x, size_t chainidx,
+                                        int *al, void *parse_arg);
+
+ int SSL_CTX_add_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
+                            unsigned int context,
+                            custom_ext_add_cb_ex add_cb,
+                            custom_ext_free_cb_ex free_cb,
+                            void *add_arg,
+                            custom_ext_parse_cb_ex parse_cb, void *parse_arg);
 
  typedef int (*custom_ext_add_cb)(SSL *s, unsigned int ext_type,
                                   const unsigned char **out,
@@ -39,18 +50,45 @@ custom_ext_add_cb, custom_ext_free_cb, custom_ext_parse_cb
                                     size_t inlen, int *al,
                                     void *parse_arg);
 
+ int SSL_CTX_add_client_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
+                                   custom_ext_add_cb add_cb,
+                                   custom_ext_free_cb free_cb, void *add_arg,
+                                   custom_ext_parse_cb parse_cb,
+                                   void *parse_arg);
+
+ int SSL_CTX_add_server_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
+                                   custom_ext_add_cb add_cb,
+                                   custom_ext_free_cb free_cb, void *add_arg,
+                                   custom_ext_parse_cb parse_cb,
+                                   void *parse_arg);
+
+ int SSL_extension_supported(unsigned int ext_type);
 
 =head1 DESCRIPTION
 
-SSL_CTX_add_client_custom_ext() adds a custom extension for a TLS client
-with extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and
-B<parse_cb>.
+SSL_CTX_add_custom_ext() adds a custom extension for a (D)TLS client or server
+for all supported protocol versions with extension type B<ext_type> and
+callbacks B<add_cb>, B<free_cb> and B<parse_cb> (see the
+L</EXTENSION CALLBACKS> section below). The B<context> value determines
+which messages and under what conditions the extension will be added/parsed (see
+the L</EXTENSION CONTEXTS> section below).
 
-SSL_CTX_add_server_custom_ext() adds a custom extension for a TLS server
-with extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and
-B<parse_cb>.
+SSL_CTX_add_client_custom_ext() adds a custom extension for a (D)TLS client with
+extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and B<parse_cb>.
+This function is similar to SSL_CTX_add_custom_ext() except it only applies
+to clients, uses the older style of callbacks, and implicitly sets the
+B<context> value to:
 
-In both cases the extension type must not be handled by OpenSSL internally
+ SSL_EXT_TLS1_2_AND_BELOW_ONLY | SSL_EXT_CLIENT_HELLO
+ | SSL_EXT_TLS1_2_SERVER_HELLO | SSL_EXT_IGNORE_ON_RESUMPTION
+
+SSL_CTX_add_server_custom_ext() adds a custom extension for a (D)TLS server with
+extension type B<ext_type> and callbacks B<add_cb>, B<free_cb> and
+B<parse_cb>. This function is similar to SSL_CTX_add_custom_ext() except it
+only applies to servers, uses the older style of callbacks, and implicitly sets
+the B<context> value to the same as for SSL_CTX_add_client_custom_ext() above.
+
+In all cases the extension type must not be handled by OpenSSL internally
 or an error occurs.
 
 SSL_extension_supported() returns 1 if the extension B<ext_type> is handled
@@ -59,9 +97,11 @@ internally by OpenSSL and 0 otherwise.
 =head1 EXTENSION CALLBACKS
 
 The callback B<add_cb> is called to send custom extension data to be
-included in ClientHello for TLS clients or ServerHello for servers. The
-B<ext_type> parameter is set to the extension type which will be added and
-B<add_arg> to the value set when the extension handler was added.
+included in various TLS messages. The B<ext_type> parameter is set to the
+extension type which will be added and B<add_arg> to the value set when the
+extension handler was added. When using the new style callbacks the B<context>
+parameter will indicate which message is currently being constructed e.g. for
+the ClientHello it will be set to B<SSL_EXT_CLIENT_HELLO>.
 
 If the application wishes to include the extension B<ext_type> it should
 set B<*out> to the extension data, set B<*outlen> to the length of the
@@ -72,16 +112,25 @@ If the B<add_cb> does not wish to include the extension it must return 0.
 If B<add_cb> returns -1 a fatal handshake error occurs using the TLS
 alert value specified in B<*al>.
 
-For clients (but not servers) if B<add_cb> is set to NULL a zero length
-extension is added for B<ext_type>.
+When constructing the ClientHello if B<add_cb> is set to NULL a zero length
+extension is added for B<ext_type>. For all other messages if B<add_cb> is set
+to NULL then no extension is added.
 
-For clients every registered B<add_cb> is always called to see if the
-application wishes to add an extension to ClientHello.
+When constructing a Certificate message the callback will be called for each
+certificate in the message. The B<x> parameter will indicate the
+current certificate and the B<chainidx> parameter will indicate the position
+of the certificate in the message. The first certificate is always the end
+entity certificate and has a B<chainidx> value of 0.
 
-For servers every registered B<add_cb> is called once if and only if the
-corresponding extension was received in ClientHello to see if the application
-wishes to add the extension to ServerHello. That is, if no corresponding extension
-was received in ClientHello then B<add_cb> will not be called.
+For all messages except the ServerHello and EncryptedExtensions every
+registered B<add_cb> is always called to see if the application wishes to add an
+extension (as long as all requirements of the specified B<context> are met).
+
+For the ServerHello and EncryptedExtension messages every registered B<add_cb>
+is called once if and only if the requirements of the specified B<context> are
+met and the corresponding extension was received in the ClientHello. That is, if
+no corresponding extension was received in the ClientHello then B<add_cb> will
+not be called.
 
 If an extension is added (that is B<add_cb> returns 1) B<free_cb> is called
 (if it is set) with the value of B<out> set by the add callback. It can be
@@ -89,12 +138,19 @@ used to free up any dynamic extension data set by B<add_cb>. Since B<out> is
 constant (to permit use of constant data in B<add_cb>) applications may need to
 cast away const to free the data.
 
-The callback B<parse_cb> receives data for TLS extensions. For TLS clients
-the extension data will come from ServerHello and for TLS servers it will
-come from ClientHello.
+The callback B<parse_cb> receives data for TLS extensions. The callback is only
+called if the extension is present and relevant for the context (see
+L</EXTENSION CONTEXTS> below).
 
 The extension data consists of B<inlen> bytes in the buffer B<in> for the
-extension B<extension_type>.
+extension B<ext_type>.
+
+If the message being parsed is a TLSv1.3 compatible Certificate message then
+B<parse_cb> will be called for each certificate contained within the message.
+The B<x> parameter will indicate the current certificate and the B<chainidx>
+parameter will indicate the position of the certificate in the message. The
+first certificate is always the end entity certificate and has a B<chainidx>
+value of 0.
 
 If the B<parse_cb> considers the extension data acceptable it must return
 1. If it returns 0 or a negative value a fatal handshake error occurs
@@ -102,6 +158,87 @@ using the TLS alert value specified in B<*al>.
 
 The buffer B<in> is a temporary internal buffer which will not be valid after
 the callback returns.
+
+=head1 EXTENSION CONTEXTS
+
+An extension context defines which messages and under which conditions an
+extension should be added or expected. The context is built up by performing
+a bitwise OR of multiple pre-defined values together. The valid context values
+are:
+
+=over 4
+
+=item SSL_EXT_TLS_ONLY
+
+The extension is only allowed in TLS
+
+=item SSL_EXT_DTLS_ONLY
+
+The extension is only allowed in DTLS
+
+=item SSL_EXT_TLS_IMPLEMENTATION_ONLY
+
+The extension is allowed in DTLS, but there is only a TLS implementation
+available (so it is ignored in DTLS).
+
+=item SSL_EXT_SSL3_ALLOWED
+
+Extensions are not typically defined for SSLv3. Setting this value will allow
+the extension in SSLv3. Applications will not typically need to use this.
+
+=item SSL_EXT_TLS1_2_AND_BELOW_ONLY
+
+The extension is only defined for (D)TLSv1.2 and below. Servers will ignore this
+extension if it is present in the ClientHello and TLSv1.3 is negotiated.
+
+=item SSL_EXT_TLS1_3_ONLY
+
+The extension is only defined for TLS1.3 and above. Servers will ignore this
+extension if it is present in the ClientHello and TLSv1.2 or below is
+negotiated.
+
+=item SSL_EXT_IGNORE_ON_RESUMPTION
+
+The extension will be ignored during parsing if a previous session is being
+successfully resumed.
+
+=item SSL_EXT_CLIENT_HELLO
+
+The extension may be present in the ClientHello message.
+
+=item SSL_EXT_TLS1_2_SERVER_HELLO
+
+The extension may be present in a TLSv1.2 or below compatible ServerHello
+message.
+
+=item SSL_EXT_TLS1_3_SERVER_HELLO
+
+The extension may be present in a TLSv1.3 compatible ServerHello message.
+
+=item SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS
+
+The extension may be present in an EncryptedExtensions message.
+
+=item SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST
+
+The extension may be present in a HelloRetryRequest message.
+
+=item SSL_EXT_TLS1_3_CERTIFICATE
+
+The extension may be present in a TLSv1.3 compatible Certificate message.
+
+=item SSL_EXT_TLS1_3_NEW_SESSION_TICKET
+
+The extension may be present in a TLSv1.3 compatible NewSessionTicket message.
+
+=item SSL_EXT_TLS1_3_CERTIFICATE_REQUEST
+
+The extension may be present in a TLSv1.3 compatible CertificateRequest message.
+
+=back
+
+The context must include at least one message value (otherwise the extension
+will never be used).
 
 =head1 NOTES
 
@@ -115,27 +252,33 @@ RFC5246 et al. It is B<not> a NID.
 
 If the same custom extension type is received multiple times a fatal
 B<decode_error> alert is sent and the handshake aborts. If a custom extension
-is received in ServerHello which was not sent in ClientHello a fatal
-B<unsupported_extension> alert is sent and the handshake is aborted. The
-ServerHello B<add_cb> callback is only called if the corresponding extension
-was received in ClientHello. This is compliant with the TLS specifications.
-This behaviour ensures that each callback is called at most once and that
-an application can never send unsolicited extensions.
+is received in a ServerHello/EncryptedExtensions message which was not sent in
+the ClientHello a fatal B<unsupported_extension> alert is sent and the
+handshake is aborted. The ServerHello/EncryptedExtensions B<add_cb> callback is
+only called if the corresponding extension was received in the ClientHello. This
+is compliant with the TLS specifications. This behaviour ensures that each
+callback is called at most once and that an application can never send
+unsolicited extensions.
 
 =head1 RETURN VALUES
 
-SSL_CTX_add_client_custom_ext() and SSL_CTX_add_server_custom_ext() return 1 for
-success and 0 for failure. A failure can occur if an attempt is made to
-add the same B<ext_type> more than once, if an attempt is made to use an
-extension type handled internally by OpenSSL or if an internal error occurs
-(for example a memory allocation failure).
+SSL_CTX_add_custom_ext(), SSL_CTX_add_client_custom_ext() and
+SSL_CTX_add_server_custom_ext() return 1 for success and 0 for failure. A
+failure can occur if an attempt is made to add the same B<ext_type> more than
+once, if an attempt is made to use an extension type handled internally by
+OpenSSL or if an internal error occurs (for example a memory allocation
+failure).
 
 SSL_extension_supported() returns 1 if the extension B<ext_type> is handled
 internally by OpenSSL and 0 otherwise.
 
+=head1 HISTORY
+
+The function SSL_CTX_add_custom_ext() was added in OpenSSL version 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2014-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2014-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -289,21 +289,24 @@ typedef int (*custom_ext_parse_cb) (SSL *s, unsigned int ext_type,
                                     size_t inlen, int *al, void *parse_arg);
 
 
-typedef int (*custom_ext_add_cb_ex) (SSL *s, unsigned int ext_type,
-                                     unsigned int context,
-                                     const unsigned char **out,
-                                     size_t *outlen, X509 *x, size_t chainidx,
-                                     int *al, void *add_arg);
+typedef int (*SSL_custom_ext_add_cb_ex) (SSL *s, unsigned int ext_type,
+                                         unsigned int context,
+                                         const unsigned char **out,
+                                         size_t *outlen, X509 *x,
+                                         size_t chainidx,
+                                         int *al, void *add_arg);
 
-typedef void (*custom_ext_free_cb_ex) (SSL *s, unsigned int ext_type,
-                                       unsigned int context,
-                                       const unsigned char *out, void *add_arg);
+typedef void (*SSL_custom_ext_free_cb_ex) (SSL *s, unsigned int ext_type,
+                                           unsigned int context,
+                                           const unsigned char *out,
+                                           void *add_arg);
 
-typedef int (*custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
-                                       unsigned int context,
-                                       const unsigned char *in,
-                                       size_t inlen, X509 *x, size_t chainidx,
-                                       int *al, void *parse_arg);
+typedef int (*SSL_custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
+                                           unsigned int context,
+                                           const unsigned char *in,
+                                           size_t inlen, X509 *x,
+                                           size_t chainidx,
+                                           int *al, void *parse_arg);
 
 /* Typedef for verification callback */
 typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
@@ -800,10 +803,10 @@ __owur int SSL_CTX_add_server_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
 
 __owur int SSL_CTX_add_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
                                   unsigned int context,
-                                  custom_ext_add_cb_ex add_cb,
-                                  custom_ext_free_cb_ex free_cb,
+                                  SSL_custom_ext_add_cb_ex add_cb,
+                                  SSL_custom_ext_free_cb_ex free_cb,
                                   void *add_arg,
-                                  custom_ext_parse_cb_ex parse_cb,
+                                  SSL_custom_ext_parse_cb_ex parse_cb,
                                   void *parse_arg);
 
 __owur int SSL_extension_supported(unsigned int ext_type);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -259,19 +259,21 @@ typedef int (*tls_session_secret_cb_fn) (SSL *s, void *secret,
 #define SSL_EXT_TLS_IMPLEMENTATION_ONLY         0x0004
 /* Most extensions are not defined for SSLv3 but EXT_TYPE_renegotiate is */
 #define SSL_EXT_SSL3_ALLOWED                    0x0008
-/* Extension is only defined for TLS1.2 and above */
+/* Extension is only defined for TLS1.2 and below */
 #define SSL_EXT_TLS1_2_AND_BELOW_ONLY           0x0010
 /* Extension is only defined for TLS1.3 and above */
 #define SSL_EXT_TLS1_3_ONLY                     0x0020
-#define SSL_EXT_CLIENT_HELLO                    0x0040
+/* Ignore this extension during parsing if we are resuming */
+#define SSL_EXT_IGNORE_ON_RESUMPTION            0x0040
+#define SSL_EXT_CLIENT_HELLO                    0x0080
 /* Really means TLS1.2 or below */
-#define SSL_EXT_TLS1_2_SERVER_HELLO             0x0080
-#define SSL_EXT_TLS1_3_SERVER_HELLO             0x0100
-#define SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS     0x0200
-#define SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST      0x0400
-#define SSL_EXT_TLS1_3_CERTIFICATE              0x0800
-#define SSL_EXT_TLS1_3_NEW_SESSION_TICKET       0x1000
-#define SSL_EXT_TLS1_3_CERTIFICATE_REQUEST      0x2000
+#define SSL_EXT_TLS1_2_SERVER_HELLO             0x0100
+#define SSL_EXT_TLS1_3_SERVER_HELLO             0x0200
+#define SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS     0x0400
+#define SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST      0x0800
+#define SSL_EXT_TLS1_3_CERTIFICATE              0x1000
+#define SSL_EXT_TLS1_3_NEW_SESSION_TICKET       0x2000
+#define SSL_EXT_TLS1_3_CERTIFICATE_REQUEST      0x4000
 
 /* Typedefs for handling custom extensions */
 
@@ -285,6 +287,23 @@ typedef void (*custom_ext_free_cb) (SSL *s, unsigned int ext_type,
 typedef int (*custom_ext_parse_cb) (SSL *s, unsigned int ext_type,
                                     const unsigned char *in,
                                     size_t inlen, int *al, void *parse_arg);
+
+
+typedef int (*custom_ext_add_cb_ex) (SSL *s, unsigned int ext_type,
+                                     unsigned int context,
+                                     const unsigned char **out,
+                                     size_t *outlen, X509 *x, size_t chainidx,
+                                     int *al, void *add_arg);
+
+typedef void (*custom_ext_free_cb_ex) (SSL *s, unsigned int ext_type,
+                                       unsigned int context,
+                                       const unsigned char *out, void *add_arg);
+
+typedef int (*custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
+                                       unsigned int context,
+                                       const unsigned char *in,
+                                       size_t inlen, X509 *x, size_t chainidx,
+                                       int *al, void *parse_arg);
 
 /* Typedef for verification callback */
 typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
@@ -777,6 +796,14 @@ __owur int SSL_CTX_add_server_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
                                   custom_ext_free_cb free_cb,
                                   void *add_arg,
                                   custom_ext_parse_cb parse_cb,
+                                  void *parse_arg);
+
+__owur int SSL_CTX_add_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
+                                  unsigned int context,
+                                  custom_ext_add_cb_ex add_cb,
+                                  custom_ext_free_cb_ex free_cb,
+                                  void *add_arg,
+                                  custom_ext_parse_cb_ex parse_cb,
                                   void *parse_arg);
 
 __owur int SSL_extension_supported(unsigned int ext_type);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -250,6 +250,29 @@ typedef int (*tls_session_secret_cb_fn) (SSL *s, void *secret,
                                          STACK_OF(SSL_CIPHER) *peer_ciphers,
                                          const SSL_CIPHER **cipher, void *arg);
 
+/* Extension context codes */
+/* This extension is only allowed in TLS */
+#define SSL_EXT_TLS_ONLY                        0x0001
+/* This extension is only allowed in DTLS */
+#define SSL_EXT_DTLS_ONLY                       0x0002
+/* Some extensions may be allowed in DTLS but we don't implement them for it */
+#define SSL_EXT_TLS_IMPLEMENTATION_ONLY         0x0004
+/* Most extensions are not defined for SSLv3 but EXT_TYPE_renegotiate is */
+#define SSL_EXT_SSL3_ALLOWED                    0x0008
+/* Extension is only defined for TLS1.2 and above */
+#define SSL_EXT_TLS1_2_AND_BELOW_ONLY           0x0010
+/* Extension is only defined for TLS1.3 and above */
+#define SSL_EXT_TLS1_3_ONLY                     0x0020
+#define SSL_EXT_CLIENT_HELLO                    0x0040
+/* Really means TLS1.2 or below */
+#define SSL_EXT_TLS1_2_SERVER_HELLO             0x0080
+#define SSL_EXT_TLS1_3_SERVER_HELLO             0x0100
+#define SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS     0x0200
+#define SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST      0x0400
+#define SSL_EXT_TLS1_3_CERTIFICATE              0x0800
+#define SSL_EXT_TLS1_3_NEW_SESSION_TICKET       0x1000
+#define SSL_EXT_TLS1_3_CERTIFICATE_REQUEST      0x2000
+
 /* Typedefs for handling custom extensions */
 
 typedef int (*custom_ext_add_cb) (SSL *s, unsigned int ext_type,

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -3,8 +3,8 @@ SOURCE[../libssl]=\
         pqueue.c packet.c \
         statem/statem_srvr.c statem/statem_clnt.c  s3_lib.c  s3_enc.c record/rec_layer_s3.c \
         statem/statem_lib.c statem/extensions.c statem/extensions_srvr.c \
-        statem/extensions_clnt.c s3_cbc.c s3_msg.c \
-        methods.c   t1_lib.c  t1_enc.c tls13_enc.c t1_ext.c \
+        statem/extensions_clnt.c statem/extensions_cust.c s3_cbc.c s3_msg.c \
+        methods.c   t1_lib.c  t1_enc.c tls13_enc.c \
         d1_lib.c  record/rec_layer_d1.c d1_msg.c \
         statem/statem_dtls.c d1_srtp.c \
         ssl_lib.c ssl_cert.c ssl_sess.c \

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -190,9 +190,7 @@ CERT *ssl_cert_dup(CERT *cert)
     ret->sec_level = cert->sec_level;
     ret->sec_ex = cert->sec_ex;
 
-    if (!custom_exts_copy(&ret->cli_ext, &cert->cli_ext))
-        goto err;
-    if (!custom_exts_copy(&ret->srv_ext, &cert->srv_ext))
+    if (!custom_exts_copy(&ret->custext, &cert->custext))
         goto err;
 #ifndef OPENSSL_NO_PSK
     if (cert->psk_identity_hint) {
@@ -254,8 +252,7 @@ void ssl_cert_free(CERT *c)
     OPENSSL_free(c->ctype);
     X509_STORE_free(c->verify_store);
     X509_STORE_free(c->chain_store);
-    custom_exts_free(&c->cli_ext);
-    custom_exts_free(&c->srv_ext);
+    custom_exts_free(&c->custext);
 #ifndef OPENSSL_NO_PSK
     OPENSSL_free(c->psk_identity_hint);
 #endif

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1616,13 +1616,16 @@ struct cert_pkey_st {
 # define SSL_CERT_FLAGS_CHECK_TLS_STRICT \
         (SSL_CERT_FLAG_SUITEB_128_LOS|SSL_CERT_FLAG_TLS_STRICT)
 
+typedef enum {
+    ENDPOINT_CLIENT = 0,
+    ENDPOINT_SERVER,
+    ENDPOINT_BOTH
+} ENDPOINT;
+
+
 typedef struct {
     unsigned short ext_type;
-    /*
-     * Set to 1 if this is only for the server side, 0 if it is only for the
-     * client side, or -1 if it is either.
-     */
-    int server;
+    ENDPOINT role;
     /* The context which this extension applies to */
     unsigned int context;
     /*
@@ -2444,8 +2447,9 @@ __owur int srp_verify_server_param(SSL *s, int *al);
 
 /* statem/extensions_cust.c */
 
-custom_ext_method *custom_ext_find(const custom_ext_methods *exts, int server,
-                                   unsigned int ext_type, size_t *idx);
+custom_ext_method *custom_ext_find(const custom_ext_methods *exts,
+                                   ENDPOINT role, unsigned int ext_type,
+                                   size_t *idx);
 
 void custom_ext_init(custom_ext_methods *meths);
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1630,10 +1630,10 @@ typedef struct {
      * part of an SSL_CTX structure.
      */
     uint32_t ext_flags;
-    custom_ext_add_cb_ex add_cb;
-    custom_ext_free_cb_ex free_cb;
+    SSL_custom_ext_add_cb_ex add_cb;
+    SSL_custom_ext_free_cb_ex free_cb;
     void *add_arg;
-    custom_ext_parse_cb_ex parse_cb;
+    SSL_custom_ext_parse_cb_ex parse_cb;
     void *parse_arg;
 } custom_ext_method;
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1619,14 +1619,21 @@ struct cert_pkey_st {
 typedef struct {
     unsigned short ext_type;
     /*
+     * Set to 1 if this is only for the server side, 0 if it is only for the
+     * client side, or -1 if it is either.
+     */
+    int server;
+    /* The context which this extension applies to */
+    unsigned int context;
+    /*
      * Per-connection flags relating to this extension type: not used if
      * part of an SSL_CTX structure.
      */
     uint32_t ext_flags;
-    custom_ext_add_cb add_cb;
-    custom_ext_free_cb free_cb;
+    custom_ext_add_cb_ex add_cb;
+    custom_ext_free_cb_ex free_cb;
     void *add_arg;
-    custom_ext_parse_cb parse_cb;
+    custom_ext_parse_cb_ex parse_cb;
     void *parse_arg;
 } custom_ext_method;
 
@@ -1706,9 +1713,8 @@ typedef struct cert_st {
      */
     X509_STORE *chain_store;
     X509_STORE *verify_store;
-    /* Custom extension methods for server and client */
-    custom_ext_methods cli_ext;
-    custom_ext_methods srv_ext;
+    /* Custom extensions */
+    custom_ext_methods custext;
     /* Security callback */
     int (*sec_cb) (const SSL *s, const SSL_CTX *ctx, int op, int bits, int nid,
                    void *other, void *ex);
@@ -2436,15 +2442,18 @@ __owur int srp_generate_server_master_secret(SSL *s);
 __owur int srp_generate_client_master_secret(SSL *s);
 __owur int srp_verify_server_param(SSL *s, int *al);
 
-/* t1_ext.c */
+/* statem/extensions_cust.c */
+
+custom_ext_method *custom_ext_find(const custom_ext_methods *exts, int server,
+                                   unsigned int ext_type, size_t *idx);
 
 void custom_ext_init(custom_ext_methods *meths);
 
-__owur int custom_ext_parse(SSL *s, int server,
-                            unsigned int ext_type,
+__owur int custom_ext_parse(SSL *s, unsigned int context, unsigned int ext_type,
                             const unsigned char *ext_data, size_t ext_size,
-                            int *al);
-__owur int custom_ext_add(SSL *s, int server, WPACKET *pkt, int *al);
+                            X509 *x, size_t chainidx, int *al);
+__owur int custom_ext_add(SSL *s, int context, WPACKET *pkt, X509 *x,
+                          size_t chainidx, int maxversion, int *al);
 
 __owur int custom_exts_copy(custom_ext_methods *dst,
                             const custom_ext_methods *src);

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -797,26 +797,15 @@ static int serverinfo_process_buffer(const unsigned char *serverinfo,
 
         /* Register callbacks for extensions */
         ext_type = (serverinfo[0] << 8) + serverinfo[1];
-        if (ctx) {
-            int have_ext_cbs = 0;
-            size_t i;
-            custom_ext_methods *exts = &ctx->cert->srv_ext;
-            custom_ext_method *meth = exts->meths;
-
-            for (i = 0; i < exts->meths_count; i++, meth++) {
-                if (ext_type == meth->ext_type) {
-                    have_ext_cbs = 1;
-                    break;
-                }
-            }
-
-            if (!have_ext_cbs && !SSL_CTX_add_server_custom_ext(ctx, ext_type,
-                                                                serverinfo_srv_add_cb,
-                                                                NULL, NULL,
-                                                                serverinfo_srv_parse_cb,
-                                                                NULL))
-                return 0;
-        }
+        if (ctx != NULL
+                && custom_ext_find(&ctx->cert->custext, 1, ext_type, NULL)
+                   == NULL
+                && !SSL_CTX_add_server_custom_ext(ctx, ext_type,
+                                                  serverinfo_srv_add_cb,
+                                                  NULL, NULL,
+                                                  serverinfo_srv_parse_cb,
+                                                  NULL))
+            return 0;
 
         serverinfo += 2;
         serverinfo_length -= 2;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -798,7 +798,8 @@ static int serverinfo_process_buffer(const unsigned char *serverinfo,
         /* Register callbacks for extensions */
         ext_type = (serverinfo[0] << 8) + serverinfo[1];
         if (ctx != NULL
-                && custom_ext_find(&ctx->cert->custext, 1, ext_type, NULL)
+                && custom_ext_find(&ctx->cert->custext, ENDPOINT_SERVER,
+                                   ext_type, NULL)
                    == NULL
                 && !SSL_CTX_add_server_custom_ext(ctx, ext_type,
                                                   serverinfo_srv_add_cb,

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -468,9 +468,10 @@ int ssl_get_prev_session(SSL *s, CLIENTHELLO_MSG *hello, int *al)
     TICKET_RETURN r;
 
     if (SSL_IS_TLS13(s)) {
-        if (!tls_parse_extension(s, TLSEXT_IDX_psk_kex_modes, EXT_CLIENT_HELLO,
-                                 hello->pre_proc_exts, NULL, 0, al)
-                || !tls_parse_extension(s, TLSEXT_IDX_psk, EXT_CLIENT_HELLO,
+        if (!tls_parse_extension(s, TLSEXT_IDX_psk_kex_modes,
+                                 SSL_EXT_CLIENT_HELLO, hello->pre_proc_exts,
+                                 NULL, 0, al)
+                || !tls_parse_extension(s, TLSEXT_IDX_psk, SSL_EXT_CLIENT_HELLO,
                                         hello->pre_proc_exts, NULL, 0, al))
             return -1;
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -373,15 +373,15 @@ static int verify_extension(SSL *s, unsigned int context, unsigned int type,
     /* Check the custom extensions */
     if (meths != NULL) {
         size_t offset = 0;
-        int server = -1;
+        ENDPOINT role = ENDPOINT_BOTH;
         custom_ext_method *meth = NULL;
 
         if ((context & SSL_EXT_CLIENT_HELLO) != 0)
-            server = 1;
+            role = ENDPOINT_SERVER;
         else if ((context & SSL_EXT_TLS1_2_SERVER_HELLO) != 0)
-            server = 0;
+            role = ENDPOINT_CLIENT;
 
-        meth = custom_ext_find(meths, server, type, &offset);
+        meth = custom_ext_find(meths, role, type, &offset);
         if (meth != NULL) {
             if (!validate_context(s, meth->context, context))
                 return 0;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -114,16 +114,16 @@ typedef struct extensions_definition_st {
 static const EXTENSION_DEFINITION ext_defs[] = {
     {
         TLSEXT_TYPE_renegotiate,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_SSL3_ALLOWED
-        | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_SSL3_ALLOWED | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         NULL, tls_parse_ctos_renegotiate, tls_parse_stoc_renegotiate,
         tls_construct_stoc_renegotiate, tls_construct_ctos_renegotiate,
         final_renegotiate
     },
     {
         TLSEXT_TYPE_server_name,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO
-        | EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
         init_server_name,
         tls_parse_ctos_server_name, tls_parse_stoc_server_name,
         tls_construct_stoc_server_name, tls_construct_ctos_server_name,
@@ -132,7 +132,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #ifndef OPENSSL_NO_SRP
     {
         TLSEXT_TYPE_srp,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         init_srp, tls_parse_ctos_srp, NULL, NULL, tls_construct_ctos_srp, NULL
     },
 #else
@@ -141,14 +141,15 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #ifndef OPENSSL_NO_EC
     {
         TLSEXT_TYPE_ec_point_formats,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         NULL, tls_parse_ctos_ec_pt_formats, tls_parse_stoc_ec_pt_formats,
         tls_construct_stoc_ec_pt_formats, tls_construct_ctos_ec_pt_formats,
         final_ec_pt_formats
     },
     {
         TLSEXT_TYPE_supported_groups,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
         NULL, tls_parse_ctos_supported_groups, NULL,
         NULL /* TODO(TLS1.3): Need to add this */,
         tls_construct_ctos_supported_groups, NULL
@@ -159,14 +160,15 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #endif
     {
         TLSEXT_TYPE_session_ticket,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         init_session_ticket, tls_parse_ctos_session_ticket,
         tls_parse_stoc_session_ticket, tls_construct_stoc_session_ticket,
         tls_construct_ctos_session_ticket, NULL
     },
     {
         TLSEXT_TYPE_signature_algorithms,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_CERTIFICATE_REQUEST,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_CERTIFICATE_REQUEST,
         init_sig_algs, tls_parse_ctos_sig_algs,
         tls_parse_ctos_sig_algs, tls_construct_ctos_sig_algs,
         tls_construct_ctos_sig_algs, final_sig_algs
@@ -174,8 +176,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #ifndef OPENSSL_NO_OCSP
     {
         TLSEXT_TYPE_status_request,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO
-        | EXT_TLS1_3_CERTIFICATE,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_3_CERTIFICATE,
         init_status_request, tls_parse_ctos_status_request,
         tls_parse_stoc_status_request, tls_construct_stoc_status_request,
         tls_construct_ctos_status_request, NULL
@@ -186,7 +188,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #ifndef OPENSSL_NO_NEXTPROTONEG
     {
         TLSEXT_TYPE_next_proto_neg,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         init_npn, tls_parse_ctos_npn, tls_parse_stoc_npn,
         tls_construct_stoc_next_proto_neg, tls_construct_ctos_npn, NULL
     },
@@ -199,16 +202,16 @@ static const EXTENSION_DEFINITION ext_defs[] = {
          * happens after server_name callbacks
          */
         TLSEXT_TYPE_application_layer_protocol_negotiation,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO
-        | EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
         init_alpn, tls_parse_ctos_alpn, tls_parse_stoc_alpn,
         tls_construct_stoc_alpn, tls_construct_ctos_alpn, final_alpn
     },
 #ifndef OPENSSL_NO_SRTP
     {
         TLSEXT_TYPE_use_srtp,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO
-        | EXT_TLS1_3_ENCRYPTED_EXTENSIONS | EXT_DTLS_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS | SSL_EXT_DTLS_ONLY,
         init_srtp, tls_parse_ctos_use_srtp, tls_parse_stoc_use_srtp,
         tls_construct_stoc_use_srtp, tls_construct_ctos_use_srtp, NULL
     },
@@ -217,15 +220,16 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #endif
     {
         TLSEXT_TYPE_encrypt_then_mac,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY | EXT_SSL3_ALLOWED,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         init_etm, tls_parse_ctos_etm, tls_parse_stoc_etm,
         tls_construct_stoc_etm, tls_construct_ctos_etm, NULL
     },
 #ifndef OPENSSL_NO_CT
     {
         TLSEXT_TYPE_signed_certificate_timestamp,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO
-        | EXT_TLS1_3_CERTIFICATE,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_3_CERTIFICATE,
         NULL,
         /*
          * No server side support for this, but can be provided by a custom
@@ -239,20 +243,23 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #endif
     {
         TLSEXT_TYPE_extended_master_secret,
-        EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
+        | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         init_ems, tls_parse_ctos_ems, tls_parse_stoc_ems,
         tls_construct_stoc_ems, tls_construct_ctos_ems, final_ems
     },
     {
         TLSEXT_TYPE_supported_versions,
-        EXT_CLIENT_HELLO | EXT_TLS_IMPLEMENTATION_ONLY | EXT_TLS1_3_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS_IMPLEMENTATION_ONLY
+        | SSL_EXT_TLS1_3_ONLY,
         NULL,
         /* Processed inline as part of version selection */
         NULL, NULL, NULL, tls_construct_ctos_supported_versions, NULL
     },
     {
         TLSEXT_TYPE_psk_kex_modes,
-        EXT_CLIENT_HELLO | EXT_TLS_IMPLEMENTATION_ONLY | EXT_TLS1_3_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS_IMPLEMENTATION_ONLY
+        | SSL_EXT_TLS1_3_ONLY,
         init_psk_kex_modes, tls_parse_ctos_psk_kex_modes, NULL, NULL,
         tls_construct_ctos_psk_kex_modes, NULL
     },
@@ -263,9 +270,9 @@ static const EXTENSION_DEFINITION ext_defs[] = {
          * been parsed before we do this one.
          */
         TLSEXT_TYPE_key_share,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_SERVER_HELLO
-        | EXT_TLS1_3_HELLO_RETRY_REQUEST | EXT_TLS_IMPLEMENTATION_ONLY
-        | EXT_TLS1_3_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_SERVER_HELLO
+        | SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST | SSL_EXT_TLS_IMPLEMENTATION_ONLY
+        | SSL_EXT_TLS1_3_ONLY,
         NULL, tls_parse_ctos_key_share, tls_parse_stoc_key_share,
         tls_construct_stoc_key_share, tls_construct_ctos_key_share,
         final_key_share
@@ -273,8 +280,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 #endif
     {
         TLSEXT_TYPE_cookie,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_HELLO_RETRY_REQUEST
-        | EXT_TLS_IMPLEMENTATION_ONLY | EXT_TLS1_3_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST
+        | SSL_EXT_TLS_IMPLEMENTATION_ONLY | SSL_EXT_TLS1_3_ONLY,
         NULL, NULL, tls_parse_stoc_cookie, NULL, tls_construct_ctos_cookie,
         NULL
     },
@@ -284,20 +291,21 @@ static const EXTENSION_DEFINITION ext_defs[] = {
          * SSL_OP_CRYPTOPRO_TLSEXT_BUG is set
          */
         TLSEXT_TYPE_cryptopro_bug,
-        EXT_TLS1_2_SERVER_HELLO | EXT_TLS1_2_AND_BELOW_ONLY,
+        SSL_EXT_TLS1_2_SERVER_HELLO | SSL_EXT_TLS1_2_AND_BELOW_ONLY,
         NULL, NULL, NULL, tls_construct_stoc_cryptopro_bug, NULL, NULL
     },
     {
         TLSEXT_TYPE_early_data,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_ENCRYPTED_EXTENSIONS
-        | EXT_TLS1_3_NEW_SESSION_TICKET,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS
+        | SSL_EXT_TLS1_3_NEW_SESSION_TICKET,
         NULL, tls_parse_ctos_early_data, tls_parse_stoc_early_data,
         tls_construct_stoc_early_data, tls_construct_ctos_early_data,
         final_early_data
     },
     {
         TLSEXT_TYPE_certificate_authorities,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_CERTIFICATE_REQUEST | EXT_TLS1_3_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_CERTIFICATE_REQUEST
+        | SSL_EXT_TLS1_3_ONLY,
         init_certificate_authorities,
         tls_parse_certificate_authorities, tls_parse_certificate_authorities,
         tls_construct_certificate_authorities,
@@ -306,7 +314,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
     {
         /* Must be immediately before pre_shared_key */
         TLSEXT_TYPE_padding,
-        EXT_CLIENT_HELLO,
+        SSL_EXT_CLIENT_HELLO,
         NULL,
         /* We send this, but don't read it */
         NULL, NULL, NULL, tls_construct_ctos_padding, NULL
@@ -314,8 +322,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
     {
         /* Required by the TLSv1.3 spec to always be the last extension */
         TLSEXT_TYPE_psk,
-        EXT_CLIENT_HELLO | EXT_TLS1_3_SERVER_HELLO | EXT_TLS_IMPLEMENTATION_ONLY
-        | EXT_TLS1_3_ONLY,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_SERVER_HELLO
+        | SSL_EXT_TLS_IMPLEMENTATION_ONLY | SSL_EXT_TLS1_3_ONLY,
         NULL, tls_parse_ctos_psk, tls_parse_stoc_psk, tls_construct_stoc_psk,
         tls_construct_ctos_psk, NULL
     }
@@ -342,9 +350,9 @@ static int verify_extension(SSL *s, unsigned int context, unsigned int type,
                 return 0;
 
             if (SSL_IS_DTLS(s)) {
-                if ((thisext->context & EXT_TLS_ONLY) != 0)
+                if ((thisext->context & SSL_EXT_TLS_ONLY) != 0)
                     return 0;
-            } else if ((thisext->context & EXT_DTLS_ONLY) != 0) {
+            } else if ((thisext->context & SSL_EXT_DTLS_ONLY) != 0) {
                     return 0;
             }
 
@@ -353,7 +361,7 @@ static int verify_extension(SSL *s, unsigned int context, unsigned int type,
         }
     }
 
-    if ((context & (EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO)) == 0) {
+    if ((context & (SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO)) == 0) {
         /*
          * Custom extensions only apply to <=TLS1.2. This extension is unknown
          * in this context - we allow it
@@ -386,12 +394,12 @@ static int extension_is_relevant(SSL *s, unsigned int extctx,
                                  unsigned int thisctx)
 {
     if ((SSL_IS_DTLS(s)
-                && (extctx & EXT_TLS_IMPLEMENTATION_ONLY) != 0)
+                && (extctx & SSL_EXT_TLS_IMPLEMENTATION_ONLY) != 0)
             || (s->version == SSL3_VERSION
-                    && (extctx & EXT_SSL3_ALLOWED) == 0)
+                    && (extctx & SSL_EXT_SSL3_ALLOWED) == 0)
             || (SSL_IS_TLS13(s)
-                && (extctx & EXT_TLS1_2_AND_BELOW_ONLY) != 0)
-            || (!SSL_IS_TLS13(s) && (extctx & EXT_TLS1_3_ONLY) != 0))
+                && (extctx & SSL_EXT_TLS1_2_AND_BELOW_ONLY) != 0)
+            || (!SSL_IS_TLS13(s) && (extctx & SSL_EXT_TLS1_3_ONLY) != 0))
         return 0;
 
     return 1;
@@ -429,10 +437,10 @@ int tls_collect_extensions(SSL *s, PACKET *packet, unsigned int context,
      * Initialise server side custom extensions. Client side is done during
      * construction of extensions for the ClientHello.
      */
-    if ((context & EXT_CLIENT_HELLO) != 0) {
+    if ((context & SSL_EXT_CLIENT_HELLO) != 0) {
         exts = &s->cert->srv_ext;
         custom_ext_init(&s->cert->srv_ext);
-    } else if ((context & EXT_TLS1_2_SERVER_HELLO) != 0) {
+    } else if ((context & SSL_EXT_TLS1_2_SERVER_HELLO) != 0) {
         exts = &s->cert->cli_ext;
     }
 
@@ -463,7 +471,7 @@ int tls_collect_extensions(SSL *s, PACKET *packet, unsigned int context,
         if (!verify_extension(s, context, type, exts, raw_extensions, &thisex)
                 || (thisex != NULL && thisex->present == 1)
                 || (type == TLSEXT_TYPE_psk
-                    && (context & EXT_CLIENT_HELLO) != 0
+                    && (context & SSL_EXT_CLIENT_HELLO) != 0
                     && PACKET_remaining(&extensions) != 0)) {
             SSLerr(SSL_F_TLS_COLLECT_EXTENSIONS, SSL_R_BAD_EXTENSION);
             *al = SSL_AD_ILLEGAL_PARAMETER;
@@ -562,7 +570,7 @@ int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
      */
     if ((!s->hit || !s->server)
             && (context
-                & (EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO)) != 0
+                & (SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO)) != 0
             && custom_ext_parse(s, s->server, currext->type,
                                 PACKET_data(&currext->data),
                                 PACKET_remaining(&currext->data),
@@ -587,9 +595,9 @@ int tls_parse_all_extensions(SSL *s, int context, RAW_EXTENSION *exts, X509 *x,
     const EXTENSION_DEFINITION *thisexd;
 
     /* Calculate the number of extensions in the extensions list */
-    if ((context & EXT_CLIENT_HELLO) != 0) {
+    if ((context & SSL_EXT_CLIENT_HELLO) != 0) {
         numexts += s->cert->srv_ext.meths_count;
-    } else if ((context & EXT_TLS1_2_SERVER_HELLO) != 0) {
+    } else if ((context & SSL_EXT_TLS1_2_SERVER_HELLO) != 0) {
         numexts += s->cert->cli_ext.meths_count;
     }
 
@@ -640,15 +648,16 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
                 * If extensions are of zero length then we don't even add the
                 * extensions length bytes to a ClientHello/ServerHello in SSLv3
                 */
-            || ((context & (EXT_CLIENT_HELLO | EXT_TLS1_2_SERVER_HELLO)) != 0
-               && s->version == SSL3_VERSION
-               && !WPACKET_set_flags(pkt,
+            || ((context &
+                 (SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO)) != 0
+                && s->version == SSL3_VERSION
+                && !WPACKET_set_flags(pkt,
                                      WPACKET_FLAGS_ABANDON_ON_ZERO_LENGTH))) {
         SSLerr(SSL_F_TLS_CONSTRUCT_EXTENSIONS, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
-    if ((context & EXT_CLIENT_HELLO) != 0) {
+    if ((context & SSL_EXT_CLIENT_HELLO) != 0) {
         reason = ssl_get_client_min_max_version(s, &min_version, &max_version);
         if (reason != 0) {
             SSLerr(SSL_F_TLS_CONSTRUCT_EXTENSIONS, reason);
@@ -657,10 +666,10 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
     }
 
     /* Add custom extensions first */
-    if ((context & EXT_CLIENT_HELLO) != 0) {
+    if ((context & SSL_EXT_CLIENT_HELLO) != 0) {
         custom_ext_init(&s->cert->cli_ext);
         addcustom = 1;
-    } else if ((context & EXT_TLS1_2_SERVER_HELLO) != 0) {
+    } else if ((context & SSL_EXT_TLS1_2_SERVER_HELLO) != 0) {
         /*
          * We already initialised the custom extensions during ClientHello
          * parsing.
@@ -690,18 +699,18 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
 
         /* Check if this extension is defined for our protocol. If not, skip */
         if ((SSL_IS_DTLS(s)
-                    && (thisexd->context & EXT_TLS_IMPLEMENTATION_ONLY)
+                    && (thisexd->context & SSL_EXT_TLS_IMPLEMENTATION_ONLY)
                        != 0)
                 || (s->version == SSL3_VERSION
-                        && (thisexd->context & EXT_SSL3_ALLOWED) == 0)
+                        && (thisexd->context & SSL_EXT_SSL3_ALLOWED) == 0)
                 || (SSL_IS_TLS13(s)
-                    && (thisexd->context & EXT_TLS1_2_AND_BELOW_ONLY)
+                    && (thisexd->context & SSL_EXT_TLS1_2_AND_BELOW_ONLY)
                        != 0)
                 || (!SSL_IS_TLS13(s)
-                    && (thisexd->context & EXT_TLS1_3_ONLY) != 0
-                    && (context & EXT_CLIENT_HELLO) == 0)
-                || ((thisexd->context & EXT_TLS1_3_ONLY) != 0
-                    && (context & EXT_CLIENT_HELLO) != 0
+                    && (thisexd->context & SSL_EXT_TLS1_3_ONLY) != 0
+                    && (context & SSL_EXT_CLIENT_HELLO) == 0)
+                || ((thisexd->context & SSL_EXT_TLS1_3_ONLY) != 0
+                    && (context & SSL_EXT_CLIENT_HELLO) != 0
                     && (SSL_IS_DTLS(s) || max_version < TLS1_3_VERSION))
                 || construct == NULL)
             continue;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1092,8 +1092,10 @@ int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             }
         }
     } else {
-        if (custom_ext_parse(s, 0, TLSEXT_TYPE_signed_certificate_timestamp,
-                             PACKET_data(pkt), PACKET_remaining(pkt), al) <= 0)
+        if (custom_ext_parse(s, context,
+                             TLSEXT_TYPE_signed_certificate_timestamp,
+                             PACKET_data(pkt), PACKET_remaining(pkt),
+                             x, chainidx, al) <= 0)
             return 0;
     }
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1307,7 +1307,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 0;
     }
 
-    if ((context & EXT_TLS1_3_HELLO_RETRY_REQUEST) != 0) {
+    if ((context & SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST) != 0) {
         unsigned const char *pcurves = NULL;
         size_t i, num_curves;
 
@@ -1411,7 +1411,7 @@ int tls_parse_stoc_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 int tls_parse_stoc_early_data(SSL *s, PACKET *pkt, unsigned int context,
                               X509 *x, size_t chainidx, int *al)
 {
-    if (context == EXT_TLS1_3_NEW_SESSION_TICKET) {
+    if (context == SSL_EXT_TLS1_3_NEW_SESSION_TICKET) {
         unsigned long max_early_data;
 
         if (!PACKET_get_net_4(pkt, &max_early_data)

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -303,10 +303,10 @@ int SSL_CTX_has_client_custom_ext(const SSL_CTX *ctx, unsigned int ext_type)
 static int add_custom_ext_intern(SSL_CTX *ctx, int server,
                                  unsigned int ext_type,
                                  unsigned int context,
-                                 custom_ext_add_cb_ex add_cb,
-                                 custom_ext_free_cb_ex free_cb,
+                                 SSL_custom_ext_add_cb_ex add_cb,
+                                 SSL_custom_ext_free_cb_ex free_cb,
                                  void *add_arg,
-                                 custom_ext_parse_cb_ex parse_cb,
+                                 SSL_custom_ext_parse_cb_ex parse_cb,
                                  void *parse_arg)
 {
     custom_ext_methods *exts = &ctx->cert->custext;
@@ -442,10 +442,10 @@ int SSL_CTX_add_server_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
 
 int SSL_CTX_add_custom_ext(SSL_CTX *ctx, unsigned int ext_type,
                            unsigned int context,
-                           custom_ext_add_cb_ex add_cb,
-                           custom_ext_free_cb_ex free_cb,
+                           SSL_custom_ext_add_cb_ex add_cb,
+                           SSL_custom_ext_free_cb_ex free_cb,
                            void *add_arg,
-                           custom_ext_parse_cb_ex parse_cb, void *parse_arg)
+                           SSL_custom_ext_parse_cb_ex parse_cb, void *parse_arg)
 {
     return add_custom_ext_intern(ctx, -1, ext_type, context, add_cb, free_cb,
                                  add_arg, parse_cb, parse_arg);

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -10,7 +10,7 @@
 /* Custom extension utility functions */
 
 #include <openssl/ct.h>
-#include "ssl_locl.h"
+#include "../ssl_locl.h"
 
 /* Find a custom extension from the list. */
 static custom_ext_method *custom_ext_find(const custom_ext_methods *exts,

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -393,11 +393,6 @@ static int add_old_custom_ext(SSL_CTX *ctx, ENDPOINT role,
     parse_cb_wrap->parse_arg = parse_arg;
     parse_cb_wrap->parse_cb = parse_cb;
 
-    /*
-     * TODO(TLS1.3): Is it possible with the old API to add custom exts for both
-     * client and server for the same type in the same SSL_CTX? We don't handle
-     * that yet.
-     */
     ret = add_custom_ext_intern(ctx, role, ext_type,
                                 context,
                                 custom_ext_add_old_cb_wrap,

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1133,7 +1133,7 @@ int tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt, unsigned int context,
 int tls_construct_stoc_early_data(SSL *s, WPACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx, int *al)
 {
-    if (context == EXT_TLS1_3_NEW_SESSION_TICKET) {
+    if (context == SSL_EXT_TLS1_3_NEW_SESSION_TICKET) {
         if (s->max_early_data == 0)
             return 1;
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1200,7 +1200,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
     }
 
     /* TLS extensions */
-    if (!tls_construct_extensions(s, pkt, EXT_CLIENT_HELLO, NULL, 0, &al)) {
+    if (!tls_construct_extensions(s, pkt, SSL_EXT_CLIENT_HELLO, NULL, 0, &al)) {
         ssl3_send_alert(s, SSL3_AL_FATAL, al);
         SSLerr(SSL_F_TLS_CONSTRUCT_CLIENT_HELLO, ERR_R_INTERNAL_ERROR);
         return 0;
@@ -1390,8 +1390,8 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
         goto f_err;
     }
 
-    context = SSL_IS_TLS13(s) ? EXT_TLS1_3_SERVER_HELLO
-                              : EXT_TLS1_2_SERVER_HELLO;
+    context = SSL_IS_TLS13(s) ? SSL_EXT_TLS1_3_SERVER_HELLO
+                              : SSL_EXT_TLS1_2_SERVER_HELLO;
     if (!tls_collect_extensions(s, &extpkt, context, &extensions, &al, NULL))
         goto f_err;
 
@@ -1400,7 +1400,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
     if (SSL_IS_TLS13(s)) {
         /* This will set s->hit if we are resuming */
         if (!tls_parse_extension(s, TLSEXT_IDX_psk,
-                                 EXT_TLS1_3_SERVER_HELLO,
+                                 SSL_EXT_TLS1_3_SERVER_HELLO,
                                  extensions, NULL, 0, &al))
             goto f_err;
     } else {
@@ -1634,9 +1634,9 @@ static MSG_PROCESS_RETURN tls_process_hello_retry_request(SSL *s, PACKET *pkt)
         goto f_err;
     }
 
-    if (!tls_collect_extensions(s, &extpkt, EXT_TLS1_3_HELLO_RETRY_REQUEST,
+    if (!tls_collect_extensions(s, &extpkt, SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST,
                                 &extensions, &al, NULL)
-            || !tls_parse_all_extensions(s, EXT_TLS1_3_HELLO_RETRY_REQUEST,
+            || !tls_parse_all_extensions(s, SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST,
                                          extensions, NULL, 0, &al))
         goto f_err;
 
@@ -1728,9 +1728,10 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt)
                 SSLerr(SSL_F_TLS_PROCESS_SERVER_CERTIFICATE, SSL_R_BAD_LENGTH);
                 goto f_err;
             }
-            if (!tls_collect_extensions(s, &extensions, EXT_TLS1_3_CERTIFICATE,
-                                        &rawexts, &al, NULL)
-                    || !tls_parse_all_extensions(s, EXT_TLS1_3_CERTIFICATE,
+            if (!tls_collect_extensions(s, &extensions,
+                                        SSL_EXT_TLS1_3_CERTIFICATE, &rawexts,
+                                        &al, NULL)
+                    || !tls_parse_all_extensions(s, SSL_EXT_TLS1_3_CERTIFICATE,
                                                  rawexts, x, chainidx, &al)) {
                 OPENSSL_free(rawexts);
                 goto f_err;
@@ -2357,9 +2358,9 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
                 goto err;
         }
         if (!tls_collect_extensions(s, &extensions,
-                                    EXT_TLS1_3_CERTIFICATE_REQUEST,
+                                    SSL_EXT_TLS1_3_CERTIFICATE_REQUEST,
                                     &rawexts, &al, NULL)
-            || !tls_parse_all_extensions(s, EXT_TLS1_3_CERTIFICATE_REQUEST,
+            || !tls_parse_all_extensions(s, SSL_EXT_TLS1_3_CERTIFICATE_REQUEST,
                                          rawexts, NULL, 0, &al)) {
             OPENSSL_free(rawexts);
             goto err;
@@ -2511,9 +2512,10 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL *s, PACKET *pkt)
 
         if (!PACKET_as_length_prefixed_2(pkt, &extpkt)
                 || !tls_collect_extensions(s, &extpkt,
-                                           EXT_TLS1_3_NEW_SESSION_TICKET,
+                                           SSL_EXT_TLS1_3_NEW_SESSION_TICKET,
                                            &exts, &al, NULL)
-                || !tls_parse_all_extensions(s, EXT_TLS1_3_NEW_SESSION_TICKET,
+                || !tls_parse_all_extensions(s,
+                                             SSL_EXT_TLS1_3_NEW_SESSION_TICKET,
                                              exts, NULL, 0, &al)) {
             SSLerr(SSL_F_TLS_PROCESS_NEW_SESSION_TICKET, SSL_R_BAD_EXTENSION);
             goto f_err;
@@ -3479,9 +3481,10 @@ static MSG_PROCESS_RETURN tls_process_encrypted_extensions(SSL *s, PACKET *pkt)
         goto err;
     }
 
-    if (!tls_collect_extensions(s, &extensions, EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
-                                &rawexts, &al, NULL)
-            || !tls_parse_all_extensions(s, EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
+    if (!tls_collect_extensions(s, &extensions,
+                                SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS, &rawexts,
+                                &al, NULL)
+            || !tls_parse_all_extensions(s, SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
                                          rawexts, NULL, 0, &al))
         goto err;
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -801,7 +801,7 @@ static int ssl_add_cert_to_wpacket(SSL *s, WPACKET *pkt, X509 *x, int chain,
     }
 
     if (SSL_IS_TLS13(s)
-            && !tls_construct_extensions(s, pkt, EXT_TLS1_3_CERTIFICATE, x,
+            && !tls_construct_extensions(s, pkt, SSL_EXT_TLS1_3_CERTIFICATE, x,
                                          chain, al))
         return 0;
 

--- a/ssl/statem/statem_locl.h
+++ b/ssl/statem/statem_locl.h
@@ -153,6 +153,8 @@ MSG_PROCESS_RETURN tls_process_end_of_early_data(SSL *s, PACKET *pkt);
 
 /* Extension processing */
 
+__owur int extension_is_relevant(SSL *s, unsigned int extctx,
+                                 unsigned int thisctx);
 __owur int tls_collect_extensions(SSL *s, PACKET *packet, unsigned int context,
                                   RAW_EXTENSION **res, int *al, size_t *len);
 __owur int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
@@ -160,6 +162,8 @@ __owur int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
                                int *al);
 __owur int tls_parse_all_extensions(SSL *s, int context, RAW_EXTENSION *exts,
                                     X509 *x, size_t chainidx, int *al);
+__owur int should_add_extension(SSL *s, unsigned int extctx,
+                                unsigned int thisctx, int max_version);
 __owur int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
                                     X509 *x, size_t chainidx, int *al);
 

--- a/ssl/statem/statem_locl.h
+++ b/ssl/statem/statem_locl.h
@@ -32,29 +32,6 @@
 /* The maximum number of incoming KeyUpdate messages we will accept */
 #define MAX_KEY_UPDATE_MESSAGES     32
 
-/* Extension context codes */
-/* This extension is only allowed in TLS */
-#define EXT_TLS_ONLY                        0x0001
-/* This extension is only allowed in DTLS */
-#define EXT_DTLS_ONLY                       0x0002
-/* Some extensions may be allowed in DTLS but we don't implement them for it */
-#define EXT_TLS_IMPLEMENTATION_ONLY         0x0004
-/* Most extensions are not defined for SSLv3 but EXT_TYPE_renegotiate is */
-#define EXT_SSL3_ALLOWED                    0x0008
-/* Extension is only defined for TLS1.2 and above */
-#define EXT_TLS1_2_AND_BELOW_ONLY           0x0010
-/* Extension is only defined for TLS1.3 and above */
-#define EXT_TLS1_3_ONLY                     0x0020
-#define EXT_CLIENT_HELLO                    0x0040
-/* Really means TLS1.2 or below */
-#define EXT_TLS1_2_SERVER_HELLO             0x0080
-#define EXT_TLS1_3_SERVER_HELLO             0x0100
-#define EXT_TLS1_3_ENCRYPTED_EXTENSIONS     0x0200
-#define EXT_TLS1_3_HELLO_RETRY_REQUEST      0x0400
-#define EXT_TLS1_3_CERTIFICATE              0x0800
-#define EXT_TLS1_3_NEW_SESSION_TICKET       0x1000
-#define EXT_TLS1_3_CERTIFICATE_REQUEST      0x2000
-
 /* Dummy message type */
 #define SSL3_MT_DUMMY   -1
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1442,7 +1442,7 @@ MSG_PROCESS_RETURN tls_process_client_hello(SSL *s, PACKET *pkt)
 
     /* Preserve the raw extensions PACKET for later use */
     extensions = clienthello->extensions;
-    if (!tls_collect_extensions(s, &extensions, EXT_CLIENT_HELLO,
+    if (!tls_collect_extensions(s, &extensions, SSL_EXT_CLIENT_HELLO,
                                 &clienthello->pre_proc_exts, &al,
                                 &clienthello->pre_proc_exts_len)) {
         /* SSLerr already been called */
@@ -1580,7 +1580,7 @@ static int tls_early_post_process_client_hello(SSL *s, int *al)
 
     /* We need to do this before getting the session */
     if (!tls_parse_extension(s, TLSEXT_IDX_extended_master_secret,
-                             EXT_CLIENT_HELLO,
+                             SSL_EXT_CLIENT_HELLO,
                              clienthello->pre_proc_exts, NULL, 0, al)) {
         SSLerr(SSL_F_TLS_EARLY_POST_PROCESS_CLIENT_HELLO, SSL_R_CLIENTHELLO_TLSEXT);
         goto err;
@@ -1708,7 +1708,7 @@ static int tls_early_post_process_client_hello(SSL *s, int *al)
 #endif                          /* !OPENSSL_NO_EC */
 
     /* TLS extensions */
-    if (!tls_parse_all_extensions(s, EXT_CLIENT_HELLO,
+    if (!tls_parse_all_extensions(s, SSL_EXT_CLIENT_HELLO,
                                   clienthello->pre_proc_exts, NULL, 0, al)) {
         SSLerr(SSL_F_TLS_EARLY_POST_PROCESS_CLIENT_HELLO, SSL_R_PARSE_TLSEXT);
         goto err;
@@ -2127,8 +2127,8 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
                 && !WPACKET_put_bytes_u8(pkt, compm))
             || !tls_construct_extensions(s, pkt,
                                          SSL_IS_TLS13(s)
-                                            ? EXT_TLS1_3_SERVER_HELLO
-                                            : EXT_TLS1_2_SERVER_HELLO,
+                                            ? SSL_EXT_TLS1_3_SERVER_HELLO
+                                            : SSL_EXT_TLS1_2_SERVER_HELLO,
                                          NULL, 0, &al)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_SERVER_HELLO, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -2510,8 +2510,9 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
             goto err;
         }
 
-        if (!tls_construct_extensions(s, pkt, EXT_TLS1_3_CERTIFICATE_REQUEST,
-                                      NULL, 0, &al)) {
+        if (!tls_construct_extensions(s, pkt,
+                                      SSL_EXT_TLS1_3_CERTIFICATE_REQUEST, NULL,
+                                      0, &al)) {
             SSLerr(SSL_F_TLS_CONSTRUCT_CERTIFICATE_REQUEST,
                    ERR_R_INTERNAL_ERROR);
             goto err;
@@ -3251,9 +3252,10 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
                 SSLerr(SSL_F_TLS_PROCESS_CLIENT_CERTIFICATE, SSL_R_BAD_LENGTH);
                 goto f_err;
             }
-            if (!tls_collect_extensions(s, &extensions, EXT_TLS1_3_CERTIFICATE,
-                                        &rawexts, &al, NULL)
-                    || !tls_parse_all_extensions(s, EXT_TLS1_3_CERTIFICATE,
+            if (!tls_collect_extensions(s, &extensions,
+                                        SSL_EXT_TLS1_3_CERTIFICATE, &rawexts,
+                                        &al, NULL)
+                    || !tls_parse_all_extensions(s, SSL_EXT_TLS1_3_CERTIFICATE,
                                                  rawexts, x, chainidx, &al)) {
                 OPENSSL_free(rawexts);
                 goto f_err;
@@ -3550,7 +3552,7 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
             || !WPACKET_close(pkt)
             || (SSL_IS_TLS13(s)
                 && !tls_construct_extensions(s, pkt,
-                                             EXT_TLS1_3_NEW_SESSION_TICKET,
+                                             SSL_EXT_TLS1_3_NEW_SESSION_TICKET,
                                              NULL, 0, &al))) {
         SSLerr(SSL_F_TLS_CONSTRUCT_NEW_SESSION_TICKET, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -3637,7 +3639,7 @@ static int tls_construct_encrypted_extensions(SSL *s, WPACKET *pkt)
 {
     int al;
 
-    if (!tls_construct_extensions(s, pkt, EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
+    if (!tls_construct_extensions(s, pkt, SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS,
                                   NULL, 0, &al)) {
         ssl3_send_alert(s, SSL3_AL_FATAL, al);
         SSLerr(SSL_F_TLS_CONSTRUCT_ENCRYPTED_EXTENSIONS, ERR_R_INTERNAL_ERROR);
@@ -3659,7 +3661,8 @@ static int tls_construct_hello_retry_request(SSL *s, WPACKET *pkt)
      */
     if (!WPACKET_put_bytes_u16(pkt, TLS1_3_VERSION_DRAFT)
             || !s->method->put_cipher_by_char(s->s3->tmp.new_cipher, pkt, &len)
-            || !tls_construct_extensions(s, pkt, EXT_TLS1_3_HELLO_RETRY_REQUEST,
+            || !tls_construct_extensions(s, pkt,
+                                         SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST,
                                          NULL, 0, &al)) {
         SSLerr(SSL_F_TLS_CONSTRUCT_HELLO_RETRY_REQUEST, ERR_R_INTERNAL_ERROR);
         goto err;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2602,7 +2602,11 @@ int test_main(int argc, char *argv[])
     ADD_ALL_TESTS(test_early_data_tls1_2, 2);
 # endif
 #endif
+#ifndef OPENSSL_NO_TLS1_3
     ADD_ALL_TESTS(test_custom_exts, 4);
+#else
+    ADD_ALL_TESTS(test_custom_exts, 2);
+#endif
 
     testresult = run_tests(argv[0]);
 

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -439,3 +439,4 @@ SSL_get0_CA_list                        439	1_1_1	EXIST::FUNCTION:
 SSL_get0_peer_CA_list                   440	1_1_1	EXIST::FUNCTION:
 SSL_CTX_add1_CA_list                    441	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get0_CA_list                    442	1_1_1	EXIST::FUNCTION:
+SSL_CTX_add_custom_ext                  443	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This updates the custom extensions API to work with TLSv1.3.

I have not updated any of the SSL_CTX_use_serverinfo*() functions as part of this PR. I will do that as a separate PR.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
