### PR TITLE
Fixes #4459 "issuserAltName" documentation typo.

### DIFF
--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -205,7 +205,7 @@ certificate (if possible).
 
 Example:
 
- issuserAltName = issuer:copy
+ issuerAltName = issuer:copy
 
 
 =head2 Authority Info Access.


### PR DESCRIPTION
See crypto/objects/objects.txt:767 -- field is "issuerAltName"

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
