### PR TITLE
fix compile error 'intrinsic function not declared' ...

### DIFF
--- a/crypto/modes/modes_lcl.h
+++ b/crypto/modes/modes_lcl.h
@@ -73,6 +73,7 @@ typedef unsigned char u8;
 #  endif
 # elif defined(_MSC_VER)
 #  if _MSC_VER>=1300
+#   include <stdlib.h>
 #   pragma intrinsic(_byteswap_uint64,_byteswap_ulong)
 #   define BSWAP8(x)    _byteswap_uint64((u64)(x))
 #   define BSWAP4(x)    _byteswap_ulong((u32)(x))


### PR DESCRIPTION
... by moving down header.

Microsoft compiler 19.00 for x86 error messages :
modes_internal_test.c
openssl.git\test\../crypto/modes/modes_lcl.h(76): warning C4164: '_byteswap_uint64': intrinsic function not declared
openssl.git\test\../crypto/modes/modes_lcl.h(76): warning C4164: '_byteswap_ulong': intrinsic function not declared
