### PR TITLE
Remove dead code.

### DIFF
--- a/crypto/bn/bn_print.c
+++ b/crypto/bn/bn_print.c
@@ -33,8 +33,6 @@ char *BN_bn2hex(const BIGNUM *a)
     p = buf;
     if (a->neg)
         *(p++) = '-';
-    if (BN_is_zero(a))
-        *(p++) = '0';
     for (i = a->top - 1; i >= 0; i--) {
         for (j = BN_BITS2 - 8; j >= 0; j -= 8) {
             /* strip leading zeros */


### PR DESCRIPTION
The second BN_is_zero test can never be true, the zero case is caught at the top of the function.
