### PR TITLE
Patch for copy and copy-if-different scripts with whitespace problem #1023 - CLA: trivial

### DIFF
--- a/util/copy-if-different.pl
+++ b/util/copy-if-different.pl
@@ -12,7 +12,7 @@ my @filelist;
 
 foreach my $arg (@ARGV) {
 	$arg =~ s|\\|/|g;	# compensate for bug/feature in cygwin glob...
-	foreach (glob $arg)
+	foreach (glob qq("$arg"))
 		{
 		push @filelist, $_;
 		}

--- a/util/copy.pl
+++ b/util/copy.pl
@@ -19,7 +19,7 @@ foreach $arg (@ARGV) {
 		next;
 		}
 	$arg =~ s|\\|/|g;	# compensate for bug/feature in cygwin glob...
-	foreach (glob $arg)
+	foreach (glob qq("$arg"))
 		{
 		push @filelist, $_;
 		}


### PR DESCRIPTION
Small "CLA: trivial" fix related to #1023
