### PR TITLE
Send a protocol version alert

### DIFF
--- a/ssl/s23_clnt.c
+++ b/ssl/s23_clnt.c
@@ -735,7 +735,35 @@ static int ssl23_get_server_hello(SSL *s)
             s->version = TLS1_2_VERSION;
             s->method = TLSv1_2_client_method();
         } else {
+            /*
+             * Unrecognised version, we'll send a protocol version alert using
+             * our preferred version.
+             */
+            switch(s->client_version) {
+            default:
+                /*
+                 * Shouldn't happen
+                 * Fall through
+                 */
+            case TLS1_2_VERSION:
+                s->version = TLS1_2_VERSION;
+                s->method = TLSv1_2_client_method();
+                break;
+            case TLS1_1_VERSION:
+                s->version = TLS1_1_VERSION;
+                s->method = TLSv1_1_client_method();
+                break;
+            case TLS1_VERSION:
+                s->version = TLS1_VERSION;
+                s->method = TLSv1_client_method();
+                break;
+            case SSL3_VERSION:
+                s->version = SSL3_VERSION;
+                s->method = SSLv3_client_method();
+                break;
+            }
             SSLerr(SSL_F_SSL23_GET_SERVER_HELLO, SSL_R_UNSUPPORTED_PROTOCOL);
+            ssl3_send_alert(s, SSL3_AL_FATAL, SSL_AD_PROTOCOL_VERSION);
             goto err;
         }
 


### PR DESCRIPTION
If we fail to negotiate a version then we should send a protocol version
alert.

Fixes #3595

Note 1: This issue only impacts 1.0.2. Version negotiation was rewritten for 1.1.0 and it does this correctly.

Note 2: The value of sending an alert in this scenario is somewhat limited because we have failed to agree a protocol version so the server is likely to reject our alert anyway. However this brings the behaviour in line with the RFC and the 1.1.0 implementation.