### PR TITLE
ECDSA timing side channel closure

### DIFF
--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -206,7 +206,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
      * small timing information leakage.  We then choose the sum that is
      * one bit longer than the modulus.
      *
-     * TODO: revist the BN_copy aiming for a memory access agnostic
+     * TODO: revisit the BN_copy aiming for a memory access agnostic
      * conditional copy.
      */
     if (!BN_add(l, k, dsa->q)

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -146,7 +146,9 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
 {
     BN_CTX *ctx = NULL;
     BIGNUM *k, *kinv = NULL, *r = *rp;
+    BIGNUM *l, *m;
     int ret = 0;
+    int q_bits;
 
     if (!dsa->p || !dsa->q || !dsa->g) {
         DSAerr(DSA_F_DSA_SIGN_SETUP, DSA_R_MISSING_PARAMETERS);
@@ -154,7 +156,9 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
     }
 
     k = BN_new();
-    if (k == NULL)
+    l = BN_new();
+    m = BN_new();
+    if (k == NULL || l == NULL || m == NULL)
         goto err;
 
     if (ctx_in == NULL) {
@@ -162,6 +166,13 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
             goto err;
     } else
         ctx = ctx_in;
+
+    /* Preallocate space */
+    q_bits = BN_num_bits(dsa->q);
+    if (!BN_set_bit(k, q_bits)
+        || !BN_set_bit(l, q_bits)
+        || !BN_set_bit(m, q_bits))
+        goto err;
 
     /* Get random k */
     do {
@@ -189,17 +200,19 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
 
     /*
      * We do not want timing information to leak the length of k, so we
-     * compute g^k using an equivalent exponent of fixed length. (This
-     * is a kludge that we need because the BN_mod_exp_mont() does not
-     * let us specify the desired timing behaviour.)
+     * compute G^k using an equivalent scalar of fixed bit-length.
+     *
+     * We unconditionally perform both of these additions to prevent a
+     * small timing information leakage.  We then choose the sum that is
+     * one bit longer than the modulus.
+     *
+     * TODO: revist the BN_copy aiming for a memory access agnostic
+     * conditional copy.
      */
-
-    if (!BN_add(k, k, dsa->q))
+    if (!BN_add(l, k, dsa->q)
+        || !BN_add(m, l, dsa->q)
+        || !BN_copy(k, BN_num_bits(l) > q_bits ? l : m))
         goto err;
-    if (BN_num_bits(k) <= BN_num_bits(dsa->q)) {
-        if (!BN_add(k, k, dsa->q))
-            goto err;
-    }
 
     if ((dsa)->meth->bn_mod_exp != NULL) {
             if (!dsa->meth->bn_mod_exp(dsa, r, dsa->g, k, dsa->p, ctx,
@@ -227,6 +240,8 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
     if (ctx != ctx_in)
         BN_CTX_free(ctx);
     BN_clear_free(k);
+    BN_clear_free(l);
+    BN_clear_free(m);
     return ret;
 }
 

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2002-2017 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -41,6 +41,7 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
     EC_POINT *tmp_point = NULL;
     const EC_GROUP *group;
     int ret = 0;
+    int order_bits;
 
     if (eckey == NULL || (group = EC_KEY_get0_group(eckey)) == NULL) {
         ECerr(EC_F_ECDSA_SIGN_SETUP, ERR_R_PASSED_NULL_PARAMETER);
@@ -77,6 +78,13 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
         goto err;
     }
 
+    /* Preallocate space */
+    order_bits = BN_num_bits(order);
+    if (!BN_set_bit(k, order_bits)
+        || !BN_set_bit(r, order_bits)
+        || !BN_set_bit(X, order_bits))
+        goto err;
+
     do {
         /* get random k */
         do
@@ -100,13 +108,19 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
         /*
          * We do not want timing information to leak the length of k, so we
          * compute G*k using an equivalent scalar of fixed bit-length.
+         *
+         * We unconditionally perform both of these additions to prevent a
+         * small timing information leakage.  We then choose the sum that is
+         * one bit longer than the order.  This guarantees the code
+         * path used in the constant time implementations elsewhere.
+         *
+         * TODO: revist the BN_copy aiming for a memory access agnostic
+         * conditional copy.
          */
-
-        if (!BN_add(k, k, order))
+        if (!BN_add(r, k, order)
+            || !BN_add(X, r, order)
+            || !BN_copy(k, BN_num_bits(r) > order_bits ? r : X))
             goto err;
-        if (BN_num_bits(k) <= BN_num_bits(order))
-            if (!BN_add(k, k, order))
-                goto err;
 
         /* compute r the x-coordinate of generator * k */
         if (!EC_POINT_mul(group, tmp_point, k, NULL, NULL, ctx)) {

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -114,7 +114,7 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
          * one bit longer than the order.  This guarantees the code
          * path used in the constant time implementations elsewhere.
          *
-         * TODO: revist the BN_copy aiming for a memory access agnostic
+         * TODO: revisit the BN_copy aiming for a memory access agnostic
          * conditional copy.
          */
         if (!BN_add(r, k, order)


### PR DESCRIPTION
Address a timing side channel whereby it is possible to determine some information about the length of the scalar used in ECDSA operations from a large number of signatures.

Thanks to Neals Fournaise, Eliane Jaulmes and Jean-René Reinhard for reporting this issue.

- [x] tests are added or updated
