### PR TITLE
Remove memory stat and PID as source of entropy

### DIFF
--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -38,7 +38,6 @@ static void readtimer(void);
 
 int RAND_poll(void)
 {
-    MEMORYSTATUS mst;
 # ifndef RAND_WINDOWS_USE_BCRYPT
     HCRYPTPROV hProvider;
 # endif
@@ -70,14 +69,6 @@ int RAND_poll(void)
 
     /* timer data */
     readtimer();
-
-    /* memory usage statistics */
-    GlobalMemoryStatus(&mst);
-    RAND_add(&mst, sizeof(mst), 1);
-
-    /* process ID */
-    w = GetCurrentProcessId();
-    RAND_add(&w, sizeof(w), 1);
 
     return (1);
 }


### PR DESCRIPTION
GlobalMemoryStatus is deprecated and may return incorrect data (https://msdn.microsoft.com/en-us/library/windows/desktop/aa366586(v=vs.85).aspx). Since we already use `BCryptGenRandom` or `CryptGenRandom`, I guess we can remove memory status and process ID as sources of randomness? #1079 removed a lot of code that manually gathers entropy. I think based on the same logic, we can remove these two as well.