### PR TITLE
Lock lhash stats.

### DIFF
--- a/crypto/lhash/lh_stats.c
+++ b/crypto/lhash/lh_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -59,37 +59,33 @@ void OPENSSL_LH_node_usage_stats(const OPENSSL_LHASH *lh, FILE *fp)
 
 # endif
 
-void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lh, BIO *out)
+void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lhp, BIO *out)
 {
-    OPENSSL_LHASH *lh_mut = (OPENSSL_LHASH *) lh;
-    int ret;
+    OPENSSL_LHASH lh;
 
-    BIO_printf(out, "num_items             = %lu\n", lh->num_items);
-    BIO_printf(out, "num_nodes             = %u\n", lh->num_nodes);
-    BIO_printf(out, "num_alloc_nodes       = %u\n", lh->num_alloc_nodes);
-    BIO_printf(out, "num_expands           = %lu\n", lh->num_expands);
-    BIO_printf(out, "num_expand_reallocs   = %lu\n", lh->num_expand_reallocs);
-    BIO_printf(out, "num_contracts         = %lu\n", lh->num_contracts);
-    BIO_printf(out, "num_contract_reallocs = %lu\n",
-               lh->num_contract_reallocs);
-    CRYPTO_atomic_add(&lh_mut->num_hash_calls, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_hash_calls        = %d\n", ret);
-    CRYPTO_atomic_add(&lh_mut->num_comp_calls, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_comp_calls        = %d\n", ret);
-    BIO_printf(out, "num_insert            = %lu\n", lh->num_insert);
-    BIO_printf(out, "num_replace           = %lu\n", lh->num_replace);
-    BIO_printf(out, "num_delete            = %lu\n", lh->num_delete);
-    BIO_printf(out, "num_no_delete         = %lu\n", lh->num_no_delete);
-    CRYPTO_atomic_add(&lh_mut->num_retrieve, 0, &ret, lh->retrieve_stats_lock);
-    BIO_printf(out, "num_retrieve          = %d\n", ret);
-    CRYPTO_atomic_add(&lh_mut->num_retrieve_miss, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_retrieve_miss     = %d\n", ret);
-    CRYPTO_atomic_add(&lh_mut->num_hash_comps, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_hash_comps        = %d\n", ret);
+    if (lhp->stats_lock == NULL)
+        return;
+
+    CRYPTO_THREAD_read_lock(lhp->stats_lock);
+    memcpy(&lh, lhp, sizeof(lh));
+    CRYPTO_THREAD_unlock(lhp->stats_lock);
+
+    BIO_printf(out, "num_items             = %lu\n", lh.num_items);
+    BIO_printf(out, "num_nodes             = %u\n",  lh.num_nodes);
+    BIO_printf(out, "num_alloc_nodes       = %u\n",  lh.num_alloc_nodes);
+    BIO_printf(out, "num_expands           = %lu\n", lh.num_expands);
+    BIO_printf(out, "num_expand_reallocs   = %lu\n", lh.num_expand_reallocs);
+    BIO_printf(out, "num_contracts         = %lu\n", lh.num_contracts);
+    BIO_printf(out, "num_contract_reallocs = %lu\n", lh.num_contract_reallocs);
+    BIO_printf(out, "num_hash_calls        = %lu\n", lh.num_hash_calls);
+    BIO_printf(out, "num_comp_calls        = %lu\n", lh.num_comp_calls);
+    BIO_printf(out, "num_insert            = %lu\n", lh.num_insert);
+    BIO_printf(out, "num_replace           = %lu\n", lh.num_replace);
+    BIO_printf(out, "num_delete            = %lu\n", lh.num_delete);
+    BIO_printf(out, "num_no_delete         = %lu\n", lh.num_no_delete);
+    BIO_printf(out, "num_retrieve          = %lu\n", lh.num_retrieve);
+    BIO_printf(out, "num_retrieve_miss     = %lu\n", lh.num_retrieve_miss);
+    BIO_printf(out, "num_hash_comps        = %lu\n", lh.num_hash_comps);
 }
 
 void OPENSSL_LH_node_stats_bio(const OPENSSL_LHASH *lh, BIO *out)

--- a/crypto/lhash/lhash_lcl.h
+++ b/crypto/lhash/lhash_lcl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -18,13 +18,7 @@ struct lhash_st {
     OPENSSL_LH_NODE **b;
     OPENSSL_LH_COMPFUNC comp;
     OPENSSL_LH_HASHFUNC hash;
-    /*
-     * some stats are updated on lookup, which callers aren't expecting to have
-     * to take an exclusive lock around. This lock protects them on platforms
-     * without atomics, and their types are int rather than unsigned long below
-     * so they can be adjusted with CRYPTO_atomic_add.
-     */
-    CRYPTO_RWLOCK *retrieve_stats_lock;
+    CRYPTO_RWLOCK *stats_lock;
     unsigned int num_nodes;
     unsigned int num_alloc_nodes;
     unsigned int p;
@@ -36,14 +30,14 @@ struct lhash_st {
     unsigned long num_expand_reallocs;
     unsigned long num_contracts;
     unsigned long num_contract_reallocs;
-    int num_hash_calls;
-    int num_comp_calls;
+    unsigned long num_hash_calls;
+    unsigned long num_comp_calls;
     unsigned long num_insert;
     unsigned long num_replace;
     unsigned long num_delete;
     unsigned long num_no_delete;
-    int num_retrieve;
-    int num_retrieve_miss;
-    int num_hash_comps;
+    unsigned long num_retrieve;
+    unsigned long num_retrieve_miss;
+    unsigned long num_hash_comps;
     int error;
 };


### PR DESCRIPTION
Remove atomic operations from the lhash statistics gathering, an inconsistent
output was more than possible.

Instead, use a lock.  The critical sections are deliberately as small as
possible.

The rationale for the NULL checks is to allow a future change to where the
statistics are optional.

