### PR TITLE
Fix apps/s_client.c's XMPP client

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1667,6 +1667,8 @@ int MAIN(int argc, char **argv)
             if (strstr(mbuf, "/stream:features>"))
                 goto shut;
             seen = BIO_read(sbio, mbuf, BUFSIZZ);
+            if (seen <= 0)
+                goto shut;
             mbuf[seen] = 0;
         }
         BIO_printf(sbio,


### PR DESCRIPTION
When an error occurs during the starttls handskake, s_client gets stuck
looping around zero bytes reads, because the server won't sent anything more
after its error tag.  Shutting down on the first zero byte read fixes this.

Fixes #3980
