### PR TITLE
Configure: base compiler-specific decisions on pre-defines.

### DIFF
--- a/Configure
+++ b/Configure
@@ -1324,8 +1324,8 @@ if (defined($config{api})) {
 if ($strict_warnings)
 	{
 	my $wopt;
-	die "ERROR --strict-warnings requires gcc, clang or icc"
-            unless $ecc eq 'gcc' || $ecc eq 'clang' || $ecc eq 'icc';
+	die "ERROR --strict-warnings requires gcc or clang"
+            unless $ecc eq 'gcc' || $ecc eq 'clang';
 	foreach $wopt (split /\s+/, $gcc_devteam_warn)
 		{
 		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)

--- a/Configure
+++ b/Configure
@@ -117,12 +117,12 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # but 'long long' type.
 
 my $gcc_devteam_warn = "-DDEBUG_UNUSED"
-        . " -Wswitch"
         . " -DPEDANTIC -pedantic -Wno-long-long"
         . " -Wall"
         . " -Wextra"
         . " -Wno-unused-parameter"
         . " -Wno-missing-field-initializers"
+        . " -Wswitch"
         . " -Wsign-compare"
         . " -Wmissing-prototypes"
         . " -Wshadow"
@@ -1257,29 +1257,29 @@ unless ($disabled{asm}) {
     }
 }
 
-my $ecc = $target{cc};
-if ($^O ne "VMS" && !$disabled{makedepend}) {
-    # Is the compiler gcc or clang?  $ecc is used below to see if
-    # error-checking can be turned on.
-    my $ccpcc = "$config{cross_compile_prefix}$target{cc}";
-    open(PIPE, "$ccpcc --version 2>&1 |");
-    my $lines = 2;
-    while ( <PIPE> ) {
-        # Find the version number and save the major.
-        m|(?:.*)\b(\d+)\.\d+\.\d+\b(?:.*)|;
-        my $compiler_major = $1;
-        # We know that GNU C version 3 and up as well as all clang
-        # versions support dependency generation
-        $config{makedepprog} = $ccpcc
-            if (/clang/ || (/gcc/ && $compiler_major >= 3));
-        $ecc = "clang" if /clang/;
-        $ecc = "gcc" if /gcc/;
-        last if ($config{makedepprog} || !$lines--);
+my %predefined;
+
+if ($^O ne "VMS") {
+    my $cc = "$config{cross_compile_prefix}$target{cc}";
+
+    # collect compiler pre-defines from gcc or gcc-alike...
+    open(PIPE, "$cc -dM -E -x c /dev/null 2>&1 |");
+    while (<PIPE>) {
+	m/^#define\s+(\w+(?:\(\w+\))?)(?:\s+(.+))?/ or last;
+	$predefined{$1} = $2 // "";
     }
     close(PIPE);
 
-    $config{makedepprog} = which('makedepend') unless $config{makedepprog};
-    $disabled{makedepend} = "unavailable" unless $config{makedepprog};
+    if (!$disabled{makedepend}) {
+	# We know that GNU C version 3 and up as well as all clang
+	# versions support dependency generation
+	if ($predefined{__GNUC__} >= 3) {
+	    $config{makedepprog} = $cc;
+	} else {
+	    $config{makedepprog} = which('makedepend');
+	    $disabled{makedepend} = "unavailable" unless $config{makedepprog};
+	}
+    }
 }
 
 
@@ -1324,13 +1324,13 @@ if (defined($config{api})) {
 if ($strict_warnings)
 	{
 	my $wopt;
-	die "ERROR --strict-warnings requires gcc or clang"
-            unless $ecc eq 'gcc' || $ecc eq 'clang';
+	die "ERROR --strict-warnings requires gcc or gcc-alike"
+            unless defined($predefined{__GNUC__});
 	foreach $wopt (split /\s+/, $gcc_devteam_warn)
 		{
 		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
 		}
-	if ($ecc eq "clang")
+	if (defined($predefined{__clang__}))
 		{
 		foreach $wopt (split /\s+/, $clang_devteam_warn)
 			{


### PR DESCRIPTION
The commit subject is a bit misleading in sense that decisions affect
only gcc and gcc-alikes, like clang, recent icc...
