### PR TITLE
add callback handler for setting DTLS timer interval

### DIFF
--- a/doc/man3/DTLS_set_timer_cb.pod
+++ b/doc/man3/DTLS_set_timer_cb.pod
@@ -1,0 +1,40 @@
+=pod
+
+=head1 NAME
+
+DTLS_timer_cb,
+DTLS_set_timer_cb
+- Set callback for controlling DTLS timer duration
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ typedef unsigned int (*DTLS_timer_cb)(SSL *s, unsigned int timer_us);
+
+ void DTLS_set_timer_cb(SSL *s, DTLS_timer_cb cb);
+
+=head1 DESCRIPTION
+
+This function sets an optional callback function for controlling the
+timeout interval on the DTLS protocol. The callback function will be
+called by DTLS for every new DTLS packet that is sent.
+
+=head1 RETURN VALUES
+
+Returns void.
+
+=head1 HISTORY
+
+This function was added in OpenSSL 1.1.1
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2260,6 +2260,12 @@ extern const char SSL_version_str[];
 
 int ERR_load_SSL_strings(void);
 
+
+typedef unsigned int (*DTLS_timer_cb)(SSL *s, unsigned int timer_us);
+
+void DTLS_set_timer_cb(SSL *s, DTLS_timer_cb cb);
+
+
 # ifdef  __cplusplus
 }
 # endif

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1624,11 +1624,15 @@ typedef struct dtls1_state_st {
      */
     struct timeval next_timeout;
     /* Timeout duration */
-    unsigned short timeout_duration;
+    unsigned int timeout_duration_us;
+
     unsigned int retransmitting;
 # ifndef OPENSSL_NO_SCTP
     int shutdown_received;
 # endif
+
+    DTLS_timer_cb timer_cb;
+
 } DTLS1_STATE;
 
 # ifndef OPENSSL_NO_EC

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -469,3 +469,4 @@ SSL_SESSION_set_max_early_data          469	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_set1_alpn_selected          470	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_set1_hostname               471	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_get0_alpn_selected          472	1_1_1	EXIST::FUNCTION:
+DTLS_set_timer_cb                       473	1_1_1	EXIST::FUNCTION:

--- a/util/private.num
+++ b/util/private.num
@@ -18,6 +18,7 @@ BIO_lookup_type                         datatype
 CRYPTO_EX_dup                           datatype
 CRYPTO_EX_free                          datatype
 CRYPTO_EX_new                           datatype
+DTLS_timer_cb                           datatype
 EVP_PKEY_gen_cb                         datatype
 EVP_PKEY_METHOD                         datatype
 GEN_SESSION_CB                          datatype


### PR DESCRIPTION
Hi OpenSSL people,

sorry about the long delay. I finally had some time to refresh the patches
and improve it based on code review.

1. the timer_cb units was changed from milliseconds to microseconds.

2. the duration calculation was changed, to avoid modulus operations.

3. testing the new API was done in the libre Protocol library:
    https://github.com/creytiv/re/tree/test_openssl_timer


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
