### PR TITLE
apps/speed.c: fix ecdh memory leak

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2779,6 +2779,8 @@ int speed_main(int argc, char **argv)
             loopargs[i].ecdh_ctx[testnum] = ctx;
             loopargs[i].outlen[testnum] = outlen;
 
+            EVP_PKEY_free(key_A);
+            EVP_PKEY_free(key_B);
             EVP_PKEY_CTX_free(kctx);
             kctx = NULL;
             EVP_PKEY_CTX_free(test_ctx);


### PR DESCRIPTION
key_A and key_B had 3 references, but only 2 were actually freed.

Reproducible via memory-debug build or via
```
valgrind --leak-check=full --show-leak-kinds=all openssl speed ecdh
```
