### PR TITLE
fix check of broken implementations of GOST ciphersuites

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2692,17 +2692,6 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto f_err;
     }
 
-    /* Check for broken implementations of GOST ciphersuites */
-    /*
-     * If key is GOST and n is exactly 64, it is bare signature without
-     * length field (CryptoPro implementations at least till CSP 4.0)
-     */
-#ifndef OPENSSL_NO_GOST
-    if (PACKET_remaining(pkt) == 64
-        && EVP_PKEY_id(pkey) == NID_id_GostR3410_2001) {
-        len = 64;
-    } else
-#endif
     {
         if (SSL_USE_SIGALGS(s)) {
             int rv;
@@ -2733,6 +2722,20 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
             }
         }
 
+        /* Check for broken implementations of GOST ciphersuites */
+        /*
+         * If key is GOST and len is exactly 64 or 128, it is signature without
+         * length field (CryptoPro implementations at least till TLS 1.2)
+         */
+#ifndef OPENSSL_NO_GOST
+        if ((PACKET_remaining(pkt) == 64
+             && (EVP_PKEY_id(pkey) == NID_id_GostR3410_2001
+                 || EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_256))
+            || (PACKET_remaining(pkt) == 128
+                && EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_512)){
+            len = PACKET_remaining(pkt);
+        } else
+#endif
         if (!PACKET_get_net_2(pkt, &len)) {
             SSLerr(SSL_F_TLS_PROCESS_CERT_VERIFY, SSL_R_LENGTH_MISMATCH);
             al = SSL_AD_DECODE_ERROR;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2692,57 +2692,56 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto f_err;
     }
 
-    {
-        if (SSL_USE_SIGALGS(s)) {
-            int rv;
+    if (SSL_USE_SIGALGS(s)) {
+        int rv;
 
-            if (!PACKET_get_bytes(pkt, &sig, 2)) {
-                al = SSL_AD_DECODE_ERROR;
-                goto f_err;
-            }
-            rv = tls12_check_peer_sigalg(&md, s, sig, pkey);
-            if (rv == -1) {
-                al = SSL_AD_INTERNAL_ERROR;
-                goto f_err;
-            } else if (rv == 0) {
-                al = SSL_AD_DECODE_ERROR;
-                goto f_err;
-            }
-#ifdef SSL_DEBUG
-            fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
-#endif
-        } else {
-            /* Use default digest for this key type */
-            int idx = ssl_cert_type(NULL, pkey);
-            if (idx >= 0)
-                md = s->s3->tmp.md[idx];
-            if (md == NULL) {
-                al = SSL_AD_INTERNAL_ERROR;
-                goto f_err;
-            }
-        }
-
-        /* Check for broken implementations of GOST ciphersuites */
-        /*
-         * If key is GOST and len is exactly 64 or 128, it is signature without
-         * length field (CryptoPro implementations at least till TLS 1.2)
-         */
-#ifndef OPENSSL_NO_GOST
-        if (!SSL_USE_SIGALGS(s)
-            && ((PACKET_remaining(pkt) == 64
-                 && (EVP_PKEY_id(pkey) == NID_id_GostR3410_2001
-                     || EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_256))
-                || (PACKET_remaining(pkt) == 128
-                    && EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_512))) {
-            len = PACKET_remaining(pkt);
-        } else
-#endif
-        if (!PACKET_get_net_2(pkt, &len)) {
-            SSLerr(SSL_F_TLS_PROCESS_CERT_VERIFY, SSL_R_LENGTH_MISMATCH);
+        if (!PACKET_get_bytes(pkt, &sig, 2)) {
             al = SSL_AD_DECODE_ERROR;
             goto f_err;
         }
+        rv = tls12_check_peer_sigalg(&md, s, sig, pkey);
+        if (rv == -1) {
+            al = SSL_AD_INTERNAL_ERROR;
+            goto f_err;
+        } else if (rv == 0) {
+            al = SSL_AD_DECODE_ERROR;
+            goto f_err;
+        }
+#ifdef SSL_DEBUG
+        fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
+#endif
+    } else {
+        /* Use default digest for this key type */
+        int idx = ssl_cert_type(NULL, pkey);
+        if (idx >= 0)
+            md = s->s3->tmp.md[idx];
+        if (md == NULL) {
+            al = SSL_AD_INTERNAL_ERROR;
+            goto f_err;
+        }
     }
+
+    /* Check for broken implementations of GOST ciphersuites */
+    /*
+     * If key is GOST and len is exactly 64 or 128, it is signature without
+     * length field (CryptoPro implementations at least till TLS 1.2)
+     */
+#ifndef OPENSSL_NO_GOST
+    if (!SSL_USE_SIGALGS(s)
+        && ((PACKET_remaining(pkt) == 64
+             && (EVP_PKEY_id(pkey) == NID_id_GostR3410_2001
+                 || EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_256))
+            || (PACKET_remaining(pkt) == 128
+                && EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_512))) {
+        len = PACKET_remaining(pkt);
+    } else
+#endif
+    if (!PACKET_get_net_2(pkt, &len)) {
+        SSLerr(SSL_F_TLS_PROCESS_CERT_VERIFY, SSL_R_LENGTH_MISMATCH);
+        al = SSL_AD_DECODE_ERROR;
+        goto f_err;
+    }
+
     j = EVP_PKEY_size(pkey);
     if (((int)len > j) || ((int)PACKET_remaining(pkt) > j)
         || (PACKET_remaining(pkt) == 0)) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2728,11 +2728,12 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
          * length field (CryptoPro implementations at least till TLS 1.2)
          */
 #ifndef OPENSSL_NO_GOST
-        if ((PACKET_remaining(pkt) == 64
-             && (EVP_PKEY_id(pkey) == NID_id_GostR3410_2001
-                 || EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_256))
-            || (PACKET_remaining(pkt) == 128
-                && EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_512)){
+        if (!SSL_USE_SIGALGS(s)
+            && ((PACKET_remaining(pkt) == 64
+                 && (EVP_PKEY_id(pkey) == NID_id_GostR3410_2001
+                     || EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_256))
+                || (PACKET_remaining(pkt) == 128
+                    && EVP_PKEY_id(pkey) == NID_id_GostR3410_2012_512))) {
             len = PACKET_remaining(pkt);
         } else
 #endif


### PR DESCRIPTION
This patch moves the current check of "broken implementations of GOST ciphersuites" to a correct place and adds new GOST 2012 nids to this check.
