### PR TITLE
crypto/mem.c: on Windows, use rand() instead of random()

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -112,6 +112,14 @@ static void parseit(void)
 }
 
 /*
+ * Windows doesn't have random(), but it has rand()
+ * Some rand() implementations aren't good, but we're not
+ * dealing with secure randomness here.
+ */
+#ifdef _WIN32
+# define random() rand()
+#endif
+/*
  * See if the current malloc should fail.
  */
 static int shouldfail(void)


### PR DESCRIPTION
Windows doesn't provide random().  In this particular case, our
requirements on the quality of randomness isn't high, so we don't
need to care how good randomness rand() does or doesn't provide.

Fixes #3778
