### PR TITLE
WIP: Add scrypt as EVP_PKEY_METHOD

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -703,6 +703,9 @@ EVP_F_RC5_CTRL:125:rc5_ctrl
 EVP_F_UPDATE:173:update
 KDF_F_PKEY_HKDF_CTRL_STR:103:pkey_hkdf_ctrl_str
 KDF_F_PKEY_HKDF_DERIVE:102:pkey_hkdf_derive
+KDF_F_PKEY_SCRYPT_CTRL_STR:104:pkey_scrypt_ctrl_str
+KDF_F_PKEY_SCRYPT_CTRL_UINT64:105:pkey_scrypt_ctrl_uint64
+KDF_F_PKEY_SCRYPT_DERIVE:109:pkey_scrypt_derive
 KDF_F_PKEY_TLS1_PRF_CTRL_STR:100:pkey_tls1_prf_ctrl_str
 KDF_F_PKEY_TLS1_PRF_DERIVE:101:pkey_tls1_prf_derive
 OBJ_F_OBJ_ADD_OBJECT:105:OBJ_add_object
@@ -1966,12 +1969,16 @@ EVP_R_UNSUPPORTED_SALT_TYPE:126:unsupported salt type
 EVP_R_WRAP_MODE_NOT_ALLOWED:170:wrap mode not allowed
 EVP_R_WRONG_FINAL_BLOCK_LENGTH:109:wrong final block length
 KDF_R_INVALID_DIGEST:100:invalid digest
+KDF_R_MISSING_ITERATION_COUNT:109:missing iteration count
 KDF_R_MISSING_KEY:104:missing key
 KDF_R_MISSING_MESSAGE_DIGEST:105:missing message digest
 KDF_R_MISSING_PARAMETER:101:missing parameter
+KDF_R_MISSING_PASS:110:missing pass
+KDF_R_MISSING_SALT:111:missing salt
 KDF_R_MISSING_SECRET:107:missing secret
 KDF_R_MISSING_SEED:106:missing seed
 KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
+KDF_R_VALUE_ERROR:108:value error
 KDF_R_VALUE_MISSING:102:value missing
 OBJ_R_OID_EXISTS:102:oid exists
 OBJ_R_UNKNOWN_NID:101:unknown nid

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -21,6 +21,7 @@ typedef int sk_cmp_fn_type(const char *const *a, const char *const *b);
 
 static STACK_OF(EVP_PKEY_METHOD) *app_pkey_methods = NULL;
 
+/* This array needs to be in order of NIDs */
 static const EVP_PKEY_METHOD *standard_methods[] = {
 #ifndef OPENSSL_NO_RSA
     &rsa_pkey_meth,
@@ -43,6 +44,9 @@ static const EVP_PKEY_METHOD *standard_methods[] = {
 #endif
 #ifndef OPENSSL_NO_DH
     &dhx_pkey_meth,
+#endif
+#ifndef OPENSSL_NO_SCRYPT
+    &scrypt_pkey_meth,
 #endif
     &tls1_prf_pkey_meth,
 #ifndef OPENSSL_NO_EC
@@ -353,6 +357,12 @@ int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
 
     return ret;
 
+}
+
+int EVP_PKEY_CTX_ctrl_uint64(EVP_PKEY_CTX *ctx, int keytype, int optype,
+                                int cmd, uint64_t value)
+{
+    return EVP_PKEY_CTX_ctrl(ctx, keytype, optype, cmd, 0, &value);
 }
 
 int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx,

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -91,6 +91,7 @@ extern const EVP_PKEY_METHOD ed25519_pkey_meth;
 extern const EVP_PKEY_METHOD hmac_pkey_meth;
 extern const EVP_PKEY_METHOD rsa_pkey_meth;
 extern const EVP_PKEY_METHOD rsa_pss_pkey_meth;
+extern const EVP_PKEY_METHOD scrypt_pkey_meth;
 extern const EVP_PKEY_METHOD tls1_prf_pkey_meth;
 extern const EVP_PKEY_METHOD hkdf_pkey_meth;
 extern const EVP_PKEY_METHOD poly1305_pkey_meth;

--- a/crypto/kdf/build.info
+++ b/crypto/kdf/build.info
@@ -1,3 +1,3 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
-        tls1_prf.c kdf_err.c hkdf.c
+        tls1_prf.c kdf_err.c hkdf.c scrypt.c

--- a/crypto/kdf/kdf_err.c
+++ b/crypto/kdf/kdf_err.c
@@ -16,6 +16,11 @@
 static const ERR_STRING_DATA KDF_str_functs[] = {
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_HKDF_CTRL_STR, 0), "pkey_hkdf_ctrl_str"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_HKDF_DERIVE, 0), "pkey_hkdf_derive"},
+    {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_SCRYPT_CTRL_STR, 0),
+     "pkey_scrypt_ctrl_str"},
+    {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_SCRYPT_CTRL_UINT64, 0),
+     "pkey_scrypt_ctrl_uint64"},
+    {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_SCRYPT_DERIVE, 0), "pkey_scrypt_derive"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_TLS1_PRF_CTRL_STR, 0),
      "pkey_tls1_prf_ctrl_str"},
     {ERR_PACK(ERR_LIB_KDF, KDF_F_PKEY_TLS1_PRF_DERIVE, 0),
@@ -25,14 +30,19 @@ static const ERR_STRING_DATA KDF_str_functs[] = {
 
 static const ERR_STRING_DATA KDF_str_reasons[] = {
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_INVALID_DIGEST), "invalid digest"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_ITERATION_COUNT),
+    "missing iteration count"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_KEY), "missing key"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_MESSAGE_DIGEST),
     "missing message digest"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_PARAMETER), "missing parameter"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_PASS), "missing pass"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_SALT), "missing salt"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_SECRET), "missing secret"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_MISSING_SEED), "missing seed"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_UNKNOWN_PARAMETER_TYPE),
     "unknown parameter type"},
+    {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_VALUE_ERROR), "value error"},
     {ERR_PACK(ERR_LIB_KDF, 0, KDF_R_VALUE_MISSING), "value missing"},
     {0, NULL}
 };

--- a/crypto/kdf/scrypt.c
+++ b/crypto/kdf/scrypt.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/hmac.h>
+#include <openssl/kdf.h>
+#include <openssl/evp.h>
+#include "internal/cryptlib.h"
+#include "internal/evp_int.h"
+
+static int atou64(const char *nptr, uint64_t *result);
+
+typedef struct {
+    unsigned char *pass;
+    size_t pass_len;
+    unsigned char *salt;
+    size_t salt_len;
+    uint64_t N, r, p;
+    uint64_t maxmem_bytes;
+} SCRYPT_PKEY_CTX;
+
+/* Custom uint64_t parser since we do not have strtoull */
+static int atou64(const char *nptr, uint64_t *result)
+{
+    uint64_t value = 0;
+
+    while (*nptr) {
+        unsigned int digit;
+        uint64_t new_value;
+
+        if ((*nptr < '0') || (*nptr > '9')) {
+            return 0;
+        }
+        digit = (unsigned int)(*nptr - '0');
+        new_value = (value * 10) + digit;
+        if ((new_value < digit) || ((new_value - digit) / 10 != value)) {
+            /* Overflow */
+            return 0;
+        }
+        value = new_value;
+        nptr++;
+    }
+    *result = value;
+    return 1;
+}
+
+static int pkey_scrypt_init(EVP_PKEY_CTX *ctx)
+{
+    SCRYPT_PKEY_CTX *kctx;
+
+    kctx = OPENSSL_zalloc(sizeof(*kctx));
+    if (kctx == NULL)
+        return 0;
+
+    /* Default values are the most conservative recommendation given in the
+     * original paper of C. Percival. Derivation uses roughly 1 GiB of memory
+     * for this parameter choice (approx. 128 * r * (N + p) bytes).
+     */
+    kctx->N = 1 << 20;
+    kctx->r = 8;
+    kctx->p = 1;
+    kctx->maxmem_bytes = 1025 * 1024 * 1024;
+
+    ctx->data = kctx;
+
+    return 1;
+}
+
+static void pkey_scrypt_cleanup(EVP_PKEY_CTX *ctx)
+{
+    SCRYPT_PKEY_CTX *kctx = ctx->data;
+
+    OPENSSL_clear_free(kctx->salt, kctx->salt_len);
+    OPENSSL_clear_free(kctx->pass, kctx->pass_len);
+    OPENSSL_free(kctx);
+}
+
+static int pkey_scrypt_set_membuf(unsigned char **buffer, size_t *buflen,
+                                  const unsigned char *new_buffer,
+                                  const int new_buflen)
+{
+    if (new_buffer == NULL)
+        return 1;
+
+    if (new_buflen < 0)
+        return 0;
+
+    if (*buffer != NULL)
+        OPENSSL_clear_free(*buffer, *buflen);
+
+    if (new_buflen > 0) {
+        *buffer = OPENSSL_memdup(new_buffer, new_buflen);
+    } else {
+        *buffer = OPENSSL_malloc(1);
+    }
+    if (*buffer == NULL)
+        return 0;
+
+    *buflen = new_buflen;
+    return 1;
+}
+
+static int is_power_of_two(uint64_t value)
+{
+    return (value != 0) && ((value & (value - 1)) == 0);
+}
+
+static int pkey_scrypt_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
+{
+    SCRYPT_PKEY_CTX *kctx = ctx->data;
+    uint64_t u64_value;
+
+    switch (type) {
+    case EVP_PKEY_CTRL_PASS:
+        return pkey_scrypt_set_membuf(&kctx->pass, &kctx->pass_len, p2, p1);
+
+    case EVP_PKEY_CTRL_SCRYPT_SALT:
+        return pkey_scrypt_set_membuf(&kctx->salt, &kctx->salt_len, p2, p1);
+
+    case EVP_PKEY_CTRL_SCRYPT_N:
+        u64_value = *((uint64_t *)p2);
+        if ((u64_value <= 1) || !is_power_of_two(u64_value))
+            return 0;
+        kctx->N = u64_value;
+        return 1;
+
+    case EVP_PKEY_CTRL_SCRYPT_R:
+        u64_value = *((uint64_t *)p2);
+        if (u64_value < 1)
+            return 0;
+        kctx->r = u64_value;
+        return 1;
+
+    case EVP_PKEY_CTRL_SCRYPT_P:
+        u64_value = *((uint64_t *)p2);
+        if (u64_value < 1)
+            return 0;
+        kctx->p = u64_value;
+        return 1;
+
+    case EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES:
+        u64_value = *((uint64_t *)p2);
+        if (u64_value < 1)
+            return 0;
+        kctx->maxmem_bytes = u64_value;
+        return 1;
+
+    default:
+        return -2;
+
+    }
+}
+
+static int pkey_scrypt_ctrl_uint64(EVP_PKEY_CTX *ctx, int type,
+                                   const char *value)
+{
+    uint64_t int_value;
+
+    if (!atou64(value, &int_value)) {
+        KDFerr(KDF_F_PKEY_SCRYPT_CTRL_UINT64, KDF_R_VALUE_ERROR);
+        return 0;
+    }
+    return pkey_scrypt_ctrl(ctx, type, 0, &int_value);
+}
+
+static int pkey_scrypt_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
+                                const char *value)
+{
+    if (value == NULL) {
+        KDFerr(KDF_F_PKEY_SCRYPT_CTRL_STR, KDF_R_VALUE_MISSING);
+        return 0;
+    }
+
+    if (strcmp(type, "pass") == 0)
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_PASS, value);
+
+    if (strcmp(type, "hexpass") == 0)
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_PASS, value);
+
+    if (strcmp(type, "salt") == 0)
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_SCRYPT_SALT, value);
+
+    if (strcmp(type, "hexsalt") == 0)
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_SCRYPT_SALT, value);
+
+    if (strcmp(type, "N") == 0)
+        return pkey_scrypt_ctrl_uint64(ctx, EVP_PKEY_CTRL_SCRYPT_N, value);
+
+    if (strcmp(type, "r") == 0)
+        return pkey_scrypt_ctrl_uint64(ctx, EVP_PKEY_CTRL_SCRYPT_R, value);
+
+    if (strcmp(type, "p") == 0)
+        return pkey_scrypt_ctrl_uint64(ctx, EVP_PKEY_CTRL_SCRYPT_P, value);
+
+    if (strcmp(type, "maxmem_bytes") == 0)
+        return pkey_scrypt_ctrl_uint64(ctx, EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES,
+                                       value);
+
+    KDFerr(KDF_F_PKEY_SCRYPT_CTRL_STR, KDF_R_UNKNOWN_PARAMETER_TYPE);
+    return -2;
+}
+
+static int pkey_scrypt_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
+                              size_t *keylen)
+{
+    SCRYPT_PKEY_CTX *kctx = ctx->data;
+
+    if (kctx->pass == NULL) {
+        KDFerr(KDF_F_PKEY_SCRYPT_DERIVE, KDF_R_MISSING_PASS);
+        return 0;
+    }
+
+    if (kctx->salt == NULL) {
+        KDFerr(KDF_F_PKEY_SCRYPT_DERIVE, KDF_R_MISSING_SALT);
+        return 0;
+    }
+
+    return EVP_PBE_scrypt((char *)kctx->pass, kctx->pass_len, kctx->salt,
+                          kctx->salt_len, kctx->N, kctx->r, kctx->p,
+                          kctx->maxmem_bytes, key, *keylen);
+}
+
+const EVP_PKEY_METHOD scrypt_pkey_meth = {
+    EVP_PKEY_SCRYPT,
+    0,
+    pkey_scrypt_init,
+    0,
+    pkey_scrypt_cleanup,
+
+    0, 0,
+    0, 0,
+
+    0,
+    0,
+
+    0,
+    0,
+
+    0, 0,
+
+    0, 0, 0, 0,
+
+    0, 0,
+
+    0, 0,
+
+    0,
+    pkey_scrypt_derive,
+    pkey_scrypt_ctrl,
+    pkey_scrypt_ctrl_str
+};

--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -1987,7 +1987,7 @@ static const ASN1_OBJECT nid_objs[NUM_NID] = {
     {"CAMELLIA-256-CCM", "camellia-256-ccm", NID_camellia_256_ccm, 8, &so[6330]},
     {"CAMELLIA-256-CTR", "camellia-256-ctr", NID_camellia_256_ctr, 8, &so[6338]},
     {"CAMELLIA-256-CMAC", "camellia-256-cmac", NID_camellia_256_cmac, 8, &so[6346]},
-    {"id-scrypt", "id-scrypt", NID_id_scrypt, 9, &so[6354]},
+    {"id-scrypt", "scrypt", NID_id_scrypt, 9, &so[6354]},
     {"id-tc26", "id-tc26", NID_id_tc26, 5, &so[6363]},
     {"gost89-cnt-12", "gost89-cnt-12", NID_gost89_cnt_12},
     {"gost-mac-12", "gost-mac-12", NID_gost_mac_12},
@@ -3883,7 +3883,6 @@ static const unsigned int ln_objs[NUM_LN] = {
      314,    /* "id-regInfo" */
      322,    /* "id-regInfo-certReq" */
      321,    /* "id-regInfo-utf8Pairs" */
-     973,    /* "id-scrypt" */
      191,    /* "id-smime-aa" */
      215,    /* "id-smime-aa-contentHint" */
      218,    /* "id-smime-aa-contentIdentifier" */
@@ -4135,6 +4134,7 @@ static const unsigned int ln_objs[NUM_LN] = {
      291,    /* "sbgp-autonomousSysNum" */
      290,    /* "sbgp-ipAddrBlock" */
      292,    /* "sbgp-routerIdentifier" */
+     973,    /* "scrypt" */
      159,    /* "sdsiCertificate" */
      859,    /* "searchGuide" */
      704,    /* "secp112r1" */

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -1524,7 +1524,8 @@ secg-scheme 14 3 : dhSinglePass-cofactorDH-sha512kdf-scheme
 1 3 6 1 4 1 311 60 2 1 3	: jurisdictionC		: jurisdictionCountryName
 
 # SCRYPT algorithm
-1 3 6 1 4 1 11591 4 11		: id-scrypt
+!Cname id-scrypt
+1 3 6 1 4 1 11591 4 11		: id-scrypt         : scrypt
 
 # NID for TLS1 PRF
                             : TLS1-PRF          : tls1-prf

--- a/doc/man7/scrypt.pod
+++ b/doc/man7/scrypt.pod
@@ -1,0 +1,158 @@
+=pod
+
+=head1 NAME
+
+scrypt - EVP_PKEY scrypt KDF support
+
+=head1 SYNOPSIS
+
+ #include <openssl/kdf.h>
+ 
+ int EVP_PKEY_CTX_set1_pbe_pass(EVP_PKEY_CTX *pctx, unsigned char *pass,
+                                int passlen);
+
+ int EVP_PKEY_CTX_set1_scrypt_salt(EVP_PKEY_CTX *pctx, unsigned char *salt,
+                                   int saltlen);
+
+ int EVP_PKEY_CTX_set_scrypt_N(EVP_PKEY_CTX *pctx, uint64_t N);
+ 
+ int EVP_PKEY_CTX_set_scrypt_r(EVP_PKEY_CTX *pctx, uint64_t r);
+ 
+ int EVP_PKEY_CTX_set_scrypt_p(EVP_PKEY_CTX *pctx, uint64_t p);
+ 
+ int EVP_PKEY_CTX_set_scrypt_maxmem_bytes(EVP_PKEY_CTX *pctx, uint64_t maxmem);
+
+=head1 DESCRIPTION
+
+The EVP_PKEY_SCRYPT algorithm implements the scrypt password based key
+derivation function, as described in RFC 7914.  It is memory-hard in the sense
+that it deliberately requires a significant amount of RAM for efficient
+computation. The intention of this is to render brute forcing of passwords on
+systems that lack large amounts of main memory (such as GPUs or ASICs)
+computationally infeasible.
+
+scrypt provides three work factors that can be customized: N, r and p. N, which
+has to be a positive power of two, is the general work factor and scales CPU
+time in an approximately linear fashion. r is the block size of the internally
+used hash function and p is the parallelization factor. Both r and p need to be
+greater than zero. The amount of RAM that scrypt requires for its computation
+is roughly (128 * N * r * p) bytes.
+
+In the original paper of Colin Percival ("Stronger Key Derivation via
+Sequential Memory-Hard Functions", 2009), the suggested values that give a
+computation time of less than 5 seconds on a 2.5 GHz Intel Core 2 Duo are N =
+2^20 = 1048576, r = 8, p = 1. Consequently, the required amount of memory for
+this computation is roughly 1 GiB. On a more recent CPU (Intel i7-5930K at 3.5
+GHz), this computation takes about 3 seconds. When N, r or p are not specified,
+they default to 1048576, 8, and 1, respectively. The default amount of RAM that
+may be used by scrypt defaults to 1025 MiB.
+
+EVP_PKEY_CTX_set1_pbe_pass() sets the B<passlen> bytes long password.
+
+EVP_PKEY_CTX_set1_scrypt_salt() sets the B<saltlen> bytes long salt value.
+
+EVP_PKEY_CTX_set_scrypt_N(), EVP_PKEY_CTX_set_scrypt_r() and
+EVP_PKEY_CTX_set_scrypt_p() configure the work factors N, r and p. 
+
+EVP_PKEY_CTX_set_scrypt_maxmem_bytes() sets how much RAM key derivation may
+maximally use, given in bytes. If RAM is exceeded because the load factors are
+chosen too high, the key derivation will fail.
+
+=head1 STRING CTRLS
+
+scrypt also supports string based control operations via
+L<EVP_PKEY_CTX_ctrl_str(3)>.
+The B<password> can be directly specified using the B<type> parameter "pass" or
+given in hex encoding using the "hexpass" parameter. Similarly, the B<salt> can
+either be specified using the B<type> parameter "salt" or in hex encoding by
+using the "hexsalt" parameter. The work factors B<N>, B<r> and B<p> as well as
+B<maxmem_bytes> can be set by using the parameters "N", "r", "p" and
+"maxmem_bytes", respectively.
+
+=head1 NOTES
+
+All these functions are implemented as macros.
+
+A context for scrypt can be obtained by calling:
+
+ EVP_PKEY_CTX *pctx = EVP_PKEY_new_id(EVP_PKEY_SCRYPT, NULL);
+
+The output length of an scrypt key derivation is specified via the length
+parameter to the L<EVP_PKEY_derive(3)> function.
+
+=head1 RETURN VALUES
+
+All these functions return 1 for success and 0 or a negative value for failure.
+In particular a return value of -2 indicates the operation is not supported by
+the public key algorithm.
+
+=head1 EXAMPLE
+
+This example derives a 64-byte long test vector using scrypt using the password
+"password", salt "NaCl" and N = 1024, r = 8, p = 16.
+
+ EVP_PKEY_CTX *pctx;
+ unsigned char out[64];
+
+ size_t outlen = sizeof(out);
+ pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_SCRYPT, NULL);
+
+ if (EVP_PKEY_derive_init(pctx) <= 0) {
+     error("EVP_PKEY_derive_init");
+ }
+ if (EVP_PKEY_CTX_set1_pbe_pass(pctx, "password", 8) <= 0) {
+     error("EVP_PKEY_CTX_set1_pbe_pass");
+ }
+ if (EVP_PKEY_CTX_set1_scrypt_salt(pctx, "NaCl", 4) <= 0) {
+     error("EVP_PKEY_CTX_set1_scrypt_salt");
+ }
+ if (EVP_PKEY_CTX_set_scrypt_N(pctx, 1024) <= 0) {
+     error("EVP_PKEY_CTX_set_scrypt_N");
+ }
+ if (EVP_PKEY_CTX_set_scrypt_r(pctx, 8) <= 0) {
+     error("EVP_PKEY_CTX_set_scrypt_r");
+ }
+ if (EVP_PKEY_CTX_set_scrypt_p(pctx, 16) <= 0) {
+     error("EVP_PKEY_CTX_set_scrypt_p");
+ }
+ if (EVP_PKEY_derive(pctx, out, &outlen) <= 0) {
+     error("EVP_PKEY_derive");
+ }
+
+ {
+     const unsigned char expected[sizeof(out)] = {
+         0xfd, 0xba, 0xbe, 0x1c, 0x9d, 0x34, 0x72, 0x00,
+         0x78, 0x56, 0xe7, 0x19, 0x0d, 0x01, 0xe9, 0xfe,
+         0x7c, 0x6a, 0xd7, 0xcb, 0xc8, 0x23, 0x78, 0x30,
+         0xe7, 0x73, 0x76, 0x63, 0x4b, 0x37, 0x31, 0x62,
+         0x2e, 0xaf, 0x30, 0xd9, 0x2e, 0x22, 0xa3, 0x88,
+         0x6f, 0xf1, 0x09, 0x27, 0x9d, 0x98, 0x30, 0xda,
+         0xc7, 0x27, 0xaf, 0xb9, 0x4a, 0x83, 0xee, 0x6d,
+         0x83, 0x60, 0xcb, 0xdf, 0xa2, 0xcc, 0x06, 0x40
+     };
+
+     assert(!memcmp(out, expected, sizeof(out)));
+ }
+
+ EVP_PKEY_CTX_free(pctx);
+
+=head1 CONFORMING TO
+
+RFC 7914
+
+=head1 SEE ALSO
+
+L<EVP_PKEY_CTX_new(3)>,
+L<EVP_PKEY_CTX_ctrl_str(3)>,
+L<EVP_PKEY_derive(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -52,6 +52,7 @@
 # define EVP_PKEY_EC     NID_X9_62_id_ecPublicKey
 # define EVP_PKEY_HMAC   NID_hmac
 # define EVP_PKEY_CMAC   NID_cmac
+# define EVP_PKEY_SCRYPT NID_id_scrypt
 # define EVP_PKEY_TLS1_PRF NID_tls1_prf
 # define EVP_PKEY_HKDF   NID_hkdf
 # define EVP_PKEY_POLY1305 NID_poly1305
@@ -1275,6 +1276,8 @@ int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
                       int cmd, int p1, void *p2);
 int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
                           const char *value);
+int EVP_PKEY_CTX_ctrl_uint64(EVP_PKEY_CTX *ctx, int keytype, int optype,
+                                int cmd, uint64_t value);
 
 int EVP_PKEY_CTX_str2ctrl(EVP_PKEY_CTX *ctx, int cmd, const char *str);
 int EVP_PKEY_CTX_hex2ctrl(EVP_PKEY_CTX *ctx, int cmd, const char *hex);

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -23,6 +23,12 @@ extern "C" {
 # define EVP_PKEY_CTRL_HKDF_KEY                 (EVP_PKEY_ALG_CTRL + 5)
 # define EVP_PKEY_CTRL_HKDF_INFO                (EVP_PKEY_ALG_CTRL + 6)
 # define EVP_PKEY_CTRL_HKDF_MODE                (EVP_PKEY_ALG_CTRL + 7)
+# define EVP_PKEY_CTRL_PASS                     (EVP_PKEY_ALG_CTRL + 8)
+# define EVP_PKEY_CTRL_SCRYPT_SALT              (EVP_PKEY_ALG_CTRL + 9)
+# define EVP_PKEY_CTRL_SCRYPT_N                 (EVP_PKEY_ALG_CTRL + 10)
+# define EVP_PKEY_CTRL_SCRYPT_R                 (EVP_PKEY_ALG_CTRL + 11)
+# define EVP_PKEY_CTRL_SCRYPT_P                 (EVP_PKEY_ALG_CTRL + 12)
+# define EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES      (EVP_PKEY_ALG_CTRL + 13)
 
 # define EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND 0
 # define EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY       1
@@ -59,6 +65,31 @@ extern "C" {
 # define EVP_PKEY_CTX_hkdf_mode(pctx, mode) \
             EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
                               EVP_PKEY_CTRL_HKDF_MODE, mode, NULL)
+
+# define EVP_PKEY_CTX_set1_pbe_pass(pctx, pass, passlen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                            EVP_PKEY_CTRL_PASS, passlen, (void *)(pass))
+
+# define EVP_PKEY_CTX_set1_scrypt_salt(pctx, salt, saltlen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                            EVP_PKEY_CTRL_SCRYPT_SALT, saltlen, (void *)(salt))
+
+# define EVP_PKEY_CTX_set_scrypt_N(pctx, n) \
+            EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                            EVP_PKEY_CTRL_SCRYPT_N, n)
+
+# define EVP_PKEY_CTX_set_scrypt_r(pctx, r) \
+            EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                            EVP_PKEY_CTRL_SCRYPT_R, r)
+
+# define EVP_PKEY_CTX_set_scrypt_p(pctx, p) \
+            EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                            EVP_PKEY_CTRL_SCRYPT_P, p)
+
+# define EVP_PKEY_CTX_set_scrypt_maxmem_bytes(pctx, maxmem_bytes) \
+            EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                            EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES, maxmem_bytes)
+
 int ERR_load_KDF_strings(void);
 
 # ifdef  __cplusplus

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -24,6 +24,9 @@ int ERR_load_KDF_strings(void);
  */
 # define KDF_F_PKEY_HKDF_CTRL_STR                         103
 # define KDF_F_PKEY_HKDF_DERIVE                           102
+# define KDF_F_PKEY_SCRYPT_CTRL_STR                       104
+# define KDF_F_PKEY_SCRYPT_CTRL_UINT64                    105
+# define KDF_F_PKEY_SCRYPT_DERIVE                         109
 # define KDF_F_PKEY_TLS1_PRF_CTRL_STR                     100
 # define KDF_F_PKEY_TLS1_PRF_DERIVE                       101
 
@@ -31,12 +34,16 @@ int ERR_load_KDF_strings(void);
  * KDF reason codes.
  */
 # define KDF_R_INVALID_DIGEST                             100
+# define KDF_R_MISSING_ITERATION_COUNT                    109
 # define KDF_R_MISSING_KEY                                104
 # define KDF_R_MISSING_MESSAGE_DIGEST                     105
 # define KDF_R_MISSING_PARAMETER                          101
+# define KDF_R_MISSING_PASS                               110
+# define KDF_R_MISSING_SALT                               111
 # define KDF_R_MISSING_SECRET                             107
 # define KDF_R_MISSING_SEED                               106
 # define KDF_R_UNKNOWN_PARAMETER_TYPE                     103
+# define KDF_R_VALUE_ERROR                                108
 # define KDF_R_VALUE_MISSING                              102
 
 #endif

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -4735,6 +4735,7 @@
 #define OBJ_jurisdictionCountryName             1L,3L,6L,1L,4L,1L,311L,60L,2L,1L,3L
 
 #define SN_id_scrypt            "id-scrypt"
+#define LN_id_scrypt            "scrypt"
 #define NID_id_scrypt           973
 #define OBJ_id_scrypt           1L,3L,6L,1L,4L,1L,11591L,4L,11L
 

--- a/test/build.info
+++ b/test/build.info
@@ -41,7 +41,8 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
-          pkey_meth_test uitest cipherbytes_test asn1_encode_test asn1_string_table_test \
+          pkey_meth_test pkey_meth_kdf_test uitest cipherbytes_test \
+          asn1_encode_test asn1_string_table_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
@@ -291,6 +292,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[pkey_meth_test]=pkey_meth_test.c
   INCLUDE[pkey_meth_test]=../include
   DEPEND[pkey_meth_test]=../libcrypto libtestutil.a
+
+  SOURCE[pkey_meth_kdf_test]=pkey_meth_kdf_test.c
+  INCLUDE[pkey_meth_kdf_test]=../include
+  DEPEND[pkey_meth_kdf_test]=../libcrypto libtestutil.a
 
   SOURCE[x509_time_test]=x509_time_test.c
   INCLUDE[x509_time_test]=.. ../include

--- a/test/pkey_meth_kdf_test.c
+++ b/test/pkey_meth_kdf_test.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Tests of the EVP_PKEY_CTX_set_* macro family */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+#include "testutil.h"
+
+static int test_kdf_hkdf(void)
+{
+    EVP_PKEY_CTX *pctx;
+    unsigned char out[10];
+    size_t outlen = sizeof(out);
+    pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+
+    if (EVP_PKEY_derive_init(pctx) <= 0) {
+        TEST_error("EVP_PKEY_derive_init");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set_hkdf_md(pctx, EVP_sha256()) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set_hkdf_md");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, "salt", 4) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set1_hkdf_salt");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set1_hkdf_key(pctx, "secret", 6) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set1_hkdf_key");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_add1_hkdf_info(pctx, "label", 5) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set1_hkdf_info");
+        return 0;
+    }
+    if (EVP_PKEY_derive(pctx, out, &outlen) <= 0) {
+        TEST_error("EVP_PKEY_derive");
+        return 0;
+    }
+
+    {
+        const unsigned char expected[sizeof(out)] = {
+            0x2a, 0xc4, 0x36, 0x9f, 0x52, 0x59, 0x96, 0xf8, 0xde, 0x13
+        };
+        if (!TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))) {
+            return 0;
+        }
+    }
+    EVP_PKEY_CTX_free(pctx);
+    return 1;
+}
+
+static int test_kdf_scrypt(void)
+{
+    EVP_PKEY_CTX *pctx;
+    unsigned char out[64];
+    size_t outlen = sizeof(out);
+    pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_SCRYPT, NULL);
+
+    if (EVP_PKEY_derive_init(pctx) <= 0) {
+        TEST_error("EVP_PKEY_derive_init");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set1_pbe_pass(pctx, "password", 8) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set1_pbe_pass");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set1_scrypt_salt(pctx, "NaCl", 4) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set1_scrypt_salt");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set_scrypt_N(pctx, 1024) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set_scrypt_N");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set_scrypt_r(pctx, 8) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set_scrypt_r");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set_scrypt_p(pctx, 16) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set_scrypt_p");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set_scrypt_maxmem_bytes(pctx, 16) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set_maxmem_bytes");
+        return 0;
+    }
+    if (EVP_PKEY_derive(pctx, out, &outlen) > 0) {
+        TEST_error("EVP_PKEY_derive should have failed");
+        return 0;
+    }
+    if (EVP_PKEY_CTX_set_scrypt_maxmem_bytes(pctx, 10 * 1024 * 1024) <= 0) {
+        TEST_error("EVP_PKEY_CTX_set_maxmem_bytes");
+        return 0;
+    }
+    if (EVP_PKEY_derive(pctx, out, &outlen) <= 0) {
+        TEST_error("EVP_PKEY_derive");
+        return 0;
+    }
+
+    {
+        const unsigned char expected[sizeof(out)] = {
+            0xfd, 0xba, 0xbe, 0x1c, 0x9d, 0x34, 0x72, 0x00,
+            0x78, 0x56, 0xe7, 0x19, 0x0d, 0x01, 0xe9, 0xfe,
+            0x7c, 0x6a, 0xd7, 0xcb, 0xc8, 0x23, 0x78, 0x30,
+            0xe7, 0x73, 0x76, 0x63, 0x4b, 0x37, 0x31, 0x62,
+            0x2e, 0xaf, 0x30, 0xd9, 0x2e, 0x22, 0xa3, 0x88,
+            0x6f, 0xf1, 0x09, 0x27, 0x9d, 0x98, 0x30, 0xda,
+            0xc7, 0x27, 0xaf, 0xb9, 0x4a, 0x83, 0xee, 0x6d,
+            0x83, 0x60, 0xcb, 0xdf, 0xa2, 0xcc, 0x06, 0x40
+        };
+        if (!TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))) {
+            return 0;
+        }
+    }
+    EVP_PKEY_CTX_free(pctx);
+    return 1;
+}
+
+int setup_tests()
+{
+    ADD_TEST(test_kdf_hkdf);
+    ADD_TEST(test_kdf_scrypt);
+    return 1;
+}

--- a/test/recipes/30-test_evp_data/evpkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf.txt
@@ -252,4 +252,54 @@ Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
 Ctrl.salt = salt:
 Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
 
+Title = id-scrypt tests (from draft-josefsson-id-scrypt-kdf-03 and others)
+
+KDF = scrypt
+Ctrl.pass = pass:
+Ctrl.salt = salt:
+Ctrl.N = N:16
+Ctrl.r = r:1
+Ctrl.p = p:1
+Output = 77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906
+
+KDF = scrypt
+Ctrl.pass = pass:password
+Ctrl.salt = salt:NaCl
+Ctrl.N = N:1024
+Ctrl.r = r:8
+Ctrl.p = p:16
+Output = fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640
+
+KDF = scrypt
+Ctrl.hexpass = hexpass:70617373776f7264
+Ctrl.salt = salt:NaCl
+Ctrl.N = N:1024
+Ctrl.r = r:8
+Ctrl.p = p:16
+Output = fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640
+
+KDF = scrypt
+Ctrl.pass = pass:password
+Ctrl.hexsalt = hexsalt:4e61436c
+Ctrl.N = N:1024
+Ctrl.r = r:8
+Ctrl.p = p:16
+Output = fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640
+
+KDF = scrypt
+Ctrl.pass = pass:pleaseletmein
+Ctrl.salt = salt:SodiumChloride
+Ctrl.N = N:16384
+Ctrl.r = r:8
+Ctrl.p = p:1
+Output = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
+
+# Out of memory
+KDF = scrypt
+Ctrl.pass = pass:pleaseletmein
+Ctrl.salt = salt:SodiumChloride
+Ctrl.N = N:1048576
+Ctrl.r = r:8
+Ctrl.p = p:1
+Result = INTERNAL_ERROR
 

--- a/test/recipes/30-test_pkey_meth_kdf.t
+++ b/test/recipes/30-test_pkey_meth_kdf.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_pkey_meth_kdf", "pkey_meth_kdf_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4379,3 +4379,4 @@ BN_priv_rand_range                      4322	1_1_1	EXIST::FUNCTION:
 ASN1_TIME_normalize                     4323	1_1_1	EXIST::FUNCTION:
 ASN1_TIME_cmp_time_t                    4324	1_1_1	EXIST::FUNCTION:
 ASN1_TIME_compare                       4325	1_1_1	EXIST::FUNCTION:
+EVP_PKEY_CTX_ctrl_uint64                4326	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This adds the scrypt KDF as a EVP_PKEY_METHOD. It is onging work in progress; converted to a PR as of the request by @snhenson.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
