### PR TITLE
Fix leak in ERR_get_state() when OPENSSL_init_crypto() isn't called yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
 
 os:
     - linux
+    - osx
 
 compiler:
     - clang
@@ -117,6 +118,9 @@ matrix:
           compiler: gcc
 
 before_script:
+    - if [ "$TRAVIS_OS_NAME" == osx ]; then
+          export CONFIG_OPTS_EXTRA=-Wno-format;
+      fi
     - env
     - if [ "$TRAVIS_PULL_REQUEST" != "false" -a -n "$EXTENDED_TEST" ]; then
           (git log -1 $TRAVIS_COMMIT_RANGE | grep '\[extended tests\]' > /dev/null) || exit 0;
@@ -149,7 +153,7 @@ before_script:
           elif which ccache >/dev/null; then
               CC="ccache $CC";
           fi;
-          $srcdir/config -v $CONFIG_OPTS;
+          $srcdir/config -v $CONFIG_OPTS $CONFIG_OPTS_EXTRA;
       fi
     - cd $top
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -667,6 +667,14 @@ ERR_STATE *ERR_get_state(void)
     if (!RUN_ONCE(&err_init, err_do_init))
         return NULL;
 
+    /*
+     * If base OPENSSL_init_crypto() hasn't been called yet, be sure to call
+     * it now to avoid state to be doubly allocated and thereby leak memory.
+     * Needed on any platform that doesn't define OPENSSL_USE_NODELETE.
+     */
+    if (!OPENSSL_init_crypto(0, NULL))
+        return NULL;
+
     state = CRYPTO_THREAD_get_local(&err_thread_local);
 
     if (state == NULL) {


### PR DESCRIPTION
The solution is to make an early call of a base OPENSSL_init_crypto().

This only happens on platforms where OPENSSL_USE_NODELETE is defined.
