### PR TITLE
Trivial bounds checking.

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -317,13 +317,12 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
             }
             if (psection == NULL)
                 psection = section;
-            v->name = OPENSSL_malloc(strlen(pname) + 1);
+            v->name = OPENSSL_strdup(pname);
             v->value = NULL;
             if (v->name == NULL) {
                 CONFerr(CONF_F_DEF_LOAD_BIO, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
-            strcpy(v->name, pname);
             if (!str_copy(conf, psection, &(v->value), start))
                 goto err;
 
@@ -347,13 +346,13 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
     }
     BUF_MEM_free(buff);
     OPENSSL_free(section);
-    return (1);
+    return 1;
  err:
     BUF_MEM_free(buff);
     OPENSSL_free(section);
     if (line != NULL)
         *line = eline;
-    sprintf(btmp, "%ld", eline);
+    BIO_snprintf(btmp, sizeof(btmp), "%ld", eline);
     ERR_add_error_data(2, "line ", btmp);
     if (h != conf->data) {
         CONF_free(conf->data);
@@ -364,7 +363,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
         OPENSSL_free(v->value);
         OPENSSL_free(v);
     }
-    return (0);
+    return 0;
 }
 
 static void clear_comments(CONF *conf, char *p)
@@ -411,7 +410,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
     BUF_MEM *buf;
 
     if ((buf = BUF_MEM_new()) == NULL)
-        return (0);
+        return 0;
 
     len = strlen(from) + 1;
     if (!BUF_MEM_grow(buf, len))
@@ -551,17 +550,17 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
     OPENSSL_free(*pto);
     *pto = buf->data;
     OPENSSL_free(buf);
-    return (1);
+    return 1;
  err:
     BUF_MEM_free(buf);
-    return (0);
+    return 0;
 }
 
 static char *eat_ws(CONF *conf, char *p)
 {
     while (IS_WS(conf, *p) && (!IS_EOF(conf, *p)))
         p++;
-    return (p);
+    return p;
 }
 
 static char *eat_alpha_numeric(CONF *conf, char *p)
@@ -572,7 +571,7 @@ static char *eat_alpha_numeric(CONF *conf, char *p)
             continue;
         }
         if (!IS_ALPHA_NUMERIC_PUNCT(conf, *p))
-            return (p);
+            return p;
         p++;
     }
 }
@@ -586,13 +585,13 @@ static char *scan_quote(CONF *conf, char *p)
         if (IS_ESC(conf, *p)) {
             p++;
             if (IS_EOF(conf, *p))
-                return (p);
+                return p;
         }
         p++;
     }
     if (*p == q)
         p++;
-    return (p);
+    return p;
 }
 
 static char *scan_dquote(CONF *conf, char *p)
@@ -612,7 +611,7 @@ static char *scan_dquote(CONF *conf, char *p)
     }
     if (*p == q)
         p++;
-    return (p);
+    return p;
 }
 
 static void dump_value_doall_arg(const CONF_VALUE *a, BIO *out)

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2002-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -170,8 +170,9 @@ static int module_run(const CONF *cnf, const char *name, const char *value,
     if (ret <= 0) {
         if (!(flags & CONF_MFLAGS_SILENT)) {
             char rcode[DECIMAL_SIZE(ret) + 1];
+
             CONFerr(CONF_F_MODULE_RUN, CONF_R_MODULE_INITIALIZATION_ERROR);
-            sprintf(rcode, "%-8d", ret);
+            BIO_snprintf(rcode, sizeof(rcode), "%-8d", ret);
             ERR_add_error_data(6, "module=", name, ", value=", value,
                                ", retcode=", rcode);
         }
@@ -475,7 +476,7 @@ void CONF_module_set_usr_data(CONF_MODULE *pmod, void *usr_data)
 
 char *CONF_get1_default_config_file(void)
 {
-    char *file;
+    char *file, *sep = "";
     int len;
 
     file = getenv("OPENSSL_CONF");
@@ -485,6 +486,7 @@ char *CONF_get1_default_config_file(void)
     len = strlen(X509_get_default_cert_area());
 #ifndef OPENSSL_SYS_VMS
     len++;
+    sep = "/";
 #endif
     len += strlen(OPENSSL_CONF);
 
@@ -492,11 +494,8 @@ char *CONF_get1_default_config_file(void)
 
     if (file == NULL)
         return NULL;
-    strcpy(file, X509_get_default_cert_area());
-#ifndef OPENSSL_SYS_VMS
-    strcat(file, "/");
-#endif
-    strcat(file, OPENSSL_CONF);
+    BIO_snprintf(file, len + 1, "%s%s%s", X509_get_default_cert_area(),
+                 sep, OPENSSL_CONF);
 
     return file;
 }

--- a/crypto/des/ecb_enc.c
+++ b/crypto/des/ecb_enc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,19 +15,16 @@
 const char *DES_options(void)
 {
     static int init = 1;
-    static char buf[32];
+    static char buf[12];
 
     if (init) {
-        const char *size;
-
         if (sizeof(DES_LONG) != sizeof(long))
-            size = "int";
+            OPENSSL_strlcpy(buf, "des(int)", sizeof(buf));
         else
-            size = "long";
-        sprintf(buf, "des(%s)", size);
+            OPENSSL_strlcpy(buf, "des(long)", sizeof(buf));
         init = 0;
     }
-    return (buf);
+    return buf;
 }
 
 void DES_ecb_encrypt(const_DES_cblock *input, DES_cblock *output,

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -90,9 +90,9 @@ int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
         char obj_tmp[80];
         EVPerr(EVP_F_EVP_PBE_CIPHERINIT, EVP_R_UNKNOWN_PBE_ALGORITHM);
         if (!pbe_obj)
-            strcpy(obj_tmp, "NULL");
+            OPENSSL_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
         else
-            i2t_ASN1_OBJECT(obj_tmp, sizeof obj_tmp, pbe_obj);
+            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), pbe_obj);
         ERR_add_error_data(2, "TYPE=", obj_tmp);
         return 0;
     }

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -40,14 +40,14 @@ static LHASH_OF(ADDED_OBJ) *added = NULL;
 
 static int sn_cmp(const ASN1_OBJECT *const *a, const unsigned int *b)
 {
-    return (strcmp((*a)->sn, nid_objs[*b].sn));
+    return strcmp((*a)->sn, nid_objs[*b].sn);
 }
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, sn);
 
 static int ln_cmp(const ASN1_OBJECT *const *a, const unsigned int *b)
 {
-    return (strcmp((*a)->ln, nid_objs[*b].ln));
+    return strcmp((*a)->ln, nid_objs[*b].ln);
 }
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, ln);
@@ -82,7 +82,7 @@ static unsigned long added_obj_hash(const ADDED_OBJ *ca)
     }
     ret &= 0x3fffffffL;
     ret |= ((unsigned long)ca->type) << 30L;
-    return (ret);
+    return ret;
 }
 
 static int added_obj_cmp(const ADDED_OBJ *ca, const ADDED_OBJ *cb)
@@ -92,31 +92,31 @@ static int added_obj_cmp(const ADDED_OBJ *ca, const ADDED_OBJ *cb)
 
     i = ca->type - cb->type;
     if (i)
-        return (i);
+        return i;
     a = ca->obj;
     b = cb->obj;
     switch (ca->type) {
     case ADDED_DATA:
         i = (a->length - b->length);
         if (i)
-            return (i);
-        return (memcmp(a->data, b->data, (size_t)a->length));
+            return i;
+        return memcmp(a->data, b->data, (size_t)a->length);
     case ADDED_SNAME:
         if (a->sn == NULL)
-            return (-1);
+            return -1;
         else if (b->sn == NULL)
-            return (1);
+            return 1;
         else
-            return (strcmp(a->sn, b->sn));
+            return strcmp(a->sn, b->sn);
     case ADDED_LNAME:
         if (a->ln == NULL)
-            return (-1);
+            return -1;
         else if (b->ln == NULL)
-            return (1);
+            return 1;
         else
-            return (strcmp(a->ln, b->ln));
+            return strcmp(a->ln, b->ln);
     case ADDED_NID:
-        return (a->nid - b->nid);
+        return a->nid - b->nid;
     default:
         /* abort(); */
         return 0;
@@ -126,9 +126,9 @@ static int added_obj_cmp(const ADDED_OBJ *ca, const ADDED_OBJ *cb)
 static int init_added(void)
 {
     if (added != NULL)
-        return (1);
+        return 1;
     added = lh_ADDED_OBJ_new(added_obj_hash, added_obj_cmp);
-    return (added != NULL);
+    return added != NULL;
 }
 
 static void cleanup1_doall(ADDED_OBJ *a)
@@ -168,7 +168,7 @@ int OBJ_new_nid(int num)
 
     i = new_nid;
     new_nid += num;
-    return (i);
+    return i;
 }
 
 int OBJ_add_object(const ASN1_OBJECT *obj)
@@ -179,7 +179,7 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
 
     if (added == NULL)
         if (!init_added())
-            return (0);
+            return 0;
     if ((o = OBJ_dup(obj)) == NULL)
         goto err;
     if ((ao[ADDED_NID] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
@@ -207,14 +207,14 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
         ~(ASN1_OBJECT_FLAG_DYNAMIC | ASN1_OBJECT_FLAG_DYNAMIC_STRINGS |
           ASN1_OBJECT_FLAG_DYNAMIC_DATA);
 
-    return (o->nid);
+    return o->nid;
  err2:
     OBJerr(OBJ_F_OBJ_ADD_OBJECT, ERR_R_MALLOC_FAILURE);
  err:
     for (i = ADDED_DATA; i <= ADDED_NID; i++)
         OPENSSL_free(ao[i]);
     OPENSSL_free(o);
-    return (NID_undef);
+    return NID_undef;
 }
 
 ASN1_OBJECT *OBJ_nid2obj(int n)
@@ -225,21 +225,21 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
     if ((n >= 0) && (n < NUM_NID)) {
         if ((n != NID_undef) && (nid_objs[n].nid == NID_undef)) {
             OBJerr(OBJ_F_OBJ_NID2OBJ, OBJ_R_UNKNOWN_NID);
-            return (NULL);
+            return NULL;
         }
-        return ((ASN1_OBJECT *)&(nid_objs[n]));
+        return (ASN1_OBJECT *)&(nid_objs[n]);
     } else if (added == NULL)
-        return (NULL);
+        return NULL;
     else {
         ad.type = ADDED_NID;
         ad.obj = &ob;
         ob.nid = n;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return (adp->obj);
+            return adp->obj;
         else {
             OBJerr(OBJ_F_OBJ_NID2OBJ, OBJ_R_UNKNOWN_NID);
-            return (NULL);
+            return NULL;
         }
     }
 }
@@ -252,21 +252,21 @@ const char *OBJ_nid2sn(int n)
     if ((n >= 0) && (n < NUM_NID)) {
         if ((n != NID_undef) && (nid_objs[n].nid == NID_undef)) {
             OBJerr(OBJ_F_OBJ_NID2SN, OBJ_R_UNKNOWN_NID);
-            return (NULL);
+            return NULL;
         }
-        return (nid_objs[n].sn);
+        return nid_objs[n].sn;
     } else if (added == NULL)
-        return (NULL);
+        return NULL;
     else {
         ad.type = ADDED_NID;
         ad.obj = &ob;
         ob.nid = n;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return (adp->obj->sn);
+            return adp->obj->sn;
         else {
             OBJerr(OBJ_F_OBJ_NID2SN, OBJ_R_UNKNOWN_NID);
-            return (NULL);
+            return NULL;
         }
     }
 }
@@ -279,21 +279,21 @@ const char *OBJ_nid2ln(int n)
     if ((n >= 0) && (n < NUM_NID)) {
         if ((n != NID_undef) && (nid_objs[n].nid == NID_undef)) {
             OBJerr(OBJ_F_OBJ_NID2LN, OBJ_R_UNKNOWN_NID);
-            return (NULL);
+            return NULL;
         }
-        return (nid_objs[n].ln);
+        return nid_objs[n].ln;
     } else if (added == NULL)
-        return (NULL);
+        return NULL;
     else {
         ad.type = ADDED_NID;
         ad.obj = &ob;
         ob.nid = n;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return (adp->obj->ln);
+            return adp->obj->ln;
         else {
             OBJerr(OBJ_F_OBJ_NID2LN, OBJ_R_UNKNOWN_NID);
-            return (NULL);
+            return NULL;
         }
     }
 }
@@ -306,10 +306,10 @@ static int obj_cmp(const ASN1_OBJECT *const *ap, const unsigned int *bp)
 
     j = (a->length - b->length);
     if (j)
-        return (j);
+        return j;
     if (a->length == 0)
         return 0;
-    return (memcmp(a->data, b->data, a->length));
+    return memcmp(a->data, b->data, a->length);
 }
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, obj);
@@ -320,9 +320,9 @@ int OBJ_obj2nid(const ASN1_OBJECT *a)
     ADDED_OBJ ad, *adp;
 
     if (a == NULL)
-        return (NID_undef);
+        return NID_undef;
     if (a->nid != 0)
-        return (a->nid);
+        return a->nid;
 
     if (a->length == 0)
         return NID_undef;
@@ -332,12 +332,12 @@ int OBJ_obj2nid(const ASN1_OBJECT *a)
         ad.obj = (ASN1_OBJECT *)a; /* XXX: ugly but harmless */
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return (adp->obj->nid);
+            return adp->obj->nid;
     }
     op = OBJ_bsearch_obj(&a, obj_objs, NUM_OBJ);
     if (op == NULL)
-        return (NID_undef);
-    return (nid_objs[*op].nid);
+        return NID_undef;
+    return nid_objs[*op].nid;
 }
 
 /*
@@ -404,7 +404,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
         buf[0] = '\0';
 
     if ((a == NULL) || (a->data == NULL))
-        return (0);
+        return 0;
 
     if (!no_name && (nid = OBJ_obj2nid(a)) != NID_undef) {
         const char *s;
@@ -500,7 +500,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             n += i;
             OPENSSL_free(bndec);
         } else {
-            sprintf(tbuf, ".%lu", l);
+            BIO_snprintf(tbuf, sizeof(tbuf), ".%lu", l);
             i = strlen(tbuf);
             if (buf && (buf_len > 0)) {
                 OPENSSL_strlcpy(buf, tbuf, buf_len);
@@ -548,12 +548,12 @@ int OBJ_ln2nid(const char *s)
         ad.obj = &o;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return (adp->obj->nid);
+            return adp->obj->nid;
     }
     op = OBJ_bsearch_ln(&oo, ln_objs, NUM_LN);
     if (op == NULL)
-        return (NID_undef);
-    return (nid_objs[*op].nid);
+        return NID_undef;
+    return nid_objs[*op].nid;
 }
 
 int OBJ_sn2nid(const char *s)
@@ -569,12 +569,12 @@ int OBJ_sn2nid(const char *s)
         ad.obj = &o;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return (adp->obj->nid);
+            return adp->obj->nid;
     }
     op = OBJ_bsearch_sn(&oo, sn_objs, NUM_SN);
     if (op == NULL)
-        return (NID_undef);
-    return (nid_objs[*op].nid);
+        return NID_undef;
+    return nid_objs[*op].nid;
 }
 
 const void *OBJ_bsearch_(const void *key, const void *base, int num, int size,
@@ -593,7 +593,7 @@ const void *OBJ_bsearch_ex_(const void *key, const void *base_, int num,
     const char *p = NULL;
 
     if (num == 0)
-        return (NULL);
+        return NULL;
     l = 0;
     h = num;
     while (l < h) {
@@ -629,7 +629,7 @@ const void *OBJ_bsearch_ex_(const void *key, const void *base_, int num,
             i--;
         p = &(base[i * size]);
     }
-    return (p);
+    return p;
 }
 
 int OBJ_create_objects(BIO *in)
@@ -642,10 +642,10 @@ int OBJ_create_objects(BIO *in)
         s = o = NULL;
         i = BIO_gets(in, buf, 512);
         if (i <= 0)
-            return (num);
+            return num;
         buf[i - 1] = '\0';
         if (!isalnum((unsigned char)buf[0]))
-            return (num);
+            return num;
         o = s = buf;
         while (isdigit((unsigned char)*s) || (*s == '.'))
             s++;
@@ -671,9 +671,9 @@ int OBJ_create_objects(BIO *in)
         } else
             s = NULL;
         if ((o == NULL) || (*o == '\0'))
-            return (num);
+            return num;
         if (!OBJ_create(o, s, l))
-            return (num);
+            return num;
         num++;
     }
 }

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -56,17 +56,17 @@ NON_EMPTY_TRANSLATION_UNIT
 # if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_VOS) || defined(OPENSSL_SYS_UEFI)
 int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
 {
-    return (-1);
+    return -1;
 }
 
 int RAND_egd(const char *path)
 {
-    return (-1);
+    return -1;
 }
 
 int RAND_egd_bytes(const char *path, int bytes)
 {
-    return (-1);
+    return -1;
 }
 # else
 #  include <openssl/opensslconf.h>
@@ -101,12 +101,12 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
     if (strlen(path) >= sizeof(addr.sun_path))
-        return (-1);
+        return -1;
     strcpy(addr.sun_path, path);
     len = offsetof(struct sockaddr_un, sun_path) + strlen(path);
     fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd == -1)
-        return (-1);
+        return -1;
     success = 0;
     while (!success) {
         if (connect(fd, (struct sockaddr *)&addr, len) == 0)
@@ -223,7 +223,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
  err:
     if (fd != -1)
         close(fd);
-    return (ret);
+    return ret;
 }
 
 int RAND_egd_bytes(const char *path, int bytes)
@@ -236,12 +236,12 @@ int RAND_egd_bytes(const char *path, int bytes)
     if (RAND_status() == 1)
         ret = num;
  err:
-    return (ret);
+    return ret;
 }
 
 int RAND_egd(const char *path)
 {
-    return (RAND_egd_bytes(path, 255));
+    return RAND_egd_bytes(path, 255);
 }
 
 # endif

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -295,8 +295,8 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
                 BIO_snprintf(b->data, b->max,
                              "%s%08lx.%s%d", ent->dir, h, postfix, k);
             } else {
-                sprintf(b->data,
-                        "%s%c%08lx.%s%d", ent->dir, c, h, postfix, k);
+                BIO_snprintf(b->data, b->max,
+                             "%s%c%08lx.%s%d", ent->dir, c, h, postfix, k);
             }
 #ifndef OPENSSL_NO_POSIX_IO
 # ifdef _WIN32

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -108,11 +108,12 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
     case GEN_IPADD:
         p = gen->d.ip->data;
         if (gen->d.ip->length == 4)
-            sprintf(oline, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
+            BIO_snprintf(oline, sizeof(oline), "%d.%d.%d.%d",
+                         p[0], p[1], p[2], p[3]);
         else if (gen->d.ip->length == 16) {
             oline[0] = 0;
             for (i = 0; i < 8; i++) {
-                sprintf(htmp, "%X", p[0] << 8 | p[1]);
+                BIO_snprintf(htmp, sizeof(htmp), "%X", p[0] << 8 | p[1]);
                 p += 2;
                 strcat(oline, htmp);
                 if (i != 7)

--- a/crypto/x509v3/v3_info.c
+++ b/crypto/x509v3/v3_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -82,12 +82,9 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
         ntmp = OPENSSL_malloc(nlen);
         if (ntmp == NULL)
             goto err;
-        strcpy(ntmp, objtmp);
-        strcat(ntmp, " - ");
-        strcat(ntmp, vtmp->name);
+        BIO_snprintf(ntmp, nlen, "%s - %s", objtmp, vtmp->name);
         OPENSSL_free(vtmp->name);
         vtmp->name = ntmp;
-
     }
     if (ret == NULL && tret == NULL)
         return sk_CONF_VALUE_new_null();


### PR DESCRIPTION
Bounds checking strpy, strcat and sprintf.
These are the remaining easy ones to cover a recently removed commit.
Some are trivial, some have been modified and a couple left as they are because the reverted change didn't bounds check properly.
