### PR TITLE
Fix the afalg engine test

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -79,7 +79,7 @@ static int afalg_create_sk(afalg_ctx *actx, const char *ciphertype,
 static int afalg_destroy(ENGINE *e);
 static int afalg_init(ENGINE *e);
 static int afalg_finish(ENGINE *e);
-const EVP_CIPHER *afalg_aes_cbc(int nid);
+static const EVP_CIPHER *afalg_aes_cbc(int nid);
 static cbc_handles *get_cipher_handle(int nid);
 static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                          const int **nids, int nid);
@@ -195,7 +195,7 @@ static int afalg_setup_async_event_notification(afalg_aio *aio)
     return 1;
 }
 
-int afalg_init_aio(afalg_aio *aio)
+static int afalg_init_aio(afalg_aio *aio)
 {
     int r = -1;
 
@@ -215,8 +215,8 @@ int afalg_init_aio(afalg_aio *aio)
     return 1;
 }
 
-int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
-                         size_t len)
+static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
+                                size_t len)
 {
     int r;
     int retry = 0;
@@ -658,7 +658,7 @@ static cbc_handles *get_cipher_handle(int nid)
     }
 }
 
-const EVP_CIPHER *afalg_aes_cbc(int nid)
+static const EVP_CIPHER *afalg_aes_cbc(int nid)
 {
     cbc_handles *cipher_handle = get_cipher_handle(nid);
     if (cipher_handle->_hidden == NULL

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -128,14 +128,14 @@ int global_init(void)
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_ENGINE
-    if ((e = ENGINE_by_id("afalg")) == NULL) {
+    if (!TEST_ptr(e = ENGINE_by_id("afalg"))) {
         /* Probably a platform env issue, not a test failure. */
-        TEST_info("Can't load AFALG engine");
-    } else {
-# ifndef OPENSSL_NO_AFALGENG
-        ADD_ALL_TESTS(test_afalg_aes_cbc, 3);
-# endif
+        TEST_info("Can't load AFALG engine, you might want to check $OPENSSL_ENGINES");
+        return 0;
     }
+# ifndef OPENSSL_NO_AFALGENG
+    ADD_ALL_TESTS(test_afalg_aes_cbc, 3);
+# endif
 #endif
 
     return 1;

--- a/test/recipes/30-test_afalg.t
+++ b/test/recipes/30-test_afalg.t
@@ -18,6 +18,6 @@ plan skip_all => "$test_name not supported for this build"
 
 plan tests => 1;
 
-$ENV{OPENSSL_ENGINES} = bldtop_dir("engines/afalg");
+$ENV{OPENSSL_ENGINES} = bldtop_dir("engines");
 
 ok(run(test(["afalgtest"])), "running afalgtest");


### PR DESCRIPTION
Unfortunately, `test/afalgtest.c` is designed to "succeed" ("not fail" is more correct) when it can't load the `afalg` engine, and our test recipe wasn't setting `OPENSSL_ENGINE` correctly, which means that this particular engine hasn't been tested for a while (since #3491).

(This is for master only, the `afalg` engine in 1.1.0 is located where its test recipe expects it to be)

I've also made a few more private `afalg` engine functions static...  purely cosmetic, but avoids exporting them on systems where all exportable symbols are exported in DSOs, or possibly to avoid certain warnings (this was suggested in [a comment in #5119](https://github.com/openssl/openssl/pull/5119#issuecomment-360161186)).