### PR TITLE
Modify type of variable and remove needless type casting.

### DIFF
--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -42,7 +42,7 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
                         long argl, char **ret)
 {
     int ok = 0;
-    char *file;
+    const char *file;
 
     switch (cmd) {
     case X509_L_FILE_LOAD:

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -47,7 +47,7 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
     switch (cmd) {
     case X509_L_FILE_LOAD:
         if (argl == X509_FILETYPE_DEFAULT) {
-            file = (char *)getenv(X509_get_default_cert_file_env());
+            file = getenv(X509_get_default_cert_file_env());
             if (file)
                 ok = (X509_load_cert_crl_file(ctx, file,
                                               X509_FILETYPE_PEM) != 0);


### PR DESCRIPTION
I suggest modify type of variable "file" from char * to const char *.
Because return value of getenv() should not change through a pointer.

And I think needless type casting of getenv()'s return value in line 50.
Because type of getenv()'s return value is char *.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
