### PR TITLE
Guard engine reference counts properly.

### DIFF
--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2018 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -124,19 +124,13 @@ static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
 
 int ENGINE_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
 {
-    int ctrl_exists, ref_exists;
+    int ctrl_exists;
+
     if (e == NULL) {
         ENGINEerr(ENGINE_F_ENGINE_CTRL, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
-    ref_exists = ((e->struct_ref > 0) ? 1 : 0);
-    CRYPTO_THREAD_unlock(global_engine_lock);
-    ctrl_exists = ((e->ctrl == NULL) ? 0 : 1);
-    if (!ref_exists) {
-        ENGINEerr(ENGINE_F_ENGINE_CTRL, ENGINE_R_NO_REFERENCE);
-        return 0;
-    }
+    ctrl_exists = e->ctrl != NULL;
     /*
      * Intercept any "root-level" commands before trying to hand them on to
      * ctrl() handlers.

--- a/crypto/engine/eng_int.h
+++ b/crypto/engine/eng_int.h
@@ -65,7 +65,8 @@ extern CRYPTO_RWLOCK *global_engine_lock;
     } while (0)
 
 # define ENGINE_FUNCT_REF(e, i)                                 \
-    CRYPTO_atomic_read(&(e)->funct_ref, (i), (e)->lock)
+    *(i) = (e)->funct_ref
+
 /*
  * Any code that will need cleanup operations should use these functions to
  * register callbacks. engine_cleanup_int() will call all registered

--- a/crypto/engine/eng_pkey.c
+++ b/crypto/engine/eng_pkey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2018 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -54,19 +54,18 @@ EVP_PKEY *ENGINE_load_private_key(ENGINE *e, const char *key_id,
                                   UI_METHOD *ui_method, void *callback_data)
 {
     EVP_PKEY *pkey;
+    int ref_cnt;
 
     if (e == NULL) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PRIVATE_KEY,
                   ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
-    if (e->funct_ref == 0) {
-        CRYPTO_THREAD_unlock(global_engine_lock);
+    ENGINE_FUNCT_REF(e, &ref_cnt);
+    if (ref_cnt == 0) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PRIVATE_KEY, ENGINE_R_NOT_INITIALISED);
         return 0;
     }
-    CRYPTO_THREAD_unlock(global_engine_lock);
     if (!e->load_privkey) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PRIVATE_KEY,
                   ENGINE_R_NO_LOAD_FUNCTION);
@@ -85,19 +84,18 @@ EVP_PKEY *ENGINE_load_public_key(ENGINE *e, const char *key_id,
                                  UI_METHOD *ui_method, void *callback_data)
 {
     EVP_PKEY *pkey;
+    int ref_cnt;
 
     if (e == NULL) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PUBLIC_KEY,
                   ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
-    if (e->funct_ref == 0) {
-        CRYPTO_THREAD_unlock(global_engine_lock);
+    ENGINE_FUNCT_REF(e, &ref_cnt);
+    if (ref_cnt == 0) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PUBLIC_KEY, ENGINE_R_NOT_INITIALISED);
         return 0;
     }
-    CRYPTO_THREAD_unlock(global_engine_lock);
     if (!e->load_pubkey) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_PUBLIC_KEY, ENGINE_R_NO_LOAD_FUNCTION);
         return 0;
@@ -116,20 +114,19 @@ int ENGINE_load_ssl_client_cert(ENGINE *e, SSL *s,
                                 EVP_PKEY **ppkey, STACK_OF(X509) **pother,
                                 UI_METHOD *ui_method, void *callback_data)
 {
+    int ref_cnt;
 
     if (e == NULL) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_SSL_CLIENT_CERT,
                   ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
-    if (e->funct_ref == 0) {
-        CRYPTO_THREAD_unlock(global_engine_lock);
+    ENGINE_FUNCT_REF(e, &ref_cnt);
+    if (ref_cnt == 0) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_SSL_CLIENT_CERT,
                   ENGINE_R_NOT_INITIALISED);
         return 0;
     }
-    CRYPTO_THREAD_unlock(global_engine_lock);
     if (!e->load_ssl_client_cert) {
         ENGINEerr(ENGINE_F_ENGINE_LOAD_SSL_CLIENT_CERT,
                   ENGINE_R_NO_LOAD_FUNCTION);

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -186,6 +186,8 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_pkey_asn1_find_str(ENGINE **pe,
                                                       int len)
 {
     ENGINE_FIND_STR fstr;
+    int ref_cnt;
+
     fstr.e = NULL;
     fstr.ameth = NULL;
     fstr.str = str;
@@ -199,11 +201,9 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_pkey_asn1_find_str(ENGINE **pe,
     CRYPTO_THREAD_write_lock(global_engine_lock);
     engine_table_doall(pkey_asn1_meth_table, look_str_cb, &fstr);
     /* If found obtain a structural reference to engine */
-    if (fstr.e) {
-        fstr.e->struct_ref++;
-        engine_ref_debug(fstr.e, 0, 1);
-    }
-    *pe = fstr.e;
+    if (fstr.e)
+        ENGINE_UP_STRUCT_REF(fstr.e, &ref_cnt);
     CRYPTO_THREAD_unlock(global_engine_lock);
+    *pe = fstr.e;
     return fstr.ameth;
 }


### PR DESCRIPTION
The existing code uses both atomic operations and a global lock to guard changes to the `struct_ref` field in the engine structure.  These won't guard against each other.

The fix is to use one method or the other universally.  The difficulty is that atomic operations are performed inside locked blocks and atomic operations will lock on some platforms.  The solution used here is a per engine lock to guard the reference count mutables.

I've also removed some of the global locking and reduced the amount of code that is globally locked.