### PR TITLE
Check for EOF in ASCII conversions.

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <stdio.h>
 #include "internal/ctype.h"
 #include "openssl/ebcdic.h"
 
@@ -225,7 +226,7 @@ static const unsigned short ctype_char_map[128] = {
 #ifdef CHARSET_EBCDIC
 int ossl_toascii(int c)
 {
-    if (c < -128 || c > 256)
+    if (c < -128 || c > 256 || c == EOF)
         return c;
     /*
      * Adjust negatively signed characters.
@@ -240,7 +241,7 @@ int ossl_toascii(int c)
 
 int ossl_fromascii(int c)
 {
-    if (c < -128 || c > 256)
+    if (c < -128 || c > 256 || c == EOF)
         return c;
     if (c < 0)
         c += 256;

--- a/test/ctype_internal_test.c
+++ b/test/ctype_internal_test.c
@@ -68,10 +68,16 @@ static int test_ctype_tolower(int n)
            && TEST_int_eq(ossl_tolower(case_change[n].l), case_change[n].l);
 }
 
+static int test_ctype_eof(void)
+{
+    return test_ctype_chars(EOF);
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_ctype_chars, 128);
     ADD_ALL_TESTS(test_ctype_toupper, OSSL_NELEM(case_change));
     ADD_ALL_TESTS(test_ctype_tolower, OSSL_NELEM(case_change));
+    ADD_TEST(test_ctype_eof);
     return 1;
 }


### PR DESCRIPTION
The C standard defines EOF as:

    ... an integer constant expression, with type int and a negative value...

This means a conforming implemenetation could define this as a one of the
printable characters.  This won't be a problem for ASCII.

A specific test case has been added for EOF.

- [x] tests are added or updated