### PR TITLE
Fix parameter name, for common aesthetics and to silence IDE warnings

### DIFF
--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -196,7 +196,7 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx);
  */
 void BN_set_negative(BIGNUM *b, int n);
 /** BN_is_negative returns 1 if the BIGNUM is negative
- * \param  a  pointer to the BIGNUM object
+ * \param  b  pointer to the BIGNUM object
  * \return 1 if a < 0 and 0 otherwise
  */
 int BN_is_negative(const BIGNUM *b);


### PR DESCRIPTION
Parameter name does not match the docs. This causes some IDE to complain. A simple one-letter fix takes care of it.


