### PR TITLE
Tweak SNI with early_data handling

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1923,18 +1923,7 @@ int s_client_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             goto end;
         }
-        /* By default the SNI should be the same as was set in the session */
-        if (!noservername && servername == NULL) {
-            servername = SSL_SESSION_get0_hostname(sess);
 
-            if (servername == NULL) {
-                /*
-                 * Force no SNI to be sent so we are consistent with the
-                 * session.
-                 */
-                noservername = 1;
-            }
-        }
         SSL_SESSION_free(sess);
     }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2340,10 +2340,14 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                 (void)BIO_flush(bio_s_out);
             }
         }
-        if (write_header)
-            BIO_printf(bio_s_out, "No early data received\n");
-        else
+        if (write_header) {
+            if (SSL_get_early_data_status(con) == SSL_EARLY_DATA_NOT_SENT)
+                BIO_printf(bio_s_out, "No early data received\n");
+            else
+                BIO_printf(bio_s_out, "Early data was rejected\n");
+        } else {
             BIO_printf(bio_s_out, "\nEnd of early data\n");
+        }
         if (SSL_is_init_finished(con))
             print_connection_info(con);
     }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -911,8 +911,6 @@ static int final_server_name(SSL *s, unsigned int context, int sent,
 
     case SSL_TLSEXT_ERR_NOACK:
         s->servername_done = 0;
-        if (s->server && s->session->ext.hostname != NULL)
-            s->ext.early_data_ok = 0;
         return 1;
 
     default:

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -736,13 +736,14 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
     edsess = s->session->ext.max_early_data != 0 ? s->session : psksess;
     s->max_early_data = edsess->ext.max_early_data;
 
-    if ((s->ext.hostname == NULL && edsess->ext.hostname != NULL)
-            || (s->ext.hostname != NULL
-                && (edsess->ext.hostname == NULL
-                    || strcmp(s->ext.hostname, edsess->ext.hostname) != 0))) {
-        SSLerr(SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA,
-               SSL_R_INCONSISTENT_EARLY_DATA_SNI);
-        return EXT_RETURN_FAIL;
+    if (edsess->ext.hostname != NULL) {
+        if (s->ext.hostname == NULL
+                || (s->ext.hostname != NULL
+                    && strcmp(s->ext.hostname, edsess->ext.hostname) != 0)) {
+            SSLerr(SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA,
+                   SSL_R_INCONSISTENT_EARLY_DATA_SNI);
+            return EXT_RETURN_FAIL;
+        }
     }
 
     if ((s->ext.alpn == NULL && edsess->ext.alpn_selected != NULL)) {

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -164,8 +164,7 @@ $proxy->clientflags("-no_tls1_3 -sess_in ".$session);
 $proxy->clientstart();
 checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
                checkhandshake::DEFAULT_EXTENSIONS
-               & ~checkhandshake::SESSION_TICKET_SRV_EXTENSION
-               & ~checkhandshake::SERVER_NAME_CLI_EXTENSION,
+               & ~checkhandshake::SESSION_TICKET_SRV_EXTENSION,
                "Resumption handshake test");
 unlink $session;
 

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -167,8 +167,7 @@ $proxy->clientstart();
 checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
                (checkhandshake::DEFAULT_EXTENSIONS
                 | checkhandshake::PSK_CLI_EXTENSION
-                | checkhandshake::PSK_SRV_EXTENSION)
-               & ~checkhandshake::SERVER_NAME_CLI_EXTENSION,
+                | checkhandshake::PSK_SRV_EXTENSION),
                "Resumption handshake test");
 
 #Test 3: A status_request handshake (client request only)
@@ -312,8 +311,7 @@ checkhandshake($proxy, checkhandshake::HRR_RESUME_HANDSHAKE,
                (checkhandshake::DEFAULT_EXTENSIONS
                 | checkhandshake::KEY_SHARE_HRR_EXTENSION
                 | checkhandshake::PSK_CLI_EXTENSION
-                | checkhandshake::PSK_SRV_EXTENSION)
-               & ~checkhandshake::SERVER_NAME_CLI_EXTENSION,
+                | checkhandshake::PSK_SRV_EXTENSION),
                "Resumption handshake with HRR test");
 
 #Test 16: Acceptable but non preferred key_share


### PR DESCRIPTION
This addresses a few different but related issues:

- s_client should not use the session to decide what SNI to send (as per this comment: https://github.com/openssl/openssl/issues/4496#issuecomment-337767145)
- Tweak s_server to give a more informative message about whether early_data wasn't sent or was rejected
- Relax the client side early_data/SNI consistency checks to allow a client to send early_data with SNI even if the session has no SNI
- If a server is not acknowledging SNI then don't reject early_data on the grounds of SNI inconsistency because the client may have sent it anyway.

These last 2 fixes have come about as a result of interoperability issues identified during testing #4701 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
