### PR TITLE
Fix memleak in EVP_DigestSignFinal/VerifyFinal.

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -123,8 +123,12 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
                 r = EVP_DigestFinal_ex(ctx, md, &mdlen);
         } else {
             EVP_MD_CTX *tmp_ctx = EVP_MD_CTX_new();
-            if (tmp_ctx == NULL || !EVP_MD_CTX_copy_ex(tmp_ctx, ctx))
+            if (tmp_ctx == NULL)
                 return 0;
+            if (!EVP_MD_CTX_copy_ex(tmp_ctx, ctx)) {
+                EVP_MD_CTX_free(tmp_ctx);
+                return 0;
+            }
             if (sctx)
                 r = tmp_ctx->pctx->pmeth->signctx(tmp_ctx->pctx,
                                                   sigret, siglen, tmp_ctx);
@@ -178,8 +182,12 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
             r = EVP_DigestFinal_ex(ctx, md, &mdlen);
     } else {
         EVP_MD_CTX *tmp_ctx = EVP_MD_CTX_new();
-        if (tmp_ctx == NULL || !EVP_MD_CTX_copy_ex(tmp_ctx, ctx))
+        if (tmp_ctx == NULL)
             return -1;
+        if (!EVP_MD_CTX_copy_ex(tmp_ctx, ctx)) {
+            EVP_MD_CTX_free(tmp_ctx);
+            return -1;
+        }
         if (vctx) {
             r = tmp_ctx->pctx->pmeth->verifyctx(tmp_ctx->pctx,
                                                 sig, siglen, tmp_ctx);


### PR DESCRIPTION
This fixes the following memory leak:

```
Direct leak of 96 byte(s) in 2 object(s) allocated from:
    #0 0x7fc17f62f850 in __interceptor_malloc ../../../../gcc-8-20170611/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x21dda91 in CRYPTO_malloc crypto/mem.c:76
    #2 0x21dda91 in CRYPTO_zalloc crypto/mem.c:100
    #3 0x21c2f1f in EVP_DigestSignFinal crypto/evp/m_sigver.c:111
    #4 0x21daecb in tls1_prf_P_hash crypto/kdf/tls1_prf.c:194
    #5 0x21db345 in tls1_prf_alg crypto/kdf/tls1_prf.c:261
    #6 0x21db345 in pkey_tls1_prf_derive crypto/kdf/tls1_prf.c:129
    #7 0x211242e in tls1_PRF ssl/t1_enc.c:82
    #8 0x211242e in tls1_final_finish_mac ssl/t1_enc.c:455
    #9 0x20c704d in ssl3_take_mac ssl/statem/statem_lib.c:121
    #10 0x20c704d in tls_get_message_body ssl/statem/statem_lib.c:474
    #11 0x20ab43c in read_state_machine ssl/statem/statem.c:578
    #12 0x20ab43c in state_machine ssl/statem/statem.c:387
    #13 0x2070c16 in ssl3_read_bytes ssl/record/rec_layer_s3.c:1031
    #14 0x2081667 in ssl3_read_internal ssl/s3_lib.c:3833
    #15 0x2081667 in ssl3_read ssl/s3_lib.c:3857
    #16 0x208f02f in SSL_read ssl/ssl_lib.c:1552
    #17 0x1d456a5 in OpcUa_P_SocketService_SslRead platforms/linux/opcua_p_socket_ssl.c:248
    #18 0x1db5373 in OpcUa_HttpsStream_Receive transport/https/opcua_httpsstream.c:2118
    #19 0x1db5373 in OpcUa_HttpsStream_DataReady transport/https/opcua_httpsstream.c:2664
    #20 0x1da6723 in OpcUa_HttpsListener_ReadEventHandler transport/https/opcua_httpslistener.c:1251
    #21 0x1da0bd5 in OpcUa_HttpsListener_EventCallback transport/https/opcua_httpslistener.c:1664
    #22 0x1d45bc3 in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:171
    #23 0x1d46432 in OpcUa_SslSocket_InternalRead platforms/linux/opcua_p_socket_ssl.c:782
    #24 0x1d46432 in OpcUa_RawSocket_EventCallback platforms/linux/opcua_p_socket_ssl.c:839
    #25 0x1d3d313 in OpcUa_Socket_HandleEvent platforms/linux/opcua_p_socket_internal.c:898
    #26 0x1d3f644 in OpcUa_P_Socket_HandleFdSet platforms/linux/opcua_p_socket_internal.c:1336
    #27 0x1d420ba in OpcUa_P_SocketManager_ServeLoopInternal platforms/linux/opcua_p_socket_internal.c:1123
    #28 0x1d420ba in OpcUa_SocketManager_AcceptHandlerThread platforms/linux/opcua_p_socket_internal.c:723
    #29 0x1d4910d in pthread_start platforms/linux/opcua_p_thread.c:46
    #30 0x7fc17f340e99 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7e99)
```

... I started to test the OPC/UA Stack with OpenSSL 1.1.0.