### PR TITLE
X509V3_EXT_add_nconf_sk, X509v3_add_ext: fix errors handling

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1547,7 +1547,6 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
 
             if (push != NULL) {
                 if (!X509_NAME_add_entry(subject, push, -1, 0)) {
-                    X509_NAME_ENTRY_free(push);
                     BIO_printf(bio_err, "Memory allocation failure\n");
                     goto end;
                 }

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -128,7 +128,8 @@ STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
     X509err(X509_F_X509V3_ADD_EXT, ERR_R_MALLOC_FAILURE);
  err2:
     X509_EXTENSION_free(new_ex);
-    sk_X509_EXTENSION_free(sk);
+    if (x != NULL && *x == NULL)
+        sk_X509_EXTENSION_free(sk);
     return NULL;
 }
 

--- a/crypto/x509v3/v3_conf.c
+++ b/crypto/x509v3/v3_conf.c
@@ -313,8 +313,12 @@ int X509V3_EXT_add_nconf_sk(CONF *conf, X509V3_CTX *ctx, const char *section,
             return 0;
         if (ctx->flags == X509V3_CTX_REPLACE)
             delete_ext(*sk, ext);
-        if (sk)
-            X509v3_add_ext(sk, ext, -1);
+        if (sk != NULL) {
+            if (X509v3_add_ext(sk, ext, -1) == NULL) {
+                X509_EXTENSION_free(ext);
+                return 0;
+            }
+        }
         X509_EXTENSION_free(ext);
     }
     return 1;


### PR DESCRIPTION
X509v3_add_ext: free 'sk' if the memory pointed to by it
was malloc-ed inside this function.
X509V3_EXT_add_nconf_sk: return an error if X509v3_add_ext() fails.
This prevents use of a freed memory in do_body:sk_X509_EXTENSION_num().

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
