### PR TITLE
Fix s_client crash where the hostname is provided as a positional arg

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1477,7 +1477,7 @@ int s_client_main(int argc, char **argv)
             goto opthelp;
         }
         connect_type = use_inet;
-        connectstr = *opt_rest();
+        freeandcopy(&connectstr, *opt_rest());
     } else if (argc != 0) {
         goto opthelp;
     }


### PR DESCRIPTION
If the hostname is provided as a positional arg then s_client crashes.
The crash occurs as s_client exits (after either a successful or
unsuccessful connection attempt).

This issue was introduced by commit 729ef85611.