### PR TITLE
Fix the speed command when using an alternation of ciphers and digests

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1357,6 +1357,7 @@ int speed_main(int argc, char **argv)
             usertime = 0;
             break;
         case OPT_EVP:
+            evp_md = NULL;
             evp_cipher = EVP_get_cipherbyname(opt_arg());
             if (evp_cipher == NULL)
                 evp_md = EVP_get_digestbyname(opt_arg());


### PR DESCRIPTION
One cannot run two successive `speed` commands because `evp_md` is a static variable that is not reset, resulting in the following output:

```
protz@Joprotze-Z420:~/Code/openssl/apps (master) $ ./openssl.exe 
OpenSSL> speed -evp sha512
Doing sha512 for 3s on 16 size blocks: 5140131 sha512's in 2.97s
(...)
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
sha512           27702.60k   110953.15k   224173.74k   356383.74k   444771.90k   446720.68k
81797 sha512's in 3.00s
OpenSSL> speed -evp chacha20
Doing chacha20 for 3s on 16 size blocks: Doing sha512 for 3s on 16 size blocks: 4960252 sha512's in 3.00s
```

Notice the interleaving... this patch fixes it.