### PR TITLE
util/mkerr.pl: allow module names prefixed with OSSL_ or OPENSSL_

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,17 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Module names can prefixed with OSSL_ or OPENSSL_.  This affects
+     util/mkerr.pl, which is adapted to allow those prefixes, leading to
+     error code calls like this:
+
+         OSSL_FOOerr(OSSL_FOO_F_SOMETHING, OSSL_FOO_R_WHATEVER);
+
+     With this change, we claim the namespaces OSSL and OPENSSL in a manner
+     that can be encoded in C.  For the foreseeable future, this will only
+     affect new modules.
+     [Richard Levitte and Tim Hudson]
+
   *) Removed BSD cryptodev engine.
      [Rich Salz]
 

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@
 
   Major changes between OpenSSL 1.1.0f and OpenSSL 1.1.1 [under development]
 
-      o
+      o Claim the namespaces OSSL and OPENSSL, represented as symbol prefixes
 
   Major changes between OpenSSL 1.1.0e and OpenSSL 1.1.0f [25 May 2017]
 

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -486,6 +486,7 @@ EOF
     print OUT "\n/*\n * $lib function codes.\n */\n";
     foreach my $i ( @function ) {
         my $z = 48 - length($i);
+        $z = 0 if $z < 0;
         if ( $fcodes{$i} eq "X" ) {
             $fassigned{$lib} =~ m/^:([^:]*):/;
             my $findcode = $1;
@@ -503,6 +504,7 @@ EOF
     print OUT "\n/*\n * $lib reason codes.\n */\n";
     foreach my $i ( @reasons ) {
         my $z = 48 - length($i);
+        $z = 0 if $z < 0;
         if ( $rcodes{$i} eq "X" ) {
             $rassigned{$lib} =~ m/^:([^:]*):/;
             my $findcode = $1;

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -198,14 +198,14 @@ if ( ! $reindex && $statefile ) {
             die "Bad line in $statefile:\n$_\n";
         }
         my $lib = $name;
-        $lib =~ s/_.*//;
+        $lib =~ s/^((?:OSSL_|OPENSSL_)?[^_]{2,}).*$/$1/;
         $lib = "SSL" if $lib =~ /TLS/;
         if ( !defined $errorfile{$lib} ) {
             print "Skipping $_";
             $skippedstate++;
             next;
         }
-        if ( $name =~ /^[A-Z0-9]+_R_/ ) {
+        if ( $name =~ /^(?:OSSL_|OPENSSL_)?[A-Z0-9]{2,}_R_/ ) {
             die "$lib reason code $code collision at $name\n"
                 if $rassigned{$lib} =~ /:$code:/;
             $rassigned{$lib} .= "$code:";
@@ -213,7 +213,7 @@ if ( ! $reindex && $statefile ) {
                 $rmax{$lib} = $code if $code > $rmax{$lib};
             }
             $rcodes{$name} = $code;
-        } elsif ( $name =~ /^[A-Z0-9]+_F_/ ) {
+        } elsif ( $name =~ /^(?:OSSL_|OPENSSL_)?[A-Z0-9]{2,}_F_/ ) {
             die "$lib function code $code collision at $name\n"
                 if $fassigned{$lib} =~ /:$code:/;
             $fassigned{$lib} .= "$code:";
@@ -378,7 +378,7 @@ foreach my $file ( @source ) {
             $func = $1;
         }
 
-        if ( /(([A-Z0-9]+)_F_([A-Z0-9_]+))/ ) {
+        if ( /(((?:OSSL_|OPENSSL_)?[A-Z0-9]{2,})_F_([A-Z0-9_]+))/ ) {
             next unless exists $errorfile{$2};
             next if $1 eq "BIO_F_BUFFER_CTX";
             $usedfuncs{$1} = 1;
@@ -395,7 +395,7 @@ foreach my $file ( @source ) {
             print STDERR "  Function $1 = $fcodes{$1}\n"
               if $debug;
         }
-        if ( /(([A-Z0-9]+)_R_[A-Z0-9_]+)/ ) {
+        if ( /(((?:OSSL_|OPENSSL_)?[A-Z0-9]{2,})_R_[A-Z0-9_]+)/ ) {
             next unless exists $errorfile{$2};
             $usedreasons{$1} = 1;
             if ( !exists $rcodes{$1} ) {


### PR DESCRIPTION
To make sure that our symbols don't clash with other libraries, we
claim the namespaces OSSL and OPENSSL.  Because C doesn't provide
namespaces, the only solution is to have them as prefixes on symbols,
thus we allow OSSL_ and OPENSSL_ as prefixes.

These namespace prefixes are optional for the foreseeable future, and
will only be used for new modules as needed on a case by case basis,
until further notice.

For extra safety, there's an added requirement that module names -
apart from the namespace prefix - be at least 2 characters long.
