### PR TITLE
Add a lock around the OBJ_NAME table

### DIFF
--- a/crypto/lhash/lh_stats.c
+++ b/crypto/lhash/lh_stats.c
@@ -61,6 +61,9 @@ void OPENSSL_LH_node_usage_stats(const OPENSSL_LHASH *lh, FILE *fp)
 
 void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lh, BIO *out)
 {
+    OPENSSL_LHASH *lh_mut = (OPENSSL_LHASH *) lh;
+    int ret;
+
     BIO_printf(out, "num_items             = %lu\n", lh->num_items);
     BIO_printf(out, "num_nodes             = %u\n", lh->num_nodes);
     BIO_printf(out, "num_alloc_nodes       = %u\n", lh->num_alloc_nodes);
@@ -69,15 +72,24 @@ void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lh, BIO *out)
     BIO_printf(out, "num_contracts         = %lu\n", lh->num_contracts);
     BIO_printf(out, "num_contract_reallocs = %lu\n",
                lh->num_contract_reallocs);
-    BIO_printf(out, "num_hash_calls        = %lu\n", lh->num_hash_calls);
-    BIO_printf(out, "num_comp_calls        = %lu\n", lh->num_comp_calls);
+    CRYPTO_atomic_add(&lh_mut->num_hash_calls, 0, &ret,
+                      lh->retrieve_stats_lock);
+    BIO_printf(out, "num_hash_calls        = %d\n", ret);
+    CRYPTO_atomic_add(&lh_mut->num_comp_calls, 0, &ret,
+                      lh->retrieve_stats_lock);
+    BIO_printf(out, "num_comp_calls        = %d\n", ret);
     BIO_printf(out, "num_insert            = %lu\n", lh->num_insert);
     BIO_printf(out, "num_replace           = %lu\n", lh->num_replace);
     BIO_printf(out, "num_delete            = %lu\n", lh->num_delete);
     BIO_printf(out, "num_no_delete         = %lu\n", lh->num_no_delete);
-    BIO_printf(out, "num_retrieve          = %lu\n", lh->num_retrieve);
-    BIO_printf(out, "num_retrieve_miss     = %lu\n", lh->num_retrieve_miss);
-    BIO_printf(out, "num_hash_comps        = %lu\n", lh->num_hash_comps);
+    CRYPTO_atomic_add(&lh_mut->num_retrieve, 0, &ret, lh->retrieve_stats_lock);
+    BIO_printf(out, "num_retrieve          = %d\n", ret);
+    CRYPTO_atomic_add(&lh_mut->num_retrieve_miss, 0, &ret,
+                      lh->retrieve_stats_lock);
+    BIO_printf(out, "num_retrieve_miss     = %d\n", ret);
+    CRYPTO_atomic_add(&lh_mut->num_hash_comps, 0, &ret,
+                      lh->retrieve_stats_lock);
+    BIO_printf(out, "num_hash_comps        = %d\n", ret);
 }
 
 void OPENSSL_LH_node_stats_bio(const OPENSSL_LHASH *lh, BIO *out)

--- a/crypto/objects/o_names.c
+++ b/crypto/objects/o_names.c
@@ -16,6 +16,7 @@
 #include <openssl/objects.h>
 #include <openssl/safestack.h>
 #include <openssl/e_os2.h>
+#include <internal/thread_once.h>
 #include "obj_lcl.h"
 
 /*
@@ -44,6 +45,7 @@ static int obj_strcmp(const char *a, const char *b)
  */
 static LHASH_OF(OBJ_NAME) *names_lh = NULL;
 static int names_type_num = OBJ_NAME_TYPE_NUM;
+static CRYPTO_RWLOCK *lock = NULL;
 
 struct name_funcs_st {
     unsigned long (*hash_func) (const char *name);
@@ -62,22 +64,32 @@ static STACK_OF(NAME_FUNCS) *name_funcs_stack;
 static unsigned long obj_name_hash(const OBJ_NAME *a);
 static int obj_name_cmp(const OBJ_NAME *a, const OBJ_NAME *b);
 
-int OBJ_NAME_init(void)
+static CRYPTO_ONCE init = CRYPTO_ONCE_STATIC_INIT;
+DEFINE_RUN_ONCE_STATIC(o_names_init)
 {
-    if (names_lh != NULL)
-        return (1);
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE);
     names_lh = lh_OBJ_NAME_new(obj_name_hash, obj_name_cmp);
+    lock = CRYPTO_THREAD_lock_new();
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
-    return (names_lh != NULL);
+    return names_lh != NULL && lock != NULL;
+}
+
+int OBJ_NAME_init(void)
+{
+    return RUN_ONCE(&init, o_names_init);
 }
 
 int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
                        int (*cmp_func) (const char *, const char *),
                        void (*free_func) (const char *, int, const char *))
 {
-    int ret, i, push;
+    int ret = 0, i, push;
     NAME_FUNCS *name_funcs;
+
+    if (!OBJ_NAME_init())
+        return 0;
+
+    CRYPTO_THREAD_write_lock(lock);
 
     if (name_funcs_stack == NULL) {
         CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE);
@@ -86,7 +98,7 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
     }
     if (name_funcs_stack == NULL) {
         /* ERROR */
-        return (0);
+        goto out;
     }
     ret = names_type_num;
     names_type_num++;
@@ -96,7 +108,8 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
         CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
         if (name_funcs == NULL) {
             OBJerr(OBJ_F_OBJ_NAME_NEW_INDEX, ERR_R_MALLOC_FAILURE);
-            return (0);
+            ret = 0;
+            goto out;
         }
         name_funcs->hash_func = OPENSSL_LH_strhash;
         name_funcs->cmp_func = obj_strcmp;
@@ -108,7 +121,8 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
         if (!push) {
             OBJerr(OBJ_F_OBJ_NAME_NEW_INDEX, ERR_R_MALLOC_FAILURE);
             OPENSSL_free(name_funcs);
-            return 0;
+            ret = 0;
+            goto out;
         }
     }
     name_funcs = sk_NAME_FUNCS_value(name_funcs_stack, ret);
@@ -118,7 +132,10 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
         name_funcs->cmp_func = cmp_func;
     if (free_func != NULL)
         name_funcs->free_func = free_func;
-    return (ret);
+
+out:
+    CRYPTO_THREAD_unlock(lock);
+    return ret;
 }
 
 static int obj_name_cmp(const OBJ_NAME *a, const OBJ_NAME *b)
@@ -134,7 +151,7 @@ static int obj_name_cmp(const OBJ_NAME *a, const OBJ_NAME *b)
         } else
             ret = strcmp(a->name, b->name);
     }
-    return (ret);
+    return ret;
 }
 
 static unsigned long obj_name_hash(const OBJ_NAME *a)
@@ -150,18 +167,20 @@ static unsigned long obj_name_hash(const OBJ_NAME *a)
         ret = OPENSSL_LH_strhash(a->name);
     }
     ret ^= a->type;
-    return (ret);
+    return ret;
 }
 
 const char *OBJ_NAME_get(const char *name, int type)
 {
     OBJ_NAME on, *ret;
     int num = 0, alias;
+    const char *value = NULL;
 
     if (name == NULL)
-        return (NULL);
-    if ((names_lh == NULL) && !OBJ_NAME_init())
-        return (NULL);
+        return NULL;
+    if (!OBJ_NAME_init())
+        return NULL;
+    CRYPTO_THREAD_write_lock(lock);
 
     alias = type & OBJ_NAME_ALIAS;
     type &= ~OBJ_NAME_ALIAS;
@@ -172,24 +191,30 @@ const char *OBJ_NAME_get(const char *name, int type)
     for (;;) {
         ret = lh_OBJ_NAME_retrieve(names_lh, &on);
         if (ret == NULL)
-            return (NULL);
+            break;
         if ((ret->alias) && !alias) {
             if (++num > 10)
-                return (NULL);
+                break;
             on.name = ret->data;
         } else {
-            return (ret->data);
+            value = ret->data;
+            break;
         }
     }
+
+    CRYPTO_THREAD_unlock(lock);    
+    return value;
 }
 
 int OBJ_NAME_add(const char *name, int type, const char *data)
 {
     OBJ_NAME *onp, *ret;
-    int alias;
+    int alias, ok = 0;
 
-    if ((names_lh == NULL) && !OBJ_NAME_init())
-        return (0);
+    if (!OBJ_NAME_init())
+        return 0;    
+
+    CRYPTO_THREAD_write_lock(lock);
 
     alias = type & OBJ_NAME_ALIAS;
     type &= ~OBJ_NAME_ALIAS;
@@ -197,7 +222,7 @@ int OBJ_NAME_add(const char *name, int type, const char *data)
     onp = OPENSSL_malloc(sizeof(*onp));
     if (onp == NULL) {
         /* ERROR */
-        return 0;
+        goto unlock;
     }
 
     onp->name = name;
@@ -223,18 +248,26 @@ int OBJ_NAME_add(const char *name, int type, const char *data)
         if (lh_OBJ_NAME_error(names_lh)) {
             /* ERROR */
             OPENSSL_free(onp);
-            return 0;
+            goto unlock;
         }
     }
-    return 1;
+
+    ok = 1;
+
+unlock:
+    CRYPTO_THREAD_unlock(lock);
+    return ok;
 }
 
 int OBJ_NAME_remove(const char *name, int type)
 {
     OBJ_NAME on, *ret;
+    int ok = 0;
 
-    if (names_lh == NULL)
-        return (0);
+    if (!OBJ_NAME_init())
+        return 0;
+
+    CRYPTO_THREAD_write_lock(lock);
 
     type &= ~OBJ_NAME_ALIAS;
     on.name = name;
@@ -253,9 +286,11 @@ int OBJ_NAME_remove(const char *name, int type)
                                                       ret->data);
         }
         OPENSSL_free(ret);
-        return (1);
-    } else
-        return (0);
+        ok = 1;
+    }
+
+    CRYPTO_THREAD_unlock(lock);
+    return ok;
 }
 
 typedef struct {
@@ -363,8 +398,10 @@ void OBJ_NAME_cleanup(int type)
     if (type < 0) {
         lh_OBJ_NAME_free(names_lh);
         sk_NAME_FUNCS_pop_free(name_funcs_stack, name_funcs_free);
+        CRYPTO_THREAD_lock_free(lock);
         names_lh = NULL;
         name_funcs_stack = NULL;
+        lock = NULL;
     } else
         lh_OBJ_NAME_set_down_load(names_lh, down_load);
 }

--- a/crypto/objects/o_names.c
+++ b/crypto/objects/o_names.c
@@ -180,7 +180,7 @@ const char *OBJ_NAME_get(const char *name, int type)
         return NULL;
     if (!OBJ_NAME_init())
         return NULL;
-    CRYPTO_THREAD_write_lock(lock);
+    CRYPTO_THREAD_read_lock(lock);
 
     alias = type & OBJ_NAME_ALIAS;
     type &= ~OBJ_NAME_ALIAS;


### PR DESCRIPTION
Various initialization functions modify this table, which can cause heap
corruption in the absence of external synchronization.

Fixes #3505