### PR TITLE
Catch SIGPIPE in TLSProxy::Proxy::clientstart

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -294,6 +294,7 @@ sub clientstart
     #Wait for either the server socket or the client socket to become readable
     my @ready;
     my $ctr = 0;
+    local $SIG{PIPE} = "IGNORE";
     while(     (!(TLSProxy::Message->end)
                 || (defined $self->sessionfile()
                     && (-s $self->sessionfile()) == 0))


### PR DESCRIPTION
Experimentally this might be sufficient to fix the sporadic test fallout.
As an alternative to #5067.