### PR TITLE
TLS 1.3: let sigalgs change on resumption

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -212,7 +212,8 @@ int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 0;
     }
 
-    if (!s->hit && !tls1_save_sigalgs(s, &supported_sig_algs)) {
+    if ((!s->hit || SSL_IS_TLS13(s))
+        && !tls1_save_sigalgs(s, &supported_sig_algs)) {
         *al = SSL_AD_DECODE_ERROR;
         return 0;
     }


### PR DESCRIPTION
TLS 1.3 lets resumption redo most of the extensions negotiation (by virtue of having the "resumption" just act as a pre-shared key in the key schedule and skipping certificate authentication), with the exception of SNI and the hash associated with the cipher suite.  So, signature algorithms are fair game to change (but not for previous versions).