### PR TITLE
Tolerate a zero length ticket nonce

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1259,10 +1259,6 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
     if (external) {
         psk = sess->master_key;
     } else {
-        if (sess->ext.tick_nonce == NULL) {
-            SSLerr(SSL_F_TLS_PSK_DO_BINDER, SSL_R_BAD_PSK);
-            goto err;
-        }
         psk = tmppsk;
         if (!tls13_hkdf_expand(s, md, sess->master_key,
                                (const unsigned char *)nonce_label,

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2422,7 +2422,6 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL *s, PACKET *pkt)
         || (SSL_IS_TLS13(s)
             && (!PACKET_get_net_4(pkt, &age_add)
                 || !PACKET_get_length_prefixed_1(pkt, &nonce)
-                || PACKET_remaining(&nonce) == 0
                 || !PACKET_memdup(&nonce, &s->session->ext.tick_nonce,
                                   &s->session->ext.tick_nonce_len)))
         || !PACKET_get_net_2(pkt, &ticklen)


### PR DESCRIPTION
TLSv1.3 draft-21 requires the ticket nonce to be at least 1 byte in length.
However NSS sends a zero length nonce. This is actually ok because the next
draft will allow zero length nonces anyway, so we should tolerate this.
