### PR TITLE
Single part sign/verify functions.

### DIFF
--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -205,8 +205,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
         goto err;
     }
 
-    if (!EVP_DigestSignUpdate(ctx, buf_in, inl)
-        || !EVP_DigestSignFinal(ctx, buf_out, &outl)) {
+    if (!EVP_DigestSign(ctx, buf_out, &outl, buf_in, inl)) {
         outl = 0;
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ERR_R_EVP_LIB);
         goto err;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -135,6 +135,14 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
     return 1;
 }
 
+int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
+                   const unsigned char *tbs, size_t tbslen)
+{
+    if (sigret != NULL && EVP_DigestSignUpdate(ctx, tbs, tbslen) <= 0)
+        return 0;
+    return EVP_DigestSignFinal(ctx, sigret, siglen);
+}
+
 int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
                           size_t siglen)
 {
@@ -166,4 +174,12 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
     if (vctx || !r)
         return r;
     return EVP_PKEY_verify(ctx->pctx, sig, siglen, md, mdlen);
+}
+
+int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
+                     size_t siglen, const unsigned char *tbs, size_t tbslen)
+{
+    if (EVP_DigestVerifyUpdate(ctx, tbs, tbslen) <= 0)
+        return -1;
+    return EVP_DigestVerifyFinal(ctx, sigret, siglen);
 }

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-EVP_DigestSignInit, EVP_DigestSignUpdate, EVP_DigestSignFinal - EVP signing functions
+EVP_DigestSignInit, EVP_DigestSignUpdate, EVP_DigestSignFinal,
+EVP_DigestSign - EVP signing functions
 
 =head1 SYNOPSIS
 
@@ -12,6 +13,10 @@ EVP_DigestSignInit, EVP_DigestSignUpdate, EVP_DigestSignFinal - EVP signing func
                         const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
  int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
  int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sig, size_t *siglen);
+
+ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret,
+                    size_t *siglen, const unsigned char *tbs,
+                    size_t tbslen);
 
 =head1 DESCRIPTION
 
@@ -35,12 +40,16 @@ B<siglen> parameter should contain the length of the B<sig> buffer, if the
 call is successful the signature is written to B<sig> and the amount of data
 written to B<siglen>.
 
+EVP_DigestSign() signs B<tbslen> bytes of data at B<tbs> and places the
+signature in B<sig> and its length in B<siglen> in a simiilar way to
+EVP_DigestSignFinal().
+
 =head1 RETURN VALUES
 
-EVP_DigestSignInit() EVP_DigestSignUpdate() and EVP_DigestSignaFinal() return
-1 for success and 0 or a negative value for failure. In particular a return
-value of -2 indicates the operation is not supported by the public key
-algorithm.
+EVP_DigestSignInit(), EVP_DigestSignUpdate(), EVP_DigestSignaFinal() and
+EVP_DigestSign() return 1 for success and 0 or a negative value for failure. In
+particular a return value of -2 indicates the operation is not supported by the
+public key algorithm.
 
 The error codes can be obtained from L<ERR_get_error(3)>.
 
@@ -49,6 +58,10 @@ The error codes can be obtained from L<ERR_get_error(3)>.
 The B<EVP> interface to digital signatures should almost always be used in
 preference to the low level interfaces. This is because the code then becomes
 transparent to the algorithm used and much more flexible.
+
+EVP_DigestSign() is a single part operation which signs a single block of data
+in one function. It is equivalent to calling EVP_DigestSignUpdate() and
+EVP_DigestSignFinal().
 
 In previous versions of OpenSSL there was a link between message digest types
 and public key algorithms. This meant that "clone" digests such as EVP_dss1()

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-EVP_DigestVerifyInit, EVP_DigestVerifyUpdate, EVP_DigestVerifyFinal - EVP signature verification functions
+EVP_DigestVerifyInit, EVP_DigestVerifyUpdate, EVP_DigestVerifyFinal,
+EVP_DigestVerify - EVP signature verification functions
 
 =head1 SYNOPSIS
 
@@ -11,7 +12,10 @@ EVP_DigestVerifyInit, EVP_DigestVerifyUpdate, EVP_DigestVerifyFinal - EVP signat
  int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                         const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
  int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
- int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen);
+ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
+                           size_t siglen);
+ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
+                      size_t siglen, const unsigned char *tbs, size_t tbslen);
 
 =head1 DESCRIPTION
 
@@ -31,16 +35,19 @@ using a macro.
 EVP_DigestVerifyFinal() verifies the data in B<ctx> against the signature in
 B<sig> of length B<siglen>.
 
+EVP_DogestVerify() verifies B<tbslen> bytes at B<tbs> against the signature
+in B<sig> of length B<siglen>.
+
 =head1 RETURN VALUES
 
 EVP_DigestVerifyInit() and EVP_DigestVerifyUpdate() return 1 for success and 0
 for failure.
 
-EVP_DigestVerifyFinal() returns 1 for success; any other value indicates
-failure.  A return value of zero indicates that the signature did not verify
-successfully (that is, tbs did not match the original data or the signature had
-an invalid form), while other values indicate a more serious error (and
-sometimes also indicate an invalid signature form).
+EVP_DigestVerifyFinal() and EVP_DigestVerify() return 1 for success; any other
+value indicates failure.  A return value of zero indicates that the signature
+did not verify successfully (that is, B<tbs> did not match the original data or
+the signature had an invalid form), while other values indicate a more serious
+error (and sometimes also indicate an invalid signature form).
 
 The error codes can be obtained from L<ERR_get_error(3)>.
 
@@ -49,6 +56,10 @@ The error codes can be obtained from L<ERR_get_error(3)>.
 The B<EVP> interface to digital signatures should almost always be used in
 preference to the low level interfaces. This is because the code then becomes
 transparent to the algorithm used and much more flexible.
+
+EVP_DigesVerify() is a single part operation which verifies a single block of
+data in one function. It is equivalent to calling EVP_DigestVerifyUpdate() and
+EVP_DigestVerifyFinal().
 
 In previous versions of OpenSSL there was a link between message digest types
 and public key algorithms. This meant that "clone" digests such as EVP_dss1()

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -603,8 +603,16 @@ __owur int EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm,
 __owur int EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s,
                          EVP_PKEY *pkey);
 
+__owur int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret,
+                          size_t *siglen, const unsigned char *tbs,
+                          size_t tbslen);
+
 __owur int EVP_VerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sigbuf,
                            unsigned int siglen, EVP_PKEY *pkey);
+
+__owur int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
+                            size_t siglen, const unsigned char *tbs,
+                            size_t tbslen);
 
 /*__owur*/ int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                   const EVP_MD *type, ENGINE *e,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4290,3 +4290,5 @@ ESS_SIGNING_CERT_V2_dup                 4232	1_1_1	EXIST::FUNCTION:TS
 ESS_CERT_ID_V2_new                      4233	1_1_1	EXIST::FUNCTION:TS
 PEM_read_bio_ex                         4234	1_1_1	EXIST::FUNCTION:
 PEM_bytes_read_bio_secmem               4235	1_1_1	EXIST::FUNCTION:
+EVP_DigestSign                          4236	1_1_1	EXIST::FUNCTION:
+EVP_DigestVerify                        4237	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

This adds two new functions EVP_DigestSign and EVP_DigestVerify. They sign or verify a single block of data supplied to the function. Currently they just call EVP_Digest*Update and EVP_Digest*Final, this will be changed in a separate PR to allow this operation to be customised by the EVP_PKEY_METHOD structure.

The purpose of these APIs is to support algorithms that do not support a  streaming (update/final) interface such as PureEdDSA as used in Ed25519.

There aren't any specific tests for these new functions but they are tested as part of some existing tests (e.g. TLS, certificate verify and CMS tests). When Ed25519 is added I'll add explicit tests to evp_test but that is waiting on #3324