### PR TITLE
Add config option for security level

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -206,7 +206,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_ALLOW_NO_DHE_KEX, \
         OPT_S_STRICT, OPT_S_SIGALGS, OPT_S_CLIENTSIGALGS, OPT_S_GROUPS, \
         OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, \
-        OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, OPT_S_COMP, \
+        OPT_S_RECORD_PADDING, OPT_S_SEC_LEVEL, OPT_S_DEBUGBROKE, OPT_S_COMP, \
         OPT_S_NO_RENEGOTIATION, OPT_S__LAST
 
 # define OPT_S_OPTIONS \
@@ -249,6 +249,8 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         {"cipher", OPT_S_CIPHER, 's', "Specify cipher list to be used"}, \
         {"record_padding", OPT_S_RECORD_PADDING, 's', \
             "Block size to pad TLS 1.3 records to."}, \
+        {"sec_level", OPT_S_SEC_LEVEL, 's', \
+            "Specify library security level"}, \
         {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \
             "Perform all sorts of protocol violations for testing purposes"}
 
@@ -278,6 +280,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         case OPT_S_NAMEDCURVE: \
         case OPT_S_CIPHER: \
         case OPT_S_RECORD_PADDING: \
+        case OPT_S_SEC_LEVEL: \
         case OPT_S_NO_RENEGOTIATION: \
         case OPT_S_DEBUGBROKE
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -120,6 +120,13 @@ Attempts to pad TLS 1.3 records so that they are a multiple of B<value> in
 length on send. A B<value> of 0 or 1 turns off padding. Otherwise, the
 B<value> must be >1 or <=16384.
 
+=item B<-sec_level>
+
+Sets the library security level to B<value>. By default, insecure ciphers
+and too short key lengths are probibited and ignored. Setting the level
+to B<0> permits everything and basically disables any of these sanity checks.
+For a description of each individual level, see L<SSL_CTX_set_security_level(3)>.
+
 =item B<-no_renegotiation>
 
 Disables all attempts at renegotiation in TLSv1.2 and earlier, same as setting
@@ -261,6 +268,13 @@ operations are permitted.
 Attempts to pad TLS 1.3 records so that they are a multiple of B<value> in
 length on send. A B<value> of 0 or 1 turns off padding. Otherwise, the
 B<value> must be >1 or <=16384.
+
+=item B<SecurityLevel>
+
+Sets the library security level to B<value>. By default, insecure ciphers
+and too short key lengths are probibited and ignored. Setting the level
+to B<0> permits everything and basically disables any of these sanity checks.
+For a description of each individual level, see L<SSL_CTX_set_security_level(3)>.
 
 =item B<NoRenegotiation>
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -550,6 +550,28 @@ static int cmd_RecordPadding(SSL_CONF_CTX *cctx, const char *value)
     return rv;
 }
 
+static int cmd_SecurityLevel(SSL_CONF_CTX *cctx, const char *value)
+{
+    int rv = 0;
+    int level = atoi(value);
+
+    /*
+     * We let the security callback check the
+     * supported security levels
+     */
+    if (level >= 0) {
+        if (cctx->ctx) {
+            SSL_CTX_set_security_level(cctx->ctx, level);
+            rv = 1;
+        }
+        if (cctx->ssl) {
+            SSL_set_security_level(cctx->ssl, level);
+            rv = 1;
+        }
+    }
+    return rv;
+}
+
 typedef struct {
     int (*cmd) (SSL_CONF_CTX *cctx, const char *value);
     const char *str_file;
@@ -632,7 +654,8 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
                  SSL_CONF_FLAG_SERVER | SSL_CONF_FLAG_CERTIFICATE,
                  SSL_CONF_TYPE_FILE),
 #endif
-    SSL_CONF_CMD_STRING(RecordPadding, "record_padding", 0)
+    SSL_CONF_CMD_STRING(RecordPadding, "record_padding", 0),
+    SSL_CONF_CMD_STRING(SecurityLevel, "sec_level", 0)
 };
 
 /* Supported switches: must match order of switches in ssl_conf_cmds */


### PR DESCRIPTION
When using s_client and s_server for testing, we occasionally want to
use insecure ciphers. Since the introduction of the security levels
in b362ccab5c1d ("Security framework."), the default level is set
to 1 which prevents us from using any export cipher or anonymous
DH key exchange in s_client and s_server.

This adds a new config option sec_level to override the default security
level.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
