### PR TITLE
Fix trace of TLSv1.3 Certificate Request message

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1244,6 +1244,10 @@ static int ssl_print_cert_request(BIO *bio, int indent, const SSL *ssl,
     if (SSL_IS_TLS13(ssl)) {
         if (!ssl_print_hexbuf(bio, indent, "request_context", 1, &msg, &msglen))
             return 0;
+        if (!ssl_print_extensions(bio, indent, 1,
+                                  SSL3_MT_CERTIFICATE_REQUEST, &msg, &msglen))
+            return 0;
+        return 1;
     } else {
         if (msglen < 1)
             return 0;


### PR DESCRIPTION
A TLSv1.3 Certificate Request message was issuing a "Message length parse
error" using the -trace option to s_server/s_client.