### PR TITLE
RSA_get0_ functions permit NULL parameters

### DIFF
--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -58,6 +58,10 @@ set with RSA_get0_factors() and RSA_set0_factors(), and the B<dmp1>,
 B<dmq1> and B<iqmp> parameters can be obtained and set with
 RSA_get0_crt_params() and RSA_set0_crt_params().
 
+For RSA_get0_key(), RSA_get0_factors(), and RSA_get0_crt_params(),  
+NULL value BIGNUM ** output parameters are permitted.  The functions 
+ignores NULL parameters but return values for other, non-NULL, parameters.
+
 RSA_set_flags() sets the flags in the B<flags> parameter on the RSA
 object. Multiple flags can be passed in one go (bitwise ORed together).
 Any flags that are already set are left set. RSA_test_flags() tests to


### PR DESCRIPTION
Document that the RSA_get0_ functions permit a NULL BIGNUM **.  Those output parameters are ignored.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
