### PR TITLE
Fix OCSP_basic_verify() cert chain construction in case bs->certs is NULL

### DIFF
--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -118,6 +118,8 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
                     goto end;
                 }
             }
+        } else if (certs != NULL) {
+            untrusted = certs;
         } else {
             untrusted = bs->certs;
         }


### PR DESCRIPTION
As proposed by @mattcaswell, backport of #4124 to 1.0.2