### PR TITLE
Update ASN1_TIME_to_tm's documentaion

### DIFF
--- a/doc/man3/ASN1_TIME_set.pod
+++ b/doc/man3/ASN1_TIME_set.pod
@@ -58,7 +58,9 @@ If B<s> is NULL, then the current time is converted. The output time is GMT.
 The B<tm_sec>, B<tm_min>, B<tm_hour>, B<tm_mday>, B<tm_wday>, B<tm_yday>,
 B<tm_mon> and B<tm_year> fields of B<tm> structure are set to proper values,
 whereas all other fields are set to 0. If B<tm> is NULL this function performs
-a format check on B<s> only.
+a format check on B<s> only. If B<s> is in Generalized format with franctional
+seconds, e.g. YYYYMMDDHHMMSS.SSSZ, the fractional seconds will be lost while
+converting B<s> to B<tm> structure.
 
 ASN1_TIME_diff() sets B<*pday> and B<*psec> to the time difference between
 B<from> and B<to>. If B<to> represents a time later than B<from> then


### PR DESCRIPTION
To state the fractional seconds part will be lost in the conversion.

[skip ci]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
