### PR TITLE
Remove parentheses of return.

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -109,13 +109,13 @@ int chopup_args(ARGS *arg, char *buf)
         }
     }
     arg->argv[arg->argc] = NULL;
-    return (1);
+    return 1;
 }
 
 #ifndef APP_INIT
 int app_init(long mesgwin)
 {
-    return (1);
+    return 1;
 }
 #endif
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -571,7 +571,7 @@ static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[])
 
     BIO_printf(bio_err, "Invalid command '%s'; type \"help\" for a list.\n",
                argv[0]);
-    return (1);
+    return 1;
 }
 
 static void list_pkey(void)

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -518,7 +518,7 @@ const OPTIONS rehash_options[] = {
 int rehash_main(int argc, char **argv)
 {
     BIO_printf(bio_err, "Not available; use c_rehash script\n");
-    return (1);
+    return 1;
 }
 
 #endif /* defined(OPENSSL_SYS_UNIX) || defined(__APPLE__) */

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -137,7 +137,7 @@ int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file)
             return (0);
         }
     }
-    return (1);
+    return 1;
 }
 
 int set_cert_key_stuff(SSL_CTX *ctx, X509 *cert, EVP_PKEY *key,

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2760,7 +2760,7 @@ static int init_ssl_connection(SSL *con)
         if ((dtlslisten && i == 0)
                 || (!dtlslisten && retry)) {
             BIO_printf(bio_s_out, "DELAY\n");
-            return (1);
+            return 1;
         }
 
         BIO_printf(bio_err, "ERROR\n");

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -24,7 +24,7 @@ int i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
     unsigned char *p, *d;
 
     if (a == NULL)
-        return (0);
+        return 0;
 
     len = a->length;
 
@@ -175,7 +175,7 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value)
     a->data[w] = ((a->data[w]) & iv) | v;
     while ((a->length > 0) && (a->data[a->length - 1] == 0))
         a->length--;
-    return (1);
+    return 1;
 }
 
 int ASN1_BIT_STRING_get_bit(const ASN1_BIT_STRING *a, int n)
@@ -185,7 +185,7 @@ int ASN1_BIT_STRING_get_bit(const ASN1_BIT_STRING *a, int n)
     w = n / 8;
     v = 1 << (7 - (n & 0x07));
     if ((a == NULL) || (a->length < (w + 1)) || (a->data == NULL))
-        return (0);
+        return 0;
     return ((a->data[w] & v) != 0);
 }
 

--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -39,7 +39,7 @@ int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type, char *data,
         return 0;
     }
     OPENSSL_free(str);
-    return (1);
+    return 1;
 }
 
 #endif
@@ -59,5 +59,5 @@ int ASN1_item_digest(const ASN1_ITEM *it, const EVP_MD *type, void *asn,
         return 0;
     }
     OPENSSL_free(str);
-    return (1);
+    return 1;
 }

--- a/crypto/asn1/a_print.c
+++ b/crypto/asn1/a_print.c
@@ -62,7 +62,7 @@ int ASN1_UNIVERSALSTRING_to_string(ASN1_UNIVERSALSTRING *s)
     *(p) = '\0';
     s->length /= 4;
     s->type = ASN1_PRINTABLE_type(s->data, s->length);
-    return (1);
+    return 1;
 }
 
 int ASN1_STRING_print(BIO *bp, const ASN1_STRING *v)
@@ -91,5 +91,5 @@ int ASN1_STRING_print(BIO *bp, const ASN1_STRING *v)
     if (n > 0)
         if (BIO_write(bp, buf, n) <= 0)
             return (0);
-    return (1);
+    return 1;
 }

--- a/crypto/asn1/evp_asn1.c
+++ b/crypto/asn1/evp_asn1.c
@@ -23,7 +23,7 @@ int ASN1_TYPE_set_octetstring(ASN1_TYPE *a, unsigned char *data, int len)
         return 0;
     }
     ASN1_TYPE_set(a, V_ASN1_OCTET_STRING, os);
-    return (1);
+    return 1;
 }
 
 /* int max_len:  for returned value    */

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -153,7 +153,7 @@ int BIO_sock_init(void)
         return (-1);
 # endif
 
-    return (1);
+    return 1;
 }
 
 void bio_sock_cleanup_int(void)

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -67,7 +67,7 @@ static int buffer_new(BIO *bi)
     bi->init = 1;
     bi->ptr = (char *)ctx;
     bi->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int buffer_free(BIO *a)
@@ -83,7 +83,7 @@ static int buffer_free(BIO *a)
     a->ptr = NULL;
     a->init = 0;
     a->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int buffer_read(BIO *b, char *out, int outl)

--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -73,7 +73,7 @@ static int linebuffer_new(BIO *bi)
     bi->init = 1;
     bi->ptr = (char *)ctx;
     bi->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int linebuffer_free(BIO *a)
@@ -88,7 +88,7 @@ static int linebuffer_free(BIO *a)
     a->ptr = NULL;
     a->init = 0;
     a->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int linebuffer_read(BIO *b, char *out, int outl)

--- a/crypto/bio/bf_nbio.c
+++ b/crypto/bio/bf_nbio.c
@@ -63,7 +63,7 @@ static int nbiof_new(BIO *bi)
     nt->lwn = -1;
     bi->ptr = (char *)nt;
     bi->init = 1;
-    return (1);
+    return 1;
 }
 
 static int nbiof_free(BIO *a)
@@ -74,7 +74,7 @@ static int nbiof_free(BIO *a)
     a->ptr = NULL;
     a->init = 0;
     a->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int nbiof_read(BIO *b, char *out, int outl)

--- a/crypto/bio/bf_null.c
+++ b/crypto/bio/bf_null.c
@@ -51,7 +51,7 @@ static int nullf_new(BIO *bi)
     bi->init = 1;
     bi->ptr = NULL;
     bi->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int nullf_free(BIO *a)
@@ -63,7 +63,7 @@ static int nullf_free(BIO *a)
     a->init=0;
     a->flags=0;
     */
-    return (1);
+    return 1;
 }
 
 static int nullf_read(BIO *b, char *out, int outl)

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -85,7 +85,7 @@ static int acpt_new(BIO *bi)
     bi->ptr = (char *)ba;
     ba->state = ACPT_S_BEFORE;
     bi->shutdown = 1;
-    return (1);
+    return 1;
 }
 
 static BIO_ACCEPT *BIO_ACCEPT_new(void)
@@ -143,7 +143,7 @@ static int acpt_free(BIO *a)
         a->flags = 0;
         a->init = 0;
     }
-    return (1);
+    return 1;
 }
 
 static int acpt_state(BIO *b, BIO_ACCEPT *c)

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -254,7 +254,7 @@ static int conn_new(BIO *bi)
     if ((bi->ptr = (char *)BIO_CONNECT_new()) == NULL)
         return (0);
     else
-        return (1);
+        return 1;
 }
 
 static void conn_close_socket(BIO *bio)
@@ -286,7 +286,7 @@ static int conn_free(BIO *a)
         a->flags = 0;
         a->init = 0;
     }
-    return (1);
+    return 1;
 }
 
 static int conn_read(BIO *b, char *out, int outl)

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -157,7 +157,7 @@ static int dgram_new(BIO *bi)
     if (data == NULL)
         return 0;
     bi->ptr = data;
-    return (1);
+    return 1;
 }
 
 static int dgram_free(BIO *a)
@@ -172,7 +172,7 @@ static int dgram_free(BIO *a)
     data = (bio_dgram_data *)a->ptr;
     OPENSSL_free(data);
 
-    return (1);
+    return 1;
 }
 
 static int dgram_clear(BIO *a)
@@ -186,7 +186,7 @@ static int dgram_clear(BIO *a)
         a->init = 0;
         a->flags = 0;
     }
-    return (1);
+    return 1;
 }
 
 static void dgram_adjust_rcv_timeout(BIO *b)
@@ -969,7 +969,7 @@ static int dgram_sctp_new(BIO *bi)
     bi->ptr = data;
 
     bi->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int dgram_sctp_free(BIO *a)
@@ -985,7 +985,7 @@ static int dgram_sctp_free(BIO *a)
     if (data != NULL)
         OPENSSL_free(data);
 
-    return (1);
+    return 1;
 }
 
 #  ifdef SCTP_AUTHENTICATION_EVENT
@@ -1895,7 +1895,7 @@ int BIO_dgram_non_fatal_error(int err)
     case EALREADY:
 # endif
 
-        return (1);
+        return 1;
     default:
         break;
     }

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -94,7 +94,7 @@ static int fd_new(BIO *bi)
     bi->num = -1;
     bi->ptr = NULL;
     bi->flags = BIO_FLAGS_UPLINK; /* essentially redundant */
-    return (1);
+    return 1;
 }
 
 static int fd_free(BIO *a)
@@ -108,7 +108,7 @@ static int fd_free(BIO *a)
         a->init = 0;
         a->flags = BIO_FLAGS_UPLINK;
     }
-    return (1);
+    return 1;
 }
 
 static int fd_read(BIO *b, char *out, int outl)
@@ -270,7 +270,7 @@ int BIO_fd_non_fatal_error(int err)
 # ifdef EALREADY
     case EALREADY:
 # endif
-        return (1);
+        return 1;
     default:
         break;
     }

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -110,7 +110,7 @@ static int slg_new(BIO *bi)
     bi->num = 0;
     bi->ptr = NULL;
     xopenlog(bi, "application", LOG_DAEMON);
-    return (1);
+    return 1;
 }
 
 static int slg_free(BIO *a)
@@ -118,7 +118,7 @@ static int slg_free(BIO *a)
     if (a == NULL)
         return (0);
     xcloselog(a);
-    return (1);
+    return 1;
 }
 
 static int slg_write(BIO *b, const char *in, int inl)

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -165,7 +165,7 @@ static int mem_buf_free(BIO *a, int free_all)
             a->ptr = NULL;
         }
     }
-    return (1);
+    return 1;
 }
 
 /*

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -46,14 +46,14 @@ static int null_new(BIO *bi)
     bi->init = 1;
     bi->num = 0;
     bi->ptr = (NULL);
-    return (1);
+    return 1;
 }
 
 static int null_free(BIO *a)
 {
     if (a == NULL)
         return (0);
-    return (1);
+    return 1;
 }
 
 static int null_read(BIO *b, char *out, int outl)

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -73,7 +73,7 @@ static int sock_new(BIO *bi)
     bi->num = 0;
     bi->ptr = NULL;
     bi->flags = 0;
-    return (1);
+    return 1;
 }
 
 static int sock_free(BIO *a)
@@ -87,7 +87,7 @@ static int sock_free(BIO *a)
         a->init = 0;
         a->flags = 0;
     }
-    return (1);
+    return 1;
 }
 
 static int sock_read(BIO *b, char *out, int outl)
@@ -223,7 +223,7 @@ int BIO_sock_non_fatal_error(int err)
 # ifdef EALREADY
     case EALREADY:
 # endif
-        return (1);
+        return 1;
     default:
         break;
     }

--- a/crypto/bn/bn_div.c
+++ b/crypto/bn/bn_div.c
@@ -34,7 +34,7 @@ int BN_div(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m, const BIGNUM *d,
         }
         if (dv != NULL)
             BN_zero(dv);
-        return (1);
+        return 1;
     }
 
     BN_CTX_start(ctx);
@@ -187,7 +187,7 @@ int BN_div(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num, const BIGNUM *divisor,
         }
         if (dv != NULL)
             BN_zero(dv);
-        return (1);
+        return 1;
     }
 
     BN_CTX_start(ctx);
@@ -411,7 +411,7 @@ int BN_div(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num, const BIGNUM *divisor,
     if (no_branch)
         bn_correct_top(res);
     BN_CTX_end(ctx);
-    return (1);
+    return 1;
  err:
     bn_check_top(rm);
     BN_CTX_end(ctx);

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -404,7 +404,7 @@ int BN_set_word(BIGNUM *a, BN_ULONG w)
     a->d[0] = w;
     a->top = (w ? 1 : 0);
     bn_check_top(a);
-    return (1);
+    return 1;
 }
 
 BIGNUM *BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret)
@@ -587,7 +587,7 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b)
         if (a != NULL)
             return (-1);
         else if (b != NULL)
-            return (1);
+            return 1;
         else
             return (0);
     }
@@ -599,7 +599,7 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b)
         if (a->neg)
             return (-1);
         else
-            return (1);
+            return 1;
     }
     if (a->neg == 0) {
         gt = 1;
@@ -643,7 +643,7 @@ int BN_set_bit(BIGNUM *a, int n)
 
     a->d[i] |= (((BN_ULONG)1) << j);
     bn_check_top(a);
-    return (1);
+    return 1;
 }
 
 int BN_clear_bit(BIGNUM *a, int n)
@@ -661,7 +661,7 @@ int BN_clear_bit(BIGNUM *a, int n)
 
     a->d[i] &= (~(((BN_ULONG)1) << j));
     bn_correct_top(a);
-    return (1);
+    return 1;
 }
 
 int BN_is_bit_set(const BIGNUM *a, int n)
@@ -697,7 +697,7 @@ int BN_mask_bits(BIGNUM *a, int n)
         a->d[w] &= ~(BN_MASK2 << b);
     }
     bn_correct_top(a);
-    return (1);
+    return 1;
 }
 
 void BN_set_negative(BIGNUM *a, int b)

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -38,7 +38,7 @@ int BN_mod_mul_montgomery(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
             r->neg = a->neg ^ b->neg;
             r->top = num;
             bn_correct_top(r);
-            return (1);
+            return 1;
         }
     }
 #endif
@@ -82,7 +82,7 @@ static int BN_from_montgomery_word(BIGNUM *ret, BIGNUM *r, BN_MONT_CTX *mont)
     nl = n->top;
     if (nl == 0) {
         ret->top = 0;
-        return (1);
+        return 1;
     }
 
     max = (2 * nl);             /* carry is stored separately */
@@ -159,7 +159,7 @@ static int BN_from_montgomery_word(BIGNUM *ret, BIGNUM *r, BN_MONT_CTX *mont)
     bn_correct_top(ret);
     bn_check_top(ret);
 
-    return (1);
+    return 1;
 }
 #endif                          /* MONT_WORD */
 

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -516,7 +516,7 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
 
     if ((al == 0) || (bl == 0)) {
         BN_zero(r);
-        return (1);
+        return 1;
     }
     top = al + bl;
 

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -350,7 +350,7 @@ static int probable_prime(BIGNUM *rnd, int bits, prime_t *mods)
     if (BN_num_bits(rnd) != bits)
         goto again;
     bn_check_top(rnd);
-    return (1);
+    return 1;
 }
 
 int bn_probable_prime_dh(BIGNUM *rnd, int bits,

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -48,7 +48,7 @@ int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *ctx)
     BN_zero(&(recp->Nr));
     recp->num_bits = BN_num_bits(d);
     recp->shift = 0;
-    return (1);
+    return 1;
 }
 
 int BN_mod_mul_reciprocal(BIGNUM *r, const BIGNUM *x, const BIGNUM *y,
@@ -101,7 +101,7 @@ int BN_div_recp(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m,
             return 0;
         }
         BN_CTX_end(ctx);
-        return (1);
+        return 1;
     }
 
     /*

--- a/crypto/bn/bn_shift.c
+++ b/crypto/bn/bn_shift.c
@@ -40,7 +40,7 @@ int BN_lshift1(BIGNUM *r, const BIGNUM *a)
         r->top++;
     }
     bn_check_top(r);
-    return (1);
+    return 1;
 }
 
 int BN_rshift1(BIGNUM *r, const BIGNUM *a)
@@ -53,7 +53,7 @@ int BN_rshift1(BIGNUM *r, const BIGNUM *a)
 
     if (BN_is_zero(a)) {
         BN_zero(r);
-        return (1);
+        return 1;
     }
     i = a->top;
     ap = a->d;
@@ -77,7 +77,7 @@ int BN_rshift1(BIGNUM *r, const BIGNUM *a)
     if (!r->top)
         r->neg = 0; /* don't allow negative zero */
     bn_check_top(r);
-    return (1);
+    return 1;
 }
 
 int BN_lshift(BIGNUM *r, const BIGNUM *a, int n)
@@ -116,7 +116,7 @@ int BN_lshift(BIGNUM *r, const BIGNUM *a, int n)
     r->top = a->top + nw + 1;
     bn_correct_top(r);
     bn_check_top(r);
-    return (1);
+    return 1;
 }
 
 int BN_rshift(BIGNUM *r, const BIGNUM *a, int n)
@@ -138,7 +138,7 @@ int BN_rshift(BIGNUM *r, const BIGNUM *a, int n)
     lb = BN_BITS2 - rb;
     if (nw >= a->top || a->top == 0) {
         BN_zero(r);
-        return (1);
+        return 1;
     }
     i = (BN_num_bits(a) - n + (BN_BITS2 - 1)) / BN_BITS2;
     if (r != a) {
@@ -171,5 +171,5 @@ int BN_rshift(BIGNUM *r, const BIGNUM *a, int n)
     if (!r->top)
         r->neg = 0; /* don't allow negative zero */
     bn_check_top(r);
-    return (1);
+    return 1;
 }

--- a/crypto/bn/bn_word.c
+++ b/crypto/bn/bn_word.c
@@ -128,7 +128,7 @@ int BN_add_word(BIGNUM *a, BN_ULONG w)
         a->d[i] = w;
     }
     bn_check_top(a);
-    return (1);
+    return 1;
 }
 
 int BN_sub_word(BIGNUM *a, BN_ULONG w)
@@ -159,7 +159,7 @@ int BN_sub_word(BIGNUM *a, BN_ULONG w)
     if ((a->top == 1) && (a->d[0] < w)) {
         a->d[0] = w - a->d[0];
         a->neg = 1;
-        return (1);
+        return 1;
     }
     i = 0;
     for (;;) {
@@ -175,7 +175,7 @@ int BN_sub_word(BIGNUM *a, BN_ULONG w)
     if ((a->d[i] == 0) && (i == (a->top - 1)))
         a->top--;
     bn_check_top(a);
-    return (1);
+    return 1;
 }
 
 int BN_mul_word(BIGNUM *a, BN_ULONG w)
@@ -197,5 +197,5 @@ int BN_mul_word(BIGNUM *a, BN_ULONG w)
         }
     }
     bn_check_top(a);
-    return (1);
+    return 1;
 }

--- a/crypto/des/rand_key.c
+++ b/crypto/des/rand_key.c
@@ -17,5 +17,5 @@ int DES_random_key(DES_cblock *ret)
             return (0);
     } while (DES_is_weak_key(ret));
     DES_set_odd_parity(ret);
-    return (1);
+    return 1;
 }

--- a/crypto/des/set_key.c
+++ b/crypto/des/set_key.c
@@ -67,7 +67,7 @@ int DES_check_key_parity(const_DES_cblock *key)
         if ((*key)[i] != odd_parity[(*key)[i]])
             return (0);
     }
-    return (1);
+    return 1;
 }
 
 /*-
@@ -114,7 +114,7 @@ int DES_is_weak_key(const_DES_cblock *key)
          * 97/03/18
          */
         if (memcmp(weak_keys[i], key, sizeof(DES_cblock)) == 0)
-            return (1);
+            return 1;
     return (0);
 }
 

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -217,11 +217,11 @@ static int dh_bn_mod_exp(const DH *dh, BIGNUM *r,
 static int dh_init(DH *dh)
 {
     dh->flags |= DH_FLAG_CACHE_MONT_P;
-    return (1);
+    return 1;
 }
 
 static int dh_finish(DH *dh)
 {
     BN_MONT_CTX_free(dh->method_mont_p);
-    return (1);
+    return 1;
 }

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -119,7 +119,7 @@ int DSA_sign(int type, const unsigned char *dgst, int dlen,
     }
     *siglen = i2d_DSA_SIG(s, &sig);
     DSA_SIG_free(s);
-    return (1);
+    return 1;
 }
 
 /* data has already been hashed (probably with SHA or SHA-1). */

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -340,11 +340,11 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
 static int dsa_init(DSA *dsa)
 {
     dsa->flags |= DSA_FLAG_CACHE_MONT_P;
-    return (1);
+    return 1;
 }
 
 static int dsa_finish(DSA *dsa)
 {
     BN_MONT_CTX_free(dsa->method_mont_p);
-    return (1);
+    return 1;
 }

--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -83,7 +83,7 @@ static int dl_load(DSO *dso)
      * (it also serves as the indicator that we are currently loaded).
      */
     dso->loaded_filename = filename;
-    return (1);
+    return 1;
  err:
     /* Cleanup! */
     OPENSSL_free(filename);
@@ -100,7 +100,7 @@ static int dl_unload(DSO *dso)
         return (0);
     }
     if (sk_num(dso->meth_data) < 1)
-        return (1);
+        return 1;
     /* Is this statement legal? */
     ptr = (shl_t) sk_pop(dso->meth_data);
     if (ptr == NULL) {
@@ -112,7 +112,7 @@ static int dl_unload(DSO *dso)
         return (0);
     }
     shl_unload(ptr);
-    return (1);
+    return 1;
 }
 
 static DSO_FUNC_TYPE dl_bind_func(DSO *dso, const char *symname)

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -120,7 +120,7 @@ static int dlfcn_load(DSO *dso)
     }
     /* Success */
     dso->loaded_filename = filename;
-    return (1);
+    return 1;
  err:
     /* Cleanup! */
     OPENSSL_free(filename);
@@ -137,7 +137,7 @@ static int dlfcn_unload(DSO *dso)
         return (0);
     }
     if (sk_void_num(dso->meth_data) < 1)
-        return (1);
+        return 1;
     ptr = sk_void_pop(dso->meth_data);
     if (ptr == NULL) {
         DSOerr(DSO_F_DLFCN_UNLOAD, DSO_R_NULL_HANDLE);
@@ -149,7 +149,7 @@ static int dlfcn_unload(DSO *dso)
     }
     /* For now I'm not aware of any errors associated with dlclose() */
     dlclose(ptr);
-    return (1);
+    return 1;
 }
 
 static DSO_FUNC_TYPE dlfcn_bind_func(DSO *dso, const char *symname)

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -64,7 +64,7 @@ int DSO_free(DSO *dso)
     int i;
 
     if (dso == NULL)
-        return (1);
+        return 1;
 
     if (CRYPTO_DOWN_REF(&dso->references, &i, dso->lock) <= 0)
         return 0;
@@ -257,7 +257,7 @@ int DSO_set_filename(DSO *dso, const char *filename)
     }
     OPENSSL_free(dso->filename);
     dso->filename = copied;
-    return (1);
+    return 1;
 }
 
 char *DSO_merge(DSO *dso, const char *filespec1, const char *filespec2)

--- a/crypto/dso/dso_vms.c
+++ b/crypto/dso/dso_vms.c
@@ -207,7 +207,7 @@ static int vms_load(DSO *dso)
 
     /* Success (for now, we lie.  We actually do not know...) */
     dso->loaded_filename = filename;
-    return (1);
+    return 1;
  err:
     /* Cleanup! */
     OPENSSL_free(p);
@@ -228,7 +228,7 @@ static int vms_unload(DSO *dso)
         return (0);
     }
     if (sk_void_num(dso->meth_data) < 1)
-        return (1);
+        return 1;
     p = (DSO_VMS_INTERNAL *)sk_void_pop(dso->meth_data);
     if (p == NULL) {
         DSOerr(DSO_F_VMS_UNLOAD, DSO_R_NULL_HANDLE);
@@ -236,7 +236,7 @@ static int vms_unload(DSO *dso)
     }
     /* Cleanup */
     OPENSSL_free(p);
-    return (1);
+    return 1;
 }
 
 /*

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -120,7 +120,7 @@ static int win32_load(DSO *dso)
     }
     /* Success */
     dso->loaded_filename = filename;
-    return (1);
+    return 1;
  err:
     /* Cleanup ! */
     OPENSSL_free(filename);
@@ -138,7 +138,7 @@ static int win32_unload(DSO *dso)
         return (0);
     }
     if (sk_void_num(dso->meth_data) < 1)
-        return (1);
+        return 1;
     p = sk_void_pop(dso->meth_data);
     if (p == NULL) {
         DSOerr(DSO_F_WIN32_UNLOAD, DSO_R_NULL_HANDLE);
@@ -154,7 +154,7 @@ static int win32_unload(DSO *dso)
     }
     /* Cleanup */
     OPENSSL_free(p);
-    return (1);
+    return 1;
 }
 
 static DSO_FUNC_TYPE win32_bind_func(DSO *dso, const char *symname)

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -398,7 +398,7 @@ int EVP_DecodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl)
             return (-1);
         ctx->num = 0;
         *outl = i;
-        return (1);
+        return 1;
     } else
-        return (1);
+        return 1;
 }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -547,7 +547,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
         *outl = n;
     } else
         *outl = 0;
-    return (1);
+    return 1;
 }
 
 int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *c, int keylen)

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -1105,7 +1105,7 @@ int PKCS7_set_signed_attributes(PKCS7_SIGNER_INFO *p7si,
             == NULL)
             return (0);
     }
-    return (1);
+    return 1;
 }
 
 int PKCS7_set_attributes(PKCS7_SIGNER_INFO *p7si,
@@ -1124,7 +1124,7 @@ int PKCS7_set_attributes(PKCS7_SIGNER_INFO *p7si,
             == NULL)
             return (0);
     }
-    return (1);
+    return 1;
 }
 
 int PKCS7_add_signed_attribute(PKCS7_SIGNER_INFO *p7si, int nid, int atrtype,
@@ -1174,5 +1174,5 @@ static int add_attribute(STACK_OF(X509_ATTRIBUTE) **sk, int nid, int atrtype,
         goto new_attrib;
     }
  end:
-    return (1);
+    return 1;
 }

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -71,7 +71,7 @@ int PKCS7_content_new(PKCS7 *p7, int type)
     if (!PKCS7_set_content(p7, ret))
         goto err;
 
-    return (1);
+    return 1;
  err:
     PKCS7_free(ret);
     return (0);
@@ -99,7 +99,7 @@ int PKCS7_set_content(PKCS7 *p7, PKCS7 *p7_data)
         PKCS7err(PKCS7_F_PKCS7_SET_CONTENT, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
         goto err;
     }
-    return (1);
+    return 1;
  err:
     return (0);
 }
@@ -171,7 +171,7 @@ int PKCS7_set_type(PKCS7 *p7, int type)
         PKCS7err(PKCS7_F_PKCS7_SET_TYPE, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
         goto err;
     }
-    return (1);
+    return 1;
  err:
     return (0);
 }
@@ -233,7 +233,7 @@ int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *psi)
 
     if (!sk_PKCS7_SIGNER_INFO_push(signer_sk, psi))
         return 0;
-    return (1);
+    return 1;
 }
 
 int PKCS7_add_certificate(PKCS7 *p7, X509 *x509)
@@ -265,7 +265,7 @@ int PKCS7_add_certificate(PKCS7 *p7, X509 *x509)
         X509_free(x509);
         return 0;
     }
-    return (1);
+    return 1;
 }
 
 int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl)
@@ -298,7 +298,7 @@ int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl)
         X509_CRL_free(crl);
         return 0;
     }
-    return (1);
+    return 1;
 }
 
 int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
@@ -457,7 +457,7 @@ int PKCS7_add_recipient_info(PKCS7 *p7, PKCS7_RECIP_INFO *ri)
 
     if (!sk_PKCS7_RECIP_INFO_push(sk, ri))
         return 0;
-    return (1);
+    return 1;
 }
 
 int PKCS7_RECIP_INFO_set(PKCS7_RECIP_INFO *p7i, X509 *x509)

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -184,7 +184,7 @@ int TXT_DB_create_index(TXT_DB *db, int field, int (*qual) (OPENSSL_STRING *),
     lh_OPENSSL_STRING_free(db->index[field]);
     db->index[field] = idx;
     db->qual[field] = qual;
-    return (1);
+    return 1;
 }
 
 long TXT_DB_write(BIO *out, TXT_DB *db)
@@ -264,7 +264,7 @@ int TXT_DB_insert(TXT_DB *db, OPENSSL_STRING *row)
     }
     if (!sk_OPENSSL_PSTRING_push(db->data, row))
         goto err1;
-    return (1);
+    return 1;
 
  err1:
     db->error = DB_ERROR_MALLOC;

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -67,7 +67,7 @@
 int WHIRLPOOL_Init(WHIRLPOOL_CTX *c)
 {
     memset(c, 0, sizeof(*c));
-    return (1);
+    return 1;
 }
 
 int WHIRLPOOL_Update(WHIRLPOOL_CTX *c, const void *_inp, size_t bytes)
@@ -88,7 +88,7 @@ int WHIRLPOOL_Update(WHIRLPOOL_CTX *c, const void *_inp, size_t bytes)
     if (bytes)
         WHIRLPOOL_BitUpdate(c, inp, bytes * 8);
 
-    return (1);
+    return 1;
 }
 
 void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
@@ -247,7 +247,7 @@ int WHIRLPOOL_Final(unsigned char *md, WHIRLPOOL_CTX *c)
     if (md) {
         memcpy(md, c->H.c, WHIRLPOOL_DIGEST_LENGTH);
         OPENSSL_cleanse(c, sizeof(*c));
-        return (1);
+        return 1;
     }
     return (0);
 }

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -186,7 +186,7 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
             goto err;
     }
 
-    return (1);
+    return 1;
  err:
     X509err(X509_F_X509_REQ_PRINT_EX, ERR_R_BUF_LIB);
     return (0);

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -266,7 +266,7 @@ int X509_ocspid_print(BIO *bp, X509 *x)
     }
     BIO_printf(bp, "\n");
 
-    return (1);
+    return 1;
  err:
     OPENSSL_free(der);
     return (0);

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -29,7 +29,7 @@ int X509_STORE_set_default_paths(X509_STORE *ctx)
     /* clear any errors */
     ERR_clear_error();
 
-    return (1);
+    return 1;
 }
 
 int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
@@ -53,5 +53,5 @@ int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
     }
     if ((path == NULL) && (file == NULL))
         return (0);
-    return (1);
+    return 1;
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -26,7 +26,7 @@ int X509_set_version(X509 *x, long version)
     if (version == 0) {
         ASN1_INTEGER_free(x->cert_info.version);
         x->cert_info.version = NULL;
-        return (1);
+        return 1;
     }
     if (x->cert_info.version == NULL) {
         if ((x->cert_info.version = ASN1_INTEGER_new()) == NULL)

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -195,7 +195,7 @@ int X509_EXTENSION_set_critical(X509_EXTENSION *ex, int crit)
     if (ex == NULL)
         return (0);
     ex->critical = (crit) ? 0xFF : -1;
-    return (1);
+    return 1;
 }
 
 int X509_EXTENSION_set_data(X509_EXTENSION *ex, ASN1_OCTET_STRING *data)
@@ -207,7 +207,7 @@ int X509_EXTENSION_set_data(X509_EXTENSION *ex, ASN1_OCTET_STRING *data)
     i = ASN1_OCTET_STRING_set(&ex->value, data->data, data->length);
     if (!i)
         return (0);
-    return (1);
+    return 1;
 }
 
 ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *ex)

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -232,7 +232,7 @@ int X509_NAME_add_entry(X509_NAME *name, const X509_NAME_ENTRY *ne, int loc,
         for (i = loc + 1; i < n; i++)
             sk_X509_NAME_ENTRY_value(sk, i - 1)->set += 1;
     }
-    return (1);
+    return 1;
  err:
     X509_NAME_ENTRY_free(new_name);
     return (0);
@@ -337,7 +337,7 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
         else
             ne->value->type = type;
     }
-    return (1);
+    return 1;
 }
 
 ASN1_OBJECT *X509_NAME_ENTRY_get_object(const X509_NAME_ENTRY *ne)

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -501,7 +501,7 @@ int BIO_ssl_copy_session_id(BIO *t, BIO *f)
         return (0);
     if (!SSL_copy_session_id(tdata->ssl, (fdata->ssl)))
         return 0;
-    return (1);
+    return 1;
 }
 
 void BIO_ssl_shutdown(BIO *b)

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -131,7 +131,7 @@ static int dtls1_copy_record(SSL *s, pitem *item)
     /* Set proper sequence number for mac calculation */
     memcpy(&(s->rlayer.read_sequence[2]), &(rdata->packet[5]), 6);
 
-    return (1);
+    return 1;
 }
 
 int dtls1_buffer_record(SSL *s, record_pqueue *queue, unsigned char *priority)
@@ -191,7 +191,7 @@ int dtls1_buffer_record(SSL *s, record_pqueue *queue, unsigned char *priority)
         return (-1);
     }
 
-    return (1);
+    return 1;
 }
 
 int dtls1_retrieve_buffered_record(SSL *s, record_pqueue *queue)
@@ -205,7 +205,7 @@ int dtls1_retrieve_buffered_record(SSL *s, record_pqueue *queue)
         OPENSSL_free(item->data);
         pitem_free(item);
 
-        return (1);
+        return 1;
     }
 
     return (0);

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -758,7 +758,7 @@ int ssl3_do_compress(SSL *ssl, SSL3_RECORD *wr)
 
     wr->input = wr->data;
 #endif
-    return (1);
+    return 1;
 }
 
 /*-
@@ -844,7 +844,7 @@ int ssl3_enc(SSL *s, SSL3_RECORD *inrecs, size_t n_recs, int sending)
         if ((bs != 1) && !sending)
             return ssl3_cbc_remove_padding(rec, bs, mac_size);
     }
-    return (1);
+    return 1;
 }
 
 #define MAX_PADDING 256
@@ -1703,7 +1703,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
     /* Mark receipt of record. */
     dtls1_record_bitmap_update(s, bitmap);
 
-    return (1);
+    return 1;
 
  f_err:
     ssl3_send_alert(s, SSL3_AL_FATAL, al);
@@ -1894,6 +1894,6 @@ int dtls1_get_record(SSL *s)
         goto again;             /* get another record */
     }
 
-    return (1);
+    return 1;
 
 }

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -210,7 +210,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
 
     OPENSSL_cleanse(exp_key, sizeof(exp_key));
     OPENSSL_cleanse(exp_iv, sizeof(exp_iv));
-    return (1);
+    return 1;
  err:
     SSLerr(SSL_F_SSL3_CHANGE_CIPHER_STATE, ERR_R_MALLOC_FAILURE);
  err2:
@@ -229,7 +229,7 @@ int ssl3_setup_key_block(SSL *s)
     SSL_COMP *comp;
 
     if (s->s3->tmp.key_block_length != 0)
-        return (1);
+        return 1;
 
     if (!ssl_cipher_get_evp(s->session, &c, &hash, NULL, NULL, &comp, 0)) {
         SSLerr(SSL_F_SSL3_SETUP_KEY_BLOCK, SSL_R_CIPHER_OR_HASH_UNAVAILABLE);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3986,7 +3986,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     default:
         return (0);
     }
-    return (1);
+    return 1;
 }
 
 long ssl3_ctx_callback_ctrl(SSL_CTX *ctx, int cmd, void (*fp) (void))
@@ -4038,7 +4038,7 @@ long ssl3_ctx_callback_ctrl(SSL_CTX *ctx, int cmd, void (*fp) (void))
     default:
         return (0);
     }
-    return (1);
+    return 1;
 }
 
 const SSL_CIPHER *ssl3_get_cipher_by_id(uint32_t id)
@@ -4310,7 +4310,7 @@ int ssl3_shutdown(SSL *s)
      */
     if (s->quiet_shutdown || SSL_in_before(s)) {
         s->shutdown = (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
-        return (1);
+        return 1;
     }
 
     if (!(s->shutdown & SSL_SENT_SHUTDOWN)) {
@@ -4346,7 +4346,7 @@ int ssl3_shutdown(SSL *s)
 
     if ((s->shutdown == (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN)) &&
         !s->s3->alert_dispatch)
-        return (1);
+        return 1;
     else
         return (0);
 }
@@ -4405,10 +4405,10 @@ int ssl3_peek(SSL *s, void *buf, size_t len, size_t *readbytes)
 int ssl3_renegotiate(SSL *s)
 {
     if (s->handshake_func == NULL)
-        return (1);
+        return 1;
 
     s->s3->renegotiate = 1;
-    return (1);
+    return 1;
 }
 
 /*

--- a/ssl/s3_msg.c
+++ b/ssl/s3_msg.c
@@ -56,7 +56,7 @@ int ssl3_do_change_cipher_spec(SSL *s)
     }
     s->s3->tmp.peer_finish_md_len = finish_md_len;
 
-    return (1);
+    return 1;
 }
 
 int ssl3_send_alert(SSL *s, int level, int desc)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -604,7 +604,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth)
         SSLerr(SSL_F_SSL_CTX_SET_SSL_VERSION, SSL_R_SSL_LIBRARY_HAS_NO_CIPHERS);
         return (0);
     }
-    return (1);
+    return 1;
 }
 
 SSL *SSL_new(SSL_CTX *ctx)
@@ -2739,9 +2739,9 @@ static unsigned long ssl_session_hash(const SSL_SESSION *a)
 static int ssl_session_cmp(const SSL_SESSION *a, const SSL_SESSION *b)
 {
     if (a->ssl_version != b->ssl_version)
-        return (1);
+        return 1;
     if (a->session_id_length != b->session_id_length)
-        return (1);
+        return 1;
     return (memcmp(a->session_id, b->session_id, a->session_id_length));
 }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -846,7 +846,7 @@ long SSL_SESSION_set_timeout(SSL_SESSION *s, long t)
     if (s == NULL)
         return (0);
     s->timeout = t;
-    return (1);
+    return 1;
 }
 
 long SSL_SESSION_get_timeout(const SSL_SESSION *s)
@@ -1022,7 +1022,7 @@ int SSL_set_session_secret_cb(SSL *s,
         return (0);
     s->ext.session_secret_cb = tls_session_secret_cb;
     s->ext.session_secret_cb_arg = arg;
-    return (1);
+    return 1;
 }
 
 int SSL_set_session_ticket_ext_cb(SSL *s, tls_session_ticket_ext_cb_fn cb,
@@ -1032,7 +1032,7 @@ int SSL_set_session_ticket_ext_cb(SSL *s, tls_session_ticket_ext_cb_fn cb,
         return (0);
     s->ext.session_ticket_cb = cb;
     s->ext.session_ticket_cb_arg = arg;
-    return (1);
+    return 1;
 }
 
 int SSL_set_session_ticket_ext(SSL *s, void *ext_data, int ext_len)
@@ -1110,7 +1110,7 @@ int ssl_clear_bad_session(SSL *s)
         !(s->shutdown & SSL_SENT_SHUTDOWN) &&
         !(SSL_in_init(s) || SSL_in_before(s))) {
         SSL_CTX_remove_session(s->session_ctx, s->session);
-        return (1);
+        return 1;
     } else
         return (0);
 }

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -145,7 +145,7 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
                    x->flags & SSL_SESS_FLAG_EXTMS ? "yes" : "no") <= 0)
         goto err;
 
-    return (1);
+    return 1;
  err:
     return (0);
 }
@@ -186,7 +186,7 @@ int SSL_SESSION_print_keylog(BIO *bp, const SSL_SESSION *x)
     if (BIO_puts(bp, "\n") <= 0)
         goto err;
 
-    return (1);
+    return 1;
  err:
     return (0);
 }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -47,7 +47,7 @@ int ssl3_do_write(SSL *s, int type)
             s->msg_callback(1, s->version, type, s->init_buf->data,
                             (size_t)(s->init_off + s->init_num), s,
                             s->msg_callback_arg);
-        return (1);
+        return 1;
     }
     s->init_off += written;
     s->init_num -= written;

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -310,7 +310,7 @@ int tls1_change_cipher_state(SSL *s, int which)
     OPENSSL_cleanse(tmp2, sizeof(tmp1));
     OPENSSL_cleanse(iv1, sizeof(iv1));
     OPENSSL_cleanse(iv2, sizeof(iv2));
-    return (1);
+    return 1;
  err:
     SSLerr(SSL_F_TLS1_CHANGE_CIPHER_STATE, ERR_R_MALLOC_FAILURE);
  err2:
@@ -332,7 +332,7 @@ int tls1_setup_key_block(SSL *s)
     int ret = 0;
 
     if (s->s3->tmp.key_block_length != 0)
-        return (1);
+        return 1;
 
     if (!ssl_cipher_get_evp(s->session, &c, &hash, &mac_type, &mac_secret_size,
                             &comp, s->ext.use_etm)) {

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -31,7 +31,7 @@ int SSL_CTX_SRP_CTX_free(struct ssl_ctx_st *ctx)
     BN_free(ctx->srp_ctx.v);
     memset(&ctx->srp_ctx, 0, sizeof(ctx->srp_ctx));
     ctx->srp_ctx.strength = SRP_MINIMAL_N;
-    return (1);
+    return 1;
 }
 
 int SSL_SRP_CTX_free(struct ssl_st *s)
@@ -50,7 +50,7 @@ int SSL_SRP_CTX_free(struct ssl_st *s)
     BN_free(s->srp_ctx.v);
     memset(&s->srp_ctx, 0, sizeof(s->srp_ctx));
     s->srp_ctx.strength = SRP_MINIMAL_N;
-    return (1);
+    return 1;
 }
 
 int SSL_SRP_CTX_init(struct ssl_st *s)
@@ -106,7 +106,7 @@ int SSL_SRP_CTX_init(struct ssl_st *s)
     }
     s->srp_ctx.srp_Mask = ctx->srp_ctx.srp_Mask;
 
-    return (1);
+    return 1;
  err:
     OPENSSL_free(s->srp_ctx.login);
     OPENSSL_free(s->srp_ctx.info);
@@ -130,7 +130,7 @@ int SSL_CTX_SRP_CTX_init(struct ssl_ctx_st *ctx)
     memset(&ctx->srp_ctx, 0, sizeof(ctx->srp_ctx));
     ctx->srp_ctx.strength = SRP_MINIMAL_N;
 
-    return (1);
+    return 1;
 }
 
 /* server side */


### PR DESCRIPTION
Since return is inconsistent, I removed unnecessary parentheses and unified them.
- return (0); -> return 0;
- return (1); -> return 1;
- return (-1); -> return -1;

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
