### PR TITLE
Fix no-tls1_2 build for 1.1.0

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -76,6 +76,7 @@ my %skip = (
   "15-certstatus.conf" => $no_tls || $no_ocsp,
   "16-dtls-certstatus.conf" => $no_dtls || $no_ocsp,
   "18-dtls-renegotiate.conf" => $no_dtls,
+  "19-mac-then-encrypt.conf" => disabled("tls1_2"),
 );
 
 foreach my $conf (@conf_files) {


### PR DESCRIPTION
Skip a test that uses a TLS 1.2-only cipher.