### PR TITLE
Fix OBJ_create() to tolerate a NULL sn and ln

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -684,7 +684,8 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
     int ok = 0;
 
     /* Check to see if short or long name already present */
-    if (OBJ_sn2nid(sn) != NID_undef || OBJ_ln2nid(ln) != NID_undef) {
+    if ((sn != NULL && OBJ_sn2nid(sn) != NID_undef)
+            || (ln != NULL && OBJ_ln2nid(ln) != NID_undef)) {
         OBJerr(OBJ_F_OBJ_CREATE, OBJ_R_OID_EXISTS);
         return 0;
     }


### PR DESCRIPTION
In 1.0.2 and before OBJ_create() allowed the sn or ln parameter to be NULL.
Commit 52832e47 changed that so that it crashed if they were NULL.

This was causing problems with the built-in config oid module. If a long
name was provided OBJ_create() is initially called with a NULL ln and
therefore causes a crash.

Fixes #3733
