### PR TITLE
Streamline SETUP_TEST_FIXTURE.

### DIFF
--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -181,7 +181,7 @@ static int execute_test(CIPHERLIST_TEST_FIXTURE *fixture)
 }
 
 #define SETUP_CIPHERLIST_TEST_FIXTURE() \
-    SETUP_TEST_FIXTURE(CIPHERLIST_TEST_FIXTURE *, set_up)
+    SETUP_TEST_FIXTURE(CIPHERLIST_TEST_FIXTURE, set_up)
 
 #define EXECUTE_CIPHERLIST_TEST() \
     EXECUTE_TEST(execute_test, tear_down)
@@ -189,7 +189,10 @@ static int execute_test(CIPHERLIST_TEST_FIXTURE *fixture)
 static int test_default_cipherlist_implicit()
 {
     SETUP_CIPHERLIST_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     EXECUTE_CIPHERLIST_TEST();
+    return result;
 }
 
 static int test_default_cipherlist_explicit()
@@ -201,6 +204,7 @@ static int test_default_cipherlist_explicit()
             || !TEST_true(SSL_CTX_set_cipher_list(fixture->client, "DEFAULT")))
         tear_down(fixture);
     EXECUTE_CIPHERLIST_TEST();
+    return result;
 }
 
 int setup_tests()

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -344,22 +344,27 @@ end:
     return success;
 }
 
-# define SETUP_CT_TEST_FIXTURE() SETUP_TEST_FIXTURE(CT_TEST_FIXTURE *, set_up)
+# define SETUP_CT_TEST_FIXTURE() SETUP_TEST_FIXTURE(CT_TEST_FIXTURE, set_up)
 # define EXECUTE_CT_TEST() EXECUTE_TEST(execute_cert_test, tear_down)
 
 static int test_no_scts_in_certificate(void)
 {
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->certs_dir = certs_dir;
     fixture->certificate_file = "leaf.pem";
     fixture->issuer_file = "subinterCA.pem";
     fixture->expected_sct_count = 0;
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_one_sct_in_certificate(void)
 {
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->certs_dir = certs_dir;
     fixture->certificate_file = "embeddedSCTs1.pem";
     fixture->issuer_file = "embeddedSCTs1_issuer.pem";
@@ -367,11 +372,14 @@ static int test_one_sct_in_certificate(void)
     fixture->sct_dir = certs_dir;
     fixture->sct_text_file = "embeddedSCTs1.sct";
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_multiple_scts_in_certificate(void)
 {
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->certs_dir = certs_dir;
     fixture->certificate_file = "embeddedSCTs3.pem";
     fixture->issuer_file = "embeddedSCTs3_issuer.pem";
@@ -379,33 +387,42 @@ static int test_multiple_scts_in_certificate(void)
     fixture->sct_dir = certs_dir;
     fixture->sct_text_file = "embeddedSCTs3.sct";
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_verify_one_sct(void)
 {
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->certs_dir = certs_dir;
     fixture->certificate_file = "embeddedSCTs1.pem";
     fixture->issuer_file = "embeddedSCTs1_issuer.pem";
     fixture->expected_sct_count = fixture->expected_valid_sct_count = 1;
     fixture->test_validity = 1;
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_verify_multiple_scts(void)
 {
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->certs_dir = certs_dir;
     fixture->certificate_file = "embeddedSCTs3.pem";
     fixture->issuer_file = "embeddedSCTs3_issuer.pem";
     fixture->expected_sct_count = fixture->expected_valid_sct_count = 3;
     fixture->test_validity = 1;
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_verify_fails_for_future_sct(void)
 {
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->epoch_time_in_ms = 1365094800000; /* Apr 4 17:00:00 2013 GMT */
     fixture->certs_dir = certs_dir;
     fixture->certificate_file = "embeddedSCTs1.pem";
@@ -414,6 +431,7 @@ static int test_verify_fails_for_future_sct(void)
     fixture->expected_valid_sct_count = 0;
     fixture->test_validity = 1;
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_decode_tls_sct(void)
@@ -437,11 +455,14 @@ static int test_decode_tls_sct(void)
         "\xED\xBF\x08";
 
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->tls_sct_list = tls_sct_list;
     fixture->tls_sct_list_len = 0x7a;
     fixture->sct_dir = ct_dir;
     fixture->sct_text_file = "tls1.sct";
     EXECUTE_CT_TEST();
+    return result;
 }
 
 static int test_encode_tls_sct(void)
@@ -454,6 +475,8 @@ static int test_encode_tls_sct(void)
     SCT *sct = NULL;
 
     SETUP_CT_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
 
     fixture->sct_list = sk_SCT_new_null();
     if (!TEST_ptr(sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
@@ -466,6 +489,7 @@ static int test_encode_tls_sct(void)
     fixture->sct_dir = ct_dir;
     fixture->sct_text_file = "tls1.sct";
     EXECUTE_CT_TEST();
+    return result;
 }
 
 /*

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -133,23 +133,26 @@ static void tear_down(SSL_TEST_CTX_TEST_FIXTURE *fixture)
 }
 
 #define SETUP_SSL_TEST_CTX_TEST_FIXTURE() \
-    SETUP_TEST_FIXTURE(SSL_TEST_CTX_TEST_FIXTURE *, set_up); \
-    if (fixture == NULL) \
-        return 0
+    SETUP_TEST_FIXTURE(SSL_TEST_CTX_TEST_FIXTURE, set_up);
 #define EXECUTE_SSL_TEST_CTX_TEST() \
     EXECUTE_TEST(execute_test, tear_down)
 
 static int test_empty_configuration()
 {
     SETUP_SSL_TEST_CTX_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->test_section = "ssltest_default";
     fixture->expected_ctx->expected_result = SSL_TEST_SUCCESS;
     EXECUTE_SSL_TEST_CTX_TEST();
+    return result;
 }
 
 static int test_good_configuration()
 {
     SETUP_SSL_TEST_CTX_TEST_FIXTURE();
+    if (fixture == NULL)
+        return 0;
     fixture->test_section = "ssltest_good";
     fixture->expected_ctx->method = SSL_TEST_METHOD_DTLS;
     fixture->expected_ctx->handshake_mode = SSL_TEST_HANDSHAKE_RESUME;
@@ -186,6 +189,7 @@ static int test_good_configuration()
         SSL_TEST_CT_VALIDATION_STRICT;
 
     EXECUTE_SSL_TEST_CTX_TEST();
+    return result;
 
 err:
     tear_down(fixture);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -65,12 +65,13 @@
  * SETUP_TEST_FIXTURE will call set_up() to create a new TEST_FIXTURE_TYPE
  * object called "fixture". It will also allocate the "result" variable used
  * by EXECUTE_TEST. set_up() should take a const char* specifying the test
- * case name and return a TEST_FIXTURE_TYPE by value.
+ * case name and return a TEST_FIXTURE_TYPE by reference.
  *
- * EXECUTE_TEST will pass fixture to execute_func() by value, call
+ * EXECUTE_TEST will pass fixture to execute_func() by reference, call
  * tear_down(), and return the result of execute_func(). execute_func() should
- * take a TEST_FIXTURE_TYPE by value and return 1 on success and 0 on
- * failure.
+ * take a TEST_FIXTURE_TYPE by reference and return 1 on success and 0 on
+ * failure.  The tear_down function is responsible for deallocation of the
+ * result variable, if required.
  *
  * Unit tests can define their own SETUP_TEST_FIXTURE and EXECUTE_TEST
  * variations like so:
@@ -91,13 +92,14 @@
  *      }
  */
 # define SETUP_TEST_FIXTURE(TEST_FIXTURE_TYPE, set_up)\
-    TEST_FIXTURE_TYPE fixture = set_up(TEST_CASE_NAME); \
+    TEST_FIXTURE_TYPE *fixture = set_up(TEST_CASE_NAME); \
     int result = 0
 
 # define EXECUTE_TEST(execute_func, tear_down)\
+    if (fixture != NULL) {\
         result = execute_func(fixture);\
         tear_down(fixture);\
-        return result
+    }
 
 /*
  * TEST_CASE_NAME is defined as the name of the test case function where


### PR DESCRIPTION
Change SETUP_TEST_FIXTURE so that the fixture structure is passed by reference not by value.  This allows an error return from the setup function and potentially parallel execution.

- [x] tests are added or updated
