### PR TITLE
rsa_gen.c: use carmichael function for exponents modulus instead of euler

### DIFF
--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -136,6 +136,10 @@ static int rsa_builtin_keygen(RSA *rsa, int bits, BIGNUM *e_value,
         goto err;               /* q-1 */
     if (!BN_mul(r0, r1, r2, ctx))
         goto err;               /* (p-1)(q-1) */
+    if (!BN_gcd(r3, r1, r2, ctx))
+        goto err;               /* gcd(p-1, q-1) */
+    if (!BN_div(r0, NULL, r0, r3, ctx))
+        goto err;               /* LCM(p-1, q-1) */
     {
         BIGNUM *pr0 = BN_new();
 


### PR DESCRIPTION
[FIPS 186-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf#page=62) puts requirements for private exponent _d_:
`2^(nlen / 2) < d < LCM(p–1, q–1)`,
implying use of Carmichael's totient function as the modulus for exponents.

But current implementation uses Euler's totient function (`(p-1)*(q-1)`) as the modulus to find multiplicative inverse of public exponent _e_, as suggested by [original RSA publication](http://people.csail.mit.edu/rivest/Rsapaper.pdf). As result current key generation method always produces larger private exponent than needed and key never meets FIPS requirements.

This commit makes use of Carmichael's totient function and makes rsa_builtin_keygen() function generate keys with minimal effective private exponent.

This change doesn't breaks any compatibility between keys, so private keys generated with any method from same (_p_, _q_) pair are interchangeable.