### PR TITLE
MSC_VERS <= 1200 isn't supported; remove dead code

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Some macro definitions to support VS6 have been removed.  Visual
+     Studio 6 has not worked since 1.1.0
+     [Rich Salz]
+
   *) Add ERR_clear_last_mark(), to allow callers to clear the last mark
      without clearing the errors.
      [Richard Levitte]

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -399,9 +399,6 @@ static SHA_LONG64 __fastcall __pull64be(const void *x)
 }
 #    endif
 #    define PULL64(x) __pull64be(&(x))
-#    if _MSC_VER<=1200
-#     pragma inline_depth(0)
-#    endif
 #   endif
 #  endif
 # endif

--- a/e_os.h
+++ b/e_os.h
@@ -196,14 +196,6 @@ static __inline unsigned int _strlen31(const char *str)
 }
 #   endif
 #   include <malloc.h>
-#   if defined(_MSC_VER) && _MSC_VER<=1200 && defined(_MT) && defined(isspace)
-       /* compensate for bug in VC6 ctype.h */
-#    undef isspace
-#    undef isdigit
-#    undef isalnum
-#    undef isupper
-#    undef isxdigit
-#   endif
 #   if defined(_MSC_VER) && !defined(_WIN32_WCE) && !defined(_DLL) && defined(stdin)
 #    if _MSC_VER>=1300 && _MSC_VER<1600
 #     undef stdin

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -23,11 +23,6 @@
 # include <openssl/bn.h>
 # include <openssl/opensslconf.h>
 
-# if defined(_MSC_VER) && defined(_MIPS_) && (_MSC_VER/100==12)
-/* suppress "too big too optimize" warning */
-#  pragma warning(disable:4959)
-# endif
-
 static size_t crv_len = 0;
 static EC_builtin_curve *curves = NULL;
 


### PR DESCRIPTION
Based on comment from Andy at https://github.com/openssl/openssl/pull/4246#discussion_r135338931
