### PR TITLE
crypto/engine/eng_list.c: compare getenv rv to NULL instead of 0

### DIFF
--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -317,7 +317,7 @@ ENGINE *ENGINE_by_id(const char *id)
      * Prevent infinite recursion if we're looking for the dynamic engine.
      */
     if (strcmp(id, "dynamic")) {
-        if ((load_dir = getenv("OPENSSL_ENGINES")) == 0)
+        if ((load_dir = getenv("OPENSSL_ENGINES")) == NULL)
             load_dir = ENGINESDIR;
         iterator = ENGINE_by_id("dynamic");
         if (!iterator || !ENGINE_ctrl_cmd_string(iterator, "ID", id, 0) ||


### PR DESCRIPTION
i know its okay by the standard. Just for consistency ..
