### PR TITLE
Generate exporter_master_secret after server Finished

### DIFF
--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -937,3 +937,12 @@ int ossl_statem_app_data_allowed(SSL *s)
 
     return 0;
 }
+
+/*
+ * This function returns 1 if TLS exporter is ready to export keying
+ * material, or 0 if otherwise.
+ */
+int ossl_statem_export_allowed(SSL *s) {
+    return s->s3->previous_server_finished_len != 0 &&
+           s->statem.hand_state != TLS_ST_SW_FINISHED;
+}

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -132,6 +132,7 @@ __owur int ossl_statem_skip_early_data(SSL *s);
 void ossl_statem_check_finish_init(SSL *s, int send);
 void ossl_statem_set_hello_verify_done(SSL *s);
 __owur int ossl_statem_app_data_allowed(SSL *s);
+__owur int ossl_statem_export_allowed(SSL *s);
 
 /* Flush the write BIO */
 int statem_flush(SSL *s);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -666,7 +666,7 @@ int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
     unsigned int hashsize, datalen;
     int ret = 0;
 
-    if (ctx == NULL)
+    if (ctx == NULL || !ossl_statem_export_allowed(s))
         goto err;
 
     if (!use_context)

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -562,16 +562,6 @@ int tls13_change_cipher_state(SSL *s, int which)
             goto err;
         }
         s->session->master_key_length = hashlen;
-
-        /* Now we create the exporter master secret */
-        if (!tls13_hkdf_expand(s, ssl_handshake_md(s), insecret,
-                               exporter_master_secret,
-                               sizeof(exporter_master_secret) - 1,
-                               hash, hashlen, s->exporter_master_secret,
-                               hashlen)) {
-            /* SSLfatal() already called */
-            goto err;
-        }
     }
 
     if (!derive_secret_key_and_iv(s, which & SSL3_CC_WRITE, md, cipher,

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -212,6 +212,11 @@ void ossl_statem_fatal(SSL *s, int al, int func, int reason, const char *file,
 {
 }
 
+int ossl_statem_export_allowed(SSL *s)
+{
+    return 1;
+}
+
 /* End of mocked out code */
 
 static int test_secret(SSL *s, unsigned char *prk,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes #4925 

I'd like to start the discussion to make exporter_master_secret available after server Finished because it is required for QUIC development.
In this PR, I moved the creation of exporter_master_secret from client_application_traffic to server_application_traffic.  It works for me, but I have no idea it is really a correct fix.

In tls13_export_keying_material, I just removed `!SSL_is_init_finished(s)`, but it may be too loose.
I think I should add another condition to prevent misuse, but I have not come up a good one.
 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
