### PR TITLE
bio_dgram uses recvmsg/sendmsg to retrieve destination and set origin address

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1634,6 +1634,7 @@ my %targets = (
     },
 
 ##### MacOS X (a.k.a. Darwin) setup
+    # has IP_PKTINFO on >10.9, despite being BSD, has IP_RECVDSTADDR, but not IP_SENDSRCADDR.
     "darwin-common" => {
         inherit_from     => [ "BASE_unix" ],
         template         => 1,
@@ -1643,6 +1644,7 @@ my %targets = (
         cppflags         => threads("-D_REENTRANT"),
         lflags           => add("-Wl,-search_paths_first"),
         sys_id           => "MACOSX",
+        defines          => add("HAVE_IP_PKTINFO"),
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",
         perlasm_scheme   => "osx32",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -692,6 +692,7 @@ my %targets = (
         lib_cppflags     => "-DOPENSSL_USE_NODELETE",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
+        defines          => add("HAVE_IP_PKTINFO"),
         thread_scheme    => "pthreads",
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1005,6 +1005,7 @@ my %targets = (
         cppflags         => threads("-D_THREAD_SAFE -D_REENTRANT"),
         ex_libs          => add(threads("-pthread")),
         enable           => add("devcryptoeng"),
+        defines          => add("HAVE_IP_RECVDSTADDR"),
         bn_ops           => "BN_LLONG",
         thread_scheme    => "pthreads",
         dso_scheme       => "dlfcn",

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -353,15 +353,15 @@ static int dgram_read_unconnected_v4(BIO *b, char *in, int inl,
     if((len = recvmsg(b->num, &mhdr, 0)) >= 0) {
         for (cmsg = CMSG_FIRSTHDR(&mhdr);
              cmsg != NULL;
-             cmsg = CMSG_NXTHDR(&mhdr, cmsg))
-	{
-            if (cmsg->cmsg_level != IPPROTO_IP)
+             cmsg = CMSG_NXTHDR(&mhdr, cmsg)) {
+            if(cmsg->cmsg_level != IPPROTO_IP)
           	continue;
-            switch(cmsg->cmsg_type) {
-            case IP_PKTINFO:
-              pkt_info = (struct in_pktinfo *)CMSG_DATA(cmsg);
-              break;
-            }
+
+            if(cmsg->cmsg_type != IP_PKTINFO)
+                continue;
+
+            pkt_info = (struct in_pktinfo *)CMSG_DATA(cmsg);
+            break;
 	}
 
         /* see if we found something */

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -372,8 +372,7 @@ static int dgram_read_unconnected_v4(BIO *b, char *in, int inl,
       mhdr.msg_controllen = sizeof(chdr);
     }
 
-    if((len = recvmsg(b->num, &mhdr, 0)) >= 0) {
-      if(dstaddr != NULL) {
+    if((len = recvmsg(b->num, &mhdr, 0)) >= 0 && dstaddr != NULL) {
         for (cmsg = CMSG_FIRSTHDR(&mhdr);
              cmsg != NULL;
              cmsg = CMSG_NXTHDR(&mhdr, cmsg)) {
@@ -442,25 +441,25 @@ static int dgram_read_unconnected_v4(BIO *b, const char *in, int inl,
       mhdr.msg_controllen = sizeof(chdr);
     }
 
-    if((len = recvmsg(b->num, &mhdr, 0)) >= 0) {
-        for (cmsg = CMSG_FIRSTHDR(&mhdr);
-             cmsg != NULL;
-             cmsg = CMSG_NXTHDR(&mhdr, cmsg)) {
-            if (cmsg->cmsg_level != IPPROTO_IP)
-          	continue;
+    if((len = recvmsg(b->num, &mhdr, 0)) >= 0 && dstaddr != NULL) {
+      for (cmsg = CMSG_FIRSTHDR(&mhdr);
+           cmsg != NULL;
+           cmsg = CMSG_NXTHDR(&mhdr, cmsg)) {
+        if (cmsg->cmsg_level != IPPROTO_IP)
+          continue;
 
-            if(cmsg->cmsg_type != IP_RECVDSTADDR)
-                continue;
+        if(cmsg->cmsg_type != IP_RECVDSTADDR)
+          continue;
 
-            dstrecv = (struct in_addr *)CMSG_DATA(cmsg);
-            break;
-	}
+        dstrecv = (struct in_addr *)CMSG_DATA(cmsg);
+        break;
+      }
 
-        /* see if we found something */
-        if(dstrecv != NULL && dstaddr != NULL) {
-          dstaddr->s_in.sin_family = AF_INET;
-          dstaddr->s_in.sin_addr =*dstrecv;
-        }
+      /* see if we found something */
+      if(dstrecv != NULL) {
+        dstaddr->s_in.sin_family = AF_INET;
+        dstaddr->s_in.sin_addr =*dstrecv;
+      }
     }
 
     /* NOTE: peer was filled in by kernel */

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -22,9 +22,9 @@
 #include <errno.h>
 #include <signal.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netinet/ip6.h>
 #include <netinet/icmp6.h>
-#include <netinet/in.h>
 
 #include "bio_local.h"
 
@@ -62,6 +62,7 @@ static long dgram_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int dgram_new(BIO *h);
 static int dgram_free(BIO *data);
 static int dgram_clear(BIO *bio);
+static int dgram_get_sockname(BIO *bio);
 
 # ifndef OPENSSL_NO_SCTP
 static int dgram_sctp_write(BIO *h, const char *buf, int num);
@@ -310,6 +311,153 @@ static void dgram_reset_rcv_timeout(BIO *b)
 # endif
 }
 
+#if defined(HAVE_IP_PKTINFO)
+/* LINUX has IP_PKTINFO for IPv4 */
+static int dgram_read_unconnected_v4(BIO *b, char *in, int inl,
+                                     int flags,
+                                     BIO_ADDR *dstaddr, BIO_ADDR *peer)
+{
+    int len = 0;
+    unsigned char    chdr[CMSG_SPACE(sizeof(struct in_pktinfo))];
+    struct iovec iov;
+    struct msghdr mhdr;
+    struct in_pktinfo *pkt_info = NULL;
+    struct cmsghdr *cmsg;
+    int val;
+
+    /* enable PKTINFO receive */
+    val = 1;
+    if(setsockopt(b->num, IPPROTO_IP, IP_PKTINFO, &val, sizeof(val)) < 0) {
+      return -1;
+    }
+
+    memset(&iov, 0, sizeof(iov));
+    iov.iov_len  = inl;
+    iov.iov_base = (caddr_t) in;
+
+    memset(&mhdr, 0, sizeof(mhdr));
+    mhdr.msg_name = (caddr_t)BIO_ADDR_sockaddr(peer);
+    mhdr.msg_namelen = sizeof(struct sockaddr_in);
+    mhdr.msg_iov = &iov;
+    mhdr.msg_iovlen = 1;
+
+    if(dstaddr != NULL) {
+      memset(chdr, 0, sizeof(chdr));
+      cmsg = (struct cmsghdr *) chdr;
+      mhdr.msg_control = (void *) cmsg;
+      mhdr.msg_controllen = sizeof(chdr);
+    }
+
+    if((len = recvmsg(b->num, &mhdr, 0)) >= 0) {
+        for (cmsg = CMSG_FIRSTHDR(&mhdr);
+             cmsg != NULL;
+             cmsg = CMSG_NXTHDR(&mhdr, cmsg))
+	{
+            if (cmsg->cmsg_level != IPPROTO_IP)
+          	continue;
+            switch(cmsg->cmsg_type) {
+            case IP_PKTINFO:
+              pkt_info = (struct in_pktinfo *)CMSG_DATA(cmsg);
+              break;
+            }
+	}
+
+        /* see if we found something */
+        if(pkt_info != NULL && dstaddr != NULL) {
+          dstaddr->s_in.sin_family = AF_INET;
+          dstaddr->s_in.sin_addr = pkt_info->ipi_addr;
+        }
+    }
+
+    /* NOTE: peer was filled in by kernel */
+    return len;
+}
+
+#else
+static int dgram_read_unconnected_v4(BIO *b, char *in, int inl,
+                                         int flags,
+                                         BIO_ADDR *dstaddr, BIO_ADDR *peer)
+{
+    struct sockaddr_in addr;
+    bio_dgram_data *data = (bio_dgram_data *)b->ptr;
+    socklen_t len = sizeof(addr);
+    unsigned int ret;
+
+    memset((void *)&addr, 0, sizeof(addr));
+    ret = recvfrom(b->num, out, outl, flags, &addr, &len);
+
+    if(ret > 0) {
+      /* successs! */
+      BIO_set_dgram_origin(b, &addr);
+    }
+    return ret;
+}
+#endif
+
+#ifdef AF_INET6
+static int dgram_read_unconnected_v6(BIO *b, char *in, int inl,
+                                     int flags,
+                                     BIO_ADDR *dstaddr, BIO_ADDR *peer)
+{
+    int len = 0;
+    //unsigned int     chdrlen = CMSG_SPACE(sizeof(struct in6_pktinfo));
+    unsigned char    chdr[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+    struct iovec iov;
+    struct msghdr mhdr;
+    struct in6_pktinfo *pkt_info = NULL;
+    struct cmsghdr *cmsg;
+    int val;
+
+    /* enable PKTINFO receive */
+    val = 1;
+    if(setsockopt(b->num, IPPROTO_IPV6, IPV6_RECVPKTINFO, &val, sizeof(val)) < 0) {
+      return -1;
+    }
+
+    memset(&iov, 0, sizeof(iov));
+    iov.iov_len  = inl;
+    iov.iov_base = (caddr_t) in;
+
+    memset(&mhdr, 0, sizeof(mhdr));
+    mhdr.msg_name = (caddr_t)BIO_ADDR_sockaddr(peer);
+    mhdr.msg_namelen = sizeof(struct sockaddr_in6);
+    mhdr.msg_iov = &iov;
+    mhdr.msg_iovlen = 1;
+
+    if(dstaddr != NULL) {
+      memset(chdr, 0, sizeof(chdr));
+      cmsg = (struct cmsghdr *) chdr;
+      mhdr.msg_control = (void *) cmsg;
+      mhdr.msg_controllen = sizeof(chdr);
+    }
+
+    if((len = recvmsg(b->num, &mhdr, 0)) >= 0) {
+        for (cmsg = CMSG_FIRSTHDR(&mhdr);
+             cmsg != NULL;
+             cmsg = CMSG_NXTHDR(&mhdr, cmsg))
+	{
+            if (cmsg->cmsg_level != IPPROTO_IPV6)
+          	continue;
+            switch(cmsg->cmsg_type) {
+            case IPV6_PKTINFO:
+              pkt_info = (struct in6_pktinfo *)CMSG_DATA(cmsg);
+              break;
+            }
+	}
+
+        /* see if we found something */
+        if(pkt_info != NULL && dstaddr != NULL) {
+          unsigned int dst_len = BIO_ADDR_sockaddr_size(dstaddr);
+          if(dst_len > sizeof(pkt_info->ipi6_addr)) dst_len = sizeof(pkt_info->ipi6_addr);
+          memcpy(BIO_ADDR_sockaddr_noconst(dstaddr), &pkt_info->ipi6_addr, dst_len);
+        }
+    }
+
+    /* NOTE: peer was filled in by kernel */
+    return len;
+}
+#endif
+
 static int dgram_read(BIO *b, char *out, int outl)
 {
     int ret = 0;
@@ -317,19 +465,44 @@ static int dgram_read(BIO *b, char *out, int outl)
     int flags = 0;
 
     BIO_ADDR peer;
-    socklen_t len = sizeof(peer);
+    BIO_ADDR addr;
 
     if (out != NULL) {
+        struct sockaddr *sa;
+
+        /* make sure we know something about the socket */
+	if(data->addr.sa.sa_family == 0) {
+		dgram_get_sockname(b);
+	}
+
+        sa = (struct sockaddr *)BIO_ADDR_sockaddr(&data->addr);
+
         clear_socket_error();
         memset(&peer, 0, sizeof(peer));
+        memset(&addr, 0, sizeof(addr));
         dgram_adjust_rcv_timeout(b);
         if (data->peekmode)
             flags = MSG_PEEK;
-        ret = recvfrom(b->num, out, outl, flags,
-                       BIO_ADDR_sockaddr_noconst(&peer), &len);
 
-        if (!data->connected && ret >= 0)
+        switch(sa->sa_family) {
+        case AF_INET:
+          ret = dgram_read_unconnected_v4(b, out, outl, flags, &addr, &peer);
+          break;
+
+#ifdef AF_INET6
+        case AF_INET6:
+          ret = dgram_read_unconnected_v6(b, out, outl, flags, &addr, &peer);
+          break;
+#endif /* AF_INET6 */
+
+        default:
+          ret = -1;
+        }
+
+        if (!data->connected && ret >= 0) {
+            BIO_ctrl(b, BIO_CTRL_DGRAM_SET_ADDR, 0, &addr);
             BIO_ctrl(b, BIO_CTRL_DGRAM_SET_PEER, 0, &peer);
+        }
 
         BIO_clear_retry_flags(b);
         if (ret < 0) {
@@ -350,7 +523,6 @@ static int dgram_write_unconnected_v4(BIO *b, const char *out, int outl)
 {
     struct sockaddr_in addr;
     struct sockaddr_in *srcaddr;
-    struct in_pktinfo *pkt_info;
     struct msghdr mhdr;
     struct cmsghdr *cmsg;
     struct iovec iov;
@@ -372,7 +544,8 @@ static int dgram_write_unconnected_v4(BIO *b, const char *out, int outl)
     mhdr.msg_iovlen = 1;
 
     srcaddr = (struct sockaddr_in *)BIO_ADDR_sockaddr(&data->addr);
-    if(srcaddr) {
+    if(srcaddr && srcaddr->sin_addr.s_addr != 0) {
+      struct in_pktinfo *pkt_info;
       memset(chdr, 0, sizeof(chdr));
 
       mhdr.msg_control = (void *) chdr;
@@ -386,9 +559,55 @@ static int dgram_write_unconnected_v4(BIO *b, const char *out, int outl)
       pkt_info = (struct in_pktinfo *)CMSG_DATA(cmsg);
       pkt_info->ipi_addr    = srcaddr->sin_addr;
       mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
-#if 0
-      printf("controllen: %d\n", mhdr.msg_controllen);
-#endif
+    }
+
+    return sendmsg(b->num, &mhdr, 0);
+}
+#elif defined(HAVE_IP_RECVDSTADDR)
+/* FREEBSD, DragonFly, NetBSD, OpenBSD, probably BSDi */
+/*    implies IP_SENDSRCADDR is available too         */
+static int dgram_write_unconnected_v4(BIO *b, const char *out, int outl)
+{
+    struct sockaddr_in addr;
+    struct sockaddr_in *srcaddr;
+    struct in_addr     *origaddr;
+    struct msghdr mhdr;
+    struct cmsghdr *cmsg;
+    struct iovec iov;
+
+    /* CMSG_SOCKET is from sys/socket.h, and makes
+     * space for a cmsghdr as well as alignment
+     */
+    char chdr[CMSG_SPACE(sizeof(struct in_addr))];
+    bio_dgram_data *data = (bio_dgram_data *)b->ptr;
+
+    memset((void *)&addr, 0, sizeof(addr));
+    addr = *(struct sockaddr_in *)BIO_ADDR_sockaddr(&data->peer);
+
+    iov.iov_len  = outl;
+    iov.iov_base = (caddr_t) out;
+
+    memset(&mhdr, 0, sizeof(mhdr));
+    mhdr.msg_name = (caddr_t)&addr;
+    mhdr.msg_namelen = sizeof(struct sockaddr_in);
+    mhdr.msg_iov = &iov;
+    mhdr.msg_iovlen = 1;
+
+    srcaddr = (struct sockaddr_in *)BIO_ADDR_sockaddr(&data->addr);
+    if(srcaddr && srcaddr->sin_addr.s_addr != 0) {
+      memset(chdr, 0, sizeof(chdr));
+
+      mhdr.msg_control = (void *) chdr;
+      mhdr.msg_controllen = sizeof(chdr);
+
+      cmsg = CMSG_FIRSTHDR(&mhdr);
+      cmsg->cmsg_len = CMSG_LEN(sizeof(*origaddr));
+      cmsg->cmsg_level = IPPROTO_IP;
+      cmsg->cmsg_type  = IP_SENDSRCADDR;
+
+      origaddr = (struct in_addr *) CMSG_DATA(cmsg);
+      *origaddr= srcaddr->sin_addr;
+      mhdr.msg_controllen = CMSG_SPACE(sizeof(*origaddr));
     }
 
     return sendmsg(b->num, &mhdr, 0);
@@ -465,6 +684,8 @@ static int dgram_write(BIO *b, const char *in, int inl)
         ret = writesocket(b->num, in, inl);
     else {
         struct sockaddr *sa = (struct sockaddr *)BIO_ADDR_sockaddr(&data->peer);
+	if(data->addr.sa.sa_family == 0)
+          dgram_get_sockname(b);
 
         switch(sa->sa_family) {
         case AF_INET:
@@ -530,6 +751,19 @@ static long dgram_get_mtu_overhead(bio_dgram_data *data)
         break;
     }
     return ret;
+}
+
+static int dgram_get_sockname(BIO *b)
+{
+    bio_dgram_data *data = NULL;
+    socklen_t addr_len = sizeof(bio_dgram_data);
+
+    data = (bio_dgram_data *)b->ptr;
+
+    if (getsockname(b->num, (struct sockaddr *)&data->addr, &addr_len) < 0) {
+	return 0;
+    }
+    return addr_len;
 }
 
 static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
@@ -717,12 +951,16 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             num = ret;
         memcpy(ptr, &data->peer, (ret = num));
         break;
+
     case BIO_CTRL_DGRAM_SET_PEER:
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;
 
     case BIO_CTRL_DGRAM_GET_ADDR:
         ret = BIO_ADDR_sockaddr_size(&data->addr);
+	if(ret == 0) /* never set, retrieve it */
+          ret = dgram_get_sockname(b);
+
         /* FIXME: if num < ret, we will only return part of an address.
            That should bee an error, no? */
         if (num == 0 || num > ret)

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -14,7 +14,10 @@
 #include <stdio.h>
 #include <errno.h>
 
+/* this is needed on Linux to get in6_pktinfo to be defined */
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
 
 /* this is needed on OSX to get IPV6_PKTINFO defined */
 #ifdef __APPLE__

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -582,6 +582,19 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_SET_PEER:
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;
+
+    case BIO_CTRL_DGRAM_GET_ADDR:
+        ret = BIO_ADDR_sockaddr_size(&data->addr);
+        /* FIXME: if num < ret, we will only return part of an address.
+           That should bee an error, no? */
+        if (num == 0 || num > ret)
+            num = ret;
+        memcpy(ptr, &data->addr, (ret = num));
+        break;
+    case BIO_CTRL_DGRAM_SET_ADDR:
+        BIO_ADDR_make(&data->addr, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
+        break;
+
     case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
         memcpy(&(data->next_timeout), ptr, sizeof(struct timeval));
         break;

--- a/doc/build.info
+++ b/doc/build.info
@@ -675,6 +675,10 @@ DEPEND[html/man3/BIO_set_callback.html]=man3/BIO_set_callback.pod
 GENERATE[html/man3/BIO_set_callback.html]=man3/BIO_set_callback.pod
 DEPEND[man/man3/BIO_set_callback.3]=man3/BIO_set_callback.pod
 GENERATE[man/man3/BIO_set_callback.3]=man3/BIO_set_callback.pod
+DEPEND[html/man3/BIO_set_dgram_origin.html]=man3/BIO_set_dgram_origin.pod
+GENERATE[html/man3/BIO_set_dgram_origin.html]=man3/BIO_set_dgram_origin.pod
+DEPEND[man/man3/BIO_set_dgram_origin.3]=man3/BIO_set_dgram_origin.pod
+GENERATE[man/man3/BIO_set_dgram_origin.3]=man3/BIO_set_dgram_origin.pod
 DEPEND[html/man3/BIO_should_retry.html]=man3/BIO_should_retry.pod
 GENERATE[html/man3/BIO_should_retry.html]=man3/BIO_should_retry.pod
 DEPEND[man/man3/BIO_should_retry.3]=man3/BIO_should_retry.pod
@@ -2896,6 +2900,7 @@ html/man3/BIO_s_mem.html \
 html/man3/BIO_s_null.html \
 html/man3/BIO_s_socket.html \
 html/man3/BIO_set_callback.html \
+html/man3/BIO_set_dgram_origin.html \
 html/man3/BIO_should_retry.html \
 html/man3/BIO_socket_wait.html \
 html/man3/BN_BLINDING_new.html \
@@ -3490,6 +3495,7 @@ man/man3/BIO_s_mem.3 \
 man/man3/BIO_s_null.3 \
 man/man3/BIO_s_socket.3 \
 man/man3/BIO_set_callback.3 \
+man/man3/BIO_set_dgram_origin.3 \
 man/man3/BIO_should_retry.3 \
 man/man3/BIO_socket_wait.3 \
 man/man3/BN_BLINDING_new.3 \

--- a/doc/build.info
+++ b/doc/build.info
@@ -563,6 +563,10 @@ DEPEND[html/man3/BIO_ctrl.html]=man3/BIO_ctrl.pod
 GENERATE[html/man3/BIO_ctrl.html]=man3/BIO_ctrl.pod
 DEPEND[man/man3/BIO_ctrl.3]=man3/BIO_ctrl.pod
 GENERATE[man/man3/BIO_ctrl.3]=man3/BIO_ctrl.pod
+DEPEND[html/man3/BIO_dgram.html]=man3/BIO_dgram.pod
+GENERATE[html/man3/BIO_dgram.html]=man3/BIO_dgram.pod
+DEPEND[man/man3/BIO_dgram.3]=man3/BIO_dgram.pod
+GENERATE[man/man3/BIO_dgram.3]=man3/BIO_dgram.pod
 DEPEND[html/man3/BIO_f_base64.html]=man3/BIO_f_base64.pod
 GENERATE[html/man3/BIO_f_base64.html]=man3/BIO_f_base64.pod
 DEPEND[man/man3/BIO_f_base64.3]=man3/BIO_f_base64.pod
@@ -2872,6 +2876,7 @@ html/man3/BIO_ADDR.html \
 html/man3/BIO_ADDRINFO.html \
 html/man3/BIO_connect.html \
 html/man3/BIO_ctrl.html \
+html/man3/BIO_dgram.html \
 html/man3/BIO_f_base64.html \
 html/man3/BIO_f_buffer.html \
 html/man3/BIO_f_cipher.html \
@@ -3467,6 +3472,7 @@ man/man3/BIO_ADDR.3 \
 man/man3/BIO_ADDRINFO.3 \
 man/man3/BIO_connect.3 \
 man/man3/BIO_ctrl.3 \
+man/man3/BIO_dgram.3 \
 man/man3/BIO_f_base64.3 \
 man/man3/BIO_f_buffer.3 \
 man/man3/BIO_f_cipher.3 \

--- a/doc/man3/BIO_dgram.pod
+++ b/doc/man3/BIO_dgram.pod
@@ -1,0 +1,53 @@
+=pod
+
+=head1 NAME
+
+BIO_set_dgram_origin, BIO_set_dgram_dest, BIO_get_dgram_origin, BIO_get_dgram_dest,
+- BIO datagram control operations
+
+=head1 SYNOPSIS
+
+ #include <openssl/bio.h>
+
+ int BIO_set_dgram_origin(BIO *b, BIO_ADDR *local);
+ int BIO_get_dgram_origin(BIO *b, BIO_ADDR *local);
+
+ int BIO_set_dgram_dest(BIO *b, BIO_ADDR *peer);
+ int BIO_get_dgram_dest(BIO *b, BIO_ADDR *peer);
+
+
+=head1 DESCRIPTION
+
+These BIO get and set functions deal with the underlying connections for datagram sockets as used by DTLS sessions.
+
+Unconnected datagram sockets can receive packets from any address, and not being bound to a particular IP address, may receive packets to any valid local address.
+
+When packets are received on these sockets, if the underlying operating system supports, they
+are sent using functions that collect the originating and destination addresses on each packet.
+After each call to BIO_dgram_read(), the origin and destination information is saved.
+The BIO_get_dgram_origin() and BIO_get_dgram_dest() may be called to retrieve the saved information.
+
+Unconnected datagram sockets can send packets from any valid local address, and can send traffic any desired destination.
+Use the BIO_set_dgram_origin() and BIO_set_dgram_dest() calls to store the desired origin and destination for the next call to BIO_dgram_write().
+
+Use of unconnected datagram sockets is critical for DTLS Hello Challenge.
+Once a Hello Challenge has passed, creation of a connected datagram socket allows the kernel to do the demultiplexing of different streams.
+
+=head1 RETURN VALUES
+
+All functions normally returns 0 for for failure, and otherwise return the size of the returned sockaddress structure.
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.1.
+
+=head1 COPYRIGHT
+
+Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/BIO_set_dgram_origin.pod
+++ b/doc/man3/BIO_set_dgram_origin.pod
@@ -1,0 +1,53 @@
+=pod
+
+=head1 NAME
+
+BIO_set_dgram_origin, BIO_set_dgram_dest, BIO_get_dgram_origin, BIO_get_dgram_dest
+- BIO datagram control operations
+
+=head1 SYNOPSIS
+
+ #include <openssl/bio.h>
+
+ int BIO_set_dgram_origin(BIO *b, BIO_ADDR *local);
+ int BIO_get_dgram_origin(BIO *b, BIO_ADDR *local);
+
+ int BIO_set_dgram_dest(BIO *b, BIO_ADDR *peer);
+ int BIO_get_dgram_dest(BIO *b, BIO_ADDR *peer);
+
+
+=head1 DESCRIPTION
+
+These BIO get and set functions deal with the underlying connections for datagram sockets as used by DTLS sessions.
+
+Unconnected datagram sockets can receive packets from any address, and not being bound to a particular IP address, may receive packets to any valid local address.
+
+When packets are received on these sockets, if the underlying operating system supports, they
+are sent using functions that collect the originating and destination addresses on each packet.
+After each call to BIO_dgram_read(), the origin and destination information is saved.
+The BIO_get_dgram_origin() and BIO_get_dgram_dest() may be called to retrieve the saved information.
+
+Unconnected datagram sockets can send packets from any valid local address, and can send traffic any desired destination.
+Use the BIO_set_dgram_origin() and BIO_set_dgram_dest() calls to store the desired origin and destination for the next call to BIO_dgram_write().
+
+Use of unconnected datagram sockets is critical for DTLS Hello Challenge.
+Once a Hello Challenge has passed, creation of a connected datagram socket allows the kernel to do the demultiplexing of different streams.
+
+=head1 RETURN VALUES
+
+All functions normally returns 0 for for failure, and otherwise return the size of the returned sockaddress structure.
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.1.
+
+=head1 COPYRIGHT
+
+Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -153,6 +153,8 @@ extern "C" {
 # endif
 
 # define BIO_CTRL_DGRAM_SET_PEEK_MODE      71
+# define BIO_CTRL_DGRAM_GET_ADDR           72 /* address data sent to/from */
+# define BIO_CTRL_DGRAM_SET_ADDR           73 /* address data sent to/from */
 
 /*
  * internal BIO:

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -479,6 +479,10 @@ struct bio_dgram_sctp_prinfo {
 # define BIO_seek(b,ofs) (int)BIO_ctrl(b,BIO_C_FILE_SEEK,ofs,NULL)
 # define BIO_tell(b)     (int)BIO_ctrl(b,BIO_C_FILE_TELL,0,NULL)
 
+  /* BIO_s_dgram */
+#define BIO_set_dgram_origin(b, addr) BIO_ctrl(b, BIO_CTRL_DGRAM_SET_ADDR, 0, addr)
+#define BIO_set_dgram_dest(b, addr)   BIO_ctrl(b, BIO_CTRL_DGRAM_SET_PEER, 0, addr)
+
 /*
  * name is cast to lose const, but might be better to route through a
  * function so we can do it safely

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -481,7 +481,9 @@ struct bio_dgram_sctp_prinfo {
 
   /* BIO_s_dgram */
 #define BIO_set_dgram_origin(b, addr) BIO_ctrl(b, BIO_CTRL_DGRAM_SET_ADDR, 0, addr)
+#define BIO_get_dgram_origin(b, addr) BIO_ctrl(b, BIO_CTRL_DGRAM_GET_ADDR, 0, addr)
 #define BIO_set_dgram_dest(b, addr)   BIO_ctrl(b, BIO_CTRL_DGRAM_SET_PEER, 0, addr)
+#define BIO_get_dgram_dest(b, addr)   BIO_ctrl(b, BIO_CTRL_DGRAM_GET_PEER, 0, addr)
 
 /*
  * name is cast to lose const, but might be better to route through a

--- a/test/bio_dgram_test_helpers.c
+++ b/test/bio_dgram_test_helpers.c
@@ -16,12 +16,6 @@
 #include "testutil/output.h"
 #include "testutil.h"
 
-#if defined(_WIN32)
-int setup_tests(void)
-{
-    return 1;
-}
-#else
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>

--- a/test/bio_dgram_test_helpers.c
+++ b/test/bio_dgram_test_helpers.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <stdio.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/bio.h>
+#include <openssl/rand.h>
+#include <openssl/bio.h>
+
+#include "testutil/output.h"
+#include "testutil.h"
+
+#if defined(_WIN32)
+int setup_tests(void)
+{
+    return 1;
+}
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+#include "bio_dgram_test_helpers.h"
+
+int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2)
+{
+  const char hello[]="hellohellohello";
+  int toggle = 0;
+  int ret;
+
+  while(--count > 0) {
+    const int sizeofhello = sizeof(hello);
+
+    if(toggle && dst2 != NULL) {
+      BIO_set_dgram_dest(bio, dst2);
+    } else {
+      BIO_set_dgram_dest(bio, dst1);
+    }
+
+    ret = BIO_write(bio, hello, sizeofhello);
+    if(ret != sizeofhello) {
+      exit(3);
+    }
+
+    toggle = !toggle;
+  }
+
+  return 0;
+}
+
+int fork_and_read_write_packets(int infd, int outfd,
+                                unsigned portnum,
+                                BIO_ADDR *dsthost1, BIO_ADDR *dsthost2)
+{
+  BIO *out;
+  int expected_count = PACKET_COUNT;
+
+  pid_t pid = fork();
+  int   count;
+
+  switch(pid) {
+  case 0:   /* child */
+    out = BIO_new_dgram(outfd, BIO_CLOSE);
+    write_packets(out, PACKET_COUNT, dsthost1, dsthost2);
+    exit(0);
+
+  case -1:  /* failure */
+    exit(10);
+
+  default:  /* parent */
+    if(dsthost2 != NULL) {
+      expected_count = expected_count / 2;
+    }
+    count = read_socket_and_discard(infd, expected_count, portnum);
+    if(count != 0) {
+      test_printf_stderr("failed receive all packets: %d\n", count);
+      exit(2);
+    }
+  }
+
+  return 1;
+}
+
+unsigned int bind_v4_socket(int infd,
+                            BIO_ADDR *dsthost)
+{
+  struct sockaddr_in localhost;
+  socklen_t          sin_len;
+
+  memset(&localhost, 0, sizeof(localhost));
+  localhost.sin_family = AF_INET;
+  localhost.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  localhost.sin_port = 0;
+
+  /* do not set port, let kernel pick. */
+  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
+    perror("bind infd");
+    exit(4);
+  }
+
+  /* extract port number, stuff it into dsthost1 */
+  sin_len = sizeof(localhost);
+  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
+    perror("getsockname");
+    exit(5);
+  }
+  BIO_ADDR_rawmake(dsthost, AF_INET,
+                   &localhost.sin_addr, sizeof(localhost.sin_addr),
+                   localhost.sin_port);
+
+  return ntohs(localhost.sin_port);
+}
+
+unsigned int bind_v6_socket(int infd,
+                            BIO_ADDR *dsthost,
+                            unsigned short portnum)
+{
+  struct sockaddr_in6 localhost;
+  socklen_t          sin_len;
+
+  memset(&localhost, 0, sizeof(localhost));
+  localhost.sin6_family = AF_INET6;
+  localhost.sin6_addr   = in6addr_loopback;
+  localhost.sin6_port   = portnum;
+
+  /* portnum may be 0, which lets kernel pick. */
+  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
+    perror("bind in6fd");
+    exit(4);
+  }
+
+  /* extract port number */
+  sin_len = sizeof(localhost);
+  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
+    perror("getsockname6");
+    exit(5);
+  }
+
+  BIO_ADDR_rawmake(dsthost, AF_INET6,
+                   &localhost.sin6_addr, sizeof(localhost.sin6_addr),
+                   localhost.sin6_port);
+
+  return ntohs(localhost.sin6_port);
+}
+

--- a/test/bio_dgram_test_helpers.h
+++ b/test/bio_dgram_test_helpers.h
@@ -20,8 +20,9 @@ extern int fork_and_read_write_packets(int infd, int outfd,
 extern unsigned int bind_v4_socket(int infd,
                                    BIO_ADDR *dsthost);
 extern unsigned int bind_v6_socket(int infd,
-                                   BIO_ADDR *dsthost);
+                                   BIO_ADDR *dsthost,
+                                   unsigned short portnum);
 
 /* this function is *provided* by the test case, and is difference between read/write */
-extern int read_socket_and_discard(int fd, int count, unsigned portnum);
+extern int read_socket_and_discard(int fd, int count, unsigned short portnum);
 #endif /* OSSL_TEST_ECDSATEST_H */

--- a/test/bio_dgram_test_helpers.h
+++ b/test/bio_dgram_test_helpers.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Headers for bio_read_test, bio_write_test, for common routines in bio_dgram_test_helpers.c */
+
+#ifndef OSSL_TEST_BIO_DGRAM_HELPERS_H
+# define OSSL_TEST_BIO_DGRAM_HELPERS_H
+
+#define PACKET_COUNT 10
+extern int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2);
+extern int fork_and_read_write_packets(int infd, int outfd,
+                                       unsigned portnum,
+                                       BIO_ADDR *dsthost1, BIO_ADDR *dsthost2);
+extern unsigned int bind_v4_socket(int infd,
+                                   BIO_ADDR *dsthost);
+extern unsigned int bind_v6_socket(int infd,
+                                   BIO_ADDR *dsthost);
+
+/* this function is *provided* by the test case, and is difference between read/write */
+extern int read_socket_and_discard(int fd, int count, unsigned portnum);
+#endif /* OSSL_TEST_ECDSATEST_H */

--- a/test/bio_dgram_test_helpers.h
+++ b/test/bio_dgram_test_helpers.h
@@ -17,11 +17,11 @@ extern int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2);
 extern int fork_and_read_write_packets(int infd, int outfd,
                                        unsigned portnum,
                                        BIO_ADDR *dsthost1, BIO_ADDR *dsthost2);
-extern unsigned int bind_v4_socket(int infd,
-                                   BIO_ADDR *dsthost);
-extern unsigned int bind_v6_socket(int infd,
-                                   BIO_ADDR *dsthost,
-                                   unsigned short portnum);
+extern int bind_v4_socket(int infd,
+                          BIO_ADDR *dsthost);
+extern int bind_v6_socket(int infd,
+                          BIO_ADDR *dsthost,
+                          unsigned short portnum);
 
 /* this function is *provided* by the test case, and is difference between read/write */
 extern int read_socket_and_discard(int fd, int count, unsigned short portnum);

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -13,7 +13,7 @@
 #include <openssl/rand.h>
 #include <openssl/bio.h>
 
-#ifdef WIN32
+#if defined(_WIN32)
 int setup_tests(void)
 {
     return 1;

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -82,7 +82,7 @@ static int test_bio_read_v4(int idx)
   int infd2 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
   BIO_ADDR          *dsthost1, *dsthost2;
   int ret = 0;
-  unsigned int portnum;
+  int portnum;
 
   dsthost1 = BIO_ADDR_new();
   dsthost2 = BIO_ADDR_new();
@@ -105,7 +105,7 @@ static int test_bio_read_v6(int idx)
     BIO_ADDR *dsthost1;
     BIO_ADDR *dsthost2;
     int ret = 0;
-    unsigned int portnum;
+    int portnum;
 
     dsthost1 = BIO_ADDR_new();
     dsthost2 = BIO_ADDR_new();

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -216,24 +216,31 @@ static unsigned int bind_v6_socket(int infd,
 
 static int test_bio_read_v6(int idx)
 {
-  int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
-  int infd1 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
-  int infd2 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
-  BIO_ADDR   *dsthost1;
-  BIO_ADDR   *dsthost2;
-  int ret = 0;
-  unsigned int portnum;
+    int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+    int infd1 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+    int infd2 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+    BIO_ADDR *dsthost1;
+    BIO_ADDR *dsthost2;
+    int ret = 0;
+    unsigned int portnum;
 
-  dsthost1 = BIO_ADDR_new();
-  dsthost2 = BIO_ADDR_new();
+    if(getenv("TRAVISCI_NO_IPV6")==NULL) {
+      dsthost1 = BIO_ADDR_new();
+      dsthost2 = BIO_ADDR_new();
 
-  portnum = bind_v6_socket(infd1, dsthost1);
-  bind_v6_socket(infd2, dsthost2);
+      portnum = bind_v6_socket(infd1, dsthost1);
+      bind_v6_socket(infd2, dsthost2);
 
-  ret = fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);
-  BIO_ADDR_free(dsthost1);
-  BIO_ADDR_free(dsthost2);
-  return ret;
+      ret =
+        fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);
+      BIO_ADDR_free(dsthost1);
+      BIO_ADDR_free(dsthost2);
+    } else {
+      test_printf_stdout("not running IPv6 tests due to travis-ci environment\n");
+      ret = 1;
+    }
+
+    return ret;
 }
 
 int setup_tests(void)

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -16,7 +16,7 @@
 #include "testutil/output.h"
 #include "testutil.h"
 
-#if defined(_WIN32) || defined(OPENSSL_NO_DGRAM)
+#if defined(_WIN32)
 int setup_tests(void)
 {
     return 1;
@@ -26,14 +26,12 @@ int setup_tests(void)
 #include <netinet/in.h>
 #include <unistd.h>
 
-#define PACKET_COUNT 10
-
 /*
  * this test case opens a pair of v4 or v6 sockets, bound to localhost.
  * A process is forked to do the writing. The write path is tested in
  * bio_write_test case.
  *
- * This code exercises the BIO_read side of things.
+ * This code exercises the BIO_read side of things in the parent task.
  *
  * The foreground process reads 5 packets from the socket and discards
  * them.
@@ -41,7 +39,9 @@ int setup_tests(void)
  * The packets being send to the other destination are just ignored for now.
  */
 
-static int read_socket_and_discard(int fd, int count, unsigned portnum)
+#include "bio_dgram_test_helpers.h"
+
+int read_socket_and_discard(int fd, int count, unsigned portnum)
 {
   char buf[512];
   BIO  *in;
@@ -56,12 +56,12 @@ static int read_socket_and_discard(int fd, int count, unsigned portnum)
 
   in = BIO_new_dgram(fd, BIO_CLOSE);
 
-  while(--count > 0 && (ret=BIO_read(in, buf, 512))>0) {
+  while(--count > 0 && (ret = BIO_read(in, buf, 512)) > 0) {
 
     /* now check out the bio structure for the origin of the packet */
     BIO_get_dgram_origin(in, ba);
     port = ntohs(BIO_ADDR_rawport(ba));
-    if(port!=0 && port != portnum) { exit(5); }
+    if(port != 0 && port != portnum) { exit(5); }
   }
 
   if(ret <= 0) {
@@ -71,95 +71,6 @@ static int read_socket_and_discard(int fd, int count, unsigned portnum)
   BIO_ADDR_free(ba);
 
   return count;
-}
-
-static int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2)
-{
-  const char hello[]="hellohellohello";
-  int toggle = 0;
-  int ret;
-
-  while(--count > 0) {
-    const int sizeofhello = sizeof(hello);
-
-    if(toggle && dst2 != NULL) {
-      BIO_set_dgram_dest(bio, dst2);
-    } else {
-      BIO_set_dgram_dest(bio, dst1);
-    }
-
-    ret = BIO_write(bio, hello, sizeofhello);
-    if(ret != sizeofhello) {
-      exit(3);
-    }
-
-    toggle = !toggle;
-  }
-
-  return 0;
-}
-
-static int fork_and_read_write_packets(int infd, int outfd,
-                                       unsigned portnum,
-                                       BIO_ADDR *dsthost1, BIO_ADDR *dsthost2)
-{
-  BIO *out;
-  int expected_count = PACKET_COUNT;
-
-  pid_t pid = fork();
-  int   count;
-
-  switch(pid) {
-  case 0:   /* child */
-    out = BIO_new_dgram(outfd, BIO_CLOSE);
-    write_packets(out, PACKET_COUNT, dsthost1, dsthost2);
-    exit(0);
-
-  case -1:  /* failure */
-    exit(10);
-
-  default:  /* parent */
-    if(dsthost2 != NULL) {
-      expected_count = expected_count / 2;
-    }
-    count = read_socket_and_discard(infd, expected_count, portnum);
-    if(count != 0) {
-      test_printf_stderr("failed receive all packets: %d\n", count);
-      exit(2);
-    }
-  }
-
-  return 1;
-}
-
-static unsigned int bind_v4_socket(int infd,
-                                   BIO_ADDR *dsthost)
-{
-  struct sockaddr_in localhost;
-  socklen_t          sin_len;
-
-  memset(&localhost, 0, sizeof(localhost));
-  localhost.sin_family = AF_INET;
-  localhost.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  localhost.sin_port = 0;
-
-  /* do not set port, let kernel pick. */
-  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
-    perror("bind infd");
-    exit(4);
-  }
-
-  /* extract port number, stuff it into dsthost1 */
-  sin_len = sizeof(localhost);
-  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
-    perror("getsockname");
-    exit(5);
-  }
-  BIO_ADDR_rawmake(dsthost, AF_INET,
-                   &localhost.sin_addr, sizeof(localhost.sin_addr),
-                   localhost.sin_port);
-
-  return ntohs(localhost.sin_port);
 }
 
 static int test_bio_read_v4(int idx)
@@ -181,37 +92,6 @@ static int test_bio_read_v4(int idx)
   BIO_ADDR_free(dsthost1);
   BIO_ADDR_free(dsthost2);
   return ret;
-}
-
-static unsigned int bind_v6_socket(int infd,
-                                   BIO_ADDR *dsthost)
-{
-  struct sockaddr_in6 localhost;
-  socklen_t          sin_len;
-
-  memset(&localhost, 0, sizeof(localhost));
-  localhost.sin6_family = AF_INET6;
-  localhost.sin6_addr   = in6addr_loopback;
-  localhost.sin6_port = 0;
-
-  /* do not set port, let kernel pick. */
-  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
-    perror("bind in6fd");
-    exit(4);
-  }
-
-  /* extract port number */
-  sin_len = sizeof(localhost);
-  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
-    perror("getsockname6");
-    exit(5);
-  }
-
-  BIO_ADDR_rawmake(dsthost, AF_INET6,
-                   &localhost.sin6_addr, sizeof(localhost.sin6_addr),
-                   localhost.sin6_port);
-
-  return ntohs(localhost.sin6_port);
 }
 
 static int test_bio_read_v6(int idx)

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -12,8 +12,15 @@
 #include <openssl/bio.h>
 #include <openssl/rand.h>
 #include <openssl/bio.h>
-#include <netinet/in.h>
+
+#ifdef WIN32
+int setup_tests(void)
+{
+    return 1;
+}
+#else
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <unistd.h>
 
 #include "testutil/output.h"
@@ -236,3 +243,4 @@ int setup_tests(void)
     return 1;
 }
 
+#endif

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <stdio.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/bio.h>
+#include <openssl/rand.h>
+#include <openssl/bio.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "testutil/output.h"
+#include "testutil.h"
+
+#define PACKET_COUNT 10
+
+/*
+ * this test case opens a pair of v4 or v6 sockets, bound to localhost.
+ * A process is forked to do the writing. The write path is tested in
+ * bio_write_test case.
+ *
+ * This code exercises the BIO_read side of things.
+ *
+ * The foreground process reads 5 packets from the socket and discards
+ * them.
+ *
+ * The packets being send to the other destination are just ignored for now.
+ */
+
+static int read_socket_and_discard(int fd, int count, unsigned portnum)
+{
+  char buf[512];
+  BIO  *in;
+  int  ret = 0;
+  BIO_ADDR *ba;
+  unsigned short port;
+
+  /* do not wait forever! */
+  alarm(60);
+
+  ba = BIO_ADDR_new();
+
+  in = BIO_new_dgram(fd, BIO_CLOSE);
+
+  while(--count > 0 && (ret=BIO_read(in, buf, 512))>0) {
+
+    /* now check out the bio structure for the origin of the packet */
+    BIO_get_dgram_origin(in, ba);
+    port = ntohs(BIO_ADDR_rawport(ba));
+    if(port!=0 && port != portnum) { exit(5); }
+  }
+
+  if(ret <= 0) {
+    test_printf_stderr("BIO_read returned %d\n", ret);
+  }
+
+  BIO_ADDR_free(ba);
+
+  return count;
+}
+
+static int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2)
+{
+  const char hello[]="hellohellohello";
+  int toggle = 0;
+  int ret;
+
+  while(--count > 0) {
+    const int sizeofhello = sizeof(hello);
+
+    if(toggle && dst2 != NULL) {
+      BIO_set_dgram_dest(bio, dst2);
+    } else {
+      BIO_set_dgram_dest(bio, dst1);
+    }
+
+    ret = BIO_write(bio, hello, sizeofhello);
+    if(ret != sizeofhello) {
+      exit(3);
+    }
+
+    toggle = !toggle;
+  }
+
+  return 0;
+}
+
+static int fork_and_read_write_packets(int infd, int outfd,
+                                       unsigned portnum,
+                                       BIO_ADDR *dsthost1, BIO_ADDR *dsthost2)
+{
+  BIO *out;
+  int expected_count = PACKET_COUNT;
+
+  pid_t pid = fork();
+  int   count;
+
+  switch(pid) {
+  case 0:   /* child */
+    out = BIO_new_dgram(outfd, BIO_CLOSE);
+    write_packets(out, PACKET_COUNT, dsthost1, dsthost2);
+    exit(0);
+
+  case -1:  /* failure */
+    exit(10);
+
+  default:  /* parent */
+    if(dsthost2 != NULL) {
+      expected_count = expected_count / 2;
+    }
+    count = read_socket_and_discard(infd, expected_count, portnum);
+    if(count != 0) {
+      test_printf_stderr("failed receive all packets: %d\n", count);
+      exit(2);
+    }
+  }
+
+  return 1;
+}
+
+static unsigned int bind_v4_socket(int infd,
+                                   BIO_ADDR *dsthost)
+{
+  struct sockaddr_in localhost;
+  socklen_t          sin_len;
+
+  memset(&localhost, 0, sizeof(localhost));
+  localhost.sin_family = AF_INET;
+  localhost.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  localhost.sin_port = 0;
+
+  /* do not set port, let kernel pick. */
+  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
+    perror("bind infd");
+    exit(4);
+  }
+
+  /* extract port number, stuff it into dsthost1 */
+  sin_len = sizeof(localhost);
+  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
+    perror("getsockname");
+    exit(5);
+  }
+  BIO_ADDR_rawmake(dsthost, AF_INET,
+                   &localhost.sin_addr, sizeof(localhost.sin_addr),
+                   localhost.sin_port);
+
+  return ntohs(localhost.sin_port);
+}
+
+static int test_bio_read_v4(int idx)
+{
+  int outfd = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  int infd1 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  int infd2 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  BIO_ADDR          *dsthost1, *dsthost2;
+  int ret = 0;
+  unsigned int portnum;
+
+  dsthost1 = BIO_ADDR_new();
+  dsthost2 = BIO_ADDR_new();
+
+  portnum = bind_v4_socket(infd1, dsthost1);
+  bind_v4_socket(infd2, dsthost2);
+
+  ret = fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);
+  BIO_ADDR_free(dsthost1);
+  BIO_ADDR_free(dsthost2);
+  return ret;
+}
+
+static unsigned int bind_v6_socket(int infd,
+                                   BIO_ADDR *dsthost)
+{
+  struct sockaddr_in6 localhost;
+  socklen_t          sin_len;
+
+  memset(&localhost, 0, sizeof(localhost));
+  localhost.sin6_family = AF_INET6;
+  localhost.sin6_addr   = in6addr_loopback;
+  localhost.sin6_port = 0;
+
+  /* do not set port, let kernel pick. */
+  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
+    perror("bind in6fd");
+    exit(4);
+  }
+
+  /* extract port number */
+  sin_len = sizeof(localhost);
+  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
+    perror("getsockname6");
+    exit(5);
+  }
+
+  BIO_ADDR_rawmake(dsthost, AF_INET6,
+                   &localhost.sin6_addr, sizeof(localhost.sin6_addr),
+                   localhost.sin6_port);
+
+  return ntohs(localhost.sin6_port);
+}
+
+static int test_bio_read_v6(int idx)
+{
+  int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  int infd1 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  int infd2 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  BIO_ADDR   *dsthost1;
+  BIO_ADDR   *dsthost2;
+  int ret = 0;
+  unsigned int portnum;
+
+  dsthost1 = BIO_ADDR_new();
+  dsthost2 = BIO_ADDR_new();
+
+  portnum = bind_v6_socket(infd1, dsthost1);
+  bind_v6_socket(infd2, dsthost2);
+
+  ret = fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);
+  BIO_ADDR_free(dsthost1);
+  BIO_ADDR_free(dsthost2);
+  return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(test_bio_read_v4, 1);
+    ADD_ALL_TESTS(test_bio_read_v6, 1);
+    return 1;
+}
+

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -13,7 +13,10 @@
 #include <openssl/rand.h>
 #include <openssl/bio.h>
 
-#if defined(_WIN32)
+#include "testutil/output.h"
+#include "testutil.h"
+
+#if defined(_WIN32) || defined(OPENSSL_NO_DGRAM)
 int setup_tests(void)
 {
     return 1;
@@ -22,9 +25,6 @@ int setup_tests(void)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>
-
-#include "testutil/output.h"
-#include "testutil.h"
 
 #define PACKET_COUNT 10
 

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -36,11 +36,12 @@ int setup_tests(void)
  * The foreground process reads 5 packets from the socket and discards
  * them.
  *
- * The packets being send to the other destination are just ignored for now.
+ * The packets being sent to the other destination are just ignored for now.
  */
 
 #include "bio_dgram_test_helpers.h"
 
+/* this runs in the parent process */
 int read_socket_and_discard(int fd, int count, unsigned portnum)
 {
   char buf[512];
@@ -61,7 +62,8 @@ int read_socket_and_discard(int fd, int count, unsigned portnum)
     /* now check out the bio structure for the origin of the packet */
     BIO_get_dgram_origin(in, ba);
     port = ntohs(BIO_ADDR_rawport(ba));
-    if(port != 0 && port != portnum) { exit(5); }
+    if(port != 0 && port != portnum)
+      TEST_error("packet from wrong port. Got %u, expected %u\n", port, portnum);
   }
 
   if(ret <= 0) {

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -88,7 +88,8 @@ static int test_bio_read_v4(int idx)
   dsthost2 = BIO_ADDR_new();
 
   portnum = bind_v4_socket(infd1, dsthost1);
-  bind_v4_socket(infd2, dsthost2);
+  if(portnum == -1 ||
+     bind_v4_socket(infd2, dsthost2) == -1) return 0;
 
   ret = fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);
   BIO_ADDR_free(dsthost1);
@@ -106,21 +107,17 @@ static int test_bio_read_v6(int idx)
     int ret = 0;
     unsigned int portnum;
 
-    if(getenv("TRAVISCI_NO_IPV6")==NULL) {
-      dsthost1 = BIO_ADDR_new();
-      dsthost2 = BIO_ADDR_new();
+    dsthost1 = BIO_ADDR_new();
+    dsthost2 = BIO_ADDR_new();
 
-      portnum = bind_v6_socket(infd1, dsthost1, 0);
-      bind_v6_socket(infd2, dsthost2, 0);
+    portnum = bind_v6_socket(infd1, dsthost1, 0);
+    if(portnum == -1 ||
+       bind_v6_socket(infd2, dsthost2, 0) == -1) return 0;
 
-      ret =
-        fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);
-      BIO_ADDR_free(dsthost1);
-      BIO_ADDR_free(dsthost2);
-    } else {
-      test_printf_stdout("not running IPv6 tests due to travis-ci environment\n");
-      ret = 1;
-    }
+    ret = fork_and_read_write_packets(infd1, outfd,
+                                      portnum, dsthost1, dsthost2);
+    BIO_ADDR_free(dsthost1);
+    BIO_ADDR_free(dsthost2);
 
     return ret;
 }

--- a/test/bio_read_test.c
+++ b/test/bio_read_test.c
@@ -42,7 +42,7 @@ int setup_tests(void)
 #include "bio_dgram_test_helpers.h"
 
 /* this runs in the parent process */
-int read_socket_and_discard(int fd, int count, unsigned portnum)
+int read_socket_and_discard(int fd, int count, unsigned short portnum)
 {
   char buf[512];
   BIO  *in;
@@ -110,8 +110,8 @@ static int test_bio_read_v6(int idx)
       dsthost1 = BIO_ADDR_new();
       dsthost2 = BIO_ADDR_new();
 
-      portnum = bind_v6_socket(infd1, dsthost1);
-      bind_v6_socket(infd2, dsthost2);
+      portnum = bind_v6_socket(infd1, dsthost1, 0);
+      bind_v6_socket(infd2, dsthost2, 0);
 
       ret =
         fork_and_read_write_packets(infd1, outfd, portnum, dsthost1, dsthost2);

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -13,7 +13,7 @@
 #include <openssl/rand.h>
 #include <openssl/bio.h>
 
-#ifdef WIN32
+#if defined(_WIN32)
 int setup_tests(void)
 {
     return 1;

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -15,7 +15,7 @@
 #include "testutil/output.h"
 #include "testutil.h"
 
-#if defined(_WIN32) || defined(OPENSSL_NO_DGRAM)
+#if defined(_WIN32)
 int setup_tests(void)
 {
     return 1;
@@ -25,11 +25,9 @@ int setup_tests(void)
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#define PACKET_COUNT 10
-
 /*
  * this test case opens a pair of v4 or v6 sockets, bound to localhost.
- * A process is forked to do the writing, which is where the BIO code
+ * A process is forked to do the *writing*, which is where the BIO code
  * is really exercised.  It writes alternately to two destinations.
  *
  * The foreground process reads 5 packets from the socket and discards
@@ -39,7 +37,8 @@ int setup_tests(void)
  * The packets being send to the other destination are just ignored for now.
  */
 
-static int read_socket_and_discard(int fd, int count)
+/* this is done with non BIO code because it is not the side that is being tested */
+int read_socket_and_discard(int fd, int count, int portnum)
 {
   char buf[512];
 
@@ -48,92 +47,6 @@ static int read_socket_and_discard(int fd, int count)
 
   while(--count > 0 && read(fd, buf, 512)>0);
   return count;
-}
-
-static int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2)
-{
-  const char hello[]="hellohellohello";
-  int toggle = 0;
-  int ret;
-
-  while(--count > 0) {
-    const int sizeofhello = sizeof(hello);
-
-    if(toggle && dst2 != NULL) {
-      BIO_set_dgram_dest(bio, dst2);
-    } else {
-      BIO_set_dgram_dest(bio, dst1);
-    }
-
-    ret = BIO_write(bio, hello, sizeofhello);
-    if(ret != sizeofhello) {
-      exit(3);
-    }
-
-    toggle = !toggle;
-  }
-
-  return 0;
-}
-
-static int fork_and_read_write_packets(int infd, int outfd,
-                                       BIO_ADDR *dsthost1, BIO_ADDR *dsthost2)
-{
-  BIO *out;
-  int expected_count = PACKET_COUNT;
-
-  pid_t pid = fork();
-  int   count;
-
-  switch(pid) {
-  case 0:   /* child */
-    out = BIO_new_dgram(outfd, BIO_CLOSE);
-    write_packets(out, PACKET_COUNT, dsthost1, dsthost2);
-    exit(0);
-
-  case -1:  /* failure */
-    exit(10);
-
-  default:  /* parent */
-    if(dsthost2 != NULL) {
-      expected_count = expected_count / 2;
-    }
-    count = read_socket_and_discard(infd, expected_count);
-    if(count != 0) {
-      test_printf_stderr("failed receive all packets: %d\n", count);
-      exit(2);
-    }
-  }
-
-  return 1;
-}
-
-static void bind_v4_socket(int infd,
-                          BIO_ADDR *dsthost)
-{
-  struct sockaddr_in localhost;
-  socklen_t          sin_len;
-
-  memset(&localhost, 0, sizeof(localhost));
-  localhost.sin_family = AF_INET;
-  localhost.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  localhost.sin_port = 0;
-
-  /* do not set port, let kernel pick. */
-  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
-    perror("bind infd");
-    exit(4);
-  }
-
-  /* extract port number, stuff it into dsthost1 */
-  sin_len = sizeof(localhost);
-  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
-    perror("getsockname");
-    exit(5);
-  }
-  BIO_ADDR_rawmake(dsthost, AF_INET,
-                   &localhost.sin_addr, sizeof(localhost.sin_addr),
-                   localhost.sin_port);
 }
 
 static int test_bio_write_v4(int idx)
@@ -156,35 +69,6 @@ static int test_bio_write_v4(int idx)
   return ret;
 }
 
-static void bind_v6_socket(int infd,
-                           BIO_ADDR *dsthost)
-{
-  struct sockaddr_in6 localhost;
-  socklen_t          sin_len;
-
-  memset(&localhost, 0, sizeof(localhost));
-  localhost.sin6_family = AF_INET6;
-  localhost.sin6_addr   = in6addr_loopback;
-  localhost.sin6_port = 0;
-
-  /* do not set port, let kernel pick. */
-  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
-    perror("bind in6fd");
-    exit(4);
-  }
-
-  /* extract port number */
-  sin_len = sizeof(localhost);
-  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
-    perror("getsockname6");
-    exit(5);
-  }
-
-  BIO_ADDR_rawmake(dsthost, AF_INET6,
-                   &localhost.sin6_addr, sizeof(localhost.sin6_addr),
-                   localhost.sin6_port);
-}
-
 static int test_bio_write_v6(int idx)
 {
   int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
@@ -193,15 +77,16 @@ static int test_bio_write_v6(int idx)
   BIO_ADDR   *dsthost1;
   BIO_ADDR   *dsthost2;
   int ret = 0;
+  unsigned short portnum1, portnum2;
 
   if(getenv("TRAVISCI_NO_IPV6")==NULL) {
     dsthost1 = BIO_ADDR_new();
     dsthost2 = BIO_ADDR_new();
 
-    bind_v6_socket(infd1, dsthost1);
-    bind_v6_socket(infd2, dsthost2);
+    portnum1 = bind_v6_socket(infd1, dsthost1, 0);
+    portnum2 = bind_v6_socket(infd2, dsthost2, portnum1);
 
-    ret = fork_and_read_write_packets(infd1, outfd, dsthost1, dsthost2);
+    ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
     BIO_ADDR_free(dsthost1);
     BIO_ADDR_free(dsthost2);
   } else {

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -45,7 +45,7 @@ int read_socket_and_discard(int fd, int count, int portnum)
   /* do not wait forever! */
   alarm(60);
 
-  while(--count > 0 && read(fd, buf, 512)>0);
+  while(--count > 0 && read(fd, buf, 512) > 0);
   return count;
 }
 
@@ -79,19 +79,15 @@ static int test_bio_write_v6(int idx)
   int ret = 0;
   unsigned short portnum1, portnum2;
 
-  if(getenv("TRAVISCI_NO_IPV6")==NULL) {
-    dsthost1 = BIO_ADDR_new();
-    dsthost2 = BIO_ADDR_new();
+  dsthost1 = BIO_ADDR_new();
+  dsthost2 = BIO_ADDR_new();
 
-    portnum1 = bind_v6_socket(infd1, dsthost1, 0);
-    portnum2 = bind_v6_socket(infd2, dsthost2, portnum1);
+  portnum1 = bind_v6_socket(infd1, dsthost1, 0);
+  portnum2 = bind_v6_socket(infd2, dsthost2, portnum1);
 
-    ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
-    BIO_ADDR_free(dsthost1);
-    BIO_ADDR_free(dsthost2);
-  } else {
-    ret = 1;
-  }
+  ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
+  BIO_ADDR_free(dsthost1);
+  BIO_ADDR_free(dsthost2);
   return ret;
 }
 

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -87,9 +87,10 @@ static int test_bio_write_v6(int idx)
 
   portnum1 = bind_v6_socket(infd1, dsthost1, 0);
   if(portnum1 == -1 ||
-     bind_v6_socket(infd2, dsthost2, portnum1) == -1) return 0;
+     bind_v6_socket(infd2, dsthost2, portnum1) == -1) goto end;
 
   ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
+ end:
   BIO_ADDR_free(dsthost1);
   BIO_ADDR_free(dsthost2);
   return ret;

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -12,8 +12,10 @@
 #include <openssl/bio.h>
 #include <openssl/rand.h>
 #include <openssl/bio.h>
+#include "testutil/output.h"
+#include "testutil.h"
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(OPENSSL_NO_DGRAM)
 int setup_tests(void)
 {
     return 1;
@@ -22,9 +24,6 @@ int setup_tests(void)
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-
-#include "testutil/output.h"
-#include "testutil.h"
 
 #define PACKET_COUNT 10
 

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -86,7 +86,8 @@ static int test_bio_write_v6(int idx)
   dsthost2 = BIO_ADDR_new();
 
   portnum1 = bind_v6_socket(infd1, dsthost1, 0);
-  bind_v6_socket(infd2, dsthost2, portnum1);
+  if(portnum1 == -1 ||
+     bind_v6_socket(infd2, dsthost2, portnum1) == -1) return 0;
 
   ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
   BIO_ADDR_free(dsthost1);

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -58,7 +58,7 @@ static int test_bio_write_v4(int idx)
   int infd2 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
   BIO_ADDR          *dsthost1, *dsthost2;
   int ret = 0;
-  unsigned short portnum1;
+  short portnum1;
 
   dsthost1 = BIO_ADDR_new();
   dsthost2 = BIO_ADDR_new();
@@ -80,7 +80,7 @@ static int test_bio_write_v6(int idx)
   BIO_ADDR   *dsthost1;
   BIO_ADDR   *dsthost2;
   int ret = 0;
-  unsigned short portnum1;
+  int portnum1;
 
   dsthost1 = BIO_ADDR_new();
   dsthost2 = BIO_ADDR_new();

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -194,15 +194,19 @@ static int test_bio_write_v6(int idx)
   BIO_ADDR   *dsthost2;
   int ret = 0;
 
-  dsthost1 = BIO_ADDR_new();
-  dsthost2 = BIO_ADDR_new();
+  if(getenv("TRAVISCI_NO_IPV6")==NULL) {
+    dsthost1 = BIO_ADDR_new();
+    dsthost2 = BIO_ADDR_new();
 
-  bind_v6_socket(infd1, dsthost1);
-  bind_v6_socket(infd2, dsthost2);
+    bind_v6_socket(infd1, dsthost1);
+    bind_v6_socket(infd2, dsthost2);
 
-  ret = fork_and_read_write_packets(infd1, outfd, dsthost1, dsthost2);
-  BIO_ADDR_free(dsthost1);
-  BIO_ADDR_free(dsthost2);
+    ret = fork_and_read_write_packets(infd1, outfd, dsthost1, dsthost2);
+    BIO_ADDR_free(dsthost1);
+    BIO_ADDR_free(dsthost2);
+  } else {
+    ret = 1;
+  }
   return ret;
 }
 

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -25,6 +25,8 @@ int setup_tests(void)
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+#include "bio_dgram_test_helpers.h"
+
 /*
  * this test case opens a pair of v4 or v6 sockets, bound to localhost.
  * A process is forked to do the *writing*, which is where the BIO code
@@ -38,7 +40,7 @@ int setup_tests(void)
  */
 
 /* this is done with non BIO code because it is not the side that is being tested */
-int read_socket_and_discard(int fd, int count, int portnum)
+int read_socket_and_discard(int fd, int count, unsigned short portnum)
 {
   char buf[512];
 
@@ -56,14 +58,15 @@ static int test_bio_write_v4(int idx)
   int infd2 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
   BIO_ADDR          *dsthost1, *dsthost2;
   int ret = 0;
+  unsigned short portnum1;
 
   dsthost1 = BIO_ADDR_new();
   dsthost2 = BIO_ADDR_new();
 
-  bind_v4_socket(infd1, dsthost1);
+  portnum1 = bind_v4_socket(infd1, dsthost1);
   bind_v4_socket(infd2, dsthost2);
 
-  ret = fork_and_read_write_packets(infd1, outfd, dsthost1, dsthost2);
+  ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
   BIO_ADDR_free(dsthost1);
   BIO_ADDR_free(dsthost2);
   return ret;
@@ -77,13 +80,13 @@ static int test_bio_write_v6(int idx)
   BIO_ADDR   *dsthost1;
   BIO_ADDR   *dsthost2;
   int ret = 0;
-  unsigned short portnum1, portnum2;
+  unsigned short portnum1;
 
   dsthost1 = BIO_ADDR_new();
   dsthost2 = BIO_ADDR_new();
 
   portnum1 = bind_v6_socket(infd1, dsthost1, 0);
-  portnum2 = bind_v6_socket(infd2, dsthost2, portnum1);
+  bind_v6_socket(infd2, dsthost2, portnum1);
 
   ret = fork_and_read_write_packets(infd1, outfd, portnum1, dsthost1, dsthost2);
   BIO_ADDR_free(dsthost1);

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <stdio.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/bio.h>
+#include <openssl/rand.h>
+#include <openssl/bio.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "testutil/output.h"
+#include "testutil.h"
+
+#define PACKET_COUNT 10
+
+/*
+ * this test case opens a pair of v4 or v6 sockets, bound to localhost.
+ * A process is forked to do the writing, which is where the BIO code
+ * is really exercised.
+ *
+ * The foreground process reads 10 packets from the socket and discards
+ * them.  This is done in the foreground because it's easier to count the
+ * packets and exit sanely.
+ */
+
+static int read_socket_and_discard(int fd, int count)
+{
+  char buf[512];
+
+  while(--count > 0 && read(fd, buf, 512)>0);
+  return count;
+}
+
+static int write_packets(BIO *bio, int count)
+{
+  const char hello[]="hellohellohello";
+
+  while(--count > 0) {
+    const int sizeofhello = sizeof(hello);
+    int ret = BIO_write(bio, hello, sizeofhello);
+    if(ret != sizeofhello) {
+      exit(3);
+    }
+  }
+
+  return 0;
+}
+
+static int fork_and_read_write_packets(int infd, int outfd,
+                                       BIO_ADDR *dsthost)
+{
+  BIO *out;
+
+  pid_t pid = fork();
+  int   count;
+  switch(pid) {
+  case 0:   /* child */
+    out = BIO_new_dgram(outfd, BIO_CLOSE);
+    BIO_set_dgram_dest(out, dsthost);
+    write_packets(out, PACKET_COUNT);
+    exit(0);
+
+  case -1:  /* failure */
+    exit(10);
+
+  default:  /* parent */
+    count = read_socket_and_discard(infd, PACKET_COUNT);
+    if(count != 0) {
+      test_printf_stderr("failed receive all packets: %d\n", count);
+      exit(2);
+    }
+  }
+
+  return 1;
+}
+
+static int test_bio_write_v4(int idx)
+{
+  int outfd = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  int infd  = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  BIO_ADDR          *dsthost;
+  struct sockaddr_in localhost;
+  socklen_t          sin_len;
+  int ret = 0;
+
+  memset(&localhost, 0, sizeof(localhost));
+  localhost.sin_family = AF_INET;
+  localhost.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  dsthost = BIO_ADDR_new();
+
+  /* do not set port, let kernel pick. */
+  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
+    perror("bind infd");
+    exit(4);
+  }
+
+  /* extract port number */
+  sin_len = sizeof(localhost);
+  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
+    perror("getsockname");
+    exit(5);
+  }
+
+  //printf("bound to port: %u\n", ntohs(localhost.sin_port));
+
+  BIO_ADDR_rawmake(dsthost, AF_INET,
+                   &localhost.sin_addr, sizeof(localhost.sin_addr),
+                   localhost.sin_port);
+
+  ret = fork_and_read_write_packets(infd, outfd, dsthost);
+  BIO_ADDR_free(dsthost);
+  return ret;
+}
+
+static int test_bio_write_v6(int idx)
+{
+  int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  int infd  = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  BIO_ADDR          *dsthost;
+  struct sockaddr_in6 localhost;
+  socklen_t          sin_len;
+  int ret = 0;
+
+  memset(&localhost, 0, sizeof(localhost));
+  localhost.sin6_family = AF_INET6;
+  localhost.sin6_addr   = in6addr_loopback;
+  dsthost = BIO_ADDR_new();
+
+  /* do not set port, let kernel pick. */
+  if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
+    perror("bind in6fd");
+    exit(4);
+  }
+
+  /* extract port number */
+  sin_len = sizeof(localhost);
+  if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
+    perror("getsockname6");
+    exit(5);
+  }
+
+#if 0
+  printf("bound to v6 port: %u\n", ntohs(localhost.sin6_port));
+#endif
+
+  BIO_ADDR_rawmake(dsthost, AF_INET6,
+                   &localhost.sin6_addr, sizeof(localhost.sin6_addr),
+                   localhost.sin6_port);
+
+  ret = fork_and_read_write_packets(infd, outfd, dsthost);
+  BIO_ADDR_free(dsthost);
+  return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(test_bio_write_v4, 1);
+    ADD_ALL_TESTS(test_bio_write_v6, 1);
+    return 1;
+}
+

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -12,9 +12,16 @@
 #include <openssl/bio.h>
 #include <openssl/rand.h>
 #include <openssl/bio.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
+
+#ifdef WIN32
+int setup_tests(void)
+{
+    return 1;
+}
+#else
 #include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 #include "testutil/output.h"
 #include "testutil.h"
@@ -206,3 +213,4 @@ int setup_tests(void)
     return 1;
 }
 
+#endif /* !WIN32 */

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -55,6 +55,7 @@ static int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2)
 {
   const char hello[]="hellohellohello";
   int toggle = 0;
+  int ret;
 
   while(--count > 0) {
     const int sizeofhello = sizeof(hello);

--- a/test/bio_write_test.c
+++ b/test/bio_write_test.c
@@ -24,55 +24,74 @@
 /*
  * this test case opens a pair of v4 or v6 sockets, bound to localhost.
  * A process is forked to do the writing, which is where the BIO code
- * is really exercised.
+ * is really exercised.  It writes alternately to two destinations.
  *
- * The foreground process reads 10 packets from the socket and discards
+ * The foreground process reads 5 packets from the socket and discards
  * them.  This is done in the foreground because it's easier to count the
  * packets and exit sanely.
+ *
+ * The packets being send to the other destination are just ignored for now.
  */
 
 static int read_socket_and_discard(int fd, int count)
 {
   char buf[512];
 
+  /* do not wait forever! */
+  alarm(60);
+
   while(--count > 0 && read(fd, buf, 512)>0);
   return count;
 }
 
-static int write_packets(BIO *bio, int count)
+static int write_packets(BIO *bio, int count, BIO_ADDR *dst1, BIO_ADDR *dst2)
 {
   const char hello[]="hellohellohello";
+  int toggle = 0;
 
   while(--count > 0) {
     const int sizeofhello = sizeof(hello);
-    int ret = BIO_write(bio, hello, sizeofhello);
+
+    if(toggle && dst2 != NULL) {
+      BIO_set_dgram_dest(bio, dst2);
+    } else {
+      BIO_set_dgram_dest(bio, dst1);
+    }
+
+    ret = BIO_write(bio, hello, sizeofhello);
     if(ret != sizeofhello) {
       exit(3);
     }
+
+    toggle = !toggle;
   }
 
   return 0;
 }
 
 static int fork_and_read_write_packets(int infd, int outfd,
-                                       BIO_ADDR *dsthost)
+                                       BIO_ADDR *dsthost1, BIO_ADDR *dsthost2)
 {
   BIO *out;
+  int expected_count = PACKET_COUNT;
 
   pid_t pid = fork();
   int   count;
+
   switch(pid) {
   case 0:   /* child */
     out = BIO_new_dgram(outfd, BIO_CLOSE);
-    BIO_set_dgram_dest(out, dsthost);
-    write_packets(out, PACKET_COUNT);
+    write_packets(out, PACKET_COUNT, dsthost1, dsthost2);
     exit(0);
 
   case -1:  /* failure */
     exit(10);
 
   default:  /* parent */
-    count = read_socket_and_discard(infd, PACKET_COUNT);
+    if(dsthost2 != NULL) {
+      expected_count = expected_count / 2;
+    }
+    count = read_socket_and_discard(infd, expected_count);
     if(count != 0) {
       test_printf_stderr("failed receive all packets: %d\n", count);
       exit(2);
@@ -82,19 +101,16 @@ static int fork_and_read_write_packets(int infd, int outfd,
   return 1;
 }
 
-static int test_bio_write_v4(int idx)
+static void bind_v4_socket(int infd,
+                          BIO_ADDR *dsthost)
 {
-  int outfd = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
-  int infd  = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
-  BIO_ADDR          *dsthost;
   struct sockaddr_in localhost;
   socklen_t          sin_len;
-  int ret = 0;
 
   memset(&localhost, 0, sizeof(localhost));
   localhost.sin_family = AF_INET;
   localhost.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  dsthost = BIO_ADDR_new();
+  localhost.sin_port = 0;
 
   /* do not set port, let kernel pick. */
   if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
@@ -102,37 +118,47 @@ static int test_bio_write_v4(int idx)
     exit(4);
   }
 
-  /* extract port number */
+  /* extract port number, stuff it into dsthost1 */
   sin_len = sizeof(localhost);
   if(getsockname(infd, (struct sockaddr *)&localhost, &sin_len) != 0) {
     perror("getsockname");
     exit(5);
   }
-
-  //printf("bound to port: %u\n", ntohs(localhost.sin_port));
-
   BIO_ADDR_rawmake(dsthost, AF_INET,
                    &localhost.sin_addr, sizeof(localhost.sin_addr),
                    localhost.sin_port);
+}
 
-  ret = fork_and_read_write_packets(infd, outfd, dsthost);
-  BIO_ADDR_free(dsthost);
+static int test_bio_write_v4(int idx)
+{
+  int outfd = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  int infd1 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  int infd2 = BIO_socket(AF_INET, SOCK_DGRAM, 0, 0);
+  BIO_ADDR          *dsthost1, *dsthost2;
+  int ret = 0;
+
+  dsthost1 = BIO_ADDR_new();
+  dsthost2 = BIO_ADDR_new();
+
+  bind_v4_socket(infd1, dsthost1);
+  bind_v4_socket(infd2, dsthost2);
+
+  ret = fork_and_read_write_packets(infd1, outfd, dsthost1, dsthost2);
+  BIO_ADDR_free(dsthost1);
+  BIO_ADDR_free(dsthost2);
   return ret;
 }
 
-static int test_bio_write_v6(int idx)
+static void bind_v6_socket(int infd,
+                           BIO_ADDR *dsthost)
 {
-  int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
-  int infd  = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
-  BIO_ADDR          *dsthost;
   struct sockaddr_in6 localhost;
   socklen_t          sin_len;
-  int ret = 0;
 
   memset(&localhost, 0, sizeof(localhost));
   localhost.sin6_family = AF_INET6;
   localhost.sin6_addr   = in6addr_loopback;
-  dsthost = BIO_ADDR_new();
+  localhost.sin6_port = 0;
 
   /* do not set port, let kernel pick. */
   if(bind(infd, (struct sockaddr *)&localhost, sizeof(localhost)) != 0) {
@@ -147,16 +173,29 @@ static int test_bio_write_v6(int idx)
     exit(5);
   }
 
-#if 0
-  printf("bound to v6 port: %u\n", ntohs(localhost.sin6_port));
-#endif
-
   BIO_ADDR_rawmake(dsthost, AF_INET6,
                    &localhost.sin6_addr, sizeof(localhost.sin6_addr),
                    localhost.sin6_port);
+}
 
-  ret = fork_and_read_write_packets(infd, outfd, dsthost);
-  BIO_ADDR_free(dsthost);
+static int test_bio_write_v6(int idx)
+{
+  int outfd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  int infd1 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  int infd2 = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0);
+  BIO_ADDR   *dsthost1;
+  BIO_ADDR   *dsthost2;
+  int ret = 0;
+
+  dsthost1 = BIO_ADDR_new();
+  dsthost2 = BIO_ADDR_new();
+
+  bind_v6_socket(infd1, dsthost1);
+  bind_v6_socket(infd2, dsthost2);
+
+  ret = fork_and_read_write_packets(infd1, outfd, dsthost1, dsthost2);
+  BIO_ADDR_free(dsthost1);
+  BIO_ADDR_free(dsthost2);
   return ret;
 }
 

--- a/test/build.info
+++ b/test/build.info
@@ -51,6 +51,7 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test param_build_test \
           bioprinttest sslapitest dtlstest sslcorrupttest \
+          bio_write_test \
           bio_enc_test pkey_meth_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips \
           asn1_encode_test asn1_decode_test asn1_string_table_test \
@@ -414,6 +415,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[dtlstest]=dtlstest.c helpers/ssltestlib.c
   INCLUDE[dtlstest]=../include ../apps/include
   DEPEND[dtlstest]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[bio_write_test]=bio_write_test.c
+  INCLUDE[bio_write_test]=../include ../apps/include
+  DEPEND[bio_write_test]=../libcrypto libtestutil.a
 
   SOURCE[sslcorrupttest]=sslcorrupttest.c helpers/ssltestlib.c
   INCLUDE[sslcorrupttest]=../include ../apps/include

--- a/test/build.info
+++ b/test/build.info
@@ -415,7 +415,7 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[dtlstest]=../include ../apps/include
   DEPEND[dtlstest]=../libcrypto ../libssl libtestutil.a
 
-  IF[{- !$disabled{sock} -}]
+  IF[{- !$disabled{dgram} -}]
     PROGRAMS{noinst}=bio_write_test bio_read_test
   ENDIF
   SOURCE[bio_write_test]=bio_write_test.c bio_dgram_test_helpers.c

--- a/test/build.info
+++ b/test/build.info
@@ -416,17 +416,23 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[dtlstest]=../include ../apps/include
   DEPEND[dtlstest]=../libcrypto ../libssl libtestutil.a
 
+  IF[{- !$disabled{sock} -}]
+    PROGRAMS{noinst}=bio_write_test bio_read_test
+  ENDIF
+  IF[{- !$disabled{dgram} -}]
+    PROGRAMS{noinst}=bio_write_test bio_read_test
+  ENDIF
   SOURCE[bio_write_test]=bio_write_test.c
   INCLUDE[bio_write_test]=../include ../apps/include
   DEPEND[bio_write_test]=../libcrypto libtestutil.a
 
-  SOURCE[sslcorrupttest]=sslcorrupttest.c helpers/ssltestlib.c
-  INCLUDE[sslcorrupttest]=../include ../apps/include
-  DEPEND[sslcorrupttest]=../libcrypto ../libssl libtestutil.a
-
   SOURCE[bio_read_test]=bio_read_test.c
   INCLUDE[bio_read_test]=../include ../apps/include
   DEPEND[bio_read_test]=../libcrypto libtestutil.a
+
+  SOURCE[sslcorrupttest]=sslcorrupttest.c helpers/ssltestlib.c
+  INCLUDE[sslcorrupttest]=../include ../apps/include
+  DEPEND[sslcorrupttest]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[bio_enc_test]=bio_enc_test.c
   INCLUDE[bio_enc_test]=../include ../apps/include

--- a/test/build.info
+++ b/test/build.info
@@ -51,7 +51,6 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test param_build_test \
           bioprinttest sslapitest dtlstest sslcorrupttest \
-          bio_write_test bio_read_test \
           bio_enc_test pkey_meth_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips \
           asn1_encode_test asn1_decode_test asn1_string_table_test \
@@ -419,14 +418,11 @@ IF[{- !$disabled{tests} -}]
   IF[{- !$disabled{sock} -}]
     PROGRAMS{noinst}=bio_write_test bio_read_test
   ENDIF
-  IF[{- !$disabled{dgram} -}]
-    PROGRAMS{noinst}=bio_write_test bio_read_test
-  ENDIF
-  SOURCE[bio_write_test]=bio_write_test.c
+  SOURCE[bio_write_test]=bio_write_test.c bio_dgram_test_helpers.c
   INCLUDE[bio_write_test]=../include ../apps/include
   DEPEND[bio_write_test]=../libcrypto libtestutil.a
 
-  SOURCE[bio_read_test]=bio_read_test.c
+  SOURCE[bio_read_test]=bio_read_test.c   bio_dgram_test_helpers.c
   INCLUDE[bio_read_test]=../include ../apps/include
   DEPEND[bio_read_test]=../libcrypto libtestutil.a
 

--- a/test/build.info
+++ b/test/build.info
@@ -51,7 +51,7 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test param_build_test \
           bioprinttest sslapitest dtlstest sslcorrupttest \
-          bio_write_test \
+          bio_write_test bio_read_test \
           bio_enc_test pkey_meth_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips \
           asn1_encode_test asn1_decode_test asn1_string_table_test \
@@ -423,6 +423,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[sslcorrupttest]=sslcorrupttest.c helpers/ssltestlib.c
   INCLUDE[sslcorrupttest]=../include ../apps/include
   DEPEND[sslcorrupttest]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[bio_read_test]=bio_read_test.c
+  INCLUDE[bio_read_test]=../include ../apps/include
+  DEPEND[bio_read_test]=../libcrypto libtestutil.a
 
   SOURCE[bio_enc_test]=bio_enc_test.c
   INCLUDE[bio_enc_test]=../include ../apps/include

--- a/test/recipes/83-test_bio_write.t
+++ b/test/recipes/83-test_bio_write.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_bio_write", "bio_write_test", "bio_write");

--- a/test/recipes/83-test_bio_write.t
+++ b/test/recipes/83-test_bio_write.t
@@ -9,4 +9,7 @@
 
 use OpenSSL::Test::Simple;
 
+plan skip_all => "datagram support is disabled in this build"
+    if disabled('dgram');
+
 simple_test("test_bio_write", "bio_write_test", "bio_write");

--- a/test/recipes/83-test_bio_write.t
+++ b/test/recipes/83-test_bio_write.t
@@ -6,10 +6,17 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use strict;
+use warnings;
 
+use OpenSSL::Test;
 use OpenSSL::Test::Simple;
+use OpenSSL::Test::Utils;
+
+setup("test_bio_write");
 
 plan skip_all => "datagram support is disabled in this build"
     if disabled('dgram');
 
 simple_test("test_bio_write", "bio_write_test", "bio_write");
+

--- a/util/other.syms
+++ b/util/other.syms
@@ -160,6 +160,8 @@ BIO_get_buffer_num_lines                define
 BIO_get_cipher_ctx                      define
 BIO_get_cipher_status                   define
 BIO_get_close                           define
+BIO_get_dgram_dest                      define
+BIO_get_dgram_origin                    define
 BIO_get_ktls_send                       define
 BIO_get_ktls_recv                       define
 BIO_get_conn_address                    define
@@ -201,6 +203,8 @@ BIO_set_conn_hostname                   define
 BIO_set_conn_port                       define
 BIO_set_conn_ip_family                  define
 BIO_set_conn_mode                       define
+BIO_set_dgram_dest                      define
+BIO_set_dgram_origin                    define
 BIO_set_fd                              define
 BIO_set_fp                              define
 BIO_set_indent                          define


### PR DESCRIPTION
This code and two test cases adjusts the bss_dgram read/write which is used in DTLS such that 
the originating and destination addresses are retrieved upon read, and are set in write.  This permits
a UDP "server" socket to be bound to :: (0.0.0.0) and receive traffic to any interface on the machine.

This code includes IP_PKTINFO (v4) for Linux, and IP_RECVDSTADDR/IP_SENDSRCADDR (v4) for *BSD, and if not falls back to recvfrom/sendto().  For IPv6, it is assumed that the stock IETF APIs
using pktinfo are available.  The choice of PKTINFO or RECVDSTADDR is determined by the Configure scripts.
These patches include four additional BIO_crtl messages to set/get the origin/dest address from the BIO.
There was previous concern about CMSG_SPACE() being constant or not; but the specifications say that those macros are guaranteed to be compile time constants.

In addition, code to enable IP_PKTINFO and IPV6_PKTINFO on OSX is included. OSX has RECDSTADDR (like other BSDs), but does not have SENDSRCADDR. IP_PKTINFO was added in OSX 10.9, prior versions may need to disable both IP_PKTINFO and IP_RECVDSTADDR.