### PR TITLE
make '-name' option of the 's_client' more generic

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -100,6 +100,7 @@ B<openssl> B<s_client>
 [B<-serverpref>]
 [B<-starttls protocol>]
 [B<-xmpphost hostname>]
+[B<-name hostname>]
 [B<-engine id>]
 [B<-tlsextdebug>]
 [B<-no_ticket>]
@@ -514,6 +515,23 @@ specifies the host for the "to" attribute of the stream element.
 If this option is not specified, then the host specified with "-connect"
 will be used.
 
+This option is an alias of the B<-name> option since OpenSSL 1.1.1 for
+"xmpp" and "xmpp-server".
+
+=item B<-name hostname>
+
+This option is used to specify hostname information for various protocols
+used with B<-starttls> option. Currently only "xmpp", "xmpp-server",
+"smtp" and "lmtp" can utilize this B<-name> option.
+
+If this option is used with "-starttls xmpp" or "-starttls xmpp-server",
+if specifies the host for the "to" attribute of the stream element. If this
+option is not specified, then the host specified with "-connect" will be used.
+
+If this option is used with "-starttls lmtp" or "-starttls smtp", it specifies
+the name to use in the "LMTP LHLO" or "SMTP EHLO" message, respectively. If
+this option is not specified, then "mail.example.com" will be used.
+
 =item B<-tlsextdebug>
 
 Print out a hex dump of any TLS extensions received from the server.
@@ -680,7 +698,8 @@ L<SSL_CTX_set_max_pipelines(3)>
 
 =head1 HISTORY
 
-The -no_alt_chains options was first added to OpenSSL 1.1.0.
+The B<-no_alt_chains> option was first added to OpenSSL 1.1.0.
+The B<-name> option was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -515,8 +515,7 @@ specifies the host for the "to" attribute of the stream element.
 If this option is not specified, then the host specified with "-connect"
 will be used.
 
-This option is an alias of the B<-name> option since OpenSSL 1.1.1 for
-"xmpp" and "xmpp-server".
+This option is an alias of the B<-name> option for "xmpp" and "xmpp-server".
 
 =item B<-name hostname>
 


### PR DESCRIPTION
In response to issue #4422

And also make '-xmpphost' an alias of the '-name' option.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
