### PR TITLE
Move randomness to allocated buffer

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -64,14 +64,12 @@ int RAND_DRBG_set(RAND_DRBG *drbg, int nid, unsigned int flags)
 RAND_DRBG *RAND_DRBG_new(int type, unsigned int flags, RAND_DRBG *parent)
 {
     RAND_DRBG *drbg = OPENSSL_zalloc(sizeof(*drbg));
-    unsigned char *ucp = OPENSSL_zalloc(RANDOMNESS_NEEDED);
 
-    if (drbg == NULL || ucp == NULL) {
+    if (drbg == NULL) {
         RANDerr(RAND_F_RAND_DRBG_NEW, ERR_R_MALLOC_FAILURE);
         goto err;
     }
     drbg->size = RANDOMNESS_NEEDED;
-    drbg->randomness = ucp;
     drbg->fork_count = rand_fork_count;
     drbg->parent = parent;
     if (RAND_DRBG_set(drbg, type, flags) < 0)
@@ -96,7 +94,6 @@ RAND_DRBG *RAND_DRBG_new(int type, unsigned int flags, RAND_DRBG *parent)
     return drbg;
 
 err:
-    OPENSSL_free(ucp);
     OPENSSL_free(drbg);
     return NULL;
 }
@@ -116,8 +113,6 @@ void RAND_DRBG_free(RAND_DRBG *drbg)
         return;
 
     ctr_uninstantiate(drbg);
-    OPENSSL_cleanse(drbg->randomness, drbg->size);
-    OPENSSL_free(drbg->randomness);
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_DRBG, drbg, &drbg->ex_data);
     OPENSSL_clear_free(drbg, sizeof(*drbg));
 }


### PR DESCRIPTION
Don't keep it in the DRBG object, just allocate/free as needed.
