### PR TITLE
Fix ca crash

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -663,6 +663,10 @@ end_of_options:
                 goto end;
             }
         }
+        if (pp[DB_name][0] == '\0') {
+            BIO_printf(bio_err, "entry %d: bad Subject\n", i + 1);
+            goto end;
+        }
     }
     if (verbose) {
         TXT_DB_write(bio_out, db->db);

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1403,6 +1403,10 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         BIO_printf(bio_err, "The Subject's Distinguished Name is as follows\n");
 
     name = X509_REQ_get_subject_name(req);
+    if (X509_NAME_entry_count(name) == 0) {
+        BIO_printf(bio_err, "Error: The supplied Subject is empty\n");
+        goto end;
+    }
     for (i = 0; i < X509_NAME_entry_count(name); i++) {
         ne = X509_NAME_get_entry(name, i);
         str = X509_NAME_ENTRY_get_data(ne);
@@ -1563,6 +1567,12 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         subject = X509_NAME_dup(name);
         if (subject == NULL)
             goto end;
+    }
+
+    if (X509_NAME_entry_count(subject) == 0) {
+        BIO_printf(bio_err,
+                   "Error: After applying policy the Subject is empty\n");
+        goto end;
     }
 
     if (verbose)


### PR DESCRIPTION
Two related issues were causing a seg fault in the ca application. Firstly it is possible to create a certificate with an empty Subject. Secondly if ca reads an index.txt file with a missing subject in an entry then it will crash.

Fixes #5109
