### PR TITLE
test suite nits

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -497,8 +497,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
     case TLSEXT_max_fragment_length_2048:
     case TLSEXT_max_fragment_length_4096:
     case TLSEXT_max_fragment_length_DISABLED:
-        TEST_true(SSL_CTX_set_tlsext_max_fragment_length(
-                        client_ctx, extra->client.max_fragment_len_mode));
+        SSL_CTX_set_tlsext_max_fragment_length(
+              client_ctx, extra->client.max_fragment_len_mode);
         break;
     }
 

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -82,6 +82,7 @@ static OCSP_BASICRESP *make_dummy_resp(void)
     ASN1_BIT_STRING_free(key);
     ASN1_INTEGER_free(serial);
     OCSP_CERTID_free(cid);
+    OCSP_BASICRESP_free(bs);
     X509_NAME_free(name);
     return bs_out;
 }

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -51,7 +51,8 @@ static OCSP_BASICRESP *make_dummy_resp(void)
     const unsigned char namestr[] = "openssl.example.com";
     unsigned char keybytes[128] = {7};
     OCSP_BASICRESP *bs = OCSP_BASICRESP_new();
-    OCSP_CERTID *cid;
+    OCSP_BASICRESP *bs_out = NULL;
+    OCSP_CERTID *cid = NULL;
     ASN1_TIME *thisupd = ASN1_TIME_set(NULL, time(NULL));
     ASN1_TIME *nextupd = ASN1_TIME_set(NULL, time(NULL) + 200);
     X509_NAME *name = X509_NAME_new();
@@ -60,9 +61,9 @@ static OCSP_BASICRESP *make_dummy_resp(void)
 
     if (!X509_NAME_add_entry_by_NID(name, NID_commonName, MBSTRING_ASC,
                                    namestr, -1, -1, 1)
-        || !ASN1_BIT_STRING_set(key, keybytes, sizeof(keybytes)
-        || !ASN1_INTEGER_set_uint64(serial, (uint64_t)1)))
-        return NULL;
+        || !ASN1_BIT_STRING_set(key, keybytes, sizeof(keybytes))
+        || !ASN1_INTEGER_set_uint64(serial, (uint64_t)1))
+        goto err;
     cid = OCSP_cert_id_new(EVP_sha256(), name, key, serial);
     if (!TEST_ptr(bs)
         || !TEST_ptr(thisupd)
@@ -71,23 +72,27 @@ static OCSP_BASICRESP *make_dummy_resp(void)
         || !TEST_true(OCSP_basic_add1_status(bs, cid,
                                              V_OCSP_CERTSTATUS_UNKNOWN,
                                              0, NULL, thisupd, nextupd)))
-        return NULL;
+        goto err;
+    bs_out = bs;
+    bs = NULL;
+ err:
     ASN1_TIME_free(thisupd);
     ASN1_TIME_free(nextupd);
     ASN1_BIT_STRING_free(key);
     ASN1_INTEGER_free(serial);
     OCSP_CERTID_free(cid);
     X509_NAME_free(name);
-    return bs;
+    return bs_out;
 }
 
 #ifndef OPENSSL_NO_OCSP
 static int test_resp_signer(void)
 {
-    OCSP_BASICRESP *bs;
+    OCSP_BASICRESP *bs = NULL;
     X509 *signer = NULL, *tmp;
     EVP_PKEY *key = NULL;
-    STACK_OF(X509) *extra_certs;
+    STACK_OF(X509) *extra_certs = NULL;
+    int ret = 0;
 
     /*
      * Test a response with no certs at all; get the signer from the
@@ -101,10 +106,10 @@ static int test_resp_signer(void)
         || !TEST_true(sk_X509_push(extra_certs, signer))
         || !TEST_true(OCSP_basic_sign(bs, signer, key, EVP_sha1(),
                                       NULL, OCSP_NOCERTS)))
-        return 0;
+        goto err;
     if (!TEST_true(OCSP_resp_get0_signer(bs, &tmp, extra_certs))
         || !TEST_int_eq(X509_cmp(tmp, signer), 0))
-        return 0;
+        goto err;
     OCSP_BASICRESP_free(bs);
 
     /* Do it again but include the signer cert */
@@ -113,15 +118,17 @@ static int test_resp_signer(void)
     if (!TEST_ptr(bs)
         || !TEST_true(OCSP_basic_sign(bs, signer, key, EVP_sha1(),
                                       NULL, 0)))
-        return 0;
+        goto err;
     if (!TEST_true(OCSP_resp_get0_signer(bs, &tmp, NULL))
         || !TEST_int_eq(X509_cmp(tmp, signer), 0))
-        return 0;
+        goto err;
+    ret = 1;
+ err:
     OCSP_BASICRESP_free(bs);
     sk_X509_free(extra_certs);
     X509_free(signer);
     EVP_PKEY_free(key);
-    return 1;
+    return ret;
 }
 #endif
 

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -21,6 +21,7 @@
 static const char *certstr;
 static const char *privkeystr;
 
+#ifndef OPENSSL_NO_OCSP
 static int get_cert_and_key(X509 **cert_out, EVP_PKEY **key_out)
 {
     BIO *certbio, *keybio;
@@ -85,7 +86,6 @@ static OCSP_BASICRESP *make_dummy_resp(void)
     return bs_out;
 }
 
-#ifndef OPENSSL_NO_OCSP
 static int test_resp_signer(void)
 {
     OCSP_BASICRESP *bs = NULL;

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -170,38 +170,42 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
                 | checkhandshake::PSK_SRV_EXTENSION),
                "Resumption handshake test");
 
-#Test 3: A status_request handshake (client request only)
-$proxy->clear();
-$proxy->clientflags("-status");
-$proxy->start();
-checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
-               checkhandshake::DEFAULT_EXTENSIONS
-               | checkhandshake::STATUS_REQUEST_CLI_EXTENSION,
-               "status_request handshake test (client)");
+SKIP: {
+    skip "No OCSP support in this OpenSSL build", 3
+        if disabled("ct") || disabled("ec") || disabled("ocsp");
+    #Test 3: A status_request handshake (client request only)
+    $proxy->clear();
+    $proxy->clientflags("-status");
+    $proxy->start();
+    checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
+                   checkhandshake::DEFAULT_EXTENSIONS
+                   | checkhandshake::STATUS_REQUEST_CLI_EXTENSION,
+                   "status_request handshake test (client)");
 
-#Test 4: A status_request handshake (server support only)
-$proxy->clear();
-$proxy->serverflags("-status_file "
-                    .srctop_file("test", "recipes", "ocsp-response.der"));
-$proxy->start();
-checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
-               checkhandshake::DEFAULT_EXTENSIONS,
-               "status_request handshake test (server)");
+    #Test 4: A status_request handshake (server support only)
+    $proxy->clear();
+    $proxy->serverflags("-status_file "
+                        .srctop_file("test", "recipes", "ocsp-response.der"));
+    $proxy->start();
+    checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
+                   checkhandshake::DEFAULT_EXTENSIONS,
+                   "status_request handshake test (server)");
 
-#Test 5: A status_request handshake (client and server)
-#TODO(TLS1.3): TLS1.3 doesn't actually have CertificateStatus messages. This is
-#a temporary test until such time as we do proper TLS1.3 style certificate
-#status
-$proxy->clear();
-$proxy->clientflags("-status");
-$proxy->serverflags("-status_file "
-                    .srctop_file("test", "recipes", "ocsp-response.der"));
-$proxy->start();
-checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
-               checkhandshake::DEFAULT_EXTENSIONS
-               | checkhandshake::STATUS_REQUEST_CLI_EXTENSION
-               | checkhandshake::STATUS_REQUEST_SRV_EXTENSION,
-               "status_request handshake test");
+    #Test 5: A status_request handshake (client and server)
+    #TODO(TLS1.3): TLS1.3 doesn't actually have CertificateStatus messages. This is
+    #a temporary test until such time as we do proper TLS1.3 style certificate
+    #status
+    $proxy->clear();
+    $proxy->clientflags("-status");
+    $proxy->serverflags("-status_file "
+                        .srctop_file("test", "recipes", "ocsp-response.der"));
+    $proxy->start();
+    checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
+                   checkhandshake::DEFAULT_EXTENSIONS
+                   | checkhandshake::STATUS_REQUEST_CLI_EXTENSION
+                   | checkhandshake::STATUS_REQUEST_SRV_EXTENSION,
+                   "status_request handshake test");
+}
 
 #Test 6: A client auth handshake
 $proxy->clear();

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -192,9 +192,6 @@ SKIP: {
                    "status_request handshake test (server)");
 
     #Test 5: A status_request handshake (client and server)
-    #TODO(TLS1.3): TLS1.3 doesn't actually have CertificateStatus messages. This is
-    #a temporary test until such time as we do proper TLS1.3 style certificate
-    #status
     $proxy->clear();
     $proxy->clientflags("-status");
     $proxy->serverflags("-status_file "


### PR DESCRIPTION
Fix some issues spotted by coverity and unbreak no-ocsp

@levitte the failure mode for the no-ocsp enable-tls1_3 mode is pretty poor, as s_client gives usage() but s_server keeps running, so the test suite appears to hang.  Is there something more systematic we should be doing as well?