### PR TITLE
Fixup include path in ossl_shim test after e_os.h work

### DIFF
--- a/test/ossl_shim/build.info
+++ b/test/ossl_shim/build.info
@@ -1,6 +1,6 @@
 IF[{- defined $target{cxx} && !$disabled{"external-tests"}-}]
   PROGRAMS_NO_INST=ossl_shim
   SOURCE[ossl_shim]=ossl_shim.cc async_bio.cc packeted_bio.cc test_config.cc
-  INCLUDE[ossl_shim]=. include ../../include
+  INCLUDE[ossl_shim]=. include ../../include ../..
   DEPEND[ossl_shim]=../../libssl ../../libcrypto
 ENDIF


### PR DESCRIPTION
The C++ include search path doesn't seem to pick up e_os.h implicitly
here.

[extended tests]

