### PR TITLE
e_os.h removal from other headers

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -10,8 +10,8 @@
 #ifndef HEADER_APPS_H
 # define HEADER_APPS_H
 
-# include "internal/nelem.h"
 # include "e_os.h"
+# include "internal/nelem.h"
 # if defined(__unix) || defined(__unix__)
 #  include <sys/time.h> /* struct timeval for DTLS */
 # endif

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,6 +10,7 @@
 #ifndef HEADER_APPS_H
 # define HEADER_APPS_H
 
+# include "internal/nelem.h"
 # include "e_os.h"
 # if defined(__unix) || defined(__unix__)
 #  include <sys/time.h> /* struct timeval for DTLS */

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -38,7 +38,6 @@
 
 #ifndef W_OK
 # define F_OK 0
-# define X_OK 1
 # define W_OK 2
 # define R_OK 4
 #endif

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <internal/cryptlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -8,12 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include "e_os.h"
 #include <openssl/e_os2.h>
 
 #ifndef OPENSSL_NO_SOCK

--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,8 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdio.h>
+#include "e_os.h"               /* for strncasecmp */
 #include "internal/cryptlib.h"
+#include <stdio.h>
 #include <openssl/asn1t.h>
 #include <openssl/x509.h>
 #include <openssl/engine.h>

--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -10,7 +10,7 @@
 #include <stddef.h>
 #include <string.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/objects.h>

--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <string.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/objects.h>

--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -26,7 +26,6 @@
 
 #  include <ucontext.h>
 #  include <setjmp.h>
-#  include "e_os.h"
 
 typedef struct async_fibre_st {
     ucontext_t fibre;

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,6 +15,7 @@
  * See ssl/ssltest.c for some hints on how this can be used.
  */
 
+#include "e_os.h"
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -23,8 +24,6 @@
 #include "bio_lcl.h"
 #include <openssl/err.h>
 #include <openssl/crypto.h>
-
-#include "e_os.h"
 
 static int bio_new(BIO *bio);
 static int bio_free(BIO *bio);

--- a/crypto/blake2/blake2_impl.h
+++ b/crypto/blake2/blake2_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,7 +15,6 @@
  */
 
 #include <string.h>
-#include "e_os.h"
 
 static ossl_inline uint32_t load32(const uint8_t *src)
 {

--- a/crypto/blake2/blake2_locl.h
+++ b/crypto/blake2/blake2_locl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,7 +15,6 @@
  */
 
 #include <stddef.h>
-#include "e_os.h"
 
 #define BLAKE2S_BLOCKBYTES    64
 #define BLAKE2S_OUTBYTES      32

--- a/crypto/blake2/blake2b.c
+++ b/crypto/blake2/blake2b.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,6 @@
 #include <assert.h>
 #include <string.h>
 #include <openssl/crypto.h>
-#include "e_os.h"
 
 #include "blake2_locl.h"
 #include "blake2_impl.h"

--- a/crypto/blake2/blake2s.c
+++ b/crypto/blake2/blake2s.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,6 @@
 #include <assert.h>
 #include <string.h>
 #include <openssl/crypto.h>
-#include "e_os.h"
 
 #include "blake2_locl.h"
 #include "blake2_impl.h"

--- a/crypto/bn/bn_dh.c
+++ b/crypto/bn/bn_dh.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2014-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,7 +8,7 @@
  */
 
 #include "bn_lcl.h"
-#include "e_os.h"
+#include "internal/nelem.h"
 
 #ifndef OPENSSL_NO_DH
 #include <openssl/dh.h>

--- a/crypto/bn/bn_srp.c
+++ b/crypto/bn/bn_srp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2014-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,7 +8,7 @@
  */
 
 #include "bn_lcl.h"
-#include "e_os.h"
+#include "internal/nelem.h"
 
 #ifndef OPENSSL_NO_SRP
 

--- a/crypto/cast/cast_lcl.h
+++ b/crypto/cast/cast_lcl.h
@@ -1,13 +1,11 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
-
-#include "e_os.h"
 
 #ifdef OPENSSL_SYS_WIN32
 # include <stdlib.h>

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -9,11 +9,11 @@
 
 /* Part of the code in here was originally in conf.c, which is now removed */
 
+#include "e_os.h"
 #include <stdlib.h>
 #include <string.h>
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
-#include "e_os.h"
 
 static void value_free_hash(const CONF_VALUE *a, LHASH_OF(CONF_VALUE) *conf);
 static void value_free_stack_doall(CONF_VALUE *a);

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <stdio.h>
 #include <string.h>
 #include "internal/conf.h"
@@ -15,7 +16,6 @@
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
 #include <openssl/lhash.h>
-#include "e_os.h"
 
 static CONF_METHOD *default_CONF_method = NULL;
 

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -7,11 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/cryptlib.h"
 #include <stdio.h>
 #include <ctype.h>
 #include <openssl/crypto.h>
-#include "internal/cryptlib.h"
-#include "e_os.h"
 #include "internal/conf.h"
 #include "internal/dso.h"
 #include <openssl/x509.h>

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -11,6 +11,7 @@
 #include <ctype.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include "internal/conf.h"
 #include "internal/dso.h"
 #include <openssl/x509.h>

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1998-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1998-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -9,6 +9,7 @@
  */
 
 #include "internal/cryptlib_int.h"
+#include "e_os.h"
 #include <openssl/safestack.h>
 
 #if     defined(__i386)   || defined(__i386__)   || defined(_M_IX86) || \

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -8,8 +8,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/cryptlib_int.h"
 #include "e_os.h"
+#include "internal/cryptlib_int.h"
 #include <openssl/safestack.h>
 
 #if     defined(__i386)   || defined(__i386__)   || defined(_M_IX86) || \

--- a/crypto/des/cfb64ede.c
+++ b/crypto/des/cfb64ede.c
@@ -8,7 +8,6 @@
  */
 
 #include "des_locl.h"
-#include "e_os.h"
 
 /*
  * The input and output encrypted as though 64bit cfb mode is being used.

--- a/crypto/des/cfb64ede.c
+++ b/crypto/des/cfb64ede.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/bn.h>
 #include "dh_locl.h"
 #include <openssl/engine.h>

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/bn.h>
 #include "dh_locl.h"
 #include <openssl/engine.h>

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include "internal/cryptlib_int.h"
+#include "e_os.h"
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 # ifdef __CYGWIN__

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/cryptlib_int.h"
 #include "e_os.h"
+#include "internal/cryptlib_int.h"
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 # ifdef __CYGWIN__

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/bn.h>
 #include "dsa_locl.h"
 #include <openssl/asn1.h>

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/bn.h>
 #include "dsa_locl.h"
 #include <openssl/asn1.h>

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -8,7 +8,7 @@
  */
 
 #include "dso_locl.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 
 static DSO_METHOD *default_DSO_meth = NULL;
 

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include "dso_locl.h"
+#include "e_os.h"
 
 static DSO_METHOD *default_DSO_meth = NULL;
 

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include "dso_locl.h"
 
 #if defined(DSO_WIN32)

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -12,6 +12,7 @@
 #include <openssl/err.h>
 #include <openssl/asn1t.h>
 #include <openssl/objects.h>
+#include "internal/nelem.h"
 
 int EC_GROUP_get_basis_type(const EC_GROUP *group)
 {

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -13,7 +13,7 @@
 #include <openssl/err.h>
 #include <openssl/obj_mac.h>
 #include <openssl/opensslconf.h>
-#include "e_os.h"
+#include "internal/nelem.h"
 
 typedef struct {
     int field_type,             /* either NID_X9_62_prime_field or

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -11,7 +11,7 @@
 #include "internal/cryptlib.h"
 #include <string.h>
 #include "ec_lcl.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/err.h>
 #include <openssl/engine.h>
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2002-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -11,6 +11,7 @@
 #include "internal/cryptlib.h"
 #include <string.h>
 #include "ec_lcl.h"
+#include "e_os.h"
 #include <openssl/err.h>
 #include <openssl/engine.h>
 

--- a/crypto/ec/ec_lcl.h
+++ b/crypto/ec/ec_lcl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -14,8 +14,6 @@
 #include <openssl/ec.h>
 #include <openssl/bn.h>
 #include "internal/refcount.h"
-
-#include "e_os.h"
 
 #if defined(__SUNPRO_C)
 # if __SUNPRO_C >= 0x520

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -14,7 +14,7 @@
 #include "internal/cryptlib.h"
 #include "internal/bn_int.h"
 #include "ec_lcl.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 
 /*
  * This file implements the wNAF-based interleaving multi-exponentiation method

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -14,6 +14,7 @@
 #include "internal/cryptlib.h"
 #include "internal/bn_int.h"
 #include "ec_lcl.h"
+#include "e_os.h"
 
 /*
  * This file implements the wNAF-based interleaving multi-exponentiation method

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -21,7 +21,7 @@
 #include "internal/cryptlib.h"
 #include "internal/bn_int.h"
 #include "ec_lcl.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 
 #if BN_BITS2 != 64
 # define TOBN(hi,lo)    lo,hi

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2014-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2014, Intel Corporation. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -21,6 +21,7 @@
 #include "internal/cryptlib.h"
 #include "internal/bn_int.h"
 #include "ec_lcl.h"
+#include "e_os.h"
 
 #if BN_BITS2 != 64
 # define TOBN(hi,lo)    lo,hi

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -14,8 +15,6 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <assert.h>
-
-#include "e_os.h"
 
 #include <openssl/evp.h>
 #include <openssl/err.h>

--- a/crypto/engine/eng_init.c
+++ b/crypto/engine/eng_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include "eng_int.h"
+#include "e_os.h"
 
 /*
  * Initialise a engine type for use (or up its functional reference count if

--- a/crypto/engine/eng_init.c
+++ b/crypto/engine/eng_init.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "eng_int.h"
 #include "e_os.h"
+#include "eng_int.h"
 
 /*
  * Initialise a engine type for use (or up its functional reference count if

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "eng_int.h"
 #include "e_os.h"
+#include "eng_int.h"
 #include <openssl/rand.h>
 #include "internal/refcount.h"
 

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -8,6 +8,7 @@
  */
 
 #include "eng_int.h"
+#include "e_os.h"
 #include <openssl/rand.h>
 #include "internal/refcount.h"
 

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include "eng_int.h"
+#include "e_os.h"
 #include <openssl/evp.h>
 #include "internal/asn1_int.h"
 

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "eng_int.h"
 #include "e_os.h"
+#include "eng_int.h"
 #include <openssl/evp.h>
 #include "internal/asn1_int.h"
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/bn.h>
 #include <openssl/err.h>
 #include <openssl/objects.h>

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/bn.h>
 #include <openssl/err.h>
 #include <openssl/objects.h>

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -25,6 +25,7 @@
 #include "internal/thread_once.h"
 #include "internal/dso.h"
 #include "internal/store.h"
+#include "e_os.h"
 
 static int stopped = 0;
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include "internal/cryptlib_int.h"
 #include <openssl/err.h>
 #include "internal/rand_int.h"
@@ -25,7 +26,6 @@
 #include "internal/thread_once.h"
 #include "internal/dso.h"
 #include "internal/store.h"
-#include "e_os.h"
 
 static int stopped = 0;
 

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <openssl/crypto.h>
+#include "e_os.h"
 #include "internal/cryptlib.h"
 #include "internal/cryptlib_int.h"
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -7,13 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
+#include "internal/cryptlib.h"
+#include "internal/cryptlib_int.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <openssl/crypto.h>
-#include "e_os.h"
-#include "internal/cryptlib.h"
-#include "internal/cryptlib_int.h"
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE
 # include <execinfo.h>
 #endif

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -15,8 +15,8 @@
  * For details on that implementation, see below (look for uppercase
  * "SECURE HEAP IMPLEMENTATION").
  */
-#include <openssl/crypto.h>
 #include "e_os.h"
+#include <openssl/crypto.h>
 
 #include <string.h>
 

--- a/crypto/o_dir.c
+++ b/crypto/o_dir.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <errno.h>
 #include "e_os.h"
+#include <errno.h>
 
 /*
  * The routines really come from the Levitte Programming, so to make life

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <limits.h>
 #include "e_os.h"
+#include <limits.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 #include "internal/o_str.h"

--- a/crypto/objects/obj_xref.c
+++ b/crypto/objects/obj_xref.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,7 @@
 
 #include <openssl/objects.h>
 #include "obj_xref.h"
-#include "e_os.h"
+#include "internal/nelem.h"
 
 static STACK_OF(nid_triple) *sig_app, *sigx_app;
 

--- a/crypto/ocsp/ocsp_ht.c
+++ b/crypto/ocsp/ocsp_ht.c
@@ -7,11 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "internal/ctype.h"
 #include <string.h>
-#include "e_os.h"
 #include <openssl/asn1.h>
 #include <openssl/ocsp.h>
 #include <openssl/err.h>

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -7,9 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdio.h>
-
 #include "e_os.h"
+#include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/rand.h>
 #include "rand_lcl.h"

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/lhash.h>
 #include "internal/bn_int.h"
 #include <openssl/engine.h>

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/lhash.h>
 #include "internal/bn_int.h"
 #include <openssl/engine.h>

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <string.h>
 #include <sys/stat.h>
 #include <assert.h>
@@ -28,8 +29,6 @@
 #include "internal/cryptlib.h"
 #include "internal/store_int.h"
 #include "store_locl.h"
-
-#include "e_os.h"
 
 #ifdef _WIN32
 # define stat    _stat

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -7,11 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <stdlib.h>
 #include <string.h>
-
-#include "e_os.h"
-
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/store.h>

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,6 +10,7 @@
 #include <openssl/e_os2.h>
 #include <openssl/err.h>
 #include <openssl/ui.h>
+#include "e_os.h"
 
 #ifndef OPENSSL_NO_UI_CONSOLE
 /*

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -7,10 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <openssl/e_os2.h>
 #include <openssl/err.h>
 #include <openssl/ui.h>
-#include "e_os.h"
 
 #ifndef OPENSSL_NO_UI_CONSOLE
 /*

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -7,13 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
+#include "internal/cryptlib.h"
 #include <stdio.h>
 #include <time.h>
 #include <errno.h>
 #include <sys/types.h>
-
-#include "internal/cryptlib.h"
-#include "e_os.h"
 
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 
 #include "internal/cryptlib.h"
+#include "e_os.h"
 
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/lhash.h>
 #include <openssl/x509.h>
 #include "internal/x509_int.h"

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/lhash.h>
 #include <openssl/x509.h>
 #include "internal/x509_int.h"

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509cset.c
+++ b/crypto/x509/x509cset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509cset.c
+++ b/crypto/x509/x509cset.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include "internal/refcount.h"
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -8,9 +8,8 @@
  */
 
 #include "e_os.h"               /* for strncasecmp */
-#include <stdio.h>
 #include "internal/cryptlib.h"
-#include "e_os.h"
+#include <stdio.h>
 #include "internal/asn1_int.h"
 #include <openssl/asn1t.h>
 #include <openssl/conf.h>

--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2003-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,8 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"               /* for strncasecmp */
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include "internal/asn1_int.h"
 #include <openssl/asn1t.h>
 #include <openssl/conf.h>

--- a/crypto/x509v3/v3_tlsf.c
+++ b/crypto/x509v3/v3_tlsf.c
@@ -7,9 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdio.h>
-#include "internal/cryptlib.h"
 #include "e_os.h"
+#include "internal/cryptlib.h"
+#include <stdio.h>
 #include "internal/o_str.h"
 #include <openssl/asn1t.h>
 #include <openssl/conf.h>

--- a/crypto/x509v3/v3_tlsf.c
+++ b/crypto/x509v3/v3_tlsf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include "internal/o_str.h"
 #include <openssl/asn1t.h>
 #include <openssl/conf.h>

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -9,10 +9,10 @@
 
 /* X509 v3 extension utilities */
 
+#include "e_os.h"
+#include "internal/cryptlib.h"
 #include <stdio.h>
 #include "internal/ctype.h"
-#include "internal/cryptlib.h"
-#include "e_os.h"
 #include <openssl/conf.h>
 #include <openssl/x509v3.h>
 #include "internal/x509_int.h"

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include "internal/ctype.h"
 #include "internal/cryptlib.h"
+#include "e_os.h"
 #include <openssl/conf.h>
 #include <openssl/x509v3.h>
 #include "internal/x509_int.h"

--- a/e_os.h
+++ b/e_os.h
@@ -53,8 +53,6 @@ extern "C" {
                              * stand for in ILP32 and LP64 */
 # endif
 
-# define OPENSSL_CONF        "openssl.cnf"
-
 # ifndef DEVRANDOM
 /*
  * set this to a comma-separated list of 'random' device files to try out. By

--- a/e_os.h
+++ b/e_os.h
@@ -10,6 +10,7 @@
 #ifndef HEADER_E_OS_H
 # define HEADER_E_OS_H
 
+# include <limits.h>
 # include <openssl/opensslconf.h>
 
 # include <openssl/e_os2.h>

--- a/e_os.h
+++ b/e_os.h
@@ -25,13 +25,6 @@
 extern "C" {
 #endif
 
-/* Used to checking reference counts, most while doing perl5 stuff :-) */
-# if defined(OPENSSL_NO_STDIO)
-#  if defined(REF_PRINT)
-#   error "REF_PRINT requires stdio"
-#  endif
-# endif
-
 /*
  * Format specifier for printing size_t. Original conundrum was to
  * get it working with -Wformat [-Werror], which can be considered
@@ -57,19 +50,6 @@ extern "C" {
 # else
 #  define OSSLzu  "lu"      /* To see that is works recall what does L
                              * stand for in ILP32 and LP64 */
-# endif
-
-# if !defined(NDEBUG) && !defined(OPENSSL_NO_STDIO)
-#  define REF_ASSERT_ISNT(test) \
-    (void)((test) ? (OPENSSL_die("refcount error", __FILE__, __LINE__), 1) : 0)
-# else
-#  define REF_ASSERT_ISNT(i)
-# endif
-# ifdef REF_PRINT
-#  define REF_PRINT_COUNT(a, b) \
-        fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
-# else
-#  define REF_PRINT_COUNT(a, b)
 # endif
 
 # define OPENSSL_CONF        "openssl.cnf"

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -55,6 +55,8 @@ typedef struct app_mem_info_st APP_INFO;
 typedef struct mem_st MEM;
 DEFINE_LHASH_OF(MEM);
 
+# define OPENSSL_CONF             "openssl.cnf"
+
 # ifndef OPENSSL_SYS_VMS
 #  define X509_CERT_AREA          OPENSSLDIR
 #  define X509_CERT_DIR           OPENSSLDIR "/certs"

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -13,8 +13,6 @@
 # include <stdlib.h>
 # include <string.h>
 
-# include "e_os.h"
-
 # ifdef OPENSSL_USE_APPLINK
 #  undef BIO_FLAGS_UPLINK
 #  define BIO_FLAGS_UPLINK 0x8000
@@ -25,6 +23,7 @@
 # include <openssl/buffer.h>
 # include <openssl/bio.h>
 # include <openssl/err.h>
+# include "internal/nelem.h"
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -9,6 +9,13 @@
 #ifndef HEADER_INTERNAL_REFCOUNT_H
 # define HEADER_INTERNAL_REFCOUNT_H
 
+/* Used to checking reference counts, most while doing perl5 stuff :-) */
+# if defined(OPENSSL_NO_STDIO)
+#  if defined(REF_PRINT)
+#   error "REF_PRINT requires stdio"
+#  endif
+# endif
+
 # if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
      && !defined(__STDC_NO_ATOMICS__)
 # include <stdatomic.h>
@@ -64,4 +71,19 @@ typedef int CRYPTO_REF_COUNT;
 # define CRYPTO_DOWN_REF(val, ret, lock) CRYPTO_atomic_add(val, -1, ret, lock)
 
 # endif
+
+# if !defined(NDEBUG) && !defined(OPENSSL_NO_STDIO)
+#  define REF_ASSERT_ISNT(test) \
+    (void)((test) ? (OPENSSL_die("refcount error", __FILE__, __LINE__), 1) : 0)
+# else
+#  define REF_ASSERT_ISNT(i)
+# endif
+
+# ifdef REF_PRINT
+#  define REF_PRINT_COUNT(a, b) \
+        fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
+# else
+#  define REF_PRINT_COUNT(a, b)
+# endif
+
 #endif

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2005-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,6 +11,7 @@
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 #include "ssl_locl.h"
+#include "e_os.h"
 
 #if defined(OPENSSL_SYS_VXWORKS)
 # include <sys/times.h>

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -7,11 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <stdio.h>
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 #include "ssl_locl.h"
-#include "e_os.h"
 
 #if defined(OPENSSL_SYS_VXWORKS)
 # include <sys/times.h>

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -11,7 +11,9 @@
 
 #include <stdio.h>
 #include <openssl/objects.h>
+#include "internal/nelem.h"
 #include "ssl_locl.h"
+#include "e_os.h"
 #include <openssl/md5.h>
 #include <openssl/dh.h>
 #include <openssl/rand.h>

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -13,7 +13,6 @@
 #include <openssl/objects.h>
 #include "internal/nelem.h"
 #include "ssl_locl.h"
-#include "e_os.h"
 #include <openssl/md5.h>
 #include <openssl/dh.h>
 #include <openssl/rand.h>

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -11,7 +11,11 @@
 #include <stdio.h>
 #include <sys/types.h>
 
-#include "e_os.h"
+#include "internal/nelem.h"
+#ifndef NO_SYS_TYPES_H
+# include <sys/types.h>
+#endif
+
 #include "internal/o_dir.h"
 #include <openssl/lhash.h>
 #include <openssl/bio.h>
@@ -20,6 +24,7 @@
 #include <openssl/dh.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
+#include "e_os.h"
 #include "ssl_locl.h"
 #include "ssl_cert_table.h"
 #include "internal/thread_once.h"

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -24,7 +24,7 @@
 #include <openssl/dh.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
-#include "e_os.h"
+#include "internal/refcount.h"
 #include "ssl_locl.h"
 #include "ssl_cert_table.h"
 #include "internal/thread_once.h"

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -12,10 +12,6 @@
 #include <sys/types.h>
 
 #include "internal/nelem.h"
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-
 #include "internal/o_dir.h"
 #include <openssl/lhash.h>
 #include <openssl/bio.h>

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -15,6 +15,7 @@
 #include <openssl/comp.h>
 #include <openssl/engine.h>
 #include <openssl/crypto.h>
+#include "internal/nelem.h"
 #include "ssl_locl.h"
 #include "internal/thread_once.h"
 #include "internal/cryptlib.h"

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2012-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,6 +12,7 @@
 #include <openssl/conf.h>
 #include <openssl/objects.h>
 #include <openssl/dh.h>
+#include "internal/nelem.h"
 
 /*
  * structure holding name tables. This is used for permitted elements in lists

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -10,7 +10,6 @@
  */
 
 #include <stdio.h>
-#include "e_os.h"
 #include "ssl_locl.h"
 #include <openssl/objects.h>
 #include <openssl/lhash.h>
@@ -23,6 +22,7 @@
 #include <openssl/ct.h>
 #include "internal/cryptlib.h"
 #include "internal/rand.h"
+#include "internal/refcount.h"
 
 const char SSL_version_str[] = OPENSSL_VERSION_TEXT;
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  * Copyright 2005 Nokia. All rights reserved.
  *
@@ -10,6 +10,7 @@
  */
 
 #include <stdio.h>
+#include "e_os.h"
 #include "ssl_locl.h"
 #include <openssl/objects.h>
 #include <openssl/lhash.h>

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -16,7 +16,7 @@
 # include <string.h>
 # include <errno.h>
 
-# include "e_os.h"
+# include "e_os.h"              /* struct timeval for Windows */
 # if defined(__unix) || defined(__unix__)
 #  include <sys/time.h>         /* struct timeval for DTLS */
 # endif

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -11,12 +11,12 @@
 
 #ifndef HEADER_SSL_LOCL_H
 # define HEADER_SSL_LOCL_H
+# include "e_os.h"              /* struct timeval for Windows */
 # include <stdlib.h>
 # include <time.h>
 # include <string.h>
 # include <errno.h>
 
-# include "e_os.h"              /* struct timeval for Windows */
 # if defined(__unix) || defined(__unix__)
 #  include <sys/time.h>         /* struct timeval for DTLS */
 # endif

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright 2005 Nokia. All rights reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -12,6 +12,7 @@
 #include <openssl/lhash.h>
 #include <openssl/rand.h>
 #include <openssl/engine.h>
+#include "e_os.h"
 #include "ssl_locl.h"
 #include "statem/statem_locl.h"
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -12,7 +12,7 @@
 #include <openssl/lhash.h>
 #include <openssl/rand.h>
 #include <openssl/engine.h>
-#include "e_os.h"
+#include "internal/refcount.h"
 #include "ssl_locl.h"
 #include "statem/statem_locl.h"
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include "internal/nelem.h"
 #include "../ssl_locl.h"
 #include "statem_locl.h"
 

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/rand.h>
 #include "e_os.h"
+#include <openssl/rand.h>
 #include "../ssl_locl.h"
 #include "statem_locl.h"
 

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "e_os.h"
+#include "internal/cryptlib.h"
 #include <openssl/rand.h>
 #include "../ssl_locl.h"
 #include "statem_locl.h"

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/rand.h>
+#include "e_os.h"
 #include "../ssl_locl.h"
 #include "statem_locl.h"
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,6 +17,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/dh.h>
 #include <openssl/bn.h>
+#include "internal/nelem.h"
 #include "ssl_locl.h"
 #include <openssl/ct.h>
 

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -19,6 +19,7 @@
 #include "testutil.h"
 
 #include "internal/nelem.h"
+
 #ifndef OPENSSL_NO_BF
 # include <openssl/blowfish.h>
 

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -6,6 +6,7 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+#include "../e_os.h"
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
@@ -13,7 +14,6 @@
 #include <ctype.h>
 
 #include "internal/nelem.h"
-#include "../e_os.h"
 #include "internal/numbers.h"
 #include <openssl/bn.h>
 #include <openssl/crypto.h>

--- a/test/ctype_internal_test.c
+++ b/test/ctype_internal_test.c
@@ -9,7 +9,7 @@
 
 #include "testutil.h"
 #include "internal/ctype.h"
-#include "../e_os.h"
+#include "internal/nelem.h"
 #include <ctype.h>
 #include <stdio.h>
 

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -7,13 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "../e_os.h"
 #include <string.h>
 
 #include <openssl/e_os2.h>
 #include <openssl/crypto.h>
 
 #include "internal/nelem.h"
-#include "../e_os.h"
 #include "ssl_test_ctx.h"
 #include "testutil.h"
 

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -9,6 +9,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
+
 /* Or gethostname won't be declared properly on Linux and GNU platforms. */
 #ifndef _BSD_SOURCE
 # define _BSD_SOURCE 1
@@ -26,8 +28,6 @@
 #include <time.h>
 
 #include "internal/nelem.h"
-
-#include "e_os.h"
 
 #ifdef OPENSSL_SYS_VMS
 /*

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -22,6 +22,7 @@
 # pragma names restore
 #endif
 
+#include "internal/nelem.h"
 #include "testutil.h"
 
 /*

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -7,9 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "../e_os.h"
 #include <string.h>
 #include "internal/nelem.h"
-#include "../e_os.h"
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "testutil.h"


### PR DESCRIPTION
Removed e_os.h from all bar two headers (apps/apps.h and crypto/bio/bio_lcl.h).
Added e_os.h into the files that need it now.
Directly reference internal/nelem.h when required.

- [x] tests are added or updated

Refer: #4174
