### PR TITLE
Configure: Fix configdata.pm help text, shorthand for --dump should be -d

### DIFF
--- a/Configure
+++ b/Configure
@@ -2506,7 +2506,7 @@ Print a brief help message and exit.
 
 Print the manual page and exit.
 
-=item B<--dump> | B<-c>
+=item B<--dump> | B<-d>
 
 Print all relevant configuration data.  This is equivalent to B<--command-line>
 B<--options> B<--environment> B<--make-variables> B<--build-parameters>.

--- a/INSTALL
+++ b/INSTALL
@@ -510,11 +510,11 @@
 
   no-<alg>
                    Build without support for the specified algorithm, where
-                   <alg> is one of: bf, blake2, camellia, cast, chacha, cmac,
-                   des, dh, dsa, ecdh, ecdsa, idea, md4, mdc2, ocb, poly1305,
-                   rc2, rc4, rmd160, scrypt, seed, siphash, sm3, sm4 or
-                   whirlpool.  The "ripemd" algorithm is deprecated and if used
-                   is synonymous with rmd160.
+                   <alg> is one of: aria, bf, blake2, camellia, cast, chacha,
+                   cmac, des, dh, dsa, ecdh, ecdsa, idea, md4, mdc2, ocb,
+                   poly1305, rc2, rc4, rmd160, scrypt, seed, siphash, sm3, sm4
+                   or whirlpool.  The "ripemd" algorithm is deprecated and if
+                   used is synonymous with rmd160.
 
   -Dxxx, -Ixxx, -Wp, -lxxx, -Lxxx, -Wl, -rpath, -R, -framework, -static
                    These system specific options will be recognised and


### PR DESCRIPTION
The shorthand for configdata.pm's --dump is -d, not -c
This just fixes the help text, GetOptions() is correct

Signed-off-by: Peter Meerwald-Stadler <pmeerw@pmeerw.net>
