### PR TITLE
Add SRVName / id-on-dnsSRV

### DIFF
--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -10,7 +10,7 @@
  */
 
 /* Serialized OID's */
-static const unsigned char so[7222] = {
+static const unsigned char so[7230] = {
     0x2A,0x86,0x48,0x86,0xF7,0x0D,                 /* [    0] OBJ_rsadsi */
     0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,            /* [    6] OBJ_pkcs */
     0x2A,0x86,0x48,0x86,0xF7,0x0D,0x02,0x02,       /* [   13] OBJ_md2 */
@@ -1016,9 +1016,10 @@ static const unsigned char so[7222] = {
     0x2A,0x83,0x1A,0x8C,0x9A,0x6E,0x01,0x01,0x22,  /* [ 7194] OBJ_aria_128_gcm */
     0x2A,0x83,0x1A,0x8C,0x9A,0x6E,0x01,0x01,0x23,  /* [ 7203] OBJ_aria_192_gcm */
     0x2A,0x83,0x1A,0x8C,0x9A,0x6E,0x01,0x01,0x24,  /* [ 7212] OBJ_aria_256_gcm */
+    0x2B,0x06,0x01,0x05,0x05,0x07,0x08,0x07,       /* [ 7221] OBJ_id_on_dnsSRV */
 };
 
-#define NUM_NID 1126
+#define NUM_NID 1127
 static const ASN1_OBJECT nid_objs[NUM_NID] = {
     {"UNDEF", "undefined", NID_undef},
     {"rsadsi", "RSA Data Security, Inc.", NID_rsadsi, 6, &so[0]},
@@ -2146,9 +2147,10 @@ static const ASN1_OBJECT nid_objs[NUM_NID] = {
     {"ARIA-128-GCM", "aria-128-gcm", NID_aria_128_gcm, 9, &so[7194]},
     {"ARIA-192-GCM", "aria-192-gcm", NID_aria_192_gcm, 9, &so[7203]},
     {"ARIA-256-GCM", "aria-256-gcm", NID_aria_256_gcm, 9, &so[7212]},
+    {"id-on-dnsSRV", "SRVName other name", NID_id_on_dnsSRV, 8, &so[7221]},
 };
 
-#define NUM_SN 1117
+#define NUM_SN 1118
 static const unsigned int sn_objs[NUM_SN] = {
      364,    /* "AD_DVCS" */
      419,    /* "AES-128-CBC" */
@@ -2759,6 +2761,7 @@ static const unsigned int sn_objs[NUM_SN] = {
      279,    /* "id-mod-qualified-cert-93" */
      281,    /* "id-mod-timestamp-protocol" */
      264,    /* "id-on" */
+    1126,    /* "id-on-dnsSRV" */
      858,    /* "id-on-permanentIdentifier" */
      347,    /* "id-on-personalData" */
      265,    /* "id-pda" */
@@ -3269,7 +3272,7 @@ static const unsigned int sn_objs[NUM_SN] = {
     1093,    /* "x509ExtAdmission" */
 };
 
-#define NUM_LN 1117
+#define NUM_LN 1118
 static const unsigned int ln_objs[NUM_LN] = {
      363,    /* "AD Time Stamping" */
      405,    /* "ANSI X9.62" */
@@ -3399,6 +3402,7 @@ static const unsigned int ln_objs[NUM_LN] = {
      167,    /* "S/MIME Capabilities" */
     1006,    /* "SNILS" */
      387,    /* "SNMPv2" */
+    1126,    /* "SRVName other name" */
     1025,    /* "SSH Client" */
     1026,    /* "SSH Server" */
      512,    /* "Secure Electronic Transactions" */
@@ -4390,7 +4394,7 @@ static const unsigned int ln_objs[NUM_LN] = {
      125,    /* "zlib compression" */
 };
 
-#define NUM_OBJ 1011
+#define NUM_OBJ 1012
 static const unsigned int obj_objs[NUM_OBJ] = {
        0,    /* OBJ_undef                        0 */
      181,    /* OBJ_iso                          1 */
@@ -5011,6 +5015,7 @@ static const unsigned int obj_objs[NUM_OBJ] = {
      346,    /* OBJ_id_cmc_confirmCertAcceptance 1 3 6 1 5 5 7 7 24 */
      347,    /* OBJ_id_on_personalData           1 3 6 1 5 5 7 8 1 */
      858,    /* OBJ_id_on_permanentIdentifier    1 3 6 1 5 5 7 8 3 */
+    1126,    /* OBJ_id_on_dnsSRV                 1 3 6 1 5 5 7 8 7 */
      348,    /* OBJ_id_pda_dateOfBirth           1 3 6 1 5 5 7 9 1 */
      349,    /* OBJ_id_pda_placeOfBirth          1 3 6 1 5 5 7 9 2 */
      351,    /* OBJ_id_pda_gender                1 3 6 1 5 5 7 9 3 */

--- a/crypto/objects/obj_mac.num
+++ b/crypto/objects/obj_mac.num
@@ -1123,3 +1123,4 @@ aria_256_ccm		1122
 aria_128_gcm		1123
 aria_192_gcm		1124
 aria_256_gcm		1125
+id_on_dnsSRV		1126

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -584,6 +584,7 @@ id-cmc 24		: id-cmc-confirmCertAcceptance
 # other names
 id-on 1			: id-on-personalData
 id-on 3			: id-on-permanentIdentifier : Permanent Identifier
+id-on 7			: id-on-dnsSRV : SRVName other name
 
 # personal data attributes
 id-pda 1		: id-pda-dateOfBirth

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -67,23 +67,35 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
 {
     unsigned char *p;
     char oline[256], htmp[5];
-    int i;
+    int i, nid;
     switch (gen->type) {
     case GEN_OTHERNAME:
-    {
-        ASN1_TYPE *value = gen->d.otherName->value;
-        int nid = OBJ_obj2nid(gen->d.otherName->type_id);
-        if ((nid == NID_id_on_dnsSRV) && (value->type == V_ASN1_IA5STRING)) {
-            if (!X509V3_add_value_uchar("SRVName",
-                                        value->value.ia5string->data,
-                                        &ret))
+        nid = OBJ_obj2nid(gen->d.otherName->type_id);
+        if (nid != NID_undef) {
+            const char *sn = OBJ_nid2sn(nid);
+            const unsigned char *data;
+            switch (gen->d.otherName->value->type) {
+            case V_ASN1_IA5STRING:
+                data = gen->d.otherName->value->value.ia5string->data;
+                break;
+            case V_ASN1_PRINTABLESTRING:
+                data = gen->d.otherName->value->value.printablestring->data;
+                break;
+            case V_ASN1_UNIVERSALSTRING:
+                data = gen->d.otherName->value->value.universalstring->data;
+                break;
+            default:
+                data = "<unsupported type>";
+                break;
+            }
+            if (!X509V3_add_value_uchar(sn, data, &ret))
                 return NULL;
         } else {
             if (!X509V3_add_value("othername", "<unsupported>", &ret))
                 return NULL;
         }
         break;
-    }
+
     case GEN_X400:
         if (!X509V3_add_value("X400Name", "<unsupported>", &ret))
             return NULL;
@@ -150,19 +162,33 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
 int GENERAL_NAME_print(BIO *out, GENERAL_NAME *gen)
 {
     unsigned char *p;
-    int i;
+    int i, nid;
     switch (gen->type) {
     case GEN_OTHERNAME:
-    {
-        ASN1_TYPE *value = gen->d.otherName->value;
-        int nid = OBJ_obj2nid(gen->d.otherName->type_id);
-        if ((nid == NID_id_on_dnsSRV) && (value->type == V_ASN1_IA5STRING)) {
-            BIO_printf(out, "SRVName:%s", value->value.ia5string->data);
+        nid = OBJ_obj2nid(gen->d.otherName->type_id);
+        if (nid != NID_undef) {
+            const char *sn = OBJ_nid2sn(nid);
+            const unsigned char *data;
+            switch (gen->d.otherName->value->type) {
+            case V_ASN1_IA5STRING:
+                data = gen->d.otherName->value->value.ia5string->data;
+                break;
+            case V_ASN1_PRINTABLESTRING:
+                data = gen->d.otherName->value->value.printablestring->data;
+                break;
+            case V_ASN1_UNIVERSALSTRING:
+                data = gen->d.otherName->value->value.universalstring->data;
+                break;
+            default:
+                data = "<unsupported type>";
+                break;
+            }
+            BIO_printf(out, "%s:%s", sn, data);
         } else {
             BIO_printf(out, "othername:<unsupported>");
         }
         break;
-    }
+
     case GEN_X400:
         BIO_printf(out, "X400Name:<unsupported>");
         break;

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -1781,6 +1781,11 @@
 #define NID_id_on_permanentIdentifier           858
 #define OBJ_id_on_permanentIdentifier           OBJ_id_on,3L
 
+#define SN_id_on_dnsSRV         "id-on-dnsSRV"
+#define LN_id_on_dnsSRV         "SRVName other name"
+#define NID_id_on_dnsSRV                1126
+#define OBJ_id_on_dnsSRV                OBJ_id_on,7L
+
 #define SN_id_pda_dateOfBirth           "id-pda-dateOfBirth"
 #define NID_id_pda_dateOfBirth          348
 #define OBJ_id_pda_dateOfBirth          OBJ_id_pda,1L


### PR DESCRIPTION
Service name are defined in RFC 4985. This patch adds the OID and NID
for id-on-dnsSRV as well as print support.

A certificate with SRVName other name can be generated with:

```
[ req ext ]
subjectAltName = @san

[ san ]
otherName.1 = 1.3.6.1.5.5.7.8.7;IA5STRING:_https.www.example.org
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
