### PR TITLE
Fix typo in files in crypto folder

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2011-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -69,7 +69,7 @@ static unsigned long (*getauxval) (unsigned long) = NULL;
 # endif
 
 /*
- * ARM puts the the feature bits for Crypto Extensions in AT_HWCAP2, whereas
+ * ARM puts the feature bits for Crypto Extensions in AT_HWCAP2, whereas
  * AArch64 used AT_HWCAP.
  */
 # if defined(__arm__) || defined (__arm)

--- a/crypto/ia64cpuid.S
+++ b/crypto/ia64cpuid.S
@@ -1,4 +1,4 @@
-// Copyright 2004-2016 The OpenSSL Project Authors. All Rights Reserved.
+// Copyright 2004-2017 The OpenSSL Project Authors. All Rights Reserved.
 //
 // Licensed under the OpenSSL license (the "License").  You may not use
 // this file except in compliance with the License.  You can obtain a copy
@@ -75,7 +75,7 @@ OPENSSL_wipe_cpu:
 { .mii;	add		r9=96*8-8,r9
 	mov		ar.ec=1		};;
 
-// One can sweep double as fast, but then we can't quarantee
+// One can sweep double as fast, but then we can't guarantee
 // that backing storage is wiped...
 .L_wipe_top:
 { .mfi;	st8		[r9]=r0,-8

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -657,7 +657,7 @@ int OPENSSL_atexit(void (*handler)(void))
          * Deliberately leak a reference to the handler. This will force the
          * library/code containing the handler to remain loaded until we run the
          * atexit handler. If -znodelete has been used then this is
-         * unneccessary.
+         * unnecessary.
          */
         {
             DSO *dso = NULL;

--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -20,7 +20,7 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
         /*
          * On VMS, gmtime_r() takes a 32-bit pointer as second argument.
          * Since we can't know that |result| is in a space that can easily
-         * translate to a 32-bit pointer, we must store temporarly on stack
+         * translate to a 32-bit pointer, we must store temporarily on stack
          * and copy the result.  The stack is always reachable with 32-bit
          * pointers.
          */


### PR DESCRIPTION
Fix typo in files in crypto folder (without its subfolder though).