### PR TITLE
Add range-checking to RAND_DRBG_set_reseed_interval

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -328,11 +328,14 @@ int RAND_DRBG_set_callbacks(DRBG_CTX *dctx,
 }
 
 /*
- * Set the reseed internal. Used mainly for the KATs.
+ * Set the reseed interval. Used mainly for the KATs.
  */
-void RAND_DRBG_set_reseed_interval(DRBG_CTX *dctx, int interval)
+int RAND_DRBG_set_reseed_interval(DRBG_CTX *dctx, int interval)
 {
+    if (interval < 0 || interval > MAX_RESEED)
+        return 0;
     dctx->reseed_interval = interval;
+    return 1;
 }
 
 /*

--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -372,7 +372,7 @@ int ctr_init(DRBG_CTX *dctx)
     }
 
     dctx->max_request = 1 << 16;
-    dctx->reseed_interval = 1 << 24;
+    dctx->reseed_interval = MAX_RESEED;
     return 1;
 }
 

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -20,6 +20,9 @@
 /* we require 256 bits of randomness */
 # define RANDOMNESS_NEEDED (256 / 8)
 
+/* Maximum count allowed in reseeding */
+#define MAX_RESEED (1 << 24)
+
 /* DRBG status values */
 #define DRBG_STATUS_UNINITIALISED	0
 #define DRBG_STATUS_READY		1

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -35,7 +35,7 @@ int RAND_DRBG_set_callbacks(DRBG_CTX *dctx,
     void (*cleanup_nonce)(DRBG_CTX *ctx, unsigned char *out, size_t olen)
     );
 
-void RAND_DRBG_set_reseed_interval(DRBG_CTX *dctx, int interval);
+int RAND_DRBG_set_reseed_interval(DRBG_CTX *dctx, int interval);
 
 #define RAND_DRBG_get_ex_new_index(l, p, newf, dupf, freef) \
     CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DRBG, l, p, newf, dupf, freef)


### PR DESCRIPTION
As suggested by Kurt.

I used our initial MAX as the upper limit on reseed_internval.