### PR TITLE
Don't auto-instantiate a DRBG when trying to use it and it's not

### DIFF
--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -18,4 +18,5 @@
 #include <openssl/rand.h>
 
 void rand_cleanup_int(void);
+void rand_cleanup_drbg_int(void);
 void rand_fork(void);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -488,6 +488,7 @@ void OPENSSL_cleanup(void)
      * obj_cleanup_int() must be called last
      */
     rand_cleanup_int();
+    rand_cleanup_drbg_int();
     conf_modules_free_int();
 #ifndef OPENSSL_NO_ENGINE
     engine_cleanup_int();

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -15,6 +15,9 @@
 #include "internal/thread_once.h"
 #include "internal/rand_int.h"
 
+static RAND_DRBG rand_drbg; /* The default global DRBG. */
+static RAND_DRBG priv_drbg; /* The global private-key DRBG. */
+
 /*
  * Support framework for NIST SP 800-90A DRBG, AES-CTR mode.
  * The RAND_DRBG is OpenSSL's pointer to an instance of the DRBG.
@@ -472,9 +475,6 @@ RAND_DRBG *RAND_DRBG_get0_priv_global(void)
 
     return &priv_drbg;
 }
-
-RAND_DRBG rand_drbg; /* The default global DRBG. */
-RAND_DRBG priv_drbg; /* The global private-key DRBG. */
 
 RAND_METHOD rand_meth = {
     drbg_seed,

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -144,8 +144,6 @@ struct rand_drbg_st {
 /* The global RAND method, and the global buffer and DRBG instance. */
 extern RAND_METHOD rand_meth;
 extern RAND_BYTES_BUFFER rand_bytes;
-extern RAND_DRBG rand_drbg;
-extern RAND_DRBG priv_drbg;
 
 /* How often we've forked (only incremented in child). */
 extern int rand_fork_count;

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -33,6 +33,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
                        const unsigned char *adin, size_t adinlen);
 int RAND_DRBG_set_reseed_interval(RAND_DRBG *drbg, int interval);
 RAND_DRBG *RAND_DRBG_get0_global(void);
+RAND_DRBG *RAND_DRBG_get0_priv_global(void);
 
 /*
  * EXDATA

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -630,7 +630,8 @@ SSL *SSL_new(SSL_CTX *ctx)
     if (RAND_get_rand_method() == RAND_OpenSSL()) {
         s->drbg = RAND_DRBG_new(NID_aes_128_ctr, RAND_DRBG_FLAG_CTR_USE_DF,
                                 RAND_DRBG_get0_global());
-        if (s->drbg == NULL) {
+        if (s->drbg == NULL
+            || RAND_DRBG_instantiate(s->drbg, NULL, 0) == 0) {
             CRYPTO_THREAD_lock_free(s->lock);
             goto err;
         }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4382,3 +4382,4 @@ ASN1_TIME_compare                       4325	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_CTX_ctrl_uint64                4326	1_1_1	EXIST::FUNCTION:
 EVP_DigestFinalXOF                      4327	1_1_1	EXIST::FUNCTION:
 ERR_clear_last_mark                     4328	1_1_1	EXIST::FUNCTION:
+RAND_DRBG_get0_priv_global              4329	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
The one creating the DRBG should instantiate it, it's there that we
know which parameters we should use to instantiate it.

This splits the rand init in two parts to avoid a deadlock
because when the global drbg is created it wands to call
rand_add on the global rand method.