### PR TITLE
added macro to create and test openssl version numbers

### DIFF
--- a/doc/man3/OPENSSL_VERSION_NUMBER.pod
+++ b/doc/man3/OPENSSL_VERSION_NUMBER.pod
@@ -47,6 +47,11 @@ number was therefore 0x0090581f.
 
 OpenSSL_version_num() returns the version number.
 
+The macro OPENSSL_VERSION_AT_LEAST(major,minor) can be used at compile
+time test if the current version is at least as new as the version provided.
+The arguments major, minor and fix correspond to the version information
+as given above.
+
 OpenSSL_version() returns different strings depending on B<t>:
 
 =over 4

--- a/doc/man7/ssl.pod
+++ b/doc/man7/ssl.pod
@@ -89,6 +89,12 @@ includes both more private SSL headers and headers from the B<crypto> library.
 Whenever you need hard-core details on the internals of the SSL API, look
 inside this header file.
 
+OPENSSL_VERSION_AT_LEAST(major,minor) can be
+used in C<#if> statements in order to determine which version of the library is
+being used. This can be used to either enable optional features at compile
+time, or work around issues with a previous version.
+See L<OPENSSL_VERSION_NUMBER(3)>.
+
 =item B<ssl2.h>
 
 Unused. Present for backwards compatibility only.

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -42,6 +42,11 @@ extern "C" {
 # define OPENSSL_VERSION_NUMBER  0x10101000L
 # define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1-dev  xx XXX xxxx"
 
+#define OPENSSL_MAKE_VERSION(maj,min,fix,patch) ((0x10000000L)+((maj&0xff)<<20)+((min&0xff)<<12)+((fix&0xff)<<4)+patch)
+
+/* use this for #if tests, should never depend upon fix/patch */
+#define OPENSSL_VERSION_AT_LEAST(maj,min) (OPENSSL_MAKE_VERSION(maj,min, 0, 0) >= OPENSSL_VERSION_NUMBER)
+
 /*-
  * The macros below are to be used for shared library (.so, .dll, ...)
  * versioning.  That kind of versioning works a bit differently between


### PR DESCRIPTION
- [X] documentation is added or updated
- [ ] tests are added or updated

ruby-openssl works around old versions, but does so with rather invasive knowledge of the openssl versioning. This macros allow the downstream user to have cleaner code.
