### PR TITLE
Don't NULL check before calling DSO_free.

### DIFF
--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -262,8 +262,7 @@ COMP_METHOD *COMP_zlib(void)
 void comp_zlib_cleanup_int(void)
 {
 #ifdef ZLIB_SHARED
-    if (zlib_dso != NULL)
-        DSO_free(zlib_dso);
+    DSO_free(zlib_dso);
     zlib_dso = NULL;
 #endif
 }


### PR DESCRIPTION
Missed during previous free-null-check cleanups.
