### PR TITLE
Fix intermittent Windows and Cygwin failures in s_server

### DIFF
--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -221,6 +221,20 @@ int do_server(int *accept_sock, const char *host, const char *port,
                 break;
             }
             i = (*cb)(sock, type, protocol, context);
+
+            /*
+             * Give the socket time to send its last data before we close it.
+             * No amount of setting SO_LINGER etc on the socket seems to
+             * persuade Windows to send the data before closing the socket...
+             * but sleeping for a short time seems to do it (units in ms)
+             * TODO: Find a better way to do this
+             */
+#if defined(OPENSSL_SYS_WINDOWS)
+            Sleep(50);
+#elif defined(OPENSSL_SYS_CYGWIN)
+            usleep(50000);
+#endif
+
             /*
              * If we ended with an alert being sent, but still with data in the
              * network buffer to be read, then calling BIO_closesocket() will


### PR DESCRIPTION
The same kind of failure that has already been observed on the
s_client can sometimes also be observed on s_server, so we need to add
the same kind of 50ms delay as was previously added on s_client.

Ref: git commit cb2e10f257a464c6b475b321dd9e4769df84dbf6:
