### PR TITLE
Clear outputs in PKCS12_parse error handling [1.0.2]

### DIFF
--- a/crypto/pkcs12/p12_kiss.c
+++ b/crypto/pkcs12/p12_kiss.c
@@ -84,6 +84,12 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 {
     STACK_OF(X509) *ocerts = NULL;
     X509 *x = NULL;
+
+    if (pkey)
+        *pkey = NULL;
+    if (cert)
+        *cert = NULL;
+
     /* Check for NULL PKCS12 structure */
 
     if (!p12) {
@@ -91,11 +97,6 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
                   PKCS12_R_INVALID_NULL_PKCS12_POINTER);
         return 0;
     }
-
-    if (pkey)
-        *pkey = NULL;
-    if (cert)
-        *cert = NULL;
 
     /* Check the mac */
 
@@ -125,7 +126,7 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 
     if (!ocerts) {
         PKCS12err(PKCS12_F_PKCS12_PARSE, ERR_R_MALLOC_FAILURE);
-        return 0;
+        goto err;
     }
 
     if (!parse_pk12(p12, pass, -1, pkey, ocerts)) {
@@ -163,10 +164,14 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 
  err:
 
-    if (pkey && *pkey)
+    if (pkey) {
         EVP_PKEY_free(*pkey);
-    if (cert && *cert)
+        *pkey = NULL;
+    }
+    if (cert) {
         X509_free(*cert);
+        *cert = NULL;
+    }
     if (x)
         X509_free(x);
     if (ocerts)


### PR DESCRIPTION
The function PKCS12_parse may return invalid pointers in *pkey and *cert
in case of an error.
This ensures that the returned values are always zero if anything happens.