### PR TITLE
Test server side session caching

### DIFF
--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -3,6 +3,7 @@
 =head1 NAME
 
 SSL_SESSION_new,
+SSL_SESSION_dup,
 SSL_SESSION_up_ref,
 SSL_SESSION_free - create, free and manage SSL_SESSION structures
 
@@ -11,6 +12,7 @@ SSL_SESSION_free - create, free and manage SSL_SESSION structures
  #include <openssl/ssl.h>
 
  SSL_SESSION *SSL_SESSION_new(void);
+ SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src);
  int SSL_SESSION_up_ref(SSL_SESSION *ses);
  void SSL_SESSION_free(SSL_SESSION *session);
 
@@ -18,6 +20,9 @@ SSL_SESSION_free - create, free and manage SSL_SESSION structures
 
 SSL_SESSION_new() creates a new SSL_SESSION structure and returns a pointer to
 it.
+
+SSL_SESSION_dup() copies the contents of the SSL_SESSION structure in B<src>
+and returns a pointer to it.
 
 SSL_SESSION_up_ref() increments the reference count on the given SSL_SESSION
 structure.
@@ -65,6 +70,10 @@ L<ssl(7)>, L<SSL_get_session(3)>,
 L<SSL_CTX_set_session_cache_mode(3)>,
 L<SSL_CTX_flush_sessions(3)>,
 L<d2i_SSL_SESSION(3)>
+
+=head1 HISTORY
+
+SSL_SESSION_dup() was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1545,6 +1545,7 @@ __owur int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
 __owur int SSL_SESSION_is_resumable(const SSL_SESSION *s);
 
 __owur SSL_SESSION *SSL_SESSION_new(void);
+__owur SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src);
 const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s,
                                         unsigned int *len);
 const unsigned char *SSL_SESSION_get0_id_context(const SSL_SESSION *s,

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -93,6 +93,11 @@ SSL_SESSION *SSL_SESSION_new(void)
     return ss;
 }
 
+SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src)
+{
+    return ssl_session_dup(src, 1);
+}
+
 /*
  * Create a new SSL_SESSION and duplicate the contents of |src| into it. If
  * ticket == 0 then no ticket information is duplicated, otherwise it is.

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -462,3 +462,4 @@ SSL_SESSION_set_protocol_version        462	1_1_1	EXIST::FUNCTION:
 OPENSSL_cipher_name                     463	1_1_1	EXIST::FUNCTION:
 SSL_alloc_buffers                       464	1_1_1	EXIST::FUNCTION:
 SSL_free_buffers                        465	1_1_1	EXIST::FUNCTION:
+SSL_SESSION_dup                         466	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
We already had tests for session caching but they only covered the client side (!!) not server side. This adds some server side caching tests. In particular it tests the scenario mentioned in #4014.

As part of this work I needed to duplicate a session object. We don't have a public API for that (although we have an internal one). This missing API was mentioned somewhere else recently (by @kroeckx I think), so I've added it as part of this PR.

I also fixed some bugs in sslapitest introduced recently by commit 7e885b7.

Note this should not be merged until #4014 is. The tests will fail (including CI) until then. Hence marked as WIP. For master only. The issue described in #4014 is present in 1.1.0 too, but it's non-trivial to backport this.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ x tests are added or updated
