### PR TITLE
Allow an ALPN callback to pretend to not exist (1.1.0)

### DIFF
--- a/doc/ssl/SSL_CTX_set_alpn_select_cb.pod
+++ b/doc/ssl/SSL_CTX_set_alpn_select_cb.pod
@@ -113,9 +113,15 @@ The ALPN select callback B<cb>, must return one of the following:
 
 ALPN protocol selected.
 
+=item SSL_TLSEXT_ERR_ALERT_FATAL
+
+There was no overlap between the client's supplied list and the server
+configuration.
+
 =item SSL_TLSEXT_ERR_NOACK
 
-ALPN protocol not selected.
+ALPN protocol not selected, e.g., because no ALPN protocols are configured for
+this connection.
 
 =back
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1799,6 +1799,9 @@ static int tls1_alpn_handle_client_hello_late(SSL *s, int *al)
             /* ALPN takes precedence over NPN. */
             s->s3->next_proto_neg_seen = 0;
 #endif
+        } else if (r == SSL_TLSEXT_ERR_NOACK) {
+            /* Behave as if no callback was present. */
+            return 1;
         } else {
             *al = SSL_AD_NO_APPLICATION_PROTOCOL;
             return 0;

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -297,7 +297,7 @@ static int server_alpn_cb(SSL *s, const unsigned char **out,
     *out = tmp_out;
     /* Unlike NPN, we don't tolerate a mismatch. */
     return ret == OPENSSL_NPN_NEGOTIATED ? SSL_TLSEXT_ERR_OK
-        : SSL_TLSEXT_ERR_NOACK;
+        : SSL_TLSEXT_ERR_ALERT_FATAL;
 }
 
 /*


### PR DESCRIPTION
Backport of #2570 to 1.1.0

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
