### PR TITLE
Fix SSLv3 client auth and one shot operations.

### DIFF
--- a/crypto/evp/m_md5_sha1.c
+++ b/crypto/evp/m_md5_sha1.c
@@ -21,11 +21,16 @@
 struct md5_sha1_ctx {
     MD5_CTX md5;
     SHA_CTX sha1;
+    unsigned char *tmpms; /* Temp master secret for SSLv3 client auth */
 };
+
+#define SSL3_MASTER_SECRET_SIZE 48
 
 static int init(EVP_MD_CTX *ctx)
 {
     struct md5_sha1_ctx *mctx = EVP_MD_CTX_md_data(ctx);
+
+    mctx->tmpms = NULL;
     if (!MD5_Init(&mctx->md5))
         return 0;
     return SHA1_Init(&mctx->sha1);
@@ -34,6 +39,7 @@ static int init(EVP_MD_CTX *ctx)
 static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
 {
     struct md5_sha1_ctx *mctx = EVP_MD_CTX_md_data(ctx);
+
     if (!MD5_Update(&mctx->md5, data, count))
         return 0;
     return SHA1_Update(&mctx->sha1, data, count);
@@ -42,6 +48,63 @@ static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
 static int final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     struct md5_sha1_ctx *mctx = EVP_MD_CTX_md_data(ctx);
+
+    /* SSLv3 client auth handling: see RFC-6101 5.6.8 */
+    if (mctx->tmpms != NULL) {
+        unsigned char padtmp[48];
+        unsigned char md5tmp[MD5_DIGEST_LENGTH];
+        unsigned char sha1tmp[SHA_DIGEST_LENGTH];
+
+        /* At this point hash contains all handshake messages, update
+         * with master secret and pad_1.
+         */
+
+        if (update(ctx, mctx->tmpms, SSL3_MASTER_SECRET_SIZE) <= 0)
+            return 0;
+
+        /* Set padtmp to pad_1 value */
+        memset(padtmp, 0x36, sizeof(padtmp));
+
+        if (!MD5_Update(&mctx->md5, padtmp, sizeof(padtmp)))
+            return 0;
+
+        if (!MD5_Final(md5tmp, &mctx->md5))
+            return 0;
+
+        if (!SHA1_Update(&mctx->sha1, padtmp, 40))
+            return 0;
+
+        if (!SHA1_Final(sha1tmp, &mctx->sha1))
+            return 0;
+
+        /* Reinitialise context */
+        if (!MD5_Init(&mctx->md5) || !SHA1_Init(&mctx->sha1))
+            return 0;
+
+        if (update(ctx, mctx->tmpms, SSL3_MASTER_SECRET_SIZE) <= 0)
+            return 0;
+
+        /* Set padtmp to pad_2 value */
+        memset(padtmp, 0x5c, sizeof(padtmp));
+
+        if (!MD5_Update(&mctx->md5, padtmp, sizeof(padtmp)))
+            return 0;
+
+        if (!MD5_Update(&mctx->md5, md5tmp, sizeof(md5tmp)))
+            return 0;
+
+        if (!SHA1_Update(&mctx->sha1, padtmp, 40))
+            return 0;
+
+        if (!SHA1_Update(&mctx->sha1, sha1tmp, sizeof(sha1tmp)))
+            return 0;
+
+        OPENSSL_cleanse(md5tmp, sizeof(md5tmp));
+        OPENSSL_cleanse(sha1tmp, sizeof(sha1tmp));
+        OPENSSL_clear_free(mctx->tmpms, SSL3_MASTER_SECRET_SIZE);
+        mctx->tmpms = NULL;
+    }
+
     if (!MD5_Final(md, &mctx->md5))
         return 0;
     return SHA1_Final(md + MD5_DIGEST_LENGTH, &mctx->sha1);
@@ -49,9 +112,6 @@ static int final(EVP_MD_CTX *ctx, unsigned char *md)
 
 static int ctrl(EVP_MD_CTX *ctx, int cmd, int mslen, void *ms)
 {
-    unsigned char padtmp[48];
-    unsigned char md5tmp[MD5_DIGEST_LENGTH];
-    unsigned char sha1tmp[SHA_DIGEST_LENGTH];
     struct md5_sha1_ctx *mctx;
 
     if (cmd != EVP_CTRL_SSL3_MASTER_SECRET)
@@ -62,62 +122,10 @@ static int ctrl(EVP_MD_CTX *ctx, int cmd, int mslen, void *ms)
 
     mctx = EVP_MD_CTX_md_data(ctx);
 
-    /* SSLv3 client auth handling: see RFC-6101 5.6.8 */
-    if (mslen != 48)
+    if (mslen != SSL3_MASTER_SECRET_SIZE)
         return 0;
-
-    /* At this point hash contains all handshake messages, update
-     * with master secret and pad_1.
-     */
-
-    if (update(ctx, ms, mslen) <= 0)
-        return 0;
-
-    /* Set padtmp to pad_1 value */
-    memset(padtmp, 0x36, sizeof(padtmp));
-
-    if (!MD5_Update(&mctx->md5, padtmp, sizeof(padtmp)))
-        return 0;
-
-    if (!MD5_Final(md5tmp, &mctx->md5))
-        return 0;
-
-    if (!SHA1_Update(&mctx->sha1, padtmp, 40))
-        return 0;
-
-    if (!SHA1_Final(sha1tmp, &mctx->sha1))
-        return 0;
-
-    /* Reinitialise context */
-
-    if (!init(ctx))
-        return 0;
-
-    if (update(ctx, ms, mslen) <= 0)
-        return 0;
-
-    /* Set padtmp to pad_2 value */
-    memset(padtmp, 0x5c, sizeof(padtmp));
-
-    if (!MD5_Update(&mctx->md5, padtmp, sizeof(padtmp)))
-        return 0;
-
-    if (!MD5_Update(&mctx->md5, md5tmp, sizeof(md5tmp)))
-        return 0;
-
-    if (!SHA1_Update(&mctx->sha1, padtmp, 40))
-        return 0;
-
-    if (!SHA1_Update(&mctx->sha1, sha1tmp, sizeof(sha1tmp)))
-        return 0;
-
-    /* Now when ctx is finalised it will return the SSL v3 hash value */
-
-    OPENSSL_cleanse(md5tmp, sizeof(md5tmp));
-    OPENSSL_cleanse(sha1tmp, sizeof(sha1tmp));
-
-    return 1;
-
+    OPENSSL_free(mctx->tmpms);
+    return (mctx->tmpms = OPENSSL_memdup(ms, SSL3_MASTER_SECRET_SIZE)) != NULL;
 }
 
 static const EVP_MD md5_sha1_md = {


### PR DESCRIPTION
Temporarily store master secret in MD5+SHA1 context so its value
can be set before updating with handshake data. This fixes SSLv3
client auth with one shot operations.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

This makes SSLv3 client auth work again. Although this looks complex all this PR does is to store the passed SSL3 master secret in the context structure and process it during finalisation. 