### PR TITLE
Fix an information leak in the RSA padding check code

### DIFF
--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -117,7 +117,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
                                       int plen, const EVP_MD *md,
                                       const EVP_MD *mgf1md)
 {
-    int i, dblen, mlen = -1, one_index = 0, msg_index;
+    int i, dblen = 0, mlen = -1, one_index = 0, msg_index;
     unsigned int good, found_one_byte;
     const unsigned char *maskedseed, *maskeddb;
     /*
@@ -234,8 +234,8 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1,
            RSA_R_OAEP_DECODING_ERROR);
  cleanup:
-    OPENSSL_free(db);
-    OPENSSL_free(em);
+    OPENSSL_clear_free(db, dblen);
+    OPENSSL_clear_free(em, num);
     return mlen;
 }
 

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -235,7 +235,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     memcpy(to, em + msg_index, mlen);
 
  err:
-    OPENSSL_free(em);
+    OPENSSL_clear_free(em, num);
     if (mlen == -1)
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_2,
                RSA_R_PKCS_DECODING_ERROR);


### PR DESCRIPTION
The memory blocks contain secret data and must be
cleared before returning to the system heap.
This happens for PCKS#1 padding and OAEP.