### PR TITLE
Fix serverinfo bug

### DIFF
--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -8,7 +8,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 #include "ssl_locl.h"
 #include "packet_locl.h"
 #include <openssl/bio.h>
@@ -904,7 +903,7 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
     int ret = 0;
     BIO *bin = NULL;
     size_t num_extensions = 0, contextoff = 0;
-    unsigned int version = 0;
+    unsigned int version;
 
     if (ctx == NULL || file == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_FILE, ERR_R_PASSED_NULL_PARAMETER);
@@ -1010,10 +1009,8 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
         extension = NULL;
     }
 
-    assert(version != 0);
-    if (version != 0)
-        ret = SSL_CTX_use_serverinfo_ex(ctx, version, serverinfo,
-                                        serverinfo_length);
+    ret = SSL_CTX_use_serverinfo_ex(ctx, version, serverinfo,
+                                    serverinfo_length);
  end:
     /* SSL_CTX_use_serverinfo makes a local copy of the serverinfo. */
     OPENSSL_free(name);


### PR DESCRIPTION
Commit 1608d658af416 (PR #3373) attempted to fix a compile error with clang. The problem was a (bogus) uninit variable "version". Although the warning was bogus the code shouldn't actually have been using "version" at that point anyway. The function SSL_CTX_use_serverinfo_file() transparently converts all v1 format data into v2 format data before calling SSL_CTX_use_serverinfo_ex() - so the version should *always* be v2 regardless of the value of the "version" variable. It's ok though, because another bug meant that SSL_CTX_use_serverinfo_ex() ignored the version field anyway and always processed the data as v2!!

Although there were tests involving both v1 and v2 data they were all loaded via SSL_CTX_use_serverinfo_file() and the two bugs together masked the problem.

This PR reverts the original commit and fixes both bugs. It also introduces a new test which would have caught the problem.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
