### PR TITLE
Verify that only NULL compression is sent in TLSv1.3 ClientHello

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1755,9 +1755,22 @@ static int tls_early_post_process_client_hello(SSL *s, int *pal)
      * algorithms from the client, starting at q.
      */
     s->s3->tmp.new_compression = NULL;
+    if (SSL_IS_TLS13(s)) {
+        /*
+         * We already checked above that the NULL compression method appears in
+         * the list. Now we check there aren't any others (which is illegal in
+         * a TLSv1.3 ClientHello.
+         */
+        if (clienthello->compressions_len != 1) {
+            al = SSL_AD_ILLEGAL_PARAMETER;
+            SSLerr(SSL_F_TLS_EARLY_POST_PROCESS_CLIENT_HELLO,
+                   SSL_R_INVALID_COMPRESSION_ALGORITHM);
+            goto err;
+        }
+    }
 #ifndef OPENSSL_NO_COMP
     /* This only happens if we have a cache hit */
-    if (s->session->compress_meth != 0 && !SSL_IS_TLS13(s)) {
+    else if (s->session->compress_meth != 0) {
         int m, comp_id = s->session->compress_meth;
         unsigned int k;
         /* Perform sanity checks on resumed compression algorithm */
@@ -1793,8 +1806,7 @@ static int tls_early_post_process_client_hello(SSL *s, int *pal)
         }
     } else if (s->hit) {
         comp = NULL;
-    } else if (ssl_allow_compression(s) && s->ctx->comp_methods
-                   && !SSL_IS_TLS13(s)) {
+    } else if (ssl_allow_compression(s) && s->ctx->comp_methods) {
         /* See if we have a match */
         int m, nn, v, done = 0;
         unsigned int o;

--- a/test/recipes/70-test_comp.t
+++ b/test/recipes/70-test_comp.t
@@ -1,0 +1,113 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file srctop_dir bldtop_dir/;
+use OpenSSL::Test::Utils;
+use File::Temp qw(tempfile);
+use TLSProxy::Proxy;
+
+my $test_name = "test_comp";
+setup($test_name);
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS|MSWin32)$/;
+
+plan skip_all => "$test_name needs the dynamic engine feature enabled"
+    if disabled("engine") || disabled("dynamic-engine");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLSv1.3 enabled"
+    if disabled("tls1_3");
+
+$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
+$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
+
+use constant {
+    MULTIPLE_COMPRESSIONS => 0,
+    NON_NULL_COMPRESSION => 1
+};
+my $testtype;
+
+my $proxy = TLSProxy::Proxy->new(
+    undef,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
+);
+
+$proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 4;
+
+SKIP: {
+    skip "TLSv1.2 disabled", 2 if disabled("tls1_2");
+    #Test 1: Check that sending multiple compression methods in a TLSv1.2
+    #        ClientHello succeeds
+    $proxy->clear();
+    $proxy->filter(\&add_comp_filter);
+    $proxy->clientflags("-no_tls1_3");
+    $testtype = MULTIPLE_COMPRESSIONS;
+    $proxy->start();
+    ok(TLSProxy::Message->success(), "Non null compression");
+
+    #Test 2: NULL compression method must be present in TLSv1.2
+    $proxy->clear();
+    $proxy->filter(\&add_comp_filter);
+    $proxy->clientflags("-no_tls1_3");
+    $testtype = NON_NULL_COMPRESSION;
+    $proxy->start();
+    ok(TLSProxy::Message->fail(), "NULL compression missing");
+}
+
+SKIP: {
+    skip "TLSv1.3 disabled", 2 if disabled("tls1_3");
+    #Test 3: Check that sending multiple compression methods in a TLSv1.3
+    #        ClientHello fails
+    $proxy->clear();
+    $proxy->filter(\&add_comp_filter);
+    $testtype = MULTIPLE_COMPRESSIONS;
+    $proxy->start();
+    ok(TLSProxy::Message->fail(), "Non null compression (TLSv1.3)");
+
+    #Test 4: NULL compression method must be present in TLSv1.2
+    $proxy->clear();
+    $proxy->filter(\&add_comp_filter);
+    $proxy->clientflags("-no_tls1_3");
+    $testtype = NON_NULL_COMPRESSION;
+    $proxy->start();
+    ok(TLSProxy::Message->fail(), "NULL compression missing (TLSv1.3)");
+}
+
+sub add_comp_filter
+{
+    my $proxy = shift;
+    my $flight;
+    my $message;
+    my @comp;
+
+    # Only look at the ClientHello
+    return if $proxy->flight != 0;
+
+    $message = ${$proxy->message_list}[0];
+
+    return if (!defined $message
+               || $message->mt != TLSProxy::Message::MT_CLIENT_HELLO);
+
+    if ($testtype == MULTIPLE_COMPRESSIONS) {
+        @comp = (
+            0x00, #Null compression method
+            0xff); #Unknown compression
+    } else {
+        @comp = (0xff); #Unknown compression
+    }
+    $message->comp_meths(\@comp);
+    $message->comp_meth_len(scalar @comp);
+    $message->repack();
+}


### PR DESCRIPTION
It is illegal in a TLSv1.3 ClientHello to send anything other than the
NULL compression method. We should send an alert if we find anything else
there. Previously we were ignoring this error.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
