### PR TITLE
Copy custom extension flags in a call to SSL_set_SSL_CTX()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3596,6 +3596,12 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
     if (new_cert == NULL) {
         return NULL;
     }
+
+    if (!custom_exts_copy_flags(&new_cert->custext, &ssl->cert->custext)) {
+        ssl_cert_free(new_cert);
+        return NULL;
+    }
+
     ssl_cert_free(ssl->cert);
     ssl->cert = new_cert;
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2470,6 +2470,8 @@ __owur int custom_ext_add(SSL *s, int context, WPACKET *pkt, X509 *x,
 
 __owur int custom_exts_copy(custom_ext_methods *dst,
                             const custom_ext_methods *src);
+__owur int custom_exts_copy_flags(custom_ext_methods *dst,
+                                  const custom_ext_methods *src);
 void custom_exts_free(custom_ext_methods *exts);
 
 void ssl_comp_free_compression_methods_int(void);

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -231,6 +231,26 @@ int custom_ext_add(SSL *s, int context, WPACKET *pkt, X509 *x, size_t chainidx,
     return 1;
 }
 
+/* Copy the flags from src to dst for any extensions that exist in both */
+int custom_exts_copy_flags(custom_ext_methods *dst,
+                           const custom_ext_methods *src)
+{
+    size_t i;
+    custom_ext_method *methsrc = src->meths;
+
+    for (i = 0; i < src->meths_count; i++, methsrc++) {
+        custom_ext_method *methdst = custom_ext_find(dst, methsrc->role,
+                                                     methsrc->ext_type, NULL);
+
+        if (methdst == NULL)
+            continue;
+
+        methdst->ext_flags = methsrc->ext_flags;
+    }
+
+    return 1;
+}
+
 /* Copy table of custom extensions */
 int custom_exts_copy(custom_ext_methods *dst, const custom_ext_methods *src)
 {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1793,6 +1793,7 @@ static int clntaddnewcb = 0;
 static int clntparsenewcb = 0;
 static int srvaddnewcb = 0;
 static int srvparsenewcb = 0;
+static int snicb = 0;
 
 #define TEST_EXT_TYPE1  0xff00
 
@@ -1886,16 +1887,30 @@ static int new_parse_cb(SSL *s, unsigned int ext_type, unsigned int context,
 
     return 1;
 }
+
+static int sni_cb(SSL *s, int *al, void *arg)
+{
+    SSL_CTX *ctx = (SSL_CTX *)arg;
+
+    if (SSL_set_SSL_CTX(s, ctx) == NULL) {
+        *al = SSL_AD_INTERNAL_ERROR;
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+    snicb++;
+    return SSL_TLSEXT_ERR_OK;
+}
+
 /*
  * Custom call back tests.
  * Test 0: Old style callbacks in TLSv1.2
  * Test 1: New style callbacks in TLSv1.2
- * Test 2: New style callbacks in TLSv1.3. Extensions in CH and EE
- * Test 3: New style callbacks in TLSv1.3. Extensions in CH, SH, EE, Cert + NST
+ * Test 2: New style callbacks in TLSv1.2 with SNI
+ * Test 3: New style callbacks in TLSv1.3. Extensions in CH and EE
+ * Test 4: New style callbacks in TLSv1.3. Extensions in CH, SH, EE, Cert + NST
  */
 static int test_custom_exts(int tst)
 {
-    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL_CTX *cctx = NULL, *sctx = NULL, *sctx2 = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
     static int server = 1;
@@ -1906,18 +1921,27 @@ static int test_custom_exts(int tst)
     /* Reset callback counters */
     clntaddoldcb = clntparseoldcb = srvaddoldcb = srvparseoldcb = 0;
     clntaddnewcb = clntparsenewcb = srvaddnewcb = srvparsenewcb = 0;
+    snicb = 0;
 
     if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
                                        TLS_client_method(), &sctx,
                                        &cctx, cert, privkey)))
         goto end;
 
-    if (tst < 2) {
+    if (tst == 2
+            && !TEST_true(create_ssl_ctx_pair(TLS_server_method(), NULL, &sctx2,
+                                              NULL, cert, privkey)))
+        goto end;
+
+
+    if (tst < 3) {
         SSL_CTX_set_options(cctx, SSL_OP_NO_TLSv1_3);
         SSL_CTX_set_options(sctx, SSL_OP_NO_TLSv1_3);
+        if (sctx2 != NULL)
+            SSL_CTX_set_options(sctx2, SSL_OP_NO_TLSv1_3);
     }
 
-    if (tst == 3) {
+    if (tst == 4) {
         context = SSL_EXT_CLIENT_HELLO
                   | SSL_EXT_TLS1_2_SERVER_HELLO
                   | SSL_EXT_TLS1_3_SERVER_HELLO
@@ -1967,6 +1991,12 @@ static int test_custom_exts(int tst)
                                               new_add_cb, new_free_cb,
                                               &server, new_parse_cb, &server)))
             goto end;
+        if (sctx2 != NULL
+                && !TEST_true(SSL_CTX_add_custom_ext(sctx2, TEST_EXT_TYPE1,
+                                                     context, new_add_cb,
+                                                     new_free_cb, &server,
+                                                     new_parse_cb, &server)))
+            goto end;
     }
 
     /* Should not be able to add duplicates */
@@ -1980,6 +2010,13 @@ static int test_custom_exts(int tst)
                                                   new_parse_cb, &server)))
         goto end;
 
+    if (tst == 2) {
+        /* Set up SNI */
+        if (!TEST_true(SSL_CTX_set_tlsext_servername_callback(sctx, sni_cb))
+                || !TEST_true(SSL_CTX_set_tlsext_servername_arg(sctx, sctx2)))
+            goto end;
+    }
+
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
                                       &clientssl, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -1992,11 +2029,13 @@ static int test_custom_exts(int tst)
                 || srvaddoldcb != 1
                 || srvparseoldcb != 1)
             goto end;
-    } else if (tst == 1 || tst == 2) {
+    } else if (tst == 1 || tst == 2 || tst == 3) {
         if (clntaddnewcb != 1
                 || clntparsenewcb != 1
                 || srvaddnewcb != 1
-                || srvparsenewcb != 1)
+                || srvparsenewcb != 1
+                || (tst != 2 && snicb != 0)
+                || (tst == 2 && snicb != 1))
             goto end;
     } else {
         if (clntaddnewcb != 1
@@ -2012,6 +2051,12 @@ static int test_custom_exts(int tst)
     SSL_free(serverssl);
     SSL_free(clientssl);
     serverssl = clientssl = NULL;
+
+    if (tst == 3) {
+        /* We don't bother with the resumption aspects for this test */
+        testresult = 1;
+        goto end;
+    }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                       NULL, NULL))
@@ -2032,7 +2077,7 @@ static int test_custom_exts(int tst)
                 || srvaddoldcb != 1
                 || srvparseoldcb != 1)
             goto end;
-    } else if (tst == 1 || tst == 2) {
+    } else if (tst == 1 || tst == 2 || tst == 3) {
         if (clntaddnewcb != 2
                 || clntparsenewcb != 2
                 || srvaddnewcb != 2
@@ -2053,6 +2098,7 @@ end:
     SSL_SESSION_free(sess);
     SSL_free(serverssl);
     SSL_free(clientssl);
+    SSL_CTX_free(sctx2);
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     return testresult;
@@ -2161,9 +2207,9 @@ int test_main(int argc, char *argv[])
 # endif
 #endif
 #ifndef OPENSSL_NO_TLS1_3
-    ADD_ALL_TESTS(test_custom_exts, 4);
+    ADD_ALL_TESTS(test_custom_exts, 5);
 #else
-    ADD_ALL_TESTS(test_custom_exts, 2);
+    ADD_ALL_TESTS(test_custom_exts, 3);
 #endif
     ADD_ALL_TESTS(test_serverinfo, 8);
 

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -518,7 +518,7 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
     SSL_CTX *clientctx = NULL;
 
     if (!TEST_ptr(serverctx = SSL_CTX_new(sm))
-            || !TEST_ptr(clientctx = SSL_CTX_new(cm)))
+            || (cctx != NULL && !TEST_ptr(clientctx = SSL_CTX_new(cm))))
         goto err;
 
     if (!TEST_int_eq(SSL_CTX_use_certificate_file(serverctx, certfile,
@@ -533,7 +533,8 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
 #endif
 
     *sctx = serverctx;
-    *cctx = clientctx;
+    if (cctx != NULL)
+        *cctx = clientctx;
     return 1;
 
  err:


### PR DESCRIPTION
The function SSL_set_SSL_CTX() can be used to swap the SSL_CTX used for
a connection as part of an SNI callback. One result of this is that the
s->cert structure is replaced. However this structure contains information
about any custom extensions that have been loaded. In particular flags are
set indicating whether a particular extension has been received in the
ClientHello. By replacing the s->cert structure we lose the custom
extension flag values, and it appears as if a client has not sent those
extensions.

SSL_set_SSL_CTX() should copy any flags for custom extensions that appear
in both the old and the new cert structure.

Fixes #2180 

This version is for master. Versions for 1.1.0 and 1.0.2 coming up.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
