### PR TITLE
Fix some issues in apps/req

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -159,7 +159,7 @@ int req_main(int argc, char **argv)
     char *template = default_config_file, *keyout = NULL;
     const char *keyalg = NULL;
     OPTION_CHOICE o;
-    int ret = 1, x509 = 0, days = 30, i = 0, newreq = 0, verbose = 0;
+    int ret = 1, x509 = 0, days = 0, i = 0, newreq = 0, verbose = 0;
     int pkey_type = -1, private = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, keyform = FORMAT_PEM;
     int modulus = 0, multirdn = 0, verify = 0, noout = 0, text = 0;
@@ -334,7 +334,7 @@ int req_main(int argc, char **argv)
         goto opthelp;
 
     if (days && !x509)
-        BIO_printf(bio_err, "Ignoring -days; not generating a certificate");
+        BIO_printf(bio_err, "Ignoring -days; not generating a certificate\n");
     if (x509 && infile == NULL)
         newreq = 1;
 
@@ -617,6 +617,10 @@ int req_main(int argc, char **argv)
 
             if (!X509_set_issuer_name(x509ss, X509_REQ_get_subject_name(req)))
                 goto end;
+            if (days == 0) {
+                /* set default days if it's not specified */
+                days = 30;
+            }
             if (!set_cert_times(x509ss, NULL, NULL, days))
                 goto end;
             if (!X509_set_subject_name

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -247,8 +247,8 @@ to the self signed certificate otherwise new request is created.
 =item B<-days n>
 
 When the B<-x509> option is being used this specifies the number of
-days to certify the certificate for, otherwise it is ignored.
-The default is 30 days.
+days to certify the certificate for, otherwise it is ignored. B<n> should
+be a positive integer. The default is 30 days.
 
 =item B<-set_serial n>
 


### PR DESCRIPTION
Currently if someone uses this command like:

```
bin/openssl req -newkey RSA:2048 -keyout /tmp/new.key -out /tmp/new.csr
```

The output will be:

```
Ignoring -days; not generating a certificateGenerating a 2048 bit RSA private key
```

There are two issues with this:

1. the 'ignore -days' warning should not be printed without '-x509'
2. the 'ignore -days' warning should terminate with new-line

This change fixes these issues.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
