### PR TITLE
Disable the EGD seeding meachanism when stdio is disabled

### DIFF
--- a/Configure
+++ b/Configure
@@ -514,7 +514,7 @@ my @disable_cascades = (
     # no-autoalginit is only useful when building non-shared
     "autoalginit"       => [ "shared", "apps" ],
 
-    "stdio"             => [ "apps", "capieng" ],
+    "stdio"             => [ "apps", "capieng", "egd" ],
     "apps"              => [ "tests" ],
     "tests"             => [ "external-tests" ],
     "comp"              => [ "zlib" ],


### PR DESCRIPTION
crypto/rand/rand_egd.c makes extensive use of stdio functions.  When
they are disabled, it makes sense to disable egd as well.
