### PR TITLE
Environment variable assignments on Configure command line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Make it possible to have environment variable assignments as
+     arguments to config / Configure.
+     [Richard Levitte]
+
   *) Add multi-prime RSA (RFC 8017) support.
      [Paul Yang]
 

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -53,14 +53,14 @@ my $vc_wince_info = {};
 sub vc_wince_info {
     unless (%$vc_wince_info) {
         # sanity check
-        $die->('%OSVERSION% is not defined') if (!defined($ENV{'OSVERSION'}));
-        $die->('%PLATFORM% is not defined')  if (!defined($ENV{'PLATFORM'}));
-        $die->('%TARGETCPU% is not defined') if (!defined($ENV{'TARGETCPU'}));
+        $die->('%OSVERSION% is not defined') if (!defined(env('OSVERSION')));
+        $die->('%PLATFORM% is not defined')  if (!defined(env('PLATFORM')));
+        $die->('%TARGETCPU% is not defined') if (!defined(env('TARGETCPU')));
 
         #
         # Idea behind this is to mimic flags set by eVC++ IDE...
         #
-        my $wcevers = $ENV{'OSVERSION'};                    # WCENNN
+        my $wcevers = env('OSVERSION');                     # WCENNN
 	my $wcevernum;
 	my $wceverdotnum;
 	if ($wcevers =~ /^WCE([1-9])([0-9]{2})$/) {
@@ -74,12 +74,12 @@ sub vc_wince_info {
         my $wcecdefs = "-D_WIN32_WCE=$wcevernum -DUNDER_CE=$wcevernum"; # -D_WIN32_WCE=NNN
         my $wcelflag = "/subsystem:windowsce,$wceverdotnum";        # ...,N.NN
 
-        my $wceplatf =  $ENV{'PLATFORM'};
+        my $wceplatf =  env('PLATFORM');
 
         $wceplatf =~ tr/a-z0-9 /A-Z0-9_/;
         $wcecdefs .= " -DWCE_PLATFORM_$wceplatf";
 
-        my $wcetgt = $ENV{'TARGETCPU'};                     # just shorter name...
+        my $wcetgt = env('TARGETCPU');                      # just shorter name...
       SWITCH: for($wcetgt) {
           /^X86/        && do { $wcecdefs.=" -Dx86 -D_X86_ -D_i386_ -Di_386_";
                                 $wcelflag.=" /machine:X86";     last; };
@@ -1407,9 +1407,9 @@ sub vms_info {
             picker(default =>
                    combine('/W3 /WX /GF /Gy /nologo -DUNICODE -D_UNICODE -DOPENSSL_SYS_WINCE -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -DDSO_WIN32 -DNO_CHMOD -DOPENSSL_SMALL_FOOTPRINT',
                            sub { vc_wince_info()->{cflags}; },
-                           sub { defined($ENV{'WCECOMPAT'})
+                           sub { defined(env('WCECOMPAT'))
                                      ? '-I$(WCECOMPAT)/include' : (); },
-                           sub { defined($ENV{'PORTSDK_LIBPATH'})
+                           sub { defined(env('PORTSDK_LIBPATH'))
                                      ? '-I$(PORTSDK_LIBPATH)/../../include' : (); },
                            sub { `cl 2>&1` =~ /Version ([0-9]+)\./ && $1>=14
                                      ? ($disabled{shared} ? " /MT" : " /MD")
@@ -1418,7 +1418,7 @@ sub vms_info {
                    release => "/O1i"),
         lflags           => combine("/nologo /opt:ref",
                                     sub { vc_wince_info()->{lflags}; },
-                                    sub { defined($ENV{PORTSDK_LIBPATH})
+                                    sub { defined(env('PORTSDK_LIBPATH'))
                                               ? "/entry:mainCRTstartup" : (); }),
         sys_id           => "WINCE",
         bn_ops           => "BN_LLONG EXPORT_VAR_AS_FN",
@@ -1426,9 +1426,9 @@ sub vms_info {
             my @ex_libs = ();
             push @ex_libs, 'ws2.lib' unless $disabled{sock};
             push @ex_libs, 'crypt32.lib';
-            if (defined($ENV{WCECOMPAT})) {
+            if (defined(env('WCECOMPAT'))) {
                 my $x = '$(WCECOMPAT)/lib';
-                if (-f "$x/$ENV{TARGETCPU}/wcecompatex.lib") {
+                if (-f "$x/env('TARGETCPU')/wcecompatex.lib") {
                     $x .= '/$(TARGETCPU)/wcecompatex.lib';
                 } else {
                     $x .= '/wcecompatex.lib';
@@ -1436,9 +1436,9 @@ sub vms_info {
                 push @ex_libs, $x;
             }
             push @ex_libs, '$(PORTSDK_LIBPATH)/portlib.lib'
-                if (defined($ENV{'PORTSDK_LIBPATH'}));
+                if (defined(env('PORTSDK_LIBPATH')));
             push @ex_libs, ' /nodefaultlib coredll.lib corelibc.lib'
-                if ($ENV{'TARGETCPU'} eq "X86");
+                if (env('TARGETCPU') eq "X86");
             return @ex_libs;
         }),
         build_scheme     => add("VC-WCE", { separator => undef }),
@@ -1738,35 +1738,35 @@ sub vms_info {
 #### uClinux
     "uClinux-dist" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "$ENV{'CC'}",
+        cc               => sub { env('CC') },
         cflags           => combine("\$(CFLAGS)",
                                     threads("-D_REENTRANT")),
         plib_lflags      => "\$(LDFLAGS)",
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
-        dso_scheme       => "$ENV{'LIBSSL_dlfcn'}",
+        dso_scheme       => sub { env('LIBSSL_dlfcn') },
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        ranlib           => "$ENV{'RANLIB'}",
+        ranlib           => sub { env('RANLIB') },
     },
     "uClinux-dist64" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "$ENV{'CC'}",
+        cc               => sub { env('CC') },
         cflags           => combine("\$(CFLAGS)",
                                     threads("-D_REENTRANT")),
         plib_lflags      => "\$(LDFLAGS)",
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
-        dso_scheme       => "$ENV{'LIBSSL_dlfcn'}",
+        dso_scheme       => sub { env('LIBSSL_dlfcn') },
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        ranlib           => "$ENV{'RANLIB'}",
+        ranlib           => sub { env('RANLIB') },
     },
 
     ##### VMS

--- a/Configure
+++ b/Configure
@@ -211,6 +211,8 @@ $config{builddir} = abs2rel($blddir);
 my @argvcopy=@ARGV;
 
 if (grep /^reconf(igure)?$/, @argvcopy) {
+    die "reconfiguring with other arguments present isn't supported"
+        if scalar @argvcopy > 1;
     if (-f "./configdata.pm") {
 	my $file = "./configdata.pm";
 	unless (my $return = do $file) {

--- a/Configure
+++ b/Configure
@@ -539,6 +539,14 @@ my @seed_sources = ();
 while (@argvcopy)
 	{
 	$_ = shift @argvcopy;
+
+	# Support env variable assignments among the options
+	if (m|^(\w+)=(.+)?$|)
+		{
+		$config{perlenv}->{$1} = $2;
+		next;
+		}
+
 	# VMS is a case insensitive environment, and depending on settings
 	# out of our control, we may receive options uppercased.  Let's
 	# downcase at least the part before any equal sign.
@@ -2530,8 +2538,12 @@ sub env
 {
     my $name = shift;
 
-    return $config{perlenv}->{$name} if exists $config{perlenv}->{$name};
-    $config{perlenv}->{$name} = $ENV{$name};
+    # Note that if $ENV{$name} doesn't exist or is undefined,
+    # $config{perlenv}->{$name} will be created with the value
+    # undef.  This is intentional.
+
+    $config{perlenv}->{$name} = $ENV{$name}
+        if ! exists $config{perlenv}->{$name};
     return $config{perlenv}->{$name};
 }
 

--- a/Configure
+++ b/Configure
@@ -225,8 +225,7 @@ if (grep /^reconf(igure)?$/, @argvcopy) {
 	    @{$configdata::config{perlargv}} : ();
 	die "Incorrect data to reconfigure, please do a normal configuration\n"
 	    if (grep(/^reconf/,@argvcopy));
-	$config{perlenv} = { defined($configdata::config{perlenv}) ?
-	    %{$configdata::config{perlenv}} : () };
+	$config{perlenv} = $configdata::config{perlenv} // {};
 
 	print "Reconfiguring with: ", join(" ",@argvcopy), "\n";
 	foreach (sort keys %{$config{perlenv}}) {

--- a/Configure
+++ b/Configure
@@ -223,25 +223,13 @@ if (grep /^reconf(igure)?$/, @argvcopy) {
 	    @{$configdata::config{perlargv}} : ();
 	die "Incorrect data to reconfigure, please do a normal configuration\n"
 	    if (grep(/^reconf/,@argvcopy));
-	$ENV{CROSS_COMPILE} = $configdata::config{cross_compile_prefix}
-	    if defined($configdata::config{cross_compile_prefix});
-	$ENV{CC} = $configdata::config{cc}
-	    if defined($configdata::config{cc});
-	$ENV{CXX} = $configdata::config{cxx}
-	    if defined($configdata::config{cxx});
-	$ENV{BUILDFILE} = $configdata::config{build_file}
-	    if defined($configdata::config{build_file});
-	$ENV{$local_config_envname} = $configdata::config{local_config_dir}
-	    if defined($configdata::config{local_config_dir});
+	$config{perlenv} = { defined($configdata::config{perlenv}) ?
+	    %{$configdata::config{perlenv}} : () };
 
 	print "Reconfiguring with: ", join(" ",@argvcopy), "\n";
-	print "    CROSS_COMPILE = ",$ENV{CROSS_COMPILE},"\n"
-	    if $ENV{CROSS_COMPILE};
-	print "    CC = ",$ENV{CC},"\n" if $ENV{CC};
-	print "    CXX = ",$ENV{CXX},"\n" if $ENV{CXX};
-	print "    BUILDFILE = ",$ENV{BUILDFILE},"\n" if $ENV{BUILDFILE};
-	print "    $local_config_envname = ",$ENV{$local_config_envname},"\n"
-	    if $ENV{$local_config_envname};
+	foreach (sort keys %{$config{perlenv}}) {
+	    print "    $_ = $config{perlenv}->{$_}\n";
+	}
     } else {
 	die "Insufficient data to reconfigure, please do a normal configuration\n";
     }
@@ -280,13 +268,13 @@ foreach (sort glob($pattern)) {
     &read_config($_);
 }
 
-if (defined $ENV{$local_config_envname}) {
+if (defined env($local_config_envname)) {
     if ($^O eq 'VMS') {
         # VMS environment variables are logical names,
         # which can be used as is
         $pattern = $local_config_envname . ':' . '*.conf';
     } else {
-        $pattern = catfile($ENV{$local_config_envname}, '*.conf');
+        $pattern = catfile(env($local_config_envname), '*.conf');
     }
 
     foreach (sort glob($pattern)) {
@@ -982,7 +970,7 @@ $target{dso_extension}=$target{shared_extension_simple};
     if ($config{target} =~ /^(?:Cygwin|mingw)/);
 
 
-$config{cross_compile_prefix} = $ENV{'CROSS_COMPILE'}
+$config{cross_compile_prefix} = env('CROSS_COMPILE')
     if $config{cross_compile_prefix} eq "";
 
 # Allow overriding the names of some tools.  USE WITH CARE
@@ -990,19 +978,19 @@ $config{cross_compile_prefix} = $ENV{'CROSS_COMPILE'}
 # the default string.
 $config{perl} =    ($^O ne "VMS" ? $^X : "perl");
 $config{hashbangperl} =
-    $ENV{'HASHBANGPERL'}           || $ENV{'PERL'}     || "/usr/bin/env perl";
-$target{cc} =      $ENV{'CC'}      || $target{cc}      || "cc";
-$target{cxx} =     $ENV{'CXX'}     || $target{cxx}     || "c++";
-$target{ranlib} =  $ENV{'RANLIB'}  || $target{ranlib}  ||
+    env('HASHBANGPERL')           || env('PERL')      || "/usr/bin/env perl";
+$target{cc} =      env('CC')      || $target{cc}      || "cc";
+$target{cxx} =     env('CXX')     || $target{cxx}     || "c++";
+$target{ranlib} =  env('RANLIB')  || $target{ranlib}  ||
                    (which("$config{cross_compile_prefix}ranlib") ?
                           "\$(CROSS_COMPILE)ranlib" : "true");
-$target{ar} =      $ENV{'AR'}      || $target{ar}      || "ar";
-$target{nm} =      $ENV{'NM'}      || $target{nm}      || "nm";
+$target{ar} =      env('AR')      || $target{ar}      || "ar";
+$target{nm} =      env('NM')      || $target{nm}      || "nm";
 $target{rc} =
-    $ENV{'RC'}  || $ENV{'WINDRES'} || $target{rc}      || "windres";
+    env('RC')  || env('WINDRES')  || $target{rc}      || "windres";
 
 # Allow overriding the build file name
-$target{build_file} = $ENV{BUILDFILE} || $target{build_file} || "Makefile";
+$target{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
 
 # Cache information necessary for reconfiguration
 $config{cc} = $target{cc};
@@ -1418,7 +1406,7 @@ if ($builder eq "unified") {
     my @build_file_templates = ();
 
     # First, look in the user provided directory, if given
-    if (defined $ENV{$local_config_envname}) {
+    if (defined env($local_config_envname)) {
 	@build_file_templates =
 	    map {
 		if ($^O eq 'VMS') {
@@ -1426,7 +1414,7 @@ if ($builder eq "unified") {
 		    # which can be used as is
 		    $local_config_envname . ':' . $_;
 		} else {
-		    catfile($ENV{$local_config_envname}, $_);
+		    catfile(env($local_config_envname), $_);
 		}
 	    }
 	    @build_file_template_names;
@@ -2009,6 +1997,22 @@ foreach (sort keys %config) {
 	print OUT "  ", $_, " => [ ", join(", ",
 					   map { quotify("perl", $_) }
 					   @{$config{$_}}), " ],\n";
+    } elsif (ref($config{$_}) eq "HASH") {
+	print OUT "  ", $_, " => {";
+        if (scalar keys %{$config{$_}} > 0) {
+            print OUT "\n";
+            foreach my $key (sort keys %{$config{$_}}) {
+                print OUT "      ",
+                    join(" => ",
+                         quotify("perl", $key),
+                         defined $config{$_}->{$key}
+                             ? quotify("perl", $config{$_}->{$key})
+                             : "undef");
+                print OUT ",\n";
+            }
+            print OUT "  ";
+        }
+        print OUT "},\n";
     } else {
 	print OUT "  ", $_, " => ", quotify("perl", $config{$_}), ",\n"
     }
@@ -2520,6 +2524,15 @@ sub which
             }
         }
     }
+}
+
+sub env
+{
+    my $name = shift;
+
+    return $config{perlenv}->{$name} if exists $config{perlenv}->{$name};
+    $config{perlenv}->{$name} = $ENV{$name};
+    return $config{perlenv}->{$name};
 }
 
 # Configuration printer ##############################################

--- a/INSTALL
+++ b/INSTALL
@@ -540,6 +540,22 @@
                    the corresponding value in the inherited environment, if
                    there is one.
 
+  reconf
+  reconfigure
+                   Reconfigure from earlier data.  This fetches the previous
+                   command line options and environment from data saved in
+                   "configdata.pm", and runs the configuration process again,
+                   using these options and environment.
+                   Note: NO other option is permitted together with "reconf".
+                   This means that you also MUST use "./Configure" (or
+                   what corresponds to that on non-Unix platforms) directly
+                   to invoke this option.
+                   Note: The original configuration saves away values for ALL
+                   environment variables that were used, and if they weren't
+                   defined, they are still saved away with information that
+                   they weren't originally defined.  This information takes
+                   precedence over environment variables that are defined
+                   when reconfiguring.
 
  Installation in Detail
  ----------------------

--- a/INSTALL
+++ b/INSTALL
@@ -532,6 +532,14 @@
                    passed through as they are to the compiler as well.  Again,
                    consult your compiler documentation.
 
+  VAR=value
+                   Assignment if environment variable for Configure.  These
+                   work just like normal environment variable assignments,
+                   but are supported on all platforms and are confined to
+                   the configuration scripts only.  These assignments override
+                   the corresponding value in the inherited environment, if
+                   there is one.
+
 
  Installation in Detail
  ----------------------

--- a/config
+++ b/config
@@ -35,7 +35,8 @@ See INSTALL for instructions.
 
 EOF
 ;;
-*) options=$options" $i" ;;
+*)  i=`echo "$i" | sed -e "s|'|'\\\\\\''|g"`
+    options="$options '$i'" ;;
 esac
 done
 
@@ -902,7 +903,9 @@ if [ $? = "0" ]; then
     echo $PERL $THERE/Configure $OUT $options
   fi  
   if [ "$DRYRUN" = "false" ]; then
-    $PERL $THERE/Configure $OUT $options
+    # eval to make sure quoted options, possibly with spaces inside,
+    # are treated right
+    eval $PERL $THERE/Configure $OUT $options
   fi
 else
   echo "This system ($OUT) is not supported. See file INSTALL for details."


### PR DESCRIPTION
For Unix, it's pretty easy to temporarly assign environment variables on the command line:

    CC=clang ./config

On other platforms, it's not as easy, so therefore, this implements an alternative (VMS shown as example):

    perl Configure "CC=whatevercc" vms-alpha

Futhermore, this also save away the environment values more effectively, and also makes sure the saved away values are used before anything on the environment when reconfiguring.