### PR TITLE
Remove 4 broken macros from ocsp.h

### DIFF
--- a/crypto/ocsp/ocsp_lcl.h
+++ b/crypto/ocsp/ocsp_lcl.h
@@ -214,3 +214,19 @@ struct ocsp_service_locator_st {
     X509_NAME *issuer;
     STACK_OF(ACCESS_DESCRIPTION) *locator;
 };
+
+#  define OCSP_REQUEST_sign(o,pkey,md) \
+        ASN1_item_sign(ASN1_ITEM_rptr(OCSP_REQINFO),\
+                &(o)->optionalSignature->signatureAlgorithm,NULL,\
+                (o)->optionalSignature->signature,&(o)->tbsRequest,pkey,md)
+
+#  define OCSP_BASICRESP_sign(o,pkey,md,d) \
+        ASN1_item_sign(ASN1_ITEM_rptr(OCSP_RESPDATA),&(o)->signatureAlgorithm,\
+                NULL,(o)->signature,&(o)->tbsResponseData,pkey,md)
+
+#  define OCSP_REQUEST_verify(a,r) ASN1_item_verify(ASN1_ITEM_rptr(OCSP_REQINFO),\
+        &(a)->optionalSignature->signatureAlgorithm,\
+        (a)->optionalSignature->signature,&(a)->tbsRequest,r)
+
+#  define OCSP_BASICRESP_verify(a,r,d) ASN1_item_verify(ASN1_ITEM_rptr(OCSP_RESPDATA),\
+        &(a)->signatureAlgorithm,(a)->signature,&(a)->tbsResponseData,r)

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -140,22 +140,6 @@ typedef struct ocsp_service_locator_st OCSP_SERVICELOC;
 
 #  define i2d_OCSP_REQUEST_bio(bp,o) ASN1_i2d_bio_of(OCSP_REQUEST,i2d_OCSP_REQUEST,bp,o)
 
-#  define OCSP_REQUEST_sign(o,pkey,md) \
-        ASN1_item_sign(ASN1_ITEM_rptr(OCSP_REQINFO),\
-                &(o)->optionalSignature->signatureAlgorithm,NULL,\
-                (o)->optionalSignature->signature,&(o)->tbsRequest,pkey,md)
-
-#  define OCSP_BASICRESP_sign(o,pkey,md,d) \
-        ASN1_item_sign(ASN1_ITEM_rptr(OCSP_RESPDATA),&(o)->signatureAlgorithm,\
-                NULL,(o)->signature,&(o)->tbsResponseData,pkey,md)
-
-#  define OCSP_REQUEST_verify(a,r) ASN1_item_verify(ASN1_ITEM_rptr(OCSP_REQINFO),\
-        &(a)->optionalSignature->signatureAlgorithm,\
-        (a)->optionalSignature->signature,&(a)->tbsRequest,r)
-
-#  define OCSP_BASICRESP_verify(a,r,d) ASN1_item_verify(ASN1_ITEM_rptr(OCSP_RESPDATA),\
-        &(a)->signatureAlgorithm,(a)->signature,&(a)->tbsResponseData,r)
-
 #  define ASN1_BIT_STRING_digest(data,type,md,len) \
         ASN1_item_digest(ASN1_ITEM_rptr(ASN1_BIT_STRING),type,data,md,len)
 


### PR DESCRIPTION
There were 4 macros in ocsp.h that have not worked since 1.1.0 because
they attempt to access the internals of an opaque structure.

For OCSP_REQUEST_sign() applications should use OCSP_request_sign() instead.
For OCSP_BASICRESP_sign() applications should use OCSP_basic_sign() instead.
For OCSP_REQUEST_verify() applications should use OCSP_request_verify()
instead.
For OCSP_BASICRESP_verify() applications should use OCSP_basic_verify()
instead.
