### PR TITLE
util/mkdef.pl: Fix incomplete cherry-pick [1.1.0]

### DIFF
--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -198,7 +198,7 @@ foreach (@ARGV, split(/ /, $config{options}))
 		}
 	}
 	if (/^no-deprecated$/) {
-		foreach (keys %disabled_algorithms) {
+		foreach (@known_algorithms) {
 			if (/^DEPRECATEDIN_/) {
 				$disabled_algorithms{$_} = 1;
 			}


### PR DESCRIPTION
The cherry pick that resulted in 65de3f1657d8a3bdb7c48063931a3c619817c921
was incomplete.
