### PR TITLE
Test the result of CMS_RecipientInfo_ktri_get0_algs() before using its output in rsa_cms_encrypt()

### DIFF
--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -773,7 +773,8 @@ static int rsa_cms_encrypt(CMS_RecipientInfo *ri)
     EVP_PKEY_CTX *pkctx = CMS_RecipientInfo_get0_pkey_ctx(ri);
     int pad_mode = RSA_PKCS1_PADDING, rv = 0, labellen;
     unsigned char *label;
-    CMS_RecipientInfo_ktri_get0_algs(ri, NULL, NULL, &alg);
+    if (CMS_RecipientInfo_ktri_get0_algs(ri, NULL, NULL, &alg) <= 0)
+        return 0;
     if (pkctx) {
         if (EVP_PKEY_CTX_get_rsa_padding(pkctx, &pad_mode) <= 0)
             return 0;


### PR DESCRIPTION
One compiler raised a warning about an uninitialized `alg` variable being used in OpenSSL 1.1.0g.  A quick look at the code seemed to confirm that if the `CMS_RecipientInfo_ktri_get0_algs()` call in `rsa_cms_encrypt()` fails, it did indeed leave `alg` uninitialized and then tries to use it, at least sometimes.

Attached is a possible trivial fix that just fails the overall operation if that call fails.  I noticed that the implementation on master is slightly different, but still appears to have the same issue.