### PR TITLE
Undo commit d420ac2

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -312,9 +312,9 @@ int enc_main(int argc, char **argv)
             for (;;) {
                 char prompt[200];
 
-                BIO_snprintf(prompt, sizeof prompt, "enter %s %s password:",
-                             OBJ_nid2ln(EVP_CIPHER_nid(cipher)),
-                             (enc) ? "encryption" : "decryption");
+                sprintf(prompt, "enter %s %s password:",
+                        OBJ_nid2ln(EVP_CIPHER_nid(cipher)),
+                        (enc) ? "encryption" : "decryption");
                 strbuf[0] = '\0';
                 i = EVP_read_pw_string((char *)strbuf, SIZE, prompt, enc);
                 if (i == 0) {

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -66,8 +66,8 @@ static int append_buf(char **buf, int *size, const char *s)
     }
 
     if (**buf != '\0')
-        OPENSSL_strlcat(*buf, ", ", *size);
-    OPENSSL_strlcat(*buf, s, *size);
+        strcat(*buf, ", ");
+    strcat(*buf, s);
 
     return 1;
 }

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -455,7 +455,7 @@ int pkcs12_main(int argc, char **argv)
         }
 
         if (!twopass)
-            OPENSSL_strlcpy(macpass, pass, sizeof macpass);
+            strcpy(macpass, pass);
 
         p12 = PKCS12_create(cpass, name, key, ucert, certs,
                             key_pbe, cert_pbe, iter, -1, keytype);

--- a/apps/req.c
+++ b/apps/req.c
@@ -984,30 +984,30 @@ static int prompt_info(X509_REQ *req,
             /* If OBJ not recognised ignore it */
             if ((nid = OBJ_txt2nid(type)) == NID_undef)
                 goto start;
-            if (BIO_snprintf(buf, sizeof buf, "%s_default", v->name)
-                >= (int)sizeof(buf)) {
+            if (strlen(v->name) + sizeof("_default") > sizeof(buf)) {
                 BIO_printf(bio_err, "Name '%s' too long\n", v->name);
                 return 0;
             }
+            sprintf(buf, "%s_default", v->name);
 
             if ((def = NCONF_get_string(req_conf, dn_sect, buf)) == NULL) {
                 ERR_clear_error();
                 def = "";
             }
 
-            BIO_snprintf(buf, sizeof buf, "%s_value", v->name);
+            sprintf(buf, "%s_value", v->name);
             if ((value = NCONF_get_string(req_conf, dn_sect, buf)) == NULL) {
                 ERR_clear_error();
                 value = NULL;
             }
 
-            BIO_snprintf(buf, sizeof buf, "%s_min", v->name);
+            sprintf(buf, "%s_min", v->name);
             if (!NCONF_get_number(req_conf, dn_sect, buf, &n_min)) {
                 ERR_clear_error();
                 n_min = -1;
             }
 
-            BIO_snprintf(buf, sizeof buf, "%s_max", v->name);
+            sprintf(buf, "%s_max", v->name);
             if (!NCONF_get_number(req_conf, dn_sect, buf, &n_max)) {
                 ERR_clear_error();
                 n_max = -1;
@@ -1044,11 +1044,11 @@ static int prompt_info(X509_REQ *req,
                 if ((nid = OBJ_txt2nid(type)) == NID_undef)
                     goto start2;
 
-                if (BIO_snprintf(buf, sizeof buf, "%s_default", type)
-                    >= (int)sizeof(buf)) {
+                if (strlen(type) + sizeof("_default") > sizeof(buf)) {
                     BIO_printf(bio_err, "Name '%s' too long\n", v->name);
                     return 0;
                 }
+                sprintf(buf, "%s_default", type);
 
                 if ((def = NCONF_get_string(req_conf, attr_sect, buf))
                     == NULL) {
@@ -1056,20 +1056,20 @@ static int prompt_info(X509_REQ *req,
                     def = "";
                 }
 
-                BIO_snprintf(buf, sizeof buf, "%s_value", type);
+                sprintf(buf, "%s_value", type);
                 if ((value = NCONF_get_string(req_conf, attr_sect, buf))
                     == NULL) {
                     ERR_clear_error();
                     value = NULL;
                 }
 
-                BIO_snprintf(buf, sizeof buf, "%s_min", type);
+                sprintf(buf, "%s_min", type);
                 if (!NCONF_get_number(req_conf, attr_sect, buf, &n_min)) {
                     ERR_clear_error();
                     n_min = -1;
                 }
 
-                BIO_snprintf(buf, sizeof buf, "%s_max", type);
+                sprintf(buf, "%s_max", type);
                 if (!NCONF_get_number(req_conf, attr_sect, buf, &n_max)) {
                     ERR_clear_error();
                     n_max = -1;
@@ -1168,8 +1168,8 @@ static int add_DN_object(X509_NAME *n, char *text, const char *def,
         BIO_printf(bio_err, "%s [%s]:", text, def);
     (void)BIO_flush(bio_err);
     if (value != NULL) {
-        OPENSSL_strlcpy(buf, value, sizeof buf);
-        OPENSSL_strlcat(buf, "\n", sizeof buf);
+        strcpy(buf, value);
+        strcat(buf, "\n");
         BIO_printf(bio_err, "%s\n", value);
     } else {
         buf[0] = '\0';
@@ -1187,8 +1187,8 @@ static int add_DN_object(X509_NAME *n, char *text, const char *def,
     if (buf[0] == '\n') {
         if ((def == NULL) || (def[0] == '\0'))
             return 1;
-        OPENSSL_strlcpy(buf, def, sizeof buf);
-        OPENSSL_strlcat(buf, "\n", sizeof buf);
+        strcpy(buf, def);
+        strcat(buf, "\n");
     } else if ((buf[0] == '.') && (buf[1] == '\n')) {
         return 1;
     }
@@ -1228,8 +1228,8 @@ static int add_attribute_object(X509_REQ *req, char *text, const char *def,
         BIO_printf(bio_err, "%s [%s]:", text, def);
     (void)BIO_flush(bio_err);
     if (value != NULL) {
-        OPENSSL_strlcpy(buf, value, sizeof buf);
-        OPENSSL_strlcat(buf, "\n", sizeof buf);
+        strcpy(buf, value);
+        strcat(buf, "\n");
         BIO_printf(bio_err, "%s\n", value);
     } else {
         buf[0] = '\0';
@@ -1247,8 +1247,8 @@ static int add_attribute_object(X509_REQ *req, char *text, const char *def,
     if (buf[0] == '\n') {
         if ((def == NULL) || (def[0] == '\0'))
             return 1;
-        OPENSSL_strlcpy(buf, def, sizeof buf);
-        OPENSSL_strlcat(buf, "\n", sizeof buf);
+        strcpy(buf, def);
+        strcat(buf, "\n");
     } else if ((buf[0] == '.') && (buf[1] == '\n')) {
         return 1;
     }

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -173,7 +173,7 @@ int s_time_main(int argc, char **argv)
             break;
         case OPT_WWW:
             www_path = opt_arg();
-            buf_size = strlen(www_path) + sizeof(fmt_http_get_cmd) - 2;  /* 2 is for %s */
+            buf_size = strlen(www_path) + sizeof(fmt_http_get_cmd);
             if (buf_size > sizeof(buf)) {
                 BIO_printf(bio_err, "%s: -www option is too long\n", prog);
                 goto end;
@@ -230,8 +230,8 @@ int s_time_main(int argc, char **argv)
             goto end;
 
         if (www_path != NULL) {
-            buf_len = BIO_snprintf(buf, sizeof buf,
-                                   fmt_http_get_cmd, www_path);
+            sprintf(buf, fmt_http_get_cmd, www_path);
+            buf_len = strlen(buf);
             if (SSL_write(scon, buf, buf_len) <= 0)
                 goto end;
             while ((i = SSL_read(scon, buf, sizeof(buf))) > 0)
@@ -288,8 +288,8 @@ int s_time_main(int argc, char **argv)
     }
 
     if (www_path != NULL) {
-        buf_len = BIO_snprintf(buf, sizeof buf,
-                               fmt_http_get_cmd, www_path);
+        sprintf(buf, fmt_http_get_cmd, www_path);
+        buf_len = strlen(buf);
         if (SSL_write(scon, buf, buf_len) <= 0)
             goto end;
         while (SSL_read(scon, buf, sizeof(buf)) > 0)
@@ -319,8 +319,7 @@ int s_time_main(int argc, char **argv)
             goto end;
 
         if (www_path != NULL) {
-            BIO_snprintf(buf, sizeof buf, "GET %s HTTP/1.0\r\n\r\n",
-                         www_path);
+            sprintf(buf, "GET %s HTTP/1.0\r\n\r\n", www_path);
             if (SSL_write(scon, buf, strlen(buf)) <= 0)
                 goto end;
             while ((i = SSL_read(scon, buf, sizeof(buf))) > 0)

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -906,15 +906,15 @@ static ASN1_INTEGER *x509_load_serial(const char *CAfile, const char *serialfile
            : (strlen(serialfile))) + 1;
     buf = app_malloc(len, "serial# buffer");
     if (serialfile == NULL) {
-        OPENSSL_strlcpy(buf, CAfile, len);
+        strcpy(buf, CAfile);
         for (p = buf; *p; p++)
             if (*p == '.') {
                 *p = '\0';
                 break;
             }
-        OPENSSL_strlcat(buf, POSTFIX, len);
+        strcat(buf, POSTFIX);
     } else {
-        OPENSSL_strlcpy(buf, serialfile, len);
+        strcpy(buf, serialfile);
     }
 
     serial = load_serial(buf, create, NULL);

--- a/crypto/asn1/a_gentm.c
+++ b/crypto/asn1/a_gentm.c
@@ -237,9 +237,9 @@ ASN1_GENERALIZEDTIME *ASN1_GENERALIZEDTIME_adj(ASN1_GENERALIZEDTIME *s,
         tmps->data = (unsigned char *)p;
     }
 
-    BIO_snprintf(p, len, "%04d%02d%02d%02d%02d%02dZ", ts->tm_year + 1900,
-                 ts->tm_mon + 1, ts->tm_mday, ts->tm_hour, ts->tm_min,
-                 ts->tm_sec);
+    sprintf(p, "%04d%02d%02d%02d%02d%02dZ", ts->tm_year + 1900,
+            ts->tm_mon + 1, ts->tm_mday, ts->tm_hour, ts->tm_min,
+            ts->tm_sec);
     tmps->length = strlen(p);
     tmps->type = V_ASN1_GENERALIZEDTIME;
 #ifdef CHARSET_EBCDIC_not

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -100,14 +100,14 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
 
     if ((minsize > 0) && (nchar < minsize)) {
         ASN1err(ASN1_F_ASN1_MBSTRING_NCOPY, ASN1_R_STRING_TOO_SHORT);
-        BIO_snprintf(strbuf, sizeof strbuf, "%ld", minsize);
+        sprintf(strbuf, "%ld", minsize);
         ERR_add_error_data(2, "minsize=", strbuf);
         return -1;
     }
 
     if ((maxsize > 0) && (nchar > maxsize)) {
         ASN1err(ASN1_F_ASN1_MBSTRING_NCOPY, ASN1_R_STRING_TOO_LONG);
-        BIO_snprintf(strbuf, sizeof strbuf, "%ld", maxsize);
+        sprintf(strbuf, "%ld", maxsize);
         ERR_add_error_data(2, "maxsize=", strbuf);
         return -1;
     }

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -64,7 +64,6 @@ ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(const ASN1_TIME *t,
 {
     ASN1_GENERALIZEDTIME *ret = NULL;
     char *str;
-    int newlen;
 
     if (!ASN1_TIME_check(t))
         return NULL;
@@ -85,16 +84,14 @@ ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(const ASN1_TIME *t,
     /* grow the string */
     if (!ASN1_STRING_set(ret, NULL, t->length + 2))
         goto err;
-    /* ASN1_STRING_set() allocated 'len + 1' bytes. */
-    newlen = t->length + 2 + 1;
     str = (char *)ret->data;
     /* Work out the century and prepend */
     if (t->data[0] >= '5')
-        OPENSSL_strlcpy(str, "19", newlen);
+        strcpy(str, "19");
     else
-        OPENSSL_strlcpy(str, "20", newlen);
+        strcpy(str, "20");
 
-    OPENSSL_strlcat(str, (const char *)t->data, newlen);
+    strcat(str, (const char *)t->data);
 
  done:
    if (out != NULL && *out == NULL)

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -199,9 +199,9 @@ ASN1_UTCTIME *ASN1_UTCTIME_adj(ASN1_UTCTIME *s, time_t t,
         s->data = (unsigned char *)p;
     }
 
-    BIO_snprintf(p, len, "%02d%02d%02d%02d%02d%02dZ", ts->tm_year % 100,
-                 ts->tm_mon + 1, ts->tm_mday, ts->tm_hour, ts->tm_min,
-                 ts->tm_sec);
+    sprintf(p, "%02d%02d%02d%02d%02d%02dZ", ts->tm_year % 100,
+            ts->tm_mon + 1, ts->tm_mday, ts->tm_hour, ts->tm_min,
+            ts->tm_sec);
     s->length = strlen(p);
     s->type = V_ASN1_UTCTIME;
 #ifdef CHARSET_EBCDIC_not

--- a/crypto/asn1/asn1_par.c
+++ b/crypto/asn1/asn1_par.c
@@ -38,13 +38,13 @@ static int asn1_print_info(BIO *bp, int tag, int xclass, int constructed,
 
     p = str;
     if ((xclass & V_ASN1_PRIVATE) == V_ASN1_PRIVATE)
-        BIO_snprintf(str, sizeof str, "priv [ %d ] ", tag);
+        sprintf(str, "priv [ %d ] ", tag);
     else if ((xclass & V_ASN1_CONTEXT_SPECIFIC) == V_ASN1_CONTEXT_SPECIFIC)
-        BIO_snprintf(str, sizeof str, "cont [ %d ]", tag);
+        sprintf(str, "cont [ %d ]", tag);
     else if ((xclass & V_ASN1_APPLICATION) == V_ASN1_APPLICATION)
-        BIO_snprintf(str, sizeof str, "appl [ %d ]", tag);
+        sprintf(str, "appl [ %d ]", tag);
     else if (tag > 30)
-        BIO_snprintf(str, sizeof str, "<ASN1 %d>", tag);
+        sprintf(str, "<ASN1 %d>", tag);
     else
         p = ASN1_tag2str(tag);
 

--- a/crypto/asn1/x_long.c
+++ b/crypto/asn1/x_long.c
@@ -89,12 +89,8 @@ static int long_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
     long ltmp;
     unsigned long utmp, sign;
     int clen, pad, i;
-    /* this exists to bypass broken gcc optimization */
-    char *cp = (char *)pval;
 
-    /* use memcpy, because we may not be long aligned */
-    memcpy(&ltmp, cp, sizeof(long));
-
+    ltmp = *(long *)pval;
     if (ltmp == it->size)
         return -1;
     /*
@@ -136,7 +132,6 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     int i;
     long ltmp;
     unsigned long utmp = 0, sign = 0x100;
-    char *cp = (char *)pval;
 
     if (len > 1) {
         /*
@@ -188,7 +183,7 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
         ASN1err(ASN1_F_LONG_C2I, ASN1_R_INTEGER_TOO_LARGE_FOR_LONG);
         return 0;
     }
-    memcpy(cp, &ltmp, sizeof(long));
+    *(long*)pval = ltmp;
     return 1;
 }
 

--- a/crypto/bio/b_dump.c
+++ b/crypto/bio/b_dump.c
@@ -54,36 +54,34 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
     if ((rows * dump_width) < len)
         rows++;
     for (i = 0; i < rows; i++) {
-        OPENSSL_strlcpy(buf, str, sizeof buf);
-        BIO_snprintf(tmp, sizeof tmp, "%04x - ", i * dump_width);
-        OPENSSL_strlcat(buf, tmp, sizeof buf);
+        strcpy(buf, str);
+        sprintf(tmp, "%04x - ", i * dump_width);
+        strcat(buf, tmp);
         for (j = 0; j < dump_width; j++) {
             if (((i * dump_width) + j) >= len) {
-                OPENSSL_strlcat(buf, "   ", sizeof buf);
+                strcat(buf, "   ");
             } else {
                 ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
-                BIO_snprintf(tmp, sizeof tmp, "%02x%c", ch,
-                             j == 7 ? '-' : ' ');
-                OPENSSL_strlcat(buf, tmp, sizeof buf);
+                sprintf(tmp, "%02x%c", ch, j == 7 ? '-' : ' ');
+                strcat(buf, tmp);
             }
         }
-        OPENSSL_strlcat(buf, "  ", sizeof buf);
+        strcat(buf, "  ");
         for (j = 0; j < dump_width; j++) {
             if (((i * dump_width) + j) >= len)
                 break;
             ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
 #ifndef CHARSET_EBCDIC
-            BIO_snprintf(tmp, sizeof tmp, "%c",
-                         ((ch >= ' ') && (ch <= '~')) ? ch : '.');
+            sprintf(tmp, "%c", ((ch >= ' ') && (ch <= '~')) ? ch : '.');
 #else
-            BIO_snprintf(tmp, sizeof tmp, "%c",
+            sprintf(tmp, "%c",
                          ((ch >= os_toascii[' ']) && (ch <= os_toascii['~']))
                          ? os_toebcdic[ch]
                          : '.');
 #endif
-            OPENSSL_strlcat(buf, tmp, sizeof buf);
+            strcat(buf, tmp);
         }
-        OPENSSL_strlcat(buf, "\n", sizeof buf);
+        strcat(buf, "\n");
         /*
          * if this is the last call then update the ddt_dump thing so that we
          * will move the selection point in the debug window
@@ -92,8 +90,7 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
     }
 #ifdef TRUNCATE
     if (trc > 0) {
-        BIO_snprintf(buf, sizeof buf, "%s%04x - <SPACES/NULS>\n", str,
-                     len + trc);
+        sprintf(buf, "%s%04x - <SPACES/NULS>\n", str, len + trc);
         ret += cb((void *)buf, strlen(buf), u);
     }
 #endif

--- a/crypto/bio/bio_cb.c
+++ b/crypto/bio/bio_cb.c
@@ -22,69 +22,67 @@ long BIO_debug_callback(BIO *bio, int cmd, const char *argp,
     char *p;
     long r = 1;
     int len;
-    size_t p_maxlen;
 
     if (BIO_CB_RETURN & cmd)
         r = ret;
 
-    len = BIO_snprintf(buf, sizeof buf, "BIO[%p]: ", (void *)bio);
+    len = sprintf(buf, "BIO[%p]: ", (void *)bio);
 
     /* Ignore errors and continue printing the other information. */
     if (len < 0)
         len = 0;
     p = buf + len;
-    p_maxlen = sizeof(buf) - len;
 
     switch (cmd) {
     case BIO_CB_FREE:
-        BIO_snprintf(p, p_maxlen, "Free - %s\n", bio->method->name);
+        sprintf(p, "Free - %s\n", bio->method->name);
         break;
     case BIO_CB_READ:
         if (bio->method->type & BIO_TYPE_DESCRIPTOR)
-            BIO_snprintf(p, p_maxlen, "read(%d,%lu) - %s fd=%d\n",
-                         bio->num, (unsigned long)argi,
-                         bio->method->name, bio->num);
+            sprintf(p, "read(%d,%lu) - %s fd=%d\n",
+                    bio->num, (unsigned long)argi,
+                    bio->method->name, bio->num);
         else
-            BIO_snprintf(p, p_maxlen, "read(%d,%lu) - %s\n",
-                         bio->num, (unsigned long)argi, bio->method->name);
+            sprintf(p, "read(%d,%lu) - %s\n",
+                    bio->num, (unsigned long)argi, bio->method->name);
         break;
     case BIO_CB_WRITE:
         if (bio->method->type & BIO_TYPE_DESCRIPTOR)
-            BIO_snprintf(p, p_maxlen, "write(%d,%lu) - %s fd=%d\n",
-                         bio->num, (unsigned long)argi,
-                         bio->method->name, bio->num);
+            sprintf(p, "write(%d,%lu) - %s fd=%d\n",
+                    bio->num, (unsigned long)argi,
+                    bio->method->name, bio->num);
         else
-            BIO_snprintf(p, p_maxlen, "write(%d,%lu) - %s\n",
-                         bio->num, (unsigned long)argi, bio->method->name);
+            sprintf(p, "write(%d,%lu) - %s\n",
+                    bio->num, (unsigned long)argi, bio->method->name);
         break;
     case BIO_CB_PUTS:
-        BIO_snprintf(p, p_maxlen, "puts() - %s\n", bio->method->name);
+        sprintf(p, "puts() - %s\n", bio->method->name);
         break;
     case BIO_CB_GETS:
-        BIO_snprintf(p, p_maxlen, "gets(%lu) - %s\n", (unsigned long)argi,
-                     bio->method->name);
+        sprintf(p, "gets(%lu) - %s\n", (unsigned long)argi,
+                bio->method->name);
         break;
     case BIO_CB_CTRL:
-        BIO_snprintf(p, p_maxlen, "ctrl(%lu) - %s\n", (unsigned long)argi,
-                     bio->method->name);
+        sprintf(p, "ctrl(%lu) - %s\n", (unsigned long)argi,
+                bio->method->name);
         break;
     case BIO_CB_RETURN | BIO_CB_READ:
-        BIO_snprintf(p, p_maxlen, "read return %ld\n", ret);
+        sprintf(p, "read return %ld\n", ret);
         break;
     case BIO_CB_RETURN | BIO_CB_WRITE:
-        BIO_snprintf(p, p_maxlen, "write return %ld\n", ret);
+        sprintf(p, "write return %ld\n", ret);
         break;
     case BIO_CB_RETURN | BIO_CB_GETS:
-        BIO_snprintf(p, p_maxlen, "gets return %ld\n", ret);
+        sprintf(p, "gets return %ld\n", ret);
         break;
     case BIO_CB_RETURN | BIO_CB_PUTS:
-        BIO_snprintf(p, p_maxlen, "puts return %ld\n", ret);
+        sprintf(p, "puts return %ld\n", ret);
         break;
     case BIO_CB_RETURN | BIO_CB_CTRL:
-        BIO_snprintf(p, p_maxlen, "ctrl return %ld\n", ret);
+        sprintf(p, "ctrl return %ld\n", ret);
         break;
     default:
-        BIO_snprintf(p, p_maxlen, "bio callback - unknown type (%d)\n", cmd);
+        sprintf(p, "bio callback - unknown type (%d)\n", cmd);
         break;
     }
 

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -271,15 +271,15 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         b->shutdown = (int)num & BIO_CLOSE;
         if (num & BIO_FP_APPEND) {
             if (num & BIO_FP_READ)
-                OPENSSL_strlcpy(p, "a+", sizeof p);
+                strcpy(p, "a+");
             else
-                OPENSSL_strlcpy(p, "a", sizeof p);
+                strcpy(p, "a");
         } else if ((num & BIO_FP_READ) && (num & BIO_FP_WRITE))
-            OPENSSL_strlcpy(p, "r+", sizeof p);
+            strcpy(p, "r+");
         else if (num & BIO_FP_WRITE)
-            OPENSSL_strlcpy(p, "w", sizeof p);
+            strcpy(p, "w");
         else if (num & BIO_FP_READ)
-            OPENSSL_strlcpy(p, "r", sizeof p);
+            strcpy(p, "r");
         else {
             BIOerr(BIO_F_FILE_CTRL, BIO_R_BAD_FOPEN_MODE);
             ret = 0;

--- a/crypto/bn/bn_print.c
+++ b/crypto/bn/bn_print.c
@@ -77,7 +77,6 @@ char *BN_bn2dec(const BIGNUM *a)
     if ((t = BN_dup(a)) == NULL)
         goto err;
 
-#define BUF_REMAIN (num+3 - (size_t)(p - buf))
     p = buf;
     lp = bn_data;
     if (BN_is_zero(t)) {
@@ -101,12 +100,12 @@ char *BN_bn2dec(const BIGNUM *a)
          * the last one needs truncation. The blocks need to be reversed in
          * order.
          */
-        BIO_snprintf(p, BUF_REMAIN, BN_DEC_FMT1, *lp);
+        sprintf(p, BN_DEC_FMT1, *lp);
         while (*p)
             p++;
         while (lp != bn_data) {
             lp--;
-            BIO_snprintf(p, BUF_REMAIN, BN_DEC_FMT2, *lp);
+            sprintf(p, BN_DEC_FMT2, *lp);
             while (*p)
                 p++;
         }
@@ -332,11 +331,11 @@ char *BN_options(void)
     if (!init) {
         init++;
 #ifdef BN_LLONG
-        BIO_snprintf(data, sizeof data, "bn(%d,%d)",
-                     (int)sizeof(BN_ULLONG) * 8, (int)sizeof(BN_ULONG) * 8);
+        sprintf(data, "bn(%d,%d)",
+                (int)sizeof(BN_ULLONG) * 8, (int)sizeof(BN_ULONG) * 8);
 #else
-        BIO_snprintf(data, sizeof data, "bn(%d,%d)",
-                     (int)sizeof(BN_ULONG) * 8, (int)sizeof(BN_ULONG) * 8);
+        sprintf(data, "bn(%d,%d)",
+                (int)sizeof(BN_ULONG) * 8, (int)sizeof(BN_ULONG) * 8);
 #endif
     }
     return (data);

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -323,7 +323,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 CONFerr(CONF_F_DEF_LOAD_BIO, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
-            OPENSSL_strlcpy(v->name, pname, strlen(pname) + 1);
+            strcpy(v->name, pname);
             if (!str_copy(conf, psection, &(v->value), start))
                 goto err;
 
@@ -353,7 +353,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
     OPENSSL_free(section);
     if (line != NULL)
         *line = eline;
-    BIO_snprintf(btmp, sizeof btmp, "%ld", eline);
+    sprintf(btmp, "%ld", eline);
     ERR_add_error_data(2, "line ", btmp);
     if (h != conf->data) {
         CONF_free(conf->data);

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -171,7 +171,7 @@ static int module_run(const CONF *cnf, const char *name, const char *value,
         if (!(flags & CONF_MFLAGS_SILENT)) {
             char rcode[DECIMAL_SIZE(ret) + 1];
             CONFerr(CONF_F_MODULE_RUN, CONF_R_MODULE_INITIALIZATION_ERROR);
-            BIO_snprintf(rcode, sizeof rcode, "%-8d", ret);
+            sprintf(rcode, "%-8d", ret);
             ERR_add_error_data(6, "module=", name, ", value=", value,
                                ", retcode=", rcode);
         }
@@ -492,11 +492,11 @@ char *CONF_get1_default_config_file(void)
 
     if (file == NULL)
         return NULL;
-    OPENSSL_strlcpy(file, X509_get_default_cert_area(), len + 1);
+    strcpy(file, X509_get_default_cert_area());
 #ifndef OPENSSL_SYS_VMS
-    OPENSSL_strlcat(file, "/", len + 1);
+    strcat(file, "/");
 #endif
-    OPENSSL_strlcat(file, OPENSSL_CONF, len + 1);
+    strcat(file, OPENSSL_CONF);
 
     return file;
 }

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -9,9 +9,7 @@
 
 #include "internal/cryptlib.h"
 
-#ifndef NO_WINDOWS_BRAINDEATH
-# include "buildinf.h"
-#endif
+#include "buildinf.h"
 
 unsigned long OpenSSL_version_num(void)
 {

--- a/crypto/des/ecb_enc.c
+++ b/crypto/des/ecb_enc.c
@@ -24,7 +24,7 @@ const char *DES_options(void)
             size = "int";
         else
             size = "long";
-        BIO_snprintf(buf, sizeof buf, "des(%s)", size);
+        sprintf(buf, "des(%s)", size);
         init = 0;
     }
     return (buf);

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -109,19 +109,15 @@ static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
     case ENGINE_CTRL_GET_NAME_LEN_FROM_CMD:
         return strlen(e->cmd_defns[idx].cmd_name);
     case ENGINE_CTRL_GET_NAME_FROM_CMD:
-        return BIO_snprintf(s, strlen(e->cmd_defns[idx].cmd_name) + 1,
-                            "%s", e->cmd_defns[idx].cmd_name);
+        return sprintf(s, "%s", e->cmd_defns[idx].cmd_name);
     case ENGINE_CTRL_GET_DESC_LEN_FROM_CMD:
         if (e->cmd_defns[idx].cmd_desc)
             return strlen(e->cmd_defns[idx].cmd_desc);
         return strlen(int_no_description);
     case ENGINE_CTRL_GET_DESC_FROM_CMD:
         if (e->cmd_defns[idx].cmd_desc)
-            return BIO_snprintf(s,
-                                strlen(e->cmd_defns[idx].cmd_desc) + 1,
-                                "%s", e->cmd_defns[idx].cmd_desc);
-        return BIO_snprintf(s, strlen(int_no_description) + 1, "%s",
-                            int_no_description);
+            return sprintf(s, "%s", e->cmd_defns[idx].cmd_desc);
+        return sprintf(s, "%s", int_no_description);
     case ENGINE_CTRL_GET_CMD_FLAGS:
         return e->cmd_defns[idx].cmd_flags;
     }

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -90,7 +90,7 @@ int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
         char obj_tmp[80];
         EVPerr(EVP_F_EVP_PBE_CIPHERINIT, EVP_R_UNKNOWN_PBE_ALGORITHM);
         if (!pbe_obj)
-            OPENSSL_strlcpy(obj_tmp, "NULL", sizeof obj_tmp);
+            strcpy(obj_tmp, "NULL");
         else
             i2t_ASN1_OBJECT(obj_tmp, sizeof obj_tmp, pbe_obj);
         ERR_add_error_data(2, "TYPE=", obj_tmp);

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -467,24 +467,19 @@ static void print_leak(const MEM *m, MEM_LEAK *l)
     } tid;
     CRYPTO_THREAD_ID ti;
 
-#define BUF_REMAIN (sizeof buf - (size_t)(bufp - buf))
-
     lcl = localtime(&m->time);
-    BIO_snprintf(bufp, BUF_REMAIN, "[%02d:%02d:%02d] ",
-                 lcl->tm_hour, lcl->tm_min, lcl->tm_sec);
+    sprintf(bufp, "[%02d:%02d:%02d] ", lcl->tm_hour, lcl->tm_min, lcl->tm_sec);
     bufp += strlen(bufp);
 
-    BIO_snprintf(bufp, BUF_REMAIN, "%5lu file=%s, line=%d, ",
-                 m->order, m->file, m->line);
+    sprintf(bufp, "%5lu file=%s, line=%d, ", m->order, m->file, m->line);
     bufp += strlen(bufp);
 
     tid.ltid = 0;
     tid.tid = m->threadid;
-    BIO_snprintf(bufp, BUF_REMAIN, "thread=%lu, ", tid.ltid);
+    sprintf(bufp, "thread=%lu, ", tid.ltid);
     bufp += strlen(bufp);
 
-    BIO_snprintf(bufp, BUF_REMAIN, "number=%d, address=%p\n",
-                 m->num, m->addr);
+    sprintf(bufp, "number=%d, address=%p\n", m->num, m->addr);
     bufp += strlen(bufp);
 
     l->print_cb(buf, strlen(buf), l->print_cb_arg);
@@ -506,20 +501,18 @@ static void print_leak(const MEM *m, MEM_LEAK *l)
             memset(buf, '>', ami_cnt);
             tid.ltid = 0;
             tid.tid = amip->threadid;
-            BIO_snprintf(buf + ami_cnt, sizeof buf - ami_cnt,
-                         " thread=%lu, file=%s, line=%d, info=\"",
-                         tid.ltid, amip->file,
-                         amip->line);
+            sprintf(buf + ami_cnt, " thread=%lu, file=%s, line=%d, info=\"",
+                    tid.ltid, amip->file, amip->line);
             buf_len = strlen(buf);
             info_len = strlen(amip->info);
             if (128 - buf_len - 3 < info_len) {
                 memcpy(buf + buf_len, amip->info, 128 - buf_len - 3);
                 buf_len = 128 - 3;
             } else {
-                OPENSSL_strlcpy(buf + buf_len, amip->info, sizeof buf - buf_len);
+                strcpy(buf + buf_len, amip->info);
                 buf_len = strlen(buf);
             }
-            BIO_snprintf(buf + buf_len, sizeof buf - buf_len, "\"\n");
+            sprintf(buf + buf_len, "\"\n");
 
             l->print_cb(buf, strlen(buf), l->print_cb_arg);
 

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -500,7 +500,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             n += i;
             OPENSSL_free(bndec);
         } else {
-            BIO_snprintf(tbuf, sizeof tbuf, ".%lu", l);
+            sprintf(tbuf, ".%lu", l);
             i = strlen(tbuf);
             if (buf && (buf_len > 0)) {
                 OPENSSL_strlcpy(buf, tbuf, buf_len);

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -90,9 +90,9 @@ void PEM_proc_type(char *buf, int type)
     else
         str = "BAD-TYPE";
 
-    OPENSSL_strlcat(buf, "Proc-Type: 4,", PEM_BUFSIZE);
-    OPENSSL_strlcat(buf, str, PEM_BUFSIZE);
-    OPENSSL_strlcat(buf, "\n", PEM_BUFSIZE);
+    strcat(buf, "Proc-Type: 4,");
+    strcat(buf, str);
+    strcat(buf, "\n");
 }
 
 void PEM_dek_info(char *buf, const char *type, int len, char *str)
@@ -101,12 +101,10 @@ void PEM_dek_info(char *buf, const char *type, int len, char *str)
     long i;
     int j;
 
-    OPENSSL_strlcat(buf, "DEK-Info: ", PEM_BUFSIZE);
-    OPENSSL_strlcat(buf, type, PEM_BUFSIZE);
-    OPENSSL_strlcat(buf, ",", PEM_BUFSIZE);
+    strcat(buf, "DEK-Info: ");
+    strcat(buf, type);
+    strcat(buf, ",");
     j = strlen(buf);
-    if (j + (len * 2) + 1 > PEM_BUFSIZE)
-        return;
     for (i = 0; i < len; i++) {
         buf[j + i * 2] = map[(str[i] >> 4) & 0x0f];
         buf[j + i * 2 + 1] = map[(str[i]) & 0x0f];

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -102,7 +102,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
     addr.sun_family = AF_UNIX;
     if (strlen(path) >= sizeof(addr.sun_path))
         return (-1);
-    OPENSSL_strlcpy(addr.sun_path, path, sizeof addr.sun_path);
+    strcpy(addr.sun_path, path);
     len = offsetof(struct sockaddr_un, sun_path) + strlen(path);
     fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd == -1)

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -295,8 +295,8 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
                 BIO_snprintf(b->data, b->max,
                              "%s%08lx.%s%d", ent->dir, h, postfix, k);
             } else {
-                BIO_snprintf(b->data, b->max,
-                             "%s%c%08lx.%s%d", ent->dir, c, h, postfix, k);
+                sprintf(b->data,
+                        "%s%c%08lx.%s%d", ent->dir, c, h, postfix, k);
             }
 #ifndef OPENSSL_NO_POSIX_IO
 # ifdef _WIN32

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -108,12 +108,11 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
     case GEN_IPADD:
         p = gen->d.ip->data;
         if (gen->d.ip->length == 4)
-            BIO_snprintf(oline, sizeof oline,
-                         "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
+            sprintf(oline, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
         else if (gen->d.ip->length == 16) {
             oline[0] = 0;
             for (i = 0; i < 8; i++) {
-                BIO_snprintf(htmp, sizeof htmp, "%X", p[0] << 8 | p[1]);
+                sprintf(htmp, "%X", p[0] << 8 | p[1]);
                 p += 2;
                 strcat(oline, htmp);
                 if (i != 7)

--- a/crypto/x509v3/v3_info.c
+++ b/crypto/x509v3/v3_info.c
@@ -78,13 +78,13 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
         tret = tmp;
         vtmp = sk_CONF_VALUE_value(tret, i);
         i2t_ASN1_OBJECT(objtmp, sizeof objtmp, desc->method);
-        nlen = strlen(objtmp) + strlen(vtmp->name) + 5;
+        nlen = strlen(objtmp) + 3 + strlen(vtmp->name) + 1;
         ntmp = OPENSSL_malloc(nlen);
         if (ntmp == NULL)
             goto err;
-        OPENSSL_strlcpy(ntmp, objtmp, nlen);
-        OPENSSL_strlcat(ntmp, " - ", nlen);
-        OPENSSL_strlcat(ntmp, vtmp->name, nlen);
+        strcpy(ntmp, objtmp);
+        strcat(ntmp, " - ");
+        strcat(ntmp, vtmp->name);
         OPENSSL_free(vtmp->name);
         vtmp->name = ntmp;
 


### PR DESCRIPTION
Original text:
    Use BUF_strlcpy() instead of strcpy().
    Use BUF_strlcat() instead of strcat().
    Use BIO_snprintf() instead of sprintf().
    In some cases, keep better track of buffer lengths.
    This is part of a large change submitted by Markus Friedl <markus@openbsd.org>
