### PR TITLE
Fix potential use-after-free and memory leak

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2613,7 +2613,6 @@ void wait_for_async(SSL *s)
     int width = 0;
     fd_set asyncfds;
     OSSL_ASYNC_FD *fds;
-    void *origfds;
     size_t numfds;
 
     if (!SSL_get_all_async_fds(s, NULL, &numfds))
@@ -2621,7 +2620,6 @@ void wait_for_async(SSL *s)
     if (numfds == 0)
         return;
     fds = app_malloc(sizeof(OSSL_ASYNC_FD) * numfds, "allocate async fds");
-    origfds = fds;
     if (!SSL_get_all_async_fds(s, fds, &numfds)) {
         OPENSSL_free(fds);
         return;
@@ -2629,11 +2627,10 @@ void wait_for_async(SSL *s)
 
     FD_ZERO(&asyncfds);
     while (numfds > 0) {
-        if (width <= (int)*fds)
-            width = (int)*fds + 1;
-        openssl_fdset((int)*fds, &asyncfds);
         numfds--;
-        fds++;
+        if (width <= (int)fds[numfds])
+            width = (int)fds[numfds] + 1;
+        openssl_fdset((int)fds[numfds], &asyncfds);
     }
     select(width, (void *)&asyncfds, NULL, NULL, NULL);
     OPENSSL_free(origfds);

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2613,6 +2613,7 @@ void wait_for_async(SSL *s)
     int width = 0;
     fd_set asyncfds;
     OSSL_ASYNC_FD *fds;
+    void *origfds;
     size_t numfds;
 
     if (!SSL_get_all_async_fds(s, NULL, &numfds))
@@ -2620,6 +2621,7 @@ void wait_for_async(SSL *s)
     if (numfds == 0)
         return;
     fds = app_malloc(sizeof(OSSL_ASYNC_FD) * numfds, "allocate async fds");
+    origfds = fds;
     if (!SSL_get_all_async_fds(s, fds, &numfds)) {
         OPENSSL_free(fds);
         return;
@@ -2634,7 +2636,7 @@ void wait_for_async(SSL *s)
         fds++;
     }
     select(width, (void *)&asyncfds, NULL, NULL, NULL);
-    OPENSSL_free(fds);
+    OPENSSL_free(origfds);
 #endif
 }
 

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2626,11 +2626,11 @@ void wait_for_async(SSL *s)
     }
 
     FD_ZERO(&asyncfds);
-    while (numfds > 0) {
-        numfds--;
-        if (width <= (int)fds[numfds])
-            width = (int)fds[numfds] + 1;
-        openssl_fdset((int)fds[numfds], &asyncfds);
+    int i;
+    for (i = 0; i < numfds; i++) {
+        if (width <= (int)fds[i])
+            width = (int)fds[i] + 1;
+        openssl_fdset((int)fds[i], &asyncfds);
     }
     select(width, (void *)&asyncfds, NULL, NULL, NULL);
     OPENSSL_free(origfds);

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2626,7 +2626,7 @@ void wait_for_async(SSL *s)
     }
 
     FD_ZERO(&asyncfds);
-    int i;
+    size_t i;
     for (i = 0; i < numfds; i++) {
         if (width <= (int)fds[i])
             width = (int)fds[i] + 1;

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2622,6 +2622,7 @@ void wait_for_async(SSL *s)
     fds = app_malloc(sizeof(OSSL_ASYNC_FD) * numfds, "allocate async fds");
     if (!SSL_get_all_async_fds(s, fds, &numfds)) {
         OPENSSL_free(fds);
+        return;
     }
 
     FD_ZERO(&asyncfds);
@@ -2633,6 +2634,7 @@ void wait_for_async(SSL *s)
         fds++;
     }
     select(width, (void *)&asyncfds, NULL, NULL, NULL);
+    OPENSSL_free(fds);
 #endif
 }
 

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2633,7 +2633,7 @@ void wait_for_async(SSL *s)
         openssl_fdset((int)fds[i], &asyncfds);
     }
     select(width, (void *)&asyncfds, NULL, NULL, NULL);
-    OPENSSL_free(origfds);
+    OPENSSL_free(fds);
 #endif
 }
 

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2614,6 +2614,7 @@ void wait_for_async(SSL *s)
     fd_set asyncfds;
     OSSL_ASYNC_FD *fds;
     size_t numfds;
+    size_t i;
 
     if (!SSL_get_all_async_fds(s, NULL, &numfds))
         return;
@@ -2626,7 +2627,6 @@ void wait_for_async(SSL *s)
     }
 
     FD_ZERO(&asyncfds);
-    size_t i;
     for (i = 0; i < numfds; i++) {
         if (width <= (int)fds[i])
             width = (int)fds[i] + 1;


### PR DESCRIPTION
In function wait_for_async(), allocated async fds is freed if `SSL_get_all_async_fds`
fails, but later `fds` is used. Interestingly, it is not freed when everything succeeds.

