### PR TITLE
VMS: build Itanium assembler files

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -152,10 +152,6 @@ sub vms_info {
             if ($? == 0) {
                 $vms_info->{as} = "ias";
                 $vms_info->{asflags} = '-d debug "-N" vms_upcase';
-                $vms_info->{asflags} .= ' "-Milp32"'
-                    if $config{target} =~ /-p32$/;
-                $vms_info->{asflags} .= ' "-Mp64"'
-                    if $config{target} =~ /-p64$/;
                 $vms_info->{asoutflag} = "-o";
                 $vms_info->{perlasm_scheme} = "ias";
             }

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1929,9 +1929,13 @@ my %targets = (
         pointer_size     => "64",
     },
     "vms-ia64" => {
-        inherit_from     => [ "vms-generic" ],
+        inherit_from     => [ "vms-generic",
+                              sub { vms_info()->{as}
+                                        ? asm("ia64_asm")->() : () } ],
         bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
         pointer_size     => "",
+
+        modes_asm_src    => "", # Because ghash-ia64.s doesn't work on VMS
     },
     "vms-ia64-p32" => {
         inherit_from     => [ "vms-ia64" ],

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -146,6 +146,20 @@ sub vms_info {
                 $vms_info->{def_zlib} =~ s|/.*$||g;
             }
         }
+
+        if ($config{target} =~ /-ia64/) {
+            `PIPE ias -H 2> NL:`;
+            if ($? == 0) {
+                $vms_info->{as} = "ias";
+                $vms_info->{asflags} = '-d debug "-N" vms_upcase';
+                $vms_info->{asflags} .= ' "-Milp32"'
+                    if $config{target} =~ /-p32$/;
+                $vms_info->{asflags} .= ' "-Mp64"'
+                    if $config{target} =~ /-p64$/;
+                $vms_info->{asoutflag} = "-o";
+                $vms_info->{perlasm_scheme} = "ias";
+            }
+        }
     }
     return $vms_info;
 }
@@ -1875,6 +1889,11 @@ my %targets = (
         shared_target    => "vms-shared",
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",
+
+        as               => sub { vms_info()->{as} },
+        asflags          => sub { vms_info()->{asflags} },
+        asoutflag        => sub { vms_info()->{asoutflag} },
+        perlasm_scheme   => sub { vms_info()->{perlasm_scheme} },
 
         apps_aux_src     => "vms_term_sock.c",
         apps_init_src    => "vms_decc_init.c",

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -177,25 +177,38 @@ DEFINES={- our $defines = join(",",
                                '__dummy', # To make comma processing easier
                                @{$config{defines}}) -}
 INCLUDES={- our $includes = join(',', @{$config{includes}}) -}
-CPPFLAGS={- our $cppflags = join('', @{$config{cppflags}}) -}
-CPPFLAGS_Q={- (my $x = $cppflags) =~ s|"|""|g; $defines =~ s|"|""|g;
-              $x .= "/DEFINE=($defines)";
+CPPFLAGS='qual_includes'{- our $cppflags = join('', @{$config{cppflags}}) -}
+CPPFLAGS_Q={- (my $x = $cppflags) =~ s|"|""|g;
+              (my $d = $defines) =~ s|"|""|g;
               $x .= "/INCLUDE=($includes)" if $includes;
+              $x .= "/DEFINE=($d)";
               $x; -}
 CFLAGS={- join('', @{$config{cflags}}) -}
 LDFLAGS= {- join('', @{$config{lflags}}) -}
 EX_LIBS= {- join('', map { ','.$_ } @{$config{ex_libs}}) -}
-LIB_DEFINES={- join("",
-                    (map { ",$_" }
-                     @{$target{shared_defines}},
-                     'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
-                     'ENGINESDIR="""$(ENGINESDIR_C)"""')) -}
-LIB_CFLAGS={- $target{lib_cflags} // "" -}
-DSO_CFLAGS={- $target{dso_cflags} // "" -}
-BIN_CFLAGS={- $target{bin_cflags} // "" -}
-NO_INST_LIB_CFLAGS={- $target{no_inst_lib_cflags} // '$(LIB_CFLAGS)' -}
-NO_INST_DSO_CFLAGS={- $target{no_inst_dso_cflags} // '$(DSO_CFLAGS)' -}
-NO_INST_BIN_CFLAGS={- $target{no_inst_bin_cflags} // '$(BIN_CFLAGS)' -}
+
+LIB_DEFINES=$(DEFINES){- join("",
+                              (map { ",$_" }
+                               @{$target{shared_defines}},
+                               'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
+                               'ENGINESDIR="""$(ENGINESDIR_C)"""')) -}
+LIB_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(LIB_DEFINES))
+LIB_CFLAGS=$(CFLAGS){- $target{lib_cflags} // "" -}
+DSO_DEFINES=$(DEFINES)
+DSO_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(DSO_DEFINES))
+DSO_CFLAGS=$(CFLAGS){- $target{dso_cflags} // "" -}
+BIN_DEFINES=$(DEFINES)
+BIN_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(BIN_DEFINES))
+BIN_CFLAGS=$(CFLAGS){- $target{bin_cflags} // "" -}
+NO_INST_LIB_CFLAGS=$(CFLAGS){- $target{no_inst_lib_cflags}
+                               // $target{lib_cflags}
+                               // "" -}
+NO_INST_DSO_CFLAGS=$(CFLAGS){- $target{no_inst_dso_cflags}
+                               // $target{dso_cflags}
+                               // "" -}
+NO_INST_BIN_CFLAGS=$(CFLAGS){- $target{no_inst_bin_cflags}
+                               // $target{bin_cflags}
+                               // "" -}
 
 PERL={- $config{perl} -}
 
@@ -622,24 +635,17 @@ EOF
                map { abs2rel(rel2abs($_), rel2abs($forward)) } @{$args{srcs}});
       my $cflags = '$(CFLAGS)';
       if ($args{installed}) {
-          $cflags .= { lib => '$(LIB_CFLAGS)',
-                       dso => '$(DSO_CFLAGS)',
-                       bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
+          $cflags = { lib => '$(LIB_CFLAGS)',
+                      dso => '$(DSO_CFLAGS)',
+                      bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
       } else {
-          $cflags .= { lib => '$(NO_INST_LIB_CFLAGS)',
-                       dso => '$(NO_INST_DSO_CFLAGS)',
-                       bin => '$(NO_INST_BIN_CFLAGS)' } -> {$args{intent}};
+          $cflags = { lib => '$(NO_INST_LIB_CFLAGS)',
+                      dso => '$(NO_INST_DSO_CFLAGS)',
+                      bin => '$(NO_INST_BIN_CFLAGS)' } -> {$args{intent}};
       }
-      $cflags .= '$(CPPFLAGS)';
       $cflags .= { lib => '$(LIB_CPPFLAGS)',
 		   dso => '$(DSO_CPPFLAGS)',
 		   bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
-      my $defines = '$(DEFINES)';
-      $defines .= { lib => '$(LIB_DEFINES)',
-		    dso => '$(DSO_DEFINES)',
-		    bin => '$(BIN_DEFINES)' } -> {$args{intent}};
-      $cflags .= '/DEFINE=('.$defines.')';
-      $cflags .= "/INCLUDE=('tmp_includes')";
       
       # We create a logical name TMP_INCLUDES: to hold the list of internal
       # includes.  However, we cannot use it directly, as logical names can't
@@ -682,9 +688,9 @@ EOF
 $obj.OBJ : $deps
         ${before}
         SET DEFAULT $forward
-        $incs_on
+        \@ $incs_on
         \$(CC) ${cflags}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
-        $incs_off
+        \@ $incs_off
         SET DEFAULT $backward
         ${after}
         - PURGE $obj.OBJ

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -187,17 +187,16 @@ CFLAGS={- join('', @{$config{cflags}}) -}
 LDFLAGS= {- join('', @{$config{lflags}}) -}
 EX_LIBS= {- join('', map { ','.$_ } @{$config{ex_libs}}) -}
 
-LIB_DEFINES=$(DEFINES){- join("",
-                              (map { ",$_" }
-                               @{$target{shared_defines}},
-                               'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
-                               'ENGINESDIR="""$(ENGINESDIR_C)"""')) -}
+LIB_DEFINES=$(DEFINES){- join("", (map { ",$_" }
+                                   @{$target{shared_defines}},
+                                   'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
+                                   'ENGINESDIR="""$(ENGINESDIR_C)"""')) -}
 LIB_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(LIB_DEFINES))
 LIB_CFLAGS=$(CFLAGS){- $target{lib_cflags} // "" -}
-DSO_DEFINES=$(DEFINES)
+DSO_DEFINES=$(DEFINES){- join("", (map { ",$_" } @{$target{dso_defines}})) -}
 DSO_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(DSO_DEFINES))
 DSO_CFLAGS=$(CFLAGS){- $target{dso_cflags} // "" -}
-BIN_DEFINES=$(DEFINES)
+BIN_DEFINES=$(DEFINES){- join("", (map { ",$_" } @{$target{bin_defines}})) -}
 BIN_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(BIN_DEFINES))
 BIN_CFLAGS=$(CFLAGS){- $target{bin_cflags} // "" -}
 NO_INST_LIB_CFLAGS=$(CFLAGS){- $target{no_inst_lib_cflags}

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -54,7 +54,7 @@
   our @install_shlibs =
       map { $unified_info{sharednames}->{$_} || () }
       grep(!/\.a$/, @{$unified_info{install}->{libraries}});
-  our @generated = ( ( map { (my $x = $_) =~ s|\.S$|\.s|; $x }
+  our @generated = ( ( map { (my $x = $_) =~ s|\.[sS]$|\.asm|; $x }
                        grep { defined $unified_info{generate}->{$_} }
                        map { @{$unified_info{sources}->{$_}} }
                        grep { /\.o$/ } keys %{$unified_info{sources}} ),
@@ -212,13 +212,10 @@ NO_INST_BIN_CFLAGS=$(CFLAGS){- $target{no_inst_bin_cflags}
 
 PERL={- $config{perl} -}
 
-# We let the C compiler driver to take care of .s files. This is done in
-# order to be excused from maintaining a separate set of architecture
-# dependent assembler flags. E.g. if you throw -mcpu=ultrasparc at SPARC
-# gcc, then the driver will automatically translate it to -xarch=v8plus
-# and pass it down to assembler.
 AS={- $config{as} -}
-ASFLAGS={- join('', @{$config{asflags}}) -}
+ASFLAGS={- join(' ', @{$config{asflags}}) -}
+ASOUTFLAG={- $target{asoutflag} -}$(OSSL_EMPTY)
+PERLASM_SCHEME= {- $target{perlasm_scheme} -}
 
 # .FIRST and .LAST are special targets with MMS and MMK.
 # The defines in there are for C.  includes that look like
@@ -588,37 +585,128 @@ reconfigure reconf :
                    : $unified_info{sharednames}->{$_}.".EXE" } @_;
   }
 
+  # Helper function to deal with inclusion directory specs.
+  # We have to deal with two things:
+  # 1. comma separation and no possibility of trailing comma
+  # 2. no inclusion directories given at all
+  # 3. long compiler command lines
+  # To resolve 1, we need to iterate through the sources of inclusion
+  # directories, and only add a comma when needed.
+  # To resolve 2, we need to have a variable that will hold the whole
+  # inclusion qualifier, or be the empty string if there are no inclusion
+  # directories.  That's the symbol 'qual_includes' that's used in CPPFLAGS
+  # To resolve 3, we creata a logical name TMP_INCLUDES: to hold the list
+  # of inclusion directories.
+  #
+  # This function returns a list of two lists, one being the collection of
+  # commands to execute before the compiler is called, and the other being
+  # the collection of commands to execute after.  It takes as arguments the
+  # collection of strings to include as directory specs.
+  sub includes {
+      my @stuff = ( @_ );
+      my @before = (
+          'qual_includes :=',
+      );
+      my @after = (
+          'DELETE/SYMBOL/LOCAL qual_includes',
+      );
+
+      if (scalar @stuff > 0) {
+          push @before, 'tmp_includes := '.shift(@stuff);
+          while (@stuff) {
+              push @before, 'tmp_add := '.shift(@stuff);
+              push @before, 'IF tmp_includes .NES. "" .AND. tmp_add .NES. "" THEN tmp_includes = tmp_includes + ","';
+              push @before, 'tmp_includes = tmp_includes + tmp_add';
+          }
+          push @before, "IF tmp_includes .NES. \"\" THEN DEFINE tmp_includes 'tmp_includes'";
+          push @before, 'IF tmp_includes .NES. "" THEN qual_includes := /INCLUDE=(tmp_includes:)';
+          push @before, 'DELETE/SYMBOL/LOCAL tmp_includes';
+          push @before, 'DELETE/SYMBOL/LOCAL tmp_add';
+          push @after, 'DEASSIGN tmp_includes:'
+      }
+      return ([ @before ], [ @after ]);
+  }
+
   sub generatesrc {
       my %args = @_;
+      (my $target = $args{src}) =~ s/\.[sS]$/.asm/;
       my $generator = join(" ", @{$args{generator}});
       my $generator_incs = join("", map { ' "-I'.$_.'"' } @{$args{generator_incs}});
       my $deps = join(", -\n\t\t", @{$args{generator_deps}}, @{$args{deps}});
 
-      if ($args{src} !~ /\.[sS]$/) {
+      if ($target !~ /\.asm$/) {
           if ($args{generator}->[0] =~ m|^.*\.in$|) {
 	      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                    "util", "dofile.pl")),
                                    rel2abs($config{builddir}));
               return <<"EOF";
-$args{src} : $args{generator}->[0] $deps
+$target : $args{generator}->[0] $deps
 	\$(PERL) "-I\$(BLDDIR)" "-Mconfigdata" $dofile \\
-	    "-o$target{build_file}" $generator > \$@
+	    "-o$target{build_file}" $generator > \$\@
 EOF
 	  } else {
               return <<"EOF";
-$args{src} : $args{generator}->[0] $deps
-	\$(PERL)$generator_incs $generator > \$@
+$target : $args{generator}->[0] $deps
+	\$(PERL)$generator_incs $generator > \$\@
 EOF
 	  }
       } else {
-          die "No method to generate assembler source present.\n";
+          if ($args{generator}->[0] =~ /\.pl$/) {
+              $generator = '$(PERL)'.$generator_incs.' '.$generator;
+          } elsif ($args{generator}->[0] =~ /\.S$/) {
+              $generator = undef;
+          } else {
+              die "Generator type for $src unknown: $generator\n";
+          }
+
+          my $cppflags = { lib => '$(LIB_CPPFLAGS)',
+                           dso => '$(DSO_CPPFLAGS)',
+                           bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+          my @incs_cmds = includes({ lib => '$(LIB_INCLUDES)',
+                                     dso => '$(DSO_INCLUDES)',
+                                     bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
+                                   '$(INCLUDES)',
+                                   @{$args{incs}});
+          my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
+          my $incs_off = join("\n\t\@ ", @{$incs_cmds[1]}) || '!';
+          if (defined($generator)) {
+              # If the target is named foo.S in build.info, we want to
+              # end up generating foo.s in two steps.
+              if ($args{src} =~ /\.S$/) {
+                   return <<"EOF";
+$target : $args{generator}->[0] $deps
+	$generator \$\@-S
+        \@ $incs_on
+	PIPE \$(CPP) $cppflags \$\@-S | -
+        \$(PERL) -ne "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@-i
+        \@ $incs_off
+        RENAME \$\@-i \$\@
+        DELETE \$\@-S
+EOF
+              }
+              # Otherwise....
+              return <<"EOF";
+$target : $args{generator}->[0] $deps
+	$generator \$\@
+EOF
+          }
+          return <<"EOF";
+$target : $args{generator}->[0] $deps
+        \@ $incs_on
+        SHOW SYMBOL qual_includes
+        PIPE \$(CPP) $cppflags $args{generator}->[0] | -
+        \$(PERL) "-ne" "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@
+        \@ $incs_off
+EOF
       }
   }
 
   sub src2obj {
       my %args = @_;
+      my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x
+                     } ( @{$args{srcs}} );
       (my $obj = $args{obj}) =~ s|\.o$||;
-      my $deps = join(", -\n\t\t", @{$args{srcs}}, @{$args{deps}});
+      my $deps = join(", -\n\t\t", @srcs, @{$args{deps}});
 
       # Because VMS C isn't very good at combining a /INCLUDE path with
       # #includes having a relative directory (like '#include "../foo.h"),
@@ -631,9 +719,21 @@ EOF
       my $objd = abs2rel(rel2abs(dirname($obj)), rel2abs($forward));
       my $objn = basename($obj);
       my $srcs =
-          join(", ",
-               map { abs2rel(rel2abs($_), rel2abs($forward)) } @{$args{srcs}});
-      my $cflags = '$(CFLAGS)';
+          join(", ", map { abs2rel(rel2abs($_), rel2abs($forward)) } @srcs);
+      my $before = $unified_info{before}->{$obj.".OBJ"} || "\@ !";
+      my $after = $unified_info{after}->{$obj.".OBJ"} || "\@ !";
+
+      if ($srcs[0] =~ /\.asm$/) {
+          return <<"EOF";
+$obj.OBJ : $deps
+        ${before}
+        SET DEFAULT $forward
+        \$(AS) \$(ASFLAGS) \$(ASOUTFLAG)${objd}${objn}.OBJ $srcs
+        SET DEFAULT $backward
+EOF
+      }
+
+      my $cflags;
       if ($args{installed}) {
           $cflags = { lib => '$(LIB_CFLAGS)',
                       dso => '$(DSO_CFLAGS)',
@@ -646,41 +746,17 @@ EOF
       $cflags .= { lib => '$(LIB_CPPFLAGS)',
 		   dso => '$(DSO_CPPFLAGS)',
 		   bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
-      
-      # We create a logical name TMP_INCLUDES: to hold the list of internal
-      # includes.  However, we cannot use it directly, as logical names can't
-      # hold zero entries, so we also create a symbol with the same name and
-      # use that instead, see the '/INCLUDE=' assignment above.  If there are
-      # no internal include directories, it will simply be the empty string,
-      # but if there are, it will be assigned "TMP_DEFINES:,"
-      my $xtraincludes = { lib => '$(LIB_INCLUDES)',
-                           dso => '$(DSO_INCLUDES)',
-                           bin => '$(BIN_INCLUDES)' } -> {$args{intent}};
-      my $incs_add =
-          'IF tmp_add .NES. "" .AND. tmp_includes .NES. "" THEN tmp_includes = "," + tmp_includes'
-          ."\n\t".'tmp_includes = tmp_add + tmp_includes';
-      my $incs_on = 'tmp_includes := '
-          ."\n\t"."tmp_add := $xtraincludes"
-          ."\n\t".$incs_add
-          ."\n\t".'tmp_add := $(INCLUDES)'
-          ."\n\t".$incs_add;
-      my $incs_off = 'DELETE/SYMBOL/LOCAL tmp_includes'
-          ."\n\t".'DELETE/SYMBOL/LOCAL tmp_add';
-      if (@{$args{incs}}) {
-          $incs_on =
-              'DEFINE tmp_includes '
-              .join(",-\n\t\t\t", map {
-                                      file_name_is_absolute($_)
-                                      ? $_ : catdir($backward,$_)
-                                  } @{$args{incs}})
-              ."\n\t".$incs_on
-              ."\n\t".'IF tmp_includes .NES. "" THEN tmp_includes = "," + tmp_includes'
-              ."\n\t".'tmp_includes = "tmp_includes:" + tmp_includes';
-          $incs_off .=
-              "\n\t".'DEASSIGN tmp_includes';
-      }
-      my $before = $unified_info{before}->{$obj.".OBJ"} || "\@ !";
-      my $after = $unified_info{after}->{$obj.".OBJ"} || "\@ !";
+
+      my @incs_cmds = includes({ lib => '$(LIB_INCLUDES)',
+                                 dso => '$(DSO_INCLUDES)',
+                                 bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
+                               '$(INCLUDES)',
+                               map {
+                                   file_name_is_absolute($_)
+                                   ? $_ : catdir($backward,$_)
+                               } @{$args{incs}});
+      my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
+      my $incs_off = join("\n\t\@ ", @{$incs_cmds[1]}) || '!';
       my $depbuild = $disabled{makedepend} ? ""
           : " /MMS=(FILE=${objd}${objn}.tmp-D,TARGET=$obj.OBJ)";
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -196,22 +196,23 @@ CXXFLAGS={- join(' ', @{$config{cxxflags}}) -}
 LDFLAGS= {- join(' ', @{$config{lflags}}) -}
 PLIB_LDFLAGS= {- join(' ', @{$config{plib_lflags}}) -}
 EX_LIBS= {- join(' ', @{$config{ex_libs}}) -}
-LIB_CPPFLAGS={- join(' ',
-                     (map { '-D'.$_ }
-                          ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
-                           'ENGINESDIR="\"$(ENGINESDIR)\""')),
-                     $target{shared_cppflag}) || "" -}
-LIB_CFLAGS={- $target{shared_cflag} || "" -}
-LIB_CXXFLAGS={- $target{shared_cxxflag} || "" -}
-LIB_LDFLAGS={- $target{shared_ldflag}." ".$config{shared_ldflag} -}
-DSO_CPPFLAGS={- $target{dso_cppflags} || "" -}
-DSO_CFLAGS={- $target{dso_cflags} || "" -}
-DSO_CXXFLAGS={- $target{dso_cxxflags} || "" -}
-DSO_LDFLAGS={- $target{dso_lflags} || "" -}
-BIN_CPPFLAGS={- $target{bin_cppflags} || "" -}
-BIN_CFLAGS={- $target{bin_cflags} || "" -}
-BIN_CXXFLAGS={- $target{bin_cxxflags} || "" -}
-BIN_LDFLAGS={- $target{bin_lflags} || "" -}
+
+LIB_CPPFLAGS=$(CPPFLAGS){- join(' ',
+                                $target{shared_cppflag},
+                                (map { '-D'.$_ }
+                                     ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
+                                      'ENGINESDIR="\"$(ENGINESDIR)\""'))) -}
+LIB_CFLAGS=$(CFLAGS) {- $target{shared_cflag} || "" -}
+LIB_CXXFLAGS=$(CXXFLAGS) {- $target{shared_cxxflag} || "" -}
+LIB_LDFLAGS=$(LDFLAGS) {- $target{shared_ldflag}." ".$config{shared_ldflag} -}
+DSO_CPPFLAGS=$(CPPFLAGS) {- $target{dso_cppflags} || "" -}
+DSO_CFLAGS=$(CFLAGS) {- $target{dso_cflags} || "" -}
+DSO_CXXFLAGS=$(CXXFLAGS) {- $target{dso_cxxflags} || "" -}
+DSO_LDFLAGS=$(LDFLAGS) {- $target{dso_lflags} || "" -}
+BIN_CPPFLAGS=$(CPPFLAGS) {- $target{bin_cppflags} || "" -}
+BIN_CFLAGS=$(CFLAGS) {- $target{bin_cflags} || "" -}
+BIN_CXXFLAGS=$(CXXFLAGS) {- $target{bin_cxxflags} || "" -}
+BIN_LDFLAGS=$(LDFLAGS) {- $target{bin_lflags} || "" -}
 
 PERL={- $config{perl} -}
 
@@ -848,6 +849,11 @@ EOF
               die "Generator type for $args{src} unknown: $generator\n";
           }
 
+          my $cppflags = {
+              lib => '$(LIB_CPPFLAGS)',
+              dso => '$(DSO_CPPFLAGS)',
+              bin => '$(BIN_CPPFLAGS)'
+          } -> {$args{intent}};
           if (defined($generator)) {
               # If the target is named foo.S in build.info, we want to
               # end up generating foo.s in two steps.
@@ -891,9 +897,9 @@ EOF
       my $srcs = join(" ",  @srcs);
       my $deps = join(" ", @srcs, @{$args{deps}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
-      my $cmd = '$(CC)';
-      my $cmdflags = '$(CFLAGS)';
-      my $cmdcompile = ' -c';
+      my $cmd;
+      my $cmdflags;
+      my $cmdcompile;
       my $makedepprog = $disabled{makedepend} ? undef : $config{makedepprog};
       if (grep /\.rc$/, @srcs) {
           $cmd = '$(RC)';
@@ -902,22 +908,20 @@ EOF
           $makedepprog = undef;
       } elsif (grep /\.(cc|cpp)$/, @srcs) {
           $cmd = '$(CXX)';
-          $cmdflags = '$(CXXFLAGS)';
-          $cmdflags .= ' ' . { lib => '$(LIB_CXXFLAGS)',
-                               dso => '$(DSO_CXXFLAGS)',
-                               bin => '$(BIN_CXXFLAGS)' } -> {$args{intent}};
-          $cmdflags .= ' $(CPPFLAGS)';
-          $cmdflags .= ' ' . { lib => '$(LIB_CPPFLAGS)',
-                               dso => '$(DSO_CPPFLAGS)',
-                               bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+          $cmdcompile = ' -c';
+          $cmdflags = {
+              lib => '$(LIB_CXXFLAGS) $(LIB_CPPFLAGS)',
+              dso => '$(DSO_CXXFLAGS) $(DSO_CPPFLAGS)',
+              bin => '$(BIN_CXXFLAGS) $(BIN_CPPFLAGS)'
+          } -> {$args{intent}};
       } else {
-          $cmdflags .= ' ' . { lib => '$(LIB_CFLAGS)',
-                               dso => '$(DSO_CFLAGS)',
-                               bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
-          $cmdflags .= ' $(CPPFLAGS)';
-          $cmdflags .= ' ' . { lib => '$(LIB_CPPFLAGS)',
-                               dso => '$(DSO_CPPFLAGS)',
-                               bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+          $cmd = '$(CC)';
+          $cmdcompile = ' -c';
+          $cmdflags = {
+              lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
+              dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
+              bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
+          } -> {$args{intent}};
       }
       $cmdflags .= $cmdcompile;
       my $recipe = <<"EOF";
@@ -997,7 +1001,7 @@ EOF
 # simplest, {libname}\$(SHLIB_EXT_IMPORT) for Windows POSIX layers and
 # {libname}\$(SHLIB_EXT_SIMPLE) for the Unix platforms.
 $target: $deps
-	\$(CC) \$(CFLAGS) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
+	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
 		-o $target_full$shared_def $objs \\
                 \$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
 EOF
@@ -1040,7 +1044,7 @@ EOF
       my $target = dso($dso);
       return <<"EOF";
 $target: $objs $deps
-	\$(CC) \$(CFLAGS) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
+	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
 		-o $target $objs \\
                 \$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
 EOF
@@ -1080,15 +1084,15 @@ EOF
                                     }
                                   } @{$args{deps}});
       my $cmd = '$(CC)';
-      my $cmdflags = '$(CFLAGS) $(BIN_CFLAGS)';
+      my $cmdflags = '$(BIN_CFLAGS)';
       if (grep /_cc\.o$/, @{$args{objs}}) {
           $cmd = '$(CXX)';
-          $cmdflags = '$(CXXFLAGS) $(BIN_CXXFLAGS)';
+          $cmdflags = '$(BIN_CXXFLAGS)';
       }
       return <<"EOF";
 $bin$exeext: $objs $deps
 	rm -f $bin$exeext
-	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(LDFLAGS) \$(BIN_LDFLAGS) \\
+	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(BIN_LDFLAGS) \\
 		-o $bin$exeext $objs \\
 		\$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
 EOF

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -197,22 +197,22 @@ LDFLAGS= {- join(' ', @{$config{lflags}}) -}
 PLIB_LDFLAGS= {- join(' ', @{$config{plib_lflags}}) -}
 EX_LIBS= {- join(' ', @{$config{ex_libs}}) -}
 
-LIB_CPPFLAGS=$(CPPFLAGS){- join(' ',
-                                $target{shared_cppflag},
-                                (map { '-D'.$_ }
-                                     ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
-                                      'ENGINESDIR="\"$(ENGINESDIR)\""'))) -}
-LIB_CFLAGS=$(CFLAGS) {- $target{shared_cflag} || "" -}
-LIB_CXXFLAGS=$(CXXFLAGS) {- $target{shared_cxxflag} || "" -}
-LIB_LDFLAGS=$(LDFLAGS) {- $target{shared_ldflag}." ".$config{shared_ldflag} -}
-DSO_CPPFLAGS=$(CPPFLAGS) {- $target{dso_cppflags} || "" -}
-DSO_CFLAGS=$(CFLAGS) {- $target{dso_cflags} || "" -}
-DSO_CXXFLAGS=$(CXXFLAGS) {- $target{dso_cxxflags} || "" -}
-DSO_LDFLAGS=$(LDFLAGS) {- $target{dso_lflags} || "" -}
-BIN_CPPFLAGS=$(CPPFLAGS) {- $target{bin_cppflags} || "" -}
-BIN_CFLAGS=$(CFLAGS) {- $target{bin_cflags} || "" -}
-BIN_CXXFLAGS=$(CXXFLAGS) {- $target{bin_cxxflags} || "" -}
-BIN_LDFLAGS=$(LDFLAGS) {- $target{bin_lflags} || "" -}
+LIB_CPPFLAGS={- join(' ', '$(CPPFLAGS)',
+                          $target{shared_cppflag},
+                          (map { '-D'.$_ }
+                               ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
+                                'ENGINESDIR="\"$(ENGINESDIR)\""'))) -}
+LIB_CFLAGS={- join(' ', '$(CFLAGS)', $target{shared_cflag} || ()) -}
+LIB_CXXFLAGS={- join(' ', '$(CXXFLAGS)', $target{shared_cxxflag} || ()) -}
+LIB_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{shared_ldflag} || (), $config{shared_ldflag} || ()) -}
+DSO_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{dso_cppflags} || ()) -}
+DSO_CFLAGS={- join(' ', '$(CFLAGS)', $target{dso_cflags} || ()) -}
+DSO_CXXFLAGS={- join(' ', '$(CXXFLAGS)', $target{dso_cxxflags} || ()) -}
+DSO_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{dso_lflags} || ()) -}
+BIN_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{bin_cppflags} || ()) -}
+BIN_CFLAGS={- join(' ', '$(CFLAGS)', $target{bin_cflags} || ()) -}
+BIN_CXXFLAGS={- join(' ', '$(CXXFLAGS)', $target{bin_cxxflags} || ()) -}
+BIN_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{bin_lflags} || ()) -}
 
 PERL={- $config{perl} -}
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -198,7 +198,7 @@ PLIB_LDFLAGS= {- join(' ', @{$config{plib_lflags}}) -}
 EX_LIBS= {- join(' ', @{$config{ex_libs}}) -}
 
 LIB_CPPFLAGS={- join(' ', '$(CPPFLAGS)',
-                          $target{shared_cppflag},
+                          $target{shared_cppflag} || (),
                           (map { '-D'.$_ }
                                ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
                                 'ENGINESDIR="\"$(ENGINESDIR)\""'))) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -175,19 +175,19 @@ LDFLAGS={- join(' ', @{$config{lflags}}) -}
 LDOUTFLAG={- $target{loutflag} || "/out:" -}$(OSSL_EMPTY)
 EX_LIBS={- join(' ', @{$config{ex_libs}}) -}
 
-LIB_CPPFLAGS=$(CPPFLAGS){- join(" ",
-                                $target{shared_cppflag} || "",
-                                (map { quotify_l("-D".$_) }
-                                 "OPENSSLDIR=\"$openssldir\"",
-                                 "ENGINESDIR=\"$enginesdir\"")) -}
-LIB_CFLAGS=$(CFLAGS){- join(" ", $target{lib_cflags}, $target{shared_cflag}) -}
-LIB_LDFLAGS=$(LDFLAGS){- join(' ', $target{shared_ldflag}, $config{shared_ldflag}) -}
-DSO_CPPFLAGS=$(CPPFLAGS){- $target{dso_cppflags} || "" -}
-DSO_CFLAGS=$(CFLAGS){- $target{dso_cflags} || "" -}
-DSO_LDFLAGS=$(LDFLAGS){- $target{dso_ldflag} || "" -}
-BIN_CPPFLAGS=$(CPPFLAGS){- $target{dso_cppflags} || "" -}
-BIN_CFLAGS=$(CFLAGS){- $target{bin_cflags} || "" -}
-BIN_LDFLAGS=$(LDFLAGS){- $target{bin_lflags} || "" -}
+LIB_CPPFLAGS={- join(' ', '$(CPPFLAGS)',
+                          $target{shared_cppflag} || (),
+                          (map { quotify_l("-D".$_) }
+                           "OPENSSLDIR=\"$openssldir\"",
+                           "ENGINESDIR=\"$enginesdir\"")) -}
+LIB_CFLAGS={- join(' ', '$(CFLAGS)', $target{lib_cflags} || (), $target{shared_cflag} || ()) -}
+LIB_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{shared_ldflag} || (), $config{shared_ldflag} || ()) -}
+DSO_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{dso_cppflags} || ()) -}
+DSO_CFLAGS={- join(' ', '$(CFLAGS)', $target{dso_cflags} || ()) -}
+DSO_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{dso_ldflag} || ()) -}
+BIN_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{dso_cppflags} || ()) -}
+BIN_CFLAGS={- join(' ', '$(CFLAGS)', $target{bin_cflags} || ()) -}
+BIN_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{bin_lflags} || ()) -}
 
 PERL={- $config{perl} -}
 

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -174,19 +174,20 @@ LD={- $config{ld} -}
 LDFLAGS={- join(' ', @{$config{lflags}}) -}
 LDOUTFLAG={- $target{loutflag} || "/out:" -}$(OSSL_EMPTY)
 EX_LIBS={- join(' ', @{$config{ex_libs}}) -}
-LIB_CPPFLAGS={- join(" ",
-                     $target{shared_cppflag} || "",
-                     (map { quotify_l("-D".$_) }
-                      "OPENSSLDIR=\"$openssldir\"",
-                      "ENGINESDIR=\"$enginesdir\"")) -}
-LIB_CFLAGS={- join(" ", $target{lib_cflags}, $target{shared_cflag}) -}
-LIB_LDFLAGS={- join(' ', $target{shared_ldflag}, $config{shared_ldflag}) -}
-DSO_CPPFLAGS={- $target{dso_cppflags} || "" -}
-DSO_CFLAGS={- $target{dso_cflags} || "" -}
-DSO_LDFLAGS={- $target{dso_ldflag} || "" -}
-BIN_CPPFLAGS={- $target{dso_cppflags} || "" -}
-BIN_CFLAGS={- $target{bin_cflags} -}
-BIN_LDFLAGS={- $target{bin_lflags} -}
+
+LIB_CPPFLAGS=$(CPPFLAGS){- join(" ",
+                                $target{shared_cppflag} || "",
+                                (map { quotify_l("-D".$_) }
+                                 "OPENSSLDIR=\"$openssldir\"",
+                                 "ENGINESDIR=\"$enginesdir\"")) -}
+LIB_CFLAGS=$(CFLAGS){- join(" ", $target{lib_cflags}, $target{shared_cflag}) -}
+LIB_LDFLAGS=$(LDFLAGS){- join(' ', $target{shared_ldflag}, $config{shared_ldflag}) -}
+DSO_CPPFLAGS=$(CPPFLAGS){- $target{dso_cppflags} || "" -}
+DSO_CFLAGS=$(CFLAGS){- $target{dso_cflags} || "" -}
+DSO_LDFLAGS=$(LDFLAGS){- $target{dso_ldflag} || "" -}
+BIN_CPPFLAGS=$(CPPFLAGS){- $target{dso_cppflags} || "" -}
+BIN_CFLAGS=$(CFLAGS){- $target{bin_cflags} || "" -}
+BIN_LDFLAGS=$(LDFLAGS){- $target{bin_lflags} || "" -}
 
 PERL={- $config{perl} -}
 
@@ -434,6 +435,10 @@ EOF
               die "Generator type for $src unknown: $generator\n";
           }
 
+          my $cppflags = $incs;
+          $cppflags .= { lib => '$(LIB_CPPFLAGS)',
+                         dso => '$(DSO_CPPFLAGS)',
+                         bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
           if (defined($generator)) {
               # If the target is named foo.S in build.info, we want to
               # end up generating foo.s in two steps.
@@ -467,12 +472,10 @@ EOF
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
-     my $cflags = '$(CFLAGS)';
-     $cflags .= { lib => ' $(LIB_CFLAGS)',
-		  dso => ' $(DSO_CFLAGS)',
-		  bin => ' $(BIN_CFLAGS)' } -> {$args{intent}};
+     my $cflags = { lib => ' $(LIB_CFLAGS)',
+		    dso => ' $(DSO_CFLAGS)',
+		    bin => ' $(BIN_CFLAGS)' } -> {$args{intent}};
      $cflags .= $incs;
-     $cflags .= ' $(CPPFLAGS)';
      $cflags .= { lib => ' $(LIB_CPPFLAGS)',
 		  dso => ' $(DSO_CPPFLAGS)',
 		  bin => ' $(BIN_CPPFLAGS)' } -> {$args{intent}};

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -6,16 +6,13 @@ SOURCE[../../libcrypto]=\
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 
 GENERATE[aes-586.s]=asm/aes-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[aes-586.s]=../perlasm/x86asm.pl
 GENERATE[vpaes-x86.s]=asm/vpaes-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[vpaes-586.s]=../perlasm/x86asm.pl
 GENERATE[aesni-x86.s]=asm/aesni-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[aesni-586.s]=../perlasm/x86asm.pl
 
 GENERATE[aes-x86_64.s]=asm/aes-x86_64.pl $(PERLASM_SCHEME)

--- a/crypto/bf/build.info
+++ b/crypto/bf/build.info
@@ -3,6 +3,5 @@ SOURCE[../../libcrypto]=bf_skey.c bf_ecb.c bf_cfb64.c bf_ofb64.c \
         {- $target{bf_asm_src} -}
 
 GENERATE[bf-586.s]=asm/bf-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[bf-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/bn/asm/ia64.S
+++ b/crypto/bn/asm/ia64.S
@@ -157,6 +157,9 @@
 #else
 #define	ADDP	add
 #endif
+#ifdef __VMS
+.alias abort, "decc$abort"
+#endif
 
 #if 1
 //
@@ -1428,6 +1431,7 @@ bn_div_words:
 	mov		ar.ec=0		// don't rotate at exit
 	mov		pr.rot=0	}
 { .mii;	mov		L=r33		// save l
+	mov		r25=r0		// needed if abort is called on VMS
 	mov		r36=r0		};;
 
 .L_divw_shift:	// -vv- note signed comparison

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -11,20 +11,16 @@ INCLUDE[../../libcrypto]=../../crypto/include
 INCLUDE[bn_exp.o]=..
 
 GENERATE[bn-586.s]=asm/bn-586.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+	$(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[bn-586.s]=../perlasm/x86asm.pl
 GENERATE[co-586.s]=asm/co-586.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+	$(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[co-586.s]=../perlasm/x86asm.pl
 GENERATE[x86-mont.s]=asm/x86-mont.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+	$(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[x86-mont.s]=../perlasm/x86asm.pl
 GENERATE[x86-gf2m.s]=asm/x86-gf2m.pl \
-	$(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+	$(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[x86-gf2m.s]=../perlasm/x86asm.pl
 
 GENERATE[sparcv9a-mont.S]=asm/sparcv9a-mont.pl $(PERLASM_SCHEME)
@@ -53,8 +49,7 @@ GENERATE[rsaz-x86_64.s]=asm/rsaz-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[rsaz-avx2.s]=asm/rsaz-avx2.pl $(PERLASM_SCHEME)
 
 GENERATE[bn-ia64.s]=asm/ia64.S
-GENERATE[ia64-mont.s]=asm/ia64-mont.pl \
-        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+GENERATE[ia64-mont.s]=asm/ia64-mont.pl $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 
 GENERATE[parisc-mont.s]=asm/parisc-mont.pl $(PERLASM_SCHEME)
 

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -19,8 +19,7 @@ GENERATE[uplink-x86_64.s]=../ms/uplink-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[uplink-ia64.s]=../ms/uplink-ia64.pl $(PERLASM_SCHEME)
 
 GENERATE[x86cpuid.s]=x86cpuid.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[x86cpuid.s]=perlasm/x86asm.pl
 
 GENERATE[x86_64cpuid.s]=x86_64cpuid.pl $(PERLASM_SCHEME)

--- a/crypto/camellia/build.info
+++ b/crypto/camellia/build.info
@@ -4,7 +4,7 @@ SOURCE[../../libcrypto]=\
         {- $target{cmll_asm_src} -}
 
 GENERATE[cmll-x86.s]=asm/cmll-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) \
         $(PROCESSOR)
 DEPEND[cmll-x86.s]=../perlasm/x86asm.pl
 GENERATE[cmll-x86_64.s]=asm/cmll-x86_64.pl $(PERLASM_SCHEME)

--- a/crypto/cast/build.info
+++ b/crypto/cast/build.info
@@ -3,6 +3,5 @@ SOURCE[../../libcrypto]=\
         c_skey.c c_ecb.c {- $target{cast_asm_src} -} c_cfb64.c c_ofb64.c
 
 GENERATE[cast-586.s]=asm/cast-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[cast-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -2,8 +2,7 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]={- $target{chacha_asm_src} -}
 
 GENERATE[chacha-x86.s]=asm/chacha-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 GENERATE[chacha-x86_64.s]=asm/chacha-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[chacha-ppc.s]=asm/chacha-ppc.pl $(PERLASM_SCHEME)
 GENERATE[chacha-armv4.S]=asm/chacha-armv4.pl $(PERLASM_SCHEME)

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -12,8 +12,8 @@ GENERATE[dest4-sparcv9.S]=asm/dest4-sparcv9.pl $(PERLASM_SCHEME)
 INCLUDE[dest4-sparcv9.o]=..
 
 GENERATE[des-586.s]=asm/des-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 DEPEND[des-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
 GENERATE[crypt586.s]=asm/crypt586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 DEPEND[crypt586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -9,8 +9,7 @@ SOURCE[../../libcrypto]=\
         {- $target{ec_asm_src} -}
 
 GENERATE[ecp_nistz256-x86.s]=asm/ecp_nistz256-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 
 GENERATE[ecp_nistz256-x86_64.s]=asm/ecp_nistz256-x86_64.pl $(PERLASM_SCHEME)
 

--- a/crypto/md5/build.info
+++ b/crypto/md5/build.info
@@ -3,7 +3,7 @@ SOURCE[../../libcrypto]=\
         md5_dgst.c md5_one.c {- $target{md5_asm_src} -}
 
 GENERATE[md5-586.s]=asm/md5-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 
 GENERATE[md5-x86_64.s]=asm/md5-x86_64.pl $(PERLASM_SCHEME)
 

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -6,11 +6,9 @@ SOURCE[../../libcrypto]=\
 
 INCLUDE[gcm128.o]=..
 
-GENERATE[ghash-ia64.s]=asm/ghash-ia64.pl \
-        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+GENERATE[ghash-ia64.s]=asm/ghash-ia64.pl $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 GENERATE[ghash-x86.s]=asm/ghash-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 GENERATE[ghash-x86_64.s]=asm/ghash-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[aesni-gcm-x86_64.s]=asm/aesni-gcm-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[ghash-sparcv9.S]=asm/ghash-sparcv9.pl $(PERLASM_SCHEME)

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -7,8 +7,7 @@ SOURCE[../../libcrypto]=\
 GENERATE[poly1305-sparcv9.S]=asm/poly1305-sparcv9.pl $(PERLASM_SCHEME)
 INCLUDE[poly1305-sparcv9.o]=..
 GENERATE[poly1305-x86.s]=asm/poly1305-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 GENERATE[poly1305-x86_64.s]=asm/poly1305-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[poly1305-ppc.s]=asm/poly1305-ppc.pl $(PERLASM_SCHEME)
 GENERATE[poly1305-ppcfp.s]=asm/poly1305-ppcfp.pl $(PERLASM_SCHEME)

--- a/crypto/rc4/build.info
+++ b/crypto/rc4/build.info
@@ -3,8 +3,7 @@ SOURCE[../../libcrypto]=\
         {- $target{rc4_asm_src} -}
 
 GENERATE[rc4-586.s]=asm/rc4-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[rc4-586.s]=../perlasm/x86asm.pl
 
 GENERATE[rc4-x86_64.s]=asm/rc4-x86_64.pl $(PERLASM_SCHEME)

--- a/crypto/rc5/build.info
+++ b/crypto/rc5/build.info
@@ -3,5 +3,5 @@ SOURCE[../../libcrypto]=\
         rc5_skey.c rc5_ecb.c {- $target{rc5_asm_src} -} rc5cfb64.c rc5ofb64.c
 
 GENERATE[rc5-586.s]=asm/rc5-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 DEPEND[rc5-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -3,5 +3,5 @@ SOURCE[../../libcrypto]=\
         rmd_dgst.c rmd_one.c {- $target{rmd160_asm_src} -}
 
 GENERATE[rmd-586.s]=asm/rmd-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 DEPEND[rmd-586.s]=../perlasm/x86asm.pl

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -4,24 +4,18 @@ SOURCE[../../libcrypto]=\
         keccak1600.c
 
 GENERATE[sha1-586.s]=asm/sha1-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[sha1-586.s]=../perlasm/x86asm.pl
 GENERATE[sha256-586.s]=asm/sha256-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[sha256-586.s]=../perlasm/x86asm.pl
 GENERATE[sha512-586.s]=asm/sha512-586.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[sha512-586.s]=../perlasm/x86asm.pl
 
-GENERATE[sha1-ia64.s]=asm/sha1-ia64.pl \
-        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
-GENERATE[sha256-ia64.s]=asm/sha512-ia64.pl \
-        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
-GENERATE[sha512-ia64.s]=asm/sha512-ia64.pl \
-        $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS)
+GENERATE[sha1-ia64.s]=asm/sha1-ia64.pl $(LIB_CFLAGS) $(LIB_CPPFLAGS)
+GENERATE[sha256-ia64.s]=asm/sha512-ia64.pl $(LIB_CFLAGS) $(LIB_CPPFLAGS)
+GENERATE[sha512-ia64.s]=asm/sha512-ia64.pl $(LIB_CFLAGS) $(LIB_CPPFLAGS)
 
 GENERATE[sha1-alpha.S]=asm/sha1-alpha.pl $(PERLASM_SCHEME)
 

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -2,8 +2,7 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=wp_dgst.c {- $target{wp_asm_src} -}
 
 GENERATE[wp-mmx.s]=asm/wp-mmx.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[wp-mmx.s]=../perlasm/x86asm.pl
 
 GENERATE[wp-x86_64.s]=asm/wp-x86_64.pl $(PERLASM_SCHEME)

--- a/engines/build.info
+++ b/engines/build.info
@@ -38,7 +38,6 @@ IF[{- !$disabled{"engine"} -}]
   ENDIF
 
   GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl \
-        $(PERLASM_SCHEME) $(CFLAGS) $(LIB_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) \
-        $(PROCESSOR)
+        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
   GENERATE[e_padlock-x86_64.s]=asm/e_padlock-x86_64.pl $(PERLASM_SCHEME)
 ENDIF


### PR DESCRIPTION
This change brings harmonization of make variables across all platform families, making that the biggest part of this PR...

The make variables LIB_CFLAGS, DSO_CFLAGS and so on were used in
addition to CFLAGS and so on.  This works without problem on Unix and
Windows, where options with different purposes (such as -D and -I) can
appear anywhere on the command line and get accumulated as they come.
This is not necessarely so on VMS.  For example, macros must all be
collected and given through one /DEFINE, and the same goes for
inclusion directories (/INCLUDE).

So, to harmonize all platforms, we repurpose make variables starting
with LIB_, DSO_ and BIN_ to be all encompassing variables that
collects the corresponding values from CFLAGS, CPPFLAGS, DEFINES,
INCLUDES and so on together with possible config target values
specific for libraries DSOs and programs, and use them instead of the
general ones everywhere.

This will, for example, allow VMS to use the exact same generators for
generated files that go through cpp as all other platforms, something
that has been impossible to do safely before now.