### PR TITLE
cryptodev: cache RSA private methods for software fallback

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -1511,6 +1511,13 @@ void ENGINE_load_cryptodev(void)
                 cryptodev_rsa.rsa_mod_exp = cryptodev_rsa_mod_exp;
             else
                 cryptodev_rsa.rsa_mod_exp = cryptodev_rsa_nocrt_mod_exp;
+        } else {
+            /* For software fallback, make sure that the values of
+             * _method_mod_* are cached to avoid artificial performance
+             * degradation. Use the default init and finish methods to set the
+             * cache flags and free allocated memory at the end */
+            cryptodev_rsa.init = rsa_meth->init;
+            cryptodev_rsa.finish = rsa_meth->finish;
         }
     }
 


### PR DESCRIPTION
If cryptodev engine is loaded but there is no available hardware
acceleration for RSA, the operations will be done in software.
However, even though the same software methods end up being used
(&rsa_pkcs1_eay_meth), the runtime behavior is not the same because the
initialization flags for the cryptodev structure are NULL. This results
in artificial slower operations that can be tested for example with
"openssl speed rsa1024".

This patch sets the flags so that the values of _method_mod_* are
cached.

Signed-off-by: Cristian Stoica <cristian.stoica@nxp.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
