### PR TITLE
Fix no-tls1_1

### DIFF
--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -19,10 +19,10 @@ test-13 = 13-RSA-PSS Signature Algorithm Selection
 test-14 = 14-RSA-PSS Certificate Signature Algorithm Selection
 test-15 = 15-Only RSA-PSS Certificate
 test-16 = 16-RSA-PSS Certificate, no PSS signature algorithms
-test-17 = 17-Only RSA-PSS Certificate, TLS v1.1
-test-18 = 18-Suite B P-256 Hash Algorithm Selection
-test-19 = 19-Suite B P-384 Hash Algorithm Selection
-test-20 = 20-TLS 1.2 Ed25519 Client Auth
+test-17 = 17-Suite B P-256 Hash Algorithm Selection
+test-18 = 18-Suite B P-384 Hash Algorithm Selection
+test-19 = 19-TLS 1.2 Ed25519 Client Auth
+test-20 = 20-Only RSA-PSS Certificate, TLS v1.1
 test-21 = 21-TLS 1.2 DSA Certificate Test
 # ===========================================================
 
@@ -547,38 +547,14 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[17-Only RSA-PSS Certificate, TLS v1.1]
-ssl_conf = 17-Only RSA-PSS Certificate, TLS v1.1-ssl
+[17-Suite B P-256 Hash Algorithm Selection]
+ssl_conf = 17-Suite B P-256 Hash Algorithm Selection-ssl
 
-[17-Only RSA-PSS Certificate, TLS v1.1-ssl]
-server = 17-Only RSA-PSS Certificate, TLS v1.1-server
-client = 17-Only RSA-PSS Certificate, TLS v1.1-client
+[17-Suite B P-256 Hash Algorithm Selection-ssl]
+server = 17-Suite B P-256 Hash Algorithm Selection-server
+client = 17-Suite B P-256 Hash Algorithm Selection-client
 
-[17-Only RSA-PSS Certificate, TLS v1.1-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[17-Only RSA-PSS Certificate, TLS v1.1-client]
-CipherString = DEFAULT
-MaxProtocol = TLSv1.1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-17]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[18-Suite B P-256 Hash Algorithm Selection]
-ssl_conf = 18-Suite B P-256 Hash Algorithm Selection-ssl
-
-[18-Suite B P-256 Hash Algorithm Selection-ssl]
-server = 18-Suite B P-256 Hash Algorithm Selection-server
-client = 18-Suite B P-256 Hash Algorithm Selection-client
-
-[18-Suite B P-256 Hash Algorithm Selection-server]
+[17-Suite B P-256 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
@@ -586,13 +562,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[18-Suite B P-256 Hash Algorithm Selection-client]
+[17-Suite B P-256 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-18]
+[test-17]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -601,14 +577,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[19-Suite B P-384 Hash Algorithm Selection]
-ssl_conf = 19-Suite B P-384 Hash Algorithm Selection-ssl
+[18-Suite B P-384 Hash Algorithm Selection]
+ssl_conf = 18-Suite B P-384 Hash Algorithm Selection-ssl
 
-[19-Suite B P-384 Hash Algorithm Selection-ssl]
-server = 19-Suite B P-384 Hash Algorithm Selection-server
-client = 19-Suite B P-384 Hash Algorithm Selection-client
+[18-Suite B P-384 Hash Algorithm Selection-ssl]
+server = 18-Suite B P-384 Hash Algorithm Selection-server
+client = 18-Suite B P-384 Hash Algorithm Selection-client
 
-[19-Suite B P-384 Hash Algorithm Selection-server]
+[18-Suite B P-384 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
@@ -616,13 +592,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[19-Suite B P-384 Hash Algorithm Selection-client]
+[18-Suite B P-384 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-19]
+[test-18]
 ExpectedResult = Success
 ExpectedServerCertType = P-384
 ExpectedServerSignHash = SHA384
@@ -631,21 +607,21 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[20-TLS 1.2 Ed25519 Client Auth]
-ssl_conf = 20-TLS 1.2 Ed25519 Client Auth-ssl
+[19-TLS 1.2 Ed25519 Client Auth]
+ssl_conf = 19-TLS 1.2 Ed25519 Client Auth-ssl
 
-[20-TLS 1.2 Ed25519 Client Auth-ssl]
-server = 20-TLS 1.2 Ed25519 Client Auth-server
-client = 20-TLS 1.2 Ed25519 Client Auth-client
+[19-TLS 1.2 Ed25519 Client Auth-ssl]
+server = 19-TLS 1.2 Ed25519 Client Auth-server
+client = 19-TLS 1.2 Ed25519 Client Auth-client
 
-[20-TLS 1.2 Ed25519 Client Auth-server]
+[19-TLS 1.2 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[20-TLS 1.2 Ed25519 Client Auth-client]
+[19-TLS 1.2 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -654,10 +630,34 @@ MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-20]
+[test-19]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
+
+
+# ===========================================================
+
+[20-Only RSA-PSS Certificate, TLS v1.1]
+ssl_conf = 20-Only RSA-PSS Certificate, TLS v1.1-ssl
+
+[20-Only RSA-PSS Certificate, TLS v1.1-ssl]
+server = 20-Only RSA-PSS Certificate, TLS v1.1-server
+client = 20-Only RSA-PSS Certificate, TLS v1.1-client
+
+[20-Only RSA-PSS Certificate, TLS v1.1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+
+[20-Only RSA-PSS Certificate, TLS v1.1-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-20]
+ExpectedResult = ServerFail
 
 
 # ===========================================================

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -266,16 +266,6 @@ our @tests = (
         },
     },
     {
-        name => "Only RSA-PSS Certificate, TLS v1.1",
-        server => $server_pss_only,
-        client => {
-            "MaxProtocol" => "TLSv1.1",
-        },
-        test   => {
-            "ExpectedResult" => "ServerFail"
-        },
-    },
-    {
         name => "Suite B P-256 Hash Algorithm Selection",
         server =>  {
             "ECDSA.Certificate" => test_pem("p256-server-cert.pem"),
@@ -332,6 +322,21 @@ our @tests = (
         },
     },
 );
+
+my @tests_tls_1_1 = (
+    {
+        name => "Only RSA-PSS Certificate, TLS v1.1",
+        server => $server_pss_only,
+        client => {
+            "MaxProtocol" => "TLSv1.1",
+        },
+        test   => {
+            "ExpectedResult" => "ServerFail"
+        },
+    },
+);
+
+push @tests, @tests_tls_1_1 unless disabled("tls1_1");
 
 my $server_tls_1_3 = {
     "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),


### PR DESCRIPTION
In 20-cert-select.conf there is a TLSv1.1 specific test which we should
skip if TLSv1.1. is disabled.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
