### PR TITLE
Fix use of "can_load()" in run_tests.pl. Fixes #3563.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -19,7 +19,7 @@ use File::Basename;
 use if $^O ne "VMS", 'File::Glob' => qw/glob/;
 use Module::Load::Conditional qw(can_load);
 
-my $TAP_Harness = can_load({modules => [ 'TAP::Harness' ]})
+my $TAP_Harness = can_load(modules => { 'TAP::Harness' => undef }) 
     ? 'TAP::Harness' : 'OpenSSL::TAP::Harness';
 
 my $srctop = $ENV{SRCTOP} || $ENV{TOP};


### PR DESCRIPTION
Fix use of "can_load()" in run_tests.pl.

Fixes #3563.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
