### PR TITLE
Set error when HKDF used without parameters

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1968,6 +1968,7 @@ KDF_R_INVALID_DIGEST:100:invalid digest
 KDF_R_MISSING_KEY:104:missing key
 KDF_R_MISSING_MESSAGE_DIGEST:105:missing message digest
 KDF_R_MISSING_PARAMETER:101:missing parameter
+KDF_R_MISSING_SECRET:107:missing secret
 KDF_R_MISSING_SEED:106:missing seed
 KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
 KDF_R_VALUE_MISSING:102:value missing

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -700,6 +700,7 @@ EVP_F_PKEY_SET_TYPE:158:pkey_set_type
 EVP_F_RC2_MAGIC_TO_METH:109:rc2_magic_to_meth
 EVP_F_RC5_CTRL:125:rc5_ctrl
 EVP_F_UPDATE:173:update
+KDF_F_PKEY_HKDF_DERIVE:102:pkey_hkdf_derive
 KDF_F_PKEY_TLS1_PRF_CTRL_STR:100:pkey_tls1_prf_ctrl_str
 KDF_F_PKEY_TLS1_PRF_DERIVE:101:pkey_tls1_prf_derive
 OBJ_F_OBJ_ADD_OBJECT:105:OBJ_add_object

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1965,7 +1965,10 @@ EVP_R_UNSUPPORTED_SALT_TYPE:126:unsupported salt type
 EVP_R_WRAP_MODE_NOT_ALLOWED:170:wrap mode not allowed
 EVP_R_WRONG_FINAL_BLOCK_LENGTH:109:wrong final block length
 KDF_R_INVALID_DIGEST:100:invalid digest
+KDF_R_MISSING_KEY:104:missing key
+KDF_R_MISSING_MESSAGE_DIGEST:105:missing message digest
 KDF_R_MISSING_PARAMETER:101:missing parameter
+KDF_R_MISSING_SEED:106:missing seed
 KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
 KDF_R_VALUE_MISSING:102:value missing
 OBJ_R_OID_EXISTS:102:oid exists

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -700,6 +700,7 @@ EVP_F_PKEY_SET_TYPE:158:pkey_set_type
 EVP_F_RC2_MAGIC_TO_METH:109:rc2_magic_to_meth
 EVP_F_RC5_CTRL:125:rc5_ctrl
 EVP_F_UPDATE:173:update
+KDF_F_PKEY_HKDF_CTRL_STR:103:pkey_hkdf_ctrl_str
 KDF_F_PKEY_HKDF_DERIVE:102:pkey_hkdf_derive
 KDF_F_PKEY_TLS1_PRF_CTRL_STR:100:pkey_tls1_prf_ctrl_str
 KDF_F_PKEY_TLS1_PRF_DERIVE:101:pkey_tls1_prf_derive
@@ -1965,6 +1966,7 @@ EVP_R_WRAP_MODE_NOT_ALLOWED:170:wrap mode not allowed
 EVP_R_WRONG_FINAL_BLOCK_LENGTH:109:wrong final block length
 KDF_R_INVALID_DIGEST:100:invalid digest
 KDF_R_MISSING_PARAMETER:101:missing parameter
+KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
 KDF_R_VALUE_MISSING:102:value missing
 OBJ_R_OID_EXISTS:102:oid exists
 OBJ_R_UNKNOWN_NID:101:unknown nid

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -177,8 +177,10 @@ static int pkey_hkdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
 {
     HKDF_PKEY_CTX *kctx = ctx->data;
 
-    if (kctx->md == NULL || kctx->key == NULL)
+    if (kctx->md == NULL || kctx->key == NULL) {
+        KDFerr(KDF_F_PKEY_HKDF_DERIVE, KDF_R_MISSING_PARAMETER);
         return 0;
+    }
 
     switch (kctx->mode) {
     case EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND:

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -148,8 +148,14 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
         return EVP_PKEY_CTX_hkdf_mode(ctx, mode);
     }
 
-    if (strcmp(type, "md") == 0)
-        return EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_get_digestbyname(value));
+    if (strcmp(type, "md") == 0) {
+        const EVP_MD *md = EVP_get_digestbyname(value);
+        if (!md) {
+            KDFerr(KDF_F_PKEY_HKDF_CTRL_STR, KDF_R_INVALID_DIGEST);
+            return 0;
+        }
+        return EVP_PKEY_CTX_set_hkdf_md(ctx, md);
+    }
 
     if (strcmp(type, "salt") == 0)
         return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
@@ -169,6 +175,7 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     if (strcmp(type, "hexinfo") == 0)
         return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
 
+    KDFerr(KDF_F_PKEY_HKDF_CTRL_STR, KDF_R_UNKNOWN_PARAMETER_TYPE);
     return -2;
 }
 

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -148,14 +148,9 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
         return EVP_PKEY_CTX_hkdf_mode(ctx, mode);
     }
 
-    if (strcmp(type, "md") == 0) {
-        const EVP_MD *md = EVP_get_digestbyname(value);
-        if (!md) {
-            KDFerr(KDF_F_PKEY_HKDF_CTRL_STR, KDF_R_INVALID_DIGEST);
-            return 0;
-        }
-        return EVP_PKEY_CTX_set_hkdf_md(ctx, md);
-    }
+    if (strcmp(type, "md") == 0)
+        return EVP_PKEY_CTX_md(ctx, EVP_PKEY_OP_DERIVE,
+                EVP_PKEY_CTRL_HKDF_MD, value);
 
     if (strcmp(type, "salt") == 0)
         return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
@@ -184,8 +179,12 @@ static int pkey_hkdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
 {
     HKDF_PKEY_CTX *kctx = ctx->data;
 
-    if (kctx->md == NULL || kctx->key == NULL) {
-        KDFerr(KDF_F_PKEY_HKDF_DERIVE, KDF_R_MISSING_PARAMETER);
+    if (kctx->md == NULL) {
+        KDFerr(KDF_F_PKEY_HKDF_DERIVE, KDF_R_MISSING_MESSAGE_DIGEST);
+        return 0;
+    }
+    if (kctx->key == NULL) {
+        KDFerr(KDF_F_PKEY_HKDF_DERIVE, KDF_R_MISSING_KEY);
         return 0;
     }
 

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -150,7 +150,7 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
 
     if (strcmp(type, "md") == 0)
         return EVP_PKEY_CTX_md(ctx, EVP_PKEY_OP_DERIVE,
-                EVP_PKEY_CTRL_HKDF_MD, value);
+                               EVP_PKEY_CTRL_HKDF_MD, value);
 
     if (strcmp(type, "salt") == 0)
         return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);

--- a/crypto/kdf/kdf_err.c
+++ b/crypto/kdf/kdf_err.c
@@ -29,6 +29,7 @@ static const ERR_STRING_DATA KDF_str_reasons[] = {
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_MESSAGE_DIGEST),
     "missing message digest"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_PARAMETER), "missing parameter"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_SECRET), "missing secret"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_SEED), "missing seed"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_UNKNOWN_PARAMETER_TYPE),
     "unknown parameter type"},

--- a/crypto/kdf/kdf_err.c
+++ b/crypto/kdf/kdf_err.c
@@ -14,6 +14,7 @@
 #ifndef OPENSSL_NO_ERR
 
 static const ERR_STRING_DATA KDF_str_functs[] = {
+    {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_HKDF_DERIVE, 0), "pkey_hkdf_derive"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_TLS1_PRF_CTRL_STR, 0),
      "pkey_tls1_prf_ctrl_str"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_TLS1_PRF_DERIVE, 0),

--- a/crypto/kdf/kdf_err.c
+++ b/crypto/kdf/kdf_err.c
@@ -14,6 +14,7 @@
 #ifndef OPENSSL_NO_ERR
 
 static const ERR_STRING_DATA KDF_str_functs[] = {
+    {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_HKDF_CTRL_STR, 0), "pkey_hkdf_ctrl_str"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_HKDF_DERIVE, 0), "pkey_hkdf_derive"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_TLS1_PRF_CTRL_STR, 0),
      "pkey_tls1_prf_ctrl_str"},
@@ -25,6 +26,8 @@ static const ERR_STRING_DATA KDF_str_functs[] = {
 static const ERR_STRING_DATA KDF_str_reasons[] = {
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_INVALID_DIGEST), "invalid digest"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_PARAMETER), "missing parameter"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_UNKNOWN_PARAMETER_TYPE),
+    "unknown parameter type"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_VALUE_MISSING), "value missing"},
     {0, NULL}
 };

--- a/crypto/kdf/kdf_err.c
+++ b/crypto/kdf/kdf_err.c
@@ -25,7 +25,11 @@ static const ERR_STRING_DATA KDF_str_functs[] = {
 
 static const ERR_STRING_DATA KDF_str_reasons[] = {
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_INVALID_DIGEST), "invalid digest"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_KEY), "missing key"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_MESSAGE_DIGEST),
+    "missing message digest"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_PARAMETER), "missing parameter"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_SEED), "missing seed"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_UNKNOWN_PARAMETER_TYPE),
     "unknown parameter type"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_VALUE_MISSING), "value missing"},

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -124,8 +124,12 @@ static int pkey_tls1_prf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
                                 size_t *keylen)
 {
     TLS1_PRF_PKEY_CTX *kctx = ctx->data;
-    if (kctx->md == NULL || kctx->sec == NULL || kctx->seedlen == 0) {
-        KDFerr(KDF_F_PKEY_TLS1_PRF_DERIVE, KDF_R_MISSING_PARAMETER);
+    if (kctx->md == NULL) {
+        KDFerr(KDF_F_PKEY_TLS1_PRF_DERIVE, KDF_R_MISSING_MESSAGE_DIGEST);
+        return 0;
+    }
+    if (kctx->sec == NULL || kctx->seedlen == 0) {
+        KDFerr(KDF_F_PKEY_TLS1_PRF_DERIVE, KDF_R_MISSING_SEED);
         return 0;
     }
     return tls1_prf_alg(kctx->md, kctx->sec, kctx->seclen,

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -128,7 +128,11 @@ static int pkey_tls1_prf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
         KDFerr(KDF_F_PKEY_TLS1_PRF_DERIVE, KDF_R_MISSING_MESSAGE_DIGEST);
         return 0;
     }
-    if (kctx->sec == NULL || kctx->seedlen == 0) {
+    if (kctx->sec == NULL) {
+        KDFerr(KDF_F_PKEY_TLS1_PRF_DERIVE, KDF_R_MISSING_SECRET);
+        return 0;
+    }
+    if (kctx->seedlen == 0) {
         KDFerr(KDF_F_PKEY_TLS1_PRF_DERIVE, KDF_R_MISSING_SEED);
         return 0;
     }

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -115,6 +115,8 @@ static int pkey_tls1_prf_ctrl_str(EVP_PKEY_CTX *ctx,
         return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_TLS_SEED, value);
     if (strcmp(type, "hexseed") == 0)
         return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_TLS_SEED, value);
+
+    KDFerr(KDF_F_PKEY_TLS1_PRF_CTRL_STR, KDF_R_UNKNOWN_PARAMETER_TYPE);
     return -2;
 }
 

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -22,6 +22,7 @@ int ERR_load_KDF_strings(void);
 /*
  * KDF function codes.
  */
+# define KDF_F_PKEY_HKDF_DERIVE                           102
 # define KDF_F_PKEY_TLS1_PRF_CTRL_STR                     100
 # define KDF_F_PKEY_TLS1_PRF_DERIVE                       101
 

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -22,6 +22,7 @@ int ERR_load_KDF_strings(void);
 /*
  * KDF function codes.
  */
+# define KDF_F_PKEY_HKDF_CTRL_STR                         103
 # define KDF_F_PKEY_HKDF_DERIVE                           102
 # define KDF_F_PKEY_TLS1_PRF_CTRL_STR                     100
 # define KDF_F_PKEY_TLS1_PRF_DERIVE                       101
@@ -31,6 +32,7 @@ int ERR_load_KDF_strings(void);
  */
 # define KDF_R_INVALID_DIGEST                             100
 # define KDF_R_MISSING_PARAMETER                          101
+# define KDF_R_UNKNOWN_PARAMETER_TYPE                     103
 # define KDF_R_VALUE_MISSING                              102
 
 #endif

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -31,7 +31,10 @@ int ERR_load_KDF_strings(void);
  * KDF reason codes.
  */
 # define KDF_R_INVALID_DIGEST                             100
+# define KDF_R_MISSING_KEY                                104
+# define KDF_R_MISSING_MESSAGE_DIGEST                     105
 # define KDF_R_MISSING_PARAMETER                          101
+# define KDF_R_MISSING_SEED                               106
 # define KDF_R_UNKNOWN_PARAMETER_TYPE                     103
 # define KDF_R_VALUE_MISSING                              102
 

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -34,6 +34,7 @@ int ERR_load_KDF_strings(void);
 # define KDF_R_MISSING_KEY                                104
 # define KDF_R_MISSING_MESSAGE_DIGEST                     105
 # define KDF_R_MISSING_PARAMETER                          101
+# define KDF_R_MISSING_SECRET                             107
 # define KDF_R_MISSING_SEED                               106
 # define KDF_R_UNKNOWN_PARAMETER_TYPE                     103
 # define KDF_R_VALUE_MISSING                              102


### PR DESCRIPTION
Introduce KDF_F_PKEY_HKDF_DERIVE and return the KDF_R_MISSING_PARAMETER
error code when required parameters have not been set. This will make
"openssl pkeyutl -kdf HKDF" return a meaningful error message instead of
simply "Public Key operation error".