### PR TITLE
Fix rsa -check option

### DIFF
--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -217,7 +217,7 @@ int rsa_main(int argc, char **argv)
     }
 
     if (check) {
-        int r = RSA_check_key(rsa);
+        int r = RSA_check_key_ex(rsa, NULL);
 
         if (r == 1) {
             BIO_printf(out, "RSA key ok\n");
@@ -226,7 +226,7 @@ int rsa_main(int argc, char **argv)
 
             while ((err = ERR_peek_error()) != 0 &&
                    ERR_GET_LIB(err) == ERR_LIB_RSA &&
-                   ERR_GET_FUNC(err) == RSA_F_RSA_CHECK_KEY &&
+                   ERR_GET_FUNC(err) == RSA_F_RSA_CHECK_KEY_EX &&
                    ERR_GET_REASON(err) != ERR_R_MALLOC_FAILURE) {
                 BIO_printf(out, "RSA key error: %s\n",
                            ERR_reason_error_string(err));


### PR DESCRIPTION
original problem: if a private key is invaild, nothing outputted. Reported in openssl-user mailing list.

the error filter in apps/rsa.c is not working any more. [Filtering on `RSA_F_RSA_CHECK_KEY`]

Since the `FUNC` is with `_EX` now, I also changed to call `RSA_check_key_ex` to keep consistent...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
