### PR TITLE
Remove test-runs dir, adjust .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,8 @@ Makefile
 /util/shlib_wrap.sh
 /tags
 /TAGS
-/crypto.map
-/ssl.map
+/libcrypto.map
+/libssl.map
 
 # Windows (legacy)
 /tmp32

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -311,7 +311,7 @@ clean: libclean
 	-$(RM) `find . -name '*{- $objext -}' -a \! -path "./.git/*"`
 	$(RM) core
 	$(RM) tags TAGS doc-nits
-	$(RM) test/.rnd
+	$(RM) -r test/test-runs
 	$(RM) openssl.pc libcrypto.pc libssl.pc
 	-$(RM) `find . -type l -a \! -path "./.git/*"`
 	$(RM) $(TARFILE)


### PR DESCRIPTION
Ignore libssl.map/libcrypto.map instead of ssl.map/crypto.map

test/test-runs is a temp directory that is not removed by
make clean or distclean.
It contains only a .rnd file but potentially others as well, therefore
RM -r is necessary to remove it.
I expect the RM for test/.rnd to be an orphan, thus removed.