### PR TITLE
Explicitly shut the socket down in s_client

### DIFF
--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -231,13 +231,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
              * and then closing the socket sends TCP-FIN first followed by
              * TCP-RST. This seems to allow the peer to read the alert data.
              */
-#ifdef _WIN32
-# ifdef SD_SEND
-            shutdown(sock, SD_SEND);
-# endif
-#elif defined(SHUT_WR)
-            shutdown(sock, SHUT_WR);
-#endif
+            shutdown(sock, 1); /* SHUT_WR */
             BIO_closesocket(sock);
         } else {
             i = (*cb)(asock, type, protocol, context);


### PR DESCRIPTION
Sometimes there is unread data and not yet sent data (due to nagle algorithm) in the client socket.
If that happens a RST packet is sent, and the not yet sent data is lost, and the test usually fails.

So the theory is by the uni-directional shutdown, the pending data is sent immediately,
and afterwards, the close can send a RST but then the data is already sent.
Re-sending lost packets will probably not be possible, but this is localhost anyway.