### PR TITLE
Ensure a space after colon in enc -v

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -549,8 +549,8 @@ int enc_main(int argc, char **argv)
 
     ret = 0;
     if (verbose) {
-        BIO_printf(bio_err, "bytes read   :%8ju\n", BIO_number_read(in));
-        BIO_printf(bio_err, "bytes written:%8ju\n", BIO_number_written(out));
+        BIO_printf(bio_err, "bytes read   : %8ju\n", BIO_number_read(in));
+        BIO_printf(bio_err, "bytes written: %8ju\n", BIO_number_written(out));
     }
  end:
     ERR_print_errors(bio_err);


### PR DESCRIPTION
This is from GitLab MR 1200 by @dot-asm.  For master only.
