### PR TITLE
Fix ex_data and session_dup issues

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -473,7 +473,7 @@ static int int_dup_ex_data(int class_index, CRYPTO_EX_DATA *to,
     if (j < mx)
         mx = j;
     if (mx > 0) {
-        if (!CRYPTO_set_ex_data(to, mx - 1, NULL))
+        if (!CRYPTO_set_ex_data(to, mx - 1, CRYPTO_get_ex_data(to, mx - 1)))
             goto skip;
         storage = OPENSSL_malloc(mx * sizeof(CRYPTO_EX_DATA_FUNCS *));
         if (!storage)

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -275,6 +275,9 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
     if (src->peer != NULL)
         CRYPTO_add(&src->peer->references, 1, CRYPTO_LOCK_X509);
 
+    if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_SSL_SESSION, dest, &dest->ex_data))
+        goto err;
+
 #ifndef OPENSSL_NO_PSK
     if (src->psk_identity_hint) {
         dest->psk_identity_hint = BUF_strdup(src->psk_identity_hint);
@@ -325,7 +328,7 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
     }
 # endif
 
-    if (ticket != 0) {
+    if (ticket != 0 && src->tlsext_tick != NULL) {
         dest->tlsext_tick = BUF_memdup(src->tlsext_tick, src->tlsext_ticklen);
         if(dest->tlsext_tick == NULL)
             goto err;


### PR DESCRIPTION
Backport of #3323 for 1.0.2

Based on commit 72549266433267905d4ad9906c4a056a8bcce695 but not
really a cherry-pick.  In particular, we don't add error handling to the uprefs in ssl_session_dup() (as they just use the raw crypto addition primitives that don't really have error returns), there's no documentation to update, and there's no existing test to update.

