### PR TITLE
util/incore: harmonize with __thumb__ clause in FIPS_ref_point()

### DIFF
--- a/util/incore
+++ b/util/incore
@@ -131,6 +131,9 @@
 		&& @sections[$st_secn]->{sh_type}	# not SHN_UNDEF
 		&& ($name=(split(chr(0),substr($strings,$elf_sym{st_name},128)))[0])
 		) {
+		if ($st_type==2 && $self->{e_machine} == 40) {
+		    $elf_sym{st_value} &= ~1;	# compensate for Thumb STT_FUNCs
+		}
 		# synthesize st_offset, ...
 	    	$elf_sym{st_offset}  = $elf_sym{st_value}
 				- @sections[$st_secn]->{sh_addr}


### PR DESCRIPTION
In ELF Thumb functions are "decorated" with 1 in least significant bit,
while fips_canister.c operates on real "undecorated" pointers to code.
References to non-Thumb functions can't have two least significant bits
set, hence masking one is effectively a no-op in non-Thumb cases.
