### PR TITLE
Avoid only exact duplicates when creating the accepted CA names list

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -566,14 +566,33 @@ int SSL_CTX_add_client_CA(SSL_CTX *ctx, X509 *x)
     return add_ca_name(&ctx->ca_names, x);
 }
 
-static int xname_sk_cmp(const X509_NAME *const *a, const X509_NAME *const *b)
-{
-    return X509_NAME_cmp(*a, *b);
-}
-
 static int xname_cmp(const X509_NAME *a, const X509_NAME *b)
 {
-    return X509_NAME_cmp(a, b);
+    unsigned char *abuf = NULL, *bbuf = NULL;
+    int alen, blen, ret;
+
+    /* X509_NAME_cmp() itself casts away constness in this way, so
+     * assume it's safe:
+     */
+    alen = i2d_X509_NAME((X509_NAME *)a, &abuf);
+    blen = i2d_X509_NAME((X509_NAME *)b, &bbuf);
+
+    if (alen < 0 || blen < 0)
+        ret = -2;
+    else if (alen != blen)
+        ret = alen - blen;
+    else /* alen == blen */
+        ret = memcmp(abuf, bbuf, alen);
+
+    OPENSSL_free(abuf);
+    OPENSSL_free(bbuf);
+
+    return ret;
+}
+
+static int xname_sk_cmp(const X509_NAME *const *a, const X509_NAME *const *b)
+{
+    return xname_cmp(*a, *b);
 }
 
 static unsigned long xname_hash(const X509_NAME *a)


### PR DESCRIPTION
This avoids situations where third party client is unable to recognize
that the client certificate was issued by the same CA with name differring
only by case or insignificant characters.

Fixes #4512 