### PR TITLE
Fix minor 'the the' typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9436,7 +9436,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) Added BIO_vprintf() and BIO_vsnprintf().
      [Richard Levitte]
 
-  *) Added more prefixes to parse for in the the strings written
+  *) Added more prefixes to parse for in the strings written
      through a logging bio, to cover all the levels that are available
      through syslog.  The prefixes are now:
 
@@ -11181,7 +11181,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      delete an unused file.
      [Ulf Möller]
 
-  *) Add support for the the free Netwide assembler (NASM) under Win32,
+  *) Add support for the free Netwide assembler (NASM) under Win32,
      since not many people have MASM (ml) and it can be hard to obtain.
      This is currently experimental but it seems to work OK and pass all
      the tests. Check out INSTALL.W32 for info.

--- a/Configurations/README
+++ b/Configurations/README
@@ -433,7 +433,7 @@ others, that's done as follows:
     GENERATE[bar.s]=asm/bar.S
 
 The value of each GENERATE line is a command line or part of it.
-Configure places no rules on the command line, except the first
+Configure places no rules on the command line, except that the first
 item must be the generator file.  It is, however, entirely up to the
 build file template to define exactly how those command lines should
 be handled, how the output is captured and so on.

--- a/Configurations/README
+++ b/Configurations/README
@@ -433,8 +433,8 @@ others, that's done as follows:
     GENERATE[bar.s]=asm/bar.S
 
 The value of each GENERATE line is a command line or part of it.
-Configure places no rules on the command line, except the the first
-item muct be the generator file.  It is, however, entirely up to the
+Configure places no rules on the command line, except the first
+item must be the generator file.  It is, however, entirely up to the
 build file template to define exactly how those command lines should
 be handled, how the output is captured and so on.
 

--- a/crypto/des/asm/des_enc.m4
+++ b/crypto/des/asm/des_enc.m4
@@ -112,7 +112,7 @@ changequote({,})
 !
 ! Loads key first round from address in parameter 5 to out0, out1.
 !
-! After the the original LibDES initial permutation, the resulting left
+! After the original LibDES initial permutation, the resulting left
 ! is in the variable initially used for right and vice versa. The macro
 ! implements the possibility to keep the halfs in the original registers.
 !
@@ -529,7 +529,7 @@ $4:
 !  parameter 4   1 for load input/output address to local5/7
 !
 !  The final permutation logic switches the halves, meaning that
-!  left and right ends up the the registers originally used.
+!  left and right ends up the registers originally used.
 
 define(fp_macro, {
 

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -572,7 +572,7 @@ ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group,
 
     if (EC_GROUP_get_asn1_flag(group)) {
         /*
-         * use the asn1 OID to describe the the elliptic curve parameters
+         * use the asn1 OID to describe the elliptic curve parameters
          */
         tmp = EC_GROUP_get_curve_name(group);
         if (tmp) {

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -338,7 +338,7 @@ EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
  */
 EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params);
 
-/** Creates an ECPARAMETERS object for the the given EC_GROUP object.
+/** Creates an ECPARAMETERS object for the given EC_GROUP object.
  *  \param  group   pointer to the EC_GROUP object
  *  \param  params  pointer to an existing ECPARAMETERS object or NULL
  *  \return pointer to the new ECPARAMETERS object or NULL
@@ -354,7 +354,7 @@ ECPARAMETERS *EC_GROUP_get_ecparameters(const EC_GROUP *group,
  */
 EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params);
 
-/** Creates an ECPKPARAMETERS object for the the given EC_GROUP object.
+/** Creates an ECPKPARAMETERS object for the given EC_GROUP object.
  *  \param  group   pointer to the EC_GROUP object
  *  \param  params  pointer to an existing ECPKPARAMETERS object or NULL
  *  \return pointer to the new ECPKPARAMETERS object or NULL

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1591,7 +1591,7 @@ typedef struct ssl3_state_st {
 
 /*
  * Flag used in message reuse to indicate the buffer contains the record
- * header as well as the the handshake message header.
+ * header as well as the handshake message header.
  */
 # define DTLS1_SKIP_RECORD_HEADER                 2
 

--- a/test/ssl-tests/13-fragmentation.conf.in
+++ b/test/ssl-tests/13-fragmentation.conf.in
@@ -104,7 +104,7 @@ our @tests = (
     # When the buffer / fragment size ratio is sufficiently large,
     # multi-buffer code kicks in on some platforms for AES-SHA.  The
     # exact minimum ratio depends on the platform, and is usually
-    # around 4. Since the the test buffer is 64kB, a 4kB fragment is
+    # around 4. Since the test buffer is 64kB, a 4kB fragment is
     # easily sufficient.
     #
     # (We run this test on all platforms though it's only true multibuffer


### PR DESCRIPTION
Similar to commit 17b602802114d53017ff7894319498934a580b17("Remove extra `the` in SSL_SESSION_set1_id.pod"), this commit removes
typos where additional 'the' have been added.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
