### PR TITLE
Update comments to match function parameter names

### DIFF
--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -186,7 +186,7 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx);
  */
 void BN_set_negative(BIGNUM *b, int n);
 /** BN_is_negative returns 1 if the BIGNUM is negative
- * \param  a  pointer to the BIGNUM object
+ * \param  b  pointer to the BIGNUM object
  * \return 1 if a < 0 and 0 otherwise
  */
 int BN_is_negative(const BIGNUM *b);

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -774,7 +774,7 @@ EC_KEY *EC_KEY_dup(const EC_KEY *src);
 int EC_KEY_up_ref(EC_KEY *key);
 
 /** Returns the ENGINE object of a EC_KEY object
- *  \param  key  EC_KEY object
+ *  \param  eckey  EC_KEY object
  *  \return the ENGINE object (possibly NULL).
  */
 ENGINE *EC_KEY_get0_engine(const EC_KEY *eckey);


### PR DESCRIPTION
The parameter names of some functions (in particular, `BN_is_negative` and `EC_KEY_get0_engine`) in the comments didn't match the ones in function prototype. I've updated the comments so that they're in agreement.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
