### PR TITLE
backport SSL_OP_NO_ENCRYPT_THEN_MAC to 1.1.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@
      VMS C's RTL has a fully up to date gmtime() and gmtime_r() since V7.1,
      which is the minimum version we support.
      [Richard Levitte]
+  *) Support for SSL_OP_NO_ENCRYPT_THEN_MAC in SSL_CONF_cmd.
+     [Emilia Käsper]
 
  Changes between 1.1.0d and 1.1.0e [16 Feb 2017]
 

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@
   *) Ignore the '-named_curve auto' value for compatibility of applications
      with OpenSSL 1.0.2.
      [Tomas Mraz <tmraz@fedoraproject.org>]
+  *) Support for SSL_OP_NO_ENCRYPT_THEN_MAC in SSL_CONF_cmd.
+     [Emilia Käsper]
 
  Changes between 1.1.0e and 1.1.0f [25 May 2017]
 
@@ -23,8 +25,6 @@
      VMS C's RTL has a fully up to date gmtime() and gmtime_r() since V7.1,
      which is the minimum version we support.
      [Richard Levitte]
-  *) Support for SSL_OP_NO_ENCRYPT_THEN_MAC in SSL_CONF_cmd.
-     [Emilia Käsper]
 
  Changes between 1.1.0d and 1.1.0e [16 Feb 2017]
 

--- a/doc/ssl/SSL_CTX_set_options.pod
+++ b/doc/ssl/SSL_CTX_set_options.pod
@@ -189,6 +189,14 @@ Allow legacy insecure renegotiation between OpenSSL and unpatched servers
 B<only>: this option is currently set by default. See the
 B<SECURE RENEGOTIATION> section for more details.
 
+=item SSL_OP_NO_ENCRYPT_THEN_MAC
+
+Normally clients and servers will transparently attempt to negotiate the
+RFC7366 Encrypt-then-MAC option on TLS and DTLS connection.
+
+If this option is set, Encrypt-then-MAC is disabled. Clients will not
+propose, and servers will not accept the extension.
+
 =back
 
 =head1 SECURE RENEGOTIATION

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -297,6 +297,8 @@ typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 # define SSL_OP_NO_COMPRESSION                           0x00020000U
 /* Permit unsafe legacy renegotiation */
 # define SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION        0x00040000U
+/* Disable encrypt-then-mac */
+# define SSL_OP_NO_ENCRYPT_THEN_MAC                      0x00080000U
 /*
  * Set on servers to choose the cipher according to the server's preferences
  */

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -357,6 +357,7 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_SRV("ECDHSingle", SSL_OP_SINGLE_ECDH_USE),
         SSL_FLAG_TBL("UnsafeLegacyRenegotiation",
                      SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION),
+        SSL_FLAG_TBL_INV("EncryptThenMac", SSL_OP_NO_ENCRYPT_THEN_MAC),
     };
     if (value == NULL)
         return -3;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1380,8 +1380,9 @@ unsigned char *ssl_add_clienthello_tlsext(SSL *s, unsigned char *buf,
      * silently failed to actually do it. It is fixed in 1.1.1 but to
      * ease the transition especially from 1.1.0b to 1.1.0c, we just
      * disable it in 1.1.0.
+     * Also skip if SSL_OP_NO_ENCRYPT_THEN_MAC is set.
      */
-    if (!SSL_IS_DTLS(s)) {
+    if (!SSL_IS_DTLS(s) && !(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)) {
         /*-
          * check for enough space.
          * 4 bytes for the ETM type and extension length
@@ -2278,7 +2279,8 @@ static int ssl_scan_clienthello_tlsext(SSL *s, PACKET *pkt, int *al)
                 return 0;
         }
 #endif
-        else if (type == TLSEXT_TYPE_encrypt_then_mac)
+        else if (type == TLSEXT_TYPE_encrypt_then_mac &&
+                 !(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC))
             s->tlsext_use_etm = 1;
         /*
          * Note: extended master secret extension handled in
@@ -2598,7 +2600,8 @@ static int ssl_scan_serverhello_tlsext(SSL *s, PACKET *pkt, int *al)
 #endif
         else if (type == TLSEXT_TYPE_encrypt_then_mac) {
             /* Ignore if inappropriate ciphersuite */
-            if (s->s3->tmp.new_cipher->algorithm_mac != SSL_AEAD
+            if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC) &&
+                s->s3->tmp.new_cipher->algorithm_mac != SSL_AEAD
                 && s->s3->tmp.new_cipher->algorithm_enc != SSL_RC4)
                 s->tlsext_use_etm = 1;
         } else if (type == TLSEXT_TYPE_extended_master_secret) {

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -29,7 +29,7 @@ map { s/\^// } @conf_files if $^O eq "VMS";
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 18;  # = scalar @conf_srcs
+plan tests => 19;  # = scalar @conf_srcs
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.

--- a/test/ssl-tests/19-mac-then-encrypt.conf
+++ b/test/ssl-tests/19-mac-then-encrypt.conf
@@ -1,0 +1,156 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 6
+
+test-0 = 0-disable-encrypt-then-mac-server-sha
+test-1 = 1-disable-encrypt-then-mac-client-sha
+test-2 = 2-disable-encrypt-then-mac-both-sha
+test-3 = 3-disable-encrypt-then-mac-server-sha2
+test-4 = 4-disable-encrypt-then-mac-client-sha2
+test-5 = 5-disable-encrypt-then-mac-both-sha2
+# ===========================================================
+
+[0-disable-encrypt-then-mac-server-sha]
+ssl_conf = 0-disable-encrypt-then-mac-server-sha-ssl
+
+[0-disable-encrypt-then-mac-server-sha-ssl]
+server = 0-disable-encrypt-then-mac-server-sha-server
+client = 0-disable-encrypt-then-mac-server-sha-client
+
+[0-disable-encrypt-then-mac-server-sha-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-disable-encrypt-then-mac-server-sha-client]
+CipherString = AES128-SHA
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[1-disable-encrypt-then-mac-client-sha]
+ssl_conf = 1-disable-encrypt-then-mac-client-sha-ssl
+
+[1-disable-encrypt-then-mac-client-sha-ssl]
+server = 1-disable-encrypt-then-mac-client-sha-server
+client = 1-disable-encrypt-then-mac-client-sha-client
+
+[1-disable-encrypt-then-mac-client-sha-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-disable-encrypt-then-mac-client-sha-client]
+CipherString = AES128-SHA
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[2-disable-encrypt-then-mac-both-sha]
+ssl_conf = 2-disable-encrypt-then-mac-both-sha-ssl
+
+[2-disable-encrypt-then-mac-both-sha-ssl]
+server = 2-disable-encrypt-then-mac-both-sha-server
+client = 2-disable-encrypt-then-mac-both-sha-client
+
+[2-disable-encrypt-then-mac-both-sha-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[2-disable-encrypt-then-mac-both-sha-client]
+CipherString = AES128-SHA
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[3-disable-encrypt-then-mac-server-sha2]
+ssl_conf = 3-disable-encrypt-then-mac-server-sha2-ssl
+
+[3-disable-encrypt-then-mac-server-sha2-ssl]
+server = 3-disable-encrypt-then-mac-server-sha2-server
+client = 3-disable-encrypt-then-mac-server-sha2-client
+
+[3-disable-encrypt-then-mac-server-sha2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[3-disable-encrypt-then-mac-server-sha2-client]
+CipherString = AES128-SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[4-disable-encrypt-then-mac-client-sha2]
+ssl_conf = 4-disable-encrypt-then-mac-client-sha2-ssl
+
+[4-disable-encrypt-then-mac-client-sha2-ssl]
+server = 4-disable-encrypt-then-mac-client-sha2-server
+client = 4-disable-encrypt-then-mac-client-sha2-client
+
+[4-disable-encrypt-then-mac-client-sha2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-disable-encrypt-then-mac-client-sha2-client]
+CipherString = AES128-SHA256
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[5-disable-encrypt-then-mac-both-sha2]
+ssl_conf = 5-disable-encrypt-then-mac-both-sha2-ssl
+
+[5-disable-encrypt-then-mac-both-sha2-ssl]
+server = 5-disable-encrypt-then-mac-both-sha2-server
+client = 5-disable-encrypt-then-mac-both-sha2-client
+
+[5-disable-encrypt-then-mac-both-sha2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Options = -EncryptThenMac
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-disable-encrypt-then-mac-both-sha2-client]
+CipherString = AES128-SHA256
+Options = -EncryptThenMac
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = Success
+
+

--- a/test/ssl-tests/19-mac-then-encrypt.conf.in
+++ b/test/ssl-tests/19-mac-then-encrypt.conf.in
@@ -1,0 +1,89 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## SSL test configurations
+
+package ssltests;
+
+our @tests = (
+    {
+        name => "disable-encrypt-then-mac-server-sha",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-client-sha",
+        server => {
+        },
+        client => {
+          "CipherString" => "AES128-SHA",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-both-sha",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-server-sha2",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA256",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-client-sha2",
+        server => {
+        },
+        client => {
+          "CipherString" => "AES128-SHA256",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+    {
+        name => "disable-encrypt-then-mac-both-sha2",
+        server => {
+          "Options" => "-EncryptThenMac",
+        },
+        client => {
+          "CipherString" => "AES128-SHA256",
+          "Options" => "-EncryptThenMac",
+        },
+        test   => {
+          "ExpectedResult" => "Success",
+        },
+    },
+);


### PR DESCRIPTION
As well as the tests for mac-then-encrypt that Emilia added.

I resolved a couple conflicts (1.1.0 disallows ETM entirely for DTLS already, so the conditional changes, etc.) and moved the CHANGES entry to reflect the new reality.

We're seeing reports that WebSphere 8.x can't handle ETM at all (regardless of whether empty extensions are last). :(