### PR TITLE
Fix fatalerrtest (1.0.2)

### DIFF
--- a/ssl/fatalerrtest.c
+++ b/ssl/fatalerrtest.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
     }
 
     /* SSL_read()/SSL_write should fail because of a previous fatal error */
-    if ((len = SSL_read(sssl, buf, sizeof(buf - 1))) > 0) {
+    if ((len = SSL_read(sssl, buf, sizeof(buf) - 1)) > 0) {
         buf[len] = '\0';
         printf("Unexpected success reading data: %s\n", buf);
         goto err;

--- a/ssl/fatalerrtest.c
+++ b/ssl/fatalerrtest.c
@@ -13,8 +13,8 @@
 
 int main(int argc, char *argv[])
 {
-    SSL_CTX *sctx, *cctx;
-    SSL *sssl, *cssl;
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
     const char *msg = "Dummy";
     BIO *err = NULL, *wbio = NULL;
     int ret = 1, len;


### PR DESCRIPTION
Some variables are uninitialised on use in the event of an error condition. This issue doesn't seem to be present in the master/1.1.0 versions, so I'm not sure how that happened.

Also a misplaced -1 means the buffer size used for the SSL_read() call is the size of a char * not the size of the array.

Fixes #4865
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
