### PR TITLE
Add -lib option to util/mkerr.pl

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -17,7 +17,7 @@ my $rebuild      = 0;
 my $reindex      = 0;
 my $static       = 0;
 my $unref        = 0;
-my %libs         = ();
+my %modules         = ();
 
 my $errors       = 0;
 my @t            = localtime();
@@ -43,11 +43,12 @@ Options:
     -internal   Generate code that is to be built as part of OpenSSL itself.
                 Also scans internal list of files.
 
-    -lib LIB    Only useful with -internal!
-                Only write files for library LIB.  Whether files are actually
-                written or not depends on other options, such as -rebuild.
+    -module M   Only useful with -internal!
+                Only write files for library module M.  Whether files are
+                actually written or not depends on other options, such as
+                -rebuild.
                 Note: this option is cumulative.  If not given at all, all
-                internal libs will be considered.
+                internal modules will be considered.
 
     -nowrite    Do not write the header/source files, even if changed.
 
@@ -93,9 +94,9 @@ while ( @ARGV ) {
     } elsif ( $arg eq "-unref" ) {
         $unref = 1;
         $nowrite = 1;
-    } elsif ( $arg eq "-lib" ) {
+    } elsif ( $arg eq "-module" ) {
         shift @ARGV;
-        $libs{uc $ARGV[0]} = 1;
+        $modules{uc $ARGV[0]} = 1;
     } elsif ( $arg =~ /-*h(elp)?/ ) {
         &help();
         exit;
@@ -112,7 +113,7 @@ if ( $internal ) {
     @source = ( glob('crypto/*.c'), glob('crypto/*/*.c'),
                 glob('ssl/*.c'), glob('ssl/*/*.c') );
 } else {
-    die "-lib isn't useful without -internal\n" if scalar keys %libs > 0;
+    die "-module isn't useful without -internal\n" if scalar keys %modules > 0;
     @source = @ARGV;
 }
 
@@ -400,7 +401,7 @@ foreach my $lib ( keys %errorfile ) {
     if ( ! $fnew{$lib} && ! $rnew{$lib} ) {
         next unless $rebuild;
     }
-    next if scalar keys %libs > 0 && !$libs{$lib};
+    next if scalar keys %modules > 0 && !$modules{$lib};
     next if $nowrite;
     print STDERR "$lib: $fnew{$lib} new functions\n" if $fnew{$lib};
     print STDERR "$lib: $rnew{$lib} new reasons\n" if $rnew{$lib};


### PR DESCRIPTION
Sometimes, one might only want to rework a subset of all the internal
error codes.  -lib allows the caller to specify exactly which sub-libs
to rewrite.

-----

I found this to be useful for the STORE project, when I wanted to rebuild only the STORE header files.