### PR TITLE
Fix no-stdio

### DIFF
--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -8,6 +8,7 @@
  */
 
 #include "eng_int.h"
+#include <stdio.h>
 
 /*
  * When querying a ENGINE-specific control command's 'description', this


### PR DESCRIPTION
The `no-stdio` build is broken. The problem is that `crypto/engine/eng_ctrl.c` uses sprintf which is defined in `stdio.h`. This got me wondering - what does `no-stdio` actually mean? `INSTALL` says this:

    no-stdio
                   Don't use any C "stdio" features. Only libcrypto and libssl
                   can be built in this way. Using this option will suppress
                   building the command line applications. Additionally since
                   the OpenSSL tests also use the command line applications the
                   tests will also be skipped.

Which seems to imply just including `stdio.h` is not allowed in this build. But it doesn't seem to be the case. We include `stdio.h` in lots of places and it isn't guarded in any way, and we also use unguarded sprintf in various places. I *think* `no-stdio` is more related to the use of the `FILE` type.

Based on this reasoning I think the correct solution in this case is to include `stdio.h` in the relevant file to fix the `no-stdio` build!!
