### PR TITLE
Fix long SNI lengths in test/handshake_helper.c

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -153,7 +153,7 @@ static int early_select_server_ctx(SSL *s, void *arg, int ignore)
         remaining <= 2)
         return 0;
     /* Extract the length of the supplied list of names. */
-    len = (*(p++) << 1);
+    len = (*(p++) << 8);
     len += *(p++);
     if (len + 2 != remaining)
         return 0;
@@ -168,7 +168,7 @@ static int early_select_server_ctx(SSL *s, void *arg, int ignore)
     /* Now we can finally pull out the byte array with the actual hostname. */
     if (remaining <= 2)
         return 0;
-    len = (*(p++) << 1);
+    len = (*(p++) << 8);
     len += *(p++);
     if (len + 2 > remaining)
         return 0;


### PR DESCRIPTION
If the server_name extension is long enough to require two bytes to
hold the length of either field, the test suite would not decode
the length properly.  Using the PACKET_ APIs would have avoided this,
but it was desired to avoid using private APIs in this part of the
test suite, to keep ourselves honest.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are added or updated
