### PR TITLE
Make BIO_METHOD struct definitions consistent

### DIFF
--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -58,7 +58,8 @@ static int fd_free(BIO *data);
 int BIO_fd_should_retry(int s);
 
 static const BIO_METHOD methods_fdp = {
-    BIO_TYPE_FD, "file descriptor",
+    BIO_TYPE_FD,
+    "file descriptor",
     /* TODO: Convert to new style write function */
     bwrite_conv,
     fd_write,

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -85,7 +85,8 @@ static void xsyslog(BIO *bp, int priority, const char *string);
 static void xcloselog(BIO *bp);
 
 static const BIO_METHOD methods_slg = {
-    BIO_TYPE_MEM, "syslog",
+    BIO_TYPE_MEM,
+    "syslog",
     /* TODO: Convert to new style write function */
     bwrite_conv,
     slg_write,

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -44,7 +44,8 @@ typedef struct b64_struct {
 } BIO_B64_CTX;
 
 static const BIO_METHOD methods_b64 = {
-    BIO_TYPE_BASE64, "base64 encoding",
+    BIO_TYPE_BASE64,
+    "base64 encoding",
     /* TODO: Convert to new style write function */
     bwrite_conv,
     b64_write,

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -40,7 +40,8 @@ typedef struct enc_struct {
 } BIO_ENC_CTX;
 
 static const BIO_METHOD methods_enc = {
-    BIO_TYPE_CIPHER, "cipher",
+    BIO_TYPE_CIPHER,
+    "cipher",
     /* TODO: Convert to new style write function */
     bwrite_conv,
     enc_write,

--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -29,7 +29,8 @@ static int md_free(BIO *data);
 static long md_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
 
 static const BIO_METHOD methods_md = {
-    BIO_TYPE_MD, "message digest",
+    BIO_TYPE_MD,
+    "message digest",
     /* TODO: Convert to new style write function */
     bwrite_conv,
     md_write,

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -108,7 +108,8 @@ typedef struct ok_struct {
 } BIO_OK_CTX;
 
 static const BIO_METHOD methods_ok = {
-    BIO_TYPE_CIPHER, "reliable",
+    BIO_TYPE_CIPHER,
+    "reliable",
     /* TODO: Convert to new style write function */
     bwrite_conv,
     ok_write,

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -34,7 +34,8 @@ typedef struct bio_ssl_st {
 } BIO_SSL;
 
 static const BIO_METHOD methods_sslp = {
-    BIO_TYPE_SSL, "ssl",
+    BIO_TYPE_SSL,
+    "ssl",
     ssl_write,
     NULL,
     ssl_read,


### PR DESCRIPTION
I noticed that some of the BIO_METHOD structs are placing the name on
the same line as the type and some don't. This commit places the name
on a separate line for consistency (which looks like what the majority
do)

CLA: trivial

##### Checklist
