### PR TITLE
bio/b_print.c: drop dependency on BN config.

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -548,8 +548,8 @@ int enc_main(int argc, char **argv)
 
     ret = 0;
     if (verbose) {
-        BIO_printf(bio_err, "bytes read   :%8"PRIu64"\n", BIO_number_read(in));
-        BIO_printf(bio_err, "bytes written:%8"PRIu64"\n", BIO_number_written(out));
+        BIO_printf(bio_err, "bytes read   :%8"BIO_PRI64"u\n", BIO_number_read(in));
+        BIO_printf(bio_err, "bytes written:%8"BIO_PRI64"u\n", BIO_number_written(out));
     }
  end:
     ERR_print_errors(bio_err);

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1002,7 +1002,7 @@ static char *hexencode(const unsigned char *data, size_t len)
     int ilen = (int) outlen;
 
     if (outlen < len || ilen < 0 || outlen != (size_t)ilen) {
-        BIO_printf(bio_err, "%s: %" PRIu64 "-byte buffer too large to hexencode\n",
+        BIO_printf(bio_err, "%s: %"BIO_PRI64"u-byte buffer too large to hexencode\n",
                    opt_getprog(), (uint64_t)len);
         exit(1);
     }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2615,8 +2615,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 #endif
 
         BIO_printf(bio,
-                   "---\nSSL handshake has read %" PRIu64
-                   " bytes and written %" PRIu64 " bytes\n",
+                   "---\nSSL handshake has read %"BIO_PRI64"u"
+                   " bytes and written %"BIO_PRI64"u bytes\n",
                    BIO_number_read(SSL_get_rbio(s)),
                    BIO_number_written(SSL_get_wbio(s)));
     }

--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -79,8 +79,8 @@ static int uint64_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *it,
                         int indent, const ASN1_PCTX *pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
-        return BIO_printf(out, "%jd\n", *(int64_t *)pval);
-    return BIO_printf(out, "%ju\n", *(uint64_t *)pval);
+        return BIO_printf(out, "%"BIO_PRI64"d\n", *(int64_t *)pval);
+    return BIO_printf(out, "%"BIO_PRI64"u\n", *(uint64_t *)pval);
 }
 
 /* 32-bit variants */

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -12,17 +12,7 @@
 #include <ctype.h>
 #include "internal/numbers.h"
 #include "internal/cryptlib.h"
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#include <openssl/bn.h>         /* To get BN_LLONG properly defined */
 #include <openssl/bio.h>
-
-#if defined(BN_LLONG) || defined(SIXTY_FOUR_BIT)
-# ifndef HAVE_LONG_LONG
-#  define HAVE_LONG_LONG 1
-# endif
-#endif
 
 /*
  * Copyright Patrick Powell 1995
@@ -37,20 +27,10 @@
 # define LDOUBLE double
 #endif
 
-#ifdef HAVE_LONG_LONG
-# if defined(_WIN32) && !defined(__GNUC__)
-#  define LLONG __int64
-# else
-#  define LLONG long long
-# endif
-#else
-# define LLONG long
-#endif
-
 static int fmtstr(char **, char **, size_t *, size_t *,
                   const char *, int, int, int);
 static int fmtint(char **, char **, size_t *, size_t *,
-                  LLONG, int, int, int, int);
+                  int64_t, int, int, int, int);
 static int fmtfp(char **, char **, size_t *, size_t *,
                  LDOUBLE, int, int, int, int);
 static int doapr_outch(char **, char **, size_t *, size_t *, int);
@@ -106,7 +86,7 @@ _dopr(char **sbuffer,
       size_t *retlen, int *truncated, const char *format, va_list args)
 {
     char ch;
-    LLONG value;
+    int64_t value;
     LDOUBLE fvalue;
     char *strvalue;
     int min;
@@ -231,7 +211,7 @@ _dopr(char **sbuffer,
                     value = va_arg(args, long int);
                     break;
                 case DP_C_LLONG:
-                    value = va_arg(args, LLONG);
+                    value = va_arg(args, int64_t);
                     break;
                 default:
                     value = va_arg(args, int);
@@ -253,13 +233,13 @@ _dopr(char **sbuffer,
                     value = (unsigned short int)va_arg(args, unsigned int);
                     break;
                 case DP_C_LONG:
-                    value = (LLONG) va_arg(args, unsigned long int);
+                    value = va_arg(args, unsigned long int);
                     break;
                 case DP_C_LLONG:
-                    value = va_arg(args, unsigned LLONG);
+                    value = va_arg(args, uint64_t);
                     break;
                 default:
-                    value = (LLONG) va_arg(args, unsigned int);
+                    value = va_arg(args, unsigned int);
                     break;
                 }
                 if (!fmtint(sbuffer, buffer, &currlen, maxlen, value,
@@ -331,9 +311,9 @@ _dopr(char **sbuffer,
                     num = va_arg(args, long int *);
                     *num = (long int)currlen;
                 } else if (cflags == DP_C_LLONG) { /* XXX */
-                    LLONG *num;
-                    num = va_arg(args, LLONG *);
-                    *num = (LLONG) currlen;
+                    int64_t *num;
+                    num = va_arg(args, int64_t *);
+                    *num = (int64_t)currlen;
                 } else {
                     int *num;
                     num = va_arg(args, int *);
@@ -434,11 +414,11 @@ static int
 fmtint(char **sbuffer,
        char **buffer,
        size_t *currlen,
-       size_t *maxlen, LLONG value, int base, int min, int max, int flags)
+       size_t *maxlen, int64_t value, int base, int min, int max, int flags)
 {
     int signvalue = 0;
     const char *prefix = "";
-    unsigned LLONG uvalue;
+    uint64_t uvalue;
     char convert[DECIMAL_SIZE(value) + 3];
     int place = 0;
     int spadlen = 0;
@@ -451,7 +431,7 @@ fmtint(char **sbuffer,
     if (!(flags & DP_F_UNSIGNED)) {
         if (value < 0) {
             signvalue = '-';
-            uvalue = 0 - (unsigned LLONG)value;
+            uvalue = 0 - (uint64_t)value;
         } else if (flags & DP_F_PLUS)
             signvalue = '+';
         else if (flags & DP_F_SPACE)

--- a/e_os.h
+++ b/e_os.h
@@ -30,18 +30,13 @@ extern "C" {
 # endif
 
 /*
- * We need a format operator for some client tools for uint64_t.  If inttypes.h
- * isn't available or did not define it, just go with hard-coded.
+ * BIO_printf format modifier for [u]int64_t.
  */
-# if defined(OPENSSL_SYS_UEFI)
-#  define PRIu64 "Lu"
-# endif
-# ifndef PRIu64
-#  ifdef SIXTY_FOUR_BIT_LONG
-#   define PRIu64 "lu"
-#  else
-#   define PRIu64 "llu"
-#  endif
+# if defined(__LP64__) || (defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__==8)
+#  define BIO_PRI64 "l"   /* 'll' does work "universally", but 'l' is here
+                            * to shut -Wformat warnings in LP64... */
+# else
+#  define BIO_PRI64 "ll"
 # endif
 
 # if !defined(NDEBUG) && !defined(OPENSSL_NO_STDIO)

--- a/e_os.h
+++ b/e_os.h
@@ -32,9 +32,9 @@ extern "C" {
 /*
  * BIO_printf format modifier for [u]int64_t.
  */
-# if defined(__LP64__) || (defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__==8)
-#  define BIO_PRI64 "l"   /* 'll' does work "universally", but 'l' is here
-                            * to shut -Wformat warnings in LP64... */
+# if defined(__LP64__) || (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__==8)
+#  define BIO_PRI64 "l"     /* 'll' does work "universally", but 'l' is
+                             * here to shut -Wformat warnings in LP64... */
 # else
 #  define BIO_PRI64 "ll"
 # endif


### PR DESCRIPTION
This might seem controversial, but it doesn't actually affect anything.
Or rather it doesn't make worse cases when it was problematic [with code
additions to 1.1.0]. One of such rare cases is 32-bit PA-RISC target
with *vendor* compiler.

It's currently marked as WIP, because initially it's meant to demonstrate a point in #3144.
