### PR TITLE
Add include path '..' for libtestutil

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -12,7 +12,7 @@ IF[{- !$disabled{tests} -}]
   SOURCE[libtestutil.a]=testutil/basic_output.c testutil/driver.c \
           testutil/tests.c testutil/test_main.c testutil/main.c \
           {- rebase_files("../apps", $target{apps_aux_src}) -}
-  INCLUDE[libtestutil.a]=../include
+  INCLUDE[libtestutil.a]=.. ../include
   DEPEND[libtestutil.a]=../libcrypto
 
   # Special hack for descrip.mms to include the MAIN object module


### PR DESCRIPTION
Since it uses some of the apps/ stuff and some of them include e_os.h...
