### PR TITLE
Remove trailing blanks.

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  * Copyright 2005 Nokia. All rights reserved.
  *
@@ -285,7 +285,7 @@ typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 /*
  * Some values are reserved until OpenSSL 1.2.0 because they were previously
  * included in SSL_OP_ALL in a 1.1.x release.
- *  
+ *
  * Reserved value (until OpenSSL 1.2.0)                  0x00000001U
  * Reserved value (until OpenSSL 1.2.0)                  0x00000002U
  */

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -826,7 +826,7 @@ static void do_reneg_setup_step(const SSL_TEST_CTX *test_ctx, PEER *peer)
         do_handshake_step(peer);
         return;
     }
-    
+
     if (!TEST_int_eq(peer->status, PEER_RETRY)
             || !TEST_true(test_ctx->handshake_mode
                               == SSL_TEST_HANDSHAKE_RENEG_SERVER

--- a/test/testutil/tap_bio.c
+++ b/test/testutil/tap_bio.c
@@ -122,7 +122,7 @@ err:
 static long tap_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
     BIO *next = BIO_next(b);
- 
+
     switch (cmd) {
     case BIO_CTRL_RESET:
         BIO_set_data(b, NULL);


### PR DESCRIPTION
This covers the remaining .c and .h files not done in #3913

- [x] tests are added or updated
