### PR TITLE
Make all private functions in e_afalg.c static [1.1.0]

### DIFF
--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -80,7 +80,7 @@ static int afalg_create_sk(afalg_ctx *actx, const char *ciphertype,
 static int afalg_destroy(ENGINE *e);
 static int afalg_init(ENGINE *e);
 static int afalg_finish(ENGINE *e);
-const EVP_CIPHER *afalg_aes_128_cbc(void);
+static const EVP_CIPHER *afalg_aes_128_cbc(void);
 static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                          const int **nids, int nid);
 static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
@@ -191,7 +191,7 @@ static int afalg_setup_async_event_notification(afalg_aio *aio)
     return 1;
 }
 
-int afalg_init_aio(afalg_aio *aio)
+static int afalg_init_aio(afalg_aio *aio)
 {
     int r = -1;
 
@@ -211,8 +211,8 @@ int afalg_init_aio(afalg_aio *aio)
     return 1;
 }
 
-int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
-                         size_t len)
+static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
+                                size_t len)
 {
     int r;
     int retry = 0;
@@ -639,7 +639,7 @@ static int afalg_cipher_cleanup(EVP_CIPHER_CTX *ctx)
     return 1;
 }
 
-const EVP_CIPHER *afalg_aes_128_cbc(void)
+static const EVP_CIPHER *afalg_aes_128_cbc(void)
 {
     if (_hidden_aes_128_cbc == NULL
         && ((_hidden_aes_128_cbc =

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -102,9 +102,13 @@ int main(int argc, char **argv)
 
     e = ENGINE_by_id("afalg");
     if (e == NULL) {
-        /* A failure to load is probably a platform environment problem */
-        fprintf(stderr, "AFALG Test: Failed to load AFALG Engine\n");
-        return 1;
+        /*
+         * A failure to load is probably a platform environment problem so we
+         * don't treat this as an OpenSSL test failure, i.e. we return 0
+         */
+        fprintf(stderr,
+                "AFALG Test: Failed to load AFALG Engine - skipping test\n");
+        return 0;
     }
 
     if (test_afalg_aes_128_cbc(e) == 0) {

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -102,13 +102,9 @@ int main(int argc, char **argv)
 
     e = ENGINE_by_id("afalg");
     if (e == NULL) {
-        /*
-         * A failure to load is probably a platform environment problem so we
-         * don't treat this as an OpenSSL test failure, i.e. we return 0
-         */
-        fprintf(stderr,
-                "AFALG Test: Failed to load AFALG Engine - skipping test\n");
-        return 0;
+        /* A failure to load is probably a platform environment problem */
+        fprintf(stderr, "AFALG Test: Failed to load AFALG Engine\n");
+        return 1;
     }
 
     if (test_afalg_aes_128_cbc(e) == 0) {


### PR DESCRIPTION
If you know that there's no afalg engine, don't run this test.
test/recipes/30-test_afalg.t checks this correctly.
