### PR TITLE
Remove OPENSSL_assert() from (some of) libcrypto

### DIFF
--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <internal/bio.h>
 #include <openssl/asn1.h>
+#include "internal/cryptlib.h"
 
 /* Must be large enough for biggest tag+length */
 #define DEFAULT_ASN1_BUF_SIZE 20
@@ -181,7 +182,8 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
 
         case ASN1_STATE_HEADER:
             ctx->buflen = ASN1_object_size(0, inl, ctx->asn1_tag) - inl;
-            OPENSSL_assert(ctx->buflen <= ctx->bufsize);
+            if (!ossl_assert(ctx->buflen <= ctx->bufsize))
+                return 0;
             p = ctx->buf;
             ASN1_put_object(&p, 0, inl, ctx->asn1_tag, ctx->asn1_class);
             ctx->copylen = inl;

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "bio_lcl.h"
@@ -565,7 +566,8 @@ static int addrinfo_wrap(int family, int socktype,
                          unsigned short port,
                          BIO_ADDRINFO **bai)
 {
-    OPENSSL_assert(bai != NULL);
+    if (bai == NULL)
+        return 0;
 
     *bai = OPENSSL_zalloc(sizeof(**bai));
     if (*bai == NULL)
@@ -760,8 +762,11 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 he_fallback_address = INADDR_ANY;
                 break;
             default:
-                OPENSSL_assert(("We forgot to handle a lookup type!" == 0));
-                break;
+                /* We forgot to handle a lookup type! */
+                assert("We forgot to handle a lookup type!" == NULL);
+                BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_INTERNAL_ERROR);
+                ret = 0;
+                goto err;
             }
         } else {
             he = gethostbyname(host);

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -566,9 +566,6 @@ static int addrinfo_wrap(int family, int socktype,
                          unsigned short port,
                          BIO_ADDRINFO **bai)
 {
-    if (bai == NULL)
-        return 0;
-
     *bai = OPENSSL_zalloc(sizeof(**bai));
     if (*bai == NULL)
         return 0;

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -805,7 +805,7 @@ static int
 doapr_outch(char **sbuffer,
             char **buffer, size_t *currlen, size_t *maxlen, int c)
 {
-    /* If we haven't at least one buffer, someone has doe a big booboo */
+    /* If we haven't at least one buffer, someone has done a big booboo */
     if (!ossl_assert(*sbuffer != NULL || buffer != NULL))
         return 0;
 

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -806,10 +806,12 @@ doapr_outch(char **sbuffer,
             char **buffer, size_t *currlen, size_t *maxlen, int c)
 {
     /* If we haven't at least one buffer, someone has doe a big booboo */
-    OPENSSL_assert(*sbuffer != NULL || buffer != NULL);
+    if (!ossl_assert(*sbuffer != NULL || buffer != NULL))
+        return 0;
 
     /* |currlen| must always be <= |*maxlen| */
-    OPENSSL_assert(*currlen <= *maxlen);
+    if (!ossl_assert(*currlen <= *maxlen))
+        return 0;
 
     if (buffer && *currlen == *maxlen) {
         if (*maxlen > INT_MAX - BUFFER_INC)
@@ -821,7 +823,8 @@ doapr_outch(char **sbuffer,
             if (*buffer == NULL)
                 return 0;
             if (*currlen > 0) {
-                OPENSSL_assert(*sbuffer != NULL);
+                if (!ossl_assert(*sbuffer != NULL))
+                    return 0;
                 memcpy(*buffer, *sbuffer, *currlen);
             }
             *sbuffer = NULL;

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -43,14 +43,13 @@ int BIO_get_host_ip(const char *str, unsigned char *ip)
         if (BIO_ADDRINFO_family(res) != AF_INET) {
             BIOerr(BIO_F_BIO_GET_HOST_IP,
                    BIO_R_GETHOSTBYNAME_ADDR_IS_NOT_AF_INET);
-        } else {
-            BIO_ADDR_rawaddress(BIO_ADDRINFO_address(res), NULL, &l);
-            /* Because only AF_INET addresses will reach this far,
-               we can assert that l should be 4 */
-            OPENSSL_assert(l == 4);
-
-            BIO_ADDR_rawaddress(BIO_ADDRINFO_address(res), ip, &l);
-            ret = 1;
+        } else if (BIO_ADDR_rawaddress(BIO_ADDRINFO_address(res), NULL, &l)) {
+            /*
+             * Because only AF_INET addresses will reach this far, we can assert
+             * that l should be 4
+             */
+            if (ossl_assert(l == 4))
+                ret = BIO_ADDR_rawaddress(BIO_ADDRINFO_address(res), ip, &l);
         }
         BIO_ADDRINFO_free(res);
     } else {

--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -145,7 +145,7 @@ extern "C" {
  */
 
 # ifdef BN_DEBUG
-
+#  include <assert.h>
 #  ifdef BN_DEBUG_RAND
 #   define bn_pollute(a) \
         do { \
@@ -169,8 +169,8 @@ extern "C" {
         do { \
                 const BIGNUM *_bnum2 = (a); \
                 if (_bnum2 != NULL) { \
-                        OPENSSL_assert(((_bnum2->top == 0) && !_bnum2->neg) || \
-                                (_bnum2->top && (_bnum2->d[_bnum2->top - 1] != 0))); \
+                        assert(((_bnum2->top == 0) && !_bnum2->neg) || \
+                               (_bnum2->top && (_bnum2->d[_bnum2->top - 1] != 0))); \
                         bn_pollute(_bnum2); \
                 } \
         } while(0)
@@ -181,8 +181,8 @@ extern "C" {
 #  define bn_wcheck_size(bn, words) \
         do { \
                 const BIGNUM *_bnum2 = (bn); \
-                OPENSSL_assert((words) <= (_bnum2)->dmax && \
-                        (words) >= (_bnum2)->top); \
+                assert((words) <= (_bnum2)->dmax && \
+                       (words) >= (_bnum2)->top); \
                 /* avoid unused variable warning with NDEBUG */ \
                 (void)(_bnum2); \
         } while(0)

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -254,7 +254,7 @@ static void nist_cp_bn_0(BN_ULONG *dst, const BN_ULONG *src, int top, int max)
     int i;
 
 #ifdef BN_DEBUG
-    OPENSSL_assert(top <= max);
+    assert(top <= max);
 #endif
     for (i = 0; i < top; i++)
         dst[i] = src[i];

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -204,7 +204,8 @@ CONF_VALUE *_CONF_new_section(CONF *conf, const char *section)
     v->value = (char *)sk;
 
     vv = lh_CONF_VALUE_insert(conf->data, v);
-    OPENSSL_assert(vv == NULL);
+    if (vv != NULL)
+        goto err;
     return v;
 
  err:

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -191,7 +191,8 @@ int EC_KEY_generate_key(EC_KEY *eckey)
 
 int ossl_ec_key_gen(EC_KEY *eckey)
 {
-    OPENSSL_assert(eckey->group->meth->keygen != NULL);
+    if (!ossl_assert(eckey->group->meth->keygen != NULL))
+        return 0;
     return eckey->group->meth->keygen(eckey);
 }
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -191,8 +191,6 @@ int EC_KEY_generate_key(EC_KEY *eckey)
 
 int ossl_ec_key_gen(EC_KEY *eckey)
 {
-    if (!ossl_assert(eckey->group->meth->keygen != NULL))
-        return 0;
     return eckey->group->meth->keygen(eckey);
 }
 

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -330,7 +330,8 @@ const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group)
 
 int EC_GROUP_order_bits(const EC_GROUP *group)
 {
-    OPENSSL_assert(group->meth->group_order_bits != NULL);
+    if (!ossl_assert(group->meth->group_order_bits != NULL))
+        return 0;
     return group->meth->group_order_bits(group);
 }
 

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -330,8 +330,6 @@ const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group)
 
 int EC_GROUP_order_bits(const EC_GROUP *group)
 {
-    if (!ossl_assert(group->meth->group_order_bits != NULL))
-        return 0;
     return group->meth->group_order_bits(group);
 }
 

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -37,7 +37,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
     if (key != NULL) {
         reset = 1;
         j = EVP_MD_block_size(md);
-        OPENSSL_assert(j <= (int)sizeof(ctx->key));
+        if (!ossl_assert(j <= (int)sizeof(ctx->key)))
+            goto err;
         if (j < len) {
             if (!EVP_DigestInit_ex(ctx->md_ctx, md, impl))
                 goto err;

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -184,7 +184,8 @@ static int tls1_prf_P_hash(const EVP_MD *md,
     int ret = 0;
 
     chunk = EVP_MD_size(md);
-    OPENSSL_assert(chunk >= 0);
+    if (!ossl_assert(chunk >= 0))
+        goto err;
 
     ctx = EVP_MD_CTX_new();
     ctx_tmp = EVP_MD_CTX_new();

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -184,7 +184,7 @@ static int tls1_prf_P_hash(const EVP_MD *md,
     int ret = 0;
 
     chunk = EVP_MD_size(md);
-    if (!ossl_assert(chunk >= 0))
+    if (!ossl_assert(chunk > 0))
         goto err;
 
     ctx = EVP_MD_CTX_new();

--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -256,7 +256,13 @@ int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
 
     if (enc != NULL) {
         objstr = OBJ_nid2sn(EVP_CIPHER_nid(enc));
-        if (objstr == NULL) {
+        if (objstr == NULL
+                   /*
+                    * Check "Proc-Type: 4,Encrypted\nDEK-Info: objstr,hex-iv\n"
+                    * fits into buf
+                    */
+                || (strlen(objstr) + 23 + 2 * EVP_CIPHER_iv_length(enc) + 13)
+                   > sizeof(buf)) {
             PEMerr(PEM_F_PEM_X509_INFO_WRITE_BIO, PEM_R_UNSUPPORTED_CIPHER);
             goto err;
         }
@@ -291,10 +297,7 @@ int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
                 goto err;
             }
 
-            /* create the right magic header stuff */
-            OPENSSL_assert(strlen(objstr) + 23
-                           + 2 * EVP_CIPHER_iv_length(enc) + 13 <=
-                           sizeof buf);
+            /* Create the right magic header stuff */ 
             buf[0] = '\0';
             PEM_proc_type(buf, PEM_TYPE_ENCRYPTED);
             PEM_dek_info(buf, objstr, EVP_CIPHER_iv_length(enc),

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -25,19 +25,22 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
 
 int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 {
-    OPENSSL_assert(*(unsigned int *)lock == 1);
+    if (!ossl_assert(*(unsigned int *)lock == 1))
+        return 0;
     return 1;
 }
 
 int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 {
-    OPENSSL_assert(*(unsigned int *)lock == 1);
+    if (!ossl_assert(*(unsigned int *)lock == 1))
+        return 0;
     return 1;
 }
 
 int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock)
 {
-    OPENSSL_assert(*(unsigned int *)lock == 1);
+    if (!ossl_assert(*(unsigned int *)lock == 1))
+        return 0;
     return 1;
 }
 

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -145,7 +145,8 @@ static int i2d_x509_aux_internal(X509 *a, unsigned char **pp)
     int length, tmplen;
     unsigned char *start = pp != NULL ? *pp : NULL;
 
-    OPENSSL_assert(pp == NULL || *pp != NULL);
+    if (!ossl_assert(pp == NULL || *pp != NULL))
+        return -1;
 
     /*
      * This might perturb *pp on error, but fixing that belongs in i2d_X509()

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -145,9 +145,6 @@ static int i2d_x509_aux_internal(X509 *a, unsigned char **pp)
     int length, tmplen;
     unsigned char *start = pp != NULL ? *pp : NULL;
 
-    if (!ossl_assert(pp == NULL || *pp != NULL))
-        return -1;
-
     /*
      * This might perturb *pp on error, but fixing that belongs in i2d_X509()
      * not here.  It should be that if a == NULL length is zero, but we check

--- a/crypto/x509v3/v3_addr.c
+++ b/crypto/x509v3/v3_addr.c
@@ -430,8 +430,6 @@ static int make_addressRange(IPAddressOrRange **result,
     if ((aor = IPAddressOrRange_new()) == NULL)
         return 0;
     aor->type = IPAddressOrRange_addressRange;
-    if (!ossl_assert(aor->u.addressRange == NULL))
-        return 0;
     if ((aor->u.addressRange = IPAddressRange_new()) == NULL)
         goto err;
     if (aor->u.addressRange->min == NULL &&

--- a/crypto/x509v3/v3_addr.c
+++ b/crypto/x509v3/v3_addr.c
@@ -496,8 +496,6 @@ static IPAddressFamily *make_IPAddressFamily(IPAddrBlocks *addr,
 
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         f = sk_IPAddressFamily_value(addr, i);
-        if (!ossl_assert(f->addressFamily->data != NULL))
-            goto err;
         if (f->addressFamily->length == keylen &&
             !memcmp(f->addressFamily->data, key, keylen))
             return f;
@@ -1201,11 +1199,6 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
     } else {
         i = 0;
         x = sk_X509_value(chain, i);
-        if (!ossl_assert(x != NULL)) {
-            if (ctx != NULL)
-                ctx->error = X509_V_ERR_UNSPECIFIED;
-            return 0;
-        }
         if ((ext = x->rfc3779_addr) == NULL)
             goto done;
     }
@@ -1227,11 +1220,6 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
      */
     for (i++; i < sk_X509_num(chain); i++) {
         x = sk_X509_value(chain, i);
-        if (!ossl_assert(x != NULL)) {
-            if (ctx != NULL)
-                ctx->error = X509_V_ERR_UNSPECIFIED;
-            return 0;
-        }
         if (!X509v3_addr_is_canonical(x->rfc3779_addr))
             validation_err(X509_V_ERR_INVALID_EXTENSION);
         if (x->rfc3779_addr == NULL) {
@@ -1275,11 +1263,6 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
     /*
      * Trust anchor can't inherit.
      */
-    if (!ossl_assert(x != NULL)) {
-        if (ctx != NULL)
-            ctx->error = X509_V_ERR_UNSPECIFIED;
-        return 0;
-    }
     if (x->rfc3779_addr != NULL) {
         for (j = 0; j < sk_IPAddressFamily_num(x->rfc3779_addr); j++) {
             IPAddressFamily *fp =
@@ -1304,8 +1287,10 @@ int X509v3_addr_validate_path(X509_STORE_CTX *ctx)
 {
     if (ctx->chain == NULL
             || sk_X509_num(ctx->chain) == 0
-            || ctx->verify_cb == NULL)
+            || ctx->verify_cb == NULL) {
+        ctx->error = X509_V_ERR_UNSPECIFIED;
         return 0;
+    }
     return addr_validate_path_internal(ctx, ctx->chain, NULL);
 }
 

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -168,8 +168,6 @@ int X509v3_asid_add_inherit(ASIdentifiers *asid, int which)
     if (*choice == NULL) {
         if ((*choice = ASIdentifierChoice_new()) == NULL)
             return 0;
-        if (!ossl_assert((*choice)->u.inherit == NULL))
-            return 0;
         if (((*choice)->u.inherit = ASN1_NULL_new()) == NULL)
             return 0;
         (*choice)->type = ASIdentifierChoice_inherit;
@@ -201,8 +199,6 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
         return 0;
     if (*choice == NULL) {
         if ((*choice = ASIdentifierChoice_new()) == NULL)
-            return 0;
-        if (!ossl_assert((*choice)->u.asIdsOrRanges == NULL))
             return 0;
         (*choice)->u.asIdsOrRanges = sk_ASIdOrRange_new(ASIdOrRange_cmp);
         if ((*choice)->u.asIdsOrRanges == NULL)
@@ -238,7 +234,7 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
 static int extract_min_max(ASIdOrRange *aor,
                            ASN1_INTEGER **min, ASN1_INTEGER **max)
 {
-    if (!ossl_assert(aor != NULL && min != NULL && max != NULL))
+    if (!ossl_assert(aor != NULL))
         return 0;
     switch (aor->type) {
     case ASIdOrRange_id:

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -743,11 +743,6 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     } else {
         i = 0;
         x = sk_X509_value(chain, i);
-        if (!ossl_assert(x != NULL)) {
-            if (ctx != NULL)
-                ctx->error = X509_V_ERR_UNSPECIFIED;
-            return 0;
-        }
         if ((ext = x->rfc3779_asid) == NULL)
             goto done;
     }
@@ -857,8 +852,10 @@ int X509v3_asid_validate_path(X509_STORE_CTX *ctx)
 {
     if (ctx->chain == NULL
             || sk_X509_num(ctx->chain) == 0
-            || ctx->verify_cb == NULL)
+            || ctx->verify_cb == NULL) {
+        ctx->error = X509_V_ERR_UNSPECIFIED;
         return 0;
+    }
     return asid_validate_path_internal(ctx, ctx->chain, NULL);
 }
 

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -11,6 +11,7 @@
  * Implementation of RFC 3779 section 3.2.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "internal/cryptlib.h"
@@ -123,13 +124,13 @@ static int ASIdOrRange_cmp(const ASIdOrRange *const *a_,
 {
     const ASIdOrRange *a = *a_, *b = *b_;
 
-    OPENSSL_assert((a->type == ASIdOrRange_id && a->u.id != NULL) ||
-                   (a->type == ASIdOrRange_range && a->u.range != NULL &&
-                    a->u.range->min != NULL && a->u.range->max != NULL));
+    assert((a->type == ASIdOrRange_id && a->u.id != NULL) ||
+           (a->type == ASIdOrRange_range && a->u.range != NULL &&
+            a->u.range->min != NULL && a->u.range->max != NULL));
 
-    OPENSSL_assert((b->type == ASIdOrRange_id && b->u.id != NULL) ||
-                   (b->type == ASIdOrRange_range && b->u.range != NULL &&
-                    b->u.range->min != NULL && b->u.range->max != NULL));
+    assert((b->type == ASIdOrRange_id && b->u.id != NULL) ||
+           (b->type == ASIdOrRange_range && b->u.range != NULL &&
+            b->u.range->min != NULL && b->u.range->max != NULL));
 
     if (a->type == ASIdOrRange_id && b->type == ASIdOrRange_id)
         return ASN1_INTEGER_cmp(a->u.id, b->u.id);
@@ -167,7 +168,8 @@ int X509v3_asid_add_inherit(ASIdentifiers *asid, int which)
     if (*choice == NULL) {
         if ((*choice = ASIdentifierChoice_new()) == NULL)
             return 0;
-        OPENSSL_assert((*choice)->u.inherit == NULL);
+        if (!ossl_assert((*choice)->u.inherit == NULL))
+            return 0;
         if (((*choice)->u.inherit = ASN1_NULL_new()) == NULL)
             return 0;
         (*choice)->type = ASIdentifierChoice_inherit;
@@ -200,7 +202,8 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
     if (*choice == NULL) {
         if ((*choice = ASIdentifierChoice_new()) == NULL)
             return 0;
-        OPENSSL_assert((*choice)->u.asIdsOrRanges == NULL);
+        if (!ossl_assert((*choice)->u.asIdsOrRanges == NULL))
+            return 0;
         (*choice)->u.asIdsOrRanges = sk_ASIdOrRange_new(ASIdOrRange_cmp);
         if ((*choice)->u.asIdsOrRanges == NULL)
             return 0;
@@ -232,20 +235,23 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
 /*
  * Extract min and max values from an ASIdOrRange.
  */
-static void extract_min_max(ASIdOrRange *aor,
-                            ASN1_INTEGER **min, ASN1_INTEGER **max)
+static int extract_min_max(ASIdOrRange *aor,
+                           ASN1_INTEGER **min, ASN1_INTEGER **max)
 {
-    OPENSSL_assert(aor != NULL && min != NULL && max != NULL);
+    if (!ossl_assert(aor != NULL && min != NULL && max != NULL))
+        return 0;
     switch (aor->type) {
     case ASIdOrRange_id:
         *min = aor->u.id;
         *max = aor->u.id;
-        return;
+        return 1;
     case ASIdOrRange_range:
         *min = aor->u.range->min;
         *max = aor->u.range->max;
-        return;
+        return 1;
     }
+
+    return 0;
 }
 
 /*
@@ -279,8 +285,9 @@ static int ASIdentifierChoice_is_canonical(ASIdentifierChoice *choice)
         ASN1_INTEGER *a_min = NULL, *a_max = NULL, *b_min = NULL, *b_max =
             NULL;
 
-        extract_min_max(a, &a_min, &a_max);
-        extract_min_max(b, &b_min, &b_max);
+        if (!extract_min_max(a, &a_min, &a_max)
+                || !extract_min_max(b, &b_min, &b_max))
+            goto done;
 
         /*
          * Punt misordered list, overlapping start, or inverted range.
@@ -318,8 +325,8 @@ static int ASIdentifierChoice_is_canonical(ASIdentifierChoice *choice)
         ASIdOrRange *a = sk_ASIdOrRange_value(choice->u.asIdsOrRanges, i);
         ASN1_INTEGER *a_min, *a_max;
         if (a != NULL && a->type == ASIdOrRange_range) {
-            extract_min_max(a, &a_min, &a_max);
-            if (ASN1_INTEGER_cmp(a_min, a_max) > 0)
+            if (!extract_min_max(a, &a_min, &a_max)
+                    || ASN1_INTEGER_cmp(a_min, a_max) > 0)
                 goto done;
         }
     }
@@ -382,13 +389,15 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
         ASN1_INTEGER *a_min = NULL, *a_max = NULL, *b_min = NULL, *b_max =
             NULL;
 
-        extract_min_max(a, &a_min, &a_max);
-        extract_min_max(b, &b_min, &b_max);
+        if (!extract_min_max(a, &a_min, &a_max)
+                || !extract_min_max(b, &b_min, &b_max))
+            goto done;
 
         /*
          * Make sure we're properly sorted (paranoia).
          */
-        OPENSSL_assert(ASN1_INTEGER_cmp(a_min, b_min) <= 0);
+        if (!ossl_assert(ASN1_INTEGER_cmp(a_min, b_min) <= 0))
+            goto done;
 
         /*
          * Punt inverted ranges.
@@ -464,13 +473,15 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
         ASIdOrRange *a = sk_ASIdOrRange_value(choice->u.asIdsOrRanges, i);
         ASN1_INTEGER *a_min, *a_max;
         if (a != NULL && a->type == ASIdOrRange_range) {
-            extract_min_max(a, &a_min, &a_max);
-            if (ASN1_INTEGER_cmp(a_min, a_max) > 0)
+            if (!extract_min_max(a, &a_min, &a_max)
+                    || ASN1_INTEGER_cmp(a_min, a_max) > 0)
                 goto done;
         }
     }
 
-    OPENSSL_assert(ASIdentifierChoice_is_canonical(choice)); /* Paranoia */
+    /* Paranoia */
+    if (!ossl_assert(ASIdentifierChoice_is_canonical(choice)))
+        goto done;
 
     ret = 1;
 
@@ -655,7 +666,8 @@ static int asid_contains(ASIdOrRanges *parent, ASIdOrRanges *child)
 
     p = 0;
     for (c = 0; c < sk_ASIdOrRange_num(child); c++) {
-        extract_min_max(sk_ASIdOrRange_value(child, c), &c_min, &c_max);
+        if (!extract_min_max(sk_ASIdOrRange_value(child, c), &c_min, &c_max))
+            return 0;
         for (;; p++) {
             if (p >= sk_ASIdOrRange_num(parent))
                 return 0;
@@ -715,9 +727,14 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     int i, ret = 1, inherit_as = 0, inherit_rdi = 0;
     X509 *x;
 
-    OPENSSL_assert(chain != NULL && sk_X509_num(chain) > 0);
-    OPENSSL_assert(ctx != NULL || ext != NULL);
-    OPENSSL_assert(ctx == NULL || ctx->verify_cb != NULL);
+    if (!ossl_assert(chain != NULL && sk_X509_num(chain) > 0)
+            || !ossl_assert(ctx != NULL || ext != NULL)
+            || !ossl_assert(ctx == NULL || ctx->verify_cb != NULL)) {
+        if (ctx != NULL)
+            ctx->error = X509_V_ERR_UNSPECIFIED;
+        return 0;
+    }
+
 
     /*
      * Figure out where to start.  If we don't have an extension to
@@ -730,7 +747,11 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     } else {
         i = 0;
         x = sk_X509_value(chain, i);
-        OPENSSL_assert(x != NULL);
+        if (!ossl_assert(x != NULL)) {
+            if (ctx != NULL)
+                ctx->error = X509_V_ERR_UNSPECIFIED;
+            return 0;
+        }
         if ((ext = x->rfc3779_asid) == NULL)
             goto done;
     }
@@ -763,7 +784,11 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
      */
     for (i++; i < sk_X509_num(chain); i++) {
         x = sk_X509_value(chain, i);
-        OPENSSL_assert(x != NULL);
+        if (!ossl_assert(x != NULL)) {
+            if (ctx != NULL)
+                ctx->error = X509_V_ERR_UNSPECIFIED;
+            return 0;
+        }
         if (x->rfc3779_asid == NULL) {
             if (child_as != NULL || child_rdi != NULL)
                 validation_err(X509_V_ERR_UNNESTED_RESOURCE);
@@ -809,7 +834,11 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     /*
      * Trust anchor can't inherit.
      */
-    OPENSSL_assert(x != NULL);
+    if (!ossl_assert(x != NULL)) {
+        if (ctx != NULL)
+            ctx->error = X509_V_ERR_UNSPECIFIED;
+        return 0;
+    }
     if (x->rfc3779_asid != NULL) {
         if (x->rfc3779_asid->asnum != NULL &&
             x->rfc3779_asid->asnum->type == ASIdentifierChoice_inherit)
@@ -830,6 +859,10 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
  */
 int X509v3_asid_validate_path(X509_STORE_CTX *ctx)
 {
+    if (ctx->chain == NULL
+            || sk_X509_num(ctx->chain) == 0
+            || ctx->verify_cb == NULL)
+        return 0;
     return asid_validate_path_internal(ctx, ctx->chain, NULL);
 }
 


### PR DESCRIPTION
This removes OPENSSL_assert() usage from a lot of libcrypto.

This is essentially all the bits from #3544 which weren't challenged as to whether they were appropriate or not. If this gains approval I will follow up with other PRs for the more controversial bits of #3544.

Where there were style type feedback comments in #3544 which didn't challenge the fundamental change, I have incorporated fixes for those here.
