### PR TITLE
Reenable s_server -dhparam option

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -795,6 +795,7 @@ const OPTIONS s_server_options[] = {
     {"pass", OPT_PASS, 's', "Private key file pass phrase source"},
     {"dcert", OPT_DCERT, '<',
      "Second certificate file to use (usually for DSA)"},
+    {"dhparam", OPT_DHPARAM, '<', "DH parameters file to use"},
     {"dcertform", OPT_DCERTFORM, 'F',
      "Second certificate format (PEM or DER) PEM default"},
     {"dkey", OPT_DKEY, '<',


### PR DESCRIPTION
This option was lost when converting to a table-driven option parser
in commit 7e1b7485706c2b11091b5fa897fe496a2faa56cc.

