### PR TITLE
Make RAND_DRBG fork-safe

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Add "atfork" functions.  If building on a system that without
+     pthreads, see doc/man3/OPENSSL_fork_prepare.pod for application
+     requirements.  The RAND facility now uses/requires this.
+     [Rich Salz]
+
   *) Add SHA3.
      [Andy Polyakov]
 

--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -18,3 +18,4 @@
 #include <openssl/rand.h>
 
 void rand_cleanup_int(void);
+void rand_fork(void);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -704,5 +704,6 @@ void OPENSSL_fork_parent(void)
 
 void OPENSSL_fork_child(void)
 {
+    rand_fork();
 }
 #endif

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -72,6 +72,7 @@ RAND_DRBG *RAND_DRBG_new(int type, unsigned int flags, RAND_DRBG *parent)
     }
     drbg->size = RANDOMNESS_NEEDED;
     drbg->randomness = ucp;
+    drbg->fork_count = rand_fork_count;
 
     drbg->parent = parent;
     if (RAND_DRBG_set(drbg, type, flags) < 0)
@@ -264,6 +265,11 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
     if (adinlen > drbg->max_adin) {
         RANDerr(RAND_F_RAND_DRBG_GENERATE, RAND_R_ADDITIONAL_INPUT_TOO_LONG);
         return 0;
+    }
+
+    if (drbg->fork_count != rand_fork_count) {
+        drbg->fork_count = rand_fork_count;
+        drbg->state = DRBG_RESEED;
     }
 
     if (drbg->reseed_counter >= drbg->reseed_interval)

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -88,6 +88,7 @@ struct rand_drbg_st {
     CRYPTO_RWLOCK *lock;
     RAND_DRBG *parent;
     int nid; /* the underlying algorithm */
+    int fork_count;
     unsigned short flags; /* various external flags */
     unsigned short filled;
     /*
@@ -126,6 +127,9 @@ extern RAND_METHOD rand_meth;
 extern RAND_BYTES_BUFFER rand_bytes;
 extern RAND_DRBG rand_drbg;
 extern RAND_DRBG priv_drbg;
+
+/* How often we've forked (only incremented in child). */
+extern int rand_fork_count;
 
 /* Hardware-based seeding functions. */
 void rand_read_tsc(RAND_poll_fn cb, void *arg);

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -25,6 +25,7 @@ static CRYPTO_RWLOCK *rand_meth_lock;
 static const RAND_METHOD *default_RAND_meth;
 static CRYPTO_ONCE rand_init = CRYPTO_ONCE_STATIC_INIT;
 RAND_BYTES_BUFFER rand_bytes;
+int rand_fork_count;
 
 #ifdef OPENSSL_RAND_SEED_RDTSC
 /*
@@ -202,6 +203,11 @@ static void free_drbg(RAND_DRBG *drbg)
     RAND_DRBG_uninstantiate(drbg);
 }
 
+void rand_fork()
+{
+    rand_fork_count++;
+}
+
 DEFINE_RUN_ONCE_STATIC(do_rand_init)
 {
     int ret = 1;
@@ -225,7 +231,6 @@ DEFINE_RUN_ONCE_STATIC(do_rand_init)
     ret &= setup_drbg(&priv_drbg);
     return ret;
 }
-
 
 void rand_cleanup_int(void)
 {


### PR DESCRIPTION
Use atfork to count child forks, and reseed DRBG when the counts don't
match.

