### PR TITLE
Fix doc nits warnings in STORE documentation

### DIFF
--- a/doc/man3/OSSL_STORE_INFO.pod
+++ b/doc/man3/OSSL_STORE_INFO.pod
@@ -16,7 +16,7 @@ OSSL_STORE_INFO_new_CRL - Functions to manipulate OSSL_STORE_INFO objects
 =head1 SYNOPSIS
 
  #include <openssl/store.h>
- 
+
  typedef struct ossl_store_info_st OSSL_STORE_INFO;
 
  int OSSL_STORE_INFO_get_type(const OSSL_STORE_INFO *store_info);

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -52,7 +52,7 @@ unregister STORE loaders for different URI schemes
  int OSSL_STORE_LOADER_set_close(OSSL_STORE_LOADER *store_loader,
                                  OSSL_STORE_close_fn store_close_function);
  void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *store_loader);
- 
+
  int OSSL_STORE_register_loader(OSSL_STORE_LOADER *loader);
  OSSL_STORE_LOADER *OSSL_STORE_unregister_loader(const char *scheme);
 

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -9,7 +9,7 @@ OSSL_STORE_close - Types and functions to read objects from a URI
 =head1 SYNOPSIS
 
  #include <openssl/store.h>
- 
+
  typedef struct ossl_store_ctx_st OSSL_STORE_CTX;
 
  typedef OSSL_STORE_INFO *(*OSSL_STORE_post_process_info_fn)(OSSL_STORE_INFO *,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes:

```
(cd ../work/openssl; /usr/bin/perl util/find-doc-nits -n -p ) >doc-nits
if [ -s doc-nits ] ; then cat doc-nits; rm doc-nits ; exit 1; fi
*** WARNING: line containing nothing but whitespace in paragraph at line 19 in file doc/man3/OSSL_STORE_INFO.pod
*** WARNING: line containing nothing but whitespace in paragraph at line 55 in file doc/man3/OSSL_STORE_LOADER.pod
*** WARNING: line containing nothing but whitespace in paragraph at line 12 in file doc/man3/OSSL_STORE_open.pod
make: *** [doc-nits] Error 1
```
