### PR TITLE
Change OPENSSL_INIT_ATFORK to _NOFORK

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -578,7 +578,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             && !RUN_ONCE(&add_all_digests, ossl_init_add_all_digests))
         return 0;
 
-    if ((opts & OPENSSL_INIT_ATFORK)
+    if ((opts & OPENSSL_INIT_NOFORK) == 0
             && !openssl_init_fork_handlers())
         return 0;
 

--- a/doc/man3/OPENSSL_fork_prepare.pod
+++ b/doc/man3/OPENSSL_fork_prepare.pod
@@ -30,7 +30,7 @@ such as Linux that have both functions will normally not need to call these
 functions as the OpenSSL library will do so automatically.
 
 L<OPENSSL_init_crypto(3)> will register these functions with the appropriate
-hander, when the B<OPENSSL_INIT_ATFORK> flag is used. For other
+hander, unless the B<OPENSSL_INIT_NOFORK> flag is used. For other
 applications, these functions can be called directly. They should be used
 according to the calling sequence described by the pthreads_atfork(3)
 documentation, which is summarized here.  OPENSSL_fork_prepare() should

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -150,9 +150,9 @@ With this option the library will automatically load and initialise all the
 built in engines listed above with the exception of the openssl and dasync
 engines. This not a default option.
 
-=item OPENSSL_INIT_ATFORK
+=item OPENSSL_INIT_NOFORK
 
-With this option the library will register its fork handlers.
+With this option the library will not register its fork handlers.
 See OPENSSL_fork_prepare(3) for details.
 
 =back

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -376,7 +376,7 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 # define OPENSSL_INIT_ENGINE_PADLOCK         0x00004000L
 # define OPENSSL_INIT_ENGINE_AFALG           0x00008000L
 # define OPENSSL_INIT_reserved_internal      0x00010000L
-# define OPENSSL_INIT_ATFORK                 0x00020000L
+# define OPENSSL_INIT_NOFORK                 0x00020000L
 /* OPENSSL_INIT flag range 0xfff00000 reserved for OPENSSL_init_ssl() */
 /* Max OPENSSL_INIT flag value is 0x80000000 */
 


### PR DESCRIPTION
Safer by default.
