### PR TITLE
Refuse min proto version > max proto version

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -544,7 +544,7 @@ static int ssl_check_allowed_versions(int min_version, int max_version)
             min_version = TLS1_3_VERSION;
 #endif
         /* Done massaging versions; do the check. */
-        if (0
+        if (min_version > max_version
 #ifdef OPENSSL_NO_SSL3
             || (min_version <= SSL3_VERSION && SSL3_VERSION <= max_version)
 #endif

--- a/test/build.info
+++ b/test/build.info
@@ -46,7 +46,8 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
-          servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest
+          servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest \
+          ssl_ctx_test
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include
@@ -484,6 +485,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   INCLUDE[sslbuffertest]=../include
   DEPEND[sslbuffertest]=../libcrypto ../libssl libtestutil.a
 ENDIF
+
+  SOURCE[ssl_ctx_test]=ssl_ctx_test.c
+  INCLUDE[ssl_ctx_test]=../include
+  DEPEND[ssl_ctx_test]=../libcrypto ../libssl libtestutil.a
 
 {-
    use File::Spec::Functions;

--- a/test/ssl_ctx_test.c
+++ b/test/ssl_ctx_test.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "testutil.h"
+#include <openssl/ssl.h>
+
+typedef struct {
+    int min_version;
+    int max_version;
+    int min_ok;
+    int max_ok;
+    int expected_min;
+    int expected_max;
+} version_test;
+
+static const version_test version_testdata[] = {
+    /* min           max             ok    expected min    expected max */
+    {0,              0,              1, 1, 0,              0},
+    {TLS1_VERSION,   TLS1_2_VERSION, 1, 1, TLS1_VERSION,   TLS1_2_VERSION},
+    {TLS1_2_VERSION, TLS1_2_VERSION, 1, 1, TLS1_2_VERSION, TLS1_2_VERSION},
+    {TLS1_2_VERSION, TLS1_1_VERSION, 1, 0, TLS1_2_VERSION, 0},
+    {7,              42,             0, 0, 0,              0},
+};
+
+static int test_set_min_max_version(int idx_tst)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    int testresult = 0;
+    version_test t = version_testdata[idx_tst];
+
+    ctx = SSL_CTX_new(TLS_server_method());
+    if (ctx == NULL)
+        goto end;
+
+    ssl = SSL_new(ctx);
+    if (ssl == NULL)
+        goto end;
+
+    if (!TEST_int_eq(SSL_CTX_set_min_proto_version(ctx, t.min_version), t.min_ok))
+        goto end;
+    if (!TEST_int_eq(SSL_CTX_set_max_proto_version(ctx, t.max_version), t.max_ok))
+        goto end;
+    if (!TEST_int_eq(SSL_CTX_get_min_proto_version(ctx), t.expected_min))
+        goto end;
+    if (!TEST_int_eq(SSL_CTX_get_max_proto_version(ctx), t.expected_max))
+        goto end;
+
+    if (!TEST_int_eq(SSL_set_min_proto_version(ssl, t.min_version), t.min_ok))
+        goto end;
+    if (!TEST_int_eq(SSL_set_max_proto_version(ssl, t.max_version), t.max_ok))
+        goto end;
+    if (!TEST_int_eq(SSL_get_min_proto_version(ssl), t.expected_min))
+        goto end;
+    if (!TEST_int_eq(SSL_get_max_proto_version(ssl), t.expected_max))
+        goto end;
+
+    testresult = 1;
+
+  end:
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(test_set_min_max_version, sizeof(version_testdata) / sizeof(version_test));
+    return 1;
+}


### PR DESCRIPTION
SSL_CTX_set_min_proto_version() and SSL_CTX_set_max_proto_version() as
well as their SSL equivalents now validate that the mininum protocol
version is lower or requal the maximum protocol version.

Add test cases for min/max protocol API

Closes: https://github.com/openssl/openssl/issues/5127
Signed-off-by: Christian Heimes <christian@python.org>

Also see https://github.com/openssl/openssl/pull/5126