### PR TITLE
Fix regression in openssl req -x509 behaviour also on 1.0.2 branch

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -331,7 +331,6 @@ int MAIN(int argc, char **argv)
         else if (strcmp(*argv, "-text") == 0)
             text = 1;
         else if (strcmp(*argv, "-x509") == 0) {
-            newreq = 1;
             x509 = 1;
         } else if (strcmp(*argv, "-asn1-kludge") == 0)
             kludge = 1;
@@ -446,6 +445,9 @@ int MAIN(int argc, char **argv)
                    " -reqopt arg    - various request text options\n\n");
         goto end;
     }
+
+    if (x509 && infile == NULL)
+        newreq = 1;
 
     ERR_load_crypto_strings();
     if (!app_passwd(bio_err, passargin, passargout, &passin, &passout)) {
@@ -753,7 +755,7 @@ int MAIN(int argc, char **argv)
         }
     }
 
-    if (newreq) {
+    if (newreq || x509) {
         if (pkey == NULL) {
             BIO_printf(bio_err, "you need to specify a private key\n");
             goto end;

--- a/doc/apps/req.pod
+++ b/doc/apps/req.pod
@@ -237,6 +237,9 @@ a self signed root CA. The extensions added to the certificate
 using the B<set_serial> option, a large random number will be used for
 the serial number.
 
+If existing request is specified with the B<-in> option, it is converted
+to the self signed certificate otherwise new request is created.
+
 =item B<-days n>
 
 when the B<-x509> option is being used this specifies the number of


### PR DESCRIPTION
Allow conversion of existing requests to certificates again.
Fixes the issue #3396

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
