### PR TITLE
Don't modify resumed session objects

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -641,14 +641,16 @@ int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
         return 0;
     }
 
-    OPENSSL_free(s->session->ext.supportedgroups);
-    s->session->ext.supportedgroups = NULL;
-    s->session->ext.supportedgroups_len = 0;
-    if (!PACKET_memdup(&supported_groups_list,
-                       &s->session->ext.supportedgroups,
-                       &s->session->ext.supportedgroups_len)) {
-        *al = SSL_AD_INTERNAL_ERROR;
-        return 0;
+    if (!s->hit || SSL_IS_TLS13(s)) {
+        OPENSSL_free(s->session->ext.supportedgroups);
+        s->session->ext.supportedgroups = NULL;
+        s->session->ext.supportedgroups_len = 0;
+        if (!PACKET_memdup(&supported_groups_list,
+                           &s->session->ext.supportedgroups,
+                           &s->session->ext.supportedgroups_len)) {
+            *al = SSL_AD_INTERNAL_ERROR;
+            return 0;
+        }
     }
 
     return 1;


### PR DESCRIPTION
If s->hit is set, s->session corresponds to a session created on
a previous connection, and is a data structure that is potentially
shared across other SSL objects.  As such, there are thread-safety
issues with modifying the structure without taking its lock (and
of course all corresponding read accesses would also need to take
the lock as well), which have been observed to cause double-frees.

Regardless of thread-safety, the resumed session object is intended
to reflect parameters of the connection that created the session,
and modifying it to reflect the parameters from the current connection
is confusing.  So, modifications to the session object during
ClientHello processing should only be performed on new connections,
i.e., those where s->hit is not set.

The code mostly got this right, providing such checks when processing
SNI and EC point formats, but the supported groups (formerly
supported curves) extension was missing it, which is fixed by this commit.
