### PR TITLE
Update OpenSSL Copyright statements automatically using a bash script

### DIFF
--- a/util/openssl-update-copyright
+++ b/util/openssl-update-copyright
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy

--- a/util/openssl-update-copyright
+++ b/util/openssl-update-copyright
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+myname="$(basename $0)"
+
+this_year="$(date '+%Y')"
+some_year="[12][0-9][0-9][0-9]"
+
+copyright_owner="The OpenSSL Project"
+
+search="Copyright \(([cC]) \)\?\(${some_year}\)\(-${some_year}\)\? ${copyright_owner}"
+replace="Copyright \1\2-${this_year} ${copyright_owner}"
+
+
+function usage() {
+	cat >&2 <<EOF
+usage: $myname [-h|--help] [file|directory] ...
+
+Updates the year ranges of all OpenSSL copyright statements in the given
+files or directories. (Directories are traversed recursively.)
+EOF
+}
+
+if [ $# -eq 0 ]; then
+	usage
+	exit 0
+fi
+
+
+for arg in "$@"; do
+	case $arg in
+		-h|--help)
+			usage
+			exit 0
+			;;
+		-*)
+			echo -e "illegal option: $arg\n" >& 2
+			usage
+			exit 1
+			;;
+		*)
+			if [ -f "$arg" ]; then
+				sed -i "s/${search}/${replace}/g" "$arg"
+			elif [ -d "$arg" ]; then
+				find "$arg" -name '.[a-z]*' -prune -o -type f -exec sed -i "s/${search}/${replace}/g" {} +
+			else
+				echo "$arg: no such file or directory" >&2
+			fi
+			;;
+	esac
+done


### PR DESCRIPTION

This PR consists of two commits: The first one adds a helper script for updating the years of all OpenSSL copyright statements, the second commit is the result of executing it.

### Add util/openssl-update-copyright shell script
    
Updates the year ranges of all OpenSSL copyright statements such that it ends at the current year. If only a single year was given, that year is converted to a range. Any `(c)` and `(C)` signs are preserved.
    
To update the copyright statements for all source files, run the shell script

```
 ./util/openssl-update-copyright
```
    
with no arguments.

### Update all OpenSSL Copyright statements to 2018
    
Automatically converted by the shell script `./util/openssl-update-copyright`
