### PR TITLE
Mv socket gunk

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -17,8 +17,6 @@ NON_EMPTY_TRANSLATION_UNIT
                                  * on OpenVMS */
 # endif
 
-# define USE_SOCKETS
-
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -21,7 +21,6 @@
 # include <openssl/engine.h>
 #endif
 #include <openssl/err.h>
-#define USE_SOCKETS /* needed for the _O_BINARY defs in the MS world */
 #include "s_apps.h"
 /* Needed to get the other O_xxx flags. */
 #ifdef OPENSSL_SYS_VMS

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -11,9 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h> /* for memcpy() and strcmp() */
-#define USE_SOCKETS
 #include "apps.h"
-#undef USE_SOCKETS
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/x509.h>

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include "e_os.h"
 #include <openssl/e_os2.h>
 
 #ifndef OPENSSL_NO_SOCK
@@ -28,7 +29,6 @@
 typedef unsigned int u_int;
 #endif
 
-#define USE_SOCKETS
 #include "apps.h"
 #include <openssl/x509.h>
 #include <openssl/ssl.h>
@@ -46,6 +46,7 @@ typedef unsigned int u_int;
 #endif
 #include "s_apps.h"
 #include "timeouts.h"
+#include "internal/sockets.h"
 
 #if defined(__has_feature)
 # if __has_feature(memory_sanitizer)

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -37,7 +37,6 @@ typedef unsigned int u_int;
 
 #include <openssl/lhash.h>
 #include <openssl/bn.h>
-#define USE_SOCKETS
 #include "apps.h"
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -59,6 +58,7 @@ typedef unsigned int u_int;
 #ifdef CHARSET_EBCDIC
 #include <openssl/ebcdic.h>
 #endif
+#include "internal/sockets.h"
 
 static int not_resumable_sess_cb(SSL *s, int is_forward_secure);
 static int sv_body(int s, int stype, int prot, unsigned char *context);

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -28,10 +28,9 @@ typedef unsigned int u_int;
 
 #ifndef OPENSSL_NO_SOCK
 
-# define USE_SOCKETS
 # include "apps.h"
-# undef USE_SOCKETS
 # include "s_apps.h"
+# include "internal/sockets.h"
 
 # include <openssl/bio.h>
 # include <openssl/err.h>

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -17,7 +17,6 @@
 
 #ifndef OPENSSL_NO_SOCK
 
-#define USE_SOCKETS
 #include "apps.h"
 #include <openssl/x509.h>
 #include <openssl/ssl.h>

--- a/crypto/bio/bio_lcl.h
+++ b/crypto/bio/bio_lcl.h
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define USE_SOCKETS
 #include "e_os.h"
+#include "internal/sockets.h"
 #include "internal/refcount.h"
 
 /* BEGIN BIO_ADDRINFO/BIO_ADDR stuff. */

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <errno.h>
-#define USE_SOCKETS
 #include "bio_lcl.h"
 #include "internal/cryptlib.h"
 

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -187,7 +187,7 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
         ret = malloc(num);
     }
 #else
-    osslargused(file); osslargused(line);
+    (void)(file); (void)(line);
     ret = malloc(num);
 #endif
 
@@ -228,7 +228,7 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
         return ret;
     }
 #else
-    osslargused(file); osslargused(line);
+    (void)(file); (void)(line);
 #endif
     return realloc(str, num);
 

--- a/e_os.h
+++ b/e_os.h
@@ -72,7 +72,6 @@ extern "C" {
 #  define REF_PRINT_COUNT(a, b)
 # endif
 
-# define osslargused(x)      (void)x
 # define OPENSSL_CONF        "openssl.cnf"
 
 # ifndef DEVRANDOM
@@ -97,6 +96,9 @@ extern "C" {
 #  define NO_SYSLOG
 # endif
 
+# define get_last_sys_error()    errno
+# define clear_sys_error()       errno=0
+
 /********************************************************************
  The Microsoft section
  ********************************************************************/
@@ -110,56 +112,16 @@ extern "C" {
 #  define MSDOS
 # endif
 
-# if (defined(MSDOS) || defined(OPENSSL_SYS_UEFI)) && !defined(GETPID_IS_MEANINGLESS)
-#  define GETPID_IS_MEANINGLESS
-# endif
-
 # ifdef WIN32
 #  define NO_SYS_UN_H
+#  undef get_last_sys_error
+#  undef clear_sys_error
 #  define get_last_sys_error()    GetLastError()
 #  define clear_sys_error()       SetLastError(0)
 #  if !defined(WINNT)
 #   define WIN_CONSOLE_BUG
 #  endif
 # else
-#  define get_last_sys_error()    errno
-#  define clear_sys_error()       errno=0
-# endif
-
-# if defined(WINDOWS)
-#  define get_last_socket_error() WSAGetLastError()
-#  define clear_socket_error()    WSASetLastError(0)
-#  define readsocket(s,b,n)       recv((s),(b),(n),0)
-#  define writesocket(s,b,n)      send((s),(b),(n),0)
-# elif defined(__DJGPP__)
-#  define WATT32
-#  define WATT32_NO_OLDIES
-#  define get_last_socket_error() errno
-#  define clear_socket_error()    errno=0
-#  define closesocket(s)          close_s(s)
-#  define readsocket(s,b,n)       read_s(s,b,n)
-#  define writesocket(s,b,n)      send(s,b,n,0)
-# elif defined(OPENSSL_SYS_VMS)
-#  define get_last_socket_error() errno
-#  define clear_socket_error()    errno=0
-#  define ioctlsocket(a,b,c)      ioctl(a,b,c)
-#  define closesocket(s)          close(s)
-#  define readsocket(s,b,n)       recv((s),(b),(n),0)
-#  define writesocket(s,b,n)      send((s),(b),(n),0)
-# elif defined(OPENSSL_SYS_VXWORKS)
-#  define get_last_socket_error() errno
-#  define clear_socket_error()    errno=0
-#  define ioctlsocket(a,b,c)          ioctl((a),(b),(int)(c))
-#  define closesocket(s)              close(s)
-#  define readsocket(s,b,n)           read((s),(b),(n))
-#  define writesocket(s,b,n)          write((s),(char *)(b),(n))
-# else
-#  define get_last_socket_error() errno
-#  define clear_socket_error()    errno=0
-#  define ioctlsocket(a,b,c)      ioctl(a,b,c)
-#  define closesocket(s)          close(s)
-#  define readsocket(s,b,n)       read((s),(b),(n))
-#  define writesocket(s,b,n)      write((s),(b),(n))
 # endif
 
 # if (defined(WINDOWS) || defined(MSDOS))
@@ -285,9 +247,6 @@ extern FILE *_imp___iob;
 
 #  define EXIT(n) exit(n)
 #  define LIST_SEPARATOR_CHAR ';'
-#  ifndef X_OK
-#   define X_OK        0
-#  endif
 #  ifndef W_OK
 #   define W_OK        2
 #  endif
@@ -378,124 +337,6 @@ extern FILE *_imp___iob;
 
 # endif
 
-/*************/
-
-# ifdef USE_SOCKETS
-#  ifdef OPENSSL_NO_SOCK
-#  elif defined(WINDOWS) || defined(MSDOS)
-      /* windows world */
-#   if !defined(__DJGPP__)
-#    if defined(_WIN32_WCE) && _WIN32_WCE<410
-#     define getservbyname _masked_declaration_getservbyname
-#    endif
-#    if !defined(IPPROTO_IP)
-         /* winsock[2].h was included already? */
-#     include <winsock.h>
-#    endif
-#    ifdef getservbyname
-#     undef getservbyname
-         /* this is used to be wcecompat/include/winsock_extras.h */
-struct servent *PASCAL getservbyname(const char *, const char *);
-#    endif
-
-#    ifdef _WIN64
-/*
- * Even though sizeof(SOCKET) is 8, it's safe to cast it to int, because
- * the value constitutes an index in per-process table of limited size
- * and not a real pointer. And we also depend on fact that all processors
- * Windows run on happen to be two's-complement, which allows to
- * interchange INVALID_SOCKET and -1.
- */
-#     define socket(d,t,p)   ((int)socket(d,t,p))
-#     define accept(s,f,l)   ((int)accept(s,f,l))
-#    endif
-#   else
-#   endif
-
-#  else
-
-#   ifndef NO_SYS_PARAM_H
-#    include <sys/param.h>
-#   endif
-#   ifdef OPENSSL_SYS_VXWORKS
-#    include <time.h>
-#   endif
-
-#   include <netdb.h>
-#   if defined(OPENSSL_SYS_VMS_NODECC)
-#    include <socket.h>
-#    include <in.h>
-#    include <inet.h>
-#   else
-#    include <sys/socket.h>
-#    ifndef NO_SYS_UN_H
-#     ifdef OPENSSL_SYS_VXWORKS
-#      include <streams/un.h>
-#     else
-#      include <sys/un.h>
-#     endif
-#     ifndef UNIX_PATH_MAX
-#      define UNIX_PATH_MAX sizeof(((struct sockaddr_un *)NULL)->sun_path)
-#     endif
-#    endif
-#    ifdef FILIO_H
-#     include <sys/filio.h> /* FIONBIO in some SVR4, e.g. unixware, solaris */
-#    endif
-#    include <netinet/in.h>
-#    include <arpa/inet.h>
-#    include <netinet/tcp.h>
-#   endif
-
-#   ifdef OPENSSL_SYS_AIX
-#    include <sys/select.h>
-#   endif
-
-#   ifdef __QNX__
-#    include <sys/select.h>
-#   endif
-
-#   ifndef VMS
-#    include <sys/ioctl.h>
-#   else
-        /* ioctl is only in VMS > 7.0 and when socketshr is not used */
-#    if !defined(TCPIP_TYPE_SOCKETSHR) && defined(__VMS_VER) && (__VMS_VER > 70000000)
-#     include <sys/ioctl.h>
-#    endif
-#   endif
-
-#   ifdef VMS
-#    include <unixio.h>
-#    if defined(TCPIP_TYPE_SOCKETSHR)
-#     include <socketshr.h>
-#    endif
-#   endif
-
-#   ifndef INVALID_SOCKET
-#    define INVALID_SOCKET      (-1)
-#   endif                       /* INVALID_SOCKET */
-#  endif
-
-/*
- * Some IPv6 implementations are broken, disable them in known bad versions.
- */
-#  if !defined(OPENSSL_USE_IPV6)
-#   if defined(AF_INET6) && !defined(NETWARE_CLIB)
-#    define OPENSSL_USE_IPV6 1
-#   else
-#    define OPENSSL_USE_IPV6 0
-#   endif
-#  endif
-
-# endif
-
-# ifndef OPENSSL_EXIT
-#  if defined(MONOLITH) && !defined(OPENSSL_C)
-#   define OPENSSL_EXIT(n) return(n)
-#  else
-#   define OPENSSL_EXIT(n) do { EXIT(n); return(n); } while(0)
-#  endif
-# endif
-
 /***********************************************/
 
 # if defined(OPENSSL_SYS_WINDOWS)
@@ -520,16 +361,12 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  include <ioLib.h>
 #  include <tickLib.h>
 #  include <sysLib.h>
-
-#  define TTY_STRUCT int
-
-#  define sleep(a) taskDelay((a) * sysClkRateGet())
-
 #  include <vxWorks.h>
 #  include <sockLib.h>
 #  include <taskLib.h>
 
-#  define getpid taskIdSelf
+#  define TTY_STRUCT int
+#  define sleep(a) taskDelay((a) * sysClkRateGet())
 
 /*
  * NOTE: these are implemented by helpers in database app! if the database is

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+
+#ifndef HEADER_OPENSSL_SOCKETS
+
+# ifdef OPENSSL_NO_SOCK
+
+# elif defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
+#  if !defined(__DJGPP__)
+#   if defined(_WIN32_WCE) && _WIN32_WCE<410
+#    define getservbyname _masked_declaration_getservbyname
+#   endif
+#   if !defined(IPPROTO_IP)
+     /* winsock[2].h was included already? */
+#    include <winsock.h>
+#   endif
+#   ifdef getservbyname
+     /* this is used to be wcecompat/include/winsock_extras.h */
+#    undef getservbyname
+struct servent *PASCAL getservbyname(const char *, const char *);
+#   endif
+
+#   ifdef _WIN64
+/*
+ * Even though sizeof(SOCKET) is 8, it's safe to cast it to int, because
+ * the value constitutes an index in per-process table of limited size
+ * and not a real pointer. And we also depend on fact that all processors
+ * Windows run on happen to be two's-complement, which allows to
+ * interchange INVALID_SOCKET and -1.
+ */
+#    define socket(d,t,p)   ((int)socket(d,t,p))
+#    define accept(s,f,l)   ((int)accept(s,f,l))
+#   endif
+#  else
+#  endif
+
+# else
+
+#  ifndef NO_SYS_PARAM_H
+#   include <sys/param.h>
+#  endif
+#  ifdef OPENSSL_SYS_VXWORKS
+#   include <time.h>
+#  endif
+
+#  include <netdb.h>
+#  if defined(OPENSSL_SYS_VMS_NODECC)
+#   include <socket.h>
+#   include <in.h>
+#   include <inet.h>
+#  else
+#   include <sys/socket.h>
+#   ifndef NO_SYS_UN_H
+#    ifdef OPENSSL_SYS_VXWORKS
+#     include <streams/un.h>
+#    else
+#     include <sys/un.h>
+#    endif
+#    ifndef UNIX_PATH_MAX
+#     define UNIX_PATH_MAX sizeof(((struct sockaddr_un *)NULL)->sun_path)
+#    endif
+#   endif
+#   ifdef FILIO_H
+#    include <sys/filio.h> /* FIONBIO in some SVR4, e.g. unixware, solaris */
+#   endif
+#   include <netinet/in.h>
+#   include <arpa/inet.h>
+#   include <netinet/tcp.h>
+#  endif
+
+#  ifdef OPENSSL_SYS_AIX
+#   include <sys/select.h>
+#  endif
+
+#  ifdef __QNX__
+#   include <sys/select.h>
+#  endif
+
+#  ifndef VMS
+#   include <sys/ioctl.h>
+#  else
+#   if !defined(TCPIP_TYPE_SOCKETSHR) && defined(__VMS_VER) && (__VMS_VER > 70000000)
+     /* ioctl is only in VMS > 7.0 and when socketshr is not used */
+#    include <sys/ioctl.h>
+#   endif
+#   include <unixio.h>
+#   if defined(TCPIP_TYPE_SOCKETSHR)
+#    include <socketshr.h>
+#   endif
+#  endif
+
+#  ifndef INVALID_SOCKET
+#   define INVALID_SOCKET      (-1)
+#  endif
+# endif
+
+/*
+ * Some IPv6 implementations are broken, disable them in known bad versions.
+ */
+# if !defined(OPENSSL_USE_IPV6)
+#  if defined(AF_INET6) && !defined(NETWARE_CLIB)
+#   define OPENSSL_USE_IPV6 1
+#  else
+#   define OPENSSL_USE_IPV6 0
+#  endif
+# endif
+
+#endif
+
+#define get_last_socket_error() errno
+#define clear_socket_error()    errno=0
+
+#if defined(OPENSSL_SYS_WINDOWS)
+# undef get_last_socket_error
+# undef clear_socket_error
+# define get_last_socket_error() WSAGetLastError()
+# define clear_socket_error()    WSASetLastError(0)
+# define readsocket(s,b,n)       recv((s),(b),(n),0)
+# define writesocket(s,b,n)      send((s),(b),(n),0)
+#elif defined(__DJGPP__)
+# define WATT32
+# define WATT32_NO_OLDIES
+# define closesocket(s)          close_s(s)
+# define readsocket(s,b,n)       read_s(s,b,n)
+# define writesocket(s,b,n)      send(s,b,n,0)
+#elif defined(OPENSSL_SYS_VMS)
+# define ioctlsocket(a,b,c)      ioctl(a,b,c)
+# define closesocket(s)          close(s)
+# define readsocket(s,b,n)       recv((s),(b),(n),0)
+# define writesocket(s,b,n)      send((s),(b),(n),0)
+#elif defined(OPENSSL_SYS_VXWORKS)
+# define ioctlsocket(a,b,c)          ioctl((a),(b),(int)(c))
+# define closesocket(s)              close(s)
+# define readsocket(s,b,n)           read((s),(b),(n))
+# define writesocket(s,b,n)          write((s),(char *)(b),(n))
+#else
+# define ioctlsocket(a,b,c)      ioctl(a,b,c)
+# define closesocket(s)          close(s)
+# define readsocket(s,b,n)       read((s),(b),(n))
+# define writesocket(s,b,n)      write((s),(b),(n))
+#endif
+

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -8,7 +8,6 @@
  */
 
 #include <stdio.h>
-#define USE_SOCKETS
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 #include "ssl_locl.h"

--- a/ssl/d1_msg.c
+++ b/ssl/d1_msg.c
@@ -7,7 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define USE_SOCKETS
 #include "ssl_locl.h"
 
 int dtls1_write_app_data_bytes(SSL *s, int type, const void *buf_, size_t len,

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <errno.h>
-#define USE_SOCKETS
 #include "../ssl_locl.h"
 #include <openssl/evp.h>
 #include <openssl/buffer.h>

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <limits.h>
 #include <errno.h>
-#define USE_SOCKETS
 #include "../ssl_locl.h"
 #include <openssl/evp.h>
 #include <openssl/buffer.h>

--- a/ssl/s3_msg.c
+++ b/ssl/s3_msg.c
@@ -7,7 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define USE_SOCKETS
 #include "ssl_locl.h"
 
 int ssl3_do_change_cipher_spec(SSL *s)

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -16,11 +16,7 @@
 #include <openssl/srp.h>
 #endif
 
-#ifndef OPENSSL_NO_SOCK
-# define USE_SOCKETS
-# include "internal/nelem.h"
-#endif
-
+#include "internal/nelem.h"
 #include "handshake_helper.h"
 #include "testutil.h"
 

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -27,7 +27,6 @@
 
 #include "internal/nelem.h"
 
-#define USE_SOCKETS
 #include "e_os.h"
 
 #ifdef OPENSSL_SYS_VMS


### PR DESCRIPTION
This moves almost all socket-related stuff out of e_os.h into a new header file which is only needed by *four* source files.

Look at crypto/bio/bio_lcl.h, not sure whether we use brackets or quotes.
