### PR TITLE
Fix Proxy where a timeout occurs waiting for both client and server

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -297,8 +297,11 @@ sub clientstart
     while(     (!(TLSProxy::Message->end)
                 || (defined $self->sessionfile()
                     && (-s $self->sessionfile()) == 0))
-            && $ctr < 10
-            && (@ready = $sel->can_read(1))) {
+            && $ctr < 10) {
+        if (!(@ready = $sel->can_read(1))) {
+            $ctr++;
+            next;
+        }
         foreach my $hand (@ready) {
             if ($hand == $server_sock) {
                 $server_sock->sysread($indata, 16384) or goto END;
@@ -311,7 +314,7 @@ sub clientstart
                 $server_sock->syswrite($indata);
                 $ctr = 0;
             } else {
-                $ctr++
+                die "Unexpected handle";
             }
         }
     }


### PR DESCRIPTION
This fixes some test failures I was experiencing in an msys2/mingw build. There are still other problems not addressed by this.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
