### PR TITLE
Fix a memleak in ec_GFp_mont_group_set_curve

### DIFF
--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -247,6 +247,8 @@ int ec_GFp_mont_group_set_curve(EC_GROUP *group, const BIGNUM *p,
         BN_CTX_free(new_ctx);
     if (mont != NULL)
         BN_MONT_CTX_free(mont);
+    if (one != NULL)
+        BN_free(one);
     return ret;
 }
 


### PR DESCRIPTION
Seems that was already fixed on 1.1.0 though.