### PR TITLE
Fix return value checking for BIO_sock_init

### DIFF
--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -62,7 +62,7 @@ int init_client(int *sock, const char *host, const char *port,
     const BIO_ADDRINFO *ai = NULL;
     int ret;
 
-    if (!BIO_sock_init())
+    if (BIO_sock_init() != 1)
         return 0;
 
     ret = BIO_lookup_ex(host, port, BIO_LOOKUP_CLIENT, family, type, protocol,
@@ -161,7 +161,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
     BIO_ADDRINFO *res = NULL;
     int ret = 0;
 
-    if (!BIO_sock_init())
+    if (BIO_sock_init() != 1)
         return 0;
 
     if (!BIO_lookup_ex(host, port, BIO_LOOKUP_SERVER, family, type, protocol,

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1135,7 +1135,7 @@ static int create_sctp_socks(int *ssock, int *csock)
     int ret = 0;
     int family = 0;
 
-    if (!BIO_sock_init())
+    if (BIO_sock_init() != 1)
         return 0;
 
     /*


### PR DESCRIPTION
BIO_sock_init returns `-1` on error, not `0`,  so it's needed to check
explicitly instead of using `!`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
