### PR TITLE
Corrected 'cms' exit status when key or certificate cannot be opened

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -977,12 +977,16 @@ int MAIN(int argc, char **argv)
 
             signer = load_cert(bio_err, signerfile, FORMAT_PEM, NULL,
                                e, "signer certificate");
-            if (!signer)
+            if (!signer) {
+                ret = 2;
                 goto end;
+            }
             key = load_key(bio_err, keyfile, keyform, 0, passin, e,
                            "signing key file");
-            if (!key)
+            if (!key) {
+                ret = 2;
                 goto end;
+            }
             for (kparam = key_first; kparam; kparam = kparam->next) {
                 if (kparam->idx == i) {
                     tflags |= CMS_KEY_PARAM;


### PR DESCRIPTION
A backport of #4997.
Fixes #4996.