### PR TITLE
Use INSTALL_PREFIX rather than DESTDIR

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -777,7 +777,7 @@
      locations, but have the package installed somewhere else so that
      it can easily be packaged, can use
 
-       $ make DESTDIR=/tmp/package-root install         # Unix
+       $ make INSTALL_PREFIX=/tmp/package-root install         # Unix
        $ mms/macro="DESTDIR=TMP:[PACKAGE-ROOT]" install ! OpenVMS
 
      The specified destination directory will be prepended to all


### PR DESCRIPTION
DESTDIR doesn't work on OpenSSL

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
