### PR TITLE
Generalize PKEY KDF controls and setters

### DIFF
--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -71,18 +71,19 @@ static int pkey_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     HKDF_PKEY_CTX *kctx = ctx->data;
 
     switch (type) {
-    case EVP_PKEY_CTRL_HKDF_MD:
+    case EVP_PKEY_CTRL_KDF_MD:
+    case EVP_PKEY_CTRL_OLD_HKDF_MD:
         if (p2 == NULL)
             return 0;
 
         kctx->md = p2;
         return 1;
 
-    case EVP_PKEY_CTRL_HKDF_MODE:
+    case EVP_PKEY_CTRL_KDF_MODE:
         kctx->mode = p1;
         return 1;
 
-    case EVP_PKEY_CTRL_HKDF_SALT:
+    case EVP_PKEY_CTRL_KDF_SALT:
         if (p1 == 0 || p2 == NULL)
             return 1;
 
@@ -99,7 +100,7 @@ static int pkey_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         kctx->salt_len = p1;
         return 1;
 
-    case EVP_PKEY_CTRL_HKDF_KEY:
+    case EVP_PKEY_CTRL_KDF_KEY:
         if (p1 < 0)
             return 0;
 
@@ -113,7 +114,7 @@ static int pkey_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         kctx->key_len  = p1;
         return 1;
 
-    case EVP_PKEY_CTRL_HKDF_INFO:
+    case EVP_PKEY_CTRL_KDF_INFO:
         if (p1 == 0 || p2 == NULL)
             return 1;
 
@@ -150,25 +151,25 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
 
     if (strcmp(type, "md") == 0)
         return EVP_PKEY_CTX_md(ctx, EVP_PKEY_OP_DERIVE,
-                               EVP_PKEY_CTRL_HKDF_MD, value);
+                               EVP_PKEY_CTRL_PBE_MD, value);
 
     if (strcmp(type, "salt") == 0)
-        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_KDF_SALT, value);
 
     if (strcmp(type, "hexsalt") == 0)
-        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_KDF_SALT, value);
 
     if (strcmp(type, "key") == 0)
-        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_KEY, value);
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_KDF_KEY, value);
 
     if (strcmp(type, "hexkey") == 0)
-        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_KEY, value);
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_KDF_KEY, value);
 
     if (strcmp(type, "info") == 0)
-        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_KDF_INFO, value);
 
     if (strcmp(type, "hexinfo") == 0)
-        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_KDF_INFO, value);
 
     KDFerr(KDF_F_PKEY_HKDF_CTRL_STR, KDF_R_UNKNOWN_PARAMETER_TYPE);
     return -2;

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -151,7 +151,7 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
 
     if (strcmp(type, "md") == 0)
         return EVP_PKEY_CTX_md(ctx, EVP_PKEY_OP_DERIVE,
-                               EVP_PKEY_CTRL_PBE_MD, value);
+                               EVP_PKEY_CTRL_KDF_MD, value);
 
     if (strcmp(type, "salt") == 0)
         return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_KDF_SALT, value);

--- a/crypto/kdf/scrypt.c
+++ b/crypto/kdf/scrypt.c
@@ -120,10 +120,10 @@ static int pkey_scrypt_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     uint64_t u64_value;
 
     switch (type) {
-    case EVP_PKEY_CTRL_PASS:
+    case EVP_PKEY_CTRL_KDF_PASS:
         return pkey_scrypt_set_membuf(&kctx->pass, &kctx->pass_len, p2, p1);
 
-    case EVP_PKEY_CTRL_SCRYPT_SALT:
+    case EVP_PKEY_CTRL_KDF_SALT:
         return pkey_scrypt_set_membuf(&kctx->salt, &kctx->salt_len, p2, p1);
 
     case EVP_PKEY_CTRL_SCRYPT_N:
@@ -181,16 +181,16 @@ static int pkey_scrypt_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     }
 
     if (strcmp(type, "pass") == 0)
-        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_PASS, value);
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_KDF_PASS, value);
 
     if (strcmp(type, "hexpass") == 0)
-        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_PASS, value);
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_KDF_PASS, value);
 
     if (strcmp(type, "salt") == 0)
-        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_SCRYPT_SALT, value);
+        return EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_KDF_SALT, value);
 
     if (strcmp(type, "hexsalt") == 0)
-        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_SCRYPT_SALT, value);
+        return EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_KDF_SALT, value);
 
     if (strcmp(type, "N") == 0)
         return pkey_scrypt_ctrl_uint64(ctx, EVP_PKEY_CTRL_SCRYPT_N, value);

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -57,7 +57,7 @@ static int pkey_tls1_prf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 {
     TLS1_PRF_PKEY_CTX *kctx = ctx->data;
     switch (type) {
-    case EVP_PKEY_CTRL_TLS_MD:
+    case EVP_PKEY_CTRL_KDF_MD:
         kctx->md = p2;
         return 1;
 

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -15,29 +15,61 @@
 extern "C" {
 #endif
 
-# define EVP_PKEY_CTRL_TLS_MD                   (EVP_PKEY_ALG_CTRL)
+/* Generic controls */
+# define EVP_PKEY_CTRL_KDF_MD                   (EVP_PKEY_ALG_CTRL)
+# define EVP_PKEY_CTRL_KDF_PASS                 (EVP_PKEY_ALG_CTRL + 8)
+# define EVP_PKEY_CTRL_KDF_SALT                 (EVP_PKEY_ALG_CTRL + 4)
+# define EVP_PKEY_CTRL_KDF_KEY                  (EVP_PKEY_ALG_CTRL + 5)
+# define EVP_PKEY_CTRL_KDF_INFO                 (EVP_PKEY_ALG_CTRL + 6)
+# define EVP_PKEY_CTRL_KDF_MODE                 (EVP_PKEY_ALG_CTRL + 7)
+
+/* KDF-specific controls */
 # define EVP_PKEY_CTRL_TLS_SECRET               (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_TLS_SEED                 (EVP_PKEY_ALG_CTRL + 2)
-# define EVP_PKEY_CTRL_HKDF_MD                  (EVP_PKEY_ALG_CTRL + 3)
-# define EVP_PKEY_CTRL_HKDF_SALT                (EVP_PKEY_ALG_CTRL + 4)
-# define EVP_PKEY_CTRL_HKDF_KEY                 (EVP_PKEY_ALG_CTRL + 5)
-# define EVP_PKEY_CTRL_HKDF_INFO                (EVP_PKEY_ALG_CTRL + 6)
-# define EVP_PKEY_CTRL_HKDF_MODE                (EVP_PKEY_ALG_CTRL + 7)
-# define EVP_PKEY_CTRL_PASS                     (EVP_PKEY_ALG_CTRL + 8)
-# define EVP_PKEY_CTRL_SCRYPT_SALT              (EVP_PKEY_ALG_CTRL + 9)
 # define EVP_PKEY_CTRL_SCRYPT_N                 (EVP_PKEY_ALG_CTRL + 10)
 # define EVP_PKEY_CTRL_SCRYPT_R                 (EVP_PKEY_ALG_CTRL + 11)
 # define EVP_PKEY_CTRL_SCRYPT_P                 (EVP_PKEY_ALG_CTRL + 12)
 # define EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES      (EVP_PKEY_ALG_CTRL + 13)
 
+/* Aliases for backwards-compatibility */
+# define EVP_PKEY_CTRL_TLS_MD                   EVP_PKEY_CTRL_KDF_MD
+# define EVP_PKEY_CTRL_HKDF_MD                  EVP_PKEY_CTRL_KDF_MD
+# define EVP_PKEY_CTRL_HKDF_SALT                EVP_PKEY_CTRL_KDF_SALT
+# define EVP_PKEY_CTRL_HKDF_KEY                 EVP_PKEY_CTRL_KDF_KEY
+# define EVP_PKEY_CTRL_HKDF_INFO                EVP_PKEY_CTRL_KDF_INFO
+# define EVP_PKEY_CTRL_HKDF_MODE                EVP_PKEY_CTRL_KDF_MODE
+
 # define EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND 0
 # define EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY       1
 # define EVP_PKEY_HKDEF_MODE_EXPAND_ONLY        2
 
-# define EVP_PKEY_CTX_set_tls1_prf_md(pctx, md) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                              EVP_PKEY_CTRL_TLS_MD, 0, (void *)(md))
 
+/* Generic setters */
+# define EVP_PKEY_CTX_set_pbe_md(pctx, md) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_KDF_MD, 0, (void *)(md))
+
+# define EVP_PKEY_CTX_set1_pbe_pass(pctx, pass, passlen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_KDF_PASS, passlen, (void *)(pass))
+
+# define EVP_PKEY_CTX_set1_pbe_salt(pctx, salt, saltlen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_KDF_SALT, saltlen, (void *)(salt))
+
+# define EVP_PKEY_CTX_set1_pbe_key(pctx, key, keylen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_KDF_KEY, keylen, (void *)(key))
+
+# define EVP_PKEY_CTX_add1_pbe_info(pctx, info, infolen) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_KDF_INFO, infolen, (void *)(info))
+
+# define EVP_PKEY_CTX_set_pbe_mode(pctx, mode) \
+            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
+                              EVP_PKEY_CTRL_KDF_MODE, mode, NULL)
+
+/* KDF-specific setters */
 # define EVP_PKEY_CTX_set1_tls1_prf_secret(pctx, sec, seclen) \
             EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
                               EVP_PKEY_CTRL_TLS_SECRET, seclen, (void *)(sec))
@@ -46,49 +78,41 @@ extern "C" {
             EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
                               EVP_PKEY_CTRL_TLS_SEED, seedlen, (void *)(seed))
 
-# define EVP_PKEY_CTX_set_hkdf_md(pctx, md) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                              EVP_PKEY_CTRL_HKDF_MD, 0, (void *)(md))
-
-# define EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt, saltlen) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                              EVP_PKEY_CTRL_HKDF_SALT, saltlen, (void *)(salt))
-
-# define EVP_PKEY_CTX_set1_hkdf_key(pctx, key, keylen) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                              EVP_PKEY_CTRL_HKDF_KEY, keylen, (void *)(key))
-
-# define EVP_PKEY_CTX_add1_hkdf_info(pctx, info, infolen) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                              EVP_PKEY_CTRL_HKDF_INFO, infolen, (void *)(info))
-
-# define EVP_PKEY_CTX_hkdf_mode(pctx, mode) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                              EVP_PKEY_CTRL_HKDF_MODE, mode, NULL)
-
-# define EVP_PKEY_CTX_set1_pbe_pass(pctx, pass, passlen) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                            EVP_PKEY_CTRL_PASS, passlen, (void *)(pass))
-
-# define EVP_PKEY_CTX_set1_scrypt_salt(pctx, salt, saltlen) \
-            EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                            EVP_PKEY_CTRL_SCRYPT_SALT, saltlen, (void *)(salt))
-
 # define EVP_PKEY_CTX_set_scrypt_N(pctx, n) \
             EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                            EVP_PKEY_CTRL_SCRYPT_N, n)
+                                     EVP_PKEY_CTRL_SCRYPT_N, n)
 
 # define EVP_PKEY_CTX_set_scrypt_r(pctx, r) \
             EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                            EVP_PKEY_CTRL_SCRYPT_R, r)
+                                     EVP_PKEY_CTRL_SCRYPT_R, r)
 
 # define EVP_PKEY_CTX_set_scrypt_p(pctx, p) \
             EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                            EVP_PKEY_CTRL_SCRYPT_P, p)
+                                     EVP_PKEY_CTRL_SCRYPT_P, p)
 
 # define EVP_PKEY_CTX_set_scrypt_maxmem_bytes(pctx, maxmem_bytes) \
             EVP_PKEY_CTX_ctrl_uint64(pctx, -1, EVP_PKEY_OP_DERIVE, \
-                            EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES, maxmem_bytes)
+                                     EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES, \
+                                     maxmem_bytes)
+
+/* Setters for backwards-compatibility */
+# define EVP_PKEY_CTX_set_tls1_prf_md(pctx, md) \
+            EVP_PKEY_CTX_set_pbe_md(pctx, md)
+
+# define EVP_PKEY_CTX_set_hkdf_md(pctx, md) \
+            EVP_PKEY_CTX_set_pbe_md(pctx, md)
+
+# define EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt, saltlen) \
+            EVP_PKEY_CTX_set1_pbe_salt(pctx, salt, saltlen)
+
+# define EVP_PKEY_CTX_set1_hkdf_key(pctx, key, keylen) \
+            EVP_PKEY_CTX_set1_pbe_key(pctx, key, keylen)
+
+# define EVP_PKEY_CTX_add1_hkdf_info(pctx, info, infolen) \
+            EVP_PKEY_CTX_add1_pbe_info(pctx, info, infolen)
+
+# define EVP_PKEY_CTX_hkdf_mode(pctx, mode) \
+            EVP_PKEY_CTX_set_pbe_mode(pctx, mode)
 
 int ERR_load_KDF_strings(void);
 

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -31,7 +31,7 @@ extern "C" {
 # define EVP_PKEY_CTRL_SCRYPT_P                 (EVP_PKEY_ALG_CTRL + 11)
 # define EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES      (EVP_PKEY_ALG_CTRL + 12)
 
-/* Deprecated, previous used control values */
+/* Deprecated, previously used control values */
 # define EVP_PKEY_CTRL_OLD_HKDF_MD              (EVP_PKEY_ALG_CTRL + 3)
 
 /* Aliases for backwards-compatibility */

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -26,10 +26,13 @@ extern "C" {
 /* KDF-specific controls */
 # define EVP_PKEY_CTRL_TLS_SECRET               (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_TLS_SEED                 (EVP_PKEY_ALG_CTRL + 2)
-# define EVP_PKEY_CTRL_SCRYPT_N                 (EVP_PKEY_ALG_CTRL + 10)
-# define EVP_PKEY_CTRL_SCRYPT_R                 (EVP_PKEY_ALG_CTRL + 11)
-# define EVP_PKEY_CTRL_SCRYPT_P                 (EVP_PKEY_ALG_CTRL + 12)
-# define EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES      (EVP_PKEY_ALG_CTRL + 13)
+# define EVP_PKEY_CTRL_SCRYPT_N                 (EVP_PKEY_ALG_CTRL + 9)
+# define EVP_PKEY_CTRL_SCRYPT_R                 (EVP_PKEY_ALG_CTRL + 10)
+# define EVP_PKEY_CTRL_SCRYPT_P                 (EVP_PKEY_ALG_CTRL + 11)
+# define EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES      (EVP_PKEY_ALG_CTRL + 12)
+
+/* Deprecated, previous used control values */
+# define EVP_PKEY_CTRL_OLD_HKDF_MD              (EVP_PKEY_ALG_CTRL + 3)
 
 /* Aliases for backwards-compatibility */
 # define EVP_PKEY_CTRL_TLS_MD                   EVP_PKEY_CTRL_KDF_MD


### PR DESCRIPTION
Instead of repeating similar code for each new KDF (e.g.,
EVP_PKEY_CTX_set1_hkdf_salt, EVP_PKEY_CTX_set1_scrypt_salt, ...), change
all of those to the more generic EVP_PKEY_CTX_set_pbe_xyz variants. For
TLS1-PRF and HKDF, introduce backwards-compatible enums and setters.
Since scrypt is fairly new (and there's no official release with scrypt
PKEY KDF yet), do not introduce backwards-compatible setters for it. For
HKDF, add a test that uses only generic setter macros. As for the CTRL
values, use the nomenclature EVP_PKEY_CTRL_KDF_* suggested by @levitte
to avoid a conflict with the already present EVP_PKEY_CTRL_MD.

Since this PR touches the KDF setters in a non-trivial way, I think it'd be great if we could merge https://github.com/openssl/openssl/pull/4196 first so I'd then update this PR in order to test both the backwards-compatible TLS1-PRF setters as well as the generic ones which are newly introduced (just as with HKDF).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ]  documentation is added or updated
- [X] tests are added or updated
