### PR TITLE
Fix comment about undefined behavior of constant_time_msb

### DIFF
--- a/include/internal/constant_time_locl.h
+++ b/include/internal/constant_time_locl.h
@@ -31,12 +31,7 @@ extern "C" {
  *      c = constant_time_select(lt, a, b);
  */
 
-/*
- * Returns the given value with the MSB copied to all the other
- * bits. Uses the fact that arithmetic shift shifts-in the sign bit.
- * However, this is not ensured by the C standard so you may need to
- * replace this with something else on odd CPUs.
- */
+/* Returns the given value with the MSB copied to all the other bits. */
 static ossl_inline unsigned int constant_time_msb(unsigned int a);
 /* Convenience method for uint64_t. */
 static ossl_inline uint64_t constant_time_msb_64(uint64_t a);


### PR DESCRIPTION
This comment was correct for the original commit introducing this
function (5a3d21c0585064292bde5cd34089e120487ab687), but was fixed
in commit d2fa182988afa33d9e950358de406cc9fb36d000 (and
67b8bcee95f225a07216700786b538bb98d63cfe)
