### PR TITLE
improve CRYPTO_free

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -254,6 +254,7 @@ void CRYPTO_free(void *str, const char *file, int line)
 {
     if (free_impl != NULL && free_impl != &CRYPTO_free) {
         free_impl(str, file, line);
+        free(str);
         return;
     }
 
@@ -265,8 +266,10 @@ void CRYPTO_free(void *str, const char *file, int line)
     } else {
         free(str);
     }
+    str = NULL;
 #else
     free(str);
+    str = NULL;
 #endif
 }
 


### PR DESCRIPTION
Hello,

I would like to suggest improve CRYPTO_free function.
As in this patch, how about substitute null for freed pointer for prevent dangling pointer? 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->