### PR TITLE
Define a value for SYS_F_FCNTL

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -89,6 +89,7 @@ static ERR_STRING_DATA ERR_str_functs[] = {
     {ERR_PACK(0, SYS_F_CLOSE, 0), "close"},
     {ERR_PACK(0, SYS_F_IOCTL, 0), "ioctl"},
     {ERR_PACK(0, SYS_F_STAT, 0), "stat"},
+    {ERR_PACK(0, SYS_F_FCNTL, 0), "fcntl"},
     {0, NULL},
 };
 

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -165,6 +165,7 @@ typedef struct err_state_st {
 # define SYS_F_CLOSE             20
 # define SYS_F_IOCTL             21
 # define SYS_F_STAT              22
+# define SYS_F_FCNTL             23
 
 /* reasons */
 # define ERR_R_SYS_LIB   ERR_LIB_SYS/* 2 */


### PR DESCRIPTION
This symbol was added in commit d33b215b331116e50947ca7e75d210e1db39b78d
but was only used in certain (presumed uncommon) preprocessor conditionals,
as no build failures have been reported yet.

Reported by Balaji Marisetti.

Closes: #4029

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
