### PR TITLE
apps/speed.c: add -seconds and -bytes options

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2402,10 +2402,10 @@ int speed_main(int argc, char **argv)
                     loopargs[k].ctx = EVP_CIPHER_CTX_new();
                     if (decrypt)
                         EVP_DecryptInit_ex(loopargs[k].ctx, evp_cipher, NULL,
-                                           key16, iv);
+                                           key32, iv);
                     else
                         EVP_EncryptInit_ex(loopargs[k].ctx, evp_cipher, NULL,
-                                           key16, iv);
+                                           key32, iv);
                     EVP_CIPHER_CTX_set_padding(loopargs[k].ctx, 0);
                 }
                 switch (EVP_CIPHER_mode(evp_cipher)) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -245,7 +245,7 @@ static double results[ALGOR_NUM][SIZE_NUM];
 static const int lengths_list[SIZE_NUM] = {
     16, 64, 256, 1024, 8 * 1024, 16 * 1024
 };
-static int lengths_single;
+static int lengths_single = 0;
 
 static const int *lengths = lengths_list;
 
@@ -1487,11 +1487,8 @@ int speed_main(int argc, char **argv)
                 goto end;
             break;
         case OPT_SECONDS:
-            seconds.sym = atoi(opt_arg());
-            seconds.rsa = atoi(opt_arg());
-            seconds.dsa = atoi(opt_arg());
-            seconds.ecdsa = atoi(opt_arg());
-            seconds.ecdh = atoi(opt_arg());
+            seconds.sym = seconds.rsa = seconds.dsa = seconds.ecdsa
+                        = seconds.ecdh = atoi(opt_arg());
             break;
         case OPT_BYTES:
             lengths_single = atoi(opt_arg());
@@ -3239,13 +3236,19 @@ static int do_multi(int multi)
 
 static void multiblock_speed(const EVP_CIPHER *evp_cipher, const SEC *seconds)
 {
-    static int mblengths[] =
+    static int mblengths_list[] =
         { 8 * 1024, 2 * 8 * 1024, 4 * 8 * 1024, 8 * 8 * 1024, 8 * 16 * 1024 };
-    int j, count, num = OSSL_NELEM(mblengths);
+    int *mblengths = mblengths_list;
+    int j, count, num = OSSL_NELEM(mblengths_list);
     const char *alg_name;
     unsigned char *inp, *out, no_key[32], no_iv[16];
     EVP_CIPHER_CTX *ctx;
     double d = 0.0;
+
+    if (lengths_single) {
+        mblengths = &lengths_single;
+        num = 1;
+    }
 
     inp = app_malloc(mblengths[num - 1], "multiblock input buffer");
     out = app_malloc(mblengths[num - 1] + 1024, "multiblock output buffer");

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -124,13 +124,13 @@
 #define MAX_ECDH_SIZE   256
 #define MISALIGN        64
 
-struct sec {
+typedef struct sec_st {
     int sym;
     int rsa;
     int dsa;
     int ecdsa;
     int ecdh;
-};
+} SEC;
 
 static volatile int run = 0;
 
@@ -337,7 +337,7 @@ static double Time_F(int s)
 #endif
 
 static void multiblock_speed(const EVP_CIPHER *evp_cipher,
-                             const struct sec *seconds);
+                             const SEC *seconds);
 
 static int found(const char *name, const OPT_PAIR *pairs, int *result)
 {
@@ -1393,8 +1393,8 @@ int speed_main(int argc, char **argv)
     int ecdh_doit[EC_NUM] = { 0 };
 #endif                          /* ndef OPENSSL_NO_EC */
 
-    struct sec seconds = {SECONDS, RSA_SECONDS, DSA_SECONDS, ECDSA_SECONDS,
-                          ECDH_SECONDS};
+    SEC seconds = {SECONDS, RSA_SECONDS, DSA_SECONDS, ECDSA_SECONDS,
+                   ECDH_SECONDS};
 
     prog = opt_init(argc, argv, speed_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -3237,8 +3237,7 @@ static int do_multi(int multi)
 }
 #endif
 
-static void multiblock_speed(const EVP_CIPHER *evp_cipher,
-                             const struct sec *seconds)
+static void multiblock_speed(const EVP_CIPHER *evp_cipher, const SEC *seconds)
 {
     static int mblengths[] =
         { 8 * 1024, 2 * 8 * 1024, 4 * 8 * 1024, 8 * 8 * 1024, 8 * 16 * 1024 };

--- a/doc/man1/speed.pod
+++ b/doc/man1/speed.pod
@@ -71,6 +71,14 @@ This can be used with a subsequent B<-rand> flag.
 Generate a B<num>-prime RSA key and use it to run the benchmarks. This option
 is only effective if RSA algorithm is specified to test.
 
+=item B<-seconds num>
+
+Run bechmarks for B<num> seconds.
+
+=item B<-bytes num>
+
+Run bechmarks on B<num>-byte buffers. Affects ciphers, digests and the CSPRNG.
+
 =item B<[zero or more test algorithms]>
 
 If any options are given, B<speed> tests those algorithms, otherwise all of


### PR DESCRIPTION
Add speed tool options to run cipher, digest and rand benchmarks for a
single buffer size specified by -bytes over a time interval specified
by -seconds.

When sampling performance data its useful to run the benchmark for more seconds. Furthermore, one is usually interested in collecting samples for single buff size, not average over different sizes.

e.g.
```
openssl speed -seconds 10 -bytes 512 -evp aes-128-gcm
Doing aes-128-gcm for 10s on 512 size blocks: x aes-128-gcm's in 9.99s
[...]
The 'numbers' are in 1000s of bytes per second processed.
type            512 bytes
aes-128-gcm             xk
```

- [x] documentation is added or updated
