### PR TITLE
Fix enable-sctp

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -16,6 +16,7 @@
 #include <openssl/srp.h>
 #endif
 
+#include "internal/sockets.h"
 #include "internal/nelem.h"
 #include "handshake_helper.h"
 #include "testutil.h"


### PR DESCRIPTION
Commit b99fe5f4 broke SCTP. This fixes it again.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

