### PR TITLE
Support 'TLSv1.3' in cipher rule string

### DIFF
--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -274,16 +274,18 @@ All these cipher suites have been removed in OpenSSL 1.1.0.
 Cipher suites using ECDSA authentication, i.e. the certificates carry ECDSA
 keys.
 
-=item B<TLSv1.2>, B<TLSv1.0>, B<SSLv3>
+=item B<TLSv1.3>, B<TLSv1.2>, B<TLSv1.0>, B<SSLv3>
 
-Lists cipher suites which are only supported in at least TLS v1.2, TLS v1.0 or
-SSL v3.0 respectively.
+Lists cipher suites which are only supported in at least TLS v1.3, TLS v1.2,
+TLS v1.0 or SSL v3.0 respectively.
 Note: there are no cipher suites specific to TLS v1.1.
 Since this is only the minimum version, if, for example, TLSv1.0 is negotiated
 then both TLSv1.0 and SSLv3.0 cipher suites are available.
 
 Note: these cipher strings B<do not> change the negotiated version of SSL or
 TLS, they only affect the list of available cipher suites.
+
+Note: There is also a B<TLSv1> option available. It's an alias of B<TLSv1.0>.
 
 =item B<AES128>, B<AES256>, B<AES>
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -142,6 +142,7 @@ extern "C" {
 # define SSL_TXT_TLSV1           "TLSv1"
 # define SSL_TXT_TLSV1_1         "TLSv1.1"
 # define SSL_TXT_TLSV1_2         "TLSv1.2"
+# define SSL_TXT_TLSV1_3         "TLSv1.3"
 
 # define SSL_TXT_ALL             "ALL"
 

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -283,6 +283,7 @@ static const SSL_CIPHER cipher_aliases[] = {
     {0, SSL_TXT_TLSV1, NULL, 0, 0, 0, 0, 0, TLS1_VERSION},
     {0, "TLSv1.0", NULL, 0, 0, 0, 0, 0, TLS1_VERSION},
     {0, SSL_TXT_TLSV1_2, NULL, 0, 0, 0, 0, 0, TLS1_2_VERSION},
+    {0, SSL_TXT_TLSV1_3, NULL, 0, 0, 0, 0, 0, TLS1_3_VERSION},
 
     /* strength classes */
     {0, SSL_TXT_LOW, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, SSL_LOW},


### PR DESCRIPTION
This obtains a set of ciphers only available for TLS v1.3.

I just found it seems no way to do this when trying to set up a TLS v1.3 web server...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
