### PR TITLE
Fix coding style in policy_data_free

### DIFF
--- a/crypto/x509v3/pcy_data.c
+++ b/crypto/x509v3/pcy_data.c
@@ -17,7 +17,7 @@
 
 void policy_data_free(X509_POLICY_DATA *data)
 {
-    if (!data)
+    if (data == NULL)
         return;
     ASN1_OBJECT_free(data->valid_policy);
     /* Don't free qualifiers if shared */
@@ -40,11 +40,11 @@ X509_POLICY_DATA *policy_data_new(POLICYINFO *policy,
 {
     X509_POLICY_DATA *ret;
     ASN1_OBJECT *id;
-    if (!policy && !cid)
+    if (policy == NULL && cid == NULL)
         return NULL;
     if (cid) {
         id = OBJ_dup(cid);
-        if (!id)
+        if (id == NULL)
             return NULL;
     } else
         id = NULL;


### PR DESCRIPTION
Hello,

I would like to suggest fix coding style in policy_data_free function.

In policy_data_free function use ! to check if a pointer is NULL.
This is not in line for OpenSSL coding style.
(see: OpenSSL coding style Chapter 21(https://www.openssl.org/policies/codingstyle.html))

As in this patch, how about fix coding style?

