### PR TITLE
HRR bug fixes

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2680,6 +2680,7 @@ int ERR_load_SSL_strings(void);
 # define SSL_R_NO_CERTIFICATES_RETURNED                   176
 # define SSL_R_NO_CERTIFICATE_ASSIGNED                    177
 # define SSL_R_NO_CERTIFICATE_SET                         179
+# define SSL_R_NO_CHANGE_FOLLOWING_HRR                    205
 # define SSL_R_NO_CIPHERS_AVAILABLE                       181
 # define SSL_R_NO_CIPHERS_SPECIFIED                       183
 # define SSL_R_NO_CIPHER_MATCH                            185

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -646,6 +646,7 @@ static ERR_STRING_DATA SSL_str_reasons[] = {
     {ERR_REASON(SSL_R_NO_CERTIFICATES_RETURNED), "no certificates returned"},
     {ERR_REASON(SSL_R_NO_CERTIFICATE_ASSIGNED), "no certificate assigned"},
     {ERR_REASON(SSL_R_NO_CERTIFICATE_SET), "no certificate set"},
+    {ERR_REASON(SSL_R_NO_CHANGE_FOLLOWING_HRR), "no change following hrr"},
     {ERR_REASON(SSL_R_NO_CIPHERS_AVAILABLE), "no ciphers available"},
     {ERR_REASON(SSL_R_NO_CIPHERS_SPECIFIED), "no ciphers specified"},
     {ERR_REASON(SSL_R_NO_CIPHER_MATCH), "no cipher match"},

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1058,6 +1058,10 @@ static int final_key_share(SSL *s, unsigned int context, int sent, int *al)
     if (!SSL_IS_TLS13(s))
         return 1;
 
+    /* Nothing to do for key_share in an HRR */
+    if ((context & SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST) != 0)
+        return 1;
+
     /*
      * If
      *     we are a client

--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -28,6 +28,11 @@ plan skip_all => "$test_name needs TLS1.3 enabled"
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 
+use constant {
+    COOKIE_ONLY => 0,
+    COOKIE_AND_KEY_SHARE => 1
+};
+
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),
@@ -36,22 +41,31 @@ my $proxy = TLSProxy::Proxy->new(
 );
 
 my $cookieseen = 0;
+my $testtype;
 
 #Test 1: Inserting a cookie into an HRR should see it echoed in the ClientHello
+$testtype = COOKIE_ONLY;
 $proxy->filter(\&cookie_filter);
-$proxy->serverflags("-curves P-256");
+$proxy->serverflags("-curves X25519");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 1;
+plan tests => 2;
+ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
+
+#Test 2: Same as test 1 but should also work where a new key_share is also
+#        required
+$testtype = COOKIE_AND_KEY_SHARE;
+$proxy->clear();
+$proxy->clientflags("-curves P-256:X25519");
+$proxy->serverflags("-curves X25519");
+$proxy->start();
 ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
 
 sub cookie_filter
 {
     my $proxy = shift;
 
-    # We're only interested in the HRR and subsequent ClientHello
-    if ($proxy->flight != 1 && $proxy->flight != 2) {
-        return;
-    }
+    # We're only interested in the HRR and both ClientHellos
+    return if ($proxy->flight > 2);
 
     my $ext = pack "C8",
         0x00, 0x06, #Cookie Length
@@ -60,22 +74,38 @@ sub cookie_filter
         0x04, 0x05;
 
     foreach my $message (@{$proxy->message_list}) {
-        if ($message->mt == TLSProxy::Message::MT_HELLO_RETRY_REQUEST) {
-
+        if ($message->mt == TLSProxy::Message::MT_HELLO_RETRY_REQUEST
+                && ${$message->records}[0]->flight == 1) {
+            $message->delete_extension(TLSProxy::Message::EXT_KEY_SHARE)
+                if ($testtype == COOKIE_ONLY);
             $message->set_extension(TLSProxy::Message::EXT_COOKIE, $ext);
             $message->repack();
-        } elsif ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO
-                    && ${$message->records}[0]->flight == 2) {
-            #cmp can behave differently dependent on locale
-            no locale;
-            my $cookie =
-                $message->extension_data->{TLSProxy::Message::EXT_COOKIE};
+        } elsif ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO) {
+            if (${$message->records}[0]->flight == 0) {
+                if ($testtype == COOKIE_ONLY) {
+                    my $ext = pack "C7",
+                        0x00, 0x05, #List Length
+                        0x00, 0x17, #P-256
+                        0x00, 0x01, #key_exchange data length
+                        0xff;       #Dummy key_share data
+                    # Trick the server into thinking we got an unacceptable
+                    # key_share
+                    $message->set_extension(
+                        TLSProxy::Message::EXT_KEY_SHARE, $ext);
+                    $message->repack();
+                }
+            } else {
+                #cmp can behave differently dependent on locale
+                no locale;
+                my $cookie =
+                    $message->extension_data->{TLSProxy::Message::EXT_COOKIE};
 
-            return if !defined($cookie);
+                return if !defined($cookie);
 
-            return if ($cookie cmp $ext) != 0;
+                return if ($cookie cmp $ext) != 0;
 
-            $cookieseen = 1;
+                $cookieseen = 1;
+            }
         }
     }
 }

--- a/util/TLSProxy/Message.pm
+++ b/util/TLSProxy/Message.pm
@@ -86,6 +86,7 @@ use constant {
     # (i.e. not read), and even then only when enabled. We use it to test
     # handling of duplicate extensions.
     EXT_DUPLICATE_EXTENSION => 0xfde8,
+    EXT_UNKNOWN => 0xfffe,
     #Unknown extension that should appear last
     EXT_FORCE_LAST => 0xffff
 };


### PR DESCRIPTION
I found a couple of bugs in our HRR handling.

Bug 1, is that the handshake was failing if an HRR was sent with a cookie in it then it only worked if a key_share was also present.

Bug 2 was only exposed by fixing bug 1: we were not checking that an HRR resulted in a change to ClientHello2, i.e. it is not valid for ClientHello1 and ClientHello2 to be the same.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
