### PR TITLE
Fix a crash in tls_construct_client_certificate

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3336,7 +3336,12 @@ int tls_construct_client_certificate(SSL *s, WPACKET *pkt)
                     SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
         SSLerr(SSL_F_TLS_CONSTRUCT_CLIENT_CERTIFICATE,
                SSL_R_CANNOT_CHANGE_CIPHER);
-        goto err;
+        /*
+         * This is a fatal error, which leaves
+         * enc_write_ctx in an inconsistent state
+         * and thus ssl3_send_alert may crash.
+         */
+        return 0;
     }
 
     return 1;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -506,7 +506,12 @@ int tls_construct_finished(SSL *s, WPACKET *pkt)
             && (!s->method->ssl3_enc->change_cipher_state(s,
                     SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
         SSLerr(SSL_F_TLS_CONSTRUCT_FINISHED, SSL_R_CANNOT_CHANGE_CIPHER);
-        goto err;
+        /*
+         * This is a fatal error, which leaves
+         * enc_write_ctx in an inconsistent state
+         * and thus ssl3_send_alert may crash.
+         */
+        return 0;
     }
 
     if (s->server) {


### PR DESCRIPTION
ssl3_send_alert may crash when change_cipher_state returns an error.
So don't send any alerts in this case, and simply return an error.
As can be seen in the following call-stack:

```
==17830==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000000c (pc 0x00000244b6fa bp 0x7f62fd158310 sp 0x7f62fd158310 T331)
==17830==The signal is caused by a READ memory access.
==17830==Hint: address points to the zero page.
    #0 0x244b6f9 in EVP_CIPHER_CTX_iv_length crypto/evp/evp_lib.c:233
    #1 0x22af861 in tls13_enc ssl/record/ssl3_record_tls13.c:56
    #2 0x22a10a5 in do_ssl3_write ssl/record/rec_layer_s3.c:950
    #3 0x22ba869 in ssl3_dispatch_alert ssl/s3_msg.c:102
    #4 0x230fa29 in tls_construct_client_certificate ssl/statem/statem_clnt.c:3344
    #5 0x230b5ee in write_state_machine ssl/statem/statem.c:792
    #6 0x230b5ee in state_machine ssl/statem/statem.c:401
    #7 0x22a26ea in ssl3_write_bytes ssl/record/rec_layer_s3.c:376
    #8 0x22d16e3 in ssl_write_internal ssl/ssl_lib.c:1771
    #9 0x22d16e3 in SSL_write ssl/ssl_lib.c:1785
    #10 0x1f7b041 in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:123
    #11 0x1f7b041 in OpcUa_P_SocketService_SslWrite platforms/linux/opcua_p_socket_ssl.c:331
    #12 0x1fce4e2 in OpcUa_HttpsConnection_WriteEventHandler transport/https/opcua_httpsconnection.c:842
    #13 0x1fcb6cc in OpcUa_HttpsConnection_SocketCallback transport/https/opcua_httpsconnection.c:1422
    #14 0x1f792e0 in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:152
    #15 0x1f79782 in OpcUa_SslSocket_InternalRead platforms/linux/opcua_p_socket_ssl.c:782
    #16 0x1f79782 in OpcUa_RawSocket_EventCallback platforms/linux/opcua_p_socket_ssl.c:839
    #17 0x1f70663 in OpcUa_Socket_HandleEvent platforms/linux/opcua_p_socket_internal.c:898
    #18 0x1f72994 in OpcUa_P_Socket_HandleFdSet platforms/linux/opcua_p_socket_internal.c:1336
    #19 0x1f73be2 in OpcUa_P_SocketManager_ServeLoopInternal platforms/linux/opcua_p_socket_internal.c:1123
    #20 0x1f6b4fa in OpcUa_P_SocketManager_ServerLoopThread platforms/linux/opcua_p_socket_interface.c:43
    #21 0x1f7c4cd in pthread_start platforms/linux/opcua_p_thread.c:46
    #22 0x7f6319d8fe99 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7e99)
    #23 0x7f6318e1f2ec in clone (/lib/x86_64-linux-gnu/libc.so.6+0xf62ec)
```