### PR TITLE
BIO_printf() doesn't know %j in this branch, use PRI[ud]64 instead

### DIFF
--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -79,8 +79,8 @@ static int uint64_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *it,
                         int indent, const ASN1_PCTX *pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
-        return BIO_printf(out, "%jd\n", *(int64_t *)pval);
-    return BIO_printf(out, "%ju\n", *(uint64_t *)pval);
+        return BIO_printf(out, "%" PRId64 "\n", *(int64_t *)pval);
+    return BIO_printf(out, "%" PRIu64 "\n", *(uint64_t *)pval);
 }
 
 /* 32-bit variants */

--- a/e_os.h
+++ b/e_os.h
@@ -35,12 +35,20 @@ extern "C" {
  */
 # if defined(OPENSSL_SYS_UEFI)
 #  define PRIu64 "Lu"
+#  define PRId64 "Ld"
 # endif
 # ifndef PRIu64
 #  ifdef SIXTY_FOUR_BIT_LONG
 #   define PRIu64 "lu"
 #  else
 #   define PRIu64 "llu"
+#  endif
+# endif
+# ifndef PRId64
+#  ifdef SIXTY_FOUR_BIT_LONG
+#   define PRId64 "ld"
+#  else
+#   define PRId64 "lld"
 #  endif
 # endif
 


### PR DESCRIPTION
This adds the definition of PRId64.

Fixes #3143