### PR TITLE
Put thread-fork-init inside a run-once guard

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -169,11 +169,20 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+# ifdef OPENSSL_SYS_UNIX
+static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
+
+static void fork_once_func(void)
+{
+    pthread_atfork(OPENSSL_fork_prepare,
+                   OPENSSL_fork_parent, OPENSSL_fork_child);
+}
+# endif
+
 int openssl_init_fork_handlers(void)
 {
 # ifdef OPENSSL_SYS_UNIX
-    if (pthread_atfork(OPENSSL_fork_prepare,
-                       OPENSSL_fork_parent, OPENSSL_fork_child) == 0)
+    if (pthread_once(&fork_once_control, fork_once_func) == 0)
         return 1;
 # endif
     return 0;


### PR DESCRIPTION
Thanks to Christian Heimes for pointing this out.

(posted on openssl-dev)