### PR TITLE
Configure: move the processing of predefined macros to a function

### DIFF
--- a/Configure
+++ b/Configure
@@ -1235,31 +1235,18 @@ unless ($disabled{asm}) {
     }
 }
 
-my %predefined;
+my %predefined = compiler_predefined($target{cc});
 
-if ($^O ne "VMS") {
-    my $cc = "$config{cross_compile_prefix}$target{cc}";
-
-    # collect compiler pre-defines from gcc or gcc-alike...
-    open(PIPE, "$cc -dM -E -x c /dev/null 2>&1 |");
-    while (<PIPE>) {
-	m/^#define\s+(\w+(?:\(\w+\))?)(?:\s+(.+))?/ or last;
-	$predefined{$1} = $2 // "";
-    }
-    close(PIPE);
-
-    if (!$disabled{makedepend}) {
-	# We know that GNU C version 3 and up as well as all clang
-	# versions support dependency generation
-	if ($predefined{__GNUC__} >= 3) {
-	    $config{makedepprog} = $cc;
-	} else {
-	    $config{makedepprog} = which('makedepend');
-	    $disabled{makedepend} = "unavailable" unless $config{makedepprog};
-	}
+if (!$disabled{makedepend}) {
+    # We know that GNU C version 3 and up as well as all clang
+    # versions support dependency generation
+    if ($predefined{__GNUC__} >= 3) {
+        $config{makedepprog} = "\$(CROSS_COMPILE)$target{cc}";
+    } else {
+        $config{makedepprog} = which('makedepend');
+        $disabled{makedepend} = "unavailable" unless $config{makedepprog};
     }
 }
-
 
 
 # Deal with bn_ops ###################################################
@@ -2512,6 +2499,32 @@ sub run_dofile
     system($cmd);
     exit 1 if $? != 0;
     rename("$out.new", $out) || die "Can't rename $out.new, $!";
+}
+
+sub compiler_predefined {
+    state %predefined;
+    my $default_compiler = shift;
+
+    return () if $^O eq 'VMS';
+
+    die 'compiler_predefines called without a default compiler'
+        unless $default_compiler;
+
+    if (! $predefined{$default_compiler}) {
+        my $cc = "$config{cross_compile_prefix}$default_compiler";
+
+        $predefined{$default_compiler} = {};
+
+        # collect compiler pre-defines from gcc or gcc-alike...
+        open(PIPE, "$cc -dM -E -x c /dev/null 2>&1 |");
+        while (my $l = <PIPE>) {
+            $l =~ m/^#define\s+(\w+(?:\(\w+\))?)(?:\s+(.+))?/ or last;
+            $predefined{$default_compiler}->{$1} = $2 // '';
+        }
+        close(PIPE);
+    }
+
+    return %{$predefined{$default_compiler}};
 }
 
 sub which


### PR DESCRIPTION
This is useful for cases when one might want to find out from more places, as shown in #4840.  It's not a *complete* solution, but combined with #4854, there is potential.