### PR TITLE
NO_SYS_TYPES_H isn't defined anywhere, stop using it as a guard

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -18,9 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+#include <sys/types.h>
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>
 # include <fcntl.h>

--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -9,12 +9,9 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <sys/types.h>
 
 #include "internal/cryptlib.h"
-
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
 
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -9,12 +9,9 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <sys/types.h>
 
 #include "internal/cryptlib.h"
-
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
 
 #include <openssl/bn.h>
 #include <openssl/evp.h>

--- a/crypto/asn1/a_verify.c
+++ b/crypto/asn1/a_verify.c
@@ -9,12 +9,9 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <sys/types.h>
 
 #include "internal/cryptlib.h"
-
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
 
 #include <openssl/bn.h>
 #include <openssl/x509.h>

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -21,9 +21,7 @@
 #ifdef OPENSSL_SYS_VMS
 # include <unixio.h>
 #endif
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+#include <sys/types.h>
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>
 # include <fcntl.h>

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -10,12 +10,10 @@
 #include <stdio.h>
 #include <time.h>
 #include <errno.h>
+#include <sys/types.h>
 
 #include "internal/cryptlib.h"
 
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>
 #endif

--- a/e_os.h
+++ b/e_os.h
@@ -323,9 +323,7 @@ extern FILE *_imp___iob;
 #   else
 #    include <unistd.h>
 #   endif
-#   ifndef NO_SYS_TYPES_H
-#    include <sys/types.h>
-#   endif
+#   include <sys/types.h>
 #   ifdef OPENSSL_SYS_WIN32_CYGWIN
 #    include <io.h>
 #    include <fcntl.h>

--- a/include/openssl/buffer.h
+++ b/include/openssl/buffer.h
@@ -22,10 +22,7 @@ extern "C" {
 #endif
 
 # include <stddef.h>
-
-# if !defined(NO_SYS_TYPES_H)
-#  include <sys/types.h>
-# endif
+# include <sys/types.h>
 
 /*
  * These names are outdated as of OpenSSL 1.1; a future release

--- a/include/openssl/seed.h
+++ b/include/openssl/seed.h
@@ -52,9 +52,7 @@ extern "C" {
 #  endif
 # endif
 
-# if !defined(NO_SYS_TYPES_H)
-#  include <sys/types.h>
-# endif
+# include <sys/types.h>
 
 # define SEED_BLOCK_SIZE 16
 # define SEED_KEY_LENGTH 16

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -9,12 +9,9 @@
  */
 
 #include <stdio.h>
+#include <sys/types.h>
 
 #include "e_os.h"
-#ifndef NO_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-
 #include "internal/o_dir.h"
 #include <openssl/lhash.h>
 #include <openssl/bio.h>


### PR DESCRIPTION
This is a vestige from pre-1.1.0 OpenSSL
