### PR TITLE
Copy custom extension flags in a call to SSL_set_SSL_CTX() (1.1.0)

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3393,6 +3393,12 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
     if (new_cert == NULL) {
         return NULL;
     }
+
+    if (!custom_exts_copy_flags(&new_cert->srv_ext, &ssl->cert->srv_ext)) {
+        ssl_cert_free(new_cert);
+        return NULL;
+    }
+
     ssl_cert_free(ssl->cert);
     ssl->cert = new_cert;
 

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2117,6 +2117,8 @@ __owur int custom_ext_add(SSL *s, int server, unsigned char **pret,
 
 __owur int custom_exts_copy(custom_ext_methods *dst,
                             const custom_ext_methods *src);
+__owur int custom_exts_copy_flags(custom_ext_methods *dst,
+                                  const custom_ext_methods *src);
 void custom_exts_free(custom_ext_methods *exts);
 
 void ssl_comp_free_compression_methods_int(void);

--- a/ssl/t1_ext.c
+++ b/ssl/t1_ext.c
@@ -131,6 +131,25 @@ int custom_ext_add(SSL *s, int server,
     return 1;
 }
 
+/* Copy the flags from src to dst for any extensions that exist in both */
+int custom_exts_copy_flags(custom_ext_methods *dst,
+                           const custom_ext_methods *src)
+{
+    size_t i;
+    custom_ext_method *methsrc = src->meths;
+
+    for (i = 0; i < src->meths_count; i++, methsrc++) {
+        custom_ext_method *methdst = custom_ext_find(dst, methsrc->ext_type);
+
+        if (methdst == NULL)
+            continue;
+
+        methdst->ext_flags = methsrc->ext_flags;
+    }
+
+    return 1;
+}
+
 /* Copy table of custom extensions */
 int custom_exts_copy(custom_ext_methods *dst, const custom_ext_methods *src)
 {

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -531,8 +531,9 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
     SSL_CTX *clientctx = NULL;
 
     serverctx = SSL_CTX_new(sm);
-    clientctx = SSL_CTX_new(cm);
-    if (serverctx == NULL || clientctx == NULL) {
+    if (cctx != NULL)
+        clientctx = SSL_CTX_new(cm);
+    if (serverctx == NULL || (cctx != NULL && clientctx == NULL)) {
         printf("Failed to create SSL_CTX\n");
         goto err;
     }
@@ -556,7 +557,8 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
 #endif
 
     *sctx = serverctx;
-    *cctx = clientctx;
+    if (cctx != NULL)
+        *cctx = clientctx;
 
     return 1;
  err:


### PR DESCRIPTION
The function SSL_set_SSL_CTX() can be used to swap the SSL_CTX used for
a connection as part of an SNI callback. One result of this is that the
s->cert structure is replaced. However this structure contains information
about any custom extensions that have been loaded. In particular flags are
set indicating whether a particular extension has been received in the
ClientHello. By replacing the s->cert structure we lose the custom
extension flag values, and it appears as if a client has not sent those
extensions.

SSL_set_SSL_CTX() should copy any flags for custom extensions that appear
in both the old and the new cert structure.

Fixes #2180

This is the 1.1.0 version of #3425
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
