### PR TITLE
Fix public headers

### DIFF
--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -14,6 +14,7 @@
 # include <openssl/e_os2.h>
 # include <openssl/opensslconf.h>
 # include <openssl/bio.h>
+# include <openssl/safestack.h>
 # include <openssl/asn1err.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -12,6 +12,7 @@
 
 # include <openssl/bio.h>
 # include <openssl/lhash.h>
+# include <openssl/safestack.h>
 # include <openssl/e_os2.h>
 # include <openssl/ossl_typ.h>
 # include <openssl/conferr.h>

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -12,6 +12,7 @@
 
 # include <openssl/e_os2.h>
 # include <openssl/bio.h>
+# include <openssl/safestack.h>
 # include <openssl/evp.h>
 # include <openssl/x509.h>
 # include <openssl/pem2.h>

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -18,6 +18,7 @@
 # include <openssl/evp.h>
 # include <openssl/bio.h>
 # include <openssl/asn1.h>
+# include <openssl/safestack.h>
 # include <openssl/rsa.h>
 # include <openssl/dsa.h>
 # include <openssl/dh.h>

--- a/include/openssl/txt_db.h
+++ b/include/openssl/txt_db.h
@@ -12,6 +12,7 @@
 
 # include <openssl/opensslconf.h>
 # include <openssl/bio.h>
+# include <openssl/safestack.h>
 # include <openssl/lhash.h>
 
 # define DB_ERROR_OK                     0

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -18,6 +18,7 @@
 # include <openssl/evp.h>
 # include <openssl/bio.h>
 # include <openssl/asn1.h>
+# include <openssl/safestack.h>
 # include <openssl/ec.h>
 
 # if OPENSSL_API_COMPAT < 0x10100000L


### PR DESCRIPTION
Put back the `#include <openssl/safestack.h>` lines in public headers.
`#include <openssl/stack.h>` have been omitted or changed since `safestack.h` includes `stack.h`.

This follows #4430 which some public headers were changed.
