### PR TITLE
Fix a possible crash in dsa_builtin_paramgen2

### DIFF
--- a/crypto/bn/bn_x931p.c
+++ b/crypto/bn/bn_x931p.c
@@ -178,6 +178,8 @@ int BN_X931_generate_Xpq(BIGNUM *Xp, BIGNUM *Xq, int nbits, BN_CTX *ctx)
 
     BN_CTX_start(ctx);
     t = BN_CTX_get(ctx);
+    if (t == NULL)
+        goto err;
 
     for (i = 0; i < 1000; i++) {
         if (!BN_rand(Xq, nbits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ANY))
@@ -216,10 +218,12 @@ int BN_X931_generate_prime_ex(BIGNUM *p, BIGNUM *p1, BIGNUM *p2,
     int ret = 0;
 
     BN_CTX_start(ctx);
-    if (!Xp1)
+    if (Xp1 == NULL)
         Xp1 = BN_CTX_get(ctx);
-    if (!Xp2)
+    if (Xp2 == NULL)
         Xp2 = BN_CTX_get(ctx);
+    if (Xp1 == NULL || Xp2 == NULL)
+        goto error;
 
     if (!BN_rand(Xp1, 101, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY))
         goto error;

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -376,6 +376,8 @@ int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
     } else {
         p = BN_CTX_get(ctx);
         q = BN_CTX_get(ctx);
+        if (q == NULL)
+            goto err;
     }
 
     if (!BN_lshift(test, BN_value_one(), L - 1))

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -608,6 +608,8 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
     r1 = BN_CTX_get(ctx);
     m1 = BN_CTX_get(ctx);
     vrfy = BN_CTX_get(ctx);
+    if (vrfy == NULL)
+        goto err;
 
     {
         BIGNUM *p = BN_new(), *q = BN_new();

--- a/crypto/rsa/rsa_x931g.c
+++ b/crypto/rsa/rsa_x931g.c
@@ -153,6 +153,8 @@ int RSA_X931_generate_key_ex(RSA *rsa, int bits, const BIGNUM *e,
     BN_CTX_start(ctx);
     Xp = BN_CTX_get(ctx);
     Xq = BN_CTX_get(ctx);
+    if (Xq == NULL)
+        goto error;
     if (!BN_X931_generate_Xpq(Xp, Xq, bits, ctx))
         goto error;
 


### PR DESCRIPTION
This is found by code review.

Another example where BN_CTX_get error handling is not quite correct.