### PR TITLE
Provide getters for min/max proto version

### DIFF
--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -3,7 +3,9 @@
 =head1 NAME
 
 SSL_CTX_set_min_proto_version, SSL_CTX_set_max_proto_version,
-SSL_set_min_proto_version, SSL_set_max_proto_version - Set minimum
+SSL_CTX_get_min_proto_version, SSL_CTX_get_max_proto_version,
+SSL_set_min_proto_version, SSL_set_max_proto_version,
+SSL_get_min_proto_version, SSL_get_max_proto_version - Get and set minimum
 and maximum supported protocol version
 
 =head1 SYNOPSIS
@@ -12,13 +14,17 @@ and maximum supported protocol version
 
  int SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version);
  int SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version);
+ int SSL_CTX_get_min_proto_version(SSL_CTX *ctx);
+ int SSL_CTX_get_max_proto_version(SSL_CTX *ctx);
 
  int SSL_set_min_proto_version(SSL *ssl, int version);
  int SSL_set_max_proto_version(SSL *ssl, int version);
+ int SSL_get_min_proto_version(SSL *ssl);
+ int SSL_get_max_proto_version(SSL *ssl);
 
 =head1 DESCRIPTION
 
-The functions set the minimum and maximum supported protocol versions
+The functions get or set the minimum and maximum supported protocol versions
 for the B<ctx> or B<ssl>.
 This works in combination with the options set via
 L<SSL_CTX_set_options(3)> that also make it possible to disable
@@ -29,13 +35,18 @@ Setting the minimum or maximum version to 0, will enable protocol
 versions down to the lowest version, or up to the highest version
 supported by the library, respectively.
 
+Getters return 0 in case B<ctx> or B<ssl> have been configured to
+automatically use the lowest or highest version supported by the library.
+
 Currently supported versions are B<SSL3_VERSION>, B<TLS1_VERSION>,
 B<TLS1_1_VERSION>, B<TLS1_2_VERSION>, B<TLS1_3_VERSION> for TLS and
 B<DTLS1_VERSION>, B<DTLS1_2_VERSION> for DTLS.
 
 =head1 RETURN VALUES
 
-These functions return 1 on success and 0 on failure.
+These setter functions return 1 on success and 0 on failure. The getter
+functions return the configured version or 0 for auto-configuration of
+lowest or highest protocol, respectively.
 
 =head1 NOTES
 
@@ -43,7 +54,8 @@ All these functions are implemented using macros.
 
 =head1 HISTORY
 
-The functions were added in OpenSSL 1.1.0
+The setter functions were added in OpenSSL 1.1.0. The getter functions
+were added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1247,6 +1247,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE     127
 # define SSL_CTRL_GET_TLSEXT_STATUS_REQ_CB       128
 # define SSL_CTRL_GET_TLSEXT_STATUS_REQ_CB_ARG   129
+# define SSL_CTRL_GET_MIN_PROTO_VERSION          130
+# define SSL_CTRL_GET_MAX_PROTO_VERSION          131
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3
@@ -1391,10 +1393,18 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_CTX_ctrl(ctx, SSL_CTRL_SET_MIN_PROTO_VERSION, version, NULL)
 #define SSL_CTX_set_max_proto_version(ctx, version) \
         SSL_CTX_ctrl(ctx, SSL_CTRL_SET_MAX_PROTO_VERSION, version, NULL)
+#define SSL_CTX_get_min_proto_version(ctx) \
+        SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MIN_PROTO_VERSION, NULL, NULL)
+#define SSL_CTX_get_max_proto_version(ctx) \
+        SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MAX_PROTO_VERSION, NULL, NULL)
 #define SSL_set_min_proto_version(s, version) \
         SSL_ctrl(s, SSL_CTRL_SET_MIN_PROTO_VERSION, version, NULL)
 #define SSL_set_max_proto_version(s, version) \
         SSL_ctrl(s, SSL_CTRL_SET_MAX_PROTO_VERSION, version, NULL)
+#define SSL_get_min_proto_version(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_MIN_PROTO_VERSION, NULL, NULL)
+#define SSL_get_max_proto_version(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, NULL, NULL)
 
 #if OPENSSL_API_COMPAT < 0x10100000L
 /* Provide some compatibility macros for removed functionality. */

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2140,10 +2140,14 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
         return ssl_check_allowed_versions(larg, s->max_proto_version)
                && ssl_set_version_bound(s->ctx->method->version, (int)larg,
                                         &s->min_proto_version);
+    case SSL_CTRL_GET_MIN_PROTO_VERSION:
+        return s->min_proto_version;
     case SSL_CTRL_SET_MAX_PROTO_VERSION:
         return ssl_check_allowed_versions(s->min_proto_version, larg)
                && ssl_set_version_bound(s->ctx->method->version, (int)larg,
                                         &s->max_proto_version);
+    case SSL_CTRL_GET_MAX_PROTO_VERSION:
+        return s->max_proto_version;
     default:
         return (s->method->ssl_ctrl(s, cmd, larg, parg));
     }
@@ -2276,10 +2280,14 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         return ssl_check_allowed_versions(larg, ctx->max_proto_version)
                && ssl_set_version_bound(ctx->method->version, (int)larg,
                                         &ctx->min_proto_version);
+    case SSL_CTRL_GET_MIN_PROTO_VERSION:
+        return ctx->min_proto_version;
     case SSL_CTRL_SET_MAX_PROTO_VERSION:
         return ssl_check_allowed_versions(ctx->min_proto_version, larg)
                && ssl_set_version_bound(ctx->method->version, (int)larg,
                                         &ctx->max_proto_version);
+    case SSL_CTRL_GET_MAX_PROTO_VERSION:
+        return ctx->max_proto_version;
     default:
         return (ctx->method->ssl_ctx_ctrl(ctx, cmd, larg, parg));
     }

--- a/util/private.num
+++ b/util/private.num
@@ -233,6 +233,8 @@ SSL_CTX_disable_ct                      define
 SSL_CTX_get0_chain_certs                define
 SSL_CTX_get_default_read_ahead          define
 SSL_CTX_get_max_cert_list               define
+SSL_CTX_get_max_proto_version           define
+SSL_CTX_get_min_proto_version           define
 SSL_CTX_get_mode                        define
 SSL_CTX_get_read_ahead                  define
 SSL_CTX_get_session_cache_mode          define
@@ -302,6 +304,8 @@ SSL_get_cipher_name                     define
 SSL_get_cipher_version                  define
 SSL_get_extms_support                   define
 SSL_get_max_cert_list                   define
+SSL_get_max_proto_version               define
+SSL_get_min_proto_version               define
 SSL_get_mode                            define
 SSL_get_peer_signature_nid              define
 SSL_get_secure_renegotiation_support    define


### PR DESCRIPTION
OpenSSL 1.1.0 made SSL_CTX and SSL structs opaque and introduced a new
API to set the minimum and maximum protocol version for SSL_CTX with
TLS_method(). Add getters to introspect the configured versions:

  int SSL_CTX_get_min_proto_version(SSL_CTX *ctx);
  int SSL_CTX_get_max_proto_version(SSL_CTX *ctx);
  int SSL_get_min_proto_version(SSL *ssl);
  int SSL_get_max_proto_version(SSL *ssl);

NOTE: The getters do not resolv the version in case when the minimum or
maxium version are configured as '0' (meaning auto-select lowest and
highst version number).

Signed-off-by: Christian Heimes <christian@python.org>

##### Checklist
- [X] documentation is added or updated
- [ ] tests are added or updated
