### PR TITLE
Use atomics for SSL_CTX stats counters

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2178,6 +2178,7 @@ LHASH_OF(SSL_SESSION) *SSL_CTX_sessions(SSL_CTX *ctx)
 long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
 {
     long l;
+    int i;
     /* For some cases with ctx == NULL perform syntax checks */
     if (ctx == NULL) {
         switch (cmd) {
@@ -2232,27 +2233,40 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     case SSL_CTRL_SESS_NUMBER:
         return (lh_SSL_SESSION_num_items(ctx->sessions));
     case SSL_CTRL_SESS_CONNECT:
-        return (ctx->stats.sess_connect);
+        return CRYPTO_atomic_read(&ctx->stats.sess_connect, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_CONNECT_GOOD:
-        return (ctx->stats.sess_connect_good);
+        return CRYPTO_atomic_read(&ctx->stats.sess_connect_good, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_CONNECT_RENEGOTIATE:
-        return (ctx->stats.sess_connect_renegotiate);
+        return CRYPTO_atomic_read(&ctx->stats.sess_connect_renegotiate, &i,
+                                  ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_ACCEPT:
-        return (ctx->stats.sess_accept);
+        return CRYPTO_atomic_read(&ctx->stats.sess_accept, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_ACCEPT_GOOD:
-        return (ctx->stats.sess_accept_good);
+        return CRYPTO_atomic_read(&ctx->stats.sess_accept_good, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_ACCEPT_RENEGOTIATE:
-        return (ctx->stats.sess_accept_renegotiate);
+        return CRYPTO_atomic_read(&ctx->stats.sess_accept_renegotiate, &i,
+                                  ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_HIT:
-        return (ctx->stats.sess_hit);
+        return CRYPTO_atomic_read(&ctx->stats.sess_hit, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_CB_HIT:
-        return (ctx->stats.sess_cb_hit);
+        return CRYPTO_atomic_read(&ctx->stats.sess_cb_hit, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_MISSES:
-        return (ctx->stats.sess_miss);
+        return CRYPTO_atomic_read(&ctx->stats.sess_miss, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_TIMEOUTS:
-        return (ctx->stats.sess_timeout);
+        return CRYPTO_atomic_read(&ctx->stats.sess_timeout, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_SESS_CACHE_FULL:
-        return (ctx->stats.sess_cache_full);
+        return CRYPTO_atomic_read(&ctx->stats.sess_cache_full, &i, ctx->lock)
+                ? i : 0;
     case SSL_CTRL_MODE:
         return (ctx->mode |= larg);
     case SSL_CTRL_CLEAR_MODE:
@@ -3203,11 +3217,14 @@ void ssl_update_cache(SSL *s, int mode)
 
     /* auto flush every 255 connections */
     if ((!(i & SSL_SESS_CACHE_NO_AUTO_CLEAR)) && ((i & mode) == mode)) {
-        if ((((mode & SSL_SESS_CACHE_CLIENT)
-              ? s->session_ctx->stats.sess_connect_good
-              : s->session_ctx->stats.sess_accept_good) & 0xff) == 0xff) {
+        int *stat, val;
+        if (mode & SSL_SESS_CACHE_CLIENT)
+            stat = &s->session_ctx->stats.sess_connect_good;
+        else
+            stat = &s->session_ctx->stats.sess_accept_good;
+        if (CRYPTO_atomic_read(stat, &val, s->session_ctx->lock)
+            && (val & 0xff) == 0xff)
             SSL_CTX_flush_sessions(s->session_ctx, (unsigned long)time(NULL));
-        }
     }
 }
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -832,7 +832,7 @@ static int init_server_name(SSL *s, unsigned int context)
 static int final_server_name(SSL *s, unsigned int context, int sent,
                                      int *al)
 {
-    int ret = SSL_TLSEXT_ERR_NOACK;
+    int ret = SSL_TLSEXT_ERR_NOACK, discard;
     int altmp = SSL_AD_UNRECOGNIZED_NAME;
     int was_ticket = (SSL_get_options(s) & SSL_OP_NO_TICKET) == 0;
 
@@ -847,6 +847,19 @@ static int final_server_name(SSL *s, unsigned int context, int sent,
     if (!sent) {
         OPENSSL_free(s->session->ext.hostname);
         s->session->ext.hostname = NULL;
+    }
+
+    /*
+     * If we switched contexts (whether here or in the client_hello callback,
+     * move the sess_accept increment from the session_ctx to the new
+     * context, to avoid the confusing situation of having sess_accept_good
+     * exceed sess_accept (zero) for the new context.
+     */
+    if (SSL_IS_FIRST_HANDSHAKE(s) && s->ctx != s->session_ctx) {
+        CRYPTO_atomic_add(&s->ctx->stats.sess_accept, 1, &discard,
+                          s->ctx->lock);
+        CRYPTO_atomic_add(&s->session_ctx->stats.sess_accept, -1, &discard,
+                          s->session_ctx->lock);
     }
 
     /*

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1266,7 +1266,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
     unsigned int compression;
     unsigned int sversion;
     unsigned int context;
-    int protverr;
+    int protverr, discard;
     RAW_EXTENSION *extensions = NULL;
 #ifndef OPENSSL_NO_COMP
     SSL_COMP *comp;
@@ -1430,7 +1430,8 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
                 || (SSL_IS_TLS13(s)
                     && s->session->ext.tick_identity
                        != TLSEXT_PSK_BAD_IDENTITY)) {
-            s->ctx->stats.sess_miss++;
+            CRYPTO_atomic_add(&s->ctx->stats.sess_miss, 1, &discard,
+                              s->ctx->lock);
             if (!ssl_get_new_session(s, 0)) {
                 goto f_err;
             }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1430,8 +1430,8 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
                 || (SSL_IS_TLS13(s)
                     && s->session->ext.tick_identity
                        != TLSEXT_PSK_BAD_IDENTITY)) {
-            CRYPTO_atomic_add(&s->ctx->stats.sess_miss, 1, &discard,
-                              s->ctx->lock);
+            CRYPTO_atomic_add(&s->session_ctx->stats.sess_miss, 1, &discard,
+                              s->session_ctx->lock);
             if (!ssl_get_new_session(s, 0)) {
                 goto f_err;
             }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1046,10 +1046,9 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs)
              */
             if (!SSL_IS_TLS13(s))
                 ssl_update_cache(s, SSL_SESS_CACHE_CLIENT);
-            if (s->hit) {
+            if (s->hit)
                 CRYPTO_atomic_add(&s->session_ctx->stats.sess_hit, 1, &discard,
                                   s->session_ctx->lock);
-            }
 
             s->handshake_func = ossl_statem_connect;
             CRYPTO_atomic_add(&s->session_ctx->stats.sess_connect_good, 1,

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -111,7 +111,9 @@ int tls_setup_handshake(SSL *s)
             return 0;
         }
         if (SSL_IS_FIRST_HANDSHAKE(s)) {
-            CRYPTO_atomic_add(&s->ctx->stats.sess_accept, 1, &i, s->ctx->lock);
+            /* N.B. s->session_ctx == s->ctx here */
+            CRYPTO_atomic_add(&s->session_ctx->stats.sess_accept, 1, &i,
+                              s->session_ctx->lock);
         } else if ((s->options & SSL_OP_NO_RENEGOTIATION)) {
             /* Renegotiation is disabled */
             ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_NO_RENEGOTIATION);
@@ -128,6 +130,7 @@ int tls_setup_handshake(SSL *s)
             ssl3_send_alert(s, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
             return 0;
         } else {
+            /* N.B. s->ctx may not equal s->session_ctx */
             CRYPTO_atomic_add(&s->ctx->stats.sess_accept_renegotiate, 1, &i,
                               s->ctx->lock);
 
@@ -136,11 +139,11 @@ int tls_setup_handshake(SSL *s)
     } else {
         int discard;
         if (SSL_IS_FIRST_HANDSHAKE(s))
-            CRYPTO_atomic_add(&s->ctx->stats.sess_connect, 1, &discard,
-                              s->ctx->lock);
+            CRYPTO_atomic_add(&s->session_ctx->stats.sess_connect, 1, &discard,
+                              s->session_ctx->lock);
         else
-            CRYPTO_atomic_add(&s->ctx->stats.sess_connect_renegotiate, 1,
-                              &discard, s->ctx->lock);
+            CRYPTO_atomic_add(&s->session_ctx->stats.sess_connect_renegotiate,
+                              1, &discard, s->session_ctx->lock);
 
         /* mark client_random uninitialized */
         memset(s->s3->client_random, 0, sizeof(s->s3->client_random));
@@ -1032,6 +1035,7 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs)
         if (s->server) {
             ssl_update_cache(s, SSL_SESS_CACHE_SERVER);
 
+            /* N.B. s->ctx may not equal s->session_ctx */
             CRYPTO_atomic_add(&s->ctx->stats.sess_accept_good, 1, &discard,
                               s->ctx->lock);
             s->handshake_func = ossl_statem_accept;
@@ -1042,13 +1046,14 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs)
              */
             if (!SSL_IS_TLS13(s))
                 ssl_update_cache(s, SSL_SESS_CACHE_CLIENT);
-            if (s->hit)
-                CRYPTO_atomic_add(&s->ctx->stats.sess_hit, 1, &discard,
-                                  s->ctx->lock);
+            if (s->hit) {
+                CRYPTO_atomic_add(&s->session_ctx->stats.sess_hit, 1, &discard,
+                                  s->session_ctx->lock);
+            }
 
             s->handshake_func = ossl_statem_connect;
-            CRYPTO_atomic_add(&s->ctx->stats.sess_connect_good, 1, &discard,
-                              s->ctx->lock);
+            CRYPTO_atomic_add(&s->session_ctx->stats.sess_connect_good, 1,
+                              &discard, s->session_ctx->lock);
         }
 
         if (s->info_callback != NULL)


### PR DESCRIPTION
Since SSL_CTX objects are shared across multiple SSL objects (and thus multiple threads), it is formally thread-unsafe to use regular integer increments and accesses for the shared statistics counters.
This pull request switches to using ```CRYPTO_atomic_*``` for these fields.  It also attempts to use the ```s->session_ctx``` spelling in cases where the affected context will always be the session ctx (e.g., clients, and servers before initial handshake processing).
The final commit does present something of a functional change, moving ```sess_accept``` counts from the session_ctx to the (switched) ctx in cases where a client_hello or servername callback has switched contexts.  This helps to avoid the nonsensical behavior of ```ctx->stats.sess_accept``` being zero while ```ctx->stats.sess_accept_good``` is large.  There are some cases of handhsake failure that would not be caught by this logic, but it would still give a sense for whether handshakes fail due to the client disappearing, certifiicate validation failure or other crypto issues, etc.