### PR TITLE
Return success in custom_ext_parse_old_cb_wrap if parse_cb is NULL

### DIFF
--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -64,6 +64,9 @@ static int custom_ext_parse_old_cb_wrap(SSL *s, unsigned int ext_type,
     custom_ext_parse_cb_wrap *parse_cb_wrap =
         (custom_ext_parse_cb_wrap *)parse_arg;
 
+    if (parse_cb_wrap->parse_cb == NULL)
+        return 1;
+
     return parse_cb_wrap->parse_cb(s, ext_type, in, inlen, al,
                                    parse_cb_wrap->parse_arg);
 }


### PR DESCRIPTION
This fixes a segfault if a NULL parse_cb is passed to
SSL_CTX_add_{client,server}_custom_ext, which was supported in the
pre-1.1.1 implementation.

This behaviour is consistent with the other custom_ext_*_old_cb_wrap
functions, and with the new SSL_CTX_add_custom_ext function.