### PR TITLE
Remove unnecessary loop in pkey_rsa_decrypt

### DIFF
--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -316,19 +316,14 @@ static int pkey_rsa_decrypt(EVP_PKEY_CTX *ctx,
     RSA_PKEY_CTX *rctx = ctx->data;
 
     if (rctx->pad_mode == RSA_PKCS1_OAEP_PADDING) {
-        int i;
         if (!setup_tbuf(rctx, ctx))
             return -1;
         ret = RSA_private_decrypt(inlen, in, rctx->tbuf,
                                   ctx->pkey->pkey.rsa, RSA_NO_PADDING);
         if (ret <= 0)
             return ret;
-        for (i = 0; i < ret; i++) {
-            if (rctx->tbuf[i])
-                break;
-        }
-        ret = RSA_padding_check_PKCS1_OAEP_mgf1(out, ret, rctx->tbuf + i,
-                                                ret - i, ret,
+        ret = RSA_padding_check_PKCS1_OAEP_mgf1(out, ret, rctx->tbuf,
+                                                ret, ret,
                                                 rctx->oaep_label,
                                                 rctx->oaep_labellen,
                                                 rctx->md, rctx->mgf1md);


### PR DESCRIPTION
It is not necessary to remove leading zeros here because
RSA_padding_check_PKCS1_OAEP_mgf1 appends them again.
As this was not done in constant time, this might have
leaked timing information.

This should work for all active branches.