### PR TITLE
Revert ".travis.yml: remove osx from build matrix."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
 
 os:
     - linux
+    - osx
 
 compiler:
     - clang


### PR DESCRIPTION
Recent changes seem to have gotten OS X back on track, so we should be
able to run our tests there again.

This reverts commit e12e903e9ac675d08f9dd0db1f0c1a2049232c21.
