### PR TITLE
Fix a compile issue when configured with non-standard options

### DIFF
--- a/ssl/s23_clnt.c
+++ b/ssl/s23_clnt.c
@@ -757,10 +757,12 @@ static int ssl23_get_server_hello(SSL *s)
                 s->version = TLS1_VERSION;
                 s->method = TLSv1_client_method();
                 break;
+#ifndef OPENSSL_NO_SSL3
             case SSL3_VERSION:
                 s->version = SSL3_VERSION;
                 s->method = SSLv3_client_method();
                 break;
+#endif
             }
             SSLerr(SSL_F_SSL23_GET_SERVER_HELLO, SSL_R_UNSUPPORTED_PROTOCOL);
             ssl3_send_alert(s, SSL3_AL_FATAL, SSL_AD_PROTOCOL_VERSION);


### PR DESCRIPTION
./config no-ssl2 no-ssl2-method no-ssl3 no-ssl3-method

fails to build.