### PR TITLE
Check directory is able to create files for various -out option

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -594,6 +594,7 @@ void store_setup_crl_download(X509_STORE *st);
 
 int app_isdir(const char *);
 int app_access(const char *, int flag);
+char *app_dirname(char *path);
 int fileno_stdin(void);
 int fileno_stdout(void);
 int raw_read_stdin(void *, int);

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -44,7 +44,7 @@ const OPTIONS genrsa_options[] = {
     {"3", OPT_3, '-', "Use 3 for the E value"},
     {"F4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
     {"f4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
-    {"out", OPT_OUT, 's', "Output the key to specified file"},
+    {"out", OPT_OUT, '>', "Output the key to specified file"},
     OPT_R_OPTIONS,
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},

--- a/apps/opt.c
+++ b/apps/opt.c
@@ -613,13 +613,17 @@ int opt_verify(int opt, X509_VERIFY_PARAM *vpm)
  */
 int opt_next(void)
 {
-    char *p;
+    char *p, *estr;
     const OPTIONS *o;
     int ival;
     long lval;
     unsigned long ulval;
     ossl_intmax_t imval;
     ossl_uintmax_t umval;
+#if !defined(_WIN32) && !defined(__VMS)
+    char *c;
+    int oerrno;
+#endif
 
     /* Look at current arg; at end of the list? */
     arg = NULL;
@@ -676,13 +680,13 @@ int opt_next(void)
             /* Just a string. */
             break;
         case '/':
-            if (app_isdir(arg) >= 0)
+            if (app_isdir(arg) > 0)
                 break;
             BIO_printf(bio_err, "%s: Not a directory: %s\n", prog, arg);
             return -1;
         case '<':
             /* Input file. */
-            if (strcmp(arg, "-") == 0 || app_access(arg, R_OK) >= 0)
+            if (strcmp(arg, "-") == 0 || app_access(arg, R_OK) == 0)
                 break;
             BIO_printf(bio_err,
                        "%s: Cannot open input file %s, %s\n",
@@ -690,11 +694,38 @@ int opt_next(void)
             return -1;
         case '>':
             /* Output file. */
-            if (strcmp(arg, "-") == 0 || app_access(arg, W_OK) >= 0 || errno == ENOENT)
+#if !defined(_WIN32) && !defined(__VMS)
+            c = OPENSSL_strdup(arg);
+            if (c == NULL) {
+                BIO_printf(bio_err,
+                           "%s: Memory allocation failure\n", prog);
+                return -1;
+            }
+            oerrno = errno;
+            errno = 0;
+            if (strcmp(arg, "-") == 0
+                || (app_access(app_dirname(c), W_OK) == 0
+                    && app_isdir(arg) <= 0
+                    && (app_access(arg, W_OK) == 0 || errno == ENOENT))) {
+                OPENSSL_free(c);
                 break;
+            }
+            OPENSSL_free(c);
+            if (errno == 0)
+                /* only possible if 'arg' is a directory */
+                estr = "is a directory";
+            else
+                estr = strerror(errno);
+            errno = oerrno;
+#else
+            if (strcmp(arg, "-") == 0 || app_access(arg, W_OK) == 0
+                || errno == ENOENT)
+                break;
+            estr = strerror(errno);
+#endif
             BIO_printf(bio_err,
                        "%s: Cannot open output file %s, %s\n",
-                       prog, arg, strerror(errno));
+                       prog, arg, estr);
             return -1;
         case 'p':
         case 'n':

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -30,7 +30,7 @@ const OPTIONS sess_id_options[] = {
     {"outform", OPT_OUTFORM, 'f',
      "Output format - default PEM (PEM, DER or NSS)"},
     {"in", OPT_IN, 's', "Input file - default stdin"},
-    {"out", OPT_OUT, 's', "Output file - default stdout"},
+    {"out", OPT_OUT, '>', "Output file - default stdout"},
     {"text", OPT_TEXT, '-', "Print ssl session id details"},
     {"cert", OPT_CERT, '-', "Output certificate "},
     {"noout", OPT_NOOUT, '-', "Don't output the encoded session info"},

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -1,0 +1,60 @@
+#! /usr/bin/env perl
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use File::Spec;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+setup("test_out_option");
+
+plan skip_all => "'-out' option tests are not available on Windows or VMS"
+    if $^O =~ /^(VMS|MSWin32)$/;
+
+plan tests => 11;
+
+# The following patterns should be tested:
+#
+# path        dirname
+# /usr/       /
+# /           /
+# .           .
+# ..          .
+
+test_illegal_path('/usr/');
+test_illegal_path('/');
+test_illegal_path('.');
+test_illegal_path('..');
+
+# Test for trying to create a file in a non-exist directory
+my @chars = ("A".."Z", "a".."z", "0".."9");
+my $rand_path = $chars[rand @chars] for 1..32;
+$rand_path .= "/test.pem";
+
+test_illegal_path($rand_path);
+test_legal_path('test.pem');
+unlink 'test.pem';
+
+sub test_illegal_path {
+    my ($path) = @_;
+
+    my $start = time();
+    ok(!run(app([ 'openssl', 'genrsa', '-out', $path, '16384'])), "invalid output path: $path");
+    my $end = time();
+    # The above process should exit in 2 seconds if the path is not valid
+    ok($end - $start < 2, "check time consumed");
+}
+
+sub test_legal_path {
+    my ($path) = @_;
+
+    ok(run(app([ 'openssl', 'genrsa', '-out', $path, '2048'])), "valid output path: $path");
+}


### PR DESCRIPTION
This is to address issue #3404 , I also encountered same problem.

Besides, some other nits while checking '/' and '<' type-args, are also fixed in this PR: `app_isdir` returns `0` if `arg` is not a directory and `app_access` would never return a value bigger than `0`.  (Both `_access` and `access` return 0 on success and -1 on failed)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
