### PR TITLE
pkeyutl return 0 if the verification succeeded

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -326,7 +326,8 @@ int MAIN(int argc, char **argv)
             BIO_puts(out, "Signature Verified Successfully\n");
             ret = 0;
         }
-        goto end;
+        if (rv >= 0)
+            goto end;
     } else {
         rv = do_keyop(ctx, pkey_op, NULL, (size_t *)&buf_outlen,
                       buf_in, (size_t)buf_inlen);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -322,10 +322,11 @@ int MAIN(int argc, char **argv)
                              buf_in, (size_t)buf_inlen);
         if (rv == 0)
             BIO_puts(out, "Signature Verification Failure\n");
-        else if (rv == 1)
+        else if (rv == 1) {
             BIO_puts(out, "Signature Verified Successfully\n");
-        if (rv >= 0)
-            goto end;
+            ret = 0;
+        }
+        goto end;
     } else {
         rv = do_keyop(ctx, pkey_op, NULL, (size_t *)&buf_outlen,
                       buf_in, (size_t)buf_inlen);


### PR DESCRIPTION
If return non-zero, which not consistent with shell conventions, the shells/scripts treat the cmd as failed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
