### PR TITLE
Add the target 'build_all_generated'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Add a build target 'build_all_generated', to build all generated files
+     and only that.  This can be used to prepare everything that requires
+     things like perl for a system that lacks perl and then move everything
+     to that system and do the rest of the build there.
+     [Richard Levitte]
+
   *) In the UI interface, make it possible to duplicate the user data.  This
      can be used by engines that need to retain the data for a longer time
      than just the call where this user data is passed.

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -269,6 +269,10 @@ build_programs_nodep : $(PROGRAMS), $(SCRIPTS)
 # Kept around for backward compatibility
 build_apps build_tests : build_programs
 
+# Convenience target to prebuild all generated files, not just the mandatory
+# ones
+build_all_generated : $(GENERATED_MANDATORY) $(GENERATED)
+
 test : tests
 {- dependmagic('tests'); -} : build_programs_nodep, build_engines_nodep
         @ ! {- output_off() if $disabled{tests}; "" -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -251,6 +251,10 @@ build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
 # Kept around for backward compatibility
 build_apps build_tests: build_programs
 
+# Convenience target to prebuild all generated files, not just the mandatory
+# ones
+build_all_generated: $(GENERATED_MANDATORY) $(GENERATED)
+
 test: tests
 {- dependmagic('tests'); -}: build_programs_nodep build_engines_nodep link-utils
 	@ : {- output_off() if $disabled{tests}; "" -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -206,6 +206,10 @@ build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
 # Kept around for backward compatibility
 build_apps build_tests: build_programs
 
+# Convenience target to prebuild all generated files, not just the mandatory
+# ones
+build_all_generated: $(GENERATED_MANDATORY) $(GENERATED)
+
 test: tests
 {- dependmagic('tests'); -}: build_programs_nodep build_engines_nodep
 	@rem {- output_off() if $disabled{tests}; "" -}


### PR DESCRIPTION
This new target is used to build all generated files and only that.
This can be used to prepare everything that requires things like perl
for a system that lacks perl and then move everything to that system
and do the rest of the build there.
