### PR TITLE
Fix some minor issues of the DRBG reseeding

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -125,9 +125,9 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
                           const unsigned char *pers, size_t perslen)
 {
     unsigned char *nonce = NULL, *entropy = NULL;
-    size_t noncelen = 0, entlen = 0;
+    size_t noncelen = 0, entropylen = 0;
 
-    if (perslen > drbg->max_pers) {
+    if (perslen > drbg->max_perslen) {
         RANDerr(RAND_F_RAND_DRBG_INSTANTIATE,
                 RAND_R_PERSONALISATION_STRING_TOO_LONG);
         goto end;
@@ -141,23 +141,23 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
 
     drbg->state = DRBG_ERROR;
     if (drbg->get_entropy != NULL)
-        entlen = drbg->get_entropy(drbg, &entropy, drbg->strength,
-                                   drbg->min_entropy, drbg->max_entropy);
-    if (entlen < drbg->min_entropy || entlen > drbg->max_entropy) {
+        entropylen = drbg->get_entropy(drbg, &entropy, drbg->strength,
+                                   drbg->min_entropylen, drbg->max_entropylen);
+    if (entropylen < drbg->min_entropylen || entropylen > drbg->max_entropylen) {
         RANDerr(RAND_F_RAND_DRBG_INSTANTIATE, RAND_R_ERROR_RETRIEVING_ENTROPY);
         goto end;
     }
 
-    if (drbg->max_nonce > 0 && drbg->get_nonce != NULL) {
+    if (drbg->max_noncelen > 0 && drbg->get_nonce != NULL) {
         noncelen = drbg->get_nonce(drbg, &nonce, drbg->strength / 2,
-                                   drbg->min_nonce, drbg->max_nonce);
-        if (noncelen < drbg->min_nonce || noncelen > drbg->max_nonce) {
+                                   drbg->min_noncelen, drbg->max_noncelen);
+        if (noncelen < drbg->min_noncelen || noncelen > drbg->max_noncelen) {
             RANDerr(RAND_F_RAND_DRBG_INSTANTIATE, RAND_R_ERROR_RETRIEVING_NONCE);
             goto end;
         }
     }
 
-    if (!ctr_instantiate(drbg, entropy, entlen,
+    if (!ctr_instantiate(drbg, entropy, entropylen,
                          nonce, noncelen, pers, perslen)) {
         RANDerr(RAND_F_RAND_DRBG_INSTANTIATE, RAND_R_ERROR_INSTANTIATING_DRBG);
         goto end;
@@ -195,7 +195,7 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
                      const unsigned char *adin, size_t adinlen)
 {
     unsigned char *entropy = NULL;
-    size_t entlen = 0;
+    size_t entropylen = 0;
 
     if (drbg->state == DRBG_ERROR) {
         RANDerr(RAND_F_RAND_DRBG_RESEED, RAND_R_IN_ERROR_STATE);
@@ -208,21 +208,21 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
 
     if (adin == NULL)
         adinlen = 0;
-    else if (adinlen > drbg->max_adin) {
+    else if (adinlen > drbg->max_adinlen) {
         RANDerr(RAND_F_RAND_DRBG_RESEED, RAND_R_ADDITIONAL_INPUT_TOO_LONG);
         return 0;
     }
 
     drbg->state = DRBG_ERROR;
     if (drbg->get_entropy != NULL)
-        entlen = drbg->get_entropy(drbg, &entropy, drbg->strength,
-                                   drbg->min_entropy, drbg->max_entropy);
-    if (entlen < drbg->min_entropy || entlen > drbg->max_entropy) {
+        entropylen = drbg->get_entropy(drbg, &entropy, drbg->strength,
+                                   drbg->min_entropylen, drbg->max_entropylen);
+    if (entropylen < drbg->min_entropylen || entropylen > drbg->max_entropylen) {
         RANDerr(RAND_F_RAND_DRBG_RESEED, RAND_R_ERROR_RETRIEVING_ENTROPY);
         goto end;
     }
 
-    if (!ctr_reseed(drbg, entropy, entlen, adin, adinlen))
+    if (!ctr_reseed(drbg, entropy, entropylen, adin, adinlen))
         goto end;
     drbg->state = DRBG_READY;
     drbg->reseed_counter = 1;
@@ -256,7 +256,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
         RANDerr(RAND_F_RAND_DRBG_GENERATE, RAND_R_REQUEST_TOO_LARGE_FOR_DRBG);
         return 0;
     }
-    if (adinlen > drbg->max_adin) {
+    if (adinlen > drbg->max_adinlen) {
         RANDerr(RAND_F_RAND_DRBG_GENERATE, RAND_R_ADDITIONAL_INPUT_TOO_LONG);
         return 0;
     }

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -168,9 +168,9 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
 
 end:
     if (entropy != NULL && drbg->cleanup_entropy != NULL)
-        drbg->cleanup_entropy(drbg, entropy);
+        drbg->cleanup_entropy(drbg, entropy, entropylen);
     if (nonce != NULL && drbg->cleanup_nonce!= NULL )
-        drbg->cleanup_nonce(drbg, nonce);
+        drbg->cleanup_nonce(drbg, nonce, noncelen);
     if (drbg->state == DRBG_READY)
         return 1;
     return 0;
@@ -229,7 +229,7 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
 
 end:
     if (entropy != NULL && drbg->cleanup_entropy != NULL)
-        drbg->cleanup_entropy(drbg, entropy);
+        drbg->cleanup_entropy(drbg, entropy, entropylen);
     if (drbg->state == DRBG_READY)
         return 1;
     return 0;

--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -237,29 +237,29 @@ static void ctr_update(RAND_DRBG *drbg,
 }
 
 int ctr_instantiate(RAND_DRBG *drbg,
-                    const unsigned char *ent, size_t entlen,
+                    const unsigned char *entropy, size_t entropylen,
                     const unsigned char *nonce, size_t noncelen,
                     const unsigned char *pers, size_t perslen)
 {
     RAND_DRBG_CTR *ctr = &drbg->ctr;
 
-    if (ent == NULL)
+    if (entropy == NULL)
         return 0;
 
     memset(ctr->K, 0, sizeof(ctr->K));
     memset(ctr->V, 0, sizeof(ctr->V));
     AES_set_encrypt_key(ctr->K, drbg->strength, &ctr->ks);
-    ctr_update(drbg, ent, entlen, pers, perslen, nonce, noncelen);
+    ctr_update(drbg, entropy, entropylen, pers, perslen, nonce, noncelen);
     return 1;
 }
 
 int ctr_reseed(RAND_DRBG *drbg,
-               const unsigned char *ent, size_t entlen,
+               const unsigned char *entropy, size_t entropylen,
                const unsigned char *adin, size_t adinlen)
 {
-    if (ent == NULL)
+    if (entropy == NULL)
         return 0;
-    ctr_update(drbg, ent, entlen, adin, adinlen, NULL, 0);
+    ctr_update(drbg, entropy, entropylen, adin, adinlen, NULL, 0);
     return 1;
 }
 
@@ -340,20 +340,20 @@ int ctr_init(RAND_DRBG *drbg)
         /* Set key schedule for df_key */
         AES_set_encrypt_key(df_key, drbg->strength, &ctr->df_ks);
 
-        drbg->min_entropy = ctr->keylen;
-        drbg->max_entropy = DRBG_MAX_LENGTH;
-        drbg->min_nonce = drbg->min_entropy / 2;
-        drbg->max_nonce = DRBG_MAX_LENGTH;
-        drbg->max_pers = DRBG_MAX_LENGTH;
-        drbg->max_adin = DRBG_MAX_LENGTH;
+        drbg->min_entropylen = ctr->keylen;
+        drbg->max_entropylen = DRBG_MAX_LENGTH;
+        drbg->min_noncelen = drbg->min_entropylen / 2;
+        drbg->max_noncelen = DRBG_MAX_LENGTH;
+        drbg->max_perslen = DRBG_MAX_LENGTH;
+        drbg->max_adinlen = DRBG_MAX_LENGTH;
     } else {
-        drbg->min_entropy = drbg->seedlen;
-        drbg->max_entropy = drbg->seedlen;
+        drbg->min_entropylen = drbg->seedlen;
+        drbg->max_entropylen = drbg->seedlen;
         /* Nonce not used */
-        drbg->min_nonce = 0;
-        drbg->max_nonce = 0;
-        drbg->max_pers = drbg->seedlen;
-        drbg->max_adin = drbg->seedlen;
+        drbg->min_noncelen = 0;
+        drbg->max_noncelen = 0;
+        drbg->max_perslen = drbg->seedlen;
+        drbg->max_adinlen = drbg->seedlen;
     }
 
     drbg->max_request = 1 << 16;

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -94,14 +94,12 @@ struct rand_drbg_st {
     int nid; /* the underlying algorithm */
     int fork_count;
     unsigned short flags; /* various external flags */
-    char filled;
     char secure;
     /*
      * This is a fixed-size buffer, but we malloc to make it a little
      * harder to find; a classic security/performance trade-off.
      */
     int size;
-    unsigned char *randomness;
 
     /* 
      * The following parameters are setup by the per-type "init" function.
@@ -157,7 +155,7 @@ void rand_read_tsc(RAND_poll_cb rand_add, void *arg);
 int rand_read_cpu(RAND_poll_cb rand_add, void *arg);
 
 /* DRBG entropy callbacks. */
-void drbg_release_entropy(RAND_DRBG *drbg, unsigned char *out);
+void drbg_release_entropy(RAND_DRBG *drbg, unsigned char *out, size_t outlen);
 size_t drbg_entropy_from_parent(RAND_DRBG *drbg,
                                 unsigned char **pout,
                                 int entropy, size_t min_len, size_t max_len);

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -153,8 +153,8 @@ extern RAND_DRBG priv_drbg;
 extern int rand_fork_count;
 
 /* Hardware-based seeding functions. */
-void rand_read_tsc(RAND_poll_fn cb, void *arg);
-int rand_read_cpu(RAND_poll_fn cb, void *arg);
+void rand_read_tsc(RAND_poll_cb rand_add, void *arg);
+int rand_read_cpu(RAND_poll_cb rand_add, void *arg);
 
 /* DRBG entropy callbacks. */
 void drbg_release_entropy(RAND_DRBG *drbg, unsigned char *out);

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -103,12 +103,28 @@ struct rand_drbg_st {
     int size;
     unsigned char *randomness;
 
-    /* These parameters are setup by the per-type "init" function. */
+    /* 
+     * The following parameters are setup by the per-type "init" function.
+     *
+     * Currently the only type is CTR_DRBG, its init function is ctr_init().
+     *
+     * The parameters are closely related to the ones described in 
+     * section '10.2.1 CTR_DRBG' of [NIST SP 800-90Ar1], with one
+     * crucial difference: In the NIST standard, all counts are given
+     * in bits, whereas in OpenSSL entropy counts are given in bits 
+     * and buffer lengths are given in bytes.
+     * 
+     * Since this difference has lead to some confusion in the past,
+     * (see [GitHub Issue #2443], formerly [rt.openssl.org #4055])
+     * the 'len' suffix has been added to all buffer sizes for 
+     * clarification.
+     */
+    
     int strength;
     size_t max_request;
-    size_t min_entropy, max_entropy;
-    size_t min_nonce, max_nonce;
-    size_t max_pers, max_adin;
+    size_t min_entropylen, max_entropylen;
+    size_t min_noncelen, max_noncelen;
+    size_t max_perslen, max_adinlen;
     unsigned int reseed_counter;
     unsigned int reseed_interval;
     size_t seedlen;
@@ -153,11 +169,11 @@ size_t drbg_entropy_from_system(RAND_DRBG *drbg,
 int ctr_init(RAND_DRBG *drbg);
 int ctr_uninstantiate(RAND_DRBG *drbg);
 int ctr_instantiate(RAND_DRBG *drbg,
-                    const unsigned char *ent, size_t entlen,
+                    const unsigned char *entropy, size_t entropylen,
                     const unsigned char *nonce, size_t noncelen,
                     const unsigned char *pers, size_t perslen);
 int ctr_reseed(RAND_DRBG *drbg,
-               const unsigned char *ent, size_t entlen,
+               const unsigned char *entropy, size_t entropylen,
                const unsigned char *adin, size_t adinlen);
 int ctr_generate(RAND_DRBG *drbg,
                  unsigned char *out, size_t outlen,

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -42,7 +42,7 @@ int rand_fork_count;
  * it's not sufficient to indicate whether or not the seeding was
  * done.
  */
-void rand_read_tsc(RAND_poll_fn cb, void *arg)
+void rand_read_tsc(RAND_poll_cb rand_add, void *arg)
 {
     unsigned char c;
     int i;
@@ -50,7 +50,7 @@ void rand_read_tsc(RAND_poll_fn cb, void *arg)
     if ((OPENSSL_ia32cap_P[0] & (1 << 4)) != 0) {
         for (i = 0; i < TSC_READ_COUNT; i++) {
             c = (unsigned char)(OPENSSL_rdtsc() & 0xFF);
-            cb(arg, &c, 1, 0.5);
+            rand_add(arg, &c, 1, 0.5);
         }
     }
 }
@@ -62,14 +62,14 @@ size_t OPENSSL_ia32_rdrand_bytes(char *buf, size_t len);
 
 extern unsigned int OPENSSL_ia32cap_P[];
 
-int rand_read_cpu(RAND_poll_fn cb, void *arg)
+int rand_read_cpu(RAND_poll_cb rand_add, void *arg)
 {
     char buff[RANDOMNESS_NEEDED];
 
     /* If RDSEED is available, use that. */
     if ((OPENSSL_ia32cap_P[2] & (1 << 18)) != 0) {
         if (OPENSSL_ia32_rdseed_bytes(buff, sizeof(buff)) == sizeof(buff)) {
-            cb(arg, buff, (int)sizeof(buff), sizeof(buff));
+            rand_add(arg, buff, (int)sizeof(buff), sizeof(buff));
             return 1;
         }
     }
@@ -77,7 +77,7 @@ int rand_read_cpu(RAND_poll_fn cb, void *arg)
     /* Second choice is RDRAND. */
     if ((OPENSSL_ia32cap_P[1] & (1 << (62 - 32))) != 0) {
         if (OPENSSL_ia32_rdrand_bytes(buff, sizeof(buff)) == sizeof(buff)) {
-            cb(arg, buff, (int)sizeof(buff), sizeof(buff));
+            rand_add(arg, buff, (int)sizeof(buff), sizeof(buff));
             return 1;
         }
     }

--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -54,7 +54,7 @@ static struct items_data_st {
     {0, 0}
 };
 
-int RAND_poll_ex(RAND_poll_fn cb, void *arg)
+int RAND_poll_ex(RAND_poll_cb rand_add, void *arg)
 {
     /* determine the number of items in the JPI array */
     struct items_data_st item_entry;
@@ -113,7 +113,7 @@ int RAND_poll_ex(RAND_poll_fn cb, void *arg)
     total_length += (tmp_length - 1);
 
     /* size of seed is total_length*4 bytes (64bytes) */
-    cb(arg, (PTR_T)data_buffer, total_length * 4, total_length * 2);
+    rand_add(arg, (PTR_T)data_buffer, total_length * 4, total_length * 2);
     return 1;
 }
 

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -39,7 +39,7 @@
 #  define INTEL_DEF_PROV L"Intel Hardware Cryptographic Service Provider"
 # endif
 
-int RAND_poll_ex(RAND_poll_fn cb, void *arg)
+int RAND_poll_ex(RAND_poll_cb rand_add, void *arg)
 {
 # ifndef USE_BCRYPTGENRANDOM
     HCRYPTPROV hProvider;
@@ -58,7 +58,7 @@ int RAND_poll_ex(RAND_poll_fn cb, void *arg)
 # ifdef USE_BCRYPTGENRANDOM
     if (BCryptGenRandom(NULL, buf, (ULONG)sizeof(buf),
                         BCRYPT_USE_SYSTEM_PREFERRED_RNG) == STATUS_SUCCESS) {
-        cb(arg, buf, sizeof(buf), sizeof(buf));
+        rand_add(arg, buf, sizeof(buf), sizeof(buf));
         return 1;
     }
 # else
@@ -66,7 +66,7 @@ int RAND_poll_ex(RAND_poll_fn cb, void *arg)
     if (CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL,
                              CRYPT_VERIFYCONTEXT | CRYPT_SILENT) != 0) {
         if (CryptGenRandom(hProvider, (DWORD)sizeof(buf), buf) != 0) {
-            cb(arg, buf, sizeof(buf), sizeof(buf));
+            rand_add(arg, buf, sizeof(buf), sizeof(buf));
             ok = 1;
         }
         CryptReleaseContext(hProvider, 0);
@@ -78,7 +78,7 @@ int RAND_poll_ex(RAND_poll_fn cb, void *arg)
     if (CryptAcquireContextW(&hProvider, NULL, INTEL_DEF_PROV, PROV_INTEL_SEC,
                              CRYPT_VERIFYCONTEXT | CRYPT_SILENT) != 0) {
         if (CryptGenRandom(hProvider, (DWORD)sizeof(buf), buf) != 0) {
-            cb(arg, buf, sizeof(buf), sizeof(buf));
+            rand_add(arg, buf, sizeof(buf), sizeof(buf));
             ok = 1;
         }
         CryptReleaseContext(hProvider, 0);

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-RAND_add, RAND_poll, RAND_poll_ex, RAND_poll_fn,
+RAND_add, RAND_poll, RAND_poll_ex, RAND_poll_cb,
 RAND_seed, RAND_status, RAND_event, RAND_screen
 - add randomness to the PRNG or get its status
 
@@ -12,9 +12,9 @@ RAND_seed, RAND_status, RAND_event, RAND_screen
 
  int RAND_status(void);
 
- typedef void (*RAND_poll_fn)(void *arg,
+ typedef void (*RAND_poll_cb)(void *arg,
                               const void *buf, int num, double randomness);
- int RAND_poll_ex(RAND_poll_fn cb, void *arg);
+ int RAND_poll_ex(RAND_poll_cb cb, void *arg);
  int RAND_poll();
 
  void RAND_add(const void *buf, int num, double randomness);

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -50,11 +50,12 @@ typedef size_t (*RAND_DRBG_get_entropy_fn)(RAND_DRBG *ctx,
                                            int entropy, size_t min_len,
                                            size_t max_len);
 typedef void (*RAND_DRBG_cleanup_entropy_fn)(RAND_DRBG *ctx,
-                                             unsigned char *out);
+                                             unsigned char *out, size_t outlen);
 typedef size_t (*RAND_DRBG_get_nonce_fn)(RAND_DRBG *ctx, unsigned char **pout,
                                          int entropy, size_t min_len,
                                          size_t max_len);
-typedef void (*RAND_DRBG_cleanup_nonce_fn)(RAND_DRBG *ctx, unsigned char *out);
+typedef void (*RAND_DRBG_cleanup_nonce_fn)(RAND_DRBG *ctx,
+                                           unsigned char *out, size_t outlen);
 
 int RAND_DRBG_set_callbacks(RAND_DRBG *dctx,
                             RAND_DRBG_get_entropy_fn get_entropy,

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -61,10 +61,10 @@ int RAND_egd(const char *path);
 int RAND_egd_bytes(const char *path, int bytes);
 # endif
 
-typedef void (*RAND_poll_fn)(void *arg,
+typedef void (*RAND_poll_cb)(void *arg,
                              const void *buf, int num, double randomness);
 int RAND_poll(void);
-int RAND_poll_ex(RAND_poll_fn cb, void *arg);
+int RAND_poll_ex(RAND_poll_cb rand_add, void *arg);
 
 # if defined(_WIN32) && (defined(BASETYPES) || defined(_WINDEF_H))
 /* application has to include <windows.h> in order to use these */

--- a/util/private.num
+++ b/util/private.num
@@ -33,7 +33,7 @@ OSSL_STORE_error_fn                     datatype
 OSSL_STORE_load_fn                      datatype
 OSSL_STORE_open_fn                      datatype
 OSSL_STORE_post_process_info_fn         datatype
-RAND_poll_fn                            datatype
+RAND_poll_cb                            datatype
 SSL_CTX_keylog_cb_func                  datatype
 SSL_early_cb_fn                         datatype
 SSL_psk_client_cb_func                  datatype


### PR DESCRIPTION
This PR contains three commits which are explained in detail separately. They are not intended to be squashed.

# Clarify difference between entropy counts and buffer lengths  (7ff7ddb653e4e50ae82e99bed9daff8f95cf2bf2)

Unlike the NIST DRBG standard, in OpenSSL the entropy counts are in bits and the buffer lengths are in bytes. The mixing of bits and bytes has occasionally lead to some confusion in the past, in fact to an error in the FIPS DRBG code (originally [RT 4055](https://rt.openssl.org/Ticket/Display.html?id=4055&user=guest&pass=guest), now Issue #2443) see [my comment added to crypto/rand/drbg_lib.c in PR #3789](https://github.com/openssl/openssl/pull/3789#pullrequestreview-48756739) (you have to click "Show outdated" to see it). To clarify the distinction between entropy counts and buffer lengths, it is useful to add a `len` suffix to all member names of `RAND_DRBG` which represent buffer lengths:
```
    -   {min,max}_{entropy,adin,nonce,pers}
    +   {min,max}_{entropy,adin,nonce,pers}len
```
This change also makes naming more consistent with existing names, as can be seen in diffs, for example:
```diff    
    -    else if (adinlen > drbg->max_adin) {
    +    else if (adinlen > drbg->max_adinlen) {
```

# Rename the RAND_poll_ex() callback and its typedef (0b2a15a6b7d6243032f8e9a2fa472c71867c74bd)

- [X] documentation is added or updated


With the introduction of RAND_poll_ex(), the good old `RAND_add()` calls were replaced by meaningless `cb(...)` calls. This commit changes the signature of `RAND_poll_ex()` from
```C
int RAND_poll_ex(RAND_poll_fn cb, void *arg);
```
to
```C
int RAND_poll_ex(RAND_add_ex_fn rand_add, void *arg);
```
such that all the nameless `cb(...)` callbacks are turned back into `rand_add(...)` calls.  Also, the misleading type name `RAND_poll_fn` is changed to `RAND_add_ex_fn`, since it's actually more a `RAND_add()` replacement. 

Actually, the `RAND_add_ex_fn` could have been called `RAND_add_fn`, if it weren't for the extra `void *arg` which is passed through, but used nowhere. Is this `arg` really needed? Of which use case are you thinking? Shouldn't it be removed again?


# Remove `randomness` buffer from `RAND_DRBG`  (8931a3741b066f27811fef9340e33645c5bf7d83)

In the original OpenSSL FIPS DRBG implementation, the function signature of the `get_entropy()` and `cleanup_entropy()` callbacks (resp. `get_nonce()` and `cleanup_nonce()`) is designed in such a way that the randomness buffer does not have to be allocated by the calling function: Instead, the calling function can pass the address of a stack local `char *randomness` pointer as `**pout` argument to the `get_entropy()` callback, which allocates the buffer and returns its address via `*pout`. After use, `address` is passed by the calling function to the `cleanup_entropy()` callback as `pout` parameter, where it is used to free the buffer.

```C
int FIPS_drbg_set_callbacks(
    DRBG_CTX *dctx,
    size_t (*get_entropy)(DRBG_CTX *ctx, unsigned
        char **pout, int entropy, size_t min_len, size_t max_len),
    void (*cleanup_entropy)(DRBG_CTX *ctx, unsigned char *out, size_t olen),
    
    ...
)
```

This implies that the pointer can be a stack local variable of the calling function, provided the two callbacks are paired properly. In particular, it is not necessary have a member in the `RAND_DRBG` struct. I pointed this out to Rich Salz a while ago and my suggestion was partly followed in commit 9d951a7872e5fa2b2a83fe8cfda3af5c52581172 which reduced the lifetime of the `randomness` buffer to the scope of the `RAND_DRBG_instantiate()` resp. `RAND_DRBG_reseed()` function. But this commit also removed the necessity to store the pointer in the `RAND_DRBG` struct, so I finally removed it.
