### PR TITLE
s390x hw support for aes-ecb/ofb/cfb/cfb8

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1734,8 +1734,7 @@ static int s390x_aes_gcm_init_key(EVP_CIPHER_CTX *ctx,
         keylen = EVP_CIPHER_CTX_key_length(ctx);
         memcpy(&gctx->kma.param.k, key, keylen);
 
-        /* Convert key size to function code. */
-        gctx->fc = S390X_AES_128 + (((keylen << 3) - 128) >> 6);
+        gctx->fc = S390X_AES_FC(keylen);
         if (!enc)
             gctx->fc |= S390X_DECRYPT;
 
@@ -2145,8 +2144,7 @@ static int s390x_aes_ccm_init_key(EVP_CIPHER_CTX *ctx,
 
     if (key != NULL) {
         keylen = EVP_CIPHER_CTX_key_length(ctx);
-        /* Convert key size to function code. */
-        cctx->aes.ccm.fc = S390X_AES_128 + (((keylen << 3) - 128) >> 6);
+        cctx->aes.ccm.fc = S390X_AES_FC(keylen);
         memcpy(cctx->aes.ccm.kmac_param.k, key, keylen);
 
         /* Store encoded m and l. */

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1407,7 +1407,7 @@ static int s390x_aes_gcm_aad(S390X_AES_GCM_CTX *ctx, const unsigned char *aad,
 
     rem = len & 0xf;
 
-    len &= ~0xf;
+    len &= ~(size_t)0xf;
     if (len) {
         s390x_kma(aad, len, NULL, 0, NULL, ctx->fc, &ctx->kma.param);
         aad += len;
@@ -1479,7 +1479,7 @@ static int s390x_aes_gcm(S390X_AES_GCM_CTX *ctx, const unsigned char *in,
 
     rem = len & 0xf;
 
-    len &= ~0xf;
+    len &= ~(size_t)0xf;
     if (len) {
         s390x_kma(ctx->ares, ctx->areslen, in, len, out,
                   ctx->fc | S390X_KMA_LAAD, &ctx->kma.param);
@@ -1965,7 +1965,7 @@ static void s390x_aes_ccm_aad(S390X_AES_CCM_CTX *ctx, const unsigned char *aad,
     ctx->aes.ccm.blocks += 2;
 
     rem = alen & 0xf;
-    alen &= ~0xf;
+    alen &= ~(size_t)0xf;
     if (alen) {
         s390x_kmac(aad, alen, ctx->aes.ccm.fc, &ctx->aes.ccm.kmac_param);
         ctx->aes.ccm.blocks += alen >> 4;
@@ -2027,7 +2027,7 @@ static int s390x_aes_ccm(S390X_AES_CCM_CTX *ctx, const unsigned char *in,
 
     num = 0;
     rem = len & 0xf;
-    len &= ~0xf;
+    len &= ~(size_t)0xf;
 
     if (enc) {
         /* mac-then-encrypt */

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -16,6 +16,8 @@ void s390x_km(const unsigned char *in, size_t len, unsigned char *out,
               unsigned int fc, void *param);
 void s390x_kmac(const unsigned char *in, size_t len, unsigned int fc,
                 void *param);
+void s390x_kmo(const unsigned char *in, size_t len, unsigned char *out,
+               unsigned int fc, void *param);
 void s390x_kma(const unsigned char *aad, size_t alen, const unsigned char *in,
                size_t len, unsigned char *out, unsigned int fc, void *param);
 

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -18,6 +18,8 @@ void s390x_kmac(const unsigned char *in, size_t len, unsigned int fc,
                 void *param);
 void s390x_kmo(const unsigned char *in, size_t len, unsigned char *out,
                unsigned int fc, void *param);
+void s390x_kmf(const unsigned char *in, size_t len, unsigned char *out,
+               unsigned int fc, void *param);
 void s390x_kma(const unsigned char *aad, size_t alen, const unsigned char *in,
                size_t len, unsigned char *out, unsigned int fc, void *param);
 

--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -305,6 +305,27 @@ ___
 }
 
 ################
+# void s390x_kmo(const unsigned char *in, size_t len, unsigned char *out,
+#                unsigned int fc, void *param)
+{
+my ($in,$len,$out,$fc,$param) = map("%r$_",(2..6));
+$code.=<<___;
+.globl	s390x_kmo
+.type	s390x_kmo,\@function
+.align	16
+s390x_kmo:
+	lr	%r0,$fc
+	l${g}r	%r1,$param
+
+	.long	0xb92b0042	# kmo $out,$in
+	brc	1,.-4		# pay attention to "partial completion"
+
+	br	$ra
+.size	s390x_kmo,.-s390x_kmo
+___
+}
+
+################
 # void s390x_kma(const unsigned char *aad, size_t alen,
 #                const unsigned char *in, size_t len,
 #                unsigned char *out, unsigned int fc, void *param)

--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -326,6 +326,27 @@ ___
 }
 
 ################
+# void s390x_kmf(const unsigned char *in, size_t len, unsigned char *out,
+#                unsigned int fc, void *param)
+{
+my ($in,$len,$out,$fc,$param) = map("%r$_",(2..6));
+$code.=<<___;
+.globl	s390x_kmf
+.type	s390x_kmf,\@function
+.align	16
+s390x_kmf:
+	lr	%r0,$fc
+	l${g}r	%r1,$param
+
+	.long	0xb92a0042	# kmf $out,$in
+	brc	1,.-4		# pay attention to "partial completion"
+
+	br	$ra
+.size	s390x_kmf,.-s390x_kmf
+___
+}
+
+################
 # void s390x_kma(const unsigned char *aad, size_t alen,
 #                const unsigned char *in, size_t len,
 #                unsigned char *out, unsigned int fc, void *param)


### PR DESCRIPTION
Add s390 hw support for various aes modes. I put those in one PR since its not so much code per mode: Each patch just adds assembly routine for the corresponding instruction plus some code for partial block processing.