### PR TITLE
Remove stale note from s_server.pod

### DIFF
--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -682,10 +682,6 @@ a web browser the command:
 
 can be used for example.
 
-Most web browsers (in particular Netscape and MSIE) only support RSA cipher
-suites, so they cannot connect to servers which don't use a certificate
-carrying an RSA key or a version of OpenSSL with RSA disabled.
-
 Although specifying an empty list of CAs when requesting a client certificate
 is strictly speaking a protocol violation, some SSL clients interpret this to
 mean any CA is acceptable. This is useful for debugging purposes.


### PR DESCRIPTION
Modern browsers are now, well, pretty modern.

Noted while reviewing #3628 but it didn't fit into that change.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
