### PR TITLE
Various build improvements, e.g., on mkdef.pl and progs.pl and Windows compatibility

### DIFF
--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -26,7 +26,7 @@ my @openssl_source =
         @{$unified_info{sources}->{$apps_openssl}};
 
 foreach my $filename (@openssl_source) {
-    open F, $filename or die "Couldn't open $_: $!\n";
+    open F, $filename or die "Couldn't open $filename: $!\n";
     foreach ( grep /$cmdre/, <F> ) {
         my @foo = /$cmdre/;
         $commands{$1} = 1;

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -73,7 +73,6 @@ struct ossl_init_stop_st {
 };
 
 static CRYPTO_RWLOCK *glock_lock = NULL;
-static CRYPTO_ONCE glock_once = CRYPTO_ONCE_STATIC_INIT;
 
 static OPENSSL_INIT_STOP *stop_handlers = NULL;
 static CRYPTO_RWLOCK *init_lock = NULL;
@@ -726,6 +725,7 @@ DEFINE_RUN_ONCE_STATIC(glock_init)
  */
 CRYPTO_RWLOCK *CRYPTO_THREAD_glock_new(const char *name)
 {
+    static CRYPTO_ONCE glock_once = CRYPTO_ONCE_STATIC_INIT;
     GLOBAL_LOCK *newlock;
 
     if (glock_lock == NULL && !RUN_ONCE(&glock_once, glock_init))

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -106,6 +106,8 @@ use OpenSSL::Glob;
 (my $SO_VARIANT = qq{\U$target{"shlib_variant"}}) =~ s/\W/_/g;
 
 my $debug=0;
+my $trace=0;
+my $verbose=0;
 
 my $crypto_num= catfile($config{sourcedir},"util","libcrypto.num");
 my $ssl_num=    catfile($config{sourcedir},"util","libssl.num");
@@ -212,6 +214,8 @@ my $zlib;
 foreach (@ARGV, split(/ /, $config{options}))
 	{
 	$debug=1 if $_ eq "debug";
+	$trace=1 if $_ eq "trace";
+	$verbose=1 if $_ eq "verbose";
 	$W32=1 if $_ eq "32";
 	die "win16 not supported" if $_ eq "16";
 	if($_ eq "NT") {
@@ -389,6 +393,7 @@ sub do_defs
 		{
 		my $fn = catfile($config{sourcedir},$file);
 		print STDERR "DEBUG: starting on $fn:\n" if $debug;
+		print STDERR "TRACE: start reading $fn\n" if $trace;
 		open(IN,"<$fn") || die "Can't open $fn, $!,";
 		my $line = "", my $def= "";
 		my %tag = (
@@ -529,19 +534,19 @@ sub do_defs
 				push(@tag,$1);
 				$tag{$1}=-1;
 				print STDERR "DEBUG: $file: found tag $1 = -1\n" if $debug;
-			} elsif (/^\#\s*if\s+!defined\(([^\)]+)\)/) {
+			} elsif (/^\#\s*if\s+!defined\s*\(([^\)]+)\)/) {
 				push(@tag,"-");
-				if (/^\#\s*if\s+(!defined\(([^\)]+)\)(\s+\&\&\s+!defined\(([^\)]+)\))*)$/) {
+				if (/^\#\s*if\s+(!defined\s*\(([^\)]+)\)(\s+\&\&\s+!defined\s*\(([^\)]+)\))*)$/) {
 					my $tmp_1 = $1;
 					my $tmp_;
 					foreach $tmp_ (split '\&\&',$tmp_1) {
-						$tmp_ =~ /!defined\(([^\)]+)\)/;
+						$tmp_ =~ /!defined\s*\(([^\)]+)\)/;
 						print STDERR "DEBUG: $file: found tag $1 = -1\n" if $debug;
 						push(@tag,$1);
 						$tag{$1}=-1;
 					}
 				} else {
-					print STDERR "Warning: $file: complicated expression: $_" if $debug; # because it is O...
+					print STDERR "Warning: $file: taking only '!defined($1)' of complicated expression: $_" if $verbose; # because it is O...
 					print STDERR "DEBUG: $file: found tag $1 = -1\n" if $debug;
 					push(@tag,$1);
 					$tag{$1}=-1;
@@ -551,19 +556,19 @@ sub do_defs
 				push(@tag,$1);
 				$tag{$1}=1;
 				print STDERR "DEBUG: $file: found tag $1 = 1\n" if $debug;
-			} elsif (/^\#\s*if\s+defined\(([^\)]+)\)/) {
+			} elsif (/^\#\s*if\s+defined\s*\(([^\)]+)\)/) {
 				push(@tag,"-");
-				if (/^\#\s*if\s+(defined\(([^\)]+)\)(\s+\|\|\s+defined\(([^\)]+)\))*)$/) {
+				if (/^\#\s*if\s+(defined\s*\(([^\)]+)\)(\s+\|\|\s+defined\s*\(([^\)]+)\))*)$/) {
 					my $tmp_1 = $1;
 					my $tmp_;
 					foreach $tmp_ (split '\|\|',$tmp_1) {
-						$tmp_ =~ /defined\(([^\)]+)\)/;
+						$tmp_ =~ /defined\s*\(([^\)]+)\)/;
 						print STDERR "DEBUG: $file: found tag $1 = 1\n" if $debug;
 						push(@tag,$1);
 						$tag{$1}=1;
 					}
 				} else {
-					print STDERR "Warning: $file: complicated expression: $_\n" if $debug; # because it is O...
+					print STDERR "Warning: $file: taking only 'defined($1)' of complicated expression: $_\n" if $verbose; # because it is O...
 					print STDERR "DEBUG: $file: found tag $1 = 1\n" if $debug;
 					push(@tag,$1);
 					$tag{$1}=1;
@@ -628,6 +633,7 @@ sub do_defs
 			} elsif (/^\#\s*if\s+/) {
 				#Some other unrecognized "if" style
 				push(@tag,"-");
+				print STDERR "Warning: $file: ignoring unrecognized expression: $_\n" if $verbose; # because it is O...
 			} elsif (/^\#\s*define\s+(\w+)\s+(\w+)/
 				 && $symhacking && $tag{'TRUE'} != -1) {
 				# This is for aliasing.  When we find an alias,
@@ -921,11 +927,13 @@ sub do_defs
 			next if(/typedef\W/);
 			next if(/\#define/);
 
+			print STDERR "TRACE: processing $_\n" if $trace && !/^\#INFO:/;
 			# Reduce argument lists to empty ()
 			# fold round brackets recursively: (t(*v)(t),t) -> (t{}{},t) -> {}
-			while(/\(.*\)/s) {
-				s/\([^\(\)]+\)/\{\}/gs;
-				s/\(\s*\*\s*(\w+)\s*\{\}\s*\)/$1/gs;	#(*f{}) -> f
+			my $nsubst = 1; # prevent infinite loop, e.g., on  int fn()
+			while($nsubst && /\(.*\)/s) {
+				$nsubst = s/\([^\(\)]+\)/\{\}/gs;
+				$nsubst+= s/\(\s*\*\s*(\w+)\s*\{\}\s*\)/$1/gs;	#(*f{}) -> f
 			}
 			# pretend as we didn't use curly braces: {} -> ()
 			s/\{\}/\(\)/gs;
@@ -1400,9 +1408,9 @@ sub load_numbers
 		$prev=$a[0];
 	}
 	if ($num_noinfo) {
-		print STDERR "Warning: $num_noinfo symbols were without info.";
+		print STDERR "Warning: $num_noinfo symbols were without info." if $verbose || !$do_rewrite;
 		if ($do_rewrite) {
-			printf STDERR "  The rewrite will fix this.\n";
+			printf STDERR "  The rewrite will fix this.\n" if $verbose;
 		} else {
 			printf STDERR "  You should do a rewrite to fix this.\n";
 		}


### PR DESCRIPTION
As requested in https://github.com/openssl/openssl/pull/4992#issuecomment-354289718
here are five commits with various small corrections for shortcomings in the build machinery of OpenSSL I recently came across while preparing https://github.com/openssl/openssl/pull/4992
- a bug fixed in `util/mkdef.pl`, which caused a loop handling declarations like `void fn()`
- a more practically useful trace option for `util/mkdef.pl`
- a new option for mkdef.pl for warning about incomplete handling of `#if` expressions
- a POSIX/ANSI compatibility warning issue with `crypto/mem.c` and Visual C fixed in `e_os.h`
- a correction of `OPENSSL_EXPORT` and `OPENSSL_EXTERN` in `e_os2.h` for native Windows builds 
- a bug fixed in a file open error message in `apps/progs.pl`

Plus one commit of the same category that is also part of https://github.com/openssl/openssl/pull/4930
- avoiding an unused `glock_once` variable in case `OPENSSL_SYS_UNIX `not defined