### PR TITLE
Revert "Add padding spaces before printing algo."

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -119,9 +119,6 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
 
     if (!(cflag & X509_FLAG_NO_SIGNAME)) {
         const X509_ALGOR *tsig_alg = X509_get0_tbs_sigalg(x);
-
-        if (BIO_puts(bp, "    ") <= 0)
-            goto err;
         if (X509_signature_print(bp, tsig_alg, NULL) <= 0)
             goto err;
     }


### PR DESCRIPTION
Some test files need to be updated.
This reverts commit 26a374a271dabd49f3fa7f43a74e05d34aca010e.
@beldmit can you give me updated test files for the cyrillic test?
