### PR TITLE
testlist/OpenSSL/Test.pm: keep default input private.

### DIFF
--- a/test/testlib/OpenSSL/Test.pm
+++ b/test/testlib/OpenSSL/Test.pm
@@ -460,6 +460,7 @@ sub run {
     # to make it easier to compare with a manual run of the command.
     if ($opts{capture} || defined($opts{prefix})) {
 	my $pipe;
+	my $_;
 
 	open($pipe, '-|', "$prefix$cmd") or die "Can't start command: $!";
 	while(<$pipe>) {

--- a/test/testlib/OpenSSL/Test.pm
+++ b/test/testlib/OpenSSL/Test.pm
@@ -460,7 +460,7 @@ sub run {
     # to make it easier to compare with a manual run of the command.
     if ($opts{capture} || defined($opts{prefix})) {
 	my $pipe;
-	my $_;
+	local $_;
 
 	open($pipe, '-|', "$prefix$cmd") or die "Can't start command: $!";
 	while(<$pipe>) {


### PR DESCRIPTION
If $_ is no private, it wipes caller's one, which can be problematic...
