### PR TITLE
Support AEAD ciphers in enc app

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -273,6 +273,14 @@ int enc_main(int argc, char **argv)
         goto opthelp;
     }
 
+    /* composite AEADs (rc4_hmac_md5, aes_cbc_hmac_sha1, aes_cbc_hmac_sha256) don't have get/set tag actions */
+    if (cipher && (
+        (EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0 &&
+        (EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_CUSTOM_CIPHER) == 0)) {
+        BIO_printf(bio_err, "%s: composite AEAD ciphers not supported\n", prog);
+        goto end;
+    }
+
     if (cipher && (EVP_CIPHER_mode(cipher) == EVP_CIPH_XTS_MODE)) {
         BIO_printf(bio_err, "%s XTS ciphers not supported\n", prog);
         goto end;
@@ -652,6 +660,8 @@ static void show_ciphers(const OBJ_NAME *name, void *arg)
     /* Filter out ciphers that we cannot use */
     cipher = EVP_get_cipherbyname(name->name);
     if (cipher == NULL ||
+            ((EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0 &&
+            (EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_CUSTOM_CIPHER) == 0) ||
             EVP_CIPHER_mode(cipher) == EVP_CIPH_XTS_MODE)
         return;
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -642,6 +642,11 @@ int enc_main(int argc, char **argv)
         }
     }
 
+    if (!BIO_flush(wbio)) {
+        BIO_printf(bio_err, "error writing output file\n");
+        goto end;
+    }
+
     ret = 0;
     if (verbose) {
         if (aeadtaglen > 0) {

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -22,6 +22,7 @@ B<openssl enc -I<cipher>>
 [B<-kfile filename>]
 [B<-K key>]
 [B<-iv IV>]
+[B<-aeadtaglen N>]
 [B<-S salt>]
 [B<-salt>]
 [B<-nosalt>]
@@ -140,6 +141,10 @@ of hex digits. When only the key is specified using the B<-K> option, the
 IV must explicitly be defined. When a password is being specified using
 one of the other options, the IV is generated from this password.
 
+=item B<-aeadtaglen N>
+
+AEAD tag length for AEAD ciphers. Usually 16.
+
 =item B<-p>
 
 Print out the key and IV used.
@@ -242,9 +247,9 @@ the B<-ciphers> option (that is B<openssl enc -ciphers>) produces a
 list of ciphers, supported by your version of OpenSSL, including
 ones provided by configured engines.
 
-The B<enc> program does not support authenticated encryption modes
-like CCM and GCM. The utility does not store or retrieve the
-authentication tag.
+Authenticated encryption modes are supported. When encrypting,
+the authentication tag is appended to output. When decrypting,
+authentication failure is indicated by non-zero exit code.
 
 
  base64             Base 64

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -19,6 +19,7 @@
 # define EVP_MAX_MD_SIZE                 64/* longest known is SHA512 */
 # define EVP_MAX_KEY_LENGTH              64
 # define EVP_MAX_IV_LENGTH               16
+# define EVP_MAX_AEAD_TAG_LENGTH         16
 # define EVP_MAX_BLOCK_LENGTH            32
 
 # define PKCS5_SALT_LEN                  8


### PR DESCRIPTION
Implemented support for all AEAD ciphers in enc app. AEAD tag length is configurable on command line, because ciphers support smaller sizes than maximum.

When encrypting, tag is appended to output.
When decrypting, read buffer is extended by expected tag length, and rotated, so that it can extract the tag from the end of stream. Any buffer size is supported.

Usage: `openssl enc -aes-128-gcm -aeadtaglen 16`

Fixes #471.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
  
  
  