### PR TITLE
Revert "Modify test/afalgtest to fail if the afalg engine couldn't be loaded"

### DIFF
--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -128,14 +128,14 @@ int global_init(void)
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_ENGINE
-    if (!TEST_ptr(e = ENGINE_by_id("afalg"))) {
+    if ((e = ENGINE_by_id("afalg")) == NULL) {
         /* Probably a platform env issue, not a test failure. */
-        TEST_info("Can't load AFALG engine, you might want to check $OPENSSL_ENGINES");
-        return 0;
-    }
+        TEST_info("Can't load AFALG engine");
+    } else {
 # ifndef OPENSSL_NO_AFALGENG
-    ADD_ALL_TESTS(test_afalg_aes_cbc, 3);
+        ADD_ALL_TESTS(test_afalg_aes_cbc, 3);
 # endif
+    }
 #endif
 
     return 1;


### PR DESCRIPTION
It turns out that even if you successfully build the engine, it might
not load properly, so we cannot make the test program fail for it.

See the message in commit 25b9d11c002e5c71840c2a6733c5009d78f2c9db

This reverts commit 227a1e3f45bf06fdb00f2bdfb922f6f0d1f1d1de.
