### PR TITLE
Null pointer used.

### DIFF
--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -199,7 +199,7 @@ int CTLOG_STORE_load_file(CTLOG_STORE *store, const char *file)
     CTLOG_STORE_LOAD_CTX* load_ctx = ctlog_store_load_ctx_new();
 
     if (load_ctx == NULL)
-        goto end;
+        return 0;
     load_ctx->log_store = store;
     load_ctx->conf = NCONF_new(NULL);
     if (load_ctx->conf == NULL)


### PR DESCRIPTION
Address coverity report of null pointer being dereferenced.


CID 1417771
