### PR TITLE
Fix #340: Parse ASN1_TIME to struct tm

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -130,20 +130,26 @@ int ASN1_TIME_set_string(ASN1_TIME *s, const char *str)
     return 1;
 }
 
-static int asn1_time_to_tm(struct tm *tm, const ASN1_TIME *t)
+int ASN1_TIME_to_tm(const ASN1_TIME *s, struct tm *tm)
 {
-    if (t == NULL) {
+    if (s == NULL) {
         time_t now_t;
+
         time(&now_t);
+        memset(tm, 0, sizeof(*tm));
         if (OPENSSL_gmtime(&now_t, tm))
             return 1;
         return 0;
     }
 
-    if (t->type == V_ASN1_UTCTIME)
-        return asn1_utctime_to_tm(tm, t);
-    else if (t->type == V_ASN1_GENERALIZEDTIME)
-        return asn1_generalizedtime_to_tm(tm, t);
+    if (s->type == V_ASN1_UTCTIME) {
+        memset(tm, 0, sizeof(*tm));
+        return asn1_utctime_to_tm(tm, s);
+    }
+    if (s->type == V_ASN1_GENERALIZEDTIME) {
+        memset(tm, 0, sizeof(*tm));
+        return asn1_generalizedtime_to_tm(tm, s);
+    }
 
     return 0;
 }
@@ -152,9 +158,10 @@ int ASN1_TIME_diff(int *pday, int *psec,
                    const ASN1_TIME *from, const ASN1_TIME *to)
 {
     struct tm tm_from, tm_to;
-    if (!asn1_time_to_tm(&tm_from, from))
+
+    if (!ASN1_TIME_to_tm(from, &tm_from))
         return 0;
-    if (!asn1_time_to_tm(&tm_to, to))
+    if (!ASN1_TIME_to_tm(to, &tm_to))
         return 0;
     return OPENSSL_gmtime_diff(pday, psec, &tm_from, &tm_to);
 }

--- a/doc/man3/ASN1_TIME_set.pod
+++ b/doc/man3/ASN1_TIME_set.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 ASN1_TIME_set, ASN1_TIME_adj, ASN1_TIME_check, ASN1_TIME_set_string,
-ASN1_TIME_print, ASN1_TIME_diff - ASN.1 Time functions
+ASN1_TIME_print, ASN1_TIME_to_tm, ASN1_TIME_diff - ASN.1 Time functions
 
 =head1 SYNOPSIS
 
@@ -13,6 +13,7 @@ ASN1_TIME_print, ASN1_TIME_diff - ASN.1 Time functions
  int ASN1_TIME_set_string(ASN1_TIME *s, const char *str);
  int ASN1_TIME_check(const ASN1_TIME *t);
  int ASN1_TIME_print(BIO *b, const ASN1_TIME *s);
+ int ASN1_TIME_to_tm(const ASN1_TIME *s, struct tm *tm);
 
  int ASN1_TIME_diff(int *pday, int *psec,
                     const ASN1_TIME *from, const ASN1_TIME *to);
@@ -41,6 +42,11 @@ format. It will be of the format MMM DD HH:MM:SS YYYY [GMT], for example
 "Feb  3 00:55:52 2015 GMT" it does not include a newline. If the time
 structure has invalid format it prints out "Bad time value" and returns
 an error.
+
+ASN1_TIME_to_tm() converts the time B<s> to the standard B<tm> structure.
+If B<s> is NULL, then the current time is converted. The output time is GMT.
+Only the B<tm_sec>, B<tm_min>, B<tm_hour>, B<tm_mday>, B<tm_mon> and B<tm_year>
+fields are updated.
 
 ASN1_TIME_diff() sets B<*pday> and B<*psec> to the time difference between
 B<from> and B<to>. If B<to> represents a time later than B<from> then
@@ -123,12 +129,19 @@ otherwise.
 ASN1_TIME_print() returns 1 if the time is successfully printed out and 0 if
 an error occurred (I/O error or invalid time format).
 
+ASN1_TIME_to_tm() returns 1 if the time is successfully parsed and 0 if an
+error occured (invalid time format).
+
 ASN1_TIME_diff() returns 1 for success and 0 for failure. It can fail if the
 pass ASN1_TIME structure has invalid syntax for example.
 
+=head1 HISTORY
+
+The ASN1_TIME_to_tm() function was added in OpenSSL 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -628,6 +628,7 @@ int ASN1_TIME_check(const ASN1_TIME *t);
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(const ASN1_TIME *t,
                                                    ASN1_GENERALIZEDTIME **out);
 int ASN1_TIME_set_string(ASN1_TIME *s, const char *str);
+int ASN1_TIME_to_tm(const ASN1_TIME *s, struct tm *tm);
 
 int i2a_ASN1_INTEGER(BIO *bp, const ASN1_INTEGER *a);
 int a2i_ASN1_INTEGER(BIO *bp, ASN1_INTEGER *bs, char *buf, int size);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4297,3 +4297,4 @@ UI_method_set_data_duplicator           4239	1_1_1	EXIST::FUNCTION:UI
 UI_dup_user_data                        4240	1_1_1	EXIST::FUNCTION:UI
 UI_method_get_data_destructor           4241	1_1_1	EXIST::FUNCTION:UI
 ERR_load_strings_const                  4242	1_1_1	EXIST::FUNCTION:
+ASN1_TIME_to_tm                         4243	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This works with ASN1_UTCTIME and ASN1_GENERALIZED_TIME

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
