### PR TITLE
Fix small memory whirlpool test failure

### DIFF
--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -174,7 +174,7 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
                 goto reconsider;
             } else
 #endif
-            if (bits >= 8) {
+            if (bits > 8) {
                 b = ((inp[0] << inpgap) | (inp[1] >> (8 - inpgap)));
                 b &= 0xff;
                 if (bitrem)

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -191,7 +191,7 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
                 }
                 if (bitrem)
                     c->data[byteoff] = b << (8 - bitrem);
-            } else {            /* remaining less than 8 bits */
+            } else {            /* remaining less than or equal to 8 bits */
 
                 b = (inp[0] << inpgap) & 0xff;
                 if (bitrem)


### PR DESCRIPTION
Fix a read off the end of the input buffer when building with OPENSSL_SMALL_FOOTPRINT defined.

It looks like an off by one error in the test to see if one or two bytes need to be read.  This warrants confirmation of course.

