### PR TITLE
Fix misleading indentation in t1_lib.c

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2328,7 +2328,7 @@ int tls_choose_sigalg(SSL *s, int *al)
                 if (lu->sig_idx != SSL_PKEY_RSA_PSS_SIGN
                         || !ssl_has_cert(s, SSL_PKEY_RSA))
                     continue;
-                    sig_idx = SSL_PKEY_RSA;
+                sig_idx = SSL_PKEY_RSA;
             }
             if (lu->sig == EVP_PKEY_EC) {
 #ifndef OPENSSL_NO_EC


### PR DESCRIPTION
The compiler complains about a misleading indentation [-Werror=misleading-indentation]

```
gcc  -I. -Iinclude -DDSO_DLFCN -DHAVE_DLFCN_H -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DRC4_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPADLOCK_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib/engines-1.1\"" -Wall -O0 -g -pthread -m64 -DL_ENDIAN  -DDEBUG_UNUSED -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wswitch -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wtype-limits -Wundef -Werror -fPIC -DOPENSSL_USE_NODELETE -MMD -MF ssl/t1_lib.d.tmp -MT ssl/t1_lib.o -c -o ssl/t1_lib.o ssl/t1_lib.c
ssl/t1_lib.c: In function 'tls_choose_sigalg':
ssl/t1_lib.c:2328:17: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
                 if (lu->sig_idx != SSL_PKEY_RSA_PSS_SIGN
                 ^~
ssl/t1_lib.c:2331:21: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                     sig_idx = SSL_PKEY_RSA;
                     ^~~~~~~
cc1: all warnings being treated as errors
```