### PR TITLE
testutil: add a wrapper around ERR_print_errors, TEST_openssl_errors()

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -9,9 +9,10 @@
 -}
 IF[{- !$disabled{tests} -}]
   LIBS_NO_INST=libtestutil.a
-  SOURCE[libtestutil.a]=testutil/basic_output.c testutil/driver.c \
-          testutil/tests.c testutil/test_main.c testutil/main.c \
-          {- rebase_files("../apps", $target{apps_aux_src}) -}
+  SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output_helpers.c \
+          testutil/driver.c testutil/tests.c \
+          {- rebase_files("../apps", $target{apps_aux_src}) -} \
+          testutil/test_main.c testutil/main.c 
   INCLUDE[libtestutil.a]=.. ../include
   DEPEND[libtestutil.a]=../libcrypto
 

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -377,5 +377,3 @@ int test_flush_stderr(void);
 
 extern BIO *bio_out;
 extern BIO *bio_err;
-
-int subtest_level(void);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -248,6 +248,7 @@ void test_error_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 void test_info(const char *file, int line, const char *desc, ...)
     PRINTF_FORMAT(3, 4);
 void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
+void test_openssl_errors(void);
 
 /*
  * The following macros provide wrapper calls to the test functions with
@@ -342,6 +343,7 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 #  define TEST_error(...)    test_error(__FILE__, __LINE__, __VA_ARGS__)
 #  define TEST_info(...)     test_info(__FILE__, __LINE__, __VA_ARGS__)
 # endif
+# define TEST_openssl_errors test_openssl_errors
 
 /*
  * For "impossible" conditions such as malloc failures or bugs in test code,
@@ -351,7 +353,7 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 # define TEST_check(condition)                  \
     do {                                        \
         if (!(condition)) {                     \
-            ERR_print_errors_fp(stderr);        \
+            TEST_openssl_errors();              \
             OPENSSL_assert(!#condition);        \
         }                                       \
     } while (0)

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -8,6 +8,7 @@
  */
 
 #include "../testutil.h"
+#include "tu_local.h"
 
 #include <string.h>
 #include <assert.h>

--- a/test/testutil/output_helpers.c
+++ b/test/testutil/output_helpers.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../testutil.h"
+#include "tu_local.h"
+
+int test_printf_stdout(const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = test_vprintf_stdout(fmt, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int test_printf_stderr(const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = test_vprintf_stderr(fmt, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int openssl_error_cb(const char *str, size_t len, void *u)
+{
+    return test_printf_stderr("%*s# %s", subtest_level(), "", str);
+}

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -46,32 +46,20 @@ static void test_fail_message(const char *prefix, const char *file, int line,
             PRINTF_FORMAT(5, 6);
 int subtest_level(void);
 
-static int helper_printf_stderr(const char *fmt, ...)
-{
-    va_list ap;
-    int ret;
-
-    va_start(ap, fmt);
-    ret = test_vprintf_stderr(fmt, ap);
-    va_end(ap);
-
-    return ret;
-}
-
 static void test_fail_message_va(const char *prefix, const char *file, int line,
                                  const char *type, const char *fmt, va_list ap)
 {
-    helper_printf_stderr("%*s# ", subtest_level(), "");
+    test_printf_stderr("%*s# ", subtest_level(), "");
     test_puts_stderr(prefix != NULL ? prefix : "ERROR");
     test_puts_stderr(":");
     if (type)
-        helper_printf_stderr(" (%s)", type);
+        test_printf_stderr(" (%s)", type);
     if (fmt != NULL) {
         test_puts_stderr(" ");
         test_vprintf_stderr(fmt, ap);
     }
     if (file != NULL) {
-        helper_printf_stderr(" @ %s:%d", file, line);
+        test_printf_stderr(" @ %s:%d", file, line);
     }
     test_puts_stderr("\n");
     test_flush_stderr();
@@ -121,11 +109,6 @@ void test_error(const char *file, int line, const char *desc, ...)
     va_start(ap, desc);
     test_fail_message_va(NULL, file, line, NULL, desc, ap);
     va_end(ap);
-}
-
-static int openssl_error_cb(const char *str, size_t len, void *u)
-{
-    return helper_printf_stderr("%*s# %s", subtest_level(), "", str);
 }
 
 void test_openssl_errors(void)

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -45,13 +45,16 @@ static void test_fail_message(const char *prefix, const char *file, int line,
             PRINTF_FORMAT(5, 6);
 int subtest_level(void);
 
-static void helper_printf_stderr(const char *fmt, ...)
+static int helper_printf_stderr(const char *fmt, ...)
 {
     va_list ap;
+    int ret;
 
     va_start(ap, fmt);
-    test_vprintf_stderr(fmt, ap);
+    ret = test_vprintf_stderr(fmt, ap);
     va_end(ap);
+
+    return ret;
 }
 
 static void test_fail_message_va(const char *prefix, const char *file, int line,
@@ -117,6 +120,16 @@ void test_error(const char *file, int line, const char *desc, ...)
     va_start(ap, desc);
     test_fail_message_va(NULL, file, line, NULL, desc, ap);
     va_end(ap);
+}
+
+static int openssl_error_cb(const char *str, size_t len, void *u)
+{
+    return helper_printf_stderr("%*s# %s", subtest_level(), "", str);
+}
+
+void test_openssl_errors(void)
+{
+    ERR_print_errors_cb(openssl_error_cb, NULL);
 }
 
 /*

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -8,6 +8,7 @@
  */
 
 #include "../testutil.h"
+#include "tu_local.h"
 
 #include <string.h>
 #include "../../e_os.h"

--- a/test/testutil/tu_local.h
+++ b/test/testutil/tu_local.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+int subtest_level(void);

--- a/test/testutil/tu_local.h
+++ b/test/testutil/tu_local.h
@@ -8,3 +8,6 @@
  */
 
 int subtest_level(void);
+int test_printf_stdout(const char *fmt, ...);
+int test_printf_stderr(const char *fmt, ...);
+int openssl_error_cb(const char *str, size_t len, void *u);


### PR DESCRIPTION
This gives a nicely TAP formatted display of the OpenSSL error stack.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
