### PR TITLE
Fix memory leak in DH_get_nid()

### DIFF
--- a/crypto/dh/dh_rfc7919.c
+++ b/crypto/dh/dh_rfc7919.c
@@ -66,10 +66,9 @@ int DH_get_nid(const DH *dh)
         BIGNUM *q = BN_dup(dh->p);
 
         /* Check q = p * 2 + 1 we already know q is odd, so just shift right */
-        if (q == NULL || !BN_rshift1(q, q) || !BN_cmp(dh->q, q)) {
-            BN_free(q);
-            return NID_undef;
-        }
+        if (q == NULL || !BN_rshift1(q, q) || !BN_cmp(dh->q, q))
+            nid = NID_undef;
+        BN_free(q);
     }
     return nid;
 }


### PR DESCRIPTION
If q is non-NULL but p is indeed a safe prime, a modified copy
of p could be leaked.
