### PR TITLE
Backport "Fix strict-warnings build"

### DIFF
--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -601,7 +601,7 @@ int asn1_valid_host(const ASN1_STRING *host)
     const unsigned char *hostptr = host->data;
     int type = host->type;
     int i;
-    char width = -1;
+    signed char width = -1;
     unsigned short chflags = 0, prevchflags;
 
     if (type > 0 && type < 31)


### PR DESCRIPTION
crypto/asn1/a_strex.c: Type of width variable in asn1_valid_host
function  needs to be changed from char to signed char to avoid
build error due to '-Werror=type-limits'.

(cherry picked from commit 34657a8da2ead453460d668771984432cc767044)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

