### PR TITLE
UI_UTIL_wrap_read_pem_callback: make sure to terminate the string received

### DIFF
--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -104,7 +104,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
     switch (UI_get_string_type(uis)) {
     case UIT_PROMPT:
         {
-            char result[PEM_BUFSIZE];
+            char result[PEM_BUFSIZE + 1];
             const struct pem_password_cb_data *data =
                 UI_method_get_ex_data(UI_get_method(ui), ui_method_data_index);
             int maxsize = UI_get_result_maxsize(uis);
@@ -112,6 +112,8 @@ static int ui_read(UI *ui, UI_STRING *uis)
                                maxsize > PEM_BUFSIZE ? PEM_BUFSIZE : maxsize,
                                data->rwflag, UI_get0_user_data(ui));
 
+            if (len >= 0)
+                result[len] = '\0';
             if (len <= 0)
                 return len;
             if (UI_set_result(ui, uis, result) >= 0)

--- a/test/uitest.c
+++ b/test/uitest.c
@@ -24,7 +24,7 @@ char *default_config_file = NULL;
 static int test_pem_password_cb(char *buf, int size, int rwflag, void *userdata)
 {
     OPENSSL_strlcpy(buf, (char *)userdata, (size_t)size);
-    return 1;
+    return strlen(buf);
 }
 
 /*


### PR DESCRIPTION
The callback we're wrapping around may or may not return a NUL-terminated string.  Let's ensure it is.
