### PR TITLE
Fix the constant time 64 test

### DIFF
--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -332,6 +332,6 @@ void register_tests(void)
     ADD_TEST(test_sizeofs);
     ADD_ALL_TESTS(test_binops, OSSL_NELEM(test_values));
     ADD_ALL_TESTS(test_signed, OSSL_NELEM(signed_test_values));
-    ADD_ALL_TESTS(test_8values, sizeof(test_values_8));
-    ADD_ALL_TESTS(test_64values, sizeof(test_values_64));
+    ADD_ALL_TESTS(test_8values, OSSL_NELEM(test_values_8));
+    ADD_ALL_TESTS(test_64values, OSSL_NELEM(test_values_64));
 }


### PR DESCRIPTION
We were adding more tests than we had data for due to use of
sizeof instead of OSSL_NELEM. I also changed the 8 bit tests
for consistency, although they were already working.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
