### PR TITLE
Safestack

### DIFF
--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -538,7 +538,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
         } else if (ret == -1)
             return -1;
         if (!*val)
-            *val = (ASN1_VALUE *)OPENSSL_sk_new_null();
+            *val = (ASN1_VALUE *)sk_ASN1_VALUE_new_null();
         else {
             /*
              * We've got a valid STACK: free up any items present

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include <string.h>
 #include "internal/cryptlib.h"
-#include <openssl/stack.h>
 #include <openssl/lhash.h>
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/stack.h>
+#include <openssl/safestack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509_ext.c
+++ b/crypto/x509/x509_ext.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/stack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/stack.h>
+#include <openssl/safestack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/stack.h>
+#include <openssl/safestack.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/stack.h>
 #include <openssl/buffer.h>
 #include <openssl/asn1.h>
 #include <openssl/evp.h>

--- a/doc/man3/DEFINE_STACK_OF.pod
+++ b/doc/man3/DEFINE_STACK_OF.pod
@@ -4,13 +4,6 @@
 
 DEFINE_STACK_OF, DEFINE_STACK_OF_CONST, DEFINE_SPECIAL_STACK_OF,
 DEFINE_SPECIAL_STACK_OF_CONST,
-OPENSSL_sk_deep_copy, OPENSSL_sk_delete, OPENSSL_sk_delete_ptr,
-OPENSSL_sk_dup, OPENSSL_sk_find, OPENSSL_sk_find_ex,
-OPENSSL_sk_free, OPENSSL_sk_insert, OPENSSL_sk_is_sorted,
-OPENSSL_sk_new, OPENSSL_sk_new_null, OPENSSL_sk_num, OPENSSL_sk_pop,
-OPENSSL_sk_pop_free, OPENSSL_sk_push, OPENSSL_sk_reserve, OPENSSL_sk_set,
-OPENSSL_sk_set_cmp_func, OPENSSL_sk_shift, OPENSSL_sk_sort,
-OPENSSL_sk_unshift, OPENSSL_sk_value, OPENSSL_sk_zero,
 sk_TYPE_num, sk_TYPE_value, sk_TYPE_new, sk_TYPE_new_null,
 sk_TYPE_reserve, sk_TYPE_free, sk_TYPE_zero, sk_TYPE_delete,
 sk_TYPE_delete_ptr, sk_TYPE_push, sk_TYPE_unshift, sk_TYPE_pop,
@@ -197,6 +190,17 @@ A failed search is indicated by a B<-1> return value.
 
 STACK_OF(), DEFINE_STACK_OF(), DEFINE_STACK_OF_CONST(), and
 DEFINE_SPECIAL_STACK_OF() are implemented as macros.
+
+The underlying utility B<OPENSSL_sk_> API should not be used directly.
+It defines these functions: OPENSSL_sk_deep_copy(),
+OPENSSL_sk_delete(), OPENSSL_sk_delete_ptr(), OPENSSL_sk_dup(),
+OPENSSL_sk_find(), OPENSSL_sk_find_ex(), OPENSSL_sk_free(),
+OPENSSL_sk_insert(), OPENSSL_sk_is_sorted(), OPENSSL_sk_new(),
+OPENSSL_sk_new_null(), OPENSSL_sk_num(), OPENSSL_sk_pop(),
+OPENSSL_sk_pop_free(), OPENSSL_sk_push(), OPENSSL_sk_reserve(),
+OPENSSL_sk_set(), OPENSSL_sk_set_cmp_func(), OPENSSL_sk_shift(),
+OPENSSL_sk_sort(), OPENSSL_sk_unshift(), OPENSSL_sk_value(),
+OPENSSL_sk_zero().
 
 =head1 RETURN VALUES
 

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,8 +14,6 @@
 # include <openssl/e_os2.h>
 # include <openssl/opensslconf.h>
 # include <openssl/bio.h>
-# include <openssl/stack.h>
-# include <openssl/safestack.h>
 # include <openssl/asn1err.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,8 +12,6 @@
 
 # include <openssl/bio.h>
 # include <openssl/lhash.h>
-# include <openssl/stack.h>
-# include <openssl/safestack.h>
 # include <openssl/e_os2.h>
 # include <openssl/ossl_typ.h>
 # include <openssl/conferr.h>

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -20,7 +20,6 @@
 #  include <stdio.h>
 # endif
 
-# include <openssl/stack.h>
 # include <openssl/safestack.h>
 # include <openssl/opensslv.h>
 # include <openssl/ossl_typ.h>

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,6 @@
 
 # include <openssl/e_os2.h>
 # include <openssl/bio.h>
-# include <openssl/stack.h>
 # include <openssl/evp.h>
 # include <openssl/x509.h>
 # include <openssl/pem2.h>

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,9 +17,7 @@
 # include <openssl/buffer.h>
 # include <openssl/evp.h>
 # include <openssl/bio.h>
-# include <openssl/stack.h>
 # include <openssl/asn1.h>
-# include <openssl/safestack.h>
 # include <openssl/rsa.h>
 # include <openssl/dsa.h>
 # include <openssl/dh.h>

--- a/include/openssl/txt_db.h
+++ b/include/openssl/txt_db.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,6 @@
 
 # include <openssl/opensslconf.h>
 # include <openssl/bio.h>
-# include <openssl/stack.h>
 # include <openssl/lhash.h>
 
 # define DB_ERROR_OK                     0

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
@@ -17,9 +17,7 @@
 # include <openssl/buffer.h>
 # include <openssl/evp.h>
 # include <openssl/bio.h>
-# include <openssl/stack.h>
 # include <openssl/asn1.h>
-# include <openssl/safestack.h>
 # include <openssl/ec.h>
 
 # if OPENSSL_API_COMPAT < 0x10100000L

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -21,7 +21,6 @@
 # include <openssl/buffer.h>
 # include <openssl/comp.h>
 # include <openssl/bio.h>
-# include <openssl/stack.h>
 # include <openssl/rsa.h>
 # include <openssl/dsa.h>
 # include <openssl/err.h>


### PR DESCRIPTION

- [x] documentation is added or updated

Exclusively use the safestack wrappers for all stack use internally.
Hide the OPENSSL_sk_ API functions a bit better in the POD.  They are still available.
Remove unnecessary `#include <openssl/(safe)?stack.h>`.