### PR TITLE
Fix bogus uses of BIO_sock_should_retry

### DIFF
--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -215,7 +215,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
         if (type == SOCK_STREAM) {
             do {
                 sock = BIO_accept_ex(asock, NULL, 0);
-            } while (sock < 0 && BIO_sock_should_retry(ret));
+            } while (sock < 0 && BIO_sock_should_retry(sock));
             if (sock < 0) {
                 ERR_print_errors(bio_err);
                 BIO_closesocket(asock);


### PR DESCRIPTION
Hi this applies to all branches (except the hunk in do_server which is not needed for 1.0.2).