### PR TITLE
Cleanup - use e_os2.h rather than stdint.h

### DIFF
--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -31,16 +31,10 @@
  * work which got its smarts from Daniel J. Bernstein's work on the same.
  */
 
-#include <openssl/opensslconf.h>
+#include <openssl/e_os2.h>
 #ifdef OPENSSL_NO_EC_NISTP_64_GCC_128
 NON_EMPTY_TRANSLATION_UNIT
 #else
-
-# ifndef OPENSSL_SYS_VMS
-#  include <stdint.h>
-# else
-#  include <inttypes.h>
-# endif
 
 # include <string.h>
 # include <openssl/err.h>

--- a/crypto/sha/keccak1600.c
+++ b/crypto/sha/keccak1600.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdint.h>
+#include <openssl/e_os2.h>
 #include <string.h>
 #include <assert.h>
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -20,11 +20,7 @@
 # include <openssl/crypto.h>
 
 # ifndef OPENSSL_NO_SCTP
-#  ifndef OPENSSL_SYS_VMS
-#   include <stdint.h>
-#  else
-#   include <inttypes.h>
-#  endif
+#  include <openssl/e_os2.h>
 # endif
 
 #ifdef  __cplusplus


### PR DESCRIPTION
Not exactly everywhere, but in those source files where stdint.h is
included conditionally, or where it will be eventually
