### PR TITLE
Refactor testutil output

### DIFF
--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -14,6 +14,7 @@
 #include <openssl/bio.h>
 #include "internal/numbers.h"
 #include "testutil.h"
+#include "testutil/output.h"
 
 #define nelem(x) (int)(sizeof(x) / sizeof((x)[0]))
 

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -261,18 +261,6 @@ void test_close_streams(void)
 {
 }
 
-int test_puts_stdout(const char *str)
-{
-    return fputs(str, stdout);
-}
-
-int test_puts_stderr(const char *str)
-{
-    return fputs(str, stderr);
-}
-
-static char vprint_buf[10240];
-
 /*
  * This works out as long as caller doesn't use any "fancy" formats.
  * But we are caller's caller, and test_str_eq is the only one called,
@@ -280,20 +268,12 @@ static char vprint_buf[10240];
  */
 int test_vprintf_stdout(const char *fmt, va_list ap)
 {
-    size_t len = vsnprintf(vprint_buf, sizeof(vprint_buf), fmt, ap);
-
-    if (len >= sizeof(vprint_buf))
-        return -1;
-    return test_puts_stdout(vprint_buf);
+    return vfprintf(stdout, fmt, ap);
 }
 
 int test_vprintf_stderr(const char *fmt, va_list ap)
 {
-    size_t len = vsnprintf(vprint_buf, sizeof(vprint_buf), fmt, ap);
-
-    if (len >= sizeof(vprint_buf))
-        return -1;
-    return test_puts_stderr(vprint_buf);
+    return vfprintf(stderr, fmt, ap);
 }
 
 int test_flush_stdout(void)

--- a/test/build.info
+++ b/test/build.info
@@ -10,7 +10,7 @@
 IF[{- !$disabled{tests} -}]
   LIBS_NO_INST=libtestutil.a
   SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output_helpers.c \
-          testutil/driver.c testutil/tests.c \
+          testutil/driver.c testutil/tests.c testutil/cb.c \
           {- rebase_files("../apps", $target{apps_aux_src}) -} \
           testutil/test_main.c testutil/main.c
   INCLUDE[libtestutil.a]=.. ../include

--- a/test/build.info
+++ b/test/build.info
@@ -9,9 +9,10 @@
 -}
 IF[{- !$disabled{tests} -}]
   LIBS_NO_INST=libtestutil.a
-  SOURCE[libtestutil.a]=testutil/basic_output.c testutil/driver.c \
-          testutil/tests.c testutil/test_main.c testutil/main.c \
-          {- rebase_files("../apps", $target{apps_aux_src}) -}
+  SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output_helpers.c \
+          testutil/driver.c testutil/tests.c \
+          {- rebase_files("../apps", $target{apps_aux_src}) -} \
+          testutil/test_main.c testutil/main.c
   INCLUDE[libtestutil.a]=.. ../include
   DEPEND[libtestutil.a]=../libcrypto
 

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -359,5 +359,4 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 extern BIO *bio_out;
 extern BIO *bio_err;
 
-int subtest_level(void);
 #endif                          /* HEADER_TESTUTIL_H */

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -248,6 +248,7 @@ void test_error_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 void test_info(const char *file, int line, const char *desc, ...)
     PRINTF_FORMAT(3, 4);
 void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
+void test_openssl_errors(void);
 
 /*
  * The following macros provide wrapper calls to the test functions with
@@ -342,6 +343,7 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 #  define TEST_error(...)    test_error(__FILE__, __LINE__, __VA_ARGS__)
 #  define TEST_info(...)     test_info(__FILE__, __LINE__, __VA_ARGS__)
 # endif
+# define TEST_openssl_errors test_openssl_errors
 
 /*
  * For "impossible" conditions such as malloc failures or bugs in test code,
@@ -351,7 +353,7 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 # define TEST_check(condition)                  \
     do {                                        \
         if (!(condition)) {                     \
-            ERR_print_errors_fp(stderr);        \
+            TEST_openssl_errors();              \
             OPENSSL_assert(!#condition);        \
         }                                       \
     } while (0)

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -355,25 +355,9 @@ void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
             OPENSSL_assert(!#condition);        \
         }                                       \
     } while (0)
-#endif                          /* HEADER_TESTUTIL_H */
-
-
-/*
- * The basic I/O functions used by the test framework.  These can be
- * overriden when needed. Note that if one is, then all must be.
- */
-void test_open_streams(void);
-void test_close_streams(void);
-/* The following ALL return the number of characters written */
-int test_puts_stdout(const char *str);
-int test_puts_stderr(const char *str);
-int test_vprintf_stdout(const char *fmt, va_list ap);
-int test_vprintf_stderr(const char *fmt, va_list ap);
-/* These return failure or success */
-int test_flush_stdout(void);
-int test_flush_stderr(void);
 
 extern BIO *bio_out;
 extern BIO *bio_err;
 
 int subtest_level(void);
+#endif                          /* HEADER_TESTUTIL_H */

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -8,6 +8,7 @@
  */
 
 #include "../testutil.h"
+#include "output.h"
 
 #include <openssl/crypto.h>
 #include <openssl/bio.h>

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -31,16 +31,6 @@ void test_close_streams(void)
     BIO_free(bio_err);
 }
 
-int test_puts_stdout(const char *str)
-{
-    return BIO_puts(bio_out, str);
-}
-
-int test_puts_stderr(const char *str)
-{
-    return BIO_puts(bio_err, str);
-}
-
 int test_vprintf_stdout(const char *fmt, va_list ap)
 {
     return BIO_vprintf(bio_out, fmt, ap);

--- a/test/testutil/cb.c
+++ b/test/testutil/cb.c
@@ -7,7 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdlib.h>              /* size_t */
+#include "output.h"
+#include "tu_local.h"
 
-int subtest_level(void);
-int openssl_error_cb(const char *str, size_t len, void *u);
+int openssl_error_cb(const char *str, size_t len, void *u)
+{
+    return test_printf_stderr("%*s# %s", subtest_level(), "", str);
+}

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -84,11 +84,6 @@ static int should_report_leaks()
 }
 #endif
 
-static int err_cb(const char *str, size_t len, void *u)
-{
-    return test_puts_stderr(str);
-}
-
 void setup_test()
 {
     char *TAP_levels = getenv("HARNESS_OSSL_LEVEL");
@@ -108,7 +103,8 @@ void setup_test()
 int finish_test(int ret)
 {
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
-    if (should_report_leaks() && CRYPTO_mem_leaks_cb(err_cb, NULL) <= 0)
+    if (should_report_leaks()
+        && CRYPTO_mem_leaks_cb(openssl_error_cb, NULL) <= 0)
         return EXIT_FAILURE;
 #endif
 
@@ -122,7 +118,7 @@ static void finalize(int success)
     if (success)
         ERR_clear_error();
     else
-        ERR_print_errors_cb(err_cb, NULL);
+        ERR_print_errors_cb(openssl_error_cb, NULL);
 }
 
 int run_tests(const char *test_prog_name)

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -125,15 +125,6 @@ static void finalize(int success)
         ERR_print_errors_cb(err_cb, NULL);
 }
 
-static void helper_printf_stdout(const char *fmt, ...)
-{
-    va_list ap;
-
-    va_start(ap, fmt);
-    test_vprintf_stdout(fmt, ap);
-    va_end(ap);
-}
-
 int run_tests(const char *test_prog_name)
 {
     int num_failed = 0;
@@ -141,13 +132,13 @@ int run_tests(const char *test_prog_name)
     int i, j;
 
     if (num_tests < 1)
-        helper_printf_stdout("%*s1..0 # Skipped: %s\n", level, "",
-                             test_prog_name);
+        test_printf_stdout("%*s1..0 # Skipped: %s\n", level, "",
+                           test_prog_name);
     else if (level > 0)
-        helper_printf_stdout("%*s1..%d # Subtest: %s\n", level, "", num_tests,
-                             test_prog_name);
+        test_printf_stdout("%*s1..%d # Subtest: %s\n", level, "", num_tests,
+                           test_prog_name);
     else
-        helper_printf_stdout("%*s1..%d\n", level, "", num_tests);
+        test_printf_stdout("%*s1..%d\n", level, "", num_tests);
     test_flush_stdout();
 
     for (i = 0; i != num_tests; ++i) {
@@ -162,8 +153,8 @@ int run_tests(const char *test_prog_name)
                 verdict = "not ok";
                 ++num_failed;
             }
-            helper_printf_stdout("%*s%s %d - %s\n", level, "", verdict, i + 1,
-                                     all_tests[i].test_case_name);
+            test_printf_stdout("%*s%s %d - %s\n", level, "", verdict, i + 1,
+                               all_tests[i].test_case_name);
             test_flush_stdout();
             finalize(ret);
         } else {
@@ -171,10 +162,10 @@ int run_tests(const char *test_prog_name)
 
             level += 4;
             if (all_tests[i].subtest) {
-                helper_printf_stdout("%*s# Subtest: %s\n", level, "",
-                                     all_tests[i].test_case_name);
-                helper_printf_stdout("%*s%d..%d\n", level, "", 1,
-                                     all_tests[i].num);
+                test_printf_stdout("%*s# Subtest: %s\n", level, "",
+                                   all_tests[i].test_case_name);
+                test_printf_stdout("%*s%d..%d\n", level, "", 1,
+                                   all_tests[i].num);
                 test_flush_stdout();
             }
 
@@ -195,7 +186,7 @@ int run_tests(const char *test_prog_name)
                         verdict = "not ok";
                         ++num_failed_inner;
                     }
-                    helper_printf_stdout("%*s%s %d\n", level, "", verdict, j + 1);
+                    test_printf_stdout("%*s%s %d\n", level, "", verdict, j + 1);
                     test_flush_stdout();
                 }
             }
@@ -206,8 +197,8 @@ int run_tests(const char *test_prog_name)
                 verdict = "not ok";
                 ++num_failed;
             }
-            helper_printf_stdout("%*s%s %d - %s\n", level, "", verdict, i + 1,
-                                 all_tests[i].test_case_name);
+            test_printf_stdout("%*s%s %d - %s\n", level, "", verdict, i + 1,
+                               all_tests[i].test_case_name);
             test_flush_stdout();
         }
     }

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -8,6 +8,7 @@
  */
 
 #include "../testutil.h"
+#include "output.h"
 
 #include <string.h>
 #include <assert.h>

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -9,6 +9,7 @@
 
 #include "../testutil.h"
 #include "output.h"
+#include "tu_local.h"
 
 #include <string.h>
 #include <assert.h>

--- a/test/testutil/output.h
+++ b/test/testutil/output.h
@@ -27,4 +27,8 @@ int test_vprintf_stderr(const char *fmt, va_list ap);
 int test_flush_stdout(void);
 int test_flush_stderr(void);
 
+/* Commodity functions.  There's no need to override these */
+int test_printf_stdout(const char *fmt, ...);
+int test_printf_stderr(const char *fmt, ...);
+
 #endif                          /* HEADER_TU_OUTPUT_H */

--- a/test/testutil/output.h
+++ b/test/testutil/output.h
@@ -19,8 +19,6 @@
 void test_open_streams(void);
 void test_close_streams(void);
 /* The following ALL return the number of characters written */
-int test_puts_stdout(const char *str);
-int test_puts_stderr(const char *str);
 int test_vprintf_stdout(const char *fmt, va_list ap);
 int test_vprintf_stderr(const char *fmt, va_list ap);
 /* These return failure or success */

--- a/test/testutil/output.h
+++ b/test/testutil/output.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_TU_OUTPUT_H
+# define HEADER_TU_OUTPUT_H
+
+#include <stdarg.h>
+
+/*
+ * The basic I/O functions used internally by the test framework.  These
+ * can be overriden when needed. Note that if one is, then all must be.
+ */
+void test_open_streams(void);
+void test_close_streams(void);
+/* The following ALL return the number of characters written */
+int test_puts_stdout(const char *str);
+int test_puts_stderr(const char *str);
+int test_vprintf_stdout(const char *fmt, va_list ap);
+int test_vprintf_stderr(const char *fmt, va_list ap);
+/* These return failure or success */
+int test_flush_stdout(void);
+int test_flush_stderr(void);
+
+#endif                          /* HEADER_TU_OUTPUT_H */

--- a/test/testutil/output_helpers.c
+++ b/test/testutil/output_helpers.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "output.h"
+
+int test_printf_stdout(const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = test_vprintf_stdout(fmt, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int test_printf_stderr(const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = test_vprintf_stderr(fmt, ap);
+    va_end(ap);
+
+    return ret;
+}

--- a/test/testutil/test_main.c
+++ b/test/testutil/test_main.c
@@ -15,7 +15,7 @@
 int test_main(int argc, char *argv[])
 {
     if (argc > 1)
-        test_puts_stderr("Warning: ignoring extra command-line arguments.\n");
+        test_printf_stderr("Warning: ignoring extra command-line arguments.\n");
 
     register_tests();
     return run_tests(argv[0]);

--- a/test/testutil/test_main.c
+++ b/test/testutil/test_main.c
@@ -8,6 +8,7 @@
  */
 
 #include "../testutil.h"
+#include "output.h"
 
 #include <stdio.h>
 

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -111,6 +111,11 @@ void test_error(const char *file, int line, const char *desc, ...)
     va_end(ap);
 }
 
+void test_openssl_errors(void)
+{
+    ERR_print_errors_cb(openssl_error_cb, NULL);
+}
+
 /*
  * Define some comparisons between pairs of various types.
  * These functions return 1 if the test is true.

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -45,29 +45,21 @@
 static void test_fail_message(const char *prefix, const char *file, int line,
                               const char *type, const char *fmt, ...)
             PRINTF_FORMAT(5, 6);
-static void helper_printf_stderr(const char *fmt, ...)
-{
-    va_list ap;
-
-    va_start(ap, fmt);
-    test_vprintf_stderr(fmt, ap);
-    va_end(ap);
-}
 
 static void test_fail_message_va(const char *prefix, const char *file, int line,
                                  const char *type, const char *fmt, va_list ap)
 {
-    helper_printf_stderr("%*s# ", subtest_level(), "");
+    test_printf_stderr("%*s# ", subtest_level(), "");
     test_puts_stderr(prefix != NULL ? prefix : "ERROR");
     test_puts_stderr(":");
     if (type)
-        helper_printf_stderr(" (%s)", type);
+        test_printf_stderr(" (%s)", type);
     if (fmt != NULL) {
         test_puts_stderr(" ");
         test_vprintf_stderr(fmt, ap);
     }
     if (file != NULL) {
-        helper_printf_stderr(" @ %s:%d", file, line);
+        test_printf_stderr(" @ %s:%d", file, line);
     }
     test_puts_stderr("\n");
     test_flush_stderr();

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -9,6 +9,7 @@
 
 #include "../testutil.h"
 #include "output.h"
+#include "tu_local.h"
 
 #include <string.h>
 #include "../../e_os.h"
@@ -44,8 +45,6 @@
 static void test_fail_message(const char *prefix, const char *file, int line,
                               const char *type, const char *fmt, ...)
             PRINTF_FORMAT(5, 6);
-int subtest_level(void);
-
 static void helper_printf_stderr(const char *fmt, ...)
 {
     va_list ap;

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -49,19 +49,17 @@ static void test_fail_message(const char *prefix, const char *file, int line,
 static void test_fail_message_va(const char *prefix, const char *file, int line,
                                  const char *type, const char *fmt, va_list ap)
 {
-    test_printf_stderr("%*s# ", subtest_level(), "");
-    test_puts_stderr(prefix != NULL ? prefix : "ERROR");
-    test_puts_stderr(":");
+    test_printf_stderr("%*s# %s: ", subtest_level(), "",
+                       prefix != NULL ? prefix : "ERROR");
     if (type)
-        test_printf_stderr(" (%s)", type);
+        test_printf_stderr("(%s)", type);
     if (fmt != NULL) {
-        test_puts_stderr(" ");
         test_vprintf_stderr(fmt, ap);
     }
     if (file != NULL) {
         test_printf_stderr(" @ %s:%d", file, line);
     }
-    test_puts_stderr("\n");
+    test_printf_stderr("\n");
     test_flush_stderr();
 }
 

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -8,6 +8,7 @@
  */
 
 #include "../testutil.h"
+#include "output.h"
 
 #include <string.h>
 #include "../../e_os.h"

--- a/test/testutil/tu_local.h
+++ b/test/testutil/tu_local.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+int subtest_level(void);


### PR DESCRIPTION
- Internal testutil printing functions become internal "for real"
- Duplicate static print helpers become internal commodity functions
- Added a wrapper for formatted OpenSSL error stack printout

Replaces #3329 and extends its original purpose