### PR TITLE
Certificate table

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2301,6 +2301,7 @@ SSL_R_MISSING_RSA_CERTIFICATE:168:missing rsa certificate
 SSL_R_MISSING_RSA_ENCRYPTING_CERT:169:missing rsa encrypting cert
 SSL_R_MISSING_RSA_SIGNING_CERT:170:missing rsa signing cert
 SSL_R_MISSING_SIGALGS_EXTENSION:112:missing sigalgs extension
+SSL_R_MISSING_SIGNING_CERT:221:missing signing cert
 SSL_R_MISSING_SRP_PARAM:358:can't find SRP server param
 SSL_R_MISSING_SUPPORTED_GROUPS_EXTENSION:209:missing supported groups extension
 SSL_R_MISSING_TMP_DH_KEY:171:missing tmp dh key

--- a/include/openssl/sslerr.h
+++ b/include/openssl/sslerr.h
@@ -483,6 +483,7 @@ int ERR_load_SSL_strings(void);
 # define SSL_R_MISSING_RSA_ENCRYPTING_CERT                169
 # define SSL_R_MISSING_RSA_SIGNING_CERT                   170
 # define SSL_R_MISSING_SIGALGS_EXTENSION                  112
+# define SSL_R_MISSING_SIGNING_CERT                       221
 # define SSL_R_MISSING_SRP_PARAM                          358
 # define SSL_R_MISSING_SUPPORTED_GROUPS_EXTENSION         209
 # define SSL_R_MISSING_TMP_DH_KEY                         171

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -976,3 +976,41 @@ int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid, void *other)
     return ctx->cert->sec_cb(NULL, ctx, op, bits, nid, other,
                              ctx->cert->sec_ex);
 }
+
+/*
+ * Certificate table information. NB: table entries must match SSL_PKEY indices
+ */
+static const SSL_CERT_LOOKUP ssl_cert_info [] = {
+    {EVP_PKEY_RSA, SSL_aRSA}, /* SSL_PKEY_RSA */
+    {EVP_PKEY_DSA, SSL_aDSS}, /* SSL_PKEY_DSA_SIGN */
+    {EVP_PKEY_EC, SSL_aECDSA}, /* SSL_PKEY_ECC */
+    {NID_id_GostR3410_2001, SSL_aGOST01}, /* SSL_PKEY_GOST01 */
+    {NID_id_GostR3410_2012_256, SSL_aGOST12}, /* SSL_PKEY_GOST12_256 */
+    {NID_id_GostR3410_2012_512, SSL_aGOST12}, /* SSL_PKEY_GOST12_512 */
+    {EVP_PKEY_ED25519, SSL_aECDSA} /* SSL_PKEY_ED25519 */
+};
+
+const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx)
+{
+    int nid = EVP_PKEY_id(pk);
+    size_t i;
+
+    if (nid == NID_undef)
+        return NULL;
+
+    for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
+        if (ssl_cert_info[i].nid == nid) {
+            if (pidx != NULL)
+                *pidx = i;
+            return &ssl_cert_info[i];
+        }
+    }
+    return NULL;
+}
+
+const SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx)
+{
+    if (idx >= OSSL_NELEM(ssl_cert_info))
+        return 0;
+    return &ssl_cert_info[idx];
+}

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -24,6 +24,7 @@
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
 #include "ssl_locl.h"
+#include "ssl_cert_table.h"
 #include "internal/thread_once.h"
 
 static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
@@ -976,19 +977,6 @@ int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid, void *other)
     return ctx->cert->sec_cb(NULL, ctx, op, bits, nid, other,
                              ctx->cert->sec_ex);
 }
-
-/*
- * Certificate table information. NB: table entries must match SSL_PKEY indices
- */
-static const SSL_CERT_LOOKUP ssl_cert_info [] = {
-    {EVP_PKEY_RSA, SSL_aRSA}, /* SSL_PKEY_RSA */
-    {EVP_PKEY_DSA, SSL_aDSS}, /* SSL_PKEY_DSA_SIGN */
-    {EVP_PKEY_EC, SSL_aECDSA}, /* SSL_PKEY_ECC */
-    {NID_id_GostR3410_2001, SSL_aGOST01}, /* SSL_PKEY_GOST01 */
-    {NID_id_GostR3410_2012_256, SSL_aGOST12}, /* SSL_PKEY_GOST12_256 */
-    {NID_id_GostR3410_2012_512, SSL_aGOST12}, /* SSL_PKEY_GOST12_512 */
-    {EVP_PKEY_ED25519, SSL_aECDSA} /* SSL_PKEY_ED25519 */
-};
 
 const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx)
 {

--- a/ssl/ssl_cert_table.h
+++ b/ssl/ssl_cert_table.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Certificate table information. NB: table entries must match SSL_PKEY indices
+ */
+static const SSL_CERT_LOOKUP ssl_cert_info [] = {
+    {EVP_PKEY_RSA, SSL_aRSA}, /* SSL_PKEY_RSA */
+    {EVP_PKEY_DSA, SSL_aDSS}, /* SSL_PKEY_DSA_SIGN */
+    {EVP_PKEY_EC, SSL_aECDSA}, /* SSL_PKEY_ECC */
+    {NID_id_GostR3410_2001, SSL_aGOST01}, /* SSL_PKEY_GOST01 */
+    {NID_id_GostR3410_2012_256, SSL_aGOST12}, /* SSL_PKEY_GOST12_256 */
+    {NID_id_GostR3410_2012_512, SSL_aGOST12}, /* SSL_PKEY_GOST12_512 */
+    {EVP_PKEY_ED25519, SSL_aECDSA} /* SSL_PKEY_ED25519 */
+};

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1857,27 +1857,6 @@ int SSL_COMP_get_id(const SSL_COMP *comp)
 #endif
 }
 
-/* For a cipher return the index corresponding to the certificate type */
-int ssl_cipher_get_cert_index(const SSL_CIPHER *c)
-{
-    uint32_t alg_a;
-
-    alg_a = c->algorithm_auth;
-
-    if (alg_a & SSL_aECDSA)
-        return SSL_PKEY_ECC;
-    else if (alg_a & SSL_aDSS)
-        return SSL_PKEY_DSA_SIGN;
-    else if (alg_a & SSL_aRSA)
-        return SSL_PKEY_RSA;
-    else if (alg_a & SSL_aGOST12)
-        return SSL_PKEY_GOST_EC;
-    else if (alg_a & SSL_aGOST01)
-        return SSL_PKEY_GOST01;
-
-    return -1;
-}
-
 const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl, const unsigned char *ptr,
                                          int all)
 {

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1996,3 +1996,12 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
 
     return 1;
 }
+
+int ssl_cert_is_disabled(size_t idx)
+{
+    const SSL_CERT_LOOKUP *cl = ssl_cert_lookup_by_idx(idx);
+
+    if (cl == NULL || (cl->amask & disabled_auth_mask) != 0)
+        return 1;
+    return 0;
+}

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -767,6 +767,8 @@ static const ERR_STRING_DATA SSL_str_reasons[] = {
     "missing rsa signing cert"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_MISSING_SIGALGS_EXTENSION),
     "missing sigalgs extension"},
+    {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_MISSING_SIGNING_CERT),
+    "missing signing cert"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_MISSING_SRP_PARAM),
     "can't find SRP server param"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_MISSING_SUPPORTED_GROUPS_EXTENSION),

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2105,7 +2105,6 @@ __owur int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
                                    size_t *int_overhead, size_t *blocksize,
                                    size_t *ext_overhead);
 __owur int ssl_cert_is_disabled(size_t idx);
-__owur int ssl_cipher_get_cert_index(const SSL_CIPHER *c);
 __owur const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl,
                                                 const unsigned char *ptr,
                                                 int all);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2136,7 +2136,6 @@ __owur int ssl_undefined_const_function(const SSL *s);
 __owur int ssl_get_server_cert_serverinfo(SSL *s,
                                           const unsigned char **serverinfo,
                                           size_t *serverinfo_length);
-__owur int ssl_cert_type(const X509 *x, const EVP_PKEY *pkey);
 void ssl_set_masks(SSL *s);
 __owur STACK_OF(SSL_CIPHER) *ssl_get_ciphers_by_id(SSL *s);
 __owur int ssl_verify_alarm_type(long type);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1345,6 +1345,15 @@ typedef struct sigalg_lookup_st {
 
 typedef struct cert_pkey_st CERT_PKEY;
 
+/*
+ * Structure containing table entry of certificate info corresponding to
+ * CERT_PKEY entries
+ */
+typedef struct {
+    int nid; /* NID of pubic key algorithm */
+    uint32_t amask; /* authmask corresponding to key type */
+} SSL_CERT_LOOKUP;
+
 typedef struct ssl3_state_st {
     long flags;
     size_t read_mac_secret_size;
@@ -2092,6 +2101,7 @@ __owur int ssl_cipher_get_evp(const SSL_SESSION *s, const EVP_CIPHER **enc,
 __owur int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
                                    size_t *int_overhead, size_t *blocksize,
                                    size_t *ext_overhead);
+__owur int ssl_cert_is_disabled(size_t idx);
 __owur int ssl_cipher_get_cert_index(const SSL_CIPHER *c);
 __owur const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl,
                                                 const unsigned char *ptr,
@@ -2113,6 +2123,10 @@ __owur int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain,
 __owur int ssl_security(const SSL *s, int op, int bits, int nid, void *other);
 __owur int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid,
                             void *other);
+
+__owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk,
+                                                      size_t *pidx);
+__owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx);
 
 int ssl_undefined_function(SSL *s);
 __owur int ssl_undefined_void_function(void);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -206,6 +206,9 @@
 # define SSL_aGOST12             0x00000080U
 /* Any appropriate signature auth (for TLS 1.3 ciphersuites) */
 # define SSL_aANY                0x00000000U
+/* All bits requiring a certificate */
+#define SSL_aCERT \
+    (SSL_aRSA | SSL_aDSS | SSL_aECDSA | SSL_aGOST01 | SSL_aGOST12)
 
 /* Bits for algorithm_enc (symmetric encryption) */
 # define SSL_DES                 0x00000001U

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -316,7 +316,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
     unsigned char *gost_data = NULL;
 #endif
     int al = SSL_AD_INTERNAL_ERROR, ret = MSG_PROCESS_ERROR;
-    int type = 0, j;
+    int j;
     unsigned int len;
     X509 *peer;
     const EVP_MD *md = NULL;
@@ -336,9 +336,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
     if (pkey == NULL)
         goto f_err;
 
-    type = X509_certificate_type(peer, pkey);
-
-    if (!(type & EVP_PKT_SIGN)) {
+    if (ssl_cert_lookup_by_pkey(pkey, NULL) == NULL) {
         SSLerr(SSL_F_TLS_PROCESS_CERT_VERIFY,
                SSL_R_SIGNATURE_FOR_NON_SIGNING_CERTIFICATE);
         al = SSL_AD_ILLEGAL_PARAMETER;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1238,35 +1238,6 @@ int tls_get_message_body(SSL *s, size_t *len)
     return 1;
 }
 
-int ssl_cert_type(const X509 *x, const EVP_PKEY *pk)
-{
-    if (pk == NULL && (pk = X509_get0_pubkey(x)) == NULL)
-        return -1;
-
-    switch (EVP_PKEY_id(pk)) {
-    default:
-        return -1;
-    case EVP_PKEY_RSA:
-        return SSL_PKEY_RSA;
-    case EVP_PKEY_DSA:
-        return SSL_PKEY_DSA_SIGN;
-#ifndef OPENSSL_NO_EC
-    case EVP_PKEY_EC:
-        return SSL_PKEY_ECC;
-    case EVP_PKEY_ED25519:
-        return SSL_PKEY_ED25519;
-#endif
-#ifndef OPENSSL_NO_GOST
-    case NID_id_GostR3410_2001:
-        return SSL_PKEY_GOST01;
-    case NID_id_GostR3410_2012_256:
-        return SSL_PKEY_GOST12_256;
-    case NID_id_GostR3410_2012_512:
-        return SSL_PKEY_GOST12_512;
-#endif
-    }
-}
-
 int ssl_verify_alarm_type(long type)
 {
     int al;

--- a/test/build.info
+++ b/test/build.info
@@ -43,7 +43,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
           pkey_meth_test uitest cipherbytes_test asn1_encode_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test recordlentest \
-          time_offset_test pemtest
+          time_offset_test pemtest ssl_cert_table_internal_test
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include
@@ -313,6 +313,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[pemtest]=pemtest.c
   INCLUDE[pemtest]=../include .
   DEPEND[pemtest]=../libcrypto libtestutil.a
+
+  SOURCE[ssl_cert_table_internal_test]=ssl_cert_table_internal_test.c
+  INCLUDE[ssl_cert_table_internal_test]=.. ../include
+  DEPEND[ssl_cert_table_internal_test]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{psk} -}]
     PROGRAMS_NO_INST=dtls_mtu_test

--- a/test/recipes/03-test_internal_ssl_cert_table.t
+++ b/test/recipes/03-test_internal_ssl_cert_table.t
@@ -1,0 +1,19 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;              # get 'plan'
+use OpenSSL::Test::Simple;
+use OpenSSL::Test::Utils;
+
+setup("test_internal_ssl_cert_table");
+
+plan skip_all => "This test is unsupported in a shared library build on Windows"
+    if $^O eq 'MSWin32' && !disabled("shared");
+
+simple_test("test_internal_ssl_cert_table", "ssl_cert_table_internal_test");

--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -1,22 +1,24 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 15
+num_tests = 17
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-Ed25519 CipherString and Signature Algorithm Selection
 test-2 = 2-RSA CipherString Selection
-test-3 = 3-ECDSA CipherString Selection, no ECDSA certificate
-test-4 = 4-ECDSA Signature Algorithm Selection
-test-5 = 5-ECDSA Signature Algorithm Selection SHA384
-test-6 = 6-ECDSA Signature Algorithm Selection SHA1
-test-7 = 7-ECDSA Signature Algorithm Selection compressed point
-test-8 = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-9 = 9-RSA Signature Algorithm Selection
-test-10 = 10-RSA-PSS Signature Algorithm Selection
-test-11 = 11-Suite B P-256 Hash Algorithm Selection
-test-12 = 12-Suite B P-384 Hash Algorithm Selection
-test-13 = 13-TLS 1.2 Ed25519 Client Auth
-test-14 = 14-TLS 1.2 DSA Certificate Test
+test-3 = 3-P-256 CipherString and Signature Algorithm Selection
+test-4 = 4-Ed25519 CipherString and Curves Selection
+test-5 = 5-ECDSA CipherString Selection, no ECDSA certificate
+test-6 = 6-ECDSA Signature Algorithm Selection
+test-7 = 7-ECDSA Signature Algorithm Selection SHA384
+test-8 = 8-ECDSA Signature Algorithm Selection SHA1
+test-9 = 9-ECDSA Signature Algorithm Selection compressed point
+test-10 = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-11 = 11-RSA Signature Algorithm Selection
+test-12 = 12-RSA-PSS Signature Algorithm Selection
+test-13 = 13-Suite B P-256 Hash Algorithm Selection
+test-14 = 14-Suite B P-384 Hash Algorithm Selection
+test-15 = 15-TLS 1.2 Ed25519 Client Auth
+test-16 = 16-TLS 1.2 DSA Certificate Test
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -117,39 +119,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[3-ECDSA CipherString Selection, no ECDSA certificate]
-ssl_conf = 3-ECDSA CipherString Selection, no ECDSA certificate-ssl
+[3-P-256 CipherString and Signature Algorithm Selection]
+ssl_conf = 3-P-256 CipherString and Signature Algorithm Selection-ssl
 
-[3-ECDSA CipherString Selection, no ECDSA certificate-ssl]
-server = 3-ECDSA CipherString Selection, no ECDSA certificate-server
-client = 3-ECDSA CipherString Selection, no ECDSA certificate-client
+[3-P-256 CipherString and Signature Algorithm Selection-ssl]
+server = 3-P-256 CipherString and Signature Algorithm Selection-server
+client = 3-P-256 CipherString and Signature Algorithm Selection-client
 
-[3-ECDSA CipherString Selection, no ECDSA certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[3-ECDSA CipherString Selection, no ECDSA certificate-client]
-CipherString = aECDSA
-MaxProtocol = TLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-3]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[4-ECDSA Signature Algorithm Selection]
-ssl_conf = 4-ECDSA Signature Algorithm Selection-ssl
-
-[4-ECDSA Signature Algorithm Selection-ssl]
-server = 4-ECDSA Signature Algorithm Selection-server
-client = 4-ECDSA Signature Algorithm Selection-client
-
-[4-ECDSA Signature Algorithm Selection-server]
+[3-P-256 CipherString and Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -159,13 +136,14 @@ EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[4-ECDSA Signature Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA256
+[3-P-256 CipherString and Signature Algorithm Selection-client]
+CipherString = aECDSA
+MaxProtocol = TLSv1.2
+SignatureAlgorithms = ECDSA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-4]
+[test-3]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -174,14 +152,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[5-ECDSA Signature Algorithm Selection SHA384]
-ssl_conf = 5-ECDSA Signature Algorithm Selection SHA384-ssl
+[4-Ed25519 CipherString and Curves Selection]
+ssl_conf = 4-Ed25519 CipherString and Curves Selection-ssl
 
-[5-ECDSA Signature Algorithm Selection SHA384-ssl]
-server = 5-ECDSA Signature Algorithm Selection SHA384-server
-client = 5-ECDSA Signature Algorithm Selection SHA384-client
+[4-Ed25519 CipherString and Curves Selection-ssl]
+server = 4-Ed25519 CipherString and Curves Selection-server
+client = 4-Ed25519 CipherString and Curves Selection-client
 
-[5-ECDSA Signature Algorithm Selection SHA384-server]
+[4-Ed25519 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -191,13 +169,103 @@ EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[5-ECDSA Signature Algorithm Selection SHA384-client]
+[4-Ed25519 CipherString and Curves Selection-client]
+CipherString = aECDSA
+Curves = X25519
+MaxProtocol = TLSv1.2
+SignatureAlgorithms = ECDSA+SHA256:ed25519
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ExpectedResult = Success
+ExpectedServerCertType = Ed25519
+ExpectedServerSignType = Ed25519
+
+
+# ===========================================================
+
+[5-ECDSA CipherString Selection, no ECDSA certificate]
+ssl_conf = 5-ECDSA CipherString Selection, no ECDSA certificate-ssl
+
+[5-ECDSA CipherString Selection, no ECDSA certificate-ssl]
+server = 5-ECDSA CipherString Selection, no ECDSA certificate-server
+client = 5-ECDSA CipherString Selection, no ECDSA certificate-client
+
+[5-ECDSA CipherString Selection, no ECDSA certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-ECDSA CipherString Selection, no ECDSA certificate-client]
+CipherString = aECDSA
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[6-ECDSA Signature Algorithm Selection]
+ssl_conf = 6-ECDSA Signature Algorithm Selection-ssl
+
+[6-ECDSA Signature Algorithm Selection-ssl]
+server = 6-ECDSA Signature Algorithm Selection-server
+client = 6-ECDSA Signature Algorithm Selection-client
+
+[6-ECDSA Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-ECDSA Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+ExpectedResult = Success
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[7-ECDSA Signature Algorithm Selection SHA384]
+ssl_conf = 7-ECDSA Signature Algorithm Selection SHA384-ssl
+
+[7-ECDSA Signature Algorithm Selection SHA384-ssl]
+server = 7-ECDSA Signature Algorithm Selection SHA384-server
+client = 7-ECDSA Signature Algorithm Selection SHA384-client
+
+[7-ECDSA Signature Algorithm Selection SHA384-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-ECDSA Signature Algorithm Selection SHA384-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-5]
+[test-7]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA384
@@ -206,14 +274,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[6-ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 6-ECDSA Signature Algorithm Selection SHA1-ssl
+[8-ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 8-ECDSA Signature Algorithm Selection SHA1-ssl
 
-[6-ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 6-ECDSA Signature Algorithm Selection SHA1-server
-client = 6-ECDSA Signature Algorithm Selection SHA1-client
+[8-ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 8-ECDSA Signature Algorithm Selection SHA1-server
+client = 8-ECDSA Signature Algorithm Selection SHA1-client
 
-[6-ECDSA Signature Algorithm Selection SHA1-server]
+[8-ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -223,13 +291,13 @@ EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[6-ECDSA Signature Algorithm Selection SHA1-client]
+[8-ECDSA Signature Algorithm Selection SHA1-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-6]
+[test-8]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA1
@@ -238,14 +306,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[7-ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 7-ECDSA Signature Algorithm Selection compressed point-ssl
+[9-ECDSA Signature Algorithm Selection compressed point]
+ssl_conf = 9-ECDSA Signature Algorithm Selection compressed point-ssl
 
-[7-ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 7-ECDSA Signature Algorithm Selection compressed point-server
-client = 7-ECDSA Signature Algorithm Selection compressed point-client
+[9-ECDSA Signature Algorithm Selection compressed point-ssl]
+server = 9-ECDSA Signature Algorithm Selection compressed point-server
+client = 9-ECDSA Signature Algorithm Selection compressed point-client
 
-[7-ECDSA Signature Algorithm Selection compressed point-server]
+[9-ECDSA Signature Algorithm Selection compressed point-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
@@ -253,13 +321,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[7-ECDSA Signature Algorithm Selection compressed point-client]
+[9-ECDSA Signature Algorithm Selection compressed point-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-7]
+[test-9]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -268,39 +336,39 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[8-ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
 
-[8-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
 
-[8-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[8-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-8]
+[test-10]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[9-RSA Signature Algorithm Selection]
-ssl_conf = 9-RSA Signature Algorithm Selection-ssl
+[11-RSA Signature Algorithm Selection]
+ssl_conf = 11-RSA Signature Algorithm Selection-ssl
 
-[9-RSA Signature Algorithm Selection-ssl]
-server = 9-RSA Signature Algorithm Selection-server
-client = 9-RSA Signature Algorithm Selection-client
+[11-RSA Signature Algorithm Selection-ssl]
+server = 11-RSA Signature Algorithm Selection-server
+client = 11-RSA Signature Algorithm Selection-client
 
-[9-RSA Signature Algorithm Selection-server]
+[11-RSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -310,13 +378,13 @@ EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[9-RSA Signature Algorithm Selection-client]
+[11-RSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-9]
+[test-11]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -325,14 +393,14 @@ ExpectedServerSignType = RSA
 
 # ===========================================================
 
-[10-RSA-PSS Signature Algorithm Selection]
-ssl_conf = 10-RSA-PSS Signature Algorithm Selection-ssl
+[12-RSA-PSS Signature Algorithm Selection]
+ssl_conf = 12-RSA-PSS Signature Algorithm Selection-ssl
 
-[10-RSA-PSS Signature Algorithm Selection-ssl]
-server = 10-RSA-PSS Signature Algorithm Selection-server
-client = 10-RSA-PSS Signature Algorithm Selection-client
+[12-RSA-PSS Signature Algorithm Selection-ssl]
+server = 12-RSA-PSS Signature Algorithm Selection-server
+client = 12-RSA-PSS Signature Algorithm Selection-client
 
-[10-RSA-PSS Signature Algorithm Selection-server]
+[12-RSA-PSS Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -342,13 +410,13 @@ EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[10-RSA-PSS Signature Algorithm Selection-client]
+[12-RSA-PSS Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA-PSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-10]
+[test-12]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -357,14 +425,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[11-Suite B P-256 Hash Algorithm Selection]
-ssl_conf = 11-Suite B P-256 Hash Algorithm Selection-ssl
+[13-Suite B P-256 Hash Algorithm Selection]
+ssl_conf = 13-Suite B P-256 Hash Algorithm Selection-ssl
 
-[11-Suite B P-256 Hash Algorithm Selection-ssl]
-server = 11-Suite B P-256 Hash Algorithm Selection-server
-client = 11-Suite B P-256 Hash Algorithm Selection-client
+[13-Suite B P-256 Hash Algorithm Selection-ssl]
+server = 13-Suite B P-256 Hash Algorithm Selection-server
+client = 13-Suite B P-256 Hash Algorithm Selection-client
 
-[11-Suite B P-256 Hash Algorithm Selection-server]
+[13-Suite B P-256 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
@@ -372,13 +440,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[11-Suite B P-256 Hash Algorithm Selection-client]
+[13-Suite B P-256 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-11]
+[test-13]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -387,14 +455,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[12-Suite B P-384 Hash Algorithm Selection]
-ssl_conf = 12-Suite B P-384 Hash Algorithm Selection-ssl
+[14-Suite B P-384 Hash Algorithm Selection]
+ssl_conf = 14-Suite B P-384 Hash Algorithm Selection-ssl
 
-[12-Suite B P-384 Hash Algorithm Selection-ssl]
-server = 12-Suite B P-384 Hash Algorithm Selection-server
-client = 12-Suite B P-384 Hash Algorithm Selection-client
+[14-Suite B P-384 Hash Algorithm Selection-ssl]
+server = 14-Suite B P-384 Hash Algorithm Selection-server
+client = 14-Suite B P-384 Hash Algorithm Selection-client
 
-[12-Suite B P-384 Hash Algorithm Selection-server]
+[14-Suite B P-384 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
@@ -402,13 +470,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[12-Suite B P-384 Hash Algorithm Selection-client]
+[14-Suite B P-384 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-12]
+[test-14]
 ExpectedResult = Success
 ExpectedServerCertType = P-384
 ExpectedServerSignHash = SHA384
@@ -417,21 +485,21 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[13-TLS 1.2 Ed25519 Client Auth]
-ssl_conf = 13-TLS 1.2 Ed25519 Client Auth-ssl
+[15-TLS 1.2 Ed25519 Client Auth]
+ssl_conf = 15-TLS 1.2 Ed25519 Client Auth-ssl
 
-[13-TLS 1.2 Ed25519 Client Auth-ssl]
-server = 13-TLS 1.2 Ed25519 Client Auth-server
-client = 13-TLS 1.2 Ed25519 Client Auth-client
+[15-TLS 1.2 Ed25519 Client Auth-ssl]
+server = 15-TLS 1.2 Ed25519 Client Auth-server
+client = 15-TLS 1.2 Ed25519 Client Auth-client
 
-[13-TLS 1.2 Ed25519 Client Auth-server]
+[15-TLS 1.2 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[13-TLS 1.2 Ed25519 Client Auth-client]
+[15-TLS 1.2 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -440,7 +508,7 @@ MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-13]
+[test-15]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
@@ -448,14 +516,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[14-TLS 1.2 DSA Certificate Test]
-ssl_conf = 14-TLS 1.2 DSA Certificate Test-ssl
+[16-TLS 1.2 DSA Certificate Test]
+ssl_conf = 16-TLS 1.2 DSA Certificate Test-ssl
 
-[14-TLS 1.2 DSA Certificate Test-ssl]
-server = 14-TLS 1.2 DSA Certificate Test-server
-client = 14-TLS 1.2 DSA Certificate Test-client
+[16-TLS 1.2 DSA Certificate Test-ssl]
+server = 16-TLS 1.2 DSA Certificate Test-server
+client = 16-TLS 1.2 DSA Certificate Test-client
 
-[14-TLS 1.2 DSA Certificate Test-server]
+[16-TLS 1.2 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DHParameters = ${ENV::TEST_CERTS_DIR}/dhp2048.pem
@@ -465,13 +533,13 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[14-TLS 1.2 DSA Certificate Test-client]
+[16-TLS 1.2 DSA Certificate Test-client]
 CipherString = ALL
 SignatureAlgorithms = DSA+SHA256:DSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-14]
+[test-16]
 ExpectedResult = Success
 
 

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -65,6 +65,38 @@ our @tests = (
         },
     },
     {
+        name => "P-256 CipherString and Signature Algorithm Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
+            "SignatureAlgorithms" => "ECDSA+SHA256:ed25519",
+        },
+        test   => {
+            "ExpectedServerCertType" => "P-256",
+            "ExpectedServerSignHash" => "SHA256",
+            "ExpectedServerSignType" => "EC",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "Ed25519 CipherString and Curves Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
+            "SignatureAlgorithms" => "ECDSA+SHA256:ed25519",
+            # Excluding P-256 from the supported curves list means server
+            # certificate should be Ed25519 and not P-256
+            "Curves" => "X25519"
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed25519",
+            "ExpectedServerSignType" =>, "Ed25519",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
         name => "ECDSA CipherString Selection, no ECDSA certificate",
         server => {
             "MaxProtocol" => "TLSv1.2"
@@ -361,6 +393,22 @@ my @tests_tls_1_3 = (
         test   => {
             "ExpectedServerCertType" => "Ed25519",
             "ExpectedServerSignType" => "Ed25519",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "TLS 1.3 Ed25519 CipherString and Groups Selection",
+        server => $server_tls_1_3,
+        client => {
+            "SignatureAlgorithms" => "ECDSA+SHA256:ed25519",
+            # Excluding P-256 from the supported groups list should
+            # mean server still uses a P-256 certificate because supported
+            # groups is not used in signature selection for TLS 1.3
+            "Groups" => "X25519"
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "P-256",
+            "ExpectedServerSignType" =>, "EC",
             "ExpectedResult" => "Success"
         },
     },

--- a/test/ssl_cert_table_internal_test.c
+++ b/test/ssl_cert_table_internal_test.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Internal tests for the x509 and x509v3 modules */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/ssl.h>
+#include "testutil.h"
+#include "e_os.h"
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
+#include "../ssl/ssl_locl.h"
+#include "../ssl/ssl_cert_table.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
+
+#define test_cert_table(nid, amask, idx) \
+    do_test_cert_table(nid, amask, idx, #idx)
+
+static int do_test_cert_table(int nid, uint32_t amask, size_t idx,
+                              const char *idxname)
+{
+    const SSL_CERT_LOOKUP *clu = &ssl_cert_info[idx];
+
+    if (clu->nid == nid && clu->amask == amask)
+        return 1;
+
+    TEST_error("Invalid table entry for certificate type %s, index %zu",
+               idxname, idx);
+    if (clu->nid != nid)
+        TEST_note("Expected %s, got %s\n", OBJ_nid2sn(nid),
+                  OBJ_nid2sn(clu->nid));
+    if (clu->amask != amask)
+        TEST_note("Expected auth mask 0x%x, got 0x%x\n", amask, clu->amask);
+    return 0;
+}
+
+/* Sanity check of ssl_cert_table */
+
+static int test_ssl_cert_table()
+{
+    TEST_size_t_eq(OSSL_NELEM(ssl_cert_info), SSL_PKEY_NUM);
+    if (!test_cert_table(EVP_PKEY_RSA, SSL_aRSA, SSL_PKEY_RSA))
+        return 0;
+    if (!test_cert_table(EVP_PKEY_DSA, SSL_aDSS, SSL_PKEY_DSA_SIGN))
+        return 0;
+    if (!test_cert_table(EVP_PKEY_EC, SSL_aECDSA, SSL_PKEY_ECC))
+        return 0;
+    if (!test_cert_table(NID_id_GostR3410_2001, SSL_aGOST01, SSL_PKEY_GOST01))
+        return 0;
+    if (!test_cert_table(NID_id_GostR3410_2012_256, SSL_aGOST12,
+                         SSL_PKEY_GOST12_256))
+        return 0;
+    if (!test_cert_table(NID_id_GostR3410_2012_512, SSL_aGOST12,
+                         SSL_PKEY_GOST12_512))
+        return 0;
+    if (!test_cert_table(EVP_PKEY_ED25519, SSL_aECDSA, SSL_PKEY_ED25519))
+        return 0;
+
+    return 1;
+}
+
+void register_tests()
+{
+    ADD_TEST(test_ssl_cert_table);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

This PR adds a certificate table containing properties of each certificate type: specifically the NID of the public key algorithm and the auth mask associated with it. This is used to remove a lot of the algorithm specific cases and make it easier to add new types in future.

It also fixes a bug in the signature selection code and adds a test for that case and some others.
