### PR TITLE
app_isdir() cleanup

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2303,8 +2303,7 @@ int app_isdir(const char *name)
         return -1;
 
 #  if !defined(_WIN32_WCE) || _WIN32_WCE>=101
-    if (!MultiByteToWideChar
-        (CP_ACP, 0, name, len_0, tempname, len_0))
+    if (!MultiByteToWideChar(CP_ACP, 0, name, len_0, tempname, MAX_PATH))
 #  endif
         for (i = 0; i < len_0; i++)
             tempname[i] = (WCHAR)name[i];

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2294,29 +2294,28 @@ int app_access(const char* name, int flag)
 #ifdef _WIN32
 int app_isdir(const char *name)
 {
-    HANDLE hList;
-    WIN32_FIND_DATA FileData;
+    DWORD attr;
 # if defined(UNICODE) || defined(_UNICODE)
     size_t i, len_0 = strlen(name) + 1;
+    WCHAR tempname[MAX_PATH];
 
-    if (len_0 > OSSL_NELEM(FileData.cFileName))
+    if (len_0 > MAX_PATH)
         return -1;
 
 #  if !defined(_WIN32_WCE) || _WIN32_WCE>=101
     if (!MultiByteToWideChar
-        (CP_ACP, 0, name, len_0, FileData.cFileName, len_0))
+        (CP_ACP, 0, name, len_0, tempname, len_0))
 #  endif
         for (i = 0; i < len_0; i++)
-            FileData.cFileName[i] = (WCHAR)name[i];
+            tempname[i] = (WCHAR)name[i];
 
-    hList = FindFirstFile(FileData.cFileName, &FileData);
+    attr = GetFileAttributes(tempname);
 # else
-    hList = FindFirstFile(name, &FileData);
+    attr = GetFileAttributes(name);
 # endif
-    if (hList == INVALID_HANDLE_VALUE)
+    if (attr == INVALID_FILE_ATTRIBUTES)
         return -1;
-    FindClose(hList);
-    return ((FileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+    return ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0);
 }
 #else
 # include <sys/stat.h>


### PR DESCRIPTION
I think it's better to use `GetFileAttributes` to obtain the attributes
of a file than `FindFirstFile`. If the input name contains `*`, this
function should return failure rather than check whether the first match
happens to be a file or a directory.
