### PR TITLE
Add missing documentation of the default format for commands.

### DIFF
--- a/doc/man1/crl.pod
+++ b/doc/man1/crl.pod
@@ -42,8 +42,8 @@ the DER form with header and footer lines.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/crl2pkcs7.pod
+++ b/doc/man1/crl2pkcs7.pod
@@ -33,13 +33,13 @@ Print out a usage message.
 
 This specifies the CRL input format. B<DER> format is DER encoded CRL
 structure.B<PEM> (the default) is a base64 encoded version of
-the DER form with header and footer lines.
+the DER form with header and footer lines. The default format is PEM.
 
 =item B<-outform DER|PEM>
 
 This specifies the PKCS#7 structure output format. B<DER> format is DER
 encoded PKCS#7 structure.B<PEM> (the default) is a base64 encoded version of
-the DER form with header and footer lines.
+the DER form with header and footer lines. The default format is PEM.
 
 =item B<-in filename>
 

--- a/doc/man1/dhparam.pod
+++ b/doc/man1/dhparam.pod
@@ -45,8 +45,8 @@ additional header and footer lines.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in> I<filename>
 

--- a/doc/man1/dsa.pod
+++ b/doc/man1/dsa.pod
@@ -62,8 +62,8 @@ PKCS#8 format is also accepted.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/dsaparam.pod
+++ b/doc/man1/dsaparam.pod
@@ -42,8 +42,8 @@ of the B<DER> format base64 encoded with additional header and footer lines.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -55,8 +55,8 @@ PKCS#8 format is also accepted.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/ecparam.pod
+++ b/doc/man1/ecparam.pod
@@ -47,8 +47,8 @@ header and footer lines.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -38,7 +38,7 @@ standard output is used.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format DER or PEM.
+This specifies the output format DER or PEM. The default format is PEM.
 
 =item B<-pass arg>
 

--- a/doc/man1/pkcs7.pod
+++ b/doc/man1/pkcs7.pod
@@ -37,8 +37,8 @@ the DER form with header and footer lines.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -52,11 +52,13 @@ reversed: it reads a private key and writes a PKCS#8 format key.
 
 =item B<-inform DER|PEM>
 
-This specifies the input format: see L<KEY FORMATS> for more details.
+This specifies the input format: see L<KEY FORMATS> for more details. The default
+format is PEM.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format: see L<KEY FORMATS> for more details.
+This specifies the output format: see L<KEY FORMATS> for more details. The default
+format is PEM.
 
 =item B<-traditional>
 

--- a/doc/man1/pkey.pod
+++ b/doc/man1/pkey.pod
@@ -38,12 +38,12 @@ Print out a usage message.
 
 =item B<-inform DER|PEM>
 
-This specifies the input format DER or PEM.
+This specifies the input format DER or PEM. The default format is PEM.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -71,8 +71,8 @@ footer lines.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/rsa.pod
+++ b/doc/man1/rsa.pod
@@ -63,8 +63,8 @@ section.
 
 =item B<-outform DER|NET|PEM>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 

--- a/doc/man1/sess_id.pod
+++ b/doc/man1/sess_id.pod
@@ -42,8 +42,8 @@ format base64 encoded with additional header and footer lines.
 =item B<-outform DER|PEM|NSS>
 
 This specifies the output format. The B<PEM> and B<DER> options have the same meaning
-as the B<-inform> option. The B<NSS> option outputs the session id and the master key
-in NSS keylog format.
+and default as the B<-inform> option. The B<NSS> option outputs the session id and
+the master key in NSS keylog format.
 
 =item B<-in filename>
 

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -92,12 +92,12 @@ certificate but this can change if other options such as B<-req> are
 present. The DER format is the DER encoding of the certificate and PEM
 is the base64 encoding of the DER encoding with header and footer lines
 added. The NET option is an obscure Netscape server format that is now
-obsolete.
+obsolete. The default format is PEM.
 
 =item B<-outform DER|PEM|NET>
 
-This specifies the output format, the options have the same meaning as the
-B<-inform> option.
+This specifies the output format, the options have the same meaning and default
+as the B<-inform> option.
 
 =item B<-in filename>
 


### PR DESCRIPTION
Just a documentation improvement.
This is one day late for the code health tuesday unfortunately.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
