### PR TITLE
Bounds check string functions in apps.

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -312,7 +312,7 @@ int enc_main(int argc, char **argv)
             for (;;) {
                 char prompt[200];
 
-                sprintf(prompt, "enter %s %s password:",
+                BIO_snprintf(prompt, sizeof(prompt), "enter %s %s password:",
                         OBJ_nid2ln(EVP_CIPHER_nid(cipher)),
                         (enc) ? "encryption" : "decryption");
                 strbuf[0] = '\0';
@@ -565,7 +565,7 @@ int enc_main(int argc, char **argv)
 #endif
     release_engine(e);
     OPENSSL_free(pass);
-    return (ret);
+    return ret;
 }
 
 static void show_ciphers(const OBJ_NAME *name, void *arg)
@@ -599,7 +599,7 @@ static int set_hex(char *in, unsigned char *out, int size)
     n = strlen(in);
     if (n > (size * 2)) {
         BIO_printf(bio_err, "hex string is too long\n");
-        return (0);
+        return 0;
     }
     memset(out, 0, size);
     for (i = 0; i < n; i++) {
@@ -609,7 +609,7 @@ static int set_hex(char *in, unsigned char *out, int size)
             break;
         if (!isxdigit(j)) {
             BIO_printf(bio_err, "non-hex digit\n");
-            return (0);
+            return 0;
         }
         j = (unsigned char)OPENSSL_hexchar2int(j);
         if (i & 1)
@@ -617,5 +617,5 @@ static int set_hex(char *in, unsigned char *out, int size)
         else
             out[i / 2] = (j << 4);
     }
-    return (1);
+    return 1;
 }

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -27,6 +27,8 @@ NON_EMPTY_TRANSLATION_UNIT
 # define CLCERTS         0x8
 # define CACERTS         0x10
 
+#define PASSWD_BUF_SIZE 2048
+
 static int get_cert_chain(X509 *cert, X509_STORE *store,
                           STACK_OF(X509) **chain);
 int dump_certs_keys_p12(BIO *out, const PKCS12 *p12,
@@ -119,7 +121,7 @@ int pkcs12_main(int argc, char **argv)
 {
     char *infile = NULL, *outfile = NULL, *keyname = NULL, *certfile = NULL;
     char *name = NULL, *csp_name = NULL;
-    char pass[2048] = "", macpass[2048] = "";
+    char pass[PASSWD_BUF_SIZE] = "", macpass[PASSWD_BUF_SIZE] = "";
     int export_cert = 0, options = 0, chain = 0, twopass = 0, keytype = 0;
     int iter = PKCS12_DEFAULT_ITER, maciter = PKCS12_DEFAULT_ITER;
 # ifndef OPENSSL_NO_RC2
@@ -455,7 +457,7 @@ int pkcs12_main(int argc, char **argv)
         }
 
         if (!twopass)
-            strcpy(macpass, pass);
+            OPENSSL_strlcpy(macpass, pass, sizeof(macpass));
 
         p12 = PKCS12_create(cpass, name, key, ucert, certs,
                             key_pbe, cert_pbe, iter, -1, keytype);
@@ -583,7 +585,7 @@ int pkcs12_main(int argc, char **argv)
     OPENSSL_free(badpass);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
-    return (ret);
+    return ret;
 }
 
 int dump_certs_keys_p12(BIO *out, const PKCS12 *p12, const char *pass,


### PR DESCRIPTION
This covers strcat, strcpy and sprintf.

In the x509 app, the code has been cleaned up as well.
Style also: `return x` instead of `return (x)`

Two changes (enc.c `sprintf` and pkcs12.c `strcpy`) are replacing trivial commits that were recently removed.
