### PR TITLE
VMS: Fix the passing of cflags for things not being installed

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1789,9 +1789,9 @@ sub vms_info {
                                    debug   => "/DEBUG/TRACEBACK",
                                    release => "/NODEBUG/NOTRACEBACK"),
         lib_cflags       => add("/NAMES=(AS_IS,SHORTENED)/EXTERN_MODEL=STRICT_REFDEF"),
-        # no_inst_bin_cflags is used instead of bin_cflags by descrip.mms.tmpl
-        # for object files belonging to selected internal programs
-        no_inst_bin_cflags => "/NAMES=(AS_IS,SHORTENED)",
+        # no_inst_lib_cflags is used instead of lib_cflags by descrip.mms.tmpl
+        # for object files belonging to selected internal libraries
+        no_inst_lib_cflags => "",
         shared_target    => "vms-shared",
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -133,7 +133,7 @@
                      objs => [ map { (my $x = $_) =~ s|\.o$||; $x }
                                @{$unified_info{sources}->{$lib}} ]);
      foreach (@{$unified_info{sources}->{$lib}}) {
-         doobj($_, $lib, intent => "lib");
+         doobj($_, $lib, intent => "lib", installed => is_installed($lib));
      }
      $cache{$lib} = 1;
  }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -157,12 +157,12 @@ CFLAGS_Q=$(CFLAGS)
 DEPFLAG= /DEFINE=({- join(",", @{$config{depdefines}}) -})
 LDFLAGS= {- $target{lflags} -}
 EX_LIBS= {- $target{ex_libs} ? ",".$target{ex_libs} : "" -}{- $config{ex_libs} ? ",".$config{ex_libs} : "" -}
-LIB_CFLAGS={- $target{lib_cflags} || "" -}
-DSO_CFLAGS={- $target{dso_cflags} || "" -}
-BIN_CFLAGS={- $target{bin_cflags} || "" -}
-NO_INST_LIB_CFLAGS={- $target{no_inst_lib_cflags} || '$(LIB_CFLAGS)' -}
-NO_INST_DSO_CFLAGS={- $target{no_inst_dso_cflags} || '$(DSO_CFLAGS)' -}
-NO_INST_BIN_CFLAGS={- $target{no_inst_bin_cflags} || '$(BIN_CFLAGS)' -}
+LIB_CFLAGS={- $target{lib_cflags} // "" -}
+DSO_CFLAGS={- $target{dso_cflags} // "" -}
+BIN_CFLAGS={- $target{bin_cflags} // "" -}
+NO_INST_LIB_CFLAGS={- $target{no_inst_lib_cflags} // '$(LIB_CFLAGS)' -}
+NO_INST_DSO_CFLAGS={- $target{no_inst_dso_cflags} // '$(DSO_CFLAGS)' -}
+NO_INST_BIN_CFLAGS={- $target{no_inst_bin_cflags} // '$(BIN_CFLAGS)' -}
 
 PERL={- $config{perl} -}
 

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -59,7 +59,17 @@ static int test_tbl_standard()
  *
  ***/
 
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "internal/asn1_int.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
+
 #include "../crypto/asn1/standard_methods.h"
 
 static int test_standard_methods()

--- a/test/chacha_internal_test.c
+++ b/test/chacha_internal_test.c
@@ -16,7 +16,17 @@
 #include <openssl/opensslconf.h>
 #include "test_main.h"
 #include "testutil.h"
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "internal/chacha.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
 
 const static unsigned int key[] = {
     0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,

--- a/test/poly1305_internal_test.c
+++ b/test/poly1305_internal_test.c
@@ -14,7 +14,18 @@
 
 #include "testutil.h"
 #include "test_main_custom.h"
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "internal/poly1305.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
+
 #include "../crypto/poly1305/poly1305_local.h"
 #include "e_os.h"
 

--- a/test/siphash_internal_test.c
+++ b/test/siphash_internal_test.c
@@ -15,7 +15,18 @@
 #include <openssl/bio.h>
 #include "testutil.h"
 #include "test_main_custom.h"
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "internal/siphash.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
+
 #include "../crypto/siphash/siphash_local.h"
 #include "e_os.h"
 

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -9,8 +9,18 @@
 
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "../ssl/ssl_locl.h"
 #include "../ssl/record/record_locl.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
 
 #include "testutil.h"
 #include "test_main.h"

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -9,7 +9,17 @@
 
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "../ssl/ssl_locl.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
 
 #include "testutil.h"
 #include "test_main.h"

--- a/test/uitest.c
+++ b/test/uitest.c
@@ -13,22 +13,13 @@
 #include <openssl/err.h>
 
 /*
- * We know that on VMS, the [.apps] object files are compiled with uppercased
- * symbols.  We must therefore follow suit, or there will be linking errors.
- * Additionally, the VMS build does stdio via a socketpair.
+ * The VMS build does stdio via a socketpair.
  */
 #ifdef __VMS
-# pragma names save
-# pragma names uppercase, truncated
-
 # include "../apps/vms_term_sock.h"
 #endif
 
 #include "../apps/apps.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
 
 #include "testutil.h"
 #include "test_main_custom.h"

--- a/test/wpackettest.c
+++ b/test/wpackettest.c
@@ -9,7 +9,18 @@
 
 #include <string.h>
 #include <openssl/buffer.h>
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "../ssl/packet_locl.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
+
 #include "testutil.h"
 #include "test_main_custom.h"
 

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -24,8 +24,17 @@
  *
  ***/
 
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "../crypto/x509v3/ext_dat.h"
 #include "../crypto/x509v3/standard_exts.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
 
 static int test_standard_exts()
 {


### PR DESCRIPTION
When building object files for libraries, information whether the
library would be installed or not wasn't passed down to the object
file building rules.

Also, make it so settings like |no_inst_lib_cflags| can be the empty
string.
