### PR TITLE
Fix potential NULL pointer dereferences found with GCC warnings

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -34,6 +34,10 @@ static long bio_call_callback(BIO *b, int oper, const char *argp, size_t len,
     long ret;
     int bareoper;
 
+    if (processed == NULL) {
+        return -1;
+    }
+
     if (b->callback_ex != NULL) {
         return b->callback_ex(b, oper, argp, len, argi, argl, inret, processed);
     }

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -208,6 +208,10 @@ static int fd_gets(BIO *bp, char *buf, int size)
     char *ptr = buf;
     char *end = buf + size - 1;
 
+    if (ptr == NULL) {
+        return ret;
+    }
+
     while (ptr < end && fd_read(bp, ptr, 1) > 0) {
         if (*ptr++ == '\n')
            break;

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -661,6 +661,10 @@ static cbc_handles *get_cipher_handle(int nid)
 const EVP_CIPHER *afalg_aes_cbc(int nid)
 {
     cbc_handles *cipher_handle = get_cipher_handle(nid);
+    if (cipher_handle == NULL) {
+        return NULL;
+    }
+
     if (cipher_handle->_hidden == NULL
         && ((cipher_handle->_hidden =
          EVP_CIPHER_meth_new(nid,

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -600,9 +600,11 @@ static int use_certificate_chain_file(SSL_CTX *ctx, SSL *ssl, const char *file)
     if (ctx != NULL) {
         passwd_callback = ctx->default_passwd_callback;
         passwd_callback_userdata = ctx->default_passwd_callback_userdata;
-    } else {
+    } else if (ssl != NULL) {
         passwd_callback = ssl->default_passwd_callback;
         passwd_callback_userdata = ssl->default_passwd_callback_userdata;
+    } else {
+        goto end;
     }
 
     in = BIO_new(BIO_s_file());

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -728,13 +728,17 @@ static void ssl_test_ctx_free_extra_data(SSL_TEST_CTX *ctx)
 
 void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx)
 {
-    ssl_test_ctx_free_extra_data(ctx);
-    OPENSSL_free(ctx->expected_npn_protocol);
-    OPENSSL_free(ctx->expected_alpn_protocol);
-    sk_X509_NAME_pop_free(ctx->expected_server_ca_names, X509_NAME_free);
-    sk_X509_NAME_pop_free(ctx->expected_client_ca_names, X509_NAME_free);
-    OPENSSL_free(ctx->expected_cipher);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        ssl_test_ctx_free_extra_data(ctx);
+        OPENSSL_free(ctx->expected_npn_protocol);
+        OPENSSL_free(ctx->expected_alpn_protocol);
+        sk_X509_NAME_pop_free(ctx->expected_server_ca_names, X509_NAME_free);
+        sk_X509_NAME_pop_free(ctx->expected_client_ca_names, X509_NAME_free);
+        OPENSSL_free(ctx->expected_cipher);
+        OPENSSL_free(ctx);
+    } else {
+        TEST_error("ctx is NULL");
+    }
 }
 
 static int parse_client_options(SSL_TEST_CLIENT_CONF *client, const CONF *conf,


### PR DESCRIPTION
These were found when compiling with GCC using the following flag:
   -Werror=null-dereference

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
