### PR TITLE
Turn off printf format checking for BIO_printf et al on Mac OS/X

### DIFF
--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -735,7 +735,8 @@ void BIO_copy_next_retry(BIO *b);
  */
 
 # define __bio_h__attr__(x)
-# if defined(__GNUC__) && defined(__STDC_VERSION__)
+# if defined(__GNUC__) && defined(__STDC_VERSION__) \
+    && !defined(__APPLE__)
     /*
      * Because we support the 'z' modifier, which made its appearance in C99,
      * we can't use __attribute__ with pre C99 dialects.


### PR DESCRIPTION
Mac OS/X has a type for %j that doesn't agree with how we define it,
which gives incorrect warnings.  The easiest way out of that situation
is simply to turn off that check on Mac OS/X.
