### PR TITLE
WIP: Add -subjectaltname flag to "openssl req"

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -159,7 +159,7 @@ static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *
  * Add a subjectAltName extension to the given certificate, with the provided
  * value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
  */
-static int x509_add_subjectaltname(CONF *req_conf, X509V3_CTX *ctx, const char *value, X509 *cert)
+static int x509_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509 *cert)
 {
   X509_EXTENSION *ext;
   ext = X509V3_EXT_nconf_nid(req_conf, ctx, NID_subject_alt_name, value);
@@ -680,7 +680,7 @@ int req_main(int argc, char **argv)
                 goto end;
             }
 
-            if (x509_add_subjectaltname(req_conf, &ext_ctx, subjectaltname, x509ss) != 1) {
+            if (x509_add_subjectaltname(&ext_ctx, subjectaltname, x509ss) != 1) {
                 BIO_printf(bio_err, "Error adding subjectaltname %s\n", subjectaltname);
                 goto end;
             }

--- a/apps/req.c
+++ b/apps/req.c
@@ -143,7 +143,7 @@ const OPTIONS req_options[] = {
  * Add a subjectAltName extension to the given X509_REQ, with the provided
  * value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
  */
-static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *req)
+static int req_add_subjectaltname(X509V3_CTX *ctx, X509_REQ *req, const char *value)
 {
   STACK_OF(X509_EXTENSION) *extlist = sk_X509_EXTENSION_new_null();
   X509_EXTENSION *ext;
@@ -159,14 +159,14 @@ static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *
  * Add a subjectAltName extension to the given certificate, with the provided
  * value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
  */
-static int x509_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509 *cert)
+static int x509_add_subjectaltname(X509V3_CTX *ctx, X509 *cert, const char *value)
 {
   X509_EXTENSION *ext;
   ext = X509V3_EXT_nconf_nid(req_conf, ctx, NID_subject_alt_name, value);
   if (ext == NULL) {
     return 0;
   }
-  X509_add_ext(&cert, ext, -1);
+  X509_add_ext(cert, ext, -1);
   X509_EXTENSION_free(ext);
   return 1;
 }
@@ -680,7 +680,7 @@ int req_main(int argc, char **argv)
                 goto end;
             }
 
-            if (x509_add_subjectaltname(&ext_ctx, subjectaltname, x509ss) != 1) {
+            if (x509_add_subjectaltname(&ext_ctx, x509ss, subjectaltname) != 1) {
                 BIO_printf(bio_err, "Error adding subjectaltname %s\n", subjectaltname);
                 goto end;
             }
@@ -716,7 +716,7 @@ int req_main(int argc, char **argv)
                 goto end;
             }
 
-            if (req_add_subjectaltname(&ext_ctx, subjectaltname, req) != 1) {
+            if (req_add_subjectaltname(&ext_ctx, req, subjectaltname) != 1) {
                 BIO_printf(bio_err, "Error adding subjectaltname %s\n", subjectaltname);
                 goto end;
             }

--- a/apps/req.c
+++ b/apps/req.c
@@ -19,7 +19,6 @@
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
-#include "../crypto/include/internal/x509_int.h"
 #include <openssl/objects.h>
 #include <openssl/pem.h>
 #include <openssl/bn.h>
@@ -140,9 +139,12 @@ const OPTIONS req_options[] = {
     {NULL}
 };
 
-// Add a subjectAltName extension to the given X509_REQ, with the provided
-// value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
-static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *req) {
+/*
+ * Add a subjectAltName extension to the given X509_REQ, with the provided
+ * value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
+ */
+static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *req)
+{
   STACK_OF(X509_EXTENSION) *extlist = sk_X509_EXTENSION_new_null();
   X509_EXTENSION *ext;
   ext = X509V3_EXT_nconf_nid(req_conf, ctx, NID_subject_alt_name, value);
@@ -153,15 +155,18 @@ static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *
   return X509_REQ_add_extensions(req, extlist);
 }
 
-// Add a subjectAltName extension to the given certificate, with the provided
-// value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
-static int x509_add_subjectaltname(CONF *req_conf, X509V3_CTX *ctx, const char *value, X509 *cert) {
+/*
+ * Add a subjectAltName extension to the given certificate, with the provided
+ * value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
+ */
+static int x509_add_subjectaltname(CONF *req_conf, X509V3_CTX *ctx, const char *value, X509 *cert)
+{
   X509_EXTENSION *ext;
   ext = X509V3_EXT_nconf_nid(req_conf, ctx, NID_subject_alt_name, value);
   if (ext == NULL) {
     return 0;
   }
-  X509v3_add_ext(&cert->cert_info.extensions, ext, -1);
+  X509_add_ext(&cert, ext, -1);
   X509_EXTENSION_free(ext);
   return 1;
 }

--- a/apps/req.c
+++ b/apps/req.c
@@ -19,6 +19,7 @@
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include "../crypto/include/internal/x509_int.h"
 #include <openssl/objects.h>
 #include <openssl/pem.h>
 #include <openssl/bn.h>
@@ -81,7 +82,7 @@ typedef enum OPTION_choice {
     OPT_VERIFY, OPT_NODES, OPT_NOOUT, OPT_VERBOSE, OPT_UTF8,
     OPT_NAMEOPT, OPT_REQOPT, OPT_SUBJ, OPT_SUBJECT, OPT_TEXT, OPT_X509,
     OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_EXTENSIONS,
-    OPT_REQEXTS, OPT_PRECERT, OPT_MD,
+    OPT_REQEXTS, OPT_PRECERT, OPT_MD, OPT_SUBJECTALTNAME,
     OPT_R_ENUM
 } OPTION_CHOICE;
 
@@ -119,6 +120,7 @@ const OPTIONS req_options[] = {
      "Output a x509 structure instead of a cert request"},
     {OPT_MORE_STR, 1, 1, "(Required by some CA's)"},
     {"subj", OPT_SUBJ, 's', "Set or modify request subject"},
+    {"subjectaltname", OPT_SUBJECTALTNAME, 's', "Set subjectAltName in request or cert"},
     {"subject", OPT_SUBJECT, '-', "Output the request's subject"},
     {"multivalue-rdn", OPT_MULTIVALUE_RDN, '-',
      "Enable support for multivalued RDNs"},
@@ -138,6 +140,32 @@ const OPTIONS req_options[] = {
     {NULL}
 };
 
+// Add a subjectAltName extension to the given X509_REQ, with the provided
+// value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
+static int req_add_subjectaltname(X509V3_CTX *ctx, const char *value, X509_REQ *req) {
+  STACK_OF(X509_EXTENSION) *extlist = sk_X509_EXTENSION_new_null();
+  X509_EXTENSION *ext;
+  ext = X509V3_EXT_nconf_nid(req_conf, ctx, NID_subject_alt_name, value);
+  if (ext == NULL) {
+    return 0;
+  }
+  sk_X509_EXTENSION_push(extlist, ext);
+  return X509_REQ_add_extensions(req, extlist);
+}
+
+// Add a subjectAltName extension to the given certificate, with the provided
+// value, e.g. "DNS:example.com". Returns 1 on success, 0 on failure.
+static int x509_add_subjectaltname(CONF *req_conf, X509V3_CTX *ctx, const char *value, X509 *cert) {
+  X509_EXTENSION *ext;
+  ext = X509V3_EXT_nconf_nid(req_conf, ctx, NID_subject_alt_name, value);
+  if (ext == NULL) {
+    return 0;
+  }
+  X509v3_add_ext(&cert->cert_info.extensions, ext, -1);
+  X509_EXTENSION_free(ext);
+  return 1;
+}
+
 int req_main(int argc, char **argv)
 {
     ASN1_INTEGER *serial = NULL;
@@ -155,7 +183,7 @@ int req_main(int argc, char **argv)
     char *keyalgstr = NULL, *p, *prog, *passargin = NULL, *passargout = NULL;
     char *passin = NULL, *passout = NULL;
     char *nofree_passin = NULL, *nofree_passout = NULL;
-    char *req_exts = NULL, *subj = NULL;
+    char *req_exts = NULL, *subj = NULL, *subjectaltname = NULL;
     char *template = default_config_file, *keyout = NULL;
     const char *keyalg = NULL;
     OPTION_CHOICE o;
@@ -309,6 +337,9 @@ int req_main(int argc, char **argv)
             break;
         case OPT_SUBJ:
             subj = opt_arg();
+            break;
+        case OPT_SUBJECTALTNAME:
+            subjectaltname = opt_arg();
             break;
         case OPT_MULTIVALUE_RDN:
             multirdn = 1;
@@ -644,6 +675,11 @@ int req_main(int argc, char **argv)
                 goto end;
             }
 
+            if (x509_add_subjectaltname(req_conf, &ext_ctx, subjectaltname, x509ss) != 1) {
+                BIO_printf(bio_err, "Error adding subjectaltname %s\n", subjectaltname);
+                goto end;
+            }
+
             /* If a pre-cert was requested, we need to add a poison extension */
             if (precert) {
                 if (X509_add1_ext_i2d(x509ss, NID_ct_precert_poison, NULL, 1, 0)
@@ -658,7 +694,7 @@ int req_main(int argc, char **argv)
                 ERR_print_errors(bio_err);
                 goto end;
             }
-        } else {
+        } else { // !x509
             X509V3_CTX ext_ctx;
 
             /* Set up V3 context struct */
@@ -674,6 +710,12 @@ int req_main(int argc, char **argv)
                            req_exts);
                 goto end;
             }
+
+            if (req_add_subjectaltname(&ext_ctx, subjectaltname, req) != 1) {
+                BIO_printf(bio_err, "Error adding subjectaltname %s\n", subjectaltname);
+                goto end;
+            }
+
             i = do_X509_REQ_sign(req, pkey, digest, sigopts);
             if (!i) {
                 ERR_print_errors(bio_err);


### PR DESCRIPTION
Fixes #3311

This works for both generating CSRs and self-signed certificates. It's
particularly useful for self-signed certificates intended to be trusted locally,
because recent browsers will not validation hostnames against the certificate
subject.

Note: This is a draft, seeking feedback. In particular, in order to reference fields
in `struct x509st`, I had to include `../crypto/include/internal/x509_int.h`. Looking
at related code in the apps/ directory, my guess is that it is intended to not use
internal interfaces of OpenSSL. I think in order to make this change work, I will
need to add a public interface `X509_add_extensions` (by analogy with
`X509_REQ_add_extensions`). Does this approach make sense? Should I be
doing it a different way? Thanks!