### PR TITLE
Don't do printf format checks on OS/X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,9 @@ before_script:
           srcdir=.;
           top=.;
       fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+          CONFIG_OPTS="$CONFIG_OPTS -Wno-format";
+      fi
     - if [ "$CC" == i686-w64-mingw32-gcc ]; then
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw $CONFIG_OPTS -Wno-pedantic-ms-format;


### PR DESCRIPTION
OS/X give spurious errors about the type not matching the format for our
own BIO_printf() function. Checking for this gets turned on by "-Wformat"
from "--strict-warnings". We override this in Travis for OS/X with
"-Wno-format".

[extended tests]

WIP until I see whether this approach works.