### PR TITLE
VMS: Copy DECC inclusion epi- and prologues to internals

### DIFF
--- a/crypto/include/internal/__DECC_INCLUDE_EPILOGUE.H
+++ b/crypto/include/internal/__DECC_INCLUDE_EPILOGUE.H
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file is only used by HP C on VMS, and is included automatically
+ * after each header file from this directory
+ */
+
+/* restore state.  Must correspond to the save in __decc_include_prologue.h */
+#pragma names restore

--- a/crypto/include/internal/__DECC_INCLUDE_PROLOGUE.H
+++ b/crypto/include/internal/__DECC_INCLUDE_PROLOGUE.H
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file is only used by HP C on VMS, and is included automatically
+ * after each header file from this directory
+ */
+
+/* save state */
+#pragma names save
+/* have the compiler shorten symbols larger than 31 chars to 23 chars
+ * followed by a 8 hex char CRC
+ */
+#pragma names as_is,shortened

--- a/include/internal/__DECC_INCLUDE_EPILOGUE.H
+++ b/include/internal/__DECC_INCLUDE_EPILOGUE.H
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file is only used by HP C on VMS, and is included automatically
+ * after each header file from this directory
+ */
+
+/* restore state.  Must correspond to the save in __decc_include_prologue.h */
+#pragma names restore

--- a/include/internal/__DECC_INCLUDE_PROLOGUE.H
+++ b/include/internal/__DECC_INCLUDE_PROLOGUE.H
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file is only used by HP C on VMS, and is included automatically
+ * after each header file from this directory
+ */
+
+/* save state */
+#pragma names save
+/* have the compiler shorten symbols larger than 31 chars to 23 chars
+ * followed by a 8 hex char CRC
+ */
+#pragma names as_is,shortened

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -59,17 +59,7 @@ static int test_tbl_standard()
  *
  ***/
 
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "internal/asn1_int.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "../crypto/asn1/standard_methods.h"
 
 static int test_standard_methods()

--- a/test/chacha_internal_test.c
+++ b/test/chacha_internal_test.c
@@ -16,17 +16,7 @@
 #include <openssl/opensslconf.h>
 #include "test_main.h"
 #include "testutil.h"
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "internal/chacha.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
 
 const static unsigned int key[] = {
     0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,

--- a/test/cipher_overhead_test.c
+++ b/test/cipher_overhead_test.c
@@ -11,7 +11,16 @@
 #include "testutil.h"
 #include "test_main.h"
 
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "../ssl/ssl_locl.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
 
 static int cipher_overhead(void)
 {

--- a/test/poly1305_internal_test.c
+++ b/test/poly1305_internal_test.c
@@ -14,18 +14,7 @@
 
 #include "testutil.h"
 #include "test_main_custom.h"
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "internal/poly1305.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "../crypto/poly1305/poly1305_local.h"
 #include "e_os.h"
 

--- a/test/siphash_internal_test.c
+++ b/test/siphash_internal_test.c
@@ -15,18 +15,7 @@
 #include <openssl/bio.h>
 #include "testutil.h"
 #include "test_main_custom.h"
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "internal/siphash.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "../crypto/siphash/siphash_local.h"
 #include "e_os.h"
 


### PR DESCRIPTION
Because many of our test programs use internal headers, we need to make
sure they know how, exactly, to mangle the symbols.  So far, we've done
so by specifying it in the affected test programs, but as things change,
that will develop into a goose chase.  Better then to declare once and
for all how symbols belonging in our libraries are meant to be treated,
internally as well as publically.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
