### PR TITLE
s390x assembly pack: define OPENSSL_s390xcap_P in s390xcap.c

### DIFF
--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2219,7 +2219,6 @@ ___
 }
 $code.=<<___;
 .string	"AES for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,80,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -13,7 +13,7 @@
 #include <setjmp.h>
 #include <signal.h>
 
-extern unsigned long OPENSSL_s390xcap_P[];
+unsigned long long OPENSSL_s390xcap_P[10];
 
 static sigjmp_buf ill_jmp;
 static void ill_handler(int sig)

--- a/crypto/s390xcpuid.S
+++ b/crypto/s390xcpuid.S
@@ -176,5 +176,3 @@ OPENSSL_instrument_bus2:
 
 .section	.init
 	brasl	%r14,OPENSSL_cpuid_setup
-
-.comm	OPENSSL_s390xcap_P,80,8

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -239,7 +239,6 @@ $code.=<<___;
 	br	%r14
 .size	sha1_block_data_order,.-sha1_block_data_order
 .string	"SHA1 block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,80,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -312,7 +312,6 @@ $code.=<<___;
 	br	%r14
 .size	$Func,.-$Func
 .string	"SHA${label} block transform for s390x, CRYPTOGAMS by <appro\@openssl.org>"
-.comm	OPENSSL_s390xcap_P,80,8
 ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;


### PR DESCRIPTION
Remove all .comm definitions from the asm modules.

See discussion in #4542 . OPENSSL_s390xcap_P type was changed from UL to ULL to be the same size on 64- and 32-bit systems
