### PR TITLE
Export keying material using early exporter master secret

### DIFF
--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -2,7 +2,9 @@
 
 =head1 NAME
 
-SSL_export_keying_material - obtain keying material for application use
+SSL_export_keying_material,
+SSL_export_keying_material_early
+- obtain keying material for application use
 
 =head1 SYNOPSIS
 
@@ -13,13 +15,27 @@ SSL_export_keying_material - obtain keying material for application use
                                 const unsigned char *context,
                                 size_t contextlen, int use_context);
 
+ int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
+                                      const char *label, size_t llen,
+                                      const unsigned char *context,
+                                      size_t contextlen, int use_context);
+
 =head1 DESCRIPTION
 
 During the creation of a TLS or DTLS connection shared keying material is
 established between the two endpoints. The function SSL_export_keying_material()
-enables an application to use some of this keying material for its own purposes
-in accordance with RFC5705 (for TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
+and SSL_export_keying_material_early() enables an application to use some of
+this keying material for its own purposes in accordance with RFC5705 (for
+TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
 TODO(TLS1.3): Update the RFC number when the RFC is published.
+
+SSL_export_keying_material() derives keying material using
+exporter_master_secret established in handshake.
+
+SSL_export_keying_material_early() is only usable with TLSv1.3, and derives
+keying material using early_exporter_master_secret. For client,
+early_exporter_master_secret is only available when client attempts to send
+0-RTT data. For server, it is only available when server accepts 0-RTT data.
 
 An application may need to securely establish the context within which this
 keying material will be used. For example this may include identifiers for the
@@ -51,6 +67,12 @@ above. Attempting to use it in SSLv3 will result in an error.
 =head1 RETURN VALUES
 
 SSL_export_keying_material() returns 0 or -1 on failure or 1 on success.
+
+SSL_export_keying_material_early() returns 0 on failure or 1 on success.
+
+=head1 HISTORY
+
+SSL_export_keying_material_early() was first added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -23,10 +23,10 @@ SSL_export_keying_material_early
 =head1 DESCRIPTION
 
 During the creation of a TLS or DTLS connection shared keying material is
-established between the two endpoints. The function SSL_export_keying_material()
-and SSL_export_keying_material_early() enables an application to use some of
-this keying material for its own purposes in accordance with RFC5705 (for
-TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
+established between the two endpoints. The functions
+SSL_export_keying_material() and SSL_export_keying_material_early() enable an
+application to use some of this keying material for its own purposes in
+accordance with RFC5705 (for TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
 TODO(TLS1.3): Update the RFC number when the RFC is published.
 
 SSL_export_keying_material() derives keying material using

--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -18,7 +18,7 @@ SSL_export_keying_material_early
  int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                       const char *label, size_t llen,
                                       const unsigned char *context,
-                                      size_t contextlen, int use_context);
+                                      size_t contextlen);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -30,12 +30,13 @@ accordance with RFC5705 (for TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
 TODO(TLS1.3): Update the RFC number when the RFC is published.
 
 SSL_export_keying_material() derives keying material using
-exporter_master_secret established in handshake.
+the exporter_master_secret established in the handshake.
 
 SSL_export_keying_material_early() is only usable with TLSv1.3, and derives
-keying material using early_exporter_master_secret. For client,
-early_exporter_master_secret is only available when client attempts to send
-0-RTT data. For server, it is only available when server accepts 0-RTT data.
+keying material using the early_exporter_master_secret. For the client, the
+early_exporter_master_secret is only available when the client attempts to send
+0-RTT data. For the server, it is only available when the server accepts 0-RTT
+data.
 
 An application may need to securely establish the context within which this
 keying material will be used. For example this may include identifiers for the

--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -30,13 +30,13 @@ accordance with RFC5705 (for TLSv1.2 and below) or RFCXXXX (for TLSv1.3).
 TODO(TLS1.3): Update the RFC number when the RFC is published.
 
 SSL_export_keying_material() derives keying material using
-the exporter_master_secret established in the handshake.
+the F<exporter_master_secret> established in the handshake.
 
 SSL_export_keying_material_early() is only usable with TLSv1.3, and derives
-keying material using the early_exporter_master_secret. For the client, the
-early_exporter_master_secret is only available when the client attempts to send
-0-RTT data. For the server, it is only available when the server accepts 0-RTT
-data.
+keying material using the F<early_exporter_master_secret> (as defined in the
+TLS 1.3 RFC). For the client, the F<early_exporter_master_secret> is only
+available when the client attempts to send 0-RTT data. For the server, it is
+only available when the server accepts 0-RTT data.
 
 An application may need to securely establish the context within which this
 keying material will be used. For example this may include identifiers for the

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -232,6 +232,21 @@ __owur int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
                                       const unsigned char *context,
                                       size_t contextlen, int use_context);
 
+/*
+ * SSL_export_keying_material_early exports a value derived from the
+ * early exporter master secret, as specified in
+ * https://tools.ietf.org/html/draft-ietf-tls-tls13-23. It writes
+ * |olen| bytes to |out| given a label and optional context. (Since a
+ * zero length context is allowed, the |use_context| flag controls
+ * whether a context is included.) It returns 1 on success and 0 or -1
+ * otherwise.
+ */
+__owur int SSL_export_keying_material_early(SSL *s, unsigned char *out,
+                                            size_t olen, const char *label,
+                                            size_t llen,
+                                            const unsigned char *context,
+                                            size_t contextlen, int use_context);
+
 int SSL_get_peer_signature_type_nid(const SSL *s, int *pnid);
 
 int SSL_get_sigalgs(SSL *s, int idx,

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -236,16 +236,14 @@ __owur int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
  * SSL_export_keying_material_early exports a value derived from the
  * early exporter master secret, as specified in
  * https://tools.ietf.org/html/draft-ietf-tls-tls13-23. It writes
- * |olen| bytes to |out| given a label and optional context. (Since a
- * zero length context is allowed, the |use_context| flag controls
- * whether a context is included.) It returns 1 on success and 0
- * otherwise.
+ * |olen| bytes to |out| given a label and optional context. It
+ * returns 1 on success and 0 otherwise.
  */
 __owur int SSL_export_keying_material_early(SSL *s, unsigned char *out,
                                             size_t olen, const char *label,
                                             size_t llen,
                                             const unsigned char *context,
-                                            size_t contextlen, int use_context);
+                                            size_t contextlen);
 
 int SSL_get_peer_signature_type_nid(const SSL *s, int *pnid);
 

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -238,7 +238,7 @@ __owur int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
  * https://tools.ietf.org/html/draft-ietf-tls-tls13-23. It writes
  * |olen| bytes to |out| given a label and optional context. (Since a
  * zero length context is allowed, the |use_context| flag controls
- * whether a context is included.) It returns 1 on success and 0 or -1
+ * whether a context is included.) It returns 1 on success and 0
  * otherwise.
  */
 __owur int SSL_export_keying_material_early(SSL *s, unsigned char *out,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2814,9 +2814,8 @@ int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                      const unsigned char *context,
                                      size_t contextlen)
 {
-    if (s->version != TLS1_3_VERSION) {
+    if (s->version != TLS1_3_VERSION)
         return 0;
-    }
 
     return tls13_export_keying_material_early(s, out, olen, label, llen,
                                               context, contextlen);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2812,14 +2812,14 @@ int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
 int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                      const char *label, size_t llen,
                                      const unsigned char *context,
-                                     size_t contextlen, int use_context)
+                                     size_t contextlen)
 {
     if (s->version != TLS1_3_VERSION) {
         return 0;
     }
 
     return tls13_export_keying_material_early(s, out, olen, label, llen,
-                                              context, contextlen, use_context);
+                                              context, contextlen);
 }
 
 static unsigned long ssl_session_hash(const SSL_SESSION *a)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2809,6 +2809,19 @@ int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
                                                        contextlen, use_context);
 }
 
+int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
+                                     const char *label, size_t llen,
+                                     const unsigned char *context,
+                                     size_t contextlen, int use_context)
+{
+    if (s->version != TLS1_3_VERSION) {
+        return -1;
+    }
+
+    return tls13_export_keying_material_early(s, out, olen, label, llen,
+                                              context, contextlen, use_context);
+}
+
 static unsigned long ssl_session_hash(const SSL_SESSION *a)
 {
     const unsigned char *session_id = a->session_id;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2815,7 +2815,7 @@ int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                      size_t contextlen, int use_context)
 {
     if (s->version != TLS1_3_VERSION) {
-        return -1;
+        return 0;
     }
 
     return tls13_export_keying_material_early(s, out, olen, label, llen,

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2410,8 +2410,7 @@ __owur int tls13_export_keying_material_early(SSL *s, unsigned char *out,
                                               size_t olen, const char *label,
                                               size_t llen,
                                               const unsigned char *context,
-                                              size_t contextlen,
-                                              int use_context);
+                                              size_t contextlen);
 __owur int tls1_alert_code(int code);
 __owur int tls13_alert_code(int code);
 __owur int ssl3_alert_code(int code);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1111,6 +1111,7 @@ struct ssl_st {
     unsigned char client_app_traffic_secret[EVP_MAX_MD_SIZE];
     unsigned char server_app_traffic_secret[EVP_MAX_MD_SIZE];
     unsigned char exporter_master_secret[EVP_MAX_MD_SIZE];
+    unsigned char early_exporter_master_secret[EVP_MAX_MD_SIZE];
     EVP_CIPHER_CTX *enc_read_ctx; /* cryptographic state */
     unsigned char read_iv[EVP_MAX_IV_LENGTH]; /* TLSv1.3 static read IV */
     EVP_MD_CTX *read_hash;      /* used for mac generation */
@@ -2405,6 +2406,12 @@ __owur int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
                                         const char *label, size_t llen,
                                         const unsigned char *context,
                                         size_t contextlen, int use_context);
+__owur int tls13_export_keying_material_early(SSL *s, unsigned char *out,
+                                              size_t olen, const char *label,
+                                              size_t llen,
+                                              const unsigned char *context,
+                                              size_t contextlen,
+                                              int use_context);
 __owur int tls1_alert_code(int code);
 __owur int tls13_alert_code(int code);
 __owur int ssl3_alert_code(int code);

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -958,5 +958,11 @@ int ossl_statem_export_allowed(SSL *s)
  */
 int ossl_statem_export_early_allowed(SSL *s)
 {
-    return s->statem.hand_state == TLS_ST_EARLY_DATA;
+    /*
+     * The early exporter secret is only present on the server if we
+     * have accepted early_data. It is present on the client as long
+     * as we have sent early_data.
+     */
+    return s->ext.early_data == SSL_EARLY_DATA_ACCEPTED
+           || (!s->server && s->ext.early_data != SSL_EARLY_DATA_NOT_SENT);
 }

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -953,8 +953,8 @@ int ossl_statem_export_allowed(SSL *s)
 }
 
 /*
- * This function returns 1 if early TLS exporter is ready to export
- * keying material, or 0 if otherwise.
+ * Return 1 if early TLS exporter is ready to export keying material,
+ * or 0 if otherwise.
  */
 int ossl_statem_export_early_allowed(SSL *s)
 {

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -951,3 +951,12 @@ int ossl_statem_export_allowed(SSL *s)
     return s->s3->previous_server_finished_len != 0
            && s->statem.hand_state != TLS_ST_SW_FINISHED;
 }
+
+/*
+ * This function returns 1 if early TLS exporter is ready to export
+ * keying material, or 0 if otherwise.
+ */
+int ossl_statem_export_early_allowed(SSL *s)
+{
+    return s->statem.hand_state == TLS_ST_EARLY_DATA;
+}

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -133,6 +133,7 @@ void ossl_statem_check_finish_init(SSL *s, int send);
 void ossl_statem_set_hello_verify_done(SSL *s);
 __owur int ossl_statem_app_data_allowed(SSL *s);
 __owur int ossl_statem_export_allowed(SSL *s);
+__owur int ossl_statem_export_early_allowed(SSL *s);
 
 /* Flush the write BIO */
 int statem_flush(SSL *s);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -707,8 +707,8 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                        const unsigned char *context,
                                        size_t contextlen)
 {
-    unsigned char exportsecret[EVP_MAX_MD_SIZE];
     static const unsigned char exporterlabel[] = "exporter";
+    unsigned char exportsecret[EVP_MAX_MD_SIZE];
     unsigned char hash[EVP_MAX_MD_SIZE], data[EVP_MAX_MD_SIZE];
     const EVP_MD *md;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -720,17 +720,17 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
         goto err;
 
     if (!s->server && s->max_early_data > 0
-        && s->session->ext.max_early_data == 0) {
+            && s->session->ext.max_early_data == 0)
         sslcipher = SSL_SESSION_get0_cipher(s->psksession);
-    } else {
+    else
         sslcipher = SSL_SESSION_get0_cipher(s->session);
-    }
+
     md = ssl_md(sslcipher->algorithm2);
 
     /*
-     * In the following code, it calculates hash value of empty
-     * string, and stores it in data.  This is because the definition
-     * of TLS-Exporter is defined like so:
+     * Calculate the hash value and store it in |data|. The reason why
+     * the empty string is used is that the definition of TLS-Exporter
+     * is like so:
      *
      * TLS-Exporter(label, context_value, key_length) =
      *     HKDF-Expand-Label(Derive-Secret(Secret, label, ""),

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -719,7 +719,12 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
     if (ctx == NULL || !ossl_statem_export_early_allowed(s))
         goto err;
 
-    sslcipher = SSL_SESSION_get0_cipher(s->session);
+    if (!s->server && s->max_early_data > 0
+        && s->session->ext.max_early_data == 0) {
+        sslcipher = SSL_SESSION_get0_cipher(s->psksession);
+    } else {
+        sslcipher = SSL_SESSION_get0_cipher(s->session);
+    }
     md = ssl_md(sslcipher->algorithm2);
 
     if (!use_context)

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -725,19 +725,21 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
     if (!use_context)
         contextlen = 0;
 
-    /* In the following code, it calculates hash value of empty
-       string, and stores it in data.  This is because the definition
-       of TLS-Exporter is defined like so:
-
-       TLS-Exporter(label, context_value, key_length) =
-           HKDF-Expand-Label(Derive-Secret(Secret, label, ""),
-                             "exporter", Hash(context_value), key_length)
-
-       Derive-Secret(Secret, Label, Messages) =
-             HKDF-Expand-Label(Secret, Label,
-                               Transcript-Hash(Messages), Hash.length)
-
-       Here Transcript-Hash is the cipher suite hash algorithm. */
+    /*
+     * In the following code, it calculates hash value of empty
+     * string, and stores it in data.  This is because the definition
+     * of TLS-Exporter is defined like so:
+     *
+     * TLS-Exporter(label, context_value, key_length) =
+     *     HKDF-Expand-Label(Derive-Secret(Secret, label, ""),
+     *                       "exporter", Hash(context_value), key_length)
+     *
+     * Derive-Secret(Secret, Label, Messages) =
+     *       HKDF-Expand-Label(Secret, Label,
+     *                         Transcript-Hash(Messages), Hash.length)
+     *
+     * Here Transcript-Hash is the cipher suite hash algorithm.
+     */
     if (EVP_DigestInit_ex(ctx, md, NULL) <= 0
             || EVP_DigestUpdate(ctx, context, contextlen) <= 0
             || EVP_DigestFinal_ex(ctx, hash, &hashsize) <= 0

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -724,6 +724,19 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
     if (!use_context)
         contextlen = 0;
 
+    /* In the following code, it calculates hash value of empty
+       string, and stores it in data.  This is because the definition
+       of TLS-Exporter is defined like so:
+
+       TLS-Exporter(label, context_value, key_length) =
+           HKDF-Expand-Label(Derive-Secret(Secret, label, ""),
+                             "exporter", Hash(context_value), key_length)
+
+       Derive-Secret(Secret, Label, Messages) =
+             HKDF-Expand-Label(Secret, Label,
+                               Transcript-Hash(Messages), Hash.length)
+
+       Here Transcript-Hash is the cipher suite hash algorithm. */
     if (EVP_DigestInit_ex(ctx, md, NULL) <= 0
             || EVP_DigestUpdate(ctx, context, contextlen) <= 0
             || EVP_DigestFinal_ex(ctx, hash, &hashsize) <= 0

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -488,7 +488,8 @@ int tls13_change_cipher_state(SSL *s, int which)
                                    sizeof(early_exporter_master_secret) - 1,
                                    hashval, hashlen,
                                    s->early_exporter_master_secret, hashlen)) {
-                SSLfatal(SSL_F_TLS13_CHANGE_CIPHER_STATE, ERR_R_INTERNAL_ERROR);
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                         SSL_F_TLS13_CHANGE_CIPHER_STATE, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
         } else if (which & SSL3_CC_HANDSHAKE) {

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -488,7 +488,7 @@ int tls13_change_cipher_state(SSL *s, int which)
                                    sizeof(early_exporter_master_secret) - 1,
                                    hashval, hashlen,
                                    s->early_exporter_master_secret, hashlen)) {
-                SSLerr(SSL_F_TLS13_CHANGE_CIPHER_STATE, ERR_R_INTERNAL_ERROR);
+                SSLfatal(SSL_F_TLS13_CHANGE_CIPHER_STATE, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
         } else if (which & SSL3_CC_HANDSHAKE) {

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -705,7 +705,7 @@ int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
 int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                        const char *label, size_t llen,
                                        const unsigned char *context,
-                                       size_t contextlen, int use_context)
+                                       size_t contextlen)
 {
     unsigned char exportsecret[EVP_MAX_MD_SIZE];
     static const unsigned char exporterlabel[] = "exporter";
@@ -726,9 +726,6 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
         sslcipher = SSL_SESSION_get0_cipher(s->session);
     }
     md = ssl_md(sslcipher->algorithm2);
-
-    if (!use_context)
-        contextlen = 0;
 
     /*
      * In the following code, it calculates hash value of empty

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3145,6 +3145,7 @@ static int test_export_key_mat(int tst)
     return testresult;
 }
 
+#ifndef OPENSSL_NO_TLS1_3
 /*
  * Test that SSL_export_keying_material_early() produces expected
  * results. There are no test vectors so all we do is test that both
@@ -3164,10 +3165,6 @@ static int test_export_key_mat_early(int idx)
     unsigned char skeymat1[80], skeymat2[80], skeymat3[80];
     unsigned char buf[1];
     size_t readbytes, written;
-
-#ifdef OPENSSL_NO_TLS1_3
-    return 1;
-#endif
 
     if (!TEST_true(setupearly_data_test(&cctx, &sctx, &clientssl, &serverssl,
                                         &sess, idx)))
@@ -3260,6 +3257,7 @@ static int test_export_key_mat_early(int idx)
 
     return testresult;
 }
+#endif /* OPENSSL_NO_TLS1_3 */
 
 static int test_ssl_clear(int idx)
 {
@@ -3533,7 +3531,9 @@ int setup_tests(void)
 #endif
     ADD_ALL_TESTS(test_serverinfo, 8);
     ADD_ALL_TESTS(test_export_key_mat, 4);
+#ifndef OPENSSL_NO_TLS1_3
     ADD_ALL_TESTS(test_export_key_mat_early, 3);
+#endif
     ADD_ALL_TESTS(test_ssl_clear, 2);
     ADD_ALL_TESTS(test_max_fragment_len_ext, OSSL_NELEM(max_fragment_len_test));
     return 1;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3161,8 +3161,8 @@ static int test_export_key_mat_early(int idx)
     const char label[] = "test label";
     const unsigned char context[] = "context";
     const unsigned char *emptycontext = NULL;
-    unsigned char ckeymat1[80], ckeymat2[80], ckeymat3[80];
-    unsigned char skeymat1[80], skeymat2[80], skeymat3[80];
+    unsigned char ckeymat1[80], ckeymat2[80];
+    unsigned char skeymat1[80], skeymat2[80];
     unsigned char buf[1];
     size_t readbytes, written;
 
@@ -3183,7 +3183,7 @@ static int test_export_key_mat_early(int idx)
                                                       sizeof(ckeymat1), label,
                                                       sizeof(label) - 1,
                                                       context,
-                                                      sizeof(context) - 1, 1),
+                                                      sizeof(context) - 1),
                      1)
             || !TEST_int_eq(SSL_export_keying_material_early(clientssl,
                                                              ckeymat2,
@@ -3191,35 +3191,23 @@ static int test_export_key_mat_early(int idx)
                                                              label,
                                                              sizeof(label) - 1,
                                                              emptycontext,
-                                                             0, 1), 1)
-            || !TEST_int_eq(SSL_export_keying_material_early(clientssl,
-                                                             ckeymat3,
-                                                             sizeof(ckeymat3),
-                                                             label,
-                                                             sizeof(label) - 1,
-                                                             NULL, 0, 0), 1)
+                                                             0), 1)
             || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
                                                              skeymat1,
                                                              sizeof(skeymat1),
                                                              label,
                                                              sizeof(label) - 1,
                                                              context,
-                                                             sizeof(context) -1,
-                                                             1),
+                                                             sizeof(context) - 1
+                                                             ),
                             1)
             || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
                                                              skeymat2,
                                                              sizeof(skeymat2),
                                                              label,
                                                              sizeof(label) - 1,
-                                                             emptycontext, 0,
-                                                             1), 1)
-            || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
-                                                             skeymat3,
-                                                             sizeof(skeymat3),
-                                                             label,
-                                                             sizeof(label) - 1,
-                                                             NULL, 0, 0), 1)
+                                                             emptycontext, 0),
+                            1)
                /*
                 * Check that both sides created the same key material with the
                 * same context.
@@ -3232,12 +3220,6 @@ static int test_export_key_mat_early(int idx)
                 */
             || !TEST_mem_eq(ckeymat2, sizeof(ckeymat2), skeymat2,
                             sizeof(skeymat2))
-               /*
-                * Check that both sides created the same key material without a
-                * context.
-                */
-            || !TEST_mem_eq(ckeymat3, sizeof(ckeymat3), skeymat3,
-                            sizeof(skeymat3))
                /* Different contexts should produce different results */
             || !TEST_mem_ne(ckeymat1, sizeof(ckeymat1), ckeymat2,
                             sizeof(ckeymat2)))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3154,12 +3154,12 @@ static int test_export_key_mat(int tst)
  */
 static int test_export_key_mat_early(int idx)
 {
+    static const char label[] = "test label";
+    static const unsigned char context[] = "context";
     int testresult = 0;
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     SSL_SESSION *sess = NULL;
-    const char label[] = "test label";
-    const unsigned char context[] = "context";
     const unsigned char *emptycontext = NULL;
     unsigned char ckeymat1[80], ckeymat2[80];
     unsigned char skeymat1[80], skeymat2[80];
@@ -3179,35 +3179,18 @@ static int test_export_key_mat_early(int idx)
                             SSL_EARLY_DATA_ACCEPTED))
         goto end;
 
-    if (!TEST_int_eq(SSL_export_keying_material_early(clientssl, ckeymat1,
-                                                      sizeof(ckeymat1), label,
-                                                      sizeof(label) - 1,
-                                                      context,
-                                                      sizeof(context) - 1),
-                     1)
-            || !TEST_int_eq(SSL_export_keying_material_early(clientssl,
-                                                             ckeymat2,
-                                                             sizeof(ckeymat2),
-                                                             label,
-                                                             sizeof(label) - 1,
-                                                             emptycontext,
-                                                             0), 1)
-            || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
-                                                             skeymat1,
-                                                             sizeof(skeymat1),
-                                                             label,
-                                                             sizeof(label) - 1,
-                                                             context,
-                                                             sizeof(context) - 1
-                                                             ),
-                            1)
-            || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
-                                                             skeymat2,
-                                                             sizeof(skeymat2),
-                                                             label,
-                                                             sizeof(label) - 1,
-                                                             emptycontext, 0),
-                            1)
+    if (!TEST_int_eq(SSL_export_keying_material_early(
+                     clientssl, ckeymat1, sizeof(ckeymat1), label,
+                     sizeof(label) - 1, context, sizeof(context) - 1), 1)
+            || !TEST_int_eq(SSL_export_keying_material_early(
+                            clientssl, ckeymat2, sizeof(ckeymat2), label,
+                            sizeof(label) - 1, emptycontext, 0), 1)
+            || !TEST_int_eq(SSL_export_keying_material_early(
+                            serverssl, skeymat1, sizeof(skeymat1), label,
+                            sizeof(label) - 1, context, sizeof(context) - 1), 1)
+            || !TEST_int_eq(SSL_export_keying_material_early(
+                            serverssl, skeymat2, sizeof(skeymat2), label,
+                            sizeof(label) - 1, emptycontext, 0), 1)
                /*
                 * Check that both sides created the same key material with the
                 * same context.

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3145,6 +3145,122 @@ static int test_export_key_mat(int tst)
     return testresult;
 }
 
+/*
+ * Test that SSL_export_keying_material_early() produces expected
+ * results. There are no test vectors so all we do is test that both
+ * sides of the communication produce the same results for different
+ * protocol versions.
+ */
+static int test_export_key_mat_early(int idx)
+{
+    int testresult = 0;
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_SESSION *sess = NULL;
+    const char label[] = "test label";
+    const unsigned char context[] = "context";
+    const unsigned char *emptycontext = NULL;
+    unsigned char ckeymat1[80], ckeymat2[80], ckeymat3[80];
+    unsigned char skeymat1[80], skeymat2[80], skeymat3[80];
+    unsigned char buf[1];
+    size_t readbytes, written;
+
+#ifdef OPENSSL_NO_TLS1_3
+    return 1;
+#endif
+
+    if (!TEST_true(setupearly_data_test(&cctx, &sctx, &clientssl, &serverssl,
+                                        &sess, idx)))
+        goto end;
+
+    /* Here writing 0 length early data is enough. */
+    if (!TEST_true(SSL_write_early_data(clientssl, NULL, 0, &written))
+            || !TEST_int_eq(SSL_read_early_data(serverssl, buf, sizeof(buf),
+                                                &readbytes),
+                            SSL_READ_EARLY_DATA_ERROR)
+            || !TEST_int_eq(SSL_get_early_data_status(serverssl),
+                            SSL_EARLY_DATA_ACCEPTED))
+        goto end;
+
+    if (!TEST_int_eq(SSL_export_keying_material_early(clientssl, ckeymat1,
+                                                      sizeof(ckeymat1), label,
+                                                      sizeof(label) - 1,
+                                                      context,
+                                                      sizeof(context) - 1, 1),
+                     1)
+            || !TEST_int_eq(SSL_export_keying_material_early(clientssl,
+                                                             ckeymat2,
+                                                             sizeof(ckeymat2),
+                                                             label,
+                                                             sizeof(label) - 1,
+                                                             emptycontext,
+                                                             0, 1), 1)
+            || !TEST_int_eq(SSL_export_keying_material_early(clientssl,
+                                                             ckeymat3,
+                                                             sizeof(ckeymat3),
+                                                             label,
+                                                             sizeof(label) - 1,
+                                                             NULL, 0, 0), 1)
+            || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
+                                                             skeymat1,
+                                                             sizeof(skeymat1),
+                                                             label,
+                                                             sizeof(label) - 1,
+                                                             context,
+                                                             sizeof(context) -1,
+                                                             1),
+                            1)
+            || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
+                                                             skeymat2,
+                                                             sizeof(skeymat2),
+                                                             label,
+                                                             sizeof(label) - 1,
+                                                             emptycontext, 0,
+                                                             1), 1)
+            || !TEST_int_eq(SSL_export_keying_material_early(serverssl,
+                                                             skeymat3,
+                                                             sizeof(skeymat3),
+                                                             label,
+                                                             sizeof(label) - 1,
+                                                             NULL, 0, 0), 1)
+               /*
+                * Check that both sides created the same key material with the
+                * same context.
+                */
+            || !TEST_mem_eq(ckeymat1, sizeof(ckeymat1), skeymat1,
+                            sizeof(skeymat1))
+               /*
+                * Check that both sides created the same key material with an
+                * empty context.
+                */
+            || !TEST_mem_eq(ckeymat2, sizeof(ckeymat2), skeymat2,
+                            sizeof(skeymat2))
+               /*
+                * Check that both sides created the same key material without a
+                * context.
+                */
+            || !TEST_mem_eq(ckeymat3, sizeof(ckeymat3), skeymat3,
+                            sizeof(skeymat3))
+               /* Different contexts should produce different results */
+            || !TEST_mem_ne(ckeymat1, sizeof(ckeymat1), ckeymat2,
+                            sizeof(ckeymat2)))
+        goto end;
+
+    testresult = 1;
+
+ end:
+    if (sess != clientpsk)
+        SSL_SESSION_free(sess);
+    SSL_SESSION_free(clientpsk);
+    SSL_SESSION_free(serverpsk);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 static int test_ssl_clear(int idx)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -3417,6 +3533,7 @@ int setup_tests(void)
 #endif
     ADD_ALL_TESTS(test_serverinfo, 8);
     ADD_ALL_TESTS(test_export_key_mat, 4);
+    ADD_ALL_TESTS(test_export_key_mat_early, 3);
     ADD_ALL_TESTS(test_ssl_clear, 2);
     ADD_ALL_TESTS(test_max_fragment_len_ext, OSSL_NELEM(max_fragment_len_test));
     return 1;

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -217,6 +217,11 @@ int ossl_statem_export_allowed(SSL *s)
     return 1;
 }
 
+int ossl_statem_export_early_allowed(SSL *s)
+{
+    return 1;
+}
+
 /* End of mocked out code */
 
 static int test_secret(SSL *s, unsigned char *prk,

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -476,3 +476,4 @@ SSL_SESSION_get_max_fragment_length     476	1_1_1	EXIST::FUNCTION:
 SSL_stateless                           477	1_1_1	EXIST::FUNCTION:
 SSL_verify_client_post_handshake        478	1_1_1	EXIST::FUNCTION:
 SSL_force_post_handshake_auth           479	1_1_1	EXIST::FUNCTION:
+SSL_export_keying_material_early        480	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
This commit adds SSL_export_keying_material_early() which exports
keying material using early exporter master secret.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes #4839 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
