### PR TITLE
Clean up s_server documentation

### DIFF
--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -8,116 +8,171 @@ s_server - SSL/TLS server program
 
 B<openssl> B<s_server>
 [B<-help>]
-[B<-port port>]
+[B<-port +int>]
 [B<-accept val>]
-[B<-naccept count>]
 [B<-unix val>]
-[B<-unlink>]
 [B<-4>]
 [B<-6>]
-[B<-context id>]
-[B<-verify depth>]
-[B<-Verify depth>]
-[B<-crl_check>]
-[B<-crl_check_all>]
-[B<-cert filename>]
-[B<-certform DER|PEM>]
-[B<-key keyfile>]
-[B<-keyform DER|PEM>]
-[B<-pass arg>]
-[B<-dcert filename>]
-[B<-dcertform DER|PEM>]
-[B<-dkey keyfile>]
-[B<-dkeyform DER|PEM>]
-[B<-dpass arg>]
-[B<-dhparam filename>]
-[B<-nbio>]
+[B<-unlink>]
+[B<-context val>]
+[B<-verify int>]
+[B<-Verify int>]
+[B<-cert infile>]
+[B<-nameopt val>]
+[B<-naccept +int>]
+[B<-serverinfo val>]
+[B<-certform PEM|DER>]
+[B<-key infile>]
+[B<-keyform format>]
+[B<-pass val>]
+[B<-dcert infile>]
+[B<-dcertform PEM|DER>]
+[B<-dkey infile>]
+[B<-dkeyform PEM|DER>]
+[B<-dpass val>]
 [B<-nbio_test>]
 [B<-crlf>]
 [B<-debug>]
 [B<-msg>]
+[B<-msgfile outfile>]
 [B<-state>]
-[B<-CApath directory>]
-[B<-CAfile filename>]
+[B<-CAfile infile>]
+[B<-CApath dir>]
 [B<-no-CAfile>]
 [B<-no-CApath>]
-[B<-attime timestamp>]
-[B<-check_ss_sig>]
-[B<-explicit_policy>]
-[B<-extended_crl>]
+[B<-nocert>]
+[B<-quiet>]
+[B<-no_resume_ephemeral>]
+[B<-www>]
+[B<-WWW>]
+[B<-servername>]
+[B<-servername_fatal>]
+[B<-cert2 infile>]
+[B<-key2 infile>]
+[B<-tlsextdebug>]
+[B<-HTTP>]
+[B<-id_prefix val>]
+[B<-rand val>]
+[B<-keymatexport val>]
+[B<-keymatexportlen +int>]
+[B<-CRL infile>]
+[B<-crl_download>]
+[B<-cert_chain infile>]
+[B<-dcert_chain infile>]
+[B<-chainCApath dir>]
+[B<-verifyCApath dir>]
+[B<-no_cache>]
+[B<-ext_cache>]
+[B<-CRLform PEM|DER>]
+[B<-verify_return_error>]
+[B<-verify_quiet>]
+[B<-build_chain>]
+[B<-chainCAfile infile>]
+[B<-verifyCAfile infile>]
+[B<-ign_eof>]
+[B<-no_ign_eof>]
+[B<-status>]
+[B<-status_verbose>]
+[B<-status_timeout int>]
+[B<-status_url val>]
+[B<-status_file infile>]
+[B<-trace>]
+[B<-security_debug>]
+[B<-security_debug_verbose>]
+[B<-brief>]
+[B<-rev>]
+[B<-async>]
+[B<-ssl_config val>]
+[B<-max_send_frag +int>]
+[B<-split_send_frag +int>]
+[B<-max_pipelines +int>]
+[B<-read_buf +int>]
+[B<-no_ssl3>]
+[B<-no_tls1>]
+[B<-no_tls1_1>]
+[B<-no_tls1_2>]
+[B<-no_tls1_3>]
+[B<-bugs>]
+[B<-no_comp>]
+[B<-comp>]
+[B<-no_ticket>]
+[B<-serverpref>]
+[B<-legacy_renegotiation>]
+[B<-no_renegotiation>]
+[B<-legacy_server_connect>]
+[B<-no_resumption_on_reneg>]
+[B<-no_legacy_server_connect>]
+[B<-strict>]
+[B<-sigalgs val>]
+[B<-client_sigalgs val>]
+[B<-groups val>]
+[B<-curves val>]
+[B<-named_curve val>]
+[B<-cipher val>]
+[B<-dhparam infile>]
+[B<-record_padding val>]
+[B<-debug_broken_protocol>]
+[B<-policy val>]
+[B<-purpose val>]
+[B<-verify_name val>]
+[B<-verify_depth int>]
+[B<-auth_level int>]
+[B<-attime intmax>]
+[B<-verify_hostname val>]
+[B<-verify_email val>]
+[B<-verify_ip>]
 [B<-ignore_critical>]
+[B<-issuer_checks>]
+[B<-crl_check>]
+[B<-crl_check_all>]
+[B<-policy_check>]
+[B<-explicit_policy>]
 [B<-inhibit_any>]
 [B<-inhibit_map>]
-[B<-no_check_time>]
-[B<-partial_chain>]
-[B<-policy arg>]
-[B<-policy_check>]
-[B<-policy_print>]
-[B<-purpose purpose>]
-[B<-suiteB_128>]
-[B<-suiteB_128_only>]
-[B<-suiteB_192>]
-[B<-trusted_first>]
-[B<-no_alt_chains>]
-[B<-use_deltas>]
-[B<-auth_level num>]
-[B<-nameopt option>]
-[B<-verify_depth num>]
-[B<-verify_return_error>]
-[B<-verify_email email>]
-[B<-verify_hostname hostname>]
-[B<-verify_ip ip>]
-[B<-verify_name name>]
 [B<-x509_strict>]
-[B<-nocert>]
-[B<-client_sigalgs sigalglist>]
-[B<-named_curve curve>]
-[B<-cipher cipherlist>]
-[B<-serverpref>]
-[B<-quiet>]
+[B<-extended_crl>]
+[B<-use_deltas>]
+[B<-policy_print>]
+[B<-check_ss_sig>]
+[B<-trusted_first>]
+[B<-suiteB_128_only>]
+[B<-suiteB_128>]
+[B<-suiteB_192>]
+[B<-partial_chain>]
+[B<-no_alt_chains>]
+[B<-no_check_time>]
+[B<-allow_proxy_certs>]
+[B<-xkey>]
+[B<-xcert>]
+[B<-xchain>]
+[B<-xchain_build>]
+[B<-xcertform PEM|DER>]
+[B<-xkeyform PEM|DER>]
+[B<-nbio>]
+[B<-psk_identity val>]
+[B<-psk_hint val>]
+[B<-psk val>]
+[B<-srpvfile infile>]
+[B<-srpuserseed val>]
 [B<-ssl3>]
 [B<-tls1>]
 [B<-tls1_1>]
 [B<-tls1_2>]
 [B<-tls1_3>]
 [B<-dtls>]
+[B<-timeout>]
+[B<-mtu +int>]
+[B<-listen>]
 [B<-dtls1>]
 [B<-dtls1_2>]
 [B<-sctp>]
-[B<-listen>]
-[B<-async>]
-[B<-max_send_frag>]
-[B<-split_send_frag>]
-[B<-max_pipelines>]
-[B<-read_buf>]
-[B<-no_ssl3>]
-[B<-no_tls1>]
-[B<-no_tls1_1>]
-[B<-no_tls1_2>]
-[B<-no_tls1_3>]
 [B<-no_dhe>]
-[B<-bugs>]
-[B<-comp>]
-[B<-no_comp>]
-[B<-brief>]
-[B<-www>]
-[B<-WWW>]
-[B<-HTTP>]
-[B<-engine id>]
-[B<-tlsextdebug>]
-[B<-no_ticket>]
-[B<-id_prefix arg>]
-[B<-rand file(s)>]
-[B<-serverinfo file>]
-[B<-no_resumption_on_reneg>]
-[B<-status>]
-[B<-status_verbose>]
-[B<-status_timeout nsec>]
-[B<-status_url url>]
-[B<-status_file file>]
-[B<-alpn protocols>]
-[B<-nextprotoneg protocols>]
-[B<-max_early_data>]
+[B<-nextprotoneg val>]
+[B<-use_srtp val>]
+[B<-alpn val>]
+[B<-engine val>]
+[B<-keylogfile outfile>]
+[B<-max_early_data int>]
 [B<-early_data>]
 
 =head1 DESCRIPTION
@@ -138,7 +193,7 @@ manual page.
 
 Print out a usage message.
 
-=item B<-port port>
+=item B<-port +int>
 
 The TCP port to listen on for connections. If not specified 4433 is used.
 
@@ -146,17 +201,9 @@ The TCP port to listen on for connections. If not specified 4433 is used.
 
 The optional TCP host and port to listen on for connections. If not specified, *:4433 is used.
 
-=item B<-naccept count>
-
-The server will exit after receiving B<number> connections, default unlimited.
-
 =item B<-unix val>
 
 Unix domain socket to accept on.
-
-=item B<-unlink>
-
-For -unix, unlink existing socket first.
 
 =item B<-4>
 
@@ -166,98 +213,16 @@ Use IPv4 only.
 
 Use IPv6 only.
 
-=item B<-context id>
+=item B<-unlink>
+
+For -unix, unlink any existing socket first.
+
+=item B<-context val>
 
 Sets the SSL context id. It can be given any string value. If this option
 is not present a default value will be used.
 
-=item B<-cert certname>
-
-The certificate to use, most servers cipher suites require the use of a
-certificate and some require a certificate with a certain public key type:
-for example the DSS cipher suites require a certificate containing a DSS
-(DSA) key. If not specified then the filename "server.pem" will be used.
-
-=item B<-certform format>
-
-The certificate format to use: DER or PEM. PEM is the default.
-
-=item B<-key keyfile>
-
-The private key to use. If not specified then the certificate file will
-be used.
-
-=item B<-keyform format>
-
-The private format to use: DER or PEM. PEM is the default.
-
-=item B<-pass arg>
-
-The private key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
-
-=item B<-dcert filename>, B<-dkey keyname>
-
-Specify an additional certificate and private key, these behave in the
-same manner as the B<-cert> and B<-key> options except there is no default
-if they are not specified (no additional certificate and key is used). As
-noted above some cipher suites require a certificate containing a key of
-a certain type. Some cipher suites need a certificate carrying an RSA key
-and some a DSS (DSA) key. By using RSA and DSS certificates and keys
-a server can support clients which only support RSA or DSS cipher suites
-by using an appropriate certificate.
-
-=item B<-dcertform format>, B<-dkeyform format>, B<-dpass arg>
-
-Additional certificate and private key format and passphrase respectively.
-
-=item B<-nocert>
-
-If this option is set then no certificate is used. This restricts the
-cipher suites available to the anonymous ones (currently just anonymous
-DH).
-
-=item B<-dhparam filename>
-
-The DH parameter file to use. The ephemeral DH cipher suites generate keys
-using a set of DH parameters. If not specified then an attempt is made to
-load the parameters from the server certificate file.
-If this fails then a static set of parameters hard coded into the B<s_server>
-program will be used.
-
-=item B<-no_dhe>
-
-If this option is set then no DH parameters will be loaded effectively
-disabling the ephemeral DH cipher suites.
-
-=item B<-crl_check>, B<-crl_check_all>
-
-Check the peer certificate has not been revoked by its CA.
-The CRL(s) are appended to the certificate file. With the B<-crl_check_all>
-option all CRLs of all CAs in the chain are checked.
-
-=item B<-CApath directory>
-
-The directory to use for client certificate verification. This directory
-must be in "hash format", see B<verify> for more information. These are
-also used when building the server certificate chain.
-
-=item B<-CAfile file>
-
-A file containing trusted certificates to use during client authentication
-and to use when attempting to build the server certificate chain. The list
-is also used in the list of acceptable client CAs passed to the client when
-a certificate is requested.
-
-=item B<-no-CAfile>
-
-Do not load the trusted CA certificates from the default file location.
-
-=item B<-no-CApath>
-
-Do not load the trusted CA certificates from the default directory location.
-
-=item B<-verify depth>, B<-Verify depth>
+=item B<-verify int>, B<-Verify int>
 
 The verify depth to use. This specifies the maximum length of the
 client certificate chain and makes the server request a certificate from
@@ -268,33 +233,73 @@ must supply a certificate or an error occurs.
 If the cipher suite cannot request a client certificate (for example an
 anonymous cipher suite or PSK) this option has no effect.
 
-=item B<-nameopt option>
+=item B<-cert infile>
+
+The certificate to use, most servers cipher suites require the use of a
+certificate and some require a certificate with a certain public key type:
+for example the DSS cipher suites require a certificate containing a DSS
+(DSA) key. If not specified then the filename "server.pem" will be used.
+
+=item B<-nameopt val>
 
 Option which determines how the subject or issuer names are displayed. The
-B<option> argument can be a single option or multiple options separated by
+B<val> argument can be a single option or multiple options separated by
 commas.  Alternatively the B<-nameopt> switch may be used more than once to
 set multiple options. See the L<x509(1)> manual page for details.
 
-=item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
-B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
-B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
-B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,
-B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,
-B<-auth_level>, B<-verify_depth>, B<-verify_email>, B<-verify_hostname>,
-B<-verify_ip>, B<-verify_name>, B<-x509_strict>
+=item B<-naccept +int>
 
-Set different peer certificate verification options.
-See the L<verify(1)> manual page for details.
+The server will exit after receiving the specified number of connections,
+default unlimited.
 
-=item B<-verify_return_error>
+=item B<-serverinfo val>
 
-Verification errors normally just print a message but allow the
-connection to continue, for debugging purposes.
-If this option is used, then verification errors close the connection.
+A file containing one or more blocks of PEM data.  Each PEM block
+must encode a TLS ServerHello extension (2 bytes type, 2 bytes length,
+followed by "length" bytes of extension data).  If the client sends
+an empty TLS ClientHello extension matching the type, the corresponding
+ServerHello extension will be returned.
 
-=item B<-state>
+=item B<-certform PEM|DER>
 
-Prints the SSL session states.
+The certificate format to use: DER or PEM. PEM is the default.
+
+=item B<-key infile>
+
+The private key to use. If not specified then the certificate file will
+be used.
+
+=item B<-keyform format>
+
+The private format to use: DER or PEM. PEM is the default.
+
+=item B<-pass val>
+
+The private key password source. For more information about the format of B<val>
+see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+
+=item B<-dcert infile>, B<-dkey infile>
+
+Specify an additional certificate and private key, these behave in the
+same manner as the B<-cert> and B<-key> options except there is no default
+if they are not specified (no additional certificate and key is used). As
+noted above some cipher suites require a certificate containing a key of
+a certain type. Some cipher suites need a certificate carrying an RSA key
+and some a DSS (DSA) key. By using RSA and DSS certificates and keys
+a server can support clients which only support RSA or DSS cipher suites
+by using an appropriate certificate.
+
+=item B<-dcertform PEM|DER>, B<-dkeyform PEM|DER>, B<-dpass val>
+
+Additional certificate and private key format and passphrase respectively.
+
+=item B<-nbio_test>
+
+Tests non blocking I/O.
+
+=item B<-crlf>
+
+This option translated a line feed from the terminal into CR+LF.
 
 =item B<-debug>
 
@@ -304,168 +309,44 @@ Print extensive debugging information including a hex dump of all traffic.
 
 Show all protocol messages with hex dump.
 
-=item B<-trace>
-
-Show verbose trace output of protocol messages. OpenSSL needs to be compiled
-with B<enable-ssl-trace> for this option to work.
-
-=item B<-msgfile>
+=item B<-msgfile outfile>
 
 File to send output of B<-msg> or B<-trace> to, default standard output.
 
-=item B<-nbio_test>
+=item B<-state>
 
-Tests non blocking I/O.
+Prints the SSL session states.
 
-=item B<-nbio>
+=item B<-CAfile infile>
 
-Turns on non blocking I/O.
+A file containing trusted certificates to use during client authentication
+and to use when attempting to build the server certificate chain. The list
+is also used in the list of acceptable client CAs passed to the client when
+a certificate is requested.
 
-=item B<-crlf>
+=item B<-CApath dir>
 
-This option translated a line feed from the terminal into CR+LF.
+The directory to use for client certificate verification. This directory
+must be in "hash format", see B<verify> for more information. These are
+also used when building the server certificate chain.
+
+=item B<-no-CAfile>
+
+Do not load the trusted CA certificates from the default file location.
+
+=item B<-no-CApath>
+
+Do not load the trusted CA certificates from the default directory location.
+
+=item B<-nocert>
+
+If this option is set then no certificate is used. This restricts the
+cipher suites available to the anonymous ones (currently just anonymous
+DH).
 
 =item B<-quiet>
 
 Inhibit printing of session and certificate information.
-
-=item B<-psk_hint hint>
-
-Use the PSK identity hint B<hint> when using a PSK cipher suite.
-
-=item B<-psk_identity identity>
-
-Expect the client to send PSK identity B<identity> when using a PSK
-cipher suite, and warn if they do not.  By default, the expected PSK
-identity is the string "Client_identity".
-
-=item B<-psk key>
-
-Use the PSK key B<key> when using a PSK cipher suite. The key is
-given as a hexadecimal number without leading 0x, for example -psk
-1a2b3c4d.
-This option must be provided in order to use a PSK cipher.
-
-=item B<-ssl2>, B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>, B<-no_ssl2>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
-
-These options require or disable the use of the specified SSL or TLS protocols.
-By default B<s_server> will negotiate the highest mutually supported protocol
-version.
-When a specific TLS version is required, only that version will be accepted
-from the client.
-
-=item B<-dtls>, B<-dtls1>, B<-dtls1_2>
-
-These options make B<s_server> use DTLS protocols instead of TLS.
-With B<-dtls>, B<s_server> will negotiate any supported DTLS protocol version,
-whilst B<-dtls1> and B<-dtls1_2> will only support DTLSv1.0 and DTLSv1.2
-respectively.
-
-=item B<-listen>
-
-This option can only be used in conjunction with one of the DTLS options above.
-With this option B<s_server> will listen on a UDP port for incoming connections.
-Any ClientHellos that arrive will be checked to see if they have a cookie in
-them or not.
-Any without a cookie will be responded to with a HelloVerifyRequest.
-If a ClientHello with a cookie is received then B<s_server> will connect to
-that peer and complete the handshake.
-
-=item B<-sctp>
-
-Use SCTP for the transport protocol instead of UDP in DTLS. Must be used in
-conjunction with B<-dtls>, B<-dtls1> or B<-dtls1_2>. This option is only
-available where OpenSSL has support for SCTP enabled.
-
-=item B<-async>
-
-Switch on asynchronous mode. Cryptographic operations will be performed
-asynchronously. This will only have an effect if an asynchronous capable engine
-is also used via the B<-engine> option. For test purposes the dummy async engine
-(dasync) can be used (if available).
-
-=item B<-max_send_frag int>
-
-The maximum size of data fragment to send.
-See L<SSL_CTX_set_max_send_fragment(3)> for further information.
-
-=item B<-split_send_frag int>
-
-The size used to split data for encrypt pipelines. If more data is written in
-one go than this value then it will be split into multiple pipelines, up to the
-maximum number of pipelines defined by max_pipelines. This only has an effect if
-a suitable cipher suite has been negotiated, an engine that supports pipelining
-has been loaded, and max_pipelines is greater than 1. See
-L<SSL_CTX_set_split_send_fragment(3)> for further information.
-
-=item B<-max_pipelines int>
-
-The maximum number of encrypt/decrypt pipelines to be used. This will only have
-an effect if an engine has been loaded that supports pipelining (e.g. the dasync
-engine) and a suitable cipher suite has been negotiated. The default value is 1.
-See L<SSL_CTX_set_max_pipelines(3)> for further information.
-
-=item B<-read_buf int>
-
-The default read buffer size to be used for connections. This will only have an
-effect if the buffer size is larger than the size that would otherwise be used
-and pipelining is in use (see L<SSL_CTX_set_default_read_buffer_len(3)> for
-further information).
-
-=item B<-bugs>
-
-There are several known bug in SSL and TLS implementations. Adding this
-option enables various workarounds.
-
-=item B<-comp>
-
-Enable negotiation of TLS compression.
-This option was introduced in OpenSSL 1.1.0.
-TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0.
-
-=item B<-no_comp>
-
-Disable negotiation of TLS compression.
-TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0.
-
-=item B<-brief>
-
-Provide a brief summary of connection parameters instead of the normal verbose
-output.
-
-=item B<-client_sigalgs sigalglist>
-
-Signature algorithms to support for client certificate authentication
-(colon-separated list).
-
-=item B<-named_curve curve>
-
-Specifies the elliptic curve to use. NOTE: this is single curve, not a list.
-For a list of all possible curves, use:
-
-    $ openssl ecparam -list_curves
-
-=item B<-cipher cipherlist>
-
-This allows the cipher list used by the server to be modified.  When
-the client sends a list of supported ciphers the first client cipher
-also included in the server list is used. Because the client specifies
-the preference order, the order of the server cipherlist irrelevant. See
-the B<ciphers> command for more information.
-
-=item B<-serverpref>
-
-Use the server's cipher preferences, rather than the client's preferences.
-
-=item B<-tlsextdebug>
-
-Print a hex dump of any TLS extensions received from the server.
-
-=item B<-no_ticket>
-
-Disable RFC4507bis session ticket support.
 
 =item B<-www>
 
@@ -480,6 +361,10 @@ Emulates a simple web server. Pages will be resolved relative to the
 current directory, for example if the URL https://myhost/page.html is
 requested the file ./page.html will be loaded.
 
+=item B<-tlsextdebug>
+
+Print a hex dump of any TLS extensions received from the server.
+
 =item B<-HTTP>
 
 Emulates a simple web server. Pages will be resolved relative to the
@@ -488,26 +373,14 @@ requested the file ./page.html will be loaded. The files loaded are
 assumed to contain a complete and correct HTTP response (lines that
 are part of the HTTP response line and headers must end with CRLF).
 
-=item B<-rev>
+=item B<-id_prefix val>
 
-Simple test server which just reverses the text received from the client
-and sends it back to the server. Also sets B<-brief>.
-
-=item B<-engine id>
-
-Specifying an engine (by its unique B<id> string) will cause B<s_server>
-to attempt to obtain a functional reference to the specified engine,
-thus initialising it if needed. The engine will then be set as the default
-for all available algorithms.
-
-=item B<-id_prefix arg>
-
-Generate SSL/TLS session IDs prefixed by B<arg>. This is mostly useful
+Generate SSL/TLS session IDs prefixed by B<val>. This is mostly useful
 for testing any SSL/TLS code (eg. proxies) that wish to deal with multiple
 servers, when each of which might be generating a unique range of session
 IDs (eg. with a certain prefix).
 
-=item B<-rand file(s)>
+=item B<-rand val>
 
 A file or files containing random data used to seed the random number
 generator, or an EGD socket (see L<RAND_egd(3)>).
@@ -515,17 +388,11 @@ Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
 
-=item B<-serverinfo file>
+=item B<-verify_return_error>
 
-A file containing one or more blocks of PEM data.  Each PEM block
-must encode a TLS ServerHello extension (2 bytes type, 2 bytes length,
-followed by "length" bytes of extension data).  If the client sends
-an empty TLS ClientHello extension matching the type, the corresponding
-ServerHello extension will be returned.
-
-=item B<-no_resumption_on_reneg>
-
-Set the B<SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION> option.
+Verification errors normally just print a message but allow the
+connection to continue, for debugging purposes.
+If this option is used, then verification errors close the connection.
 
 =item B<-status>
 
@@ -536,37 +403,226 @@ Enables certificate status request support (aka OCSP stapling).
 Enables certificate status request support (aka OCSP stapling) and gives
 a verbose printout of the OCSP response.
 
-=item B<-status_timeout nsec>
+=item B<-status_timeout int>
 
-Sets the timeout for OCSP response to B<nsec> seconds.
+Sets the timeout for OCSP response to B<int> seconds.
 
-=item B<-status_url url>
+=item B<-status_url val>
 
 Sets a fallback responder URL to use if no responder URL is present in the
 server certificate. Without this option an error is returned if the server
 certificate does not contain a responder address.
 
-=item B<-status_file file>
+=item B<-status_file infile>
 
 Overrides any OCSP responder URLs from the certificate and always provides the
 OCSP Response stored in the file. The file must be in DER format.
 
-=item B<-alpn protocols>, B<-nextprotoneg protocols>
+=item B<-trace>
+
+Show verbose trace output of protocol messages. OpenSSL needs to be compiled
+with B<enable-ssl-trace> for this option to work.
+
+=item B<-brief>
+
+Provide a brief summary of connection parameters instead of the normal verbose
+output.
+
+=item B<-rev>
+
+Simple test server which just reverses the text received from the client
+and sends it back to the server. Also sets B<-brief>.
+
+=item B<-async>
+
+Switch on asynchronous mode. Cryptographic operations will be performed
+asynchronously. This will only have an effect if an asynchronous capable engine
+is also used via the B<-engine> option. For test purposes the dummy async engine
+(dasync) can be used (if available).
+
+=item B<-max_send_frag +int>
+
+The maximum size of data fragment to send.
+See L<SSL_CTX_set_max_send_fragment(3)> for further information.
+
+=item B<-split_send_frag +int>
+
+The size used to split data for encrypt pipelines. If more data is written in
+one go than this value then it will be split into multiple pipelines, up to the
+maximum number of pipelines defined by max_pipelines. This only has an effect if
+a suitable cipher suite has been negotiated, an engine that supports pipelining
+has been loaded, and max_pipelines is greater than 1. See
+L<SSL_CTX_set_split_send_fragment(3)> for further information.
+
+=item B<-max_pipelines +int>
+
+The maximum number of encrypt/decrypt pipelines to be used. This will only have
+an effect if an engine has been loaded that supports pipelining (e.g. the dasync
+engine) and a suitable cipher suite has been negotiated. The default value is 1.
+See L<SSL_CTX_set_max_pipelines(3)> for further information.
+
+=item B<-read_buf +int>
+
+The default read buffer size to be used for connections. This will only have an
+effect if the buffer size is larger than the size that would otherwise be used
+and pipelining is in use (see L<SSL_CTX_set_default_read_buffer_len(3)> for
+further information).
+
+=item B<-ssl2>, B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>, B<-no_ssl2>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
+
+These options require or disable the use of the specified SSL or TLS protocols.
+By default B<s_server> will negotiate the highest mutually supported protocol
+version.
+When a specific TLS version is required, only that version will be accepted
+from the client.
+
+=item B<-bugs>
+
+There are several known bug in SSL and TLS implementations. Adding this
+option enables various workarounds.
+
+=item B<-no_comp>
+
+Disable negotiation of TLS compression.
+TLS compression is not recommended and is off by default as of
+OpenSSL 1.1.0.
+
+=item B<-comp>
+
+Enable negotiation of TLS compression.
+This option was introduced in OpenSSL 1.1.0.
+TLS compression is not recommended and is off by default as of
+OpenSSL 1.1.0.
+
+=item B<-no_ticket>
+
+Disable RFC4507bis session ticket support.
+
+=item B<-serverpref>
+
+Use the server's cipher preferences, rather than the client's preferences.
+
+=item B<-no_resumption_on_reneg>
+
+Set the B<SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION> option.
+
+=item B<-client_sigalgs val>
+
+Signature algorithms to support for client certificate authentication
+(colon-separated list).
+
+=item B<-named_curve val>
+
+Specifies the elliptic curve to use. NOTE: this is single curve, not a list.
+For a list of all possible curves, use:
+
+    $ openssl ecparam -list_curves
+
+=item B<-cipher val>
+
+This allows the cipher list used by the server to be modified.  When
+the client sends a list of supported ciphers the first client cipher
+also included in the server list is used. Because the client specifies
+the preference order, the order of the server cipherlist irrelevant. See
+the B<ciphers> command for more information.
+
+=item B<-dhparam infile>
+
+The DH parameter file to use. The ephemeral DH cipher suites generate keys
+using a set of DH parameters. If not specified then an attempt is made to
+load the parameters from the server certificate file.
+If this fails then a static set of parameters hard coded into the B<s_server>
+program will be used.
+
+=item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
+B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
+B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
+B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,
+B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,
+B<-auth_level>, B<-verify_depth>, B<-verify_email>, B<-verify_hostname>,
+B<-verify_ip>, B<-verify_name>, B<-x509_strict>
+
+Set different peer certificate verification options.
+See the L<verify(1)> manual page for details.
+
+=item B<-crl_check>, B<-crl_check_all>
+
+Check the peer certificate has not been revoked by its CA.
+The CRL(s) are appended to the certificate file. With the B<-crl_check_all>
+option all CRLs of all CAs in the chain are checked.
+
+=item B<-nbio>
+
+Turns on non blocking I/O.
+
+=item B<-psk_identity val>
+
+Expect the client to send PSK identity B<val> when using a PSK
+cipher suite, and warn if they do not.  By default, the expected PSK
+identity is the string "Client_identity".
+
+=item B<-psk_hint val>
+
+Use the PSK identity hint B<val> when using a PSK cipher suite.
+
+=item B<-psk val>
+
+Use the PSK key B<val> when using a PSK cipher suite. The key is
+given as a hexadecimal number without leading 0x, for example -psk
+1a2b3c4d.
+This option must be provided in order to use a PSK cipher.
+
+=item B<-listen>
+
+This option can only be used in conjunction with one of the DTLS options above.
+With this option B<s_server> will listen on a UDP port for incoming connections.
+Any ClientHellos that arrive will be checked to see if they have a cookie in
+them or not.
+Any without a cookie will be responded to with a HelloVerifyRequest.
+If a ClientHello with a cookie is received then B<s_server> will connect to
+that peer and complete the handshake.
+
+=item B<-dtls>, B<-dtls1>, B<-dtls1_2>
+
+These options make B<s_server> use DTLS protocols instead of TLS.
+With B<-dtls>, B<s_server> will negotiate any supported DTLS protocol version,
+whilst B<-dtls1> and B<-dtls1_2> will only support DTLSv1.0 and DTLSv1.2
+respectively.
+
+=item B<-sctp>
+
+Use SCTP for the transport protocol instead of UDP in DTLS. Must be used in
+conjunction with B<-dtls>, B<-dtls1> or B<-dtls1_2>. This option is only
+available where OpenSSL has support for SCTP enabled.
+
+=item B<-no_dhe>
+
+If this option is set then no DH parameters will be loaded effectively
+disabling the ephemeral DH cipher suites.
+
+=item B<-alpn val>, B<-nextprotoneg val>
 
 These flags enable the Enable the Application-Layer Protocol Negotiation
 or Next Protocol Negotiation (NPN) extension, respectively. ALPN is the
 IETF standard and replaces NPN.
-The B<protocols> list is a comma-separated list of supported protocol
+The B<val> list is a comma-separated list of supported protocol
 names.  The list should contain the most desirable protocols first.
 Protocol names are printable ASCII strings, for example "http/1.1" or
 "spdy/3".
 
-=item B<-keylogfile path>
+=item B<-engine val>
+
+Specifying an engine (by its unique id string in B<val>) will cause B<s_server>
+to attempt to obtain a functional reference to the specified engine,
+thus initialising it if needed. The engine will then be set as the default
+for all available algorithms.
+
+=item B<-keylogfile outfile>
 
 Appends TLS secrets to the specified keylog file such that external programs
 (like Wireshark) can decrypt TLS connections.
 
-=item B<-max_early_data arg>
+=item B<-max_early_data int>
 
 Change the default maximum early data bytes that are specified for new sessions
 and any incoming early data (when used in conjunction with the B<-early_data>


### PR DESCRIPTION
List the options in the same order and in the same style as the output from
"openssl s_server -help"

There are still a number of inconsistencies here. For example some options are not documented here at all, but we refer to another page (SSL_CONF_cmd) where they are documented. Other options are documented on both pages. I'll deal with that separately.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
