### PR TITLE
Apply system_default configuration on SSL_CTX_new()

### DIFF
--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -229,6 +229,22 @@ For example:
  ECDSA.Certificate = server-ecdsa.pem
  Ciphers = ALL:!RC4
 
+The system default configuration with name B<system_default> if present will
+be applied during any creation of the B<SSL_CTX> structure.
+
+Example of a configuration with the system default:
+
+ ssl_conf = ssl_sect
+
+ [ssl_sect]
+
+ system_default = system_default_sect
+
+ [system_default_sect]
+
+ MinProtocol = TLSv1.2
+
+
 =head1 NOTES
 
 If a configuration file attempts to expand a variable that doesn't exist

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2994,6 +2994,8 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
      */
     ret->max_early_data = SSL3_RT_MAX_PLAIN_LENGTH;
 
+    ssl_ctx_system_config(ret);
+
     return ret;
  err:
     SSLerr(SSL_F_SSL_CTX_NEW, ERR_R_MALLOC_FAILURE);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2579,6 +2579,9 @@ void custom_exts_free(custom_ext_methods *exts);
 
 void ssl_comp_free_compression_methods_int(void);
 
+/* ssl_mcnf.c */
+void ssl_ctx_system_config(SSL_CTX *ctx);
+
 # else /* OPENSSL_UNIT_TEST */
 
 #  define ssl_init_wbio_buffer SSL_test_functions()->p_ssl_init_wbio_buffer

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -134,7 +134,7 @@ static const struct ssl_conf_name *ssl_name_find(const char *name)
     return NULL;
 }
 
-static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name)
+static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
 {
     SSL_CONF_CTX *cctx = NULL;
     size_t i;
@@ -147,17 +147,24 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name)
         SSLerr(SSL_F_SSL_DO_CONFIG, ERR_R_PASSED_NULL_PARAMETER);
         goto err;
     }
+
+    if (name == NULL && system) {
+        name = "system_default";
+    }
     nm = ssl_name_find(name);
     if (nm == NULL) {
-        SSLerr(SSL_F_SSL_DO_CONFIG, SSL_R_INVALID_CONFIGURATION_NAME);
-        ERR_add_error_data(2, "name=", name);
+        if (!system) {
+            SSLerr(SSL_F_SSL_DO_CONFIG, SSL_R_INVALID_CONFIGURATION_NAME);
+            ERR_add_error_data(2, "name=", name);
+        }
         goto err;
     }
     cctx = SSL_CONF_CTX_new();
     if (cctx == NULL)
         goto err;
     flags = SSL_CONF_FLAG_FILE;
-    flags |= SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_REQUIRE_PRIVATE;
+    if (!system)
+        flags |= SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_REQUIRE_PRIVATE;
     if (s != NULL) {
         meth = s->method;
         SSL_CONF_CTX_set_ssl(cctx, s);
@@ -190,10 +197,15 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name)
 
 int SSL_config(SSL *s, const char *name)
 {
-    return ssl_do_config(s, NULL, name);
+    return ssl_do_config(s, NULL, name, 0);
 }
 
 int SSL_CTX_config(SSL_CTX *ctx, const char *name)
 {
-    return ssl_do_config(NULL, ctx, name);
+    return ssl_do_config(NULL, ctx, name, 0);
+}
+
+void ssl_ctx_system_config(SSL_CTX *ctx)
+{
+    ssl_do_config(NULL, ctx, NULL, 1);
 }

--- a/test/build.info
+++ b/test/build.info
@@ -45,7 +45,8 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
-          servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest
+          servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest \
+          sysdefaulttest
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include
@@ -482,6 +483,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[sslbuffertest]=sslbuffertest.c ssltestlib.c
   INCLUDE[sslbuffertest]=../include
   DEPEND[sslbuffertest]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[sysdefaulttest]=sysdefaulttest.c
+  INCLUDE[sysdefaulttest]=../include
+  DEPEND[sysdefaulttest]=../libcrypto ../libssl libtestutil.a
 ENDIF
 
 {-

--- a/test/recipes/90-test_sysdefault.t
+++ b/test/recipes/90-test_sysdefault.t
@@ -1,0 +1,23 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+my $test_name = "test_sysdefault";
+setup($test_name);
+
+plan skip_all => "$test_name is not supported in this build"
+    if disabled("tls1_2") || disabled("rsa");
+
+plan tests => 1;
+
+$ENV{OPENSSL_CONF} = srctop_file("test", "sysdefault.cnf");
+
+ok(run(test(["sysdefaulttest"])), "sysdefaulttest");

--- a/test/sysdefault.cnf
+++ b/test/sysdefault.cnf
@@ -1,0 +1,15 @@
+# Configuration file to test system default SSL configuration
+
+openssl_conf = default_conf
+
+[ default_conf ]
+
+ssl_conf = ssl_sect
+
+[ssl_sect]
+
+system_default = ssl_default_sect
+
+[ssl_default_sect]
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2

--- a/test/sysdefaulttest.c
+++ b/test/sysdefaulttest.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <openssl/opensslconf.h>
+
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+#include <openssl/tls1.h>
+#include "testutil.h"
+
+static SSL_CTX *ctx;
+
+static int test_func(void)
+{
+    if (!TEST_int_eq(SSL_CTX_get_min_proto_version(ctx), TLS1_2_VERSION)
+        && !TEST_int_eq(SSL_CTX_get_max_proto_version(ctx), TLS1_2_VERSION)) {
+        TEST_info("min/max version setting incorrect");
+        return 0;
+    }
+    return 1;
+}
+
+int global_init(void)
+{
+    if (!OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN
+                          | OPENSSL_INIT_LOAD_CONFIG, NULL))
+        return 0;
+    return 1;
+}
+
+int setup_tests(void)
+{
+    if (!TEST_ptr(ctx = SSL_CTX_new(TLS_method())))
+        return 0;
+    ADD_TEST(test_func);
+    return 1;
+}
+
+void cleanup_tests(void)
+{
+    SSL_CTX_free(ctx);
+}


### PR DESCRIPTION
When SSL_CTX is created preinitialize it with system default
configuration from system_default section.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
