### PR TITLE
[WIP, Parked] Configure: rethink target resolving, take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
 
 os:
     - linux
+    - osx
 
 compiler:
     - clang
@@ -117,6 +118,9 @@ matrix:
           compiler: gcc
 
 before_script:
+    - if [ "$TRAVIS_OS_NAME" == osx ]; then
+          export CONFIG_OPTS_EXTRA=-Wno-format;
+      fi
     - env
     - if [ "$TRAVIS_PULL_REQUEST" != "false" -a -n "$EXTENDED_TEST" ]; then
           (git log -1 $TRAVIS_COMMIT_RANGE | grep '\[extended tests\]' > /dev/null) || exit 0;
@@ -149,7 +153,7 @@ before_script:
           elif which ccache >/dev/null; then
               CC="ccache $CC";
           fi;
-          $srcdir/config -v $CONFIG_OPTS;
+          $srcdir/config -v $CONFIG_OPTS $CONFIG_OPTS_EXTRA;
       fi
     - cd $top
 

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -59,6 +59,14 @@ my %targets=(
         inherit_from    => [ "BASE_common" ],
         template        => 1,
 
+        cc              => "cc",
+        cxx             => "c++",
+        ranlib          => "ranlib",
+        ar              => "ar",
+        nm              => "nm",
+        rc              => "windres",
+        ranlib          => "ranlib", # This gets special treatment in Configure
+
         ex_libs         =>
             sub {
                 unless ($disabled{zlib}) {
@@ -80,6 +88,10 @@ my %targets=(
         inherit_from    => [ "BASE_common" ],
         template        => 1,
 
+        cc              => "cl",
+        cxx             => undef,
+        ld              => "link",
+        rc              => "rc",
         ex_libs         =>
             sub {
                 unless ($disabled{zlib}) {
@@ -110,6 +122,9 @@ my %targets=(
     BASE_VMS => {
         inherit_from    => [ "BASE_common" ],
         template        => 1,
+
+        cc              => "CC/DECC",
+        cxx             => undef,
 
         build_file       => "descrip.mms",
         build_scheme     => [ "unified", "VMS" ],

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -17,9 +17,8 @@ sub detect_gnu_ld {
     return grep /^GNU ld/, @lines;
 }
 sub detect_gnu_cc {
-    my @lines =
-        `$config{cross_compile_prefix}$target{cc} -v 2>&1`;
-    return grep /gcc/, @lines;
+    my %predefined = compiler_predefined($target{cc});
+    return defined %predefined{__GNUC__};
 }
 
 my %shared_info;

--- a/Configure
+++ b/Configure
@@ -907,7 +907,64 @@ $config{target} = $target;
     };
 }
 
-%target = ( %{$table{DEFAULTS}}, resolve_config($target) );
+{
+    package OpenSSL::ConfigHash;
+    # Also implements Tie::StdHash and Tie::ExtraHash
+    require Tie::Hash;
+    our @ISA = qw(Tie::ExtraHash);
+
+    sub _process_values {
+        my @object    = ( shift );
+        my $target    = shift;
+        my $entry     = shift;
+
+        while(ref($object[0]) eq "CODE") {
+            @object = $object[0]->();
+        }
+        if (ref($object[0]) eq "ARRAY") {
+            return [ map { my @x = _process_values($_, $target, $entry);
+                           @x; }
+                         @{$object[0]} ];
+        }
+        if (ref($object[0]) eq "") {
+            return @object;
+        }
+        die "cannot handle reference type ",ref($object[0])
+            ," found in target ",$target," -> ",$entry,"\n";
+    }
+
+    sub TIEHASH {
+        my $class = shift;
+        my $data = shift;
+        my $target = shift;
+        die "usage error" if @_;
+        die "data error" unless ref $data eq "HASH";
+        return bless [ { %$data }, {}, $target ], $class;
+    }
+    sub FETCH {
+        my $this = shift;
+        my $key = shift;
+        unless ($this->[1]->{$key}) {
+            my @x = _process_values($this->[0]->{$key}, $this->[2], $key);
+            $this->[0]->{$key} = $x[0];
+            delete $this->[0]->{$key}
+                unless defined $this->[0]->{$key};
+            $this->[1]->{$key} = 1;
+        }
+        return $this->[0]->{$key};
+    }
+    sub STORE {
+        my $this = shift;
+        my $key = shift;
+        my $value = shift;
+        $this->[1]->{$key} = 1;
+        return $this->SUPER::STORE($key, $value);
+    }
+}
+
+tie my %target, 'OpenSSL::ConfigHash',
+    { %{$table{DEFAULTS}}, resolve_config($target) },
+    $config{target};
 
 %target = ( %{$table{DEFAULTS}}, %target );
 
@@ -2430,116 +2487,80 @@ sub read_config {
 # recursively
 sub resolve_config {
     my $target = shift;
-    my @breadcrumbs = @_;
 
-#    my $extra_checks = defined($ENV{CONFIGURE_EXTRA_CHECKS});
+    sub withcontext {
+        my $code = pop;
+        my @context = @_;
 
-    if (grep { $_ eq $target } @breadcrumbs) {
-	die "inherit_from loop!  target backtrace:\n  "
-	    ,$target,"\n  ",join("\n  ", @breadcrumbs),"\n";
+        return sub { $code->(combine(@context)->()); };
     }
 
-    if (!defined($table{$target})) {
-	warn "Warning! target $target doesn't exist!\n";
-	return ();
-    }
-    # Recurse through all inheritances.  They will be resolved on the
-    # fly, so when this operation is done, they will all just be a
-    # bunch of attributes with string values.
-    # What we get here, though, are keys with references to lists of
-    # the combined values of them all.  We will deal with lists after
-    # this stage is done.
-    my %combined_inheritance = ();
-    if ($table{$target}->{inherit_from}) {
-	my @inherit_from =
-	    map { ref($_) eq "CODE" ? $_->() : $_ } @{$table{$target}->{inherit_from}};
-	foreach (@inherit_from) {
-	    my %inherited_config = resolve_config($_, $target, @breadcrumbs);
+    sub resolve_inheritance {
+        my $target = shift;
+        my @breadcrumbs = @_;
 
-	    # 'template' is a marker that's considered private to
-	    # the config that had it.
-	    delete $inherited_config{template};
+#        my $extra_checks = defined($ENV{CONFIGURE_EXTRA_CHECKS});
 
-	    foreach (keys %inherited_config) {
-		if (!$combined_inheritance{$_}) {
-		    $combined_inheritance{$_} = [];
-		}
-		push @{$combined_inheritance{$_}}, $inherited_config{$_};
-	    }
-	}
-    }
-
-    # We won't need inherit_from in this target any more, since we've
-    # resolved all the inheritances that lead to this
-    delete $table{$target}->{inherit_from};
-
-    # Now is the time to deal with those lists.  Here's the place to
-    # decide what shall be done with those lists, all based on the
-    # values of the target we're currently dealing with.
-    # - If a value is a coderef, it will be executed with the list of
-    #   inherited values as arguments.
-    # - If the corresponding key doesn't have a value at all or is the
-    #   empty string, the inherited value list will be run through the
-    #   default combiner (below), and the result becomes this target's
-    #   value.
-    # - Otherwise, this target's value is assumed to be a string that
-    #   will simply override the inherited list of values.
-    my $default_combiner = add();
-
-    my %all_keys =
-	map { $_ => 1 } (keys %combined_inheritance,
-			 keys %{$table{$target}});
-
-    sub process_values {
-	my $object    = shift;
-	my $inherited = shift;  # Always a [ list ]
-	my $target    = shift;
-	my $entry     = shift;
-
-        $add_called = 0;
-
-        while(ref($object) eq "CODE") {
-            $object = $object->(@$inherited);
+        if (grep { $_ eq $target } @breadcrumbs) {
+            die "inherit_from loop!  target backtrace:\n  "
+                ,$target,"\n  ",join("\n  ", @breadcrumbs),"\n";
         }
-        if (!defined($object)) {
+
+        if (!defined($table{$target})) {
+            warn "Warning! target $target doesn't exist!\n";
             return ();
         }
-        elsif (ref($object) eq "ARRAY") {
-            local $add_called;  # To make sure recursive calls don't affect it
-            return [ map { process_values($_, $inherited, $target, $entry) }
-                     @$object ];
-        } elsif (ref($object) eq "") {
-            return $object;
-        } else {
-            die "cannot handle reference type ",ref($object)
-                ," found in target ",$target," -> ",$entry,"\n";
+        # Recurse through all inheritances.  The inheritance chain itself
+        # is resolved on the fly, executing CODErefs to get the intended
+        # targets to inherit from when needed.
+        # When all is done, we have a bunch of attributes with smart values,
+        # either literals if they weren't CODErefs in the currently processed
+        # target, or CODErefs that combine these with inherited values.
+        # The final execution of all the CODErefs is left to the caller,
+        # thereby allowing for late processing if that's appropriate.
+
+        my @values_stack = ();
+        my %new_values = ( %{$table{$target}} );
+        if ($new_values{inherit_from}) {
+            my @inherit_from =
+                map { ref($_) eq "CODE" ? $_->() : $_ }
+                @{$new_values{inherit_from}};
+            my %combined_inheritance = ();
+
+            foreach (@inherit_from) {
+                my %inherited_config = resolve_inheritance($_, $target,
+                                                           @breadcrumbs);
+
+                # 'template' is a marker that's considered private to
+                # the config that had it.
+                delete $inherited_config{template};
+
+                foreach (keys %inherited_config) {
+                    if (!$combined_inheritance{$_}) {
+                        $combined_inheritance{$_} = [];
+                    }
+                    push @{$combined_inheritance{$_}}, $inherited_config{$_};
+                }
+            }
+
+            foreach (keys %combined_inheritance) {
+                if (! defined $new_values{$_}) {
+                    $new_values{$_} = combine(@{$combined_inheritance{$_}});
+                } elsif (ref($new_values{$_}) eq 'CODE') {
+                    $new_values{$_} = withcontext(@{$combined_inheritance{$_}},
+                                                  $new_values{$_});
+                }
+                # If neither undefined or CODEref, $new_values{$_} is left alone
+            }
+
+            delete $new_values{inherit_from};
         }
+
+        $table{$target} = { %new_values };
+        return %new_values;
     }
 
-    foreach (sort keys %all_keys) {
-        my $previous = $combined_inheritance{$_};
-
-	# Current target doesn't have a value for the current key?
-	# Assign it the default combiner, the rest of this loop body
-	# will handle it just like any other coderef.
-	if (!exists $table{$target}->{$_}) {
-	    $table{$target}->{$_} = $default_combiner;
-	}
-
-	$table{$target}->{$_} = process_values($table{$target}->{$_},
-					       $combined_inheritance{$_},
-					       $target, $_);
-        unless(defined($table{$target}->{$_})) {
-            delete $table{$target}->{$_};
-        }
-#        if ($extra_checks &&
-#            $previous && !($add_called ||  $previous ~~ $table{$target}->{$_})) {
-#            warn "$_ got replaced in $target\n";
-#        }
-    }
-
-    # Finally done, return the result.
-    return %{$table{$target}};
+    return resolve_inheritance($target);
 }
 
 sub usage
@@ -2660,8 +2681,9 @@ sub env
 sub print_table_entry
 {
     my $target = shift;
-    my %target = resolve_config($target);
     my $type = shift;
+
+    tie my %target, 'OpenSSL::ConfigHash', { resolve_config($target) }, $target;
 
     # Don't print the templates
     return if $target{template};

--- a/Configure
+++ b/Configure
@@ -875,9 +875,39 @@ if ($d) {
     }
 }
 $config{target} = $target;
-my %target = resolve_config($target);
+&usage if (!$table{$target} || $table{$target}->{template});
 
-&usage if (!%target || $target{template});
+{
+    my %overrides;
+
+    # This is hackery, should really be in the config files.
+    $overrides{exe_extension}="";
+    $overrides{exe_extension}=".exe"
+        if $config{target} eq "DJGPP" || $config{target} =~ /^(?:Cygwin|mingw)/;
+    $overrides{exe_extension}=".pm"
+        if ($config{target} =~ /vos/);
+
+    # Allow overriding certain values through the environment
+    $overrides{cc} =      env('CC')             if env('CC');
+    $overrides{cxx} =     env('CXX')            if env('CXX');
+    $overrides{ranlib} =  env('RANLIB')         if env('RANLIB');
+    $overrides{ar} =      env('AR')             if env('AR');
+    $overrides{nm} =      env('NM')             if env('NM');
+    $overrides{rc} =      env('RC')  || env('WINDRES')
+        if env('RC')  || env('WINDRES');
+    $overrides{build_file} = env('BUILDFILE')   if env('BUILDFILE');
+
+    # Overrides for thread_scheme and shared_target in case they are disabled
+    $overrides{thread_scheme} = "(unknown)"     if $disabled{threads};
+    $overrides{shared_target} = ""              if $disabled{shared};
+
+    $table{$target} = {
+        %{$table{$target}},
+        %overrides,
+    };
+}
+
+%target = ( %{$table{DEFAULTS}}, resolve_config($target) );
 
 %target = ( %{$table{DEFAULTS}}, %target );
 
@@ -1005,19 +1035,20 @@ foreach (sort (keys %disabled))
 	print "\n";
 	}
 
+# Some late overrides that can't be done within the config stuff
 $target{cxxflags}=$target{cflags} unless defined $target{cxxflags};
-$target{exe_extension}="";
-$target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
-                                  || $config{target} =~ /^(?:Cygwin|mingw)/);
-$target{exe_extension}=".pm"  if ($config{target} =~ /vos/);
-
 ($target{shared_extension_simple}=$target{shared_extension})
     =~ s|\.\$\(SHLIB_VERSION_NUMBER\)||;
 $target{dso_extension}=$target{shared_extension_simple};
 ($target{shared_import_extension}=$target{shared_extension_simple}.".a")
     if ($config{target} =~ /^(?:Cygwin|mingw)/);
 
+# ranlib gets a special treatment...  if it doesn't exist, it's not required
+$target{ranlib} = which("$config{cross_compile_prefix}$target{ranlib}")
+    ? "\$(CROSS_COMPILE)$target{ranlib}" : "true"
+    if defined $target{ranlib};
 
+# Now, some initial configuration parameters
 $config{cross_compile_prefix} = env('CROSS_COMPILE')
     if $config{cross_compile_prefix} eq "";
 
@@ -1027,18 +1058,6 @@ $config{cross_compile_prefix} = env('CROSS_COMPILE')
 $config{perl} =    ($^O ne "VMS" ? $^X : "perl");
 $config{hashbangperl} =
     env('HASHBANGPERL')           || env('PERL')      || "/usr/bin/env perl";
-$target{cc} =      env('CC')      || $target{cc}      || "cc";
-$target{cxx} =     env('CXX')     || $target{cxx}     || "c++";
-$target{ranlib} =  env('RANLIB')  || $target{ranlib}  ||
-                   (which("$config{cross_compile_prefix}ranlib") ?
-                          "\$(CROSS_COMPILE)ranlib" : "true");
-$target{ar} =      env('AR')      || $target{ar}      || "ar";
-$target{nm} =      env('NM')      || $target{nm}      || "nm";
-$target{rc} =
-    env('RC')  || env('WINDRES')  || $target{rc}      || "windres";
-
-# Allow overriding the build file name
-$target{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
 
 # Cache information necessary for reconfiguration
 $config{cc} = $target{cc};


### PR DESCRIPTION
This replaces #4684 with a slightly different idea: lazy/delayed evaluation

The idea is that the computation of certain config target attribute may depend on something that in turn depends on another attribute in the same config target.  We end up in a kind of catch 22, which *could* be resolved by having certain specific attributes resolved before other, but that leads to a spaghetti of code that must be carefully tuned each time we need to do this.  However, only computing each attribute value when it's asked for and not before changes this so we don't have to be overly careful any more.