### PR TITLE
Revert non-trivial commits from wipedout@yandex.ru

### DIFF
--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -156,21 +156,23 @@ static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
      * if the second file specification is missing.
      */
     if (!filespec2 || filespec1[0] == '/') {
-        merged = OPENSSL_strdup(filespec1);
+        merged = OPENSSL_malloc(strlen(filespec1) + 1);
         if (merged == NULL) {
             DSOerr(DSO_F_DL_MERGER, ERR_R_MALLOC_FAILURE);
             return (NULL);
         }
+        strcpy(merged, filespec1);
     }
     /*
      * If the first file specification is missing, the second one rules.
      */
     else if (!filespec1) {
-        merged = OPENSSL_strdup(filespec2);
+        merged = OPENSSL_malloc(strlen(filespec2) + 1);
         if (merged == NULL) {
             DSOerr(DSO_F_DL_MERGER, ERR_R_MALLOC_FAILURE);
             return (NULL);
         }
+        strcpy(merged, filespec2);
     } else
         /*
          * This part isn't as trivial as it looks.  It assumes that the

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -196,21 +196,23 @@ static char *dlfcn_merger(DSO *dso, const char *filespec1,
      * if the second file specification is missing.
      */
     if (!filespec2 || (filespec1 != NULL && filespec1[0] == '/')) {
-        merged = OPENSSL_strdup(filespec1);
+        merged = OPENSSL_malloc(strlen(filespec1) + 1);
         if (merged == NULL) {
             DSOerr(DSO_F_DLFCN_MERGER, ERR_R_MALLOC_FAILURE);
             return (NULL);
         }
+        strcpy(merged, filespec1);
     }
     /*
      * If the first file specification is missing, the second one rules.
      */
     else if (!filespec1) {
-        merged = OPENSSL_strdup(filespec2);
+        merged = OPENSSL_malloc(strlen(filespec2) + 1);
         if (merged == NULL) {
             DSOerr(DSO_F_DLFCN_MERGER, ERR_R_MALLOC_FAILURE);
             return (NULL);
         }
+        strcpy(merged, filespec2);
     } else {
         /*
          * This part isn't as trivial as it looks.  It assumes that the

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -207,6 +207,8 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
 
     if (maxmem == 0)
         maxmem = SCRYPT_MAX_MEM;
+    if (maxmem > SIZE_MAX)
+        maxmem = SIZE_MAX;
 
     if (Blen + Vlen > maxmem) {
         EVPerr(EVP_F_EVP_PBE_SCRYPT, EVP_R_MEMORY_LIMIT_EXCEEDED);

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -27,14 +27,12 @@ int OPENSSL_memcmp(const void *v1, const void *v2, size_t n)
 char *CRYPTO_strdup(const char *str, const char* file, int line)
 {
     char *ret;
-    size_t size;
 
     if (str == NULL)
         return NULL;
-    size = strlen(str) + 1;
-    ret = CRYPTO_malloc(size, file, line);
+    ret = CRYPTO_malloc(strlen(str) + 1, file, line);
     if (ret != NULL)
-        memcpy(ret, str, size);
+        strcpy(ret, str);
     return ret;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2471,7 +2471,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
             *p = '\0';
             return buf;
         }
-        memcpy(p, c->name, n + 1);
+        strcpy(p, c->name);
         p += n;
         *(p++) = ':';
         len -= n + 1;


### PR DESCRIPTION
Reverting commits that could be considered non-trivial.

The changes to pbe_crypt.c are security altering.
