### PR TITLE
Fix overzealous cleanup command

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -249,7 +249,9 @@ clean: libclean
 	-del /Q /S /F *.d
 	-del /Q /S /F *.obj
 	-del /Q /S /F *.pdb
-	-del /Q /S /F *.exp
+	-del /Q /F *.exp
+	-del /Q /F apps\*.exp
+	-del /Q /F engines\*.exp
 	-del /Q /S /F engines\*.ilk
 	-del /Q /S /F engines\*.lib
 	-del /Q /S /F apps\*.lib


### PR DESCRIPTION
Concerns only the windows build chain.
When I was calling ` nmake clean`, it ends deleting some .exp  and .export file in the krb5 submodule  ...
There is no reason to touch these files.