### PR TITLE
Fix gcc 7 warnings in 1.1.0

### DIFF
--- a/apps/engine.c
+++ b/apps/engine.c
@@ -311,6 +311,7 @@ int engine_main(int argc, char **argv)
             break;
         case OPT_TT:
             test_avail_noise++;
+            /* fall thru */
         case OPT_T:
             test_avail++;
             break;

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -282,6 +282,7 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         switch (cert_error) {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
+            /* fall thru */
         case X509_V_ERR_CERT_HAS_EXPIRED:
 
             /*

--- a/crypto/bf/bf_locl.h
+++ b/crypto/bf/bf_locl.h
@@ -17,12 +17,19 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 7: l2|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 6: l2|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 5: l2|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall thru */                              \
                         case 4: l1 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 3: l1|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
                                 } \
                         }
@@ -32,12 +39,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)    )&0xff); \
+                        /* fall thru */                                    \
                         case 7: *(--(c))=(unsigned char)(((l2)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 6: *(--(c))=(unsigned char)(((l2)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 5: *(--(c))=(unsigned char)(((l2)>>24)&0xff); \
+                        /* fall thru */                                    \
                         case 4: *(--(c))=(unsigned char)(((l1)    )&0xff); \
+                        /* fall thru */                                    \
                         case 3: *(--(c))=(unsigned char)(((l1)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
                                 } \
                         }

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -258,6 +258,7 @@ _dopr(char **sbuffer,
                 break;
             case 'E':
                 flags |= DP_F_UP;
+                /* fall thru */
             case 'e':
                 if (cflags == DP_C_LDOUBLE)
                     fvalue = va_arg(args, LDOUBLE);
@@ -269,6 +270,7 @@ _dopr(char **sbuffer,
                 break;
             case 'G':
                 flags |= DP_F_UP;
+                /* fall thru */
             case 'g':
                 if (cflags == DP_C_LDOUBLE)
                     fvalue = va_arg(args, LDOUBLE);

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -144,6 +144,7 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
     switch (cmd) {
     case BIO_CTRL_RESET:
         num = 0;
+        /* fall thru */
     case BIO_C_FILE_SEEK:
         ret = (long)UP_lseek(b->num, num, 0);
         break;

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -295,10 +295,13 @@ static BN_ULONG *bn_expand_internal(const BIGNUM *b, int words)
         switch (b->top & 3) {
         case 3:
             A[2] = B[2];
+            /* fall thru */
         case 2:
             A[1] = B[1];
+            /* fall thru */
         case 1:
             A[0] = B[0];
+            /* fall thru */
         case 0:
             /* Without the "case 0" some old optimizers got this wrong. */
             ;
@@ -390,10 +393,13 @@ BIGNUM *BN_copy(BIGNUM *a, const BIGNUM *b)
     switch (b->top & 3) {
     case 3:
         A[2] = B[2];
+        /* fall thru */
     case 2:
         A[1] = B[1];
+        /* fall thru */
     case 1:
         A[0] = B[0];
+        /* fall thru */
     case 0:;
     }
 #else

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -115,10 +115,12 @@ BN_ULONG bn_sub_part_words(BN_ULONG *r,
                     r[1] = a[1];
                     if (--dl <= 0)
                         break;
+                    /* fall thru */
                 case 2:
                     r[2] = a[2];
                     if (--dl <= 0)
                         break;
+                    /* fall thru */
                 case 3:
                     r[3] = a[3];
                     if (--dl <= 0)
@@ -206,10 +208,12 @@ BN_ULONG bn_add_part_words(BN_ULONG *r,
                     r[1] = b[1];
                     if (++dl >= 0)
                         break;
+                    /* fall thru */
                 case 2:
                     r[2] = b[2];
                     if (++dl >= 0)
                         break;
+                    /* fall thru */
                 case 3:
                     r[3] = b[3];
                     if (++dl >= 0)
@@ -276,10 +280,12 @@ BN_ULONG bn_add_part_words(BN_ULONG *r,
                     r[1] = a[1];
                     if (--dl <= 0)
                         break;
+                    /* fall thru */
                 case 2:
                     r[2] = a[2];
                     if (--dl <= 0)
                         break;
+                    /* fall thru */
                 case 3:
                     r[3] = a[3];
                     if (--dl <= 0)

--- a/crypto/cast/cast_lcl.h
+++ b/crypto/cast/cast_lcl.h
@@ -64,12 +64,19 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 7: l2|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 6: l2|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 5: l2|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall thru */                              \
                         case 4: l1 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 3: l1|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
                                 } \
                         }
@@ -79,12 +86,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)    )&0xff); \
+                        /* fall thru */                                    \
                         case 7: *(--(c))=(unsigned char)(((l2)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 6: *(--(c))=(unsigned char)(((l2)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 5: *(--(c))=(unsigned char)(((l2)>>24)&0xff); \
+                        /* fall thru */                                    \
                         case 4: *(--(c))=(unsigned char)(((l1)    )&0xff); \
+                        /* fall thru */                                    \
                         case 3: *(--(c))=(unsigned char)(((l1)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
                                 } \
                         }

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -292,6 +292,7 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     case ASN1_OP_STREAM_PRE:
         if (CMS_stream(&sarg->boundary, cms) <= 0)
             return 0;
+        /* fall thru */
     case ASN1_OP_DETACHED_PRE:
         sarg->ndef_bio = CMS_dataInit(cms, sarg->out);
         if (!sarg->ndef_bio)

--- a/crypto/des/des_locl.h
+++ b/crypto/des/des_locl.h
@@ -41,13 +41,20 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((DES_LONG)(*(--(c))))<<24L; \
+                        /* fall thru */                          \
                         case 7: l2|=((DES_LONG)(*(--(c))))<<16L; \
+                        /* fall thru */                          \
                         case 6: l2|=((DES_LONG)(*(--(c))))<< 8L; \
-                        case 5: l2|=((DES_LONG)(*(--(c))));     \
+                        /* fall thru */                          \
+                        case 5: l2|=((DES_LONG)(*(--(c))));      \
+                        /* fall thru */                          \
                         case 4: l1 =((DES_LONG)(*(--(c))))<<24L; \
+                        /* fall thru */                          \
                         case 3: l1|=((DES_LONG)(*(--(c))))<<16L; \
+                        /* fall thru */                          \
                         case 2: l1|=((DES_LONG)(*(--(c))))<< 8L; \
-                        case 1: l1|=((DES_LONG)(*(--(c))));     \
+                        /* fall thru */                          \
+                        case 1: l1|=((DES_LONG)(*(--(c))));      \
                                 } \
                         }
 
@@ -77,12 +84,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)>>24L)&0xff); \
+                        /* fall thru */                                     \
                         case 7: *(--(c))=(unsigned char)(((l2)>>16L)&0xff); \
+                        /* fall thru */                                     \
                         case 6: *(--(c))=(unsigned char)(((l2)>> 8L)&0xff); \
+                        /* fall thru */                                     \
                         case 5: *(--(c))=(unsigned char)(((l2)     )&0xff); \
+                        /* fall thru */                                     \
                         case 4: *(--(c))=(unsigned char)(((l1)>>24L)&0xff); \
+                        /* fall thru */                                     \
                         case 3: *(--(c))=(unsigned char)(((l1)>>16L)&0xff); \
+                        /* fall thru */                                     \
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
+                        /* fall thru */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
                                 } \
                         }

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1978,6 +1978,7 @@ static int aes_ccm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 
     case EVP_CTRL_AEAD_SET_IVLEN:
         arg = 15 - arg;
+        /* fall thru */
     case EVP_CTRL_CCM_SET_L:
         if (arg < 2 || arg > 8)
             return 0;

--- a/crypto/idea/idea_lcl.h
+++ b/crypto/idea/idea_lcl.h
@@ -38,12 +38,19 @@ else \
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 7: l2|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 6: l2|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 5: l2|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall thru */                              \
                         case 4: l1 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 3: l1|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
                                 } \
                         }
@@ -53,12 +60,19 @@ else \
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)    )&0xff); \
+                        /* fall thru */                                    \
                         case 7: *(--(c))=(unsigned char)(((l2)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 6: *(--(c))=(unsigned char)(((l2)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 5: *(--(c))=(unsigned char)(((l2)>>24)&0xff); \
+                        /* fall thru */                                    \
                         case 4: *(--(c))=(unsigned char)(((l1)    )&0xff); \
+                        /* fall thru */                                    \
                         case 3: *(--(c))=(unsigned char)(((l1)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
                                 } \
                         }

--- a/crypto/ocsp/ocsp_ht.c
+++ b/crypto/ocsp/ocsp_ht.c
@@ -298,10 +298,12 @@ int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx)
         }
         rctx->state = OHS_ASN1_WRITE_INIT;
 
+        /* fall thru */
     case OHS_ASN1_WRITE_INIT:
         rctx->asn1_len = BIO_get_mem_data(rctx->mem, NULL);
         rctx->state = OHS_ASN1_WRITE;
 
+        /* fall thru */
     case OHS_ASN1_WRITE:
         n = BIO_get_mem_data(rctx->mem, &p);
 
@@ -323,6 +325,7 @@ int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx)
 
         (void)BIO_reset(rctx->mem);
 
+        /* fall thru */
     case OHS_ASN1_FLUSH:
 
         i = BIO_flush(rctx->io);

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -120,6 +120,7 @@ static int do_blob_header(const unsigned char **in, unsigned int length,
 
     case MS_DSS1MAGIC:
         *pisdss = 1;
+        /* fall thru */
     case MS_RSA1MAGIC:
         if (*pispub == 0) {
             PEMerr(PEM_F_DO_BLOB_HEADER, PEM_R_EXPECTING_PRIVATE_KEY_BLOB);
@@ -129,6 +130,7 @@ static int do_blob_header(const unsigned char **in, unsigned int length,
 
     case MS_DSS2MAGIC:
         *pisdss = 1;
+        /* fall thru */
     case MS_RSA2MAGIC:
         if (*pispub == 1) {
             PEMerr(PEM_F_DO_BLOB_HEADER, PEM_R_EXPECTING_PUBLIC_KEY_BLOB);

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -40,6 +40,7 @@ static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     case ASN1_OP_STREAM_PRE:
         if (PKCS7_stream(&sarg->boundary, *pp7) <= 0)
             return 0;
+        /* fall thru */
     case ASN1_OP_DETACHED_PRE:
         sarg->ndef_bio = PKCS7_dataInit(*pp7, sarg->out);
         if (!sarg->ndef_bio)

--- a/crypto/rc2/rc2_locl.h
+++ b/crypto/rc2/rc2_locl.h
@@ -20,13 +20,20 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))<<24L; \
+                        /* fall thru */                               \
                         case 7: l2|=((unsigned long)(*(--(c))))<<16L; \
+                        /* fall thru */                               \
                         case 6: l2|=((unsigned long)(*(--(c))))<< 8L; \
-                        case 5: l2|=((unsigned long)(*(--(c))));     \
+                        /* fall thru */                               \
+                        case 5: l2|=((unsigned long)(*(--(c))));      \
+                        /* fall thru */                               \
                         case 4: l1 =((unsigned long)(*(--(c))))<<24L; \
+                        /* fall thru */                               \
                         case 3: l1|=((unsigned long)(*(--(c))))<<16L; \
+                        /* fall thru */                               \
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8L; \
-                        case 1: l1|=((unsigned long)(*(--(c))));     \
+                        /* fall thru */                               \
+                        case 1: l1|=((unsigned long)(*(--(c))));      \
                                 } \
                         }
 
@@ -42,12 +49,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)>>24L)&0xff); \
+                        /* fall thru */                                     \
                         case 7: *(--(c))=(unsigned char)(((l2)>>16L)&0xff); \
+                        /* fall thru */                                     \
                         case 6: *(--(c))=(unsigned char)(((l2)>> 8L)&0xff); \
+                        /* fall thru */                                     \
                         case 5: *(--(c))=(unsigned char)(((l2)     )&0xff); \
+                        /* fall thru */                                     \
                         case 4: *(--(c))=(unsigned char)(((l1)>>24L)&0xff); \
+                        /* fall thru */                                     \
                         case 3: *(--(c))=(unsigned char)(((l1)>>16L)&0xff); \
+                        /* fall thru */                                     \
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
+                        /* fall thru */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
                                 } \
                         }
@@ -58,12 +72,19 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 7: l2|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 6: l2|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 5: l2|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall thru */                              \
                         case 4: l1 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 3: l1|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
                                 } \
                         }
@@ -73,12 +94,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)    )&0xff); \
+                        /* fall thru */                                    \
                         case 7: *(--(c))=(unsigned char)(((l2)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 6: *(--(c))=(unsigned char)(((l2)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 5: *(--(c))=(unsigned char)(((l2)>>24)&0xff); \
+                        /* fall thru */                                    \
                         case 4: *(--(c))=(unsigned char)(((l1)    )&0xff); \
+                        /* fall thru */                                    \
                         case 3: *(--(c))=(unsigned char)(((l1)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
                                 } \
                         }

--- a/crypto/rc5/rc5_locl.h
+++ b/crypto/rc5/rc5_locl.h
@@ -22,13 +22,20 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))<<24L; \
+                        /* fall thru */                               \
                         case 7: l2|=((unsigned long)(*(--(c))))<<16L; \
+                        /* fall thru */                               \
                         case 6: l2|=((unsigned long)(*(--(c))))<< 8L; \
-                        case 5: l2|=((unsigned long)(*(--(c))));     \
+                        /* fall thru */                               \
+                        case 5: l2|=((unsigned long)(*(--(c))));      \
+                        /* fall thru */                               \
                         case 4: l1 =((unsigned long)(*(--(c))))<<24L; \
+                        /* fall thru */                               \
                         case 3: l1|=((unsigned long)(*(--(c))))<<16L; \
+                        /* fall thru */                               \
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8L; \
-                        case 1: l1|=((unsigned long)(*(--(c))));     \
+                        /* fall thru */                               \
+                        case 1: l1|=((unsigned long)(*(--(c))));      \
                                 } \
                         }
 
@@ -44,12 +51,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)>>24L)&0xff); \
+                        /* fall thru */                                     \
                         case 7: *(--(c))=(unsigned char)(((l2)>>16L)&0xff); \
+                        /* fall thru */                                     \
                         case 6: *(--(c))=(unsigned char)(((l2)>> 8L)&0xff); \
+                        /* fall thru */                                     \
                         case 5: *(--(c))=(unsigned char)(((l2)     )&0xff); \
+                        /* fall thru */                                     \
                         case 4: *(--(c))=(unsigned char)(((l1)>>24L)&0xff); \
+                        /* fall thru */                                     \
                         case 3: *(--(c))=(unsigned char)(((l1)>>16L)&0xff); \
+                        /* fall thru */                                     \
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
+                        /* fall thru */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
                                 } \
                         }
@@ -60,12 +74,19 @@
                         l1=l2=0; \
                         switch (n) { \
                         case 8: l2 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 7: l2|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 6: l2|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 5: l2|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall thru */                              \
                         case 4: l1 =((unsigned long)(*(--(c))))    ; \
+                        /* fall thru */                              \
                         case 3: l1|=((unsigned long)(*(--(c))))<< 8; \
+                        /* fall thru */                              \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
+                        /* fall thru */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
                                 } \
                         }
@@ -75,12 +96,19 @@
                         c+=n; \
                         switch (n) { \
                         case 8: *(--(c))=(unsigned char)(((l2)    )&0xff); \
+                        /* fall thru */                                    \
                         case 7: *(--(c))=(unsigned char)(((l2)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 6: *(--(c))=(unsigned char)(((l2)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 5: *(--(c))=(unsigned char)(((l2)>>24)&0xff); \
+                        /* fall thru */                                    \
                         case 4: *(--(c))=(unsigned char)(((l1)    )&0xff); \
+                        /* fall thru */                                    \
                         case 3: *(--(c))=(unsigned char)(((l1)>> 8)&0xff); \
+                        /* fall thru */                                    \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
+                        /* fall thru */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
                                 } \
                         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2717,6 +2717,7 @@ static int ssl_check_clienthello_tlsext_early(SSL *s)
 
     case SSL_TLSEXT_ERR_NOACK:
         s->servername_done = 0;
+        /* fall thru */
     default:
         return 1;
     }
@@ -2904,6 +2905,7 @@ int ssl_check_serverhello_tlsext(SSL *s)
 
     case SSL_TLSEXT_ERR_NOACK:
         s->servername_done = 0;
+        /* fall thru */
     default:
         return 1;
     }


### PR DESCRIPTION
master & 1.0.2 have these "fall thru" comments already,
but I somehow missed 1.1.0 :-(