### PR TITLE
Introduce EVP_PKEY_meth_destroy function

### DIFF
--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -90,6 +90,8 @@ void evp_cleanup_int(void)
 
     EVP_PBE_cleanup();
     OBJ_sigid_free();
+
+    evp_app_cleanup_int();
 }
 
 struct doall_cipher {

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -296,6 +296,21 @@ int EVP_PKEY_meth_add0(const EVP_PKEY_METHOD *pmeth)
     return 1;
 }
 
+void evp_app_cleanup_int(void)
+{
+    if (app_pkey_methods != NULL)
+        sk_EVP_PKEY_METHOD_pop_free(app_pkey_methods, EVP_PKEY_meth_free);
+}
+
+int EVP_PKEY_meth_remove(const EVP_PKEY_METHOD *pmeth)
+{
+    const EVP_PKEY_METHOD *ret;
+
+    ret = sk_EVP_PKEY_METHOD_delete_ptr(app_pkey_methods, pmeth);
+
+    return ret == NULL ? 0 : 1;
+}
+
 size_t EVP_PKEY_meth_get_count(void)
 {
     size_t rv = OSSL_NELEM(standard_methods);

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -393,6 +393,7 @@ struct evp_pkey_st {
 void openssl_add_all_ciphers_int(void);
 void openssl_add_all_digests_int(void);
 void evp_cleanup_int(void);
+void evp_app_cleanup_int(void);
 
 /* Pulling defines out of C soure files */
 

--- a/doc/man3/EVP_PKEY_meth_new.pod
+++ b/doc/man3/EVP_PKEY_meth_new.pod
@@ -13,7 +13,8 @@ EVP_PKEY_meth_get_init, EVP_PKEY_meth_get_copy, EVP_PKEY_meth_get_cleanup,
 EVP_PKEY_meth_get_paramgen, EVP_PKEY_meth_get_keygen, EVP_PKEY_meth_get_sign,
 EVP_PKEY_meth_get_verify, EVP_PKEY_meth_get_verify_recover, EVP_PKEY_meth_get_signctx,
 EVP_PKEY_meth_get_verifyctx, EVP_PKEY_meth_get_encrypt, EVP_PKEY_meth_get_decrypt,
-EVP_PKEY_meth_get_derive, EVP_PKEY_meth_get_ctrl, EVP_PKEY_meth_get_check
+EVP_PKEY_meth_get_derive, EVP_PKEY_meth_get_ctrl, EVP_PKEY_meth_get_check,
+EVP_PKEY_meth_remove
 - manipulating EVP_PKEY_METHOD structure
 
 =head1 SYNOPSIS
@@ -27,6 +28,7 @@ EVP_PKEY_meth_get_derive, EVP_PKEY_meth_get_ctrl, EVP_PKEY_meth_get_check
  void EVP_PKEY_meth_copy(EVP_PKEY_METHOD *dst, const EVP_PKEY_METHOD *src);
  const EVP_PKEY_METHOD *EVP_PKEY_meth_find(int type);
  int EVP_PKEY_meth_add0(const EVP_PKEY_METHOD *pmeth);
+ int EVP_PKEY_meth_remove(const EVP_PKEY_METHOD *pmeth);
 
  void EVP_PKEY_meth_set_init(EVP_PKEY_METHOD *pmeth,
                              int (*init) (EVP_PKEY_CTX *ctx));
@@ -350,6 +352,9 @@ then the built-in objects.
 
 EVP_PKEY_meth_add0() adds B<pmeth> to the user defined stack of methods.
 
+EVP_PKEY_meth_remove() removes an B<EVP_PKEY_METHOD> object added by
+EVP_PKEY_meth_new().
+
 The EVP_PKEY_meth_set functions set the corresponding fields of
 B<EVP_PKEY_METHOD> structure with the arguments passed.
 
@@ -368,6 +373,9 @@ object or returns NULL if not found.
 
 EVP_PKEY_meth_add0() returns 1 if method is added successfully or 0
 if an error occurred.
+
+EVP_PKEY_meth_remove() returns 1 if method is removed successfully or
+0 if an error occurred.
 
 All EVP_PKEY_meth_set and EVP_PKEY_meth_get functions have no return
 values. For the 'get' functions, function pointers are returned by

--- a/doc/man3/EVP_PKEY_meth_new.pod
+++ b/doc/man3/EVP_PKEY_meth_new.pod
@@ -353,7 +353,7 @@ then the built-in objects.
 EVP_PKEY_meth_add0() adds B<pmeth> to the user defined stack of methods.
 
 EVP_PKEY_meth_remove() removes an B<EVP_PKEY_METHOD> object added by
-EVP_PKEY_meth_new().
+EVP_PKEY_meth_add0().
 
 The EVP_PKEY_meth_set functions set the corresponding fields of
 B<EVP_PKEY_METHOD> structure with the arguments passed.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1276,6 +1276,7 @@ void EVP_PKEY_meth_get0_info(int *ppkey_id, int *pflags,
 void EVP_PKEY_meth_copy(EVP_PKEY_METHOD *dst, const EVP_PKEY_METHOD *src);
 void EVP_PKEY_meth_free(EVP_PKEY_METHOD *pmeth);
 int EVP_PKEY_meth_add0(const EVP_PKEY_METHOD *pmeth);
+int EVP_PKEY_meth_remove(const EVP_PKEY_METHOD *pmeth);
 size_t EVP_PKEY_meth_get_count(void);
 const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx);
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -524,8 +524,3 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_EVP_PKEY_check, OSSL_NELEM(keycheckdata));
     return 1;
 }
-
-void cleanup_tests(void)
-{
-    EVP_PKEY_meth_free(custom_pmeth);
-}

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4396,3 +4396,4 @@ UI_get_result_string_length             4339	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_check                          4340	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_set_check                 4341	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_check                 4342	1_1_1	EXIST::FUNCTION:
+EVP_PKEY_meth_remove                    4343	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
To address travis failure in #4337 . This function is used to delete all application added pmeth. ~Only the last commit is related.~ Only last two commits are related to this PR. The first commit is loaned from #4337 ...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
