### PR TITLE
Don't nullify s->ext.ocsp.resp on 2nd or later Certificate in TLSv1.3

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -857,14 +857,6 @@ static int init_status_request(SSL *s, unsigned int context)
 {
     if (s->server) {
         s->ext.status_type = TLSEXT_STATUSTYPE_nothing;
-    } else {
-        /*
-         * Ensure we get sensible values passed to tlsext_status_cb in the event
-         * that we don't receive a status message
-         */
-        OPENSSL_free(s->ext.ocsp.resp);
-        s->ext.ocsp.resp = NULL;
-        s->ext.ocsp.resp_len = 0;
     }
 
     return 1;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1056,10 +1056,6 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
         if (chainidx != 0)
             return 1;
 
-        /*
-         * Ensure we get sensible values passed to tlsext_status_cb in the event
-         * that we don't receive a status message
-         */
         OPENSSL_free(s->ext.ocsp.resp);
         s->ext.ocsp.resp = NULL;
         s->ext.ocsp.resp_len = 0;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1055,11 +1055,28 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
          */
         if (chainidx != 0)
             return 1;
+
+        /*
+         * Ensure we get sensible values passed to tlsext_status_cb in the event
+         * that we don't receive a status message
+         */
+        OPENSSL_free(s->ext.ocsp.resp);
+        s->ext.ocsp.resp = NULL;
+        s->ext.ocsp.resp_len = 0;
+
         return tls_process_cert_status_body(s, pkt, al);
     }
 
     /* Set flag to expect CertificateStatus message */
     s->ext.status_expected = 1;
+
+    /*
+     * Ensure we get sensible values passed to tlsext_status_cb in the event
+     * that we don't receive a status message
+     */
+    OPENSSL_free(s->ext.ocsp.resp);
+    s->ext.ocsp.resp = NULL;
+    s->ext.ocsp.resp_len = 0;
 
     return 1;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

Fixes #3150