### PR TITLE
Make it easier to add new compilers to use --strict-warnings with

### DIFF
--- a/Configurations/90-team.conf
+++ b/Configurations/90-team.conf
@@ -16,7 +16,8 @@
     "debug-erbridge" => {
         inherit_from     => [ "x86_64_asm" ],
         cc               => "gcc",
-        cflags           => combine("$gcc_devteam_warn -DBN_DEBUG -DCONF_DEBUG -m64 -DL_ENDIAN -DTERMIO -g",
+        cflags           => combine($devteam_common_warn,
+                                    "-DBN_DEBUG -DCONF_DEBUG -m64 -DL_ENDIAN -DTERMIO -g",
                                     threads("-D_REENTRANT")),
         ex_libs          => add(" ","-ldl"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -84,7 +85,8 @@
     "debug-test-64-clang" => {
         inherit_from     => [ "x86_64_asm" ],
         cc               => "clang",
-        cflags           => combine("$gcc_devteam_warn -Wno-error=overlength-strings -Wno-error=extended-offsetof -Wno-error=language-extension-token -Wno-error=unused-const-variable -Wstrict-overflow -Qunused-arguments -DBN_DEBUG -DCONF_DEBUG -DDEBUG_SAFESTACK -DDEBUG_UNUSED -g3 -O3 -pipe",
+        cflags           => combine($devteam_common_warn,
+                                    "-Wno-error=overlength-strings -Wno-error=extended-offsetof -Wno-error=language-extension-token -Wno-error=unused-const-variable -Wstrict-overflow -Qunused-arguments -DBN_DEBUG -DCONF_DEBUG -DDEBUG_SAFESTACK -DDEBUG_UNUSED -g3 -O3 -pipe",
                                     threads("${BSDthreads}")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
@@ -97,7 +99,9 @@
     "darwin64-debug-test-64-clang" => {
         inherit_from     => [ "x86_64_asm" ],
         cc               => "clang",
-        cflags           => combine("-arch x86_64 -DL_ENDIAN $gcc_devteam_warn -Wno-error=overlength-strings -Wno-error=extended-offsetof -Wno-error=language-extension-token -Wno-error=unused-const-variable -Wstrict-overflow -Qunused-arguments -DBN_DEBUG -DCONF_DEBUG -DDEBUG_SAFESTACK -DDEBUG_UNUSED -g3 -O3 -pipe",
+        cflags           => combine("-arch x86_64 -DL_ENDIAN",
+                                    $devteam_common_warn,
+                                    "-Wno-error=overlength-strings -Wno-error=extended-offsetof -Wno-error=language-extension-token -Wno-error=unused-const-variable -Wstrict-overflow -Qunused-arguments -DBN_DEBUG -DCONF_DEBUG -DDEBUG_SAFESTACK -DDEBUG_UNUSED -g3 -O3 -pipe",
                                     threads("${BSDthreads}")),
         sys_id           => "MACOSX",
         bn_ops           => "SIXTY_FOUR_BIT_LONG",

--- a/Configure
+++ b/Configure
@@ -116,7 +116,8 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # code, so we just tell compiler to be pedantic about everything
 # but 'long long' type.
 
-my $gcc_devteam_warn = "-DDEBUG_UNUSED"
+# These are common to all GCC compatible compilers
+our $devteam_common_warn = "-DDEBUG_UNUSED"
         . " -DPEDANTIC -pedantic -Wno-long-long"
         . " -Wall"
         . " -Wextra"
@@ -132,7 +133,11 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
         . " -Werror"
         ;
 
-# These are used in addition to $gcc_devteam_warn when the compiler is clang.
+# In addition to the warning options above, select compilers get their own
+# set of additional warning options.  Use a compiler specific predefined
+# macro as index.
+our %devteam_additional_warn = ();
+
 # TODO(openssl-team): fix problems and investigate if (at least) the
 # following warnings can also be enabled:
 #       -Wcast-align
@@ -140,7 +145,7 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 #       -Wlanguage-extension-token -- no, we use asm()
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
-my $clang_devteam_warn = ""
+$devteam_additional_warn{__clang__} = ""
         . " -Wswitch-default"
         . " -Wno-parentheses-equality"
         . " -Wno-language-extension-token"
@@ -1329,17 +1334,23 @@ if ($strict_warnings)
 	{
 	my $wopt;
 	my $gccver = $predefined{__GNUC__} // -1;
+	my $extra_gcc_warn = undef;
 
 	die "ERROR --strict-warnings requires gcc[>=4] or gcc-alike"
             unless $gccver >= 4;
-	$gcc_devteam_warn .= " -Wmisleading-indentation" if $gccver >= 6;
-	foreach $wopt (split /\s+/, $gcc_devteam_warn)
+	$extra_gcc_warn = "-Wmisleading-indentation" if $gccver >= 6;
+	foreach $wopt (split /\s+/, $devteam_common_warn)
 		{
 		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
 		}
-	if (defined($predefined{__clang__}))
+	foreach $wopt (split /\s+/, $extra_gcc_warn)
 		{
-		foreach $wopt (split /\s+/, $clang_devteam_warn)
+		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+		}
+	foreach my $ecc (grep { defined($predefined{$_}) }
+			 keys %devteam_additional_warn)
+		{
+		foreach $wopt (split /\s+/, $devteam_additional_warn{$ecc})
 			{
 			$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
 			}

--- a/Configure
+++ b/Configure
@@ -117,7 +117,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # but 'long long' type.
 
 # These are common to all GCC compatible compilers
-our $devteam_common_warn = "-DDEBUG_UNUSED"
+our $gcc_strict_warnings = "-DDEBUG_UNUSED"
         . " -DPEDANTIC -pedantic -Wno-long-long"
         . " -Wall"
         . " -Wextra"
@@ -136,7 +136,7 @@ our $devteam_common_warn = "-DDEBUG_UNUSED"
 # In addition to the warning options above, select compilers get their own
 # set of additional warning options.  Use a compiler specific predefined
 # macro as index.
-our %devteam_additional_warn = ();
+our %additional_strict_warnings = ();
 
 # TODO(openssl-team): fix problems and investigate if (at least) the
 # following warnings can also be enabled:
@@ -145,7 +145,7 @@ our %devteam_additional_warn = ();
 #       -Wlanguage-extension-token -- no, we use asm()
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
-$devteam_additional_warn{__clang__} = ""
+$additional_strict_warnings{__clang__} = ""
         . " -Wswitch-default"
         . " -Wno-parentheses-equality"
         . " -Wno-language-extension-token"
@@ -1339,20 +1339,23 @@ if ($strict_warnings)
 	die "ERROR --strict-warnings requires gcc[>=4] or gcc-alike"
             unless $gccver >= 4;
 	$extra_gcc_warn = "-Wmisleading-indentation" if $gccver >= 6;
-	foreach $wopt (split /\s+/, $devteam_common_warn)
+	foreach $wopt (split /\s+/, $gcc_strict_warnings)
 		{
-		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+		$config{cflags} .= " $wopt"
+			unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
 		}
 	foreach $wopt (split /\s+/, $extra_gcc_warn)
 		{
-		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+		$config{cflags} .= " $wopt"
+			unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
 		}
 	foreach my $ecc (grep { defined($predefined{$_}) }
-			 keys %devteam_additional_warn)
+			 keys %additional_strict_warnings)
 		{
-		foreach $wopt (split /\s+/, $devteam_additional_warn{$ecc})
+		foreach $wopt (split /\s+/, $additional_strict_warnings{$ecc})
 			{
-			$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+			$config{cflags} .= " $wopt"
+				unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
 			}
 		}
 	}


### PR DESCRIPTION
Instead of adding new code for each compiler, all that's needed is to
create an entry for each in %devteam_additional_warn, at least the
empty string.
