### PR TITLE
Fix crash in ecdh_simple_compute_key

### DIFF
--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -66,6 +66,10 @@ int ecdh_simple_compute_key(unsigned char **pout, size_t *poutlen,
     BN_CTX_start(ctx);
     x = BN_CTX_get(ctx);
     y = BN_CTX_get(ctx);
+    if (y == NULL) {
+        ECerr(EC_F_ECDH_SIMPLE_COMPUTE_KEY, ERR_R_MALLOC_FAILURE);
+        goto err;
+    }
 
     priv_key = EC_KEY_get0_private_key(ecdh);
     if (priv_key == NULL) {


### PR DESCRIPTION
This fixes the following crash in ecdh_simple_compute_key:

```
=================================================================
==22222==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x0000023b9282 bp 0x7f2e8618ad00 sp 0x7f2e8618ad00 T265)
==22222==The signal is caused by a READ memory access.
==22222==Hint: address points to the zero page.
    #0 0x23b9281 in BN_num_bits crypto/bn/bn_lib.c:163
    #1 0x23fd0a7 in ecdh_simple_compute_key crypto/ec/ecdh_ossl.c:114
    #2 0x23f47e9 in ECDH_compute_key crypto/ec/ec_kmeth.c:142
    #3 0x260c7ec in pkey_ec_derive crypto/ec/ec_pmeth.c:176
    #4 0x260c7ec in pkey_ec_kdf_derive crypto/ec/ec_pmeth.c:191
    #5 0x22b9cb1 in ssl_derive ssl/s3_lib.c:4207
    #6 0x22fe2f3 in tls_parse_stoc_key_share ssl/statem/extensions_clnt.c:1431
    #7 0x22f5e44 in tls_parse_extension ssl/statem/extensions.c:597
    #8 0x22f5e44 in tls_parse_all_extensions ssl/statem/extensions.c:634
    #9 0x2315c92 in tls_process_server_hello ssl/statem/statem_clnt.c:1529
    #10 0x23219da in ossl_statem_client_process_message ssl/statem/statem_clnt.c:965
    #11 0x230c030 in read_state_machine ssl/statem/statem.c:595
    #12 0x230c030 in state_machine ssl/statem/statem.c:392
    #13 0x22a275a in ssl3_write_bytes ssl/record/rec_layer_s3.c:376
    #14 0x22d1753 in ssl_write_internal ssl/ssl_lib.c:1771
    #15 0x22d1753 in SSL_write ssl/ssl_lib.c:1785
    #16 0x1f7b0b1 in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:123
    #17 0x1f7b0b1 in OpcUa_P_SocketService_SslWrite platforms/linux/opcua_p_socket_ssl.c:331
    #18 0x1fce552 in OpcUa_HttpsConnection_WriteEventHandler transport/https/opcua_httpsconnection.c:842
    #19 0x1fcb73c in OpcUa_HttpsConnection_SocketCallback transport/https/opcua_httpsconnection.c:1422
    #20 0x1f79350 in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:152
    #21 0x1f797f2 in OpcUa_SslSocket_InternalRead platforms/linux/opcua_p_socket_ssl.c:782
    #22 0x1f797f2 in OpcUa_RawSocket_EventCallback platforms/linux/opcua_p_socket_ssl.c:839
    #23 0x1f706d3 in OpcUa_Socket_HandleEvent platforms/linux/opcua_p_socket_internal.c:898
    #24 0x1f72a04 in OpcUa_P_Socket_HandleFdSet platforms/linux/opcua_p_socket_internal.c:1336
    #25 0x1f73c52 in OpcUa_P_SocketManager_ServeLoopInternal platforms/linux/opcua_p_socket_internal.c:1123
    #26 0x1f6b56a in OpcUa_P_SocketManager_ServerLoopThread platforms/linux/opcua_p_socket_interface.c:43
    #27 0x1f7c53d in pthread_start platforms/linux/opcua_p_thread.c:46
    #28 0x7f2e9435de99 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7e99)
    #29 0x7f2e933ed2ec in clone (/lib/x86_64-linux-gnu/libc.so.6+0xf62ec)
```

For master and 1.1.0 branch.