### PR TITLE
WIP: add callback for TLS cipher suite selection

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1949,6 +1949,18 @@ void SSL_set_not_resumable_session_callback(SSL *ssl,
                                             int (*cb) (SSL *ssl,
                                                        int
                                                        is_forward_secure));
+
+/* Cipher selection callback */
+
+typedef int (*SSL_choose_cipher_cb_func) (SSL *ssl, STACK_OF(SSL_CIPHER) *client,
+                                          const SSL_CIPHER **selected);
+
+void SSL_CTX_set_choose_cipher_callback(SSL_CTX *ctx, SSL_choose_cipher_cb_func cb);
+SSL_choose_cipher_cb_func SSL_CTX_get_choose_cipher_callback(SSL_CTX *ctx);
+
+void SSL_set_choose_cipher_callback(SSL *ssl, SSL_choose_cipher_cb_func cb);
+SSL_choose_cipher_cb_func SSL_get_choose_cipher_callback(SSL *ssl);
+
 # if OPENSSL_API_COMPAT < 0x10100000L
 #  define SSL_cache_hit(s) SSL_session_reused(s)
 # endif

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3672,6 +3672,10 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
     int i, ii, ok;
     unsigned long alg_k = 0, alg_a = 0, mask_k, mask_a;
 
+    /* Let the consumer decide if they like */
+    if (s->choose_cipher_cb && s->choose_cipher_cb(s, clnt, &ret))
+        return ret;
+
     /* Let's see which ciphers we can support */
 
     /*

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -576,6 +576,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     memcpy(&s->sid_ctx, &ctx->sid_ctx, sizeof(s->sid_ctx));
     s->verify_callback = ctx->default_verify_callback;
     s->generate_session_id = ctx->generate_session_id;
+    s->choose_cipher_cb = ctx->choose_cipher_cb;
 
     s->param = X509_VERIFY_PARAM_new();
     if (s->param == NULL)
@@ -4815,4 +4816,24 @@ int SSL_set_max_early_data(SSL *s, uint32_t max_early_data)
 uint32_t SSL_get_max_early_data(const SSL *s)
 {
     return s->max_early_data;
+}
+
+void SSL_CTX_set_choose_cipher_callback(SSL_CTX *ctx, SSL_choose_cipher_cb_func cb)
+{
+    ctx->choose_cipher_cb = cb;
+}
+
+SSL_choose_cipher_cb_func SSL_CTX_get_choose_cipher_callback(SSL_CTX *ctx)
+{
+    return ctx->choose_cipher_cb;
+}
+
+void SSL_set_choose_cipher_callback(SSL *ssl, SSL_choose_cipher_cb_func cb)
+{
+    ssl->choose_cipher_cb = cb;
+}
+
+SSL_choose_cipher_cb_func SSL_get_choose_cipher_callback(SSL *ssl)
+{
+    return ssl->choose_cipher_cb;
 }

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -973,6 +973,9 @@ struct ssl_ctx_st {
 
     /* The maximum number of bytes that can be sent as early data */
     uint32_t max_early_data;
+
+    /* Callback for selecting a cipher, given a client's preference list */
+    SSL_choose_cipher_cb_func choose_cipher_cb;
 };
 
 struct ssl_st {
@@ -1290,6 +1293,9 @@ struct ssl_st {
     uint32_t early_data_count;
 
     CRYPTO_RWLOCK *lock;
+
+    /* Callback for selecting a cipher, given a client's preference list */
+    SSL_choose_cipher_cb_func choose_cipher_cb;
 };
 
 /*

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -441,3 +441,7 @@ SSL_CTX_add1_CA_list                    441	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get0_CA_list                    442	1_1_1	EXIST::FUNCTION:
 SSL_CTX_add_custom_ext                  443	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_is_resumable                444	1_1_1	EXIST::FUNCTION:
+SSL_set_choose_cipher_callback          445	1_1_1	EXIST::FUNCTION:
+SSL_CTX_get_choose_cipher_callback      446	1_1_1	EXIST::FUNCTION:
+SSL_get_choose_cipher_callback          447	1_1_1	EXIST::FUNCTION:
+SSL_CTX_set_choose_cipher_callback      448	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This can be used to implement more complex behaviors, such as prioritizing
ChaCha only when the client prefers it (see #541).

TBD:
- How should this work for TLS 1.3?
- Documentation.
- Tests.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
