### PR TITLE
Fix windows build after too aggressive e_os.h removal

### DIFF
--- a/test/bntest.c
+++ b/test/bntest.c
@@ -13,6 +13,7 @@
 #include <ctype.h>
 
 #include <internal/nelem.h>
+#include "../e_os.h"
 #include <internal/numbers.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -13,6 +13,7 @@
 #include <openssl/crypto.h>
 
 #include <internal/nelem.h>
+#include "../e_os.h"
 #include "ssl_test_ctx.h"
 #include "testutil.h"
 

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -9,6 +9,7 @@
 
 #include <string.h>
 #include <internal/nelem.h>
+#include "../e_os.h"
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "testutil.h"


### PR DESCRIPTION
Fix windows build after too aggressive e_os.h removal
Too hastily merged.

- [x] tests are added or updated
