### PR TITLE
fuzz/{client,server}.c: omit _time64 "overload method".

### DIFF
--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -31,15 +31,13 @@ static int idx;
 #define TIME_IMPL(t) { if (t != NULL) *t = FUZZTIME; return FUZZTIME; }
 
 /*
- * This might not in all cases and still get the current time
- * instead of the fixed time. This will just result in things
- * not being fully reproducible and have a slightly different
- * coverage.
+ * This might not work in all cases (and definitely not on Windows
+ * because of the way linkers are) and callees can still get the
+ * current time instead of the fixed time. This will just result
+ * in things not being fully reproducible and have a slightly
+ * different coverage.
  */
-#if defined(_WIN32) && defined(_TIME64_T_DEFINED)
-__time64_t _time64(__time64_t *t) TIME_IMPL(t)
-#endif
-#if !defined(_WIN32) || !defined(_MSC_VER)
+#if !defined(_WIN32)
 time_t time(time_t *t) TIME_IMPL(t)
 #endif
 

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -478,15 +478,13 @@ static int idx;
 #define TIME_IMPL(t) { if (t != NULL) *t = FUZZTIME; return FUZZTIME; }
 
 /*
- * This might not in all cases and still get the current time
- * instead of the fixed time. This will just result in things
- * not being fully reproducible and have a slightly different
- * coverage.
+ * This might not work in all cases (and definitely not on Windows
+ * because of the way linkers are) and callees can still get the
+ * current time instead of the fixed time. This will just result
+ * in things not being fully reproducible and have a slightly
+ * different coverage.
  */
-#if defined(_WIN32) && defined(_TIME64_T_DEFINED)
-__time64_t _time64(__time64_t *t) TIME_IMPL(t)
-#endif
-#if !defined(_WIN32) || !defined(_MSC_VER)
+#if !defined(_WIN32)
 time_t time(time_t *t) TIME_IMPL(t)
 #endif
 


### PR DESCRIPTION
Approach was opportunistic in Windows context from its inception
and on top of that it was proven to be error-prone at link stage.
Correct answer is to introduce library-specific time function that
we can control in platform-neutral manner.  Meanwhile we just let
be attempts to override time on Windows.
