### PR TITLE
s_time: retry SSL_read on ERROR_WANT_READ/WRITE

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -234,7 +234,9 @@ int s_time_main(int argc, char **argv)
                                    fmt_http_get_cmd, www_path);
             if (SSL_write(scon, buf, buf_len) <= 0)
                 goto end;
-            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 || SSL_get_error(scon, i) == SSL_ERROR_WANT_READ)
+            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 ||
+                        SSL_get_error(scon, i) == SSL_ERROR_WANT_READ ||
+                        SSL_get_error(scon, i) == SSL_ERROR_WANT_WRITE)
                 if (i > 0) bytes_read += i;
         }
 #ifdef NO_SHUTDOWN
@@ -292,7 +294,9 @@ int s_time_main(int argc, char **argv)
                                fmt_http_get_cmd, www_path);
         if (SSL_write(scon, buf, buf_len) <= 0)
             goto end;
-        while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 || SSL_get_error(scon, i) == SSL_ERROR_WANT_READ)
+        while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 ||
+                    SSL_get_error(scon, i) == SSL_ERROR_WANT_READ ||
+                    SSL_get_error(scon, i) == SSL_ERROR_WANT_WRITE)
             continue;
     }
 #ifdef NO_SHUTDOWN
@@ -323,7 +327,9 @@ int s_time_main(int argc, char **argv)
                          www_path);
             if (SSL_write(scon, buf, strlen(buf)) <= 0)
                 goto end;
-            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 || SSL_get_error(scon, i) == SSL_ERROR_WANT_READ)
+            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 ||
+                        SSL_get_error(scon, i) == SSL_ERROR_WANT_READ ||
+                        SSL_get_error(scon, i) == SSL_ERROR_WANT_WRITE)
                 if (i > 0) bytes_read += i;
         }
 #ifdef NO_SHUTDOWN

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -234,8 +234,8 @@ int s_time_main(int argc, char **argv)
                                    fmt_http_get_cmd, www_path);
             if (SSL_write(scon, buf, buf_len) <= 0)
                 goto end;
-            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0)
-                bytes_read += i;
+            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 || SSL_get_error(scon, i) == SSL_ERROR_WANT_READ)
+                if (i > 0) bytes_read += i;
         }
 #ifdef NO_SHUTDOWN
         SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
@@ -292,7 +292,7 @@ int s_time_main(int argc, char **argv)
                                fmt_http_get_cmd, www_path);
         if (SSL_write(scon, buf, buf_len) <= 0)
             goto end;
-        while (SSL_read(scon, buf, sizeof(buf)) > 0)
+        while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 || SSL_get_error(scon, i) == SSL_ERROR_WANT_READ)
             continue;
     }
 #ifdef NO_SHUTDOWN
@@ -323,8 +323,8 @@ int s_time_main(int argc, char **argv)
                          www_path);
             if (SSL_write(scon, buf, strlen(buf)) <= 0)
                 goto end;
-            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0)
-                bytes_read += i;
+            while ((i = SSL_read(scon, buf, sizeof(buf))) > 0 || SSL_get_error(scon, i) == SSL_ERROR_WANT_READ)
+                if (i > 0) bytes_read += i;
         }
 #ifdef NO_SHUTDOWN
         SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);


### PR DESCRIPTION
This resolves the s_time retry issue in general, but also the specific case where a TLS 1.3 server sends a post-handshake NewSessionTicket message prior to appdata.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
