### PR TITLE
add mips r6 support

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -723,6 +723,31 @@ sub vms_info {
         shared_ldflag    => add("-mabi=64"),
         multilib         => "64",
     },
+    "linux-mips32r6" => {
+# Configure script adds minimally required -march for assembly
+# support, if no -march was specified at command line.
+       inherit_from     => [ "linux-generic32"],
+       cflags           => add("-mabi=32"),
+       perlasm_scheme   => "o32",
+       shared_ldflag    => add("-mabi=32"),
+    },
+# mips32 and mips64 below refer to contemporary MIPS Architecture
+# specifications, MIPS32 and MIPS64, rather than to kernel bitness.
+    "linux-mips64r6" => {
+       inherit_from     => [ "linux-generic32"],
+       cflags           => add("-mabi=n32"),
+       bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR",
+       perlasm_scheme   => "n32",
+       shared_ldflag    => add("-mabi=n32"),
+       multilib         => "32",
+    },
+    "linux64-mips64r6" => {
+       inherit_from     => [ "linux-generic64"],
+       cflags           => add("-mabi=64"),
+       perlasm_scheme   => "64",
+       shared_ldflag    => add("-mabi=64"),
+       multilib         => "64",
+    },
 
     #### IA-32 targets...
     #### These two targets are a bit aged and are to be used on older Linux


### PR DESCRIPTION
mips r6 is quite similar with current mips architectures,
while mips r6 drops and replace some insn,
so they are not compatible with previous version.

Here for openssl, we disable ASM, and -DBN_DIV3W.

Debian BTS https://bugs.debian.org/882007
Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>

- [X] documentation is added or updated
- [X] tests are added or updated
