### PR TITLE
Fix small bug in EVP_EncryptUpdate() and improve documentation

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -321,7 +321,7 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         *outl = 0;
         return inl == 0;
     }
-    if (is_partially_overlapping(out + ctx->buf_len, in, cmpl)) {
+    if (out != NULL && is_partially_overlapping(out + ctx->buf_len, in, cmpl)) {
         EVPerr(EVP_F_EVP_ENCRYPTUPDATE, EVP_R_PARTIALLY_OVERLAPPING);
         return 0;
     }

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -137,7 +137,10 @@ as a result the amount of data written may be anything from zero bytes
 to (inl + cipher_block_size - 1) so B<out> should contain sufficient
 room. The actual number of bytes written is placed in B<outl>. It also
 checks if B<in> and B<out> are partially overlapping, and if they are
-0 is returned to indicate failure.
+0 is returned to indicate failure. Fully overlapping B<in> and B<out>
+will not lead to this. B<out> may be NULL to indicate that B<in> is
+additional data that shouldn't be encrypted but still used to calculate
+the MAC.
 
 If padding is enabled (the default) then EVP_EncryptFinal_ex() encrypts
 the "final" data, that is any data that remains in a partial block.


### PR DESCRIPTION
Improves `EVP_EncryptInit(3)` manpage to mention `EVP_EncryptUpdate()` AEAD usage and clarifies usage of overlapping buffers
`EVP_EncryptUpdate()` now skips the buffer overlap check iff `out == NULL`
Fixes #4610