### PR TITLE
Fix typo in comment

### DIFF
--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -230,7 +230,7 @@ int rsa_main(int argc, char **argv)
                    ERR_GET_REASON(err) != ERR_R_MALLOC_FAILURE) {
                 BIO_printf(out, "RSA key error: %s\n",
                            ERR_reason_error_string(err));
-                ERR_get_error(); /* remove e from error stack */
+                ERR_get_error(); /* remove err from error stack */
             }
         } else if (r == -1) {
             ERR_print_errors(bio_err);


### PR DESCRIPTION
The one in rsa.c was overlooked when fixing the same comment in
pkey.c as part of eff1752b66cb7bf6ca8af816eb10ead26910d025.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
