### PR TITLE
Fix fatal processing

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -850,11 +850,14 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         }
     }
 
-    if (PACKET_remaining(&binder) != hashsize
-            || tls_psk_do_binder(s, md,
-                                 (const unsigned char *)s->init_buf->data,
-                                 binderoffset, PACKET_data(&binder), NULL,
-                                 sess, 0, ext) != 1) {
+    if (PACKET_remaining(&binder) != hashsize) {
+        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PARSE_CTOS_PSK,
+                 SSL_R_BAD_EXTENSION);
+        goto err;
+    }
+    if (tls_psk_do_binder(s, md, (const unsigned char *)s->init_buf->data,
+                          binderoffset, PACKET_data(&binder), NULL, sess, 0,
+                          ext) != 1) {
         /* SSLfatal() already called */
         goto err;
     }

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -135,7 +135,7 @@ void ossl_statem_fatal(SSL *s, int al, int func, int reason, const char *file,
 #define check_fatal(s, f) \
     do { \
         if (!ossl_assert((s)->statem.in_init \
-                         || (s)->statem.state != MSG_FLOW_ERROR)) \
+                         && (s)->statem.state == MSG_FLOW_ERROR)) \
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, (f), \
                      SSL_R_MISSING_FATAL); \
     } while (0)


### PR DESCRIPTION
The check_fatal macro is supposed to only be called if we are already
expecting to be in the fatal state. The macro asserts that we are and
puts us into the fatal state if not. A bug meant that this detection wasn't working.

There is also a bug in TLSv1.3 PSK processing where there is a code patch that results in an error occurring but us not going into the fatal state. This bug combined with the bug above means that we don't end up in the fatal state even though a fatal error has occurred.

Credit to OSS-Fuzz for finding this issue.