### PR TITLE
In asn1_encode_test.c, add custom DER encoding checks

### DIFF
--- a/test/asn1_encode_test.c
+++ b/test/asn1_encode_test.c
@@ -38,6 +38,9 @@ static unsigned char t_zero[] = {
 static unsigned char t_one[] = {
     0x01
 };
+static unsigned char t_one_neg[] = {
+    0xff
+};
 static unsigned char t_longundef[] = {
     0x7f, 0xff, 0xff, 0xff
 };
@@ -95,6 +98,7 @@ static TEST_CUSTOM_DATA test_custom_data[] = {
     CUSTOM_DATA(t_zero),
     CUSTOM_DATA(t_longundef),
     CUSTOM_DATA(t_one),
+    CUSTOM_DATA(t_one_neg),
     CUSTOM_DATA(t_9bytes_1),
     CUSTOM_DATA(t_8bytes_1),
     CUSTOM_DATA(t_8bytes_2),
@@ -194,6 +198,7 @@ static ASN1_LONG_DATA long_expected_32bit[] = {
     { 0xff, 0, 1 }, { 0, 0, 0 }, /* t_zero */
     { 0, 0, 0 }, { 0xff, 1, 0x7fffffff }, /* t_longundef */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
+    CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_2 */
@@ -228,6 +233,7 @@ static ASN1_LONG_DATA long_expected_64bit[] = {
     { 0xff, 0, 1 }, { 0, 0, 0 }, /* t_zero */
     { 0, 0, 0 }, { 0xff, 1, 0x7fffffff }, /* t_longundef */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
+    CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_SUCCESS(LONG_MAX, LONG_MAX), /* t_8bytes_2 */
@@ -279,6 +285,7 @@ static ASN1_INT32_DATA int32_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(0, 0), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
+    CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_2 */
@@ -325,6 +332,7 @@ static ASN1_UINT32_DATA uint32_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(0, 0), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
+    CUSTOM_EXPECTED_FAILURE,     /* t_one_neg (illegal negative value) */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_2 */
@@ -371,6 +379,7 @@ static ASN1_INT64_DATA int64_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(0, 0), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
+    CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 (too large positive) */
     CUSTOM_EXPECTED_SUCCESS(INT64_MAX, INT64_MAX), /* t_8bytes_2 */
@@ -418,6 +427,7 @@ static ASN1_UINT64_DATA uint64_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(0, 0), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
+    CUSTOM_EXPECTED_FAILURE,     /* t_one_neg (illegal negative value) */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_SUCCESS((uint64_t)INT64_MAX+1, (uint64_t)INT64_MAX+1),
                                  /* t_8bytes_1 */

--- a/test/asn1_encode_test.c
+++ b/test/asn1_encode_test.c
@@ -132,7 +132,7 @@ static TEST_CUSTOM_DATA test_custom_data[] = {
  * A structure to collect all test information in.  There MUST be one instance
  * of this for each test
  */
-typedef int i2d_fn(void **a, unsigned char **pp);
+typedef int i2d_fn(void *a, unsigned char **pp);
 typedef void *d2i_fn(void **a, unsigned char **pp, long length);
 typedef void ifree_fn(void *a);
 typedef struct {


### PR DESCRIPTION
We're already checking that custom DER decodes to expected values (or
fails to do so), but we didn't check if values encode back to expected
DER.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
