### PR TITLE
TLSProxy::Proxy:  If we don't support IPv6, force IPv4

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -167,6 +167,9 @@ sub start
             .($self->server_port)
             ." -cert ".$self->cert." -cert2 ".$self->cert
             ." -naccept ".$self->serverconnects;
+        unless ($self->supports_IPv6) {
+            $execcmd .= " -4";
+        }
         if ($self->ciphers ne "") {
             $execcmd .= " -cipher ".$self->ciphers;
         }
@@ -228,6 +231,9 @@ sub clientstart
             my $execcmd = "echo ".$echostr." | ".$self->execute
                  ." s_client -engine ossltest -connect "
                  .($self->proxy_addr).":".($self->proxy_port);
+            unless ($self->supports_IPv6) {
+                $execcmd .= " -4";
+            }
             if ($self->cipherc ne "") {
                 $execcmd .= " -cipher ".$self->cipherc;
             }


### PR DESCRIPTION
We use the first we can of the following IO::Socket modules to create
sockets:

- IO::Socket::INET6
- IO::Socket::IP
- IO::Socket::INET

The last of them doesn't support IPv6, so if that's the one available,
we must force the s_client and s_server processes to use IPv4.
