### PR TITLE
Add BN support to the test infrastructure.

### DIFF
--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -167,8 +167,8 @@ static int x9_62_test_internal(int nid, const char *r_in, const char *s_in)
     if (!TEST_true(BN_dec2bn(&r, r_in)) || !TEST_true(BN_dec2bn(&s, s_in)))
         goto x962_int_err;
     ECDSA_SIG_get0(signature, &sig_r, &sig_s);
-    if (!TEST_int_eq(BN_cmp(sig_r, r), 0)
-            || !TEST_int_eq(BN_cmp(sig_s, s), 0))
+    if (!TEST_BN_eq(sig_r, r)
+            || !TEST_BN_eq(sig_s, s))
         goto x962_int_err;
 
     /* verify the signature */

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -345,7 +345,7 @@ static int prime_field_tests(void)
     /* G_y value taken from the standard: */
     if (!TEST_true(BN_hex2bn(&z,                         "23a62855"
                                  "3168947d59dcc912042351377ac5fb32"))
-        || !TEST_int_eq(0, BN_cmp(y, z))
+        || !TEST_BN_eq(y, z)
         || !TEST_int_eq(EC_GROUP_get_degree(group), 160)
         || !group_order_tests(group)
         || !TEST_ptr(P_160 = EC_GROUP_new(EC_GROUP_method_of(group)))
@@ -380,7 +380,7 @@ static int prime_field_tests(void)
     /* G_y value taken from the standard: */
     if (!TEST_true(BN_hex2bn(&z,                 "07192B95FFC8DA78"
                                  "631011ED6B24CDD573F977A11E794811"))
-        || !TEST_int_eq(0, BN_cmp(y, z))
+        || !TEST_BN_eq(y, z)
         || !TEST_true(BN_add(yplusone, y, BN_value_one()))
     /*
      * When (x, y) is on the curve, (x, y + 1) is, as it happens, not,
@@ -422,7 +422,7 @@ static int prime_field_tests(void)
     /* G_y value taken from the standard: */
     if (!TEST_true(BN_hex2bn(&z,         "BD376388B5F723FB4C22DFE6"
                                  "CD4375A05A07476444D5819985007E34"))
-        || !TEST_int_eq(0, BN_cmp(y, z))
+        || !TEST_BN_eq(y, z)
         || !TEST_true(BN_add(yplusone, y, BN_value_one()))
     /*
      * When (x, y) is on the curve, (x, y + 1) is, as it happens, not,
@@ -465,7 +465,7 @@ static int prime_field_tests(void)
     /* G_y value taken from the standard: */
     if (!TEST_true(BN_hex2bn(&z, "4FE342E2FE1A7F9B8EE7EB4A7C0F9E16"
                                  "2BCE33576B315ECECBB6406837BF51F5"))
-        || !TEST_int_eq(0, BN_cmp(y, z))
+        || !TEST_BN_eq(y, z)
         || !TEST_true(BN_add(yplusone, y, BN_value_one()))
     /*
      * When (x, y) is on the curve, (x, y + 1) is, as it happens, not,
@@ -514,7 +514,7 @@ static int prime_field_tests(void)
     if (!TEST_true(BN_hex2bn(&z, "3617DE4A96262C6F5D9E98BF9292DC29"
                                  "F8F41DBD289A147CE9DA3113B5F0B8C0"
                                  "0A60B1CE1D7E819D7A431D7C90EA0E5F"))
-        || !TEST_int_eq(0, BN_cmp(y, z))
+        || !TEST_BN_eq(y, z)
         || !TEST_true(BN_add(yplusone, y, BN_value_one()))
     /*
      * When (x, y) is on the curve, (x, y + 1) is, as it happens, not,
@@ -573,7 +573,7 @@ static int prime_field_tests(void)
                                  "98F54449579B446817AFBD17273E662C"
                                  "97EE72995EF42640C550B9013FAD0761"
                                  "353C7086A272C24088BE94769FD16650"))
-        || !TEST_int_eq(0, BN_cmp(y, z))
+        || !TEST_BN_eq(y, z)
         || !TEST_true(BN_add(yplusone, y, BN_value_one()))
     /*
      * When (x, y) is on the curve, (x, y + 1) is, as it happens, not,
@@ -607,7 +607,7 @@ static int prime_field_tests(void)
 
     if (!TEST_true(EC_GROUP_get_order(group, z, ctx))
         || !TEST_true(BN_add(y, z, BN_value_one()))
-        || !TEST_false(BN_is_odd(y))
+        || !TEST_BN_even(y)
         || !TEST_true(BN_rshift1(y, y)))
         goto err;
     scalars[0] = y;         /* (group order + 1)/2, so y*Q + y*Q = Q */
@@ -905,7 +905,7 @@ static int char2_curve_test(int n)
     BIO_printf(bio_out, "\n");
     /* G_y value taken from the standard: */
     if (!TEST_true(BN_hex2bn(&z, test->y))
-        || !TEST_int_eq(0, BN_cmp(y, z)))
+        || !TEST_BN_eq(y, z))
         goto err;
 # else
     /*
@@ -953,7 +953,7 @@ static int char2_curve_test(int n)
         points[2] = Q;
 
         if (!TEST_true(BN_add(y, z, BN_value_one()))
-            || !TEST_false(BN_is_odd(y))
+            || !TEST_BN_even(y)
             || !TEST_true(BN_rshift1(y, y)))
             goto err;
         scalars[0] = y;         /* (group order + 1)/2, so y*Q + y*Q = Q */

--- a/test/exptest.c
+++ b/test/exptest.c
@@ -109,7 +109,7 @@ static int test_mod_exp_zero()
     if (!TEST_true(BN_mod_exp_mont_word(r, one_word, p, m, ctx, NULL)))
         goto err;
 
-    if (!TEST_true(BN_is_zero(r))) {
+    if (!TEST_BN_eq_zero(r)) {
         fprintf(stderr, "BN_mod_exp_mont_word failed:\n");
         fprintf(stderr, "1 ** 0 mod 1 = r (should be 0)\n");
         BN_print_var(r);
@@ -173,15 +173,15 @@ static int test_mod_exp(int round)
         || !TEST_true(BN_mod_exp_mont_consttime(r_mont_const, a, b, m, ctx, NULL)))
         goto err;
 
-    if (!TEST_int_eq(BN_cmp(r_simple, r_mont), 0)
-        || !TEST_int_eq(BN_cmp(r_simple, r_recp), 0)
-        || !TEST_int_eq(BN_cmp(r_simple, r_mont_const), 0)) {
+    if (!TEST_BN_eq(r_simple, r_mont)
+        || !TEST_BN_eq(r_simple, r_recp)
+        || !TEST_BN_eq(r_simple, r_mont_const)) {
         if (BN_cmp(r_simple, r_mont) != 0)
-            fprintf(stderr, "simple and mont results differ\n");
+            TEST_info("simple and mont results differ");
         if (BN_cmp(r_simple, r_mont_const) != 0)
-            fprintf(stderr, "simple and mont const time results differ\n");
+            TEST_info("simple and mont const time results differ");
         if (BN_cmp(r_simple, r_recp) != 0)
-            fprintf(stderr, "simple and recp results differ\n");
+            TEST_info("simple and recp results differ");
 
         BN_print_var(a);
         BN_print_var(b);

--- a/test/srptest.c
+++ b/test/srptest.c
@@ -70,7 +70,7 @@ static int run_srp(const char *username, const char *client_pass,
     /* Server random */
     RAND_bytes(rand_tmp, sizeof(rand_tmp));
     b = BN_bin2bn(rand_tmp, sizeof(rand_tmp), NULL);
-    if (!TEST_false(BN_is_zero(b)))
+    if (!TEST_BN_ne_zero(b))
         goto end;
     showbn("b", b);
 
@@ -84,7 +84,7 @@ static int run_srp(const char *username, const char *client_pass,
     /* Client random */
     RAND_bytes(rand_tmp, sizeof(rand_tmp));
     a = BN_bin2bn(rand_tmp, sizeof(rand_tmp), NULL);
-    if (!TEST_false(BN_is_zero(a)))
+    if (!TEST_BN_ne_zero(a))
         goto end;
     showbn("a", a);
 
@@ -107,7 +107,7 @@ static int run_srp(const char *username, const char *client_pass,
     Kserver = SRP_Calc_server_key(Apub, v, u, b, GN->N);
     showbn("Server's key", Kserver);
 
-    if (!TEST_int_eq(BN_cmp(Kclient, Kserver), 0))
+    if (!TEST_BN_eq(Kclient, Kserver))
         goto end;
 
     ret = 1;
@@ -130,19 +130,16 @@ end:
 static int check_bn(const char *name, const BIGNUM *bn, const char *hexbn)
 {
     BIGNUM *tmp = NULL;
+    int r;
 
     if (!TEST_true(BN_hex2bn(&tmp, hexbn)))
         return 0;
 
-    if (!TEST_int_eq(BN_cmp(bn, tmp), 0)) {
-        TEST_info("Unexpected %s value", name);
-        showbn("expecting", tmp);
-        showbn("received", bn);
-        BN_free(tmp);
-        return 0;
-    }
+    if (BN_cmp(bn, tmp) != 0)
+        TEST_error("unexpected %s value", name);
+    r = TEST_BN_eq(bn, tmp);
     BN_free(tmp);
-    return 1;
+    return r;
 }
 
 /* SRP test vectors from RFC5054 */

--- a/test/test_test.c
+++ b/test/test_test.c
@@ -17,6 +17,7 @@
 #include <openssl/opensslconf.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>
+#include <openssl/bn.h>
 
 #include "e_os.h"
 #include "testutil.h"
@@ -287,6 +288,74 @@ static int test_memory_overflow(void)
     return TEST(0, TEST_mem_eq(p, strlen(p), q, strlen(q)));
 }
 
+static int test_bignum(void)
+{
+    BIGNUM *a = NULL, *b = NULL, *c = NULL;
+    int r = 0;
+
+    if (!TEST(1, TEST_int_eq(BN_dec2bn(&a, "0"), 1))
+        | !TEST(1, TEST_BN_eq_word(a, 0))
+        | !TEST(0, TEST_BN_eq_word(a, 30))
+        | !TEST(1, TEST_BN_abs_eq_word(a, 0))
+        | !TEST(0, TEST_BN_eq_one(a))
+        | !TEST(1, TEST_BN_eq_zero(a))
+        | !TEST(0, TEST_BN_ne_zero(a))
+        | !TEST(1, TEST_BN_le_zero(a))
+        | !TEST(0, TEST_BN_lt_zero(a))
+        | !TEST(1, TEST_BN_ge_zero(a))
+        | !TEST(0, TEST_BN_gt_zero(a))
+        | !TEST(1, TEST_BN_even(a))
+        | !TEST(0, TEST_BN_odd(a))
+        | !TEST(1, TEST_int_eq(BN_dec2bn(&b, "1"), 1))
+        | !TEST(1, TEST_BN_eq_word(b, 1))
+        | !TEST(1, TEST_BN_eq_one(b))
+        | !TEST(0, TEST_BN_abs_eq_word(b, 0))
+        | !TEST(1, TEST_BN_abs_eq_word(b, 1))
+        | !TEST(0, TEST_BN_eq_zero(b))
+        | !TEST(1, TEST_BN_ne_zero(b))
+        | !TEST(0, TEST_BN_le_zero(b))
+        | !TEST(0, TEST_BN_lt_zero(b))
+        | !TEST(1, TEST_BN_ge_zero(b))
+        | !TEST(1, TEST_BN_gt_zero(b))
+        | !TEST(0, TEST_BN_even(b))
+        | !TEST(1, TEST_BN_odd(b))
+        | !TEST(1, TEST_int_eq(BN_dec2bn(&c, "-334739439"), 10))
+        | !TEST(0, TEST_BN_eq_word(c, 334739439))
+        | !TEST(1, TEST_BN_abs_eq_word(c, 334739439))
+        | !TEST(0, TEST_BN_eq_zero(c))
+        | !TEST(1, TEST_BN_ne_zero(c))
+        | !TEST(1, TEST_BN_le_zero(c))
+        | !TEST(1, TEST_BN_lt_zero(c))
+        | !TEST(0, TEST_BN_ge_zero(c))
+        | !TEST(0, TEST_BN_gt_zero(c))
+        | !TEST(0, TEST_BN_even(c))
+        | !TEST(1, TEST_BN_odd(c))
+        | !TEST(1, TEST_BN_eq(a, a))
+        | !TEST(0, TEST_BN_ne(a, a))
+        | !TEST(0, TEST_BN_eq(a, b))
+        | !TEST(1, TEST_BN_ne(a, b))
+        | !TEST(0, TEST_BN_lt(a, c))
+        | !TEST(1, TEST_BN_lt(c, b))
+        | !TEST(0, TEST_BN_lt(b, c))
+        | !TEST(0, TEST_BN_le(a, c))
+        | !TEST(1, TEST_BN_le(c, b))
+        | !TEST(0, TEST_BN_le(b, c))
+        | !TEST(1, TEST_BN_gt(a, c))
+        | !TEST(0, TEST_BN_gt(c, b))
+        | !TEST(1, TEST_BN_gt(b, c))
+        | !TEST(1, TEST_BN_ge(a, c))
+        | !TEST(0, TEST_BN_ge(c, b))
+        | !TEST(1, TEST_BN_ge(b, c)))
+        goto err;
+
+    r = 1;
+err:
+    BN_free(a);
+    BN_free(b);
+    BN_free(c);
+    return r;
+}
+
 static int test_long_output(void)
 {
     const char *p = "1234567890123456789012345678901234567890123456789012";
@@ -381,6 +450,7 @@ void register_tests(void)
     ADD_TEST(test_string);
     ADD_TEST(test_memory);
     ADD_TEST(test_memory_overflow);
+    ADD_TEST(test_bignum);
     ADD_TEST(test_long_output);
     ADD_TEST(test_messages);
     ADD_TEST(test_single_eval);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -14,6 +14,7 @@
 
 #include <openssl/err.h>
 #include <openssl/e_os2.h>
+#include <openssl/bn.h>
 
 /*-
  * Simple unit tests should implement register_tests().
@@ -239,6 +240,27 @@ int test_true(const char *file, int line, const char *s, int b);
 int test_false(const char *file, int line, const char *s, int b);
 
 /*
+ * Comparisons between BIGNUMs.
+ * BIGNUMS can be compared against other BIGNUMs or zero.
+ * Some additional equality tests against 1 & specific values are provided.
+ * Tests for parity are included as well.
+ */
+DECLARE_COMPARISONS(BIGNUM *, BN)
+int test_BN_eq_zero(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_ne_zero(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_lt_zero(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_le_zero(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_gt_zero(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_ge_zero(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_eq_one(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_odd(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_even(const char *file, int line, const char *s, const BIGNUM *a);
+int test_BN_eq_word(const char *file, int line, const char *bns, const char *ws,
+                    const BIGNUM *a, BN_ULONG w);
+int test_BN_abs_eq_word(const char *file, int line, const char *bns,
+                        const char *ws, const BIGNUM *a, BN_ULONG w);
+
+/*
  * Pretty print a failure message.
  * These should not be called directly, use the TEST_xxx macros below instead.
  */
@@ -331,6 +353,20 @@ void test_openssl_errors(void);
 
 # define TEST_true(a)         test_true(__FILE__, __LINE__, #a, (a) != 0)
 # define TEST_false(a)        test_false(__FILE__, __LINE__, #a, (a) != 0)
+
+# define TEST_BN_eq(a, b)     test_BN_eq(__FILE__, __LINE__, #a, #b, a, b)
+# define TEST_BN_ne(a, b)     test_BN_ne(__FILE__, __LINE__, #a, #b, a, b)
+# define TEST_BN_eq_zero(a)   test_BN_eq_zero(__FILE__, __LINE__, #a, a)
+# define TEST_BN_ne_zero(a)   test_BN_ne_zero(__FILE__, __LINE__, #a, a)
+# define TEST_BN_lt_zero(a)   test_BN_lt_zero(__FILE__, __LINE__, #a, a)
+# define TEST_BN_gt_zero(a)   test_BN_gt_zero(__FILE__, __LINE__, #a, a)
+# define TEST_BN_le_zero(a)   test_BN_le_zero(__FILE__, __LINE__, #a, a)
+# define TEST_BN_ge_zero(a)   test_BN_ge_zero(__FILE__, __LINE__, #a, a)
+# define TEST_BN_eq_one(a)    test_BN_eq_one(__FILE__, __LINE__, #a, a)
+# define TEST_BN_eq_word(a, w) test_BN_eq_word(__FILE__, __LINE__, #a, #w, a, w)
+# define TEST_BN_abs_eq_word(a, w) test_BN_abs_eq_word(__FILE__, __LINE__, #a, #w, a, w)
+# define TEST_BN_odd(a)       test_BN_odd(__FILE__, __LINE__, #a, a)
+# define TEST_BN_even(a)      test_BN_even(__FILE__, __LINE__, #a, a)
 
 /*
  * TEST_error(desc, ...) prints an informative error message in the standard

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -356,6 +356,10 @@ void test_openssl_errors(void);
 
 # define TEST_BN_eq(a, b)     test_BN_eq(__FILE__, __LINE__, #a, #b, a, b)
 # define TEST_BN_ne(a, b)     test_BN_ne(__FILE__, __LINE__, #a, #b, a, b)
+# define TEST_BN_lt(a, b)     test_BN_lt(__FILE__, __LINE__, #a, #b, a, b)
+# define TEST_BN_gt(a, b)     test_BN_gt(__FILE__, __LINE__, #a, #b, a, b)
+# define TEST_BN_le(a, b)     test_BN_le(__FILE__, __LINE__, #a, #b, a, b)
+# define TEST_BN_ge(a, b)     test_BN_ge(__FILE__, __LINE__, #a, #b, a, b)
 # define TEST_BN_eq_zero(a)   test_BN_eq_zero(__FILE__, __LINE__, #a, a)
 # define TEST_BN_ne_zero(a)   test_BN_ne_zero(__FILE__, __LINE__, #a, a)
 # define TEST_BN_lt_zero(a)   test_BN_lt_zero(__FILE__, __LINE__, #a, a)

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -628,12 +628,12 @@ int test_BN_abs_eq_word(const char *file, int line, const char *bns,
     if (a != NULL && BN_abs_is_word(a, w))
         return 1;
     bw = BN_new();
-    aa = BN_new();
-    BN_copy(aa, a);
+    aa = BN_dup(a);
     BN_set_negative(aa, 0);
     BN_set_word(bw, w);
     test_fail_bignum_message(NULL, file, line, "BIGNUM", bns, ws, "abs==",
                              aa, bw);
     BN_free(bw);
+    BN_free(aa);
     return 0;
 }


### PR DESCRIPTION

- [x] tests are added or updated

This includes support for:

- comparisions between pairs of BIGNUMs
- comparisions between BIGNUMs and zero
- equality comparison between BIGNUMs and one
- equality comparisons between BIGNUMs and constants
- parity checks for BIGNUMs
