### PR TITLE
Fix assertion failure in s_server

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -206,7 +206,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         OPT_S_SERVERPREF, OPT_S_LEGACYRENEG, OPT_S_LEGACYCONN, \
         OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_ALLOW_NO_DHE_KEX, \
         OPT_S_STRICT, OPT_S_SIGALGS, OPT_S_CLIENTSIGALGS, OPT_S_GROUPS, \
-        OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, OPT_S_DHPARAM, \
+        OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, \
         OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, OPT_S_COMP, \
         OPT_S_NO_RENEGOTIATION, OPT_S__LAST
 
@@ -248,8 +248,6 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         {"named_curve", OPT_S_NAMEDCURVE, 's', \
             "Elliptic curve used for ECDHE (server-side only)" }, \
         {"cipher", OPT_S_CIPHER, 's', "Specify cipher list to be used"}, \
-        {"dhparam", OPT_S_DHPARAM, '<', \
-            "DH parameter file to use, in cert file if not specified"}, \
         {"record_padding", OPT_S_RECORD_PADDING, 's', \
             "Block size to pad TLS 1.3 records to."}, \
         {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \
@@ -280,7 +278,6 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         case OPT_S_CURVES: \
         case OPT_S_NAMEDCURVE: \
         case OPT_S_CIPHER: \
-        case OPT_S_DHPARAM: \
         case OPT_S_RECORD_PADDING: \
         case OPT_S_NO_RENEGOTIATION: \
         case OPT_S_DEBUGBROKE


### PR DESCRIPTION
Avoid duplicate assertion by removing dhparam from SSL_CONF parameter list:
dhparam is handled manually by s_server.

Or put another way #4398 causes s_server to bomb on a debug build with a duplicate parameter assertion failure. This is because the dhparam option *was* handled but was wrongly assumed to be dealt with by the SSL_CONF functions. So we have to remove the duplicate reference.

For master and 1.1.0.