### PR TITLE
Make possible variant SONAMEs and symbol versions (1.1.0 version)

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -86,6 +86,25 @@ In each table entry, the following keys are significant:
                            files.  On unix, this defaults to "" (NOTE:
                            this is here for future use, it's not
                            implemented yet)
+        shlib_variant   => A "variant" identifier inserted between the base
+                           shared library name and the extension.  This
+                           supports installation of custom OpenSSL libraries
+                           that don't conflict with OpenSSL libraries provided
+                           by the operating system.  The variant identifier
+                           becomes part of the SONAME of the library and also
+                           any symbol versions.  For example, on a system where
+                           a default build would normally create the SSL shared
+                           library as 'libssl.so -> libssl.so.1.1' with the
+                           value of the symlink as the SONAME, a target
+                           definition that sets 'shlib_variant => "-abc"' will
+                           create 'libssl.so -> libssl-abc.so.1.1', again with
+                           an SONAME equal to the value of the symlink.  The
+                           symbol versions associated with the variant library
+                           would then be 'OPENSSL_ABC_<version>' rather than
+                           the default 'OPENSSL_<version>'. The string inserted
+                           into symbol versions is obtained by mapping all
+                           letters in the "variant" identifier to upper case
+                           and all non-alphanumeric characters to '_'.
 
         thread_scheme   => The type of threads is used on the
                            configured platform.  Currently known

--- a/Configurations/README
+++ b/Configurations/README
@@ -87,15 +87,17 @@ In each table entry, the following keys are significant:
                            this is here for future use, it's not
                            implemented yet)
         shlib_variant   => A "variant" identifier inserted between the base
-                           shared library name and the extension.  This
+                           shared library name and the extension.  On "unixy"
+                           platforms (BSD, Linux, Solaris, MacOS/X, ...) this
                            supports installation of custom OpenSSL libraries
-                           that don't conflict with OpenSSL libraries provided
-                           by the operating system.  The variant identifier
+                           that don't conflict with other builds of OpenSSL
+                           installed on the system.  The variant identifier
                            becomes part of the SONAME of the library and also
-                           any symbol versions.  For example, on a system where
-                           a default build would normally create the SSL shared
-                           library as 'libssl.so -> libssl.so.1.1' with the
-                           value of the symlink as the SONAME, a target
+                           any symbol versions (symbol versions are not used or
+                           needed with MacOS/X).  For example, on a system
+                           where a default build would normally create the SSL
+                           shared library as 'libssl.so -> libssl.so.1.1' with
+                           the value of the symlink as the SONAME, a target
                            definition that sets 'shlib_variant => "-abc"' will
                            create 'libssl.so -> libssl-abc.so.1.1', again with
                            an SONAME equal to the value of the symlink.  The

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -8,6 +8,7 @@
      our $exeext = $target{exe_extension} || "";
      our $libext = $target{lib_extension} || ".a";
      our $shlibext = $target{shared_extension} || ".so";
+     our $shlibvariant = $target{shlib_variant} || "";
      our $shlibextsimple = $target{shared_extension_simple} || ".so";
      our $shlibextimport = $target{shared_import_extension} || "";
      our $dsoext = $target{dso_extension} || ".so";
@@ -40,7 +41,7 @@
      sub shlib {
          return () if $disabled{shared};
          my $lib = shift;
-         return $unified_info{sharednames}->{$lib} . $shlibext;
+         return $unified_info{sharednames}->{$lib}. $shlibvariant. $shlibext;
      }
      sub shlib_simple {
          return () if $disabled{shared};

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -53,6 +53,58 @@ use FindBin;
 use lib "$FindBin::Bin/perl";
 use OpenSSL::Glob;
 
+# When building a "variant" shared library, with a custom SONAME, also customize
+# all the symbol versions.  This produces a shared object that can coexist
+# without conflict in the same address space as a default build, or an object
+# with a different variant tag.
+#
+# For example, with a target definition that includes:
+#
+#         shlib_variant => "-opt",
+#
+# we build the following objects:
+#
+# $ perl -le '
+#     for (@ARGV) {
+#         if ($l = readlink) {
+#             printf "%s -> %s\n", $_, $l
+#         } else {
+#             print
+#         }
+#     }' *.so*
+# libcrypto-opt.so.1.1
+# libcrypto.so -> libcrypto-opt.so.1.1
+# libssl-opt.so.1.1
+# libssl.so -> libssl-opt.so.1.1
+#
+# whose SONAMEs and dependencies are:
+#
+# $ for l in *.so; do
+#     echo $l
+#     readelf -d $l | egrep 'SONAME|NEEDED.*(ssl|crypto)'
+#   done
+# libcrypto.so
+#  0x000000000000000e (SONAME)             Library soname: [libcrypto-opt.so.1.1]
+# libssl.so
+#  0x0000000000000001 (NEEDED)             Shared library: [libcrypto-opt.so.1.1]
+#  0x000000000000000e (SONAME)             Library soname: [libssl-opt.so.1.1]
+#
+# We case-fold the variant tag to upper case and replace all non-alnum
+# characters with "_".  This yields the following symbol versions:
+#
+# $ nm libcrypto.so | grep -w A
+# 0000000000000000 A OPENSSL_OPT_1_1_0
+# 0000000000000000 A OPENSSL_OPT_1_1_0a
+# 0000000000000000 A OPENSSL_OPT_1_1_0c
+# 0000000000000000 A OPENSSL_OPT_1_1_0d
+# 0000000000000000 A OPENSSL_OPT_1_1_0f
+# 0000000000000000 A OPENSSL_OPT_1_1_0g
+# $ nm libssl.so | grep -w A
+# 0000000000000000 A OPENSSL_OPT_1_1_0
+# 0000000000000000 A OPENSSL_OPT_1_1_0d
+#
+(my $SO_VARIANT = qq{\U$target{"shlib_variant"}}) =~ s/\W/_/g;
+
 my $debug=0;
 
 my $crypto_num= catfile($config{sourcedir},"util","libcrypto.num");
@@ -1263,13 +1315,13 @@ EOF
 						if ($symversion ne $prevsymversion) {
 							if ($prevsymversion ne "") {
 								if ($prevprevsymversion ne "") {
-									print OUT "} OPENSSL_"
+									print OUT "} OPENSSL${SO_VARIANT}_"
 												."$prevprevsymversion;\n\n";
 								} else {
 									print OUT "};\n\n";
 								}
 							}
-							print OUT "OPENSSL_$symversion {\n    global:\n";
+							print OUT "OPENSSL${SO_VARIANT}_$symversion {\n    global:\n";
 							$prevprevsymversion = $prevsymversion;
 							$prevsymversion = $symversion;
 						}
@@ -1318,7 +1370,7 @@ EOF
 	} while ($linux && $thisversion ne $currversion);
 	if ($linux) {
 		if ($prevprevsymversion ne "") {
-			print OUT "    local: *;\n} OPENSSL_$prevprevsymversion;\n\n";
+			print OUT "    local: *;\n} OPENSSL${SO_VARIANT}_$prevprevsymversion;\n\n";
 		} else {
 			print OUT "    local: *;\n};\n\n";
 		}


### PR DESCRIPTION
This small change in the Unix template and shared library build
scripts makes it possible to build "variant" shared libraries.  A
"variant" shared library has a non-default SONAME, and non default
symbol versions.

This makes it possible to build (say) an OpenSSL 1.1.0 library that
can coexist without conflict in the same process address space as
the system's default OpenSSL library which may be OpenSSL 1.0.2.

This is makes it possible to link applications against a newer
OpenSSL library installed in /opt/openssl/1.1 or similar location,
and not risk conflict with an indirectly loaded OpenSSL runtime
that is required by some other dependency.

This has been fully tested under Linux, and builds successfully on
MacOS/X producing variant DYLD names, but it is not obvious to me
whether this is sufficient (along with Darwins non-flat namespace
for libraries) to avoid symbol conflicts on MacOS/X.

Of course the feature is optional and off by default.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
