### PR TITLE
Fix check of cpuid_asm_src config attribute

### DIFF
--- a/Configure
+++ b/Configure
@@ -1290,7 +1290,7 @@ if ($target{sys_id} ne "")
 
 unless ($disabled{asm}) {
     $target{cpuid_asm_src}=$table{DEFAULTS}->{cpuid_asm_src} if ($config{processor} eq "386");
-    push @{$config{defines}}, "OPENSSL_CPUID_OBJ" if ($target{cpuid_asm_src} ne "mem_clr.o");
+    push @{$config{defines}}, "OPENSSL_CPUID_OBJ" if ($target{cpuid_asm_src} ne "mem_clr.c");
 
     $target{bn_asm_src} =~ s/\w+-gf2m.c// if (defined($disabled{ec2m}));
 


### PR DESCRIPTION
The contents of that attribute is C file names, not object file names.
This went undetected because quite a lot of systems have assembler
implementations anyway, so setting OPENSSL_CPUID_OBJ was correct for
them.