### PR TITLE
s390x: implement OPENSSL_rdtsc as STCKF

### DIFF
--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -129,6 +129,14 @@ OPENSSL_s390x_facilities:
 .type	OPENSSL_rdtsc,\@function
 .align	16
 OPENSSL_rdtsc:
+	larl	%r4,OPENSSL_s390xcap_P
+	tm	S390X_STFLE+3(%r4),0x40	# check for store-clock-fast facility
+	jz	.Lstck
+
+	.long	0xb27cf010	# stckf 16($sp)
+	lg	%r2,16($sp)
+	br	$ra
+.Lstck:
 	stck	16($sp)
 	lg	%r2,16($sp)
 	br	$ra


### PR DESCRIPTION
STCK has an artificial delay to ensure uniqueness which can result in a performance penalty if used heavily concurrently.

Artificially delaying a high precision clock is a counter-intuitive thing to do for a timer function like rdtsc. Uniqueness is only required for nonces (which are better implemented using a counter anyway) and its effect on clock based entropy harvesting is not clear.

On the other hand, STCK has been observed to slow down applications which use it concurrently. libcrypto seems to use it in a safe way, but better replace it by STCKF if available.