### PR TITLE
Add missing prototype for FIPS callback

### DIFF
--- a/crypto/o_init.c
+++ b/crypto/o_init.c
@@ -58,6 +58,11 @@
 #ifdef OPENSSL_FIPS
 # include <openssl/fips.h>
 # include <openssl/rand.h>
+
+# ifndef OPENSSL_NO_DEPRECATED
+/* the prototype is missing in <openssl/fips.h> */
+void FIPS_crypto_set_id_callback(unsigned long (*func)(void));
+# endif
 #endif
 
 /*


### PR DESCRIPTION
Fixes #2533

The call to FIPS_crypto_set_id_callback() was added in revision a43cfd7bb1fc681d563e, but there is no prototype for it in <openssl/fips.h>.
