### PR TITLE
Fix certificate version number in test

### DIFF
--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -251,7 +251,7 @@ static X509 *make_cert()
 
     if (!TEST_ptr(crt = X509_new()))
         return NULL;
-    if (!TEST_true(X509_set_version(crt, 3))) {
+    if (!TEST_true(X509_set_version(crt, 2))) {
         X509_free(crt);
         return NULL;
     }


### PR DESCRIPTION
CLA: Trivial

The version number 3 means version 4, while 2 means version 3. Since this is the v3nametest, version 3 should be used.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
