### PR TITLE
Fix copyright date for the ARIA evp file.

### DIFF
--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2017, Oracle and/or its affiliates.  All rights reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use


### PR DESCRIPTION
The beginning copyright date was wildly incorrect.  This corrects it.
