### PR TITLE
Remove parentheses of return.

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -663,7 +663,7 @@ X509 *load_cert(const char *file, int format, const char *cert_descrip)
         ERR_print_errors(bio_err);
     }
     BIO_free(cert);
-    return (x);
+    return x;
 }
 
 X509_CRL *load_crl(const char *infile, int format)
@@ -697,7 +697,7 @@ X509_CRL *load_crl(const char *infile, int format)
 
  end:
     BIO_free(in);
-    return (x);
+    return x;
 }
 
 EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
@@ -769,7 +769,7 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
         BIO_printf(bio_err, "unable to load %s\n", key_descrip);
         ERR_print_errors(bio_err);
     }
-    return (pkey);
+    return pkey;
 }
 
 EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
@@ -855,7 +855,7 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
     BIO_free(key);
     if (pkey == NULL)
         BIO_printf(bio_err, "unable to load %s\n", key_descrip);
-    return (pkey);
+    return pkey;
 }
 
 static int load_certs_crls(const char *file, int format,
@@ -1334,7 +1334,7 @@ static int index_serial_cmp(const OPENSSL_CSTRING *a,
 
     for (aa = a[DB_serial]; *aa == '0'; aa++) ;
     for (bb = b[DB_serial]; *bb == '0'; bb++) ;
-    return (strcmp(aa, bb));
+    return strcmp(aa, bb);
 }
 
 static int index_name_qual(char **a)
@@ -1349,7 +1349,7 @@ static unsigned long index_name_hash(const OPENSSL_CSTRING *a)
 
 int index_name_cmp(const OPENSSL_CSTRING *a, const OPENSSL_CSTRING *b)
 {
-    return (strcmp(a[DB_name], b[DB_name]));
+    return strcmp(a[DB_name], b[DB_name]);
 }
 
 static IMPLEMENT_LHASH_HASH_FN(index_serial, OPENSSL_CSTRING)
@@ -1400,7 +1400,7 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
  err:
     BIO_free(in);
     ASN1_INTEGER_free(ai);
-    return (ret);
+    return ret;
 }
 
 int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial,
@@ -1450,7 +1450,7 @@ int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial
  err:
     BIO_free_all(out);
     ASN1_INTEGER_free(ai);
-    return (ret);
+    return ret;
 }
 
 int rotate_serial(const char *serialfile, const char *new_suffix,
@@ -2153,7 +2153,7 @@ double app_tminterval(int stop, int usertime)
         ret = (__int64)(tmstop.QuadPart - tmstart.QuadPart) * 1e-7;
     }
 
-    return (ret);
+    return ret;
 }
 #elif defined(OPENSSL_SYSTEM_VXWORKS)
 # include <time.h>
@@ -2189,7 +2189,7 @@ double app_tminterval(int stop, int usertime)
     else
         ret = (now - tmstart) / (double)sysClkRateGet();
 # endif
-    return (ret);
+    return ret;
 }
 
 #elif defined(OPENSSL_SYSTEM_VMS)
@@ -2223,7 +2223,7 @@ double app_tminterval(int stop, int usertime)
     else
         ret = (now - tmstart) / (double)(CLK_TCK);
 
-    return (ret);
+    return ret;
 }
 
 #elif defined(_SC_CLK_TCK)      /* by means of unistd.h */
@@ -2246,7 +2246,7 @@ double app_tminterval(int stop, int usertime)
         ret = (now - tmstart) / (double)tck;
     }
 
-    return (ret);
+    return ret;
 }
 
 #else
@@ -2371,9 +2371,9 @@ int raw_read_stdin(void *buf, int siz)
 {
     DWORD n;
     if (ReadFile(GetStdHandle(STD_INPUT_HANDLE), buf, siz, &n, NULL))
-        return (n);
+        return n;
     else
-        return (-1);
+        return -1;
 }
 #elif defined(__VMS)
 # include <sys/socket.h>
@@ -2394,9 +2394,9 @@ int raw_write_stdout(const void *buf, int siz)
 {
     DWORD n;
     if (WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), buf, siz, &n, NULL))
-        return (n);
+        return n;
     else
-        return (-1);
+        return -1;
 }
 #else
 int raw_write_stdout(const void *buf, int siz)

--- a/apps/asn1pars.c
+++ b/apps/asn1pars.c
@@ -306,7 +306,7 @@ int asn1parse_main(int argc, char **argv)
         OPENSSL_free(str);
     ASN1_TYPE_free(at);
     sk_OPENSSL_STRING_free(osk);
-    return (ret);
+    return ret;
 }
 
 static int do_generate(char *genstr, const char *genconf, BUF_MEM *buf)

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1235,7 +1235,7 @@ end_of_options:
     NCONF_free(conf);
     NCONF_free(extconf);
     release_engine(e);
-    return (ret);
+    return ret;
 }
 
 static char *lookup_conf(const CONF *conf, const char *section, const char *tag)
@@ -1312,7 +1312,7 @@ static int certify(X509 **xret, const char *infile, EVP_PKEY *pkey, X509 *x509,
  end:
     X509_REQ_free(req);
     BIO_free(in);
-    return (ok);
+    return ok;
 }
 
 static int certify_cert(X509 **xret, const char *infile, EVP_PKEY *pkey, X509 *x509,
@@ -1365,7 +1365,7 @@ static int certify_cert(X509 **xret, const char *infile, EVP_PKEY *pkey, X509 *x
  end:
     X509_REQ_free(rreq);
     X509_free(req);
-    return (ok);
+    return ok;
 }
 
 static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
@@ -1866,7 +1866,7 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         X509_free(ret);
     else
         *xret = ret;
-    return (ok);
+    return ok;
 }
 
 static void write_new_certificate(BIO *bp, X509 *x, int output_der, int notext)
@@ -2013,7 +2013,7 @@ static int certify_spkac(X509 **xret, const char *infile, EVP_PKEY *pkey,
     NETSCAPE_SPKI_free(spki);
     X509_NAME_ENTRY_free(ne);
 
-    return (ok);
+    return ok;
 }
 
 static int check_time_format(const char *str)
@@ -2119,7 +2119,7 @@ static int do_revoke(X509 *x509, CA_DB *db, REVINFO_TYPE rev_type,
  end:
     for (i = 0; i < DB_NUMBER; i++)
         OPENSSL_free(row[i]);
-    return (ok);
+    return ok;
 }
 
 static int get_certificate_status(const char *serial, CA_DB *db)
@@ -2186,7 +2186,7 @@ static int get_certificate_status(const char *serial, CA_DB *db)
     for (i = 0; i < DB_NUMBER; i++) {
         OPENSSL_free(row[i]);
     }
-    return (ok);
+    return ok;
 }
 
 static int do_updatedb(CA_DB *db)
@@ -2244,7 +2244,7 @@ static int do_updatedb(CA_DB *db)
 
     ASN1_UTCTIME_free(a_tm);
     OPENSSL_free(a_tm_s);
-    return (cnt);
+    return cnt;
 }
 
 static const char *crl_reasons[] = {

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1103,7 +1103,7 @@ int cms_main(int argc, char **argv)
     BIO_free(indata);
     BIO_free_all(out);
     OPENSSL_free(passin);
-    return (ret);
+    return ret;
 }
 
 static int save_certs(char *signerfile, STACK_OF(X509) *signers)

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -337,5 +337,5 @@ int crl_main(int argc, char **argv)
     X509_CRL_free(x);
     X509_STORE_CTX_free(ctx);
     X509_STORE_free(store);
-    return (ret);
+    return ret;
 }

--- a/apps/crl2p7.c
+++ b/apps/crl2p7.c
@@ -162,7 +162,7 @@ int crl2pkcs7_main(int argc, char **argv)
     PKCS7_free(p7);
     X509_CRL_free(crl);
 
-    return (ret);
+    return ret;
 }
 
 /*-
@@ -212,5 +212,5 @@ static int add_certs_from_file(STACK_OF(X509) *stack, char *certfile)
     /* never need to OPENSSL_free x */
     BIO_free(in);
     sk_X509_INFO_free(sk);
-    return (ret);
+    return ret;
 }

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -398,7 +398,7 @@ int dgst_main(int argc, char **argv)
     OPENSSL_free(sigbuf);
     BIO_free(bmd);
     release_engine(e);
-    return (ret);
+    return ret;
 }
 
 int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -364,7 +364,7 @@ int dhparam_main(int argc, char **argv)
     BIO_free_all(out);
     DH_free(dh);
     release_engine(e);
-    return (ret);
+    return ret;
 }
 
 static int dh_cb(int p, int n, BN_GENCB *cb)

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -256,6 +256,6 @@ int dsa_main(int argc, char **argv)
     release_engine(e);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
-    return (ret);
+    return ret;
 }
 #endif

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -230,7 +230,7 @@ int dsaparam_main(int argc, char **argv)
     BIO_free_all(out);
     DSA_free(dsa);
     release_engine(e);
-    return (ret);
+    return ret;
 }
 
 static int dsa_cb(int p, int n, BN_GENCB *cb)

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -277,6 +277,6 @@ int ec_main(int argc, char **argv)
     release_engine(e);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
-    return (ret);
+    return ret;
 }
 #endif

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -437,7 +437,7 @@ int ecparam_main(int argc, char **argv)
     release_engine(e);
     BIO_free(in);
     BIO_free_all(out);
-    return (ret);
+    return ret;
 }
 
 #endif

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -483,6 +483,6 @@ int engine_main(int argc, char **argv)
     sk_OPENSSL_STRING_free(pre_cmds);
     sk_OPENSSL_STRING_free(post_cmds);
     BIO_free_all(out);
-    return (ret);
+    return ret;
 }
 #endif

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -62,5 +62,5 @@ int errstr_main(int argc, char **argv)
         }
     }
  end:
-    return (ret);
+    return ret;
 }

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -133,6 +133,6 @@ int gendsa_main(int argc, char **argv)
     DSA_free(dsa);
     release_engine(e);
     OPENSSL_free(passout);
-    return (ret);
+    return ret;
 }
 #endif

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -166,7 +166,7 @@ opthelp:
     OPENSSL_free(passout);
     if (ret != 0)
         ERR_print_errors(bio_err);
-    return (ret);
+    return ret;
 }
 
 static int genrsa_cb(int p, int n, BN_GENCB *cb)

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -109,5 +109,5 @@ int nseq_main(int argc, char **argv)
     BIO_free_all(out);
     NETSCAPE_CERT_SEQUENCE_free(seq);
 
-    return (ret);
+    return ret;
 }

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -747,7 +747,7 @@ redo_accept:
     OPENSSL_free(tport);
     OPENSSL_free(tpath);
 
-    return (ret);
+    return ret;
 }
 
 static int add_ocsp_cert(OCSP_REQUEST **req, X509 *cert,

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -534,7 +534,7 @@ static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[])
     FUNCTION f, *fp;
 
     if (argc <= 0 || argv[0] == NULL)
-        return (0);
+        return 0;
     f.name = argv[0];
     fp = lh_FUNCTION_retrieve(prog, &f);
     if (fp == NULL) {
@@ -549,7 +549,7 @@ static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[])
         }
     }
     if (fp != NULL) {
-        return (fp->func(argc, argv));
+        return fp->func(argc, argv);
     }
     if ((strncmp(argv[0], "no-", 3)) == 0) {
         /*
@@ -559,7 +559,7 @@ static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[])
         f.name = argv[0] + 3;
         if (lh_FUNCTION_retrieve(prog, &f) == NULL) {
             BIO_printf(bio_out, "%s\n", argv[0]);
-            return (0);
+            return 0;
         }
         BIO_printf(bio_out, "%s\n", argv[0] + 3);
         return 1;
@@ -790,7 +790,7 @@ static LHASH_OF(FUNCTION) *prog_init(void)
     qsort(functions, i, sizeof(*functions), SortFnByName);
 
     if ((ret = lh_FUNCTION_new(function_hash, function_cmp)) == NULL)
-        return (NULL);
+        return NULL;
 
     for (f = functions; f->name != NULL; f++)
         (void)lh_FUNCTION_insert(ret, f);

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -295,7 +295,7 @@ int passwd_main(int argc, char **argv)
     OPENSSL_free(salt_malloc);
     OPENSSL_free(passwd_malloc);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 /*

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -193,5 +193,5 @@ int pkcs7_main(int argc, char **argv)
     release_engine(e);
     BIO_free(in);
     BIO_free_all(out);
-    return (ret);
+    return ret;
 }

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -128,5 +128,5 @@ int rand_main(int argc, char **argv)
         ERR_print_errors(bio_err);
     release_engine(e);
     BIO_free_all(out);
-    return (ret);
+    return ret;
 }

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -307,6 +307,6 @@ int rsa_main(int argc, char **argv)
     RSA_free(rsa);
     OPENSSL_free(passin);
     OPENSSL_free(passout);
-    return (ret);
+    return ret;
 }
 #endif

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -100,7 +100,7 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
         policies_print(ctx);
     if (ok && !verify_args.quiet)
         BIO_printf(bio_err, "verify return:%d\n", ok);
-    return (ok);
+    return ok;
 }
 
 int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file)
@@ -111,7 +111,7 @@ int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file)
             BIO_printf(bio_err, "unable to get certificate from '%s'\n",
                        cert_file);
             ERR_print_errors(bio_err);
-            return (0);
+            return 0;
         }
         if (key_file == NULL)
             key_file = cert_file;
@@ -119,7 +119,7 @@ int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file)
             BIO_printf(bio_err, "unable to get private key from '%s'\n",
                        key_file);
             ERR_print_errors(bio_err);
-            return (0);
+            return 0;
         }
 
         /*
@@ -134,7 +134,7 @@ int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file)
         if (!SSL_CTX_check_private_key(ctx)) {
             BIO_printf(bio_err,
                        "Private key does not match the certificate public key\n");
-            return (0);
+            return 0;
         }
     }
     return 1;
@@ -423,19 +423,19 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp,
 
     out = (BIO *)BIO_get_callback_arg(bio);
     if (out == NULL)
-        return (ret);
+        return ret;
 
     if (cmd == (BIO_CB_READ | BIO_CB_RETURN)) {
         BIO_printf(out, "read from %p [%p] (%lu bytes => %ld (0x%lX))\n",
                    (void *)bio, (void *)argp, (unsigned long)argi, ret, ret);
         BIO_dump(out, argp, (int)ret);
-        return (ret);
+        return ret;
     } else if (cmd == (BIO_CB_WRITE | BIO_CB_RETURN)) {
         BIO_printf(out, "write to %p [%p] (%lu bytes => %ld (0x%lX))\n",
                    (void *)bio, (void *)argp, (unsigned long)argi, ret, ret);
         BIO_dump(out, argp, (int)ret);
     }
-    return (ret);
+    return ret;
 }
 
 void apps_ssl_info_callback(const SSL *s, int where, int ret)

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3053,7 +3053,7 @@ int s_client_main(int argc, char **argv)
     bio_c_out = NULL;
     BIO_free(bio_c_msg);
     bio_c_msg = NULL;
-    return (ret);
+    return ret;
 }
 
 static void print_stuff(BIO *bio, SSL *s, int full)

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -255,7 +255,7 @@ static int ssl_srp_server_param_cb(SSL *s, int *ad, void *arg)
     if (p->login == NULL && p->user == NULL) {
         p->login = SSL_get_srp_username(s);
         BIO_printf(bio_err, "SRP username = \"%s\"\n", p->login);
-        return (-1);
+        return -1;
     }
 
     if (p->user == NULL) {
@@ -355,9 +355,9 @@ static int ebcdic_read(BIO *b, char *out, int outl)
     BIO *next = BIO_next(b);
 
     if (out == NULL || outl == 0)
-        return (0);
+        return 0;
     if (next == NULL)
-        return (0);
+        return 0;
 
     ret = BIO_read(next, out, outl);
     if (ret > 0)
@@ -373,7 +373,7 @@ static int ebcdic_write(BIO *b, const char *in, int inl)
     int num;
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
     if (next == NULL)
         return 0;
 
@@ -396,7 +396,7 @@ static int ebcdic_write(BIO *b, const char *in, int inl)
 
     ret = BIO_write(next, wbuf->buff, inl);
 
-    return (ret);
+    return ret;
 }
 
 static long ebcdic_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -405,7 +405,7 @@ static long ebcdic_ctrl(BIO *b, int cmd, long num, void *ptr)
     BIO *next = BIO_next(b);
 
     if (next == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     case BIO_CTRL_DUP:
         ret = 0L;
@@ -414,7 +414,7 @@ static long ebcdic_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = BIO_ctrl(next, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int ebcdic_gets(BIO *bp, char *buf, int size)
@@ -2140,7 +2140,7 @@ int s_server_main(int argc, char *argv[])
 #ifdef CHARSET_EBCDIC
     BIO_meth_free(methods_ebcdic);
 #endif
-    return (ret);
+    return ret;
 }
 
 static void print_stats(BIO *bio, SSL_CTX *ssl_ctx)
@@ -2657,7 +2657,7 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
     if (ret >= 0)
         BIO_printf(bio_s_out, "ACCEPT\n");
     (void)BIO_flush(bio_s_out);
-    return (ret);
+    return ret;
 }
 
 static void close_accept_socket(void)
@@ -2772,7 +2772,7 @@ static int init_ssl_connection(SSL *con)
         }
         /* Always print any error messages */
         ERR_print_errors(bio_err);
-        return (0);
+        return 0;
     }
 
     print_connection_info(con);
@@ -2875,7 +2875,7 @@ static DH *load_dh_param(const char *dhfile)
     ret = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
  err:
     BIO_free(bio);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -3263,7 +3263,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
         BIO_printf(bio_s_out, "ACCEPT\n");
     OPENSSL_free(buf);
     BIO_free_all(io);
-    return (ret);
+    return ret;
 }
 
 static int rev_body(int s, int stype, int prot, unsigned char *context)
@@ -3416,7 +3416,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
 
     OPENSSL_free(buf);
     BIO_free_all(io);
-    return (ret);
+    return ret;
 }
 
 #define MAX_SESSION_ID_ATTEMPTS 10

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -163,7 +163,7 @@ int sess_id_main(int argc, char **argv)
  end:
     BIO_free_all(out);
     SSL_SESSION_free(x);
-    return (ret);
+    return ret;
 }
 
 static SSL_SESSION *load_sess_id(char *infile, int format)
@@ -186,5 +186,5 @@ static SSL_SESSION *load_sess_id(char *infile, int format)
 
  end:
     BIO_free(in);
-    return (x);
+    return x;
 }

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -609,7 +609,7 @@ int smime_main(int argc, char **argv)
     BIO_free(indata);
     BIO_free_all(out);
     OPENSSL_free(passin);
-    return (ret);
+    return ret;
 }
 
 static int save_certs(char *signerfile, STACK_OF(X509) *signers)

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2938,7 +2938,7 @@ int speed_main(int argc, char **argv)
     }
     OPENSSL_free(loopargs);
     release_engine(e);
-    return (ret);
+    return ret;
 }
 
 static void print_message(const char *s, long num, int length)

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -197,5 +197,5 @@ int spkac_main(int argc, char **argv)
     EVP_PKEY_free(pkey);
     release_engine(e);
     OPENSSL_free(passin);
-    return (ret);
+    return ret;
 }

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -603,6 +603,6 @@ int srp_main(int argc, char **argv)
     NCONF_free(conf);
     free_index(db);
     release_engine(e);
-    return (ret);
+    return ret;
 }
 #endif

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -320,7 +320,7 @@ int ts_main(int argc, char **argv)
     X509_VERIFY_PARAM_free(vpm);
     NCONF_free(conf);
     OPENSSL_free(password);
-    return (ret);
+    return ret;
 }
 
 /*

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -313,5 +313,5 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         policies_print(ctx);
     if (!v_verbose)
         ERR_clear_error();
-    return (ok);
+    return ok;
 }

--- a/apps/version.c
+++ b/apps/version.c
@@ -188,5 +188,5 @@ opthelp:
     }
     ret = 0;
  end:
-    return (ret);
+    return ret;
 }

--- a/apps/vms_term_sock.c
+++ b/apps/vms_term_sock.c
@@ -184,7 +184,7 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
                 close (TerminalSocketPair[0]);
             if (TerminalSocketPair[1])
                 close (TerminalSocketPair[1]);
-            return (TERM_SOCK_FAILURE);
+            return TERM_SOCK_FAILURE;
         }
 
         /*
@@ -197,7 +197,7 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
             LogMessage ("TerminalSocket: SYS$ASSIGN () - %08X", status);
             close (TerminalSocketPair[0]);
             close (TerminalSocketPair[1]);
-            return (TERM_SOCK_FAILURE);
+            return TERM_SOCK_FAILURE;
         }
 
         /*
@@ -216,7 +216,7 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
             LogMessage ("TerminalSocket: SYS$QIO () - %08X", status);
             close (TerminalSocketPair[0]);
             close (TerminalSocketPair[1]);
-            return (TERM_SOCK_FAILURE);
+            return TERM_SOCK_FAILURE;
         }
 
         /*
@@ -234,7 +234,7 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
             LogMessage ("TerminalSocket: SYS$CANCEL () - %08X", status);
             close (TerminalSocketPair[0]);
             close (TerminalSocketPair[1]);
-            return (TERM_SOCK_FAILURE);
+            return TERM_SOCK_FAILURE;
         }
 
         /*
@@ -245,7 +245,7 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
             LogMessage ("TerminalSocket: SYS$DASSGN () - %08X", status);
             close (TerminalSocketPair[0]);
             close (TerminalSocketPair[1]);
-            return (TERM_SOCK_FAILURE);
+            return TERM_SOCK_FAILURE;
         }
 
         /*
@@ -265,14 +265,14 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
 	** Invalid function code
 	*/
         LogMessage ("TerminalSocket: Invalid Function Code - %d", FunctionCode);
-        return (TERM_SOCK_FAILURE);
+        return TERM_SOCK_FAILURE;
         break;
     }
 
     /*
     ** Return success
     */
-    return (TERM_SOCK_SUCCESS);
+    return TERM_SOCK_SUCCESS;
 
 }
 
@@ -312,7 +312,7 @@ static int CreateSocketPair (int SocketFamily,
     SockDesc1 = socket (SocketFamily, SocketType, 0);
     if (SockDesc1 < 0) {
         LogMessage ("CreateSocketPair: socket () - %d", errno);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -331,7 +331,7 @@ static int CreateSocketPair (int SocketFamily,
     if (status < 0) {
         LogMessage ("CreateSocketPair: bind () - %d", errno);
         close (SockDesc1);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -341,7 +341,7 @@ static int CreateSocketPair (int SocketFamily,
     if (status < 0) {
         LogMessage ("CreateSocketPair: getsockname () - %d", errno);
         close (SockDesc1);
-        return (-1);
+        return -1;
     } else
         LocalHostPort = sin.sin_port;
 
@@ -360,7 +360,7 @@ static int CreateSocketPair (int SocketFamily,
     if (! (status & 1)) {
         LogMessage ("CreateSocketPair: SYS$BINTIM () - %08X", status);
         close (SockDesc1);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -371,7 +371,7 @@ static int CreateSocketPair (int SocketFamily,
     if (! (status & 1)) {
         LogMessage ("CreateSocketPair: SYS$ASSIGN () - %08X", status);
         close (SockDesc1);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -393,7 +393,7 @@ static int CreateSocketPair (int SocketFamily,
         LogMessage ("CreateSocketPair: SYS$QIO () - %08X", status);
         close (SockDesc1);
         sys$dassgn (TcpDeviceChan);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -429,7 +429,7 @@ static int CreateSocketPair (int SocketFamily,
         close (SockDesc1);
         close (SockDesc2);
         sys$dassgn (TcpDeviceChan);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -448,7 +448,7 @@ static int CreateSocketPair (int SocketFamily,
         close (SockDesc1);
         close (SockDesc2);
         sys$dassgn (TcpDeviceChan);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -468,7 +468,7 @@ static int CreateSocketPair (int SocketFamily,
         close (SockDesc1);
         close (SockDesc2);
         sys$dassgn (TcpDeviceChan);
-        return (-1);
+        return -1;
     }
 
     /*

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -61,7 +61,7 @@ int i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
 
     ret = 1 + len;
     if (pp == NULL)
-        return (ret);
+        return ret;
 
     p = *pp;
 
@@ -73,7 +73,7 @@ int i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
         p[-1] &= (0xff << bits);
     }
     *pp = p;
-    return (ret);
+    return ret;
 }
 
 ASN1_BIT_STRING *c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
@@ -96,7 +96,7 @@ ASN1_BIT_STRING *c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
 
     if ((a == NULL) || ((*a) == NULL)) {
         if ((ret = ASN1_BIT_STRING_new()) == NULL)
-            return (NULL);
+            return NULL;
     } else
         ret = (*a);
 
@@ -132,12 +132,12 @@ ASN1_BIT_STRING *c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
     if (a != NULL)
         (*a) = ret;
     *pp = p;
-    return (ret);
+    return ret;
  err:
     ASN1err(ASN1_F_C2I_ASN1_BIT_STRING, i);
     if ((a == NULL) || (*a != ret))
         ASN1_BIT_STRING_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 /*
@@ -161,7 +161,7 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value)
 
     if ((a->length < (w + 1)) || (a->data == NULL)) {
         if (!value)
-            return (1);         /* Don't need to set */
+            return 1;         /* Don't need to set */
         c = OPENSSL_clear_realloc(a->data, a->length, w + 1);
         if (c == NULL) {
             ASN1err(ASN1_F_ASN1_BIT_STRING_SET_BIT, ERR_R_MALLOC_FAILURE);

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -25,12 +25,12 @@ void *ASN1_d2i_fp(void *(*xnew) (void), d2i_of_void *d2i, FILE *in, void **x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ASN1err(ASN1_F_ASN1_D2I_FP, ERR_R_BUF_LIB);
-        return (NULL);
+        return NULL;
     }
     BIO_set_fp(b, in, BIO_NOCLOSE);
     ret = ASN1_d2i_bio(xnew, d2i, b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 # endif
 
@@ -49,7 +49,7 @@ void *ASN1_d2i_bio(void *(*xnew) (void), d2i_of_void *d2i, BIO *in, void **x)
     ret = d2i(x, &p, len);
  err:
     BUF_MEM_free(b);
-    return (ret);
+    return ret;
 }
 
 #endif
@@ -69,7 +69,7 @@ void *ASN1_item_d2i_bio(const ASN1_ITEM *it, BIO *in, void *x)
     ret = ASN1_item_d2i(x, &p, len, it);
  err:
     BUF_MEM_free(b);
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_STDIO
@@ -80,12 +80,12 @@ void *ASN1_item_d2i_fp(const ASN1_ITEM *it, FILE *in, void *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_D2I_FP, ERR_R_BUF_LIB);
-        return (NULL);
+        return NULL;
     }
     BIO_set_fp(b, in, BIO_NOCLOSE);
     ret = ASN1_item_d2i_bio(it, b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 

--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -29,7 +29,7 @@ int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type, char *data,
     i = i2d(data, NULL);
     if ((str = OPENSSL_malloc(i)) == NULL) {
         ASN1err(ASN1_F_ASN1_DIGEST, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
     p = str;
     i2d(data, &p);
@@ -52,7 +52,7 @@ int ASN1_item_digest(const ASN1_ITEM *it, const EVP_MD *type, void *asn,
 
     i = ASN1_item_i2d(asn, &str, it);
     if (!str)
-        return (0);
+        return 0;
 
     if (!EVP_Digest(str, i, md, len, type, NULL)) {
         OPENSSL_free(str);

--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -21,20 +21,20 @@ void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, void *x)
     char *ret;
 
     if (x == NULL)
-        return (NULL);
+        return NULL;
 
     i = i2d(x, NULL);
     b = OPENSSL_malloc(i + 10);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_DUP, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
     p = b;
     i = i2d(x, &p);
     p2 = b;
     ret = d2i(NULL, &p2, i);
     OPENSSL_free(b);
-    return (ret);
+    return ret;
 }
 
 #endif
@@ -54,15 +54,15 @@ void *ASN1_item_dup(const ASN1_ITEM *it, void *x)
     void *ret;
 
     if (x == NULL)
-        return (NULL);
+        return NULL;
 
     i = ASN1_item_i2d(x, &b, it);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_DUP, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
     p = b;
     ret = ASN1_item_d2i(NULL, &p, i, it);
     OPENSSL_free(b);
-    return (ret);
+    return ret;
 }

--- a/crypto/asn1/a_i2d_fp.c
+++ b/crypto/asn1/a_i2d_fp.c
@@ -22,12 +22,12 @@ int ASN1_i2d_fp(i2d_of_void *i2d, FILE *out, void *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ASN1err(ASN1_F_ASN1_I2D_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, out, BIO_NOCLOSE);
     ret = ASN1_i2d_bio(i2d, b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 # endif
 
@@ -41,7 +41,7 @@ int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, unsigned char *x)
     b = OPENSSL_malloc(n);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_I2D_BIO, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
 
     p = (unsigned char *)b;
@@ -59,7 +59,7 @@ int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, unsigned char *x)
         n -= i;
     }
     OPENSSL_free(b);
-    return (ret);
+    return ret;
 }
 
 #endif
@@ -72,12 +72,12 @@ int ASN1_item_i2d_fp(const ASN1_ITEM *it, FILE *out, void *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_I2D_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, out, BIO_NOCLOSE);
     ret = ASN1_item_i2d_bio(it, b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -89,7 +89,7 @@ int ASN1_item_i2d_bio(const ASN1_ITEM *it, BIO *out, void *x)
     n = ASN1_item_i2d(x, &b, it);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_I2D_BIO, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
 
     for (;;) {
@@ -104,5 +104,5 @@ int ASN1_item_i2d_bio(const ASN1_ITEM *it, BIO *out, void *x)
         n -= i;
     }
     OPENSSL_free(b);
-    return (ret);
+    return ret;
 }

--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -396,7 +396,7 @@ ASN1_INTEGER *d2i_ASN1_UINTEGER(ASN1_INTEGER **a, const unsigned char **pp,
 
     if ((a == NULL) || ((*a) == NULL)) {
         if ((ret = ASN1_INTEGER_new()) == NULL)
-            return (NULL);
+            return NULL;
         ret->type = V_ASN1_INTEGER;
     } else
         ret = (*a);
@@ -438,12 +438,12 @@ ASN1_INTEGER *d2i_ASN1_UINTEGER(ASN1_INTEGER **a, const unsigned char **pp,
     if (a != NULL)
         (*a) = ret;
     *pp = p;
-    return (ret);
+    return ret;
  err:
     ASN1err(ASN1_F_D2I_ASN1_UINTEGER, i);
     if ((a == NULL) || (*a != ret))
         ASN1_INTEGER_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 static ASN1_STRING *bn_to_asn1_string(const BIGNUM *bn, ASN1_STRING *ai,
@@ -487,7 +487,7 @@ static ASN1_STRING *bn_to_asn1_string(const BIGNUM *bn, ASN1_STRING *ai,
  err:
     if (ret != ai)
         ASN1_INTEGER_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 static BIGNUM *asn1_string_to_bn(const ASN1_INTEGER *ai, BIGNUM *bn,

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -24,7 +24,7 @@ int i2d_ASN1_OBJECT(const ASN1_OBJECT *a, unsigned char **pp)
     int objsize;
 
     if ((a == NULL) || (a->data == NULL))
-        return (0);
+        return 0;
 
     objsize = ASN1_object_size(0, a->length, V_ASN1_OBJECT);
     if (pp == NULL || objsize == -1)
@@ -36,7 +36,7 @@ int i2d_ASN1_OBJECT(const ASN1_OBJECT *a, unsigned char **pp)
     p += a->length;
 
     *pp = p;
-    return (objsize);
+    return objsize;
 }
 
 int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
@@ -49,7 +49,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
     BIGNUM *bl = NULL;
 
     if (num == 0)
-        return (0);
+        return 0;
     else if (num == -1)
         num = strlen(buf);
 
@@ -158,12 +158,12 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
     if (tmp != ftmp)
         OPENSSL_free(tmp);
     BN_free(bl);
-    return (len);
+    return len;
  err:
     if (tmp != ftmp)
         OPENSSL_free(tmp);
     BN_free(bl);
-    return (0);
+    return 0;
 }
 
 int i2t_ASN1_OBJECT(char *buf, int buf_len, const ASN1_OBJECT *a)
@@ -177,7 +177,7 @@ int i2a_ASN1_OBJECT(BIO *bp, const ASN1_OBJECT *a)
     int i;
 
     if ((a == NULL) || (a->data == NULL))
-        return (BIO_write(bp, "NULL", 4));
+        return BIO_write(bp, "NULL", 4);
     i = i2t_ASN1_OBJECT(buf, sizeof buf, a);
     if (i > (int)(sizeof(buf) - 1)) {
         p = OPENSSL_malloc(i + 1);
@@ -193,7 +193,7 @@ int i2a_ASN1_OBJECT(BIO *bp, const ASN1_OBJECT *a)
     BIO_write(bp, p, i);
     if (p != buf)
         OPENSSL_free(p);
-    return (i);
+    return i;
 }
 
 ASN1_OBJECT *d2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
@@ -221,7 +221,7 @@ ASN1_OBJECT *d2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
     return ret;
  err:
     ASN1err(ASN1_F_D2I_ASN1_OBJECT, i);
-    return (NULL);
+    return NULL;
 }
 
 ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
@@ -281,7 +281,7 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
     if ((a == NULL) || ((*a) == NULL) ||
         !((*a)->flags & ASN1_OBJECT_FLAG_DYNAMIC)) {
         if ((ret = ASN1_OBJECT_new()) == NULL)
-            return (NULL);
+            return NULL;
     } else
         ret = (*a);
 
@@ -312,12 +312,12 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
     if (a != NULL)
         (*a) = ret;
     *pp = p;
-    return (ret);
+    return ret;
  err:
     ASN1err(ASN1_F_C2I_ASN1_OBJECT, i);
     if ((a == NULL) || (*a != ret))
         ASN1_OBJECT_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 ASN1_OBJECT *ASN1_OBJECT_new(void)
@@ -327,10 +327,10 @@ ASN1_OBJECT *ASN1_OBJECT_new(void)
     ret = OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1err(ASN1_F_ASN1_OBJECT_NEW, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
     ret->flags = ASN1_OBJECT_FLAG_DYNAMIC;
-    return (ret);
+    return ret;
 }
 
 void ASN1_OBJECT_free(ASN1_OBJECT *a)
@@ -367,5 +367,5 @@ ASN1_OBJECT *ASN1_OBJECT_create(int nid, unsigned char *data, int len,
     o.length = len;
     o.flags = ASN1_OBJECT_FLAG_DYNAMIC | ASN1_OBJECT_FLAG_DYNAMIC_STRINGS |
         ASN1_OBJECT_FLAG_DYNAMIC_DATA;
-    return (OBJ_dup(&o));
+    return OBJ_dup(&o);
 }

--- a/crypto/asn1/a_print.c
+++ b/crypto/asn1/a_print.c
@@ -21,7 +21,7 @@ int ASN1_PRINTABLE_type(const unsigned char *s, int len)
     if (len <= 0)
         len = -1;
     if (s == NULL)
-        return (V_ASN1_PRINTABLESTRING);
+        return V_ASN1_PRINTABLESTRING;
 
     while ((*s) && (len-- != 0)) {
         c = *(s++);
@@ -31,10 +31,10 @@ int ASN1_PRINTABLE_type(const unsigned char *s, int len)
             t61 = 1;
     }
     if (t61)
-        return (V_ASN1_T61STRING);
+        return V_ASN1_T61STRING;
     if (ia5)
-        return (V_ASN1_IA5STRING);
-    return (V_ASN1_PRINTABLESTRING);
+        return V_ASN1_IA5STRING;
+    return V_ASN1_PRINTABLESTRING;
 }
 
 int ASN1_UNIVERSALSTRING_to_string(ASN1_UNIVERSALSTRING *s)
@@ -43,9 +43,9 @@ int ASN1_UNIVERSALSTRING_to_string(ASN1_UNIVERSALSTRING *s)
     unsigned char *p;
 
     if (s->type != V_ASN1_UNIVERSALSTRING)
-        return (0);
+        return 0;
     if ((s->length % 4) != 0)
-        return (0);
+        return 0;
     p = s->data;
     for (i = 0; i < s->length; i += 4) {
         if ((p[0] != '\0') || (p[1] != '\0') || (p[2] != '\0'))
@@ -54,7 +54,7 @@ int ASN1_UNIVERSALSTRING_to_string(ASN1_UNIVERSALSTRING *s)
             p += 4;
     }
     if (i < s->length)
-        return (0);
+        return 0;
     p = s->data;
     for (i = 3; i < s->length; i += 4) {
         *(p++) = s->data[i];
@@ -72,7 +72,7 @@ int ASN1_STRING_print(BIO *bp, const ASN1_STRING *v)
     const char *p;
 
     if (v == NULL)
-        return (0);
+        return 0;
     n = 0;
     p = (const char *)v->data;
     for (i = 0; i < v->length; i++) {
@@ -84,12 +84,12 @@ int ASN1_STRING_print(BIO *bp, const ASN1_STRING *v)
         n++;
         if (n >= 80) {
             if (BIO_write(bp, buf, n) <= 0)
-                return (0);
+                return 0;
             n = 0;
         }
     }
     if (n > 0)
         if (BIO_write(bp, buf, n) <= 0)
-            return (0);
+            return 0;
     return 1;
 }

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -103,7 +103,7 @@ int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
     EVP_MD_CTX_free(ctx);
     OPENSSL_clear_free((char *)buf_in, (unsigned int)inl);
     OPENSSL_clear_free((char *)buf_out, outll);
-    return (outl);
+    return outl;
 }
 
 #endif
@@ -225,5 +225,5 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
  err:
     OPENSSL_clear_free((char *)buf_in, (unsigned int)inl);
     OPENSSL_clear_free((char *)buf_out, outll);
-    return (outl);
+    return outl;
 }

--- a/crypto/asn1/a_type.c
+++ b/crypto/asn1/a_type.c
@@ -16,9 +16,9 @@
 int ASN1_TYPE_get(const ASN1_TYPE *a)
 {
     if ((a->value.ptr != NULL) || (a->type == V_ASN1_NULL))
-        return (a->type);
+        return a->type;
     else
-        return (0);
+        return 0;
 }
 
 void ASN1_TYPE_set(ASN1_TYPE *a, int type, void *value)

--- a/crypto/asn1/a_verify.c
+++ b/crypto/asn1/a_verify.c
@@ -76,7 +76,7 @@ int ASN1_verify(i2d_of_void *i2d, X509_ALGOR *a, ASN1_BIT_STRING *signature,
     ret = 1;
  err:
     EVP_MD_CTX_free(ctx);
-    return (ret);
+    return ret;
 }
 
 #endif

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -859,7 +859,7 @@ static int mime_hdr_cmp(const MIME_HEADER *const *a,
     if (!(*a)->name || !(*b)->name)
         return ! !(*a)->name - ! !(*b)->name;
 
-    return (strcmp((*a)->name, (*b)->name));
+    return strcmp((*a)->name, (*b)->name);
 }
 
 static int mime_param_cmp(const MIME_PARAM *const *a,
@@ -867,7 +867,7 @@ static int mime_param_cmp(const MIME_PARAM *const *a,
 {
     if (!(*a)->param_name || !(*b)->param_name)
         return ! !(*a)->param_name - ! !(*b)->param_name;
-    return (strcmp((*a)->param_name, (*b)->param_name));
+    return strcmp((*a)->param_name, (*b)->param_name);
 }
 
 /* Find a header with a given name (if possible) */

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -95,7 +95,7 @@ static const BIO_METHOD methods_asn1 = {
 
 const BIO_METHOD *BIO_f_asn1(void)
 {
-    return (&methods_asn1);
+    return &methods_asn1;
 }
 
 static int asn1_bio_new(BIO *b)

--- a/crypto/asn1/d2i_pr.c
+++ b/crypto/asn1/d2i_pr.c
@@ -27,7 +27,7 @@ EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
     if ((a == NULL) || (*a == NULL)) {
         if ((ret = EVP_PKEY_new()) == NULL) {
             ASN1err(ASN1_F_D2I_PRIVATEKEY, ERR_R_EVP_LIB);
-            return (NULL);
+            return NULL;
         }
     } else {
         ret = *a;
@@ -64,11 +64,11 @@ EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
     *pp = p;
     if (a != NULL)
         (*a) = ret;
-    return (ret);
+    return ret;
  err:
     if (a == NULL || *a != ret)
         EVP_PKEY_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 /*

--- a/crypto/asn1/d2i_pu.c
+++ b/crypto/asn1/d2i_pu.c
@@ -27,7 +27,7 @@ EVP_PKEY *d2i_PublicKey(int type, EVP_PKEY **a, const unsigned char **pp,
     if ((a == NULL) || (*a == NULL)) {
         if ((ret = EVP_PKEY_new()) == NULL) {
             ASN1err(ASN1_F_D2I_PUBLICKEY, ERR_R_EVP_LIB);
-            return (NULL);
+            return NULL;
         }
     } else
         ret = *a;
@@ -69,9 +69,9 @@ EVP_PKEY *d2i_PublicKey(int type, EVP_PKEY **a, const unsigned char **pp,
     }
     if (a != NULL)
         (*a) = ret;
-    return (ret);
+    return ret;
  err:
     if (a == NULL || *a != ret)
         EVP_PKEY_free(ret);
-    return (NULL);
+    return NULL;
 }

--- a/crypto/asn1/evp_asn1.c
+++ b/crypto/asn1/evp_asn1.c
@@ -17,7 +17,7 @@ int ASN1_TYPE_set_octetstring(ASN1_TYPE *a, unsigned char *data, int len)
     ASN1_STRING *os;
 
     if ((os = ASN1_OCTET_STRING_new()) == NULL)
-        return (0);
+        return 0;
     if (!ASN1_OCTET_STRING_set(os, data, len)) {
         ASN1_OCTET_STRING_free(os);
         return 0;
@@ -34,7 +34,7 @@ int ASN1_TYPE_get_octetstring(const ASN1_TYPE *a, unsigned char *data, int max_l
 
     if ((a->type != V_ASN1_OCTET_STRING) || (a->value.octet_string == NULL)) {
         ASN1err(ASN1_F_ASN1_TYPE_GET_OCTETSTRING, ASN1_R_DATA_IS_WRONG);
-        return (-1);
+        return -1;
     }
     p = ASN1_STRING_get0_data(a->value.octet_string);
     ret = ASN1_STRING_length(a->value.octet_string);
@@ -43,7 +43,7 @@ int ASN1_TYPE_get_octetstring(const ASN1_TYPE *a, unsigned char *data, int max_l
     else
         num = max_len;
     memcpy(data, p, num);
-    return (ret);
+    return ret;
 }
 
 typedef struct {

--- a/crypto/asn1/f_int.c
+++ b/crypto/asn1/f_int.c
@@ -20,7 +20,7 @@ int i2a_ASN1_INTEGER(BIO *bp, const ASN1_INTEGER *a)
     char buf[2];
 
     if (a == NULL)
-        return (0);
+        return 0;
 
     if (a->type & V_ASN1_NEG) {
         if (BIO_write(bp, "-", 1) != 1)
@@ -46,9 +46,9 @@ int i2a_ASN1_INTEGER(BIO *bp, const ASN1_INTEGER *a)
             n += 2;
         }
     }
-    return (n);
+    return n;
  err:
-    return (-1);
+    return -1;
 }
 
 int a2i_ASN1_INTEGER(BIO *bp, ASN1_INTEGER *bs, char *buf, int size)

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -20,7 +20,7 @@ int i2a_ASN1_STRING(BIO *bp, const ASN1_STRING *a, int type)
     char buf[2];
 
     if (a == NULL)
-        return (0);
+        return 0;
 
     if (a->length == 0) {
         if (BIO_write(bp, "0", 1) != 1)
@@ -40,9 +40,9 @@ int i2a_ASN1_STRING(BIO *bp, const ASN1_STRING *a, int type)
             n += 2;
         }
     }
-    return (n);
+    return n;
  err:
-    return (-1);
+    return -1;
 }
 
 int a2i_ASN1_STRING(BIO *bp, ASN1_STRING *bs, char *buf, int size)

--- a/crypto/bf/bf_ecb.c
+++ b/crypto/bf/bf_ecb.c
@@ -19,7 +19,7 @@
 
 const char *BF_options(void)
 {
-    return ("blowfish(ptr)");
+    return "blowfish(ptr)";
 }
 
 void BF_ecb_encrypt(const unsigned char *in, unsigned char *out,

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -859,7 +859,7 @@ int BIO_printf(BIO *bio, const char *format, ...)
     ret = BIO_vprintf(bio, format, args);
 
     va_end(args);
-    return (ret);
+    return ret;
 }
 
 int BIO_vprintf(BIO *bio, const char *format, va_list args)
@@ -886,7 +886,7 @@ int BIO_vprintf(BIO *bio, const char *format, va_list args)
     } else {
         ret = BIO_write(bio, hugebuf, (int)retlen);
     }
-    return (ret);
+    return ret;
 }
 
 /*
@@ -905,7 +905,7 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
     ret = BIO_vsnprintf(buf, n, format, args);
 
     va_end(args);
-    return (ret);
+    return ret;
 }
 
 int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -66,7 +66,7 @@ int BIO_get_port(const char *str, unsigned short *port_ptr)
 
     if (str == NULL) {
         BIOerr(BIO_F_BIO_GET_PORT, BIO_R_NO_PORT_DEFINED);
-        return (0);
+        return 0;
     }
 
     if (BIO_sock_init() != 1)
@@ -102,9 +102,9 @@ int BIO_sock_error(int sock)
      */
     i = getsockopt(sock, SOL_SOCKET, SO_ERROR, (void *)&j, &size);
     if (i < 0)
-        return (get_last_socket_error());
+        return get_last_socket_error();
     else
-        return (j);
+        return j;
 }
 
 # if OPENSSL_API_COMPAT < 0x10100000L
@@ -142,7 +142,7 @@ int BIO_sock_init(void)
             err = WSAGetLastError();
             SYSerr(SYS_F_WSASTARTUP, err);
             BIOerr(BIO_F_BIO_SOCK_INIT, BIO_R_WSASTARTUP);
-            return (-1);
+            return -1;
         }
     }
 # endif                         /* OPENSSL_SYS_WINDOWS */
@@ -150,7 +150,7 @@ int BIO_sock_init(void)
     extern int _watt_do_exit;
     _watt_do_exit = 0;          /* don't make sock_init() call exit() */
     if (sock_init())
-        return (-1);
+        return -1;
 # endif
 
     return 1;
@@ -201,7 +201,7 @@ int BIO_socket_ioctl(int fd, long type, void *arg)
 #  endif                        /* __DJGPP__ */
     if (i < 0)
         SYSerr(SYS_F_IOCTLSOCKET, get_last_socket_error());
-    return (i);
+    return i;
 }
 
 # if OPENSSL_API_COMPAT < 0x10100000L

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -41,7 +41,7 @@ static const BIO_METHOD methods_buffer = {
 
 const BIO_METHOD *BIO_f_buffer(void)
 {
-    return (&methods_buffer);
+    return &methods_buffer;
 }
 
 static int buffer_new(BIO *bi)
@@ -49,19 +49,19 @@ static int buffer_new(BIO *bi)
     BIO_F_BUFFER_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 
     if (ctx == NULL)
-        return (0);
+        return 0;
     ctx->ibuf_size = DEFAULT_BUFFER_SIZE;
     ctx->ibuf = OPENSSL_malloc(DEFAULT_BUFFER_SIZE);
     if (ctx->ibuf == NULL) {
         OPENSSL_free(ctx);
-        return (0);
+        return 0;
     }
     ctx->obuf_size = DEFAULT_BUFFER_SIZE;
     ctx->obuf = OPENSSL_malloc(DEFAULT_BUFFER_SIZE);
     if (ctx->obuf == NULL) {
         OPENSSL_free(ctx->ibuf);
         OPENSSL_free(ctx);
-        return (0);
+        return 0;
     }
 
     bi->init = 1;
@@ -75,7 +75,7 @@ static int buffer_free(BIO *a)
     BIO_F_BUFFER_CTX *b;
 
     if (a == NULL)
-        return (0);
+        return 0;
     b = (BIO_F_BUFFER_CTX *)a->ptr;
     OPENSSL_free(b->ibuf);
     OPENSSL_free(b->obuf);
@@ -92,11 +92,11 @@ static int buffer_read(BIO *b, char *out, int outl)
     BIO_F_BUFFER_CTX *ctx;
 
     if (out == NULL)
-        return (0);
+        return 0;
     ctx = (BIO_F_BUFFER_CTX *)b->ptr;
 
     if ((ctx == NULL) || (b->next_bio == NULL))
-        return (0);
+        return 0;
     num = 0;
     BIO_clear_retry_flags(b);
 
@@ -111,7 +111,7 @@ static int buffer_read(BIO *b, char *out, int outl)
         ctx->ibuf_len -= i;
         num += i;
         if (outl == i)
-            return (num);
+            return num;
         outl -= i;
         out += i;
     }
@@ -130,11 +130,11 @@ static int buffer_read(BIO *b, char *out, int outl)
                 if (i < 0)
                     return ((num > 0) ? num : i);
                 if (i == 0)
-                    return (num);
+                    return num;
             }
             num += i;
             if (outl == i)
-                return (num);
+                return num;
             out += i;
             outl -= i;
         }
@@ -148,7 +148,7 @@ static int buffer_read(BIO *b, char *out, int outl)
         if (i < 0)
             return ((num > 0) ? num : i);
         if (i == 0)
-            return (num);
+            return num;
     }
     ctx->ibuf_off = 0;
     ctx->ibuf_len = i;
@@ -163,10 +163,10 @@ static int buffer_write(BIO *b, const char *in, int inl)
     BIO_F_BUFFER_CTX *ctx;
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
     ctx = (BIO_F_BUFFER_CTX *)b->ptr;
     if ((ctx == NULL) || (b->next_bio == NULL))
-        return (0);
+        return 0;
 
     BIO_clear_retry_flags(b);
  start:
@@ -197,7 +197,7 @@ static int buffer_write(BIO *b, const char *in, int inl)
                 if (i < 0)
                     return ((num > 0) ? num : i);
                 if (i == 0)
-                    return (num);
+                    return num;
             }
             ctx->obuf_off += i;
             ctx->obuf_len -= i;
@@ -219,13 +219,13 @@ static int buffer_write(BIO *b, const char *in, int inl)
             if (i < 0)
                 return ((num > 0) ? num : i);
             if (i == 0)
-                return (num);
+                return num;
         }
         num += i;
         in += i;
         inl -= i;
         if (inl == 0)
-            return (num);
+            return num;
     }
 
     /*
@@ -252,7 +252,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         ctx->obuf_off = 0;
         ctx->obuf_len = 0;
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
     case BIO_CTRL_EOF:
@@ -275,7 +275,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = (long)ctx->obuf_len;
         if (ret == 0) {
             if (b->next_bio == NULL)
-                return (0);
+                return 0;
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         }
         break;
@@ -283,7 +283,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = (long)ctx->ibuf_len;
         if (ret == 0) {
             if (b->next_bio == NULL)
-                return (0);
+                return 0;
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         }
         break;
@@ -347,7 +347,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_C_DO_STATE_MACHINE:
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         BIO_clear_retry_flags(b);
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         BIO_copy_next_retry(b);
@@ -355,7 +355,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
 
     case BIO_CTRL_FLUSH:
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         if (ctx->obuf_len <= 0) {
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
             break;
@@ -368,7 +368,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
                               &(ctx->obuf[ctx->obuf_off]), ctx->obuf_len);
                 BIO_copy_next_retry(b);
                 if (r <= 0)
-                    return ((long)r);
+                    return (long)r;
                 ctx->obuf_off += r;
                 ctx->obuf_len -= r;
             } else {
@@ -398,14 +398,14 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     default:
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
  malloc_error:
     BIOerr(BIO_F_BUFFER_CTRL, ERR_R_MALLOC_FAILURE);
-    return (0);
+    return 0;
 }
 
 static long buffer_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -413,13 +413,13 @@ static long buffer_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     long ret = 1;
 
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     default:
         ret = BIO_callback_ctrl(b->next_bio, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int buffer_gets(BIO *b, char *buf, int size)
@@ -450,7 +450,7 @@ static int buffer_gets(BIO *b, char *buf, int size)
             ctx->ibuf_off += i;
             if (flag || size == 0) {
                 *buf = '\0';
-                return (num);
+                return num;
             }
         } else {                /* read another chunk */
 
@@ -461,7 +461,7 @@ static int buffer_gets(BIO *b, char *buf, int size)
                 if (i < 0)
                     return ((num > 0) ? num : i);
                 if (i == 0)
-                    return (num);
+                    return num;
             }
             ctx->ibuf_len = i;
             ctx->ibuf_off = 0;
@@ -471,5 +471,5 @@ static int buffer_gets(BIO *b, char *buf, int size)
 
 static int buffer_puts(BIO *b, const char *str)
 {
-    return (buffer_write(b, str, strlen(str)));
+    return buffer_write(b, str, strlen(str));
 }

--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -46,7 +46,7 @@ static const BIO_METHOD methods_linebuffer = {
 
 const BIO_METHOD *BIO_f_linebuffer(void)
 {
-    return (&methods_linebuffer);
+    return &methods_linebuffer;
 }
 
 typedef struct bio_linebuffer_ctx_struct {
@@ -61,11 +61,11 @@ static int linebuffer_new(BIO *bi)
 
     ctx = OPENSSL_malloc(sizeof(*ctx));
     if (ctx == NULL)
-        return (0);
+        return 0;
     ctx->obuf = OPENSSL_malloc(DEFAULT_LINEBUFFER_SIZE);
     if (ctx->obuf == NULL) {
         OPENSSL_free(ctx);
-        return (0);
+        return 0;
     }
     ctx->obuf_size = DEFAULT_LINEBUFFER_SIZE;
     ctx->obuf_len = 0;
@@ -81,7 +81,7 @@ static int linebuffer_free(BIO *a)
     BIO_LINEBUFFER_CTX *b;
 
     if (a == NULL)
-        return (0);
+        return 0;
     b = (BIO_LINEBUFFER_CTX *)a->ptr;
     OPENSSL_free(b->obuf);
     OPENSSL_free(a->ptr);
@@ -96,13 +96,13 @@ static int linebuffer_read(BIO *b, char *out, int outl)
     int ret = 0;
 
     if (out == NULL)
-        return (0);
+        return 0;
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     ret = BIO_read(b->next_bio, out, outl);
     BIO_clear_retry_flags(b);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static int linebuffer_write(BIO *b, const char *in, int inl)
@@ -111,10 +111,10 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
     BIO_LINEBUFFER_CTX *ctx;
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
     ctx = (BIO_LINEBUFFER_CTX *)b->ptr;
     if ((ctx == NULL) || (b->next_bio == NULL))
-        return (0);
+        return 0;
 
     BIO_clear_retry_flags(b);
 
@@ -160,7 +160,7 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
                 if (i < 0)
                     return ((num > 0) ? num : i);
                 if (i == 0)
-                    return (num);
+                    return num;
             }
             if (i < ctx->obuf_len)
                 memmove(ctx->obuf, ctx->obuf + i, ctx->obuf_len - i);
@@ -178,7 +178,7 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
                 if (i < 0)
                     return ((num > 0) ? num : i);
                 if (i == 0)
-                    return (num);
+                    return num;
             }
             num += i;
             in += i;
@@ -214,7 +214,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_RESET:
         ctx->obuf_len = 0;
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
     case BIO_CTRL_INFO:
@@ -224,7 +224,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = (long)ctx->obuf_len;
         if (ret == 0) {
             if (b->next_bio == NULL)
-                return (0);
+                return 0;
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         }
         break;
@@ -248,7 +248,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_C_DO_STATE_MACHINE:
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         BIO_clear_retry_flags(b);
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         BIO_copy_next_retry(b);
@@ -256,7 +256,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
 
     case BIO_CTRL_FLUSH:
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         if (ctx->obuf_len <= 0) {
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
             break;
@@ -268,7 +268,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
                 r = BIO_write(b->next_bio, ctx->obuf, ctx->obuf_len);
                 BIO_copy_next_retry(b);
                 if (r <= 0)
-                    return ((long)r);
+                    return (long)r;
                 if (r < ctx->obuf_len)
                     memmove(ctx->obuf, ctx->obuf + r, ctx->obuf_len - r);
                 ctx->obuf_len -= r;
@@ -286,14 +286,14 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     default:
         if (b->next_bio == NULL)
-            return (0);
+            return 0;
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
  malloc_error:
     BIOerr(BIO_F_LINEBUFFER_CTRL, ERR_R_MALLOC_FAILURE);
-    return (0);
+    return 0;
 }
 
 static long linebuffer_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -301,23 +301,23 @@ static long linebuffer_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     long ret = 1;
 
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     default:
         ret = BIO_callback_ctrl(b->next_bio, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int linebuffer_gets(BIO *b, char *buf, int size)
 {
     if (b->next_bio == NULL)
-        return (0);
-    return (BIO_gets(b->next_bio, buf, size));
+        return 0;
+    return BIO_gets(b->next_bio, buf, size);
 }
 
 static int linebuffer_puts(BIO *b, const char *str)
 {
-    return (linebuffer_write(b, str, strlen(str)));
+    return linebuffer_write(b, str, strlen(str));
 }

--- a/crypto/bio/bf_nbio.c
+++ b/crypto/bio/bf_nbio.c
@@ -50,7 +50,7 @@ static const BIO_METHOD methods_nbiof = {
 
 const BIO_METHOD *BIO_f_nbio_test(void)
 {
-    return (&methods_nbiof);
+    return &methods_nbiof;
 }
 
 static int nbiof_new(BIO *bi)
@@ -58,7 +58,7 @@ static int nbiof_new(BIO *bi)
     NBIO_TEST *nt;
 
     if ((nt = OPENSSL_zalloc(sizeof(*nt))) == NULL)
-        return (0);
+        return 0;
     nt->lrn = -1;
     nt->lwn = -1;
     bi->ptr = (char *)nt;
@@ -69,7 +69,7 @@ static int nbiof_new(BIO *bi)
 static int nbiof_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     OPENSSL_free(a->ptr);
     a->ptr = NULL;
     a->init = 0;
@@ -84,9 +84,9 @@ static int nbiof_read(BIO *b, char *out, int outl)
     unsigned char n;
 
     if (out == NULL)
-        return (0);
+        return 0;
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
 
     BIO_clear_retry_flags(b);
     if (RAND_bytes(&n, 1) <= 0)
@@ -104,7 +104,7 @@ static int nbiof_read(BIO *b, char *out, int outl)
         if (ret < 0)
             BIO_copy_next_retry(b);
     }
-    return (ret);
+    return ret;
 }
 
 static int nbiof_write(BIO *b, const char *in, int inl)
@@ -115,9 +115,9 @@ static int nbiof_write(BIO *b, const char *in, int inl)
     unsigned char n;
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     nt = (NBIO_TEST *)b->ptr;
 
     BIO_clear_retry_flags(b);
@@ -144,7 +144,7 @@ static int nbiof_write(BIO *b, const char *in, int inl)
             nt->lwn = inl;
         }
     }
-    return (ret);
+    return ret;
 }
 
 static long nbiof_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -152,7 +152,7 @@ static long nbiof_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret;
 
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     case BIO_C_DO_STATE_MACHINE:
         BIO_clear_retry_flags(b);
@@ -166,7 +166,7 @@ static long nbiof_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static long nbiof_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -174,25 +174,25 @@ static long nbiof_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     long ret = 1;
 
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     default:
         ret = BIO_callback_ctrl(b->next_bio, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int nbiof_gets(BIO *bp, char *buf, int size)
 {
     if (bp->next_bio == NULL)
-        return (0);
-    return (BIO_gets(bp->next_bio, buf, size));
+        return 0;
+    return BIO_gets(bp->next_bio, buf, size);
 }
 
 static int nbiof_puts(BIO *bp, const char *str)
 {
     if (bp->next_bio == NULL)
-        return (0);
-    return (BIO_puts(bp->next_bio, str));
+        return 0;
+    return BIO_puts(bp->next_bio, str);
 }

--- a/crypto/bio/bf_null.c
+++ b/crypto/bio/bf_null.c
@@ -43,7 +43,7 @@ static const BIO_METHOD methods_nullf = {
 
 const BIO_METHOD *BIO_f_null(void)
 {
-    return (&methods_nullf);
+    return &methods_nullf;
 }
 
 static int nullf_new(BIO *bi)
@@ -57,7 +57,7 @@ static int nullf_new(BIO *bi)
 static int nullf_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     /*-
     a->ptr=NULL;
     a->init=0;
@@ -71,13 +71,13 @@ static int nullf_read(BIO *b, char *out, int outl)
     int ret = 0;
 
     if (out == NULL)
-        return (0);
+        return 0;
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     ret = BIO_read(b->next_bio, out, outl);
     BIO_clear_retry_flags(b);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static int nullf_write(BIO *b, const char *in, int inl)
@@ -85,13 +85,13 @@ static int nullf_write(BIO *b, const char *in, int inl)
     int ret = 0;
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     ret = BIO_write(b->next_bio, in, inl);
     BIO_clear_retry_flags(b);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static long nullf_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -99,7 +99,7 @@ static long nullf_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret;
 
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     case BIO_C_DO_STATE_MACHINE:
         BIO_clear_retry_flags(b);
@@ -112,7 +112,7 @@ static long nullf_ctrl(BIO *b, int cmd, long num, void *ptr)
     default:
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
     }
-    return (ret);
+    return ret;
 }
 
 static long nullf_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -120,25 +120,25 @@ static long nullf_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     long ret = 1;
 
     if (b->next_bio == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     default:
         ret = BIO_callback_ctrl(b->next_bio, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int nullf_gets(BIO *bp, char *buf, int size)
 {
     if (bp->next_bio == NULL)
-        return (0);
-    return (BIO_gets(bp->next_bio, buf, size));
+        return 0;
+    return BIO_gets(bp->next_bio, buf, size);
 }
 
 static int nullf_puts(BIO *bp, const char *str)
 {
     if (bp->next_bio == NULL)
-        return (0);
-    return (BIO_puts(bp->next_bio, str));
+        return 0;
+    return BIO_puts(bp->next_bio, str);
 }

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -75,7 +75,7 @@ BIO *BIO_new(const BIO_METHOD *method)
 
     if (bio == NULL) {
         BIOerr(BIO_F_BIO_NEW, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
 
     bio->method = method;
@@ -435,7 +435,7 @@ int BIO_gets(BIO *b, char *buf, int size)
 
     if ((b == NULL) || (b->method == NULL) || (b->method->bgets == NULL)) {
         BIOerr(BIO_F_BIO_GETS, BIO_R_UNSUPPORTED_METHOD);
-        return (-2);
+        return -2;
     }
 
     if (size < 0) {
@@ -451,7 +451,7 @@ int BIO_gets(BIO *b, char *buf, int size)
 
     if (!b->init) {
         BIOerr(BIO_F_BIO_GETS, BIO_R_UNINITIALIZED);
-        return (-2);
+        return -2;
     }
 
     ret = b->method->bgets(b, buf, size);
@@ -493,7 +493,7 @@ long BIO_int_ctrl(BIO *b, int cmd, long larg, int iarg)
     int i;
 
     i = iarg;
-    return (BIO_ctrl(b, cmd, larg, (char *)&i));
+    return BIO_ctrl(b, cmd, larg, (char *)&i);
 }
 
 void *BIO_ptr_ctrl(BIO *b, int cmd, long larg)
@@ -501,9 +501,9 @@ void *BIO_ptr_ctrl(BIO *b, int cmd, long larg)
     void *p = NULL;
 
     if (BIO_ctrl(b, cmd, larg, (char *)&p) <= 0)
-        return (NULL);
+        return NULL;
     else
-        return (p);
+        return p;
 }
 
 long BIO_ctrl(BIO *b, int cmd, long larg, void *parg)
@@ -540,11 +540,11 @@ long BIO_callback_ctrl(BIO *b, int cmd,
     long ret;
 
     if (b == NULL)
-        return (0);
+        return 0;
 
     if ((b->method == NULL) || (b->method->callback_ctrl == NULL)) {
         BIOerr(BIO_F_BIO_CALLBACK_CTRL, BIO_R_UNSUPPORTED_METHOD);
-        return (-2);
+        return -2;
     }
 
     if (b->callback != NULL || b->callback_ex != NULL) {
@@ -584,7 +584,7 @@ BIO *BIO_push(BIO *b, BIO *bio)
     BIO *lb;
 
     if (b == NULL)
-        return (bio);
+        return bio;
     lb = b;
     while (lb->next_bio != NULL)
         lb = lb->next_bio;
@@ -593,7 +593,7 @@ BIO *BIO_push(BIO *b, BIO *bio)
         bio->prev_bio = lb;
     /* called to do internal processing */
     BIO_ctrl(b, BIO_CTRL_PUSH, 0, lb);
-    return (b);
+    return b;
 }
 
 /* Remove the first and return the rest */
@@ -602,7 +602,7 @@ BIO *BIO_pop(BIO *b)
     BIO *ret;
 
     if (b == NULL)
-        return (NULL);
+        return NULL;
     ret = b->next_bio;
 
     BIO_ctrl(b, BIO_CTRL_POP, 0, b);
@@ -614,7 +614,7 @@ BIO *BIO_pop(BIO *b)
 
     b->next_bio = NULL;
     b->prev_bio = NULL;
-    return (ret);
+    return ret;
 }
 
 BIO *BIO_get_retry_BIO(BIO *bio, int *reason)
@@ -632,12 +632,12 @@ BIO *BIO_get_retry_BIO(BIO *bio, int *reason)
     }
     if (reason != NULL)
         *reason = last->retry_reason;
-    return (last);
+    return last;
 }
 
 int BIO_get_retry_reason(BIO *bio)
 {
-    return (bio->retry_reason);
+    return bio->retry_reason;
 }
 
 void BIO_set_retry_reason(BIO *bio, int reason)
@@ -658,13 +658,13 @@ BIO *BIO_find_type(BIO *bio, int type)
 
             if (!mask) {
                 if (mt & type)
-                    return (bio);
+                    return bio;
             } else if (mt == type)
-                return (bio);
+                return bio;
         }
         bio = bio->next_bio;
     } while (bio != NULL);
-    return (NULL);
+    return NULL;
 }
 
 BIO *BIO_next(BIO *b)
@@ -732,11 +732,11 @@ BIO *BIO_dup_chain(BIO *in)
             eoc = new_bio;
         }
     }
-    return (ret);
+    return ret;
  err:
     BIO_free_all(ret);
 
-    return (NULL);
+    return NULL;
 }
 
 void BIO_copy_next_retry(BIO *b)
@@ -747,12 +747,12 @@ void BIO_copy_next_retry(BIO *b)
 
 int BIO_set_ex_data(BIO *bio, int idx, void *data)
 {
-    return (CRYPTO_set_ex_data(&(bio->ex_data), idx, data));
+    return CRYPTO_set_ex_data(&(bio->ex_data), idx, data);
 }
 
 void *BIO_get_ex_data(BIO *bio, int idx)
 {
-    return (CRYPTO_get_ex_data(&(bio->ex_data), idx));
+    return CRYPTO_get_ex_data(&(bio->ex_data), idx);
 }
 
 uint64_t BIO_number_read(BIO *bio)

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -70,7 +70,7 @@ static const BIO_METHOD methods_acceptp = {
 
 const BIO_METHOD *BIO_s_accept(void)
 {
-    return (&methods_acceptp);
+    return &methods_acceptp;
 }
 
 static int acpt_new(BIO *bi)
@@ -81,7 +81,7 @@ static int acpt_new(BIO *bi)
     bi->num = (int)INVALID_SOCKET;
     bi->flags = 0;
     if ((ba = BIO_ACCEPT_new()) == NULL)
-        return (0);
+        return 0;
     bi->ptr = (char *)ba;
     ba->state = ACPT_S_BEFORE;
     bi->shutdown = 1;
@@ -93,10 +93,10 @@ static BIO_ACCEPT *BIO_ACCEPT_new(void)
     BIO_ACCEPT *ret;
 
     if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL)
-        return (NULL);
+        return NULL;
     ret->accept_family = BIO_FAMILY_IPANY;
     ret->accept_sock = (int)INVALID_SOCKET;
-    return (ret);
+    return ret;
 }
 
 static void BIO_ACCEPT_free(BIO_ACCEPT *a)
@@ -133,7 +133,7 @@ static int acpt_free(BIO *a)
     BIO_ACCEPT *data;
 
     if (a == NULL)
-        return (0);
+        return 0;
     data = (BIO_ACCEPT *)a->ptr;
 
     if (a->shutdown) {
@@ -359,12 +359,12 @@ static int acpt_read(BIO *b, char *out, int outl)
     while (b->next_bio == NULL) {
         ret = acpt_state(b, data);
         if (ret <= 0)
-            return (ret);
+            return ret;
     }
 
     ret = BIO_read(b->next_bio, out, outl);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static int acpt_write(BIO *b, const char *in, int inl)
@@ -378,12 +378,12 @@ static int acpt_write(BIO *b, const char *in, int inl)
     while (b->next_bio == NULL) {
         ret = acpt_state(b, data);
         if (ret <= 0)
-            return (ret);
+            return ret;
     }
 
     ret = BIO_write(b->next_bio, in, inl);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -527,7 +527,7 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int acpt_puts(BIO *bp, const char *str)
@@ -536,7 +536,7 @@ static int acpt_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = acpt_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 BIO *BIO_new_accept(const char *str)
@@ -545,11 +545,11 @@ BIO *BIO_new_accept(const char *str)
 
     ret = BIO_new(BIO_s_accept());
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     if (BIO_set_accept_name(ret, str))
-        return (ret);
+        return ret;
     BIO_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 #endif

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -216,7 +216,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
     if (cb != NULL)
         ret = cb((BIO *)b, c->state, ret);
  end:
-    return (ret);
+    return ret;
 }
 
 BIO_CONNECT *BIO_CONNECT_new(void)
@@ -224,10 +224,10 @@ BIO_CONNECT *BIO_CONNECT_new(void)
     BIO_CONNECT *ret;
 
     if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL)
-        return (NULL);
+        return NULL;
     ret->state = BIO_CONN_S_BEFORE;
     ret->connect_family = BIO_FAMILY_IPANY;
-    return (ret);
+    return ret;
 }
 
 void BIO_CONNECT_free(BIO_CONNECT *a)
@@ -243,7 +243,7 @@ void BIO_CONNECT_free(BIO_CONNECT *a)
 
 const BIO_METHOD *BIO_s_connect(void)
 {
-    return (&methods_connectp);
+    return &methods_connectp;
 }
 
 static int conn_new(BIO *bi)
@@ -252,7 +252,7 @@ static int conn_new(BIO *bi)
     bi->num = (int)INVALID_SOCKET;
     bi->flags = 0;
     if ((bi->ptr = (char *)BIO_CONNECT_new()) == NULL)
-        return (0);
+        return 0;
     else
         return 1;
 }
@@ -276,7 +276,7 @@ static int conn_free(BIO *a)
     BIO_CONNECT *data;
 
     if (a == NULL)
-        return (0);
+        return 0;
     data = (BIO_CONNECT *)a->ptr;
 
     if (a->shutdown) {
@@ -298,7 +298,7 @@ static int conn_read(BIO *b, char *out, int outl)
     if (data->state != BIO_CONN_S_OK) {
         ret = conn_state(b, data);
         if (ret <= 0)
-            return (ret);
+            return ret;
     }
 
     if (out != NULL) {
@@ -310,7 +310,7 @@ static int conn_read(BIO *b, char *out, int outl)
                 BIO_set_retry_read(b);
         }
     }
-    return (ret);
+    return ret;
 }
 
 static int conn_write(BIO *b, const char *in, int inl)
@@ -322,7 +322,7 @@ static int conn_write(BIO *b, const char *in, int inl)
     if (data->state != BIO_CONN_S_OK) {
         ret = conn_state(b, data);
         if (ret <= 0)
-            return (ret);
+            return ret;
     }
 
     clear_socket_error();
@@ -332,7 +332,7 @@ static int conn_write(BIO *b, const char *in, int inl)
         if (BIO_sock_should_retry(ret))
             BIO_set_retry_write(b);
     }
-    return (ret);
+    return ret;
 }
 
 static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -492,7 +492,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static long conn_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -513,7 +513,7 @@ static long conn_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int conn_puts(BIO *bp, const char *str)
@@ -522,7 +522,7 @@ static int conn_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = conn_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 BIO *BIO_new_connect(const char *str)
@@ -531,11 +531,11 @@ BIO *BIO_new_connect(const char *str)
 
     ret = BIO_new(BIO_s_connect());
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     if (BIO_set_conn_hostname(ret, str))
-        return (ret);
+        return ret;
     BIO_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 #endif

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -136,7 +136,7 @@ typedef struct bio_dgram_sctp_data_st {
 
 const BIO_METHOD *BIO_s_datagram(void)
 {
-    return (&methods_dgramp);
+    return &methods_dgramp;
 }
 
 BIO *BIO_new_dgram(int fd, int close_flag)
@@ -145,9 +145,9 @@ BIO *BIO_new_dgram(int fd, int close_flag)
 
     ret = BIO_new(BIO_s_datagram());
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     BIO_set_fd(ret, fd, close_flag);
-    return (ret);
+    return ret;
 }
 
 static int dgram_new(BIO *bi)
@@ -165,7 +165,7 @@ static int dgram_free(BIO *a)
     bio_dgram_data *data;
 
     if (a == NULL)
-        return (0);
+        return 0;
     if (!dgram_clear(a))
         return 0;
 
@@ -178,7 +178,7 @@ static int dgram_free(BIO *a)
 static int dgram_clear(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     if (a->shutdown) {
         if (a->init) {
             BIO_closesocket(a->num);
@@ -325,7 +325,7 @@ static int dgram_read(BIO *b, char *out, int outl)
 
         dgram_reset_rcv_timeout(b);
     }
-    return (ret);
+    return ret;
 }
 
 static int dgram_write(BIO *b, const char *in, int inl)
@@ -355,7 +355,7 @@ static int dgram_write(BIO *b, const char *in, int inl)
             data->_errno = get_last_socket_error();
         }
     }
-    return (ret);
+    return ret;
 }
 
 static long dgram_get_mtu_overhead(bio_dgram_data *data)
@@ -799,7 +799,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int dgram_puts(BIO *bp, const char *str)
@@ -808,13 +808,13 @@ static int dgram_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = dgram_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 # ifndef OPENSSL_NO_SCTP
 const BIO_METHOD *BIO_s_datagram_sctp(void)
 {
-    return (&methods_dgramp_sctp);
+    return &methods_dgramp_sctp;
 }
 
 BIO *BIO_new_dgram_sctp(int fd, int close_flag)
@@ -836,7 +836,7 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
 
     bio = BIO_new(BIO_s_datagram_sctp());
     if (bio == NULL)
-        return (NULL);
+        return NULL;
     BIO_set_fd(bio, fd, close_flag);
 
     /* Activate SCTP-AUTH for DATA and FORWARD-TSN chunks */
@@ -848,7 +848,7 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
         BIO_vfree(bio);
         BIOerr(BIO_F_BIO_NEW_DGRAM_SCTP, ERR_R_SYS_LIB);
         ERR_add_error_data(1, "Ensure SCTP AUTH chunks are enabled in kernel");
-        return (NULL);
+        return NULL;
     }
     auth.sauth_chunk = OPENSSL_SCTP_FORWARD_CUM_TSN_CHUNK_TYPE;
     ret =
@@ -858,7 +858,7 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
         BIO_vfree(bio);
         BIOerr(BIO_F_BIO_NEW_DGRAM_SCTP, ERR_R_SYS_LIB);
         ERR_add_error_data(1, "Ensure SCTP AUTH chunks are enabled in kernel");
-        return (NULL);
+        return NULL;
     }
 
     /*
@@ -871,14 +871,14 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
     authchunks = OPENSSL_zalloc(sockopt_len);
     if (authchunks == NULL) {
         BIO_vfree(bio);
-        return (NULL);
+        return NULL;
     }
     ret = getsockopt(fd, IPPROTO_SCTP, SCTP_LOCAL_AUTH_CHUNKS, authchunks,
                    &sockopt_len);
     if (ret < 0) {
         OPENSSL_free(authchunks);
         BIO_vfree(bio);
-        return (NULL);
+        return NULL;
     }
 
     for (p = (unsigned char *)authchunks->gauth_chunks;
@@ -912,14 +912,14 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
                    sizeof(struct sctp_event));
     if (ret < 0) {
         BIO_vfree(bio);
-        return (NULL);
+        return NULL;
     }
 #   else
     sockopt_len = (socklen_t) sizeof(struct sctp_event_subscribe);
     ret = getsockopt(fd, IPPROTO_SCTP, SCTP_EVENTS, &event, &sockopt_len);
     if (ret < 0) {
         BIO_vfree(bio);
-        return (NULL);
+        return NULL;
     }
 
     event.sctp_authentication_event = 1;
@@ -929,7 +929,7 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
                    sizeof(struct sctp_event_subscribe));
     if (ret < 0) {
         BIO_vfree(bio);
-        return (NULL);
+        return NULL;
     }
 #   endif
 #  endif
@@ -943,10 +943,10 @@ BIO *BIO_new_dgram_sctp(int fd, int close_flag)
                    sizeof(optval));
     if (ret < 0) {
         BIO_vfree(bio);
-        return (NULL);
+        return NULL;
     }
 
-    return (bio);
+    return bio;
 }
 
 int BIO_dgram_is_sctp(BIO *bio)
@@ -977,7 +977,7 @@ static int dgram_sctp_free(BIO *a)
     bio_dgram_sctp_data *data;
 
     if (a == NULL)
-        return (0);
+        return 0;
     if (!dgram_clear(a))
         return 0;
 
@@ -1222,7 +1222,7 @@ static int dgram_sctp_read(BIO *b, char *out, int outl)
             data->peer_auth_tested = 1;
         }
     }
-    return (ret);
+    return ret;
 }
 
 /*
@@ -1338,7 +1338,7 @@ static int dgram_sctp_write(BIO *b, const char *in, int inl)
             data->_errno = get_last_socket_error();
         }
     }
-    return (ret);
+    return ret;
 }
 
 static long dgram_sctp_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -1573,7 +1573,7 @@ static long dgram_sctp_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = dgram_ctrl(b, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 int BIO_dgram_sctp_notification_cb(BIO *b,
@@ -1830,7 +1830,7 @@ static int dgram_sctp_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = dgram_sctp_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 # endif
 
@@ -1849,9 +1849,9 @@ static int BIO_dgram_should_retry(int i)
          */
 # endif
 
-        return (BIO_dgram_non_fatal_error(err));
+        return BIO_dgram_non_fatal_error(err);
     }
-    return (0);
+    return 0;
 }
 
 int BIO_dgram_non_fatal_error(int err)
@@ -1899,7 +1899,7 @@ int BIO_dgram_non_fatal_error(int err)
     default:
         break;
     }
-    return (0);
+    return 0;
 }
 
 static void get_current_time(struct timeval *t)

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -75,7 +75,7 @@ static const BIO_METHOD methods_fdp = {
 
 const BIO_METHOD *BIO_s_fd(void)
 {
-    return (&methods_fdp);
+    return &methods_fdp;
 }
 
 BIO *BIO_new_fd(int fd, int close_flag)
@@ -83,9 +83,9 @@ BIO *BIO_new_fd(int fd, int close_flag)
     BIO *ret;
     ret = BIO_new(BIO_s_fd());
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     BIO_set_fd(ret, fd, close_flag);
-    return (ret);
+    return ret;
 }
 
 static int fd_new(BIO *bi)
@@ -100,7 +100,7 @@ static int fd_new(BIO *bi)
 static int fd_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     if (a->shutdown) {
         if (a->init) {
             UP_close(a->num);
@@ -124,7 +124,7 @@ static int fd_read(BIO *b, char *out, int outl)
                 BIO_set_retry_read(b);
         }
     }
-    return (ret);
+    return ret;
 }
 
 static int fd_write(BIO *b, const char *in, int inl)
@@ -137,7 +137,7 @@ static int fd_write(BIO *b, const char *in, int inl)
         if (BIO_fd_should_retry(ret))
             BIO_set_retry_write(b);
     }
-    return (ret);
+    return ret;
 }
 
 static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -189,7 +189,7 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int fd_puts(BIO *bp, const char *str)
@@ -198,7 +198,7 @@ static int fd_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = fd_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 static int fd_gets(BIO *bp, char *buf, int size)
@@ -216,7 +216,7 @@ static int fd_gets(BIO *bp, char *buf, int size)
 
     if (buf[0] != '\0')
         ret = strlen(buf);
-    return (ret);
+    return ret;
 }
 
 int BIO_fd_should_retry(int i)
@@ -226,9 +226,9 @@ int BIO_fd_should_retry(int i)
     if ((i == 0) || (i == -1)) {
         err = get_last_sys_error();
 
-        return (BIO_fd_non_fatal_error(err));
+        return BIO_fd_non_fatal_error(err);
     }
-    return (0);
+    return 0;
 }
 
 int BIO_fd_non_fatal_error(int err)
@@ -274,6 +274,6 @@ int BIO_fd_non_fatal_error(int err)
     default:
         break;
     }
-    return (0);
+    return 0;
 }
 #endif

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -101,7 +101,7 @@ static const BIO_METHOD methods_slg = {
 
 const BIO_METHOD *BIO_s_log(void)
 {
-    return (&methods_slg);
+    return &methods_slg;
 }
 
 static int slg_new(BIO *bi)
@@ -116,7 +116,7 @@ static int slg_new(BIO *bi)
 static int slg_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     xcloselog(a);
     return 1;
 }
@@ -196,7 +196,7 @@ static int slg_write(BIO *b, const char *in, int inl)
     };
 
     if ((buf = OPENSSL_malloc(inl + 1)) == NULL) {
-        return (0);
+        return 0;
     }
     strncpy(buf, in, inl);
     buf[inl] = '\0';
@@ -210,7 +210,7 @@ static int slg_write(BIO *b, const char *in, int inl)
     xsyslog(b, priority, pp);
 
     OPENSSL_free(buf);
-    return (ret);
+    return ret;
 }
 
 static long slg_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -223,7 +223,7 @@ static long slg_ctrl(BIO *b, int cmd, long num, void *ptr)
     default:
         break;
     }
-    return (0);
+    return 0;
 }
 
 static int slg_puts(BIO *bp, const char *str)
@@ -232,7 +232,7 @@ static int slg_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = slg_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 # if defined(OPENSSL_SYS_WIN32)

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -70,7 +70,7 @@ typedef struct bio_buf_mem_st {
 
 const BIO_METHOD *BIO_s_mem(void)
 {
-    return (&mem_method);
+    return &mem_method;
 }
 
 const BIO_METHOD *BIO_s_secmem(void)
@@ -130,23 +130,23 @@ static int mem_init(BIO *bi, unsigned long flags)
 
 static int mem_new(BIO *bi)
 {
-    return (mem_init(bi, 0L));
+    return mem_init(bi, 0L);
 }
 
 static int secmem_new(BIO *bi)
 {
-    return (mem_init(bi, BUF_MEM_FLAG_SECURE));
+    return mem_init(bi, BUF_MEM_FLAG_SECURE);
 }
 
 static int mem_free(BIO *a)
 {
-    return (mem_buf_free(a, 1));
+    return mem_buf_free(a, 1);
 }
 
 static int mem_buf_free(BIO *a, int free_all)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     if (a->shutdown) {
         if ((a->init) && (a->ptr != NULL)) {
             BUF_MEM *b;
@@ -182,7 +182,7 @@ static int mem_buf_sync(BIO *b)
             bbm->readp->data = bbm->buf->data;
         }
     }
-    return (0);
+    return 0;
 }
 
 static int mem_read(BIO *b, char *out, int outl)
@@ -202,7 +202,7 @@ static int mem_read(BIO *b, char *out, int outl)
         if (ret != 0)
             BIO_set_retry_read(b);
     }
-    return (ret);
+    return ret;
 }
 
 static int mem_write(BIO *b, const char *in, int inl)
@@ -228,7 +228,7 @@ static int mem_write(BIO *b, const char *in, int inl)
     *bbm->readp = *bbm->buf;
     ret = inl;
  end:
-    return (ret);
+    return ret;
 }
 
 static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -305,7 +305,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int mem_gets(BIO *bp, char *buf, int size)
@@ -341,7 +341,7 @@ static int mem_gets(BIO *bp, char *buf, int size)
     if (i > 0)
         buf[i] = '\0';
     ret = i;
-    return (ret);
+    return ret;
 }
 
 static int mem_puts(BIO *bp, const char *str)
@@ -351,5 +351,5 @@ static int mem_puts(BIO *bp, const char *str)
     n = strlen(str);
     ret = mem_write(bp, str, n);
     /* memory semantics is that it will always work */
-    return (ret);
+    return ret;
 }

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -38,7 +38,7 @@ static const BIO_METHOD null_method = {
 
 const BIO_METHOD *BIO_s_null(void)
 {
-    return (&null_method);
+    return &null_method;
 }
 
 static int null_new(BIO *bi)
@@ -52,18 +52,18 @@ static int null_new(BIO *bi)
 static int null_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     return 1;
 }
 
 static int null_read(BIO *b, char *out, int outl)
 {
-    return (0);
+    return 0;
 }
 
 static int null_write(BIO *b, const char *in, int inl)
 {
-    return (inl);
+    return inl;
 }
 
 static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -88,17 +88,17 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int null_gets(BIO *bp, char *buf, int size)
 {
-    return (0);
+    return 0;
 }
 
 static int null_puts(BIO *bp, const char *str)
 {
     if (str == NULL)
-        return (0);
-    return (strlen(str));
+        return 0;
+    return strlen(str);
 }

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -53,7 +53,7 @@ static const BIO_METHOD methods_sockp = {
 
 const BIO_METHOD *BIO_s_socket(void)
 {
-    return (&methods_sockp);
+    return &methods_sockp;
 }
 
 BIO *BIO_new_socket(int fd, int close_flag)
@@ -62,9 +62,9 @@ BIO *BIO_new_socket(int fd, int close_flag)
 
     ret = BIO_new(BIO_s_socket());
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     BIO_set_fd(ret, fd, close_flag);
-    return (ret);
+    return ret;
 }
 
 static int sock_new(BIO *bi)
@@ -79,7 +79,7 @@ static int sock_new(BIO *bi)
 static int sock_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     if (a->shutdown) {
         if (a->init) {
             BIO_closesocket(a->num);
@@ -103,7 +103,7 @@ static int sock_read(BIO *b, char *out, int outl)
                 BIO_set_retry_read(b);
         }
     }
-    return (ret);
+    return ret;
 }
 
 static int sock_write(BIO *b, const char *in, int inl)
@@ -117,7 +117,7 @@ static int sock_write(BIO *b, const char *in, int inl)
         if (BIO_sock_should_retry(ret))
             BIO_set_retry_write(b);
     }
-    return (ret);
+    return ret;
 }
 
 static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -155,7 +155,7 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int sock_puts(BIO *bp, const char *str)
@@ -164,7 +164,7 @@ static int sock_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = sock_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 int BIO_sock_should_retry(int i)
@@ -174,9 +174,9 @@ int BIO_sock_should_retry(int i)
     if ((i == 0) || (i == -1)) {
         err = get_last_socket_error();
 
-        return (BIO_sock_non_fatal_error(err));
+        return BIO_sock_non_fatal_error(err);
     }
-    return (0);
+    return 0;
 }
 
 int BIO_sock_non_fatal_error(int err)
@@ -227,7 +227,7 @@ int BIO_sock_non_fatal_error(int err)
     default:
         break;
     }
-    return (0);
+    return 0;
 }
 
 #endif                          /* #ifndef OPENSSL_NO_SOCK */

--- a/crypto/blake2/m_blake2b.c
+++ b/crypto/blake2/m_blake2b.c
@@ -54,6 +54,6 @@ static const EVP_MD blake2b_md = {
 
 const EVP_MD *EVP_blake2b512(void)
 {
-    return (&blake2b_md);
+    return &blake2b_md;
 }
 #endif

--- a/crypto/blake2/m_blake2s.c
+++ b/crypto/blake2/m_blake2s.c
@@ -54,6 +54,6 @@ static const EVP_MD blake2s_md = {
 
 const EVP_MD *EVP_blake2s256(void)
 {
-    return (&blake2s_md);
+    return &blake2s_md;
 }
 #endif

--- a/crypto/bn/asm/x86_64-gcc.c
+++ b/crypto/bn/asm/x86_64-gcc.c
@@ -120,7 +120,7 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
     BN_ULONG c1 = 0;
 
     if (num <= 0)
-        return (c1);
+        return c1;
 
     while (num & ~3) {
         mul_add(rp[0], ap[0], w, c1);
@@ -142,7 +142,7 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
         return c1;
     }
 
-    return (c1);
+    return c1;
 }
 
 BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
@@ -150,7 +150,7 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
     BN_ULONG c1 = 0;
 
     if (num <= 0)
-        return (c1);
+        return c1;
 
     while (num & ~3) {
         mul(rp[0], ap[0], w, c1);
@@ -170,7 +170,7 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
             return c1;
         mul(rp[2], ap[2], w, c1);
     }
-    return (c1);
+    return c1;
 }
 
 void bn_sqr_words(BN_ULONG *r, const BN_ULONG *a, int n)
@@ -268,7 +268,7 @@ BN_ULONG bn_sub_words(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n)
     int c = 0;
 
     if (n <= 0)
-        return ((BN_ULONG)0);
+        return (BN_ULONG)0;
 
     for (;;) {
         t1 = a[0];
@@ -307,7 +307,7 @@ BN_ULONG bn_sub_words(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n)
         b += 4;
         r += 4;
     }
-    return (c);
+    return c;
 }
 # endif
 

--- a/crypto/bn/bn_asm.c
+++ b/crypto/bn/bn_asm.c
@@ -21,7 +21,7 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
 
     assert(num >= 0);
     if (num <= 0)
-        return (c1);
+        return c1;
 
 # ifndef OPENSSL_SMALL_FOOTPRINT
     while (num & ~3) {
@@ -41,7 +41,7 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
         num--;
     }
 
-    return (c1);
+    return c1;
 }
 
 BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
@@ -50,7 +50,7 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
 
     assert(num >= 0);
     if (num <= 0)
-        return (c1);
+        return c1;
 
 # ifndef OPENSSL_SMALL_FOOTPRINT
     while (num & ~3) {
@@ -69,7 +69,7 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
         rp++;
         num--;
     }
-    return (c1);
+    return c1;
 }
 
 void bn_sqr_words(BN_ULONG *r, const BN_ULONG *a, int n)
@@ -108,7 +108,7 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
 
     assert(num >= 0);
     if (num <= 0)
-        return ((BN_ULONG)0);
+        return (BN_ULONG)0;
 
     bl = LBITS(w);
     bh = HBITS(w);
@@ -130,7 +130,7 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
         rp++;
         num--;
     }
-    return (c);
+    return c;
 }
 
 BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
@@ -140,7 +140,7 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
 
     assert(num >= 0);
     if (num <= 0)
-        return ((BN_ULONG)0);
+        return (BN_ULONG)0;
 
     bl = LBITS(w);
     bh = HBITS(w);
@@ -162,7 +162,7 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
         rp++;
         num--;
     }
-    return (carry);
+    return carry;
 }
 
 void bn_sqr_words(BN_ULONG *r, const BN_ULONG *a, int n)
@@ -210,7 +210,7 @@ BN_ULONG bn_div_words(BN_ULONG h, BN_ULONG l, BN_ULONG d)
     int i, count = 2;
 
     if (d == 0)
-        return (BN_MASK2);
+        return BN_MASK2;
 
     i = BN_num_bits_word(d);
     assert((i == BN_BITS2) || (h <= (BN_ULONG)1 << i));
@@ -264,7 +264,7 @@ BN_ULONG bn_div_words(BN_ULONG h, BN_ULONG l, BN_ULONG d)
         l = (l & BN_MASK2l) << BN_BITS4;
     }
     ret |= q;
-    return (ret);
+    return ret;
 }
 #endif                          /* !defined(BN_LLONG) && defined(BN_DIV2W) */
 
@@ -276,7 +276,7 @@ BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
 
     assert(n >= 0);
     if (n <= 0)
-        return ((BN_ULONG)0);
+        return (BN_ULONG)0;
 
 # ifndef OPENSSL_SMALL_FOOTPRINT
     while (n & ~3) {
@@ -307,7 +307,7 @@ BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
         r++;
         n--;
     }
-    return ((BN_ULONG)ll);
+    return (BN_ULONG)ll;
 }
 #else                           /* !BN_LLONG */
 BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
@@ -317,7 +317,7 @@ BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
 
     assert(n >= 0);
     if (n <= 0)
-        return ((BN_ULONG)0);
+        return (BN_ULONG)0;
 
     c = 0;
 # ifndef OPENSSL_SMALL_FOOTPRINT
@@ -364,7 +364,7 @@ BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
         r++;
         n--;
     }
-    return ((BN_ULONG)c);
+    return (BN_ULONG)c;
 }
 #endif                          /* !BN_LLONG */
 
@@ -376,7 +376,7 @@ BN_ULONG bn_sub_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
 
     assert(n >= 0);
     if (n <= 0)
-        return ((BN_ULONG)0);
+        return (BN_ULONG)0;
 
 #ifndef OPENSSL_SMALL_FOOTPRINT
     while (n & ~3) {
@@ -417,7 +417,7 @@ BN_ULONG bn_sub_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
         r++;
         n--;
     }
-    return (c);
+    return c;
 }
 
 #if defined(BN_MUL_COMBA) && !defined(OPENSSL_SMALL_FOOTPRINT)

--- a/crypto/bn/bn_blind.c
+++ b/crypto/bn/bn_blind.c
@@ -119,7 +119,7 @@ int BN_BLINDING_update(BN_BLINDING *b, BN_CTX *ctx)
  err:
     if (b->counter == BN_BLINDING_COUNTER)
         b->counter = 0;
-    return (ret);
+    return ret;
 }
 
 int BN_BLINDING_convert(BIGNUM *n, BN_BLINDING *b, BN_CTX *ctx)
@@ -135,14 +135,14 @@ int BN_BLINDING_convert_ex(BIGNUM *n, BIGNUM *r, BN_BLINDING *b, BN_CTX *ctx)
 
     if ((b->A == NULL) || (b->Ai == NULL)) {
         BNerr(BN_F_BN_BLINDING_CONVERT_EX, BN_R_NOT_INITIALIZED);
-        return (0);
+        return 0;
     }
 
     if (b->counter == -1)
         /* Fresh blinding, doesn't need updating. */
         b->counter = 0;
     else if (!BN_BLINDING_update(b, ctx))
-        return (0);
+        return 0;
 
     if (r != NULL) {
         if (!BN_copy(r, b->Ai))
@@ -172,13 +172,13 @@ int BN_BLINDING_invert_ex(BIGNUM *n, const BIGNUM *r, BN_BLINDING *b,
     else {
         if (b->Ai == NULL) {
             BNerr(BN_F_BN_BLINDING_INVERT_EX, BN_R_NOT_INITIALIZED);
-            return (0);
+            return 0;
         }
         ret = BN_mod_mul(n, n, b->Ai, b->mod, ctx);
     }
 
     bn_check_top(n);
-    return (ret);
+    return ret;
 }
 
 int BN_BLINDING_is_current_thread(BN_BLINDING *b)

--- a/crypto/bn/bn_div.c
+++ b/crypto/bn/bn_div.c
@@ -24,13 +24,13 @@ int BN_div(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m, const BIGNUM *d,
     bn_check_top(d);
     if (BN_is_zero(d)) {
         BNerr(BN_F_BN_DIV, BN_R_DIV_BY_ZERO);
-        return (0);
+        return 0;
     }
 
     if (BN_ucmp(m, d) < 0) {
         if (rem != NULL) {
             if (BN_copy(rem, m) == NULL)
-                return (0);
+                return 0;
         }
         if (dv != NULL)
             BN_zero(dv);
@@ -81,7 +81,7 @@ int BN_div(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m, const BIGNUM *d,
     ret = 1;
  end:
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }
 
 #else
@@ -174,13 +174,13 @@ int BN_div(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num, const BIGNUM *divisor,
 
     if (BN_is_zero(divisor)) {
         BNerr(BN_F_BN_DIV, BN_R_DIV_BY_ZERO);
-        return (0);
+        return 0;
     }
 
     if (!no_branch && BN_ucmp(num, divisor) < 0) {
         if (rm != NULL) {
             if (BN_copy(rm, num) == NULL)
-                return (0);
+                return 0;
         }
         if (dv != NULL)
             BN_zero(dv);
@@ -412,6 +412,6 @@ int BN_div(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num, const BIGNUM *divisor,
  err:
     bn_check_top(rm);
     BN_CTX_end(ctx);
-    return (0);
+    return 0;
 }
 #endif

--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -155,7 +155,7 @@ int BN_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, const BIGNUM *m,
 #endif
 
     bn_check_top(r);
-    return (ret);
+    return ret;
 }
 
 int BN_mod_exp_recp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
@@ -290,7 +290,7 @@ int BN_mod_exp_recp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     BN_CTX_end(ctx);
     BN_RECP_CTX_free(&recp);
     bn_check_top(r);
-    return (ret);
+    return ret;
 }
 
 int BN_mod_exp_mont(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
@@ -316,7 +316,7 @@ int BN_mod_exp_mont(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
 
     if (!BN_is_odd(m)) {
         BNerr(BN_F_BN_MOD_EXP_MONT, BN_R_CALLED_WITH_EVEN_MODULUS);
-        return (0);
+        return 0;
     }
     bits = BN_num_bits(p);
     if (bits == 0) {
@@ -470,7 +470,7 @@ int BN_mod_exp_mont(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
         BN_MONT_CTX_free(mont);
     BN_CTX_end(ctx);
     bn_check_top(rr);
-    return (ret);
+    return ret;
 }
 
 #if defined(SPARC_T4_MONT)
@@ -618,7 +618,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
 
     if (!BN_is_odd(m)) {
         BNerr(BN_F_BN_MOD_EXP_MONT_CONSTTIME, BN_R_CALLED_WITH_EVEN_MODULUS);
-        return (0);
+        return 0;
     }
 
     top = m->top;
@@ -1089,7 +1089,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
         OPENSSL_free(powerbufFree);
     }
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }
 
 int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,
@@ -1130,7 +1130,7 @@ int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,
 
     if (!BN_is_odd(m)) {
         BNerr(BN_F_BN_MOD_EXP_MONT_WORD, BN_R_CALLED_WITH_EVEN_MODULUS);
-        return (0);
+        return 0;
     }
     if (m->top == 1)
         a %= m->d[0];           /* make sure that 'a' is reduced */
@@ -1236,7 +1236,7 @@ int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,
         BN_MONT_CTX_free(mont);
     BN_CTX_end(ctx);
     bn_check_top(rr);
-    return (ret);
+    return ret;
 }
 
 /* The old fallback, simple version :-) */
@@ -1357,5 +1357,5 @@ int BN_mod_exp_simple(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
  err:
     BN_CTX_end(ctx);
     bn_check_top(r);
-    return (ret);
+    return ret;
 }

--- a/crypto/bn/bn_exp2.c
+++ b/crypto/bn/bn_exp2.c
@@ -34,7 +34,7 @@ int BN_mod_exp2_mont(BIGNUM *rr, const BIGNUM *a1, const BIGNUM *p1,
 
     if (!(m->d[0] & 1)) {
         BNerr(BN_F_BN_MOD_EXP2_MONT, BN_R_CALLED_WITH_EVEN_MODULUS);
-        return (0);
+        return 0;
     }
     bits1 = BN_num_bits(p1);
     bits2 = BN_num_bits(p2);
@@ -197,5 +197,5 @@ int BN_mod_exp2_mont(BIGNUM *rr, const BIGNUM *a1, const BIGNUM *p1,
         BN_MONT_CTX_free(mont);
     BN_CTX_end(ctx);
     bn_check_top(rr);
-    return (ret);
+    return ret;
 }

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -48,7 +48,7 @@ int BN_gcd(BIGNUM *r, const BIGNUM *in_a, const BIGNUM *in_b, BN_CTX *ctx)
  err:
     BN_CTX_end(ctx);
     bn_check_top(r);
-    return (ret);
+    return ret;
 }
 
 static BIGNUM *euclid(BIGNUM *a, BIGNUM *b)
@@ -111,9 +111,9 @@ static BIGNUM *euclid(BIGNUM *a, BIGNUM *b)
             goto err;
     }
     bn_check_top(a);
-    return (a);
+    return a;
  err:
-    return (NULL);
+    return NULL;
 }
 
 /* solves ax == 1 (mod n) */
@@ -441,7 +441,7 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
         BN_free(R);
     BN_CTX_end(ctx);
     bn_check_top(ret);
-    return (ret);
+    return ret;
 }
 
 /*
@@ -612,5 +612,5 @@ static BIGNUM *BN_mod_inverse_no_branch(BIGNUM *in,
         BN_free(R);
     BN_CTX_end(ctx);
     bn_check_top(ret);
-    return (ret);
+    return ret;
 }

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -904,7 +904,7 @@ int BN_GF2m_mod_exp_arr(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     bn_check_top(b);
 
     if (BN_is_zero(b))
-        return (BN_one(r));
+        return BN_one(r);
 
     if (BN_abs_is_word(b, 1))
         return (BN_copy(r, a) != NULL);

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -65,15 +65,15 @@ void BN_set_params(int mult, int high, int low, int mont)
 int BN_get_params(int which)
 {
     if (which == 0)
-        return (bn_limit_bits);
+        return bn_limit_bits;
     else if (which == 1)
-        return (bn_limit_bits_high);
+        return bn_limit_bits_high;
     else if (which == 2)
-        return (bn_limit_bits_low);
+        return bn_limit_bits_low;
     else if (which == 3)
-        return (bn_limit_bits_mont);
+        return bn_limit_bits_mont;
     else
-        return (0);
+        return 0;
 }
 #endif
 
@@ -83,7 +83,7 @@ const BIGNUM *BN_value_one(void)
     static const BIGNUM const_one =
         { (BN_ULONG *)&data_one, 1, 1, 0, BN_FLG_STATIC_DATA };
 
-    return (&const_one);
+    return &const_one;
 }
 
 int BN_num_bits_word(BN_ULONG l)
@@ -215,11 +215,11 @@ BIGNUM *BN_new(void)
 
     if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_NEW, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
     ret->flags = BN_FLG_MALLOCED;
     bn_check_top(ret);
-    return (ret);
+    return ret;
 }
 
  BIGNUM *BN_secure_new(void)
@@ -227,7 +227,7 @@ BIGNUM *BN_new(void)
      BIGNUM *ret = BN_new();
      if (ret != NULL)
          ret->flags |= BN_FLG_SECURE;
-     return (ret);
+     return ret;
  }
 
 /* This is used by bn_expand2() */
@@ -244,7 +244,7 @@ static BN_ULONG *bn_expand_internal(const BIGNUM *b, int words)
     }
     if (BN_get_flags(b, BN_FLG_STATIC_DATA)) {
         BNerr(BN_F_BN_EXPAND_INTERNAL, BN_R_EXPAND_ON_STATIC_BIGNUM_DATA);
-        return (NULL);
+        return NULL;
     }
     if (BN_get_flags(b, BN_FLG_SECURE))
         a = OPENSSL_secure_zalloc(words * sizeof(*a));
@@ -252,7 +252,7 @@ static BN_ULONG *bn_expand_internal(const BIGNUM *b, int words)
         a = OPENSSL_zalloc(words * sizeof(*a));
     if (a == NULL) {
         BNerr(BN_F_BN_EXPAND_INTERNAL, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
 
     assert(b->top <= words);
@@ -388,7 +388,7 @@ int BN_set_word(BIGNUM *a, BN_ULONG w)
 {
     bn_check_top(a);
     if (bn_expand(a, (int)sizeof(BN_ULONG) * 8) == NULL)
-        return (0);
+        return 0;
     a->neg = 0;
     a->d[0] = w;
     a->top = (w ? 1 : 0);
@@ -406,7 +406,7 @@ BIGNUM *BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret)
     if (ret == NULL)
         ret = bn = BN_new();
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     bn_check_top(ret);
     /* Skip leading zero's. */
     for ( ; len > 0 && *s == 0; s++, len--)
@@ -414,7 +414,7 @@ BIGNUM *BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret)
     n = len;
     if (n == 0) {
         ret->top = 0;
-        return (ret);
+        return ret;
     }
     i = ((n - 1) / BN_BYTES) + 1;
     m = ((n - 1) % (BN_BYTES));
@@ -438,7 +438,7 @@ BIGNUM *BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret)
      * bit set (-ve number)
      */
     bn_correct_top(ret);
-    return (ret);
+    return ret;
 }
 
 /* ignore negative */
@@ -487,7 +487,7 @@ BIGNUM *BN_lebin2bn(const unsigned char *s, int len, BIGNUM *ret)
     if (ret == NULL)
         ret = bn = BN_new();
     if (ret == NULL)
-        return (NULL);
+        return NULL;
     bn_check_top(ret);
     s += len;
     /* Skip trailing zeroes. */
@@ -554,7 +554,7 @@ int BN_ucmp(const BIGNUM *a, const BIGNUM *b)
 
     i = a->top - b->top;
     if (i != 0)
-        return (i);
+        return i;
     ap = a->d;
     bp = b->d;
     for (i = a->top - 1; i >= 0; i--) {
@@ -563,7 +563,7 @@ int BN_ucmp(const BIGNUM *a, const BIGNUM *b)
         if (t1 != t2)
             return ((t1 > t2) ? 1 : -1);
     }
-    return (0);
+    return 0;
 }
 
 int BN_cmp(const BIGNUM *a, const BIGNUM *b)
@@ -574,11 +574,11 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b)
 
     if ((a == NULL) || (b == NULL)) {
         if (a != NULL)
-            return (-1);
+            return -1;
         else if (b != NULL)
             return 1;
         else
-            return (0);
+            return 0;
     }
 
     bn_check_top(a);
@@ -586,7 +586,7 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b)
 
     if (a->neg != b->neg) {
         if (a->neg)
-            return (-1);
+            return -1;
         else
             return 1;
     }
@@ -599,18 +599,18 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b)
     }
 
     if (a->top > b->top)
-        return (gt);
+        return gt;
     if (a->top < b->top)
-        return (lt);
+        return lt;
     for (i = a->top - 1; i >= 0; i--) {
         t1 = a->d[i];
         t2 = b->d[i];
         if (t1 > t2)
-            return (gt);
+            return gt;
         if (t1 < t2)
-            return (lt);
+            return lt;
     }
-    return (0);
+    return 0;
 }
 
 int BN_set_bit(BIGNUM *a, int n)
@@ -624,7 +624,7 @@ int BN_set_bit(BIGNUM *a, int n)
     j = n % BN_BITS2;
     if (a->top <= i) {
         if (bn_wexpand(a, i + 1) == NULL)
-            return (0);
+            return 0;
         for (k = a->top; k < i + 1; k++)
             a->d[k] = 0;
         a->top = i + 1;
@@ -646,7 +646,7 @@ int BN_clear_bit(BIGNUM *a, int n)
     i = n / BN_BITS2;
     j = n % BN_BITS2;
     if (a->top <= i)
-        return (0);
+        return 0;
 
     a->d[i] &= (~(((BN_ULONG)1) << j));
     bn_correct_top(a);
@@ -712,7 +712,7 @@ int bn_cmp_words(const BN_ULONG *a, const BN_ULONG *b, int n)
         if (aa != bb)
             return ((aa > bb) ? 1 : -1);
     }
-    return (0);
+    return 0;
 }
 
 /*
@@ -889,7 +889,7 @@ BN_GENCB *BN_GENCB_new(void)
 
     if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_GENCB_NEW, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
 
     return ret;

--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -96,7 +96,7 @@ int BN_mod_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, const BIGNUM *m,
     ret = 1;
  err:
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }
 
 int BN_mod_sqr(BIGNUM *r, const BIGNUM *a, const BIGNUM *m, BN_CTX *ctx)

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -33,7 +33,7 @@ int BN_mod_mul_montgomery(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
 
     if (num > 1 && a->top == num && b->top == num) {
         if (bn_wexpand(r, num) == NULL)
-            return (0);
+            return 0;
         if (bn_mul_mont(r->d, a->d, b->d, mont->N.d, mont->n0, num)) {
             r->neg = a->neg ^ b->neg;
             r->top = num;
@@ -68,7 +68,7 @@ int BN_mod_mul_montgomery(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     ret = 1;
  err:
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }
 
 #ifdef MONT_WORD
@@ -87,7 +87,7 @@ static int BN_from_montgomery_word(BIGNUM *ret, BIGNUM *r, BN_MONT_CTX *mont)
 
     max = (2 * nl);             /* carry is stored separately */
     if (bn_wexpand(r, max) == NULL)
-        return (0);
+        return 0;
 
     r->neg ^= n->neg;
     np = n->d;
@@ -110,7 +110,7 @@ static int BN_from_montgomery_word(BIGNUM *ret, BIGNUM *r, BN_MONT_CTX *mont)
     }
 
     if (bn_wexpand(ret, nl) == NULL)
-        return (0);
+        return 0;
     ret->top = nl;
     ret->neg = r->neg;
 
@@ -207,7 +207,7 @@ int BN_from_montgomery(BIGNUM *ret, const BIGNUM *a, BN_MONT_CTX *mont,
  err:
     BN_CTX_end(ctx);
 #endif                          /* MONT_WORD */
-    return (retn);
+    return retn;
 }
 
 BN_MONT_CTX *BN_MONT_CTX_new(void)
@@ -215,11 +215,11 @@ BN_MONT_CTX *BN_MONT_CTX_new(void)
     BN_MONT_CTX *ret;
 
     if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL)
-        return (NULL);
+        return NULL;
 
     BN_MONT_CTX_init(ret);
     ret->flags = BN_FLG_MALLOCED;
-    return (ret);
+    return ret;
 }
 
 void BN_MONT_CTX_init(BN_MONT_CTX *ctx)
@@ -384,7 +384,7 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
 BN_MONT_CTX *BN_MONT_CTX_copy(BN_MONT_CTX *to, BN_MONT_CTX *from)
 {
     if (to == from)
-        return (to);
+        return to;
 
     if (!BN_copy(&(to->RR), &(from->RR)))
         return NULL;
@@ -395,7 +395,7 @@ BN_MONT_CTX *BN_MONT_CTX_copy(BN_MONT_CTX *to, BN_MONT_CTX *from)
     to->ri = from->ri;
     to->n0[0] = from->n0[0];
     to->n0[1] = from->n0[1];
-    return (to);
+    return to;
 }
 
 BN_MONT_CTX *BN_MONT_CTX_set_locked(BN_MONT_CTX **pmont, CRYPTO_RWLOCK *lock,

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -606,7 +606,7 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
  err:
     bn_check_top(r);
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }
 
 void bn_mul_normal(BN_ULONG *r, BN_ULONG *a, int na, BN_ULONG *b, int nb)

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -241,7 +241,7 @@ int BN_is_prime_fasttest_ex(const BIGNUM *a, int checks, BN_CTX *ctx_passed,
     }
     BN_MONT_CTX_free(mont);
 
-    return (ret);
+    return ret;
 }
 
 static int witness(BIGNUM *w, const BIGNUM *a, const BIGNUM *a1,
@@ -280,7 +280,7 @@ static int probable_prime(BIGNUM *rnd, int bits, prime_t *mods)
 
  again:
     if (!BN_priv_rand(rnd, bits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ODD))
-        return (0);
+        return 0;
     /* we now have a random number 'rnd' to test. */
     for (i = 1; i < NUMPRIMES; i++) {
         BN_ULONG mod = BN_mod_word(rnd, (BN_ULONG)primes[i]);
@@ -346,7 +346,7 @@ static int probable_prime(BIGNUM *rnd, int bits, prime_t *mods)
         }
     }
     if (!BN_add_word(rnd, delta))
-        return (0);
+        return 0;
     if (BN_num_bits(rnd) != bits)
         goto again;
     bn_check_top(rnd);
@@ -399,7 +399,7 @@ int bn_probable_prime_dh(BIGNUM *rnd, int bits,
  err:
     BN_CTX_end(ctx);
     bn_check_top(rnd);
-    return (ret);
+    return ret;
 }
 
 static int probable_prime_dh_safe(BIGNUM *p, int bits, const BIGNUM *padd,
@@ -466,5 +466,5 @@ static int probable_prime_dh_safe(BIGNUM *p, int bits, const BIGNUM *padd,
  err:
     BN_CTX_end(ctx);
     bn_check_top(p);
-    return (ret);
+    return ret;
 }

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -87,7 +87,7 @@ static int bnrand(BNRAND_FLAG flag, BIGNUM *rnd, int bits, int top, int bottom)
  err:
     OPENSSL_clear_free(buf, bytes);
     bn_check_top(rnd);
-    return (ret);
+    return ret;
 
 toosmall:
     BNerr(BN_F_BNRAND, BN_R_BITS_TOO_SMALL);

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -22,12 +22,12 @@ BN_RECP_CTX *BN_RECP_CTX_new(void)
     BN_RECP_CTX *ret;
 
     if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL)
-        return (NULL);
+        return NULL;
 
     bn_init(&(ret->N));
     bn_init(&(ret->Nr));
     ret->flags = BN_FLG_MALLOCED;
-    return (ret);
+    return ret;
 }
 
 void BN_RECP_CTX_free(BN_RECP_CTX *recp)
@@ -77,7 +77,7 @@ int BN_mod_mul_reciprocal(BIGNUM *r, const BIGNUM *x, const BIGNUM *y,
  err:
     BN_CTX_end(ctx);
     bn_check_top(r);
-    return (ret);
+    return ret;
 }
 
 int BN_div_recp(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m,
@@ -161,7 +161,7 @@ int BN_div_recp(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m,
     BN_CTX_end(ctx);
     bn_check_top(dv);
     bn_check_top(rem);
-    return (ret);
+    return ret;
 }
 
 /*
@@ -189,5 +189,5 @@ int BN_reciprocal(BIGNUM *r, const BIGNUM *m, int len, BN_CTX *ctx)
  err:
     bn_check_top(r);
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }

--- a/crypto/bn/bn_shift.c
+++ b/crypto/bn/bn_shift.c
@@ -21,11 +21,11 @@ int BN_lshift1(BIGNUM *r, const BIGNUM *a)
     if (r != a) {
         r->neg = a->neg;
         if (bn_wexpand(r, a->top + 1) == NULL)
-            return (0);
+            return 0;
         r->top = a->top;
     } else {
         if (bn_wexpand(r, a->top + 1) == NULL)
-            return (0);
+            return 0;
     }
     ap = a->d;
     rp = r->d;
@@ -60,7 +60,7 @@ int BN_rshift1(BIGNUM *r, const BIGNUM *a)
     j = i - (ap[i - 1] == 1);
     if (a != r) {
         if (bn_wexpand(r, j) == NULL)
-            return (0);
+            return 0;
         r->neg = a->neg;
     }
     rp = r->d;
@@ -96,7 +96,7 @@ int BN_lshift(BIGNUM *r, const BIGNUM *a, int n)
 
     nw = n / BN_BITS2;
     if (bn_wexpand(r, a->top + nw + 1) == NULL)
-        return (0);
+        return 0;
     r->neg = a->neg;
     lb = n % BN_BITS2;
     rb = BN_BITS2 - lb;
@@ -143,7 +143,7 @@ int BN_rshift(BIGNUM *r, const BIGNUM *a, int n)
     i = (BN_num_bits(a) - n + (BN_BITS2 - 1)) / BN_BITS2;
     if (r != a) {
         if (bn_wexpand(r, i) == NULL)
-            return (0);
+            return 0;
         r->neg = a->neg;
     } else {
         if (n == 0)

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -98,7 +98,7 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
     bn_check_top(rr);
     bn_check_top(tmp);
     BN_CTX_end(ctx);
-    return (ret);
+    return ret;
 }
 
 /* tmp must have 2*n words */

--- a/crypto/bn/bn_sqrt.c
+++ b/crypto/bn/bn_sqrt.c
@@ -39,7 +39,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
         }
 
         BNerr(BN_F_BN_MOD_SQRT, BN_R_P_IS_NOT_PRIME);
-        return (NULL);
+        return NULL;
     }
 
     if (BN_is_zero(a) || BN_is_one(a)) {

--- a/crypto/bn/bn_word.c
+++ b/crypto/bn/bn_word.c
@@ -55,7 +55,7 @@ BN_ULONG BN_mod_word(const BIGNUM *a, BN_ULONG w)
                            (BN_ULLONG) w);
 #endif
     }
-    return ((BN_ULONG)ret);
+    return (BN_ULONG)ret;
 }
 
 BN_ULONG BN_div_word(BIGNUM *a, BN_ULONG w)
@@ -92,7 +92,7 @@ BN_ULONG BN_div_word(BIGNUM *a, BN_ULONG w)
     if (!a->top)
         a->neg = 0; /* don't allow negative zero */
     bn_check_top(a);
-    return (ret);
+    return ret;
 }
 
 int BN_add_word(BIGNUM *a, BN_ULONG w)
@@ -115,7 +115,7 @@ int BN_add_word(BIGNUM *a, BN_ULONG w)
         i = BN_sub_word(a, w);
         if (!BN_is_zero(a))
             a->neg = !(a->neg);
-        return (i);
+        return i;
     }
     for (i = 0; w != 0 && i < a->top; i++) {
         a->d[i] = l = (a->d[i] + w) & BN_MASK2;
@@ -153,7 +153,7 @@ int BN_sub_word(BIGNUM *a, BN_ULONG w)
         a->neg = 0;
         i = BN_add_word(a, w);
         a->neg = 1;
-        return (i);
+        return i;
     }
 
     if ((a->top == 1) && (a->d[0] < w)) {
@@ -191,7 +191,7 @@ int BN_mul_word(BIGNUM *a, BN_ULONG w)
             ll = bn_mul_words(a->d, a->d, a->top, w);
             if (ll) {
                 if (bn_wexpand(a, a->top + 1) == NULL)
-                    return (0);
+                    return 0;
                 a->d[a->top++] = ll;
             }
         }

--- a/crypto/buffer/buffer.c
+++ b/crypto/buffer/buffer.c
@@ -25,7 +25,7 @@ BUF_MEM *BUF_MEM_new_ex(unsigned long flags)
     ret = BUF_MEM_new();
     if (ret != NULL)
         ret->flags = flags;
-    return (ret);
+    return ret;
 }
 
 BUF_MEM *BUF_MEM_new(void)
@@ -35,9 +35,9 @@ BUF_MEM *BUF_MEM_new(void)
     ret = OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         BUFerr(BUF_F_BUF_MEM_NEW, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
-    return (ret);
+    return ret;
 }
 
 void BUF_MEM_free(BUF_MEM *a)
@@ -68,7 +68,7 @@ static char *sec_alloc_realloc(BUF_MEM *str, size_t len)
             str->data = NULL;
         }
     }
-    return (ret);
+    return ret;
 }
 
 size_t BUF_MEM_grow(BUF_MEM *str, size_t len)
@@ -78,13 +78,13 @@ size_t BUF_MEM_grow(BUF_MEM *str, size_t len)
 
     if (str->length >= len) {
         str->length = len;
-        return (len);
+        return len;
     }
     if (str->max >= len) {
         if (str->data != NULL)
             memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
-        return (len);
+        return len;
     }
     /* This limit is sufficient to ensure (len+3)/3*4 < 2**31 */
     if (len > LIMIT_BEFORE_EXPANSION) {
@@ -105,7 +105,7 @@ size_t BUF_MEM_grow(BUF_MEM *str, size_t len)
         memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
     }
-    return (len);
+    return len;
 }
 
 size_t BUF_MEM_grow_clean(BUF_MEM *str, size_t len)
@@ -117,12 +117,12 @@ size_t BUF_MEM_grow_clean(BUF_MEM *str, size_t len)
         if (str->data != NULL)
             memset(&str->data[len], 0, str->length - len);
         str->length = len;
-        return (len);
+        return len;
     }
     if (str->max >= len) {
         memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
-        return (len);
+        return len;
     }
     /* This limit is sufficient to ensure (len+3)/3*4 < 2**31 */
     if (len > LIMIT_BEFORE_EXPANSION) {
@@ -143,7 +143,7 @@ size_t BUF_MEM_grow_clean(BUF_MEM *str, size_t len)
         memset(&str->data[str->length], 0, len - str->length);
         str->length = len;
     }
-    return (len);
+    return len;
 }
 
 void BUF_reverse(unsigned char *out, const unsigned char *in, size_t size)

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -256,7 +256,7 @@ COMP_METHOD *COMP_zlib(void)
     meth = &zlib_stateful_method;
 #endif
 
-    return (meth);
+    return meth;
 }
 
 void comp_zlib_cleanup_int(void)

--- a/crypto/comp/comp_lib.c
+++ b/crypto/comp/comp_lib.c
@@ -19,13 +19,13 @@ COMP_CTX *COMP_CTX_new(COMP_METHOD *meth)
     COMP_CTX *ret;
 
     if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL)
-        return (NULL);
+        return NULL;
     ret->meth = meth;
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         OPENSSL_free(ret);
         ret = NULL;
     }
-    return (ret);
+    return ret;
 }
 
 const COMP_METHOD *COMP_CTX_get_method(const COMP_CTX *ctx)
@@ -59,14 +59,14 @@ int COMP_compress_block(COMP_CTX *ctx, unsigned char *out, int olen,
 {
     int ret;
     if (ctx->meth->compress == NULL) {
-        return (-1);
+        return -1;
     }
     ret = ctx->meth->compress(ctx, out, olen, in, ilen);
     if (ret > 0) {
         ctx->compress_in += ilen;
         ctx->compress_out += ret;
     }
-    return (ret);
+    return ret;
 }
 
 int COMP_expand_block(COMP_CTX *ctx, unsigned char *out, int olen,
@@ -75,14 +75,14 @@ int COMP_expand_block(COMP_CTX *ctx, unsigned char *out, int olen,
     int ret;
 
     if (ctx->meth->expand == NULL) {
-        return (-1);
+        return -1;
     }
     ret = ctx->meth->expand(ctx, out, olen, in, ilen);
     if (ret > 0) {
         ctx->expand_in += ilen;
         ctx->expand_out += ret;
     }
-    return (ret);
+    return ret;
 }
 
 int COMP_CTX_get_type(const COMP_CTX* comp)

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -24,11 +24,11 @@ CONF_VALUE *_CONF_get_section(const CONF *conf, const char *section)
     CONF_VALUE *v, vv;
 
     if ((conf == NULL) || (section == NULL))
-        return (NULL);
+        return NULL;
     vv.name = NULL;
     vv.section = (char *)section;
     v = lh_CONF_VALUE_retrieve(conf->data, &vv);
-    return (v);
+    return v;
 }
 
 /* Up until OpenSSL 0.9.5a, this was CONF_get_section */
@@ -41,7 +41,7 @@ STACK_OF(CONF_VALUE) *_CONF_get_section_values(const CONF *conf,
     if (v != NULL)
         return ((STACK_OF(CONF_VALUE) *)v->value);
     else
-        return (NULL);
+        return NULL;
 }
 
 int _CONF_add_string(CONF *conf, CONF_VALUE *section, CONF_VALUE *value)
@@ -73,29 +73,29 @@ char *_CONF_get_string(const CONF *conf, const char *section,
     char *p;
 
     if (name == NULL)
-        return (NULL);
+        return NULL;
     if (conf != NULL) {
         if (section != NULL) {
             vv.name = (char *)name;
             vv.section = (char *)section;
             v = lh_CONF_VALUE_retrieve(conf->data, &vv);
             if (v != NULL)
-                return (v->value);
+                return v->value;
             if (strcmp(section, "ENV") == 0) {
                 p = getenv(name);
                 if (p != NULL)
-                    return (p);
+                    return p;
             }
         }
         vv.section = "default";
         vv.name = (char *)name;
         v = lh_CONF_VALUE_retrieve(conf->data, &vv);
         if (v != NULL)
-            return (v->value);
+            return v->value;
         else
-            return (NULL);
+            return NULL;
     } else
-        return (getenv(name));
+        return getenv(name);
 }
 
 static unsigned long conf_value_hash(const CONF_VALUE *v)
@@ -110,14 +110,14 @@ static int conf_value_cmp(const CONF_VALUE *a, const CONF_VALUE *b)
     if (a->section != b->section) {
         i = strcmp(a->section, b->section);
         if (i)
-            return (i);
+            return i;
     }
 
     if ((a->name != NULL) && (b->name != NULL)) {
         i = strcmp(a->name, b->name);
-        return (i);
+        return i;
     } else if (a->name == b->name)
-        return (0);
+        return 0;
     else
         return ((a->name == NULL) ? -1 : 1);
 }

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -186,7 +186,7 @@ CONF *NCONF_new(CONF_METHOD *meth)
     ret = meth->create(meth);
     if (ret == NULL) {
         CONFerr(CONF_F_NCONF_NEW, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
 
     return ret;

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -23,26 +23,26 @@ const char *OpenSSL_version(int t)
     if (t == OPENSSL_BUILT_ON) {
 #ifdef DATE
 # ifdef OPENSSL_USE_BUILD_DATE
-        return (DATE);
+        return DATE;
 # else
-        return ("built on: reproducible build, date unspecified");
+        return "built on: reproducible build, date unspecified";
 # endif
 #else
-        return ("built on: date not available");
+        return "built on: date not available";
 #endif
     }
     if (t == OPENSSL_CFLAGS) {
 #ifdef CFLAGS
-        return (CFLAGS);
+        return CFLAGS;
 #else
-        return ("compiler: information not available");
+        return "compiler: information not available";
 #endif
     }
     if (t == OPENSSL_PLATFORM) {
 #ifdef PLATFORM
-        return (PLATFORM);
+        return PLATFORM;
 #else
-        return ("platform: information not available");
+        return "platform: information not available";
 #endif
     }
     if (t == OPENSSL_DIR) {
@@ -59,5 +59,5 @@ const char *OpenSSL_version(int t)
         return "ENGINESDIR: N/A";
 #endif
     }
-    return ("not available");
+    return "not available";
 }

--- a/crypto/des/cbc_cksm.c
+++ b/crypto/des/cbc_cksm.c
@@ -49,5 +49,5 @@ DES_LONG DES_cbc_cksum(const unsigned char *in, DES_cblock *output,
         | ((tout1 >> 8L) & 0x0000FF00)
         | ((tout1 << 8L) & 0x00FF0000)
         | ((tout1 << 24L) & 0xFF000000);
-    return (tout1);
+    return tout1;
 }

--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -60,7 +60,7 @@ char *DES_crypt(const char *buf, const char *salt)
     static char buff[14];
 
 #ifndef CHARSET_EBCDIC
-    return (DES_fcrypt(buf, salt, buff));
+    return DES_fcrypt(buf, salt, buff);
 #else
     char e_salt[2 + 1];
     char e_buf[32 + 1];         /* replace 32 by 8 ? */
@@ -145,5 +145,5 @@ char *DES_fcrypt(const char *buf, const char *salt, char *ret)
         ret[i] = cov_2char[c];
     }
     ret[13] = '\0';
-    return (ret);
+    return ret;
 }

--- a/crypto/des/qud_cksm.c
+++ b/crypto/des/qud_cksm.c
@@ -72,5 +72,5 @@ DES_LONG DES_quad_cksum(const unsigned char *input, DES_cblock output[],
             *lp++ = z1;
         }
     }
-    return (z0);
+    return z0;
 }

--- a/crypto/des/rand_key.c
+++ b/crypto/des/rand_key.c
@@ -14,7 +14,7 @@ int DES_random_key(DES_cblock *ret)
 {
     do {
         if (RAND_bytes((unsigned char *)ret, sizeof(DES_cblock)) != 1)
-            return (0);
+            return 0;
     } while (DES_is_weak_key(ret));
     DES_set_odd_parity(ret);
     return 1;

--- a/crypto/des/set_key.c
+++ b/crypto/des/set_key.c
@@ -64,7 +64,7 @@ int DES_check_key_parity(const_DES_cblock *key)
 
     for (i = 0; i < DES_KEY_SZ; i++) {
         if ((*key)[i] != odd_parity[(*key)[i]])
-            return (0);
+            return 0;
     }
     return 1;
 }
@@ -106,7 +106,7 @@ int DES_is_weak_key(const_DES_cblock *key)
     for (i = 0; i < NUM_WEAK_KEY; i++)
         if (memcmp(weak_keys[i], key, sizeof(DES_cblock)) == 0)
             return 1;
-    return (0);
+    return 0;
 }
 
 /*-
@@ -293,9 +293,9 @@ int DES_set_key(const_DES_cblock *key, DES_key_schedule *schedule)
 int DES_set_key_checked(const_DES_cblock *key, DES_key_schedule *schedule)
 {
     if (!DES_check_key_parity(key))
-        return (-1);
+        return -1;
     if (DES_is_weak_key(key))
-        return (-2);
+        return -2;
     DES_set_key_unchecked(key, schedule);
     return 0;
 }
@@ -368,5 +368,5 @@ void DES_set_key_unchecked(const_DES_cblock *key, DES_key_schedule *schedule)
 
 int DES_key_sched(const_DES_cblock *key, DES_key_schedule *schedule)
 {
-    return (DES_set_key(key, schedule));
+    return DES_set_key(key, schedule);
 }

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -326,7 +326,7 @@ static int do_dh_print(BIO *bp, const DH *x, int indent, int ptype)
                 goto err;
         }
         if (BIO_write(bp, "\n", 1) <= 0)
-            return (0);
+            return 0;
     }
     if (x->counter && !ASN1_bn_print(bp, "counter:", x->counter, NULL, indent))
         goto err;
@@ -346,7 +346,7 @@ static int do_dh_print(BIO *bp, const DH *x, int indent, int ptype)
 
 static int int_dh_size(const EVP_PKEY *pkey)
 {
-    return (DH_size(pkey->pkey.dh));
+    return DH_size(pkey->pkey.dh);
 }
 
 static int dh_bits(const EVP_PKEY *pkey)

--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -49,7 +49,7 @@ int DH_check_params(const DH *dh, int *ret)
         BN_CTX_end(ctx);
         BN_CTX_free(ctx);
     }
-    return (ok);
+    return ok;
 }
 
 /*-
@@ -139,7 +139,7 @@ int DH_check(const DH *dh, int *ret)
         BN_CTX_end(ctx);
         BN_CTX_free(ctx);
     }
-    return (ok);
+    return ok;
 }
 
 int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
@@ -177,5 +177,5 @@ int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
         BN_CTX_end(ctx);
         BN_CTX_free(ctx);
     }
-    return (ok);
+    return ok;
 }

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -150,7 +150,7 @@ static int generate_key(DH *dh)
     if (priv_key != dh->priv_key)
         BN_free(priv_key);
     BN_CTX_free(ctx);
-    return (ok);
+    return ok;
 }
 
 static int compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
@@ -204,7 +204,7 @@ static int compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
         BN_CTX_end(ctx);
         BN_CTX_free(ctx);
     }
-    return (ret);
+    return ret;
 }
 
 static int dh_bn_mod_exp(const DH *dh, BIGNUM *r,

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -139,12 +139,12 @@ int DH_up_ref(DH *r)
 
 int DH_set_ex_data(DH *d, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&d->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&d->ex_data, idx, arg);
 }
 
 void *DH_get_ex_data(DH *d, int idx)
 {
-    return (CRYPTO_get_ex_data(&d->ex_data, idx));
+    return CRYPTO_get_ex_data(&d->ex_data, idx);
 }
 
 int DH_bits(const DH *dh)
@@ -154,7 +154,7 @@ int DH_bits(const DH *dh)
 
 int DH_size(const DH *dh)
 {
-    return (BN_num_bytes(dh->p));
+    return BN_num_bytes(dh->p);
 }
 
 int DH_security_bits(const DH *dh)

--- a/crypto/dh/dh_prn.c
+++ b/crypto/dh/dh_prn.c
@@ -20,11 +20,11 @@ int DHparams_print_fp(FILE *fp, const DH *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         DHerr(DH_F_DHPARAMS_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = DHparams_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -55,7 +55,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     case DLL_PROCESS_DETACH:
         break;
     }
-    return (TRUE);
+    return TRUE;
 }
 #endif
 

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -250,7 +250,7 @@ static int dsa_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
 
 static int int_dsa_size(const EVP_PKEY *pkey)
 {
-    return (DSA_size(pkey->pkey.dsa));
+    return DSA_size(pkey->pkey.dsa);
 }
 
 static int dsa_bits(const EVP_PKEY *pkey)
@@ -365,7 +365,7 @@ static int do_dsa_print(BIO *bp, const DSA *x, int off, int ptype)
         goto err;
     ret = 1;
  err:
-    return (ret);
+    return ret;
 }
 
 static int dsa_param_decode(EVP_PKEY *pkey,

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -115,7 +115,7 @@ int DSA_sign(int type, const unsigned char *dgst, int dlen,
     s = DSA_do_sign(dgst, dlen, dsa);
     if (s == NULL) {
         *siglen = 0;
-        return (0);
+        return 0;
     }
     *siglen = i2d_DSA_SIG(s, &sig);
     DSA_SIG_free(s);
@@ -140,7 +140,7 @@ int DSA_verify(int type, const unsigned char *dgst, int dgst_len,
 
     s = DSA_SIG_new();
     if (s == NULL)
-        return (ret);
+        return ret;
     if (d2i_DSA_SIG(&s, &p, siglen) == NULL)
         goto err;
     /* Ensure signature uses DER and doesn't have trailing garbage */
@@ -151,5 +151,5 @@ int DSA_verify(int type, const unsigned char *dgst, int dgst_len,
  err:
     OPENSSL_clear_free(der, derlen);
     DSA_SIG_free(s);
-    return (ret);
+    return ret;
 }

--- a/crypto/dsa/dsa_key.c
+++ b/crypto/dsa/dsa_key.c
@@ -73,5 +73,5 @@ static int dsa_builtin_keygen(DSA *dsa)
     if (priv_key != dsa->priv_key)
         BN_free(priv_key);
     BN_CTX_free(ctx);
-    return (ok);
+    return ok;
 }

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -160,17 +160,17 @@ int DSA_size(const DSA *r)
     i = i2d_ASN1_INTEGER(&bs, NULL);
     i += i;                     /* r and s */
     ret = ASN1_object_size(1, i, V_ASN1_SEQUENCE);
-    return (ret);
+    return ret;
 }
 
 int DSA_set_ex_data(DSA *d, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&d->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&d->ex_data, idx, arg);
 }
 
 void *DSA_get_ex_data(DSA *d, int idx)
 {
-    return (CRYPTO_get_ex_data(&d->ex_data, idx));
+    return CRYPTO_get_ex_data(&d->ex_data, idx);
 }
 
 int DSA_security_bits(const DSA *d)

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -332,7 +332,7 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
     BN_free(u1);
     BN_free(u2);
     BN_free(t1);
-    return (ret);
+    return ret;
 }
 
 static int dsa_init(DSA *dsa)

--- a/crypto/dsa/dsa_prn.c
+++ b/crypto/dsa/dsa_prn.c
@@ -20,12 +20,12 @@ int DSA_print_fp(FILE *fp, const DSA *x, int off)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         DSAerr(DSA_F_DSA_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = DSA_print(b, x, off);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 
 int DSAparams_print_fp(FILE *fp, const DSA *x)
@@ -35,12 +35,12 @@ int DSAparams_print_fp(FILE *fp, const DSA *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         DSAerr(DSA_F_DSAPARAMS_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = DSAparams_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 

--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -89,7 +89,7 @@ static int dl_load(DSO *dso)
     OPENSSL_free(filename);
     if (ptr != NULL)
         shl_unload(ptr);
-    return (0);
+    return 0;
 }
 
 static int dl_unload(DSO *dso)
@@ -97,7 +97,7 @@ static int dl_unload(DSO *dso)
     shl_t ptr;
     if (dso == NULL) {
         DSOerr(DSO_F_DL_UNLOAD, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if (sk_num(dso->meth_data) < 1)
         return 1;
@@ -109,7 +109,7 @@ static int dl_unload(DSO *dso)
          * Should push the value back onto the stack in case of a retry.
          */
         sk_push(dso->meth_data, (char *)ptr);
-        return (0);
+        return 0;
     }
     shl_unload(ptr);
     return 1;
@@ -122,25 +122,25 @@ static DSO_FUNC_TYPE dl_bind_func(DSO *dso, const char *symname)
 
     if ((dso == NULL) || (symname == NULL)) {
         DSOerr(DSO_F_DL_BIND_FUNC, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (sk_num(dso->meth_data) < 1) {
         DSOerr(DSO_F_DL_BIND_FUNC, DSO_R_STACK_ERROR);
-        return (NULL);
+        return NULL;
     }
     ptr = (shl_t) sk_value(dso->meth_data, sk_num(dso->meth_data) - 1);
     if (ptr == NULL) {
         DSOerr(DSO_F_DL_BIND_FUNC, DSO_R_NULL_HANDLE);
-        return (NULL);
+        return NULL;
     }
     if (shl_findsym(&ptr, symname, TYPE_UNDEFINED, &sym) < 0) {
         char errbuf[160];
         DSOerr(DSO_F_DL_BIND_FUNC, DSO_R_SYM_FAILURE);
         if (openssl_strerror_r(errno, errbuf, sizeof(errbuf)))
             ERR_add_error_data(4, "symname(", symname, "): ", errbuf);
-        return (NULL);
+        return NULL;
     }
-    return ((DSO_FUNC_TYPE)sym);
+    return (DSO_FUNC_TYPE)sym;
 }
 
 static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
@@ -149,7 +149,7 @@ static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
 
     if (!filespec1 && !filespec2) {
         DSOerr(DSO_F_DL_MERGER, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     /*
      * If the first file specification is a rooted path, it rules. same goes
@@ -159,7 +159,7 @@ static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
         merged = OPENSSL_strdup(filespec1);
         if (merged == NULL) {
             DSOerr(DSO_F_DL_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     }
     /*
@@ -169,7 +169,7 @@ static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
         merged = OPENSSL_strdup(filespec2);
         if (merged == NULL) {
             DSOerr(DSO_F_DL_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else
         /*
@@ -192,13 +192,13 @@ static char *dl_merger(DSO *dso, const char *filespec1, const char *filespec2)
         merged = OPENSSL_malloc(len + 2);
         if (merged == NULL) {
             DSOerr(DSO_F_DL_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
         strcpy(merged, filespec2);
         merged[spec2len] = '/';
         strcpy(&merged[spec2len + 1], filespec1);
     }
-    return (merged);
+    return merged;
 }
 
 /*
@@ -225,7 +225,7 @@ static char *dl_name_converter(DSO *dso, const char *filename)
     translated = OPENSSL_malloc(rsize);
     if (translated == NULL) {
         DSOerr(DSO_F_DL_NAME_CONVERTER, DSO_R_NAME_TRANSLATION_FAILED);
-        return (NULL);
+        return NULL;
     }
     if (transform) {
         if ((DSO_flags(dso) & DSO_FLAG_NAME_TRANSLATION_EXT_ONLY) == 0)
@@ -234,7 +234,7 @@ static char *dl_name_converter(DSO *dso, const char *filename)
             sprintf(translated, "%s%s", filename, DSO_EXTENSION);
     } else
         sprintf(translated, "%s", filename);
-    return (translated);
+    return translated;
 }
 
 static int dl_pathbyaddr(void *addr, char *path, int sz)

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -126,7 +126,7 @@ static int dlfcn_load(DSO *dso)
     OPENSSL_free(filename);
     if (ptr != NULL)
         dlclose(ptr);
-    return (0);
+    return 0;
 }
 
 static int dlfcn_unload(DSO *dso)
@@ -134,7 +134,7 @@ static int dlfcn_unload(DSO *dso)
     void *ptr;
     if (dso == NULL) {
         DSOerr(DSO_F_DLFCN_UNLOAD, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if (sk_void_num(dso->meth_data) < 1)
         return 1;
@@ -145,7 +145,7 @@ static int dlfcn_unload(DSO *dso)
          * Should push the value back onto the stack in case of a retry.
          */
         sk_void_push(dso->meth_data, ptr);
-        return (0);
+        return 0;
     }
     /* For now I'm not aware of any errors associated with dlclose() */
     dlclose(ptr);
@@ -162,22 +162,22 @@ static DSO_FUNC_TYPE dlfcn_bind_func(DSO *dso, const char *symname)
 
     if ((dso == NULL) || (symname == NULL)) {
         DSOerr(DSO_F_DLFCN_BIND_FUNC, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (sk_void_num(dso->meth_data) < 1) {
         DSOerr(DSO_F_DLFCN_BIND_FUNC, DSO_R_STACK_ERROR);
-        return (NULL);
+        return NULL;
     }
     ptr = sk_void_value(dso->meth_data, sk_void_num(dso->meth_data) - 1);
     if (ptr == NULL) {
         DSOerr(DSO_F_DLFCN_BIND_FUNC, DSO_R_NULL_HANDLE);
-        return (NULL);
+        return NULL;
     }
     u.dlret = dlsym(ptr, symname);
     if (u.dlret == NULL) {
         DSOerr(DSO_F_DLFCN_BIND_FUNC, DSO_R_SYM_FAILURE);
         ERR_add_error_data(4, "symname(", symname, "): ", dlerror());
-        return (NULL);
+        return NULL;
     }
     return u.sym;
 }
@@ -189,7 +189,7 @@ static char *dlfcn_merger(DSO *dso, const char *filespec1,
 
     if (!filespec1 && !filespec2) {
         DSOerr(DSO_F_DLFCN_MERGER, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     /*
      * If the first file specification is a rooted path, it rules. same goes
@@ -199,7 +199,7 @@ static char *dlfcn_merger(DSO *dso, const char *filespec1,
         merged = OPENSSL_strdup(filespec1);
         if (merged == NULL) {
             DSOerr(DSO_F_DLFCN_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     }
     /*
@@ -209,7 +209,7 @@ static char *dlfcn_merger(DSO *dso, const char *filespec1,
         merged = OPENSSL_strdup(filespec2);
         if (merged == NULL) {
             DSOerr(DSO_F_DLFCN_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else {
         /*
@@ -231,13 +231,13 @@ static char *dlfcn_merger(DSO *dso, const char *filespec1,
         merged = OPENSSL_malloc(len + 2);
         if (merged == NULL) {
             DSOerr(DSO_F_DLFCN_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
         strcpy(merged, filespec2);
         merged[spec2len] = '/';
         strcpy(&merged[spec2len + 1], filespec1);
     }
-    return (merged);
+    return merged;
 }
 
 static char *dlfcn_name_converter(DSO *dso, const char *filename)
@@ -257,7 +257,7 @@ static char *dlfcn_name_converter(DSO *dso, const char *filename)
     translated = OPENSSL_malloc(rsize);
     if (translated == NULL) {
         DSOerr(DSO_F_DLFCN_NAME_CONVERTER, DSO_R_NAME_TRANSLATION_FAILED);
-        return (NULL);
+        return NULL;
     }
     if (transform) {
         if ((DSO_flags(dso) & DSO_FLAG_NAME_TRANSLATION_EXT_ONLY) == 0)
@@ -266,7 +266,7 @@ static char *dlfcn_name_converter(DSO *dso, const char *filename)
             sprintf(translated, "%s" DSO_EXTENSION, filename);
     } else
         sprintf(translated, "%s", filename);
-    return (translated);
+    return translated;
 }
 
 # ifdef __sgi

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -27,14 +27,14 @@ static DSO *DSO_new_method(DSO_METHOD *meth)
     ret = OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         DSOerr(DSO_F_DSO_NEW_METHOD, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
     ret->meth_data = sk_void_new_null();
     if (ret->meth_data == NULL) {
         /* sk_new doesn't generate any errors so we do */
         DSOerr(DSO_F_DSO_NEW_METHOD, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(ret);
-        return (NULL);
+        return NULL;
     }
     ret->meth = default_DSO_meth;
     ret->references = 1;
@@ -163,11 +163,11 @@ DSO *DSO_load(DSO *dso, const char *filename, DSO_METHOD *meth, int flags)
         goto err;
     }
     /* Load succeeded */
-    return (ret);
+    return ret;
  err:
     if (allocated)
         DSO_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 DSO_FUNC_TYPE DSO_bind_func(DSO *dso, const char *symname)
@@ -176,18 +176,18 @@ DSO_FUNC_TYPE DSO_bind_func(DSO *dso, const char *symname)
 
     if ((dso == NULL) || (symname == NULL)) {
         DSOerr(DSO_F_DSO_BIND_FUNC, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (dso->meth->dso_bind_func == NULL) {
         DSOerr(DSO_F_DSO_BIND_FUNC, DSO_R_UNSUPPORTED);
-        return (NULL);
+        return NULL;
     }
     if ((ret = dso->meth->dso_bind_func(dso, symname)) == NULL) {
         DSOerr(DSO_F_DSO_BIND_FUNC, DSO_R_SYM_FAILURE);
-        return (NULL);
+        return NULL;
     }
     /* Success */
-    return (ret);
+    return ret;
 }
 
 /*
@@ -203,7 +203,7 @@ long DSO_ctrl(DSO *dso, int cmd, long larg, void *parg)
 {
     if (dso == NULL) {
         DSOerr(DSO_F_DSO_CTRL, ERR_R_PASSED_NULL_PARAMETER);
-        return (-1);
+        return -1;
     }
     /*
      * We should intercept certain generic commands and only pass control to
@@ -214,27 +214,27 @@ long DSO_ctrl(DSO *dso, int cmd, long larg, void *parg)
         return dso->flags;
     case DSO_CTRL_SET_FLAGS:
         dso->flags = (int)larg;
-        return (0);
+        return 0;
     case DSO_CTRL_OR_FLAGS:
         dso->flags |= (int)larg;
-        return (0);
+        return 0;
     default:
         break;
     }
     if ((dso->meth == NULL) || (dso->meth->dso_ctrl == NULL)) {
         DSOerr(DSO_F_DSO_CTRL, DSO_R_UNSUPPORTED);
-        return (-1);
+        return -1;
     }
-    return (dso->meth->dso_ctrl(dso, cmd, larg, parg));
+    return dso->meth->dso_ctrl(dso, cmd, larg, parg);
 }
 
 const char *DSO_get_filename(DSO *dso)
 {
     if (dso == NULL) {
         DSOerr(DSO_F_DSO_GET_FILENAME, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
-    return (dso->filename);
+    return dso->filename;
 }
 
 int DSO_set_filename(DSO *dso, const char *filename)
@@ -243,17 +243,17 @@ int DSO_set_filename(DSO *dso, const char *filename)
 
     if ((dso == NULL) || (filename == NULL)) {
         DSOerr(DSO_F_DSO_SET_FILENAME, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if (dso->loaded_filename) {
         DSOerr(DSO_F_DSO_SET_FILENAME, DSO_R_DSO_ALREADY_LOADED);
-        return (0);
+        return 0;
     }
     /* We'll duplicate filename */
     copied = OPENSSL_strdup(filename);
     if (copied == NULL) {
         DSOerr(DSO_F_DSO_SET_FILENAME, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
     OPENSSL_free(dso->filename);
     dso->filename = copied;
@@ -266,7 +266,7 @@ char *DSO_merge(DSO *dso, const char *filespec1, const char *filespec2)
 
     if (dso == NULL || filespec1 == NULL) {
         DSOerr(DSO_F_DSO_MERGE, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if ((dso->flags & DSO_FLAG_NO_NAME_TRANSLATION) == 0) {
         if (dso->merger != NULL)
@@ -274,7 +274,7 @@ char *DSO_merge(DSO *dso, const char *filespec1, const char *filespec2)
         else if (dso->meth->dso_merger != NULL)
             result = dso->meth->dso_merger(dso, filespec1, filespec2);
     }
-    return (result);
+    return result;
 }
 
 char *DSO_convert_filename(DSO *dso, const char *filename)
@@ -283,13 +283,13 @@ char *DSO_convert_filename(DSO *dso, const char *filename)
 
     if (dso == NULL) {
         DSOerr(DSO_F_DSO_CONVERT_FILENAME, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (filename == NULL)
         filename = dso->filename;
     if (filename == NULL) {
         DSOerr(DSO_F_DSO_CONVERT_FILENAME, DSO_R_NO_FILENAME);
-        return (NULL);
+        return NULL;
     }
     if ((dso->flags & DSO_FLAG_NO_NAME_TRANSLATION) == 0) {
         if (dso->name_converter != NULL)
@@ -301,10 +301,10 @@ char *DSO_convert_filename(DSO *dso, const char *filename)
         result = OPENSSL_strdup(filename);
         if (result == NULL) {
             DSOerr(DSO_F_DSO_CONVERT_FILENAME, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     }
-    return (result);
+    return result;
 }
 
 int DSO_pathbyaddr(void *addr, char *path, int sz)

--- a/crypto/dso/dso_vms.c
+++ b/crypto/dso/dso_vms.c
@@ -212,7 +212,7 @@ static int vms_load(DSO *dso)
     /* Cleanup! */
     OPENSSL_free(p);
     OPENSSL_free(filename);
-    return (0);
+    return 0;
 }
 
 /*
@@ -225,14 +225,14 @@ static int vms_unload(DSO *dso)
     DSO_VMS_INTERNAL *p;
     if (dso == NULL) {
         DSOerr(DSO_F_VMS_UNLOAD, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if (sk_void_num(dso->meth_data) < 1)
         return 1;
     p = (DSO_VMS_INTERNAL *)sk_void_pop(dso->meth_data);
     if (p == NULL) {
         DSOerr(DSO_F_VMS_UNLOAD, DSO_R_NULL_HANDLE);
-        return (0);
+        return 0;
     }
     /* Cleanup */
     OPENSSL_free(p);
@@ -441,7 +441,7 @@ static char *vms_merger(DSO *dso, const char *filespec1,
                                "filespec \"", filespec1, "\", ",
                                "defaults \"", filespec2, "\": ", errstring);
         }
-        return (NULL);
+        return NULL;
     }
 
     merged = OPENSSL_malloc(nam.NAMX_ESL + 1);
@@ -449,7 +449,7 @@ static char *vms_merger(DSO *dso, const char *filespec1,
         goto malloc_err;
     strncpy(merged, nam.NAMX_ESA, nam.NAMX_ESL);
     merged[nam.NAMX_ESL] = '\0';
-    return (merged);
+    return merged;
  malloc_err:
     DSOerr(DSO_F_VMS_MERGER, ERR_R_MALLOC_FAILURE);
 }
@@ -460,7 +460,7 @@ static char *vms_name_converter(DSO *dso, const char *filename)
     char *not_translated = OPENSSL_malloc(len + 1);
     if (not_translated != NULL)
         strcpy(not_translated, filename);
-    return (not_translated);
+    return not_translated;
 }
 
 #endif                          /* OPENSSL_SYS_VMS */

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -127,7 +127,7 @@ static int win32_load(DSO *dso)
     OPENSSL_free(p);
     if (h != NULL)
         FreeLibrary(h);
-    return (0);
+    return 0;
 }
 
 static int win32_unload(DSO *dso)
@@ -135,14 +135,14 @@ static int win32_unload(DSO *dso)
     HINSTANCE *p;
     if (dso == NULL) {
         DSOerr(DSO_F_WIN32_UNLOAD, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if (sk_void_num(dso->meth_data) < 1)
         return 1;
     p = sk_void_pop(dso->meth_data);
     if (p == NULL) {
         DSOerr(DSO_F_WIN32_UNLOAD, DSO_R_NULL_HANDLE);
-        return (0);
+        return 0;
     }
     if (!FreeLibrary(*p)) {
         DSOerr(DSO_F_WIN32_UNLOAD, DSO_R_UNLOAD_FAILED);
@@ -150,7 +150,7 @@ static int win32_unload(DSO *dso)
          * We should push the value back onto the stack in case of a retry.
          */
         sk_void_push(dso->meth_data, p);
-        return (0);
+        return 0;
     }
     /* Cleanup */
     OPENSSL_free(p);
@@ -167,24 +167,24 @@ static DSO_FUNC_TYPE win32_bind_func(DSO *dso, const char *symname)
 
     if ((dso == NULL) || (symname == NULL)) {
         DSOerr(DSO_F_WIN32_BIND_FUNC, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (sk_void_num(dso->meth_data) < 1) {
         DSOerr(DSO_F_WIN32_BIND_FUNC, DSO_R_STACK_ERROR);
-        return (NULL);
+        return NULL;
     }
     ptr = sk_void_value(dso->meth_data, sk_void_num(dso->meth_data) - 1);
     if (ptr == NULL) {
         DSOerr(DSO_F_WIN32_BIND_FUNC, DSO_R_NULL_HANDLE);
-        return (NULL);
+        return NULL;
     }
     sym.f = GetProcAddress(*ptr, symname);
     if (sym.p == NULL) {
         DSOerr(DSO_F_WIN32_BIND_FUNC, DSO_R_SYM_FAILURE);
         ERR_add_error_data(3, "symname(", symname, ")");
-        return (NULL);
+        return NULL;
     }
-    return ((DSO_FUNC_TYPE)sym.f);
+    return (DSO_FUNC_TYPE)sym.f;
 }
 
 struct file_st {
@@ -210,13 +210,13 @@ static struct file_st *win32_splitter(DSO *dso, const char *filename,
 
     if (!filename) {
         DSOerr(DSO_F_WIN32_SPLITTER, DSO_R_NO_FILENAME);
-        return (NULL);
+        return NULL;
     }
 
     result = OPENSSL_zalloc(sizeof(*result));
     if (result == NULL) {
         DSOerr(DSO_F_WIN32_SPLITTER, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
 
     position = IN_DEVICE;
@@ -236,7 +236,7 @@ static struct file_st *win32_splitter(DSO *dso, const char *filename,
             if (position != IN_DEVICE) {
                 DSOerr(DSO_F_WIN32_SPLITTER, DSO_R_INCORRECT_FILE_SYNTAX);
                 OPENSSL_free(result);
-                return (NULL);
+                return NULL;
             }
             result->device = start;
             result->devicelen = (int)(filename - start);
@@ -297,7 +297,7 @@ static struct file_st *win32_splitter(DSO *dso, const char *filename,
     if (!result->filelen)
         result->file = NULL;
 
-    return (result);
+    return result;
 }
 
 static char *win32_joiner(DSO *dso, const struct file_st *file_split)
@@ -308,7 +308,7 @@ static char *win32_joiner(DSO *dso, const struct file_st *file_split)
 
     if (!file_split) {
         DSOerr(DSO_F_WIN32_JOINER, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (file_split->node) {
         len += 2 + file_split->nodelen; /* 2 for starting \\ */
@@ -329,13 +329,13 @@ static char *win32_joiner(DSO *dso, const struct file_st *file_split)
 
     if (!len) {
         DSOerr(DSO_F_WIN32_JOINER, DSO_R_EMPTY_FILE_STRUCTURE);
-        return (NULL);
+        return NULL;
     }
 
     result = OPENSSL_malloc(len + 1);
     if (result == NULL) {
         DSOerr(DSO_F_WIN32_JOINER, ERR_R_MALLOC_FAILURE);
-        return (NULL);
+        return NULL;
     }
 
     if (file_split->node) {
@@ -383,7 +383,7 @@ static char *win32_joiner(DSO *dso, const struct file_st *file_split)
     strncpy(&result[offset], file_split->file, file_split->filelen);
     offset += file_split->filelen;
     result[offset] = '\0';
-    return (result);
+    return result;
 }
 
 static char *win32_merger(DSO *dso, const char *filespec1,
@@ -395,31 +395,31 @@ static char *win32_merger(DSO *dso, const char *filespec1,
 
     if (!filespec1 && !filespec2) {
         DSOerr(DSO_F_WIN32_MERGER, ERR_R_PASSED_NULL_PARAMETER);
-        return (NULL);
+        return NULL;
     }
     if (!filespec2) {
         merged = OPENSSL_strdup(filespec1);
         if (merged == NULL) {
             DSOerr(DSO_F_WIN32_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else if (!filespec1) {
         merged = OPENSSL_strdup(filespec2);
         if (merged == NULL) {
             DSOerr(DSO_F_WIN32_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else {
         filespec1_split = win32_splitter(dso, filespec1, 0);
         if (!filespec1_split) {
             DSOerr(DSO_F_WIN32_MERGER, ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
         filespec2_split = win32_splitter(dso, filespec2, 1);
         if (!filespec2_split) {
             DSOerr(DSO_F_WIN32_MERGER, ERR_R_MALLOC_FAILURE);
             OPENSSL_free(filespec1_split);
-            return (NULL);
+            return NULL;
         }
 
         /* Fill in into filespec1_split */
@@ -446,7 +446,7 @@ static char *win32_merger(DSO *dso, const char *filespec1,
     }
     OPENSSL_free(filespec1_split);
     OPENSSL_free(filespec2_split);
-    return (merged);
+    return merged;
 }
 
 static char *win32_name_converter(DSO *dso, const char *filename)
@@ -466,13 +466,13 @@ static char *win32_name_converter(DSO *dso, const char *filename)
         translated = OPENSSL_malloc(len + 1);
     if (translated == NULL) {
         DSOerr(DSO_F_WIN32_NAME_CONVERTER, DSO_R_NAME_TRANSLATION_FAILED);
-        return (NULL);
+        return NULL;
     }
     if (transform)
         sprintf(translated, "%s.dll", filename);
     else
         sprintf(translated, "%s", filename);
-    return (translated);
+    return translated;
 }
 
 static const char *openssl_strnchr(const char *string, int c, size_t len)

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -360,7 +360,7 @@ static int ec_asn1_group2fieldid(const EC_GROUP *group, X9_62_FIELDID *field)
 
  err:
     BN_free(tmp);
-    return (ok);
+    return ok;
 }
 
 static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
@@ -466,7 +466,7 @@ static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
     OPENSSL_free(buffer_2);
     BN_free(tmp_1);
     BN_free(tmp_2);
-    return (ok);
+    return ok;
 }
 
 ECPARAMETERS *EC_GROUP_get_ecparameters(const EC_GROUP *group,
@@ -828,7 +828,7 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
     BN_free(a);
     BN_free(b);
     EC_POINT_free(point);
-    return (ret);
+    return ret;
 }
 
 EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params)
@@ -894,7 +894,7 @@ EC_GROUP *d2i_ECPKParameters(EC_GROUP **a, const unsigned char **in, long len)
 
     ECPKPARAMETERS_free(params);
     *in = p;
-    return (group);
+    return group;
 }
 
 int i2d_ECPKParameters(const EC_GROUP *a, unsigned char **out)
@@ -911,7 +911,7 @@ int i2d_ECPKParameters(const EC_GROUP *a, unsigned char **out)
         return 0;
     }
     ECPKPARAMETERS_free(tmp);
-    return (ret);
+    return ret;
 }
 
 /* some EC_KEY functions */
@@ -986,7 +986,7 @@ EC_KEY *d2i_ECPrivateKey(EC_KEY **a, const unsigned char **in, long len)
         *a = ret;
     EC_PRIVATEKEY_free(priv_key);
     *in = p;
-    return (ret);
+    return ret;
 
  err:
     if (a == NULL || *a != ret)
@@ -1234,5 +1234,5 @@ int ECDSA_size(const EC_KEY *r)
     i = i2d_ASN1_INTEGER(&bs, NULL);
     i += i;                     /* r and s */
     ret = ASN1_object_size(1, i, V_ASN1_SEQUENCE);
-    return (ret);
+    return ret;
 }

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -237,7 +237,7 @@ EC_GROUP *EC_GROUP_dup(const EC_GROUP *a)
         return NULL;
 
     if ((t = EC_GROUP_new(a->meth)) == NULL)
-        return (NULL);
+        return NULL;
     if (!EC_GROUP_copy(t, a))
         goto err;
 
@@ -623,7 +623,7 @@ EC_POINT *EC_POINT_dup(const EC_POINT *a, const EC_GROUP *group)
 
     t = EC_POINT_new(group);
     if (t == NULL)
-        return (NULL);
+        return NULL;
     r = EC_POINT_copy(t, a);
     if (!r) {
         EC_POINT_free(t);

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -182,7 +182,7 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
         BN_CTX_free(ctx);
     EC_POINT_free(tmp_point);
     BN_clear_free(X);
-    return (ret);
+    return ret;
 }
 
 int ossl_ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in, BIGNUM **kinvp,
@@ -327,7 +327,7 @@ int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
 
     s = ECDSA_SIG_new();
     if (s == NULL)
-        return (ret);
+        return ret;
     if (d2i_ECDSA_SIG(&s, &p, sig_len) == NULL)
         goto err;
     /* Ensure signature uses DER and doesn't have trailing garbage */
@@ -338,7 +338,7 @@ int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
  err:
     OPENSSL_clear_free(der, derlen);
     ECDSA_SIG_free(s);
-    return (ret);
+    return ret;
 }
 
 int ossl_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,

--- a/crypto/ec/eck_prn.c
+++ b/crypto/ec/eck_prn.c
@@ -22,12 +22,12 @@ int ECPKParameters_print_fp(FILE *fp, const EC_GROUP *x, int off)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ECerr(EC_F_ECPKPARAMETERS_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = ECPKParameters_print(b, x, off);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 
 int EC_KEY_print_fp(FILE *fp, const EC_KEY *x, int off)
@@ -37,12 +37,12 @@ int EC_KEY_print_fp(FILE *fp, const EC_KEY *x, int off)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ECerr(EC_F_EC_KEY_PRINT_FP, ERR_R_BIO_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = EC_KEY_print(b, x, off);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 
 int ECParameters_print_fp(FILE *fp, const EC_KEY *x)
@@ -52,12 +52,12 @@ int ECParameters_print_fp(FILE *fp, const EC_KEY *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         ECerr(EC_F_ECPARAMETERS_PRINT_FP, ERR_R_BIO_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = ECParameters_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -226,7 +226,7 @@ int ECPKParameters_print(BIO *bp, const EC_GROUP *x, int off)
     BN_free(b);
     BN_free(gen);
     BN_CTX_free(ctx);
-    return (ret);
+    return ret;
 }
 
 static int print_bin(BIO *fp, const char *name, const unsigned char *buf,

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -174,12 +174,12 @@ void engine_cleanup_int(void)
 
 int ENGINE_set_ex_data(ENGINE *e, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&e->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&e->ex_data, idx, arg);
 }
 
 void *ENGINE_get_ex_data(const ENGINE *e, int idx)
 {
-    return (CRYPTO_get_ex_data(&e->ex_data, idx));
+    return CRYPTO_get_ex_data(&e->ex_data, idx);
 }
 
 /*

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -418,50 +418,50 @@ void ERR_clear_error(void)
 
 unsigned long ERR_get_error(void)
 {
-    return (get_error_values(1, 0, NULL, NULL, NULL, NULL));
+    return get_error_values(1, 0, NULL, NULL, NULL, NULL);
 }
 
 unsigned long ERR_get_error_line(const char **file, int *line)
 {
-    return (get_error_values(1, 0, file, line, NULL, NULL));
+    return get_error_values(1, 0, file, line, NULL, NULL);
 }
 
 unsigned long ERR_get_error_line_data(const char **file, int *line,
                                       const char **data, int *flags)
 {
-    return (get_error_values(1, 0, file, line, data, flags));
+    return get_error_values(1, 0, file, line, data, flags);
 }
 
 unsigned long ERR_peek_error(void)
 {
-    return (get_error_values(0, 0, NULL, NULL, NULL, NULL));
+    return get_error_values(0, 0, NULL, NULL, NULL, NULL);
 }
 
 unsigned long ERR_peek_error_line(const char **file, int *line)
 {
-    return (get_error_values(0, 0, file, line, NULL, NULL));
+    return get_error_values(0, 0, file, line, NULL, NULL);
 }
 
 unsigned long ERR_peek_error_line_data(const char **file, int *line,
                                        const char **data, int *flags)
 {
-    return (get_error_values(0, 0, file, line, data, flags));
+    return get_error_values(0, 0, file, line, data, flags);
 }
 
 unsigned long ERR_peek_last_error(void)
 {
-    return (get_error_values(0, 1, NULL, NULL, NULL, NULL));
+    return get_error_values(0, 1, NULL, NULL, NULL, NULL);
 }
 
 unsigned long ERR_peek_last_error_line(const char **file, int *line)
 {
-    return (get_error_values(0, 1, file, line, NULL, NULL));
+    return get_error_values(0, 1, file, line, NULL, NULL);
 }
 
 unsigned long ERR_peek_last_error_line_data(const char **file, int *line,
                                             const char **data, int *flags)
 {
-    return (get_error_values(0, 1, file, line, data, flags));
+    return get_error_values(0, 1, file, line, data, flags);
 }
 
 static unsigned long get_error_values(int inc, int top, const char **file,

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -113,7 +113,7 @@ static int b64_read(BIO *b, char *out, int outl)
     BIO *next;
 
     if (out == NULL)
-        return (0);
+        return 0;
     ctx = (BIO_B64_CTX *)BIO_get_data(b);
 
     next = BIO_next(b);
@@ -346,7 +346,7 @@ static int b64_write(BIO *b, const char *in, int inl)
         i = BIO_write(next, &(ctx->buf[ctx->buf_off]), n);
         if (i <= 0) {
             BIO_copy_next_retry(b);
-            return (i);
+            return i;
         }
         OPENSSL_assert(i <= n);
         ctx->buf_off += i;
@@ -359,7 +359,7 @@ static int b64_write(BIO *b, const char *in, int inl)
     ctx->buf_len = 0;
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
 
     while (inl > 0) {
         n = (inl > B64_BLOCK_SIZE) ? B64_BLOCK_SIZE : inl;
@@ -432,7 +432,7 @@ static int b64_write(BIO *b, const char *in, int inl)
         ctx->buf_len = 0;
         ctx->buf_off = 0;
     }
-    return (ret);
+    return ret;
 }
 
 static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -534,7 +534,7 @@ static long b64_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
         ret = BIO_callback_ctrl(next, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int b64_puts(BIO *b, const char *str)

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -57,7 +57,7 @@ static const BIO_METHOD methods_enc = {
 
 const BIO_METHOD *BIO_f_cipher(void)
 {
-    return (&methods_enc);
+    return &methods_enc;
 }
 
 static int enc_new(BIO *bi)
@@ -108,7 +108,7 @@ static int enc_read(BIO *b, char *out, int outl)
     BIO *next;
 
     if (out == NULL)
-        return (0);
+        return 0;
     ctx = BIO_get_data(b);
 
     next = BIO_next(b);
@@ -248,7 +248,7 @@ static int enc_write(BIO *b, const char *in, int inl)
         i = BIO_write(next, &(ctx->buf[ctx->buf_off]), n);
         if (i <= 0) {
             BIO_copy_next_retry(b);
-            return (i);
+            return i;
         }
         ctx->buf_off += i;
         n -= i;
@@ -256,7 +256,7 @@ static int enc_write(BIO *b, const char *in, int inl)
     /* at this point all pending data has been written */
 
     if ((in == NULL) || (inl <= 0))
-        return (0);
+        return 0;
 
     ctx->buf_off = 0;
     while (inl > 0) {
@@ -286,7 +286,7 @@ static int enc_write(BIO *b, const char *in, int inl)
         ctx->buf_off = 0;
     }
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -381,7 +381,7 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = BIO_ctrl(next, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static long enc_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -390,13 +390,13 @@ static long enc_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     BIO *next = BIO_next(b);
 
     if (next == NULL)
-        return (0);
+        return 0;
     switch (cmd) {
     default:
         ret = BIO_callback_ctrl(next, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 int BIO_set_cipher(BIO *b, const EVP_CIPHER *c, const unsigned char *k,

--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -46,7 +46,7 @@ static const BIO_METHOD methods_md = {
 
 const BIO_METHOD *BIO_f_md(void)
 {
-    return (&methods_md);
+    return &methods_md;
 }
 
 static int md_new(BIO *bi)
@@ -55,7 +55,7 @@ static int md_new(BIO *bi)
 
     ctx = EVP_MD_CTX_new();
     if (ctx == NULL)
-        return (0);
+        return 0;
 
     BIO_set_init(bi, 1);
     BIO_set_data(bi, ctx);
@@ -66,7 +66,7 @@ static int md_new(BIO *bi)
 static int md_free(BIO *a)
 {
     if (a == NULL)
-        return (0);
+        return 0;
     EVP_MD_CTX_free(BIO_get_data(a));
     BIO_set_data(a, NULL);
     BIO_set_init(a, 0);
@@ -81,25 +81,25 @@ static int md_read(BIO *b, char *out, int outl)
     BIO *next;
 
     if (out == NULL)
-        return (0);
+        return 0;
 
     ctx = BIO_get_data(b);
     next = BIO_next(b);
 
     if ((ctx == NULL) || (next == NULL))
-        return (0);
+        return 0;
 
     ret = BIO_read(next, out, outl);
     if (BIO_get_init(b)) {
         if (ret > 0) {
             if (EVP_DigestUpdate(ctx, (unsigned char *)out,
                                  (unsigned int)ret) <= 0)
-                return (-1);
+                return -1;
         }
     }
     BIO_clear_retry_flags(b);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static int md_write(BIO *b, const char *in, int inl)
@@ -194,7 +194,7 @@ static long md_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = BIO_ctrl(next, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static long md_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -212,7 +212,7 @@ static long md_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
         ret = BIO_callback_ctrl(next, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int md_gets(BIO *bp, char *buf, int size)
@@ -228,5 +228,5 @@ static int md_gets(BIO *bp, char *buf, int size)
     if (EVP_DigestFinal_ex(ctx, (unsigned char *)buf, &ret) <= 0)
         return -1;
 
-    return ((int)ret);
+    return (int)ret;
 }

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -125,7 +125,7 @@ static const BIO_METHOD methods_ok = {
 
 const BIO_METHOD *BIO_f_reliable(void)
 {
-    return (&methods_ok);
+    return &methods_ok;
 }
 
 static int ok_new(BIO *bi)
@@ -266,7 +266,7 @@ static int ok_write(BIO *b, const char *in, int inl)
     ret = inl;
 
     if ((ctx == NULL) || (next == NULL) || (BIO_get_init(b) == 0))
-        return (0);
+        return 0;
 
     if (ctx->sigio && !sig_out(b))
         return 0;
@@ -280,7 +280,7 @@ static int ok_write(BIO *b, const char *in, int inl)
                 BIO_copy_next_retry(b);
                 if (!BIO_should_retry(b))
                     ctx->cont = 0;
-                return (i);
+                return i;
             }
             ctx->buf_off += i;
             n -= i;
@@ -294,7 +294,7 @@ static int ok_write(BIO *b, const char *in, int inl)
         }
 
         if ((in == NULL) || (inl <= 0))
-            return (0);
+            return 0;
 
         n = (inl + ctx->buf_len > OK_BLOCK_SIZE + OK_BLOCK_BLOCK) ?
             (int)(OK_BLOCK_SIZE + OK_BLOCK_BLOCK - ctx->buf_len) : inl;
@@ -314,7 +314,7 @@ static int ok_write(BIO *b, const char *in, int inl)
 
     BIO_clear_retry_flags(b);
     BIO_copy_next_retry(b);
-    return (ret);
+    return ret;
 }
 
 static long ok_ctrl(BIO *b, int cmd, long num, void *ptr)

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -140,7 +140,7 @@ static const EVP_CIPHER chacha20 = {
 
 const EVP_CIPHER *EVP_chacha20(void)
 {
-    return (&chacha20);
+    return &chacha20;
 }
 
 # ifndef OPENSSL_NO_POLY1305

--- a/crypto/evp/e_null.c
+++ b/crypto/evp/e_null.c
@@ -32,7 +32,7 @@ static const EVP_CIPHER n_cipher = {
 
 const EVP_CIPHER *EVP_enc_null(void)
 {
-    return (&n_cipher);
+    return &n_cipher;
 }
 
 static int null_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -72,12 +72,12 @@ static const EVP_CIPHER r2_40_cbc_cipher = {
 
 const EVP_CIPHER *EVP_rc2_64_cbc(void)
 {
-    return (&r2_64_cbc_cipher);
+    return &r2_64_cbc_cipher;
 }
 
 const EVP_CIPHER *EVP_rc2_40_cbc(void)
 {
-    return (&r2_40_cbc_cipher);
+    return &r2_40_cbc_cipher;
 }
 
 static int rc2_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
@@ -94,13 +94,13 @@ static int rc2_meth_to_magic(EVP_CIPHER_CTX *e)
 
     EVP_CIPHER_CTX_ctrl(e, EVP_CTRL_GET_RC2_KEY_BITS, 0, &i);
     if (i == 128)
-        return (RC2_128_MAGIC);
+        return RC2_128_MAGIC;
     else if (i == 64)
-        return (RC2_64_MAGIC);
+        return RC2_64_MAGIC;
     else if (i == 40)
-        return (RC2_40_MAGIC);
+        return RC2_40_MAGIC;
     else
-        return (0);
+        return 0;
 }
 
 static int rc2_magic_to_meth(int i)
@@ -113,7 +113,7 @@ static int rc2_magic_to_meth(int i)
         return 40;
     else {
         EVPerr(EVP_F_RC2_MAGIC_TO_METH, EVP_R_UNSUPPORTED_KEY_SIZE);
-        return (0);
+        return 0;
     }
 }
 
@@ -155,7 +155,7 @@ static int rc2_set_asn1_type_and_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
                                           (unsigned char *)EVP_CIPHER_CTX_original_iv(c),
                                           j);
     }
-    return (i);
+    return i;
 }
 
 static int rc2_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)

--- a/crypto/evp/e_rc4.c
+++ b/crypto/evp/e_rc4.c
@@ -58,12 +58,12 @@ static const EVP_CIPHER r4_40_cipher = {
 
 const EVP_CIPHER *EVP_rc4(void)
 {
-    return (&r4_cipher);
+    return &r4_cipher;
 }
 
 const EVP_CIPHER *EVP_rc4_40(void)
 {
-    return (&r4_40_cipher);
+    return &r4_40_cipher;
 }
 
 static int rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -257,6 +257,6 @@ static EVP_CIPHER r4_hmac_md5_cipher = {
 
 const EVP_CIPHER *EVP_rc4_hmac_md5(void)
 {
-    return (&r4_hmac_md5_cipher);
+    return &r4_hmac_md5_cipher;
 }
 #endif

--- a/crypto/evp/e_xcbc_d.c
+++ b/crypto/evp/e_xcbc_d.c
@@ -46,7 +46,7 @@ static const EVP_CIPHER d_xcbc_cipher = {
 
 const EVP_CIPHER *EVP_desx_cbc(void)
 {
-    return (&d_xcbc_cipher);
+    return &d_xcbc_cipher;
 }
 
 static int desx_cbc_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -212,7 +212,7 @@ int EVP_EncodeBlock(unsigned char *t, const unsigned char *f, int dlen)
     }
 
     *t = '\0';
-    return (ret);
+    return ret;
 }
 
 void EVP_DecodeInit(EVP_ENCODE_CTX *ctx)
@@ -345,7 +345,7 @@ end:
     /* Legacy behaviour. This should probably rather be zeroed on error. */
     *outl = ret;
     ctx->num = n;
-    return (rv);
+    return rv;
 }
 
 int EVP_DecodeBlock(unsigned char *t, const unsigned char *f, int n)
@@ -367,7 +367,7 @@ int EVP_DecodeBlock(unsigned char *t, const unsigned char *f, int n)
         n--;
 
     if (n % 4 != 0)
-        return (-1);
+        return -1;
 
     for (i = 0; i < n; i += 4) {
         a = conv_ascii2bin(*(f++));
@@ -375,7 +375,7 @@ int EVP_DecodeBlock(unsigned char *t, const unsigned char *f, int n)
         c = conv_ascii2bin(*(f++));
         d = conv_ascii2bin(*(f++));
         if ((a & 0x80) || (b & 0x80) || (c & 0x80) || (d & 0x80))
-            return (-1);
+            return -1;
         l = ((((unsigned long)a) << 18L) |
              (((unsigned long)b) << 12L) |
              (((unsigned long)c) << 6L) | (((unsigned long)d)));
@@ -384,7 +384,7 @@ int EVP_DecodeBlock(unsigned char *t, const unsigned char *f, int n)
         *(t++) = (unsigned char)(l) & 0xff;
         ret += 3;
     }
-    return (ret);
+    return ret;
 }
 
 int EVP_DecodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl)
@@ -395,7 +395,7 @@ int EVP_DecodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl)
     if (ctx->num != 0) {
         i = EVP_DecodeBlock(out, ctx->enc_data, ctx->num);
         if (i < 0)
-            return (-1);
+            return -1;
         ctx->num = 0;
         *outl = i;
         return 1;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -522,7 +522,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     if (b > 1) {
         if (ctx->buf_len || !ctx->final_used) {
             EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_WRONG_FINAL_BLOCK_LENGTH);
-            return (0);
+            return 0;
         }
         OPENSSL_assert(b <= sizeof ctx->final);
 
@@ -533,12 +533,12 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
         n = ctx->final[b - 1];
         if (n == 0 || n > (int)b) {
             EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_BAD_DECRYPT);
-            return (0);
+            return 0;
         }
         for (i = 0; i < n; i++) {
             if (ctx->final[--b] != n) {
                 EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_BAD_DECRYPT);
-                return (0);
+                return 0;
             }
         }
         n = ctx->cipher->block_size - n;

--- a/crypto/evp/evp_key.c
+++ b/crypto/evp/evp_key.c
@@ -30,9 +30,9 @@ void EVP_set_pw_prompt(const char *prompt)
 char *EVP_get_pw_prompt(void)
 {
     if (prompt_string[0] == '\0')
-        return (NULL);
+        return NULL;
     else
-        return (prompt_string);
+        return prompt_string;
 }
 
 /*
@@ -87,7 +87,7 @@ int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
     OPENSSL_assert(niv <= EVP_MAX_IV_LENGTH);
 
     if (data == NULL)
-        return (nkey);
+        return nkey;
 
     c = EVP_MD_CTX_new();
     if (c == NULL)

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -40,7 +40,7 @@ int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
         }
     } else
         ret = -1;
-    return (ret);
+    return ret;
 }
 
 int EVP_CIPHER_asn1_to_param(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
@@ -69,7 +69,7 @@ int EVP_CIPHER_asn1_to_param(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
         }
     } else
         ret = -1;
-    return (ret);
+    return ret;
 }
 
 int EVP_CIPHER_get_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
@@ -82,11 +82,11 @@ int EVP_CIPHER_get_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
         OPENSSL_assert(l <= sizeof(c->iv));
         i = ASN1_TYPE_get_octetstring(type, c->oiv, l);
         if (i != (int)l)
-            return (-1);
+            return -1;
         else if (i > 0)
             memcpy(c->iv, c->oiv, l);
     }
-    return (i);
+    return i;
 }
 
 int EVP_CIPHER_set_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
@@ -99,7 +99,7 @@ int EVP_CIPHER_set_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
         OPENSSL_assert(j <= sizeof(c->iv));
         i = ASN1_TYPE_set_octetstring(type, c->oiv, j);
     }
-    return (i);
+    return i;
 }
 
 /* Convert the various cipher NIDs and dummies to a proper OID NID */

--- a/crypto/evp/m_md4.c
+++ b/crypto/evp/m_md4.c
@@ -50,6 +50,6 @@ static const EVP_MD md4_md = {
 
 const EVP_MD *EVP_md4(void)
 {
-    return (&md4_md);
+    return &md4_md;
 }
 #endif

--- a/crypto/evp/m_md5.c
+++ b/crypto/evp/m_md5.c
@@ -50,6 +50,6 @@ static const EVP_MD md5_md = {
 
 const EVP_MD *EVP_md5(void)
 {
-    return (&md5_md);
+    return &md5_md;
 }
 #endif

--- a/crypto/evp/m_mdc2.c
+++ b/crypto/evp/m_mdc2.c
@@ -50,6 +50,6 @@ static const EVP_MD mdc2_md = {
 
 const EVP_MD *EVP_mdc2(void)
 {
-    return (&mdc2_md);
+    return &mdc2_md;
 }
 #endif

--- a/crypto/evp/m_null.c
+++ b/crypto/evp/m_null.c
@@ -45,5 +45,5 @@ static const EVP_MD null_md = {
 
 const EVP_MD *EVP_md_null(void)
 {
-    return (&null_md);
+    return &null_md;
 }

--- a/crypto/evp/m_ripemd.c
+++ b/crypto/evp/m_ripemd.c
@@ -50,6 +50,6 @@ static const EVP_MD ripemd160_md = {
 
 const EVP_MD *EVP_ripemd160(void)
 {
-    return (&ripemd160_md);
+    return &ripemd160_md;
 }
 #endif

--- a/crypto/evp/m_sha1.c
+++ b/crypto/evp/m_sha1.c
@@ -107,7 +107,7 @@ static const EVP_MD sha1_md = {
 
 const EVP_MD *EVP_sha1(void)
 {
-    return (&sha1_md);
+    return &sha1_md;
 }
 
 static int init224(EVP_MD_CTX *ctx)
@@ -151,7 +151,7 @@ static const EVP_MD sha224_md = {
 
 const EVP_MD *EVP_sha224(void)
 {
-    return (&sha224_md);
+    return &sha224_md;
 }
 
 static const EVP_MD sha256_md = {
@@ -170,7 +170,7 @@ static const EVP_MD sha256_md = {
 
 const EVP_MD *EVP_sha256(void)
 {
-    return (&sha256_md);
+    return &sha256_md;
 }
 
 static int init384(EVP_MD_CTX *ctx)
@@ -210,7 +210,7 @@ static const EVP_MD sha384_md = {
 
 const EVP_MD *EVP_sha384(void)
 {
-    return (&sha384_md);
+    return &sha384_md;
 }
 
 static const EVP_MD sha512_md = {
@@ -229,5 +229,5 @@ static const EVP_MD sha512_md = {
 
 const EVP_MD *EVP_sha512(void)
 {
-    return (&sha512_md);
+    return &sha512_md;
 }

--- a/crypto/evp/m_wp.c
+++ b/crypto/evp/m_wp.c
@@ -49,6 +49,6 @@ static const EVP_MD whirlpool_md = {
 
 const EVP_MD *EVP_whirlpool(void)
 {
-    return (&whirlpool_md);
+    return &whirlpool_md;
 }
 #endif

--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -24,10 +24,10 @@ int EVP_add_cipher(const EVP_CIPHER *c)
     r = OBJ_NAME_add(OBJ_nid2sn(c->nid), OBJ_NAME_TYPE_CIPHER_METH,
                      (const char *)c);
     if (r == 0)
-        return (0);
+        return 0;
     r = OBJ_NAME_add(OBJ_nid2ln(c->nid), OBJ_NAME_TYPE_CIPHER_METH,
                      (const char *)c);
-    return (r);
+    return r;
 }
 
 int EVP_add_digest(const EVP_MD *md)
@@ -38,21 +38,21 @@ int EVP_add_digest(const EVP_MD *md)
     name = OBJ_nid2sn(md->type);
     r = OBJ_NAME_add(name, OBJ_NAME_TYPE_MD_METH, (const char *)md);
     if (r == 0)
-        return (0);
+        return 0;
     r = OBJ_NAME_add(OBJ_nid2ln(md->type), OBJ_NAME_TYPE_MD_METH,
                      (const char *)md);
     if (r == 0)
-        return (0);
+        return 0;
 
     if (md->pkey_type && md->type != md->pkey_type) {
         r = OBJ_NAME_add(OBJ_nid2sn(md->pkey_type),
                          OBJ_NAME_TYPE_MD_METH | OBJ_NAME_ALIAS, name);
         if (r == 0)
-            return (0);
+            return 0;
         r = OBJ_NAME_add(OBJ_nid2ln(md->pkey_type),
                          OBJ_NAME_TYPE_MD_METH | OBJ_NAME_ALIAS, name);
     }
-    return (r);
+    return r;
 }
 
 const EVP_CIPHER *EVP_get_cipherbyname(const char *name)
@@ -63,7 +63,7 @@ const EVP_CIPHER *EVP_get_cipherbyname(const char *name)
         return NULL;
 
     cp = (const EVP_CIPHER *)OBJ_NAME_get(name, OBJ_NAME_TYPE_CIPHER_METH);
-    return (cp);
+    return cp;
 }
 
 const EVP_MD *EVP_get_digestbyname(const char *name)
@@ -74,7 +74,7 @@ const EVP_MD *EVP_get_digestbyname(const char *name)
         return NULL;
 
     cp = (const EVP_MD *)OBJ_NAME_get(name, OBJ_NAME_TYPE_MD_METH);
-    return (cp);
+    return cp;
 }
 
 void evp_cleanup_int(void)

--- a/crypto/evp/p_dec.c
+++ b/crypto/evp/p_dec.c
@@ -32,5 +32,5 @@ int EVP_PKEY_decrypt_old(unsigned char *key, const unsigned char *ek, int ekl,
                             RSA_PKCS1_PADDING);
  err:
 #endif
-    return (ret);
+    return ret;
 }

--- a/crypto/evp/p_enc.c
+++ b/crypto/evp/p_enc.c
@@ -31,5 +31,5 @@ int EVP_PKEY_encrypt_old(unsigned char *ek, const unsigned char *key,
                            RSA_PKCS1_PADDING);
  err:
 #endif
-    return (ret);
+    return ret;
 }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -56,7 +56,7 @@ int EVP_PKEY_save_parameters(EVP_PKEY *pkey, int mode)
 
         if (mode >= 0)
             pkey->save_parameters = mode;
-        return (ret);
+        return ret;
     }
 #endif
 #ifndef OPENSSL_NO_EC
@@ -65,10 +65,10 @@ int EVP_PKEY_save_parameters(EVP_PKEY *pkey, int mode)
 
         if (mode >= 0)
             pkey->save_parameters = mode;
-        return (ret);
+        return ret;
     }
 #endif
-    return (0);
+    return 0;
 }
 
 int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)

--- a/crypto/evp/p_open.c
+++ b/crypto/evp/p_open.c
@@ -58,7 +58,7 @@ int EVP_OpenInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
     ret = 1;
  err:
     OPENSSL_clear_free(key, size);
-    return (ret);
+    return ret;
 }
 
 int EVP_OpenFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
@@ -68,6 +68,6 @@ int EVP_OpenFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     i = EVP_DecryptFinal_ex(ctx, out, outl);
     if (i)
         i = EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, NULL);
-    return (i);
+    return i;
 }
 #endif

--- a/crypto/evp/p_seal.c
+++ b/crypto/evp/p_seal.c
@@ -43,9 +43,9 @@ int EVP_SealInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
             EVP_PKEY_encrypt_old(ek[i], key, EVP_CIPHER_CTX_key_length(ctx),
                                  pubk[i]);
         if (ekl[i] <= 0)
-            return (-1);
+            return -1;
     }
-    return (npubk);
+    return npubk;
 }
 
 int EVP_SealFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)

--- a/crypto/idea/i_ecb.c
+++ b/crypto/idea/i_ecb.c
@@ -13,7 +13,7 @@
 
 const char *IDEA_options(void)
 {
-    return ("idea(int)");
+    return "idea(int)";
 }
 
 void IDEA_ecb_encrypt(const unsigned char *in, unsigned char *out,

--- a/crypto/idea/i_skey.c
+++ b/crypto/idea/i_skey.c
@@ -108,5 +108,5 @@ static IDEA_INT inverse(unsigned int xin)
             }
         } while (r != 0);
     }
-    return ((IDEA_INT) b2);
+    return (IDEA_INT)b2;
 }

--- a/crypto/md2/md2_dgst.c
+++ b/crypto/md2/md2_dgst.c
@@ -63,9 +63,9 @@ static const MD2_INT S[256] = {
 const char *MD2_options(void)
 {
     if (sizeof(MD2_INT) == 1)
-        return ("md2(char)");
+        return "md2(char)";
     else
-        return ("md2(int)");
+        return "md2(int)";
 }
 
 int MD2_Init(MD2_CTX *c)

--- a/crypto/md2/md2_one.c
+++ b/crypto/md2/md2_one.c
@@ -43,5 +43,5 @@ unsigned char *MD2(const unsigned char *d, size_t n, unsigned char *md)
 #endif
     MD2_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c)); /* Security consideration */
-    return (md);
+    return md;
 }

--- a/crypto/md4/md4_one.c
+++ b/crypto/md4/md4_one.c
@@ -43,5 +43,5 @@ unsigned char *MD4(const unsigned char *d, size_t n, unsigned char *md)
 #endif
     MD4_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c)); /* security consideration */
-    return (md);
+    return md;
 }

--- a/crypto/md5/md5_one.c
+++ b/crypto/md5/md5_one.c
@@ -43,5 +43,5 @@ unsigned char *MD5(const unsigned char *d, size_t n, unsigned char *md)
 #endif
     MD5_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c)); /* security consideration */
-    return (md);
+    return md;
 }

--- a/crypto/mdc2/mdc2_one.c
+++ b/crypto/mdc2/mdc2_one.c
@@ -23,5 +23,5 @@ unsigned char *MDC2(const unsigned char *d, size_t n, unsigned char *md)
     MDC2_Update(&c, d, n);
     MDC2_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c)); /* security consideration */
-    return (md);
+    return md;
 }

--- a/crypto/objects/obj_lib.c
+++ b/crypto/objects/obj_lib.c
@@ -21,12 +21,12 @@ ASN1_OBJECT *OBJ_dup(const ASN1_OBJECT *o)
         return NULL;
     /* If object isn't dynamic it's an internal OID which is never freed */
     if (!(o->flags & ASN1_OBJECT_FLAG_DYNAMIC))
-        return ((ASN1_OBJECT *)o);
+        return (ASN1_OBJECT *)o;
 
     r = ASN1_OBJECT_new();
     if (r == NULL) {
         OBJerr(OBJ_F_OBJ_DUP, ERR_R_ASN1_LIB);
-        return (NULL);
+        return NULL;
     }
 
     /* Set dynamic flags so everything gets freed up on error */
@@ -60,6 +60,6 @@ int OBJ_cmp(const ASN1_OBJECT *a, const ASN1_OBJECT *b)
 
     ret = (a->length - b->length);
     if (ret)
-        return (ret);
-    return (memcmp(a->data, b->data, a->length));
+        return ret;
+    return memcmp(a->data, b->data, a->length);
 }

--- a/crypto/ocsp/ocsp_ext.c
+++ b/crypto/ocsp/ocsp_ext.c
@@ -22,7 +22,7 @@
 
 int OCSP_REQUEST_get_ext_count(OCSP_REQUEST *x)
 {
-    return (X509v3_get_ext_count(x->tbsRequest.requestExtensions));
+    return X509v3_get_ext_count(x->tbsRequest.requestExtensions);
 }
 
 int OCSP_REQUEST_get_ext_by_NID(OCSP_REQUEST *x, int nid, int lastpos)
@@ -46,12 +46,12 @@ int OCSP_REQUEST_get_ext_by_critical(OCSP_REQUEST *x, int crit, int lastpos)
 
 X509_EXTENSION *OCSP_REQUEST_get_ext(OCSP_REQUEST *x, int loc)
 {
-    return (X509v3_get_ext(x->tbsRequest.requestExtensions, loc));
+    return X509v3_get_ext(x->tbsRequest.requestExtensions, loc);
 }
 
 X509_EXTENSION *OCSP_REQUEST_delete_ext(OCSP_REQUEST *x, int loc)
 {
-    return (X509v3_delete_ext(x->tbsRequest.requestExtensions, loc));
+    return X509v3_delete_ext(x->tbsRequest.requestExtensions, loc);
 }
 
 void *OCSP_REQUEST_get1_ext_d2i(OCSP_REQUEST *x, int nid, int *crit, int *idx)
@@ -76,18 +76,18 @@ int OCSP_REQUEST_add_ext(OCSP_REQUEST *x, X509_EXTENSION *ex, int loc)
 
 int OCSP_ONEREQ_get_ext_count(OCSP_ONEREQ *x)
 {
-    return (X509v3_get_ext_count(x->singleRequestExtensions));
+    return X509v3_get_ext_count(x->singleRequestExtensions);
 }
 
 int OCSP_ONEREQ_get_ext_by_NID(OCSP_ONEREQ *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->singleRequestExtensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->singleRequestExtensions, nid, lastpos);
 }
 
 int OCSP_ONEREQ_get_ext_by_OBJ(OCSP_ONEREQ *x, const ASN1_OBJECT *obj,
                                int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->singleRequestExtensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->singleRequestExtensions, obj, lastpos);
 }
 
 int OCSP_ONEREQ_get_ext_by_critical(OCSP_ONEREQ *x, int crit, int lastpos)
@@ -98,12 +98,12 @@ int OCSP_ONEREQ_get_ext_by_critical(OCSP_ONEREQ *x, int crit, int lastpos)
 
 X509_EXTENSION *OCSP_ONEREQ_get_ext(OCSP_ONEREQ *x, int loc)
 {
-    return (X509v3_get_ext(x->singleRequestExtensions, loc));
+    return X509v3_get_ext(x->singleRequestExtensions, loc);
 }
 
 X509_EXTENSION *OCSP_ONEREQ_delete_ext(OCSP_ONEREQ *x, int loc)
 {
-    return (X509v3_delete_ext(x->singleRequestExtensions, loc));
+    return X509v3_delete_ext(x->singleRequestExtensions, loc);
 }
 
 void *OCSP_ONEREQ_get1_ext_d2i(OCSP_ONEREQ *x, int nid, int *crit, int *idx)
@@ -127,7 +127,7 @@ int OCSP_ONEREQ_add_ext(OCSP_ONEREQ *x, X509_EXTENSION *ex, int loc)
 
 int OCSP_BASICRESP_get_ext_count(OCSP_BASICRESP *x)
 {
-    return (X509v3_get_ext_count(x->tbsResponseData.responseExtensions));
+    return X509v3_get_ext_count(x->tbsResponseData.responseExtensions);
 }
 
 int OCSP_BASICRESP_get_ext_by_NID(OCSP_BASICRESP *x, int nid, int lastpos)
@@ -152,12 +152,12 @@ int OCSP_BASICRESP_get_ext_by_critical(OCSP_BASICRESP *x, int crit,
 
 X509_EXTENSION *OCSP_BASICRESP_get_ext(OCSP_BASICRESP *x, int loc)
 {
-    return (X509v3_get_ext(x->tbsResponseData.responseExtensions, loc));
+    return X509v3_get_ext(x->tbsResponseData.responseExtensions, loc);
 }
 
 X509_EXTENSION *OCSP_BASICRESP_delete_ext(OCSP_BASICRESP *x, int loc)
 {
-    return (X509v3_delete_ext(x->tbsResponseData.responseExtensions, loc));
+    return X509v3_delete_ext(x->tbsResponseData.responseExtensions, loc);
 }
 
 void *OCSP_BASICRESP_get1_ext_d2i(OCSP_BASICRESP *x, int nid, int *crit,
@@ -184,34 +184,34 @@ int OCSP_BASICRESP_add_ext(OCSP_BASICRESP *x, X509_EXTENSION *ex, int loc)
 
 int OCSP_SINGLERESP_get_ext_count(OCSP_SINGLERESP *x)
 {
-    return (X509v3_get_ext_count(x->singleExtensions));
+    return X509v3_get_ext_count(x->singleExtensions);
 }
 
 int OCSP_SINGLERESP_get_ext_by_NID(OCSP_SINGLERESP *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->singleExtensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->singleExtensions, nid, lastpos);
 }
 
 int OCSP_SINGLERESP_get_ext_by_OBJ(OCSP_SINGLERESP *x, const ASN1_OBJECT *obj,
                                    int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->singleExtensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->singleExtensions, obj, lastpos);
 }
 
 int OCSP_SINGLERESP_get_ext_by_critical(OCSP_SINGLERESP *x, int crit,
                                         int lastpos)
 {
-    return (X509v3_get_ext_by_critical(x->singleExtensions, crit, lastpos));
+    return X509v3_get_ext_by_critical(x->singleExtensions, crit, lastpos);
 }
 
 X509_EXTENSION *OCSP_SINGLERESP_get_ext(OCSP_SINGLERESP *x, int loc)
 {
-    return (X509v3_get_ext(x->singleExtensions, loc));
+    return X509v3_get_ext(x->singleExtensions, loc);
 }
 
 X509_EXTENSION *OCSP_SINGLERESP_delete_ext(OCSP_SINGLERESP *x, int loc)
 {
-    return (X509v3_delete_ext(x->singleExtensions, loc));
+    return X509v3_delete_ext(x->singleExtensions, loc);
 }
 
 void *OCSP_SINGLERESP_get1_ext_d2i(OCSP_SINGLERESP *x, int nid, int *crit,

--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -26,12 +26,12 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read(FILE *fp, STACK_OF(X509_INFO) *sk,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_X509_INFO_READ, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_X509_INFO_read_bio(b, sk, cb, u);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -240,7 +240,7 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read_bio(BIO *bp, STACK_OF(X509_INFO) *sk,
     OPENSSL_free(name);
     OPENSSL_free(header);
     OPENSSL_free(data);
-    return (ret);
+    return ret;
 }
 
 /* A TJH addition */
@@ -333,5 +333,5 @@ int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
 
  err:
     OPENSSL_cleanse(buf, PEM_BUFSIZE);
-    return (ret);
+    return ret;
 }

--- a/crypto/pem/pem_oth.c
+++ b/crypto/pem/pem_oth.c
@@ -32,5 +32,5 @@ void *PEM_ASN1_read_bio(d2i_of_void *d2i, const char *name, BIO *bp, void **x,
     if (ret == NULL)
         PEMerr(PEM_F_PEM_ASN1_READ_BIO, ERR_R_ASN1_LIB);
     OPENSSL_free(data);
-    return (ret);
+    return ret;
 }

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -183,7 +183,7 @@ static int do_pk8pkey_fp(FILE *fp, EVP_PKEY *x, int isder, int nid,
 
     if ((bp = BIO_new_fp(fp, BIO_NOCLOSE)) == NULL) {
         PEMerr(PEM_F_DO_PK8PKEY_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     ret = do_pk8pkey(bp, x, isder, nid, enc, kstr, klen, cb, u);
     BIO_free(bp);

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -89,7 +89,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
  err:
     OPENSSL_secure_free(nm);
     OPENSSL_secure_clear_free(data, len);
-    return (ret);
+    return ret;
 }
 
 int PEM_write_bio_PrivateKey(BIO *bp, EVP_PKEY *x, const EVP_CIPHER *enc,
@@ -148,7 +148,7 @@ EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x)
         PEMerr(PEM_F_PEM_READ_BIO_PARAMETERS, ERR_R_ASN1_LIB);
     OPENSSL_free(nm);
     OPENSSL_free(data);
-    return (ret);
+    return ret;
 }
 
 int PEM_write_bio_Parameters(BIO *bp, EVP_PKEY *x)
@@ -171,12 +171,12 @@ EVP_PKEY *PEM_read_PrivateKey(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_READ_PRIVATEKEY, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_read_bio_PrivateKey(b, x, cb, u);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 
 int PEM_write_PrivateKey(FILE *fp, EVP_PKEY *x, const EVP_CIPHER *enc,
@@ -233,12 +233,12 @@ DH *PEM_read_DHparams(FILE *fp, DH **x, pem_password_cb *cb, void *u)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         PEMerr(PEM_F_PEM_READ_DHPARAMS, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = PEM_read_bio_DHparams(b, x, cb, u);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 # endif
 

--- a/crypto/pem/pem_sign.c
+++ b/crypto/pem/pem_sign.c
@@ -46,5 +46,5 @@ int PEM_SignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
  err:
     /* ctx has been zeroed by EVP_SignFinal() */
     OPENSSL_free(m);
-    return (ret);
+    return ret;
 }

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -807,7 +807,7 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
     ret = 1;
  err:
     EVP_MD_CTX_free(ctx_tmp);
-    return (ret);
+    return ret;
 }
 
 int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
@@ -1039,7 +1039,7 @@ int PKCS7_signatureVerify(BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si,
     ret = 1;
  err:
     EVP_MD_CTX_free(mdc_tmp);
-    return (ret);
+    return ret;
 }
 
 PKCS7_ISSUER_AND_SERIAL *PKCS7_get_issuer_and_serial(PKCS7 *p7, int idx)
@@ -1057,19 +1057,19 @@ PKCS7_ISSUER_AND_SERIAL *PKCS7_get_issuer_and_serial(PKCS7 *p7, int idx)
     if (rsk == NULL)
         return NULL;
     if (sk_PKCS7_RECIP_INFO_num(rsk) <= idx)
-        return (NULL);
+        return NULL;
     ri = sk_PKCS7_RECIP_INFO_value(rsk, idx);
-    return (ri->issuer_and_serial);
+    return ri->issuer_and_serial;
 }
 
 ASN1_TYPE *PKCS7_get_signed_attribute(PKCS7_SIGNER_INFO *si, int nid)
 {
-    return (get_attribute(si->auth_attr, nid));
+    return get_attribute(si->auth_attr, nid);
 }
 
 ASN1_TYPE *PKCS7_get_attribute(PKCS7_SIGNER_INFO *si, int nid)
 {
-    return (get_attribute(si->unauth_attr, nid));
+    return get_attribute(si->unauth_attr, nid);
 }
 
 static ASN1_TYPE *get_attribute(STACK_OF(X509_ATTRIBUTE) *sk, int nid)
@@ -1103,7 +1103,7 @@ int PKCS7_set_signed_attributes(PKCS7_SIGNER_INFO *p7si,
                                    X509_ATTRIBUTE_dup(sk_X509_ATTRIBUTE_value
                                                       (sk, i))))
             == NULL)
-            return (0);
+            return 0;
     }
     return 1;
 }
@@ -1122,7 +1122,7 @@ int PKCS7_set_attributes(PKCS7_SIGNER_INFO *p7si,
                                    X509_ATTRIBUTE_dup(sk_X509_ATTRIBUTE_value
                                                       (sk, i))))
             == NULL)
-            return (0);
+            return 0;
     }
     return 1;
 }
@@ -1130,13 +1130,13 @@ int PKCS7_set_attributes(PKCS7_SIGNER_INFO *p7si,
 int PKCS7_add_signed_attribute(PKCS7_SIGNER_INFO *p7si, int nid, int atrtype,
                                void *value)
 {
-    return (add_attribute(&(p7si->auth_attr), nid, atrtype, value));
+    return add_attribute(&(p7si->auth_attr), nid, atrtype, value);
 }
 
 int PKCS7_add_attribute(PKCS7_SIGNER_INFO *p7si, int nid, int atrtype,
                         void *value)
 {
-    return (add_attribute(&(p7si->unauth_attr), nid, atrtype, value));
+    return add_attribute(&(p7si->unauth_attr), nid, atrtype, value);
 }
 
 static int add_attribute(STACK_OF(X509_ATTRIBUTE) **sk, int nid, int atrtype,

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -57,7 +57,7 @@ long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
         PKCS7err(PKCS7_F_PKCS7_CTRL, PKCS7_R_UNKNOWN_OPERATION);
         ret = 0;
     }
-    return (ret);
+    return ret;
 }
 
 int PKCS7_content_new(PKCS7 *p7, int type)
@@ -74,7 +74,7 @@ int PKCS7_content_new(PKCS7 *p7, int type)
     return 1;
  err:
     PKCS7_free(ret);
-    return (0);
+    return 0;
 }
 
 int PKCS7_set_content(PKCS7 *p7, PKCS7 *p7_data)
@@ -101,7 +101,7 @@ int PKCS7_set_content(PKCS7 *p7, PKCS7 *p7_data)
     }
     return 1;
  err:
-    return (0);
+    return 0;
 }
 
 int PKCS7_set_type(PKCS7 *p7, int type)
@@ -173,7 +173,7 @@ int PKCS7_set_type(PKCS7 *p7, int type)
     }
     return 1;
  err:
-    return (0);
+    return 0;
 }
 
 int PKCS7_set0_type_other(PKCS7 *p7, int type, ASN1_TYPE *other)
@@ -202,7 +202,7 @@ int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *psi)
         break;
     default:
         PKCS7err(PKCS7_F_PKCS7_ADD_SIGNER, PKCS7_R_WRONG_CONTENT_TYPE);
-        return (0);
+        return 0;
     }
 
     nid = OBJ_obj2nid(psi->digest_alg->algorithm);
@@ -221,7 +221,7 @@ int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *psi)
             || (alg->parameter = ASN1_TYPE_new()) == NULL) {
             X509_ALGOR_free(alg);
             PKCS7err(PKCS7_F_PKCS7_ADD_SIGNER, ERR_R_MALLOC_FAILURE);
-            return (0);
+            return 0;
         }
         alg->algorithm = OBJ_nid2obj(nid);
         alg->parameter->type = V_ASN1_NULL;
@@ -251,7 +251,7 @@ int PKCS7_add_certificate(PKCS7 *p7, X509 *x509)
         break;
     default:
         PKCS7err(PKCS7_F_PKCS7_ADD_CERTIFICATE, PKCS7_R_WRONG_CONTENT_TYPE);
-        return (0);
+        return 0;
     }
 
     if (*sk == NULL)
@@ -283,7 +283,7 @@ int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl)
         break;
     default:
         PKCS7err(PKCS7_F_PKCS7_ADD_CRL, PKCS7_R_WRONG_CONTENT_TYPE);
-        return (0);
+        return 0;
     }
 
     if (*sk == NULL)
@@ -369,10 +369,10 @@ PKCS7_SIGNER_INFO *PKCS7_add_signature(PKCS7 *p7, X509 *x509, EVP_PKEY *pkey,
         goto err;
     if (!PKCS7_add_signer(p7, si))
         goto err;
-    return (si);
+    return si;
  err:
     PKCS7_SIGNER_INFO_free(si);
-    return (NULL);
+    return NULL;
 }
 
 int PKCS7_set_digest(PKCS7 *p7, const EVP_MD *md)
@@ -396,11 +396,11 @@ STACK_OF(PKCS7_SIGNER_INFO) *PKCS7_get_signer_info(PKCS7 *p7)
     if (p7 == NULL || p7->d.ptr == NULL)
         return NULL;
     if (PKCS7_type_is_signed(p7)) {
-        return (p7->d.sign->signer_info);
+        return p7->d.sign->signer_info;
     } else if (PKCS7_type_is_signedAndEnveloped(p7)) {
-        return (p7->d.signed_and_enveloped->signer_info);
+        return p7->d.signed_and_enveloped->signer_info;
     } else
-        return (NULL);
+        return NULL;
 }
 
 void PKCS7_SIGNER_INFO_get0_algs(PKCS7_SIGNER_INFO *si, EVP_PKEY **pk,
@@ -452,7 +452,7 @@ int PKCS7_add_recipient_info(PKCS7 *p7, PKCS7_RECIP_INFO *ri)
     default:
         PKCS7err(PKCS7_F_PKCS7_ADD_RECIPIENT_INFO,
                  PKCS7_R_WRONG_CONTENT_TYPE);
-        return (0);
+        return 0;
     }
 
     if (!sk_PKCS7_RECIP_INFO_push(sk, ri))
@@ -512,7 +512,7 @@ X509 *PKCS7_cert_from_signer_info(PKCS7 *p7, PKCS7_SIGNER_INFO *si)
                                                si->
                                                issuer_and_serial->serial));
     else
-        return (NULL);
+        return NULL;
 }
 
 int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher)
@@ -530,7 +530,7 @@ int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher)
         break;
     default:
         PKCS7err(PKCS7_F_PKCS7_SET_CIPHER, PKCS7_R_WRONG_CONTENT_TYPE);
-        return (0);
+        return 0;
     }
 
     /* Check cipher OID exists and has data in it */
@@ -538,7 +538,7 @@ int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher)
     if (i == NID_undef) {
         PKCS7err(PKCS7_F_PKCS7_SET_CIPHER,
                  PKCS7_R_CIPHER_HAS_NO_OBJECT_IDENTIFIER);
-        return (0);
+        return 0;
     }
 
     ec->cipher = cipher;

--- a/crypto/rc4/rc4_skey.c
+++ b/crypto/rc4/rc4_skey.c
@@ -14,9 +14,9 @@
 const char *RC4_options(void)
 {
     if (sizeof(RC4_INT) == 1)
-        return ("rc4(char)");
+        return "rc4(char)";
     else
-        return ("rc4(int)");
+        return "rc4(int)";
 }
 
 /*-

--- a/crypto/ripemd/rmd_one.c
+++ b/crypto/ripemd/rmd_one.c
@@ -24,5 +24,5 @@ unsigned char *RIPEMD160(const unsigned char *d, size_t n, unsigned char *md)
     RIPEMD160_Update(&c, d, n);
     RIPEMD160_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c)); /* security consideration */
-    return (md);
+    return md;
 }

--- a/crypto/sha/sha1_one.c
+++ b/crypto/sha/sha1_one.c
@@ -24,5 +24,5 @@ unsigned char *SHA1(const unsigned char *d, size_t n, unsigned char *md)
     SHA1_Update(&c, d, n);
     SHA1_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c));
-    return (md);
+    return md;
 }

--- a/crypto/sha/sha256.c
+++ b/crypto/sha/sha256.c
@@ -57,7 +57,7 @@ unsigned char *SHA224(const unsigned char *d, size_t n, unsigned char *md)
     SHA256_Update(&c, d, n);
     SHA256_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c));
-    return (md);
+    return md;
 }
 
 unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md)
@@ -71,7 +71,7 @@ unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md)
     SHA256_Update(&c, d, n);
     SHA256_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c));
-    return (md);
+    return md;
 }
 
 int SHA224_Update(SHA256_CTX *c, const void *data, size_t len)

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -257,7 +257,7 @@ unsigned char *SHA384(const unsigned char *d, size_t n, unsigned char *md)
     SHA512_Update(&c, d, n);
     SHA512_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c));
-    return (md);
+    return md;
 }
 
 unsigned char *SHA512(const unsigned char *d, size_t n, unsigned char *md)
@@ -271,7 +271,7 @@ unsigned char *SHA512(const unsigned char *d, size_t n, unsigned char *md)
     SHA512_Update(&c, d, n);
     SHA512_Final(md, &c);
     OPENSSL_cleanse(&c, sizeof(c));
-    return (md);
+    return md;
 }
 
 #ifndef SHA512_ASM

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -124,7 +124,7 @@ TXT_DB *TXT_DB_read(BIO *in, int num)
         OPENSSL_free(ret->qual);
         OPENSSL_free(ret);
     }
-    return (NULL);
+    return NULL;
 }
 
 OPENSSL_STRING *TXT_DB_get_by_index(TXT_DB *db, int idx,
@@ -135,16 +135,16 @@ OPENSSL_STRING *TXT_DB_get_by_index(TXT_DB *db, int idx,
 
     if (idx >= db->num_fields) {
         db->error = DB_ERROR_INDEX_OUT_OF_RANGE;
-        return (NULL);
+        return NULL;
     }
     lh = db->index[idx];
     if (lh == NULL) {
         db->error = DB_ERROR_NO_INDEX;
-        return (NULL);
+        return NULL;
     }
     ret = lh_OPENSSL_STRING_retrieve(lh, value);
     db->error = DB_ERROR_OK;
-    return (ret);
+    return ret;
 }
 
 int TXT_DB_create_index(TXT_DB *db, int field, int (*qual) (OPENSSL_STRING *),
@@ -156,12 +156,12 @@ int TXT_DB_create_index(TXT_DB *db, int field, int (*qual) (OPENSSL_STRING *),
 
     if (field >= db->num_fields) {
         db->error = DB_ERROR_INDEX_OUT_OF_RANGE;
-        return (0);
+        return 0;
     }
     /* FIXME: we lose type checking at this point */
     if ((idx = (LHASH_OF(OPENSSL_STRING) *)OPENSSL_LH_new(hash, cmp)) == NULL) {
         db->error = DB_ERROR_MALLOC;
-        return (0);
+        return 0;
     }
     n = sk_OPENSSL_PSTRING_num(db->data);
     for (i = 0; i < n; i++) {
@@ -173,12 +173,12 @@ int TXT_DB_create_index(TXT_DB *db, int field, int (*qual) (OPENSSL_STRING *),
             db->arg1 = sk_OPENSSL_PSTRING_find(db->data, k);
             db->arg2 = i;
             lh_OPENSSL_STRING_free(idx);
-            return (0);
+            return 0;
         }
         if (lh_OPENSSL_STRING_retrieve(idx, r) == NULL) {
             db->error = DB_ERROR_MALLOC;
             lh_OPENSSL_STRING_free(idx);
-            return (0);
+            return 0;
         }
     }
     lh_OPENSSL_STRING_free(db->index[field]);
@@ -231,7 +231,7 @@ long TXT_DB_write(BIO *out, TXT_DB *db)
     ret = tot;
  err:
     BUF_MEM_free(buf);
-    return (ret);
+    return ret;
 }
 
 int TXT_DB_insert(TXT_DB *db, OPENSSL_STRING *row)
@@ -276,7 +276,7 @@ int TXT_DB_insert(TXT_DB *db, OPENSSL_STRING *row)
         }
     }
  err:
-    return (0);
+    return 0;
 }
 
 void TXT_DB_free(TXT_DB *db)

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -17,7 +17,7 @@
 
 UI *UI_new(void)
 {
-    return (UI_new_method(NULL));
+    return UI_new_method(NULL);
 }
 
 UI *UI_new_method(const UI_METHOD *method)
@@ -572,12 +572,12 @@ int UI_ctrl(UI *ui, int cmd, long i, void *p, void (*f) (void))
 
 int UI_set_ex_data(UI *r, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&r->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&r->ex_data, idx, arg);
 }
 
 void *UI_get_ex_data(UI *r, int idx)
 {
-    return (CRYPTO_get_ex_data(&r->ex_data, idx));
+    return CRYPTO_get_ex_data(&r->ex_data, idx);
 }
 
 const UI_METHOD *UI_get_method(UI *ui)

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -687,7 +687,7 @@ static int noecho_fgets(char *buf, int size, FILE *tty)
         FlushConsoleInputBuffer(inh);
     }
 #  endif
-    return (strlen(buf));
+    return strlen(buf);
 }
 # endif
 

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -25,7 +25,7 @@ int UI_UTIL_read_pw_string(char *buf, int length, const char *prompt,
         UI_UTIL_read_pw(buf, buff, (length > BUFSIZ) ? BUFSIZ : length,
                         prompt, verify);
     OPENSSL_cleanse(buff, BUFSIZ);
-    return (ret);
+    return ret;
 }
 
 int UI_UTIL_read_pw(char *buf, char *buff, int size, const char *prompt,
@@ -48,7 +48,7 @@ int UI_UTIL_read_pw(char *buf, char *buff, int size, const char *prompt,
     }
     if (ok > 0)
         ok = 0;
-    return (ok);
+    return ok;
 }
 
 /*

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -241,7 +241,7 @@ int WHIRLPOOL_Final(unsigned char *md, WHIRLPOOL_CTX *c)
         OPENSSL_cleanse(c, sizeof(*c));
         return 1;
     }
-    return (0);
+    return 0;
 }
 
 unsigned char *WHIRLPOOL(const void *inp, size_t bytes, unsigned char *md)
@@ -254,5 +254,5 @@ unsigned char *WHIRLPOOL(const void *inp, size_t bytes, unsigned char *md)
     WHIRLPOOL_Init(&ctx);
     WHIRLPOOL_Update(&ctx, inp, bytes);
     WHIRLPOOL_Final(md, &ctx);
-    return (md);
+    return md;
 }

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -61,7 +61,7 @@ static X509_LOOKUP_METHOD x509_dir_lookup = {
 
 X509_LOOKUP_METHOD *X509_LOOKUP_hash_dir(void)
 {
-    return (&x509_dir_lookup);
+    return &x509_dir_lookup;
 }
 
 static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
@@ -89,7 +89,7 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
             ret = add_cert_dir(ld, argp, (int)argl);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int new_dir(X509_LOOKUP *lu)
@@ -216,7 +216,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
     const char *postfix = "";
 
     if (name == NULL)
-        return (0);
+        return 0;
 
     stmp.type = type;
     if (type == X509_LU_X509) {
@@ -386,5 +386,5 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
     }
  finish:
     BUF_MEM_free(b);
-    return (ok);
+    return ok;
 }

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -34,7 +34,7 @@ static X509_LOOKUP_METHOD x509_file_lookup = {
 
 X509_LOOKUP_METHOD *X509_LOOKUP_file(void)
 {
-    return (&x509_file_lookup);
+    return &x509_file_lookup;
 }
 
 static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
@@ -68,7 +68,7 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp,
         }
         break;
     }
-    return (ok);
+    return ok;
 }
 
 int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
@@ -125,7 +125,7 @@ int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
  err:
     X509_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
@@ -182,7 +182,7 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
  err:
     X509_CRL_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type)

--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -23,12 +23,12 @@ int X509_CRL_print_fp(FILE *fp, X509_CRL *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         X509err(X509_F_X509_CRL_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = X509_CRL_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -25,12 +25,12 @@ int X509_REQ_print_fp(FILE *fp, X509_REQ *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         X509err(X509_F_X509_REQ_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = X509_REQ_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -189,7 +189,7 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
     return 1;
  err:
     X509err(X509_F_X509_REQ_PRINT_EX, ERR_R_BUF_LIB);
-    return (0);
+    return 0;
 }
 
 int X509_REQ_print(BIO *bp, X509_REQ *x)

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -30,12 +30,12 @@ int X509_print_ex_fp(FILE *fp, X509 *x, unsigned long nmflag,
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         X509err(X509_F_X509_PRINT_EX_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = X509_print_ex(b, x, nmflag, cflag);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -212,7 +212,7 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
     ret = 1;
  err:
     OPENSSL_free(m);
-    return (ret);
+    return ret;
 }
 
 int X509_ocspid_print(BIO *bp, X509 *x)
@@ -269,7 +269,7 @@ int X509_ocspid_print(BIO *bp, X509 *x)
     return 1;
  err:
     OPENSSL_free(der);
-    return (0);
+    return 0;
 }
 
 int X509_signature_dump(BIO *bp, const ASN1_STRING *sig, int indent)

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -28,8 +28,8 @@ int X509at_get_attr_by_NID(const STACK_OF(X509_ATTRIBUTE) *x, int nid,
     const ASN1_OBJECT *obj = OBJ_nid2obj(nid);
 
     if (obj == NULL)
-        return (-2);
-    return (X509at_get_attr_by_OBJ(x, obj, lastpos));
+        return -2;
+    return X509at_get_attr_by_OBJ(x, obj, lastpos);
 }
 
 int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
@@ -39,7 +39,7 @@ int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
     X509_ATTRIBUTE *ex;
 
     if (sk == NULL)
-        return (-1);
+        return -1;
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
@@ -47,9 +47,9 @@ int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_ATTRIBUTE_value(sk, lastpos);
         if (OBJ_cmp(ex->object, obj) == 0)
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 X509_ATTRIBUTE *X509at_get_attr(const STACK_OF(X509_ATTRIBUTE) *x, int loc)
@@ -65,9 +65,9 @@ X509_ATTRIBUTE *X509at_delete_attr(STACK_OF(X509_ATTRIBUTE) *x, int loc)
     X509_ATTRIBUTE *ret;
 
     if (x == NULL || sk_X509_ATTRIBUTE_num(x) <= loc || loc < 0)
-        return (NULL);
+        return NULL;
     ret = sk_X509_ATTRIBUTE_delete(x, loc);
-    return (ret);
+    return ret;
 }
 
 STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
@@ -93,13 +93,13 @@ STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
         goto err;
     if (*x == NULL)
         *x = sk;
-    return (sk);
+    return sk;
  err:
     X509err(X509_F_X509AT_ADD1_ATTR, ERR_R_MALLOC_FAILURE);
  err2:
     X509_ATTRIBUTE_free(new_attr);
     sk_X509_ATTRIBUTE_free(sk);
-    return (NULL);
+    return NULL;
 }
 
 STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr_by_OBJ(STACK_OF(X509_ATTRIBUTE)
@@ -175,12 +175,12 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_NID(X509_ATTRIBUTE **attr, int nid,
     obj = OBJ_nid2obj(nid);
     if (obj == NULL) {
         X509err(X509_F_X509_ATTRIBUTE_CREATE_BY_NID, X509_R_UNKNOWN_NID);
-        return (NULL);
+        return NULL;
     }
     ret = X509_ATTRIBUTE_create_by_OBJ(attr, obj, atrtype, data, len);
     if (ret == NULL)
         ASN1_OBJECT_free(obj);
-    return (ret);
+    return ret;
 }
 
 X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_OBJ(X509_ATTRIBUTE **attr,
@@ -194,7 +194,7 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_OBJ(X509_ATTRIBUTE **attr,
         if ((ret = X509_ATTRIBUTE_new()) == NULL) {
             X509err(X509_F_X509_ATTRIBUTE_CREATE_BY_OBJ,
                     ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else
         ret = *attr;
@@ -206,11 +206,11 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_OBJ(X509_ATTRIBUTE **attr,
 
     if ((attr != NULL) && (*attr == NULL))
         *attr = ret;
-    return (ret);
+    return ret;
  err:
     if ((attr == NULL) || (ret != *attr))
         X509_ATTRIBUTE_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_txt(X509_ATTRIBUTE **attr,
@@ -226,7 +226,7 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_txt(X509_ATTRIBUTE **attr,
         X509err(X509_F_X509_ATTRIBUTE_CREATE_BY_TXT,
                 X509_R_INVALID_FIELD_NAME);
         ERR_add_error_data(2, "name=", atrname);
-        return (NULL);
+        return NULL;
     }
     nattr = X509_ATTRIBUTE_create_by_OBJ(attr, obj, type, bytes, len);
     ASN1_OBJECT_free(obj);
@@ -236,7 +236,7 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create_by_txt(X509_ATTRIBUTE **attr,
 int X509_ATTRIBUTE_set1_object(X509_ATTRIBUTE *attr, const ASN1_OBJECT *obj)
 {
     if ((attr == NULL) || (obj == NULL))
-        return (0);
+        return 0;
     ASN1_OBJECT_free(attr->object);
     attr->object = OBJ_dup(obj);
     return attr->object != NULL;
@@ -303,8 +303,8 @@ int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *attr)
 ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)
 {
     if (attr == NULL)
-        return (NULL);
-    return (attr->object);
+        return NULL;
+    return attr->object;
 }
 
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -24,8 +24,8 @@ int X509_issuer_and_serial_cmp(const X509 *a, const X509 *b)
     bi = &b->cert_info;
     i = ASN1_INTEGER_cmp(&ai->serialNumber, &bi->serialNumber);
     if (i)
-        return (i);
-    return (X509_NAME_cmp(ai->issuer, bi->issuer));
+        return i;
+    return X509_NAME_cmp(ai->issuer, bi->issuer);
 }
 
 #ifndef OPENSSL_NO_MD5
@@ -55,23 +55,23 @@ unsigned long X509_issuer_and_serial_hash(X509 *a)
         ) & 0xffffffffL;
  err:
     EVP_MD_CTX_free(ctx);
-    return (ret);
+    return ret;
 }
 #endif
 
 int X509_issuer_name_cmp(const X509 *a, const X509 *b)
 {
-    return (X509_NAME_cmp(a->cert_info.issuer, b->cert_info.issuer));
+    return X509_NAME_cmp(a->cert_info.issuer, b->cert_info.issuer);
 }
 
 int X509_subject_name_cmp(const X509 *a, const X509 *b)
 {
-    return (X509_NAME_cmp(a->cert_info.subject, b->cert_info.subject));
+    return X509_NAME_cmp(a->cert_info.subject, b->cert_info.subject);
 }
 
 int X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b)
 {
-    return (X509_NAME_cmp(a->crl.issuer, b->crl.issuer));
+    return X509_NAME_cmp(a->crl.issuer, b->crl.issuer);
 }
 
 int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
@@ -81,24 +81,24 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 
 X509_NAME *X509_get_issuer_name(const X509 *a)
 {
-    return (a->cert_info.issuer);
+    return a->cert_info.issuer;
 }
 
 unsigned long X509_issuer_name_hash(X509 *x)
 {
-    return (X509_NAME_hash(x->cert_info.issuer));
+    return X509_NAME_hash(x->cert_info.issuer);
 }
 
 #ifndef OPENSSL_NO_MD5
 unsigned long X509_issuer_name_hash_old(X509 *x)
 {
-    return (X509_NAME_hash_old(x->cert_info.issuer));
+    return X509_NAME_hash_old(x->cert_info.issuer);
 }
 #endif
 
 X509_NAME *X509_get_subject_name(const X509 *a)
 {
-    return (a->cert_info.subject);
+    return a->cert_info.subject;
 }
 
 ASN1_INTEGER *X509_get_serialNumber(X509 *a)
@@ -113,13 +113,13 @@ const ASN1_INTEGER *X509_get0_serialNumber(const X509 *a)
 
 unsigned long X509_subject_name_hash(X509 *x)
 {
-    return (X509_NAME_hash(x->cert_info.subject));
+    return X509_NAME_hash(x->cert_info.subject);
 }
 
 #ifndef OPENSSL_NO_MD5
 unsigned long X509_subject_name_hash_old(X509 *x)
 {
-    return (X509_NAME_hash_old(x->cert_info.subject));
+    return X509_NAME_hash_old(x->cert_info.subject);
 }
 #endif
 
@@ -194,7 +194,7 @@ unsigned long X509_NAME_hash(X509_NAME *x)
     ret = (((unsigned long)md[0]) | ((unsigned long)md[1] << 8L) |
            ((unsigned long)md[2] << 16L) | ((unsigned long)md[3] << 24L)
         ) & 0xffffffffL;
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_MD5
@@ -223,7 +223,7 @@ unsigned long X509_NAME_hash_old(X509_NAME *x)
             ) & 0xffffffffL;
     EVP_MD_CTX_free(md_ctx);
 
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -243,9 +243,9 @@ X509 *X509_find_by_issuer_and_serial(STACK_OF(X509) *sk, X509_NAME *name,
     for (i = 0; i < sk_X509_num(sk); i++) {
         x509 = sk_X509_value(sk, i);
         if (X509_issuer_and_serial_cmp(x509, &x) == 0)
-            return (x509);
+            return x509;
     }
-    return (NULL);
+    return NULL;
 }
 
 X509 *X509_find_by_subject(STACK_OF(X509) *sk, X509_NAME *name)
@@ -256,9 +256,9 @@ X509 *X509_find_by_subject(STACK_OF(X509) *sk, X509_NAME *name)
     for (i = 0; i < sk_X509_num(sk); i++) {
         x509 = sk_X509_value(sk, i);
         if (X509_NAME_cmp(X509_get_subject_name(x509), name) == 0)
-            return (x509);
+            return x509;
     }
-    return (NULL);
+    return NULL;
 }
 
 EVP_PKEY *X509_get0_pubkey(const X509 *x)

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -18,12 +18,12 @@ int X509_STORE_set_default_paths(X509_STORE *ctx)
 
     lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_file());
     if (lookup == NULL)
-        return (0);
+        return 0;
     X509_LOOKUP_load_file(lookup, NULL, X509_FILETYPE_DEFAULT);
 
     lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_hash_dir());
     if (lookup == NULL)
-        return (0);
+        return 0;
     X509_LOOKUP_add_dir(lookup, NULL, X509_FILETYPE_DEFAULT);
 
     /* clear any errors */
@@ -40,18 +40,18 @@ int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
     if (file != NULL) {
         lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_file());
         if (lookup == NULL)
-            return (0);
+            return 0;
         if (X509_LOOKUP_load_file(lookup, file, X509_FILETYPE_PEM) != 1)
-            return (0);
+            return 0;
     }
     if (path != NULL) {
         lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_hash_dir());
         if (lookup == NULL)
-            return (0);
+            return 0;
         if (X509_LOOKUP_add_dir(lookup, path, X509_FILETYPE_PEM) != 1)
-            return (0);
+            return 0;
     }
     if ((path == NULL) && (file == NULL))
-        return (0);
+        return 0;
     return 1;
 }

--- a/crypto/x509/x509_def.c
+++ b/crypto/x509/x509_def.c
@@ -14,30 +14,30 @@
 
 const char *X509_get_default_private_dir(void)
 {
-    return (X509_PRIVATE_DIR);
+    return X509_PRIVATE_DIR;
 }
 
 const char *X509_get_default_cert_area(void)
 {
-    return (X509_CERT_AREA);
+    return X509_CERT_AREA;
 }
 
 const char *X509_get_default_cert_dir(void)
 {
-    return (X509_CERT_DIR);
+    return X509_CERT_DIR;
 }
 
 const char *X509_get_default_cert_file(void)
 {
-    return (X509_CERT_FILE);
+    return X509_CERT_FILE;
 }
 
 const char *X509_get_default_cert_dir_env(void)
 {
-    return (X509_CERT_DIR_EVP);
+    return X509_CERT_DIR_EVP;
 }
 
 const char *X509_get_default_cert_file_env(void)
 {
-    return (X509_CERT_FILE_EVP);
+    return X509_CERT_FILE_EVP;
 }

--- a/crypto/x509/x509_ext.c
+++ b/crypto/x509/x509_ext.c
@@ -18,33 +18,33 @@
 
 int X509_CRL_get_ext_count(const X509_CRL *x)
 {
-    return (X509v3_get_ext_count(x->crl.extensions));
+    return X509v3_get_ext_count(x->crl.extensions);
 }
 
 int X509_CRL_get_ext_by_NID(const X509_CRL *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->crl.extensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->crl.extensions, nid, lastpos);
 }
 
 int X509_CRL_get_ext_by_OBJ(const X509_CRL *x, const ASN1_OBJECT *obj,
                             int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->crl.extensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->crl.extensions, obj, lastpos);
 }
 
 int X509_CRL_get_ext_by_critical(const X509_CRL *x, int crit, int lastpos)
 {
-    return (X509v3_get_ext_by_critical(x->crl.extensions, crit, lastpos));
+    return X509v3_get_ext_by_critical(x->crl.extensions, crit, lastpos);
 }
 
 X509_EXTENSION *X509_CRL_get_ext(const X509_CRL *x, int loc)
 {
-    return (X509v3_get_ext(x->crl.extensions, loc));
+    return X509v3_get_ext(x->crl.extensions, loc);
 }
 
 X509_EXTENSION *X509_CRL_delete_ext(X509_CRL *x, int loc)
 {
-    return (X509v3_delete_ext(x->crl.extensions, loc));
+    return X509v3_delete_ext(x->crl.extensions, loc);
 }
 
 void *X509_CRL_get_ext_d2i(const X509_CRL *x, int nid, int *crit, int *idx)
@@ -65,17 +65,17 @@ int X509_CRL_add_ext(X509_CRL *x, X509_EXTENSION *ex, int loc)
 
 int X509_get_ext_count(const X509 *x)
 {
-    return (X509v3_get_ext_count(x->cert_info.extensions));
+    return X509v3_get_ext_count(x->cert_info.extensions);
 }
 
 int X509_get_ext_by_NID(const X509 *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->cert_info.extensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->cert_info.extensions, nid, lastpos);
 }
 
 int X509_get_ext_by_OBJ(const X509 *x, const ASN1_OBJECT *obj, int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->cert_info.extensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->cert_info.extensions, obj, lastpos);
 }
 
 int X509_get_ext_by_critical(const X509 *x, int crit, int lastpos)
@@ -86,12 +86,12 @@ int X509_get_ext_by_critical(const X509 *x, int crit, int lastpos)
 
 X509_EXTENSION *X509_get_ext(const X509 *x, int loc)
 {
-    return (X509v3_get_ext(x->cert_info.extensions, loc));
+    return X509v3_get_ext(x->cert_info.extensions, loc);
 }
 
 X509_EXTENSION *X509_delete_ext(X509 *x, int loc)
 {
-    return (X509v3_delete_ext(x->cert_info.extensions, loc));
+    return X509v3_delete_ext(x->cert_info.extensions, loc);
 }
 
 int X509_add_ext(X509 *x, X509_EXTENSION *ex, int loc)
@@ -113,33 +113,33 @@ int X509_add1_ext_i2d(X509 *x, int nid, void *value, int crit,
 
 int X509_REVOKED_get_ext_count(const X509_REVOKED *x)
 {
-    return (X509v3_get_ext_count(x->extensions));
+    return X509v3_get_ext_count(x->extensions);
 }
 
 int X509_REVOKED_get_ext_by_NID(const X509_REVOKED *x, int nid, int lastpos)
 {
-    return (X509v3_get_ext_by_NID(x->extensions, nid, lastpos));
+    return X509v3_get_ext_by_NID(x->extensions, nid, lastpos);
 }
 
 int X509_REVOKED_get_ext_by_OBJ(const X509_REVOKED *x, const ASN1_OBJECT *obj,
                                 int lastpos)
 {
-    return (X509v3_get_ext_by_OBJ(x->extensions, obj, lastpos));
+    return X509v3_get_ext_by_OBJ(x->extensions, obj, lastpos);
 }
 
 int X509_REVOKED_get_ext_by_critical(const X509_REVOKED *x, int crit, int lastpos)
 {
-    return (X509v3_get_ext_by_critical(x->extensions, crit, lastpos));
+    return X509v3_get_ext_by_critical(x->extensions, crit, lastpos);
 }
 
 X509_EXTENSION *X509_REVOKED_get_ext(const X509_REVOKED *x, int loc)
 {
-    return (X509v3_get_ext(x->extensions, loc));
+    return X509v3_get_ext(x->extensions, loc);
 }
 
 X509_EXTENSION *X509_REVOKED_delete_ext(X509_REVOKED *x, int loc)
 {
-    return (X509v3_delete_ext(x->extensions, loc));
+    return X509v3_delete_ext(x->extensions, loc);
 }
 
 int X509_REVOKED_add_ext(X509_REVOKED *x, X509_EXTENSION *ex, int loc)

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -172,10 +172,10 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         p = buf;
     if (i == 0)
         *p = '\0';
-    return (p);
+    return p;
  err:
     X509err(X509_F_X509_NAME_ONELINE, ERR_R_MALLOC_FAILURE);
  end:
     BUF_MEM_free(b);
-    return (NULL);
+    return NULL;
 }

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -54,24 +54,24 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
         if (!X509_REQ_sign(ret, pkey, md))
             goto err;
     }
-    return (ret);
+    return ret;
  err:
     X509_REQ_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req)
 {
     if (req == NULL)
-        return (NULL);
-    return (X509_PUBKEY_get(req->req_info.pubkey));
+        return NULL;
+    return X509_PUBKEY_get(req->req_info.pubkey);
 }
 
 EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req)
 {
     if (req == NULL)
         return NULL;
-    return (X509_PUBKEY_get0(req->req_info.pubkey));
+    return X509_PUBKEY_get0(req->req_info.pubkey);
 }
 
 X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req)
@@ -115,7 +115,7 @@ int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k)
     }
 
     EVP_PKEY_free(xk);
-    return (ok);
+    return ok;
 }
 
 /*
@@ -158,7 +158,7 @@ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
     const unsigned char *p;
 
     if ((req == NULL) || !ext_nids)
-        return (NULL);
+        return NULL;
     for (pnid = ext_nids; *pnid != NID_undef; pnid++) {
         idx = X509_REQ_get_attr_by_NID(req, *pnid, -1);
         if (idx == -1)

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -22,7 +22,7 @@
 int X509_set_version(X509 *x, long version)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     if (version == 0) {
         ASN1_INTEGER_free(x->cert_info.version);
         x->cert_info.version = NULL;
@@ -30,9 +30,9 @@ int X509_set_version(X509 *x, long version)
     }
     if (x->cert_info.version == NULL) {
         if ((x->cert_info.version = ASN1_INTEGER_new()) == NULL)
-            return (0);
+            return 0;
     }
-    return (ASN1_INTEGER_set(x->cert_info.version, version));
+    return ASN1_INTEGER_set(x->cert_info.version, version);
 }
 
 int X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial)
@@ -50,15 +50,15 @@ int X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial)
 int X509_set_issuer_name(X509 *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
-    return (X509_NAME_set(&x->cert_info.issuer, name));
+        return 0;
+    return X509_NAME_set(&x->cert_info.issuer, name);
 }
 
 int X509_set_subject_name(X509 *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
-    return (X509_NAME_set(&x->cert_info.subject, name));
+        return 0;
+    return X509_NAME_set(&x->cert_info.subject, name);
 }
 
 int x509_set1_time(ASN1_TIME **ptm, const ASN1_TIME *tm)
@@ -92,8 +92,8 @@ int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm)
 int X509_set_pubkey(X509 *x, EVP_PKEY *pkey)
 {
     if (x == NULL)
-        return (0);
-    return (X509_PUBKEY_set(&(x->cert_info.key), pkey));
+        return 0;
+    return X509_PUBKEY_set(&(x->cert_info.key), pkey);
 }
 
 int X509_up_ref(X509 *x)

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -22,161 +22,161 @@ const char *X509_verify_cert_error_string(long n)
 {
     switch ((int)n) {
     case X509_V_OK:
-        return ("ok");
+        return "ok";
     case X509_V_ERR_UNSPECIFIED:
-        return ("unspecified certificate verification error");
+        return "unspecified certificate verification error";
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
-        return ("unable to get issuer certificate");
+        return "unable to get issuer certificate";
     case X509_V_ERR_UNABLE_TO_GET_CRL:
-        return ("unable to get certificate CRL");
+        return "unable to get certificate CRL";
     case X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE:
-        return ("unable to decrypt certificate's signature");
+        return "unable to decrypt certificate's signature";
     case X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE:
-        return ("unable to decrypt CRL's signature");
+        return "unable to decrypt CRL's signature";
     case X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY:
-        return ("unable to decode issuer public key");
+        return "unable to decode issuer public key";
     case X509_V_ERR_CERT_SIGNATURE_FAILURE:
-        return ("certificate signature failure");
+        return "certificate signature failure";
     case X509_V_ERR_CRL_SIGNATURE_FAILURE:
-        return ("CRL signature failure");
+        return "CRL signature failure";
     case X509_V_ERR_CERT_NOT_YET_VALID:
-        return ("certificate is not yet valid");
+        return "certificate is not yet valid";
     case X509_V_ERR_CERT_HAS_EXPIRED:
-        return ("certificate has expired");
+        return "certificate has expired";
     case X509_V_ERR_CRL_NOT_YET_VALID:
-        return ("CRL is not yet valid");
+        return "CRL is not yet valid";
     case X509_V_ERR_CRL_HAS_EXPIRED:
-        return ("CRL has expired");
+        return "CRL has expired";
     case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
-        return ("format error in certificate's notBefore field");
+        return "format error in certificate's notBefore field";
     case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
-        return ("format error in certificate's notAfter field");
+        return "format error in certificate's notAfter field";
     case X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD:
-        return ("format error in CRL's lastUpdate field");
+        return "format error in CRL's lastUpdate field";
     case X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD:
-        return ("format error in CRL's nextUpdate field");
+        return "format error in CRL's nextUpdate field";
     case X509_V_ERR_OUT_OF_MEM:
-        return ("out of memory");
+        return "out of memory";
     case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
-        return ("self signed certificate");
+        return "self signed certificate";
     case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
-        return ("self signed certificate in certificate chain");
+        return "self signed certificate in certificate chain";
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
-        return ("unable to get local issuer certificate");
+        return "unable to get local issuer certificate";
     case X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE:
-        return ("unable to verify the first certificate");
+        return "unable to verify the first certificate";
     case X509_V_ERR_CERT_CHAIN_TOO_LONG:
-        return ("certificate chain too long");
+        return "certificate chain too long";
     case X509_V_ERR_CERT_REVOKED:
-        return ("certificate revoked");
+        return "certificate revoked";
     case X509_V_ERR_INVALID_CA:
-        return ("invalid CA certificate");
+        return "invalid CA certificate";
     case X509_V_ERR_PATH_LENGTH_EXCEEDED:
-        return ("path length constraint exceeded");
+        return "path length constraint exceeded";
     case X509_V_ERR_INVALID_PURPOSE:
-        return ("unsupported certificate purpose");
+        return "unsupported certificate purpose";
     case X509_V_ERR_CERT_UNTRUSTED:
-        return ("certificate not trusted");
+        return "certificate not trusted";
     case X509_V_ERR_CERT_REJECTED:
-        return ("certificate rejected");
+        return "certificate rejected";
     case X509_V_ERR_SUBJECT_ISSUER_MISMATCH:
-        return ("subject issuer mismatch");
+        return "subject issuer mismatch";
     case X509_V_ERR_AKID_SKID_MISMATCH:
-        return ("authority and subject key identifier mismatch");
+        return "authority and subject key identifier mismatch";
     case X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH:
-        return ("authority and issuer serial number mismatch");
+        return "authority and issuer serial number mismatch";
     case X509_V_ERR_KEYUSAGE_NO_CERTSIGN:
-        return ("key usage does not include certificate signing");
+        return "key usage does not include certificate signing";
     case X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER:
-        return ("unable to get CRL issuer certificate");
+        return "unable to get CRL issuer certificate";
     case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
-        return ("unhandled critical extension");
+        return "unhandled critical extension";
     case X509_V_ERR_KEYUSAGE_NO_CRL_SIGN:
-        return ("key usage does not include CRL signing");
+        return "key usage does not include CRL signing";
     case X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION:
-        return ("unhandled critical CRL extension");
+        return "unhandled critical CRL extension";
     case X509_V_ERR_INVALID_NON_CA:
-        return ("invalid non-CA certificate (has CA markings)");
+        return "invalid non-CA certificate (has CA markings)";
     case X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED:
-        return ("proxy path length constraint exceeded");
+        return "proxy path length constraint exceeded";
     case X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE:
-        return ("key usage does not include digital signature");
+        return "key usage does not include digital signature";
     case X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED:
         return
-            ("proxy certificates not allowed, please set the appropriate flag");
+            "proxy certificates not allowed, please set the appropriate flag";
     case X509_V_ERR_INVALID_EXTENSION:
-        return ("invalid or inconsistent certificate extension");
+        return "invalid or inconsistent certificate extension";
     case X509_V_ERR_INVALID_POLICY_EXTENSION:
-        return ("invalid or inconsistent certificate policy extension");
+        return "invalid or inconsistent certificate policy extension";
     case X509_V_ERR_NO_EXPLICIT_POLICY:
-        return ("no explicit policy");
+        return "no explicit policy";
     case X509_V_ERR_DIFFERENT_CRL_SCOPE:
-        return ("Different CRL scope");
+        return "Different CRL scope";
     case X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE:
-        return ("Unsupported extension feature");
+        return "Unsupported extension feature";
     case X509_V_ERR_UNNESTED_RESOURCE:
-        return ("RFC 3779 resource not subset of parent's resources");
+        return "RFC 3779 resource not subset of parent's resources";
     case X509_V_ERR_PERMITTED_VIOLATION:
-        return ("permitted subtree violation");
+        return "permitted subtree violation";
     case X509_V_ERR_EXCLUDED_VIOLATION:
-        return ("excluded subtree violation");
+        return "excluded subtree violation";
     case X509_V_ERR_SUBTREE_MINMAX:
-        return ("name constraints minimum and maximum not supported");
+        return "name constraints minimum and maximum not supported";
     case X509_V_ERR_APPLICATION_VERIFICATION:
-        return ("application verification failure");
+        return "application verification failure";
     case X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE:
-        return ("unsupported name constraint type");
+        return "unsupported name constraint type";
     case X509_V_ERR_UNSUPPORTED_CONSTRAINT_SYNTAX:
-        return ("unsupported or invalid name constraint syntax");
+        return "unsupported or invalid name constraint syntax";
     case X509_V_ERR_UNSUPPORTED_NAME_SYNTAX:
-        return ("unsupported or invalid name syntax");
+        return "unsupported or invalid name syntax";
     case X509_V_ERR_CRL_PATH_VALIDATION_ERROR:
-        return ("CRL path validation error");
+        return "CRL path validation error";
     case X509_V_ERR_PATH_LOOP:
-        return ("Path Loop");
+        return "Path Loop";
     case X509_V_ERR_SUITE_B_INVALID_VERSION:
-        return ("Suite B: certificate version invalid");
+        return "Suite B: certificate version invalid";
     case X509_V_ERR_SUITE_B_INVALID_ALGORITHM:
-        return ("Suite B: invalid public key algorithm");
+        return "Suite B: invalid public key algorithm";
     case X509_V_ERR_SUITE_B_INVALID_CURVE:
-        return ("Suite B: invalid ECC curve");
+        return "Suite B: invalid ECC curve";
     case X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM:
-        return ("Suite B: invalid signature algorithm");
+        return "Suite B: invalid signature algorithm";
     case X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED:
-        return ("Suite B: curve not allowed for this LOS");
+        return "Suite B: curve not allowed for this LOS";
     case X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256:
-        return ("Suite B: cannot sign P-384 with P-256");
+        return "Suite B: cannot sign P-384 with P-256";
     case X509_V_ERR_HOSTNAME_MISMATCH:
-        return ("Hostname mismatch");
+        return "Hostname mismatch";
     case X509_V_ERR_EMAIL_MISMATCH:
-        return ("Email address mismatch");
+        return "Email address mismatch";
     case X509_V_ERR_IP_ADDRESS_MISMATCH:
-        return ("IP address mismatch");
+        return "IP address mismatch";
     case X509_V_ERR_DANE_NO_MATCH:
-        return ("No matching DANE TLSA records");
+        return "No matching DANE TLSA records";
     case X509_V_ERR_EE_KEY_TOO_SMALL:
-        return ("EE certificate key too weak");
+        return "EE certificate key too weak";
     case X509_V_ERR_CA_KEY_TOO_SMALL:
-        return ("CA certificate key too weak");
+        return "CA certificate key too weak";
     case X509_V_ERR_CA_MD_TOO_WEAK:
-        return ("CA signature digest algorithm too weak");
+        return "CA signature digest algorithm too weak";
     case X509_V_ERR_INVALID_CALL:
-        return ("Invalid certificate verification context");
+        return "Invalid certificate verification context";
     case X509_V_ERR_STORE_LOOKUP:
-        return ("Issuer certificate lookup error");
+        return "Issuer certificate lookup error";
     case X509_V_ERR_NO_VALID_SCTS:
-        return ("Certificate Transparency required, but no valid SCTs found");
+        return "Certificate Transparency required, but no valid SCTs found";
     case X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION:
-        return ("proxy subject name violation");
+        return "proxy subject name violation";
     case X509_V_ERR_OCSP_VERIFY_NEEDED:
-        return("OCSP verification needed");
+        return "OCSP verification needed";
     case X509_V_ERR_OCSP_VERIFY_FAILED:
-        return("OCSP verification failed");
+        return "OCSP verification failed";
     case X509_V_ERR_OCSP_CERT_UNKNOWN:
-        return("OCSP unknown cert");
+        return "OCSP unknown cert";
 
     default:
         /* Printing an error number into a static buffer is not thread-safe */
-        return ("unknown certificate verification error");
+        return "unknown certificate verification error";
     }
 }

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -20,8 +20,8 @@
 int X509v3_get_ext_count(const STACK_OF(X509_EXTENSION) *x)
 {
     if (x == NULL)
-        return (0);
-    return (sk_X509_EXTENSION_num(x));
+        return 0;
+    return sk_X509_EXTENSION_num(x);
 }
 
 int X509v3_get_ext_by_NID(const STACK_OF(X509_EXTENSION) *x, int nid,
@@ -31,8 +31,8 @@ int X509v3_get_ext_by_NID(const STACK_OF(X509_EXTENSION) *x, int nid,
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return (-2);
-    return (X509v3_get_ext_by_OBJ(x, obj, lastpos));
+        return -2;
+    return X509v3_get_ext_by_OBJ(x, obj, lastpos);
 }
 
 int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
@@ -42,7 +42,7 @@ int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
     X509_EXTENSION *ex;
 
     if (sk == NULL)
-        return (-1);
+        return -1;
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
@@ -50,9 +50,9 @@ int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_EXTENSION_value(sk, lastpos);
         if (OBJ_cmp(ex->object, obj) == 0)
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 int X509v3_get_ext_by_critical(const STACK_OF(X509_EXTENSION) *sk, int crit,
@@ -62,7 +62,7 @@ int X509v3_get_ext_by_critical(const STACK_OF(X509_EXTENSION) *sk, int crit,
     X509_EXTENSION *ex;
 
     if (sk == NULL)
-        return (-1);
+        return -1;
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
@@ -70,9 +70,9 @@ int X509v3_get_ext_by_critical(const STACK_OF(X509_EXTENSION) *sk, int crit,
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_EXTENSION_value(sk, lastpos);
         if (((ex->critical > 0) && crit) || ((ex->critical <= 0) && !crit))
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 X509_EXTENSION *X509v3_get_ext(const STACK_OF(X509_EXTENSION) *x, int loc)
@@ -88,9 +88,9 @@ X509_EXTENSION *X509v3_delete_ext(STACK_OF(X509_EXTENSION) *x, int loc)
     X509_EXTENSION *ret;
 
     if (x == NULL || sk_X509_EXTENSION_num(x) <= loc || loc < 0)
-        return (NULL);
+        return NULL;
     ret = sk_X509_EXTENSION_delete(x, loc);
-    return (ret);
+    return ret;
 }
 
 STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
@@ -123,13 +123,13 @@ STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
         goto err;
     if (*x == NULL)
         *x = sk;
-    return (sk);
+    return sk;
  err:
     X509err(X509_F_X509V3_ADD_EXT, ERR_R_MALLOC_FAILURE);
  err2:
     X509_EXTENSION_free(new_ex);
     sk_X509_EXTENSION_free(sk);
-    return (NULL);
+    return NULL;
 }
 
 X509_EXTENSION *X509_EXTENSION_create_by_NID(X509_EXTENSION **ex, int nid,
@@ -142,12 +142,12 @@ X509_EXTENSION *X509_EXTENSION_create_by_NID(X509_EXTENSION **ex, int nid,
     obj = OBJ_nid2obj(nid);
     if (obj == NULL) {
         X509err(X509_F_X509_EXTENSION_CREATE_BY_NID, X509_R_UNKNOWN_NID);
-        return (NULL);
+        return NULL;
     }
     ret = X509_EXTENSION_create_by_OBJ(ex, obj, crit, data);
     if (ret == NULL)
         ASN1_OBJECT_free(obj);
-    return (ret);
+    return ret;
 }
 
 X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **ex,
@@ -160,7 +160,7 @@ X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **ex,
         if ((ret = X509_EXTENSION_new()) == NULL) {
             X509err(X509_F_X509_EXTENSION_CREATE_BY_OBJ,
                     ERR_R_MALLOC_FAILURE);
-            return (NULL);
+            return NULL;
         }
     } else
         ret = *ex;
@@ -174,17 +174,17 @@ X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **ex,
 
     if ((ex != NULL) && (*ex == NULL))
         *ex = ret;
-    return (ret);
+    return ret;
  err:
     if ((ex == NULL) || (ret != *ex))
         X509_EXTENSION_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 int X509_EXTENSION_set_object(X509_EXTENSION *ex, const ASN1_OBJECT *obj)
 {
     if ((ex == NULL) || (obj == NULL))
-        return (0);
+        return 0;
     ASN1_OBJECT_free(ex->object);
     ex->object = OBJ_dup(obj);
     return ex->object != NULL;
@@ -193,7 +193,7 @@ int X509_EXTENSION_set_object(X509_EXTENSION *ex, const ASN1_OBJECT *obj)
 int X509_EXTENSION_set_critical(X509_EXTENSION *ex, int crit)
 {
     if (ex == NULL)
-        return (0);
+        return 0;
     ex->critical = (crit) ? 0xFF : -1;
     return 1;
 }
@@ -203,31 +203,31 @@ int X509_EXTENSION_set_data(X509_EXTENSION *ex, ASN1_OCTET_STRING *data)
     int i;
 
     if (ex == NULL)
-        return (0);
+        return 0;
     i = ASN1_OCTET_STRING_set(&ex->value, data->data, data->length);
     if (!i)
-        return (0);
+        return 0;
     return 1;
 }
 
 ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *ex)
 {
     if (ex == NULL)
-        return (NULL);
-    return (ex->object);
+        return NULL;
+    return ex->object;
 }
 
 ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *ex)
 {
     if (ex == NULL)
-        return (NULL);
+        return NULL;
     return &ex->value;
 }
 
 int X509_EXTENSION_get_critical(const X509_EXTENSION *ex)
 {
     if (ex == NULL)
-        return (0);
+        return 0;
     if (ex->critical > 0)
         return 1;
     return 0;

--- a/crypto/x509/x509cset.c
+++ b/crypto/x509/x509cset.c
@@ -19,19 +19,19 @@
 int X509_CRL_set_version(X509_CRL *x, long version)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     if (x->crl.version == NULL) {
         if ((x->crl.version = ASN1_INTEGER_new()) == NULL)
-            return (0);
+            return 0;
     }
-    return (ASN1_INTEGER_set(x->crl.version, version));
+    return ASN1_INTEGER_set(x->crl.version, version);
 }
 
 int X509_CRL_set_issuer_name(X509_CRL *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
-    return (X509_NAME_set(&x->crl.issuer, name));
+        return 0;
+    return X509_NAME_set(&x->crl.issuer, name);
 }
 
 int X509_CRL_set1_lastUpdate(X509_CRL *x, const ASN1_TIME *tm)
@@ -142,7 +142,7 @@ int X509_REVOKED_set_revocationDate(X509_REVOKED *x, ASN1_TIME *tm)
     ASN1_TIME *in;
 
     if (x == NULL)
-        return (0);
+        return 0;
     in = x->revocationDate;
     if (in != tm) {
         in = ASN1_STRING_dup(tm);
@@ -164,7 +164,7 @@ int X509_REVOKED_set_serialNumber(X509_REVOKED *x, ASN1_INTEGER *serial)
     ASN1_INTEGER *in;
 
     if (x == NULL)
-        return (0);
+        return 0;
     in = &x->serialNumber;
     if (in != serial)
         return ASN1_STRING_copy(in, serial);

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -22,8 +22,8 @@ int X509_NAME_get_text_by_NID(X509_NAME *name, int nid, char *buf, int len)
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return (-1);
-    return (X509_NAME_get_text_by_OBJ(name, obj, buf, len));
+        return -1;
+    return X509_NAME_get_text_by_OBJ(name, obj, buf, len);
 }
 
 int X509_NAME_get_text_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, char *buf,
@@ -34,21 +34,21 @@ int X509_NAME_get_text_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, char *buf
 
     i = X509_NAME_get_index_by_OBJ(name, obj, -1);
     if (i < 0)
-        return (-1);
+        return -1;
     data = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     i = (data->length > (len - 1)) ? (len - 1) : data->length;
     if (buf == NULL)
-        return (data->length);
+        return data->length;
     memcpy(buf, data->data, i);
     buf[i] = '\0';
-    return (i);
+    return i;
 }
 
 int X509_NAME_entry_count(const X509_NAME *name)
 {
     if (name == NULL)
-        return (0);
-    return (sk_X509_NAME_ENTRY_num(name->entries));
+        return 0;
+    return sk_X509_NAME_ENTRY_num(name->entries);
 }
 
 int X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos)
@@ -57,8 +57,8 @@ int X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos)
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return (-2);
-    return (X509_NAME_get_index_by_OBJ(name, obj, lastpos));
+        return -2;
+    return X509_NAME_get_index_by_OBJ(name, obj, lastpos);
 }
 
 /* NOTE: you should be passing -1, not 0 as lastpos */
@@ -69,7 +69,7 @@ int X509_NAME_get_index_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, int last
     STACK_OF(X509_NAME_ENTRY) *sk;
 
     if (name == NULL)
-        return (-1);
+        return -1;
     if (lastpos < 0)
         lastpos = -1;
     sk = name->entries;
@@ -77,9 +77,9 @@ int X509_NAME_get_index_by_OBJ(X509_NAME *name, const ASN1_OBJECT *obj, int last
     for (lastpos++; lastpos < n; lastpos++) {
         ne = sk_X509_NAME_ENTRY_value(sk, lastpos);
         if (OBJ_cmp(ne->object, obj) == 0)
-            return (lastpos);
+            return lastpos;
     }
-    return (-1);
+    return -1;
 }
 
 X509_NAME_ENTRY *X509_NAME_get_entry(const X509_NAME *name, int loc)
@@ -186,7 +186,7 @@ int X509_NAME_add_entry(X509_NAME *name, const X509_NAME_ENTRY *ne, int loc,
     STACK_OF(X509_NAME_ENTRY) *sk;
 
     if (name == NULL)
-        return (0);
+        return 0;
     sk = name->entries;
     n = sk_X509_NAME_ENTRY_num(sk);
     if (loc > n)
@@ -235,7 +235,7 @@ int X509_NAME_add_entry(X509_NAME *name, const X509_NAME_ENTRY *ne, int loc,
     return 1;
  err:
     X509_NAME_ENTRY_free(new_name);
-    return (0);
+    return 0;
 }
 
 X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_txt(X509_NAME_ENTRY **ne,
@@ -251,7 +251,7 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_txt(X509_NAME_ENTRY **ne,
         X509err(X509_F_X509_NAME_ENTRY_CREATE_BY_TXT,
                 X509_R_INVALID_FIELD_NAME);
         ERR_add_error_data(2, "name=", field);
-        return (NULL);
+        return NULL;
     }
     nentry = X509_NAME_ENTRY_create_by_OBJ(ne, obj, type, bytes, len);
     ASN1_OBJECT_free(obj);
@@ -269,7 +269,7 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_NID(X509_NAME_ENTRY **ne, int nid,
     obj = OBJ_nid2obj(nid);
     if (obj == NULL) {
         X509err(X509_F_X509_NAME_ENTRY_CREATE_BY_NID, X509_R_UNKNOWN_NID);
-        return (NULL);
+        return NULL;
     }
     nentry = X509_NAME_ENTRY_create_by_OBJ(ne, obj, type, bytes, len);
     ASN1_OBJECT_free(obj);
@@ -285,7 +285,7 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_OBJ(X509_NAME_ENTRY **ne,
 
     if ((ne == NULL) || (*ne == NULL)) {
         if ((ret = X509_NAME_ENTRY_new()) == NULL)
-            return (NULL);
+            return NULL;
     } else
         ret = *ne;
 
@@ -296,11 +296,11 @@ X509_NAME_ENTRY *X509_NAME_ENTRY_create_by_OBJ(X509_NAME_ENTRY **ne,
 
     if ((ne != NULL) && (*ne == NULL))
         *ne = ret;
-    return (ret);
+    return ret;
  err:
     if ((ne == NULL) || (ret != *ne))
         X509_NAME_ENTRY_free(ret);
-    return (NULL);
+    return NULL;
 }
 
 int X509_NAME_ENTRY_set_object(X509_NAME_ENTRY *ne, const ASN1_OBJECT *obj)
@@ -308,7 +308,7 @@ int X509_NAME_ENTRY_set_object(X509_NAME_ENTRY *ne, const ASN1_OBJECT *obj)
     if ((ne == NULL) || (obj == NULL)) {
         X509err(X509_F_X509_NAME_ENTRY_SET_OBJECT,
                 ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     ASN1_OBJECT_free(ne->object);
     ne->object = OBJ_dup(obj);
@@ -321,7 +321,7 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
     int i;
 
     if ((ne == NULL) || ((bytes == NULL) && (len != 0)))
-        return (0);
+        return 0;
     if ((type > 0) && (type & MBSTRING_FLAG))
         return ASN1_STRING_set_by_NID(&ne->value, bytes,
                                       len, type,
@@ -330,7 +330,7 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
         len = strlen((const char *)bytes);
     i = ASN1_STRING_set(ne->value, bytes, len);
     if (!i)
-        return (0);
+        return 0;
     if (type != V_ASN1_UNDEF) {
         if (type == V_ASN1_APP_CHOOSE)
             ne->value->type = ASN1_PRINTABLE_type(bytes, len);
@@ -343,15 +343,15 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
 ASN1_OBJECT *X509_NAME_ENTRY_get_object(const X509_NAME_ENTRY *ne)
 {
     if (ne == NULL)
-        return (NULL);
-    return (ne->object);
+        return NULL;
+    return ne->object;
 }
 
 ASN1_STRING *X509_NAME_ENTRY_get_data(const X509_NAME_ENTRY *ne)
 {
     if (ne == NULL)
-        return (NULL);
-    return (ne->value);
+        return NULL;
+    return ne->value;
 }
 
 int X509_NAME_ENTRY_set(const X509_NAME_ENTRY *ne)

--- a/crypto/x509/x509rset.c
+++ b/crypto/x509/x509rset.c
@@ -18,23 +18,23 @@
 int X509_REQ_set_version(X509_REQ *x, long version)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     x->req_info.enc.modified = 1;
-    return (ASN1_INTEGER_set(x->req_info.version, version));
+    return ASN1_INTEGER_set(x->req_info.version, version);
 }
 
 int X509_REQ_set_subject_name(X509_REQ *x, X509_NAME *name)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     x->req_info.enc.modified = 1;
-    return (X509_NAME_set(&x->req_info.subject, name));
+    return X509_NAME_set(&x->req_info.subject, name);
 }
 
 int X509_REQ_set_pubkey(X509_REQ *x, EVP_PKEY *pkey)
 {
     if (x == NULL)
-        return (0);
+        return 0;
     x->req_info.enc.modified = 1;
-    return (X509_PUBKEY_set(&x->req_info.pubkey, pkey));
+    return X509_PUBKEY_set(&x->req_info.pubkey, pkey);
 }

--- a/crypto/x509/x509spki.c
+++ b/crypto/x509/x509spki.c
@@ -14,15 +14,15 @@
 int NETSCAPE_SPKI_set_pubkey(NETSCAPE_SPKI *x, EVP_PKEY *pkey)
 {
     if ((x == NULL) || (x->spkac == NULL))
-        return (0);
-    return (X509_PUBKEY_set(&(x->spkac->pubkey), pkey));
+        return 0;
+    return X509_PUBKEY_set(&(x->spkac->pubkey), pkey);
 }
 
 EVP_PKEY *NETSCAPE_SPKI_get_pubkey(NETSCAPE_SPKI *x)
 {
     if ((x == NULL) || (x->spkac == NULL))
-        return (NULL);
-    return (X509_PUBKEY_get(x->spkac->pubkey));
+        return NULL;
+    return X509_PUBKEY_get(x->spkac->pubkey);
 }
 
 /* Load a Netscape SPKI from a base64 encoded string */

--- a/crypto/x509/x509type.c
+++ b/crypto/x509/x509type.c
@@ -19,7 +19,7 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
     int ret = 0, i;
 
     if (x == NULL)
-        return (0);
+        return 0;
 
     if (pkey == NULL)
         pk = X509_get0_pubkey(x);
@@ -27,7 +27,7 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
         pk = pkey;
 
     if (pk == NULL)
-        return (0);
+        return 0;
 
     switch (EVP_PKEY_id(pk)) {
     case EVP_PKEY_RSA:
@@ -76,5 +76,5 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
         }
     }
 
-    return (ret);
+    return ret;
 }

--- a/crypto/x509/x_attrib.c
+++ b/crypto/x509/x_attrib.c
@@ -39,7 +39,7 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create(int nid, int atrtype, void *value)
     ASN1_TYPE *val = NULL;
 
     if ((ret = X509_ATTRIBUTE_new()) == NULL)
-        return (NULL);
+        return NULL;
     ret->object = OBJ_nid2obj(nid);
     if ((val = ASN1_TYPE_new()) == NULL)
         goto err;
@@ -47,9 +47,9 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create(int nid, int atrtype, void *value)
         goto err;
 
     ASN1_TYPE_set(val, atrtype, value);
-    return (ret);
+    return ret;
  err:
     X509_ATTRIBUTE_free(ret);
     ASN1_TYPE_free(val);
-    return (NULL);
+    return NULL;
 }

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -61,7 +61,7 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
     X509_PUBKEY *pk = NULL;
 
     if (x == NULL)
-        return (0);
+        return 0;
 
     if ((pk = X509_PUBKEY_new()) == NULL)
         goto error;
@@ -304,17 +304,17 @@ EC_KEY *d2i_EC_PUBKEY(EC_KEY **a, const unsigned char **pp, long length)
     q = *pp;
     pkey = d2i_PUBKEY(NULL, &q, length);
     if (!pkey)
-        return (NULL);
+        return NULL;
     key = EVP_PKEY_get1_EC_KEY(pkey);
     EVP_PKEY_free(pkey);
     if (!key)
-        return (NULL);
+        return NULL;
     *pp = q;
     if (a) {
         EC_KEY_free(*a);
         *a = key;
     }
-    return (key);
+    return key;
 }
 
 int i2d_EC_PUBKEY(EC_KEY *a, unsigned char **pp)
@@ -322,15 +322,15 @@ int i2d_EC_PUBKEY(EC_KEY *a, unsigned char **pp)
     EVP_PKEY *pktmp;
     int ret;
     if (!a)
-        return (0);
+        return 0;
     if ((pktmp = EVP_PKEY_new()) == NULL) {
         ASN1err(ASN1_F_I2D_EC_PUBKEY, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
     EVP_PKEY_set1_EC_KEY(pktmp, a);
     ret = i2d_PUBKEY(pktmp, pp);
     EVP_PKEY_free(pktmp);
-    return (ret);
+    return ret;
 }
 #endif
 

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -89,12 +89,12 @@ IMPLEMENT_ASN1_DUP_FUNCTION(X509)
 
 int X509_set_ex_data(X509 *r, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&r->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&r->ex_data, idx, arg);
 }
 
 void *X509_get_ex_data(X509 *r, int idx)
 {
-    return (CRYPTO_get_ex_data(&r->ex_data, idx));
+    return CRYPTO_get_ex_data(&r->ex_data, idx);
 }
 
 /*

--- a/include/internal/constant_time_locl.h
+++ b/include/internal/constant_time_locl.h
@@ -124,7 +124,7 @@ static ossl_inline size_t constant_time_lt_s(size_t a, size_t b)
 static ossl_inline unsigned char constant_time_lt_8(unsigned int a,
                                                     unsigned int b)
 {
-    return (unsigned char)(constant_time_lt(a, b));
+    return (unsigned char)constant_time_lt(a, b);
 }
 
 static ossl_inline uint64_t constant_time_lt_64(uint64_t a, uint64_t b)
@@ -146,12 +146,12 @@ static ossl_inline size_t constant_time_ge_s(size_t a, size_t b)
 static ossl_inline unsigned char constant_time_ge_8(unsigned int a,
                                                     unsigned int b)
 {
-    return (unsigned char)(constant_time_ge(a, b));
+    return (unsigned char)constant_time_ge(a, b);
 }
 
 static ossl_inline unsigned char constant_time_ge_8_s(size_t a, size_t b)
 {
-    return (unsigned char)(constant_time_ge_s(a, b));
+    return (unsigned char)constant_time_ge_s(a, b);
 }
 
 static ossl_inline unsigned int constant_time_is_zero(unsigned int a)
@@ -166,7 +166,7 @@ static ossl_inline size_t constant_time_is_zero_s(size_t a)
 
 static ossl_inline unsigned char constant_time_is_zero_8(unsigned int a)
 {
-    return (unsigned char)(constant_time_is_zero(a));
+    return (unsigned char)constant_time_is_zero(a);
 }
 
 static ossl_inline unsigned int constant_time_eq(unsigned int a,
@@ -183,12 +183,12 @@ static ossl_inline size_t constant_time_eq_s(size_t a, size_t b)
 static ossl_inline unsigned char constant_time_eq_8(unsigned int a,
                                                     unsigned int b)
 {
-    return (unsigned char)(constant_time_eq(a, b));
+    return (unsigned char)constant_time_eq(a, b);
 }
 
 static ossl_inline unsigned char constant_time_eq_8_s(size_t a, size_t b)
 {
-    return (unsigned char)(constant_time_eq_s(a, b));
+    return (unsigned char)constant_time_eq_s(a, b);
 }
 
 static ossl_inline unsigned int constant_time_eq_int(int a, int b)
@@ -219,19 +219,19 @@ static ossl_inline unsigned char constant_time_select_8(unsigned char mask,
                                                         unsigned char a,
                                                         unsigned char b)
 {
-    return (unsigned char)(constant_time_select(mask, a, b));
+    return (unsigned char)constant_time_select(mask, a, b);
 }
 
 static ossl_inline int constant_time_select_int(unsigned int mask, int a,
                                                 int b)
 {
-    return (int)(constant_time_select(mask, (unsigned)(a), (unsigned)(b)));
+    return (int)constant_time_select(mask, (unsigned)(a), (unsigned)(b));
 }
 
 static ossl_inline int constant_time_select_int_s(size_t mask, int a, int b)
 {
-    return (int)(constant_time_select((unsigned)mask, (unsigned)(a),
-                                      (unsigned)(b)));
+    return (int)constant_time_select((unsigned)mask, (unsigned)(a),
+                                      (unsigned)(b));
 }
 
 static ossl_inline uint64_t constant_time_select_64(uint64_t mask, uint64_t a,

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -49,7 +49,7 @@ static const BIO_METHOD methods_sslp = {
 
 const BIO_METHOD *BIO_f_ssl(void)
 {
-    return (&methods_sslp);
+    return &methods_sslp;
 }
 
 static int ssl_new(BIO *bi)
@@ -58,7 +58,7 @@ static int ssl_new(BIO *bi)
 
     if (bs == NULL) {
         BIOerr(BIO_F_SSL_NEW, ERR_R_MALLOC_FAILURE);
-        return (0);
+        return 0;
     }
     BIO_set_init(bi, 0);
     BIO_set_data(bi, bs);
@@ -73,7 +73,7 @@ static int ssl_free(BIO *a)
     BIO_SSL *bs;
 
     if (a == NULL)
-        return (0);
+        return 0;
     bs = BIO_get_data(a);
     if (bs->ssl != NULL)
         SSL_shutdown(bs->ssl);
@@ -232,7 +232,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
     next = BIO_next(b);
     ssl = bs->ssl;
     if ((ssl == NULL) && (cmd != BIO_C_SET_SSL))
-        return (0);
+        return 0;
     switch (cmd) {
     case BIO_CTRL_RESET:
         SSL_shutdown(ssl);
@@ -394,7 +394,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = BIO_ctrl(ssl->rbio, cmd, num, ptr);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static long ssl_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
@@ -419,7 +419,7 @@ static long ssl_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
         ret = BIO_callback_ctrl(ssl->rbio, cmd, fp);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 static int ssl_puts(BIO *bp, const char *str)
@@ -428,7 +428,7 @@ static int ssl_puts(BIO *bp, const char *str)
 
     n = strlen(str);
     ret = BIO_write(bp, str, n);
-    return (ret);
+    return ret;
 }
 
 BIO *BIO_new_buffer_ssl_connect(SSL_CTX *ctx)
@@ -437,17 +437,17 @@ BIO *BIO_new_buffer_ssl_connect(SSL_CTX *ctx)
     BIO *ret = NULL, *buf = NULL, *ssl = NULL;
 
     if ((buf = BIO_new(BIO_f_buffer())) == NULL)
-        return (NULL);
+        return NULL;
     if ((ssl = BIO_new_ssl_connect(ctx)) == NULL)
         goto err;
     if ((ret = BIO_push(buf, ssl)) == NULL)
         goto err;
-    return (ret);
+    return ret;
  err:
     BIO_free(buf);
     BIO_free(ssl);
 #endif
-    return (NULL);
+    return NULL;
 }
 
 BIO *BIO_new_ssl_connect(SSL_CTX *ctx)
@@ -456,16 +456,16 @@ BIO *BIO_new_ssl_connect(SSL_CTX *ctx)
     BIO *ret = NULL, *con = NULL, *ssl = NULL;
 
     if ((con = BIO_new(BIO_s_connect())) == NULL)
-        return (NULL);
+        return NULL;
     if ((ssl = BIO_new_ssl(ctx, 1)) == NULL)
         goto err;
     if ((ret = BIO_push(ssl, con)) == NULL)
         goto err;
-    return (ret);
+    return ret;
  err:
     BIO_free(con);
 #endif
-    return (NULL);
+    return NULL;
 }
 
 BIO *BIO_new_ssl(SSL_CTX *ctx, int client)
@@ -474,10 +474,10 @@ BIO *BIO_new_ssl(SSL_CTX *ctx, int client)
     SSL *ssl;
 
     if ((ret = BIO_new(BIO_f_ssl())) == NULL)
-        return (NULL);
+        return NULL;
     if ((ssl = SSL_new(ctx)) == NULL) {
         BIO_free(ret);
-        return (NULL);
+        return NULL;
     }
     if (client)
         SSL_set_connect_state(ssl);
@@ -485,7 +485,7 @@ BIO *BIO_new_ssl(SSL_CTX *ctx, int client)
         SSL_set_accept_state(ssl);
 
     BIO_set_ssl(ret, ssl, BIO_CLOSE);
-    return (ret);
+    return ret;
 }
 
 int BIO_ssl_copy_session_id(BIO *t, BIO *f)
@@ -498,7 +498,7 @@ int BIO_ssl_copy_session_id(BIO *t, BIO *f)
     tdata = BIO_get_data(t);
     fdata = BIO_get_data(f);
     if ((tdata->ssl == NULL) || (fdata->ssl == NULL))
-        return (0);
+        return 0;
     if (!SSL_copy_session_id(tdata->ssl, (fdata->ssl)))
         return 0;
     return 1;

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -236,7 +236,7 @@ long dtls1_ctrl(SSL *s, int cmd, long larg, void *parg)
         ret = ssl3_ctrl(s, cmd, larg, parg);
         break;
     }
-    return (ret);
+    return ret;
 }
 
 void dtls1_start_timer(SSL *s)

--- a/ssl/d1_msg.c
+++ b/ssl/d1_msg.c
@@ -17,7 +17,7 @@ int dtls1_write_app_data_bytes(SSL *s, int type, const void *buf_, size_t len,
     if (SSL_in_init(s) && !ossl_statem_get_in_handshake(s)) {
         i = s->handshake_func(s);
         if (i < 0)
-            return (i);
+            return i;
         if (i == 0) {
             SSLerr(SSL_F_DTLS1_WRITE_APP_DATA_BYTES,
                    SSL_R_SSL_HANDSHAKE_FAILURE);

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -21,7 +21,7 @@ int DTLS_RECORD_LAYER_new(RECORD_LAYER *rl)
     DTLS_RECORD_LAYER *d;
 
     if ((d = OPENSSL_malloc(sizeof(*d))) == NULL)
-        return (0);
+        return 0;
 
     rl->d = d;
 
@@ -36,7 +36,7 @@ int DTLS_RECORD_LAYER_new(RECORD_LAYER *rl)
         pqueue_free(d->buffered_app_data.q);
         OPENSSL_free(d);
         rl->d = NULL;
-        return (0);
+        return 0;
     }
 
     return 1;
@@ -179,7 +179,7 @@ int dtls1_buffer_record(SSL *s, record_pqueue *queue, unsigned char *priority)
         OPENSSL_free(rdata->rbuf.buf);
         OPENSSL_free(rdata);
         pitem_free(item);
-        return (-1);
+        return -1;
     }
 
     /* insert should not fail, since duplicates are dropped */
@@ -188,7 +188,7 @@ int dtls1_buffer_record(SSL *s, record_pqueue *queue, unsigned char *priority)
         OPENSSL_free(rdata->rbuf.buf);
         OPENSSL_free(rdata);
         pitem_free(item);
-        return (-1);
+        return -1;
     }
 
     return 1;
@@ -208,7 +208,7 @@ int dtls1_retrieve_buffered_record(SSL *s, record_pqueue *queue)
         return 1;
     }
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -339,7 +339,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
     if (!SSL3_BUFFER_is_initialised(&s->rlayer.rbuf)) {
         /* Not initialized yet */
         if (!ssl3_setup_buffers(s))
-            return (-1);
+            return -1;
     }
 
     if ((type && (type != SSL3_RT_APPLICATION_DATA) &&

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -657,7 +657,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
     if (s->s3->alert_dispatch) {
         i = s->method->ssl_dispatch_alert(s);
         if (i <= 0)
-            return (i);
+            return i;
         /* if it went, fall through and send more stuff */
     }
 
@@ -1104,7 +1104,7 @@ int ssl3_write_pending(SSL *s, int type, const unsigned char *buf, size_t len,
                  */
                 SSL3_BUFFER_set_left(&wb[currbuf], 0);
             }
-            return (i);
+            return i;
         }
         SSL3_BUFFER_add_offset(&wb[currbuf], tmpwrit);
         SSL3_BUFFER_sub_left(&wb[currbuf], tmpwrit);

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -758,7 +758,7 @@ int ssl3_do_compress(SSL *ssl, SSL3_RECORD *wr)
                             (int)(wr->length + SSL3_RT_MAX_COMPRESSED_OVERHEAD),
                             wr->input, (int)wr->length);
     if (i < 0)
-        return (0);
+        return 0;
     else
         wr->length = i;
 
@@ -1714,7 +1714,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
  f_err:
     ssl3_send_alert(s, SSL3_AL_FATAL, al);
  err:
-    return (0);
+    return 0;
 }
 
 /*

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -216,7 +216,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
  err2:
     OPENSSL_cleanse(exp_key, sizeof(exp_key));
     OPENSSL_cleanse(exp_iv, sizeof(exp_iv));
-    return (0);
+    return 0;
 }
 
 int ssl3_setup_key_block(SSL *s)
@@ -233,7 +233,7 @@ int ssl3_setup_key_block(SSL *s)
 
     if (!ssl_cipher_get_evp(s->session, &c, &hash, NULL, NULL, &comp, 0)) {
         SSLerr(SSL_F_SSL3_SETUP_KEY_BLOCK, SSL_R_CIPHER_OR_HASH_UNAVAILABLE);
-        return (0);
+        return 0;
     }
 
     s->s3->tmp.new_sym_enc = c;
@@ -283,7 +283,7 @@ int ssl3_setup_key_block(SSL *s)
 
  err:
     SSLerr(SSL_F_SSL3_SETUP_KEY_BLOCK, ERR_R_MALLOC_FAILURE);
-    return (0);
+    return 0;
 }
 
 void ssl3_cleanup_key_block(SSL *s)
@@ -471,72 +471,72 @@ int ssl3_alert_code(int code)
 {
     switch (code) {
     case SSL_AD_CLOSE_NOTIFY:
-        return (SSL3_AD_CLOSE_NOTIFY);
+        return SSL3_AD_CLOSE_NOTIFY;
     case SSL_AD_UNEXPECTED_MESSAGE:
-        return (SSL3_AD_UNEXPECTED_MESSAGE);
+        return SSL3_AD_UNEXPECTED_MESSAGE;
     case SSL_AD_BAD_RECORD_MAC:
-        return (SSL3_AD_BAD_RECORD_MAC);
+        return SSL3_AD_BAD_RECORD_MAC;
     case SSL_AD_DECRYPTION_FAILED:
-        return (SSL3_AD_BAD_RECORD_MAC);
+        return SSL3_AD_BAD_RECORD_MAC;
     case SSL_AD_RECORD_OVERFLOW:
-        return (SSL3_AD_BAD_RECORD_MAC);
+        return SSL3_AD_BAD_RECORD_MAC;
     case SSL_AD_DECOMPRESSION_FAILURE:
-        return (SSL3_AD_DECOMPRESSION_FAILURE);
+        return SSL3_AD_DECOMPRESSION_FAILURE;
     case SSL_AD_HANDSHAKE_FAILURE:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_NO_CERTIFICATE:
-        return (SSL3_AD_NO_CERTIFICATE);
+        return SSL3_AD_NO_CERTIFICATE;
     case SSL_AD_BAD_CERTIFICATE:
-        return (SSL3_AD_BAD_CERTIFICATE);
+        return SSL3_AD_BAD_CERTIFICATE;
     case SSL_AD_UNSUPPORTED_CERTIFICATE:
-        return (SSL3_AD_UNSUPPORTED_CERTIFICATE);
+        return SSL3_AD_UNSUPPORTED_CERTIFICATE;
     case SSL_AD_CERTIFICATE_REVOKED:
-        return (SSL3_AD_CERTIFICATE_REVOKED);
+        return SSL3_AD_CERTIFICATE_REVOKED;
     case SSL_AD_CERTIFICATE_EXPIRED:
-        return (SSL3_AD_CERTIFICATE_EXPIRED);
+        return SSL3_AD_CERTIFICATE_EXPIRED;
     case SSL_AD_CERTIFICATE_UNKNOWN:
-        return (SSL3_AD_CERTIFICATE_UNKNOWN);
+        return SSL3_AD_CERTIFICATE_UNKNOWN;
     case SSL_AD_ILLEGAL_PARAMETER:
-        return (SSL3_AD_ILLEGAL_PARAMETER);
+        return SSL3_AD_ILLEGAL_PARAMETER;
     case SSL_AD_UNKNOWN_CA:
-        return (SSL3_AD_BAD_CERTIFICATE);
+        return SSL3_AD_BAD_CERTIFICATE;
     case SSL_AD_ACCESS_DENIED:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_DECODE_ERROR:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_DECRYPT_ERROR:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_EXPORT_RESTRICTION:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_PROTOCOL_VERSION:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_INSUFFICIENT_SECURITY:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_INTERNAL_ERROR:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_USER_CANCELLED:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_NO_RENEGOTIATION:
-        return (-1);            /* Don't send it :-) */
+        return -1;            /* Don't send it :-) */
     case SSL_AD_UNSUPPORTED_EXTENSION:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_CERTIFICATE_UNOBTAINABLE:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_UNRECOGNIZED_NAME:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_BAD_CERTIFICATE_STATUS_RESPONSE:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_BAD_CERTIFICATE_HASH_VALUE:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_UNKNOWN_PSK_IDENTITY:
-        return (TLS1_AD_UNKNOWN_PSK_IDENTITY);
+        return TLS1_AD_UNKNOWN_PSK_IDENTITY;
     case SSL_AD_INAPPROPRIATE_FALLBACK:
-        return (TLS1_AD_INAPPROPRIATE_FALLBACK);
+        return TLS1_AD_INAPPROPRIATE_FALLBACK;
     case SSL_AD_NO_APPLICATION_PROTOCOL:
-        return (TLS1_AD_NO_APPLICATION_PROTOCOL);
+        return TLS1_AD_NO_APPLICATION_PROTOCOL;
     case SSL_AD_CERTIFICATE_REQUIRED:
         return SSL_AD_HANDSHAKE_FAILURE;
     default:
-        return (-1);
+        return -1;
     }
 }

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3276,15 +3276,15 @@ long ssl3_default_timeout(void)
 
 int ssl3_num_ciphers(void)
 {
-    return (SSL3_NUM_CIPHERS);
+    return SSL3_NUM_CIPHERS;
 }
 
 const SSL_CIPHER *ssl3_get_cipher(unsigned int u)
 {
     if (u < SSL3_NUM_CIPHERS)
-        return (&(ssl3_ciphers[SSL3_NUM_CIPHERS - 1 - u]));
+        return &(ssl3_ciphers[SSL3_NUM_CIPHERS - 1 - u]);
     else
-        return (NULL);
+        return NULL;
 }
 
 int ssl3_set_handshake_header(SSL *s, WPACKET *pkt, int htype)
@@ -3429,7 +3429,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             EVP_PKEY *pkdh = NULL;
             if (dh == NULL) {
                 SSLerr(SSL_F_SSL3_CTRL, ERR_R_PASSED_NULL_PARAMETER);
-                return (ret);
+                return ret;
             }
             pkdh = ssl_dh_to_pkey(dh);
             if (pkdh == NULL) {
@@ -3450,7 +3450,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_SET_TMP_DH_CB:
         {
             SSLerr(SSL_F_SSL3_CTRL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-            return (ret);
+            return ret;
         }
     case SSL_CTRL_SET_DH_AUTO:
         s->cert->dh_tmp_auto = larg;
@@ -3715,7 +3715,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     default:
         break;
     }
-    return (ret);
+    return ret;
 }
 
 long ssl3_callback_ctrl(SSL *s, int cmd, void (*fp) (void))
@@ -3743,7 +3743,7 @@ long ssl3_callback_ctrl(SSL *s, int cmd, void (*fp) (void))
     default:
         break;
     }
-    return (ret);
+    return ret;
 }
 
 long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
@@ -3776,7 +3776,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     case SSL_CTRL_SET_TMP_DH_CB:
         {
             SSLerr(SSL_F_SSL3_CTX_CTRL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-            return (0);
+            return 0;
         }
     case SSL_CTRL_SET_DH_AUTO:
         ctx->cert->dh_tmp_auto = larg;
@@ -3984,7 +3984,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         return ssl_cert_set_current(ctx->cert, larg);
 
     default:
-        return (0);
+        return 0;
     }
     return 1;
 }
@@ -4036,7 +4036,7 @@ long ssl3_ctx_callback_ctrl(SSL_CTX *ctx, int cmd, void (*fp) (void))
         }
         break;
     default:
-        return (0);
+        return 0;
     }
     return 1;
 }
@@ -4229,7 +4229,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
             break;
         }
     }
-    return (ret);
+    return ret;
 }
 
 int ssl3_get_req_cert_type(SSL *s, WPACKET *pkt)
@@ -4321,7 +4321,7 @@ int ssl3_shutdown(SSL *s)
          * written, s->s3->alert_dispatch will be true
          */
         if (s->s3->alert_dispatch)
-            return (-1);        /* return WANT_WRITE */
+            return -1;        /* return WANT_WRITE */
     } else if (s->s3->alert_dispatch) {
         /* resend it if not sent */
         ret = s->method->ssl_dispatch_alert(s);
@@ -4331,7 +4331,7 @@ int ssl3_shutdown(SSL *s)
              * have already signalled return 0 upon a previous invocation,
              * return WANT_WRITE
              */
-            return (ret);
+            return ret;
         }
     } else if (!(s->shutdown & SSL_RECEIVED_SHUTDOWN)) {
         size_t readbytes;
@@ -4348,7 +4348,7 @@ int ssl3_shutdown(SSL *s)
         !s->s3->alert_dispatch)
         return 1;
     else
-        return (0);
+        return 0;
 }
 
 int ssl3_write(SSL *s, const void *buf, size_t len, size_t *written)

--- a/ssl/s3_msg.c
+++ b/ssl/s3_msg.c
@@ -25,16 +25,16 @@ int ssl3_do_change_cipher_spec(SSL *s)
         if (s->session == NULL || s->session->master_key_length == 0) {
             /* might happen if dtls1_read_bytes() calls this */
             SSLerr(SSL_F_SSL3_DO_CHANGE_CIPHER_SPEC, SSL_R_CCS_RECEIVED_EARLY);
-            return (0);
+            return 0;
         }
 
         s->session->cipher = s->s3->tmp.new_cipher;
         if (!s->method->ssl3_enc->setup_key_block(s))
-            return (0);
+            return 0;
     }
 
     if (!s->method->ssl3_enc->change_cipher_state(s, i))
-        return (0);
+        return 0;
 
     /*
      * we have to record the message digest at this point so we can get it

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -572,7 +572,7 @@ int SSL_CTX_add_client_CA(SSL_CTX *ctx, X509 *x)
 
 static int xname_sk_cmp(const X509_NAME *const *a, const X509_NAME *const *b)
 {
-    return (X509_NAME_cmp(*a, *b));
+    return X509_NAME_cmp(*a, *b);
 }
 
 static int xname_cmp(const X509_NAME *a, const X509_NAME *b)
@@ -647,7 +647,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file)
     lh_X509_NAME_free(name_hash);
     if (ret != NULL)
         ERR_clear_error();
-    return (ret);
+    return ret;
 }
 
 /**

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1776,7 +1776,7 @@ SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n)
     int i, nn;
 
     if ((n == 0) || (sk == NULL))
-        return (NULL);
+        return NULL;
     nn = sk_SSL_COMP_num(sk);
     for (i = 0; i < nn; i++) {
         ctmp = sk_SSL_COMP_value(sk, i);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -602,7 +602,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth)
                                 SSL_DEFAULT_CIPHER_LIST, ctx->cert);
     if ((sk == NULL) || (sk_SSL_CIPHER_num(sk) <= 0)) {
         SSLerr(SSL_F_SSL_CTX_SET_SSL_VERSION, SSL_R_SSL_LIBRARY_HAS_NO_CIPHERS);
-        return (0);
+        return 0;
     }
     return 1;
 }
@@ -613,11 +613,11 @@ SSL *SSL_new(SSL_CTX *ctx)
 
     if (ctx == NULL) {
         SSLerr(SSL_F_SSL_NEW, SSL_R_NULL_SSL_CTX);
-        return (NULL);
+        return NULL;
     }
     if (ctx->method == NULL) {
         SSLerr(SSL_F_SSL_NEW, SSL_R_SSL_CTX_HAS_NO_DEFAULT_SSL_VERSION);
-        return (NULL);
+        return NULL;
     }
 
     s = OPENSSL_zalloc(sizeof(*s));
@@ -1248,7 +1248,7 @@ int SSL_get_rfd(const SSL *s)
     r = BIO_find_type(b, BIO_TYPE_DESCRIPTOR);
     if (r != NULL)
         BIO_get_fd(r, &ret);
-    return (ret);
+    return ret;
 }
 
 int SSL_get_wfd(const SSL *s)
@@ -1260,7 +1260,7 @@ int SSL_get_wfd(const SSL *s)
     r = BIO_find_type(b, BIO_TYPE_DESCRIPTOR);
     if (r != NULL)
         BIO_get_fd(r, &ret);
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_SOCK
@@ -1279,7 +1279,7 @@ int SSL_set_fd(SSL *s, int fd)
     SSL_set_bio(s, bio, bio);
     ret = 1;
  err:
-    return (ret);
+    return ret;
 }
 
 int SSL_set_wfd(SSL *s, int fd)
@@ -1356,7 +1356,7 @@ size_t SSL_get_peer_finished(const SSL *s, void *buf, size_t count)
 
 int SSL_get_verify_mode(const SSL *s)
 {
-    return (s->verify_mode);
+    return s->verify_mode;
 }
 
 int SSL_get_verify_depth(const SSL *s)
@@ -1365,12 +1365,12 @@ int SSL_get_verify_depth(const SSL *s)
 }
 
 int (*SSL_get_verify_callback(const SSL *s)) (int, X509_STORE_CTX *) {
-    return (s->verify_callback);
+    return s->verify_callback;
 }
 
 int SSL_CTX_get_verify_mode(const SSL_CTX *ctx)
 {
-    return (ctx->verify_mode);
+    return ctx->verify_mode;
 }
 
 int SSL_CTX_get_verify_depth(const SSL_CTX *ctx)
@@ -1379,7 +1379,7 @@ int SSL_CTX_get_verify_depth(const SSL_CTX *ctx)
 }
 
 int (*SSL_CTX_get_verify_callback(const SSL_CTX *ctx)) (int, X509_STORE_CTX *) {
-    return (ctx->default_verify_callback);
+    return ctx->default_verify_callback;
 }
 
 void SSL_set_verify(SSL *s, int mode,
@@ -1448,11 +1448,11 @@ X509 *SSL_get_peer_certificate(const SSL *s)
         r = s->session->peer;
 
     if (r == NULL)
-        return (r);
+        return r;
 
     X509_up_ref(r);
 
-    return (r);
+    return r;
 }
 
 STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *s)
@@ -1469,7 +1469,7 @@ STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *s)
      * we are a server, it does not.
      */
 
-    return (r);
+    return r;
 }
 
 /*
@@ -1509,14 +1509,14 @@ int SSL_CTX_check_private_key(const SSL_CTX *ctx)
 {
     if ((ctx == NULL) || (ctx->cert->key->x509 == NULL)) {
         SSLerr(SSL_F_SSL_CTX_CHECK_PRIVATE_KEY, SSL_R_NO_CERTIFICATE_ASSIGNED);
-        return (0);
+        return 0;
     }
     if (ctx->cert->key->privatekey == NULL) {
         SSLerr(SSL_F_SSL_CTX_CHECK_PRIVATE_KEY, SSL_R_NO_PRIVATE_KEY_ASSIGNED);
-        return (0);
+        return 0;
     }
-    return (X509_check_private_key
-            (ctx->cert->key->x509, ctx->cert->key->privatekey));
+    return X509_check_private_key
+            (ctx->cert->key->x509, ctx->cert->key->privatekey);
 }
 
 /* Fix this function so that it takes an optional type parameter */
@@ -1524,18 +1524,18 @@ int SSL_check_private_key(const SSL *ssl)
 {
     if (ssl == NULL) {
         SSLerr(SSL_F_SSL_CHECK_PRIVATE_KEY, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if (ssl->cert->key->x509 == NULL) {
         SSLerr(SSL_F_SSL_CHECK_PRIVATE_KEY, SSL_R_NO_CERTIFICATE_ASSIGNED);
-        return (0);
+        return 0;
     }
     if (ssl->cert->key->privatekey == NULL) {
         SSLerr(SSL_F_SSL_CHECK_PRIVATE_KEY, SSL_R_NO_PRIVATE_KEY_ASSIGNED);
-        return (0);
+        return 0;
     }
-    return (X509_check_private_key(ssl->cert->key->x509,
-                                   ssl->cert->key->privatekey));
+    return X509_check_private_key(ssl->cert->key->x509,
+                                   ssl->cert->key->privatekey);
 }
 
 int SSL_waiting_for_async(SSL *s)
@@ -1588,7 +1588,7 @@ int SSL_connect(SSL *s)
 
 long SSL_get_default_timeout(const SSL *s)
 {
-    return (s->method->get_timeout());
+    return s->method->get_timeout();
 }
 
 static int ssl_start_async_job(SSL *s, struct ssl_async_args *args,
@@ -2035,7 +2035,7 @@ int SSL_renegotiate(SSL *s)
     s->renegotiate = 1;
     s->new_session = 1;
 
-    return (s->method->ssl_renegotiate(s));
+    return s->method->ssl_renegotiate(s);
 }
 
 int SSL_renegotiate_abbreviated(SSL *s)
@@ -2053,7 +2053,7 @@ int SSL_renegotiate_abbreviated(SSL *s)
     s->renegotiate = 1;
     s->new_session = 0;
 
-    return (s->method->ssl_renegotiate(s));
+    return s->method->ssl_renegotiate(s);
 }
 
 int SSL_renegotiate_pending(SSL *s)
@@ -2071,11 +2071,11 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
 
     switch (cmd) {
     case SSL_CTRL_GET_READ_AHEAD:
-        return (RECORD_LAYER_get_read_ahead(&s->rlayer));
+        return RECORD_LAYER_get_read_ahead(&s->rlayer);
     case SSL_CTRL_SET_READ_AHEAD:
         l = RECORD_LAYER_get_read_ahead(&s->rlayer);
         RECORD_LAYER_set_read_ahead(&s->rlayer, larg);
-        return (l);
+        return l;
 
     case SSL_CTRL_SET_MSG_CALLBACK_ARG:
         s->msg_callback_arg = parg;
@@ -2086,7 +2086,7 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_CLEAR_MODE:
         return (s->mode &= ~larg);
     case SSL_CTRL_GET_MAX_CERT_LIST:
-        return (long)(s->max_cert_list);
+        return (long)s->max_cert_list;
     case SSL_CTRL_SET_MAX_CERT_LIST:
         if (larg < 0)
             return 0;
@@ -2151,7 +2151,7 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_MAX_PROTO_VERSION:
         return s->max_proto_version;
     default:
-        return (s->method->ssl_ctrl(s, cmd, larg, parg));
+        return s->method->ssl_ctrl(s, cmd, larg, parg);
     }
 }
 
@@ -2166,7 +2166,7 @@ long SSL_callback_ctrl(SSL *s, int cmd, void (*fp) (void))
         return 1;
 
     default:
-        return (s->method->ssl_callback_ctrl(s, cmd, fp));
+        return s->method->ssl_callback_ctrl(s, cmd, fp);
     }
 }
 
@@ -2195,18 +2195,18 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
 
     switch (cmd) {
     case SSL_CTRL_GET_READ_AHEAD:
-        return (ctx->read_ahead);
+        return ctx->read_ahead;
     case SSL_CTRL_SET_READ_AHEAD:
         l = ctx->read_ahead;
         ctx->read_ahead = larg;
-        return (l);
+        return l;
 
     case SSL_CTRL_SET_MSG_CALLBACK_ARG:
         ctx->msg_callback_arg = parg;
         return 1;
 
     case SSL_CTRL_GET_MAX_CERT_LIST:
-        return (long)(ctx->max_cert_list);
+        return (long)ctx->max_cert_list;
     case SSL_CTRL_SET_MAX_CERT_LIST:
         if (larg < 0)
             return 0;
@@ -2221,38 +2221,38 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         ctx->session_cache_size = (size_t)larg;
         return l;
     case SSL_CTRL_GET_SESS_CACHE_SIZE:
-        return (long)(ctx->session_cache_size);
+        return (long)ctx->session_cache_size;
     case SSL_CTRL_SET_SESS_CACHE_MODE:
         l = ctx->session_cache_mode;
         ctx->session_cache_mode = larg;
-        return (l);
+        return l;
     case SSL_CTRL_GET_SESS_CACHE_MODE:
-        return (ctx->session_cache_mode);
+        return ctx->session_cache_mode;
 
     case SSL_CTRL_SESS_NUMBER:
-        return (lh_SSL_SESSION_num_items(ctx->sessions));
+        return lh_SSL_SESSION_num_items(ctx->sessions);
     case SSL_CTRL_SESS_CONNECT:
-        return (ctx->stats.sess_connect);
+        return ctx->stats.sess_connect;
     case SSL_CTRL_SESS_CONNECT_GOOD:
-        return (ctx->stats.sess_connect_good);
+        return ctx->stats.sess_connect_good;
     case SSL_CTRL_SESS_CONNECT_RENEGOTIATE:
-        return (ctx->stats.sess_connect_renegotiate);
+        return ctx->stats.sess_connect_renegotiate;
     case SSL_CTRL_SESS_ACCEPT:
-        return (ctx->stats.sess_accept);
+        return ctx->stats.sess_accept;
     case SSL_CTRL_SESS_ACCEPT_GOOD:
-        return (ctx->stats.sess_accept_good);
+        return ctx->stats.sess_accept_good;
     case SSL_CTRL_SESS_ACCEPT_RENEGOTIATE:
-        return (ctx->stats.sess_accept_renegotiate);
+        return ctx->stats.sess_accept_renegotiate;
     case SSL_CTRL_SESS_HIT:
-        return (ctx->stats.sess_hit);
+        return ctx->stats.sess_hit;
     case SSL_CTRL_SESS_CB_HIT:
-        return (ctx->stats.sess_cb_hit);
+        return ctx->stats.sess_cb_hit;
     case SSL_CTRL_SESS_MISSES:
-        return (ctx->stats.sess_miss);
+        return ctx->stats.sess_miss;
     case SSL_CTRL_SESS_TIMEOUTS:
-        return (ctx->stats.sess_timeout);
+        return ctx->stats.sess_timeout;
     case SSL_CTRL_SESS_CACHE_FULL:
-        return (ctx->stats.sess_cache_full);
+        return ctx->stats.sess_cache_full;
     case SSL_CTRL_MODE:
         return (ctx->mode |= larg);
     case SSL_CTRL_CLEAR_MODE:
@@ -2291,7 +2291,7 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_MAX_PROTO_VERSION:
         return ctx->max_proto_version;
     default:
-        return (ctx->method->ssl_ctx_ctrl(ctx, cmd, larg, parg));
+        return ctx->method->ssl_ctx_ctrl(ctx, cmd, larg, parg);
     }
 }
 
@@ -2306,7 +2306,7 @@ long SSL_CTX_callback_ctrl(SSL_CTX *ctx, int cmd, void (*fp) (void))
         return 1;
 
     default:
-        return (ctx->method->ssl_ctx_callback_ctrl(ctx, cmd, fp));
+        return ctx->method->ssl_ctx_callback_ctrl(ctx, cmd, fp);
     }
 }
 
@@ -2335,12 +2335,12 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *s)
 {
     if (s != NULL) {
         if (s->cipher_list != NULL) {
-            return (s->cipher_list);
+            return s->cipher_list;
         } else if ((s->ctx != NULL) && (s->ctx->cipher_list != NULL)) {
-            return (s->ctx->cipher_list);
+            return s->ctx->cipher_list;
         }
     }
-    return (NULL);
+    return NULL;
 }
 
 STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *s)
@@ -2380,12 +2380,12 @@ STACK_OF(SSL_CIPHER) *ssl_get_ciphers_by_id(SSL *s)
 {
     if (s != NULL) {
         if (s->cipher_list_by_id != NULL) {
-            return (s->cipher_list_by_id);
+            return s->cipher_list_by_id;
         } else if ((s->ctx != NULL) && (s->ctx->cipher_list_by_id != NULL)) {
-            return (s->ctx->cipher_list_by_id);
+            return s->ctx->cipher_list_by_id;
         }
     }
-    return (NULL);
+    return NULL;
 }
 
 /** The old interface to get the same thing as SSL_get_ciphers() */
@@ -2395,14 +2395,14 @@ const char *SSL_get_cipher_list(const SSL *s, int n)
     STACK_OF(SSL_CIPHER) *sk;
 
     if (s == NULL)
-        return (NULL);
+        return NULL;
     sk = SSL_get_ciphers(s);
     if ((sk == NULL) || (sk_SSL_CIPHER_num(sk) <= n))
-        return (NULL);
+        return NULL;
     c = sk_SSL_CIPHER_value(sk, n);
     if (c == NULL)
-        return (NULL);
-    return (c->name);
+        return NULL;
+    return c->name;
 }
 
 /** return a STACK of the ciphers available for the SSL_CTX and in order of
@@ -2462,7 +2462,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
     int i;
 
     if ((s->session == NULL) || (s->session->ciphers == NULL) || (len < 2))
-        return (NULL);
+        return NULL;
 
     p = buf;
     sk = s->session->ciphers;
@@ -2487,7 +2487,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
         len -= n + 1;
     }
     p[-1] = '\0';
-    return (buf);
+    return buf;
 }
 
 /** return a servername extension value if provided in Client Hello, or NULL.
@@ -2726,7 +2726,7 @@ static unsigned long ssl_session_hash(const SSL_SESSION *a)
         ((unsigned long)session_id[1] << 8L) |
         ((unsigned long)session_id[2] << 16L) |
         ((unsigned long)session_id[3] << 24L);
-    return (l);
+    return l;
 }
 
 /*
@@ -2742,7 +2742,7 @@ static int ssl_session_cmp(const SSL_SESSION *a, const SSL_SESSION *b)
         return 1;
     if (a->session_id_length != b->session_id_length)
         return 1;
-    return (memcmp(a->session_id, b->session_id, a->session_id_length));
+    return memcmp(a->session_id, b->session_id, a->session_id_length);
 }
 
 /*
@@ -2758,7 +2758,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
 
     if (meth == NULL) {
         SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_NULL_SSL_METHOD_PASSED);
-        return (NULL);
+        return NULL;
     }
 
     if (!OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL))
@@ -3218,7 +3218,7 @@ const SSL_METHOD *SSL_CTX_get_ssl_method(SSL_CTX *ctx)
 
 const SSL_METHOD *SSL_get_ssl_method(SSL *s)
 {
-    return (s->method);
+    return s->method;
 }
 
 int SSL_set_ssl_method(SSL *s, const SSL_METHOD *meth)
@@ -3242,7 +3242,7 @@ int SSL_set_ssl_method(SSL *s, const SSL_METHOD *meth)
         else if (hf == sm->ssl_accept)
             s->handshake_func = meth->ssl_accept;
     }
-    return (ret);
+    return ret;
 }
 
 int SSL_get_error(const SSL *s, int i)
@@ -3252,7 +3252,7 @@ int SSL_get_error(const SSL *s, int i)
     BIO *bio;
 
     if (i > 0)
-        return (SSL_ERROR_NONE);
+        return SSL_ERROR_NONE;
 
     /*
      * Make things return SSL_ERROR_SYSCALL when doing SSL_do_handshake etc,
@@ -3260,15 +3260,15 @@ int SSL_get_error(const SSL *s, int i)
      */
     if ((l = ERR_peek_error()) != 0) {
         if (ERR_GET_LIB(l) == ERR_LIB_SYS)
-            return (SSL_ERROR_SYSCALL);
+            return SSL_ERROR_SYSCALL;
         else
-            return (SSL_ERROR_SSL);
+            return SSL_ERROR_SSL;
     }
 
     if (SSL_want_read(s)) {
         bio = SSL_get_rbio(s);
         if (BIO_should_read(bio))
-            return (SSL_ERROR_WANT_READ);
+            return SSL_ERROR_WANT_READ;
         else if (BIO_should_write(bio))
             /*
              * This one doesn't make too much sense ... We never try to write
@@ -3279,15 +3279,15 @@ int SSL_get_error(const SSL *s, int i)
              * wbio *are* the same, this test works around that bug; so it
              * might be safer to keep it.
              */
-            return (SSL_ERROR_WANT_WRITE);
+            return SSL_ERROR_WANT_WRITE;
         else if (BIO_should_io_special(bio)) {
             reason = BIO_get_retry_reason(bio);
             if (reason == BIO_RR_CONNECT)
-                return (SSL_ERROR_WANT_CONNECT);
+                return SSL_ERROR_WANT_CONNECT;
             else if (reason == BIO_RR_ACCEPT)
-                return (SSL_ERROR_WANT_ACCEPT);
+                return SSL_ERROR_WANT_ACCEPT;
             else
-                return (SSL_ERROR_SYSCALL); /* unknown */
+                return SSL_ERROR_SYSCALL; /* unknown */
         }
     }
 
@@ -3295,24 +3295,24 @@ int SSL_get_error(const SSL *s, int i)
         /* Access wbio directly - in order to use the buffered bio if present */
         bio = s->wbio;
         if (BIO_should_write(bio))
-            return (SSL_ERROR_WANT_WRITE);
+            return SSL_ERROR_WANT_WRITE;
         else if (BIO_should_read(bio))
             /*
              * See above (SSL_want_read(s) with BIO_should_write(bio))
              */
-            return (SSL_ERROR_WANT_READ);
+            return SSL_ERROR_WANT_READ;
         else if (BIO_should_io_special(bio)) {
             reason = BIO_get_retry_reason(bio);
             if (reason == BIO_RR_CONNECT)
-                return (SSL_ERROR_WANT_CONNECT);
+                return SSL_ERROR_WANT_CONNECT;
             else if (reason == BIO_RR_ACCEPT)
-                return (SSL_ERROR_WANT_ACCEPT);
+                return SSL_ERROR_WANT_ACCEPT;
             else
-                return (SSL_ERROR_SYSCALL);
+                return SSL_ERROR_SYSCALL;
         }
     }
     if (SSL_want_x509_lookup(s))
-        return (SSL_ERROR_WANT_X509_LOOKUP);
+        return SSL_ERROR_WANT_X509_LOOKUP;
     if (SSL_want_async(s))
         return SSL_ERROR_WANT_ASYNC;
     if (SSL_want_async_job(s))
@@ -3322,9 +3322,9 @@ int SSL_get_error(const SSL *s, int i)
 
     if ((s->shutdown & SSL_RECEIVED_SHUTDOWN) &&
         (s->s3->warn_alert == SSL_AD_CLOSE_NOTIFY))
-        return (SSL_ERROR_ZERO_RETURN);
+        return SSL_ERROR_ZERO_RETURN;
 
-    return (SSL_ERROR_SYSCALL);
+    return SSL_ERROR_SYSCALL;
 }
 
 static int ssl_do_handshake_intern(void *vargs)
@@ -3392,25 +3392,25 @@ void SSL_set_connect_state(SSL *s)
 int ssl_undefined_function(SSL *s)
 {
     SSLerr(SSL_F_SSL_UNDEFINED_FUNCTION, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-    return (0);
+    return 0;
 }
 
 int ssl_undefined_void_function(void)
 {
     SSLerr(SSL_F_SSL_UNDEFINED_VOID_FUNCTION,
            ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-    return (0);
+    return 0;
 }
 
 int ssl_undefined_const_function(const SSL *s)
 {
-    return (0);
+    return 0;
 }
 
 const SSL_METHOD *ssl_bad_method(int ver)
 {
     SSLerr(SSL_F_SSL_BAD_METHOD, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-    return (NULL);
+    return NULL;
 }
 
 const char *ssl_protocol_to_string(int version)
@@ -3468,7 +3468,7 @@ SSL *SSL_dup(SSL *s)
      * Otherwise, copy configuration state, and session if set.
      */
     if ((ret = SSL_new(SSL_get_SSL_CTX(s))) == NULL)
-        return (NULL);
+        return NULL;
 
     if (s->session != NULL) {
         /*
@@ -3599,17 +3599,17 @@ void ssl_clear_cipher_ctx(SSL *s)
 X509 *SSL_get_certificate(const SSL *s)
 {
     if (s->cert != NULL)
-        return (s->cert->key->x509);
+        return s->cert->key->x509;
     else
-        return (NULL);
+        return NULL;
 }
 
 EVP_PKEY *SSL_get_privatekey(const SSL *s)
 {
     if (s->cert != NULL)
-        return (s->cert->key->privatekey);
+        return s->cert->key->privatekey;
     else
-        return (NULL);
+        return NULL;
 }
 
 X509 *SSL_CTX_get0_certificate(const SSL_CTX *ctx)
@@ -3631,8 +3631,8 @@ EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx)
 const SSL_CIPHER *SSL_get_current_cipher(const SSL *s)
 {
     if ((s->session != NULL) && (s->session->cipher != NULL))
-        return (s->session->cipher);
-    return (NULL);
+        return s->session->cipher;
+    return NULL;
 }
 
 const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s)
@@ -3701,7 +3701,7 @@ void SSL_CTX_set_quiet_shutdown(SSL_CTX *ctx, int mode)
 
 int SSL_CTX_get_quiet_shutdown(const SSL_CTX *ctx)
 {
-    return (ctx->quiet_shutdown);
+    return ctx->quiet_shutdown;
 }
 
 void SSL_set_quiet_shutdown(SSL *s, int mode)
@@ -3711,7 +3711,7 @@ void SSL_set_quiet_shutdown(SSL *s, int mode)
 
 int SSL_get_quiet_shutdown(const SSL *s)
 {
-    return (s->quiet_shutdown);
+    return s->quiet_shutdown;
 }
 
 void SSL_set_shutdown(SSL *s, int mode)
@@ -3788,7 +3788,7 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
 
 int SSL_CTX_set_default_verify_paths(SSL_CTX *ctx)
 {
-    return (X509_STORE_set_default_paths(ctx->cert_store));
+    return X509_STORE_set_default_paths(ctx->cert_store);
 }
 
 int SSL_CTX_set_default_verify_dir(SSL_CTX *ctx)
@@ -3825,7 +3825,7 @@ int SSL_CTX_set_default_verify_file(SSL_CTX *ctx)
 int SSL_CTX_load_verify_locations(SSL_CTX *ctx, const char *CAfile,
                                   const char *CApath)
 {
-    return (X509_STORE_load_locations(ctx->cert_store, CAfile, CApath));
+    return X509_STORE_load_locations(ctx->cert_store, CAfile, CApath);
 }
 
 void SSL_set_info_callback(SSL *ssl,
@@ -3851,7 +3851,7 @@ void SSL_set_verify_result(SSL *ssl, long arg)
 
 long SSL_get_verify_result(const SSL *ssl)
 {
-    return (ssl->verify_result);
+    return ssl->verify_result;
 }
 
 size_t SSL_get_client_random(const SSL *ssl, unsigned char *out, size_t outlen)
@@ -3899,27 +3899,27 @@ int SSL_SESSION_set1_master_key(SSL_SESSION *sess, const unsigned char *in,
 
 int SSL_set_ex_data(SSL *s, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&s->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&s->ex_data, idx, arg);
 }
 
 void *SSL_get_ex_data(const SSL *s, int idx)
 {
-    return (CRYPTO_get_ex_data(&s->ex_data, idx));
+    return CRYPTO_get_ex_data(&s->ex_data, idx);
 }
 
 int SSL_CTX_set_ex_data(SSL_CTX *s, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&s->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&s->ex_data, idx, arg);
 }
 
 void *SSL_CTX_get_ex_data(const SSL_CTX *s, int idx)
 {
-    return (CRYPTO_get_ex_data(&s->ex_data, idx));
+    return CRYPTO_get_ex_data(&s->ex_data, idx);
 }
 
 X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx)
 {
-    return (ctx->cert_store);
+    return ctx->cert_store;
 }
 
 void SSL_CTX_set_cert_store(SSL_CTX *ctx, X509_STORE *store)
@@ -3937,7 +3937,7 @@ void SSL_CTX_set1_cert_store(SSL_CTX *ctx, X509_STORE *store)
 
 int SSL_want(const SSL *s)
 {
-    return (s->rwstate);
+    return s->rwstate;
 }
 
 /**
@@ -4001,14 +4001,14 @@ const char *SSL_get_psk_identity_hint(const SSL *s)
 {
     if (s == NULL || s->session == NULL)
         return NULL;
-    return (s->session->psk_identity_hint);
+    return s->session->psk_identity_hint;
 }
 
 const char *SSL_get_psk_identity(const SSL *s)
 {
     if (s == NULL || s->session == NULL)
         return NULL;
-    return (s->session->psk_identity);
+    return s->session->psk_identity;
 }
 
 void SSL_set_psk_client_callback(SSL *s, SSL_psk_client_cb_func cb)

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -29,7 +29,7 @@ int SSL_use_certificate(SSL *ssl, X509 *x)
     int rv;
     if (x == NULL) {
         SSLerr(SSL_F_SSL_USE_CERTIFICATE, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     rv = ssl_security_cert(ssl, NULL, x, 0, 1);
     if (rv != 1) {
@@ -37,7 +37,7 @@ int SSL_use_certificate(SSL *ssl, X509 *x)
         return 0;
     }
 
-    return (ssl_set_cert(ssl->cert, x));
+    return ssl_set_cert(ssl->cert, x);
 }
 
 int SSL_use_certificate_file(SSL *ssl, const char *file, int type)
@@ -78,7 +78,7 @@ int SSL_use_certificate_file(SSL *ssl, const char *file, int type)
  end:
     X509_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_use_certificate_ASN1(SSL *ssl, const unsigned char *d, int len)
@@ -89,12 +89,12 @@ int SSL_use_certificate_ASN1(SSL *ssl, const unsigned char *d, int len)
     x = d2i_X509(NULL, &d, (long)len);
     if (x == NULL) {
         SSLerr(SSL_F_SSL_USE_CERTIFICATE_ASN1, ERR_R_ASN1_LIB);
-        return (0);
+        return 0;
     }
 
     ret = SSL_use_certificate(ssl, x);
     X509_free(x);
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_RSA
@@ -105,11 +105,11 @@ int SSL_use_RSAPrivateKey(SSL *ssl, RSA *rsa)
 
     if (rsa == NULL) {
         SSLerr(SSL_F_SSL_USE_RSAPRIVATEKEY, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if ((pkey = EVP_PKEY_new()) == NULL) {
         SSLerr(SSL_F_SSL_USE_RSAPRIVATEKEY, ERR_R_EVP_LIB);
-        return (0);
+        return 0;
     }
 
     RSA_up_ref(rsa);
@@ -121,7 +121,7 @@ int SSL_use_RSAPrivateKey(SSL *ssl, RSA *rsa)
 
     ret = ssl_set_pkey(ssl->cert, pkey);
     EVP_PKEY_free(pkey);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -131,7 +131,7 @@ static int ssl_set_pkey(CERT *c, EVP_PKEY *pkey)
 
     if (ssl_cert_lookup_by_pkey(pkey, &i) == NULL) {
         SSLerr(SSL_F_SSL_SET_PKEY, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
-        return (0);
+        return 0;
     }
 
     if (c->pkeys[i].x509 != NULL) {
@@ -208,7 +208,7 @@ int SSL_use_RSAPrivateKey_file(SSL *ssl, const char *file, int type)
     RSA_free(rsa);
  end:
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_use_RSAPrivateKey_ASN1(SSL *ssl, const unsigned char *d, long len)
@@ -220,12 +220,12 @@ int SSL_use_RSAPrivateKey_ASN1(SSL *ssl, const unsigned char *d, long len)
     p = d;
     if ((rsa = d2i_RSAPrivateKey(NULL, &p, (long)len)) == NULL) {
         SSLerr(SSL_F_SSL_USE_RSAPRIVATEKEY_ASN1, ERR_R_ASN1_LIB);
-        return (0);
+        return 0;
     }
 
     ret = SSL_use_RSAPrivateKey(ssl, rsa);
     RSA_free(rsa);
-    return (ret);
+    return ret;
 }
 #endif                          /* !OPENSSL_NO_RSA */
 
@@ -235,10 +235,10 @@ int SSL_use_PrivateKey(SSL *ssl, EVP_PKEY *pkey)
 
     if (pkey == NULL) {
         SSLerr(SSL_F_SSL_USE_PRIVATEKEY, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     ret = ssl_set_pkey(ssl->cert, pkey);
-    return (ret);
+    return ret;
 }
 
 int SSL_use_PrivateKey_file(SSL *ssl, const char *file, int type)
@@ -277,7 +277,7 @@ int SSL_use_PrivateKey_file(SSL *ssl, const char *file, int type)
     EVP_PKEY_free(pkey);
  end:
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_use_PrivateKey_ASN1(int type, SSL *ssl, const unsigned char *d,
@@ -290,12 +290,12 @@ int SSL_use_PrivateKey_ASN1(int type, SSL *ssl, const unsigned char *d,
     p = d;
     if ((pkey = d2i_PrivateKey(type, NULL, &p, (long)len)) == NULL) {
         SSLerr(SSL_F_SSL_USE_PRIVATEKEY_ASN1, ERR_R_ASN1_LIB);
-        return (0);
+        return 0;
     }
 
     ret = SSL_use_PrivateKey(ssl, pkey);
     EVP_PKEY_free(pkey);
-    return (ret);
+    return ret;
 }
 
 int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x)
@@ -303,14 +303,14 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x)
     int rv;
     if (x == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     rv = ssl_security_cert(NULL, ctx, x, 0, 1);
     if (rv != 1) {
         SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE, rv);
         return 0;
     }
-    return (ssl_set_cert(ctx->cert, x));
+    return ssl_set_cert(ctx->cert, x);
 }
 
 static int ssl_set_cert(CERT *c, X509 *x)
@@ -321,7 +321,7 @@ static int ssl_set_cert(CERT *c, X509 *x)
     pkey = X509_get0_pubkey(x);
     if (pkey == NULL) {
         SSLerr(SSL_F_SSL_SET_CERT, SSL_R_X509_LIB);
-        return (0);
+        return 0;
     }
 
     if (ssl_cert_lookup_by_pkey(pkey, &i) == NULL) {
@@ -411,7 +411,7 @@ int SSL_CTX_use_certificate_file(SSL_CTX *ctx, const char *file, int type)
  end:
     X509_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_CTX_use_certificate_ASN1(SSL_CTX *ctx, int len, const unsigned char *d)
@@ -422,12 +422,12 @@ int SSL_CTX_use_certificate_ASN1(SSL_CTX *ctx, int len, const unsigned char *d)
     x = d2i_X509(NULL, &d, (long)len);
     if (x == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_ASN1, ERR_R_ASN1_LIB);
-        return (0);
+        return 0;
     }
 
     ret = SSL_CTX_use_certificate(ctx, x);
     X509_free(x);
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_RSA
@@ -438,11 +438,11 @@ int SSL_CTX_use_RSAPrivateKey(SSL_CTX *ctx, RSA *rsa)
 
     if (rsa == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_RSAPRIVATEKEY, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
     if ((pkey = EVP_PKEY_new()) == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_RSAPRIVATEKEY, ERR_R_EVP_LIB);
-        return (0);
+        return 0;
     }
 
     RSA_up_ref(rsa);
@@ -454,7 +454,7 @@ int SSL_CTX_use_RSAPrivateKey(SSL_CTX *ctx, RSA *rsa)
 
     ret = ssl_set_pkey(ctx->cert, pkey);
     EVP_PKEY_free(pkey);
-    return (ret);
+    return ret;
 }
 
 int SSL_CTX_use_RSAPrivateKey_file(SSL_CTX *ctx, const char *file, int type)
@@ -493,7 +493,7 @@ int SSL_CTX_use_RSAPrivateKey_file(SSL_CTX *ctx, const char *file, int type)
     RSA_free(rsa);
  end:
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_CTX_use_RSAPrivateKey_ASN1(SSL_CTX *ctx, const unsigned char *d,
@@ -506,12 +506,12 @@ int SSL_CTX_use_RSAPrivateKey_ASN1(SSL_CTX *ctx, const unsigned char *d,
     p = d;
     if ((rsa = d2i_RSAPrivateKey(NULL, &p, (long)len)) == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_RSAPRIVATEKEY_ASN1, ERR_R_ASN1_LIB);
-        return (0);
+        return 0;
     }
 
     ret = SSL_CTX_use_RSAPrivateKey(ctx, rsa);
     RSA_free(rsa);
-    return (ret);
+    return ret;
 }
 #endif                          /* !OPENSSL_NO_RSA */
 
@@ -519,9 +519,9 @@ int SSL_CTX_use_PrivateKey(SSL_CTX *ctx, EVP_PKEY *pkey)
 {
     if (pkey == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_PRIVATEKEY, ERR_R_PASSED_NULL_PARAMETER);
-        return (0);
+        return 0;
     }
-    return (ssl_set_pkey(ctx->cert, pkey));
+    return ssl_set_pkey(ctx->cert, pkey);
 }
 
 int SSL_CTX_use_PrivateKey_file(SSL_CTX *ctx, const char *file, int type)
@@ -560,7 +560,7 @@ int SSL_CTX_use_PrivateKey_file(SSL_CTX *ctx, const char *file, int type)
     EVP_PKEY_free(pkey);
  end:
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_CTX_use_PrivateKey_ASN1(int type, SSL_CTX *ctx,
@@ -573,12 +573,12 @@ int SSL_CTX_use_PrivateKey_ASN1(int type, SSL_CTX *ctx,
     p = d;
     if ((pkey = d2i_PrivateKey(type, NULL, &p, (long)len)) == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_PRIVATEKEY_ASN1, ERR_R_ASN1_LIB);
-        return (0);
+        return 0;
     }
 
     ret = SSL_CTX_use_PrivateKey(ctx, pkey);
     EVP_PKEY_free(pkey);
-    return (ret);
+    return ret;
 }
 
 /*
@@ -680,7 +680,7 @@ static int use_certificate_chain_file(SSL_CTX *ctx, SSL *ssl, const char *file)
  end:
     X509_free(x);
     BIO_free(in);
-    return (ret);
+    return ret;
 }
 
 int SSL_CTX_use_certificate_chain_file(SSL_CTX *ctx, const char *file)

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -31,7 +31,7 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck);
 SSL_SESSION *SSL_get_session(const SSL *ssl)
 /* aka SSL_get0_session; gets 0 objects, just returns a copy of the pointer */
 {
-    return (ssl->session);
+    return ssl->session;
 }
 
 SSL_SESSION *SSL_get1_session(SSL *ssl)
@@ -53,12 +53,12 @@ SSL_SESSION *SSL_get1_session(SSL *ssl)
 
 int SSL_SESSION_set_ex_data(SSL_SESSION *s, int idx, void *arg)
 {
-    return (CRYPTO_set_ex_data(&s->ex_data, idx, arg));
+    return CRYPTO_set_ex_data(&s->ex_data, idx, arg);
 }
 
 void *SSL_SESSION_get_ex_data(const SSL_SESSION *s, int idx)
 {
-    return (CRYPTO_get_ex_data(&s->ex_data, idx));
+    return CRYPTO_get_ex_data(&s->ex_data, idx);
 }
 
 SSL_SESSION *SSL_SESSION_new(void)
@@ -751,7 +751,7 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck)
             ctx->remove_session_cb(ctx, c);
     } else
         ret = 0;
-    return (ret);
+    return ret;
 }
 
 void SSL_SESSION_free(SSL_SESSION *ss)
@@ -844,7 +844,7 @@ int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
 long SSL_SESSION_set_timeout(SSL_SESSION *s, long t)
 {
     if (s == NULL)
-        return (0);
+        return 0;
     s->timeout = t;
     return 1;
 }
@@ -852,23 +852,23 @@ long SSL_SESSION_set_timeout(SSL_SESSION *s, long t)
 long SSL_SESSION_get_timeout(const SSL_SESSION *s)
 {
     if (s == NULL)
-        return (0);
-    return (s->timeout);
+        return 0;
+    return s->timeout;
 }
 
 long SSL_SESSION_get_time(const SSL_SESSION *s)
 {
     if (s == NULL)
-        return (0);
-    return (s->time);
+        return 0;
+    return s->time;
 }
 
 long SSL_SESSION_set_time(SSL_SESSION *s, long t)
 {
     if (s == NULL)
-        return (0);
+        return 0;
     s->time = t;
-    return (t);
+    return t;
 }
 
 int SSL_SESSION_get_protocol_version(const SSL_SESSION *s)
@@ -1001,17 +1001,17 @@ long SSL_CTX_set_timeout(SSL_CTX *s, long t)
 {
     long l;
     if (s == NULL)
-        return (0);
+        return 0;
     l = s->session_timeout;
     s->session_timeout = t;
-    return (l);
+    return l;
 }
 
 long SSL_CTX_get_timeout(const SSL_CTX *s)
 {
     if (s == NULL)
-        return (0);
-    return (s->session_timeout);
+        return 0;
+    return s->session_timeout;
 }
 
 int SSL_set_session_secret_cb(SSL *s,
@@ -1019,7 +1019,7 @@ int SSL_set_session_secret_cb(SSL *s,
                               void *arg)
 {
     if (s == NULL)
-        return (0);
+        return 0;
     s->ext.session_secret_cb = tls_session_secret_cb;
     s->ext.session_secret_cb_arg = arg;
     return 1;
@@ -1029,7 +1029,7 @@ int SSL_set_session_ticket_ext_cb(SSL *s, tls_session_ticket_ext_cb_fn cb,
                                   void *arg)
 {
     if (s == NULL)
-        return (0);
+        return 0;
     s->ext.session_ticket_cb = cb;
     s->ext.session_ticket_cb_arg = arg;
     return 1;
@@ -1112,7 +1112,7 @@ int ssl_clear_bad_session(SSL *s)
         SSL_CTX_remove_session(s->session_ctx, s->session);
         return 1;
     } else
-        return (0);
+        return 0;
 }
 
 /* locked by SSL_CTX in the calling function */

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -20,12 +20,12 @@ int SSL_SESSION_print_fp(FILE *fp, const SSL_SESSION *x)
 
     if ((b = BIO_new(BIO_s_file())) == NULL) {
         SSLerr(SSL_F_SSL_SESSION_PRINT_FP, ERR_R_BUF_LIB);
-        return (0);
+        return 0;
     }
     BIO_set_fp(b, fp, BIO_NOCLOSE);
     ret = SSL_SESSION_print(b, x);
     BIO_free(b);
-    return (ret);
+    return ret;
 }
 #endif
 
@@ -147,7 +147,7 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
 
     return 1;
  err:
-    return (0);
+    return 0;
 }
 
 /*
@@ -188,5 +188,5 @@ int SSL_SESSION_print_keylog(BIO *bp, const SSL_SESSION *x)
 
     return 1;
  err:
-    return (0);
+    return 0;
 }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3474,7 +3474,7 @@ int ssl_cipher_list_to_bytes(SSL *s, STACK_OF(SSL_CIPHER) *sk, WPACKET *pkt)
     ssl_set_client_disabled(s);
 
     if (sk == NULL)
-        return (0);
+        return 0;
 
 #ifdef OPENSSL_MAX_TLS1_2_CIPHER_LENGTH
 # if OPENSSL_MAX_TLS1_2_CIPHER_LENGTH < 6

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -31,7 +31,7 @@ int ssl3_do_write(SSL *s, int type)
     ret = ssl3_write_bytes(s, type, &s->init_buf->data[s->init_off],
                            s->init_num, &written);
     if (ret < 0)
-        return (-1);
+        return -1;
     if (type == SSL3_RT_HANDSHAKE)
         /*
          * should not be done for 'Hello Request's, but in that case we'll
@@ -51,7 +51,7 @@ int ssl3_do_write(SSL *s, int type)
     }
     s->init_off += written;
     s->init_num -= written;
-    return (0);
+    return 0;
 }
 
 int tls_close_construct_packet(SSL *s, WPACKET *pkt, int htype)
@@ -1309,7 +1309,7 @@ int ssl_verify_alarm_type(long type)
         al = SSL_AD_CERTIFICATE_UNKNOWN;
         break;
     }
-    return (al);
+    return al;
 }
 
 int ssl_allow_compression(SSL *s)

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -318,7 +318,7 @@ int tls1_change_cipher_state(SSL *s, int which)
     OPENSSL_cleanse(tmp2, sizeof(tmp1));
     OPENSSL_cleanse(iv1, sizeof(iv1));
     OPENSSL_cleanse(iv2, sizeof(iv2));
-    return (0);
+    return 0;
 }
 
 int tls1_setup_key_block(SSL *s)
@@ -337,7 +337,7 @@ int tls1_setup_key_block(SSL *s)
     if (!ssl_cipher_get_evp(s->session, &c, &hash, &mac_type, &mac_secret_size,
                             &comp, s->ext.use_etm)) {
         SSLerr(SSL_F_TLS1_SETUP_KEY_BLOCK, SSL_R_CIPHER_OR_HASH_UNAVAILABLE);
-        return (0);
+        return 0;
     }
 
     s->s3->tmp.new_sym_enc = c;
@@ -412,7 +412,7 @@ int tls1_setup_key_block(SSL *s)
 
     ret = 1;
  err:
-    return (ret);
+    return ret;
 }
 
 size_t tls1_final_finish_mac(SSL *s, const char *str, size_t slen,
@@ -569,79 +569,79 @@ int tls1_export_keying_material(SSL *s, unsigned char *out, size_t olen,
     rv = 0;
  ret:
     OPENSSL_clear_free(val, vallen);
-    return (rv);
+    return rv;
 }
 
 int tls1_alert_code(int code)
 {
     switch (code) {
     case SSL_AD_CLOSE_NOTIFY:
-        return (SSL3_AD_CLOSE_NOTIFY);
+        return SSL3_AD_CLOSE_NOTIFY;
     case SSL_AD_UNEXPECTED_MESSAGE:
-        return (SSL3_AD_UNEXPECTED_MESSAGE);
+        return SSL3_AD_UNEXPECTED_MESSAGE;
     case SSL_AD_BAD_RECORD_MAC:
-        return (SSL3_AD_BAD_RECORD_MAC);
+        return SSL3_AD_BAD_RECORD_MAC;
     case SSL_AD_DECRYPTION_FAILED:
-        return (TLS1_AD_DECRYPTION_FAILED);
+        return TLS1_AD_DECRYPTION_FAILED;
     case SSL_AD_RECORD_OVERFLOW:
-        return (TLS1_AD_RECORD_OVERFLOW);
+        return TLS1_AD_RECORD_OVERFLOW;
     case SSL_AD_DECOMPRESSION_FAILURE:
-        return (SSL3_AD_DECOMPRESSION_FAILURE);
+        return SSL3_AD_DECOMPRESSION_FAILURE;
     case SSL_AD_HANDSHAKE_FAILURE:
-        return (SSL3_AD_HANDSHAKE_FAILURE);
+        return SSL3_AD_HANDSHAKE_FAILURE;
     case SSL_AD_NO_CERTIFICATE:
-        return (-1);
+        return -1;
     case SSL_AD_BAD_CERTIFICATE:
-        return (SSL3_AD_BAD_CERTIFICATE);
+        return SSL3_AD_BAD_CERTIFICATE;
     case SSL_AD_UNSUPPORTED_CERTIFICATE:
-        return (SSL3_AD_UNSUPPORTED_CERTIFICATE);
+        return SSL3_AD_UNSUPPORTED_CERTIFICATE;
     case SSL_AD_CERTIFICATE_REVOKED:
-        return (SSL3_AD_CERTIFICATE_REVOKED);
+        return SSL3_AD_CERTIFICATE_REVOKED;
     case SSL_AD_CERTIFICATE_EXPIRED:
-        return (SSL3_AD_CERTIFICATE_EXPIRED);
+        return SSL3_AD_CERTIFICATE_EXPIRED;
     case SSL_AD_CERTIFICATE_UNKNOWN:
-        return (SSL3_AD_CERTIFICATE_UNKNOWN);
+        return SSL3_AD_CERTIFICATE_UNKNOWN;
     case SSL_AD_ILLEGAL_PARAMETER:
-        return (SSL3_AD_ILLEGAL_PARAMETER);
+        return SSL3_AD_ILLEGAL_PARAMETER;
     case SSL_AD_UNKNOWN_CA:
-        return (TLS1_AD_UNKNOWN_CA);
+        return TLS1_AD_UNKNOWN_CA;
     case SSL_AD_ACCESS_DENIED:
-        return (TLS1_AD_ACCESS_DENIED);
+        return TLS1_AD_ACCESS_DENIED;
     case SSL_AD_DECODE_ERROR:
-        return (TLS1_AD_DECODE_ERROR);
+        return TLS1_AD_DECODE_ERROR;
     case SSL_AD_DECRYPT_ERROR:
-        return (TLS1_AD_DECRYPT_ERROR);
+        return TLS1_AD_DECRYPT_ERROR;
     case SSL_AD_EXPORT_RESTRICTION:
-        return (TLS1_AD_EXPORT_RESTRICTION);
+        return TLS1_AD_EXPORT_RESTRICTION;
     case SSL_AD_PROTOCOL_VERSION:
-        return (TLS1_AD_PROTOCOL_VERSION);
+        return TLS1_AD_PROTOCOL_VERSION;
     case SSL_AD_INSUFFICIENT_SECURITY:
-        return (TLS1_AD_INSUFFICIENT_SECURITY);
+        return TLS1_AD_INSUFFICIENT_SECURITY;
     case SSL_AD_INTERNAL_ERROR:
-        return (TLS1_AD_INTERNAL_ERROR);
+        return TLS1_AD_INTERNAL_ERROR;
     case SSL_AD_USER_CANCELLED:
-        return (TLS1_AD_USER_CANCELLED);
+        return TLS1_AD_USER_CANCELLED;
     case SSL_AD_NO_RENEGOTIATION:
-        return (TLS1_AD_NO_RENEGOTIATION);
+        return TLS1_AD_NO_RENEGOTIATION;
     case SSL_AD_UNSUPPORTED_EXTENSION:
-        return (TLS1_AD_UNSUPPORTED_EXTENSION);
+        return TLS1_AD_UNSUPPORTED_EXTENSION;
     case SSL_AD_CERTIFICATE_UNOBTAINABLE:
-        return (TLS1_AD_CERTIFICATE_UNOBTAINABLE);
+        return TLS1_AD_CERTIFICATE_UNOBTAINABLE;
     case SSL_AD_UNRECOGNIZED_NAME:
-        return (TLS1_AD_UNRECOGNIZED_NAME);
+        return TLS1_AD_UNRECOGNIZED_NAME;
     case SSL_AD_BAD_CERTIFICATE_STATUS_RESPONSE:
-        return (TLS1_AD_BAD_CERTIFICATE_STATUS_RESPONSE);
+        return TLS1_AD_BAD_CERTIFICATE_STATUS_RESPONSE;
     case SSL_AD_BAD_CERTIFICATE_HASH_VALUE:
-        return (TLS1_AD_BAD_CERTIFICATE_HASH_VALUE);
+        return TLS1_AD_BAD_CERTIFICATE_HASH_VALUE;
     case SSL_AD_UNKNOWN_PSK_IDENTITY:
-        return (TLS1_AD_UNKNOWN_PSK_IDENTITY);
+        return TLS1_AD_UNKNOWN_PSK_IDENTITY;
     case SSL_AD_INAPPROPRIATE_FALLBACK:
-        return (TLS1_AD_INAPPROPRIATE_FALLBACK);
+        return TLS1_AD_INAPPROPRIATE_FALLBACK;
     case SSL_AD_NO_APPLICATION_PROTOCOL:
-        return (TLS1_AD_NO_APPLICATION_PROTOCOL);
+        return TLS1_AD_NO_APPLICATION_PROTOCOL;
     case SSL_AD_CERTIFICATE_REQUIRED:
         return SSL_AD_HANDSHAKE_FAILURE;
     default:
-        return (-1);
+        return -1;
     }
 }

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -119,7 +119,7 @@ int SSL_SRP_CTX_init(struct ssl_st *s)
     BN_free(s->srp_ctx.b);
     BN_free(s->srp_ctx.v);
     memset(&s->srp_ctx, 0, sizeof(s->srp_ctx));
-    return (0);
+    return 0;
 }
 
 int SSL_CTX_SRP_CTX_init(struct ssl_ctx_st *ctx)


### PR DESCRIPTION
Since return is inconsistent, I removed unnecessary parentheses and
unified them.

This request is based on #4533.
@mattcaswell I remove unnecessary merge.

@kroeckx Almost codes are fixed by script.
```
#! /bin/sh
#
# sh_replace_return_with_variable.sh
# Copyright (C) 2017 kaoru <kaoru@localhost>
#
# Distributed under terms of the MIT license.
#

replace_return () {
        perl -i -pe "s/return \(([->&_A-Za-z0-9\.]*)\);$/return \1;/" $1

        # for string
        # return ("hoge"); -> return "hoge";
        # return ("blowfish(ptr)");
        perl -i -pe "s/return \(\"([->: '&_A-Za-z0-9,\.\(\)]+)\"\);$/return \"\1\";/" $1
        perl -i -pe "s/return\(\"([->: '&_A-Za-z0-9,\.\(\)]+)\"\);$/return \"\1\";/" $1


        # for function-call
        # return (mem_buf_free(a, 1));
        # return mem_buf_free(a, 1);
        # return (foo->bar(hoge));
        # return (foo->bar(a[foo], b[bar]));
        perl -i -pe "s/return \(([->0-9a-zA-Z_]+)\(([->: &_A-Za-z0-9\., \[\]\(\)\*\"]+)\)\);$/return \1(\2);/" $1

        # ./crypto/bio/bf_lbuf.c:    return (linebuffer_write(b, str, strlen(str)));
        # ./crypto/bio/bf_nbio.c:    return (BIO_gets(bp->next_bio, buf, size));
        # ./crypto/bio/bf_nbio.c:    return (BIO_puts(bp->next_bio, str));

        # for function-call
        # return (foo()); -> return foo();
        perl -i -pe "s/return \(([->a-zA-Z_]+)\(\)\);$/return \1();/" $1

        # for cast
        # return ((int)ret);
        # target
        # ((int)(hoge));
        # ((int *)hoge);
        perl -i -pe "s/return \(\(([a-zA-Z0-9_ \*]+)\)[ ]*([->&_A-Za-z0-9\.\[\]]+)\);$/return (\1)\2;/" $1
        # ((HOGE *)&(foo[n]))
        perl -i -pe "s/return \(\(([a-zA-Z0-9_ \*]+)\)[ ]*&[ ]*\(([->&_A-Za-z0-9\.\[\]]+)\)\);$/return (\1)&\2;/" $1
        perl -i -pe "s/return \(\(([a-zA-Z0-9_ \*]+)\)[ ]*([->&_A-Za-z0-9\.\[\]]+)\);$/return (\1)\2;/" $1

        perl -i -pe "s/return \(long\)\(([->&_A-Za-z0-9\.\[\]]+)\);$/return (long)\1;/" $1
}

main () {
        for i in `find . -name "*.c" `
        do
                #echo $i
                replace_return $i
        done
}
main
```

These code are fixed by hand.
- ./include/internal/constant_time_locl.h
- ./crypto/x509/x509_txt.c
- ./crypto/asn1/a_bitstr.c
- ./ssl/s3_enc.c
- ./ssl/s3_lib.c
- ./ssl/ssl_lib.c