### PR TITLE
TLSProxy::Proxy: don't waste time redirecting STDOUT and STDERR

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -157,11 +157,6 @@ sub start
 
     $pid = fork();
     if ($pid == 0) {
-        if (!$self->debug) {
-            open(STDOUT, ">", File::Spec->devnull())
-                or die "Failed to redirect stdout: $!";
-            open(STDERR, ">&STDOUT");
-        }
         my $execcmd = $self->execute
             ." s_server -no_comp -rev -engine ossltest -accept "
             .($self->server_port)
@@ -191,11 +186,6 @@ sub clientstart
     my ($self) = shift;
     my $oldstdout;
 
-    if(!$self->debug) {
-        open DEVNULL, ">", File::Spec->devnull();
-        $oldstdout = select(DEVNULL);
-    }
-
     # Create the Proxy socket
     my $proxaddr = $self->proxy_addr;
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]
@@ -217,11 +207,6 @@ sub clientstart
     if ($self->execute) {
         my $pid = fork();
         if ($pid == 0) {
-            if (!$self->debug) {
-                open(STDOUT, ">", File::Spec->devnull())
-                    or die "Failed to redirect stdout: $!";
-                open(STDERR, ">&STDOUT");
-            }
             my $echostr;
             if ($self->reneg()) {
                 $echostr = "R";


### PR DESCRIPTION
On Windows, it seems that doing so in a forked (pseudo-)process
sometimes affects the parent, and thereby hides all the results that
are supposed to be seen by the running test framework (the "ok" and
"not ok" lines).

It turns out that our redirection isn't necessary, as the test
framework seems to swallow it all in non-verbose mode anyway.
It's possible that we did need this at some point, but the framework
has undergone some refinement since then...
