### PR TITLE
extending afalg with aes-cbc-192/256, afalgtest.c also updated accord…

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -80,6 +80,7 @@ static int afalg_destroy(ENGINE *e);
 static int afalg_init(ENGINE *e);
 static int afalg_finish(ENGINE *e);
 const EVP_CIPHER *afalg_aes_cbc(int nid);
+cbc_handles *get_cipher_handle(int nid);
 static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                          const int **nids, int nid);
 static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
@@ -845,7 +846,7 @@ static int afalg_finish(ENGINE *e)
 
 static int free_cbc(void)
 {
-    short int i;
+    short unsigned int i;
     for(i = 0; i < OSSL_NELEM(afalg_cipher_nids); i++) {
         EVP_CIPHER_meth_free(cbc_handle[i]._hidden);
         cbc_handle[i]._hidden = NULL;

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -80,7 +80,7 @@ static int afalg_destroy(ENGINE *e);
 static int afalg_init(ENGINE *e);
 static int afalg_finish(ENGINE *e);
 const EVP_CIPHER *afalg_aes_cbc(int nid);
-cbc_handles *get_cipher_handle(int nid);
+static cbc_handles *get_cipher_handle(int nid);
 static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                          const int **nids, int nid);
 static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -644,7 +644,7 @@ static int afalg_cipher_cleanup(EVP_CIPHER_CTX *ctx)
     return 1;
 }
 
-cbc_handles *get_cipher_handle(int nid)
+static cbc_handles *get_cipher_handle(int nid)
 {
     switch (nid) {
     case NID_aes_128_cbc:

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -18,6 +18,7 @@
 #include <openssl/engine.h>
 #include <openssl/async.h>
 #include <openssl/err.h>
+#include "internal/nelem.h"
 
 #include <sys/socket.h>
 #include <linux/version.h>
@@ -78,7 +79,7 @@ static int afalg_create_sk(afalg_ctx *actx, const char *ciphertype,
 static int afalg_destroy(ENGINE *e);
 static int afalg_init(ENGINE *e);
 static int afalg_finish(ENGINE *e);
-const EVP_CIPHER *afalg_aes_128_cbc(void);
+const EVP_CIPHER *afalg_aes_cbc(int nid);
 static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                          const int **nids, int nid);
 static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
@@ -93,10 +94,14 @@ static const char *engine_afalg_id = "afalg";
 static const char *engine_afalg_name = "AFALG engine support";
 
 static int afalg_cipher_nids[] = {
-    NID_aes_128_cbc
+    NID_aes_128_cbc,
+    NID_aes_192_cbc,
+    NID_aes_256_cbc,
 };
 
-static EVP_CIPHER *_hidden_aes_128_cbc = NULL;
+static cbc_handles cbc_handle[] = {{AES_KEY_SIZE_128, NULL},
+                                    {AES_KEY_SIZE_192, NULL},
+                                    {AES_KEY_SIZE_256, NULL}};
 
 static ossl_inline int io_setup(unsigned n, aio_context_t *ctx)
 {
@@ -350,7 +355,6 @@ static ossl_inline int afalg_set_key(afalg_ctx *actx, const unsigned char *key,
         AFALGerr(AFALG_F_AFALG_SET_KEY, AFALG_R_SOCKET_SET_KEY_FAILED);
         return 0;
     }
-
     return 1;
 }
 
@@ -515,6 +519,8 @@ static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     ciphertype = EVP_CIPHER_CTX_nid(ctx);
     switch (ciphertype) {
     case NID_aes_128_cbc:
+    case NID_aes_192_cbc:
+    case NID_aes_256_cbc:
         strncpy(ciphername, "cbc(aes)", ALG_MAX_SALG_NAME);
         break;
     default:
@@ -637,29 +643,45 @@ static int afalg_cipher_cleanup(EVP_CIPHER_CTX *ctx)
     return 1;
 }
 
-const EVP_CIPHER *afalg_aes_128_cbc(void)
+cbc_handles *get_cipher_handle(int nid)
 {
-    if (_hidden_aes_128_cbc == NULL
-        && ((_hidden_aes_128_cbc =
-             EVP_CIPHER_meth_new(NID_aes_128_cbc,
-                                 AES_BLOCK_SIZE,
-                                 AES_KEY_SIZE_128)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_cbc, AES_IV_LEN)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_cbc,
-                                          EVP_CIPH_CBC_MODE |
-                                          EVP_CIPH_FLAG_DEFAULT_ASN1)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_cbc,
-                                         afalg_cipher_init)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_cbc,
-                                              afalg_do_cipher)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_aes_128_cbc,
-                                            afalg_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_cbc,
-                                                  sizeof(afalg_ctx)))) {
-        EVP_CIPHER_meth_free(_hidden_aes_128_cbc);
-        _hidden_aes_128_cbc = NULL;
+    switch (nid) {
+    case NID_aes_128_cbc:
+        return &cbc_handle[AES_CBC_128];
+    case NID_aes_192_cbc:
+        return &cbc_handle[AES_CBC_192];
+    case NID_aes_256_cbc:
+        return &cbc_handle[AES_CBC_256];
+    default:
+        return NULL;
     }
-    return _hidden_aes_128_cbc;
+}
+
+const EVP_CIPHER *afalg_aes_cbc(int nid)
+{
+    cbc_handles *cipher_handle = get_cipher_handle(nid);
+    if (cipher_handle->_hidden == NULL
+        && ((cipher_handle->_hidden =
+         EVP_CIPHER_meth_new(nid,
+                             AES_BLOCK_SIZE,
+                             cipher_handle->key_size)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(cipher_handle->_hidden,
+                                          AES_IV_LEN)
+        || !EVP_CIPHER_meth_set_flags(cipher_handle->_hidden,
+                                      EVP_CIPH_CBC_MODE |
+                                      EVP_CIPH_FLAG_DEFAULT_ASN1)
+        || !EVP_CIPHER_meth_set_init(cipher_handle->_hidden,
+                                     afalg_cipher_init)
+        || !EVP_CIPHER_meth_set_do_cipher(cipher_handle->_hidden,
+                                          afalg_do_cipher)
+        || !EVP_CIPHER_meth_set_cleanup(cipher_handle->_hidden,
+                                        afalg_cipher_cleanup)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(cipher_handle->_hidden,
+                                              sizeof(afalg_ctx)))) {
+        EVP_CIPHER_meth_free(cipher_handle->_hidden);
+        cipher_handle->_hidden= NULL;
+    }
+    return cipher_handle->_hidden;
 }
 
 static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
@@ -674,19 +696,21 @@ static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
 
     switch (nid) {
     case NID_aes_128_cbc:
-        *cipher = afalg_aes_128_cbc();
+    case NID_aes_192_cbc:
+    case NID_aes_256_cbc:
+        *cipher = afalg_aes_cbc(nid);
         break;
     default:
         *cipher = NULL;
         r = 0;
     }
-
     return r;
 }
 
 static int bind_afalg(ENGINE *e)
 {
     /* Ensure the afalg error handling is set up */
+    unsigned short i;
     ERR_load_AFALG_strings();
 
     if (!ENGINE_set_id(e, engine_afalg_id)
@@ -699,13 +723,15 @@ static int bind_afalg(ENGINE *e)
     }
 
     /*
-     * Create _hidden_aes_128_cbc by calling afalg_aes_128_cbc
+     * Create _hidden_aes_xxx_cbc by calling afalg_aes_xxx_cbc
      * now, as bind_aflag can only be called by one thread at a
      * time.
      */
-    if (afalg_aes_128_cbc() == NULL) {
-        AFALGerr(AFALG_F_BIND_AFALG, AFALG_R_INIT_FAILED);
-        return 0;
+    for(i = 0; i < OSSL_NELEM(afalg_cipher_nids); i++) {
+        if (afalg_aes_cbc(afalg_cipher_nids[i]) == NULL) {
+            AFALGerr(AFALG_F_BIND_AFALG, AFALG_R_INIT_FAILED);
+            return 0;
+        }
     }
 
     if (!ENGINE_set_ciphers(e, afalg_ciphers)) {
@@ -817,11 +843,20 @@ static int afalg_finish(ENGINE *e)
     return 1;
 }
 
+static int free_cbc(void)
+{
+    short int i;
+    for(i = 0; i < OSSL_NELEM(afalg_cipher_nids); i++) {
+        EVP_CIPHER_meth_free(cbc_handle[i]._hidden);
+        cbc_handle[i]._hidden = NULL;
+    }
+    return 1;
+}
+
 static int afalg_destroy(ENGINE *e)
 {
     ERR_unload_AFALG_strings();
-    EVP_CIPHER_meth_free(_hidden_aes_128_cbc);
-    _hidden_aes_128_cbc = NULL;
+    free_cbc();
     return 1;
 }
 

--- a/engines/e_afalg.h
+++ b/engines/e_afalg.h
@@ -41,6 +41,8 @@
 #  define AES_BLOCK_SIZE   16
 # endif
 # define AES_KEY_SIZE_128 16
+# define AES_KEY_SIZE_192 24
+# define AES_KEY_SIZE_256 32
 # define AES_IV_LEN       16
 
 # define MAX_INFLIGHTS 1
@@ -50,6 +52,19 @@ typedef enum {
     MODE_SYNC,
     MODE_ASYNC
 } op_mode;
+
+enum {
+    AES_CBC_128 = 0,
+    AES_CBC_192,
+    AES_CBC_256
+};
+
+struct cbc_cipher_handles {
+    int key_size;
+    EVP_CIPHER *_hidden;
+};
+
+typedef struct cbc_cipher_handles cbc_handles;
 
 struct afalg_aio_st {
     int efd;

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -17,7 +17,7 @@
 #include "testutil.h"
 
 /* Use a buffer size which is not aligned to block size */
-#define BUFFER_SIZE     (8 * 1024) - 13
+#define BUFFER_SIZE     17
 
 #ifndef OPENSSL_NO_ENGINE
 static ENGINE *e;
@@ -41,30 +41,59 @@ static ENGINE *e;
 #endif
 
 #ifndef OPENSSL_NO_AFALGENG
-static int test_afalg_aes_128_cbc(void)
+static int test_afalg_aes_cbc(int keysize_idx)
 {
     EVP_CIPHER_CTX *ctx;
-    const EVP_CIPHER *cipher = EVP_aes_128_cbc();
-    unsigned char key[] = "\x5F\x4D\xCC\x3B\x5A\xA7\x65\xD6\
-                           \x1D\x83\x27\xDE\xB8\x82\xCF\x99";
-    unsigned char iv[] = "\x2B\x95\x99\x0A\x91\x51\x37\x4A\
-                          \xBD\x8F\xF8\xC5\xA7\xA0\xFE\x08";
-
-    unsigned char in[BUFFER_SIZE];
+    const EVP_CIPHER *cipher;
+    unsigned char key[] = "\x06\xa9\x21\x40\x36\xb8\xa1\x5b"
+                          "\x51\x2e\x03\xd5\x34\x12\x00\x06"
+                          "\x06\xa9\x21\x40\x36\xb8\xa1\x5b"
+                          "\x51\x2e\x03\xd5\x34\x12\x00\x06";
+    unsigned char iv[] = "\x3d\xaf\xba\x42\x9d\x9e\xb4\x30"
+                         "\xb4\x22\xda\x80\x2c\x9f\xac\x41";
+    /* input = "Single block msg\n"  17Bytes*/
+    unsigned char in[BUFFER_SIZE] = "\x53\x69\x6e\x67\x6c\x65\x20\x62"
+                                    "\x6c\x6f\x63\x6b\x20\x6d\x73\x67\x0a";
     unsigned char ebuf[BUFFER_SIZE + 32];
     unsigned char dbuf[BUFFER_SIZE + 32];
+    unsigned char encresult_128[] = "\xe3\x53\x77\x9c\x10\x79\xae\xb8"
+                                    "\x27\x08\x94\x2d\xbe\x77\x18\x1a\x2d";
+    unsigned char encresult_192[] = "\xf7\xe4\x26\xd1\xd5\x4f\x8f\x39"
+                                    "\xb1\x9e\xe0\xdf\x61\xb9\xc2\x55\xeb";
+    unsigned char encresult_256[] = "\xa0\x76\x85\xfd\xc1\x65\x71\x9d"
+                                    "\xc7\xe9\x13\x6e\xae\x55\x49\xb4\x13";
+    unsigned char *enc_result;
+
     int encl, encf, decl, decf;
     int ret = 0;
 
+    switch (keysize_idx) {
+        case 0:
+            cipher = EVP_aes_128_cbc();
+            enc_result = &encresult_128[0];
+            break;
+        case 1:
+            cipher = EVP_aes_192_cbc();
+            enc_result = &encresult_192[0];
+            break;
+        case 2:
+            cipher = EVP_aes_256_cbc();
+            enc_result = &encresult_256[0];
+            break;
+        default:
+            cipher = NULL;
+    }
     if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
             return 0;
-    RAND_bytes(in, BUFFER_SIZE);
 
     if (!TEST_true(EVP_CipherInit_ex(ctx, cipher, e, key, iv, 1))
             || !TEST_true(EVP_CipherUpdate(ctx, ebuf, &encl, in, BUFFER_SIZE))
             || !TEST_true(EVP_CipherFinal_ex(ctx, ebuf+encl, &encf)))
         goto end;
     encl += encf;
+
+    if (!TEST_mem_eq(enc_result, BUFFER_SIZE, ebuf, BUFFER_SIZE))
+        goto end;
 
     if (!TEST_true(EVP_CIPHER_CTX_reset(ctx))
             || !TEST_true(EVP_CipherInit_ex(ctx, cipher, e, key, iv, 0))
@@ -104,7 +133,7 @@ int setup_tests(void)
         TEST_info("Can't load AFALG engine");
     } else {
 # ifndef OPENSSL_NO_AFALGENG
-        ADD_TEST(test_afalg_aes_128_cbc);
+        ADD_ALL_TESTS(test_afalg_aes_cbc, 3);
 # endif
     }
 #endif

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -62,7 +62,7 @@ static int test_afalg_aes_cbc(int keysize_idx)
                                     "\xb1\x9e\xe0\xdf\x61\xb9\xc2\x55\xeb";
     unsigned char encresult_256[] = "\xa0\x76\x85\xfd\xc1\x65\x71\x9d"
                                     "\xc7\xe9\x13\x6e\xae\x55\x49\xb4\x13";
-    unsigned char *enc_result;
+    unsigned char *enc_result = NULL;
 
     int encl, encf, decl, decf;
     int ret = 0;


### PR DESCRIPTION
HI 
Please consider the new pull request which considers the latest comments from matt and stephen.
The changes are for extending afalg support for aes cbc key sizes 192 and 256 bits.
The tests also have been added which encrypt and match the encrypted bytes with known good values. Also the tests decrypt and match  the decrypted bytes with the original plain text.

The known good encrypted bytes have been taken as the following (without afalg engine):

jlulla@ubuntu:~/openssl-master2/apps$ od --format=x1 /home/jlulla/plain
0000000 53 69 6e 67 6c 65 20 62 6c 6f 63 6b 20 6d 73 67
0000020 0a

jlulla@ubuntu:~/openssl-master2/apps$ ./openssl enc -aes128 -in /home/jlulla/plain -out /home/jlulla/encrypted1  -K 06a9214036b8a15b512e03d534120006 -iv 3dafba429d9eb430b422da802c9fac41

jlulla@ubuntu:~/openssl-master2/apps$ od --format=x1 /home/jlulla/encrypted1    
0000000 e3 53 77 9c 10 79 ae b8 27 08 94 2d be 77 18 1a
0000020 2d 34 aa 3e 5a 6f 8d 05 69 ef 36 5d 48 27 a9 bb

jlulla@ubuntu:~/openssl-master2/apps$ ./openssl enc -aes192 -in /home/jlulla/plain -out /home/jlulla/encrypted1  -K 06a9214036b8a15b512e03d53412000606a9214036b8a15b -iv 3dafba429d9eb430b422da802c9fac41

jlulla@ubuntu:~/openssl-master2/apps$ od --format=x1 /home/jlulla/encrypted1    
0000000 f7 e4 26 d1 d5 4f 8f 39 b1 9e e0 df 61 b9 c2 55
0000020 eb 7d 5a a2 1a 66 1e da 99 e9 14 2c 6c 23 e7 7c

jlulla@ubuntu:~/openssl-master2/apps$ ./openssl enc -aes256 -in /home/jlulla/plain -out /home/jlulla/encrypted1  -K 06a9214036b8a15b512e03d53412000606a9214036b8a15b512e03d534120006 -iv 3dafba429d9eb430b422da802c9fac41

jlulla@ubuntu:~/openssl-master2/apps$ od --format=x1 /home/jlulla/encrypted1    
0000000 a0 76 85 fd c1 65 71 9d c7 e9 13 6e ae 55 49 b4
0000020 13 aa 1d a7 39 f3 df c3 40 66 d0 7b dd d5 30 d5

Please review the changes. 

Thanks
Jitendra 

Previous pull requests:

https://github.com/openssl/openssl/pull/4448
https://github.com/openssl/openssl/pull/4465
https://github.com/openssl/openssl/pull/4482
https://github.com/openssl/openssl/pull/4484
https://github.com/openssl/openssl/pull/4567


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
