### PR TITLE
Add a missing break in test/shlibloadtest.c

### DIFF
--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -159,6 +159,7 @@ static int test_lib(void)
         if (!TEST_true(shlib_close(cryptolib))
                 || !TEST_true(shlib_close(ssllib)))
             goto end;
+        break;
     case SSL_FIRST:
         if (!TEST_true(shlib_close(ssllib))
                 || !TEST_true(shlib_close(cryptolib)))

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -117,6 +117,7 @@ static int test_lib(void)
         if (!TEST_true(shlib_load(path_crypto, &cryptolib))
                 || !TEST_true(shlib_load(path_ssl, &ssllib)))
             goto end;
+        break;
     case SSL_FIRST:
         if (!TEST_true(shlib_load(path_ssl, &ssllib))
                 || !TEST_true(shlib_load(path_crypto, &cryptolib)))


### PR DESCRIPTION
This fixes a gcc warning about missing break (or fallthru comment).