### PR TITLE
Make data argument const in SSL_dane_tlsa_add

### DIFF
--- a/doc/man3/SSL_CTX_dane_enable.pod
+++ b/doc/man3/SSL_CTX_dane_enable.pod
@@ -18,7 +18,7 @@ TLS client
                             uint8_t mtype, uint8_t ord);
  int SSL_dane_enable(SSL *s, const char *basedomain);
  int SSL_dane_tlsa_add(SSL *s, uint8_t usage, uint8_t selector,
-                       uint8_t mtype, unsigned char *data, size_t dlen);
+                       uint8_t mtype, unsigned const char *data, size_t dlen);
  int SSL_get0_dane_authority(SSL *s, X509 **mcert, EVP_PKEY **mspki);
  int SSL_get0_dane_tlsa(SSL *s, uint8_t *usage, uint8_t *selector,
                         uint8_t *mtype, unsigned const char **data,
@@ -76,6 +76,8 @@ TLSA records that apply to the remote TLS peer.
 The arguments specify the fields of the TLSA record.
 The B<data> field is provided in binary (wire RDATA) form, not the hexadecimal
 ASCII presentation form, with an explicit length passed via B<dlen>.
+The library takes a copy of the B<data> buffer contents and the caller may
+free the original B<data> buffer when convenient.
 A return value of 0 indicates that "unusable" TLSA records (with invalid or
 unsupported parameters) were provided.
 A negative return value indicates an internal error in processing the record.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1667,7 +1667,7 @@ __owur int SSL_CTX_dane_mtype_set(SSL_CTX *ctx, const EVP_MD *md,
                                   uint8_t mtype, uint8_t ord);
 __owur int SSL_dane_enable(SSL *s, const char *basedomain);
 __owur int SSL_dane_tlsa_add(SSL *s, uint8_t usage, uint8_t selector,
-                             uint8_t mtype, unsigned char *data, size_t dlen);
+                             uint8_t mtype, unsigned const char *data, size_t dlen);
 __owur int SSL_get0_dane_authority(SSL *s, X509 **mcert, EVP_PKEY **mspki);
 __owur int SSL_get0_dane_tlsa(SSL *s, uint8_t *usage, uint8_t *selector,
                               uint8_t *mtype, unsigned const char **data,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -290,7 +290,7 @@ static const EVP_MD *tlsa_md_get(SSL_DANE *dane, uint8_t mtype)
 static int dane_tlsa_add(SSL_DANE *dane,
                          uint8_t usage,
                          uint8_t selector,
-                         uint8_t mtype, unsigned char *data, size_t dlen)
+                         uint8_t mtype, unsigned const char *data, size_t dlen)
 {
     danetls_record *t;
     const EVP_MD *md = NULL;
@@ -1089,7 +1089,7 @@ SSL_DANE *SSL_get0_dane(SSL *s)
 }
 
 int SSL_dane_tlsa_add(SSL *s, uint8_t usage, uint8_t selector,
-                      uint8_t mtype, unsigned char *data, size_t dlen)
+                      uint8_t mtype, unsigned const char *data, size_t dlen)
 {
     return dane_tlsa_add(&s->dane, usage, selector, mtype, data, dlen);
 }


### PR DESCRIPTION
The data argument of SSL_dane_tlsa_add is used read-only, so it
should be const.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
