### PR TITLE
Fix SSL_set_tlsext_debug_callback/-tlsextdebug

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -520,6 +520,11 @@ int tls_collect_extensions(SSL *s, PACKET *packet, unsigned int context,
             thisex->present = 1;
             thisex->type = type;
             thisex->received_order = i++;
+            if (s->ext.debug_cb)
+                s->ext.debug_cb(s, !s->server, thisex->type,
+                                PACKET_data(&thisex->data),
+                                PACKET_remaining(&thisex->data),
+                                s->ext.debug_arg);
         }
     }
 
@@ -570,12 +575,6 @@ int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
     /* Skip if the extension is not present */
     if (!currext->present)
         return 1;
-
-    if (s->ext.debug_cb)
-        s->ext.debug_cb(s, !s->server, currext->type,
-                        PACKET_data(&currext->data),
-                        PACKET_remaining(&currext->data),
-                        s->ext.debug_arg);
 
     /* Skip if we've already parsed this extension */
     if (currext->parsed)


### PR DESCRIPTION
Some extensions were being displayed twice, before they were parsed, and
again after they were parsed.
The supported_versions extension was not being fully displayed, as it
was processed differently than other extensions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
