### PR TITLE
Fix "make tar" and "make dist"

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -682,6 +682,7 @@ tags TAGS: FORCE
 TAR_COMMAND=$(TAR) $(TARFLAGS) --owner 0 --group 0 -cvf -
 PREPARE_CMD=:
 tar:
+	set -e; \
 	TMPDIR=/var/tmp/openssl-copy.$$$$; \
 	DISTDIR=$(NAME); \
 	mkdir -p $$TMPDIR/$$DISTDIR; \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -679,6 +679,8 @@ tags TAGS: FORCE
 
 # Release targets (note: only available on Unix) #####################
 
+# If your tar command doesn't support --owner and --group, make sure to
+# use one that does, for example GNU tar
 TAR_COMMAND=$(TAR) $(TARFLAGS) --owner 0 --group 0 -cvf -
 PREPARE_CMD=:
 tar:

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -693,7 +693,7 @@ tar:
 	 excl_re="^(fuzz/corpora|`echo $$excl_re | sed -e 's/ /$$|/g'`\$$)"; \
 	 echo "$$excl_re"; \
 	 git ls-tree -r --name-only --full-tree HEAD \
-	 | grep -v -E "$$excl_re" \
+	 | egrep -v "$$excl_re" \
 	 | while read F; do \
 	       mkdir -p $$TMPDIR/$$DISTDIR/`dirname $$F`; \
 	       cp $$F $$TMPDIR/$$DISTDIR/$$F; \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -696,12 +696,12 @@ tar:
 	       mkdir -p $$TMPDIR/$$DISTDIR/`dirname $$F`; \
 	       cp $$F $$TMPDIR/$$DISTDIR/$$F; \
 	   done); \
-	(cd $$TMPDIR; \
+	(cd $$TMPDIR/$$DISTDIR; \
 	 $(PREPARE_CMD); \
-	 find $$TMPDIR/$$DISTDIR -type d -print | xargs chmod 755; \
-	 find $$TMPDIR/$$DISTDIR -type f -print | xargs chmod a+r; \
-	 find $$TMPDIR/$$DISTDIR -type f -perm -0100 -print | xargs chmod a+x; \
-	 $(TAR_COMMAND) $$DISTDIR) \
+	 find . -type d -print | xargs chmod 755; \
+	 find . -type f -print | xargs chmod a+r; \
+	 find . -type f -perm -0100 -print | xargs chmod a+x); \
+	(cd $$TMPDIR; $(TAR_COMMAND) $$DISTDIR) \
 	| (cd $(SRCDIR); gzip --best > $(TARFILE).gz); \
 	rm -rf $$TMPDIR
 	cd $(SRCDIR); ls -l $(TARFILE).gz


### PR DESCRIPTION
The "tar" make target wasn't quite right, it didn't change directory correctly, making the preparation command given in the "dist" target useless.  This also clarifies that a tar command that understands `--owner` and `--group` is expected.

-----

This is an alternative to the fix in #4114