### PR TITLE
Fix test/recipes/95-test_external_krb5.t

### DIFF
--- a/test/recipes/95-test_external_krb5.t
+++ b/test/recipes/95-test_external_krb5.t
@@ -16,7 +16,7 @@ setup("test_external_krb5");
 plan tests => 1;
 
 SKIP: {
-    skip "No external tests in this configuration"
+    skip "No external tests in this configuration", 1
         if disabled("external-tests");
     skip "krb5 not available", 1
         if ! -f srctop_file("krb5", "README");


### PR DESCRIPTION
"skip() needs to know $how_many tests are in the block"

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
