### PR TITLE
Use .subsections_via_symbols to support dead_strip.

### DIFF
--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -174,4 +174,6 @@ while(my $line=<>) {
     print "\n";
 }
 
+print ".subsections_via_symbols\n"      if ($flavour =~ /ios/);
+
 close STDOUT;

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -1200,7 +1200,7 @@ while(defined(my $line=<>)) {
 
 print "\n$current_segment\tENDS\n"	if ($current_segment && $masm);
 print "END\n"				if ($masm);
-
+print ".subsections_via_symbols\n"      if ($flavour eq "macosx");
 close STDOUT;
 
 #################################################

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -164,6 +164,8 @@ sub ::file_end
 	    foreach $i (keys %non_lazy_ptr)
 	    {	push(@out,"$non_lazy_ptr{$i}:\n.indirect_symbol\t$i\n.long\t0\n");   }
 	}
+	# Support dead code stripping
+	push(@out,".subsections_via_symbols\n");
     }
     if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out) {
 	my $tmp=".comm\t${nmdecor}OPENSSL_ia32cap_P,16";


### PR DESCRIPTION
On macOS/iOS, the linker requires .subsections_via_symbols in order to enable
-dead_strip to remove assembly code. See the .subsections_via_symbols documentation
for more details:

https://developer.apple.com/library/content/documentation/DeveloperTools/Reference/Assembler/040-Assembler_Directives/asm_directives.html#//apple_ref/doc/uid/TP30000823-SW13

----

If .subsections_via_symbols is not specified, assembly code that is only included via dead code will not be stripped with -dead_strip; the result can be a large amount of unwanted code (e.g. unused hashes, unused bignum or ECC routines) included in the final binary. In extreme cases this can save up to 100KB of space in a final binary.

To test, compile the library with

    ./Configure darwin64-x86_64-cc no-shared no-dso no-engine no-autoalginit

to avoid automatic inclusion of algorithms, then compile the following test program:

```c
#include <openssl/rsa.h>
#include <stdio.h>
#include <string.h>

int main(int argc, char **argv) {
    RSA *rsa_pubkey = RSA_new();
    unsigned char key[32];
    unsigned char enckey[RSA_size(rsa_pubkey)];
    if((int)sizeof(enckey) != RSA_public_encrypt(sizeof(key), (unsigned char *)&key, enckey, rsa_pubkey, RSA_PKCS1_OAEP_PADDING))
        return 1;

    return 0;
}
```

using 

    cc test.c -lcrypto -o test -Wl,-dead_strip

With `nm` without this patch, the result will contain functions like `_sha256_block_data_order` even though SHA-256 is not used for OAEP. With this patch, those functions disappear, and only `_sha1_block_data_order` (and related methods) are present.