### PR TITLE
Fix struct timeval include guards.

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -10,11 +10,8 @@
 #ifndef HEADER_APPS_H
 # define HEADER_APPS_H
 
-# include "e_os.h"
+# include "e_os.h" /* struct timeval for DTLS */
 # include "internal/nelem.h"
-# if defined(__unix) || defined(__unix__)
-#  include <sys/time.h> /* struct timeval for DTLS */
-# endif
 # include <assert.h>
 
 # include <openssl/e_os2.h>

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2005-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,10 +12,6 @@
 
 #include "bio_lcl.h"
 #ifndef OPENSSL_NO_DGRAM
-
-# if !defined(_WIN32)
-#  include <sys/time.h>
-# endif
 
 # ifndef OPENSSL_NO_SCTP
 #  include <netinet/sctp.h>

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,11 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include "internal/cryptlib.h"
-
-#if defined(OPENSSL_SYS_UNIX)
-# include <sys/time.h>
-#endif
 
 #include <openssl/objects.h>
 #include <openssl/ts.h>

--- a/e_os.h
+++ b/e_os.h
@@ -234,6 +234,12 @@ extern FILE *_imp___iob;
 
 # else                          /* The non-microsoft world */
 
+#  if defined(OPENSSL_SYS_VXWORKS)
+#   include <sys/times.h>
+#  else
+#   include <sys/time.h>
+#  endif
+
 #  ifdef OPENSSL_SYS_VMS
 #   define VMS 1
   /*

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -13,12 +13,6 @@
 #include <openssl/rand.h>
 #include "ssl_locl.h"
 
-#if defined(OPENSSL_SYS_VXWORKS)
-# include <sys/times.h>
-#elif !defined(OPENSSL_SYS_WIN32)
-# include <sys/time.h>
-#endif
-
 static void get_current_time(struct timeval *t);
 static int dtls1_handshake_write(SSL *s);
 static size_t dtls1_link_min_mtu(void);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -11,15 +11,12 @@
 
 #ifndef HEADER_SSL_LOCL_H
 # define HEADER_SSL_LOCL_H
-# include "e_os.h"              /* struct timeval for Windows */
+
+# include "e_os.h"              /* struct timeval for DTLS */
 # include <stdlib.h>
 # include <time.h>
 # include <string.h>
 # include <errno.h>
-
-# if defined(__unix) || defined(__unix__)
-#  include <sys/time.h>         /* struct timeval for DTLS */
-# endif
 
 # include <openssl/buffer.h>
 # include <openssl/comp.h>

--- a/test/ossl_shim/packeted_bio.h
+++ b/test/ossl_shim/packeted_bio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,17 +10,9 @@
 #ifndef HEADER_PACKETED_BIO
 #define HEADER_PACKETED_BIO
 
+#include "e_os.h"
 #include <openssl/base.h>
 #include <openssl/bio.h>
-
-#if defined(OPENSSL_SYS_WINDOWS)
-OPENSSL_MSVC_PRAGMA(warning(push, 3))
-#include <winsock2.h>
-OPENSSL_MSVC_PRAGMA(warning(pop))
-#else
-#include <sys/time.h>
-#endif
-
 
 // PacketedBioCreate creates a filter BIO which implements a reliable in-order
 // blocking datagram socket. It internally maintains a clock and honors


### PR DESCRIPTION
Move `struct timeval` includes into `e_os.h` (where the Windows ones were).
Ensure that the include is guarded canonically.

Refer #4271

- [x] tests are added or updated
