### PR TITLE
OSSL_STORE: Avoid testing with URIs on the command line

### DIFF
--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -38,7 +38,7 @@ setup($test_name);
 # Checking for both msys perl operating environment and that the target name
 # starts with "mingw", we're doing what we can to assure that other configs
 # that might link openssl.exe with the MSYS run-time are not disturbed.
-my $msys = $^O eq 'msys' && config('target') =~ m|^mingw|;
+my $msys_mingw = ($^O eq 'msys') && (config('target') =~ m|^mingw|);
 
 my @noexist_files =
     ( "test/blahdiblah.pem",
@@ -119,7 +119,7 @@ indir "store_$$" => sub {
                 ok(!run(app(["openssl", "storeutl", $file])));
                 ok(!run(app(["openssl", "storeutl", to_abs_file($file)])));
 
-                skip "No test of URI form of $file for mingw", 1 if $msys;
+                skip "No test of URI form of $file for mingw", 1 if $msys_mingw;
 
                 ok(!run(app(["openssl", "storeutl", to_abs_file_uri($file)])));
             }
@@ -130,7 +130,7 @@ indir "store_$$" => sub {
                 ok(run(app(["openssl", "storeutl", $file])));
                 ok(run(app(["openssl", "storeutl", to_abs_file($file)])));
 
-                skip "No test of URI form of $file for mingw", 4 if $msys;
+                skip "No test of URI form of $file for mingw", 4 if $msys_mingw;
 
                 ok(run(app(["openssl", "storeutl", to_abs_file_uri($file)])));
                 ok(run(app(["openssl", "storeutl",
@@ -148,7 +148,7 @@ indir "store_$$" => sub {
                 ok(run(app(["openssl", "storeutl", "-passin", "pass:password",
                             to_abs_file($_)])));
 
-                skip "No test of URI form of $_ for mingw", 2 if $msys;
+                skip "No test of URI form of $_ for mingw", 2 if $msys_mingw;
 
                 ok(run(app(["openssl", "storeutl", "-passin", "pass:password",
                             to_abs_file_uri($_)])));
@@ -158,14 +158,14 @@ indir "store_$$" => sub {
         }
         foreach (values %generated_file_files) {
         SKIP: {
-                skip "No test of $_ for mingw", 1 if $msys;
+                skip "No test of $_ for mingw", 1 if $msys_mingw;
 
                 ok(run(app(["openssl", "storeutl", $_])));
             }
         }
         foreach (@noexist_file_files) {
         SKIP: {
-                skip "No test of $_ for mingw", 1 if $msys;
+                skip "No test of $_ for mingw", 1 if $msys_mingw;
 
                 ok(!run(app(["openssl", "storeutl", $_])));
             }
@@ -176,7 +176,7 @@ indir "store_$$" => sub {
                 ok(run(app(["openssl", "storeutl", $dir])));
                 ok(run(app(["openssl", "storeutl", to_abs_file($dir, 1)])));
 
-                skip "No test of URI form of $dir for mingw", 1 if $msys;
+                skip "No test of URI form of $dir for mingw", 1 if $msys_mingw;
 
                 ok(run(app(["openssl", "storeutl", to_abs_file_uri($dir, 1)])));
             }

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -15,8 +15,8 @@ use OpenSSL::Test::Utils;
 my $test_name = "test_store";
 setup($test_name);
 
-# Programs built with mingw have init code that mangles arguments that look
-# like paths.  The exact conversion rules are listed here:
+# The MSYS run-time mangles arguments that look like paths.  The exact
+# conversion rules are listed here:
 #
 #       http://www.mingw.org/wiki/Posix_path_conversion
 #

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -20,7 +20,7 @@ setup($test_name);
 #
 #       http://www.mingw.org/wiki/Posix_path_conversion
 #
-# With the built in configurations (all having names starting with "mingw"),
+# With the built-in configurations (all having names starting with "mingw"),
 # the openssl application is not linked with the MSYS2 run-time, and therefore,
 # it will receive possibly converted arguments from the process that executes
 # it.  This conversion is fine for normal path arguments, but when those

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -10,7 +10,6 @@ use File::Spec;
 use File::Copy;
 use MIME::Base64;
 use OpenSSL::Test qw(:DEFAULT srctop_file srctop_dir bldtop_file data_file);
-use OpenSSL::Test::Utils;
 
 my $test_name = "test_store";
 setup($test_name);
@@ -24,7 +23,7 @@ setup($test_name);
 # some suitable pattern ("*" to avoid conversions entirely), but that has
 # other unsuitable side effects on paths in the form of URIs, so best avoid
 # them on mingw.
-my $mingw = config('target') =~ m|^mingw|;
+my $msys = $^O eq 'msys';
 
 my @noexist_files =
     ( "test/blahdiblah.pem",
@@ -105,7 +104,7 @@ indir "store_$$" => sub {
                 ok(!run(app(["openssl", "storeutl", $file])));
                 ok(!run(app(["openssl", "storeutl", to_abs_file($file)])));
 
-                skip "No test of URI form of $file on mingw", 1 if $mingw;
+                skip "No test of URI form of $file on mingw", 1 if $msys;
 
                 ok(!run(app(["openssl", "storeutl", to_abs_file_uri($file)])));
             }
@@ -116,7 +115,7 @@ indir "store_$$" => sub {
                 ok(run(app(["openssl", "storeutl", $file])));
                 ok(run(app(["openssl", "storeutl", to_abs_file($file)])));
 
-                skip "No test of URI form of $file on mingw", 4 if $mingw;
+                skip "No test of URI form of $file on mingw", 4 if $msys;
 
                 ok(run(app(["openssl", "storeutl", to_abs_file_uri($file)])));
                 ok(run(app(["openssl", "storeutl",
@@ -134,7 +133,7 @@ indir "store_$$" => sub {
                 ok(run(app(["openssl", "storeutl", "-passin", "pass:password",
                             to_abs_file($_)])));
 
-                skip "No test of URI form of $_ on mingw", 2 if $mingw;
+                skip "No test of URI form of $_ on mingw", 2 if $msys;
 
                 ok(run(app(["openssl", "storeutl", "-passin", "pass:password",
                             to_abs_file_uri($_)])));
@@ -144,14 +143,14 @@ indir "store_$$" => sub {
         }
         foreach (values %generated_file_files) {
         SKIP: {
-                skip "No test of $_ on mingw", 1 if $mingw;
+                skip "No test of $_ on mingw", 1 if $msys;
 
                 ok(run(app(["openssl", "storeutl", $_])));
             }
         }
         foreach (@noexist_file_files) {
         SKIP: {
-                skip "No test of $_ on mingw", 1 if $mingw;
+                skip "No test of $_ on mingw", 1 if $msys;
 
                 ok(!run(app(["openssl", "storeutl", $_])));
             }
@@ -162,7 +161,7 @@ indir "store_$$" => sub {
                 ok(run(app(["openssl", "storeutl", $dir])));
                 ok(run(app(["openssl", "storeutl", to_abs_file($dir, 1)])));
 
-                skip "No test of URI form of $dir on mingw", 1 if $mingw;
+                skip "No test of URI form of $dir on mingw", 1 if $msys;
 
                 ok(run(app(["openssl", "storeutl", to_abs_file_uri($dir, 1)])));
             }


### PR DESCRIPTION
URIs get mistreated by mingw-built programs in the init code.
Unfortunately, avoiding this conversion doesn't help either.

    http://www.mingw.org/wiki/Posix_path_conversion

Fixes #4314