### PR TITLE
Fix typo in SSL_state_string_long

### DIFF
--- a/ssl/ssl_stat.c
+++ b/ssl/ssl_stat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright 2005 Nokia. All rights reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use

--- a/ssl/ssl_stat.c
+++ b/ssl/ssl_stat.c
@@ -24,7 +24,7 @@ const char *SSL_state_string_long(const SSL *s)
     case TLS_ST_SR_NEXT_PROTO:
         return "SSLv3/TLS read next proto";
     case TLS_ST_SW_CERT_STATUS:
-        return "SSLv3/TLS write next proto";
+        return "SSLv3/TLS write certificate status";
     case TLS_ST_BEFORE:
         return "before SSL initialization";
     case TLS_ST_OK:

--- a/ssl/ssl_stat.c
+++ b/ssl/ssl_stat.c
@@ -22,7 +22,7 @@ const char *SSL_state_string_long(const SSL *s)
     case TLS_ST_CW_NEXT_PROTO:
         return "SSLv3/TLS write next proto";
     case TLS_ST_SR_NEXT_PROTO:
-        return "SSLv3/TLS write next proto";
+        return "SSLv3/TLS read next proto";
     case TLS_ST_SW_CERT_STATUS:
         return "SSLv3/TLS write next proto";
     case TLS_ST_BEFORE:


### PR DESCRIPTION
I guess TLS_ST_SR_NEXT_PROTO means "SSLv3/TLS read next proto" and `TLS_ST_SW_CERT_STATUS` means "SSLv3/TLS write certificate status".