### PR TITLE
[openssl/master] Add SSL_SESSION_dup with docs

### DIFF
--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -3,14 +3,16 @@
 =head1 NAME
 
 SSL_SESSION_new,
+SSL_SESSION_dup,
 SSL_SESSION_up_ref,
-SSL_SESSION_free - create, free and manage SSL_SESSION structures
+SSL_SESSION_free - create, duplicate, free and manage SSL_SESSION structures
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
  SSL_SESSION *SSL_SESSION_new(void);
+ SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src);
  int SSL_SESSION_up_ref(SSL_SESSION *ses);
  void SSL_SESSION_free(SSL_SESSION *session);
 
@@ -26,6 +28,10 @@ SSL_SESSION_free() decrements the reference count of B<session> and removes
 the B<SSL_SESSION> structure pointed to by B<session> and frees up the allocated
 memory, if the reference count has reached 0.
 If B<session> is NULL nothing is done.
+
+SSL_SESSION_dup() returns a pointer to a clone of the passed in SSL_SESSION.
+The reference count on the returned object is set to 1.  The session returned
+is not referenced by any caches.
 
 =head1 NOTES
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1516,6 +1516,7 @@ __owur int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
 __owur int SSL_SESSION_is_resumable(const SSL_SESSION *s);
 
 __owur SSL_SESSION *SSL_SESSION_new(void);
+__owur SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src);
 const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s,
                                         unsigned int *len);
 const unsigned char *SSL_SESSION_get0_id_context(const SSL_SESSION *s,

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -246,6 +246,11 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
     return NULL;
 }
 
+SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src)
+{
+    return ssl_session_dup(src, src->ext.tick != NULL ? 1 : 0);
+}
+
 const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s, unsigned int *len)
 {
     if (len)

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -450,3 +450,4 @@ SSL_set_block_padding                   450	1_1_1	EXIST::FUNCTION:
 SSL_set_record_padding_callback_arg     451	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_record_padding_callback_arg 452	1_1_1	EXIST::FUNCTION:
 SSL_CTX_use_serverinfo_ex               453	1_1_1	EXIST::FUNCTION:
+SSL_SESSION_dup                         454	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
CLA: trivial

The current approach to cloning a session is to serialize/deserialize with `d2i_SSL_SESSION` and `i2d_SSL_SESSION`.  Exposing the dup function makes this much faster.  

In a benchmark we ran that serialized 4 sessions, 3 without tickets, comparing the d2i/i2d (clone) vs. the dup function:
```
============================================================================
clone                                                       68.46us   14.61K
dup                                             9163.29%   747.06ns    1.34M
============================================================================
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
