### PR TITLE
Simplify dataflow in TEST_true/TEST_false to prevent

### DIFF
--- a/test/packettest.c
+++ b/test/packettest.c
@@ -350,7 +350,7 @@ static int test_PACKET_get_length_prefixed_1()
     unsigned char buf1[BUF_LEN];
     const size_t len = 16;
     unsigned int i;
-    PACKET pkt, short_pkt, subpkt = {0};
+    PACKET pkt, short_pkt, subpkt;
 
     buf1[0] = len;
     for (i = 1; i < BUF_LEN; i++)
@@ -374,7 +374,7 @@ static int test_PACKET_get_length_prefixed_2()
     unsigned char buf1[1024];
     const size_t len = 516;  /* 0x0204 */
     unsigned int i;
-    PACKET pkt, short_pkt, subpkt = {0};
+    PACKET pkt, short_pkt, subpkt;
 
     for (i = 1; i <= 1024; i++)
         buf1[i - 1] = (i * 2) & 0xff;
@@ -397,7 +397,7 @@ static int test_PACKET_get_length_prefixed_3()
     unsigned char buf1[1024];
     const size_t len = 516;  /* 0x000204 */
     unsigned int i;
-    PACKET pkt, short_pkt, subpkt = {0};
+    PACKET pkt, short_pkt, subpkt;
 
     for (i = 0; i < 1024; i++)
         buf1[i] = (i * 2) & 0xff;

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -328,8 +328,8 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 # define TEST_mem_eq(a, m, b, n) test_mem_eq(__FILE__, __LINE__, #a, #b, a, m, b, n)
 # define TEST_mem_ne(a, m, b, n) test_mem_ne(__FILE__, __LINE__, #a, #b, a, m, b, n)
 
-# define TEST_true(a)         test_true(__FILE__, __LINE__, #a, (a) != 0)
-# define TEST_false(a)        test_false(__FILE__, __LINE__, #a, (a) != 0)
+# define TEST_true(a)  ((a) == 0 ? test_true(__FILE__, __LINE__, #a, 0), 0 : 1)
+# define TEST_false(a) ((a) != 0 ? test_false(__FILE__, __LINE__, #a, 1), 0 : 1)
 
 /*
  * TEST_error(desc, ...) prints an informative error message in the standard


### PR DESCRIPTION
false positive GCC-7 warnings in clienthellotest.c

without this patch ./config --strict-warnings fails:
```
test/clienthellotest.c: In function 'test_client_hello':
test/clienthellotest.c:60:17: error: 'pkt2.curr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     PACKET pkt, pkt2, pkt3;
                 ^~~~
In file included from test/clienthellotest.c:20:0:
test/../ssl/packet_locl.h:36:20: error: 'pkt2.remaining' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     pkt->remaining -= len;
                    ^~
test/clienthellotest.c:60:17: note: 'pkt2.remaining' was declared here
     PACKET pkt, pkt2, pkt3;
                 ^~~~
In file included from test/clienthellotest.c:20:0:
test/../ssl/packet_locl.h:100:8: error: 'pkt3.remaining' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     if (PACKET_remaining(pkt) != num)
        ^
test/clienthellotest.c:60:23: note: 'pkt3.remaining' was declared here
     PACKET pkt, pkt2, pkt3;
                       ^~~~
In file included from test/clienthellotest.c:20:0:
test/../ssl/packet_locl.h:102:12: error: 'pkt3.curr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return CRYPTO_memcmp(pkt->curr, ptr, num) == 0;
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/clienthellotest.c:60:23: note: 'pkt3.curr' was declared here
     PACKET pkt, pkt2, pkt3;
                       ^~~~
In file included from test/clienthellotest.c:20:0:
test/../ssl/packet_locl.h:36:20: error: 'pkt.remaining' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     pkt->remaining -= len;
                    ^~
test/clienthellotest.c:60:12: note: 'pkt.remaining' was declared here
     PACKET pkt, pkt2, pkt3;
            ^~~
In file included from test/clienthellotest.c:20:0:
test/../ssl/packet_locl.h:35:15: error: 'pkt.curr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     pkt->curr += len;
               ^~
test/clienthellotest.c:60:12: note: 'pkt.curr' was declared here
     PACKET pkt, pkt2, pkt3;
            ^~~
cc1: all warnings being treated as errors
make[1]: *** [test/clienthellotest.o] Error 1
```

This is because test_true is an external function while 
PACKET_get_length_prefixed_1 is an inline function,
and thus gcc knows that the output is only initialized
if the function returns true.
So if TEST_true is an identity function the data flow
is correct, but if you don't know that, test_true could
always return true, and in that case undefined values
could be used, that is what the warnings are all about.