### PR TITLE
Reorder tls12_sigalgs for TLS 1.3 compliance

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -678,17 +678,17 @@ static const uint16_t tls12_sigalgs[] = {
     TLSEXT_SIGALG_rsa_pkcs1_sha256,
     TLSEXT_SIGALG_rsa_pkcs1_sha384,
     TLSEXT_SIGALG_rsa_pkcs1_sha512,
-
+#ifndef OPENSSL_NO_DSA
+    TLSEXT_SIGALG_dsa_sha256,
+    TLSEXT_SIGALG_dsa_sha384,
+    TLSEXT_SIGALG_dsa_sha512,
+#endif
 #ifndef OPENSSL_NO_EC
     TLSEXT_SIGALG_ecdsa_sha1,
 #endif
     TLSEXT_SIGALG_rsa_pkcs1_sha1,
 #ifndef OPENSSL_NO_DSA
     TLSEXT_SIGALG_dsa_sha1,
-
-    TLSEXT_SIGALG_dsa_sha256,
-    TLSEXT_SIGALG_dsa_sha384,
-    TLSEXT_SIGALG_dsa_sha512
 #endif
 };
 


### PR DESCRIPTION
In draft-ietf-tls-tls13-19 section 4.2.3 we find that:

    rsa_pkcs1_sha1, dsa_sha1, and ecdsa_sha1 SHOULD NOT be offered.
    Clients offering these values for backwards compatibility MUST list
    them as the lowest priority (listed after all other algorithms in
    SignatureSchemeList).  TLS 1.3 servers MUST NOT offer a SHA-1 signed
    certificate unless no valid certificate chain can be produced without
    it (see Section 4.4.2.2).

However, we are currently sending the SHA2-based DSA signature schemes
after the SHA1-based ones (for all signature types), which is
in contradiction with the specification.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

