### PR TITLE
Revert "Replace '0' .. '9' compares with isdigit()"

### DIFF
--- a/crypto/asn1/a_gentm.c
+++ b/crypto/asn1/a_gentm.c
@@ -13,7 +13,6 @@
 
 #include <stdio.h>
 #include <time.h>
-#include <ctype.h>
 #include "internal/cryptlib.h"
 #include <openssl/asn1.h>
 #include "asn1_locl.h"

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -383,7 +383,7 @@ static int is_numeric(unsigned long value)
         return 0;
     ch = (int)value;
 #ifndef CHARSET_EBCDIC
-    if (!isdigit(ch) && ch != ' ')
+    if (ch > '9' || (ch < '0' && ch != ' '))
         return 0;
 #else
     if (ch > os_toascii['9'])

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <limits.h>
-#include <ctype.h>
 #include "internal/cryptlib.h"
 #include <openssl/buffer.h>
 #include <openssl/asn1.h>
@@ -85,7 +84,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
             c = *(p++);
             if ((c == ' ') || (c == '.'))
                 break;
-            if (!isdigit(c)) {
+            if ((c < '0') || (c > '9')) {
                 ASN1err(ASN1_F_A2D_ASN1_OBJECT, ASN1_R_INVALID_DIGIT);
                 goto err;
             }

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -16,7 +16,6 @@
 
 #include <stdio.h>
 #include <time.h>
-#include <ctype.h>
 #include "internal/cryptlib.h"
 #include <openssl/asn1t.h>
 #include "asn1_locl.h"
@@ -124,14 +123,14 @@ int asn1_time_to_tm(struct tm *tm, const ASN1_TIME *d)
             i++;
             break;
         }
-        if (!isdigit(a[o]))
+        if ((a[o] < '0') || (a[o] > '9'))
             goto err;
         n = a[o] - '0';
         /* incomplete 2-digital number */
         if (++o == l)
             goto err;
 
-        if (!isdigit(a[o]))
+        if ((a[o] < '0') || (a[o] > '9'))
             goto err;
         n = (n * 10) + a[o] - '0';
         /* no more bytes to read, but we haven't seen time-zone yet */
@@ -192,7 +191,7 @@ int asn1_time_to_tm(struct tm *tm, const ASN1_TIME *d)
         if (++o == l)
             goto err;
         i = o;
-        while ((o < l) && isdigit(a[o]))
+        while ((o < l) && (a[o] >= '0') && (a[o] <= '9'))
             o++;
         /* Must have at least one digit after decimal point */
         if (i == o)
@@ -223,11 +222,11 @@ int asn1_time_to_tm(struct tm *tm, const ASN1_TIME *d)
         if (o + 4 != l)
             goto err;
         for (i = end; i < end + 2; i++) {
-            if (!isdigit(a[o]))
+            if ((a[o] < '0') || (a[o] > '9'))
                 goto err;
             n = a[o] - '0';
             o++;
-            if (!isdigit(a[o]))
+            if ((a[o] < '0') || (a[o] > '9'))
                 goto err;
             n = (n * 10) + a[o] - '0';
             i2 = (d->type == V_ASN1_UTCTIME) ? i + 1 : i;
@@ -489,7 +488,7 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
         if (tm->length > 15 && v[14] == '.') {
             f = &v[14];
             f_len = 1;
-            while (14 + f_len < l && isdigit(f[f_len]))
+            while (14 + f_len < l && f[f_len] >= '0' && f[f_len] <= '9')
                 ++f_len;
         }
 

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <time.h>
-#include <ctype.h>
 #include "internal/cryptlib.h"
 #include <openssl/asn1.h>
 #include "asn1_locl.h"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Reverts isdigit() changes from PR #2753 

Windows codepage issues could cause problems. Also reverts use of isdigit() in a_mbstr.c

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
