### PR TITLE
Correct GCM docs.

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -442,9 +442,8 @@ either be 16 or the value previously set via EVP_CTRL_OCB_SET_TAGLEN.
  EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, taglen, tag);
 
 Sets the expected tag to B<taglen> bytes from B<tag>. This call is only legal
-when decrypting data and must be made B<before> any data is processed (e.g.
-before any EVP_DecryptUpdate() call). For OCB mode the taglen must
-either be 16 or the value previously set via EVP_CTRL_AEAD_SET_TAG.
+when decrypting data. For OCB mode the taglen must either be 16 or the value
+previously set via EVP_CTRL_AEAD_SET_TAG.
 
 In OCB mode calling this with B<tag> set to NULL sets the tag length. The tag
 length can only be set before specifying an IV. If not called a default tag


### PR DESCRIPTION
Fix GCM documentation: the tag does not have to be supplied before
decrypting any data any more.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

Also applies to 1.1.0 and 1.0.2 docs.