### PR TITLE
Fix Configure

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -82,8 +82,7 @@
                              generator_incs => $unified_info{includes}->{$script},
                              generator_deps => $unified_info{depends}->{$script},
                              deps => $unified_info{depends}->{$src},
-                             incs => [ @{$unified_info{includes}->{$bin}},
-                                       @{$unified_info{includes}->{$obj}} ],
+                             incs => $unified_info{includes}->{$obj},
                              %opts);
          foreach (@{$unified_info{depends}->{$src}}) {
              dogenerate($_, $obj, $bin, %opts);
@@ -104,8 +103,7 @@
                          product => $bin,
                          srcs => $unified_info{sources}->{$obj},
                          deps => $unified_info{depends}->{$obj},
-                         incs => [ @{$unified_info{includes}->{$bin}},
-                                   @{$unified_info{includes}->{$obj}} ],
+                         incs => $unified_info{includes}->{$obj},
                          %opts);
          foreach ((@{$unified_info{sources}->{$obj}},
                    @{$unified_info{depends}->{$obj}})) {

--- a/Configure
+++ b/Configure
@@ -1946,13 +1946,6 @@ EOF
                 }
                 $d .= $e;
                 $unified_info{depends}->{$ddest}->{$d} = 1;
-                # If we depend on a header file or a perl module, let's make
-                # sure it can get included
-                if ($dest ne "" && $d =~ /\.(h|pm)$/) {
-                    my $i = dirname($d);
-                    push @{$unified_info{includes}->{$ddest}->{source}}, $i
-                        unless grep { $_ eq $i } @{$unified_info{includes}->{$ddest}->{source}};
-                }
             }
         }
 
@@ -1989,6 +1982,25 @@ EOF
 
     # Massage the result
 
+    # If we depend on a header file or a perl module, add an inclusion of
+    # its directory to allow smoothe inclusion
+    foreach my $dest (keys %{$unified_info{depends}}) {
+        next if $dest eq "";
+        foreach my $d (keys %{$unified_info{depends}->{$dest}}) {
+            next unless $d =~ /\.(h|pm)$/;
+            if ($d eq "configdata.pm"
+                    || defined($unified_info{generate}->{$d})) {
+                my $i = cleandir($blddir, dirname($d));
+                push @{$unified_info{includes}->{$dest}->{build}}, $i
+                    unless grep { $_ eq $i } @{$unified_info{includes}->{$dest}->{build}};
+            } else {
+                my $i = cleandir($srcdir, dirname($d));
+                push @{$unified_info{includes}->{$dest}->{source}}, $i
+                    unless grep { $_ eq $i } @{$unified_info{includes}->{$dest}->{source}};
+            }
+        }
+    }
+
     # Trickle down includes placed on libraries, engines and programs to
     # their sources (i.e. object files)
     foreach my $dest (keys %{$unified_info{engines}},
@@ -2024,8 +2036,9 @@ EOF
     # Includes
     foreach my $dest (sort keys %{$unified_info{includes}}) {
         if (defined($unified_info{includes}->{$dest}->{build})) {
-            my @source_includes =
-                ( @{$unified_info{includes}->{$dest}->{source}} );
+            my @source_includes = ();
+            @source_includes = ( @{$unified_info{includes}->{$dest}->{source}} )
+                if defined($unified_info{includes}->{$dest}->{source});
             $unified_info{includes}->{$dest} =
                 [ @{$unified_info{includes}->{$dest}->{build}} ];
             foreach my $inc (@source_includes) {

--- a/Configure
+++ b/Configure
@@ -1987,6 +1987,28 @@ They are ignored and should be replaced with a combination of GENERATE,
 DEPEND and SHARED_SOURCE.
 EOF
 
+    # Massage the result
+
+    # Trickle down includes placed on libraries, engines and programs to
+    # their sources (i.e. object files)
+    foreach my $dest (keys %{$unified_info{engines}},
+                      keys %{$unified_info{libraries}},
+                      keys %{$unified_info{programs}}) {
+        foreach my $k (("source", "build")) {
+            next unless defined($unified_info{includes}->{$dest}->{$k});
+            my @incs = reverse @{$unified_info{includes}->{$dest}->{$k}};
+            foreach my $obj (grep /\.o$/,
+                             (keys %{$unified_info{sources}->{$dest}},
+                              keys %{$unified_info{shared_sources}->{$dest}})) {
+                foreach my $inc (@incs) {
+                    unshift @{$unified_info{includes}->{$obj}->{$k}}, $inc
+                        unless grep { $_ eq $inc } @{$unified_info{includes}->{$obj}->{$k}};
+                }
+            }
+        }
+        delete $unified_info{includes}->{$dest};
+    }
+
     ### Make unified_info a bit more efficient
     # One level structures
     foreach (("programs", "libraries", "engines", "scripts", "extra", "overrides")) {

--- a/test/build.info
+++ b/test/build.info
@@ -268,7 +268,6 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   INCLUDE[cipherlist_test]=../include
   DEPEND[cipherlist_test]=../libcrypto ../libssl libtestutil.a
 
-  INCLUDE[testutil.o]=..
   INCLUDE[ssl_test_ctx.o]=../include
   INCLUDE[handshake_helper.o]=../include
   INCLUDE[ssltestlib.o]=.. ../include
@@ -371,7 +370,6 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   ENDIF
 
   SOURCE[uitest]=uitest.c ../apps/apps.c ../apps/opt.c
-  DEPEND[uitest.o]=../apps/progs.h
   INCLUDE[uitest]=.. ../include ../apps
   DEPEND[uitest]=../libcrypto ../libssl libtestutil.a
 


### PR DESCRIPTION
Configure: let INCLUDEs set on binaries "trickle down" to the objects
----------

This ensures that only one set of includes is associated with each
object file, reagardless of where it's used.

For example, if apps/build.info has this:

    SOURCE[openssl]=foo.c
    INCLUDE[openssl]=.. ../include

and test/build.info has this:

    SOURCE[footest]=../apps/foo.c
    INCLUDE[footest]=../include

The inclusion directories used for apps/foo.o would differ depending
on which program's dependencies get generated first in the build file.

With this change, all those INCLUDEs get combined into one set of
inclusion directories tied to the object file.

Configure: ensure that a DEPEND generates the correct inclusion directory
----------

We incorrectly assumed that explicit dependencies meant that the
source directory would be added for inclusion.  However, if the
dependent file is generated, it's stored in the build directory, and
that should be used for inclusion rather than the source directory.