### PR TITLE
Fix HRR with early_data

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -678,6 +678,11 @@ int tls_parse_ctos_early_data(SSL *s, PACKET *pkt, unsigned int context,
         return 0;
     }
 
+    if (s->hello_retry_request) {
+        *al = SSL_AD_ILLEGAL_PARAMETER;
+        return 0;
+    }
+
     return 1;
 }
 

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -157,13 +157,8 @@ int ossl_statem_skip_early_data(SSL *s)
     if (s->ext.early_data != SSL_EARLY_DATA_REJECTED)
         return 0;
 
-    if (s->hello_retry_request) {
-        if (s->statem.hand_state != TLS_ST_SW_HELLO_RETRY_REQUEST)
-            return 0;
-    } else {
-        if (!s->server || s->statem.hand_state != TLS_ST_EARLY_DATA)
-            return 0;
-    }
+    if (!s->server || s->statem.hand_state != TLS_ST_EARLY_DATA)
+        return 0;
 
     return 1;
 }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1571,6 +1571,13 @@ static MSG_PROCESS_RETURN tls_process_hello_retry_request(SSL *s, PACKET *pkt)
 
     s->hello_retry_request = 1;
 
+    /*
+     * If we were sending early_data then the enc_write_ctx is now invalid and
+     * should not be used.
+     */
+    EVP_CIPHER_CTX_free(s->enc_write_ctx);
+    s->enc_write_ctx = NULL;
+
     /* This will fail if it doesn't choose TLSv1.3+ */
     errorcode = ssl_choose_client_version(s, sversion, 0, &al);
     if (errorcode != 0) {


### PR DESCRIPTION
Early Data after an HRR is not allowed. We failed to handle that scenario correctly (s_client would hang). This fixes it and adds a test.

I swear this *used* to work!!

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
