### PR TITLE
Fix typo in OPENSSL_LH_new compat API

### DIFF
--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -95,7 +95,7 @@ void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
 #  define _LHASH OPENSSL_LHASH
 #  define LHASH_NODE OPENSSL_LH_NODE
 #  define lh_error OPENSSL_LH_error
-#  define lh_new OPENSSL_lh_new
+#  define lh_new OPENSSL_LH_new
 #  define lh_free OPENSSL_LH_free
 #  define lh_insert OPENSSL_LH_insert
 #  define lh_delete OPENSSL_LH_delete


### PR DESCRIPTION
In the compat API for lh_* functions for pre-1.1.0, there was a typo in the lh_new definition. It should be OPENSSL_LH_new instead of OPENSSL_lh_new

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->