### PR TITLE
Add missing HTML tag in www_body in s_server.c

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3113,9 +3113,10 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                 PEM_write_bio_X509(io, peer);
                 X509_free(peer);
                 peer = NULL;
-            } else
+            } else {
                 BIO_puts(io, "no client certificate available\n");
-            BIO_puts(io, "</BODY></HTML>\r\n\r\n");
+            }
+            BIO_puts(io, "</pre></BODY></HTML>\r\n\r\n");
             break;
         } else if ((www == 2 || www == 3)
                    && (strncmp("GET /", buf, 5) == 0)) {


### PR DESCRIPTION
In the generated HTML document, the `<pre>` tag is not closed (open tag is at [Line 3033](https://github.com/openssl/openssl/blob/13160ec4d9570223f96163ab4d4a9a42c0bb58ee/apps/s_server.c#L3033)). This patch also has a trivial code-style improvement, unrelated to the bug fix.
