### PR TITLE
apps: drop default values from the config file

### DIFF
--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -126,17 +126,17 @@ string_mask = utf8only
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)
-countryName_default		= AU
+#countryName_default		= AU
 countryName_min			= 2
 countryName_max			= 2
 
 stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= Some-State
+#stateOrProvinceName_default	= Some-State
 
 localityName			= Locality Name (eg, city)
 
 0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Internet Widgits Pty Ltd
+#0.organizationName_default	= Internet Widgits Pty Ltd
 
 # we can do this but it is not needed normally :-)
 #1.organizationName		= Second Organization Name (eg, company)

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -126,17 +126,17 @@ string_mask = utf8only
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)
-countryName_default		= AU
+#countryName_default		= AU
 countryName_min			= 2
 countryName_max			= 2
 
 stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= Some-State
+#stateOrProvinceName_default	= Some-State
 
 localityName			= Locality Name (eg, city)
 
 0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Internet Widgits Pty Ltd
+#0.organizationName_default	= Internet Widgits Pty Ltd
 
 # we can do this but it is not needed normally :-)
 #1.organizationName		= Second Organization Name (eg, company)


### PR DESCRIPTION
This comes via Debian's bug report #397507 [0]. The user complains that
it is not possible to skip the entries for country, state, organisation.
It seems that the file contains the default values since SSLeay and has
hardly changed overrall.
I hereby suggest to comment the default entry and thus making it possible
to skip one of these entries. Since it is commented out, it should be
obvious that it is possible to set a default value.

[0] https://bugs.debian.org/397507

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>