### PR TITLE
Remove filename argument to x86 asm_init.

### DIFF
--- a/crypto/aes/asm/aes-586.pl
+++ b/crypto/aes/asm/aes-586.pl
@@ -202,7 +202,7 @@ $output = pop;
 open OUT,">$output";
 *STDOUT=*OUT;
 
-&asm_init($ARGV[0],"aes-586.pl",$x86only = $ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$x86only = $ARGV[$#ARGV] eq "386");
 &static_label("AES_Te");
 &static_label("AES_Td");
 

--- a/crypto/aes/asm/aesni-x86.pl
+++ b/crypto/aes/asm/aesni-x86.pl
@@ -80,7 +80,7 @@ $output = pop;
 open OUT,">$output";
 *STDOUT=*OUT;
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 &external_label("OPENSSL_ia32cap_P");
 &static_label("key_const");

--- a/crypto/aes/asm/vpaes-x86.pl
+++ b/crypto/aes/asm/vpaes-x86.pl
@@ -62,7 +62,7 @@ $output = pop;
 open OUT,">$output";
 *STDOUT=*OUT;
 
-&asm_init($ARGV[0],"vpaes-x86.pl",$x86only = $ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$x86only = $ARGV[$#ARGV] eq "386");
 
 $PREFIX="vpaes";
 

--- a/crypto/bf/asm/bf-586.pl
+++ b/crypto/bf/asm/bf-586.pl
@@ -15,7 +15,7 @@ require "cbc.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"bf-586.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $BF_ROUNDS=16;
 $BF_OFF=($BF_ROUNDS+2)*4;

--- a/crypto/bn/asm/bn-586.pl
+++ b/crypto/bn/asm/bn-586.pl
@@ -14,7 +14,7 @@ require "x86asm.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/bn/asm/co-586.pl
+++ b/crypto/bn/asm/co-586.pl
@@ -13,7 +13,7 @@ require "x86asm.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 &bn_mul_comba("bn_mul_comba8",8);
 &bn_mul_comba("bn_mul_comba4",4);

--- a/crypto/bn/asm/via-mont.pl
+++ b/crypto/bn/asm/via-mont.pl
@@ -91,7 +91,7 @@ require "x86asm.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"via-mont.pl");
+&asm_init($ARGV[0]);
 
 # int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp, const BN_ULONG *np,const BN_ULONG *n0, int num);
 $func="bn_mul_mont_padlock";

--- a/crypto/bn/asm/x86-gf2m.pl
+++ b/crypto/bn/asm/x86-gf2m.pl
@@ -46,7 +46,7 @@ require "x86asm.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0,$x86only = $ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$x86only = $ARGV[$#ARGV] eq "386");
 
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/bn/asm/x86-mont.pl
+++ b/crypto/bn/asm/x86-mont.pl
@@ -40,7 +40,7 @@ require "x86asm.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/bn/asm/x86.pl
+++ b/crypto/bn/asm/x86.pl
@@ -20,7 +20,7 @@ require("x86/comba.pl");
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 &bn_mul_add_words("bn_mul_add_words");
 &bn_mul_words("bn_mul_words");

--- a/crypto/camellia/asm/cmll-x86.pl
+++ b/crypto/camellia/asm/cmll-x86.pl
@@ -52,7 +52,7 @@ $OPENSSL=1;
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"cmll-586.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 @T=("eax","ebx","ecx","edx");
 $idx="esi";

--- a/crypto/cast/asm/cast-586.pl
+++ b/crypto/cast/asm/cast-586.pl
@@ -21,7 +21,7 @@ require "cbc.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"cast-586.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $CAST_ROUNDS=16;
 $L="edi";

--- a/crypto/chacha/asm/chacha-x86.pl
+++ b/crypto/chacha/asm/chacha-x86.pl
@@ -43,7 +43,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"chacha-x86.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $xmm=$ymm=0;
 for (@ARGV) { $xmm=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/des/asm/crypt586.pl
+++ b/crypto/des/asm/crypt586.pl
@@ -16,7 +16,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"crypt586.pl");
+&asm_init($ARGV[0]);
 
 $L="edi";
 $R="esi";

--- a/crypto/des/asm/des-586.pl
+++ b/crypto/des/asm/des-586.pl
@@ -23,7 +23,7 @@ require "desboth.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"des-586.pl");
+&asm_init($ARGV[0]);
 
 $L="edi";
 $R="esi";

--- a/crypto/ec/asm/ecp_nistz256-x86.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86.pl
@@ -45,7 +45,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"ecp_nistz256-x86.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/md5/asm/md5-586.pl
+++ b/crypto/md5/asm/md5-586.pl
@@ -21,7 +21,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 $A="eax";
 $B="ebx";

--- a/crypto/modes/asm/ghash-x86.pl
+++ b/crypto/modes/asm/ghash-x86.pl
@@ -139,7 +139,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"ghash-x86.pl",$x86only = $ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$x86only = $ARGV[$#ARGV] eq "386");
 
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/perlasm/README
+++ b/crypto/perlasm/README
@@ -9,7 +9,7 @@ require "x86asm.pl";
 
 The first thing we do is setup the file and type of assembler
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 The first argument is the 'type'.  Currently
 'cpp', 'sol', 'a.out', 'elf' or 'win32'.
@@ -62,7 +62,7 @@ So a very simple version of this function could be coded as
 	push(@INC,"perlasm","../../perlasm");
 	require "x86asm.pl";
 	
-	&asm_init($ARGV[0],"cacl.pl");
+	&asm_init($ARGV[0]);
 
 	&external_label("other");
 

--- a/crypto/perlasm/x86asm.pl
+++ b/crypto/perlasm/x86asm.pl
@@ -8,7 +8,7 @@
 
 
 # require 'x86asm.pl';
-# &asm_init(<flavor>,"des-586.pl"[,$i386only]);
+# &asm_init(<flavor>[,$i386only]);
 # &function_begin("foo");
 # ...
 # &function_end("foo");
@@ -259,9 +259,8 @@ sub ::asm_finish
 }
 
 sub ::asm_init
-{ my ($type,$fn,$cpu)=@_;
+{ my ($type,$cpu)=@_;
 
-    $filename=$fn;
     $i386=$cpu;
 
     $elf=$cpp=$coff=$aout=$macosx=$win32=$netware=$mwerks=$android=0;
@@ -301,8 +300,7 @@ EOF
     $pic=0;
     for (@ARGV) { $pic=1 if (/\-[fK]PIC/i); }
 
-    $filename =~ s/\.pl$//;
-    &file($filename);
+    &file();
 }
 
 sub ::hidden {}

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -104,7 +104,7 @@ sub ::BC	{ @_;		}
 sub ::DWC	{ @_;		}
 
 sub ::file
-{   push(@out,".file\t\"$_[0].s\"\n.text\n");	}
+{   push(@out,".text\n");	}
 
 sub ::function_begin_B
 { my $func=shift;

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -85,7 +85,6 @@ sub ::DWC	{ "@_"; }
 
 sub ::file
 { my $tmp=<<___;
-TITLE	$_[0].asm
 IF \@Version LT 800
 ECHO MASM version 8.00 or later is strongly recommended.
 ENDIF

--- a/crypto/poly1305/asm/poly1305-x86.pl
+++ b/crypto/poly1305/asm/poly1305-x86.pl
@@ -50,7 +50,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"poly1305-x86.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $sse2=$avx=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/rc4/asm/rc4-586.pl
+++ b/crypto/rc4/asm/rc4-586.pl
@@ -73,7 +73,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"rc4-586.pl",$x86only = $ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$x86only = $ARGV[$#ARGV] eq "386");
 
 $xx="eax";
 $yy="ebx";

--- a/crypto/rc5/asm/rc5-586.pl
+++ b/crypto/rc5/asm/rc5-586.pl
@@ -15,7 +15,7 @@ require "cbc.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"rc5-586.pl");
+&asm_init($ARGV[0]);
 
 $RC5_MAX_ROUNDS=16;
 $RC5_32_OFF=($RC5_MAX_ROUNDS+2)*4;

--- a/crypto/ripemd/asm/rmd-586.pl
+++ b/crypto/ripemd/asm/rmd-586.pl
@@ -19,7 +19,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 $A="ecx";
 $B="esi";

--- a/crypto/sha/asm/sha1-586.pl
+++ b/crypto/sha/asm/sha1-586.pl
@@ -127,7 +127,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"sha1-586.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $xmm=$ymm=0;
 for (@ARGV) { $xmm=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/sha/asm/sha256-586.pl
+++ b/crypto/sha/asm/sha256-586.pl
@@ -76,7 +76,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"sha512-586.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $xmm=$avx=0;
 for (@ARGV) { $xmm=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/sha/asm/sha512-586.pl
+++ b/crypto/sha/asm/sha512-586.pl
@@ -62,7 +62,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"sha512-586.pl",$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
 
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }

--- a/crypto/whrlpool/asm/wp-mmx.pl
+++ b/crypto/whrlpool/asm/wp-mmx.pl
@@ -59,7 +59,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"wp-mmx.pl");
+&asm_init($ARGV[0]);
 
 sub L()  { &data_byte(@_); }
 sub LL()

--- a/crypto/x86cpuid.pl
+++ b/crypto/x86cpuid.pl
@@ -14,7 +14,7 @@ $output = pop;
 open OUT,">$output";
 *STDOUT=*OUT;
 
-&asm_init($ARGV[0],"x86cpuid");
+&asm_init($ARGV[0]);
 
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 

--- a/engines/asm/e_padlock-x86.pl
+++ b/engines/asm/e_padlock-x86.pl
@@ -45,7 +45,7 @@ require "x86asm.pl";
 $output=pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$0);
+&asm_init($ARGV[0]);
 
 %PADLOCK_PREFETCH=(ecb=>128, cbc=>64);	# prefetch errata
 $PADLOCK_CHUNK=512;	# Must be a power of 2 larger than 16

--- a/ms/uplink-x86.pl
+++ b/ms/uplink-x86.pl
@@ -15,7 +15,7 @@ require "uplink-common.pl";
 $output = pop;
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],"uplink-x86");
+&asm_init($ARGV[0]);
 
 &external_label("OPENSSL_Uplink");
 &public_label("OPENSSL_UplinkTable");


### PR DESCRIPTION
@dot-asm, does this seem reasonable to you? We were running into issues on our end with the `.file` directive in the x86 files. As far as I can tell, it's entirely vestigial (x86_64 doesn't do it), but maybe you know of a reason for them that I'm missing.

---

The assembler already knows the actual path to the generated file and,
in other perlasm architectures, is left to manage debug symbols itself.
Notably, in OpenSSL 1.1.x's new build system, which allows a separate
build directory, converting .pl to .s as the scripts currently do result
in the wrong paths.

This also avoids inconsistencies from some of the files using $0 and
some passing in the filename.
