### PR TITLE
New /dev/crypto engine

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Add devcrypto engine.  This has been implemented against cryptodev-linux,
+     then adjusted to work on FreeBSD 8.4 as well.
+     Enable by configuring with 'enable-devcryptoeng'.  This is done by default
+     on BSD implementations, as cryptodev.h is assumed to exist on all of them.
+     [Richard Levitte]
+
   *) Module names can prefixed with OSSL_ or OPENSSL_.  This affects
      util/mkerr.pl, which is adapted to allow those prefixes, leading to
      error code calls like this:

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -984,6 +984,7 @@ sub vms_info {
                                            debug   => "-O0 -g",
                                            release => "-O3"),
                                     threads("-pthread -D_THREAD_SAFE -D_REENTRANT")),
+        enable           => add("devcryptoeng"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
         dso_scheme       => "dlfcn",

--- a/Configure
+++ b/Configure
@@ -345,6 +345,7 @@ my @disablables = (
     "ct",
     "deprecated",
     "des",
+    "devcryptoeng",
     "dgram",
     "dh",
     "dsa",
@@ -431,6 +432,7 @@ our %disabled = ( # "what"         => "comment"
                   "asan"		=> "default",
 		  "crypto-mdebug"       => "default",
 		  "crypto-mdebug-backtrace" => "default",
+		  "devcryptoeng"	=> "default",
 		  "ec_nistp_64_gcc_128" => "default",
 		  "egd"                 => "default",
 		  "external-tests"	=> "default",
@@ -504,7 +506,7 @@ my @disable_cascades = (
     # Without position independent code, there can be no shared libraries or DSOs
     "pic"               => [ "shared" ],
     "shared"            => [ "dynamic-engine" ],
-    "engine"            => [ "afalgeng" ],
+    "engine"            => [ "afalgeng", "devcryptoeng" ],
 
     # no-autoalginit is only useful when building non-shared
     "autoalginit"       => [ "shared", "apps" ],

--- a/crypto/engine/build.info
+++ b/crypto/engine/build.info
@@ -6,3 +6,6 @@ SOURCE[../../libcrypto]=\
         tb_cipher.c tb_digest.c tb_pkmeth.c tb_asnmth.c tb_eckey.c \
         eng_openssl.c eng_cnf.c eng_dyn.c \
         eng_rdrand.c
+IF[{- !$disabled{devcryptoeng} -}]
+  SOURCE[../../libcrypto]=eng_devcrypto.c
+ENDIF

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -530,10 +530,6 @@ static void prepare_digest_methods()
                                                        NID_undef)) == NULL
             || !EVP_MD_meth_set_result_size(known_digest_methods[i],
                                             digest_data[i].digestlen)
-#if 0
-            || !EVP_MD_meth_set_flags(known_digest_methods[i],
-                                      digest_data[i].flags)
-#endif
             || !EVP_MD_meth_set_init(known_digest_methods[i], digest_init)
             || !EVP_MD_meth_set_update(known_digest_methods[i], digest_update)
             || !EVP_MD_meth_set_final(known_digest_methods[i], digest_final)

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -245,7 +245,8 @@ static void prepare_cipher_methods()
             || !EVP_CIPHER_meth_set_iv_length(known_cipher_methods[i],
                                               cipher_data[i].ivlen)
             || !EVP_CIPHER_meth_set_flags(known_cipher_methods[i],
-                                          cipher_data[i].flags)
+                                          cipher_data[i].flags
+                                          | EVP_CIPH_FLAG_DEFAULT_ASN1)
             || !EVP_CIPHER_meth_set_init(known_cipher_methods[i], cipher_init)
             || !EVP_CIPHER_meth_set_do_cipher(known_cipher_methods[i],
                                               cipher_do_cipher)

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -134,7 +134,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     struct cipher_ctx *cipher_ctx =
         (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     const struct cipher_data_st *cipher_d =
-        get_cipher_data(EVP_CIPHER_CTX_type(ctx));
+        get_cipher_data(EVP_CIPHER_CTX_nid(ctx));
 
     if ((cipher_ctx->cfd = open("/dev/crypto", O_RDWR, 0)) < 0) {
         SYSerr(SYS_F_OPEN, errno);

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -600,7 +600,28 @@ void engine_load_devcrypto_int()
     if (!ENGINE_set_id(e, "devcrypto")
         || !ENGINE_set_name(e, "/dev/crypto engine")
         || !ENGINE_set_destroy_function(e, devcrypto_unload)
-#if 0                            /* Not supported yet */
+
+/*
+ * Asymmetric ciphers aren't well supported with /dev/crypto.  Among the BSD
+ * implementations, it seems to only exist in FreeBSD, and regarding the
+ * parameters in its crypt_kop, the manual crypto(4) has this to say:
+ *
+ *    The semantics of these arguments are currently undocumented.
+ *
+ * Reading through the FreeBSD source code doesn't give much more than
+ * their CRK_MOD_EXP implementation for ubsec.
+ *
+ * It doesn't look much better with cryptodev-linux.  They have the crypt_kop
+ * structure as well as the command (CRK_*) in cryptodev.h, but no support
+ * seems to be implemented at all for the moment.
+ *
+ * At the time of writing, it seems impossible to write proper support for
+ * FreeBSD's asym features without some very deep knowledge and access to
+ * specific kernel modules.
+ *
+ * /Richard Levitte, 2017-05-11
+ */
+#if 0
 # ifndef OPENSSL_NO_RSA
         || !ENGINE_set_RSA(e, devcrypto_rsa)
 # endif

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -176,6 +176,7 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     cryp.flags = 0;
 
     if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
+        assert(inl >= EVP_CIPHER_CTX_iv_length(ctx));
         if (!EVP_CIPHER_CTX_encrypting(ctx)) {
             unsigned char *ivptr = in + inl - EVP_CIPHER_CTX_iv_length(ctx);
 
@@ -195,6 +196,7 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
         unsigned char *ivptr = saved_iv;
 
+        assert(inl >= EVP_CIPHER_CTX_iv_length(ctx));
         if (!EVP_CIPHER_CTX_encrypting(ctx))
             ivptr = out + inl - EVP_CIPHER_CTX_iv_length(ctx);
 

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "e_os.h"
+
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/engine.h>
+#include <openssl/objects.h>
+#include <crypto/cryptodev.h>
+
+#include "internal/engine.h"
+
+#ifdef CRYPTO_ALGORITHM_MIN
+# define CHECK_BSD_STYLE_MACROS
+#endif
+
+/******************************************************************************
+ *
+ * Ciphers
+ *
+ * Because they all do the same basic operation, we have only one set of
+ * method functions for them all to share, and a mapping table between
+ * NIDs and cryptodev IDs, with all the necessary size data.
+ *
+ *****/
+
+struct cipher_ctx {
+    int cfd;
+    struct session_op sess;
+
+    /* to pass from init to do_cipher */
+    const unsigned char *iv;
+    int op;                      /* COP_ENCRYPT or COP_DECRYPT */
+};
+
+static const struct cipher_data_st {
+    int nid;
+    int blocksize;
+    int keylen;
+    int ivlen;
+    int flags;
+    int devcryptoid;
+} cipher_data[] = {
+#ifndef OPENSSL_NO_DES
+    { NID_des_cbc, 8, 8, 8, EVP_CIPH_CBC_MODE, CRYPTO_DES_CBC },
+    { NID_des_ede3_cbc, 8, 24, 8, EVP_CIPH_CBC_MODE, CRYPTO_3DES_CBC },
+#endif
+#ifndef OPENSSL_NO_BF
+    { NID_bf_cbc, 8, 16, 8, EVP_CIPH_CBC_MODE, CRYPTO_BLF_CBC },
+#endif
+#ifndef OPENSSL_NO_CAST
+    { NID_cast5_cbc, 8, 16, 8, EVP_CIPH_CBC_MODE, CRYPTO_CAST_CBC },
+#endif
+    { NID_aes_128_cbc, 16, 128 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC },
+    { NID_aes_192_cbc, 16, 192 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC },
+    { NID_aes_256_cbc, 16, 256 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC },
+#ifndef OPENSSL_NO_RC4
+    { NID_rc4, 1, 16, 0, CRYPTO_ARC4 },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_CTR)
+    { NID_aes_128_ctr, 16, 128 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
+    { NID_aes_192_ctr, 16, 192 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
+    { NID_aes_256_ctr, 16, 256 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
+#endif
+#if 0                            /* Not yet supported */
+    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
+    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_ECB)
+    { NID_aes_128_ecb, 16, 128 / 8, 16, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+    { NID_aes_192_ecb, 16, 192 / 8, 16, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+    { NID_aes_256_ecb, 16, 256 / 8, 16, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+#endif
+#if 0                            /* Not yet supported */
+    { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
+    { NID_aes_192_gcm, 16, 192 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
+    { NID_aes_256_gcm, 16, 256 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
+#endif
+#ifndef OPENSSL_NO_CAMELLIA
+    { NID_camellia_128_cbc, 16, 128 / 8, 16, EVP_CIPH_CBC_MODE,
+      CRYPTO_CAMELLIA_CBC },
+    { NID_camellia_192_cbc, 16, 192 / 8, 16, EVP_CIPH_CBC_MODE,
+      CRYPTO_CAMELLIA_CBC },
+    { NID_camellia_256_cbc, 16, 256 / 8, 16, EVP_CIPH_CBC_MODE,
+      CRYPTO_CAMELLIA_CBC },
+#endif
+};
+
+static size_t get_cipher_data_index(int nid)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(cipher_data); i++)
+        if (nid == cipher_data[i].nid)
+            return i;
+
+    /*
+     * Code further down must make sure that only NIDs in the table above
+     * are used.  If any other NID reaches this function, there's a grave
+     * coding error further down.
+     */
+    assert("Code that never should be reached" == NULL);
+    return -1;
+}
+
+static const struct cipher_data_st *get_cipher_data(int nid)
+{
+    return &cipher_data[get_cipher_data_index(nid)];
+}
+
+/*
+ * Following are the three necessary functions to map OpenSSL functionality
+ * with cryptodev.
+ */
+
+static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                       const unsigned char *iv, int enc)
+{
+    struct cipher_ctx *cipher_ctx =
+        (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    const struct cipher_data_st *cipher_d =
+        get_cipher_data(EVP_CIPHER_CTX_type(ctx));
+
+    if ((cipher_ctx->cfd = open("/dev/crypto", O_RDWR, 0)) < 0) {
+        SYSerr(SYS_F_OPEN, errno);
+        return 0;
+    }
+
+    memset(&cipher_ctx->sess, 0, sizeof(cipher_ctx->sess));
+    cipher_ctx->sess.cipher = cipher_d->devcryptoid;
+    cipher_ctx->sess.keylen = cipher_d->keylen;
+    cipher_ctx->sess.key = (void *)key;
+    cipher_ctx->op = enc ? COP_ENCRYPT : COP_DECRYPT;
+    if (ioctl(cipher_ctx->cfd, CIOCGSESSION, &cipher_ctx->sess) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        close(cipher_ctx->cfd);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                            const unsigned char *in, size_t inl)
+{
+    struct cipher_ctx *cipher_ctx =
+        (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    struct crypt_op cryp;
+
+    memset(&cryp, 0, sizeof(cryp));
+    cryp.ses = cipher_ctx->sess.ses;
+    cryp.len = inl;
+    cryp.src = (void *)in;
+    cryp.dst = (void *)out;
+    cryp.iv = (void *)EVP_CIPHER_CTX_iv_noconst(ctx);
+    cryp.op = cipher_ctx->op;
+    cryp.flags = COP_FLAG_WRITE_IV;
+    if (ioctl(cipher_ctx->cfd, CIOCCRYPT, &cryp) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int cipher_cleanup(EVP_CIPHER_CTX *ctx)
+{
+    struct cipher_ctx *cipher_ctx =
+        (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+
+    if (ioctl(cipher_ctx->cfd, CIOCFSESSION, &cipher_ctx->sess) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        return 0;
+    }
+    if (close(cipher_ctx->cfd) < 0) {
+        SYSerr(SYS_F_CLOSE, errno);
+        return 0;
+    }
+
+    return 1;
+}
+
+/*
+ * Keep a table of known nids and associated methods.
+ * Note that known_cipher_nids[] isn't necessarely indexed the same way as
+ * cipher_data[] above, which known_cipher_methods[] is.
+ */
+static int known_cipher_nids[OSSL_NELEM(cipher_data)];
+static int known_cipher_nids_amount = -1; /* -1 indicates not yet initialised */
+static EVP_CIPHER *known_cipher_methods[OSSL_NELEM(cipher_data)] = { NULL, };
+
+static void prepare_cipher_methods()
+{
+    size_t i;
+
+    for (i = 0, known_cipher_nids_amount = 0;
+         i < OSSL_NELEM(cipher_data); i++)
+        if ((known_cipher_methods[i] =
+                 EVP_CIPHER_meth_new(cipher_data[i].nid,
+                                     cipher_data[i].blocksize,
+                                     cipher_data[i].keylen)) == NULL
+            || !EVP_CIPHER_meth_set_iv_length(known_cipher_methods[i],
+                                              cipher_data[i].ivlen)
+            || !EVP_CIPHER_meth_set_flags(known_cipher_methods[i],
+                                          cipher_data[i].flags)
+            || !EVP_CIPHER_meth_set_init(known_cipher_methods[i], cipher_init)
+            || !EVP_CIPHER_meth_set_do_cipher(known_cipher_methods[i],
+                                              cipher_do_cipher)
+            || !EVP_CIPHER_meth_set_cleanup(known_cipher_methods[i],
+                                            cipher_cleanup)
+            || !EVP_CIPHER_meth_set_impl_ctx_size(known_cipher_methods[i],
+                                                  sizeof(struct cipher_ctx))) {
+            EVP_CIPHER_meth_free(known_cipher_methods[i]);
+            known_cipher_methods[i] = NULL;
+        } else {
+            known_cipher_nids[known_cipher_nids_amount++] =
+                cipher_data[i].nid;
+        }
+}
+
+static const EVP_CIPHER *get_cipher_method(int nid)
+{
+    size_t i = get_cipher_data_index(nid);
+
+    if (i == (size_t)-1)
+        return NULL;
+    return known_cipher_methods[i];
+}
+
+static int get_cipher_nids(const int **nids)
+{
+    *nids = known_cipher_nids;
+    return known_cipher_nids_amount;
+}
+
+static void destroy_cipher_method(int nid)
+{
+    size_t i = get_cipher_data_index(nid);
+
+    EVP_CIPHER_meth_free(known_cipher_methods[i]);
+    known_cipher_methods[i] = NULL;
+}
+
+static void destroy_all_cipher_methods()
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(cipher_data); i++)
+        destroy_cipher_method(cipher_data[i].nid);
+}
+
+static int devcrypto_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
+                             const int **nids, int nid)
+{
+    if (cipher == NULL)
+        return get_cipher_nids(nids);
+
+    *cipher = get_cipher_method(nid);
+
+    return *cipher != NULL;
+}
+
+/******************************************************************************
+ *
+ * Digests
+ *
+ * Because they all do the same basic operation, we have only one set of
+ * method functions for them all to share, and a mapping table between
+ * NIDs and cryptodev IDs, with all the necessary size data.
+ *
+ *****/
+
+struct digest_ctx {
+    int cfd;
+    struct session_op sess;
+    int init;
+};
+
+static const struct digest_data_st {
+    int nid;
+    int digestlen;
+    int devcryptoid;
+} digest_data[] = {
+#ifndef OPENSSL_NO_MD5
+    { NID_md5, 16, CRYPTO_MD5 },
+#endif
+    { NID_sha1, 20, CRYPTO_SHA1 },
+#ifndef OPENSSL_NO_RMD160
+# if !defined(CHECK_BSD_STYLE_MACROS) && defined(CRYPTO_RIPEMD160)
+    { NID_ripemd160, 20, CRYPTO_RIPEMD160 },
+# endif
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) && defined(CRYPTO_SHA2_224)
+    { NID_sha224, 224 / 8, CRYPTO_SHA2_224 },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) && defined(CRYPTO_SHA2_256)
+    { NID_sha256, 256 / 8, CRYPTO_SHA2_256 },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) && defined(CRYPTO_SHA2_384)
+    { NID_sha384, 384 / 8, CRYPTO_SHA2_384 },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) && defined(CRYPTO_SHA2_512)
+    { NID_sha512, 512 / 8, CRYPTO_SHA2_512 },
+#endif
+};
+
+static size_t get_digest_data_index(int nid)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(digest_data); i++)
+        if (nid == digest_data[i].nid)
+            return i;
+
+    /*
+     * Code further down must make sure that only NIDs in the table above
+     * are used.  If any other NID reaches this function, there's a grave
+     * coding error further down.
+     */
+    assert("Code that never should be reached" == NULL);
+    return -1;
+}
+
+static const struct digest_data_st *get_digest_data(int nid)
+{
+    return &digest_data[get_digest_data_index(nid)];
+}
+
+/*
+ * Following are the four necessary functions to map OpenSSL functionality
+ * with cryptodev.
+ */
+
+static int digest_init(EVP_MD_CTX *ctx)
+{
+    struct digest_ctx *digest_ctx =
+        (struct digest_ctx *)EVP_MD_CTX_md_data(ctx);
+    const struct digest_data_st *digest_d =
+        get_digest_data(EVP_MD_CTX_type(ctx));
+
+    if (digest_ctx->init == 0
+        && (digest_ctx->cfd = open("/dev/crypto", O_RDWR, 0)) < 0) {
+        SYSerr(SYS_F_OPEN, errno);
+        return 0;
+    }
+
+    digest_ctx->init = 1;
+
+    memset(&digest_ctx->sess, 0, sizeof(digest_ctx->sess));
+    digest_ctx->sess.mac = digest_d->devcryptoid;
+    if (ioctl(digest_ctx->cfd, CIOCGSESSION, &digest_ctx->sess) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        close(digest_ctx->cfd);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
+{
+    struct digest_ctx *digest_ctx =
+        (struct digest_ctx *)EVP_MD_CTX_md_data(ctx);
+    struct crypt_op cryp;
+
+    memset(&cryp, 0, sizeof(cryp));
+    cryp.ses = digest_ctx->sess.ses;
+    cryp.len = count;
+    cryp.src = (void *)data;
+    cryp.flags = COP_FLAG_UPDATE;
+    if (ioctl(digest_ctx->cfd, CIOCCRYPT, &cryp) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
+{
+    struct digest_ctx *digest_ctx =
+        (struct digest_ctx *)EVP_MD_CTX_md_data(ctx);
+    struct crypt_op cryp;
+
+    memset(&cryp, 0, sizeof(cryp));
+    cryp.ses = digest_ctx->sess.ses;
+    cryp.len = 0;
+    cryp.src = NULL;
+    cryp.mac = (void *)md;
+    cryp.flags = COP_FLAG_FINAL;
+    if (ioctl(digest_ctx->cfd, CIOCCRYPT, &cryp) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        return 0;
+    }
+    if (ioctl(digest_ctx->cfd, CIOCFSESSION, &digest_ctx->sess) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int digest_cleanup(EVP_MD_CTX *ctx)
+{
+    struct digest_ctx *digest_ctx =
+        (struct digest_ctx *)EVP_MD_CTX_md_data(ctx);
+
+    if (close(digest_ctx->cfd) < 0) {
+        SYSerr(SYS_F_CLOSE, errno);
+        return 0;
+    }
+
+    return 1;
+}
+
+/*
+ * Keep a table of known nids and associated methods.
+ * Note that known_digest_nids[] isn't necessarely indexed the same way as
+ * digest_data[] above, which known_digest_methods[] is.
+ */
+static int known_digest_nids[OSSL_NELEM(digest_data)];
+static int known_digest_nids_amount = -1; /* -1 indicates not yet initialised */
+static EVP_MD *known_digest_methods[OSSL_NELEM(digest_data)] = { NULL, };
+
+static void prepare_digest_methods()
+{
+    size_t i;
+
+    for (i = 0, known_digest_nids_amount = 0; i < OSSL_NELEM(digest_data); i++)
+        if ((known_digest_methods[i] = EVP_MD_meth_new(digest_data[i].nid,
+                                                       NID_undef)) == NULL
+            || !EVP_MD_meth_set_result_size(known_digest_methods[i],
+                                            digest_data[i].digestlen)
+#if 0
+            || !EVP_MD_meth_set_flags(known_digest_methods[i],
+                                      digest_data[i].flags)
+#endif
+            || !EVP_MD_meth_set_init(known_digest_methods[i], digest_init)
+            || !EVP_MD_meth_set_update(known_digest_methods[i], digest_update)
+            || !EVP_MD_meth_set_final(known_digest_methods[i], digest_final)
+            || !EVP_MD_meth_set_cleanup(known_digest_methods[i], digest_cleanup)
+            || !EVP_MD_meth_set_app_datasize(known_digest_methods[i],
+                                             sizeof(struct digest_ctx))) {
+            EVP_MD_meth_free(known_digest_methods[i]);
+            known_digest_methods[i] = NULL;
+        } else {
+            known_digest_nids[known_digest_nids_amount++] = digest_data[i].nid;
+        }
+}
+
+static const EVP_MD *get_digest_method(int nid)
+{
+    size_t i = get_digest_data_index(nid);
+
+    if (i == (size_t)-1)
+        return NULL;
+    return known_digest_methods[i];
+}
+
+static int get_digest_nids(const int **nids)
+{
+    *nids = known_digest_nids;
+    return known_digest_nids_amount;
+}
+
+static void destroy_digest_method(int nid)
+{
+    size_t i = get_digest_data_index(nid);
+
+    EVP_MD_meth_free(known_digest_methods[i]);
+    known_digest_methods[i] = NULL;
+}
+
+static void destroy_all_digest_methods()
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(digest_data); i++)
+        destroy_digest_method(digest_data[i].nid);
+}
+
+static int devcrypto_digests(ENGINE *e, const EVP_MD **digest,
+                             const int **nids, int nid)
+{
+    if (digest == NULL)
+        return get_digest_nids(nids);
+
+    *digest = get_digest_method(nid);
+
+    return *digest != NULL;
+}
+
+/******************************************************************************
+ *
+ * LOAD / UNLOAD
+ *
+ *****/
+
+static int devcrypto_unload(ENGINE *e)
+{
+    destroy_all_cipher_methods();
+    destroy_all_digest_methods();
+    return 1;
+}
+/*
+ * This engine is always built into libcrypto, so it doesn't offer any
+ * ability to be dynamically loadable.
+ */
+void engine_load_devcrypto_int()
+{
+    ENGINE *e = NULL;
+
+    if (access("/dev/crypto", R_OK | W_OK) < 0) {
+        fprintf(stderr,
+                "/dev/crypto not present, not enabling devcrypto engine\n");
+        return;
+    }
+
+    prepare_cipher_methods();
+    prepare_digest_methods();
+
+    if ((e = ENGINE_new()) == NULL)
+        return;
+
+    if (!ENGINE_set_id(e, "devcrypto")
+        || !ENGINE_set_name(e, "/dev/crypto engine")
+        || !ENGINE_set_destroy_function(e, devcrypto_unload)
+#if 0                            /* Not supported yet */
+# ifndef OPENSSL_NO_RSA
+        || !ENGINE_set_RSA(e, devcrypto_rsa)
+# endif
+# ifndef OPENSSL_NO_DSA
+        || !ENGINE_set_DSA(e, devcrypto_dsa)
+# endif
+# ifndef OPENSSL_NO_DH
+        || !ENGINE_set_DH(e, devcrypto_dh)
+# endif
+# ifndef OPENSSL_NO_EC
+        || !ENGINE_set_EC(e, devcrypto_ec)
+# endif
+#endif
+        || !ENGINE_set_ciphers(e, devcrypto_ciphers)
+        || !ENGINE_set_digests(e, devcrypto_digests)) {
+        ENGINE_free(e);
+        return;
+    }
+
+    ENGINE_add(e);
+    ENGINE_free(e);          /* Loose our local reference */
+    ERR_clear_error();
+}

--- a/crypto/engine/eng_err.c
+++ b/crypto/engine/eng_err.c
@@ -14,6 +14,7 @@
 #ifndef OPENSSL_NO_ERR
 
 static const ERR_STRING_DATA ENGINE_str_functs[] = {
+    {ERR_PACK(ERR_LIB_ENGINE, ENGINE_F_DIGEST_UPDATE, 0), "digest_update"},
     {ERR_PACK(ERR_LIB_ENGINE, ENGINE_F_DYNAMIC_CTRL, 0), "dynamic_ctrl"},
     {ERR_PACK(ERR_LIB_ENGINE, ENGINE_F_DYNAMIC_GET_DATA_CTX, 0),
      "dynamic_get_data_ctx"},

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -117,6 +117,7 @@ static ERR_STRING_DATA ERR_str_reasons[] = {
     {ERR_R_INTERNAL_ERROR, "internal error"},
     {ERR_R_DISABLED, "called a function that was disabled at compile-time"},
     {ERR_R_INIT_FAIL, "init fail"},
+    {ERR_R_OPERATION_FAIL, "operation fail"},
 
     {0, NULL},
 };

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -84,6 +84,9 @@ static ERR_STRING_DATA ERR_str_functs[] = {
     {ERR_PACK(0, SYS_F_GETSOCKNAME, 0), "getsockname"},
     {ERR_PACK(0, SYS_F_GETHOSTBYNAME, 0), "gethostbyname"},
     {ERR_PACK(0, SYS_F_FFLUSH, 0), "fflush"},
+    {ERR_PACK(0, SYS_F_OPEN, 0), "open"},
+    {ERR_PACK(0, SYS_F_CLOSE, 0), "close"},
+    {ERR_PACK(0, SYS_F_IOCTL, 0), "ioctl"},
     {0, NULL},
 };
 

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -589,6 +589,7 @@ EC_F_PKEY_EC_DERIVE:217:pkey_ec_derive
 EC_F_PKEY_EC_KEYGEN:199:pkey_ec_keygen
 EC_F_PKEY_EC_PARAMGEN:219:pkey_ec_paramgen
 EC_F_PKEY_EC_SIGN:218:pkey_ec_sign
+ENGINE_F_DIGEST_UPDATE:198:digest_update
 ENGINE_F_DYNAMIC_CTRL:180:dynamic_ctrl
 ENGINE_F_DYNAMIC_GET_DATA_CTX:181:dynamic_get_data_ctx
 ENGINE_F_DYNAMIC_LOAD:182:dynamic_load

--- a/crypto/include/internal/engine.h
+++ b/crypto/include/internal/engine.h
@@ -10,6 +10,7 @@
 #include <openssl/engine.h>
 
 void engine_load_openssl_int(void);
+void engine_load_devcrypto_int(void);
 void engine_load_rdrand_int(void);
 void engine_load_dynamic_int(void);
 void engine_load_padlock_int(void);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -241,6 +241,18 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
     engine_load_openssl_int();
     return 1;
 }
+# ifndef OPENSSL_NO_DEVCRYPTOENG
+static CRYPTO_ONCE engine_devcrypto = CRYPTO_ONCE_STATIC_INIT;
+DEFINE_RUN_ONCE_STATIC(ossl_init_engine_devcrypto)
+{
+#  ifdef OPENSSL_INIT_DEBUG
+    fprintf(stderr, "OPENSSL_INIT: ossl_init_engine_devcrypto: "
+                    "engine_load_devcrypto_int()\n");
+#  endif
+    engine_load_devcrypto_int();
+    return 1;
+}
+# endif
 
 # ifndef OPENSSL_NO_RDRAND
 static CRYPTO_ONCE engine_rdrand = CRYPTO_ONCE_STATIC_INIT;
@@ -560,6 +572,11 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     if ((opts & OPENSSL_INIT_ENGINE_OPENSSL)
             && !RUN_ONCE(&engine_openssl, ossl_init_engine_openssl))
         return 0;
+# if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_DEVCRYPTOENG)
+    if ((opts & OPENSSL_INIT_ENGINE_CRYPTODEV)
+            && !RUN_ONCE(&engine_devcrypto, ossl_init_engine_devcrypto))
+        return 0;
+# endif
 # ifndef OPENSSL_NO_RDRAND
     if ((opts & OPENSSL_INIT_ENGINE_RDRAND)
             && !RUN_ONCE(&engine_rdrand, ossl_init_engine_rdrand))

--- a/include/openssl/engineerr.h
+++ b/include/openssl/engineerr.h
@@ -22,6 +22,7 @@ int ERR_load_ENGINE_strings(void);
 /*
  * ENGINE function codes.
  */
+# define ENGINE_F_DIGEST_UPDATE                           198
 # define ENGINE_F_DYNAMIC_CTRL                            180
 # define ENGINE_F_DYNAMIC_GET_DATA_CTX                    181
 # define ENGINE_F_DYNAMIC_LOAD                            182

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -160,6 +160,9 @@ typedef struct err_state_st {
 # define SYS_F_GETSOCKNAME       16
 # define SYS_F_GETHOSTBYNAME     17
 # define SYS_F_FFLUSH            18
+# define SYS_F_OPEN              19
+# define SYS_F_CLOSE             20
+# define SYS_F_IOCTL             21
 
 /* reasons */
 # define ERR_R_SYS_LIB   ERR_LIB_SYS/* 2 */

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -192,6 +192,7 @@ typedef struct err_state_st {
 # define ERR_R_DISABLED                          (5|ERR_R_FATAL)
 # define ERR_R_INIT_FAIL                         (6|ERR_R_FATAL)
 # define ERR_R_PASSED_INVALID_ARGUMENT           (7)
+# define ERR_R_OPERATION_FAIL                    (8|ERR_R_FATAL)
 
 /*
  * 99 is the maximum possible ERR_R_... code, higher values are reserved for


### PR DESCRIPTION
Add a new devcrypto engine.  This has been implemented based on [cryptodev-linux](https://github.com/cryptodev-linux/cryptodev-linux) and then adjusted to work on FreeBSD 8.4.  It is assumed to build on other BSD platforms as well (**testers welcome!**).

To enable on non-BSD platforms, add `-DOPENSSL_USE_DEVCRYPTO` to your configuration.

Assymetric operations are *not* supported due to the deplaurable documentation.