### PR TITLE
Correct EVP_CIPHER_meth_new.pod and EVP_MD_meth_new.pod

### DIFF
--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -204,17 +204,32 @@ EVP_CIPHER_CTX_get_cipher_data().
 This cleanup function is called by EVP_CIPHER_CTX_reset() and
 EVP_CIPHER_CTX_free().
 
+EVP_CIPHER_meth_set_set_asn1_params() sets the function for B<cipher>
+to set the AlgorithmIdentifier "parameter" based on the passed cipher.
+This function is called by EVP_CIPHER_param_to_asn1().
+EVP_CIPHER_meth_set_get_asn1_params() sets the function for B<cipher>
+that sets the cipher parameters based on an ASN.1 AlgorithmIdentifier
+"parameter".
+Both these functions are needed when there's a need for custom data
+(more or other than the cipher IV).
+They are called by EVP_CIPHER_param_to_asn1() and
+EVP_CIPHER_asn1_to_param() respectively if defined.
+
 EVP_CIPHER_meth_set_ctrl() sets the control function for B<cipher>.
+
+EVP_CIPHER_meth_get_init(), EVP_CIPHER_meth_get_do_cipher(),
+EVP_CIPHER_meth_get_cleanup(), EVP_CIPHER_meth_get_set_asn1_params(),
+EVP_CIPHER_meth_get_get_asn1_params() and EVP_CIPHER_meth_get_ctrl()
+are all used to retrieve the method data given with the
+EVP_CIPHER_meth_set_*() functions above.
 
 =head1 RETURN VALUES
 
-EVP_CIPHER_meth_get_input_blocksize(), EVP_CIPHER_meth_get_result_size(),
-EVP_CIPHER_meth_get_app_datasize(), EVP_CIPHER_meth_get_flags(),
-EVP_CIPHER_meth_get_init(), EVP_CIPHER_meth_get_update(),
-EVP_CIPHER_meth_get_final(), EVP_CIPHER_meth_get_copy(),
-EVP_CIPHER_meth_get_cleanup() and EVP_CIPHER_meth_get_ctrl() are all used
-to retrieve the method data given with the EVP_CIPHER_meth_set_*()
-functions above.
+EVP_CIPHER_meth_new() and EVP_CIPHER_meth_dup() return a pointer to a
+newly created B<EVP_CIPHER>, or NULL on failure.
+All EVP_CIPHER_meth_set_*() functions return 1.
+All EVP_CIPHER_meth_get_*() functions return pointers to their
+respective B<cipher> function.
 
 =head1 SEE ALSO
 

--- a/doc/man3/EVP_MD_meth_new.pod
+++ b/doc/man3/EVP_MD_meth_new.pod
@@ -34,7 +34,6 @@ EVP_MD_meth_get_ctrl, EVP_MD_CTX_md_data
                                                     unsigned char *md));
  int EVP_MD_meth_set_copy(EVP_MD *md, int (*copy)(EVP_MD_CTX *to,
                                                   const EVP_MD_CTX *from));
- void *EVP_MD_CTX_md_data(const EVP_MD_CTX *ctx);
  int EVP_MD_meth_set_cleanup(EVP_MD *md, int (*cleanup)(EVP_MD_CTX *ctx));
  int EVP_MD_meth_set_ctrl(EVP_MD *md, int (*ctrl)(EVP_MD_CTX *ctx, int cmd,
                                                   int p1, void *p2));
@@ -140,7 +139,6 @@ EVP_MD_CTX_free().
 
 EVP_MD_meth_set_ctrl() sets the control function for B<md>.
 
-
 EVP_MD_meth_get_input_blocksize(), EVP_MD_meth_get_result_size(),
 EVP_MD_meth_get_app_datasize(), EVP_MD_meth_get_flags(),
 EVP_MD_meth_get_init(), EVP_MD_meth_get_update(),
@@ -148,6 +146,17 @@ EVP_MD_meth_get_final(), EVP_MD_meth_get_copy(),
 EVP_MD_meth_get_cleanup() and EVP_MD_meth_get_ctrl() are all used
 to retrieve the method data given with the EVP_MD_meth_set_*()
 functions above.
+
+=head1 RETURN VALUES
+
+EVP_MD_meth_new() and EVP_MD_meth_dup() return a pointer to a newly
+created B<EVP_MD>, or NULL on failure.
+All EVP_MD_meth_set_*() functions return 1.
+EVP_MD_get_input_blocksize(), EVP_MD_meth_get_result_size(),
+EVP_MD_meth_get_app_datasize() and EVP_MD_meth_get_flags() return the
+indicated sizes or flags.
+All other EVP_CIPHER_meth_get_*() functions return pointers to their
+respective B<md> function.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
One had some lines copied from the other, and both were missing a
proper RETURN VALUES section.

Fixes #4781
