### PR TITLE
Rename static global "lock" to "obj_lock"

### DIFF
--- a/crypto/objects/o_names.c
+++ b/crypto/objects/o_names.c
@@ -45,7 +45,7 @@ static int obj_strcmp(const char *a, const char *b)
  */
 static LHASH_OF(OBJ_NAME) *names_lh = NULL;
 static int names_type_num = OBJ_NAME_TYPE_NUM;
-static CRYPTO_RWLOCK *lock = NULL;
+static CRYPTO_RWLOCK *obj_lock = NULL;
 
 struct name_funcs_st {
     unsigned long (*hash_func) (const char *name);
@@ -69,9 +69,9 @@ DEFINE_RUN_ONCE_STATIC(o_names_init)
 {
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE);
     names_lh = lh_OBJ_NAME_new(obj_name_hash, obj_name_cmp);
-    lock = CRYPTO_THREAD_lock_new();
+    obj_lock = CRYPTO_THREAD_lock_new();
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
-    return names_lh != NULL && lock != NULL;
+    return names_lh != NULL && obj_lock != NULL;
 }
 
 int OBJ_NAME_init(void)
@@ -89,7 +89,7 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
     if (!OBJ_NAME_init())
         return 0;
 
-    CRYPTO_THREAD_write_lock(lock);
+    CRYPTO_THREAD_write_lock(obj_lock);
 
     if (name_funcs_stack == NULL) {
         CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_DISABLE);
@@ -134,7 +134,7 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
         name_funcs->free_func = free_func;
 
 out:
-    CRYPTO_THREAD_unlock(lock);
+    CRYPTO_THREAD_unlock(obj_lock);
     return ret;
 }
 
@@ -180,7 +180,7 @@ const char *OBJ_NAME_get(const char *name, int type)
         return NULL;
     if (!OBJ_NAME_init())
         return NULL;
-    CRYPTO_THREAD_read_lock(lock);
+    CRYPTO_THREAD_read_lock(obj_lock);
 
     alias = type & OBJ_NAME_ALIAS;
     type &= ~OBJ_NAME_ALIAS;
@@ -202,7 +202,7 @@ const char *OBJ_NAME_get(const char *name, int type)
         }
     }
 
-    CRYPTO_THREAD_unlock(lock);    
+    CRYPTO_THREAD_unlock(obj_lock);
     return value;
 }
 
@@ -212,9 +212,9 @@ int OBJ_NAME_add(const char *name, int type, const char *data)
     int alias, ok = 0;
 
     if (!OBJ_NAME_init())
-        return 0;    
+        return 0;
 
-    CRYPTO_THREAD_write_lock(lock);
+    CRYPTO_THREAD_write_lock(obj_lock);
 
     alias = type & OBJ_NAME_ALIAS;
     type &= ~OBJ_NAME_ALIAS;
@@ -255,7 +255,7 @@ int OBJ_NAME_add(const char *name, int type, const char *data)
     ok = 1;
 
 unlock:
-    CRYPTO_THREAD_unlock(lock);
+    CRYPTO_THREAD_unlock(obj_lock);
     return ok;
 }
 
@@ -267,7 +267,7 @@ int OBJ_NAME_remove(const char *name, int type)
     if (!OBJ_NAME_init())
         return 0;
 
-    CRYPTO_THREAD_write_lock(lock);
+    CRYPTO_THREAD_write_lock(obj_lock);
 
     type &= ~OBJ_NAME_ALIAS;
     on.name = name;
@@ -289,7 +289,7 @@ int OBJ_NAME_remove(const char *name, int type)
         ok = 1;
     }
 
-    CRYPTO_THREAD_unlock(lock);
+    CRYPTO_THREAD_unlock(obj_lock);
     return ok;
 }
 
@@ -398,10 +398,10 @@ void OBJ_NAME_cleanup(int type)
     if (type < 0) {
         lh_OBJ_NAME_free(names_lh);
         sk_NAME_FUNCS_pop_free(name_funcs_stack, name_funcs_free);
-        CRYPTO_THREAD_lock_free(lock);
+        CRYPTO_THREAD_lock_free(obj_lock);
         names_lh = NULL;
         name_funcs_stack = NULL;
-        lock = NULL;
+        obj_lock = NULL;
     } else
         lh_OBJ_NAME_set_down_load(names_lh, down_load);
 }


### PR DESCRIPTION
Breaks djgpp, masks a common kernel function name.
Thanks to Gisle Vanem for pointing this out.

See his comment at https://github.com/openssl/openssl/commit/be606c013d31847718ceb5d97c567988a771c2e5#commitcomment-22768254
