### PR TITLE
Omit DSA sigalgs from TLS 1.3-only ClientHellos

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1447,6 +1447,12 @@ static int tls12_sigalg_allowed(SSL *s, int op, const SIGALG_LOOKUP *lu)
     /* DSA is not allowed in TLS 1.3 */
     if (SSL_IS_TLS13(s) && lu->sig == EVP_PKEY_DSA)
         return 0;
+    /* TODO(OpenSSL1.2) fully axe DSA/etc. in ClientHello per TLS 1.3 spec */
+    if (!s->server && !SSL_IS_DTLS(s) && s->s3->tmp.min_ver >= TLS1_3_VERSION
+        && (lu->sig == EVP_PKEY_DSA || lu->hash_idx == SSL_MD_SHA1_IDX
+            || lu->hash_idx == SSL_MD_MD5_IDX
+            || lu->hash_idx == SSL_MD_SHA224_IDX))
+        return 0;
     /* See if public key algorithm allowed */
     if (tls12_get_pkey_idx(lu->sig) == -1)
         return 0;

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -21,6 +21,7 @@
 #include "testutil.h"
 #include "e_os.h"
 
+#ifndef OPENSSL_NO_DSA
 static int dsa_cb(int p, int n, BN_GENCB *arg);
 
 /*
@@ -134,6 +135,7 @@ static int dsa_cb(int p, int n, BN_GENCB *arg)
     }
     return 1;
 }
+#endif /* OPENSSL_NO_DSA */
 
 void register_tests(void)
 {

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -39,7 +39,9 @@ use constant {
     EMPTY_SIG_ALGS_EXT => 1,
     NO_KNOWN_SIG_ALGS => 2,
     NO_PSS_SIG_ALGS => 3,
-    PSS_ONLY_SIG_ALGS => 4
+    PSS_ONLY_SIG_ALGS => 4,
+    PURE_SIGALGS => 5,
+    COMPAT_SIGALGS => 6
 };
 
 #Note: Throughout this test we override the default ciphersuites where TLSv1.2
@@ -48,7 +50,7 @@ use constant {
 
 #Test 1: Default sig algs should succeed
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 16;
+plan tests => 18;
 ok(TLSProxy::Message->success, "Default sigalgs");
 my $testtype;
 
@@ -197,6 +199,29 @@ SKIP: {
     ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs, ECDSA");
 }
 
+my ($dsa_status, $sha1_status, $sha224_status);
+SKIP: {
+    skip "TLSv1.3 disabled", 2 if disabled("tls1_3") || disabled("dsa");
+    #Test 17: signature_algorithms with 1.3-only ClientHello
+    $testtype = PURE_SIGALGS;
+    $dsa_status = $sha1_status = $sha224_status = 0;
+    $proxy->clear();
+    $proxy->clientflags("-tls1_3");
+    $proxy->filter(\&modify_sigalgs_filter);
+    $proxy->start();
+    ok($dsa_status && $sha1_status && $sha224_status,
+       "DSA/SHA2 sigalg sent for 1.3-only ClientHello");
+
+    #Test 18: signature_algorithms with backwards compatible ClientHello
+    $testtype = COMPAT_SIGALGS;
+    $dsa_status = $sha1_status = $sha224_status = 0;
+    $proxy->clear();
+    $proxy->filter(\&modify_sigalgs_filter);
+    $proxy->start();
+    ok($dsa_status && $sha1_status && $sha224_status,
+       "DSA sigalg not sent for compat ClientHello");
+}
+
 
 
 sub sigalgs_filter
@@ -229,6 +254,63 @@ sub sigalgs_filter
             }
 
             $message->repack();
+        }
+    }
+}
+
+sub modify_sigalgs_filter
+{
+    my $proxy = shift;
+
+    # We're only interested in the initial ClientHello
+    return if ($proxy->flight != 0);
+
+    foreach my $message (@{$proxy->message_list}) {
+        my $ext;
+        my @algs;
+
+        if ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO) {
+            if ($testtype == PURE_SIGALGS) {
+                my $ok = 1;
+                $ext = $message->extension_data->{TLSProxy::Message::EXT_SIG_ALGS};
+                @algs = unpack('S>*', $ext);
+                # unpack will unpack the length as well
+                shift @algs;
+                foreach (@algs) {
+                    if ($_ == TLSProxy::Message::SIG_ALG_DSA_SHA256
+                        || $_ == TLSProxy::Message::SIG_ALG_DSA_SHA384
+                        || $_ == TLSProxy::Message::SIG_ALG_DSA_SHA512
+                        || $_ == TLSProxy::Message::OSSL_SIG_ALG_DSA_SHA224
+                        || $_ == TLSProxy::Message::SIG_ALG_RSA_PKCS1_SHA1
+                        || $_ == TLSProxy::Message::SIG_ALG_DSA_SHA1
+                        || $_ == TLSProxy::Message::SIG_ALG_ECDSA_SHA1) {
+                        $ok = 0;
+                    }
+                }
+                $sha1_status = $dsa_status = $sha224_status = 1 if ($ok);
+            } elsif ($testtype == COMPAT_SIGALGS) {
+                $ext = $message->extension_data->{TLSProxy::Message::EXT_SIG_ALGS};
+                @algs = unpack('S>*', $ext);
+                # unpack will unpack the length as well
+                shift @algs;
+                foreach (@algs) {
+                    if ($_ == TLSProxy::Message::SIG_ALG_DSA_SHA256
+                        || $_ == TLSProxy::Message::SIG_ALG_DSA_SHA384
+                        || $_ == TLSProxy::Message::SIG_ALG_DSA_SHA512) {
+                        $dsa_status = 1;
+                    }
+                    if ($_ == TLSProxy::Message::SIG_ALG_RSA_PKCS1_SHA1
+                        || $_ == TLSProxy::Message::SIG_ALG_DSA_SHA1
+                        || $_ == TLSProxy::Message::SIG_ALG_ECDSA_SHA1) {
+                        $sha1_status = 1;
+                    }
+                    if ($_ == TLSProxy::Message::OSSL_SIG_ALG_RSA_PKCS1_SHA224
+                        || $_ == TLSProxy::Message::OSSL_SIG_ALG_DSA_SHA224
+                        || $_ == TLSProxy::Message::OSSL_SIG_ALG_ECDSA_SHA224) {
+                        $sha224_status = 1;
+                    }
+                }
+            }
         }
     }
 }

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -430,18 +430,6 @@ my @tests_tls_1_3 = (
             "ExpectedResult" => "Success"
         },
     },
-    {
-        name => "TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms",
-        server => {
-            "ClientSignatureAlgorithms" => "ECDSA+SHA1:DSA+SHA256:RSA+SHA256",
-            "VerifyCAFile" => test_pem("root-cert.pem"),
-            "VerifyMode" => "Request"
-        },
-        client => {},
-        test   => {
-            "ExpectedResult" => "ServerFail"
-        },
-    },
 );
 
 push @tests, @tests_tls_1_3 unless disabled("tls1_3");
@@ -468,6 +456,18 @@ my @tests_dsa_tls_1_2 = (
 );
 
 my @tests_dsa_tls_1_3 = (
+    {
+        name => "TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms",
+        server => {
+            "ClientSignatureAlgorithms" => "ECDSA+SHA1:DSA+SHA256:RSA+SHA256",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Request"
+        },
+        client => {},
+        test   => {
+            "ExpectedResult" => "ServerFail"
+        },
+    },
     {
         name => "TLS 1.3 DSA Certificate Test",
         server => {

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -91,6 +91,33 @@ use constant {
     EXT_FORCE_LAST => 0xffff
 };
 
+# SignatureScheme of TLS 1.3, from
+# https://tools.ietf.org/html/draft-ietf-tls-tls13-20#appendix-B.3.1.3
+# TODO(TLS1.3) update link to IANA registry after publication
+# We have to manually grab the SHA224 equivalents from the old registry
+use constant {
+    SIG_ALG_RSA_PKCS1_SHA256 => 0x0401,
+    SIG_ALG_RSA_PKCS1_SHA384 => 0x0501,
+    SIG_ALG_RSA_PKCS1_SHA512 => 0x0601,
+    SIG_ALG_ECDSA_SECP256R1_SHA256 => 0x0403,
+    SIG_ALG_ECDSA_SECP384R1_SHA384 => 0x0503,
+    SIG_ALG_ECDSA_SECP521R1_SHA512 => 0x0603,
+    SIG_ALG_RSA_PSS_SHA256 => 0x0804,
+    SIG_ALG_RSA_PSS_SHA384 => 0x0805,
+    SIG_ALG_RSA_PSS_SHA512 => 0x0806,
+    SIG_ALG_ED25519 => 0x0807,
+    SIG_ALG_ED448 => 0x0808,
+    SIG_ALG_RSA_PKCS1_SHA1 => 0x0201,
+    SIG_ALG_ECDSA_SHA1 => 0x0203,
+    SIG_ALG_DSA_SHA1 => 0x0202,
+    SIG_ALG_DSA_SHA256 => 0x0402,
+    SIG_ALG_DSA_SHA384 => 0x0502,
+    SIG_ALG_DSA_SHA512 => 0x0602,
+    OSSL_SIG_ALG_RSA_PKCS1_SHA224 => 0x0301,
+    OSSL_SIG_ALG_DSA_SHA224 => 0x0302,
+    OSSL_SIG_ALG_ECDSA_SHA224 => 0x0303
+};
+
 use constant {
     CIPHER_DHE_RSA_AES_128_SHA => 0x0033,
     CIPHER_ADH_AES_128_SHA => 0x0034,


### PR DESCRIPTION
The TLS 1.3 spec strongly discourages sending DSA sigalgs in the ClientHello, though we are forced to continue to do so due to our stability guarantees within a release branch (given that master will become 1.1.1, not 1.2.0).  So, take the step that we can and do not send DSA sigalgs when we are only offering TLS 1.3.

Inspired by discussion on #3294 .

(N.B. the perl bits probably need help.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
