### PR TITLE
CRYPTO_atomic_read

### DIFF
--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -125,6 +125,12 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
+{
+    *ret  = *val;
+    return 1;
+}
+
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -127,7 +127,13 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 
 int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
 {
-    *ret  = *val;
+    *ret = *val;
+    return 1;
+}
+
+int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock)
+{
+    *val = n;
     return 1;
 }
 

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -169,6 +169,25 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
+{
+# if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
+    if (__atomic_is_lock_free(sizeof(*val), val)) {
+        __atomic_load(val, ret, __ATOMIC_ACQUIRE);
+        return 1;
+    }
+# endif
+    if (!CRYPTO_THREAD_write_lock(lock))
+        return 0;
+
+    *ret  = *val;
+
+    if (!CRYPTO_THREAD_unlock(lock))
+        return 0;
+
+    return 1;
+}
+
 # ifdef OPENSSL_SYS_UNIX
 static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
 

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -188,6 +188,25 @@ int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock)
+{
+# if defined(__GNUC__) && defined(__ATOMIC_RELEASE)
+    if (__atomic_is_lock_free(sizeof(*val), val)) {
+        __atomic_store(val, &n, __ATOMIC_RELEASE);
+        return 1;
+    }
+# endif
+    if (!CRYPTO_THREAD_write_lock(lock))
+        return 0;
+
+    *val = n;
+
+    if (!CRYPTO_THREAD_unlock(lock))
+        return 0;
+
+    return 1;
+}
+
 # ifdef OPENSSL_SYS_UNIX
 static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -133,6 +133,12 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
+{
+    InterlockedCompareExchange(val, 0, 0);
+    return 1;
+}
+
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -139,6 +139,12 @@ int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock)
+{
+    InterlockedExchange(val, n);
+    return 1;
+}
+
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -4,7 +4,8 @@
 
 CRYPTO_THREAD_run_once,
 CRYPTO_THREAD_lock_new, CRYPTO_THREAD_read_lock, CRYPTO_THREAD_write_lock,
-CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free, CRYPTO_atomic_add - OpenSSL thread support
+CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free, CRYPTO_atomic_add,
+CRYPTO_atomic_read - OpenSSL thread support
 
 =head1 SYNOPSIS
 
@@ -20,6 +21,7 @@ CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free, CRYPTO_atomic_add - OpenSSL threa
  void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
 
  int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
+ int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock);
 
 =head1 DESCRIPTION
 
@@ -73,6 +75,12 @@ result of the operation in B<ret>. B<lock> will be locked, unless atomic
 operations are supported on the specific platform. Because of this, if a
 variable is modified by CRYPTO_atomic_add() then CRYPTO_atomic_add() must
 be the only way that the variable is modified.
+
+=item *
+
+CRYPTO_atomic_read() atomically reads B<val> and returns the result of
+the operation in B<ret>. B<lock> will be locked, unless atomic operations
+are supported on the specific platform.
 
 =back
 

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -5,7 +5,7 @@
 CRYPTO_THREAD_run_once,
 CRYPTO_THREAD_lock_new, CRYPTO_THREAD_read_lock, CRYPTO_THREAD_write_lock,
 CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free, CRYPTO_atomic_add,
-CRYPTO_atomic_read - OpenSSL thread support
+CRYPTO_atomic_read, CRYPTO_atomic_write - OpenSSL thread support
 
 =head1 SYNOPSIS
 
@@ -22,6 +22,7 @@ CRYPTO_atomic_read - OpenSSL thread support
 
  int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
  int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock);
+ int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock);
 
 =head1 DESCRIPTION
 
@@ -81,6 +82,11 @@ be the only way that the variable is modified.
 CRYPTO_atomic_read() atomically reads B<val> and returns the result of
 the operation in B<ret>. B<lock> will be locked, unless atomic operations
 are supported on the specific platform.
+
+=item *
+
+CRYPTO_atomic_write() atomically writes B<n> to B<val>. B<lock> will be
+locked, unless atomic operations are supported on the specific platform.
 
 =back
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -74,6 +74,7 @@ int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);
 void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
 
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
+int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock);
 
 /*
  * The following can be used to detect memory leaks in the library. If

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -75,6 +75,7 @@ void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
 
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
 int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock);
+int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock);
 
 /*
  * The following can be used to detect memory leaks in the library. If

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4398,3 +4398,4 @@ EVP_PKEY_meth_set_check                 4341	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_check                 4342	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_remove                    4343	1_1_1	EXIST::FUNCTION:
 OPENSSL_sk_reserve                      4344	1_1_1	EXIST::FUNCTION:
+CRYPTO_atomic_read                      4345	1_1_1	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4399,3 +4399,4 @@ EVP_PKEY_meth_get_check                 4342	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_remove                    4343	1_1_1	EXIST::FUNCTION:
 OPENSSL_sk_reserve                      4344	1_1_1	EXIST::FUNCTION:
 CRYPTO_atomic_read                      4345	1_1_1	EXIST::FUNCTION:
+CRYPTO_atomic_write                     4346	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Add a CRYPTO_atomic_read call which allows an int variable to be read in an atomic fashion.


- [x] documentation is added or updated
- [x] tests are added or updated
