### PR TITLE
Fix padding and tests

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -843,7 +843,7 @@ EXT_RETURN tls_construct_ctos_padding(SSL *s, WPACKET *pkt,
          * 1 byte long so as not to have an empty extension last (WebSphere 7.x,
          * 8.x are intolerant of that condition)
          */
-        if (hlen >= 4)
+        if (hlen > 4)
             hlen -= 4;
         else
             hlen = 1;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -90,16 +90,14 @@ static int test_client_hello(int currtest)
     case TEST_PADDING_NOT_NEEDED:
         SSL_CTX_set_options(ctx, SSL_OP_TLSEXT_PADDING);
         /*
-         * Add lots of ciphersuites so that the ClientHello is at least
+         * Add ome dummy ALPN protocols so that the ClientHello is at least
          * F5_WORKAROUND_MIN_MSG_LEN bytes long - meaning padding will be
-         * needed. Also add some dummy ALPN protocols in case we still don't
-         * have enough.
+         * needed.
          */
         if (currtest == TEST_ADD_PADDING
-                && (!TEST_true(SSL_CTX_set_cipher_list(ctx, "ALL"))
-                    || !TEST_false(SSL_CTX_set_alpn_protos(ctx,
-                                               (unsigned char *)alpn_prots,
-                                               sizeof(alpn_prots) - 1))))
+                && (!TEST_false(SSL_CTX_set_alpn_protos(ctx,
+                                    (unsigned char *)alpn_prots,
+                                    sizeof(alpn_prots) - 1))))
             goto end;
 
         break;


### PR DESCRIPTION
The padding extension should always be at least 1 byte long.

Also, clienthellotest tries to fill out the size of the ClientHello by adding
extra ciphersuites in order to test the padding extension. This is
unreliable because they are very dependent on configuration options. If we
add too much data the test will fail! We were already also adding some dummy
ALPN protocols to pad out the size, and it turns out that this is sufficient
just in itself, so drop the extra ciphersuites.

This fixes the test failure reported on openssl-dev by Uri Blumenthal.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
