### PR TITLE
Fix password callback improper NULL termination

### DIFF
--- a/apps/srp.c
+++ b/apps/srp.c
@@ -133,7 +133,8 @@ static char *srp_verify_user(const char *user, const char *srp_verifier,
             BIO_printf(bio_err,
                        "Validating\n   user=\"%s\"\n srp_verifier=\"%s\"\n srp_usersalt=\"%s\"\n g=\"%s\"\n N=\"%s\"\n",
                        user, srp_verifier, srp_usersalt, g, N);
-        BIO_printf(bio_err, "Pass %s\n", password);
+        if (verbose > 1)
+            BIO_printf(bio_err, "Pass %s\n", password);
 
         OPENSSL_assert(srp_usersalt != NULL);
         if (!(gNid = SRP_create_verifier(user, password, &srp_usersalt,

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -126,7 +126,8 @@ static char *srp_verify_user(const char *user, const char *srp_verifier,
     cb_tmp.prompt_info = user;
     cb_tmp.password = passin;
 
-    if ((len = password_callback(password, sizeof(password)-1, 0, &cb_tmp)) > 0) {
+    len = password_callback(password, sizeof(password)-1, 0, &cb_tmp);
+    if (len > 0) {
         password[len] = 0;
         if (verbose)
             BIO_printf(bio_err,
@@ -135,10 +136,8 @@ static char *srp_verify_user(const char *user, const char *srp_verifier,
         BIO_printf(bio_err, "Pass %s\n", password);
 
         OPENSSL_assert(srp_usersalt != NULL);
-        if (!
-            (gNid =
-             SRP_create_verifier(user, password, &srp_usersalt, &verifier, N,
-                                 g))) {
+        if (!(gNid = SRP_create_verifier(user, password, &srp_usersalt,
+                                         &verifier, N, g)) ) {
             BIO_printf(bio_err, "Internal error validating SRP verifier\n");
         } else {
             if (strcmp(verifier, srp_verifier))
@@ -161,21 +160,21 @@ static char *srp_create_user(char *user, char **srp_verifier,
     cb_tmp.prompt_info = user;
     cb_tmp.password = passout;
 
-    if ((len = password_callback(password, sizeof(password)-1, 1, &cb_tmp)) > 0) {
+    len = password_callback(password, sizeof(password)-1, 1, &cb_tmp);
+    if (len > 0) {
         password[len] = 0;
         if (verbose)
             BIO_printf(bio_err, "Creating\n user=\"%s\"\n g=\"%s\"\n N=\"%s\"\n",
                        user, g, N);
-        if (!
-            (gNid =
-             SRP_create_verifier(user, password, &salt, srp_verifier, N,
-                                 g))) {
+        if (!(gNid = SRP_create_verifier(user, password, &salt,
+                                         srp_verifier, N, g)) ) {
             BIO_printf(bio_err, "Internal error creating SRP verifier\n");
-        } else
+        } else {
             *srp_usersalt = salt;
+        }
         if (verbose > 1)
-            BIO_printf(bio_err, "gNid=%s salt =\"%s\"\n verifier =\"%s\"\n", gNid,
-                       salt, *srp_verifier);
+            BIO_printf(bio_err, "gNid=%s salt =\"%s\"\n verifier =\"%s\"\n",
+                       gNid, salt, *srp_verifier);
 
     }
     return gNid;
@@ -253,7 +252,7 @@ int srp_main(int argc, char **argv)
         case OPT_LIST:
             if (mode != OPT_ERR) {
                 BIO_printf(bio_err,
-                           "%s: Only one of -add/delete-modify/-list\n",
+                           "%s: Only one of -add/-delete/-modify/-list\n",
                            prog);
                 goto opthelp;
             }

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -144,6 +144,7 @@ static char *srp_verify_user(const char *user, const char *srp_verifier,
                 gNid = NULL;
             OPENSSL_free(verifier);
         }
+        OPENSSL_cleanse(password, len);
     }
     return gNid;
 }
@@ -172,6 +173,7 @@ static char *srp_create_user(char *user, char **srp_verifier,
         } else {
             *srp_usersalt = salt;
         }
+        OPENSSL_cleanse(password, len);
         if (verbose > 1)
             BIO_printf(bio_err, "gNid=%s salt =\"%s\"\n verifier =\"%s\"\n",
                        gNid, salt, *srp_verifier);

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -294,7 +294,7 @@ int srp_main(int argc, char **argv)
                    "Need at least one user for options -add, -delete, -modify. \n");
         goto opthelp;
     }
-    if ((passin || passout) && argc != 1) {
+    if ((passinarg || passoutarg) && argc != 1) {
         BIO_printf(bio_err,
                    "-passin, -passout arguments only valid with one user.\n");
         goto opthelp;

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -117,15 +117,17 @@ static char *srp_verify_user(const char *user, const char *srp_verifier,
                              char *srp_usersalt, const char *g, const char *N,
                              const char *passin, int verbose)
 {
-    char password[1024];
+    char password[1025];
     PW_CB_DATA cb_tmp;
     char *verifier = NULL;
     char *gNid = NULL;
+    int len;
 
     cb_tmp.prompt_info = user;
     cb_tmp.password = passin;
 
-    if (password_callback(password, sizeof(password), 0, &cb_tmp) > 0) {
+    if ((len = password_callback(password, sizeof(password)-1, 0, &cb_tmp)) > 0) {
+        password[len] = 0;
         if (verbose)
             BIO_printf(bio_err,
                        "Validating\n   user=\"%s\"\n srp_verifier=\"%s\"\n srp_usersalt=\"%s\"\n g=\"%s\"\n N=\"%s\"\n",
@@ -151,14 +153,16 @@ static char *srp_create_user(char *user, char **srp_verifier,
                              char **srp_usersalt, char *g, char *N,
                              char *passout, int verbose)
 {
-    char password[1024];
+    char password[1025];
     PW_CB_DATA cb_tmp;
     char *gNid = NULL;
     char *salt = NULL;
+    int len;
     cb_tmp.prompt_info = user;
     cb_tmp.password = passout;
 
-    if (password_callback(password, sizeof(password), 1, &cb_tmp) > 0) {
+    if ((len = password_callback(password, sizeof(password)-1, 1, &cb_tmp)) > 0) {
+        password[len] = 0;
         if (verbose)
             BIO_printf(bio_err, "Creating\n user=\"%s\"\n g=\"%s\"\n N=\"%s\"\n",
                        user, g, N);


### PR DESCRIPTION
The password_callback() function is not copying the terminating NULL
when a password is provided in the callback data.
This makes the -passin and -passout options of many openssl commands
to fail inexplicably and randomly.

Note that this affects 1.1.0 and 1.0.2, as well as older, unmaintained releases.