### PR TITLE
Expose negotiated cipher to alpn_select_cb

### DIFF
--- a/doc/man3/SSL_get_current_cipher.pod
+++ b/doc/man3/SSL_get_current_cipher.pod
@@ -3,13 +3,15 @@
 =head1 NAME
 
 SSL_get_current_cipher, SSL_get_cipher_name, SSL_get_cipher,
-SSL_get_cipher_bits, SSL_get_cipher_version - get SSL_CIPHER of a connection
+SSL_get_cipher_bits, SSL_get_cipher_version,
+SSL_get_pending_cipher - get SSL_CIPHER of a connection
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
  SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
+ SSL_CIPHER *SSL_get_pending_cipher(const SSL *ssl);
 
  const char *SSL_get_cipher_name(const SSL *s);
  const char *SSL_get_cipher(const SSL *s);
@@ -30,14 +32,28 @@ SSL_get_cipher_bits() is a
 macro to obtain the number of secret/algorithm bits used and
 SSL_get_cipher_version() returns the protocol name.
 
+SSL_get_pending_cipher() returns a pointer to an SSL_CIPHER object containing
+the description of the cipher (if any) that has been negotiated for future use
+on the connection established with the B<ssl> object, but is not yet in use.
+This may be the case during handshake processing, when control flow can be
+returned to the application via any of several callback methods.  The internal
+sequencing of handshake processing and callback invocation is not guaranteed
+to be stable from release to release, and at present only the callback set
+by SSL_CTX_set_alpn_select_cb() is guaranteed to have a non-NULL return value.
+Other callbacks may be added to this list over time.
+
 =head1 RETURN VALUES
 
 SSL_get_current_cipher() returns the cipher actually used, or NULL if
 no session has been established.
 
+SSL_get_pending_cipher() returns the cipher to be used at the next change
+of cipher suite, or NULL if no such cipher is known.
+
 =head1 NOTES
 
-These are implemented as macros.
+SSL_get_cipher, SSL_get_cipher_bits, SSL_get_cipher_version, and
+SSL_get_cipher_name are implemented as macros.
 
 =head1 SEE ALSO
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1430,6 +1430,7 @@ __owur int SSL_clear(SSL *s);
 void SSL_CTX_flush_sessions(SSL_CTX *ctx, long tm);
 
 __owur const SSL_CIPHER *SSL_get_current_cipher(const SSL *s);
+__owur const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s);
 __owur int SSL_CIPHER_get_bits(const SSL_CIPHER *c, int *alg_bits);
 __owur const char *SSL_CIPHER_get_version(const SSL_CIPHER *c);
 __owur const char *SSL_CIPHER_get_name(const SSL_CIPHER *c);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3613,6 +3613,11 @@ const SSL_CIPHER *SSL_get_current_cipher(const SSL *s)
     return (NULL);
 }
 
+const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s)
+{
+    return s->s3->tmp.new_cipher;
+}
+
 const COMP_METHOD *SSL_get_current_compression(SSL *s)
 {
 #ifndef OPENSSL_NO_COMP

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -463,3 +463,4 @@ OPENSSL_cipher_name                     463	1_1_1	EXIST::FUNCTION:
 SSL_alloc_buffers                       464	1_1_1	EXIST::FUNCTION:
 SSL_free_buffers                        465	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_dup                         466	1_1_1	EXIST::FUNCTION:
+SSL_get_pending_cipher                  467	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Rearrange control flow so the alpn_select_cb is called after ciphersuite negotiation (put it back by OCSP handling as was done in the former ssl_check_clienthello_tlsext_late function), and provide an accessor for the negotiated cipher.  Hedge quite strongly in the documentation to allow future rearrangements of handshake handling.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
