### PR TITLE
Use new setup_tests in code of rsa_test

### DIFF
--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -22,9 +22,10 @@
 #include "testutil.h"
 
 #ifdef OPENSSL_NO_RSA
-void setup_tests(void)
+int setup_tests(void)
 {
     /* No tests */
+    return 1;
 }
 #else
 # include <openssl/rsa.h>


### PR DESCRIPTION
Although this piece of code will not be compiled at current stage, but
there seems a plan to re-open the 'no-rsa' option in the future so this
should be fixed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

