### PR TITLE
fixing incorrect OID of signingCertificateV2

### DIFF
--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -976,7 +976,7 @@ static const unsigned char so[6911] = {
     0x2A,0x83,0x1A,0x8C,0x9A,0x6E,0x01,0x01,0x0D,  /* [ 6872] OBJ_aria_256_cfb128 */
     0x2A,0x83,0x1A,0x8C,0x9A,0x6E,0x01,0x01,0x0E,  /* [ 6881] OBJ_aria_256_ofb128 */
     0x2A,0x83,0x1A,0x8C,0x9A,0x6E,0x01,0x01,0x0F,  /* [ 6890] OBJ_aria_256_ctr */
-    0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x09,0x10,0x02,0x1E,  /* [ 6899] OBJ_id_smime_aa_signingCertificateV2 */
+    0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x09,0x10,0x02,0x2F,  /* [ 6899] OBJ_id_smime_aa_signingCertificateV2 */
 };
 
 #define NUM_NID 1087
@@ -5177,7 +5177,7 @@ static const unsigned int obj_objs[NUM_OBJ] = {
      238,    /* OBJ_id_smime_aa_ets_archiveTimeStamp 1 2 840 113549 1 9 16 2 27 */
      239,    /* OBJ_id_smime_aa_signatureType    1 2 840 113549 1 9 16 2 28 */
      240,    /* OBJ_id_smime_aa_dvcs_dvc         1 2 840 113549 1 9 16 2 29 */
-    1086,    /* OBJ_id_smime_aa_signingCertificateV2 1 2 840 113549 1 9 16 2 30 */
+    1086,    /* OBJ_id_smime_aa_signingCertificateV2 1 2 840 113549 1 9 16 2 47 */
      241,    /* OBJ_id_smime_alg_ESDHwith3DES    1 2 840 113549 1 9 16 3 1 */
      242,    /* OBJ_id_smime_alg_ESDHwithRC2     1 2 840 113549 1 9 16 3 2 */
      243,    /* OBJ_id_smime_alg_3DESwrap        1 2 840 113549 1 9 16 3 3 */

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -294,7 +294,7 @@ id-smime-aa 26		: id-smime-aa-ets-certCRLTimestamp
 id-smime-aa 27		: id-smime-aa-ets-archiveTimeStamp
 id-smime-aa 28		: id-smime-aa-signatureType
 id-smime-aa 29		: id-smime-aa-dvcs-dvc
-id-smime-aa 30		: id-smime-aa-signingCertificateV2
+id-smime-aa 47		: id-smime-aa-signingCertificateV2
 
 # S/MIME Algorithm Identifiers
 # obsolete

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -934,7 +934,7 @@
 
 #define SN_id_smime_aa_signingCertificateV2             "id-smime-aa-signingCertificateV2"
 #define NID_id_smime_aa_signingCertificateV2            1086
-#define OBJ_id_smime_aa_signingCertificateV2            OBJ_id_smime_aa,30L
+#define OBJ_id_smime_aa_signingCertificateV2            OBJ_id_smime_aa,47L
 
 #define SN_id_smime_alg_ESDHwith3DES            "id-smime-alg-ESDHwith3DES"
 #define NID_id_smime_alg_ESDHwith3DES           241


### PR DESCRIPTION
This PR addresses https://github.com/openssl/openssl/issues/3537

The OID for id-smime-aa-signinCertificateV2 in [RFC5035](https://tools.ietf.org/html/rfc5035#section-5.4.1) ends with 47 instead of 30

    id-aa-signingCertificateV2 OBJECT IDENTIFIER ::= { iso(1)
        member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs9(9)
        smime(16) id-aa(2) 47 }
