### PR TITLE
Minor cleanup of the rsa mp limits code

### DIFF
--- a/crypto/rsa/rsa_locl.h
+++ b/crypto/rsa/rsa_locl.h
@@ -10,9 +10,8 @@
 #include <openssl/rsa.h>
 #include "internal/refcount.h"
 
-#define RSA_MAX_PRIME_NUM 16
-#define RSA_MIN_PRIME_SIZE 64
-#define RSA_MIN_MODULUS_BITS	512
+#define RSA_MAX_PRIME_NUM       5
+#define RSA_MIN_MODULUS_BITS    512
 
 typedef struct rsa_prime_info_st {
     BIGNUM *r;

--- a/crypto/rsa/rsa_mp.c
+++ b/crypto/rsa/rsa_mp.c
@@ -105,5 +105,8 @@ int rsa_multip_cap(int bits)
     else if (bits < 8192)
         cap = 4;
 
+    if (cap > RSA_MAX_PRIME_NUM)
+        cap = RSA_MAX_PRIME_NUM;
+
     return cap;
 }


### PR DESCRIPTION
Reduce RSA_MAX_PRIME_NUM to 5.
Remove no longer used RSA_MIN_PRIME_SIZE.
Make rsa_multip_cap honor RSA_MAX_PRIME_NUM.
