### PR TITLE
Forbid to specify -nextprotoneg if -tls1_3 is enabled

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1424,6 +1424,12 @@ int s_client_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+#ifndef OPENSSL_NO_NEXTPROTONEG
+    if (min_version == TLS1_3_VERSION && next_proto_neg_in != NULL) {
+        BIO_printf(bio_err, "Cannot supply -nextprotoneg with TLSv1.3\n");
+        goto opthelp;
+    }
+#endif
     if (proxystr != NULL) {
         int res;
         char *tmp_host = host, *tmp_port = port;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1536,6 +1536,12 @@ int s_server_main(int argc, char *argv[])
     argc = opt_num_rest();
     argv = opt_rest();
 
+#ifndef OPENSSL_NO_NEXTPROTONEG
+    if (min_version == TLS1_3_VERSION && next_proto_neg_in != NULL) {
+        BIO_printf(bio_err, "Cannot supply -nextprotoneg with TLSv1.3\n");
+        goto opthelp;
+    }
+#endif
 #ifndef OPENSSL_NO_DTLS
     if (www && socket_type == SOCK_DGRAM) {
         BIO_printf(bio_err, "Can't use -HTTP, -www or -WWW with DTLS\n");

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -564,6 +564,7 @@ for example "http/1.1" or "spdy/3".
 An empty list of protocols is treated specially and will cause the
 client to advertise support for the TLS extension but disconnect just
 after receiving ServerHello with a list of server supported protocols.
+The flag B<-nextprotoneg> cannot be specified if B<-tls1_3> is used.
 
 =item B<-ct|noct>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -609,6 +609,7 @@ The B<val> list is a comma-separated list of supported protocol
 names.  The list should contain the most desirable protocols first.
 Protocol names are printable ASCII strings, for example "http/1.1" or
 "spdy/3".
+The flag B<-nextprotoneg> cannot be specified if B<-tls1_3> is used.
 
 =item B<-engine val>
 


### PR DESCRIPTION
This applies both to s_client and s_server app.

Reaction to Issue #3665.

Seems it's unnecessary to describe this in `s_client` and `s_server`'s -help output.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
