### PR TITLE
Remove the TEST_check macro.

### DIFF
--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -413,7 +413,8 @@ static int test_handshake(int idx)
     result = do_handshake(server_ctx, server2_ctx, client_ctx,
                           resume_server_ctx, resume_client_ctx, test_ctx);
 
-    ret = check_test(result, test_ctx);
+    if (result != NULL)
+        ret = check_test(result, test_ctx);
 
 err:
     CONF_modules_unload(0);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -390,19 +390,6 @@ void test_perror(const char *s);
 # define TEST_openssl_errors test_openssl_errors
 # define TEST_perror         test_perror
 
-/*
- * For "impossible" conditions such as malloc failures or bugs in test code,
- * where continuing the test would be meaningless. Note that OPENSSL_assert
- * is fatal, and is never compiled out.  This macro should be avoided.
- */
-# define TEST_check(condition)                  \
-    do {                                        \
-        if (!(condition)) {                     \
-            TEST_openssl_errors();              \
-            OPENSSL_assert(!#condition);        \
-        }                                       \
-    } while (0)
-
 extern BIO *bio_out;
 extern BIO *bio_err;
 


### PR DESCRIPTION
This macro aborts the using process which prevents later tests from running and doesn't play well with the test framework.

- [x] tests are added or updated
