### PR TITLE
Fix ctype checks

### DIFF
--- a/test/ctype_internal_test.c
+++ b/test/ctype_internal_test.c
@@ -70,7 +70,7 @@ static int test_ctype_tolower(int n)
 
 int setup_tests(void)
 {
-    ADD_ALL_TESTS(test_ctype_chars, 256);
+    ADD_ALL_TESTS(test_ctype_chars, 128);
     ADD_ALL_TESTS(test_ctype_toupper, OSSL_NELEM(case_change));
     ADD_ALL_TESTS(test_ctype_tolower, OSSL_NELEM(case_change));
     return 1;

--- a/test/ctype_internal_test.c
+++ b/test/ctype_internal_test.c
@@ -42,11 +42,6 @@ static int test_ctype_chars(int n)
            && TEST_int_eq(isxdigit(n) != 0, ossl_isxdigit(n) != 0);
 }
 
-static int test_ctype_negative(int n)
-{
-    return test_ctype_chars(-n);
-}
-
 static struct {
     int u;
     int l;
@@ -58,10 +53,7 @@ static struct {
     { '%', '%' },
     { '~', '~' },
     {   0,   0 },
-    { EOF, EOF },
-    { 333, 333 },
-    { -333, -333 },
-    { -128, -128 }
+    { EOF, EOF }
 };
 
 static int test_ctype_toupper(int n)
@@ -79,7 +71,6 @@ static int test_ctype_tolower(int n)
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_ctype_chars, 256);
-    ADD_ALL_TESTS(test_ctype_negative, 128);
     ADD_ALL_TESTS(test_ctype_toupper, OSSL_NELEM(case_change));
     ADD_ALL_TESTS(test_ctype_tolower, OSSL_NELEM(case_change));
     return 1;


### PR DESCRIPTION
Our comparisons of ctype functions vs our internal replacements go a bit beyond what's possible.  The results for negative values and values above 255 are undefined.  Furthermore, values above 127 can give locale dependent results that differ from what our internal functions return.