### PR TITLE
Fix setting of IPV6_V6ONLY on Windows

### DIFF
--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -175,8 +175,10 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         return 0;
 
 # ifndef OPENSSL_SYS_WINDOWS
-    /* SO_REUSEADDR has different behavior on Windows than on
-     * other operating systems, don't set it there. */
+    /*
+     * SO_REUSEADDR has different behavior on Windows than on
+     * other operating systems, don't set it there.
+     */
     if (options & BIO_SOCK_REUSEADDR) {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                        (const void *)&on, sizeof(on)) != 0) {
@@ -207,8 +209,10 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
 
 # ifdef IPV6_V6ONLY
     if (BIO_ADDR_family(addr) == AF_INET6) {
-        /* Note: Windows default of IPV6_V6ONLY is ON, and Linux is OFF.
-         * Therefore we always have to use setsockopt here. */
+        /*
+         * Note: Windows default of IPV6_V6ONLY is ON, and Linux is OFF.
+         * Therefore we always have to use setsockopt here.
+         */
         on = options & BIO_SOCK_V6_ONLY ? 1 : 0;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (const void *)&on, sizeof(on)) != 0) {

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -206,7 +206,10 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     }
 
 # ifdef IPV6_V6ONLY
-    if ((options & BIO_SOCK_V6_ONLY) && BIO_ADDR_family(addr) == AF_INET6) {
+    if (BIO_ADDR_family(addr) == AF_INET6) {
+        /* Note: Windows default of IPV6_V6ONLY is ON, and Linux is OFF.
+         * Therefore we always have to use setsockopt here. */
+        on = options & BIO_SOCK_V6_ONLY ? 1 : 0;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (const void *)&on, sizeof(on)) != 0) {
             SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());


### PR DESCRIPTION
On Windows, the default of IPV6_V6ONLY is different than on Linux.

That means that on Windows (at least Windows 7)
`openssl s_server -accept 4443 -6`
listens on [::]:4443 only,
that means: `openssl s_client -connect [::1]:4443`  succeeds
while `openssl s_client -connect [127.0.0.1]:4443` fails.

while on Linux both commands succeed.