### PR TITLE
Fix no-poly1305 and no-chacha

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -66,7 +66,7 @@ my %conf_dependent_tests = (
   "19-mac-then-encrypt.conf" => !$is_default_tls,
   "20-cert-select.conf" => !$is_default_tls || $no_dh || $no_dsa,
   "22-compression.conf" => !$is_default_tls,
-  "25-cipher.conf" => disabled("poly1305"),
+  "25-cipher.conf" => disabled("poly1305") || disabled("chacha"),
 );
 
 # Add your test here if it should be skipped for some compile-time

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -66,6 +66,7 @@ my %conf_dependent_tests = (
   "19-mac-then-encrypt.conf" => !$is_default_tls,
   "20-cert-select.conf" => !$is_default_tls || $no_dh || $no_dsa,
   "22-compression.conf" => !$is_default_tls,
+  "25-cipher.conf" => disabled("poly1305"),
 );
 
 # Add your test here if it should be skipped for some compile-time

--- a/test/ssl-tests/25-cipher.conf
+++ b/test/ssl-tests/25-cipher.conf
@@ -207,13 +207,13 @@ Options = ServerPreference,PrioritizeChaCha
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-cipher-server-pref-mobile-client]
-CipherString = ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384
+CipherString = ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-7]
-ExpectedCipher = ECDHE-RSA-CHACHA20-POLY1305
+ExpectedCipher = ECDHE-RSA-AES256-SHA384
 
 
 # ===========================================================
@@ -233,12 +233,12 @@ Options = ServerPreference,PrioritizeChaCha
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-cipher-server-pref-mobile2-client]
-CipherString = ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305
+CipherString = ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-8]
-ExpectedCipher = ECDHE-RSA-AES256-SHA384
+ExpectedCipher = ECDHE-RSA-CHACHA20-POLY1305
 
 

--- a/test/ssl-tests/25-cipher.conf.in
+++ b/test/ssl-tests/25-cipher.conf.in
@@ -13,7 +13,7 @@ use strict;
 use warnings;
 
 package ssltests;
-
+use OpenSSL::Test::Utils;
 
 our @tests = (
     {
@@ -127,12 +127,15 @@ our @tests = (
         },
         client => {
             "MaxProtocol" => "TLSv1.2",
-            "CipherString" => "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
+            "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305",
         },
         test => {
-            "ExpectedCipher" => "ECDHE-RSA-CHACHA20-POLY1305",
+            "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",
         },
     },
+);
+
+my @tests_poly1305 = (
     {
         name => "cipher-server-pref-mobile2",
         server => {
@@ -142,10 +145,12 @@ our @tests = (
         },
         client => {
             "MaxProtocol" => "TLSv1.2",
-            "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305",
+            "CipherString" => "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
         },
         test => {
-            "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",
+            "ExpectedCipher" => "ECDHE-RSA-CHACHA20-POLY1305",
         },
     },
 );
+
+push @tests, @tests_poly1305 unless disabled("poly1305");

--- a/test/ssl-tests/25-cipher.conf.in
+++ b/test/ssl-tests/25-cipher.conf.in
@@ -153,4 +153,4 @@ my @tests_poly1305 = (
     },
 );
 
-push @tests, @tests_poly1305 unless disabled("poly1305");
+push @tests, @tests_poly1305 unless disabled("poly1305") || disabled("chacha");

--- a/test/ssl-tests/25-cipher.conf.in
+++ b/test/ssl-tests/25-cipher.conf.in
@@ -19,12 +19,12 @@ our @tests = (
     {
         name => "cipher-server-1",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
+    },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384"
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384"
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",
@@ -33,12 +33,12 @@ our @tests = (
     {
         name => "cipher-server-2",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES128-SHA256"
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES128-SHA256"
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES128-SHA256",
@@ -47,12 +47,12 @@ our @tests = (
     {
         name => "cipher-server-client-list",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES128-SHA256",
@@ -61,13 +61,13 @@ our @tests = (
     {
         name => "cipher-server-pref-1",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
-	    "Options" => "ServerPreference",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
+            "Options" => "ServerPreference",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384"
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384"
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",
@@ -76,13 +76,13 @@ our @tests = (
     {
         name => "cipher-server-pref-2",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
-	    "Options" => "ServerPreference",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
+            "Options" => "ServerPreference",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES128-SHA256"
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES128-SHA256"
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES128-SHA256",
@@ -91,13 +91,13 @@ our @tests = (
     {
         name => "cipher-server-pref-client-list",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
-	    "Options" => "ServerPreference",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256",
+            "Options" => "ServerPreference",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",
@@ -106,13 +106,13 @@ our @tests = (
     {
         name => "cipher-server-pref-not-mobile",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305",
-	    "Options" => "ServerPreference",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305",
+            "Options" => "ServerPreference",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",
@@ -121,13 +121,13 @@ our @tests = (
     {
         name => "cipher-server-pref-mobile",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305",
-	    "Options" => "ServerPreference,PrioritizeChaCha",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305",
+            "Options" => "ServerPreference,PrioritizeChaCha",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384",
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-CHACHA20-POLY1305",
@@ -136,13 +136,13 @@ our @tests = (
     {
         name => "cipher-server-pref-mobile2",
         server => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305",
-	    "Options" => "ServerPreference,PrioritizeChaCha",
-	},
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305",
+            "Options" => "ServerPreference,PrioritizeChaCha",
+        },
         client => {
-	    "MaxProtocol" => "TLSv1.2",
-	    "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305",
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305",
         },
         test => {
             "ExpectedCipher" => "ECDHE-RSA-AES256-SHA384",


### PR DESCRIPTION
I also (in a separate commit) replaced tabs with spaces in 25-cipher.conf.in
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
