### PR TITLE
Further group handling revision.

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2347,7 +2347,7 @@ SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 #  ifndef OPENSSL_NO_EC
 
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t curve_id);
-__owur int tls1_check_curve(SSL *s, const unsigned char *p, size_t len);
+__owur int tls1_check_group_id(SSL *s, uint16_t group_id);
 __owur uint16_t tls1_shared_group(SSL *s, int nmatch);
 __owur int tls1_set_groups(uint16_t **pext, size_t *pextlen,
                            int *curves, size_t ncurves);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2085,6 +2085,13 @@ static ossl_inline int ssl_has_cert(const SSL *s, int idx)
         && s->cert->pkeys[idx].privatekey != NULL;
 }
 
+static ossl_inline void tls1_get_peer_groups(SSL *s, const uint16_t **pgroups,
+                                             size_t *pgroupslen)
+{
+    *pgroups = s->session->ext.supportedgroups;
+    *pgroupslen = s->session->ext.supportedgroups_len;
+}
+
 # ifndef OPENSSL_UNIT_TEST
 
 __owur int ssl_read_internal(SSL *s, void *buf, size_t num, size_t *readbytes);
@@ -2354,8 +2361,8 @@ __owur EVP_PKEY *ssl_generate_param_group(uint16_t id);
 #  endif                        /* OPENSSL_NO_EC */
 
 __owur int tls_curve_allowed(SSL *s, uint16_t curve, int op);
-void tls1_get_grouplist(SSL *s, int sess, const uint16_t **pcurves,
-                        size_t *num_curves);
+void tls1_get_supported_groups(SSL *s, const uint16_t **pgroups,
+                               size_t *pgroupslen);
 
 __owur int tls1_set_server_sigalgs(SSL *s);
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1167,25 +1167,25 @@ static int final_key_share(SSL *s, unsigned int context, int sent, int *al)
                 && (!s->hit
                     || (s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE_DHE)
                        != 0)) {
-            const uint16_t *pcurves, *clntcurves;
-            size_t num_curves, clnt_num_curves, i;
+            const uint16_t *pgroups, *clntgroups;
+            size_t num_groups, clnt_num_groups, i;
             unsigned int group_id = 0;
 
             /* Check if a shared group exists */
 
             /* Get the clients list of supported groups. */
-            tls1_get_peer_groups(s, &clntcurves, &clnt_num_curves);
-            tls1_get_supported_groups(s, &pcurves, &num_curves);
+            tls1_get_peer_groups(s, &clntgroups, &clnt_num_groups);
+            tls1_get_supported_groups(s, &pgroups, &num_groups);
 
             /* Find the first group we allow that is also in client's list */
-            for (i = 0; i < num_curves; i++) {
-                group_id = pcurves[i];
+            for (i = 0; i < num_groups; i++) {
+                group_id = pgroups[i];
 
-                if (check_in_list(s, group_id, clntcurves, clnt_num_curves, 1))
+                if (check_in_list(s, group_id, clntgroups, clnt_num_groups, 1))
                     break;
             }
 
-            if (i < num_curves) {
+            if (i < num_groups) {
                 /* A shared group exists so send a HelloRetryRequest */
                 s->s3->group_id = group_id;
                 s->hello_retry_request = 1;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1174,8 +1174,8 @@ static int final_key_share(SSL *s, unsigned int context, int sent, int *al)
             /* Check if a shared group exists */
 
             /* Get the clients list of supported groups. */
-            tls1_get_grouplist(s, 1, &clntcurves, &clnt_num_curves);
-            tls1_get_grouplist(s, 0, &pcurves, &num_curves);
+            tls1_get_peer_groups(s, &clntcurves, &clnt_num_curves);
+            tls1_get_supported_groups(s, &pcurves, &num_curves);
 
             /* Find the first group we allow that is also in client's list */
             for (i = 0; i < num_curves; i++) {

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -149,7 +149,7 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
      * Add TLS extension supported_groups to the ClientHello message
      */
     /* TODO(TLS1.3): Add support for DHE groups */
-    tls1_get_grouplist(s, 0, &pcurves, &num_curves);
+    tls1_get_supported_groups(s, &pcurves, &num_curves);
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_supported_groups)
                /* Sub-packet for supported_groups extension */
@@ -604,7 +604,7 @@ EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
         return EXT_RETURN_FAIL;
     }
 
-    tls1_get_grouplist(s, 0, &pcurves, &num_curves);
+    tls1_get_supported_groups(s, &pcurves, &num_curves);
 
     /*
      * TODO(TLS1.3): Make the number of key_shares sent configurable. For
@@ -1534,7 +1534,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         }
 
         /* Validate the selected group is one we support */
-        tls1_get_grouplist(s, 0, &pcurves, &num_curves);
+        tls1_get_supported_groups(s, &pcurves, &num_curves);
         for (i = 0; i < num_curves; i++) {
             if (group_id == pcurves[i])
                 break;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -520,9 +520,9 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     /* Get our list of supported curves */
-    tls1_get_grouplist(s, 0, &srvrcurves, &srvr_num_curves);
+    tls1_get_supported_groups(s, &srvrcurves, &srvr_num_curves);
     /* Get the clients list of supported curves. */
-    tls1_get_grouplist(s, 1, &clntcurves, &clnt_num_curves);
+    tls1_get_peer_groups(s, &clntcurves, &clnt_num_curves);
     if (clnt_num_curves == 0) {
         /*
          * This can only happen if the supported_groups extension was not sent,
@@ -885,7 +885,7 @@ EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
         return EXT_RETURN_NOT_SENT;
 
     /* Get our list of supported groups */
-    tls1_get_grouplist(s, 0, &groups, &numgroups);
+    tls1_get_supported_groups(s, &groups, &numgroups);
     if (numgroups == 0) {
         SSLerr(SSL_F_TLS_CONSTRUCT_STOC_SUPPORTED_GROUPS, ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -499,8 +499,8 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 #ifndef OPENSSL_NO_TLS1_3
     unsigned int group_id;
     PACKET key_share_list, encoded_pt;
-    const uint16_t *clntcurves, *srvrcurves;
-    size_t clnt_num_curves, srvr_num_curves;
+    const uint16_t *clntgroups, *srvrgroups;
+    size_t clnt_num_groups, srvr_num_groups;
     int found = 0;
 
     if (s->hit && (s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE_DHE) == 0)
@@ -519,11 +519,11 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 0;
     }
 
-    /* Get our list of supported curves */
-    tls1_get_supported_groups(s, &srvrcurves, &srvr_num_curves);
-    /* Get the clients list of supported curves. */
-    tls1_get_peer_groups(s, &clntcurves, &clnt_num_curves);
-    if (clnt_num_curves == 0) {
+    /* Get our list of supported groups */
+    tls1_get_supported_groups(s, &srvrgroups, &srvr_num_groups);
+    /* Get the clients list of supported groups. */
+    tls1_get_peer_groups(s, &clntgroups, &clnt_num_groups);
+    if (clnt_num_groups == 0) {
         /*
          * This can only happen if the supported_groups extension was not sent,
          * because we verify that the length is non-zero when we process that
@@ -553,14 +553,14 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             continue;
 
         /* Check if this share is in supported_groups sent from client */
-        if (!check_in_list(s, group_id, clntcurves, clnt_num_curves, 0)) {
+        if (!check_in_list(s, group_id, clntgroups, clnt_num_groups, 0)) {
             *al = SSL_AD_ILLEGAL_PARAMETER;
             SSLerr(SSL_F_TLS_PARSE_CTOS_KEY_SHARE, SSL_R_BAD_KEY_SHARE);
             return 0;
         }
 
         /* Check if this share is for a group we can use */
-        if (!check_in_list(s, group_id, srvrcurves, srvr_num_curves, 1)) {
+        if (!check_in_list(s, group_id, srvrgroups, srvr_num_groups, 1)) {
             /* Share not suitable */
             continue;
         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -186,12 +186,12 @@ static const uint16_t suiteb_curves[] = {
     TLSEXT_curve_P_384
 };
 
-const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t curve_id)
+const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t group_id)
 {
     /* ECC curves from RFC 4492 and RFC 7027 */
-    if (curve_id < 1 || curve_id > OSSL_NELEM(nid_list))
+    if (group_id < 1 || group_id > OSSL_NELEM(nid_list))
         return NULL;
-    return &nid_list[curve_id - 1];
+    return &nid_list[group_id - 1];
 }
 
 static uint16_t tls1_nid2group_id(int nid)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -268,34 +268,6 @@ static int tls1_in_list(uint16_t id, const uint16_t *list, size_t listlen)
     return 0;
 }
 
-/* Check a curve is one of our preferences */
-int tls1_check_curve(SSL *s, const unsigned char *p, size_t len)
-{
-    const uint16_t *curves;
-    size_t num_curves;
-    uint16_t curve_id;
-
-    if (len != 3 || p[0] != NAMED_CURVE_TYPE)
-        return 0;
-    curve_id = (p[1] << 8) | p[2];
-    /* Check curve matches Suite B preferences */
-    if (tls1_suiteb(s)) {
-        unsigned long cid = s->s3->tmp.new_cipher->id;
-        if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256) {
-            if (curve_id != TLSEXT_curve_P_256)
-                return 0;
-        } else if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384) {
-            if (curve_id != TLSEXT_curve_P_384)
-                return 0;
-        } else                  /* Should never happen */
-            return 0;
-    }
-    tls1_get_supported_groups(s, &curves, &num_curves);
-    if (!tls1_in_list(curve_id, curves, num_curves))
-        return 0;
-    return tls_curve_allowed(s, curve_id, SSL_SECOP_CURVE_CHECK);
-}
-
 /*-
  * For nmatch >= 0, return the id of the |nmatch|th shared group or 0
  * if there is no match.
@@ -493,7 +465,7 @@ static int tls1_check_pkey_comp(SSL *s, EVP_PKEY *pkey)
 }
 
 /* Check a group id matches preferences */
-static int tls1_check_group_id(SSL *s, uint16_t group_id)
+int tls1_check_group_id(SSL *s, uint16_t group_id)
     {
     const uint16_t *groups;
     size_t groups_len;
@@ -501,12 +473,28 @@ static int tls1_check_group_id(SSL *s, uint16_t group_id)
     if (group_id == 0)
         return 0;
 
-    if (!tls_curve_allowed(s, group_id, SSL_SECOP_CURVE_CHECK))
-        return 0;
+    /* If we have a cipher check group matches Suite B preferences */
+    if (tls1_suiteb(s) && s->s3->tmp.new_cipher != NULL) {
+        unsigned long cid = s->s3->tmp.new_cipher->id;
+
+        if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256) {
+            if (group_id != TLSEXT_curve_P_256)
+                return 0;
+        } else if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384) {
+            if (group_id != TLSEXT_curve_P_384)
+                return 0;
+        } else {
+            /* Should never happen */
+            return 0;
+        }
+    }
 
     /* Check group is one of our preferences */
     tls1_get_supported_groups(s, &groups, &groups_len);
     if (!tls1_in_list(group_id, groups, groups_len))
+        return 0;
+
+    if (!tls_curve_allowed(s, group_id, SSL_SECOP_CURVE_CHECK))
         return 0;
 
     /* For clients, nothing more to check */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This further tidies up group handling. References to "curves" are replaced with "groups" where relevant. To make things clearer the supported groups and peer groups are now retrieved using separate functions (one is so trivial it is inlined). The tls1_check_curve function has been merged into tls1_check_group and the calling code simplified.