### PR TITLE
Fix return value of ASN1_TIME_compare

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -543,7 +543,7 @@ int ASN1_TIME_compare(const ASN1_TIME *a, const ASN1_TIME *b)
 {
     int day, sec;
 
-    if (!ASN1_TIME_diff(&day, &sec, a, b))
+    if (!ASN1_TIME_diff(&day, &sec, b, a))
         return -2;
     if (day > 0 || sec > 0)
         return 1;

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -274,6 +274,51 @@ static int test_table_neg_64bit(int idx)
     return test_table(tbl_testdata_neg_64bit, idx);
 }
 
+struct compare_testdata {
+    ASN1_TIME t1;
+    ASN1_TIME t2;
+    int result;
+};
+
+static unsigned char TODAY_GEN_STR[] = "20170825000000Z";
+static unsigned char TOMORROW_GEN_STR[] = "20170826000000Z";
+static unsigned char TODAY_UTC_STR[] = "170825000000Z";
+static unsigned char TOMORROW_UTC_STR[] = "170826000000Z";
+
+#define TODAY_GEN    { sizeof(TODAY_GEN_STR)-1, V_ASN1_GENERALIZEDTIME, TODAY_GEN_STR, 0 }
+#define TOMORROW_GEN { sizeof(TOMORROW_GEN_STR)-1, V_ASN1_GENERALIZEDTIME, TOMORROW_GEN_STR, 0 }
+#define TODAY_UTC    { sizeof(TODAY_UTC_STR)-1, V_ASN1_UTCTIME, TODAY_UTC_STR, 0 }
+#define TOMORROW_UTC { sizeof(TOMORROW_UTC_STR)-1, V_ASN1_UTCTIME, TOMORROW_UTC_STR, 0 }
+
+static struct compare_testdata tbl_compare_testdata[] = {
+    { TODAY_GEN,    TODAY_GEN,     0 },
+    { TODAY_GEN,    TODAY_UTC,     0 },
+    { TODAY_GEN,    TOMORROW_GEN, -1 },
+    { TODAY_GEN,    TOMORROW_UTC, -1 },
+
+    { TODAY_UTC,    TODAY_GEN,     0 },
+    { TODAY_UTC,    TODAY_UTC,     0 },
+    { TODAY_UTC,    TOMORROW_GEN, -1 },
+    { TODAY_UTC,    TOMORROW_UTC, -1 },
+
+    { TOMORROW_GEN, TODAY_GEN,     1 },
+    { TOMORROW_GEN, TODAY_UTC,     1 },
+    { TOMORROW_GEN, TOMORROW_GEN,  0 },
+    { TOMORROW_GEN, TOMORROW_UTC,  0 },
+
+    { TOMORROW_UTC, TODAY_GEN,     1 },
+    { TOMORROW_UTC, TODAY_UTC,     1 },
+    { TOMORROW_UTC, TOMORROW_GEN,  0 },
+    { TOMORROW_UTC, TOMORROW_UTC,  0 }
+};
+
+static int test_table_compare(int idx)
+{
+    struct compare_testdata *td = &tbl_compare_testdata[idx];
+
+    return TEST_int_eq(ASN1_TIME_compare(&td->t1, &td->t2), td->result);
+}
+
 int setup_tests(void)
 {
     /*
@@ -305,5 +350,6 @@ int setup_tests(void)
             ADD_ALL_TESTS(test_table_neg_64bit, OSSL_NELEM(tbl_testdata_neg_64bit));
         }
     }
+    ADD_ALL_TESTS(test_table_compare, OSSL_NELEM(tbl_compare_testdata));
     return 1;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [X] tests are added or updated
