### PR TITLE
test/testutil.c: Flush stdout when running tests

### DIFF
--- a/test/testutil.c
+++ b/test/testutil.c
@@ -114,6 +114,7 @@ int run_tests(const char *test_prog_name)
 
     printf("%s: %d test case%s\n", test_prog_name, num_test_cases,
            num_test_cases == 1 ? "" : "s");
+    fflush(stdout);
 
     for (i = 0; i != num_tests; ++i) {
         if (all_tests[i].num == -1) {
@@ -122,6 +123,7 @@ int run_tests(const char *test_prog_name)
             if (!ret) {
                 printf("** %s failed **\n--------\n",
                        all_tests[i].test_case_name);
+                fflush(stdout);
                 ++num_failed;
             }
             finalize(ret);
@@ -132,6 +134,7 @@ int run_tests(const char *test_prog_name)
                 if (!ret) {
                     printf("** %s failed test %d\n--------\n",
                            all_tests[i].test_case_name, j);
+                    fflush(stdout);
                     ++num_failed;
                 }
                 finalize(ret);
@@ -142,9 +145,11 @@ int run_tests(const char *test_prog_name)
     if (num_failed != 0) {
         printf("%s: %d test%s failed (out of %d)\n", test_prog_name,
                num_failed, num_failed != 1 ? "s" : "", num_test_cases);
+        fflush(stdout);
         return EXIT_FAILURE;
     }
     printf("  All tests passed.\n");
+    fflush(stdout);
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Because stdout is usually buffered and stderr isn't, error output
might get printed in one bunch and all the lines saying which test
failed all in one bunch, making it difficult to see exactly what error
output belongs to what test.  Flushing stdout makes sure the runner
output is displayed together with the corresponding error output.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
