### PR TITLE
Configuration: move the handling of zlib_include to config files

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -7,6 +7,7 @@ my %targets=(
 	cppflags	=> "",
 	lflags		=> "",
 	defines		=> [],
+	includes	=> [],
 	thread_scheme	=> "(unknown)", # Assume we don't know
 	thread_defines	=> [],
 
@@ -70,6 +71,13 @@ my %targets=(
                 push @defs, "ZLIB_SHARED" unless $disabled{"zlib-dynamic"};
                 return [ @defs ];
             },
+        includes        =>
+            sub {
+                my @incs = ();
+                push @incs, $withargs{zlib_include}
+                    if !$disabled{zlib} && $withargs{zlib_include};
+                return [ @incs ];
+            },
     },
 
     BASE_unix => {
@@ -128,6 +136,16 @@ my %targets=(
     BASE_VMS => {
         inherit_from    => [ "BASE_common" ],
         template        => 1,
+
+        includes        =>
+            add(sub {
+                    my @incs = ();
+                    # GNV$ZLIB_INCLUDE is the standard logical name for later
+                    # zlib incarnations.
+                    push @incs, 'GNV$ZLIB_INCLUDE:'
+                        if !$disabled{zlib} && !$withargs{zlib_include};
+                    return [ @incs ];
+                }),
 
         build_file       => "descrip.mms",
         build_scheme     => [ "unified", "VMS" ],

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -580,7 +580,7 @@ my %targets = (
         cc               => "gcc",
         cflags           => "-O3",
         cppflags         => "-D_ENDIAN -DBN_DIV2W -D_POSIX_SOURCE -D_SOCKET_SOURCE",
-        includes         => [ "/SYSLOG/PUB" ],
+        includes         => add("/SYSLOG/PUB"),
         sys_id           => "MPE",
         lflags           => add("-L/SYSLOG/PUB"),
         ex_libs          => add("-lsyslog -lsocket -lcurses"),
@@ -1444,10 +1444,11 @@ my %targets = (
                                 "NO_CHMOD", "OPENSSL_SMALL_FOOTPRINT" ],
                    debug   => [ "DEBUG", "_DEBUG" ]),
         includes         =>
-            combine(sub { defined(env('WCECOMPAT'))
-                          ? '$(WCECOMPAT)/include' : (); },
-                    sub { defined(env('PORTSDK_LIBPATH'))
-                          ? '$(PORTSDK_LIBPATH)/../../include' : (); }),
+            add(combine(sub { defined(env('WCECOMPAT'))
+                              ? '$(WCECOMPAT)/include' : (); },
+                        sub { defined(env('PORTSDK_LIBPATH'))
+                                  ? '$(PORTSDK_LIBPATH)/../../include'
+                                  : (); })),
         lflags           => add(combine("/nologo /opt:ref",
                                         sub { vc_wince_info()->{lflags}; },
                                         sub { defined(env('PORTSDK_LIBPATH'))

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -640,13 +640,6 @@ EOF
       $cflags .= '/DEFINE=('.$defines.')';
       $cflags .= "/INCLUDE=('tmp_includes')";
       
-      my @incs = ();
-      push @incs, @{$args{incs}} if @{$args{incs}};
-      unless ($disabled{zlib}) {
-          # GNV$ZLIB_INCLUDE is the standard logical name for later zlib
-          # incarnations.
-          push @incs, ($withargs{zlib_include} || 'GNV$ZLIB_INCLUDE:');
-      }
       # We create a logical name TMP_INCLUDES: to hold the list of internal
       # includes.  However, we cannot use it directly, as logical names can't
       # hold zero entries, so we also create a symbol with the same name and
@@ -666,13 +659,13 @@ EOF
           ."\n\t".$incs_add;
       my $incs_off = 'DELETE/SYMBOL/LOCAL tmp_includes'
           ."\n\t".'DELETE/SYMBOL/LOCAL tmp_add';
-      if (@incs) {
+      if (@{$args{incs}}) {
           $incs_on =
               'DEFINE tmp_includes '
               .join(",-\n\t\t\t", map {
                                       file_name_is_absolute($_)
                                       ? $_ : catdir($backward,$_)
-                                  } @incs)
+                                  } @{$args{incs}})
               ."\n\t".$incs_on
               ."\n\t".'IF tmp_includes .NES. "" THEN tmp_includes = "," + tmp_includes'
               ."\n\t".'tmp_includes = "tmp_includes:" + tmp_includes';

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -891,11 +891,6 @@ EOF
       my $srcs = join(" ",  @srcs);
       my $deps = join(" ", @srcs, @{$args{deps}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
-      unless ($disabled{zlib}) {
-          if ($withargs{zlib_include}) {
-              $incs .= " -I".$withargs{zlib_include};
-          }
-      }
       my $cmd = '$(CC)';
       my $cmdflags = '$(CFLAGS)';
       my $cmdcompile = ' -c';

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -466,11 +466,6 @@ EOF
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
-     unless ($disabled{zlib}) {
-         if ($withargs{zlib_include}) {
-             $incs .= ' /I "'.$withargs{zlib_include}.'"';
-         }
-     }
      my $cflags = '$(CFLAGS)';
      $cflags .= { lib => ' $(LIB_CFLAGS)',
 		  dso => ' $(DSO_CFLAGS)',


### PR DESCRIPTION
It was a bit absurd to have this being specially handled in the build
file templates, especially that we have the 'includes' attribute.
