### PR TITLE
fix build breaks with nonstandard options

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -541,9 +541,9 @@ struct ssl_session_st {
 # ifndef OPENSSL_NO_EC
         size_t ecpointformats_len;
         unsigned char *ecpointformats; /* peer's list */
+# endif                         /* OPENSSL_NO_EC */
         size_t supportedgroups_len;
         uint16_t *supportedgroups; /* peer's list */
-# endif                         /* OPENSSL_NO_EC */
     /* RFC4507 info */
         unsigned char *tick; /* Session ticket */
         size_t ticklen;      /* Session ticket length */
@@ -1202,10 +1202,10 @@ struct ssl_st {
         size_t ecpointformats_len;
         /* our list */
         unsigned char *ecpointformats;
+# endif                         /* OPENSSL_NO_EC */
         size_t supportedgroups_len;
         /* our list */
         uint16_t *supportedgroups;
-# endif                         /* OPENSSL_NO_EC */
         /* TLS Session Ticket extension override */
         TLS_SESSION_TICKET_EXT *session_ticket;
         /* TLS Session Ticket extension callback */

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -118,7 +118,7 @@ static int validate_client_hello(BIO *wbio)
     long len;
     unsigned char *data;
     int cookie_found = 0;
-    unsigned int u;
+    unsigned int u = 0;
 
     len = BIO_get_mem_data(wbio, (char **)&data);
     if (!PACKET_buf_init(&pkt, data, len))


### PR DESCRIPTION
The no-ec automatic builder has been failing.  While testing that fix, I ran into an issue specific to my gcc version's -O1 (-O0 or -O2 do not trigger it), so it's less clear that the second commit is worth including.