### PR TITLE
Alternate fix for ../test/recipes/80-test_ssl_old.t with no-ec

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -941,7 +941,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      },
 
-#ifndef OPENSSL_NO_EC
     {
      1,
      TLS1_TXT_ECDHE_ECDSA_WITH_NULL_SHA,
@@ -1268,9 +1267,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-#endif                          /* OPENSSL_NO_EC */
 
-#ifndef OPENSSL_NO_PSK
     {
      1,
      TLS1_TXT_PSK_WITH_NULL_SHA,
@@ -1757,7 +1754,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      0,
      0,
      },
-# ifndef OPENSSL_NO_EC
 #  ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
     {
      1,
@@ -1888,10 +1884,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      0,
      0,
      },
-# endif                         /* OPENSSL_NO_EC */
-#endif                          /* OPENSSL_NO_PSK */
 
-#ifndef OPENSSL_NO_SRP
 # ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
     {
      1,
@@ -2038,10 +2031,8 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-#endif                          /* OPENSSL_NO_SRP */
 
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
-# ifndef OPENSSL_NO_RSA
     {
      1,
      TLS1_TXT_DHE_RSA_WITH_CHACHA20_POLY1305,
@@ -2058,9 +2049,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-# endif                         /* OPENSSL_NO_RSA */
 
-# ifndef OPENSSL_NO_EC
     {
      1,
      TLS1_TXT_ECDHE_RSA_WITH_CHACHA20_POLY1305,
@@ -2093,9 +2082,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-# endif                         /* OPENSSL_NO_EC */
 
-# ifndef OPENSSL_NO_PSK
     {
      1,
      TLS1_TXT_PSK_WITH_CHACHA20_POLY1305,
@@ -2160,7 +2147,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-# endif                         /* OPENSSL_NO_PSK */
 #endif                          /* !defined(OPENSSL_NO_CHACHA) &&
                                  * !defined(OPENSSL_NO_POLY1305) */
 
@@ -2422,7 +2408,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      },
 
-# ifndef OPENSSL_NO_EC
     {
      1,
      TLS1_TXT_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256,
@@ -2487,7 +2472,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-# endif                         /* OPENSSL_NO_EC */
 
 # ifndef OPENSSL_NO_PSK
     {
@@ -2825,7 +2809,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      },
 
-# ifndef OPENSSL_NO_EC
     {
      1,
      TLS1_TXT_ECDHE_PSK_WITH_RC4_128_SHA,
@@ -2890,7 +2873,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      128,
      },
-# endif                         /* OPENSSL_NO_EC */
 
 # ifndef OPENSSL_NO_PSK
     {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -940,7 +940,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      128,
      },
-
     {
      1,
      TLS1_TXT_ECDHE_ECDSA_WITH_NULL_SHA,
@@ -1267,7 +1266,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-
     {
      1,
      TLS1_TXT_PSK_WITH_NULL_SHA,
@@ -2049,7 +2047,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-
     {
      1,
      TLS1_TXT_ECDHE_RSA_WITH_CHACHA20_POLY1305,
@@ -2082,7 +2079,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-
     {
      1,
      TLS1_TXT_PSK_WITH_CHACHA20_POLY1305,
@@ -2407,7 +2403,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      128,
      },
-
     {
      1,
      TLS1_TXT_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256,
@@ -2472,8 +2467,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-
-# ifndef OPENSSL_NO_PSK
     {
      1,
      TLS1_TXT_PSK_WITH_CAMELLIA_128_CBC_SHA256,
@@ -2602,8 +2595,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-# endif                         /* OPENSSL_NO_PSK */
-
 #endif                          /* OPENSSL_NO_CAMELLIA */
 
 #ifndef OPENSSL_NO_GOST
@@ -2808,7 +2799,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      128,
      },
-
     {
      1,
      TLS1_TXT_ECDHE_PSK_WITH_RC4_128_SHA,
@@ -2873,8 +2863,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      128,
      },
-
-# ifndef OPENSSL_NO_PSK
     {
      1,
      TLS1_TXT_PSK_WITH_RC4_128_SHA,
@@ -2923,8 +2911,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      128,
      128,
      },
-# endif                         /* OPENSSL_NO_PSK */
-
 #endif                          /* OPENSSL_NO_WEAK_SSL_CIPHERS */
 
 #ifndef OPENSSL_NO_ARIA
@@ -3056,7 +3042,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-
     {
      1,
      TLS1_TXT_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256,
@@ -3153,7 +3138,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      256,
      256,
      },
-
     {
      1,
      TLS1_TXT_RSA_PSK_WITH_ARIA_128_GCM_SHA256,

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -401,7 +401,7 @@ int ssl_load_ciphers(void)
     disabled_mkey_mask |= SSL_kDHE | SSL_kDHEPSK;
 #endif
 #ifdef OPENSSL_NO_EC
-    disabled_mkey_mask |= SSL_kECDHEPSK;
+    disabled_mkey_mask |= SSL_kECDHE | SSL_kECDHEPSK;
     disabled_auth_mask |= SSL_aECDSA;
 #endif
 #ifdef OPENSSL_NO_PSK

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -398,21 +398,11 @@ sub testssl {
         my @exkeys = ();
         my $ciphers = "-EXP:-PSK:-SRP:-kDH:-kECDHe";
 
-        if ($no_dh) {
-            note "skipping DHE tests\n";
-            $ciphers .= ":-kDHE";
-        }
-        if ($no_dsa) {
-            note "skipping DSA tests\n";
-            $ciphers .= ":-aDSA";
-        } else {
+        if (!$no_dsa) {
             push @exkeys, "-s_cert", "certD.ss", "-s_key", "keyD.ss";
         }
 
-        if ($no_ec) {
-            note "skipping EC tests\n";
-            $ciphers .= ":!aECDSA:!kECDH";
-        } else {
+        if (!$no_ec) {
             push @exkeys, "-s_cert", "certE.ss", "-s_key", "keyE.ss";
         }
 


### PR DESCRIPTION
Alternative, more aggressive approach at fixing test/recipes/80-test_ssl_old.t;
Seems to work at least with no-ec and no-dh configurations.