### PR TITLE
TLSProxy::Proxy: Don't use ReuseAddr on Windows

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -189,13 +189,15 @@ sub clientstart
     # Create the Proxy socket
     my $proxaddr = $self->proxy_addr;
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]
-    my $proxy_sock = $IP_factory->(
+    my @proxyargs = (
         LocalHost   => $proxaddr,
         LocalPort   => $self->proxy_port,
         Proto       => "tcp",
         Listen      => SOMAXCONN,
-        ReuseAddr   => 1
-    );
+       );
+    push @proxyargs, ReuseAddr => 1
+        unless $^O eq "MSWin32";
+    my $proxy_sock = $IP_factory->(@proxyargs);
 
     if ($proxy_sock) {
         print "Proxy started on port ".$self->proxy_port."\n";


### PR DESCRIPTION
On Windows, we sometimes see a behavior with SO_REUSEADDR where there
remains lingering listening sockets on the same address and port as a
newly created one.

An easy solution is not to use ReuseAddr on Windows.

Thanks Bernd Edlinger for the suggestion.

-----

This is an alternative to #5095