### PR TITLE
New load_csr() in apps.c simplifiying req, x509, and ca apps and allowing DER input to ca

### DIFF
--- a/apps/crl.c
+++ b/apps/crl.c
@@ -205,7 +205,7 @@ int crl_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    x = load_crl(infile, informat);
+    x = load_crl(infile, informat, "CRL");
     if (x == NULL)
         goto end;
 
@@ -250,7 +250,7 @@ int crl_main(int argc, char **argv)
             BIO_puts(bio_err, "Missing CRL signing key\n");
             goto end;
         }
-        newcrl = load_crl(crldiff, informat);
+        newcrl = load_crl(crldiff, informat, "other CRL");
         if (!newcrl)
             goto end;
         pkey = load_key(keyfile, keyformat, 0, NULL, NULL, "CRL signing key");

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -104,16 +104,17 @@ int set_ext_copy(int *copy_type, const char *arg);
 int copy_extensions(X509 *x, X509_REQ *req, int copy_type);
 int app_passwd(const char *arg1, const char *arg2, char **pass1, char **pass2);
 int add_oid_section(CONF *conf);
-X509 *load_cert(const char *file, int format, const char *cert_descrip);
-X509_CRL *load_crl(const char *infile, int format);
+X509_REQ *load_csr(const char *file, int format, const char *desc);
+X509 *load_cert(const char *file, int format, const char *desc);
+X509_CRL *load_crl(const char *infile, int format, const char *desc);
 EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
-                   const char *pass, ENGINE *e, const char *key_descrip);
+                   const char *pass, ENGINE *e, const char *desc);
 EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
-                      const char *pass, ENGINE *e, const char *key_descrip);
+                      const char *pass, ENGINE *e, const char *desc);
 int load_certs(const char *file, STACK_OF(X509) **certs, int format,
-               const char *pass, const char *cert_descrip);
+               const char *pass, const char *desc);
 int load_crls(const char *file, STACK_OF(X509_CRL) **crls, int format,
-              const char *pass, const char *cert_descrip);
+              const char *pass, const char *desc);
 X509_STORE *setup_verify(const char *CAfile, int noCAfile,
                          const char *CApath, int noCApath,
                          const char *CAstore, int noCAstore);

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -342,6 +342,7 @@ char *opt_init(int ac, char **av, const OPTIONS * o);
 int opt_next(void);
 void opt_begin(void);
 int opt_format(const char *s, unsigned long flags, int *result);
+const char *format2str(int format);
 int opt_int(const char *arg, int *result);
 int opt_ulong(const char *arg, unsigned long *result);
 int opt_long(const char *arg, long *result);
@@ -370,6 +371,7 @@ int opt_provider(int i);
 void opt_help(const OPTIONS * list);
 void opt_print(const OPTIONS * opt, int doingparams, int width);
 int opt_format_error(const char *s, unsigned long flags);
+void print_format_error(int format, unsigned long flags);
 int opt_isdir(const char *name);
 int opt_printf_stderr(const char *fmt, ...);
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -472,9 +472,14 @@ X509 *load_cert(const char *file, int format, const char *desc)
         if (!load_pkcs12(cert, desc, NULL, NULL, NULL, &x, NULL))
             goto end;
     } else {
-        BIO_printf(bio_err, "bad input format specified for %s\n", cert_descrip);
+        print_format_error(format,
+#if !defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_NO_SOCK)
+                                   OPT_FMT_HTTP |
+#endif
+                                   OPT_FMT_PEMDER | OPT_FMT_PKCS12);
         goto end;
     }
+
  end:
     if (x == NULL && desc != NULL) {
         BIO_printf(bio_err, "unable to load %s\n", desc);
@@ -504,7 +509,7 @@ X509_CRL *load_crl(const char *infile, int format, const char *desc)
     } else if (format == FORMAT_PEM) {
         x = PEM_read_bio_X509_CRL(in, NULL, NULL, NULL);
     } else {
-        BIO_printf(bio_err, "bad input format specified for input crl\n");
+        print_format_error(format, OPT_FMT_PEMDER);
         goto end;
     }
 
@@ -531,8 +536,10 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
         req = d2i_X509_REQ_bio(in, NULL);
     else if (format == FORMAT_PEM)
         req = PEM_read_bio_X509_REQ(in, NULL, NULL, NULL);
-    else if (desc)
-        BIO_printf(bio_err, "unsupported format for loading %s\n", desc);
+    else {
+        print_format_error(format, OPT_FMT_PEMDER);
+        goto end;
+    }
 
  end:
     if (req == NULL && desc != NULL) {
@@ -602,7 +609,14 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
         pkey = b2i_PVK_bio(key, wrap_password_callback, &cb_data);
 #endif
     } else {
-        BIO_printf(bio_err, "bad input format specified for key file\n");
+        print_format_error(format, OPT_FMT_PEMDER | OPT_FMT_PKCS12
+#if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DSA) && !defined (OPENSSL_NO_RC4)
+                                 | OPT_FMT_MSBLOB | FORMAT_PVK
+#endif
+#ifndef OPENSSL_NO_ENGINE
+                                 | OPT_FMT_ENGINE
+#endif
+                           );
         goto end;
     }
  end:
@@ -693,6 +707,12 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
     } else if (format == FORMAT_MSBLOB) {
         pkey = b2i_PublicKey_bio(key);
 #endif
+    } else {
+        print_format_error(format, OPT_FMT_PEMDER
+#if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DSA)
+                                 | OPT_FMT_MSBLOB
+#endif
+                           );
     }
  end:
     BIO_free(key);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -410,7 +410,7 @@ static int load_pkcs12(BIO *in, const char *desc,
     int len, ret = 0;
     PKCS12 *p12;
     p12 = d2i_PKCS12_bio(in, NULL);
-    if (p12 == NULL) {
+    if (p12 == NULL && desc != NULL) {
         BIO_printf(bio_err, "Error loading PKCS12 file for %s\n", desc);
         goto die;
     }
@@ -422,7 +422,8 @@ static int load_pkcs12(BIO *in, const char *desc,
             pem_cb = (pem_password_cb *)password_callback;
         len = pem_cb(tpass, PEM_BUFSIZE, 0, cb_data);
         if (len < 0) {
-            BIO_printf(bio_err, "Passphrase callback error for %s\n", desc);
+            BIO_printf(bio_err, "Passphrase callback error for %s\n",
+                                desc != NULL ? desc : "PKCS12 input");
             goto die;
         }
         if (len < PEM_BUFSIZE)
@@ -430,7 +431,7 @@ static int load_pkcs12(BIO *in, const char *desc,
         if (!PKCS12_verify_mac(p12, tpass, len)) {
             BIO_printf(bio_err,
                        "Mac verify error (wrong password?) in PKCS12 file for %s\n",
-                       desc);
+                       desc != NULL ? desc : "PKCS12 input");
             goto die;
         }
         pass = tpass;
@@ -441,7 +442,7 @@ static int load_pkcs12(BIO *in, const char *desc,
     return ret;
 }
 
-X509 *load_cert(const char *file, int format, const char *cert_descrip)
+X509 *load_cert(const char *file, int format, const char *desc)
 {
     X509 *x = NULL;
     BIO *cert;
@@ -468,22 +469,22 @@ X509 *load_cert(const char *file, int format, const char *cert_descrip)
         x = PEM_read_bio_X509_AUX(cert, NULL,
                                   (pem_password_cb *)password_callback, NULL);
     } else if (format == FORMAT_PKCS12) {
-        if (!load_pkcs12(cert, cert_descrip, NULL, NULL, NULL, &x, NULL))
+        if (!load_pkcs12(cert, desc, NULL, NULL, NULL, &x, NULL))
             goto end;
     } else {
         BIO_printf(bio_err, "bad input format specified for %s\n", cert_descrip);
         goto end;
     }
  end:
-    if (x == NULL) {
-        BIO_printf(bio_err, "unable to load certificate\n");
+    if (x == NULL && desc != NULL) {
+        BIO_printf(bio_err, "unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     BIO_free(cert);
     return x;
 }
 
-X509_CRL *load_crl(const char *infile, int format)
+X509_CRL *load_crl(const char *infile, int format, const char *desc)
 {
     X509_CRL *x = NULL;
     BIO *in = NULL;
@@ -506,19 +507,44 @@ X509_CRL *load_crl(const char *infile, int format)
         BIO_printf(bio_err, "bad input format specified for input crl\n");
         goto end;
     }
-    if (x == NULL) {
-        BIO_printf(bio_err, "unable to load CRL\n");
+
+ end:
+    if (x == NULL && desc != NULL) {
+        BIO_printf(bio_err, "unable to load %s\n", desc);
         ERR_print_errors(bio_err);
         goto end;
     }
-
- end:
     BIO_free(in);
     return x;
 }
 
+X509_REQ *load_csr(const char *file, int format, const char *desc)
+{
+    X509_REQ *req = NULL;
+    BIO *in;
+
+    in = bio_open_default(file, 'r', format);
+    if (in == NULL)
+        goto end;
+
+    if (format == FORMAT_ASN1)
+        req = d2i_X509_REQ_bio(in, NULL);
+    else if (format == FORMAT_PEM)
+        req = PEM_read_bio_X509_REQ(in, NULL, NULL, NULL);
+    else if (desc)
+        BIO_printf(bio_err, "unsupported format for loading %s\n", desc);
+
+ end:
+    if (req == NULL && desc != NULL) {
+        BIO_printf(bio_err, "unable to load %s\n", desc);
+        ERR_print_errors(bio_err);
+    }
+    BIO_free(in);
+    return req;
+}
+
 EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
-                   const char *pass, ENGINE *e, const char *key_descrip)
+                   const char *pass, ENGINE *e, const char *desc)
 {
     BIO *key = NULL;
     EVP_PKEY *pkey = NULL;
@@ -542,8 +568,8 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
                                                &cb_data);
                 ENGINE_finish(e);
             }
-            if (pkey == NULL) {
-                BIO_printf(bio_err, "cannot load %s from engine\n", key_descrip);
+            if (pkey == NULL && desc != NULL) {
+                BIO_printf(bio_err, "cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
 #else
@@ -565,7 +591,8 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
     } else if (format == FORMAT_PEM) {
         pkey = PEM_read_bio_PrivateKey(key, NULL, wrap_password_callback, &cb_data);
     } else if (format == FORMAT_PKCS12) {
-        if (!load_pkcs12(key, key_descrip, wrap_password_callback, &cb_data,
+        if (!load_pkcs12(key, desc,
+                         (pem_password_cb *)password_callback, &cb_data,
                          &pkey, NULL, NULL))
             goto end;
 #if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DSA) && !defined (OPENSSL_NO_RC4)
@@ -580,15 +607,15 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
     }
  end:
     BIO_free(key);
-    if (pkey == NULL) {
-        BIO_printf(bio_err, "unable to load %s\n", key_descrip);
+    if (pkey == NULL && desc != NULL) {
+        BIO_printf(bio_err, "unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     return pkey;
 }
 
 EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
-                      const char *pass, ENGINE *e, const char *key_descrip)
+                      const char *pass, ENGINE *e, const char *desc)
 {
     BIO *key = NULL;
     EVP_PKEY *pkey = NULL;
@@ -608,8 +635,8 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
 #ifndef OPENSSL_NO_ENGINE
             pkey = ENGINE_load_public_key(e, file, (UI_METHOD *)get_ui_method(),
                                           &cb_data);
-            if (pkey == NULL) {
-                BIO_printf(bio_err, "cannot load %s from engine\n", key_descrip);
+            if (pkey == NULL && desc != NULL) {
+                BIO_printf(bio_err, "cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
 #else
@@ -669,8 +696,10 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
     }
  end:
     BIO_free(key);
-    if (pkey == NULL)
-        BIO_printf(bio_err, "unable to load %s\n", key_descrip);
+    if (pkey == NULL && desc != NULL) {
+        BIO_printf(bio_err, "unable to load %s\n", desc);
+        ERR_print_errors(bio_err);
+    }
     return pkey;
 }
 
@@ -749,9 +778,11 @@ static int load_certs_crls(const char *file, int format,
             sk_X509_CRL_pop_free(*pcrls, X509_CRL_free);
             *pcrls = NULL;
         }
-        BIO_printf(bio_err, "unable to load %s\n",
-                   pcerts ? "certificates" : "CRLs");
-        ERR_print_errors(bio_err);
+        if (desc != NULL) {
+            BIO_printf(bio_err, "unable to load %s for %s\n",
+                       pcerts ? "certificates" : "CRLs", desc);
+            ERR_print_errors(bio_err);
+        }
     }
     return rv;
 }
@@ -1889,7 +1920,7 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
         DIST_POINT *dp = sk_DIST_POINT_value(crldp, i);
         urlptr = get_dp_url(dp);
         if (urlptr)
-            return load_crl(urlptr, FORMAT_HTTP);
+            return load_crl(urlptr, FORMAT_HTTP, "CRL via CDP");
     }
     return NULL;
 }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -481,7 +481,7 @@ X509 *load_cert(const char *file, int format, const char *desc)
 
  end:
     if (x == NULL && desc != NULL) {
-        BIO_printf(bio_err, "unable to load %s\n", desc);
+        BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     BIO_free(cert);
@@ -512,7 +512,7 @@ X509_CRL *load_crl(const char *infile, int format, const char *desc)
 
  end:
     if (x == NULL && desc != NULL) {
-        BIO_printf(bio_err, "unable to load %s\n", desc);
+        BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     BIO_free(in);
@@ -537,7 +537,7 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
 
  end:
     if (req == NULL && desc != NULL) {
-        BIO_printf(bio_err, "unable to load %s\n", desc);
+        BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     BIO_free(in);
@@ -555,12 +555,12 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
     cb_data.prompt_info = file;
 
     if (file == NULL && (!maybe_stdin || format == FORMAT_ENGINE)) {
-        BIO_printf(bio_err, "no keyfile specified\n");
+        BIO_printf(bio_err, "No keyfile specified\n");
         goto end;
     }
     if (format == FORMAT_ENGINE) {
         if (e == NULL) {
-            BIO_printf(bio_err, "no engine specified\n");
+            BIO_printf(bio_err, "No engine specified\n");
         } else {
 #ifndef OPENSSL_NO_ENGINE
             if (ENGINE_init(e)) {
@@ -570,11 +570,11 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
                 ENGINE_finish(e);
             }
             if (pkey == NULL && desc != NULL) {
-                BIO_printf(bio_err, "cannot load %s from engine\n", desc);
+                BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
 #else
-            BIO_printf(bio_err, "engines not supported\n");
+            BIO_printf(bio_err, "Engines not supported\n");
 #endif
         }
         goto end;
@@ -616,7 +616,7 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
  end:
     BIO_free(key);
     if (pkey == NULL && desc != NULL) {
-        BIO_printf(bio_err, "unable to load %s\n", desc);
+        BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     return pkey;
@@ -633,22 +633,22 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
     cb_data.prompt_info = file;
 
     if (file == NULL && (!maybe_stdin || format == FORMAT_ENGINE)) {
-        BIO_printf(bio_err, "no keyfile specified\n");
+        BIO_printf(bio_err, "No keyfile specified\n");
         goto end;
     }
     if (format == FORMAT_ENGINE) {
         if (e == NULL) {
-            BIO_printf(bio_err, "no engine specified\n");
+            BIO_printf(bio_err, "No engine specified\n");
         } else {
 #ifndef OPENSSL_NO_ENGINE
             pkey = ENGINE_load_public_key(e, file, (UI_METHOD *)get_ui_method(),
                                           &cb_data);
             if (pkey == NULL && desc != NULL) {
-                BIO_printf(bio_err, "cannot load %s from engine\n", desc);
+                BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
 #else
-            BIO_printf(bio_err, "engines not supported\n");
+            BIO_printf(bio_err, "Engines not supported\n");
 #endif
         }
         goto end;
@@ -711,7 +711,7 @@ EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
  end:
     BIO_free(key);
     if (pkey == NULL && desc != NULL) {
-        BIO_printf(bio_err, "unable to load %s\n", desc);
+        BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     return pkey;
@@ -733,7 +733,7 @@ static int load_certs_crls(const char *file, int format,
     cb_data.prompt_info = file;
 
     if (format != FORMAT_PEM) {
-        BIO_printf(bio_err, "bad input format specified for %s\n", desc);
+        BIO_printf(bio_err, "Bad input format specified for %s\n", desc);
         return 0;
     }
 
@@ -793,7 +793,7 @@ static int load_certs_crls(const char *file, int format,
             *pcrls = NULL;
         }
         if (desc != NULL) {
-            BIO_printf(bio_err, "unable to load %s for %s\n",
+            BIO_printf(bio_err, "Unable to load %s for %s\n",
                        pcerts ? "certificates" : "CRLs", desc);
             ERR_print_errors(bio_err);
         }
@@ -1128,6 +1128,7 @@ X509_STORE *setup_verify(const char *CAfile, int noCAfile,
     ERR_clear_error();
     return store;
  end:
+    ERR_print_errors(bio_err);
     X509_STORE_free(store);
     return NULL;
 }
@@ -1155,13 +1156,13 @@ ENGINE *setup_engine(const char *engine, int debug)
 #ifndef OPENSSL_NO_ENGINE
     if (engine != NULL) {
         if (strcmp(engine, "auto") == 0) {
-            BIO_printf(bio_err, "enabling auto ENGINE support\n");
+            BIO_printf(bio_err, "Enabling auto ENGINE support\n");
             ENGINE_register_all_complete();
             return NULL;
         }
         if ((e = ENGINE_by_id(engine)) == NULL
             && (e = try_load_engine(engine)) == NULL) {
-            BIO_printf(bio_err, "invalid engine \"%s\"\n", engine);
+            BIO_printf(bio_err, "Invalid engine \"%s\"\n", engine);
             ERR_print_errors(bio_err);
             return NULL;
         }
@@ -1171,13 +1172,13 @@ ENGINE *setup_engine(const char *engine, int debug)
         ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0, (void *)get_ui_method(),
                         0, 1);
         if (!ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
-            BIO_printf(bio_err, "can't use that engine\n");
+            BIO_printf(bio_err, "Cannot use engine \"%s\"\n", ENGINE_get_id(e));
             ERR_print_errors(bio_err);
             ENGINE_free(e);
             return NULL;
         }
 
-        BIO_printf(bio_err, "engine \"%s\" set.\n", ENGINE_get_id(e));
+        BIO_printf(bio_err, "Engine \"%s\" set.\n", ENGINE_get_id(e));
     }
 #endif
     return e;
@@ -1256,14 +1257,13 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
             BIO_printf(bio_err, "Out of memory\n");
     } else {
         if (!a2i_ASN1_INTEGER(in, ai, buf, 1024)) {
-            BIO_printf(bio_err, "unable to load number from %s\n",
+            BIO_printf(bio_err, "Unable to load number from %s\n",
                        serialfile);
             goto err;
         }
         ret = ASN1_INTEGER_to_BN(ai, NULL);
         if (ret == NULL) {
-            BIO_printf(bio_err,
-                       "error converting number from bin to BIGNUM\n");
+            BIO_printf(bio_err, "Error converting number from bin to BIGNUM\n");
             goto err;
         }
     }
@@ -1273,6 +1273,7 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         ai = NULL;
     }
  err:
+    ERR_print_errors(bio_err);
     BIO_free(in);
     ASN1_INTEGER_free(ai);
     return ret;
@@ -1292,7 +1293,7 @@ int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial
     else
         j = strlen(serialfile) + strlen(suffix) + 1;
     if (j >= BSIZE) {
-        BIO_printf(bio_err, "file name too long\n");
+        BIO_printf(bio_err, "File name too long\n");
         goto err;
     }
 
@@ -1307,7 +1308,6 @@ int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial
     }
     out = BIO_new_file(buf[0], "w");
     if (out == NULL) {
-        ERR_print_errors(bio_err);
         goto err;
     }
 
@@ -1323,6 +1323,8 @@ int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial
         ai = NULL;
     }
  err:
+    if (!ret)
+        ERR_print_errors(bio_err);
     BIO_free_all(out);
     ASN1_INTEGER_free(ai);
     return ret;
@@ -1339,7 +1341,7 @@ int rotate_serial(const char *serialfile, const char *new_suffix,
     if (i > j)
         j = i;
     if (j + 1 >= BSIZE) {
-        BIO_printf(bio_err, "file name too long\n");
+        BIO_printf(bio_err, "File name too long\n");
         goto err;
     }
 #ifndef OPENSSL_SYS_VMS
@@ -1355,19 +1357,20 @@ int rotate_serial(const char *serialfile, const char *new_suffix,
 #endif
         ) {
         BIO_printf(bio_err,
-                   "unable to rename %s to %s\n", serialfile, buf[1]);
+                   "Unable to rename %s to %s\n", serialfile, buf[1]);
         perror("reason");
         goto err;
     }
     if (rename(buf[0], serialfile) < 0) {
         BIO_printf(bio_err,
-                   "unable to rename %s to %s\n", buf[0], serialfile);
+                   "Unable to rename %s to %s\n", buf[0], serialfile);
         perror("reason");
         rename(buf[1], serialfile);
         goto err;
     }
     return 1;
  err:
+    ERR_print_errors(bio_err);
     return 0;
 }
 
@@ -1408,17 +1411,14 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
 #endif
 
     in = BIO_new_file(dbfile, "r");
-    if (in == NULL) {
-        ERR_print_errors(bio_err);
+    if (in == NULL)
         goto err;
-    }
 
 #ifndef OPENSSL_NO_POSIX_IO
     BIO_get_fp(in, &dbfp);
     if (fstat(fileno(dbfp), &dbst) == -1) {
         ERR_raise_data(ERR_LIB_SYS, errno,
                        "calling fstat(%s)", dbfile);
-        ERR_print_errors(bio_err);
         goto err;
     }
 #endif
@@ -1455,6 +1455,7 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
 #endif
 
  err:
+    ERR_print_errors(bio_err);
     NCONF_free(dbattr_conf);
     TXT_DB_free(tmpdb);
     BIO_free_all(in);
@@ -1470,20 +1471,23 @@ int index_index(CA_DB *db)
                              LHASH_HASH_FN(index_serial),
                              LHASH_COMP_FN(index_serial))) {
         BIO_printf(bio_err,
-                   "error creating serial number index:(%ld,%ld,%ld)\n",
+                   "Error creating serial number index:(%ld,%ld,%ld)\n",
                    db->db->error, db->db->arg1, db->db->arg2);
-        return 0;
+        goto err;
     }
 
     if (db->attributes.unique_subject
         && !TXT_DB_create_index(db->db, DB_name, index_name_qual,
                                 LHASH_HASH_FN(index_name),
                                 LHASH_COMP_FN(index_name))) {
-        BIO_printf(bio_err, "error creating name index:(%ld,%ld,%ld)\n",
+        BIO_printf(bio_err, "Error creating name index:(%ld,%ld,%ld)\n",
                    db->db->error, db->db->arg1, db->db->arg2);
-        return 0;
+        goto err;
     }
     return 1;
+ err:
+    ERR_print_errors(bio_err);
+    return 0;
 }
 
 int save_index(const char *dbfile, const char *suffix, CA_DB *db)
@@ -1494,7 +1498,7 @@ int save_index(const char *dbfile, const char *suffix, CA_DB *db)
 
     j = strlen(dbfile) + strlen(suffix);
     if (j + 6 >= BSIZE) {
-        BIO_printf(bio_err, "file name too long\n");
+        BIO_printf(bio_err, "File name too long\n");
         goto err;
     }
 #ifndef OPENSSL_SYS_VMS
@@ -1509,7 +1513,7 @@ int save_index(const char *dbfile, const char *suffix, CA_DB *db)
     out = BIO_new_file(buf[0], "w");
     if (out == NULL) {
         perror(dbfile);
-        BIO_printf(bio_err, "unable to open '%s'\n", dbfile);
+        BIO_printf(bio_err, "Unable to open '%s'\n", dbfile);
         goto err;
     }
     j = TXT_DB_write(out, db->db);
@@ -1520,7 +1524,7 @@ int save_index(const char *dbfile, const char *suffix, CA_DB *db)
     out = BIO_new_file(buf[1], "w");
     if (out == NULL) {
         perror(buf[2]);
-        BIO_printf(bio_err, "unable to open '%s'\n", buf[2]);
+        BIO_printf(bio_err, "Unable to open '%s'\n", buf[2]);
         goto err;
     }
     BIO_printf(out, "unique_subject = %s\n",
@@ -1529,6 +1533,7 @@ int save_index(const char *dbfile, const char *suffix, CA_DB *db)
 
     return 1;
  err:
+    ERR_print_errors(bio_err);
     return 0;
 }
 
@@ -1543,7 +1548,7 @@ int rotate_index(const char *dbfile, const char *new_suffix,
     if (i > j)
         j = i;
     if (j + 6 >= BSIZE) {
-        BIO_printf(bio_err, "file name too long\n");
+        BIO_printf(bio_err, "File name too long\n");
         goto err;
     }
 #ifndef OPENSSL_SYS_VMS
@@ -1564,12 +1569,12 @@ int rotate_index(const char *dbfile, const char *new_suffix,
         && errno != ENOTDIR
 #endif
         ) {
-        BIO_printf(bio_err, "unable to rename %s to %s\n", dbfile, buf[1]);
+        BIO_printf(bio_err, "Unable to rename %s to %s\n", dbfile, buf[1]);
         perror("reason");
         goto err;
     }
     if (rename(buf[0], dbfile) < 0) {
-        BIO_printf(bio_err, "unable to rename %s to %s\n", buf[0], dbfile);
+        BIO_printf(bio_err, "Unable to rename %s to %s\n", buf[0], dbfile);
         perror("reason");
         rename(buf[1], dbfile);
         goto err;
@@ -1579,14 +1584,14 @@ int rotate_index(const char *dbfile, const char *new_suffix,
         && errno != ENOTDIR
 #endif
         ) {
-        BIO_printf(bio_err, "unable to rename %s to %s\n", buf[4], buf[3]);
+        BIO_printf(bio_err, "Unable to rename %s to %s\n", buf[4], buf[3]);
         perror("reason");
         rename(dbfile, buf[0]);
         rename(buf[1], dbfile);
         goto err;
     }
     if (rename(buf[2], buf[4]) < 0) {
-        BIO_printf(bio_err, "unable to rename %s to %s\n", buf[2], buf[4]);
+        BIO_printf(bio_err, "Unable to rename %s to %s\n", buf[2], buf[4]);
         perror("reason");
         rename(buf[3], buf[4]);
         rename(dbfile, buf[0]);
@@ -1595,6 +1600,7 @@ int rotate_index(const char *dbfile, const char *new_suffix,
     }
     return 1;
  err:
+    ERR_print_errors(bio_err);
     return 0;
 }
 
@@ -1685,7 +1691,7 @@ X509_NAME *parse_name(const char *cp, long chtype, int canmulti)
             }
             if (*cp == '\\' && *++cp == '\0') {
                 BIO_printf(bio_err,
-                           "%s: escape character at end of string\n",
+                           "%s: Escape character at end of string\n",
                            opt_getprog());
                 goto err;
             }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -477,7 +477,6 @@ X509 *load_cert(const char *file, int format, const char *desc)
                                    OPT_FMT_HTTP |
 #endif
                                    OPT_FMT_PEMDER | OPT_FMT_PKCS12);
-        goto end;
     }
 
  end:
@@ -508,16 +507,13 @@ X509_CRL *load_crl(const char *infile, int format, const char *desc)
         x = d2i_X509_CRL_bio(in, NULL);
     } else if (format == FORMAT_PEM) {
         x = PEM_read_bio_X509_CRL(in, NULL, NULL, NULL);
-    } else {
+    } else
         print_format_error(format, OPT_FMT_PEMDER);
-        goto end;
-    }
 
  end:
     if (x == NULL && desc != NULL) {
         BIO_printf(bio_err, "unable to load %s\n", desc);
         ERR_print_errors(bio_err);
-        goto end;
     }
     BIO_free(in);
     return x;
@@ -536,10 +532,8 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
         req = d2i_X509_REQ_bio(in, NULL);
     else if (format == FORMAT_PEM)
         req = PEM_read_bio_X509_REQ(in, NULL, NULL, NULL);
-    else {
+    else
         print_format_error(format, OPT_FMT_PEMDER);
-        goto end;
-    }
 
  end:
     if (req == NULL && desc != NULL) {
@@ -617,8 +611,8 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
                                  | OPT_FMT_ENGINE
 #endif
                            );
-        goto end;
     }
+
  end:
     BIO_free(key);
     if (pkey == NULL && desc != NULL) {

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -282,6 +282,41 @@ int opt_format(const char *s, unsigned long flags, int *result)
     return 1;
 }
 
+/* Return string representing the given format. */
+const char *format2str(int format)
+{
+    switch (format) {
+    default:
+        return "(undefined)";
+    case FORMAT_PEM:
+        return "PEM";
+    case FORMAT_ASN1:
+        return "DER";
+    case FORMAT_TEXT:
+        return "TEXT";
+    case FORMAT_NSS:
+        return "NSS";
+    case FORMAT_SMIME:
+        return "SMIME";
+    case FORMAT_MSBLOB:
+        return "MSBLOB";
+    case FORMAT_ENGINE:
+        return "ENGINE";
+    case FORMAT_HTTP:
+        return "HTTP";
+    case FORMAT_PKCS12:
+        return "P12";
+    case FORMAT_PVK:
+        return "PVK";
+    }
+}
+
+/* Print an error message about unsuitable/unsupported format requested. */
+void print_format_error(int format, unsigned long flags)
+{
+    (void)opt_format_error(format2str(format), flags);
+}
+
 /* Parse a cipher name, put it in *EVP_CIPHER; return 0 on failure, else 1. */
 int opt_cipher(const char *name, const EVP_CIPHER **cipherp)
 {

--- a/apps/req.c
+++ b/apps/req.c
@@ -588,12 +588,9 @@ int req_main(int argc, char **argv)
 
     if (keyfile != NULL) {
         pkey = load_key(keyfile, keyform, 0, passin, e, "Private Key");
-        if (pkey == NULL) {
-            /* load_key() has already printed an appropriate message */
+        if (pkey == NULL)
             goto end;
-        } else {
-            app_RAND_load_conf(req_conf, section);
-        }
+        app_RAND_load_conf(req_conf, section);
     }
 
     if (newreq && (pkey == NULL)) {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1730,12 +1730,9 @@ int s_client_main(int argc, char **argv)
 
     if (crl_file != NULL) {
         X509_CRL *crl;
-        crl = load_crl(crl_file, crl_format);
-        if (crl == NULL) {
-            BIO_puts(bio_err, "Error loading CRL\n");
-            ERR_print_errors(bio_err);
+        crl = load_crl(crl_file, crl_format, "CRL");
+        if (crl == NULL)
             goto end;
-        }
         crls = sk_X509_CRL_new_null();
         if (crls == NULL || !sk_X509_CRL_push(crls, crl)) {
             BIO_puts(bio_err, "Error adding CRL\n");

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1708,18 +1708,14 @@ int s_client_main(int argc, char **argv)
     if (key_file != NULL) {
         key = load_key(key_file, key_format, 0, pass, e,
                        "client certificate private key file");
-        if (key == NULL) {
-            ERR_print_errors(bio_err);
+        if (key == NULL)
             goto end;
-        }
     }
 
     if (cert_file != NULL) {
         cert = load_cert(cert_file, cert_format, "client certificate file");
-        if (cert == NULL) {
-            ERR_print_errors(bio_err);
+        if (cert == NULL)
             goto end;
-        }
     }
 
     if (chain_file != NULL) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1730,18 +1730,14 @@ int s_server_main(int argc, char *argv[])
     if (nocert == 0) {
         s_key = load_key(s_key_file, s_key_format, 0, pass, engine,
                          "server certificate private key file");
-        if (s_key == NULL) {
-            ERR_print_errors(bio_err);
+        if (s_key == NULL)
             goto end;
-        }
 
         s_cert = load_cert(s_cert_file, s_cert_format,
                            "server certificate file");
 
-        if (s_cert == NULL) {
-            ERR_print_errors(bio_err);
+        if (s_cert == NULL)
             goto end;
-        }
         if (s_chain_file != NULL) {
             if (!load_certs(s_chain_file, &s_chain, FORMAT_PEM, NULL,
                             "server certificate chain"))
@@ -1751,18 +1747,14 @@ int s_server_main(int argc, char *argv[])
         if (tlsextcbp.servername != NULL) {
             s_key2 = load_key(s_key_file2, s_key_format, 0, pass, engine,
                               "second server certificate private key file");
-            if (s_key2 == NULL) {
-                ERR_print_errors(bio_err);
+            if (s_key2 == NULL)
                 goto end;
-            }
 
             s_cert2 = load_cert(s_cert_file2, s_cert_format,
                                 "second server certificate file");
 
-            if (s_cert2 == NULL) {
-                ERR_print_errors(bio_err);
+            if (s_cert2 == NULL)
                 goto end;
-            }
         }
     }
 #if !defined(OPENSSL_NO_NEXTPROTONEG)
@@ -1800,10 +1792,8 @@ int s_server_main(int argc, char *argv[])
 
         s_dkey = load_key(s_dkey_file, s_dkey_format,
                           0, dpass, engine, "second certificate private key file");
-        if (s_dkey == NULL) {
-            ERR_print_errors(bio_err);
+        if (s_dkey == NULL)
             goto end;
-        }
 
         s_dcert = load_cert(s_dcert_file, s_dcert_format,
                             "second server certificate file");

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1781,12 +1781,9 @@ int s_server_main(int argc, char *argv[])
 
     if (crl_file != NULL) {
         X509_CRL *crl;
-        crl = load_crl(crl_file, crl_format);
-        if (crl == NULL) {
-            BIO_puts(bio_err, "Error loading CRL\n");
-            ERR_print_errors(bio_err);
+        crl = load_crl(crl_file, crl_format, "CRL");
+        if (crl == NULL)
             goto end;
-        }
         crls = sk_X509_CRL_new_null();
         if (crls == NULL || !sk_X509_CRL_push(crls, crl)) {
             BIO_puts(bio_err, "Error adding CRL\n");

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -568,14 +568,8 @@ int x509_main(int argc, char **argv)
 
     if (reqfile) {
         EVP_PKEY *pkey;
-        BIO *in;
 
-        in = bio_open_default(infile, 'r', informat);
-        if (in == NULL)
-            goto end;
-        req = PEM_read_bio_X509_REQ(in, NULL, NULL, NULL);
-        BIO_free(in);
-
+        req = load_csr(infile, informat, "certificate request input");
         if (req == NULL) {
             ERR_print_errors(bio_err);
             goto end;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -570,10 +570,8 @@ int x509_main(int argc, char **argv)
         EVP_PKEY *pkey;
 
         req = load_csr(infile, informat, "certificate request input");
-        if (req == NULL) {
-            ERR_print_errors(bio_err);
+        if (req == NULL)
             goto end;
-        }
 
         if ((pkey = X509_REQ_get0_pubkey(req)) == NULL) {
             BIO_printf(bio_err, "error unpacking public key\n");

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -36,8 +36,10 @@ B<openssl> B<ca>
 [B<-key> I<arg>]
 [B<-passin> I<arg>]
 [B<-cert> I<file>]
+[B<-certform> B<DER>|<PEM>]
 [B<-selfsign>]
 [B<-in> I<file>]
+[B<-inform> B<DER>|<PEM>]
 [B<-out> I<file>]
 [B<-notext>]
 [B<-outdir> I<dir>]
@@ -104,6 +106,11 @@ B<default_ca> in the B<ca> section).
 An input filename containing a single certificate request to be
 signed by the CA.
 
+=item B<-inform> B<DER>|B<PEM>
+
+The format of the data in CSR input files.
+The default is PEM.
+
 =item B<-ss_cert> I<filename>
 
 A single self-signed certificate to be signed by the CA.
@@ -134,6 +141,11 @@ F<.pem> appended.
 =item B<-cert>
 
 The CA certificate file.
+
+=item B<-certform> B<DER>|B<PEM>
+
+The format of the data in certificate input files.
+The default is PEM.
 
 =item B<-keyfile> I<filename>
 

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -32,12 +32,12 @@ plan tests => 6;
 
      $ENV{OPENSSL_CONFIG} = '-config "'.srctop_file("test", "Uss.cnf").'"';
      skip "failed creating new certificate request", 3
-	 if !ok(run(perlapp(["CA.pl","-newreq"])),
+	 if !ok(run(perlapp(["CA.pl","-newreq",
+                             "-extra-req","-outform DER"])),
 		'creating certificate request');
-
-     $ENV{OPENSSL_CONFIG} = '-rand_serial -config "'.$std_openssl_cnf.'"';
+     $ENV{OPENSSL_CONFIG} = '-rand_serial -inform DER -config "'.$std_openssl_cnf.'"';
      skip "failed to sign certificate request", 2
-	 if !is(yes(cmdstr(perlapp(["CA.pl", "-sign"]))), 0,
+	 if !is(yes(cmdstr(perlapp(["CA.pl", "-sign", "-extra-ca"]))), 0,
 		'signing certificate request');
 
      ok(run(perlapp(["CA.pl", "-verify", "newcert.pem"])),


### PR DESCRIPTION
New helper function `X509_REQ *load_csr(const char *file, int format, const char *desc)` 
in `apps/apps.c` simplifying and generalizing CSR loading in `req.c`, `x509.c`, and `ca.c`.
Moreover, new `-inform` and `-certform` CLI options to ca app now allowing DER input.
Tested with DER (rather than PEM) CSR input format in `80-test_ca.t`.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
