### PR TITLE
VMS: for testutil, make sure to use BIO_f_linebuffer

### DIFF
--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -120,9 +120,10 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
 
     do {
         const char *p;
+        char c;
 
-        for (p = in; p < in + inl && *p != '\n'; p++) ;
-        if (*p == '\n') {
+        for (p = in, c = '\0'; p < in + inl && (c = *p) != '\n'; p++) ;
+        if (c == '\n') {
             p++;
             foundnl = 1;
         } else

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -21,6 +21,10 @@ void test_open_streams(void)
 {
     bio_out = BIO_new_fp(stdout, BIO_NOCLOSE | BIO_FP_TEXT);
     bio_err = BIO_new_fp(stderr, BIO_NOCLOSE | BIO_FP_TEXT);
+#ifdef __VMS
+    bio_out = BIO_push(BIO_new(BIO_f_linebuffer()), bio_out);
+    bio_err = BIO_push(BIO_new(BIO_f_linebuffer()), bio_err);
+#endif
     bio_err = BIO_push(BIO_new(BIO_f_tap()), bio_err);
 
     OPENSSL_assert(bio_out != NULL);
@@ -29,7 +33,7 @@ void test_open_streams(void)
 
 void test_close_streams(void)
 {
-    BIO_free(bio_out);
+    BIO_free_all(bio_out);
     BIO_free_all(bio_err);
 }
 


### PR DESCRIPTION
Without that, output comes one character per line.  It's the same
issue as has been observed before, this happens when using write()
on a record oriented stream (possibly unbuffered too).

This also uncovered a bug in BIO_f_linebuffer, where this would cause
an error:

    BIO_write(bio, "1\n", 1);

I.e. there's a \n just after the part of the string that we currently
ask to get written.
