### PR TITLE
asn1/a_int.c: fix "one less minimal negative" corner case in c2i_ibuf.

### DIFF
--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -167,10 +167,21 @@ static size_t c2i_ibuf(unsigned char *b, int *pneg,
         }
         return 1;
     }
-    if (p[0] == 0 || p[0] == 0xFF)
+
+    pad = 0;
+    if (p[0] == 0) {
         pad = 1;
-    else
-        pad = 0;
+    } else if (p[0] == 0xFF) {
+        size_t i;
+
+        /*
+         * Special case [of "one less minimal negative" for given length]:
+         * if any other bytes non zero it was padded, otherwise not.
+         */
+        for (pad = 0, i = 1; i < plen; i++)
+            pad |= p[i];
+        pad = pad != 0 ? 1 : 0;
+    }
     /* reject illegal padding: first two octets MSB can't match */
     if (pad && (neg == (p[1] & 0x80))) {
         ASN1err(ASN1_F_C2I_IBUF, ASN1_R_ILLEGAL_PADDING);

--- a/test/asn1_encode_test.c
+++ b/test/asn1_encode_test.c
@@ -41,6 +41,9 @@ static unsigned char t_one[] = {
 static unsigned char t_one_neg[] = {
     0xff
 };
+static unsigned char t_minus_256[] = {
+    0xff, 0x00
+};
 static unsigned char t_longundef[] = {
     0x7f, 0xff, 0xff, 0xff
 };
@@ -99,6 +102,7 @@ static TEST_CUSTOM_DATA test_custom_data[] = {
     CUSTOM_DATA(t_longundef),
     CUSTOM_DATA(t_one),
     CUSTOM_DATA(t_one_neg),
+    CUSTOM_DATA(t_minus_256),
     CUSTOM_DATA(t_9bytes_1),
     CUSTOM_DATA(t_8bytes_1),
     CUSTOM_DATA(t_8bytes_2),
@@ -200,6 +204,7 @@ static ASN1_LONG_DATA long_expected_32bit[] = {
     { 0, 0, 0 }, { 0xff, 1, 0x7fffffff }, /* t_longundef */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
     CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
+    CUSTOM_EXPECTED_SUCCESS(-256, -256), /* t_minus_256 */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_2 */
@@ -235,6 +240,7 @@ static ASN1_LONG_DATA long_expected_64bit[] = {
     { 0, 0, 0 }, { 0xff, 1, 0x7fffffff }, /* t_longundef */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
     CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
+    CUSTOM_EXPECTED_SUCCESS(-256, -256), /* t_minus_256 */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_SUCCESS(LONG_MAX, LONG_MAX), /* t_8bytes_2 */
@@ -287,6 +293,7 @@ static ASN1_INT32_DATA int32_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
     CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
+    CUSTOM_EXPECTED_SUCCESS(-256, -256), /* t_minus_256 */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_2 */
@@ -334,6 +341,7 @@ static ASN1_UINT32_DATA uint32_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
     CUSTOM_EXPECTED_FAILURE,     /* t_one_neg (illegal negative value) */
+    CUSTOM_EXPECTED_FAILURE,     /* t_minus_256 (illegal negative value) */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_2 */
@@ -381,6 +389,7 @@ static ASN1_INT64_DATA int64_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
     CUSTOM_EXPECTED_SUCCESS(-1, -1), /* t_one_neg */
+    CUSTOM_EXPECTED_SUCCESS(-256, -256), /* t_minus_256 */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_FAILURE,     /* t_8bytes_1 (too large positive) */
     CUSTOM_EXPECTED_SUCCESS(INT64_MAX, INT64_MAX), /* t_8bytes_2 */
@@ -429,6 +438,7 @@ static ASN1_UINT64_DATA uint64_expected[] = {
     CUSTOM_EXPECTED_SUCCESS(ASN1_LONG_UNDEF, ASN1_LONG_UNDEF), /* t_zero */
     CUSTOM_EXPECTED_SUCCESS(1, 1), /* t_one */
     CUSTOM_EXPECTED_FAILURE,     /* t_one_neg (illegal negative value) */
+    CUSTOM_EXPECTED_FAILURE,     /* t_minus_256 (illegal negative value) */
     CUSTOM_EXPECTED_FAILURE,     /* t_9bytes_1 */
     CUSTOM_EXPECTED_SUCCESS((uint64_t)INT64_MAX+1, (uint64_t)INT64_MAX+1),
                                  /* t_8bytes_1 */


### PR DESCRIPTION
Thanks to Kazuki Yamaguchi for report.

----
This is alternative to #3339.