### PR TITLE
Restore makedepend capabilities for Windows and VMS

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -640,7 +640,7 @@ EOF
       my $depbuild = $disabled{makedepend} ? ""
           : " /MMS=(FILE=${objd}${objn}.tmp-D,TARGET=$obj.OBJ)";
 
-      return <<"EOF";
+      return <<"EOF"
 $obj.OBJ : $deps
         ${before}
         SET DEFAULT $forward
@@ -649,11 +649,14 @@ $obj.OBJ : $deps
         $incs_off
         SET DEFAULT $backward
         ${after}
+        - PURGE $obj.OBJ
+EOF
+      . ($disabled{makedepend} ? "" : <<"EOF"
         \@ PIPE ( \$(PERL) -e "use File::Compare qw/compare_text/; my \$x = compare_text(""$obj.D"",""$obj.tmp-D""); exit(0x10000000 + (\$x == 0));" || -
                  RENAME $obj.tmp-D $obj.d )
         \@ IF F\$SEARCH("$obj.tmp-D") .NES. "" THEN DELETE $obj.tmp-D;*
-        - PURGE $obj.OBJ
 EOF
+        );
   }
   sub libobj2shlib {
       my %args = @_;

--- a/Configure
+++ b/Configure
@@ -1237,7 +1237,10 @@ unless ($disabled{asm}) {
 
 my %predefined = compiler_predefined($target{cc});
 
-if (!$disabled{makedepend}) {
+# Check for makedepend capabilities.  Note that for VC- and vms- targets,
+# this should not be done, as it's likely to turn off a functionality that
+# actually exists, currently hard coded for cl (Windows) and CC/DECC (VMS).
+if ($config{target} !~ /^(VC|vms)-/ && !$disabled{makedepend}) {
     # We know that GNU C version 3 and up as well as all clang
     # versions support dependency generation
     if ($predefined{__GNUC__} >= 3) {

--- a/Configure
+++ b/Configure
@@ -1237,15 +1237,19 @@ unless ($disabled{asm}) {
 
 my %predefined = compiler_predefined($target{cc});
 
-# Check for makedepend capabilities.  Note that for VC- and vms- targets,
-# this should not be done, as it's likely to turn off a functionality that
-# actually exists, currently hard coded for cl (Windows) and CC/DECC (VMS).
-if ($config{target} !~ /^(VC|vms)-/ && !$disabled{makedepend}) {
-    # We know that GNU C version 3 and up as well as all clang
-    # versions support dependency generation
-    if ($predefined{__GNUC__} >= 3) {
+# Check for makedepend capabilities.
+if (!$disabled{makedepend}) {
+    if ($config{target} =~ /^(VC|vms)-/) {
+        # For VC- and vms- targets, there's nothing more to do here.  The
+        # functionality is hard coded in the corresponding build files for
+        # cl (Windows) and CC/DECC (VMS).
+    } elsif ($predefined{__GNUC__} >= 3) {
+        # We know that GNU C version 3 and up as well as all clang
+        # versions support dependency generation
         $config{makedepprog} = "\$(CROSS_COMPILE)$target{cc}";
     } else {
+        # In all other cases, we look for 'makedepend', and disable the
+        # capability if not found.
         $config{makedepprog} = which('makedepend');
         $disabled{makedepend} = "unavailable" unless $config{makedepprog};
     }


### PR DESCRIPTION
This got lost somehow.  The methods to do makedepend on Windows and
VMS are hard coded for cl (Windows) and CC/DECC (VMS), because that's
what we currently support natively.
