### PR TITLE
X509_cmp_time: only return 1, 0, -1.

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1865,10 +1865,11 @@ int X509_cmp_time(const ASN1_TIME *ctm, time_t *cmp_time)
             return 1;
     }
     i = strcmp(buff1, buff2);
-    if (i == 0)                 /* wait a second then return younger :-) */
-        return -1;
-    else
-        return i;
+    /*
+     * X509_cmp_time comparison is <=.
+     * The return value 0 is reserved for errors.
+     */
+    return i > 0 ? 1 : -1;
 }
 
 ASN1_TIME *X509_gmtime_adj(ASN1_TIME *s, long adj)


### PR DESCRIPTION
    X509_cmp_time: only return 1, 0, -1.
    
    The behaviour of X509_cmp_time used to be undocumented.
    
    The new behaviour, documented in master, is to return only 0, 1, or -1.
    Make the code in the other branches adhere to this behaviour too,
    to reduce confusion. There is nothing to be gained from returning
    other values.
    
    Fixes GH#4954

For 1.1.0 and 1.0.2