### PR TITLE
Fix an invalid memory allocation function

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -224,7 +224,7 @@ DEFINE_RUN_ONCE_STATIC(do_rand_init)
     rand_bytes.curr = 0;
     rand_bytes.size = MAX_RANDOMNESS_HELD;
     /* TODO: Should this be secure malloc? */
-    rand_bytes.buff = malloc(rand_bytes.size);
+    rand_bytes.buff = OPENSSL_malloc(rand_bytes.size);
 
     ret &= rand_bytes.buff != NULL;
     ret &= setup_drbg(&rand_drbg);


### PR DESCRIPTION
A memory block allocated with `malloc()` at https://github.com/openssl/openssl/commit/75e2c877650444fb829547bdb58d46eb1297bc1a#diff-baca3d0b945f277b98ef9b654387b6bfR191 is later freed with  `OPENSSL_clear_free()` at https://github.com/openssl/openssl/commit/ddc6a5c8f5900959bdbdfee79e1625a3f7808acd#diff-baca3d0b945f277b98ef9b654387b6bfR240.  This breaks applications that use `CRYPTO_set_mem_functions()`.

CLA: trivial