### PR TITLE
TLSv1.3: Do not allow non (EC)DHE based resumption by default

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -214,10 +214,11 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         OPT_S_NOSSL3, OPT_S_NOTLS1, OPT_S_NOTLS1_1, OPT_S_NOTLS1_2, \
         OPT_S_NOTLS1_3, OPT_S_BUGS, OPT_S_NO_COMP, OPT_S_NOTICKET, \
         OPT_S_SERVERPREF, OPT_S_LEGACYRENEG, OPT_S_LEGACYCONN, \
-        OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_STRICT, OPT_S_SIGALGS, \
-        OPT_S_CLIENTSIGALGS, OPT_S_GROUPS, OPT_S_CURVES, OPT_S_NAMEDCURVE, \
-        OPT_S_CIPHER, OPT_S_DHPARAM, OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, \
-        OPT_S_COMP, OPT_S_NO_RENEGOTIATION, OPT_S__LAST
+        OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_ALLOW_NO_DHE_KEX, \
+        OPT_S_STRICT, OPT_S_SIGALGS, OPT_S_CLIENTSIGALGS, OPT_S_GROUPS, \
+        OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, OPT_S_DHPARAM, \
+        OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, OPT_S_COMP, \
+        OPT_S_NO_RENEGOTIATION, OPT_S__LAST
 
 # define OPT_S_OPTIONS \
         {"no_ssl3", OPT_S_NOSSL3, '-',"Just disable SSLv3" }, \
@@ -241,6 +242,8 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
             "Disallow session resumption on renegotiation"}, \
         {"no_legacy_server_connect", OPT_S_NOLEGACYCONN, '-', \
             "Disallow initial connection to servers that don't support RI"}, \
+        {"allow_no_dhe_kex", OPT_S_ALLOW_NO_DHE_KEX, '-', \
+            "In TLSv1.3 allow non-(ec)dhe based key exchange on resumption"}, \
         {"strict", OPT_S_STRICT, '-', \
             "Enforce strict certificate checks as per TLS standard"}, \
         {"sigalgs", OPT_S_SIGALGS, 's', \
@@ -279,6 +282,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         case OPT_S_LEGACYCONN: \
         case OPT_S_ONRESUMP: \
         case OPT_S_NOLEGACYCONN: \
+        case OPT_S_ALLOW_NO_DHE_KEX: \
         case OPT_S_STRICT: \
         case OPT_S_SIGALGS: \
         case OPT_S_CLIENTSIGALGS: \

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -93,6 +93,7 @@ B<openssl> B<s_client>
 [B<-bugs>]
 [B<-comp>]
 [B<-no_comp>]
+[B<-allow_no_dhe_kex>]
 [B<-sigalgs sigalglist>]
 [B<-curves curvelist>]
 [B<-cipher cipherlist>]

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -102,6 +102,7 @@ B<openssl> B<s_server>
 [B<-legacy_server_connect>]
 [B<-no_resumption_on_reneg>]
 [B<-no_legacy_server_connect>]
+[B<-allow_no_dhe_kex>]
 [B<-strict>]
 [B<-sigalgs val>]
 [B<-client_sigalgs val>]

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -186,6 +186,11 @@ permits or prohibits the use of unsafe legacy renegotiation for OpenSSL
 clients only. Equivalent to setting or clearing B<SSL_OP_LEGACY_SERVER_CONNECT>.
 Set by default.
 
+=item B<-allow_no_dhe_kex>
+
+In TLSv1.3 allow a non-(ec)dhe based key exchange mode on resumption. This means
+that there will be no forward secrecy for the resumed session.
+
 =item B<-strict>
 
 enables strict mode protocol handling. Equivalent to setting
@@ -398,6 +403,10 @@ Set by default.
 B<EncryptThenMac>: use encrypt-then-mac extension, enabled by
 default. Inverse of B<SSL_OP_NO_ENCRYPT_THEN_MAC>: that is,
 B<-EncryptThenMac> is the same as setting B<SSL_OP_NO_ENCRYPT_THEN_MAC>.
+
+B<AllowNoDHEKEX>: In TLSv1.3 allow a non-(ec)dhe based key exchange mode on
+resumption. This means that there will be no forward secrecy for the resumed
+session. Equivalent to B<SSL_OP_ALLOW_NO_DHE_KEX>.
 
 =item B<VerifyMode>
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -175,6 +175,11 @@ propose, and servers will not accept the extension.
 Disable all renegotiation in TLSv1.2 and earlier. Do not send HelloRequest
 messages, and ignore renegotiation requests via ClientHello.
 
+=item SSL_OP_ALLOW_NO_DHE_KEX
+
+In TLSv1.3 allow a non-(ec)dhe based key exchange mode on resumption. This means
+that there will be no forward secrecy for the resumed session.
+
 =back
 
 The following options no longer have any effect but their identifiers are

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -282,13 +282,13 @@ typedef int (*SSL_custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
 /* Typedef for verification callback */
 typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 
-/* In TLSv1.3 allow a non-(ec)dhe based kex_mode */
-# define SSL_OP_ALLOW_NO_DHE_KEX                         0x00000001U
-
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U
 # define SSL_OP_TLSEXT_PADDING                           0x00000010U
 # define SSL_OP_SAFARI_ECDHE_ECDSA_BUG                   0x00000040U
+
+/* In TLSv1.3 allow a non-(ec)dhe based kex_mode */
+# define SSL_OP_ALLOW_NO_DHE_KEX                         0x00000400U
 
 /*
  * Disable SSL 3.0/TLS 1.0 CBC vulnerability workaround that was added in

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -282,6 +282,9 @@ typedef int (*SSL_custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
 /* Typedef for verification callback */
 typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 
+/* In TLSv1.3 allow a non-(ec)dhe based kex_mode */
+# define SSL_OP_ALLOW_NO_DHE_KEX                         0x00000001U
+
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U
 # define SSL_OP_TLSEXT_PADDING                           0x00000010U

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -282,10 +282,25 @@ typedef int (*SSL_custom_ext_parse_cb_ex) (SSL *s, unsigned int ext_type,
 /* Typedef for verification callback */
 typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 
+/*
+ * Some values are reserved until OpenSSL 1.2.0 because they were previously
+ * included in SSL_OP_ALL in a 1.1.x release.
+ *  
+ * Reserved value (until OpenSSL 1.2.0)                  0x00000001U
+ * Reserved value (until OpenSSL 1.2.0)                  0x00000002U
+ */
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U
+
+/* Reserved value (until OpenSSL 1.2.0)                  0x00000008U */
 # define SSL_OP_TLSEXT_PADDING                           0x00000010U
+/* Reserved value (until OpenSSL 1.2.0)                  0x00000020U */
 # define SSL_OP_SAFARI_ECDHE_ECDSA_BUG                   0x00000040U
+/*
+ * Reserved value (until OpenSSL 1.2.0)                  0x00000080U
+ * Reserved value (until OpenSSL 1.2.0)                  0x00000100U
+ * Reserved value (until OpenSSL 1.2.0)                  0x00000200U
+ */
 
 /* In TLSv1.3 allow a non-(ec)dhe based kex_mode */
 # define SSL_OP_ALLOW_NO_DHE_KEX                         0x00000400U

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -367,6 +367,7 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
                      SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION),
         SSL_FLAG_TBL_INV("EncryptThenMac", SSL_OP_NO_ENCRYPT_THEN_MAC),
         SSL_FLAG_TBL("NoRenegotiation", SSL_OP_NO_RENEGOTIATION),
+        SSL_FLAG_TBL("AllowNoDHEKEX", SSL_OP_ALLOW_NO_DHE_KEX)
     };
     if (value == NULL)
         return -3;
@@ -585,6 +586,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_SWITCH("no_renegotiation", 0),
     SSL_CONF_CMD_SWITCH("no_resumption_on_reneg", SSL_CONF_FLAG_SERVER),
     SSL_CONF_CMD_SWITCH("no_legacy_server_connect", SSL_CONF_FLAG_SERVER),
+    SSL_CONF_CMD_SWITCH("allow_no_dhe_kex", 0),
     SSL_CONF_CMD_SWITCH("strict", 0),
     SSL_CONF_CMD_STRING(SignatureAlgorithms, "sigalgs", 0),
     SSL_CONF_CMD_STRING(ClientSignatureAlgorithms, "client_sigalgs", 0),
@@ -655,6 +657,8 @@ static const ssl_switch_tbl ssl_cmd_switches[] = {
     {SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION, 0},
     /* no_legacy_server_connect */
     {SSL_OP_LEGACY_SERVER_CONNECT, SSL_TFLAG_INV},
+    /* allow_no_dhe_kex */
+    {SSL_OP_ALLOW_NO_DHE_KEX, 0},
     {SSL_CERT_FLAG_TLS_STRICT, SSL_TFLAG_CERT}, /* strict */
 };
 

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -477,7 +477,8 @@ int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
     while (PACKET_get_1(&psk_kex_modes, &mode)) {
         if (mode == TLSEXT_KEX_MODE_KE_DHE)
             s->ext.psk_kex_mode |= TLSEXT_KEX_MODE_FLAG_KE_DHE;
-        else if (mode == TLSEXT_KEX_MODE_KE)
+        else if (mode == TLSEXT_KEX_MODE_KE
+                && (s->options & SSL_OP_ALLOW_NO_DHE_KEX) != 0)
             s->ext.psk_kex_mode |= TLSEXT_KEX_MODE_FLAG_KE;
     }
 #endif

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -171,7 +171,8 @@ ok(TLSProxy::Message->fail(), "Resume with empty kex modes");
 #Test 4: Attempt a resume with non-dhe kex mode only. Should resume without a
 #        key_share
 $proxy->clear();
-$proxy->clientflags("-sess_in ".$session);
+$proxy->clientflags("-allow_no_dhe_kex -sess_in ".$session);
+$proxy->serverflags("-allow_no_dhe_kex");
 $testtype = NON_DHE_KEX_MODE_ONLY;
 $proxy->start();
 checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
@@ -256,8 +257,8 @@ checkhandshake($proxy, checkhandshake::HRR_RESUME_HANDSHAKE,
 #         initial key_share and no overlapping groups. Should resume without a
 #         key_share
 $proxy->clear();
-$proxy->clientflags("-curves P-384 -sess_in ".$session);
-$proxy->serverflags("-curves P-256");
+$proxy->clientflags("-allow_no_dhe_kex -curves P-384 -sess_in ".$session);
+$proxy->serverflags("-allow_no_dhe_kex -curves P-256");
 $testtype = BOTH_KEX_MODES;
 $proxy->start();
 checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,


### PR DESCRIPTION
OpenSSL supports both the kex modes defined by TLSv1.3: psk_ke and psk_dhe_ke. The kex modes define whether an (ec)dhe based key_share is sent during resumption or not. If not then we will resume without forward secrecy. This PR changes the default so that we always use psk_dhe_ke. We will additionally support psk_ke if the option SSL_OP_ALLOW_NO_DHE_KEX is set.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
