### PR TITLE
Do not document SSL_CTX_set1_cert_store()

### DIFF
--- a/doc/ssl/ssl.pod
+++ b/doc/ssl/ssl.pod
@@ -320,8 +320,6 @@ protocol context defined in the B<SSL_CTX> structure.
 
 =item void B<SSL_CTX_set_cert_store>(SSL_CTX *ctx, X509_STORE *cs);
 
-=item void B<SSL_CTX_set1_cert_store>(SSL_CTX *ctx, X509_STORE *cs);
-
 =item void B<SSL_CTX_set_cert_verify_cb>(SSL_CTX *ctx, int (*cb)(), char *arg)
 
 =item int B<SSL_CTX_set_cipher_list>(SSL_CTX *ctx, char *str);


### PR DESCRIPTION
It does not exist on this branch.

Arguably one should run find-doc-nits against the whole branch, but I did not have time to fight with getting the requisite perl modules checked out right now.