### PR TITLE
Set maskHash when creating parameters.

### DIFF
--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -567,6 +567,8 @@ RSA_PSS_PARAMS *rsa_pss_params_create(const EVP_MD *sigmd,
         mgf1md = sigmd;
     if (!rsa_md_to_mgf1(&pss->maskGenAlgorithm, mgf1md))
         goto err;
+    if (!rsa_md_to_algor(&pss->maskHash, mgf1md))
+        goto err;
     return pss;
  err:
     RSA_PSS_PARAMS_free(pss);

--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -504,7 +504,7 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 *(const EVP_MD **)p2 = rctx->md;
         } else {
             if (rsa_pss_restricted(rctx)) {
-                if (EVP_MD_type(rctx->md) == EVP_MD_type(p2))
+                if (EVP_MD_type(rctx->mgf1md) == EVP_MD_type(p2))
                     return 1;
                 RSAerr(RSA_F_PKEY_RSA_CTRL, RSA_R_MGF1_DIGEST_NOT_ALLOWED);
                 return 0;

--- a/test/recipes/30-test_evp_data/evppkey.txt
+++ b/test/recipes/30-test_evp_data/evppkey.txt
@@ -17447,3 +17447,37 @@ Result = DIGESTUPDATE_ERROR
 DigestSign = SHA256
 Key = ED25519-1
 Result = DIGESTSIGNINIT_ERROR
+
+# Key generation tests
+KeyGen = rsaEncryption
+Ctrl = rsa_keygen_bits:128
+KeyName = tmprsa
+Result = PKEY_CTRL_INVALID
+Function = pkey_rsa_ctrl
+Reason = key size too small
+
+# RSA-PSS with restrictions, should succeed.
+KeyGen = RSASSA-PSS
+KeyName = tmppss
+Ctrl = rsa_pss_keygen_md:sha256
+Ctrl = rsa_pss_keygen_mgf1_md:sha512
+
+# Check MGF1 restrictions
+DigestVerify = SHA256
+Key = tmppss
+Ctrl = rsa_mgf1_md:sha256
+Result = PKEY_CTRL_ERROR
+
+# Test valid digest and MGF1 parameters. Verify will fail
+DigestVerify = SHA256
+Key = tmppss
+Ctrl = rsa_mgf1_md:sha512
+Input = ""
+Output = ""
+Result = VERIFY_ERROR
+
+# Check caching of key MGF1 digest restriction
+DigestVerify = SHA256
+Key = tmppss
+Ctrl = rsa_mgf1_md:sha1
+Result = PKEY_CTRL_ERROR


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

This addresses #2963 when generating an RSA-PSS key we didn't set the cached mask parameter so if we signed using the key immediately it wouldn't use the correct PSS parameters.