### PR TITLE
Fix multiple definition of _time64

### DIFF
--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -31,15 +31,11 @@ static int idx;
 #define TIME_IMPL(t) { if (t != NULL) *t = FUZZTIME; return FUZZTIME; }
 
 /*
- * This might not in all cases and still get the current time
- * instead of the fixed time. This will just result in things
- * not being fully reproducible and have a slightly different
- * coverage.
+ * This might not work in all cases and still get the current time instead of
+ * the fixed time. This will just result in things not being fully reproducible
+ * and have a slightly different coverage.
  */
-#if defined(_WIN32) && defined(_TIME64_T_DEFINED)
-__time64_t _time64(__time64_t *t) TIME_IMPL(t)
-#endif
-#if !defined(_WIN32) || !defined(_MSC_VER)
+#if !defined(_WIN32)
 time_t time(time_t *t) TIME_IMPL(t)
 #endif
 


### PR DESCRIPTION
Fix as suggested by Andy Polyakov in #3280

Fixes #3280.

[extended tests]

I can't reproduce this issue locally, so lets see what extended tests report.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
