### PR TITLE
Perl: Use File::Glob::bsd_glob rather than File::Glob::glob

### DIFF
--- a/Configure
+++ b/Configure
@@ -15,7 +15,7 @@ use Config;
 use File::Basename;
 use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs/;
 use File::Path qw/mkpath/;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 
 # see INSTALL for instructions.
 

--- a/test/build.info
+++ b/test/build.info
@@ -450,7 +450,7 @@ ENDIF
 {-
    use File::Spec::Functions;
    use File::Basename;
-   use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+   use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 
    my @nogo_headers = ( "asn1_mac.h",
                         "__decc_include_prologue.h",

--- a/test/recipes/15-test_ecparam.t
+++ b/test/recipes/15-test_ecparam.t
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 use OpenSSL::Test qw/:DEFAULT data_file/;
 use OpenSSL::Test::Utils;
 

--- a/test/recipes/40-test_rehash.t
+++ b/test/recipes/40-test_rehash.t
@@ -13,7 +13,7 @@ use warnings;
 use File::Spec::Functions;
 use File::Copy;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_rehash");

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -12,7 +12,7 @@ use warnings;
 
 use File::Basename;
 use File::Compare qw/compare_text/;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 
 use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file/;
 use OpenSSL::Test::Utils qw/disabled alldisabled available_protocols/;

--- a/test/recipes/99-test_fuzz.t
+++ b/test/recipes/99-test_fuzz.t
@@ -9,7 +9,7 @@
 use strict;
 use warnings;
 
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 use OpenSSL::Test qw/:DEFAULT srctop_file/;
 use OpenSSL::Test::Utils;
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -16,7 +16,7 @@ BEGIN {
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 use Module::Load::Conditional qw(can_load);
 
 my $TAP_Harness = can_load(modules => { 'TAP::Harness' => undef }) 

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -49,7 +49,7 @@ use lib ".";
 use configdata;
 use File::Spec::Functions;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 
 my $debug=0;
 

--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -13,7 +13,7 @@ use File::Spec::Functions;
 use File::Basename;
 use File::Copy;
 use File::Path;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use if $^O ne "VMS", 'File::Glob' => qw/:bsd_glob/;
 use Getopt::Long;
 use Pod::Usage;
 


### PR DESCRIPTION
File::Glob::glob is deprecated, it's use generates this kind of
message:

    File::Glob::glob() will disappear in perl 5.30. Use File::Glob::bsd_glob() instead. at ../master/Configure line 277.

So instead, use a construction that makes the caller glob() use
File::Glob::bsd_glob().

Note that we're still excluding VMS, as it's directory specs use '['
and ']', which have a different meaning with bsd_glob and would need
some extra quoting.  This might change, but later.
