### PR TITLE
BUF_MEM grow should do memset only from old max in case of expansion

### DIFF
--- a/crypto/buffer/buffer.c
+++ b/crypto/buffer/buffer.c
@@ -100,11 +100,11 @@ int BUF_MEM_grow(BUF_MEM *str, size_t len)
     size_t n;
 
     if (str->length >= len) {
+        memset(&str->data[len], 0, str->length - len);
         str->length = len;
         return (len);
     }
     if (str->max >= len) {
-        memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
         return (len);
     }
@@ -122,9 +122,13 @@ int BUF_MEM_grow(BUF_MEM *str, size_t len)
         BUFerr(BUF_F_BUF_MEM_GROW, ERR_R_MALLOC_FAILURE);
         len = 0;
     } else {
+        if (str->data == NULL) {
+            memset(ret, 0, n);
+        } else {
+            memset(&ret[str->max], 0, n - str->max);
+        }
         str->data = ret;
         str->max = n;
-        memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
     }
     return (len);
@@ -141,7 +145,6 @@ int BUF_MEM_grow_clean(BUF_MEM *str, size_t len)
         return (len);
     }
     if (str->max >= len) {
-        memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
         return (len);
     }
@@ -159,9 +162,13 @@ int BUF_MEM_grow_clean(BUF_MEM *str, size_t len)
         BUFerr(BUF_F_BUF_MEM_GROW_CLEAN, ERR_R_MALLOC_FAILURE);
         len = 0;
     } else {
+        if (str->data == NULL) {
+            memset(ret, 0, n);
+        } else {
+            memset(&ret[str->max], 0, n - str->max);
+        }
         str->data = ret;
         str->max = n;
-        memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
     }
     return (len);

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -670,7 +670,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, int len)
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if (len < tot) {
+    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wnum)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return (-1);
     }

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -670,7 +670,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, int len)
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wnum)))) {
+    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wpend_tot)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return (-1);
     }

--- a/ssl/s3_pkt.c
+++ b/ssl/s3_pkt.c
@@ -670,7 +670,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, int len)
      * promptly send beyond the end of the users buffer ... so we trap and
      * report the error in a way the user will notice
      */
-    if ((len < tot) || ((tot != 0) && (len < (tot + s->s3->wpend_tot)))) {
+    if ((len < tot) || ((wb->left != 0) && (len < (tot + s->s3->wpend_tot)))) {
         SSLerr(SSL_F_SSL3_WRITE_BYTES, SSL_R_BAD_LENGTH);
         return (-1);
     }


### PR DESCRIPTION
In SSL handshake, messages are kept in `BUF_MEM` structure variable `s->init_buf`. This is initially allocated for 16k and later shrunk or expanded. While receiving peer's message in `ssl3_get_message`, its shrunk(only length is reduced, not shrunk buf) to the received msg size. While sending message its expanded in some cases.

For example consider `ssl3_send_certificate_request`, here we are copying few data and then grow is called. If we written more data than `buf->length` before calling grow, then grow will reset it. **As it does memset from old length to new length.** 

So current BUF_MEM grow may cause some data lose. So below things are done in this PR.
1) After malloc memset `ret` for `n` bytes.
2) After realloc memset `ret` from max to `n`.
3) After shrink (`(str->length >= len)` case) memset from `len` to `str->length`
4) After expand (`(str->max >= len)` case) do not memset