### PR TITLE
Avoid possible memleak in X509_policy_check()

### DIFF
--- a/crypto/x509v3/pcy_tree.c
+++ b/crypto/x509v3/pcy_tree.c
@@ -638,6 +638,7 @@ int X509_policy_check(X509_POLICY_TREE **ptree, int *pexplicit_policy,
 {
     int init_ret;
     int ret;
+    int calc_ret;
     X509_POLICY_TREE *tree = NULL;
     STACK_OF(X509_POLICY_NODE) *nodes, *auth_nodes = NULL;
 
@@ -675,11 +676,14 @@ int X509_policy_check(X509_POLICY_TREE **ptree, int *pexplicit_policy,
     }
 
     /* Tree is not empty: continue */
-    if ((ret = tree_calculate_authority_set(tree, &auth_nodes)) == 0 ||
-        !tree_calculate_user_set(tree, policy_oids, auth_nodes))
+
+    if ((calc_ret = tree_calculate_authority_set(tree, &auth_nodes)) == 0)
         goto error;
-    if (ret == TREE_CALC_OK_DOFREE)
+    ret = tree_calculate_user_set(tree, policy_oids, auth_nodes);
+    if (calc_ret == TREE_CALC_OK_DOFREE)
         sk_X509_POLICY_NODE_free(auth_nodes);
+    if (!ret)
+        goto error;
 
     *ptree = tree;
 


### PR DESCRIPTION
When tree_calculate_user_set() fails, a jump to error failed to
deallocate a possibly allocated |auth_nodes|.
