### PR TITLE
Fix a memleak in ec_copy_parameters.

### DIFF
--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -298,17 +298,21 @@ static int ec_missing_parameters(const EVP_PKEY *pkey)
 static int ec_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 {
     EC_GROUP *group = EC_GROUP_dup(EC_KEY_get0_group(from->pkey.ec));
+
     if (group == NULL)
         return 0;
     if (to->pkey.ec == NULL) {
         to->pkey.ec = EC_KEY_new();
         if (to->pkey.ec == NULL)
-            return 0;
+            goto err;
     }
     if (EC_KEY_set_group(to->pkey.ec, group) == 0)
-        return 0;
+        goto err;
     EC_GROUP_free(group);
     return 1;
+ err:
+    EC_GROUP_free(group);
+    return 0;
 }
 
 static int ec_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)


### PR DESCRIPTION
This fixes the following memory leak:

```
Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f31c14ac850 in __interceptor_malloc ../../../../gcc-8-20170611/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x2236d41 in CRYPTO_malloc crypto/mem.c:163
    #2 0x2236d41 in CRYPTO_zalloc crypto/mem.c:188
    #3 0x218766b in BN_new crypto/bn/bn_lib.c:227
    #4 0x21c562c in EC_GROUP_new crypto/ec/ec_lib.c:46
    #5 0x21c562c in EC_GROUP_dup crypto/ec/ec_lib.c:244
    #6 0x21b4c16 in ec_copy_parameters crypto/ec/ec_ameth.c:300
    #7 0x221d6fb in EVP_PKEY_copy_parameters crypto/evp/p_lib.c:96
    #8 0x23d9e6b in pkey_ec_keygen crypto/ec/ec_pmeth.c:419
    #9 0x2222abd in EVP_PKEY_keygen crypto/evp/pmeth_gn.c:107
    #10 0x208738d in ssl_generate_pkey ssl/s3_lib.c:4141
    #11 0x20d7a38 in tls_construct_stoc_key_share ssl/statem/extensions_srvr.c:1145
    #12 0x20c4576 in tls_construct_extensions ssl/statem/extensions.c:747
    #13 0x21046cb in tls_construct_server_hello ssl/statem/statem_srvr.c:2129
    #14 0x20d96ae in write_state_machine ssl/statem/statem.c:794
    #15 0x20d96ae in state_machine ssl/statem/statem.c:401
    #16 0x2071e80 in ssl3_read_bytes ssl/record/rec_layer_s3.c:1201
    #17 0x2086122 in ssl3_read_internal ssl/s3_lib.c:3931
    #18 0x2086122 in ssl3_read ssl/s3_lib.c:3955
    #19 0x209be7b in ssl_read_internal ssl/ssl_lib.c:1580
    #20 0x209be7b in SSL_read ssl/ssl_lib.c:1594
    #21 0x1d46745 in OpcUa_P_SocketService_SslRead platforms/linux/opcua_p_socket_ssl.c:248
    #22 0x1db6483 in OpcUa_HttpsStream_Receive transport/https/opcua_httpsstream.c:2118
    #23 0x1db6483 in OpcUa_HttpsStream_DataReady transport/https/opcua_httpsstream.c:2664
    #24 0x1da7833 in OpcUa_HttpsListener_ReadEventHandler transport/https/opcua_httpslistener.c:1251
    #25 0x1da1ce5 in OpcUa_HttpsListener_EventCallback transport/https/opcua_httpslistener.c:1664
    #26 0x1d46c63 in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:171
    #27 0x1d474d2 in OpcUa_SslSocket_InternalRead platforms/linux/opcua_p_socket_ssl.c:782
    #28 0x1d474d2 in OpcUa_RawSocket_EventCallback platforms/linux/opcua_p_socket_ssl.c:839
    #29 0x1d3e3b3 in OpcUa_Socket_HandleEvent platforms/linux/opcua_p_socket_internal.c:898
    #30 0x1d406e4 in OpcUa_P_Socket_HandleFdSet platforms/linux/opcua_p_socket_internal.c:1336
    #31 0x1d4315a in OpcUa_P_SocketManager_ServeLoopInternal platforms/linux/opcua_p_socket_internal.c:1123
    #32 0x1d4315a in OpcUa_SocketManager_AcceptHandlerThread platforms/linux/opcua_p_socket_internal.c:723
    #33 0x1d4a21d in pthread_start platforms/linux/opcua_p_thread.c:46
    #34 0x7f31c11bde99 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7e99)
```

For master & 1.1.0

1.0.2 needs a backport.