### PR TITLE
Fix more OCSP_resp_get0_signer() nits

### DIFF
--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -139,7 +139,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
 }
 
 int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, X509 **signer,
-                     STACK_OF(X509) *extra_certs)
+                          STACK_OF(X509) *extra_certs)
 {
     int ret;
 

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -80,7 +80,7 @@ single response B<bs>.
 
 OCSP_resp_get0_certs() returns any certificates included in B<bs>.
 
-OCSP_resp_get0_signer() attempts to retrive the certificate that directly
+OCSP_resp_get0_signer() attempts to retrieve the certificate that directly
 signed B<bs>.  The OCSP protocol does not require that this certificate
 is included in the B<certs> field of the response, so additional certificates
 can be supplied in B<extra_certs> if the certificates that may have


### PR DESCRIPTION
Fix a typo for "retrieve" and some indentation.
Need to fix these on master before merging back to 1.1.0 in #4723 
cc @mattcaswell 