### PR TITLE
ssltest.c: cb_ticket2 appears to not return a value when it "should"

### DIFF
--- a/ssl/ssltest.c
+++ b/ssl/ssltest.c
@@ -554,6 +554,7 @@ static int cb_ticket2(SSL* s, unsigned char* key_name, unsigned char *iv, EVP_CI
 {
     fprintf(stderr, "ticket callback for SNI context should never be called\n");
     EXIT(1);
+    return 0;
 }
 #endif
 


### PR DESCRIPTION
cb_ticket2() does an exit, and should therefore not need to return anything.
Some compilers don't detect that, or don't care, and warn about a non-void
function without a return statement.
