### PR TITLE
TLSv1.3: Export keying material

### DIFF
--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -18,7 +18,8 @@ SSL_export_keying_material - obtain keying material for application use
 During the creation of a TLS or DTLS connection shared keying material is
 established between the two endpoints. The function SSL_export_keying_material()
 enables an application to use some of this keying material for its own purposes
-in accordance with RFC5705.
+in accordance with RFC5705 (for TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
+TODO(TLS1.3): Update the RFC number when the RFC is published.
 
 An application may need to securely establish the context within which this
 keying material will be used. For example this may include identifiers for the
@@ -32,8 +33,10 @@ pointed to by B<context> and should be B<contextlen> bytes long. Provision of
 a context is optional. If the context should be omitted entirely then
 B<use_context> should be set to 0. Otherwise it should be any other value. If
 B<use_context> is 0 then the values of B<context> and B<contextlen> are ignored.
-Note that a zero length context is treated differently to no context at all, and
-will result in different keying material being returned.
+Note that in TLSv1.2 and below a zero length context is treated differently to
+no context at all, and will result in different keying material being returned.
+In TLSv1.3 a zero length context is that same as no context at all and will
+result in the same keying material being returned.
 
 An application specific label should be provided in the location pointed to by
 B<label> and should be B<llen> bytes long. Typically this will be a value from

--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -33,7 +33,7 @@ pointed to by B<context> and should be B<contextlen> bytes long. Provision of
 a context is optional. If the context should be omitted entirely then
 B<use_context> should be set to 0. Otherwise it should be any other value. If
 B<use_context> is 0 then the values of B<context> and B<contextlen> are ignored.
-Note that in TLSv1.2 and below a zero length context is treated differently to
+Note that in TLSv1.2 and below a zero length context is treated differently from
 no context at all, and will result in different keying material being returned.
 In TLSv1.3 a zero length context is that same as no context at all and will
 result in the same keying material being returned.

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1073,6 +1073,7 @@ struct ssl_st {
     unsigned char handshake_traffic_hash[EVP_MAX_MD_SIZE];
     unsigned char client_app_traffic_secret[EVP_MAX_MD_SIZE];
     unsigned char server_app_traffic_secret[EVP_MAX_MD_SIZE];
+    unsigned char exporter_master_secret[EVP_MAX_MD_SIZE];
     EVP_CIPHER_CTX *enc_read_ctx; /* cryptographic state */
     unsigned char read_iv[EVP_MAX_IV_LENGTH]; /* TLSv1.3 static read IV */
     EVP_MD_CTX *read_hash;      /* used for mac generation */
@@ -2288,6 +2289,10 @@ __owur int tls1_export_keying_material(SSL *s, unsigned char *out, size_t olen,
                                        const char *label, size_t llen,
                                        const unsigned char *p, size_t plen,
                                        int use_context);
+__owur int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
+                                        const char *label, size_t llen,
+                                        const unsigned char *context,
+                                        size_t contextlen, int use_context);
 __owur int tls1_alert_code(int code);
 __owur int tls13_alert_code(int code);
 __owur int ssl3_alert_code(int code);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -82,7 +82,7 @@ SSL3_ENC_METHOD const TLSv1_3_enc_data = {
     TLS_MD_CLIENT_FINISH_CONST, TLS_MD_CLIENT_FINISH_CONST_SIZE,
     TLS_MD_SERVER_FINISH_CONST, TLS_MD_SERVER_FINISH_CONST_SIZE,
     tls13_alert_code,
-    tls1_export_keying_material,
+    tls13_export_keying_material,
     SSL_ENC_FLAG_SIGALGS | SSL_ENC_FLAG_SHA256_PRF,
     ssl3_set_handshake_header,
     tls_close_construct_packet,

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -611,10 +611,7 @@ int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
     unsigned int hashsize;
     int ret = 0;
 
-    if (ctx == NULL)
-        goto err;
-
-    if (!SSL_is_init_finished(s))
+    if (ctx == NULL || !SSL_is_init_finished(s))
         goto err;
 
     if (!use_context)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2493,7 +2493,7 @@ static int test_serverinfo(int tst)
  */
 static int test_export_key_mat(int tst)
 {
-    int testresult = 0, proto;
+    int testresult = 0;
     SSL_CTX *cctx = NULL, *sctx = NULL, *sctx2 = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     const char label[] = "test label";
@@ -2501,6 +2501,12 @@ static int test_export_key_mat(int tst)
     const unsigned char *emptycontext = NULL;
     unsigned char ckeymat1[80], ckeymat2[80], ckeymat3[80];
     unsigned char skeymat1[80], skeymat2[80], skeymat3[80];
+    const int protocols[] = {
+        TLS1_VERSION,
+        TLS1_1_VERSION,
+        TLS1_2_VERSION,
+        TLS1_3_VERSION
+    };
 
 #ifdef OPENSSL_NO_TLS1
     if (tst == 0)
@@ -2523,28 +2529,9 @@ static int test_export_key_mat(int tst)
                                        &cctx, cert, privkey)))
         goto end;
 
-    switch (tst) {
-    case 0:
-        proto = TLS1_VERSION;
-        break;
-
-    case 1:
-        proto = TLS1_1_VERSION;
-        break;
-
-    case 2:
-        proto = TLS1_2_VERSION;
-        break;
-
-    case 3:
-        proto = TLS1_3_VERSION;
-        break;
-
-    default:
-        goto end;
-    }
-    SSL_CTX_set_max_proto_version(cctx, proto);
-    SSL_CTX_set_min_proto_version(cctx, proto);
+    OPENSSL_assert(tst >= 0 && (size_t)tst < OSSL_NELEM(protocols));
+    SSL_CTX_set_max_proto_version(cctx, protocols[tst]);
+    SSL_CTX_set_min_proto_version(cctx, protocols[tst]);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
                                       NULL))


### PR DESCRIPTION
This updates SSL_export_keying_material() for TLSv1.3. I've added a test, but there are no test vectors available, so all it does is check that both sides create the same value and that it looks sane.

Fixes #3680
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
