### PR TITLE
apps/openssl.c: initialise dc variable to satisfy old compilers.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -520,7 +520,7 @@ static void list_type(FUNC_TYPE ft, int one)
 {
     FUNCTION *fp;
     int i = 0;
-    DISPLAY_COLUMNS dc;
+    DISPLAY_COLUMNS dc = {0};
 
     if (!one)
         calculate_columns(&dc);


### PR DESCRIPTION
When compiling with -Wall on a machine with an old compiler it gives a false
positive that the dc variable which is a structure of type DISPLAY_COLUMNS
could be used uninitialised. In fact the dc variable's members will always get
set in the case it is used, otherwise it is left uninitialised.
This fix just causes the dc variable's members to always get initialised to 0
at declaration, so the false positive will not get flagged.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
