### PR TITLE
Nameopt fixes

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -966,6 +966,18 @@ int load_crls(const char *file, STACK_OF(X509_CRL) **crls, int format,
 #define X509_FLAG_CA (X509_FLAG_NO_ISSUER | X509_FLAG_NO_PUBKEY | \
                          X509_FLAG_NO_HEADER | X509_FLAG_NO_VERSION)
 
+static unsigned long nmflag = XN_FLAG_ONELINE;
+
+int set_nameopt(const char *arg)
+{
+  return set_name_ex(&nmflag, arg);
+}
+
+unsigned long get_nameopt()
+{
+  return nmflag;
+}
+
 int set_cert_ex(unsigned long *flags, const char *arg)
 {
     static const NAME_EX_TBL cert_tbl[] = {

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -151,18 +151,10 @@ int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path)
 
 int dump_cert_text(BIO *out, X509 *x)
 {
-    char *p;
-
-    p = X509_NAME_oneline(X509_get_subject_name(x), NULL, 0);
-    BIO_puts(out, "subject=");
-    BIO_puts(out, p);
-    OPENSSL_free(p);
-
-    p = X509_NAME_oneline(X509_get_issuer_name(x), NULL, 0);
-    BIO_puts(out, "\nissuer=");
-    BIO_puts(out, p);
-    BIO_puts(out, "\n");
-    OPENSSL_free(p);
+    print_name(out, "subject=", X509_get_subject_name(x), get_nameopt());
+		BIO_puts(out, "\n");
+    print_name(out, "issuer=", X509_get_issuer_name(x), get_nameopt());
+		BIO_puts(out, "\n");
 
     return 0;
 }

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -400,6 +400,8 @@ void print_name(BIO *out, const char *title, X509_NAME *nm,
 void print_bignum_var(BIO *, const BIGNUM *, const char*,
                       int, unsigned char *);
 void print_array(BIO *, const char *, int, const unsigned char *);
+int set_nameopt(const char *arg);
+unsigned long get_nameopt();
 int set_cert_ex(unsigned long *flags, const char *arg);
 int set_name_ex(unsigned long *flags, const char *arg);
 int set_ext_copy(int *copy_type, const char *arg);

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -258,7 +258,7 @@ int ca_main(int argc, char **argv)
     int ret = 1, email_dn = 1, req = 0, verbose = 0, gencrl = 0, dorevoke = 0;
     int i, j, selfsign = 0;
     long crldays = 0, crlhours = 0, crlsec = 0, days = 0;
-    unsigned long chtype = MBSTRING_ASC, nameopt = 0, certopt = 0;
+    unsigned long chtype = MBSTRING_ASC, certopt = 0;
     X509 *x509 = NULL, *x509p = NULL, *x = NULL;
     REVINFO_TYPE rev_type = REV_NONE;
     X509_REVOKED *r = NULL;
@@ -569,14 +569,11 @@ end_of_options:
     f = NCONF_get_string(conf, section, ENV_NAMEOPT);
 
     if (f) {
-        if (!set_name_ex(&nameopt, f)) {
+        if (!set_nameopt(f)) {
             BIO_printf(bio_err, "Invalid name options: \"%s\"\n", f);
             goto end;
         }
         default_op = 0;
-    } else {
-        nameopt = XN_FLAG_ONELINE;
-        ERR_clear_error();
     }
 
     f = NCONF_get_string(conf, section, ENV_CERTOPT);
@@ -866,7 +863,7 @@ end_of_options:
             j = certify_spkac(&x, spkac_file, pkey, x509, dgst, sigopts,
                               attribs, db, serial, subj, chtype, multirdn,
                               email_dn, startdate, enddate, days, extensions,
-                              conf, verbose, certopt, nameopt, default_op,
+                              conf, verbose, certopt, get_nameopt(), default_op,
                               ext_copy);
             if (j < 0)
                 goto end;
@@ -891,7 +888,7 @@ end_of_options:
                              attribs,
                              db, serial, subj, chtype, multirdn, email_dn,
                              startdate, enddate, days, batch, extensions,
-                             conf, verbose, certopt, nameopt, default_op,
+                             conf, verbose, certopt, get_nameopt(), default_op,
                              ext_copy);
             if (j < 0)
                 goto end;
@@ -911,7 +908,7 @@ end_of_options:
             j = certify(&x, infile, pkey, x509p, dgst, sigopts, attribs, db,
                         serial, subj, chtype, multirdn, email_dn, startdate,
                         enddate, days, batch, extensions, conf, verbose,
-                        certopt, nameopt, default_op, ext_copy, selfsign);
+                        certopt, get_nameopt(), default_op, ext_copy, selfsign);
             if (j < 0)
                 goto end;
             if (j > 0) {
@@ -930,7 +927,7 @@ end_of_options:
             j = certify(&x, argv[i], pkey, x509p, dgst, sigopts, attribs, db,
                         serial, subj, chtype, multirdn, email_dn, startdate,
                         enddate, days, batch, extensions, conf, verbose,
-                        certopt, nameopt, default_op, ext_copy, selfsign);
+                        certopt, get_nameopt(), default_op, ext_copy, selfsign);
             if (j < 0)
                 goto end;
             if (j > 0) {

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -69,8 +69,6 @@ int crl_main(int argc, char **argv)
     X509_OBJECT *xobj = NULL;
     EVP_PKEY *pkey;
     const EVP_MD *digest = EVP_sha1();
-    unsigned long nmflag = 0;
-    char nmflag_set = 0;
     char *infile = NULL, *outfile = NULL, *crldiff = NULL, *keyfile = NULL;
     const char *CAfile = NULL, *CApath = NULL, *prog;
     OPTION_CHOICE o;
@@ -169,8 +167,7 @@ int crl_main(int argc, char **argv)
             badsig = 1;
             break;
         case OPT_NAMEOPT:
-            nmflag_set = 1;
-            if (!set_name_ex(&nmflag, opt_arg()))
+            if (!set_nameopt(opt_arg()))
                 goto opthelp;
             break;
         case OPT_MD:
@@ -181,9 +178,6 @@ int crl_main(int argc, char **argv)
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;
-
-    if (!nmflag_set)
-        nmflag = XN_FLAG_ONELINE;
 
     x = load_crl(infile, informat);
     if (x == NULL)
@@ -260,7 +254,7 @@ int crl_main(int argc, char **argv)
         for (i = 1; i <= num; i++) {
             if (issuer == i) {
                 print_name(bio_out, "issuer=", X509_CRL_get_issuer(x),
-                           nmflag);
+                           get_nameopt());
             }
             if (crlnumber == i) {
                 ASN1_INTEGER *crlnum;

--- a/apps/req.c
+++ b/apps/req.c
@@ -163,8 +163,7 @@ int req_main(int argc, char **argv)
     int modulus = 0, multirdn = 0, verify = 0, noout = 0, text = 0;
     int nodes = 0, newhdr = 0, subject = 0, pubkey = 0, precert = 0;
     long newkey = -1;
-    unsigned long chtype = MBSTRING_ASC, nmflag = 0, reqflag = 0;
-    char nmflag_set = 0;
+    unsigned long chtype = MBSTRING_ASC, reqflag = 0;
 
 #ifndef OPENSSL_NO_DES
     cipher = EVP_des_ede3_cbc();
@@ -277,8 +276,7 @@ int req_main(int argc, char **argv)
             chtype = MBSTRING_UTF8;
             break;
         case OPT_NAMEOPT:
-            nmflag_set = 1;
-            if (!set_name_ex(&nmflag, opt_arg()))
+            if (!set_nameopt(opt_arg()))
                 goto opthelp;
             break;
         case OPT_REQOPT:
@@ -332,9 +330,6 @@ int req_main(int argc, char **argv)
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;
-
-    if (!nmflag_set)
-        nmflag = XN_FLAG_ONELINE;
 
     /* TODO: simplify this as pkey is still always NULL here */
     private = newreq && (pkey == NULL) ? 1 : 0;
@@ -695,7 +690,7 @@ int req_main(int argc, char **argv)
         if (verbose) {
             BIO_printf(bio_err, "Modifying Request's Subject\n");
             print_name(bio_err, "old subject=",
-                       X509_REQ_get_subject_name(req), nmflag);
+                       X509_REQ_get_subject_name(req), get_nameopt());
         }
 
         if (build_subject(req, subj, chtype, multirdn) == 0) {
@@ -706,7 +701,7 @@ int req_main(int argc, char **argv)
 
         if (verbose) {
             print_name(bio_err, "new subject=",
-                       X509_REQ_get_subject_name(req), nmflag);
+                       X509_REQ_get_subject_name(req), get_nameopt());
         }
     }
 
@@ -755,18 +750,18 @@ int req_main(int argc, char **argv)
 
     if (text) {
         if (x509)
-            X509_print_ex(out, x509ss, nmflag, reqflag);
+            X509_print_ex(out, x509ss, get_nameopt(), reqflag);
         else
-            X509_REQ_print_ex(out, req, nmflag, reqflag);
+            X509_REQ_print_ex(out, req, get_nameopt(), reqflag);
     }
 
     if (subject) {
         if (x509)
             print_name(out, "subject=", X509_get_subject_name(x509ss),
-                       nmflag);
+                       get_nameopt());
         else
             print_name(out, "subject=", X509_REQ_get_subject_name(req),
-                       nmflag);
+                       get_nameopt());
     }
 
     if (modulus) {

--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -44,8 +44,6 @@ int should_retry(int i);
 long bio_dump_callback(BIO *bio, int cmd, const char *argp,
                        int argi, long argl, long ret);
 
-int set_nameopt(const char *arg);
-
 #ifdef HEADER_SSL_H
 void apps_ssl_info_callback(const SSL *s, int where, int ret);
 void msg_cb(int write_p, int version, int content_type, const void *buf,

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -33,12 +33,6 @@ static unsigned char cookie_secret[COOKIE_SECRET_LENGTH];
 static int cookie_initialized = 0;
 #endif
 static BIO *bio_keylog = NULL;
-static unsigned long nmflag = XN_FLAG_ONELINE;
-
-int set_nameopt(const char *arg)
-{
-  return set_name_ex(&nmflag, arg);
-}
 
 static const char *lookup(int val, const STRINT_PAIR* list, const char* def)
 {
@@ -62,7 +56,7 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
         if (err_cert) {
             X509_NAME_print_ex(bio_err,
                                X509_get_subject_name(err_cert),
-                               0, nmflag);
+                               0, get_nameopt());
             BIO_puts(bio_err, "\n");
         } else
             BIO_puts(bio_err, "<no cert>\n");
@@ -83,7 +77,7 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
         BIO_puts(bio_err, "issuer= ");
         X509_NAME_print_ex(bio_err, X509_get_issuer_name(err_cert),
-                           0, nmflag);
+                           0, get_nameopt());
         BIO_puts(bio_err, "\n");
         break;
     case X509_V_ERR_CERT_NOT_YET_VALID:
@@ -836,7 +830,7 @@ static int set_cert_cb(SSL *ssl, void *arg)
         rv = SSL_check_chain(ssl, exc->cert, exc->key, exc->chain);
         BIO_printf(bio_err, "Checking cert chain %d:\nSubject: ", i);
         X509_NAME_print_ex(bio_err, X509_get_subject_name(exc->cert), 0,
-                           nmflag);
+                           get_nameopt());
         BIO_puts(bio_err, "\n");
         print_chain_flags(ssl, rv);
         if (rv & CERT_PKEY_VALID) {
@@ -1125,7 +1119,7 @@ void print_ssl_summary(SSL *s)
 
         BIO_puts(bio_err, "Peer certificate: ");
         X509_NAME_print_ex(bio_err, X509_get_subject_name(peer),
-                           0, nmflag);
+                           0, get_nameopt());
         BIO_puts(bio_err, "\n");
         if (SSL_get_peer_signature_nid(s, &nid))
             BIO_printf(bio_err, "Hash used: %s\n", OBJ_nid2sn(nid));

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -22,7 +22,6 @@ static int check(X509_STORE *ctx, const char *file,
                  STACK_OF(X509) *uchain, STACK_OF(X509) *tchain,
                  STACK_OF(X509_CRL) *crls, int show_chain);
 static int v_verbose = 0, vflags = 0;
-static unsigned long nmflag = 0;
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -70,7 +69,6 @@ int verify_main(int argc, char **argv)
     const char *prog, *CApath = NULL, *CAfile = NULL;
     int noCApath = 0, noCAfile = 0;
     int vpmtouched = 0, crl_download = 0, show_chain = 0, i = 0, ret = 1;
-    char nmflag_set = 0;
     OPTION_CHOICE o;
 
     if ((vpm = X509_VERIFY_PARAM_new()) == NULL)
@@ -153,8 +151,7 @@ int verify_main(int argc, char **argv)
             show_chain = 1;
             break;
         case OPT_NAMEOPT:
-            nmflag_set = 1;
-            if (!set_name_ex(&nmflag, opt_arg()))
+            if (!set_nameopt(opt_arg()))
                 goto end;
             break;
         case OPT_VERBOSE:
@@ -170,9 +167,6 @@ int verify_main(int argc, char **argv)
                    prog);
         goto end;
     }
-
-    if (!nmflag_set)
-        nmflag = XN_FLAG_ONELINE;
 
     if ((store = setup_verify(CAfile, CApath, noCAfile, noCApath)) == NULL)
         goto end;
@@ -253,7 +247,7 @@ static int check(X509_STORE *ctx, const char *file,
                 printf("depth=%d: ", j);
                 X509_NAME_print_ex_fp(stdout,
                                       X509_get_subject_name(cert),
-                                      0, nmflag);
+                                      0, get_nameopt());
                 if (j < num_untrusted)
                     printf(" (untrusted)");
                 printf("\n");
@@ -282,7 +276,7 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         if (current_cert) {
             X509_NAME_print_ex(bio_err,
                             X509_get_subject_name(current_cert),
-                            0, nmflag);
+                            0, get_nameopt());
             BIO_printf(bio_err, "\n");
         }
         BIO_printf(bio_err, "%serror %d at %d depth lookup: %s\n",

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -172,8 +172,7 @@ int x509_main(int argc, char **argv)
     int text = 0, serial = 0, subject = 0, issuer = 0, startdate = 0;
     int enddate = 0;
     time_t checkoffset = 0;
-    unsigned long nmflag = 0, certflag = 0;
-    char nmflag_set = 0;
+    unsigned long certflag = 0;
     OPTION_CHOICE o;
     ENGINE *e = NULL;
 #ifndef OPENSSL_NO_MD5
@@ -308,8 +307,7 @@ int x509_main(int argc, char **argv)
                 goto opthelp;
             break;
         case OPT_NAMEOPT:
-            nmflag_set = 1;
-            if (!set_name_ex(&nmflag, opt_arg()))
+            if (!set_nameopt(opt_arg()))
                 goto opthelp;
             break;
         case OPT_ENGINE:
@@ -447,9 +445,6 @@ int x509_main(int argc, char **argv)
         goto opthelp;
     }
 
-    if (!nmflag_set)
-        nmflag = XN_FLAG_ONELINE;
-
     out = bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
@@ -539,7 +534,7 @@ int x509_main(int argc, char **argv)
             BIO_printf(bio_err, "Signature ok\n");
 
         print_name(bio_err, "subject=", X509_REQ_get_subject_name(req),
-                   nmflag);
+                   get_nameopt());
 
         if ((x = X509_new()) == NULL)
             goto end;
@@ -618,10 +613,10 @@ int x509_main(int argc, char **argv)
     if (num) {
         for (i = 1; i <= num; i++) {
             if (issuer == i) {
-                print_name(out, "issuer=", X509_get_issuer_name(x), nmflag);
+                print_name(out, "issuer=", X509_get_issuer_name(x), get_nameopt());
             } else if (subject == i) {
                 print_name(out, "subject=",
-                           X509_get_subject_name(x), nmflag);
+                           X509_get_subject_name(x), get_nameopt());
             } else if (serial == i) {
                 BIO_printf(out, "serial=");
                 i2a_ASN1_INTEGER(out, X509_get_serialNumber(x));
@@ -747,7 +742,7 @@ int x509_main(int argc, char **argv)
                 print_array(out, "the_certificate", len, (unsigned char *)m);
                 OPENSSL_free(m);
             } else if (text == i) {
-                X509_print_ex(out, x, nmflag, certflag);
+                X509_print_ex(out, x, get_nameopt(), certflag);
             } else if (startdate == i) {
                 BIO_puts(out, "notBefore=");
                 ASN1_TIME_print(out, X509_get0_notBefore(x));


### PR DESCRIPTION
This pull request unifies -nameopt flag processing in command-line apps and reduces usage of the X509_NAME_online function.
