### PR TITLE
Simplify the handling of shared library version numbers

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -183,7 +183,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         thread_scheme    => "pthreads",
         shared_target    => "solaris-shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 #### Solaris x86 with GNU C setups
     "solaris-x86-gcc" => {
@@ -333,7 +333,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "irix-shared",
         shared_ldflag    => "-mabi=n32",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "32",
     },
     "irix-mips3-cc" => {
@@ -350,7 +350,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "irix-shared",
         shared_ldflag    => "-n32",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "32",
     },
     # N64 ABI builds.
@@ -368,7 +368,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "irix-shared",
         shared_ldflag    => "-mabi=64",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "64",
     },
     "irix64-mips4-cc" => {
@@ -385,7 +385,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "irix-shared",
         shared_ldflag    => "-64",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "64",
     },
 
@@ -431,7 +431,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
-        shared_extension => ".sl.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".sl.\$(SHLIB_VERSION_NUMBER)",
     },
     "hpux-parisc1_1-gcc" => {
         inherit_from     => [ "hpux-parisc-gcc", asm("parisc11_asm") ],
@@ -451,7 +451,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "-fpic",
         shared_ldflag    => "-shared",
-        shared_extension => ".sl.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".sl.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/pa20_64",
     },
 
@@ -473,7 +473,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "+Z",
         shared_ldflag    => "-b",
-        shared_extension => ".sl.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".sl.\$(SHLIB_VERSION_NUMBER)",
     },
     "hpux-parisc1_1-cc" => {
         inherit_from     => [ "hpux-parisc-cc", asm("parisc11_asm") ],
@@ -494,7 +494,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "+Z",
         shared_ldflag    => "+DD64 -b",
-        shared_extension => ".sl.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".sl.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/pa20_64",
     },
 
@@ -513,7 +513,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "+Z",
         shared_ldflag    => "+DD32 -b",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux32",
     },
     # Frank Geurts <frank.geurts@nl.abnamro.com> has patiently assisted
@@ -532,7 +532,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "+Z",
         shared_ldflag    => "+DD64 -b",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux64",
     },
     # GCC builds...
@@ -550,7 +550,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "-fpic",
         shared_ldflag    => "-shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux32",
     },
     "hpux64-ia64-gcc" => {
@@ -567,7 +567,7 @@ sub vms_info {
         shared_target    => "hpux-shared",
         shared_cflag     => "-fpic",
         shared_ldflag    => "-mlp64 -shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux64",
     },
 
@@ -632,7 +632,7 @@ sub vms_info {
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC -DOPENSSL_USE_NODELETE",
         shared_ldflag    => "-Wl,-znodelete",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "linux-generic64" => {
         inherit_from     => [ "linux-generic32" ],
@@ -874,7 +874,7 @@ sub vms_info {
         shared_target    => "linux-shared",
         shared_cflag     => "--pic",
         shared_ldflag    => add("-z --sysv --shared"),
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         ranlib           => "true",
     },
 
@@ -990,7 +990,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "BSD-generic64" => {
         inherit_from     => [ "BSD-generic32" ],
@@ -1046,7 +1046,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
     "nextstep" => {
@@ -1080,7 +1080,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "QNX6-i386" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
@@ -1090,7 +1090,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
 #### SCO/Caldera targets.
@@ -1133,7 +1133,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "svr5-shared",
         shared_cflag     => "-Kpic",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "unixware-7-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
@@ -1147,7 +1147,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "gnu-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 # SCO 5 - Ben Laurie <ben@algroup.co.uk> says the -O breaks the SCO cc.
     "sco5-cc" => {
@@ -1160,7 +1160,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "svr3-shared",
         shared_cflag     => "-Kpic",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "sco5-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
@@ -1173,7 +1173,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "svr3-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
 #### IBM's AIX.
@@ -1196,7 +1196,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "aix-shared",
         shared_ldflag    => "-shared -static-libgcc -Wl,-G",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         arflags          => "-X32",
     },
     "aix64-gcc" => {
@@ -1213,7 +1213,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "aix-shared",
         shared_ldflag    => "-maix64 -shared -static-libgcc -Wl,-G",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         arflags          => "-X64",
     },
     "aix-cc" => {
@@ -1231,7 +1231,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "aix-shared",
         shared_ldflag    => "-q32 -G",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         arflags          => "-X 32",
     },
     "aix64-cc" => {
@@ -1249,7 +1249,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "aix-shared",
         shared_ldflag    => "-q64 -G",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         arflags          => "-X 64",
     },
 
@@ -1593,7 +1593,7 @@ sub vms_info {
         shared_target    => "darwin-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-dynamiclib",
-        shared_extension => ".\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+        shared_extension => ".\$(SHLIB_VERSION_NUMBER).dylib",
     },
     # Option "freeze" such as -std=gnu9x can't negatively interfere
     # with future defaults for below two targets, because MacOS X
@@ -1677,7 +1677,7 @@ sub vms_info {
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
 ##### VxWorks for various targets
@@ -1757,7 +1757,7 @@ sub vms_info {
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         ranlib           => "$ENV{'RANLIB'}",
     },
     "uClinux-dist64" => {
@@ -1773,7 +1773,7 @@ sub vms_info {
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         ranlib           => "$ENV{'RANLIB'}",
     },
 

--- a/Configurations/50-haiku.conf
+++ b/Configurations/50-haiku.conf
@@ -14,7 +14,7 @@
         shared_target    => "gnu-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "haiku-x86" => {
         inherit_from     => [ "haiku-common", asm("x86_elf_asm") ],

--- a/Configurations/90-team.conf
+++ b/Configurations/90-team.conf
@@ -26,7 +26,7 @@
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-m64",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "64",
     },
     "debug-linux-pentium" => {
@@ -74,7 +74,7 @@
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "dist" => {
         cc               => "cc",
@@ -92,7 +92,7 @@
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "darwin64-debug-test-64-clang" => {
         inherit_from     => [ "x86_64_asm" ],
@@ -107,6 +107,6 @@
         shared_target    => "darwin-shared",
         shared_cflag     => "-fPIC -fno-common",
         shared_ldflag    => "-arch x86_64 -dynamiclib",
-        shared_extension => ".\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+        shared_extension => ".\$(SHLIB_VERSION_NUMBER).dylib",
     },
 );

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -9,7 +9,7 @@
   our $osslprefix = 'OSSL$';
   (our $osslprefix_q = $osslprefix) =~ s/\$/\\\$/;
 
-  our $sover = sprintf "%02d%02d", $config{shlib_major}, $config{shlib_minor};
+  our $sover_dirname = sprintf "%02d%02d", split(/\./, $config{shlib_version_number});
   our $osslver = sprintf "%02d%02d", split(/\./, $config{version});
 
   our $sourcedir = $config{sourcedir};
@@ -169,7 +169,7 @@ OPENSSLDIR={- catdir($config{openssldir}) or
 # The same, but for C
 OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 # Where installed engines reside, for C
-ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover.$target{pointer_size} -}:
+ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
 CC= {- $target{cc} -}
 CFLAGS= /DEFINE=({- join(",", @{$target{defines}}, @{$config{defines}},"OPENSSLDIR=\"\"\"\$(OPENSSLDIR_C)\"\"\"","ENGINESDIR=\"\"\"\$(ENGINESDIR_C)\"\"\"") -}) {- $target{cflags} -} {- $config{cflags} -}
@@ -442,9 +442,9 @@ install_runtime : install_shared _install_runtime_ns
 install_engines : check_INSTALLTOP
         @ {- output_off() unless scalar @{$unified_info{engines}}; "" -} !
         @ WRITE SYS$OUTPUT "*** Installing engines"
-        - CREATE/DIR ossl_installroot:[ENGINES{- $sover.$target{pointer_size} -}.'arch']
+        - CREATE/DIR ossl_installroot:[ENGINES{- $sover_dirname.$target{pointer_size} -}.'arch']
         {- join("\n        ",
-                map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover$target{pointer_size}.'arch']" }
+                map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover_dirname$target{pointer_size}.'arch']" }
                 @{$unified_info{install}->{engines}}) -}
         @ {- output_on() unless scalar @{$unified_info{engines}}; "" -} !
 
@@ -497,6 +497,7 @@ vmsconfig.pm : configdata.pm
         WRITE CONFIG "our %config = ("
         WRITE CONFIG "  target => '","{- $config{target} -}","',"
         WRITE CONFIG "  version => '","{- $config{version} -}","',"
+        WRITE CONFIG "  shlib_version_number => '","{- $config{shlib_version_number} -}","',"
         WRITE CONFIG "  shlib_major => '","{- $config{shlib_major} -}","',"
         WRITE CONFIG "  shlib_minor => '","{- $config{shlib_minor} -}","',"
         WRITE CONFIG "  no_shared => '","{- $disabled{shared} -}","',"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -14,9 +14,9 @@
 
      sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw)/ }
 
-     our $sover = $config{target} =~ /^mingw/
-         ? $config{shlib_major}."_".$config{shlib_minor}
-         : $config{shlib_major}.".".$config{shlib_minor};
+     our $sover_dirname = $config{shlib_version_number};
+     $sover_dirname =~ s|\.|_|g
+         if $config{target} =~ /^mingw/;
 
      # shlib and shlib_simple both take a static library name and figure
      # out what the shlib name should be.
@@ -40,16 +40,16 @@
      sub shlib {
          my $lib = shift;
          return () if $disabled{shared} || $lib =~ /\.a$/;
-         return $unified_info{sharednames}->{$lib} . $shlibext;
+         return $unified_info{sharednames}->{$lib} . '$(SHLIB_EXT)';
      }
      sub shlib_simple {
          my $lib = shift;
          return () if $disabled{shared} || $lib =~ /\.a$/;
 
          if (windowsdll()) {
-             return $lib . $shlibextimport;
+             return $lib . '$(SHLIB_EXT_IMPORT)';
          }
-         return $lib .  $shlibextsimple;
+         return $lib .  '$(SHLIB_EXT_SIMPLE)';
      }
 
      # Easy fixing of static library names
@@ -89,6 +89,9 @@ SHLIB_VERSION_HISTORY={- $config{shlib_version_history} -}
 SHLIB_MAJOR={- $config{shlib_major} -}
 SHLIB_MINOR={- $config{shlib_minor} -}
 SHLIB_TARGET={- $target{shared_target} -}
+SHLIB_EXT={- $shlibext -}
+SHLIB_EXT_SIMPLE={- $shlibextsimple -}
+SHLIB_EXT_IMPORT={- $shlibextimport -}
 
 LIBS={- join(" ", map { lib($_) } @{$unified_info{libraries}}) -}
 SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{libraries}}) -}
@@ -160,7 +163,7 @@ LIBDIR={- #
           our $libdir = $config{libdir} || "lib$multilib";
           $libdir -}
 ENGINESDIR={- use File::Spec::Functions;
-              catdir($prefix,$libdir,"engines-$sover") -}
+              catdir($prefix,$libdir,"engines-$sover_dirname") -}
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications
@@ -722,7 +725,7 @@ libcrypto.pc:
 	    echo 'exec_prefix=$${prefix}'; \
 	    echo 'libdir=$${exec_prefix}/$(LIBDIR)'; \
 	    echo 'includedir=$${prefix}/include'; \
-	    echo 'enginesdir=$${libdir}/engines-{- $sover -}'; \
+	    echo 'enginesdir=$${libdir}/engines-{- $sover_dirname -}'; \
 	    echo ''; \
 	    echo 'Name: OpenSSL-libcrypto'; \
 	    echo 'Description: OpenSSL cryptography library'; \
@@ -937,8 +940,8 @@ EOF
 # With all other Unix platforms, we often build a shared library with the
 # SO version built into the file name and a symlink without the SO version
 # It's not necessary to have both as targets.  The choice falls on the
-# simplest, {libname}$shlibextimport for Windows POSIX layers and
-# {libname}$shlibextsimple for the Unix platforms.
+# simplest, {libname}\$(SHLIB_EXT_IMPORT) for Windows POSIX layers and
+# {libname}\$(SHLIB_EXT_SIMPLE) for the Unix platforms.
 $target: $lib$libext $deps $ordinalsfile
 	\$(MAKE) -f \$(SRCDIR)/Makefile.shared -e \\
 		ECHO=\$(ECHO) \\
@@ -946,7 +949,7 @@ $target: $lib$libext $deps $ordinalsfile
 		PERL="\$(PERL)" SRCDIR='\$(SRCDIR)' DSTDIR="$libd" \\
 		INSTALLTOP='\$(INSTALLTOP)' LIBDIR='\$(LIBDIR)' \\
 		LIBDEPS='\$(PLIB_LDFLAGS) '"$linklibs"' \$(EX_LIBS)' \\
-		LIBNAME=$libname SHLIBVERSION=\$(SHLIB_MAJOR).\$(SHLIB_MINOR) \\
+		LIBNAME=$libname SHLIBVERSION=\$(SHLIB_VERSION_NUMBER) \\
 		STLIBNAME=$lib$libext \\
 		SHLIBNAME=$target SHLIBNAME_FULL=$target_full \\
 		CC='\$(CC)' CFLAGS='\$(CFLAGS) \$(LIB_CFLAGS)' \\
@@ -955,10 +958,10 @@ $target: $lib$libext $deps $ordinalsfile
 		link_shlib.$shlib_target
 EOF
 	  . (windowsdll() ? <<"EOF" : "");
-	rm -f apps/$shlib$shlibext
-	rm -f test/$shlib$shlibext
-	cp -p $shlib$shlibext apps/
-	cp -p $shlib$shlibext test/
+	rm -f apps/$shlib'\$(SHLIB_EXT)'
+	rm -f test/$shlib'\$(SHLIB_EXT)'
+	cp -p $shlib'\$(SHLIB_EXT)' apps/
+	cp -p $shlib'\$(SHLIB_EXT)' test/
 EOF
   }
   sub obj2dso {

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -11,7 +11,7 @@
  our $shlibextimport = $target{shared_import_extension} || ".lib";
  our $dsoext = $target{dso_extension} || ".dll";
 
- our $sover = $config{shlib_major}."_".$config{shlib_minor};
+ (our $sover_dirname = $config{shlib_version_number}) =~ s|\.|_|g;
 
  my $win_installenv =
      $target{build_scheme}->[2] eq "VC-W32" ?
@@ -142,7 +142,7 @@ OPENSSLDIR_dir={- $openssldir_dir -}
 LIBDIR={- our $libdir = $config{libdir} || "lib";
           $libdir -}
 ENGINESDIR_dev={- use File::Spec::Functions qw(:DEFAULT splitpath);
-                  our $enginesdir = catdir($prefix,$libdir,"engines-$sover");
+                  our $enginesdir = catdir($prefix,$libdir,"engines-$sover_dirname");
                   our ($enginesdir_dev, $enginesdir_dir, $enginesdir_file) =
                       splitpath($enginesdir, 1);
                   $enginesdir_dev -}

--- a/Configure
+++ b/Configure
@@ -992,7 +992,7 @@ $target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
 $target{exe_extension}=".pm"  if ($config{target} =~ /vos/);
 
 ($target{shared_extension_simple}=$target{shared_extension})
-    =~ s|\.\$\(SHLIB_MAJOR\)\.\$\(SHLIB_MINOR\)||;
+    =~ s|\.\$\(SHLIB_VERSION_NUMBER\)||;
 $target{dso_extension}=$target{shared_extension_simple};
 ($target{shared_import_extension}=$target{shared_extension_simple}.".a")
     if ($config{target} =~ /^(?:Cygwin|mingw)/);

--- a/VMS/openssl_shutdown.com.in
+++ b/VMS/openssl_shutdown.com.in
@@ -26,7 +26,7 @@ $	ENDIF
 $
 $	! Abbrevs
 $	DEAS := DEASSIGN /NOLOG 'P1'
-$	sv   := {- sprintf "%02d%02d", $config{shlib_major}, $config{shlib_minor} -}
+$	sv   := {- sprintf "%02d%02d", split m|\.|, $config{shlib_version_number} -}
 $	pz   := {- $config{pointer_size} -}
 $
 $	DEAS OSSL$DATAROOT

--- a/VMS/openssl_startup.com.in
+++ b/VMS/openssl_startup.com.in
@@ -88,7 +88,7 @@ $
 $	! Abbrevs
 $	DEFT := DEFINE /TRANSLATION=CONCEALED /NOLOG 'P1'
 $	DEF  := DEFINE /NOLOG 'P1'
-$	sv   := {- sprintf "%02d%02d", $config{shlib_major}, $config{shlib_minor} -}
+$	sv   := {- sprintf "%02d%02d", split m|\.|, $config{shlib_version_number} -}
 $	pz   := {- $config{pointer_size} -}
 $
 $	DEFT OSSL$DATAROOT		'OPENSSLDIR_']

--- a/build.info
+++ b/build.info
@@ -1,3 +1,13 @@
+{-
+     our $sover = $config{shlib_version_number};
+     our $sover_filename = $sover;
+     $sover_filename =~ s|\.|_|g
+         if $config{target} =~ /^mingw/ || $config{target} =~ /^VC-/;
+     $sover_filename =
+         sprintf "%02d%02d", split m|\.|, $config{shlib_version_number}
+         if $config{target} =~ /^vms/;
+     "";
+-}
 LIBS=libcrypto libssl
 ORDINALS[libcrypto]=crypto
 ORDINALS[libssl]=ssl
@@ -18,14 +28,14 @@ GENERATE[crypto/include/internal/dso_conf.h]=crypto/include/internal/dso_conf.h.
 
 
 IF[{- $config{target} =~ /^Cygwin/ -}]
- SHARED_NAME[libcrypto]=cygcrypto-{- $config{shlib_major}.".".$config{shlib_minor} -}
- SHARED_NAME[libssl]=cygssl-{- $config{shlib_major}.".".$config{shlib_minor} -}
+ SHARED_NAME[libcrypto]=cygcrypto-{- $sover_filename -}
+ SHARED_NAME[libssl]=cygssl-{- $sover_filename -}
 ELSIF[{- $config{target} =~ /^mingw/ -}]
- SHARED_NAME[libcrypto]=libcrypto-{- $config{shlib_major}."_".$config{shlib_minor} -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
- SHARED_NAME[libssl]=libssl-{- $config{shlib_major}."_".$config{shlib_minor} -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
+ SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
+ SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
 ELSIF[{- $config{target} =~ /^VC-/ -}]
- SHARED_NAME[libcrypto]=libcrypto-{- $config{shlib_major}."_".$config{shlib_minor} -}{- $target{multilib} -}
- SHARED_NAME[libssl]=libssl-{- $config{shlib_major}."_".$config{shlib_minor} -}{- $target{multilib} -}
+ SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $target{multilib} -}
+ SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $target{multilib} -}
 ENDIF
 
 # VMS has a cultural standard where all libraries are prefixed.
@@ -36,6 +46,6 @@ ENDIF
 IF[{- $config{target} =~ /^vms/ -}]
  RENAME[libcrypto]=ossl$libcrypto{- $target{pointer_size} -}
  RENAME[libssl]=ossl$libssl{- $target{pointer_size} -}
- SHARED_NAME[libcrypto]=ossl$libcrypto{- sprintf "%02d%02d", $config{shlib_major}, $config{shlib_minor} -}_shr{- $target{pointer_size} -}
- SHARED_NAME[libssl]=ossl$libssl{- sprintf "%02d%02d", $config{shlib_major}, $config{shlib_minor} -}_shr{- $target{pointer_size} -}
+ SHARED_NAME[libcrypto]=ossl$libcrypto{- $sover_filename -}_shr{- $target{pointer_size} -}
+ SHARED_NAME[libssl]=ossl$libssl{- $sover_filename -}_shr{- $target{pointer_size} -}
 ENDIF


### PR DESCRIPTION
$(SHLIB_MAJOR).$(SHLIB_MINOR) is really a synonym for
$(SHLIB_VERSION_NUMBER), and is therefore an added complexity,
so better to use $(SHLIB_VERSION_NUMBER) directly.  SHLIB_MAJOR and
SHLIB_MINOR are now unused, but are kept around purely as information
in case someone relies on their existence.

At the same time, add support for custom shared library extensions
with the three new Makefile variables SHLIB_EXT, SHLIB_EXT_SIMPLE and
SHLIB_EXT_IMPORT.  By default, they hold the variants of shared
library extensions we support.  On mingw and cygwin, SHLIB_EXT_IMPORT
is defined; on all other Unix platforms, it's empty.

An example to get shared libraries without SOVER is this:

    $ make SHLIB_VERSION_NUMBER= SHLIB_EXT=.so

Fixes #3902
