### PR TITLE
Remove support for OPENSSL_SSL_TRACE_CRYPTO

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -228,23 +228,6 @@ int ssl3_change_cipher_state(SSL *s, int which)
     if (!EVP_CipherInit_ex(dd, c, NULL, key, iv, (which & SSL3_CC_WRITE)))
         goto err2;
 
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (s->msg_callback) {
-
-        int wh = which & SSL3_CC_WRITE ?
-            TLS1_RT_CRYPTO_WRITE : TLS1_RT_CRYPTO_READ;
-        s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_MAC,
-                        mac_secret, EVP_MD_size(m), s, s->msg_callback_arg);
-        if (c->key_len)
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_KEY,
-                            key, c->key_len, s, s->msg_callback_arg);
-        if (k) {
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_IV,
-                            iv, k, s, s->msg_callback_arg);
-        }
-    }
-#endif
-
     OPENSSL_cleanse(exp_key, sizeof(exp_key));
     OPENSSL_cleanse(exp_iv, sizeof(exp_iv));
     return (1);
@@ -462,9 +445,6 @@ int ssl3_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     int i, ret = 0;
     unsigned int n;
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    unsigned char *tmpout = out;
-#endif
 
     if (ctx == NULL) {
         SSLerr(SSL_F_SSL3_GENERATE_MASTER_SECRET, ERR_R_MALLOC_FAILURE);
@@ -493,21 +473,6 @@ int ssl3_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
     }
     EVP_MD_CTX_free(ctx);
 
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (ret > 0 && s->msg_callback) {
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_PREMASTER,
-                        p, len, s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_CLIENT_RANDOM,
-                        s->s3->client_random, SSL3_RANDOM_SIZE,
-                        s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_SERVER_RANDOM,
-                        s->s3->server_random, SSL3_RANDOM_SIZE,
-                        s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_MASTER,
-                        tmpout, SSL3_MASTER_SECRET_SIZE,
-                        s, s->msg_callback_arg);
-    }
-#endif
     OPENSSL_cleanse(buf, sizeof(buf));
     return (ret);
 }

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -313,25 +313,6 @@ int tls1_change_cipher_state(SSL *s, int which)
         SSLerr(SSL_F_TLS1_CHANGE_CIPHER_STATE, ERR_R_INTERNAL_ERROR);
         goto err2;
     }
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (s->msg_callback) {
-        int wh = which & SSL3_CC_WRITE ? TLS1_RT_CRYPTO_WRITE : 0;
-        if (*mac_secret_size)
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_MAC,
-                            mac_secret, *mac_secret_size,
-                            s, s->msg_callback_arg);
-        if (c->key_len)
-            s->msg_callback(2, s->version, wh | TLS1_RT_CRYPTO_KEY,
-                            key, c->key_len, s, s->msg_callback_arg);
-        if (k) {
-            if (EVP_CIPHER_mode(c) == EVP_CIPH_GCM_MODE)
-                wh |= TLS1_RT_CRYPTO_FIXED_IV;
-            else
-                wh |= TLS1_RT_CRYPTO_IV;
-            s->msg_callback(2, s->version, wh, iv, k, s, s->msg_callback_arg);
-        }
-    }
-#endif
 
 #ifdef SSL_DEBUG
     printf("which = %04X\nkey=", which);
@@ -526,22 +507,6 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
     fprintf(stderr, "Master Secret:\n");
     BIO_dump_fp(stderr, (char *)s->session->master_key,
                 SSL3_MASTER_SECRET_SIZE);
-#endif
-
-#ifdef OPENSSL_SSL_TRACE_CRYPTO
-    if (s->msg_callback) {
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_PREMASTER,
-                        p, len, s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_CLIENT_RANDOM,
-                        s->s3->client_random, SSL3_RANDOM_SIZE,
-                        s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_SERVER_RANDOM,
-                        s->s3->server_random, SSL3_RANDOM_SIZE,
-                        s, s->msg_callback_arg);
-        s->msg_callback(2, s->version, TLS1_RT_CRYPTO_MASTER,
-                        s->session->master_key,
-                        SSL3_MASTER_SECRET_SIZE, s, s->msg_callback_arg);
-    }
 #endif
 
     return (SSL3_MASTER_SECRET_SIZE);

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -547,21 +547,6 @@ static ssl_trace_tbl ssl_ctype_tbl[] = {
     {66, "ecdsa_fixed_ecdh"}
 };
 
-static ssl_trace_tbl ssl_crypto_tbl[] = {
-    {TLS1_RT_CRYPTO_PREMASTER, "Premaster Secret"},
-    {TLS1_RT_CRYPTO_CLIENT_RANDOM, "Client Random"},
-    {TLS1_RT_CRYPTO_SERVER_RANDOM, "Server Random"},
-    {TLS1_RT_CRYPTO_MASTER, "Master Secret"},
-    {TLS1_RT_CRYPTO_MAC | TLS1_RT_CRYPTO_WRITE, "Write Mac Secret"},
-    {TLS1_RT_CRYPTO_MAC | TLS1_RT_CRYPTO_READ, "Read Mac Secret"},
-    {TLS1_RT_CRYPTO_KEY | TLS1_RT_CRYPTO_WRITE, "Write Key"},
-    {TLS1_RT_CRYPTO_KEY | TLS1_RT_CRYPTO_READ, "Read Key"},
-    {TLS1_RT_CRYPTO_IV | TLS1_RT_CRYPTO_WRITE, "Write IV"},
-    {TLS1_RT_CRYPTO_IV | TLS1_RT_CRYPTO_READ, "Read IV"},
-    {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_WRITE, "Write IV (fixed part)"},
-    {TLS1_RT_CRYPTO_FIXED_IV | TLS1_RT_CRYPTO_READ, "Read IV (fixed part)"}
-};
-
 static void ssl_print_hex(BIO *bio, int indent, const char *name,
                           const unsigned char *msg, size_t msglen)
 {
@@ -1283,12 +1268,6 @@ void SSL_trace(int write_p, int version, int content_type,
     const unsigned char *msg = buf;
     BIO *bio = arg;
 
-    if (write_p == 2) {
-        BIO_puts(bio, "Session ");
-        ssl_print_hex(bio, 0,
-                      ssl_trace_str(content_type, ssl_crypto_tbl), msg, msglen);
-        return;
-    }
     switch (content_type) {
     case SSL3_RT_HEADER:
         {


### PR DESCRIPTION
This trace option does not appear in Configure as a separate option and is
undocumented. It can be switched on using "-DOPENSSL_SSL_TRACE_CRYPTO",
however this does not compile in master or in any 1.1.0 released version.

This is a backport to 1.1.0 of the just the OPENSSL_SSL_TRACE_CRYPTO portion of #3408.
