### PR TITLE
Fix memory leak in session cache test

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -992,10 +992,12 @@ static int execute_test_session(int maxprot, int use_int_cache,
          * the external cache. We take a copy first because
          * SSL_CTX_remove_session() also marks the session as non-resumable.
          */
-        if (use_int_cache
-                && (!TEST_ptr(tmp = SSL_SESSION_dup(sess2))
-                    || !TEST_true(SSL_CTX_remove_session(sctx, sess2))))
-            goto end;
+        if (use_int_cache) {
+            if (!TEST_ptr(tmp = SSL_SESSION_dup(sess2))
+                    || !TEST_true(SSL_CTX_remove_session(sctx, sess2)))
+                goto end;
+            SSL_SESSION_free(sess2);
+        }
         sess2 = tmp;
     }
 


### PR DESCRIPTION
When we are using the internal cache we have to make a copy of the
session before removing it from the parent context's cache, since
we want our copy to still be resumable.  However, SSL_CTX_remove_session()
just detaches the session from the SSL_CTX; it does not free the session.
So, we must call SSL_SESSION_free() ourselves before overwriting the
variable that we dup'd from.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
