### PR TITLE
openssl enc: Don't unbuffer stdin

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -291,7 +291,6 @@ int enc_main(int argc, char **argv)
     buff = app_malloc(EVP_ENCODE_LENGTH(bsize), "evp buffer");
 
     if (infile == NULL) {
-        unbuffer(stdin);
         in = dup_bio_in(informat);
     } else
         in = bio_open_default(infile, 'r', informat);


### PR DESCRIPTION
 - unbuffer causes single-byte reads from stdin and poor performance

Fixes #3281
CLA: trivial