### PR TITLE
Consistent formatting for sizeof(foo)

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1425,9 +1425,9 @@ int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial
         OPENSSL_strlcpy(buf[0], serialfile, BSIZE);
     else {
 #ifndef OPENSSL_SYS_VMS
-        j = BIO_snprintf(buf[0], sizeof buf[0], "%s.%s", serialfile, suffix);
+        j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s.%s", serialfile, suffix);
 #else
-        j = BIO_snprintf(buf[0], sizeof buf[0], "%s-%s", serialfile, suffix);
+        j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s-%s", serialfile, suffix);
 #endif
     }
     out = BIO_new_file(buf[0], "w");
@@ -1468,11 +1468,11 @@ int rotate_serial(const char *serialfile, const char *new_suffix,
         goto err;
     }
 #ifndef OPENSSL_SYS_VMS
-    j = BIO_snprintf(buf[0], sizeof buf[0], "%s.%s", serialfile, new_suffix);
-    j = BIO_snprintf(buf[1], sizeof buf[1], "%s.%s", serialfile, old_suffix);
+    j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s.%s", serialfile, new_suffix);
+    j = BIO_snprintf(buf[1], sizeof(buf[1]), "%s.%s", serialfile, old_suffix);
 #else
-    j = BIO_snprintf(buf[0], sizeof buf[0], "%s-%s", serialfile, new_suffix);
-    j = BIO_snprintf(buf[1], sizeof buf[1], "%s-%s", serialfile, old_suffix);
+    j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s-%s", serialfile, new_suffix);
+    j = BIO_snprintf(buf[1], sizeof(buf[1]), "%s-%s", serialfile, old_suffix);
 #endif
     if (rename(serialfile, buf[1]) < 0 && errno != ENOENT
 #ifdef ENOTDIR
@@ -1537,9 +1537,9 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
         goto err;
 
 #ifndef OPENSSL_SYS_VMS
-    BIO_snprintf(buf, sizeof buf, "%s.attr", dbfile);
+    BIO_snprintf(buf, sizeof(buf), "%s.attr", dbfile);
 #else
-    BIO_snprintf(buf, sizeof buf, "%s-attr", dbfile);
+    BIO_snprintf(buf, sizeof(buf), "%s-attr", dbfile);
 #endif
     dbattr_conf = app_load_config(buf);
 
@@ -1600,13 +1600,13 @@ int save_index(const char *dbfile, const char *suffix, CA_DB *db)
         goto err;
     }
 #ifndef OPENSSL_SYS_VMS
-    j = BIO_snprintf(buf[2], sizeof buf[2], "%s.attr", dbfile);
-    j = BIO_snprintf(buf[1], sizeof buf[1], "%s.attr.%s", dbfile, suffix);
-    j = BIO_snprintf(buf[0], sizeof buf[0], "%s.%s", dbfile, suffix);
+    j = BIO_snprintf(buf[2], sizeof(buf[2]), "%s.attr", dbfile);
+    j = BIO_snprintf(buf[1], sizeof(buf[1]), "%s.attr.%s", dbfile, suffix);
+    j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s.%s", dbfile, suffix);
 #else
-    j = BIO_snprintf(buf[2], sizeof buf[2], "%s-attr", dbfile);
-    j = BIO_snprintf(buf[1], sizeof buf[1], "%s-attr-%s", dbfile, suffix);
-    j = BIO_snprintf(buf[0], sizeof buf[0], "%s-%s", dbfile, suffix);
+    j = BIO_snprintf(buf[2], sizeof(buf[2]), "%s-attr", dbfile);
+    j = BIO_snprintf(buf[1], sizeof(buf[1]), "%s-attr-%s", dbfile, suffix);
+    j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s-%s", dbfile, suffix);
 #endif
     out = BIO_new_file(buf[0], "w");
     if (out == NULL) {
@@ -1649,17 +1649,17 @@ int rotate_index(const char *dbfile, const char *new_suffix,
         goto err;
     }
 #ifndef OPENSSL_SYS_VMS
-    j = BIO_snprintf(buf[4], sizeof buf[4], "%s.attr", dbfile);
-    j = BIO_snprintf(buf[3], sizeof buf[3], "%s.attr.%s", dbfile, old_suffix);
-    j = BIO_snprintf(buf[2], sizeof buf[2], "%s.attr.%s", dbfile, new_suffix);
-    j = BIO_snprintf(buf[1], sizeof buf[1], "%s.%s", dbfile, old_suffix);
-    j = BIO_snprintf(buf[0], sizeof buf[0], "%s.%s", dbfile, new_suffix);
+    j = BIO_snprintf(buf[4], sizeof(buf[4]), "%s.attr", dbfile);
+    j = BIO_snprintf(buf[3], sizeof(buf[3]), "%s.attr.%s", dbfile, old_suffix);
+    j = BIO_snprintf(buf[2], sizeof(buf[2]), "%s.attr.%s", dbfile, new_suffix);
+    j = BIO_snprintf(buf[1], sizeof(buf[1]), "%s.%s", dbfile, old_suffix);
+    j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s.%s", dbfile, new_suffix);
 #else
-    j = BIO_snprintf(buf[4], sizeof buf[4], "%s-attr", dbfile);
-    j = BIO_snprintf(buf[3], sizeof buf[3], "%s-attr-%s", dbfile, old_suffix);
-    j = BIO_snprintf(buf[2], sizeof buf[2], "%s-attr-%s", dbfile, new_suffix);
-    j = BIO_snprintf(buf[1], sizeof buf[1], "%s-%s", dbfile, old_suffix);
-    j = BIO_snprintf(buf[0], sizeof buf[0], "%s-%s", dbfile, new_suffix);
+    j = BIO_snprintf(buf[4], sizeof(buf[4]), "%s-attr", dbfile);
+    j = BIO_snprintf(buf[3], sizeof(buf[3]), "%s-attr-%s", dbfile, old_suffix);
+    j = BIO_snprintf(buf[2], sizeof(buf[2]), "%s-attr-%s", dbfile, new_suffix);
+    j = BIO_snprintf(buf[1], sizeof(buf[1]), "%s-%s", dbfile, old_suffix);
+    j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s-%s", dbfile, new_suffix);
 #endif
     if (rename(dbfile, buf[1]) < 0 && errno != ENOENT
 #ifdef ENOTDIR

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -236,7 +236,7 @@ int ciphers_main(int argc, char **argv)
                     nm = "UNKNOWN";
                 BIO_printf(bio_out, "%s - ", nm);
             }
-            BIO_puts(bio_out, SSL_CIPHER_description(c, buf, sizeof buf));
+            BIO_puts(bio_out, SSL_CIPHER_description(c, buf, sizeof(buf)));
         }
     }
 

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -319,9 +319,9 @@ int dhparam_main(int argc, char **argv)
                         "\n"
                         "    if (dh == NULL)\n"
                         "        return NULL;\n");
-        BIO_printf(out, "    dhp_bn = BN_bin2bn(dhp_%d, sizeof (dhp_%d), NULL);\n",
+        BIO_printf(out, "    dhp_bn = BN_bin2bn(dhp_%d, sizeof(dhp_%d), NULL);\n",
                    bits, bits);
-        BIO_printf(out, "    dhg_bn = BN_bin2bn(dhg_%d, sizeof (dhg_%d), NULL);\n",
+        BIO_printf(out, "    dhg_bn = BN_bin2bn(dhg_%d, sizeof(dhg_%d), NULL);\n",
                    bits, bits);
         BIO_printf(out, "    if (dhp_bn == NULL || dhg_bn == NULL\n"
                         "            || !DH_set0_pqg(dh, dhp_bn, NULL, dhg_bn)) {\n"

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -180,11 +180,11 @@ int dsaparam_main(int argc, char **argv)
                             "\n");
         BIO_printf(bio_out, "    if (dsa == NULL)\n"
                             "        return NULL;\n");
-        BIO_printf(bio_out, "    dsa->p = BN_bin2bn(dsap_%d, sizeof (dsap_%d), NULL);\n",
+        BIO_printf(bio_out, "    dsa->p = BN_bin2bn(dsap_%d, sizeof(dsap_%d), NULL);\n",
                bits_p, bits_p);
-        BIO_printf(bio_out, "    dsa->q = BN_bin2bn(dsaq_%d, sizeof (dsaq_%d), NULL);\n",
+        BIO_printf(bio_out, "    dsa->q = BN_bin2bn(dsaq_%d, sizeof(dsaq_%d), NULL);\n",
                bits_p, bits_p);
-        BIO_printf(bio_out, "    dsa->g = BN_bin2bn(dsag_%d, sizeof (dsag_%d), NULL);\n",
+        BIO_printf(bio_out, "    dsa->g = BN_bin2bn(dsag_%d, sizeof(dsag_%d), NULL);\n",
                bits_p, bits_p);
         BIO_printf(bio_out, "    if (!dsa->p || !dsa->q || !dsa->g) {\n"
                             "        DSA_free(dsa);\n"

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -347,24 +347,24 @@ int ecparam_main(int argc, char **argv)
                         "    BIGNUM *tmp_3 = NULL;\n"
                         "\n");
 
-        BIO_printf(out, "    if ((tmp_1 = BN_bin2bn(ec_p_%d, sizeof (ec_p_%d), NULL)) == NULL)\n"
+        BIO_printf(out, "    if ((tmp_1 = BN_bin2bn(ec_p_%d, sizeof(ec_p_%d), NULL)) == NULL)\n"
                         "        goto err;\n", len, len);
-        BIO_printf(out, "    if ((tmp_2 = BN_bin2bn(ec_a_%d, sizeof (ec_a_%d), NULL)) == NULL)\n"
+        BIO_printf(out, "    if ((tmp_2 = BN_bin2bn(ec_a_%d, sizeof(ec_a_%d), NULL)) == NULL)\n"
                         "        goto err;\n", len, len);
-        BIO_printf(out, "    if ((tmp_3 = BN_bin2bn(ec_b_%d, sizeof (ec_b_%d), NULL)) == NULL)\n"
+        BIO_printf(out, "    if ((tmp_3 = BN_bin2bn(ec_b_%d, sizeof(ec_b_%d), NULL)) == NULL)\n"
                         "        goto err;\n", len, len);
         BIO_printf(out, "    if ((group = EC_GROUP_new_curve_GFp(tmp_1, tmp_2, tmp_3, NULL)) == NULL)\n"
                         "        goto err;\n"
                         "\n");
         BIO_printf(out, "    /* build generator */\n");
-        BIO_printf(out, "    if ((tmp_1 = BN_bin2bn(ec_gen_%d, sizeof (ec_gen_%d), tmp_1)) == NULL)\n"
+        BIO_printf(out, "    if ((tmp_1 = BN_bin2bn(ec_gen_%d, sizeof(ec_gen_%d), tmp_1)) == NULL)\n"
                         "        goto err;\n", len, len);
         BIO_printf(out, "    point = EC_POINT_bn2point(group, tmp_1, NULL, NULL);\n");
         BIO_printf(out, "    if (point == NULL)\n"
                         "        goto err;\n");
-        BIO_printf(out, "    if ((tmp_2 = BN_bin2bn(ec_order_%d, sizeof (ec_order_%d), tmp_2)) == NULL)\n"
+        BIO_printf(out, "    if ((tmp_2 = BN_bin2bn(ec_order_%d, sizeof(ec_order_%d), tmp_2)) == NULL)\n"
                         "        goto err;\n", len, len);
-        BIO_printf(out, "    if ((tmp_3 = BN_bin2bn(ec_cofactor_%d, sizeof (ec_cofactor_%d), tmp_3)) == NULL)\n"
+        BIO_printf(out, "    if ((tmp_3 = BN_bin2bn(ec_cofactor_%d, sizeof(ec_cofactor_%d), tmp_3)) == NULL)\n"
                         "        goto err;\n", len, len);
         BIO_printf(out, "    if (!EC_GROUP_set_generator(group, point, tmp_2, tmp_3))\n"
                         "        goto err;\n"

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -98,7 +98,7 @@ int enc_main(int argc, char **argv)
     char *hkey = NULL, *hiv = NULL, *hsalt = NULL, *p;
     char *infile = NULL, *outfile = NULL, *prog;
     char *str = NULL, *passarg = NULL, *pass = NULL, *strbuf = NULL;
-    char mbuf[sizeof magic - 1];
+    char mbuf[sizeof(magic) - 1];
     OPTION_CHOICE o;
     int bsize = BSIZE, verbose = 0, debug = 0, olb64 = 0, nosalt = 0;
     int enc = 1, printkey = 0, i, k;
@@ -220,7 +220,7 @@ int enc_main(int argc, char **argv)
             in = bio_open_default(opt_arg(), 'r', FORMAT_TEXT);
             if (in == NULL)
                 goto opthelp;
-            i = BIO_gets(in, buf, sizeof buf);
+            i = BIO_gets(in, buf, sizeof(buf));
             BIO_free(in);
             in = NULL;
             if (i <= 0) {
@@ -409,11 +409,11 @@ int enc_main(int argc, char **argv)
             } else {
                 if (enc) {
                     if (hsalt) {
-                        if (!set_hex(hsalt, salt, sizeof salt)) {
+                        if (!set_hex(hsalt, salt, sizeof(salt))) {
                             BIO_printf(bio_err, "invalid hex salt value\n");
                             goto end;
                         }
-                    } else if (RAND_bytes(salt, sizeof salt) <= 0) {
+                    } else if (RAND_bytes(salt, sizeof(salt)) <= 0) {
                         goto end;
                     }
                     /*
@@ -421,20 +421,20 @@ int enc_main(int argc, char **argv)
                      */
                     if ((printkey != 2)
                         && (BIO_write(wbio, magic,
-                                      sizeof magic - 1) != sizeof magic - 1
+                                      sizeof(magic) - 1) != sizeof(magic) - 1
                             || BIO_write(wbio,
                                          (char *)salt,
-                                         sizeof salt) != sizeof salt)) {
+                                         sizeof(salt)) != sizeof(salt))) {
                         BIO_printf(bio_err, "error writing output file\n");
                         goto end;
                     }
-                } else if (BIO_read(rbio, mbuf, sizeof mbuf) != sizeof mbuf
+                } else if (BIO_read(rbio, mbuf, sizeof(mbuf)) != sizeof(mbuf)
                            || BIO_read(rbio,
                                        (unsigned char *)salt,
-                                       sizeof salt) != sizeof salt) {
+                                       sizeof(salt)) != sizeof(salt)) {
                     BIO_printf(bio_err, "error reading input file\n");
                     goto end;
-                } else if (memcmp(mbuf, magic, sizeof magic - 1)) {
+                } else if (memcmp(mbuf, magic, sizeof(magic) - 1)) {
                     BIO_printf(bio_err, "bad magic number\n");
                     goto end;
                 }

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -57,7 +57,7 @@ int errstr_main(int argc, char **argv)
              */
             OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
                              | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-            ERR_error_string_n(l, buf, sizeof buf);
+            ERR_error_string_n(l, buf, sizeof(buf));
             BIO_printf(bio_out, "%s\n", buf);
         }
     }

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1088,7 +1088,7 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio)
     *pcbio = cbio;
 
     /* Read the request line. */
-    len = BIO_gets(cbio, reqbuf, sizeof reqbuf);
+    len = BIO_gets(cbio, reqbuf, sizeof(reqbuf));
     if (len <= 0)
         return 1;
     if (strncmp(reqbuf, "GET ", 4) == 0) {
@@ -1130,7 +1130,7 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio)
 
     /* Read and skip past the headers. */
     for (;;) {
-        len = BIO_gets(cbio, inbuf, sizeof inbuf);
+        len = BIO_gets(cbio, inbuf, sizeof(inbuf));
         if (len <= 0)
             return 1;
         if ((inbuf[0] == '\r') || (inbuf[0] == '\n'))

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
     for (;;) {
         ret = 0;
         /* Read a line, continue reading if line ends with \ */
-        for (p = buf, n = sizeof buf, i = 0, first = 1; n > 0; first = 0) {
+        for (p = buf, n = sizeof(buf), i = 0, first = 1; n > 0; first = 0) {
             prompt = first ? "OpenSSL> " : "> ";
             p[0] = '\0';
 #ifndef READLINE

--- a/apps/opt.c
+++ b/apps/opt.c
@@ -58,8 +58,8 @@ char *opt_progname(const char *argv0)
         n -= 4;
 
     /* Copy over the name, in lowercase. */
-    if (n > sizeof prog - 1)
-        n = sizeof prog - 1;
+    if (n > sizeof(prog) - 1)
+        n = sizeof(prog) - 1;
     for (q = prog, i = 0; i < n; i++, p++)
         *q++ = tolower((unsigned char)*p);
     *q = '\0';
@@ -80,9 +80,9 @@ char *opt_progname(const char *argv0)
         }
 
     q = strrchr(p, '.');
-    strncpy(prog, p, sizeof prog - 1);
-    prog[sizeof prog - 1] = '\0';
-    if (q != NULL && q - p < sizeof prog)
+    strncpy(prog, p, sizeof(prog) - 1);
+    prog[sizeof(prog) - 1] = '\0';
+    if (q != NULL && q - p < sizeof(prog))
         prog[q - p] = '\0';
     return prog;
 }
@@ -99,8 +99,8 @@ char *opt_progname(const char *argv0)
             p++;
             break;
         }
-    strncpy(prog, p, sizeof prog - 1);
-    prog[sizeof prog - 1] = '\0';
+    strncpy(prog, p, sizeof(prog) - 1);
+    prog[sizeof(prog) - 1] = '\0';
     return prog;
 }
 #endif
@@ -859,7 +859,7 @@ void opt_help(const OPTIONS *list)
             i += 1 + strlen(valtype2param(o));
         if (i < MAX_OPT_HELP_WIDTH && i > width)
             width = i;
-        assert(i < (int)sizeof start);
+        assert(i < (int)sizeof(start));
     }
 
     if (standard_prolog)
@@ -876,7 +876,7 @@ void opt_help(const OPTIONS *list)
 
         /* Pad out prefix */
         memset(start, ' ', sizeof(start) - 1);
-        start[sizeof start - 1] = '\0';
+        start[sizeof(start) - 1] = '\0';
 
         if (o->name == OPT_MORE_STR) {
             /* Continuation of previous line; pad and print. */

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -274,7 +274,7 @@ int passwd_main(int argc, char **argv)
                     /* ignore rest of line */
                     char trash[BUFSIZ];
                     do
-                        r = BIO_gets(in, trash, sizeof trash);
+                        r = BIO_gets(in, trash, sizeof(trash));
                     while ((r > 0) && (!strchr(trash, '\n')));
                 }
 
@@ -325,14 +325,14 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
 
     out_buf[0] = 0;
     magic_len = strlen(magic);
-    OPENSSL_strlcpy(ascii_magic, magic, sizeof ascii_magic);
+    OPENSSL_strlcpy(ascii_magic, magic, sizeof(ascii_magic));
 #ifdef CHARSET_EBCDIC
     if ((magic[0] & 0x80) != 0)    /* High bit is 1 in EBCDIC alnums */
         ebcdic2ascii(ascii_magic, ascii_magic, magic_len);
 #endif
 
     /* The salt gets truncated to 8 chars */
-    OPENSSL_strlcpy(ascii_salt, salt, sizeof ascii_salt);
+    OPENSSL_strlcpy(ascii_salt, salt, sizeof(ascii_salt));
     salt_len = strlen(ascii_salt);
 #ifdef CHARSET_EBCDIC
     ebcdic2ascii(ascii_salt, ascii_salt, salt_len);
@@ -347,16 +347,16 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
 #endif
 
     if (magic_len > 0) {
-        OPENSSL_strlcat(out_buf, ascii_dollar, sizeof out_buf);
+        OPENSSL_strlcat(out_buf, ascii_dollar, sizeof(out_buf));
 
         if (magic_len > 4)    /* assert it's  "1" or "apr1" */
             goto err;
 
-        OPENSSL_strlcat(out_buf, ascii_magic, sizeof out_buf);
-        OPENSSL_strlcat(out_buf, ascii_dollar, sizeof out_buf);
+        OPENSSL_strlcat(out_buf, ascii_magic, sizeof(out_buf));
+        OPENSSL_strlcat(out_buf, ascii_dollar, sizeof(out_buf));
     }
 
-    OPENSSL_strlcat(out_buf, ascii_salt, sizeof out_buf);
+    OPENSSL_strlcat(out_buf, ascii_salt, sizeof(out_buf));
 
     if (strlen(out_buf) > 6 + 8) /* assert "$apr1$..salt.." */
         goto err;
@@ -392,8 +392,8 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
         || !EVP_DigestFinal_ex(md2, buf, NULL))
         goto err;
 
-    for (i = passwd_len; i > sizeof buf; i -= sizeof buf) {
-        if (!EVP_DigestUpdate(md, buf, sizeof buf))
+    for (i = passwd_len; i > sizeof(buf); i -= sizeof(buf)) {
+        if (!EVP_DigestUpdate(md, buf, sizeof(buf)))
             goto err;
     }
     if (!EVP_DigestUpdate(md, buf, i))
@@ -413,7 +413,7 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
             goto err;
         if (!EVP_DigestUpdate(md2,
                               (i & 1) ? (unsigned const char *)passwd : buf,
-                              (i & 1) ? passwd_len : sizeof buf))
+                              (i & 1) ? passwd_len : sizeof(buf)))
             goto err;
         if (i % 3) {
             if (!EVP_DigestUpdate(md2, ascii_salt, salt_len))
@@ -425,7 +425,7 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
         }
         if (!EVP_DigestUpdate(md2,
                               (i & 1) ? buf : (unsigned const char *)passwd,
-                              (i & 1) ? sizeof buf : passwd_len))
+                              (i & 1) ? sizeof(buf) : passwd_len))
                 goto err;
         if (!EVP_DigestFinal_ex(md2, buf, NULL))
                 goto err;
@@ -437,7 +437,7 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
 
     {
         /* transform buf into output string */
-        unsigned char buf_perm[sizeof buf];
+        unsigned char buf_perm[sizeof(buf)];
         int dest, source;
         char *output;
 
@@ -449,7 +449,7 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
         buf_perm[15] = buf[11];
 # ifndef PEDANTIC              /* Unfortunately, this generates a "no
                                  * effect" warning */
-        assert(16 == sizeof buf_perm);
+        assert(16 == sizeof(buf_perm));
 # endif
 
         output = salt_out + salt_len;
@@ -558,14 +558,14 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
         }
     }
 
-    OPENSSL_strlcpy(ascii_magic, magic, sizeof ascii_magic);
+    OPENSSL_strlcpy(ascii_magic, magic, sizeof(ascii_magic));
 #ifdef CHARSET_EBCDIC
     if ((magic[0] & 0x80) != 0)    /* High bit is 1 in EBCDIC alnums */
         ebcdic2ascii(ascii_magic, ascii_magic, magic_len);
 #endif
 
     /* The salt gets truncated to 16 chars */
-    OPENSSL_strlcpy(ascii_salt, salt, sizeof ascii_salt);
+    OPENSSL_strlcpy(ascii_salt, salt, sizeof(ascii_salt));
     salt_len = strlen(ascii_salt);
 #ifdef CHARSET_EBCDIC
     ebcdic2ascii(ascii_salt, ascii_salt, salt_len);
@@ -580,9 +580,9 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
 #endif
 
     out_buf[0] = 0;
-    OPENSSL_strlcat(out_buf, ascii_dollar, sizeof out_buf);
-    OPENSSL_strlcat(out_buf, ascii_magic, sizeof out_buf);
-    OPENSSL_strlcat(out_buf, ascii_dollar, sizeof out_buf);
+    OPENSSL_strlcat(out_buf, ascii_dollar, sizeof(out_buf));
+    OPENSSL_strlcat(out_buf, ascii_magic, sizeof(out_buf));
+    OPENSSL_strlcat(out_buf, ascii_dollar, sizeof(out_buf));
     if (rounds_custom) {
         char tmp_buf[80]; /* "rounds=999999999" */
         sprintf(tmp_buf, "rounds=%u", rounds);
@@ -591,10 +591,10 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
         if (tmp_buf[0] != 0x72)  /* ASCII 'r' */
             ebcdic2ascii(tmp_buf, tmp_buf, strlen(tmp_buf));
 #endif
-        OPENSSL_strlcat(out_buf, tmp_buf, sizeof out_buf);
-        OPENSSL_strlcat(out_buf, ascii_dollar, sizeof out_buf);
+        OPENSSL_strlcat(out_buf, tmp_buf, sizeof(out_buf));
+        OPENSSL_strlcat(out_buf, ascii_dollar, sizeof(out_buf));
     }
-    OPENSSL_strlcat(out_buf, ascii_salt, sizeof out_buf);
+    OPENSSL_strlcat(out_buf, ascii_salt, sizeof(out_buf));
 
     /* assert "$5$rounds=999999999$......salt......" */
     if (strlen(out_buf) > 3 + 17 * rounds_custom + salt_len )

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -319,8 +319,8 @@ int pkcs12_main(int argc, char **argv)
         /* To avoid bit rot */
         if (1) {
 #ifndef OPENSSL_NO_UI_CONSOLE
-            if (EVP_read_pw_string
-                (macpass, sizeof macpass, "Enter MAC Password:", export_cert)) {
+            if (EVP_read_pw_string(
+                macpass, sizeof(macpass), "Enter MAC Password:", export_cert)) {
                 BIO_printf(bio_err, "Can't read Password\n");
                 goto end;
             }
@@ -438,8 +438,8 @@ int pkcs12_main(int argc, char **argv)
             /* To avoid bit rot */
             if (1) {
 #ifndef OPENSSL_NO_UI_CONSOLE
-                if (EVP_read_pw_string(pass, sizeof pass, "Enter Export Password:",
-                                       1)) {
+                if (EVP_read_pw_string(pass, sizeof(pass),
+                                       "Enter Export Password:", 1)) {
                     BIO_printf(bio_err, "Can't read Password\n");
                     goto export_end;
                 }
@@ -504,7 +504,7 @@ int pkcs12_main(int argc, char **argv)
     if (!noprompt) {
         if (1) {
 #ifndef OPENSSL_NO_UI_CONSOLE
-            if (EVP_read_pw_string(pass, sizeof pass, "Enter Import Password:",
+            if (EVP_read_pw_string(pass, sizeof(pass), "Enter Import Password:",
                                    0)) {
                 BIO_printf(bio_err, "Can't read Password\n");
                 goto end;
@@ -517,7 +517,7 @@ int pkcs12_main(int argc, char **argv)
     }
 
     if (!twopass)
-        OPENSSL_strlcpy(macpass, pass, sizeof macpass);
+        OPENSSL_strlcpy(macpass, pass, sizeof(macpass));
 
     if ((options & INFO) && PKCS12_mac_present(p12)) {
         const ASN1_INTEGER *tmaciter;

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -245,7 +245,7 @@ int pkcs8_main(int argc, char **argv)
 #ifndef OPENSSL_NO_UI_CONSOLE
                 p8pass = pass;
                 if (EVP_read_pw_string
-                    (pass, sizeof pass, "Enter Encryption Password:", 1)) {
+                    (pass, sizeof(pass), "Enter Encryption Password:", 1)) {
                     X509_ALGOR_free(pbe);
                     goto end;
                 }
@@ -305,7 +305,7 @@ int pkcs8_main(int argc, char **argv)
         } else if (1) {
 #ifndef OPENSSL_NO_UI_CONSOLE
             p8pass = pass;
-            if (EVP_read_pw_string(pass, sizeof pass, "Enter Password:", 0)) {
+            if (EVP_read_pw_string(pass, sizeof(pass), "Enter Password:", 0)) {
                 BIO_printf(bio_err, "Can't read Password\n");
                 goto end;
             }

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -102,7 +102,7 @@ int rand_main(int argc, char **argv)
 
         chunk = num;
         if (chunk > (int)sizeof(buf))
-            chunk = sizeof buf;
+            chunk = sizeof(buf);
         r = RAND_bytes(buf, chunk);
         if (r <= 0)
             goto end;

--- a/apps/req.c
+++ b/apps/req.c
@@ -1168,7 +1168,7 @@ static int add_DN_object(X509_NAME *n, char *text, const char *def,
     } else {
         buf[0] = '\0';
         if (!batch) {
-            if (!fgets(buf, sizeof buf, stdin))
+            if (!fgets(buf, sizeof(buf), stdin))
                 return 0;
         } else {
             buf[0] = '\n';
@@ -1228,7 +1228,7 @@ static int add_attribute_object(X509_REQ *req, char *text, const char *def,
     } else {
         buf[0] = '\0';
         if (!batch) {
-            if (!fgets(buf, sizeof buf, stdin))
+            if (!fgets(buf, sizeof(buf), stdin))
                 return 0;
         } else {
             buf[0] = '\n';

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2019,7 +2019,7 @@ int s_server_main(int argc, char *argv[])
     SSL_CTX_set_verify(ctx, s_server_verify, verify_callback);
     if (!SSL_CTX_set_session_id_context(ctx,
                                         (void *)&s_server_session_id_context,
-                                        sizeof s_server_session_id_context)) {
+                                        sizeof(s_server_session_id_context))) {
         BIO_printf(bio_err, "error setting session id context\n");
         ERR_print_errors(bio_err);
         goto end;
@@ -2033,7 +2033,7 @@ int s_server_main(int argc, char *argv[])
         SSL_CTX_set_verify(ctx2, s_server_verify, verify_callback);
         if (!SSL_CTX_set_session_id_context(ctx2,
                     (void *)&s_server_session_id_context,
-                    sizeof s_server_session_id_context)) {
+                    sizeof(s_server_session_id_context))) {
             BIO_printf(bio_err, "error setting session id context\n");
             ERR_print_errors(bio_err);
             goto end;
@@ -2812,7 +2812,7 @@ static void print_connection_info(SSL *con)
         peer = NULL;
     }
 
-    if (SSL_get_shared_ciphers(con, buf, sizeof buf) != NULL)
+    if (SSL_get_shared_ciphers(con, buf, sizeof(buf)) != NULL)
         BIO_printf(bio_s_out, "Shared ciphers:%s\n", buf);
     str = SSL_CIPHER_get_name(SSL_get_current_cipher(con));
     ssl_print_sigalgs(bio_s_out, con);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3084,7 +3084,7 @@ static char *sstrsep(char **string, const char *delim)
     if (**string == 0)
         return NULL;
 
-    memset(isdelim, 0, sizeof isdelim);
+    memset(isdelim, 0, sizeof(isdelim));
     isdelim[0] = 1;
 
     while (*delim) {
@@ -3145,7 +3145,7 @@ static int do_multi(int multi, int size_num)
         char *p;
 
         f = fdopen(fds[n], "r");
-        while (fgets(buf, sizeof buf, f)) {
+        while (fgets(buf, sizeof(buf), f)) {
             p = strchr(buf, '\n');
             if (p)
                 *p = '\0';

--- a/apps/vms_term_sock.c
+++ b/apps/vms_term_sock.c
@@ -144,7 +144,7 @@ int main (int argc, char *argv[], char *envp[])
         ** Process the terminal input
         */
         LogMessage ("Waiting on terminal I/O ...\n");
-        len = recv (TermSock, TermBuff, sizeof (TermBuff), 0) ;
+        len = recv (TermSock, TermBuff, sizeof(TermBuff), 0) ;
         TermBuff[len] = '\0';
         LogMessage ("Received terminal I/O [%s]", TermBuff);
 
@@ -210,7 +210,7 @@ int TerminalSocket (int FunctionCode, int *ReturnSocket)
                           TerminalDeviceAst,
                           0,
                           TerminalDeviceBuff,
-                          sizeof (TerminalDeviceBuff) - 2,
+                          sizeof(TerminalDeviceBuff) - 2,
                           0, 0, 0, 0);
         if (! (status & 1)) {
             LogMessage ("TerminalSocket: SYS$QIO () - %08X", status);
@@ -318,7 +318,7 @@ static int CreateSocketPair (int SocketFamily,
     /*
     ** Initialize the socket information
     */
-    slen = sizeof (sin);
+    slen = sizeof(sin);
     memset ((char *) &sin, 0, slen);
     sin.sin_family = SocketFamily;
     sin.sin_addr.s_addr = inet_addr (LocalHostAddr);
@@ -435,12 +435,12 @@ static int CreateSocketPair (int SocketFamily,
     /*
     ** Now issue the connect
     */
-    memset ((char *) &sin, 0, sizeof (sin)) ;
+    memset ((char *) &sin, 0, sizeof(sin)) ;
     sin.sin_family = SocketFamily;
     sin.sin_addr.s_addr = inet_addr (LocalHostAddr) ;
     sin.sin_port = LocalHostPort ;
 
-    status = connect (SockDesc2, (struct sockaddr *) &sin, sizeof (sin));
+    status = connect (SockDesc2, (struct sockaddr *) &sin, sizeof(sin));
     if (status < 0 ) {
         LogMessage ("CreateSocketPair: connect () - %d", errno);
         sys$cantim (&sptb, 0);
@@ -529,7 +529,7 @@ static int TerminalDeviceAst (int astparm)
                       TerminalDeviceAst,
                       0,
                       TerminalDeviceBuff,
-                      sizeof (TerminalDeviceBuff) - 1,
+                      sizeof(TerminalDeviceBuff) - 1,
                       0, 0, 0, 0);
 
     /*

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -43,7 +43,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
 {
     int i, first, len = 0, c, use_bn;
     char ftmp[24], *tmp = ftmp;
-    int tmpsize = sizeof ftmp;
+    int tmpsize = sizeof(ftmp);
     const char *p;
     unsigned long l;
     BIGNUM *bl = NULL;
@@ -178,7 +178,7 @@ int i2a_ASN1_OBJECT(BIO *bp, const ASN1_OBJECT *a)
 
     if ((a == NULL) || (a->data == NULL))
         return BIO_write(bp, "NULL", 4);
-    i = i2t_ASN1_OBJECT(buf, sizeof buf, a);
+    i = i2t_ASN1_OBJECT(buf, sizeof(buf), a);
     if (i > (int)(sizeof(buf) - 1)) {
         p = OPENSSL_malloc(i + 1);
         if (p == NULL)

--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -73,13 +73,13 @@ static int do_esc_char(unsigned long c, unsigned short flags, char *do_quotes,
     if (c > 0xffffffffL)
         return -1;
     if (c > 0xffff) {
-        BIO_snprintf(tmphex, sizeof tmphex, "\\W%08lX", c);
+        BIO_snprintf(tmphex, sizeof(tmphex), "\\W%08lX", c);
         if (!io_ch(arg, tmphex, 10))
             return -1;
         return 10;
     }
     if (c > 0xff) {
-        BIO_snprintf(tmphex, sizeof tmphex, "\\U%04lX", c);
+        BIO_snprintf(tmphex, sizeof(tmphex), "\\U%04lX", c);
         if (!io_ch(arg, tmphex, 6))
             return -1;
         return 6;
@@ -183,7 +183,7 @@ static int do_buf(unsigned char *buf, int buflen,
         if (type & BUF_TYPE_CONVUTF8) {
             unsigned char utfbuf[6];
             int utflen;
-            utflen = UTF8_putc(utfbuf, sizeof utfbuf, c);
+            utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
             for (i = 0; i < utflen; i++) {
                 /*
                  * We don't need to worry about setting orflags correctly
@@ -478,7 +478,7 @@ static int do_name_ex(char_io *io_ch, void *arg, const X509_NAME *n,
         if (fn_opt != XN_FLAG_FN_NONE) {
             int objlen, fld_len;
             if ((fn_opt == XN_FLAG_FN_OID) || (fn_nid == NID_undef)) {
-                OBJ_obj2txt(objtmp, sizeof objtmp, fn, 1);
+                OBJ_obj2txt(objtmp, sizeof(objtmp), fn, 1);
                 fld_len = 0;    /* XXX: what should this be? */
                 objbuf = objtmp;
             } else {

--- a/crypto/asn1/tasn_prn.c
+++ b/crypto/asn1/tasn_prn.c
@@ -410,7 +410,7 @@ static int asn1_print_oid(BIO *out, const ASN1_OBJECT *oid)
     ln = OBJ_nid2ln(OBJ_obj2nid(oid));
     if (!ln)
         ln = "";
-    OBJ_obj2txt(objbuf, sizeof objbuf, oid, 1);
+    OBJ_obj2txt(objbuf, sizeof(objbuf), oid, 1);
     if (BIO_printf(out, "%s (%s)", ln, objbuf) <= 0)
         return 0;
     return 1;

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -36,7 +36,7 @@ static async_ctx *async_ctx_new(void)
 {
     async_ctx *nctx = NULL;
 
-    nctx = OPENSSL_malloc(sizeof (async_ctx));
+    nctx = OPENSSL_malloc(sizeof(*nctx));
     if (nctx == NULL) {
         ASYNCerr(ASYNC_F_ASYNC_CTX_NEW, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -81,7 +81,7 @@ static ASYNC_JOB *async_job_new(void)
 {
     ASYNC_JOB *job = NULL;
 
-    job = OPENSSL_zalloc(sizeof (ASYNC_JOB));
+    job = OPENSSL_zalloc(sizeof(*job));
     if (job == NULL) {
         ASYNCerr(ASYNC_F_ASYNC_JOB_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -330,7 +330,7 @@ int ASYNC_init_thread(size_t max_size, size_t init_size)
         return 0;
     }
 
-    pool = OPENSSL_zalloc(sizeof *pool);
+    pool = OPENSSL_zalloc(sizeof(*pool));
     if (pool == NULL) {
         ASYNCerr(ASYNC_F_ASYNC_INIT_THREAD, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/async/async_wait.c
+++ b/crypto/async/async_wait.c
@@ -47,7 +47,7 @@ int ASYNC_WAIT_CTX_set_wait_fd(ASYNC_WAIT_CTX *ctx, const void *key,
 {
     struct fd_lookup_st *fdlookup;
 
-    fdlookup = OPENSSL_zalloc(sizeof *fdlookup);
+    fdlookup = OPENSSL_zalloc(sizeof(*fdlookup));
     if (fdlookup == NULL)
         return 0;
 

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -676,7 +676,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         int gai_ret = 0;
         struct addrinfo hints;
 
-        memset(&hints, 0, sizeof hints);
+        memset(&hints, 0, sizeof(hints));
 
         hints.ai_family = family;
         hints.ai_socktype = socktype;

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -665,7 +665,7 @@ fmtfp(char **sbuffer,
         iconvert[iplace++] = "0123456789"[intpart % 10];
         intpart = (intpart / 10);
     } while (intpart && (iplace < (int)sizeof(iconvert)));
-    if (iplace == sizeof iconvert)
+    if (iplace == sizeof(iconvert))
         iplace--;
     iconvert[iplace] = 0;
 
@@ -683,7 +683,7 @@ fmtfp(char **sbuffer,
         fracpart = (fracpart / 10);
     }
 
-    if (fplace == sizeof fconvert)
+    if (fplace == sizeof(fconvert))
         fplace--;
     fconvert[fplace] = 0;
 

--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -77,7 +77,7 @@ char *DES_crypt(const char *buf, const char *salt)
 
     /* Convert password to ASCII. */
     OPENSSL_strlcpy(e_buf, buf, sizeof(e_buf));
-    ebcdic2ascii(e_buf, e_buf, sizeof e_buf);
+    ebcdic2ascii(e_buf, e_buf, sizeof(e_buf));
 
     /* Encrypt it (from/to ASCII); if it worked, convert back. */
     ret = DES_fcrypt(e_buf, e_salt, buff);

--- a/crypto/des/set_key.c
+++ b/crypto/des/set_key.c
@@ -310,7 +310,7 @@ void DES_set_key_unchecked(const_DES_cblock *key, DES_key_schedule *schedule)
     register int i;
 
 #ifdef OPENBSD_DEV_CRYPTO
-    memcpy(schedule->key, key, sizeof schedule->key);
+    memcpy(schedule->key, key, sizeof(schedule->key));
     schedule->session = NULL;
 #endif
     k = &schedule->ks->deslong[0];

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -218,11 +218,11 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 
     totalnum = num + numblocks;
 
-    wsize = OPENSSL_malloc(totalnum * sizeof wsize[0]);
-    wNAF_len = OPENSSL_malloc(totalnum * sizeof wNAF_len[0]);
-    wNAF = OPENSSL_malloc((totalnum + 1) * sizeof wNAF[0]); /* includes space
-                                                             * for pivot */
-    val_sub = OPENSSL_malloc(totalnum * sizeof val_sub[0]);
+    wsize = OPENSSL_malloc(totalnum * sizeof(wsize[0]));
+    wNAF_len = OPENSSL_malloc(totalnum * sizeof(wNAF_len[0]));
+    /* include space for pivot */
+    wNAF = OPENSSL_malloc((totalnum + 1) * sizeof(wNAF[0]));
+    val_sub = OPENSSL_malloc(totalnum * sizeof(val_sub[0]));
 
     /* Ensure wNAF is initialised in case we end up going to err */
     if (wNAF != NULL)
@@ -368,7 +368,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
      * 'val_sub[i]' is a pointer to the subarray for the i-th point, or to a
      * subarray of 'pre_comp->points' if we already have precomputation.
      */
-    val = OPENSSL_malloc((num_val + 1) * sizeof val[0]);
+    val = OPENSSL_malloc((num_val + 1) * sizeof(val[0]));
     if (val == NULL) {
         ECerr(EC_F_EC_WNAF_MUL, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -337,7 +337,7 @@ static int BN_to_felem(felem out, const BIGNUM *bn)
     /* BN_bn2bin eats leading zeroes */
     memset(b_out, 0, sizeof(b_out));
     num_bytes = BN_num_bytes(bn);
-    if (num_bytes > sizeof b_out) {
+    if (num_bytes > sizeof(b_out)) {
         ECerr(EC_F_BN_TO_FELEM, EC_R_BIGNUM_OUT_OF_RANGE);
         return 0;
     }
@@ -356,8 +356,8 @@ static BIGNUM *felem_to_BN(BIGNUM *out, const felem in)
 {
     felem_bytearray b_in, b_out;
     felem_to_bin28(b_in, in);
-    flip_endian(b_out, b_in, sizeof b_out);
-    return BN_bin2bn(b_out, sizeof b_out, out);
+    flip_endian(b_out, b_in, sizeof(b_out));
+    return BN_bin2bn(b_out, sizeof(b_out), out);
 }
 
 /******************************************************************************/

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -165,7 +165,7 @@ static int BN_to_felem(felem out, const BIGNUM *bn)
     /* BN_bn2bin eats leading zeroes */
     memset(b_out, 0, sizeof(b_out));
     num_bytes = BN_num_bytes(bn);
-    if (num_bytes > sizeof b_out) {
+    if (num_bytes > sizeof(b_out)) {
         ECerr(EC_F_BN_TO_FELEM, EC_R_BIGNUM_OUT_OF_RANGE);
         return 0;
     }
@@ -184,8 +184,8 @@ static BIGNUM *smallfelem_to_BN(BIGNUM *out, const smallfelem in)
 {
     felem_bytearray b_in, b_out;
     smallfelem_to_bin32(b_in, in);
-    flip_endian(b_out, b_in, sizeof b_out);
-    return BN_bin2bn(b_out, sizeof b_out, out);
+    flip_endian(b_out, b_in, sizeof(b_out));
+    return BN_bin2bn(b_out, sizeof(b_out), out);
 }
 
 /*-

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -188,7 +188,7 @@ static int BN_to_felem(felem out, const BIGNUM *bn)
     /* BN_bn2bin eats leading zeroes */
     memset(b_out, 0, sizeof(b_out));
     num_bytes = BN_num_bytes(bn);
-    if (num_bytes > sizeof b_out) {
+    if (num_bytes > sizeof(b_out)) {
         ECerr(EC_F_BN_TO_FELEM, EC_R_BIGNUM_OUT_OF_RANGE);
         return 0;
     }
@@ -207,8 +207,8 @@ static BIGNUM *felem_to_BN(BIGNUM *out, const felem in)
 {
     felem_bytearray b_in, b_out;
     felem_to_bin66(b_in, in);
-    flip_endian(b_out, b_in, sizeof b_out);
-    return BN_bin2bn(b_out, sizeof b_out, out);
+    flip_endian(b_out, b_in, sizeof(b_out));
+    return BN_bin2bn(b_out, sizeof(b_out), out);
 }
 
 /*-

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1216,7 +1216,7 @@ int ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
     if (tmp_Z == NULL)
         goto err;
 
-    prod_Z = OPENSSL_malloc(num * sizeof prod_Z[0]);
+    prod_Z = OPENSSL_malloc(num * sizeof(prod_Z[0]));
     if (prod_Z == NULL)
         goto err;
     for (i = 0; i < num; i++) {

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -34,7 +34,7 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
     tid.tid = CRYPTO_THREAD_get_current_id();
 
     while ((l = ERR_get_error_line_data(&file, &line, &data, &flags)) != 0) {
-        ERR_error_string_n(l, buf, sizeof buf);
+        ERR_error_string_n(l, buf, sizeof(buf));
         BIO_snprintf(buf2, sizeof(buf2), "%lu:%s:%s:%d:%s\n", tid.ltid, buf,
                      file, line, (flags & ERR_TXT_STRING) ? data : "");
         if (cb(buf2, strlen(buf2), u) <= 0)

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -392,7 +392,7 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     }
 
     b = ctx->cipher->block_size;
-    OPENSSL_assert(b <= sizeof ctx->buf);
+    OPENSSL_assert(b <= sizeof(ctx->buf));
     if (b == 1) {
         *outl = 0;
         return 1;
@@ -453,7 +453,7 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     if (ctx->flags & EVP_CIPH_NO_PADDING)
         return EVP_EncryptUpdate(ctx, out, outl, in, inl);
 
-    OPENSSL_assert(b <= sizeof ctx->final);
+    OPENSSL_assert(b <= sizeof(ctx->final));
 
     if (ctx->final_used) {
         /* see comment about PTRDIFF_T comparison above */
@@ -525,7 +525,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_WRONG_FINAL_BLOCK_LENGTH);
             return 0;
         }
-        OPENSSL_assert(b <= sizeof ctx->final);
+        OPENSSL_assert(b <= sizeof(ctx->final));
 
         /*
          * The following assumes that the ciphertext has been authenticated.

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -200,7 +200,7 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
         goto err;
     }
     keylen = EVP_CIPHER_CTX_key_length(ctx);
-    OPENSSL_assert(keylen <= sizeof key);
+    OPENSSL_assert(keylen <= sizeof(key));
 
     /* Decode parameter */
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -53,7 +53,7 @@ static struct thread_local_inits_st *ossl_init_get_thread_local(int alloc)
         CRYPTO_THREAD_get_local(&threadstopkey);
 
     if (local == NULL && alloc) {
-        local = OPENSSL_zalloc(sizeof *local);
+        local = OPENSSL_zalloc(sizeof(*local));
         if (local != NULL && !CRYPTO_THREAD_set_local(&threadstopkey, local)) {
             OPENSSL_free(local);
             return NULL;

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -374,7 +374,7 @@ static int sh_init(size_t size, int minsize)
     size_t pgsize;
     size_t aligned;
 
-    memset(&sh, 0, sizeof sh);
+    memset(&sh, 0, sizeof(sh));
 
     /* make sure size and minsize are powers of 2 */
     OPENSSL_assert(size > 0);
@@ -401,7 +401,7 @@ static int sh_init(size_t size, int minsize)
     for (i = sh.bittable_size; i; i >>= 1)
         sh.freelist_size++;
 
-    sh.freelist = OPENSSL_zalloc(sh.freelist_size * sizeof (char *));
+    sh.freelist = OPENSSL_zalloc(sh.freelist_size * sizeof(char *));
     OPENSSL_assert(sh.freelist != NULL);
     if (sh.freelist == NULL)
         goto err;
@@ -498,7 +498,7 @@ static void sh_done()
     OPENSSL_free(sh.bitmalloc);
     if (sh.map_result != NULL && sh.map_size)
         munmap(sh.map_result, sh.map_size);
-    memset(&sh, 0, sizeof sh);
+    memset(&sh, 0, sizeof(sh));
 }
 
 static int sh_allocated(const char *ptr)

--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -111,7 +111,7 @@ int RSA_verify_PKCS1_PSS_mgf1(RSA *rsa, const unsigned char *mHash,
         goto err;
     }
     if (!EVP_DigestInit_ex(ctx, Hash, NULL)
-        || !EVP_DigestUpdate(ctx, zeroes, sizeof zeroes)
+        || !EVP_DigestUpdate(ctx, zeroes, sizeof(zeroes))
         || !EVP_DigestUpdate(ctx, mHash, hLen))
         goto err;
     if (maskedDBLen - i) {
@@ -209,7 +209,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
     if (ctx == NULL)
         goto err;
     if (!EVP_DigestInit_ex(ctx, Hash, NULL)
-        || !EVP_DigestUpdate(ctx, zeroes, sizeof zeroes)
+        || !EVP_DigestUpdate(ctx, zeroes, sizeof(zeroes))
         || !EVP_DigestUpdate(ctx, mHash, hLen))
         goto err;
     if (sLen && !EVP_DigestUpdate(ctx, salt, sLen))

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -343,7 +343,7 @@ int X509_aux_print(BIO *out, X509 *x, int indent)
                 BIO_puts(out, ", ");
             else
                 first = 0;
-            OBJ_obj2txt(oidstr, sizeof oidstr,
+            OBJ_obj2txt(oidstr, sizeof(oidstr),
                         sk_ASN1_OBJECT_value(trust, i), 0);
             BIO_puts(out, oidstr);
         }
@@ -358,7 +358,7 @@ int X509_aux_print(BIO *out, X509 *x, int indent)
                 BIO_puts(out, ", ");
             else
                 first = 0;
-            OBJ_obj2txt(oidstr, sizeof oidstr,
+            OBJ_obj2txt(oidstr, sizeof(oidstr),
                         sk_ASN1_OBJECT_value(reject, i), 0);
             BIO_puts(out, oidstr);
         }

--- a/crypto/x509v3/v3_admis.c
+++ b/crypto/x509v3/v3_admis.c
@@ -92,7 +92,7 @@ static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
         if (BIO_printf(bp, "%*s  admissionAuthorityId: ", ind, "") <= 0)
             goto err;
 
-        OBJ_obj2txt(objbuf, sizeof objbuf, namingAuthority->namingAuthorityId, 1);
+        OBJ_obj2txt(objbuf, sizeof(objbuf), namingAuthority->namingAuthorityId, 1);
 
         if (BIO_printf(bp, "%s%s%s%s\n", ln ? ln : "",
                        ln ? " (" : "", objbuf, ln ? ")" : "") <= 0)

--- a/crypto/x509v3/v3_info.c
+++ b/crypto/x509v3/v3_info.c
@@ -77,7 +77,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
             goto err;
         tret = tmp;
         vtmp = sk_CONF_VALUE_value(tret, i);
-        i2t_ASN1_OBJECT(objtmp, sizeof objtmp, desc->method);
+        i2t_ASN1_OBJECT(objtmp, sizeof(objtmp), desc->method);
         nlen = strlen(objtmp) + 3 + strlen(vtmp->name) + 1;
         ntmp = OPENSSL_malloc(nlen);
         if (ntmp == NULL)

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -580,7 +580,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             s->rwstate = SSL_NOTHING;
             s->s3->fatal_alert = alert_descr;
             SSLerr(SSL_F_DTLS1_READ_BYTES, SSL_AD_REASON_OFFSET + alert_descr);
-            BIO_snprintf(tmp, sizeof tmp, "%d", alert_descr);
+            BIO_snprintf(tmp, sizeof(tmp), "%d", alert_descr);
             ERR_add_error_data(2, "SSL alert number ", tmp);
             s->shutdown |= SSL_RECEIVED_SHUTDOWN;
             SSL_CTX_remove_session(s->session_ctx, s->session);

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -784,7 +784,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
 
     totlen = 0;
     /* Clear our SSL3_RECORD structures */
-    memset(wr, 0, sizeof wr);
+    memset(wr, 0, sizeof(wr));
     for (j = 0; j < numpipes; j++) {
         unsigned int version = SSL_TREAT_AS_TLS13(s) ? TLS1_VERSION : s->version;
         unsigned char *compressdata = NULL;
@@ -1403,7 +1403,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
         size_t *dest_len = NULL;
 
         if (SSL3_RECORD_get_type(rr) == SSL3_RT_HANDSHAKE) {
-            dest_maxlen = sizeof s->rlayer.handshake_fragment;
+            dest_maxlen = sizeof(s->rlayer.handshake_fragment);
             dest = s->rlayer.handshake_fragment;
             dest_len = &s->rlayer.handshake_fragment_len;
         }
@@ -1525,7 +1525,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             s->rwstate = SSL_NOTHING;
             s->s3->fatal_alert = alert_descr;
             SSLerr(SSL_F_SSL3_READ_BYTES, SSL_AD_REASON_OFFSET + alert_descr);
-            BIO_snprintf(tmp, sizeof tmp, "%d", alert_descr);
+            BIO_snprintf(tmp, sizeof(tmp), "%d", alert_descr);
             ERR_add_error_data(2, "SSL alert number ", tmp);
             s->shutdown |= SSL_RECEIVED_SHUTDOWN;
             SSL3_RECORD_set_read(rr);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3241,9 +3241,9 @@ static int cipher_compare(const void *a, const void *b)
 
 void ssl_sort_cipher_list(void)
 {
-    qsort(ssl3_ciphers, SSL3_NUM_CIPHERS, sizeof ssl3_ciphers[0],
+    qsort(ssl3_ciphers, SSL3_NUM_CIPHERS, sizeof(ssl3_ciphers[0]),
           cipher_compare);
-    qsort(ssl3_scsvs, SSL3_NUM_SCSVS, sizeof ssl3_scsvs[0], cipher_compare);
+    qsort(ssl3_scsvs, SSL3_NUM_SCSVS, sizeof(ssl3_scsvs[0]), cipher_compare);
 }
 
 const SSL3_ENC_METHOD SSLv3_enc_data = {

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -729,15 +729,15 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
         char buf[1024];
         int r;
 
-        if (strlen(dir) + strlen(filename) + 2 > sizeof buf) {
+        if (strlen(dir) + strlen(filename) + 2 > sizeof(buf)) {
             SSLerr(SSL_F_SSL_ADD_DIR_CERT_SUBJECTS_TO_STACK,
                    SSL_R_PATH_TOO_LONG);
             goto err;
         }
 #ifdef OPENSSL_SYS_VMS
-        r = BIO_snprintf(buf, sizeof buf, "%s%s", dir, filename);
+        r = BIO_snprintf(buf, sizeof(buf), "%s%s", dir, filename);
 #else
-        r = BIO_snprintf(buf, sizeof buf, "%s/%s", dir, filename);
+        r = BIO_snprintf(buf, sizeof(buf), "%s/%s", dir, filename);
 #endif
         if (r <= 0 || r >= (int)sizeof(buf))
             goto err;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -677,7 +677,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     s->record_padding_arg = ctx->record_padding_arg;
     s->block_padding = ctx->block_padding;
     s->sid_ctx_length = ctx->sid_ctx_length;
-    if (!ossl_assert(s->sid_ctx_length <= sizeof s->sid_ctx))
+    if (!ossl_assert(s->sid_ctx_length <= sizeof(s->sid_ctx)))
         goto err;
     memcpy(&s->sid_ctx, &ctx->sid_ctx, sizeof(s->sid_ctx));
     s->verify_callback = ctx->default_verify_callback;
@@ -806,7 +806,7 @@ int SSL_up_ref(SSL *s)
 int SSL_CTX_set_session_id_context(SSL_CTX *ctx, const unsigned char *sid_ctx,
                                    unsigned int sid_ctx_len)
 {
-    if (sid_ctx_len > sizeof ctx->sid_ctx) {
+    if (sid_ctx_len > sizeof(ctx->sid_ctx)) {
         SSLerr(SSL_F_SSL_CTX_SET_SESSION_ID_CONTEXT,
                SSL_R_SSL_SESSION_ID_CONTEXT_TOO_LONG);
         return 0;
@@ -859,7 +859,7 @@ int SSL_has_matching_session_id(const SSL *ssl, const unsigned char *id,
      */
     SSL_SESSION r, *p;
 
-    if (id_len > sizeof r.session_id)
+    if (id_len > sizeof(r.session_id))
         return 0;
 
     r.ssl_version = ssl->version;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -428,7 +428,7 @@ int ssl_get_new_session(SSL *s, int session)
         ss->session_id_length = 0;
     }
 
-    if (s->sid_ctx_length > sizeof ss->sid_ctx) {
+    if (s->sid_ctx_length > sizeof(ss->sid_ctx)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_GET_NEW_SESSION,
                  ERR_R_INTERNAL_ERROR);
         SSL_SESSION_free(ss);
@@ -782,8 +782,8 @@ void SSL_SESSION_free(SSL_SESSION *ss)
 
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_SSL_SESSION, ss, &ss->ex_data);
 
-    OPENSSL_cleanse(ss->master_key, sizeof ss->master_key);
-    OPENSSL_cleanse(ss->session_id, sizeof ss->session_id);
+    OPENSSL_cleanse(ss->master_key, sizeof(ss->master_key));
+    OPENSSL_cleanse(ss->session_id, sizeof(ss->session_id));
     X509_free(ss->peer);
     sk_X509_pop_free(ss->peer_chain, X509_free);
     sk_SSL_CIPHER_free(ss->ciphers);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1360,7 +1360,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
             goto err;
         }
         session_id_len = PACKET_remaining(&session_id);
-        if (session_id_len > sizeof s->session->session_id
+        if (session_id_len > sizeof(s->session->session_id)
             || session_id_len > SSL3_SESSION_ID_SIZE) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_F_TLS_PROCESS_SERVER_HELLO,

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -356,7 +356,7 @@ static int test_bf_cbc(void)
     BF_set_key(&key, 16, cbc_key);
     memset(cbc_in, 0, sizeof(cbc_in));
     memset(cbc_out, 0, sizeof(cbc_out));
-    memcpy(iv, cbc_iv, sizeof iv);
+    memcpy(iv, cbc_iv, sizeof(iv));
     BF_cbc_encrypt((unsigned char *)cbc_data, cbc_out, len,
                    &key, iv, BF_ENCRYPT);
     if (!TEST_mem_eq(cbc_out, 32, cbc_ok, 32))

--- a/test/d2i_test.c
+++ b/test/d2i_test.c
@@ -67,7 +67,7 @@ static int test_bad_asn1(void)
      * performs sanity checks on the input and can reject it before the
      * decoder is called.
      */
-    len = BIO_read(bio, buf, sizeof buf);
+    len = BIO_read(bio, buf, sizeof(buf));
     if (!TEST_int_ge(len, 0))
         goto err;
 

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -232,7 +232,7 @@ static int prime_field_tests(void)
 
     len =
         EC_POINT_point2oct(group, Q, POINT_CONVERSION_COMPRESSED, buf,
-                           sizeof buf, ctx);
+                           sizeof(buf), ctx);
     if (!TEST_size_t_ne(len, 0)
         || !TEST_true(EC_POINT_oct2point(group, P, buf, len, ctx))
         || !TEST_int_eq(0, EC_POINT_cmp(group, P, Q, ctx)))
@@ -241,7 +241,7 @@ static int prime_field_tests(void)
                        buf, len);
 
     len = EC_POINT_point2oct(group, Q, POINT_CONVERSION_UNCOMPRESSED,
-                             buf, sizeof buf, ctx);
+                             buf, sizeof(buf), ctx);
     if (!TEST_size_t_ne(len, 0)
         || !TEST_true(EC_POINT_oct2point(group, P, buf, len, ctx))
         || !TEST_int_eq(0, EC_POINT_cmp(group, P, Q, ctx)))
@@ -250,7 +250,7 @@ static int prime_field_tests(void)
                        buf, len);
 
     len = EC_POINT_point2oct(group, Q, POINT_CONVERSION_HYBRID,
-                             buf, sizeof buf, ctx);
+                             buf, sizeof(buf), ctx);
     if (!TEST_size_t_ne(len, 0)
         || !TEST_true(EC_POINT_oct2point(group, P, buf, len, ctx))
         || !TEST_int_eq(0, EC_POINT_cmp(group, P, Q, ctx)))
@@ -1071,7 +1071,7 @@ static int char2_field_tests(void)
 /* Change test based on whether binary point compression is enabled or not. */
 #  ifdef OPENSSL_EC_BIN_PT_COMP
     len = EC_POINT_point2oct(group, Q, POINT_CONVERSION_COMPRESSED,
-                             buf, sizeof buf, ctx);
+                             buf, sizeof(buf), ctx);
     if (!TEST_size_t_ne(len, 0)
         || !TEST_true(EC_POINT_oct2point(group, P, buf, len, ctx))
         || !TEST_int_eq(0, EC_POINT_cmp(group, P, Q, ctx)))
@@ -1081,7 +1081,7 @@ static int char2_field_tests(void)
 #  endif
 
     len = EC_POINT_point2oct(group, Q, POINT_CONVERSION_UNCOMPRESSED,
-                             buf, sizeof buf, ctx);
+                             buf, sizeof(buf), ctx);
     if (!TEST_size_t_ne(len, 0)
         || !TEST_true(EC_POINT_oct2point(group, P, buf, len, ctx))
         || !TEST_int_eq(0, EC_POINT_cmp(group, P, Q, ctx)))
@@ -1092,7 +1092,7 @@ static int char2_field_tests(void)
 /* Change test based on whether binary point compression is enabled or not. */
 #  ifdef OPENSSL_EC_BIN_PT_COMP
     len =
-        EC_POINT_point2oct(group, Q, POINT_CONVERSION_HYBRID, buf, sizeof buf,
+        EC_POINT_point2oct(group, Q, POINT_CONVERSION_HYBRID, buf, sizeof(buf),
                            ctx);
     if (!TEST_size_t_ne(len, 0)
         || !TEST_true(EC_POINT_oct2point(group, P, buf, len, ctx))

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -153,29 +153,29 @@ static int test_ige_vectors(int n)
         return 0;
 
     if (v->encrypt == AES_ENCRYPT)
-        AES_set_encrypt_key(v->key, 8 * sizeof v->key, &key);
+        AES_set_encrypt_key(v->key, 8 * sizeof(v->key), &key);
     else
-        AES_set_decrypt_key(v->key, 8 * sizeof v->key, &key);
-    memcpy(iv, v->iv, sizeof iv);
+        AES_set_decrypt_key(v->key, 8 * sizeof(v->key), &key);
+    memcpy(iv, v->iv, sizeof(iv));
     AES_ige_encrypt(v->in, buf, v->length, &key, iv, v->encrypt);
 
     if (!TEST_mem_eq(v->out, v->length, buf, v->length)) {
         TEST_info("IGE test vector %d failed", n);
-        test_output_memory("key", v->key, sizeof v->key);
-        test_output_memory("iv", v->iv, sizeof v->iv);
+        test_output_memory("key", v->key, sizeof(v->key));
+        test_output_memory("iv", v->iv, sizeof(v->iv));
         test_output_memory("in", v->in, v->length);
         testresult = 0;
     }
 
     /* try with in == out */
-    memcpy(iv, v->iv, sizeof iv);
+    memcpy(iv, v->iv, sizeof(iv));
     memcpy(buf, v->in, v->length);
     AES_ige_encrypt(buf, buf, v->length, &key, iv, v->encrypt);
 
     if (!TEST_mem_eq(v->out, v->length, buf, v->length)) {
         TEST_info("IGE test vector %d failed (with in == out)", n);
-        test_output_memory("key", v->key, sizeof v->key);
-        test_output_memory("iv", v->iv, sizeof v->iv);
+        test_output_memory("key", v->key, sizeof(v->key));
+        test_output_memory("iv", v->iv, sizeof(v->iv));
         test_output_memory("in", v->in, v->length);
         testresult = 0;
     }
@@ -205,9 +205,9 @@ static int test_bi_ige_vectors(int n)
                        v->encrypt);
 
     if (!TEST_mem_eq(v->out, v->length, buf, v->length)) {
-        test_output_memory("key 1", v->key1, sizeof v->key1);
-        test_output_memory("key 2", v->key2, sizeof v->key2);
-        test_output_memory("iv", v->iv, sizeof v->iv);
+        test_output_memory("key 1", v->key1, sizeof(v->key1));
+        test_output_memory("key 2", v->key2, sizeof(v->key2));
+        test_output_memory("iv", v->iv, sizeof(v->iv));
         test_output_memory("in", v->in, v->length);
         return 0;
     }
@@ -222,12 +222,12 @@ static int test_ige_enc_dec(void)
     unsigned char ciphertext[BIG_TEST_SIZE];
     unsigned char checktext[BIG_TEST_SIZE];
 
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
     AES_ige_encrypt(plaintext, ciphertext, TEST_SIZE, &key, iv, AES_ENCRYPT);
 
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
     AES_ige_encrypt(ciphertext, checktext, TEST_SIZE, &key, iv, AES_DECRYPT);
 
     return TEST_mem_eq(checktext, TEST_SIZE, plaintext, TEST_SIZE);
@@ -240,16 +240,16 @@ static int test_ige_enc_chaining(void)
     unsigned char ciphertext[BIG_TEST_SIZE];
     unsigned char checktext[BIG_TEST_SIZE];
 
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
     AES_ige_encrypt(plaintext, ciphertext, TEST_SIZE / 2, &key, iv,
                     AES_ENCRYPT);
     AES_ige_encrypt(plaintext + TEST_SIZE / 2,
                     ciphertext + TEST_SIZE / 2, TEST_SIZE / 2,
                     &key, iv, AES_ENCRYPT);
 
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
     AES_ige_encrypt(ciphertext, checktext, TEST_SIZE, &key, iv, AES_DECRYPT);
 
     return TEST_mem_eq(checktext, TEST_SIZE, plaintext, TEST_SIZE);
@@ -262,16 +262,16 @@ static int test_ige_dec_chaining(void)
     unsigned char ciphertext[BIG_TEST_SIZE];
     unsigned char checktext[BIG_TEST_SIZE];
 
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
     AES_ige_encrypt(plaintext, ciphertext, TEST_SIZE / 2, &key, iv,
                     AES_ENCRYPT);
     AES_ige_encrypt(plaintext + TEST_SIZE / 2,
                     ciphertext + TEST_SIZE / 2, TEST_SIZE / 2,
                     &key, iv, AES_ENCRYPT);
 
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
     AES_ige_encrypt(ciphertext, checktext, TEST_SIZE / 2, &key, iv,
                     AES_DECRYPT);
     AES_ige_encrypt(ciphertext + TEST_SIZE / 2,
@@ -292,20 +292,20 @@ static int test_ige_garble_forwards(void)
     const size_t ctsize = sizeof(checktext);
     size_t matches;
 
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_ige_encrypt(plaintext, ciphertext, sizeof(plaintext), &key, iv,
                     AES_ENCRYPT);
 
     /* corrupt halfway through */
-    ++ciphertext[sizeof ciphertext / 2];
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_ige_encrypt(ciphertext, checktext, sizeof checktext, &key, iv,
+    ++ciphertext[sizeof(ciphertext) / 2];
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_ige_encrypt(ciphertext, checktext, sizeof(checktext), &key, iv,
                     AES_DECRYPT);
 
     matches = 0;
-    for (n = 0; n < sizeof checktext; ++n)
+    for (n = 0; n < sizeof(checktext); ++n)
         if (checktext[n] == plaintext[n])
             ++matches;
 
@@ -326,14 +326,14 @@ static int test_bi_ige_enc_dec(void)
     unsigned char ciphertext[BIG_TEST_SIZE];
     unsigned char checktext[BIG_TEST_SIZE];
 
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_encrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
     AES_bi_ige_encrypt(plaintext, ciphertext, TEST_SIZE, &key, &key2, iv,
                        AES_ENCRYPT);
 
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_decrypt_key(rkey2, 8 * sizeof rkey2, &key2);
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_decrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
     AES_bi_ige_encrypt(ciphertext, checktext, TEST_SIZE, &key, &key2, iv,
                        AES_DECRYPT);
 
@@ -349,26 +349,26 @@ static int test_bi_ige_garble1(void)
     unsigned int n;
     size_t matches;
 
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
-    AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_encrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
+    AES_ige_encrypt(plaintext, ciphertext, sizeof(plaintext), &key, iv,
                     AES_ENCRYPT);
 
     /* corrupt halfway through */
-    ++ciphertext[sizeof ciphertext / 2];
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_decrypt_key(rkey2, 8 * sizeof rkey2, &key2);
-    AES_ige_encrypt(ciphertext, checktext, sizeof checktext, &key, iv,
+    ++ciphertext[sizeof(ciphertext) / 2];
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_decrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
+    AES_ige_encrypt(ciphertext, checktext, sizeof(checktext), &key, iv,
                     AES_DECRYPT);
 
     matches = 0;
-    for (n = 0; n < sizeof checktext; ++n)
+    for (n = 0; n < sizeof(checktext); ++n)
         if (checktext[n] == plaintext[n])
             ++matches;
 
     /* Fail if there is more than 1% matching bytes */
-    return TEST_size_t_le(matches, sizeof checktext / 100);
+    return TEST_size_t_le(matches, sizeof(checktext) / 100);
 }
 
 static int test_bi_ige_garble2(void)
@@ -380,26 +380,26 @@ static int test_bi_ige_garble2(void)
     unsigned int n;
     size_t matches;
 
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
-    AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_encrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
+    AES_ige_encrypt(plaintext, ciphertext, sizeof(plaintext), &key, iv,
                     AES_ENCRYPT);
 
     /* corrupt right at the end */
-    ++ciphertext[sizeof ciphertext - 1];
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_decrypt_key(rkey2, 8 * sizeof rkey2, &key2);
-    AES_ige_encrypt(ciphertext, checktext, sizeof checktext, &key, iv,
+    ++ciphertext[sizeof(ciphertext) - 1];
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_decrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
+    AES_ige_encrypt(ciphertext, checktext, sizeof(checktext), &key, iv,
                     AES_DECRYPT);
 
     matches = 0;
-    for (n = 0; n < sizeof checktext; ++n)
+    for (n = 0; n < sizeof(checktext); ++n)
         if (checktext[n] == plaintext[n])
             ++matches;
 
     /* Fail if there is more than 1% matching bytes */
-    return TEST_size_t_le(matches, sizeof checktext / 100);
+    return TEST_size_t_le(matches, sizeof(checktext) / 100);
 }
 
 static int test_bi_ige_garble3(void)
@@ -411,34 +411,34 @@ static int test_bi_ige_garble3(void)
     unsigned int n;
     size_t matches;
 
-    memcpy(iv, saved_iv, sizeof iv);
-    AES_set_encrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_encrypt_key(rkey2, 8 * sizeof rkey2, &key2);
-    AES_ige_encrypt(plaintext, ciphertext, sizeof plaintext, &key, iv,
+    memcpy(iv, saved_iv, sizeof(iv));
+    AES_set_encrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_encrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
+    AES_ige_encrypt(plaintext, ciphertext, sizeof(plaintext), &key, iv,
                     AES_ENCRYPT);
 
     /* corrupt right at the start */
     ++ciphertext[0];
-    AES_set_decrypt_key(rkey, 8 * sizeof rkey, &key);
-    AES_set_decrypt_key(rkey2, 8 * sizeof rkey2, &key2);
-    AES_ige_encrypt(ciphertext, checktext, sizeof checktext, &key, iv,
+    AES_set_decrypt_key(rkey, 8 * sizeof(rkey), &key);
+    AES_set_decrypt_key(rkey2, 8 * sizeof(rkey2), &key2);
+    AES_ige_encrypt(ciphertext, checktext, sizeof(checktext), &key, iv,
                     AES_DECRYPT);
 
     matches = 0;
-    for (n = 0; n < sizeof checktext; ++n)
+    for (n = 0; n < sizeof(checktext); ++n)
         if (checktext[n] == plaintext[n])
             ++matches;
 
     /* Fail if there is more than 1% matching bytes */
-    return TEST_size_t_le(matches, sizeof checktext / 100);
+    return TEST_size_t_le(matches, sizeof(checktext) / 100);
 }
 
 int setup_tests(void)
 {
-    RAND_bytes(rkey, sizeof rkey);
-    RAND_bytes(rkey2, sizeof rkey2);
-    RAND_bytes(plaintext, sizeof plaintext);
-    RAND_bytes(saved_iv, sizeof saved_iv);
+    RAND_bytes(rkey, sizeof(rkey));
+    RAND_bytes(rkey2, sizeof(rkey2));
+    RAND_bytes(plaintext, sizeof(plaintext));
+    RAND_bytes(saved_iv, sizeof(saved_iv));
 
     ADD_TEST(test_ige_enc_dec);
     ADD_TEST(test_ige_enc_chaining);

--- a/test/sanitytest.c
+++ b/test/sanitytest.c
@@ -18,7 +18,7 @@ static int test_sanity_null_zero(void)
 
     /* Is NULL equivalent to all-bytes-zero? */
     p = NULL;
-    memset(bytes, 0, sizeof bytes);
+    memset(bytes, 0, sizeof(bytes));
     return TEST_mem_eq(&p, sizeof(p), bytes, sizeof(bytes));
 }
 

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -1471,9 +1471,9 @@ int main(int argc, char *argv[])
     {
         int session_id_context = 0;
         if (!SSL_CTX_set_session_id_context(s_ctx, (void *)&session_id_context,
-                                            sizeof session_id_context) ||
+                                            sizeof(session_id_context)) ||
             !SSL_CTX_set_session_id_context(s_ctx2, (void *)&session_id_context,
-                                            sizeof session_id_context)) {
+                                            sizeof(session_id_context))) {
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -1915,8 +1915,8 @@ int doit_localhost(SSL *s_ssl, SSL *c_ssl, int family, long count,
             if (cw_num > 0) {
                 /* Write to server. */
 
-                if (cw_num > (long)sizeof cbuf)
-                    i = sizeof cbuf;
+                if (cw_num > (long)sizeof(cbuf))
+                    i = sizeof(cbuf);
                 else
                     i = (int)cw_num;
                 r = BIO_write(c_ssl_bio, cbuf, i);
@@ -1994,8 +1994,8 @@ int doit_localhost(SSL *s_ssl, SSL *c_ssl, int family, long count,
             if (sw_num > 0) {
                 /* Write to client. */
 
-                if (sw_num > (long)sizeof sbuf)
-                    i = sizeof sbuf;
+                if (sw_num > (long)sizeof(sbuf))
+                    i = sizeof(sbuf);
                 else
                     i = (int)sw_num;
                 r = BIO_write(s_ssl_bio, sbuf, i);
@@ -2177,8 +2177,8 @@ int doit_biopair(SSL *s_ssl, SSL *c_ssl, long count,
             if (cw_num > 0) {
                 /* Write to server. */
 
-                if (cw_num > (long)sizeof cbuf)
-                    i = sizeof cbuf;
+                if (cw_num > (long)sizeof(cbuf))
+                    i = sizeof(cbuf);
                 else
                     i = (int)cw_num;
                 r = BIO_write(c_ssl_bio, cbuf, i);
@@ -2256,8 +2256,8 @@ int doit_biopair(SSL *s_ssl, SSL *c_ssl, long count,
             if (sw_num > 0) {
                 /* Write to client. */
 
-                if (sw_num > (long)sizeof sbuf)
-                    i = sizeof sbuf;
+                if (sw_num > (long)sizeof(sbuf))
+                    i = sizeof(sbuf);
                 else
                     i = (int)sw_num;
                 r = BIO_write(s_ssl_bio, sbuf, i);
@@ -2750,7 +2750,7 @@ static int verify_callback(int ok, X509_STORE_CTX *ctx)
     char *s, buf[256];
 
     s = X509_NAME_oneline(X509_get_subject_name(X509_STORE_CTX_get_current_cert(ctx)),
-                          buf, sizeof buf);
+                          buf, sizeof(buf));
     if (s != NULL) {
         if (ok)
             printf("depth=%d %s\n", X509_STORE_CTX_get_error_depth(ctx), buf);


### PR DESCRIPTION
Spurred by the recent bug that had the "-1" inside the sizeof argument, this PR fixes all uses of sizeof to be conformant with our style guide.  Not going to cherry-pick back; I could do separate PR's for the other branches if someone feels strongly about wanting it.
