### PR TITLE
Fix building without scrypt

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -819,6 +819,7 @@ static int alg_print(const X509_ALGOR *alg)
             BIO_printf(bio_err, ", Iteration %ld, PRF %s",
                        ASN1_INTEGER_get(kdf->iter), OBJ_nid2sn(prfnid));
             PBKDF2PARAM_free(kdf);
+#ifndef OPENSSL_NO_SCRYPT
         } else if (pbenid == NID_id_scrypt) {
             SCRYPT_PARAMS *kdf = NULL;
 
@@ -835,6 +836,7 @@ static int alg_print(const X509_ALGOR *alg)
                        ASN1_INTEGER_get(kdf->blockSize),
                        ASN1_INTEGER_get(kdf->parallelizationParameter));
             SCRYPT_PARAMS_free(kdf);
+#endif
         }
         PBE2PARAM_free(pbe2);
     } else {

--- a/crypto/kdf/scrypt.c
+++ b/crypto/kdf/scrypt.c
@@ -15,6 +15,8 @@
 #include "internal/cryptlib.h"
 #include "internal/evp_int.h"
 
+#ifndef OPENSSL_NO_SCRYPT
+
 static int atou64(const char *nptr, uint64_t *result);
 
 typedef struct {
@@ -256,3 +258,5 @@ const EVP_PKEY_METHOD scrypt_pkey_meth = {
     pkey_scrypt_ctrl,
     pkey_scrypt_ctrl_str
 };
+
+#endif

--- a/test/pkey_meth_kdf_test.c
+++ b/test/pkey_meth_kdf_test.c
@@ -60,6 +60,7 @@ static int test_kdf_hkdf(void)
     return 1;
 }
 
+#ifndef OPENSSL_NO_SCRYPT
 static int test_kdf_scrypt(void)
 {
     EVP_PKEY_CTX *pctx;
@@ -126,10 +127,13 @@ static int test_kdf_scrypt(void)
     EVP_PKEY_CTX_free(pctx);
     return 1;
 }
+#endif
 
 int setup_tests()
 {
     ADD_TEST(test_kdf_hkdf);
+#ifndef OPENSSL_NO_SCRYPT
     ADD_TEST(test_kdf_scrypt);
+#endif
     return 1;
 }


### PR DESCRIPTION
Building without the scrypt KDF is now possible, the OPENSSL_NO_SCRYPT
define is honored in code. Previous this lead to undefined references.

Note that this fixes some code I've introduced in the last few commits (adding scrypt KDF), but also the PKCS#12 code suffered from the same issue (i.e., the build with "no-scrypt" was broken even before I broke it more). Maybe there should be a test build for this?