### PR TITLE
Remove notification settings from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,11 +62,3 @@ test_script:
             cmd /c "nmake install install_docs DESTDIR=..\_install 2>&1"
         }
     - cd ..
-
-notifications:
-    - provider: Email
-      to:
-          - openssl-commits@openssl.org
-      on_build_success: false
-      on_build_failure: true
-      on_build_status_changed: true


### PR DESCRIPTION
Notifications can be (and should be) configured on account basis on
the CI web site.  This avoids getting emails to openssl-commits for
personal accounts that also build OpenSSL stuff.

-----

Note: I've already added notification settings for openssl/openssl to mimic what was in appveyor.yml