### PR TITLE
Make sure we check the return value of extract_min_max()

### DIFF
--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -667,7 +667,9 @@ static int asid_contains(ASIdOrRanges *parent, ASIdOrRanges *child)
         for (;; p++) {
             if (p >= sk_ASIdOrRange_num(parent))
                 return 0;
-            extract_min_max(sk_ASIdOrRange_value(parent, p), &p_min, &p_max);
+            if (!extract_min_max(sk_ASIdOrRange_value(parent, p), &p_min,
+                                 &p_max))
+                return 0;
             if (ASN1_INTEGER_cmp(p_max, c_max) < 0)
                 continue;
             if (ASN1_INTEGER_cmp(p_min, c_min) > 0)


### PR DESCRIPTION
Commit 42d7d7dd6 turned this function from returning void to
returning an int error code. This instance of calling it was
missed.

Found by Coverity.
