### PR TITLE
Remove remaining NETWARE ifdef's

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) The last traces of Netware support, first removed in 1.1.0, have
+     now been removed.
+     [Rich Salz]
+
   *) Get rid of Makefile.shared, and in the process, make the processing
      of certain files (rc.obj, or the .def/.map/.opt files produced from
      the ordinal files) more visible and hopefully easier to trace and

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -33,21 +33,6 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <openssl/bn.h>
 # include <openssl/x509v3.h>
 
-# if defined(NETWARE_CLIB)
-#  ifdef NETWARE_BSDSOCK
-#   include <sys/socket.h>
-#   include <sys/bsdskt.h>
-#  else
-#   include <novsock2.h>
-#  endif
-# elif defined(NETWARE_LIBC)
-#  ifdef NETWARE_BSDSOCK
-#   include <sys/select.h>
-#  else
-#   include <novsock2.h>
-#  endif
-# endif
-
 /* Maximum leeway in validity period: default 5 minutes */
 # define MAX_VALIDITY_PERIOD    (5 * 60)
 

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -11,10 +11,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "bio_lcl.h"
-#if defined(NETWARE_CLIB)
-# include <sys/ioctl.h>
-NETDB_DEFINE_CONTEXT
-#endif
 #ifndef OPENSSL_NO_SOCK
 # define SOCKET_PROTOCOL IPPROTO_TCP
 # ifdef SO_MAXCONN
@@ -114,11 +110,7 @@ struct hostent *BIO_gethostbyname(const char *name)
      * Caching gethostbyname() results forever is wrong, so we have to let
      * the true gethostbyname() worry about this
      */
-#  if (defined(NETWARE_BSDSOCK) && !defined(__NOVELL_LIBC__))
-    return gethostbyname((char *)name);
-#  else
     return gethostbyname(name);
-#  endif
 }
 # endif
 

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -339,13 +339,8 @@ static int dgram_write(BIO *b, const char *in, int inl)
     else {
         int peerlen = BIO_ADDR_sockaddr_size(&data->peer);
 
-# if defined(NETWARE_CLIB) && defined(NETWARE_BSDSOCK)
-        ret = sendto(b->num, (char *)in, inl, 0,
-                     BIO_ADDR_sockaddr(&data->peer), peerlen);
-# else
         ret = sendto(b->num, in, inl, 0,
                      BIO_ADDR_sockaddr(&data->peer), peerlen);
-# endif
     }
 
     BIO_clear_retry_flags(b);

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -39,8 +39,6 @@ void *_malloc32(__size_t);
 #  endif                        /* __INITIAL_POINTER_SIZE == 64 */
 # endif                         /* __INITIAL_POINTER_SIZE && defined
                                  * _ANSI_C_SOURCE */
-#elif defined(OPENSSL_SYS_NETWARE)
-# define NO_SYSLOG
 #elif (!defined(MSDOS) || defined(WATT32)) && !defined(OPENSSL_SYS_VXWORKS) && !defined(NO_SYSLOG)
 # include <syslog.h>
 #endif

--- a/crypto/perlasm/x86asm.pl
+++ b/crypto/perlasm/x86asm.pl
@@ -263,7 +263,7 @@ sub ::asm_init
 
     $i386=$cpu;
 
-    $elf=$cpp=$coff=$aout=$macosx=$win32=$netware=$mwerks=$android=0;
+    $elf=$cpp=$coff=$aout=$macosx=$win32=$mwerks=$android=0;
     if    (($type eq "elf"))
     {	$elf=1;			require "x86gas.pl";	}
     elsif (($type eq "elf-1"))
@@ -274,10 +274,6 @@ sub ::asm_init
     {	$coff=1;		require "x86gas.pl";	}
     elsif (($type eq "win32n"))
     {	$win32=1;		require "x86nasm.pl";	}
-    elsif (($type eq "nw-nasm"))
-    {	$netware=1;		require "x86nasm.pl";	}
-    #elsif (($type eq "nw-mwasm"))
-    #{	$netware=1; $mwerks=1;	require "x86nasm.pl";	}
     elsif (($type eq "win32"))
     {	$win32=1;		require "x86masm.pl";	}
     elsif (($type eq "macosx"))
@@ -291,7 +287,6 @@ Pick one target type from
 	a.out	- DJGPP, elder OpenBSD, etc.
 	coff	- GAS/COFF such as Win32 targets
 	win32n	- Windows 95/Windows NT NASM format
-	nw-nasm - NetWare NASM format
 	macosx	- Mac OS X
 EOF
 	exit(1);

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -12,7 +12,7 @@ package x86nasm;
 *out=\@::out;
 
 $::lbdecor="L\$";		# local label decoration
-$nmdecor=$::netware?"":"_";	# external name decoration
+$nmdecor="_";			# external name decoration
 $drdecor=$::mwerks?".":"";	# directive decoration
 
 $initseg="";

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -116,14 +116,11 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 # endif
 
 /*
- * Some IPv6 implementations are broken, disable them in known bad versions.
+ * Some IPv6 implementations are broken, you can disable them in known
+ * bad versions.
  */
 # if !defined(OPENSSL_USE_IPV6)
-#  if defined(AF_INET6) && !defined(NETWARE_CLIB)
-#   define OPENSSL_USE_IPV6 1
-#  else
-#   define OPENSSL_USE_IPV6 0
-#  endif
+#  define OPENSSL_USE_IPV6 1
 # endif
 
 # define get_last_socket_error() errno


### PR DESCRIPTION
The config stuff was partially removed in 1.1.0; this removes the last vestiges.
