### PR TITLE
Clarify CLI OCSP documentation

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -108,7 +108,7 @@ const OPTIONS ocsp_options[] = {
     {"host", OPT_HOST, 's', "TCP/IP hostname:port to connect to"},
     {"port", OPT_PORT, 'p', "Port to run responder on"},
     {"ignore_err", OPT_IGNORE_ERR, '-',
-     "Ignore Error response from OCSP responder, and retry "},
+     "Ignore error on OCSP request or response and continue running"},
     {"noverify", OPT_NOVERIFY, '-', "Don't verify response at all"},
     {"nonce", OPT_NONCE, '-', "Add OCSP nonce to request"},
     {"no_nonce", OPT_NO_NONCE, '-', "Don't add OCSP nonce to request"},

--- a/doc/man1/ocsp.pod
+++ b/doc/man1/ocsp.pod
@@ -74,6 +74,7 @@ B<openssl> B<ocsp>
 [B<-no_cert_checks>]
 [B<-no_explicit>]
 [B<-port num>]
+[B<-ignore_err>]
 [B<-index file>]
 [B<-CA file>]
 [B<-rsigner file>]
@@ -342,6 +343,12 @@ specified in the B<rsigner> option is used.
 
 Port to listen for OCSP requests on. The port may also be specified
 using the B<url> option.
+
+=item B<-ignore_err>
+
+Ignore malformed requests or responses: When acting as an OCSP client, retry if
+a malformed response is received. When acting as an OCSP responder, continue
+running instead of terminating upon receiving a malformed request.
 
 =item B<-nrequest number>
 


### PR DESCRIPTION
This fixes issue #3043, which ultimately was reported because
documentation was not clear on the meaning of the "-ignore_err" option.
Update both command line documentation and add this option to manpage.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
