### PR TITLE
Document that PKCS#12 functions assume UTF-8 for passwords

### DIFF
--- a/doc/man3/PKCS12_newpass.pod
+++ b/doc/man3/PKCS12_newpass.pod
@@ -17,6 +17,18 @@ PKCS12_newpass() changes the password of a PKCS12 structure.
 B<p12> is a pointer to a PKCS12 structure. B<oldpass> is the existing password
 and B<newpass> is the new password.
 
+=head1 NOTES
+
+Each of B<oldpass> and B<newpass> is independently interpreted as a string in
+the UTF-8 encoding. If it is not valid UTF-8, it is assumed to be ISO8859-1
+instead.
+
+In particular, this means that passwords in the locale character set
+(or code page on Windows) must potentially be converted to UTF-8 before
+use. This may include passwords from local text files, or input from
+the terminal or command line. Refer to the documentation of
+L<UI_OpenSSL(3)>, for example.
+
 =head1 RETURN VALUES
 
 PKCS12_newpass() returns 1 on success or 0 on failure. Applications can

--- a/doc/man3/PKCS12_parse.pod
+++ b/doc/man3/PKCS12_parse.pod
@@ -29,6 +29,15 @@ The B<friendlyName> and B<localKeyID> attributes (if present) on each
 certificate will be stored in the B<alias> and B<keyid> attributes of the
 B<X509> structure.
 
+The parameter B<pass> is interpreted as a string in the UTF-8 encoding. If it
+is not valid UTF-8, then it is assumed to be ISO8859-1 instead.
+
+In particular, this means that passwords in the locale character set
+(or code page on Windows) must potentially be converted to UTF-8 before
+use. This may include passwords from local text files, or input from
+the terminal or command line. Refer to the documentation of
+L<UI_OpenSSL(3)>, for example.
+
 =head1 RETURN VALUES
 
 PKCS12_parse() returns 1 for success and zero if an error occurred.


### PR DESCRIPTION
Part of issue #3531

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
