### PR TITLE
test/run_tests.pl: don't mask test failures.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -62,7 +62,9 @@ if ($list_mode) {
     @tests = map { abs2rel($_, rel2abs(curdir())); } @tests;
 
     my $harness = $TAP_Harness->new(\%tapargs);
-    $harness->runtests(sort @tests);
+    my $ret = $harness->runtests(sort @tests);
+
+    exit $ret->has_errors if (ref($ret) eq "TAP::Parser::Aggregator");
 }
 
 


### PR DESCRIPTION
Switch to TAP::Harness inadvertently masked test failures.
Test::Harness::runtests was terminating with non-zero exit code in case
of failure[s], while TAP::Harness apparently holds caller responsible
for doing so.

This is just 1.1.0-specific version of #3501.