### PR TITLE
testutil: Fix non-standard subtest output

### DIFF
--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -127,14 +127,14 @@ int run_tests(const char *test_prog_name)
     char *verdict = NULL;
     int i, j;
 
-    if (num_tests < 1)
+    if (num_tests < 1) {
         test_printf_stdout("%*s1..0 # Skipped: %s\n", level, "",
                            test_prog_name);
-    else if (level > 0)
-        test_printf_stdout("%*s1..%d # Subtest: %s\n", level, "", num_tests,
-                           test_prog_name);
-    else
+    } else {
+        if (level > 0)
+            test_printf_stdout("%*s# Subtest: %s\n", level, "", test_prog_name);
         test_printf_stdout("%*s1..%d\n", level, "", num_tests);
+    }
     test_flush_stdout();
 
     for (i = 0; i != num_tests; ++i) {


### PR DESCRIPTION
In some cases, testutil outputs subtests like this:

    1..6 # Subtest: progname

The standard set by Test::More (because there really is no actual
standard yet) gives this display:

    # Subtest: progname
    1..6

Until the standard is actually agreed upon, let's do it like
Test::More.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
