### PR TITLE
Add test cases and docs for ASN1_STRING_TABLE_* functions

### DIFF
--- a/doc/man3/ASN1_STRING_TABLE_add.pod
+++ b/doc/man3/ASN1_STRING_TABLE_add.pod
@@ -1,0 +1,65 @@
+=pod
+
+=head1 NAME
+
+ASN1_STRING_TABLE, ASN1_STRING_TABLE_add, ASN1_STRING_TABLE_get,
+ASN1_STRING_TABLE_cleanup - ASN1_STRING_TABLE manipulation functions
+
+=head1 SYNOPSIS
+
+ #include <openssl/asn1.h>
+
+ typedef struct asn1_string_table_st ASN1_STRING_TABLE;
+
+ int ASN1_STRING_TABLE_add(int nid, long minsize, long maxsize,
+                           unsigned long mask, unsigned long flags);
+ ASN1_STRING_TABLE * ASN1_STRING_TABLE_get(int nid);
+ void ASN1_STRING_TABLE_cleanup(void);
+
+=head1 DESCRIPTION
+
+=head2 Types
+
+B<ASN1_STRING_TABLE> is a table which holds string information
+(basically minimum size, maximum size, type and etc) for a NID object.
+
+=head2 Functions
+
+ASN1_STRING_TABLE_add() adds a new B<ASN1_STRING_TABLE> item into the
+local ASN1 string table based on the B<nid> along with other parameters.
+
+If the item is already in the table, fields of B<ASN1_STRING_TABLE> are
+updated (depending on the values of those parameters, e.g., B<minsize>
+and B<maxsize> >= 0, B<mask> and B<flags> != 0). If the B<nid> is standard,
+a copy of the standard B<ASN1_STRING_TABLE> is created and updated with
+other parameters.
+
+ASN1_STRING_TABLE_get() searches for an B<ASN1_STRING_TABLE> item based
+on B<nid>. It will search the local table first, then the standard one.
+
+ASN1_STRING_TABLE_cleanup() frees all B<ASN1_STRING_TABLE> items added
+by ASN1_STRING_TABLE_add().
+
+=head1 RETURN VALUES
+
+ASN1_STRING_TABLE_add() returns 1 on success, 0 if an error occurred.
+
+ASN1_STRING_TABLE_get() returns a valid B<ASN1_STRING_TABLE> structure
+or B<NULL> if nothing is found.
+
+ASN1_STRING_TABLE_cleanup() does not return a value.
+
+=head1 SEE ALSO
+
+L<ERR_get_error(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/test/asn1_string_table_test.c
+++ b/test/asn1_string_table_test.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Tests for the ANS1_STRING_TABLE_* functions */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/asn1.h>
+#include "testutil.h"
+
+static int test_string_tbl()
+{
+    const ASN1_STRING_TABLE *tmp = NULL;
+    int nid = 12345678, nid2 = 87654321, rv = 0, ret = 0;
+
+    tmp = ASN1_STRING_TABLE_get(nid);
+    if (!TEST_ptr_null(tmp)) {
+        TEST_info("asn1 string table: ASN1_STRING_TABLE_get non-exist nid");
+        goto out;
+    }
+
+    ret = ASN1_STRING_TABLE_add(nid, -1, -1, MBSTRING_ASC, 0);
+    if (!TEST_true(ret)) {
+        TEST_info("asn1 string table: add NID(%d) failed", nid);
+        goto out;
+    }
+
+    ret = ASN1_STRING_TABLE_add(nid2, -1, -1, MBSTRING_ASC, 0);
+    if (!TEST_true(ret)) {
+        TEST_info("asn1 string table: add NID(%d) failed", nid2);
+        goto out;
+    }
+
+    tmp = ASN1_STRING_TABLE_get(nid);
+    if (!TEST_ptr(tmp)) {
+        TEST_info("asn1 string table: get NID(%d) failed", nid);
+        goto out;
+    }
+
+    tmp = ASN1_STRING_TABLE_get(nid2);
+    if (!TEST_ptr(tmp)) {
+        TEST_info("asn1 string table: get NID(%d) failed", nid2);
+        goto out;
+    }
+
+    ASN1_STRING_TABLE_cleanup();
+
+    /* check if all newly added NIDs are cleaned up */
+    tmp = ASN1_STRING_TABLE_get(nid);
+    if (!TEST_ptr_null(tmp)) {
+        TEST_info("asn1 string table: get NID(%d) failed", nid);
+        goto out;
+    }
+
+    tmp = ASN1_STRING_TABLE_get(nid2);
+    if (!TEST_ptr_null(tmp)) {
+        TEST_info("asn1 string table: get NID(%d) failed", nid2);
+        goto out;
+    }
+
+    rv = 1;
+ out:
+    return rv;
+}
+
+void register_tests(void)
+{
+    ADD_TEST(test_string_tbl);
+}

--- a/test/build.info
+++ b/test/build.info
@@ -41,7 +41,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
-          pkey_meth_test uitest cipherbytes_test asn1_encode_test \
+          pkey_meth_test uitest cipherbytes_test asn1_encode_test asn1_string_table_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test
@@ -360,6 +360,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[asn1_encode_test]=asn1_encode_test.c
   INCLUDE[asn1_encode_test]=../include
   DEPEND[asn1_encode_test]=../libcrypto libtestutil.a
+
+  SOURCE[asn1_string_table_test]=asn1_string_table_test.c
+  INCLUDE[asn1_string_table_test]=../include
+  DEPEND[asn1_string_table_test]=../libcrypto libtestutil.a
 
   SOURCE[time_offset_test]=time_offset_test.c
   INCLUDE[time_offset_test]=.. ../include

--- a/test/recipes/04-test_asn1_string_table.t
+++ b/test/recipes/04-test_asn1_string_table.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_asn1_string_table", "asn1_string_table_test");

--- a/util/private.num
+++ b/util/private.num
@@ -8,6 +8,7 @@ OPENSSL_MALLOC_FAILURES                 environment
 OPENSSL_instrument_bus                  assembler
 OPENSSL_instrument_bus2                 assembler
 #
+ASN1_STRING_TABLE                       datatype
 BIO_ADDR                                datatype
 BIO_ADDRINFO                            datatype
 BIO_callback_fn                         datatype


### PR DESCRIPTION
This PR follows #3934 , and the test case could pass only if that one is merged.

Note: descriptions in documentation follows the master branch. In 1.0.2, the behaviors of those functions are not exactly the same. Should a `HISTORY` section be added or write new doc for 1.0.2?

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
