### PR TITLE
Avoid a self-assignment.

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -251,9 +251,9 @@ int ossl_fromascii(int c)
 int ossl_ctype_check(int c, unsigned int mask)
 {
     const int max = sizeof(ctype_char_map) / sizeof(*ctype_char_map);
+    const int a = ossl_toascii(c);
 
-    c = ossl_toascii(c);
-    return c >= 0 && c < max && (ctype_char_map[c] & mask) != 0;
+    return a >= 0 && a < max && (ctype_char_map[a] & mask) != 0;
 }
 
 #if defined(CHARSET_EBCDIC) && !defined(CHARSET_EBCDIC_TEST)


### PR DESCRIPTION
Clang is generating a warning over an assignment of a variable to itself.
This occurs on an ASCII based machine where the convert to ASCII macro doesn't
do anything.  The fix is to introduce a temporary variable.

```
clang-3.6  -I. -Icrypto/include -Iinclude -DDSO_DLFCN -DHAVE_DLFCN_H -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DRC4_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPADLOCK_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/local/openssl/ssl\"" -DENGINESDIR="\"/usr/local/openssl/lib/engines-1.1\"" -Wall -O0 -g -pthread -m64 -DL_ENDIAN  -DDEBUG_UNUSED -Wswitch -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wtype-limits -Wundef -Werror -Qunused-arguments -Wswitch-default -Wno-parentheses-equality -Wno-language-extension-token -Wno-extended-offsetof -Wconditional-uninitialized -Wincompatible-pointer-types-discards-qualifiers -Wmissing-variable-declarations -rdynamic -Qunused-arguments -fPIC -DOPENSSL_USE_NODELETE -MMD -MF crypto/ctype.d.tmp -MT crypto/ctype.o -c -o crypto/ctype.o crypto/ctype.c
crypto/ctype.c:255:7: error: explicitly assigning value of variable of type 'int' to itself [-Werror,-Wself-assign]
    c = (c);
    ~ ^  ~
1 error generated.
```
