### PR TITLE
Remove OPENSSL_assert() from libcrypto

### DIFF
--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -36,17 +36,30 @@ typedef struct {
 
 void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
                      size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc)
+                     unsigned char *ivec, const int enc) {
+    /* Ignore the return value since we are void */
+    AES_ige_encrypt_ex(in, out, length, key, ivec, enc);
+}
+
+int AES_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                       size_t length, const AES_KEY *key,
+                       unsigned char *ivec, const int enc)
 {
     size_t n;
     size_t len = length;
 
+    /* Nothing to do */
     if (length == 0)
-        return;
+        return 1;
 
-    OPENSSL_assert(in && out && key && ivec);
-    OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));
-    OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);
+    if (in == NULL || out == NULL || key == NULL || ivec == NULL)
+        return 0;
+
+    if ((AES_ENCRYPT != enc) && (AES_DECRYPT != enc))
+        return 0;
+
+    if ((length % AES_BLOCK_SIZE) != 0)
+        return 0;
 
     len = length / AES_BLOCK_SIZE;
 
@@ -157,6 +170,8 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
             memcpy(ivec + AES_BLOCK_SIZE, iv2.data, AES_BLOCK_SIZE);
         }
     }
+
+    return 1;
 }
 
 /*
@@ -171,6 +186,15 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
                         const AES_KEY *key2, const unsigned char *ivec,
                         const int enc)
 {
+    /* Ignore the return value since we are void */
+    AES_bi_ige_encrypt(in, out, length, key, key2, ivec, enc);
+}
+
+int AES_bi_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                          size_t length, const AES_KEY *key,
+                          const AES_KEY *key2, const unsigned char *ivec,
+                          const int enc)
+{
     size_t n;
     size_t len = length;
     unsigned char tmp[AES_BLOCK_SIZE];
@@ -180,9 +204,14 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
     const unsigned char *iv;
     const unsigned char *iv2;
 
-    OPENSSL_assert(in && out && key && ivec);
-    OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));
-    OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);
+    if (in == NULL || out == NULL || key == NULL || ivec == NULL)
+        return 0;
+
+    if ((AES_ENCRYPT != enc) && (AES_DECRYPT != enc))
+        return 0;
+
+    if ((length % AES_BLOCK_SIZE) != 0)
+        return 0;
 
     if (AES_ENCRYPT == enc) {
         /*
@@ -281,4 +310,6 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
             out += AES_BLOCK_SIZE;
         }
     }
+
+    return 1;
 }

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -36,9 +36,11 @@ typedef struct {
 
 void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
                      size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc) {
+                     unsigned char *ivec, const int enc)
+{
     /* Ignore the return value since we are void */
-    AES_ige_encrypt_ex(in, out, length, key, ivec, enc);
+    if (!ossl_assert(AES_ige_encrypt_ex(in, out, length, key, ivec, enc)))
+        return;
 }
 
 int AES_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
@@ -186,8 +188,9 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
                         const AES_KEY *key2, const unsigned char *ivec,
                         const int enc)
 {
-    /* Ignore the return value since we are void */
-    AES_bi_ige_encrypt(in, out, length, key, key2, ivec, enc);
+    if (!ossl_assert(AES_bi_ige_encrypt_ex(in, out, length, key, key2, ivec,
+                     enc)))
+        return;
 }
 
 int AES_bi_ige_encrypt_ex(const unsigned char *in, unsigned char *out,

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <internal/bio.h>
 #include <openssl/asn1.h>
+#include "e_os.h"
 
 /* Must be large enough for biggest tag+length */
 #define DEFAULT_ASN1_BUF_SIZE 20
@@ -181,7 +182,8 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
 
         case ASN1_STATE_HEADER:
             ctx->buflen = ASN1_object_size(0, inl, ctx->asn1_tag) - inl;
-            OPENSSL_assert(ctx->buflen <= ctx->bufsize);
+            if (!ossl_assert(ctx->buflen <= ctx->bufsize))
+                return 0;
             p = ctx->buf;
             ASN1_put_object(&p, 0, inl, ctx->asn1_tag, ctx->asn1_class);
             ctx->copylen = inl;

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "bio_lcl.h"
@@ -565,7 +566,8 @@ static int addrinfo_wrap(int family, int socktype,
                          unsigned short port,
                          BIO_ADDRINFO **bai)
 {
-    OPENSSL_assert(bai != NULL);
+    if (bai == NULL)
+        return 0;
 
     *bai = OPENSSL_zalloc(sizeof(**bai));
     if (*bai == NULL)
@@ -760,8 +762,11 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 he_fallback_address = INADDR_ANY;
                 break;
             default:
-                OPENSSL_assert(("We forgot to handle a lookup type!" == 0));
-                break;
+                /* We forgot to handle a lookup type! */
+                assert(0);
+                BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_INTERNAL_ERROR);
+                ret = 0;
+                goto err;
             }
         } else {
             he = gethostbyname(host);

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -806,10 +806,12 @@ doapr_outch(char **sbuffer,
             char **buffer, size_t *currlen, size_t *maxlen, int c)
 {
     /* If we haven't at least one buffer, someone has doe a big booboo */
-    OPENSSL_assert(*sbuffer != NULL || buffer != NULL);
+    if (!ossl_assert(*sbuffer != NULL || buffer != NULL))
+        return 0;
 
     /* |currlen| must always be <= |*maxlen| */
-    OPENSSL_assert(*currlen <= *maxlen);
+    if (!ossl_assert(*currlen <= *maxlen))
+        return 0;
 
     if (buffer && *currlen == *maxlen) {
         if (*maxlen > INT_MAX - BUFFER_INC)
@@ -821,7 +823,8 @@ doapr_outch(char **sbuffer,
             if (*buffer == NULL)
                 return 0;
             if (*currlen > 0) {
-                OPENSSL_assert(*sbuffer != NULL);
+                if (!ossl_assert(*sbuffer != NULL))
+                    return 0;
                 memcpy(*buffer, *sbuffer, *currlen);
             }
             *sbuffer = NULL;

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -47,7 +47,10 @@ int BIO_get_host_ip(const char *str, unsigned char *ip)
             BIO_ADDR_rawaddress(BIO_ADDRINFO_address(res), NULL, &l);
             /* Because only AF_INET addresses will reach this far,
                we can assert that l should be 4 */
-            OPENSSL_assert(l == 4);
+            if (!ossl_assert(l == 4)) {
+                BIO_ADDRINFO_free(res);
+                return 0;
+            }
 
             BIO_ADDR_rawaddress(BIO_ADDRINFO_address(res), ip, &l);
             ret = 1;

--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -145,7 +145,7 @@ extern "C" {
  */
 
 # ifdef BN_DEBUG
-
+#  include <assert.h>
 #  ifdef BN_DEBUG_RAND
 #   define bn_pollute(a) \
         do { \
@@ -169,7 +169,7 @@ extern "C" {
         do { \
                 const BIGNUM *_bnum2 = (a); \
                 if (_bnum2 != NULL) { \
-                        OPENSSL_assert(((_bnum2->top == 0) && !_bnum2->neg) || \
+                        assert(((_bnum2->top == 0) && !_bnum2->neg) || \
                                 (_bnum2->top && (_bnum2->d[_bnum2->top - 1] != 0))); \
                         bn_pollute(_bnum2); \
                 } \
@@ -181,7 +181,7 @@ extern "C" {
 #  define bn_wcheck_size(bn, words) \
         do { \
                 const BIGNUM *_bnum2 = (bn); \
-                OPENSSL_assert((words) <= (_bnum2)->dmax && \
+                assert((words) <= (_bnum2)->dmax && \
                         (words) >= (_bnum2)->top); \
                 /* avoid unused variable warning with NDEBUG */ \
                 (void)(_bnum2); \

--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -170,7 +170,7 @@ extern "C" {
                 const BIGNUM *_bnum2 = (a); \
                 if (_bnum2 != NULL) { \
                         assert(((_bnum2->top == 0) && !_bnum2->neg) || \
-                                (_bnum2->top && (_bnum2->d[_bnum2->top - 1] != 0))); \
+                               (_bnum2->top && (_bnum2->d[_bnum2->top - 1] != 0))); \
                         bn_pollute(_bnum2); \
                 } \
         } while(0)
@@ -182,7 +182,7 @@ extern "C" {
         do { \
                 const BIGNUM *_bnum2 = (bn); \
                 assert((words) <= (_bnum2)->dmax && \
-                        (words) >= (_bnum2)->top); \
+                       (words) >= (_bnum2)->top); \
                 /* avoid unused variable warning with NDEBUG */ \
                 (void)(_bnum2); \
         } while(0)

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -254,7 +254,7 @@ static void nist_cp_bn_0(BN_ULONG *dst, const BN_ULONG *src, int top, int max)
     int i;
 
 #ifdef BN_DEBUG
-    OPENSSL_assert(top <= max);
+    assert(top <= max);
 #endif
     for (i = 0; i < top; i++)
         dst[i] = src[i];

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -204,7 +204,8 @@ CONF_VALUE *_CONF_new_section(CONF *conf, const char *section)
     v->value = (char *)sk;
 
     vv = lh_CONF_VALUE_insert(conf->data, v);
-    OPENSSL_assert(vv == NULL);
+    if (vv != NULL)
+        goto err;
     return v;
 
  err:

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -196,7 +196,8 @@ int EC_KEY_generate_key(EC_KEY *eckey)
 
 int ossl_ec_key_gen(EC_KEY *eckey)
 {
-    OPENSSL_assert(eckey->group->meth->keygen != NULL);
+    if (!ossl_assert(eckey->group->meth->keygen != NULL))
+        return 0;
     return eckey->group->meth->keygen(eckey);
 }
 

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -335,7 +335,8 @@ const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group)
 
 int EC_GROUP_order_bits(const EC_GROUP *group)
 {
-    OPENSSL_assert(group->meth->group_order_bits != NULL);
+    if (!ossl_assert(group->meth->group_order_bits != NULL))
+        return 0;
     return group->meth->group_order_bits(group);
 }
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -162,7 +162,8 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *size)
 {
     int ret;
 
-    OPENSSL_assert(ctx->digest->md_size <= EVP_MAX_MD_SIZE);
+    if (!ossl_assert(ctx->digest->md_size <= EVP_MAX_MD_SIZE))
+        return 0;
     ret = ctx->digest->final(ctx, md);
     if (size != NULL)
         *size = ctx->digest->md_size;

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -127,7 +127,8 @@ static int rc2_get_asn1_type_and_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
 
     if (type != NULL) {
         l = EVP_CIPHER_CTX_iv_length(c);
-        OPENSSL_assert(l <= sizeof(iv));
+        if (!ossl_assert(l <= sizeof(iv)))
+            return -1;
         i = ASN1_TYPE_get_int_octetstring(type, &num, iv, l);
         if (i != (int)l)
             return -1;

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -131,7 +131,8 @@ int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
     *outl = 0;
     if (inl <= 0)
         return 0;
-    OPENSSL_assert(ctx->length <= (int)sizeof(ctx->enc_data));
+    if (!ossl_assert(ctx->length <= (int)sizeof(ctx->enc_data)))
+        return 0;
     if (ctx->length - ctx->num > inl) {
         memcpy(&(ctx->enc_data[ctx->num]), in, inl);
         ctx->num += inl;
@@ -302,7 +303,10 @@ int EVP_DecodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
                 rv = -1;
                 goto end;
             }
-            OPENSSL_assert(n < (int)sizeof(ctx->enc_data));
+            if(!ossl_assert(n < (int)sizeof(ctx->enc_data))) {
+                rv = -1;
+                goto end;
+            }
             d[n++] = tmp;
         }
 

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -150,9 +150,12 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
  skip_to_init:
 #endif
     /* we assume block size is a power of 2 in *cryptUpdate */
-    OPENSSL_assert(ctx->cipher->block_size == 1
-                   || ctx->cipher->block_size == 8
-                   || ctx->cipher->block_size == 16);
+    if (!ossl_assert(ctx->cipher->block_size == 1
+                     || ctx->cipher->block_size == 8
+                     || ctx->cipher->block_size == 16)) {
+        EVPerr(EVP_F_EVP_CIPHERINIT_EX, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
 
     if (!(ctx->flags & EVP_CIPHER_CTX_FLAG_WRAP_ALLOW)
         && EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_WRAP_MODE) {
@@ -174,9 +177,11 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
             /* fall-through */
 
         case EVP_CIPH_CBC_MODE:
-
-            OPENSSL_assert(EVP_CIPHER_CTX_iv_length(ctx) <=
-                           (int)sizeof(ctx->iv));
+            if (!ossl_assert(EVP_CIPHER_CTX_iv_length(ctx) <=
+                             (int)sizeof(ctx->iv))) {
+                EVPerr(EVP_F_EVP_CIPHERINIT_EX, ERR_R_INTERNAL_ERROR);
+                return 0;
+            }
             if (iv)
                 memcpy(ctx->oiv, iv, EVP_CIPHER_CTX_iv_length(ctx));
             memcpy(ctx->iv, ctx->oiv, EVP_CIPHER_CTX_iv_length(ctx));
@@ -336,7 +341,10 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         }
     }
     i = ctx->buf_len;
-    OPENSSL_assert(bl <= (int)sizeof(ctx->buf));
+    if (!ossl_assert(bl <= (int)sizeof(ctx->buf))) {
+        EVPerr(EVP_F_EVP_ENCRYPTUPDATE, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
     if (i != 0) {
         if (bl - i > inl) {
             memcpy(&(ctx->buf[i]), in, inl);
@@ -391,7 +399,10 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     }
 
     b = ctx->cipher->block_size;
-    OPENSSL_assert(b <= sizeof ctx->buf);
+    if (!ossl_assert(b <= sizeof ctx->buf)) {
+        EVPerr(EVP_F_EVP_ENCRYPTFINAL_EX, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
     if (b == 1) {
         *outl = 0;
         return 1;
@@ -452,7 +463,10 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     if (ctx->flags & EVP_CIPH_NO_PADDING)
         return EVP_EncryptUpdate(ctx, out, outl, in, inl);
 
-    OPENSSL_assert(b <= sizeof ctx->final);
+    if (!ossl_assert(b <= sizeof ctx->final)) {
+        EVPerr(EVP_F_EVP_DECRYPTUPDATE, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
 
     if (ctx->final_used) {
         /* see comment about PTRDIFF_T comparison above */
@@ -524,7 +538,10 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_WRONG_FINAL_BLOCK_LENGTH);
             return (0);
         }
-        OPENSSL_assert(b <= sizeof ctx->final);
+        if (!ossl_assert(b <= sizeof ctx->final)) {
+            EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
 
         /*
          * The following assumes that the ciphertext has been authenticated.

--- a/crypto/evp/evp_key.c
+++ b/crypto/evp/evp_key.c
@@ -83,8 +83,9 @@ int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
     int rv = 0;
     nkey = EVP_CIPHER_key_length(type);
     niv = EVP_CIPHER_iv_length(type);
-    OPENSSL_assert(nkey <= EVP_MAX_KEY_LENGTH);
-    OPENSSL_assert(niv <= EVP_MAX_IV_LENGTH);
+    if (!ossl_assert(nkey <= EVP_MAX_KEY_LENGTH)
+            || !ossl_assert(niv <= EVP_MAX_IV_LENGTH))
+        return 0;
 
     if (data == NULL)
         return (nkey);

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -79,7 +79,8 @@ int EVP_CIPHER_get_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
 
     if (type != NULL) {
         l = EVP_CIPHER_CTX_iv_length(c);
-        OPENSSL_assert(l <= sizeof(c->iv));
+        if (!ossl_assert(l <= sizeof(c->iv)))
+            return -1;
         i = ASN1_TYPE_get_octetstring(type, c->oiv, l);
         if (i != (int)l)
             return (-1);
@@ -96,7 +97,8 @@ int EVP_CIPHER_set_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
 
     if (type != NULL) {
         j = EVP_CIPHER_CTX_iv_length(c);
-        OPENSSL_assert(j <= sizeof(c->iv));
+        if (!ossl_assert(j <= sizeof(c->iv)))
+            return 0;
         i = ASN1_TYPE_set_octetstring(type, c->oiv, j);
     }
     return (i);

--- a/crypto/evp/p5_crpt.c
+++ b/crypto/evp/p5_crpt.c
@@ -86,9 +86,13 @@ int PKCS5_PBE_keyivgen(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
         if (!EVP_DigestFinal_ex(ctx, md_tmp, NULL))
             goto err;
     }
-    OPENSSL_assert(EVP_CIPHER_key_length(cipher) <= (int)sizeof(md_tmp));
+    if (!ossl_assert(EVP_CIPHER_key_length(cipher) <= (int)sizeof(md_tmp))) {
+        EVPerr(EVP_F_PKCS5_PBE_KEYIVGEN, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
     memcpy(key, md_tmp, EVP_CIPHER_key_length(cipher));
-    OPENSSL_assert(EVP_CIPHER_iv_length(cipher) <= 16);
+    if (!ossl_assert(EVP_CIPHER_iv_length(cipher) <= 16))
+        goto err;
     memcpy(iv, md_tmp + (16 - EVP_CIPHER_iv_length(cipher)),
            EVP_CIPHER_iv_length(cipher));
     if (!EVP_CipherInit_ex(cctx, cipher, NULL, key, iv, en_de))

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -201,7 +201,10 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
         goto err;
     }
     keylen = EVP_CIPHER_CTX_key_length(ctx);
-    OPENSSL_assert(keylen <= sizeof key);
+    if (!ossl_assert(keylen <= sizeof key)) {
+        EVPerr(EVP_F_PKCS5_V2_PBKDF2_KEYIVGEN, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
 
     /* Decode parameter */
 

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -37,7 +37,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
     if (key != NULL) {
         reset = 1;
         j = EVP_MD_block_size(md);
-        OPENSSL_assert(j <= (int)sizeof(ctx->key));
+        if (!ossl_assert(j <= (int)sizeof(ctx->key)))
+            goto err;
         if (j < len) {
             if (!EVP_DigestInit_ex(ctx->md_ctx, md, impl))
                 goto err;

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -174,7 +174,8 @@ static int tls1_prf_P_hash(const EVP_MD *md,
     int ret = 0;
 
     chunk = EVP_MD_size(md);
-    OPENSSL_assert(chunk >= 0);
+    if (!ossl_assert(chunk >= 0))
+        goto err;
 
     ctx = EVP_MD_CTX_new();
     ctx_tmp = EVP_MD_CTX_new();

--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -292,9 +292,9 @@ int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
             }
 
             /* create the right magic header stuff */
-            OPENSSL_assert(strlen(objstr) + 23
-                           + 2 * EVP_CIPHER_iv_length(enc) + 13 <=
-                           sizeof buf);
+            if (!ossl_assert(strlen(objstr) + 23 + 2 * EVP_CIPHER_iv_length(enc)
+                             + 13 <= sizeof buf))
+                goto err;
             buf[0] = '\0';
             PEM_proc_type(buf, PEM_TYPE_ENCRYPTED);
             PEM_dek_info(buf, objstr, EVP_CIPHER_iv_length(enc),

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -370,7 +370,8 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp,
             kstr = (unsigned char *)buf;
         }
         RAND_add(data, i, 0);   /* put in the RSA key. */
-        OPENSSL_assert(EVP_CIPHER_iv_length(enc) <= (int)sizeof(iv));
+        if (!ossl_assert(EVP_CIPHER_iv_length(enc) <= (int)sizeof(iv)))
+            goto err;
         if (RAND_bytes(iv, EVP_CIPHER_iv_length(enc)) <= 0) /* Generate a salt */
             goto err;
         /*
@@ -383,8 +384,9 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp,
         if (kstr == (unsigned char *)buf)
             OPENSSL_cleanse(buf, PEM_BUFSIZE);
 
-        OPENSSL_assert(strlen(objstr) + 23 + 2 * EVP_CIPHER_iv_length(enc) + 13
-                       <= sizeof buf);
+        if (!ossl_assert(strlen(objstr) + 23 + 2 * EVP_CIPHER_iv_length(enc)
+                         + 13 <= sizeof buf))
+            goto err;
 
         buf[0] = '\0';
         PEM_proc_type(buf, PEM_TYPE_ENCRYPTED);

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -24,19 +24,22 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
 
 int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 {
-    OPENSSL_assert(*(unsigned int *)lock == 1);
+    if (!ossl_assert(*(unsigned int *)lock == 1))
+        return 0;
     return 1;
 }
 
 int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 {
-    OPENSSL_assert(*(unsigned int *)lock == 1);
+    if (!ossl_assert(*(unsigned int *)lock == 1))
+        return 0;
     return 1;
 }
 
 int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock)
 {
-    OPENSSL_assert(*(unsigned int *)lock == 1);
+    if (!ossl_assert(*(unsigned int *)lock == 1))
+        return 0;
     return 1;
 }
 

--- a/crypto/ts/ts_verify_ctx.c
+++ b/crypto/ts/ts_verify_ctx.c
@@ -23,7 +23,6 @@ TS_VERIFY_CTX *TS_VERIFY_CTX_new(void)
 
 void TS_VERIFY_CTX_init(TS_VERIFY_CTX *ctx)
 {
-    OPENSSL_assert(ctx != NULL);
     memset(ctx, 0, sizeof(*ctx));
 }
 
@@ -106,7 +105,6 @@ TS_VERIFY_CTX *TS_REQ_to_TS_VERIFY_CTX(TS_REQ *req, TS_VERIFY_CTX *ctx)
     ASN1_OCTET_STRING *msg;
     const ASN1_INTEGER *nonce;
 
-    OPENSSL_assert(req != NULL);
     if (ret)
         TS_VERIFY_CTX_cleanup(ret);
     else if ((ret = TS_VERIFY_CTX_new()) == NULL)

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -145,7 +145,8 @@ static int i2d_x509_aux_internal(X509 *a, unsigned char **pp)
     int length, tmplen;
     unsigned char *start = pp != NULL ? *pp : NULL;
 
-    OPENSSL_assert(pp == NULL || *pp != NULL);
+    if (!ossl_assert(pp == NULL || *pp != NULL))
+        return -1;
 
     /*
      * This might perturb *pp on error, but fixing that belongs in i2d_X509()

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -11,6 +11,7 @@
  * Implementation of RFC 3779 section 3.2.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "internal/cryptlib.h"
@@ -123,13 +124,13 @@ static int ASIdOrRange_cmp(const ASIdOrRange *const *a_,
 {
     const ASIdOrRange *a = *a_, *b = *b_;
 
-    OPENSSL_assert((a->type == ASIdOrRange_id && a->u.id != NULL) ||
-                   (a->type == ASIdOrRange_range && a->u.range != NULL &&
-                    a->u.range->min != NULL && a->u.range->max != NULL));
+    assert((a->type == ASIdOrRange_id && a->u.id != NULL) ||
+           (a->type == ASIdOrRange_range && a->u.range != NULL &&
+            a->u.range->min != NULL && a->u.range->max != NULL));
 
-    OPENSSL_assert((b->type == ASIdOrRange_id && b->u.id != NULL) ||
-                   (b->type == ASIdOrRange_range && b->u.range != NULL &&
-                    b->u.range->min != NULL && b->u.range->max != NULL));
+    assert((b->type == ASIdOrRange_id && b->u.id != NULL) ||
+           (b->type == ASIdOrRange_range && b->u.range != NULL &&
+            b->u.range->min != NULL && b->u.range->max != NULL));
 
     if (a->type == ASIdOrRange_id && b->type == ASIdOrRange_id)
         return ASN1_INTEGER_cmp(a->u.id, b->u.id);
@@ -167,7 +168,8 @@ int X509v3_asid_add_inherit(ASIdentifiers *asid, int which)
     if (*choice == NULL) {
         if ((*choice = ASIdentifierChoice_new()) == NULL)
             return 0;
-        OPENSSL_assert((*choice)->u.inherit == NULL);
+        if (!ossl_assert((*choice)->u.inherit == NULL))
+            return 0;
         if (((*choice)->u.inherit = ASN1_NULL_new()) == NULL)
             return 0;
         (*choice)->type = ASIdentifierChoice_inherit;
@@ -200,7 +202,8 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
     if (*choice == NULL) {
         if ((*choice = ASIdentifierChoice_new()) == NULL)
             return 0;
-        OPENSSL_assert((*choice)->u.asIdsOrRanges == NULL);
+        if (!ossl_assert((*choice)->u.asIdsOrRanges == NULL))
+            return 0;
         (*choice)->u.asIdsOrRanges = sk_ASIdOrRange_new(ASIdOrRange_cmp);
         if ((*choice)->u.asIdsOrRanges == NULL)
             return 0;
@@ -232,20 +235,23 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
 /*
  * Extract min and max values from an ASIdOrRange.
  */
-static void extract_min_max(ASIdOrRange *aor,
+static int extract_min_max(ASIdOrRange *aor,
                             ASN1_INTEGER **min, ASN1_INTEGER **max)
 {
-    OPENSSL_assert(aor != NULL && min != NULL && max != NULL);
+    if (!ossl_assert(aor != NULL && min != NULL && max != NULL))
+        return 0;
     switch (aor->type) {
     case ASIdOrRange_id:
         *min = aor->u.id;
         *max = aor->u.id;
-        return;
+        return 1;
     case ASIdOrRange_range:
         *min = aor->u.range->min;
         *max = aor->u.range->max;
-        return;
+        return 1;
     }
+
+    return 0;
 }
 
 /*
@@ -279,8 +285,9 @@ static int ASIdentifierChoice_is_canonical(ASIdentifierChoice *choice)
         ASN1_INTEGER *a_min = NULL, *a_max = NULL, *b_min = NULL, *b_max =
             NULL;
 
-        extract_min_max(a, &a_min, &a_max);
-        extract_min_max(b, &b_min, &b_max);
+        if (!extract_min_max(a, &a_min, &a_max)
+                || !extract_min_max(b, &b_min, &b_max))
+            goto done;
 
         /*
          * Punt misordered list, overlapping start, or inverted range.
@@ -318,8 +325,8 @@ static int ASIdentifierChoice_is_canonical(ASIdentifierChoice *choice)
         ASIdOrRange *a = sk_ASIdOrRange_value(choice->u.asIdsOrRanges, i);
         ASN1_INTEGER *a_min, *a_max;
         if (a != NULL && a->type == ASIdOrRange_range) {
-            extract_min_max(a, &a_min, &a_max);
-            if (ASN1_INTEGER_cmp(a_min, a_max) > 0)
+            if (!extract_min_max(a, &a_min, &a_max)
+                    || ASN1_INTEGER_cmp(a_min, a_max) > 0)
                 goto done;
         }
     }
@@ -382,13 +389,15 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
         ASN1_INTEGER *a_min = NULL, *a_max = NULL, *b_min = NULL, *b_max =
             NULL;
 
-        extract_min_max(a, &a_min, &a_max);
-        extract_min_max(b, &b_min, &b_max);
+        if (!extract_min_max(a, &a_min, &a_max)
+                || !extract_min_max(b, &b_min, &b_max))
+            goto done;
 
         /*
          * Make sure we're properly sorted (paranoia).
          */
-        OPENSSL_assert(ASN1_INTEGER_cmp(a_min, b_min) <= 0);
+        if (!ossl_assert(ASN1_INTEGER_cmp(a_min, b_min) <= 0))
+            goto done;
 
         /*
          * Punt inverted ranges.
@@ -464,13 +473,15 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
         ASIdOrRange *a = sk_ASIdOrRange_value(choice->u.asIdsOrRanges, i);
         ASN1_INTEGER *a_min, *a_max;
         if (a != NULL && a->type == ASIdOrRange_range) {
-            extract_min_max(a, &a_min, &a_max);
-            if (ASN1_INTEGER_cmp(a_min, a_max) > 0)
+            if (!extract_min_max(a, &a_min, &a_max)
+                    || ASN1_INTEGER_cmp(a_min, a_max) > 0)
                 goto done;
         }
     }
 
-    OPENSSL_assert(ASIdentifierChoice_is_canonical(choice)); /* Paranoia */
+    /* Paranoia */
+    if (!ossl_assert(ASIdentifierChoice_is_canonical(choice)))
+        goto done;
 
     ret = 1;
 
@@ -655,7 +666,8 @@ static int asid_contains(ASIdOrRanges *parent, ASIdOrRanges *child)
 
     p = 0;
     for (c = 0; c < sk_ASIdOrRange_num(child); c++) {
-        extract_min_max(sk_ASIdOrRange_value(child, c), &c_min, &c_max);
+        if (!extract_min_max(sk_ASIdOrRange_value(child, c), &c_min, &c_max))
+            return 0;
         for (;; p++) {
             if (p >= sk_ASIdOrRange_num(parent))
                 return 0;
@@ -715,9 +727,14 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     int i, ret = 1, inherit_as = 0, inherit_rdi = 0;
     X509 *x;
 
-    OPENSSL_assert(chain != NULL && sk_X509_num(chain) > 0);
-    OPENSSL_assert(ctx != NULL || ext != NULL);
-    OPENSSL_assert(ctx == NULL || ctx->verify_cb != NULL);
+    if (!ossl_assert(chain != NULL && sk_X509_num(chain) > 0)
+            || !ossl_assert(ctx != NULL || ext != NULL)
+            || !ossl_assert(ctx == NULL || ctx->verify_cb != NULL)) {
+        if (ctx != NULL)
+            ctx->error = X509_V_ERR_UNSPECIFIED;
+        return 0;
+    }
+
 
     /*
      * Figure out where to start.  If we don't have an extension to
@@ -730,7 +747,11 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     } else {
         i = 0;
         x = sk_X509_value(chain, i);
-        OPENSSL_assert(x != NULL);
+        if (!ossl_assert(x != NULL)) {
+            if (ctx != NULL)
+                ctx->error = X509_V_ERR_UNSPECIFIED;
+            return 0;
+        }
         if ((ext = x->rfc3779_asid) == NULL)
             goto done;
     }
@@ -763,7 +784,11 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
      */
     for (i++; i < sk_X509_num(chain); i++) {
         x = sk_X509_value(chain, i);
-        OPENSSL_assert(x != NULL);
+        if (!ossl_assert(x != NULL)) {
+            if (ctx != NULL)
+                ctx->error = X509_V_ERR_UNSPECIFIED;
+            return 0;
+        }
         if (x->rfc3779_asid == NULL) {
             if (child_as != NULL || child_rdi != NULL)
                 validation_err(X509_V_ERR_UNNESTED_RESOURCE);
@@ -809,7 +834,11 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     /*
      * Trust anchor can't inherit.
      */
-    OPENSSL_assert(x != NULL);
+    if (!ossl_assert(x != NULL)) {
+        if (ctx != NULL)
+            ctx->error = X509_V_ERR_UNSPECIFIED;
+        return 0;
+    }
     if (x->rfc3779_asid != NULL) {
         if (x->rfc3779_asid->asnum != NULL &&
             x->rfc3779_asid->asnum->type == ASIdentifierChoice_inherit)
@@ -830,6 +859,10 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
  */
 int X509v3_asid_validate_path(X509_STORE_CTX *ctx)
 {
+    if (ctx->chain == NULL
+            || sk_X509_num(ctx->chain) == 0
+            || ctx->verify_cb == NULL)
+        return 0;
     return asid_validate_path_internal(ctx, ctx->chain, NULL);
 }
 

--- a/doc/man3/AES_ige_encrypt_ex.pod
+++ b/doc/man3/AES_ige_encrypt_ex.pod
@@ -1,0 +1,96 @@
+=pod
+
+=head1 NAME
+
+AES_ige_encrypt_ex, AES_bi_ige_encrypt_ex, AES_ige_encrypt, AES_bi_ige_encrypt
+- AES IGE encryption routines
+
+=head1 SYNOPSIS
+
+ int AES_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                        size_t length, const AES_KEY *key,
+                        unsigned char *ivec, const int enc);
+
+ int AES_bi_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                           size_t length, const AES_KEY *key,
+                           const AES_KEY *key2, const unsigned char *ivec,
+                           const int enc);
+
+Scheduled for future deprecation:
+
+ #if OPENSSL_API_COMPAT < 0x10200000L
+
+ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
+                      size_t length, const AES_KEY *key, unsigned, char *ivec,
+                      const int enc))
+
+ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
+                         size_t length, const AES_KEY *key, const AES_KEY *key2,
+                         const unsigned char *ivec, const int enc))
+
+ #endif
+
+=head1 DESCRIPTION
+
+AES_ige_encrypt_ex() encrypts or decrypts the data pointed to by B<in> and puts
+the output in the buffer at B<out> using AES as the block cipher in IGE mode.
+
+IGE (Infinite Garble Extension) mode has the property that errors are propagated
+forward in the stream indefinitely, i.e. a change in the ciphertext at a
+particular point in the stream will cause all plaintext after that point to be
+corrupted. Bi-directional IGE has the additional property that a change in the
+ciphertext at a particular point will cause all the plaintext to be corrupted.  
+
+The input buffer is expected to be B<length> bytes long and must be a multiple
+of AES_BLOCK_SIZE. The output buffer B<out> must also be at least B<length>
+bytes long.
+
+IGE mode expects an IV of twice the block size (i.e. 2 * AES_BLOCK_SIZE) to be
+stored in the location pointed to by B<ivec>. The key pointed to by B<key>
+should have been previously initialised via a call to L<AES_set_encrypt_key(3)>
+or L<AES_set_decrypt_key(3)> as appropriate. The value of B<enc> should either
+be AES_ENCRYPT or AES_DECRYPT depending on whether encryption or decryption is
+required.
+
+On successful completion of the function the contents of the buffer pointed to
+by B<ivec> will be updated with a new Initialisation Vector suitable for any
+further data in the same stream. In this way AES_ige_encrypt_ex() can be called
+repeatedly on successive chunks of the data stream.
+
+AES_bi_ige_encrypt_ex() works in the same way as AES_ige_encrypt_ex() except
+that it uses AES in bi-directional IGE mode. The parameters for this function
+have the same meanings as for AES_ige_encrypt_ex() except that bi-directional
+IGE mode expects the IV at B<ivec> to be four times the block size (i.e.
+4 * AES_BLOCK_SIZE). Additionally a second key is required and is provided by
+B<key2>. Finally AES_bi_ige_encrypt_ex() does not update the value in B<ivec>
+for streaming operation on successful completion. Calls to
+AES_bi_ige_encrypt_ex() must fully encrypt or decrypt the data in a single pass.
+
+AES_ige_encrypt() is exactly the same as AES_ige_encrypt_ex() except that errors
+are silently ignored. For this reason AES_ige_encrypt_ex() should be used in
+preference. Similarly AES_bi_ige_encrypt() is exactly the same as
+AES_bi_ige_encrypt_ex() and also silently ignores errors, so
+AES_bi_ige_encrypt_ex() should be used in preference.
+
+=head1 RETURN VALUES
+
+AES_ige_encrypt_ex() and AES_bi_ige_encrypt_ex() return 1 on success or 0 on
+failure.
+
+=head1 HISTORY
+
+AES_ige_encrypt_ex() and AES_bi_ige_encrypt_ex() were added in OpenSSL 1.1.1.
+
+AES_ige_encrypt() and AES_bi_ige_encrypt() are scheduled for deprecation from
+OpenSSL 1.2.0.
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -68,14 +68,27 @@ void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
                         unsigned char *ivec, int *num);
 /* NB: the IV is _two_ blocks long */
-void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
-                     size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc);
+DEPRECATEDIN_1_2_0(void AES_ige_encrypt(const unsigned char *in,
+                                        unsigned char *out, size_t length,
+                                        const AES_KEY *key, unsigned char *ivec,
+                                        const int enc))
 /* NB: the IV is _four_ blocks long */
-void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
-                        size_t length, const AES_KEY *key,
-                        const AES_KEY *key2, const unsigned char *ivec,
-                        const int enc);
+DEPRECATEDIN_1_2_0(void AES_bi_ige_encrypt(const unsigned char *in,
+                                           unsigned char *out, size_t length,
+                                           const AES_KEY *key,
+                                           const AES_KEY *key2,
+                                           const unsigned char *ivec,
+                                           const int enc))
+
+/* NB: the IV is _two_ blocks long */
+int AES_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                       size_t length, const AES_KEY *key,
+                       unsigned char *ivec, const int enc);
+/* NB: the IV is _four_ blocks long */
+int AES_bi_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                          size_t length, const AES_KEY *key,
+                          const AES_KEY *key2, const unsigned char *ivec,
+                          const int enc);
 
 int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out,

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -11,6 +11,7 @@
 # define HEADER_AES_H
 
 # include <openssl/opensslconf.h>
+# include <openssl/e_os2.h>
 
 # include <stddef.h>
 # ifdef  __cplusplus
@@ -81,14 +82,14 @@ DEPRECATEDIN_1_2_0(void AES_bi_ige_encrypt(const unsigned char *in,
                                            const int enc))
 
 /* NB: the IV is _two_ blocks long */
-int AES_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
-                       size_t length, const AES_KEY *key,
-                       unsigned char *ivec, const int enc);
+__owur int AES_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                              size_t length, const AES_KEY *key,
+                              unsigned char *ivec, const int enc);
 /* NB: the IV is _four_ blocks long */
-int AES_bi_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
-                          size_t length, const AES_KEY *key,
-                          const AES_KEY *key2, const unsigned char *ivec,
-                          const int enc);
+__owur int AES_bi_ige_encrypt_ex(const unsigned char *in, unsigned char *out,
+                                 size_t length, const AES_KEY *key,
+                                 const AES_KEY *key2, const unsigned char *ivec,
+                                 const int enc);
 
 int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out,

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -95,6 +95,9 @@ extern "C" {
 # define OPENSSL_API_COMPAT OPENSSL_MIN_API
 #endif
 
+/* Functions may be flagged for future deprecation */
+#define DEPRECATEDIN_1_2_0(f)   f;
+
 #if OPENSSL_API_COMPAT < 0x10100000L
 # define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
 #else

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4292,3 +4292,5 @@ PEM_read_bio_ex                         4234	1_1_1	EXIST::FUNCTION:
 PEM_bytes_read_bio_secmem               4235	1_1_1	EXIST::FUNCTION:
 EVP_DigestSign                          4236	1_1_1	EXIST::FUNCTION:
 EVP_DigestVerify                        4237	1_1_1	EXIST::FUNCTION:
+AES_ige_encrypt_ex                      4238	1_1_1	EXIST::FUNCTION:
+AES_bi_ige_encrypt_ex                   4239	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This removes all instances of OPENSSL_assert() from libcrypto. In most cases there has been a straight replacement with ossl_assert(). 

In some cases it seems that OPENSSL_assert() was being used to validate input parameters coming from application code. For those I removed OPENSSL_assert() completely and just replaced with a check and error return. For AES_ige_encrypt() and AES_bi_ige_encrypt() this was problematic because they are void functions - so I had to create _ex versions of them that do return an error.

In the bn module there was some usage in some macros which would have been very disruptive to add error returns for. However it turned out that they were all guarded by "ifdef BN_DEBUG", so these macros never get invoked in a production build anyway. Therefore for those I replaced with standard assert().

There were a couple of functions in mem_sec.c which, while it could have been done, it was quite tricky and disruptive to change the return value because there was already a return value in place that did not allow for an error value. In those cases I decided to replace with standard assert(). Replacing them with ossl_assert() was too disruptive for low value.