### PR TITLE
Wait longer for the server in TLSProxy to start

### DIFF
--- a/util/TLSProxy/Proxy.pm
+++ b/util/TLSProxy/Proxy.pm
@@ -255,7 +255,7 @@ sub clientstart
     print "Connection opened\n";
 
     # Now connect to the server
-    my $retry = 3;
+    my $retry = 10;
     my $server_sock;
     #We loop over this a few times because sometimes s_server can take a while
     #to start up


### PR DESCRIPTION
In a recent PR (#3566) it seems that TLSProxy gave up trying to connect to
the server process too quickly. This meant the test failed even though the
server *did* eventually start. Currently we try 3 times to connect with a
0.1 second pause between each attempt. That is probably too aggressive.