### PR TITLE
Fix glibc specific conditional for Mac OS/X

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -231,7 +231,8 @@ static uint64_t get_timer_bits(void)
 # if defined(_POSIX_C_SOURCE) \
      && defined(_POSIX_TIMERS) \
      && _POSIX_C_SOURCE >= 199309L \
-     && (!defined(__GLIBC__) || __GLIBC_PREREQ(2, 17))
+     && (!defined(__GLIBC__) \
+         || (defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 17)))
     {
         struct timespec ts;
         clockid_t cid;


### PR DESCRIPTION
MacOS seems to define __GLIBC__ but not __GLIBC_PREREQ.

The issue was reported against [this commit](https://github.com/openssl/openssl/commit/2b66fd5720c38c6e89f9cd00d36d2c828ed4cd4b#commitcomment-27386396).  It follows on from the changes in #5231

