### PR TITLE
Document default section and library configuration

### DIFF
--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -64,7 +64,9 @@ file.
 To enable library configuration the default section needs to contain an
 appropriate line which points to the main configuration section. The default
 name is B<openssl_conf> which is used by the B<openssl> utility. Other
-applications may use an alternative name such as B<myapplicaton_conf>.
+applications may use an alternative name such as B<myapplication_conf>.
+All library configuration lines appear in the default section at the start
+of the configuration file.
 
 The configuration section should consist of a set of name value pairs which
 contain specific module configuration information. The B<name> represents
@@ -72,6 +74,7 @@ the name of the I<configuration module> the meaning of the B<value> is
 module specific: it may, for example, represent a further configuration
 section containing configuration module specific information. E.g.
 
+ # This must be in the default section
  openssl_conf = openssl_init
 
  [openssl_init]


### PR DESCRIPTION
It is talked around but not explicitly stated in one part of the
documentation that you should put library configuration lines at the
start of the configuration file.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
