### PR TITLE
Remove code that prints "<SPACE/NULS>" in hexdumps

### DIFF
--- a/crypto/bio/b_dump.c
+++ b/crypto/bio/b_dump.c
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include "bio_lcl.h"
 
-#define TRUNCATE
 #define DUMP_WIDTH      16
 #define DUMP_WIDTH_LESS_INDENT(i) (DUMP_WIDTH - ((i - (i > 6 ? 6 : i) + 3) / 4))
 
@@ -31,16 +30,9 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
 {
     int ret = 0;
     char buf[288 + 1];
-    int i, j, rows, trc, n;
+    int i, j, rows, n;
     unsigned char ch;
     int dump_width;
-
-    trc = 0;
-
-#ifdef TRUNCATE
-    for (; (len > 0) && ((s[len - 1] == ' ') || (s[len - 1] == '\0')); len--)
-        trc++;
-#endif
 
     if (indent < 0)
         indent = 0;
@@ -95,13 +87,6 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
          */
         ret += cb((void *)buf, n, u);
     }
-#ifdef TRUNCATE
-    if (trc > 0) {
-        n = BIO_snprintf(buf, sizeof(buf), "%*s%04x - <SPACES/NULS>\n",
-                         indent, "", len + trc);
-        ret += cb((void *)buf, n, u);
-    }
-#endif
     return ret;
 }
 


### PR DESCRIPTION
when the data block ends with SPACEs or NULs.

The problem is, you can't see if the data ends
with SPACE or NUL or a combination of both.

This can happen for instance with
openssl rsautl -decrypt -hexdump
