### PR TITLE
Clarify error for unrecognized app arguments.

### DIFF
--- a/apps/opt.c
+++ b/apps/opt.c
@@ -278,7 +278,7 @@ int opt_cipher(const char *name, const EVP_CIPHER **cipherp)
     *cipherp = EVP_get_cipherbyname(name);
     if (*cipherp != NULL)
         return 1;
-    BIO_printf(bio_err, "%s: Unknown cipher %s\n", prog, name);
+    BIO_printf(bio_err, "%s: Unrecognized flag %s\n", prog, name);
     return 0;
 }
 
@@ -290,7 +290,7 @@ int opt_md(const char *name, const EVP_MD **mdp)
     *mdp = EVP_get_digestbyname(name);
     if (*mdp != NULL)
         return 1;
-    BIO_printf(bio_err, "%s: Unknown digest %s\n", prog, name);
+    BIO_printf(bio_err, "%s: Unrecognized flag %s\n", prog, name);
     return 0;
 }
 


### PR DESCRIPTION
Many of the sub-commands under apps/ accept cipher or digest arguments like
"-sha256". These are implemented using a catchall flag that runs the result
through opt_md() or opt_cipher(). That means any unrecognized flag, including
typos, gets sent to those two functions, producing confusing error messages like
below:

    $ ./apps/openssl req -x590
    req: Unrecognized digest x590
    req: Use -help for summary.

This change switches these two functions to say "Unrecognized flag X" instead.
The new message deliberately leaves off the "-" from the flag name, because
there are some cases where opt_md() and opt_cipher() are passed a flag value
instead (for instance, openssl ca -md). I think the new message is generic
enough that it can serve both cases with improved clarity.