### PR TITLE
Add 'openssl req' option to specify extension values on command line

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -442,7 +442,7 @@ static char *app_get_pass(const char *arg, int keepbio)
     return OPENSSL_strdup(tpass);
 }
 
-static CONF *app_load_config_(BIO *in, const char *filename)
+CONF *app_load_config_bio(BIO *in, const char *filename)
 {
     long errorline = -1;
     CONF *conf;
@@ -453,12 +453,17 @@ static CONF *app_load_config_(BIO *in, const char *filename)
     if (i > 0)
         return conf;
 
-    if (errorline <= 0)
-        BIO_printf(bio_err, "%s: Can't load config file \"%s\"\n",
-                   opt_getprog(), filename);
+    if (errorline <= 0) {
+        BIO_printf(bio_err, "%s: Can't load ", opt_getprog());
+    } else {
+        BIO_printf(bio_err, "%s: Error on line %ld of ", opt_getprog(),
+                   errorline);
+    }
+    if (filename != NULL)
+        BIO_printf(bio_err, "config file \"%s\"\n", filename);
     else
-        BIO_printf(bio_err, "%s: Error on line %ld of config file \"%s\"\n",
-                   opt_getprog(), errorline, filename);
+        BIO_printf(bio_err, "config input");
+
     NCONF_free(conf);
     return NULL;
 }
@@ -472,7 +477,7 @@ CONF *app_load_config(const char *filename)
     if (in == NULL)
         return NULL;
 
-    conf = app_load_config_(in, filename);
+    conf = app_load_config_bio(in, filename);
     BIO_free(in);
     return conf;
 }
@@ -486,7 +491,7 @@ CONF *app_load_config_quiet(const char *filename)
     if (in == NULL)
         return NULL;
 
-    conf = app_load_config_(in, filename);
+    conf = app_load_config_bio(in, filename);
     BIO_free(in);
     return conf;
 }

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -52,6 +52,7 @@ BIO *dup_bio_err(int format);
 BIO *bio_open_owner(const char *filename, int format, int private);
 BIO *bio_open_default(const char *filename, char mode, int format);
 BIO *bio_open_default_quiet(const char *filename, char mode, int format);
+CONF *app_load_config_bio(BIO *in, const char *filename);
 CONF *app_load_config(const char *filename);
 CONF *app_load_config_quiet(const char *filename);
 int app_load_modules(const CONF *config);

--- a/apps/req.c
+++ b/apps/req.c
@@ -70,6 +70,7 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
                                     int *pkey_type, long *pkeylen,
                                     char **palgnam, ENGINE *keygen_engine);
 static CONF *req_conf = NULL;
+static CONF *cmd_conf = NULL;
 static int batch = 0;
 
 typedef enum OPTION_choice {
@@ -80,7 +81,7 @@ typedef enum OPTION_choice {
     OPT_PKEYOPT, OPT_SIGOPT, OPT_BATCH, OPT_NEWHDR, OPT_MODULUS,
     OPT_VERIFY, OPT_NODES, OPT_NOOUT, OPT_VERBOSE, OPT_UTF8,
     OPT_NAMEOPT, OPT_REQOPT, OPT_SUBJ, OPT_SUBJECT, OPT_TEXT, OPT_X509,
-    OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_EXTENSIONS,
+    OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_EXTENSION, OPT_EXTENSIONS,
     OPT_REQEXTS, OPT_PRECERT, OPT_MD,
     OPT_R_ENUM
 } OPTION_CHOICE;
@@ -124,6 +125,8 @@ const OPTIONS req_options[] = {
      "Enable support for multivalued RDNs"},
     {"days", OPT_DAYS, 'p', "Number of days cert is valid for"},
     {"set_serial", OPT_SET_SERIAL, 's', "Serial number to use"},
+    {"extension", OPT_EXTENSION, 's',
+     "Additional cert extension (may be given more than once)"},
     {"extensions", OPT_EXTENSIONS, 's',
      "Cert extension section (override value in config file)"},
     {"reqexts", OPT_REQEXTS, 's',
@@ -150,6 +153,7 @@ int req_main(int argc, char **argv)
     X509_REQ *req = NULL;
     const EVP_CIPHER *cipher = NULL;
     const EVP_MD *md_alg = NULL, *digest = NULL;
+    BIO *extension_bio = NULL;
     char *extensions = NULL, *infile = NULL;
     char *outfile = NULL, *keyfile = NULL;
     char *keyalgstr = NULL, *p, *prog, *passargin = NULL, *passargout = NULL;
@@ -313,6 +317,12 @@ int req_main(int argc, char **argv)
         case OPT_MULTIVALUE_RDN:
             multirdn = 1;
             break;
+        case OPT_EXTENSION:
+            if (extension_bio == NULL) {
+                extension_bio = BIO_new(BIO_s_mem());
+            }
+            BIO_printf(extension_bio, "%s\n", opt_arg());
+            break;
         case OPT_EXTENSIONS:
             extensions = opt_arg();
             break;
@@ -349,6 +359,12 @@ int req_main(int argc, char **argv)
     if (verbose)
         BIO_printf(bio_err, "Using configuration from %s\n", template);
     req_conf = app_load_config(template);
+    if (extension_bio) {
+        if (verbose)
+            BIO_printf(bio_err,
+                       "Using additional configuraton from command line\n");
+        cmd_conf = app_load_config_bio(extension_bio, NULL);
+    }
     if (template != default_config_file && !app_load_modules(req_conf))
         goto end;
 
@@ -398,6 +414,16 @@ int req_main(int argc, char **argv)
         if (!X509V3_EXT_add_nconf(req_conf, &ctx, extensions, NULL)) {
             BIO_printf(bio_err,
                        "Error Loading extension section %s\n", extensions);
+            goto end;
+        }
+    }
+    if (cmd_conf != NULL) {
+        /* Check syntax of command line extensions */
+        X509V3_CTX ctx;
+        X509V3_set_ctx_test(&ctx);
+        X509V3_set_nconf(&ctx, cmd_conf);
+        if (!X509V3_EXT_add_nconf(cmd_conf, &ctx, "default", NULL)) {
+            BIO_printf(bio_err, "Error Loading command line extensions\n");
             goto end;
         }
     }
@@ -605,7 +631,8 @@ int req_main(int argc, char **argv)
                 goto end;
 
             /* Set version to V3 */
-            if (extensions != NULL && !X509_set_version(x509ss, 2))
+            if ((extensions != NULL || cmd_conf != NULL)
+                && !X509_set_version(x509ss, 2))
                 goto end;
             if (serial != NULL) {
                 if (!X509_set_serialNumber(x509ss, serial))
@@ -643,6 +670,12 @@ int req_main(int argc, char **argv)
                            extensions);
                 goto end;
             }
+            if (cmd_conf != NULL
+                && !X509V3_EXT_add_nconf(cmd_conf, &ext_ctx, "default",
+                                         x509ss)) {
+                BIO_printf(bio_err, "Error Loading command line extensions\n");
+                goto end;
+            }
 
             /* If a pre-cert was requested, we need to add a poison extension */
             if (precert) {
@@ -672,6 +705,12 @@ int req_main(int argc, char **argv)
                                              req_exts, req)) {
                 BIO_printf(bio_err, "Error Loading extension section %s\n",
                            req_exts);
+                goto end;
+            }
+            if (cmd_conf != NULL
+                && !X509V3_EXT_REQ_add_nconf(cmd_conf, &ext_ctx, "default",
+                                             req)) {
+                BIO_printf(bio_err, "Error Loading command line extensions\n");
                 goto end;
             }
             i = do_X509_REQ_sign(req, pkey, digest, sigopts);

--- a/apps/req.c
+++ b/apps/req.c
@@ -126,7 +126,7 @@ const OPTIONS req_options[] = {
     {"days", OPT_DAYS, 'p', "Number of days cert is valid for"},
     {"set_serial", OPT_SET_SERIAL, 's', "Serial number to use"},
     {"extension", OPT_EXTENSION, 's',
-     "Additional cert extension key/value pair (may be given more than once)"},
+     "Additional cert extension key=value pair (may be given more than once)"},
     {"extensions", OPT_EXTENSIONS, 's',
      "Cert extension section (override value in config file)"},
     {"reqexts", OPT_REQEXTS, 's',

--- a/apps/req.c
+++ b/apps/req.c
@@ -126,7 +126,7 @@ const OPTIONS req_options[] = {
     {"days", OPT_DAYS, 'p', "Number of days cert is valid for"},
     {"set_serial", OPT_SET_SERIAL, 's', "Serial number to use"},
     {"extension", OPT_EXTENSION, 's',
-     "Additional cert extension (may be given more than once)"},
+     "Additional cert extension key/value pair (may be given more than once)"},
     {"extensions", OPT_EXTENSIONS, 's',
      "Cert extension section (override value in config file)"},
     {"reqexts", OPT_REQEXTS, 's',

--- a/apps/req.c
+++ b/apps/req.c
@@ -321,7 +321,9 @@ int req_main(int argc, char **argv)
             if (rawext_bio == NULL) {
                 rawext_bio = BIO_new(BIO_s_mem());
             }
-            BIO_printf(rawext_bio, "%s\n", opt_arg());
+            if (rawext_bio == NULL
+                || BIO_printf(rawext_bio, "%s\n", opt_arg()) < 0)
+                goto end;
             break;
         case OPT_EXTENSIONS:
             extensions = opt_arg();
@@ -856,6 +858,7 @@ int req_main(int argc, char **argv)
         ERR_print_errors(bio_err);
     }
     NCONF_free(req_conf);
+    BIO_free(rawext_bio);
     BIO_free(in);
     BIO_free_all(out);
     EVP_PKEY_free(pkey);

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -260,7 +260,10 @@ may be specified as a decimal value or a hex value if preceded by B<0x>.
 
 Add a specific extension to the certificate (if the B<-x509> option is
 present) or certificate request.  The argument must have the form of
-config value lines.
+config key/value pairs (i.e. the lines you commonly find in the config
+file).
+
+This option can be given multiple times, it's values will be accumulated.
 
 =item B<-extensions section>
 
@@ -597,6 +600,14 @@ Sample configuration containing all field values:
 
  [ req_attributes ]
  challengePassword              = A challenge password
+
+Example of giving the most common attributes (subject and extensions)
+on the command line:
+
+ openssl req -new -subj "/C=GB/CN=foo" \
+                  -extension "subjectAltName = DNS:foo.co.uk" \
+                  -extension "certificatePolicies = 1.2.3.4" \
+                  -newkey rsa:2048 -keyout key.pem -out req.pem
 
 
 =head1 NOTES

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -37,7 +37,7 @@ B<openssl> B<req>
 [B<-days n>]
 [B<-set_serial n>]
 [B<-newhdr>]
-[B<-rawext ext>]
+[B<-addext ext>]
 [B<-extensions section>]
 [B<-reqexts section>]
 [B<-precert>]
@@ -256,7 +256,7 @@ be a positive integer. The default is 30 days.
 Serial number to use when outputting a self signed certificate. This
 may be specified as a decimal value or a hex value if preceded by B<0x>.
 
-=item B<-rawext ext>
+=item B<-addext ext>
 
 Add a specific extension to the certificate (if the B<-x509> option is
 present) or certificate request.  The argument must have the form of
@@ -604,8 +604,8 @@ Example of giving the most common attributes (subject and extensions)
 on the command line:
 
  openssl req -new -subj "/C=GB/CN=foo" \
-                  -rawext "subjectAltName = DNS:foo.co.uk" \
-                  -rawext "certificatePolicies = 1.2.3.4" \
+                  -addext "subjectAltName = DNS:foo.co.uk" \
+                  -addext "certificatePolicies = 1.2.3.4" \
                   -newkey rsa:2048 -keyout key.pem -out req.pem
 
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -262,7 +262,7 @@ Add a specific extension to the certificate (if the B<-x509> option is
 present) or certificate request.  The argument must have the form of
 a key=value pair as it would appear in a config file.
 
-This option can be given multiple times, its values will be accumulated.
+This option can be given multiple times.
 
 =item B<-extensions section>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -260,10 +260,9 @@ may be specified as a decimal value or a hex value if preceded by B<0x>.
 
 Add a specific extension to the certificate (if the B<-x509> option is
 present) or certificate request.  The argument must have the form of
-config key/value pairs (i.e. the lines you commonly find in the config
-file).
+a key=value pair as they would appear in a config file.
 
-This option can be given multiple times, it's values will be accumulated.
+This option can be given multiple times, its values will be accumulated.
 
 =item B<-extensions section>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -37,6 +37,7 @@ B<openssl> B<req>
 [B<-days n>]
 [B<-set_serial n>]
 [B<-newhdr>]
+[B<-extension ext>]
 [B<-extensions section>]
 [B<-reqexts section>]
 [B<-precert>]
@@ -254,6 +255,12 @@ be a positive integer. The default is 30 days.
 
 Serial number to use when outputting a self signed certificate. This
 may be specified as a decimal value or a hex value if preceded by B<0x>.
+
+=item B<-extension ext>
+
+Add a specific extension to the certificate (if the B<-x509> option is
+present) or certificate request.  The argument must have the form of
+config value lines.
 
 =item B<-extensions section>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -37,7 +37,7 @@ B<openssl> B<req>
 [B<-days n>]
 [B<-set_serial n>]
 [B<-newhdr>]
-[B<-extension ext>]
+[B<-rawext ext>]
 [B<-extensions section>]
 [B<-reqexts section>]
 [B<-precert>]
@@ -256,11 +256,11 @@ be a positive integer. The default is 30 days.
 Serial number to use when outputting a self signed certificate. This
 may be specified as a decimal value or a hex value if preceded by B<0x>.
 
-=item B<-extension ext>
+=item B<-rawext ext>
 
 Add a specific extension to the certificate (if the B<-x509> option is
 present) or certificate request.  The argument must have the form of
-a key=value pair as they would appear in a config file.
+a key=value pair as it would appear in a config file.
 
 This option can be given multiple times, its values will be accumulated.
 
@@ -604,8 +604,8 @@ Example of giving the most common attributes (subject and extensions)
 on the command line:
 
  openssl req -new -subj "/C=GB/CN=foo" \
-                  -extension "subjectAltName = DNS:foo.co.uk" \
-                  -extension "certificatePolicies = 1.2.3.4" \
+                  -rawext "subjectAltName = DNS:foo.co.uk" \
+                  -rawext "certificatePolicies = 1.2.3.4" \
                   -newkey rsa:2048 -keyout key.pem -out req.pem
 
 


### PR DESCRIPTION
The idea is to be able to add extension value lines directly on the
command line instead of through the config file, for example:

    openssl req -new -extension 'subjectAltName = DNS:dom.ain, DNS:oth.er' \
                     -extension 'certificatePolicies = 1.2.3.4'

Fixes #3311

Thank you Jacob Hoffman-Andrews for the inspiration

-----

This is an alternative to #4971