### PR TITLE
tsget.in: remove call of WWW::Curl::Easy::global_cleanup

### DIFF
--- a/apps/tsget.in
+++ b/apps/tsget.in
@@ -198,4 +198,3 @@ REQUEST: foreach (@ARGV) {
     STDERR->printflush(", $output written.\n") if $options{v};
 }
 $curl->cleanup();
-WWW::Curl::Easy::global_cleanup();


### PR DESCRIPTION
This function is undocumented, but similarly named functions (such as
'curl_global_cleanup') are documented as internals that should not be
called by scripts.

Fixes #3765
