### PR TITLE
Clean up uClinux targets

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1700,9 +1700,7 @@ my %targets = (
     "uClinux-dist" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => sub { env('CC') },
-        cflags           => combine("\$(CFLAGS)",
-                                    threads("-D_REENTRANT")),
-        plib_lflags      => "\$(LDFLAGS)",
+        cflags           => combine(threads("-D_REENTRANT")),
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
@@ -1715,9 +1713,7 @@ my %targets = (
     "uClinux-dist64" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => sub { env('CC') },
-        cflags           => combine("\$(CFLAGS)",
-                                    threads("-D_REENTRANT")),
-        plib_lflags      => "\$(LDFLAGS)",
+        cflags           => combine(threads("-D_REENTRANT")),
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",


### PR DESCRIPTION
The uClinux targets included some attributes that would result in
circular references of CFLAGS and LDCLAGS.
