### PR TITLE
Apps rand style

### DIFF
--- a/apps/app_rand.c
+++ b/apps/app_rand.c
@@ -10,108 +10,82 @@
 #include "apps.h"
 #include <openssl/bio.h>
 #include <openssl/rand.h>
+#include <openssl/conf.h>
 
-static int seeded = 0;
-static int egdsocket = 0;
+static const char *save_rand_file;
 
-int app_RAND_load_file(const char *file, int dont_warn)
+void app_RAND_load_conf(CONF *c, const char *section)
 {
-    int consider_randfile = (file == NULL);
-    char buffer[200];
+    const char *randfile = NCONF_get_string(c, section, "RANDFILE");
 
-    if (file == NULL) {
-        file = RAND_file_name(buffer, sizeof buffer);
-#ifndef OPENSSL_NO_EGD
-    } else if (RAND_egd(file) > 0) {
-        /*
-         * we try if the given filename is an EGD socket. if it is, we don't
-         * write anything back to the file.
-         */
-        egdsocket = 1;
-        return 1;
-#endif
+    if (randfile == NULL) {
+        ERR_clear_error();
+        return;
     }
-
-    if (file == NULL || !RAND_load_file(file, -1)) {
-        if (RAND_status() == 0) {
-            if (!dont_warn) {
-                BIO_printf(bio_err, "unable to load 'random state'\n");
-                BIO_printf(bio_err,
-                           "This means that the random number generator has not been seeded\n");
-                BIO_printf(bio_err, "with much random data.\n");
-                if (consider_randfile) { /* explanation does not apply when a
-                                          * file is explicitly named */
-                    BIO_printf(bio_err,
-                               "Consider setting the RANDFILE environment variable to point at a file that\n");
-                    BIO_printf(bio_err,
-                               "'random' data can be kept in (the file will be overwritten).\n");
-                }
-            }
-            return 0;
-        }
+    if (RAND_load_file(randfile, -1) < 0) {
+        BIO_printf(bio_err, "Can't load %s into RNG\n", randfile);
+        ERR_print_errors(bio_err);
+        return;
     }
-    seeded = 1;
-    return 1;
+    if (save_rand_file == NULL)
+        save_rand_file = randfile;
 }
 
-long app_RAND_load_files(char *name)
+static int loadfiles(char *name)
 {
     char *p, *n;
-    int last;
-    long tot = 0;
-#ifndef OPENSSL_NO_EGD
-    int egd;
-#endif
+    int last, ret = 1;
 
-    for (;;) {
+    for ( ; ; ) {
         last = 0;
-        for (p = name; ((*p != '\0') && (*p != LIST_SEPARATOR_CHAR)); p++) ;
+        for (p = name; *p != '\0' && *p != LIST_SEPARATOR_CHAR; p++)
+            continue;
         if (*p == '\0')
             last = 1;
         *p = '\0';
+        if (RAND_load_file(name, -1) < 0) {
+            BIO_printf(bio_err, "Can't load %s into RNG\n", name);
+            ERR_print_errors(bio_err);
+            ret = 0;
+        }
         n = name;
-        name = p + 1;
-        if (*n == '\0')
-            break;
-
-#ifndef OPENSSL_NO_EGD
-        egd = RAND_egd(n);
-        if (egd > 0)
-            tot += egd;
-        else
-#endif
-            tot += RAND_load_file(n, -1);
         if (last)
             break;
+        name = p + 1;
+        if (*name == '\0')
+            break;
     }
-    if (tot > 512)
-        app_RAND_allow_write_file();
-    return (tot);
+    return ret;
 }
 
-int app_RAND_write_file(const char *file)
+void app_RAND_write(void)
 {
-    char buffer[200];
-
-    if (egdsocket || !seeded) {
-        /*
-         * If we didn't manage to read the seed file, don't write a
-         * file out -- it would suppress a crucial warning the next
-         * time we want to use it.
-         */
-        return 0;
+    if (save_rand_file == NULL)
+        return;
+    if (RAND_write_file(save_rand_file) == -1) {
+        BIO_printf(bio_err, "Cannot write random bytes:\n");
+        ERR_print_errors(bio_err);
     }
+}
 
-    if (file == NULL)
-        file = RAND_file_name(buffer, sizeof buffer);
-    if (file == NULL || !RAND_write_file(file)) {
-        BIO_printf(bio_err, "unable to write 'random state'\n");
-        return 0;
+
+/*
+ * See comments in opt_verify for explanation of this.
+ */
+enum r_range { OPT_R_ENUM };
+
+int opt_rand(int opt)
+{
+    switch ((enum r_range)opt) {
+    case OPT_R__FIRST:
+    case OPT_R__LAST:
+        break;
+    case OPT_R_RAND:
+        return loadfiles(opt_arg());
+        break;
+    case OPT_R_WRITERAND:
+        save_rand_file = opt_arg();
+        break;
     }
     return 1;
-}
-
-void app_RAND_allow_write_file(void)
-{
-    seeded = 1;
 }

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -40,16 +40,8 @@
  */
 #define _UC(c) ((unsigned char)(c))
 
-int app_RAND_load_file(const char *file, int dont_warn);
-int app_RAND_write_file(const char *file);
-/*
- * When `file' is NULL, use defaults. `bio_e' is for error messages.
- */
-void app_RAND_allow_write_file(void);
-long app_RAND_load_files(char *file); /* `file' is a list of files to read,
-                                       * separated by LIST_SEPARATOR_CHAR
-                                       * (see e_os.h).  The string is
-                                       * destroyed! */
+void app_RAND_load_conf(CONF *c, const char *section);
+void app_RAND_write(void);
 
 extern char *default_config_file;
 extern BIO *bio_in;
@@ -177,7 +169,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         case OPT_V_ALLOW_PROXY_CERTS
 
 /*
- * Common "extended"? options.
+ * Common "extended validation" options.
  */
 # define OPT_X_ENUM \
         OPT_X__FIRST=1000, \
@@ -300,6 +292,20 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
   || o == OPT_S_NOTLS1_2 || o == OPT_S_NOTLS1_3)
 
 /*
+ * Random state options.
+ */
+# define OPT_R_ENUM \
+        OPT_R__FIRST=1500, OPT_R_RAND, OPT_R_WRITERAND, OPT_R__LAST
+
+# define OPT_R_OPTIONS \
+    {"rand", OPT_R_RAND, 's', "Load the file(s) into the random number generator"}, \
+    {"writerand", OPT_R_WRITERAND, '>', "Write random data to the specified file"}
+
+# define OPT_R_CASES \
+        OPT_R__FIRST: case OPT_R__LAST: break; \
+        case OPT_R_RAND: case OPT_R_WRITERAND
+
+/*
  * Option parsing.
  */
 extern const char OPT_HELP_STR[];
@@ -373,6 +379,7 @@ char *opt_reset(void);
 char **opt_rest(void);
 int opt_num_rest(void);
 int opt_verify(int i, X509_VERIFY_PARAM *vpm);
+int opt_rand(int i);
 void opt_help(const OPTIONS * list);
 int opt_format_error(const char *s, unsigned long flags);
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -76,10 +76,11 @@ typedef enum OPTION_choice {
     OPT_RR_ALL, OPT_RR_FIRST, OPT_RCTFORM, OPT_CERTFILE, OPT_CAFILE,
     OPT_CAPATH, OPT_NOCAPATH, OPT_NOCAFILE,OPT_CONTENT, OPT_PRINT,
     OPT_SECRETKEY, OPT_SECRETKEYID, OPT_PWRI_PASSWORD, OPT_ECONTENT_TYPE,
-    OPT_RAND, OPT_PASSIN, OPT_TO, OPT_FROM, OPT_SUBJECT, OPT_SIGNER, OPT_RECIP,
+    OPT_PASSIN, OPT_TO, OPT_FROM, OPT_SUBJECT, OPT_SIGNER, OPT_RECIP,
     OPT_CERTSOUT, OPT_MD, OPT_INKEY, OPT_KEYFORM, OPT_KEYOPT, OPT_RR_FROM,
     OPT_RR_TO, OPT_AES128_WRAP, OPT_AES192_WRAP, OPT_AES256_WRAP,
     OPT_3DES_WRAP, OPT_ENGINE,
+    OPT_R_ENUM,
     OPT_V_ENUM,
     OPT_CIPHER
 } OPTION_CHOICE;
@@ -152,8 +153,6 @@ const OPTIONS cms_options[] = {
     {"secretkeyid", OPT_SECRETKEYID, 's'},
     {"pwri_password", OPT_PWRI_PASSWORD, 's'},
     {"econtent_type", OPT_ECONTENT_TYPE, 's'},
-    {"rand", OPT_RAND, 's',
-     "Load the file(s) into the random number generator"},
     {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
     {"to", OPT_TO, 's', "To address"},
     {"from", OPT_FROM, 's', "From address"},
@@ -169,6 +168,7 @@ const OPTIONS cms_options[] = {
     {"receipt_request_from", OPT_RR_FROM, 's'},
     {"receipt_request_to", OPT_RR_TO, 's'},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
+    OPT_R_OPTIONS,
     OPT_V_OPTIONS,
     {"aes128-wrap", OPT_AES128_WRAP, '-', "Use AES128 to wrap key"},
     {"aes192-wrap", OPT_AES192_WRAP, '-', "Use AES192 to wrap key"},
@@ -202,16 +202,13 @@ int cms_main(int argc, char **argv)
     const char *CAfile = NULL, *CApath = NULL;
     char *certsoutfile = NULL;
     int noCAfile = 0, noCApath = 0;
-    char *infile = NULL, *outfile = NULL, *rctfile = NULL, *inrand = NULL;
-    char *passinarg = NULL, *passin = NULL, *signerfile = NULL, *recipfile =
-        NULL;
+    char *infile = NULL, *outfile = NULL, *rctfile = NULL;
+    char *passinarg = NULL, *passin = NULL, *signerfile = NULL, *recipfile = NULL;
     char *to = NULL, *from = NULL, *subject = NULL, *prog;
     cms_key_param *key_first = NULL, *key_param = NULL;
-    int flags = CMS_DETACHED, noout = 0, print = 0, keyidx = -1, vpmtouched =
-        0;
+    int flags = CMS_DETACHED, noout = 0, print = 0, keyidx = -1, vpmtouched = 0;
     int informat = FORMAT_SMIME, outformat = FORMAT_SMIME;
-    int need_rand = 0, operation = 0, ret = 1, rr_print = 0, rr_allorfirst =
-        -1;
+    int operation = 0, ret = 1, rr_print = 0, rr_allorfirst = -1;
     int verify_retcode = 0, rctformat = FORMAT_SMIME, keyform = FORMAT_PEM;
     size_t secret_keylen = 0, secret_keyidlen = 0;
     unsigned char *pwri_pass = NULL, *pwri_tmp = NULL;
@@ -449,10 +446,6 @@ int cms_main(int argc, char **argv)
                 goto opthelp;
             }
             break;
-        case OPT_RAND:
-            inrand = opt_arg();
-            need_rand = 1;
-            break;
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
             break;
@@ -568,6 +561,10 @@ int cms_main(int argc, char **argv)
                 goto end;
             vpmtouched++;
             break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
+            break;
         case OPT_3DES_WRAP:
 # ifndef OPENSSL_NO_DES
             wrap_cipher = EVP_des_ede3_wrap();
@@ -624,7 +621,6 @@ int cms_main(int argc, char **argv)
         }
         signerfile = NULL;
         keyfile = NULL;
-        need_rand = 1;
     } else if (operation == SMIME_DECRYPT) {
         if (recipfile == NULL && keyfile == NULL
             && secret_key == NULL && pwri_pass == NULL) {
@@ -638,7 +634,6 @@ int cms_main(int argc, char **argv)
             BIO_printf(bio_err, "No recipient(s) certificate(s) specified\n");
             goto opthelp;
         }
-        need_rand = 1;
     } else if (!operation) {
         goto opthelp;
     }
@@ -646,13 +641,6 @@ int cms_main(int argc, char **argv)
     if (!app_passwd(passinarg, NULL, &passin, NULL)) {
         BIO_printf(bio_err, "Error getting password\n");
         goto end;
-    }
-
-    if (need_rand) {
-        app_RAND_load_file(NULL, (inrand != NULL));
-        if (inrand != NULL)
-            BIO_printf(bio_err, "%ld semi-random bytes loaded\n",
-                       app_RAND_load_files(inrand));
     }
 
     ret = 2;
@@ -1083,8 +1071,6 @@ int cms_main(int argc, char **argv)
  end:
     if (ret)
         ERR_print_errors(bio_err);
-    if (need_rand)
-        app_RAND_write_file(NULL);
     sk_X509_pop_free(encerts, X509_free);
     sk_X509_pop_free(other, X509_free);
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -43,7 +43,8 @@ typedef enum OPTION_choice {
     OPT_E, OPT_IN, OPT_OUT, OPT_PASS, OPT_ENGINE, OPT_D, OPT_P, OPT_V,
     OPT_NOPAD, OPT_SALT, OPT_NOSALT, OPT_DEBUG, OPT_UPPER_P, OPT_UPPER_A,
     OPT_A, OPT_Z, OPT_BUFSIZE, OPT_K, OPT_KFILE, OPT_UPPER_K, OPT_NONE,
-    OPT_UPPER_S, OPT_IV, OPT_MD, OPT_CIPHER
+    OPT_UPPER_S, OPT_IV, OPT_MD, OPT_CIPHER,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS enc_options[] = {
@@ -74,6 +75,7 @@ const OPTIONS enc_options[] = {
     {"md", OPT_MD, 's', "Use specified digest to create a key from the passphrase"},
     {"none", OPT_NONE, '-', "Don't encrypt"},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
+    OPT_R_OPTIONS,
 #ifdef ZLIB
     {"z", OPT_Z, '-', "Use zlib as the 'encryption'"},
 #endif
@@ -254,6 +256,10 @@ int enc_main(int argc, char **argv)
             break;
         case OPT_NONE:
             cipher = NULL;
+            break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         }
     }

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -26,7 +26,8 @@ NON_EMPTY_TRANSLATION_UNIT
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_RAND, OPT_CIPHER
+    OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_CIPHER,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS gendsa_options[] = {
@@ -35,8 +36,7 @@ const OPTIONS gendsa_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
     {"out", OPT_OUT, '>', "Output the key to the specified file"},
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
-    {"rand", OPT_RAND, 's',
-     "Load the file(s) into the random number generator"},
+    OPT_R_OPTIONS,
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
 # ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
@@ -50,7 +50,7 @@ int gendsa_main(int argc, char **argv)
     BIO *out = NULL, *in = NULL;
     DSA *dsa = NULL;
     const EVP_CIPHER *enc = NULL;
-    char *inrand = NULL, *dsaparams = NULL;
+    char *dsaparams = NULL;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL, *prog;
     OPTION_CHOICE o;
     int ret = 1, private = 0;
@@ -77,8 +77,9 @@ int gendsa_main(int argc, char **argv)
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
             break;
-        case OPT_RAND:
-            inrand = opt_arg();
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         case OPT_CIPHER:
             if (!opt_cipher(opt_unknown(), &enc))
@@ -114,20 +115,10 @@ int gendsa_main(int argc, char **argv)
     if (out == NULL)
         goto end2;
 
-    if (!app_RAND_load_file(NULL, 1) && inrand == NULL) {
-        BIO_printf(bio_err,
-                   "warning, not much extra random data, consider using the -rand option\n");
-    }
-    if (inrand != NULL)
-        BIO_printf(bio_err, "%ld semi-random bytes loaded\n",
-                   app_RAND_load_files(inrand));
-
     DSA_get0_pqg(dsa, &p, NULL, NULL);
     BIO_printf(bio_err, "Generating DSA key, %d bits\n", BN_num_bits(p));
     if (!DSA_generate_key(dsa))
         goto end;
-
-    app_RAND_write_file(NULL);
 
     assert(private);
     if (!PEM_write_bio_DSAPrivateKey(out, dsa, enc, NULL, 0, NULL, passout))

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -33,7 +33,8 @@ static int genrsa_cb(int p, int n, BN_GENCB *cb);
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_3, OPT_F4, OPT_ENGINE,
-    OPT_OUT, OPT_RAND, OPT_PASSOUT, OPT_CIPHER
+    OPT_OUT, OPT_PASSOUT, OPT_CIPHER,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS genrsa_options[] = {
@@ -42,8 +43,7 @@ const OPTIONS genrsa_options[] = {
     {"F4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
     {"f4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
     {"out", OPT_OUT, 's', "Output the key to specified file"},
-    {"rand", OPT_RAND, 's',
-     "Load the file(s) into the random number generator"},
+    OPT_R_OPTIONS,
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
 # ifndef OPENSSL_NO_ENGINE
@@ -65,7 +65,7 @@ int genrsa_main(int argc, char **argv)
     int ret = 1, num = DEFBITS, private = 0;
     unsigned long f4 = RSA_F4;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL;
-    char *inrand = NULL, *prog, *hexe, *dece;
+    char *prog, *hexe, *dece;
     OPTION_CHOICE o;
 
     if (bn == NULL || cb == NULL)
@@ -96,8 +96,9 @@ int genrsa_main(int argc, char **argv)
         case OPT_ENGINE:
             eng = setup_engine(opt_arg(), 0);
             break;
-        case OPT_RAND:
-            inrand = opt_arg();
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         case OPT_PASSOUT:
             passoutarg = opt_arg();
@@ -124,15 +125,6 @@ int genrsa_main(int argc, char **argv)
     if (out == NULL)
         goto end;
 
-    if (!app_RAND_load_file(NULL, 1) && inrand == NULL
-        && !RAND_status()) {
-        BIO_printf(bio_err,
-                   "warning, not much extra random data, consider using the -rand option\n");
-    }
-    if (inrand != NULL)
-        BIO_printf(bio_err, "%ld semi-random bytes loaded\n",
-                   app_RAND_load_files(inrand));
-
     BIO_printf(bio_err, "Generating RSA private key, %d bit long modulus\n",
                num);
     rsa = eng ? RSA_new_method(eng) : RSA_new();
@@ -141,8 +133,6 @@ int genrsa_main(int argc, char **argv)
 
     if (!BN_set_word(bn, f4) || !RSA_generate_key_ex(rsa, num, bn, cb))
         goto end;
-
-    app_RAND_write_file(NULL);
 
     RSA_get0_key(rsa, NULL, &e, NULL);
     hexe = BN_bn2hex(e);

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -240,6 +240,7 @@ int main(int argc, char *argv[])
     OPENSSL_free(default_config_file);
     lh_FUNCTION_free(prog);
     OPENSSL_free(arg.argv);
+    app_RAND_write();
 
     BIO_free(bio_in);
     BIO_free_all(bio_out);

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -65,7 +65,8 @@ typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_IN,
     OPT_NOVERIFY, OPT_QUIET, OPT_TABLE, OPT_REVERSE, OPT_APR1,
-    OPT_1, OPT_5, OPT_6, OPT_CRYPT, OPT_AIXMD5, OPT_SALT, OPT_STDIN
+    OPT_1, OPT_5, OPT_6, OPT_CRYPT, OPT_AIXMD5, OPT_SALT, OPT_STDIN,
+    OPT_R_ENUM,
 } OPTION_CHOICE;
 
 const OPTIONS passwd_options[] = {
@@ -90,6 +91,7 @@ const OPTIONS passwd_options[] = {
 # ifndef OPENSSL_NO_DES
     {"crypt", OPT_CRYPT, '-', "Standard Unix password algorithm (default)"},
 # endif
+    OPT_R_OPTIONS,
     {NULL}
 };
 
@@ -181,6 +183,10 @@ int passwd_main(int argc, char **argv)
                 goto opthelp;
             in_stdin = 1;
             pw_source_defined = 1;
+            break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         }
     }

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -24,7 +24,8 @@ typedef enum OPTION_choice {
     OPT_SCRYPT, OPT_SCRYPT_N, OPT_SCRYPT_R, OPT_SCRYPT_P,
 #endif
     OPT_V2, OPT_V1, OPT_V2PRF, OPT_ITER, OPT_PASSIN, OPT_PASSOUT,
-    OPT_TRADITIONAL
+    OPT_TRADITIONAL,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkcs8_options[] = {
@@ -36,6 +37,7 @@ const OPTIONS pkcs8_options[] = {
     {"topk8", OPT_TOPK8, '-', "Output PKCS8 file"},
     {"noiter", OPT_NOITER, '-', "Use 1 as iteration count"},
     {"nocrypt", OPT_NOCRYPT, '-', "Use or expect unencrypted private key"},
+    OPT_R_OPTIONS,
     {"v2", OPT_V2, 's', "Use PKCS#5 v2.0 and cipher"},
     {"v1", OPT_V1, 's', "Use PKCS#5 v1.5 and cipher"},
     {"v2prf", OPT_V2PRF, 's', "Set the PRF algorithm to use with PKCS#5 v2.0"},
@@ -111,6 +113,10 @@ int pkcs8_main(int argc, char **argv)
             break;
         case OPT_NOCRYPT:
             nocrypt = 1;
+            break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         case OPT_TRADITIONAL:
             traditional = 1;
@@ -248,7 +254,6 @@ int pkcs8_main(int argc, char **argv)
                 BIO_printf(bio_err, "Password required\n");
                 goto end;
             }
-            app_RAND_load_file(NULL, 0);
             p8 = PKCS8_set0_pbe(p8pass, strlen(p8pass), p8inf, pbe);
             if (p8 == NULL) {
                 X509_ALGOR_free(pbe);
@@ -256,7 +261,6 @@ int pkcs8_main(int argc, char **argv)
                 ERR_print_errors(bio_err);
                 goto end;
             }
-            app_RAND_write_file(NULL);
             assert(private);
             if (outformat == FORMAT_PEM)
                 PEM_write_bio_PKCS8(out, p8);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -36,7 +36,8 @@ typedef enum OPTION_choice {
     OPT_PUBIN, OPT_CERTIN, OPT_ASN1PARSE, OPT_HEXDUMP, OPT_SIGN,
     OPT_VERIFY, OPT_VERIFYRECOVER, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
     OPT_DERIVE, OPT_SIGFILE, OPT_INKEY, OPT_PEERKEY, OPT_PASSIN,
-    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_KDF, OPT_KDFLEN
+    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_KDF, OPT_KDFLEN,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkeyutl_options[] = {
@@ -64,6 +65,7 @@ const OPTIONS pkeyutl_options[] = {
     {"peerform", OPT_PEERFORM, 'E', "Peer key format - default PEM"},
     {"keyform", OPT_KEYFORM, 'E', "Private key format - default PEM"},
     {"pkeyopt", OPT_PKEYOPT, 's', "Public key options as opt:value"},
+    OPT_R_OPTIONS,
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
     {"engine_impl", OPT_ENGINE_IMPL, '-',
@@ -133,6 +135,10 @@ int pkeyutl_main(int argc, char **argv)
         case OPT_KEYFORM:
             if (!opt_format(opt_arg(), OPT_FMT_PDE, &keyform))
                 goto opthelp;
+            break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
@@ -237,9 +243,6 @@ int pkeyutl_main(int argc, char **argv)
                    "%s: No signature file specified for verify\n", prog);
         goto end;
     }
-
-/* FIXME: seed PRNG only if needed */
-    app_RAND_load_file(NULL, 0);
 
     if (pkey_op != EVP_PKEY_OP_DERIVE) {
         in = bio_open_default(infile, 'r', FORMAT_BINARY);

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -32,7 +32,8 @@ typedef enum OPTION_choice {
     OPT_ENGINE, OPT_IN, OPT_OUT, OPT_ASN1PARSE, OPT_HEXDUMP,
     OPT_RAW, OPT_OAEP, OPT_SSL, OPT_PKCS, OPT_X931,
     OPT_SIGN, OPT_VERIFY, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
-    OPT_PUBIN, OPT_CERTIN, OPT_INKEY, OPT_PASSIN, OPT_KEYFORM
+    OPT_PUBIN, OPT_CERTIN, OPT_INKEY, OPT_PASSIN, OPT_KEYFORM,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS rsautl_options[] = {
@@ -57,6 +58,7 @@ const OPTIONS rsautl_options[] = {
     {"encrypt", OPT_ENCRYPT, '-', "Encrypt with public key"},
     {"decrypt", OPT_DECRYPT, '-', "Decrypt with private key"},
     {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
+    OPT_R_OPTIONS,
 # ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
 # endif
@@ -153,6 +155,10 @@ int rsautl_main(int argc, char **argv)
         case OPT_PASSIN:
             passinarg = opt_arg();
             break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
+            break;
         }
     }
     argc = opt_num_rest();
@@ -168,9 +174,6 @@ int rsautl_main(int argc, char **argv)
         BIO_printf(bio_err, "Error getting password\n");
         goto end;
     }
-
-/* FIXME: seed PRNG only if needed */
-    app_RAND_load_file(NULL, 0);
 
     switch (key_type) {
     case KEY_PRIVKEY:

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -342,7 +342,7 @@ static int found(const char *name, const OPT_PAIR *pairs, int *result)
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_ELAPSED, OPT_EVP, OPT_DECRYPT, OPT_ENGINE, OPT_MULTI,
-    OPT_MR, OPT_MB, OPT_MISALIGN, OPT_ASYNCJOBS
+    OPT_MR, OPT_MB, OPT_MISALIGN, OPT_ASYNCJOBS, OPT_R_ENUM,
 } OPTION_CHOICE;
 
 const OPTIONS speed_options[] = {
@@ -365,6 +365,7 @@ const OPTIONS speed_options[] = {
     {"async_jobs", OPT_ASYNCJOBS, 'p',
      "Enable async mode and start pnum jobs"},
 #endif
+    OPT_R_OPTIONS,
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
 #endif
@@ -1409,6 +1410,10 @@ int speed_main(int argc, char **argv)
                        prog);
             goto end;
 #endif
+            break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
             break;
         }
     }

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -175,8 +175,11 @@ int RAND_write_file(const char *file)
 
     if (out == NULL)
         out = openssl_fopen(file, "wb");
-    if (out == NULL)
+    if (out == NULL) {
+        RANDerr(RAND_F_RAND_LOAD_FILE, RAND_R_CANNOT_OPEN_FILE);
+        ERR_add_error_data(2, "Filename=", file);
         return -1;
+    }
 
 #if !defined(NO_CHMOD) && !defined(OPENSSL_NO_POSIX_IO)
     /*

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -52,6 +52,8 @@ B<openssl> B<ca>
 [B<-utf8>]
 [B<-create_serial>]
 [B<-multivalue-rdn>]
+[B<-rand file...>]
+[B<-writerand file>]
 
 =head1 DESCRIPTION
 
@@ -266,6 +268,19 @@ I</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 If -multi-rdn is not used then the UID value is I<123456+CN=John Doe>.
 
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
+
 =back
 
 =head1 CRL OPTIONS
@@ -397,8 +412,8 @@ CA private key. Mandatory.
 
 =item B<RANDFILE>
 
-A file used to read and write random number seed information, or
-an EGD socket (see L<RAND_egd(3)>).
+At startup the specified file is loaded into the random number generator,
+and at exit 256 bytes will be written to it.
 
 =item B<default_days>
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -92,7 +92,8 @@ B<openssl> B<cms>
 [B<-inkey file>]
 [B<-keyopt name:parameter>]
 [B<-passin arg>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<cert.pem...>]
 [B<-to addr>]
 [B<-from addr>]
@@ -461,13 +462,18 @@ or to modify default parameters for ECDH.
 The private key password source. For more information about the format of B<arg>
 see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<cert.pem...>
 

--- a/doc/man1/dgst.pod
+++ b/doc/man1/dgst.pod
@@ -23,6 +23,7 @@ B<openssl> B<dgst>
 [B<-signature filename>]
 [B<-hmac key>]
 [B<-fips-fingerprint>]
+[B<-rand file...>]
 [B<-engine id>]
 [B<-engine_impl>]
 [B<file...>]
@@ -149,13 +150,18 @@ for example exactly 32 chars for gost-mac.
 
 =back
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-fips-fingerprint>
 

--- a/doc/man1/dhparam.pod
+++ b/doc/man1/dhparam.pod
@@ -19,7 +19,8 @@ B<openssl dhparam>
 [B<-C>]
 [B<-2>]
 [B<-5>]
-[B<-rand> I<file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-engine id>]
 [I<numbits>]
 
@@ -82,13 +83,18 @@ input file is ignored and parameters are generated instead. If not
 present but B<numbits> is present, parameters are generated with the
 default generator 2.
 
-=item B<-rand> I<file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item I<numbits>
 

--- a/doc/man1/dsaparam.pod
+++ b/doc/man1/dsaparam.pod
@@ -15,7 +15,8 @@ B<openssl dsaparam>
 [B<-noout>]
 [B<-text>]
 [B<-C>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-genkey>]
 [B<-engine id>]
 [B<numbits>]
@@ -74,13 +75,18 @@ be loaded by calling the get_dsaXXX() function.
 This option will generate a DSA either using the specified or generated
 parameters.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<numbits>
 

--- a/doc/man1/ecparam.pod
+++ b/doc/man1/ecparam.pod
@@ -21,7 +21,8 @@ B<openssl ecparam>
 [B<-conv_form arg>]
 [B<-param_enc arg>]
 [B<-no_seed>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-genkey>]
 [B<-engine id>]
 
@@ -116,13 +117,18 @@ is included in the ECParameters structure (see RFC 3279).
 
 This option will generate an EC private key using the specified parameters.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-engine id>
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -31,6 +31,8 @@ B<openssl enc -ciphername>
 [B<-nopad>]
 [B<-debug>]
 [B<-none>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-engine id>]
 
 =head1 DESCRIPTION
@@ -164,6 +166,19 @@ or zlib-dynamic option.
 =item B<-none>
 
 Use NULL cipher (no encryption or decryption of input).
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =back
 

--- a/doc/man1/gendsa.pod
+++ b/doc/man1/gendsa.pod
@@ -21,7 +21,8 @@ B<openssl> B<gendsa>
 [B<-des>]
 [B<-des3>]
 [B<-idea>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-engine id>]
 [B<paramfile>]
 
@@ -49,13 +50,18 @@ These options encrypt the private key with specified
 cipher before outputting it. A pass phrase is prompted for.
 If none of these options is specified no encryption is used.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-engine id>
 

--- a/doc/man1/genrsa.pod
+++ b/doc/man1/genrsa.pod
@@ -24,7 +24,8 @@ B<openssl> B<genrsa>
 [B<-idea>]
 [B<-f4>]
 [B<-3>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-engine id>]
 [B<numbits>]
 
@@ -61,13 +62,18 @@ for if it is not supplied via the B<-passout> argument.
 
 The public exponent to use, either 65537 or 3. The default is 65537.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-engine id>
 

--- a/doc/man1/passwd.pod
+++ b/doc/man1/passwd.pod
@@ -20,6 +20,8 @@ B<openssl passwd>
 [B<-noverify>]
 [B<-quiet>]
 [B<-table>]
+[B<-rand file...>]
+[B<-writerand file>]
 {I<password>}
 
 =head1 DESCRIPTION
@@ -87,6 +89,19 @@ Don't output warnings when passwords given at the command line are truncated.
 
 In the output list, prepend the cleartext password and a TAB character
 to each password hash.
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =back
 

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -36,7 +36,8 @@ B<openssl> B<pkcs12>
 [B<-password arg>]
 [B<-passin arg>]
 [B<-passout arg>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-CAfile file>]
 [B<-CApath dir>]
 [B<-no-CAfile>]
@@ -275,13 +276,18 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 Don't attempt to provide the MAC integrity.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-CAfile file>
 

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -17,6 +17,8 @@ B<openssl> B<pkcs8>
 [B<-passout arg>]
 [B<-iter count>]
 [B<-noiter>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-nocrypt>]
 [B<-traditional>]
 [B<-v2 alg>]
@@ -98,6 +100,19 @@ this option an unencrypted PrivateKeyInfo structure is expected or output.
 This option does not encrypt private keys at all and should only be used
 when absolutely necessary. Certain software such as some versions of Java
 code signing software used unencrypted private keys.
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-v2 alg>
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -30,6 +30,8 @@ B<openssl> B<pkeyutl>
 [B<-pkeyopt opt:value>]
 [B<-hexdump>]
 [B<-asn1parse>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-engine id>]
 [B<-engine_impl>]
 
@@ -145,6 +147,19 @@ hex dump the output data.
 
 Parse the ASN.1 output data, this is useful when combined with the
 B<-verifyrecover> option when an ASN1 structure is signed.
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-engine id>
 

--- a/doc/man1/rand.pod
+++ b/doc/man1/rand.pod
@@ -9,7 +9,8 @@ rand - generate pseudo-random bytes
 B<openssl rand>
 [B<-help>]
 [B<-out> I<file>]
-[B<-rand> I<file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-base64>]
 [B<-hex>]
 I<num>
@@ -31,17 +32,22 @@ seeding was obtained from these sources.
 
 Print out a usage message.
 
-=item B<-out> I<file>
+=item B<-out file>
 
 Write to I<file> instead of standard output.
 
-=item B<-rand> I<file(s)>
+=item B<-rand file...>
 
-Use specified file or files or EGD socket (see L<RAND_egd(3)>)
-for seeding the random number generator.
+A file or files containing random data used to seed the random number
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-base64>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -20,7 +20,8 @@ B<openssl> B<req>
 [B<-verify>]
 [B<-modulus>]
 [B<-new>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-newkey rsa:bits>]
 [B<-newkey alg:file>]
 [B<-nodes>]
@@ -130,13 +131,18 @@ in the configuration file and any requested extensions.
 If the B<-key> option is not used it will generate a new RSA private
 key using information specified in the configuration file.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-newkey arg>
 
@@ -365,8 +371,8 @@ and long names are the same when this option is used.
 
 =item B<RANDFILE>
 
-This specifies a filename in which random number seed information is
-placed and read from, or an EGD socket (see L<RAND_egd(3)>).
+At startup the specified file is loaded into the random number generator,
+and at exit 256 bytes will be written to it.
 It is used for private key generation.
 
 =item B<encrypt_key>

--- a/doc/man1/rsautl.pod
+++ b/doc/man1/rsautl.pod
@@ -18,6 +18,8 @@ B<openssl> B<rsautl>
 [B<-verify>]
 [B<-encrypt>]
 [B<-decrypt>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-pkcs>]
 [B<-ssl>]
 [B<-raw>]
@@ -79,6 +81,19 @@ Encrypt the input data using an RSA public key.
 =item B<-decrypt>
 
 Decrypt the input data using an RSA private key.
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-pkcs, -oaep, -ssl, -raw>
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -105,7 +105,8 @@ B<openssl> B<s_client>
 [B<-no_ticket>]
 [B<-sess_out filename>]
 [B<-sess_in filename>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-serverinfo types>]
 [B<-status>]
 [B<-alpn protocols>]
@@ -536,13 +537,18 @@ to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-serverinfo types>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -52,7 +52,8 @@ B<openssl> B<s_server>
 [B<-tlsextdebug>]
 [B<-HTTP>]
 [B<-id_prefix val>]
-[B<-rand val>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-keymatexport val>]
 [B<-keymatexportlen +int>]
 [B<-CRL infile>]
@@ -381,13 +382,18 @@ for testing any SSL/TLS code (eg. proxies) that wish to deal with multiple
 servers, when each of which might be generating a unique range of session
 IDs (eg. with a certain prefix).
 
-=item B<-rand val>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-verify_return_error>
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -65,7 +65,8 @@ B<openssl> B<smime>
 [B<-indef>]
 [B<-noindef>]
 [B<-stream>]
-[B<-rand file(s)>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-md digest>]
 [cert.pem]...
 
@@ -295,13 +296,18 @@ specified, the argument is given to the engine as a key identifier.
 The private key password source. For more information about the format of B<arg>
 see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
 
-=item B<-rand file(s)>
+=item B<-rand file...>
 
 A file or files containing random data used to seed the random number
-generator, or an EGD socket (see L<RAND_egd(3)>).
+generator.
 Multiple files can be specified separated by an OS-dependent character.
 The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
 all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<cert.pem...>
 

--- a/doc/man1/speed.pod
+++ b/doc/man1/speed.pod
@@ -12,6 +12,8 @@ B<openssl speed>
 [B<-elapsed>]
 [B<-evp algo>]
 [B<-decrypt>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<algorithm...>]
 
 =head1 DESCRIPTION
@@ -47,6 +49,19 @@ Use the specified cipher or message digest algorithm via the EVP interface.
 =item B<-decrypt>
 
 Time the decryption instead of encryption. Affects only the EVP testing.
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<[zero or more test algorithms]>
 

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -8,7 +8,8 @@ ts - Time Stamping Authority tool (client/server)
 
 B<openssl> B<ts>
 B<-query>
-[B<-rand> file:file...]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-config> configfile]
 [B<-data> file_to_hash]
 [B<-digest> digest_bytes]
@@ -131,11 +132,18 @@ request with the following options:
 
 =over 4
 
-=item B<-rand> file:file...
+=item B<-rand file...>
 
-The files containing random data for seeding the random number
-generator. Multiple files can be specified, the separator is B<;> for
-MS-Windows, B<,> for VMS and B<:> for all other platforms. (Optional)
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-config> configfile
 

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -59,6 +59,8 @@ B<openssl> B<x509>
 [B<-clrext>]
 [B<-extfile filename>]
 [B<-extensions section>]
+[B<-rand file...>]
+[B<-writerand file>]
 [B<-engine id>]
 [B<-preserve_dates>]
 
@@ -114,6 +116,19 @@ digest, such as the B<-fingerprint>, B<-signkey> and B<-CA> options.
 Any digest supported by the OpenSSL B<dgst> command can be used.
 If not specified then SHA1 is used with B<-fingerprint> or
 the default digest for the signing algorithm is used, typically SHA256.
+
+=item B<-rand file...>
+
+A file or files containing random data used to seed the random number
+generator.
+Multiple files can be specified separated by an OS-dependent character.
+The separator is B<;> for MS-Windows, B<,> for OpenVMS, and B<:> for
+all others.
+
+=item [B<-writerand file>]
+
+Writes random data to the specified I<file> upon exit.
+This can be used with a subsequent B<-rand> flag.
 
 =item B<-engine id>
 


### PR DESCRIPTION
This PR standardizes the apps behavior with respect to RNG state files.
Some commands got the -rand flag documented; some sources got code added if it was documented.
Every command that has -rand ow has -writerand.

Internal comments about RAND_load_file and RAND_write_file are now documented, and those limits are enforced in the code.  This made it possible to clean up those functions.

Will be squashed when merged.