### PR TITLE
crypto/rand/rand_lib.c: fix undefined reference to `clock_gettime'

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -210,7 +210,7 @@ size_t rand_drbg_get_additional_data(unsigned char **pout, size_t max_len)
     size_t len;
 #ifdef OPENSSL_SYS_UNIX
     pid_t pid;
-    struct timespec ts;
+    struct timeval tv;
 #elif defined(OPENSSL_SYS_WIN32)
     DWORD pid;
     FILETIME ft;
@@ -241,10 +241,8 @@ size_t rand_drbg_get_additional_data(unsigned char **pout, size_t max_len)
 #endif
 
 #ifdef OPENSSL_SYS_UNIX
-    if (tsc == 0 && clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
-        RAND_POOL_add(pool, (unsigned char *)&ts, sizeof(ts), 0);
-    if (clock_gettime(CLOCK_REALTIME, &ts) == 0)
-        RAND_POOL_add(pool, (unsigned char *)&ts, sizeof(ts), 0);
+    if (gettimeofday(&tv, NULL) == 0)
+        RAND_POOL_add(pool, (unsigned char *)&tv, sizeof(tv), 0);
 #elif defined(OPENSSL_SYS_WIN32)
     if (tsc == 0 && QueryPerformanceCounter(&pc) != 0)
         RAND_POOL_add(pool, (unsigned char *)&pc, sizeof(pc), 0);

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -216,7 +216,9 @@ size_t rand_drbg_get_additional_data(unsigned char **pout, size_t max_len)
     FILETIME ft;
     LARGE_INTEGER pc;
 #endif
+#ifdef OPENSSL_CPUID_OBJ
     uint32_t tsc = 0;
+#endif
 
     pool = RAND_POOL_new(0, 0, max_len);
     if (pool == NULL)
@@ -244,7 +246,7 @@ size_t rand_drbg_get_additional_data(unsigned char **pout, size_t max_len)
     if (gettimeofday(&tv, NULL) == 0)
         RAND_POOL_add(pool, (unsigned char *)&tv, sizeof(tv), 0);
 #elif defined(OPENSSL_SYS_WIN32)
-    if (tsc == 0 && QueryPerformanceCounter(&pc) != 0)
+    if (QueryPerformanceCounter(&pc) != 0)
         RAND_POOL_add(pool, (unsigned char *)&pc, sizeof(pc), 0);
     GetSystemTimeAsFileTime(&ft);
     RAND_POOL_add(pool, (unsigned char *)&ft, sizeof(ft), 0);


### PR DESCRIPTION
Add feature test (_POSIX_C_SOURCE >= 199309L) for clock_gettime()
and fall back to gettimeofday() if clock_gettime() is not available.

Signed-off-by: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>


Fixes: https://mta.openssl.org/pipermail/openssl-commits/2018-January/017804.html