### PR TITLE
tsget: remove call of WWW::Curl::Easy::global_cleanup (1.0.2)

### DIFF
--- a/apps/tsget
+++ b/apps/tsget
@@ -193,4 +193,3 @@ REQUEST: foreach (@ARGV) {
     STDERR->printflush(", $output written.\n") if $options{v};
 }
 $curl->cleanup();
-WWW::Curl::Easy::global_cleanup();


### PR DESCRIPTION
This function is undocumented, but similarly named functions (such as
'curl_global_cleanup') are documented as internals that should not be
called by scripts.

Fixes #3765
