### PR TITLE
if log fails, avoid pms getting double free

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2858,8 +2858,10 @@ static int tls_construct_cke_rsa(SSL *s, WPACKET *pkt, int *al)
     s->s3->tmp.pmslen = pmslen;
 
     /* Log the premaster secret, if logging is enabled. */
-    if (!ssl_log_rsa_client_key_exchange(s, encdata, enclen, pms, pmslen))
+    if (!ssl_log_rsa_client_key_exchange(s, encdata, enclen, pms, pmslen)) {
+        s->s3->tmp.pms = NULL;
         goto err;
+    }
 
     return 1;
  err:

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2854,14 +2854,12 @@ static int tls_construct_cke_rsa(SSL *s, WPACKET *pkt, int *al)
         goto err;
     }
 
+    /* Log the premaster secret, if logging is enabled. */
+    if (!ssl_log_rsa_client_key_exchange(s, encdata, enclen, pms, pmslen))
+        goto err;
+
     s->s3->tmp.pms = pms;
     s->s3->tmp.pmslen = pmslen;
-
-    /* Log the premaster secret, if logging is enabled. */
-    if (!ssl_log_rsa_client_key_exchange(s, encdata, enclen, pms, pmslen)) {
-        s->s3->tmp.pms = NULL;
-        goto err;
-    }
 
     return 1;
  err:


### PR DESCRIPTION
If logging premaster secret fails, this lead to double free of s->s3->tmp.pms
assigning pms after log is successful to handle this.

Applicable to master and 1.1.0