### PR TITLE
Document SSL_OP_NO_RENEGOTIATION as new in 1.1.1

### DIFF
--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -315,7 +315,8 @@ L<dhparam(1)>
 The attempt to always try to use secure renegotiation was added in
 Openssl 0.9.8m.
 
-B<SSL_OP_PRIORITIZE_CHACHA> was added in OpenSSL 1.1.1.
+B<SSL_OP_PRIORITIZE_CHACHA> and B<SSL_OP_NO_RENEGOTIATION> were added in
+OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Closes: https://github.com/openssl/openssl/issues/4897
Signed-off-by: Christian Heimes <christian@python.org>
