### PR TITLE
Refactor ASN1_TIME_print functions to reduce duplicated code

### DIFF
--- a/crypto/asn1/a_gentm.c
+++ b/crypto/asn1/a_gentm.c
@@ -108,56 +108,9 @@ ASN1_GENERALIZEDTIME *ASN1_GENERALIZEDTIME_adj(ASN1_GENERALIZEDTIME *s,
     return NULL;
 }
 
-static const char _asn1_mon[12][4] = {
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-};
-
 int ASN1_GENERALIZEDTIME_print(BIO *bp, const ASN1_GENERALIZEDTIME *tm)
 {
-    char *v;
-    int gmt = 0;
-    int i;
-    int y = 0, M = 0, d = 0, h = 0, m = 0, s = 0;
-    char *f = NULL;
-    int f_len = 0;
-
-    i = tm->length;
-    v = (char *)tm->data;
-
-    if (i < 12)
-        goto err;
-    if (v[i - 1] == 'Z')
-        gmt = 1;
-    for (i = 0; i < 12; i++)
-        if ((v[i] > '9') || (v[i] < '0'))
-            goto err;
-    y = (v[0] - '0') * 1000 + (v[1] - '0') * 100
-        + (v[2] - '0') * 10 + (v[3] - '0');
-    M = (v[4] - '0') * 10 + (v[5] - '0');
-    if ((M > 12) || (M < 1))
-        goto err;
-    d = (v[6] - '0') * 10 + (v[7] - '0');
-    h = (v[8] - '0') * 10 + (v[9] - '0');
-    m = (v[10] - '0') * 10 + (v[11] - '0');
-    if (tm->length >= 14 &&
-        (v[12] >= '0') && (v[12] <= '9') &&
-        (v[13] >= '0') && (v[13] <= '9')) {
-        s = (v[12] - '0') * 10 + (v[13] - '0');
-        /* Check for fractions of seconds. */
-        if (tm->length >= 15 && v[14] == '.') {
-            int l = tm->length;
-            f = &v[14];         /* The decimal point. */
-            f_len = 1;
-            while (14 + f_len < l && f[f_len] >= '0' && f[f_len] <= '9')
-                ++f_len;
-        }
-    }
-
-    return BIO_printf(bp, "%s %2d %02d:%02d:%02d%.*s %d%s",
-                      _asn1_mon[M - 1], d, h, m, s, f_len, f, y,
-                      (gmt) ? " GMT" : "") > 0;
- err:
-    BIO_write(bp, "Bad time value", 14);
-    return 0;
+    if (tm->type != V_ASN1_GENERALIZEDTIME)
+        return 0;
+    return ASN1_TIME_print(bp, tm);
 }

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -457,8 +457,10 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
     int f_len = 0;
     int l = 0, idx = 0;
 
-    if (tm->type != V_ASN1_UTCTIME && tm->type != V_ASN1_GENERALIZEDTIME)
+    if (!asn1_time_to_tm(NULL, tm)) {
+        /* asn1_time_to_tm will check the time type */
         goto err;
+    }
 
     i = tm->length;
     v = (char *)tm->data;

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -463,7 +463,7 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
     i = tm->length;
     v = (char *)tm->data;
 
-    l = (tm->type == V_ASN1_GENERALIZEDTIME) ? 12 :10;
+    l = (tm->type == V_ASN1_GENERALIZEDTIME) ? 12 : 10;
 
     if (i < l)
         goto err;
@@ -495,9 +495,9 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
         s = (v[idx] - '0') * 10 + (v[idx + 1] - '0');
         if (tm->type == V_ASN1_GENERALIZEDTIME) {
             /* Check for fractions of seconds. */
-            if (tm->length >= 15 && v[14] == '.') {
+            if (tm->length >= 15 && v[idx + 2] == '.') {
                 l = tm->length;
-                f = &v[14];         /* The decimal point. */
+                f = &v[idx + 2];         /* The decimal point. */
                 f_len = 1;
                 while (14 + f_len < l && f[f_len] >= '0' && f[f_len] <= '9')
                     ++f_len;

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -129,45 +129,9 @@ int ASN1_UTCTIME_cmp_time_t(const ASN1_UTCTIME *s, time_t t)
     return 0;
 }
 
-static const char _asn1_mon[12][4] = {
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-};
-
 int ASN1_UTCTIME_print(BIO *bp, const ASN1_UTCTIME *tm)
 {
-    const char *v;
-    int gmt = 0;
-    int i;
-    int y = 0, M = 0, d = 0, h = 0, m = 0, s = 0;
-
-    i = tm->length;
-    v = (const char *)tm->data;
-
-    if (i < 10)
-        goto err;
-    if (v[i - 1] == 'Z')
-        gmt = 1;
-    for (i = 0; i < 10; i++)
-        if ((v[i] > '9') || (v[i] < '0'))
-            goto err;
-    y = (v[0] - '0') * 10 + (v[1] - '0');
-    if (y < 50)
-        y += 100;
-    M = (v[2] - '0') * 10 + (v[3] - '0');
-    if ((M > 12) || (M < 1))
-        goto err;
-    d = (v[4] - '0') * 10 + (v[5] - '0');
-    h = (v[6] - '0') * 10 + (v[7] - '0');
-    m = (v[8] - '0') * 10 + (v[9] - '0');
-    if (tm->length >= 12 &&
-        (v[10] >= '0') && (v[10] <= '9') && (v[11] >= '0') && (v[11] <= '9'))
-        s = (v[10] - '0') * 10 + (v[11] - '0');
-
-    return BIO_printf(bp, "%s %2d %02d:%02d:%02d %d%s",
-                      _asn1_mon[M - 1], d, h, m, s, y + 1900,
-                      (gmt) ? " GMT" : "") > 0;
- err:
-    BIO_write(bp, "Bad time value", 14);
-    return 0;
+    if (tm->type != V_ASN1_UTCTIME)
+        return 0;
+    return ASN1_TIME_print(bp, tm);
 }


### PR DESCRIPTION
This follow[s] what discussed at https://github.com/openssl/openssl/pull/4001#discussion_r129092251

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
