### PR TITLE
Make SNI behavior more clear in s_client doc and help text

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -650,7 +650,7 @@ const OPTIONS s_client_options[] = {
      "CA file for certificate verification (PEM format)"},
     {"nocommands", OPT_NOCMDS, '-', "Do not use interactive command letters"},
     {"servername", OPT_SERVERNAME, 's',
-     "Set TLS extension servername in ClientHello"},
+     "Set TLS extension servername (SNI) in ClientHello (default)"},
     {"noservername", OPT_NOSERVERNAME, '-',
      "Do not send the server name (SNI) extension in the ClientHello"},
     {"tlsextdebug", OPT_TLSEXTDEBUG, '-',

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -159,16 +159,20 @@ Use IPv6 only.
 =item B<-servername name>
 
 Set the TLS SNI (Server Name Indication) extension in the ClientHello message to
-the given value.
+the given value. If both this option and the B<-noservername> are not given, the
+TLS SNI extension is still set to the hostname provided to the B<-connect> option,
+or "localhost" if B<-connect> has not been supplied. This is default since OpenSSL
+1.1.1.
+
+Even though SNI name should normally be a DNS name and not an IP address, this
+option will not make the distinction when parsing B<-connect> and will send
+IP address if one passed.
 
 =item B<-noservername>
 
 Suppresses sending of the SNI (Server Name Indication) extension in the
 ClientHello message. Cannot be used in conjunction with the B<-servername> or
-<-dane_tlsa_domain> options. If this option is not given then the hostname
-provided to the B<-connect> option is used in the SNI extension, or "localhost"
-if B<-connect> has not been supplied. Note that an SNI name should normally be a
-DNS name and not an IP address.
+<-dane_tlsa_domain> options.
 
 =item B<-cert certname>
 


### PR DESCRIPTION
This is different from 1.1.0 and earlier versions. There is no description in -help option. Besides I think it's better to move the statements from `-noservername` section to `-servername` section in s_client pod file.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
