### PR TITLE
Add a config target for the use of ICC on Windows x86_64

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1262,9 +1262,9 @@ my %targets = (
                                       return [ @defs ];
                                     }),
         coutflag         => "/Fo",
-        lib_cflags       => add("/Zi /Fdossl_static"),
-        dso_cflags       => "/Zi /Fddso",
-        bin_cflags       => "/Zi /Fdapp",
+        lib_cflags       => add("/Zi /Fdossl_static.pdb"),
+        dso_cflags       => "/Zi /Fddso.pdb",
+        bin_cflags       => "/Zi /Fdapp.pdb",
         lflags           => add("/debug"),
         shared_ldflag    => "/dll",
         shared_target    => "win-shared", # meaningless except it gives Configure a hint

--- a/Configurations/80-windows.conf
+++ b/Configurations/80-windows.conf
@@ -1,0 +1,17 @@
+## -*- mode: perl; -*-
+# Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+(
+    'ICC-WIN64A' => {
+        inherit_from    => [ 'VC-WIN64A' ],
+        cc              => 'icl',
+        cflags          => sub { my $a = join(' ', @_);
+                                 $a =~ s| /O2| /O3|;
+                                 $a },
+    },
+);

--- a/apps/build.info
+++ b/apps/build.info
@@ -1,4 +1,5 @@
-{- our $tsget_name = $config{target} =~ /^(VC|vms)-/ ? "tsget.pl" : "tsget";
+{- our $tsget_name =
+       $config{target} =~ /^(\w+-WIN(?:32|64)|vms)-/ ? "tsget.pl" : "tsget";
    our @apps_openssl_src =
        ( qw(openssl.c
             asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c dhparam.c

--- a/build.info
+++ b/build.info
@@ -2,7 +2,8 @@
      our $sover = $config{shlib_version_number};
      our $sover_filename = $sover;
      $sover_filename =~ s|\.|_|g
-         if $config{target} =~ /^mingw/ || $config{target} =~ /^VC-/;
+         if $config{target} =~ /^mingw/
+             || $config{target} =~ /^\w+-WIN(?:32|64)/;
      $sover_filename =
          sprintf "%02d%02d", split m|\.|, $config{shlib_version_number}
          if $config{target} =~ /^vms/;
@@ -45,7 +46,7 @@ IF[{- defined $target{shared_defflag} -}]
 ENDIF
 # VMS and VC don't have parametrised .def / .symvec generation, so they get
 # special treatment, since we know they do use these files
-IF[{- $config{target} =~ /^VC-/ -}]
+IF[{- $config{target} =~ /^\w+-WIN(?:32|64)/ -}]
   GENERATE[libcrypto.def]=util/mkdef.pl crypto 32
   DEPEND[libcrypto.def]=util/libcrypto.num
   GENERATE[libssl.def]=util/mkdef.pl ssl 32
@@ -63,7 +64,7 @@ ELSIF[{- $config{target} =~ /^vms/ -}]
   SHARED_SOURCE[libssl]=libssl.opt
 ENDIF
 
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
+IF[{- $config{target} =~ /^(?:Cygwin|mingw|\w+-WIN(?:32|64))/ -}]
   GENERATE[libcrypto.rc]=util/mkrc.pl libcrypto
   GENERATE[libssl.rc]=util/mkrc.pl libssl
 
@@ -77,7 +78,7 @@ IF[{- $config{target} =~ /^Cygwin/ -}]
 ELSIF[{- $config{target} =~ /^mingw/ -}]
  SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
  SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
-ELSIF[{- $config{target} =~ /^VC-/ -}]
+ELSIF[{- $config{target} =~ /^\w+-WIN(?:32|64)/ -}]
  SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $target{multilib} -}
  SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $target{multilib} -}
 ENDIF

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -34,6 +34,6 @@ INCLUDE[armv4cpuid.o]=.
 GENERATE[s390xcpuid.S]=s390xcpuid.pl $(PERLASM_SCHEME)
 INCLUDE[s390xcpuid.o]=.
 
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
+IF[{- $config{target} =~ /^(?:Cygwin|mingw|\w+-WIN(?:32|64))/ -}]
   SHARED_SOURCE[../libcrypto]=dllmain.c
 ENDIF

--- a/tools/build.info
+++ b/tools/build.info
@@ -1,5 +1,5 @@
 {- our $c_rehash_name =
-       $config{target} =~ /^(VC|vms)-/ ? "c_rehash.pl" : "c_rehash";
+       $config{target} =~ /^(\w+-WIN(?:32|64)|vms)-/ ? "c_rehash.pl" : "c_rehash";
    "" -}
 IF[{- !$disabled{apps} -}]
   SCRIPTS={- $c_rehash_name -}


### PR DESCRIPTION
Note that ICC is currently not treating the /Fd value quite like MSVC,
but that's quite all right, all that's to get them working the same
way is to make the extension explicit.

Fixes #1150

-----

Note that this follows the numbering scheme from #5043, and this config target is placed in the "unknown" category until further notice.