### PR TITLE
Fix an include location problem in the extrended tests.

### DIFF
--- a/test/ossl_shim/build.info
+++ b/test/ossl_shim/build.info
@@ -1,6 +1,6 @@
 IF[{- defined $target{cxx} && !$disabled{"external-tests"}-}]
   PROGRAMS_NO_INST=ossl_shim
   SOURCE[ossl_shim]=ossl_shim.cc async_bio.cc packeted_bio.cc test_config.cc
-  INCLUDE[ossl_shim]=. include ../../include ../..
+  INCLUDE[ossl_shim]=. include ../../include
   DEPEND[ossl_shim]=../../libssl ../../libcrypto
 ENDIF

--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,6 +11,7 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+#include "packeted_bio.h"
 #include <openssl/e_os2.h>
 
 #if !defined(OPENSSL_SYS_WINDOWS)
@@ -53,7 +54,6 @@ OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #include <vector>
 
 #include "async_bio.h"
-#include "packeted_bio.h"
 #include "test_config.h"
 
 namespace bssl {

--- a/test/ossl_shim/packeted_bio.h
+++ b/test/ossl_shim/packeted_bio.h
@@ -10,7 +10,7 @@
 #ifndef HEADER_PACKETED_BIO
 #define HEADER_PACKETED_BIO
 
-#include "e_os.h"
+#include "../../e_os.h"
 #include <openssl/base.h>
 #include <openssl/bio.h>
 


### PR DESCRIPTION
The e_os.h header wan't being found properly.
It was included non-first in one place.

[extended tests]


- [x] tests are added or updated
