### PR TITLE
Change 64-bit time type for windows

### DIFF
--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -37,7 +37,7 @@ static int idx;
  * coverage.
  */
 #if defined(_WIN32) && defined(_TIME64_T_DEFINED)
-time64_t _time64(time64_t *t) TIME_IMPL(t)
+__time64_t _time64(__time64_t *t) TIME_IMPL(t)
 #endif
 #if !defined(_WIN32) || !defined(_MSC_VER)
 time_t time(time_t *t) TIME_IMPL(t)

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -484,7 +484,7 @@ static int idx;
  * coverage.
  */
 #if defined(_WIN32) && defined(_TIME64_T_DEFINED)
-time64_t _time64(time64_t *t) TIME_IMPL(t)
+__time64_t _time64(__time64_t *t) TIME_IMPL(t)
 #endif
 #if !defined(_WIN32) || !defined(_MSC_VER)
 time_t time(time_t *t) TIME_IMPL(t)


### PR DESCRIPTION
Changed the type from time64_t to __time64_t to stop a compile failure on Windows with Visual Studio 2010