### PR TITLE
Ignore an s_client psk in TLSv1.3 if not TLSv1.3 suitable

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -207,7 +207,7 @@ static int psk_use_session_cb(SSL *s, const EVP_MD *md,
             *id = NULL;
             *idlen = 0;
             *sess = NULL;
-            return 0;
+            return 1;
         }
         usesess = SSL_SESSION_new();
         if (usesess == NULL

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -349,7 +349,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
     {
         TLSEXT_TYPE_early_data,
         SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS
-        | SSL_EXT_TLS1_3_NEW_SESSION_TICKET,
+        | SSL_EXT_TLS1_3_NEW_SESSION_TICKET | SSL_EXT_TLS1_3_ONLY,
         NULL, tls_parse_ctos_early_data, tls_parse_stoc_early_data,
         tls_construct_stoc_early_data, tls_construct_ctos_early_data,
         final_early_data


### PR DESCRIPTION
The s_client psk_use_session_cb callback has a comment stating that we
should ignore a key that isn't suitable for TLSv1.3. However we were
actually causing the connection to fail. Changing the return value fixes
the issue.

Also related to this is that the early_data extension was not marked as
TLSv1.3 only which it should be.

Fixes #5202

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
