### PR TITLE
Fix information leak in rsa padding check

### DIFF
--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -237,10 +237,14 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1,
            RSA_R_OAEP_DECODING_ERROR);
  cleanup:
-    if (db != NULL)
+    if (db != NULL) {
+        OPENSSL_cleanse(db, dblen);
         OPENSSL_free(db);
-    if (em != NULL)
+    }
+    if (em != NULL) {
+        OPENSSL_cleanse(em, num);
         OPENSSL_free(em);
+    }
     return mlen;
 }
 

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -264,8 +264,10 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     memcpy(to, em + msg_index, mlen);
 
  err:
-    if (em != NULL)
+    if (em != NULL) {
+        OPENSSL_cleanse(em, num);
         OPENSSL_free(em);
+    }
     if (mlen == -1)
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_2,
                RSA_R_PKCS_DECODING_ERROR);


### PR DESCRIPTION
The memory blocks contain secret data and must be
cleared before returning to the system heap.
This PR is for the 1.0.2 branch