### PR TITLE
Only reset the ctx when a cipher is given

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -50,7 +50,8 @@ void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx)
 int EVP_CipherInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
                    const unsigned char *key, const unsigned char *iv, int enc)
 {
-    EVP_CIPHER_CTX_reset(ctx);
+    if (cipher)
+        EVP_CIPHER_CTX_reset(ctx);
     return EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, enc);
 }
 


### PR DESCRIPTION
This restores the 1.0.2 behaviour

This was pointed out by @davidben in https://github.com/openssh/openssh-portable/pull/48#discussion_r145259985