### PR TITLE
Simplify the stack reservation

### DIFF
--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -336,14 +336,12 @@ int ASYNC_init_thread(size_t max_size, size_t init_size)
         return 0;
     }
 
-    pool->jobs = sk_ASYNC_JOB_new_null();
+    pool->jobs = sk_ASYNC_JOB_new_reserve(NULL, init_size);
     if (pool->jobs == NULL) {
         ASYNCerr(ASYNC_F_ASYNC_INIT_THREAD, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(pool);
         return 0;
     }
-    if (!sk_ASYNC_JOB_reserve(pool->jobs, init_size))
-        goto err;
 
     pool->max_size = max_size;
 

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -201,11 +201,11 @@ static GENERAL_NAMES *v2i_issuer_alt(X509V3_EXT_METHOD *method,
                                      X509V3_CTX *ctx,
                                      STACK_OF(CONF_VALUE) *nval)
 {
-    GENERAL_NAMES *gens = sk_GENERAL_NAME_new_null();
     const int num = sk_CONF_VALUE_num(nval);
+    GENERAL_NAMES *gens = sk_GENERAL_NAME_new_reserve(NULL, num);
     int i;
 
-    if (gens == NULL || !sk_GENERAL_NAME_reserve(gens, num)) {
+    if (gens == NULL) {
         X509V3err(X509V3_F_V2I_ISSUER_ALT, ERR_R_MALLOC_FAILURE);
         sk_GENERAL_NAME_free(gens);
         return NULL;
@@ -283,8 +283,8 @@ static GENERAL_NAMES *v2i_subject_alt(X509V3_EXT_METHOD *method,
     const int num = sk_CONF_VALUE_num(nval);
     int i;
 
-    gens = sk_GENERAL_NAME_new_null();
-    if (gens == NULL || !sk_GENERAL_NAME_reserve(gens, num)) {
+    gens = sk_GENERAL_NAME_new_reserve(NULL, num);
+    if (gens == NULL) {
         X509V3err(X509V3_F_V2I_SUBJECT_ALT, ERR_R_MALLOC_FAILURE);
         sk_GENERAL_NAME_free(gens);
         return NULL;
@@ -380,8 +380,8 @@ GENERAL_NAMES *v2i_GENERAL_NAMES(const X509V3_EXT_METHOD *method,
     const int num = sk_CONF_VALUE_num(nval);
     int i;
 
-    gens = sk_GENERAL_NAME_new_null();
-    if (gens == NULL || !sk_GENERAL_NAME_reserve(gens, num)) {
+    gens = sk_GENERAL_NAME_new_reserve(NULL, num);
+    if (gens == NULL) {
         X509V3err(X509V3_F_V2I_GENERAL_NAMES, ERR_R_MALLOC_FAILURE);
         sk_GENERAL_NAME_free(gens);
         return NULL;

--- a/crypto/x509v3/v3_cpols.c
+++ b/crypto/x509v3/v3_cpols.c
@@ -102,8 +102,8 @@ static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
         return NULL;
     }
 
-    pols = sk_POLICYINFO_new_null();
-    if (pols == NULL || !sk_POLICYINFO_reserve(pols, num)) {
+    pols = sk_POLICYINFO_new_reserve(NULL, num);
+    if (pols == NULL) {
         X509V3err(X509V3_F_R2I_CERTPOL, ERR_R_MALLOC_FAILURE);
         goto err;
     }

--- a/crypto/x509v3/v3_crld.c
+++ b/crypto/x509v3/v3_crld.c
@@ -244,8 +244,8 @@ static void *v2i_crld(const X509V3_EXT_METHOD *method,
     const int num = sk_CONF_VALUE_num(nval);
     int i;
 
-    crld = sk_DIST_POINT_new_null();
-    if (crld == NULL || !sk_DIST_POINT_reserve(crld, num))
+    crld = sk_DIST_POINT_new_reserve(NULL, num);
+    if (crld == NULL)
         goto merr;
     for (i = 0; i < num; i++) {
         DIST_POINT *point;

--- a/crypto/x509v3/v3_extku.c
+++ b/crypto/x509v3/v3_extku.c
@@ -77,8 +77,8 @@ static void *v2i_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *method,
     const int num = sk_CONF_VALUE_num(nval);
     int i;
 
-    extku = sk_ASN1_OBJECT_new_null();
-    if (extku == NULL || !sk_ASN1_OBJECT_reserve(extku, num)) {
+    extku = sk_ASN1_OBJECT_new_reserve(NULL, num);
+    if (extku == NULL) {
         X509V3err(X509V3_F_V2I_EXTENDED_KEY_USAGE, ERR_R_MALLOC_FAILURE);
         sk_ASN1_OBJECT_free(extku);
         return NULL;

--- a/crypto/x509v3/v3_info.c
+++ b/crypto/x509v3/v3_info.c
@@ -110,12 +110,10 @@ static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
     const int num = sk_CONF_VALUE_num(nval);
     char *objtmp, *ptmp;
 
-    if ((ainfo = sk_ACCESS_DESCRIPTION_new_null()) == NULL) {
+    if ((ainfo = sk_ACCESS_DESCRIPTION_new_reserve(NULL, num)) == NULL) {
         X509V3err(X509V3_F_V2I_AUTHORITY_INFO_ACCESS, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    if (!sk_ACCESS_DESCRIPTION_reserve(ainfo, num))
-        goto err;
     for (i = 0; i < num; i++) {
         cnf = sk_CONF_VALUE_value(nval, i);
         if ((acc = ACCESS_DESCRIPTION_new()) == NULL) {

--- a/crypto/x509v3/v3_pmaps.c
+++ b/crypto/x509v3/v3_pmaps.c
@@ -72,12 +72,10 @@ static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *method,
     const int num = sk_CONF_VALUE_num(nval);
     int i;
 
-    if ((pmaps = sk_POLICY_MAPPING_new_null()) == NULL) {
+    if ((pmaps = sk_POLICY_MAPPING_new_reserve(NULL, num)) == NULL) {
         X509V3err(X509V3_F_V2I_POLICY_MAPPINGS, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    if (!sk_POLICY_MAPPING_reserve(pmaps, num))
-        goto err;
 
     for (i = 0; i < num; i++) {
         val = sk_CONF_VALUE_value(nval, i);

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -463,13 +463,9 @@ STACK_OF(X509_NAME) *SSL_dup_CA_list(const STACK_OF(X509_NAME) *sk)
     STACK_OF(X509_NAME) *ret;
     X509_NAME *name;
 
-    ret = sk_X509_NAME_new_null();
+    ret = sk_X509_NAME_new_reserve(NULL, num);
     if (ret == NULL) {
         SSLerr(SSL_F_SSL_DUP_CA_LIST, ERR_R_MALLOC_FAILURE);
-        return NULL;
-    }
-    if (!sk_X509_NAME_reserve(ret, num)) {
-        sk_X509_NAME_free(ret);
         return NULL;
     }
     for (i = 0; i < num; i++) {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -164,14 +164,12 @@ static int ssl_dane_dup(SSL *to, SSL *from)
     dane_final(&to->dane);
     to->dane.flags = from->dane.flags;
     to->dane.dctx = &to->ctx->dane;
-    to->dane.trecs = sk_danetls_record_new_null();
+    to->dane.trecs = sk_danetls_record_new_reserve(NULL, num);
 
     if (to->dane.trecs == NULL) {
         SSLerr(SSL_F_SSL_DANE_DUP, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    if (!sk_danetls_record_reserve(to->dane.trecs, num))
-        return 0;
 
     for (i = 0; i < num; ++i) {
         danetls_record *t = sk_danetls_record_value(from->dane.trecs, i);


### PR DESCRIPTION
Use the newly introduced sk_TYPE_new_reserve API (as per #4559 ) to simplify the
reservation of stack as creating it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

