### PR TITLE
Reproducible build: do not leak compiler path

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -55,7 +55,7 @@ top:
 all: shared
 
 buildinf.h: ../Makefile
-	$(PERL) $(TOP)/util/mkbuildinf.pl "$$(basename $(CC)) $(CFLAGS)" "$(PLATFORM)" >buildinf.h
+	$(PERL) $(TOP)/util/mkbuildinf.pl "`basename $(CC)` $(CFLAGS)" "$(PLATFORM)" >buildinf.h
 
 x86cpuid.s:	x86cpuid.pl perlasm/x86asm.pl
 	$(PERL) x86cpuid.pl $(PERLASM_SCHEME) $(CFLAGS) $(PROCESSOR) > $@

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -55,7 +55,7 @@ top:
 all: shared
 
 buildinf.h: ../Makefile
-	$(PERL) $(TOP)/util/mkbuildinf.pl "$(CC) $(CFLAGS)" "$(PLATFORM)" >buildinf.h
+	$(PERL) $(TOP)/util/mkbuildinf.pl "$$(basename $(CC)) $(CFLAGS)" "$(PLATFORM)" >buildinf.h
 
 x86cpuid.s:	x86cpuid.pl perlasm/x86asm.pl
 	$(PERL) x86cpuid.pl $(PERLASM_SCHEME) $(CFLAGS) $(PROCESSOR) > $@


### PR DESCRIPTION
Enable reproducible build: do not leak compiler path into executable:
use $$(basename $(CC)) instead of $(CC) (which will contain the complete/absolute
compiler path in some cross-compile enviornments (e.g. buildroot)
 