### PR TITLE
Decrypt CMS messages with any key type without a certificate.

### DIFF
--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -583,19 +583,20 @@ static int cms_kari_set1_pkey(CMS_ContentInfo *cms, CMS_RecipientInfo *ri,
     STACK_OF(CMS_RecipientEncryptedKey) *reks;
     CMS_RecipientEncryptedKey *rek;
     reks = CMS_RecipientInfo_kari_get0_reks(ri);
-    if (!cert)
-        return 0;
     for (i = 0; i < sk_CMS_RecipientEncryptedKey_num(reks); i++) {
         int rv;
         rek = sk_CMS_RecipientEncryptedKey_value(reks, i);
-        if (CMS_RecipientEncryptedKey_cert_cmp(rek, cert))
+        if (cert != NULL && CMS_RecipientEncryptedKey_cert_cmp(rek, cert))
             continue;
         CMS_RecipientInfo_kari_set0_pkey(ri, pk);
         rv = CMS_RecipientInfo_kari_decrypt(cms, ri, rek);
         CMS_RecipientInfo_kari_set0_pkey(ri, NULL);
         if (rv > 0)
             return 1;
-        return -1;
+        if (cert == NULL)
+            return 0;
+        else
+            return -1;
     }
     return 0;
 }
@@ -659,8 +660,8 @@ int CMS_decrypt_set1_pkey(CMS_ContentInfo *cms, EVP_PKEY *pk, X509 *cert)
                 return 1;
         }
     }
-    /* If no cert and not debugging always return success */
-    if (match_ri && !cert && !debug) {
+    /* If no cert, key transport and not debugging always return success */
+    if (cert == NULL && ri_type == CMS_RECIPINFO_TRANS && match_ri && !debug) {
         ERR_clear_error();
         return 1;
     }

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -349,6 +349,15 @@ my @smime_cms_param_tests = (
 	"-in", "test.cms", "-out", "smtst.txt" ]
     ],
 
+    [ "enveloped content test streaming S/MIME format, DES, ECDH, 2 recipients, key only used",
+      [ "-encrypt", "-in", $smcont,
+	"-stream", "-out", "test.cms",
+	catfile($smdir, "smec1.pem"),
+	catfile($smdir, "smec2.pem") ],
+      [ "-decrypt", "-inkey", catfile($smdir, "smec2.pem"),
+	"-in", "test.cms", "-out", "smtst.txt" ]
+    ],
+
     [ "enveloped content test streaming S/MIME format, ECDH, DES, key identifier",
       [ "-encrypt", "-keyid", "-in", $smcont,
 	"-stream", "-out", "test.cms",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

This fixes a bug where CMS decrypt without a certificate only worked for key transport (RSA) keys. This now supports other key types too. Unlike the RSA case an unsuccessful decrypt doesn't leak any useful information to an attacker so it is OK to return an error to the caller.

This is a bug in the sense that the code behaviour didn't match the documentation in which case it should arguably be back ported. If this is deemed a new feature we can instead only have this in master and fix the documentation in other branches.