### PR TITLE
Install custom RAND_METHOD for fuzzing

### DIFF
--- a/crypto/rand/ossl_rand.c
+++ b/crypto/rand/ossl_rand.c
@@ -27,10 +27,6 @@
 #include <internal/thread_once.h>
 #include "rand_lcl.h"
 
-#if defined(BN_DEBUG) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-# define PREDICT 1
-#endif
-
 #define STATE_SIZE      1023
 
 typedef struct ossl_rand_state_st OSSL_RAND_STATE;
@@ -58,10 +54,6 @@ static unsigned int crypto_lock_rand = 0;
  * valid iff crypto_lock_rand is set
  */
 static CRYPTO_THREAD_ID locking_threadid;
-
-#ifdef PREDICT
-int rand_predictable = 0;
-#endif
 
 static int rand_hw_seed(EVP_MD_CTX *ctx);
 
@@ -111,11 +103,6 @@ static int rand_add(const void *buf, int num, double add)
 
     if (!num)
         return 1;
-
-#ifdef PREDICT
-    if (rand_predictable)
-        return 1;
-#endif
 
     /*
      * (Based on the rand(3) manpage)
@@ -295,16 +282,6 @@ static int rand_bytes(unsigned char *buf, int num)
 #else
     struct timeval tv;
     gettimeofday(&tv, NULL);
-#endif
-
-#ifdef PREDICT
-    if (rand_predictable) {
-        unsigned char val = 1;
-
-        for (i = 0; i < num; i++)
-            buf[i] = val++;
-        return (1);
-    }
 #endif
 
     if (num <= 0)

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -31,11 +31,6 @@
 #include <openssl/rand.h>
 #include "fuzzer.h"
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-extern int rand_predictable;
-#endif
-#define ENTROPY_NEEDED 32
-
 static ASN1_ITEM_EXP *item_type[] = {
     ASN1_ITEM_ref(ACCESS_DESCRIPTION),
 #ifndef OPENSSL_NO_RFC3779
@@ -216,12 +211,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);
-    RAND_add("", 1, ENTROPY_NEEDED);
-    RAND_status();
-
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    rand_predictable = 1;
-#endif
+    FuzzerSetRand();
 
     return 1;
 }

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -18,11 +18,6 @@
 #include <openssl/err.h>
 #include "fuzzer.h"
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-extern int rand_predictable;
-#endif
-#define ENTROPY_NEEDED 32
-
 /* unused, to avoid warning. */
 static int idx;
 
@@ -50,15 +45,10 @@ int FuzzerInitialize(int *argc, char ***argv)
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
-    RAND_add("", 1, ENTROPY_NEEDED);
-    RAND_status();
+    FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
     OPENSSL_sk_sort((OPENSSL_STACK *)comp_methods);
 
-
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    rand_predictable = 1;
-#endif
 
     return 1;
 }

--- a/fuzz/fuzzer.h
+++ b/fuzz/fuzzer.h
@@ -11,3 +11,4 @@
 int FuzzerTestOneInput(const uint8_t *buf, size_t len);
 int FuzzerInitialize(int *argc, char ***argv);
 void FuzzerCleanup(void);
+void FuzzerSetRand(void);

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -465,11 +465,6 @@ static const char DSACertPEM[] = {
 };
 #endif
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-extern int rand_predictable;
-#endif
-#define ENTROPY_NEEDED 32
-
 /* unused, to avoid warning. */
 static int idx;
 
@@ -497,15 +492,10 @@ int FuzzerInitialize(int *argc, char ***argv)
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
-    RAND_add("", 1, ENTROPY_NEEDED);
-    RAND_status();
+    FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
     OPENSSL_sk_sort((OPENSSL_STACK *)comp_methods);
 
-
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    rand_predictable = 1;
-#endif
 
     return 1;
 }

--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -18,7 +18,38 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <openssl/crypto.h>
+#include <openssl/rand.h>
 #include "fuzzer.h"
+
+static int fuzz_bytes(unsigned char *buf, int num)
+{
+    unsigned char val = 1;
+
+    while (--num >= 0)
+        *buf++ = val++;
+    return 1;
+}
+
+static int fuzz_status(void)
+{
+    return 1;
+}
+
+static RAND_METHOD fuzz_rand_method = {
+    NULL,
+    fuzz_bytes,
+    NULL,
+    NULL,
+    fuzz_bytes,
+    fuzz_status
+};
+
+void FuzzerSetRand(void)
+{
+    RAND_set_rand_method(&fuzz_rand_method);
+}
+
+
 
 int main(int argc, char **argv) {
     int n;

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -14,22 +14,12 @@
 #include <openssl/rand.h>
 #include "fuzzer.h"
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-extern int rand_predictable;
-#endif
-#define ENTROPY_NEEDED 32
-
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_get_state();
     CRYPTO_free_ex_index(0, -1);
-    RAND_add("", 1, ENTROPY_NEEDED);
-    RAND_status();
-
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    rand_predictable = 1;
-#endif
+    FuzzerSetRand();
     return 1;
 }
 

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -28,10 +28,6 @@ struct rand_meth_st {
     int (*status) (void);
 };
 
-# ifdef BN_DEBUG
-extern int rand_predictable;
-# endif
-
 int RAND_set_rand_method(const RAND_METHOD *meth);
 const RAND_METHOD *RAND_get_rand_method(void);
 # ifndef OPENSSL_NO_ENGINE


### PR DESCRIPTION
Instead of setting a "magic" global variable to force RAND to keep
consistent state and always generate the same bytestream, have
the fuzzing code install its own RAND_METHOD that does this.  For
BN_RAND_DEBUG, we just don't do it; that debugging was about mucking
with BN's internal representation, not requiring predictable rand
bytes.

ping @kroeckx :)