### PR TITLE
ENGINE_REF_COUNT_DEBUG

### DIFF
--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -82,7 +82,7 @@ int engine_free_util(ENGINE *e, int not_locked)
     else
         i = --e->struct_ref;
 #endif
-    engine_ref_debug(e, 0, -1)
+    engine_ref_debug(e, 0, -1);
     if (i > 0)
         return 1;
     REF_ASSERT_ISNT(i < 0);


### PR DESCRIPTION
A missing semicolon prevents compilation with ENGINE_REF_COUNT_DEBUG enabled.

