### PR TITLE
Don't perform long actions if outfile is invalid

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -144,6 +144,10 @@ int dhparam_main(int argc, char **argv)
     if (g && !num)
         num = DEFBITS;
 
+    out = bio_open_default(outfile, 'w', outformat);
+    if (out == NULL)
+        goto end;
+
 # ifndef OPENSSL_NO_DSA
     if (dsaparam && g) {
         BIO_printf(bio_err,
@@ -265,10 +269,6 @@ int dhparam_main(int argc, char **argv)
 
         /* dh != NULL */
     }
-
-    out = bio_open_default(outfile, 'w', outformat);
-    if (out == NULL)
-        goto end;
 
     if (text) {
         DHparams_print(out, dh);


### PR DESCRIPTION
There are also other instances of this, but I didn't have time to find all of them this after, may update later with some others

Basically this arises in situations like `openssl dhparam -out /etc/nginx/ssl/dhparam.pem 4096` if the `/etc/ngainc/ssl` directory doesn't exist. The program will do the action (which takes a long time), then fail with no output AFTER the action has finished (often several minutes or hours later). Other utilities such as `genrsa` and `rsa` seem to catch this, but a few like `dhparam` don't.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
