### PR TITLE
test/run_tests.pl: don't mask test failures.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -82,7 +82,10 @@ foreach my $arg (@ARGV ? @ARGV : ('alltests')) {
 }
 
 my $harness = $TAP_Harness->new(\%tapargs);
-$harness->runtests(map { abs2rel($_, rel2abs(curdir())); } sort keys %tests);
+my $ret = $harness->runtests(map { abs2rel($_, rel2abs(curdir())); }
+                                 sort keys %tests);
+
+exit $ret->has_errors if (ref($ret) eq "TAP::Parser::Aggregator");
 
 sub find_matching_tests {
     my ($glob) = @_;


### PR DESCRIPTION
Switch to TAP::Harness inadvertently masked test failures.
Test::Harness::runtests was terminating with non-zero exit code in case
of failure[s], while TAP::Harness apparently holds caller responsible
for doing so.
