### PR TITLE
Rework the "global lock" implementation

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -17,6 +17,7 @@
 #include <openssl/err.h>
 #include <openssl/buffer.h>
 #include "internal/thread_once.h"
+#include "internal/glock.h"
 
 CRYPTO_RWLOCK *bio_lookup_lock;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
@@ -603,7 +604,7 @@ static int addrinfo_wrap(int family, int socktype,
 DEFINE_RUN_ONCE_STATIC(do_bio_lookup_init)
 {
     OPENSSL_init_crypto(0, NULL);
-    bio_lookup_lock = CRYPTO_THREAD_glock_new("bio_lookup");
+    bio_lookup_lock = global_locks[CRYPTO_GLOCK_BIO_LOOKUP];
     return bio_lookup_lock != NULL;
 }
 

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -19,7 +19,6 @@
 #include "internal/thread_once.h"
 #include "internal/glock.h"
 
-CRYPTO_RWLOCK *bio_lookup_lock;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
 
 /*
@@ -603,9 +602,7 @@ static int addrinfo_wrap(int family, int socktype,
 
 DEFINE_RUN_ONCE_STATIC(do_bio_lookup_init)
 {
-    OPENSSL_init_crypto(0, NULL);
-    bio_lookup_lock = global_locks[CRYPTO_GLOCK_BIO_LOOKUP];
-    return bio_lookup_lock != NULL;
+    return OPENSSL_init_crypto(0, NULL);
 }
 
 int BIO_lookup(const char *host, const char *service,
@@ -747,7 +744,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             goto err;
         }
 
-        CRYPTO_THREAD_write_lock(bio_lookup_lock);
+        OPENSSL_LOCK_lock(CRYPTO_GLOCK_BIO_LOOKUP);
         he_fallback_address = INADDR_ANY;
         if (host == NULL) {
             he = &he_fallback;
@@ -887,7 +884,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             ret = 1;
         }
      err:
-        CRYPTO_THREAD_unlock(bio_lookup_lock);
+        OPENSSL_LOCK_unlock(CRYPTO_GLOCK_BIO_LOOKUP);
     }
 
     return ret;

--- a/crypto/bio/bio_lcl.h
+++ b/crypto/bio/bio_lcl.h
@@ -138,8 +138,6 @@ struct bio_st {
 typedef unsigned int socklen_t;
 # endif
 
-extern CRYPTO_RWLOCK *bio_lookup_lock;
-
 int BIO_ADDR_make(BIO_ADDR *ap, const struct sockaddr *sa);
 const struct sockaddr *BIO_ADDR_sockaddr(const BIO_ADDR *ap);
 struct sockaddr *BIO_ADDR_sockaddr_noconst(BIO_ADDR *ap);
@@ -147,8 +145,6 @@ socklen_t BIO_ADDR_sockaddr_size(const BIO_ADDR *ap);
 socklen_t BIO_ADDRINFO_sockaddr_size(const BIO_ADDRINFO *bai);
 const struct sockaddr *BIO_ADDRINFO_sockaddr(const BIO_ADDRINFO *bai);
 #endif
-
-extern CRYPTO_RWLOCK *bio_type_lock;
 
 void bio_sock_cleanup_int(void);
 

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -778,9 +778,9 @@ void bio_cleanup(void)
 {
 #ifndef OPENSSL_NO_SOCK
     bio_sock_cleanup_int();
-    CRYPTO_THREAD_lock_free(bio_lookup_lock);
+    /* Clear the local handle to the global lock, freed elsewhere. */
     bio_lookup_lock = NULL;
 #endif
-    CRYPTO_THREAD_lock_free(bio_type_lock);
+    /* Clear the local handle to the global lock, freed elsewhere. */
     bio_type_lock = NULL;
 }

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -778,9 +778,5 @@ void bio_cleanup(void)
 {
 #ifndef OPENSSL_NO_SOCK
     bio_sock_cleanup_int();
-    /* Clear the local handle to the global lock, freed elsewhere. */
-    bio_lookup_lock = NULL;
 #endif
-    /* Clear the local handle to the global lock, freed elsewhere. */
-    bio_type_lock = NULL;
 }

--- a/crypto/bio/bio_meth.c
+++ b/crypto/bio/bio_meth.c
@@ -9,13 +9,14 @@
 
 #include "bio_lcl.h"
 #include "internal/thread_once.h"
+#include "internal/glock.h"
 
 CRYPTO_RWLOCK *bio_type_lock = NULL;
 static CRYPTO_ONCE bio_type_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE_STATIC(do_bio_type_init)
 {
-    bio_type_lock = CRYPTO_THREAD_glock_new("bio_type");
+    bio_type_lock = global_locks[CRYPTO_GLOCK_BIO_TYPE];
     return bio_type_lock != NULL;
 }
 

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -8,6 +8,7 @@
  */
 
 #include "eng_int.h"
+#include "internal/glock.h"
 
 /*
  * When querying a ENGINE-specific control command's 'description', this
@@ -129,9 +130,9 @@ int ENGINE_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
         ENGINEerr(ENGINE_F_ENGINE_CTRL, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ENGINE);
     ref_exists = ((e->struct_ref > 0) ? 1 : 0);
-    CRYPTO_THREAD_unlock(global_engine_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
     ctrl_exists = ((e->ctrl == NULL) ? 0 : 1);
     if (!ref_exists) {
         ENGINEerr(ENGINE_F_ENGINE_CTRL, ENGINE_R_NO_REFERENCE);

--- a/crypto/engine/eng_int.h
+++ b/crypto/engine/eng_int.h
@@ -20,8 +20,6 @@
 extern "C" {
 #endif
 
-extern CRYPTO_RWLOCK *global_engine_lock;
-
 /*
  * If we compile with this symbol defined, then both reference counts in the
  * ENGINE structure will be monitored with a line of output on stderr for

--- a/crypto/engine/eng_pkey.c
+++ b/crypto/engine/eng_pkey.c
@@ -8,6 +8,7 @@
  */
 
 #include "eng_int.h"
+#include "internal/glock.h"
 
 /* Basic get/set stuff */
 
@@ -60,13 +61,13 @@ EVP_PKEY *ENGINE_load_private_key(ENGINE *e, const char *key_id,
                   ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ENGINE);
     if (e->funct_ref == 0) {
-        CRYPTO_THREAD_unlock(global_engine_lock);
+        OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PRIVATE_KEY, ENGINE_R_NOT_INITIALISED);
         return 0;
     }
-    CRYPTO_THREAD_unlock(global_engine_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
     if (!e->load_privkey) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PRIVATE_KEY,
                   ENGINE_R_NO_LOAD_FUNCTION);
@@ -91,13 +92,13 @@ EVP_PKEY *ENGINE_load_public_key(ENGINE *e, const char *key_id,
                   ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ENGINE);
     if (e->funct_ref == 0) {
-        CRYPTO_THREAD_unlock(global_engine_lock);
+        OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PUBLIC_KEY, ENGINE_R_NOT_INITIALISED);
         return 0;
     }
-    CRYPTO_THREAD_unlock(global_engine_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
     if (!e->load_pubkey) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PUBLIC_KEY, ENGINE_R_NO_LOAD_FUNCTION);
         return 0;
@@ -122,14 +123,14 @@ int ENGINE_load_ssl_client_cert(ENGINE *e, SSL *s,
                   ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ENGINE);
     if (e->funct_ref == 0) {
-        CRYPTO_THREAD_unlock(global_engine_lock);
+        OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
         ENGINEerr(ENGINE_F_ENGINE_LOAD_SSL_CLIENT_CERT,
                   ENGINE_R_NOT_INITIALISED);
         return 0;
     }
-    CRYPTO_THREAD_unlock(global_engine_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
     if (!e->load_ssl_client_cert) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_SSL_CLIENT_CERT,
                   ENGINE_R_NO_LOAD_FUNCTION);

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -11,6 +11,7 @@
 #include "eng_int.h"
 #include <openssl/evp.h>
 #include "internal/asn1_int.h"
+#include "internal/glock.h"
 
 /*
  * If this symbol is defined then ENGINE_get_pkey_asn1_meth_engine(), the
@@ -195,7 +196,7 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_pkey_asn1_find_str(ENGINE **pe,
         return NULL;
     }
 
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ENGINE);
     engine_table_doall(pkey_asn1_meth_table, look_str_cb, &fstr);
     /* If found obtain a structural reference to engine */
     if (fstr.e) {
@@ -203,6 +204,6 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_pkey_asn1_find_str(ENGINE **pe,
         engine_ref_debug(fstr.e, 0, 1);
     }
     *pe = fstr.e;
-    CRYPTO_THREAD_unlock(global_engine_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ENGINE);
     return fstr.ameth;
 }

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -137,7 +137,6 @@ static int set_err_thread_local;
 static CRYPTO_THREAD_LOCAL err_thread_local;
 
 static CRYPTO_ONCE err_string_init = CRYPTO_ONCE_STATIC_INIT;
-static CRYPTO_RWLOCK *err_string_lock;
 
 static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *);
 
@@ -173,9 +172,9 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 {
     ERR_STRING_DATA *p = NULL;
 
-    CRYPTO_THREAD_read_lock(err_string_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ERR_STRING);
     p = lh_ERR_STRING_DATA_retrieve(int_error_hash, d);
-    CRYPTO_THREAD_unlock(err_string_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ERR_STRING);
 
     return p;
 }
@@ -202,9 +201,9 @@ static void build_SYS_str_reasons(void)
     static int init = 1;
     int i;
 
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ERR_STRING);
     if (!init) {
-        CRYPTO_THREAD_unlock(err_string_lock);
+        OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ERR_STRING);
         return;
     }
 
@@ -228,7 +227,7 @@ static void build_SYS_str_reasons(void)
 
     init = 0;
 
-    CRYPTO_THREAD_unlock(err_string_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ERR_STRING);
     err_load_strings(SYS_str_reasons);
 }
 #endif
@@ -268,18 +267,15 @@ static void ERR_STATE_free(ERR_STATE *s)
 DEFINE_RUN_ONCE_STATIC(do_err_strings_init)
 {
     OPENSSL_init_crypto(0, NULL);
-    err_string_lock = global_locks[CRYPTO_GLOCK_ERR_STRING];
     int_error_hash = lh_ERR_STRING_DATA_new(err_string_data_hash,
                                             err_string_data_cmp);
-    return err_string_lock != NULL && int_error_hash != NULL;
+    return int_error_hash != NULL;
 }
 
 void err_cleanup(void)
 {
     if (set_err_thread_local != 0)
         CRYPTO_THREAD_cleanup_local(&err_thread_local);
-    /* Clear the local handle to the global lock, freed elsewhere. */
-    err_string_lock = NULL;
     lh_ERR_STRING_DATA_free(int_error_hash);
     int_error_hash = NULL;
 }
@@ -300,11 +296,11 @@ static void err_patch(int lib, ERR_STRING_DATA *str)
  */
 static int err_load_strings(const ERR_STRING_DATA *str)
 {
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ERR_STRING);
     for (; str->error; str++)
         (void)lh_ERR_STRING_DATA_insert(int_error_hash,
                                        (ERR_STRING_DATA *)str);
-    CRYPTO_THREAD_unlock(err_string_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ERR_STRING);
     return 1;
 }
 
@@ -346,14 +342,14 @@ int ERR_unload_strings(int lib, ERR_STRING_DATA *str)
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
         return 0;
 
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ERR_STRING);
     /*
      * We don't need to ERR_PACK the lib, since that was done (to
      * the table) when it was loaded.
      */
     for (; str->error; str++)
         (void)lh_ERR_STRING_DATA_delete(int_error_hash, str);
-    CRYPTO_THREAD_unlock(err_string_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ERR_STRING);
 
     return 1;
 }
@@ -715,9 +711,9 @@ int ERR_get_next_error_library(void)
         return 0;
     }
 
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_ERR_STRING);
     ret = int_err_library_number++;
-    CRYPTO_THREAD_unlock(err_string_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_ERR_STRING);
     return ret;
 }
 

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -9,6 +9,7 @@
 
 #include "internal/cryptlib_int.h"
 #include "internal/thread_once.h"
+#include "internal/glock.h"
 #include <openssl/lhash.h>
 
 /*
@@ -39,7 +40,7 @@ static CRYPTO_ONCE ex_data_init = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(do_ex_data_init)
 {
     OPENSSL_init_crypto(0, NULL);
-    ex_data_lock = CRYPTO_THREAD_glock_new("ex_data");
+    ex_data_lock = global_locks[CRYPTO_GLOCK_EX_DATA];
     return ex_data_lock != NULL;
 }
 
@@ -101,7 +102,7 @@ void crypto_cleanup_all_ex_data_int(void)
         ip->meth = NULL;
     }
 
-    CRYPTO_THREAD_lock_free(ex_data_lock);
+    /* Clear out the local handle to the global lock, freed elsewhere. */
     ex_data_lock = NULL;
 }
 

--- a/crypto/include/internal/glock.h
+++ b/crypto/include/internal/glock.h
@@ -32,4 +32,4 @@ enum {
     CRYPTO_NUM_GLOCKS
 };
 
-CRYPTO_RWLOCK *global_locks[CRYPTO_NUM_GLOCKS];
+extern CRYPTO_RWLOCK *openssl_locks[CRYPTO_NUM_GLOCKS];

--- a/crypto/include/internal/glock.h
+++ b/crypto/include/internal/glock.h
@@ -14,22 +14,21 @@
  * the corresponding indices so that the lock that is first in the order has
  * the lower index.
  */
-enum {
-    CRYPTO_GLOCK_INIT = 0,
-    CRYPTO_GLOCK_BIO_LOOKUP,
-    CRYPTO_GLOCK_BIO_TYPE,
-    CRYPTO_GLOCK_RAND_METH,
-    CRYPTO_GLOCK_RAND_ENGINE,
-    CRYPTO_GLOCK_ENGINE,
-    CRYPTO_GLOCK_EX_DATA,
-    CRYPTO_GLOCK_OBJ,
-    CRYPTO_GLOCK_REGISTRY,
-    CRYPTO_GLOCK_ERR_STRING,
-    CRYPTO_GLOCK_DRBG,
-    CRYPTO_GLOCK_PRIV_DRBG,
-    CRYPTO_GLOCK_RAND_BYTES,
-    CRYPTO_GLOCK_SEC_MALLOC,
-    CRYPTO_NUM_GLOCKS
-};
+#define CRYPTO_GLOCK_INIT         0
+#define CRYPTO_GLOCK_BIO_LOOKUP   1
+#define CRYPTO_GLOCK_BIO_TYPE     2
+#define CRYPTO_GLOCK_RAND_METH    3
+#define CRYPTO_GLOCK_RAND_ENGINE  4
+#define CRYPTO_GLOCK_ENGINE       5
+#define CRYPTO_GLOCK_EX_DATA      6
+#define CRYPTO_GLOCK_OBJ          7
+#define CRYPTO_GLOCK_REGISTRY     8
+#define CRYPTO_GLOCK_ERR_STRING   9
+#define CRYPTO_GLOCK_DRBG        10
+#define CRYPTO_GLOCK_PRIV_DRBG   11
+#define CRYPTO_GLOCK_RAND_BYTES  12
+#define CRYPTO_GLOCK_SEC_MALLOC  13
+#define CRYPTO_NUM_GLOCKS        14
 
-extern CRYPTO_RWLOCK *openssl_locks[CRYPTO_NUM_GLOCKS];
+int OPENSSL_LOCK_lock(int index);
+int OPENSSL_LOCK_unlock(int index);

--- a/crypto/include/internal/glock.h
+++ b/crypto/include/internal/glock.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Indexes into the global arrays of glocks and names. */
+/*
+ * Be careful about lock ordering requirements here!  If there is any codepath
+ * in which more than one of these locks is held at the same time, order
+ * the corresponding indices so that the lock that is first in the order has
+ * the lower index.
+ */
+enum {
+    CRYPTO_GLOCK_INIT = 0,
+    CRYPTO_GLOCK_BIO_LOOKUP,
+    CRYPTO_GLOCK_BIO_TYPE,
+    CRYPTO_GLOCK_RAND_METH,
+    CRYPTO_GLOCK_RAND_ENGINE,
+    CRYPTO_GLOCK_ENGINE,
+    CRYPTO_GLOCK_EX_DATA,
+    CRYPTO_GLOCK_OBJ,
+    CRYPTO_GLOCK_REGISTRY,
+    CRYPTO_GLOCK_ERR_STRING,
+    CRYPTO_GLOCK_DRBG,
+    CRYPTO_GLOCK_PRIV_DRBG,
+    CRYPTO_GLOCK_RAND_BYTES,
+    CRYPTO_GLOCK_SEC_MALLOC,
+    CRYPTO_NUM_GLOCKS
+};
+
+CRYPTO_RWLOCK *global_locks[CRYPTO_NUM_GLOCKS];

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -708,12 +708,10 @@ int OPENSSL_atexit(void (*handler)(void))
  */
 static void unlock_all(void)
 {
-    CRYPTO_RWLOCK *lp;
     int i;
 
     for (i = CRYPTO_NUM_GLOCKS - 1; i >= 0; i--) {
-        lp = global_locks + i;
-        CRYPTO_THREAD_unlock(lp);
+        CRYPTO_THREAD_unlock(global_locks[i]);
     }
 }
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -732,17 +732,26 @@ void OPENSSL_fork_prepare(void)
 {
     size_t i;
 
+    if (!base_inited)
+        return;
+
     for (i = 0; i < CRYPTO_NUM_GLOCKS; i++)
         CRYPTO_THREAD_write_lock(global_locks[i]);
 }
 
 void OPENSSL_fork_parent(void)
 {
+    if (!base_inited)
+        return;
+
     unlock_all();
 }
 
 void OPENSSL_fork_child(void)
 {
+    if (!base_inited)
+        return;
+
     unlock_all();
     rand_fork();
 }

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -90,8 +90,8 @@ static CRYPTO_THREAD_ID disabling_threadid;
 
 DEFINE_RUN_ONCE_STATIC(do_memdbg_init)
 {
-    malloc_lock = CRYPTO_THREAD_glock_new("malloc");
-    long_malloc_lock = CRYPTO_THREAD_glock_new("long_malloc");
+    malloc_lock = CRYPTO_THREAD_lock_new();
+    long_malloc_lock = CRYPTO_THREAD_lock_new();
     if (malloc_lock == NULL || long_malloc_lock == NULL
         || !CRYPTO_THREAD_init_local(&appinfokey, NULL)) {
         CRYPTO_THREAD_lock_free(malloc_lock);

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -59,7 +59,6 @@ typedef enum drbg_status_e {
  * drbg_add*; the functions with an asterisk lock).
  */
 typedef struct rand_bytes_buffer_st {
-    CRYPTO_RWLOCK *lock;
     unsigned char *buff;
     size_t size;
     size_t curr;
@@ -89,8 +88,8 @@ typedef struct rand_drbg_ctr_st {
  * right now.
  */
 struct rand_drbg_st {
-    CRYPTO_RWLOCK *lock;
     RAND_DRBG *parent;
+    int priv; /* If this is the private pool, which has its own lock. */
     int nid; /* the underlying algorithm */
     int fork_count;
     unsigned short flags; /* various external flags */

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -20,9 +20,7 @@
 #ifndef OPENSSL_NO_ENGINE
 /* non-NULL if default_RAND_meth is ENGINE-provided */
 static ENGINE *funct_ref;
-static CRYPTO_RWLOCK *rand_engine_lock;
 #endif
-static CRYPTO_RWLOCK *rand_meth_lock;
 static const RAND_METHOD *default_RAND_meth;
 static CRYPTO_ONCE rand_init = CRYPTO_ONCE_STATIC_INIT;
 RAND_BYTES_BUFFER rand_bytes;
@@ -117,11 +115,11 @@ size_t drbg_entropy_from_system(RAND_DRBG *drbg,
                                     : OPENSSL_malloc(drbg->size);
 
     /* If we don't have enough, try to get more. */
-    CRYPTO_THREAD_write_lock(rand_bytes.lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_RAND_BYTES);
     for (i = RAND_POLL_RETRIES; rand_bytes.curr < min_len && --i >= 0; ) {
-        CRYPTO_THREAD_unlock(rand_bytes.lock);
+        OPENSSL_LOCK_unlock(CRYPTO_GLOCK_RAND_BYTES);
         RAND_poll();
-        CRYPTO_THREAD_write_lock(rand_bytes.lock);
+        OPENSSL_LOCK_lock(CRYPTO_GLOCK_RAND_BYTES);
     }
 
     /* Get desired amount, but no more than we have. */
@@ -134,7 +132,7 @@ size_t drbg_entropy_from_system(RAND_DRBG *drbg,
         if (rand_bytes.curr != 0)
             memmove(rand_bytes.buff, &rand_bytes.buff[min_len], rand_bytes.curr);
     }
-    CRYPTO_THREAD_unlock(rand_bytes.lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_RAND_BYTES);
     *pout = randomness;
     return min_len;
 }
@@ -182,15 +180,6 @@ DEFINE_RUN_ONCE_STATIC(do_rand_init)
 {
     int ret = 1;
 
-#ifndef OPENSSL_NO_ENGINE
-    rand_engine_lock = global_locks[CRYPTO_GLOCK_RAND_ENGINE];
-    ret &= rand_engine_lock != NULL;
-#endif
-    rand_meth_lock = global_locks[CRYPTO_GLOCK_RAND_METH];
-    ret &= rand_meth_lock != NULL;
-
-    rand_bytes.lock = global_locks[CRYPTO_GLOCK_RAND_BYTES];
-    ret &= rand_bytes.lock != NULL;
     rand_bytes.curr = 0;
     rand_bytes.size = MAX_RANDOMNESS_HELD;
     rand_bytes.secure = CRYPTO_secure_malloc_initialized();
@@ -208,13 +197,6 @@ void rand_cleanup_int(void)
     if (meth != NULL && meth->cleanup != NULL)
         meth->cleanup();
     RAND_set_rand_method(NULL);
-#ifndef OPENSSL_NO_ENGINE
-    /* Clear the local handle to the global lock, freed elsewhere. */
-    rand_engine_lock = NULL;
-#endif
-    /* Clear local handles to global locks, freed elsewhere. */
-    rand_meth_lock = NULL;
-    rand_bytes.lock = NULL;
     if (rand_bytes.secure)
         OPENSSL_secure_clear_free(rand_bytes.buff, rand_bytes.size);
     else
@@ -240,13 +222,13 @@ int RAND_set_rand_method(const RAND_METHOD *meth)
     if (!RUN_ONCE(&rand_init, do_rand_init))
         return 0;
 
-    CRYPTO_THREAD_write_lock(rand_meth_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_RAND_METH);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(funct_ref);
     funct_ref = NULL;
 #endif
     default_RAND_meth = meth;
-    CRYPTO_THREAD_unlock(rand_meth_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_RAND_METH);
     return 1;
 }
 
@@ -257,7 +239,7 @@ const RAND_METHOD *RAND_get_rand_method(void)
     if (!RUN_ONCE(&rand_init, do_rand_init))
         return NULL;
 
-    CRYPTO_THREAD_write_lock(rand_meth_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_RAND_METH);
     if (default_RAND_meth == NULL) {
 #ifndef OPENSSL_NO_ENGINE
         ENGINE *e;
@@ -276,7 +258,7 @@ const RAND_METHOD *RAND_get_rand_method(void)
 #endif
     }
     tmp_meth = default_RAND_meth;
-    CRYPTO_THREAD_unlock(rand_meth_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_RAND_METH);
     return tmp_meth;
 }
 
@@ -297,11 +279,11 @@ int RAND_set_rand_engine(ENGINE *engine)
             return 0;
         }
     }
-    CRYPTO_THREAD_write_lock(rand_engine_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_RAND_ENGINE);
     /* This function releases any prior ENGINE so call it first */
     RAND_set_rand_method(tmp_meth);
     funct_ref = engine;
-    CRYPTO_THREAD_unlock(rand_engine_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_RAND_ENGINE);
     return 1;
 }
 #endif

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -16,13 +16,11 @@
 #include "store_locl.h"
 #include "internal/glock.h"
 
-static CRYPTO_RWLOCK *registry_lock;
 static CRYPTO_ONCE registry_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE_STATIC(do_registry_init)
 {
-    registry_lock = global_locks[CRYPTO_GLOCK_REGISTRY];
-    return registry_lock != NULL;
+    return OPENSSL_init_crypto(0, NULL);
 }
 
 /*
@@ -167,7 +165,7 @@ int ossl_store_register_loader_int(OSSL_STORE_LOADER *loader)
                       ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(registry_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_REGISTRY);
 
     if (loader_register == NULL) {
         loader_register = lh_OSSL_STORE_LOADER_new(store_loader_hash,
@@ -179,7 +177,7 @@ int ossl_store_register_loader_int(OSSL_STORE_LOADER *loader)
             || lh_OSSL_STORE_LOADER_error(loader_register) == 0))
         ok = 1;
 
-    CRYPTO_THREAD_unlock(registry_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_REGISTRY);
 
     return ok;
 }
@@ -209,7 +207,7 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
                       ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    CRYPTO_THREAD_write_lock(registry_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_REGISTRY);
 
     loader = lh_OSSL_STORE_LOADER_retrieve(loader_register, &template);
 
@@ -219,7 +217,7 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
         ERR_add_error_data(2, "scheme=", scheme);
     }
 
-    CRYPTO_THREAD_unlock(registry_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_REGISTRY);
 
     return loader;
 }
@@ -240,7 +238,7 @@ OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
                       ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    CRYPTO_THREAD_write_lock(registry_lock);
+    OPENSSL_LOCK_lock(CRYPTO_GLOCK_REGISTRY);
 
     loader = lh_OSSL_STORE_LOADER_delete(loader_register, &template);
 
@@ -250,7 +248,7 @@ OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
         ERR_add_error_data(2, "scheme=", scheme);
     }
 
-    CRYPTO_THREAD_unlock(registry_lock);
+    OPENSSL_LOCK_unlock(CRYPTO_GLOCK_REGISTRY);
 
     return loader;
 }
@@ -266,8 +264,6 @@ void ossl_store_destroy_loaders_int(void)
     assert(lh_OSSL_STORE_LOADER_num_items(loader_register) == 0);
     lh_OSSL_STORE_LOADER_free(loader_register);
     loader_register = NULL;
-    /* Clear the local handle to the global lock, freed elsewhere. */
-    registry_lock = NULL;
 }
 
 /*

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -14,13 +14,14 @@
 #include <openssl/err.h>
 #include <openssl/lhash.h>
 #include "store_locl.h"
+#include "internal/glock.h"
 
 static CRYPTO_RWLOCK *registry_lock;
 static CRYPTO_ONCE registry_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE_STATIC(do_registry_init)
 {
-    registry_lock = CRYPTO_THREAD_glock_new("registry");
+    registry_lock = global_locks[CRYPTO_GLOCK_REGISTRY];
     return registry_lock != NULL;
 }
 
@@ -265,7 +266,7 @@ void ossl_store_destroy_loaders_int(void)
     assert(lh_OSSL_STORE_LOADER_num_items(loader_register) == 0);
     lh_OSSL_STORE_LOADER_free(loader_register);
     loader_register = NULL;
-    CRYPTO_THREAD_lock_free(registry_lock);
+    /* Clear the local handle to the global lock, freed elsewhere. */
     registry_lock = NULL;
 }
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -68,7 +68,6 @@ typedef struct {
 typedef void CRYPTO_RWLOCK;
 
 CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void);
-CRYPTO_RWLOCK *CRYPTO_THREAD_glock_new(const char *name);
 int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock);
 int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock);
 int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4389,4 +4389,3 @@ EVP_aria_256_ccm                        4332	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_128_gcm                        4333	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_128_ccm                        4334	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_192_gcm                        4335	1_1_1	EXIST::FUNCTION:ARIA
-CRYPTO_THREAD_glock_new                 4336	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Remove -CRYPTO_THREAD_glock_new() and replace it with a fixed
array of locks; it is unsafe to allow registering additional
global locks at runtime.

Because locks are now identified as offsets into a global table via
enumerated constants, there is no longer a need for the separate 'name'
field, so the array can be of type CRYPTO_RWLOCK* directly.

This also allows us to make the init lock a global lock; it just
happens to be the first one that is initialized, though the init lock
(and a separate glock_lock) are no longer needed to protect the list
structure of the linked list of global locks.

Also enforce the invariant that global locks are only allocated/destroyed
at library initialization/cleanup; remove places where preexisting code
had been freeing a global lock in case of error.

The malloc_lock and long_malloc_lock used by mem_dbg.c are not compatible
with that invariant, as they are used after OPENSSL_cleanup() (in
CRYPTO_mem_leaks_cb()) and before OPENSSL_init_crypto() (since leak
detection must be enabled before the first OPENSSL_malloc()).  As such,
revert them to being non-global locks.  Since they are only used with
the memory debugging facility, it will hopefully be acceptable that
they provide a weaker level of fork/thread-safety than the rest of the
library.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated

but an undocumented function is removed!
