### PR TITLE
Fix memory leaks in CTLOG_new_from_base64

### DIFF
--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -24,7 +24,7 @@
 static int ct_base64_decode(const char *in, unsigned char **out)
 {
     size_t inlen = strlen(in);
-    int outlen;
+    int outlen, i;
     unsigned char *outbuf = NULL;
 
     if (inlen == 0) {
@@ -45,9 +45,11 @@ static int ct_base64_decode(const char *in, unsigned char **out)
         goto err;
     }
 
-    /* Subtract padding bytes from |outlen| */
-    while (in[--inlen] == '=') {
+    /* Subtract padding bytes from |outlen|.  Any more than 2 is malformed. */
+    i = 0;
+    while (in[--inlen] == '=' && i < 2) {
         --outlen;
+        ++i;
     }
 
     *out = outbuf;
@@ -132,7 +134,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 int CTLOG_new_from_base64(CTLOG **ct_log, const char *pkey_base64, const char *name)
 {
     unsigned char *pkey_der = NULL;
-    int pkey_der_len = ct_base64_decode(pkey_base64, &pkey_der);
+    int pkey_der_len;
     const unsigned char *p;
     EVP_PKEY *pkey = NULL;
 
@@ -141,7 +143,8 @@ int CTLOG_new_from_base64(CTLOG **ct_log, const char *pkey_base64, const char *n
         return 0;
     }
 
-    if (pkey_der_len <= 0) {
+    pkey_der_len = ct_base64_decode(pkey_base64, &pkey_der);
+    if (pkey_der_len < 0) {
         CTerr(CT_F_CTLOG_NEW_FROM_BASE64, CT_R_LOG_CONF_INVALID_KEY);
         return 0;
     }

--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -47,9 +47,10 @@ static int ct_base64_decode(const char *in, unsigned char **out)
 
     /* Subtract padding bytes from |outlen|.  Any more than 2 is malformed. */
     i = 0;
-    while (in[--inlen] == '=' && i < 2) {
+    while (in[--inlen] == '=') {
         --outlen;
-        ++i;
+        if (++i > 2)
+            goto err;
     }
 
     *out = outbuf;

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -345,7 +345,7 @@ end:
 #define SETUP_CT_TEST_FIXTURE() SETUP_TEST_FIXTURE(CT_TEST_FIXTURE, set_up)
 #define EXECUTE_CT_TEST() EXECUTE_TEST(execute_cert_test, tear_down)
 
-static int test_no_scts_in_certificate()
+static int test_no_scts_in_certificate(void)
 {
     SETUP_CT_TEST_FIXTURE();
     fixture.certs_dir = certs_dir;
@@ -355,7 +355,7 @@ static int test_no_scts_in_certificate()
     EXECUTE_CT_TEST();
 }
 
-static int test_one_sct_in_certificate()
+static int test_one_sct_in_certificate(void)
 {
     SETUP_CT_TEST_FIXTURE();
     fixture.certs_dir = certs_dir;
@@ -367,7 +367,7 @@ static int test_one_sct_in_certificate()
     EXECUTE_CT_TEST();
 }
 
-static int test_multiple_scts_in_certificate()
+static int test_multiple_scts_in_certificate(void)
 {
     SETUP_CT_TEST_FIXTURE();
     fixture.certs_dir = certs_dir;
@@ -379,7 +379,7 @@ static int test_multiple_scts_in_certificate()
     EXECUTE_CT_TEST();
 }
 
-static int test_verify_one_sct()
+static int test_verify_one_sct(void)
 {
     SETUP_CT_TEST_FIXTURE();
     fixture.certs_dir = certs_dir;
@@ -390,7 +390,7 @@ static int test_verify_one_sct()
     EXECUTE_CT_TEST();
 }
 
-static int test_verify_multiple_scts()
+static int test_verify_multiple_scts(void)
 {
     SETUP_CT_TEST_FIXTURE();
     fixture.certs_dir = certs_dir;
@@ -401,7 +401,7 @@ static int test_verify_multiple_scts()
     EXECUTE_CT_TEST();
 }
 
-static int test_verify_fails_for_future_sct()
+static int test_verify_fails_for_future_sct(void)
 {
     SETUP_CT_TEST_FIXTURE();
     fixture.epoch_time_in_ms = 1365094800000; /* Apr 4 17:00:00 2013 GMT */
@@ -414,7 +414,7 @@ static int test_verify_fails_for_future_sct()
     EXECUTE_CT_TEST();
 }
 
-static int test_decode_tls_sct()
+static int test_decode_tls_sct(void)
 {
     const unsigned char tls_sct_list[] = "\x00\x78" /* length of list */
         "\x00\x76"
@@ -442,7 +442,7 @@ static int test_decode_tls_sct()
     EXECUTE_CT_TEST();
 }
 
-static int test_encode_tls_sct()
+static int test_encode_tls_sct(void)
 {
     const char log_id[] = "3xwuwRUAlFJHqWFoMl3cXHlZ6PfG04j8AC4LvT9012Q=";
     const uint64_t timestamp = 1;
@@ -470,7 +470,7 @@ static int test_encode_tls_sct()
  * Tests that the CT_POLICY_EVAL_CTX default time is approximately now.
  * Allow +-10 minutes, as it may compensate for clock skew.
  */
-static int test_default_ct_policy_eval_ctx_time_is_now()
+static int test_default_ct_policy_eval_ctx_time_is_now(void)
 {
     int success = 0;
     CT_POLICY_EVAL_CTX *ct_policy_ctx = CT_POLICY_EVAL_CTX_new();

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -487,6 +487,20 @@ end:
     return success;
 }
 
+static int test_ctlog_from_base64(void)
+{
+    CTLOG *log = NULL;
+    const char notb64[] = "\01\02\03\04";
+    const char pad[] = "====";
+    const char name[] = "name";
+
+    /* We expect these to both fail! */
+    if (!TEST_true(!CTLOG_new_from_base64(&log, notb64, name))
+        || !TEST_true(!CTLOG_new_from_base64(&log, pad, name)))
+        return 0;
+    return 1;
+}
+
 int test_main(int argc, char *argv[])
 {
     if ((ct_dir = getenv("CT_DIR")) == NULL)
@@ -503,6 +517,7 @@ int test_main(int argc, char *argv[])
     ADD_TEST(test_decode_tls_sct);
     ADD_TEST(test_encode_tls_sct);
     ADD_TEST(test_default_ct_policy_eval_ctx_time_is_now);
+    ADD_TEST(test_ctlog_from_base64);
 
     return run_tests(argv[0]);
 }


### PR DESCRIPTION
Move the call to ct_base64_decode(), which allocates, until after
the check for NULL output parameter.

Also adjust for a fencepost error, as ct_base64_decode() can return
0 along with allocated storage, e.g., for input of "====".

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
