### PR TITLE
Fix an uninit read in igetest

### DIFF
--- a/test/igetest.c
+++ b/test/igetest.c
@@ -362,6 +362,7 @@ static int test_bi_ige_garble1(void)
     unsigned int n;
     size_t matches;
 
+    memcpy(iv, saved_iv, sizeof iv);
     AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
     AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
     AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,
@@ -392,6 +393,7 @@ static int test_bi_ige_garble2(void)
     unsigned int n;
     size_t matches;
 
+    memcpy(iv, saved_iv, sizeof iv);
     AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
     AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
     AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,
@@ -422,6 +424,7 @@ static int test_bi_ige_garble3(void)
     unsigned int n;
     size_t matches;
 
+    memcpy(iv, saved_iv, sizeof iv);
     AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
     AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
     AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,


### PR DESCRIPTION
Introduced by commit 0e534337b

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
