### PR TITLE
Use RAND_DRBG_bytes() for RAND_bytes() and RAND_priv_bytes()

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -772,9 +772,6 @@ static int drbg_bytes(unsigned char *out, int count)
         return 0;
 
     CRYPTO_THREAD_write_lock(drbg->lock);
-    if (drbg->state == DRBG_UNINITIALISED)
-        goto err;
-
     for ( ; count > 0; count -= chunk, out += chunk) {
         chunk = count;
         if (chunk > drbg->max_request)

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -546,10 +546,22 @@ int RAND_DRBG_bytes(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
 {
     unsigned char *additional = NULL;
     size_t additional_len;
+    size_t chunk;
     size_t ret;
 
     additional_len = rand_drbg_get_additional_data(&additional, drbg->max_adinlen);
-    ret = RAND_DRBG_generate(drbg, out, outlen, 0, additional, additional_len);
+
+    for ( ; outlen > 0; outlen -= chunk, out += chunk) {
+        chunk = outlen;
+        if (chunk > drbg->max_request)
+            chunk = drbg->max_request;
+        ret = RAND_DRBG_generate(drbg, out, chunk, 0, additional, additional_len);
+        if (!ret)
+            goto err;
+    }
+    ret = 1;
+
+err:
     if (additional_len != 0)
         OPENSSL_secure_clear_free(additional, additional_len);
 

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -776,26 +776,16 @@ void rand_drbg_cleanup_int(void)
 /* Implements the default OpenSSL RAND_bytes() method */
 static int drbg_bytes(unsigned char *out, int count)
 {
-    int ret = 0;
-    size_t chunk;
+    int ret;
     RAND_DRBG *drbg = RAND_DRBG_get0_public();
 
     if (drbg == NULL)
         return 0;
 
     CRYPTO_THREAD_write_lock(drbg->lock);
-    for ( ; count > 0; count -= chunk, out += chunk) {
-        chunk = count;
-        if (chunk > drbg->max_request)
-            chunk = drbg->max_request;
-        ret = RAND_DRBG_generate(drbg, out, chunk, 0, NULL, 0);
-        if (!ret)
-            goto err;
-    }
-    ret = 1;
-
-err:
+    ret = RAND_DRBG_bytes(drbg, out, count);
     CRYPTO_THREAD_unlock(drbg->lock);
+
     return ret;
 }
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -719,7 +719,7 @@ int RAND_priv_bytes(unsigned char *buf, int num)
 
     /* We have to lock the DRBG before generating bits from it. */
     CRYPTO_THREAD_write_lock(drbg->lock);
-    ret = RAND_DRBG_generate(drbg, buf, num, 0, NULL, 0);
+    ret = RAND_DRBG_bytes(drbg, buf, num);
     CRYPTO_THREAD_unlock(drbg->lock);
     return ret;
 }


### PR DESCRIPTION
### Use RAND_DRBG_bytes() for RAND_bytes() and RAND_priv_bytes()

The functions `RAND_bytes()` and `RAND_priv_bytes()` are now both based on a common implementation using `RAND_DRBG_bytes()` (if the default OpenSSL rand method is active). This not only simplifies the code but also has the advantage that additional input from a high precision timer is added on every generate call if the timer is available.


_While implementing this change, two bugs were noticed and fixed:_

### Fix size limitation of RAND_DRBG_bytes()

When comparing the implementations of `drbg_bytes()` and `RAND_DRBG_bytes()`, it was noticed that the former split the buffer into chunks when calling `RAND_DRBG_generate()` to circumvent the size limitation of the buffer to `outlen <= drb->max_request`. This loop was missing in `RAND_DRBG_bytes()`, so it was adopted from `drbg_bytes()`.

### drbg_bytes: remove check for DRBG_UNINITIALIZED state

This check not only prevented the automatic reinstantiation of the DRBG, which is implemented in `RAND_DRBG_generate()`, but also prevented an error message from being generated in the case of failure.
