### PR TITLE
Add dependency on apps/progs.h for test/uitest.o

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -336,6 +336,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   ENDIF
 
   SOURCE[uitest]=uitest.c ../apps/apps.c ../apps/opt.c
+  DEPEND[uitest.o]=../apps/progs.h
   INCLUDE[uitest]=.. ../include ../apps
   DEPEND[uitest]=../libcrypto ../libssl libtestutil.a
 


### PR DESCRIPTION
uitest.o depends on apps.h which depends on progs.h, which is
dynamically generated, so we need to explicitely add a dependency
between uitest.o and progs.h for the latter to be generated in time.

Fixed #3793
