### PR TITLE
Make possible variant SONAMEs and symbol versions

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -102,15 +102,17 @@ In each table entry, the following keys are significant:
                            this is here for future use, it's not
                            implemented yet)
         shlib_variant   => A "variant" identifier inserted between the base
-                           shared library name and the extension.  This
+                           shared library name and the extension.  On "unixy"
+                           platforms (BSD, Linux, Solaris, MacOS/X, ...) this
                            supports installation of custom OpenSSL libraries
-                           that don't conflict with OpenSSL libraries provided
-                           by the operating system.  The variant identifier
+                           that don't conflict with other builds of OpenSSL
+                           installed on the system.  The variant identifier
                            becomes part of the SONAME of the library and also
-                           any symbol versions.  For example, on a system where
-                           a default build would normally create the SSL shared
-                           library as 'libssl.so -> libssl.so.1.1' with the
-                           value of the symlink as the SONAME, a target
+                           any symbol versions (symbol versions are not used or
+                           needed with MacOS/X).  For example, on a system
+                           where a default build would normally create the SSL
+                           shared library as 'libssl.so -> libssl.so.1.1' with
+                           the value of the symlink as the SONAME, a target
                            definition that sets 'shlib_variant => "-abc"' will
                            create 'libssl.so -> libssl-abc.so.1.1', again with
                            an SONAME equal to the value of the symlink.  The

--- a/Configurations/README
+++ b/Configurations/README
@@ -101,6 +101,25 @@ In each table entry, the following keys are significant:
                            files.  On unix, this defaults to "" (NOTE:
                            this is here for future use, it's not
                            implemented yet)
+        shlib_variant   => A "variant" identifier inserted between the base
+                           shared library name and the extension.  This
+                           supports installation of custom OpenSSL libraries
+                           that don't conflict with OpenSSL libraries provided
+                           by the operating system.  The variant identifier
+                           becomes part of the SONAME of the library and also
+                           any symbol versions.  For example, on a system where
+                           a default build would normally create the SSL shared
+                           library as 'libssl.so -> libssl.so.1.1' with the
+                           value of the symlink as the SONAME, a target
+                           definition that sets 'shlib_variant => "-abc"' will
+                           create 'libssl.so -> libssl-abc.so.1.1', again with
+                           an SONAME equal to the value of the symlink.  The
+                           symbol versions associated with the variant library
+                           would then be 'OPENSSL_ABC_<version>' rather than
+                           the default 'OPENSSL_<version>'. The string inserted
+                           into symbol versions is obtained by mapping all
+                           letters in the "variant" identifier to upper case
+                           and all non-alphanumeric characters to '_'.
 
         thread_scheme   => The type of threads is used on the
                            configured platform.  Currently known

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -8,6 +8,7 @@
      our $exeext = $target{exe_extension} || "";
      our $libext = $target{lib_extension} || ".a";
      our $shlibext = $target{shared_extension} || ".so";
+     our $shlibvariant = $target{shlib_variant} || "";
      our $shlibextsimple = $target{shared_extension_simple} || ".so";
      our $shlibextimport = $target{shared_import_extension} || "";
      our $dsoext = $target{dso_extension} || ".so";
@@ -40,7 +41,7 @@
      sub shlib {
          my $lib = shift;
          return () if $disabled{shared} || $lib =~ /\.a$/;
-         return $unified_info{sharednames}->{$lib} . '$(SHLIB_EXT)';
+         return $unified_info{sharednames}->{$lib}. $shlibvariant. '$(SHLIB_EXT)';
      }
      sub shlib_simple {
          my $lib = shift;


### PR DESCRIPTION
This small change in the Unix template and shared library build
scripts makes it possible to build "variant" shared libraries.  A
"variant" shared library has a non-default SONAME, and non default
symbol versions.

This makes it possible to build (say) an OpenSSL 1.1.0 library that
can coexist without conflict in the same process address space as
the system's default OpenSSL library which may be OpenSSL 1.0.2.

This is makes it possible to link applications against a newer
OpenSSL library installed in /opt/openssl/1.1 or similar location,
and not risk conflict with an indirectly loaded OpenSSL runtime
that is required by some other dependency.

This has been fully tested under Linux, and builds successfully on
MacOS/X producing variant DYLD names, but it is not obvious to me
whether this is sufficient (along with Darwins non-flat namespace
for libraries) to avoid symbol conflicts on MacOS/X.

Of course the feature is optional and off by default.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
