### PR TITLE
Fix strict-warnings build on FreeBSD

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -44,10 +44,13 @@
 #if (defined(__unix__) || defined(unix)) && !defined(USG) && \
         (defined(OpenBSD) || defined(__FreeBSD__))
 # include <sys/param.h>
-# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || __FreeBSD_version >= 500041)
+# if (defined(OpenBSD) && (OpenBSD >= 200112)) || \
+     (defined(__FreeBSD_version) && \
+      ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || \
+       __FreeBSD_version >= 500041))
 #  define HAVE_CRYPTODEV
 # endif
-# if (OpenBSD >= 200110)
+# if defined(OpenBSD) && (OpenBSD >= 200110)
 #  define HAVE_SYSLOG_R
 # endif
 #endif


### PR DESCRIPTION
The cryptodev engine is only available for OpenBSD and FreeBSD,
but for the OS version-specific checks the OpenBSD macro is not
defined on FreeBSD.  When building with -Werror and -Wundef (enabled
by strict-warnings), the FreeBSD build fails:

crypto/engine/eng_cryptodev.c:47:7: error: 'OpenBSD' is not defined,
evaluates to 0
      [-Werror,-Wundef]
\# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 &&
\# __FreeBSD_versi...
      ^

The reverse case would be true on OpenBSD (__FreeBSD_version would
not be defined), but since the boolean will short-circuit and this
code is only executed on OpenBSD and FreeBSD, and the line is
already pretty long, leave that out for now.

