### PR TITLE
Warn if -days without -x509

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -333,6 +333,8 @@ int req_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    if (days && !x509)
+        BIO_printf(bio_err, "Ignoring -days; not generating a certificate");
     if (x509 && infile == NULL)
         newreq = 1;
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -247,7 +247,8 @@ to the self signed certificate otherwise new request is created.
 =item B<-days n>
 
 When the B<-x509> option is being used this specifies the number of
-days to certify the certificate for. The default is 30 days.
+days to certify the certificate for, otherwise it is ignored.
+The default is 30 days.
 
 =item B<-set_serial n>
 


### PR DESCRIPTION
A source of confusion on the mailing list, apparently.
