### PR TITLE
crypto/cryptlib.c: mask more capability bits upon FXSR bit flip.

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -747,8 +747,7 @@ void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)
 # endif
 # if    defined(GHASH_ASM_X86_OR_64)
 #  if   !defined(GHASH_ASM_X86) || defined(OPENSSL_IA32_SSE2)
-    if (OPENSSL_ia32cap_P[0] & (1 << 24) && /* check FXSR bit */
-        OPENSSL_ia32cap_P[1] & (1 << 1)) { /* check PCLMULQDQ bit */
+    if (OPENSSL_ia32cap_P[1] & (1 << 1)) { /* check PCLMULQDQ bit */
         if (((OPENSSL_ia32cap_P[1] >> 22) & 0x41) == 0x41) { /* AVX+MOVBE */
             gcm_init_avx(ctx->Htable, ctx->H.u);
             ctx->gmult = gcm_gmult_avx;


### PR DESCRIPTION
OPENSSL_ia32cap.pod discusses possibility to disable operations on
XMM register bank. This formally means that this flag has to checked
in combination with other flags. But it customarily isn't. But instead
of chasing all the cases we can flip more bits together with FXSR one.
