### PR TITLE
Use size of server key when selecting signature algorithm.

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2285,6 +2285,7 @@ int tls_choose_sigalg(SSL *s, int *al)
         /* Look for a certificate matching shared sigalgs */
         for (i = 0; i < s->cert->shared_sigalgslen; i++) {
             lu = s->cert->shared_sigalgs[i];
+            sig_idx = -1;
 
             /* Skip SHA1, SHA224, DSA and RSA if not PSS */
             if (lu->hash == NID_sha1
@@ -2317,9 +2318,23 @@ int tls_choose_sigalg(SSL *s, int *al)
 #endif
             } else if (lu->sig == EVP_PKEY_RSA_PSS) {
                 /* validate that key is large enough for the signature algorithm */
-                const RSA *rsa = EVP_PKEY_get0_RSA(s->cert->pkeys[SSL_PKEY_RSA_PSS_SIGN].privatekey);
+                EVP_PKEY *pkey;
+                int pkey_id;
 
-                if (!rsa_pss_check_min_key_size(rsa, lu))
+                if (sig_idx == -1)
+                    pkey = s->cert->pkeys[lu->sig_idx].privatekey;
+                else
+                    pkey = s->cert->pkeys[sig_idx].privatekey;
+                pkey_id = EVP_PKEY_id(pkey);
+                if (pkey_id != EVP_PKEY_RSA_PSS
+                    && pkey_id != EVP_PKEY_RSA)
+                    continue;
+                /*
+                 * The pkey type is EVP_PKEY_RSA_PSS or EVP_PKEY_RSA
+                 * EVP_PKEY_get0_RSA returns NULL if the type is not EVP_PKEY_RSA
+                 * so use EVP_PKEY_get0 instead
+                 */
+                if (!rsa_pss_check_min_key_size(EVP_PKEY_get0(pkey), lu))
                     continue;
             }
             break;
@@ -2377,9 +2392,13 @@ int tls_choose_sigalg(SSL *s, int *al)
                     }
                     if (lu->sig == EVP_PKEY_RSA_PSS) {
                         /* validate that key is large enough for the signature algorithm */
-                        const RSA *rsa = EVP_PKEY_get0_RSA(s->cert->pkeys[SSL_PKEY_RSA_PSS_SIGN].privatekey);
+                        EVP_PKEY *pkey = s->cert->pkeys[sig_idx].privatekey;
+                        int pkey_id = EVP_PKEY_id(pkey);
 
-                        if (!rsa_pss_check_min_key_size(rsa, lu))
+                        if (pkey_id != EVP_PKEY_RSA_PSS
+                            && pkey_id != EVP_PKEY_RSA)
+                            continue;
+                        if (!rsa_pss_check_min_key_size(EVP_PKEY_get0(pkey), lu))
                             continue;
                     }
 #ifndef OPENSSL_NO_EC

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -788,6 +788,27 @@ int tls1_lookup_md(const SIGALG_LOOKUP *lu, const EVP_MD **pmd)
 }
 
 /*
+ * Check if key is large enough to generate RSA-PSS signature.
+ *
+ * The key must greater than or equal to 2 * hash length + 2.
+ * SHA512 has a hash length of 64 bytes, which is incompatible
+ * with a 128 byte (1024 bit) key.
+ */
+#define RSA_PSS_MINIMUM_KEY_SIZE(md) (2 * EVP_MD_size(md) + 2)
+static int rsa_pss_check_min_key_size(const RSA *rsa, const SIGALG_LOOKUP *lu)
+{
+    const EVP_MD *md;
+
+    if (rsa == NULL)
+        return 0;
+    if (!tls1_lookup_md(lu, &md) || md == NULL)
+        return 0;
+    if (RSA_size(rsa) < RSA_PSS_MINIMUM_KEY_SIZE(md))
+        return 0;
+    return 1;
+}
+
+/*
  * Return a signature algorithm for TLS < 1.2 where the signature type
  * is fixed by the certificate type.
  */
@@ -2294,6 +2315,12 @@ int tls_choose_sigalg(SSL *s, int *al)
 #else
                 continue;
 #endif
+            } else if (lu->sig == EVP_PKEY_RSA_PSS) {
+                /* validate that key is large enough for the signature algorithm */
+                const RSA *rsa = EVP_PKEY_get0_RSA(s->cert->pkeys[SSL_PKEY_RSA_PSS_SIGN].privatekey);
+
+                if (!rsa_pss_check_min_key_size(rsa, lu))
+                    continue;
             }
             break;
         }
@@ -2347,6 +2374,13 @@ int tls_choose_sigalg(SSL *s, int *al)
                                 continue;
                             sig_idx = SSL_PKEY_RSA;
                         }
+                    }
+                    if (lu->sig == EVP_PKEY_RSA_PSS) {
+                        /* validate that key is large enough for the signature algorithm */
+                        const RSA *rsa = EVP_PKEY_get0_RSA(s->cert->pkeys[SSL_PKEY_RSA_PSS_SIGN].privatekey);
+
+                        if (!rsa_pss_check_min_key_size(rsa, lu))
+                            continue;
                     }
 #ifndef OPENSSL_NO_EC
                     if (curve == -1 || lu->curve == curve)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
The server should not pick a signature algorithm that is incompatible with its configured key if the client offers a compatible algorithm of lower preference.

Fixes #4042
