### PR TITLE
Suppress compiler warnings if using -Wunused-parameter

### DIFF
--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -183,6 +183,7 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
     OPENSSL_assert(in && out && key && ivec);
     OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));
     OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);
+    OPENSSL_unused_param(key2);
 
     if (AES_ENCRYPT == enc) {
         /*

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -330,6 +330,7 @@ ossl_noreturn void OPENSSL_die(const char *assertion, const char *file, int line
 # endif
 # define OPENSSL_assert(e) \
     (void)((e) ? 0 : (OPENSSL_die("assertion failed: " #e, OPENSSL_FILE, OPENSSL_LINE), 1))
+# define OPENSSL_unused_param(x) (void)(x)
 
 int OPENSSL_isservice(void);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This is a suggestion: I noticed there are unused parameters of many functions, so how about using the method in this PR to suppress the warnings introduced by applying `-Wunused-parameter`