### PR TITLE
TLSProxy: When in debug mode, show the exact subprocess commands

### DIFF
--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -171,6 +171,9 @@ sub start
         if ($self->serverflags ne "") {
             $execcmd .= " ".$self->serverflags;
         }
+        if ($self->debug) {
+            print STDERR "Server command: $execcmd\n";
+        }
         exec($execcmd);
     }
     $self->serverpid($pid);
@@ -231,6 +234,9 @@ sub clientstart
             }
             if (defined $self->sessionfile) {
                 $execcmd .= " -ign_eof";
+            }
+            if ($self->debug) {
+                print STDERR "Client command: $execcmd\n";
             }
             exec($execcmd);
         }


### PR DESCRIPTION
When you want to debug a test that goes wrong, it's useful to know
exactly what subprocess commands are run.

##### Checklist
- [x] tests are added or updated
