### PR TITLE
Fix a couple nits in DEFINE_STACK_OF.pod

### DIFF
--- a/doc/man3/DEFINE_STACK_OF.pod
+++ b/doc/man3/DEFINE_STACK_OF.pod
@@ -109,7 +109,7 @@ sk_TYPE_new_reserve() allocates a new stack. The new stack will have additional
 memory allocated to hold B<n> elements if B<n> is positive. The next B<n> calls
 to sk_TYPE_insert(), sk_TYPE_push() or sk_TYPE_unshift() will not fail or cause
 memory to be allocated or reallocated. If B<n> is zero or less than zero, no
-memory is allocated. sk_TYPE_reserve() also sets the comparison function
+memory is allocated. sk_TYPE_new_reserve() also sets the comparison function
 B<compare> to the newly created stack. If B<compare> is B<NULL> then no
 comparison function is used.
 
@@ -257,7 +257,7 @@ stack.
 Before OpenSSL 1.1.0, this was implemented via macros and not inline functions
 and was not a public API.
 
-sk_TYPE_new_reserve() was added in OpenSSL 1.1.1.
+sk_TYPE_reserve() and sk_TYPE_new_reserve() were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Only the 'new' variant of sk_TYPE_new_reserve() deals with
compression functions.

Mention both new 'reserve' APIs as being added in OpenSSL 1.1.1.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
