### PR TITLE
Fix compilation of AF_ALG engine

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -105,7 +105,7 @@ static ossl_inline int io_setup(unsigned n, aio_context_t *ctx)
 
 static ossl_inline int eventfd(int n)
 {
-    return syscall(__NR_eventfd, n);
+    return syscall(__NR_eventfd2, n, 0);
 }
 
 static ossl_inline int io_destroy(aio_context_t ctx)

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -24,7 +24,7 @@
 #define K_MAJ   4
 #define K_MIN1  1
 #define K_MIN2  0
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(K_MAJ, K_MIN1, K_MIN2) || \
+#if LINUX_VERSION_CODE < KERNEL_VERSION(K_MAJ, K_MIN1, K_MIN2) || \
     !defined(AF_ALG)
 # ifndef PEDANTIC
 #  warning "AFALG ENGINE requires Kernel Headers >= 4.1.0"

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -29,7 +29,7 @@ static ENGINE *e;
 # define K_MAJ   4
 # define K_MIN1  1
 # define K_MIN2  0
-# if LINUX_VERSION_CODE <= KERNEL_VERSION(K_MAJ, K_MIN1, K_MIN2)
+# if LINUX_VERSION_CODE < KERNEL_VERSION(K_MAJ, K_MIN1, K_MIN2)
 /*
  * If we get here then it looks like there is a mismatch between the linux
  * headers and the actual kernel version, so we have tried to compile with


### PR DESCRIPTION
Two small commits for AF_ALG engine, one fixing a kernel version comparison, and the other one fixing compilation on aarch64 (#1685)