### PR TITLE
Add MySQL support to s_client -starttls

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -493,7 +493,7 @@ command for more information.
 Send the protocol-specific message(s) to switch to TLS for communication.
 B<protocol> is a keyword for the intended protocol.  Currently, the only
 supported keywords are "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server",
-"irc", "postgres", "lmtp", "nntp", "sieve" and "ldap".
+"irc", "postgres", "mysql", "lmtp", "nntp", "sieve" and "ldap".
 
 =item B<-xmpphost hostname>
 


### PR DESCRIPTION
Hello,

This patch adds MySQL support to s_client -starttls. First, receive handshake packet from server, and then send mysql packet with CLIENT_SSL set on the capability flags field. Purpose of this feature is to check certificate of MySQL server.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
