### PR TITLE
Fix SSL_clear() for TLSv1.3

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -566,10 +566,12 @@ int SSL_clear(SSL *s)
 
     /*
      * Check to see if we were changed into a different method, if so, revert
-     * back if we are not doing session-id reuse.
+     * back. We always do this in TLSv1.3. Below that we only do it if we are
+     * not doing session-id reuse.
      */
-    if (!ossl_statem_get_in_handshake(s) && (s->session == NULL)
-        && (s->method != s->ctx->method)) {
+    if (s->method != s->ctx->method
+            && (SSL_IS_TLS13(s)
+                || (!ossl_statem_get_in_handshake(s) && s->session == NULL))) {
         s->method->ssl_free(s);
         s->method = s->ctx->method;
         if (!s->method->ssl_new(s))

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -566,12 +566,9 @@ int SSL_clear(SSL *s)
 
     /*
      * Check to see if we were changed into a different method, if so, revert
-     * back. We always do this in TLSv1.3. Below that we only do it if we are
-     * not doing session-id reuse.
+     * back.
      */
-    if (s->method != s->ctx->method
-            && (SSL_IS_TLS13(s)
-                || (!ossl_statem_get_in_handshake(s) && s->session == NULL))) {
+    if (s->method != s->ctx->method) {
         s->method->ssl_free(s);
         s->method = s->ctx->method;
         if (!s->method->ssl_new(s))


### PR DESCRIPTION
SSL_clear() does not reset the SSL_METHOD if a session already exists in
the SSL object. However, TLSv1.3 does not have an externally visible
version fixed method (only an internal one). The state machine assumes
that we are always starting from a version flexible method for TLSv1.3.
The simplest solution is to just fix SSL_clear() to always reset the method
if it is using the internal TLSv1.3 version fixed method.

[Aside: SSL_clear() is a horrendous abomination that should be deprecated at some point in the future]
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
