### PR TITLE
Fix a gcc fallthru warning

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -804,6 +804,7 @@ static handshake_status_t handshake_status(peer_status_t last_status,
              */
             return INTERNAL_ERROR;
         }
+        break;
 
     case PEER_RETRY:
         if (previous_status == PEER_RETRY) {


### PR DESCRIPTION
GCC warns here because the previous switch statement has no default label,
so technically the control flow can fall thru into the next block.