### PR TITLE
doc: Bad prototypes of EVP_PKEY_CTX_new()

### DIFF
--- a/doc/man3/EVP_PKEY_decrypt.pod
+++ b/doc/man3/EVP_PKEY_decrypt.pod
@@ -55,7 +55,7 @@ Decrypt data using OAEP (for RSA keys):
  EVP_PKEY *key;
 
  /*
-  * NB: assumes eng, key in, inlen are already set up
+  * NB: assumes key, eng, in, inlen are already set up
   * and that key is an RSA private key
   */
  ctx = EVP_PKEY_CTX_new(key, eng);

--- a/doc/man3/EVP_PKEY_decrypt.pod
+++ b/doc/man3/EVP_PKEY_decrypt.pod
@@ -49,15 +49,16 @@ Decrypt data using OAEP (for RSA keys):
  #include <openssl/rsa.h>
 
  EVP_PKEY_CTX *ctx;
+ ENGINE *eng;
  unsigned char *out, *in;
  size_t outlen, inlen;
  EVP_PKEY *key;
 
  /*
-  * NB: assumes key in, inlen are already set up
+  * NB: assumes eng, key in, inlen are already set up
   * and that key is an RSA private key
   */
- ctx = EVP_PKEY_CTX_new(key);
+ ctx = EVP_PKEY_CTX_new(key, eng);
  if (!ctx)
      /* Error occurred */
  if (EVP_PKEY_decrypt_init(ctx) <= 0)

--- a/doc/man3/EVP_PKEY_derive.pod
+++ b/doc/man3/EVP_PKEY_derive.pod
@@ -54,7 +54,7 @@ Derive shared secret (for example DH or EC keys):
  unsigned char *skey;
  size_t skeylen;
  EVP_PKEY *pkey, *peerkey;
- /* NB: assumes eng, pkey, peerkey have been already set up */
+ /* NB: assumes pkey, eng, peerkey have been already set up */
 
  ctx = EVP_PKEY_CTX_new(pkey, eng);
  if (!ctx)

--- a/doc/man3/EVP_PKEY_derive.pod
+++ b/doc/man3/EVP_PKEY_derive.pod
@@ -50,12 +50,13 @@ Derive shared secret (for example DH or EC keys):
  #include <openssl/rsa.h>
 
  EVP_PKEY_CTX *ctx;
+ ENGINE *eng;
  unsigned char *skey;
  size_t skeylen;
  EVP_PKEY *pkey, *peerkey;
- /* NB: assumes pkey, peerkey have been already set up */
+ /* NB: assumes eng, pkey, peerkey have been already set up */
 
- ctx = EVP_PKEY_CTX_new(pkey);
+ ctx = EVP_PKEY_CTX_new(pkey, eng);
  if (!ctx)
      /* Error occurred */
  if (EVP_PKEY_derive_init(ctx) <= 0)

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -141,7 +141,7 @@ Generate a key from a set of parameters:
  ENGINE *eng;
  EVP_PKEY *pkey = NULL, *param;
 
- /* Assumed eng, param are set up already */
+ /* Assumed param, eng are set up already */
  ctx = EVP_PKEY_CTX_new(param, eng);
  if (!ctx)
      /* Error occurred */

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -138,10 +138,11 @@ Generate a key from a set of parameters:
  #include <openssl/rsa.h>
 
  EVP_PKEY_CTX *ctx;
+ ENGINE *eng;
  EVP_PKEY *pkey = NULL, *param;
 
- /* Assumed param is set up already */
- ctx = EVP_PKEY_CTX_new(param);
+ /* Assumed eng, param are set up already */
+ ctx = EVP_PKEY_CTX_new(param, eng);
  if (!ctx)
      /* Error occurred */
  if (EVP_PKEY_keygen_init(ctx) <= 0)

--- a/doc/man3/EVP_PKEY_verify.pod
+++ b/doc/man3/EVP_PKEY_verify.pod
@@ -60,7 +60,7 @@ Verify signature using PKCS#1 and SHA256 digest:
   * NB: assumes verify_key, sig, siglen md and mdlen are already set up
   * and that verify_key is an RSA public key
   */
- ctx = EVP_PKEY_CTX_new(verify_key);
+ ctx = EVP_PKEY_CTX_new(verify_key, NULL /* no engine */);
  if (!ctx)
      /* Error occurred */
  if (EVP_PKEY_verify_init(ctx) <= 0)

--- a/doc/man3/EVP_PKEY_verify_recover.pod
+++ b/doc/man3/EVP_PKEY_verify_recover.pod
@@ -65,7 +65,7 @@ Recover digest originally signed using PKCS#1 and SHA256 digest:
   * NB: assumes verify_key, sig and siglen are already set up
   * and that verify_key is an RSA public key
   */
- ctx = EVP_PKEY_CTX_new(verify_key);
+ ctx = EVP_PKEY_CTX_new(verify_key, NULL /* no engine */);
  if (!ctx)
      /* Error occurred */
  if (EVP_PKEY_verify_recover_init(ctx) <= 0)


### PR DESCRIPTION
While checking manual pages, I hit the issue that in several places, the second argument of the function `EVP_PKEY_CTX_new` is omitted. It is overall not used consistently throughout the documentation, either as NULL with comment or with "assumed-set-up" `*eng` variable.

If one of the way is preferred over the other, please let me know and I will adjust the change.

##### Checklist
- [X] documentation is added or updated