### PR TITLE
Clear error stack on successful OSSL_STORE_open()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Add ERR_clear_last_mark(), to allow callers to clear the last mark
+     without clearing the errors.
+     [Richard Levitte]
+
   *) Add "atfork" functions.  If building on a system that without
      pthreads, see doc/man3/OPENSSL_fork_prepare.pod for application
      requirements.  The RAND facility now uses/requires this.

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -824,7 +824,7 @@ int ERR_clear_last_mark(void)
 
     top = es->top;
     while (es->bottom != top
-           && (es->err_flags[es->top] & ERR_FLAG_MARK) == 0) {
+           && (es->err_flags[top] & ERR_FLAG_MARK) == 0) {
         top -= 1;
         if (top == -1)
             top = ERR_NUM_ERRORS - 1;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -812,3 +812,26 @@ int ERR_pop_to_mark(void)
     es->err_flags[es->top] &= ~ERR_FLAG_MARK;
     return 1;
 }
+
+int ERR_clear_last_mark(void)
+{
+    ERR_STATE *es;
+    int top;
+
+    es = ERR_get_state();
+    if (es == NULL)
+        return 0;
+
+    top = es->top;
+    while (es->bottom != top
+           && (es->err_flags[es->top] & ERR_FLAG_MARK) == 0) {
+        top -= 1;
+        if (top == -1)
+            top = ERR_NUM_ERRORS - 1;
+    }
+
+    if (es->bottom == top)
+        return 0;
+    es->err_flags[top] &= ~ERR_FLAG_MARK;
+    return 1;
+}

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -64,22 +64,23 @@ OSSL_STORE_CTX *OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method,
         }
     }
 
+    ERR_set_mark();
+
     /* Try each scheme until we find one that could open the URI */
     for (i = 0; loader_ctx == NULL && i < schemes_n; i++) {
         if ((loader = ossl_store_get0_loader_int(schemes[i])) != NULL)
             loader_ctx = loader->open(loader, uri, ui_method, ui_data);
     }
     if (loader_ctx == NULL)
-        goto done;
+        goto err;
 
     if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
         OSSL_STOREerr(OSSL_STORE_F_OSSL_STORE_OPEN, ERR_R_MALLOC_FAILURE);
-        goto done;
+        goto err;
     }
 
     ctx->loader = loader;
     ctx->loader_ctx = loader_ctx;
-    loader_ctx = NULL;
     ctx->ui_method = ui_method;
     ctx->ui_data = ui_data;
     ctx->post_process = post_process;
@@ -90,9 +91,12 @@ OSSL_STORE_CTX *OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method,
      * other scheme loader succeeded, the failure to open with the 'file'
      * scheme loader leaves an error on the error stack.  Let's remove it.
      */
-    ERR_clear_error();
+    ERR_pop_to_mark();
 
- done:
+    return ctx;
+
+ err:
+    ERR_clear_last_mark();
     if (loader_ctx != NULL) {
         /*
          * We ignore a returned error because we will return NULL anyway in
@@ -101,7 +105,7 @@ OSSL_STORE_CTX *OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method,
          */
         (void)loader->close(loader_ctx);
     }
-    return ctx;
+    return NULL;
 }
 
 int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ...)

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -85,6 +85,13 @@ OSSL_STORE_CTX *OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method,
     ctx->post_process = post_process;
     ctx->post_process_data = post_process_data;
 
+    /*
+     * If the attempt to open with the 'file' scheme loader failed and the
+     * other scheme loader succeeded, the failure to open with the 'file'
+     * scheme loader leaves an error on the error stack.  Let's remove it.
+     */
+    ERR_clear_error();
+
  done:
     if (loader_ctx != NULL) {
         /*

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -262,6 +262,7 @@ int ERR_get_next_error_library(void);
 
 int ERR_set_mark(void);
 int ERR_pop_to_mark(void);
+int ERR_clear_last_mark(void)
 
 #ifdef  __cplusplus
 }

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -262,7 +262,7 @@ int ERR_get_next_error_library(void);
 
 int ERR_set_mark(void);
 int ERR_pop_to_mark(void);
-int ERR_clear_last_mark(void)
+int ERR_clear_last_mark(void);
 
 #ifdef  __cplusplus
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4381,3 +4381,4 @@ ASN1_TIME_cmp_time_t                    4324	1_1_1	EXIST::FUNCTION:
 ASN1_TIME_compare                       4325	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_CTX_ctrl_uint64                4326	1_1_1	EXIST::FUNCTION:
 EVP_DigestFinalXOF                      4327	1_1_1	EXIST::FUNCTION:
+ERR_clear_last_mark                     4328	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Since OSSL_STORE_open() tries with the 'file' scheme loader first, and
then on the loader implied by the URI if the former fails, the former
leaves an error on the error stack.  This is confusing, so let's clear
the error stack on success.

Fixes #4089
