### PR TITLE
Fix a possible crash in the error handling

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -378,6 +378,8 @@ void ERR_put_error(int lib, int func, int reason, const char *file, int line)
     }
 #endif
     es = ERR_get_state();
+    if (es == NULL)
+        return;
 
     es->top = (es->top + 1) % ERR_NUM_ERRORS;
     if (es->top == es->bottom)
@@ -395,6 +397,8 @@ void ERR_clear_error(void)
     ERR_STATE *es;
 
     es = ERR_get_state();
+    if (es == NULL)
+        return;
 
     for (i = 0; i < ERR_NUM_ERRORS; i++) {
         err_clear(es, i);
@@ -459,6 +463,8 @@ static unsigned long get_error_values(int inc, int top, const char **file,
     unsigned long ret;
 
     es = ERR_get_state();
+    if (es == NULL)
+        return 0;
 
     if (inc && top) {
         if (file)
@@ -709,6 +715,8 @@ void ERR_set_error_data(char *data, int flags)
     int i;
 
     es = ERR_get_state();
+    if (es == NULL)
+        return;
 
     i = es->top;
     if (i == 0)
@@ -764,6 +772,8 @@ int ERR_set_mark(void)
     ERR_STATE *es;
 
     es = ERR_get_state();
+    if (es == NULL)
+        return 0;
 
     if (es->bottom == es->top)
         return 0;
@@ -776,6 +786,8 @@ int ERR_pop_to_mark(void)
     ERR_STATE *es;
 
     es = ERR_get_state();
+    if (es == NULL)
+        return 0;
 
     while (es->bottom != es->top
            && (es->err_flags[es->top] & ERR_FLAG_MARK) == 0) {


### PR DESCRIPTION
This fixes crashes in the crypto error handling module:

```
==1925==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000244 (pc 0x0000021ef338 bp 0x7f555666ecb0 sp 0x7f555666ec90 T3679)
==1925==The signal is caused by a READ memory access.
==1925==Hint: address points to the zero page.
    #0 0x21ef337 in ERR_set_mark crypto/err/err.c:768
    #1 0x22f8d8c in pubkey_cb crypto/x509/x_pubkey.c:44
    #2 0x21587a4 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:396
    #3 0x2153dbd in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:606
    #4 0x2153dbd in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:482
    #5 0x215806d in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:347
    #6 0x2153dbd in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:606
    #7 0x2153dbd in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:482
    #8 0x21599e6 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:347
    #9 0x21599e6 in ASN1_item_ex_d2i crypto/asn1/tasn_dec.c:114
    #10 0x21599e6 in ASN1_item_d2i crypto/asn1/tasn_dec.c:104
```

For master and 1.1.0 branch.