### PR TITLE
Remove OPENSSL_SSL_TRACE_CRYPTO and support TLSv1.3 content types in SSL_trace

### DIFF
--- a/doc/man3/SSL_CTX_set_msg_callback.pod
+++ b/doc/man3/SSL_CTX_set_msg_callback.pod
@@ -2,7 +2,11 @@
 
 =head1 NAME
 
-SSL_CTX_set_msg_callback, SSL_CTX_set_msg_callback_arg, SSL_set_msg_callback, SSL_set_msg_callback_arg - install callback for observing protocol messages
+SSL_CTX_set_msg_callback,
+SSL_CTX_set_msg_callback_arg,
+SSL_set_msg_callback,
+SSL_set_msg_callback_arg
+- install callback for observing protocol messages
 
 =head1 SYNOPSIS
 
@@ -19,7 +23,8 @@ SSL_CTX_set_msg_callback, SSL_CTX_set_msg_callback_arg, SSL_set_msg_callback, SS
 SSL_CTX_set_msg_callback() or SSL_set_msg_callback() can be used to
 define a message callback function I<cb> for observing all SSL/TLS
 protocol messages (such as handshake messages) that are received or
-sent.  SSL_CTX_set_msg_callback_arg() and SSL_set_msg_callback_arg()
+sent, as well as other events that occur during processing.
+SSL_CTX_set_msg_callback_arg() and SSL_set_msg_callback_arg()
 can be used to set argument I<arg> to the callback function, which is
 available for arbitrary application use.
 
@@ -27,10 +32,10 @@ SSL_CTX_set_msg_callback() and SSL_CTX_set_msg_callback_arg() specify
 default settings that will be copied to new B<SSL> objects by
 L<SSL_new(3)>. SSL_set_msg_callback() and
 SSL_set_msg_callback_arg() modify the actual settings of an B<SSL>
-object. Using a B<0> pointer for I<cb> disables the message callback.
+object. Using a B<NULL> pointer for I<cb> disables the message callback.
 
-When I<cb> is called by the SSL/TLS library for a protocol message,
-the function arguments have the following meaning:
+When I<cb> is called by the SSL/TLS library the function arguments have the
+following meaning:
 
 =over 4
 
@@ -42,23 +47,23 @@ when a protocol message has been sent.
 =item I<version>
 
 The protocol version according to which the protocol message is
-interpreted by the library. Currently, this is one of
-B<SSL2_VERSION>, B<SSL3_VERSION> and B<TLS1_VERSION> (for SSL 2.0, SSL
-3.0 and TLS 1.0, respectively).
+interpreted by the library such as B<TLS1_3_VERSION>, B<TLS1_2_VERSION> etc.
+This is set to 0 for the SSL3_RT_HEADER pseudo content type (see NOTES below).
 
 =item I<content_type>
 
-In the case of SSL 2.0, this is always B<0>.  In the case of SSL 3.0
-or TLS 1.0, this is one of the B<ContentType> values defined in the
-protocol specification (B<change_cipher_spec(20)>, B<alert(21)>,
-B<handshake(22)>; but never B<application_data(23)> because the
-callback will only be called for protocol messages).
+This is one of the content type values defined in the protocol specification
+(B<SSL3_RT_CHANGE_CIPHER_SPEC>, B<SSL3_RT_ALERT>, B<SSL3_RT_HANDSHAKE>; but never
+B<SSL3_RT_APPLICATION_DATA> because the callback will only be called for protocol
+messages). Alternatively it may be a "pseudo" content type. These pseudo
+content types are used to signal some other event in the processing of data (see
+NOTES below).
 
 =item I<buf>, I<len>
 
-I<buf> points to a buffer containing the protocol message, which
-consists of I<len> bytes. The buffer is no longer valid after the
-callback function has returned.
+I<buf> points to a buffer containing the protocol message or other data (in the
+case of pseudo content types), which consists of I<len> bytes. The buffer is no
+longer valid after the callback function has returned.
 
 =item I<ssl>
 
@@ -87,13 +92,37 @@ necessarily the protocol version used by the sender of the message: If
 a TLS 1.0 ClientHello message is received by an SSL 3.0-only server,
 I<version> will be B<SSL3_VERSION>.
 
+Pseudo content type values may be sent at various points during the processing
+of data. The following pseudo content types are currently defined:
+
+=over 4
+
+=item B<SSL3_RT_HEADER>
+
+Used when a record is sent or received. The B<buf> contains the record header
+bytes only.
+
+=item B<SSL3_RT_INNER_CONTENT_TYPE>
+
+Used when an encrypted TLSv1.3 record is sent or received. In encrypted TLSv1.3
+records the content type in the record header is always
+SSL3_RT_APPLICATION_DATA. The real content type for the record is contained in
+an "inner" content type. B<buf> contains the encoded "inner" content type byte.
+
+=back
+
 =head1 SEE ALSO
 
 L<ssl(7)>, L<SSL_new(3)>
 
+=head1 HISTORY
+
+The pseudo content type B<SSL3_RT_INNER_CONTENT_TYPE> was added in OpenSSL
+1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -223,8 +223,9 @@ extern "C" {
 # define TLS1_RT_CRYPTO_IV               (TLS1_RT_CRYPTO | 0x7)
 # define TLS1_RT_CRYPTO_FIXED_IV         (TLS1_RT_CRYPTO | 0x8)
 
-/* Pseudo content type for SSL/TLS header info */
+/* Pseudo content types for SSL/TLS header info */
 # define SSL3_RT_HEADER                  0x100
+# define SSL3_RT_INNER_CONTENT_TYPE      0x101
 
 # define SSL3_AL_WARNING                 1
 # define SSL3_AL_FATAL                   2

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -995,6 +995,13 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
             s->msg_callback(1, 0, SSL3_RT_HEADER, recordstart,
                             SSL3_RT_HEADER_LENGTH, s,
                             s->msg_callback_arg);
+
+            if (SSL_TREAT_AS_TLS13(s) && s->enc_write_ctx != NULL) {
+                unsigned char ctype = type;
+
+                s->msg_callback(1, s->version, SSL3_RT_INNER_CONTENT_TYPE,
+                                &ctype, 1, s, s->msg_callback_arg);
+            }
         }
 
         if (!WPACKET_finish(thispkt)) {

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -247,11 +247,6 @@ int ssl3_get_record(SSL *s)
                 }
             } else {
                 /* SSLv3+ style record */
-                /*
-                 * TODO(TLS1.3): This callback only provides the "outer" record
-                 * type to the callback. Somehow we need to pass the "inner"
-                 * record type
-                 */
                 if (s->msg_callback)
                     s->msg_callback(0, 0, SSL3_RT_HEADER, p, 5, s,
                                     s->msg_callback_arg);
@@ -643,6 +638,9 @@ int ssl3_get_record(SSL *s)
                 SSLerr(SSL_F_SSL3_GET_RECORD, SSL_R_BAD_RECORD_TYPE);
                 goto f_err;
             }
+            if (s->msg_callback)
+                s->msg_callback(0, s->version, SSL3_RT_INNER_CONTENT_TYPE,
+                                &thisrr->data[end], 1, s, s->msg_callback_arg);
         }
 
         if (thisrr->length > SSL3_RT_MAX_PLAIN_LENGTH) {

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -315,25 +315,6 @@ int tls1_change_cipher_state(SSL *s, int which)
         SSLerr(SSL_F_TLS1_CHANGE_CIPHER_STATE, ERR_R_INTERNAL_ERROR);
         goto err2;
     }
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (s->msg_callback) {
-        int wh = which & SSL3_CC_WRITE ? TLS1_RT_CRYPTO_WRITE : 0;
-        if (*mac_secret_size)
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_MAC,
-                            mac_secret, *mac_secret_size,
-                            s, s->msg_callback_arg);
-        if (c->key_len)
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_KEY,
-                            key, c->key_len, s, s->msg_callback_arg);
-        if (k) {
-            if (EVP_CIPHER_mode(c) == EVP_CIPH_GCM_MODE)
-                wh |= TLS1_RT_CRYPTO_FIXED_IV;
-            else
-                wh |= TLS1_RT_CRYPTO_IV;
-            s->msg_callback(2, s->version, wh, iv, k, s, s->msg_callback_arg);
-        }
-    }
-#endif
 
 #ifdef SSL_DEBUG
     printf("which = %04X\nkey=", which);
@@ -528,22 +509,6 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
     fprintf(stderr, "Master Secret:\n");
     BIO_dump_fp(stderr, (char *)s->session->master_key,
                 SSL3_MASTER_SECRET_SIZE);
-#endif
-
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (s->msg_callback) {
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_PREMASTER,
-                        p, len, s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_CLIENT_RANDOM,
-                        s->s3->client_random, SSL3_RANDOM_SIZE,
-                        s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_SERVER_RANDOM,
-                        s->s3->server_random, SSL3_RANDOM_SIZE,
-                        s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_MASTER,
-                        s->session->master_key,
-                        SSL3_MASTER_SECRET_SIZE, s, s->msg_callback_arg);
-    }
 #endif
 
     *secret_size = SSL3_MASTER_SECRET_SIZE;

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1494,6 +1494,12 @@ void SSL_trace(int write_p, int version, int content_type,
                        msg[msglen - 2] << 8 | msg[msglen - 1]);
         }
         break;
+
+    case SSL3_RT_INNER_CONTENT_TYPE:
+        BIO_printf(bio, "  Inner Content Type = %s (%d)",
+                   ssl_trace_str(msg[0], ssl_content_tbl), msg[0]);
+        break;
+
     case SSL3_RT_HANDSHAKE:
         if (!ssl_print_handshake(bio, ssl, ssl->server ? write_p : !write_p,
                                  msg, msglen, 4))

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -568,21 +568,6 @@ static ssl_trace_tbl ssl_psk_kex_modes_tbl[] = {
     {TLSEXT_KEX_MODE_KE_DHE, "psk_dhe_ke"}
 };
 
-static ssl_trace_tbl ssl_crypto_tbl[] = {
-    {TLS1_RT_CRYPTO_PREMASTER, "Premaster Secret"},
-    {TLS1_RT_CRYPTO_CLIENT_RANDOM, "Client Random"},
-    {TLS1_RT_CRYPTO_SERVER_RANDOM, "Server Random"},
-    {TLS1_RT_CRYPTO_MASTER, "Master Secret"},
-    {TLS1_RT_CRYPTO_MAC | TLS1_RT_CRYPTO_WRITE, "Write Mac Secret"},
-    {TLS1_RT_CRYPTO_MAC | TLS1_RT_CRYPTO_READ, "Read Mac Secret"},
-    {TLS1_RT_CRYPTO_KEY | TLS1_RT_CRYPTO_WRITE, "Write Key"},
-    {TLS1_RT_CRYPTO_KEY | TLS1_RT_CRYPTO_READ, "Read Key"},
-    {TLS1_RT_CRYPTO_IV | TLS1_RT_CRYPTO_WRITE, "Write IV"},
-    {TLS1_RT_CRYPTO_IV | TLS1_RT_CRYPTO_READ, "Read IV"},
-    {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_WRITE, "Write IV (fixed part)"},
-    {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_READ, "Read IV (fixed part)"}
-};
-
 static ssl_trace_tbl ssl_key_update_tbl[] = {
     {SSL_KEY_UPDATE_NOT_REQUESTED, "update_not_requested"},
     {SSL_KEY_UPDATE_REQUESTED, "update_requested"}
@@ -1489,12 +1474,6 @@ void SSL_trace(int write_p, int version, int content_type,
     const unsigned char *msg = buf;
     BIO *bio = arg;
 
-    if (write_p == 2) {
-        BIO_puts(bio, "Session ");
-        ssl_print_hex(bio, 0,
-                      ssl_trace_str(content_type, ssl_crypto_tbl), msg, msglen);
-        return;
-    }
     switch (content_type) {
     case SSL3_RT_HEADER:
         {

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -321,20 +321,6 @@ static int derive_secret_key_and_iv(SSL *s, int sending, const EVP_MD *md,
         goto err;
     }
 
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (s->msg_callback) {
-        int wh = sending ? TLS1_RT_CRYPTO_WRITE : 0;
-
-        if (ciph->key_len)
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_KEY,
-                            key, ciph->key_len, s, s->msg_callback_arg);
-
-        wh |= TLS1_RT_CRYPTO_IV;
-        s->msg_callback(2, s->version, wh, iv, ivlen, s,
-                        s->msg_callback_arg);
-    }
-#endif
-
     return 1;
  err:
     OPENSSL_cleanse(key, sizeof(key));


### PR DESCRIPTION
The "enable-ssl-trace" option  is a useful and documented Configure option. There is an additional macro used in the code OPENSSL_SSL_TRACE_CRYPTO which you cannot turn on directly via Configure (you have to use "-DOPENSSL_SSL_TRACE_CRYPTO") which causes addition items to be traced via SSL_trace(). However defining that macro fails to compile in master or in any 1.1.0 version. 

This PR removes this unused option. It also adds support for TLSv1.3 inner content types. Without this all TLSv1.3 records appear as "application data", even though in reality the inner content type may be different.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
