### PR TITLE
Enginetest fails to link if OPENSSL_NO_ENGINE is defined

### DIFF
--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -12,12 +12,13 @@
 #include <stdlib.h>
 #include <openssl/e_os2.h>
 
+# include "testutil.h"
+
 #ifndef OPENSSL_NO_ENGINE
 # include <openssl/buffer.h>
 # include <openssl/crypto.h>
 # include <openssl/engine.h>
 # include <openssl/err.h>
-# include "testutil.h"
 
 static void display_engine_list(void)
 {

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -142,7 +142,7 @@ const char *test_get_option_argument(const char *option);
  * rather link to one of the helper main() methods.
  */
 
-void add_test(const char *test_case_name, int (*test_fn) ());
+void add_test(const char *test_case_name, int (*test_fn) (void));
 void add_all_tests(const char *test_case_name, int (*test_fn)(int idx), int num,
                    int subtest);
 
@@ -170,7 +170,7 @@ void cleanup_tests(void);
 # endif
 #endif
 
-#  define DECLARE_COMPARISON(type, name, opname)                        \
+# define DECLARE_COMPARISON(type, name, opname)                         \
     int test_ ## name ## _ ## opname(const char *, int,                 \
                                      const char *, const char *,        \
                                      const type, const type);


### PR DESCRIPTION

- [x] tests are added or updated

Also fixed an indent issue and a prototype one.
