### PR TITLE
Update copyright year in mkerr.pl

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -702,7 +702,7 @@ if ( $newstate )  {
     open(OUT, ">$statefile.new")
         || die "Can't write $statefile.new, $!";
     print OUT <<"EOF";
-# Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1999-$YEAR The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -702,7 +702,7 @@ if ( $newstate )  {
     open(OUT, ">$statefile.new")
         || die "Can't write $statefile.new, $!";
     print OUT <<"EOF";
-# Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
Update copyright year in mkerr.pl

We call this script from our engine makefiles to autogenerate the error files.
It was noticed that the txt file also generated by this script had the wrong copyright year.
I guess this was just missed in the previous commit.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
