### PR TITLE
Fix return-value checks in OCSP_resp_get1_id()

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -230,7 +230,7 @@ int OCSP_resp_get1_id(const OCSP_BASICRESP *bs,
     } else {
         return 0;
     }
-    if (pname == NULL && pid == NULL)
+    if (*pname == NULL && *pid == NULL)
         return 0;
     return 1;
 }


### PR DESCRIPTION
Commit db17e43d882ecde217e1dce4a2b8c76c3ed134bf added the function
but would improperly report success if the underlying dup operation
failed.

