### PR TITLE
Perl: Use our own globbing wrapper rather than File::Glob::glob [1.1.0]

### DIFF
--- a/Configure
+++ b/Configure
@@ -11,10 +11,12 @@
 
 use 5.10.0;
 use strict;
+use FindBin;
+use lib "$FindBin::Bin/util";
 use File::Basename;
 use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs/;
 use File::Path qw/mkpath/;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use OpenSSL::Glob;
 
 # see INSTALL for instructions.
 
@@ -1353,7 +1355,6 @@ my %unified_info = ();
 
 my $buildinfo_debug = defined($ENV{CONFIGURE_DEBUG_BUILDINFO});
 if ($builder eq "unified") {
-    use lib catdir(dirname(__FILE__),"util");
     use with_fallback qw(Text::Template);
 
     sub cleandir {
@@ -1477,8 +1478,10 @@ if ($builder eq "unified") {
         my %generate = ();
 
         push @{$config{build_infos}}, catfile(abs2rel($sourced, $blddir), $f);
-        my $template = Text::Template->new(TYPE => 'FILE',
-                                           SOURCE => catfile($sourced, $f));
+        my $template =
+            Text::Template->new(TYPE => 'FILE',
+                                SOURCE => catfile($sourced, $f),
+                                PREPEND => qq{use lib "$FindBin::Bin/util";});
         die "Something went wrong with $sourced/$f: $!\n" unless $template;
         my @text =
             split /^/m,

--- a/test/build.info
+++ b/test/build.info
@@ -293,7 +293,7 @@ ENDIF
 {-
    use File::Spec::Functions;
    use File::Basename;
-   use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+   use OpenSSL::Glob;
 
    my @nogo_headers = ( "asn1_mac.h",
                         "__decc_include_prologue.h",

--- a/test/recipes/40-test_rehash.t
+++ b/test/recipes/40-test_rehash.t
@@ -13,7 +13,7 @@ use warnings;
 use File::Spec::Functions;
 use File::Copy;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_rehash");

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -12,8 +12,7 @@ use warnings;
 
 use File::Basename;
 use File::Compare qw/compare_text/;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
-
+use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file/;
 use OpenSSL::Test::Utils qw/disabled alldisabled available_protocols/;
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -16,7 +16,9 @@ BEGIN {
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/../util";
+use OpenSSL::Glob;
 use Module::Load::Conditional qw(can_load);
 
 my $TAP_Harness = can_load(modules => { 'TAP::Harness' => undef }) 

--- a/util/OpenSSL/Glob.pm
+++ b/util/OpenSSL/Glob.pm
@@ -1,0 +1,21 @@
+package OpenSSL::Glob;
+
+use strict;
+use warnings;
+
+use File::Glob;
+
+use Exporter;
+use vars qw($VERSION @ISA @EXPORT);
+
+$VERSION = '0.1';
+@ISA = qw(Exporter);
+@EXPORT = qw(glob);
+
+sub glob {
+    goto &File::Glob::bsd_glob if $^O ne "VMS";
+    goto &CORE::glob;
+}
+
+1;
+__END__

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -48,6 +48,10 @@
 use lib ".";
 use configdata;
 use File::Spec::Functions;
+use File::Basename;
+use FindBin;
+use lib "$FindBin::Bin";
+use OpenSSL::Glob;
 
 my $debug=0;
 

--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -13,7 +13,9 @@ use File::Spec::Functions;
 use File::Basename;
 use File::Copy;
 use File::Path;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin";
+use OpenSSL::Glob;
 use Getopt::Long;
 use Pod::Usage;
 


### PR DESCRIPTION
File::Glob::glob is deprecated, it's use generates this kind of
message:

    File::Glob::glob() will disappear in perl 5.30. Use File::Glob::bsd_glob() instead. at ../master/Configure line 277.

The first idea was to use a construction that makes the caller glob()
use File::Glob::bsd_glob().  That turned out not to work well
everywhere, so instead, we make our own wrapper, OpenSSL::Glob and use
that.

Fixes #4636

(this is an adaptation of #4040 and part of #4069, for 1.1.0)
