### PR TITLE
Use passed drbg, not global one

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -117,7 +117,7 @@ size_t drbg_entropy_from_system(RAND_DRBG *drbg,
         min_len = drbg->size;
     }
 
-    if (rand_drbg.filled) {
+    if (drbg->filled) {
         /* Re-use what we have. */
         *pout = drbg->randomness;
         return drbg->size;
@@ -136,7 +136,7 @@ size_t drbg_entropy_from_system(RAND_DRBG *drbg,
         min_len = rand_bytes.curr;
     if (min_len != 0) {
         memcpy(drbg->randomness, rand_bytes.buff, min_len);
-        rand_drbg.filled = 1;
+        drbg->filled = 1;
         /* Update amount left and shift it down. */
         rand_bytes.curr -= min_len;
         if (rand_bytes.curr != 0)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

This fixes access of uninitialised memory errors in some tests. To see this either compile with enable-msan or run test/bntest under valgrind.