### PR TITLE
Avoid failing s_server when client's psk_identity is unexpected

### DIFF
--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -333,6 +333,12 @@ Inhibit printing of session and certificate information.
 
 Use the PSK identity hint B<hint> when using a PSK cipher suite.
 
+=item B<-psk_identity identity>
+
+Expect the client to send PSK identity B<identity> when using a PSK
+cipher suite, and warn if they do not.  By default, the expected PSK
+identity is the string "Client_identity".
+
 =item B<-psk key>
 
 Use the PSK key B<key> when using a PSK cipher suite. The key is


### PR DESCRIPTION
s_server has traditionally been very brittle in PSK mode.  If the
client offered any PSK identity other than "Client_identity" s_server
would simply abort.

This is breakage for breakage's sake, and unlike most other parts of
s_server, which tend to allow more flexible connections.

This change accomplishes two things:

 * when the client's psk_identity does *not* match the identity
   expected by the server, just warn, don't fail.

 * allow the server to expect instead a different psk_identity from
   the client besides "Client_identity"

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
