### PR TITLE
Correct travis.yml to only build extended tests when explicitely asked to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ matrix:
 
 before_script:
     - env
-    - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" -a -n "$EXTENDED_TEST" ]; then
+    - if [ "$TRAVIS_PULL_REQUEST" != "false" -a -n "$EXTENDED_TEST" ]; then
           (git log -1 $TRAVIS_COMMIT_RANGE | grep '\[extended tests\]' > /dev/null) || exit 0;
       fi
     - if [ -n "$DESTDIR" ]; then


### PR DESCRIPTION
The check for this was done by checking if $TRAVIS_EVENT_TYPE is
"pull_request".  The trouble is that when new data is pushed to an
already existing pull request, the event type is "push".

Better then to go with another documented variable, $TRAVIS_PULL_REQUEST,
which is "false" in non-PR builds.

Ref: https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
