### PR TITLE
Fixes for no-tls1_2 and no-tls1_2-method

### DIFF
--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -105,20 +105,23 @@ static const uint32_t default_ciphers_in_order[] = {
 # endif
 #endif  /* !OPENSSL_NO_TLS1_2 */
 
-#ifndef OPENSSL_NO_EC
+#if !defined(OPENSSL_NO_TLS1_2) || defined(OPENSSL_NO_TLS1_3)
+    /* These won't be usable if TLSv1.3 is available but TLSv1.2 isn't */
+# ifndef OPENSSL_NO_EC
     TLS1_CK_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
     TLS1_CK_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-#endif
-#ifndef OPENSSL_NO_DH
+# endif
+ #ifndef OPENSSL_NO_DH
     TLS1_CK_DHE_RSA_WITH_AES_256_SHA,
-#endif
-#ifndef OPENSSL_NO_EC
+# endif
+# ifndef OPENSSL_NO_EC
     TLS1_CK_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
     TLS1_CK_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-#endif
-#ifndef OPENSSL_NO_DH
+# endif
+# ifndef OPENSSL_NO_DH
     TLS1_CK_DHE_RSA_WITH_AES_128_SHA,
-#endif
+# endif
+#endif /* !defined(OPENSSL_NO_TLS1_2) || defined(OPENSSL_NO_TLS1_3) */
 
 #ifndef OPENSSL_NO_TLS1_2
     TLS1_CK_RSA_WITH_AES_256_GCM_SHA384,
@@ -135,8 +138,11 @@ static const uint32_t default_ciphers_in_order[] = {
     TLS1_CK_RSA_WITH_AES_256_SHA256,
     TLS1_CK_RSA_WITH_AES_128_SHA256,
 #endif
+#if !defined(OPENSSL_NO_TLS1_2) || defined(OPENSSL_NO_TLS1_3)
+    /* These won't be usable if TLSv1.3 is available but TLSv1.2 isn't */
     TLS1_CK_RSA_WITH_AES_256_SHA,
     TLS1_CK_RSA_WITH_AES_128_SHA,
+#endif
 };
 
 static int test_default_cipherlist(SSL_CTX *ctx)

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -81,9 +81,14 @@ static int test_client_hello(int currtest)
 
     switch(currtest) {
     case TEST_SET_SESSION_TICK_DATA_VER_NEG:
+#if !defined(OPENSSL_NO_TLS1_3) && defined(OPENSSL_NO_TLS1_2)
+        /* TLSv1.3 is enabled and TLSv1.2 is disabled so can't do this test */
+        return 1;
+#else
         /* Testing for session tickets <= TLS1.2; not relevant for 1.3 */
         if (!TEST_true(SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION)))
             goto end;
+#endif
         break;
 
     case TEST_ADD_PADDING_AND_PSK:

--- a/test/recipes/70-test_sslcertstatus.t
+++ b/test/recipes/70-test_sslcertstatus.t
@@ -27,7 +27,8 @@ plan skip_all => "$test_name needs the ocsp feature enabled"
     if disabled("ocsp");
 
 plan skip_all => "$test_name needs TLS enabled"
-    if alldisabled(available_protocols("tls"));
+    if alldisabled(available_protocols("tls"))
+       || (!disabled("tls1_3") && disabled("tls1_2"));
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -26,7 +26,8 @@ plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
 
 plan skip_all => "$test_name needs TLS enabled"
-    if alldisabled(available_protocols("tls"));
+    if alldisabled(available_protocols("tls"))
+       || (!disabled("tls1_3") && disabled("tls1_2"));
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -216,13 +216,16 @@ SKIP: {
        "DSA/SHA2 sigalg sent for 1.3-only ClientHello");
 
     #Test 18: signature_algorithms with backwards compatible ClientHello
-    $testtype = COMPAT_SIGALGS;
-    $dsa_status = $sha1_status = $sha224_status = 0;
-    $proxy->clear();
-    $proxy->filter(\&modify_sigalgs_filter);
-    $proxy->start();
-    ok($dsa_status && $sha1_status && $sha224_status,
-       "DSA sigalg not sent for compat ClientHello");
+    SKIP: {
+        skip "TLSv1.2 disabled", 1 if disabled("tls1_2");
+        $testtype = COMPAT_SIGALGS;
+        $dsa_status = $sha1_status = $sha224_status = 0;
+        $proxy->clear();
+        $proxy->filter(\&modify_sigalgs_filter);
+        $proxy->start();
+        ok($dsa_status && $sha1_status && $sha224_status,
+           "DSA sigalg not sent for compat ClientHello");
+   }
 }
 
 SKIP: {

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -40,6 +40,7 @@ my $is_default_dtls = (!disabled("dtls1") && !disabled("dtls1_2"));
 
 my @all_pre_tls1_3 = ("ssl3", "tls1", "tls1_1", "tls1_2");
 my $no_tls = alldisabled(available_protocols("tls"));
+my $no_tls_below1_3 = $no_tls || (disabled("tls1_2") && !disabled("tls1_3"));
 my $no_pre_tls1_3 = alldisabled(@all_pre_tls1_3);
 my $no_dtls = alldisabled(available_protocols("dtls"));
 my $no_npn = disabled("nextprotoneg");
@@ -73,6 +74,7 @@ my %conf_dependent_tests = (
 # configurations. Default is $no_tls but some tests have different skip
 # conditions.
 my %skip = (
+  "06-sni-ticket.conf" => $no_tls_below1_3,
   "07-dtls-protocol-version.conf" => $no_dtls,
   "08-npn.conf" => (disabled("tls1") && disabled("tls1_1")
                     && disabled("tls1_2")) || $no_npn,
@@ -87,6 +89,7 @@ my %skip = (
   "14-curves.conf" => disabled("tls1_2") || $no_ec || $no_ec2m,
   "15-certstatus.conf" => $no_tls || $no_ocsp,
   "16-dtls-certstatus.conf" => $no_dtls || $no_ocsp,
+  "17-renegotiate.conf" => $no_tls_below1_3,
   "18-dtls-renegotiate.conf" => $no_dtls,
   "19-mac-then-encrypt.conf" => $no_pre_tls1_3,
   "20-cert-select.conf" => disabled("tls1_2") || $no_ec,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -254,6 +254,7 @@ static int test_keylog_output(char *buffer, const SSL *ssl,
     return 1;
 }
 
+#if !defined(OPENSSL_NO_TLS1_2) || defined(OPENSSL_NO_TLS1_3)
 static int test_keylog(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -330,6 +331,7 @@ end:
 
     return testresult;
 }
+#endif
 
 #ifndef OPENSSL_NO_TLS1_3
 static int test_keylog_no_master_key(void)
@@ -1273,6 +1275,7 @@ static int test_ssl_bio_change_wbio(void)
     return execute_test_ssl_bio(0, CHANGE_WBIO);
 }
 
+#if !defined(OPENSSL_NO_TLS1_2) || defined(OPENSSL_NO_TLS1_3)
 typedef struct {
     /* The list of sig algs */
     const int *list;
@@ -1287,25 +1290,25 @@ typedef struct {
 } sigalgs_list;
 
 static const int validlist1[] = {NID_sha256, EVP_PKEY_RSA};
-#ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC
 static const int validlist2[] = {NID_sha256, EVP_PKEY_RSA, NID_sha512, EVP_PKEY_EC};
 static const int validlist3[] = {NID_sha512, EVP_PKEY_EC};
-#endif
+# endif
 static const int invalidlist1[] = {NID_undef, EVP_PKEY_RSA};
 static const int invalidlist2[] = {NID_sha256, NID_undef};
 static const int invalidlist3[] = {NID_sha256, EVP_PKEY_RSA, NID_sha256};
 static const int invalidlist4[] = {NID_sha256};
 static const sigalgs_list testsigalgs[] = {
     {validlist1, OSSL_NELEM(validlist1), NULL, 1, 1},
-#ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC
     {validlist2, OSSL_NELEM(validlist2), NULL, 1, 1},
     {validlist3, OSSL_NELEM(validlist3), NULL, 1, 0},
-#endif
+# endif
     {NULL, 0, "RSA+SHA256", 1, 1},
-#ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC
     {NULL, 0, "RSA+SHA256:ECDSA+SHA512", 1, 1},
     {NULL, 0, "ECDSA+SHA512", 1, 0},
-#endif
+# endif
     {invalidlist1, OSSL_NELEM(invalidlist1), NULL, 0, 0},
     {invalidlist2, OSSL_NELEM(invalidlist2), NULL, 0, 0},
     {invalidlist3, OSSL_NELEM(invalidlist3), NULL, 0, 0},
@@ -1401,6 +1404,7 @@ static int test_set_sigalgs(int idx)
 
     return testresult;
 }
+#endif
 
 #ifndef OPENSSL_NO_TLS1_3
 
@@ -2778,6 +2782,12 @@ static int test_custom_exts(int tst)
     SSL_SESSION *sess = NULL;
     unsigned int context;
 
+#if defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_TLS1_3)
+    /* Skip tests for TLSv1.2 and below in this case */
+    if (tst < 3)
+        return 1;
+#endif
+
     /* Reset callback counters */
     clntaddoldcb = clntparseoldcb = srvaddoldcb = srvparseoldcb = 0;
     clntaddnewcb = clntparsenewcb = srvaddnewcb = srvparsenewcb = 0;
@@ -3389,8 +3399,10 @@ int setup_tests(void)
     ADD_TEST(test_ssl_bio_pop_ssl_bio);
     ADD_TEST(test_ssl_bio_change_rbio);
     ADD_TEST(test_ssl_bio_change_wbio);
+#if !defined(OPENSSL_NO_TLS1_2) || defined(OPENSSL_NO_TLS1_3)
     ADD_ALL_TESTS(test_set_sigalgs, OSSL_NELEM(testsigalgs) * 2);
     ADD_TEST(test_keylog);
+#endif
 #ifndef OPENSSL_NO_TLS1_3
     ADD_TEST(test_keylog_no_master_key);
 #endif


### PR DESCRIPTION
The no-tls1_2 option does not work properly in conjunction with TLSv1.3
being enabled (which is now the default). This commit fixes the issues.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
