### PR TITLE
Fix 'key' option in s_server can be in ENGINE keyform (1.1.0)

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -704,7 +704,7 @@ OPTIONS s_server_options[] = {
      "PEM serverinfo file for certificate"},
     {"certform", OPT_CERTFORM, 'F',
      "Certificate format (PEM or DER) PEM default"},
-    {"key", OPT_KEY, '<',
+    {"key", OPT_KEY, 's',
      "Private Key if not in -cert; default is " TEST_CERT},
     {"keyform", OPT_KEYFORM, 'f',
      "Key format (PEM, DER or ENGINE) PEM default"},


### PR DESCRIPTION
Basically it is a reflection of `key` in  s_client.c: https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/apps/s_client.c#L580