### PR TITLE
Fix invalid function type casts in 1.1.0

### DIFF
--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -65,7 +65,7 @@ static int asn1_bio_gets(BIO *h, char *str, int size);
 static long asn1_bio_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int asn1_bio_new(BIO *h);
 static int asn1_bio_free(BIO *data);
-static long asn1_bio_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long asn1_bio_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 
 static int asn1_bio_init(BIO_ASN1_BUF_CTX *ctx, int size);
 static int asn1_bio_flush_ex(BIO *b, BIO_ASN1_BUF_CTX *ctx,
@@ -301,7 +301,7 @@ static int asn1_bio_gets(BIO *b, char *str, int size)
     return BIO_gets(next, str, size);
 }
 
-static long asn1_bio_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long asn1_bio_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     BIO *next = BIO_next(b);
     if (next == NULL)

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -19,7 +19,7 @@ static int buffer_gets(BIO *h, char *str, int size);
 static long buffer_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int buffer_new(BIO *h);
 static int buffer_free(BIO *data);
-static long buffer_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long buffer_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 #define DEFAULT_BUFFER_SIZE     4096
 
 static const BIO_METHOD methods_buffer = {
@@ -388,7 +388,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (0);
 }
 
-static long buffer_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long buffer_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
 

--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -20,7 +20,7 @@ static int linebuffer_gets(BIO *h, char *str, int size);
 static long linebuffer_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int linebuffer_new(BIO *h);
 static int linebuffer_free(BIO *data);
-static long linebuffer_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long linebuffer_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 
 /* A 10k maximum should be enough for most purposes */
 #define DEFAULT_LINEBUFFER_SIZE 1024*10
@@ -292,7 +292,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (0);
 }
 
-static long linebuffer_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long linebuffer_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
 

--- a/crypto/bio/bf_nbio.c
+++ b/crypto/bio/bf_nbio.c
@@ -24,7 +24,7 @@ static int nbiof_gets(BIO *h, char *str, int size);
 static long nbiof_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int nbiof_new(BIO *h);
 static int nbiof_free(BIO *data);
-static long nbiof_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long nbiof_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 typedef struct nbio_test_st {
     /* only set if we sent a 'should retry' error */
     int lrn;
@@ -165,7 +165,7 @@ static long nbiof_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static long nbiof_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long nbiof_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
 

--- a/crypto/bio/bf_null.c
+++ b/crypto/bio/bf_null.c
@@ -23,7 +23,7 @@ static int nullf_gets(BIO *h, char *str, int size);
 static long nullf_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int nullf_new(BIO *h);
 static int nullf_free(BIO *data);
-static long nullf_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long nullf_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 static const BIO_METHOD methods_nullf = {
     BIO_TYPE_NULL_FILTER,
     "NULL filter",
@@ -111,7 +111,7 @@ static long nullf_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static long nullf_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long nullf_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
 

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -350,9 +350,7 @@ long BIO_ctrl(BIO *b, int cmd, long larg, void *parg)
     return (ret);
 }
 
-long BIO_callback_ctrl(BIO *b, int cmd,
-                       void (*fp) (struct bio_st *, int, const char *, int,
-                                   long, long))
+long BIO_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret;
     long (*cb) (BIO *, int, const char *, int, long, long);

--- a/crypto/bio/bio_meth.c
+++ b/crypto/bio/bio_meth.c
@@ -131,14 +131,14 @@ int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *))
     return 1;
 }
 
-long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom)) (BIO *, int, bio_info_cb *)
+long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom)) (BIO *, int, BIO_info_cb *)
 {
     return biom->callback_ctrl;
 }
 
 int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
                                long (*callback_ctrl) (BIO *, int,
-                                                      bio_info_cb *))
+                                                      BIO_info_cb *))
 {
     biom->callback_ctrl = callback_ctrl;
     return 1;

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -32,7 +32,7 @@ typedef struct bio_connect_st {
      * The callback should return 'ret'.  state is for compatibility with the
      * ssl info_callback
      */
-    int (*info_callback) (const BIO *bio, int state, int ret);
+    BIO_info_cb *info_callback;
 } BIO_CONNECT;
 
 static int conn_write(BIO *h, const char *buf, int num);
@@ -41,7 +41,7 @@ static int conn_puts(BIO *h, const char *str);
 static long conn_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int conn_new(BIO *h);
 static int conn_free(BIO *data);
-static long conn_callback_ctrl(BIO *h, int cmd, bio_info_cb *);
+static long conn_callback_ctrl(BIO *h, int cmd, BIO_info_cb *);
 
 static int conn_state(BIO *b, BIO_CONNECT *c);
 static void conn_close_socket(BIO *data);
@@ -71,7 +71,7 @@ static const BIO_METHOD methods_connectp = {
 static int conn_state(BIO *b, BIO_CONNECT *c)
 {
     int ret = -1, i;
-    int (*cb) (const BIO *, int, int) = NULL;
+    BIO_info_cb *cb = NULL;
 
     if (c->info_callback != NULL)
         cb = c->info_callback;
@@ -469,8 +469,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
              * FIXME: the cast of the function seems unlikely to be a good
              * idea
              */
-            (void)BIO_set_info_callback(dbio,
-                                        (bio_info_cb *)data->info_callback);
+            (void)BIO_set_info_callback(dbio, data->info_callback);
         }
         break;
     case BIO_CTRL_SET_CALLBACK:
@@ -486,9 +485,9 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_GET_CALLBACK:
         {
-            int (**fptr) (const BIO *bio, int state, int xret);
+            BIO_info_cb **fptr;
 
-            fptr = (int (**)(const BIO *bio, int state, int xret))ptr;
+            fptr = (BIO_info_cb **)ptr;
             *fptr = data->info_callback;
         }
         break;
@@ -499,7 +498,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static long conn_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long conn_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
     BIO_CONNECT *data;
@@ -509,8 +508,7 @@ static long conn_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     switch (cmd) {
     case BIO_CTRL_SET_CALLBACK:
         {
-            data->info_callback =
-                (int (*)(const struct bio_st *, int, int))fp;
+            data->info_callback = fp;
         }
         break;
     default:

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -292,7 +292,7 @@ static int bio_zlib_free(BIO *bi);
 static int bio_zlib_read(BIO *b, char *out, int outl);
 static int bio_zlib_write(BIO *b, const char *in, int inl);
 static long bio_zlib_ctrl(BIO *b, int cmd, long num, void *ptr);
-static long bio_zlib_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp);
+static long bio_zlib_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
 
 static const BIO_METHOD bio_meth_zlib = {
     BIO_TYPE_COMP,
@@ -604,7 +604,7 @@ static long bio_zlib_ctrl(BIO *b, int cmd, long num, void *ptr)
     return ret;
 }
 
-static long bio_zlib_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long bio_zlib_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     BIO *next = BIO_next(b);
     if (next == NULL)

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -23,7 +23,7 @@ static int b64_puts(BIO *h, const char *str);
 static long b64_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int b64_new(BIO *h);
 static int b64_free(BIO *data);
-static long b64_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long b64_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 #define B64_BLOCK_SIZE  1024
 #define B64_BLOCK_SIZE2 768
 #define B64_NONE        0
@@ -522,7 +522,7 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
     return ret;
 }
 
-static long b64_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long b64_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
     BIO *next = BIO_next(b);

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -25,7 +25,7 @@ static int enc_read(BIO *h, char *buf, int size);
 static long enc_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int enc_new(BIO *h);
 static int enc_free(BIO *data);
-static long enc_callback_ctrl(BIO *h, int cmd, bio_info_cb *fps);
+static long enc_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fps);
 #define ENC_BLOCK_SIZE  (1024*4)
 #define ENC_MIN_CHUNK   (256)
 #define BUF_OFFSET      (ENC_MIN_CHUNK + EVP_MAX_BLOCK_LENGTH)
@@ -387,7 +387,7 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static long enc_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long enc_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
     BIO *next = BIO_next(b);

--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -29,7 +29,7 @@ static int md_gets(BIO *h, char *str, int size);
 static long md_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int md_new(BIO *h);
 static int md_free(BIO *data);
-static long md_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long md_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 
 static const BIO_METHOD methods_md = {
     BIO_TYPE_MD,
@@ -197,7 +197,7 @@ static long md_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static long md_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long md_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
     BIO *next;

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -83,7 +83,7 @@ static int ok_read(BIO *h, char *buf, int size);
 static long ok_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int ok_new(BIO *h);
 static int ok_free(BIO *data);
-static long ok_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long ok_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 
 static __owur int sig_out(BIO *b);
 static __owur int sig_in(BIO *b);
@@ -399,7 +399,7 @@ static long ok_ctrl(BIO *b, int cmd, long num, void *ptr)
     return ret;
 }
 
-static long ok_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long ok_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     long ret = 1;
     BIO *next;

--- a/doc/crypto/BIO_ctrl.pod
+++ b/doc/crypto/BIO_ctrl.pod
@@ -5,17 +5,17 @@
 BIO_ctrl, BIO_callback_ctrl, BIO_ptr_ctrl, BIO_int_ctrl, BIO_reset,
 BIO_seek, BIO_tell, BIO_flush, BIO_eof, BIO_set_close, BIO_get_close,
 BIO_pending, BIO_wpending, BIO_ctrl_pending, BIO_ctrl_wpending,
-BIO_get_info_callback, BIO_set_info_callback, bio_info_cb
+BIO_get_info_callback, BIO_set_info_callback, BIO_info_cb
 - BIO control operations
 
 =head1 SYNOPSIS
 
  #include <openssl/bio.h>
 
- typedef void bio_info_cb(BIO *b, int oper, const char *ptr, int arg1, long arg2, long arg3);
+ typedef int BIO_info_cb(BIO *b, int state, int res);
 
  long BIO_ctrl(BIO *bp, int cmd, long larg, void *parg);
- long BIO_callback_ctrl(BIO *b, int cmd, bio_info_cb *cb);
+ long BIO_callback_ctrl(BIO *b, int cmd, BIO_info_cb *cb);
  char *BIO_ptr_ctrl(BIO *bp, int cmd, long larg);
  long BIO_int_ctrl(BIO *bp, int cmd, long larg, int iarg);
 
@@ -31,8 +31,8 @@ BIO_get_info_callback, BIO_set_info_callback, bio_info_cb
  size_t BIO_ctrl_pending(BIO *b);
  size_t BIO_ctrl_wpending(BIO *b);
 
- int BIO_get_info_callback(BIO *b, bio_info_cb **cbp);
- int BIO_set_info_callback(BIO *b, bio_info_cb *cb);
+ int BIO_get_info_callback(BIO *b, BIO_info_cb **cbp);
+ int BIO_set_info_callback(BIO *b, BIO_info_cb *cb);
 
 =head1 DESCRIPTION
 

--- a/doc/crypto/BIO_meth_new.pod
+++ b/doc/crypto/BIO_meth_new.pod
@@ -37,10 +37,10 @@ BIO_meth_set_callback_ctrl - Routines to build up BIO methods
  int (*BIO_meth_get_destroy(BIO_METHOD *biom)) (BIO *);
  int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *));
  long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom))
-                                  (BIO *, int, bio_info_cb *);
+                                  (BIO *, int, BIO_info_cb *);
  int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
                                 long (*callback_ctrl) (BIO *, int,
-                                                      bio_info_cb *));
+                                                      BIO_info_cb *));
 
 =head1 DESCRIPTION
 

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -19,7 +19,7 @@ struct bio_method_st {
     long (*ctrl) (BIO *, int, long, void *);
     int (*create) (BIO *);
     int (*destroy) (BIO *);
-    long (*callback_ctrl) (BIO *, int, bio_info_cb *);
+    long (*callback_ctrl) (BIO *, int, BIO_info_cb *);
 };
 
 void bio_free_ex_data(BIO *bio);

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -246,7 +246,8 @@ typedef struct bio_method_st BIO_METHOD;
 const char *BIO_method_name(const BIO *b);
 int BIO_method_type(const BIO *b);
 
-typedef void bio_info_cb(BIO *, int, const char *, int, long, long);
+typedef int BIO_info_cb(BIO *, int, int);
+typedef BIO_info_cb bio_info_cb;  /* backward compatibility */
 
 DEFINE_STACK_OF(BIO)
 
@@ -547,8 +548,7 @@ int BIO_write(BIO *b, const void *data, int len);
 int BIO_puts(BIO *bp, const char *buf);
 int BIO_indent(BIO *b, int indent, int max);
 long BIO_ctrl(BIO *bp, int cmd, long larg, void *parg);
-long BIO_callback_ctrl(BIO *b, int cmd,
-                       void (*fp) (BIO *, int, const char *, int, long, long));
+long BIO_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
 void *BIO_ptr_ctrl(BIO *bp, int cmd, long larg);
 long BIO_int_ctrl(BIO *bp, int cmd, long larg, int iarg);
 BIO *BIO_push(BIO *b, BIO *append);
@@ -750,10 +750,10 @@ int BIO_meth_set_create(BIO_METHOD *biom, int (*create) (BIO *));
 int (*BIO_meth_get_destroy(BIO_METHOD *biom)) (BIO *);
 int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *));
 long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom))
-                                 (BIO *, int, bio_info_cb *);
+                                 (BIO *, int, BIO_info_cb *);
 int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
                                long (*callback_ctrl) (BIO *, int,
-                                                      bio_info_cb *));
+                                                      BIO_info_cb *));
 
 /* BEGIN ERROR CODES */
 /*

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -22,7 +22,7 @@ static int ssl_puts(BIO *h, const char *str);
 static long ssl_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int ssl_new(BIO *h);
 static int ssl_free(BIO *data);
-static long ssl_callback_ctrl(BIO *h, int cmd, bio_info_cb *fp);
+static long ssl_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 typedef struct bio_ssl_st {
     SSL *ssl;                   /* The ssl handle :-) */
     /* re-negotiate every time the total number of bytes is this size */
@@ -394,14 +394,6 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
 #endif
         }
         break;
-    case BIO_CTRL_GET_CALLBACK:
-        {
-            void (**fptr) (const SSL *xssl, int type, int val);
-
-            fptr = (void (**)(const SSL *xssl, int type, int val))ptr;
-            *fptr = SSL_get_info_callback(ssl);
-        }
-        break;
     default:
         ret = BIO_ctrl(ssl->rbio, cmd, num, ptr);
         break;
@@ -409,7 +401,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
     return (ret);
 }
 
-static long ssl_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+static long ssl_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
     SSL *ssl;
     BIO_SSL *bs;
@@ -419,16 +411,10 @@ static long ssl_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
     ssl = bs->ssl;
     switch (cmd) {
     case BIO_CTRL_SET_CALLBACK:
-        {
-            /*
-             * FIXME: setting this via a completely different prototype seems
-             * like a crap idea
-             */
-            SSL_set_info_callback(ssl, (void (*)(const SSL *, int, int))fp);
-        }
+        ret = BIO_callback_ctrl(ssl->rbio, cmd, fp);
         break;
     default:
-        ret = BIO_callback_ctrl(ssl->rbio, cmd, fp);
+        ret = 0;
         break;
     }
     return (ret);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -2736,6 +2736,20 @@ void ssl_sort_cipher_list(void)
           cipher_compare);
 }
 
+static int ssl_undefined_function_1(SSL *ssl, unsigned char *r, size_t s,
+                                    const char * t, size_t u,
+                                    const unsigned char * v, size_t w, int x)
+{
+    (void)r;
+    (void)s;
+    (void)t;
+    (void)u;
+    (void)v;
+    (void)w;
+    (void)x;
+    return ssl_undefined_function(ssl);
+}
+
 const SSL3_ENC_METHOD SSLv3_enc_data = {
     ssl3_enc,
     n_ssl3_mac,
@@ -2747,9 +2761,7 @@ const SSL3_ENC_METHOD SSLv3_enc_data = {
     SSL3_MD_CLIENT_FINISHED_CONST, 4,
     SSL3_MD_SERVER_FINISHED_CONST, 4,
     ssl3_alert_code,
-    (int (*)(SSL *, unsigned char *, size_t, const char *,
-             size_t, const unsigned char *, size_t,
-             int use_context))ssl_undefined_function,
+    ssl_undefined_function_1,
     0,
     SSL3_HM_HEADER_LENGTH,
     ssl3_set_handshake_header,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -54,28 +54,82 @@
 
 const char SSL_version_str[] = OPENSSL_VERSION_TEXT;
 
+static int ssl_undefined_function_1(SSL *ssl, SSL3_RECORD *r, unsigned int s,
+                                    int t)
+{
+    (void)r;
+    (void)s;
+    (void)t;
+    return ssl_undefined_function(ssl);
+}
+
+static int ssl_undefined_function_2(SSL *ssl, SSL3_RECORD *r, unsigned char *s,
+                                    int t)
+{
+    (void)r;
+    (void)s;
+    (void)t;
+    return ssl_undefined_function(ssl);
+}
+
+static int ssl_undefined_function_3(SSL *ssl, unsigned char *r,
+                                    unsigned char *s, int t)
+{
+    (void)r;
+    (void)s;
+    (void)t;
+    return ssl_undefined_function(ssl);
+}
+
+static int ssl_undefined_function_4(SSL *ssl, int r)
+{
+    (void)r;
+    return ssl_undefined_function(ssl);
+}
+
+static int ssl_undefined_function_5(SSL *ssl, const char *r, int s,
+                                    unsigned char *t)
+{
+    (void)r;
+    (void)s;
+    (void)t;
+    return ssl_undefined_function(ssl);
+}
+
+static int ssl_undefined_function_6(int r)
+{
+    (void)r;
+    return ssl_undefined_function(NULL);
+}
+
+static int ssl_undefined_function_7(SSL *ssl, unsigned char *r, size_t s,
+                                    const char *t, size_t u,
+                                    const unsigned char *v, size_t w, int x)
+{
+    (void)r;
+    (void)s;
+    (void)t;
+    (void)u;
+    (void)v;
+    (void)w;
+    (void)x;
+    return ssl_undefined_function(ssl);
+}
+
 SSL3_ENC_METHOD ssl3_undef_enc_method = {
-    /*
-     * evil casts, but these functions are only called if there's a library
-     * bug
-     */
-    (int (*)(SSL *, SSL3_RECORD *, unsigned int, int))ssl_undefined_function,
-    (int (*)(SSL *, SSL3_RECORD *, unsigned char *, int))ssl_undefined_function,
+    ssl_undefined_function_1,
+    ssl_undefined_function_2,
     ssl_undefined_function,
-    (int (*)(SSL *, unsigned char *, unsigned char *, int))
-        ssl_undefined_function,
-    (int (*)(SSL *, int))ssl_undefined_function,
-    (int (*)(SSL *, const char *, int, unsigned char *))
-        ssl_undefined_function,
+    ssl_undefined_function_3,
+    ssl_undefined_function_4,
+    ssl_undefined_function_5,
     0,                          /* finish_mac_length */
     NULL,                       /* client_finished_label */
     0,                          /* client_finished_label_len */
     NULL,                       /* server_finished_label */
     0,                          /* server_finished_label_len */
-    (int (*)(int))ssl_undefined_function,
-    (int (*)(SSL *, unsigned char *, size_t, const char *,
-             size_t, const unsigned char *, size_t,
-             int use_context))ssl_undefined_function,
+    ssl_undefined_function_6,
+    ssl_undefined_function_7,
 };
 
 struct ssl_async_args {

--- a/util/indent.pro
+++ b/util/indent.pro
@@ -512,6 +512,7 @@
 -T asn1_ps_func
 -T bio_dgram_data
 -T bio_info_cb
+-T BIO_info_cb
 -T BIO_callback_fn
 -T char_io
 -T conf_finish_func


### PR DESCRIPTION
This is the back-port of #4493 to 1.1.0