### PR TITLE
Retore the use of LDCMD when linking applications

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1053,7 +1053,7 @@ EOF
       return <<"EOF";
 $bin$exeext: $objs $deps
 	rm -f $bin$exeext
-	$cmd $cmdflags \$(LDFLAGS) \$(BIN_LDFLAGS) -o $bin$exeext $objs \\
+	\$\${LDCMD:-$cmd} $cmdflags \$(LDFLAGS) \$(BIN_LDFLAGS) -o $bin$exeext $objs \\
 		\$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
 EOF
   }


### PR DESCRIPTION
It is a hack, but it existed in the recently removed Makefile.shared,
and its use is documented in fuzz/README.md, so we cannot drop it now.

Fixes https://github.com/google/oss-fuzz/issues/1037
