### PR TITLE
WIP: Lhash optional statistics collection.

### DIFF
--- a/crypto/lhash/lh_stats.c
+++ b/crypto/lhash/lh_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -59,37 +59,33 @@ void OPENSSL_LH_node_usage_stats(const OPENSSL_LHASH *lh, FILE *fp)
 
 # endif
 
-void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lh, BIO *out)
+void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lhp, BIO *out)
 {
-    OPENSSL_LHASH *lh_mut = (OPENSSL_LHASH *) lh;
-    int ret;
+    OPENSSL_LHASH lh;
 
-    BIO_printf(out, "num_items             = %lu\n", lh->num_items);
-    BIO_printf(out, "num_nodes             = %u\n", lh->num_nodes);
-    BIO_printf(out, "num_alloc_nodes       = %u\n", lh->num_alloc_nodes);
-    BIO_printf(out, "num_expands           = %lu\n", lh->num_expands);
-    BIO_printf(out, "num_expand_reallocs   = %lu\n", lh->num_expand_reallocs);
-    BIO_printf(out, "num_contracts         = %lu\n", lh->num_contracts);
-    BIO_printf(out, "num_contract_reallocs = %lu\n",
-               lh->num_contract_reallocs);
-    CRYPTO_atomic_add(&lh_mut->num_hash_calls, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_hash_calls        = %d\n", ret);
-    CRYPTO_atomic_add(&lh_mut->num_comp_calls, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_comp_calls        = %d\n", ret);
-    BIO_printf(out, "num_insert            = %lu\n", lh->num_insert);
-    BIO_printf(out, "num_replace           = %lu\n", lh->num_replace);
-    BIO_printf(out, "num_delete            = %lu\n", lh->num_delete);
-    BIO_printf(out, "num_no_delete         = %lu\n", lh->num_no_delete);
-    CRYPTO_atomic_add(&lh_mut->num_retrieve, 0, &ret, lh->retrieve_stats_lock);
-    BIO_printf(out, "num_retrieve          = %d\n", ret);
-    CRYPTO_atomic_add(&lh_mut->num_retrieve_miss, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_retrieve_miss     = %d\n", ret);
-    CRYPTO_atomic_add(&lh_mut->num_hash_comps, 0, &ret,
-                      lh->retrieve_stats_lock);
-    BIO_printf(out, "num_hash_comps        = %d\n", ret);
+    if (lhp->stats_lock == NULL)
+        return;
+
+    CRYPTO_THREAD_read_lock(lhp->stats_lock);
+    memcpy(&lh, lhp, sizeof(lh));
+    CRYPTO_THREAD_unlock(lhp->stats_lock);
+
+    BIO_printf(out, "num_items             = %lu\n", lh.num_items);
+    BIO_printf(out, "num_nodes             = %u\n",  lh.num_nodes);
+    BIO_printf(out, "num_alloc_nodes       = %u\n",  lh.num_alloc_nodes);
+    BIO_printf(out, "num_expands           = %lu\n", lh.num_expands);
+    BIO_printf(out, "num_expand_reallocs   = %lu\n", lh.num_expand_reallocs);
+    BIO_printf(out, "num_contracts         = %lu\n", lh.num_contracts);
+    BIO_printf(out, "num_contract_reallocs = %lu\n", lh.num_contract_reallocs);
+    BIO_printf(out, "num_hash_calls        = %lu\n", lh.num_hash_calls);
+    BIO_printf(out, "num_comp_calls        = %lu\n", lh.num_comp_calls);
+    BIO_printf(out, "num_insert            = %lu\n", lh.num_insert);
+    BIO_printf(out, "num_replace           = %lu\n", lh.num_replace);
+    BIO_printf(out, "num_delete            = %lu\n", lh.num_delete);
+    BIO_printf(out, "num_no_delete         = %lu\n", lh.num_no_delete);
+    BIO_printf(out, "num_retrieve          = %lu\n", lh.num_retrieve);
+    BIO_printf(out, "num_retrieve_miss     = %lu\n", lh.num_retrieve_miss);
+    BIO_printf(out, "num_hash_comps        = %lu\n", lh.num_hash_comps);
 }
 
 void OPENSSL_LH_node_stats_bio(const OPENSSL_LHASH *lh, BIO *out)

--- a/crypto/lhash/lhash_lcl.h
+++ b/crypto/lhash/lhash_lcl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -18,13 +18,7 @@ struct lhash_st {
     OPENSSL_LH_NODE **b;
     OPENSSL_LH_COMPFUNC comp;
     OPENSSL_LH_HASHFUNC hash;
-    /*
-     * some stats are updated on lookup, which callers aren't expecting to have
-     * to take an exclusive lock around. This lock protects them on platforms
-     * without atomics, and their types are int rather than unsigned long below
-     * so they can be adjusted with CRYPTO_atomic_add.
-     */
-    CRYPTO_RWLOCK *retrieve_stats_lock;
+    CRYPTO_RWLOCK *stats_lock;
     unsigned int num_nodes;
     unsigned int num_alloc_nodes;
     unsigned int p;
@@ -36,14 +30,14 @@ struct lhash_st {
     unsigned long num_expand_reallocs;
     unsigned long num_contracts;
     unsigned long num_contract_reallocs;
-    int num_hash_calls;
-    int num_comp_calls;
+    unsigned long num_hash_calls;
+    unsigned long num_comp_calls;
     unsigned long num_insert;
     unsigned long num_replace;
     unsigned long num_delete;
     unsigned long num_no_delete;
-    int num_retrieve;
-    int num_retrieve_miss;
-    int num_hash_comps;
+    unsigned long num_retrieve;
+    unsigned long num_retrieve_miss;
+    unsigned long num_hash_comps;
     int error;
 };

--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -8,7 +8,8 @@ LHASH_DOALL_ARG_FN_TYPE,
 IMPLEMENT_LHASH_HASH_FN, IMPLEMENT_LHASH_COMP_FN,
 lh_TYPE_new, lh_TYPE_free,
 lh_TYPE_insert, lh_TYPE_delete, lh_TYPE_retrieve,
-lh_TYPE_doall, lh_TYPE_doall_arg, lh_TYPE_error - dynamic hash table
+lh_TYPE_doall, lh_TYPE_doall_arg, lh_TYPE_error,
+lh_TYPE_set_stats - dynamic hash table
 
 =head1 SYNOPSIS
 
@@ -28,6 +29,8 @@ lh_TYPE_doall, lh_TYPE_doall_arg, lh_TYPE_error - dynamic hash table
  void lh_TYPE_doall(LHASH_OF(TYPE *table, OPENSSL_LH_DOALL_FUNC func);
  void lh_TYPE_doall_arg(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNCARG func,
           TYPE, TYPE *arg);
+
+ int lh_TYPE_set_stats(LHASH_OF(TYPE) *table, int enable);
 
  int lh_TYPE_error(LHASH_OF(TYPE) *table);
 
@@ -153,6 +156,10 @@ that is provided by the caller):
                    logging_bio);
 
 
+lh_TYPE_set_stats() is used to enable and disable the collection of
+statistical information about the hash table. After OPENSSL_LH_new
+collection is disabled.
+
 lh_TYPE_error() can be used to determine if an error occurred in the last
 operation.
 
@@ -169,6 +176,8 @@ there is no such value in the hash table.
 
 lh_TYPE_retrieve() returns the hash table entry if it has been found,
 B<NULL> otherwise.
+
+lh_TYPE_set_stats() return 1 if successful and 0 on error.
 
 lh_TYPE_error() returns 1 if an error occurred in the last operation, 0
 otherwise.
@@ -229,7 +238,7 @@ type checking.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/OPENSSL_LH_stats.pod
+++ b/doc/man3/OPENSSL_LH_stats.pod
@@ -20,8 +20,10 @@ OPENSSL_LH_node_stats_bio, OPENSSL_LH_node_usage_stats_bio - LHASH statistics
 
 =head1 DESCRIPTION
 
-The B<LHASH> structure records statistics about most aspects of
-accessing the hash table.
+The B<LHASH> structure can record statistics about most aspects of
+accessing the hash table. Please see L<OPENSSL_LH_stats(3)> for
+the call B<lh_TYPE_set_stats> to enable statistics collection.
+Statistics collection is disabled by default.
 
 OPENSSL_LH_stats() prints out statistics on the size of the hash table, how
 many entries are in it, and the number and result of calls to the
@@ -48,11 +50,11 @@ These functions do not return values.
 
 =head1 SEE ALSO
 
-L<bio(7)>, L<LHASH(3)>
+L<bio(7)>, L<OPENSSL_LH_stats(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -90,6 +90,7 @@ void OPENSSL_LH_node_usage_stats(const OPENSSL_LHASH *lh, FILE *fp);
 void OPENSSL_LH_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
 void OPENSSL_LH_node_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
+int OPENSSL_LH_set_stats(OPENSSL_LHASH *lh, int enable);
 
 # if OPENSSL_API_COMPAT < 0x10100000L
 #  define _LHASH OPENSSL_LHASH
@@ -162,6 +163,10 @@ void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
     static ossl_inline void lh_##type##_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_stats_bio((const OPENSSL_LHASH *)lh, out); \
+    } \
+    static ossl_inline int lh_##type##_set_stats(LHASH_OF(type) *lh, int enable) \
+    { \
+        return OPENSSL_LH_set_stats((OPENSSL_LHASH *)lh, enable); \
     } \
     static ossl_inline unsigned long lh_##type##_get_down_load(LHASH_OF(type) *lh) \
     { \

--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -174,6 +174,9 @@ static int test_stress(void)
     if (!TEST_ptr(h))
         goto end;
 
+    if (!lh_int_set_stats(h, 1))
+        TEST_info("lh_int_set_stats failed, continuing without statistics");
+
     /* insert */
     for (i = 0; i < n; i++) {
         p = OPENSSL_malloc(sizeof(i));

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4397,3 +4397,4 @@ EVP_PKEY_check                          4340	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_set_check                 4341	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_check                 4342	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_remove                    4343	1_1_1	EXIST::FUNCTION:
+OPENSSL_LH_set_stats                    4344	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION

- [x] documentation is added or updated
- [x] tests are added or updated

This PR makes the statistics collection in the lhash object optional and disabled by default.
This means zero locking overhead unless the gathering is enabled.

This depends on #4418 for the locking changes to the lhash object.  Only the final commit is relevant and this will be squashed before merge.

This is an API breaking change in the sense that the statistics functions `OPENSSL_LH_stats` and `OPENSSL_LH_stats_bio` will not function properly without adding an enable call.  The other stats calls still work.
