### PR TITLE
Updated 1.0.2 so thread safe gmtime_r/localtime_r are used on supported systems. 

### DIFF
--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -633,6 +633,7 @@ static void print_leak_doall_arg(const MEM *m, MEM_LEAK *l)
     APP_INFO *amip;
     int ami_cnt;
     struct tm *lcl = NULL;
+    struct tm result = {0};
     CRYPTO_THREADID ti;
 
 #define BUF_REMAIN (sizeof buf - (size_t)(bufp - buf))
@@ -641,8 +642,13 @@ static void print_leak_doall_arg(const MEM *m, MEM_LEAK *l)
         return;
 
     if (options & V_CRYPTO_MDEBUG_TIME) {
+# if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && \
+            !defined(OPENSSL_SYS_OS2) && !defined(OPENSSL_SYS_SUNOS) && \
+            (!defined(OPENSSL_SYS_VMS) || defined(localtime_r))
+        lcl = localtime_r(&m->time, &result);
+# else
         lcl = localtime(&m->time);
-
+# endif
         BIO_snprintf(bufp, BUF_REMAIN, "[%02d:%02d:%02d] ",
                      lcl->tm_hour, lcl->tm_min, lcl->tm_sec);
         bufp += strlen(bufp);

--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -105,7 +105,7 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
 {
     struct tm *ts = NULL;
 
-#if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && !defined(OPENSSL_SYS_OS2) && (!defined(OPENSSL_SYS_VMS) || defined(gmtime_r)) && !defined(OPENSSL_SYS_MACOSX) && !defined(OPENSSL_SYS_SUNOS)
+#if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && !defined(OPENSSL_SYS_OS2) && (!defined(OPENSSL_SYS_VMS) || defined(gmtime_r)) && !defined(OPENSSL_SYS_SUNOS)
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -58,6 +58,7 @@
  */
 
 #include "cryptlib.h"
+#include "o_time.h"
 
 #if defined(OPENSSL_SYS_UNIX)
 # include <sys/time.h>
@@ -948,6 +949,7 @@ static ASN1_GENERALIZEDTIME
 {
     time_t time_sec = (time_t)sec;
     struct tm *tm = NULL;
+    struct tm result = {0};
     char genTime_str[17 + TS_MAX_CLOCK_PRECISION_DIGITS];
     char *p = genTime_str;
     char *p_end = genTime_str + sizeof(genTime_str);
@@ -955,7 +957,7 @@ static ASN1_GENERALIZEDTIME
     if (precision > TS_MAX_CLOCK_PRECISION_DIGITS)
         goto err;
 
-    if (!(tm = gmtime(&time_sec)))
+    if (!(tm = OPENSSL_gmtime(&time_sec, &result)))
         goto err;
 
     /*

--- a/ssl/kssl.c
+++ b/ssl/kssl.c
@@ -78,6 +78,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/krb5_asn.h>
+#include "o_time.h"
 #include "kssl_lcl.h"
 
 #ifndef OPENSSL_NO_KRB5
@@ -2026,6 +2027,8 @@ krb5_error_code kssl_check_authent(
     int outl, unencbufsize;
     struct tm tm_time, *tm_l, *tm_g;
     time_t now, tl, tg, tr, tz_offset;
+    struct tm gmt_result = {0};
+    struct tm lt_result = {0};
 
     EVP_CIPHER_CTX_init(&ciph_ctx);
     *atimep = 0;
@@ -2140,9 +2143,17 @@ krb5_error_code kssl_check_authent(
     if (k_gmtime(auth->ctime, &tm_time) &&
         ((tr = mktime(&tm_time)) != (time_t)(-1))) {
         now = time(&now);
+        tm_g = OPENSSL_gmtime(&now, &gmt_result);
+
+# if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && \
+            !defined(OPENSSL_SYS_OS2) && !defined(OPENSSL_SYS_SUNOS) && \
+            (!defined(OPENSSL_SYS_VMS) || defined(localtime_r))
+        tm_l = localtime_r(&now, &lt_result);
+# else
         tm_l = localtime(&now);
+# endif
+
         tl = mktime(tm_l);
-        tm_g = gmtime(&now);
         tg = mktime(tm_g);
         tz_offset = tg - tl;
 


### PR DESCRIPTION
macOS supports the thread safe`gmtime_r` so I changed the logic in `OPENSSL_gmtime()` to make it choose that over `gmtime`. 

Calls to `gmtime` have been updated to use `OPENSSL_gmtime()` which makes the right decision on which function to use depending on the system.

Updated calls to localtime to call localtime_r if supported on that system. (Used similar logic as `OPENSSL_gmtime()` uses to determine which systems support it. If `gmtime_r` is supported so should `localtime_r`.)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
