### PR TITLE
Clear outputs in PKCS12_parse error handling

### DIFF
--- a/crypto/pkcs12/p12_kiss.c
+++ b/crypto/pkcs12/p12_kiss.c
@@ -34,6 +34,12 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 {
     STACK_OF(X509) *ocerts = NULL;
     X509 *x = NULL;
+
+    if (pkey)
+        *pkey = NULL;
+    if (cert)
+        *cert = NULL;
+
     /* Check for NULL PKCS12 structure */
 
     if (!p12) {
@@ -41,11 +47,6 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
                   PKCS12_R_INVALID_NULL_PKCS12_POINTER);
         return 0;
     }
-
-    if (pkey)
-        *pkey = NULL;
-    if (cert)
-        *cert = NULL;
 
     /* Check the mac */
 
@@ -75,7 +76,7 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 
     if (!ocerts) {
         PKCS12err(PKCS12_F_PKCS12_PARSE, ERR_R_MALLOC_FAILURE);
-        return 0;
+        goto err;
     }
 
     if (!parse_pk12(p12, pass, -1, pkey, ocerts)) {
@@ -111,10 +112,14 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 
  err:
 
-    if (pkey)
+    if (pkey) {
         EVP_PKEY_free(*pkey);
-    if (cert)
+        *pkey = NULL;
+    }
+    if (cert) {
         X509_free(*cert);
+        *cert = NULL;
+    }
     X509_free(x);
     sk_X509_pop_free(ocerts, X509_free);
     return 0;

--- a/doc/man3/PKCS12_parse.pod
+++ b/doc/man3/PKCS12_parse.pod
@@ -42,6 +42,9 @@ L<UI_OpenSSL(3)>, for example.
 
 PKCS12_parse() returns 1 for success and zero if an error occurred.
 
+If an error occurred B<*pkey> and B<*cert> are set to B<NULL>,
+but B<*ca> is not and may need to be cleaned up.
+
 The error can be obtained from L<ERR_get_error(3)>
 
 =head1 BUGS


### PR DESCRIPTION
The function PKCS12_parse may return invalid pointers in *pkey and *cert
in case of an error.
This ensures that the returned values are always zero if anything happens.