### PR TITLE
Allow DigestSignInit() series to do RSA-PSS on a hardware token

### DIFF
--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -635,7 +635,7 @@ int cms_SignedData_final(CMS_ContentInfo *cms, BIO *chain)
 int CMS_SignerInfo_sign(CMS_SignerInfo *si)
 {
     EVP_MD_CTX *mctx = si->mctx;
-    EVP_PKEY_CTX *pctx;
+    EVP_PKEY_CTX *pctx = NULL;
     unsigned char *abuf = NULL;
     int alen;
     size_t siglen;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -19,8 +19,12 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey,
                           int ver)
 {
-    if (ctx->pctx == NULL)
-        ctx->pctx = EVP_PKEY_CTX_new(pkey, e);
+    if (ctx->pctx == NULL) {
+        if (pctx && *pctx)
+            ctx->pctx = *pctx;
+        else
+            ctx->pctx = EVP_PKEY_CTX_new(pkey, e);
+    }
     if (ctx->pctx == NULL)
         return 0;
 

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -813,7 +813,7 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
 int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
 {
     EVP_MD_CTX *mctx;
-    EVP_PKEY_CTX *pctx;
+    EVP_PKEY_CTX *pctx = NULL;
     unsigned char *abuf = NULL;
     int alen;
     size_t siglen;

--- a/doc/crypto/EVP_DigestSignInit.pod
+++ b/doc/crypto/EVP_DigestSignInit.pod
@@ -19,9 +19,15 @@ The EVP signature routines are a high level interface to digital signatures.
 
 EVP_DigestSignInit() sets up signing context B<ctx> to use digest B<type> from
 ENGINE B<impl> and private key B<pkey>. B<ctx> must be created with
-EVP_MD_CTX_new() before calling this function. If B<pctx> is not NULL the
+EVP_MD_CTX_new() before calling this function. If B<pctx> is not NULL 
+and B<*pctx> is NULL, the
 EVP_PKEY_CTX of the signing operation will be written to B<*pctx>: this can
-be used to set alternative signing options.
+be used to set alternative signing options. If B<pctx> is not NULL and
+B<*pctx> is not NULL, then the provided B<*pctx> will be used as
+EVP_PKEY_CTX of the signing operations. This allows, for example,
+offloading to the engine the entire signing operation such as RSA-PSS,
+but still having data digest performed in software. It is necessary,
+for example, when signature is performed by an HSM device.
 
 EVP_DigestSignUpdate() hashes B<cnt> bytes of data at B<d> into the
 signature context B<ctx>. This function can be called several times on the


### PR DESCRIPTION
This PR deals with performing digital signatures on hardware tokens, such as HSM devices.

Current implementation of `EVP_DigestSignInit()` allows `ENGINE *` argument, but it must apply to everything, including data digest operations. Setting this argument to `NULL` (while loading the private key from the engine) makes the code to send only the last step of the signing (raw RSA operation) to the token. This makes it impossible to sign on an HSM, as HSM typically do not support raw RSA for security reasons, and they also do not do data digests in hardware.

This PR allows providing signing context to the `EVP_DigestSignInit()`, while keeping data digest operations in software (not forcing the engine upon `EVP_MD_CTX *`. This way, the engine can do internal padding such as RSA-PSS.

I've tested this with PIV tokens (including CAC, and YubiKey NEO and 4), and HSM (including YubiHSM2). It works as expected: if `pctx==NULL`, no context is passed back, if `pctx != NULL && *pctx == NULL` signing context is created and passed back, and if `pctx != NULL && *pctx != NULL` then provided `*pctx` is used as signing context - and everything works fine.

Without this PR, when engine pointer is given, OpenSSL tries to request the engine to do data digest, and returns an error "unimplemented digest" (correctly, as the engine does not do data digests). When the engine pointer is not given, OpenSSL does everything in software, and requests only the raw RSA operation from the engine - which fails because the device on the other end refuses to do raw RSA. Here's what I'm trying to remedy:
```
. . . . .
140736337826752:error:260BA093:engine routines:ENGINE_get_digest:unimplemented digest:crypto/engine/tb_digest.c:74:
140736337826752:error:06080086:digital envelope routines:EVP_DigestInit_ex:initialization error:crypto/evp/digest.c:95:
```

I think the reason and the root cause of this problem is this line https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/crypto/evp/m_sigver.c#L62
that forces the digest to be offloaded to the engine.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated

