### PR TITLE
WIP Resolve /WX errors on VC-WIN64

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2071,12 +2071,12 @@ static int WIN32_rename(const char *from, const char *to)
             goto err;
         tto = tfrom + flen;
 # if !defined(_WIN32_WCE) || _WIN32_WCE>=101
-        if (!MultiByteToWideChar(CP_ACP, 0, from, flen, (WCHAR *)tfrom, flen))
+        if (!MultiByteToWideChar(CP_ACP, 0, from, (int)flen, (WCHAR *)tfrom, (int)flen))
 # endif
             for (i = 0; i < flen; i++)
                 tfrom[i] = (TCHAR)from[i];
 # if !defined(_WIN32_WCE) || _WIN32_WCE>=101
-        if (!MultiByteToWideChar(CP_ACP, 0, to, tlen, (WCHAR *)tto, tlen))
+        if (!MultiByteToWideChar(CP_ACP, 0, to, (int)tlen, (WCHAR *)tto, (int)tlen))
 # endif
             for (i = 0; i < tlen; i++)
                 tto[i] = (TCHAR)to[i];

--- a/crypto/LPdir_win.c
+++ b/crypto/LPdir_win.c
@@ -105,13 +105,13 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
             do {
 # ifdef CP_UTF8
                 if ((sz = MultiByteToWideChar((cp = CP_UTF8), 0,
-                                              directory, len_0,
+                                              directory, (int)len_0,
                                               NULL, 0)) > 0 ||
                     GetLastError() != ERROR_NO_UNICODE_TRANSLATION)
                     break;
 # endif
                 sz = MultiByteToWideChar((cp = CP_ACP), 0,
-                                         directory, len_0,
+                                         directory, (int)len_0,
                                          NULL, 0);
             } while (0);
 
@@ -121,7 +121,7 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
                  * concatenate asterisk, |sz| covers trailing '\0'!
                  */
                 wdir = _alloca((sz + 2) * sizeof(TCHAR));
-                if (!MultiByteToWideChar(cp, 0, directory, len_0,
+                if (!MultiByteToWideChar(cp, 0, directory, (int)len_0,
                                          (WCHAR *)wdir, sz)) {
                     free(*ctx);
                     *ctx = NULL;
@@ -131,7 +131,7 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
             } else
 #endif
             {
-                sz = len_0;
+                sz = (int)len_0;
                 /*
                  * allocate two additional characters in case we need to
                  * concatenate asterisk, |sz| covers trailing '\0'!
@@ -186,7 +186,7 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
         len_0++;
 
 #ifdef LP_MULTIBYTE_AVAILABLE
-        if (!WideCharToMultiByte(CP_DEFAULT, 0, (WCHAR *)wdir, len_0,
+        if (!WideCharToMultiByte(CP_DEFAULT, 0, (WCHAR *)wdir, (int)len_0,
                                  (*ctx)->entry_name,
                                  sizeof((*ctx)->entry_name), NULL, 0))
 #endif

--- a/crypto/aes/aes_wrap.c
+++ b/crypto/aes/aes_wrap.c
@@ -15,13 +15,13 @@ int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out,
                  const unsigned char *in, unsigned int inlen)
 {
-    return CRYPTO_128_wrap(key, iv, out, in, inlen, (block128_f) AES_encrypt);
+    return (int)CRYPTO_128_wrap(key, iv, out, in, inlen, (block128_f) AES_encrypt);
 }
 
 int AES_unwrap_key(AES_KEY *key, const unsigned char *iv,
                    unsigned char *out,
                    const unsigned char *in, unsigned int inlen)
 {
-    return CRYPTO_128_unwrap(key, iv, out, in, inlen,
+    return (int)CRYPTO_128_unwrap(key, iv, out, in, inlen,
                              (block128_f) AES_decrypt);
 }

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -95,7 +95,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 {
     BUF_MEM *b;
     unsigned char *p;
-    int i;
+    ptrdiff_t i;
     size_t want = HEADER_SIZE;
     uint32_t eos = 0;
     size_t off = 0;
@@ -120,7 +120,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
                 ASN1err(ASN1_F_ASN1_D2I_READ_BIO, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
-            i = BIO_read(in, &(b->data[len]), want);
+            i = BIO_read(in, &(b->data[len]), (int)want);
             if ((i < 0) && ((len - off) == 0)) {
                 ASN1err(ASN1_F_ASN1_D2I_READ_BIO, ASN1_R_NOT_ENOUGH_DATA);
                 goto err;
@@ -137,7 +137,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 
         p = (unsigned char *)&(b->data[off]);
         q = p;
-        inf = ASN1_get_object(&q, &slen, &tag, &xclass, len - off);
+        inf = ASN1_get_object(&q, &slen, &tag, &xclass, (long)(len - off));
         if (inf & 0x80) {
             unsigned long e;
 
@@ -192,7 +192,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
                     }
                     want -= chunk;
                     while (chunk > 0) {
-                        i = BIO_read(in, &(b->data[len]), chunk);
+                        i = BIO_read(in, &(b->data[len]), (int)chunk);
                         if (i <= 0) {
                             ASN1err(ASN1_F_ASN1_D2I_READ_BIO,
                                     ASN1_R_NOT_ENOUGH_DATA);
@@ -227,7 +227,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
     }
 
     *pb = b;
-    return off;
+    return (int)off;
  err:
     BUF_MEM_free(b);
     return -1;

--- a/crypto/asn1/a_gentm.c
+++ b/crypto/asn1/a_gentm.c
@@ -36,7 +36,7 @@ int ASN1_GENERALIZEDTIME_set_string(ASN1_GENERALIZEDTIME *s, const char *str)
     ASN1_GENERALIZEDTIME t;
 
     t.type = V_ASN1_GENERALIZEDTIME;
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = 0;
 

--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -200,7 +200,7 @@ static size_t c2i_ibuf(unsigned char *b, int *pneg,
 
 int i2c_ASN1_INTEGER(ASN1_INTEGER *a, unsigned char **pp)
 {
-    return i2c_ibuf(a->data, a->length, a->type & V_ASN1_NEG, pp);
+    return (int)i2c_ibuf(a->data, a->length, a->type & V_ASN1_NEG, pp);
 }
 
 /* Convert big endian buffer into uint64_t, return 0 on error */
@@ -297,7 +297,7 @@ ASN1_INTEGER *c2i_ASN1_INTEGER(ASN1_INTEGER **a, const unsigned char **pp,
     } else
         ret = *a;
 
-    if (ASN1_STRING_set(ret, NULL, r) == 0)
+    if (ASN1_STRING_set(ret, NULL, (int)r) == 0)
         goto err;
 
     c2i_ibuf(ret->data, &neg, *pp, len);
@@ -347,7 +347,7 @@ static int asn1_string_set_int64(ASN1_STRING *a, int64_t r, int itype)
         off = asn1_put_uint64(tbuf, r);
         a->type &= ~V_ASN1_NEG;
     }
-    return ASN1_STRING_set(a, tbuf + off, sizeof(tbuf) - off);
+    return ASN1_STRING_set(a, tbuf + off, (int)(sizeof(tbuf) - off));
 }
 
 static int asn1_string_get_uint64(uint64_t *pr, const ASN1_STRING *a,
@@ -375,7 +375,7 @@ static int asn1_string_set_uint64(ASN1_STRING *a, uint64_t r, int itype)
 
     a->type = itype;
     off = asn1_put_uint64(tbuf, r);
-    return ASN1_STRING_set(a, tbuf + off, sizeof(tbuf) - off);
+    return ASN1_STRING_set(a, tbuf + off, (int)(sizeof(tbuf) - off));
 }
 
 /*
@@ -625,6 +625,6 @@ int i2c_uint64_int(unsigned char *p, uint64_t r, int neg)
     size_t off;
 
     off = asn1_put_uint64(buf, r);
-    return i2c_ibuf(buf + off, sizeof(buf) - off, neg, &p);
+    return (int)i2c_ibuf(buf + off, sizeof(buf) - off, neg, &p);
 }
 

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -52,7 +52,7 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
     char strbuf[32];
     int (*cpyfunc) (unsigned long, void *) = NULL;
     if (len == -1)
-        len = strlen((const char *)in);
+        len = (int)strlen((const char *)in);
     if (!mask)
         mask = DIRSTRING_TYPE;
 

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -51,7 +51,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
     if (num == 0)
         return 0;
     else if (num == -1)
-        num = strlen(buf);
+        num = (int)strlen(buf);
 
     p = buf;
     c = *(p++);

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -215,7 +215,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
     OPENSSL_free(signature->data);
     signature->data = buf_out;
     buf_out = NULL;
-    signature->length = outl;
+    signature->length = (int)outl;
     /*
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
@@ -225,5 +225,5 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
  err:
     OPENSSL_clear_free((char *)buf_in, (unsigned int)inl);
     OPENSSL_clear_free((char *)buf_out, outll);
-    return outl;
+    return (int)outl;
 }

--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -312,7 +312,7 @@ static int do_print_ex(char_io *io_ch, void *arg, unsigned long lflags,
     if (lflags & ASN1_STRFLGS_SHOW_TYPE) {
         const char *tagname;
         tagname = ASN1_tag2str(type);
-        outlen += strlen(tagname);
+        outlen += (int)strlen(tagname);
         if (!io_ch(arg, tagname, outlen) || !io_ch(arg, ":", 1))
             return -1;
         outlen++;
@@ -493,7 +493,7 @@ static int do_name_ex(char_io *io_ch, void *arg, const X509_NAME *n,
                     objbuf = "";
                 }
             }
-            objlen = strlen(objbuf);
+            objlen = (int)strlen(objbuf);
             if (!io_ch(arg, objbuf, objlen))
                 return -1;
             if ((objlen < fld_len) && (flags & XN_FLAG_FN_ALIGN)) {

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -283,7 +283,7 @@ ASN1_TIME *asn1_time_from_tm(ASN1_TIME *s, struct tm *ts, int type)
     if (tmps == NULL)
         return NULL;
 
-    if (!ASN1_STRING_set(tmps, NULL, len))
+    if (!ASN1_STRING_set(tmps, NULL, (int)len))
         goto err;
 
     tmps->type = type;
@@ -377,7 +377,7 @@ int ASN1_TIME_set_string_X509(ASN1_TIME *s, const char *str)
     struct tm tm;
     int rv = 0;
 
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = ASN1_STRING_FLAG_X509_TIME;
 

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -33,7 +33,7 @@ int ASN1_UTCTIME_set_string(ASN1_UTCTIME *s, const char *str)
     ASN1_UTCTIME t;
 
     t.type = V_ASN1_UTCTIME;
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = 0;
 

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -159,7 +159,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
         if (r & 0x80)
             goto err;
         /* Update copy length */
-        cpy_len -= cpy_start - orig_der;
+        cpy_len -= (int)(cpy_start - orig_der);
         /*
          * For IMPLICIT tagging the length should match the original length
          * and constructed flag should be consistent.
@@ -254,8 +254,8 @@ static int asn1_cb(const char *elem, int len, void *bitstr)
         /* Look for the ':' in name value pairs */
         if (*p == ':') {
             vstart = p + 1;
-            vlen = len - (vstart - elem);
-            len = p - elem;
+            vlen = len - (int)(vstart - elem);
+            len = (int)(p - elem);
             break;
         }
     }
@@ -363,7 +363,7 @@ static int parse_tagging(const char *vstart, int vlen, int *ptag, int *pclass)
     *ptag = tag_num;
     /* If we have non numeric characters, parse them */
     if (eptr)
-        vlen -= eptr - vstart;
+        vlen -= (int)(eptr - vstart);
     else
         vlen = 0;
     if (vlen) {
@@ -564,7 +564,7 @@ static int asn1_str2tag(const char *tagstr, int len)
     };
 
     if (len == -1)
-        len = strlen(tagstr);
+        len = (int)strlen(tagstr);
 
     tntmp = tnst;
     for (i = 0; i < OSSL_NELEM(tnst); i++, tntmp++) {

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -277,7 +277,7 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len)
         if (data == NULL)
             return 0;
         else
-            len = strlen(data);
+            len = (int)strlen(data);
     }
     if ((str->length <= len) || (str->data == NULL)) {
         c = str->data;

--- a/crypto/asn1/asn1_par.c
+++ b/crypto/asn1/asn1_par.c
@@ -95,7 +95,7 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
             ret = 0;
             goto end;
         }
-        hl = (p - op);
+        hl = (int)(p - op);
         length -= hl;
         /*
          * if j == 0x21 it is a constructed indefinite length object
@@ -128,14 +128,14 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
             if ((j == 0x21) && (len == 0)) {
                 for (;;) {
                     r = asn1_parse2(bp, &p, (long)(tot - p),
-                                    offset + (p - *pp), depth + 1,
+                                    offset + (int)(p - *pp), depth + 1,
                                     indent, dump);
                     if (r == 0) {
                         ret = 0;
                         goto end;
                     }
                     if ((r == 2) || (p >= tot)) {
-                        len = p - sp;
+                        len = (int)(p - sp);
                         break;
                     }
                 }
@@ -145,13 +145,13 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
                 while (p < ep) {
                     sp = p;
                     r = asn1_parse2(bp, &p, tmp,
-                                    offset + (p - *pp), depth + 1,
+                                    offset + (int)(p - *pp), depth + 1,
                                     indent, dump);
                     if (r == 0) {
                         ret = 0;
                         goto end;
                     }
-                    tmp -= p - sp;
+                    tmp -= (int)(p - sp);
                 }
             }
         } else if (xclass != 0) {

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -566,7 +566,7 @@ static int multi_split(BIO *bio, const char *bound, STACK_OF(BIO) **ret)
     STACK_OF(BIO) *parts;
     char state, part, first;
 
-    blen = strlen(bound);
+    blen = (int)strlen(bound);
     part = 0;
     state = 0;
     first = 1;
@@ -927,9 +927,9 @@ static void mime_param_free(MIME_PARAM *param)
 static int mime_bound_check(char *line, int linelen, const char *bound, int blen)
 {
     if (linelen == -1)
-        linelen = strlen(line);
+        linelen = (int)strlen(line);
     if (blen == -1)
-        blen = strlen(bound);
+        blen = (int)strlen(bound);
     /* Quickly eliminate if line length too short */
     if (blen + 2 > linelen)
         return 0;

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -296,7 +296,7 @@ static int asn1_bio_read(BIO *b, char *in, int inl)
 
 static int asn1_bio_puts(BIO *b, const char *str)
 {
-    return asn1_bio_write(b, str, strlen(str));
+    return asn1_bio_write(b, str, (int)strlen(str));
 }
 
 static int asn1_bio_gets(BIO *b, char *str, int size)

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -123,8 +123,7 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
 
     if (!*ndef_aux->boundary)
         return 0;
-
-    *plen = *ndef_aux->boundary - *pbuf;
+    *plen = (int)(*ndef_aux->boundary - *pbuf);
 
     return 1;
 }
@@ -193,7 +192,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     if (!*ndef_aux->boundary)
         return 0;
     *pbuf = *ndef_aux->boundary;
-    *plen = derlen - (*ndef_aux->boundary - ndef_aux->derbuf);
+    *plen = derlen - (int)(*ndef_aux->boundary - ndef_aux->derbuf);
 
     return 1;
 }

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -159,10 +159,10 @@ static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, size_t saltlen,
         saltlen = PKCS5_SALT_LEN;
 
     /* This will either copy salt or grow the buffer */
-    if (ASN1_STRING_set(sparam->salt, salt, saltlen) == 0)
+    if (ASN1_STRING_set(sparam->salt, salt, (int)saltlen) == 0)
         goto merr;
 
-    if (salt == NULL && RAND_bytes(sparam->salt->data, saltlen) <= 0)
+    if (salt == NULL && RAND_bytes(sparam->salt->data, (int)saltlen) <= 0)
         goto err;
 
     if (ASN1_INTEGER_set_uint64(sparam->costParameter, N) == 0)

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -276,7 +276,7 @@ static int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
         } else if (ret == -1)
             return -1;
         if (aux && (aux->flags & ASN1_AFLG_BROKEN)) {
-            len = tmplen - (p - *in);
+            len = tmplen - (long)(p - *in);
             seq_nolen = 1;
         }
         /* If indefinite we don't do a length check */
@@ -325,7 +325,7 @@ static int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
                     ASN1err(ASN1_F_ASN1_ITEM_EMBED_D2I, ASN1_R_UNEXPECTED_EOC);
                     goto err;
                 }
-                len -= p - q;
+                len -= (long)(p - q);
                 seq_eoc = 0;
                 q = p;
                 break;
@@ -356,7 +356,7 @@ static int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
                 continue;
             }
             /* Update length */
-            len -= p - q;
+            len -= (long)(p - q);
         }
 
         /* Check for EOC if expecting one */
@@ -391,7 +391,7 @@ static int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
             }
         }
         /* Save encoding */
-        if (!asn1_enc_save(pval, *in, p - *in, it))
+        if (!asn1_enc_save(pval, *in, (int)(p - *in), it))
             goto auxerr;
         if (asn1_cb && !asn1_cb(ASN1_OP_D2I_POST, pval, it, NULL))
             goto auxerr;
@@ -461,7 +461,7 @@ static int asn1_template_ex_d2i(ASN1_VALUE **val,
             return 0;
         }
         /* We read the field in OK so update length */
-        len -= p - q;
+        len -= (long)(p - q);
         if (exp_eoc) {
             /* If NDEF we must have an EOC here */
             if (!asn1_check_eoc(&p, len)) {
@@ -567,7 +567,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
                             ASN1_R_UNEXPECTED_EOC);
                     goto err;
                 }
-                len -= p - q;
+                len -= (long)(p - q);
                 sk_eoc = 0;
                 break;
             }
@@ -580,7 +580,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
                 ASN1_item_free(skfield, ASN1_ITEM_ptr(tt->item));
                 goto err;
             }
-            len -= p - q;
+            len -= (long)(p - q);
             if (!sk_ASN1_VALUE_push((STACK_OF(ASN1_VALUE) *)*val, skfield)) {
                 ASN1err(ASN1_F_ASN1_TEMPLATE_NOEXP_D2I, ERR_R_MALLOC_FAILURE);
                 ASN1_item_free(skfield, ASN1_ITEM_ptr(tt->item));
@@ -700,9 +700,9 @@ static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
         if (inf) {
             if (!asn1_find_end(&p, plen, inf))
                 goto err;
-            len = p - cont;
+            len = (long)(p - cont);
         } else {
-            len = p - cont + plen;
+            len = (long)(p - cont) + plen;
             p += plen;
         }
     } else if (cst) {
@@ -724,7 +724,7 @@ static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
         if (!asn1_collect(&buf, &p, plen, inf, -1, V_ASN1_UNIVERSAL, 0)) {
             goto err;
         }
-        len = buf.length;
+        len = (long)buf.length;
         /* Append a final null to string */
         if (!BUF_MEM_grow_clean(&buf, len + 1)) {
             ASN1err(ASN1_F_ASN1_D2I_EX_PRIMITIVE, ERR_R_MALLOC_FAILURE);
@@ -937,7 +937,7 @@ static int asn1_find_end(const unsigned char **in, long len, char inf)
         } else {
             p += plen;
         }
-        len -= p - q;
+        len -= (long)(p - q);
     }
     if (expected_eoc) {
         ASN1err(ASN1_F_ASN1_FIND_END, ASN1_R_MISSING_EOC);
@@ -1010,7 +1010,7 @@ static int asn1_collect(BUF_MEM *buf, const unsigned char **in, long len,
                 return 0;
         } else if (plen && !collect_data(buf, &p, plen))
             return 0;
-        len -= p - q;
+        len -= (long)(p - q);
     }
     if (inf) {
         ASN1err(ASN1_F_ASN1_COLLECT, ASN1_R_MISSING_EOC);
@@ -1022,9 +1022,9 @@ static int asn1_collect(BUF_MEM *buf, const unsigned char **in, long len,
 
 static int collect_data(BUF_MEM *buf, const unsigned char **p, long plen)
 {
-    int len;
+    long len;
     if (buf) {
-        len = buf->length;
+        len = (long)buf->length;
         if (!BUF_MEM_grow_clean(buf, len + plen)) {
             ASN1err(ASN1_F_COLLECT_DATA, ERR_R_MALLOC_FAILURE);
             return 0;
@@ -1082,7 +1082,7 @@ static int asn1_check_tlen(long *olen, int *otag, unsigned char *oclass,
             ctx->plen = plen;
             ctx->pclass = pclass;
             ctx->ptag = ptag;
-            ctx->hdrlen = p - q;
+            ctx->hdrlen = (int)(p - q);
             ctx->valid = 1;
             /*
              * If definite length, and no error, length + header can't exceed
@@ -1120,7 +1120,7 @@ static int asn1_check_tlen(long *olen, int *otag, unsigned char *oclass,
     }
 
     if (i & 1)
-        plen = len - (p - q);
+        plen = len - (long)(p - q);
 
     if (inf)
         *inf = i & 1;

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -336,7 +336,7 @@ int ASYNC_init_thread(size_t max_size, size_t init_size)
         return 0;
     }
 
-    pool->jobs = sk_ASYNC_JOB_new_reserve(NULL, init_size);
+    pool->jobs = sk_ASYNC_JOB_new_reserve(NULL, (int)init_size);
     if (pool->jobs == NULL) {
         ASYNCerr(ASYNC_F_ASYNC_INIT_THREAD, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(pool);

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -389,7 +389,7 @@ int BIO_ADDRINFO_protocol(const BIO_ADDRINFO *bai)
 socklen_t BIO_ADDRINFO_sockaddr_size(const BIO_ADDRINFO *bai)
 {
     if (bai != NULL)
-        return bai->bai_addrlen;
+        return (socklen_t)bai->bai_addrlen;
     return 0;
 }
 

--- a/crypto/bio/b_dump.c
+++ b/crypto/bio/b_dump.c
@@ -108,7 +108,7 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
 #ifndef OPENSSL_NO_STDIO
 static int write_fp(const void *data, size_t len, void *fp)
 {
-    return UP_fwrite(data, len, 1, fp);
+    return (int)UP_fwrite(data, len, 1, fp);
 }
 
 int BIO_dump_fp(FILE *fp, const char *s, int len)
@@ -124,7 +124,7 @@ int BIO_dump_indent_fp(FILE *fp, const char *s, int len, int indent)
 
 static int write_bio(const void *data, size_t len, void *bp)
 {
-    return BIO_write((BIO *)bp, (const char *)data, len);
+    return BIO_write((BIO *)bp, (const char *)data, (int)len);
 }
 
 int BIO_dump(BIO *bp, const char *s, int len)

--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -140,9 +140,9 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
             if (p - in > 0) {
                 if (i >= p - in) {
                     memcpy(&(ctx->obuf[ctx->obuf_len]), in, p - in);
-                    ctx->obuf_len += p - in;
-                    inl -= p - in;
-                    num += p - in;
+                    ctx->obuf_len += (int)(p - in);
+                    inl -= (int)(p - in);
+                    num += (int)(p - in);
                     in = p;
                 } else {
                     memcpy(&(ctx->obuf[ctx->obuf_len]), in, i);
@@ -172,7 +172,7 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
          * if a NL was found and there is anything to write.
          */
         if ((foundnl || p - in > ctx->obuf_size) && p - in > 0) {
-            i = BIO_write(b->next_bio, in, p - in);
+            i = BIO_write(b->next_bio, in, (int)(p - in));
             if (i <= 0) {
                 BIO_copy_next_retry(b);
                 if (i < 0)

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -55,7 +55,7 @@ static long bio_call_callback(BIO *b, int oper, const char *argp, size_t len,
         if (inret && (oper & BIO_CB_RETURN)) {
             if (*processed > INT_MAX)
                 return -1;
-            inret = *processed;
+            inret = (long)*processed;
         }
     }
 

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -185,7 +185,7 @@ static int bio_read(BIO *bio, char *buf, int size_)
     }
     while (rest);
 
-    return size;
+    return (int)size;
 }
 
 /*-
@@ -334,7 +334,7 @@ static int bio_write(BIO *bio, const char *buf, int num_)
     }
     while (rest);
 
-    return num;
+    return (int)num;
 }
 
 /*-
@@ -476,7 +476,7 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
         if (b->peer == NULL || b->closed)
             ret = 0;
         else
-            ret = (long)b->size - b->len;
+            ret = (long)(b->size - b->len);
         break;
 
     case BIO_C_GET_READ_REQUEST:
@@ -697,12 +697,12 @@ int BIO_new_bio_pair(BIO **bio1_p, size_t writebuf1,
         goto err;
 
     if (writebuf1) {
-        r = BIO_set_write_buf_size(bio1, writebuf1);
+        r = BIO_set_write_buf_size(bio1, (long)writebuf1);
         if (!r)
             goto err;
     }
     if (writebuf2) {
-        r = BIO_set_write_buf_size(bio2, writebuf2);
+        r = BIO_set_write_buf_size(bio2, (long)writebuf2);
         if (!r)
             goto err;
     }

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -117,7 +117,7 @@ static int fd_read(BIO *b, char *out, int outl)
 
     if (out != NULL) {
         clear_sys_error();
-        ret = UP_read(b->num, out, outl);
+        ret = (int)UP_read(b->num, out, outl);
         BIO_clear_retry_flags(b);
         if (ret <= 0) {
             if (BIO_fd_should_retry(ret))
@@ -131,7 +131,7 @@ static int fd_write(BIO *b, const char *in, int inl)
 {
     int ret;
     clear_sys_error();
-    ret = UP_write(b->num, in, inl);
+    ret = (int)UP_write(b->num, in, inl);
     BIO_clear_retry_flags(b);
     if (ret <= 0) {
         if (BIO_fd_should_retry(ret))

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -143,9 +143,9 @@ static int file_read(BIO *b, char *out, int outl)
 
     if (b->init && (out != NULL)) {
         if (b->flags & BIO_FLAGS_UPLINK)
-            ret = UP_fread(out, 1, (int)outl, b->ptr);
+            ret = (int)UP_fread(out, 1, (int)outl, b->ptr);
         else
-            ret = fread(out, 1, (int)outl, (FILE *)b->ptr);
+            ret = (int)fread(out, 1, (int)outl, (FILE *)b->ptr);
         if (ret == 0
             && (b->flags & BIO_FLAGS_UPLINK) ? UP_ferror((FILE *)b->ptr) :
                                                ferror((FILE *)b->ptr)) {
@@ -163,9 +163,9 @@ static int file_write(BIO *b, const char *in, int inl)
 
     if (b->init && (in != NULL)) {
         if (b->flags & BIO_FLAGS_UPLINK)
-            ret = UP_fwrite(in, (int)inl, 1, b->ptr);
+            ret = (int)UP_fwrite(in, (int)inl, 1, b->ptr);
         else
-            ret = fwrite(in, (int)inl, 1, (FILE *)b->ptr);
+            ret = (int)fwrite(in, (int)inl, 1, (FILE *)b->ptr);
         if (ret)
             ret = inl;
         /* ret=fwrite(in,1,(int)inl,(FILE *)b->ptr); */

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -220,7 +220,7 @@ static int mem_write(BIO *b, const char *in, int inl)
         goto end;
     }
     BIO_clear_retry_flags(b);
-    blen = bbm->readp->length;
+    blen = (int)bbm->readp->length;
     mem_buf_sync(b);
     if (BUF_MEM_grow_clean(bbm->buf, blen + inl) == 0)
         goto end;
@@ -317,7 +317,7 @@ static int mem_gets(BIO *bp, char *buf, int size)
     BUF_MEM *bm = bbm->readp;
 
     BIO_clear_retry_flags(bp);
-    j = bm->length;
+    j = (int)bm->length;
     if ((size - 1) < j)
         j = size - 1;
     if (j <= 0) {

--- a/crypto/blake2/blake2s.c
+++ b/crypto/blake2/blake2s.c
@@ -134,7 +134,7 @@ static void blake2s_compress(BLAKE2S_CTX *S,
         }
 
         /* blake2s_increment_counter */
-        S->t[0] += increment;
+        S->t[0] += (uint32_t)increment;
         S->t[1] += (S->t[0] < increment);
 
         v[ 8] = blake2s_IV[0];

--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -96,7 +96,7 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
         carry &= (t2 == 0);
     }
     *rp = carry;
-    r->top += carry;
+    r->top += (int)carry;
 
     r->neg = 0;
     bn_check_top(r);

--- a/crypto/bn/bn_intern.c
+++ b/crypto/bn/bn_intern.c
@@ -25,7 +25,7 @@ signed char *bn_compute_wNAF(const BIGNUM *scalar, int w, size_t *ret_len)
     signed char *r = NULL;
     int sign = 1;
     int bit, next_bit, mask;
-    size_t len = 0, j;
+    int len = 0, j;
 
     if (BN_is_zero(scalar)) {
         r = OPENSSL_malloc(1);

--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -121,7 +121,7 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
         int bl;
         if (!EVP_CIPHER_CTX_cipher(ctx->cctx))
             return 0;
-        if (!EVP_CIPHER_CTX_set_key_length(ctx->cctx, keylen))
+        if (!EVP_CIPHER_CTX_set_key_length(ctx->cctx, (int)keylen))
             return 0;
         if (!EVP_EncryptInit_ex(ctx->cctx, NULL, NULL, key, zero_iv))
             return 0;
@@ -144,7 +144,7 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
 int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
 {
     const unsigned char *data = in;
-    size_t bl;
+    int bl;
     if (ctx->nlast_block == -1)
         return 0;
     if (dlen == 0)
@@ -158,7 +158,7 @@ int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
             nleft = dlen;
         memcpy(ctx->last_block + ctx->nlast_block, data, nleft);
         dlen -= nleft;
-        ctx->nlast_block += nleft;
+        ctx->nlast_block += (int)nleft;
         /* If no more to process return */
         if (dlen == 0)
             return 1;
@@ -168,7 +168,7 @@ int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
             return 0;
     }
     /* Encrypt all but one of the complete blocks left */
-    while (dlen > bl) {
+    while (dlen > (unsigned int)bl) {
         if (!EVP_Cipher(ctx->cctx, ctx->tbl, data, bl))
             return 0;
         dlen -= bl;
@@ -176,7 +176,7 @@ int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
     }
     /* Copy any data left to last block buffer */
     memcpy(ctx->last_block, data, dlen);
-    ctx->nlast_block = dlen;
+    ctx->nlast_block = (int)dlen;
     return 1;
 
 }

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -106,7 +106,7 @@ BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec)
 
     if (ec->keylen != tkeylen) {
         /* If necessary set key length */
-        if (EVP_CIPHER_CTX_set_key_length(ctx, ec->keylen) <= 0) {
+        if (EVP_CIPHER_CTX_set_key_length(ctx, (int)ec->keylen) <= 0) {
             /*
              * Only reveal failure if debugging so we don't leak information
              * which may be useful in MMA.

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -339,7 +339,7 @@ static int cms_RecipientInfo_ktri_encrypt(CMS_ContentInfo *cms,
     if (EVP_PKEY_encrypt(pctx, ek, &eklen, ec->key, ec->keylen) <= 0)
         goto err;
 
-    ASN1_STRING_set0(ktri->encryptedKey, ek, eklen);
+    ASN1_STRING_set0(ktri->encryptedKey, ek, (int)eklen);
     ek = NULL;
 
     ret = 1;
@@ -536,7 +536,7 @@ CMS_RecipientInfo *CMS_add0_recipient_key(CMS_ContentInfo *cms, int nid,
     kekri->key = key;
     kekri->keylen = keylen;
 
-    ASN1_STRING_set0(kekri->kekid->keyIdentifier, id, idlen);
+    ASN1_STRING_set0(kekri->kekid->keyIdentifier, id, (int)idlen);
 
     kekri->kekid->date = date;
 
@@ -628,7 +628,7 @@ static int cms_RecipientInfo_kekri_encrypt(CMS_ContentInfo *cms,
         return 0;
     }
 
-    if (AES_set_encrypt_key(kekri->key, kekri->keylen << 3, &actx)) {
+    if (AES_set_encrypt_key(kekri->key, (int)kekri->keylen << 3, &actx)) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT,
                CMS_R_ERROR_SETTING_KEY);
         goto err;
@@ -641,7 +641,7 @@ static int cms_RecipientInfo_kekri_encrypt(CMS_ContentInfo *cms,
         goto err;
     }
 
-    wkeylen = AES_wrap_key(&actx, NULL, wkey, ec->key, ec->keylen);
+    wkeylen = AES_wrap_key(&actx, NULL, wkey, ec->key, (int)ec->keylen);
 
     if (wkeylen <= 0) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, CMS_R_WRAP_ERROR);
@@ -698,7 +698,7 @@ static int cms_RecipientInfo_kekri_decrypt(CMS_ContentInfo *cms,
         goto err;
     }
 
-    if (AES_set_decrypt_key(kekri->key, kekri->keylen << 3, &actx)) {
+    if (AES_set_decrypt_key(kekri->key, (int)kekri->keylen << 3, &actx)) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT,
                CMS_R_ERROR_SETTING_KEY);
         goto err;

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -203,12 +203,12 @@ static int cms_kek_cipher(unsigned char **pout, size_t *poutlen,
     if (!EVP_CipherInit_ex(kari->ctx, NULL, NULL, kek, NULL, enc))
         goto err;
     /* obtain output length of ciphered key */
-    if (!EVP_CipherUpdate(kari->ctx, NULL, &outlen, in, inlen))
+    if (!EVP_CipherUpdate(kari->ctx, NULL, &outlen, in, (int)inlen))
         goto err;
     out = OPENSSL_malloc(outlen);
     if (out == NULL)
         goto err;
-    if (!EVP_CipherUpdate(kari->ctx, out, &outlen, in, inlen))
+    if (!EVP_CipherUpdate(kari->ctx, out, &outlen, in, (int)inlen))
         goto err;
     *pout = out;
     *poutlen = (size_t)outlen;
@@ -403,7 +403,7 @@ int cms_RecipientInfo_kari_encrypt(CMS_ContentInfo *cms,
         if (!cms_kek_cipher(&enckey, &enckeylen, ec->key, ec->keylen,
                             kari, 1))
             return 0;
-        ASN1_STRING_set0(rek->encryptedKey, enckey, enckeylen);
+        ASN1_STRING_set0(rek->encryptedKey, enckey, (int)enckeylen);
     }
 
     return 1;

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -591,7 +591,7 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
             OPENSSL_free(sig);
             goto err;
         }
-        ASN1_STRING_set0(si->signature, sig, siglen);
+        ASN1_STRING_set0(si->signature, sig, (int)siglen);
     } else {
         unsigned char *sig;
         unsigned int siglen;
@@ -688,7 +688,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
 
     EVP_MD_CTX_reset(mctx);
 
-    ASN1_STRING_set0(si->signature, abuf, siglen);
+    ASN1_STRING_set0(si->signature, abuf, (int)siglen);
 
     return 1;
 

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -207,7 +207,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
         *p = '\0';
         BIO_gets(in, p, CONFBUFSIZE - 1);
         p[CONFBUFSIZE - 1] = '\0';
-        ii = i = strlen(p);
+        ii = i = (int)strlen(p);
         if (i == 0 && !again)
             break;
         again = 0;
@@ -411,7 +411,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
     if ((buf = BUF_MEM_new()) == NULL)
         return 0;
 
-    len = strlen(from) + 1;
+    len = (int)strlen(from) + 1;
     if (!BUF_MEM_grow(buf, len))
         goto err;
 
@@ -533,7 +533,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
              * Since we change the pointer 'from', we also have to change the
              * perceived length of the string it points at.  /RL
              */
-            len -= e - from;
+            len -= (int)(e - from);
             from = e;
 
             /*

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -268,9 +268,9 @@ static CONF_MODULE *module_find(const char *name)
     p = strrchr(name, '.');
 
     if (p)
-        nchar = p - name;
+        nchar = (int)(p - name);
     else
-        nchar = strlen(name);
+        nchar = (int)strlen(name);
 
     for (i = 0; i < sk_CONF_MODULE_num(supported_modules); i++) {
         tmod = sk_CONF_MODULE_value(supported_modules, i);
@@ -483,12 +483,12 @@ char *CONF_get1_default_config_file(void)
     if (file)
         return OPENSSL_strdup(file);
 
-    len = strlen(X509_get_default_cert_area());
+    len = (int)strlen(X509_get_default_cert_area());
 #ifndef OPENSSL_SYS_VMS
     len++;
     sep = "/";
 #endif
-    len += strlen(OPENSSL_CONF);
+    len += (int)strlen(OPENSSL_CONF);
 
     file = OPENSSL_malloc(len + 1);
 
@@ -537,7 +537,7 @@ int CONF_parse_list(const char *list_, int sep, int nospc,
                 while (isspace((unsigned char)*tmpend))
                     tmpend--;
             }
-            ret = list_cb(lstart, tmpend - lstart + 1, arg);
+            ret = list_cb(lstart, (int)(tmpend - lstart + 1), arg);
         }
         if (ret <= 0)
             return ret;

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -141,7 +141,7 @@ int OPENSSL_isservice(void)
     }
 
     if (_OPENSSL_isservice.p != (void *)-1)
-        return (*_OPENSSL_isservice.f) ();
+        return (int)(*_OPENSSL_isservice.f) ();
 
     h = GetProcessWindowStation();
     if (h == NULL)
@@ -216,7 +216,7 @@ void OPENSSL_showfatal(const char *fmta, ...)
     else
         do {
             int keepgoing;
-            size_t len_0 = strlen(fmta) + 1, i;
+            int len_0 = (int)strlen(fmta) + 1, i;
             WCHAR *fmtw;
 
             fmtw = (WCHAR *)alloca(len_0 * sizeof(WCHAR));

--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -23,7 +23,7 @@
  */
 static int ct_base64_decode(const char *in, unsigned char **out)
 {
-    size_t inlen = strlen(in);
+    int inlen = (int)strlen(in);
     int outlen, i;
     unsigned char *outbuf = NULL;
 

--- a/crypto/ct/ct_oct.c
+++ b/crypto/ct/ct_oct.c
@@ -64,7 +64,7 @@ int o2i_SCT_signature(SCT *sct, const unsigned char **in, size_t len)
     len_remaining -= siglen;
     *in = p + siglen;
 
-    return len - len_remaining;
+    return (int)(len - len_remaining);
 }
 
 SCT *o2i_SCT(SCT **psct, const unsigned char **in, size_t len)
@@ -152,7 +152,7 @@ err:
 
 int i2o_SCT_signature(const SCT *sct, unsigned char **out)
 {
-    size_t len;
+    int len;
     unsigned char *p = NULL, *pstart = NULL;
 
     if (!SCT_signature_is_complete(sct)) {
@@ -170,7 +170,7 @@ int i2o_SCT_signature(const SCT *sct, unsigned char **out)
     * (1 byte) Signature algorithm
     * (2 bytes + ?) Signature
     */
-    len = 4 + sct->sig_len;
+    len = (int)(4 + sct->sig_len);
 
     if (out != NULL) {
         if (*out != NULL) {
@@ -199,7 +199,7 @@ err:
 
 int i2o_SCT(const SCT *sct, unsigned char **out)
 {
-    size_t len;
+    int len;
     unsigned char *p = NULL, *pstart = NULL;
 
     if (!SCT_is_complete(sct)) {
@@ -213,9 +213,9 @@ int i2o_SCT(const SCT *sct, unsigned char **out)
      * bytes + ?) Signature
      */
     if (sct->version == SCT_VERSION_V1)
-        len = 43 + sct->ext_len + 4 + sct->sig_len;
+        len = (int)(43 + sct->ext_len + 4 + sct->sig_len);
     else
-        len = sct->sct_len;
+        len = (int)sct->sct_len;
 
     if (out == NULL)
         return len;
@@ -321,7 +321,7 @@ STACK_OF(SCT) *o2i_SCT_LIST(STACK_OF(SCT) **a, const unsigned char **pp,
 int i2o_SCT_LIST(const STACK_OF(SCT) *a, unsigned char **pp)
 {
     int len, sct_len, i, is_pp_new = 0;
-    size_t len2;
+    int len2;
     unsigned char *p = NULL, *p2;
 
     if (pp != NULL) {

--- a/crypto/ct/ct_prn.c
+++ b/crypto/ct/ct_prn.c
@@ -82,7 +82,7 @@ void SCT_print(const SCT *sct, BIO *out, int indent,
 
     if (sct->version != SCT_VERSION_V1) {
         BIO_printf(out, "unknown\n%*s", indent + 16, "");
-        BIO_hex_string(out, indent + 16, 16, sct->sct, sct->sct_len);
+        BIO_hex_string(out, indent + 16, 16, sct->sct, (int)sct->sct_len);
         return;
     }
 
@@ -94,7 +94,7 @@ void SCT_print(const SCT *sct, BIO *out, int indent,
     }
 
     BIO_printf(out, "\n%*sLog ID    : ", indent + 4, "");
-    BIO_hex_string(out, indent + 16, 16, sct->log_id, sct->log_id_len);
+    BIO_hex_string(out, indent + 16, 16, sct->log_id, (int)sct->log_id_len);
 
     BIO_printf(out, "\n%*sTimestamp : ", indent + 4, "");
     timestamp_print(sct->timestamp, out);
@@ -103,12 +103,12 @@ void SCT_print(const SCT *sct, BIO *out, int indent,
     if (sct->ext_len == 0)
         BIO_printf(out, "none");
     else
-        BIO_hex_string(out, indent + 16, 16, sct->ext, sct->ext_len);
+        BIO_hex_string(out, indent + 16, 16, sct->ext, (int)sct->ext_len);
 
     BIO_printf(out, "\n%*sSignature : ", indent + 4, "");
     SCT_signature_algorithms_print(sct, out);
     BIO_printf(out, "\n%*s            ", indent + 4, "");
-    BIO_hex_string(out, indent + 16, 16, sct->sig, sct->sig_len);
+    BIO_hex_string(out, indent + 16, 16, sct->sig, (int)sct->sig_len);
 }
 
 void SCT_LIST_print(const STACK_OF(SCT) *sct_list, BIO *out, int indent,

--- a/crypto/des/str2key.c
+++ b/crypto/des/str2key.c
@@ -16,7 +16,7 @@ void DES_string_to_key(const char *str, DES_cblock *key)
     int i, length;
 
     memset(key, 0, 8);
-    length = strlen(str);
+    length = (int)strlen(str);
     for (i = 0; i < length; i++) {
         register unsigned char j = str[i];
 
@@ -44,7 +44,7 @@ void DES_string_to_2keys(const char *str, DES_cblock *key1, DES_cblock *key2)
 
     memset(key1, 0, 8);
     memset(key2, 0, 8);
-    length = strlen(str);
+    length = (int)strlen(str);
     for (i = 0; i < length; i++) {
         register unsigned char j = str[i];
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -674,7 +674,7 @@ static int dh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
     ASN1_OCTET_STRING *ukm;
     const unsigned char *p;
     unsigned char *dukm = NULL;
-    size_t dukmlen = 0;
+    int dukmlen = 0;
     int keylen, plen;
     const EVP_CIPHER *kekcipher;
     EVP_CIPHER_CTX *kekctx;
@@ -784,7 +784,7 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
     ASN1_OCTET_STRING *ukm;
     unsigned char *penc = NULL, *dukm = NULL;
     int penclen;
-    size_t dukmlen = 0;
+    int dukmlen = 0;
     int rv = 0;
     int kdf_type, wrap_nid;
     const EVP_MD *kdf_md;

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -36,7 +36,7 @@ static int skip_asn1(unsigned char **pp, long *plen, int exptag)
         return 0;
     if (tag == V_ASN1_OBJECT)
         q += tmplen;
-    *plen -= q - *pp;
+    *plen -= (long)(q - *pp);
     *pp = (unsigned char *)q;
     return 1;
 }
@@ -72,11 +72,11 @@ static int dh_sharedinfo_encode(unsigned char **pder, unsigned char **pctr,
         ukm_oct.type = V_ASN1_OCTET_STRING;
         ukm_oct.flags = 0;
         ukm_oct.data = (unsigned char *)ukm;
-        ukm_oct.length = ukmlen;
+        ukm_oct.length = (int)ukmlen;
         pukm_oct = &ukm_oct;
     } else
         pukm_oct = NULL;
-    derlen = CMS_SharedInfo_encode(pder, &atmp, pukm_oct, outlen);
+    derlen = CMS_SharedInfo_encode(pder, &atmp, pukm_oct, (int)outlen);
     if (derlen <= 0)
         return 0;
     p = *pder;

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -187,7 +187,7 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     case EVP_PKEY_CTRL_GET_DH_KDF_OUTLEN:
-        *(int *)p2 = dctx->kdf_outlen;
+        *(int *)p2 = (int)dctx->kdf_outlen;
         return 1;
 
     case EVP_PKEY_CTRL_DH_KDF_UKM:
@@ -201,7 +201,7 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case EVP_PKEY_CTRL_GET_DH_KDF_UKM:
         *(unsigned char **)p2 = dctx->kdf_ukm;
-        return dctx->kdf_ukmlen;
+        return (int)dctx->kdf_ukmlen;
 
     case EVP_PKEY_CTRL_DH_KDF_OID:
         ASN1_OBJECT_free(dctx->kdf_oid);
@@ -271,16 +271,16 @@ static int pkey_dh_ctrl_str(EVP_PKEY_CTX *ctx,
 
 #ifndef OPENSSL_NO_DSA
 
-extern int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
+extern int dsa_builtin_paramgen(DSA *ret, int bits, int qbits,
                                 const EVP_MD *evpmd,
-                                const unsigned char *seed_in, size_t seed_len,
+                                const unsigned char *seed_in, int seed_len,
                                 unsigned char *seed_out, int *counter_ret,
                                 unsigned long *h_ret, BN_GENCB *cb);
 
-extern int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
+extern int dsa_builtin_paramgen2(DSA *ret, int L, int N,
                                  const EVP_MD *evpmd,
                                  const unsigned char *seed_in,
-                                 size_t seed_len, int idx,
+                                 int seed_len, int idx,
                                  unsigned char *seed_out, int *counter_ret,
                                  unsigned long *h_ret, BN_GENCB *cb);
 

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -33,7 +33,7 @@ int DSA_generate_parameters_ex(DSA *ret, int bits,
                                        counter_ret, h_ret, cb);
     else {
         const EVP_MD *evpmd = bits >= 2048 ? EVP_sha256() : EVP_sha1();
-        size_t qbits = EVP_MD_size(evpmd) * 8;
+        int qbits = EVP_MD_size(evpmd) * 8;
 
         return dsa_builtin_paramgen(ret, bits, qbits, evpmd,
                                     seed_in, seed_len, NULL, counter_ret,
@@ -41,9 +41,9 @@ int DSA_generate_parameters_ex(DSA *ret, int bits,
     }
 }
 
-int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
+int dsa_builtin_paramgen(DSA *ret, int bits, int qbits,
                          const EVP_MD *evpmd, const unsigned char *seed_in,
-                         size_t seed_len, unsigned char *seed_out,
+                         int seed_len, unsigned char *seed_out,
                          int *counter_ret, unsigned long *h_ret, BN_GENCB *cb)
 {
     int ok = 0;
@@ -74,11 +74,11 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
     bits = (bits + 63) / 64 * 64;
 
     if (seed_in != NULL) {
-        if (seed_len < (size_t)qsize) {
+        if (seed_len < qsize) {
             DSAerr(DSA_F_DSA_BUILTIN_PARAMGEN, DSA_R_SEED_LEN_SMALL);
             return 0;
         }
-        if (seed_len > (size_t)qsize) {
+        if (seed_len > qsize) {
             /* Only consume as much seed as is expected. */
             seed_len = qsize;
         }
@@ -105,7 +105,7 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
     if (test == NULL)
         goto err;
 
-    if (!BN_lshift(test, BN_value_one(), bits - 1))
+    if (!BN_lshift(test, BN_value_one(), (int)(bits - 1)))
         goto err;
 
     for (;;) {
@@ -297,9 +297,9 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
  * described in FIPS 186-3.
  */
 
-int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
+int dsa_builtin_paramgen2(DSA *ret, int L, int N,
                           const EVP_MD *evpmd, const unsigned char *seed_in,
-                          size_t seed_len, int idx, unsigned char *seed_out,
+                          int seed_len, int idx, unsigned char *seed_out,
                           int *counter_ret, unsigned long *h_ret,
                           BN_GENCB *cb)
 {
@@ -390,7 +390,7 @@ int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
                 goto err;
 
             if (!seed_in) {
-                if (RAND_bytes(seed, seed_len) <= 0)
+                if (RAND_bytes(seed, (int)seed_len) <= 0)
                     goto err;
             }
             /* step 2 */

--- a/crypto/dsa/dsa_locl.h
+++ b/crypto/dsa/dsa_locl.h
@@ -64,14 +64,14 @@ struct dsa_method {
     int (*dsa_keygen) (DSA *dsa);
 };
 
-int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
+int dsa_builtin_paramgen(DSA *ret, int bits, int qbits,
                          const EVP_MD *evpmd, const unsigned char *seed_in,
-                         size_t seed_len, unsigned char *seed_out,
+                         int seed_len, unsigned char *seed_out,
                          int *counter_ret, unsigned long *h_ret,
                          BN_GENCB *cb);
 
-int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
+int dsa_builtin_paramgen2(DSA *ret, int L, int N,
                           const EVP_MD *evpmd, const unsigned char *seed_in,
-                          size_t seed_len, int idx, unsigned char *seed_out,
+                          int seed_len, int idx, unsigned char *seed_out,
                           int *counter_ret, unsigned long *h_ret,
                           BN_GENCB *cb);

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -85,7 +85,7 @@ static int pkey_dsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
             return 0;
     }
 
-    ret = DSA_sign(0, tbs, tbslen, sig, &sltmp, dsa);
+    ret = DSA_sign(0, tbs, (int)tbslen, sig, &sltmp, dsa);
 
     if (ret <= 0)
         return ret;
@@ -109,7 +109,7 @@ static int pkey_dsa_verify(EVP_PKEY_CTX *ctx,
             return 0;
     }
 
-    ret = DSA_verify(0, tbs, tbslen, sig, siglen, dsa);
+    ret = DSA_verify(0, tbs, (int)tbslen, sig, (int)siglen, dsa);
 
     return ret;
 }

--- a/crypto/ec/ec2_oct.c
+++ b/crypto/ec/ec2_oct.c
@@ -293,7 +293,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     if (yxi == NULL)
         goto err;
 
-    if (!BN_bin2bn(buf + 1, field_len, x))
+    if (!BN_bin2bn(buf + 1, (int)field_len, x))
         goto err;
     if (BN_ucmp(x, group->field) >= 0) {
         ECerr(EC_F_EC_GF2M_SIMPLE_OCT2POINT, EC_R_INVALID_ENCODING);
@@ -305,7 +305,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
             (group, point, x, y_bit, ctx))
             goto err;
     } else {
-        if (!BN_bin2bn(buf + 1 + field_len, field_len, y))
+        if (!BN_bin2bn(buf + 1 + field_len, (int)field_len, y))
             goto err;
         if (BN_ucmp(y, group->field) >= 0) {
             ECerr(EC_F_EC_GF2M_SIMPLE_OCT2POINT, EC_R_INVALID_ENCODING);

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -510,7 +510,7 @@ static int ec_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return EC_KEY_oct2key(EVP_PKEY_get0_EC_KEY(pkey), arg2, arg1, NULL);
 
     case ASN1_PKEY_CTRL_GET1_TLS_ENCPT:
-        return EC_KEY_key2buf(EVP_PKEY_get0_EC_KEY(pkey),
+        return (int)EC_KEY_key2buf(EVP_PKEY_get0_EC_KEY(pkey),
                               POINT_CONVERSION_UNCOMPRESSED, arg2, NULL);
 
     default:

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -369,7 +369,7 @@ static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
     BIGNUM *tmp_1 = NULL, *tmp_2 = NULL;
     unsigned char *buffer_1 = NULL, *buffer_2 = NULL,
         *a_buf = NULL, *b_buf = NULL;
-    size_t len_1, len_2;
+    int len_1, len_2;
     unsigned char char_zero = 0;
 
     if (!group || !curve || !curve->a || !curve->b)
@@ -398,8 +398,8 @@ static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
         }
     }
 #endif
-    len_1 = (size_t)BN_num_bytes(tmp_1);
-    len_2 = (size_t)BN_num_bytes(tmp_2);
+    len_1 = BN_num_bytes(tmp_1);
+    len_2 = BN_num_bytes(tmp_2);
 
     if (len_1 == 0) {
         /* len_1 == 0 => a == 0 */
@@ -520,7 +520,7 @@ ECPARAMETERS *EC_GROUP_get_ecparameters(const EC_GROUP *group,
         ECerr(EC_F_EC_GROUP_GET_ECPARAMETERS, ERR_R_MALLOC_FAILURE);
         goto err;
     }
-    ASN1_STRING_set0(ret->base, buffer, len);
+    ASN1_STRING_set0(ret->base, buffer, (int)len);
 
     /* set the order */
     tmp = EC_GROUP_get0_order(group);
@@ -1023,7 +1023,7 @@ int i2d_ECPrivateKey(EC_KEY *a, unsigned char **out)
         goto err;
     }
 
-    ASN1_STRING_set0(priv_key->privateKey, priv, privlen);
+    ASN1_STRING_set0(priv_key->privateKey, priv, (int)privlen);
     priv = NULL;
 
     if (!(a->enc_flag & EC_PKEY_NO_PARAMETERS)) {
@@ -1051,7 +1051,7 @@ int i2d_ECPrivateKey(EC_KEY *a, unsigned char **out)
 
         priv_key->publicKey->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
         priv_key->publicKey->flags |= ASN1_STRING_FLAG_BITS_LEFT;
-        ASN1_STRING_set0(priv_key->publicKey, pub, publen);
+        ASN1_STRING_set0(priv_key->publicKey, pub, (int)publen);
         pub = NULL;
     }
 
@@ -1141,7 +1141,7 @@ int i2o_ECPublicKey(const EC_KEY *a, unsigned char **out)
 
     if (out == NULL || buf_len == 0)
         /* out == NULL => just return the length of the octet string */
-        return buf_len;
+        return (int)buf_len;
 
     if (*out == NULL) {
         if ((*out = OPENSSL_malloc(buf_len)) == NULL) {
@@ -1161,7 +1161,7 @@ int i2o_ECPublicKey(const EC_KEY *a, unsigned char **out)
     }
     if (!new_buffer)
         *out += buf_len;
-    return buf_len;
+    return (int)buf_len;
 }
 
 ASN1_SEQUENCE(ECDSA_SIG) = {

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -562,9 +562,9 @@ size_t EC_KEY_priv2oct(const EC_KEY *eckey,
 size_t ec_key_simple_priv2oct(const EC_KEY *eckey,
                               unsigned char *buf, size_t len)
 {
-    size_t buf_len;
+    unsigned int buf_len;
 
-    buf_len = (EC_GROUP_order_bits(eckey->group) + 7) / 8;
+    buf_len = (unsigned int)(EC_GROUP_order_bits(eckey->group) + 7) / 8;
     if (eckey->priv_key == NULL)
         return 0;
     if (buf == NULL)
@@ -601,7 +601,7 @@ int ec_key_simple_oct2priv(EC_KEY *eckey, const unsigned char *buf, size_t len)
         ECerr(EC_F_EC_KEY_SIMPLE_OCT2PRIV, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    eckey->priv_key = BN_bin2bn(buf, len, eckey->priv_key);
+    eckey->priv_key = BN_bin2bn(buf, (int)len, eckey->priv_key);
     if (eckey->priv_key == NULL) {
         ECerr(EC_F_EC_KEY_SIMPLE_OCT2PRIV, ERR_R_BN_LIB);
         return 0;

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -149,7 +149,7 @@ int ECDH_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
         memcpy(out, sec, outlen);
     }
     OPENSSL_clear_free(sec, seclen);
-    return outlen;
+    return (int)outlen;
 }
 
 EC_KEY_METHOD *EC_KEY_METHOD_new(const EC_KEY_METHOD *meth)

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -246,7 +246,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         num_val += (size_t)1 << (wsize[i] - 1);
         wNAF[i + 1] = NULL;     /* make sure we always have a pivot */
         wNAF[i] =
-            bn_compute_wNAF((i < num ? scalars[i] : scalar), wsize[i],
+            bn_compute_wNAF((i < num ? scalars[i] : scalar), (int)wsize[i],
                             &wNAF_len[i]);
         if (wNAF[i] == NULL)
             goto err;
@@ -276,7 +276,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
              * use the window size for which we have precomputation
              */
             wsize[num] = pre_comp->w;
-            tmp_wNAF = bn_compute_wNAF(scalar, wsize[num], &tmp_len);
+            tmp_wNAF = bn_compute_wNAF(scalar, (int)wsize[num], &tmp_len);
             if (!tmp_wNAF)
                 goto err;
 
@@ -426,7 +426,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 
     r_is_at_infinity = 1;
 
-    for (k = max_len - 1; k >= 0; k--) {
+    for (k = (int)max_len - 1; k >= 0; k--) {
         if (!r_is_at_infinity) {
             if (!EC_POINT_dbl(group, r, r, ctx))
                 goto err;

--- a/crypto/ec/ec_pmeth.c
+++ b/crypto/ec/ec_pmeth.c
@@ -116,7 +116,7 @@ static int pkey_ec_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
     else
         type = NID_sha1;
 
-    ret = ECDSA_sign(type, tbs, tbslen, sig, &sltmp, ec);
+    ret = ECDSA_sign(type, tbs, (int)tbslen, sig, &sltmp, ec);
 
     if (ret <= 0)
         return ret;
@@ -137,7 +137,7 @@ static int pkey_ec_verify(EVP_PKEY_CTX *ctx,
     else
         type = NID_sha1;
 
-    ret = ECDSA_verify(type, tbs, tbslen, sig, siglen, ec);
+    ret = ECDSA_verify(type, tbs, (int)tbslen, sig, (int)siglen, ec);
 
     return ret;
 }
@@ -296,7 +296,7 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     case EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN:
-        *(int *)p2 = dctx->kdf_outlen;
+        *(int *)p2 = (int)dctx->kdf_outlen;
         return 1;
 
     case EVP_PKEY_CTRL_EC_KDF_UKM:
@@ -310,7 +310,7 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case EVP_PKEY_CTRL_GET_EC_KDF_UKM:
         *(unsigned char **)p2 = dctx->kdf_ukm;
-        return dctx->kdf_ukmlen;
+        return (int)dctx->kdf_ukmlen;
 
     case EVP_PKEY_CTRL_MD:
         if (EVP_MD_type((const EVP_MD *)p2) != NID_sha1 &&

--- a/crypto/ec/ec_print.c
+++ b/crypto/ec/ec_print.c
@@ -23,7 +23,7 @@ BIGNUM *EC_POINT_point2bn(const EC_GROUP *group,
     if (buf_len == 0)
         return NULL;
 
-    ret = BN_bin2bn(buf, buf_len, ret);
+    ret = BN_bin2bn(buf, (int)buf_len, ret);
 
     OPENSSL_free(buf);
 

--- a/crypto/ec/ecp_oct.c
+++ b/crypto/ec/ecp_oct.c
@@ -273,7 +273,7 @@ int ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     int y_bit;
     BN_CTX *new_ctx = NULL;
     BIGNUM *x, *y;
-    size_t field_len, enc_len;
+    unsigned int field_len, enc_len;
     int ret = 0;
 
     if (len == 0) {

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -105,14 +105,14 @@ static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
         cdp++;
         return int_ctrl_cmd_is_null(cdp) ? 0 : cdp->cmd_num;
     case ENGINE_CTRL_GET_NAME_LEN_FROM_CMD:
-        return strlen(cdp->cmd_name);
+        return (int)strlen(cdp->cmd_name);
     case ENGINE_CTRL_GET_NAME_FROM_CMD:
-        return strlen(strcpy(s, cdp->cmd_name));
+        return (int)strlen(strcpy(s, cdp->cmd_name));
     case ENGINE_CTRL_GET_DESC_LEN_FROM_CMD:
-        return strlen(cdp->cmd_desc == NULL ? int_no_description
+        return (int)strlen(cdp->cmd_desc == NULL ? int_no_description
                                             : cdp->cmd_desc);
     case ENGINE_CTRL_GET_DESC_FROM_CMD:
-        return strlen(strcpy(s, cdp->cmd_desc == NULL ? int_no_description
+        return (int)strlen(strcpy(s, cdp->cmd_desc == NULL ? int_no_description
                                                       : cdp->cmd_desc));
     case ENGINE_CTRL_GET_CMD_FLAGS:
         return cdp->cmd_flags;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -743,7 +743,7 @@ void ERR_add_error_vdata(int num, va_list args)
         a = va_arg(args, char *);
         if (a == NULL)
             a = "<NULL>";
-        n += strlen(a);
+        n += (int)strlen(a);
         if (n > s) {
             s = n + 20;
             p = OPENSSL_realloc(str, s + 1);

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -44,7 +44,7 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
 
 static int print_bio(const char *str, size_t len, void *bp)
 {
-    return BIO_write((BIO *)bp, str, len);
+    return BIO_write((BIO *)bp, str, (int)len);
 }
 
 void ERR_print_errors(BIO *bp)

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -208,13 +208,13 @@ static int b64_read(BIO *b, char *out, int outl)
 
                 k = EVP_DecodeUpdate(ctx->base64,
                                      (unsigned char *)ctx->buf,
-                                     &num, p, q - p);
+                                     &num, p, (int)(q - p));
                 if ((k <= 0) && (num == 0) && (ctx->start))
                     EVP_DecodeInit(ctx->base64);
                 else {
                     if (p != (unsigned char *)
                         &(ctx->tmp[0])) {
-                        i -= (p - (unsigned char *)
+                        i -= (int)(p - (unsigned char *)
                               &(ctx->tmp[0]));
                         for (x = 0; x < i; x++)
                             ctx->tmp[x] = p[x];
@@ -239,7 +239,7 @@ static int b64_read(BIO *b, char *out, int outl)
                         ctx->tmp_len = 0;
                     }
                 } else if (p != q) { /* finished on a '\n' */
-                    n = q - p;
+                    n = (int)(q - p);
                     for (ii = 0; ii < n; ii++)
                         ctx->tmp[ii] = p[ii];
                     ctx->tmp_len = n;
@@ -539,5 +539,5 @@ static long b64_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
 
 static int b64_puts(BIO *b, const char *str)
 {
-    return b64_write(b, str, strlen(str));
+    return b64_write(b, str, (int)strlen(str));
 }

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -150,7 +150,7 @@ static int enc_read(BIO *b, char *out, int outl)
             if (i > 0)
                 ctx->read_end += i;
         } else {
-            i = ctx->read_end - ctx->read_start;
+            i = (int)(ctx->read_end - ctx->read_start);
         }
 
         if (i <= 0) {

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -185,7 +185,7 @@ static int ok_read(BIO *b, char *out, int outl)
 
         /* copy clean bytes to output buffer */
         if (ctx->blockout) {
-            i = ctx->buf_len - ctx->buf_off;
+            i = (int)(ctx->buf_len - ctx->buf_off);
             if (i > outl)
                 i = outl;
             memcpy(out, &(ctx->buf[ctx->buf_off]), i);
@@ -217,7 +217,7 @@ static int ok_read(BIO *b, char *out, int outl)
             break;
 
         /* no clean bytes in buffer -- fill it */
-        n = IOBS - ctx->buf_len;
+        n = (int)(IOBS - ctx->buf_len);
         i = BIO_read(next, &(ctx->buf[ctx->buf_len]), n);
 
         if (i <= 0)
@@ -273,7 +273,7 @@ static int ok_write(BIO *b, const char *in, int inl)
 
     do {
         BIO_clear_retry_flags(b);
-        n = ctx->buf_len - ctx->buf_off;
+        n = (int)(ctx->buf_len - ctx->buf_off);
         while (ctx->blockout && n > 0) {
             i = BIO_write(next, &(ctx->buf[ctx->buf_off]), n);
             if (i <= 0) {
@@ -349,7 +349,7 @@ static long ok_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_PENDING:     /* More to read in buffer */
     case BIO_CTRL_WPENDING:    /* More to read in buffer */
-        ret = ctx->blockout ? ctx->buf_len - ctx->buf_off : 0;
+        ret = ctx->blockout ? (long)(ctx->buf_len - ctx->buf_off) : 0;
         if (ret <= 0)
             ret = BIO_ctrl(next, cmd, num, ptr);
         break;
@@ -544,7 +544,7 @@ static int block_out(BIO *b)
     digest = EVP_MD_CTX_md(md);
     md_size = EVP_MD_size(digest);
 
-    tl = ctx->buf_len - OK_BLOCK_BLOCK;
+    tl = (unsigned long)(ctx->buf_len - OK_BLOCK_BLOCK);
     ctx->buf[0] = (unsigned char)(tl >> 24);
     ctx->buf[1] = (unsigned char)(tl >> 16);
     ctx->buf[2] = (unsigned char)(tl >> 8);

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1580,7 +1580,7 @@ static int aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         out += len;
         /* Finally write tag */
         CRYPTO_gcm128_tag(&gctx->gcm, out, EVP_GCM_TLS_TAG_LEN);
-        rv = len + EVP_GCM_TLS_EXPLICIT_IV_LEN + EVP_GCM_TLS_TAG_LEN;
+        rv = (int)(len + EVP_GCM_TLS_EXPLICIT_IV_LEN + EVP_GCM_TLS_TAG_LEN);
     } else {
         /* Decrypt */
         if (gctx->ctr) {
@@ -1627,7 +1627,7 @@ static int aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             OPENSSL_cleanse(out, len);
             goto err;
         }
-        rv = len;
+        rv = (int)len;
     }
 
  err:
@@ -1742,7 +1742,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                     return -1;
             }
         }
-        return len;
+        return (int)len;
     } else {
         if (!EVP_CIPHER_CTX_encrypting(ctx)) {
             if (gctx->taglen < 0)
@@ -2102,7 +2102,7 @@ static int aes_ccm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             return -1;
         if (!CRYPTO_ccm128_tag(ccm, out + len, cctx->M))
             return -1;
-        return len + EVP_CCM_TLS_EXPLICIT_IV_LEN + cctx->M;
+        return (int)(len + EVP_CCM_TLS_EXPLICIT_IV_LEN + cctx->M);
     } else {
         if (cctx->str ? !CRYPTO_ccm128_decrypt_ccm64(ccm, in, out, len,
                                                      cctx->str) :
@@ -2110,7 +2110,7 @@ static int aes_ccm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             unsigned char tag[16];
             if (CRYPTO_ccm128_tag(ccm, tag, cctx->M)) {
                 if (!CRYPTO_memcmp(tag, in + len, cctx->M))
-                    return len;
+                    return (int)len;
             }
         }
         OPENSSL_cleanse(out, len);
@@ -2145,13 +2145,13 @@ static int aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                     15 - cctx->L, len))
                 return -1;
             cctx->len_set = 1;
-            return len;
+            return (int)len;
         }
         /* If have AAD need message length */
         if (!cctx->len_set && len)
             return -1;
         CRYPTO_ccm128_aad(ccm, in, len);
-        return len;
+        return (int)len;
     }
     /* If not set length yet do it */
     if (!cctx->len_set) {
@@ -2166,7 +2166,7 @@ static int aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             CRYPTO_ccm128_encrypt(ccm, in, out, len))
             return -1;
         cctx->tag_set = 1;
-        return len;
+        return (int)len;
     } else {
         int rv = -1;
         if (cctx->str ? !CRYPTO_ccm128_decrypt_ccm64(ccm, in, out, len,
@@ -2176,7 +2176,7 @@ static int aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             if (CRYPTO_ccm128_tag(ccm, tag, cctx->M)) {
                 if (!CRYPTO_memcmp(tag, EVP_CIPHER_CTX_buf_noconst(ctx),
                                    cctx->M))
-                    rv = len;
+                    rv = (int)len;
             }
         }
         if (rv == -1)
@@ -2248,7 +2248,7 @@ static int aes_wrap_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     /* If not padding input must be multiple of 8 */
     if (!pad && inlen & 0x7)
         return -1;
-    if (is_partially_overlapping(out, in, inlen)) {
+    if (is_partially_overlapping(out, in, (int)inlen)) {
         EVPerr(EVP_F_AES_WRAP_CIPHER, EVP_R_PARTIALLY_OVERLAPPING);
         return 0;
     }
@@ -2258,14 +2258,14 @@ static int aes_wrap_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             if (pad)
                 inlen = (inlen + 7) / 8 * 8;
             /* 8 byte prefix */
-            return inlen + 8;
+            return (int)(inlen + 8);
         } else {
             /*
              * If not padding output will be exactly 8 bytes smaller than
              * input. If padding it will be at least 8 bytes smaller but we
              * don't know how much.
              */
-            return inlen - 8;
+            return (int)(inlen - 8);
         }
     }
     if (pad) {
@@ -2571,7 +2571,7 @@ static int aes_ocb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             buf = octx->data_buf;
             buf_len = &(octx->data_buf_len);
 
-            if (is_partially_overlapping(out + *buf_len, in, len)) {
+            if (is_partially_overlapping(out + *buf_len, in, (int)len)) {
                 EVPerr(EVP_F_AES_OCB_CIPHER, EVP_R_PARTIALLY_OVERLAPPING);
                 return 0;
             }
@@ -2587,7 +2587,7 @@ static int aes_ocb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             remaining = AES_BLOCK_SIZE - (*buf_len);
             if (remaining > len) {
                 memcpy(buf + (*buf_len), in, len);
-                *(buf_len) += len;
+                *(buf_len) += (int)len;
                 return 0;
             }
             memcpy(buf + (*buf_len), in, remaining);
@@ -2634,14 +2634,14 @@ static int aes_ocb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                     (&octx->ocb, in, out, len - trailing_len))
                     return -1;
             }
-            written_len += len - trailing_len;
+            written_len += (int)(len - trailing_len);
             in += len - trailing_len;
         }
 
         /* Handle any trailing partial block */
         if (trailing_len > 0) {
             memcpy(buf, in, trailing_len);
-            *buf_len = trailing_len;
+            *buf_len = (int)trailing_len;
         }
 
         return written_len;

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -217,7 +217,7 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             Poly1305_Update(POLY1305_ctx(actx), in, len);
             actx->len.aad += len;
             actx->aad = 1;
-            return len;
+            return (int)len;
         } else {                                /* plain- or ciphertext */
             if (actx->aad) {                    /* wrap up aad */
                 if ((rem = (size_t)actx->len.aad % POLY1305_BLOCK_SIZE))
@@ -309,7 +309,7 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                 return -1;
         }
     }
-    return len;
+    return (int)len;
 }
 
 static int chacha20_poly1305_cleanup(EVP_CIPHER_CTX *ctx)

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -321,7 +321,7 @@ static int des_ede3_unwrap(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (inl < 24)
         return -1;
     if (out == NULL)
-        return inl - 16;
+        return (int)(inl - 16);
     memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), wrap_iv, 8);
     /* Decrypt first block which will end up as icv */
     des_ede_cbc_cipher(ctx, icv, in, 8);
@@ -348,7 +348,7 @@ static int des_ede3_unwrap(EVP_CIPHER_CTX *ctx, unsigned char *out,
     SHA1(out, inl - 16, sha1tmp);
 
     if (!CRYPTO_memcmp(sha1tmp, icv, 8))
-        rv = inl - 16;
+        rv = (int)(inl - 16);
     OPENSSL_cleanse(icv, 8);
     OPENSSL_cleanse(sha1tmp, SHA_DIGEST_LENGTH);
     OPENSSL_cleanse(iv, 8);
@@ -364,7 +364,7 @@ static int des_ede3_wrap(EVP_CIPHER_CTX *ctx, unsigned char *out,
 {
     unsigned char sha1tmp[SHA_DIGEST_LENGTH];
     if (out == NULL)
-        return inl + 16;
+        return (int)(inl + 16);
     /* Copy input to output buffer + 8 so we have space for IV */
     memmove(out + 8, in, inl);
     /* Work out ICV */
@@ -380,7 +380,7 @@ static int des_ede3_wrap(EVP_CIPHER_CTX *ctx, unsigned char *out,
     BUF_reverse(out, NULL, inl + 16);
     memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), wrap_iv, 8);
     des_ede_cbc_cipher(ctx, out, out, inl + 16);
-    return inl + 16;
+    return (int)(inl + 16);
 }
 
 static int des_ede3_wrap_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
@@ -394,7 +394,7 @@ static int des_ede3_wrap_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (inl >= EVP_MAXCHUNK || inl % 8)
         return -1;
 
-    if (is_partially_overlapping(out, in, inl)) {
+    if (is_partially_overlapping(out, in, (int)inl)) {
         EVPerr(EVP_F_DES_EDE3_WRAP_CIPHER, EVP_R_PARTIALLY_OVERLAPPING);
         return 0;
     }

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -96,8 +96,8 @@ static int rc4_hmac_md5_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             blocks *= MD5_CBLOCK;
             rc4_off += blocks;
             md5_off += blocks;
-            key->md.Nh += blocks >> 29;
-            key->md.Nl += blocks <<= 3;
+            key->md.Nh += (MD5_LONG)(blocks >> 29);
+            key->md.Nl += (MD5_LONG)(blocks <<= 3);
             if (key->md.Nl < (unsigned int)blocks)
                 key->md.Nh++;
         } else {
@@ -144,7 +144,7 @@ static int rc4_hmac_md5_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             if (l < key->md.Nl)
                 key->md.Nh++;
             key->md.Nl = l;
-            key->md.Nh += blocks >> 29;
+            key->md.Nh += (MD5_LONG)(blocks >> 29);
         } else {
             md5_off = 0;
             rc4_off = 0;

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -166,7 +166,7 @@ int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
     if (inl != 0)
         memcpy(&(ctx->enc_data[0]), in, inl);
     ctx->num = inl;
-    *outl = total;
+    *outl = (int)total;
 
     return 1;
 }

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -102,7 +102,7 @@ int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
     if (!pass)
         passlen = 0;
     else if (passlen == -1)
-        passlen = strlen(pass);
+        passlen = (int)strlen(pass);
 
     if (cipher_nid == -1)
         cipher = NULL;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -177,7 +177,7 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
         vctx = 0;
     if (ctx->flags & EVP_MD_CTX_FLAG_FINALISE) {
         if (vctx) {
-            r = ctx->pctx->pmeth->verifyctx(ctx->pctx, sig, siglen, ctx);
+            r = ctx->pctx->pmeth->verifyctx(ctx->pctx, sig, (int)siglen, ctx);
         } else
             r = EVP_DigestFinal_ex(ctx, md, &mdlen);
     } else {
@@ -190,7 +190,7 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
         }
         if (vctx) {
             r = tmp_ctx->pctx->pmeth->verifyctx(tmp_ctx->pctx,
-                                                sig, siglen, tmp_ctx);
+                                                sig, (int)siglen, tmp_ctx);
         } else
             r = EVP_DigestFinal_ex(tmp_ctx, md, &mdlen);
         EVP_MD_CTX_free(tmp_ctx);

--- a/crypto/evp/p5_crpt.c
+++ b/crypto/evp/p5_crpt.c
@@ -58,7 +58,7 @@ int PKCS5_PBE_keyivgen(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
     if (!pass)
         passlen = 0;
     else if (passlen == -1)
-        passlen = strlen(pass);
+        passlen = (int)strlen(pass);
 
     ctx = EVP_MD_CTX_new();
     if (ctx == NULL) {

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -51,7 +51,7 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
         pass = empty;
         passlen = 0;
     } else if (passlen == -1) {
-        passlen = strlen(pass);
+        passlen = (int)strlen(pass);
     }
     if (!HMAC_Init_ex(hctx_tpl, pass, passlen, digest, NULL)) {
         HMAC_CTX_free(hctx_tpl);

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -520,7 +520,7 @@ int EVP_PKEY_set1_tls_encodedpoint(EVP_PKEY *pkey,
 {
     if (ptlen > INT_MAX)
         return 0;
-    if (evp_pkey_asn1_ctrl(pkey, ASN1_PKEY_CTRL_SET1_TLS_ENCPT, ptlen,
+    if (evp_pkey_asn1_ctrl(pkey, ASN1_PKEY_CTRL_SET1_TLS_ENCPT, (int)ptlen,
                            (void *)pt) <= 0)
         return 0;
     return 1;

--- a/crypto/evp/p_sign.c
+++ b/crypto/evp/p_sign.c
@@ -53,7 +53,7 @@ int EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
         goto err;
     if (EVP_PKEY_sign(pkctx, sigret, &sltmp, m, m_len) <= 0)
         goto err;
-    *siglen = sltmp;
+    *siglen = (unsigned int)sltmp;
     i = 1;
  err:
     EVP_PKEY_CTX_free(pkctx);

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -235,15 +235,15 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     X = (uint32_t *)(B + Blen);
     T = X + 32 * r;
     V = T + 32 * r;
-    if (PKCS5_PBKDF2_HMAC(pass, passlen, salt, saltlen, 1, EVP_sha256(),
+    if (PKCS5_PBKDF2_HMAC(pass, (int)passlen, salt, (int)saltlen, 1, EVP_sha256(),
                           (int)Blen, B) == 0)
         goto err;
 
     for (i = 0; i < p; i++)
         scryptROMix(B + 128 * r * i, r, N, X, T, V);
 
-    if (PKCS5_PBKDF2_HMAC(pass, passlen, B, (int)Blen, 1, EVP_sha256(),
-                          keylen, key) == 0)
+    if (PKCS5_PBKDF2_HMAC(pass, (int)passlen, B, (int)Blen, 1, EVP_sha256(),
+                          (int)keylen, key) == 0)
         goto err;
     rv = 1;
  err:

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -333,7 +333,7 @@ const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx)
     idx -= OSSL_NELEM(standard_methods);
     if (idx >= (size_t)sk_EVP_PKEY_METHOD_num(app_pkey_methods))
         return NULL;
-    return sk_EVP_PKEY_METHOD_value(app_pkey_methods, idx);
+    return sk_EVP_PKEY_METHOD_value(app_pkey_methods, (int)idx);
 }
 
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx)
@@ -408,7 +408,7 @@ int EVP_PKEY_CTX_str2ctrl(EVP_PKEY_CTX *ctx, int cmd, const char *str)
     len = strlen(str);
     if (len > INT_MAX)
         return -1;
-    return ctx->pmeth->ctrl(ctx, cmd, len, (void *)str);
+    return ctx->pmeth->ctrl(ctx, cmd, (int)len, (void *)str);
 }
 
 int EVP_PKEY_CTX_hex2ctrl(EVP_PKEY_CTX *ctx, int cmd, const char *hex)

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -267,7 +267,7 @@ static unsigned char *HKDF_Extract(const EVP_MD *evp_md,
 {
     unsigned int tmp_len;
 
-    if (!HMAC(evp_md, salt, salt_len, key, key_len, prk, &tmp_len))
+    if (!HMAC(evp_md, salt, (int)salt_len, key, (int)key_len, prk, &tmp_len))
         return NULL;
 
     *prk_len = tmp_len;
@@ -297,7 +297,7 @@ static unsigned char *HKDF_Expand(const EVP_MD *evp_md,
     if ((hmac = HMAC_CTX_new()) == NULL)
         return NULL;
 
-    if (!HMAC_Init_ex(hmac, prk, prk_len, evp_md, NULL))
+    if (!HMAC_Init_ex(hmac, prk, (int)prk_len, evp_md, NULL))
         goto err;
 
     for (i = 1; i <= n; i++) {

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -193,7 +193,7 @@ static int tls1_prf_P_hash(const EVP_MD *md,
     if (ctx == NULL || ctx_tmp == NULL || ctx_init == NULL)
         goto err;
     EVP_MD_CTX_set_flags(ctx_init, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-    mac_key = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, sec, sec_len);
+    mac_key = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, sec, (int)sec_len);
     if (mac_key == NULL)
         goto err;
     if (!EVP_DigestSignInit(ctx_init, NULL, md, NULL, mac_key))

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -18,6 +18,10 @@
 # include <execinfo.h>
 #endif
 
+#ifdef _WIN32
+#define write(fd, buf, count) _write(fd, buf, count)
+#endif
+
 /*
  * the following pointers may be changed as long as 'allow_customize' is set
  */

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -235,7 +235,7 @@ static unsigned long mem_hash(const MEM *a)
     ret = (size_t)a->addr;
 
     ret = ret * 17851 + (ret >> 14) * 7 + (ret >> 4) * 251;
-    return ret;
+    return (unsigned long)ret;
 }
 
 /* returns 1 if there was an info to pop, 0 if the stack was empty. */
@@ -347,7 +347,7 @@ void CRYPTO_mem_debug_malloc(void *addr, size_t num, int before_p,
             m->addr = addr;
             m->file = file;
             m->line = line;
-            m->num = num;
+            m->num = (int)num;
             m->threadid = CRYPTO_THREAD_get_current_id();
 
             if (order == break_order_num) {
@@ -432,7 +432,7 @@ void CRYPTO_mem_debug_realloc(void *addr1, void *addr2, size_t num,
             mp = lh_MEM_delete(mh, &m);
             if (mp != NULL) {
                 mp->addr = addr2;
-                mp->num = num;
+                mp->num = (int)num;
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE
                 mp->array_siz = backtrace(mp->array, OSSL_NELEM(mp->array));
 #endif
@@ -450,7 +450,7 @@ typedef struct mem_leak_st {
     int (*print_cb) (const char *str, size_t len, void *u);
     void *print_cb_arg;
     int chunks;
-    long bytes;
+    size_t bytes;
 } MEM_LEAK;
 
 static void print_leak(const MEM *m, MEM_LEAK *l)
@@ -515,8 +515,8 @@ static void print_leak(const MEM *m, MEM_LEAK *l)
         ti = amip->threadid;
 
         do {
-            int buf_len;
-            int info_len;
+            size_t buf_len;
+            size_t info_len;
 
             ami_cnt++;
             if (ami_cnt >= sizeof(buf) - 1)
@@ -631,7 +631,7 @@ int CRYPTO_mem_leaks_cb(int (*cb) (const char *str, size_t len, void *u),
 
 static int print_bio(const char *str, size_t len, void *b)
 {
-    return BIO_write((BIO *)b, str, len);
+    return BIO_write((BIO *)b, str, (int)len);
 }
 
 int CRYPTO_mem_leaks(BIO *b)

--- a/crypto/modes/wrap128.c
+++ b/crypto/modes/wrap128.c
@@ -196,7 +196,7 @@ size_t CRYPTO_128_wrap_pad(void *key, const unsigned char *icv,
     const size_t padding_len = padded_len - inlen;
     /* RFC 5649 section 3: Alternative Initial Value */
     unsigned char aiv[8];
-    int ret;
+    size_t ret;
 
     /* Section 1: use 32-bit fixed field for plaintext octet length */
     if (inlen == 0 || inlen >= CRYPTO128_WRAP_MAX)

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -179,7 +179,7 @@ unsigned char *OPENSSL_hexstr2buf(const char *str, long *len)
     }
 
     if (len)
-        *len = q - hexbuf;
+        *len = (long)(q - hexbuf);
     return hexbuf;
 }
 

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -414,7 +414,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
         if (s) {
             if (buf)
                 OPENSSL_strlcpy(buf, s, buf_len);
-            n = strlen(s);
+            n = (int)strlen(s);
             return n;
         }
     }
@@ -480,7 +480,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             bndec = BN_bn2dec(bl);
             if (!bndec)
                 goto err;
-            i = strlen(bndec);
+            i = (int)strlen(bndec);
             if (buf) {
                 if (buf_len > 1) {
                     *buf++ = '.';
@@ -501,7 +501,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             OPENSSL_free(bndec);
         } else {
             BIO_snprintf(tbuf, sizeof(tbuf), ".%lu", l);
-            i = strlen(tbuf);
+            i = (int)strlen(tbuf);
             if (buf && (buf_len > 0)) {
                 OPENSSL_strlcpy(buf, tbuf, buf_len);
                 if (i > buf_len) {

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -34,7 +34,7 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
     const char *prompt;
 
     if (key) {
-        i = strlen(key);
+        i = (int)strlen(key);
         i = (i > num) ? num : i;
         memcpy(buf, key, i);
         return i;
@@ -57,7 +57,7 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
             memset(buf, 0, (unsigned int)num);
             return -1;
         }
-        j = strlen(buf);
+        j = (int)strlen(buf);
         if (min_len && j < min_len) {
             fprintf(stderr,
                     "phrase is too short, needs to be at least %d chars\n",
@@ -89,7 +89,7 @@ void PEM_dek_info(char *buf, const char *type, int len, char *str)
 {
     long i;
     char *p = buf + strlen(buf);
-    int j = PEM_BUFSIZE - (size_t)(p - buf), n;
+    int j = (int)(PEM_BUFSIZE - (p - buf)), n;
 
     n = BIO_snprintf(p, j, "DEK-Info: %s,", type);
     if (n > 0) {
@@ -617,14 +617,14 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
     }
 
     EVP_EncodeInit(ctx);
-    nlen = strlen(name);
+    nlen = (int)strlen(name);
 
     if ((BIO_write(bp, "-----BEGIN ", 11) != 11) ||
         (BIO_write(bp, name, nlen) != nlen) ||
         (BIO_write(bp, "-----\n", 6) != 6))
         goto err;
 
-    i = strlen(header);
+    i = (int)strlen(header);
     if (i > 0) {
         if ((BIO_write(bp, header, i) != i) || (BIO_write(bp, "\n", 1) != 1))
             goto err;
@@ -729,7 +729,7 @@ static int get_name(BIO *bp, char **name, unsigned int flags)
 {
     char *linebuf;
     int ret = 0;
-    size_t len;
+    unsigned int len;
 
     /*
      * Need to hold trailing NUL (accounted for by BIO_gets() and the newline
@@ -925,7 +925,7 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
 
     EVP_DecodeInit(ctx);
     BIO_get_mem_ptr(dataB, &buf_mem);
-    len = buf_mem->length;
+    len = (int)buf_mem->length;
     if (EVP_DecodeUpdate(ctx, (unsigned char*)buf_mem->data, &len,
                          (unsigned char*)buf_mem->data, len) < 0
             || EVP_DecodeFinal(ctx, (unsigned char*)&(buf_mem->data[len]),
@@ -977,8 +977,8 @@ int PEM_read_bio(BIO *bp, char **name, char **header, unsigned char **data,
 
 int pem_check_suffix(const char *pem_str, const char *suffix)
 {
-    int pem_len = strlen(pem_str);
-    int suffix_len = strlen(suffix);
+    size_t pem_len = strlen(pem_str);
+    size_t suffix_len = strlen(suffix);
     const char *p;
     if (suffix_len + 1 >= pem_len)
         return 0;
@@ -988,5 +988,5 @@ int pem_check_suffix(const char *pem_str, const char *suffix)
     p--;
     if (*p != ' ')
         return 0;
-    return p - pem_str;
+    return (int)(p - pem_str);
 }

--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -20,7 +20,7 @@ unsigned char *OPENSSL_asc2uni(const char *asc, int asclen,
     unsigned char *unitmp;
 
     if (asclen == -1)
-        asclen = strlen(asc);
+        asclen = (int)strlen(asc);
     ulen = asclen * 2 + 2;
     if ((unitmp = OPENSSL_malloc(ulen)) == NULL)
         return NULL;
@@ -75,7 +75,7 @@ unsigned char *OPENSSL_utf82uni(const char *asc, int asclen,
     unsigned long utf32chr = 0;
 
     if (asclen == -1)
-        asclen = strlen(asc);
+        asclen = (int)strlen(asc);
 
     for (ulen = 0, i = 0; i < asclen; i += j) {
         j = UTF8_getc((const unsigned char *)asc+i, asclen-i, &utf32chr);

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -124,7 +124,7 @@ static int pkcs7_encode_rinfo(PKCS7_RECIP_INFO *ri,
     if (EVP_PKEY_encrypt(pctx, ek, &eklen, key, keylen) <= 0)
         goto err;
 
-    ASN1_STRING_set0(ri->enc_key, ek, eklen);
+    ASN1_STRING_set0(ri->enc_key, ek, (int)eklen);
     ek = NULL;
 
     ret = 1;
@@ -180,7 +180,7 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
 
     OPENSSL_clear_free(*pek, *peklen);
     *pek = ek;
-    *peklen = eklen;
+    *peklen = (int)eklen;
 
  err:
     EVP_PKEY_CTX_free(pctx);
@@ -862,7 +862,7 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
 
     EVP_MD_CTX_free(mctx);
 
-    ASN1_STRING_set0(si->enc_digest, abuf, siglen);
+    ASN1_STRING_set0(si->enc_digest, abuf, (int)siglen);
 
     return 1;
 

--- a/crypto/poly1305/poly1305_pmeth.c
+++ b/crypto/poly1305/poly1305_pmeth.c
@@ -134,7 +134,7 @@ static int pkey_poly1305_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             key = EVP_PKEY_get0_poly1305(EVP_PKEY_CTX_get0_pkey(ctx), &len);
         }
         if (key == NULL || len != POLY1305_KEY_SIZE ||
-            !ASN1_OCTET_STRING_set(&pctx->ktmp, key, len))
+            !ASN1_OCTET_STRING_set(&pctx->ktmp, key, (int)len))
             return 0;
         Poly1305_Init(&pctx->ctx, ASN1_STRING_get0_data(&pctx->ktmp));
         break;

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -570,7 +570,7 @@ void rand_drbg_cleanup_int(void)
 static int drbg_bytes(unsigned char *out, int count)
 {
     int ret = 0;
-    size_t chunk;
+    size_t size = count, chunk;
     RAND_DRBG *drbg = RAND_DRBG_get0_global();
 
     if (drbg == NULL)
@@ -580,8 +580,8 @@ static int drbg_bytes(unsigned char *out, int count)
     if (drbg->state == DRBG_UNINITIALISED)
         goto err;
 
-    for ( ; count > 0; count -= chunk, out += chunk) {
-        chunk = count;
+    for ( ; size > 0; size -= chunk, out += chunk) {
+        chunk = size;
         if (chunk > drbg->max_request)
             chunk = drbg->max_request;
         ret = RAND_DRBG_generate(drbg, out, chunk, 0, NULL, 0);

--- a/crypto/rand/drbg_rand.c
+++ b/crypto/rand/drbg_rand.c
@@ -182,7 +182,7 @@ static void ctr_df(RAND_DRBG_CTR *ctr,
     ctr_BCC_update(ctr, &c80, 1);
     ctr_BCC_final(ctr);
     /* Set up key K */
-    AES_set_encrypt_key(ctr->KX, ctr->keylen * 8, &ctr->df_kxks);
+    AES_set_encrypt_key(ctr->KX, (int)ctr->keylen * 8, &ctr->df_kxks);
     /* X follows key K */
     AES_encrypt(ctr->KX + ctr->keylen, ctr->KX, &ctr->df_kxks);
     AES_encrypt(ctr->KX, ctr->KX + 16, &ctr->df_kxks);
@@ -326,7 +326,7 @@ int ctr_init(RAND_DRBG *drbg)
     }
 
     ctr->keylen = keylen;
-    drbg->strength = keylen * 8;
+    drbg->strength = (int)keylen * 8;
     drbg->seedlen = keylen + 16;
 
     if (drbg->flags & RAND_DRBG_FLAG_CTR_USE_DF) {

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -271,7 +271,7 @@ int RAND_poll(void)
 
         if (meth->add == NULL
             || meth->add(RAND_POOL_buffer(pool),
-                         RAND_POOL_length(pool),
+                         (int)RAND_POOL_length(pool),
                          (RAND_POOL_entropy(pool) / 8.0)) == 0)
             goto err;
 
@@ -308,7 +308,7 @@ struct rand_pool_st {
  * Allocate memory and initialize a new random pool
  */
 
-RAND_POOL *RAND_POOL_new(int entropy, size_t min_len, size_t max_len)
+RAND_POOL *RAND_POOL_new(size_t entropy, size_t min_len, size_t max_len)
 {
     RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
 

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -65,7 +65,7 @@ size_t RAND_POOL_acquire_entropy(RAND_POOL *pool)
     buffer = RAND_POOL_add_begin(pool, bytes_needed);
     if (buffer != NULL) {
         size_t bytes = 0;
-        if (BCryptGenRandom(NULL, buffer, bytes_needed,
+        if (BCryptGenRandom(NULL, buffer, (ULONG)bytes_needed,
             BCRYPT_USE_SYSTEM_PREFERRED_RNG) == STATUS_SUCCESS)
             bytes = bytes_needed;
 

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -102,7 +102,7 @@ int RAND_load_file(const char *file, long bytes)
             n = (bytes < RAND_FILE_SIZE) ? (int)bytes : RAND_FILE_SIZE;
         else
             n = RAND_FILE_SIZE;
-        i = fread(buf, 1, n, in);
+        i = (int)fread(buf, 1, n, in);
         if (i <= 0)
             break;
         RAND_add(buf, i, (double)i);
@@ -189,7 +189,8 @@ int RAND_write_file(const char *file)
     chmod(file, 0600);
 #endif
 
-    ret = fwrite(buf, 1, RAND_FILE_SIZE, out);
+    ret = (int)fwrite(buf, 1, RAND_FILE_SIZE, out);
+    ret = (int)fwrite(buf, 1, RAND_FILE_SIZE, out);
     fclose(out);
     OPENSSL_cleanse(buf, RAND_FILE_SIZE);
     return ret;

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -135,7 +135,7 @@ void SipHash_Update(SIPHASH *ctx, const unsigned char *in, size_t inlen)
         /* not enough to fill leavings */
         if (inlen < available) {
             memcpy(&ctx->leavings[ctx->len], in, inlen);
-            ctx->len += inlen;
+            ctx->len += (unsigned int)inlen;
             return;
         }
 

--- a/crypto/siphash/siphash_pmeth.c
+++ b/crypto/siphash/siphash_pmeth.c
@@ -101,7 +101,7 @@ static int siphash_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
     EVP_MD_CTX_set_flags(mctx, EVP_MD_CTX_FLAG_NO_INIT);
     EVP_MD_CTX_set_update_fn(mctx, int_update);
     /* use default rounds (2,4) */
-    hash_size = SipHash_hash_size(&pctx->ctx);
+    hash_size = (int)SipHash_hash_size(&pctx->ctx);
     return SipHash_Init(&pctx->ctx, key, hash_size, 0, 0);
 }
 static int siphash_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
@@ -147,10 +147,10 @@ static int pkey_siphash_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             key = EVP_PKEY_get0_siphash(EVP_PKEY_CTX_get0_pkey(ctx), &len);
         }
         if (key == NULL || len != SIPHASH_KEY_SIZE ||
-            !ASN1_OCTET_STRING_set(&pctx->ktmp, key, len))
+            !ASN1_OCTET_STRING_set(&pctx->ktmp, key, (int)len))
             return 0;
         /* use default rounds (2,4) */
-        hash_size = SipHash_hash_size(&pctx->ctx);
+        hash_size = (int)SipHash_hash_size(&pctx->ctx);
         return SipHash_Init(&pctx->ctx, ASN1_STRING_get0_data(&pctx->ktmp), hash_size, 0, 0);
 
     default:

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -59,7 +59,7 @@ static char *file_get_pass(const UI_METHOD *ui_method, char *pass,
         OSSL_STOREerr(OSSL_STORE_F_FILE_GET_PASS, ERR_R_MALLOC_FAILURE);
         pass = NULL;
     } else if (!UI_add_input_string(ui, prompt, UI_INPUT_FLAG_DEFAULT_PWD,
-                                    pass, 0, maxsize - 1)) {
+                                    pass, 0, (int)maxsize - 1)) {
         OSSL_STOREerr(OSSL_STORE_F_FILE_GET_PASS, ERR_R_UI_LIB);
         pass = NULL;
     } else {
@@ -207,7 +207,7 @@ static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
             /* No match, there is no PEM PKCS12 tag */
             return NULL;
 
-        if ((p12 = d2i_PKCS12(NULL, &blob, len)) != NULL) {
+        if ((p12 = d2i_PKCS12(NULL, &blob, (long)len)) != NULL) {
             char *pass = NULL;
             char tpass[PEM_BUFSIZE];
             EVP_PKEY *pkey = NULL;
@@ -339,7 +339,7 @@ static OSSL_STORE_INFO *try_decode_PKCS8Encrypted(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((p8 = d2i_X509_SIG(NULL, &blob, len)) == NULL)
+    if ((p8 = d2i_X509_SIG(NULL, &blob, (long)len)) == NULL)
         return NULL;
 
     *matchcount = 1;
@@ -406,7 +406,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
     if (pem_name != NULL) {
         if (strcmp(pem_name, PEM_STRING_PKCS8INF) == 0) {
             PKCS8_PRIV_KEY_INFO *p8inf =
-                d2i_PKCS8_PRIV_KEY_INFO(NULL, &blob, len);
+                d2i_PKCS8_PRIV_KEY_INFO(NULL, &blob, (long)len);
 
             *matchcount = 1;
             if (p8inf != NULL)
@@ -419,7 +419,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
                 && (ameth = EVP_PKEY_asn1_find_str(NULL, pem_name,
                                                    slen)) != NULL) {
                 *matchcount = 1;
-                pkey = d2i_PrivateKey(ameth->pkey_id, NULL, &blob, len);
+                pkey = d2i_PrivateKey(ameth->pkey_id, NULL, &blob, (long)len);
             }
         }
     } else {
@@ -433,7 +433,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
             if (ameth->pkey_flags & ASN1_PKEY_ALIAS)
                 continue;
 
-            tmp_pkey = d2i_PrivateKey(ameth->pkey_id, NULL, &tmp_blob, len);
+            tmp_pkey = d2i_PrivateKey(ameth->pkey_id, NULL, &tmp_blob, (long)len);
             if (tmp_pkey != NULL) {
                 if (pkey != NULL)
                     EVP_PKEY_free(tmp_pkey);
@@ -485,7 +485,7 @@ static OSSL_STORE_INFO *try_decode_PUBKEY(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((pkey = d2i_PUBKEY(NULL, &blob, len)) != NULL) {
+    if ((pkey = d2i_PUBKEY(NULL, &blob, (long)len)) != NULL) {
         *matchcount = 1;
         store_info = OSSL_STORE_INFO_new_PKEY(pkey);
     }
@@ -531,7 +531,7 @@ static OSSL_STORE_INFO *try_decode_params(const char *pem_name,
         if (EVP_PKEY_set_type_str(pkey, pem_name, slen)
             && (ameth = EVP_PKEY_get0_asn1(pkey)) != NULL
             && ameth->param_decode != NULL
-            && ameth->param_decode(pkey, &blob, len))
+            && ameth->param_decode(pkey, &blob, (long)len))
             ok = 1;
     } else {
         int i;
@@ -552,7 +552,7 @@ static OSSL_STORE_INFO *try_decode_params(const char *pem_name,
             if (EVP_PKEY_set_type(tmp_pkey, ameth->pkey_id)
                 && (ameth = EVP_PKEY_get0_asn1(tmp_pkey)) != NULL
                 && ameth->param_decode != NULL
-                && ameth->param_decode(tmp_pkey, &tmp_blob, len)) {
+                && ameth->param_decode(tmp_pkey, &tmp_blob, (long)len)) {
                 if (pkey != NULL)
                     EVP_PKEY_free(tmp_pkey);
                 else
@@ -614,8 +614,8 @@ static OSSL_STORE_INFO *try_decode_X509Certificate(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((cert = d2i_X509_AUX(NULL, &blob, len)) != NULL
-        || (ignore_trusted && (cert = d2i_X509(NULL, &blob, len)) != NULL)) {
+    if ((cert = d2i_X509_AUX(NULL, &blob, (long)len)) != NULL
+        || (ignore_trusted && (cert = d2i_X509(NULL, &blob, (long)len)) != NULL)) {
         *matchcount = 1;
         store_info = OSSL_STORE_INFO_new_CERT(cert);
     }
@@ -652,7 +652,7 @@ static OSSL_STORE_INFO *try_decode_X509CRL(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((crl = d2i_X509_CRL(NULL, &blob, len)) != NULL) {
+    if ((crl = d2i_X509_CRL(NULL, &blob, (long)len)) != NULL) {
         *matchcount = 1;
         store_info = OSSL_STORE_INFO_new_CRL(crl);
     }

--- a/crypto/ts/ts_lib.c
+++ b/crypto/ts/ts_lib.c
@@ -28,7 +28,7 @@ int TS_ASN1_INTEGER_print_bio(BIO *bio, const ASN1_INTEGER *num)
     ASN1_INTEGER_to_BN(num, num_bn);
     if ((hex = BN_bn2hex(num_bn))) {
         result = BIO_write(bio, "0x", 2) > 0;
-        result = result && BIO_write(bio, hex, strlen(hex)) > 0;
+        result = result && BIO_write(bio, hex, (int)strlen(hex)) > 0;
         OPENSSL_free(hex);
     }
     BN_free(num_bn);

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -66,7 +66,7 @@ TXT_DB *TXT_DB_read(BIO *in, int num)
             break;
         if ((offset == 0) && (buf->data[0] == '#'))
             continue;
-        i = strlen(&(buf->data[offset]));
+        i = (int)strlen(&(buf->data[offset]));
         offset += i;
         if (buf->data[offset - 1] != '\n')
             continue;
@@ -204,7 +204,7 @@ long TXT_DB_write(BIO *out, TXT_DB *db)
         l = 0;
         for (j = 0; j < nn; j++) {
             if (pp[j] != NULL)
-                l += strlen(pp[j]);
+                l += (long)strlen(pp[j]);
         }
         if (!BUF_MEM_grow_clean(buf, (int)(l * 2 + nn)))
             goto err;
@@ -223,7 +223,7 @@ long TXT_DB_write(BIO *out, TXT_DB *db)
             *(p++) = '\t';
         }
         p[-1] = '\n';
-        j = p - buf->data;
+        j = (long)(p - buf->data);
         if (BIO_write(out, buf->data, (int)j) != j)
             goto err;
         tot += j;

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -369,9 +369,9 @@ char *UI_construct_prompt(UI *ui, const char *object_desc,
 
         if (object_desc == NULL)
             return NULL;
-        len = sizeof(prompt1) - 1 + strlen(object_desc);
+        len = (int)(sizeof(prompt1) - 1 + strlen(object_desc));
         if (object_name != NULL)
-            len += sizeof(prompt2) - 1 + strlen(object_name);
+            len += (int)(sizeof(prompt2) - 1 + strlen(object_name));
         len += sizeof(prompt3) - 1;
 
         prompt = OPENSSL_malloc(len + 1);
@@ -814,7 +814,7 @@ int UI_get_result_string_length(UI_STRING *uis)
     switch (uis->type) {
     case UIT_PROMPT:
     case UIT_VERIFY:
-        return uis->result_len;
+        return (int)uis->result_len;
     case UIT_NONE:
     case UIT_BOOLEAN:
     case UIT_INFO:
@@ -878,7 +878,7 @@ int UI_set_result(UI *ui, UI_STRING *uis, const char *result)
      */
     UIerr(UI_F_UI_SET_RESULT, ERR_R_DISABLED);
 #endif
-    return UI_set_result_ex(ui, uis, result, strlen(result));
+    return UI_set_result_ex(ui, uis, result, (int)strlen(result));
 }
 
 int UI_set_result_ex(UI *ui, UI_STRING *uis, const char *result, int len)

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -66,7 +66,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             i2t_ASN1_OBJECT(tmp_buf, sizeof(tmp_buf), ne->object);
             s = tmp_buf;
         }
-        l1 = strlen(s);
+        l1 = (int)strlen(s);
 
         type = ne->value->type;
         num = ne->value->length;

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -327,7 +327,7 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
                                       len, type,
                                       OBJ_obj2nid(ne->object)) ? 1 : 0;
     if (len < 0)
-        len = strlen((const char *)bytes);
+        len = (int)strlen((const char *)bytes);
     i = ASN1_STRING_set(ne->value, bytes, len);
     if (!i)
         return 0;

--- a/crypto/x509/x509spki.c
+++ b/crypto/x509/x509spki.c
@@ -34,7 +34,7 @@ NETSCAPE_SPKI *NETSCAPE_SPKI_b64_decode(const char *str, int len)
     int spki_len;
     NETSCAPE_SPKI *spki;
     if (len <= 0)
-        len = strlen(str);
+        len = (int)strlen(str);
     if ((spki_der = OPENSSL_malloc(len + 1)) == NULL) {
         X509err(X509_F_NETSCAPE_SPKI_B64_DECODE, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -220,7 +220,7 @@ static int x509_name_ex_i2d(ASN1_VALUE **val, unsigned char **out,
         if (ret < 0)
             return ret;
     }
-    ret = a->bytes->length;
+    ret = (int)a->bytes->length;
     if (out != NULL) {
         memcpy(*out, a->bytes->data, ret);
         *out += ret;
@@ -446,7 +446,7 @@ static int asn1_string_canon(ASN1_STRING *out, const ASN1_STRING *in)
         }
     }
 
-    out->length = to - out->data;
+    out->length = (int)(to - out->data);
 
     return 1;
 
@@ -503,7 +503,7 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
                                 (ossl_isupper(s[2]) && (s[3] == '='))
               ))) || (*s == '\0'))
         {
-            i = s - c;
+            i = (int)(s - c);
             if (BIO_write(bp, c, i) != i)
                 goto err;
             c = s + 1;          /* skip following slash */

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -120,7 +120,7 @@ X509 *d2i_X509_AUX(X509 **a, const unsigned char **pp, long length)
     if (ret == NULL)
         return NULL;
     /* update length */
-    length -= q - *pp;
+    length -= (long)(q - *pp);
     if (length > 0 && !d2i_X509_CERT_AUX(&ret->aux, &q, length))
         goto err;
     *pp = q;

--- a/crypto/x509v3/v3_addr.c
+++ b/crypto/x509v3/v3_addr.c
@@ -972,8 +972,8 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
             continue;
         }
 
-        i1 = strspn(s, addr_chars);
-        i2 = i1 + strspn(s + i1, " \t");
+        i1 = (int)strspn(s, addr_chars);
+        i2 = i1 + (int)strspn(s + i1, " \t");
         delim = s[i2++];
         s[i1] = '\0';
 
@@ -998,8 +998,8 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
             }
             break;
         case '-':
-            i1 = i2 + strspn(s + i2, " \t");
-            i2 = i1 + strspn(s + i1, addr_chars);
+            i1 = i2 + (int)strspn(s + i2, " \t");
+            i2 = i1 + (int)strspn(s + i1, addr_chars);
             if (i1 == i2 || s[i2] != '\0') {
                 X509V3err(X509V3_F_V2I_IPADDRBLOCKS,
                           X509V3_R_EXTENSION_VALUE_ERROR);

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -481,7 +481,7 @@ GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
     if (is_string) {
         if ((gen->d.ia5 = ASN1_IA5STRING_new()) == NULL ||
             !ASN1_STRING_set(gen->d.ia5, (unsigned char *)value,
-                             strlen(value))) {
+                             (int)strlen(value))) {
             X509V3err(X509V3_F_A2I_GENERAL_NAME, ERR_R_MALLOC_FAILURE);
             goto err;
         }
@@ -553,7 +553,7 @@ static int do_othername(GENERAL_NAME *gen, const char *value, X509V3_CTX *ctx)
     ASN1_TYPE_free(gen->d.otherName->value);
     if ((gen->d.otherName->value = ASN1_generate_v3(p + 1, ctx)) == NULL)
         return 0;
-    objlen = p - value;
+    objlen = (int)(p - value);
     objtmp = OPENSSL_strndup(value, objlen);
     if (objtmp == NULL)
         return 0;

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -546,12 +546,12 @@ static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
         /*
          * Number, range, or mistake, pick it apart and figure out which.
          */
-        i1 = strspn(val->value, "0123456789");
+        i1 = (int)strspn(val->value, "0123456789");
         if (val->value[i1] == '\0') {
             is_range = 0;
         } else {
             is_range = 1;
-            i2 = i1 + strspn(val->value + i1, " \t");
+            i2 = i1 + (int)strspn(val->value + i1, " \t");
             if (val->value[i2] != '-') {
                 X509V3err(X509V3_F_V2I_ASIDENTIFIERS,
                           X509V3_R_INVALID_ASNUMBER);
@@ -559,8 +559,8 @@ static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
                 goto err;
             }
             i2++;
-            i2 = i2 + strspn(val->value + i2, " \t");
-            i3 = i2 + strspn(val->value + i2, "0123456789");
+            i2 = i2 + (int)strspn(val->value + i2, " \t");
+            i3 = i2 + (int)strspn(val->value + i2, "0123456789");
             if (val->value[i3] != '\0') {
                 X509V3err(X509V3_F_V2I_ASIDENTIFIERS,
                           X509V3_R_INVALID_ASRANGE);

--- a/crypto/x509v3/v3_cpols.c
+++ b/crypto/x509v3/v3_cpols.c
@@ -200,7 +200,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
             if ((qual->d.cpsuri = ASN1_IA5STRING_new()) == NULL)
                 goto merr;
             if (!ASN1_STRING_set(qual->d.cpsuri, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (!name_cmp(cnf->name, "userNotice")) {
             STACK_OF(CONF_VALUE) *unot;
@@ -251,7 +251,7 @@ static int displaytext_get_tag_len(const char *tagstr)
 {
     char *colon = strchr(tagstr, ':');
 
-    return (colon == NULL) ? -1 : colon - tagstr;
+    return (colon == NULL) ? -1 : (int)(colon - tagstr);
 }
 
 static int displaytext_str2tag(const char *tagstr, unsigned int *tag_len)
@@ -308,7 +308,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
                 goto merr;
             if (tag_len != 0)
                 value += tag_len + 1;
-            len = strlen(value);
+            len = (int)strlen(value);
             if (!ASN1_STRING_set(not->exptext, value, len))
                 goto merr;
         } else if (strcmp(cnf->name, "organization") == 0) {
@@ -324,7 +324,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
             else
                 nref->organization->type = V_ASN1_VISIBLESTRING;
             if (!ASN1_STRING_set(nref->organization, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (strcmp(cnf->name, "noticeNumbers") == 0) {
             NOTICEREF *nref;

--- a/crypto/x509v3/v3_ia5.c
+++ b/crypto/x509v3/v3_ia5.c
@@ -51,7 +51,7 @@ ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
     }
     if ((ia5 = ASN1_IA5STRING_new()) == NULL)
         goto err;
-    if (!ASN1_STRING_set((ASN1_STRING *)ia5, str, strlen(str))) {
+    if (!ASN1_STRING_set((ASN1_STRING *)ia5, str, (int)strlen(str))) {
         ASN1_IA5STRING_free(ia5);
         return NULL;
     }

--- a/crypto/x509v3/v3_info.c
+++ b/crypto/x509v3/v3_info.c
@@ -78,7 +78,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
         tret = tmp;
         vtmp = sk_CONF_VALUE_value(tret, i);
         i2t_ASN1_OBJECT(objtmp, sizeof objtmp, desc->method);
-        nlen = strlen(objtmp) + 3 + strlen(vtmp->name) + 1;
+        nlen = (int)strlen(objtmp) + 3 + (int)strlen(vtmp->name) + 1;
         ntmp = OPENSSL_malloc(nlen);
         if (ntmp == NULL)
             goto err;
@@ -128,7 +128,7 @@ static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
                       X509V3_R_INVALID_SYNTAX);
             goto err;
         }
-        objlen = ptmp - cnf->name;
+        objlen = (int)(ptmp - cnf->name);
         ctmp.name = ptmp + 1;
         ctmp.value = cnf->value;
         if (!v2i_GENERAL_NAME_ex(acc->location, method, ctx, &ctmp, 0))

--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -526,9 +526,9 @@ static int nc_uri(ASN1_IA5STRING *uri, ASN1_IA5STRING *base)
         p = strchr(hostptr, '/');
 
     if (!p)
-        hostlen = strlen(hostptr);
+        hostlen = (int)strlen(hostptr);
     else
-        hostlen = p - hostptr;
+        hostlen = (int)(p - hostptr);
 
     if (hostlen == 0)
         return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;

--- a/crypto/x509v3/v3_pci.c
+++ b/crypto/x509v3/v3_pci.c
@@ -198,7 +198,7 @@ static int process_pci_value(CONF_VALUE *val,
                 goto err;
             }
         } else if (strncmp(val->value, "text:", 5) == 0) {
-            val_len = strlen(val->value + 5);
+            val_len = (long)strlen(val->value + 5);
             tmp_data = OPENSSL_realloc((*policy)->data,
                                        (*policy)->length + val_len + 1);
             if (tmp_data) {

--- a/crypto/x509v3/v3_sxnet.c
+++ b/crypto/x509v3/v3_sxnet.c
@@ -145,7 +145,7 @@ int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *zone, const char *user,
         return 0;
     }
     if (userlen == -1)
-        userlen = strlen(user);
+        userlen = (int)strlen(user);
     if (userlen > 64) {
         X509V3err(X509V3_F_SXNET_ADD_ID_INTEGER, X509V3_R_USER_TOO_LONG);
         return 0;
@@ -166,7 +166,7 @@ int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *zone, const char *user,
     if ((id = SXNETID_new()) == NULL)
         goto err;
     if (userlen == -1)
-        userlen = strlen(user);
+        userlen = (int)strlen(user);
 
     if (!ASN1_OCTET_STRING_set(id->user, (const unsigned char *)user, userlen))
         goto err;

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -78,7 +78,7 @@ int RAND_DRBG_set_callbacks(RAND_DRBG *dctx,
 /*
  * RAND_POOL functions
  */
-RAND_POOL *RAND_POOL_new(int entropy_requested, size_t min_len, size_t max_len);
+RAND_POOL *RAND_POOL_new(size_t entropy_requested, size_t min_len, size_t max_len);
 void RAND_POOL_free(RAND_POOL *pool);
 
 const unsigned char *RAND_POOL_buffer(RAND_POOL *pool);

--- a/ms/uplink.c
+++ b/ms/uplink.c
@@ -89,7 +89,7 @@ void OPENSSL_Uplink(volatile void **table, int index)
         } else
             p = applinktable;
 
-        if (index > (int)p[0])
+        if (index > (INT_PTR)p[0])
             break;
 
         if (p[index])


### PR DESCRIPTION
Currently the /WX (treat warnings as errors) compiler option can only be used for VC-WIN32 builds (see 0d2394a8c035c9d1b5a55f1569c1ea9c880b128c) but not for VC-WIN64 builds. The reason is that there are just too many truncation warnings, like the following:

```
  warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
  warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
```

This pull request attempts to reduce the number of warnings. 

### Background

The above warning is the predominant type of warning on VC-WIN64 builds and originates from the fact that the `int` and `long` types are only 32bit wide, whereas `size_t` and pointer differences require 64bit. Traditionally, the `int` type was used for buffer sizes, but nowadays the `size_t` type is preferred. Not only do these types have different sizes, but also one is signed and the other unsigned. Since the APIs are fixed, there is nothing much one can do about it.


### The first step

The first step is to silence the compiler warnings by inserting explicit type casts and or changing variable types to reduce the necessity to convert.  The first commit of this PR silences all warnings for libcrypto, so I am about half way through. Well not quite, since there are a lot of ciphers which are disabled by default (no-xxx), see configuration below. I will continue on the libssl warnings if your feedback is positive.

It has been a lot of warnings and if I had known how many, I probably wouldn't have started to fix them ;-)


### What's next

It is clear to me that introducing casts is not sufficient. The code needs to be inspected and analyzed, whether the truncation causes an issue which needs to be dealt with. I tried to be as accurate as possible, there was no search&replace involved, every compiler warning was inspected by me manually. 

The next step is to decide where the possible loss of data can be ignored, or where bound checks and/or error messages need to be added. This is a lot of work and also needs to be done by insiders familiar with the code. Maybe it's a task for the next Code Health Tuesday?

My initial work helps doing the review, since it turns all compiler warnings about implicit casts into explicit casts which are visible in the change set. So it's easier to check the code because one does not have to jump from compiler warnings to code and back. 

### Your vote?

So before I go on, I would like to know whether you are interested in cleaning up these warnings and are willing to participate. In particular, it has to be decided how to deal with cases like

- assignments of strlen() to int
- assignments of pointer differences to int (or long)
- calls from modern crypto APIs like EVP (using 'size_t') into legacy crypto APIs (using 'int')

and the code needs to be reviewed thoroughly.


### Configuration

The following configuration was used for fixing the warnings:

```
perl Configure VC-WIN64A threads shared enable-egd enable-crypto-mdebug -WX

Using implicit seed configuration
Configuring OpenSSL version 1.1.1-dev (0x10101000L)
for VC-WIN64A
    no-aria         [default]  OPENSSL_NO_ARIA (skip dir)
    no-asan         [default]  OPENSSL_NO_ASAN
    no-crypto-mdebug-backtrace [default]  OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE
    no-devcryptoeng [default]  OPENSSL_NO_DEVCRYPTOENG
    no-ec_nistp_64_gcc_128 [default]  OPENSSL_NO_EC_NISTP_64_GCC_128
    no-external-tests [default]  OPENSSL_NO_EXTERNAL_TESTS
    no-fuzz-afl     [default]  OPENSSL_NO_FUZZ_AFL
    no-fuzz-libfuzzer [default]  OPENSSL_NO_FUZZ_LIBFUZZER
    no-heartbeats   [default]  OPENSSL_NO_HEARTBEATS
    no-md2          [default]  OPENSSL_NO_MD2 (skip dir)
    no-msan         [default]  OPENSSL_NO_MSAN
    no-rc5          [default]  OPENSSL_NO_RC5 (skip dir)
    no-sctp         [default]  OPENSSL_NO_SCTP
    no-ssl-trace    [default]  OPENSSL_NO_SSL_TRACE
    no-ssl3         [default]  OPENSSL_NO_SSL3
    no-ssl3-method  [default]  OPENSSL_NO_SSL3_METHOD
    no-tls13downgrade [default]  OPENSSL_NO_TLS13DOWNGRADE
    no-tls1_3       [default]  OPENSSL_NO_TLS1_3
    no-ubsan        [default]  OPENSSL_NO_UBSAN
    no-unit-test    [default]  OPENSSL_NO_UNIT_TEST
    no-weak-ssl-ciphers [default]  OPENSSL_NO_WEAK_SSL_CIPHERS
    no-zlib         [default]
    no-zlib-dynamic [default]

PERL          =C:\PERL64\BIN\perl.exe
PERLVERSION   =5.16.3 for MSWin32-x64-multi-thread
HASHBANGPERL  =/usr/bin/env perl
CC            =cl
CFLAG         =-W3 -wd4090 -Gs0 -GF -Gy -nologo -DOPENSSL_SYS_WIN32 -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -D_CRT_SECURE_NO_DE
PRECATE -D_WINSOCK_DEPRECATED_NO_WARNINGS -DUNICODE -D_UNICODE /MD /O2  -WX
CXX           =c++
CXXFLAG       =-W3 -wd4090 -Gs0 -GF -Gy -nologo -DOPENSSL_SYS_WIN32 -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -D_CRT_SECURE_NO_DE
PRECATE -D_WINSOCK_DEPRECATED_NO_WARNINGS -DUNICODE -D_UNICODE /MD /O2  -WX
DEFINES       =OPENSSL_USE_APPLINK DSO_WIN32 NDEBUG OPENSSL_THREADS OPENSSL_NO_STATIC_ENGINE OPENSSL_PIC OPENSSL_IA32_SS
E2 OPENSSL_BN_ASM_MONT OPENSSL_BN_ASM_MONT5 OPENSSL_BN_ASM_GF2m SHA1_ASM SHA256_ASM SHA512_ASM RC4_ASM MD5_ASM AES_ASM V
PAES_ASM BSAES_ASM GHASH_ASM ECP_NISTZ256_ASM PADLOCK_ASM POLY1305_ASM
EX_LIBS       =ws2_32.lib gdi32.lib advapi32.lib crypt32.lib user32.lib
```
