### PR TITLE
WorK In Progress : Copy nonempty dirs

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -679,7 +679,13 @@ tags TAGS: FORCE
 
 # Release targets (note: only available on Unix) #####################
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),SunOS)
+# tar in Solaris doesn't have --owner and --group options
+TAR_COMMAND=$(TAR) $(TARFLAGS) -cvf -
+else
 TAR_COMMAND=$(TAR) $(TARFLAGS) --owner 0 --group 0 -cvf -
+endif
 PREPARE_CMD=:
 tar:
 	TMPDIR=/var/tmp/openssl-copy.$$$$; \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -702,8 +702,9 @@ tar:
 	           cp $$F $$TMPDIR/$$DISTDIR/$$F; \
 	       fi; \
 	   done); \
-	(cd $$TMPDIR; \
+	(cd $$TMPDIR/$$DISTDIR; \
 	 $(PREPARE_CMD); \
+	 cd $$TMPDIR; \
 	 find $$TMPDIR/$$DISTDIR -type d -print | xargs chmod 755; \
 	 find $$TMPDIR/$$DISTDIR -type f -print | xargs chmod a+r; \
 	 find $$TMPDIR/$$DISTDIR -type f -perm -0100 -print | xargs chmod a+x; \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -679,13 +679,8 @@ tags TAGS: FORCE
 
 # Release targets (note: only available on Unix) #####################
 
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),SunOS)
 # tar in Solaris doesn't have --owner and --group options
-TAR_COMMAND=$(TAR) $(TARFLAGS) -cvf -
-else
 TAR_COMMAND=$(TAR) $(TARFLAGS) --owner 0 --group 0 -cvf -
-endif
 PREPARE_CMD=:
 tar:
 	TMPDIR=/var/tmp/openssl-copy.$$$$; \
@@ -708,14 +703,26 @@ tar:
 	           cp $$F $$TMPDIR/$$DISTDIR/$$F; \
 	       fi; \
 	   done); \
+	(UNAME_S=`uname -s`; \
+	# tar in Solaris doesn't have --owner and --group options \
+	if [ $$UNAME_S == "SunOS" ]; then \
 	(cd $$TMPDIR/$$DISTDIR; \
+	$(PREPARE_CMD); \
+	cd $$TMPDIR; \
+	find $$TMPDIR/$$DISTDIR -type d -print | xargs chmod 755; \
+	find $$TMPDIR/$$DISTDIR -type f -print | xargs chmod a+r; \
+	find $$TMPDIR/$$DISTDIR -type f -perm -0100 -print | xargs chmod a+x; \
+	$(TAR) $(TARFLAGS) -cvf - $$DISTDIR) \
+	| (cd $(SRCDIR); gzip --best > $(TARFILE).gz); \
+	else \
+	(cd $$TMPDIR; \
 	 $(PREPARE_CMD); \
-	 cd $$TMPDIR; \
 	 find $$TMPDIR/$$DISTDIR -type d -print | xargs chmod 755; \
 	 find $$TMPDIR/$$DISTDIR -type f -print | xargs chmod a+r; \
 	 find $$TMPDIR/$$DISTDIR -type f -perm -0100 -print | xargs chmod a+x; \
 	 $(TAR_COMMAND) $$DISTDIR) \
 	| (cd $(SRCDIR); gzip --best > $(TARFILE).gz); \
+        fi; )
 	rm -rf $$TMPDIR
 	cd $(SRCDIR); ls -l $(TARFILE).gz
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -689,8 +689,18 @@ tar:
 	 git ls-tree -r --name-only --full-tree HEAD \
          | grep -v '^fuzz/corpora' \
 	 | while read F; do \
-	       mkdir -p $$TMPDIR/$$DISTDIR/`dirname $$F`; \
-	       cp $$F $$TMPDIR/$$DISTDIR/$$F; \
+	       PARENT_DIR=`dirname $$F`; \
+	       mkdir -p $$TMPDIR/$$DISTDIR/$$PAREENT_DIR; \
+	       # do not copy empty directories \
+	       IS_DIR=`ls -Al $$PARENT_DIR | grep ^d | grep $$F | wc -l`; \
+	       if [ $$IS_DIR == 1 ]; then \
+	           FILES_COUNT=`ls -1 $$PARENT_DIR/$$F | wc -l`; \
+	           if [ $$FILES_COUNT -gt 0 ]; then \
+	               cp $$F $$TMPDIR/$$DISTDIR/$$F; \
+	           fi; \
+	       else \
+	           cp $$F $$TMPDIR/$$DISTDIR/$$F; \
+	       fi; \
 	   done); \
 	(cd $$TMPDIR; \
 	 $(PREPARE_CMD); \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -690,7 +690,7 @@ tar:
          | grep -v '^fuzz/corpora' \
 	 | while read F; do \
 	       PARENT_DIR=`dirname $$F`; \
-	       mkdir -p $$TMPDIR/$$DISTDIR/$$PAREENT_DIR; \
+	       mkdir -p $$TMPDIR/$$DISTDIR/$$PARENT_DIR; \
 	       # do not copy empty directories \
 	       IS_DIR=`ls -Al $$PARENT_DIR | grep ^d | grep $$F | wc -l`; \
 	       if [ $$IS_DIR == 1 ]; then \


### PR DESCRIPTION
I am using Jenkins with build using .travis.yml option on Solaris. 

Problem#1) When we invoke "dist" or "tar" target in Makefile, it is failing when it tries to copy empty directory as shown below :
```
    $ cp boringssl /var/tmp/openssl-copy.2972/openssl-1.1.1-dev/boringssl
    cp: boringssl: is a directory

```
Fix : Do not copy an empty directories.

Problem#2) It was failing with error "Can't open perl script "./Configure": No such file or directory. The problem was  Configure script is present in /var/tmp/openssl-copy.15468/openssl-1.1.1-dev/ and not in /var/tmp/openssl-copy.15468/.

Problem#3) tar in Solars doesn't have --owner and --group option.

Problem#4) It creates openssl-1.1.1-dev.tar.gz  but is looking for _srcdist.tar.gz as shown below
```
	cd .; ls -l ../openssl-1.1.1-dev.tar.gz
        -rw-r--r--   1 mevyas   staff    6150045 Aug  8 10:37 ../openssl-1.1.1-dev.tar.gz
        tar: _srcdist.tar.gz: No such file or directory

```
Suggested Fix:
```
diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
index 9412ac6..e64f60a 100644
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -727,7 +727,7 @@ tar:
        cd $(SRCDIR); ls -l $(TARFILE).gz
 
 dist:
-       @$(MAKE) PREPARE_CMD='$(PERL) ./Configure dist' tar
+       @$(MAKE) PREPARE_CMD='$(PERL) ./Configure dist' TARFILE=$(TARFILE) NAME=$(NAME) tar
 
 # Helper targets #####################################################
```
Problem# 5) Move the following osx if condition to appropriate configuration file
```
if [ "$1" == osx ]; then
    make NAME='_srcdist' TARFILE='_srcdist.tar' \
         TAR_COMMAND='$(TAR) $(TARFLAGS) -cvf -' tar
else
    make TARFILE='_srcdist.tar' NAME='_srcdist' dist
fi
```