### PR TITLE
Add explanatory comment about fitting into a size_t.

### DIFF
--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -207,6 +207,8 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
 
     if (maxmem == 0)
         maxmem = SCRYPT_MAX_MEM;
+
+    /* Check that the maximum memory doesn't exceed a size_t limits */
     if (maxmem > SIZE_MAX)
         maxmem = SIZE_MAX;
 


### PR DESCRIPTION
As mentioned by @dot-asm in #4357
A comment has been added to explain the rational behind the range check (i.e. the value must fit into a size_t integer).
