### PR TITLE
Make sure OSSL_STORE_load() isn't caught in an endless loop

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -90,6 +90,9 @@ OSSL_STORE_INFO *OSSL_STORE_load(OSSL_STORE_CTX *ctx)
     OSSL_STORE_INFO *v = NULL;
 
  again:
+    if (OSSL_STORE_eof(ctx))
+        return NULL;
+
     v = ctx->loader->load(ctx->loader_ctx, ctx->ui_method, ctx->ui_data);
 
     if (ctx->post_process != NULL && v != NULL) {


### PR DESCRIPTION
The post process callback might potentially say "no" to everything (by
constantly returning NULL) and thereby cause an endless loop.  Ensure
that we stop all processing when "eof" is reached.
