### PR TITLE
  Add X509_get0_authority_key_id() function

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -192,6 +192,21 @@ const ASN1_GENERALIZEDTIME *OCSP_resp_get0_produced_at(const OCSP_BASICRESP* bs)
     return bs->tbsResponseData.producedAt;
 }
 
+int OCSP_resp_set_produced_at(OCSP_BASICRESP* bs, long adj)
+{
+    ASN1_GENERALIZEDTIME * time = NULL;
+
+    if (!bs) return 0;
+
+    if ((time = X509_gmtime_adj(bs->tbsResponseData.producedAt, adj)) == NULL)
+	    return 0;
+
+    if (bs->tbsResponseData.producedAt == NULL)
+	   bs->tbsResponseData.producedAt = time;
+
+    return 1;
+}
+
 const STACK_OF(X509) *OCSP_resp_get0_certs(const OCSP_BASICRESP *bs)
 {
     return bs->certs;

--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -83,6 +83,17 @@ OCSP_RESPONSE *OCSP_response_create(int status, OCSP_BASICRESP *bs)
     return NULL;
 }
 
+/* Set the status of an OCSP response */
+int OCSP_response_set_status(int status, OCSP_RESPONSE *rsp) {
+
+    // Sets the status in the response
+    if (!rsp || !(ASN1_ENUMERATED_set(rsp->responseStatus, status)))
+        return 0;
+
+    // Success
+    return 1;
+}
+
 OCSP_SINGLERESP *OCSP_basic_add1_status(OCSP_BASICRESP *rsp,
                                         OCSP_CERTID *cid,
                                         int status, int reason,

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -848,6 +848,13 @@ const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x)
     return x->skid;
 }
 
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x)
+{
+    /* Call for side-effect of computing hash and caching extensions */
+    X509_check_purpose(x, -1, -1);
+    return (x->akid != NULL ? x->akid->keyid : NULL);
+}
+
 long X509_get_pathlen(X509 *x)
 {
     /* Called for side effect of caching extensions */

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -6,6 +6,7 @@ OCSP_resp_get0_certs,
 OCSP_resp_get0_id,
 OCSP_resp_get1_id,
 OCSP_resp_get0_produced_at,
+OCSP_resp_set_produced_at,
 OCSP_resp_find_status, OCSP_resp_count, OCSP_resp_get0, OCSP_resp_find,
 OCSP_single_get0_status, OCSP_check_validity
 - OCSP response utility functions
@@ -30,6 +31,8 @@ OCSP_single_get0_status, OCSP_check_validity
 
  const ASN1_GENERALIZEDTIME *OCSP_resp_get0_produced_at(
                              const OCSP_BASICRESP* single);
+
+ int OCSP_resp_set_produced_at(OCSP_BASICRESP* bs, long adj);
 
  const STACK_OF(X509) *OCSP_resp_get0_certs(const OCSP_BASICRESP *bs);
 
@@ -73,6 +76,10 @@ B<*revtime>, B<*thisupd> and B<*nextupd>.
 
 OCSP_resp_get0_produced_at() extracts the B<producedAt> field from the
 single response B<bs>.
+
+OCSP_resp_set_produced_at() sets the B<producedAt> field in the single
+response. The B<adj> parameter is used to specify the offset (in seconds)
+relative to the current time.
 
 OCSP_resp_get0_certs() returns any certificates included in B<bs>.
 

--- a/doc/man3/OCSP_response_status.pod
+++ b/doc/man3/OCSP_response_status.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-OCSP_response_status, OCSP_response_get1_basic, OCSP_response_create,
+OCSP_response_status, OCSP_response_set_status, 
+OCSP_response_get1_basic, OCSP_response_create,
 OCSP_RESPONSE_free, OCSP_RESPID_set_by_name,
 OCSP_RESPID_set_by_key, OCSP_RESPID_match - OCSP response functions
 
@@ -11,6 +12,7 @@ OCSP_RESPID_set_by_key, OCSP_RESPID_match - OCSP response functions
  #include <openssl/ocsp.h>
 
  int OCSP_response_status(OCSP_RESPONSE *resp);
+ int OCSP_response_set_status(int status, OCSP_RESPONSE *resp);
  OCSP_BASICRESP *OCSP_response_get1_basic(OCSP_RESPONSE *resp);
  OCSP_RESPONSE *OCSP_response_create(int status, OCSP_BASICRESP *bs);
  void OCSP_RESPONSE_free(OCSP_RESPONSE *resp);
@@ -23,6 +25,11 @@ OCSP_RESPID_set_by_key, OCSP_RESPID_match - OCSP response functions
 
 OCSP_response_status() returns the OCSP response status of B<resp>. It returns
 one of the values: B<OCSP_RESPONSE_STATUS_SUCCESSFUL>,
+B<OCSP_RESPONSE_STATUS_MALFORMEDREQUEST>,
+B<OCSP_RESPONSE_STATUS_INTERNALERROR>, B<OCSP_RESPONSE_STATUS_TRYLATER>
+B<OCSP_RESPONSE_STATUS_SIGREQUIRED>, or B<OCSP_RESPONSE_STATUS_UNAUTHORIZED>.
+
+OCSP_response_set_status() sets the status of B<resp>. The B<status> shoud be one of the values: B<OCSP_RESPONSE_STATUS_SUCCESSFUL>,
 B<OCSP_RESPONSE_STATUS_MALFORMEDREQUEST>,
 B<OCSP_RESPONSE_STATUS_INTERNALERROR>, B<OCSP_RESPONSE_STATUS_TRYLATER>
 B<OCSP_RESPONSE_STATUS_SIGREQUIRED>, or B<OCSP_RESPONSE_STATUS_UNAUTHORIZED>.
@@ -51,7 +58,9 @@ with the X509 certificate B<cert>.
 
 =head1 RETURN VALUES
 
-OCSP_RESPONSE_status() returns a status value.
+OCSP_response_status() returns a status value.
+
+OCSP_response_set_status() returns 1 if successful or 0 if an error occurred.
 
 OCSP_response_get1_basic() returns an B<OCSP_BASICRESP> structure pointer or
 B<NULL> if an error occurred.

--- a/doc/man3/X509_get_extension_flags.pod
+++ b/doc/man3/X509_get_extension_flags.pod
@@ -3,6 +3,7 @@
 =head1 NAME
 
 X509_get0_subject_key_id,
+X509_get0_authority_key_id,
 X509_get_pathlen,
 X509_get_extension_flags,
 X509_get_key_usage,

--- a/doc/man3/X509_get_extension_flags.pod
+++ b/doc/man3/X509_get_extension_flags.pod
@@ -20,6 +20,7 @@ X509_get_proxy_pathlen - retrieve certificate extension data
  uint32_t X509_get_key_usage(X509 *x);
  uint32_t X509_get_extended_key_usage(X509 *x);
  const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
+ const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x);
  void X509_set_proxy_flag(X509 *x);
  void X509_set_proxy_pathlen(int l);
  long X509_get_proxy_pathlen(X509 *x);
@@ -106,6 +107,10 @@ Additionally B<XKU_SGC> is set if either Netscape or Microsoft SGC OIDs are
 present.
 
 X509_get0_subject_key_id() returns an internal pointer to the subject key
+identifier of B<x> as an B<ASN1_OCTET_STRING> or B<NULL> if the extension
+is not present or cannot be parsed.
+
+X509_get0_authority_key_id() returns an internal pointer to the authority key
 identifier of B<x> as an B<ASN1_OCTET_STRING> or B<NULL> if the extension
 is not present or cannot be parsed.
 

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -217,6 +217,7 @@ const ASN1_OCTET_STRING *OCSP_resp_get0_signature(const OCSP_BASICRESP *bs);
 int OCSP_resp_count(OCSP_BASICRESP *bs);
 OCSP_SINGLERESP *OCSP_resp_get0(OCSP_BASICRESP *bs, int idx);
 const ASN1_GENERALIZEDTIME *OCSP_resp_get0_produced_at(const OCSP_BASICRESP* bs);
+int OCSP_resp_set_produced_at(OCSP_BASICRESP* bs, long adj);
 const STACK_OF(X509) *OCSP_resp_get0_certs(const OCSP_BASICRESP *bs);
 int OCSP_resp_get0_id(const OCSP_BASICRESP *bs,
                       const ASN1_OCTET_STRING **pid,
@@ -255,6 +256,7 @@ int OCSP_id_get0_info(ASN1_OCTET_STRING **piNameHash, ASN1_OBJECT **pmd,
                       ASN1_INTEGER **pserial, OCSP_CERTID *cid);
 int OCSP_request_is_signed(OCSP_REQUEST *req);
 OCSP_RESPONSE *OCSP_response_create(int status, OCSP_BASICRESP *bs);
+int OCSP_response_set_status(int status, OCSP_RESPONSE *rsp);
 OCSP_SINGLERESP *OCSP_basic_add1_status(OCSP_BASICRESP *rsp,
                                         OCSP_CERTID *cid,
                                         int status, int reason,

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -660,6 +660,7 @@ uint32_t X509_get_extension_flags(X509 *x);
 uint32_t X509_get_key_usage(X509 *x);
 uint32_t X509_get_extended_key_usage(X509 *x);
 const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x);
 
 int X509_PURPOSE_get_count(void);
 X509_PURPOSE *X509_PURPOSE_get0(int idx);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4418,3 +4418,4 @@ RAND_POOL_add_begin                     4362	1_1_1	EXIST::FUNCTION:
 RAND_POOL_add_end                       4363	1_1_1	EXIST::FUNCTION:
 RAND_POOL_acquire_entropy               4364	1_1_1	EXIST::FUNCTION:
 OPENSSL_sk_new_reserve                  4365	1_1_1	EXIST::FUNCTION:
+X509_get0_authority_key_id              4366	1_1_1	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4419,3 +4419,5 @@ RAND_POOL_add_end                       4363	1_1_1	EXIST::FUNCTION:
 RAND_POOL_acquire_entropy               4364	1_1_1	EXIST::FUNCTION:
 OPENSSL_sk_new_reserve                  4365	1_1_1	EXIST::FUNCTION:
 X509_get0_authority_key_id              4366	1_1_1	EXIST::FUNCTION:
+OCSP_resp_set_produced_at               4367    1_1_1   EXIST::FUNCTION:
+OCSP_response_set_status                4368    1_1_1   EXIST::FUNCTION:


### PR DESCRIPTION
Add X509_get0_authority_key_id() function  

This function makes it easier to retrieve a reference to the
authority key identifier (akid->keyid) inside a certificate.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
