### PR TITLE
Increase x509 reference

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3930,7 +3930,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
                 return (0);
         }
         sk_X509_push(ctx->extra_certs, (X509 *)parg);
-        
+        CRYPTO_add(&((X509 *)parg)->references, 1, CRYPTO_LOCK_X509);
         break;
 
     case SSL_CTRL_GET_EXTRA_CHAIN_CERTS:

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3930,6 +3930,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
                 return (0);
         }
         sk_X509_push(ctx->extra_certs, (X509 *)parg);
+        CRYPTO_add(&((X509 *)parg)->references, 1, CRYPTO_LOCK_X509);
         break;
 
     case SSL_CTRL_GET_EXTRA_CHAIN_CERTS:

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3930,7 +3930,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
                 return (0);
         }
         sk_X509_push(ctx->extra_certs, (X509 *)parg);
-        CRYPTO_add(&((X509 *)parg)->references, 1, CRYPTO_LOCK_X509);
+        
         break;
 
     case SSL_CTRL_GET_EXTRA_CHAIN_CERTS:


### PR DESCRIPTION
when SSL_CTX_add_extra_chain_cert called
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
