### PR TITLE
Fix typo in comment

### DIFF
--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -169,7 +169,7 @@ int pkey_main(int argc, char **argv)
             while ((err = ERR_peek_error()) != 0) {
                 BIO_printf(out, "Detailed error: %s\n",
                            ERR_reason_error_string(err));
-                ERR_get_error(); /* remove e from error stack */
+                ERR_get_error(); /* remove err from error stack */
             }
         }
         EVP_PKEY_CTX_free(ctx);


### PR DESCRIPTION
The peek result is now called 'err', not just 'e'.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
