### PR TITLE
Fix overflow in c2i_ASN1_BIT_STRING.

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/asn1.h>
@@ -85,6 +86,11 @@ ASN1_BIT_STRING *c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
 
     if (len < 1) {
         i = ASN1_R_STRING_TOO_SHORT;
+        goto err;
+    }
+
+    if (len > INT_MAX) {
+        i = ASN1_R_STRING_TOO_LONG;
         goto err;
     }
 


### PR DESCRIPTION
c2i_ASN1_BIT_STRING takes length as a long but uses it as an int.  Check
bounds before doing so. Previously, excessively large inputs to the
function could write a single byte outside the target buffer. (This is
unreachable as asn1_ex_c2i already uses int for the length.)

Thanks to NCC for finding this issue. Fix written by Martin Kreichgauer.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
