### PR TITLE
Disabled list doesn't contain SM3 and SM4.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -750,6 +750,12 @@ static void list_disabled(void)
 #ifdef OPENSSL_NO_SEED
     BIO_puts(bio_out, "SEED\n");
 #endif
+#ifdef OPENSSL_NO_SM3
+    BIO_puts(bio_out, "SM3\n");
+#endif
+#ifdef OPENSSL_NO_SM4
+    BIO_puts(bio_out, "SM4\n");
+#endif
 #ifdef OPENSSL_NO_SOCK
     BIO_puts(bio_out, "SOCK\n");
 #endif


### PR DESCRIPTION
The Chinese cryptographic operations should appear in the disabled list if they are disabled.
