### PR TITLE
Ensure password strings are cleared (apps/enc.c)

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -444,14 +444,6 @@ int enc_main(int argc, char **argv)
                 BIO_printf(bio_err, "EVP_BytesToKey failed\n");
                 goto end;
             }
-            /*
-             * zero the complete buffer or the string passed from the command
-             * line bug picked up by Larry J. Hughes Jr. <hughes@indiana.edu>
-             */
-            if (str == strbuf)
-                OPENSSL_cleanse(str, SIZE);
-            else
-                OPENSSL_cleanse(str, str_len);
         }
         if (hiv != NULL) {
             int siz = EVP_CIPHER_iv_length(cipher);

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -560,7 +560,7 @@ int enc_main(int argc, char **argv)
     }
  end:
     ERR_print_errors(bio_err);
-    OPENSSL_free(strbuf);
+    OPENSSL_clear_free(strbuf, SIZE);
     OPENSSL_free(buff);
     BIO_free(in);
     BIO_free_all(out);
@@ -570,7 +570,7 @@ int enc_main(int argc, char **argv)
     BIO_free(bzl);
 #endif
     release_engine(e);
-    OPENSSL_free(pass);
+    OPENSSL_clear_free(pass, strlen(pass));
     return ret;
 }
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -570,7 +570,8 @@ int enc_main(int argc, char **argv)
     BIO_free(bzl);
 #endif
     release_engine(e);
-    OPENSSL_clear_free(pass, strlen(pass));
+    if (pass != NULL)
+        OPENSSL_clear_free(pass, strlen(pass));
     return ret;
 }
 


### PR DESCRIPTION
`strbuf` and `pass` are heap-allocated buffers that may contain passwords if not NULL. They are cleansed at [Line 451](https://github.com/openssl/openssl/blob/ee31db0588b8250ffd346cd9370df37e56ed9f2f/apps/enc.c#L451), but if any error occurs before Line 451, the execution goes to `end` directly, bypassing the cleansing. This patch fixes this issue by clearing `strbuf` and `pass` when they are freed.