### PR TITLE
Overflow prevention

### DIFF
--- a/crypto/bn/bn_print.c
+++ b/crypto/bn/bn_print.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -46,7 +46,7 @@ char *BN_bn2hex(const BIGNUM *a)
     }
     *p = '\0';
  err:
-    return (buf);
+    return buf;
 }
 
 /* Must 'OPENSSL_free' the returned data */
@@ -128,7 +128,7 @@ int BN_hex2bn(BIGNUM **bn, const char *a)
     int num;
 
     if ((a == NULL) || (*a == '\0'))
-        return (0);
+        return 0;
 
     if (*a == '-') {
         neg = 1;
@@ -143,12 +143,12 @@ int BN_hex2bn(BIGNUM **bn, const char *a)
 
     num = i + neg;
     if (bn == NULL)
-        return (num);
+        return num;
 
     /* a is the start of the hex digits, and it is 'i' long */
     if (*bn == NULL) {
         if ((ret = BN_new()) == NULL)
-            return (0);
+            return 0;
     } else {
         ret = *bn;
         BN_zero(ret);
@@ -186,11 +186,11 @@ int BN_hex2bn(BIGNUM **bn, const char *a)
     /* Don't set the negative flag if it's zero. */
     if (ret->top != 0)
         ret->neg = neg;
-    return (num);
+    return num;
  err:
     if (*bn == NULL)
         BN_free(ret);
-    return (0);
+    return 0;
 }
 
 int BN_dec2bn(BIGNUM **bn, const char *a)
@@ -201,7 +201,7 @@ int BN_dec2bn(BIGNUM **bn, const char *a)
     int num;
 
     if ((a == NULL) || (*a == '\0'))
-        return (0);
+        return 0;
     if (*a == '-') {
         neg = 1;
         a++;
@@ -215,7 +215,7 @@ int BN_dec2bn(BIGNUM **bn, const char *a)
 
     num = i + neg;
     if (bn == NULL)
-        return (num);
+        return num;
 
     /*
      * a is the start of the digits, and it is 'i' long. We chop it into
@@ -223,7 +223,7 @@ int BN_dec2bn(BIGNUM **bn, const char *a)
      */
     if (*bn == NULL) {
         if ((ret = BN_new()) == NULL)
-            return (0);
+            return 0;
     } else {
         ret = *bn;
         BN_zero(ret);
@@ -256,11 +256,11 @@ int BN_dec2bn(BIGNUM **bn, const char *a)
     /* Don't set the negative flag if it's zero. */
     if (ret->top != 0)
         ret->neg = neg;
-    return (num);
+    return num;
  err:
     if (*bn == NULL)
         BN_free(ret);
-    return (0);
+    return 0;
 }
 
 int BN_asc2bn(BIGNUM **bn, const char *a)
@@ -290,11 +290,11 @@ int BN_print_fp(FILE *fp, const BIGNUM *a)
     int ret;
 
     if ((b = BIO_new(BIO_s_file())) == NULL)
-        return (0);
+        return 0;
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = BN_print(b, a);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 # endif
 
@@ -320,7 +320,7 @@ int BN_print(BIO *bp, const BIGNUM *a)
     }
     ret = 1;
  end:
-    return (ret);
+    return ret;
 }
 
 char *BN_options(void)
@@ -338,5 +338,5 @@ char *BN_options(void)
                 (int)sizeof(BN_ULONG) * 8, (int)sizeof(BN_ULONG) * 8);
 #endif
     }
-    return (data);
+    return data;
 }

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -183,7 +183,7 @@ int CRYPTO_mem_ctrl(int mode)
         break;
     }
     CRYPTO_THREAD_unlock(malloc_lock);
-    return (ret);
+    return ret;
 #endif
 }
 
@@ -206,7 +206,7 @@ static int mem_check_on(void)
 
         CRYPTO_THREAD_unlock(malloc_lock);
     }
-    return (ret);
+    return ret;
 }
 
 static int mem_cmp(const MEM *a, const MEM *b)
@@ -231,7 +231,7 @@ static unsigned long mem_hash(const MEM *a)
     ret = (size_t)a->addr;
 
     ret = ret * 17851 + (ret >> 14) * 7 + (ret >> 4) * 251;
-    return (ret);
+    return ret;
 }
 
 /* returns 1 if there was an info to pop, 0 if the stack was empty. */
@@ -292,7 +292,7 @@ int CRYPTO_mem_debug_push(const char *info, const char *file, int line)
         CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
     }
 
-    return (ret);
+    return ret;
 }
 
 int CRYPTO_mem_debug_pop(void)
@@ -304,7 +304,7 @@ int CRYPTO_mem_debug_pop(void)
         ret = pop_info();
         CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ENABLE);
     }
-    return (ret);
+    return ret;
 }
 
 static unsigned long break_order_num = 0;

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -113,12 +113,12 @@ void *PEM_ASN1_read(d2i_of_void *d2i, const char *name, FILE *fp, void **x,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_ASN1_READ, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_ASN1_read_bio(d2i, name, b, x, cb, u);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -298,12 +298,12 @@ int PEM_ASN1_write(i2d_of_void *i2d, const char *name, FILE *fp,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_ASN1_WRITE, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_ASN1_write_bio(i2d, name, b, x, enc, kstr, klen, callback, u);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -402,7 +402,7 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp,
     EVP_CIPHER_CTX_free(ctx);
     OPENSSL_cleanse(buf, PEM_BUFSIZE);
     OPENSSL_clear_free(data, (unsigned int)dsize);
-    return (ret);
+    return ret;
 }
 
 int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *plen,
@@ -570,14 +570,14 @@ static int load_iv(char **fromp, unsigned char *to, int num)
         v = OPENSSL_hexchar2int(*from);
         if (v < 0) {
             PEMerr(PEM_F_LOAD_IV, PEM_R_BAD_IV_CHARS);
-            return (0);
+            return 0;
         }
         from++;
         to[i / 2] |= v << (long)((!(i & 1)) * 4);
     }
 
     *fromp = from;
-    return (1);
+    return 1;
 }
 
 #ifndef OPENSSL_NO_STDIO
@@ -589,12 +589,12 @@ int PEM_write(FILE *fp, const char *name, const char *header,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_WRITE, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_write_bio(b, name, header, data, len);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -651,12 +651,12 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
         goto err;
     OPENSSL_clear_free(buf, PEM_BUFSIZE * 8);
     EVP_ENCODE_CTX_free(ctx);
-    return (i + outl);
+    return i + outl;
  err:
     OPENSSL_clear_free(buf, PEM_BUFSIZE * 8);
     EVP_ENCODE_CTX_free(ctx);
     PEMerr(PEM_F_PEM_WRITE_BIO, reason);
-    return (0);
+    return 0;
 }
 
 #ifndef OPENSSL_NO_STDIO
@@ -668,12 +668,12 @@ int PEM_read(FILE *fp, char **name, char **header, unsigned char **data,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_READ, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_read_bio(b, name, header, data, len);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 


### PR DESCRIPTION
Addressing strcpy, strcat and sprintf issues in `crypto/bn/bn_print.c`, `crypto/mem_dbg.c` and `crypto/pem/pem_lib.c`

Also replace `return (x)` with `return x`

