### PR TITLE
Fix memory leak in GENERAL_NAME_set0_othername.

### DIFF
--- a/crypto/x509v3/v3_genn.c
+++ b/crypto/x509v3/v3_genn.c
@@ -181,6 +181,7 @@ int GENERAL_NAME_set0_othername(GENERAL_NAME *gen,
     oth = OTHERNAME_new();
     if (oth == NULL)
         return 0;
+    ASN1_TYPE_free(oth->value);
     oth->type_id = oid;
     oth->value = value;
     GENERAL_NAME_set0_value(gen, GEN_OTHERNAME, oth);


### PR DESCRIPTION
CLA: trivial.

Do the same as https://github.com/openssl/openssl/blob/270a4bba49849de7f928f4fab186205abd132411/crypto/x509v3/v3_alt.c#L552 does to fix memory leak issue in function `GENERAL_NAME_set0_othername`.