### PR TITLE
Fix no-comp in 1.0.2

### DIFF
--- a/ssl/ssltest.c
+++ b/ssl/ssltest.c
@@ -1239,13 +1239,21 @@ int main(int argc, char *argv[])
         } else if (strcmp(*argv, "-time") == 0) {
             print_time = 1;
         }
-#ifndef OPENSSL_NO_COMP
         else if (strcmp(*argv, "-zlib") == 0) {
+#ifndef OPENSSL_NO_COMP
             comp = COMP_ZLIB;
-        } else if (strcmp(*argv, "-rle") == 0) {
-            comp = COMP_RLE;
-        }
+#else
+            fprintf(stderr,
+                    "ignoring -zlib, since I'm compiled without COMP\n");
 #endif
+        } else if (strcmp(*argv, "-rle") == 0) {
+#ifndef OPENSSL_NO_COMP
+            comp = COMP_RLE;
+#else
+            fprintf(stderr,
+                    "ignoring -rle, since I'm compiled without COMP\n");
+#endif
+        }
         else if (strcmp(*argv, "-named_curve") == 0) {
             if (--argc < 1)
                 goto bad;


### PR DESCRIPTION
Fixes make test when configured with no-comp.

This was actually written by @bernd-edlinger but was tacked onto #2595. I think it deserves a separate PR so I'm opening it here.

This is urgent as I'd like to include it in today's release.