### PR TITLE
Extend timeout for TLSProxy

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -255,7 +255,7 @@ sub clientstart
     print "Connection opened\n";
 
     # Now connect to the server
-    my $retry = 10;
+    my $retry = 50;
     my $server_sock;
     #We loop over this a few times because sometimes s_server can take a while
     #to start up


### PR DESCRIPTION
I received this error from a TLSProxy test:

Failed to start up server (localhost,4443): Transport endpoint is not
connected

So, extend the timeout before we give up trying to connect to the server.
