### PR TITLE
Make pkeyutl a bit more user-friendly

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -37,8 +37,8 @@ typedef enum OPTION_choice {
     OPT_PUBIN, OPT_CERTIN, OPT_ASN1PARSE, OPT_HEXDUMP, OPT_SIGN,
     OPT_VERIFY, OPT_VERIFYRECOVER, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
     OPT_DERIVE, OPT_SIGFILE, OPT_INKEY, OPT_PEERKEY, OPT_PASSIN,
-    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_KDF, OPT_KDFLEN,
-    OPT_R_ENUM
+    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_PKEYOPT_PASSIN, OPT_KDF,
+    OPT_KDFLEN, OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkeyutl_options[] = {
@@ -66,6 +66,8 @@ const OPTIONS pkeyutl_options[] = {
     {"peerform", OPT_PEERFORM, 'E', "Peer key format - default PEM"},
     {"keyform", OPT_KEYFORM, 'E', "Private key format - default PEM"},
     {"pkeyopt", OPT_PKEYOPT, 's', "Public key options as opt:value"},
+    {"pkeyopt_passin", OPT_PKEYOPT_PASSIN, 's',
+     "Public key option that is read as a passphrase argument opt:passphrase"},
     OPT_R_OPTIONS,
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
@@ -94,6 +96,7 @@ int pkeyutl_main(int argc, char **argv)
     const char *kdfalg = NULL;
     int kdflen = 0;
     STACK_OF(OPENSSL_STRING) *pkeyopts = NULL;
+    STACK_OF(OPENSSL_STRING) *pkeyopts_passin = NULL;
 
     prog = opt_init(argc, argv, pkeyutl_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -192,6 +195,14 @@ int pkeyutl_main(int argc, char **argv)
                 goto end;
             }
             break;
+        case OPT_PKEYOPT_PASSIN:
+            if ((pkeyopts_passin == NULL &&
+                 (pkeyopts_passin = sk_OPENSSL_STRING_new_null()) == NULL) ||
+                sk_OPENSSL_STRING_push(pkeyopts_passin, opt_arg()) == 0) {
+                BIO_puts(bio_err, "out of memory\n");
+                goto end;
+            }
+            break;
         }
     }
     argc = opt_num_rest();
@@ -238,6 +249,45 @@ int pkeyutl_main(int argc, char **argv)
                 ERR_print_errors(bio_err);
                 goto end;
             }
+        }
+    }
+    if (pkeyopts_passin != NULL) {
+        int num = sk_OPENSSL_STRING_num(pkeyopts_passin);
+        int i;
+
+        for (i = 0; i < num; i++) {
+            char *opt = sk_OPENSSL_STRING_value(pkeyopts_passin, i);
+            char *passin = strchr(opt, ':');
+            char *passwd;
+
+            if (passin == NULL) {
+                /* Get password interactively */
+                char passwd_buf[4096];
+                snprintf(passwd_buf, sizeof(passwd_buf), "Enter %s: ", opt);
+                EVP_read_pw_string(passwd_buf, sizeof(passwd_buf) - 1,
+                                   passwd_buf, 0);
+                passwd = OPENSSL_strdup(passwd_buf);
+                if (passwd == NULL) {
+                    BIO_puts(bio_err, "out of memory\n");
+                    goto end;
+                }
+            } else {
+                /* Get password as a passin argument: First split option name
+                 * and passphrase argument into two strings */
+                *passin = 0;
+                passin++;
+                if (app_passwd(passin, NULL, &passwd, NULL) == 0) {
+                    BIO_printf(bio_err, "failed to get '%s'\n", opt);
+                    goto end;
+                }
+            }
+
+            if (EVP_PKEY_CTX_ctrl_str(ctx, opt, passwd) <= 0) {
+                BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n",
+                           prog, opt);
+                goto end;
+            }
+            OPENSSL_free(passwd);
         }
     }
 
@@ -349,6 +399,7 @@ int pkeyutl_main(int argc, char **argv)
     OPENSSL_free(buf_out);
     OPENSSL_free(sig);
     sk_OPENSSL_STRING_free(pkeyopts);
+    sk_OPENSSL_STRING_free(pkeyopts_passin);
     return ret;
 }
 

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -37,8 +37,8 @@ typedef enum OPTION_choice {
     OPT_PUBIN, OPT_CERTIN, OPT_ASN1PARSE, OPT_HEXDUMP, OPT_SIGN,
     OPT_VERIFY, OPT_VERIFYRECOVER, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
     OPT_DERIVE, OPT_SIGFILE, OPT_INKEY, OPT_PEERKEY, OPT_PASSIN,
-    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_PKEYOPT_PASSIN, OPT_KDF,
-    OPT_KDFLEN, OPT_R_ENUM
+    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_KDF, OPT_KDFLEN,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkeyutl_options[] = {
@@ -66,8 +66,6 @@ const OPTIONS pkeyutl_options[] = {
     {"peerform", OPT_PEERFORM, 'E', "Peer key format - default PEM"},
     {"keyform", OPT_KEYFORM, 'E', "Private key format - default PEM"},
     {"pkeyopt", OPT_PKEYOPT, 's', "Public key options as opt:value"},
-    {"pkeyopt_passin", OPT_PKEYOPT_PASSIN, 's',
-     "Public key option that is read as a passphrase argument opt:passphrase"},
     OPT_R_OPTIONS,
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
@@ -96,7 +94,6 @@ int pkeyutl_main(int argc, char **argv)
     const char *kdfalg = NULL;
     int kdflen = 0;
     STACK_OF(OPENSSL_STRING) *pkeyopts = NULL;
-    STACK_OF(OPENSSL_STRING) *pkeyopts_passin = NULL;
 
     prog = opt_init(argc, argv, pkeyutl_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -195,14 +192,6 @@ int pkeyutl_main(int argc, char **argv)
                 goto end;
             }
             break;
-        case OPT_PKEYOPT_PASSIN:
-            if ((pkeyopts_passin == NULL &&
-                 (pkeyopts_passin = sk_OPENSSL_STRING_new_null()) == NULL) ||
-                sk_OPENSSL_STRING_push(pkeyopts_passin, opt_arg()) == 0) {
-                BIO_puts(bio_err, "out of memory\n");
-                goto end;
-            }
-            break;
         }
     }
     argc = opt_num_rest();
@@ -249,45 +238,6 @@ int pkeyutl_main(int argc, char **argv)
                 ERR_print_errors(bio_err);
                 goto end;
             }
-        }
-    }
-    if (pkeyopts_passin != NULL) {
-        int num = sk_OPENSSL_STRING_num(pkeyopts_passin);
-        int i;
-
-        for (i = 0; i < num; i++) {
-            char *opt = sk_OPENSSL_STRING_value(pkeyopts_passin, i);
-            char *passin = strchr(opt, ':');
-            char *passwd;
-
-            if (passin == NULL) {
-                /* Get password interactively */
-                char passwd_buf[4096];
-                snprintf(passwd_buf, sizeof(passwd_buf), "Enter %s: ", opt);
-                EVP_read_pw_string(passwd_buf, sizeof(passwd_buf) - 1,
-                                   passwd_buf, 0);
-                passwd = OPENSSL_strdup(passwd_buf);
-                if (passwd == NULL) {
-                    BIO_puts(bio_err, "out of memory\n");
-                    goto end;
-                }
-            } else {
-                /* Get password as a passin argument: First split option name
-                 * and passphrase argument into two strings */
-                *passin = 0;
-                passin++;
-                if (app_passwd(passin, NULL, &passwd, NULL) == 0) {
-                    BIO_printf(bio_err, "failed to get '%s'\n", opt);
-                    goto end;
-                }
-            }
-
-            if (EVP_PKEY_CTX_ctrl_str(ctx, opt, passwd) <= 0) {
-                BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n",
-                           prog, opt);
-                goto end;
-            }
-            OPENSSL_free(passwd);
         }
     }
 
@@ -399,7 +349,6 @@ int pkeyutl_main(int argc, char **argv)
     OPENSSL_free(buf_out);
     OPENSSL_free(sig);
     sk_OPENSSL_STRING_free(pkeyopts);
-    sk_OPENSSL_STRING_free(pkeyopts_passin);
     return ret;
 }
 

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -408,7 +408,6 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
             if (kdfnid == NID_undef) {
                 BIO_printf(bio_err, "The given KDF \"%s\" is unknown.\n",
                            kdfalg);
-                print_supported_kdfs();
                 goto end;
             }
         }

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -31,6 +31,10 @@ static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
                     unsigned char *out, size_t *poutlen,
                     const unsigned char *in, size_t inlen);
 
+static void print_supported_kdfs(void);
+
+static void print_kdf_options(const char *kdfalg);
+
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_ENGINE, OPT_ENGINE_IMPL, OPT_IN, OPT_OUT,
@@ -40,6 +44,40 @@ typedef enum OPTION_choice {
     OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_KDF, OPT_KDFLEN,
     OPT_R_ENUM
 } OPTION_CHOICE;
+
+struct pkey_option {
+    const char *keys;
+    const char *description;
+    int mandatory;
+};
+
+struct kdf_info {
+    const char *name;
+    const char *description;
+    const struct pkey_option *pkey_options;
+};
+
+static struct pkey_option kdf_tls1_prf_options[] = {
+    { "md", "message digest", 1 },
+    { "secret | hexsecret", "KDF secret (either as a string or hex-encoded)", 1 },
+    { "seed | hexseed", "KDF seed (either as a string or hex-encoded)", 1 },
+    { NULL }
+};
+
+static struct pkey_option kdf_hkdf_options[] = {
+    { "mode", "HKDF operation mode. Must be one of EXTRACT_AND_EXPAND, EXTRACT_ONLY or EXPAND_ONLY. Defaults to EXTRACT_AND_EXPAND.", 0 },
+    { "md", "message digest", 1 },
+    { "salt | hexsalt", "Optional salt value (either as a string or hex-encoded)", 0 },
+    { "key | hexkey", "HMAC key (either as a string or hex-encoded)", 1 },
+    { "info | hexinfo", "Optional context and application specific information (either as a string or hex-encoded)", 0 },
+    { NULL }
+};
+
+static const struct kdf_info supported_kdfs[] = {
+    { "TLS1-PRF", "TLS1 pseudo random function", kdf_tls1_prf_options },
+    { "HKDF", "HMAC-based KDF (RFC5869)", kdf_hkdf_options },
+    { NULL }
+};
 
 const OPTIONS pkeyutl_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
@@ -322,6 +360,7 @@ int pkeyutl_main(int argc, char **argv)
             BIO_puts(bio_err, "Public Key operation error\n");
         } else {
             BIO_puts(bio_err, "Key derivation failed\n");
+            print_kdf_options(kdfalg);
         }
         ERR_print_errors(bio_err);
         goto end;
@@ -405,6 +444,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
             if (kdfnid == NID_undef) {
                 BIO_printf(bio_err, "The given KDF \"%s\" is unknown.\n",
                            kdfalg);
+                print_supported_kdfs();
                 goto end;
             }
         }
@@ -509,4 +549,35 @@ static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
 
     }
     return rv;
+}
+
+static void print_supported_kdfs(void) {
+    BIO_printf(bio_err, "Supported KDFs:\n");
+    const struct kdf_info *kdf = supported_kdfs;
+    while (kdf->name) {
+        BIO_printf(bio_err, "  %-10s %s\n", kdf->name, kdf->description);
+        kdf++;
+    }
+}
+
+static void print_kdf_options(const char *kdfalg) {
+    const struct kdf_info *kdf = supported_kdfs;
+    while (kdf->name) {
+        if (!strcmp(kdfalg, kdf->name)) {
+            break;
+        }
+        kdf++;
+    }
+
+    if (!kdf->name) {
+        /* KDF not listed in info entries */
+        return;
+    }
+
+    BIO_printf(bio_err, "Supported options of the \"%s\" KDF:\n", kdfalg);
+    const struct pkey_option *option = kdf->pkey_options;
+    while (option->keys) {
+        BIO_printf(bio_err, "  %-20s %s%s\n", option->keys, option->description, option->mandatory ? "; mandatory argument" : "");
+        option++;
+    }
 }

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -318,7 +318,11 @@ int pkeyutl_main(int argc, char **argv)
                       buf_in, (size_t)buf_inlen);
     }
     if (rv <= 0) {
-        BIO_puts(bio_err, "Public Key operation error\n");
+        if (pkey_op != EVP_PKEY_OP_DERIVE) {
+            BIO_puts(bio_err, "Public Key operation error\n");
+        } else {
+            BIO_puts(bio_err, "Key derivation failed\n");
+        }
         ERR_print_errors(bio_err);
         goto end;
     }

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -59,17 +59,21 @@ struct kdf_info {
 
 static struct pkey_option kdf_tls1_prf_options[] = {
     { "md", "message digest", 1 },
-    { "secret | hexsecret", "KDF secret (either as a string or hex-encoded)", 1 },
+    { "secret | hexsecret",
+        "KDF secret (either as a string or hex-encoded)", 1 },
     { "seed | hexseed", "KDF seed (either as a string or hex-encoded)", 1 },
     { NULL }
 };
 
 static struct pkey_option kdf_hkdf_options[] = {
-    { "mode", "HKDF operation mode. Must be one of EXTRACT_AND_EXPAND, EXTRACT_ONLY or EXPAND_ONLY. Defaults to EXTRACT_AND_EXPAND.", 0 },
+    { "mode", "HKDF operation mode. Must be one of EXTRACT_AND_EXPAND, " \
+        "EXTRACT_ONLY or EXPAND_ONLY. Defaults to EXTRACT_AND_EXPAND.", 0 },
     { "md", "message digest", 1 },
-    { "salt | hexsalt", "Optional salt value (either as a string or hex-encoded)", 0 },
+    { "salt | hexsalt",
+        "Optional salt value (either as a string or hex-encoded)", 0 },
     { "key | hexkey", "HMAC key (either as a string or hex-encoded)", 1 },
-    { "info | hexinfo", "Optional context and application specific information (either as a string or hex-encoded)", 0 },
+    { "info | hexinfo", "Optional context and application specific " \
+        "information (either as a string or hex-encoded)", 0 },
     { NULL }
 };
 
@@ -239,14 +243,17 @@ int pkeyutl_main(int argc, char **argv)
 
     if (kdfalg != NULL) {
         if (kdflen == 0) {
-           BIO_printf(bio_err, "%s: no KDF length given (-kdflen parameter).\n", prog);
+           BIO_printf(bio_err,
+                    "%s: no KDF length given (-kdflen parameter).\n", prog);
            goto opthelp;
         }
     } else if (inkey == NULL) {
-        BIO_printf(bio_err, "%s: no private key given (-inkey parameter).\n", prog);
+        BIO_printf(bio_err,
+                "%s: no private key given (-inkey parameter).\n", prog);
         goto opthelp;
     } else if (peerkey != NULL && pkey_op != EVP_PKEY_OP_DERIVE) {
-        BIO_printf(bio_err, "%s: no peer key given (-peerkey parameter).\n", prog);
+        BIO_printf(bio_err,
+                "%s: no peer key given (-peerkey parameter).\n", prog);
         goto opthelp;
     }
     ctx = init_ctx(kdfalg, &keysize, inkey, keyform, key_type,
@@ -269,7 +276,8 @@ int pkeyutl_main(int argc, char **argv)
             const char *opt = sk_OPENSSL_STRING_value(pkeyopts, i);
 
             if (pkey_ctrl_string(ctx, opt) <= 0) {
-                BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n", prog, opt);
+                BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n",
+                        prog, opt);
                 ERR_print_errors(bio_err);
                 goto end;
             }
@@ -578,7 +586,9 @@ static void print_kdf_options(const char *kdfalg) {
     BIO_printf(bio_err, "Supported options of the \"%s\" KDF:\n", kdfalg);
     option = kdf->pkey_options;
     while (option->keys) {
-        BIO_printf(bio_err, "  %-20s %s%s\n", option->keys, option->description, option->mandatory ? "; mandatory argument" : "");
+        BIO_printf(bio_err, "  %-20s %s%s\n",
+                option->keys, option->description,
+                option->mandatory ? "; mandatory argument" : "");
         option++;
     }
 }

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -200,10 +200,15 @@ int pkeyutl_main(int argc, char **argv)
         goto opthelp;
 
     if (kdfalg != NULL) {
-        if (kdflen == 0)
-            goto opthelp;
-    } else if ((inkey == NULL)
-            || (peerkey != NULL && pkey_op != EVP_PKEY_OP_DERIVE)) {
+        if (kdflen == 0) {
+           BIO_printf(bio_err, "%s: no KDF length given (-kdflen parameter).\n", prog);
+           goto opthelp;
+        }
+    } else if (inkey == NULL) {
+        BIO_printf(bio_err, "%s: no private key given (-inkey parameter).\n", prog);
+        goto opthelp;
+    } else if (peerkey != NULL && pkey_op != EVP_PKEY_OP_DERIVE) {
+        BIO_printf(bio_err, "%s: no peer key given (-peerkey parameter).\n", prog);
         goto opthelp;
     }
     ctx = init_ctx(kdfalg, &keysize, inkey, keyform, key_type,
@@ -393,8 +398,11 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
 
         if (kdfnid == NID_undef) {
             kdfnid = OBJ_ln2nid(kdfalg);
-            if (kdfnid == NID_undef)
+            if (kdfnid == NID_undef) {
+                BIO_printf(bio_err, "The given KDF \"%s\" is unknown.\n",
+                           kdfalg);
                 goto end;
+            }
         }
         ctx = EVP_PKEY_CTX_new_id(kdfnid, impl);
     } else {

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -552,8 +552,8 @@ static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
 }
 
 static void print_supported_kdfs(void) {
-    BIO_printf(bio_err, "Supported KDFs:\n");
     const struct kdf_info *kdf = supported_kdfs;
+    BIO_printf(bio_err, "Supported KDFs:\n");
     while (kdf->name) {
         BIO_printf(bio_err, "  %-10s %s\n", kdf->name, kdf->description);
         kdf++;
@@ -562,6 +562,7 @@ static void print_supported_kdfs(void) {
 
 static void print_kdf_options(const char *kdfalg) {
     const struct kdf_info *kdf = supported_kdfs;
+    const struct pkey_option *option;
     while (kdf->name) {
         if (!strcmp(kdfalg, kdf->name)) {
             break;
@@ -575,7 +576,7 @@ static void print_kdf_options(const char *kdfalg) {
     }
 
     BIO_printf(bio_err, "Supported options of the \"%s\" KDF:\n", kdfalg);
-    const struct pkey_option *option = kdf->pkey_options;
+    option = kdf->pkey_options;
     while (option->keys) {
         BIO_printf(bio_err, "  %-20s %s%s\n", option->keys, option->description, option->mandatory ? "; mandatory argument" : "");
         option++;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -231,7 +231,7 @@ int pkeyutl_main(int argc, char **argv)
             const char *opt = sk_OPENSSL_STRING_value(pkeyopts, i);
 
             if (pkey_ctrl_string(ctx, opt) <= 0) {
-                BIO_printf(bio_err, "%s: Can't set parameter:\n", prog);
+                BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n", prog, opt);
                 ERR_print_errors(bio_err);
                 goto end;
             }


### PR DESCRIPTION
Give meaningful error messages when the user incorrectly uses pkeyutl.

Rationale: Currently, pkeyutl just aborts and says "look at the help page" when the user does something wrong like specifying an unknown KDF, forgetting to set -kdflen when specified -kdf and such. This patch makes pkeyutl a little less hostile in that regard.

I would have liked to improve it further to not only show that the given KDF could not be resolved to a NID (i.e., it's unknown), but also show a list of *known* and recognized KDFs. However, I'm unsure how the obj_dat OID database works in that regard and don't think there's an (easy) way to find out if a specific name is suitable for use as a KDF -- or is there? If so, please give me a pointer and I'd happily also provide a patch for this.