### PR TITLE
Fix the buffer sizing in the fatalerrtest (master)

### DIFF
--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -59,7 +59,7 @@ static int test_fatalerr(void)
         goto err;
 
     /* SSL_read()/SSL_write should fail because of a previous fatal error */
-    if (!TEST_int_le(len = SSL_read(sssl, buf, sizeof(buf - 1)), 0)) {
+    if (!TEST_int_le(len = SSL_read(sssl, buf, sizeof(buf) - 1), 0)) {
         buf[len] = '\0';
         TEST_error("Unexpected success reading data: %s\n", buf);
         goto err;


### PR DESCRIPTION
A misplaced -1 means the wrong buffer size is used in the SSL_read() call.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
