### PR TITLE
Fix rsa pss

### DIFF
--- a/doc/man7/RSA-PSS.pod
+++ b/doc/man7/RSA-PSS.pod
@@ -2,8 +2,7 @@
 
 =head1 NAME
 
-EVP_PKEY_CTX_set_rsa_pss_keygen_md, EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md,
-EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen - RSA PSS signature algorithm
+RSA-PSS - EVP_PKEY RSA-PSS algorithm support
 
 =head1 SYNOPSIS
 
@@ -18,10 +17,9 @@ EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen - RSA PSS signature algorithm
 
 =head1 DESCRIPTION
 
-The B<EVP_PKEY_RSA_PSS> algorithm implements the RSA PSS signature algorithm.
-It is a restricted version of the RSA algorithm which only supports signing,
-verification and key generation using PSS padding modes with optional
-parameter restrictions.
+The B<RSA-PSS> EVP_PKEY implementation is a restricted version of the RSA
+algorithm which only supports signing, verification and key generation
+using PSS padding modes with optional parameter restrictions.
 
 It has associated private key and public key formats.
 
@@ -57,7 +55,7 @@ similar to the B<RSA> versions.
 =head1 KEY GENERATION
 
 As with RSA key generation the EVP_PKEY_CTX_set_rsa_rsa_keygen_bits()
-and EVP_PKEY_CTX_set_rsa_keygen_pubexp() macros are supported for RSA PSS:
+and EVP_PKEY_CTX_set_rsa_keygen_pubexp() macros are supported for RSA-PSS:
 they have exactly the same meaning as for the RSA algorithm.
 
 Optional parameter restrictions can be specified when generating a PSS key. By
@@ -76,6 +74,18 @@ generated key can use to B<md>.
 
 EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen() restricts the minimum salt length
 to B<saltlen>.
+
+=head1 NOTES
+
+A context for the B<RSA-PSS> algorithm can be obtained by calling:
+
+ EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA_PSS, NULL);
+
+The public key format is documented in RFC4055.
+
+The PKCS#8 private key format used for RSA-PSS keys is similar to the RSA
+format except it uses the B<id-RSASSA-PSS> OID and the parameters field, if
+present, restricts the key parameters in the same way as the public key.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -147,7 +147,7 @@ extern "C" {
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT,  \
                           EVP_PKEY_CTRL_GET_RSA_OAEP_LABEL, 0, (void *)(l))
 
-# define  EVP_PKEY_CTX_rsa_pss_keygen_md(ctx, md) \
+# define  EVP_PKEY_CTX_set_rsa_pss_keygen_md(ctx, md) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS,  \
                           EVP_PKEY_OP_TYPE_KEYGEN, EVP_PKEY_CTRL_MD,  \
                           0, (void *)(md))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

This fixes the define for EVP_PKEY_CTX_set_rsa_pss_keygen_md. It also moves and updates the documentation for the RSA-PSS algorithm: instead of hanging it off a non-obvious ctrl page it now has an algorithm specific page.