### PR TITLE
Acknowledge SNI during resumption

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -864,7 +864,7 @@ EXT_RETURN tls_construct_stoc_server_name(SSL *s, WPACKET *pkt,
                                           unsigned int context, X509 *x,
                                           size_t chainidx, int *al)
 {
-    if (s->hit || s->servername_done != 1
+    if (s->servername_done != 1
             || s->session->ext.hostname == NULL)
         return EXT_RETURN_NOT_SENT;
 


### PR DESCRIPTION
Previously a server would not acknowledge a valid SNI request when
resuming a session.

This came to light while writing tests for #3926. In that PR we have to sanity check consistency of SNI/ALPN settings when sending early_data. However I found that if the client sends SNI with early data, the server was never acknowledging the SNI and so to the client it appeared that the server had accepted early_data with different SNI settings.

Technically this is a behaviour change - but really I think this should be called a bug. Arguably we should backport it to 1.1.0 which also exhibits this behaviour. I haven't checked 1.0.2 but I suspect it does this too.

There are no tests in this PR because I already wrote one that detected this in a soon-to-be-pushed update to #3926.
