### PR TITLE
Remove version rollback checking for SSL v2

### DIFF
--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -45,7 +45,7 @@ const OPTIONS rsautl_options[] = {
     {"keyform", OPT_KEYFORM, 'E', "Private key format - default PEM"},
     {"pubin", OPT_PUBIN, '-', "Input is an RSA public"},
     {"certin", OPT_CERTIN, '-', "Input is a cert carrying an RSA public key"},
-    {"ssl", OPT_SSL, '-', "Use SSL v2 padding"},
+    {"ssl", OPT_SSL, '-', "Use SSL v2 padding (deprecated)"},
     {"raw", OPT_RAW, '-', "Use no padding"},
     {"pkcs", OPT_PKCS, '-', "Use PKCS#1 v1.5 padding (default)"},
     {"oaep", OPT_OAEP, '-', "Use PKCS#1 OAEP"},

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -7,6 +7,20 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * TODO (OpenSSL 1.2):
+ * This whole file should be removed in OpenSSL 1.2, the next version
+ * we can make some API- and ABI-breaking changes (as well as all related
+ * SSLv23 stuff in other code).
+ *
+ * For OpenSSL 1.1.1, since breaking changes are not permitted, we limit
+ * ourselves to replacing the "remove padding" function with a stub that
+ * always returns an error -- this is not considered an ABI-breaking change
+ * because OpenSSL 1.1.0 removed support for native SSLv2; for all other inputs
+ * this function could never succeed.  The "add padding" function will remain
+ * until OpenSSL 1.2.0.
+ */
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/bn.h>
@@ -55,54 +69,6 @@ int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
 int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
                              const unsigned char *from, int flen, int num)
 {
-    int i, j, k;
-    const unsigned char *p;
-
-    p = from;
-    if (flen < 10) {
-        RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_DATA_TOO_SMALL);
-        return -1;
-    }
-    /* Accept even zero-padded input */
-    if (flen == num) {
-        if (*(p++) != 0) {
-            RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_BLOCK_TYPE_IS_NOT_02);
-            return -1;
-        }
-        flen--;
-    }
-    if ((num != (flen + 1)) || (*(p++) != 02)) {
-        RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_BLOCK_TYPE_IS_NOT_02);
-        return -1;
-    }
-
-    /* scan over padding data */
-    j = flen - 1;               /* one for type */
-    for (i = 0; i < j; i++)
-        if (*(p++) == 0)
-            break;
-
-    if ((i == j) || (i < 8)) {
-        RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23,
-               RSA_R_NULL_BEFORE_BLOCK_MISSING);
-        return -1;
-    }
-    for (k = -9; k < -1; k++) {
-        if (p[k] != 0x03)
-            break;
-    }
-    if (k == -1) {
-        RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_SSLV3_ROLLBACK_ATTACK);
-        return -1;
-    }
-
-    i++;                        /* Skip over the '\0' */
-    j -= i;
-    if (j > tlen) {
-        RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_DATA_TOO_LARGE);
-        return -1;
-    }
-    memcpy(to, p, (unsigned int)j);
-
-    return j;
+    RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_SSLV3_ROLLBACK_ATTACK);
+    return -1;
 }

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -216,8 +216,8 @@ B<pkeyopt> values are supported:
 =item B<rsa_padding_mode:mode>
 
 This sets the RSA padding mode. Acceptable values for B<mode> are B<pkcs1> for
-PKCS#1 padding, B<sslv23> for SSLv23 padding, B<none> for no padding, B<oaep>
-for B<OAEP> mode, B<x931> for X9.31 mode and B<pss> for PSS.
+PKCS#1 padding, B<sslv23> for SSLv23 padding (deprecated), B<none> for no padding,
+B<oaep> for B<OAEP> mode, B<x931> for X9.31 mode and B<pss> for PSS.
 
 In PKCS#1 padding if the message digest is not set then the supplied data is
 signed or verified directly instead of using a B<DigestInfo> structure. If a


### PR DESCRIPTION
The thing is: SSLv2 is not supported any more and this piece of code seems not useful anymore during SSL/TLS handshake.

But there are some *entries* to use this padding scheme standalone, such as: `openssl rsautl -ssl ...` or `sslv23` in EVP interface or `RSA_SSLV23_PADDING` with some RSA related APIs. And those usage will be failed.

I propose to remove this checking logic if the *standalone* usage is still necessary (though I don't see actual use-case on this).

Or just remove this SSLv23 padding as well as all related stuff, might be also an option. 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
