### PR TITLE
Fix printf format specifier compiler warnings

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -563,8 +564,8 @@ int enc_main(int argc, char **argv)
 
     ret = 0;
     if (verbose) {
-        BIO_printf(bio_err, "bytes read   : %8ju\n", BIO_number_read(in));
-        BIO_printf(bio_err, "bytes written: %8ju\n", BIO_number_written(out));
+        BIO_printf(bio_err, "bytes read   : %8" PRIu64 "\n", BIO_number_read(in));
+        BIO_printf(bio_err, "bytes written: %8" PRIu64 "\n", BIO_number_written(out));
     }
  end:
     ERR_print_errors(bio_err);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -10,6 +10,7 @@
 
 #include "e_os.h"
 #include <ctype.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -3160,8 +3161,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 #endif
 
         BIO_printf(bio,
-                   "---\nSSL handshake has read %ju bytes "
-                   "and written %ju bytes\n",
+                   "---\nSSL handshake has read %" PRIu64 " bytes "
+                   "and written %" PRIu64" bytes\n",
                    BIO_number_read(SSL_get_rbio(s)),
                    BIO_number_written(SSL_get_wbio(s)));
     }

--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include "internal/numbers.h"
@@ -102,8 +103,8 @@ static int uint64_print(BIO *out, ASN1_VALUE **pval, const ASN1_ITEM *it,
                         int indent, const ASN1_PCTX *pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
-        return BIO_printf(out, "%jd\n", **(int64_t **)pval);
-    return BIO_printf(out, "%ju\n", **(uint64_t **)pval);
+        return BIO_printf(out, "%" PRId64 "d\n", **(int64_t **)pval);
+    return BIO_printf(out, "%" PRIu64 "\n", **(uint64_t **)pval);
 }
 
 /* 32-bit variants */

--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "internal/nelem.h"
 #include "internal/constant_time_locl.h"
@@ -66,11 +67,11 @@ static int test_binary_op_64(uint64_t (*op)(uint64_t a, uint64_t b),
 
     if (is_true && c != CONSTTIME_TRUE_64) {
         TEST_error("TRUE %s op failed", op_name);
-        BIO_printf(bio_err, "a=%jx b=%jx\n", a, b);
+        BIO_printf(bio_err, "a=%" PRIu64 "b=%" PRIu64 "\n", a, b);
         return 0;
     } else if (!is_true && c != CONSTTIME_FALSE_64) {
         TEST_error("FALSE %s op failed", op_name);
-        BIO_printf(bio_err, "a=%jx b=%jx\n", a, b);
+        BIO_printf(bio_err, "a=%" PRIu64 "b=%" PRIu64 "\n", a, b);
         return 0;
     }
     return 1;
@@ -137,12 +138,14 @@ static int test_select_64(uint64_t a, uint64_t b)
 
     if (selected != a) {
         TEST_error("test_select_64 TRUE failed");
-        BIO_printf(bio_err, "a=%jx b=%jx got %jx wanted a\n", a, b, selected);
+        BIO_printf(bio_err, "a=%" PRIu64 "b=%" PRIu64 " got %" PRIu64
+                   " wanted a\n", a, b, selected);
         return 0;
     }
     selected = constant_time_select_64(CONSTTIME_FALSE_64, a, b);
     if (selected != b) {
-        BIO_printf(bio_err, "a=%jx b=%jx got %jx wanted b\n", a, b, selected);
+        BIO_printf(bio_err, "a=%" PRIu64 "b=%" PRIu64 " got %" PRIu64
+                   " wanted b\n", a, b, selected);
         return 0;
     }
     return 1;


### PR DESCRIPTION
Currently there are a few compiler warnings regarding the printf format
specifiers, for example:
```console
test/constant_time_test.c:69:46:
warning: format specifies type 'uintmax_t' (aka 'unsigned long') but the
      argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
        BIO_printf(bio_err, "a=%jx b=%jx\n", a, b);
                               ~~~           ^
                               %llx
```
This commit attempts to fix these warnings using the macros specified in
inttypes.h.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
