### PR TITLE
Test output formatting for strings, memory and bignums

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -11,6 +11,7 @@ IF[{- !$disabled{tests} -}]
   LIBS_NO_INST=libtestutil.a
   SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output_helpers.c \
           testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
+          testutil/format_output.c \
           {- rebase_files("../apps", $target{apps_aux_src}) -} \
           testutil/test_main.c testutil/main.c
   INCLUDE[libtestutil.a]=.. ../include

--- a/test/exptest.c
+++ b/test/exptest.c
@@ -22,14 +22,7 @@
 
 #define NUM_BITS        (BN_BITS2 * 4)
 
-#define BN_print_var(v) bn_print_var(#v, v)
-
-static void bn_print_var(const char *var, const BIGNUM *bn)
-{
-    fprintf(stderr, "%s (%3d) = ", var, BN_num_bits(bn));
-    BN_print_fp(stderr, bn);
-    fprintf(stderr, "\n");
-}
+#define BN_print_var(v) test_output_bignum(#v, v)
 
 /*
  * Test that r == 0 in test_exp_mod_zero(). Returns one on success,
@@ -39,8 +32,7 @@ static int a_is_zero_mod_one(const char *method, const BIGNUM *r,
                              const BIGNUM *a)
 {
     if (!BN_is_zero(r)) {
-        fprintf(stderr, "%s failed:\n", method);
-        fprintf(stderr, "a ** 0 mod 1 = r (should be 0)\n");
+        TEST_error("%s failed: a ** 0 mod 1 = r (should be 0)", method);
         BN_print_var(a);
         BN_print_var(r);
         return 0;
@@ -110,8 +102,8 @@ static int test_mod_exp_zero()
         goto err;
 
     if (!TEST_BN_eq_zero(r)) {
-        fprintf(stderr, "BN_mod_exp_mont_word failed:\n");
-        fprintf(stderr, "1 ** 0 mod 1 = r (should be 0)\n");
+        TEST_error("BN_mod_exp_mont_word failed: "
+                   "1 ** 0 mod 1 = r (should be 0)");
         BN_print_var(r);
         goto err;
     }

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -27,19 +27,6 @@ static unsigned char rkey2[16];
 static unsigned char plaintext[BIG_TEST_SIZE];
 static unsigned char saved_iv[AES_BLOCK_SIZE * 4];
 
-static void hexdump(FILE *f, const char *title, const unsigned char *s, int l)
-{
-    int n = 0;
-
-    fprintf(f, "%s", title);
-    for (; n < l; ++n) {
-        if ((n % 16) == 0)
-            fprintf(f, "\n%04x", n);
-        fprintf(f, " %02x", s[n]);
-    }
-    fprintf(f, "\n");
-}
-
 #define MAX_VECTOR_SIZE 64
 
 struct ige_test {
@@ -174,9 +161,9 @@ static int test_ige_vectors(int n)
 
     if (!TEST_mem_eq(v->out, v->length, buf, v->length)) {
         TEST_info("IGE test vector %d failed", n);
-        hexdump(stderr, "key", v->key, sizeof v->key);
-        hexdump(stderr, "iv", v->iv, sizeof v->iv);
-        hexdump(stderr, "in", v->in, v->length);
+        test_output_memory("key", v->key, sizeof v->key);
+        test_output_memory("iv", v->iv, sizeof v->iv);
+        test_output_memory("in", v->in, v->length);
         testresult = 0;
     }
 
@@ -187,9 +174,9 @@ static int test_ige_vectors(int n)
 
     if (!TEST_mem_eq(v->out, v->length, buf, v->length)) {
         TEST_info("IGE test vector %d failed (with in == out)", n);
-        hexdump(stderr, "key", v->key, sizeof v->key);
-        hexdump(stderr, "iv", v->iv, sizeof v->iv);
-        hexdump(stderr, "in", v->in, v->length);
+        test_output_memory("key", v->key, sizeof v->key);
+        test_output_memory("iv", v->iv, sizeof v->iv);
+        test_output_memory("in", v->in, v->length);
         testresult = 0;
     }
 
@@ -218,10 +205,10 @@ static int test_bi_ige_vectors(int n)
                        v->encrypt);
 
     if (!TEST_mem_eq(v->out, v->length, buf, v->length)) {
-        hexdump(stderr, "key 1", v->key1, sizeof v->key1);
-        hexdump(stderr, "key 2", v->key2, sizeof v->key2);
-        hexdump(stderr, "iv", v->iv, sizeof v->iv);
-        hexdump(stderr, "in", v->in, v->length);
+        test_output_memory("key 1", v->key1, sizeof v->key1);
+        test_output_memory("key 2", v->key2, sizeof v->key2);
+        test_output_memory("iv", v->iv, sizeof v->iv);
+        test_output_memory("in", v->in, v->length);
         return 0;
     }
 

--- a/test/test_test.c
+++ b/test/test_test.c
@@ -480,6 +480,38 @@ static int test_single_eval(void)
            && TEST_mem_eq(p--, sizeof("456"), "456", sizeof("456"));
 }
 
+static int test_output(void)
+{
+    const char s[] = "1234567890123456789012345678901234567890123456789012"
+                     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    test_output_string("test", s, sizeof(s) - 1);
+    test_output_memory("test", (const unsigned char *)s, sizeof(s));
+    return 1;
+}
+
+static const char *bn_output_tests[] = {
+    NULL,
+    "0",
+    "-12345678",
+    "1234567890123456789012345678901234567890123456789012"
+    "1234567890123456789012345678901234567890123456789013"
+    "987657"
+};
+
+static int test_bn_output(int n)
+{
+    BIGNUM *b = NULL;
+
+    if (bn_output_tests[n] != NULL
+            && !TEST_true(BN_hex2bn(&b, bn_output_tests[n])))
+        return 0;
+    test_output_bignum(bn_output_tests[n], b);
+    BN_free(b);
+    return 1;
+}
+
+
 void register_tests(void)
 {
     ADD_TEST(test_int);
@@ -499,4 +531,6 @@ void register_tests(void)
     ADD_TEST(test_long_output);
     ADD_TEST(test_messages);
     ADD_TEST(test_single_eval);
+    ADD_TEST(test_output);
+    ADD_ALL_TESTS(test_bn_output, OSSL_NELEM(bn_output_tests));
 }

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -271,6 +271,7 @@ void test_error_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 void test_info(const char *file, int line, const char *desc, ...)
     PRINTF_FORMAT(3, 4);
 void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
+void test_note(const char *desc, ...) PRINTF_FORMAT(1, 2);
 void test_openssl_errors(void);
 
 /*
@@ -384,6 +385,7 @@ void test_openssl_errors(void);
 #  define TEST_error(...)    test_error(__FILE__, __LINE__, __VA_ARGS__)
 #  define TEST_info(...)     test_info(__FILE__, __LINE__, __VA_ARGS__)
 # endif
+# define TEST_note           test_note
 # define TEST_openssl_errors test_openssl_errors
 
 /*
@@ -401,6 +403,14 @@ void test_openssl_errors(void);
 
 extern BIO *bio_out;
 extern BIO *bio_err;
+
+/*
+ * Formatted output for strings, memory and bignums.
+ */
+void test_output_string(const char *name, const char *m, size_t l);
+void test_output_bignum(const char *name, const BIGNUM *bn);
+void test_output_memory(const char *name, const unsigned char *m, size_t l);
+
 
 /*
  * Utilities to parse a test file.

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -196,6 +196,7 @@ int run_tests(const char *test_prog_name)
             test_printf_stdout("%*s%s %d - %s\n", level, "", verdict, ii + 1,
                                test_title);
             test_flush_stdout();
+            test_flush_stderr();
             finalize(ret);
         } else {
             int num_failed_inner = 0;

--- a/test/testutil/format_output.c
+++ b/test/testutil/format_output.c
@@ -1,0 +1,528 @@
+#include "../testutil.h"
+#include "output.h"
+#include "tu_local.h"
+
+#include <string.h>
+#include <ctype.h>
+#include "../../e_os.h"
+
+/* The size of memory buffers to display on failure */
+#define MEM_BUFFER_SIZE     (2000)
+#define MAX_STRING_WIDTH    (80)
+#define BN_OUTPUT_SIZE      (8)
+
+/* Output a diff header */
+static void test_diff_header(const char *left, const char *right)
+{
+    test_printf_stderr("%*s# --- %s\n", subtest_level(), "", left);
+    test_printf_stderr("%*s# +++ %s\n", subtest_level(), "", right);
+}
+
+/* Formatted string output routines */
+static void test_string_null_empty(const char *m, char c)
+{
+    if (m == NULL)
+        test_printf_stderr("%*s# % 4s %c NULL\n", subtest_level(), "", "", c);
+    else
+        test_printf_stderr("%*s# % 4u:%c ''\n", subtest_level(), "", 0u, c);
+}
+
+static void test_fail_string_common(const char *prefix, const char *file,
+                                    int line, const char *type,
+                                    const char *left, const char *right,
+                                    const char *op, const char *m1, size_t l1,
+                                    const char *m2, size_t l2)
+{
+    const int indent = subtest_level();
+    const size_t width = (MAX_STRING_WIDTH - indent - 12) / 16 * 16;
+    char b1[MAX_STRING_WIDTH + 1], b2[MAX_STRING_WIDTH + 1];
+    char bdiff[MAX_STRING_WIDTH + 1];
+    size_t n1, n2, i;
+    unsigned int cnt = 0, diff;
+
+    test_fail_message_prefix(prefix, file, line, type, left, right, op);
+    if (m1 == NULL)
+        l1 = 0;
+    if (m2 == NULL)
+        l2 = 0;
+    if (l1 == 0 && l2 == 0) {
+        if ((m1 == NULL) == (m2 == NULL)) {
+            test_string_null_empty(m1, ' ');
+        } else {
+            test_diff_header(left, right);
+            test_string_null_empty(m1, '-');
+            test_string_null_empty(m2, '+');
+        }
+        goto fin;
+    }
+
+    if (l1 != l2 || strcmp(m1, m2) != 0)
+        test_diff_header(left, right);
+
+    while (l1 > 0 || l2 > 0) {
+        n1 = n2 = 0;
+        if (l1 > 0) {
+            b1[n1 = l1 > width ? width : l1] = 0;
+            for (i = 0; i < n1; i++)
+                b1[i] = isprint(m1[i]) ? m1[i] : '.';
+        }
+        if (l2 > 0) {
+            b2[n2 = l2 > width ? width : l2] = 0;
+            for (i = 0; i < n2; i++)
+                b2[i] = isprint(m2[i]) ? m2[i] : '.';
+        }
+        diff = 0;
+        i = 0;
+        if (n1 > 0 && n2 > 0) {
+            const size_t j = n1 < n2 ? n1 : n2;
+
+            for (; i < j; i++)
+                if (m1[i] == m2[i]) {
+                    bdiff[i] = ' ';
+                } else {
+                    bdiff[i] = '^';
+                    diff = 1;
+                }
+            bdiff[i] = '\0';
+        }
+        if (n1 == n2 && !diff) {
+            test_printf_stderr("%*s# % 4u:  '%s'\n", indent, "", cnt,
+                               n2 > n1 ? b2 : b1);
+        } else {
+            if (cnt == 0 && (m1 == NULL || *m1 == '\0'))
+                test_string_null_empty(m1, '-');
+            else if (n1 > 0)
+                test_printf_stderr("%*s# % 4u:- '%s'\n", indent, "", cnt, b1);
+            if (cnt == 0 && (m2 == NULL || *m2 == '\0'))
+               test_string_null_empty(m2, '+');
+            else if (n2 > 0)
+                test_printf_stderr("%*s# % 4u:+ '%s'\n", indent, "", cnt, b2);
+            if (diff && i > 0)
+                test_printf_stderr("%*s# % 4s    %s\n", indent, "", "", bdiff);
+        }
+        m1 += n1;
+        m2 += n2;
+        l1 -= n1;
+        l2 -= n2;
+        cnt += width;
+    }
+fin:
+    test_flush_stderr();
+}
+
+/*
+ * Wrapper routines so that the underlying code can be shared.
+ * The first is the call from inside the test utilities when a conditional
+ * fails.  The second is the user's call to dump a string.
+ */
+void test_fail_string_message(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op, const char *m1, size_t l1,
+                              const char *m2, size_t l2)
+{
+    test_fail_string_common(prefix, file, line, type, left, right, op,
+                            m1, l1, m2, l2);
+    test_printf_stderr("\n");
+}
+
+void test_output_string(const char *name, const char *m, size_t l)
+{
+    test_fail_string_common("string", NULL, 0, NULL, NULL, NULL, name,
+                            m, l, m, l);
+}
+
+/* BIGNUM formatted output routines */
+
+/*
+ * A basic memory byte to hex digit converter with allowance for spacing
+ * every so often.
+ */
+static void hex_convert_memory(const unsigned char *m, size_t n, char *b,
+                               size_t width)
+{
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        const unsigned char c = *m++;
+
+        *b++ = "0123456789abcdef"[c >> 4];
+        *b++ = "0123456789abcdef"[c & 15];
+        if (i % width == width - 1 && i != n - 1)
+            *b++ = ' ';
+    }
+    *b = '\0';
+}
+
+/*
+ * Constants to define the number of bytes to display per line and the number
+ * of characters these take.
+ */
+static const int bn_bytes = (MAX_STRING_WIDTH - 9) / (BN_OUTPUT_SIZE * 2 + 1)
+                            * BN_OUTPUT_SIZE;
+static const int bn_chars = (MAX_STRING_WIDTH - 9) / (BN_OUTPUT_SIZE * 2 + 1)
+                            * (BN_OUTPUT_SIZE * 2 + 1) - 1;
+
+/*
+ * Output the header line for the bignum
+ */
+static void test_bignum_header_line(void)
+{
+    test_printf_stderr("%*s#  %*s\n", subtest_level(), "", bn_chars + 6,
+                       "bit position");
+}
+
+static const char *test_bignum_zero_null(const BIGNUM *bn)
+{
+    if (bn != NULL)
+        return BN_is_negative(bn) ? "-0" : "0";
+    return "NULL";
+}
+
+/*
+ * Print a bignum zero taking care to include the correct sign.
+ * This routine correctly deals with a NULL bignum pointer as input.
+ */
+static void test_bignum_zero_print(const BIGNUM *bn, char sep)
+{
+    const char *v = test_bignum_zero_null(bn);
+    const char *suf = bn != NULL ? ":    0" : "";
+
+    test_printf_stderr("%*s# %c%*s%s\n", subtest_level(), "", sep, bn_chars,
+                       v, suf);
+}
+
+/*
+ * Convert a section of memory from inside a bignum into a displayable
+ * string with appropriate visual aid spaces inserted.
+ */
+static int convert_bn_memory(const unsigned char *in, size_t bytes,
+                             char *out, int *lz, const BIGNUM *bn)
+{
+    int n = bytes * 2, i;
+    char *p = out, *q = NULL;
+
+    if (bn != NULL && !BN_is_zero(bn)) {
+        hex_convert_memory(in, bytes, out, BN_OUTPUT_SIZE);
+        if (*lz) {
+            for (; *p == '0' || *p == ' '; p++)
+                if (*p == '0') {
+                    q = p;
+                    *p = ' ';
+                    n--;
+                }
+            if (*p == '\0') {
+                /*
+                 * in[bytes] is defined because we're converting a non-zero
+                 * number and we've not seen a non-zero yet.
+                 */
+                if ((in[bytes] & 0xf0) != 0 && BN_is_negative(bn)) {
+                    *lz = 0;
+                    *q = '-';
+                    n++;
+                }
+            } else {
+                *lz = 0;
+                if (BN_is_negative(bn)) {
+                    /*
+                     * This is valid because we always convert more digits than
+                     * the number holds.
+                     */
+                    *q = '-';
+                    n++;
+                }
+            }
+        }
+       return n;
+    }
+
+    for (i = 0; i < n; i++) {
+        *p++ = ' ';
+        if (i % (2 * BN_OUTPUT_SIZE) == 2 * BN_OUTPUT_SIZE - 1 && i != n - 1)
+            *p++ = ' ';
+    }
+    *p = '\0';
+    if (bn == NULL)
+        q = "NULL";
+    else
+        q = BN_is_negative(bn) ? "-0" : "0";
+    strcpy(p - strlen(q), q);
+    return 0;
+}
+
+/*
+ * Common code to display either one or two bignums, including the diff
+ * pointers for changes (only when there are two).
+ */
+static void test_fail_bignum_common(const char *prefix, const char *file,
+                                    int line, const char *type,
+                                    const char *left, const char *right,
+                                    const char *op,
+                                    const BIGNUM *bn1, const BIGNUM *bn2)
+{
+    const int indent = subtest_level();
+    const size_t bytes = bn_bytes;
+    char b1[MAX_STRING_WIDTH + 1], b2[MAX_STRING_WIDTH + 1];
+    char *p, bdiff[MAX_STRING_WIDTH + 1];
+    size_t l1, l2, n1, n2, i, len;
+    unsigned int cnt, diff, real_diff;
+    unsigned char *m1 = NULL, *m2 = NULL;
+    int lz1 = 1, lz2 = 1;
+    unsigned char buffer[MEM_BUFFER_SIZE * 2], *bufp = buffer;
+
+    test_fail_message_prefix(prefix, file, line, type, left, right, op);
+    l1 = bn1 == NULL ? 0 : (BN_num_bytes(bn1) + (BN_is_negative(bn1) ? 1 : 0));
+    l2 = bn2 == NULL ? 0 : (BN_num_bytes(bn2) + (BN_is_negative(bn2) ? 1 : 0));
+    if (l1 == 0 && l2 == 0) {
+        if ((bn1 == NULL) == (bn2 == NULL)) {
+            test_bignum_header_line();
+            test_bignum_zero_print(bn1, ' ');
+        } else {
+            test_diff_header(left, right);
+            test_bignum_header_line();
+            test_bignum_zero_print(bn1, '-');
+            test_bignum_zero_print(bn2, '+');
+        }
+        goto fin;
+    }
+
+    if (l1 != l2 || bn1 == NULL || bn2 == NULL || BN_cmp(bn1, bn2) != 0)
+        test_diff_header(left, right);
+    test_bignum_header_line();
+
+    len = ((l1 > l2 ? l1 : l2) + bytes - 1) / bytes * bytes;
+
+    if (len > MEM_BUFFER_SIZE && (bufp = OPENSSL_malloc(len * 2)) == NULL) {
+        bufp = buffer;
+        len = MEM_BUFFER_SIZE;
+        test_printf_stderr("%*s# WARNING: these BIGNUMs have been truncated",
+                           indent, "");
+    }
+
+    if (bn1 != NULL) {
+        m1 = bufp;
+        BN_bn2binpad(bn1, m1, len);
+    }
+    if (bn2 != NULL) {
+        m2 = bufp + len;
+        BN_bn2binpad(bn2, m2, len);
+    }
+
+    while (len > 0) {
+        cnt = 8 * (len - bytes);
+        n1 = convert_bn_memory(m1, bytes, b1, &lz1, bn1);
+        n2 = convert_bn_memory(m2, bytes, b2, &lz2, bn2);
+
+        diff = real_diff = 0;
+        i = 0;
+        p = bdiff;
+        for (i=0; b1[i] != '\0'; i++)
+            if (b1[i] == b2[i] || b1[i] == ' ' || b2[i] == ' ') {
+                *p++ = ' ';
+                diff |= b1[i] != b2[i];
+            } else {
+                *p++ = '^';
+                real_diff = diff = 1;
+            }
+        *p++ = '\0';
+        if (!diff) {
+            test_printf_stderr("%*s#  %s:% 5d\n", indent, "",
+                               n2 > n1 ? b2 : b1, cnt);
+        } else {
+            if (cnt == 0 && bn1 == NULL)
+                test_printf_stderr("%*s# -%s\n", indent, "", b1);
+            else if (cnt == 0 || n1 > 0)
+                test_printf_stderr("%*s# -%s:% 5d\n", indent, "", b1, cnt);
+            if (cnt == 0 && bn2 == NULL)
+                test_printf_stderr("%*s# +%s\n", indent, "", b2);
+            else if (cnt == 0 || n2 > 0)
+                test_printf_stderr("%*s# +%s:% 5d\n", indent, "", b2, cnt);
+            if (real_diff && (cnt == 0 || (n1 > 0 && n2 > 0))
+                    && bn1 != NULL && bn2 != NULL)
+                test_printf_stderr("%*s#  %s\n", indent, "", bdiff);
+        }
+        if (m1 != NULL)
+            m1 += bytes;
+        if (m2 != NULL)
+            m2 += bytes;
+        len -= bytes;
+    }
+fin:
+    test_flush_stderr();
+    if (bufp != buffer)
+        OPENSSL_free(bufp);
+}
+
+/*
+ * Wrapper routines so that the underlying code can be shared.
+ * The first two are calls from inside the test utilities when a conditional
+ * fails.  The third is the user's call to dump a bignum.
+ */
+void test_fail_bignum_message(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op,
+                              const BIGNUM *bn1, const BIGNUM *bn2)
+{
+    test_fail_bignum_common(prefix, file, line, type, left, right, op, bn1, bn2);
+    test_printf_stderr("\n");
+}
+
+void test_fail_bignum_mono_message(const char *prefix, const char *file,
+                                   int line, const char *type,
+                                   const char *left, const char *right,
+                                   const char *op, const BIGNUM *bn)
+{
+    test_fail_bignum_common(prefix, file, line, type, left, right, op, bn, bn);
+    test_printf_stderr("\n");
+}
+
+void test_output_bignum(const char *name, const BIGNUM *bn)
+{
+    if (bn == NULL || BN_is_zero(bn)) {
+        test_printf_stderr("%*s# bignum: '%s' = %s\n", subtest_level(), "",
+                           name, test_bignum_zero_null(bn));
+    } else if (BN_num_bytes(bn) <= BN_OUTPUT_SIZE) {
+        unsigned char buf[BN_OUTPUT_SIZE];
+        char out[2 * sizeof(buf) + 1];
+        char *p = out;
+        int n = BN_bn2bin(bn, buf);
+
+        hex_convert_memory(buf, n, p, BN_OUTPUT_SIZE);
+        while (*p == '0' && *++p != '\0')
+            ;
+        test_printf_stderr("%*s# bignum: '%s' = %s0x%s\n", subtest_level(), "",
+                           name, BN_is_negative(bn) ? "-" : "", p);
+    } else {
+        test_fail_bignum_common("bignum", NULL, 0, NULL, NULL, NULL, name,
+                                bn, bn);
+    }
+}
+
+/* Memory output routines */
+
+/*
+ * Handle zero length blocks of memory or NULL pointers to memory
+ */
+static void test_memory_null_empty(const unsigned char *m, int indent, char c)
+{
+    if (m == NULL)
+        test_printf_stderr("%*s# % 4s %c%s\n", indent, "", "", c, "NULL");
+    else
+        test_printf_stderr("%*s# %04x %c%s\n", indent, "", 0u, c, "empty");
+}
+
+/*
+ * Common code to display one or two blocks of memory.
+ */
+static void test_fail_memory_common(const char *prefix, const char *file,
+                                    int line, const char *type,
+                                    const char *left, const char *right,
+                                    const char *op,
+                                    const unsigned char *m1, size_t l1,
+                                    const unsigned char *m2, size_t l2)
+{
+    const int indent = subtest_level();
+    const size_t bytes = (MAX_STRING_WIDTH - 9) / 17 * 8;
+    char b1[MAX_STRING_WIDTH + 1], b2[MAX_STRING_WIDTH + 1];
+    char *p, bdiff[MAX_STRING_WIDTH + 1];
+    size_t n1, n2, i;
+    unsigned int cnt = 0, diff;
+
+    test_fail_message_prefix(prefix, file, line, type, left, right, op);
+    if (m1 == NULL)
+        l1 = 0;
+    if (m2 == NULL)
+        l2 = 0;
+    if (l1 == 0 && l2 == 0) {
+        if ((m1 == NULL) == (m2 == NULL)) {
+            test_memory_null_empty(m1, indent, ' ');
+        } else {
+            test_diff_header(left, right);
+            test_memory_null_empty(m1, indent, '-');
+            test_memory_null_empty(m2, indent, '+');
+        }
+        goto fin;
+    }
+
+    if (l1 != l2 || (m1 != m2 && memcmp(m1, m2, l1) != 0))
+        test_diff_header(left, right);
+
+    while (l1 > 0 || l2 > 0) {
+        n1 = n2 = 0;
+        if (l1 > 0) {
+            n1 = l1 > bytes ? bytes : l1;
+            hex_convert_memory(m1, n1, b1, 8);
+        }
+        if (l2 > 0) {
+            n2 = l2 > bytes ? bytes : l2;
+            hex_convert_memory(m2, n2, b2, 8);
+        }
+
+        diff = 0;
+        i = 0;
+        p = bdiff;
+        if (n1 > 0 && n2 > 0) {
+            const size_t j = n1 < n2 ? n1 : n2;
+
+            for (; i < j; i++) {
+                if (m1[i] == m2[i]) {
+                    *p++ = ' ';
+                    *p++ = ' ';
+                } else {
+                    *p++ = '^';
+                    *p++ = '^';
+                    diff = 1;
+                }
+                if (i % 8 == 7 && i != j - 1)
+                    *p++ = ' ';
+            }
+            *p++ = '\0';
+        }
+
+        if (n1 == n2 && !diff) {
+            test_printf_stderr("%*s# %04x: %s\n", indent, "", cnt, b1);
+        } else {
+            if (cnt == 0 && (m1 == NULL || l1 == 0))
+                test_memory_null_empty(m1, indent, '-');
+            else if (n1 > 0)
+                test_printf_stderr("%*s# %04x:-%s\n", indent, "", cnt, b1);
+            if (cnt == 0 && (m2 == NULL || l2 == 0))
+                test_memory_null_empty(m2, indent, '+');
+            else if (n2 > 0)
+                test_printf_stderr("%*s# %04x:+%s\n", indent, "", cnt, b2);
+            if (diff && i > 0)
+                test_printf_stderr("%*s# % 4s  %s\n", indent, "", "", bdiff);
+        }
+        m1 += n1;
+        m2 += n2;
+        l1 -= n1;
+        l2 -= n2;
+        cnt += bytes;
+    }
+fin:
+    test_flush_stderr();
+}
+
+/*
+ * Wrapper routines so that the underlying code can be shared.
+ * The first is the call from inside the test utilities when a conditional
+ * fails.  The second is the user's call to dump memory.
+ */
+void test_fail_memory_message(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op,
+                              const unsigned char *m1, size_t l1,
+                              const unsigned char *m2, size_t l2)
+{
+    test_fail_memory_common(prefix, file, line, type, left, right, op,
+                            m1, l1, m2, l2);
+    test_printf_stderr("\n");
+}
+
+void test_output_memory(const char *name, const unsigned char *m, size_t l)
+{
+    test_fail_memory_common("memory", NULL, 0, NULL, NULL, NULL, name,
+                            m, l, m, l);
+}

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -15,34 +15,31 @@
 #include <ctype.h>
 #include "../../e_os.h"
 
-/* The size of memory buffers to display on failure */
-#define MEM_BUFFER_SIZE     (2000)
-#define MAX_STRING_WIDTH    (80)
-#define BN_OUTPUT_SIZE      (8)
-
-/* Output a failed test first line */
-static void test_fail_message_prefix(const char *prefix, const char *file,
-                                     int line, const char *type,
-                                     const char *left, const char *right,
-                                     const char *op)
+/*
+ * Output a failed test first line.
+ * All items are optional are generally not preinted if passed as NULL.
+ * The special cases are for prefix where "ERROR" is assumed and for left
+ * and right where a non-failure message is produced if either is NULL.
+ */
+void test_fail_message_prefix(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op)
 {
     test_printf_stderr("%*s# %s: ", subtest_level(), "",
                        prefix != NULL ? prefix : "ERROR");
     if (type)
         test_printf_stderr("(%s) ", type);
-    if (op != NULL)
-        test_printf_stderr("'%s %s %s' failed", left, op, right);
+    if (op != NULL) {
+        if (left != NULL && right != NULL)
+            test_printf_stderr("'%s %s %s' failed", left, op, right);
+        else
+            test_printf_stderr("'%s'", op);
+    }
     if (file != NULL) {
         test_printf_stderr(" @ %s:%d", file, line);
     }
     test_printf_stderr("\n");
-}
-
-/* Output a diff header */
-static void test_diff_header(const char *left, const char *right)
-{
-    test_printf_stderr("%*s# --- %s\n", subtest_level(), "", left);
-    test_printf_stderr("%*s# +++ %s\n", subtest_level(), "", right);
 }
 
 /*
@@ -85,407 +82,6 @@ static void test_fail_message_va(const char *prefix, const char *file,
         test_vprintf_stderr(fmt, ap);
         test_printf_stderr("\n");
     }
-    test_printf_stderr("\n");
-    test_flush_stderr();
-}
-
-static void test_string_null_empty(const char *m, int indent, char c)
-{
-    if (m == NULL)
-        test_printf_stderr("%*s# % 4s %c NULL\n", indent, "", "", c);
-    else
-        test_printf_stderr("%*s# % 4u:%c ''\n", indent, "", 0u, c);
-}
-
-static void test_fail_string_message(const char *prefix, const char *file,
-                                     int line, const char *type,
-                                     const char *left, const char *right,
-                                     const char *op, const char *m1, size_t l1,
-                                     const char *m2, size_t l2)
-{
-    const int indent = subtest_level();
-    const size_t width = (MAX_STRING_WIDTH - indent - 12) / 16 * 16;
-    char b1[MAX_STRING_WIDTH + 1], b2[MAX_STRING_WIDTH + 1];
-    char bdiff[MAX_STRING_WIDTH + 1];
-    size_t n1, n2, i;
-    unsigned int cnt = 0, diff;
-
-    test_fail_message_prefix(prefix, file, line, type, left, right, op);
-    if (m1 == NULL)
-        l1 = 0;
-    if (m2 == NULL)
-        l2 = 0;
-    if (l1 == 0 && l2 == 0) {
-        if ((m1 == NULL) == (m2 == NULL)) {
-            test_string_null_empty(m1, indent, ' ');
-        } else {
-            test_diff_header(left, right);
-            test_string_null_empty(m1, indent, '-');
-            test_string_null_empty(m2, indent, '+');
-        }
-        goto fin;
-    }
-
-    if (l1 != l2 || strcmp(m1, m2) != 0)
-        test_diff_header(left, right);
-
-    while (l1 > 0 || l2 > 0) {
-        n1 = n2 = 0;
-        if (l1 > 0) {
-            b1[n1 = l1 > width ? width : l1] = 0;
-            for (i = 0; i < n1; i++)
-                b1[i] = isprint(m1[i]) ? m1[i] : '.';
-        }
-        if (l2 > 0) {
-            b2[n2 = l2 > width ? width : l2] = 0;
-            for (i = 0; i < n2; i++)
-                b2[i] = isprint(m2[i]) ? m2[i] : '.';
-        }
-        diff = 0;
-        i = 0;
-        if (n1 > 0 && n2 > 0) {
-            const size_t j = n1 < n2 ? n1 : n2;
-
-            for (; i < j; i++)
-                if (m1[i] == m2[i]) {
-                    bdiff[i] = ' ';
-                } else {
-                    bdiff[i] = '^';
-                    diff = 1;
-                }
-            bdiff[i] = '\0';
-        }
-        if (n1 == n2 && !diff) {
-            test_printf_stderr("%*s# % 4u:  '%s'\n", indent, "", cnt,
-                               n2 > n1 ? b2 : b1);
-        } else {
-            if (cnt == 0 && (m1 == NULL || *m1 == '\0'))
-                test_string_null_empty(m1, indent, '-');
-            else if (n1 > 0)
-                test_printf_stderr("%*s# % 4u:- '%s'\n", indent, "", cnt, b1);
-            if (cnt == 0 && (m2 == NULL || *m2 == '\0'))
-               test_string_null_empty(m2, indent, '+');
-            else if (n2 > 0)
-                test_printf_stderr("%*s# % 4u:+ '%s'\n", indent, "", cnt, b2);
-            if (diff && i > 0)
-                test_printf_stderr("%*s# % 4s    %s\n", indent, "", "", bdiff);
-        }
-        m1 += n1;
-        m2 += n2;
-        l1 -= n1;
-        l2 -= n2;
-        cnt += width;
-    }
-fin:
-    test_printf_stderr("\n");
-    test_flush_stderr();
-}
-
-static void hex_convert_memory(const unsigned char *m, size_t n, char *b,
-                               size_t width)
-{
-    size_t i;
-
-    for (i = 0; i < n; i++) {
-        const unsigned char c = *m++;
-
-        *b++ = "0123456789abcdef"[c >> 4];
-        *b++ = "0123456789abcdef"[c & 15];
-        if (i % width == width - 1 && i != n - 1)
-            *b++ = ' ';
-    }
-    *b = '\0';
-}
-
-static const int bn_bytes = (MAX_STRING_WIDTH - 9) / (BN_OUTPUT_SIZE * 2 + 1)
-                            * BN_OUTPUT_SIZE;
-static const int bn_chars = (MAX_STRING_WIDTH - 9) / (BN_OUTPUT_SIZE * 2 + 1)
-                            * (BN_OUTPUT_SIZE * 2 + 1) - 1;
-
-static void test_bignum_header_line(void)
-{
-    test_printf_stderr("%*s#  %*s\n", subtest_level(), "", bn_chars + 6,
-                       "bit position");
-}
-
-static void test_bignum_zero_print(const BIGNUM *bn, char sep)
-{
-    const char *v = "NULL", *suf = "";
-    if (bn != NULL) {
-        suf = ":    0";
-        v = BN_is_negative(bn) ? "-0" : "0";
-    }
-    test_printf_stderr("%*s# %c%*s%s\n", subtest_level(), "", sep, bn_chars,
-                       v, suf);
-}
-
-static int convert_bn_memory(const unsigned char *in, size_t bytes,
-                             char *out, int *lz, const BIGNUM *bn)
-{
-    int n = bytes * 2, i;
-    char *p = out, *q = NULL;
-
-    if (bn != NULL && !BN_is_zero(bn)) {
-        hex_convert_memory(in, bytes, out, BN_OUTPUT_SIZE);
-        if (*lz) {
-            for (; *p == '0' || *p == ' '; p++)
-                if (*p == '0') {
-                    q = p;
-                    *p = ' ';
-                    n--;
-                }
-            if (*p == '\0') {
-                /*
-                 * in[bytes] is defined because we're converting a non-zero
-                 * number and we've not seen a non-zero yet.
-                 */
-                if ((in[bytes] & 0xf0) != 0 && BN_is_negative(bn)) {
-                    *lz = 0;
-                    *q = '-';
-                    n++;
-                }
-            } else {
-                *lz = 0;
-                if (BN_is_negative(bn)) {
-                    /*
-                     * This is valid because we always convert more digits than
-                     * the number holds.
-                     */
-                    *q = '-';
-                    n++;
-                }
-            }
-        }
-       return n;
-    }
-
-    for (i = 0; i < n; i++) {
-        *p++ = ' ';
-        if (i % (2 * BN_OUTPUT_SIZE) == 2 * BN_OUTPUT_SIZE - 1 && i != n - 1)
-            *p++ = ' ';
-    }
-    *p = '\0';
-    if (bn == NULL)
-        q = "NULL";
-    else
-        q = BN_is_negative(bn) ? "-0" : "0";
-    strcpy(p - strlen(q), q);
-    return 0;
-}
-
-static void test_fail_bignum_common(const char *prefix, const char *file,
-                                    int line, const char *type,
-                                    const char *left, const char *right,
-                                    const char *op,
-                                    const BIGNUM *bn1, const BIGNUM *bn2)
-{
-    const int indent = subtest_level();
-    const size_t bytes = bn_bytes;
-    char b1[MAX_STRING_WIDTH + 1], b2[MAX_STRING_WIDTH + 1];
-    char *p, bdiff[MAX_STRING_WIDTH + 1];
-    size_t l1, l2, n1, n2, i, len;
-    unsigned int cnt, diff, real_diff;
-    unsigned char *m1 = NULL, *m2 = NULL;
-    int lz1 = 1, lz2 = 1;
-    unsigned char buffer[MEM_BUFFER_SIZE * 2], *bufp = buffer;
-
-    l1 = bn1 == NULL ? 0 : (BN_num_bytes(bn1) + (BN_is_negative(bn1) ? 1 : 0));
-    l2 = bn2 == NULL ? 0 : (BN_num_bytes(bn2) + (BN_is_negative(bn2) ? 1 : 0));
-    if (l1 == 0 && l2 == 0) {
-        if ((bn1 == NULL) == (bn2 == NULL)) {
-            test_bignum_header_line();
-            test_bignum_zero_print(bn1, ' ');
-        } else {
-            test_diff_header(left, right);
-            test_bignum_header_line();
-            test_bignum_zero_print(bn1, '-');
-            test_bignum_zero_print(bn2, '+');
-        }
-        goto fin;
-    }
-
-    if (l1 != l2 || bn1 == NULL || bn2 == NULL || BN_cmp(bn1, bn2) != 0)
-        test_diff_header(left, right);
-    test_bignum_header_line();
-
-    len = ((l1 > l2 ? l1 : l2) + bytes - 1) / bytes * bytes;
-
-    if (len > MEM_BUFFER_SIZE && (bufp = OPENSSL_malloc(len * 2)) == NULL) {
-        bufp = buffer;
-        len = MEM_BUFFER_SIZE;
-        test_printf_stderr("%*s# WARNING: these BIGNUMs have been truncated",
-                           indent, "");
-    }
-
-    if (bn1 != NULL) {
-        m1 = bufp;
-        BN_bn2binpad(bn1, m1, len);
-    }
-    if (bn2 != NULL) {
-        m2 = bufp + len;
-        BN_bn2binpad(bn2, m2, len);
-    }
-
-    while (len > 0) {
-        cnt = 8 * (len - bytes);
-        n1 = convert_bn_memory(m1, bytes, b1, &lz1, bn1);
-        n2 = convert_bn_memory(m2, bytes, b2, &lz2, bn2);
-
-        diff = real_diff = 0;
-        i = 0;
-        p = bdiff;
-        for (i=0; b1[i] != '\0'; i++)
-            if (b1[i] == b2[i] || b1[i] == ' ' || b2[i] == ' ') {
-                *p++ = ' ';
-                diff |= b1[i] != b2[i];
-            } else {
-                *p++ = '^';
-                real_diff = diff = 1;
-            }
-        *p++ = '\0';
-        if (!diff) {
-            test_printf_stderr("%*s#  %s:% 5d\n", indent, "",
-                               n2 > n1 ? b2 : b1, cnt);
-        } else {
-            if (cnt == 0 && bn1 == NULL)
-                test_printf_stderr("%*s# -%s\n", indent, "", b1);
-            else if (cnt == 0 || n1 > 0)
-                test_printf_stderr("%*s# -%s:% 5d\n", indent, "", b1, cnt);
-            if (cnt == 0 && bn2 == NULL)
-                test_printf_stderr("%*s# +%s\n", indent, "", b2);
-            else if (cnt == 0 || n2 > 0)
-                test_printf_stderr("%*s# +%s:% 5d\n", indent, "", b2, cnt);
-            if (real_diff && (cnt == 0 || (n1 > 0 && n2 > 0))
-                    && bn1 != NULL && bn2 != NULL)
-                test_printf_stderr("%*s#  %s\n", indent, "", bdiff);
-        }
-        if (m1 != NULL)
-            m1 += bytes;
-        if (m2 != NULL)
-            m2 += bytes;
-        len -= bytes;
-    }
-fin:
-    test_printf_stderr("\n");
-    test_flush_stderr();
-    if (bufp != buffer)
-        OPENSSL_free(bufp);
-}
-
-static void test_fail_bignum_message(const char *prefix, const char *file,
-                                     int line, const char *type,
-                                     const char *left, const char *right,
-                                     const char *op,
-                                     const BIGNUM *bn1, const BIGNUM *bn2)
-{
-    test_fail_message_prefix(prefix, file, line, type, left, right, op);
-    test_fail_bignum_common(prefix, file, line, type, left, right, op, bn1, bn2);
-}
-
-static void test_fail_bignum_mono_message(const char *prefix, const char *file,
-                                          int line, const char *type,
-                                          const char *left, const char *right,
-                                          const char *op, const BIGNUM *bn)
-{
-    test_fail_message_prefix(prefix, file, line, type, left, right, op);
-    test_fail_bignum_common(prefix, file, line, type, left, right, op, bn, bn);
-}
-
-static void test_memory_null_empty(const unsigned char *m, int indent, char c)
-{
-    if (m == NULL)
-        test_printf_stderr("%*s# % 4s %c%s\n", indent, "", "", c, "NULL");
-    else
-        test_printf_stderr("%*s# %04x %c%s\n", indent, "", 0u, c, "empty");
-}
-
-static void test_fail_memory_message(const char *prefix, const char *file,
-                                     int line, const char *type,
-                                     const char *left, const char *right,
-                                     const char *op,
-                                     const unsigned char *m1, size_t l1,
-                                     const unsigned char *m2, size_t l2)
-{
-    const int indent = subtest_level();
-    const size_t bytes = (MAX_STRING_WIDTH - 9) / 17 * 8;
-    char b1[MAX_STRING_WIDTH + 1], b2[MAX_STRING_WIDTH + 1];
-    char *p, bdiff[MAX_STRING_WIDTH + 1];
-    size_t n1, n2, i;
-    unsigned int cnt = 0, diff;
-
-    test_fail_message_prefix(prefix, file, line, type, left, right, op);
-    if (m1 == NULL)
-        l1 = 0;
-    if (m2 == NULL)
-        l2 = 0;
-    if (l1 == 0 && l2 == 0) {
-        if ((m1 == NULL) == (m2 == NULL)) {
-            test_memory_null_empty(m1, indent, ' ');
-        } else {
-            test_diff_header(left, right);
-            test_memory_null_empty(m1, indent, '-');
-            test_memory_null_empty(m2, indent, '+');
-        }
-        goto fin;
-    }
-
-    if (l1 != l2 || memcmp(m1, m2, l1) != 0)
-        test_diff_header(left, right);
-
-    while (l1 > 0 || l2 > 0) {
-        n1 = n2 = 0;
-        if (l1 > 0) {
-            n1 = l1 > bytes ? bytes : l1;
-            hex_convert_memory(m1, n1, b1, 8);
-        }
-        if (l2 > 0) {
-            n2 = l2 > bytes ? bytes : l2;
-            hex_convert_memory(m2, n2, b2, 8);
-        }
-
-        diff = 0;
-        i = 0;
-        p = bdiff;
-        if (n1 > 0 && n2 > 0) {
-            const size_t j = n1 < n2 ? n1 : n2;
-
-            for (; i < j; i++) {
-                if (m1[i] == m2[i]) {
-                    *p++ = ' ';
-                    *p++ = ' ';
-                } else {
-                    *p++ = '^';
-                    *p++ = '^';
-                    diff = 1;
-                }
-                if (i % 8 == 7 && i != j - 1)
-                    *p++ = ' ';
-            }
-            *p++ = '\0';
-        }
-
-        if (n1 == n2 && !diff) {
-            test_printf_stderr("%*s# %04x: %s\n", indent, "", cnt, b1);
-        } else {
-            if (cnt == 0 && (m1 == NULL || l1 == 0))
-                test_memory_null_empty(m1, indent, '-');
-            else if (n1 > 0)
-                test_printf_stderr("%*s# %04x:-%s\n", indent, "", cnt, b1);
-            if (cnt == 0 && (m2 == NULL || l2 == 0))
-                test_memory_null_empty(m2, indent, '+');
-            else if (n2 > 0)
-                test_printf_stderr("%*s# %04x:+%s\n", indent, "", cnt, b2);
-            if (diff && i > 0)
-                test_printf_stderr("%*s# % 4s  %s\n", indent, "", "", bdiff);
-        }
-        m1 += n1;
-        m2 += n2;
-        l1 -= n1;
-        l2 -= n2;
-        cnt += bytes;
-    }
-fin:
-    test_printf_stderr("\n");
     test_flush_stderr();
 }
 
@@ -526,6 +122,7 @@ void test_error_c90(const char *desc, ...)
     va_start(ap, desc);
     test_fail_message_va(NULL, NULL, -1, NULL, NULL, NULL, NULL, desc, ap);
     va_end(ap);
+    test_printf_stderr("\n");
 }
 
 void test_error(const char *file, int line, const char *desc, ...)
@@ -535,6 +132,19 @@ void test_error(const char *file, int line, const char *desc, ...)
     va_start(ap, desc);
     test_fail_message_va(NULL, file, line, NULL, NULL, NULL, NULL, desc, ap);
     va_end(ap);
+    test_printf_stderr("\n");
+}
+
+void test_note(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (fmt != NULL) {
+        test_printf_stderr("%*s# ", subtest_level(), "");
+        test_vprintf_stderr(fmt, ap);
+        test_printf_stderr("\n");
+    }
+    test_flush_stderr();
 }
 
 void test_openssl_errors(void)

--- a/test/testutil/tu_local.h
+++ b/test/testutil/tu_local.h
@@ -8,6 +8,36 @@
  */
 
 #include <stdlib.h>              /* size_t */
+#include <openssl/bn.h>
 
 int subtest_level(void);
 int openssl_error_cb(const char *str, size_t len, void *u);
+
+void test_fail_message_prefix(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op);
+
+void test_fail_string_message(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op, const char *m1, size_t l1,
+                              const char *m2, size_t l2);
+
+void test_fail_bignum_message(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op,
+                              const BIGNUM *bn1, const BIGNUM *bn2);
+void test_fail_bignum_mono_message(const char *prefix, const char *file,
+                                   int line, const char *type,
+                                   const char *left, const char *right,
+                                   const char *op, const BIGNUM *bn);
+
+void test_fail_memory_message(const char *prefix, const char *file,
+                              int line, const char *type,
+                              const char *left, const char *right,
+                              const char *op,
+                              const unsigned char *m1, size_t l1,
+                              const unsigned char *m2, size_t l2);
+


### PR DESCRIPTION

- [x] tests are added or updated

Addition of user callable routines to output memory block, strings and bignums in a standard format that is equivalent to the test failure output of these (sans the diff).

The relevant test cases that did their own thing, now call the library routines.

The output code has been moved to its own file rather than cluttering up the tests source file.