### PR TITLE
Drop support for OPENSSL_NO_TLS1_3_METHOD

### DIFF
--- a/Configure
+++ b/Configure
@@ -416,7 +416,7 @@ my @disablables = (
 foreach my $proto ((@tls, @dtls))
 	{
 	push(@disablables, $proto);
-	push(@disablables, "$proto-method");
+	push(@disablables, "$proto-method") unless $proto eq "tls1_3";
 	}
 
 my %deprecated_disablables = (

--- a/ssl/methods.c
+++ b/ssl/methods.c
@@ -19,12 +19,10 @@ IMPLEMENT_tls_meth_func(TLS_ANY_VERSION, 0, 0,
                         TLS_method,
                         ossl_statem_accept,
                         ossl_statem_connect, TLSv1_2_enc_data)
-#ifndef OPENSSL_NO_TLS1_3_METHOD
 IMPLEMENT_tls_meth_func(TLS1_3_VERSION, 0, SSL_OP_NO_TLSv1_3,
                         tlsv1_3_method,
                         ossl_statem_accept,
                         ossl_statem_connect, TLSv1_3_enc_data)
-#endif
 #ifndef OPENSSL_NO_TLS1_2_METHOD
 IMPLEMENT_tls_meth_func(TLS1_2_VERSION, 0, SSL_OP_NO_TLSv1_2,
                         tlsv1_2_method,
@@ -52,12 +50,10 @@ IMPLEMENT_tls_meth_func(TLS_ANY_VERSION, 0, 0,
                         TLS_server_method,
                         ossl_statem_accept,
                         ssl_undefined_function, TLSv1_2_enc_data)
-#ifndef OPENSSL_NO_TLS1_3_METHOD
 IMPLEMENT_tls_meth_func(TLS1_3_VERSION, 0, SSL_OP_NO_TLSv1_3,
                         tlsv1_3_server_method,
                         ossl_statem_accept,
                         ssl_undefined_function, TLSv1_3_enc_data)
-#endif
 #ifndef OPENSSL_NO_TLS1_2_METHOD
 IMPLEMENT_tls_meth_func(TLS1_2_VERSION, 0, SSL_OP_NO_TLSv1_2,
                         tlsv1_2_server_method,
@@ -87,12 +83,10 @@ IMPLEMENT_tls_meth_func(TLS_ANY_VERSION, 0, 0,
                         TLS_client_method,
                         ssl_undefined_function,
                         ossl_statem_connect, TLSv1_2_enc_data)
-#ifndef OPENSSL_NO_TLS1_3_METHOD
 IMPLEMENT_tls_meth_func(TLS1_3_VERSION, 0, SSL_OP_NO_TLSv1_3,
                         tlsv1_3_client_method,
                         ssl_undefined_function,
                         ossl_statem_connect, TLSv1_3_enc_data)
-#endif
 #ifndef OPENSSL_NO_TLS1_2_METHOD
 IMPLEMENT_tls_meth_func(TLS1_2_VERSION, 0, SSL_OP_NO_TLSv1_2,
                         tlsv1_2_client_method,


### PR DESCRIPTION
There are no public TLSv1_3_*method() functions so
OPENSSL_NO_TLS1_3_METHOD doesn't make any sense and should be removed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
