### PR TITLE
Fixes config file when $CC is empty and there is a target with "-" in Configure LIST (i.e android)

### DIFF
--- a/config
+++ b/config
@@ -985,9 +985,11 @@ fi
 # compiler for the platform ... in which case we add it on
 # the end ... otherwise we leave it off
 
-$PERL ./Configure LIST | grep "$OUT-$CC" > /dev/null
-if [ $? = "0" ]; then
-  OUT="$OUT-$CC"
+if [ "$CC" != "" ]; then
+  $PERL ./Configure LIST | grep "$OUT-$CC" > /dev/null
+  if [ $? = "0" ]; then
+    OUT="$OUT-$CC"
+  fi
 fi
 
 OUT="$PREFIX$OUT"

--- a/config
+++ b/config
@@ -985,11 +985,9 @@ fi
 # compiler for the platform ... in which case we add it on
 # the end ... otherwise we leave it off
 
-if [ "$CC" != "" ]; then
-  $PERL ./Configure LIST | grep "$OUT-$CC" > /dev/null
-  if [ $? = "0" ]; then
-    OUT="$OUT-$CC"
-  fi
+$PERL ./Configure LIST | grep "^$OUT-$CC$" > /dev/null
+if [ $? = "0" ]; then
+  OUT="$OUT-$CC"
 fi
 
 OUT="$PREFIX$OUT"

--- a/config
+++ b/config
@@ -985,7 +985,7 @@ fi
 # compiler for the platform ... in which case we add it on
 # the end ... otherwise we leave it off
 
-$PERL ./Configure LIST | grep "^$OUT-$CC$" > /dev/null
+$PERL ./Configure LIST | grep "^$OUT-$CC\$" > /dev/null
 if [ $? = "0" ]; then
   OUT="$OUT-$CC"
 fi


### PR DESCRIPTION
When there are platforms matching with and without "-" like with android:
$ echo $OUT
android
$ perl Configure LIST | grep "android-"
android
android-armv7
android-x86
android64-aarch64

And $CC is empty, current script generates output like "android-" for the android target.
This applies to all branches.