### PR TITLE
Don't try to use ucontext_t on aarch64 with glibc version < 2.20

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -17,9 +17,16 @@
 
 # include <unistd.h>
 
-# if _POSIX_VERSION >= 200112L
+/*
+ * Glibc before v2.20 doesn't have ucontext_t for aarch64, so on top of
+ * the POSIX version check, we check the glibc version as well, but only
+ * on aarch64.
+ */
+# if _POSIX_VERSION >= 200112L \
+    && (!defined(__aarch64__) || !defined(__GLIBC_PREREQ) \
+        || __GLIBC_PREREQ(2,20))
 
-# include <pthread.h>
+#  include <pthread.h>
 
 #  define ASYNC_POSIX
 #  define ASYNC_ARCH


### PR DESCRIPTION
A study of the glibc source, version by version, shows that there
isn't a aarch64 specific sys/ucontext.h before version 2.20.

-----

This is alternative to #4307 to resolved the issue shown in https://mta.openssl.org/pipermail/openssl-commits/2017-August/016192.html