### PR TITLE
Set randomness buffer pointer in get_entropy calls.

### DIFF
--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -243,6 +243,9 @@ int ctr_instantiate(RAND_DRBG *drbg,
 {
     RAND_DRBG_CTR *ctr = &drbg->ctr;
 
+    if (ent == NULL)
+        return 0;
+
     memset(ctr->K, 0, sizeof(ctr->K));
     memset(ctr->V, 0, sizeof(ctr->V));
     AES_set_encrypt_key(ctr->K, drbg->strength, &ctr->ks);
@@ -254,6 +257,8 @@ int ctr_reseed(RAND_DRBG *drbg,
                const unsigned char *ent, size_t entlen,
                const unsigned char *adin, size_t adinlen)
 {
+    if (ent == NULL)
+        return 0;
     ctr_update(drbg, ent, entlen, adin, adinlen, NULL, 0);
     return 1;
 }

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -143,6 +143,7 @@ size_t drbg_entropy_from_system(RAND_DRBG *drbg,
             memmove(rand_bytes.buff, &rand_bytes.buff[min_len], rand_bytes.curr);
     }
     CRYPTO_THREAD_unlock(rand_bytes.lock);
+    *pout = drbg->randomness;
     return min_len;
 }
 
@@ -163,6 +164,7 @@ size_t drbg_entropy_from_parent(RAND_DRBG *drbg,
     if (st == 0)
         return 0;
     drbg->filled = 1;
+    *pout = drbg->randomness;
     return min_len;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

When we retrieve randomness and populate drbg->randomness we need to set *pout to the buffer containing the randomness. This fixes the  ssl_new test failures. Add sanity check so this is caught sooner.