### PR TITLE
doc: BN_free() is NULL-safe

### DIFF
--- a/doc/crypto/BN_new.pod
+++ b/doc/crypto/BN_new.pod
@@ -30,6 +30,7 @@ to the value 0.
 BN_free() frees the components of the B<BIGNUM>, and if it was created
 by BN_new(), also the structure itself. BN_clear_free() additionally
 overwrites the data before the memory is returned to the system.
+If B<a> is NULL, nothing is done.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
document that parameter to BN_free can be NULL

backport from master

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
