### PR TITLE
Fix ssl_test_new with no-tls1_2

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -94,7 +94,7 @@ my %skip = (
   "23-srp.conf" => (disabled("tls1") && disabled ("tls1_1")
                     && disabled("tls1_2")) || disabled("srp"),
   "24-padding.conf" => disabled("tls1_3"),
-  "25-cipher.conf" => disabled("ec"),
+  "25-cipher.conf" => disabled("ec") || disabled("tls1_2"),
 );
 
 foreach my $conf (@conf_files) {


### PR DESCRIPTION
The tests in 25-cipher.conf all use TLSv1.2 ciphersuites so we shouldn't
run it if we don't have TLSv1.2

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
