### PR TITLE
[WIP] crypto/rand/rand_lib.c: use `clock_gettime' if available [1.2]

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -637,7 +637,7 @@ my %targets = (
                                            release => "-O3"),
                                     threads("-pthread")),
         cppflags         => "-DOPENSSL_USE_NODELETE",
-        ex_libs          => add("-ldl", threads("-pthread")),
+        ex_libs          => add("-ldl -lrt", threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",
         dso_scheme       => "dlfcn",


### PR DESCRIPTION
This pull request restores the code which was removed from PR #5199, because `clock_gettime` is not available without adding the `-lrt`, which is not desirable for the 1.1.1 release. It will be held back until version 1.2.