### PR TITLE
In TLSProxy::Proxy::clientstart(), don't cut off all com at once

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -315,6 +315,7 @@ sub clientstart
                         }
                     }
                     $sel->remove($server_sock);
+                    $client_sock->shutdown(1);
                     next;
                 }
                 $indata = $self->process_packet(1, $indata);
@@ -332,6 +333,7 @@ sub clientstart
                         }
                     }
                     $sel->remove($client_sock);
+                    $server_sock->shutdown(1);
                     next;
                 }
                 $indata = $self->process_packet(0, $indata);


### PR DESCRIPTION
Whenever the client or the server would cut off communication, the
proxy would immediately take down the proxy entirely.  However, it's
very possible that just because one side stopped communicating, the
other side might still have a packet on its way.

Since the proxy runs filters, and most of all checks for specific
records to see if the communication was successful or not, it seems
important that none of them are ignored.

Therefore, recode the loop to simply ignore the channel where
communication has stopped, but continue to receive data on the other
until that one shuts down as well.
