### PR TITLE
Fix compiler warnings

### DIFF
--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -488,14 +488,14 @@ end:
 
 static int test_ctlog_from_base64(void)
 {
-    CTLOG *log = NULL;
+    CTLOG *logp = NULL;
     const char notb64[] = "\01\02\03\04";
     const char pad[] = "====";
     const char name[] = "name";
 
     /* We expect these to both fail! */
-    if (!TEST_true(!CTLOG_new_from_base64(&log, notb64, name))
-        || !TEST_true(!CTLOG_new_from_base64(&log, pad, name)))
+    if (!TEST_true(!CTLOG_new_from_base64(&logp, notb64, name))
+        || !TEST_true(!CTLOG_new_from_base64(&logp, pad, name)))
         return 0;
     return 1;
 }

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -488,14 +488,14 @@ end:
 
 static int test_ctlog_from_base64(void)
 {
-    CTLOG *logp = NULL;
+    CTLOG *ctlogp = NULL;
     const char notb64[] = "\01\02\03\04";
     const char pad[] = "====";
     const char name[] = "name";
 
     /* We expect these to both fail! */
-    if (!TEST_true(!CTLOG_new_from_base64(&logp, notb64, name))
-        || !TEST_true(!CTLOG_new_from_base64(&logp, pad, name)))
+    if (!TEST_true(!CTLOG_new_from_base64(&ctlogp, notb64, name))
+        || !TEST_true(!CTLOG_new_from_base64(&ctlogp, pad, name)))
         return 0;
     return 1;
 }


### PR DESCRIPTION
I get the following error when I use  gcc 4.4.7 with Travis YML plugin and Jenkins : 

gcc  -Icrypto/include -Iinclude -I../_srcdist/crypto/include -I../_srcdist/include -DDSO_DLFCN -DHAVE_DLFCN_H -DNDEBUG -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib64/engines-1.1\"" -Wall -O3 -pthread -m64 -DL_ENDIAN  -DDEBUG_UNUSED -Wswitch -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wtype-limits -Wundef -Werror  -MMD -MF test/ct_test.d.tmp -MT test/ct_test.o -c -o test/ct_test.o ../_srcdist/test/ct_test.c
cc1: warnings being treated as errors
../_srcdist/test/ct_test.c: In function 'test_ctlog_from_base64':
../_srcdist/test/ct_test.c:491: error: declaration of 'log' shadows a global declaration
/usr/include/bits/mathcalls.h:110: error: shadowed declaration is here
make[1]: *** [test/ct_test.o] Error 1

This patch fixes the problem.