### PR TITLE
Processing GNU-style "make variables"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Added processing of "make variables" to Configure.
+     [Richard Levitte]
+
   *) Added SHA512/224 and SHA512/256 algorithm support.
      [Paul Dale]
 

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -38,10 +38,22 @@ my %targets=(
 	shared_rcflag	=> "",
 	shared_extension	=> "",
 
-	hashbangperl	=> "PERL", # Only Unix actually cares
+	#### Defaults for the benefit of the config targets who don't inherit
+	#### a BASE and assume Unixly defaults
+	#### THESE WILL DISAPPEAR IN OpenSSL 1.2
+	build_scheme	=> [ "unified", "unix" ],
+	build_file	=> "Makefile",
 
-        build_scheme    => [ "unified", "unix" ],
-        build_file      => "Makefile",
+	ar		=> "ar",
+	arflags		=> "r",
+	cc		=> "cc",
+	hashbangperl	=> "/usr/bin/env perl",
+	ranlib		=> sub { which("$config{cross_compile_prefix}ranlib") ?
+				     "\$(CROSS_COMPILE)ranlib" : "true"; },
+	rc		=> "windres",
+
+	#### THESE WILL BE ENABLED IN OpenSSL 1.2
+	#hashbangperl	=> "PERL", # Only Unix actually cares
     },
 
     BASE_common => {

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -38,6 +38,8 @@ my %targets=(
 	shared_rcflag	=> "",
 	shared_extension	=> "",
 
+	hashbangperl	=> "PERL", # Only Unix actually cares
+
         build_scheme    => [ "unified", "unix" ],
         build_file      => "Makefile",
     },
@@ -61,12 +63,19 @@ my %targets=(
         inherit_from    => [ "BASE_common" ],
         template        => 1,
 
+        ar              => "ar",
+        arflags         => "r",
+        cc              => "cc",
         lflags          =>
             sub { $withargs{zlib_lib} ? "-L".$withargs{zlib_lib} : () },
         ex_libs         =>
             sub { !defined($disabled{zlib})
                   && defined($disabled{"zlib-dynamic"})
                   ? "-lz" : () },
+        hashbangperl    => "/usr/bin/env perl", # Only Unix actually cares
+        ranlib          => sub { which("$config{cross_compile_prefix}ranlib") ?
+                                     "\$(CROSS_COMPILE)ranlib" : "true"; },
+        rc              => "windres",
 
         build_scheme    => [ "unified", "unix" ],
         build_file      => "Makefile",

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -4,6 +4,8 @@ my %targets=(
 	template	=> 1,
 
 	cflags		=> "",
+	cppflags	=> "",
+	lflags		=> "",
 	defines		=> [],
 	thread_scheme	=> "(unknown)", # Assume we don't know
 	thread_defines	=> [],

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -107,7 +107,7 @@ sub vc_wince_info {
             $wcelflag.=" /machine:$wcetgt";                     last; };
       }
 
-        $vc_wince_info = { cflags => $wcecdefs,
+        $vc_wince_info = { cppflags => $wcecdefs,
                            lflags => $wcelflag };
     }
     return $vc_wince_info;
@@ -164,9 +164,10 @@ my %targets = (
     "vos-gcc" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "gcc",
-        cflags           => picker(default => "-Wall -DOPENSSL_SYS_VOS -D_POSIX_C_SOURCE=200112L -D_BSD -D_VOS_EXTENDED_NAMES -DB_ENDIAN",
+        cflags           => picker(default => "-Wall",
                                    debug   => "-O0 -g",
                                    release => "-O3"),
+        cppflags         => "-D_POSIX_C_SOURCE=200112L -D_BSD -D_VOS_EXTENDED_NAMES -DB_ENDIAN",
         thread_scheme    => "(unknown)",
         sys_id           => "VOS",
         lflags           => add("-Wl,-map"),
@@ -178,7 +179,7 @@ my %targets = (
     "solaris-common" => {
         inherit_from     => [ "BASE_unix" ],
         template         => 1,
-        cflags           => "-DFILIO_H",
+        cppflags         => "-DFILIO_H",
         ex_libs          => add("-lsocket -lnsl -ldl"),
         dso_scheme       => "dlfcn",
         thread_scheme    => "pthreads",
@@ -192,10 +193,11 @@ my %targets = (
         # failures [at least] in 32-bit build.
         inherit_from     => [ "solaris-common", asm("x86_elf_asm") ],
         cc               => "gcc",
-        cflags           => add_before(picker(default => "-Wall -DL_ENDIAN",
+        cflags           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
                                               release => "-O3 -fomit-frame-pointer"),
                                        threads("-pthread")),
+        cppflags         => add("-DL_DEBIAN"),
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG",
         shared_cflag     => "-fPIC",
@@ -212,10 +214,11 @@ my %targets = (
         #                        -- <appro@openssl.org>
         inherit_from     => [ "solaris-common", asm("x86_64_asm") ],
         cc               => "gcc",
-        cflags           => add_before(picker(default => "-m64 -Wall -DL_ENDIAN",
+        cflags           => add_before(picker(default => "-m64 -Wall",
                                               debug   => "-O0 -g",
                                               release => "-O3"),
                                        threads("-pthread")),
+        cppflags         => add("-DL_DEBIAN"),
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "elf",
@@ -240,10 +243,10 @@ my %targets = (
     "solaris64-x86_64-cc" => {
         inherit_from     => [ "solaris-common", asm("x86_64_asm") ],
         cc               => "cc",
-        cflags           => add_before(picker(default => "-xarch=generic64 -xstrconst -Xa -DL_ENDIAN",
+        cflags           => add_before(picker(default => "-xarch=generic64 -xstrconst -Xa",
                                               debug   => "-g",
-                                              release => "-xO5 -xdepend -xbuiltin"),
-                                       threads("-D_REENTRANT")),
+                                              release => "-xO5 -xdepend -xbuiltin")),
+        cppflags         => add("-DL_DEBIAN", threads("-D_REENTRANT")),
         thread_scheme    => "pthreads",
         lflags           => add(threads("-mt")),
         ex_libs          => add(threads("-lpthread")),
@@ -258,10 +261,11 @@ my %targets = (
     "solaris-sparcv7-gcc" => {
         inherit_from     => [ "solaris-common" ],
         cc               => "gcc",
-        cflags           => add_before(picker(default => "-Wall -DB_ENDIAN -DBN_DIV2W",
+        cflags           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
                                               release => "-O3"),
                                        threads("-pthread")),
+        cppflags         => add("-DB_DEBIAN -DBN_DIV2W"),
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         shared_cflag     => "-fPIC",
@@ -291,10 +295,11 @@ my %targets = (
     "solaris-sparcv7-cc" => {
         inherit_from     => [ "solaris-common" ],
         cc               => "cc",
-        cflags           => add_before(picker(default => "-xstrconst -Xa -DB_ENDIAN -DBN_DIV2W",
+        cflags           => add_before(picker(default => "-xstrconst -Xa",
                                               debug   => "-g",
-                                              release => "-xO5 -xdepend"),
-                                       threads("-D_REENTRANT")),
+                                              release => "-xO5 -xdepend")),
+        cppflags         => add("-DB_DEBIAN -DBN_DIV2W",
+                                threads("-D_REENTRANT")),
         lflags           => add(threads("-mt")),
         ex_libs          => add(threads("-lpthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
@@ -322,9 +327,10 @@ my %targets = (
     "irix-mips3-gcc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-mabi=n32 -DB_ENDIAN -DBN_DIV3W",
+        cflags           => combine(picker(default => "-mabi=n32",
                                            debug   => "-g -O0",
-                                           release => "-O3"),
+                                           release => "-O3")),
+        cppflags         => combine("-DB_DEBIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
         bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT",
@@ -338,9 +344,10 @@ my %targets = (
     "irix-mips3-cc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "-n32 -mips3 -use_readonly_const -G0 -rdata_shared -DB_ENDIAN -DBN_DIV3W",
+        cflags           => combine(picker(default => "-n32 -mips3 -use_readonly_const -G0 -rdata_shared",
                                            debug   => "-g -O0",
-                                           release => "-O2"),
+                                           release => "-O2")),
+        cppflags         => combine("-DB_DEBIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
         bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT",
@@ -355,9 +362,10 @@ my %targets = (
     "irix64-mips4-gcc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-mabi=64 -mips4 -DB_ENDIAN -DBN_DIV3W",
+        cflags           => combine(picker(default => "-mabi=64 -mips4",
                                            debug   => "-g -O0",
-                                           release => "-O3"),
+                                           release => "-O3")),
+        cppflags         => combine("-DB_DEBIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
         bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT_LONG",
@@ -371,9 +379,10 @@ my %targets = (
     "irix64-mips4-cc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "-64 -mips4 -use_readonly_const -G0 -rdata_shared -DB_ENDIAN -DBN_DIV3W",
+        cflags           => combine(picker(default => "-64 -mips4 -use_readonly_const -G0 -rdata_shared",
                                            debug   => "-g -O0",
-                                           release => "-O2"),
+                                           release => "-O2")),
+        cppflags         => combine("-DB_DEBIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
         bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT_LONG",
@@ -415,10 +424,10 @@ my %targets = (
     "hpux-parisc-gcc" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-DB_ENDIAN -DBN_DIV2W",
-                                           debug   => "-O0 -g",
+        cflags           => combine(picker(debug   => "-O0 -g",
                                            release => "-O3"),
                                     threads("-pthread")),
+        cppflags         => "-DB_DEBIAN -DBN_DIV2W",
         ex_libs          => add("-Wl,+s -ldld", threads("-pthread")),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
@@ -435,10 +444,9 @@ my %targets = (
     "hpux64-parisc2-gcc" => {
         inherit_from     => [ "BASE_unix", asm("parisc20_64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-DB_ENDIAN",
-                                           debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-D_REENTRANT")),
+        cflags           => combine(picker(debug   => "-O0 -g",
+                                           release => "-O3")),
+        cppflags         => combine("-DB_DEBIAN", threads("-D_REENTRANT")),
         ex_libs          => add("-ldl"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         thread_scheme    => "pthreads",
@@ -454,9 +462,10 @@ my %targets = (
     "hpux-parisc-cc" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
-        cflags           => combine(picker(default => "+Optrs_strongly_typed -Ae +ESlit -DB_ENDIAN -DBN_DIV2W -DMD32_XARRAY",
+        cflags           => combine(picker(default => "+Optrs_strongly_typed -Ae +ESlit",
                                            debug   => "+O0 +d -g",
-                                           release => "+O3"),
+                                           release => "+O3")),
+        cppflags         => combine("-DB_DEBIAN -DBN_DIV2W -DMD32_XARRAY",
                                     threads("-D_REENTRANT")),
         ex_libs          => add("-Wl,+s -ldld",threads("-lpthread")),
         bn_ops           => "RC4_CHAR",
@@ -475,9 +484,10 @@ my %targets = (
     "hpux64-parisc2-cc" => {
         inherit_from     => [ "BASE_unix", asm("parisc20_64_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "+DD64 +Optrs_strongly_typed -Ae +ESlit -DB_ENDIAN -DMD32_XARRAY",
+        cflags           => combine(picker(default => "+DD64 +Optrs_strongly_typed -Ae +ESlit",
                                            debug   => "+O0 +d -g",
-                                           release => "+O3"),
+                                           release => "+O3")),
+        cppflags         => combine("-DB_DEBIAN -DMD32_XARRAY",
                                     threads("-D_REENTRANT")),
         ex_libs          => add("-ldl",threads("-lpthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
@@ -494,10 +504,10 @@ my %targets = (
     "hpux-ia64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "-Ae +DD32 +Olit=all -z -DB_ENDIAN",
+        cflags           => combine(picker(default => "-Ae +DD32 +Olit=all -z",
                                            debug   => "+O0 +d -g",
-                                           release => "+O2"),
-                                    threads("-D_REENTRANT")),
+                                           release => "+O2")),
+        cppflags         => combine("-DB_DEBIAN", threads("-D_REENTRANT")),
         ex_libs          => add("-ldl",threads("-lpthread")),
         bn_ops           => "SIXTY_FOUR_BIT",
         thread_scheme    => "pthreads",
@@ -511,10 +521,10 @@ my %targets = (
     "hpux64-ia64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "-Ae +DD64 +Olit=all -z -DB_ENDIAN",
+        cflags           => combine(picker(default => "-Ae +DD64 +Olit=all -z",
                                            debug   => "+O0 +d -g",
-                                           release => "+O3"),
-                                    threads("-D_REENTRANT")),
+                                           release => "+O3")),
+        cppflags         => combine("-DB_DEBIAN", threads("-D_REENTRANT")),
         ex_libs          => add("-ldl", threads("-lpthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
@@ -529,10 +539,10 @@ my %targets = (
     "hpux-ia64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-DB_ENDIAN",
-                                           debug   => "-O0 -g",
+        cflags           => combine(picker(debug   => "-O0 -g",
                                            release => "-O3"),
                                     threads("-pthread")),
+        cppflags         => "-DB_DEBIAN",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "SIXTY_FOUR_BIT",
         thread_scheme    => "pthreads",
@@ -546,10 +556,11 @@ my %targets = (
     "hpux64-ia64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-mlp64 -DB_ENDIAN",
+        cflags           => combine(picker(default => "-mlp64",
                                            debug   => "-O0 -g",
                                            release => "-O3"),
                                     threads("-pthread")),
+        cppflags         => "-DB_DEBIAN",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
@@ -565,7 +576,9 @@ my %targets = (
     "MPE/iX-gcc" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "gcc",
-        cflags           => "-D_ENDIAN -DBN_DIV2W -O3 -D_POSIX_SOURCE -D_SOCKET_SOURCE -I/SYSLOG/PUB",
+        cflags           => "-O3",
+        cppflags         => "-D_ENDIAN -DBN_DIV2W -D_POSIX_SOURCE -D_SOCKET_SOURCE",
+        includes         => [ "/SYSLOG/PUB" ],
         sys_id           => "MPE",
         lflags           => add("-L/SYSLOG/PUB"),
         ex_libs          => add("-lsyslog -lsocket -lcurses"),
@@ -580,8 +593,8 @@ my %targets = (
     "tru64-alpha-gcc" => {
         inherit_from     => [ "BASE_unix", asm("alpha_asm") ],
         cc               => "gcc",
-        cflags           => combine("-std=c9x -D_XOPEN_SOURCE=500 -D_OSF_SOURCE -O3",
-                                    threads("-pthread")),
+        cflags           => combine("-std=c9x -O3", threads("-pthread")),
+        cppflags         => "-D_XOPEN_SOURCE=500 -D_OSF_SOURCE",
         ex_libs          => add("-lrt", threads("-pthread")), # for mlock(2)
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
@@ -592,8 +605,9 @@ my %targets = (
     "tru64-alpha-cc" => {
         inherit_from     => [ "BASE_unix", asm("alpha_asm") ],
         cc               => "cc",
-        cflags           => combine("-std1 -D_XOPEN_SOURCE=500 -D_OSF_SOURCE -tune host -fast -readonly_strings",
+        cflags           => combine("-std1 -tune host -fast -readonly_strings",
                                     threads("-pthread")),
+        cppflags         => "-D_XOPEN_SOURCE=500 -D_OSF_SOURCE",
         ex_libs          => add("-lrt", threads("-pthread")), # for mlock(2)
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
@@ -616,12 +630,13 @@ my %targets = (
                                            debug   => "-O0 -g",
                                            release => "-O3"),
                                     threads("-pthread")),
+        cppflags         => "-DOPENSSL_USE_NODELETE",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",
-        shared_cflag     => "-fPIC -DOPENSSL_USE_NODELETE",
+        shared_cflag     => "-fPIC",
         shared_ldflag    => "-Wl,-znodelete",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
@@ -636,13 +651,15 @@ my %targets = (
     },
     "linux-ppc64" => {
         inherit_from     => [ "linux-generic64", asm("ppc64_asm") ],
-        cflags           => add("-m64 -DB_ENDIAN"),
+        cflags           => add("-m64"),
+        cppflags         => add("-DB_ENDIAN"),
         perlasm_scheme   => "linux64",
         multilib         => "64",
     },
     "linux-ppc64le" => {
         inherit_from     => [ "linux-generic64", asm("ppc64_asm") ],
-        cflags           => add("-m64 -DL_ENDIAN"),
+        cflags           => add("-m64"),
+        cppflags         => add("-DL_ENDIAN"),
         perlasm_scheme   => "linux64le",
     },
 
@@ -696,21 +713,24 @@ my %targets = (
         # Configure script adds minimally required -march for assembly
         # support, if no -march was specified at command line.
         inherit_from     => [ "linux-generic32", asm("mips32_asm") ],
-        cflags           => add("-mabi=32 -DBN_DIV3W"),
+        cflags           => add("-mabi=32"),
+        cppflags         => add("-DBN_DIV3W"),
         perlasm_scheme   => "o32",
     },
     # mips32 and mips64 below refer to contemporary MIPS Architecture
     # specifications, MIPS32 and MIPS64, rather than to kernel bitness.
     "linux-mips64" => {
         inherit_from     => [ "linux-generic32", asm("mips64_asm") ],
-        cflags           => add("-mabi=n32 -DBN_DIV3W"),
+        cflags           => add("-mabi=n32"),
+        cppflags         => add("-DBN_DIV3W"),
         bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR",
         perlasm_scheme   => "n32",
         multilib         => "32",
     },
     "linux64-mips64" => {
         inherit_from     => [ "linux-generic64", asm("mips64_asm") ],
-        cflags           => add("-mabi=64 -DBN_DIV3W"),
+        cflags           => add("-mabi=64"),
+        cppflags         => add("-DBN_DIV3W"),
         perlasm_scheme   => "64",
         multilib         => "64",
     },
@@ -720,16 +740,17 @@ my %targets = (
     #### machines where gcc doesn't understand -m32 and -m64
     "linux-elf" => {
         inherit_from     => [ "linux-generic32", asm("x86_elf_asm") ],
-        cflags           => add(picker(default => "-DL_ENDIAN",
-                                       release => "-fomit-frame-pointer")),
+        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
     },
     "linux-aout" => {
         inherit_from     => [ "BASE_unix", asm("x86_asm") ],
         cc               => "gcc",
-        cflags           => add(picker(default => "-DL_ENDIAN -Wall",
+        cflags           => add(picker(default => "-Wall",
                                        debug   => "-O0 -g",
                                        release => "-O3 -fomit-frame-pointer")),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "(unknown)",
         perlasm_scheme   => "a.out",
@@ -738,8 +759,9 @@ my %targets = (
     #### X86 / X86_64 targets
     "linux-x86" => {
         inherit_from     => [ "linux-generic32", asm("x86_asm") ],
-        cflags           => add(picker(default => "-m32 -DL_ENDIAN",
+        cflags           => add(picker(default => "-m32",
                                        release => "-fomit-frame-pointer")),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
         perlasm_scheme   => "elf",
     },
@@ -751,7 +773,8 @@ my %targets = (
     },
     "linux-x86_64" => {
         inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
-        cflags           => add("-m64 -DL_ENDIAN"),
+        cflags           => add("-m64"),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "elf",
         multilib         => "64",
@@ -764,7 +787,8 @@ my %targets = (
     },
     "linux-x32" => {
         inherit_from     => [ "linux-generic32", asm("x86_64_asm") ],
-        cflags           => add("-mx32 -DL_ENDIAN"),
+        cflags           => add("-mx32"),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT",
         perlasm_scheme   => "elf32",
         multilib         => "x32",
@@ -777,7 +801,8 @@ my %targets = (
 
     "linux64-s390x" => {
         inherit_from     => [ "linux-generic64", asm("s390x_asm") ],
-        cflags           => add("-m64 -DB_ENDIAN"),
+        cflags           => add("-m64"),
+        cppflags         => add("-DB_ENDIAN"),
         perlasm_scheme   => "64",
         multilib         => "64",
     },
@@ -799,7 +824,8 @@ my %targets = (
         # sysdeps/s390/dl-procinfo.c affecting ldconfig and ld.so.1...
         #
         inherit_from     => [ "linux-generic32", asm("s390x_asm") ],
-        cflags           => add("-m31 -Wa,-mzarch -DB_ENDIAN"),
+        cflags           => add("-m31 -Wa,-mzarch"),
+        cppflags         => add("-DB_ENDIAN"),
         bn_asm_src       => sub { my $r=join(" ",@_); $r=~s|asm/s390x\.S|bn_asm.c|; $r; },
         perlasm_scheme   => "31",
         multilib         => "/highgprs",
@@ -808,32 +834,36 @@ my %targets = (
     #### SPARC Linux setups
     "linux-sparcv8" => {
         inherit_from     => [ "linux-generic32", asm("sparcv8_asm") ],
-        cflags           => add("-mcpu=v8 -DB_ENDIAN -DBN_DIV2W"),
+        cflags           => add("-mcpu=v8"),
+        cppflags         => add("-DB_ENDIAN -DBN_DIV2W"),
     },
     "linux-sparcv9" => {
         # it's a real mess with -mcpu=ultrasparc option under Linux,
         # but -Wa,-Av8plus should do the trick no matter what.
         inherit_from     => [ "linux-generic32", asm("sparcv9_asm") ],
-        cflags           => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus -DB_ENDIAN -DBN_DIV2W"),
+        cflags           => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus"),
+        cppflags         => add("-DB_ENDIAN -DBN_DIV2W"),
     },
     "linux64-sparcv9" => {
         # GCC 3.1 is a requirement
         inherit_from     => [ "linux-generic64", asm("sparcv9_asm") ],
-        cflags           => add("-m64 -mcpu=ultrasparc -DB_ENDIAN"),
+        cflags           => add("-m64 -mcpu=ultrasparc"),
+        cppflags         => add("-DB_ENDIAN"),
         bn_ops           => "BN_LLONG RC4_CHAR",
         multilib         => "64",
     },
 
     "linux-alpha-gcc" => {
         inherit_from     => [ "linux-generic64", asm("alpha_asm") ],
-        cflags           => add("-DL_ENDIAN"),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
     },
     "linux-c64xplus" => {
         inherit_from     => [ "BASE_unix" ],
         # TI_CGT_C6000_7.3.x is a requirement
         cc               => "cl6x",
-        cflags           => combine("--linux -ea=.s -eo=.o -mv6400+ -o2 -ox -ms -pden -DOPENSSL_SMALL_FOOTPRINT",
+        cflags           => "--linux -ea=.s -eo=.o -mv6400+ -o2 -ox -ms -pden",
+        cppflags         => combine("-DOPENSSL_SMALL_FOOTPRINT",
                                     threads("-D_REENTRANT")),
         bn_ops           => "BN_LLONG",
         cpuid_asm_src    => "c64xpluscpuid.s",
@@ -959,7 +989,8 @@ my %targets = (
         cflags           => combine(picker(default => "-Wall",
                                            debug   => "-O0 -g",
                                            release => "-O3"),
-                                    threads("-pthread -D_THREAD_SAFE -D_REENTRANT")),
+                                    threads("-pthread")),
+        cppflags         => threads("-D_THREAD_SAFE -D_REENTRANT"),
         ex_libs          => add(threads("-pthread")),
         enable           => add("devcryptoeng"),
         bn_ops           => "BN_LLONG",
@@ -976,8 +1007,8 @@ my %targets = (
 
     "BSD-x86" => {
         inherit_from     => [ "BSD-generic32", asm("x86_asm") ],
-        cflags           => add(picker(default => "-DL_ENDIAN",
-                                       release => "-fomit-frame-pointer")),
+        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
         shared_target    => "bsd-shared",
         perlasm_scheme   => "a.out",
@@ -989,26 +1020,27 @@ my %targets = (
 
     "BSD-sparcv8" => {
         inherit_from     => [ "BSD-generic32", asm("sparcv8_asm") ],
-        cflags           => add("-mcpu=v8 -DB_ENDIAN"),
+        cflags           => add("-mcpu=v8"),
+        cppflags         => add("-DB_ENDIAN"),
     },
     "BSD-sparc64" => {
         # -DMD32_REG_T=int doesn't actually belong in sparc64 target, it
         # simply *happens* to work around a compiler bug in gcc 3.3.3,
         # triggered by RIPEMD160 code.
         inherit_from     => [ "BSD-generic64", asm("sparcv9_asm") ],
-        cflags           => add("-DB_ENDIAN -DMD32_REG_T=int"),
+        cppflags         => add("-DB_ENDIAN -DMD32_REG_T=int"),
         bn_ops           => "BN_LLONG",
     },
 
     "BSD-ia64" => {
         inherit_from     => [ "BSD-generic64", asm("ia64_asm") ],
-        cflags           => add_before("-DL_ENDIAN"),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
     },
 
     "BSD-x86_64" => {
         inherit_from     => [ "BSD-generic64", asm("x86_64_asm") ],
-        cflags           => add_before("-DL_ENDIAN"),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "elf",
     },
@@ -1016,7 +1048,8 @@ my %targets = (
     "bsdi-elf-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
         cc               => "gcc",
-        cflags           => "-DPERL5 -DL_ENDIAN -fomit-frame-pointer -O3 -Wall",
+        cflags           => "-fomit-frame-pointer -O3 -Wall",
+        cppflags         => "-DPERL5 -DL_ENDIAN",
         ex_libs          => add("-ldl"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "(unknown)",
@@ -1047,7 +1080,8 @@ my %targets = (
     "qnx4" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
-        cflags           => "-DL_ENDIAN -DTERMIO",
+        cflags           => "",
+        cppflags         => "-DL_ENDIAN -DTERMIO",
         thread_scheme    => "(unknown)",
     },
     "QNX6" => {
@@ -1062,7 +1096,8 @@ my %targets = (
     "QNX6-i386" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
         cc               => "gcc",
-        cflags           => "-DL_ENDIAN -O2 -Wall",
+        cflags           => "-O2 -Wall",
+        cppflags         => "-DL_ENDIAN",
         ex_libs          => add("-lsocket"),
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
@@ -1084,24 +1119,24 @@ my %targets = (
     "unixware-2.0" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
-        cflags           => combine("-DFILIO_H -DNO_STRINGS_H",
-                                    threads("-Kthread")),
+        cflags           => combine(threads("-Kthread")),
+        cppflags         => "-DFILIO_H -DNO_STRINGS_H",
         ex_libs          => add("-lsocket -lnsl -lresolv -lx"),
         thread_scheme    => "uithreads",
     },
     "unixware-2.1" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
-        cflags           => combine("-O -DFILIO_H",
-                                    threads("-Kthread")),
+        cflags           => combine("-O", threads("-Kthread")),
+        cppflags         => "-DFILIO_H",
         ex_libs          => add("-lsocket -lnsl -lresolv -lx"),
         thread_scheme    => "uithreads",
     },
     "unixware-7" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
         cc               => "cc",
-        cflags           => combine("-O -DFILIO_H -Kalloca",
-                                    threads("-Kthread")),
+        cflags           => combine("-O -Kalloca", threads("-Kthread")),
+        cppflags         => "-DFILIO_H",
         ex_libs          => add("-lsocket -lnsl"),
         thread_scheme    => "uithreads",
         bn_ops           => "BN_LLONG",
@@ -1114,8 +1149,9 @@ my %targets = (
     "unixware-7-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
         cc               => "gcc",
-        cflags           => combine("-DL_ENDIAN -DFILIO_H -O3 -fomit-frame-pointer -Wall",
-                                    threads("-D_REENTRANT")),
+        cflags           => combine("-O3 -fomit-frame-pointer -Wall"),
+        cppflags         => add("-DL_ENDIAN -DFILIO_H",
+                                threads("-D_REENTRANT")),
         ex_libs          => add("-lsocket -lnsl"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
@@ -1161,10 +1197,10 @@ my %targets = (
     "aix-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-DB_ENDIAN",
-                                           debug   => "-O0 -g",
+        cflags           => combine(picker(debug   => "-O0 -g",
                                            release => "-O"),
                                     threads("-pthread")),
+        cppflags         => "-DB_ENDIAN",
         ex_libs          => add(threads("-pthread")),
         sys_id           => "AIX",
         bn_ops           => "BN_LLONG RC4_CHAR",
@@ -1179,10 +1215,11 @@ my %targets = (
     "aix64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-maix64 -DB_ENDIAN",
+        cflags           => combine(picker(default => "-maix64",
                                            debug   => "-O0 -g",
                                            release => "-O"),
                                     threads("-pthread")),
+        cppflags         => "-DB_ENDIAN",
         ex_libs          => add(threads("-pthread")),
         sys_id           => "AIX",
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
@@ -1197,10 +1234,11 @@ my %targets = (
     "aix-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "-q32 -DB_ENDIAN -qmaxmem=16384 -qro -qroconst",
+        cflags           => combine(picker(default => "-q32 -qmaxmem=16384 -qro -qroconst",
                                            debug   => "-O0 -g",
                                            release => "-O"),
-                                    threads("-qthreaded -D_THREAD_SAFE")),
+                                    threads("-qthreaded")),
+        cppflags         => combine("-DB_ENDIAN", threads("-D_THREAD_SAFE")),
         sys_id           => "AIX",
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",
@@ -1215,10 +1253,11 @@ my %targets = (
     "aix64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
         cc               => "cc",
-        cflags           => combine(picker(default => "-q64 -DB_ENDIAN -qmaxmem=16384 -qro -qroconst",
+        cflags           => combine(picker(default => "-q64 -qmaxmem=16384 -qro -qroconst",
                                            debug   => "-O0 -g",
                                            release => "-O"),
-                                    threads("-qthreaded -D_THREAD_SAFE")),
+                                    threads("-qthreaded")),
+        cppflags         => combine("-DB_ENDIAN", threads("-D_THREAD_SAFE")),
         sys_id           => "AIX",
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         thread_scheme    => "pthreads",
@@ -1235,7 +1274,8 @@ my %targets = (
     "BS2000-OSD" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "c89",
-        cflags           => "-O -XLLML -XLLMK -XL -DB_ENDIAN -DCHARSET_EBCDIC",
+        cflags           => "-O -XLLML -XLLMK -XL",
+        cppflags         => "-DB_ENDIAN -DCHARSET_EBCDIC",
         ex_libs          => add("-lsocket -lnsl"),
         bn_ops           => "THIRTY_TWO_BIT RC4_CHAR",
         thread_scheme    => "(unknown)",
@@ -1256,8 +1296,11 @@ my %targets = (
         inherit_from     => [ "BASE_Windows" ],
         template         => 1,
         cc               => "cl",
-        cflags           => "-W3 -wd4090 -Gs0 -GF -Gy -nologo -DOPENSSL_SYS_WIN32 -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -D_CRT_SECURE_NO_DEPRECATE -D_WINSOCK_DEPRECATED_NO_WARNINGS",
-        defines          => add(sub { my @defs = ();
+        cflags           => "-W3 -wd4090 -Gs0 -GF -Gy -nologo",
+        defines          => add("OPENSSL_SYS_WIN32", "WIN32_LEAN_AND_MEAN",
+                                "L_ENDIAN", "_CRT_SECURE_NO_DEPRECATE",
+                                "_WINSOCK_DEPRECATED_NO_WARNINGS",
+                                sub { my @defs = ();
                                       unless ($disabled{"zlib-dynamic"}) {
                                           my $zlib =
                                               $withargs{zlib_lib} // "ZLIB1";
@@ -1266,7 +1309,7 @@ my %targets = (
                                                       'LIBZ="' . $zlib . '"');
                                       }
                                       return [ @defs ];
-                                    }),
+                                  }),
         coutflag         => "/Fo",
         lib_cflags       => add("/Zi /Fdossl_static"),
         dso_cflags       => "/Zi /Fddso",
@@ -1281,17 +1324,18 @@ my %targets = (
     "VC-noCE-common" => {
         inherit_from     => [ "VC-common" ],
         template         => 1,
-        cflags           => add(picker(default => "-DUNICODE -D_UNICODE",
-                                       debug   =>
+        cflags           => add(picker(debug   =>
                                        sub {
                                            ($disabled{shared} ? "" : "/MDd")
-                                               ." /Od -DDEBUG -D_DEBUG";
+                                               ." /Od";
                                        },
                                        release =>
                                        sub {
                                            ($disabled{shared} ? "" : "/MD")
                                                ." /O2";
                                        })),
+        defines          => add(picker(default => [ "UNICODE", "_UNICODE" ],
+                                       debug   => [ "DEBUG", "_DEBUG" ])),
         lib_cflags       => add(sub { $disabled{shared} ? "/MT /Zl" : () }),
         # Following might/should appears controversial, i.e. defining
         # /MDd without evaluating $disabled{shared}. It works in
@@ -1380,17 +1424,24 @@ my %targets = (
         cc               => "cl",
         cflags           =>
             picker(default =>
-                   combine('/W3 /WX /GF /Gy /nologo -DUNICODE -D_UNICODE -DOPENSSL_SYS_WINCE -DWIN32_LEAN_AND_MEAN -DL_ENDIAN -DDSO_WIN32 -DNO_CHMOD -DOPENSSL_SMALL_FOOTPRINT',
+                   combine('/W3 /WX /GF /Gy /nologo',
                            sub { vc_wince_info()->{cflags}; },
-                           sub { defined(env('WCECOMPAT'))
-                                     ? '-I$(WCECOMPAT)/include' : (); },
-                           sub { defined(env('PORTSDK_LIBPATH'))
-                                     ? '-I$(PORTSDK_LIBPATH)/../../include' : (); },
                            sub { `cl 2>&1` =~ /Version ([0-9]+)\./ && $1>=14
                                      ? ($disabled{shared} ? " /MT" : " /MD")
                                      : " /MC"; }),
-                   debug   => "/Od -DDEBUG -D_DEBUG",
+                   debug   => "/Od",
                    release => "/O1i"),
+        cppflags         => sub { vc_wince_info()->{defines}; },
+        defines          =>
+            picker(default => [ "UNICODE", "_UNICODE", "OPENSSL_SYS_WINCE",
+                                "WIN32_LEAN_AND_MEAN", "L_ENDIAN", "DSO_WIN32",
+                                "NO_CHMOD", "OPENSSL_SMALL_FOOTPRINT" ],
+                   debug   => [ "DEBUG", "_DEBUG" ]),
+        includes         =>
+            combine(sub { defined(env('WCECOMPAT'))
+                          ? '$(WCECOMPAT)/include' : (); },
+                    sub { defined(env('PORTSDK_LIBPATH'))
+                          ? '$(PORTSDK_LIBPATH)/../../include' : (); }),
         lflags           => add(combine("/nologo /opt:ref",
                                         sub { vc_wince_info()->{lflags}; },
                                         sub { defined(env('PORTSDK_LIBPATH'))
@@ -1424,10 +1475,11 @@ my %targets = (
         inherit_from     => [ "BASE_unix", asm("x86_asm"),
                               sub { $disabled{shared} ? () : "x86_uplink" } ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-DL_ENDIAN -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE -m32 -Wall",
-                                           debug   => "-g -O0",
-                                           release => "-O3 -fomit-frame-pointer"),
-                                    threads("-D_MT")),
+        cflags           => picker(default => "-m32 -Wall",
+                                   debug   => "-g -O0",
+                                   release => "-O3 -fomit-frame-pointer"),
+        cppflags         => combine("-DL_ENDIAN -DWIN32_LEAN_AND_MEAN",
+                                    "-DUNICODE -D_UNICODE", threads("-D_MT")),
         sys_id           => "MINGW32",
         ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
         bn_ops           => "BN_LLONG EXPORT_VAR_AS_FN",
@@ -1435,7 +1487,7 @@ my %targets = (
         perlasm_scheme   => "coff",
         dso_scheme       => "win32",
         shared_target    => "mingw-shared",
-        shared_cflag     => add("-D_WINDLL"),
+        shared_cppflags  => add("_WINDLL"),
         shared_ldflag    => "-static-libgcc",
         shared_rcflag    => "--target=pe-i386",
         shared_extension => ".dll",
@@ -1453,10 +1505,11 @@ my %targets = (
         # Applink is never engaged and can as well be omitted.
         inherit_from     => [ "BASE_unix", asm("x86_64_asm") ],
         cc               => "gcc",
-        cflags           => combine(picker(default => "-DL_ENDIAN -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE -m64 -Wall",
-                                           debug   => "-g -O0",
-                                           release => "-O3"),
-                                    threads("-D_MT")),
+        cflags           => picker(default => "-m64 -Wall",
+                                   debug   => "-g -O0",
+                                   release => "-O3"),
+        cppflags         => combine("-DL_ENDIAN -DWIN32_LEAN_AND_MEAN",
+                                    "-DUNICODE -D_UNICODE", threads("-D_MT")),
         sys_id           => "MINGW64",
         ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
         bn_ops           => "SIXTY_FOUR_BIT EXPORT_VAR_AS_FN",
@@ -1464,7 +1517,7 @@ my %targets = (
         perlasm_scheme   => "mingw64",
         dso_scheme       => "win32",
         shared_target    => "mingw-shared",
-        shared_cflag     => add("-D_WINDLL"),
+        shared_cppflags  => add("_WINDLL"),
         shared_ldflag    => "-static-libgcc",
         shared_rcflag    => "--target=pe-x86-64",
         shared_extension => ".dll",
@@ -1476,7 +1529,8 @@ my %targets = (
     "UEFI" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
-        cflags           => "-DL_ENDIAN -O",
+        cflags           => "-O",
+        cppflags         => "-DL_ENDIAN",
         sys_id           => "UEFI",
     },
 
@@ -1484,7 +1538,8 @@ my %targets = (
     "UWIN" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
-        cflags           => "-DTERMIOS -DL_ENDIAN -O -Wall",
+        cflags           => "-O -Wall",
+        cppflags         => "-DTERMIOS -DL_ENDIAN",
         sys_id           => "UWIN",
         bn_ops           => "BN_LLONG",
         dso_scheme       => "win32",
@@ -1494,31 +1549,33 @@ my %targets = (
     "Cygwin-x86" => {
         inherit_from     => [ "BASE_unix", asm("x86_asm") ],
         cc               => "gcc",
-        cflags           => picker(default => "-DTERMIOS -DL_ENDIAN -Wall",
+        cflags           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3 -fomit-frame-pointer"),
+        cppflags         => "-DTERMIOS -DL_ENDIAN",
         sys_id           => "CYGWIN",
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthread",
         perlasm_scheme   => "coff",
         dso_scheme       => "dlfcn",
         shared_target    => "cygwin-shared",
-        shared_cflag     => "-D_WINDLL",
+        shared_cppflags  => "-D_WINDLL",
         shared_extension => ".dll",
     },
     "Cygwin-x86_64" => {
         inherit_from     => [ "BASE_unix", asm("x86_64_asm") ],
         cc               => "gcc",
-        cflags           => picker(default => "-DTERMIOS -DL_ENDIAN -Wall",
+        cflags           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3"),
+        cppflags         => "-DTERMIOS -DL_ENDIAN",
         sys_id           => "CYGWIN",
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthread",
         perlasm_scheme   => "mingw64",
         dso_scheme       => "dlfcn",
         shared_target    => "cygwin-shared",
-        shared_cflag     => "-D_WINDLL",
+        shared_cppflags  => "-D_WINDLL",
         shared_extension => ".dll",
     },
     # Backward compatibility for those using this target
@@ -1544,10 +1601,10 @@ my %targets = (
         inherit_from     => [ "BASE_unix" ],
         template         => 1,
         cc               => "cc",
-        cflags           => combine(picker(default => "",
-                                           debug   => "-g -O0",
-                                           release => "-O3"),
-                                   threads("-D_REENTRANT")),
+        cflags           => picker(default => "",
+                                   debug   => "-g -O0",
+                                   release => "-O3"),
+        cppflags         => threads("-D_REENTRANT"),
         sys_id           => "MACOSX",
         plib_lflags      => "-Wl,-search_paths_first",
         bn_ops           => "BN_LLONG RC4_CHAR",
@@ -1564,25 +1621,29 @@ my %targets = (
     # for PPC has no future, it was discontinued by vendor in 2009.
     "darwin-ppc-cc" => {
         inherit_from     => [ "darwin-common", asm("ppc32_asm") ],
-        cflags           => add("-arch ppc -std=gnu9x -DB_ENDIAN -Wa,-force_cpusubtype_ALL"),
+        cflags           => add("-arch ppc -std=gnu9x -Wa,-force_cpusubtype_ALL"),
+        cppflags         => add("-DB_ENDIAN"),
         perlasm_scheme   => "osx32",
     },
     "darwin64-ppc-cc" => {
         inherit_from     => [ "darwin-common", asm("ppc64_asm") ],
-        cflags           => add("-arch ppc64 -std=gnu9x -DB_ENDIAN"),
+        cflags           => add("-arch ppc64 -std=gnu9x"),
+        cppflags         => add("-DB_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         perlasm_scheme   => "osx64",
     },
     "darwin-i386-cc" => {
         inherit_from     => [ "darwin-common", asm("x86_asm") ],
-        cflags           => add(picker(default => "-arch i386 -DL_ENDIAN",
+        cflags           => add(picker(default => "-arch i386",
                                        release => "-fomit-frame-pointer")),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG RC4_INT",
         perlasm_scheme   => "macosx",
     },
     "darwin64-x86_64-cc" => {
         inherit_from     => [ "darwin-common", asm("x86_64_asm") ],
-        cflags           => add("-arch x86_64 -DL_ENDIAN -Wall"),
+        cflags           => add("-arch x86_64 -Wall"),
+        cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "macosx",
     },
@@ -1629,8 +1690,9 @@ my %targets = (
         inherit_from     => [ "BASE_unix" ],
         inherit_from     => [ asm("x86_elf_asm") ],
         cc               => "gcc",
-        cflags           => combine("-DL_ENDIAN -O3 -fomit-frame-pointer -Wall",
+        cflags           => combine("-O3 -fomit-frame-pointer -Wall",
                                     threads("-pthread")),
+        cppflags         => "-DL_ENDIAN",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
@@ -1644,7 +1706,11 @@ my %targets = (
     "vxworks-ppc60x" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccppc",
-        cflags           => "-D_REENTRANT -mrtp -mhard-float -mstrict-align -fno-implicit-fp -DPPC32_fp60x -O2 -fstrength-reduce -fno-builtin -fno-strict-aliasing -Wall -DCPU=PPC32 -DTOOL_FAMILY=gnu -DTOOL=gnu -I\$(WIND_BASE)/target/usr/h -I\$(WIND_BASE)/target/usr/h/wrn/coreip",
+        cflags           => "-mrtp -mhard-float -mstrict-align -fno-implicit-fp -O2 -fstrength-reduce -fno-builtin -fno-strict-aliasing -Wall",
+        cppflags         => combine("-D_REENTRANT -DPPC32_fp60x -DCPU=PPC32",
+                                    "_DTOOL_FAMILY=gnu -DTOOL=gnu",
+                                    "-I\$(WIND_BASE)/target/usr/h",
+                                    "-I\$(WIND_BASE)/target/usr/h/wrn/coreip"),
         sys_id           => "VXWORKS",
         lflags           => add("-L \$(WIND_BASE)/target/usr/lib/ppc/PPC32/common"),
         ex_libs          => add("-Wl,--defsym,__wrs_rtp_base=0xe0000000"),
@@ -1652,7 +1718,11 @@ my %targets = (
     "vxworks-ppcgen" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccppc",
-        cflags           => "-D_REENTRANT -mrtp -msoft-float -mstrict-align -O1 -fno-builtin -fno-strict-aliasing -Wall -DCPU=PPC32 -DTOOL_FAMILY=gnu -DTOOL=gnu -I\$(WIND_BASE)/target/usr/h -I\$(WIND_BASE)/target/usr/h/wrn/coreip",
+        cflags           => "-mrtp -msoft-float -mstrict-align -O1 -fno-builtin -fno-strict-aliasing -Wall",
+        cppflags         => combine("-D_REENTRANT -DPPC32 -DCPU=PPC32",
+                                    "-DTOOL_FAMILY=gnu -DTOOL=gnu",
+                                    "-I\$(WIND_BASE)/target/usr/h",
+                                    "-I\$(WIND_BASE)/target/usr/h/wrn/coreip"),
         sys_id           => "VXWORKS",
         lflags           => add("-L \$(WIND_BASE)/target/usr/lib/ppc/PPC32/sfcommon"),
         ex_libs          => add("-Wl,--defsym,__wrs_rtp_base=0xe0000000"),
@@ -1660,35 +1730,51 @@ my %targets = (
     "vxworks-ppc405" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccppc",
-        cflags           => "-g -msoft-float -mlongcall -DCPU=PPC405 -I\$(WIND_BASE)/target/h",
+        cflags           => "-g -msoft-float -mlongcall",
+        cppflags         => combine("-D_REENTRANT -DPPC32 -DCPU=PPC405",
+                                    "-DTOOL_FAMILY=gnu -DTOOL=gnu",
+                                    "-I\$(WIND_BASE)/target/h"),
         sys_id           => "VXWORKS",
         lflags           => add("-r"),
     },
     "vxworks-ppc750" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccppc",
-        cflags           => "-ansi -nostdinc -DPPC750 -D_REENTRANT -fvolatile -fno-builtin -fno-for-scope -fsigned-char -Wall -msoft-float -mlongcall -DCPU=PPC604 -I\$(WIND_BASE)/target/h \$(DEBUG_FLAG)",
+        cflags           => "-ansi -nostdinc -fvolatile -fno-builtin -fno-for-scope -fsigned-char -Wall -msoft-float -mlongcall \$(DEBUG_FLAG)",
+        cppflags         => combine("-DPPC750 -D_REENTRANT -DCPU=PPC604",
+                                    "-I\$(WIND_BASE)/target/h"),
         sys_id           => "VXWORKS",
         lflags           => add("-r"),
     },
     "vxworks-ppc750-debug" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccppc",
-        cflags           => "-ansi -nostdinc -DPPC750 -D_REENTRANT -fvolatile -fno-builtin -fno-for-scope -fsigned-char -Wall -msoft-float -mlongcall -DCPU=PPC604 -I\$(WIND_BASE)/target/h -DPEDANTIC -DDEBUG -g",
+        cflags           => "-ansi -nostdinc -fvolatile -fno-builtin -fno-for-scope -fsigned-char -Wall -msoft-float -mlongcall -g",
+        cppflags         => combine("-DPPC750 -D_REENTRANT -DCPU=PPC604",
+                                    "-DPEDANTIC -DDEBUG",
+                                    "-I\$(WIND_BASE)/target/h"),
         sys_id           => "VXWORKS",
         lflags           => add("-r"),
     },
     "vxworks-ppc860" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccppc",
-        cflags           => "-nostdinc -msoft-float -DCPU=PPC860 -DNO_STRINGS_H -I\$(WIND_BASE)/target/h",
+        cflags           => "-nostdinc -msoft-float",
+        cppflags         => combine("-DCPU=PPC860 -DNO_STRINGS_H",
+                                    "-I\$(WIND_BASE)/target/h"),
         sys_id           => "VXWORKS",
         lflags           => add("-r"),
     },
     "vxworks-simlinux" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => "ccpentium",
-        cflags           => "-B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -D_VSB_CONFIG_FILE=\"\$(WIND_BASE)/target/lib/h/config/vsbConfig.h\" -DL_ENDIAN -DCPU=SIMLINUX -DTOOL_FAMILY=gnu -DTOOL=gnu -fno-builtin -fno-defer-pop -DNO_STRINGS_H -I\$(WIND_BASE)/target/h -I\$(WIND_BASE)/target/h/wrn/coreip -DOPENSSL_NO_HW_PADLOCK",
+        cflags           => "-B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -fno-builtin -fno-defer-pop",
+        cppflags         => combine("-D_VSB_CONFIG_FILE=\"\$(WIND_BASE)/target/lib/h/config/vsbConfig.h\"",
+                                    "-DL_ENDIAN -DCPU=SIMLINUX -DNO_STRINGS_H",
+                                    "-DTOOL_FAMILY=gnu -DTOOL=gnu",
+                                    "-DOPENSSL_NO_HW_PADLOCK",
+                                    "-I\$(WIND_BASE)/target/h",
+                                    "-I\$(WIND_BASE)/target/h/wrn/coreip"),
         sys_id           => "VXWORKS",
         lflags           => add("-r"),
         ranlib           => "ranlibpentium",
@@ -1696,8 +1782,14 @@ my %targets = (
     "vxworks-mips" => {
         inherit_from     => [ "BASE_unix", asm("mips32_asm") ],
         cc               => "ccmips",
-        cflags           => combine("-mrtp -mips2 -O -G 0 -B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -D_VSB_CONFIG_FILE=\"\$(WIND_BASE)/target/lib/h/config/vsbConfig.h\" -DCPU=MIPS32 -msoft-float -mno-branch-likely -DTOOL_FAMILY=gnu -DTOOL=gnu -fno-builtin -fno-defer-pop -DNO_STRINGS_H -I\$(WIND_BASE)/target/usr/h -I\$(WIND_BASE)/target/h/wrn/coreip",
-                                    threads("-D_REENTRANT")),
+        cflags           => "-mrtp -mips2 -O -G 0 -B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -msoft-float -mno-branch-likely -fno-builtin -fno-defer-pop",
+        cppflags         => combine("-D_VSB_CONFIG_FILE=\"\$(WIND_BASE)/target/lib/h/config/vsbConfig.h\"",
+                                    "-DCPU=MIPS32 -DNO_STRINGS_H",
+                                    "-DTOOL_FAMILY=gnu -DTOOL=gnu",
+                                    "-DOPENSSL_NO_HW_PADLOCK",
+                                    threads("-D_REENTRANT"),
+                                    "-I\$(WIND_BASE)/target/h",
+                                    "-I\$(WIND_BASE)/target/h/wrn/coreip"),
         sys_id           => "VXWORKS",
         lflags           => add("-L \$(WIND_BASE)/target/usr/lib/mips/MIPSI32/sfcommon"),
         ex_libs          => add("-Wl,--defsym,__wrs_rtp_base=0xe0000000"),
@@ -1710,7 +1802,7 @@ my %targets = (
     "uClinux-dist" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => sub { env('CC') },
-        cflags           => combine(threads("-D_REENTRANT")),
+        cppflags         => threads("-D_REENTRANT"),
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
@@ -1723,7 +1815,7 @@ my %targets = (
     "uClinux-dist64" => {
         inherit_from     => [ "BASE_unix" ],
         cc               => sub { env('CC') },
-        cflags           => combine(threads("-D_REENTRANT")),
+        cppflags         => threads("-D_REENTRANT"),
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -148,6 +148,7 @@ my %targets = (
 
 #### Basic configs that should work on any 32-bit box
     "gcc" => {
+        inherit_from     => [ "BASE_unix" ],
         cc               => "gcc",
         cflags           => picker(debug   => "-O0 -g",
                                    release => "-O3"),
@@ -155,6 +156,7 @@ my %targets = (
         bn_ops           => "BN_LLONG",
     },
     "cc" => {
+        inherit_from     => [ "BASE_unix" ],
         cc               => "cc",
         cflags           => "-O",
         thread_scheme    => "(unknown)",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1408,7 +1408,7 @@ my %targets = (
             # WIN32 UNICODE build gets linked with unicows.lib for
             # backward compatibility with Win9x.
             push @ex_libs, 'unicows.lib'
-                if (grep { $_ eq "UNICODE" } @user_defines);
+                if (grep { $_ eq "UNICODE" } @{$user{CPPDEFINES}});
             return join(" ", @ex_libs, @_);
         }),
         sys_id           => "WIN32",

--- a/Configurations/90-team.conf
+++ b/Configurations/90-team.conf
@@ -3,18 +3,20 @@
 
 my %targets = (
     "purify" => {
+        inherit_from     => [ 'BASE_unix' ],
         cc               => "purify gcc",
         cflags           => "-g -Wall",
         thread_scheme    => "(unknown)",
         ex_libs          => add(" ","-lsocket -lnsl"),
     },
     "debug" => {
+        inherit_from     => [ 'BASE_unix' ],
         cc               => "gcc",
         cflags           => "-DBN_DEBUG -DREF_DEBUG -DCONF_DEBUG -DBN_CTX_DEBUG -DOPENSSL_NO_ASM -ggdb -g2 -Wformat -Wshadow -Wmissing-prototypes -Wmissing-declarations -Werror",
         thread_scheme    => "(unknown)",
     },
     "debug-erbridge" => {
-        inherit_from     => [ "x86_64_asm" ],
+        inherit_from     => [ 'BASE_unix', "x86_64_asm" ],
         cc               => "gcc",
         cflags           => combine("$gcc_devteam_warn -DBN_DEBUG -DCONF_DEBUG -m64 -DL_ENDIAN -DTERMIO -g",
                                     threads("-D_REENTRANT")),
@@ -30,7 +32,7 @@ my %targets = (
         multilib         => "64",
     },
     "debug-linux-pentium" => {
-        inherit_from     => [ "x86_elf_asm" ],
+        inherit_from     => [ 'BASE_unix', "x86_elf_asm" ],
         cc               => "gcc",
         cflags           => combine("-DBN_DEBUG -DREF_DEBUG -DCONF_DEBUG -DBN_CTX_DEBUG -DL_ENDIAN -g -mcpu=pentium -Wall",
                                     threads("-D_REENTRANT")),
@@ -40,7 +42,7 @@ my %targets = (
         dso_scheme       => "dlfcn",
     },
     "debug-linux-ppro" => {
-        inherit_from     => [ "x86_elf_asm" ],
+        inherit_from     => [ 'BASE_unix', "x86_elf_asm" ],
         cc               => "gcc",
         cflags           => combine("-DBN_DEBUG -DREF_DEBUG -DCONF_DEBUG -DBN_CTX_DEBUG -DL_ENDIAN -g -mcpu=pentiumpro -Wall",
                                     threads("-D_REENTRANT")),
@@ -50,6 +52,7 @@ my %targets = (
         dso_scheme       => "dlfcn",
     },
     "debug-linux-ia32-aes" => {
+        inherit_from     => [ 'BASE_unix' ],
         cc               => "gcc",
         cflags           => combine("-DL_ENDIAN -O3 -fomit-frame-pointer -Wall",
                                     threads("-D_REENTRANT")),
@@ -77,12 +80,13 @@ my %targets = (
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "dist" => {
+        inherit_from     => [ 'BASE_unix' ],
         cc               => "cc",
         cflags           => "-O",
         thread_scheme    => "(unknown)",
     },
     "debug-test-64-clang" => {
-        inherit_from     => [ "x86_64_asm" ],
+        inherit_from     => [ 'BASE_unix', "x86_64_asm" ],
         cc               => "clang",
         cflags           => combine("$gcc_devteam_warn -Wno-error=overlength-strings -Wno-error=extended-offsetof -Wno-error=language-extension-token -Wno-error=unused-const-variable -Wstrict-overflow -Qunused-arguments -DBN_DEBUG -DCONF_DEBUG -DDEBUG_SAFESTACK -DDEBUG_UNUSED -g3 -O3 -pipe",
                                     threads("${BSDthreads}")),
@@ -95,7 +99,7 @@ my %targets = (
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "darwin64-debug-test-64-clang" => {
-        inherit_from     => [ "x86_64_asm" ],
+        inherit_from     => [ 'BASE_unix', "x86_64_asm" ],
         cc               => "clang",
         cflags           => combine("-arch x86_64 -DL_ENDIAN $gcc_devteam_warn -Wno-error=overlength-strings -Wno-error=extended-offsetof -Wno-error=language-extension-token -Wno-error=unused-const-variable -Wstrict-overflow -Qunused-arguments -DBN_DEBUG -DCONF_DEBUG -DDEBUG_SAFESTACK -DDEBUG_UNUSED -g3 -O3 -pipe",
                                     threads("${BSDthreads}")),

--- a/Configurations/README
+++ b/Configurations/README
@@ -45,6 +45,19 @@ In each table entry, the following keys are significant:
                            Note: if the same feature is both enabled
                            and disabled, disable wins.
 
+        cpp             => The C preprocessor command, normally not
+                           given, as the build file defaults are
+                           usually good enough.
+        cppflags        => The C preprocessor flags.
+        defines         => As an alternative, macro definitions may be
+                           given here instead of in `cppflags'.  If
+                           given here, they MUST be as an array of the
+                           string such as "MACRO=value", or just
+                           "MACRO" for definitions without value.
+        includes        => As an alternative, inclusion directories
+                           may be given here instead of in `cppflags'.
+                           If given here, the MUST be an array of
+                           strings, one directory specification each.
         cc              => The C compiler command, usually one of "cc",
                            "gcc" or "clang".  This command is normally
                            also used to link object files and
@@ -59,11 +72,6 @@ In each table entry, the following keys are significant:
         cxxflags        => Flags that are used at all times when
                            compiling C++ object files.  If unset, it
                            gets the same value as cflags.
-        defines         => As an alternative, macro definitions may be
-                           present here instead of in `cflags'.  If
-                           given here, they MUST be as an array of the
-                           string such as "MACRO=value", or just
-                           "MACRO" for definitions without value.
         shared_cflag    => Extra compilation flags used when
                            compiling for shared libraries, typically
                            something like "-fPIC".

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -171,16 +171,16 @@ OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 # Where installed engines reside, for C
 ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
-CC= {- $target{cc} -}
+CC= {- $config{cc} -}
 DEFINES={- our $defines = join(",",
                                '__dummy', # To make comma processing easier
-                               @{$target{defines}}, @{$config{defines}}) -}
-CPPFLAGS={- our $cppflags = join('', $target{cppflags}, $config{cppflags}) -}
+                               @{$config{defines}}) -}
+CPPFLAGS={- our $cppflags = join('', @{$config{cppflags}}) -}
 CPPFLAGS_Q={- $cppflags =~ s|"|""|g; $defines =~ s|"|""|g;
               $cppflags."/DEFINE($defines)" -}
-CFLAGS={- $target{cflags} -} {- $config{cflags} -}
-LDFLAGS= {- $target{lflags} -}
-EX_LIBS= {- $target{ex_libs} ? ",".$target{ex_libs} : "" -}{- $config{ex_libs} ? ",".$config{ex_libs} : "" -}
+CFLAGS={- join('', @{$config{cflags}}) -}
+LDFLAGS= {- join('', @{$config{lflags}}) -}
+EX_LIBS= {- join('', map { ','.$_ } @{$config{ex_libs}}) -}
 LIB_DEFINES={- join("",
                     (map { ",$_" }
                      @{$target{shared_defines}},
@@ -200,8 +200,8 @@ PERL={- $config{perl} -}
 # dependent assembler flags. E.g. if you throw -mcpu=ultrasparc at SPARC
 # gcc, then the driver will automatically translate it to -xarch=v8plus
 # and pass it down to assembler.
-AS={- $target{as} -}
-ASFLAG={- $target{asflags} -}
+AS={- $config{as} -}
+ASFLAGS={- join('', @{$config{asflags}}) -}
 
 # .FIRST and .LAST are special targets with MMS and MMK.
 # The defines in there are for C.  includes that look like

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -172,11 +172,20 @@ OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
 CC= {- $target{cc} -}
-CFLAGS= /DEFINE=({- join(",", @{$target{defines}}, @{$config{defines}},"OPENSSLDIR=\"\"\"\$(OPENSSLDIR_C)\"\"\"","ENGINESDIR=\"\"\"\$(ENGINESDIR_C)\"\"\"") -}) {- $target{cflags} -} {- $config{cflags} -}
-CFLAGS_Q=$(CFLAGS)
-DEPFLAG= /DEFINE=({- join(",", @{$config{depdefines}}) -})
+DEFINES={- our $defines = join(",",
+                               '__dummy', # To make comma processing easier
+                               @{$target{defines}}, @{$config{defines}}) -}
+CPPFLAGS={- our $cppflags = join('', $target{cppflags}, $config{cppflags}) -}
+CPPFLAGS_Q={- $cppflags =~ s|"|""|g; $defines =~ s|"|""|g;
+              $cppflags."/DEFINE($defines)" -}
+CFLAGS={- $target{cflags} -} {- $config{cflags} -}
 LDFLAGS= {- $target{lflags} -}
 EX_LIBS= {- $target{ex_libs} ? ",".$target{ex_libs} : "" -}{- $config{ex_libs} ? ",".$config{ex_libs} : "" -}
+LIB_DEFINES={- join("",
+                    (map { ",$_" }
+                     @{$target{shared_defines}},
+                     'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
+                     'ENGINESDIR="""$(ENGINESDIR_C)"""')) -}
 LIB_CFLAGS={- $target{lib_cflags} // "" -}
 DSO_CFLAGS={- $target{dso_cflags} // "" -}
 BIN_CFLAGS={- $target{bin_cflags} // "" -}
@@ -605,16 +614,26 @@ EOF
       my $srcs =
           join(", ",
                map { abs2rel(rel2abs($_), rel2abs($forward)) } @{$args{srcs}});
-      my $ecflags;
+      my $cflags = '$(CFLAGS)';
       if ($args{installed}) {
-          $ecflags = { lib => '$(LIB_CFLAGS)',
+          $cflags .= { lib => '$(LIB_CFLAGS)',
                        dso => '$(DSO_CFLAGS)',
                        bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
       } else {
-          $ecflags = { lib => '$(NO_INST_LIB_CFLAGS)',
+          $cflags .= { lib => '$(NO_INST_LIB_CFLAGS)',
                        dso => '$(NO_INST_DSO_CFLAGS)',
                        bin => '$(NO_INST_BIN_CFLAGS)' } -> {$args{intent}};
       }
+      $cflags .= '$(CPPFLAGS)';
+      $cflags .= { lib => '$(LIB_CPPFLAGS)',
+		   dso => '$(DSO_CPPFLAGS)',
+		   bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+      my $defines = '$(DEFINES)';
+      $defines .= { lib => '$(LIB_DEFINES)',
+		    dso => '$(DSO_DEFINES)',
+		    bin => '$(BIN_DEFINES)' } -> {$args{intent}};
+      $cflags .= '/DEFINE=('.$defines.')';
+      
       my $incs_on = "\@ !";
       my $incs_off = "\@ !";
       my $incs = "";
@@ -645,7 +664,7 @@ $obj.OBJ : $deps
         ${before}
         SET DEFAULT $forward
         $incs_on
-        \$(CC) \$(CFLAGS)${ecflags}${incs}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
+        \$(CC) ${cflags}${incs}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
         $incs_off
         SET DEFAULT $backward
         ${after}

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -13,12 +13,12 @@
 
 sub detect_gnu_ld {
     my @lines =
-        `$config{cross_compile_prefix}$target{cc} -Wl,-V /dev/null 2>&1`;
+        `$config{cross_compile_prefix}$config{cc} -Wl,-V /dev/null 2>&1`;
     return grep /^GNU ld/, @lines;
 }
 sub detect_gnu_cc {
     my @lines =
-        `$config{cross_compile_prefix}$target{cc} -v 2>&1`;
+        `$config{cross_compile_prefix}$config{cc} -v 2>&1`;
     return grep /gcc/, @lines;
 }
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -185,24 +185,22 @@ ECHO = echo
 
 CROSS_COMPILE= {- $config{cross_compile_prefix} -}
 CPPFLAGS={- our $cppflags = join(" ",
-                                 (map { "-D".$_}
-                                  @{$target{defines}}, @{$config{defines}}),
-                                 (map { "-I".$_}
-                                  @{$target{includes}}, @{$config{includes}}),
-                                 $target{cppflags}, $config{cppflags}) -}
+                                 (map { "-D".$_} @{$config{defines}}),
+                                 (map { "-I".$_} @{$config{includes}}),
+                                 @{$config{cppflags}}) -}
 CPPFLAGS_Q={- $cppflags =~ s|([\\"])|\\$1|g; $cppflags -}
-CC= $(CROSS_COMPILE){- $target{cc} -}
-CFLAGS={- $target{cflags} -} {- $config{cflags} -}
-CXX= $(CROSS_COMPILE){- $target{cxx} -}
-CXXFLAGS={- $target{cxxflags} -} {- $config{cxxflags} -} -std=c++11
-LDFLAGS= {- $config{lflags} -} {- $target{lflags} -}
-PLIB_LDFLAGS= {- $target{plib_lflags} -}
-EX_LIBS= {- $target{ex_libs} -} {- $config{ex_libs} -}
-LIB_CPPFLAGS={- join(" ",
-                     (map { "-D".$_}
-                      'OPENSSLDIR="\"$(OPENSSLDIR)\""',
-                      'ENGINESDIR="\"$(ENGINESDIR)\""'),
-                     $target{shared_cppflag} || "") -}
+CC= $(CROSS_COMPILE){- $config{cc} -}
+CFLAGS={- join(' ', @{$config{cflags}}) -}
+CXX= $(CROSS_COMPILE){- $config{cxx} -}
+CXXFLAGS={- join(' ', @{$config{cxxflags}}) -} -std=c++11
+LDFLAGS= {- join(' ', @{$config{lflags}}) -}
+PLIB_LDFLAGS= {- join(' ', @{$config{plib_lflags}}) -}
+EX_LIBS= {- join(' ', @{$config{ex_libs}}) -}
+LIB_CPPFLAGS={- join(' ',
+                     (map { '-D'.$_ }
+                          ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
+                           'ENGINESDIR="\"$(ENGINESDIR)\""')),
+                     $target{shared_cppflag}) || "" -}
 LIB_CFLAGS={- $target{shared_cflag} || "" -}
 LIB_CXXFLAGS={- $target{shared_cxxflag} || "" -}
 LIB_LDFLAGS={- $target{shared_ldflag}." ".$config{shared_ldflag} -}
@@ -217,12 +215,11 @@ BIN_LDFLAGS={- $target{bin_lflags} || "" -}
 
 PERL={- $config{perl} -}
 
-ARFLAGS= {- $target{arflags} -}
-AR=$(CROSS_COMPILE){- $target{ar} || "ar" -} $(ARFLAGS) r
-RANLIB= {- $target{ranlib} -}
-NM= $(CROSS_COMPILE){- $target{nm} || "nm" -}
-RCFLAGS={- $target{shared_rcflag} -}
+AR=$(CROSS_COMPILE){- $config{ar} -}
+ARFLAGS= {- join(' ', @{$config{arflags}}) -}
+RANLIB= {- $config{ranlib} -}
 RC= $(CROSS_COMPILE){- $target{rc} || "windres" -}
+RCFLAGS={- join(' ', @{$config{rcflags}}) -} {- $target{shared_rcflag} -}
 RM= rm -f
 RMDIR= rmdir
 TAR= {- $target{tar} || "tar" -}
@@ -238,8 +235,8 @@ TARFILE=        ../$(NAME).tar
 # dependent assembler flags. E.g. if you throw -mcpu=ultrasparc at SPARC
 # gcc, then the driver will automatically translate it to -xarch=v8plus
 # and pass it down to assembler.
-AS=$(CC) -c
-ASFLAG=$(CFLAGS)
+AS={- $config{as} || '$(CC) -c' -}
+ASFLAGS={- join(' ', @{$config{asflags}}) || '$(CFLAGS)' -}
 PERLASM_SCHEME= {- $target{perlasm_scheme} -}
 
 # For x86 assembler: Set PROCESSOR to 386 if you want to support
@@ -1057,7 +1054,7 @@ EOF
       my $objs = join(" ", @objs);
       return <<"EOF";
 $lib$libext: $objs
-	\$(AR) \$\@ \$\?
+	\$(AR) \$(ARFLAGS) \$\@ \$\?
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF
   }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -184,20 +184,33 @@ HTMLSUFFIX=html
 ECHO = echo
 
 CROSS_COMPILE= {- $config{cross_compile_prefix} -}
+CPPFLAGS={- our $cppflags = join(" ",
+                                 (map { "-D".$_}
+                                  @{$target{defines}}, @{$config{defines}}),
+                                 (map { "-I".$_}
+                                  @{$target{includes}}, @{$config{includes}}),
+                                 $target{cppflags}, $config{cppflags}) -}
+CPPFLAGS_Q={- $cppflags =~ s|([\\"])|\\$1|g; $cppflags -}
 CC= $(CROSS_COMPILE){- $target{cc} -}
-CFLAGS={- our $cflags2 = join(" ",(map { "-D".$_} @{$target{defines}}, @{$config{defines}}),"-DOPENSSLDIR=\"\\\"\$(OPENSSLDIR)\\\"\"","-DENGINESDIR=\"\\\"\$(ENGINESDIR)\\\"\"") -} {- $target{cflags} -} {- $config{cflags} -}
-CFLAGS_Q={- $cflags2 =~ s|([\\"])|\\$1|g; $cflags2 -} {- $config{cflags} -}
+CFLAGS={- $target{cflags} -} {- $config{cflags} -}
 CXX= $(CROSS_COMPILE){- $target{cxx} -}
-CXXFLAGS={- our $cxxflags2 = join(" ",(map { "-D".$_} @{$target{defines}}, @{$config{defines}}),"-DOPENSSLDIR=\"\\\"\$(OPENSSLDIR)\\\"\"","-DENGINESDIR=\"\\\"\$(ENGINESDIR)\\\"\"") -} {- $target{cxxflags} -} {- $config{cxxflags} -} -std=c++11
+CXXFLAGS={- $target{cxxflags} -} {- $config{cxxflags} -} -std=c++11
 LDFLAGS= {- $config{lflags} -} {- $target{lflags} -}
 PLIB_LDFLAGS= {- $target{plib_lflags} -}
 EX_LIBS= {- $target{ex_libs} -} {- $config{ex_libs} -}
+LIB_CPPFLAGS={- join(" ",
+                     (map { "-D".$_}
+                      'OPENSSLDIR="\"$(OPENSSLDIR)\""',
+                      'ENGINESDIR="\"$(ENGINESDIR)\""'),
+                     $target{shared_cppflag} || "") -}
 LIB_CFLAGS={- $target{shared_cflag} || "" -}
 LIB_CXXFLAGS={- $target{shared_cxxflag} || "" -}
 LIB_LDFLAGS={- $target{shared_ldflag}." ".$config{shared_ldflag} -}
+DSO_CPPFLAGS={- $target{dso_cppflags} || "" -}
 DSO_CFLAGS={- $target{dso_cflags} || "" -}
 DSO_CXXFLAGS={- $target{dso_cxxflags} || "" -}
 DSO_LDFLAGS={- $target{dso_lflags} || "" -}
+BIN_CPPFLAGS={- $target{bin_cppflags} || "" -}
 BIN_CFLAGS={- $target{bin_cflags} || "" -}
 BIN_CXXFLAGS={- $target{bin_cxxflags} || "" -}
 BIN_LDFLAGS={- $target{bin_lflags} || "" -}
@@ -844,7 +857,7 @@ EOF
 $target: $args{generator}->[0] $deps
 	( trap "rm -f \$@.*" INT 0; \\
 	  $generator \$@.S; \\
-	  \$(CC) $incs \$(CFLAGS) -E \$@.S | \\
+	  \$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) -E \$@.S | \\
 	  \$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@.i && \\
 	  mv -f \$@.i \$@ )
 EOF
@@ -857,7 +870,7 @@ EOF
           }
           return <<"EOF";
 $args{src}: $args{generator}->[0] $deps
-	\$(CC) $incs \$(CFLAGS) -E $args{generator}->[0] | \\
+	\$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) -E $args{generator}->[0] | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
 EOF
       }
@@ -884,23 +897,34 @@ EOF
           }
       }
       my $cmd = '$(CC)';
-      my $cmdflags = '$(CFLAGS) -c';
+      my $cmdflags = '$(CFLAGS)';
+      my $cmdcompile = ' -c';
       my $makedepprog = $disabled{makedepend} ? undef : $config{makedepprog};
       if (grep /\.rc$/, @srcs) {
           $cmd = '$(RC)';
           $cmdflags = '$(RCFLAGS)';
+          $cmdcompile = '';
           $makedepprog = undef;
       } elsif (grep /\.(cc|cpp)$/, @srcs) {
           $cmd = '$(CXX)';
-          $cmdflags = '$(CXXFLAGS) -c';
+          $cmdflags = '$(CXXFLAGS)';
           $cmdflags .= ' ' . { lib => '$(LIB_CXXFLAGS)',
                                dso => '$(DSO_CXXFLAGS)',
                                bin => '$(BIN_CXXFLAGS)' } -> {$args{intent}};
+          $cmdflags .= ' $(CPPFLAGS)';
+          $cmdflags .= ' ' . { lib => '$(LIB_CPPFLAGS)',
+                               dso => '$(DSO_CPPFLAGS)',
+                               bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
       } else {
           $cmdflags .= ' ' . { lib => '$(LIB_CFLAGS)',
                                dso => '$(DSO_CFLAGS)',
                                bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
+          $cmdflags .= ' $(CPPFLAGS)';
+          $cmdflags .= ' ' . { lib => '$(LIB_CPPFLAGS)',
+                               dso => '$(DSO_CPPFLAGS)',
+                               bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
       }
+      $cmdflags .= $cmdcompile;
       my $recipe = <<"EOF";
 $obj$objext: $deps
 EOF

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -159,29 +159,27 @@ OPENSSLDIR=$(OPENSSLDIR_dev)$(OPENSSLDIR_dir)
 ENGINESDIR=$(ENGINESDIR_dev)$(ENGINESDIR_dir)
 !ENDIF
 
-CC={- $target{cc} -}
+CC={- $config{cc} -}
 CPPFLAGS={- our $cppflags = join(" ",
-                                 (map { "-D".$_}
-                                  @{$target{defines}}, @{$config{defines}}),
-                                 (map { " /I ".$_}
-                                  @{$target{includes}}, @{$config{includes}}),
-                                 $target{cppflags}, $config{cppflags}) -}
+                                 (map { "-D".$_} @{$config{defines}}),
+                                 (map { " /I ".$_} @{$config{includes}}),
+                                 @{$config{cppflags}}) -}
 CPPFLAGS_Q={- $cppflags =~ s|([\\"])|\\$1|g; $cppflags -}
-CFLAGS={- $target{cflags} -} {- $config{cflags} -}
+CFLAGS={- join(' ', @{$config{cflags}}) -}
 COUTFLAG={- $target{coutflag} || "/Fo" -}$(OSSL_EMPTY)
-RC={- $target{rc} || "rc" -}
+RC={- $config{rc} -}
 RCOUTFLAG={- $target{rcoutflag} || "/fo" -}$(OSSL_EMPTY)
-LD={- $target{ld} || "link" -}
-LDFLAGS={- $target{lflags} -}
+LD={- $config{ld} -}
+LDFLAGS={- join(' ', @{$config{lflags}}) -}
 LDOUTFLAG={- $target{loutflag} || "/out:" -}$(OSSL_EMPTY)
-EX_LIBS={- $target{ex_libs} -}
+EX_LIBS={- join(' ', @{$config{ex_libs}}) -}
 LIB_CPPFLAGS={- join(" ",
                      $target{shared_cppflag} || "",
                      (map { quotiry_l("-D".$_) }
                       'OPENSSLDIR="$(OPENSSLDIR)"',
                       'ENGINESDIR="$(ENGINESDIR)"')) -}
-LIB_CFLAGS={- join(" ", $target{lib_cflags}, $target{shared_cflag}) || "" -}
-LIB_LDFLAGS={- $target{shared_ldflag} || "" -}
+LIB_CFLAGS={- join(" ", $target{lib_cflags}, $target{shared_cflag}) -}
+LIB_LDFLAGS={- join(' ', $target{shared_ldflag}, $config{shared_ldflag}) -}
 DSO_CPPFLAGS={- $target{dso_cppflags} || "" -}
 DSO_CFLAGS={- $target{dso_cflags} || "" -}
 DSO_LDFLAGS={- $target{dso_ldflag} || "" -}
@@ -191,17 +189,17 @@ BIN_LDFLAGS={- $target{bin_lflags} -}
 
 PERL={- $config{perl} -}
 
-AR={- $target{ar} -}
-ARFLAGS= {- $target{arflags} -}
+AR={- $config{ar} -}
+ARFLAGS= {- join(' ', @{$config{arflags}}) -}
 AROUTFLAG={- $target{aroutflag} || "/out:" -}$(OSSL_EMPTY)
 
-MT={- $target{mt} -}
-MTFLAGS= {- $target{mtflags} -}
+MT={- $config{mt} -}
+MTFLAGS= {- join(' ', @{$config{mtflags}}) -}
 MTINFLAG={- $target{mtinflag} || "-manifest " -}$(OSSL_EMPTY)
 MTOUTFLAG={- $target{mtoutflag} || "-outputresource:" -}$(OSSL_EMPTY)
 
-AS={- $target{as} -}
-ASFLAGS={- $target{asflags} -}
+AS={- $config{as} -}
+ASFLAGS={- join(' ', @{$config{asflags}}) -}
 ASOUTFLAG={- $target{asoutflag} -}$(OSSL_EMPTY)
 PERLASM_SCHEME= {- $target{perlasm_scheme} -}
 
@@ -316,10 +314,10 @@ install_dev:
 	@if "$(INSTALLTOP)"=="" ( echo INSTALLTOP should not be empty & exit 1 )
 	@echo *** Installing development files
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\include\openssl"
-	@rem {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
+	@rem {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$config{defines}}; "" -}
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\ms\applink.c" \
 				       "$(INSTALLTOP)\include\openssl"
-	@rem {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$target{defines}}; "" -}
+	@rem {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$config{defines}}; "" -}
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\include\openssl\*.h" \
 				       "$(INSTALLTOP)\include\openssl"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(BLDDIR)\include\openssl\*.h \

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -160,7 +160,14 @@ ENGINESDIR=$(ENGINESDIR_dev)$(ENGINESDIR_dir)
 !ENDIF
 
 CC={- $target{cc} -}
-CFLAGS={- join(" ",(map { "-D".$_} @{$target{defines}}, @{$config{defines}})) -} {- join(" ", quotify_l("-DENGINESDIR=\"$enginesdir\"", "-DOPENSSLDIR=\"$openssldir\"")) -} {- $target{cflags} -} {- $config{cflags} -}
+CPPFLAGS={- our $cppflags = join(" ",
+                                 (map { "-D".$_}
+                                  @{$target{defines}}, @{$config{defines}}),
+                                 (map { " /I ".$_}
+                                  @{$target{includes}}, @{$config{includes}}),
+                                 $target{cppflags}, $config{cppflags}) -}
+CPPFLAGS_Q={- $cppflags =~ s|([\\"])|\\$1|g; $cppflags -}
+CFLAGS={- $target{cflags} -} {- $config{cflags} -}
 COUTFLAG={- $target{coutflag} || "/Fo" -}$(OSSL_EMPTY)
 RC={- $target{rc} || "rc" -}
 RCOUTFLAG={- $target{rcoutflag} || "/fo" -}$(OSSL_EMPTY)
@@ -168,10 +175,17 @@ LD={- $target{ld} || "link" -}
 LDFLAGS={- $target{lflags} -}
 LDOUTFLAG={- $target{loutflag} || "/out:" -}$(OSSL_EMPTY)
 EX_LIBS={- $target{ex_libs} -}
+LIB_CPPFLAGS={- join(" ",
+                     $target{shared_cppflag} || "",
+                     (map { quotiry_l("-D".$_) }
+                      'OPENSSLDIR="$(OPENSSLDIR)"',
+                      'ENGINESDIR="$(ENGINESDIR)"')) -}
 LIB_CFLAGS={- join(" ", $target{lib_cflags}, $target{shared_cflag}) || "" -}
 LIB_LDFLAGS={- $target{shared_ldflag} || "" -}
+DSO_CPPFLAGS={- $target{dso_cppflags} || "" -}
 DSO_CFLAGS={- $target{dso_cflags} || "" -}
 DSO_LDFLAGS={- $target{dso_ldflag} || "" -}
+BIN_CPPFLAGS={- $target{dso_cppflags} || "" -}
 BIN_CFLAGS={- $target{bin_cflags} -}
 BIN_LDFLAGS={- $target{bin_lflags} -}
 
@@ -427,7 +441,7 @@ EOF
 $target: "$args{generator}->[0]" $deps
 	set ASM=\$(AS)
 	$generator \$@.S
-	\$(CC) $incs \$(CFLAGS) /EP /C \$@.S > \$@.i && move /Y \$@.i \$@
+	\$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) /EP /C \$@.S > \$@.i && move /Y \$@.i \$@
         del /Q \$@.S
 EOF
               }
@@ -440,7 +454,7 @@ EOF
           }
           return <<"EOF";
 $target: "$args{generator}->[0]" $deps
-	\$(CC) $incs \$(CFLAGS) /EP /C "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
+	\$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) /EP /C "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
 EOF
       }
   }
@@ -457,9 +471,15 @@ EOF
              $incs .= ' /I "'.$withargs{zlib_include}.'"';
          }
      }
-     my $ecflags = { lib => '$(LIB_CFLAGS)',
-		     dso => '$(DSO_CFLAGS)',
-		     bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
+     my $cflags = '$(CFLAGS)';
+     $cflags .= { lib => ' $(LIB_CFLAGS)',
+		  dso => ' $(DSO_CFLAGS)',
+		  bin => ' $(BIN_CFLAGS)' } -> {$args{intent}};
+     $cflags .= $incs;
+     $cflags .= ' $(CPPFLAGS)';
+     $cflags .= { lib => ' $(LIB_CPPFLAGS)',
+		  dso => ' $(DSO_CPPFLAGS)',
+		  bin => ' $(BIN_CPPFLAGS)' } -> {$args{intent}};
      my $makedepprog = $config{makedepprog};
      if ($srcs[0] =~ /\.rc$/) {
          return <<"EOF";
@@ -476,7 +496,7 @@ EOF
      }
      return <<"EOF"	if (!$disabled{makedepend});
 $obj$depext: $deps
-	\$(CC) \$(CFLAGS) $ecflags$inc /Zs /showIncludes $srcs 2>&1 | \\
+	\$(CC) $cflags /Zs /showIncludes $srcs 2>&1 | \\
 	    "\$(PERL)" -n << > $obj$depext
 chomp;
 s/^Note: including file: *//;
@@ -484,13 +504,13 @@ s/^Note: including file: *//;
 END { print '$obj$objext: ',join(" ", sort keys \%collect),"\\n" }
 <<
 $obj$objext: $obj$depext
-	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ @<<
+	\$(CC) $cflags -c \$(COUTFLAG)\$\@ @<<
 $srcs
 <<
 EOF
     return <<"EOF"	if ($disabled{makedepend});
 $obj$objext: $deps
-	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ $srcs
+	\$(CC) $cflags -c \$(COUTFLAG)\$\@ $srcs
 EOF
  }
 

--- a/Configure
+++ b/Configure
@@ -576,16 +576,6 @@ my %user_to_target = (
     LDFLAGS     => 'lflags',
     LDLIBS      => 'ex_libs',
    );
-my %user_defaults = (
-    AR          => 'ar',
-    ARFLAGS     => [ 'r' ],
-    CC          => 'cc',
-    CXX         => 'c++',
-    HASHBANGPERL=> '/usr/bin/env perl', # Only Unix actually cares
-    RANLIB      => sub { which("$config{cross_compile_prefix}ranlib") ?
-                             "\$(CROSS_COMPILE)ranlib" : "true"; },
-    RC          => 'windres',
-   );
 
 $config{openssl_api_defines}=[];
 $config{openssl_algorithm_defines}=[];
@@ -1158,8 +1148,6 @@ foreach (keys %user) {
     $config{$target_key} =
         $mkvalue->($ref_type, $user{$_})
         || $mkvalue->($ref_type, $target{$target_key});
-    $config{$target_key} ||=$mkvalue->($ref_type, $user_defaults{$_})
-        if exists $user_defaults{$_};
     if (defined $useradd{$_} && @{$useradd{$_}}) {
         if (defined $config{$target_key}) {
             push @{$config{$target_key}}, @{$useradd{$_}};

--- a/Configure
+++ b/Configure
@@ -520,7 +520,9 @@ my $no_sse2=0;
 &usage if ($#ARGV < 0);
 
 my $user_cflags="";
+my $user_cppflags=();
 my @user_defines=();
+my @user_includes=();
 $config{openssl_api_defines}=[];
 $config{openssl_algorithm_defines}=[];
 $config{openssl_thread_defines}=[];
@@ -761,6 +763,14 @@ while (@argvcopy)
 		elsif (/^-D(.*)$/)
 			{
 			push @user_defines, $1;
+			}
+		elsif (/^-I(.*)$/)
+			{
+			push @user_includes, $1;
+			}
+		elsif (/^-Wp,$/)
+			{
+			$user_cppflags.=" ".$_;
 			}
 		else	# common if (/^[-+]/), just pass down...
 			{
@@ -1053,6 +1063,8 @@ $config{build_file} = $target{build_file};
 # or release_ attributes.
 # Do it in such a way that no spurious space is appended (hence the grep).
 $config{defines} = [];
+$config{includes} = [];
+$config{cppflags} = "";
 $config{cflags} = "";
 $config{cxxflags} = "";
 $config{lflags} = "";
@@ -1099,10 +1111,6 @@ if ($target =~ /linux.*-mips/ && !$disabled{asm} && $user_cflags !~ /-m(ips|arch
 	$config{cflags}="-mips3 $config{cflags}" if ($target =~ /mips64/);
 }
 
-my $no_shared_warn=0;
-my $no_user_cflags=0;
-my $no_user_defines=0;
-
 # The DSO code currently always implements all functions so that no
 # applications will have to worry about that from a compilation point
 # of view. However, the "method"s may return zero unless that platform
@@ -1145,7 +1153,7 @@ unless ($disabled{threads}) {
             # system-dependent compiler options that are necessary.  We
             # can't truly check that the given options are correct, but
             # we expect the user to know what [s]He is doing.
-            if ($no_user_cflags && $no_user_defines) {
+            if (!$user_cflags && !@user_defines) {
                 die "You asked for multi-threading support, but didn't\n"
                     ,"provide any system-specific compiler options\n";
             }
@@ -1166,6 +1174,7 @@ if (defined($disabled{"deprecated"})) {
         $config{api} = $maxapi;
 }
 
+my $no_shared_warn=0;
 if ($target{shared_target} eq "")
 	{
 	$no_shared_warn = 1
@@ -1208,8 +1217,10 @@ unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
 # This saves the build files from having to check
 if ($disabled{pic})
 	{
-	foreach (qw(shared_cflag shared_cxxflag shared_ldflag
-		    dso_cflags dso_cxxflags dso_lflags))
+	foreach (qw(shared_cflag shared_cxxflag shared_cppflag
+                    shared_defines shared_includes shared_ldflag
+		    dso_cflags dso_cxxflags dso_cppflags
+                    dso_defines dso_includes dso_lflags))
 		{
 		$target{$_} = "";
 		}
@@ -1378,10 +1389,11 @@ unless ($disabled{"crypto-mdebug-backtrace"})
 		}
 	}
 
-if ($user_cflags ne "") { $config{cflags}="$config{cflags}$user_cflags"; $config{cxxflags}="$config{cxxflags}$user_cflags";}
-else                    { $no_user_cflags=1;  }
-if (@user_defines) { $config{defines}=[ @{$config{defines}}, @user_defines ]; }
-else               { $no_user_defines=1;    }
+$config{cppflags}.=$user_cppflags;
+push @{$config{defines}}, @user_defines;
+push @{$config{includes}}, @user_includes;
+$config{cflags}.=$user_cflags;
+$config{cxxflags}.=$user_cflags;
 
 # ALL MODIFICATIONS TO %config and %target MUST BE DONE FROM HERE ON
 
@@ -2689,9 +2701,12 @@ sub print_table_entry
 
     my @sequence = (
 	"sys_id",
+	"cpp",
+	"cppflags",
+	"defines",
+	"includes",
 	"cc",
 	"cflags",
-	"defines",
 	"unistd",
 	"ld",
 	"lflags",

--- a/Configure
+++ b/Configure
@@ -519,20 +519,82 @@ my $no_sse2=0;
 
 &usage if ($#ARGV < 0);
 
-my $user_cflags="";
-my $user_cppflags=();
-my @user_defines=();
-my @user_includes=();
+# For the "make variables" CINCLUDES and CDEFINES, we support lists with
+# platform specific list separators.  Users from those platforms should
+# recognise those separators from how you set up the PATH to find executables.
+# The default is the Unix like separator, :, but as an exception, we also
+# support the space as separator.
+my $list_separator_re =
+    { VMS           => qr/(?<!\^),/,
+      MSWin32       => qr/(?<!\\);/ } -> {$^O} // qr/(?<!\\)[:\s]/;
+# All the "make variables" we support
+my %user = (
+    AR          => undef,
+    ARFLAGS     => [],
+    AS          => undef,
+    ASFLAGS     => [],
+    CC          => undef,
+    CFLAGS      => [],
+    CXX         => undef,
+    CXXFLAGS    => [],
+    CPP         => undef,
+    CPPFLAGS    => [],  # -D, -I, -Wp,
+    CPPDEFINES  => [],  # Alternative for -D
+    CPPINCLUDES => [],  # Alternative for -I
+    HASHBANGPERL=> undef,
+    LD          => undef,
+    LDFLAGS     => [],  # -L, -Wl,
+    LDLIBS      => [],  # -l
+    MT          => undef,
+    MTFLAGS     => [],
+    RANLIB      => undef,
+    RC          => undef,
+    RCFLAGS     => [],
+    RM          => undef,
+   );
+# The same but for flags given as Configure options.  These are *additional*
+# input, as opposed to the VAR=string option that override the corresponding
+# config target attributes
+my %useradd = (
+    CPPDEFINES  => [],
+    CPPINCLUDES => [],
+    CPPFLAGS    => [],
+    CFLAGS      => [],
+    CXXFLAGS    => [],
+    LDFLAGS     => [],
+    LDLIBS      => [],
+   );
+
+my %user_synonyms = (
+    HASHBANGPERL=> 'PERL',
+    RC          => 'WINDRES',
+   );
+my %user_to_target = (
+    # If not given here, the value is the lc of the key
+    CPPDEFINES  => 'defines',
+    CPPINCLUDES => 'includes',
+    LDFLAGS     => 'lflags',
+    LDLIBS      => 'ex_libs',
+   );
+my %user_defaults = (
+    AR          => 'ar',
+    ARFLAGS     => [ 'r' ],
+    CC          => 'cc',
+    CXX         => 'c++',
+    HASHBANGPERL=> '/usr/bin/env perl', # Only Unix actually cares
+    RANLIB      => sub { which("$config{cross_compile_prefix}ranlib") ?
+                             "\$(CROSS_COMPILE)ranlib" : "true"; },
+    RC          => 'windres',
+   );
+
 $config{openssl_api_defines}=[];
 $config{openssl_algorithm_defines}=[];
 $config{openssl_thread_defines}=[];
 $config{openssl_sys_defines}=[];
 $config{openssl_other_defines}=[];
-my $ldflags="";
-my $libs="";
-my $target="";
 $config{options}="";
 $config{build_type} = "release";
+my $target="";
 
 my %unsupported_options = ();
 my %deprecated_options = ();
@@ -547,6 +609,16 @@ while (@argvcopy)
 	if (m|^(\w+)=(.+)?$|)
 		{
 		$config{perlenv}->{$1} = $2;
+		# Every time a variable is given as a configuration argument,
+		# it acts as a reset if the variable.
+		if (exists $user{$1})
+			{
+			$user{$1} = ref $user{$1} eq "ARRAY" ? [] : undef;
+			}
+		if (exists $useradd{$1})
+			{
+			$useradd{$1} = [];
+			}
 		next;
 		}
 
@@ -734,15 +806,15 @@ while (@argvcopy)
 			}
 		elsif (/^-L(.*)$/)
 			{
-			$ldflags.=$_." ";
+			push @{$useradd{LDFLAGS}}, $_;
 			}
 		elsif (/^-l(.*)$/ or /^-Wl,/)
 			{
-			$libs.=$_." ";
+			push @{$useradd{LDLIBS}}, $_;
 			}
 		elsif (/^-framework$/)
 			{
-			$libs.=$_." ".shift(@argvcopy)." ";
+			push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
 			}
 		elsif (/^-rpath$/ or /^-R$/)
 			# -rpath is the OSF1 rpath flag
@@ -750,11 +822,11 @@ while (@argvcopy)
 			{
 			my $rpath = shift(@argvcopy) || "";
 			$rpath .= " " if $rpath ne "";
-			$libs.=$_." ".$rpath;
+			push @{$useradd{LDFLAGS}}, $_, $rpath;
 			}
 		elsif (/^-static$/)
 			{
-			$libs.=$_." ";
+			push @{$useradd{LDFLAGS}}, $_;
 			$disabled{"dso"} = "forced";
 			$disabled{"pic"} = "forced";
 			$disabled{"shared"} = "forced";
@@ -762,20 +834,21 @@ while (@argvcopy)
 			}
 		elsif (/^-D(.*)$/)
 			{
-			push @user_defines, $1;
+			push @{$useradd{CPPDEFINES}}, $1;
 			}
 		elsif (/^-I(.*)$/)
 			{
-			push @user_includes, $1;
+			push @{$useradd{CPPINCLUDES}}, $1;
 			}
 		elsif (/^-Wp,$/)
 			{
-			$user_cppflags.=" ".$_;
+			push @{$useradd{CPPFLAGS}}, $1;
 			}
 		else	# common if (/^[-+]/), just pass down...
 			{
 			$_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
-			$user_cflags.=" ".$_;
+			push @{$useradd{CFLAGS}}, $_;
+			push @{$useradd{CXXFLAGS}}, $_;
 			}
 		}
 	else
@@ -812,7 +885,20 @@ while (@argvcopy)
 		}
 	}
 
-if ($libs =~ /(^|\s)-Wl,-rpath,/
+foreach (keys %user) {
+    my $value = env($_);
+    $value //= defined $user_synonyms{$_} ? env($user_synonyms{$_}) : undef;
+
+    if (defined $value) {
+        if (ref $user{$_} eq 'ARRAY') {
+            $user{$_} = [ split /$list_separator_re/, $value ];
+        } elsif (!defined $user{$_}) {
+            $user{$_} = $value;
+        }
+    }
+}
+
+if (grep { $_ =~ /(^|\s)-Wl,-rpath,/ } ($user{LDLIBS} ? @{$user{LDLIBS}} : ())
     && !$disabled{shared}
     && !($disabled{asan} && $disabled{msan} && $disabled{ubsan})) {
     die "***** Cannot simultaneously use -rpath, shared libraries, and\n",
@@ -1012,7 +1098,10 @@ foreach (sort (keys %disabled))
 			push @{$config{openssl_other_defines}}, "OPENSSL_NO_$WHAT";
 			print " OPENSSL_NO_$WHAT";
 
-			if (/^err$/)	{ push @user_defines, "OPENSSL_NO_ERR"; }
+			if (/^err$/)
+				{
+				push @{$useradd{CPPDEFINES}}, "OPENSSL_NO_ERR";
+				}
 			}
 		}
 
@@ -1039,37 +1128,51 @@ $config{cross_compile_prefix} = env('CROSS_COMPILE')
 # Note: only Unix cares about HASHBANGPERL...  that explains
 # the default string.
 $config{perl} =    ($^O ne "VMS" ? $^X : "perl");
-$config{hashbangperl} =
-    env('HASHBANGPERL')           || env('PERL')      || "/usr/bin/env perl";
-$target{cc} =      env('CC')      || $target{cc}      || "cc";
-$target{cxx} =     env('CXX')     || $target{cxx}     || "c++";
-$target{ranlib} =  env('RANLIB')  || $target{ranlib}  ||
-                   (which("$config{cross_compile_prefix}ranlib") ?
-                          "\$(CROSS_COMPILE)ranlib" : "true");
-$target{ar} =      env('AR')      || $target{ar}      || "ar";
-$target{nm} =      env('NM')      || $target{nm}      || "nm";
-$target{rc} =
-    env('RC')  || env('WINDRES')  || $target{rc}      || "windres";
+foreach (keys %user) {
+    my $target_key = $user_to_target{$_} // lc $_;
+    my $ref_type = ref $user{$_};
+
+    # Temporary function.  Takes an intended ref type (empty string or "ARRAY")
+    # and a value that's to be coerced into that type.
+    my $mkvalue = sub {
+        my $type = shift;
+        my $value = shift;
+        my $undef_p = shift;
+
+        die "Too many arguments for \$mkvalue" if @_;
+
+        while (ref $value eq 'CODE') {
+            $value = $value->();
+        }
+
+        if ($type eq 'ARRAY') {
+            return undef unless defined $value;
+            return undef if ref $value ne 'ARRAY' && !$value;
+            return undef if ref $value eq 'ARRAY' && !@$value;
+            return [ $value ] unless ref $value eq 'ARRAY';
+        }
+        return undef unless $value;
+        return $value;
+    };
+
+    $config{$target_key} =
+        $mkvalue->($ref_type, $user{$_})
+        || $mkvalue->($ref_type, $target{$target_key});
+    $config{$target_key} ||=$mkvalue->($ref_type, $user_defaults{$_})
+        if exists $user_defaults{$_};
+    if (defined $useradd{$_} && @{$useradd{$_}}) {
+        if (defined $config{$target_key}) {
+            push @{$config{$target_key}}, @{$useradd{$_}};
+        } else {
+            $config{$target_key} = [ @{$useradd{$_}} ];
+        }
+    }
+    delete $config{$target_key} unless defined $config{$target_key};
+}
+$config{plib_lflags} = [ $target{plib_lflags} ];
 
 # Allow overriding the build file name
-$target{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
-
-# Cache information necessary for reconfiguration
-$config{cc} = $target{cc};
-$config{cxx} = $target{cxx};
-$config{build_file} = $target{build_file};
-
-# For cflags, lflags, plib_lflags, ex_libs and defines, add the debug_
-# or release_ attributes.
-# Do it in such a way that no spurious space is appended (hence the grep).
-$config{defines} = [];
-$config{includes} = [];
-$config{cppflags} = "";
-$config{cflags} = "";
-$config{cxxflags} = "";
-$config{lflags} = "";
-$config{ex_libs} = "";
-$config{shared_ldflag} = "";
+$config{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
 
 # Make sure build_scheme is consistent.
 $target{build_scheme} = [ $target{build_scheme} ]
@@ -1099,16 +1202,17 @@ foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
 
 push @{$config{defines}}, "NDEBUG"    if $config{build_type} eq "release";
 
-if ($target =~ /^mingw/ && `$target{cc} --target-help 2>&1` =~ m/-mno-cygwin/m)
+if ($target =~ /^mingw/ && `$config{cc} --target-help 2>&1` =~ m/-mno-cygwin/m)
 	{
-	$config{cflags} .= " -mno-cygwin";
-	$config{shared_ldflag} .= " -mno-cygwin";
+	push @{$config{cflags}}, "-mno-cygwin";
+	push @{$config{shared_ldflag}}, "-mno-cygwin";
 	}
 
-if ($target =~ /linux.*-mips/ && !$disabled{asm} && $user_cflags !~ /-m(ips|arch=)/) {
+if ($target =~ /linux.*-mips/ && !$disabled{asm}
+        && !grep { $_ !~ /-m(ips|arch=)/ } @{$user{CFLAGS}}) {
 	# minimally required architecture flags for assembly modules
-	$config{cflags}="-mips2 $config{cflags}" if ($target =~ /mips32/);
-	$config{cflags}="-mips3 $config{cflags}" if ($target =~ /mips64/);
+	unshift @{$config{cflags}}, '-mips2' if ($target =~ /mips32/);
+	unshift @{$config{cflags}}, '-mips3' if ($target =~ /mips64/);
 }
 
 # The DSO code currently always implements all functions so that no
@@ -1134,9 +1238,6 @@ if (!$disabled{dso} && $target{dso_scheme} ne "")
 		}
 	}
 
-$config{ex_libs}="$libs$config{ex_libs}" if ($libs ne "");
-$config{lflags}="$config{lflags}$ldflags" if ($ldflags ne "");
-
 # If threads aren't disabled, check how possible they are
 unless ($disabled{threads}) {
     if ($auto_threads) {
@@ -1153,7 +1254,7 @@ unless ($disabled{threads}) {
             # system-dependent compiler options that are necessary.  We
             # can't truly check that the given options are correct, but
             # we expect the user to know what [s]He is doing.
-            if (!$user_cflags && !@user_defines) {
+            if (!@{$user{CFLAGS}} && !@{$user{CPPDEFINES}}) {
                 die "You asked for multi-threading support, but didn't\n"
                     ,"provide any system-specific compiler options\n";
             }
@@ -1164,9 +1265,7 @@ unless ($disabled{threads}) {
 # If threads still aren't disabled, add a C macro to ensure the source
 # code knows about it.  Any other flag is taken care of by the configs.
 unless($disabled{threads}) {
-    foreach (("defines", "openssl_thread_defines")) {
-        push @{$config{$_}}, "OPENSSL_THREADS";
-    }
+    push @{$config{openssl_thread_defines}}, "OPENSSL_THREADS";
 }
 
 # With "deprecated" disable all deprecated features.
@@ -1193,22 +1292,22 @@ if ($disabled{"dynamic-engine"}) {
 }
 
 unless ($disabled{asan}) {
-    $config{cflags} .= "-fsanitize=address ";
+    push @{$config{cflags}}, "-fsanitize=address";
 }
 
 unless ($disabled{ubsan}) {
     # -DPEDANTIC or -fnosanitize=alignment may also be required on some
     # platforms.
-    $config{cflags} .= "-fsanitize=undefined -fno-sanitize-recover=all ";
+    push @{$config{cflags}}, "-fsanitize=undefined", "-fno-sanitize-recover=all";
 }
 
 unless ($disabled{msan}) {
-  $config{cflags} .= "-fsanitize=memory ";
+  push @{$config{cflags}}, "-fsanitize=memory";
 }
 
 unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
         && $disabled{asan} && $disabled{ubsan} && $disabled{msan}) {
-    $config{cflags} .= "-fno-omit-frame-pointer -g ";
+    push @{$config{cflags}}, "-fno-omit-frame-pointer", "-g";
 }
 #
 # Platform fix-ups
@@ -1222,6 +1321,7 @@ if ($disabled{pic})
 		    dso_cflags dso_cxxflags dso_cppflags
                     dso_defines dso_includes dso_lflags))
 		{
+		delete $config{$_};
 		$target{$_} = "";
 		}
 	}
@@ -1294,7 +1394,7 @@ unless ($disabled{asm}) {
     }
 }
 
-my %predefined = compiler_predefined($target{cc});
+my %predefined = compiler_predefined($config{cc});
 
 # Check for makedepend capabilities.
 if (!$disabled{makedepend}) {
@@ -1305,7 +1405,7 @@ if (!$disabled{makedepend}) {
     } elsif ($predefined{__GNUC__} >= 3) {
         # We know that GNU C version 3 and up as well as all clang
         # versions support dependency generation
-        $config{makedepprog} = "\$(CROSS_COMPILE)$target{cc}";
+        $config{makedepprog} = "\$(CROSS_COMPILE)$config{cc}";
     } else {
         # In all other cases, we look for 'makedepend', and disable the
         # capability if not found.
@@ -1344,7 +1444,8 @@ die "Exactly one of SIXTY_FOUR_BIT|SIXTY_FOUR_BIT_LONG|THIRTY_TWO_BIT can be set
 
 # "Stringify" the C flags string.  This permits it to be made part of a string
 # and works as well on command lines.
-$config{cflags} =~ s/([\\\"])/\\$1/g;
+$config{cflags} = [ map { (my $x = $_) =~ s/([\\\"])/\\$1/g; $x }
+                        @{$config{cflags}} ];
 
 if (defined($config{api})) {
     $config{openssl_api_defines} = [ "OPENSSL_MIN_API=".$apitable->{$config{api}} ];
@@ -1353,7 +1454,7 @@ if (defined($config{api})) {
 }
 
 if (defined($predefined{__clang__}) && !$disabled{asm}) {
-    $config{cflags} .= " -Qunused-arguments";
+    push @{$config{cflags}}, "-Qunused-arguments";
 }
 
 if ($strict_warnings)
@@ -1366,13 +1467,15 @@ if ($strict_warnings)
 	$gcc_devteam_warn .= " -Wmisleading-indentation" if $gccver >= 6;
 	foreach $wopt (split /\s+/, $gcc_devteam_warn)
 		{
-		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+		push @{$config{cflags}}, $wopt
+			unless grep { $_ eq $wopt } @{$config{cflags}};
 		}
 	if (defined($predefined{__clang__}))
 		{
 		foreach $wopt (split /\s+/, $clang_devteam_warn)
 			{
-			$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+			push @{$config{cflags}}, $wopt
+				unless grep { $_ eq $wopt } @{$config{cflags}};
 			}
 		}
 	}
@@ -1381,21 +1484,14 @@ unless ($disabled{"crypto-mdebug-backtrace"})
 	{
 	foreach my $wopt (split /\s+/, $memleak_devteam_backtrace)
 		{
-		$config{cflags} .= " $wopt" unless ($config{cflags} =~ /(?:^|\s)$wopt(?:\s|$)/)
+		push @{$config{cflags}}, $wopt
+			unless grep { $_ eq $wopt } @{$config{cflags}};
 		}
 	if ($target =~ /^BSD-/)
 		{
-		$config{ex_libs} .= " -lexecinfo";
+		push @{$config{ex_libs}}, "-lexecinfo";
 		}
 	}
-
-$config{cppflags}.=$user_cppflags;
-push @{$config{defines}}, @user_defines;
-push @{$config{includes}}, @user_includes;
-$config{cflags}.=$user_cflags;
-$config{cxxflags}.=$user_cflags;
-
-# ALL MODIFICATIONS TO %config and %target MUST BE DONE FROM HERE ON
 
 unless ($disabled{afalgeng}) {
     $config{afalgeng}="";
@@ -1420,6 +1516,8 @@ unless ($disabled{afalgeng}) {
 }
 
 push @{$config{openssl_other_defines}}, "OPENSSL_NO_AFALGENG" if ($disabled{afalgeng});
+
+# ALL MODIFICATIONS TO %config and %target MUST BE DONE FROM HERE ON
 
 # If we use the unified build, collect information from build.info files
 my %unified_info = ();
@@ -2220,18 +2318,25 @@ print "PROCESSOR     =$config{processor}\n" if $config{processor};
 print "PERL          =$config{perl}\n";
 print "PERLVERSION   =$Config{version} for $Config{archname}\n";
 print "HASHBANGPERL  =$config{hashbangperl}\n";
-print "CC            =$config{cross_compile_prefix}$target{cc}\n";
-print "CFLAG         =$target{cflags} $config{cflags}\n";
-print "CXX           =$config{cross_compile_prefix}$target{cxx}\n"
-    if defined $target{cxx};
-print "CXXFLAG       =$target{cxxflags} $config{cxxflags}\n"
-    if defined $target{cxx};
-print "DEFINES       =",join(" ", @{$target{defines}}, @{$config{defines}}),"\n";
-#print "RANLIB        =", $target{ranlib} eq '$(CROSS_COMPILE)ranlib' ?
-#                             "$config{cross_compile_prefix}ranlib" :
-#                             "$target{ranlib}", "\n";
-print "LDFLAGS       =$config{lflags} $target{lflags}\n";
-print "EX_LIBS       =$target{ex_libs} $config{ex_libs}\n";
+print "DEFINES       =",join(" ", @{$config{defines}}),"\n"
+    if defined $config{defines};
+print "INCLUDES      =",join(" ", @{$config{includes}}),"\n"
+    if defined $config{includes};
+print "CPPFLAGS      =",join(" ", @{$config{cppflags}}),"\n"
+    if defined $config{cppflags};
+print "CC            =$config{cross_compile_prefix}$config{cc}\n";
+print "CFLAGS        =",join(" ", @{$config{cflags}}),"\n"
+    if defined $config{cflags};
+print "CXX           =$config{cross_compile_prefix}$config{cxx}\n"
+    if defined $config{cxx};
+print "CXXFLAGS      =",join(" ", @{$config{cxxflags}}),"\n"
+    if defined $config{cxxflags};
+print "LD            =$config{cross_compile_prefix}$config{ld}\n"
+    if defined $config{ld};
+print "LDFLAGS       =",join(" ", @{$config{lflags}}),"\n"
+    if defined $config{lflags};
+print "EX_LIBS       =",join(" ", @{$config{ex_libs}}),"\n"
+    if defined $config{ex_libs};
 
 my %builders = (
     unified => sub {

--- a/INSTALL
+++ b/INSTALL
@@ -516,7 +516,7 @@
                    whirlpool.  The "ripemd" algorithm is deprecated and if used
                    is synonymous with rmd160.
 
-  -Dxxx, lxxx, -Lxxx, -Wl, -rpath, -R, -framework, -static
+  -Dxxx, -Ixxx, -Wp, -lxxx, -Lxxx, -Wl, -rpath, -R, -framework, -static
                    These system specific options will be recognised and
                    passed through to the compiler to allow you to define
                    preprocessor symbols, specify additional libraries, library
@@ -527,10 +527,16 @@
                    unsuitable for execution on other, typically older,
                    processor. Consult your compiler documentation.
 
+                   Take note of the VAR=value documentation below and how
+                   these flags interact with those variables.
+
   -xxx, +xxx
                    Additional options that are not otherwise recognised are
                    passed through as they are to the compiler as well.  Again,
                    consult your compiler documentation.
+
+                   Take note of the VAR=value documentation below and how
+                   these flags interact with those variables.
 
   VAR=value
                    Assignment if environment variable for Configure.  These
@@ -539,6 +545,68 @@
                    the configuration scripts only.  These assignments override
                    the corresponding value in the inherited environment, if
                    there is one.
+
+                   The following variables are used as "make variables" and
+                   can be used as an alternative to giving preprocessor,
+                   compiler and linker options directly as configuration.
+                   The following variables are supported:
+
+                   AR              The static library archiver.
+                   ARFLAGS         Flags for the static library archiver.
+                   AS              The assembler compiler.
+                   ASFLAGS         Flags for the assembler compiler.
+                   CC              The C compiler.
+                   CFLAGS          Flags for the C compiler.
+                   CXX             The C++ compiler.
+                   CXXFLAGS        Flags for the C++ compiler.
+                   CPP             The C/C++ preprocessor.
+                   CPPFLAGS        Flags for the C/C++ preprocessor.
+                   CPPDEFINES      List of CPP macro definitions, separated
+                                   by a platform specific character (':' or
+                                   space for Unix, ';' for Windows, ',' for
+                                   VMS).  This can be used in place of -D.
+                   CPPINCLUDES     List of CPP inclusion directories, separated
+                                   the same way as for CPPDEFINES.  This can
+                                   be used in place of -I.
+                   HASHBANGPERL    Perl invocation to be inserted after '#!'
+                                   in public perl scripts.
+                   LD              The program linker (not used on Unix, $(CC)
+                                   is used there).
+                   LDFLAGS         Flags for the shared library, DSO and
+                                   program linker.
+                   LDLIBS          Extra libraries to use when linking.
+                                   Takes the form of a space separated list
+                                   of library specifications on Unix and
+                                   Windows, and as a comma separated list of
+                                   libraries on VMS.
+                   RANLIB          The library archive indexer.
+                   RC              The Windows resources manipulator.
+                   RCFLAGS         Flags for the Windows reources manipulator.
+                   RM              The command to remove files and directories.
+
+                   These can be mixed with flags given on the command line.
+                   Any variable assignment resets any corresponding flags
+                   given before it, so for example:
+
+                       ./config -DFOO CPPFLAGS=-DBAR -DCOOKIE
+
+                   Will end up having 'CPPFLAGS=-DBAR -DCOOKIE'.
+
+                   Here is how the flags documented above are collected as
+                   augmentation of these variables:
+
+                   -Dxxx           xxx is collected in CPPDEFINES
+                   -Ixxx           xxx is collected in CPPINCLUDES
+                   -Wp,xxx         collected in CPPFLAGS
+                   -Lxxx           collected in LDFLAGS
+                   -lxxx           collected in LDLIBS
+                   -Wp,xxx         collected in LDLIBS
+                   -rpath xxx      collected in LDLIBS
+                   -R xxx          collected in LDLIBS
+                   -framework xxx  collected in LDLIBS
+                   -static         collected in LDLIBS
+                   -xxx            collected in CFLAGS
+                   +xxx            collected in CFLAGS
 
   reconf
   reconfigure

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@
 
   Major changes between OpenSSL 1.1.0f and OpenSSL 1.1.1 [under development]
 
-      o 
+      o Allow GNU style "make variables" to be used with Configure.
       o Add a STORE module (OSSL_STORE)
       o Claim the namespaces OSSL and OPENSSL, represented as symbol prefixes
 

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -5,11 +5,17 @@ SOURCE[../../libcrypto]=\
 
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 
-GENERATE[aes-586.s]=asm/aes-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[aes-586.s]=asm/aes-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[aes-586.s]=../perlasm/x86asm.pl
-GENERATE[vpaes-x86.s]=asm/vpaes-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[vpaes-x86.s]=asm/vpaes-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[vpaes-586.s]=../perlasm/x86asm.pl
-GENERATE[aesni-x86.s]=asm/aesni-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[aesni-x86.s]=asm/aesni-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[aesni-586.s]=../perlasm/x86asm.pl
 
 GENERATE[aes-x86_64.s]=asm/aes-x86_64.pl $(PERLASM_SCHEME)

--- a/crypto/bf/build.info
+++ b/crypto/bf/build.info
@@ -2,5 +2,7 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=bf_skey.c bf_ecb.c bf_cfb64.c bf_ofb64.c \
         {- $target{bf_asm_src} -}
 
-GENERATE[bf-586.s]=asm/bf-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[bf-586.s]=asm/bf-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[bf-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -11,16 +11,20 @@ INCLUDE[../../libcrypto]=../../crypto/include
 INCLUDE[bn_exp.o]=..
 
 GENERATE[bn-586.s]=asm/bn-586.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[bn-586.s]=../perlasm/x86asm.pl
 GENERATE[co-586.s]=asm/co-586.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[co-586.s]=../perlasm/x86asm.pl
 GENERATE[x86-mont.s]=asm/x86-mont.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[x86-mont.s]=../perlasm/x86asm.pl
 GENERATE[x86-gf2m.s]=asm/x86-gf2m.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[x86-gf2m.s]=../perlasm/x86asm.pl
 
 GENERATE[sparcv9a-mont.S]=asm/sparcv9a-mont.pl $(PERLASM_SCHEME)
@@ -49,7 +53,8 @@ GENERATE[rsaz-x86_64.s]=asm/rsaz-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[rsaz-avx2.s]=asm/rsaz-avx2.pl $(PERLASM_SCHEME)
 
 GENERATE[bn-ia64.s]=asm/ia64.S
-GENERATE[ia64-mont.s]=asm/ia64-mont.pl $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[ia64-mont.s]=asm/ia64-mont.pl \
+        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 
 GENERATE[parisc-mont.s]=asm/parisc-mont.pl $(PERLASM_SCHEME)
 

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -11,14 +11,16 @@ EXTRA=  ../ms/uplink-x86.pl ../ms/uplink.c ../ms/applink.c \
         ppccpuid.pl pariscid.pl alphacpuid.pl arm64cpuid.pl armv4cpuid.pl
 
 DEPEND[cversion.o]=buildinf.h
-GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(CFLAGS_Q)" "$(PLATFORM)"
+GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
 DEPEND[buildinf.h]=../configdata.pm
 
 GENERATE[uplink-x86.s]=../ms/uplink-x86.pl $(PERLASM_SCHEME)
 GENERATE[uplink-x86_64.s]=../ms/uplink-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[uplink-ia64.s]=../ms/uplink-ia64.pl $(PERLASM_SCHEME)
 
-GENERATE[x86cpuid.s]=x86cpuid.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[x86cpuid.s]=x86cpuid.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[x86cpuid.s]=perlasm/x86asm.pl
 
 GENERATE[x86_64cpuid.s]=x86_64cpuid.pl $(PERLASM_SCHEME)

--- a/crypto/camellia/build.info
+++ b/crypto/camellia/build.info
@@ -3,7 +3,9 @@ SOURCE[../../libcrypto]=\
         cmll_ecb.c cmll_ofb.c cmll_cfb.c cmll_ctr.c \
         {- $target{cmll_asm_src} -}
 
-GENERATE[cmll-x86.s]=asm/cmll-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[cmll-x86.s]=asm/cmll-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[cmll-x86.s]=../perlasm/x86asm.pl
 GENERATE[cmll-x86_64.s]=asm/cmll-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[cmllt4-sparcv9.S]=asm/cmllt4-sparcv9.pl $(PERLASM_SCHEME)

--- a/crypto/cast/build.info
+++ b/crypto/cast/build.info
@@ -2,5 +2,7 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         c_skey.c c_ecb.c {- $target{cast_asm_src} -} c_cfb64.c c_ofb64.c
 
-GENERATE[cast-586.s]=asm/cast-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[cast-586.s]=asm/cast-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[cast-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -1,7 +1,9 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]={- $target{chacha_asm_src} -}
 
-GENERATE[chacha-x86.s]=asm/chacha-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[chacha-x86.s]=asm/chacha-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 GENERATE[chacha-x86_64.s]=asm/chacha-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[chacha-ppc.s]=asm/chacha-ppc.pl $(PERLASM_SCHEME)
 GENERATE[chacha-armv4.S]=asm/chacha-armv4.pl $(PERLASM_SCHEME)

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -11,7 +11,9 @@ GENERATE[des_enc-sparc.S]=asm/des_enc.m4
 GENERATE[dest4-sparcv9.S]=asm/dest4-sparcv9.pl $(PERLASM_SCHEME)
 INCLUDE[dest4-sparcv9.o]=..
 
-GENERATE[des-586.s]=asm/des-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[des-586.s]=asm/des-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 DEPEND[des-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
-GENERATE[crypt586.s]=asm/crypt586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[crypt586.s]=asm/crypt586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 DEPEND[crypt586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -8,7 +8,9 @@ SOURCE[../../libcrypto]=\
         ecdsa_ossl.c ecdsa_sign.c ecdsa_vrf.c curve25519.c ecx_meth.c \
         {- $target{ec_asm_src} -}
 
-GENERATE[ecp_nistz256-x86.s]=asm/ecp_nistz256-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[ecp_nistz256-x86.s]=asm/ecp_nistz256-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 
 GENERATE[ecp_nistz256-x86_64.s]=asm/ecp_nistz256-x86_64.pl $(PERLASM_SCHEME)
 

--- a/crypto/md5/build.info
+++ b/crypto/md5/build.info
@@ -2,7 +2,8 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         md5_dgst.c md5_one.c {- $target{md5_asm_src} -}
 
-GENERATE[md5-586.s]=asm/md5-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[md5-586.s]=asm/md5-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 
 GENERATE[md5-x86_64.s]=asm/md5-x86_64.pl $(PERLASM_SCHEME)
 

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -6,8 +6,11 @@ SOURCE[../../libcrypto]=\
 
 INCLUDE[gcm128.o]=..
 
-GENERATE[ghash-ia64.s]=asm/ghash-ia64.pl $(CFLAGS) $(LIB_CFLAGS)
-GENERATE[ghash-x86.s]=asm/ghash-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[ghash-ia64.s]=asm/ghash-ia64.pl \
+        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+GENERATE[ghash-x86.s]=asm/ghash-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 GENERATE[ghash-x86_64.s]=asm/ghash-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[aesni-gcm-x86_64.s]=asm/aesni-gcm-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[ghash-sparcv9.S]=asm/ghash-sparcv9.pl $(PERLASM_SCHEME)

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -6,7 +6,9 @@ SOURCE[../../libcrypto]=\
 
 GENERATE[poly1305-sparcv9.S]=asm/poly1305-sparcv9.pl $(PERLASM_SCHEME)
 INCLUDE[poly1305-sparcv9.o]=..
-GENERATE[poly1305-x86.s]=asm/poly1305-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[poly1305-x86.s]=asm/poly1305-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 GENERATE[poly1305-x86_64.s]=asm/poly1305-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[poly1305-ppc.s]=asm/poly1305-ppc.pl $(PERLASM_SCHEME)
 GENERATE[poly1305-ppcfp.s]=asm/poly1305-ppcfp.pl $(PERLASM_SCHEME)

--- a/crypto/rc4/build.info
+++ b/crypto/rc4/build.info
@@ -2,7 +2,9 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         {- $target{rc4_asm_src} -}
 
-GENERATE[rc4-586.s]=asm/rc4-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[rc4-586.s]=asm/rc4-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[rc4-586.s]=../perlasm/x86asm.pl
 
 GENERATE[rc4-x86_64.s]=asm/rc4-x86_64.pl $(PERLASM_SCHEME)

--- a/crypto/rc5/build.info
+++ b/crypto/rc5/build.info
@@ -2,5 +2,6 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         rc5_skey.c rc5_ecb.c {- $target{rc5_asm_src} -} rc5cfb64.c rc5ofb64.c
 
-GENERATE[rc5-586.s]=asm/rc5-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[rc5-586.s]=asm/rc5-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 DEPEND[rc5-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -2,5 +2,6 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         rmd_dgst.c rmd_one.c {- $target{rmd160_asm_src} -}
 
-GENERATE[rmd-586.s]=asm/rmd-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[rmd-586.s]=asm/rmd-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 DEPEND[rmd-586.s]=../perlasm/x86asm.pl

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -3,16 +3,25 @@ SOURCE[../../libcrypto]=\
         sha1dgst.c sha1_one.c sha256.c sha512.c {- $target{sha1_asm_src} -} \
         keccak1600.c
 
-GENERATE[sha1-586.s]=asm/sha1-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[sha1-586.s]=asm/sha1-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[sha1-586.s]=../perlasm/x86asm.pl
-GENERATE[sha256-586.s]=asm/sha256-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[sha256-586.s]=asm/sha256-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[sha256-586.s]=../perlasm/x86asm.pl
-GENERATE[sha512-586.s]=asm/sha512-586.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[sha512-586.s]=asm/sha512-586.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[sha512-586.s]=../perlasm/x86asm.pl
 
-GENERATE[sha1-ia64.s]=asm/sha1-ia64.pl $(CFLAGS) $(LIB_CFLAGS)
-GENERATE[sha256-ia64.s]=asm/sha512-ia64.pl $(CFLAGS) $(LIB_CFLAGS)
-GENERATE[sha512-ia64.s]=asm/sha512-ia64.pl $(CFLAGS) $(LIB_CFLAGS)
+GENERATE[sha1-ia64.s]=asm/sha1-ia64.pl \
+        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+GENERATE[sha256-ia64.s]=asm/sha512-ia64.pl \
+        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+GENERATE[sha512-ia64.s]=asm/sha512-ia64.pl \
+        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
 
 GENERATE[sha1-alpha.S]=asm/sha1-alpha.pl $(PERLASM_SCHEME)
 

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -1,7 +1,9 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=wp_dgst.c {- $target{wp_asm_src} -}
 
-GENERATE[wp-mmx.s]=asm/wp-mmx.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+GENERATE[wp-mmx.s]=asm/wp-mmx.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
 DEPEND[wp-mmx.s]=../perlasm/x86asm.pl
 
 GENERATE[wp-x86_64.s]=asm/wp-x86_64.pl $(PERLASM_SCHEME)

--- a/engines/build.info
+++ b/engines/build.info
@@ -37,6 +37,8 @@ IF[{- !$disabled{"engine"} -}]
     INCLUDE[ossltest]=../include
   ENDIF
 
-  GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(PROCESSOR)
+  GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl \
+        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PROCESSOR)
   GENERATE[e_padlock-x86_64.s]=asm/e_padlock-x86_64.pl $(PERLASM_SCHEME)
 ENDIF


### PR DESCRIPTION
The first step is to separate C preprocessor flags from C flags, which
has the advantage that we don't get loads of macro definitions and
inclusion directory specs when linking shared libraries, DSOs and
programs.

With that done, we can support a large set of "make variables" that we use:

```
AR              (GNU compatible)
ARFLAGS         (GNU Compatible)
AS              (GNU Compatible)
ASFLAGS         (GNU Compatible)
CC              (GNU Compatible)
CFLAGS          (GNU Compatible)
CXX             (GNU Compatible)
CXXFLAGS        (GNU Compatible)
CPP             (GNU Compatible)
CPPFLAGS        (GNU Compatible)
CPPDEFINES      List of CPP macro definitions.  Alternative for -D
CPPINCLUDES     List of CPP inclusion directories.  Alternative for -I
HASHBANGPERL    Perl invocation to be inserted after '#!' in public
                perl scripts.
LDFLAGS         (GNU Compatible)
LDLIBS          (GNU Compatible)
RANLIB          Program to generate library archive index
RC              Program to manipulate Windows resources
RCFLAGS         Flags for $(RC)
RM              (GNU Compatible)
```

Setting one of these overrides the corresponding data from our config
targets.  However, flags given directly on the configuration command
line are additional, and are therefore added to the flags coming from
one of the variables above or the config target.

Fixes #2420
