### PR TITLE
WIP: Add SHA3 support to EVP

### DIFF
--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -12,7 +12,7 @@ SOURCE[../../libcrypto]=\
         evp_pkey.c evp_pbe.c p5_crpt.c p5_crpt2.c scrypt.c \
         e_old.c pmeth_lib.c pmeth_fn.c pmeth_gn.c m_sigver.c \
         e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha256.c e_rc4_hmac_md5.c \
-        e_chacha20_poly1305.c cmeth_lib.c
+        e_chacha20_poly1305.c cmeth_lib.c m_sha3.c
 
 INCLUDE[e_aes.o]=.. ../modes
 INCLUDE[e_aes_cbc_hmac_sha1.o]=../modes

--- a/crypto/evp/c_alld.c
+++ b/crypto/evp/c_alld.c
@@ -46,4 +46,5 @@ void openssl_add_all_digests_int(void)
     EVP_add_digest(EVP_blake2b512());
     EVP_add_digest(EVP_blake2s256());
 #endif
+    EVP_add_digest(EVP_sha3_256());
 }

--- a/crypto/evp/m_sha3.c
+++ b/crypto/evp/m_sha3.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include "internal/cryptlib.h"
+
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+#include "internal/evp_int.h"
+
+size_t SHA3_absorb(uint64_t A[5][5], const unsigned char *inp, size_t len,
+                   size_t r);
+void SHA3_squeeze(uint64_t A[5][5], unsigned char *out, size_t len, size_t r);
+
+struct keccak1600_ctx_st
+{
+    uint64_t A[5][5];
+};
+
+typedef struct keccak1600_ctx_st KECCAK1600_CTX;
+
+#define SHA3_256_D (256/8)
+#define SHA3_256_R ((1600-512)/8)
+
+static int init(EVP_MD_CTX *evp_ctx)
+{
+    KECCAK1600_CTX *ctx = EVP_MD_CTX_md_data(evp_ctx);
+
+    memset(ctx->A, 0, sizeof(ctx->A));
+    return 1;
+}
+
+static int update_256(EVP_MD_CTX *evp_ctx, const void *data, size_t count)
+{
+    KECCAK1600_CTX *ctx = EVP_MD_CTX_md_data(evp_ctx);
+
+    /* TODO: subblock buffering, padding */
+    SHA3_absorb(ctx->A, data, count, SHA3_256_R);
+    return 1;
+}
+
+static int final_256(EVP_MD_CTX *evp_ctx, unsigned char *md)
+{
+    KECCAK1600_CTX *ctx = EVP_MD_CTX_md_data(evp_ctx);
+
+    SHA3_squeeze(ctx->A, md, SHA3_256_D, SHA3_256_R);
+    return 1;
+}
+
+static const EVP_MD sha3_256_md = {
+    NID_sha3_256,
+    0,
+    SHA3_256_D,
+    0,
+    init,
+    update_256,
+    final_256,
+    NULL,
+    NULL,
+    0,
+    sizeof(EVP_MD *) + sizeof(KECCAK1600_CTX),
+};
+
+const EVP_MD *EVP_sha3_256(void)
+{
+    return (&sha3_256_md);
+}
+

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -695,6 +695,7 @@ const EVP_MD *EVP_sha224(void);
 const EVP_MD *EVP_sha256(void);
 const EVP_MD *EVP_sha384(void);
 const EVP_MD *EVP_sha512(void);
+const EVP_MD *EVP_sha3_256(void);
 # ifndef OPENSSL_NO_MDC2
 const EVP_MD *EVP_mdc2(void);
 # endif


### PR DESCRIPTION
This currently doesn't even link, SHA3_squeeze and SHA3_absorb don't seem to exist, while I expected it to link. @dot-asm: Are those functions supposed to be available?

It clearly also won't work properly,  since it's not using the SHA3_absorb() function properly yet.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
