### PR TITLE
Add EVP_PKEY_METHOD enumeration functions.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -51,6 +51,7 @@
 static LHASH_OF(FUNCTION) *prog_init(void);
 static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[]);
 static void list_pkey(void);
+static void list_pkey_meth(void);
 static void list_type(FUNC_TYPE ft);
 static void list_disabled(void);
 char *default_config_file = NULL;
@@ -308,7 +309,7 @@ typedef enum HELPLIST_CHOICE {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_COMMANDS, OPT_DIGEST_COMMANDS,
     OPT_DIGEST_ALGORITHMS, OPT_CIPHER_COMMANDS, OPT_CIPHER_ALGORITHMS,
-    OPT_PK_ALGORITHMS, OPT_DISABLED, OPT_MISSING_HELP
+    OPT_PK_ALGORITHMS, OPT_PK_METHOD, OPT_DISABLED, OPT_MISSING_HELP
 } HELPLIST_CHOICE;
 
 const OPTIONS list_options[] = {
@@ -323,6 +324,8 @@ const OPTIONS list_options[] = {
      "List of cipher algorithms"},
     {"public-key-algorithms", OPT_PK_ALGORITHMS, '-',
      "List of public key algorithms"},
+    {"public-key-methods", OPT_PK_METHOD, '-',
+     "List of public key methods"},
     {"disabled", OPT_DISABLED, '-',
      "List of disabled features"},
     {"missing-help", OPT_MISSING_HELP, '-',
@@ -363,6 +366,9 @@ int list_main(int argc, char **argv)
             break;
         case OPT_PK_ALGORITHMS:
             list_pkey();
+            break;
+        case OPT_PK_METHOD:
+            list_pkey_meth();
             break;
         case OPT_DISABLED:
             list_disabled();
@@ -537,6 +543,22 @@ static void list_pkey(void)
             BIO_printf(bio_out, "\tPEM string: %s\n", pem_str);
         }
 
+    }
+}
+
+static void list_pkey_meth(void)
+{
+    size_t i;
+    size_t meth_count = EVP_PKEY_meth_get_count();
+
+    for (i = 0; i < meth_count; i++) {
+        const EVP_PKEY_METHOD *pmeth = EVP_PKEY_meth_get0(i);
+        int pkey_id, pkey_flags;
+
+        EVP_PKEY_meth_get0_info(&pkey_id, &pkey_flags, pmeth);
+        BIO_printf(bio_out, "%s\n", OBJ_nid2ln(pkey_id));
+        BIO_printf(bio_out, "\tType: %s Algorithm\n",
+                   pkey_flags & ASN1_PKEY_DYNAMIC ?  "External" : "Builtin");
     }
 }
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -290,6 +290,27 @@ int EVP_PKEY_meth_add0(const EVP_PKEY_METHOD *pmeth)
     return 1;
 }
 
+size_t EVP_PKEY_meth_get_count(void)
+{
+    size_t rv = OSSL_NELEM(standard_methods);
+
+    if (app_pkey_methods)
+        rv += sk_EVP_PKEY_METHOD_num(app_pkey_methods);
+    return rv;
+}
+
+const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx)
+{
+    if (idx < OSSL_NELEM(standard_methods))
+        return standard_methods[idx];
+    if (app_pkey_methods == NULL)
+        return NULL;
+    idx -= OSSL_NELEM(standard_methods);
+    if (idx >= (size_t)sk_EVP_PKEY_METHOD_num(app_pkey_methods))
+        return NULL;
+    return sk_EVP_PKEY_METHOD_value(app_pkey_methods, idx);
+}
+
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx)
 {
     if (ctx == NULL)

--- a/doc/man1/list.pod
+++ b/doc/man1/list.pod
@@ -14,6 +14,7 @@ B<openssl list>
 [B<-cipher-commands>]
 [B<-cipher-algorithms>]
 [B<-public-key-algorithms>]
+[B<-public-key-methods>]
 [B<-disabled>]
 
 =head1 DESCRIPTION
@@ -61,6 +62,11 @@ then B<foo> is an alias for the official algorithm name, B<bar>.
 
 Display a list of public key algorithms, with each algorithm as
 a block of multiple lines, all but the first are indented.
+
+=item B<-public-key-methods>
+
+Display a list of public key method OIDs: this also includes public key methods
+without an associated ASN.1 method, for example, KDF algorithms.
 
 =item B<-disabled>
 

--- a/doc/man3/EVP_PKEY_meth_get_count.pod
+++ b/doc/man3/EVP_PKEY_meth_get_count.pod
@@ -1,0 +1,50 @@
+=pod
+
+=head1 NAME
+
+EVP_PKEY_meth_get_count, EVP_PKEY_meth_get0, EVP_PKEY_meth_get0_info - enumeratepublic key methods
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ size_t EVP_PKEY_meth_get_count(void);
+ const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx);
+ void EVP_PKEY_meth_get0_info(int *ppkey_id, int *pflags,
+                              const EVP_PKEY_METHOD *meth);
+
+=head1 DESCRIPTION
+
+EVP_PKEY_meth_count() returns a count of the number of public key methods
+available: it includes standard methods and any methods added by the
+application.
+
+EVP_PKEY_meth_get0() returns the public key method B<idx>. The value of B<idx>
+must be between zero and EVP_PKEY_meth_get_count() - 1.
+
+EVP_PKEY_meth_get0_info() returns the public key ID (a NID) and any flags
+associated with the public key method B<*meth>.
+
+=head1 RETURN VALUES
+
+EVP_PKEY_meth_count() returns the number of available public key methods.
+
+EVP_PKEY_meth_get0() return a public key method or B<NULL> if B<idx> is
+out of range.
+
+EVP_PKEY_meth_get0_info() does not return a value.
+
+=head1 SEE ALSO
+
+L<EVP_PKEY_new(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1263,6 +1263,8 @@ void EVP_PKEY_meth_get0_info(int *ppkey_id, int *pflags,
 void EVP_PKEY_meth_copy(EVP_PKEY_METHOD *dst, const EVP_PKEY_METHOD *src);
 void EVP_PKEY_meth_free(EVP_PKEY_METHOD *pmeth);
 int EVP_PKEY_meth_add0(const EVP_PKEY_METHOD *pmeth);
+size_t EVP_PKEY_meth_get_count(void);
+const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx);
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);

--- a/test/pkey_meth_test.c
+++ b/test/pkey_meth_test.c
@@ -15,13 +15,8 @@
 #include <openssl/evp.h>
 #include "testutil.h"
 
-/**********************************************************************
- *
- * Test of EVP_PKEY_ASN1 method ordering
- *
- ***/
-
-static int test_asn1_meths()
+/* Test of EVP_PKEY_ASN1_METHOD ordering */
+static int test_asn1_meths(void)
 {
     int i;
     int prev = -1;
@@ -52,8 +47,37 @@ static int test_asn1_meths()
     return good;
 }
 
+/* Test of EVP_PKEY_METHOD ordering */
+static int test_pkey_meths()
+{
+    size_t i;
+    int prev = -1;
+    int good = 1;
+    int pkey_id;
+    const EVP_PKEY_METHOD *pmeth;
+
+    for (i = 0; i < EVP_PKEY_meth_get_count(); i++) {
+        pmeth = EVP_PKEY_meth_get0(i);
+        EVP_PKEY_meth_get0_info(&pkey_id, NULL, pmeth);
+        if (pkey_id < prev)
+            good = 0;
+        prev = pkey_id;
+
+    }
+    if (!good) {
+        TEST_error("EVP_PKEY_METHOD table out of order");
+        for (i = 0; i < EVP_PKEY_meth_get_count(); i++) {
+            pmeth = EVP_PKEY_meth_get0(i);
+            EVP_PKEY_meth_get0_info(&pkey_id, NULL, pmeth);
+            TEST_note("%d : %s", pkey_id, OBJ_nid2ln(pkey_id));
+        }
+    }
+    return good;
+}
+
 int setup_tests()
 {
     ADD_TEST(test_asn1_meths);
+    ADD_TEST(test_pkey_meths);
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4371,3 +4371,5 @@ d2i_SCRYPT_PARAMS                       4313	1_1_1	EXIST::FUNCTION:SCRYPT
 SCRYPT_PARAMS_it                        4314	1_1_1	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:SCRYPT
 SCRYPT_PARAMS_it                        4314	1_1_1	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:SCRYPT
 CRYPTO_secure_clear_free                4315	1_1_0g	EXIST::FUNCTION:
+EVP_PKEY_meth_get0                      4316	1_1_1	EXIST::FUNCTION:
+EVP_PKEY_meth_get_count                 4317	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

This PR adds a way to enumerate public key methods. It adds a test to ensure the table is correctly ordered and adds a -public-key-methods switch to the list command.