### PR TITLE
Remove uses of the TEST_check macro.

### DIFF
--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL licenses, (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,6 +9,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include <openssl/opensslconf.h>
 #include <openssl/err.h>
@@ -27,14 +28,27 @@ typedef struct cipherlist_test_fixture {
 } CIPHERLIST_TEST_FIXTURE;
 
 
-static CIPHERLIST_TEST_FIXTURE set_up(const char *const test_case_name)
+static void tear_down(CIPHERLIST_TEST_FIXTURE *fixture)
 {
-    CIPHERLIST_TEST_FIXTURE fixture;
+    if (fixture != NULL) {
+        SSL_CTX_free(fixture->server);
+        SSL_CTX_free(fixture->client);
+        fixture->server = fixture->client = NULL;
+    }
+}
+
+static CIPHERLIST_TEST_FIXTURE *set_up(const char *const test_case_name)
+{
+    static CIPHERLIST_TEST_FIXTURE fixture;
+
+    memset(&fixture, 0, sizeof(fixture));
     fixture.test_case_name = test_case_name;
-    fixture.server = SSL_CTX_new(TLS_server_method());
-    fixture.client = SSL_CTX_new(TLS_client_method());
-    TEST_check(fixture.client != NULL && fixture.server != NULL);
-    return fixture;
+    if (!TEST_ptr(fixture.server = SSL_CTX_new(TLS_server_method()))
+            || !TEST_ptr(fixture.client = SSL_CTX_new(TLS_client_method()))) {
+        tear_down(&fixture);
+        return NULL;
+    }
+    return &fixture;
 }
 
 /*
@@ -123,16 +137,18 @@ static const uint32_t default_ciphers_in_order[] = {
 
 static int test_default_cipherlist(SSL_CTX *ctx)
 {
-    STACK_OF(SSL_CIPHER) *ciphers;
-    SSL *ssl;
+    STACK_OF(SSL_CIPHER) *ciphers = NULL;
+    SSL *ssl = NULL;
     int i, ret = 0, num_expected_ciphers, num_ciphers;
     uint32_t expected_cipher_id, cipher_id;
 
-    ssl = SSL_new(ctx);
-    TEST_check(ssl != NULL);
+    if (ctx == NULL)
+        return 0;
 
-    ciphers = SSL_get1_supported_ciphers(ssl);
-    TEST_check(ciphers != NULL);
+    if (!TEST_ptr(ssl = SSL_new(ctx))
+            || !TEST_ptr(ciphers = SSL_get1_supported_ciphers(ssl)))
+        goto err;
+
     num_expected_ciphers = OSSL_NELEM(default_ciphers_in_order);
     num_ciphers = sk_SSL_CIPHER_num(ciphers);
     if (!TEST_int_eq(num_ciphers, num_expected_ciphers))
@@ -155,20 +171,15 @@ static int test_default_cipherlist(SSL_CTX *ctx)
     return ret;
 }
 
-static int execute_test(CIPHERLIST_TEST_FIXTURE fixture)
+static int execute_test(CIPHERLIST_TEST_FIXTURE *fixture)
 {
-    return test_default_cipherlist(fixture.server)
-        && test_default_cipherlist(fixture.client);
-}
-
-static void tear_down(CIPHERLIST_TEST_FIXTURE fixture)
-{
-    SSL_CTX_free(fixture.server);
-    SSL_CTX_free(fixture.client);
+    return fixture != NULL
+        && test_default_cipherlist(fixture->server)
+        && test_default_cipherlist(fixture->client);
 }
 
 #define SETUP_CIPHERLIST_TEST_FIXTURE() \
-    SETUP_TEST_FIXTURE(CIPHERLIST_TEST_FIXTURE, set_up)
+    SETUP_TEST_FIXTURE(CIPHERLIST_TEST_FIXTURE *, set_up)
 
 #define EXECUTE_CIPHERLIST_TEST() \
     EXECUTE_TEST(execute_test, tear_down)
@@ -182,8 +193,11 @@ static int test_default_cipherlist_implicit()
 static int test_default_cipherlist_explicit()
 {
     SETUP_CIPHERLIST_TEST_FIXTURE();
-    TEST_check(SSL_CTX_set_cipher_list(fixture.server, "DEFAULT"));
-    TEST_check(SSL_CTX_set_cipher_list(fixture.client, "DEFAULT"));
+    if (fixture == NULL)
+        return 0;
+    if (!TEST_true(SSL_CTX_set_cipher_list(fixture->server, "DEFAULT"))
+            || !TEST_true(SSL_CTX_set_cipher_list(fixture->client, "DEFAULT")))
+        tear_down(fixture);
     EXECUTE_CIPHERLIST_TEST();
 }
 

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -393,7 +393,7 @@ void test_perror(const char *s);
 /*
  * For "impossible" conditions such as malloc failures or bugs in test code,
  * where continuing the test would be meaningless. Note that OPENSSL_assert
- * is fatal, and is never compiled out.
+ * is fatal, and is never compiled out.  This macro should be avoided.
  */
 # define TEST_check(condition)                  \
     do {                                        \


### PR DESCRIPTION
- [x] tests are added or updated

This macro aborts the test which prevents later tests from executing.  It also
bypasses the test framework output functionality.

The only remaining uses of `TEST_check` are in `handshake_helper.c`

There doesn't appear to be a documented way to error out/return early from a function that uses `SETUP_TEST_FIXTURE` which is required here.