### PR TITLE
test/ossl_shim/packeted_bio.h: don't include e_os.h

### DIFF
--- a/test/ossl_shim/packeted_bio.h
+++ b/test/ossl_shim/packeted_bio.h
@@ -10,7 +10,6 @@
 #ifndef HEADER_PACKETED_BIO
 #define HEADER_PACKETED_BIO
 
-#include "../../e_os.h"
 #include <openssl/base.h>
 #include <openssl/bio.h>
 


### PR DESCRIPTION
That inclusion turned out to be completely unnecessary

[extended tests]
