### PR TITLE
Stack sorting safety

### DIFF
--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -49,7 +49,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
-    OPENSSL_sk_sort((OPENSSL_STACK *)comp_methods);
+    sk_SSL_COMP_sort(comp_methods);
 
 
     return 1;

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -496,7 +496,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
-    OPENSSL_sk_sort((OPENSSL_STACK *)comp_methods);
+    sk_SSL_COMP_sort(comp_methods);
 
 
     return 1;


### PR DESCRIPTION
Use the defined type checking safe stack method to sort the compression methods rather than using the generic stack sort function by applying type casts.

