### PR TITLE
Create one permanent proxy socket per TLSProxy::Proxy instance

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -118,7 +118,6 @@ sub new
         print "Proxy started on port ".$self->{proxy_port}."\n";
     } else {
         warn "Failed creating proxy socket (".$proxaddr.",".$self->{proxy_port}."): $!\n";
-        return undef;
     }
 
     return bless $self, $class;
@@ -181,6 +180,10 @@ sub start
 {
     my ($self) = shift;
     my $pid;
+
+    if ($self->{proxy_sock} == 0) {
+        return 0;
+    }
 
     $pid = fork();
     if ($pid == 0) {

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -222,7 +222,7 @@ sub clientstart
             }
             my $execcmd = "echo ".$echostr." | ".$self->execute
                  ." s_client -engine ossltest -connect "
-                 .($self->{proxy_addr}).":".($self->{proxy_port});
+                 .($self->proxy_addr).":".($self->proxy_port);
             unless ($self->supports_IPv6) {
                 $execcmd .= " -4";
             }
@@ -438,24 +438,18 @@ sub supports_IPv6
     my $self = shift;
     return $have_IPv6;
 }
+sub proxy_addr
+{
+    my $self = shift;
+    return $self->{proxy_addr};
+}
+sub proxy_port
+{
+    my $self = shift;
+    return $self->{proxy_port};
+}
 
-##Read/write accessors
-#sub proxy_addr
-#{
-#    my $self = shift;
-#    if (@_) {
-#        $self->{proxy_addr} = shift;
-#    }
-#    return $self->{proxy_addr};
-#}
-#sub proxy_port
-#{
-#    my $self = shift;
-#    if (@_) {
-#        $self->{proxy_port} = shift;
-#    }
-#    return $self->{proxy_port};
-#}
+#Read/write accessors
 sub server_addr
 {
     my $self = shift;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -104,13 +104,15 @@ sub new
     # Create the Proxy socket
     my $proxaddr = $self->{proxy_addr};
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]
-    $self->{proxy_sock} = $IP_factory->(
+    my @proxyargs = (
         LocalHost   => $proxaddr,
         LocalPort   => $self->{proxy_port},
         Proto       => "tcp",
         Listen      => SOMAXCONN,
-        ReuseAddr   => 1
-    );
+       );
+    push @proxyargs, ReuseAddr => 1
+        unless $^O eq "MSWin32";
+    $self->{proxy_sock} = $IP_factory->(@proxyargs);
 
     if ($self->{proxy_sock}) {
         print "Proxy started on port ".$self->{proxy_port}."\n";


### PR DESCRIPTION
On Windows, we sometimes see a behavior with SO_REUSEADDR where there
remains lingering listening sockets on the same address and port as a
newly created one.

To avoid this scenario, we don't create a new proxy port for each new
client run.  Instead, we create one proxy socket when the proxy object
is created, and close it when destroying that object.
