### PR TITLE
test/exptest.c: stop marking progress with a period

### DIFF
--- a/test/exptest.c
+++ b/test/exptest.c
@@ -173,12 +173,9 @@ static int test_mod_exp(int round)
         || !TEST_true(BN_mod_exp_mont_consttime(r_mont_const, a, b, m, ctx, NULL)))
         goto err;
 
-    if (TEST_int_eq(BN_cmp(r_simple, r_mont), 0)
-        && TEST_int_eq(BN_cmp(r_simple, r_recp), 0)
-        && TEST_int_eq(BN_cmp(r_simple, r_mont_const), 0)) {
-        printf(".");
-        fflush(stdout);
-    } else {
+    if (!TEST_int_eq(BN_cmp(r_simple, r_mont), 0)
+        || !TEST_int_eq(BN_cmp(r_simple, r_recp), 0)
+        || !TEST_int_eq(BN_cmp(r_simple, r_mont_const), 0)) {
         if (BN_cmp(r_simple, r_mont) != 0)
             fprintf(stderr, "simple and mont results differ\n");
         if (BN_cmp(r_simple, r_mont_const) != 0)


### PR DESCRIPTION
Because we now have TAP output for every mod_exp round, there's no
more need to mark the round with outputting a period.

##### Checklist
- [x] tests are added or updated
