### PR TITLE
Don't do format checks on OS/X (header file fix)

### DIFF
--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -738,9 +738,10 @@ void BIO_copy_next_retry(BIO *b);
 # if defined(__GNUC__) && defined(__STDC_VERSION__)
     /*
      * Because we support the 'z' modifier, which made its appearance in C99,
-     * we can't use __attribute__ with pre C99 dialects.
+     * we can't use __attribute__ with pre C99 dialects. Also OS/X gives
+     * spurious warnings for some formats so we disable this there too.
      */
-#  if __STDC_VERSION__ >= 199901L
+#  if __STDC_VERSION__ >= 199901L && !defined(__APPLE__)
 #   undef __bio_h__attr__
 #   define __bio_h__attr__ __attribute__
 #  endif


### PR DESCRIPTION
Format checks for BIO_printf et al give spurious warnings on OS/X so we
disable that there.

This is an alternative solution to #5300.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
