### PR TITLE
In VS2015 IDE project solution. some compiling error fixing. CLA: trivial

### DIFF
--- a/crypto/evp/c_allc.c
+++ b/crypto/evp/c_allc.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <openssl/opensslconf.h>
 #include "internal/cryptlib.h"
 #include <openssl/evp.h>
 #include "internal/evp_int.h"

--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -8,6 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/opensslconf.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_ARIA
 # include <openssl/evp.h>


### PR DESCRIPTION
In VS2015 IDE project solution. some compiling error fixing.
Please see my repository https://github.com/ShadowsocksR-Live/openssl4w
CLA: trivial

The OPENSSL_NO_ARIA flag will not effect if we don't add "#include <openssl/opensslconf.h>" lines.
