### PR TITLE
VMS: MMS wants a space before the target / dependecies separator

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -553,7 +553,7 @@ configdata.pm : $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{bu
         @ WRITE SYS$OUTPUT "*************************************************"
         @ PIPE ( EXIT %X10000000 )
 
-reconfigure reconf:
+reconfigure reconf :
 	perl configdata.pm -r -v
 
 {-


### PR DESCRIPTION
So as not to be mixed up with a device specification...
