### PR TITLE
Fix external session cache issue caused by checking return value of SSL_CTX_add_session

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1444,7 +1444,7 @@ int SSL_SESSION_up_ref(SSL_SESSION *ses);
 void SSL_SESSION_free(SSL_SESSION *ses);
 __owur int i2d_SSL_SESSION(SSL_SESSION *in, unsigned char **pp);
 __owur int SSL_set_session(SSL *to, SSL_SESSION *session);
-__owur int SSL_CTX_add_session(SSL_CTX *s, SSL_SESSION *c);
+int SSL_CTX_add_session(SSL_CTX *s, SSL_SESSION *c);
 int SSL_CTX_remove_session(SSL_CTX *, SSL_SESSION *c);
 __owur int SSL_CTX_set_generate_session_id(SSL_CTX *, GEN_SESSION_CB);
 __owur int SSL_set_generate_session_id(SSL *, GEN_SESSION_CB);

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -535,10 +535,7 @@ int ssl_get_prev_session(SSL *s, const PACKET *ext, const PACKET *session_id)
                  * interrupt the session resumption process. The return
                  * value is intentionally ignored.
                  */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
                 SSL_CTX_add_session(s->session_ctx, ret);
-#pragma GCC diagnostic pop
             }
         }
     }

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -531,11 +531,14 @@ int ssl_get_prev_session(SSL *s, const PACKET *ext, const PACKET *session_id)
                 (s->session_ctx->session_cache_mode &
                  SSL_SESS_CACHE_NO_INTERNAL_STORE)) {
                 /*
-                 * The following should not return 1, otherwise, things are
-                 * very strange
+                 * Either return value of SSL_CTX_add_session should not
+                 * interrupt the session resumption process. The return
+                 * value is intentionally ignored.
                  */
-                if (SSL_CTX_add_session(s->session_ctx, ret))
-                    goto err;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+                SSL_CTX_add_session(s->session_ctx, ret);
+#pragma GCC diagnostic pop
             }
         }
     }


### PR DESCRIPTION
The original comment `The following should not return 1, otherwise, things are very strange` in function `ssl_get_prev_session()` in `ssl/ssl_sess.c` is from the very first commit of OpenSSL. The
really meaning of the comment should be if the identical session can be found from internal cache after calling `get_session_cb` but not found before calling `get_session_cb`, it is just strange.

The value `1` should be originated from the old doc of SSLeay:

> int SSL_CTX_add_session(SSL_CTX *s, SSL_SESSION *c);
SSL_CTX_add_session() returns 1 if the session was already in the cache (so it
was not added).

It is reversed (i.e. returns 0 if the session was already in the cache) from the actual return value of SSL_CTX_add_session().

I admit that is my guess. But on the other hand, current logic followed by that comment is pretty strange. `get_session_cb` is only called when specified session cannot be found in the internal store. Then if `get_session_cb` returned a not-NULL legal `SSL_SESSION *`, the session cannot in the internal store unless it was manually put into internal store via `SSL_CTX_add_session()` or something else if exists. If internal session cache store is not disabled via `SSL_SESS_CACHE_NO_INTERNAL_STORE`, the external cached session is going to be added into internal store. Even the man page tells:

> SSL_SESS_CACHE_NO_INTERNAL_STORE
> ... Note: in any SSL/TLS servers where external caching is configured, any successful session lookups in the external cache (ie. for session-resume requests) would normally be copied into the local cache before processing continues - this flag prevents these additions to the internal cache as well.

But in current logic, if `SSL_CTX_add_session(s->session_ctx, ret)` returned `1`, i.e. the returned session from `get_session_cb` is successfully added into the internal cache, it would be treated as an error. Then almost all external cached session cannot be resumed if `SSL_SESS_CACHE_NO_INTERNAL_STORE` is not set, at least for the first time. And `SSL_CTX_add_session()` may also be called in `get_session_cb`, so both return value of `SSL_CTX_add_session()` return value should be okay. IMHO at least it should not interrupt the session resumption process even if it was failed. So the checking of return value of SSL_CTX_add_session() is not necessary.

I think the same change should also be made on master branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
