### PR TITLE
Add Version/Ciphersuite sanity checks (draft18 version)

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2169,8 +2169,7 @@ __owur int ssl_check_version_downgrade(SSL *s);
 __owur int ssl_set_version_bound(int method_version, int version, int *bound);
 __owur int ssl_choose_server_version(SSL *s, CLIENTHELLO_MSG *hello);
 __owur int ssl_choose_client_version(SSL *s, int version);
-int ssl_get_client_min_max_version(const SSL *s, int *min_version,
-                                   int *max_version);
+int ssl_get_min_max_version(const SSL *s, int *min_version, int *max_version);
 
 __owur long tls1_default_timeout(void);
 __owur int dtls1_do_write(SSL *s, int type);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -639,7 +639,7 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
     }
 
     if ((context & EXT_CLIENT_HELLO) != 0) {
-        reason = ssl_get_client_min_max_version(s, &min_version, &max_version);
+        reason = ssl_get_min_max_version(s, &min_version, &max_version);
         if (reason != 0) {
             SSLerr(SSL_F_TLS_CONSTRUCT_EXTENSIONS, reason);
             goto err;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -464,7 +464,7 @@ int tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
         return 0;
     }
 
-    reason = ssl_get_client_min_max_version(s, &min_version, &max_version);
+    reason = ssl_get_min_max_version(s, &min_version, &max_version);
     if (reason != 0) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_VERSIONS, reason);
         return 0;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3470,7 +3470,7 @@ int ssl_do_client_cert_cb(SSL *s, X509 **px509, EVP_PKEY **ppkey)
 int ssl_cipher_list_to_bytes(SSL *s, STACK_OF(SSL_CIPHER) *sk, WPACKET *pkt)
 {
     int i;
-    size_t totlen = 0, len, maxlen;
+    size_t totlen = 0, len, maxlen, maxverok = 0;
     int empty_reneg_info_scsv = !s->renegotiate;
     /* Set disabled masks for this session */
     ssl_set_client_disabled(s);
@@ -3512,11 +3512,29 @@ int ssl_cipher_list_to_bytes(SSL *s, STACK_OF(SSL_CIPHER) *sk, WPACKET *pkt)
             return 0;
         }
 
+        /* Sanity check that the maximum version we offer has ciphers enabled */
+        if (!maxverok) {
+            if (SSL_IS_DTLS(s)) {
+                if (DTLS_VERSION_GE(c->max_dtls, s->s3->tmp.max_ver)
+                        && DTLS_VERSION_LE(c->min_dtls, s->s3->tmp.max_ver))
+                    maxverok = 1;
+            } else {
+                if (c->max_tls >= s->s3->tmp.max_ver
+                        && c->min_tls <= s->s3->tmp.max_ver)
+                    maxverok = 1;
+            }
+        }
+
         totlen += len;
     }
 
-    if (totlen == 0) {
+    if (totlen == 0 || !maxverok) {
         SSLerr(SSL_F_SSL_CIPHER_LIST_TO_BYTES, SSL_R_NO_CIPHERS_AVAILABLE);
+
+        if (!maxverok)
+            ERR_add_error_data(1, "No ciphers enabled for max supported "
+                                  "SSL/TLS version");
+
         return 0;
     }
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1013,7 +1013,7 @@ void ssl_set_client_disabled(SSL *s)
     s->s3->tmp.mask_a = 0;
     s->s3->tmp.mask_k = 0;
     ssl_set_sig_mask(&s->s3->tmp.mask_a, s, SSL_SECOP_SIGALG_MASK);
-    ssl_get_client_min_max_version(s, &s->s3->tmp.min_ver, &s->s3->tmp.max_ver);
+    ssl_get_min_max_version(s, &s->s3->tmp.min_ver, &s->s3->tmp.max_ver);
 #ifndef OPENSSL_NO_PSK
     /* with PSK there must be client callback set */
     if (!s->psk_client_callback) {

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -396,6 +396,7 @@ SKIP: {
     skip "No EC support in this OpenSSL build", 1 if disabled("ec");
     $proxy->clear();
     $proxy->clientflags("-no_tls1_3");
+    $proxy->serverflags("-no_tls1_3");
     $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     checkhandshake($proxy, checkhandshake::EC_HANDSHAKE,

--- a/test/ssl-tests/02-protocol-version.conf
+++ b/test/ssl-tests/02-protocol-version.conf
@@ -700,7 +700,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-0]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -850,7 +850,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-6]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -1314,7 +1314,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-24]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -1339,7 +1339,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-25]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -4759,7 +4759,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-156]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -4915,7 +4915,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-162]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -5397,7 +5397,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-180]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -5423,7 +5423,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-181]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -17393,7 +17393,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-624]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -17549,7 +17549,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-630]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -18031,7 +18031,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-648]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -18057,7 +18057,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-649]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -18082,7 +18082,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-650]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -18232,7 +18232,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-656]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -18696,7 +18696,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-674]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 
 # ===========================================================
@@ -18721,6 +18721,6 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-675]
-ExpectedResult = InternalError
+ExpectedResult = ClientFail
 
 

--- a/test/ssl-tests/14-curves.conf
+++ b/test/ssl-tests/14-curves.conf
@@ -50,6 +50,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [0-curve-sect163k1-client]
 CipherString = ECDHE
 Curves = sect163k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -77,6 +78,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [1-curve-sect163r1-client]
 CipherString = ECDHE
 Curves = sect163r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -104,6 +106,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [2-curve-sect163r2-client]
 CipherString = ECDHE
 Curves = sect163r2
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -131,6 +134,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [3-curve-sect193r1-client]
 CipherString = ECDHE
 Curves = sect193r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -158,6 +162,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [4-curve-sect193r2-client]
 CipherString = ECDHE
 Curves = sect193r2
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -185,6 +190,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [5-curve-sect233k1-client]
 CipherString = ECDHE
 Curves = sect233k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -212,6 +218,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [6-curve-sect233r1-client]
 CipherString = ECDHE
 Curves = sect233r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -239,6 +246,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [7-curve-sect239k1-client]
 CipherString = ECDHE
 Curves = sect239k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -266,6 +274,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [8-curve-sect283k1-client]
 CipherString = ECDHE
 Curves = sect283k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -293,6 +302,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [9-curve-sect283r1-client]
 CipherString = ECDHE
 Curves = sect283r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -320,6 +330,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [10-curve-sect409k1-client]
 CipherString = ECDHE
 Curves = sect409k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -347,6 +358,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [11-curve-sect409r1-client]
 CipherString = ECDHE
 Curves = sect409r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -374,6 +386,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [12-curve-sect571k1-client]
 CipherString = ECDHE
 Curves = sect571k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -401,6 +414,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [13-curve-sect571r1-client]
 CipherString = ECDHE
 Curves = sect571r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -428,6 +442,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [14-curve-secp160k1-client]
 CipherString = ECDHE
 Curves = secp160k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -455,6 +470,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [15-curve-secp160r1-client]
 CipherString = ECDHE
 Curves = secp160r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -482,6 +498,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [16-curve-secp160r2-client]
 CipherString = ECDHE
 Curves = secp160r2
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -509,6 +526,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [17-curve-secp192k1-client]
 CipherString = ECDHE
 Curves = secp192k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -536,6 +554,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [18-curve-prime192v1-client]
 CipherString = ECDHE
 Curves = prime192v1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -563,6 +582,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [19-curve-secp224k1-client]
 CipherString = ECDHE
 Curves = secp224k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -590,6 +610,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [20-curve-secp224r1-client]
 CipherString = ECDHE
 Curves = secp224r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -617,6 +638,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [21-curve-secp256k1-client]
 CipherString = ECDHE
 Curves = secp256k1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -644,6 +666,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [22-curve-prime256v1-client]
 CipherString = ECDHE
 Curves = prime256v1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -671,6 +694,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [23-curve-secp384r1-client]
 CipherString = ECDHE
 Curves = secp384r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -698,6 +722,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [24-curve-secp521r1-client]
 CipherString = ECDHE
 Curves = secp521r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -725,6 +750,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [25-curve-brainpoolP256r1-client]
 CipherString = ECDHE
 Curves = brainpoolP256r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -752,6 +778,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [26-curve-brainpoolP384r1-client]
 CipherString = ECDHE
 Curves = brainpoolP384r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -779,6 +806,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [27-curve-brainpoolP512r1-client]
 CipherString = ECDHE
 Curves = brainpoolP512r1
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -806,6 +834,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [28-curve-X25519-client]
 CipherString = ECDHE
 Curves = X25519
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/14-curves.conf.in
+++ b/test/ssl-tests/14-curves.conf.in
@@ -25,14 +25,15 @@ sub generate_tests() {
     foreach (0..$#curves) {
         my $curve = $curves[$_];
         push @tests, {
-	    name => "curve-${curve}",
+            name => "curve-${curve}",
             server => {
                 "Curves" => $curve,
                 # TODO(TLS1.3): Can we get this to work for TLSv1.3?
                 "MaxProtocol" => "TLSv1.2"
             },
             client => {
-		"CipherString" => "ECDHE",
+                "CipherString" => "ECDHE",
+                "MaxProtocol" => "TLSv1.2",
                 "Curves" => $curve
             },
             test   => {

--- a/test/ssl-tests/17-renegotiate.conf
+++ b/test/ssl-tests/17-renegotiate.conf
@@ -198,12 +198,12 @@ client = 6-renegotiate-aead-to-non-aead-client
 [6-renegotiate-aead-to-non-aead-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = TLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-renegotiate-aead-to-non-aead-client]
 CipherString = AES128-GCM-SHA256
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -230,12 +230,12 @@ client = 7-renegotiate-non-aead-to-aead-client
 [7-renegotiate-non-aead-to-aead-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = TLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-renegotiate-non-aead-to-aead-client]
 CipherString = AES128-SHA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -262,12 +262,12 @@ client = 8-renegotiate-non-aead-to-non-aead-client
 [8-renegotiate-non-aead-to-non-aead-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = TLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-renegotiate-non-aead-to-non-aead-client]
 CipherString = AES128-SHA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -294,12 +294,12 @@ client = 9-renegotiate-aead-to-aead-client
 [9-renegotiate-aead-to-aead-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = TLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-renegotiate-aead-to-aead-client]
 CipherString = AES128-GCM-SHA256
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/17-renegotiate.conf.in
+++ b/test/ssl-tests/17-renegotiate.conf.in
@@ -114,10 +114,10 @@ our @tests_tls1_2 = (
         name => "renegotiate-aead-to-non-aead",
         server => {
             "Options" => "NoResumptionOnRenegotiation",
-            "MaxProtocol" => "TLSv1.2"
         },
         client => {
             "CipherString" => "AES128-GCM-SHA256",
+            "MaxProtocol" => "TLSv1.2",
             extra => {
                 "RenegotiateCiphers" => "AES128-SHA"
             }
@@ -133,10 +133,10 @@ our @tests_tls1_2 = (
         name => "renegotiate-non-aead-to-aead",
         server => {
             "Options" => "NoResumptionOnRenegotiation",
-            "MaxProtocol" => "TLSv1.2"
         },
         client => {
             "CipherString" => "AES128-SHA",
+            "MaxProtocol" => "TLSv1.2",
             extra => {
                 "RenegotiateCiphers" => "AES128-GCM-SHA256"
             }
@@ -152,10 +152,10 @@ our @tests_tls1_2 = (
         name => "renegotiate-non-aead-to-non-aead",
         server => {
             "Options" => "NoResumptionOnRenegotiation",
-            "MaxProtocol" => "TLSv1.2"
         },
         client => {
             "CipherString" => "AES128-SHA",
+            "MaxProtocol" => "TLSv1.2",
             extra => {
                 "RenegotiateCiphers" => "AES256-SHA"
             }
@@ -171,10 +171,10 @@ our @tests_tls1_2 = (
         name => "renegotiate-aead-to-aead",
         server => {
             "Options" => "NoResumptionOnRenegotiation",
-            "MaxProtocol" => "TLSv1.2"
         },
         client => {
             "CipherString" => "AES128-GCM-SHA256",
+            "MaxProtocol" => "TLSv1.2",
             extra => {
                 "RenegotiateCiphers" => "AES256-GCM-SHA384"
             }

--- a/test/ssl-tests/19-mac-then-encrypt.conf
+++ b/test/ssl-tests/19-mac-then-encrypt.conf
@@ -96,12 +96,12 @@ client = 3-disable-encrypt-then-mac-server-sha2-client
 [3-disable-encrypt-then-mac-server-sha2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = TLSv1.2
 Options = -EncryptThenMac
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-disable-encrypt-then-mac-server-sha2-client]
 CipherString = AES128-SHA256
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/19-mac-then-encrypt.conf.in
+++ b/test/ssl-tests/19-mac-then-encrypt.conf.in
@@ -61,10 +61,10 @@ my @tests_tls1_2 = (
         name => "disable-encrypt-then-mac-server-sha2",
         server => {
           "Options" => "-EncryptThenMac",
-          "MaxProtocol" => "TLSv1.2"
         },
         client => {
           "CipherString" => "AES128-SHA256",
+          "MaxProtocol" => "TLSv1.2"
         },
         test   => {
           "ExpectedResult" => "Success",

--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -34,6 +34,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-ECDSA CipherString Selection-client]
 CipherString = aECDSA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -62,6 +63,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-RSA CipherString Selection-client]
 CipherString = aRSA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -88,6 +90,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-ECDSA CipherString Selection, no ECDSA certificate-client]
 CipherString = aECDSA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -21,6 +21,7 @@ our @tests = (
         server => $server,
         client => {
             "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
         },
         test   => {
             "ExpectedServerCertType" =>, "P-256",
@@ -33,6 +34,7 @@ our @tests = (
         server => $server,
         client => {
             "CipherString" => "aRSA",
+            "MaxProtocol" => "TLSv1.2",
         },
         test   => {
             "ExpectedServerCertType" =>, "RSA",
@@ -46,7 +48,8 @@ our @tests = (
             "MaxProtocol" => "TLSv1.2"
         },
         client => {
-            "CipherString" => "aECDSA"
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2"
         },
         test   => {
             "ExpectedResult" => "ServerFail"

--- a/test/ssl-tests/23-srp.conf
+++ b/test/ssl-tests/23-srp.conf
@@ -18,6 +18,7 @@ client = 0-srp-client
 [0-srp-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SRP
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-srp-client]
@@ -52,6 +53,7 @@ client = 1-srp-bad-password-client
 [1-srp-bad-password-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SRP
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-srp-bad-password-client]
@@ -86,6 +88,7 @@ client = 2-srp-auth-client
 [2-srp-auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = aSRP
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-srp-auth-client]
@@ -120,6 +123,7 @@ client = 3-srp-auth-bad-password-client
 [3-srp-auth-bad-password-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = aSRP
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-srp-auth-bad-password-client]

--- a/test/ssl-tests/23-srp.conf.in
+++ b/test/ssl-tests/23-srp.conf.in
@@ -15,89 +15,93 @@ package ssltests;
 
 our @tests = (
     {
-	name => "srp",
-	server => {
-	    "CipherString" => "SRP",
-	    extra => {
-	       	"SRPUser" => "user",
-		"SRPPassword" => "password",
-	    },
+        name => "srp",
+        server => {
+            "CipherString" => "SRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "password",
+            },
         },
-	client => {
-	    "CipherString" => "SRP",
-	    "MaxProtocol" => "TLSv1.2",
-	    extra => {
-	        "SRPUser" => "user",
-		"SRPPassword" => "password",
-	    },
-	},
-	test => {
-	    "ExpectedResult" => "Success"
-	},
+        client => {
+            "CipherString" => "SRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "password",
+            },
+        },
+        test => {
+            "ExpectedResult" => "Success"
+        },
     },
     {
-	name => "srp-bad-password",
-	server => {
-	    "CipherString" => "SRP",
-	    extra => {
-	       	"SRPUser" => "user",
-		"SRPPassword" => "password",
-	    },
+        name => "srp-bad-password",
+        server => {
+            "CipherString" => "SRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "password",
+            },
         },
-	client => {
-	    "CipherString" => "SRP",
-	    "MaxProtocol" => "TLSv1.2",
-	    extra => {
-	        "SRPUser" => "user",
-		"SRPPassword" => "passw0rd",
-	    },
-	},
-	test => {
-	    # Server fails first with bad client Finished.
-	    "ExpectedResult" => "ServerFail"
-	},
+        client => {
+            "CipherString" => "SRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "passw0rd",
+            },
+        },
+        test => {
+            # Server fails first with bad client Finished.
+            "ExpectedResult" => "ServerFail"
+        },
     },
     {
-	name => "srp-auth",
-	server => {
-	    "CipherString" => "aSRP",
-	    extra => {
-	       	"SRPUser" => "user",
-		"SRPPassword" => "password",
-	    },
+        name => "srp-auth",
+        server => {
+            "CipherString" => "aSRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "password",
+            },
         },
-	client => {
-	    "CipherString" => "aSRP",
-	    "MaxProtocol" => "TLSv1.2",
-	    extra => {
-	        "SRPUser" => "user",
-		"SRPPassword" => "password",
-	    },
-	},
-	test => {
-	    "ExpectedResult" => "Success"
-	},
+        client => {
+            "CipherString" => "aSRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "password",
+            },
+        },
+        test => {
+            "ExpectedResult" => "Success"
+        },
     },
     {
-	name => "srp-auth-bad-password",
-	server => {
-	    "CipherString" => "aSRP",
-	    extra => {
-	       	"SRPUser" => "user",
-		"SRPPassword" => "password",
-	    },
+        name => "srp-auth-bad-password",
+        server => {
+            "CipherString" => "aSRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "password",
+            },
         },
-	client => {
-	    "CipherString" => "aSRP",
-	    "MaxProtocol" => "TLSv1.2",
-	    extra => {
-	        "SRPUser" => "user",
-		"SRPPassword" => "passw0rd",
-	    },
-	},
-	test => {
-	    # Server fails first with bad client Finished.
-	    "ExpectedResult" => "ServerFail"
-	},
+        client => {
+            "CipherString" => "aSRP",
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "SRPUser" => "user",
+                "SRPPassword" => "passw0rd",
+            },
+        },
+        test => {
+            # Server fails first with bad client Finished.
+            "ExpectedResult" => "ServerFail"
+        },
     },
 );

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -125,6 +125,37 @@ sub generate_version_tests {
             }
         }
     }
+    return @tests if disabled("tls1_3") || disabled("tls1_2") || $dtls;
+
+    #Add some version/ciphersuite sanity check tests
+    push @tests, {
+        "name" => "ciphersuite-sanity-check-client",
+        "client" => {
+            #Offering only <=TLSv1.2 ciphersuites with TLSv1.3 should fail
+            "CipherString" => "AES128-SHA",
+        },
+        "server" => {
+            "MaxProtocol" => "TLSv1.2"
+        },
+        "test" => {
+            "ExpectedResult" => "InternalError",
+        }
+    };
+    push @tests, {
+        "name" => "ciphersuite-sanity-check-server",
+        "client" => {
+            "CipherString" => "AES128-SHA",
+            "MaxProtocol" => "TLSv1.2"
+        },
+        "server" => {
+            #Allowing only <=TLSv1.2 ciphersuites with TLSv1.3 should fail
+            "CipherString" => "AES128-SHA",
+        },
+        "test" => {
+            "ExpectedResult" => "ServerFail",
+        }
+    };
+
     return @tests;
 }
 

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -242,7 +242,11 @@ sub expected_result {
     $c_max = min $c_max, $max_enabled;
     $s_max = min $s_max, $max_enabled;
 
-    if ($c_min > $c_max) {
+    if ($c_min > $c_max && $s_min > $s_max) {
+        # Client will fail to send a hello and server will fail to start. The
+        # client failed first so this is reported as ClientFail.
+        return ("ClientFail", undef);
+    } elsif ($c_min > $c_max) {
         # Client should fail to even send a hello.
         # This results in an internal error since the server will be
         # waiting for input that never arrives.


### PR DESCRIPTION
This is a backport of the commits contained in PR #3316 to the draft-18 branch. I had to make a few tweaks to get this to work - mostly in the tests.

The description from PR #3316:

With TLSv1.3 it is possible to misconfigure OpenSSL such that the maximum supported version (TLSv1.3) has no ciphersuites enabled.

On the client side we should fail to send the ClientHello if the maximum supported version doesn't have any ciphersuites.

On the server side we should fail immediately (regardless of the client version) if a misconfiguration of this type exists.

This change adds sanity checks for this.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
