### PR TITLE
Avoid unnecessary MSYS2 conversion of some arguments [1.1.0]

### DIFF
--- a/test/recipes/04-test_pem.t
+++ b/test/recipes/04-test_pem.t
@@ -88,7 +88,11 @@ SKIP: {
     skip "DSA support disabled, skipping...", (scalar keys %dsa_expected) unless !disabled("dsa");
     foreach my $input (keys %dsa_expected) {
         my @common = ($cmd, "pkey", "-inform", "PEM", "-passin", "file:" . data_file("wellknown"), "-noout", "-text", "-in");
-        my @data = run(app([@common, data_file($input)], stderr => undef), capture => 1);
+        my @data;
+        {
+            local $ENV{MSYS2_ARG_CONV_EXCL} = "file:";
+            @data = run(app([@common, data_file($input)], stderr => undef), capture => 1);
+        }
         my @match = grep /68:42:02:16:63:54:16:eb:06:5c:ab:06:72:3b:78:/, @data;
         is((scalar @match > 0 ? 1 : 0), $dsa_expected{$input});
     }


### PR DESCRIPTION
Fixes #4740

The MSYS2 run-time convert arguments that look like paths when
executing a program unless that application is linked with the MSYS
run-time. The exact conversion rules are listed here:

    http://www.mingw.org/wiki/Posix_path_conversion

With the built-in configurations (all having names starting with
"mingw"), the openssl application is not linked with the MSYS2
run-time, and therefore, it will receive possibly converted arguments
from the process that executes it. This conversion is fine for normal
path arguments, but it happens that some arguments to the openssl
application get converted when they shouldn't. In one case, it's
arguments like '-passin file:something', and in another, it's a file:
URI (what typically happens is that URIs without an authority
component get converted, 'cause the conversion mechanism doesn't
recognise them as URIs).

To avoid conversion where we don't want it, we simply assign
MSYS2_ARG_CONV_EXCL a pattern to avoid specific conversions. As a
precaution, we only do this where we obviously need it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
