### PR TITLE
enc, change salt handling, way 1

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -429,7 +429,6 @@ int enc_main(int argc, char **argv)
     }
 
     if (cipher != NULL) {
-
         if (str != NULL) { /* a passphrase is available */
             /*
              * Salt handling: if encrypting generate a salt if not supplied,
@@ -467,7 +466,6 @@ int enc_main(int argc, char **argv)
                         }
                     }
                 } else {    /* decryption */
-
                     if (hsalt == NULL) {
                         if (BIO_read(rbio, mbuf, sizeof(mbuf)) != sizeof(mbuf)) {
                             BIO_printf(bio_err, "error reading input file\n");
@@ -479,8 +477,7 @@ int enc_main(int argc, char **argv)
                                 BIO_printf(bio_err, "error reading input file\n");
                                 goto end;
                             }
-                        }
-                        else { /* file is NOT salted, NO salt available */
+                        } else { /* file is NOT salted, NO salt available */
                             BIO_printf(bio_err, "bad magic number\n");
                             goto end;
                         }

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -143,6 +143,8 @@ encrypting, this is the default.
 =item B<-S> I<salt>
 
 The actual salt to use: this must be represented as a string of hex digits.
+If this option is used while encrypting, the same exact value will be needed 
+again during decryption.
 
 =item B<-K> I<key>
 
@@ -230,9 +232,11 @@ OpenSSL.
 Without the B<-salt> option it is possible to perform efficient dictionary
 attacks on the password and to attack stream cipher encrypted data. The reason
 for this is that without the salt the same password always generates the same
-encryption key. When the salt is being used the first eight bytes of the
-encrypted data are reserved for the salt: it is generated at random when
-encrypting a file and read from the encrypted file when it is decrypted.
+encryption key. 
+
+When the salt is generated at random (that means when encrypting using a
+passphrase without explicit salt given using B<-S> option), the first bytes
+of the encrypted data are reserved to store the salt for later decrypting.
 
 Some of the ciphers do not have large keys and others have security
 implications if not used correctly. A beginner is advised to just use


### PR DESCRIPTION
This is an attempt to workaround the 'curse' of the salt handling using the `enc` command :
The salt is not always stored with the encrypted data.
As could be expected, it is stored when it was generated on the fly (not supplied with args), but not only.
It is stored when no key is given.
And when stored, even good IV and key fails to decrypt.
You must enter the password (but are NOT prompted for).

This first PR act as folows : 
If encrypting generate a salt IF NOT supplied using args.
If decrypting use salt from input BIO IF NOT supplied using args.

see also #4487, #2083
