### PR TITLE
test/recipes/80-test_tsa.t: Don't trust 'OPENSSL_CONF'

### DIFF
--- a/test/recipes/80-test_tsa.t
+++ b/test/recipes/80-test_tsa.t
@@ -23,9 +23,10 @@ plan skip_all => "TS is not supported by this OpenSSL build"
 
 # All these are modified inside indir further down. They need to exist
 # here, however, to be available in all subroutines.
+my $openssl_conf;
 my $testtsa;
 my $CAtsa;
-my @RUN = ("openssl", "ts");
+my @RUN;
 
 sub create_tsa_cert {
     my $INDEX = shift;
@@ -33,7 +34,7 @@ sub create_tsa_cert {
     my $r = 1;
     $ENV{TSDNSECT} = "ts_cert_dn";
 
-    ok(run(app(["openssl", "req", "-new",
+    ok(run(app(["openssl", "req", "-config", $openssl_conf, "-new",
                 "-out", "tsa_req${INDEX}.pem",
                 "-keyout", "tsa_key${INDEX}.pem"])));
     note "using extension $EXT";
@@ -42,7 +43,7 @@ sub create_tsa_cert {
                 "-out", "tsa_cert${INDEX}.pem",
                 "-CA", "tsaca.pem", "-CAkey", "tsacakey.pem",
                 "-CAcreateserial",
-                "-extfile", $ENV{OPENSSL_CONF}, "-extensions", $EXT])));
+                "-extfile", $openssl_conf, "-extensions", $EXT])));
 }
 
 sub create_time_stamp_response {
@@ -83,17 +84,20 @@ plan tests => 20;
 note "setting up TSA test directory";
 indir "tsa" => sub
 {
-    $ENV{OPENSSL_CONF} = srctop_file("test", "CAtsa.cnf");
-    # Because that's what ../apps/CA.pl really looks at
-    $ENV{OPENSSL_CONFIG} = "-config ".$ENV{OPENSSL_CONF};
-    $ENV{OPENSSL} = cmdstr(app(["openssl"]), display => 1);
+    $openssl_conf = srctop_file("test", "CAtsa.cnf");
     $testtsa = srctop_file("test", "recipes", "80-test_tsa.t");
     $CAtsa = srctop_file("test", "CAtsa.cnf");
+    @RUN = ("openssl", "ts", "-config", $openssl_conf);
+
+    # ../apps/CA.pl needs these
+    $ENV{OPENSSL_CONFIG} = "-config $openssl_conf";
+    $ENV{OPENSSL} = cmdstr(app(["openssl"]), display => 1);
 
  SKIP: {
      $ENV{TSDNSECT} = "ts_ca_dn";
      skip "failed", 19
-         unless ok(run(app(["openssl", "req", "-new", "-x509", "-nodes",
+         unless ok(run(app(["openssl", "req", "-config", $openssl_conf,
+                            "-new", "-x509", "-nodes",
                             "-out", "tsaca.pem", "-keyout", "tsacakey.pem"])),
                    'creating a new CA for the TSA tests');
 


### PR DESCRIPTION
There's a case when the environment variable OPENSSL_CONF is
useless...  when cross compiling for mingw and your wine environment
has an environment variable OPENSSL_CONF.  The latter will override
anything that's given when starting wine and there make the use of
that environment variable useless in our tests.

Therefore, we should not trust it, and use explicit '-config' options
instead.
