### PR TITLE
CHANGES: strip trailing whitespaces

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1190,13 +1190,13 @@
      [Steve Henson]
 
   *) Experimental encrypt-then-mac support.
-    
+
      Experimental support for encrypt then mac from
      draft-gutmann-tls-encrypt-then-mac-02.txt
 
      To enable it set the appropriate extension number (0x42 for the test
      server) using e.g. -DTLSEXT_TYPE_encrypt_then_mac=0x42
- 
+
      For non-compliant peers (i.e. just about everything) this should have no
      effect.
 
@@ -1247,7 +1247,7 @@
 
   *) Use separate DRBG fields for internal and external flags. New function
      FIPS_drbg_health_check() to perform on demand health checking. Add
-     generation tests to fips_test_suite with reduced health check interval to 
+     generation tests to fips_test_suite with reduced health check interval to
      demonstrate periodic health checking. Add "nodh" option to
      fips_test_suite to skip very slow DH test.
      [Steve Henson]
@@ -1261,7 +1261,7 @@
      combination: call this in fips_test_suite.
      [Steve Henson]
 
-  *) Add support for canonical generation of DSA parameter 'g'. See 
+  *) Add support for canonical generation of DSA parameter 'g'. See
      FIPS 186-3 A.2.3.
 
   *) Add support for HMAC DRBG from SP800-90. Update DRBG algorithm test and
@@ -1285,7 +1285,7 @@
      requested amount of entropy.
      [Steve Henson]
 
-  *) Add PRNG security strength checks to RSA, DSA and ECDSA using 
+  *) Add PRNG security strength checks to RSA, DSA and ECDSA using
      information in FIPS186-3, SP800-57 and SP800-131A.
      [Steve Henson]
 
@@ -1377,7 +1377,7 @@
      can be set or retrieved with a ctrl. The IV length is by default 12
      bytes (96 bits) but can be set to an alternative value. If the IV
      length exceeds the maximum IV length (currently 16 bytes) it cannot be
-     set before the key. 
+     set before the key.
      [Steve Henson]
 
   *) New flag in ciphers: EVP_CIPH_FLAG_CUSTOM_CIPHER. This means the
@@ -1420,7 +1420,7 @@
      Add CMAC pkey methods.
      [Steve Henson]
 
-  *) Experimental renegotiation in s_server -www mode. If the client 
+  *) Experimental renegotiation in s_server -www mode. If the client
      browses /reneg connection is renegotiated. If /renegcert it is
      renegotiated requesting a certificate.
      [Steve Henson]
@@ -1440,7 +1440,7 @@
   *) New macro __owur for "OpenSSL Warn Unused Result". This makes use of
      a gcc attribute to warn if the result of a function is ignored. This
      is enable if DEBUG_UNUSED is set. Add to several functions in evp.h
-     whose return value is often ignored. 
+     whose return value is often ignored.
      [Steve Henson]
 
   *) New -noct, -requestct, -requirect and -ctlogfile options for s_client.
@@ -2245,7 +2245,7 @@
      [Steve Henson]
 
   *) Add new "valid_flags" field to CERT_PKEY structure which determines what
-     the certificate can be used for (if anything). Set valid_flags field 
+     the certificate can be used for (if anything). Set valid_flags field
      in new tls1_check_chain function. Simplify ssl_set_cert_masks which used
      to have similar checks in it.
 
@@ -2288,7 +2288,7 @@
   *) Fix OCSP checking.
      [Rob Stradling <rob.stradling@comodo.com> and Ben Laurie]
 
-  *) Initial experimental support for explicitly trusted non-root CAs. 
+  *) Initial experimental support for explicitly trusted non-root CAs.
      OpenSSL still tries to build a complete chain to a root but if an
      intermediate CA has a trust setting included that is used. The first
      setting is used: whether to trust (e.g., -addtrust option to the x509
@@ -2339,7 +2339,7 @@
      to set list of supported curves.
      [Steve Henson]
 
-  *) New ctrls to retrieve supported signature algorithms and 
+  *) New ctrls to retrieve supported signature algorithms and
      supported curve values as an array of NIDs. Extend openssl utility
      to print out received values.
      [Steve Henson]
@@ -2544,7 +2544,7 @@
      [Adam Langley, Bodo Moeller]
 
   *) Add additional DigestInfo checks.
- 
+
      Re-encode DigestInto in DER and check against the original when
      verifying RSA signature: this will reject any improperly encoded
      DigestInfo structures.
@@ -2714,7 +2714,7 @@
 
  Changes between 1.0.1e and 1.0.1f [6 Jan 2014]
 
-  *) Fix for TLS record tampering bug. A carefully crafted invalid 
+  *) Fix for TLS record tampering bug. A carefully crafted invalid
      handshake could crash OpenSSL with a NULL pointer exception.
      Thanks to Anton Johansson for reporting this issues.
      (CVE-2013-4353)
@@ -2742,9 +2742,9 @@
 
   *) Make the decoding of SSLv3, TLS and DTLS CBC records constant time.
 
-     This addresses the flaw in CBC record processing discovered by 
+     This addresses the flaw in CBC record processing discovered by
      Nadhem Alfardan and Kenny Paterson. Details of this attack can be found
-     at: http://www.isg.rhul.ac.uk/tls/     
+     at: http://www.isg.rhul.ac.uk/tls/
 
      Thanks go to Nadhem Alfardan and Kenny Paterson of the Information
      Security Group at Royal Holloway, University of London
@@ -2862,7 +2862,7 @@
   *) The format used for MDC2 RSA signatures is inconsistent between EVP
      and the RSA_sign/RSA_verify functions. This was made more apparent when
      OpenSSL used RSA_sign/RSA_verify for some RSA signatures in particular
-     those which went through EVP_PKEY_METHOD in 1.0.0 and later. Detect 
+     those which went through EVP_PKEY_METHOD in 1.0.0 and later. Detect
      the correct format in RSA_verify so both forms transparently work.
      [Steve Henson]
 
@@ -2935,7 +2935,7 @@
 
   *) New -sigopt option to the ca, req and x509 utilities. Additional
      signature parameters can be passed using this option and in
-     particular PSS. 
+     particular PSS.
      [Steve Henson]
 
   *) Add RSA PSS signing function. This will generate and set the
@@ -2960,7 +2960,7 @@
      [Steve Henson, Martin Kaiser <lists@kaiser.cx>]
 
   *) Add algorithm specific signature printing. An individual ASN1 method
-     can now print out signatures instead of the standard hex dump. 
+     can now print out signatures instead of the standard hex dump.
 
      More complex signatures (e.g. PSS) can print out more meaningful
      information. Include DSA version that prints out the signature
@@ -2997,7 +2997,7 @@
 
   *) Add GCM support to TLS library. Some custom code is needed to split
      the IV between the fixed (from PRF) and explicit (from TLS record)
-     portions. This adds all GCM ciphersuites supported by RFC5288 and 
+     portions. This adds all GCM ciphersuites supported by RFC5288 and
      RFC5289. Generalise some AES* cipherstrings to include GCM and
      add a special AESGCM string for GCM only.
      [Steve Henson]
@@ -3051,10 +3051,10 @@
      to use them can use the private_* version instead.
      [Steve Henson]
 
-  *) Redirect cipher operations to FIPS module for FIPS builds. 
+  *) Redirect cipher operations to FIPS module for FIPS builds.
      [Steve Henson]
 
-  *) Redirect digest operations to FIPS module for FIPS builds. 
+  *) Redirect digest operations to FIPS module for FIPS builds.
      [Steve Henson]
 
   *) Update build system to add "fips" flag which will link in fipscanister.o
@@ -3066,7 +3066,7 @@
      This should be configurable so applications can judge speed vs strength.
      [Steve Henson]
 
-  *) Add TLS v1.2 server support for client authentication. 
+  *) Add TLS v1.2 server support for client authentication.
      [Steve Henson]
 
   *) Add support for FIPS mode in ssl library: disable SSLv3, non-FIPS ciphers
@@ -3149,7 +3149,7 @@
      this issue. (CVE-2012-0884)
      [Steve Henson]
 
-  *) Fix CVE-2011-4619: make sure we really are receiving a 
+  *) Fix CVE-2011-4619: make sure we really are receiving a
      client hello before rejecting multiple SGC restarts. Thanks to
      Ivan Nestlerode <inestlerode@us.ibm.com> for discovering this bug.
      [Steve Henson]
@@ -3276,12 +3276,12 @@
      [Steve Henson]
 
   *) Fix WIN32 build system to correctly link an ENGINE directory into
-     a DLL. 
+     a DLL.
      [Steve Henson]
 
  Changes between 1.0.0 and 1.0.0a  [01 Jun 2010]
 
-  *) Check return value of int_rsa_verify in pkey_rsa_verifyrecover 
+  *) Check return value of int_rsa_verify in pkey_rsa_verifyrecover
      (CVE-2010-1633)
      [Steve Henson, Peter-Michael Hager <hager@dortmund.net>]
 
@@ -3350,7 +3350,7 @@
      retrieve a digest flags is by accessing the structure directly. Update
      EVP_MD_do_all*() and EVP_CIPHER_do_all*() to include the name a digest
      or cipher is registered as in the "from" argument. Print out all
-     registered digests in the dgst usage message instead of manually 
+     registered digests in the dgst usage message instead of manually
      attempting to work them out.
      [Steve Henson]
 
@@ -3384,7 +3384,7 @@
   *) Update Gost ENGINE to support parameter files.
      [Victor B. Wagner <vitus@cryptocom.ru>]
 
-  *) Support GeneralizedTime in ca utility. 
+  *) Support GeneralizedTime in ca utility.
      [Oliver Martin <oliver@volatilevoid.net>, Steve Henson]
 
   *) Enhance the hash format used for certificate directory links. The new
@@ -3622,7 +3622,7 @@
      [Bodo Moeller]
 
   *) Update ssl code to support digests other than SHA1+MD5 for handshake
-     MAC. 
+     MAC.
 
      [Victor B. Wagner <vitus@cryptocom.ru>]
 
@@ -3634,7 +3634,7 @@
      If a client application caches session in an SSL_SESSION structure
      support is transparent because tickets are now stored in the encoded
      SSL_SESSION.
-     
+
      The SSL_CTX structure automatically generates keys for ticket
      protection in servers so again support should be possible
      with no application modification.
@@ -3671,7 +3671,7 @@
 
   *) New option -sigopt to dgst utility. Update dgst to use
      EVP_Digest{Sign,Verify}*. These two changes make it possible to use
-     alternative signing parameters such as X9.31 or PSS in the dgst 
+     alternative signing parameters such as X9.31 or PSS in the dgst
      utility.
      [Steve Henson]
 
@@ -3742,14 +3742,14 @@
 
   *) Initial incomplete changes to avoid need for function casts in OpenSSL
      some compilers (gcc 4.2 and later) reject their use. Safestack is
-     reimplemented.  Update ASN1 to avoid use of legacy functions. 
+     reimplemented.  Update ASN1 to avoid use of legacy functions.
      [Steve Henson]
 
   *) Win32/64 targets are linked with Winsock2.
      [Andy Polyakov]
 
   *) Add an X509_CRL_METHOD structure to allow CRL processing to be redirected
-     to external functions. This can be used to increase CRL handling 
+     to external functions. This can be used to increase CRL handling
      efficiency especially when CRLs are very large by (for example) storing
      the CRL revoked certificates in a database.
      [Steve Henson]
@@ -3783,7 +3783,7 @@
 
   *) New function X509_CRL_match() to check if two CRLs are identical. Normally
      this would be called X509_CRL_cmp() but that name is already used by
-     a function that just compares CRL issuer names. Cache several CRL 
+     a function that just compares CRL issuer names. Cache several CRL
      extensions in X509_CRL structure and cache CRLDP in X509.
      [Steve Henson]
 
@@ -3792,7 +3792,7 @@
      Name comparison can then be performed rapidly using memcmp().
      [Steve Henson]
 
-  *) Non-blocking OCSP request processing. Add -timeout option to ocsp 
+  *) Non-blocking OCSP request processing. Add -timeout option to ocsp
      utility.
      [Steve Henson]
 
@@ -3918,7 +3918,7 @@
      type for signing if it is not explicitly indicated.
      [Steve Henson]
 
-  *) Use OID cross reference table in ASN1_sign() and ASN1_verify(). New 
+  *) Use OID cross reference table in ASN1_sign() and ASN1_verify(). New
      EVP_MD flag EVP_MD_FLAG_PKEY_METHOD_SIGNATURE. This uses the relevant
      signing method from the key type. This effectively removes the link
      between digests and public key types.
@@ -3927,7 +3927,7 @@
   *) Add an OID cross reference table and utility functions. Its purpose is to
      translate between signature OIDs such as SHA1WithrsaEncryption and SHA1,
      rsaEncryption. This will allow some of the algorithm specific hackery
-     needed to use the correct OID to be removed. 
+     needed to use the correct OID to be removed.
      [Steve Henson]
 
   *) Remove algorithm specific dependencies when setting PKCS7_SIGNER_INFO
@@ -3943,7 +3943,7 @@
      [Steve Henson]
 
   *) Add DSA pkey method and DH pkey methods, extend DH ASN1 method to support
-     public and private key formats. As a side effect these add additional 
+     public and private key formats. As a side effect these add additional
      command line functionality not previously available: DSA signatures can be
      generated and verified using pkeyutl and DH key support and generation in
      pkey, genpkey.
@@ -3964,7 +3964,7 @@
 
   *) Add functions for main EVP_PKEY_method operations. The undocumented
      functions EVP_PKEY_{encrypt,decrypt} have been renamed to
-     EVP_PKEY_{encrypt,decrypt}_old. 
+     EVP_PKEY_{encrypt,decrypt}_old.
      [Steve Henson]
 
   *) Initial definitions for EVP_PKEY_METHOD. This will be a high level public
@@ -3989,7 +3989,7 @@
      type.
      [Steve Henson]
 
-  *) Transfer public key printing routines to EVP_PKEY_ASN1_METHOD. New 
+  *) Transfer public key printing routines to EVP_PKEY_ASN1_METHOD. New
      functions EVP_PKEY_print_public(), EVP_PKEY_print_private(),
      EVP_PKEY_print_param() to print public key data from an EVP_PKEY
      structure.
@@ -4010,11 +4010,11 @@
   *) Add initial support for RFC 4279 PSK TLS ciphersuites. Add members
      for the psk identity [hint] and the psk callback functions to the
      SSL_SESSION, SSL and SSL_CTX structure.
-     
+
      New ciphersuites:
          PSK-RC4-SHA, PSK-3DES-EDE-CBC-SHA, PSK-AES128-CBC-SHA,
          PSK-AES256-CBC-SHA
- 
+
      New functions:
          SSL_CTX_use_psk_identity_hint
          SSL_get_psk_identity_hint
@@ -4083,7 +4083,7 @@
      [Andy Polyakov]
 
   *) New option SSL_OP_NO_COMP to disable use of compression selectively
-     in SSL structures. New SSL ctrl to set maximum send fragment size. 
+     in SSL structures. New SSL ctrl to set maximum send fragment size.
      Save memory by seeting the I/O buffer sizes dynamically instead of
      using the maximum available value.
      [Steve Henson]
@@ -4137,7 +4137,7 @@
      protection is active.  (CVE-2010-0740)
      [Bodo Moeller, Adam Langley <agl@chromium.org>]
 
-  *) Fix for CVE-2010-0433 where some kerberos enabled versions of OpenSSL 
+  *) Fix for CVE-2010-0433 where some kerberos enabled versions of OpenSSL
      could be crashed if the relevant tables were not present (e.g. chrooted).
      [Tomas Hoger <thoger@redhat.com>]
 
@@ -4280,7 +4280,7 @@
      sequence number made no sense and would be part of another handshake.
      So only messages with sequence numbers less than 10 in advance will be
      buffered.  (CVE-2009-1378)
-     [Robin Seggelmann, discovered by Daniel Mentz] 	
+     [Robin Seggelmann, discovered by Daniel Mentz]
 
   *) Records are buffered if they arrive with a future epoch to be
      processed after finishing the corresponding handshake. There is
@@ -4289,11 +4289,11 @@
      memory left. This patch adds the pqueue_size() function to determine
      the size of a buffer and limits the record buffer to 100 entries.
      (CVE-2009-1377)
-     [Robin Seggelmann, discovered by Daniel Mentz] 	
+     [Robin Seggelmann, discovered by Daniel Mentz]
 
   *) Keep a copy of frag->msg_header.frag_len so it can be used after the
      parent structure is freed.  (CVE-2009-1379)
-     [Daniel Mentz] 	
+     [Daniel Mentz]
 
   *) Handle non-blocking I/O properly in SSL_shutdown() call.
      [Darryl Miles <darryl-mailinglists@netbauds.net>]
@@ -4328,7 +4328,7 @@
      a legal length. (CVE-2009-0590)
      [Steve Henson]
 
-  *) Set S/MIME signing as the default purpose rather than setting it 
+  *) Set S/MIME signing as the default purpose rather than setting it
      unconditionally. This allows applications to override it at the store
      level.
      [Steve Henson]
@@ -4461,11 +4461,11 @@
 
   *) Fix flaw if 'Server Key exchange message' is omitted from a TLS
      handshake which could lead to a cilent crash as found using the
-     Codenomicon TLS test suite (CVE-2008-1672) 
+     Codenomicon TLS test suite (CVE-2008-1672)
      [Steve Henson, Mark Cox]
 
   *) Fix double free in TLS server name extensions which could lead to
-     a remote crash found by Codenomicon TLS test suite (CVE-2008-0891) 
+     a remote crash found by Codenomicon TLS test suite (CVE-2008-0891)
      [Joe Orton]
 
   *) Clear error queue in SSL_CTX_use_certificate_chain_file()
@@ -4566,7 +4566,7 @@
   *) Fix BN flag handling in RSA_eay_mod_exp() and BN_MONT_CTX_set()
      to get the expected BN_FLG_CONSTTIME behavior.
      [Bodo Moeller (Google)]
-  
+
   *) Netware support:
 
      - fixed wrong usage of ioctlsocket() when build for LIBC BSD sockets
@@ -4618,7 +4618,7 @@
      (gcc 4.2 and later) reject their use.
      [Kurt Roeckx <kurt@roeckx.be>, Peter Hartley <pdh@utter.chaos.org.uk>,
       Steve Henson]
-  
+
   *) Add RFC4507 support to OpenSSL. This includes the corrections in
      RFC4507bis. The encrypted ticket format is an encrypted encoded
      SSL_SESSION structure, that way new session features are automatically
@@ -4627,7 +4627,7 @@
      If a client application caches session in an SSL_SESSION structure
      support is transparent because tickets are now stored in the encoded
      SSL_SESSION.
-     
+
      The SSL_CTX structure automatically generates keys for ticket
      protection in servers so again support should be possible
      with no application modification.
@@ -4807,7 +4807,7 @@
   *) Fix ASN.1 parsing of certain invalid structures that can result
      in a denial of service.  (CVE-2006-2937)  [Steve Henson]
 
-  *) Fix buffer overflow in SSL_get_shared_ciphers() function. 
+  *) Fix buffer overflow in SSL_get_shared_ciphers() function.
      (CVE-2006-3738) [Tavis Ormandy and Will Drewry, Google Security Team]
 
   *) Fix SSL client code which could crash if connecting to a
@@ -5087,7 +5087,7 @@
   *) New structure X509_VERIFY_PARAM which combines current verify parameters,
      update associated structures and add various utility functions.
 
-     Add new policy related verify parameters, include policy checking in 
+     Add new policy related verify parameters, include policy checking in
      standard verify code. Enhance 'smime' application with extra parameters
      to support policy checking and print out.
      [Steve Henson]
@@ -5136,12 +5136,12 @@
      [Steve Henson]
 
   *) Add new EVP function EVP_CIPHER_CTX_rand_key and associated functionality.
-     This will generate a random key of the appropriate length based on the 
+     This will generate a random key of the appropriate length based on the
      cipher context. The EVP_CIPHER can provide its own random key generation
-     routine to support keys of a specific form. This is used in the des and 
+     routine to support keys of a specific form. This is used in the des and
      3des routines to generate a key of the correct parity. Update S/MIME
      code to use new functions and hence generate correct parity DES keys.
-     Add EVP_CHECK_DES_KEY #define to return an error if the key is not 
+     Add EVP_CHECK_DES_KEY #define to return an error if the key is not
      valid (weak or incorrect parity).
      [Steve Henson]
 
@@ -5254,7 +5254,7 @@
      functions.
      [Steve Henson]
 
-  *) New function PKCS7_set0_type_other() this initializes a PKCS7 
+  *) New function PKCS7_set0_type_other() this initializes a PKCS7
      structure of type "other".
      [Steve Henson]
 
@@ -5463,7 +5463,7 @@
      [Geoff Thorpe]
 
   *) Change the ZLIB compression method to be stateful, and make it
-     available to TLS with the number defined in 
+     available to TLS with the number defined in
      draft-ietf-tls-compression-04.txt.
      [Richard Levitte]
 
@@ -5487,7 +5487,7 @@
      Makefile.shared, for Cygwin's sake.
      [Richard Levitte]
 
-  *) Extend the BIGNUM API by creating a function 
+  *) Extend the BIGNUM API by creating a function
           void BN_set_negative(BIGNUM *a, int neg);
      and a macro that behave like
           int  BN_is_negative(const BIGNUM *a);
@@ -5640,7 +5640,7 @@
 
   *) Add binary polynomial arithmetic software in crypto/bn/bn_gf2m.c.
      Polynomials are represented as BIGNUMs (where the sign bit is not
-     used) in the following functions [macros]:  
+     used) in the following functions [macros]:
 
           BN_GF2m_add
           BN_GF2m_sub             [= BN_GF2m_add]
@@ -5733,7 +5733,7 @@
      EC_METHOD_get_field_type() returns this value.
      [Nils Larsch <nla@trustcenter.de>]
 
-  *) Add functions 
+  *) Add functions
           EC_POINT_point2bn()
           EC_POINT_bn2point()
           EC_POINT_point2hex()
@@ -5792,7 +5792,7 @@
          EC_GROUP_set_curve_name()
          EC_GROUP_get_curve_name()
      [Nils Larsch <larsch@trustcenter.de, Bodo Moeller]
- 
+
   *) Remove a few calls to bn_wexpand() in BN_sqr() (the one in there
      was actually never needed) and in BN_mul().  The removal in BN_mul()
      required a small change in bn_mul_part_recursive() and the addition
@@ -5804,7 +5804,7 @@
 
  Changes between 0.9.7l and 0.9.7m  [23 Feb 2007]
 
-  *) Cleanse PEM buffers before freeing them since they may contain 
+  *) Cleanse PEM buffers before freeing them since they may contain
      sensitive data.
      [Benjamin Bennett <ben@psc.edu>]
 
@@ -5852,7 +5852,7 @@
   *) Fix ASN.1 parsing of certain invalid structures that can result
      in a denial of service.  (CVE-2006-2937)  [Steve Henson]
 
-  *) Fix buffer overflow in SSL_get_shared_ciphers() function. 
+  *) Fix buffer overflow in SSL_get_shared_ciphers() function.
      (CVE-2006-3738) [Tavis Ormandy and Will Drewry, Google Security Team]
 
   *) Fix SSL client code which could crash if connecting to a
@@ -5906,10 +5906,10 @@
   *) Fixes for VC++ 2005 build under Windows.
      [Steve Henson]
 
-  *) Add new Windows build target VC-32-GMAKE for VC++. This uses GNU make 
+  *) Add new Windows build target VC-32-GMAKE for VC++. This uses GNU make
      from a Windows bash shell such as MSYS. It is autodetected from the
      "config" script when run from a VC++ environment. Modify standard VC++
-     build to use fipscanister.o from the GNU make build. 
+     build to use fipscanister.o from the GNU make build.
      [Steve Henson]
 
  Changes between 0.9.7h and 0.9.7i  [14 Oct 2005]
@@ -6022,7 +6022,7 @@
         values.
 
      The OpenSSL team would like to thank the UK NISCC for bringing this issue
-     to our attention. 
+     to our attention.
 
      [Stephen Henson, reported by UK NISCC]
 
@@ -6067,7 +6067,7 @@
 
  Changes between 0.9.7d and 0.9.7e  [25 Oct 2004]
 
-  *) Avoid a race condition when CRLs are checked in a multi threaded 
+  *) Avoid a race condition when CRLs are checked in a multi threaded
      environment. This would happen due to the reordering of the revoked
      entries during signature checking and serial number lookup. Now the
      encoding is cached and the serial number sort performed under a lock.
@@ -6091,13 +6091,13 @@
 
  Changes between 0.9.7c and 0.9.7d  [17 Mar 2004]
 
-  *) Fix null-pointer assignment in do_change_cipher_spec() revealed           
-     by using the Codenomicon TLS Test Tool (CVE-2004-0079)                    
-     [Joe Orton, Steve Henson]   
+  *) Fix null-pointer assignment in do_change_cipher_spec() revealed
+     by using the Codenomicon TLS Test Tool (CVE-2004-0079)
+     [Joe Orton, Steve Henson]
 
   *) Fix flaw in SSL/TLS handshaking when using Kerberos ciphersuites
      (CVE-2004-0112)
-     [Joe Orton, Steve Henson]   
+     [Joe Orton, Steve Henson]
 
   *) Make it possible to have multiple active certificates with the same
      subject in the CA index file.  This is done only if the keyword
@@ -6107,7 +6107,7 @@
      named like the index file with '.attr' appended to the name.
      [Richard Levitte]
 
-  *) X509 verify fixes. Disable broken certificate workarounds when 
+  *) X509 verify fixes. Disable broken certificate workarounds when
      X509_V_FLAGS_X509_STRICT is set. Check CRL issuer has cRLSign set if
      keyUsage extension present. Don't accept CRLs with unhandled critical
      extensions: since verify currently doesn't process CRL extensions this
@@ -6116,7 +6116,7 @@
      [Steve Henson]
 
   *) When creating an OCSP nonce use an OCTET STRING inside the extnValue.
-     A clarification of RFC2560 will require the use of OCTET STRINGs and 
+     A clarification of RFC2560 will require the use of OCTET STRINGs and
      some implementations cannot handle the current raw format. Since OpenSSL
      copies and compares OCSP nonces as opaque blobs without any attempt at
      parsing them this should not create any compatibility issues.
@@ -6140,7 +6140,7 @@
 
      Stop out of bounds reads in the ASN1 code when presented with
      invalid tags (CVE-2003-0543 and CVE-2003-0544).
-     
+
      Free up ASN1_TYPE correctly if ANY type is invalid (CVE-2003-0545).
 
      If verify callback ignores invalid public key errors don't try to check
@@ -6170,7 +6170,7 @@
      blocks during encryption.
      [Richard Levitte]
 
-  *) Various fixes to base64 BIO and non blocking I/O. On write 
+  *) Various fixes to base64 BIO and non blocking I/O. On write
      flushes were not handled properly if the BIO retried. On read
      data was not being buffered properly and had various logic bugs.
      This also affects blocking I/O when the data being decoded is a
@@ -6218,7 +6218,7 @@
 
   *) Target "mingw" now allows native Windows code to be generated in
      the Cygwin environment as well as with the MinGW compiler.
-     [Ulf Moeller] 
+     [Ulf Moeller]
 
  Changes between 0.9.7 and 0.9.7a  [19 Feb 2003]
 
@@ -6254,7 +6254,7 @@
 
   *) Allow an application to disable the automatic SSL chain building.
      Before this a rather primitive chain build was always performed in
-     ssl3_output_cert_chain(): an application had no way to send the 
+     ssl3_output_cert_chain(): an application had no way to send the
      correct chain if the automatic operation produced an incorrect result.
 
      Now the chain builder is disabled if either:
@@ -6502,7 +6502,7 @@
      error in AES-CFB decryption.
      [Richard Levitte]
 
-  *) Remove most calls to EVP_CIPHER_CTX_cleanup() in evp_enc.c, this 
+  *) Remove most calls to EVP_CIPHER_CTX_cleanup() in evp_enc.c, this
      allows existing EVP_CIPHER_CTX structures to be reused after
      calling EVP_*Final(). This behaviour is used by encryption
      BIOs and some applications. This has the side effect that
@@ -6529,8 +6529,8 @@
      [Lutz Jaenicke]
 
   *) Add an "init" command to the ENGINE config module and auto initialize
-     ENGINEs. Without any "init" command the ENGINE will be initialized 
-     after all ctrl commands have been executed on it. If init=1 the 
+     ENGINEs. Without any "init" command the ENGINE will be initialized
+     after all ctrl commands have been executed on it. If init=1 the
      ENGINE is initailized at that point (ctrls before that point are run
      on the uninitialized ENGINE and after on the initialized one). If
      init=0 then the ENGINE will not be iniatialized at all.
@@ -6571,7 +6571,7 @@
   *) Config modules support in openssl utility.
 
      Most commands now load modules from the config file,
-     though in a few (such as version) this isn't done 
+     though in a few (such as version) this isn't done
      because it couldn't be used for anything.
 
      In the case of ca and req the config file used is
@@ -6637,7 +6637,7 @@
      but report on the latest error recorded rather than the first one
      still in the error queue.
      [Ben Laurie, Bodo Moeller]
-        
+
   *) default_algorithms option in ENGINE config module. This allows things
      like:
      default_algorithms = ALL
@@ -6754,7 +6754,7 @@
      [Richard Levitte]
 
   *) Test for certificates which contain unsupported critical extensions.
-     If such a certificate is found during a verify operation it is 
+     If such a certificate is found during a verify operation it is
      rejected by default: this behaviour can be overridden by either
      handling the new error X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION or
      by setting the verify flag X509_V_FLAG_IGNORE_CRITICAL. A new function
@@ -7119,7 +7119,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      [Steve Henson]
 
   *) Add copies of X509_STORE_CTX fields and callbacks to X509_STORE
-     structure. These are inherited by X509_STORE_CTX when it is 
+     structure. These are inherited by X509_STORE_CTX when it is
      initialised. This allows various defaults to be set in the
      X509_STORE structure (such as flags for CRL checking and custom
      purpose or trust settings) for functions which only use X509_STORE_CTX
@@ -7283,7 +7283,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
      EC_GFp_simple_method() uses the basic BN_mod_mul and BN_mod_sqr
      operations and provides various method functions that can also
-     operate with faster implementations of modular arithmetic.     
+     operate with faster implementations of modular arithmetic.
 
      EC_GFp_mont_method() reuses most functions that are part of
      EC_GFp_simple_method, but uses Montgomery arithmetic.
@@ -7471,7 +7471,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) New option -set_serial to 'req' and 'x509' this allows the serial
      number to use to be specified on the command line. Previously self
-     signed certificates were hard coded with serial number 0 and the 
+     signed certificates were hard coded with serial number 0 and the
      CA options of 'x509' had to use a serial number in a file which was
      auto incremented.
      [Steve Henson]
@@ -7496,7 +7496,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      option to ocsp utility.
      [Steve Henson]
 
-  *) New nonce behavior. The return value of OCSP_check_nonce() now 
+  *) New nonce behavior. The return value of OCSP_check_nonce() now
      reflects the various checks performed. Applications can decide
      whether to tolerate certain situations such as an absent nonce
      in a response when one was present in a request: the ocsp application
@@ -7570,7 +7570,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Various new functions. EVP_Digest() combines EVP_Digest{Init,Update,Final}()
      in a single operation. X509_get0_pubkey_bitstr() extracts the public_key
      structure from a certificate. X509_pubkey_digest() digests the public_key
-     contents: this is used in various key identifiers. 
+     contents: this is used in various key identifiers.
      [Steve Henson]
 
   *) Make sk_sort() tolerate a NULL argument.
@@ -7758,7 +7758,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Update OCSP API. Remove obsolete extensions argument from
      various functions. Extensions are now handled using the new
-     OCSP extension code. New simple OCSP HTTP function which 
+     OCSP extension code. New simple OCSP HTTP function which
      can be used to send requests and parse the response.
      [Steve Henson]
 
@@ -8144,7 +8144,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
      Stop out of bounds reads in the ASN1 code when presented with
      invalid tags (CVE-2003-0543 and CVE-2003-0544).
-     
+
      If verify callback ignores invalid public key errors don't try to check
      certificate signature with the NULL public key.
 
@@ -8223,7 +8223,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      [Zeev Lieber <zeev-l@yahoo.com>]
 
   *) Undo an undocumented change introduced in 0.9.6e which caused
-     repeated calls to OpenSSL_add_all_ciphers() and 
+     repeated calls to OpenSSL_add_all_ciphers() and
      OpenSSL_add_all_digests() to be ignored, even after calling
      EVP_cleanup().
      [Richard Levitte]
@@ -8397,7 +8397,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      a generator of the order-q subgroup is just as good, if not
      better.
      [Bodo Moeller]
- 
+
   *) Map new X509 verification errors to alerts. Discovered and submitted by
      Tom Wu <tom@arcot.com>.
      [Lutz Jaenicke]
@@ -8510,7 +8510,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      [Broadcom, Nalin Dahyabhai <nalin@redhat.com>, Mark Cox]
 
   *) [In 0.9.6c-engine release:]
-     Add support for SureWare crypto accelerator cards from 
+     Add support for SureWare crypto accelerator cards from
      Baltimore Technologies.  (Use engine 'sureware')
      [Baltimore Technologies and Mark Cox]
 
@@ -8853,8 +8853,8 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      Computations, J. Cryptology 14 (2001) 2, 101-119,
      http://theory.stanford.edu/~dabo/papers/faults.ps.gz).
      [Ulf Moeller]
-  
-  *) MIPS assembler BIGNUM division bug fix. 
+
+  *) MIPS assembler BIGNUM division bug fix.
      [Andy Polyakov]
 
   *) Disabled incorrect Alpha assembler code.
@@ -8910,7 +8910,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      2. Fix logical glitch in is_MemCheck_on() aka CRYPTO_is_mem_check_on().
 
      3. Count how many times MemCheck_off() has been called so that
-        nested use can be treated correctly.  This also avoids 
+        nested use can be treated correctly.  This also avoids
         inband-signalling in the previous code (which relied on the
         assumption that thread ID 0 is impossible).
      [Bodo Moeller]
@@ -9024,7 +9024,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) rand_win.c fix for Borland C.
      [Ulf Möller]
- 
+
   *) BN_rshift bugfix for n == 0.
      [Bodo Moeller]
 
@@ -9094,7 +9094,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      and not in SSL_clear because the latter is also used by the
      accept/connect functions; previously, the settings made by
      SSL_set_read_ahead would be lost during the handshake.
-     [Bodo Moeller; problems reported by Anders Gertz <gertz@epact.se>]     
+     [Bodo Moeller; problems reported by Anders Gertz <gertz@epact.se>]
 
   *) Correct util/mkdef.pl to be selective about disabled algorithms.
      Previously, it would create entries for disabled algorithms no
@@ -9184,7 +9184,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      doc package contains the contents of the doc directory.  The original
      openssl.spec was provided by Damien Miller <djm@mindrot.org>.
      [Richard Levitte]
-     
+
   *) Add a large number of documentation files for many SSL routines.
      [Lutz Jaenicke <Lutz.Jaenicke@aet.TU-Cottbus.DE>]
 
@@ -9230,19 +9230,19 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Allow the verify time to be set by an application,
      rather than always using the current time.
      [Steve Henson]
-  
+
   *) Phase 2 verify code reorganisation. The certificate
      verify code now looks up an issuer certificate by a
      number of criteria: subject name, authority key id
      and key usage. It also verifies self signed certificates
      by the same criteria. The main comparison function is
      X509_check_issued() which performs these checks.
- 
+
      Lot of changes were necessary in order to support this
      without completely rewriting the lookup code.
- 
+
      Authority and subject key identifier are now cached.
- 
+
      The LHASH 'certs' is X509_STORE has now been replaced
      by a STACK_OF(X509_OBJECT). This is mainly because an
      LHASH can't store or retrieve multiple objects with
@@ -9252,10 +9252,10 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      use only) have changed to handle the new X509_STORE
      structure. This will break anything that messed round
      with X509_STORE internally.
- 
+
      The functions X509_STORE_add_cert() now checks for an
      exact match, rather than just subject name.
- 
+
      The X509_STORE API doesn't directly support the retrieval
      of multiple certificates matching a given criteria, however
      this can be worked round by performing a lookup first
@@ -9263,9 +9263,9 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      and then examining the cache for matches. This is probably
      the best we can do without throwing out X509_LOOKUP
      entirely (maybe later...).
- 
+
      The X509_VERIFY_CTX structure has been enhanced considerably.
- 
+
      All certificate lookup operations now go via a get_issuer()
      callback. Although this currently uses an X509_STORE it
      can be replaced by custom lookups. This is a simple way
@@ -9274,15 +9274,15 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      in future. A very simple version which uses a simple
      STACK for its trusted certificate store is also provided
      using X509_STORE_CTX_trusted_stack().
- 
+
      The verify_cb() and verify() callbacks now have equivalents
      in the X509_STORE_CTX structure.
- 
+
      X509_STORE_CTX also has a 'flags' field which can be used
      to customise the verify behaviour.
      [Steve Henson]
- 
-  *) Add new PKCS#7 signing option PKCS7_NOSMIMECAP which 
+
+  *) Add new PKCS#7 signing option PKCS7_NOSMIMECAP which
      excludes S/MIME capabilities.
      [Steve Henson]
 
@@ -9344,7 +9344,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Modification to PKCS#7 encoding routines to output definite
      length encoding. Since currently the whole structures are in
-     memory there's not real point in using indefinite length 
+     memory there's not real point in using indefinite length
      constructed encoding. However if OpenSSL is compiled with
      the flag PKCS7_INDEFINITE_ENCODING the old form is used.
      [Steve Henson]
@@ -9423,7 +9423,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) New functions ASN1_STRING_print_ex() and X509_NAME_print_ex()
      these print out strings and name structures based on various
      flags including RFC2253 support and proper handling of
-     multibyte characters. Added options to the 'x509' utility 
+     multibyte characters. Added options to the 'x509' utility
      to allow the various flags to be set.
      [Steve Henson]
 
@@ -9501,7 +9501,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      to check that it worked correctly is to look in obj_dat.h and
      check the array nid_objs and make sure the objects haven't moved
      around (this is important!).  Additions are OK, as well as
-     consistent name changes. 
+     consistent name changes.
      [Richard Levitte]
 
   *) Add BSD-style MD5-based passwords to 'openssl passwd' (option '-1').
@@ -9525,9 +9525,9 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      added extra typesafe functions: these no longer exist.
      [Steve Henson]
 
-  *) Reorganisation of the stack code. The macros are now all 
+  *) Reorganisation of the stack code. The macros are now all
      collected in safestack.h . Each macro is defined in terms of
-     a "stack macro" of the form SKM_<name>(type, a, b). The 
+     a "stack macro" of the form SKM_<name>(type, a, b). The
      DEBUG_SAFESTACK is now handled in terms of function casts,
      this has the advantage of retaining type safety without the
      use of additional functions. If DEBUG_SAFESTACK is not defined
@@ -9545,7 +9545,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      new functions i2d_RSA_NET(), d2i_RSA_NET() etc which are the same
      as the old Netscape_RSA functions except they have an additional
      'sgckey' parameter which uses the modified algorithm. Also added
-     an -sgckey command line option to the rsa utility. Thanks to 
+     an -sgckey command line option to the rsa utility. Thanks to
      Adrian Peck <bertie@ncipher.com> for posting details of the modified
      algorithm to openssl-dev.
      [Steve Henson]
@@ -9557,7 +9557,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) New X509_get1_email() and X509_REQ_get1_email() functions that return
      a STACK of email addresses from a certificate or request, these look
-     in the subject name and the subject alternative name extensions and 
+     in the subject name and the subject alternative name extensions and
      omit any duplicate addresses.
      [Steve Henson]
 
@@ -9789,7 +9789,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      <attili@amaxo.com>]
 
   *) Fix for HMAC. It wasn't zeroing the rest of the block if the key length
-     was larger than the MD block size.      
+     was larger than the MD block size.
      [Steve Henson, pointed out by Yost William <YostW@tce.com>]
 
   *) Modernise PKCS12_parse() so it uses STACK_OF(X509) for its ca argument
@@ -9924,7 +9924,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Add an optional second argument to the set_label() in the perl
      assembly language builder. If this argument exists and is set
-     to 1 it signals that the assembler should use a symbol whose 
+     to 1 it signals that the assembler should use a symbol whose
      scope is the entire file, not just the current function. This
      is needed with MASM which uses the format label:: for this scope.
      [Steve Henson, pointed out by Peter Runestig <peter@runestig.com>]
@@ -10087,7 +10087,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Source code cleanups: use const where appropriate, eliminate casts,
      use void * instead of char * in lhash.
-     [Ulf Möller] 
+     [Ulf Möller]
 
   *) Bugfix: ssl3_send_server_key_exchange was not restartable
      (the state was not changed to SSL3_ST_SW_KEY_EXCH_B, and because of
@@ -10112,7 +10112,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      loop rather than for the current invocation of the inner loop.
      DSA_generate_parameters additionally can call the callback
      function with an 'iteration count' of -1, meaning that a
-     candidate has passed the trial division test (when q is generated 
+     candidate has passed the trial division test (when q is generated
      from an application-provided seed, trial division is skipped).
      [Bodo Moeller]
 
@@ -10221,7 +10221,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Add missing #ifndefs that caused missing symbols when building libssl
      as a shared library without RSA.  Use #ifndef NO_SSL2 instead of
-     NO_RSA in ssl/s2*.c. 
+     NO_RSA in ssl/s2*.c.
      [Kris Kennaway <kris@hub.freebsd.org>, modified by Ulf Möller]
 
   *) Precautions against using the PRNG uninitialized: RAND_bytes() now
@@ -10263,9 +10263,9 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Honor the no-xxx Configure options when creating .DEF files.
      [Ulf Möller]
 
-  *) Add PKCS#10 attributes to field table: challengePassword, 
+  *) Add PKCS#10 attributes to field table: challengePassword,
      unstructuredName and unstructuredAddress. These are taken from
-     draft PKCS#9 v2.0 but are compatible with v1.2 provided no 
+     draft PKCS#9 v2.0 but are compatible with v1.2 provided no
      international characters are used.
 
      More changes to X509_ATTRIBUTE code: allow the setting of types
@@ -10432,7 +10432,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      debugging functions are used, CRYPTO_dbg_set_options can be used to
      request additional information:
      CRYPTO_dbg_set_options(V_CYRPTO_MDEBUG_xxx) corresponds to setting
-     the CRYPTO_MDEBUG_xxx macro when compiling the library.   
+     the CRYPTO_MDEBUG_xxx macro when compiling the library.
 
      Also, things like CRYPTO_set_mem_functions will always give the
      expected result (the new set of functions is used for allocation
@@ -10575,7 +10575,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      other than PKCS#8 should be dumped: but the other formats have to
      stay in the name of compatibility.
 
-     With public keys and the benefit of hindsight one standard format 
+     With public keys and the benefit of hindsight one standard format
      is used which works with EVP_PKEY, RSA or DSA structures: though
      it clearly returns an error if you try to read the wrong kind of key.
 
@@ -10692,7 +10692,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      will also read in any additional "auxiliary information". By
      doing things this way a fair degree of compatibility can be
      retained: existing certificates can have this information added
-     using the new 'x509' options. 
+     using the new 'x509' options.
 
      Current auxiliary information includes an "alias" and some trust
      settings. The trust settings will ultimately be used in enhanced
@@ -10708,7 +10708,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      performance improvement for 1024 bit RSA signs.
      [Mark Cox]
 
-  *) Hack to fix PKCS#7 decryption when used with some unorthodox RC2 
+  *) Hack to fix PKCS#7 decryption when used with some unorthodox RC2
      handling. Most clients have the effective key size in bits equal to
      the key length in bits: so a 40 bit RC2 key uses a 40 bit (5 byte) key.
      A few however don't do this and instead use the size of the decrypted key
@@ -10720,7 +10720,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      the key length and effective key length are equal.
      [Steve Henson]
 
-  *) Add a bunch of functions that should simplify the creation of 
+  *) Add a bunch of functions that should simplify the creation of
      X509_NAME structures. Now you should be able to do:
      X509_NAME_add_entry_by_txt(nm, "CN", MBSTRING_ASC, "Steve", -1, -1, 0);
      and have it automatically work out the correct field type and fill in
@@ -10753,7 +10753,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
      Use the random seed file in some applications that previously did not:
           ca,
-          dsaparam -genkey (which also ignored its '-rand' option), 
+          dsaparam -genkey (which also ignored its '-rand' option),
           s_client,
           s_server,
           x509 (when signing).
@@ -10790,7 +10790,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Add various functions that can check a certificate's extensions
      to see if it usable for various purposes such as SSL client,
-     server or S/MIME and CAs of these types. This is currently 
+     server or S/MIME and CAs of these types. This is currently
      VERY EXPERIMENTAL but will ultimately be used for certificate chain
      verification. Also added a -purpose flag to x509 utility to
      print out all the purposes.
@@ -10963,7 +10963,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      provides hooks that allow the default DSA functions or functions on a
      "per key" basis to be replaced. This allows hardware acceleration and
      hardware key storage to be handled without major modification to the
-     library. Also added low level modexp hooks and CRYPTO_EX structure and 
+     library. Also added low level modexp hooks and CRYPTO_EX structure and
      associated functions.
      [Steve Henson]
 
@@ -11008,7 +11008,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      [Bodo Moeller]
 
  Changes between 0.9.3a and 0.9.4  [09 Aug 1999]
-  
+
   *) Install libRSAglue.a when OpenSSL is built with RSAref.
      [Ralf S. Engelschall]
 
@@ -11113,7 +11113,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      for verifying the consistency of RSA keys.
      [Ulf Moeller, Bodo Moeller]
 
-  *) Various changes to make Win32 compile work: 
+  *) Various changes to make Win32 compile work:
      1. Casts to avoid "loss of data" warnings in p5_crpt2.c
      2. Change unsigned int to int in b_dump.c to avoid "signed/unsigned
         comparison" warnings.
@@ -11137,7 +11137,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
      Omitting parameters is no longer recommended. The test was also
      the wrong way round! This was probably due to unusual behaviour in
-     EVP_cmp_parameters() which returns 1 if the parameters match. 
+     EVP_cmp_parameters() which returns 1 if the parameters match.
      This meant that parameters were omitted when they *didn't* match and
      the certificate was useless. Certificates signed with 'ca' didn't have
      this bug.
@@ -11214,7 +11214,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Complete the PEM_* macros with DECLARE_PEM versions to replace the
      function prototypes in pem.h, also change util/mkdef.pl to add the
-     necessary function names. 
+     necessary function names.
      [Steve Henson]
 
   *) mk1mf.pl (used by Windows builds) did not properly read the
@@ -11254,7 +11254,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Add initial documentation of the X509V3 functions.
      [Steve Henson]
 
-  *) Add a new pair of functions PEM_write_PKCS8PrivateKey() and 
+  *) Add a new pair of functions PEM_write_PKCS8PrivateKey() and
      PEM_write_bio_PKCS8PrivateKey() that are equivalent to
      PEM_write_PrivateKey() and PEM_write_bio_PrivateKey() but use the more
      secure PKCS#8 private key format with a high iteration count.
@@ -11396,11 +11396,11 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
  Changes between 0.9.2b and 0.9.3  [24 May 1999]
 
   *) Bignum library bug fix. IRIX 6 passes "make test" now!
-     This also avoids the problems with SC4.2 and unpatched SC5.  
+     This also avoids the problems with SC4.2 and unpatched SC5.
      [Andy Polyakov <appro@fy.chalmers.se>]
 
   *) New functions sk_num, sk_value and sk_set to replace the previous macros.
-     These are required because of the typesafe stack would otherwise break 
+     These are required because of the typesafe stack would otherwise break
      existing code. If old code used a structure member which used to be STACK
      and is now STACK_OF (for example cert in a PKCS7_SIGNED structure) with
      sk_num or sk_value it would produce an error because the num, data members
@@ -11461,7 +11461,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Fix various things to let OpenSSL even pass ``egcc -pipe -O2 -Wall
      -Wshadow -Wpointer-arith -Wcast-align -Wmissing-prototypes
-     -Wmissing-declarations -Wnested-externs -Winline'' with EGCS 1.1.2+ 
+     -Wmissing-declarations -Wnested-externs -Winline'' with EGCS 1.1.2+
      [Ralf S. Engelschall]
 
   *) Various fixes to the EVP and PKCS#7 code. It may now be able to
@@ -11482,7 +11482,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      in different behaviour than observed with earlier library versions:
      Changing settings for an SSL_CTX *ctx after having done s = SSL_new(ctx)
      does not influence s as it used to.
-     
+
      In order to clean up things more thoroughly, inside SSL_SESSION
      we don't use CERT any longer, but a new structure SESS_CERT
      that holds per-session data (if available); currently, this is
@@ -11530,7 +11530,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Update HPUX configuration.
      [Anonymous]
-  
+
   *) Add missing sk_<type>_unshift() function to safestack.h
      [Ralf S. Engelschall]
 
@@ -11634,11 +11634,11 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Fix lots of warnings.
      [Richard Levitte <levitte@stacken.kth.se>]
- 
+
   *) In add_cert_dir() in crypto/x509/by_dir.c, break out of the loop if
      the directory spec didn't end with a LIST_SEPARATOR_CHAR.
      [Richard Levitte <levitte@stacken.kth.se>]
- 
+
   *) Fix problems with sizeof(long) == 8.
      [Andy Polyakov <appro@fy.chalmers.se>]
 
@@ -11749,7 +11749,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) New config option to avoid instructions that are illegal on the 80386.
      The default code is faster, but requires at least a 486.
      [Ulf Möller]
-  
+
   *) Got rid of old SSL2_CLIENT_VERSION (inconsistently used) and
      SSL2_SERVER_VERSION (not used at all) macros, which are now the
      same as SSL2_VERSION anyway.
@@ -11792,8 +11792,8 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      OAEP isn't supported when OpenSSL is built with RSAref.
      [Ulf Moeller <ulf@fitug.de>]
 
-  *) Move definitions of IS_SET/IS_SEQUENCE inside crypto/asn1/asn1.h 
-     so they no longer are missing under -DNOPROTO. 
+  *) Move definitions of IS_SET/IS_SEQUENCE inside crypto/asn1/asn1.h
+     so they no longer are missing under -DNOPROTO.
      [Soren S. Jorvang <soren@t.dk>]
 
 
@@ -11950,14 +11950,14 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      [Ben Laurie]
 
   *) Add a bunch of fixes to the PKCS#7 stuff. It used to sometimes reorder
-     signed attributes when verifying signatures (this would break them), 
+     signed attributes when verifying signatures (this would break them),
      the detached data encoding was wrong and public keys obtained using
      X509_get_pubkey() weren't freed.
      [Steve Henson]
 
   *) Add text documentation for the BUFFER functions. Also added a work around
      to a Win95 console bug. This was triggered by the password read stuff: the
-     last character typed gets carried over to the next fread(). If you were 
+     last character typed gets carried over to the next fread(). If you were
      generating a new cert request using 'req' for example then the last
      character of the passphrase would be CR which would then enter the first
      field as blank.
@@ -11966,7 +11966,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Added the new `Includes OpenSSL Cryptography Software' button as
      doc/openssl_button.{gif,html} which is similar in style to the old SSLeay
      button and can be used by applications based on OpenSSL to show the
-     relationship to the OpenSSL project.  
+     relationship to the OpenSSL project.
      [Ralf S. Engelschall]
 
   *) Remove confusing variables in function signatures in files
@@ -11997,7 +11997,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      See http://www.stack.nl/~dimitri/doxygen/index.html, and run doxygen with
      openssl.doxy as the configuration file.
      [Ben Laurie]
-  
+
   *) Get rid of remaining C++-style comments which strict C compilers hate.
      [Ralf S. Engelschall, pointed out by Carlos Amengual]
 
@@ -12010,12 +12010,12 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      their SSL_CTX_xxx() counterparts but work on a per-connection basis. This
      is needed for applications which have to configure certificates on a
      per-connection basis (e.g. Apache+mod_ssl) instead of a per-context basis
-     (e.g. s_server). 
+     (e.g. s_server).
         For the RSA certificate situation is makes no difference, but
      for the DSA certificate situation this fixes the "no shared cipher"
      problem where the OpenSSL cipher selection procedure failed because the
      temporary keys were not overtaken from the context and the API provided
-     no way to reconfigure them. 
+     no way to reconfigure them.
         The new functions now let applications reconfigure the stuff and they
      are in detail: SSL_need_tmp_RSA, SSL_set_tmp_rsa, SSL_set_tmp_dh,
      SSL_set_tmp_rsa_callback and SSL_set_tmp_dh_callback.  Additionally a new
@@ -12162,7 +12162,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      message is now correct (it understands "crypto" and "ssl" on its
      command line). There is also now an "update" option. This will update
      the util/ssleay.num and util/libeay.num files with any new functions.
-     If you do a: 
+     If you do a:
      perl util/mkdef.pl crypto ssl update
      it will update them.
      [Steve Henson]
@@ -12213,7 +12213,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Fixed ms/32all.bat script: `no_asm' -> `no-asm'
      [Rainer W. Gerling <gerling@mpg-gv.mpg.de>]
-  
+
   *) New program nseq to manipulate netscape certificate sequences
      [Steve Henson]
 
@@ -12268,7 +12268,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Spelling mistake in C version of CAST-128.
      [Ben Laurie, reported by Jeremy Hylton <jeremy@cnri.reston.va.us>]
 
-  *) Changes to the error generation code. The perl script err-code.pl 
+  *) Changes to the error generation code. The perl script err-code.pl
      now reads in the old error codes and retains the old numbers, only
      adding new ones if necessary. It also only changes the .err files if new
      codes are added. The makefiles have been modified to only insert errors
@@ -12320,7 +12320,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) The function OBJ_txt2nid was broken. It was supposed to return a nid
      based on a text string, looking up short and long names and finally
      "dot" format. The "dot" format stuff didn't work. Added new function
-     OBJ_txt2obj to do the same but return an ASN1_OBJECT and rewrote 
+     OBJ_txt2obj to do the same but return an ASN1_OBJECT and rewrote
      OBJ_txt2nid to use it. OBJ_txt2obj can also return objects even if the
      OID is not part of the table.
      [Steve Henson]
@@ -12414,7 +12414,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Fix renumbering bug in X509_NAME_delete_entry().
      [Ben Laurie]
 
-  *) Enhanced the err-ins.pl script so it makes the error library number 
+  *) Enhanced the err-ins.pl script so it makes the error library number
      global and can add a library name. This is needed for external ASN1 and
      other error libraries.
      [Steve Henson]
@@ -12422,7 +12422,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Fixed sk_insert which never worked properly.
      [Steve Henson]
 
-  *) Fix ASN1 macros so they can handle indefinite length constructed 
+  *) Fix ASN1 macros so they can handle indefinite length constructed
      EXPLICIT tags. Some non standard certificates use these: they can now
      be read in.
      [Steve Henson]
@@ -12467,10 +12467,10 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
  Changes between 0.9.1b and 0.9.1c  [23-Dec-1998]
 
-  *) Added OPENSSL_VERSION_NUMBER to crypto/crypto.h and 
+  *) Added OPENSSL_VERSION_NUMBER to crypto/crypto.h and
      changed SSLeay to OpenSSL in version strings.
      [Ralf S. Engelschall]
-  
+
   *) Some fixups to the top-level documents.
      [Paul Sutton]
 
@@ -12478,7 +12478,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      because the symlink to include/ was missing.
      [Ralf S. Engelschall]
 
-  *) Incorporated the popular no-RSA/DSA-only patches 
+  *) Incorporated the popular no-RSA/DSA-only patches
      which allow to compile a RSA-free SSLeay.
      [Andrew Cooke / Interrader Ldt., Ralf S. Engelschall]
 
@@ -12486,7 +12486,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      when "ssleay" is still not found.
      [Ralf S. Engelschall]
 
-  *) Added more platforms to Configure: Cray T3E, HPUX 11, 
+  *) Added more platforms to Configure: Cray T3E, HPUX 11,
      [Ralf S. Engelschall, Beckmann <beckman@acl.lanl.gov>]
 
   *) Updated the README file.
@@ -12502,13 +12502,13 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
   *) Cleaned up the top-level documents;
      o new files: CHANGES and LICENSE
-     o merged VERSION, HISTORY* and README* files a CHANGES.SSLeay 
+     o merged VERSION, HISTORY* and README* files a CHANGES.SSLeay
      o merged COPYRIGHT into LICENSE
      o removed obsolete TODO file
      o renamed MICROSOFT to INSTALL.W32
      [Ralf S. Engelschall]
 
-  *) Removed dummy files from the 0.9.1b source tree: 
+  *) Removed dummy files from the 0.9.1b source tree:
      crypto/asn1/x crypto/bio/cd crypto/bio/fg crypto/bio/grep crypto/bio/vi
      crypto/bn/asm/......add.c crypto/bn/asm/a.out crypto/dsa/f crypto/md5/f
      crypto/pem/gmon.out crypto/perlasm/f crypto/pkcs7/build crypto/rsa/f
@@ -12524,7 +12524,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      Young and Tim J. Hudson created while they were working for C2Net until
      summer 1998.
      [The OpenSSL Project]
- 
+
 
  Changes between 0.9.0b and 0.9.1b  [not released]
 
@@ -12534,17 +12534,17 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Changed some BIGNUM api stuff.
      [Eric A. Young]
 
-  *) Various platform ports: OpenBSD, Ultrix, IRIX 64bit, NetBSD, 
+  *) Various platform ports: OpenBSD, Ultrix, IRIX 64bit, NetBSD,
      DGUX x86, Linux Alpha, etc.
      [Eric A. Young]
 
-  *) New COMP library [crypto/comp/] for SSL Record Layer Compression: 
+  *) New COMP library [crypto/comp/] for SSL Record Layer Compression:
      RLE (dummy implemented) and ZLIB (really implemented when ZLIB is
      available).
      [Eric A. Young]
 
-  *) Add -strparse option to asn1pars program which parses nested 
-     binary structures 
+  *) Add -strparse option to asn1pars program which parses nested
+     binary structures
      [Dr Stephen Henson <shenson@bigfoot.com>]
 
   *) Added "oid_file" to ssleay.cnf for "ca" and "req" programs.
@@ -12623,7 +12623,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Fixed various code and comment typos.
      [Eric A. Young]
 
-  *) A minor bug in ssl/s3_clnt.c where there would always be 4 0 
+  *) A minor bug in ssl/s3_clnt.c where there would always be 4 0
      bytes sent in the client random.
      [Edward Bishop <ebishop@spyglass.com>]
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This simply strips out all trailing whitespaces in the `CHANGES` file.

As mentioned in #4552 by @dot-asm .

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
