### PR TITLE
Add a recursive option to 'openssl storeutl'

### DIFF
--- a/doc/man1/storeutl.pod
+++ b/doc/man1/storeutl.pod
@@ -13,6 +13,7 @@ B<openssl> B<storeutl>
 [B<-passin arg>]
 [B<-text arg>]
 [B<-engine id>]
+[B<-r>]
 B<uri> ...
 
 =head1 DESCRIPTION
@@ -53,6 +54,10 @@ specifying an engine (by its unique B<id> string) will cause B<storeutl>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed.
 The engine will then be set as the default for all available algorithms.
+
+=item B<-r>
+
+Fetch objects recursively when possible.
 
 =back
 


### PR DESCRIPTION
Simply put, any NAME type OSS_STORE_INTO is a new object that can be
looked into, and potentially lead to a whole tree of data to dive
into.  The recursive option allows someone to view the whole tree and
its data in one go.
