### PR TITLE
In OPENSSL_init_ssl(), run the base ssl init before OPENSSL_init_crypto()

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -80,8 +80,8 @@ static int apps_startup()
 #endif
 
     /* Set non-default library initialisation settings */
-    if (!OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN
-                             | OPENSSL_INIT_LOAD_CONFIG, NULL))
+    if (!OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN
+                          | OPENSSL_INIT_LOAD_CONFIG, NULL))
         return 0;
 
     setup_ui_method();

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -195,11 +195,11 @@ int OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS * settings)
         return 0;
     }
 
-    if (!OPENSSL_init_crypto(opts | OPENSSL_INIT_ADD_ALL_CIPHERS
-                             | OPENSSL_INIT_ADD_ALL_DIGESTS, settings))
+    if (!RUN_ONCE(&ssl_base, ossl_init_ssl_base))
         return 0;
 
-    if (!RUN_ONCE(&ssl_base, ossl_init_ssl_base))
+    if (!OPENSSL_init_crypto(opts | OPENSSL_INIT_ADD_ALL_CIPHERS
+                             | OPENSSL_INIT_ADD_ALL_DIGESTS, settings))
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_LOAD_SSL_STRINGS)


### PR DESCRIPTION
IF OPENSSL_init_ssl() is called with the option flag
OPENSSL_INIT_LOAD_CONFIG, any SSL config will be handled wrongly
(i.e. there will be an attempt to load libssl_conf.so or whatever
corresponds to that on non-Unix platforms).  Therefore, at least
SSL_add_ssl_module() MUST be called before OPENSSL_init_crypto() is
called.  The base ssl init does that, plus adds all kinds of ciphers
and digests, which is harmless.

Fixes #4788
