### PR TITLE
CONSTTIME error fixed

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -332,6 +332,9 @@ BIGNUM *BN_copy(BIGNUM *a, const BIGNUM *b)
     if (b->top > 0)
         memcpy(a->d, b->d, sizeof(b->d[0]) * b->top);
 
+    if (BN_get_flags(b, BN_FLG_CONSTTIME) != 0)
+        BN_set_flags(a, BN_FLG_CONSTTIME);
+
     a->top = b->top;
     a->neg = b->neg;
     bn_check_top(a);

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -258,6 +258,8 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
     R = &(mont->RR);            /* grab RR as a temp */
     if (!BN_copy(&(mont->N), mod))
         goto err;               /* Set N */
+    if (BN_get_flags(mod, BN_FLG_CONSTTIME) != 0)
+        BN_set_flags(&(mont->N), BN_FLG_CONSTTIME);
     mont->N.neg = 0;
 
 #ifdef MONT_WORD
@@ -269,6 +271,9 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
         tmod.d = buf;
         tmod.dmax = 2;
         tmod.neg = 0;
+
+        if (BN_get_flags(mod, BN_FLG_CONSTTIME) != 0)
+            BN_set_flags(&tmod, BN_FLG_CONSTTIME);
 
         mont->ri = (BN_num_bits(mod) + (BN_BITS2 - 1)) / BN_BITS2 * BN_BITS2;
 

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -258,8 +258,6 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
     R = &(mont->RR);            /* grab RR as a temp */
     if (!BN_copy(&(mont->N), mod))
         goto err;               /* Set N */
-    if (BN_get_flags(mod, BN_FLG_CONSTTIME) != 0)
-        BN_set_flags(&(mont->N), BN_FLG_CONSTTIME);
     mont->N.neg = 0;
 
 #ifdef MONT_WORD


### PR DESCRIPTION
Fixed error in propagating BN_FLG_CONSTTIME flag through BN_MONT_CTX_set, which could lead to information disclosure on RSA primes p and q.

