### PR TITLE
ssl_session_dup() missing ext.alpn_session

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -122,6 +122,7 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
     dest->ext.supportedgroups = NULL;
 #endif
     dest->ext.tick = NULL;
+    dest->ext.alpn_selected = NULL;
 #ifndef OPENSSL_NO_SRP
     dest->srp_username = NULL;
 #endif
@@ -210,6 +211,15 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
     } else {
         dest->ext.tick_lifetime_hint = 0;
         dest->ext.ticklen = 0;
+    }
+
+    if (src->ext.alpn_selected) {
+        dest->ext.alpn_selected =
+            (unsigned char*)OPENSSL_strndup((char*)src->ext.alpn_selected,
+                                            src->ext.alpn_selected_len);
+        if (dest->ext.alpn_selected == NULL) {
+            goto err;
+        }
     }
 
 #ifndef OPENSSL_NO_SRP


### PR DESCRIPTION
Properly copy ext.alpn_session in ssl_session_dup()
Use OPENSSL_strndup() as that's used in ssl_asn1.c

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

