### PR TITLE
Suggestion for improvements to x509.pod

### DIFF
--- a/doc/man7/x509.pod
+++ b/doc/man7/x509.pod
@@ -30,20 +30,20 @@ extension) and a few more.
 Finally, there's the supertype X509_INFO, which can contain a CRL, a
 certificate and a corresponding private key.
 
-B<X509_>I<...>, B<d2i_X509_>I<...> and B<i2d_X509_>I<...> handle X.509
-certificates, with some exceptions, shown below.
+B<X509_>I<XXX>, B<d2i_X509_>I<XXX>, and B<i2d_X509_>I<XXX> functions
+handle X.509 certificates, with some exceptions, shown below.
 
-B<X509_CRL_>I<...>, B<d2i_X509_CRL_>I<...> and B<i2d_X509_CRL_>I<...>
-handle X.509 CRLs.
+B<X509_CRL_>I<XXX>, B<d2i_X509_CRL_>I<XXX>, and B<i2d_X509_CRL_>I<XXX>
+functions handle X.509 CRLs.
 
-B<X509_REQ_>I<...>, B<d2i_X509_REQ_>I<...> and B<i2d_X509_REQ_>I<...>
-handle PKCS#10 certificate requests.
+B<X509_REQ_>I<XXX>, B<d2i_X509_REQ_>I<XXX>, and B<i2d_X509_REQ_>I<XXX>
+functions handle PKCS#10 certificate requests.
 
-B<X509_NAME_>I<...> handle certificate names.
+B<X509_NAME_>I<XXX> functions handle certificate names.
 
-B<X509_ATTRIBUTE_>I<...> handle certificate attributes.
+B<X509_ATTRIBUTE_>I<XXX> functions handle certificate attributes.
 
-B<X509_EXTENSION_>I<...> handle certificate extensions.
+B<X509_EXTENSION_>I<XXX> functions handle certificate extensions.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This commit is a suggestion to hopefully improve x509.pod. I had to
re-read it the first time through and with these changes it reads a
little easier, and wondering if others agree.

man output:
```console
DESCRIPTION
       ...
       
       X509_XXX, d2i_X509_XXX, and i2d_X509_XXX functions handle X.509
       certificates, with some exceptions, shown below.

       X509_CRL_XXX, d2i_X509_CRL_XXX, and i2d_X509_CRL_XXX functions handle
       X.509 CRLs.

       X509_REQ_XXX, d2i_X509_REQ_XXX, and i2d_X509_REQ_XXX functions handle
       PKCS#10 certificate requests.

       X509_NAME_XXX functions handle certificate names.

       X509_ATTRIBUTE_XXX functions handle certificate attributes.

       X509_EXTENSION_XXX functions handle certificate extensions.

SEE ALSO
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
