### PR TITLE
WIP: Only enable TLS 1.2 by default

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2372,7 +2372,10 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         goto err;
 
     ret->method = meth;
-    ret->min_proto_version = 0;
+    if (meth->version == TLS_ANY_VERSION)
+        ret->min_proto_version = TLS1_2_VERSION;
+    else
+        ret->min_proto_version = 0;
     ret->max_proto_version = 0;
     ret->session_cache_mode = SSL_SESS_CACHE_SERVER;
     ret->session_cache_size = SSL_SESSION_CACHE_MAX_SIZE_DEFAULT;

--- a/test/ssl-tests/02-protocol-version.conf
+++ b/test/ssl-tests/02-protocol-version.conf
@@ -376,11 +376,13 @@ client = 0-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -401,11 +403,13 @@ client = 1-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -426,11 +430,13 @@ client = 2-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -451,11 +457,13 @@ client = 3-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -475,11 +483,13 @@ client = 4-version-negotiation-client
 [4-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -506,6 +516,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [5-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -532,6 +543,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [6-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -558,6 +570,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [7-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -584,6 +597,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [8-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -609,6 +623,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [9-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -635,6 +650,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [10-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -661,6 +677,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [11-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -687,6 +704,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [12-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -712,6 +730,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [13-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -738,6 +757,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [14-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -764,6 +784,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [15-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -789,6 +810,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [16-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -815,6 +837,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [17-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -840,6 +863,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [18-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -860,11 +884,13 @@ client = 19-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [19-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -885,11 +911,13 @@ client = 20-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [20-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -911,11 +939,13 @@ client = 21-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [21-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -937,11 +967,13 @@ client = 22-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [22-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -962,11 +994,13 @@ client = 23-version-negotiation-client
 [23-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [23-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -994,6 +1028,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [24-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1020,6 +1055,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [25-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1047,6 +1083,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [26-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1074,6 +1111,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [27-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1100,6 +1138,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [28-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1127,6 +1166,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [29-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1154,6 +1194,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [30-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1181,6 +1222,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [31-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1207,6 +1249,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [32-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1234,6 +1277,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [33-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1260,6 +1304,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [34-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1285,6 +1330,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [35-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1311,6 +1357,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [36-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1336,6 +1383,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [37-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1356,11 +1404,13 @@ client = 38-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [38-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1381,11 +1431,13 @@ client = 39-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [39-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1407,11 +1459,13 @@ client = 40-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [40-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1433,11 +1487,13 @@ client = 41-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [41-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1458,11 +1514,13 @@ client = 42-version-negotiation-client
 [42-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [42-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1490,6 +1548,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [43-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1516,6 +1575,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [44-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1543,6 +1603,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [45-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1570,6 +1631,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [46-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1596,6 +1658,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [47-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1623,6 +1686,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [48-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1650,6 +1714,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [49-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1677,6 +1742,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [50-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1703,6 +1769,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [51-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1730,6 +1797,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [52-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1757,6 +1825,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [53-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1783,6 +1852,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [54-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1810,6 +1880,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [55-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1835,6 +1906,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [56-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1855,11 +1927,13 @@ client = 57-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [57-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1880,11 +1954,13 @@ client = 58-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [58-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1906,11 +1982,13 @@ client = 59-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [59-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1932,11 +2010,13 @@ client = 60-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [60-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1957,11 +2037,13 @@ client = 61-version-negotiation-client
 [61-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [61-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1989,6 +2071,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [62-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2015,6 +2098,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [63-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2042,6 +2126,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [64-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2069,6 +2154,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [65-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2095,6 +2181,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [66-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2122,6 +2209,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [67-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2149,6 +2237,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [68-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2176,6 +2265,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [69-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2202,6 +2292,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [70-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2229,6 +2320,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [71-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2256,6 +2348,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [72-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2282,6 +2375,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [73-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2309,6 +2403,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [74-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2335,6 +2430,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [75-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2356,10 +2452,12 @@ client = 76-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [76-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2380,10 +2478,12 @@ client = 77-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [77-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2405,10 +2505,12 @@ client = 78-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [78-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2430,10 +2532,12 @@ client = 79-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [79-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2454,10 +2558,12 @@ client = 80-version-negotiation-client
 [80-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [80-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2484,6 +2590,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [81-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2509,6 +2616,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [82-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2535,6 +2643,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [83-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2561,6 +2670,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [84-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2586,6 +2696,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [85-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2612,6 +2723,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [86-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2638,6 +2750,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [87-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2664,6 +2777,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [88-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2689,6 +2803,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [89-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2715,6 +2830,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [90-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2741,6 +2857,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [91-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2766,6 +2883,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [92-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2792,6 +2910,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [93-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2817,6 +2936,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [94-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -2838,6 +2958,7 @@ client = 95-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [95-version-negotiation-client]
@@ -2864,6 +2985,7 @@ client = 96-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [96-version-negotiation-client]
@@ -2890,6 +3012,7 @@ client = 97-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [97-version-negotiation-client]
@@ -2916,6 +3039,7 @@ client = 98-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [98-version-negotiation-client]
@@ -2941,6 +3065,7 @@ client = 99-version-negotiation-client
 [99-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [99-version-negotiation-client]
@@ -3341,6 +3466,7 @@ client = 114-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [114-version-negotiation-client]
@@ -3367,6 +3493,7 @@ client = 115-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [115-version-negotiation-client]
@@ -3394,6 +3521,7 @@ client = 116-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [116-version-negotiation-client]
@@ -3421,6 +3549,7 @@ client = 117-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [117-version-negotiation-client]
@@ -3447,6 +3576,7 @@ client = 118-version-negotiation-client
 [118-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [118-version-negotiation-client]
@@ -3856,6 +3986,7 @@ client = 133-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [133-version-negotiation-client]
@@ -3882,6 +4013,7 @@ client = 134-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [134-version-negotiation-client]
@@ -3909,6 +4041,7 @@ client = 135-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [135-version-negotiation-client]
@@ -3936,6 +4069,7 @@ client = 136-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [136-version-negotiation-client]
@@ -3962,6 +4096,7 @@ client = 137-version-negotiation-client
 [137-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [137-version-negotiation-client]
@@ -4374,6 +4509,7 @@ client = 152-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [152-version-negotiation-client]
@@ -4400,6 +4536,7 @@ client = 153-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [153-version-negotiation-client]
@@ -4427,6 +4564,7 @@ client = 154-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [154-version-negotiation-client]
@@ -4454,6 +4592,7 @@ client = 155-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [155-version-negotiation-client]
@@ -4480,6 +4619,7 @@ client = 156-version-negotiation-client
 [156-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [156-version-negotiation-client]
@@ -4894,6 +5034,7 @@ client = 171-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [171-version-negotiation-client]
@@ -4919,6 +5060,7 @@ client = 172-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [172-version-negotiation-client]
@@ -4945,6 +5087,7 @@ client = 173-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [173-version-negotiation-client]
@@ -4971,6 +5114,7 @@ client = 174-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [174-version-negotiation-client]
@@ -4996,6 +5140,7 @@ client = 175-version-negotiation-client
 [175-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [175-version-negotiation-client]
@@ -5395,6 +5540,7 @@ client = 190-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [190-version-negotiation-client]
@@ -5421,6 +5567,7 @@ client = 191-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [191-version-negotiation-client]
@@ -5448,6 +5595,7 @@ client = 192-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [192-version-negotiation-client]
@@ -5475,6 +5623,7 @@ client = 193-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [193-version-negotiation-client]
@@ -5501,6 +5650,7 @@ client = 194-version-negotiation-client
 [194-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [194-version-negotiation-client]
@@ -5910,6 +6060,7 @@ client = 209-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [209-version-negotiation-client]
@@ -5936,6 +6087,7 @@ client = 210-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [210-version-negotiation-client]
@@ -5963,6 +6115,7 @@ client = 211-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [211-version-negotiation-client]
@@ -5990,6 +6143,7 @@ client = 212-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [212-version-negotiation-client]
@@ -6016,6 +6170,7 @@ client = 213-version-negotiation-client
 [213-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [213-version-negotiation-client]
@@ -6428,6 +6583,7 @@ client = 228-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [228-version-negotiation-client]
@@ -6454,6 +6610,7 @@ client = 229-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [229-version-negotiation-client]
@@ -6481,6 +6638,7 @@ client = 230-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [230-version-negotiation-client]
@@ -6508,6 +6666,7 @@ client = 231-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [231-version-negotiation-client]
@@ -6534,6 +6693,7 @@ client = 232-version-negotiation-client
 [232-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [232-version-negotiation-client]
@@ -6948,6 +7108,7 @@ client = 247-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [247-version-negotiation-client]
@@ -6973,6 +7134,7 @@ client = 248-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [248-version-negotiation-client]
@@ -6999,6 +7161,7 @@ client = 249-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [249-version-negotiation-client]
@@ -7025,6 +7188,7 @@ client = 250-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [250-version-negotiation-client]
@@ -7050,6 +7214,7 @@ client = 251-version-negotiation-client
 [251-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [251-version-negotiation-client]
@@ -7449,6 +7614,7 @@ client = 266-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [266-version-negotiation-client]
@@ -7475,6 +7641,7 @@ client = 267-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [267-version-negotiation-client]
@@ -7501,6 +7668,7 @@ client = 268-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [268-version-negotiation-client]
@@ -7528,6 +7696,7 @@ client = 269-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [269-version-negotiation-client]
@@ -7554,6 +7723,7 @@ client = 270-version-negotiation-client
 [270-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [270-version-negotiation-client]
@@ -7964,6 +8134,7 @@ client = 285-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [285-version-negotiation-client]
@@ -7990,6 +8161,7 @@ client = 286-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [286-version-negotiation-client]
@@ -8016,6 +8188,7 @@ client = 287-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [287-version-negotiation-client]
@@ -8043,6 +8216,7 @@ client = 288-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [288-version-negotiation-client]
@@ -8069,6 +8243,7 @@ client = 289-version-negotiation-client
 [289-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [289-version-negotiation-client]
@@ -8481,6 +8656,7 @@ client = 304-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [304-version-negotiation-client]
@@ -8506,6 +8682,7 @@ client = 305-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [305-version-negotiation-client]
@@ -8531,6 +8708,7 @@ client = 306-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [306-version-negotiation-client]
@@ -8557,6 +8735,7 @@ client = 307-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [307-version-negotiation-client]
@@ -8582,6 +8761,7 @@ client = 308-version-negotiation-client
 [308-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [308-version-negotiation-client]
@@ -8979,6 +9159,7 @@ client = 323-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [323-version-negotiation-client]
@@ -9005,6 +9186,7 @@ client = 324-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [324-version-negotiation-client]
@@ -9031,6 +9213,7 @@ client = 325-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [325-version-negotiation-client]
@@ -9057,6 +9240,7 @@ client = 326-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [326-version-negotiation-client]
@@ -9083,6 +9267,7 @@ client = 327-version-negotiation-client
 [327-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [327-version-negotiation-client]
@@ -9492,6 +9677,7 @@ client = 342-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = SSLv3
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [342-version-negotiation-client]
@@ -9517,6 +9703,7 @@ client = 343-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [343-version-negotiation-client]
@@ -9542,6 +9729,7 @@ client = 344-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [344-version-negotiation-client]
@@ -9567,6 +9755,7 @@ client = 345-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [345-version-negotiation-client]
@@ -9592,6 +9781,7 @@ client = 346-version-negotiation-client
 [346-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [346-version-negotiation-client]

--- a/test/ssl-tests/07-dtls-protocol-version.conf
+++ b/test/ssl-tests/07-dtls-protocol-version.conf
@@ -79,11 +79,13 @@ client = 0-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -106,11 +108,13 @@ client = 1-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -132,11 +136,13 @@ client = 2-version-negotiation-client
 [2-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -165,6 +171,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [3-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -193,6 +200,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [4-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -220,6 +228,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [5-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -248,6 +257,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [6-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -274,6 +284,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [7-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -295,11 +306,13 @@ client = 8-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -322,11 +335,13 @@ client = 9-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -348,11 +363,13 @@ client = 10-version-negotiation-client
 [10-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -381,6 +398,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [11-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -409,6 +427,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [12-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -436,6 +455,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [13-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -464,6 +484,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [14-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -491,6 +512,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 [15-version-negotiation-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -513,10 +535,12 @@ client = 16-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [16-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -539,10 +563,12 @@ client = 17-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [17-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -564,10 +590,12 @@ client = 18-version-negotiation-client
 [18-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [18-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -595,6 +623,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [19-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -622,6 +651,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [20-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -648,6 +678,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [21-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -675,6 +706,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [22-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -701,6 +733,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [23-version-negotiation-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -723,6 +756,7 @@ client = 24-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [24-version-negotiation-client]
@@ -751,6 +785,7 @@ client = 25-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [25-version-negotiation-client]
@@ -778,6 +813,7 @@ client = 26-version-negotiation-client
 [26-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [26-version-negotiation-client]
@@ -947,6 +983,7 @@ client = 32-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [32-version-negotiation-client]
@@ -975,6 +1012,7 @@ client = 33-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [33-version-negotiation-client]
@@ -1002,6 +1040,7 @@ client = 34-version-negotiation-client
 [34-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [34-version-negotiation-client]
@@ -1173,6 +1212,7 @@ client = 40-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [40-version-negotiation-client]
@@ -1200,6 +1240,7 @@ client = 41-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [41-version-negotiation-client]
@@ -1226,6 +1267,7 @@ client = 42-version-negotiation-client
 [42-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [42-version-negotiation-client]
@@ -1391,6 +1433,7 @@ client = 48-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [48-version-negotiation-client]
@@ -1418,6 +1461,7 @@ client = 49-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [49-version-negotiation-client]
@@ -1445,6 +1489,7 @@ client = 50-version-negotiation-client
 [50-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [50-version-negotiation-client]
@@ -1615,6 +1660,7 @@ client = 56-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [56-version-negotiation-client]
@@ -1641,6 +1687,7 @@ client = 57-version-negotiation-client
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [57-version-negotiation-client]
@@ -1667,6 +1714,7 @@ client = 58-version-negotiation-client
 [58-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [58-version-negotiation-client]

--- a/test/ssl-tests/10-resumption.conf
+++ b/test/ssl-tests/10-resumption.conf
@@ -61,10 +61,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -97,10 +99,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -133,10 +137,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -169,10 +175,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -205,10 +213,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -241,10 +251,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -277,10 +289,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -313,10 +327,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -349,10 +365,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -385,10 +403,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -421,10 +441,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -457,10 +479,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [11-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -493,10 +517,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -529,10 +555,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [13-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -565,10 +593,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [14-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -601,10 +631,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [15-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -637,10 +669,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [16-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -673,10 +707,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [17-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -700,6 +736,7 @@ resume-client = 18-resumption-resume-client
 [18-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -713,6 +750,7 @@ VerifyMode = Peer
 [18-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -736,6 +774,7 @@ resume-client = 19-resumption-resume-client
 [19-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -749,6 +788,7 @@ VerifyMode = Peer
 [19-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -772,6 +812,7 @@ resume-client = 20-resumption-resume-client
 [20-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -785,6 +826,7 @@ VerifyMode = Peer
 [20-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -808,6 +850,7 @@ resume-client = 21-resumption-resume-client
 [21-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -821,6 +864,7 @@ VerifyMode = Peer
 [21-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -844,6 +888,7 @@ resume-client = 22-resumption-resume-client
 [22-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -857,6 +902,7 @@ VerifyMode = Peer
 [22-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -880,6 +926,7 @@ resume-client = 23-resumption-resume-client
 [23-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -893,6 +940,7 @@ VerifyMode = Peer
 [23-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -916,6 +964,7 @@ resume-client = 24-resumption-resume-client
 [24-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -929,6 +978,7 @@ VerifyMode = Peer
 [24-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -952,6 +1002,7 @@ resume-client = 25-resumption-resume-client
 [25-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -965,6 +1016,7 @@ VerifyMode = Peer
 [25-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -988,6 +1040,7 @@ resume-client = 26-resumption-resume-client
 [26-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1001,6 +1054,7 @@ VerifyMode = Peer
 [26-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1024,6 +1078,7 @@ resume-client = 27-resumption-resume-client
 [27-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1037,6 +1092,7 @@ VerifyMode = Peer
 [27-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1060,6 +1116,7 @@ resume-client = 28-resumption-resume-client
 [28-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1073,6 +1130,7 @@ VerifyMode = Peer
 [28-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1096,6 +1154,7 @@ resume-client = 29-resumption-resume-client
 [29-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1109,6 +1168,7 @@ VerifyMode = Peer
 [29-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1132,6 +1192,7 @@ resume-client = 30-resumption-resume-client
 [30-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1145,6 +1206,7 @@ VerifyMode = Peer
 [30-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1168,6 +1230,7 @@ resume-client = 31-resumption-resume-client
 [31-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1181,6 +1244,7 @@ VerifyMode = Peer
 [31-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1204,6 +1268,7 @@ resume-client = 32-resumption-resume-client
 [32-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1217,6 +1282,7 @@ VerifyMode = Peer
 [32-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1240,6 +1306,7 @@ resume-client = 33-resumption-resume-client
 [33-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1253,6 +1320,7 @@ VerifyMode = Peer
 [33-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1276,6 +1344,7 @@ resume-client = 34-resumption-resume-client
 [34-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1289,6 +1358,7 @@ VerifyMode = Peer
 [34-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1312,6 +1382,7 @@ resume-client = 35-resumption-resume-client
 [35-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -1325,6 +1396,7 @@ VerifyMode = Peer
 [35-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/11-dtls_resumption.conf
+++ b/test/ssl-tests/11-dtls_resumption.conf
@@ -41,10 +41,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -78,10 +80,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -115,10 +119,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -152,10 +158,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -189,10 +197,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -226,10 +236,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -263,10 +275,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -300,10 +314,12 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-resumption-client]
 CipherString = DEFAULT
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -328,6 +344,7 @@ resume-client = 8-resumption-resume-client
 [8-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -341,6 +358,7 @@ VerifyMode = Peer
 [8-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -365,6 +383,7 @@ resume-client = 9-resumption-resume-client
 [9-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -378,6 +397,7 @@ VerifyMode = Peer
 [9-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -402,6 +422,7 @@ resume-client = 10-resumption-resume-client
 [10-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -415,6 +436,7 @@ VerifyMode = Peer
 [10-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -439,6 +461,7 @@ resume-client = 11-resumption-resume-client
 [11-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -452,6 +475,7 @@ VerifyMode = Peer
 [11-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -476,6 +500,7 @@ resume-client = 12-resumption-resume-client
 [12-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -489,6 +514,7 @@ VerifyMode = Peer
 [12-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -513,6 +539,7 @@ resume-client = 13-resumption-resume-client
 [13-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -526,6 +553,7 @@ VerifyMode = Peer
 [13-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -550,6 +578,7 @@ resume-client = 14-resumption-resume-client
 [14-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -563,6 +592,7 @@ VerifyMode = Peer
 [14-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -587,6 +617,7 @@ resume-client = 15-resumption-resume-client
 [15-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
+MinProtocol = None
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -600,6 +631,7 @@ VerifyMode = Peer
 [15-resumption-resume-client]
 CipherString = DEFAULT
 MaxProtocol = DTLSv1.2
+MinProtocol = None
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -89,6 +89,7 @@ sub generate_version_tests {
     my @max_protocols = $dtls ? @max_dtls_protocols : @max_tls_protocols;
     my $min_enabled  = $dtls ? $min_dtls_enabled : $min_tls_enabled;
     my $max_enabled  = $dtls ? $max_dtls_enabled : $max_tls_enabled;
+    $min_protocols[0] = "None";
 
     if (no_tests($dtls)) {
         return;
@@ -162,13 +163,16 @@ sub generate_resumption_tests {
                 # Client is flexible, server upgrades/downgrades.
                 push @server_tests, {
                     "name" => "resumption",
-                    "client" => { },
+                    "client" => {
+                        "MinProtocol" => "None",
+                    },
                     "server" => {
                         "MinProtocol" => $protocols[$original_protocol],
                         "MaxProtocol" => $protocols[$original_protocol],
                         "Options" => $ticket,
                     },
                     "resume_server" => {
+                        "MinProtocol" => "None",
                         "MaxProtocol" => $protocols[$resume_protocol],
                     },
                     "test" => {
@@ -187,8 +191,10 @@ sub generate_resumption_tests {
                     },
                     "server" => {
                         "Options" => $ticket,
+                        "MinProtocol" => "None",
                     },
                     "resume_client" => {
+                        "MinProtocol" => "None",
                         "MaxProtocol" => $protocols[$resume_protocol],
                     },
                     "test" => {


### PR DESCRIPTION
As an alternative to disabling TLS 1.0 and 1.1 completely, I've been thinking about disabling them by default by allowing to enable them again. I currently don't intend to use it.

But this patch is giving me resumption failures for some reason except for TLS 1.2. Does anybody have an idea what is going on?