### PR TITLE
remove lhash.h includes.

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -18,7 +18,6 @@
 # include <openssl/ossl_typ.h>
 # include <openssl/bio.h>
 # include <openssl/x509.h>
-# include <openssl/lhash.h>
 # include <openssl/conf.h>
 # include <openssl/txt_db.h>
 # include <openssl/engine.h>

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include "apps.h"
 #include <openssl/bio.h>
-#include <openssl/lhash.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -35,7 +35,6 @@
 typedef unsigned int u_int;
 #endif
 
-#include <openssl/lhash.h>
 #include <openssl/bn.h>
 #include "apps.h"
 #include <openssl/err.h>

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -16,7 +16,6 @@
 #include <openssl/conf.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
-#include <openssl/lhash.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -13,7 +13,6 @@
 #include "internal/cryptlib_int.h"
 #include "internal/err.h"
 #include "internal/err_int.h"
-#include <openssl/lhash.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>
 #include <openssl/buffer.h>

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/lhash.h>
 #include <openssl/crypto.h>
 #include <openssl/buffer.h>
 #include <openssl/err.h>

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 
 #include "internal/cryptlib_int.h"
 #include "internal/thread_once.h"
-#include <openssl/lhash.h>
 
 /*
  * Each structure type (sometimes called a class), that supports

--- a/crypto/objects/obj_lib.c
+++ b/crypto/objects/obj_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/lhash.h>
 #include <openssl/objects.h>
 #include <openssl/buffer.h>
 #include "internal/asn1_int.h"

--- a/crypto/rsa/rsa_crpt.c
+++ b/crypto/rsa/rsa_crpt.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
-#include <openssl/lhash.h>
 #include "internal/bn_int.h"
 #include <openssl/rand.h>
 #include "rsa_locl.h"

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -11,7 +11,6 @@
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
-#include <openssl/lhash.h>
 #include "internal/bn_int.h"
 #include <openssl/engine.h>
 #include <openssl/evp.h>

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -18,8 +18,6 @@
 # include <sys/stat.h>
 #endif
 
-
-#include <openssl/lhash.h>
 #include <openssl/x509.h>
 #include "internal/x509_int.h"
 #include "x509_lcl.h"

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -12,7 +12,6 @@
 #include <errno.h>
 
 #include "internal/cryptlib.h"
-#include <openssl/lhash.h>
 #include <openssl/buffer.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
-#include <openssl/lhash.h>
 #include <openssl/x509.h>
 #include "internal/x509_int.h"
 #include <openssl/x509v3.h>

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include <openssl/lhash.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 #include <openssl/buffer.h>

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,6 @@
 #include <errno.h>
 
 #include "internal/cryptlib.h"
-#include <openssl/lhash.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/asn1.h>

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -15,7 +15,6 @@
 #include "internal/ctype.h"
 #include "internal/cryptlib.h"
 #include <openssl/crypto.h>
-#include <openssl/lhash.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/asn1.h>

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2004-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,7 +11,6 @@
 
 #include "internal/cryptlib.h"
 #include <openssl/crypto.h>
-#include <openssl/lhash.h>
 #include <openssl/buffer.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -19,9 +19,9 @@
 # if OPENSSL_API_COMPAT < 0x10100000L
 #  include <openssl/x509.h>
 #  include <openssl/crypto.h>
-#  include <openssl/lhash.h>
 #  include <openssl/buffer.h>
 # endif
+# include <openssl/lhash.h>
 # include <openssl/pem.h>
 # include <openssl/hmac.h>
 # include <openssl/async.h>

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -13,7 +13,6 @@
 
 #include "internal/nelem.h"
 #include "internal/o_dir.h"
-#include <openssl/lhash.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/x509v3.h>

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include "ssl_locl.h"
 #include <openssl/objects.h>
-#include <openssl/lhash.h>
 #include <openssl/x509v3.h>
 #include <openssl/rand.h>
 #include <openssl/ocsp.h>

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -9,7 +9,6 @@
  */
 
 #include <stdio.h>
-#include <openssl/lhash.h>
 #include <openssl/rand.h>
 #include <openssl/engine.h>
 #include "internal/refcount.h"


### PR DESCRIPTION
Remove unnecessary #include <openssl/lhash.h> directives.

