### PR TITLE
Fix BoringSSL alert related test failures

### DIFF
--- a/test/ossl_shim/ossl_config.json
+++ b/test/ossl_shim/ossl_config.json
@@ -256,7 +256,7 @@
         ":UNEXPECTED_RECORD:":"unexpected message",
         ":TLSV1_ALERT_RECORD_OVERFLOW:":"tlsv1 alert record overflow",
         ":WRONG_SSL_VERSION:":"no protocols available",
-        ":BAD_ALERT:":"tlsv1 alert record overflow",
+        ":BAD_ALERT:":"invalid alert",
         ":HTTP_REQUEST:":"http request",
         ":HTTPS_PROXY_REQUEST:":"https proxy request",
         ":WRONG_CERTIFICATE_TYPE:":"wrong certificate type",


### PR DESCRIPTION
Commit bd990e2535 changed our handling of alerts. Some of the BoringSSl
tests were expecting specific errors to be created if bad alerts were sent.
Those errors have now changed as a result of that commit, so the BoringSSL
test config needs to be updated to match.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
