### PR TITLE
Add a configure option to opt-out secure memory

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -21,7 +21,7 @@
 #include <string.h>
 
 /* e_os.h includes unistd.h, which defines _POSIX_VERSION */
-#if defined(OPENSSL_SYS_UNIX) \
+#if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
     && defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
 # define IMPLEMENTED
 # include <stdlib.h>


### PR DESCRIPTION
./config -DOPENSSL_NO_SECURE_MEMORY

For those who do not need that feature.