### PR TITLE
Fix chacha-armv4.pl with clang -fno-integrated-as.

### DIFF
--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -172,8 +172,10 @@ $code.=<<___;
 #include "arm_arch.h"
 
 .text
-#if defined(__thumb2__)
+#if defined(__thumb2__) || defined(__clang__)
 .syntax	unified
+#endif
+#if defined(__thumb2__)
 .thumb
 #else
 .code	32


### PR DESCRIPTION
@dot-asm, does this look right? I'm not fully up to speed with all the details around ARM assembly syntax variants and am piecing things together as I go.

---

The `__clang__`-guarded `#define`s cause `gas` to complain if `clang` is passed
`-fno-integrated-as`. Emitting `.syntax unified` when those are used fixes
this. This matches the change made to ghash-armv4.pl in
6cf412c473d8145562b76219ce3da73b201b3255.