### PR TITLE
Make configdata.pm runnable and move all display of information there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ before_script:
           fi;
           $srcdir/config -v $CONFIG_OPTS;
       fi
+    - ./configdata.pm --dump
     - cd $top
 
 script:

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.0f and 1.1.1 [xx XXX xxxx]
 
+  *) Changed Configure so it only says what it does and doesn't dump
+     so much data.  Instead, ./configdata.pm should be used as a script
+     to display all sorts of configuration data.
+     [Richard Levitte]
+
   *) Added processing of "make variables" to Configure.
      [Richard Levitte]
 

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -545,8 +545,7 @@ debug_logicals :
 # Building targets ###################################################
 
 configdata.pm : $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{build_file_templates}}, @{$config{build_infos}}, @{$config{conf_files}}) -}
-        @ WRITE SYS$OUTPUT "Reconfiguring..."
-        perl $(SRCDIR)Configure reconf
+        perl configdata.pm -r -v
         @ WRITE SYS$OUTPUT "*************************************************"
         @ WRITE SYS$OUTPUT "***                                           ***"
         @ WRITE SYS$OUTPUT "***   Please run the same mms command again   ***"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -785,8 +785,7 @@ openssl.pc:
 
 configdata.pm: $(SRCDIR)/Configure $(SRCDIR)/config {- join(" ", @{$config{build_file_templates}}, @{$config{build_infos}}, @{$config{conf_files}}) -}
 	@echo "Detected changed: $?"
-	@echo "Reconfiguring..."
-	$(PERL) $(SRCDIR)/Configure reconf
+	$(PERL) configdata.pm -r -v
 	@echo "**************************************************"
 	@echo "***                                            ***"
 	@echo "***   Please run the same make command again   ***"

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -370,8 +370,7 @@ uninstall_html_docs:
 
 configdata.pm: "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{build_file_templates}}, @{$config{build_infos}}, @{$config{conf_files}}) -}
 	@echo "Detected changed: $?"
-	@echo "Reconfiguring..."
-	"$(PERL)" "$(SRCDIR)\Configure" reconf
+	"$(PERL)" configdata.pm -r -v
 	@echo "**************************************************"
 	@echo "***                                            ***"
 	@echo "***   Please run the same make command again   ***"

--- a/Configure
+++ b/Configure
@@ -2554,6 +2554,17 @@ my %builders = (
 
 $builders{$builder}->($builder_platform, @builder_opts);
 
+# Show a note on the use of configdata.pm, but ONLY for release 1.1.1
+# (i.e. this message disappears with the following update, 1.1.1a)
+print <<"EOF" if ($config{version_num} =~ m|^0x1010100.L$|);
+
+NOTE: Starting with OpenSSL 1.1.1, 'Configure' doesn't display all the disabled
+options or the "make variables" with their values.  Instead, you must use
+'configdata.pm' as a script to get a display of the configuration data.  For
+help, please do this:
+
+        perl configdata.pm --help
+EOF
 print <<"EOF" if ($disabled{threads} eq "unavailable");
 
 The library could not be configured for supporting multi-threaded

--- a/Configure
+++ b/Configure
@@ -2327,6 +2327,7 @@ unless (caller) {
 
     my $here = dirname($0);
 
+    my $dump = undef;
     my $cmdline = undef;
     my $envvars = undef;
     my $makevars = undef;

--- a/Configure
+++ b/Configure
@@ -1098,7 +1098,7 @@ foreach my $what (sort keys %disabled) {
     if (!grep { $what eq $_ } ( 'dso', 'threads', 'shared', 'pic',
                                 'dynamic-engine', 'makedepend',
                                 'zlib-dynamic', 'zlib', 'sse2' )) {
-        my $WHAT = uc $what;
+        (my $WHAT = uc $what) =~ s|-|_|g;
 
         # Fix up C macro end names
         $WHAT = "RMD160" if $what eq "ripemd";

--- a/Configure
+++ b/Configure
@@ -2347,10 +2347,14 @@ unless (caller) {
                'man'                    => \$man)
         or die "Errors in command line arguments\n";
 
-    pod2usage(-exitval => 2,
-              -verbose => 0)
-        unless ($dump || $cmdline || $envvars || $makevars || $buildparams
-                || $reconf || $verbose || $help || $man);
+    unless ($dump || $cmdline || $envvars || $makevars || $buildparams
+            || $reconf || $verbose || $help || $man) {
+        print STDERR <<"_____";
+You must give at least one option.
+For more information, do '$0 --help'
+_____
+        exit(2);
+    }
 
     if ($help) {
         pod2usage(-exitval => 0,

--- a/Configure
+++ b/Configure
@@ -2401,10 +2401,10 @@ _____
         my @buildfile = ($config{builddir}, $config{build_file});
         unshift @buildfile, $here
             unless file_name_is_absolute($config{builddir});
-        print "\nbuild file:\n";
-        print "\n    ", canonpath(catfile(@buildfile));
+        print "\nbuild file:\n\n";
+        print "    ", canonpath(catfile(@buildfile)),"\n";
 
-        print "\nbuild file templates:\n";
+        print "\nbuild file templates:\n\n";
         foreach (@{$config{build_file_templates}}) {
             my @tmpl = ($_);
             unshift @tmpl, $here

--- a/Configure
+++ b/Configure
@@ -2444,7 +2444,7 @@ _____
         }
 
         chdir $here;
-        exec $config{perl},catfile($config{sourcedir}, 'Configure'),'reconf';
+        exec $^X,catfile($config{sourcedir}, 'Configure'),'reconf';
     }
 }
 

--- a/Configure
+++ b/Configure
@@ -226,11 +226,6 @@ if (grep /^reconf(igure)?$/, @argvcopy) {
 	die "Incorrect data to reconfigure, please do a normal configuration\n"
 	    if (grep(/^reconf/,@argvcopy));
 	$config{perlenv} = $configdata::config{perlenv} // {};
-
-	print "Reconfiguring with: ", join(" ",@argvcopy), "\n";
-	foreach (sort keys %{$config{perlenv}}) {
-	    print "    $_ = $config{perlenv}->{$_}\n";
-	}
     } else {
 	die "Insufficient data to reconfigure, please do a normal configuration\n";
     }
@@ -2176,8 +2171,11 @@ foreach (grep /_(asm|aux)_src$/, keys %target) {
 
 # Write down our configuration where it fits #########################
 
+print "Creating configdata.pm\n";
 open(OUT,">configdata.pm") || die "unable to create configdata.pm: $!\n";
 print OUT <<"EOF";
+#! $config{hashbangperl}
+
 package configdata;
 
 use strict;
@@ -2312,36 +2310,214 @@ if ($builder eq "unified") {
 
 EOF
 }
-print OUT "1;\n";
-close(OUT);
+print OUT "my \%makevars = (\n";
+foreach (sort keys %user) {
+    print OUT '    ',$_,' ' x (20 - length $_),'=> ',
+        "'",$user_to_target{$_} || lc $_,"',\n";
+}
+print OUT ");\n";
+print OUT << 'EOF';
 
-print "\n";
-print "PROCESSOR     =$config{processor}\n" if $config{processor};
-print "PERL          =$config{perl}\n";
-print "PERLVERSION   =$Config{version} for $Config{archname}\n";
-print "HASHBANGPERL  =$config{hashbangperl}\n";
-print "DEFINES       =",join(" ", @{$config{defines}}),"\n"
-    if defined $config{defines};
-print "INCLUDES      =",join(" ", @{$config{includes}}),"\n"
-    if defined $config{includes};
-print "CPPFLAGS      =",join(" ", @{$config{cppflags}}),"\n"
-    if defined $config{cppflags};
-print "CC            =$config{cross_compile_prefix}$config{cc}\n";
-print "CFLAGS        =",join(" ", @{$config{cflags}}),"\n"
-    if defined $config{cflags};
-print "CXX           =$config{cross_compile_prefix}$config{cxx}\n"
-    if defined $config{cxx};
-print "CXXFLAGS      =",join(" ", @{$config{cxxflags}}),"\n"
-    if defined $config{cxxflags};
-print "LD            =$config{cross_compile_prefix}$config{ld}\n"
-    if defined $config{ld};
-print "LDFLAGS       =",join(" ", @{$config{lflags}}),"\n"
-    if defined $config{lflags};
-print "EX_LIBS       =",join(" ", @{$config{ex_libs}}),"\n"
-    if defined $config{ex_libs};
+# If run directly, we can give some answers, and even reconfigure
+unless (caller) {
+    use Getopt::Long;
+    use File::Spec::Functions;
+    use File::Basename;
+    use Pod::Usage;
+
+    my $here = dirname($0);
+
+    my $cmdline = undef;
+    my $envvars = undef;
+    my $makevars = undef;
+    my $buildparams = undef;
+    my $reconf = undef;
+    my $verbose = undef;
+    my $help = undef;
+    my $man = undef;
+    GetOptions('dump|d'                 => \$dump,
+               'command-line|c'         => \$cmdline,
+               'environment|e'          => \$envvars,
+               'make-variables|m'       => \$makevars,
+               'build-parameters|b'     => \$buildparams,
+               'reconfigure|reconf|r'   => \$reconf,
+               'verbose|v'              => \$verbose,
+               'help'                   => \$help,
+               'man'                    => \$man)
+        or die "Errors in command line arguments\n";
+
+    pod2usage(-exitval => 2,
+              -verbose => 0)
+        unless ($dump || $cmdline || $envvars || $makevars || $buildparams
+                || $reconf || $verbose || $help || $man);
+
+    if ($help) {
+        pod2usage(-exitval => 0,
+                  -verbose => 1);
+    }
+    if ($man) {
+        pod2usage(-exitval => 0,
+                  -verbose => 2);
+    }
+    if ($dump || $cmdline) {
+        print "\n(with current working directory = $here)";
+        print "\nCommand line:\n\n";
+        print '    ',join(' ',
+                          $config{perl},
+                          catfile($config{sourcedir}, 'Configure'),
+                          @{$config{perlargv}}), "\n";
+    }
+    if ($dump || $envvars) {
+        print "\nRecorded environment:\n\n";
+        foreach (sort keys %{$config{perlenv}}) {
+            print '    ',$_,' = ',($config{perlenv}->{$_} || ''),"\n";
+        }
+    }
+    if ($dump || $makevars) {
+        print "\nMakevars:\n\n";
+        foreach (sort keys %makevars) {
+            print '    ',$_,' ' x (16 - length $_),'= ',
+                (ref $config{$makevars{$_}} eq 'ARRAY'
+                 ? join(' ', @{$config{$makevars{$_}}})
+                 : $config{$makevars{$_}}),
+                "\n"
+                if defined $config{$makevars{$_}};
+        }
+
+        my @buildfile = ($config{builddir}, $config{build_file});
+        unshift @buildfile, $here
+            unless file_name_is_absolute($config{builddir});
+        my $buildfile = canonpath(catdir(@buildfile));
+        print <<"_____";
+
+NOTE: These variables only represent the configuration view.  The build file
+template may have processed these variables further, please have a look at the
+build file for more exact data:
+    $buildfile
+_____
+    }
+    if ($dump || $buildparams) {
+        my @buildfile = ($config{builddir}, $config{build_file});
+        unshift @buildfile, $here
+            unless file_name_is_absolute($config{builddir});
+        print "\nbuild file:\n";
+        print "\n    ", canonpath(catfile(@buildfile));
+
+        print "\nbuild file templates:\n";
+        foreach (@{$config{build_file_templates}}) {
+            my @tmpl = ($_);
+            unshift @tmpl, $here
+                unless file_name_is_absolute($config{sourcedir});
+            print '    ',canonpath(catfile(@tmpl)),"\n";
+        }
+    }
+    if ($reconf) {
+        if ($verbose) {
+            print 'Reconfiguring with: ', join(' ',@{$config{perlargv}}), "\n";
+	    foreach (sort keys %{$config{perlenv}}) {
+	        print '    ',$_,' = ',($config{perlenv}->{$_} || ""),"\n";
+	    }
+        }
+
+        chdir $here;
+        exec $config{perl},catfile($config{sourcedir}, 'Configure'),'reconf';
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+configdata.pm - configuration data for OpenSSL builds
+
+=head1 SYNOPSIS
+
+Interactive:
+
+  perl configdata.pm [options]
+
+As data bank module:
+
+  use configdata;
+
+=head1 DESCRIPTION
+
+This module can be used in two modes, interactively and as a module containing
+all the data recorded by OpenSSL's Configure script.
+
+When used interactively, simply run it as any perl script, with at least one
+option, and you will get the information you ask for.  See L</OPTIONS> below.
+
+When loaded as a module, you get a few databanks with useful information to
+perform build related tasks.  The databanks are:
+
+    %config             Configured things.
+    %target             The OpenSSL config target with all inheritances
+                        resolved.
+    %disabled           The features that are disabled.
+    @disablables        The list of features that can be disabled.
+    %withargs           All data given through --with-THING options.
+    %unified_info       All information that was computed from the build.info
+                        files.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<--help>
+
+Print a brief help message and exit.
+
+=item B<--man>
+
+Print the manual page and exit.
+
+=item B<--dump> | B<-c>
+
+Print all relevant configuration data.  This is equivalent to B<--command-line>
+B<--environment> B<--make-variables> B<--build-parameters>.
+
+=item B<--command-line> | B<-c>
+
+Print the current configuration command line.
+
+=item B<--environment> | B<-e>
+
+Print the environment variables and their values at the time of configuration.
+
+=item B<--make-variables> | B<-m>
+
+Print the main make variables generated in the current configuration
+
+=item B<--build-parameters> | B<-b>
+
+Print the build parameters, i.e. build file and build file templates.
+
+=item B<--reconfigure> | B<--reconf> | B<-r>
+
+Redo the configuration.
+
+=item B<--verbose> | B<-v>
+
+Verbose output.
+
+=back
+
+=cut
+
+EOF
+close(OUT);
+if ($builder_platform eq 'unix') {
+    my $mode = (0755 & ~umask);
+    chmod $mode, 'configdata.pm'
+        or warn sprintf("WARNING: Couldn't change mode for 'configdata.pm' to 0%03o: %s\n",$mode,$!);
+}
 
 my %builders = (
     unified => sub {
+        print 'Creating ',$target{build_file},"\n";
         run_dofile(catfile($blddir, $target{build_file}),
                    @{$config{build_file_templates}});
     },

--- a/Configure
+++ b/Configure
@@ -1024,68 +1024,6 @@ foreach my $feature (@{$target{enable}}) {
     }
 }
 
-foreach (sort (keys %disabled))
-	{
-	$config{options} .= " no-$_";
-
-	printf "    no-%-12s %-10s", $_, "[$disabled{$_}]";
-
-	if (/^dso$/)
-		{ }
-	elsif (/^threads$/)
-		{ }
-	elsif (/^shared$/)
-		{ }
-	elsif (/^pic$/)
-		{ }
-	elsif (/^zlib$/)
-		{ }
-	elsif (/^dynamic-engine$/)
-		{ }
-	elsif (/^makedepend$/)
-		{ }
-	elsif (/^zlib-dynamic$/)
-		{ }
-	elsif (/^sse2$/)
-		{ }
-	elsif (/^engine$/)
-		{
-		@{$config{dirs}} = grep !/^engines$/, @{$config{dirs}};
-		@{$config{sdirs}} = grep !/^engine$/, @{$config{sdirs}};
-		push @{$config{openssl_other_defines}}, "OPENSSL_NO_ENGINE";
-		print " OPENSSL_NO_ENGINE (skip engines)";
-		}
-	else
-		{
-		my ($WHAT, $what);
-
-		($WHAT = $what = $_) =~ tr/[\-a-z]/[_A-Z]/;
-
-		# Fix up C macro end names
-		$WHAT = "RMD160" if $what eq "ripemd";
-
-		# fix-up crypto/directory name(s)
-		$what = "ripemd" if $what eq "rmd160";
-		$what = "whrlpool" if $what eq "whirlpool";
-
-		if ($what ne "async" && $what ne "err"
-		    && grep { $_ eq $what } @{$config{sdirs}})
-			{
-			push @{$config{openssl_algorithm_defines}}, "OPENSSL_NO_$WHAT";
-			@{$config{sdirs}} = grep { $_ ne $what} @{$config{sdirs}};
-
-			print " OPENSSL_NO_$WHAT (skip dir)";
-			}
-		else
-			{
-			push @{$config{openssl_other_defines}}, "OPENSSL_NO_$WHAT";
-			print " OPENSSL_NO_$WHAT";
-			}
-		}
-
-	print "\n";
-	}
-
 $target{cxxflags}//=$target{cflags} if $target{cxx};
 $target{exe_extension}="";
 $target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
@@ -1149,6 +1087,46 @@ $config{plib_lflags} = [ $target{plib_lflags} ];
 
 # Allow overriding the build file name
 $config{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
+
+# ALL USE OF %useradd MUST BE DONE FROM HERE ON
+%useradd = undef;
+
+my %disabled_info = ();         # For configdata.pm
+foreach my $what (sort keys %disabled) {
+    $config{options} .= " no-$what";
+
+    if (!grep { $what eq $_ } ( 'dso', 'threads', 'shared', 'pic',
+                                'dynamic-engine', 'makedepend',
+                                'zlib-dynamic', 'zlib', 'sse2' )) {
+        my $WHAT = uc $what;
+
+        # Fix up C macro end names
+        $WHAT = "RMD160" if $what eq "ripemd";
+
+        # fix-up crypto/directory name(s)
+        $what = "ripemd" if $what eq "rmd160";
+        $what = "whrlpool" if $what eq "whirlpool";
+
+        my $macro = $disabled_info{$what}->{macro} = "OPENSSL_NO_$WHAT";
+
+        if ((grep { $what eq $_ } @{$config{sdirs}})
+                && $what ne 'async' && $what ne 'err') {
+            @{$config{sdirs}} = grep { $what ne $_} @{$config{sdirs}};
+            $disabled_info{$what}->{skipped} = [ catdir('crypto', $what) ];
+
+            if ($what ne 'engine') {
+                push @{$config{openssl_algorithm_defines}}, $macro;
+            } else {
+                @{$config{dirs}} = grep !/^engines$/, @{$config{dirs}};
+                push @{$disabled_info{engine}->{skipped}}, catdir('engines');
+                push @{$config{openssl_other_defines}}, $macro;
+            }
+        } else {
+            push @{$config{openssl_other_defines}}, $macro;
+        }
+
+    }
+}
 
 # Make sure build_scheme is consistent.
 $target{build_scheme} = [ $target{build_scheme} ]
@@ -2316,8 +2294,23 @@ foreach (sort keys %user) {
         "'",$user_to_target{$_} || lc $_,"',\n";
 }
 print OUT ");\n";
+print OUT "my \%disabled_info = (\n";
+foreach my $what (sort keys %disabled_info) {
+    print OUT "    '$what' => {\n";
+    foreach my $info (sort keys %{$disabled_info{$what}}) {
+        if (ref $disabled_info{$what}->{$info} eq 'ARRAY') {
+            print OUT "        $info => [ ",
+                join(', ', map { "'$_'" } @{$disabled_info{$what}->{$info}}),
+                " ],\n";
+        } else {
+            print OUT "        $info => '", $disabled_info{$what}->{$info},
+                "',\n";
+        }
+    }
+    print OUT "    },\n";
+}
+print OUT ");\n";
 print OUT << 'EOF';
-
 # If run directly, we can give some answers, and even reconfigure
 unless (caller) {
     use Getopt::Long;
@@ -2329,6 +2322,7 @@ unless (caller) {
 
     my $dump = undef;
     my $cmdline = undef;
+    my $options = undef;
     my $envvars = undef;
     my $makevars = undef;
     my $buildparams = undef;
@@ -2338,6 +2332,7 @@ unless (caller) {
     my $man = undef;
     GetOptions('dump|d'                 => \$dump,
                'command-line|c'         => \$cmdline,
+               'options|o'              => \$options,
                'environment|e'          => \$envvars,
                'make-variables|m'       => \$makevars,
                'build-parameters|b'     => \$buildparams,
@@ -2347,8 +2342,8 @@ unless (caller) {
                'man'                    => \$man)
         or die "Errors in command line arguments\n";
 
-    unless ($dump || $cmdline || $envvars || $makevars || $buildparams
-            || $reconf || $verbose || $help || $man) {
+    unless ($dump || $cmdline || $options || $envvars || $makevars
+            || $buildparams || $reconf || $verbose || $help || $man) {
         print STDERR <<"_____";
 You must give at least one option.
 For more information, do '$0 --help'
@@ -2371,6 +2366,30 @@ _____
                           $config{perl},
                           catfile($config{sourcedir}, 'Configure'),
                           @{$config{perlargv}}), "\n";
+    }
+    if ($dump || $options) {
+        my $longest = 0;
+        foreach my $what (@disablables) {
+            $longest = length($what) if $longest < length($what);
+        }
+        print "\nEnabled features:\n\n";
+        foreach my $what (@disablables) {
+            print "    $what\n" unless $disabled{$what};
+        }
+        print "\nDisabled features:\n\n";
+        foreach my $what (@disablables) {
+            if ($disabled{$what}) {
+                print "    $what", ' ' x ($longest - length($what) + 1),
+                    "[$disabled{$what}]", ' ' x (10 - length($disabled{$what}));
+                print $disabled_info{$what}->{macro}
+                    if $disabled_info{$what}->{macro};
+                print ' (skip ',
+                    join(', ', @{$disabled_info{$what}->{skipped}}),
+                    ')'
+                    if $disabled_info{$what}->{skipped};
+                print "\n";
+            }
+        }
     }
     if ($dump || $envvars) {
         print "\nRecorded environment:\n\n";
@@ -2482,11 +2501,16 @@ Print the manual page and exit.
 =item B<--dump> | B<-c>
 
 Print all relevant configuration data.  This is equivalent to B<--command-line>
-B<--environment> B<--make-variables> B<--build-parameters>.
+B<--options> B<--environment> B<--make-variables> B<--build-parameters>.
 
 =item B<--command-line> | B<-c>
 
 Print the current configuration command line.
+
+=item B<--options> | B<-o>
+
+Print the features, both enabled and disabled, and display defined macro and
+skipped directories where applicable.
 
 =item B<--environment> | B<-e>
 

--- a/INSTALL
+++ b/INSTALL
@@ -635,11 +635,11 @@
 
  For more information, please do:
 
-       $ ./configdata.pm -help                          # Unix
+       $ ./configdata.pm --help                         # Unix
 
        or
 
-       $ perl configdata.pm -help                       # Windows and VMS
+       $ perl configdata.pm --help                      # Windows and VMS
 
  Installation in Detail
  ----------------------

--- a/INSTALL
+++ b/INSTALL
@@ -625,6 +625,22 @@
                    precedence over environment variables that are defined
                    when reconfiguring.
 
+ Displaying configuration data
+ -----------------------------
+
+ The configuration script itself will say very little, and finishes by
+ creating "configdata.pm".  This perl module can be loaded by other scripts
+ to find all the configuration data, and it can also be used as a script to
+ display all sorts of configuration data in a human readable form.
+
+ For more information, please do:
+
+       $ ./configdata.pm -help                          # Unix
+
+       or
+
+       $ perl configdata.pm -help                       # Windows and VMS
+
  Installation in Detail
  ----------------------
 

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@
 
   Major changes between OpenSSL 1.1.0f and OpenSSL 1.1.1 [under development]
 
+      o Move the display of configuration data to configdata.pm.
       o Allow GNU style "make variables" to be used with Configure.
       o Add a STORE module (OSSL_STORE)
       o Claim the namespaces OSSL and OPENSSL, represented as symbol prefixes

--- a/README
+++ b/README
@@ -68,7 +68,7 @@
  and create an issue on GitHub:
 
     - OpenSSL version: output of 'openssl version -a'
-    - Configuration data: output of 'perl configdata.pm -dump'
+    - Configuration data: output of 'perl configdata.pm --dump'
     - OS Name, Version, Hardware platform
     - Compiler Details (name, version)
     - Application Details (name, version)

--- a/README
+++ b/README
@@ -68,8 +68,7 @@
  and create an issue on GitHub:
 
     - OpenSSL version: output of 'openssl version -a'
-    - Any "Configure" options that you selected during compilation of the
-      library if applicable (see INSTALL)
+    - Configuration data: output of 'perl configdata.pm -dump'
     - OS Name, Version, Hardware platform
     - Compiler Details (name, version)
     - Application Details (name, version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ before_build:
     - mkdir _build
     - cd _build
     - perl ..\Configure %TARGET% %SHARED%
+    - perl configdata.pm --dump
     - cd ..
     - ps: >-
         if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`


### PR DESCRIPTION
The "make variable" information displayed by Configure was selective
and incomplete, and possibly undesirable (too verbose).

Instead, we make configdata.pm and have the user run it to get the
information they desire, and also make it possible to have it perform
a reconfiguration.

Possibilities so far:

```
perl configdata.pm --dump               Displays everything (i.e. the
                                        combined output from
                                        --command-line, --environment,
                                        --make-variables and
                                        --build-parameters.
perl configdata.pm --command-line       Displays the config command
                                        line.
perl configdata.pm --options            Display the features, both
                                        enabled and disabled, and
                                        display defined macro and
                                        skipped directories where
                                        applicable.perl configdata.pm --envirnoment        Displays the recorded
                                        environment variables.
perl configdata.pm --make-variables     Displays the configured "make
                                        variables".
perl configdata.pm --build-parameters   Displays the build file and
                                        the template files to create
                                        it.
perl configdata.pm --reconfigure        Re-runs the configuration with
                                        the recorded environment
                                        variables.
```

--verbose can be used to have --reconfigure be a bit more verbose.
