### PR TITLE
Remove the possibility to disable the UI module entirely

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,17 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) The UI API becomes a permanent and integral part of libcrypto, i.e.
+     not possible to disable entirely.  However, it's still possible to
+     disable the console reading UI method, UI_OpenSSL() (use UI_null()
+     as a fallback).
+
+     To disable, configure with 'no-ui-console'.  'no-ui' is still
+     possible to use as an alias.  Check at compile time with the
+     macro OPENSSL_NO_UI_CONSOLE.  The macro OPENSSL_NO_UI is still
+     possible to check and is an alias for OPENSSL_NO_UI_CONSOLE.
+     [Richard Levitte]
+
   *) Add a STORE module, which implements a uniform and URI based reader of
      stores that can contain keys, certificates, CRLs and numerous other
      objects.  The main API is loosely based on a few stdio functions,

--- a/Configure
+++ b/Configure
@@ -406,7 +406,7 @@ my @disablables = (
     "tls13downgrade",
     "ts",
     "ubsan",
-    "ui",
+    "ui-console",
     "unit-test",
     "whirlpool",
     "weak-ssl-ciphers",
@@ -422,7 +422,8 @@ foreach my $proto ((@tls, @dtls))
 my %deprecated_disablables = (
     "ssl2" => undef,
     "buf-freelists" => undef,
-    "ripemd" => "rmd160"
+    "ripemd" => "rmd160",
+    "ui" => "ui-console",
     );
 
 # All of the following is disabled by default (RC5 was enabled before 0.9.8):

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -308,7 +308,7 @@ int enc_main(int argc, char **argv)
 
     if ((str == NULL) && (cipher != NULL) && (hkey == NULL)) {
         if (1) {
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
             for (;;) {
                 char prompt[200];
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -70,18 +70,14 @@ static int apps_startup()
                              | OPENSSL_INIT_LOAD_CONFIG, NULL))
         return 0;
 
-#ifndef OPENSSL_NO_UI
     setup_ui_method();
-#endif
 
     return 1;
 }
 
 static void apps_shutdown()
 {
-#ifndef OPENSSL_NO_UI
     destroy_ui_method();
-#endif
 }
 
 static char *make_config_name()

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -100,7 +100,7 @@ int passwd_main(int argc, char **argv)
     char *salt_malloc = NULL, *passwd_malloc = NULL, *prog;
     OPTION_CHOICE o;
     int in_stdin = 0, pw_source_defined = 0;
-# ifndef OPENSSL_NO_UI
+# ifndef OPENSSL_NO_UI_CONSOLE
     int in_noverify = 0;
 # endif
     int passed_salt = 0, quiet = 0, table = 0, reverse = 0;
@@ -129,7 +129,7 @@ int passwd_main(int argc, char **argv)
             pw_source_defined = 1;
             break;
         case OPT_NOVERIFY:
-# ifndef OPENSSL_NO_UI
+# ifndef OPENSSL_NO_UI_CONSOLE
             in_noverify = 1;
 # endif
             break;
@@ -246,7 +246,7 @@ int passwd_main(int argc, char **argv)
          * avoid rot of not-frequently-used code.
          */
         if (1) {
-# ifndef OPENSSL_NO_UI
+# ifndef OPENSSL_NO_UI_CONSOLE
             /* build a null-terminated list */
             static char *passwds_static[2] = { NULL, NULL };
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -322,7 +322,7 @@ int pkcs12_main(int argc, char **argv)
     if (twopass) {
         /* To avoid bit rot */
         if (1) {
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
             if (EVP_read_pw_string
                 (macpass, sizeof macpass, "Enter MAC Password:", export_cert)) {
                 BIO_printf(bio_err, "Can't read Password\n");
@@ -441,7 +441,7 @@ int pkcs12_main(int argc, char **argv)
         if (!noprompt) {
             /* To avoid bit rot */
             if (1) {
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
                 if (EVP_read_pw_string(pass, sizeof pass, "Enter Export Password:",
                                        1)) {
                     BIO_printf(bio_err, "Can't read Password\n");
@@ -507,7 +507,7 @@ int pkcs12_main(int argc, char **argv)
 
     if (!noprompt) {
         if (1) {
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
             if (EVP_read_pw_string(pass, sizeof pass, "Enter Import Password:",
                                    0)) {
                 BIO_printf(bio_err, "Can't read Password\n");

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -65,7 +65,7 @@ int pkcs8_main(int argc, char **argv)
     const EVP_CIPHER *cipher = NULL;
     char *infile = NULL, *outfile = NULL;
     char *passinarg = NULL, *passoutarg = NULL, *prog;
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
     char pass[APP_PASS_LEN];
 #endif
     char *passin = NULL, *passout = NULL, *p8pass = NULL;
@@ -236,7 +236,7 @@ int pkcs8_main(int argc, char **argv)
                 p8pass = passout;
             } else if (1) {
                 /* To avoid bit rot */
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
                 p8pass = pass;
                 if (EVP_read_pw_string
                     (pass, sizeof pass, "Enter Encryption Password:", 1)) {
@@ -299,7 +299,7 @@ int pkcs8_main(int argc, char **argv)
         if (passin != NULL) {
             p8pass = passin;
         } else if (1) {
-#ifndef OPENSSL_NO_UI
+#ifndef OPENSSL_NO_UI_CONSOLE
             p8pass = pass;
             if (EVP_read_pw_string(pass, sizeof pass, "Enter Password:", 0)) {
                 BIO_printf(bio_err, "Can't read Password\n");

--- a/crypto/err/err_all.c
+++ b/crypto/err/err_all.c
@@ -83,9 +83,7 @@ int err_load_crypto_strings_int(void)
 # ifndef OPENSSL_NO_OCSP
         ERR_load_OCSP_strings() == 0 ||
 # endif
-#ifndef OPENSSL_NO_UI
         ERR_load_UI_strings() == 0 ||
-#endif
 # ifndef OPENSSL_NO_CMS
         ERR_load_CMS_strings() == 0 ||
 # endif

--- a/crypto/evp/evp_key.c
+++ b/crypto/evp/evp_key.c
@@ -14,7 +14,6 @@
 #include <openssl/evp.h>
 #include <openssl/ui.h>
 
-#ifndef OPENSSL_NO_UI
 /* should be init to zeros. */
 static char prompt_string[80];
 
@@ -69,7 +68,6 @@ int EVP_read_pw_string_min(char *buf, int min, int len, const char *prompt,
     OPENSSL_cleanse(buff, BUFSIZ);
     return ret;
 }
-#endif /* OPENSSL_NO_UI */
 
 int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
                    const unsigned char *salt, const unsigned char *data,

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -30,12 +30,8 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 int PEM_def_callback(char *buf, int num, int w, void *key)
 {
-#if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
-    int i;
-#else
     int i, j;
     const char *prompt;
-#endif
 
     if (key) {
         i = strlen(key);
@@ -44,10 +40,6 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
         return i;
     }
 
-#if defined(OPENSSL_NO_STDIO) || defined(OPENSSL_NO_UI)
-    PEMerr(PEM_F_PEM_DEF_CALLBACK, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-    return -1;
-#else
     prompt = EVP_get_pw_prompt();
     if (prompt == NULL)
         prompt = "Enter PEM pass phrase:";
@@ -74,7 +66,6 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
             break;
     }
     return j;
-#endif
 }
 
 void PEM_proc_type(char *buf, int type)

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -37,9 +37,10 @@ UI *UI_new_method(const UI_METHOD *method)
     }
 
     if (method == NULL)
-        ret->meth = UI_get_default_method();
-    else
-        ret->meth = method;
+        method = UI_get_default_method();
+    if (method == NULL)
+        method = UI_null();
+    ret->meth = method;
 
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_UI, ret, &ret->ex_data)) {
         OPENSSL_free(ret);

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -9,64 +9,66 @@
 
 #include <openssl/e_os2.h>
 #include <openssl/err.h>
+#include <openssl/ui.h>
 
+#ifndef OPENSSL_NO_UI_CONSOLE
 /*
  * need for #define _POSIX_C_SOURCE arises whenever you pass -ansi to gcc
  * [maybe others?], because it masks interfaces not discussed in standard,
  * sigaction and fileno included. -pedantic would be more appropriate for the
  * intended purposes, but we can't prevent users from adding -ansi.
  */
-#if defined(OPENSSL_SYS_VXWORKS)
-# include <sys/types.h>
-#endif
-
-#if !defined(_POSIX_C_SOURCE) && defined(OPENSSL_SYS_VMS)
-# ifndef _POSIX_C_SOURCE
-#  define _POSIX_C_SOURCE 2
+# if defined(OPENSSL_SYS_VXWORKS)
+#  include <sys/types.h>
 # endif
-#endif
-#include <signal.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
 
-#if !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS)
-# ifdef OPENSSL_UNISTD
-#  include OPENSSL_UNISTD
-# else
-#  include <unistd.h>
+# if !defined(_POSIX_C_SOURCE) && defined(OPENSSL_SYS_VMS)
+#  ifndef _POSIX_C_SOURCE
+#   define _POSIX_C_SOURCE 2
+#  endif
 # endif
+# include <signal.h>
+# include <stdio.h>
+# include <string.h>
+# include <errno.h>
+
+# if !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS)
+#  ifdef OPENSSL_UNISTD
+#   include OPENSSL_UNISTD
+#  else
+#   include <unistd.h>
+#  endif
 /*
  * If unistd.h defines _POSIX_VERSION, we conclude that we are on a POSIX
  * system and have sigaction and termios.
  */
-# if defined(_POSIX_VERSION)
+#  if defined(_POSIX_VERSION)
 
-#  define SIGACTION
-#  if !defined(TERMIOS) && !defined(TERMIO) && !defined(SGTTY)
-#   define TERMIOS
+#   define SIGACTION
+#   if !defined(TERMIOS) && !defined(TERMIO) && !defined(SGTTY)
+#    define TERMIOS
+#   endif
+
 #  endif
-
 # endif
-#endif
 
 /* 06-Apr-92 Luke Brennan    Support for VMS */
-#include "ui_locl.h"
-#include "internal/cryptlib.h"
+# include "ui_locl.h"
+# include "internal/cryptlib.h"
 
-#ifdef OPENSSL_SYS_VMS          /* prototypes for sys$whatever */
-# include <starlet.h>
-# ifdef __DECC
-#  pragma message disable DOLLARID
+# ifdef OPENSSL_SYS_VMS          /* prototypes for sys$whatever */
+#  include <starlet.h>
+#  ifdef __DECC
+#   pragma message disable DOLLARID
+#  endif
 # endif
-#endif
 
-#ifdef WIN_CONSOLE_BUG
-# include <windows.h>
-# ifndef OPENSSL_SYS_WINCE
-#  include <wincon.h>
+# ifdef WIN_CONSOLE_BUG
+#  include <windows.h>
+#  ifndef OPENSSL_SYS_WINCE
+#   include <wincon.h>
+#  endif
 # endif
-#endif
 
 /*
  * There are 6 types of terminal interface supported, TERMIO, TERMIOS, VMS,
@@ -80,81 +82,81 @@
  * may eventually opt to remove it's use entirely.
  */
 
-#if !defined(TERMIOS) && !defined(TERMIO) && !defined(SGTTY)
+# if !defined(TERMIOS) && !defined(TERMIO) && !defined(SGTTY)
 
-# if defined(_LIBC)
-#  undef  TERMIOS
-#  define TERMIO
-#  undef  SGTTY
+#  if defined(_LIBC)
+#   undef  TERMIOS
+#   define TERMIO
+#   undef  SGTTY
 /*
  * We know that VMS, MSDOS, VXWORKS, use entirely other mechanisms.
  */
-# elif !defined(OPENSSL_SYS_VMS) \
+#  elif !defined(OPENSSL_SYS_VMS) \
 	&& !defined(OPENSSL_SYS_MSDOS) \
 	&& !defined(OPENSSL_SYS_VXWORKS)
-#  define TERMIOS
-#  undef  TERMIO
-#  undef  SGTTY
+#   define TERMIOS
+#   undef  TERMIO
+#   undef  SGTTY
+#  endif
+
 # endif
 
-#endif
+# ifdef TERMIOS
+#  include <termios.h>
+#  define TTY_STRUCT             struct termios
+#  define TTY_FLAGS              c_lflag
+#  define TTY_get(tty,data)      tcgetattr(tty,data)
+#  define TTY_set(tty,data)      tcsetattr(tty,TCSANOW,data)
+# endif
 
-#ifdef TERMIOS
-# include <termios.h>
-# define TTY_STRUCT             struct termios
-# define TTY_FLAGS              c_lflag
-# define TTY_get(tty,data)      tcgetattr(tty,data)
-# define TTY_set(tty,data)      tcsetattr(tty,TCSANOW,data)
-#endif
+# ifdef TERMIO
+#  include <termio.h>
+#  define TTY_STRUCT             struct termio
+#  define TTY_FLAGS              c_lflag
+#  define TTY_get(tty,data)      ioctl(tty,TCGETA,data)
+#  define TTY_set(tty,data)      ioctl(tty,TCSETA,data)
+# endif
 
-#ifdef TERMIO
-# include <termio.h>
-# define TTY_STRUCT             struct termio
-# define TTY_FLAGS              c_lflag
-# define TTY_get(tty,data)      ioctl(tty,TCGETA,data)
-# define TTY_set(tty,data)      ioctl(tty,TCSETA,data)
-#endif
+# ifdef SGTTY
+#  include <sgtty.h>
+#  define TTY_STRUCT             struct sgttyb
+#  define TTY_FLAGS              sg_flags
+#  define TTY_get(tty,data)      ioctl(tty,TIOCGETP,data)
+#  define TTY_set(tty,data)      ioctl(tty,TIOCSETP,data)
+# endif
 
-#ifdef SGTTY
-# include <sgtty.h>
-# define TTY_STRUCT             struct sgttyb
-# define TTY_FLAGS              sg_flags
-# define TTY_get(tty,data)      ioctl(tty,TIOCGETP,data)
-# define TTY_set(tty,data)      ioctl(tty,TIOCSETP,data)
-#endif
+# if !defined(_LIBC) && !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS)
+#  include <sys/ioctl.h>
+# endif
 
-#if !defined(_LIBC) && !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS)
-# include <sys/ioctl.h>
-#endif
+# ifdef OPENSSL_SYS_MSDOS
+#  include <conio.h>
+# endif
 
-#ifdef OPENSSL_SYS_MSDOS
-# include <conio.h>
-#endif
-
-#ifdef OPENSSL_SYS_VMS
-# include <ssdef.h>
-# include <iodef.h>
-# include <ttdef.h>
-# include <descrip.h>
+# ifdef OPENSSL_SYS_VMS
+#  include <ssdef.h>
+#  include <iodef.h>
+#  include <ttdef.h>
+#  include <descrip.h>
 struct IOSB {
     short iosb$w_value;
     short iosb$w_count;
     long iosb$l_info;
 };
-#endif
+# endif
 
-#ifndef NX509_SIG
-# define NX509_SIG 32
-#endif
+# ifndef NX509_SIG
+#  define NX509_SIG 32
+# endif
 
 /* Define globals.  They are protected by a lock */
-#ifdef SIGACTION
+# ifdef SIGACTION
 static struct sigaction savsig[NX509_SIG];
-#else
+# else
 static void (*savsig[NX509_SIG]) (int);
-#endif
+# endif
 
-#ifdef OPENSSL_SYS_VMS
+# ifdef OPENSSL_SYS_VMS
 static struct IOSB iosb;
 static $DESCRIPTOR(terminal, "TT");
 static long tty_orig[3], tty_new[3]; /* XXX Is there any guarantee that this
@@ -162,26 +164,26 @@ static long tty_orig[3], tty_new[3]; /* XXX Is there any guarantee that this
                                       * structures? */
 static long status;
 static unsigned short channel = 0;
-#elif defined(_WIN32) && !defined(_WIN32_WCE)
+# elif defined(_WIN32) && !defined(_WIN32_WCE)
 static DWORD tty_orig, tty_new;
-#else
-# if !defined(OPENSSL_SYS_MSDOS) || defined(__DJGPP__)
+# else
+#  if !defined(OPENSSL_SYS_MSDOS) || defined(__DJGPP__)
 static TTY_STRUCT tty_orig, tty_new;
+#  endif
 # endif
-#endif
 static FILE *tty_in, *tty_out;
 static int is_a_tty;
 
 /* Declare static functions */
-#if !defined(OPENSSL_SYS_WINCE)
+# if !defined(OPENSSL_SYS_WINCE)
 static int read_till_nl(FILE *);
 static void recsig(int);
 static void pushsig(void);
 static void popsig(void);
-#endif
-#if defined(OPENSSL_SYS_MSDOS) && !defined(_WIN32)
+# endif
+# if defined(OPENSSL_SYS_MSDOS) && !defined(_WIN32)
 static int noecho_fgets(char *buf, int size, FILE *tty);
-#endif
+# endif
 static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl);
 
 static int read_string(UI *ui, UI_STRING *uis);
@@ -191,34 +193,6 @@ static int open_console(UI *ui);
 static int echo_console(UI *ui);
 static int noecho_console(UI *ui);
 static int close_console(UI *ui);
-
-static UI_METHOD ui_openssl = {
-    "OpenSSL default user interface",
-    open_console,
-    write_string,
-    NULL,                       /* No flusher is needed for command lines */
-    read_string,
-    close_console,
-    NULL
-};
-
-static const UI_METHOD *default_UI_meth = &ui_openssl;
-
-void UI_set_default_method(const UI_METHOD *meth)
-{
-    default_UI_meth = meth;
-}
-
-const UI_METHOD *UI_get_default_method(void)
-{
-    return default_UI_meth;
-}
-
-/* The method with all the built-in thingies */
-UI_METHOD *UI_OpenSSL(void)
-{
-    return &ui_openssl;
-}
 
 /*
  * The following function makes sure that info and error strings are printed
@@ -280,11 +254,11 @@ static int read_string(UI *ui, UI_STRING *uis)
     return 1;
 }
 
-#if !defined(OPENSSL_SYS_WINCE)
+# if !defined(OPENSSL_SYS_WINCE)
 /* Internal functions to read a string without echoing */
 static int read_till_nl(FILE *in)
 {
-# define SIZE 4
+#  define SIZE 4
     char buf[SIZE + 1];
 
     do {
@@ -295,7 +269,7 @@ static int read_till_nl(FILE *in)
 }
 
 static volatile sig_atomic_t intr_signal;
-#endif
+# endif
 
 static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
 {
@@ -303,7 +277,7 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
     int ok;
     char result[BUFSIZ];
     int maxsize = BUFSIZ - 1;
-#if !defined(OPENSSL_SYS_WINCE)
+# if !defined(OPENSSL_SYS_WINCE)
     char *p = NULL;
     int echo_eol = !echo;
 
@@ -319,10 +293,10 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
     ps = 2;
 
     result[0] = '\0';
-# if defined(_WIN32)
+#  if defined(_WIN32)
     if (is_a_tty) {
         DWORD numread;
-#  if defined(CP_UTF8)
+#   if defined(CP_UTF8)
         if (GetEnvironmentVariableW(L"OPENSSL_WIN32_UTF8", NULL, 0) != 0) {
             WCHAR wresult[BUFSIZ];
 
@@ -342,7 +316,7 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
                 OPENSSL_cleanse(wresult, sizeof(wresult));
             }
         } else
-#  endif
+#   endif
         if (ReadConsoleA(GetStdHandle(STD_INPUT_HANDLE),
                          result, maxsize, &numread, NULL)) {
             if (numread >= 2 &&
@@ -354,12 +328,12 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
             p = result;
         }
     } else
-# elif defined(OPENSSL_SYS_MSDOS)
+#  elif defined(OPENSSL_SYS_MSDOS)
     if (!echo) {
         noecho_fgets(result, maxsize, tty_in);
         p = result;             /* FIXME: noecho_fgets doesn't return errors */
     } else
-# endif
+#  endif
     p = fgets(result, maxsize, tty_in);
     if (p == NULL)
         goto error;
@@ -385,9 +359,9 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
 
     if (ps >= 1)
         popsig();
-#else
+# else
     ok = 1;
-#endif
+# endif
 
     OPENSSL_cleanse(result, BUFSIZ);
     return ok;
@@ -399,10 +373,10 @@ static int open_console(UI *ui)
     CRYPTO_THREAD_write_lock(ui->lock);
     is_a_tty = 1;
 
-#if defined(OPENSSL_SYS_VXWORKS)
+# if defined(OPENSSL_SYS_VXWORKS)
     tty_in = stdin;
     tty_out = stderr;
-#elif defined(_WIN32) && !defined(_WIN32_WCE)
+# elif defined(_WIN32) && !defined(_WIN32_WCE)
     if ((tty_out = fopen("conout$", "w")) == NULL)
         tty_out = stderr;
 
@@ -413,26 +387,26 @@ static int open_console(UI *ui)
         if ((tty_in = fopen("conin$", "r")) == NULL)
             tty_in = stdin;
     }
-#else
-# ifdef OPENSSL_SYS_MSDOS
-#  define DEV_TTY "con"
 # else
-#  define DEV_TTY "/dev/tty"
-# endif
+#  ifdef OPENSSL_SYS_MSDOS
+#   define DEV_TTY "con"
+#  else
+#   define DEV_TTY "/dev/tty"
+#  endif
     if ((tty_in = fopen(DEV_TTY, "r")) == NULL)
         tty_in = stdin;
     if ((tty_out = fopen(DEV_TTY, "w")) == NULL)
         tty_out = stderr;
-#endif
+# endif
 
-#if defined(TTY_get) && !defined(OPENSSL_SYS_VMS)
+# if defined(TTY_get) && !defined(OPENSSL_SYS_VMS)
     if (TTY_get(fileno(tty_in), &tty_orig) == -1) {
-# ifdef ENOTTY
+#  ifdef ENOTTY
         if (errno == ENOTTY)
             is_a_tty = 0;
         else
-# endif
-# ifdef EINVAL
+#  endif
+#  ifdef EINVAL
             /*
              * Ariel Glenn ariel@columbia.edu reports that solaris can return
              * EINVAL instead.  This should be ok
@@ -440,8 +414,8 @@ static int open_console(UI *ui)
         if (errno == EINVAL)
             is_a_tty = 0;
         else
-# endif
-# ifdef ENODEV
+#  endif
+#  ifdef ENODEV
             /*
              * MacOS X returns ENODEV (Operation not supported by device),
              * which seems appropriate.
@@ -449,7 +423,7 @@ static int open_console(UI *ui)
         if (errno == ENODEV)
             is_a_tty = 0;
         else
-# endif
+#  endif
             {
                 char tmp_num[10];
                 BIO_snprintf(tmp_num, sizeof(tmp_num) - 1, "%d", errno);
@@ -459,8 +433,8 @@ static int open_console(UI *ui)
                 return 0;
             }
     }
-#endif
-#ifdef OPENSSL_SYS_VMS
+# endif
+# ifdef OPENSSL_SYS_VMS
     status = sys$assign(&terminal, &channel, 0, 0);
 
     /* if there isn't a TT device, something is very wrong */
@@ -479,22 +453,22 @@ static int open_console(UI *ui)
     /* If IO$_SENSEMODE doesn't work, this is not a terminal device */
     if ((status != SS$_NORMAL) || (iosb.iosb$w_value != SS$_NORMAL))
         is_a_tty = 0;
-#endif
+# endif
     return 1;
 }
 
 static int noecho_console(UI *ui)
 {
-#ifdef TTY_FLAGS
+# ifdef TTY_FLAGS
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
     tty_new.TTY_FLAGS &= ~ECHO;
-#endif
+# endif
 
-#if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
+# if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     if (is_a_tty && (TTY_set(fileno(tty_in), &tty_new) == -1))
         return 0;
-#endif
-#ifdef OPENSSL_SYS_VMS
+# endif
+# ifdef OPENSSL_SYS_VMS
     if (is_a_tty) {
         tty_new[0] = tty_orig[0];
         tty_new[1] = tty_orig[1] | TT$M_NOECHO;
@@ -514,29 +488,29 @@ static int noecho_console(UI *ui)
             return 0;
         }
     }
-#endif
-#if defined(_WIN32) && !defined(_WIN32_WCE)
+# endif
+# if defined(_WIN32) && !defined(_WIN32_WCE)
     if (is_a_tty) {
         tty_new = tty_orig;
         tty_new &= ~ENABLE_ECHO_INPUT;
         SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), tty_new);
     }
-#endif
+# endif
     return 1;
 }
 
 static int echo_console(UI *ui)
 {
-#if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
+# if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
     tty_new.TTY_FLAGS |= ECHO;
-#endif
+# endif
 
-#if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
+# if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     if (is_a_tty && (TTY_set(fileno(tty_in), &tty_new) == -1))
         return 0;
-#endif
-#ifdef OPENSSL_SYS_VMS
+# endif
+# ifdef OPENSSL_SYS_VMS
     if (is_a_tty) {
         tty_new[0] = tty_orig[0];
         tty_new[1] = tty_orig[1] & ~TT$M_NOECHO;
@@ -556,14 +530,14 @@ static int echo_console(UI *ui)
             return 0;
         }
     }
-#endif
-#if defined(_WIN32) && !defined(_WIN32_WCE)
+# endif
+# if defined(_WIN32) && !defined(_WIN32_WCE)
     if (is_a_tty) {
         tty_new = tty_orig;
         tty_new |= ENABLE_ECHO_INPUT;
         SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), tty_new);
     }
-#endif
+# endif
     return 1;
 }
 
@@ -573,7 +547,7 @@ static int close_console(UI *ui)
         fclose(tty_in);
     if (tty_out != stderr)
         fclose(tty_out);
-#ifdef OPENSSL_SYS_VMS
+# ifdef OPENSSL_SYS_VMS
     status = sys$dassgn(channel);
     if (status != SS$_NORMAL) {
         char tmp_num[12];
@@ -583,97 +557,97 @@ static int close_console(UI *ui)
         ERR_add_error_data(2, "status=", tmp_num);
         return 0;
     }
-#endif
+# endif
     CRYPTO_THREAD_unlock(ui->lock);
 
     return 1;
 }
 
-#if !defined(OPENSSL_SYS_WINCE)
+# if !defined(OPENSSL_SYS_WINCE)
 /* Internal functions to handle signals and act on them */
 static void pushsig(void)
 {
-# ifndef OPENSSL_SYS_WIN32
+#  ifndef OPENSSL_SYS_WIN32
     int i;
-# endif
-# ifdef SIGACTION
+#  endif
+#  ifdef SIGACTION
     struct sigaction sa;
 
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = recsig;
-# endif
+#  endif
 
-# ifdef OPENSSL_SYS_WIN32
+#  ifdef OPENSSL_SYS_WIN32
     savsig[SIGABRT] = signal(SIGABRT, recsig);
     savsig[SIGFPE] = signal(SIGFPE, recsig);
     savsig[SIGILL] = signal(SIGILL, recsig);
     savsig[SIGINT] = signal(SIGINT, recsig);
     savsig[SIGSEGV] = signal(SIGSEGV, recsig);
     savsig[SIGTERM] = signal(SIGTERM, recsig);
-# else
+#  else
     for (i = 1; i < NX509_SIG; i++) {
-#  ifdef SIGUSR1
+#   ifdef SIGUSR1
         if (i == SIGUSR1)
             continue;
-#  endif
-#  ifdef SIGUSR2
+#   endif
+#   ifdef SIGUSR2
         if (i == SIGUSR2)
             continue;
-#  endif
-#  ifdef SIGKILL
+#   endif
+#   ifdef SIGKILL
         if (i == SIGKILL)       /* We can't make any action on that. */
             continue;
-#  endif
-#  ifdef SIGACTION
+#   endif
+#   ifdef SIGACTION
         sigaction(i, &sa, &savsig[i]);
-#  else
+#   else
         savsig[i] = signal(i, recsig);
-#  endif
+#   endif
     }
-# endif
+#  endif
 
-# ifdef SIGWINCH
+#  ifdef SIGWINCH
     signal(SIGWINCH, SIG_DFL);
-# endif
+#  endif
 }
 
 static void popsig(void)
 {
-# ifdef OPENSSL_SYS_WIN32
+#  ifdef OPENSSL_SYS_WIN32
     signal(SIGABRT, savsig[SIGABRT]);
     signal(SIGFPE, savsig[SIGFPE]);
     signal(SIGILL, savsig[SIGILL]);
     signal(SIGINT, savsig[SIGINT]);
     signal(SIGSEGV, savsig[SIGSEGV]);
     signal(SIGTERM, savsig[SIGTERM]);
-# else
+#  else
     int i;
     for (i = 1; i < NX509_SIG; i++) {
-#  ifdef SIGUSR1
+#   ifdef SIGUSR1
         if (i == SIGUSR1)
             continue;
-#  endif
-#  ifdef SIGUSR2
+#   endif
+#   ifdef SIGUSR2
         if (i == SIGUSR2)
             continue;
-#  endif
-#  ifdef SIGACTION
+#   endif
+#   ifdef SIGACTION
         sigaction(i, &savsig[i], NULL);
-#  else
+#   else
         signal(i, savsig[i]);
-#  endif
+#   endif
     }
-# endif
+#  endif
 }
 
 static void recsig(int i)
 {
     intr_signal = i;
 }
-#endif
+# endif
 
 /* Internal functions specific for Windows */
-#if defined(OPENSSL_SYS_MSDOS) && !defined(_WIN32)
+# if defined(OPENSSL_SYS_MSDOS) && !defined(_WIN32)
 static int noecho_fgets(char *buf, int size, FILE *tty)
 {
     int i;
@@ -686,11 +660,11 @@ static int noecho_fgets(char *buf, int size, FILE *tty)
             break;
         }
         size--;
-# if defined(_WIN32)
+#  if defined(_WIN32)
         i = _getch();
-# else
+#  else
         i = getch();
-# endif
+#  endif
         if (i == '\r')
             i = '\n';
         *(p++) = i;
@@ -699,7 +673,7 @@ static int noecho_fgets(char *buf, int size, FILE *tty)
             break;
         }
     }
-# ifdef WIN_CONSOLE_BUG
+#  ifdef WIN_CONSOLE_BUG
     /*
      * Win95 has several evil console bugs: one of these is that the last
      * character read using getch() is passed to the next read: this is
@@ -711,7 +685,41 @@ static int noecho_fgets(char *buf, int size, FILE *tty)
         inh = GetStdHandle(STD_INPUT_HANDLE);
         FlushConsoleInputBuffer(inh);
     }
-# endif
+#  endif
     return (strlen(buf));
 }
+# endif
+
+static UI_METHOD ui_openssl = {
+    "OpenSSL default user interface",
+    open_console,
+    write_string,
+    NULL,                       /* No flusher is needed for command lines */
+    read_string,
+    close_console,
+    NULL
+};
+
+/* The method with all the built-in console thingies */
+UI_METHOD *UI_OpenSSL(void)
+{
+    return &ui_openssl;
+}
+
+static const UI_METHOD *default_UI_meth = &ui_openssl;
+
+#else
+
+static const UI_METHOD *default_UI_meth = NULL;
+
 #endif
+
+void UI_set_default_method(const UI_METHOD *meth)
+{
+    default_UI_meth = meth;
+}
+
+const UI_METHOD *UI_get_default_method(void)
+{
+    return default_UI_meth;
+}

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -546,13 +546,11 @@ __owur int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type);
 __owur int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md,
                            unsigned int *s);
 
-#ifndef OPENSSL_NO_UI
 int EVP_read_pw_string(char *buf, int length, const char *prompt, int verify);
 int EVP_read_pw_string_min(char *buf, int minlen, int maxlen,
                            const char *prompt, int verify);
 void EVP_set_pw_prompt(const char *prompt);
 char *EVP_get_pw_prompt(void);
-#endif
 
 __owur int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
                           const unsigned char *salt,

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -12,19 +12,24 @@
 
 # include <openssl/opensslconf.h>
 
-# ifndef OPENSSL_NO_UI
+# if OPENSSL_API_COMPAT < 0x10100000L
+#  include <openssl/crypto.h>
+# endif
+# include <openssl/safestack.h>
+# include <openssl/pem.h>
+# include <openssl/ossl_typ.h>
+# include <openssl/uierr.h>
 
-#  if OPENSSL_API_COMPAT < 0x10100000L
-#   include <openssl/crypto.h>
+/* For compatibility reasons, the macro OPENSSL_NO_UI is currently retained */
+# if OPENSSL_API_COMPAT < 0x10200000L
+#  ifdef OPENSSL_NO_UI_CONSOLE
+#   define OPENSSL_NO_UI
 #  endif
-#  include <openssl/safestack.h>
-#  include <openssl/pem.h>
-#  include <openssl/ossl_typ.h>
-#  include <openssl/uierr.h>
+# endif
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 extern "C" {
-#endif
+# endif
 
 /*
  * All the following functions return -1 or NULL on error and in some cases
@@ -112,7 +117,7 @@ int UI_dup_error_string(UI *ui, const char *text);
  * each UI being marked with this flag, or the application might get
  * confused.
  */
-#  define UI_INPUT_FLAG_DEFAULT_PWD       0x02
+# define UI_INPUT_FLAG_DEFAULT_PWD       0x02
 
 /*-
  * The user of these routines may want to define flags of their own.  The core
@@ -124,7 +129,7 @@ int UI_dup_error_string(UI *ui, const char *text);
  *    #define MY_UI_FLAG1       (0x01 << UI_INPUT_FLAG_USER_BASE)
  *
 */
-#  define UI_INPUT_FLAG_USER_BASE 16
+# define UI_INPUT_FLAG_USER_BASE 16
 
 /*-
  * The following function helps construct a prompt.  object_desc is a
@@ -187,7 +192,7 @@ int UI_ctrl(UI *ui, int cmd, long i, void *p, void (*f) (void));
  * OpenSSL error stack before printing any info or added error messages and
  * before any prompting.
  */
-#  define UI_CTRL_PRINT_ERRORS            1
+# define UI_CTRL_PRINT_ERRORS            1
 /*
  * Check if a UI_process() is possible to do again with the same instance of
  * a user interface.  This makes UI_ctrl() return 1 if it is redoable, and 0
@@ -199,7 +204,7 @@ int UI_ctrl(UI *ui, int cmd, long i, void *p, void (*f) (void));
 # define UI_set_app_data(s,arg)         UI_set_ex_data(s,0,arg)
 # define UI_get_app_data(s)             UI_get_ex_data(s,0)
 
-#define UI_get_ex_new_index(l, p, newf, dupf, freef) \
+# define UI_get_ex_new_index(l, p, newf, dupf, freef) \
     CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI, l, p, newf, dupf, freef)
 int UI_set_ex_data(UI *r, int idx, void *arg);
 void *UI_get_ex_data(UI *r, int idx);
@@ -210,8 +215,12 @@ const UI_METHOD *UI_get_default_method(void);
 const UI_METHOD *UI_get_method(UI *ui);
 const UI_METHOD *UI_set_method(UI *ui, const UI_METHOD *meth);
 
+# ifndef OPENSSL_NO_UI_CONSOLE
+
 /* The method with all the built-in thingies */
 UI_METHOD *UI_OpenSSL(void);
+
+# endif
 
 /*
  * NULL method.  Literally does nothing, but may serve as a placeholder
@@ -351,8 +360,7 @@ UI_METHOD *UI_UTIL_wrap_read_pem_callback(pem_password_cb *cb, int rwflag);
 
 int ERR_load_UI_strings(void);
 
-#  ifdef  __cplusplus
+# ifdef  __cplusplus
 }
-#  endif
 # endif
 #endif

--- a/test/uitest.c
+++ b/test/uitest.c
@@ -17,8 +17,7 @@
 /* apps/apps.c depend on these */
 char *default_config_file = NULL;
 
-#ifndef OPENSSL_NO_UI
-# include <openssl/ui.h>
+#include <openssl/ui.h>
 
 /* Old style PEM password callback */
 static int test_pem_password_cb(char *buf, int size, int rwflag, void *userdata)
@@ -89,12 +88,8 @@ static int test_new_ui()
     return ok;
 }
 
-#endif
-
 void register_tests(void)
 {
-#ifndef OPENSSL_NO_UI
     ADD_TEST(test_old);
     ADD_TEST(test_new_ui);
-#endif
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -30,7 +30,7 @@ GENERAL_NAME_get0_otherName             29	1_1_0	EXIST::FUNCTION:
 ASN1_INTEGER_get_uint64                 30	1_1_0	EXIST::FUNCTION:
 EVP_DigestInit_ex                       31	1_1_0	EXIST::FUNCTION:
 CTLOG_new                               32	1_1_0	EXIST::FUNCTION:CT
-UI_get_result_minsize                   33	1_1_0	EXIST::FUNCTION:UI
+UI_get_result_minsize                   33	1_1_0	EXIST::FUNCTION:
 EVP_PBE_alg_add_type                    34	1_1_0	EXIST::FUNCTION:
 EVP_cast5_ofb                           35	1_1_0	EXIST::FUNCTION:CAST
 d2i_PUBKEY_fp                           36	1_1_0	EXIST::FUNCTION:STDIO
@@ -39,7 +39,7 @@ BF_decrypt                              38	1_1_0	EXIST::FUNCTION:BF
 PEM_read_bio_PUBKEY                     39	1_1_0	EXIST::FUNCTION:
 X509_NAME_delete_entry                  40	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_verify_recover        41	1_1_0	EXIST::FUNCTION:
-UI_set_method                           42	1_1_0	EXIST::FUNCTION:UI
+UI_set_method                           42	1_1_0	EXIST::FUNCTION:
 PKCS7_ISSUER_AND_SERIAL_it              43	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 PKCS7_ISSUER_AND_SERIAL_it              43	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 EC_GROUP_method_of                      44	1_1_0	EXIST::FUNCTION:EC
@@ -77,7 +77,7 @@ ASN1_item_print                         76	1_1_0	EXIST::FUNCTION:
 CONF_set_nconf                          77	1_1_0	EXIST::FUNCTION:
 RAND_set_rand_method                    78	1_1_0	EXIST::FUNCTION:
 BN_GF2m_mod_mul                         79	1_1_0	EXIST::FUNCTION:EC2M
-UI_add_input_boolean                    80	1_1_0	EXIST::FUNCTION:UI
+UI_add_input_boolean                    80	1_1_0	EXIST::FUNCTION:
 ASN1_TIME_adj                           81	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_get0_info                 82	1_1_0	EXIST::FUNCTION:
 BN_add_word                             83	1_1_0	EXIST::FUNCTION:
@@ -85,7 +85,7 @@ EVP_des_ede                             84	1_1_0	EXIST::FUNCTION:DES
 EVP_PKEY_add1_attr_by_OBJ               85	1_1_0	EXIST::FUNCTION:
 ASYNC_WAIT_CTX_get_all_fds              86	1_1_0	EXIST::FUNCTION:
 EVP_CIPHER_meth_set_do_cipher           87	1_1_0	EXIST::FUNCTION:
-EVP_set_pw_prompt                       88	1_1_0	EXIST::FUNCTION:UI
+EVP_set_pw_prompt                       88	1_1_0	EXIST::FUNCTION:
 d2i_OCSP_RESPBYTES                      89	1_1_0	EXIST::FUNCTION:OCSP
 TS_REQ_get_ext_by_NID                   90	1_1_0	EXIST::FUNCTION:TS
 ASN1_item_ndef_i2d                      91	1_1_0	EXIST::FUNCTION:
@@ -206,7 +206,7 @@ SCT_set_version                         206	1_1_0	EXIST::FUNCTION:CT
 CMS_add1_ReceiptRequest                 207	1_1_0	EXIST::FUNCTION:CMS
 d2i_CRL_DIST_POINTS                     208	1_1_0	EXIST::FUNCTION:
 X509_CRL_INFO_free                      209	1_1_0	EXIST::FUNCTION:
-ERR_load_UI_strings                     210	1_1_0	EXIST::FUNCTION:UI
+ERR_load_UI_strings                     210	1_1_0	EXIST::FUNCTION:
 ERR_load_strings                        211	1_1_0	EXIST::FUNCTION:
 RSA_X931_hash_id                        212	1_1_0	EXIST::FUNCTION:RSA
 EC_KEY_set_method                       213	1_1_0	EXIST::FUNCTION:EC
@@ -272,7 +272,7 @@ EVP_OpenInit                            272	1_1_0	EXIST::FUNCTION:RSA
 OCSP_response_get1_basic                273	1_1_0	EXIST::FUNCTION:OCSP
 CRYPTO_gcm128_tag                       274	1_1_0	EXIST::FUNCTION:
 OCSP_parse_url                          275	1_1_0	EXIST::FUNCTION:OCSP
-UI_get0_test_string                     276	1_1_0	EXIST::FUNCTION:UI
+UI_get0_test_string                     276	1_1_0	EXIST::FUNCTION:
 CRYPTO_secure_free                      277	1_1_0	EXIST::FUNCTION:
 DSA_print_fp                            278	1_1_0	EXIST::FUNCTION:DSA,STDIO
 X509_get_ext_d2i                        279	1_1_0	EXIST::FUNCTION:
@@ -314,7 +314,7 @@ EVP_CIPHER_CTX_set_flags                314	1_1_0	EXIST::FUNCTION:
 err_free_strings_int                    315	1_1_0	EXIST::FUNCTION:
 PEM_write_bio_PKCS7_stream              316	1_1_0	EXIST::FUNCTION:
 d2i_X509_CERT_AUX                       317	1_1_0	EXIST::FUNCTION:
-UI_process                              318	1_1_0	EXIST::FUNCTION:UI
+UI_process                              318	1_1_0	EXIST::FUNCTION:
 X509_get_subject_name                   319	1_1_0	EXIST::FUNCTION:
 DH_get_1024_160                         320	1_1_0	EXIST::FUNCTION:DH
 i2d_ASN1_UNIVERSALSTRING                321	1_1_0	EXIST::FUNCTION:
@@ -331,7 +331,7 @@ CRYPTO_ccm128_tag                       331	1_1_0	EXIST::FUNCTION:
 BIO_new_dgram_sctp                      332	1_1_0	EXIST::FUNCTION:DGRAM,SCTP
 d2i_RSAPrivateKey_fp                    333	1_1_0	EXIST::FUNCTION:RSA,STDIO
 s2i_ASN1_IA5STRING                      334	1_1_0	EXIST::FUNCTION:
-UI_get_ex_data                          335	1_1_0	EXIST::FUNCTION:UI
+UI_get_ex_data                          335	1_1_0	EXIST::FUNCTION:
 EVP_EncryptUpdate                       336	1_1_0	EXIST::FUNCTION:
 SRP_create_verifier                     337	1_1_0	EXIST::FUNCTION:SRP
 TS_TST_INFO_print_bio                   338	1_1_0	EXIST::FUNCTION:TS
@@ -372,7 +372,7 @@ SEED_ecb_encrypt                        370	1_1_0	EXIST::FUNCTION:SEED
 X509_PUBKEY_get0_param                  371	1_1_0	EXIST::FUNCTION:
 ASN1_i2d_fp                             372	1_1_0	EXIST::FUNCTION:STDIO
 BIO_new_mem_buf                         373	1_1_0	EXIST::FUNCTION:
-UI_get_input_flags                      374	1_1_0	EXIST::FUNCTION:UI
+UI_get_input_flags                      374	1_1_0	EXIST::FUNCTION:
 X509V3_EXT_REQ_add_nconf                375	1_1_0	EXIST::FUNCTION:
 X509v3_asid_subset                      376	1_1_0	EXIST::FUNCTION:RFC3779
 RSA_check_key_ex                        377	1_1_0	EXIST::FUNCTION:RSA
@@ -492,7 +492,7 @@ BN_GF2m_mod_sqr_arr                     492	1_1_0	EXIST::FUNCTION:EC2M
 ASN1_PRINTABLESTRING_it                 493	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 ASN1_PRINTABLESTRING_it                 493	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 BIO_f_cipher                            494	1_1_0	EXIST::FUNCTION:
-UI_destroy_method                       495	1_1_0	EXIST::FUNCTION:UI
+UI_destroy_method                       495	1_1_0	EXIST::FUNCTION:
 BN_get_rfc3526_prime_3072               496	1_1_0	EXIST::FUNCTION:
 X509_INFO_new                           497	1_1_0	EXIST::FUNCTION:
 OCSP_RESPDATA_it                        498	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:OCSP
@@ -626,7 +626,7 @@ CRYPTO_secure_malloc_done               625	1_1_0	EXIST::FUNCTION:
 RSA_OAEP_PARAMS_new                     626	1_1_0	EXIST::FUNCTION:RSA
 X509_NAME_free                          627	1_1_0	EXIST::FUNCTION:
 PKCS12_set_mac                          628	1_1_0	EXIST::FUNCTION:
-UI_get0_result_string                   629	1_1_0	EXIST::FUNCTION:UI
+UI_get0_result_string                   629	1_1_0	EXIST::FUNCTION:
 TS_RESP_CTX_add_policy                  630	1_1_0	EXIST::FUNCTION:TS
 X509_REQ_dup                            631	1_1_0	EXIST::FUNCTION:
 d2i_DSA_PUBKEY_fp                       633	1_1_0	EXIST::FUNCTION:DSA,STDIO
@@ -640,9 +640,9 @@ CRYPTO_THREAD_write_lock                639	1_1_0	EXIST::FUNCTION:
 X509V3_NAME_from_section                640	1_1_0	EXIST::FUNCTION:
 EC_POINT_set_compressed_coordinates_GFp 641	1_1_0	EXIST::FUNCTION:EC
 OCSP_SINGLERESP_get0_id                 642	1_1_0	EXIST::FUNCTION:OCSP
-UI_add_info_string                      643	1_1_0	EXIST::FUNCTION:UI
+UI_add_info_string                      643	1_1_0	EXIST::FUNCTION:
 OBJ_NAME_remove                         644	1_1_0	EXIST::FUNCTION:
-UI_get_method                           645	1_1_0	EXIST::FUNCTION:UI
+UI_get_method                           645	1_1_0	EXIST::FUNCTION:
 CONF_modules_unload                     646	1_1_0	EXIST::FUNCTION:
 CRYPTO_ccm128_encrypt_ccm64             647	1_1_0	EXIST::FUNCTION:
 CRYPTO_secure_malloc_init               648	1_1_0	EXIST::FUNCTION:
@@ -717,7 +717,7 @@ PKCS7_add_signature                     716	1_1_0	EXIST::FUNCTION:
 OBJ_ln2nid                              717	1_1_0	EXIST::FUNCTION:
 CRYPTO_128_unwrap                       718	1_1_0	EXIST::FUNCTION:
 BIO_new_PKCS7                           719	1_1_0	EXIST::FUNCTION:
-UI_get0_user_data                       720	1_1_0	EXIST::FUNCTION:UI
+UI_get0_user_data                       720	1_1_0	EXIST::FUNCTION:
 TS_RESP_get_token                       721	1_1_0	EXIST::FUNCTION:TS
 OCSP_RESPID_new                         722	1_1_0	EXIST::FUNCTION:OCSP
 ASN1_SET_ANY_it                         723	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
@@ -760,7 +760,7 @@ X509_policy_node_get0_qualifiers        758	1_1_0	EXIST::FUNCTION:
 OCSP_cert_status_str                    759	1_1_0	EXIST::FUNCTION:OCSP
 EVP_MD_meth_get_flags                   760	1_1_0	EXIST::FUNCTION:
 ASN1_ENUMERATED_set                     761	1_1_0	EXIST::FUNCTION:
-UI_UTIL_read_pw                         762	1_1_0	EXIST::FUNCTION:UI
+UI_UTIL_read_pw                         762	1_1_0	EXIST::FUNCTION:
 PKCS7_ENC_CONTENT_free                  763	1_1_0	EXIST::FUNCTION:
 CMS_RecipientInfo_type                  764	1_1_0	EXIST::FUNCTION:CMS
 OCSP_BASICRESP_get_ext                  765	1_1_0	EXIST::FUNCTION:OCSP
@@ -772,7 +772,7 @@ ENGINE_init                             770	1_1_0	EXIST::FUNCTION:ENGINE
 TS_RESP_CTX_add_flags                   771	1_1_0	EXIST::FUNCTION:TS
 BIO_gethostbyname                       772	1_1_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SOCK
 X509V3_EXT_add                          773	1_1_0	EXIST::FUNCTION:
-UI_add_verify_string                    774	1_1_0	EXIST::FUNCTION:UI
+UI_add_verify_string                    774	1_1_0	EXIST::FUNCTION:
 EVP_rc5_32_12_16_cfb64                  775	1_1_0	EXIST::FUNCTION:RC5
 PKCS7_dataVerify                        776	1_1_0	EXIST::FUNCTION:
 PKCS7_SIGNER_INFO_free                  777	1_1_0	EXIST::FUNCTION:
@@ -909,13 +909,13 @@ PKCS5_pbe2_set_iv                       905	1_1_0	EXIST::FUNCTION:
 ASN1_add_stable_module                  906	1_1_0	EXIST::FUNCTION:
 EVP_camellia_128_cbc                    907	1_1_0	EXIST::FUNCTION:CAMELLIA
 COMP_zlib                               908	1_1_0	EXIST::FUNCTION:COMP
-EVP_read_pw_string                      909	1_1_0	EXIST::FUNCTION:UI
+EVP_read_pw_string                      909	1_1_0	EXIST::FUNCTION:
 i2d_ASN1_NULL                           910	1_1_0	EXIST::FUNCTION:
 DES_encrypt1                            911	1_1_0	EXIST::FUNCTION:DES
 BN_mod_lshift1_quick                    912	1_1_0	EXIST::FUNCTION:
 BN_get_rfc3526_prime_6144               913	1_1_0	EXIST::FUNCTION:
 OBJ_obj2txt                             914	1_1_0	EXIST::FUNCTION:
-UI_set_result                           915	1_1_0	EXIST::FUNCTION:UI
+UI_set_result                           915	1_1_0	EXIST::FUNCTION:
 EVP_EncodeUpdate                        916	1_1_0	EXIST::FUNCTION:
 PEM_write_bio_X509_CRL                  917	1_1_0	EXIST::FUNCTION:
 BN_cmp                                  918	1_1_0	EXIST::FUNCTION:
@@ -1020,11 +1020,11 @@ ASN1_UTCTIME_it                         1013	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:
 i2d_DSA_PUBKEY_fp                       1014	1_1_0	EXIST::FUNCTION:DSA,STDIO
 X509at_get_attr_by_OBJ                  1015	1_1_0	EXIST::FUNCTION:
 EVP_MD_CTX_copy_ex                      1016	1_1_0	EXIST::FUNCTION:
-UI_dup_error_string                     1017	1_1_0	EXIST::FUNCTION:UI
+UI_dup_error_string                     1017	1_1_0	EXIST::FUNCTION:
 OPENSSL_LH_num_items                    1018	1_1_0	EXIST::FUNCTION:
 ASN1_INTEGER_cmp                        1020	1_1_0	EXIST::FUNCTION:
 X509_NAME_entry_count                   1021	1_1_0	EXIST::FUNCTION:
-UI_method_set_closer                    1022	1_1_0	EXIST::FUNCTION:UI
+UI_method_set_closer                    1022	1_1_0	EXIST::FUNCTION:
 OPENSSL_LH_get_down_load                1023	1_1_0	EXIST::FUNCTION:
 EVP_md4                                 1024	1_1_0	EXIST::FUNCTION:MD4
 X509_set_subject_name                   1025	1_1_0	EXIST::FUNCTION:
@@ -1100,7 +1100,7 @@ X509_print_ex_fp                        1093	1_1_0	EXIST::FUNCTION:STDIO
 ERR_load_PEM_strings                    1094	1_1_0	EXIST::FUNCTION:
 ENGINE_unregister_pkey_asn1_meths       1095	1_1_0	EXIST::FUNCTION:ENGINE
 IPAddressFamily_free                    1096	1_1_0	EXIST::FUNCTION:RFC3779
-UI_method_get_prompt_constructor        1097	1_1_0	EXIST::FUNCTION:UI
+UI_method_get_prompt_constructor        1097	1_1_0	EXIST::FUNCTION:
 ASN1_NULL_it                            1098	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 ASN1_NULL_it                            1098	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 X509_REQ_get_pubkey                     1099	1_1_0	EXIST::FUNCTION:
@@ -1262,7 +1262,7 @@ OPENSSL_DIR_read                        1250	1_1_0	EXIST::FUNCTION:
 CMS_add_smimecap                        1251	1_1_0	EXIST::FUNCTION:CMS
 X509_check_email                        1252	1_1_0	EXIST::FUNCTION:
 CRYPTO_cts128_decrypt_block             1253	1_1_0	EXIST::FUNCTION:
-UI_method_get_opener                    1254	1_1_0	EXIST::FUNCTION:UI
+UI_method_get_opener                    1254	1_1_0	EXIST::FUNCTION:
 EVP_aes_192_gcm                         1255	1_1_0	EXIST::FUNCTION:
 TS_CONF_set_tsa_name                    1256	1_1_0	EXIST::FUNCTION:TS
 X509_email_free                         1257	1_1_0	EXIST::FUNCTION:
@@ -1292,7 +1292,7 @@ ASN1_TIME_free                          1281	1_1_0	EXIST::FUNCTION:
 i2o_SCT_LIST                            1282	1_1_0	EXIST::FUNCTION:CT
 AES_encrypt                             1283	1_1_0	EXIST::FUNCTION:
 MD5_Init                                1284	1_1_0	EXIST::FUNCTION:MD5
-UI_add_error_string                     1285	1_1_0	EXIST::FUNCTION:UI
+UI_add_error_string                     1285	1_1_0	EXIST::FUNCTION:
 X509_TRUST_cleanup                      1286	1_1_0	EXIST::FUNCTION:
 PEM_read_X509                           1287	1_1_0	EXIST::FUNCTION:STDIO
 EC_KEY_new_method                       1288	1_1_0	EXIST::FUNCTION:EC
@@ -1315,11 +1315,11 @@ BN_rshift1                              1303	1_1_0	EXIST::FUNCTION:
 i2d_PKCS7_ENVELOPE                      1304	1_1_0	EXIST::FUNCTION:
 PBKDF2PARAM_it                          1305	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 PBKDF2PARAM_it                          1305	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
-UI_get_result_maxsize                   1306	1_1_0	EXIST::FUNCTION:UI
+UI_get_result_maxsize                   1306	1_1_0	EXIST::FUNCTION:
 PBEPARAM_it                             1307	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 PBEPARAM_it                             1307	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 TS_ACCURACY_set_seconds                 1308	1_1_0	EXIST::FUNCTION:TS
-UI_get0_action_string                   1309	1_1_0	EXIST::FUNCTION:UI
+UI_get0_action_string                   1309	1_1_0	EXIST::FUNCTION:
 RC2_decrypt                             1310	1_1_0	EXIST::FUNCTION:RC2
 OPENSSL_atexit                          1311	1_1_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap               1312	1_1_0	EXIST::FUNCTION:CMS
@@ -1391,7 +1391,7 @@ PROXY_CERT_INFO_EXTENSION_it            1377	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:
 CT_POLICY_EVAL_CTX_set1_cert            1378	1_1_0	EXIST::FUNCTION:CT
 X509_NAME_hash                          1379	1_1_0	EXIST::FUNCTION:
 SCT_set_timestamp                       1380	1_1_0	EXIST::FUNCTION:CT
-UI_new                                  1381	1_1_0	EXIST::FUNCTION:UI
+UI_new                                  1381	1_1_0	EXIST::FUNCTION:
 TS_REQ_get_msg_imprint                  1382	1_1_0	EXIST::FUNCTION:TS
 i2d_PKCS12_BAGS                         1383	1_1_0	EXIST::FUNCTION:
 CERTIFICATEPOLICIES_free                1385	1_1_0	EXIST::FUNCTION:
@@ -1410,7 +1410,7 @@ PEM_read_bio_PrivateKey                 1398	1_1_0	EXIST::FUNCTION:
 d2i_PKCS7_ENCRYPT                       1399	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_ctrl                       1400	1_1_0	EXIST::FUNCTION:
 X509_REQ_set_pubkey                     1401	1_1_0	EXIST::FUNCTION:
-UI_create_method                        1402	1_1_0	EXIST::FUNCTION:UI
+UI_create_method                        1402	1_1_0	EXIST::FUNCTION:
 X509_REQ_add_extensions_nid             1403	1_1_0	EXIST::FUNCTION:
 PEM_X509_INFO_write_bio                 1404	1_1_0	EXIST::FUNCTION:
 BIO_dump_cb                             1405	1_1_0	EXIST::FUNCTION:
@@ -1478,7 +1478,7 @@ BN_gcd                                  1465	1_1_0	EXIST::FUNCTION:
 CMS_dataInit                            1466	1_1_0	EXIST::FUNCTION:CMS
 TS_CONF_get_tsa_section                 1467	1_1_0	EXIST::FUNCTION:TS
 i2d_PKCS7_SIGNER_INFO                   1468	1_1_0	EXIST::FUNCTION:
-EVP_get_pw_prompt                       1469	1_1_0	EXIST::FUNCTION:UI
+EVP_get_pw_prompt                       1469	1_1_0	EXIST::FUNCTION:
 BN_bn2bin                               1470	1_1_0	EXIST::FUNCTION:
 d2i_ASN1_BIT_STRING                     1471	1_1_0	EXIST::FUNCTION:
 OCSP_CERTSTATUS_new                     1472	1_1_0	EXIST::FUNCTION:OCSP
@@ -1491,7 +1491,7 @@ SHA384_Final                            1478	1_1_0	EXIST::FUNCTION:
 TS_RESP_CTX_set_certs                   1479	1_1_0	EXIST::FUNCTION:TS
 BN_MONT_CTX_free                        1480	1_1_0	EXIST::FUNCTION:
 BN_GF2m_mod_solve_quad_arr              1481	1_1_0	EXIST::FUNCTION:EC2M
-UI_add_input_string                     1482	1_1_0	EXIST::FUNCTION:UI
+UI_add_input_string                     1482	1_1_0	EXIST::FUNCTION:
 TS_TST_INFO_get_version                 1483	1_1_0	EXIST::FUNCTION:TS
 BIO_accept_ex                           1484	1_1_0	EXIST::FUNCTION:SOCK
 CRYPTO_get_mem_functions                1485	1_1_0	EXIST::FUNCTION:
@@ -1600,7 +1600,7 @@ SRP_Verify_A_mod_N                      1587	1_1_0	EXIST::FUNCTION:SRP
 SRP_VBASE_free                          1588	1_1_0	EXIST::FUNCTION:SRP
 PKCS7_add0_attrib_signing_time          1589	1_1_0	EXIST::FUNCTION:
 X509_STORE_set_flags                    1590	1_1_0	EXIST::FUNCTION:
-UI_get0_output_string                   1591	1_1_0	EXIST::FUNCTION:UI
+UI_get0_output_string                   1591	1_1_0	EXIST::FUNCTION:
 ERR_get_error_line_data                 1592	1_1_0	EXIST::FUNCTION:
 CTLOG_get0_name                         1593	1_1_0	EXIST::FUNCTION:CT
 ASN1_TBOOLEAN_it                        1594	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
@@ -1699,7 +1699,7 @@ CMS_EncryptedData_set1_key              1686	1_1_0	EXIST::FUNCTION:CMS
 OBJ_find_sigid_by_algs                  1687	1_1_0	EXIST::FUNCTION:
 ASN1_generate_nconf                     1688	1_1_0	EXIST::FUNCTION:
 CMS_add0_recipient_password             1689	1_1_0	EXIST::FUNCTION:CMS
-UI_get_string_type                      1690	1_1_0	EXIST::FUNCTION:UI
+UI_get_string_type                      1690	1_1_0	EXIST::FUNCTION:
 PEM_read_bio_ECPrivateKey               1691	1_1_0	EXIST::FUNCTION:EC
 EVP_PKEY_get_attr                       1692	1_1_0	EXIST::FUNCTION:
 PEM_read_bio_ECPKParameters             1693	1_1_0	EXIST::FUNCTION:EC
@@ -1720,7 +1720,7 @@ X509_policy_tree_get0_level             1706	1_1_0	EXIST::FUNCTION:
 ASN1_parse_dump                         1708	1_1_0	EXIST::FUNCTION:
 BIO_vfree                               1709	1_1_0	EXIST::FUNCTION:
 CRYPTO_cbc128_decrypt                   1710	1_1_0	EXIST::FUNCTION:
-UI_dup_verify_string                    1711	1_1_0	EXIST::FUNCTION:UI
+UI_dup_verify_string                    1711	1_1_0	EXIST::FUNCTION:
 d2i_PKCS7_bio                           1712	1_1_0	EXIST::FUNCTION:
 ENGINE_set_default_digests              1713	1_1_0	EXIST::FUNCTION:ENGINE
 i2d_PublicKey                           1714	1_1_0	EXIST::FUNCTION:
@@ -1738,7 +1738,7 @@ BIO_nwrite0                             1725	1_1_0	EXIST::FUNCTION:
 CAST_encrypt                            1726	1_1_0	EXIST::FUNCTION:CAST
 a2d_ASN1_OBJECT                         1727	1_1_0	EXIST::FUNCTION:
 OCSP_ONEREQ_delete_ext                  1728	1_1_0	EXIST::FUNCTION:OCSP
-UI_method_get_reader                    1729	1_1_0	EXIST::FUNCTION:UI
+UI_method_get_reader                    1729	1_1_0	EXIST::FUNCTION:
 CMS_unsigned_get_attr                   1730	1_1_0	EXIST::FUNCTION:CMS
 EVP_aes_256_cbc                         1731	1_1_0	EXIST::FUNCTION:
 X509_check_ip_asc                       1732	1_1_0	EXIST::FUNCTION:
@@ -1866,7 +1866,7 @@ TS_RESP_CTX_set_serial_cb               1851	1_1_0	EXIST::FUNCTION:TS
 POLICY_MAPPING_it                       1852	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 POLICY_MAPPING_it                       1852	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 ERR_load_KDF_strings                    1853	1_1_0	EXIST::FUNCTION:
-UI_method_set_reader                    1854	1_1_0	EXIST::FUNCTION:UI
+UI_method_set_reader                    1854	1_1_0	EXIST::FUNCTION:
 BIO_next                                1855	1_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_default_mask_asc        1856	1_1_0	EXIST::FUNCTION:
 X509_CRL_new                            1857	1_1_0	EXIST::FUNCTION:
@@ -1913,7 +1913,7 @@ EVP_aes_192_cfb128                      1896	1_1_0	EXIST::FUNCTION:
 OCSP_REQ_CTX_nbio                       1897	1_1_0	EXIST::FUNCTION:OCSP
 EVP_CIPHER_CTX_copy                     1898	1_1_0	EXIST::FUNCTION:
 CRYPTO_secure_allocated                 1899	1_1_0	EXIST::FUNCTION:
-UI_UTIL_read_pw_string                  1900	1_1_0	EXIST::FUNCTION:UI
+UI_UTIL_read_pw_string                  1900	1_1_0	EXIST::FUNCTION:
 NOTICEREF_free                          1901	1_1_0	EXIST::FUNCTION:
 AES_cfb1_encrypt                        1902	1_1_0	EXIST::FUNCTION:
 X509v3_get_ext                          1903	1_1_0	EXIST::FUNCTION:
@@ -1966,7 +1966,7 @@ PKCS12_unpack_p7data                    1951	1_1_0	EXIST::FUNCTION:
 ECDSA_sign                              1952	1_1_0	EXIST::FUNCTION:EC
 d2i_PKCS12_fp                           1953	1_1_0	EXIST::FUNCTION:STDIO
 CMS_unsigned_get_attr_by_NID            1954	1_1_0	EXIST::FUNCTION:CMS
-UI_add_user_data                        1955	1_1_0	EXIST::FUNCTION:UI
+UI_add_user_data                        1955	1_1_0	EXIST::FUNCTION:
 BN_bntest_rand                          1956	1_1_0	EXIST::FUNCTION:
 X509_get_pubkey                         1957	1_1_0	EXIST::FUNCTION:
 i2d_X509_NAME                           1958	1_1_0	EXIST::FUNCTION:
@@ -2032,7 +2032,7 @@ EC_POINT_point2hex                      2013	1_1_0	EXIST::FUNCTION:EC
 ENGINE_get_default_DSA                  2014	1_1_0	EXIST::FUNCTION:ENGINE
 ENGINE_register_all_complete            2015	1_1_0	EXIST::FUNCTION:ENGINE
 SRP_get_default_gN                      2016	1_1_0	EXIST::FUNCTION:SRP
-UI_dup_input_boolean                    2017	1_1_0	EXIST::FUNCTION:UI
+UI_dup_input_boolean                    2017	1_1_0	EXIST::FUNCTION:
 PKCS7_dup                               2018	1_1_0	EXIST::FUNCTION:
 i2d_TS_REQ_fp                           2019	1_1_0	EXIST::FUNCTION:STDIO,TS
 i2d_OTHERNAME                           2020	1_1_0	EXIST::FUNCTION:
@@ -2045,9 +2045,9 @@ ENGINE_get_pkey_asn1_meth_str           2026	1_1_0	EXIST::FUNCTION:ENGINE
 PKCS7_signatureVerify                   2027	1_1_0	EXIST::FUNCTION:
 CRYPTO_ocb128_new                       2028	1_1_0	EXIST::FUNCTION:OCB
 EC_curve_nist2nid                       2029	1_1_0	EXIST::FUNCTION:EC
-UI_get0_result                          2030	1_1_0	EXIST::FUNCTION:UI
+UI_get0_result                          2030	1_1_0	EXIST::FUNCTION:
 OCSP_request_add1_nonce                 2031	1_1_0	EXIST::FUNCTION:OCSP
-UI_construct_prompt                     2032	1_1_0	EXIST::FUNCTION:UI
+UI_construct_prompt                     2032	1_1_0	EXIST::FUNCTION:
 ENGINE_unregister_RSA                   2033	1_1_0	EXIST::FUNCTION:ENGINE
 EC_GROUP_order_bits                     2034	1_1_0	EXIST::FUNCTION:EC
 d2i_CMS_bio                             2035	1_1_0	EXIST::FUNCTION:CMS
@@ -2076,10 +2076,10 @@ EVP_CIPHER_CTX_original_iv              2054	1_1_0	EXIST::FUNCTION:
 PKCS7_SIGNED_free                       2055	1_1_0	EXIST::FUNCTION:
 X509_TRUST_get0_name                    2056	1_1_0	EXIST::FUNCTION:
 ENGINE_get_load_pubkey_function         2057	1_1_0	EXIST::FUNCTION:ENGINE
-UI_get_default_method                   2058	1_1_0	EXIST::FUNCTION:UI
+UI_get_default_method                   2058	1_1_0	EXIST::FUNCTION:
 PKCS12_add_CSPName_asc                  2059	1_1_0	EXIST::FUNCTION:
 PEM_write_PUBKEY                        2060	1_1_0	EXIST::FUNCTION:STDIO
-UI_method_set_prompt_constructor        2061	1_1_0	EXIST::FUNCTION:UI
+UI_method_set_prompt_constructor        2061	1_1_0	EXIST::FUNCTION:
 OBJ_length                              2062	1_1_0	EXIST::FUNCTION:
 BN_GENCB_get_arg                        2063	1_1_0	EXIST::FUNCTION:
 EVP_MD_CTX_clear_flags                  2064	1_1_0	EXIST::FUNCTION:
@@ -2107,7 +2107,7 @@ i2d_ASN1_GENERALSTRING                  2085	1_1_0	EXIST::FUNCTION:
 POLICYQUALINFO_new                      2086	1_1_0	EXIST::FUNCTION:
 PKCS7_RECIP_INFO_get0_alg               2087	1_1_0	EXIST::FUNCTION:
 EVP_PKEY_base_id                        2088	1_1_0	EXIST::FUNCTION:
-UI_method_set_opener                    2089	1_1_0	EXIST::FUNCTION:UI
+UI_method_set_opener                    2089	1_1_0	EXIST::FUNCTION:
 X509v3_get_ext_by_NID                   2090	1_1_0	EXIST::FUNCTION:
 TS_CONF_set_policies                    2091	1_1_0	EXIST::FUNCTION:TS
 CMS_SignerInfo_cert_cmp                 2092	1_1_0	EXIST::FUNCTION:CMS
@@ -2368,7 +2368,7 @@ ASN1_PRINTABLE_type                     2338	1_1_0	EXIST::FUNCTION:
 TS_CONF_set_ess_cert_id_chain           2339	1_1_0	EXIST::FUNCTION:TS
 PEM_read_DSAPrivateKey                  2340	1_1_0	EXIST::FUNCTION:DSA,STDIO
 DH_generate_parameters_ex               2341	1_1_0	EXIST::FUNCTION:DH
-UI_dup_input_string                     2342	1_1_0	EXIST::FUNCTION:UI
+UI_dup_input_string                     2342	1_1_0	EXIST::FUNCTION:
 X509_keyid_set1                         2343	1_1_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_set1                  2344	1_1_0	EXIST::FUNCTION:
 EC_GROUP_get_asn1_flag                  2345	1_1_0	EXIST::FUNCTION:EC
@@ -2444,7 +2444,7 @@ ASN1_PCTX_set_nm_flags                  2413	1_1_0	EXIST::FUNCTION:
 BIO_ctrl                                2414	1_1_0	EXIST::FUNCTION:
 X509_CRL_set_default_method             2415	1_1_0	EXIST::FUNCTION:
 d2i_RSAPublicKey_fp                     2417	1_1_0	EXIST::FUNCTION:RSA,STDIO
-UI_method_get_flusher                   2418	1_1_0	EXIST::FUNCTION:UI
+UI_method_get_flusher                   2418	1_1_0	EXIST::FUNCTION:
 EC_POINT_dbl                            2419	1_1_0	EXIST::FUNCTION:EC
 i2d_X509_CRL_INFO                       2420	1_1_0	EXIST::FUNCTION:
 i2d_OCSP_CERTSTATUS                     2421	1_1_0	EXIST::FUNCTION:OCSP
@@ -2570,7 +2570,7 @@ X509_PURPOSE_add                        2537	1_1_0	EXIST::FUNCTION:
 PKCS7_ENVELOPE_free                     2538	1_1_0	EXIST::FUNCTION:
 PKCS12_key_gen_uni                      2539	1_1_0	EXIST::FUNCTION:
 WHIRLPOOL                               2540	1_1_0	EXIST::FUNCTION:WHIRLPOOL
-UI_set_default_method                   2542	1_1_0	EXIST::FUNCTION:UI
+UI_set_default_method                   2542	1_1_0	EXIST::FUNCTION:
 EC_POINT_is_at_infinity                 2543	1_1_0	EXIST::FUNCTION:EC
 i2d_NOTICEREF                           2544	1_1_0	EXIST::FUNCTION:
 EC_KEY_new                              2545	1_1_0	EXIST::FUNCTION:EC
@@ -2795,8 +2795,8 @@ CT_POLICY_EVAL_CTX_new                  2756	1_1_0	EXIST::FUNCTION:CT
 NETSCAPE_SPKI_it                        2757	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 NETSCAPE_SPKI_it                        2757	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 CRYPTO_THREAD_unlock                    2758	1_1_0	EXIST::FUNCTION:
-UI_method_set_writer                    2759	1_1_0	EXIST::FUNCTION:UI
-UI_dup_info_string                      2760	1_1_0	EXIST::FUNCTION:UI
+UI_method_set_writer                    2759	1_1_0	EXIST::FUNCTION:
+UI_dup_info_string                      2760	1_1_0	EXIST::FUNCTION:
 OPENSSL_init                            2761	1_1_0	EXIST::FUNCTION:
 TS_RESP_get_tst_info                    2762	1_1_0	EXIST::FUNCTION:TS
 X509_VERIFY_PARAM_get_depth             2763	1_1_0	EXIST::FUNCTION:
@@ -3236,7 +3236,7 @@ RSAPrivateKey_dup                       3188	1_1_0	EXIST::FUNCTION:RSA
 BN_mod_add                              3189	1_1_0	EXIST::FUNCTION:
 EC_POINT_set_affine_coordinates_GFp     3190	1_1_0	EXIST::FUNCTION:EC
 X509_get_default_cert_file              3191	1_1_0	EXIST::FUNCTION:
-UI_method_set_flusher                   3192	1_1_0	EXIST::FUNCTION:UI
+UI_method_set_flusher                   3192	1_1_0	EXIST::FUNCTION:
 RSA_new_method                          3193	1_1_0	EXIST::FUNCTION:RSA
 OCSP_request_verify                     3194	1_1_0	EXIST::FUNCTION:OCSP
 CRYPTO_THREAD_run_once                  3195	1_1_0	EXIST::FUNCTION:
@@ -3299,7 +3299,7 @@ CMS_set1_eContentType                   3251	1_1_0	EXIST::FUNCTION:CMS
 EVP_des_ede3_wrap                       3252	1_1_0	EXIST::FUNCTION:DES
 GENERAL_SUBTREE_it                      3253	1_1_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 GENERAL_SUBTREE_it                      3253	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
-EVP_read_pw_string_min                  3254	1_1_0	EXIST::FUNCTION:UI
+EVP_read_pw_string_min                  3254	1_1_0	EXIST::FUNCTION:
 X509_set1_notBefore                     3255	1_1_0	EXIST::FUNCTION:
 MD4                                     3256	1_1_0	EXIST::FUNCTION:MD4
 EVP_PKEY_CTX_dup                        3257	1_1_0	EXIST::FUNCTION:
@@ -3466,7 +3466,7 @@ ASN1_mbstring_copy                      3417	1_1_0	EXIST::FUNCTION:
 PKCS7_set_type                          3418	1_1_0	EXIST::FUNCTION:
 BIO_gets                                3419	1_1_0	EXIST::FUNCTION:
 RSA_padding_check_PKCS1_type_1          3420	1_1_0	EXIST::FUNCTION:RSA
-UI_ctrl                                 3421	1_1_0	EXIST::FUNCTION:UI
+UI_ctrl                                 3421	1_1_0	EXIST::FUNCTION:
 i2d_X509_REQ_fp                         3422	1_1_0	EXIST::FUNCTION:STDIO
 BN_BLINDING_convert_ex                  3423	1_1_0	EXIST::FUNCTION:
 ASN1_GENERALIZEDTIME_print              3424	1_1_0	EXIST::FUNCTION:
@@ -3479,7 +3479,7 @@ OCSP_SINGLERESP_get_ext_count           3430	1_1_0	EXIST::FUNCTION:OCSP
 EC_POINT_free                           3431	1_1_0	EXIST::FUNCTION:EC
 EVP_OpenFinal                           3432	1_1_0	EXIST::FUNCTION:RSA
 RAND_egd_bytes                          3433	1_1_0	EXIST::FUNCTION:EGD
-UI_method_get_writer                    3434	1_1_0	EXIST::FUNCTION:UI
+UI_method_get_writer                    3434	1_1_0	EXIST::FUNCTION:
 BN_secure_new                           3435	1_1_0	EXIST::FUNCTION:
 SHA1_Update                             3437	1_1_0	EXIST::FUNCTION:
 BIO_s_connect                           3438	1_1_0	EXIST::FUNCTION:SOCK
@@ -3642,7 +3642,7 @@ RAND_bytes                              3596	1_1_0	EXIST::FUNCTION:
 PKCS7_free                              3597	1_1_0	EXIST::FUNCTION:
 X509_NAME_ENTRY_create_by_txt           3598	1_1_0	EXIST::FUNCTION:
 DES_cbc_cksum                           3599	1_1_0	EXIST::FUNCTION:DES
-UI_free                                 3600	1_1_0	EXIST::FUNCTION:UI
+UI_free                                 3600	1_1_0	EXIST::FUNCTION:
 BN_is_prime                             3601	1_1_0	EXIST::FUNCTION:DEPRECATEDIN_0_9_8
 CMS_get0_signers                        3602	1_1_0	EXIST::FUNCTION:CMS
 i2d_PrivateKey_fp                       3603	1_1_0	EXIST::FUNCTION:STDIO
@@ -3665,7 +3665,7 @@ TS_CONF_set_signer_digest               3619	1_1_0	EXIST::FUNCTION:TS
 OBJ_new_nid                             3620	1_1_0	EXIST::FUNCTION:
 CMS_ReceiptRequest_new                  3621	1_1_0	EXIST::FUNCTION:CMS
 SRP_VBASE_get1_by_user                  3622	1_1_0	EXIST::FUNCTION:SRP
-UI_method_get_closer                    3623	1_1_0	EXIST::FUNCTION:UI
+UI_method_get_closer                    3623	1_1_0	EXIST::FUNCTION:
 ENGINE_get_ex_data                      3624	1_1_0	EXIST::FUNCTION:ENGINE
 BN_print_fp                             3625	1_1_0	EXIST::FUNCTION:STDIO
 MD2_Update                              3626	1_1_0	EXIST::FUNCTION:MD2
@@ -3759,7 +3759,7 @@ ENGINE_register_all_digests             3713	1_1_0	EXIST::FUNCTION:ENGINE
 X509_REQ_get_version                    3714	1_1_0	EXIST::FUNCTION:
 i2d_ASN1_UTCTIME                        3715	1_1_0	EXIST::FUNCTION:
 TS_STATUS_INFO_new                      3716	1_1_0	EXIST::FUNCTION:TS
-UI_set_ex_data                          3717	1_1_0	EXIST::FUNCTION:UI
+UI_set_ex_data                          3717	1_1_0	EXIST::FUNCTION:
 ASN1_TIME_set                           3718	1_1_0	EXIST::FUNCTION:
 TS_RESP_verify_response                 3719	1_1_0	EXIST::FUNCTION:TS
 X509_REVOKED_get0_serialNumber          3720	1_1_0	EXIST::FUNCTION:
@@ -3796,7 +3796,7 @@ EVP_PKEY_meth_get_sign                  3750	1_1_0	EXIST::FUNCTION:
 TS_REQ_get_nonce                        3751	1_1_0	EXIST::FUNCTION:TS
 ENGINE_unregister_EC                    3752	1_1_0	EXIST::FUNCTION:ENGINE
 X509v3_get_ext_count                    3753	1_1_0	EXIST::FUNCTION:
-UI_OpenSSL                              3754	1_1_0	EXIST::FUNCTION:UI
+UI_OpenSSL                              3754	1_1_0	EXIST::FUNCTION:UI_CONSOLE
 CRYPTO_ccm128_decrypt                   3755	1_1_0	EXIST::FUNCTION:
 d2i_OCSP_RESPDATA                       3756	1_1_0	EXIST::FUNCTION:OCSP
 BIO_set_callback                        3757	1_1_0	EXIST::FUNCTION:
@@ -3826,7 +3826,7 @@ RSA_PSS_PARAMS_it                       3779	1_1_0	EXIST:EXPORT_VAR_AS_FUNCTION:
 X509_STORE_CTX_get_error_depth          3780	1_1_0	EXIST::FUNCTION:
 ASN1_GENERALIZEDTIME_set_string         3781	1_1_0	EXIST::FUNCTION:
 EC_GROUP_new_curve_GFp                  3782	1_1_0	EXIST::FUNCTION:EC
-UI_new_method                           3783	1_1_0	EXIST::FUNCTION:UI
+UI_new_method                           3783	1_1_0	EXIST::FUNCTION:
 Camellia_ofb128_encrypt                 3784	1_1_0	EXIST::FUNCTION:CAMELLIA
 X509_new                                3785	1_1_0	EXIST::FUNCTION:
 EC_KEY_get_conv_form                    3786	1_1_0	EXIST::FUNCTION:EC
@@ -4224,9 +4224,9 @@ X509_VERIFY_PARAM_set_inh_flags         4174	1_1_0d	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_inh_flags         4175	1_1_0d	EXIST::FUNCTION:
 EVP_PKEY_CTX_md                         4176	1_1_1	EXIST::FUNCTION:
 RSA_pkey_ctx_ctrl                       4177	1_1_1	EXIST::FUNCTION:RSA
-UI_method_set_ex_data                   4178	1_1_1	EXIST::FUNCTION:UI
-UI_method_get_ex_data                   4179	1_1_1	EXIST::FUNCTION:UI
-UI_UTIL_wrap_read_pem_callback          4180	1_1_1	EXIST::FUNCTION:UI
+UI_method_set_ex_data                   4178	1_1_1	EXIST::FUNCTION:
+UI_method_get_ex_data                   4179	1_1_1	EXIST::FUNCTION:
+UI_UTIL_wrap_read_pem_callback          4180	1_1_1	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_time              4181	1_1_0d	EXIST::FUNCTION:
 EVP_PKEY_get0_poly1305                  4182	1_1_1	EXIST::FUNCTION:POLY1305
 DH_check_params                         4183	1_1_0d	EXIST::FUNCTION:DH
@@ -4252,7 +4252,7 @@ EVP_aria_256_ecb                        4202	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_256_ctr                        4203	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_128_ctr                        4204	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_192_ctr                        4205	1_1_1	EXIST::FUNCTION:ARIA
-UI_null                                 4206	1_1_1	EXIST::FUNCTION:UI
+UI_null                                 4206	1_1_1	EXIST::FUNCTION:
 EC_KEY_get0_engine                      4207	1_1_1	EXIST::FUNCTION:EC
 INT32_it                                4208	1_1_0f	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 INT32_it                                4208	1_1_0f	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
@@ -4292,10 +4292,10 @@ PEM_read_bio_ex                         4234	1_1_1	EXIST::FUNCTION:
 PEM_bytes_read_bio_secmem               4235	1_1_1	EXIST::FUNCTION:
 EVP_DigestSign                          4236	1_1_1	EXIST::FUNCTION:
 EVP_DigestVerify                        4237	1_1_1	EXIST::FUNCTION:
-UI_method_get_data_duplicator           4238	1_1_1	EXIST::FUNCTION:UI
-UI_method_set_data_duplicator           4239	1_1_1	EXIST::FUNCTION:UI
-UI_dup_user_data                        4240	1_1_1	EXIST::FUNCTION:UI
-UI_method_get_data_destructor           4241	1_1_1	EXIST::FUNCTION:UI
+UI_method_get_data_duplicator           4238	1_1_1	EXIST::FUNCTION:
+UI_method_set_data_duplicator           4239	1_1_1	EXIST::FUNCTION:
+UI_dup_user_data                        4240	1_1_1	EXIST::FUNCTION:
+UI_method_get_data_destructor           4241	1_1_1	EXIST::FUNCTION:
 ERR_load_strings_const                  4242	1_1_1	EXIST::FUNCTION:
 ASN1_TIME_to_tm                         4243	1_1_1	EXIST::FUNCTION:
 ASN1_TIME_set_string_X509               4244	1_1_1	EXIST::FUNCTION:

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -127,7 +127,7 @@ my @known_algorithms = ( "RC2", "RC4", "RC5", "IDEA", "DES", "BF",
 			 # Unit testing
 		 	 "UNIT_TEST",
 			 # User Interface
-			 "UI",
+			 "UI_CONSOLE",
 			 #
 			 "TS",
 			 # OCB mode


### PR DESCRIPTION
Instead, make it possible to disable the console reader that's part of
the UI module.  This makes it possible to use the UI API and other UI
methods in environments where the console reader isn't useful.

To disable the console reader, configure with 'no-ui-console' /
'disable-ui-console'.

'no-ui' / 'disable-ui' is now an alias for  'no-ui-console' /
'disable-ui-console'.

Fixes #3806
