### PR TITLE
Fix reading heap overflow in a test case

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1977,7 +1977,7 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out,
             return SSL_TLSEXT_ERR_NOACK;
 
         if (protlen == strlen(servalpn)
-                && memcmp(prot, "goodalpn", protlen) == 0) {
+                && memcmp(prot, servalpn, protlen) == 0) {
             *out = prot;
             *outlen = protlen;
             return SSL_TLSEXT_ERR_OK;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1964,15 +1964,16 @@ static int hostname_cb(SSL *s, int *al, void *arg)
 
 static const char *servalpn;
 
-static int alpn_select_cb (SSL *ssl, const unsigned char **out, unsigned char *outlen,
-                    const unsigned char *in, unsigned int inlen, void *arg)
+static int alpn_select_cb(SSL *ssl, const unsigned char **out,
+                          unsigned char *outlen, const unsigned char *in,
+                          unsigned int inlen, void *arg)
 {
-    unsigned int i, protlen = 0;
+    unsigned int protlen = 0;
     const unsigned char *prot;
 
-    for (i = 0, prot = in; i < inlen; i += protlen, prot += protlen) {
-        protlen = *(prot++);
-        if (inlen - i < protlen)
+    for (prot = in; prot < in + inlen; prot += protlen) {
+        protlen = *prot++;
+        if (in + inlen - prot < protlen)
             return SSL_TLSEXT_ERR_NOACK;
 
         if (protlen == strlen(servalpn)


### PR DESCRIPTION
This is caught by AddressSanitizer. Reading goes beyond the boundary...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
