### PR TITLE
extending afalg with aes-cbc-192/256

### DIFF
--- a/engines/e_afalg.h
+++ b/engines/e_afalg.h
@@ -41,6 +41,8 @@
 #  define AES_BLOCK_SIZE   16
 # endif
 # define AES_KEY_SIZE_128 16
+# define AES_KEY_SIZE_192 24
+# define AES_KEY_SIZE_256 32
 # define AES_IV_LEN       16
 
 # define MAX_INFLIGHTS 1


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Hi,

Please consider this changeset which is the result of comments from pull request 4448.
These changes extend support for aes-cbc-192 and aes-cbc-256 in afalg.

Thanks
Jitendra
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
