### PR TITLE
testutil: set test title

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2077,6 +2077,7 @@ static int do_test_file(const char *testfile)
     char buf[10240];
     EVP_TEST t;
 
+    set_test_title(testfile);
     current_test_file = testfile;
     if (!TEST_ptr(in = BIO_new_file(testfile, "rb")))
         return 0;

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -140,6 +140,7 @@ void add_test(const char *test_case_name, int (*test_fn) ());
 void add_all_tests(const char *test_case_name, int (*test_fn)(int idx), int num,
                    int subtest);
 __owur int run_tests(const char *test_prog_name);
+void set_test_title(const char *title);
 
 /*
  * Declarations for user defined functions

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -121,6 +121,13 @@ static void finalize(int success)
         ERR_print_errors_cb(openssl_error_cb, NULL);
 }
 
+static const char *test_title = NULL;
+
+void set_test_title(const char *title)
+{
+    test_title = title;
+}
+
 int run_tests(const char *test_prog_name)
 {
     int num_failed = 0;
@@ -139,7 +146,10 @@ int run_tests(const char *test_prog_name)
 
     for (i = 0; i != num_tests; ++i) {
         if (all_tests[i].num == -1) {
-            int ret = all_tests[i].test_fn();
+            int ret = 0;
+
+            set_test_title(all_tests[i].test_case_name);
+            ret = all_tests[i].test_fn();
 
             test_flush_stdout();
             test_flush_stderr();
@@ -150,7 +160,7 @@ int run_tests(const char *test_prog_name)
                 ++num_failed;
             }
             test_printf_stdout("%*s%s %d - %s\n", level, "", verdict, i + 1,
-                               all_tests[i].test_case_name);
+                               test_title);
             test_flush_stdout();
             finalize(ret);
         } else {
@@ -166,7 +176,10 @@ int run_tests(const char *test_prog_name)
             }
 
             for (j = 0; j < all_tests[i].num; j++) {
-                int ret = all_tests[i].param_test_fn(j);
+                int ret = 0;
+
+                set_test_title(NULL);
+                ret = all_tests[i].param_test_fn(j);
 
                 test_flush_stdout();
                 test_flush_stderr();
@@ -182,7 +195,12 @@ int run_tests(const char *test_prog_name)
                         verdict = "not ok";
                         ++num_failed_inner;
                     }
-                    test_printf_stdout("%*s%s %d\n", level, "", verdict, j + 1);
+                    if (test_title != NULL)
+                        test_printf_stdout("%*s%s %d - %s\n", level, "", verdict,
+                                           j + 1, test_title);
+                    else
+                        test_printf_stdout("%*s%s %d\n", level, "", verdict,
+                                           j + 1);
                     test_flush_stdout();
                 }
             }


### PR DESCRIPTION
Sometimes, notably in `evp_test`, it may be useful for the subtests to be able to set their own title.  In the case of `evp_test`, the test file name is a nice possiblity.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
