### PR TITLE
Prefer TAP::Harness over Test::Harness

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -17,7 +17,10 @@ BEGIN {
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
 use File::Basename;
 use if $^O ne "VMS", 'File::Glob' => qw/glob/;
-use Test::Harness qw/runtests $switches/;
+use Module::Load::Conditional qw(can_load);
+
+my $TAP_Harness = can_load({modules => [ 'TAP::Harness' ]})
+    ? 'TAP::Harness' : 'OpenSSL::TAP::Harness';
 
 my $srctop = $ENV{SRCTOP} || $ENV{TOP};
 my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
@@ -25,15 +28,12 @@ my $recipesdir = catdir($srctop, "test", "recipes");
 my $testlib = catdir($srctop, "test", "testlib");
 my $utillib = catdir($srctop, "util");
 
-# It seems that $switches is getting interpreted with 'eval' or something
-# like that, and that we need to take care of backslashes or they will
-# disappear along the way.
-$testlib =~ s|\\|\\\\|g if $^O eq "MSWin32";
-$utillib =~ s|\\|\\\\|g if $^O eq "MSWin32";
-
-# Test::Harness provides the variable $switches to give it
-# switches to be used when it calls our recipes.
-$switches = "-w \"-I$testlib\" \"-I$utillib\"";
+my %tapargs =
+    ( verbosity => $ENV{VERBOSE} || $ENV{V} || $ENV{HARNESS_VERBOSE} ? 1 : 0,
+      lib       => [ $testlib, $utillib ],
+      switches  => '-w',
+      merge     => 1
+    );
 
 my @alltests = find_matching_tests("*");
 my %tests = ();
@@ -81,7 +81,8 @@ foreach my $arg (@ARGV ? @ARGV : ('alltests')) {
     $initial_arg = 0;
 }
 
-runtests(map { abs2rel($_, rel2abs(curdir())); } sort keys %tests);
+my $harness = $TAP_Harness->new(\%tapargs);
+$harness->runtests(map { abs2rel($_, rel2abs(curdir())); } sort keys %tests);
 
 sub find_matching_tests {
     my ($glob) = @_;
@@ -90,4 +91,39 @@ sub find_matching_tests {
         return glob(catfile($recipesdir,"$glob-*.t"));
     }
     return glob(catfile($recipesdir,"*-$glob.t"));
+}
+
+
+# Fake TAP::Harness in case it's not loaded
+use Test::Harness;
+package OpenSSL::TAP::Harness;
+
+sub new {
+    my $class = shift;
+    my %args = %{ shift() };
+
+    return bless { %args }, $class;
+}
+
+sub runtests {
+    my $self = shift;
+
+    my @switches = ();
+    if ($self->{switches}) {
+	push @switches, $self->{switches};
+    }
+    if ($self->{lib}) {
+	foreach (@{$self->{lib}}) {
+	    my $l = $_;
+
+	    # It seems that $switches is getting interpreted with 'eval' or
+	    # something like that, and that we need to take care of backslashes
+	    # or they will disappear along the way.
+	    $l =~ s|\\|\\\\|g if $^O eq "MSWin32";
+	    push @switches, "-I$l";
+	}
+    }
+
+    $Test::Harness::switches = join(' ', @switches);
+    Test::Harness::runtests(@_);
 }


### PR DESCRIPTION
TAP:Harness came along in perl 5.10.1, and since we claim to support
perl 5.10.0 in configuration and testing, we can only load it
conditionally.

The main reason to use TAP::Harness rather than Test::Harness is its
capability to merge stdout and stderr output from the test recipes,
which Test::Harness can't.  The merge gives much more comprehensible
output when testing verbosely.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
