### PR TITLE
RSA_padding_check_PKCS1_type_2 is not constant time.

### DIFF
--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -105,6 +105,13 @@ The RSA_padding_check_xxx() functions return the length of the
 recovered data, -1 on error. Error codes can be obtained by calling
 L<ERR_get_error(3)>.
 
+=head1 WARNING
+
+The RSA_padding_check_PKCS1_type_2() padding check leaks timing
+information which can potentially be used to mount a Bleichenbacher
+padding oracle attack. This is an inherent weakness in the PKCS #1
+v1.5 padding design. Prefer PKCS1_OAEP padding.
+
 =head1 SEE ALSO
 
 L<RSA_public_encrypt(3)>,

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -67,6 +67,13 @@ recovered plaintext.
 On error, -1 is returned; the error codes can be
 obtained by L<ERR_get_error(3)>.
 
+=head1 WARNING
+
+Decryption failures in the RSA_PKCS1_PADDING mode leak information
+which can potentially be used to mount a Bleichenbacher padding oracle
+attack. This is an inherent weakness in the PKCS #1 v1.5 padding
+design. Prefer RSA_PKCS1_OAEP_PADDING.
+
 =head1 CONFORMING TO
 
 SSL, PKCS #1 v2.0


### PR DESCRIPTION
This is an inherent weakness of the padding mode. We can't make the
implementation constant time (see the comments in rsa_pk1.c), so add a
warning to the docs.
