### PR TITLE
Make default_method mostly compile-time

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1465,12 +1465,8 @@ int speed_main(int argc, char **argv)
             continue;
         }
 #ifndef OPENSSL_NO_RSA
-# ifndef RSA_NULL
-        if (strcmp(*argv, "openssl") == 0) {
-            RSA_set_default_method(RSA_PKCS1_OpenSSL());
+        if (strcmp(*argv, "openssl") == 0)
             continue;
-        }
-# endif
         if (strcmp(*argv, "rsa") == 0) {
             rsa_doit[R_RSA_512] = rsa_doit[R_RSA_1024] =
                 rsa_doit[R_RSA_2048] = rsa_doit[R_RSA_3072] =

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -56,9 +56,21 @@ static DH_METHOD dh_ossl = {
     NULL
 };
 
+static const DH_METHOD *default_DH_method = &dh_ossl;
+
 const DH_METHOD *DH_OpenSSL(void)
 {
     return &dh_ossl;
+}
+
+void DH_set_default_method(const DH_METHOD *meth)
+{
+    default_DH_method = meth;
+}
+
+const DH_METHOD *DH_get_default_method(void)
+{
+    return default_DH_method;
 }
 
 static int generate_key(DH *dh)

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -13,20 +13,6 @@
 #include "dh_locl.h"
 #include <openssl/engine.h>
 
-static const DH_METHOD *default_DH_method = NULL;
-
-void DH_set_default_method(const DH_METHOD *meth)
-{
-    default_DH_method = meth;
-}
-
-const DH_METHOD *DH_get_default_method(void)
-{
-    if (!default_DH_method)
-        default_DH_method = DH_OpenSSL();
-    return default_DH_method;
-}
-
 int DH_set_method(DH *dh, const DH_METHOD *meth)
 {
     /*

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -17,20 +17,6 @@
 #include <openssl/engine.h>
 #include <openssl/dh.h>
 
-static const DSA_METHOD *default_DSA_method = NULL;
-
-void DSA_set_default_method(const DSA_METHOD *meth)
-{
-    default_DSA_method = meth;
-}
-
-const DSA_METHOD *DSA_get_default_method(void)
-{
-    if (!default_DSA_method)
-        default_DSA_method = DSA_OpenSSL();
-    return default_DSA_method;
-}
-
 DSA *DSA_new(void)
 {
     return DSA_new_method(NULL);

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -41,6 +41,18 @@ static DSA_METHOD openssl_dsa_meth = {
     NULL
 };
 
+static const DSA_METHOD *default_DSA_method = &openssl_dsa_meth;
+
+void DSA_set_default_method(const DSA_METHOD *meth)
+{
+    default_DSA_method = meth;
+}
+
+const DSA_METHOD *DSA_get_default_method(void)
+{
+    return default_DSA_method;
+}
+
 const DSA_METHOD *DSA_OpenSSL(void)
 {
     return &openssl_dsa_meth;

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -15,31 +15,9 @@
 #include <openssl/engine.h>
 #include "rsa_locl.h"
 
-static const RSA_METHOD *default_RSA_meth = NULL;
-
 RSA *RSA_new(void)
 {
-    RSA *r = RSA_new_method(NULL);
-
-    return r;
-}
-
-void RSA_set_default_method(const RSA_METHOD *meth)
-{
-    default_RSA_meth = meth;
-}
-
-const RSA_METHOD *RSA_get_default_method(void)
-{
-    if (default_RSA_meth == NULL) {
-#ifdef RSA_NULL
-        default_RSA_meth = RSA_null_method();
-#else
-        default_RSA_meth = RSA_PKCS1_OpenSSL();
-#endif
-    }
-
-    return default_RSA_meth;
+    return RSA_new_method(NULL);
 }
 
 const RSA_METHOD *RSA_get_method(const RSA *rsa)

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -11,8 +11,6 @@
 #include "internal/bn_int.h"
 #include "rsa_locl.h"
 
-#ifndef RSA_NULL
-
 static int rsa_ossl_public_encrypt(int flen, const unsigned char *from,
                                   unsigned char *to, RSA *rsa, int padding);
 static int rsa_ossl_private_encrypt(int flen, const unsigned char *from,
@@ -26,7 +24,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *i, RSA *rsa,
 static int rsa_ossl_init(RSA *rsa);
 static int rsa_ossl_finish(RSA *rsa);
 static RSA_METHOD rsa_pkcs1_ossl_meth = {
-    "OpenSSL PKCS#1 RSA (from Eric Young)",
+    "OpenSSL PKCS#1 RSA",
     rsa_ossl_public_encrypt,
     rsa_ossl_public_decrypt,     /* signature verification */
     rsa_ossl_private_encrypt,    /* signing */
@@ -42,6 +40,18 @@ static RSA_METHOD rsa_pkcs1_ossl_meth = {
     0,                          /* rsa_verify */
     NULL                        /* rsa_keygen */
 };
+
+static const RSA_METHOD *default_RSA_meth = &rsa_pkcs1_ossl_meth;
+
+void RSA_set_default_method(const RSA_METHOD *meth)
+{
+    default_RSA_meth = meth;
+}
+
+const RSA_METHOD *RSA_get_default_method(void)
+{
+    return default_RSA_meth;
+}
 
 const RSA_METHOD *RSA_PKCS1_OpenSSL(void)
 {
@@ -786,5 +796,3 @@ static int rsa_ossl_finish(RSA *rsa)
     BN_MONT_CTX_free(rsa->_method_mod_q);
     return (1);
 }
-
-#endif

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -15,8 +15,6 @@
 #include <openssl/err.h>
 #include "ui_locl.h"
 
-static const UI_METHOD *default_UI_meth = NULL;
-
 UI *UI_new(void)
 {
     return (UI_new_method(NULL));
@@ -529,19 +527,6 @@ int UI_set_ex_data(UI *r, int idx, void *arg)
 void *UI_get_ex_data(UI *r, int idx)
 {
     return (CRYPTO_get_ex_data(&r->ex_data, idx));
-}
-
-void UI_set_default_method(const UI_METHOD *meth)
-{
-    default_UI_meth = meth;
-}
-
-const UI_METHOD *UI_get_default_method(void)
-{
-    if (default_UI_meth == NULL) {
-        default_UI_meth = UI_OpenSSL();
-    }
-    return default_UI_meth;
 }
 
 const UI_METHOD *UI_get_method(UI *ui)

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -202,6 +202,18 @@ static UI_METHOD ui_openssl = {
     NULL
 };
 
+static const UI_METHOD *default_UI_meth = &ui_openssl;
+
+void UI_set_default_method(const UI_METHOD *meth)
+{
+    default_UI_meth = meth;
+}
+
+const UI_METHOD *UI_get_default_method(void)
+{
+    return default_UI_meth;
+}
+
 /* The method with all the built-in thingies */
 UI_METHOD *UI_OpenSSL(void)
 {

--- a/doc/crypto/DH_set_method.pod
+++ b/doc/crypto/DH_set_method.pod
@@ -31,8 +31,11 @@ Initially, the default DH_METHOD is the OpenSSL internal implementation, as
 returned by DH_OpenSSL().
 
 DH_set_default_method() makes B<meth> the default method for all DH
-structures created later. B<NB>: This is true only whilst no ENGINE has been set
+structures created later.
+B<NB>: This is true only whilst no ENGINE has been set
 as a default for DH, so this function is no longer recommended.
+This function is not thread-safe and should not be called at the same time
+as other OpenSSL functions.
 
 DH_get_default_method() returns a pointer to the current default DH_METHOD.
 However, the meaningfulness of this result is dependent on whether the ENGINE

--- a/doc/crypto/DSA_set_method.pod
+++ b/doc/crypto/DSA_set_method.pod
@@ -31,8 +31,11 @@ Initially, the default DSA_METHOD is the OpenSSL internal implementation,
 as returned by DSA_OpenSSL().
 
 DSA_set_default_method() makes B<meth> the default method for all DSA
-structures created later. B<NB>: This is true only whilst no ENGINE has
+structures created later.
+B<NB>: This is true only whilst no ENGINE has
 been set as a default for DSA, so this function is no longer recommended.
+This function is not thread-safe and should not be called at the same time
+as other OpenSSL functions.
 
 DSA_get_default_method() returns a pointer to the current default
 DSA_METHOD. However, the meaningfulness of this result is dependent on

--- a/doc/crypto/RSA_set_method.pod
+++ b/doc/crypto/RSA_set_method.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 RSA_set_default_method, RSA_get_default_method, RSA_set_method,
-RSA_get_method, RSA_PKCS1_OpenSSL, RSA_null_method, RSA_flags,
+RSA_get_method, RSA_PKCS1_OpenSSL, RSA_flags,
 RSA_new_method - select RSA method
 
 =head1 SYNOPSIS
@@ -19,8 +19,6 @@ RSA_new_method - select RSA method
  RSA_METHOD *RSA_get_method(const RSA *rsa);
 
  RSA_METHOD *RSA_PKCS1_OpenSSL(void);
-
- RSA_METHOD *RSA_null_method(void);
 
  int RSA_flags(const RSA *rsa);
 
@@ -38,8 +36,11 @@ Initially, the default RSA_METHOD is the OpenSSL internal implementation,
 as returned by RSA_PKCS1_OpenSSL().
 
 RSA_set_default_method() makes B<meth> the default method for all RSA
-structures created later. B<NB>: This is true only whilst no ENGINE has
+structures created later.
+B<NB>: This is true only whilst no ENGINE has
 been set as a default for RSA, so this function is no longer recommended.
+This function is not thread-safe and should not be called at the same time
+as other OpenSSL functions.
 
 RSA_get_default_method() returns a pointer to the current default
 RSA_METHOD. However, the meaningfulness of this result is dependent on
@@ -167,6 +168,11 @@ not currently exist).
 =head1 SEE ALSO
 
 L<RSA_new(3)>
+
+=head1 HISTORY
+
+The RSA_null_method(), which was a partial attempt to avoid patent issues,
+was replaced to always return NULL in OpenSSL 1.1.0f.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
This is #2244 picked to 1.1.0
It keeps the RSA_null stuff.
