### PR TITLE
Fix Windows build file template to recognise .res files

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -501,7 +501,7 @@ EOF
      my $lib = $args{lib};
      my $shlib = $args{shlib};
      my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x }
-                grep { $_ =~ m|\.o$| }
+                grep { $_ =~ m/\.(?:o|res)$/ }
                 @{$args{objs}};
      my @defs = grep { $_ =~ /\.def$/ } @{$args{objs}};
      my @deps = compute_lib_depends(@{$args{deps}});


### PR DESCRIPTION
Only when building the main shared libraries

Fixes #5075
