### PR TITLE
Do not lookup zero-length session ID

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -491,7 +491,8 @@ int ssl_get_prev_session(SSL *s, CLIENTHELLO_MSG *hello, int *al)
             goto err;
         case TICKET_NONE:
         case TICKET_EMPTY:
-            try_session_cache = 1;
+            if (hello->session_id_len > 0)
+                try_session_cache = 1;
             break;
         case TICKET_NO_DECRYPT:
         case TICKET_SUCCESS:


### PR DESCRIPTION
A condition was removed by commit 1053a6e2281d; presumably it was an
unintended change. Restore the previous behavior so the get_session_cb
won't be called with zero-length session ID.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x].
- [ ] documentation is added or updated -->
- [x] tests are added or updated
