### PR TITLE
Fix include in manpage of X509_check_host

### DIFF
--- a/doc/man3/X509_check_host.pod
+++ b/doc/man3/X509_check_host.pod
@@ -6,7 +6,7 @@ X509_check_host, X509_check_email, X509_check_ip, X509_check_ip_asc - X.509 cert
 
 =head1 SYNOPSIS
 
- #include <openssl/x509.h>
+ #include <openssl/x509v3.h>
 
  int X509_check_host(X509 *, const char *name, size_t namelen,
                      unsigned int flags, char **peername);


### PR DESCRIPTION
This changes the include to the file where the constants are defined.

Fixes #5255 