### PR TITLE
Modify type of variable in OPENSSL_cpuid_setup function

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -97,7 +97,7 @@ static unsigned long (*getauxval) (unsigned long) = NULL;
 
 void OPENSSL_cpuid_setup(void)
 {
-    char *e;
+    const char *e;
     struct sigaction ill_oact, ill_act;
     sigset_t oset;
     static int trigger = 0;


### PR DESCRIPTION
I suggest modify type of variable "e" from char * to const char *.
Because return value of getenv() should not change through a pointer.
