### PR TITLE
Fix typo in documents

### DIFF
--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -166,14 +166,14 @@ Don't output the text form of a certificate to the output file.
 This allows the start date to be explicitly set. The format of the
 date is YYMMDDHHMMSSZ (the same as an ASN1 UTCTime structure), or
 YYYYMMDDHHMMSSZ (the same as an ASN1 GeneralizedTime structure). In
-both formats, seconds SS and timzone Z must be present.
+both formats, seconds SS and timezone Z must be present.
 
 =item B<-enddate date>
 
 This allows the expiry date to be explicitly set. The format of the
 date is YYMMDDHHMMSSZ (the same as an ASN1 UTCTime structure), or
 YYYYMMDDHHMMSSZ (the same as an ASN1 GeneralizedTime structure). In
-both formats, seconds SS and timzone Z must be present.
+both formats, seconds SS and timezone Z must be present.
 
 =item B<-days arg>
 

--- a/doc/man3/BIO_get_ex_new_index.pod
+++ b/doc/man3/BIO_get_ex_new_index.pod
@@ -45,7 +45,7 @@ with the correct B<index> value.
 TYPE_set_ex_data() is a function that calls CRYPTO_set_ex_data() with
 an offset into the opaque exdata part of the TYPE object.
 
-TYPE_get_ex_data() is a function that calls CRYPTO_get_ex_data() with an
+TYPE_get_ex_data() is a function that calls CRYPTO_get_ex_data() with
 an offset into the opaque exdata part of the TYPE object.
 
 =head1 SEE ALSO
@@ -54,7 +54,7 @@ L<CRYPTO_get_ex_new_index(3)>.
 
 =head1 COPYRIGHT
 
-Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BIO_meth_new.pod
+++ b/doc/man3/BIO_meth_new.pod
@@ -59,7 +59,7 @@ BIO_meth_set_callback_ctrl - Routines to build up BIO methods
 =head1 DESCRIPTION
 
 The B<BIO_METHOD> type is a structure used for the implementation of new BIO
-types. It provides a set of of functions used by OpenSSL for the implementation
+types. It provides a set of functions used by OpenSSL for the implementation
 of the various BIO capabilities. See the L<bio> page for more information.
 
 BIO_meth_new() creates a new B<BIO_METHOD> structure. It should be given a
@@ -143,7 +143,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -87,7 +87,7 @@ BN_bn2binpad() returns the number of bytes written or -1 if the supplied
 buffer is too small.
 
 BN_bn2hex() and BN_bn2dec() return a null-terminated string, or NULL
-on error. BN_hex2bn() and BN_dec2bn() return the the length of valid
+on error. BN_hex2bn() and BN_dec2bn() return the length of valid
 representation in hexadecimal or decimal digits, and 0 on error, in which
 case no new B<BIGNUM> will be created.
 

--- a/doc/man3/DH_meth_new.pod
+++ b/doc/man3/DH_meth_new.pod
@@ -59,7 +59,7 @@ DH_meth_set_generate_params - Routines to build up DH methods
 =head1 DESCRIPTION
 
 The B<DH_METHOD> type is a structure used for the provision of custom DH
-implementations. It provides a set of of functions used by OpenSSL for the
+implementations. It provides a set of functions used by OpenSSL for the
 implementation of the various DH capabilities.
 
 DH_meth_new() creates a new B<DH_METHOD> structure. It should be given a
@@ -157,7 +157,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/DSA_meth_new.pod
+++ b/doc/man3/DSA_meth_new.pod
@@ -87,7 +87,7 @@ DSA_meth_set_keygen - Routines to build up DSA methods
 =head1 DESCRIPTION
 
 The B<DSA_METHOD> type is a structure used for the provision of custom DSA
-implementations. It provides a set of of functions used by OpenSSL for the
+implementations. It provides a set of functions used by OpenSSL for the
 implementation of the various DSA capabilities. See the L<dsa> page for more
 information.
 
@@ -205,7 +205,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -148,7 +148,7 @@ Use the default EVP routines to pass IV to and from ASN.1.
 =item EVP_CIPH_FLAG_LENGTH_BITS
 
 Signals that the length of the input buffer for encryption /
-decryption is to be understood as the number of bits bits instead of
+decryption is to be understood as the number of bits instead of
 bytes for this implementation.
 This is only useful for CFB1 ciphers.
 
@@ -226,7 +226,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/EVP_PKEY_print_private.pod
+++ b/doc/man3/EVP_PKEY_print_private.pod
@@ -28,8 +28,7 @@ be used.
 
 =head1 NOTES
 
-Currently no public key algorithms include any options in the B<pctx> parameter
-parameter.
+Currently no public key algorithms include any options in the B<pctx> parameter.
 
 If the key does not include all the components indicated by the function then
 only those contained in the key will be printed. For example passing a public
@@ -52,7 +51,7 @@ These functions were first added to OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 
-Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/EVP_PKEY_verify.pod
+++ b/doc/man3/EVP_PKEY_verify.pod
@@ -36,7 +36,7 @@ context if several operations are performed using the same parameters.
 
 EVP_PKEY_verify_init() and EVP_PKEY_verify() return 1 if the verification was
 successful and 0 if it failed. Unlike other functions the return value 0 from
-EVP_PKEY_verify() only indicates that the signature did not not verify
+EVP_PKEY_verify() only indicates that the signature did not verify
 successfully (that is tbs did not match the original data or the signature was
 of invalid form) it is not an indication of a more serious error.
 
@@ -93,7 +93,7 @@ These functions were first added to OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 
-Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/OPENSSL_fork_prepare.pod
+++ b/doc/man3/OPENSSL_fork_prepare.pod
@@ -29,7 +29,7 @@ to call them manually, as described in the following paragraph.  Platforms
 such as Linux that have both functions will normally not need to call these
 functions as the OpenSSL library will do so automatically.
 
-L<OPENSSL_init_crypto(3)> will register these funtions with the appropriate
+L<OPENSSL_init_crypto(3)> will register these functions with the appropriate
 hander, when the B<OPENSSL_INIT_ATFORK> flag is used. For other
 applications, these functions can be called directly. They should be used
 according to the calling sequence described by the pthreads_atfork(3)

--- a/doc/man3/OSSL_STORE_INFO.pod
+++ b/doc/man3/OSSL_STORE_INFO.pod
@@ -47,7 +47,7 @@ OSSL_STORE_INFO_new_CRL - Functions to manipulate OSSL_STORE_INFO objects
 
 =head1 DESCRIPTION
 
-These functions are primarly useful for applications to retrieve
+These functions are primarily useful for applications to retrieve
 supported objects from B<OSSL_STORE_INFO> objects and for scheme specific
 loaders to create B<OSSL_STORE_INFO> holders.
 
@@ -139,7 +139,7 @@ An X.509 certificate.
 
 =item OSSL_STORE_INFO_CRL
 
-A X.509 certificate reocation list.
+A X.509 certificate revocation list.
 
 =back
 

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -118,9 +118,9 @@ L<OSSL_STORE_INFO(3)> functions.
 If no more data is available or an error occurs, this function is
 expected to return NULL.
 The B<OSSL_STORE_eof_fn> and B<OSSL_STORE_error_fn> functions must indicate if
-it was in fact the end of data or if an error occured.
+it was in fact the end of data or if an error occurred.
 
-Note that this function retrives I<one> data item only.
+Note that this function retrieves I<one> data item only.
 
 =item B<OSSL_STORE_eof_fn>
 

--- a/doc/man3/RAND_cleanup.pod
+++ b/doc/man3/RAND_cleanup.pod
@@ -16,7 +16,7 @@ RAND_cleanup - erase the PRNG state
 
 Prior to OpenSSL 1.1.0, RAND_cleanup() released all resources used by
 the PRNG.  As of version 1.1.0, it does nothing and should not be called,
-since since no explicit initialisation or de-initialisation is necessary. See
+since no explicit initialisation or de-initialisation is necessary. See
 L<OPENSSL_init_crypto(3)>.
 
 =head1 RETURN VALUE

--- a/doc/man3/RSA_meth_new.pod
+++ b/doc/man3/RSA_meth_new.pod
@@ -114,7 +114,7 @@ RSA_meth_set_verify, RSA_meth_get_keygen, RSA_meth_set_keygen
 =head1 DESCRIPTION
 
 The B<RSA_METHOD> type is a structure used for the provision of custom
-RSA implementations. It provides a set of of functions used by OpenSSL
+RSA implementations. It provides a set of functions used by OpenSSL
 for the implementation of the various RSA capabilities. See the L<rsa>
 page for more information.
 
@@ -232,7 +232,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/Ed25519.pod
+++ b/doc/man7/Ed25519.pod
@@ -17,7 +17,7 @@ verifying a digest must B<NOT> be specified.
 
 =head1 NOTES
 
-The PureEdDSA algorithm does not support the the streaming mechanism
+The PureEdDSA algorithm does not support the streaming mechanism
 of other signature algorithms using, for example, EVP_DigestUpdate().
 The message to sign or verify must be passed using the one shot
 EVP_DigestSign() asn EVP_DigestVerify() functions.

--- a/doc/openssl-c-indent.el
+++ b/doc/openssl-c-indent.el
@@ -2,7 +2,7 @@
 ;;;
 ;;; This definition is for the "CC mode" package, which is the default
 ;;; mode for editing C source files in Emacs 20, not for the older
-;;; c-mode.el (which was the default in less recent releaes of Emacs 19).
+;;; c-mode.el (which was the default in less recent releases of Emacs 19).
 ;;;
 ;;; Recommended use is to add this line in your .emacs:
 ;;;


### PR DESCRIPTION
I scanned all files in the doc folder with a spell checker (https://github.com/EWSoftware/VSSpellChecker).
This patch (hopefully) corrected all spell errors that it found.
