### PR TITLE
Add master DRBG for reseeding

### DIFF
--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -313,7 +313,7 @@ int ctr_init(RAND_DRBG *drbg)
     switch (drbg->nid) {
     default:
         /* This can't happen, but silence the compiler warning. */
-        return -1;
+        return 0;
     case NID_aes_128_ctr:
         keylen = 16;
         break;

--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -301,7 +301,7 @@ int ctr_generate(RAND_DRBG *drbg,
 
 int ctr_uninstantiate(RAND_DRBG *drbg)
 {
-    memset(&drbg->ctr, 0, sizeof(drbg->ctr));
+    OPENSSL_cleanse(&drbg->ctr, sizeof(drbg->ctr));
     return 1;
 }
 
@@ -357,6 +357,6 @@ int ctr_init(RAND_DRBG *drbg)
     }
 
     drbg->max_request = 1 << 16;
-    drbg->reseed_interval = MAX_RESEED;
+    drbg->reseed_interval = MAX_RESEED_INTERVAL;
     return 1;
 }

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -20,12 +20,17 @@
 /* How many times to read the TSC as a randomness source. */
 # define TSC_READ_COUNT                 4
 
-/* Maximum reseed interval */
+/* Maximum reseed intervals */
 # define MAX_RESEED_INTERVAL                     (1 << 24)
+# define MAX_RESEED_TIME_INTERVAL                (1 << 20) /* approx. 12 days */
 
 /* Default reseed intervals */
 # define MASTER_RESEED_INTERVAL                  (1 << 8)
 # define SLAVE_RESEED_INTERVAL                   (1 << 16)
+# define MASTER_RESEED_TIME_INTERVAL             (60*60)   /* 1 hour */
+# define SLAVE_RESEED_TIME_INTERVAL              (7*60)    /* 7 minutes */
+
+
 
 /* Max size of additional input and personalization string. */
 # define DRBG_MAX_LENGTH                4096
@@ -118,6 +123,13 @@ struct rand_drbg_st {
      * This value is ignored if it is zero.
      */
     unsigned int reseed_interval;
+    /* Stores the time when the last reseeding occurred */
+    time_t reseed_time;
+    /*
+     * Specifies the maximum time interval (in seconds) between reseeds.
+     * This value is ignored if it is zero.
+     */
+    time_t reseed_time_interval;
     /*
      * Counts the number of reseeds since instantiation.
      * This value is ignored if it is zero.

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -20,8 +20,12 @@
 /* How many times to read the TSC as a randomness source. */
 # define TSC_READ_COUNT                 4
 
-/* Maximum count allowed in reseeding */
-# define MAX_RESEED                     (1 << 24)
+/* Maximum reseed interval */
+# define MAX_RESEED_INTERVAL                     (1 << 24)
+
+/* Default reseed intervals */
+# define MASTER_RESEED_INTERVAL                  (1 << 8)
+# define SLAVE_RESEED_INTERVAL                   (1 << 16)
 
 /* Max size of additional input and personalization string. */
 # define DRBG_MAX_LENGTH                4096
@@ -106,8 +110,26 @@ struct rand_drbg_st {
     size_t min_entropylen, max_entropylen;
     size_t min_noncelen, max_noncelen;
     size_t max_perslen, max_adinlen;
-    unsigned int reseed_counter;
+
+    /* Counts the number of generate requests since the last reseed. */
+    unsigned int generate_counter;
+    /*
+     * Maximum number of generate requests until a reseed is required.
+     * This value is ignored if it is zero.
+     */
     unsigned int reseed_interval;
+    /*
+     * Counts the number of reseeds since instantiation.
+     * This value is ignored if it is zero.
+     *
+     * This counter is used only for seed propagation from the <master> DRBG
+     * to its two children, the <public> and <private> DRBG. This feature is
+     * very special and its sole purpose is to ensure that any randomness which
+     * is added by RAND_add() or RAND_seed() will have an immediate effect on
+     * the output of RAND_bytes() resp. RAND_priv_bytes().
+     */
+    unsigned int reseed_counter;
+
     size_t seedlen;
     DRBG_STATUS state;
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -246,8 +246,8 @@ int RAND_poll(void)
     const RAND_METHOD *meth = RAND_get_rand_method();
 
     if (meth == RAND_OpenSSL()) {
-        /* fill random pool and seed the default DRBG */
-        RAND_DRBG *drbg = RAND_DRBG_get0_global();
+        /* fill random pool and seed the master DRBG */
+        RAND_DRBG *drbg = RAND_DRBG_get0_master();
 
         if (drbg == NULL)
             return 0;
@@ -639,7 +639,7 @@ int RAND_priv_bytes(unsigned char *buf, int num)
     if (meth != RAND_OpenSSL())
         return RAND_bytes(buf, num);
 
-    drbg = RAND_DRBG_get0_priv_global();
+    drbg = RAND_DRBG_get0_private();
     if (drbg == NULL)
         return 0;
 

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -42,9 +42,11 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
 int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
                        int prediction_resistance,
                        const unsigned char *adin, size_t adinlen);
-int RAND_DRBG_set_reseed_interval(RAND_DRBG *drbg, int interval);
-RAND_DRBG *RAND_DRBG_get0_global(void);
-RAND_DRBG *RAND_DRBG_get0_priv_global(void);
+int RAND_DRBG_set_reseed_interval(RAND_DRBG *drbg, unsigned int interval);
+
+RAND_DRBG *RAND_DRBG_get0_master(void);
+RAND_DRBG *RAND_DRBG_get0_public(void);
+RAND_DRBG *RAND_DRBG_get0_private(void);
 
 /*
  * EXDATA

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -43,6 +43,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
                        int prediction_resistance,
                        const unsigned char *adin, size_t adinlen);
 int RAND_DRBG_set_reseed_interval(RAND_DRBG *drbg, unsigned int interval);
+int RAND_DRBG_set_reseed_time_interval(RAND_DRBG *drbg, time_t interval);
 
 RAND_DRBG *RAND_DRBG_get0_master(void);
 RAND_DRBG *RAND_DRBG_get0_public(void);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -691,7 +691,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     if (RAND_get_rand_method() == RAND_OpenSSL()) {
         s->drbg =
             RAND_DRBG_new(RAND_DRBG_NID, RAND_DRBG_FLAG_CTR_USE_DF,
-                          RAND_DRBG_get0_global());
+                          RAND_DRBG_get0_public());
         if (s->drbg == NULL
             || RAND_DRBG_instantiate(s->drbg,
                                      (const unsigned char *) SSL_version_str,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4447,3 +4447,4 @@ RSA_get_version                         4391	1_1_1	EXIST::FUNCTION:RSA
 RSA_meth_get_multi_prime_keygen         4392	1_1_1	EXIST::FUNCTION:RSA
 RSA_meth_set_multi_prime_keygen         4393	1_1_1	EXIST::FUNCTION:RSA
 RAND_DRBG_get0_master                   4394	1_1_1	EXIST::FUNCTION:
+RAND_DRBG_set_reseed_time_interval      4395	1_1_1	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4371,7 +4371,7 @@ SCRYPT_PARAMS_it                        4314	1_1_1	EXIST:EXPORT_VAR_AS_FUNCTION:
 CRYPTO_secure_clear_free                4315	1_1_0g	EXIST::FUNCTION:
 EVP_PKEY_meth_get0                      4316	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_count                 4317	1_1_1	EXIST::FUNCTION:
-RAND_DRBG_get0_global                   4319	1_1_1	EXIST::FUNCTION:
+RAND_DRBG_get0_public                   4319	1_1_1	EXIST::FUNCTION:
 RAND_priv_bytes                         4320	1_1_1	EXIST::FUNCTION:
 BN_priv_rand                            4321	1_1_1	EXIST::FUNCTION:
 BN_priv_rand_range                      4322	1_1_1	EXIST::FUNCTION:
@@ -4381,7 +4381,7 @@ ASN1_TIME_compare                       4325	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_CTX_ctrl_uint64                4326	1_1_1	EXIST::FUNCTION:
 EVP_DigestFinalXOF                      4327	1_1_1	EXIST::FUNCTION:
 ERR_clear_last_mark                     4328	1_1_1	EXIST::FUNCTION:
-RAND_DRBG_get0_priv_global              4329	1_1_1	EXIST::FUNCTION:
+RAND_DRBG_get0_private                  4329	1_1_1	EXIST::FUNCTION:
 EVP_aria_192_ccm                        4330	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_256_gcm                        4331	1_1_1	EXIST::FUNCTION:ARIA
 EVP_aria_256_ccm                        4332	1_1_1	EXIST::FUNCTION:ARIA
@@ -4446,3 +4446,4 @@ RSA_set0_multi_prime_params             4390	1_1_1	EXIST::FUNCTION:RSA
 RSA_get_version                         4391	1_1_1	EXIST::FUNCTION:RSA
 RSA_meth_get_multi_prime_keygen         4392	1_1_1	EXIST::FUNCTION:RSA
 RSA_meth_set_multi_prime_keygen         4393	1_1_1	EXIST::FUNCTION:RSA
+RAND_DRBG_get0_master                   4394	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
##### Checklist

- [x] documentation is added or updated  (as comments)
- [x] tests are added or updated

# The master DRBG

Up to now, there was an asymmetry between the public and the private global DRBG. Only the former was reseeded by the `RAND_add()` call. This pull request introduces a master DRBG which is not publicly accessible. So there are now three global DRBGs:

```
 <os entropy sources>
        |
     <master>          \
      /   \            | three global DRBGs with locking
<public>  <private>    /
    |
  <ssl>
```
The master DRBG is the only DRBG that pulls entropy from the trusted entropy sources, and that is reseeded by the `RAND_add()` call. Three of the DRBGs, namely master, public and private DRBG, have a locking mechanism, while the DRBGs chained to the public DRBG are intended to be used by a single thread and have no locking.

## Naming

In order to get a consistent naming of the three global DRBGs, the two existing DRBGs had to be renamed. This includes the `RAND_DRBG_get0_*()` method which are exported from libcrypto to libssl, but that's no problem because these functions were introduced in master only recently and are not part of an official API yet.

### Module globals

```C
static RAND_DRBG drbg_master;  /* The master DRBG. Seeded from the os */
static RAND_DRBG drbg_public;  /* The global public DRBG. */
static RAND_DRBG drbg_private; /* The global private-key DRBG. */
``` 

### Accessors

```C
RAND_DRBG *RAND_DRBG_get0_master(void);
RAND_DRBG *RAND_DRBG_get0_public(void);
RAND_DRBG *RAND_DRBG_get0_private(void);
```

## Seed Propagation

Instead of having `RAND_add()` reseed all global DRBGs (which would require taking all three locks), we only reseed the master DRBG (because it holds the lock already) and use a simple mechanism to propagate the reseeding to to all chained DRBGs: Every DRBG has a seed count which is incremented whenever the DRBG pulls fresh random input. Any chained DRBG compares in the `RAND_DRBG_generate()` call its seed count with the one of its parent. If there is a mismatch, it seeds itself automatically.

This propagation works for regular reseedings, too, not only for the ones triggered by `RAND_add()`.

**Update:** _As suggested by @paulidale, seed propagation will not proceed to the DRBGs which are owned by a thread or an SSL context, because this would make `RAND_add()` a very expensive operation. Only the global public and private DRBGs will be automatically restarted._  

**Remark:** This "seed count" should have been named `seed_count`, however this name unfortunately collides with the `reseed_counter` member which actually counts generate requests, not reseeds. However, the name `reseed_counter` comes from the NIST standard, so I didn't dare to rename it. Hence I called my counter the `restart_count`.  If anybody has a better suggestion for the name, I'm happy to hear about it.

## Locking

Currently, only the three global DRBGs have a lock. The other chained (SSL) locks are considered to be owned by a single thread. So all locking code needs to check for the presence of the lock first. The lock is currently taken by the caller and it is not clear, whether all cases are currently handled. This is somewhat unsatisfying.

* The lock is owned by the RAND_DRBG "class", which should be an opaque structure, in particular the locking should be managed entirely from within the RAND_DRBG "methods". (Sorry for my C++ speak).
* I doubt that the performance gain of having an rwlock only in some dedicated global DRBGs does not justifies destroying simplicity. So why not have an rwlock in all DRBGs and don't have  to check for the presence of the rwlock. (But I'm not an expert w.r.t. the performance of rwlocks.)

## Debugging

You can debug into the code paths of `RAND_add()` using the `openssl rand` command:

```
echo 'this is some random input' > /tmp/randfile
./util/shlib_wrap.sh gdb --args ./apps/openssl rand -hex -rand /tmp/randfile  12

(gdb) start
(gdb) b drbg_setup
(gdb) b drbg_add
```
