### PR TITLE
Fix lshift tests

### DIFF
--- a/test/bntest.c
+++ b/test/bntest.c
@@ -1089,7 +1089,9 @@ static int file_lshift(STANZA *s)
 
     if (!TEST_ptr(a = getBN(s, "A"))
             || !TEST_ptr(lshift = getBN(s, "LShift"))
-            || !TEST_ptr(ret = BN_new()))
+            || !TEST_ptr(ret = BN_new())
+            || !getint(s, &n, "N"))
+        goto err;
 
     if (!TEST_true(BN_lshift(ret, a, n))
             || !equalBN("A << N", lshift, ret)


### PR DESCRIPTION
Commit 30bea14be6 converted bntest.c to the new TEST framework.
Unfortunately a missing "goto err" means that the lshift tests skip
the actual bit that tests them. Replacing the "goto err" reveals that
the conversion also broke the tests. This adds back the missing "goto err"
and fixes the tests.

Fixes #4808

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
