### PR TITLE
Fix a pedantic gcc-7 warning.

### DIFF
--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -57,7 +57,7 @@ static int test_client_hello(int currtest)
     BIO *wbio;
     long len;
     unsigned char *data;
-    PACKET pkt, pkt2, pkt3;
+    PACKET pkt = {0}, pkt2 = {0}, pkt3 = {0};
     char *dummytick = "Hello World!";
     unsigned int type = 0;
     int testresult = 0;


### PR DESCRIPTION
This is an alternative patch to fix the warning, more like the work-around in packettest.c
Fortunately this was the only place where this warning bites us, so if you like it better
this way, here you are.