### PR TITLE
Fix a memory leak in ecdh/ecdsa_check

### DIFF
--- a/crypto/ecdh/ech_lib.c
+++ b/crypto/ecdh/ech_lib.c
@@ -225,9 +225,16 @@ ECDH_DATA *ecdh_check(EC_KEY *key)
              */
             ecdh_data_free(ecdh_data);
             ecdh_data = (ECDH_DATA *)data;
+        } else if (EC_KEY_get_key_method_data(key, ecdh_data_dup,
+                                              ecdh_data_free,
+                                              ecdh_data_free) != ecdh_data) {
+            /* Or an out of memory error in EC_KEY_insert_key_method_data. */
+            ecdh_data_free(ecdh_data);
+            return NULL;
         }
-    } else
+    } else {
         ecdh_data = (ECDH_DATA *)data;
+    }
 #ifdef OPENSSL_FIPS
     if (FIPS_mode() && !(ecdh_data->flags & ECDH_FLAG_FIPS_METHOD)
         && !(EC_KEY_get_flags(key) & EC_FLAG_NON_FIPS_ALLOW)) {

--- a/crypto/ecdsa/ecs_lib.c
+++ b/crypto/ecdsa/ecs_lib.c
@@ -203,9 +203,16 @@ ECDSA_DATA *ecdsa_check(EC_KEY *key)
              */
             ecdsa_data_free(ecdsa_data);
             ecdsa_data = (ECDSA_DATA *)data;
+        } else if (EC_KEY_get_key_method_data(key, ecdsa_data_dup,
+                                              ecdsa_data_free,
+                                              ecdsa_data_free) != ecdsa_data) {
+            /* Or an out of memory error in EC_KEY_insert_key_method_data. */
+            ecdsa_data_free(ecdsa_data);
+            return NULL;
         }
-    } else
+    } else {
         ecdsa_data = (ECDSA_DATA *)data;
+    }
 #ifdef OPENSSL_FIPS
     if (FIPS_mode() && !(ecdsa_data->flags & ECDSA_FLAG_FIPS_METHOD)
         && !(EC_KEY_get_flags(key) & EC_FLAG_NON_FIPS_ALLOW)) {


### PR DESCRIPTION
This should fix a memleak in ecdh/ecdsa_check.
For 1.0.2 branch at the moment.

```
Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7fdf3760437a in __interceptor_malloc ../../../../gcc-8-20170625/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x5412478 in CRYPTO_malloc /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/crypto/mem.c:346
    #2 0x579df30 in ECDH_DATA_new_method /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/crypto/ecdh/ech_lib.c:140
    #3 0x579ea94 in ecdh_data_new /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/crypto/ecdh/ech_lib.c:178
    #4 0x579ea94 in ecdh_check /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/crypto/ecdh/ech_lib.c:215
    #5 0x54a8e88 in ECDH_compute_key /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/crypto/ecdh/ech_key.c:77
    #6 0x5381d7f in ssl3_send_client_key_exchange /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/ssl/s3_clnt.c:2929
    #7 0x5393b97 in ssl3_connect /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/ssl/s3_clnt.c:435
    #8 0x52ad27f in ssl23_get_server_hello /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/ssl/s23_clnt.c:802
    #9 0x52ad27f in ssl23_connect /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/ssl/s23_clnt.c:231
    #10 0x52b1af1 in ssl23_write /home/ed/OPCToolboxV5/Source/Core/linux/x86_64/gcc8/release/openssl-1.0.2l/ssl/s23_lib.c:173
    #11 0x4cf5dea in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:123
    #12 0x4cf5dea in OpcUa_P_SocketService_SslWrite platforms/linux/opcua_p_socket_ssl.c:331
    #13 0x4c89e32 in OpcUa_HttpsConnection_WriteEventHandler transport/https/opcua_httpsconnection.c:842
    #14 0x4c848f8 in OpcUa_HttpsConnection_SocketCallback transport/https/opcua_httpsconnection.c:1422
    #15 0x4cf2c8b in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:152
    #16 0x4cf347d in OpcUa_SslSocket_InternalRead platforms/linux/opcua_p_socket_ssl.c:782
    #17 0x4cf347d in OpcUa_RawSocket_EventCallback platforms/linux/opcua_p_socket_ssl.c:839
    #18 0x4d166af in OpcUa_Socket_HandleEvent platforms/linux/opcua_p_socket_internal.c:898
    #19 0x4d18928 in OpcUa_P_Socket_HandleFdSet platforms/linux/opcua_p_socket_internal.c:1336
    #20 0x4d1a81f in OpcUa_P_SocketManager_ServeLoopInternal platforms/linux/opcua_p_socket_internal.c:1123
    #21 0x4ce06eb in OpcUa_P_SocketManager_ServerLoopThread platforms/linux/opcua_p_socket_interface.c:43
    #22 0x4bfbd53 in pthread_start platforms/linux/opcua_p_thread.c:46
    #23 0x7fdf373106b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
```