### PR TITLE
Additional name for all commands

### DIFF
--- a/doc/apps/asn1parse.pod
+++ b/doc/apps/asn1parse.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-asn1parse,
 asn1parse - ASN.1 parsing tool
 
 =head1 SYNOPSIS

--- a/doc/apps/ca.pod
+++ b/doc/apps/ca.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-ca,
 ca - sample minimal CA application
 
 =head1 SYNOPSIS

--- a/doc/apps/ciphers.pod
+++ b/doc/apps/ciphers.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-ciphers,
 ciphers - SSL cipher display and cipher list tool.
 
 =head1 SYNOPSIS

--- a/doc/apps/cms.pod
+++ b/doc/apps/cms.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-cms,
 cms - CMS utility
 
 =head1 SYNOPSIS

--- a/doc/apps/crl.pod
+++ b/doc/apps/crl.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-crl,
 crl - CRL utility
 
 =head1 SYNOPSIS

--- a/doc/apps/crl2pkcs7.pod
+++ b/doc/apps/crl2pkcs7.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-crl2pkcs7,
 crl2pkcs7 - Create a PKCS#7 structure from a CRL and certificates.
 
 =head1 SYNOPSIS

--- a/doc/apps/dgst.pod
+++ b/doc/apps/dgst.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-dgst,
 dgst, sha, sha1, mdc2, ripemd160, sha224, sha256, sha384, sha512, md2, md4, md5, dss1 - message digests
 
 =head1 SYNOPSIS

--- a/doc/apps/dhparam.pod
+++ b/doc/apps/dhparam.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-dhparam,
 dhparam - DH parameter manipulation and generation
 
 =head1 SYNOPSIS

--- a/doc/apps/dsa.pod
+++ b/doc/apps/dsa.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-dsa,
 dsa - DSA key processing
 
 =head1 SYNOPSIS

--- a/doc/apps/dsaparam.pod
+++ b/doc/apps/dsaparam.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-dsaparam,
 dsaparam - DSA parameter manipulation and generation
 
 =head1 SYNOPSIS

--- a/doc/apps/ec.pod
+++ b/doc/apps/ec.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-ec,
 ec - EC key processing
 
 =head1 SYNOPSIS

--- a/doc/apps/ecparam.pod
+++ b/doc/apps/ecparam.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-ecparam,
 ecparam - EC parameter manipulation and generation
 
 =head1 SYNOPSIS

--- a/doc/apps/enc.pod
+++ b/doc/apps/enc.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-enc,
 enc - symmetric cipher routines
 
 =head1 SYNOPSIS

--- a/doc/apps/errstr.pod
+++ b/doc/apps/errstr.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-errstr,
 errstr - lookup error codes
 
 =head1 SYNOPSIS

--- a/doc/apps/gendsa.pod
+++ b/doc/apps/gendsa.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-gendsa,
 gendsa - generate a DSA private key from a set of parameters
 
 =head1 SYNOPSIS

--- a/doc/apps/genpkey.pod
+++ b/doc/apps/genpkey.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-genpkey,
 genpkey - generate a private key
 
 =head1 SYNOPSIS

--- a/doc/apps/genrsa.pod
+++ b/doc/apps/genrsa.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-genrsa,
 genrsa - generate an RSA private key
 
 =head1 SYNOPSIS

--- a/doc/apps/nseq.pod
+++ b/doc/apps/nseq.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-nseq,
 nseq - create or examine a netscape certificate sequence
 
 =head1 SYNOPSIS

--- a/doc/apps/ocsp.pod
+++ b/doc/apps/ocsp.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-ocsp,
 ocsp - Online Certificate Status Protocol utility
 
 =head1 SYNOPSIS

--- a/doc/apps/passwd.pod
+++ b/doc/apps/passwd.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-passwd,
 passwd - compute password hashes
 
 =head1 SYNOPSIS

--- a/doc/apps/pkcs12.pod
+++ b/doc/apps/pkcs12.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-pkcs12,
 pkcs12 - PKCS#12 file utility
 
 =head1 SYNOPSIS

--- a/doc/apps/pkcs7.pod
+++ b/doc/apps/pkcs7.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-pkcs7,
 pkcs7 - PKCS#7 utility
 
 =head1 SYNOPSIS

--- a/doc/apps/pkcs8.pod
+++ b/doc/apps/pkcs8.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-pkcs8,
 pkcs8 - PKCS#8 format private key conversion tool
 
 =head1 SYNOPSIS

--- a/doc/apps/pkey.pod
+++ b/doc/apps/pkey.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-pkey,
 pkey - public or private key processing tool
 
 =head1 SYNOPSIS

--- a/doc/apps/pkeyparam.pod
+++ b/doc/apps/pkeyparam.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-pkeyparam,
 pkeyparam - public key algorithm parameter processing tool
 
 =head1 SYNOPSIS

--- a/doc/apps/pkeyutl.pod
+++ b/doc/apps/pkeyutl.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-pkeyutl,
 pkeyutl - public key algorithm utility
 
 =head1 SYNOPSIS

--- a/doc/apps/rand.pod
+++ b/doc/apps/rand.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-rand,
 rand - generate pseudo-random bytes
 
 =head1 SYNOPSIS

--- a/doc/apps/req.pod
+++ b/doc/apps/req.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-req,
 req - PKCS#10 certificate request and certificate generating utility.
 
 =head1 SYNOPSIS

--- a/doc/apps/rsa.pod
+++ b/doc/apps/rsa.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-rsa,
 rsa - RSA key processing tool
 
 =head1 SYNOPSIS

--- a/doc/apps/rsautl.pod
+++ b/doc/apps/rsautl.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-rsautl,
 rsautl - RSA utility
 
 =head1 SYNOPSIS

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-s_client,
 s_client - SSL/TLS client program
 
 =head1 SYNOPSIS

--- a/doc/apps/s_server.pod
+++ b/doc/apps/s_server.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-s_server,
 s_server - SSL/TLS server program
 
 =head1 SYNOPSIS

--- a/doc/apps/s_time.pod
+++ b/doc/apps/s_time.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-s_time,
 s_time - SSL/TLS performance timing program
 
 =head1 SYNOPSIS

--- a/doc/apps/sess_id.pod
+++ b/doc/apps/sess_id.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-sess_id,
 sess_id - SSL/TLS session handling utility
 
 =head1 SYNOPSIS

--- a/doc/apps/smime.pod
+++ b/doc/apps/smime.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-smime,
 smime - S/MIME utility
 
 =head1 SYNOPSIS

--- a/doc/apps/speed.pod
+++ b/doc/apps/speed.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-speed,
 speed - test library performance
 
 =head1 SYNOPSIS

--- a/doc/apps/spkac.pod
+++ b/doc/apps/spkac.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-spkac,
 spkac - SPKAC printing and generating utility
 
 =head1 SYNOPSIS

--- a/doc/apps/ts.pod
+++ b/doc/apps/ts.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-ts,
 ts - Time Stamping Authority tool (client/server)
 
 =head1 SYNOPSIS

--- a/doc/apps/tsget.pod
+++ b/doc/apps/tsget.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-tsget,
 tsget - Time Stamping HTTP/HTTPS client
 
 =head1 SYNOPSIS

--- a/doc/apps/verify.pod
+++ b/doc/apps/verify.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-verify,
 verify - Utility to verify certificates.
 
 =head1 SYNOPSIS

--- a/doc/apps/version.pod
+++ b/doc/apps/version.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+openssl-version,
 version - print OpenSSL version information
 
 =head1 SYNOPSIS

--- a/doc/apps/x509.pod
+++ b/doc/apps/x509.pod
@@ -3,6 +3,7 @@
 
 =head1 NAME
 
+openssl-x509,
 x509 - Certificate display and signing utility
 
 =head1 SYNOPSIS


### PR DESCRIPTION
Add openssl-foo as a name for the openssl "foo" command.
Recommended by a usability study conducted by Martin Ukrop at CRoCS, FI MU
Fixes: #4548
