### PR TITLE
[packettest] Fix misplaced parentheses

### DIFF
--- a/test/packettest.c
+++ b/test/packettest.c
@@ -18,12 +18,12 @@ static int test_PACKET_remaining(void)
 {
     PACKET pkt;
 
-    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, sizeof(smbuf))
+    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, sizeof(smbuf)))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), BUF_LEN)
             || !TEST_true(PACKET_forward(&pkt, BUF_LEN - 1))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), 1)
             || !TEST_true(PACKET_forward(&pkt, 1))
-            || !TEST_size_t_eq(PACKET_remaining(&pkt), 0)))
+            || !TEST_size_t_eq(PACKET_remaining(&pkt), 0))
         return 0;
 
     return 1;
@@ -33,13 +33,13 @@ static int test_PACKET_end(void)
 {
     PACKET pkt;
 
-    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, sizeof(smbuf))
+    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, sizeof(smbuf)))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), BUF_LEN)
-            || !TEST_ptr_ne(PACKET_end(&pkt), smbuf + BUF_LEN)
+            || !TEST_ptr_eq(PACKET_end(&pkt), smbuf + BUF_LEN)
             || !TEST_true(PACKET_forward(&pkt, BUF_LEN - 1))
             || !TEST_ptr_eq(PACKET_end(&pkt), smbuf + BUF_LEN)
             || !TEST_true(PACKET_forward(&pkt, 1))
-            || !TEST_ptr_eq(PACKET_end(&pkt), smbuf + BUF_LEN)))
+            || !TEST_ptr_eq(PACKET_end(&pkt), smbuf + BUF_LEN))
         return 0;
 
     return 1;
@@ -430,9 +430,9 @@ static int test_PACKET_as_length_prefixed_1(void)
             || !TEST_true(PACKET_buf_init(&exact_pkt, buf1, len + 1))
             || !TEST_false(PACKET_as_length_prefixed_1(&pkt, &subpkt))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), BUF_LEN)
-            || !TEST_true(PACKET_as_length_prefixed_1(&exact_pkt, &subpkt)
+            || !TEST_true(PACKET_as_length_prefixed_1(&exact_pkt, &subpkt))
             || !TEST_size_t_eq(PACKET_remaining(&exact_pkt), 0)
-            || !TEST_size_t_eq(PACKET_remaining(&subpkt), len)))
+            || !TEST_size_t_eq(PACKET_remaining(&subpkt), len))
         return 0;
 
     return 1;


### PR DESCRIPTION
Hi there,

I am analyzing the OpenSSL's test suite and discovered one issue.
Few tests in the packettest test suite have misplaced parentheses, which leads to shadowing of some assertions.

The patch fixes the misplacement, which uncovers one failing test:
```
> ./test/packettest
1..23
ok 1 - test_PACKET_buf_init
ok 2 - test_PACKET_null_init
ok 3 - test_PACKET_remaining
# ERROR: (void *) 'PACKET_end(&pkt) != smbuf + BUF_LEN' failed @ test/packettest.c:38
# [0x1053fd2af] compared to [0x1053fd2af]
not ok 4 - test_PACKET_end
ok 5 - test_PACKET_equal
ok 6 - test_PACKET_get_1
ok 7 - test_PACKET_get_4
ok 8 - test_PACKET_get_net_2
ok 9 - test_PACKET_get_net_3
ok 10 - test_PACKET_get_net_4
ok 11 - test_PACKET_get_sub_packet
ok 12 - test_PACKET_get_bytes
ok 13 - test_PACKET_copy_bytes
ok 14 - test_PACKET_copy_all
ok 15 - test_PACKET_memdup
ok 16 - test_PACKET_strndup
ok 17 - test_PACKET_contains_zero_byte
ok 18 - test_PACKET_forward
ok 19 - test_PACKET_get_length_prefixed_1
ok 20 - test_PACKET_get_length_prefixed_2
ok 21 - test_PACKET_get_length_prefixed_3
ok 22 - test_PACKET_as_length_prefixed_1
ok 23 - test_PACKET_as_length_prefixed_2
```

I do not know the domain very well, so I will the fix for maintainers.
I hope it helps.

Best regards,
Alex.