### PR TITLE
asn1_item_embed_new(): don't free an embedded item

### DIFF
--- a/crypto/asn1/asn1_locl.h
+++ b/crypto/asn1/asn1_locl.h
@@ -63,6 +63,7 @@ int asn1_enc_restore(int *len, unsigned char **out, ASN1_VALUE **pval,
 int asn1_enc_save(ASN1_VALUE **pval, const unsigned char *in, int inlen,
                   const ASN1_ITEM *it);
 
+void asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed);
 void asn1_primitive_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed);
 void asn1_template_free(ASN1_VALUE **pval, const ASN1_TEMPLATE *tt);
 

--- a/crypto/asn1/tasn_fre.c
+++ b/crypto/asn1/tasn_fre.c
@@ -13,9 +13,6 @@
 #include <openssl/objects.h>
 #include "asn1_locl.h"
 
-static void asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it,
-                                 int embed);
-
 /* Free up an ASN1 structure */
 
 void ASN1_item_free(ASN1_VALUE *val, const ASN1_ITEM *it)
@@ -28,8 +25,7 @@ void ASN1_item_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
     asn1_item_embed_free(pval, it, 0);
 }
 
-static void asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it,
-                                 int embed)
+void asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
 {
     const ASN1_TEMPLATE *tt = NULL, *seqtt;
     const ASN1_EXTERN_FUNCS *ef;

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -142,8 +142,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
     return 1;
 
  memerr2:
-    if (!embed)
-        ASN1_item_ex_free(pval, it);
+    asn1_item_embed_free(pval, it, embed);
  memerr:
     ASN1err(ASN1_F_ASN1_ITEM_EMBED_NEW, ERR_R_MALLOC_FAILURE);
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
@@ -152,8 +151,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
     return 0;
 
  auxerr2:
-    if (!embed)
-        ASN1_item_ex_free(pval, it);
+    asn1_item_embed_free(pval, it, embed);
  auxerr:
     ASN1err(ASN1_F_ASN1_ITEM_EMBED_NEW, ASN1_R_AUX_ERROR);
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -124,8 +124,13 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
                 goto memerr;
         }
         /* 0 : init. lock */
-        if (asn1_do_lock(pval, 0, it) < 0)
-            goto memerr2;
+        if (asn1_do_lock(pval, 0, it) < 0) {
+            if (!embed) {
+                OPENSSL_free(*pval);
+                *pval = NULL;
+            }
+            goto memerr;
+        }
         asn1_enc_init(pval, it);
         for (i = 0, tt = it->templates; i < it->tcount; tt++, i++) {
             pseqval = asn1_get_field_ptr(pval, tt);


### PR DESCRIPTION
The previous change with this intention didn't quite do it.  An
embedded item must not be freed itself, but might potentially contain
non-embedded elements, which must be freed.

So instead of calling ASN1_item_ex_free(), where we can't pass the
embed flag, we call asn1_item_embed_free() directly.

This changes asn1_item_embed_free() from being a static function to
being a private non-static function.