### PR TITLE
Add setter for EVP_PKEY_ASN1_METHOD->siginf_set

### DIFF
--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -291,8 +291,7 @@ void EVP_PKEY_asn1_set_private(EVP_PKEY_ASN1_METHOD *ameth,
                                                    const EVP_PKEY *pk),
                                int (*priv_print) (BIO *out,
                                                   const EVP_PKEY *pkey,
-                                                  int indent,
-                                                  ASN1_PCTX *pctx))
+                                                  int indent, ASN1_PCTX *pctx))
 {
     ameth->priv_decode = priv_decode;
     ameth->priv_encode = priv_encode;
@@ -358,4 +357,12 @@ void EVP_PKEY_asn1_set_item(EVP_PKEY_ASN1_METHOD *ameth,
 {
     ameth->item_sign = item_sign;
     ameth->item_verify = item_verify;
+}
+
+void EVP_PKEY_asn1_set_siginf_set(EVP_PKEY_ASN1_METHOD *ameth,
+                                  int (*siginf_set) (X509_SIG_INFO * siginf,
+                                                     const X509_ALGOR *alg,
+                                                     const ASN1_STRING *sig))
+{
+    ameth->siginf_set = siginf_set;
 }

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1195,6 +1195,11 @@ void EVP_PKEY_asn1_set_item(EVP_PKEY_ASN1_METHOD *ameth,
                                               X509_ALGOR *alg2,
                                               ASN1_BIT_STRING *sig));
 
+void EVP_PKEY_asn1_set_siginf_set(EVP_PKEY_ASN1_METHOD *ameth,
+                                  int (*siginf_set) (X509_SIG_INFO *siginf,
+                                                     const X509_ALGOR *alg,
+                                                     const ASN1_STRING *sig));
+
 void EVP_PKEY_asn1_set_security_bits(EVP_PKEY_ASN1_METHOD *ameth,
                                      int (*pkey_security_bits) (const EVP_PKEY
                                                                 *pk));

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4393,3 +4393,4 @@ CRYPTO_THREAD_glock_new                 4336	1_1_1	EXIST::FUNCTION:
 UI_get_result_length                    4337	1_1_1	EXIST::FUNCTION:
 UI_set_result_ex                        4338	1_1_1	EXIST::FUNCTION:
 UI_get_result_string_length             4339	1_1_1	EXIST::FUNCTION:
+EVP_PKEY_asn1_set_siginf_set            4340	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
PR #3301, with commit 786dd2c, adds support for custom signature
parameters: this is used e.g. with RSA-PSS and EdDSA where the signature
type is defined by a single OID (instead of 2 OIDs for the public key
type and the digest).

Unfortunately the commit forgets to add a corresponding setter hook for
the opaque EVP_PKEY_ASN1_METHOD structure, so e.g. ENGINE
implementations do not have access to this new facility.

This is a very simple fix, just adding the mentioned hook and adding it
to the public EVP API.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
<!--
##### Checklist
-->
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
<!--
- [ ] documentation is added or updated
- [ ] tests are added or updated
-->