### PR TITLE
Fix error in return value evaluation in ECDH_compute_key

### DIFF
--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -131,14 +131,15 @@ int ECDH_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
 {
     unsigned char *sec = NULL;
     int ret;
+    const int error = -1;
     size_t seclen;
     if (eckey->meth->compute_key == NULL) {
         ECerr(EC_F_ECDH_COMPUTE_KEY, EC_R_OPERATION_NOT_SUPPORTED);
-        return 0;
+        return error;
     }
     if (outlen > INT_MAX) {
         ECerr(EC_F_ECDH_COMPUTE_KEY, EC_R_INVALID_OUTPUT_LENGTH);
-        return 0;
+        return error;
     }
     ret = eckey->meth->compute_key(&sec, &seclen, pub_key, eckey);
     if (ret <= 0)

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -130,6 +130,7 @@ int ECDH_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
                                    size_t *outlen))
 {
     unsigned char *sec = NULL;
+    int ret;
     size_t seclen;
     if (eckey->meth->compute_key == NULL) {
         ECerr(EC_F_ECDH_COMPUTE_KEY, EC_R_OPERATION_NOT_SUPPORTED);
@@ -139,8 +140,9 @@ int ECDH_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
         ECerr(EC_F_ECDH_COMPUTE_KEY, EC_R_INVALID_OUTPUT_LENGTH);
         return 0;
     }
-    if (!eckey->meth->compute_key(&sec, &seclen, pub_key, eckey))
-        return 0;
+    ret = eckey->meth->compute_key(&sec, &seclen, pub_key, eckey);
+    if (ret <= 0)
+        return ret;
     if (KDF != NULL) {
         KDF(sec, seclen, out, &outlen);
     } else {


### PR DESCRIPTION
Function compute_key, called in ECDH_compute_key returns "-1" in error cases. But ECDH_compute_key checks for not "0" only.

