### PR TITLE
Improve BN_CTX documentation

### DIFF
--- a/doc/man3/BN_CTX_new.pod
+++ b/doc/man3/BN_CTX_new.pod
@@ -26,12 +26,14 @@ BN_CTX_secure_new() allocates and initializes a B<BN_CTX> structure
 but uses the secure heap (see L<CRYPTO_secure_malloc(3)>) to hold the
 B<BIGNUM>s.
 
-BN_CTX_free() frees the components of the B<BN_CTX>, and if it was
-created by BN_CTX_new(), also the structure itself.
-If L<BN_CTX_start(3)> has been used on the B<BN_CTX>,
-L<BN_CTX_end(3)> must be called before the B<BN_CTX>
-may be freed by BN_CTX_free().
-If B<c> is NULL, nothing is done.
+BN_CTX_free() frees the components of the B<BN_CTX> and the structure itself.
+Since BN_CTX_start() is required in order to obtain B<BIGNUM>s from the
+B<BN_CTX>, in most cases BN_CTX_end() must be called before the B<BN_CTX> may
+be freed by BN_CTX_free().  If B<c> is NULL, nothing is done.
+
+A given B<BN_CTX> must only be used by a single thread of execution.  No
+locking is performed, and the internal pool allocator will not properly handle
+multiple threads of execution.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
Since BN_CTX_init() is gone, all calls use BN_CTX_new().  Also,
essentially all consumers will use BN_CTX_start()/BN_CTX_end(),
so make that more clear from the BN_CTX_new() man page.

Document the thread-unsafety of individual BN_CTX objects.
