### PR TITLE
util/mkdef.pl: use better array in search of 'DEPRECATEDIN_'

### DIFF
--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -152,7 +152,7 @@ my %disabled_algorithms =
     map { (my $x = uc $_) =~ s|-|_|g; $x => 1; } keys %disabled;
 
 my $apiv = sprintf "%x%02x%02x", split(/\./, $config{api});
-foreach (keys %disabled_algorithms) {
+foreach (@known_algorithms) {
 	if (/^DEPRECATEDIN_(\d+)_(\d+)_(\d+)$/) {
 		my $depv = sprintf "%x%02x%02x", $1, $2, $3;
 		$disabled_algorithms{$_} = 1 if $apiv ge $depv;


### PR DESCRIPTION
%disabled_algorithms isn't necessarily initialised with the "algos"
'DEPRECATEDIN_1_1_0' etc.  However, we know that @known_algorithms has
them all, so use that to find them instead.

Fixes #5157
(where this was reported)
