### PR TITLE
No contractions

### DIFF
--- a/doc/man1/CA.pl.pod
+++ b/doc/man1/CA.pl.pod
@@ -194,7 +194,7 @@ can be used and the B<OPENSSL_CONF> environment variable changed to point to
 the correct path of the configuration file.
 
 The script is intended as a simple front end for the B<openssl> program for use
-by a beginner. Its behaviour isn't always what is wanted. For more control over the
+by a beginner. Its behaviour is not always what is wanted. For more control over the
 behaviour of the certificate commands call the B<openssl> command directly.
 
 =head1 SEE ALSO

--- a/doc/man1/asn1parse.pod
+++ b/doc/man1/asn1parse.pod
@@ -173,11 +173,11 @@ Parse a DER file:
 
 Generate a simple UTF8String:
 
- openssl asn1parse -genstr 'UTF8:Hello World'
+ openssl asn1parse -genstr "UTF8:Hello World"
 
 Generate and write out a UTF8String, do not print parsed output:
 
- openssl asn1parse -genstr 'UTF8:Hello World' -noout -out utf8.der
+ openssl asn1parse -genstr "UTF8:Hello World" -noout -out utf8.der
 
 Generate using a config file:
 

--- a/doc/man1/asn1parse.pod
+++ b/doc/man1/asn1parse.pod
@@ -54,7 +54,7 @@ combined with the B<-strparse> option.
 
 =item B<-noout>
 
-Don't output the parsed version of the input file.
+Do not output the parsed version of the input file.
 
 =item B<-offset number>
 
@@ -175,7 +175,7 @@ Generate a simple UTF8String:
 
  openssl asn1parse -genstr 'UTF8:Hello World'
 
-Generate and write out a UTF8String, don't print parsed output:
+Generate and write out a UTF8String, do not print parsed output:
 
  openssl asn1parse -genstr 'UTF8:Hello World' -noout -out utf8.der
 

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -137,7 +137,7 @@ The default is PEM.
 
 The password used to encrypt the private key. Since on some
 systems the command line arguments are visible (e.g. Unix with
-the 'ps' utility) this option should be used with caution.
+the L<ps(1)> utility) this option should be used with caution.
 
 =item B<-selfsign>
 
@@ -494,7 +494,7 @@ The same as B<-preserveDN>
 =item B<email_in_dn>
 
 The same as B<-noemailDN>. If you want the EMAIL field to be removed
-from the DN of the certificate simply set this to 'no'. If not present
+from the DN of the certificate simply set this to "no". If not present
 the default is to allow for the EMAIL filed in the certificate's DN.
 
 =item B<msie_hack>

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -363,7 +363,7 @@ include. If no CRL extension section is present then a V1 CRL is
 created, if the CRL extension section is present (even if it is
 empty) then a V2 CRL is created. The CRL extensions specified are
 CRL extensions and B<not> CRL entry extensions.  It should be noted
-that some software (for example Netscape) can't handle V2 CRLs. See
+that some software (for example Netscape) cannot handle V2 CRLs. See
 L<x509v3_config(5)> manual page for details of the
 extension section format.
 

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -465,7 +465,7 @@ database must have unique subjects.  if the value B<no> is given,
 several valid certificate entries may have the exact same subject.
 The default value is B<yes>, to be compatible with older (pre 0.9.8)
 versions of OpenSSL.  However, to make CA certificate roll-over easier,
-it's recommended to use the value B<no>, especially if combined with
+it is recommended to use the value B<no>, especially if combined with
 the B<-selfsign> command line option.
 
 =item B<serial>

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -136,8 +136,8 @@ The default is PEM.
 =item B<-key password>
 
 The password used to encrypt the private key. Since on some
-systems the command line arguments are visible (e.g. Unix with
-the L<ps(1)> utility) this option should be used with caution.
+systems the command line arguments are visible (e.g., Linux using
+the C<ps> command), utility) this option should be used with caution.
 
 =item B<-selfsign>
 

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -160,7 +160,7 @@ see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
 
 =item B<-notext>
 
-Don't output the text form of a certificate to the output file.
+Do not output the text form of a certificate to the output file.
 
 =item B<-startdate date>
 
@@ -631,11 +631,11 @@ A sample configuration file with the relevant sections for B<ca>:
  default_md     = md5                   # md to use
 
  policy         = policy_any            # default policy
- email_in_dn    = no                    # Don't add the email into cert DN
+ email_in_dn    = no                    # Do not add the email into cert DN
 
  name_opt       = ca_default            # Subject name display option
  cert_opt       = ca_default            # Certificate display option
- copy_extensions = none                 # Don't copy extensions from request
+ copy_extensions = none                 # Do not copy extensions from request
 
  [ policy_any ]
  countryName            = supplied

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -723,36 +723,42 @@ listed here because some ciphers were excluded at compile time.
 
 =head1 EXAMPLES
 
+In the following examples, the cipher specifications listed in quotes
+may require some additional charcters to escape command-line shell behavior.
+For example, using the exclamation point requires the string to be
+put in single quotes for C<bash>, while C<tcsh> requires a backslash
+before it.
+
 Verbose listing of all OpenSSL ciphers including NULL ciphers:
 
- openssl ciphers -v "ALL:eNULL"
+ openssl ciphers -v 'ALL:eNULL'
 
 Include all ciphers except NULL and anonymous DH then sort by
 strength:
 
- openssl ciphers -v "ALL:!ADH:@STRENGTH"
+ openssl ciphers -v 'ALL:!ADH:@STRENGTH'
 
 Include all ciphers except ones with no encryption (eNULL) or no
 authentication (aNULL):
 
- openssl ciphers -v "ALL:!aNULL"
+ openssl ciphers -v 'ALL:!aNULL'
 
 Include only 3DES ciphers and then place RSA ciphers last:
 
- openssl ciphers -v "3DES:+RSA"
+ openssl ciphers -v '3DES:+RSA'
 
 Include all RC4 ciphers but leave out those without authentication:
 
- openssl ciphers -v "RC4:!COMPLEMENTOFDEFAULT"
+ openssl ciphers -v 'RC4:!COMPLEMENTOFDEFAULT'
 
 Include all ciphers with RSA authentication but leave out ciphers without
 encryption.
 
- openssl ciphers -v "RSA:!COMPLEMENTOFALL"
+ openssl ciphers -v 'RSA:!COMPLEMENTOFALL'
 
 Set security level to 2 and display all ciphers consistent with level 2:
 
- openssl ciphers -s -v "ALL:@SECLEVEL=2"
+ openssl ciphers -s -v 'ALL:@SECLEVEL=2'
 
 =head1 SEE ALSO
 

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -141,7 +141,7 @@ If B<-> is used then the ciphers are deleted from the list, but some or
 all of the ciphers can be added again by later options.
 
 If B<+> is used then the ciphers are moved to the end of the list. This
-option doesn't add any new ciphers it just moves matching existing ones.
+option does not add any new ciphers it just moves matching existing ones.
 
 If none of these characters is present then the string is just interpreted
 as a list of ciphers to be appended to the current preference list. If the

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -725,34 +725,34 @@ listed here because some ciphers were excluded at compile time.
 
 Verbose listing of all OpenSSL ciphers including NULL ciphers:
 
- openssl ciphers -v 'ALL:eNULL'
+ openssl ciphers -v "ALL:eNULL"
 
 Include all ciphers except NULL and anonymous DH then sort by
 strength:
 
- openssl ciphers -v 'ALL:!ADH:@STRENGTH'
+ openssl ciphers -v "ALL:!ADH:@STRENGTH"
 
 Include all ciphers except ones with no encryption (eNULL) or no
 authentication (aNULL):
 
- openssl ciphers -v 'ALL:!aNULL'
+ openssl ciphers -v "ALL:!aNULL"
 
 Include only 3DES ciphers and then place RSA ciphers last:
 
- openssl ciphers -v '3DES:+RSA'
+ openssl ciphers -v "3DES:+RSA"
 
 Include all RC4 ciphers but leave out those without authentication:
 
- openssl ciphers -v 'RC4:!COMPLEMENTOFDEFAULT'
+ openssl ciphers -v "RC4:!COMPLEMENTOFDEFAULT"
 
 Include all ciphers with RSA authentication but leave out ciphers without
 encryption.
 
- openssl ciphers -v 'RSA:!COMPLEMENTOFALL'
+ openssl ciphers -v "RSA:!COMPLEMENTOFALL"
 
 Set security level to 2 and display all ciphers consistent with level 2:
 
- openssl ciphers -s -v 'ALL:@SECLEVEL=2'
+ openssl ciphers -s -v "ALL:@SECLEVEL=2"
 
 =head1 SEE ALSO
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -707,7 +707,7 @@ encryption certificate.
 Ideally a database should be maintained of a certificates for each email
 address.
 
-The code doesn't currently take note of the permitted symmetric encryption
+The code does not currently take note of the permitted symmetric encryption
 algorithms as supplied in the SMIMECapabilities signed attribute. this means the
 user has to manually include the correct encryption algorithm. It should store
 the list of permitted ciphers in a database and only use those.

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -508,7 +508,7 @@ a blank line. Piping the mail directly to sendmail is one way to
 achieve the correct format.
 
 The supplied message to be signed or encrypted must include the
-necessary MIME headers or many S/MIME clients won't display it
+necessary MIME headers or many S/MIME clients will not display it
 properly (if at all). You can use the B<-text> option to automatically
 add plain text headers.
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -696,8 +696,7 @@ Use SHA256 KDF with an ECDH certificate:
 
 =head1 BUGS
 
-The MIME parser isn't very clever: it seems to handle most messages that I've
-thrown at it but it may choke on others.
+The MIME parser is not very clever and may fail to parse some valid messages.
 
 The code currently will only write out the signer's certificate to a file: if
 the signer has a separate encryption certificate this must be manually

--- a/doc/man1/crl.pod
+++ b/doc/man1/crl.pod
@@ -66,7 +66,7 @@ the description of B<-nameopt> in L<x509(1)>.
 
 =item B<-noout>
 
-Don't output the encoded version of the CRL.
+Do not output the encoded version of the CRL.
 
 =item B<-hash>
 

--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -32,7 +32,7 @@ B<openssl> B<ec>
 
 The B<ec> command processes EC keys. They can be converted between various
 forms and their components printed out. B<Note> OpenSSL uses the
-private key format specified in 'SEC 1: Elliptic Curve Cryptography'
+private key format specified in I<SEC 1: Elliptic Curve Cryptography>
 (http://www.secg.org/). To convert an OpenSSL EC private key into the
 PKCS#8 private key format use the B<pkcs8> command.
 

--- a/doc/man1/ecparam.pod
+++ b/doc/man1/ecparam.pod
@@ -151,7 +151,7 @@ B<ecparam> can only create EC parameters from known (named) curves.
 
 =head1 EXAMPLES
 
-To create EC parameters with the group 'prime192v1':
+To create EC parameters with the group prime192v1:
 
   openssl ecparam -out ec_param.pem -name prime192v1
 
@@ -167,7 +167,7 @@ To create EC parameters and a private key:
 
   openssl ecparam -out ec_key.pem -name prime192v1 -genkey
 
-To change the point encoding to 'compressed':
+To change the point encoding to compressed:
 
   openssl ecparam -in ec_in.pem -out ec_out.pem -conv_form compressed
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -188,7 +188,7 @@ This can be used with a subsequent B<-rand> flag.
 =head1 NOTES
 
 The program can be called either as B<openssl cipher> or
-B<openssl enc -cipher>. The first form doesn't work with
+B<openssl enc -cipher>. The first form does not work with
 engine-provided ciphers, because this form is processed before the
 configuration file is read and any ENGINEs loaded.
 Use the B<list> command to get a list of supported ciphers.
@@ -358,7 +358,7 @@ Decrypt some data using a supplied 40 bit RC4 key:
 
 =head1 BUGS
 
-The B<-A> option when used with large files doesn't work properly.
+The B<-A> option when used with large files does not work properly.
 
 There should be an option to allow an iteration count to be included.
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -364,7 +364,7 @@ There should be an option to allow an iteration count to be included.
 
 The B<enc> program only supports a fixed number of algorithms with
 certain parameters. So if, for example, you want to use RC2 with a
-76 bit key or RC4 with an 84 bit key you can't use this program.
+76 bit key or RC4 with an 84 bit key you cannot use this program.
 
 =head1 HISTORY
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -223,7 +223,7 @@ a strong block cipher, such as AES, in CBC mode.
 All the block ciphers normally use PKCS#5 padding, also known as standard
 block padding. This allows a rudimentary integrity or password check to
 be performed. However since the chance of random data passing the test
-is better than 1 in 256 it isn't a very good test.
+is better than 1 in 256 it is not a very good test.
 
 If padding is disabled then the input data must be a multiple of the cipher
 block length.

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -110,7 +110,7 @@ The default algorithm is sha-256.
 
 =item B<-nosalt>
 
-Don't use a salt in the key derivation routines. This option B<SHOULD NOT> be
+Do not use a salt in the key derivation routines. This option B<SHOULD NOT> be
 used except for test purposes or compatibility with ancient versions of
 OpenSSL.
 
@@ -145,7 +145,7 @@ Print out the key and IV used.
 
 =item B<-P>
 
-Print out the key and IV used then immediately exit: don't do any encryption
+Print out the key and IV used then immediately exit: do not do any encryption
 or decryption.
 
 =item B<-bufsize number>

--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -127,7 +127,7 @@ If set the key is restricted and can only use B<digest> for signing.
 
 =item B<rsa_pss_keygen_mgf1_md:digest>
 
-If set the key is restricted and can only use B<digest> as it's MGF1
+If set the key is restricted and can only use B<digest> as its MGF1
 parameter.
 
 =item B<rsa_pss_keygen_saltlen:len>

--- a/doc/man1/ocsp.pod
+++ b/doc/man1/ocsp.pod
@@ -409,8 +409,8 @@ with the B<-VAfile> option.
 =head1 NOTES
 
 As noted, most of the verify options are for testing or debugging purposes.
-Normally only the B<-CApath>, B<-CAfile> and (if the responder is a 'global
-VA') B<-VAfile> options need to be used.
+Normally only the B<-CApath>, B<-CAfile> and (if the responder is a "global
+VA") B<-VAfile> options need to be used.
 
 The OCSP server is only useful for test and demonstration purposes: it is
 not really usable as a full OCSP responder. It contains only a very

--- a/doc/man1/ocsp.pod
+++ b/doc/man1/ocsp.pod
@@ -232,7 +232,7 @@ B<-verify_other> and B<-trust_other> options.
 
 =item B<-noverify>
 
-Don't attempt to verify the OCSP response signature or the nonce
+Do not attempt to verify the OCSP response signature or the nonce
 values. This option will normally only be used for debugging since it
 disables all verification of the responders certificate.
 
@@ -244,13 +244,13 @@ with either the B<-verify_other> or B<-VAfile> options.
 
 =item B<-no_signature_verify>
 
-Don't check the signature on the OCSP response. Since this option
+Do not check the signature on the OCSP response. Since this option
 tolerates invalid signatures on OCSP responses it will normally only be
 used for testing purposes.
 
 =item B<-no_cert_verify>
 
-Don't verify the OCSP response signers certificate at all. Since this
+Do not verify the OCSP response signers certificate at all. Since this
 option allows the OCSP response to be signed by any certificate it should
 only be used for testing purposes.
 
@@ -265,7 +265,7 @@ Do not explicitly trust the root CA if it is set to be trusted for OCSP signing.
 
 =item B<-no_cert_checks>
 
-Don't perform any additional checks on the OCSP response signers certificate.
+Do not perform any additional checks on the OCSP response signers certificate.
 That is do not make any checks to see if the signers certificate is authorised
 to provide the necessary status information: as a result this option should
 only be used for testing purposes.
@@ -327,7 +327,7 @@ Additional certificates to include in the OCSP response.
 
 =item B<-resp_no_certs>
 
-Don't include any certificates in the OCSP response.
+Do not include any certificates in the OCSP response.
 
 =item B<-resp_key_id>
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -215,14 +215,14 @@ by  L<B<pkeyutl>|pkeyutl(1)>.
 =item L<B<s_client>|s_client(1)>
 
 This implements a generic SSL/TLS client which can establish a transparent
-connection to a remote server speaking SSL/TLS. It's intended for testing
+connection to a remote server speaking SSL/TLS. It is intended for testing
 purposes only and provides only rudimentary interface functionality but
 internally uses mostly all functionality of the OpenSSL B<ssl> library.
 
 =item L<B<s_server>|s_server(1)>
 
 This implements a generic SSL/TLS server which accepts connections from remote
-clients speaking SSL/TLS. It's intended for testing purposes only and provides
+clients speaking SSL/TLS. It is intended for testing purposes only and provides
 only rudimentary interface functionality but internally uses mostly all
 functionality of the OpenSSL B<ssl> library.  It provides both an own command
 line oriented protocol for testing SSL functions and a simple HTTP response

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -388,7 +388,7 @@ terminal with echoing turned off.
 =item B<pass:password>
 
 The actual password is B<password>. Since the password is visible
-to utilities (like 'ps' under Unix) this form should only be used
+to utilities (like L<ps(1)> under Unix) this form should only be used
 where security is not important.
 
 =item B<env:var>

--- a/doc/man1/passwd.pod
+++ b/doc/man1/passwd.pod
@@ -79,11 +79,11 @@ Read passwords from B<stdin>.
 
 =item B<-noverify>
 
-Don't verify when reading a password from the terminal.
+Do not verify when reading a password from the terminal.
 
 =item B<-quiet>
 
-Don't output warnings when passwords given at the command line are truncated.
+Do not output warnings when passwords given at the command line are truncated.
 
 =item B<-table>
 

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -143,11 +143,11 @@ Use Camellia to encrypt private keys before outputting.
 
 =item B<-nodes>
 
-Don't encrypt the private keys at all.
+Do not encrypt the private keys at all.
 
 =item B<-nomacver>
 
-Don't attempt to verify the integrity MAC before reading the file.
+Do not attempt to verify the integrity MAC before reading the file.
 
 =item B<-twopass>
 
@@ -274,7 +274,7 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 =item B<-nomac>
 
-Don't attempt to provide the MAC integrity.
+Do not attempt to provide the MAC integrity.
 
 =item B<-rand file...>
 
@@ -357,7 +357,7 @@ Output only client certificates to a file:
 
  openssl pkcs12 -in file.p12 -clcerts -out file.pem
 
-Don't encrypt the private key:
+Do not encrypt the private key:
 
  openssl pkcs12 -in file.p12 -out file.pem -nodes
 

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -332,7 +332,7 @@ the B<-nokeys -cacerts> options to just output CA certificates.
 
 The B<-keypbe> and B<-certpbe> algorithms allow the precise encryption
 algorithms for private keys and certificates to be specified. Normally
-the defaults are fine but occasionally software can't handle triple DES
+the defaults are fine but occasionally software cannot handle triple DES
 encrypted private keys, then the option B<-keypbe PBE-SHA1-RC2-40> can
 be used to reduce the private key encryption to 40 bit RC2. A complete
 description of all algorithms is contained in the B<pkcs8> manual page.

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -174,7 +174,7 @@ by default.
 =item B<-in filename>
 
 The filename to read certificates and private keys from, standard input by
-default.  They must all be in PEM format. The order doesn't matter but one
+default.  They must all be in PEM format. The order does not matter but one
 private key and its corresponding certificate should be present. If additional
 certificates are present they will also be included in the PKCS#12 file.
 
@@ -264,7 +264,7 @@ By default both MAC and encryption iteration counts are set to 2048, using
 these options the MAC and encryption iteration counts can be set to 1, since
 this reduces the file security you should not use these options unless you
 really have to. Most software supports both MAC and key iteration counts.
-MSIE 4.0 doesn't support MAC iteration counts so it needs the B<-nomaciter>
+MSIE 4.0 does not support MAC iteration counts so it needs the B<-nomaciter>
 option.
 
 =item B<-maciter>

--- a/doc/man1/pkcs7.pod
+++ b/doc/man1/pkcs7.pod
@@ -62,7 +62,7 @@ issuer names.
 
 =item B<-noout>
 
-Don't output the encoded version of the PKCS#7 structure (or certificates
+Do not output the encoded version of the PKCS#7 structure (or certificates
 is B<-print_certs> is set).
 
 =item B<-engine id>

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -121,13 +121,13 @@ This can be used with a subsequent B<-rand> flag.
 This option sets the PKCS#5 v2.0 algorithm.
 
 The B<alg> argument is the encryption algorithm to use, valid values include
-B<aes128>, B<aes256> and B<des3>. If this option isn't specified then B<aes256>
+B<aes128>, B<aes256> and B<des3>. If this option is not specified then B<aes256>
 is used.
 
 =item B<-v2prf alg>
 
 This option sets the PRF algorithm to use with PKCS#5 v2.0. A typical value
-value would be B<hmacWithSHA256>. If this option isn't set then the default
+value would be B<hmacWithSHA256>. If this option is not set then the default
 for the cipher is used or B<hmacWithSHA256> if there is no default.
 
 Some implementations may not support custom PRF algorithms and may require

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -191,7 +191,7 @@ In case of RSA, ECDSA and DSA signatures, this utility
 will not perform hashing on input data but rather use the data directly as
 input of signature algorithm. Depending on key type, signature type and mode
 of padding, the maximum acceptable lengths of input data differ. In general,
-with RSA the signed data can't be longer than the key modulus, in case of ECDSA
+with RSA the signed data cannot be longer than the key modulus, in case of ECDSA
 and DSA the data shouldn't be longer than field size, otherwise it will be
 silently truncated to field size.
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -192,7 +192,7 @@ will not perform hashing on input data but rather use the data directly as
 input of signature algorithm. Depending on key type, signature type and mode
 of padding, the maximum acceptable lengths of input data differ. In general,
 with RSA the signed data cannot be longer than the key modulus, in case of ECDSA
-and DSA the data shouldn't be longer than field size, otherwise it will be
+and DSA the data should not be longer than field size, otherwise it will be
 silently truncated to field size.
 
 In other words, if the value of digest is B<sha1> the input should be 20 bytes

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -647,7 +647,7 @@ for more information.
 
 OpenSSL's handling of T61Strings (aka TeletexStrings) is broken: it effectively
 treats them as ISO-8859-1 (Latin 1), Netscape and MSIE have similar behaviour.
-This can cause problems if you need characters that aren't available in
+This can cause problems if you need characters that are not available in
 PrintableStrings and you do not want to or cannot use BMPStrings.
 
 As a consequence of the T61String handling the only correct way to represent

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -624,7 +624,7 @@ This is followed some time later by...
 
 The first error message is the clue: it can't find the configuration
 file! Certain operations (like examining a certificate request) do not
-need a configuration file so its use isn't enforced. Generation of
+need a configuration file so its use is not enforced. Generation of
 certificates or requests however does need a configuration file. This
 could be regarded as a bug.
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -656,7 +656,7 @@ currently chokes on these. If you have to use accented characters with Netscape
 and MSIE then you currently need to use the invalid T61String form.
 
 The current prompting is not very friendly. It does not allow you to confirm what
-you've just entered. Other things like extensions in certificate requests are
+you have just entered. Other things like extensions in certificate requests are
 statically defined in the configuration file. Some of these: like an email
 address in subjectAltName should be input by the user.
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -622,7 +622,7 @@ This is followed some time later by...
         unable to find 'distinguished_name' in config
         problems making Certificate Request
 
-The first error message is the clue: it can't find the configuration
+The first error message is the clue: it cannot find the configuration
 file! Certain operations (like examining a certificate request) do not
 need a configuration file so its use is not enforced. Generation of
 certificates or requests however does need a configuration file. This
@@ -648,7 +648,7 @@ for more information.
 OpenSSL's handling of T61Strings (aka TeletexStrings) is broken: it effectively
 treats them as ISO-8859-1 (Latin 1), Netscape and MSIE have similar behaviour.
 This can cause problems if you need characters that aren't available in
-PrintableStrings and you do not want to or can't use BMPStrings.
+PrintableStrings and you do not want to or cannot use BMPStrings.
 
 As a consequence of the T61String handling the only correct way to represent
 accented characters in OpenSSL is to use a BMPString: unfortunately Netscape

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -655,7 +655,7 @@ accented characters in OpenSSL is to use a BMPString: unfortunately Netscape
 currently chokes on these. If you have to use accented characters with Netscape
 and MSIE then you currently need to use the invalid T61String form.
 
-The current prompting is not very friendly. It doesn't allow you to confirm what
+The current prompting is not very friendly. It does not allow you to confirm what
 you've just entered. Other things like extensions in certificate requests are
 statically defined in the configuration file. Some of these: like an email
 address in subjectAltName should be input by the user.

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -623,7 +623,7 @@ This is followed some time later by...
         problems making Certificate Request
 
 The first error message is the clue: it can't find the configuration
-file! Certain operations (like examining a certificate request) don't
+file! Certain operations (like examining a certificate request) do not
 need a configuration file so its use isn't enforced. Generation of
 certificates or requests however does need a configuration file. This
 could be regarded as a bug.
@@ -648,7 +648,7 @@ for more information.
 OpenSSL's handling of T61Strings (aka TeletexStrings) is broken: it effectively
 treats them as ISO-8859-1 (Latin 1), Netscape and MSIE have similar behaviour.
 This can cause problems if you need characters that aren't available in
-PrintableStrings and you don't want to or can't use BMPStrings.
+PrintableStrings and you do not want to or can't use BMPStrings.
 
 As a consequence of the T61String handling the only correct way to represent
 accented characters in OpenSSL is to use a BMPString: unfortunately Netscape

--- a/doc/man1/rsa.pod
+++ b/doc/man1/rsa.pod
@@ -196,7 +196,7 @@ Output the public part of a private key in B<RSAPublicKey> format:
 
 =head1 BUGS
 
-The command line password arguments don't currently work with
+The command line password arguments do not currently work with
 B<NET> format.
 
 There should be an option that automatically handles .key files,

--- a/doc/man1/s_time.pod
+++ b/doc/man1/s_time.pod
@@ -147,7 +147,7 @@ To connect to an SSL HTTP server and get the default page the command
 
  openssl s_time -connect servername:443 -www / -CApath yourdir -CAfile yourfile.pem -cipher commoncipher [-ssl3]
 
-would typically be used (https uses port 443). 'commoncipher' is a cipher to
+would typically be used (https uses port 443). The "commoncipher" is a cipher to
 which both client and server can agree, see the L<ciphers(1)> command
 for details.
 

--- a/doc/man1/sess_id.pod
+++ b/doc/man1/sess_id.pod
@@ -72,8 +72,8 @@ This option prevents output of the encoded version of the session.
 =item B<-context ID>
 
 This option can set the session id so the output session information uses the
-supplied ID. The ID can be any string of characters. This option won't normally
-be used.
+supplied ID. The ID can be any string of characters. This option will not
+normally be used.
 
 =back
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -342,7 +342,7 @@ a blank line. Piping the mail directly to sendmail is one way to
 achieve the correct format.
 
 The supplied message to be signed or encrypted must include the
-necessary MIME headers or many S/MIME clients won't display it
+necessary MIME headers or many S/MIME clients will not display it
 properly (if at all). You can use the B<-text> option to automatically
 add plain text headers.
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -224,12 +224,12 @@ Do not verify the signers certificate of a signed message.
 
 =item B<-nochain>
 
-Do not do chain verification of signers certificates: that is don't
+Do not do chain verification of signers certificates: that is do not
 use the certificates in the signed message as untrusted CAs.
 
 =item B<-nosigs>
 
-Don't try to verify the signatures on the message.
+Do not try to verify the signatures on the message.
 
 =item B<-nocerts>
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -483,8 +483,7 @@ Add a signer to an existing message:
 
 =head1 BUGS
 
-The MIME parser is not very clever: it seems to handle most messages that I've
-thrown at it but it may choke on others.
+The MIME parser is not very clever, and may fail to parse some valid messages.
 
 The code currently will only write out the signer's certificate to a file: if
 the signer has a separate encryption certificate this must be manually

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -494,7 +494,7 @@ encryption certificate.
 Ideally a database should be maintained of a certificates for each email
 address.
 
-The code doesn't currently take note of the permitted symmetric encryption
+The code does not currently take note of the permitted symmetric encryption
 algorithms as supplied in the SMIMECapabilities signed attribute. This means the
 user has to manually include the correct encryption algorithm. It should store
 the list of permitted ciphers in a database and only use those.

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -483,7 +483,7 @@ Add a signer to an existing message:
 
 =head1 BUGS
 
-The MIME parser isn't very clever: it seems to handle most messages that I've
+The MIME parser is not very clever: it seems to handle most messages that I've
 thrown at it but it may choke on others.
 
 The code currently will only write out the signer's certificate to a file: if

--- a/doc/man1/spkac.pod
+++ b/doc/man1/spkac.pod
@@ -78,7 +78,7 @@ SPKAC. The default is the default section.
 
 =item B<-noout>
 
-Don't output the text version of the SPKAC (not used if an
+Do not output the text version of the SPKAC (not used if an
 SPKAC is being created).
 
 =item B<-pubkey>

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -614,7 +614,7 @@ To verify a time stamp token against a message imprint:
   openssl ts -verify -digest b7e5d3f93198b38379852f2c04e78d73abdd0f4b \
          -in design2.tsr -CAfile cacert.pem
 
-You could also look at the 'test' directory for more examples.
+See the C<test> directory for more examples.
 
 =head1 BUGS
 

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -287,7 +287,7 @@ to the output file. This option does not require a request, it is
 useful e.g. when you need to examine the content of a response or
 token or you want to extract the time stamp token from a response. If
 the input is a token and the output is a time stamp response a default
-'granted' status info is added to the token. (Optional)
+"granted" status info is added to the token. (Optional)
 
 =item B<-token_in>
 
@@ -556,9 +556,12 @@ OID section of the config file):
 
 Before generating a response a signing certificate must be created for
 the TSA that contains the B<timeStamping> critical extended key usage extension
-without any other key usage extensions. You can add the
-'extendedKeyUsage = critical,timeStamping' line to the user certificate section
-of the config file to generate a proper certificate. See L<req(1)>,
+without any other key usage extensions. You can add the following line
+to the user certificate section of the config file:
+
+  extendedKeyUsage = critical,timeStamping
+
+to generate a proper certificate. See L<req(1)>,
 L<ca(1)>, L<x509(1)> for instructions. The examples
 below assume that cacert.pem contains the certificate of the CA,
 tsacert.pem is the signing certificate issued by cacert.pem and
@@ -589,7 +592,7 @@ To extract the time stamp token from a response:
 
   openssl ts -reply -in design1.tsr -out design1_token.der -token_out
 
-To add 'granted' status info to a time stamp token thereby creating a
+To add "granted" status info to a time stamp token thereby creating a
 valid response:
 
   openssl ts -reply -in design1_token.der -token_in -out design1.tsr

--- a/doc/man1/tsget.pod
+++ b/doc/man1/tsget.pod
@@ -174,13 +174,11 @@ protected):
         -k client_key.pem -c client_cert.pem file1.tsq
 
 You can shorten the previous command line if you make use of the B<TSGET>
-environment variable. The following commands do the same as the previous
+environment variable. The following command is the same as the previous
 example:
 
-  TSGET="-h https://tsa.opentsa.org:8443/tsa -C cacerts.pem \
-        -k client_key.pem -c client_cert.pem"
-  export TSGET
-  tsget file1.tsq
+  env TSGET="-h https://tsa.opentsa.org:8443/tsa -C cacerts.pem \
+        -k client_key.pem -c client_cert.pem" tsget file1.tsq
 
 =head1 SEE ALSO
 

--- a/doc/man1/tsget.pod
+++ b/doc/man1/tsget.pod
@@ -58,7 +58,7 @@ The URL of the HTTP/HTTPS server listening for time stamp requests.
 
 If the B<-o> option is not given this argument specifies the extension of the
 output files. The base name of the output file will be the same as those of
-the input files. Default extension is '.tsr'. (Optional)
+the input files. Default extension is C<.tsr>. (Optional)
 
 =item B<-o> output
 
@@ -177,8 +177,8 @@ You can shorten the previous command line if you make use of the B<TSGET>
 environment variable. The following commands do the same as the previous
 example:
 
-  TSGET='-h https://tsa.opentsa.org:8443/tsa -C cacerts.pem \
-        -k client_key.pem -c client_cert.pem'
+  TSGET="-h https://tsa.opentsa.org:8443/tsa -C cacerts.pem \
+        -k client_key.pem -c client_cert.pem"
   export TSGET
   tsget file1.tsq
 

--- a/doc/man1/verify.pod
+++ b/doc/man1/verify.pod
@@ -351,7 +351,7 @@ certificate.
 If a certificate is found which is its own issuer it is assumed to be the root
 CA.
 
-The process of 'looking up the issuers certificate' itself involves a number of
+The process of looking up the issuer's certificate itself involves a number of
 steps.
 After all certificates whose subject name matches the issuer name of the current
 certificate are subject to further tests.

--- a/doc/man1/verify.pod
+++ b/doc/man1/verify.pod
@@ -98,7 +98,7 @@ current system time. B<timestamp> is the number of seconds since
 =item B<-check_ss_sig>
 
 Verify the signature on the self-signed root CA. This is disabled by default
-because it doesn't add any security.
+because it does not add any security.
 
 =item B<-CRLfile file>
 

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -623,48 +623,48 @@ Use the old format. This is equivalent to specifying no output options at all.
 
 =item B<no_header>
 
-Don't print header information: that is the lines saying "Certificate"
+Do not print header information: that is the lines saying "Certificate"
 and "Data".
 
 =item B<no_version>
 
-Don't print out the version number.
+Do not print out the version number.
 
 =item B<no_serial>
 
-Don't print out the serial number.
+Do not print out the serial number.
 
 =item B<no_signame>
 
-Don't print out the signature algorithm used.
+Do not print out the signature algorithm used.
 
 =item B<no_validity>
 
-Don't print the validity, that is the B<notBefore> and B<notAfter> fields.
+Do not print the validity, that is the B<notBefore> and B<notAfter> fields.
 
 =item B<no_subject>
 
-Don't print out the subject name.
+Do not print out the subject name.
 
 =item B<no_issuer>
 
-Don't print out the issuer name.
+Do not print out the issuer name.
 
 =item B<no_pubkey>
 
-Don't print out the public key.
+Do not print out the public key.
 
 =item B<no_sigdump>
 
-Don't give a hexadecimal dump of the certificate signature.
+Do not give a hexadecimal dump of the certificate signature.
 
 =item B<no_aux>
 
-Don't print out certificate trust information.
+Do not print out certificate trust information.
 
 =item B<no_extensions>
 
-Don't print out any X509V3 extensions.
+Do not print out any X509V3 extensions.
 
 =item B<ext_default>
 
@@ -874,7 +874,7 @@ The extended key usage extension must be absent or include the "email
 protection" OID. Netscape certificate type must be absent or should have the
 S/MIME bit set. If the S/MIME bit is not set in Netscape certificate type
 then the SSL client bit is tolerated as an alternative but a warning is shown:
-this is because some Verisign certificates don't set the S/MIME bit.
+this is because some Verisign certificates do not set the S/MIME bit.
 
 =item B<S/MIME Signing>
 

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -459,7 +459,7 @@ extension section format.
 
 When a certificate is created set its public key to B<key> instead of the
 key in the certificate or certificate request. This option is useful for
-creating certificates where the algorithm can't normally sign requests, for
+creating certificates where the algorithm cannot normally sign requests, for
 example DH.
 
 The format or B<key> can be specified using the B<-keyform> option.

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -864,7 +864,7 @@ basicConstraints extension is absent.
 =item B<Netscape SSL Server>
 
 For Netscape SSL clients to connect to an SSL server it must have the
-keyEncipherment bit set if the keyUsage extension is present. This isn't
+keyEncipherment bit set if the keyUsage extension is present. This is not
 always valid because some cipher suites use the key for digital signing.
 Otherwise it is the same as a normal SSL server.
 

--- a/doc/man3/ASN1_STRING_length.pod
+++ b/doc/man3/ASN1_STRING_length.pod
@@ -58,7 +58,7 @@ should be freed using OPENSSL_free().
 =head1 NOTES
 
 Almost all ASN1 types in OpenSSL are represented as an B<ASN1_STRING>
-structure. Other types such as B<ASN1_OCTET_STRING> are simply typedef'ed
+structure. Other types such as B<ASN1_OCTET_STRING> are simply C<typedef>'d
 to B<ASN1_STRING> and the functions call the B<ASN1_STRING> equivalents.
 B<ASN1_STRING> is also used for some B<CHOICE> types which consist
 entirely of primitive string types such as B<DirectoryString> and

--- a/doc/man3/ASN1_generate_nconf.pod
+++ b/doc/man3/ASN1_generate_nconf.pod
@@ -193,7 +193,7 @@ SEQUENCE consisting of a BOOL an OID and a UTF8String:
 
 This example produces an RSAPrivateKey structure, this is the
 key contained in the file client.pem in all OpenSSL distributions
-(note: the field names such as 'coeff' are ignored and are present just
+(note: the field names such as "coeff" are ignored and are present just
 for clarity):
 
  asn1=SEQUENCE:private_key

--- a/doc/man3/ASYNC_start_job.pod
+++ b/doc/man3/ASYNC_start_job.pod
@@ -199,7 +199,7 @@ The following example demonstrates how to use most of the core async APIs:
      unsigned char *msg;
      int pipefds[2] = {0, 0};
      OSSL_ASYNC_FD *wptr;
-     char buf = 'X';
+     char buf = '!';
 
      currjob = ASYNC_get_current_job();
      if (currjob != NULL) {

--- a/doc/man3/BF_encrypt.pod
+++ b/doc/man3/BF_encrypt.pod
@@ -87,7 +87,7 @@ the same way.
 BF_encrypt() and BF_decrypt() are the lowest level functions for Blowfish
 encryption.  They encrypt/decrypt the first 64 bits of the vector pointed by
 B<data>, using the key B<key>.  These functions should not be used unless you
-implement 'modes' of Blowfish.  The alternative is to use BF_ecb_encrypt().
+implement modes of Blowfish.  The alternative is to use BF_ecb_encrypt().
 If you still want to use these functions, you should be aware that they take
 each 32-bit chunk in host-byte order, which is little-endian on little-endian
 platforms and big-endian on big-endian ones.

--- a/doc/man3/BF_encrypt.pod
+++ b/doc/man3/BF_encrypt.pod
@@ -56,7 +56,7 @@ The mode functions BF_cbc_encrypt(), BF_cfb64_encrypt() and BF_ofb64_encrypt()
 all operate on variable length data.  They all take an initialization vector
 B<ivec> which needs to be passed along into the next call of the same function
 for the same message.  B<ivec> may be initialized with anything, but the
-recipient needs to know what it was initialized with, or it won't be able
+recipient needs to know what it was initialized with, or it will not be able
 to decrypt.  Some programs and protocols simplify this, like SSH, where
 B<ivec> is simply initialized to zero.
 BF_cbc_encrypt() operates on data that is a multiple of 8 bytes long, while

--- a/doc/man3/BIO_ADDR.pod
+++ b/doc/man3/BIO_ADDR.pod
@@ -107,7 +107,7 @@ return B<NULL> on error and leave an error indication on the
 OpenSSL error stack.
 
 All other functions described here return 0 or B<NULL> when the
-information they should return isn't available.
+information they should return is not available.
 
 =head1 SEE ALSO
 

--- a/doc/man3/BIO_ADDRINFO.pod
+++ b/doc/man3/BIO_ADDRINFO.pod
@@ -88,7 +88,7 @@ occurred, and will leave an error indication on the OpenSSL error stack in that
 case.
 
 All other functions described here return 0 or B<NULL> when the
-information they should return isn't available.
+information they should return is not available.
 
 =head1 NOTES
 

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -150,7 +150,7 @@ unencrypted example in L<BIO_s_connect(3)>.
  sbio = BIO_new_ssl_connect(ctx);
  BIO_get_ssl(sbio, &ssl);
  if (ssl == NULL) {
-     fprintf(stderr, "Can't locate SSL pointer\n");
+     fprintf(stderr, "Cannot locate SSL pointer\n");
      ERR_print_errors_fp(stderr);
      exit(1);
  }
@@ -215,7 +215,7 @@ a client and also echoes the request to standard output.
  sbio = BIO_new_ssl(ctx, 0);
  BIO_get_ssl(sbio, &ssl);
  if (ssl == NULL) {
-     fprintf(stderr, "Can't locate SSL pointer\n");
+     fprintf(stderr, "Cannot locate SSL pointer\n");
      ERR_print_errors_fp(stderr);
      exit(1);
  }

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -155,7 +155,7 @@ unencrypted example in L<BIO_s_connect(3)>.
      exit(1);
  }
 
- /* Don't want any retries */
+ /* Do not want any retries */
  SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
 
  /* XXX We might want to do other things with ssl here */

--- a/doc/man3/BIO_parse_hostserv.pod
+++ b/doc/man3/BIO_parse_hostserv.pod
@@ -35,8 +35,8 @@ The syntax the BIO_parse_hostserv() recognises is:
  host
  service
 
-The host part can be a name or an IP address.  If it is a IPv6
-address, it MUST be enclosed in brackets, such as '[::1]'.
+The host part can be a name or an IP address.  If it is an IPv6
+address, it MUST be enclosed in brackets, such as "[::1]".
 
 The service part can  be a service name or its port number.
 

--- a/doc/man3/BIO_parse_hostserv.pod
+++ b/doc/man3/BIO_parse_hostserv.pod
@@ -35,7 +35,7 @@ The syntax the BIO_parse_hostserv() recognises is:
  host
  service
 
-The host part can be a name or an IP address.  If it's a IPv6
+The host part can be a name or an IP address.  If it is a IPv6
 address, it MUST be enclosed in brackets, such as '[::1]'.
 
 The service part can  be a service name or its port number.

--- a/doc/man3/BIO_set_callback.pod
+++ b/doc/man3/BIO_set_callback.pod
@@ -62,7 +62,7 @@ The BIO the callback is attached to is passed in B<b>.
 
 B<oper> is set to the operation being performed. For some operations
 the callback is called twice, once before and once after the actual
-operation, the latter case has B<oper> or'ed with BIO_CB_RETURN.
+operation, the latter case has B<oper> or'd with BIO_CB_RETURN.
 
 =item B<len>
 

--- a/doc/man3/BN_BLINDING_new.pod
+++ b/doc/man3/BN_BLINDING_new.pod
@@ -98,7 +98,7 @@ success and 0 if an error occurred.
 BN_BLINDING_is_current_thread() returns 1 if the current thread owns
 the B<BN_BLINDING> object, 0 otherwise.
 
-BN_BLINDING_set_current_thread() doesn't return anything.
+BN_BLINDING_set_current_thread() does not return anything.
 
 BN_BLINDING_lock(), BN_BLINDING_unlock() return 1 if the operation
 succeeded or 0 on error.

--- a/doc/man3/BN_num_bytes.pod
+++ b/doc/man3/BN_num_bytes.pod
@@ -37,7 +37,7 @@ Some have tried using BN_num_bits() on individual numbers in RSA keys,
 DH keys and DSA keys, and found that they do not always come up with
 the number of bits they expected (something like 512, 1024, 2048,
 ...).  This is because generating a number with some specific number
-of bits doesn't always set the highest bits, thereby making the number
+of bits does not always set the highest bits, thereby making the number
 of I<significant> bits a little lower.  If you want to know the "key
 size" of such a key, either use functions like RSA_size(), DH_size()
 and DSA_size(), or use BN_num_bytes() and multiply with 8 (although

--- a/doc/man3/BN_num_bytes.pod
+++ b/doc/man3/BN_num_bytes.pod
@@ -34,7 +34,7 @@ The size.
 =head1 NOTES
 
 Some have tried using BN_num_bits() on individual numbers in RSA keys,
-DH keys and DSA keys, and found that they don't always come up with
+DH keys and DSA keys, and found that they do not always come up with
 the number of bits they expected (something like 512, 1024, 2048,
 ...).  This is because generating a number with some specific number
 of bits doesn't always set the highest bits, thereby making the number

--- a/doc/man3/CMS_final.pod
+++ b/doc/man3/CMS_final.pod
@@ -12,7 +12,7 @@ CMS_final - finalise a CMS_ContentInfo structure
 
 =head1 DESCRIPTION
 
-CMS_final() finalises the structure B<cms>. It's purpose is to perform any
+CMS_final() finalises the structure B<cms>. Its purpose is to perform any
 operations necessary on B<cms> (digest computation for example) and set the
 appropriate fields. The parameter B<data> contains the content to be
 processed. The B<dcont> parameter contains a BIO to write content to after

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -26,7 +26,7 @@ CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free, CRYPTO_atomic_add - OpenSSL threa
 OpenSSL can be safely used in multi-threaded applications provided that
 support for the underlying OS threading API is built-in. Currently, OpenSSL
 supports the pthread and Windows APIs. OpenSSL can also be built without
-any multi-threading support, for example on platforms that don't provide
+any multi-threading support, for example on platforms that do not provide
 any threading support or that provide a threading API that is not yet
 supported by OpenSSL.
 

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -83,7 +83,7 @@ are called in increasing order of their B<index> value.
 If a dynamic library can be unloaded, it should call CRYPTO_free_ex_index()
 when this is done.
 This will replace the callbacks with no-ops
-so that applications don't crash.  Any existing exdata will be leaked.
+so that applications do not crash.  Any existing exdata will be leaked.
 
 To set or get the exdata on an object, the appropriate type-specific
 routine must be used.  This is because the containing structure is opaque

--- a/doc/man3/DES_random_key.pod
+++ b/doc/man3/DES_random_key.pod
@@ -164,7 +164,7 @@ last block is copied to a temporary area and zero filled.  The output
 is always an integral multiple of eight bytes.
 
 DES_xcbc_encrypt() is RSA's DESX mode of DES.  It uses I<inw> and
-I<outw> to 'whiten' the encryption.  I<inw> and I<outw> are secret
+I<outw> to whiten the encryption.  I<inw> and I<outw> are secret
 (unlike the iv) and are as such, part of the key.  So the key is sort
 of 24 bytes.  This is much better than CBC DES.
 
@@ -192,8 +192,8 @@ DES_cfb64_encrypt()
 implements CFB mode of DES with 64bit feedback.  Why is this
 useful you ask?  Because this routine will allow you to encrypt an
 arbitrary number of bytes, no 8 byte padding.  Each call to this
-routine will encrypt the input bytes to output and then update ivec
-and num.  num contains 'how far' we are though ivec.  If this does
+routine will encrypt the input bytes to output and then update B<ivec>
+and B<num>; B<num> contains "how far" we are though ivec.  If this does
 not make much sense, read more about cfb mode of DES :-).
 
 DES_ede3_cfb64_encrypt() and DES_ede2_cfb64_encrypt() is the same as

--- a/doc/man3/DH_generate_parameters.pod
+++ b/doc/man3/DH_generate_parameters.pod
@@ -58,13 +58,13 @@ following bits may be set:
 =item DH_CHECK_P_NOT_PRIME
 
 The parameter B<p> has been determined to not being an odd prime.
-Note that the lack of this bit doesn't guarantee that B<p> is a
+Note that the lack of this bit does not guarantee that B<p> is a
 prime.
 
 =item DH_NOT_SUITABLE_GENERATOR
 
 The generator B<g> is not suitable.
-Note that the lack of this bit doesn't guarantee that B<g> is
+Note that the lack of this bit does not guarantee that B<g> is
 suitable, unless B<p> is known to be a strong prime.
 
 =back

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -152,7 +152,7 @@ integer.
 
 EC_KEY_copy() returns a pointer to the destination key, or NULL on error.
 
-EC_KEY_get0_engine() returns a pointer to an ENGINE, or NULL if it wasn't set.
+EC_KEY_get0_engine() returns a pointer to an ENGINE, or NULL if it was not set.
 
 EC_KEY_up_ref(), EC_KEY_set_group(), EC_KEY_set_private_key(),
 EC_KEY_set_public_key(), EC_KEY_precompute_mult(), EC_KEY_generate_key(),

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -294,7 +294,7 @@ table trying to initialise each of them in turn, in case one of them is
 operational. If it returns a functional reference to an ENGINE, it will
 also cache another reference to speed up processing future queries (without
 needing to iterate across the table). Likewise, it will cache a NULL
-response if no ENGINE was available so that future queries won't repeat the
+response if no ENGINE was available so that future queries will not repeat the
 same iteration unless the state table changes. This behaviour can also be
 changed; if the ENGINE_TABLE_FLAG_NOINIT flag is set (using
 ENGINE_set_table_flags()), no attempted initialisations will take place,

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -252,7 +252,7 @@ operational ENGINE for a given cryptographic purpose.
 
 To obtain a functional reference from an existing structural reference,
 call the ENGINE_init() function. This returns zero if the ENGINE was not
-already operational and couldn't be successfully initialised (eg. lack of
+already operational and could not be successfully initialised (eg. lack of
 system drivers, no special hardware attached, etc), otherwise it will
 return non-zero to indicate that the ENGINE is now operational and will
 have allocated a new B<functional> reference to the ENGINE. All functional
@@ -357,7 +357,7 @@ illustrates how to approach this;
      /* the engine is not available */
      return;
  if (!ENGINE_init(e)) {
-     /* the engine couldn't initialise, release 'e' */
+     /* the engine could not initialise, release 'e' */
      ENGINE_free(e);
      return;
  }

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -479,7 +479,7 @@ boolean success or failure.
 Note that ENGINE_ctrl_cmd_string() accepts a boolean argument that can
 relax the semantics of the function - if set non-zero it will only return
 failure if the ENGINE supported the given command name but failed while
-executing it, if the ENGINE doesn't support the command name it will simply
+executing it, if the ENGINE does not support the command name it will simply
 return success without doing anything. In this case we assume the user is
 only supplying commands specific to the given ENGINE so we set this to
 FALSE.

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -174,8 +174,8 @@ implementation includes the following abstractions;
  RSA_METHOD - for providing alternative RSA implementations
  DSA_METHOD, DH_METHOD, RAND_METHOD, ECDH_METHOD, ECDSA_METHOD,
        - similarly for other OpenSSL APIs
- EVP_CIPHER - potentially multiple cipher algorithms (indexed by 'nid')
- EVP_DIGEST - potentially multiple hash algorithms (indexed by 'nid')
+ EVP_CIPHER - potentially multiple cipher algorithms (indexed by nid)
+ EVP_DIGEST - potentially multiple hash algorithms (indexed by nid)
  key-loading - loading public and/or private EVP_PKEY keys
 
 =head2 Reference counting and handles
@@ -271,11 +271,11 @@ algorithm-specific types in OpenSSL, such as RSA, DSA, EVP_CIPHER_CTX, etc.
 For each supported abstraction, the ENGINE code maintains an internal table
 of state to control which implementations are available for a given
 abstraction and which should be used by default. These implementations are
-registered in the tables and indexed by an 'nid' value, because
+registered in the tables and indexed by a "nid" value, because
 abstractions like EVP_CIPHER and EVP_DIGEST support many distinct
 algorithms and modes, and ENGINEs can support arbitrarily many of them.
 In the case of other abstractions like RSA, DSA, etc, there is only one
-"algorithm" so all implementations implicitly register using the same 'nid'
+"algorithm" so all implementations implicitly register using the same "nid"
 index.
 
 When a default ENGINE is requested for a given abstraction/algorithm/mode, (eg.
@@ -303,7 +303,7 @@ instead the only way for the state table to return a non-NULL ENGINE to the
 ENGINE_set_default_RSA() does the same job as ENGINE_register_RSA() except
 that it also sets the state table's cached response for the "get_default"
 query. In the case of abstractions like EVP_CIPHER, where implementations are
-indexed by 'nid', these flags and cached-responses are distinct for each 'nid'
+indexed by "nid", these flags and cached-responses are distinct for each "nid"
 value.
 
 =head2 Application requirements
@@ -357,13 +357,13 @@ illustrates how to approach this;
      /* the engine is not available */
      return;
  if (!ENGINE_init(e)) {
-     /* the engine could not initialise, release 'e' */
+     /* the engine could not initialise, release |e| */
      ENGINE_free(e);
      return;
  }
  if (!ENGINE_set_default_RSA(e))
      /*
-      * This should only happen when 'e' cannot initialise, but the previous
+      * This should only happen when |e| cannot initialise, but the previous
       * statement suggests it did.
       */
      abort();
@@ -376,7 +376,7 @@ illustrates how to approach this;
 
 I<Automatically using builtin ENGINE implementations>
 
-Here we'll assume we want to load and register all ENGINE implementations
+Here we assume we want to load and register all ENGINE implementations
 bundled with OpenSSL, such that for any cryptographic algorithm required by
 OpenSSL - if there is an ENGINE that implements it and can be initialised,
 it should be used. The following code illustrates how this can work;
@@ -540,7 +540,7 @@ command name exists, and the remaining commands take a command identifier and
 return properties of the corresponding commands. All except
 ENGINE_CTRL_GET_FLAGS return the string length of a command name or description,
 or populate a supplied character buffer with a copy of the command name or
-description. ENGINE_CTRL_GET_FLAGS returns a bitwise-OR'd mask of the following
+description. ENGINE_CTRL_GET_FLAGS returns a bitwise-or'd mask of the following
 possible values:
 
  ENGINE_CMD_FLAG_NUMERIC

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -363,7 +363,7 @@ illustrates how to approach this;
  }
  if (!ENGINE_set_default_RSA(e))
      /*
-      * This should only happen when 'e' can't initialise, but the previous
+      * This should only happen when 'e' cannot initialise, but the previous
       * statement suggests it did.
       */
      abort();

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -194,7 +194,7 @@ that the structure can not be deallocated until the reference is released.
 
 However, a structural reference provides no guarantee that the ENGINE is
 initialised and able to use any of its cryptographic
-implementations. Indeed it's quite possible that most ENGINEs will not
+implementations. Indeed it is quite possible that most ENGINEs will not
 initialise at all in typical environments, as ENGINEs are typically used to
 support specialised hardware. To use an ENGINE's functionality, you need a
 B<functional> reference. This kind of reference can be considered a

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -354,7 +354,7 @@ illustrates how to approach this;
  ENGINE_load_builtin_engines();
  e = ENGINE_by_id(engine_id);
  if (!e)
-     /* the engine isn't available */
+     /* the engine is not available */
      return;
  if (!ENGINE_init(e)) {
      /* the engine couldn't initialise, release 'e' */

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -342,7 +342,7 @@ call ENGINE_cleanup() before the program exits.
 
 I<Using a specific ENGINE implementation>
 
-Here we'll assume an application has been configured by its user or admin
+Here we assume an application has been configured by its user or admin
 to want to use the "ACME" ENGINE if it is available in the version of
 OpenSSL the application was compiled with. If it is available, it should be
 used by default for all RSA, DSA, and symmetric cipher operations, otherwise

--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -153,7 +153,7 @@ bytes for this implementation.
 This is only useful for CFB1 ciphers.
 
 =begin comment
-The FIPS flags seem to be unused, so I'm hiding them until I get an
+The FIPS flags seem to be unused, so I am hiding them until I get an
 explanation or they get removed.  /RL
 
 =item EVP_CIPH_FLAG_FIPS

--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -121,7 +121,7 @@ the key length in B<arg>.
 
 =item EVP_CIPH_NO_PADDING
 
-Don't use standard block padding.
+Do not use standard block padding.
 
 =item EVP_CIPH_RAND_KEY
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -568,7 +568,7 @@ Encrypt a string using IDEA:
      /*
       * Need binary mode for fopen because encrypted data is
       * binary data. Also cannot use strlen() on it because
-      * it won't be NUL terminated and may contain embedded
+      * it will not be NUL terminated and may contain embedded
       * NULs.
       */
      out = fopen(outfile, "wb");

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -165,7 +165,7 @@ EVP_CipherInit_ex(), EVP_CipherUpdate() and EVP_CipherFinal_ex() are
 functions that can be used for decryption or encryption. The operation
 performed depends on the value of the B<enc> parameter. It should be set
 to 1 for encryption, 0 for decryption and -1 to leave the value unchanged
-(the actual value of 'enc' being supplied in a previous call).
+(the actual value of B<enc> being supplied in a previous call).
 
 EVP_CIPHER_CTX_reset() clears all information from a cipher context
 and free up any allocated memory associate with it, except the B<ctx>
@@ -537,7 +537,7 @@ Encrypt a string using IDEA:
      unsigned char outbuf[1024];
      int outlen, tmplen;
      /*
-      * Bogus key and IV: we'd normally set these from
+      * Bogus key and IV: we would normally set these from
       * another source.
       */
      unsigned char key[] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
@@ -597,7 +597,7 @@ with a 128-bit key:
      int inlen, outlen;
      EVP_CIPHER_CTX *ctx;
      /*
-      * Bogus key and IV: we'd normally set these from
+      * Bogus key and IV: we would normally set these from
       * another source.
       */
      unsigned char key[] = "0123456789abcdeF";

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -603,7 +603,7 @@ with a 128-bit key:
      unsigned char key[] = "0123456789abcdeF";
      unsigned char iv[] = "1234567887654321";
 
-     /* Don't set key or IV right away; we want to check lengths */
+     /* Do not set key or IV right away; we want to check lengths */
      ctx = EVP_CIPHER_CTX_new();
      EVP_CipherInit_ex(&ctx, EVP_aes_128_cbc(), NULL, NULL, NULL,
                        do_encrypt);

--- a/doc/man3/EVP_PKEY_cmp.pod
+++ b/doc/man3/EVP_PKEY_cmp.pod
@@ -19,7 +19,7 @@ EVP_PKEY_cmp - public key parameter and comparison functions
 
 The function EVP_PKEY_missing_parameters() returns 1 if the public key
 parameters of B<pkey> are missing and 0 if they are present or the algorithm
-doesn't use parameters.
+does not use parameters.
 
 The function EVP_PKEY_copy_parameters() copies the parameters from key
 B<from> to key B<to>. An error is returned if the parameters are missing in
@@ -47,7 +47,7 @@ a public key.
 
 The function EVP_PKEY_missing_parameters() returns 1 if the public key
 parameters of B<pkey> are missing and 0 if they are present or the algorithm
-doesn't use parameters.
+does not use parameters.
 
 These functions EVP_PKEY_copy_parameters() returns 1 for success and 0 for
 failure.

--- a/doc/man3/EVP_PKEY_cmp.pod
+++ b/doc/man3/EVP_PKEY_cmp.pod
@@ -53,7 +53,7 @@ These functions EVP_PKEY_copy_parameters() returns 1 for success and 0 for
 failure.
 
 The function EVP_PKEY_cmp_parameters() and EVP_PKEY_cmp() return 1 if the
-keys match, 0 if they don't match, -1 if the key types are different and
+keys match, 0 if they do not match, -1 if the key types are different and
 -2 if the operation is not supported.
 
 =head1 SEE ALSO

--- a/doc/man3/EVP_PKEY_encrypt.pod
+++ b/doc/man3/EVP_PKEY_encrypt.pod
@@ -45,7 +45,7 @@ indicates the operation is not supported by the public key algorithm.
 
 Encrypt data using OAEP (for RSA keys). See also L<PEM_read_PUBKEY(3)> or
 L<d2i_X509(3)> for means to load a public key. You may also simply
-set 'eng = NULL;' to start with the default OpenSSL RSA implementation:
+set the engine to B<NULL> to start with the default OpenSSL RSA implementation:
 
  #include <openssl/evp.h>
  #include <openssl/rsa.h>

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -151,7 +151,7 @@ Create a new object directly:
 
 =head1 BUGS
 
-OBJ_obj2txt() is awkward and messy to use: it doesn't follow the
+OBJ_obj2txt() is awkward and messy to use: it does not follow the
 convention of other OpenSSL functions where the buffer can be set
 to B<NULL> to determine the amount of data that should be written.
 Instead B<buf> must point to a valid buffer and B<buf_len> should

--- a/doc/man3/OCSP_request_add1_nonce.pod
+++ b/doc/man3/OCSP_request_add1_nonce.pod
@@ -59,7 +59,7 @@ The return values of OCSP_check_nonce() can be checked to cover each case.  A
 positive return value effectively indicates success: nonces are both present
 and match, both absent or present in the response only. A non-zero return
 additionally covers the case where the nonce is present in the request only:
-this will happen if the responder doesn't support nonces. A zero return value
+this will happen if the responder does not support nonces. A zero return value
 indicates present and mismatched nonces: this should be treated as an error
 condition.
 

--- a/doc/man3/OPENSSL_Applink.pod
+++ b/doc/man3/OPENSSL_Applink.pod
@@ -12,7 +12,7 @@ OPENSSL_Applink - glue between OpenSSL BIO and Win32 compiler run-time
 
 OPENSSL_Applink is application-side interface which provides a glue
 between OpenSSL BIO layer and Win32 compiler run-time environment.
-Even though it appears at application side, it's essentially OpenSSL
+Even though it appears at application side, it is essentially OpenSSL
 private interface. For this reason application developers are not
 expected to implement it, but to compile provided module with
 compiler of their choice and link it into the target application.

--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -44,7 +44,7 @@ and value fields.  In the description here, I<TYPE> is used a placeholder
 for any of the OpenSSL datatypes, such as I<SSL_SESSION>.
 
 lh_TYPE_new() creates a new B<LHASH_OF(TYPE)> structure to store
-arbitrary data entries, and specifies the 'hash' and 'compare'
+arbitrary data entries, and specifies the B<hash> and B<compare>
 callbacks to be used in organising the table's entries.  The B<hash>
 callback takes a pointer to a table entry as its argument and returns
 an unsigned long hash value for its key field.  The hash value is
@@ -110,7 +110,7 @@ lh_TYPE_doall() will, for every entry in the hash table, call
 B<func> with the data item as its parameter.
 For example:
 
- /* Cleans up resources belonging to 'a' (this is implemented elsewhere) */
+ /* Cleans up resources belonging to |a| (this is implemented elsewhere) */
  void TYPE_cleanup_doall(TYPE *a);
 
  /* Implement a prototype-compatible wrapper for "TYPE_cleanup" */
@@ -142,7 +142,7 @@ variables before calling your type-specific callbacks.  An example of
 this is demonstrated here (printing all hash table entries to a BIO
 that is provided by the caller):
 
- /* Prints item 'a' to 'output_bio' (this is implemented elsewhere) */
+ /* Prints item |a| to |output_bio| (this is implemented elsewhere) */
  void TYPE_print_doall_arg(const TYPE *a, BIO *output_bio);
 
  /* Implement a prototype-compatible wrapper for "TYPE_print" */
@@ -185,34 +185,34 @@ corruption and other hard-to-find bugs.  It also, apparently, violates
 ANSI-C.
 
 The LHASH code regards table entries as constant data.  As such, it
-internally represents lh_insert()'d items with a "const void *"
+internally represents lh_insert()'d items with a C<const void *>
 pointer type.  This is why callbacks such as those used by lh_doall()
-and lh_doall_arg() declare their prototypes with "const", even for the
+and lh_doall_arg() declare their prototypes with C<const>, even for the
 parameters that pass back the table items' data pointers - for
-consistency, user-provided data is "const" at all times as far as the
+consistency, user-provided data is C<const> at all times as far as the
 LHASH code is concerned.  However, as callers are themselves providing
 these pointers, they can choose whether they too should be treating
 all such parameters as constant.
 
 As an example, a hash table may be maintained by code that, for
-reasons of encapsulation, has only "const" access to the data being
-indexed in the hash table (ie. it is returned as "const" from
+reasons of encapsulation, has only C<const> access to the data being
+indexed in the hash table (ie. it is returned as C<const> from
 elsewhere in their code) - in this case the LHASH prototypes are
 appropriate as-is.  Conversely, if the caller is responsible for the
 life-time of the data in question, then they may well wish to make
 modifications to table item passed back in the lh_doall() or
 lh_doall_arg() callbacks (see the "TYPE_cleanup" example above).  If
-so, the caller can either cast the "const" away (if they're providing
+so, the caller can either cast the C<const> away (if they are providing
 the raw callbacks themselves) or use the macros to declare/implement
-the wrapper functions without "const" types.
+the wrapper functions without C<const> types.
 
-Callers that only have "const" access to data they're indexing in a
+Callers that only have C<const> access to data they are indexing in a
 table, yet declare callbacks without constant types (or cast the
-"const" away themselves), are therefore creating their own risks/bugs
+C<const> away themselves), are therefore creating their own risks/bugs
 without being encouraged to do so by the API.  On a related note,
 those auditing code should pay special attention to any instances of
 DECLARE/IMPLEMENT_LHASH_DOALL_[ARG_]_FN macros that provide types
-without any "const" qualifiers.
+without any C<const> qualifiers.
 
 =head1 BUGS
 

--- a/doc/man3/OPENSSL_LH_stats.pod
+++ b/doc/man3/OPENSSL_LH_stats.pod
@@ -27,16 +27,16 @@ OPENSSL_LH_stats() prints out statistics on the size of the hash table, how
 many entries are in it, and the number and result of calls to the
 routines in this library.
 
-OPENSSL_LH_node_stats() prints the number of entries for each 'bucket' in the
+OPENSSL_LH_node_stats() prints the number of entries for each bucket in the
 hash table.
 
 OPENSSL_LH_node_usage_stats() prints out a short summary of the state of the
-hash table.  It prints the 'load' and the 'actual load'.  The load is
-the average number of data items per 'bucket' in the hash table.  The
-'actual load' is the average number of items per 'bucket', but only
-for buckets which contain entries.  So the 'actual load' is the
+hash table.  It prints the "load" and the "actual load".  The load is
+the average number of data items per bucket in the hash table.  The
+actual load is the average number of items per bucket, but only
+for buckets which contain entries.  So the actual load is the
 average number of searches that will need to find an item in the hash
-table, while the 'load' is the average number that will be done to
+table, while the load is the average number that will be done to
 record a miss.
 
 OPENSSL_LH_stats_bio(), OPENSSL_LH_node_stats_bio() and OPENSSL_LH_node_usage_stats_bio()

--- a/doc/man3/OPENSSL_config.pod
+++ b/doc/man3/OPENSSL_config.pod
@@ -44,7 +44,7 @@ advisable. For example, to load dynamic ENGINEs from shared libraries (DSOs).
 However very few applications currently support the control interface and so
 very few can load and use dynamic ENGINEs. Equally in future more sophisticated
 ENGINEs will require certain control operations to customize them. If an
-application calls OPENSSL_config() it doesn't need to know or care about
+application calls OPENSSL_config() it does not need to know or care about
 ENGINE control operations because they can be performed by editing a
 configuration file.
 

--- a/doc/man3/OPENSSL_ia32cap.pod
+++ b/doc/man3/OPENSSL_ia32cap.pod
@@ -70,9 +70,9 @@ enable XMM registers. Historically address of the capability vector copy
 was exposed to application through OPENSSL_ia32cap_loc(), but not
 anymore. Now the only way to affect the capability detection is to set
 OPENSSL_ia32cap environment variable prior target application start. To
-give a specific example, on Intel P4 processor 'env
-OPENSSL_ia32cap=0x16980010 apps/openssl', or better yet 'env
-OPENSSL_ia32cap=~0x1000000 apps/openssl' would achieve the desired
+give a specific example, on Intel P4 processor
+C<env OPENSSL_ia32cap=0x16980010 apps/openssl>, or better yet
+C<env OPENSSL_ia32cap=~0x1000000 apps/openssl> would achieve the desired
 effect. Alternatively you can reconfigure the toolkit with no-sse2
 option and recompile.
 
@@ -112,9 +112,9 @@ a.k.a. AVX512IFMA extension;
 
 =back
 
-To control this extended capability word use ':' as delimiter when
+To control this extended capability word use ":" as delimiter when
 setting up OPENSSL_ia32cap environment variable. For example assigning
-':~0x20' would disable AVX2 code paths, and ':0' - all post-AVX
+":~0x20" would disable AVX2 code paths, and ":0" - all post-AVX
 extensions.
 
 It should be noted that whether or not some of the most "fancy"

--- a/doc/man3/OPENSSL_ia32cap.pod
+++ b/doc/man3/OPENSSL_ia32cap.pod
@@ -77,7 +77,7 @@ effect. Alternatively you can reconfigure the toolkit with no-sse2
 option and recompile.
 
 Less intuitive is clearing bit #28, or ~0x10000000 in the "environment
-variable" terms. The truth is that it's not copied from CPUID output
+variable" terms. The truth is that it is not copied from CPUID output
 verbatim, but is adjusted to reflect whether or not the data cache is
 actually shared between logical cores. This in turn affects the decision
 on whether or not expensive countermeasures against cache-timing attacks
@@ -137,7 +137,7 @@ Even though AVX512 support was implemented in llvm 3.6, compilation of
 assembly modules apparently requires explicit -march flag. But then
 compiler generates processor-specific code, which in turn contradicts
 the mere idea of run-time switch execution facilitated by the variable
-in question. Till the limitation is lifted, it's possible to work around
+in question. Till the limitation is lifted, it is possible to work around
 the problem by making build procedure use following script:
 
    #!/bin/sh

--- a/doc/man3/OPENSSL_ia32cap.pod
+++ b/doc/man3/OPENSSL_ia32cap.pod
@@ -143,7 +143,7 @@ the problem by making build procedure use following script:
    #!/bin/sh
    exec clang -no-integrated-as "$@"
 
-instead of real clang. In which case it doesn't matter which clang
+instead of real clang. In which case it does not matter which clang
 version is used, as it is GNU assembler version that will be checked.
 
 =head1 COPYRIGHT

--- a/doc/man3/OPENSSL_instrument_bus.pod
+++ b/doc/man3/OPENSSL_instrument_bus.pod
@@ -17,7 +17,7 @@ It was empirically found that timings of references to primary memory
 are subject to irregular, apparently non-deterministic variations. The
 subroutines in question instrument these references for purposes of
 gathering randomness for random number generator. In order to make it
-bus-bound a 'flush cache line' instruction is used between probes. In
+bus-bound, a "flush cache line" instruction is used between probes. In
 addition probes are added to B<vector> elements in atomic or
 interlocked manner, which should contribute additional noise on
 multi-processor systems. This also means that B<vector[num]> should be
@@ -35,9 +35,9 @@ with B<max> value of 0 meaning "as many as it takes."
 =head1 RETURN VALUE
 
 Return value of 0 indicates that CPU is not capable of performing the
-benchmark, either because oscillator counter or 'flush cache line' is
-not available on current platform. For reference, on x86 'flush cache
-line' was introduced with the SSE2 extensions.
+benchmark, either because oscillator counter or "flush cache line" is
+not available on current platform. For reference, on x86 "flush cache
+line" was introduced with the SSE2 extensions.
 
 Otherwise number of recorded values is returned.
 

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -227,8 +227,8 @@ return 1 on success or 0 on failure.
 
 =head1 NOTES
 
-While it's permitted to swap out only a few and not all the functions
-with CRYPTO_set_mem_functions(), it's recommended to swap them all out
+While it is permitted to swap out only a few and not all the functions
+with CRYPTO_set_mem_functions(), it is recommended to swap them all out
 at once.  I<This applies specially if OpenSSL was built with the
 configuration option> C<crypto-mdebug> I<enabled.  In case, swapping out
 only, say, the malloc() implementation is outright dangerous.>

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -33,7 +33,7 @@ from a given URI (see L</SUPPORTED SCHEMES> for more information on
 the supported URI schemes).
 The general method to do so is to "open" the URI using OSSL_STORE_open(),
 read each available and supported object using OSSL_STORE_load() as long as
-OSSL_STORE_eof() hasn't been reached, and finish it off with OSSL_STORE_close().
+OSSL_STORE_eof() has not been reached, and finish it off with OSSL_STORE_close().
 
 The retrieved information is stored in a B<OSSL_STORE_INFO>, which is further
 described in L<OSSL_STORE_INFO(3)>.

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -352,7 +352,7 @@ Skeleton pass phrase callback:
      /* We'd probably do something else if 'rwflag' is 1 */
      printf("Enter pass phrase for \"%s\"\n", (char *)u);
 
-     /* get pass phrase, length 'len' into 'tmp' */
+     /* get pass phrase, length |len| into |tmp| */
      tmp = "hello";
      len = strlen(tmp);
      if (len <= 0)

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -349,7 +349,7 @@ Skeleton pass phrase callback:
      int len;
      char *tmp;
 
-     /* We'd probably do something else if 'rwflag' is 1 */
+     /* We would probably do something else if |rwflag| is 1 */
      printf("Enter pass phrase for \"%s\"\n", (char *)u);
 
      /* get pass phrase, length |len| into |tmp| */

--- a/doc/man3/RSA_check_key.pod
+++ b/doc/man3/RSA_check_key.pod
@@ -51,7 +51,7 @@ override the way key data is stored and handled, and can even provide
 support for HSM keys - in which case the RSA structure may contain B<no>
 key data at all! If the ENGINE in question is only being used for
 acceleration or analysis purposes, then in all likelihood the RSA key data
-is complete and untouched, but this can't be assumed in the general case.
+is complete and untouched, but this cannot be assumed in the general case.
 
 =head1 BUGS
 

--- a/doc/man3/RSA_set_method.pod
+++ b/doc/man3/RSA_set_method.pod
@@ -116,7 +116,7 @@ the default method is used.
       * RSA_FLAG_EXT_PKEY        - rsa_mod_exp is called for private key
       *                            operations, even if p,q,dmp1,dmq1,iqmp
       *                            are NULL
-      * RSA_METHOD_FLAG_NO_CHECK - don't check pub/private match
+      * RSA_METHOD_FLAG_NO_CHECK - do not check pub/private match
       */
      int flags;
 

--- a/doc/man3/SSL_CONF_CTX_set_flags.pod
+++ b/doc/man3/SSL_CONF_CTX_set_flags.pod
@@ -50,7 +50,7 @@ file an error occurs.
 =item SSL_CONF_FLAG_SHOW_ERRORS
 
 indicate errors relating to unrecognised options or missing arguments in
-the error queue. If this option isn't set such errors are only reflected
+the error queue. If this option is not set such errors are only reflected
 in the return values of SSL_CONF_set_cmd() or SSL_CONF_set_argv()
 
 =back

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -346,7 +346,7 @@ Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
 B<TLSv1.2>, B<DTLSv1> and B<DTLSv1.2>.
 The special value B<ALL> refers to all supported versions.
 
-This can't enable protocols that are disabled using B<MinProtocol>
+This cannot enable protocols that are disabled using B<MinProtocol>
 or B<MaxProtocol>, but can disable protocols that are still allowed
 by them.
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -457,7 +457,7 @@ The value is a directory name.
 
 =item B<SSL_CONF_TYPE_NONE>
 
-The value string is not used e.g. a command line option which doesn't take an
+The value string is not used e.g. a command line option which does not take an
 argument.
 
 =back
@@ -586,7 +586,7 @@ L<SSL_CTX_set_options(3)>
 
 SSL_CONF_cmd() was first added to OpenSSL 1.0.2
 
-B<SSL_OP_NO_SSL2> doesn't have effect since 1.1.0, but the macro is retained
+B<SSL_OP_NO_SSL2> does not have effect since 1.1.0, but the macro is retained
 for backwards compatibility.
 
 B<SSL_CONF_TYPE_NONE> was first added to OpenSSL 1.1.0. In earlier versions of

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -590,7 +590,7 @@ B<SSL_OP_NO_SSL2> does not have effect since 1.1.0, but the macro is retained
 for backwards compatibility.
 
 B<SSL_CONF_TYPE_NONE> was first added to OpenSSL 1.1.0. In earlier versions of
-OpenSSL passing a command which didn't take an argument would return
+OpenSSL passing a command which did not take an argument would return
 B<SSL_CONF_TYPE_UNKNOWN>.
 
 B<MinProtocol> and B<MaxProtocol> where added in OpenSSL 1.1.0.

--- a/doc/man3/SSL_CONF_cmd_argv.pod
+++ b/doc/man3/SSL_CONF_cmd_argv.pod
@@ -24,7 +24,7 @@ or a negative error code.
 
 If -2 is returned then an argument for a command is missing.
 
-If -1 is returned the command is recognised but couldn't be processed due
+If -1 is returned the command is recognised but could not be processed due
 to an error: for example a syntax error in the argument.
 
 =head1 SEE ALSO

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -33,7 +33,7 @@ It should be noted, that inclusion of a cipher to be used into the list is
 a necessary condition. On the client side, the inclusion into the list is
 also sufficient unless the security level excludes it. On the server side,
 additional restrictions apply. All ciphers have additional requirements.
-ADH ciphers don't need a certificate, but DH-parameters must have been set.
+ADH ciphers do not need a certificate, but DH-parameters must have been set.
 All other ciphers need a corresponding certificate and key.
 
 A RSA cipher can only be chosen, when a RSA certificate is available.

--- a/doc/man3/SSL_CTX_set_early_cb.pod
+++ b/doc/man3/SSL_CTX_set_early_cb.pod
@@ -38,7 +38,7 @@ SSL_early_isv2() indicates whether the ClientHello was carried in a
 SSLv2 record and is in the SSLv2 format.  The SSLv2 format has substantial
 differences from the normal SSLv3 format, including using three bytes per
 cipher suite, and not allowing extensions.  Additionally, the SSLv2 format
-'challenge' field is exposed via SSL_early_get0_random(), padded to
+challenge field is exposed via SSL_early_get0_random(), padded to
 SSL3_RANDOM_SIZE bytes with zeros if needed.  For SSLv2 format ClientHellos,
 SSL_early_get0_compression_methods() returns a dummy list that only includes
 the null compression method, since the SSLv2 format does not include a

--- a/doc/man3/SSL_CTX_set_early_cb.pod
+++ b/doc/man3/SSL_CTX_set_early_cb.pod
@@ -94,7 +94,7 @@ and SSL_early_get0_compression_methods() return the length of the corresponding
 ClientHello fields.  If zero is returned, the output pointer should not be
 assumed to be valid.
 
-SSL_early_get0_ext() returns 1 if the extension of type 'type' is present, and
+SSL_early_get0_ext() returns 1 if the extension of type B<type> is present, and
 0 otherwise.
 
 SSL_early_get1_extensions_present() returns 1 on success and 0 on failure.

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -64,7 +64,7 @@ The following B<bug workaround> options are available:
 
 =item SSL_OP_SAFARI_ECDHE_ECDSA_BUG
 
-Don't prefer ECDHE-ECDSA ciphers when the client appears to be Safari on OS X.
+Do not prefer ECDHE-ECDSA ciphers when the client appears to be Safari on OS X.
 OS X 10.8..10.8.3 has broken support for ECDHE-ECDSA ciphers.
 
 =item SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -59,7 +59,7 @@ application specific value.
 
 =head1 DEFAULT CALLBACK BEHAVIOUR
 
-If an application doesn't set its own security callback the default
+If an application does not set its own security callback the default
 callback is used. It is intended to provide sane defaults. The meaning
 of each level is described below.
 

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -105,7 +105,7 @@ This indicates an error.
 =head1 NOTES
 
 Session resumption shortcuts the TLS so that the client certificate
-negotiation don't occur. It makes up for this by storing client certificate
+negotiation do not occur. It makes up for this by storing client certificate
 an all other negotiated state information encrypted within the ticket. In a
 resumed session the applications will have all this state information available
 exactly as if a full negotiation had occurred.

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -145,7 +145,7 @@ Reference Implementation:
                                  * an aes_key, a hmac_key and optionally
                                  * an expire time.
                                  */
-             if (key == NULL) /* key couldn't be created */
+             if (key == NULL) /* key could not be created */
                  return 0;
          }
          memcpy(key_name, key->name, 16);

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -138,7 +138,7 @@ Reference Implementation:
 
          key = currentkey(); /* something that you need to implement */
          if (key == NULL) {
-             /* current key does not exist or isn't valid */
+             /* current key does not exist or is not valid */
              key = createkey(); /*
                                  * Something that you need to implement.
                                  * createkey needs to initialise a name,

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -40,7 +40,7 @@ ticket.
 Before the callback function is started I<ctx> and I<hctx> have been
 initialised with EVP_CIPHER_CTX_init and HMAC_CTX_init respectively.
 
-For new sessions tickets, when the client doesn't present a session ticket, or
+For new sessions tickets, when the client does not present a session ticket, or
 an attempted retrieval of the ticket failed, or a renew option was indicated,
 the callback function will be called with I<enc> equal to 1. The OpenSSL
 library expects that the function will set an arbitrary I<name>, initialize
@@ -138,7 +138,7 @@ Reference Implementation:
 
          key = currentkey(); /* something that you need to implement */
          if (key == NULL) {
-             /* current key doesn't exist or isn't valid */
+             /* current key does not exist or isn't valid */
              key = createkey(); /*
                                  * Something that you need to implement.
                                  * createkey needs to initialise a name,

--- a/doc/man3/SSL_CTX_set_tmp_dh_callback.pod
+++ b/doc/man3/SSL_CTX_set_tmp_dh_callback.pod
@@ -62,8 +62,8 @@ generate their own DH parameters during the installation process using the
 openssl L<dhparam(1)> application. This application
 guarantees that "strong" primes are used.
 
-Files dh2048.pem, and dh4096.pem in the 'apps' directory of the current
-version of the OpenSSL distribution contain the 'SKIP' DH parameters,
+Files dh2048.pem, and dh4096.pem in the C<apps> directory of the current
+version of the OpenSSL distribution contain the "SKIP" DH parameters,
 which use safe primes and were generated verifiably pseudo-randomly.
 These files can be converted into C code using the B<-C> option of the
 L<dhparam(1)> application. Generation of custom DH

--- a/doc/man3/SSL_CTX_set_verify.pod
+++ b/doc/man3/SSL_CTX_set_verify.pod
@@ -46,7 +46,7 @@ verification that shall be allowed for B<ssl>.
 =head1 NOTES
 
 The verification of certificates can be controlled by a set of logically
-or'ed B<mode> flags:
+or'd B<mode> flags:
 
 =over 4
 

--- a/doc/man3/SSL_alert_type_string.pod
+++ b/doc/man3/SSL_alert_type_string.pod
@@ -130,9 +130,9 @@ other fields. This is always fatal.
 
 =item "DC"/"decryption failed"
 
-A TLSCiphertext decrypted in an invalid way: either it wasn't an
+A TLSCiphertext decrypted in an invalid way: either it was not an
 even multiple of the block length or its padding values, when
-checked, weren't correct. This message is always fatal.
+checked, were not correct. This message is always fatal.
 
 =item "RO"/"record overflow"
 
@@ -144,7 +144,7 @@ with more than 2^14+1024 bytes. This message is always fatal.
 
 A valid certificate chain or partial chain was received, but the
 certificate was not accepted because the CA certificate could not
-be located or couldn't be matched with a known, trusted CA.  This
+be located or could not be matched with a known, trusted CA.  This
 message is always fatal.
 
 =item "AD"/"access denied"

--- a/doc/man3/SSL_get_client_random.pod
+++ b/doc/man3/SSL_get_client_random.pod
@@ -46,7 +46,7 @@ suitable for the ciphersuite associated with the SSL_SESSION.
 
 =head1 NOTES
 
-You probably shouldn't use these functions.
+You probably should not use these functions.
 
 These functions expose internal values from the TLS handshake, for
 use in low-level protocols.  You probably should not use them, unless

--- a/doc/man3/SSL_read.pod
+++ b/doc/man3/SSL_read.pod
@@ -115,7 +115,7 @@ Call L<SSL_get_error(3)> with the return value B<ret> to find out the reason.
 
 Old documentation indicated a difference between 0 and -1, and that -1 was
 retryable.
-You should instead call SSL_get_error() to find out if it's retryable.
+You should instead call SSL_get_error() to find out if it is retryable.
 
 =back
 

--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -99,7 +99,7 @@ Call SSL_get_error() with the return value B<ret> to find out the reason.
 
 Old documentation indicated a difference between 0 and -1, and that -1 was
 retryable.
-You should instead call SSL_get_error() to find out if it's retryable.
+You should instead call SSL_get_error() to find out if it is retryable.
 
 =back
 

--- a/doc/man3/UI_STRING.pod
+++ b/doc/man3/UI_STRING.pod
@@ -83,7 +83,7 @@ For B<UIT_BOOLEAN> type UI strings, this sets the first character of
 the result retrievable with UI_get0_result_string() to the first
 B<ok_char> given with UI_add_input_boolean() or UI_dup_input_boolean()
 if the B<result> matched any of them, or the first of the
-B<cancel_chars> if the B<result> matched any of them, otherwise it's
+B<cancel_chars> if the B<result> matched any of them, otherwise it is
 set to the NUL char C<\0>.
 See L<UI_add_input_boolean(3)> for more information on B<ok_chars> and
 B<cancel_chars>.

--- a/doc/man3/UI_create_method.pod
+++ b/doc/man3/UI_create_method.pod
@@ -103,7 +103,7 @@ Regarding the writer and the reader, do not assume the former should
 only write and do not assume the latter should only read.
 This depends on the needs of the method.
 
-For example, a typical tty reader wouldn't write the prompts in the
+For example, a typical TTY reader would not write the prompts in the
 write, but would rather do so in the reader, because of the sequential
 nature of prompting on a tty.
 This is how the UI_OpenSSL() method does it.

--- a/doc/man3/UI_create_method.pod
+++ b/doc/man3/UI_create_method.pod
@@ -99,8 +99,8 @@ Only the flusher or the reader are expected to return -1.
 If returned by another of the functions, it's treated as if 0 was
 returned.
 
-Regarding the writer and the reader, don't assume the former should
-only write and don't assume the latter should only read.
+Regarding the writer and the reader, do not assume the former should
+only write and do not assume the latter should only read.
 This depends on the needs of the method.
 
 For example, a typical tty reader wouldn't write the prompts in the

--- a/doc/man3/UI_create_method.pod
+++ b/doc/man3/UI_create_method.pod
@@ -96,7 +96,7 @@ All of these functions are expected to return 0 on error, 1 on
 success, or -1 on out-off-band events, for example if some prompting
 has been cancelled (by pressing Ctrl-C, for example).
 Only the flusher or the reader are expected to return -1.
-If returned by another of the functions, it's treated as if 0 was
+If returned by another of the functions, it is treated as if 0 was
 returned.
 
 Regarding the writer and the reader, do not assume the former should
@@ -193,7 +193,7 @@ UI_method_get_opener(), UI_method_get_writer(),
 UI_method_get_flusher(), UI_method_get_reader(),
 UI_method_get_closer(), UI_method_get_data_duplicator(),
 UI_method_get_data_destructor() and UI_method_get_prompt_constructor()
-return the requested function pointer if it's set in the method,
+return the requested function pointer if it is set in the method,
 otherwise NULL.
 
 UI_method_get_ex_data() returns a pointer to the application specific

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -119,7 +119,7 @@ information is used to prompt for information, for example a password,
 and to verify a password (i.e. having the user enter it twice and check
 that the same string was entered twice).  UI_add_verify_string() takes
 and extra argument that should be a pointer to the result buffer of the
-input string that it's supposed to verify, or verification will fail.
+input string that it is supposed to verify, or verification will fail.
 
 UI_add_input_boolean() adds a prompt to the UI that's supposed to be answered
 in a boolean way, with a single character for yes and a different character

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -80,7 +80,7 @@ The first thing to do is to create a UI with UI_new() or UI_new_method(),
 then add information to it with the UI_add or UI_dup functions.  Also,
 user-defined random data can be passed down to the underlying method
 through calls to UI_add_user_data() or UI_dup_user_data().  The default
-UI method doesn't care about these data, but other methods might.  Finally,
+UI method does not care about these data, but other methods might.  Finally,
 use UI_process() to actually perform the prompting and UI_get0_result()
 to find the result to the prompt.
 
@@ -156,8 +156,8 @@ string and may include encodings that will be processed by the other
 method functions.
 
 UI_add_user_data() adds a user data pointer for the method to use at any
-time.  The builtin UI method doesn't care about this info.  Note that several
-calls to this function doesn't add data, it replaces the previous blob
+time.  The builtin UI method does not care about this info.  Note that several
+calls to this function does not add data, it replaces the previous blob
 with the one given as argument.
 
 UI_dup_user_data() duplicates the user data and works as an alternative
@@ -165,7 +165,7 @@ to UI_add_user_data() when the user data needs to be preserved for a longer
 duration, perhaps even the lifetime of the application.  The UI object takes
 ownership of this duplicate and will free it whenever it gets replaced or
 the UI is destroyed.  UI_dup_user_data() returns 0 on success, or -1 on memory
-allocation failure or if the method doesn't have a duplicator function.
+allocation failure or if the method does not have a duplicator function.
 
 UI_get0_user_data() retrieves the data that has last been given to the
 UI with UI_add_user_data() or UI_dup_user_data.

--- a/doc/man3/X509_NAME_get_index_by_NID.pod
+++ b/doc/man3/X509_NAME_get_index_by_NID.pod
@@ -29,7 +29,7 @@ and issuer names.
 X509_NAME_get_index_by_NID() and X509_NAME_get_index_by_OBJ() retrieve
 the next index matching B<nid> or B<obj> after B<lastpos>. B<lastpos>
 should initially be set to -1. If there are no more entries -1 is returned.
-If B<nid> is invalid (doesn't correspond to a valid OID) then -2 is returned.
+If B<nid> is invalid (does not correspond to a valid OID) then -2 is returned.
 
 X509_NAME_entry_count() returns the total number of entries in B<name>.
 

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -36,9 +36,9 @@ characters. Multiple lines are used if the output (including indent) exceeds
 =head1 NOTES
 
 The functions X509_NAME_oneline() and X509_NAME_print()
-produce a non standard output form, they don't handle multi character fields and
-have various quirks and inconsistencies.
-Their use is strongly discouraged in new applications and they could
+produce a non-standard output form, they do not handle multi-character fields,
+and have various quirks and inconsistencies.
+Their use is strongly discouraged and they could
 be deprecated in a future release.
 
 Although there are a large number of possible flags for most purposes

--- a/doc/man3/X509_STORE_CTX_set_verify_cb.pod
+++ b/doc/man3/X509_STORE_CTX_set_verify_cb.pod
@@ -111,11 +111,11 @@ to continue after this error:
      /* Tolerate certificate expiration */
      if (X509_STORE_CTX_get_error(ctx) == X509_V_ERR_CERT_HAS_EXPIRED)
          return 1;
-     /* Otherwise don't override */
+     /* Otherwise do not override */
      return ok;
  }
 
-More complex example, we don't wish to continue after B<any> certificate has
+More complex example, we do not wish to continue after B<any> certificate has
 expired just one specific case:
 
  int verify_callback(int ok, X509_STORE_CTX *ctx)

--- a/doc/man3/X509_STORE_set_verify_cb_func.pod
+++ b/doc/man3/X509_STORE_set_verify_cb_func.pod
@@ -138,7 +138,7 @@ function will be used instead.>
 
 X509_STORE_set_check_issued() sets the function to check that a given
 certificate B<x> is issued with the issuer certificate B<issuer>.
-This function must return 0 on failure (among others if B<x> hasn't
+This function must return 0 on failure (among others if B<x> has not
 been issued with B<issuer>) and 1 on success.
 I<If no function to get the issuer is provided, the internal default
 function will be used instead.>

--- a/doc/man3/X509_STORE_set_verify_cb_func.pod
+++ b/doc/man3/X509_STORE_set_verify_cb_func.pod
@@ -187,7 +187,7 @@ function will be used instead.>
 
 X509_STORE_set_cleanup() sets the final cleanup function, which is
 called when the context (B<X509_STORE_CTX>) is being torn down.
-This function doesn't return any value.
+This function does not return any value.
 I<If no function to get the issuer is provided, the internal default
 function will be used instead.>
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -242,7 +242,7 @@ If B<X509_V_FLAG_USE_DELTAS> is set delta CRLs (if present) are used to
 determine certificate status. If not set deltas are ignored.
 
 B<X509_V_FLAG_CHECK_SS_SIGNATURE> enables checking of the root CA self signed
-certificate signature. By default this check is disabled because it doesn't
+certificate signature. By default this check is disabled because it does not
 add any additional security but in some cases applications might want to
 check the signature anyway. A side effect of not checking the root CA
 signature is that disabled or unsupported message digests on the root CA

--- a/doc/man3/X509_check_private_key.pod
+++ b/doc/man3/X509_check_private_key.pod
@@ -32,7 +32,7 @@ obtained using L<ERR_get_error(3)>.
 
 =head1 BUGS
 
-The B<check_private_key> functions don't check if B<k> itself is indeed
+The B<check_private_key> functions do not check if B<k> itself is indeed
 a private key or not. It merely compares the public materials (e.g. exponent
 and modulus of an RSA key) and/or key parameters (e.g. EC params of an EC key)
 of a key pair. So if you pass a public key to these functions in B<k>, it will

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -36,7 +36,7 @@ The function X509_up_ref() if useful if a certificate structure is being
 used by several different operations each of which will free it up after
 use: this avoids the need to duplicate the entire certificate structure.
 
-The function X509_chain_up_ref() doesn't just up the reference count of
+The function X509_chain_up_ref() does not just up the reference count of
 each certificate it also returns a copy of the stack, using sk_X509_dup(),
 but it serves a similar purpose: the returned chain persists after the
 original has been freed.

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -289,9 +289,9 @@ default section both values can be looked up with B<TEMP> taking
 priority and B</tmp> used if neither is defined:
 
  TMP=/tmp
- # The above value is used if TMP isn't in the environment
+ # The above value is used if TMP is not in the environment
  TEMP=$ENV::TMP
- # The above value is used if TEMP isn't in the environment
+ # The above value is used if TEMP is not in the environment
  tmpfile=${ENV::TEMP}/tmp.filename
 
 Simple OpenSSL library configuration example to enter FIPS mode:
@@ -353,7 +353,7 @@ Currently there is no way to include characters using the octal B<\nnn>
 form. Strings are all null terminated so nulls cannot form part of
 the value.
 
-The escaping isn't quite right: if you want to use sequences like B<\n>
+The escaping is not quite right: if you want to use sequences like B<\n>
 you can't use any quote escaping on the same line.
 
 Files are loaded in a single pass. This means that an variable expansion

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -354,7 +354,7 @@ form. Strings are all null terminated so nulls cannot form part of
 the value.
 
 The escaping is not quite right: if you want to use sequences like B<\n>
-you can't use any quote escaping on the same line.
+you cannot use any quote escaping on the same line.
 
 Files are loaded in a single pass. This means that an variable expansion
 will only work if the variables referenced are defined earlier in the

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -311,7 +311,7 @@ Simple OpenSSL library configuration example to enter FIPS mode:
 Note: in the above example you will get an error in non FIPS capable versions
 of OpenSSL.
 
-More complex OpenSSL library configuration. Add OID and don't enter FIPS mode:
+More complex OpenSSL library configuration. Add OID and do not enter FIPS mode:
 
  # Default appname: should match "appname" parameter (if any)
  # supplied to CONF_modules_load_file et al.

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -183,7 +183,7 @@ For example:
  dynamic_path = /some/path/fooengine.so
  # A foo specific ctrl.
  some_ctrl = some_value
- # Another ctrl that doesn't take a value.
+ # Another ctrl that does not take a value.
  other_ctrl = EMPTY
  # Supply all default algorithms
  default_algorithms = ALL
@@ -228,9 +228,9 @@ For example:
 
 =head1 NOTES
 
-If a configuration file attempts to expand a variable that doesn't exist
+If a configuration file attempts to expand a variable that does not exist
 then an error is flagged and the file will not load. This can happen
-if an attempt is made to expand an environment variable that doesn't
+if an attempt is made to expand an environment variable that does not
 exist. For example in a previous version of OpenSSL the default OpenSSL
 master configuration file used the value of B<HOME> which may not be
 defined on non Unix systems and would cause an error.
@@ -283,7 +283,7 @@ Suppose you want a variable called B<tmpfile> to refer to a
 temporary filename. The directory it is placed in can determined by
 the B<TEMP> or B<TMP> environment variables but they may not be
 set to any value at all. If you just include the environment variable
-names and the variable doesn't exist then this will cause an error when
+names and the variable does not exist then this will cause an error when
 an attempt is made to load the configuration file. By making use of the
 default section both values can be looked up with B<TEMP> taking
 priority and B</tmp> used if neither is defined:

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -164,7 +164,7 @@ B<URI> a uniform resource indicator, B<DNS> (a DNS domain name), B<RID> (a
 registered ID: OBJECT IDENTIFIER), B<IP> (an IP address), B<dirName>
 (a distinguished name) and otherName.
 
-The email option include a special 'copy' value. This will automatically
+The email option include a special C<copy> value. This will automatically
 include any email addresses contained in the certificate subject name in
 the extension.
 
@@ -329,7 +329,7 @@ This section can include explicitText, organization and noticeNumbers
 options. explicitText and organization are text strings, noticeNumbers is a
 comma separated list of numbers. The organization and noticeNumbers options
 (if included) must BOTH be present. If you use the userNotice option with IE5
-then you need the 'ia5org' option at the top level to modify the encoding:
+then you need the C<ia5org> option at the top level to modify the encoding:
 otherwise it will not be interpreted properly.
 
 Example:

--- a/doc/man7/des_modes.pod
+++ b/doc/man7/des_modes.pod
@@ -174,7 +174,7 @@ Each re-initialization should use a value of the start variable
 different from the start variable values used before with the same
 key.  The reason for this is that an identical bit stream would be
 produced each time from the same parameters.  This would be
-susceptible to a known plaintext attack.
+susceptible to a known-plaintext attack.
 
 =back
 

--- a/doc/man7/des_modes.pod
+++ b/doc/man7/des_modes.pod
@@ -29,7 +29,7 @@ The order of the blocks can be rearranged without detection.
 =item *
 
 The same plaintext block always produces the same ciphertext block
-(for the same key) making it vulnerable to a 'dictionary attack'.
+(for the same key) making it vulnerable to a dictionary attack.
 
 =item *
 
@@ -174,7 +174,7 @@ Each re-initialization should use a value of the start variable
 different from the start variable values used before with the same
 key.  The reason for this is that an identical bit stream would be
 produced each time from the same parameters.  This would be
-susceptible to a 'known plaintext' attack.
+susceptible to a known plaintext attack.
 
 =back
 

--- a/doc/man7/ossl_store.pod
+++ b/doc/man7/ossl_store.pod
@@ -43,7 +43,7 @@ possible PEM headers, together with the decoded PEM body.  Since PEM
 formatted files can contain more than one object, the file handlers
 are called upon for each such object.
 
-If the file isn't determined to be formatted as PEM, the content is
+If the file is not determined to be formatted as PEM, the content is
 loaded in raw form in its entirety and passed to the available file
 handlers as is, with no PEM name or headers.
 
@@ -59,6 +59,10 @@ only).
 
 =head2 A generic call
 
+ /*
+  * There is also a OSSL_STORE_open_file() that can be used for file paths
+  * that cannot be represented as URIs, such as Windows backslashes
+  */
  OSSL_STORE_CTX *ctx = OSSL_STORE_open("file:/foo/bar/data.pem");
 
  /*

--- a/doc/man7/ssl.pod
+++ b/doc/man7/ssl.pod
@@ -96,13 +96,13 @@ Unused. Present for backwards compatibility only.
 =item B<ssl3.h>
 
 That's the sub header file dealing with the SSLv3 protocol only.
-I<Usually you don't have to include it explicitly because
+I<Usually you do not have to include it explicitly because
 it's already included by ssl.h>.
 
 =item B<tls1.h>
 
 That's the sub header file dealing with the TLSv1 protocol only.
-I<Usually you don't have to include it explicitly because
+I<Usually you do not have to include it explicitly because
 it's already included by ssl.h>.
 
 =back

--- a/doc/man7/ssl.pod
+++ b/doc/man7/ssl.pod
@@ -42,9 +42,9 @@ structures:
 
 =item B<SSL_METHOD> (SSL Method)
 
-That's a dispatch structure describing the internal B<ssl> library
+That is a dispatch structure describing the internal B<ssl> library
 methods/functions which implement the various protocol versions (SSLv3
-TLSv1, ...). It's needed to create an B<SSL_CTX>.
+TLSv1, ...). It is needed to create an B<SSL_CTX>.
 
 =item B<SSL_CIPHER> (SSL Cipher)
 
@@ -55,7 +55,7 @@ B<SSL_SESSION>.
 
 =item B<SSL_CTX> (SSL Context)
 
-That's the global context structure which is created by a server or client
+That is the global context structure which is created by a server or client
 once per program life-time and which holds mainly default values for the
 B<SSL> structures which are later created for the connections.
 
@@ -66,7 +66,7 @@ connection: B<SSL_CIPHER>s, client and server certificates, keys, etc.
 
 =item B<SSL> (SSL Connection)
 
-That's the main SSL/TLS structure which is created by a server or client per
+That is the main SSL/TLS structure which is created by a server or client per
 established connection. This actually is the core structure in the SSL API.
 Under run-time the application usually deals with this structure which has
 links to mostly all other structures.
@@ -83,7 +83,7 @@ containing the prototypes for the data structures and functions:
 
 =item B<ssl.h>
 
-That's the common header file for the SSL/TLS API.  Include it into your
+That is the common header file for the SSL/TLS API.  Include it into your
 program to make the API of the B<ssl> library available. It internally
 includes both more private SSL headers and headers from the B<crypto> library.
 Whenever you need hard-core details on the internals of the SSL API, look
@@ -95,15 +95,15 @@ Unused. Present for backwards compatibility only.
 
 =item B<ssl3.h>
 
-That's the sub header file dealing with the SSLv3 protocol only.
+That is the sub header file dealing with the SSLv3 protocol only.
 I<Usually you do not have to include it explicitly because
-it's already included by ssl.h>.
+it is already included by ssl.h>.
 
 =item B<tls1.h>
 
-That's the sub header file dealing with the TLSv1 protocol only.
+That is the sub header file dealing with the TLSv1 protocol only.
 I<Usually you do not have to include it explicitly because
-it's already included by ssl.h>.
+it is already included by ssl.h>.
 
 =back
 

--- a/doc/man7/x509.pod
+++ b/doc/man7/x509.pod
@@ -27,7 +27,7 @@ X509_NAME (to express a certificate name), X509_ATTRIBUTE (to express
 a certificate attributes), X509_EXTENSION (to express a certificate
 extension) and a few more.
 
-Finally, there's the supertype X509_INFO, which can contain a CRL, a
+Finally, there is the supertype X509_INFO, which can contain a CRL, a
 certificate and a corresponding private key.
 
 B<X509_>I<...>, B<d2i_X509_>I<...> and B<i2d_X509_>I<...> handle X.509

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -179,6 +179,11 @@ sub check()
         if $contents =~ /=over([^ ][^24])/;
     print "$id Possible version style issue\n"
         if $contents =~ /OpenSSL version [019]/;
+    # Leave out foo'd and foo's
+    print "$id Contraction $1\n"
+        if $contents =~ /([\w]'[abce-rt-z][^'\w])/;
+    #print "$id Maybe contraction \"$1\"\n"
+    #    if $contents =~ /(.{1,10}[\w]'[a-z].{1,10})/;
 
     if ( $contents !~ /=for comment multiple includes/ ) {
         # Look for multiple consecutive openssl #include lines


### PR DESCRIPTION
Following @kaduk's comment about avoiding contractions in docs, I did it.  Also updated the script to warn about them (not all, sadly, since we using possessive and things like or'd for flags).
