### PR TITLE
openssl/rand.h: fix formatting.

### DIFF
--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -60,8 +60,6 @@ int RAND_egd(const char *path);
 int RAND_egd_bytes(const char *path, int bytes);
 # endif
 
-typedef void (*RAND_poll_cb)(void *arg,
-                             const void *buf, int num, double randomness);
 int RAND_poll(void);
 
 # if defined(_WIN32) && (defined(BASETYPES) || defined(_WINDEF_H))

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -48,7 +48,6 @@ void RAND_seed(const void *buf, int num);
 # if defined(__ANDROID__) && defined(__NDK_FPABI__)
 __NDK_FPABI__	/* __attribute__((pcs("aapcs"))) on ARM */
 # endif
-
 void RAND_add(const void *buf, int num, double randomness);
 int RAND_load_file(const char *file, long max_bytes);
 int RAND_write_file(const char *file);

--- a/util/private.num
+++ b/util/private.num
@@ -43,7 +43,6 @@ OSSL_STORE_open_fn                      datatype
 OSSL_STORE_post_process_info_fn         datatype
 PROFESSION_INFO                         datatype
 PROFESSION_INFOS                        datatype
-RAND_poll_cb                            datatype
 SSL_CTX_keylog_cb_func                  datatype
 SSL_client_hello_cb_fn                  datatype
 SSL_psk_client_cb_func                  datatype


### PR DESCRIPTION
This is not for approval yet. For the moment it's just a mark that something needs to done about __NDK_FPABI__ even in RAND_poll_ex context. For reference, it won't be sufficient to modify just header. For the moment it's just formatting thing, but since there will be other occurrence[s], it might be appropriate to simplify it to something like this:
```
#ifndef __NDK_FPABI__
# define __NDK_FPABI__
#endif

__NDK_FPABI__ void RAND_add(const void *buf, int num, double randomness);
```
Thought?

For reference. What's __NDK_FPABI__? It's Android thing, and it's a way to make library agnostic to application FP calling convention. In more practical terms you can compile application code with either -mfloat-abi=soft or -mfloat-abi=hard, and still use same library. Android system libraries are like that...