### PR TITLE
With nmake, invoking $(MAKE) needs /$(MAKEFLAGS)

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -59,7 +59,7 @@
  sub dependmagic {
      my $target = shift;
 
-     return "$target: build_generated\n\t\$(MAKE) depend && \$(MAKE) _$target\n_$target";
+     return "$target: build_generated\n\t\$(MAKE) /\$(MAKEFLAGS) depend && \$(MAKE) /\$(MAKEFLAGS) _$target\n_$target";
  }
  '';
 -}


### PR DESCRIPTION
The slash should be there according to Microsoft documentation,
see https://msdn.microsoft.com/en-us/library/7cafx990.aspx

Fixes #5277
