### PR TITLE
Fix possible memory over-read in apps/s_client.c

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2172,7 +2172,7 @@ int s_client_main(int argc, char **argv)
              * HTTP/d.d ddd Reason text\r\n
              */
             mbuf_len = BIO_gets(fbio, mbuf, BUFSIZZ);
-            if (mbuf_len < strlen("HTTP/1.0 200")) {
+            if (mbuf_len < (int)strlen("HTTP/1.0 200")) {
                 BIO_printf(bio_err,
                            "%s: HTTP CONNECT failed, insufficient response "
                            "from proxy (got %d octets)\n", prog, mbuf_len);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2172,8 +2172,7 @@ int s_client_main(int argc, char **argv)
              * HTTP/d.d ddd Reason text\r\n
              */
             mbuf_len = BIO_gets(fbio, mbuf, BUFSIZZ);
-            if (mbuf_len < 12) {
-                /* '12' stands for the length of 'HTTP/d.d ddd' */
+            if (mbuf_len < sizeof("HTTP/1.0 200") - 1) {
                 BIO_printf(bio_err,
                            "%s: HTTP CONNECT failed, insufficient response "
                            "from proxy (got %d octets)\n", prog, mbuf_len);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2172,7 +2172,7 @@ int s_client_main(int argc, char **argv)
              * HTTP/d.d ddd Reason text\r\n
              */
             mbuf_len = BIO_gets(fbio, mbuf, BUFSIZZ);
-            if (mbuf_len < sizeof("HTTP/1.0 200") - 1) {
+            if (mbuf_len < strlen("HTTP/1.0 200")) {
                 BIO_printf(bio_err,
                            "%s: HTTP CONNECT failed, insufficient response "
                            "from proxy (got %d octets)\n", prog, mbuf_len);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2172,6 +2172,16 @@ int s_client_main(int argc, char **argv)
              * HTTP/d.d ddd Reason text\r\n
              */
             mbuf_len = BIO_gets(fbio, mbuf, BUFSIZZ);
+            if (mbuf_len < 12) {
+                /* '12' stands for the length of 'HTTP/d.d ddd' */
+                BIO_printf(bio_err,
+                           "%s: HTTP CONNECT failed, insufficient response "
+                           "from proxy (got %d octets)\n", prog, mbuf_len);
+                (void)BIO_flush(fbio);
+                BIO_pop(fbio);
+                BIO_free(fbio);
+                goto shut;
+            }
             if (mbuf[8] != ' ') {
                 BIO_printf(bio_err,
                            "%s: HTTP CONNECT failed, incorrect response "


### PR DESCRIPTION
a buffer returned from BIO_gets is not checked for it's length before
reading its contents.

Signed-off-by: Paul Yang <paulyang.inf@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
