### PR TITLE
 Fix bug where early_data does not work if no SNI callback is present

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -834,6 +834,11 @@ static int final_server_name(SSL *s, unsigned int context, int sent,
         ret = s->session_ctx->ext.servername_cb(s, &altmp,
                                        s->session_ctx->ext.servername_arg);
 
+    if (!sent) {
+        OPENSSL_free(s->session->ext.hostname);
+        s->session->ext.hostname = NULL;
+    }
+
     /*
      * If we're expecting to send a ticket, and tickets were previously enabled,
      * and now tickets are disabled, then turn off expected ticket.

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1507,6 +1507,16 @@ static int setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx, SSL **clientssl,
                                       NULL, NULL)))
         return 0;
 
+    /*
+     * For one of the run throughs (doesn't matter which one), we'll try sending
+     * some SNI data in the initial ClientHello. This will be ignored (because
+     * there is no SNI cb set up by the server), so it should not impact
+     * early_data.
+     */
+    if (idx == 1
+            && !TEST_true(SSL_set_tlsext_host_name(*clientssl, "localhost")))
+        return 0;
+
     if (idx == 2) {
         /* Create the PSK */
         const SSL_CIPHER *cipher = NULL;


### PR DESCRIPTION
Fixes #4496
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
