### PR TITLE
Fix a Proxy race condition

### DIFF
--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -49,6 +49,7 @@ sub new
         clientflags => "",
         serverconnects => 1,
         serverpid => 0,
+        clientpid => 0,
         reneg => 0,
         sessionfile => undef,
 
@@ -113,6 +114,7 @@ sub clearClient
     $self->{message_list} = [];
     $self->{clientflags} = "";
     $self->{sessionfile} = undef;
+    $self->{clientpid} = 0;
     $is_tls13 = 0;
     $ciphersuite = undef;
 
@@ -240,6 +242,7 @@ sub clientstart
             }
             exec($execcmd);
         }
+        $self->clientpid($pid);
     }
 
     # Wait for incoming connection from client
@@ -338,6 +341,10 @@ sub clientstart
         waitpid( $self->serverpid, 0);
         die "exit code $? from server process\n" if $? != 0;
     }
+    die "clientpid is zero\n" if $self->clientpid == 0;
+    print "Waiting for client process to close: ".$self->clientpid."\n";
+    waitpid($self->clientpid, 0);
+
     return 1;
 }
 
@@ -530,6 +537,14 @@ sub serverpid
         $self->{serverpid} = shift;
     }
     return $self->{serverpid};
+}
+sub clientpid
+{
+    my $self = shift;
+    if (@_) {
+        $self->{clientpid} = shift;
+    }
+    return $self->{clientpid};
 }
 
 sub fill_known_data


### PR DESCRIPTION
Issue #3562 describes a problem where a race condition can occur in the
Proxy such that a test "ok" line can appear in the middle of other text
causing the test harness to miss it. The issue is that we do not wait for
the client process to finish after the test is complete, so that process may
continue to write data to stdout/stderr at the same time that the test
harness does.

This commit fixes TLSProxy so that we always wait for the client process to
finish before continuing.

I've not actually been able to trigger this race condition on my own machine so this fix is based on the analysis of output from other tests. Only time will tell if it really works.

Fixes #3562

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
