### PR TITLE
bn/bn_add.c: address performance regression.

### DIFF
--- a/crypto/bn/asm/x86_64-gcc.c
+++ b/crypto/bn/asm/x86_64-gcc.c
@@ -225,7 +225,8 @@ BN_ULONG bn_add_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                   "       adcq    (%5,%2,8),%0    \n"
                   "       movq    %0,(%3,%2,8)    \n"
                   "       lea     1(%2),%2        \n"
-                  "       loop    1b              \n"
+                  "       dec     %1              \n"
+                  "       jnz     1b              \n"
                   "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
                   "+r"(i)
                   :"r"(rp), "r"(ap), "r"(bp)
@@ -251,7 +252,8 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                   "       sbbq    (%5,%2,8),%0    \n"
                   "       movq    %0,(%3,%2,8)    \n"
                   "       lea     1(%2),%2        \n"
-                  "       loop    1b              \n"
+                  "       dec     %1              \n"
+                  "       jnz     1b              \n"
                   "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
                   "+r"(i)
                   :"r"(rp), "r"(ap), "r"(bp)

--- a/crypto/bn/asm/x86_64-gcc.c
+++ b/crypto/bn/asm/x86_64-gcc.c
@@ -227,8 +227,8 @@ BN_ULONG bn_add_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                   "       lea     1(%2),%2        \n"
                   "       dec     %1              \n"
                   "       jnz     1b              \n"
-                  "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
-                  "+r"(i)
+                  "       sbbq    %0,%0           \n"
+                  :"=&r" (ret), "+c"(n), "+r"(i)
                   :"r"(rp), "r"(ap), "r"(bp)
                   :"cc", "memory");
 
@@ -254,8 +254,8 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                   "       lea     1(%2),%2        \n"
                   "       dec     %1              \n"
                   "       jnz     1b              \n"
-                  "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
-                  "+r"(i)
+                  "       sbbq    %0,%0           \n"
+                  :"=&r" (ret), "+c"(n), "+r"(i)
                   :"r"(rp), "r"(ap), "r"(bp)
                   :"cc", "memory");
 

--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -141,9 +141,13 @@ int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
         borrow &= (t1 == 0);
     }
 
+    while (max && *--rp == 0)
+        max--;
+
     r->top = max;
     r->neg = 0;
-    bn_correct_top(r);
+    bn_pollute(r);
+
     return 1;
 }
 


### PR DESCRIPTION
Performance regression was reported for EC key generation between
1.0.2 and 1.1.x [in GH#2891]. It naturally depends on platform,
values between 6 and 9% were observed.
