### PR TITLE
Added function to retrieve the authority key identifier from a certificate.

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -848,6 +848,13 @@ const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x)
     return x->skid;
 }
 
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x)
+{
+    /* Call for side-effect of computing hash and caching extensions */
+    X509_check_purpose(x, -1, -1);
+    return (x->akid != NULL ? x->akid->keyid : NULL);
+}
+
 long X509_get_pathlen(X509 *x)
 {
     /* Called for side effect of caching extensions */

--- a/doc/man3/X509_get_extension_flags.pod
+++ b/doc/man3/X509_get_extension_flags.pod
@@ -20,6 +20,7 @@ X509_get_proxy_pathlen - retrieve certificate extension data
  uint32_t X509_get_key_usage(X509 *x);
  uint32_t X509_get_extended_key_usage(X509 *x);
  const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
+ const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x);
  void X509_set_proxy_flag(X509 *x);
  void X509_set_proxy_pathlen(int l);
  long X509_get_proxy_pathlen(X509 *x);
@@ -106,6 +107,10 @@ Additionally B<XKU_SGC> is set if either Netscape or Microsoft SGC OIDs are
 present.
 
 X509_get0_subject_key_id() returns an internal pointer to the subject key
+identifier of B<x> as an B<ASN1_OCTET_STRING> or B<NULL> if the extension
+is not present or cannot be parsed.
+
+X509_get0_authority_key_id() returns an internal pointer to the authority key
 identifier of B<x> as an B<ASN1_OCTET_STRING> or B<NULL> if the extension
 is not present or cannot be parsed.
 

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -660,6 +660,7 @@ uint32_t X509_get_extension_flags(X509 *x);
 uint32_t X509_get_key_usage(X509 *x);
 uint32_t X509_get_extended_key_usage(X509 *x);
 const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x);
 
 int X509_PURPOSE_get_count(void);
 X509_PURPOSE *X509_PURPOSE_get0(int idx);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4418,3 +4418,4 @@ RAND_POOL_add_begin                     4362	1_1_1	EXIST::FUNCTION:
 RAND_POOL_add_end                       4363	1_1_1	EXIST::FUNCTION:
 RAND_POOL_acquire_entropy               4364	1_1_1	EXIST::FUNCTION:
 OPENSSL_sk_new_reserve                  4365	1_1_1	EXIST::FUNCTION:
+X509_get0_authority_key_id              4366	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This pull adds the X509_get0_authority_key_id() function that returns a 'const' reference to the key identifier (keyid) in the AUTHORITY_KEYID structure in a certificate (akid->keyid).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

