### PR TITLE
Support longer cookies per TLS 1.3 draft-14

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -547,7 +547,7 @@ typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 # define SSL_CONF_TYPE_NONE              0x4
 
 /* Length of a TLSv1.3 cookie */
-# define SSL_COOKIE_LENGTH                       255
+# define SSL_COOKIE_LENGTH                       65535
 
 /*
  * Note: SSL[_CTX]_set_{options,mode} use |= op on the previous value, they


### PR DESCRIPTION
[Cookies can now be up to 2^16-1 bytes](https://tools.ietf.org/html/draft-ietf-tls-tls13-23#section-4.2.2).

It's unclear to me if `DTLS1_COOKIE_LENGTH` should also be updated, or whether there are other less obvious places that need changing as well for this to work in practice.