### PR TITLE
Fix crash in BUF_MEM_grow_clean

### DIFF
--- a/crypto/buffer/buffer.c
+++ b/crypto/buffer/buffer.c
@@ -62,9 +62,11 @@ static char *sec_alloc_realloc(BUF_MEM *str, size_t len)
 
     ret = OPENSSL_secure_malloc(len);
     if (str->data != NULL) {
-        if (ret != NULL)
+        if (ret != NULL) {
             memcpy(ret, str->data, str->length);
-        OPENSSL_secure_free(str->data);
+            OPENSSL_secure_free(str->data);
+            str->data = NULL;
+        }
     }
     return (ret);
 }

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -859,7 +859,8 @@ static int get_header_and_data(BIO *bp, BIO **header, BIO **data, char *name,
          * Else, a line of text -- could be header or data; we don't
          * know yet.  Just pass it through.
          */
-        BIO_puts(tmp, linebuf);
+        if (BIO_puts(tmp, linebuf) < 0)
+            goto err;
         /*
          * Only encrypted files need the line length check applied.
          */


### PR DESCRIPTION
This is a heap-use-after-free type of error.

```
 =================================================================
==32058==ERROR: AddressSanitizer: heap-use-after-free on address 0x616000079e80 at pc 0x7f9621cce7e2 bp 0x7f9613a71380 sp 0x7f9613a70b30
READ of size 585 at 0x616000079e80 thread T20
    #0 0x7f9621cce7e1 in __interceptor_memcpy ../../../../gcc-8-20170625/libsanitizer/asan/asan_interceptors.cc:456
    #1 0x550d34a in sec_alloc_realloc crypto/buffer/buffer.c:66
    #2 0x550d34a in BUF_MEM_grow_clean crypto/buffer/buffer.c:132
    #3 0x54f099e in mem_write crypto/bio/bss_mem.c:225
    #4 0x54f099e in mem_puts crypto/bio/bss_mem.c:352
    #5 0x54de22e in BIO_puts crypto/bio/bio_lib.c:407
    #6 0x5708c95 in get_header_and_data crypto/pem/pem_lib.c:870
    #7 0x5708c95 in PEM_read_bio_ex crypto/pem/pem_lib.c:930
    #8 0x570a667 in pem_bytes_read_bio_flags crypto/pem/pem_lib.c:260
    #9 0x570b94d in PEM_bytes_read_bio_secmem crypto/pem/pem_lib.c:298
    #10 0x570d650 in PEM_read_bio_PrivateKey crypto/pem/pem_pkey.c:35
    #11 0x4cdb3cf in OpcUa_P_OpenSSL_RSA_LoadPrivateKeyFromFile platforms/linux/opcua_p_openssl_rsa.c:139
    #12 0x35aa966 in FoundationStack::loadPrivateKey(OpcUa_Crypto_Key_&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/Core/OT/FoundationStack.cpp:1093
    #13 0x3e1474e in X509IdentityTokenStruct::loadPrivateKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/Core/OT/X509IdentityTokenStruct.cpp:289
    #14 0x298cbe1 in OTX509IdentityTokenLoadPrivateKey /home/ed/OPCToolboxV5/Source/Core/OT/CApi.cpp:38773
    #15 0x1f9ebe2 in SoftingOPCToolbox5::X509IdentityToken::loadPrivateKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/api/X509IdentityToken.cpp:146
    #16 0x188ab46 in SoftingOPCToolbox5::UserIdentityToken::setX509IdentityToken(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, SoftingOPCToolbox5::IByteString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/ed/OPCToolboxV5/Source/api/UserIdentityToken.cpp:236
    #17 0x10f6db7 in TestCase_Authentication::connect() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCase_Authentication.cpp:68
    #18 0x110088b in TestCase_Authentication::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCase_Authentication.cpp:194
    #19 0xf814e3 in TestCall::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCall.cpp:36
    #20 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #21 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #22 0x146735f in ExecutionThread::run() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/AsynchTestExecution.cpp:122
    #23 0xfb8f2c in ClientUtil_PosixThreadProc(void*) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/ClientUtil_Thread.cpp:30
    #24 0x7f9621a5b6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
    #25 0x7f961fdc93dc in clone (/lib/x86_64-linux-gnu/libc.so.6+0x1073dc)

0x616000079e80 is located 0 bytes inside of 608-byte region [0x616000079e80,0x61600007a0e0)
freed by thread T20 here:
    #0 0x7f9621d4f058 in __interceptor_free ../../../../gcc-8-20170625/libsanitizer/asan/asan_malloc_linux.cc:45
    #1 0x550d37a in sec_alloc_realloc crypto/buffer/buffer.c:67
    #2 0x550d37a in BUF_MEM_grow_clean crypto/buffer/buffer.c:132
    #3 0x54f099e in mem_write crypto/bio/bss_mem.c:225
    #4 0x54f099e in mem_puts crypto/bio/bss_mem.c:352
    #5 0x54de22e in BIO_puts crypto/bio/bio_lib.c:407
    #6 0x5708c95 in get_header_and_data crypto/pem/pem_lib.c:870
    #7 0x5708c95 in PEM_read_bio_ex crypto/pem/pem_lib.c:930
    #8 0x570a667 in pem_bytes_read_bio_flags crypto/pem/pem_lib.c:260
    #9 0x570b94d in PEM_bytes_read_bio_secmem crypto/pem/pem_lib.c:298
    #10 0x570d650 in PEM_read_bio_PrivateKey crypto/pem/pem_pkey.c:35
    #11 0x4cdb3cf in OpcUa_P_OpenSSL_RSA_LoadPrivateKeyFromFile platforms/linux/opcua_p_openssl_rsa.c:139
    #12 0x35aa966 in FoundationStack::loadPrivateKey(OpcUa_Crypto_Key_&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/Core/OT/FoundationStack.cpp:1093
    #13 0x3e1474e in X509IdentityTokenStruct::loadPrivateKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/Core/OT/X509IdentityTokenStruct.cpp:289
    #14 0x298cbe1 in OTX509IdentityTokenLoadPrivateKey /home/ed/OPCToolboxV5/Source/Core/OT/CApi.cpp:38773
    #15 0x1f9ebe2 in SoftingOPCToolbox5::X509IdentityToken::loadPrivateKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/api/X509IdentityToken.cpp:146
    #16 0x188ab46 in SoftingOPCToolbox5::UserIdentityToken::setX509IdentityToken(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, SoftingOPCToolbox5::IByteString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/ed/OPCToolboxV5/Source/api/UserIdentityToken.cpp:236
    #17 0x10f6db7 in TestCase_Authentication::connect() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCase_Authentication.cpp:68
    #18 0x110088b in TestCase_Authentication::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCase_Authentication.cpp:194
    #19 0xf814e3 in TestCall::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCall.cpp:36
    #20 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #21 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #22 0x146735f in ExecutionThread::run() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/AsynchTestExecution.cpp:122
    #23 0xfb8f2c in ClientUtil_PosixThreadProc(void*) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/ClientUtil_Thread.cpp:30
    #24 0x7f9621a5b6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)

previously allocated by thread T20 here:
    #0 0x7f9621d4f37a in __interceptor_malloc ../../../../gcc-8-20170625/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x550d2c1 in sec_alloc_realloc crypto/buffer/buffer.c:63
    #2 0x550d2c1 in BUF_MEM_grow_clean crypto/buffer/buffer.c:132
    #3 0x54f099e in mem_write crypto/bio/bss_mem.c:225
    #4 0x54f099e in mem_puts crypto/bio/bss_mem.c:352
    #5 0x54de22e in BIO_puts crypto/bio/bio_lib.c:407
    #6 0x5708c95 in get_header_and_data crypto/pem/pem_lib.c:870
    #7 0x5708c95 in PEM_read_bio_ex crypto/pem/pem_lib.c:930
    #8 0x570a667 in pem_bytes_read_bio_flags crypto/pem/pem_lib.c:260
    #9 0x570b94d in PEM_bytes_read_bio_secmem crypto/pem/pem_lib.c:298
    #10 0x570d650 in PEM_read_bio_PrivateKey crypto/pem/pem_pkey.c:35
    #11 0x4cdb3cf in OpcUa_P_OpenSSL_RSA_LoadPrivateKeyFromFile platforms/linux/opcua_p_openssl_rsa.c:139
    #12 0x35aa966 in FoundationStack::loadPrivateKey(OpcUa_Crypto_Key_&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/Core/OT/FoundationStack.cpp:1093
    #13 0x3e1474e in X509IdentityTokenStruct::loadPrivateKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/Core/OT/X509IdentityTokenStruct.cpp:289
    #14 0x298cbe1 in OTX509IdentityTokenLoadPrivateKey /home/ed/OPCToolboxV5/Source/Core/OT/CApi.cpp:38773
    #15 0x1f9ebe2 in SoftingOPCToolbox5::X509IdentityToken::loadPrivateKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ed/OPCToolboxV5/Source/api/X509IdentityToken.cpp:146
    #16 0x188ab46 in SoftingOPCToolbox5::UserIdentityToken::setX509IdentityToken(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, SoftingOPCToolbox5::IByteString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/ed/OPCToolboxV5/Source/api/UserIdentityToken.cpp:236
    #17 0x10f6db7 in TestCase_Authentication::connect() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCase_Authentication.cpp:68
    #18 0x110088b in TestCase_Authentication::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCase_Authentication.cpp:194
    #19 0xf814e3 in TestCall::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestCall.cpp:36
    #20 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #21 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #22 0x146735f in ExecutionThread::run() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/AsynchTestExecution.cpp:122
    #23 0xfb8f2c in ClientUtil_PosixThreadProc(void*) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/ClientUtil_Thread.cpp:30
    #24 0x7f9621a5b6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)

Thread T20 created by T7 here:
    #0 0x7f9621ca7a10 in __interceptor_pthread_create ../../../../gcc-8-20170625/libsanitizer/asan/asan_interceptors.cc:243
    #1 0xfb8cc2 in ClientUtil_Thread::start() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/ClientUtil_Thread.cpp:127
    #2 0x146955f in AsynchTestExecution::execute(TestCallInterface*) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/AsynchTestExecution.cpp:30
    #3 0x910b6c in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:309
    #4 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #5 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #6 0x910fd8 in TestList::execute(bool) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestList.cpp:353
    #7 0x1466b08 in ExecutionThread::run() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/AsynchTestExecution.cpp:142
    #8 0xfb8f2c in ClientUtil_PosixThreadProc(void*) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/ClientUtil_Thread.cpp:30
    #9 0x7f9621a5b6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)

Thread T7 created by T0 here:
    #0 0x7f9621ca7a10 in __interceptor_pthread_create ../../../../gcc-8-20170625/libsanitizer/asan/asan_interceptors.cc:243
    #1 0xfb8cc2 in ClientUtil_Thread::start() /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/ClientUtil_Thread.cpp:127
    #2 0x146955f in AsynchTestExecution::execute(TestCallInterface*) /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/AsynchTestExecution.cpp:30
    #3 0x595a4a in main /home/ed/OPCToolboxV5/Source/Apps/Test/Cpp/TestClient/TestClient.cpp:398
    #4 0x7f961fce282f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

SUMMARY: AddressSanitizer: heap-use-after-free ../../../../gcc-8-20170625/libsanitizer/asan/asan_interceptors.cc:456 in __interceptor_memcpy
Shadow bytes around the buggy address:
  0x0c2c80007380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2c80007390: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2c800073a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2c800073b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2c800073c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c2c800073d0:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2c800073e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2c800073f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2c80007400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2c80007410: fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c2c80007420: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==32058==ABORTING

```