### PR TITLE
Configure: unify clang's -Qunused-arguments option treatment.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -763,7 +763,7 @@ sub vms_info {
         inherit_from     => [ "linux-x86" ],
         cc               => "clang",
         cxx              => "clang++",
-        cflags           => add("-Wextra -Qunused-arguments"),
+        cflags           => add("-Wextra"),
     },
     "linux-x86_64" => {
         inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
@@ -777,7 +777,7 @@ sub vms_info {
         inherit_from     => [ "linux-x86_64" ],
         cc               => "clang",
         cxx              => "clang++",
-        cflags           => add("-Wextra -Qunused-arguments"),
+        cflags           => add("-Wextra"),
     },
     "linux-x32" => {
         inherit_from     => [ "linux-generic32", asm("x86_64_asm") ],

--- a/Configure
+++ b/Configure
@@ -141,7 +141,6 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
 my $clang_devteam_warn = ""
-        . " -Qunused-arguments"
         . " -Wswitch-default"
         . " -Wno-parentheses-equality"
         . " -Wno-language-extension-token"
@@ -1319,6 +1318,10 @@ if (defined($config{api})) {
     $config{openssl_api_defines} = [ "OPENSSL_MIN_API=".$apitable->{$config{api}} ];
     my $apiflag = sprintf("OPENSSL_API_COMPAT=%s", $apitable->{$config{api}});
     push @{$config{defines}}, $apiflag;
+}
+
+if (defined($predefined{__clang__}) && !$disabled{asm}) {
+    $config{cflags} .= " -Qunused-arguments";
 }
 
 if ($strict_warnings)


### PR DESCRIPTION
Detect clang even if it's disguised, e.g. cross-compiler or invoked by
explicit path name, and add the option based on that.
