### PR TITLE
Corrected 'cms' exit status when key or certificate cannot be opened

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -921,11 +921,15 @@ int cms_main(int argc, char **argv)
             keyfile = sk_OPENSSL_STRING_value(skkeys, i);
 
             signer = load_cert(signerfile, FORMAT_PEM, "signer certificate");
-            if (signer == NULL)
+            if (signer == NULL) {
+                ret = 2;
                 goto end;
+            }
             key = load_key(keyfile, keyform, 0, passin, e, "signing key file");
-            if (key == NULL)
+            if (key == NULL) {
+                ret = 2;
                 goto end;
+            }
             for (kparam = key_first; kparam; kparam = kparam->next) {
                 if (kparam->idx == i) {
                     tflags |= CMS_KEY_PARAM;


### PR DESCRIPTION
Fixes #4996.

Should tests be added? I do not see any testing for nonzero exit codes in `tests/cms-examples.pl`...