### PR TITLE
Fix const correctness of EC_KEY_METHOD_get_*

### DIFF
--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -236,7 +236,7 @@ void EC_KEY_METHOD_set_verify(EC_KEY_METHOD *meth,
     meth->verify_sig = verify_sig;
 }
 
-void EC_KEY_METHOD_get_init(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_init(const EC_KEY_METHOD *meth,
                             int (**pinit)(EC_KEY *key),
                             void (**pfinish)(EC_KEY *key),
                             int (**pcopy)(EC_KEY *dest, const EC_KEY *src),
@@ -261,14 +261,14 @@ void EC_KEY_METHOD_get_init(EC_KEY_METHOD *meth,
         *pset_public = meth->set_public;
 }
 
-void EC_KEY_METHOD_get_keygen(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_keygen(const EC_KEY_METHOD *meth,
                               int (**pkeygen)(EC_KEY *key))
 {
     if (pkeygen != NULL)
         *pkeygen = meth->keygen;
 }
 
-void EC_KEY_METHOD_get_compute_key(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_compute_key(const EC_KEY_METHOD *meth,
                                    int (**pck)(unsigned char **pout,
                                                size_t *poutlen,
                                                const EC_POINT *pub_key,
@@ -278,7 +278,7 @@ void EC_KEY_METHOD_get_compute_key(EC_KEY_METHOD *meth,
         *pck = meth->compute_key;
 }
 
-void EC_KEY_METHOD_get_sign(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_sign(const EC_KEY_METHOD *meth,
                             int (**psign)(int type, const unsigned char *dgst,
                                           int dlen, unsigned char *sig,
                                           unsigned int *siglen,
@@ -300,7 +300,7 @@ void EC_KEY_METHOD_get_sign(EC_KEY_METHOD *meth,
         *psign_sig = meth->sign_sig;
 }
 
-void EC_KEY_METHOD_get_verify(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
                               int (**pverify)(int type, const unsigned
                                               char *dgst, int dgst_len,
                                               const unsigned char *sigbuf,

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1217,7 +1217,7 @@ void EC_KEY_METHOD_set_verify(EC_KEY_METHOD *meth,
                                                 const ECDSA_SIG *sig,
                                                 EC_KEY *eckey));
 
-void EC_KEY_METHOD_get_init(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_init(const EC_KEY_METHOD *meth,
                             int (**pinit)(EC_KEY *key),
                             void (**pfinish)(EC_KEY *key),
                             int (**pcopy)(EC_KEY *dest, const EC_KEY *src),
@@ -1228,16 +1228,16 @@ void EC_KEY_METHOD_get_init(EC_KEY_METHOD *meth,
                             int (**pset_public)(EC_KEY *key,
                                                 const EC_POINT *pub_key));
 
-void EC_KEY_METHOD_get_keygen(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_keygen(const EC_KEY_METHOD *meth,
                               int (**pkeygen)(EC_KEY *key));
 
-void EC_KEY_METHOD_get_compute_key(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_compute_key(const EC_KEY_METHOD *meth,
                                    int (**pck)(unsigned char **psec,
                                                size_t *pseclen,
                                                const EC_POINT *pub_key,
                                                const EC_KEY *ecdh));
 
-void EC_KEY_METHOD_get_sign(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_sign(const EC_KEY_METHOD *meth,
                             int (**psign)(int type, const unsigned char *dgst,
                                           int dlen, unsigned char *sig,
                                           unsigned int *siglen,
@@ -1251,7 +1251,7 @@ void EC_KEY_METHOD_get_sign(EC_KEY_METHOD *meth,
                                                      const BIGNUM *in_r,
                                                      EC_KEY *eckey));
 
-void EC_KEY_METHOD_get_verify(EC_KEY_METHOD *meth,
+void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
                               int (**pverify)(int type, const unsigned
                                               char *dgst, int dgst_len,
                                               const unsigned char *sigbuf,


### PR DESCRIPTION
Changes the EC_KEY_METHOD_get_* family to not need a EC_KEY_METHOD* as its first parameter, but a const EC_KEY_METHOD*, which is entirely sufficient.

Discussion is here: https://mta.openssl.org/pipermail/openssl-dev/2017-July/009522.html

Rationale: One might directly want to access the signing method getters of the const EC_KEY_METHOD* that is returned by EC_KEY_OpenSSL() without having it to cast to a mutable EC_KEY_METHOD* first (also gives a nasty -Wcast-qual diagnostic). Since mutability isn't require it, make the prototype of the getter functions take a const EC_KEY_METHOD*.