### PR TITLE
Tell the ciphers which DRBG to use for generating random bytes.

### DIFF
--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -18,9 +18,11 @@
 #include <openssl/aes.h>
 #include <openssl/sha.h>
 #include <openssl/rand.h>
+#include <internal/rand.h>
 #include "modes_lcl.h"
 #include "internal/constant_time_locl.h"
 #include "internal/evp_int.h"
+#include "evp_locl.h"
 
 typedef struct {
     AES_KEY ks;
@@ -150,7 +152,8 @@ void aesni_multi_cbc_encrypt(CIPH_DESC *, void *, int);
 static size_t tls1_1_multi_block_encrypt(EVP_AES_HMAC_SHA256 *key,
                                          unsigned char *out,
                                          const unsigned char *inp,
-                                         size_t inp_len, int n4x)
+                                         size_t inp_len, int n4x,
+                                         RAND_DRBG *drbg)
 {                               /* n4x is 1 or 2 */
     HASH_DESC hash_d[8], edges[8];
     CIPH_DESC ciph_d[8];
@@ -170,8 +173,13 @@ static size_t tls1_1_multi_block_encrypt(EVP_AES_HMAC_SHA256 *key,
 #  endif
 
     /* ask for IVs in bulk */
-    if (RAND_bytes((IVs = blocks[0].c), 16 * x4) <= 0)
+    IVs = blocks[0].c;
+    if (drbg != NULL) {
+        if (RAND_DRBG_bytes(drbg, IVs, 16 * x4) == 0)
+            return 0;
+    } else if (RAND_bytes(IVs, 16 * x4) <= 0) {
         return 0;
+    }
 
     /* align */
     ctx = (SHA256_MB_CTX *) (storage + 32 - ((size_t)storage % 32));
@@ -877,7 +885,8 @@ static int aesni_cbc_hmac_sha256_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
 
             return (int)tls1_1_multi_block_encrypt(key, param->out,
                                                    param->inp, param->len,
-                                                   param->interleave / 4);
+                                                   param->interleave / 4,
+                                                   ctx->drbg);
         }
     case EVP_CTRL_TLS1_1_MULTIBLOCK_DECRYPT:
 # endif

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -15,6 +15,8 @@
 # include "internal/evp_int.h"
 # include <openssl/des.h>
 # include <openssl/rand.h>
+# include <internal/rand.h>
+# include "evp_locl.h"
 
 typedef struct {
     union {
@@ -229,8 +231,12 @@ static int des_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 
     switch (type) {
     case EVP_CTRL_RAND_KEY:
-        if (RAND_bytes(ptr, 8) <= 0)
+        if (c->drbg != NULL) {
+            if (RAND_DRBG_bytes(c->drbg, ptr, 8) == 0)
+                return 0;
+        } else if (RAND_bytes(ptr, 8) <= 0) {
             return 0;
+        }
         DES_set_odd_parity((DES_cblock *)ptr);
         return 1;
 

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -39,6 +39,7 @@ struct evp_cipher_ctx_st {
     int final_used;
     int block_mask;
     unsigned char final[EVP_MAX_BLOCK_LENGTH]; /* possible final block */
+    RAND_DRBG *drbg;
 } /* EVP_CIPHER_CTX */ ;
 
 int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,

--- a/crypto/evp/p_seal.c
+++ b/crypto/evp/p_seal.c
@@ -14,6 +14,8 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
+#include <internal/rand.h>
+#include "evp_locl.h"
 
 int EVP_SealInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                  unsigned char **ek, int *ekl, unsigned char *iv,
@@ -31,9 +33,14 @@ int EVP_SealInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
         return 1;
     if (EVP_CIPHER_CTX_rand_key(ctx, key) <= 0)
         return 0;
-    if (EVP_CIPHER_CTX_iv_length(ctx)
-        && RAND_bytes(iv, EVP_CIPHER_CTX_iv_length(ctx)) <= 0)
-        return 0;
+    if (EVP_CIPHER_CTX_iv_length(ctx)) {
+        if (ctx->drbg) {
+            if (RAND_DRBG_bytes(ctx->drbg, iv, EVP_CIPHER_CTX_iv_length(ctx)) == 0)
+                return 0;
+        } else if (RAND_bytes(iv, EVP_CIPHER_CTX_iv_length(ctx)) <= 0) {
+            return 0;
+        }
+    }
 
     if (!EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
         return 0;

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -457,6 +457,20 @@ This call is only valid when decrypting data.
 
 =back
 
+=head1 Random numbers
+
+The following can be used to select the DRBG that is used to generate the random
+numbers:
+
+EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_SET_DRBG, 0, drbg)
+
+The following can be used to get the DRBG:
+
+EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GET_DRBG, 0, &drbg)
+
+By default it's set to NULL which results in RAND_bytes() being used.
+
+
 =head1 NOTES
 
 Where possible the B<EVP> interface to symmetric ciphers should be used in

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -344,6 +344,8 @@ int (*EVP_CIPHER_meth_get_ctrl(const EVP_CIPHER *cipher))(EVP_CIPHER_CTX *,
 # define         EVP_CTRL_SET_PIPELINE_INPUT_BUFS        0x23
 /* Set the input buffer lengths to use for a pipelined operation */
 # define         EVP_CTRL_SET_PIPELINE_INPUT_LENS        0x24
+# define         EVP_CTRL_GET_DRBG                       0x25
+# define         EVP_CTRL_SET_DRBG                       0x26
 
 /* Padding modes */
 #define EVP_PADDING_PKCS7       1

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -167,6 +167,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
              */
             EVP_CIPHER_CTX_reset(s->enc_write_ctx);
         }
+        EVP_CIPHER_CTX_ctrl(s->enc_write_ctx, EVP_CTRL_SET_DRBG, 0, s->drbg);
         dd = s->enc_write_ctx;
         if (ssl_replace_hash(&s->write_hash, m) == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL3_CHANGE_CIPHER_STATE,

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3753,6 +3753,7 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
                  SSL_F_TLS_CONSTRUCT_NEW_SESSION_TICKET, ERR_R_MALLOC_FAILURE);
         goto err;
     }
+    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_SET_DRBG, 0, s->drbg);
 
     p = senc;
     if (!i2d_SSL_SESSION(s->session, &p)) {

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -170,6 +170,7 @@ int tls1_change_cipher_state(SSL *s, int which)
                      ERR_R_MALLOC_FAILURE);
             goto err;
         }
+        EVP_CIPHER_CTX_ctrl(s->enc_write_ctx, EVP_CTRL_SET_DRBG, 0, s->drbg);
         dd = s->enc_write_ctx;
         if (SSL_IS_DTLS(s)) {
             mac_ctx = EVP_MD_CTX_new();

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -405,6 +405,7 @@ int tls13_change_cipher_state(SSL *s, int which)
                          SSL_F_TLS13_CHANGE_CIPHER_STATE, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
+            EVP_CIPHER_CTX_ctrl(s->enc_write_ctx, EVP_CTRL_SET_DRBG, 0, s->drbg);
         }
         ciph_ctx = s->enc_write_ctx;
         iv = s->write_iv;


### PR DESCRIPTION
This changes some of the places that use RAND_bytes() to use ssl specific DRBG.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated

