### PR TITLE
Remove useless macros in apps/speed.c

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -10,7 +10,6 @@
 
 #undef SECONDS
 #define SECONDS                 3
-#define PRIME_SECONDS   10
 #define RSA_SECONDS             10
 #define DSA_SECONDS             10
 #define ECDSA_SECONDS   10
@@ -118,7 +117,6 @@
 
 #define ALGOR_NUM       30
 #define SIZE_NUM        6
-#define PRIME_NUM       3
 #define RSA_NUM         7
 #define DSA_NUM         3
 


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

