### PR TITLE
Fix bug in BIO_f_linebuffer()

### DIFF
--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -116,9 +116,10 @@ static int linebuffer_write(BIO *b, const char *in, int inl)
 
     do {
         const char *p;
+        char c;
 
-        for (p = in; p < in + inl && *p != '\n'; p++) ;
-        if (*p == '\n') {
+        for (p = in, c = '\0'; p < in + inl && (c = *p) != '\n'; p++) ;
+        if (c == '\n') {
             p++;
             foundnl = 1;
         } else


### PR DESCRIPTION
In BIO_f_linebuffer, this would cause an error:

    BIO_write(bio, "1\n", 1);

I.e. there's a \n just after the part of the string that we currently
ask to get written.
