### PR TITLE
TLS 1.3 draft-23 ASAN followup

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1781,7 +1781,7 @@ static int sig_cb(const char *elem, int len, void *arg)
 
     /* Reject duplicates */
     for (i = 0; i < sarg->sigalgcnt - 1; i++) {
-        if (sarg->sigalgs[i] == sarg->sigalgs[sarg->sigalgcnt]) {
+        if (sarg->sigalgs[i] == sarg->sigalgs[sarg->sigalgcnt - 1]) {
             sarg->sigalgcnt--;
             return 0;
         }


### PR DESCRIPTION
The check for a duplicate value was reading one entry past
where it was supposed to, getting an uninitialized value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
