### PR TITLE
Fix memory leak when using PSK session files

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3009,6 +3009,7 @@ int s_client_main(int argc, char **argv)
             print_stuff(bio_c_out, con, 1);
         SSL_free(con);
     }
+    SSL_SESSION_free(psksess);
 #if !defined(OPENSSL_NO_NEXTPROTONEG)
     OPENSSL_free(next_proto.data);
 #endif

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2104,6 +2104,7 @@ int s_server_main(int argc, char *argv[])
     ret = 0;
  end:
     SSL_CTX_free(ctx);
+    SSL_SESSION_free(psksess);
     set_keylog_file(NULL, NULL);
     X509_free(s_cert);
     sk_X509_CRL_pop_free(crls, X509_CRL_free);


### PR DESCRIPTION
We were not freeing the session created when loading a PSK session file.