### PR TITLE
Test fixtures changed to pointers.

### DIFF
--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -34,21 +34,23 @@ static void tear_down(CIPHERLIST_TEST_FIXTURE *fixture)
         SSL_CTX_free(fixture->server);
         SSL_CTX_free(fixture->client);
         fixture->server = fixture->client = NULL;
+        OPENSSL_free(fixture);
     }
 }
 
 static CIPHERLIST_TEST_FIXTURE *set_up(const char *const test_case_name)
 {
-    static CIPHERLIST_TEST_FIXTURE fixture;
+    CIPHERLIST_TEST_FIXTURE *fixture;
 
-    memset(&fixture, 0, sizeof(fixture));
-    fixture.test_case_name = test_case_name;
-    if (!TEST_ptr(fixture.server = SSL_CTX_new(TLS_server_method()))
-            || !TEST_ptr(fixture.client = SSL_CTX_new(TLS_client_method()))) {
-        tear_down(&fixture);
+    if (!TEST_ptr(fixture = OPENSSL_zalloc(sizeof(*fixture))))
+        return NULL;
+    fixture->test_case_name = test_case_name;
+    if (!TEST_ptr(fixture->server = SSL_CTX_new(TLS_server_method()))
+            || !TEST_ptr(fixture->client = SSL_CTX_new(TLS_client_method()))) {
+        tear_down(fixture);
         return NULL;
     }
-    return &fixture;
+    return fixture;
 }
 
 /*


### PR DESCRIPTION
- [x] tests are added or updated

Change the fixture types to pointers to structures that are heap allocated in the tests that use SETUP_TEST_FIXTURE.  This will permit error returns from the setup function and allow for future running tests in parallel.

Also removed a call of `exit(2)` which allows the remaining tests to run if one fails to initialise.

It is possible to more tightly integrate the pointer return semantics into the `SETUP_TEST_FIXTURE` macro.  Would this be desirable?
