### PR TITLE
asn1/a_time.c: make handling of 'fractional point' formally correct.

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -463,28 +463,29 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
     v = (char *)tm->data;
     if (v[l - 1] == 'Z')
         gmt = 1;
-    /*
-     * Try to parse fractional seconds. '14' is the place of
-     * 'fraction point' in a GeneralizedTime string.
-     */
-    if (tm->type == V_ASN1_GENERALIZEDTIME
-        && tm->length >= 15 && v[14] == '.') {
-        f = &v[14];
-        f_len = 1;
-        while (14 + f_len < l && f[f_len] >= '0' && f[f_len] <= '9')
-            ++f_len;
-    }
 
-    if (tm->type == V_ASN1_GENERALIZEDTIME)
+    if (tm->type == V_ASN1_GENERALIZEDTIME) {
+        /*
+         * Try to parse fractional seconds. '14' is the place of
+         * 'fraction point' in a GeneralizedTime string.
+         */
+        if (tm->length > 15 && v[14] == '.') {
+            f = &v[14];
+            f_len = 1;
+            while (14 + f_len < l && f[f_len] >= '0' && f[f_len] <= '9')
+                ++f_len;
+        }
+
         return BIO_printf(bp, "%s %2d %02d:%02d:%02d%.*s %d%s",
                           _asn1_mon[stm.tm_mon], stm.tm_mday, stm.tm_hour,
                           stm.tm_min, stm.tm_sec, f_len, f, stm.tm_year + 1900,
-                          (gmt) ? " GMT" : "") > 0;
-    else
+                          (gmt ? " GMT" : "")) > 0;
+    } else {
         return BIO_printf(bp, "%s %2d %02d:%02d:%02d %d%s",
                           _asn1_mon[stm.tm_mon], stm.tm_mday, stm.tm_hour,
                           stm.tm_min, stm.tm_sec, stm.tm_year + 1900,
-                          (gmt) ? " GMT" : "") > 0;
+                          (gmt ? " GMT" : "")) > 0;
+    }
  err:
     BIO_write(bp, "Bad time value", 14);
     return 0;

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -450,8 +450,7 @@ static const char _asn1_mon[12][4] = {
 int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
 {
     char *v;
-    char *f = NULL;
-    int f_len = 0, gmt = 0, l;
+    int gmt = 0, l;
     struct tm stm;
 
     if (!asn1_time_to_tm(&stm, tm)) {
@@ -465,6 +464,9 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
         gmt = 1;
 
     if (tm->type == V_ASN1_GENERALIZEDTIME) {
+        char *f = NULL;
+        int f_len = 0;
+
         /*
          * Try to parse fractional seconds. '14' is the place of
          * 'fraction point' in a GeneralizedTime string.


### PR DESCRIPTION
Even though tm->length >= 15 && v[14] == '.' works in practice,
[because "YYYYMMDDHHMMSS." would be rejected as invalid by
asn1_time_to_tm,] formal correctness with respect to buffer
overstep in few lines vicinity improves readability.

[Also fold one if condition and improve expression readability.]
