### PR TITLE
Fix clang compile time error

### DIFF
--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
 #include "ssl_locl.h"
 #include "packet_locl.h"
 #include <openssl/bio.h>
@@ -903,7 +904,7 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
     int ret = 0;
     BIO *bin = NULL;
     size_t num_extensions = 0, contextoff = 0;
-    unsigned int version;
+    unsigned int version = 0;
 
     if (ctx == NULL || file == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_FILE, ERR_R_PASSED_NULL_PARAMETER);
@@ -1009,8 +1010,10 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
         extension = NULL;
     }
 
-    ret = SSL_CTX_use_serverinfo_ex(ctx, version, serverinfo,
-                                    serverinfo_length);
+    assert(version != 0);
+    if (version != 0)
+        ret = SSL_CTX_use_serverinfo_ex(ctx, version, serverinfo,
+                                        serverinfo_length);
  end:
     /* SSL_CTX_use_serverinfo makes a local copy of the serverinfo. */
     OPENSSL_free(name);


### PR DESCRIPTION
|version| "could" be used uninitialized here, not really, but the
compiler doesn't understand the flow

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
