### PR TITLE
ignore err in engine

### DIFF
--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -446,6 +446,7 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
          */
         if (vcheck_res < OSSL_DYNAMIC_OLDEST) {
             /* Fail */
+            ERR_clear_error();
             ctx->bind_engine = NULL;
             ctx->v_check = NULL;
             DSO_free(ctx->dynamic_dso);
@@ -478,6 +479,7 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
 
     /* Try to bind the ENGINE onto our own ENGINE structure */
     if (!ctx->bind_engine(e, ctx->engine_id, &fns)) {
+        ERR_clear_error();
         ctx->bind_engine = NULL;
         ctx->v_check = NULL;
         DSO_free(ctx->dynamic_dso);


### PR DESCRIPTION
The engine that loaded by ```dlopen``` may call ```ERR_PUT_error``` to save ```__FILE__``` to ```ERR_STATE```(Qat_engine does). The address of ```__FILE__``` in engine is mapped while engine is loaded, but when we call ```dlclose``` to close DSO , the address of ```__FILE__``` is unmapped, but it still exists in err_thread_local. So when we call ```ERR_print_errors``` to flush error to bio, segmentfault happens.

It's hard to restrict the third party to coding without ```ERR_PUT_error``` but we can discard the error.

Using ```RTLD_NODELETE ``` may become a solution on UNIX and FreeBSD, but not on other platform. 
  