### PR TITLE
Cygwin is POSIX, don't say it isn't

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -11,7 +11,7 @@
 #define OPENSSL_ASYNC_ARCH_ASYNC_POSIX_H
 #include <openssl/e_os2.h>
 
-#if (defined(OPENSSL_SYS_UNIX) || defined(OPENSSL_SYS_CYGWIN)) \
+#if defined(OPENSSL_SYS_UNIX) \
     && defined(OPENSSL_THREADS) && !defined(OPENSSL_NO_ASYNC) \
     && !defined(__ANDROID__) && !defined(__OpenBSD__)
 

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -105,7 +105,7 @@ void OPENSSL_cpuid_setup(void)
 }
 #endif
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32)
 # include <tchar.h>
 # include <signal.h>
 # ifdef __WATCOMC__
@@ -320,7 +320,7 @@ void OPENSSL_die(const char *message, const char *file, int line)
 {
     OPENSSL_showfatal("%s:%d: OpenSSL internal error: %s\n",
                       file, line, message);
-#if !defined(_WIN32) || defined(__CYGWIN__)
+#if !defined(_WIN32)
     abort();
 #else
     /*

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -20,7 +20,9 @@
 
 #include <string.h>
 
-#if defined(OPENSSL_SYS_LINUX) || defined(OPENSSL_SYS_UNIX)
+/* e_os.h includes unistd.h, which defines _POSIX_VERSION */
+#if defined(OPENSSL_SYS_UNIX) \
+    && defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
 # define IMPLEMENTED
 # include <stdlib.h>
 # include <assert.h>

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -25,7 +25,7 @@
 #include <openssl/ssl.h>
 #include <openssl/modes.h>
 
-#if (defined(OPENSSL_SYS_UNIX) || defined(OPENSSL_SYS_CYGWIN)) && defined(OPENSSL_THREADS)
+#if defined(OPENSSL_SYS_UNIX) && defined(OPENSSL_THREADS)
 # undef ASYNC_POSIX
 # define ASYNC_POSIX
 # include <unistd.h>

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -49,7 +49,6 @@ extern "C" {
 #  define OPENSSL_SYS_WIN32_UWIN
 # else
 #  if defined(__CYGWIN__) || defined(OPENSSL_SYS_CYGWIN)
-#   undef OPENSSL_SYS_UNIX
 #   define OPENSSL_SYS_WIN32_CYGWIN
 #  else
 #   if defined(_WIN32) || defined(OPENSSL_SYS_WIN32)


### PR DESCRIPTION
More to the point, Cygwin is a POSIX API.  In our library, the use of
a POSIX API is marked by defining the macro OPENSSL_SYS_UNIX.
Therefore, that macro shouldn't be undefined when building for Cygwin.
