### PR TITLE
Fix SSL_CTX_get_{min,max}_proto_version integer conversion warning

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1403,9 +1403,9 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 #define SSL_CTX_set_max_proto_version(ctx, version) \
         SSL_CTX_ctrl(ctx, SSL_CTRL_SET_MAX_PROTO_VERSION, version, NULL)
 #define SSL_CTX_get_min_proto_version(ctx) \
-        SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MIN_PROTO_VERSION, NULL, NULL)
+        SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, NULL)
 #define SSL_CTX_get_max_proto_version(ctx) \
-        SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MAX_PROTO_VERSION, NULL, NULL)
+        SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
 #define SSL_set_min_proto_version(s, version) \
         SSL_ctrl(s, SSL_CTRL_SET_MIN_PROTO_VERSION, version, NULL)
 #define SSL_set_max_proto_version(s, version) \


### PR DESCRIPTION
When using the SSL_CTX_get_min_min_version macro while compiling with
-Wall, my compiler rightfully complains about this construction:

warning: passing argument 3 of ‘SSL_CTX_ctrl’ makes integer from
pointer without a cast [-Wint-conversion]

These macro's should use 0, instead of NULL, for the third argument,
like most other SSL_CTX_ctrl 'get' wrappers do.

Signed-off-by: Steffan Karger <steffan.karger@fox-it.com>

I consider this to be a 'trivial' contribution, but am willing to sign a CLA if needed.