### PR TITLE
test: don't make it more complicated than necessary.

### DIFF
--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -11,12 +11,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <openssl/e_os2.h>
-#ifdef OPENSSL_SYS_WINDOWS
-# include <winsock.h>
-#else
-# include OPENSSL_UNISTD
-#endif
 #include <openssl/bio.h>
 #include "internal/numbers.h"
 #include "testutil.h"
@@ -268,16 +262,21 @@ void test_close_streams(void)
 
 int test_puts_stdout(const char *str)
 {
-    return write(1, str, strlen(str));
+    return fputs(str, stdout);
 }
 
 int test_puts_stderr(const char *str)
 {
-    return write(2, str, strlen(str));
+    return fputs(str, stderr);
 }
 
 static char vprint_buf[10240];
 
+/*
+ * This works out as long as caller doesn't use any "fancy" formats.
+ * But we are caller's caller, and test_str_eq is the only one called,
+ * and it uses only "%s", which is not "fancy"...
+ */
 int test_vprintf_stdout(const char *fmt, va_list ap)
 {
     size_t len = vsnprintf(vprint_buf, sizeof(vprint_buf), fmt, ap);
@@ -298,10 +297,10 @@ int test_vprintf_stderr(const char *fmt, va_list ap)
 
 int test_flush_stdout(void)
 {
-    return 0;
+    return fflush(stdout);
 }
 
 int test_flush_stderr(void)
 {
-    return 0;
+    return fflush(stderr);
 }

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -15,29 +15,10 @@
 BIO *bio_out = NULL;
 BIO *bio_err = NULL;
 
-#ifdef OPENSSL_USE_APPLINK
-/*
- * Using BIO_new_fd() obligates the use of applinks on platforms where it's
- * relevant.  Because it becomes a module of the libtestutil library and would
- * be disregarded if not actively referred to, we have this dummy that does
- * exactly this.  For any module that uses the rest of the routines here,
- * OPENSSL_Applink should tag along for sure.
- */
-void Applink_dummy(void);
-void Applink_dummy(void)
-{
-    OPENSSL_EXTERN void OPENSSL_Applink(void);
-
-    OPENSSL_Applink();
-}
-/* Generate an error for anyone who tries to actually use this dummy */
-# define Applink_dummy "DON'T USE THIS"
-#endif
-
 void test_open_streams(void)
 {
-    bio_out = BIO_new_fd(1, 0);
-    bio_err = BIO_new_fd(2, 0);
+    bio_out = BIO_new_fp(stdout, BIO_NOCLOSE | BIO_FP_TEXT);
+    bio_err = BIO_new_fp(stderr, BIO_NOCLOSE | BIO_FP_TEXT);
 
     OPENSSL_assert(bio_out != NULL);
     OPENSSL_assert(bio_err != NULL);


### PR DESCRIPTION
Original rationale behind using write in testutil was to accommodate
no-stdio builds. But is there evidence that no-stdio users would have
write or pre-defined meaning for file descriptors 1 and 2? Correct
answer is to provide way for no-stdio users who want to exercise
tests to plug in own BIO, not to make assumption that they have write.
And since we don't have to make such assumption, we can as well go
for simplest that works with standard library as specified by C
language standard.
