### PR TITLE
Set FIPS thread id callback.

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -469,11 +469,18 @@ void CRYPTO_THREADID_set_pointer(CRYPTO_THREADID *id, void *ptr)
     }
 }
 
+#ifdef OPENSSL_FIPS
+extern int FIPS_crypto_threadid_set_callback(void (*func) (CRYPTO_THREADID *));
+#endif
+
 int CRYPTO_THREADID_set_callback(void (*func) (CRYPTO_THREADID *))
 {
     if (threadid_callback)
         return 0;
     threadid_callback = func;
+#ifdef OPENSSL_FIPS
+    FIPS_crypto_threadid_set_callback(func);
+#endif
     return 1;
 }
 


### PR DESCRIPTION
Fixes #4180

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This sets the FIPS thread id callback for FIPS capable versions of OpenSSL. 