### PR TITLE
Correct value for BN_security_bits()

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -812,7 +812,7 @@ int BN_security_bits(int L, int N)
     int secbits, bits;
     if (L >= 15360)
         secbits = 256;
-    else if (L >= 7690)
+    else if (L >= 7680)
         secbits = 192;
     else if (L >= 3072)
         secbits = 128;


### PR DESCRIPTION
The function BN_security_bits() uses the values from SP800-57 to assign
security bit values for different FF key sizes. However the value for 192
security bits is wrong. SP800-57 has it as 7680 but the code had it as
7690.