### PR TITLE
Fix double array increment in s_client mysql connect

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2406,10 +2406,9 @@ int s_client_main(int argc, char **argv)
                 } else if (packet[pos++] == '\0') {
                     break;
                 }
-                pos++;
             }
 
-            /* make sure we have more 15 bytes left in the packet */
+            /* make sure we have at least 15 bytes left in the packet */
             if (pos + 15 > bytes) {
                 BIO_printf(bio_err,
                            "MySQL server handshake packet is broken.\n");


### PR DESCRIPTION
The packet parsing code for the server version string was incrementing
the array index twice on every iteration. This meant that strings with
an even number of characters would pass, but strings with an odd number
(5.7.18-0ubuntu0.16.04.1) would cause the pos variable to get out of sync.

This would cause a later failure with "MySQL packet is broken."
