### PR TITLE
doc: note that the BN_new() initialises the BIGNUM

### DIFF
--- a/doc/crypto/BN_new.pod
+++ b/doc/crypto/BN_new.pod
@@ -33,7 +33,8 @@ overwrites the data before the memory is returned to the system.
 
 =head1 RETURN VALUES
 
-BN_new() returns a pointer to the B<BIGNUM>. If the allocation fails,
+BN_new() returns a pointer to the B<BIGNUM> initialised to the value 0.
+If the allocation fails,
 it returns B<NULL> and sets an error code that can be obtained
 by L<ERR_get_error(3)|ERR_get_error(3)>.
 


### PR DESCRIPTION
BN_new() and BN_secure_new() not only allocate memory, but also
initialise it to deterministic value - 0.

Document that behaviour to make it explicit

backport from #4438

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated