### PR TITLE
OpenSSL::Test: supported filtered command output

### DIFF
--- a/test/recipes/95-test_external_boringssl.t
+++ b/test/recipes/95-test_external_boringssl.t
@@ -22,22 +22,10 @@ plan skip_all => "BoringSSL runner not detected"
 plan tests => 1;
 
 indir $ENV{BORING_RUNNER_DIR} => sub {
-    ok(filter_run(cmd(["go", "test", "-shim-path",
-                       bldtop_file("test", "ossl_shim", "ossl_shim"),
-                       "-shim-config",
-                       srctop_file("test", "ossl_shim", "ossl_config.json"),
-                       "-pipe", "-allow-unimplemented"])),
+    ok(run(cmd(["go", "test", "-shim-path",
+                bldtop_file("test", "ossl_shim", "ossl_shim"),
+                "-shim-config",
+                srctop_file("test", "ossl_shim", "ossl_config.json"),
+                "-pipe", "-allow-unimplemented"]), prefix => "go test: "),
        "running BoringSSL tests");
 }, create => 0, cleanup => 0;
-
-# Filter the output so that the "ok" printed by go test doesn't confuse
-# Test::More. Without that it thinks there has been one more test run than was
-# planned
-sub filter_run {
-    my $cmd = cmdstr(shift);
-    open(PIPE, "-|", $cmd);
-    while(<PIPE>) {
-        print STDOUT "go test: ", $_;
-    }
-    close PIPE;
-}

--- a/test/testlib/OpenSSL/Test.pm
+++ b/test/testlib/OpenSSL/Test.pm
@@ -403,6 +403,12 @@ return the resulting output as an array of lines.  If false or not given,
 the command will be executed with C<system()>, and C<run> will return 1 if
 the command was successful or 0 if it wasn't.
 
+=item B<prefix =E<gt> EXPR>
+
+If specified, EXPR will be used as a string to prefix the output from the
+command.  This is useful if the output contains lines starting with C<ok >
+or C<not ok > that can disturb Test::Harness.
+
 =item B<statusvar =E<gt> VARREF>
 
 If used, B<VARREF> must be a reference to a scalar variable.  It will be
@@ -452,8 +458,19 @@ sub run {
     # do.  For example, a program that gets aborted (and therefore signals
     # SIGABRT = 6) will appear to exit with the code 134.  We mimic this
     # to make it easier to compare with a manual run of the command.
-    if ($opts{capture}) {
-	@r = `$prefix$cmd`;
+    if ($opts{capture} || defined($opts{prefix})) {
+	my $pipe;
+
+	open($pipe, '-|', "$prefix$cmd") or die "Can't start command: $!";
+	while(<$pipe>) {
+	    my $l = ($opts{prefix} // "") . $_;
+	    if ($opts{capture}) {
+		push @r, $l;
+	    } else {
+		print STDOUT $l;
+	    }
+	}
+	close $pipe;
     } else {
 	system("$prefix$cmd");
     }


### PR DESCRIPTION
95-test_external_boringssl.t had a specialised run() variant to prefix
the command output so it wouldn't disturb Test::Harness.  This
functionality if now moved to the run() command, using the added
option 'prefix' that can be set to the string to prefix the output
with.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
