### PR TITLE
Move ossl_assert

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -545,23 +545,6 @@ struct servent *getservbyname(const char *name, const char *proto);
 # define CRYPTO_memcmp memcmp
 #endif
 
-#ifdef NDEBUG
-# define ossl_assert(x) (int)(x)
-#else
-__owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
-                                              const char *file, int line)
-{
-    if (!expr)
-        OPENSSL_die(exprstr, file, line);
-
-    return expr;
-}
-
-# define ossl_assert(x) ossl_assert_int((int)(x), "Assertion failed: "#x, \
-                                         __FILE__, __LINE__)
-
-#endif
-
 #ifdef  __cplusplus
 }
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -30,6 +30,23 @@
 extern "C" {
 #endif
 
+#ifdef NDEBUG
+# define ossl_assert(x) ((x) != 0)
+#else
+__owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
+                                              const char *file, int line)
+{
+    if (!expr)
+        OPENSSL_die(exprstr, file, line);
+
+    return expr;
+}
+
+# define ossl_assert(x) ossl_assert_int((x) != 0, "Assertion failed: "#x, \
+                                         __FILE__, __LINE__)
+
+#endif
+
 typedef struct ex_callback_st EX_CALLBACK;
 
 DEFINE_STACK_OF(EX_CALLBACK)

--- a/ssl/packet.c
+++ b/ssl/packet.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "e_os.h"
+#include "internal/cryptlib.h"
 #include "packet_locl.h"
 
 #define DEFAULT_BUF_SIZE    256

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -15,6 +15,7 @@
 #include <openssl/buffer.h>
 #include "record_locl.h"
 #include "../packet_locl.h"
+#include "internal/cryptlib.h"
 
 int DTLS_RECORD_LAYER_new(RECORD_LAYER *rl)
 {

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -11,6 +11,7 @@
 #include "internal/constant_time_locl.h"
 #include <openssl/rand.h>
 #include "record_locl.h"
+#include "internal/cryptlib.h"
 
 static const unsigned char ssl3_pad_1[48] = {
     0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36,

--- a/ssl/record/ssl3_record_tls13.c
+++ b/ssl/record/ssl3_record_tls13.c
@@ -9,6 +9,7 @@
 
 #include "../ssl_locl.h"
 #include "record_locl.h"
+#include "internal/cryptlib.h"
 
 /*-
  * tls13_enc encrypts/decrypts |n_recs| in |recs|.

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -9,6 +9,7 @@
 
 #include "internal/constant_time_locl.h"
 #include "ssl_locl.h"
+#include "internal/cryptlib.h"
 
 #include <openssl/md5.h>
 #include <openssl/sha.h>

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -12,6 +12,7 @@
 #include "ssl_locl.h"
 #include <openssl/evp.h>
 #include <openssl/md5.h>
+#include "internal/cryptlib.h"
 
 static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
 {

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -17,6 +17,7 @@
 #include <openssl/crypto.h>
 #include "ssl_locl.h"
 #include "internal/thread_once.h"
+#include "internal/cryptlib.h"
 
 #define SSL_ENC_DES_IDX         0
 #define SSL_ENC_3DES_IDX        1

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -20,6 +20,7 @@
 #include <openssl/engine.h>
 #include <openssl/async.h>
 #include <openssl/ct.h>
+#include "internal/cryptlib.h"
 
 const char SSL_version_str[] = OPENSSL_VERSION_TEXT;
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -9,6 +9,7 @@
 
 #include <openssl/ocsp.h>
 #include "../ssl_locl.h"
+#include "internal/cryptlib.h"
 #include "statem_locl.h"
 
 EXT_RETURN tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt,

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -11,6 +11,7 @@
 
 #include <openssl/ct.h>
 #include "../ssl_locl.h"
+#include "internal/cryptlib.h"
 #include "statem_locl.h"
 
 typedef struct {

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include "../ssl_locl.h"
 #include "statem_locl.h"
+#include "internal/cryptlib.h"
 #include <openssl/buffer.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include "../ssl_locl.h"
 #include "statem_locl.h"
+#include "internal/cryptlib.h"
 #include <openssl/buffer.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
Move the definition of ossl_assert() out of e_os.h which is intended for OS
specific things. Instead it is moved into internal/cryptlib.h.

This also changes the definition to remove the (int) cast.

This is in response to comments made by @dot-asm in #3740 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
