### PR TITLE
Atomic fixes

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -177,7 +177,7 @@ int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
         return 1;
     }
 # endif
-    if (!CRYPTO_THREAD_write_lock(lock))
+    if (!CRYPTO_THREAD_read_lock(lock))
         return 0;
 
     *ret  = *val;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -135,7 +135,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 
 int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
 {
-    InterlockedCompareExchange(val, 0, 0);
+    *ret = InterlockedCompareExchange(val, 0, 0);
     return 1;
 }
 


### PR DESCRIPTION
Return a value from atomic read on Windows.
Use a read lock when reading using pthreads.
