### PR TITLE
Add some man page cross-references

### DIFF
--- a/doc/man3/SSL_CTX_set_early_cb.pod
+++ b/doc/man3/SSL_CTX_set_early_cb.pod
@@ -62,7 +62,8 @@ by the client in order to select an appropriate certificate to present,
 and make other configuration adjustments relevant to that server name
 and its configuration.  Such configuration changes can include swapping out
 the associated SSL_CTX pointer, modifying the server's list of permitted TLS
-versions, changing the server's cipher list, etc.
+versions, changing the server's cipher list in response to the client's
+cipher list, etc.
 
 It is also recommended that applications utilize an early callback and
 not use a servername callback, in order to avoid unexpected behavior that
@@ -89,7 +90,8 @@ SSL_early_get0_ext() returns 1 if the extension of type 'type' is present, and
 
 =head1 SEE ALSO
 
-L<ssl(7)>, L<SSL_CTX_set_tlsext_servername_callback(3)>
+L<ssl(7)>, L<SSL_CTX_set_tlsext_servername_callback(3)>,
+L<SSL_bytes_to_cipher_list>
 
 =head1 HISTORY
 

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -19,6 +19,10 @@ SSL_get_servername_type, SSL_get_servername - handle server name indication
 
 =head1 DESCRIPTION
 
+The functionality provided by the servername callback is superseded by
+the early callback, which can be set using SSL_CTX_set_early_cb().
+The servername callback is retained for historical compatibility.
+
 SSL_CTX_set_tlsext_servername_callback() sets the application callback B<cb>
 used by a server to perform any actions or configuration required based on
 the servername extension received in the incoming connection. When B<cb>
@@ -37,8 +41,9 @@ B<TLSEXT_NAMETYPE_host_name>.
 
 =head1 NOTES
 
-The ALPN and SNI callbacks are both executed during Client Hello processing.
-The servername callback is executed first, followed by the ALPN callback.
+Several callbacks are executed during ClientHello processing, including
+the early, ALPN, and servername callbacks.  The early callback is executed
+first, then the servername callback, followed by the ALPN callback.
 
 =head1 RETURN VALUES
 
@@ -48,7 +53,7 @@ SSL_CTX_set_tlsext_servername_arg() both always return 1 indicating success.
 =head1 SEE ALSO
 
 L<ssl(7)>, L<SSL_CTX_set_alpn_select_cb(3)>,
-L<SSL_get0_alpn_selected(3)>
+L<SSL_get0_alpn_selected(3)>, L<SSL_CTX_set_early_cb(3)>
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The old/deprecated servername callback should refer back to the
new/preferred early callback mechanism, as well as indicate that
it is superseded by the early callback.

The early callback should also mention the API for turning the
raw cipherlist octets from the client into usable data structures.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
