### PR TITLE
Fix leaked password in pkcs8 pkey decrypt

### DIFF
--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -131,6 +131,7 @@ EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
     }
     p8inf = PKCS8_decrypt(p8, psbuf, klen);
     X509_SIG_free(p8);
+    OPENSSL_cleanse(psbuf, klen);
     if (!p8inf)
         return NULL;
     ret = EVP_PKCS82PKEY(p8inf);

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -67,6 +67,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
         }
         p8inf = PKCS8_decrypt(p8, psbuf, klen);
         X509_SIG_free(p8);
+        OPENSSL_cleanse(psbuf, klen);
         if (!p8inf)
             goto p8err;
         ret = EVP_PKCS82PKEY(p8inf);

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -74,7 +74,7 @@ my $n = (3 * scalar @noexist_files)
     + (4 * scalar @generated_files)
     + (scalar keys %generated_file_files)
     + (scalar @noexist_file_files)
-    + 3;
+    + 4;
 
 plan tests => $n;
 
@@ -82,6 +82,10 @@ indir "store_$$" => sub {
  SKIP:
     {
         skip "failed initialisation", $n unless init();
+
+        # test PEM_read_bio_PrivateKey
+        ok(run(app(["openssl", "rsa", "-in", "rsa-key-pkcs8-pbes2-sha256.pem",
+                    "-passin", "pass:password"])));
 
         foreach (@noexist_files) {
             my $file = srctop_file($_);


### PR DESCRIPTION
When a pkcs8 private key is decrypted the used password is left on the stack.
As there is zero test coverage, I wanted to have at least one test that executes
this code, so I thought I extend the only test that uses the pkcs8 command.