### PR TITLE
Prioritize /dev/prandom over /dev/urandom on s390x

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -58,7 +58,11 @@ extern "C" {
  * set this to a comma-separated list of 'random' device files to try out. By
  * default, we will try to read at least one of these files
  */
-#  define DEVRANDOM "/dev/urandom","/dev/random","/dev/srandom"
+#  if defined(__s390__)
+#   define DEVRANDOM "/dev/prandom","/dev/urandom","/dev/hwrng","/dev/random"
+#  else
+#   define DEVRANDOM "/dev/urandom","/dev/random","/dev/srandom"
+#  endif
 # endif
 # if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
 /*


### PR DESCRIPTION
/dev/prandom is provided by the s390 prng kernel module which conditions entropy from the kernels random pool and the clock using a hardware implementation of a SHA-512 based Hash_DRBG (NIST SP 800-90A). RAND_poll performs ~3-time better reading from prandom instead of urandom (on z14). Users who still prefer urandom can just unload the prng module.
