### PR TITLE
Fix: crypto/mem_sec.c:32:26: fatal error: linux/mman.h: No such file …

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -29,7 +29,6 @@
 # include <sys/mman.h>
 # if defined(OPENSSL_SYS_LINUX)
 #  include <sys/syscall.h>
-#  include <linux/mman.h>
 #  include <errno.h>
 # endif
 # include <sys/param.h>


### PR DESCRIPTION
…or directory #5101

Fix: crypto/mem_sec.c:32:26: fatal error: linux/mman.h: No such file or directory #5101

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
