### PR TITLE
Remove tests dependence on e_os.h

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,6 +14,8 @@
 
 # include <openssl/e_os2.h>
 # include <openssl/crypto.h>
+# include <internal/nelem.h>
+
 /*
  * <openssl/e_os2.h> contains what we can justify to make visible to the
  * outside; this file e_os.h is not part of the exported interface.
@@ -539,8 +541,6 @@ struct servent *getservbyname(const char *name, const char *proto);
 
 # endif
 /* end vxworks */
-
-#define OSSL_NELEM(x)    (sizeof(x)/sizeof((x)[0]))
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 # define CRYPTO_memcmp memcmp

--- a/include/internal/nelem.h
+++ b/include/internal/nelem.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_NELEM_H
+# define HEADER_NELEM_H
+
+# define OSSL_NELEM(x)    (sizeof(x)/sizeof((x)[0]))
+#endif

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -16,7 +16,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 /**********************************************************************
  *

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -16,7 +16,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 struct testdata {
     char *data;             /* TIME string value */

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -39,7 +39,7 @@
 #include <openssl/kdf.h>
 
 #include "../ssl/packet_locl.h"
-#include "../e_os.h" /* for OSSL_NELEM() */
+#include <internal/nelem.h>
 
 #include "testutil.h"
 

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -19,7 +19,7 @@
 
 #include "testutil.h"
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 
 #ifndef OPENSSL_NO_BF
 # include <openssl/blowfish.h>

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include <internal/numbers.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>

--- a/test/casttest.c
+++ b/test/casttest.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 
 #include <openssl/opensslconf.h> /* To see if OPENSSL_NO_CAST is defined */
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_CAST

--- a/test/cipher_overhead_test.c
+++ b/test/cipher_overhead_test.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifdef __VMS

--- a/test/cipherbytes_test.c
+++ b/test/cipherbytes_test.c
@@ -18,7 +18,7 @@
 #include <openssl/ssl3.h>
 #include <openssl/tls1.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 static SSL_CTX *ctx;

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -18,7 +18,7 @@
 #include <openssl/ssl3.h>
 #include <openssl/tls1.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 typedef struct cipherlist_test_fixture {

--- a/test/ciphername_test.c
+++ b/test/ciphername_test.c
@@ -19,7 +19,7 @@
 #include <openssl/ssl3.h>
 #include <openssl/tls1.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 typedef struct cipher_id_name {

--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "internal/constant_time_locl.h"
 #include "testutil.h"
 #include "internal/numbers.h"

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include <string.h>
 #include <openssl/bio.h>
 #include <openssl/crypto.h>

--- a/test/d2i_test.c
+++ b/test/d2i_test.c
@@ -20,7 +20,7 @@
 #include <openssl/err.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
-#include "e_os.h"
+#include <internal/nelem.h>
 
 static const ASN1_ITEM *item_type;
 static const char *test_file;

--- a/test/danetest.c
+++ b/test/danetest.c
@@ -24,7 +24,7 @@
 #endif
 #include "testutil.h"
 
-#include "e_os.h"
+#include <internal/nelem.h>
 
 #define _UC(c) ((unsigned char)(c))
 

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include <openssl/crypto.h>
 #include <openssl/bio.h>
 #include <openssl/bn.h>

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -8,7 +8,7 @@
  */
 
 #include <string.h>
-#include "e_os.h"
+#include <internal/nelem.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -19,7 +19,7 @@
 #include <openssl/dsa.h>
 
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 #ifndef OPENSSL_NO_DSA
 static int dsa_cb(int p, int n, BN_GENCB *arg);

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -12,7 +12,7 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/conf.h>
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_SOCK

--- a/test/ecstresstest.c
+++ b/test/ecstresstest.c
@@ -8,7 +8,7 @@
  * or in the file LICENSE in the source distribution.
  */
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #include <stdio.h>

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -8,7 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_EC

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -16,7 +16,7 @@
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 /*
  * kExampleRSAKeyDER is an RSA private key in ASN.1, DER format. Of course, you

--- a/test/exptest.c
+++ b/test/exptest.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 
 #include <openssl/bio.h>
 #include <openssl/bn.h>

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -18,7 +18,7 @@
 
 #ifndef OPENSSL_NO_SOCK
 # define USE_SOCKETS
-# include "e_os.h"
+# include <internal/nelem.h>
 #endif
 
 #include "handshake_helper.h"

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 
 # include <openssl/hmac.h>
 # include <openssl/sha.h>

--- a/test/ideatest.c
+++ b/test/ideatest.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_IDEA

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -12,7 +12,7 @@
 #include <openssl/rand.h>
 #include <stdio.h>
 #include <string.h>
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #define TEST_SIZE       128

--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -16,7 +16,7 @@
 #include <openssl/err.h>
 #include <openssl/crypto.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 /*

--- a/test/md2test.c
+++ b/test/md2test.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_MD2

--- a/test/mdc2_internal_test.c
+++ b/test/mdc2_internal_test.c
@@ -14,7 +14,7 @@
 
 #include <openssl/mdc2.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 typedef struct {
     const char *input;

--- a/test/mdc2test.c
+++ b/test/mdc2test.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #if defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_MDC2)

--- a/test/modes_internal_test.c
+++ b/test/modes_internal_test.c
@@ -16,7 +16,7 @@
 #include <openssl/modes.h>
 #include "../crypto/modes/modes_lcl.h"
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 typedef struct {
     size_t size;

--- a/test/poly1305_internal_test.c
+++ b/test/poly1305_internal_test.c
@@ -15,7 +15,7 @@
 #include "testutil.h"
 #include "internal/poly1305.h"
 #include "../crypto/poly1305/poly1305_local.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 typedef struct {
     size_t size;

--- a/test/rc2test.c
+++ b/test/rc2test.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_RC2

--- a/test/rc4test.c
+++ b/test/rc4test.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_RC4

--- a/test/rc5test.c
+++ b/test/rc5test.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#include "../e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_RC5

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 
 #include <openssl/crypto.h>
 #include <openssl/err.h>

--- a/test/servername_test.c
+++ b/test/servername_test.c
@@ -21,7 +21,7 @@
 #include "../ssl/packet_locl.h"
 
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 #define CLIENT_VERSION_LEN      2
 

--- a/test/siphash_internal_test.c
+++ b/test/siphash_internal_test.c
@@ -16,7 +16,7 @@
 #include "testutil.h"
 #include "internal/siphash.h"
 #include "../crypto/siphash/siphash_local.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 static BIO* b_stderr = NULL;
 static BIO* b_stdout = NULL;

--- a/test/ssl_cert_table_internal_test.c
+++ b/test/ssl_cert_table_internal_test.c
@@ -14,7 +14,7 @@
 
 #include <openssl/ssl.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 #ifdef __VMS
 # pragma names save

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -12,7 +12,7 @@
 #include <openssl/e_os2.h>
 #include <openssl/crypto.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "ssl_test_ctx.h"
 #include "testutil.h"
 

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "ssl_test_ctx.h"
 #include "testutil.h"
 #include <openssl/e_os2.h>

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -17,7 +17,7 @@
 
 #include "ssltestlib.h"
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "../ssl/ssl_locl.h"
 
 static char *cert = NULL;

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <internal/nelem.h>
+
 #define USE_SOCKETS
 #include "e_os.h"
 

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "ssltestlib.h"
 #include "testutil.h"
 

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -16,7 +16,7 @@
 #include <openssl/err.h>
 #include <openssl/crypto.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 /* The macros below generate unused functions which error out one of the clang

--- a/test/test_test.c
+++ b/test/test_test.c
@@ -16,7 +16,7 @@
 #include <openssl/crypto.h>
 #include <openssl/bn.h>
 
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 #define TEST(expected, test) test_case((expected), #test, (test))

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "../../e_os.h"
+#include <internal/nelem.h>
 #include <openssl/bio.h>
 
 /*

--- a/test/testutil/format_output.c
+++ b/test/testutil/format_output.c
@@ -13,7 +13,7 @@
 
 #include <string.h>
 #include <ctype.h>
-#include "../../e_os.h"
+#include <internal/nelem.h>
 
 /* The size of memory buffers to display on failure */
 #define MEM_BUFFER_SIZE     (2000)

--- a/test/testutil/main.c
+++ b/test/testutil/main.c
@@ -8,7 +8,7 @@
  */
 
 #include "../testutil.h"
-#include "../../e_os.h"
+#include <internal/nelem.h>
 #include "output.h"
 #include "tu_local.h"
 

--- a/test/testutil/stanza.c
+++ b/test/testutil/stanza.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "e_os.h"
+#include "internal/nelem.h"
 #include "../testutil.h"
 #include "tu_local.h"
 

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>
-#include "../../e_os.h"
+#include <internal/nelem.h>
 
 /*
  * Output a failed test first line.

--- a/test/time_offset_test.c
+++ b/test/time_offset_test.c
@@ -16,7 +16,7 @@
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 typedef struct {
     const char *data;

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -8,7 +8,7 @@
  */
 
 #include <string.h>
-#include "e_os.h"
+#include <internal/nelem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "testutil.h"

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -15,7 +15,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 /**********************************************************************
  *

--- a/test/x509_time_test.c
+++ b/test/x509_time_test.c
@@ -15,7 +15,7 @@
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 #include "testutil.h"
-#include "e_os.h"
+#include <internal/nelem.h>
 
 typedef struct {
     const char *data;

--- a/test/x509aux.c
+++ b/test/x509aux.c
@@ -16,7 +16,7 @@
 #include <openssl/pem.h>
 #include <openssl/conf.h>
 #include <openssl/err.h>
-#include "e_os.h"
+#include <internal/nelem.h>
 #include "testutil.h"
 
 static int test_certs(int num)


### PR DESCRIPTION
Apart from ssltest_old.c, the test suite relied on e_os.h for the
OSSL_NELEM macro and nothing else.

The ssltest_old.c also requires EXIT and some socket macros.

Create a new header to define the OSSL_NELEM macro and use that instead.

- [x] tests are added or updated

q.v. #4174
