### PR TITLE
Fix compile error/warning in packettest.c

### DIFF
--- a/test/packettest.c
+++ b/test/packettest.c
@@ -420,7 +420,7 @@ static int test_PACKET_as_length_prefixed_1()
     unsigned char buf1[BUF_LEN];
     const size_t len = 16;
     unsigned int i;
-    PACKET pkt, exact_pkt, subpkt;
+    PACKET pkt, exact_pkt, subpkt = {0};
 
     buf1[0] = len;
     for (i = 1; i < BUF_LEN; i++)
@@ -443,7 +443,7 @@ static int test_PACKET_as_length_prefixed_2()
     unsigned char buf[1024];
     const size_t len = 516;  /* 0x0204 */
     unsigned int i;
-    PACKET pkt, exact_pkt, subpkt;
+    PACKET pkt, exact_pkt, subpkt = {0};
 
     for (i = 1; i <= 1024; i++)
         buf[i-1] = (i * 2) & 0xff;


### PR DESCRIPTION
Uninitialized value in subpkt; used same fix as in test_PACKET_get_length_prefixed_3()
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
