### PR TITLE
VMS: correct and update bn_ops in the vms config targets

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1873,7 +1873,7 @@ my %targets = (
         #as               => "???",
         #debug_aflags     => "/NOOPTIMIZE/DEBUG",
         #release_aflags   => "/OPTIMIZE/NODEBUG",
-        bn_opts          => "SIXTY_FOUR_BIT RC4_INT",
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-alpha-p32" => {
         inherit_from     => [ "vms-generic" ],
@@ -1891,6 +1891,7 @@ my %targets = (
                             }),
         ex_libs          => add(sub { return vms_info(32)->{zlib} || (); }),
         pointer_size     => sub { return vms_info(32)->{pointer_size} },
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-alpha-p64" => {
         inherit_from     => [ "vms-generic" ],
@@ -1908,6 +1909,7 @@ my %targets = (
                             }),
         ex_libs          => add(sub { return vms_info(64)->{zlib} || (); }),
         pointer_size     => sub { return vms_info(64)->{pointer_size} },
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-ia64" => {
         inherit_from     => [ "vms-generic" ],
@@ -1925,7 +1927,7 @@ my %targets = (
         #as               => "I4S",
         #debug_aflags     => "/NOOPTIMIZE/DEBUG",
         #release_aflags   => "/OPTIMIZE/NODEBUG",
-        bn_opts          => "SIXTY_FOUR_BIT RC4_INT",
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-ia64-p32" => {
         inherit_from     => [ "vms-generic" ],
@@ -1943,6 +1945,7 @@ my %targets = (
                             }),
         ex_libs          => add(sub { return vms_info(32)->{zlib} || (); }),
         pointer_size     => sub { return vms_info(32)->{pointer_size} },
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
     },
     "vms-ia64-p64" => {
         inherit_from     => [ "vms-generic" ],
@@ -1960,6 +1963,7 @@ my %targets = (
                             }),
         ex_libs          => add(sub { return vms_info(64)->{zlib} || (); }),
         pointer_size     => sub { return vms_info(64)->{pointer_size} },
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
     },
 
 );


### PR DESCRIPTION
Incorrectly spelt where given, but mostly not given at all.
Fortunately not critical as long as no assembler is involved, but
probably results in quite inefficient bignum calculations.
