### PR TITLE
Make sure that apps/openssl prefixes its output with '# ' during tests, take 2

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -2428,14 +2428,25 @@ BIO *dup_bio_in(int format)
                       BIO_NOCLOSE | (istext(format) ? BIO_FP_TEXT : 0));
 }
 
+static BIO_METHOD *prefix_method = NULL;
 BIO *dup_bio_out(int format)
 {
     BIO *b = BIO_new_fp(stdout,
                         BIO_NOCLOSE | (istext(format) ? BIO_FP_TEXT : 0));
+    void *prefix = NULL;
+
 #ifdef OPENSSL_SYS_VMS
     if (istext(format))
         b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
 #endif
+
+    if (istext(format) && (prefix = getenv("HARNESS_OSSL_PREFIX")) != NULL) {
+        if (prefix_method == NULL)
+            prefix_method = apps_bf_prefix();
+        b = BIO_push(BIO_new(prefix_method), b);
+        BIO_ctrl(b, PREFIX_CTRL_SET_PREFIX, 0, prefix);
+    }
+
     return b;
 }
 
@@ -2448,6 +2459,12 @@ BIO *dup_bio_err(int format)
         b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
 #endif
     return b;
+}
+
+void destroy_prefix_method()
+{
+    BIO_meth_free(prefix_method);
+    prefix_method = NULL;
 }
 
 void unbuffer(FILE *fp)

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -55,6 +55,12 @@ BIO_METHOD *apps_bf_prefix(void);
  * remains epsilon for the foreseeable future and beyond.
  */
 #define PREFIX_CTRL_SET_PREFIX  (1 << 15)
+/*
+ * apps_bf_prefix() returns a dynamically created BIO_METHOD, which we
+ * need to destroy at some point.  When created internally, it's stored
+ * in an internal pointer which can be freed with the following function
+ */
+void destroy_prefix_method(void);
 
 BIO *dup_bio_in(int format);
 BIO *dup_bio_out(int format);

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -48,6 +48,14 @@ extern const unsigned char tls13_aes128gcmsha256_id[];
 extern const unsigned char tls13_aes256gcmsha384_id[];
 extern BIO_ADDR *ourpeer;
 
+BIO_METHOD *apps_bf_prefix(void);
+/*
+ * The control used to set the prefix with BIO_ctrl()
+ * We make it high enough so the chance of ever clashing with the BIO library
+ * remains epsilon for the foreseeable future and beyond.
+ */
+#define PREFIX_CTRL_SET_PREFIX  (1 << 15)
+
 BIO *dup_bio_in(int format);
 BIO *dup_bio_out(int format);
 BIO *dup_bio_err(int format);

--- a/apps/bf_prefix.c
+++ b/apps/bf_prefix.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <openssl/bio.h>
+#include "apps.h"
+
+static int prefix_write(BIO *b, const char *out, size_t outl,
+                        size_t *numwritten);
+static int prefix_read(BIO *b, char *buf, size_t size, size_t *numread);
+static int prefix_puts(BIO *b, const char *str);
+static int prefix_gets(BIO *b, char *str, int size);
+static long prefix_ctrl(BIO *b, int cmd, long arg1, void *arg2);
+static int prefix_create(BIO *b);
+static int prefix_destroy(BIO *b);
+static long prefix_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
+
+static BIO_METHOD *prefix_meth = NULL;
+
+BIO_METHOD *apps_bf_prefix(void)
+{
+    if (prefix_meth == NULL) {
+        if ((prefix_meth =
+             BIO_meth_new(BIO_TYPE_FILTER, "Prefix filter")) == NULL
+            || !BIO_meth_set_create(prefix_meth, prefix_create)
+            || !BIO_meth_set_destroy(prefix_meth, prefix_destroy)
+            || !BIO_meth_set_write_ex(prefix_meth, prefix_write)
+            || !BIO_meth_set_read_ex(prefix_meth, prefix_read)
+            || !BIO_meth_set_puts(prefix_meth, prefix_puts)
+            || !BIO_meth_set_gets(prefix_meth, prefix_gets)
+            || !BIO_meth_set_ctrl(prefix_meth, prefix_ctrl)
+            || !BIO_meth_set_callback_ctrl(prefix_meth, prefix_callback_ctrl)) {
+            BIO_meth_free(prefix_meth);
+            prefix_meth = NULL;
+        }
+    }
+    return prefix_meth;
+}
+
+typedef struct prefix_ctx_st {
+    char *prefix;
+    int linestart;               /* flag to indicate we're at the line start */
+} PREFIX_CTX;
+
+static int prefix_create(BIO *b)
+{
+    PREFIX_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+
+    if (ctx == NULL)
+        return 0;
+
+    ctx->prefix = NULL;
+    ctx->linestart = 1;
+    BIO_set_data(b, ctx);
+    BIO_set_init(b, 1);
+    return 1;
+}
+
+static int prefix_destroy(BIO *b)
+{
+    PREFIX_CTX *ctx = BIO_get_data(b);
+
+    OPENSSL_free(ctx->prefix);
+    OPENSSL_free(ctx);
+    return 1;
+}
+
+static int prefix_read(BIO *b, char *in, size_t size, size_t *numread)
+{
+    return BIO_read_ex(BIO_next(b), in, size, numread);
+}
+
+static int prefix_write(BIO *b, const char *out, size_t outl,
+                        size_t *numwritten)
+{
+    PREFIX_CTX *ctx = BIO_get_data(b);
+
+    if (ctx == NULL)
+        return 0;
+
+    /* If no prefix is set or if it's empty, we've got nothing to do here */
+    if (ctx->prefix == NULL || *ctx->prefix == '\0') {
+        /* We do note if what comes next will be a new line, though */
+        if (outl > 0)
+            ctx->linestart = (out[outl-1] == '\n');
+        return BIO_write_ex(BIO_next(b), out, outl, numwritten);
+    }
+
+    *numwritten = 0;
+
+    while (*out != '\0') {
+        size_t i;
+        char c;
+
+        /* If we know that we're at the start of the line, output the prefix */
+        if (ctx->linestart) {
+            size_t dontcare;
+
+            if (!BIO_write_ex(BIO_next(b), ctx->prefix, strlen(ctx->prefix),
+                              &dontcare))
+                return 0;
+            ctx->linestart = 0;
+        }
+
+        /* Now, go look for the next LF, or the end of the string */
+        for (i = 0; (c = out[i]) != '\n' && c != '\0'; i++)
+            continue;
+        if (c == '\n')
+            i++;
+
+        /* Output what we found so far */
+        while (i > 0) {
+            size_t num = 0;
+
+            if (!BIO_write_ex(BIO_next(b), out, i, &num))
+                return 0;
+            out += num;
+            *numwritten += num;
+            i -= num;
+        }
+
+        /* If we found a LF, what follows is a new line, so take note */
+        if (c == '\n')
+            ctx->linestart = 1;
+    }
+
+    return 1;
+}
+
+static long prefix_ctrl(BIO *b, int cmd, long num, void *ptr)
+{
+    long ret = 0;
+
+    switch (cmd) {
+    case PREFIX_CTRL_SET_PREFIX:
+        {
+            PREFIX_CTX *ctx = BIO_get_data(b);
+
+            if (ctx == NULL)
+                break;
+
+            OPENSSL_free(ctx->prefix);
+            ctx->prefix = OPENSSL_strdup((const char *)ptr);
+            ret = ctx->prefix != NULL;
+        }
+        break;
+    default:
+        if (BIO_next(b) != NULL)
+            ret = BIO_ctrl(BIO_next(b), cmd, num, ptr);
+        break;
+    }
+    return ret;
+}
+
+static long prefix_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
+{
+    return BIO_callback_ctrl(BIO_next(b), cmd, fp);
+}
+
+static int prefix_gets(BIO *b, char *buf, int size)
+{
+    return BIO_gets(BIO_next(b), buf, size);
+}
+
+static int prefix_puts(BIO *b, const char *str)
+{
+    return BIO_write(b, str, strlen(str));
+}

--- a/apps/build.info
+++ b/apps/build.info
@@ -8,7 +8,7 @@
           s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c
           srp.c ts.c verify.c version.c x509.c rehash.c storeutl.c);
    our @apps_lib_src =
-       ( qw(apps.c opt.c s_cb.c s_socket.c app_rand.c),
+       ( qw(apps.c opt.c s_cb.c s_socket.c app_rand.c bf_prefix.c),
          split(/\s+/, $target{apps_aux_src}) );
    our @apps_init_src = split(/\s+/, $target{apps_init_src});
    "" -}

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -730,7 +730,7 @@ redo_accept:
     free_index(rdb);
     BIO_free_all(cbio);
     BIO_free_all(acbio);
-    BIO_free(out);
+    BIO_free_all(out);
     OCSP_REQUEST_free(req);
     OCSP_RESPONSE_free(resp);
     OCSP_BASICRESP_free(bs);

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -93,6 +93,7 @@ static int apps_startup()
 static void apps_shutdown()
 {
     destroy_ui_method();
+    destroy_prefix_method();
 }
 
 static char *make_config_name()

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -476,7 +476,9 @@ sub run {
 	}
 	close $pipe;
     } else {
+	$ENV{HARNESS_OSSL_PREFIX} = "# ";
 	system("$prefix$cmd");
+	delete $ENV{HARNESS_OSSL_PREFIX};
     }
     $e = ($? & 0x7f) ? ($? & 0x7f)|0x80 : ($? >> 8);
     $r = $hooks{exit_checker}->($e);


### PR DESCRIPTION
The reason to do this is that some output might start with an 'ok',
which TAP catches and takes for TAP output.  The TAP compatible way is
to make all output it shouldn't catch look like comments.

We do this by setting the environment variable HARNESS_OSSL_PREFIX
during tests.  When that is set, apps/openssl uses BIO_f_linebuffer
and sets its prefix to the content of that environment variable.

-----

Notes:
- This PR replaces #5179
- This PR is made on top of #5222 
- ~~This PR *also* needs #5223 to work properly~~