### PR TITLE
Configure: move --noexecstack probe to Configure.

### DIFF
--- a/Configure
+++ b/Configure
@@ -1281,6 +1281,26 @@ if ($^O ne "VMS") {
 	    $disabled{makedepend} = "unavailable" unless $config{makedepprog};
 	}
     }
+
+    if (!$disabled{asm}) {
+	# probe for -Wa,--noexecstack option...
+	if ($predefined{__clang__}) {
+	    # clang [which has builtin assembler] seems to recognize the
+	    # option in question on all supported platforms even when
+	    # it's meaningless...
+	    $config{cflags} .= " -Wa,--noexecstack";
+	} else {
+	    open(PIPE, "$cc -Wa,--help -c -o null.$$.o -x assembler /dev/null 2>&1 |");
+	    while(<PIPE>) {
+		if (m/\-\-noexecstack/) {
+		    $config{cflags} .= " -Wa,--noexecstack";
+		    last;
+		}
+	    }
+	    close(PIPE);
+	    unlink("null.$$.o");
+	}
+    }
 }
 
 

--- a/config
+++ b/config
@@ -822,12 +822,6 @@ if [ -n "$CONFIG_OPTIONS" ]; then
   options="$options $CONFIG_OPTIONS"
 fi
 
-if expr "$options" : '.*no\-asm' > /dev/null; then :; else
-  sh -c "$CROSS_COMPILE${CC:-gcc} -Wa,--help -c -o /tmp/null.$$.o -x assembler /dev/null && rm /tmp/null.$$.o" 2>&1 | \
-  grep \\--noexecstack >/dev/null && \
-  options="$options -Wa,--noexecstack"
-fi
-
 # gcc < 2.8 does not support -march=ultrasparc
 if [ "$OUT" = solaris-sparcv9-gcc -a $GCCVER -lt 28 ]
 then


### PR DESCRIPTION
config probe doesn't work in cross-compile scenarios or with clang.
