### PR TITLE
Fix travis clang-3.9 builds

### DIFF
--- a/.travis-apt-pin.preferences
+++ b/.travis-apt-pin.preferences
@@ -1,0 +1,15 @@
+Package: clang-3.9
+Pin: release o=Ubuntu
+Pin-Priority: -1
+
+Package: libclang-common-3.9-dev
+Pin: release o=Ubuntu
+Pin-Priority: -1
+
+Package: libclang1-3.9
+Pin: release o=Ubuntu
+Pin-Priority: -1
+
+Package: libllvm3.9v4
+Pin: release o=Ubuntu
+Pin-Priority: -1

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,6 @@ matrix:
           compiler: gcc-5
           env: CONFIG_OPTS="--strict-warnings enable-tls1_3" TESTS="-test_fuzz" COMMENT="Move to the BORINGTEST build when interoperable"
         - os: linux
-          addons:
-              apt:
-                  packages:
-                      - clang-3.9
-                  sources:
-                      - llvm-toolchain-trusty-3.9
-                      - ubuntu-toolchain-r-test
           compiler: clang-3.9
           env: CONFIG_OPTS="--strict-warnings no-deprecated" BUILDONLY="yes"
         - os: linux
@@ -83,33 +76,12 @@ matrix:
           compiler: gcc-5
           env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-external-tests" BORINGSSL_TESTS="yes" CXX="g++-5" TESTS=95
         - os: linux
-          addons:
-              apt:
-                  packages:
-                      - clang-3.9
-                  sources:
-                      - llvm-toolchain-trusty-3.9
-                      - ubuntu-toolchain-r-test
           compiler: clang-3.9
           env: EXTENDED_TEST="yes" CONFIG_OPTS="enable-msan"
         - os: linux
-          addons:
-              apt:
-                  packages:
-                      - clang-3.9
-                  sources:
-                      - llvm-toolchain-trusty-3.9
-                      - ubuntu-toolchain-r-test
           compiler: clang-3.9
           env:  EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-aria enable-ssl3 enable-ssl3-method enable-nextprotoneg -fno-sanitize=alignment no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
         - os: linux
-          addons:
-              apt:
-                  packages:
-                      - clang-3.9
-                  sources:
-                      - llvm-toolchain-trusty-3.9
-                      - ubuntu-toolchain-r-test
           compiler: clang-3.9
           env: EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2 enable-aria no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
         - os: linux
@@ -167,7 +139,14 @@ before_script:
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
       else
-          if which ccache >/dev/null && [ "$CC" != clang-3.9 ]; then
+          if [ "$CC" == clang-3.9 ]; then
+              sudo cp .travis-apt-pin.preferences /etc/apt/preferences.d/no-ubuntu-clang;
+              curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -;
+              echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee -a /etc/apt/sources.list > /dev/null;
+              sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test";
+              sudo -E apt-get -yq update;
+              sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-3.9;
+          elif which ccache >/dev/null; then
               CC="ccache $CC";
           fi;
           $srcdir/config -v $CONFIG_OPTS;


### PR DESCRIPTION
Something environmental changed in travis so that it started preferring
the ubuntu clang-3.9 version instead of the llvm.org one. This breaks the
sanitiser based builds. This change forces travis to de-prioritise the
ubuntu clang packages.

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
