### PR TITLE
Fix OSSL_STORE's 'file' loader: make sure peekbuf is initialised

### DIFF
--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -855,7 +855,7 @@ static OSSL_STORE_LOADER_CTX *file_open(const OSSL_STORE_LOADER *loader,
         }
     } else {
         BIO *buff = NULL;
-        char peekbuf[4096];
+        char peekbuf[4096] = { 0, };
 
         if ((buff = BIO_new(BIO_f_buffer())) == NULL
             || (ctx->_.file.file = BIO_new_file(path, "rb")) == NULL) {


### PR DESCRIPTION
This quiets down complaints about the use of uninitialised memory
