### PR TITLE
Avoid surpising password dialog in X509 file lookup

### DIFF
--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -88,7 +88,7 @@ int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
 
     if (type == X509_FILETYPE_PEM) {
         for (;;) {
-            x = PEM_read_bio_X509_AUX(in, NULL, NULL, NULL);
+            x = PEM_read_bio_X509_AUX(in, NULL, NULL, "");
             if (x == NULL) {
                 if ((ERR_GET_REASON(ERR_peek_last_error()) ==
                      PEM_R_NO_START_LINE) && (count > 0)) {
@@ -145,7 +145,7 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
 
     if (type == X509_FILETYPE_PEM) {
         for (;;) {
-            x = PEM_read_bio_X509_CRL(in, NULL, NULL, NULL);
+            x = PEM_read_bio_X509_CRL(in, NULL, NULL, "");
             if (x == NULL) {
                 if ((ERR_GET_REASON(ERR_peek_last_error()) ==
                      PEM_R_NO_START_LINE) && (count > 0)) {
@@ -200,7 +200,7 @@ int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type)
         X509err(X509_F_X509_LOAD_CERT_CRL_FILE, ERR_R_SYS_LIB);
         return 0;
     }
-    inf = PEM_X509_INFO_read_bio(in, NULL, NULL, NULL);
+    inf = PEM_X509_INFO_read_bio(in, NULL, NULL, "");
     BIO_free(in);
     if (!inf) {
         X509err(X509_F_X509_LOAD_CERT_CRL_FILE, ERR_R_PEM_LIB);


### PR DESCRIPTION
A CRL or X509 file in PEM format can be manually modified by adding
the encryption header Lines from e.g. an encrypted RSA private key file.
This can cause the file lookup functions in by_file.c to wait for a password.

For instance:
 
```
-----BEGIN X509 CRL-----
Proc-Type: 4,ENCRYPTED
DEK-Info: DES-EDE3-CBC,3ACE0B1CAC45074F

MIICNDCCARwCAQEwDQYJKoZIhvcNAQELBQAwgcMxCzAJBgNVBAYTAkRFMQ8wDQYD
....
h+D/yoyuEH2H3J2paIFdCrD64RVv44e9RmysJ52F5J4MJKSGT6kmoA==
-----END X509 CRL-----
```
