### PR TITLE
Fix regression in openssl req -x509 behaviour.

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -288,7 +288,6 @@ int req_main(int argc, char **argv)
             break;
         case OPT_X509:
             x509 = 1;
-            newreq = 1;
             break;
         case OPT_DAYS:
             days = atoi(opt_arg());
@@ -330,6 +329,9 @@ int req_main(int argc, char **argv)
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;
+
+    if (x509 && infile == NULL)
+        newreq = 1;
 
     /* TODO: simplify this as pkey is still always NULL here */
     private = newreq && (pkey == NULL) ? 1 : 0;
@@ -582,7 +584,7 @@ int req_main(int argc, char **argv)
         }
     }
 
-    if (newreq) {
+    if (newreq || x509) {
         if (pkey == NULL) {
             BIO_printf(bio_err, "you need to specify a private key\n");
             goto end;

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -234,6 +234,9 @@ a self signed root CA. The extensions added to the certificate
 using the B<set_serial> option, a large random number will be used for
 the serial number.
 
+If existing request is specified with the B<-in> option, it is converted
+to the self signed certificate otherwise new request is created.
+
 =item B<-days n>
 
 When the B<-x509> option is being used this specifies the number of


### PR DESCRIPTION
Allow conversion of existing requests to certificates again.
Fixes the issue #3396

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x ] documentation is added or updated
