### PR TITLE
Add len check in X509_NAME_get_text_by_OBJ()

### DIFF
--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -37,7 +37,7 @@ int X509_NAME_get_text_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, char *buf
         return (-1);
     data = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     i = (data->length > (len - 1)) ? (len - 1) : data->length;
-    if (buf == NULL)
+    if (buf == NULL || len <= 0)
         return (data->length);
     memcpy(buf, data->data, i);
     buf[i] = '\0';


### PR DESCRIPTION
Though X509_NAME_get_text_by_NID() and X509_NAME_get_text_by_OBJ() are
legacy functions, it's still better to do necessary parameter check
(len should > 0) to avoid wrong memory operation.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
