### PR TITLE
perlasm/x86_64-xlate.pl: work around problem with hex constants in masm.

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -212,8 +212,9 @@ my %globals;
 	    }
 	    sprintf "\$%s",$self->{value};
 	} else {
-	    $self->{value} =~ s/0x([0-9a-f]+)/0$1h/ig if ($masm);
-	    sprintf "%s",$self->{value};
+	    my $value = $self->{value};
+	    $value =~ s/0x([0-9a-f]+)/0$1h/ig if ($masm);
+	    sprintf "%s",$value;
 	}
     }
 }


### PR DESCRIPTION
Perl, multiple versions, for some reason occasionally takes issue with
letter b[?] in ox([0-9a-f]+) regex. As result some constants, such as
0xb1 came out wrong when generating code for MASM. Fixes GH#3241.
