### PR TITLE
Fix WinCE config target

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1433,7 +1433,7 @@ my %targets = (
                                      : " /MC"; }),
                    debug   => "/Od",
                    release => "/O1i"),
-        cppflags         => sub { vc_wince_info()->{defines}; },
+        cppflags         => sub { vc_wince_info()->{cppflags}; },
         defines          =>
             picker(default => [ "UNICODE", "_UNICODE", "OPENSSL_SYS_WINCE",
                                 "WIN32_LEAN_AND_MEAN", "L_ENDIAN", "DSO_WIN32",


### PR DESCRIPTION
vc_wince_info()->{defines} was left around, when it should be
vc_wince_info()->{cppflags}
