### PR TITLE
Free pre-allocated value pointer in OTHERNAME before overwritting.

### DIFF
--- a/crypto/x509v3/v3_genn.c
+++ b/crypto/x509v3/v3_genn.c
@@ -181,6 +181,7 @@ int GENERAL_NAME_set0_othername(GENERAL_NAME *gen,
     oth = OTHERNAME_new();
     if (oth == NULL)
         return 0;
+    ASN1_TYPE_free(oth->value); // Free the pointer as do_othername() does.
     oth->type_id = oid;
     oth->value = value;
     GENERAL_NAME_set0_value(gen, GEN_OTHERNAME, oth);


### PR DESCRIPTION
CLA: trivial.

Do the same as https://github.com/openssl/openssl/blob/270a4bba49849de7f928f4fab186205abd132411/crypto/x509v3/v3_alt.c#L552 does to fix memory leak from the overwritten pointer in function `GENERAL_NAME_set0_othername`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
