### PR TITLE
Add two missing SSL_CIPHER_* functions

### DIFF
--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -93,14 +93,14 @@ SSL_CIPHER_is_aead() returns 1 if the cipher B<c> is AEAD (e.g. GCM or
 ChaCha20/Poly1305), and 0 if it is not AEAD.
 
 SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID stored
-in B<ptr>. The B<ptr> parameter is a two elements array of B<char>, which stores the
-two-byte TLS cipher ID (as allocalted by IANA) in network byte order. This parameter
+in B<ptr>. The B<ptr> parameter is a two element array of B<char>, which stores the
+two-byte TLS cipher ID (as allocated by IANA) in network byte order. This parameter
 is usually retrieved from a TLS packet by using functions like L<SSL_early_get0_ciphers(3)>.
 SSL_CIPHER_find() returns NULL if an error occurs or the indicated cipher is not found.
 
 SSL_CIPHER_get_id() returns the ID of the given cipher B<c>. The ID here is an
 OpenSSL-specific concept, which stores a prefix of 0x0300 in the higher two bytes,
-and the IANA-specified chipher suit ID in the lower two bytes. For instance,
+and the IANA-specified chipher suite ID in the lower two bytes. For instance,
 TLS_RSA_WITH_NULL_MD5 has IANA ID "0x00, 0x01", but the SSL_CIPHER_get_id()
 function will return an ID with value 0x03000001.
 

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -103,7 +103,7 @@ SSL_CIPHER_find() returns NULL if an error occurs or the indicated cipher is not
 SSL_CIPHER_get_id() returns the OpenSSL-specific ID of the given cipher B<c>. That ID is
 not the same as the IANA-specific ID.
 
-SSL_CIPHER_get_protocol_id() returns the two-byte ID used in SSL/TLS protocol of the given
+SSL_CIPHER_get_protocol_id() returns the two-byte ID used in the TLS protocol of the given
 cipher B<c>.
 
 SSL_CIPHER_description() returns a textual description of the cipher used

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -92,12 +92,17 @@ TLS 1.3 cipher suites) B<NID_auth_any> is returned. Examples (not comprehensive)
 SSL_CIPHER_is_aead() returns 1 if the cipher B<c> is AEAD (e.g. GCM or
 ChaCha20/Poly1305), and 0 if it is not AEAD.
 
-SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID B<ptr>.
-The B<ptr> parameter is a two elements array of B<char>, which stores the two bytes
-TLS cipher ID in network byte order. This parameter is usually retrieved from a TLS
-packet by using functions like L<PACKET_get_bytes(3)>.
+SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID stored in
+B<ptr>. The B<ptr> parameter is a two elements array of B<char>, which stores the two
+bytes TLS cipher ID in network byte order. This parameter is usually retrieved from a
+TLS packet by using functions like L<PACKET_get_bytes(3)>. SSL_CIPHER_find() returns
+NULL if error occurs or cipher is not found.
 
-SSL_CIPHER_get_id() returns the ID of the given cipher B<c>.
+SSL_CIPHER_get_id() returns the ID of the given cipher B<c>. The ID here is an
+OpenSSL-specific concept, which stores a prefix of 0x0300 in the higher two bytes,
+and the IANA-specified chipher suit ID in the lower two bytes. For instance,
+TLS_RSA_WITH_NULL_MD5, has IANA ID "0x00, 0x01", but the SSL_CIPHER_get_id()
+function will return an ID with value 0x03000001.
 
 SSL_CIPHER_description() returns a textual description of the cipher used
 into the buffer B<buf> of length B<len> provided.  If B<buf> is provided, it

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -15,7 +15,8 @@ SSL_CIPHER_get_kx_nid,
 SSL_CIPHER_get_auth_nid,
 SSL_CIPHER_is_aead,
 SSL_CIPHER_find,
-SSL_CIPHER_get_id
+SSL_CIPHER_get_id,
+SSL_CIPHER_get_standard_id
 - get SSL_CIPHER properties
 
 =head1 SYNOPSIS
@@ -36,6 +37,7 @@ SSL_CIPHER_get_id
  int SSL_CIPHER_is_aead(const SSL_CIPHER *c);
  const SSL_CIPHER *SSL_CIPHER_find(SSL *ssl, const unsigned char *ptr);
  uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
+ uint32_t SSL_CIPHER_get_standard_id(const SSL_CIPHER *c);
 
 =head1 DESCRIPTION
 
@@ -98,11 +100,10 @@ two-byte TLS cipher ID (as allocated by IANA) in network byte order. This parame
 is usually retrieved from a TLS packet by using functions like L<SSL_early_get0_ciphers(3)>.
 SSL_CIPHER_find() returns NULL if an error occurs or the indicated cipher is not found.
 
-SSL_CIPHER_get_id() returns the ID of the given cipher B<c>. The ID here is an
-OpenSSL-specific concept, which stores a prefix of 0x0300 in the higher two bytes,
-and the IANA-specified chipher suite ID in the lower two bytes. For instance,
-TLS_RSA_WITH_NULL_MD5 has IANA ID "0x00, 0x01", but the SSL_CIPHER_get_id()
-function will return an ID with value 0x03000001.
+SSL_CIPHER_get_id() returns the OpenSSL-specific ID of the given cipher B<c>. That ID is
+not the same as the IANA-specific ID.
+
+SSL_CIPHER_get_standard_id() returns the IANA-specific ID of the given cipher B<c>.
 
 SSL_CIPHER_description() returns a textual description of the cipher used
 into the buffer B<buf> of length B<len> provided.  If B<buf> is provided, it

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -92,16 +92,16 @@ TLS 1.3 cipher suites) B<NID_auth_any> is returned. Examples (not comprehensive)
 SSL_CIPHER_is_aead() returns 1 if the cipher B<c> is AEAD (e.g. GCM or
 ChaCha20/Poly1305), and 0 if it is not AEAD.
 
-SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID stored in
-B<ptr>. The B<ptr> parameter is a two elements array of B<char>, which stores the two
-bytes TLS cipher ID in network byte order. This parameter is usually retrieved from a
-TLS packet by using functions like L<PACKET_get_bytes(3)>. SSL_CIPHER_find() returns
-NULL if error occurs or cipher is not found.
+SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID stored
+in B<ptr>. The B<ptr> parameter is a two elements array of B<char>, which stores the
+two-byte TLS cipher ID (as allocalted by IANA) in network byte order. This parameter
+is usually retrieved from a TLS packet by using functions like L<SSL_early_get0_ciphers(3)>.
+SSL_CIPHER_find() returns NULL if an error occurs or the indicated cipher is not found.
 
 SSL_CIPHER_get_id() returns the ID of the given cipher B<c>. The ID here is an
 OpenSSL-specific concept, which stores a prefix of 0x0300 in the higher two bytes,
 and the IANA-specified chipher suit ID in the lower two bytes. For instance,
-TLS_RSA_WITH_NULL_MD5, has IANA ID "0x00, 0x01", but the SSL_CIPHER_get_id()
+TLS_RSA_WITH_NULL_MD5 has IANA ID "0x00, 0x01", but the SSL_CIPHER_get_id()
 function will return an ID with value 0x03000001.
 
 SSL_CIPHER_description() returns a textual description of the cipher used

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -16,7 +16,7 @@ SSL_CIPHER_get_auth_nid,
 SSL_CIPHER_is_aead,
 SSL_CIPHER_find,
 SSL_CIPHER_get_id,
-SSL_CIPHER_get_standard_id
+SSL_CIPHER_get_protocol_id
 - get SSL_CIPHER properties
 
 =head1 SYNOPSIS
@@ -37,7 +37,7 @@ SSL_CIPHER_get_standard_id
  int SSL_CIPHER_is_aead(const SSL_CIPHER *c);
  const SSL_CIPHER *SSL_CIPHER_find(SSL *ssl, const unsigned char *ptr);
  uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
- uint32_t SSL_CIPHER_get_standard_id(const SSL_CIPHER *c);
+ uint32_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c);
 
 =head1 DESCRIPTION
 
@@ -103,7 +103,8 @@ SSL_CIPHER_find() returns NULL if an error occurs or the indicated cipher is not
 SSL_CIPHER_get_id() returns the OpenSSL-specific ID of the given cipher B<c>. That ID is
 not the same as the IANA-specific ID.
 
-SSL_CIPHER_get_standard_id() returns the IANA-specific ID of the given cipher B<c>.
+SSL_CIPHER_get_protocol_id() returns the two-byte ID used in SSL/TLS protocol of the given
+cipher B<c>.
 
 SSL_CIPHER_description() returns a textual description of the cipher used
 into the buffer B<buf> of length B<len> provided.  If B<buf> is provided, it

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -13,7 +13,9 @@ SSL_CIPHER_get_digest_nid,
 SSL_CIPHER_get_handshake_digest,
 SSL_CIPHER_get_kx_nid,
 SSL_CIPHER_get_auth_nid,
-SSL_CIPHER_is_aead
+SSL_CIPHER_is_aead,
+SSL_CIPHER_find,
+SSL_CIPHER_get_id
 - get SSL_CIPHER properties
 
 =head1 SYNOPSIS
@@ -32,6 +34,8 @@ SSL_CIPHER_is_aead
  int SSL_CIPHER_get_kx_nid(const SSL_CIPHER *c);
  int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *c);
  int SSL_CIPHER_is_aead(const SSL_CIPHER *c);
+ const SSL_CIPHER *SSL_CIPHER_find(SSL *ssl, const unsigned char *ptr);
+ uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
 
 =head1 DESCRIPTION
 
@@ -87,6 +91,13 @@ TLS 1.3 cipher suites) B<NID_auth_any> is returned. Examples (not comprehensive)
 
 SSL_CIPHER_is_aead() returns 1 if the cipher B<c> is AEAD (e.g. GCM or
 ChaCha20/Poly1305), and 0 if it is not AEAD.
+
+SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID B<ptr>.
+The B<ptr> parameter is a two elements array of B<char>, which stores the two bytes
+TLS cipher ID in network byte order. This parameter is usually retrieved from a TLS
+packet by using functions like L<PACKET_get_bytes(3)>.
+
+SSL_CIPHER_get_id() returns the ID of the given cipher B<c>.
 
 SSL_CIPHER_description() returns a textual description of the cipher used
 into the buffer B<buf> of length B<len> provided.  If B<buf> is provided, it

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1437,6 +1437,7 @@ __owur const char *SSL_CIPHER_get_name(const SSL_CIPHER *c);
 __owur const char *SSL_CIPHER_standard_name(const SSL_CIPHER *c);
 __owur const char *OPENSSL_cipher_name(const char *rfc_name);
 __owur uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
+__owur uint32_t SSL_CIPHER_get_standard_id(const SSL_CIPHER *c);
 __owur int SSL_CIPHER_get_kx_nid(const SSL_CIPHER *c);
 __owur int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *c);
 __owur const EVP_MD *SSL_CIPHER_get_handshake_digest(const SSL_CIPHER *c);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1437,7 +1437,7 @@ __owur const char *SSL_CIPHER_get_name(const SSL_CIPHER *c);
 __owur const char *SSL_CIPHER_standard_name(const SSL_CIPHER *c);
 __owur const char *OPENSSL_cipher_name(const char *rfc_name);
 __owur uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
-__owur uint32_t SSL_CIPHER_get_standard_id(const SSL_CIPHER *c);
+__owur uint16_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c);
 __owur int SSL_CIPHER_get_kx_nid(const SSL_CIPHER *c);
 __owur int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *c);
 __owur const EVP_MD *SSL_CIPHER_get_handshake_digest(const SSL_CIPHER *c);

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1749,11 +1749,9 @@ uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c)
     return c->id;
 }
 
-uint32_t SSL_CIPHER_get_standard_id(const SSL_CIPHER *c)
+uint16_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c)
 {
-    if (c->id & SSL3_CK_CIPHERSUITE_FLAG)
-        return c->id & ~SSL3_CK_CIPHERSUITE_FLAG;
-    return c->id;
+    return c->id & 0xFFFF;
 }
 
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n)

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1749,6 +1749,13 @@ uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c)
     return c->id;
 }
 
+uint32_t SSL_CIPHER_get_standard_id(const SSL_CIPHER *c)
+{
+    if (c->id & SSL3_CK_CIPHERSUITE_FLAG)
+        return c->id & ~SSL3_CK_CIPHERSUITE_FLAG;
+    return c->id;
+}
+
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n)
 {
     SSL_COMP *ctmp;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -464,3 +464,4 @@ SSL_alloc_buffers                       464	1_1_1	EXIST::FUNCTION:
 SSL_free_buffers                        465	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_dup                         466	1_1_1	EXIST::FUNCTION:
 SSL_get_pending_cipher                  467	1_1_1	EXIST::FUNCTION:
+SSL_CIPHER_get_standard_id              468	1_1_1	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -464,4 +464,4 @@ SSL_alloc_buffers                       464	1_1_1	EXIST::FUNCTION:
 SSL_free_buffers                        465	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_dup                         466	1_1_1	EXIST::FUNCTION:
 SSL_get_pending_cipher                  467	1_1_1	EXIST::FUNCTION:
-SSL_CIPHER_get_standard_id              468	1_1_1	EXIST::FUNCTION:
+SSL_CIPHER_get_protocol_id              468	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This is yet another 'code health' commit to respond to this round of code health
Tuesday

[skip ci]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
