### PR TITLE
crypto/x509: remove redundant parenthesis

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -63,7 +63,7 @@ static X509_LOOKUP_METHOD x509_dir_lookup = {
 
 X509_LOOKUP_METHOD *X509_LOOKUP_hash_dir(void)
 {
-    return (&x509_dir_lookup);
+    return &x509_dir_lookup;
 }
 
 static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
@@ -91,7 +91,7 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
             ret = add_cert_dir(ld, argp, (int)argl);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int new_dir(X509_LOOKUP *lu)
@@ -160,7 +160,7 @@ static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
     s = dir;
     p = s;
     do {
-        if ((*p == LIST_SEPARATOR_CHAR) || (*p == '\0')) {
+        if (*p == LIST_SEPARATOR_CHAR || *p == '\0') {
             BY_DIR_ENTRY *ent;
             int j;
             size_t len;
@@ -219,7 +219,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
     const char *postfix = "";
 
     if (name == NULL)
-        return (0);
+        return 0;
 
     stmp.type = type;
     if (type == X509_LU_X509) {
@@ -308,10 +308,10 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
 #endif
             /* found one. */
             if (type == X509_LU_X509) {
-                if ((X509_load_cert_file(xl, b->data, ent->dir_type)) == 0)
+                if (X509_load_cert_file(xl, b->data, ent->dir_type) == 0)
                     break;
             } else if (type == X509_LU_CRL) {
-                if ((X509_load_crl_file(xl, b->data, ent->dir_type)) == 0)
+                if (X509_load_crl_file(xl, b->data, ent->dir_type) == 0)
                     break;
             }
             /* else case will caught higher up */
@@ -389,5 +389,5 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
     }
  finish:
     BUF_MEM_free(b);
-    return (ok);
+    return ok;
 }

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -35,7 +35,7 @@ static X509_LOOKUP_METHOD x509_file_lookup = {
 
 X509_LOOKUP_METHOD *X509_LOOKUP_file(void)
 {
-    return (&x509_file_lookup);
+    return &x509_file_lookup;
 }
 
 static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
@@ -69,7 +69,7 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
         }
         break;
     }
-    return (ok);
+    return ok;
 }
 
 int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
@@ -81,7 +81,7 @@ int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
 
     in = BIO_new(BIO_s_file());
 
-    if ((in == NULL) || (BIO_read_filename(in, file) <= 0)) {
+    if (in == NULL || BIO_read_filename(in, file) <= 0) {
         X509err(X509_F_X509_LOAD_CERT_FILE, ERR_R_SYS_LIB);
         goto err;
     }
@@ -90,8 +90,8 @@ int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
         for (;;) {
             x = PEM_read_bio_X509_AUX(in, NULL, NULL, "");
             if (x == NULL) {
-                if ((ERR_GET_REASON(ERR_peek_last_error()) ==
-                     PEM_R_NO_START_LINE) && (count > 0)) {
+                if (ERR_GET_REASON(ERR_peek_last_error() ==
+                     PEM_R_NO_START_LINE) && count > 0) {
                     ERR_clear_error();
                     break;
                 } else {
@@ -126,7 +126,7 @@ int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
  err:
     X509_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
@@ -138,7 +138,7 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
 
     in = BIO_new(BIO_s_file());
 
-    if ((in == NULL) || (BIO_read_filename(in, file) <= 0)) {
+    if (in == NULL || BIO_read_filename(in, file) <= 0) {
         X509err(X509_F_X509_LOAD_CRL_FILE, ERR_R_SYS_LIB);
         goto err;
     }
@@ -147,8 +147,8 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
         for (;;) {
             x = PEM_read_bio_X509_CRL(in, NULL, NULL, "");
             if (x == NULL) {
-                if ((ERR_GET_REASON(ERR_peek_last_error()) ==
-                     PEM_R_NO_START_LINE) && (count > 0)) {
+                if (ERR_GET_REASON(ERR_peek_last_error()) ==
+                    PEM_R_NO_START_LINE && count > 0) {
                     ERR_clear_error();
                     break;
                 } else {
@@ -183,7 +183,7 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
  err:
     X509_CRL_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type)

--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -23,12 +23,12 @@ int X509_CRL_print_fp(FILE *fp, X509_CRL *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         X509err(X509_F_X509_CRL_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = X509_CRL_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -25,12 +25,12 @@ int X509_REQ_print_fp(FILE *fp, X509_REQ *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         X509err(X509_F_X509_REQ_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = X509_REQ_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -135,10 +135,10 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
                         goto err;
                 if (BIO_puts(bp, ":") <= 0)
                     goto err;
-                if ((type == V_ASN1_PRINTABLESTRING) ||
-                    (type == V_ASN1_T61STRING) ||
-                    (type == V_ASN1_UTF8STRING) ||
-                    (type == V_ASN1_IA5STRING)) {
+                if (type == V_ASN1_PRINTABLESTRING ||
+                    type == V_ASN1_T61STRING ||
+                    type == V_ASN1_UTF8STRING ||
+                    type == V_ASN1_IA5STRING) {
                     if (BIO_write(bp, (char *)bs->data, bs->length)
                         != bs->length)
                         goto err;
@@ -186,10 +186,10 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
             goto err;
     }
 
-    return (1);
+    return 1;
  err:
     X509err(X509_F_X509_REQ_PRINT_EX, ERR_R_BUF_LIB);
-    return (0);
+    return 0;
 }
 
 int X509_REQ_print(BIO *bp, X509_REQ *x)

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -30,12 +30,12 @@ int X509_print_ex_fp(FILE *fp, X509 *x, unsigned long nmflag,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         X509err(X509_F_X509_PRINT_EX_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = X509_print_ex(b, x, nmflag, cflag);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -110,7 +110,7 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
 
             for (i = 0; i < bs->length; i++) {
                 if (BIO_printf(bp, "%02x%c", bs->data[i],
-                               ((i + 1 == bs->length) ? '\n' : ':')) <= 0)
+                               i + 1 == bs->length ? '\n' : ':') <= 0)
                     goto err;
             }
         }
@@ -212,7 +212,7 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
     ret = 1;
  err:
     OPENSSL_free(m);
-    return (ret);
+    return ret;
 }
 
 int X509_ocspid_print(BIO *bp, X509 *x)
@@ -266,10 +266,10 @@ int X509_ocspid_print(BIO *bp, X509 *x)
     }
     BIO_printf(bp, "\n");
 
-    return (1);
+    return 1;
  err:
     OPENSSL_free(der);
-    return (0);
+    return 0;
 }
 
 int X509_signature_dump(BIO *bp, const ASN1_STRING *sig, int indent)
@@ -286,7 +286,7 @@ int X509_signature_dump(BIO *bp, const ASN1_STRING *sig, int indent)
             if (BIO_indent(bp, indent, indent) <= 0)
                 return 0;
         }
-        if (BIO_printf(bp, "%02x%s", s[i], ((i + 1) == n) ? "" : ":") <= 0)
+        if (BIO_printf(bp, "%02x%s", s[i], (i + 1) == n ? "" : ":") <= 0)
             return 0;
     }
     if (BIO_write(bp, "\n", 1) != 1)

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -28,8 +28,8 @@ int X509at_get_attr_by_NID(const STACK_OF(X509_ATTRIBUTE) *x, int nid,
     const ASN1_OBJECT *obj = OBJ_nid2obj(nid);
 
     if (obj == NULL)
-        return (-2);
-    return (X509at_get_attr_by_OBJ(x, obj, lastpos));
+        return -2;
+    return X509at_get_attr_by_OBJ(x, obj, lastpos);
 }
 
 int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
@@ -39,7 +39,7 @@ int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
     X509_ATTRIBUTE *ex;
 
     if (sk == NULL)
-        return (-1);
+        return -1;
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
@@ -47,9 +47,9 @@ int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_ATTRIBUTE_value(sk, lastpos);
         if (OBJ_cmp(ex->object, obj) == 0)
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 X509_ATTRIBUTE *X509at_get_attr(const STACK_OF(X509_ATTRIBUTE) *x, int loc)
@@ -65,9 +65,9 @@ X509_ATTRIBUTE *X509at_delete_attr(STACK_OF(X509_ATTRIBUTE) *x, int loc)
     X509_ATTRIBUTE *ret;
 
     if (x == NULL || sk_X509_ATTRIBUTE_num(x) <= loc || loc < 0)
-        return (NULL);
+        return NULL;
     ret = sk_X509_ATTRIBUTE_delete(x, loc);
-    return (ret);
+    return ret;
 }
 
 STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
@@ -93,13 +93,13 @@ STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
         goto err;
     if (*x == NULL)
         *x = sk;
-    return (sk);
+    return sk;
  err:
     X509err(X509_F_X509AT_ADD1_ATTR, ERR_R_MALLOC_FAILURE);
  err2:
     X509_ATTRIBUTE_free(new_attr);
     sk_X509_ATTRIBUTE_free(sk);
-    return (NULL);
+    return NULL;
 }
 
 STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr_by_OBJ(STACK_OF(X509_ATTRIBUTE)
@@ -157,7 +157,7 @@ void *X509at_get0_data_by_OBJ(STACK_OF(X509_ATTRIBUTE) *x,
     i = X509at_get_attr_by_OBJ(x, obj, lastpos);
     if (i == -1)
         return NULL;
-    if ((lastpos <= -2) && (X509at_get_attr_by_OBJ(x, obj, i) != -1))
+    if (lastpos <= -2 && X509at_get_attr_by_OBJ(x, obj, i) != -1)
         return NULL;
     at = X509at_get_attr(x, i);
     if (lastpos <= -3 && (X509_ATTRIBUTE_count(at) != 1))
@@ -175,12 +175,12 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_NID(X509_ATTRIBUTE **attr, int nid,
     obj = OBJ_nid2obj(nid);
     if (obj == NULL) {
         X509err(X509_F_X509_ATTRIBUTE_CREATE_BY_NID, X509_R_UNKNOWN_NID);
-        return (NULL);
+        return NULL;
     }
     ret = X509_ATTRIBUTE_create_by_OBJ(attr, obj, atrtype, data, len);
     if (ret == NULL)
         ASN1_OBJECT_free(obj);
-    return (ret);
+    return ret;
 }
 
 X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_OBJ(X509_ATTRIBUTE **attr,
@@ -190,11 +190,11 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_OBJ(X509_ATTRIBUTE **attr,
 {
     X509_ATTRIBUTE *ret;
 
-    if ((attr == NULL) || (*attr == NULL)) {
+    if (attr == NULL || *attr == NULL) {
         if ((ret = X509_ATTRIBUTE_new()) == NULL) {
             X509err(X509_F_X509_ATTRIBUTE_CREATE_BY_OBJ,
                     ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else
         ret = *attr;
@@ -204,13 +204,13 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_OBJ(X509_ATTRIBUTE **attr,
     if (!X509_ATTRIBUTE_set1_data(ret, atrtype, data, len))
         goto err;
 
-    if ((attr != NULL) && (*attr == NULL))
+    if (attr != NULL && *attr == NULL)
         *attr = ret;
-    return (ret);
+    return ret;
  err:
-    if ((attr == NULL) || (ret != *attr))
+    if (attr == NULL || ret != *attr)
         X509_ATTRIBUTE_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_txt(X509_ATTRIBUTE **attr,
@@ -226,7 +226,7 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_txt(X509_ATTRIBUTE **attr,
         X509err(X509_F_X509_ATTRIBUTE_CREATE_BY_TXT,
                 X509_R_INVALID_FIELD_NAME);
         ERR_add_error_data(2, "name=", atrname);
-        return (NULL);
+        return NULL;
     }
     nattr = X509_ATTRIBUTE_create_by_OBJ(attr, obj, type, bytes, len);
     ASN1_OBJECT_free(obj);
@@ -235,8 +235,8 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_txt(X509_ATTRIBUTE **attr,
 
 int X509_ATTRIBUTE_set1_object(X509_ATTRIBUTE *attr, const ASN1_OBJECT *obj)
 {
-    if ((attr == NULL) || (obj == NULL))
-        return (0);
+    if (attr == NULL || obj == NULL)
+        return 0;
     ASN1_OBJECT_free(attr->object);
     attr->object = OBJ_dup(obj);
     return attr->object != NULL;
@@ -276,7 +276,7 @@ int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
     }
     if ((ttmp = ASN1_TYPE_new()) == NULL)
         goto err;
-    if ((len == -1) && !(attrtype & MBSTRING_FLAG)) {
+    if (len == -1 && !(attrtype & MBSTRING_FLAG)) {
         if (!ASN1_TYPE_set1(ttmp, attrtype, data))
             goto err;
     } else {
@@ -303,8 +303,8 @@ int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *attr)
 ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)
 {
     if (attr == NULL)
-        return (NULL);
-    return (attr->object);
+        return NULL;
+    return attr->object;
 }
 
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -50,10 +50,10 @@ unsigned long X509_issuer_and_serial_hash(X509 *a)
         goto err;
     if (!EVP_DigestFinal_ex(ctx, &(md[0]), NULL))
         goto err;
-    ret = (((unsigned long)md[0]) |
-           ((unsigned long)md[1] << 8L) |
-           ((unsigned long)md[2] << 16L) |
-           ((unsigned long)md[3] << 24L)
+    ret = ((unsigned long)md[0] |
+           (unsigned long)md[1] << 8L |
+           (unsigned long)md[2] << 16L |
+           (unsigned long)md[3] << 24L
         ) & 0xffffffffL;
  err:
     EVP_MD_CTX_free(ctx);
@@ -193,10 +193,10 @@ unsigned long X509_NAME_hash(X509_NAME *x)
                     NULL))
         return 0;
 
-    ret = (((unsigned long)md[0]) |
-           ((unsigned long)md[1] << 8L) |
-           ((unsigned long)md[2] << 16L) |
-           ((unsigned long)md[3] << 24L)
+    ret = ((unsigned long)md[0] |
+           (unsigned long)md[1] << 8L |
+           (unsigned long)md[2] << 16L |
+           (unsigned long)md[3] << 24L
         ) & 0xffffffffL;
     return ret;
 }
@@ -222,10 +222,10 @@ unsigned long X509_NAME_hash_old(X509_NAME *x)
     if (EVP_DigestInit_ex(md_ctx, EVP_md5(), NULL)
         && EVP_DigestUpdate(md_ctx, x->bytes->data, x->bytes->length)
         && EVP_DigestFinal_ex(md_ctx, md, NULL))
-        ret = (((unsigned long)md[0]) |
-               ((unsigned long)md[1] << 8L) |
-               ((unsigned long)md[2] << 16L) |
-               ((unsigned long)md[3] << 24L)
+        ret = ((unsigned long)md[0] |
+               (unsigned long)md[1] << 8L |
+               (unsigned long)md[2] << 16L |
+               (unsigned long)md[3] << 24L
             ) & 0xffffffffL;
     EVP_MD_CTX_free(md_ctx);
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -24,8 +24,8 @@ int X509_issuer_and_serial_cmp(const X509 *a, const X509 *b)
     bi = &b->cert_info;
     i = ASN1_INTEGER_cmp(&ai->serialNumber, &bi->serialNumber);
     if (i)
-        return (i);
-    return (X509_NAME_cmp(ai->issuer, bi->issuer));
+        return i;
+    return X509_NAME_cmp(ai->issuer, bi->issuer);
 }
 
 #ifndef OPENSSL_NO_MD5
@@ -50,28 +50,30 @@ unsigned long X509_issuer_and_serial_hash(X509 *a)
         goto err;
     if (!EVP_DigestFinal_ex(ctx, &(md[0]), NULL))
         goto err;
-    ret = (((unsigned long)md[0]) | ((unsigned long)md[1] << 8L) |
-           ((unsigned long)md[2] << 16L) | ((unsigned long)md[3] << 24L)
+    ret = (((unsigned long)md[0]) |
+           ((unsigned long)md[1] << 8L) |
+           ((unsigned long)md[2] << 16L) |
+           ((unsigned long)md[3] << 24L)
         ) & 0xffffffffL;
  err:
     EVP_MD_CTX_free(ctx);
-    return (ret);
+    return ret;
 }
 #endif
 
 int X509_issuer_name_cmp(const X509 *a, const X509 *b)
 {
-    return (X509_NAME_cmp(a->cert_info.issuer, b->cert_info.issuer));
+    return X509_NAME_cmp(a->cert_info.issuer, b->cert_info.issuer);
 }
 
 int X509_subject_name_cmp(const X509 *a, const X509 *b)
 {
-    return (X509_NAME_cmp(a->cert_info.subject, b->cert_info.subject));
+    return X509_NAME_cmp(a->cert_info.subject, b->cert_info.subject);
 }
 
 int X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b)
 {
-    return (X509_NAME_cmp(a->crl.issuer, b->crl.issuer));
+    return X509_NAME_cmp(a->crl.issuer, b->crl.issuer);
 }
 
 int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
@@ -81,24 +83,24 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 
 X509_NAME *X509_get_issuer_name(const X509 *a)
 {
-    return (a->cert_info.issuer);
+    return a->cert_info.issuer;
 }
 
 unsigned long X509_issuer_name_hash(X509 *x)
 {
-    return (X509_NAME_hash(x->cert_info.issuer));
+    return X509_NAME_hash(x->cert_info.issuer);
 }
 
 #ifndef OPENSSL_NO_MD5
 unsigned long X509_issuer_name_hash_old(X509 *x)
 {
-    return (X509_NAME_hash_old(x->cert_info.issuer));
+    return X509_NAME_hash_old(x->cert_info.issuer);
 }
 #endif
 
 X509_NAME *X509_get_subject_name(const X509 *a)
 {
-    return (a->cert_info.subject);
+    return a->cert_info.subject;
 }
 
 ASN1_INTEGER *X509_get_serialNumber(X509 *a)
@@ -113,13 +115,13 @@ const ASN1_INTEGER *X509_get0_serialNumber(const X509 *a)
 
 unsigned long X509_subject_name_hash(X509 *x)
 {
-    return (X509_NAME_hash(x->cert_info.subject));
+    return X509_NAME_hash(x->cert_info.subject);
 }
 
 #ifndef OPENSSL_NO_MD5
 unsigned long X509_subject_name_hash_old(X509 *x)
 {
-    return (X509_NAME_hash_old(x->cert_info.subject));
+    return X509_NAME_hash_old(x->cert_info.subject);
 }
 #endif
 
@@ -191,10 +193,12 @@ unsigned long X509_NAME_hash(X509_NAME *x)
                     NULL))
         return 0;
 
-    ret = (((unsigned long)md[0]) | ((unsigned long)md[1] << 8L) |
-           ((unsigned long)md[2] << 16L) | ((unsigned long)md[3] << 24L)
+    ret = (((unsigned long)md[0]) |
+           ((unsigned long)md[1] << 8L) |
+           ((unsigned long)md[2] << 16L) |
+           ((unsigned long)md[3] << 24L)
         ) & 0xffffffffL;
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_MD5
@@ -218,12 +222,14 @@ unsigned long X509_NAME_hash_old(X509_NAME *x)
     if (EVP_DigestInit_ex(md_ctx, EVP_md5(), NULL)
         && EVP_DigestUpdate(md_ctx, x->bytes->data, x->bytes->length)
         && EVP_DigestFinal_ex(md_ctx, md, NULL))
-        ret = (((unsigned long)md[0]) | ((unsigned long)md[1] << 8L) |
-               ((unsigned long)md[2] << 16L) | ((unsigned long)md[3] << 24L)
+        ret = (((unsigned long)md[0]) |
+               ((unsigned long)md[1] << 8L) |
+               ((unsigned long)md[2] << 16L) |
+               ((unsigned long)md[3] << 24L)
             ) & 0xffffffffL;
     EVP_MD_CTX_free(md_ctx);
 
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -243,9 +249,9 @@ X509 *X509_find_by_issuer_and_serial(STACK_OF(X509) *sk, X509_NAME *name,
     for (i = 0; i < sk_X509_num(sk); i++) {
         x509 = sk_X509_value(sk, i);
         if (X509_issuer_and_serial_cmp(x509, &x) == 0)
-            return (x509);
+            return x509;
     }
-    return (NULL);
+    return NULL;
 }
 
 X509 *X509_find_by_subject(STACK_OF(X509) *sk, X509_NAME *name)
@@ -256,9 +262,9 @@ X509 *X509_find_by_subject(STACK_OF(X509) *sk, X509_NAME *name)
     for (i = 0; i < sk_X509_num(sk); i++) {
         x509 = sk_X509_value(sk, i);
         if (X509_NAME_cmp(X509_get_subject_name(x509), name) == 0)
-            return (x509);
+            return x509;
     }
-    return (NULL);
+    return NULL;
 }
 
 EVP_PKEY *X509_get0_pubkey(const X509 *x)

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -18,18 +18,18 @@ int X509_STORE_set_default_paths(X509_STORE *ctx)
 
     lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_file());
     if (lookup == NULL)
-        return (0);
+        return 0;
     X509_LOOKUP_load_file(lookup, NULL, X509_FILETYPE_DEFAULT);
 
     lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_hash_dir());
     if (lookup == NULL)
-        return (0);
+        return 0;
     X509_LOOKUP_add_dir(lookup, NULL, X509_FILETYPE_DEFAULT);
 
     /* clear any errors */
     ERR_clear_error();
 
-    return (1);
+    return 1;
 }
 
 int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
@@ -40,18 +40,18 @@ int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
     if (file != NULL) {
         lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_file());
         if (lookup == NULL)
-            return (0);
+            return 0;
         if (X509_LOOKUP_load_file(lookup, file, X509_FILETYPE_PEM) != 1)
-            return (0);
+            return 0;
     }
     if (path != NULL) {
         lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_hash_dir());
         if (lookup == NULL)
-            return (0);
+            return 0;
         if (X509_LOOKUP_add_dir(lookup, path, X509_FILETYPE_PEM) != 1)
-            return (0);
+            return 0;
     }
-    if ((path == NULL) && (file == NULL))
-        return (0);
-    return (1);
+    if (path == NULL && file == NULL)
+        return 0;
+    return 1;
 }

--- a/crypto/x509/x509_def.c
+++ b/crypto/x509/x509_def.c
@@ -14,30 +14,30 @@
 
 const char *X509_get_default_private_dir(void)
 {
-    return (X509_PRIVATE_DIR);
+    return X509_PRIVATE_DIR;
 }
 
 const char *X509_get_default_cert_area(void)
 {
-    return (X509_CERT_AREA);
+    return X509_CERT_AREA;
 }
 
 const char *X509_get_default_cert_dir(void)
 {
-    return (X509_CERT_DIR);
+    return X509_CERT_DIR;
 }
 
 const char *X509_get_default_cert_file(void)
 {
-    return (X509_CERT_FILE);
+    return X509_CERT_FILE;
 }
 
 const char *X509_get_default_cert_dir_env(void)
 {
-    return (X509_CERT_DIR_EVP);
+    return X509_CERT_DIR_EVP;
 }
 
 const char *X509_get_default_cert_file_env(void)
 {
-    return (X509_CERT_FILE_EVP);
+    return X509_CERT_FILE_EVP;
 }

--- a/crypto/x509/x509_ext.c
+++ b/crypto/x509/x509_ext.c
@@ -19,33 +19,33 @@
 
 int X509_CRL_get_ext_count(const X509_CRL *x)
 {
-    return (X509v3_get_ext_count(x->crl.extensions));
+    return X509v3_get_ext_count(x->crl.extensions);
 }
 
 int X509_CRL_get_ext_by_NID(const X509_CRL *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->crl.extensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->crl.extensions, nid, lastpos);
 }
 
 int X509_CRL_get_ext_by_OBJ(const X509_CRL *x, const ASN1_OBJECT *obj,
                             int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->crl.extensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->crl.extensions, obj, lastpos);
 }
 
 int X509_CRL_get_ext_by_critical(const X509_CRL *x, int crit, int lastpos)
 {
-    return (X509v3_get_ext_by_critical(x->crl.extensions, crit, lastpos));
+    return X509v3_get_ext_by_critical(x->crl.extensions, crit, lastpos);
 }
 
 X509_EXTENSION *X509_CRL_get_ext(const X509_CRL *x, int loc)
 {
-    return (X509v3_get_ext(x->crl.extensions, loc));
+    return X509v3_get_ext(x->crl.extensions, loc);
 }
 
 X509_EXTENSION *X509_CRL_delete_ext(X509_CRL *x, int loc)
 {
-    return (X509v3_delete_ext(x->crl.extensions, loc));
+    return X509v3_delete_ext(x->crl.extensions, loc);
 }
 
 void *X509_CRL_get_ext_d2i(const X509_CRL *x, int nid, int *crit, int *idx)
@@ -61,43 +61,43 @@ int X509_CRL_add1_ext_i2d(X509_CRL *x, int nid, void *value, int crit,
 
 int X509_CRL_add_ext(X509_CRL *x, X509_EXTENSION *ex, int loc)
 {
-    return (X509v3_add_ext(&(x->crl.extensions), ex, loc) != NULL);
+    return X509v3_add_ext(&(x->crl.extensions), ex, loc) != NULL;
 }
 
 int X509_get_ext_count(const X509 *x)
 {
-    return (X509v3_get_ext_count(x->cert_info.extensions));
+    return X509v3_get_ext_count(x->cert_info.extensions);
 }
 
 int X509_get_ext_by_NID(const X509 *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->cert_info.extensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->cert_info.extensions, nid, lastpos);
 }
 
 int X509_get_ext_by_OBJ(const X509 *x, const ASN1_OBJECT *obj, int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->cert_info.extensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->cert_info.extensions, obj, lastpos);
 }
 
 int X509_get_ext_by_critical(const X509 *x, int crit, int lastpos)
 {
-    return (X509v3_get_ext_by_critical
-            (x->cert_info.extensions, crit, lastpos));
+    return X509v3_get_ext_by_critical
+           (x->cert_info.extensions, crit, lastpos);
 }
 
 X509_EXTENSION *X509_get_ext(const X509 *x, int loc)
 {
-    return (X509v3_get_ext(x->cert_info.extensions, loc));
+    return X509v3_get_ext(x->cert_info.extensions, loc);
 }
 
 X509_EXTENSION *X509_delete_ext(X509 *x, int loc)
 {
-    return (X509v3_delete_ext(x->cert_info.extensions, loc));
+    return X509v3_delete_ext(x->cert_info.extensions, loc);
 }
 
 int X509_add_ext(X509 *x, X509_EXTENSION *ex, int loc)
 {
-    return (X509v3_add_ext(&(x->cert_info.extensions), ex, loc) != NULL);
+    return X509v3_add_ext(&(x->cert_info.extensions), ex, loc) != NULL;
 }
 
 void *X509_get_ext_d2i(const X509 *x, int nid, int *crit, int *idx)
@@ -114,38 +114,38 @@ int X509_add1_ext_i2d(X509 *x, int nid, void *value, int crit,
 
 int X509_REVOKED_get_ext_count(const X509_REVOKED *x)
 {
-    return (X509v3_get_ext_count(x->extensions));
+    return X509v3_get_ext_count(x->extensions);
 }
 
 int X509_REVOKED_get_ext_by_NID(const X509_REVOKED *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->extensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->extensions, nid, lastpos);
 }
 
 int X509_REVOKED_get_ext_by_OBJ(const X509_REVOKED *x, const ASN1_OBJECT *obj,
                                 int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->extensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->extensions, obj, lastpos);
 }
 
 int X509_REVOKED_get_ext_by_critical(const X509_REVOKED *x, int crit, int lastpos)
 {
-    return (X509v3_get_ext_by_critical(x->extensions, crit, lastpos));
+    return X509v3_get_ext_by_critical(x->extensions, crit, lastpos);
 }
 
 X509_EXTENSION *X509_REVOKED_get_ext(const X509_REVOKED *x, int loc)
 {
-    return (X509v3_get_ext(x->extensions, loc));
+    return X509v3_get_ext(x->extensions, loc);
 }
 
 X509_EXTENSION *X509_REVOKED_delete_ext(X509_REVOKED *x, int loc)
 {
-    return (X509v3_delete_ext(x->extensions, loc));
+    return X509v3_delete_ext(x->extensions, loc);
 }
 
 int X509_REVOKED_add_ext(X509_REVOKED *x, X509_EXTENSION *ex, int loc)
 {
-    return (X509v3_add_ext(&(x->extensions), ex, loc) != NULL);
+    return X509v3_add_ext(&(x->extensions), ex, loc) != NULL;
 }
 
 void *X509_REVOKED_get_ext_d2i(const X509_REVOKED *x, int nid, int *crit, int *idx)

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -24,7 +24,7 @@ X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method)
         return NULL;
 
     ret->method = method;
-    if ((method->new_item != NULL) && !method->new_item(ret)) {
+    if (method->new_item != NULL && !method->new_item(ret)) {
         OPENSSL_free(ret);
         return NULL;
     }
@@ -35,7 +35,7 @@ void X509_LOOKUP_free(X509_LOOKUP *ctx)
 {
     if (ctx == NULL)
         return;
-    if ((ctx->method != NULL) && (ctx->method->free != NULL))
+    if (ctx->method != NULL && ctx->method->free != NULL)
         (*ctx->method->free) (ctx);
     OPENSSL_free(ctx);
 }
@@ -84,7 +84,7 @@ int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
 int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                            X509_NAME *name, X509_OBJECT *ret)
 {
-    if ((ctx->method == NULL) || (ctx->method->get_by_subject == NULL))
+    if (ctx->method == NULL || ctx->method->get_by_subject == NULL)
         return 0;
     if (ctx->skip)
         return 0;
@@ -95,7 +95,7 @@ int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                                  X509_NAME *name, ASN1_INTEGER *serial,
                                  X509_OBJECT *ret)
 {
-    if ((ctx->method == NULL) || (ctx->method->get_by_issuer_serial == NULL))
+    if (ctx->method == NULL || ctx->method->get_by_issuer_serial == NULL)
         return 0;
     return ctx->method->get_by_issuer_serial(ctx, type, name, serial, ret);
 }
@@ -104,7 +104,7 @@ int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                                const unsigned char *bytes, int len,
                                X509_OBJECT *ret)
 {
-    if ((ctx->method == NULL) || (ctx->method->get_by_fingerprint == NULL))
+    if (ctx->method == NULL || ctx->method->get_by_fingerprint == NULL)
         return 0;
     return ctx->method->get_by_fingerprint(ctx, type, bytes, len, ret);
 }
@@ -112,7 +112,7 @@ int X509_LOOKUP_by_fingerprint(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
 int X509_LOOKUP_by_alias(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                          const char *str, int len, X509_OBJECT *ret)
 {
-    if ((ctx->method == NULL) || (ctx->method->get_by_alias == NULL))
+    if (ctx->method == NULL || ctx->method->get_by_alias == NULL)
         return 0;
     return ctx->method->get_by_alias(ctx, type, str, len, ret);
 }
@@ -122,7 +122,7 @@ static int x509_object_cmp(const X509_OBJECT *const *a,
 {
     int ret;
 
-    ret = ((*a)->type - (*b)->type);
+    ret = (*a)->type - (*b)->type;
     if (ret)
         return ret;
     switch ((*a)->type) {
@@ -211,7 +211,7 @@ int X509_STORE_up_ref(X509_STORE *vfy)
 
     REF_PRINT_COUNT("X509_STORE", a);
     REF_ASSERT_ISNT(i < 2);
-    return ((i > 1) ? 1 : 0);
+    return i > 1 ? 1 : 0;
 }
 
 X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *v, X509_LOOKUP_METHOD *m)
@@ -561,7 +561,7 @@ X509_OBJECT *X509_OBJECT_retrieve_match(STACK_OF(X509_OBJECT) *h,
     idx = sk_X509_OBJECT_find(h, x);
     if (idx == -1)
         return NULL;
-    if ((x->type != X509_LU_X509) && (x->type != X509_LU_CRL))
+    if (x->type != X509_LU_X509 && x->type != X509_LU_CRL)
         return sk_X509_OBJECT_value(h, idx);
     for (i = idx; i < sk_X509_OBJECT_num(h); i++) {
         obj = sk_X509_OBJECT_value(h, i);

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -63,7 +63,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
     for (i = 0; i < sk_X509_NAME_ENTRY_num(a->entries); i++) {
         ne = sk_X509_NAME_ENTRY_value(a->entries, i);
         n = OBJ_obj2nid(ne->object);
-        if ((n == NID_undef) || ((s = OBJ_nid2sn(n)) == NULL)) {
+        if (n == NID_undef || (s = OBJ_nid2sn(n)) == NULL) {
             i2t_ASN1_OBJECT(tmp_buf, sizeof(tmp_buf), ne->object);
             s = tmp_buf;
         }
@@ -89,7 +89,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         }
 #endif
 
-        if ((type == V_ASN1_GENERALSTRING) && ((num % 4) == 0)) {
+        if (type == V_ASN1_GENERALSTRING && (num % 4) == 0) {
             gs_doit[0] = gs_doit[1] = gs_doit[2] = gs_doit[3] = 0;
             for (j = 0; j < num; j++)
                 if (q[j] != 0)
@@ -109,11 +109,11 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 continue;
             l2++;
 #ifndef CHARSET_EBCDIC
-            if ((q[j] < ' ') || (q[j] > '~'))
+            if (q[j] < ' ' || q[j] > '~')
                 l2 += 3;
 #else
-            if ((os_toascii[q[j]] < os_toascii[' ']) ||
-                (os_toascii[q[j]] > os_toascii['~']))
+            if (os_toascii[q[j]] < os_toascii[' '] ||
+                os_toascii[q[j]] > os_toascii['~'])
                 l2 += 3;
 #endif
         }
@@ -146,7 +146,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 continue;
 #ifndef CHARSET_EBCDIC
             n = q[j];
-            if ((n < ' ') || (n > '~')) {
+            if (n < ' ' || n > '~') {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 *(p++) = hex[(n >> 4) & 0x0f];
@@ -155,7 +155,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 *(p++) = n;
 #else
             n = os_toascii[q[j]];
-            if ((n < os_toascii[' ']) || (n > os_toascii['~'])) {
+            if (n < os_toascii[' '] || n > os_toascii['~']) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 *(p++) = hex[(n >> 4) & 0x0f];
@@ -173,10 +173,10 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         p = buf;
     if (i == 0)
         *p = '\0';
-    return (p);
+    return p;
  err:
     X509err(X509_F_X509_NAME_ONELINE, ERR_R_MALLOC_FAILURE);
  end:
     BUF_MEM_free(b);
-    return (NULL);
+    return NULL;
 }

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -54,24 +54,24 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
         if (!X509_REQ_sign(ret, pkey, md))
             goto err;
     }
-    return (ret);
+    return ret;
  err:
     X509_REQ_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req)
 {
     if (req == NULL)
-        return (NULL);
-    return (X509_PUBKEY_get(req->req_info.pubkey));
+        return NULL;
+    return X509_PUBKEY_get(req->req_info.pubkey);
 }
 
 EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req)
 {
     if (req == NULL)
         return NULL;
-    return (X509_PUBKEY_get0(req->req_info.pubkey));
+    return X509_PUBKEY_get0(req->req_info.pubkey);
 }
 
 X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req)
@@ -115,7 +115,7 @@ int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k)
     }
 
     EVP_PKEY_free(xk);
-    return (ok);
+    return ok;
 }
 
 /*
@@ -157,8 +157,8 @@ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
     int idx, *pnid;
     const unsigned char *p;
 
-    if ((req == NULL) || !ext_nids)
-        return (NULL);
+    if (req == NULL || !ext_nids)
+        return NULL;
     for (pnid = ext_nids; *pnid != NID_undef; pnid++) {
         idx = X509_REQ_get_attr_by_NID(req, *pnid, -1);
         if (idx == -1)

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -21,17 +21,17 @@
 int X509_set_version(X509 *x, long version)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     if (version == 0) {
         ASN1_INTEGER_free(x->cert_info.version);
         x->cert_info.version = NULL;
-        return (1);
+        return 1;
     }
     if (x->cert_info.version == NULL) {
         if ((x->cert_info.version = ASN1_INTEGER_new()) == NULL)
-            return (0);
+            return 0;
     }
-    return (ASN1_INTEGER_set(x->cert_info.version, version));
+    return ASN1_INTEGER_set(x->cert_info.version, version);
 }
 
 int X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial)
@@ -49,15 +49,15 @@ int X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial)
 int X509_set_issuer_name(X509 *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
-    return (X509_NAME_set(&x->cert_info.issuer, name));
+        return 0;
+    return X509_NAME_set(&x->cert_info.issuer, name);
 }
 
 int X509_set_subject_name(X509 *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
-    return (X509_NAME_set(&x->cert_info.subject, name));
+        return 0;
+    return X509_NAME_set(&x->cert_info.subject, name);
 }
 
 int x509_set1_time(ASN1_TIME **ptm, const ASN1_TIME *tm)
@@ -71,7 +71,7 @@ int x509_set1_time(ASN1_TIME **ptm, const ASN1_TIME *tm)
             *ptm = in;
         }
     }
-    return (in != NULL);
+    return in != NULL;
 }
 
 int X509_set1_notBefore(X509 *x, const ASN1_TIME *tm)
@@ -91,8 +91,8 @@ int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm)
 int X509_set_pubkey(X509 *x, EVP_PKEY *pkey)
 {
     if (x == NULL)
-        return (0);
-    return (X509_PUBKEY_set(&(x->cert_info.key), pkey));
+        return 0;
+    return X509_PUBKEY_set(&(x->cert_info.key), pkey);
 }
 
 int X509_up_ref(X509 *x)
@@ -104,7 +104,7 @@ int X509_up_ref(X509 *x)
 
     REF_PRINT_COUNT("X509", x);
     REF_ASSERT_ISNT(i < 2);
-    return ((i > 1) ? 1 : 0);
+    return i > 1 ? 1 : 0;
 }
 
 long X509_get_version(const X509 *x)

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -98,7 +98,7 @@ int X509_TRUST_get_by_id(int id)
 {
     X509_TRUST tmp;
     int idx;
-    if ((id >= X509_TRUST_MIN) && (id <= X509_TRUST_MAX))
+    if (id >= X509_TRUST_MIN && id <= X509_TRUST_MAX)
         return id - X509_TRUST_MIN;
     tmp.trust = id;
     if (!trtable)

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -23,161 +23,161 @@ const char *X509_verify_cert_error_string(long n)
 {
     switch ((int)n) {
     case X509_V_OK:
-        return ("ok");
+        return "ok";
     case X509_V_ERR_UNSPECIFIED:
-        return ("unspecified certificate verification error");
+        return "unspecified certificate verification error";
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
-        return ("unable to get issuer certificate");
+        return "unable to get issuer certificate";
     case X509_V_ERR_UNABLE_TO_GET_CRL:
-        return ("unable to get certificate CRL");
+        return "unable to get certificate CRL";
     case X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE:
-        return ("unable to decrypt certificate's signature");
+        return "unable to decrypt certificate's signature";
     case X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE:
-        return ("unable to decrypt CRL's signature");
+        return "unable to decrypt CRL's signature";
     case X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY:
-        return ("unable to decode issuer public key");
+        return "unable to decode issuer public key";
     case X509_V_ERR_CERT_SIGNATURE_FAILURE:
-        return ("certificate signature failure");
+        return "certificate signature failure";
     case X509_V_ERR_CRL_SIGNATURE_FAILURE:
-        return ("CRL signature failure");
+        return "CRL signature failure";
     case X509_V_ERR_CERT_NOT_YET_VALID:
-        return ("certificate is not yet valid");
+        return "certificate is not yet valid";
     case X509_V_ERR_CERT_HAS_EXPIRED:
-        return ("certificate has expired");
+        return "certificate has expired";
     case X509_V_ERR_CRL_NOT_YET_VALID:
-        return ("CRL is not yet valid");
+        return "CRL is not yet valid";
     case X509_V_ERR_CRL_HAS_EXPIRED:
-        return ("CRL has expired");
+        return "CRL has expired";
     case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
-        return ("format error in certificate's notBefore field");
+        return "format error in certificate's notBefore field";
     case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
-        return ("format error in certificate's notAfter field");
+        return "format error in certificate's notAfter field";
     case X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD:
-        return ("format error in CRL's lastUpdate field");
+        return "format error in CRL's lastUpdate field";
     case X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD:
-        return ("format error in CRL's nextUpdate field");
+        return "format error in CRL's nextUpdate field";
     case X509_V_ERR_OUT_OF_MEM:
-        return ("out of memory");
+        return "out of memory";
     case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
-        return ("self signed certificate");
+        return "self signed certificate";
     case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
-        return ("self signed certificate in certificate chain");
+        return "self signed certificate in certificate chain";
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
-        return ("unable to get local issuer certificate");
+        return "unable to get local issuer certificate";
     case X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE:
-        return ("unable to verify the first certificate");
+        return "unable to verify the first certificate";
     case X509_V_ERR_CERT_CHAIN_TOO_LONG:
-        return ("certificate chain too long");
+        return "certificate chain too long";
     case X509_V_ERR_CERT_REVOKED:
-        return ("certificate revoked");
+        return "certificate revoked";
     case X509_V_ERR_INVALID_CA:
-        return ("invalid CA certificate");
+        return "invalid CA certificate";
     case X509_V_ERR_PATH_LENGTH_EXCEEDED:
-        return ("path length constraint exceeded");
+        return "path length constraint exceeded";
     case X509_V_ERR_INVALID_PURPOSE:
-        return ("unsupported certificate purpose");
+        return "unsupported certificate purpose";
     case X509_V_ERR_CERT_UNTRUSTED:
-        return ("certificate not trusted");
+        return "certificate not trusted";
     case X509_V_ERR_CERT_REJECTED:
-        return ("certificate rejected");
+        return "certificate rejected";
     case X509_V_ERR_SUBJECT_ISSUER_MISMATCH:
-        return ("subject issuer mismatch");
+        return "subject issuer mismatch";
     case X509_V_ERR_AKID_SKID_MISMATCH:
-        return ("authority and subject key identifier mismatch");
+        return "authority and subject key identifier mismatch";
     case X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH:
-        return ("authority and issuer serial number mismatch");
+        return "authority and issuer serial number mismatch";
     case X509_V_ERR_KEYUSAGE_NO_CERTSIGN:
-        return ("key usage does not include certificate signing");
+        return "key usage does not include certificate signing";
     case X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER:
-        return ("unable to get CRL issuer certificate");
+        return "unable to get CRL issuer certificate";
     case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
-        return ("unhandled critical extension");
+        return "unhandled critical extension";
     case X509_V_ERR_KEYUSAGE_NO_CRL_SIGN:
-        return ("key usage does not include CRL signing");
+        return "key usage does not include CRL signing";
     case X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION:
-        return ("unhandled critical CRL extension");
+        return "unhandled critical CRL extension";
     case X509_V_ERR_INVALID_NON_CA:
-        return ("invalid non-CA certificate (has CA markings)");
+        return "invalid non-CA certificate (has CA markings)";
     case X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED:
-        return ("proxy path length constraint exceeded");
+        return "proxy path length constraint exceeded";
     case X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE:
-        return ("key usage does not include digital signature");
+        return "key usage does not include digital signature";
     case X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED:
         return
             ("proxy certificates not allowed, please set the appropriate flag");
     case X509_V_ERR_INVALID_EXTENSION:
-        return ("invalid or inconsistent certificate extension");
+        return "invalid or inconsistent certificate extension";
     case X509_V_ERR_INVALID_POLICY_EXTENSION:
-        return ("invalid or inconsistent certificate policy extension");
+        return "invalid or inconsistent certificate policy extension";
     case X509_V_ERR_NO_EXPLICIT_POLICY:
-        return ("no explicit policy");
+        return "no explicit policy";
     case X509_V_ERR_DIFFERENT_CRL_SCOPE:
-        return ("Different CRL scope");
+        return "Different CRL scope";
     case X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE:
-        return ("Unsupported extension feature");
+        return "Unsupported extension feature";
     case X509_V_ERR_UNNESTED_RESOURCE:
-        return ("RFC 3779 resource not subset of parent's resources");
+        return "RFC 3779 resource not subset of parent's resources";
     case X509_V_ERR_PERMITTED_VIOLATION:
-        return ("permitted subtree violation");
+        return "permitted subtree violation";
     case X509_V_ERR_EXCLUDED_VIOLATION:
-        return ("excluded subtree violation");
+        return "excluded subtree violation";
     case X509_V_ERR_SUBTREE_MINMAX:
-        return ("name constraints minimum and maximum not supported");
+        return "name constraints minimum and maximum not supported";
     case X509_V_ERR_APPLICATION_VERIFICATION:
-        return ("application verification failure");
+        return "application verification failure";
     case X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE:
-        return ("unsupported name constraint type");
+        return "unsupported name constraint type";
     case X509_V_ERR_UNSUPPORTED_CONSTRAINT_SYNTAX:
-        return ("unsupported or invalid name constraint syntax");
+        return "unsupported or invalid name constraint syntax";
     case X509_V_ERR_UNSUPPORTED_NAME_SYNTAX:
-        return ("unsupported or invalid name syntax");
+        return "unsupported or invalid name syntax";
     case X509_V_ERR_CRL_PATH_VALIDATION_ERROR:
-        return ("CRL path validation error");
+        return "CRL path validation error";
     case X509_V_ERR_PATH_LOOP:
-        return ("Path Loop");
+        return "Path Loop";
     case X509_V_ERR_SUITE_B_INVALID_VERSION:
-        return ("Suite B: certificate version invalid");
+        return "Suite B: certificate version invalid";
     case X509_V_ERR_SUITE_B_INVALID_ALGORITHM:
-        return ("Suite B: invalid public key algorithm");
+        return "Suite B: invalid public key algorithm";
     case X509_V_ERR_SUITE_B_INVALID_CURVE:
-        return ("Suite B: invalid ECC curve");
+        return "Suite B: invalid ECC curve";
     case X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM:
-        return ("Suite B: invalid signature algorithm");
+        return "Suite B: invalid signature algorithm";
     case X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED:
-        return ("Suite B: curve not allowed for this LOS");
+        return "Suite B: curve not allowed for this LOS";
     case X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256:
-        return ("Suite B: cannot sign P-384 with P-256");
+        return "Suite B: cannot sign P-384 with P-256";
     case X509_V_ERR_HOSTNAME_MISMATCH:
-        return ("Hostname mismatch");
+        return "Hostname mismatch";
     case X509_V_ERR_EMAIL_MISMATCH:
-        return ("Email address mismatch");
+        return "Email address mismatch";
     case X509_V_ERR_IP_ADDRESS_MISMATCH:
-        return ("IP address mismatch");
+        return "IP address mismatch";
     case X509_V_ERR_DANE_NO_MATCH:
-        return ("No matching DANE TLSA records");
+        return "No matching DANE TLSA records";
     case X509_V_ERR_EE_KEY_TOO_SMALL:
-        return ("EE certificate key too weak");
+        return "EE certificate key too weak";
     case X509_V_ERR_CA_KEY_TOO_SMALL:
-        return ("CA certificate key too weak");
+        return "CA certificate key too weak";
     case X509_V_ERR_CA_MD_TOO_WEAK:
-        return ("CA signature digest algorithm too weak");
+        return "CA signature digest algorithm too weak";
     case X509_V_ERR_INVALID_CALL:
-        return ("Invalid certificate verification context");
+        return "Invalid certificate verification context";
     case X509_V_ERR_STORE_LOOKUP:
-        return ("Issuer certificate lookup error");
+        return "Issuer certificate lookup error";
     case X509_V_ERR_NO_VALID_SCTS:
-        return ("Certificate Transparency required, but no valid SCTs found");
+        return "Certificate Transparency required, but no valid SCTs found";
     case X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION:
-        return ("proxy subject name violation");
+        return "proxy subject name violation";
     case X509_V_ERR_OCSP_VERIFY_NEEDED:
-        return("OCSP verification needed");
+        return "OCSP verification needed";
     case X509_V_ERR_OCSP_VERIFY_FAILED:
-        return("OCSP verification failed");
+        return "OCSP verification failed";
     case X509_V_ERR_OCSP_CERT_UNKNOWN:
-        return("OCSP unknown cert");
+        return "OCSP unknown cert";
 
     default:
         /* Printing an error number into a static buffer is not thread-safe */
-        return ("unknown certificate verification error");
+        return "unknown certificate verification error";
     }
 }

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -20,8 +20,8 @@
 int X509v3_get_ext_count(const STACK_OF(X509_EXTENSION) *x)
 {
     if (x == NULL)
-        return (0);
-    return (sk_X509_EXTENSION_num(x));
+        return 0;
+    return sk_X509_EXTENSION_num(x);
 }
 
 int X509v3_get_ext_by_NID(const STACK_OF(X509_EXTENSION) *x, int nid,
@@ -31,8 +31,8 @@ int X509v3_get_ext_by_NID(const STACK_OF(X509_EXTENSION) *x, int nid,
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return (-2);
-    return (X509v3_get_ext_by_OBJ(x, obj, lastpos));
+        return -2;
+    return X509v3_get_ext_by_OBJ(x, obj, lastpos);
 }
 
 int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
@@ -42,7 +42,7 @@ int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
     X509_EXTENSION *ex;
 
     if (sk == NULL)
-        return (-1);
+        return -1;
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
@@ -50,9 +50,9 @@ int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_EXTENSION_value(sk, lastpos);
         if (OBJ_cmp(ex->object, obj) == 0)
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 int X509v3_get_ext_by_critical(const STACK_OF(X509_EXTENSION) *sk, int crit,
@@ -62,17 +62,17 @@ int X509v3_get_ext_by_critical(const STACK_OF(X509_EXTENSION) *sk, int crit,
     X509_EXTENSION *ex;
 
     if (sk == NULL)
-        return (-1);
+        return -1;
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
     n = sk_X509_EXTENSION_num(sk);
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_EXTENSION_value(sk, lastpos);
-        if (((ex->critical > 0) && crit) || ((ex->critical <= 0) && !crit))
-            return (lastpos);
+        if ((ex->critical > 0 && crit) || (ex->critical <= 0 && !crit))
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 X509_EXTENSION *X509v3_get_ext(const STACK_OF(X509_EXTENSION) *x, int loc)
@@ -88,9 +88,9 @@ X509_EXTENSION *X509v3_delete_ext(STACK_OF(X509_EXTENSION) *x, int loc)
     X509_EXTENSION *ret;
 
     if (x == NULL || sk_X509_EXTENSION_num(x) <= loc || loc < 0)
-        return (NULL);
+        return NULL;
     ret = sk_X509_EXTENSION_delete(x, loc);
-    return (ret);
+    return ret;
 }
 
 STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
@@ -123,13 +123,13 @@ STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
         goto err;
     if (*x == NULL)
         *x = sk;
-    return (sk);
+    return sk;
  err:
     X509err(X509_F_X509V3_ADD_EXT, ERR_R_MALLOC_FAILURE);
  err2:
     X509_EXTENSION_free(new_ex);
     sk_X509_EXTENSION_free(sk);
-    return (NULL);
+    return NULL;
 }
 
 X509_EXTENSION *X509_EXTENSION_create_by_NID(X509_EXTENSION **ex, int nid,
@@ -142,12 +142,12 @@ X509_EXTENSION *X509_EXTENSION_create_by_NID(X509_EXTENSION **ex, int nid,
     obj = OBJ_nid2obj(nid);
     if (obj == NULL) {
         X509err(X509_F_X509_EXTENSION_CREATE_BY_NID, X509_R_UNKNOWN_NID);
-        return (NULL);
+        return NULL;
     }
     ret = X509_EXTENSION_create_by_OBJ(ex, obj, crit, data);
     if (ret == NULL)
         ASN1_OBJECT_free(obj);
-    return (ret);
+    return ret;
 }
 
 X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **ex,
@@ -156,11 +156,11 @@ X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **ex,
 {
     X509_EXTENSION *ret;
 
-    if ((ex == NULL) || (*ex == NULL)) {
+    if (ex == NULL || *ex == NULL) {
         if ((ret = X509_EXTENSION_new()) == NULL) {
             X509err(X509_F_X509_EXTENSION_CREATE_BY_OBJ,
                     ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else
         ret = *ex;
@@ -172,19 +172,19 @@ X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **ex,
     if (!X509_EXTENSION_set_data(ret, data))
         goto err;
 
-    if ((ex != NULL) && (*ex == NULL))
+    if (ex != NULL && *ex == NULL)
         *ex = ret;
-    return (ret);
+    return ret;
  err:
-    if ((ex == NULL) || (ret != *ex))
+    if (ex == NULL || ret != *ex)
         X509_EXTENSION_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 int X509_EXTENSION_set_object(X509_EXTENSION *ex, const ASN1_OBJECT *obj)
 {
-    if ((ex == NULL) || (obj == NULL))
-        return (0);
+    if (ex == NULL || obj == NULL)
+        return 0;
     ASN1_OBJECT_free(ex->object);
     ex->object = OBJ_dup(obj);
     return ex->object != NULL;
@@ -193,9 +193,9 @@ int X509_EXTENSION_set_object(X509_EXTENSION *ex, const ASN1_OBJECT *obj)
 int X509_EXTENSION_set_critical(X509_EXTENSION *ex, int crit)
 {
     if (ex == NULL)
-        return (0);
+        return 0;
     ex->critical = (crit) ? 0xFF : -1;
-    return (1);
+    return 1;
 }
 
 int X509_EXTENSION_set_data(X509_EXTENSION *ex, ASN1_OCTET_STRING *data)
@@ -203,31 +203,31 @@ int X509_EXTENSION_set_data(X509_EXTENSION *ex, ASN1_OCTET_STRING *data)
     int i;
 
     if (ex == NULL)
-        return (0);
+        return 0;
     i = ASN1_OCTET_STRING_set(&ex->value, data->data, data->length);
     if (!i)
-        return (0);
-    return (1);
+        return 0;
+    return 1;
 }
 
 ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *ex)
 {
     if (ex == NULL)
-        return (NULL);
-    return (ex->object);
+        return NULL;
+    return ex->object;
 }
 
 ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *ex)
 {
     if (ex == NULL)
-        return (NULL);
+        return NULL;
     return &ex->value;
 }
 
 int X509_EXTENSION_get_critical(const X509_EXTENSION *ex)
 {
     if (ex == NULL)
-        return (0);
+        return 0;
     if (ex->critical > 0)
         return 1;
     return 0;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -275,7 +275,7 @@ int X509_verify_cert(X509_STORE_CTX *ctx)
      * the first entry is in place
      */
     if (((ctx->chain = sk_X509_new_null()) == NULL) ||
-        (!sk_X509_push(ctx->chain, ctx->cert))) {
+        !sk_X509_push(ctx->chain, ctx->cert)) {
         X509err(X509_F_X509_VERIFY_CERT, ERR_R_MALLOC_FAILURE);
         ctx->error = X509_V_ERR_OUT_OF_MEM;
         return -1;
@@ -345,7 +345,7 @@ static int check_issued(X509_STORE_CTX *ctx, X509 *x, X509 *issuer)
         }
     }
 
-    return (ret == X509_V_OK);
+    return ret == X509_V_OK;
 }
 
 /* Alternative lookup method: look from a STACK stored in other_ctx */
@@ -484,7 +484,7 @@ static int check_chain_extensions(X509_STORE_CTX *ctx)
         switch (must_be_ca) {
         case -1:
             if ((ctx->param->flags & X509_V_FLAG_X509_STRICT)
-                && (ret != 1) && (ret != 0)) {
+                && ret != 1 && ret != 0) {
                 ret = 0;
                 ctx->error = X509_V_ERR_INVALID_CA;
             } else
@@ -499,9 +499,9 @@ static int check_chain_extensions(X509_STORE_CTX *ctx)
             break;
         default:
             /* X509_V_FLAG_X509_STRICT is implicit for intermediate CAs */
-            if ((ret == 0)
+            if (ret == 0
                 || ((i + 1 < num || ctx->param->flags & X509_V_FLAG_X509_STRICT)
-                    && (ret != 1))) {
+                    && ret != 1)) {
                 ret = 0;
                 ctx->error = X509_V_ERR_INVALID_CA;
             } else
@@ -514,7 +514,7 @@ static int check_chain_extensions(X509_STORE_CTX *ctx)
         if (purpose > 0 && !check_purpose(ctx, x, purpose, i, must_be_ca))
             return 0;
         /* Check pathlen if not self issued */
-        if ((i > 1) && !(x->ex_flags & EXFLAG_SI)
+        if (i > 1 && !(x->ex_flags & EXFLAG_SI)
             && (x->ex_pathlen != -1)
             && (plen > (x->ex_pathlen + proxy_path_length + 1))) {
             if (!verify_cb_cert(ctx, x, i, X509_V_ERR_PATH_LENGTH_EXCEEDED))
@@ -948,7 +948,7 @@ static int check_crl_time(X509_STORE_CTX *ctx, X509_CRL *crl, int notify)
                 return 0;
         }
         /* Ignore expiry of base CRL is delta is valid */
-        if ((i < 0) && !(ctx->current_crl_score & CRL_SCORE_TIME_DELTA)) {
+        if (i < 0 && !(ctx->current_crl_score & CRL_SCORE_TIME_DELTA)) {
             if (!notify)
                 return 0;
             if (!verify_cb_crl(ctx, X509_V_ERR_CRL_HAS_EXPIRED))
@@ -1852,7 +1852,7 @@ int X509_get_pubkey_parameters(EVP_PKEY *pkey, STACK_OF(X509) *chain)
     EVP_PKEY *ktmp = NULL, *ktmp2;
     int i, j;
 
-    if ((pkey != NULL) && !EVP_PKEY_missing_parameters(pkey))
+    if (pkey != NULL && !EVP_PKEY_missing_parameters(pkey))
         return 1;
 
     for (i = 0; i < sk_X509_num(chain); i++) {

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -145,7 +145,7 @@ void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param)
 
 #define test_x509_verify_param_copy(field, def) \
         (to_overwrite || \
-                ((src->field != def) && (to_default || (dest->field == def))))
+                (src->field != def && (to_default || dest->field == def)))
 
 /* Macro to test and copy a field if necessary */
 

--- a/crypto/x509/x509cset.c
+++ b/crypto/x509/x509cset.c
@@ -18,19 +18,19 @@
 int X509_CRL_set_version(X509_CRL *x, long version)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     if (x->crl.version == NULL) {
         if ((x->crl.version = ASN1_INTEGER_new()) == NULL)
-            return (0);
+            return 0;
     }
-    return (ASN1_INTEGER_set(x->crl.version, version));
+    return ASN1_INTEGER_set(x->crl.version, version);
 }
 
 int X509_CRL_set_issuer_name(X509_CRL *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
-    return (X509_NAME_set(&x->crl.issuer, name));
+        return 0;
+    return X509_NAME_set(&x->crl.issuer, name);
 }
 
 int X509_CRL_set1_lastUpdate(X509_CRL *x, const ASN1_TIME *tm)
@@ -72,7 +72,7 @@ int X509_CRL_up_ref(X509_CRL *crl)
 
     REF_PRINT_COUNT("X509_CRL", crl);
     REF_ASSERT_ISNT(i < 2);
-    return ((i > 1) ? 1 : 0);
+    return i > 1 ? 1 : 0;
 }
 
 long X509_CRL_get_version(const X509_CRL *crl)
@@ -141,7 +141,7 @@ int X509_REVOKED_set_revocationDate(X509_REVOKED *x, ASN1_TIME *tm)
     ASN1_TIME *in;
 
     if (x == NULL)
-        return (0);
+        return 0;
     in = x->revocationDate;
     if (in != tm) {
         in = ASN1_STRING_dup(tm);
@@ -150,7 +150,7 @@ int X509_REVOKED_set_revocationDate(X509_REVOKED *x, ASN1_TIME *tm)
             x->revocationDate = in;
         }
     }
-    return (in != NULL);
+    return in != NULL;
 }
 
 const ASN1_INTEGER *X509_REVOKED_get0_serialNumber(const X509_REVOKED *x)
@@ -163,7 +163,7 @@ int X509_REVOKED_set_serialNumber(X509_REVOKED *x, ASN1_INTEGER *serial)
     ASN1_INTEGER *in;
 
     if (x == NULL)
-        return (0);
+        return 0;
     in = &x->serialNumber;
     if (in != serial)
         return ASN1_STRING_copy(in, serial);

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -22,8 +22,8 @@ int X509_NAME_get_text_by_NID(X509_NAME *name, int nid, char *buf, int len)
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return (-1);
-    return (X509_NAME_get_text_by_OBJ(name, obj, buf, len));
+        return -1;
+    return X509_NAME_get_text_by_OBJ(name, obj, buf, len);
 }
 
 int X509_NAME_get_text_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, char *buf,
@@ -34,21 +34,21 @@ int X509_NAME_get_text_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, char *buf
 
     i = X509_NAME_get_index_by_OBJ(name, obj, -1);
     if (i < 0)
-        return (-1);
+        return -1;
     data = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     i = (data->length > (len - 1)) ? (len - 1) : data->length;
     if (buf == NULL)
-        return (data->length);
+        return data->length;
     memcpy(buf, data->data, i);
     buf[i] = '\0';
-    return (i);
+    return i;
 }
 
 int X509_NAME_entry_count(const X509_NAME *name)
 {
     if (name == NULL)
-        return (0);
-    return (sk_X509_NAME_ENTRY_num(name->entries));
+        return 0;
+    return sk_X509_NAME_ENTRY_num(name->entries);
 }
 
 int X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos)
@@ -57,8 +57,8 @@ int X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos)
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return (-2);
-    return (X509_NAME_get_index_by_OBJ(name, obj, lastpos));
+        return -2;
+    return X509_NAME_get_index_by_OBJ(name, obj, lastpos);
 }
 
 /* NOTE: you should be passing -1, not 0 as lastpos */
@@ -69,7 +69,7 @@ int X509_NAME_get_index_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, int last
     STACK_OF(X509_NAME_ENTRY) *sk;
 
     if (name == NULL)
-        return (-1);
+        return -1;
     if (lastpos < 0)
         lastpos = -1;
     sk = name->entries;
@@ -77,9 +77,9 @@ int X509_NAME_get_index_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, int last
     for (lastpos++; lastpos < n; lastpos++) {
         ne = sk_X509_NAME_ENTRY_value(sk, lastpos);
         if (OBJ_cmp(ne->object, obj) == 0)
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 X509_NAME_ENTRY *X509_NAME_get_entry(const X509_NAME *name, int loc)
@@ -186,7 +186,7 @@ int X509_NAME_add_entry(X509_NAME *name, const X509_NAME_ENTRY *ne, int loc,
     STACK_OF(X509_NAME_ENTRY) *sk;
 
     if (name == NULL)
-        return (0);
+        return 0;
     sk = name->entries;
     n = sk_X509_NAME_ENTRY_num(sk);
     if (loc > n)
@@ -232,10 +232,10 @@ int X509_NAME_add_entry(X509_NAME *name, const X509_NAME_ENTRY *ne, int loc,
         for (i = loc + 1; i < n; i++)
             sk_X509_NAME_ENTRY_value(sk, i - 1)->set += 1;
     }
-    return (1);
+    return 1;
  err:
     X509_NAME_ENTRY_free(new_name);
-    return (0);
+    return 0;
 }
 
 X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_txt(X509_NAME_ENTRY **ne,
@@ -251,7 +251,7 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_txt(X509_NAME_ENTRY **ne,
         X509err(X509_F_X509_NAME_ENTRY_CREATE_BY_TXT,
                 X509_R_INVALID_FIELD_NAME);
         ERR_add_error_data(2, "name=", field);
-        return (NULL);
+        return NULL;
     }
     nentry = X509_NAME_ENTRY_create_by_OBJ(ne, obj, type, bytes, len);
     ASN1_OBJECT_free(obj);
@@ -269,7 +269,7 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_NID(X509_NAME_ENTRY **ne, int nid,
     obj = OBJ_nid2obj(nid);
     if (obj == NULL) {
         X509err(X509_F_X509_NAME_ENTRY_CREATE_BY_NID, X509_R_UNKNOWN_NID);
-        return (NULL);
+        return NULL;
     }
     nentry = X509_NAME_ENTRY_create_by_OBJ(ne, obj, type, bytes, len);
     ASN1_OBJECT_free(obj);
@@ -283,9 +283,9 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_OBJ(X509_NAME_ENTRY **ne,
 {
     X509_NAME_ENTRY *ret;
 
-    if ((ne == NULL) || (*ne == NULL)) {
+    if (ne == NULL || *ne == NULL) {
         if ((ret = X509_NAME_ENTRY_new()) == NULL)
-            return (NULL);
+            return NULL;
     } else
         ret = *ne;
 
@@ -294,25 +294,25 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_OBJ(X509_NAME_ENTRY **ne,
     if (!X509_NAME_ENTRY_set_data(ret, type, bytes, len))
         goto err;
 
-    if ((ne != NULL) && (*ne == NULL))
+    if (ne != NULL && *ne == NULL)
         *ne = ret;
-    return (ret);
+    return ret;
  err:
-    if ((ne == NULL) || (ret != *ne))
+    if (ne == NULL || ret != *ne)
         X509_NAME_ENTRY_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 int X509_NAME_ENTRY_set_object(X509_NAME_ENTRY *ne, const ASN1_OBJECT *obj)
 {
-    if ((ne == NULL) || (obj == NULL)) {
+    if (ne == NULL || obj == NULL) {
         X509err(X509_F_X509_NAME_ENTRY_SET_OBJECT,
                 ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     ASN1_OBJECT_free(ne->object);
     ne->object = OBJ_dup(obj);
-    return ((ne->object == NULL) ? 0 : 1);
+    return ne->object == NULL ? 0 : 1;
 }
 
 int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
@@ -320,9 +320,9 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
 {
     int i;
 
-    if ((ne == NULL) || ((bytes == NULL) && (len != 0)))
-        return (0);
-    if ((type > 0) && (type & MBSTRING_FLAG))
+    if (ne == NULL || (bytes == NULL && len != 0))
+        return 0;
+    if (type > 0 && (type & MBSTRING_FLAG))
         return ASN1_STRING_set_by_NID(&ne->value, bytes,
                                       len, type,
                                       OBJ_obj2nid(ne->object)) ? 1 : 0;
@@ -330,28 +330,28 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
         len = strlen((const char *)bytes);
     i = ASN1_STRING_set(ne->value, bytes, len);
     if (!i)
-        return (0);
+        return 0;
     if (type != V_ASN1_UNDEF) {
         if (type == V_ASN1_APP_CHOOSE)
             ne->value->type = ASN1_PRINTABLE_type(bytes, len);
         else
             ne->value->type = type;
     }
-    return (1);
+    return 1;
 }
 
 ASN1_OBJECT *X509_NAME_ENTRY_get_object(const X509_NAME_ENTRY *ne)
 {
     if (ne == NULL)
-        return (NULL);
-    return (ne->object);
+        return NULL;
+    return ne->object;
 }
 
 ASN1_STRING *X509_NAME_ENTRY_get_data(const X509_NAME_ENTRY *ne)
 {
     if (ne == NULL)
-        return (NULL);
-    return (ne->value);
+        return NULL;
+    return ne->value;
 }
 
 int X509_NAME_ENTRY_set(const X509_NAME_ENTRY *ne)

--- a/crypto/x509/x509rset.c
+++ b/crypto/x509/x509rset.c
@@ -18,23 +18,23 @@
 int X509_REQ_set_version(X509_REQ *x, long version)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     x->req_info.enc.modified = 1;
-    return (ASN1_INTEGER_set(x->req_info.version, version));
+    return ASN1_INTEGER_set(x->req_info.version, version);
 }
 
 int X509_REQ_set_subject_name(X509_REQ *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     x->req_info.enc.modified = 1;
-    return (X509_NAME_set(&x->req_info.subject, name));
+    return X509_NAME_set(&x->req_info.subject, name);
 }
 
 int X509_REQ_set_pubkey(X509_REQ *x, EVP_PKEY *pkey)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     x->req_info.enc.modified = 1;
-    return (X509_PUBKEY_set(&x->req_info.pubkey, pkey));
+    return X509_PUBKEY_set(&x->req_info.pubkey, pkey);
 }

--- a/crypto/x509/x509spki.c
+++ b/crypto/x509/x509spki.c
@@ -13,16 +13,16 @@
 
 int NETSCAPE_SPKI_set_pubkey(NETSCAPE_SPKI *x, EVP_PKEY *pkey)
 {
-    if ((x == NULL) || (x->spkac == NULL))
-        return (0);
-    return (X509_PUBKEY_set(&(x->spkac->pubkey), pkey));
+    if (x == NULL || x->spkac == NULL)
+        return 0;
+    return X509_PUBKEY_set(&(x->spkac->pubkey), pkey);
 }
 
 EVP_PKEY *NETSCAPE_SPKI_get_pubkey(NETSCAPE_SPKI *x)
 {
-    if ((x == NULL) || (x->spkac == NULL))
-        return (NULL);
-    return (X509_PUBKEY_get(x->spkac->pubkey));
+    if (x == NULL || x->spkac == NULL)
+        return NULL;
+    return X509_PUBKEY_get(x->spkac->pubkey);
 }
 
 /* Load a Netscape SPKI from a base64 encoded string */

--- a/crypto/x509/x509type.c
+++ b/crypto/x509/x509type.c
@@ -19,7 +19,7 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
     int ret = 0, i;
 
     if (x == NULL)
-        return (0);
+        return 0;
 
     if (pkey == NULL)
         pk = X509_get0_pubkey(x);
@@ -27,7 +27,7 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
         pk = pkey;
 
     if (pk == NULL)
-        return (0);
+        return 0;
 
     switch (EVP_PKEY_id(pk)) {
     case EVP_PKEY_RSA:
@@ -76,5 +76,5 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
         }
     }
 
-    return (ret);
+    return ret;
 }

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -24,28 +24,28 @@ int X509_verify(X509 *a, EVP_PKEY *r)
 {
     if (X509_ALGOR_cmp(&a->sig_alg, &a->cert_info.signature))
         return 0;
-    return (ASN1_item_verify(ASN1_ITEM_rptr(X509_CINF), &a->sig_alg,
-                             &a->signature, &a->cert_info, r));
+    return ASN1_item_verify(ASN1_ITEM_rptr(X509_CINF), &a->sig_alg,
+                            &a->signature, &a->cert_info, r);
 }
 
 int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r)
 {
-    return (ASN1_item_verify(ASN1_ITEM_rptr(X509_REQ_INFO),
-                             &a->sig_alg, a->signature, &a->req_info, r));
+    return ASN1_item_verify(ASN1_ITEM_rptr(X509_REQ_INFO),
+                            &a->sig_alg, a->signature, &a->req_info, r);
 }
 
 int NETSCAPE_SPKI_verify(NETSCAPE_SPKI *a, EVP_PKEY *r)
 {
-    return (ASN1_item_verify(ASN1_ITEM_rptr(NETSCAPE_SPKAC),
-                             &a->sig_algor, a->signature, a->spkac, r));
+    return ASN1_item_verify(ASN1_ITEM_rptr(NETSCAPE_SPKAC),
+                            &a->sig_algor, a->signature, a->spkac, r);
 }
 
 int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
     x->cert_info.enc.modified = 1;
-    return (ASN1_item_sign(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
-                           &x->sig_alg, &x->signature, &x->cert_info, pkey,
-                           md));
+    return ASN1_item_sign(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
+                          &x->sig_alg, &x->signature, &x->cert_info, pkey,
+                          md);
 }
 
 int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx)
@@ -66,8 +66,8 @@ int X509_http_nbio(OCSP_REQ_CTX *rctx, X509 **pcert)
 
 int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    return (ASN1_item_sign(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
-                           x->signature, &x->req_info, pkey, md));
+    return ASN1_item_sign(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
+                          x->signature, &x->req_info, pkey, md);
 }
 
 int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx)
@@ -80,8 +80,8 @@ int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx)
 int X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
     x->crl.enc.modified = 1;
-    return (ASN1_item_sign(ASN1_ITEM_rptr(X509_CRL_INFO), &x->crl.sig_alg,
-                           &x->sig_alg, &x->signature, &x->crl, pkey, md));
+    return ASN1_item_sign(ASN1_ITEM_rptr(X509_CRL_INFO), &x->crl.sig_alg,
+                          &x->sig_alg, &x->signature, &x->crl, pkey, md);
 }
 
 int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx)
@@ -103,8 +103,8 @@ int X509_CRL_http_nbio(OCSP_REQ_CTX *rctx, X509_CRL **pcrl)
 
 int NETSCAPE_SPKI_sign(NETSCAPE_SPKI *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    return (ASN1_item_sign(ASN1_ITEM_rptr(NETSCAPE_SPKAC), &x->sig_algor, NULL,
-                           x->signature, x->spkac, pkey, md));
+    return ASN1_item_sign(ASN1_ITEM_rptr(NETSCAPE_SPKAC), &x->sig_algor, NULL,
+                          x->signature, x->spkac, pkey, md);
 }
 
 #ifndef OPENSSL_NO_STDIO
@@ -370,8 +370,8 @@ int X509_digest(const X509 *data, const EVP_MD *type, unsigned char *md,
         memcpy(md, data->sha1_hash, sizeof(data->sha1_hash));
         return 1;
     }
-    return (ASN1_item_digest
-            (ASN1_ITEM_rptr(X509), type, (char *)data, md, len));
+    return ASN1_item_digest
+           (ASN1_ITEM_rptr(X509), type, (char *)data, md, len);
 }
 
 int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
@@ -384,30 +384,30 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
         memcpy(md, data->sha1_hash, sizeof(data->sha1_hash));
         return 1;
     }
-    return (ASN1_item_digest
-            (ASN1_ITEM_rptr(X509_CRL), type, (char *)data, md, len));
+    return ASN1_item_digest
+           (ASN1_ITEM_rptr(X509_CRL), type, (char *)data, md, len);
 }
 
 int X509_REQ_digest(const X509_REQ *data, const EVP_MD *type,
                     unsigned char *md, unsigned int *len)
 {
-    return (ASN1_item_digest
-            (ASN1_ITEM_rptr(X509_REQ), type, (char *)data, md, len));
+    return ASN1_item_digest
+           (ASN1_ITEM_rptr(X509_REQ), type, (char *)data, md, len);
 }
 
 int X509_NAME_digest(const X509_NAME *data, const EVP_MD *type,
                      unsigned char *md, unsigned int *len)
 {
-    return (ASN1_item_digest
-            (ASN1_ITEM_rptr(X509_NAME), type, (char *)data, md, len));
+    return ASN1_item_digest
+           (ASN1_ITEM_rptr(X509_NAME), type, (char *)data, md, len);
 }
 
 int PKCS7_ISSUER_AND_SERIAL_digest(PKCS7_ISSUER_AND_SERIAL *data,
                                    const EVP_MD *type, unsigned char *md,
                                    unsigned int *len)
 {
-    return (ASN1_item_digest(ASN1_ITEM_rptr(PKCS7_ISSUER_AND_SERIAL), type,
-                             (char *)data, md, len));
+    return ASN1_item_digest(ASN1_ITEM_rptr(PKCS7_ISSUER_AND_SERIAL), type,
+                            (char *)data, md, len);
 }
 
 #ifndef OPENSSL_NO_STDIO

--- a/crypto/x509/x_attrib.c
+++ b/crypto/x509/x_attrib.c
@@ -39,7 +39,7 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create(int nid, int atrtype, void *value)
     ASN1_TYPE *val = NULL;
 
     if ((ret = X509_ATTRIBUTE_new()) == NULL)
-        return (NULL);
+        return NULL;
     ret->object = OBJ_nid2obj(nid);
     if ((val = ASN1_TYPE_new()) == NULL)
         goto err;
@@ -47,9 +47,9 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create(int nid, int atrtype, void *value)
         goto err;
 
     ASN1_TYPE_set(val, atrtype, value);
-    return (ret);
+    return ret;
  err:
     X509_ATTRIBUTE_free(ret);
     ASN1_TYPE_free(val);
-    return (NULL);
+    return NULL;
 }

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -210,9 +210,9 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                 crl->flags |= EXFLAG_FRESHEST;
             if (X509_EXTENSION_get_critical(ext)) {
                 /* We handle IDP and deltas */
-                if ((nid == NID_issuing_distribution_point)
-                    || (nid == NID_authority_key_identifier)
-                    || (nid == NID_delta_crl))
+                if (nid == NID_issuing_distribution_point
+                    || nid == NID_authority_key_identifier
+                    || nid == NID_delta_crl)
                     continue;
                 crl->flags |= EXFLAG_CRITICAL;
                 break;
@@ -302,8 +302,8 @@ IMPLEMENT_ASN1_DUP_FUNCTION(X509_CRL)
 static int X509_REVOKED_cmp(const X509_REVOKED *const *a,
                             const X509_REVOKED *const *b)
 {
-    return (ASN1_STRING_cmp((ASN1_STRING *)&(*a)->serialNumber,
-                            (ASN1_STRING *)&(*b)->serialNumber));
+    return ASN1_STRING_cmp((ASN1_STRING *)&(*a)->serialNumber,
+                           (ASN1_STRING *)&(*b)->serialNumber);
 }
 
 int X509_CRL_add0_revoked(X509_CRL *crl, X509_REVOKED *rev)

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -476,7 +476,7 @@ int X509_NAME_set(X509_NAME **xn, X509_NAME *name)
     X509_NAME *in;
 
     if (!xn || !name)
-        return (0);
+        return 0;
 
     if (*xn != name) {
         in = X509_NAME_dup(name);
@@ -485,7 +485,7 @@ int X509_NAME_set(X509_NAME **xn, X509_NAME *name)
             *xn = in;
         }
     }
-    return (*xn != NULL);
+    return *xn != NULL;
 }
 
 int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
@@ -506,10 +506,10 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
 
     c = s;
     for (;;) {
-        if (((*s == '/') &&
-             (ossl_isupper(s[1]) && ((s[2] == '=') ||
-                                (ossl_isupper(s[2]) && (s[3] == '='))
-              ))) || (*s == '\0'))
+        if ((*s == '/' &&
+             (ossl_isupper(s[1]) && (s[2] == '=' ||
+                                (ossl_isupper(s[2]) && s[3] == '=')
+              ))) || *s == '\0')
         {
             i = s - c;
             if (BIO_write(bp, c, i) != i)

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -61,7 +61,7 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
     X509_PUBKEY *pk = NULL;
 
     if (x == NULL)
-        return (0);
+        return 0;
 
     if ((pk = X509_PUBKEY_new()) == NULL)
         goto error;
@@ -304,17 +304,17 @@ EC_KEY *d2i_EC_PUBKEY(EC_KEY **a, const unsigned char **pp, long length)
     q = *pp;
     pkey = d2i_PUBKEY(NULL, &q, length);
     if (!pkey)
-        return (NULL);
+        return NULL;
     key = EVP_PKEY_get1_EC_KEY(pkey);
     EVP_PKEY_free(pkey);
     if (!key)
-        return (NULL);
+        return NULL;
     *pp = q;
     if (a) {
         EC_KEY_free(*a);
         *a = key;
     }
-    return (key);
+    return key;
 }
 
 int i2d_EC_PUBKEY(EC_KEY *a, unsigned char **pp)
@@ -322,15 +322,15 @@ int i2d_EC_PUBKEY(EC_KEY *a, unsigned char **pp)
     EVP_PKEY *pktmp;
     int ret;
     if (!a)
-        return (0);
+        return 0;
     if ((pktmp = EVP_PKEY_new()) == NULL) {
         ASN1err(ASN1_F_I2D_EC_PUBKEY, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
     EVP_PKEY_set1_EC_KEY(pktmp, a);
     ret = i2d_PUBKEY(pktmp, pp);
     EVP_PKEY_free(pktmp);
-    return (ret);
+    return ret;
 }
 #endif
 

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -89,12 +89,12 @@ IMPLEMENT_ASN1_DUP_FUNCTION(X509)
 
 int X509_set_ex_data(X509 *r, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&r->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&r->ex_data, idx, arg);
 }
 
 void *X509_get_ex_data(X509 *r, int idx)
 {
-    return (CRYPTO_get_ex_data(&r->ex_data, idx));
+    return CRYPTO_get_ex_data(&r->ex_data, idx);
 }
 
 /*


### PR DESCRIPTION
Remove redundant parenthesis from `return` statements and
from combined comparisons, as in `if ((x == NULL) || (b > 0))`,
plus few more similar cases.

