### PR TITLE
Ignore ORDINALS in build.info files, and remove its documentation

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -399,15 +399,6 @@ support build static libraries and DLLs at the same time, so using
 static libraries on Windows can only be done when configured
 'no-shared'.
 
-For some libraries, we maintain files with public symbols and their
-slot in a transfer vector (important on some platforms).  It can be
-declared like this:
-
-    ORDINALS[libcrypto]=crypto
-
-The value is not the name of the file in question, but rather the
-argument to util/mkdef.pl that indicates which file to use.
-
 One some platforms, shared libraries come with a name that's different
 from their static counterpart.  That's declared as follows:
 
@@ -645,8 +636,7 @@ They are all expected to return a string with the lines they produce.
                         libobj2shlib(shlib => "PATH/TO/shlibfile",
                                      lib => "PATH/TO/libfile",
                                      objs => [ "PATH/TO/objectfile", ... ],
-                                     deps => [ "PATH/TO/otherlibfile", ... ],
-                                     ordinals => [ "word", "/PATH/TO/ordfile" ]);
+                                     deps => [ "PATH/TO/otherlibfile", ... ]);
 
                   'lib' has the intended library file name *without*
                   extension, libobj2shlib is expected to add that.
@@ -655,11 +645,7 @@ They are all expected to return a string with the lines they produce.
                   libraries (also *without* extension) this library
                   needs to be linked with.  'objs' has the list of
                   object files (also *without* extension) to build
-                  this library.  'ordinals' MAY be present, and when
-                  it is, its value is an array where the word is
-                  "crypto" or "ssl" and the file is one of the ordinal
-                  files util/libeay.num or util/ssleay.num in the
-                  source directory.
+                  this library.
 
                   This function has a choice; it can use the
                   corresponding static library as input to make the

--- a/Configurations/README.design
+++ b/Configurations/README.design
@@ -41,10 +41,9 @@ end products.  There are variants for them with '_NO_INST' as suffix
 (PROGRAM_NO_INST etc) to specify end products that shouldn't get
 installed.
 
-The variables SOURCE, DEPEND, INCLUDE and ORDINALS are indexed by a
-produced file, and their values are the source used to produce that
-particular produced file, extra dependencies, include directories
-needed, and ordinal files (explained further below.
+The variables SOURCE, DEPEND and INCLUDE are indexed by a produced
+file, and their values are the source used to produce that particular
+produced file, extra dependencies, and include directories needed.
 
 All their values in all the build.info throughout the source tree are
 collected together and form a set of programs, libraries, engines and
@@ -57,18 +56,15 @@ dependencies.
 
     # build.info
     LIBS=libcrypto libssl
-    ORDINALS[libcrypto]=crypto
-    ORDINALS[libssl]=ssl
     INCLUDE[libcrypto]=include
     INCLUDE[libssl]=include
     DEPEND[libssl]=libcrypto
 
 This is the top directory build.info file, and it tells us that two
-libraries are to be built, there are some ordinals to be used to
-declare what symbols in those libraries are seen as public, the
-include directory 'include/' shall be used throughout when building
-anything that will end up in each library, and that the library
-'libssl' depend on the library 'libcrypto' to function properly.
+libraries are to be built, the include directory 'include/' shall be
+used throughout when building anything that will end up in each
+library, and that the library 'libssl' depend on the library
+'libcrypto' to function properly.
 
     # apps/build.info
     PROGRAMS=openssl
@@ -150,11 +146,9 @@ When Configure digests these build.info files, the accumulated
 information comes down to this:
 
     LIBS=libcrypto libssl
-    ORDINALS[libcrypto]=crypto
     SOURCE[libcrypto]=crypto/aes.c crypto/evp.c crypto/cversion.c
     DEPEND[crypto/cversion.o]=crypto/buildinf.h
     INCLUDE[libcrypto]=include
-    ORDINALS[libssl]=ssl
     SOURCE[libssl]=ssl/tls.c
     INCLUDE[libssl]=include
     DEPEND[libssl]=libcrypto
@@ -187,9 +181,9 @@ PROGRAMS may be used to declare programs only.
 
 ENGINES may be used to declare engines only.
 
-The indexes for SOURCE and ORDINALS must only be end product files,
-such as libraries, programs or engines.  The values of SOURCE
-variables must only be source files (possibly generated)
+The indexes for SOURCE must only be end product files, such as
+libraries, programs or engines.  The values of SOURCE variables must
+only be source files (possibly generated).
 
 INCLUDE and DEPEND shows a relationship between different files
 (usually produced files) or between files and directories, such as a
@@ -235,12 +229,6 @@ indexes:
 
   libraries => a list of libraries.  These are directly inferred from
                the LIBS variable in build.info files.
-
-  ordinals  => a hash table containing 'file' => [ 'word', 'ordfile' ]
-               pairs.  'file' and 'word' are directly inferred from
-               the ORDINALS variables in build.info files, while the
-               file 'ofile' comes from internal knowledge in
-               Configure.
 
   programs  => a list of programs.  These are directly inferred from
                the PROGRAMS variable in build.info files.
@@ -359,19 +347,6 @@ section above would be digested into a %unified_info table:
                 "libcrypto",
                 "libssl",
             ],
-        "ordinals" =>
-            {
-                "libcrypto" =>
-                    [
-                        "crypto",
-                        "util/libcrypto.num",
-                    ],
-                "libssl" =>
-                    [
-                        "ssl",
-                        "util/libssl.num",
-                    ],
-            },
         "programs" =>
             [
                 "apps/openssl",
@@ -530,8 +505,7 @@ etc.
                         libobj2shlib(shlib => "PATH/TO/shlibfile",
                                      lib => "PATH/TO/libfile",
                                      objs => [ "PATH/TO/objectfile", ... ],
-                                     deps => [ "PATH/TO/otherlibfile", ... ],
-                                     ordinals => [ "word", "/PATH/TO/ordfile" ]);
+                                     deps => [ "PATH/TO/otherlibfile", ... ]);
 
                   'lib' has the intended library file name *without*
                   extension, libobj2shlib is expected to add that.
@@ -540,11 +514,7 @@ etc.
                   libraries (also *without* extension) this library
                   needs to be linked with.  'objs' has the list of
                   object files (also *without* extension) to build
-                  this library.  'ordinals' MAY be present, and when
-                  it is, its value is an array where the word is
-                  "crypto" or "ssl" and the file is one of the ordinal
-                  files util/libcrypto.num or util/libssl.num in the
-                  source directory.
+                  this library.
 
                   This function has a choice; it can use the
                   corresponding static library as input to make the
@@ -617,8 +587,7 @@ following calls:
     libobj2shlib(shlib => "libcrypto",
                  lib => "libcrypto",
                  objs => [ "crypto/aes", "crypto/evp", "crypto/cversion" ],
-                 deps => [  ]
-                 ordinals => [ "crypto", "util/libcrypto.num" ]);
+                 deps => [  ]);
 
     obj2lib(lib => "libcrypto"
             objs => [ "crypto/aes", "crypto/evp", "crypto/cversion" ]);

--- a/Configure
+++ b/Configure
@@ -1503,6 +1503,7 @@ if ($builder eq "unified") {
 
     $config{build_infos} = [ ];
 
+    my %ordinals = ();
     foreach (@build_infos) {
         my $sourced = catdir($srcdir, $_->[0]);
         my $buildd = catdir($blddir, $_->[0]);
@@ -1524,7 +1525,6 @@ if ($builder eq "unified") {
         my @intermediates = ();
         my @rawlines = ();
 
-        my %ordinals = ();
         my %sources = ();
         my %shared_sources = ();
         my %includes = ();
@@ -1818,27 +1818,6 @@ EOF
                 if @doubles;
         }
 
-        foreach (keys %ordinals) {
-            my $dest = $_;
-            my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
-            foreach (@{$ordinals{$dest}}) {
-                my %known_ordinals =
-                    (
-                     crypto =>
-                     cleanfile($sourced, catfile("util", "libcrypto.num"), $blddir),
-                     ssl =>
-                     cleanfile($sourced, catfile("util", "libssl.num"), $blddir)
-                    );
-                my $o = $known_ordinals{$_};
-                die "Ordinals for $ddest defined more than once\n"
-                    if $unified_info{ordinals}->{$ddest};
-                $unified_info{ordinals}->{$ddest} = [ $_, $o ];
-            }
-        }
-
         foreach (keys %sources) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
@@ -1992,6 +1971,14 @@ EOF
             }
         }
     }
+
+    my $ordinals_text = join(', ', sort keys %ordinals);
+    warn <<"EOF" if $ordinals_text;
+
+WARNING: ORDINALS were specified for $ordinals_text
+They are ignored and should be replaced with a combination of GENERATE,
+DEPEND and SHARED_SOURCE.
+EOF
 
     ### Make unified_info a bit more efficient
     # One level structures


### PR DESCRIPTION
Following the changes that removed Makefile.shared, we also changed
the generation of .def / .map / .opt files from ordinals more
explicit, removing the need to the "magic" ORDINALS declaration.
