### PR TITLE
Rearrange test/recipes/95-test_*.t to use skip_all

### DIFF
--- a/test/recipes/95-test_external_boringssl.t
+++ b/test/recipes/95-test_external_boringssl.t
@@ -15,7 +15,6 @@ setup("test_external_boringssl");
 
 plan skip_all => "No external tests in this configuration"
     if disabled("external-tests");
-
 plan skip_all => "BoringSSL runner not detected"
     if !$ENV{BORING_RUNNER_DIR};
 

--- a/test/recipes/95-test_external_krb5.t
+++ b/test/recipes/95-test_external_krb5.t
@@ -13,13 +13,11 @@ use OpenSSL::Test qw/:DEFAULT data_file srctop_file/;
 
 setup("test_external_krb5");
 
+plan skip_all "No external tests in this configuration"
+    if disabled("external-tests");
+plan skip_all "krb5 not available"
+    if ! -f srctop_file("krb5", "README");
+
 plan tests => 1;
 
-SKIP: {
-    skip "No external tests in this configuration", 1
-        if disabled("external-tests");
-    skip "krb5 not available", 1
-        if ! -f srctop_file("krb5", "README");
-
-    ok(run(cmd([data_file("krb5.sh")])), "running krb5 tests");
-}
+ok(run(cmd([data_file("krb5.sh")])), "running krb5 tests");

--- a/test/recipes/95-test_external_pyca.t
+++ b/test/recipes/95-test_external_pyca.t
@@ -15,18 +15,14 @@ setup("test_external");
 
 plan skip_all => "No external tests in this configuration"
     if disabled("external-tests");
+plan skip_all "PYCA tests not available on Windows or VMS"
+    if $^O =~ /^(VMS|MSWin32)$/;
+plan skip_all "PYCA Cryptography not available"
+    if ! -f srctop_file("pyca-cryptography", "setup.py");
+plan skip_all "PYCA tests only available in a shared build"
+    if disabled("shared");
 
 plan tests => 1;
 
-SKIP: {
-    skip "PYCA Cryptography not available", 1
-        if ! -f srctop_file("pyca-cryptography", "setup.py");
-    skip "PYCA tests not available on Windows or VMS", 1
-        if $^O =~ /^(VMS|MSWin32)$/;
-    skip "PYCA tests only available in a shared build", 1
-        if disabled("shared");
-
-    ok(run(cmd(["sh", data_file("cryptography.sh")])),
-        "running Python Cryptography tests");
-}
-
+ok(run(cmd(["sh", data_file("cryptography.sh")])),
+   "running Python Cryptography tests");


### PR DESCRIPTION
The conditions to skip these recipes entirely don't show in a
non-verbose test harness output.  We prefer to know, so use skip_all,
as it is a little bit more verbose.

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
