### PR TITLE
Fix possible usage of NULL pointers in apps/spkac.c

### DIFF
--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -122,19 +122,22 @@ int spkac_main(int argc, char **argv)
         goto end;
     }
 
-    if (keyfile) {
+    if (keyfile != NULL) {
         pkey = load_key(strcmp(keyfile, "-") ? keyfile : NULL,
                         keyformat, 1, passin, e, "private key");
-        if (!pkey) {
+        if (pkey == NULL)
             goto end;
-        }
         spki = NETSCAPE_SPKI_new();
-        if (challenge)
+        if (spki == NULL)
+            goto end;
+        if (challenge != NULL)
             ASN1_STRING_set(spki->spkac->challenge,
                             challenge, (int)strlen(challenge));
         NETSCAPE_SPKI_set_pubkey(spki, pkey);
         NETSCAPE_SPKI_sign(spki, pkey, EVP_md5());
         spkstr = NETSCAPE_SPKI_b64_encode(spki);
+        if (spkstr == NULL)
+            goto end;
 
         out = bio_open_default(outfile, 'w', FORMAT_TEXT);
         if (out == NULL) {
@@ -160,7 +163,7 @@ int spkac_main(int argc, char **argv)
 
     spki = NETSCAPE_SPKI_b64_decode(spkstr, -1);
 
-    if (!spki) {
+    if (spki == NULL) {
         BIO_printf(bio_err, "Error loading SPKAC\n");
         ERR_print_errors(bio_err);
         goto end;
@@ -175,9 +178,9 @@ int spkac_main(int argc, char **argv)
     pkey = NETSCAPE_SPKI_get_pubkey(spki);
     if (verify) {
         i = NETSCAPE_SPKI_verify(spki, pkey);
-        if (i > 0)
+        if (i > 0) {
             BIO_printf(bio_err, "Signature OK\n");
-        else {
+        } else {
             BIO_printf(bio_err, "Signature Failure\n");
             ERR_print_errors(bio_err);
             goto end;


### PR DESCRIPTION
Check return value of NETSCAPE_SPKI_new() and
NETSCAPE_SPKI_b64_encode(), and also clean up coding style incidentally.

Signed-off-by: Paul Yang <paulyang.inf@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
