### PR TITLE
Internalize X509_SIG_INFO_get and X509_SIG_INFO_set

### DIFF
--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -14,6 +14,7 @@
 #include <openssl/rand.h>
 #include "internal/asn1_int.h"
 #include "internal/evp_int.h"
+#include "internal/x509_int.h"
 #include "ec_lcl.h"
 
 #define X25519_KEYLEN        32

--- a/crypto/include/internal/x509_int.h
+++ b/crypto/include/internal/x509_int.h
@@ -283,3 +283,7 @@ int a2i_ipadd(unsigned char *ipout, const char *ipasc);
 int x509_set1_time(ASN1_TIME **ptm, const ASN1_TIME *tm);
 
 void x509_init_sig_info(X509 *x);
+int X509_SIG_INFO_get(const X509_SIG_INFO *siginf, int *mdnid, int *pknid,
+                      int *secbits, uint32_t *flags);
+void X509_SIG_INFO_set(X509_SIG_INFO *siginf, int mdnid, int pknid,
+                       int secbits, uint32_t flags);

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -15,6 +15,7 @@
 #include <openssl/cms.h>
 #include "internal/asn1_int.h"
 #include "internal/evp_int.h"
+#include "internal/x509_int.h"
 #include "rsa_locl.h"
 
 #ifndef OPENSSL_NO_CMS

--- a/doc/man3/X509_get0_signature.pod
+++ b/doc/man3/X509_get0_signature.pod
@@ -4,8 +4,7 @@
 
 X509_get0_signature, X509_get_signature_nid, X509_get0_tbs_sigalg,
 X509_REQ_get0_signature, X509_REQ_get_signature_nid, X509_CRL_get0_signature,
-X509_CRL_get_signature_nid, X509_get_signature_info, X509_SIG_INFO_get,
-X509_SIG_INFO_set - signature information
+X509_CRL_get_signature_nid, X509_get_signature_info - signature information
 
 =head1 SYNOPSIS
 
@@ -30,11 +29,6 @@ X509_SIG_INFO_set - signature information
  int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
                              uint32_t *flags);
 
- int X509_SIG_INFO_get(const X509_SIG_INFO *siginf, int *mdnid, int *pknid,
-                      int *secbits, uint32_t *flags);
- void X509_SIG_INFO_set(X509_SIG_INFO *siginf, int mdnid, int pknid,
-                        int secbits, uint32_t flags);
-
 =head1 DESCRIPTION
 
 X509_get0_signature() sets B<*psig> to the signature of B<x> and B<*palg>
@@ -56,12 +50,6 @@ certificate B<x>. The NID of the signing digest is written to B<*mdnid>,
 the public key algorithm to B<*pknid>, the effective security bits to
 B<*secbits> and flag details to B<*flags>. Any of the parameters can
 be set to B<NULL> if the information is not required.
-
-X509_SIG_INFO_get() and X509_SIG_INFO_set() get and set information
-about a signature in an B<X509_SIG_INFO> structure. They are only
-used by implementations of algorithms which need to set custom
-signature information: most applications will never need to call
-them.
 
 =head1 NOTES
 

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -560,11 +560,6 @@ X509 *d2i_X509_AUX(X509 **a, const unsigned char **pp, long length);
 
 int i2d_re_X509_tbs(X509 *x, unsigned char **pp);
 
-int X509_SIG_INFO_get(const X509_SIG_INFO *siginf, int *mdnid, int *pknid,
-                      int *secbits, uint32_t *flags);
-void X509_SIG_INFO_set(X509_SIG_INFO *siginf, int mdnid, int pknid,
-                       int secbits, uint32_t flags);
-
 int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
                             uint32_t *flags);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4273,9 +4273,7 @@ ZINT64_it                               4215	1_1_0f	EXIST:EXPORT_VAR_AS_FUNCTION
 CRYPTO_mem_leaks_cb                     4216	1_1_1	EXIST::FUNCTION:CRYPTO_MDEBUG
 BIO_lookup_ex                           4217	1_1_1	EXIST::FUNCTION:SOCK
 X509_CRL_print_ex                       4218	1_1_1	EXIST::FUNCTION:
-X509_SIG_INFO_get                       4219	1_1_1	EXIST::FUNCTION:
 X509_get_signature_info                 4220	1_1_1	EXIST::FUNCTION:
-X509_SIG_INFO_set                       4221	1_1_1	EXIST::FUNCTION:
 ESS_CERT_ID_V2_free                     4222	1_1_1	EXIST::FUNCTION:TS
 ESS_SIGNING_CERT_V2_new                 4223	1_1_1	EXIST::FUNCTION:TS
 d2i_ESS_SIGNING_CERT_V2                 4224	1_1_1	EXIST::FUNCTION:TS


### PR DESCRIPTION
Fixes: #3894

I propose to make this an internal API, before 1.1.1 is officially released.