### PR TITLE
Contain test runs in separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,12 +60,7 @@ Makefile
 /test/ossl_shim/ossl_shim
 
 # Certain files that get created by tests on the fly
-/test/*.ss
-/test/*.srl
-/test/.rnd
-/test/test*.pem
-/test/newkey.pem
-/test/*.log
+/test/test-runs
 /test/buildtest_*
 
 # Fuzz stuff.

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -277,8 +277,10 @@ test : tests
 {- dependmagic('tests'); -} : build_programs_nodep, build_engines_nodep
         @ ! {- output_off() if $disabled{tests}; "" -}
         SET DEFAULT [.test]{- move("test") -}
+        CREATE/DIR [.test-runs]
         DEFINE SRCTOP {- sourcedir() -}
         DEFINE BLDTOP {- builddir() -}
+        DEFINE RESULT_D {- builddir(qw(test test-runs)) -}
         DEFINE OPENSSL_ENGINES {- builddir("engines") -}
         DEFINE OPENSSL_DEBUG_MEMORY "on"
         IF "$(VERBOSE)" .NES. "" THEN DEFINE VERBOSE "$(VERBOSE)"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -263,11 +263,13 @@ test: tests
 {- dependmagic('tests'); -}: build_programs_nodep build_engines_nodep link-utils
 	@ : {- output_off() if $disabled{tests}; "" -}
 	( cd test; \
+	  mkdir -p test-runs; \
 	  SRCTOP=../$(SRCDIR) \
 	  BLDTOP=../$(BLDDIR) \
+	  RESULT_D=test-runs \
 	  PERL="$(PERL)" \
 	  EXE_EXT={- $exeext -} \
-	  OPENSSL_ENGINES=../$(BLDDIR)/engines \
+	  OPENSSL_ENGINES=`cd ../$(BLDDIR)/engines; pwd` \
 	  OPENSSL_DEBUG_MEMORY=on \
 	    $(PERL) ../$(SRCDIR)/test/run_tests.pl $(TESTS) )
 	@ : {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -214,8 +214,10 @@ build_all_generated: $(GENERATED_MANDATORY) $(GENERATED)
 test: tests
 {- dependmagic('tests'); -}: build_programs_nodep build_engines_nodep
 	@rem {- output_off() if $disabled{tests}; "" -}
+	-mkdir $(BLDDIR)\test\test-runs
 	set SRCTOP=$(SRCDIR)
 	set BLDTOP=$(BLDDIR)
+	set RESULT_D=$(BLDDIR)\test\test-runs
 	set PERL=$(PERL)
 	set OPENSSL_DEBUG_MEMORY=on
 	"$(PERL)" "$(SRCDIR)\test\run_tests.pl" $(TESTS)

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -905,9 +905,9 @@ sub __test_file {
 
     my $e = pop || "";
     my $f = pop;
-    $f = catfile($directories{BLDTEST},@_,$f . $e);
-    $f = catfile($directories{SRCTEST},@_,$f) unless -f $f;
-    return $f;
+    my $out = catfile($directories{BLDTEST},@_,$f . $e);
+    $out = catfile($directories{SRCTEST},@_,$f) unless -f $out;
+    return $out;
 }
 
 sub __apps_file {
@@ -915,9 +915,9 @@ sub __apps_file {
 
     my $e = pop || "";
     my $f = pop;
-    $f = catfile($directories{BLDAPPS},@_,$f . $e);
-    $f = catfile($directories{SRCAPPS},@_,$f) unless -f $f;
-    return $f;
+    my $out = catfile($directories{BLDAPPS},@_,$f . $e);
+    $out = catfile($directories{SRCAPPS},@_,$f) unless -f $out;
+    return $out;
 }
 
 sub __fuzz_file {
@@ -925,9 +925,9 @@ sub __fuzz_file {
 
     my $e = pop || "";
     my $f = pop;
-    $f = catfile($directories{BLDFUZZ},@_,$f . $e);
-    $f = catfile($directories{SRCFUZZ},@_,$f) unless -f $f;
-    return $f;
+    my $out = catfile($directories{BLDFUZZ},@_,$f . $e);
+    $out = catfile($directories{SRCFUZZ},@_,$f) unless -f $out;
+    return $out;
 }
 
 sub __data_file {


### PR DESCRIPTION
Files being created by the test recipes ended up in `test/`.  With an in-source build, they are easily mixed up with source files, and as a matter of fact, our `.gitignore` was set to ignore some files that shouldn't be ignored as a result.

So instead, create a directory `test/test-runs` and have all test results end up in there.

Fortunately, the perly test framework was already prepared for this possibility, so changes are minimal.