### PR TITLE
DRBG tidying

### DIFF
--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -77,7 +77,7 @@ static void ctr_XOR(DRBG_CTR_CTX *cctx, const unsigned char *in, size_t inlen)
         /* Should never happen */
         n = 16;
     }
-    for (i = 0; i < 16; i++)
+    for (i = 0; i < n; i++)
         cctx->V[i] ^= in[i + cctx->keylen];
 }
 

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -68,16 +68,13 @@ struct drbg_ctx_st {
     DRBG_CTR_CTX ctr;
 
     /* entropy gathering function */
-    size_t (*get_entropy)(DRBG_CTX *ctx, unsigned char **pout,
-            int entropy, size_t min_len, size_t max_len);
+    RAND_DRBG_get_entropy_fn get_entropy;
     /* Indicates we have finished with entropy buffer */
-    void (*cleanup_entropy)(DRBG_CTX *ctx, unsigned char *out, size_t olen);
-
+    RAND_DRBG_cleanup_entropy_fn cleanup_entropy;
     /* nonce gathering function */
-    size_t (*get_nonce)(DRBG_CTX *ctx, unsigned char **pout,
-            int entropy, size_t min_len, size_t max_len);
+    RAND_DRBG_get_nonce_fn get_nonce;
     /* Indicates we have finished with nonce buffer */
-    void (*cleanup_nonce)(DRBG_CTX *ctx, unsigned char *out, size_t olen);
+    RAND_DRBG_cleanup_nonce_fn cleanup_nonce;
 };
 
 

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -26,14 +26,22 @@ int RAND_DRBG_generate(DRBG_CTX *dctx, unsigned char *out, size_t outlen,
                        const unsigned char *adin, size_t adinlen);
 void RAND_DRBG_free(DRBG_CTX *dctx);
 
+typedef size_t (*RAND_DRBG_get_entropy_fn)(DRBG_CTX *ctx, unsigned char **pout,
+                                           int entropy, size_t min_len,
+                                           size_t max_len);
+typedef void (*RAND_DRBG_cleanup_entropy_fn)(DRBG_CTX *ctx, unsigned char *out,
+                                             size_t olen);
+typedef size_t (*RAND_DRBG_get_nonce_fn)(DRBG_CTX *ctx, unsigned char **pout,
+                                         int entropy, size_t min_len,
+                                         size_t max_len);
+typedef void (*RAND_DRBG_cleanup_nonce_fn)(DRBG_CTX *ctx, unsigned char *out,
+                                           size_t olen);
+
 int RAND_DRBG_set_callbacks(DRBG_CTX *dctx,
-    size_t (*get_entropy)(DRBG_CTX *ctx, unsigned char **pout,
-                          int entropy, size_t min_len, size_t max_len),
-    void (*cleanup_entropy)(DRBG_CTX *ctx, unsigned char *out, size_t olen),
-    size_t (*get_nonce)(DRBG_CTX *ctx, unsigned char **pout,
-                        int entropy, size_t min_len, size_t max_len),
-    void (*cleanup_nonce)(DRBG_CTX *ctx, unsigned char *out, size_t olen)
-    );
+                            RAND_DRBG_get_entropy_fn get_entropy,
+                            RAND_DRBG_cleanup_entropy_fn cleanup_entropy,
+                            RAND_DRBG_get_nonce_fn get_nonce,
+                            RAND_DRBG_cleanup_nonce_fn cleanup_nonce);
 
 void RAND_DRBG_set_reseed_interval(DRBG_CTX *dctx, int interval);
 

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -323,7 +323,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
      */
 
     /* Test too small nonce */
-    if (dctx->min_nonce) { 
+    if (dctx->min_nonce) {
         t.noncelen = dctx->min_nonce - 1;
         if (!init(dctx, td, &t)
                 || RAND_DRBG_instantiate(dctx, td->pers, td->perslen) > 0
@@ -366,7 +366,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
             || !uninstantiate(dctx))
         goto err;
 
-    /* Instantiate again with valid data */ 
+    /* Instantiate again with valid data */
     if (!instantiate(dctx, td, &t))
         goto err;
     reseed_counter_tmp = dctx->reseed_counter;


### PR DESCRIPTION
A few things found in post-commit review.

Add some typedefs and remove trailing whitespace to help the style.

Eliminate a potential read buffer overrun.