### PR TITLE
When building a tarball, avoid trying to copy submodules

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -686,8 +686,10 @@ tar:
 	DISTDIR=$(NAME); \
 	mkdir -p $$TMPDIR/$$DISTDIR; \
 	(cd $(SRCDIR); \
+	 submodule_re=`git submodule status | sed -e 's/^.//' | cut -d' ' -f2`; \
+	 submodule_re="^(`echo $$submodule_re | sed -e 's/ /|/g'`)\$$"; \
 	 git ls-tree -r --name-only --full-tree HEAD \
-         | grep -v '^fuzz/corpora' \
+	 | grep -v '^fuzz/corpora' | egrep -v "$$submodule_re" \
 	 | while read F; do \
 	       mkdir -p $$TMPDIR/$$DISTDIR/`dirname $$F`; \
 	       cp $$F $$TMPDIR/$$DISTDIR/$$F; \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -686,10 +686,11 @@ tar:
 	DISTDIR=$(NAME); \
 	mkdir -p $$TMPDIR/$$DISTDIR; \
 	(cd $(SRCDIR); \
-	 submodule_re=`git submodule status | sed -e 's/^.//' | cut -d' ' -f2`; \
-	 submodule_re="^(`echo $$submodule_re | sed -e 's/ /|/g'`)\$$"; \
+	 excl_re=`git submodule status | sed -e 's/^.//' | cut -d' ' -f2`; \
+	 excl_re="^(fuzz/corpora|`echo $$excl_re | sed -e 's/ /$$|/g'`\$$)"; \
+	 echo "$$excl_re"; \
 	 git ls-tree -r --name-only --full-tree HEAD \
-	 | grep -v '^fuzz/corpora' | egrep -v "$$submodule_re" \
+	 | grep -v -E "$$excl_re" \
 	 | while read F; do \
 	       mkdir -p $$TMPDIR/$$DISTDIR/`dirname $$F`; \
 	       cp $$F $$TMPDIR/$$DISTDIR/$$F; \


### PR DESCRIPTION
submodules are directories that we don't want in our tarballs, so
avoid them.

-----

This is an alternative to #4114