### PR TITLE
Undo one UI fix

### DIFF
--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -521,7 +521,6 @@ int UI_process(UI *ui)
         }
     }
 
-    state = NULL;
  err:
     if (ui->meth->ui_close_session != NULL
         && ui->meth->ui_close_session(ui) <= 0)


### PR DESCRIPTION
Undoing:
> - in UI_process(), |state| was never made NULL, which means an error
>   when closing the session wouldn't be accurately reported.

This was a faulty cherry-pick from master
