### PR TITLE
Configure: allow to enable afalgeng if target does not start with Linux

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -624,6 +624,7 @@ my %targets = (
         shared_cflag     => "-fPIC -DOPENSSL_USE_NODELETE",
         shared_ldflag    => "-Wl,-znodelete",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
+        enable           => [ "afalgeng" ],
     },
     "linux-generic64" => {
         inherit_from     => [ "linux-generic32" ],

--- a/Configure
+++ b/Configure
@@ -1387,7 +1387,7 @@ else               { $no_user_defines=1;    }
 
 unless ($disabled{afalgeng}) {
     $config{afalgeng}="";
-    if ($target =~ m/^linux/) {
+    if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
         my $minver = 4*10000 + 1*100 + 0;
         if ($config{cross_compile_prefix} eq "") {
             my $verstr = `uname -r`;


### PR DESCRIPTION
The Debian build system uses a `debian' target which sets CFLAGS and
then we have for instance debian-amd64 which inherits from
linux-x86_64 and debian [0]. So far so good.

Unless there are different suggestions how to do this, I would keep it.
However since the target name does not start with 'linux', the build
system does not enable the afalg engine. So in order to get enabled, I
added a

	afalgeng => "enable",

line to the debian target and set explicit to disable on the three
non-linux targets (that is hurd and the two kfreebsd ones). In order to
get it working I need this change to get a check for this option of the
target is not linux.

Other suggestions to get this are welcome.

[0] https://sources.debian.org/src/openssl/1.1.0g-2/Configurations/20-debian.conf/
BTS: https://bugs.debian.org/888305
Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>