### PR TITLE
Dtls listen refactor

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -10,6 +10,16 @@
 #include <stdio.h>
 #include <errno.h>
 
+#define __USE_GNU
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <signal.h>
+#include <arpa/inet.h>
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
+#include <netinet/in.h>
+
 #include "bio_lcl.h"
 #ifndef OPENSSL_NO_DGRAM
 
@@ -101,6 +111,7 @@ static const BIO_METHOD methods_dgramp_sctp = {
 
 typedef struct bio_dgram_data_st {
     BIO_ADDR peer;
+    BIO_ADDR addr;
     unsigned int connected;
     unsigned int _errno;
     unsigned int mtu;
@@ -328,24 +339,116 @@ static int dgram_read(BIO *b, char *out, int outl)
     return ret;
 }
 
+static int dgram_write_unconnected_v4(BIO *b, const char *in, int inl)
+{
+    struct sockaddr_in addr;
+    struct sockaddr_in *srcaddr;
+    struct in_pktinfo *pkt_info;
+    struct msghdr mhdr;
+    struct cmsghdr *cmsg;
+    struct iovec iov;
+    char __attribute__((aligned(8))) chdr[CMSG_SPACE(sizeof(struct in_pktinfo))];
+    bio_dgram_data *data = (bio_dgram_data *)b->ptr;
+
+    memset((void *)&addr, 0, sizeof(addr));
+    addr = *(struct sockaddr_in *)BIO_ADDR_sockaddr(&data->peer);
+
+    iov.iov_len  = inl;
+    iov.iov_base = (caddr_t) in;
+
+    memset(&mhdr, 0, sizeof(mhdr));
+    mhdr.msg_name = (caddr_t)&addr;
+    mhdr.msg_namelen = sizeof(struct sockaddr_in);
+    mhdr.msg_iov = &iov;
+    mhdr.msg_iovlen = 1;
+
+    srcaddr = (struct sockaddr_in *)BIO_ADDR_sockaddr(&data->addr);
+    if(srcaddr) {
+      memset(chdr, 0, sizeof(chdr));
+      cmsg = (struct cmsghdr *) chdr;
+
+      cmsg->cmsg_len   = CMSG_LEN(sizeof(struct in6_pktinfo));
+      cmsg->cmsg_level = IPPROTO_IP;
+      cmsg->cmsg_type  = IP_PKTINFO;
+
+      pkt_info = (struct in_pktinfo *)CMSG_DATA(cmsg);
+      pkt_info->ipi_addr    = srcaddr->sin_addr;
+      mhdr.msg_control = (void *) cmsg;
+      mhdr.msg_controllen = sizeof(chdr);
+    }
+
+    return sendmsg(b->num, &mhdr, 0);
+}
+
+#ifdef AF_INET6
+static int dgram_write_unconnected_v6(BIO *b, const char *in, int inl)
+{
+    struct sockaddr_in6 addr;
+    struct sockaddr_in6 *srcaddr;
+    struct in6_pktinfo *pkt_info;
+    struct msghdr mhdr;
+    struct cmsghdr *cmsg;
+    struct iovec iov;
+    char __attribute__((aligned(8))) chdr[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+    bio_dgram_data *data = (bio_dgram_data *)b->ptr;
+
+    memset((void *)&addr, 0, sizeof(addr));
+    addr = *(struct sockaddr_in6 *)BIO_ADDR_sockaddr(&data->peer);
+
+    iov.iov_len  = inl;
+    iov.iov_base = (caddr_t) in;
+
+    memset(&mhdr, 0, sizeof(mhdr));
+    mhdr.msg_name = (caddr_t)&addr;
+    mhdr.msg_namelen = sizeof(struct sockaddr_in6);
+    mhdr.msg_iov = &iov;
+    mhdr.msg_iovlen = 1;
+
+    srcaddr = (struct sockaddr_in6 *)BIO_ADDR_sockaddr(&data->addr);
+    if(srcaddr) {
+      memset(chdr, 0, sizeof(chdr));
+      cmsg = (struct cmsghdr *) chdr;
+
+      cmsg->cmsg_len   = CMSG_LEN(sizeof(struct in6_pktinfo));
+      cmsg->cmsg_level = IPPROTO_IPV6;
+      cmsg->cmsg_type  = IPV6_PKTINFO;
+
+      pkt_info = (struct in6_pktinfo *)CMSG_DATA(cmsg);
+      pkt_info->ipi6_addr    = srcaddr->sin6_addr;
+      mhdr.msg_control = (void *) cmsg;
+      mhdr.msg_controllen = sizeof(chdr);
+    }
+
+    return sendmsg(b->num, &mhdr, 0);
+}
+#endif /* AF_INET6 */
+
 static int dgram_write(BIO *b, const char *in, int inl)
 {
     int ret;
     bio_dgram_data *data = (bio_dgram_data *)b->ptr;
+
     clear_socket_error();
 
     if (data->connected)
         ret = writesocket(b->num, in, inl);
     else {
-        int peerlen = BIO_ADDR_sockaddr_size(&data->peer);
+        struct sockaddr *sa = (struct sockaddr *)BIO_ADDR_sockaddr(&data->peer);
 
-# if defined(NETWARE_CLIB) && defined(NETWARE_BSDSOCK)
-        ret = sendto(b->num, (char *)in, inl, 0,
-                     BIO_ADDR_sockaddr(&data->peer), peerlen);
-# else
-        ret = sendto(b->num, in, inl, 0,
-                     BIO_ADDR_sockaddr(&data->peer), peerlen);
-# endif
+        switch(sa->sa_family) {
+        case AF_INET:
+          ret = dgram_write_unconnected_v4(b, in, inl);
+          break;
+
+#ifdef AF_INET6
+        case AF_INET6:
+          ret = dgram_write_unconnected_v6(b, in, inl);
+          break;
+#endif /* AF_INET6 */
+
+        default:
+          ret = -1;
+        }
     }
 
     BIO_clear_retry_flags(b);
@@ -357,6 +460,7 @@ static int dgram_write(BIO *b, const char *in, int inl)
     }
     return ret;
 }
+
 
 static long dgram_get_mtu_overhead(bio_dgram_data *data)
 {

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -689,6 +689,19 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_SET_PEER:
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;
+
+    case BIO_CTRL_DGRAM_GET_ADDR:
+        ret = BIO_ADDR_sockaddr_size(&data->addr);
+        /* FIXME: if num < ret, we will only return part of an address.
+           That should bee an error, no? */
+        if (num == 0 || num > ret)
+            num = ret;
+        memcpy(ptr, &data->addr, (ret = num));
+        break;
+    case BIO_CTRL_DGRAM_SET_ADDR:
+        BIO_ADDR_make(&data->addr, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
+        break;
+
     case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
         memcpy(&(data->next_timeout), ptr, sizeof(struct timeval));
         break;

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -660,7 +660,7 @@ static int dgram_get_sockname(BIO *b)
     data = (bio_dgram_data *)b->ptr;
 
     if(data->addr.sa.sa_family == 0) {
-      socklen_t addr_len = sizeof(data->addr.sa);
+      socklen_t addr_len = sizeof(data->addr);
 
       if (getsockname(b->num, &data->addr.sa, &addr_len) < 0) {
         return -1;
@@ -848,7 +848,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DGRAM_GET_PEER:
         if(data->peer.sa.sa_family == 0) {
-          socklen_t addr_len = sizeof(data->peer.sa);
+          socklen_t addr_len = sizeof(data->peer);
 
           if (getpeername(b->num, &data->peer.sa, &addr_len) < 0) {
             ret = 0;
@@ -862,6 +862,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             num = ret;
         memcpy(ptr, &data->peer, (ret = num));
         break;
+
     case BIO_CTRL_DGRAM_SET_PEER:
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;
@@ -875,6 +876,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             num = ret;
         memcpy(ptr, &data->addr, (ret = num));
         break;
+
     case BIO_CTRL_DGRAM_SET_ADDR:
         BIO_ADDR_make(&data->addr, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -16,6 +16,7 @@
 #  include <stdio.h>
 # endif
 # include <stdarg.h>
+#include <sys/socket.h>
 
 # include <openssl/crypto.h>
 # include <openssl/bioerr.h>
@@ -657,6 +658,8 @@ void BIO_ADDR_free(BIO_ADDR *);
 void BIO_ADDR_clear(BIO_ADDR *ap);
 int BIO_ADDR_family(const BIO_ADDR *ap);
 int BIO_ADDR_rawaddress(const BIO_ADDR *ap, void *p, size_t *l);
+const struct sockaddr *BIO_ADDR_sockaddr(const BIO_ADDR *ap);
+socklen_t BIO_ADDR_sockaddr_size(const BIO_ADDR *ap);
 unsigned short BIO_ADDR_rawport(const BIO_ADDR *ap);
 char *BIO_ADDR_hostname_string(const BIO_ADDR *ap, int numeric);
 char *BIO_ADDR_service_string(const BIO_ADDR *ap, int numeric);

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -144,6 +144,8 @@ extern "C" {
 # endif
 
 # define BIO_CTRL_DGRAM_SET_PEEK_MODE      71
+# define BIO_CTRL_DGRAM_GET_ADDR           72 /* address data sent to/from */
+# define BIO_CTRL_DGRAM_SET_ADDR           73 /* address data sent to/from */
 
 /* modifiers */
 # define BIO_FP_READ             0x02

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -526,6 +526,10 @@ int BIO_ctrl_reset_read_request(BIO *b);
          (int)BIO_ctrl(b, BIO_CTRL_DGRAM_GET_PEER, 0, (char *)(peer))
 # define BIO_dgram_set_peer(b,peer) \
          (int)BIO_ctrl(b, BIO_CTRL_DGRAM_SET_PEER, 0, (char *)(peer))
+# define BIO_dgram_get_addr(b,addr) \
+         (int)BIO_ctrl(b, BIO_CTRL_DGRAM_GET_ADDR, 0, (char *)(addr))
+# define BIO_dgram_set_addr(b,addr) \
+         (int)BIO_ctrl(b, BIO_CTRL_DGRAM_SET_ADDR, 0, (char *)(addr))
 # define BIO_dgram_get_mtu_overhead(b) \
          (unsigned int)BIO_ctrl((b), BIO_CTRL_DGRAM_GET_MTU_OVERHEAD, 0, NULL)
 

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -42,6 +42,11 @@ extern "C" {
 # define OPENSSL_VERSION_NUMBER  0x10101000L
 # define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1-dev  xx XXX xxxx"
 
+#define OPENSSL_MAKE_VERSION(maj,min,fix,patch,status) (((maj&0xf) << 28)+((min&0xff)<<20)+((fix&0xff)<<12)+((patch&0xff)<<4)+status)
+
+/* use this for #if tests, should never depend upon patch/status */
+#define OPENSSL_VERSION_AT_LEAST(maj,min,fix) (OPENSSL_MAKE_VERSION(maj,min,fix, 0, 0) >= OPENSSL_VERSION_NUMBER)
+
 /*-
  * The macros below are to be used for shared library (.so, .dll, ...)
  * versioning.  That kind of versioning works a bit differently between

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2082,6 +2082,7 @@ void SSL_trace(int write_p, int version, int content_type,
 
 # ifndef OPENSSL_NO_SOCK
 int DTLSv1_listen(SSL *s, BIO_ADDR *client);
+int DTLSv1_accept(SSL *serv, SSL *connection, BIO_ADDR *client);
 # endif
 
 # ifndef OPENSSL_NO_CT

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2082,7 +2082,7 @@ void SSL_trace(int write_p, int version, int content_type,
 
 # ifndef OPENSSL_NO_SOCK
 int DTLSv1_listen(SSL *s, BIO_ADDR *client);
-int DTLSv1_accept(SSL *serv, SSL *connection, BIO_ADDR *client);
+int DTLSv1_accept(SSL *serv, SSL *connection, BIO_ADDR *client, int nfd);
 # endif
 
 # ifndef OPENSSL_NO_CT

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -9,9 +9,11 @@
 
 #include "e_os.h"
 #include <stdio.h>
+#include <sys/socket.h>
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 #include "ssl_locl.h"
+#include "ssl/record/record_locl.h"
 
 static void get_current_time(struct timeval *t);
 static int dtls1_handshake_write(SSL *s);
@@ -920,74 +922,131 @@ int DTLSv1_accept(SSL *serv, SSL *connection, BIO_ADDR *client)
 {
     int ret = 0;
     unsigned char seq[SEQ_NUM_SIZE];
-    BIO *rbio, *wbio;
+    BIO_ADDR     *ouraddr;
+    BIO *rbio,   *wbio;
+    BIO *rbio_c, *wbio_c;
+    SSL3_BUFFER *rb;
+    int  rfd, wfd;
+    unsigned char *addrbuf, *sockname;
+    size_t addrlen;
 
-    if (s->handshake_func == NULL) {
+    ouraddr = BIO_ADDR_new();
+    if(ouraddr == NULL) goto end;
+
+    if (serv->handshake_func == NULL) {
         /* Not properly initialized yet */
-        SSL_set_accept_state(s);
+        SSL_set_accept_state(serv);
     }
 
     /* Ensure there is no state left over from a previous invocation */
-    if (!SSL_clear(s))
+    if (!SSL_clear(serv))
         return -1;
 
     ERR_clear_error();
 
-    rbio = SSL_get_rbio(s);
-    wbio = SSL_get_wbio(s);
+    rbio = SSL_get_rbio(serv);
+    wbio = SSL_get_wbio(serv);
 
     if (!rbio || !wbio) {
         SSLerr(SSL_F_DTLSV1_LISTEN, SSL_R_BIO_NOT_SET);
         return -1;
     }
 
-    if((ret = DTLSv1_answerHello(s, rbio, wbio)) != 1) {
+    if((ret = DTLSv1_answerHello(serv, rbio, wbio)) != 1) {
       goto end;
     }
 
     /* At this point, there is a real ClientHello in s->init_buf */
 
-    /* We need to move the init_buf over to connection, set up
+    /*
+     * We need to move the init_buf over to connection, set up
      * a new socket, and then call SSL_accept() on the new SSL
      */
-    connection->init_buf = s->init_buf;
-    connection->init_num = s->init_num;
-    s->init_buf = NULL;
-    s->init_num = 0;
+    rb = &connection->rlayer.rbuf;
+    if (rb->buf == NULL) {
+      if (!ssl3_setup_read_buffer(connection)) {
+          goto end;
+      }
+    }
 
-    /* dump the data out of the old socket: reads it in again actually */
-    BIO_read(rbio, connection->init_buf->data, SSL3_RT_MAX_PLAIN_LENGTH);
+    memcpy(rb->buf, serv->init_buf, serv->init_num);
+    rb->offset = 0;
+    rb->left   = serv->init_num;
+
+    BIO_ctrl(SSL_get_rbio(serv), BIO_CTRL_DGRAM_SET_PEEK_MODE, 0, NULL);
+
+    /* dump the data out of the old socket */
+    BIO_read(rbio, serv->init_buf->data, SSL3_RT_MAX_PLAIN_LENGTH);
 
     /*
      * Set expected sequence numbers to continue the handshake.
      */
-    s->d1->handshake_read_seq = 1;
-    s->d1->handshake_write_seq = 1;
-    s->d1->next_handshake_write_seq = 1;
-    DTLS_RECORD_LAYER_set_write_sequence(&s->rlayer, seq);
+    connection->d1->handshake_read_seq = 1;
+    connection->d1->handshake_write_seq = 1;
+    connection->d1->next_handshake_write_seq = 1;
+    DTLS_RECORD_LAYER_set_write_sequence(&connection->rlayer, seq);
 
     /*
      * We are doing cookie exchange, so make sure we set that option in the
      * SSL object
      */
-    SSL_set_options(s, SSL_OP_COOKIE_EXCHANGE);
+    SSL_set_options(connection, SSL_OP_COOKIE_EXCHANGE);
 
     /*
      * Tell the state machine that we've done the initial hello verify
      * exchange
      */
-    ossl_statem_set_hello_verify_done(s);
+    ossl_statem_set_hello_verify_done(connection);
 
     /*
-     * Some BIOs may not support this. If we fail we clear the client address
+     * now set up a socket based upon the original rbio's peer/addr
      */
+    /* see if there an FD burried in the rbio */
+    rbio_c = SSL_get_rbio(connection);
+    wbio_c = SSL_get_wbio(connection);
+    rfd    = BIO_get_fd(rbio_c, NULL);
+    wfd    = BIO_get_fd(wbio_c, NULL);
+
+    /* dig the address peers out of s */
     if (BIO_dgram_get_peer(rbio, client) <= 0)
-        BIO_ADDR_clear(client);
+      goto end;
+
+    if (BIO_dgram_get_addr(rbio, ouraddr) <= 0)
+      goto end;
+
+    if(rfd == -1 || wfd == -1) {
+      int socket_type = SOCK_DGRAM;
+      int family      = BIO_ADDR_family(client);
+      int protocol    = 0;  /* UDP has nothing here */
+
+      rfd = socket(family, socket_type, protocol);
+      BIO_set_fd(rbio_c, rfd, 0);
+      BIO_set_fd(wbio_c, rfd, 0);
+      wfd = rfd;
+    }
+
+    /* find out size of addrbuf needed */
+    if(BIO_ADDR_rawaddress(client,   &addrbuf,  &addrlen)==0) {
+      goto end;
+    }
+    if(BIO_ADDR_rawaddress(ouraddr,  &sockname, &addrlen)==0) {
+      goto end;
+    }
+
+    if(connect(rfd, (struct sockaddr *)addrbuf, addrlen) != 0) {
+      goto end;
+    }
+    if(bind(rfd, (struct sockaddr *)sockname, addrlen) != 0) {
+      goto end;
+    }
 
     ret = 1;
 
  end:
-    BIO_ctrl(SSL_get_rbio(s), BIO_CTRL_DGRAM_SET_PEEK_MODE, 0, NULL);
+    if(ouraddr) {
+      BIO_ADDR_free(ouraddr);
+    }
+    BIO_ctrl(SSL_get_rbio(serv), BIO_CTRL_DGRAM_SET_PEEK_MODE, 0, NULL);
     return ret;
 }
 #endif

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -955,7 +955,7 @@ int DTLSv1_accept(SSL *serv, SSL *connection, BIO_ADDR *client, int nfd)
       goto end;
     }
 
-    /* At this point, there is a real ClientHello in s->init_buf */
+    /* At this point, there is a real ClientHello in serv->init_buf */
 
     /*
      * We need to move the init_buf over to connection, set up
@@ -968,7 +968,7 @@ int DTLSv1_accept(SSL *serv, SSL *connection, BIO_ADDR *client, int nfd)
       }
     }
 
-    memcpy(rb->buf, serv->init_buf, serv->init_num);
+    memcpy(rb->buf, serv->init_buf->data, serv->init_num);
     rb->offset = 0;
     rb->left   = serv->init_num;
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2280,9 +2280,6 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
                 /* SSLfatal() already called */
                 goto err;
             }
-#ifdef SSL_DEBUG
-            fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
-#endif
         } else if (!tls1_set_peer_legacy_sigalg(s, pkey)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);
@@ -2295,6 +2292,9 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
             goto err;
         }
 
+#ifdef SSL_DEBUG
+            fprintf(stderr, "USING TLSv1.2 HASH %s\n", EVP_MD_name(md));
+#endif
         if (!PACKET_get_length_prefixed_2(pkt, &signature)
             || PACKET_remaining(pkt) != 0) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PROCESS_KEY_EXCHANGE,

--- a/test/build.info
+++ b/test/build.info
@@ -38,7 +38,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           crltest danetest bad_dtls_test lhash_test \
           constant_time_test verify_extra_test clienthellotest \
           packettest asynctest secmemtest srptest memleaktest stack_test \
-          dtlsv1listentest ct_test threadstest afalgtest d2i_test \
+          dtlsv1listentest dtlsv1accepttest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
           pkey_meth_test pkey_meth_kdf_test uitest cipherbytes_test \
@@ -239,6 +239,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[dtlsv1listentest]=dtlsv1listentest.c
   INCLUDE[dtlsv1listentest]=.. ../include
   DEPEND[dtlsv1listentest]=../libssl libtestutil.a
+
+  SOURCE[dtlsv1accepttest]=dtlsv1accepttest.c
+  INCLUDE[dtlsv1accepttest]=.. ../include
+  DEPEND[dtlsv1accepttest]=../libssl libtestutil.a
 
   SOURCE[ct_test]=ct_test.c
   INCLUDE[ct_test]=../crypto/include ../include

--- a/test/dtlsv1accepttest.c
+++ b/test/dtlsv1accepttest.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include "internal/nelem.h"
+#include "testutil/output.h"
+#include "testutil.h"
+
+#ifndef OPENSSL_NO_SOCK
+
+# define COOKIE_LEN  20
+
+static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
+{
+    unsigned int i;
+
+    for (i = 0; i < COOKIE_LEN; i++, cookie++)
+        *cookie = i;
+    *cookie_len = COOKIE_LEN;
+
+    return 1;
+}
+
+static int cookie_verify(SSL *ssl, const unsigned char *cookie,
+                         unsigned int cookie_len)
+{
+    unsigned int i;
+
+    if (cookie_len != COOKIE_LEN)
+        return 0;
+
+    for (i = 0; i < COOKIE_LEN; i++, cookie++) {
+        if (*cookie != i)
+            return 0;
+    }
+
+    return 1;
+}
+
+static int dtls_accept_test(int unused)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    SSL *connection = NULL;
+    BIO *outbio = NULL;
+    BIO *inbio = NULL;
+    BIO_ADDR *peer = NULL;
+    const char *stage = NULL;
+    //char *data;
+    //long datalen;
+    int ret, success = 0;
+    int socket_type = SOCK_DGRAM;
+    int family      = AF_INET6;
+    int protocol    = 0;  /* UDP has nothing here */
+    int portnum;
+    struct sockaddr_in6 loopback;
+    socklen_t           loopback_len;
+    int listen_fd   = -1;
+
+    /* initialize loopback socket addr */
+    memset(&loopback, 0, sizeof(loopback));
+    loopback.sin6_addr = in6addr_loopback;
+    loopback.sin6_family= AF_INET6;
+
+    stage = "ctx_new";
+    if (!TEST_ptr(ctx = SSL_CTX_new(DTLS_server_method()))
+            || !TEST_ptr(peer = BIO_ADDR_new()))
+        goto err;
+    SSL_CTX_set_cookie_generate_cb(ctx, cookie_gen);
+    SSL_CTX_set_cookie_verify_cb(ctx, cookie_verify);
+
+    /*
+     * create a socket on loopback with a random (kernel allocated)
+     * port number, extract port number to use with test client
+     * process.
+     */
+    stage = "socket";
+    listen_fd = socket(family, socket_type, protocol);
+    if(listen_fd < 0) goto err;
+
+    stage = "ssl";
+    if (!TEST_ptr(ssl = SSL_new(ctx)))
+      goto err;
+
+    stage = "connection-ssl";
+    if (!TEST_ptr(connection = SSL_new(ctx)))
+      goto err;
+
+    inbio  = BIO_new(BIO_s_datagram());
+    BIO_set_fd(inbio, listen_fd, BIO_NOCLOSE);
+    outbio = inbio;
+    SSL_set_bio(ssl, inbio, outbio);
+
+    stage = "bind";
+    /* bind it to ::1 */
+    if(bind(listen_fd,
+            (struct sockaddr *)&loopback, sizeof(struct sockaddr_in6)) != 0) {
+      goto err;
+    }
+
+    stage = "getsockname";
+    /* dig out the port number with getsockname */
+    loopback_len = sizeof(loopback);
+    if(getsockname(listen_fd, (struct sockaddr *)&loopback,
+                   &loopback_len) < 0) {
+      goto err;
+    }
+    portnum = loopback.sin6_port;
+    test_printf_stdout("listening on port: %u\n", ntohs(portnum));
+
+    while((ret = DTLSv1_accept(ssl, connection, peer)) != -1) {
+      pid_t          pid;
+      int            i;
+      unsigned short port;
+      const char *host;
+
+      if(ret == 0) continue;  /* no new connection ready */
+
+      /* new connection found! */
+      host = BIO_ADDR_hostname_string(peer, 0);
+      port = BIO_ADDR_rawport(peer);
+      test_printf_stdout("connection from %s:%u\n", host, port);
+
+      /* process this connection in a sub-process */
+      pid = fork();
+      switch(pid) {
+      case 0:
+        /* child process */
+        {
+          char buf[256];
+          unsigned int bufsize = sizeof(buf);
+
+          BIO *rbio = SSL_get_rbio(connection);
+          BIO *wbio = SSL_get_wbio(connection);
+
+          i = 1;
+          while(i > 0) {
+            i = BIO_read(rbio, buf, bufsize - 1);
+            test_printf_stdout("read: %s[%d]", buf, i);
+            BIO_write(wbio, buf, i);
+          }
+        }
+
+        exit(0);
+        break;
+
+      case -1:
+        perror("fork");
+        break;
+
+      default:
+        test_printf_stderr("created child pid=%d\n", pid);
+        /* parent process */
+      }
+
+      /* create a fresh connection for next connection */
+      SSL_free(connection);
+
+      if (!TEST_ptr(connection = SSL_new(ctx)))
+        goto err;
+    }
+
+
+    success = 1;
+
+ err:
+    if(success == 0) perror(stage);
+    if(listen_fd >=0) close(listen_fd);
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    if(peer) OPENSSL_free(peer);
+    return success;
+}
+#endif
+
+int setup_tests()
+{
+  ADD_ALL_TESTS(dtls_accept_test, 1);
+  return 1;
+}

--- a/test/dtlsv1accepttest.c
+++ b/test/dtlsv1accepttest.c
@@ -105,6 +105,7 @@ static int dtls_accept_test(int unused)
     struct sockaddr_in6 loopback;
     socklen_t           loopback_len;
     int listen_fd   = -1;
+    int conn_fd     = -1;
     int client_count = 0;
 
     /* initialize loopback socket addr */
@@ -140,7 +141,11 @@ static int dtls_accept_test(int unused)
     listen_fd = socket(family, socket_type, protocol);
     if(listen_fd < 0) goto err;
 
+    conn_fd   = socket(family, socket_type, protocol);
+    if(conn_fd < 0) goto err;
+
     if(setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0) goto err;
+    if(setsockopt(conn_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0) goto err;
 
     stage = "ssl";
     if (!TEST_ptr(ssl = SSL_new(ctx)))
@@ -179,7 +184,7 @@ static int dtls_accept_test(int unused)
     alarm(60);
 
     while(client_count < CLIENT_TEST_COUNT &&
-          (ret = DTLSv1_accept(ssl, connection, peer)) != -1) {
+          (ret = DTLSv1_accept(ssl, connection, peer, conn_fd)) != -1) {
       pid_t          pid;
       int            i;
       unsigned short port;

--- a/test/recipes/80-test_dtls.t
+++ b/test/recipes/80-test_dtls.t
@@ -16,5 +16,9 @@ plan skip_all => "No DTLS protocols are supported by this OpenSSL build"
 
 plan tests => 1;
 
+# this runs test/dtlstest.c, which creates an ssl_ctx_pair to connect
+# the DTLS_server_method to DTLS_client_method and see how it interacts with
+# itself.
+
 ok(run(test(["dtlstest", srctop_file("apps", "server.pem"),
              srctop_file("apps", "server.pem")])), "running dtlstest");

--- a/test/recipes/80-test_dtlsv1listen.t
+++ b/test/recipes/80-test_dtlsv1listen.t
@@ -9,4 +9,7 @@
 
 use OpenSSL::Test::Simple;
 
+# this runs test/test/dtlsv1listentest.c, with a set of testpackets which
+# are contained in C code inside of the test case.
+
 simple_test("test_dtlsv1listen", "dtlsv1listentest", "dh");

--- a/test/recipes/81-test_dtlsv1accept.t
+++ b/test/recipes/81-test_dtlsv1accept.t
@@ -17,4 +17,5 @@ plan skip_all => "DTLSv1 is not supported by this OpenSSL build"
 
 plan tests => 1;
 
-simple_test("test_dtls_accept", "dtlsv1accepttest", "dh")
+ok(run(test(["dtlsv1accepttest", srctop_file("apps", "server.pem"),
+             srctop_file("apps", "server.pem")])), "running dtlsv1accepttest");

--- a/test/recipes/81-test_dtlsv1accept.t
+++ b/test/recipes/81-test_dtlsv1accept.t
@@ -1,0 +1,20 @@
+#! /usr/bin/env perl
+# Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_accept_dtls");
+
+plan skip_all => "DTLSv1 is not supported by this OpenSSL build"
+    if disabled("dtls1");
+
+plan tests => 1;
+
+simple_test("test_dtls_accept", "dtlsv1accepttest", "dh")

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4448,3 +4448,5 @@ RSA_meth_get_multi_prime_keygen         4392	1_1_1	EXIST::FUNCTION:RSA
 RSA_meth_set_multi_prime_keygen         4393	1_1_1	EXIST::FUNCTION:RSA
 RAND_DRBG_get0_master                   4394	1_1_1	EXIST::FUNCTION:
 RAND_DRBG_set_reseed_time_interval      4395	1_1_1	EXIST::FUNCTION:
+BIO_ADDR_sockaddr                       4396	1_1_1	EXIST::FUNCTION:SOCK
+BIO_ADDR_sockaddr_size                  4397	1_1_1	EXIST::FUNCTION:SOCK

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -473,3 +473,4 @@ DTLS_set_timer_cb                       473	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_tlsext_max_fragment_length  474	1_1_1	EXIST::FUNCTION:
 SSL_set_tlsext_max_fragment_length      475	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_get_max_fragment_length     476	1_1_1	EXIST::FUNCTION:
+DTLSv1_accept                           477	1_1_1	EXIST::FUNCTION:SOCK


### PR DESCRIPTION
- [x ] documentation is added or updated
- [x] tests are added or updated

This is repeated in an email to the -dev list

This patch refactors the DTLSv1_listen() to create an alternative API that is called DTLSv1_accept().
DTLSv1_accept() is useable by programs that need to treat DTLS interfaces in a way similar to TCP: new connections must be accepted, and new sockets created.
There are a number of changes included here:

1. dgram_write() and dgram_read() now use sendmsg(2) and recvmsg(2) in order to set and collect the local address used in the datagram.  This allows a socket to bound to ::, while still sending traffic correctly from the address that the other peer used. The IPv6 version of this code is according to rfc3542 API, but the IPv4 of the code is Linux specific and needs to be either abstracted and translated for *BSD and Windows, or IPv6 mapped IPv4 sockets could be used.
2. a new BIO control SET_ADDR and GET_ADDR are added, and if the address is not set then it pulls it out of the socket using getsockname(2).
3. DTLSv1_accept() accepts a second SSL* on which new connections are setup. A new socket is set up using the addresses from the received message and it is inserted into the BIO. There is a race condition during setup which turned out to be unavoidable: between the bind(2) and the connect(2), the new socket could have the same address as the "listen" socket, and additional hello packets could arrive on the wrong socket.  Such packets will hopefully be dropped as garbage. It was thought that connect(2) could be called before bind(2), but that seems to cause the kernel to allocate a local address for the new socket (a random port), which the subsequent bind(2) can not seem to change.
4. the use of POSIX socket APIs inside this code is likely inappropriate and this routine should be split up in some better way so that socket activities can be done by the application, using the correct abstractions for the OS.
5. a new test case dtlsaccepttest was created.  It uses fork() and also calls system() on "openssl s_client". Probably it should just call code internally, but apps/* is not in a library form that can be used. Perhaps this use is acceptable.  Other test functions just use canned packets in/out, but since this is testing the creation/adaption of socket code, real sockets would seem to be necessary.  Probably this test case should be disabled on non-Unix platforms.
6. routines BIO_ADDR_sockaddr and BIO_ADDR_sockaddr_size exposed from libcrypto to libssl.  There might be a better way to do this, perhaps a BIO_CTRL would be better?

