### PR TITLE
Test cleaning and modernisation

### DIFF
--- a/test/README
+++ b/test/README
@@ -39,9 +39,9 @@ A recipe that just runs a test executable
 A script that just runs a program looks like this:
 
     #! /usr/bin/perl
-    
+
     use OpenSSL::Test::Simple;
-    
+
     simple_test("test_{name}", "{name}test", "{name}");
 
 {name} is the unique name you have chosen for your test.
@@ -63,28 +63,28 @@ documentation.  For OpenSSL::Test, do `perldoc test/testlib/OpenSSL/Test.pm'.
 A script to start from could be this:
 
     #! /usr/bin/perl
-    
+
     use strict;
     use warnings;
     use OpenSSL::Test;
-    
+
     setup("test_{name}");
-    
+
     plan tests => 2;                # The number of tests being performed
-    
+
     ok(test1, "test1");
     ok(test2, "test1");
-    
+
     sub test1
     {
         # test feature 1
     }
-    
+
     sub test2
     {
         # test feature 2
     }
-    
+
 
 Changes to test/build.info
 ==========================

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -287,7 +287,7 @@ static int print_test_data(void)
     for (j = 0; j < strlen(cbc_data) + 1; j++)
         printf("%02X", ofb64_ok[j]);
     printf("\n");
-    return (0);
+    return 0;
 }
 
 static int test_bf_ecb_raw(int n)

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -23,7 +23,7 @@
 int main(int argc, char *argv[])
 {
     printf("No DH support\n");
-    return (0);
+    return EXIT_SUCCESS;
 }
 #else
 # include <openssl/dh.h>

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -9,13 +9,14 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <openssl/e_os2.h>
 
 #ifdef OPENSSL_NO_ENGINE
 int main(int argc, char *argv[])
 {
     printf("No ENGINE support\n");
-    return (0);
+    return EXIT_SUCCESS;
 }
 #else
 # include <openssl/buffer.h>

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -826,7 +826,7 @@ static void do_reneg_setup_step(const SSL_TEST_CTX *test_ctx, PEER *peer)
         do_handshake_step(peer);
         return;
     }
-    
+
     if (!TEST_int_eq(peer->status, PEER_RETRY)
             || !TEST_true(test_ctx->handshake_mode
                               == SSL_TEST_HANDSHAKE_RENEG_SERVER

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -232,7 +232,7 @@ static char *pt(unsigned char *md, unsigned int len)
 
     for (i = 0; i < len; i++)
         sprintf(&(buf[i * 2]), "%02x", md[i]);
-    return (buf);
+    return buf;
 }
 # endif
 

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -42,7 +42,7 @@ void register_tests(void)
                         BN_bin2bn(dmq1, sizeof(dmq1)-1, NULL),  \
                         BN_bin2bn(iqmp, sizeof(iqmp)-1, NULL)); \
     memcpy(c, ctext_ex, sizeof(ctext_ex) - 1);                  \
-    return (sizeof(ctext_ex) - 1);
+    return sizeof(ctext_ex) - 1;
 
 static int key1(RSA *key, unsigned char *c)
 {
@@ -215,8 +215,8 @@ static int pad_unknown(void)
     unsigned long l;
     while ((l = ERR_get_error()) != 0)
         if (ERR_GET_REASON(l) == RSA_R_UNKNOWN_PADDING_TYPE)
-            return (1);
-    return (0);
+            return 1;
+    return 0;
 }
 
 static int rsa_setkey(RSA** key, unsigned char* ctext, int idx)


### PR DESCRIPTION
- [x] tests are added or updated

Fix style issues `return (x)` becoming `return x` and spaces at the end of lines removed.
Clean up returns from main to use EXIT_SUCCESS and EXIT_FAILURE instead of magic numbers.
