### PR TITLE
ec/curve25519.c: avoid 2^51 radix on SPARC.

### DIFF
--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -12,6 +12,7 @@
 #include <openssl/sha.h>
 
 #if !defined(PEDANTIC) && \
+    !defined(__sparc__) && \
     (defined(__SIZEOF_INT128__) && __SIZEOF_INT128__==16)
 /*
  * Base 2^51 implementation.


### PR DESCRIPTION
SPARC ISA doesn't have provisions to back up 128-bit multiplications
and additions. And so multiplications are done with library calls
and carries with comparisons and conditional moves. As result base
2^51 code is >40% slower...
