### PR TITLE
Generalize setup_engine of apps/apps.c to allow specific crypto methods

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -212,13 +212,6 @@ static int read_config(void);
 static CONF *conf = NULL; /* OpenSSL config file context structure */
 static OSSL_CMP_CTX *cmp_ctx = NULL; /* the client-side CMP context */
 
-/* TODO remove when new setup_engine_flags() is in apps/lib/apps.c (PR #4277) */
-static
-ENGINE *setup_engine_flags(const char *engine, unsigned int flags, int debug)
-{
-    return setup_engine(engine, debug);
-}
-
 /* the type of cmp command we want to send */
 typedef enum {
     CMP_IR,
@@ -3089,7 +3082,7 @@ int cmp_main(int argc, char **argv)
     }
 
     if (opt_engine != NULL)
-        e = setup_engine_flags(opt_engine, 0 /* not: ENGINE_METHOD_ALL */, 0);
+        e = setup_engine_methods(opt_engine, 0 /* not: ENGINE_METHOD_ALL */, 0);
 
     if (opt_port != NULL) {
         if (opt_use_mock_srv) {

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -128,12 +128,8 @@ __owur int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
 
 # endif
 
-ENGINE *setup_engine_flags(const char *engine, unsigned int flags, int debug);
-# ifndef OPENSSL_NO_ENGINE
-#  define setup_engine(e, debug) setup_engine_flags(e, ENGINE_METHOD_ALL, debug)
-# else
-#  define setup_engine(e, debug) setup_engine_flags(e, 0, debug)
-# endif
+ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug);
+# define setup_engine(e, debug) setup_engine_methods(e, (unsigned int)-1, debug)
 void release_engine(ENGINE *e);
 
 # ifndef OPENSSL_NO_OCSP

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -12,6 +12,7 @@
 
 # include "e_os.h" /* struct timeval for DTLS */
 # include "internal/nelem.h"
+# include "internal/sockets.h" /* for openssl_fdset() */
 # include <assert.h>
 
 # include <sys/types.h>
@@ -34,13 +35,6 @@
 # include "opt.h"
 # include "fmt.h"
 # include "platform.h"
-
-/* also in include/internal/sockets.h */
-# if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WINCE)
-#  define openssl_fdset(a,b) FD_SET((unsigned int)a, b)
-# else
-#  define openssl_fdset(a,b) FD_SET(a, b)
-# endif
 
 /*
  * quick macro when you need to pass an unsigned char instead of a char.

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -41,7 +41,7 @@
  * this is true for some implementations of the is*() functions, for
  * example.
  */
-#define _UC(c) ((unsigned char)(c))
+# define _UC(c) ((unsigned char)(c))
 
 void app_RAND_load_conf(CONF *c, const char *section);
 void app_RAND_write(void);
@@ -117,7 +117,7 @@ __owur int ctx_set_verify_locations(SSL_CTX *ctx,
                                     const char *CApath, int noCApath,
                                     const char *CAstore, int noCAstore);
 
-#ifndef OPENSSL_NO_CT
+# ifndef OPENSSL_NO_CT
 
 /*
  * Sets the file to load the Certificate Transparency log list from.
@@ -126,9 +126,14 @@ __owur int ctx_set_verify_locations(SSL_CTX *ctx,
  */
 __owur int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
 
-#endif
+# endif
 
-ENGINE *setup_engine(const char *engine, int debug);
+ENGINE *setup_engine_flags(const char *engine, unsigned int flags, int debug);
+# ifndef OPENSSL_NO_ENGINE
+#  define setup_engine(e, debug) setup_engine_flags(e, ENGINE_METHOD_ALL, debug)
+# else
+#  define setup_engine(e, debug) setup_engine_flags(e, 0, debug)
+# endif
 void release_engine(ENGINE *e);
 
 # ifndef OPENSSL_NO_OCSP

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1164,7 +1164,7 @@ static ENGINE *try_load_engine(const char *engine)
 }
 #endif
 
-ENGINE *setup_engine(const char *engine, int debug)
+ENGINE *setup_engine_flags(const char *engine, unsigned int flags, int debug)
 {
     ENGINE *e = NULL;
 
@@ -1181,12 +1181,11 @@ ENGINE *setup_engine(const char *engine, int debug)
             ERR_print_errors(bio_err);
             return NULL;
         }
-        if (debug) {
-            ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
-        }
-        ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0, (void *)get_ui_method(),
-                        0, 1);
-        if (!ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
+        if (debug)
+            (void)ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
+        if (!ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0,
+                             (void *)get_ui_method(), 0, 1)
+                || !ENGINE_set_default(e, flags)) {
             BIO_printf(bio_err, "Cannot use engine \"%s\"\n", ENGINE_get_id(e));
             ERR_print_errors(bio_err);
             ENGINE_free(e);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1164,20 +1164,20 @@ static ENGINE *try_load_engine(const char *engine)
 }
 #endif
 
-ENGINE *setup_engine_flags(const char *engine, unsigned int flags, int debug)
+ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug)
 {
     ENGINE *e = NULL;
 
 #ifndef OPENSSL_NO_ENGINE
-    if (engine != NULL) {
-        if (strcmp(engine, "auto") == 0) {
+    if (id != NULL) {
+        if (strcmp(id, "auto") == 0) {
             BIO_printf(bio_err, "Enabling auto ENGINE support\n");
             ENGINE_register_all_complete();
             return NULL;
         }
-        if ((e = ENGINE_by_id(engine)) == NULL
-            && (e = try_load_engine(engine)) == NULL) {
-            BIO_printf(bio_err, "Invalid engine \"%s\"\n", engine);
+        if ((e = ENGINE_by_id(id)) == NULL
+            && (e = try_load_engine(id)) == NULL) {
+            BIO_printf(bio_err, "Invalid engine \"%s\"\n", id);
             ERR_print_errors(bio_err);
             return NULL;
         }
@@ -1185,7 +1185,7 @@ ENGINE *setup_engine_flags(const char *engine, unsigned int flags, int debug)
             (void)ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
         if (!ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0,
                              (void *)get_ui_method(), 0, 1)
-                || !ENGINE_set_default(e, flags)) {
+                || !ENGINE_set_default(e, methods)) {
             BIO_printf(bio_err, "Cannot use engine \"%s\"\n", ENGINE_get_id(e));
             ERR_print_errors(bio_err);
             ENGINE_free(e);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1577,7 +1577,9 @@ int s_server_main(int argc, char *argv[])
             session_id_prefix = opt_arg();
             break;
         case OPT_ENGINE:
-            engine = setup_engine(opt_arg(), 1);
+#ifndef OPENSSL_NO_ENGINE
+            engine = setup_engine_flags(opt_arg(), ENGINE_METHOD_ALL, s_debug);
+#endif
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1578,7 +1578,7 @@ int s_server_main(int argc, char *argv[])
             break;
         case OPT_ENGINE:
 #ifndef OPENSSL_NO_ENGINE
-            engine = setup_engine_flags(opt_arg(), ENGINE_METHOD_ALL, s_debug);
+            engine = setup_engine(opt_arg(), s_debug);
 #endif
             break;
         case OPT_R_CASES:

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -154,9 +154,9 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 
 /* also in apps/include/apps.h */
 # if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WINCE)
-#  define openssl_fdset(a,b) FD_SET((unsigned int)a, b)
+#  define openssl_fdset(a, b) FD_SET((unsigned int)(a), b)
 # else
-#  define openssl_fdset(a,b) FD_SET(a, b)
+#  define openssl_fdset(a, b) FD_SET(a, b)
 # endif
 
 #endif


### PR DESCRIPTION
The function `ENGINE *setup_engine(const char *engine, int debug)`, defined in `apps/apps.c`, is used by many OpenSSL apps. So far it unconditionally sets all the crypto methods of the given engine as the application-wide default. This is likely what  is needed for most (simple) use cases, in particular if an application uses just one private key (and related set of algorithms) or just one engine (corresponding to one type of key store) for all its key material.

Yet when several implementations for the same type of algorithm need to be used where, for instance, one of them is taken from an engine and others should be the standard ones defined in the crypto lib or taken from a different engine, it is not appropriate to make (all) the methods of one engine the default for all crypto algorithms. This holds in particular for a new app I am currently enhancing for later inclusion with OpenSSL. [CMPforOpenSSL](https://sourceforge.net/p/cmpforopenssl/git/ci/cmp/tree/) is a CMP client that can use signatures for protecting messages both at application and at TLS level, where for example the private key for CMP-level protection is held in a smart card (and accessed via an engine) and the private key for the (optional) TLS channel is stored in a password-protected file (and the keys may even be of different type, say, RSA and ECC).

I tried to make use of the given implementation of `setup_engine()` and to unregister any conflicting crypto methods, but this does not work. The only (clean) solution is to use a variant of `setup_engine()` that does not automatically call `ENGINE_set_default` with argument `ENGINE_METHOD_ALL`. Then for each private key one has full flexibility which crypto engine and methods (or the default OpenSSL crypto lib implementation) to use.

Therefore I propose to generalize `setup_engine()` by adding an extra argument, `unsigned int flags`, to be handed to `ENGINE_set_default`. This allows to decide if `ENGINE_set_default()` has any effect at all and to choose for which types of methods the implementation given by the engine is taken as the default.
Backward compatibility with existing code can be achieved easily by providing a macro that uses `ENGINE_METHOD_ALL` as value for the `flags`.