### PR TITLE
When building shared libraries, only ln -s when simple and full name differ

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -994,8 +994,10 @@ EOF
 EOF
       } else {
           $recipe .= <<"EOF";
-	rm -f $target
-	ln -s $target_full $target
+	if [ '$target' != '$target_full' ]; then \\
+		rm -f $target; \\
+		ln -s $target_full $target; \\
+	fi
 EOF
       }
   }


### PR DESCRIPTION
Fixes #5143
