### PR TITLE
Fix setting of IPV6_V6ONLY on Windows

### DIFF
--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -172,8 +172,10 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         return 0;
 
 # ifndef OPENSSL_SYS_WINDOWS
-    /* SO_REUSEADDR has different behavior on Windows than on
-     * other operating systems, don't set it there. */
+    /*
+     * SO_REUSEADDR has different behavior on Windows than on
+     * other operating systems, don't set it there.
+     */
     if (options & BIO_SOCK_REUSEADDR) {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) != 0) {
             SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
@@ -200,7 +202,12 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     }
 
 # ifdef IPV6_V6ONLY
-    if ((options & BIO_SOCK_V6_ONLY) && BIO_ADDR_family(addr) == AF_INET6) {
+    if (BIO_ADDR_family(addr) == AF_INET6) {
+        /*
+         * Note: Windows default of IPV6_V6ONLY is ON, and Linux is OFF.
+         * Therefore we always have to use setsockopt here.
+         */
+        on = options & BIO_SOCK_V6_ONLY ? 1 : 0;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) != 0) {
             SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_LISTEN_V6_ONLY);


### PR DESCRIPTION
This is the back-port of #5139 for 1.1.0