### PR TITLE
Add EC_FLAG_EXT_PKEY to optionally disable checking private key against certificate

### DIFF
--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -108,11 +108,14 @@ point_conversion_forms please see L<EC_POINT_new(3)>.
 
 EC_KEY_set_flags() sets the flags in the B<flags> parameter on the EC_KEY
 object. Any flags that are already set are left set. The flags currently
-defined are EC_FLAG_NON_FIPS_ALLOW and EC_FLAG_FIPS_CHECKED. In
-addition there is the flag EC_FLAG_COFACTOR_ECDH which is specific to ECDH.
-EC_KEY_get_flags() returns the current flags that are set for this EC_KEY.
-EC_KEY_clear_flags() clears the flags indicated by the B<flags> parameter; all
-other flags are left in their existing state.
+defined are EC_FLAG_NON_FIPS_ALLOW, EC_FLAG_FIPS_CHECKED, and EC_FLAG_EXT_PKEY.
+EC_FLAG_EXT_PKEY disables comparing a private key with the corresponding
+public key while they are set on an SSL/SSL_CTX object, which is useful for 
+externally stored private keys. In addition there is the flag 
+EC_FLAG_COFACTOR_ECDH which is specific to ECDH.  EC_KEY_get_flags() returns 
+the current flags that are set for this EC_KEY.  EC_KEY_clear_flags() clears 
+the flags indicated by the B<flags> parameter; all other flags are left in 
+their existing state.
 
 EC_KEY_set_asn1_flag() sets the asn1_flag on the underlying EC_GROUP object
 (if set). Refer to L<EC_GROUP_copy(3)> for further information on the

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -729,6 +729,7 @@ int ECPKParameters_print_fp(FILE *fp, const EC_GROUP *x, int off);
 /* some values for the flags field */
 # define EC_FLAG_NON_FIPS_ALLOW  0x1
 # define EC_FLAG_FIPS_CHECKED    0x2
+# define EC_FLAG_EXT_PKEY        0x4
 # define EC_FLAG_COFACTOR_ECDH   0x1000
 
 /** Creates a new EC_KEY object.


### PR DESCRIPTION
RSA_METHOD_FLAG_NO_CHECK permits a private key to be loaded without being checked against the certificate. This PR adds the same functionality for EC keys as well. Based off of PR #2273

CLA: trivial