### PR TITLE
Fix intermittent Cygwin failures in s_client

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3025,7 +3025,7 @@ int s_client_main(int argc, char **argv)
     if (in_init)
         print_stuff(bio_c_out, con, full_log);
     do_ssl_shutdown(con);
-#if defined(OPENSSL_SYS_WINDOWS)
+
     /*
      * Give the socket time to send its last data before we close it.
      * No amount of setting SO_LINGER etc on the socket seems to persuade
@@ -3033,8 +3033,12 @@ int s_client_main(int argc, char **argv)
      * for a short time seems to do it (units in ms)
      * TODO: Find a better way to do this
      */
+#if defined(OPENSSL_SYS_WINDOWS)
     Sleep(50);
+#elif defined(OPENSSL_SYS_CYGWIN)
+    usleep(50000);
 #endif
+
     /*
      * If we ended with an alert being sent, but still with data in the
      * network buffer to be read, then calling BIO_closesocket() will


### PR DESCRIPTION
This was identified for Windows almost two years ago for VC and
msys/mingw.  It seems that Cygwin suffers from the same issue, and
since Cygwin doesn't define OPENSSL_SYS_WINDOWS, we need to make a
special case to have a 50ms pause before closing the TLS connection.

Ref: git commit cb2e10f257a464c6b475b321dd9e4769df84dbf6
