### PR TITLE
Simplify the function OPENSSL_isservice

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -100,19 +100,19 @@ int OPENSSL_isservice(void)
     DWORD len;
     WCHAR *name;
     static FARPROC f_isservice = NULL;
+    static int is_first_time = 1;
 
     /* Allow application to override OPENSSL_isservice by exporting
      * _OPENSSL_isservice function from the .exe file.
      */
-    if (f_isservice == NULL) {
+    if (is_first_time == 1) {
+        is_first_time = 0;
         HANDLE mod = GetModuleHandle(NULL);
         if (mod != NULL)
             f_isservice = GetProcAddress(mod, "_OPENSSL_isservice");
-        if (f_isservice == NULL)
-            f_isservice = (FARPROC)-1;
     }
 
-    if (f_isservice != (FARPROC)-1)
+    if (f_isservice != NULL)
         return (*f_isservice) ();
 
     h = GetProcessWindowStation();

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -96,13 +96,14 @@ void OPENSSL_cpuid_setup(void)
 # if defined(_WIN32_WINNT) && _WIN32_WINNT>=0x0333
 int OPENSSL_isservice(void)
 {
+    static FARPROC f_isservice = NULL;
+    static int is_first_time = 1;
     HWINSTA h;
     DWORD len;
     WCHAR *name;
-    static FARPROC f_isservice = NULL;
-    static int is_first_time = 1;
 
-    /* Allow application to override OPENSSL_isservice by exporting
+    /*
+     * Allow application to override OPENSSL_isservice by exporting
      * _OPENSSL_isservice function from the .exe file.
      */
     if (is_first_time == 1) {

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -107,10 +107,10 @@ int OPENSSL_isservice(void)
      * _OPENSSL_isservice function from the .exe file.
      */
     if (is_first_time == 1) {
-        is_first_time = 0;
         HANDLE mod = GetModuleHandle(NULL);
         if (mod != NULL)
             f_isservice = GetProcAddress(mod, "_OPENSSL_isservice");
+        is_first_time = 0;
     }
 
     if (f_isservice != NULL)


### PR DESCRIPTION
I am not sure why a union is needed here. It seems to me a simple static function pointer variable is OK.
Also added a comment to clarify why we want to call the exported function `_OPENSSL_isservice`.
