### PR TITLE
Add stricter checking in NAME section

### DIFF
--- a/doc/man3/BIO_meth_new.pod
+++ b/doc/man3/BIO_meth_new.pod
@@ -9,7 +9,7 @@ BIO_meth_set_write, BIO_meth_get_read, BIO_meth_set_read, BIO_meth_get_puts,
 BIO_meth_set_puts, BIO_meth_get_gets, BIO_meth_set_gets, BIO_meth_get_ctrl,
 BIO_meth_set_ctrl, BIO_meth_get_create, BIO_meth_set_create,
 BIO_meth_get_destroy, BIO_meth_set_destroy, BIO_meth_get_callback_ctrl,
-BIO_meth_set_callback_ctrl  - Routines to build up BIO methods
+BIO_meth_set_callback_ctrl - Routines to build up BIO methods
 
 =head1 SYNOPSIS
 

--- a/doc/man3/DSA_meth_new.pod
+++ b/doc/man3/DSA_meth_new.pod
@@ -10,7 +10,7 @@ DSA_meth_get_verify, DSA_meth_set_verify, DSA_meth_get_mod_exp,
 DSA_meth_set_mod_exp, DSA_meth_get_bn_mod_exp, DSA_meth_set_bn_mod_exp,
 DSA_meth_get_init, DSA_meth_set_init, DSA_meth_get_finish, DSA_meth_set_finish,
 DSA_meth_get_paramgen, DSA_meth_set_paramgen, DSA_meth_get_keygen,
-DSA_meth_set_keygen  - Routines to build up DSA methods
+DSA_meth_set_keygen - Routines to build up DSA methods
 
 =head1 SYNOPSIS
 

--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -10,7 +10,7 @@ EVP_CIPHER_meth_set_set_asn1_params, EVP_CIPHER_meth_set_get_asn1_params,
 EVP_CIPHER_meth_set_ctrl, EVP_CIPHER_meth_get_init,
 EVP_CIPHER_meth_get_do_cipher, EVP_CIPHER_meth_get_cleanup,
 EVP_CIPHER_meth_get_set_asn1_params, EVP_CIPHER_meth_get_get_asn1_params,
-EVP_CIPHER_meth_get_ctrl  - Routines to build up EVP_CIPHER methods
+EVP_CIPHER_meth_get_ctrl - Routines to build up EVP_CIPHER methods
 
 =head1 SYNOPSIS
 

--- a/doc/man3/SCT_new.pod
+++ b/doc/man3/SCT_new.pod
@@ -11,7 +11,7 @@ SCT_get_signature_nid, SCT_set_signature_nid,
 SCT_get0_signature, SCT_set0_signature, SCT_set1_signature,
 SCT_get0_extensions, SCT_set0_extensions, SCT_set1_extensions,
 SCT_get_source, SCT_set_source
- - A Certificate Transparency Signed Certificate Timestamp
+- A Certificate Transparency Signed Certificate Timestamp
 
 =head1 SYNOPSIS
 

--- a/doc/man3/SSL_CTX_dane_enable.pod
+++ b/doc/man3/SSL_CTX_dane_enable.pod
@@ -5,8 +5,8 @@
 SSL_CTX_dane_enable, SSL_CTX_dane_mtype_set, SSL_dane_enable,
 SSL_dane_tlsa_add, SSL_get0_dane_authority, SSL_get0_dane_tlsa,
 SSL_CTX_dane_set_flags, SSL_CTX_dane_clear_flags,
-SSL_dane_set_flags, SSL_dane_clear_flags -
-enable DANE TLS authentication of the remote TLS server in the local
+SSL_dane_set_flags, SSL_dane_clear_flags
+- enable DANE TLS authentication of the remote TLS server in the local
 TLS client
 
 =head1 SYNOPSIS

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -60,7 +60,9 @@ sub name_synopsis()
     my $tmp = $1;
     $tmp =~ tr/\n/ /;
     print "$id trailing comma before - in NAME\n" if $tmp =~ /, *-/;
-    $tmp =~ s/-.*//g;
+    $tmp =~ s/ -.*//g;
+    $tmp =~ s/  */ /g;
+    print "$id missing comma in NAME\n" if $tmp =~ /[^,] /;
     $tmp =~ s/,//g;
 
     my $dirname = dirname($filename);


### PR DESCRIPTION
Require a comma between every name and a single space before the dash

This is a followon to #3557.
