### PR TITLE
Fix a switch statement fallthrough

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1301,13 +1301,15 @@ void SSL_trace(int write_p, int version, int content_type,
         break;
 
     case SSL3_RT_ALERT:
-        if (msglen != 2)
+        if (msglen != 2) {
             BIO_puts(bio, "    Illegal Alert Length\n");
-        else {
+        } else {
             BIO_printf(bio, "    Level=%s(%d), description=%s(%d)\n",
                        SSL_alert_type_string_long(msg[0] << 8),
                        msg[0], SSL_alert_desc_string_long(msg[1]), msg[1]);
         }
+        break;
+
     case DTLS1_RT_HEARTBEAT:
         ssl_print_heartbeat(bio, 4, msg, msglen);
         break;


### PR DESCRIPTION
SSL_trace() has a case which was inadvertently falling through.

My compiler was complaining about this fall through. The same problem exists in 1.0.2 but for some reason that I don't understand my compiler isn't complaining about that one - but we should fix it anyway. The cherry-pick isn't entirely clean but it is trivial to resolve. This doesn't affect the master branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
