### PR TITLE
Pass TARFILE="$(TARFILE)" NAME="$(NAME)" to tar target

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -709,7 +709,7 @@ tar:
 	cd $(SRCDIR); ls -l $(TARFILE).gz
 
 dist:
-	@$(MAKE) PREPARE_CMD='$(PERL) ./Configure dist' tar
+	@$(MAKE) PREPARE_CMD='$(PERL) ./Configure dist' TARFILE="$(TARFILE)" NAME="$(NAME)" tar
 
 # Helper targets #####################################################
 


### PR DESCRIPTION
Pass TARFILE="$(TARFILE)" NAME="$(NAME)" to tar target otherwise on Solaris it creates a tarfile of different name and looks for a different tar file name later.
