### PR TITLE
Divide the apps modules into direct CLI command modules and support library modules

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -11,6 +11,7 @@ my %targets=(
 	thread_defines	=> [],
 
 	apps_aux_src	=> "",
+	apps_init_src	=> "",
 	cpuid_asm_src	=> "mem_clr.c",
 	uplink_aux_src	=> "",
 	bn_asm_src	=> "bn_asm.c",
@@ -134,7 +135,7 @@ my %targets=(
 
     uplink_common => {
 	template	=> 1,
-	apps_aux_src	=> add("../ms/applink.c"),
+	apps_init_src	=> add("../ms/applink.c"),
 	uplink_aux_src	=> add("../ms/uplink.c"),
 	defines		=> add("OPENSSL_USE_APPLINK"),
     },

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1852,7 +1852,8 @@ my %targets = (
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",
 
-        apps_aux_src     => "vms_decc_init.c vms_term_sock.c",
+        apps_aux_src     => "vms_term_sock.c",
+        apps_init_src    => "vms_decc_init.c",
     },
 
     "vms-alpha" => {

--- a/Configurations/README
+++ b/Configurations/README
@@ -212,8 +212,14 @@ In each table entry, the following keys are significant:
                                                 export vars as
                                                 accessor functions.
 
-        apps_extra_src  => Extra source to build apps/openssl, as
-                           needed by the target.
+        apps_aux_src    => Extra source to build apps/openssl and other
+                           apps, as needed by the target and that can be
+                           collected in a library.
+        apps_init_src   => Init source to build apps/openssl and other
+                           apps, as needed by the target.  This code
+                           cannot be placed in a library, as the rest
+                           of the code isn't expected to link to it
+                           explicitely.
         cpuid_asm_src   => assembler implementation of cpuid code as
                            well as OPENSSL_cleanse().
                            Default to mem_clr.c

--- a/Configurations/windows-checker.pm
+++ b/Configurations/windows-checker.pm
@@ -6,7 +6,7 @@ use Config;
 # we expect for the platform
 use File::Spec::Functions qw(:DEFAULT rel2abs);
 
-if (rel2abs('.') !~ m|\\|) {
+if (!$ENV{CONFIGURE_INSIST} && rel2abs('.') !~ m|\\|) {
     die <<EOF;
 
 ******************************************************************************

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -600,6 +600,4 @@ typedef struct verify_options_st {
 
 extern VERIFY_CB_ARGS verify_args;
 
-# include "progs.h"
-
 #endif

--- a/apps/asn1pars.c
+++ b/apps/asn1pars.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>

--- a/apps/build.info
+++ b/apps/build.info
@@ -1,21 +1,27 @@
 {- our $tsget_name = $config{target} =~ /^(VC|vms)-/ ? "tsget.pl" : "tsget";
    our @apps_openssl_src =
-       ( qw(openssl.c
-            asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c dhparam.c
-            dsa.c dsaparam.c ec.c ecparam.c enc.c engine.c errstr.c gendsa.c
-            genpkey.c genrsa.c nseq.c ocsp.c passwd.c pkcs12.c pkcs7.c pkcs8.c
-            pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c rsa.c rsautl.c
-            s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c
-            srp.c ts.c verify.c version.c x509.c rehash.c storeutl.c
-            apps.c opt.c s_cb.c s_socket.c
-            app_rand.c),
-          split(/\s+/, $target{apps_aux_src}) );
+       qw(openssl.c
+          asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c dhparam.c
+          dsa.c dsaparam.c ec.c ecparam.c enc.c engine.c errstr.c gendsa.c
+          genpkey.c genrsa.c nseq.c ocsp.c passwd.c pkcs12.c pkcs7.c pkcs8.c
+          pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c rsa.c rsautl.c
+          s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c
+          srp.c ts.c verify.c version.c x509.c rehash.c storeutl.c);
+   our @apps_lib_src =
+       ( qw(apps.c opt.c s_cb.c s_socket.c app_rand.c),
+         split(/\s+/, $target{apps_aux_src}) );
+   our @apps_init_src = split(/\s+/, $target{apps_init_src});
    "" -}
 IF[{- !$disabled{apps} -}]
+  LIBS_NO_INST=libapps.a
+  SOURCE[libapps.a]={- join(" ", @apps_lib_src) -}
+  INCLUDE[libapps.a]=.. ../include
+
   PROGRAMS=openssl
+  SOURCE[openssl]={- join(" ", @apps_init_src) -}
   SOURCE[openssl]={- join(" ", @apps_openssl_src) -}
   INCLUDE[openssl]=.. ../include
-  DEPEND[openssl]=../libssl
+  DEPEND[openssl]=libapps.a ../libssl
 
   {- join("\n  ", map { (my $x = $_) =~ s|\.c$|.o|; "DEPEND[$x]=progs.h" }
                   @apps_openssl_src) -}

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -32,6 +32,7 @@
 #endif
 
 #include "apps.h"
+#include "progs.h"
 
 #ifndef W_OK
 # define F_OK 0

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 
 #ifndef OPENSSL_NO_CMS
 

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/x509.h>

--- a/apps/crl2p7.c
+++ b/apps/crl2p7.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -17,6 +17,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <time.h>
 # include <string.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/bn.h>

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -17,6 +17,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <string.h>
 # include <time.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/dsa.h>

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -17,6 +17,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <time.h>
 # include <string.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/bn.h>

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -16,6 +16,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <stdlib.h>
 # include <string.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/evp.h>

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -18,6 +18,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <time.h>
 # include <string.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/bn.h>

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <limits.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -13,6 +13,7 @@ NON_EMPTY_TRANSLATION_UNIT
 #else
 
 # include "apps.h"
+# include "progs.h"
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -17,6 +17,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <sys/types.h>
 # include <sys/stat.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/bn.h>

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -17,6 +17,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <sys/types.h>
 # include <sys/stat.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/bn.h>

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/pem.h>
 #include <openssl/err.h>
 

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -25,6 +25,7 @@ NON_EMPTY_TRANSLATION_UNIT
 
 /* Needs to be included before the openssl headers */
 # include "apps.h"
+# include "progs.h"
 # include <openssl/e_os2.h>
 # include <openssl/crypto.h>
 # include <openssl/err.h>

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -27,8 +27,9 @@
 #ifdef OPENSSL_SYS_VMS
 # include <unixio.h>
 #endif
-#define INCLUDE_FUNCTION_TABLE
 #include "apps.h"
+#define INCLUDE_FUNCTION_TABLE
+#include "progs.h"
 
 /* Structure to hold the number of columns to be displayed and the
  * field width used to display them.

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "apps.h"
+#include "progs.h"
 
 #include <openssl/bio.h>
 #include <openssl/err.h>

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -16,6 +16,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <stdlib.h>
 # include <string.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/crypto.h>
 # include <openssl/err.h>
 # include <openssl/pem.h>

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/err.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -8,6 +8,7 @@
  */
 
 #include "apps.h"
+#include "progs.h"
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>

--- a/apps/prime.c
+++ b/apps/prime.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bn.h>
 
 typedef enum OPTION_choice {

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -8,6 +8,7 @@
  */
 
 #include "apps.h"
+#include "progs.h"
 
 #include <ctype.h>
 #include <stdio.h>

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -9,6 +9,7 @@
  */
 
 #include "apps.h"
+#include "progs.h"
 
 #if defined(OPENSSL_SYS_UNIX) || defined(__APPLE__) || \
     (defined(__VMS) && defined(__DECC) && __CRTL_VER >= 80300000)

--- a/apps/req.c
+++ b/apps/req.c
@@ -12,6 +12,7 @@
 #include <time.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/conf.h>

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -17,6 +17,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <string.h>
 # include <time.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/rsa.h>

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -13,6 +13,7 @@ NON_EMPTY_TRANSLATION_UNIT
 #else
 
 # include "apps.h"
+# include "progs.h"
 # include <string.h>
 # include <openssl/err.h>
 # include <openssl/pem.h>

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -30,6 +30,7 @@ typedef unsigned int u_int;
 #endif
 
 #include "apps.h"
+#include "progs.h"
 #include <openssl/x509.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -37,6 +37,7 @@ typedef unsigned int u_int;
 
 #include <openssl/bn.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -18,6 +18,7 @@
 #ifndef OPENSSL_NO_SOCK
 
 #include "apps.h"
+#include "progs.h"
 #include <openssl/x509.h>
 #include <openssl/ssl.h>
 #include <openssl/pem.h>

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/x509.h>

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/crypto.h>
 #include <openssl/pem.h>
 #include <openssl/err.h>

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <math.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/conf.h>
 #include <openssl/err.h>

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -22,6 +22,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <openssl/buffer.h>
 # include <openssl/srp.h>
 # include "apps.h"
+# include "progs.h"
 
 # define BASE_SECTION    "srp"
 # define CONFIG_FILE "openssl.cnf"

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -10,6 +10,7 @@
 #include <openssl/opensslconf.h>
 
 #include "apps.h"
+#include "progs.h"
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/store.h>

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -15,6 +15,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <stdlib.h>
 # include <string.h>
 # include "apps.h"
+# include "progs.h"
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/pem.h>

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/x509.h>

--- a/apps/version.c
+++ b/apps/version.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/bn.h>

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "apps.h"
+#include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/asn1.h>
 #include <openssl/err.h>

--- a/test/build.info
+++ b/test/build.info
@@ -12,7 +12,6 @@ IF[{- !$disabled{tests} -}]
   SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output_helpers.c \
           testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
           testutil/format_output.c testutil/tap_bio.c \
-          {- rebase_files("../apps", $target{apps_aux_src}) -} \
           testutil/test_cleanup.c testutil/main.c testutil/init.c
   INCLUDE[libtestutil.a]=../include
   DEPEND[libtestutil.a]=../libcrypto
@@ -369,9 +368,11 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
     DEPEND[cipher_overhead_test]=../libcrypto ../libssl libtestutil.a
   ENDIF
 
-  SOURCE[uitest]=uitest.c ../apps/apps.c ../apps/opt.c
+  SOURCE[uitest]=uitest.c \
+                 {- rebase_files("../apps",
+                                 split(/\s+/, $target{apps_init_src})) -}
   INCLUDE[uitest]=.. ../include ../apps
-  DEPEND[uitest]=../libcrypto ../libssl libtestutil.a
+  DEPEND[uitest]=../apps/libapps.a ../libcrypto ../libssl libtestutil.a
 
   SOURCE[cipherbytes_test]=cipherbytes_test.c
   INCLUDE[cipherbytes_test]=../include


### PR DESCRIPTION
For starters, everything in apps includes apps.h, because that one declares apps internal library routines.  However, progs.h doesn't declare library routines, but rather the main commands and their options, and there's no reason why the library modules should include it.

So, remove the inclusion of progs.h from apps.h and add that inclusion in all command source files.

Then, and mostly for practical purposes, we place the support library modules in a
private, static library.

Finally, this greatly simplifies our dealing with apps stuff in the test C framework