### PR TITLE
[master] Catch EC_R_UNKNOWN_GROUP in check_unsupported()

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -469,6 +469,18 @@ static int check_unsupported()
         ERR_clear_error();
         return 1;
     }
+#ifndef OPENSSL_NO_EC
+    /*
+     * If EC support is enabled we should catch also EC_R_UNKNOWN_GROUP as an
+     * hint to an unsupported algorithm/curve (e.g. if binary EC support is
+     * disabled).
+     */
+    if (ERR_GET_LIB(err) == ERR_LIB_EC
+        && ERR_GET_REASON(err) == EC_R_UNKNOWN_GROUP) {
+        ERR_clear_error();
+        return 1;
+    }
+#endif // OPENSSL_NO_EC
     return 0;
 }
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -480,7 +480,7 @@ static int check_unsupported()
         ERR_clear_error();
         return 1;
     }
-#endif // OPENSSL_NO_EC
+#endif /* OPENSSL_NO_EC */
     return 0;
 }
 


### PR DESCRIPTION
This issue is mentioned in https://github.com/openssl/openssl/pull/3222#issuecomment-294134456

If EC support is enabled we should catch also EC_R_UNKNOWN_GROUP as an hint to
an unsupported algorithm/curve (e.g. if binary EC support is disabled).

Before this commit the issue arise for example if binary EC keys are added in
evptests.txt, and the test is run when EC is enabled but EC2m is disabled.

E.g. adding these lines to evptests.txt would reproduce the issue:

~~~

PrivateKey=KAS-ECC-CDH_K-163_C0
-----BEGIN PRIVATE KEY-----
MGMCAQAwEAYHKoZIzj0CAQYFK4EEAAEETDBKAgEBBBUAZlO2B3OY+tx79eYBWBcB
SMPcRSehLgMsAAQHH4sod9YCfZwa3kJE8t6hJpLvI9UFwV7ndiIccrhLNHzjg/OA
Z7icPpo=
-----END PRIVATE KEY-----

PublicKey=KAS-ECC-CDH_K-163_C0-PUBLIC
-----BEGIN PUBLIC KEY-----
MEAwEAYHKoZIzj0CAQYFK4EEAAEDLAAEBx+LKHfWAn2cGt5CRPLeoSaS7yPVBcFe
53YiHHK4SzR844PzgGe4nD6a
-----END PUBLIC KEY-----

PublicKey=KAS-ECC-CDH_K-163_C0-Peer-PUBLIC
-----BEGIN PUBLIC KEY-----
MEAwEAYHKoZIzj0CAQYFK4EEAAEDLAAEBXQjbxQoxDITCUZ4Ols6q7bCfqXWB5CM
JRuNoCHLrCgfEj969PrFs9u4
-----END PUBLIC KEY-----

Derive=KAS-ECC-CDH_K-163_C0
PeerKey=KAS-ECC-CDH_K-163_C0-Peer-PUBLIC
Ctrl=ecdh_cofactor_mode:1
SharedSecret=04325bff38f1b0c83c27f554a6c972a80f14bc23bc

~~~

After merging of PR #3218 evptests.txt contains such keys, so currently building wit EC support enabled but binary EC support disabled results in the test failing during parsing.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
