### PR TITLE
Fix wrong app_isdir check in opt_next()

### DIFF
--- a/apps/opt.c
+++ b/apps/opt.c
@@ -676,7 +676,7 @@ int opt_next(void)
             /* Just a string. */
             break;
         case '/':
-            if (app_isdir(arg) >= 0)
+            if (app_isdir(arg) > 0)
                 break;
             BIO_printf(bio_err, "%s: Not a directory: %s\n", prog, arg);
             return -1;


### PR DESCRIPTION
`app_isdir(arg)` returns 1 if `arg` is a directory, returns 0 if `arg` is a file,
and returns -1 if `arg` doesn't exist. So `app_isdir(arg) >= 0` only checks whether
`arg` exists, but it doesn't check if it's a directory. It should be `app_isdir(arg) > 0`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated
