### PR TITLE
Improvements for multithreading code in speed.c

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -275,7 +275,8 @@ static SIGRETTYPE sig_done(int sig)
 # if !defined(SIGALRM)
 #  define SIGALRM
 # endif
-static unsigned int lapse, schlock;
+static unsigned int lapse;
+static volatile unsigned int schlock;
 static void alarm_win32(unsigned int secs)
 {
     lapse = secs * 1000;


### PR DESCRIPTION
1. Change `CreateThread` to `_beginthreadex()`. The MSDN document says:

> A thread in an executable that calls the C run-time library (CRT)
> should use the _beginthreadex and _endthreadex functions for thread
> management rather than CreateThread and ExitThread.

https://msdn.microsoft.com/en-us/library/windows/desktop/ms682453(v=vs.85).aspx

2. `schlock` should be marked as `volatile`, so that the while loop is guaranteed not to be optimized to an infinite loop.

3. Change `TerminateThread` to wait for an event object, so that the thread can exit itself.