### PR TITLE
Build files: parametrize cpp

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1308,6 +1308,7 @@ my %targets = (
         inherit_from     => [ "BASE_Windows" ],
         template         => 1,
         cc               => "cl",
+        cpp              => '$(CC) /EP /C',
         cflags           => "-W3 -wd4090 -Gs0 -GF -Gy -nologo",
         defines          => add("OPENSSL_SYS_WIN32", "WIN32_LEAN_AND_MEAN",
                                 "L_ENDIAN", "_CRT_SECURE_NO_DEPRECATE",
@@ -1848,6 +1849,7 @@ my %targets = (
         inherit_from     => [ "BASE_VMS" ],
         template         => 1,
         cc               => "CC/DECC",
+        cpp              => '$(CC)/PREPROCESS_ONLY=SYS$OUTPUT:',
         cflags           =>
             combine(picker(default => "/STANDARD=(ISOC94,RELAXED)/NOLIST/PREFIX=ALL",
                            debug   => "/NOOPTIMIZE/DEBUG",

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -172,6 +172,7 @@ OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
 CC= {- $config{cc} -}
+CPP= {- $config{cpp} -}
 DEFINES={- our $defines = join(",",
                                '__dummy', # To make comma processing easier
                                @{$config{defines}}) -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -857,7 +857,7 @@ EOF
 $target: $args{generator}->[0] $deps
 	( trap "rm -f \$@.*" INT 0; \\
 	  $generator \$@.S; \\
-	  \$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) -E \$@.S | \\
+	  \$(CPP) $incs $cppflags \$@.S | \\
 	  \$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@.i && \\
 	  mv -f \$@.i \$@ )
 EOF
@@ -870,7 +870,7 @@ EOF
           }
           return <<"EOF";
 $args{src}: $args{generator}->[0] $deps
-	\$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) -E $args{generator}->[0] | \\
+	\$(CPP) $incs $cppflags $args{generator}->[0] | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
 EOF
       }

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -160,6 +160,7 @@ ENGINESDIR=$(ENGINESDIR_dev)$(ENGINESDIR_dir)
 !ENDIF
 
 CC={- $config{cc} -}
+CPP={- $config{cpp} -}
 CPPFLAGS={- our $cppflags = join(" ",
                                  (map { "-D".$_} @{$config{defines}}),
                                  (map { " /I ".$_} @{$config{includes}}),
@@ -441,7 +442,7 @@ EOF
 $target: "$args{generator}->[0]" $deps
 	set ASM=\$(AS)
 	$generator \$@.S
-	\$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) /EP /C \$@.S > \$@.i && move /Y \$@.i \$@
+	\$(CPP) $cppflags \$@.S > \$@.i && move /Y \$@.i \$@
         del /Q \$@.S
 EOF
               }
@@ -454,7 +455,7 @@ EOF
           }
           return <<"EOF";
 $target: "$args{generator}->[0]" $deps
-	\$(CC) $incs \$(CFLAGS) \$(CPPFLAGS) /EP /C "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
+	\$(CPP) $incs $cppflags "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
 EOF
       }
   }


### PR DESCRIPTION
Instead of having the knowledge of the exact flags to run the C
preprocessor only and have it output on standard output in the deeper
recesses of the build file template, make it a config parameter, or
rely on build CPP in value ('$(CC) -E' on Unix).
