### PR TITLE
OSSL_STORE: Add OSSL_STORE_vctrl()

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -112,7 +112,7 @@ int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ...)
     int ret;
 
     va_start(args, cmd);
-    ret = OSSL_STORE_vctrl(ctx->loader_ctx, cmd, args);
+    ret = OSSL_STORE_vctrl(ctx, cmd, args);
     va_end(args);
 
     return ret;
@@ -121,7 +121,7 @@ int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ...)
 int OSSL_STORE_vctrl(OSSL_STORE_CTX *ctx, int cmd, va_list args)
 {
     if (ctx->loader->ctrl != NULL)
-        return ctx->loader->ctrl(ctx, cmd, args);
+        return ctx->loader->ctrl(ctx->loader_ctx, cmd, args);
     return 0;
 }
 

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -121,7 +121,7 @@ int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ...)
 int OSSL_STORE_vctrl(OSSL_STORE_CTX *ctx, int cmd, va_list args)
 {
     if (ctx->loader->ctrl != NULL)
-        return ctx->loader->ctrl(ctx->loader_ctx, cmd, args);
+        return ctx->loader->ctrl(ctx, cmd, args);
     return 0;
 }
 

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -109,14 +109,20 @@ OSSL_STORE_CTX *OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method,
 int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ...)
 {
     va_list args;
-    int ret = 0;
+    int ret;
 
     va_start(args, cmd);
-    if (ctx->loader->ctrl != NULL)
-        ret = ctx->loader->ctrl(ctx->loader_ctx, cmd, args);
+    ret = OSSL_STORE_vctrl(ctx->loader_ctx, cmd, args);
     va_end(args);
 
     return ret;
+}
+
+int OSSL_STORE_vctrl(OSSL_STORE_CTX *ctx, int cmd, va_list args)
+{
+    if (ctx->loader->ctrl != NULL)
+        return ctx->loader->ctrl(ctx->loader_ctx, cmd, args);
+    return 0;
 }
 
 OSSL_STORE_INFO *OSSL_STORE_load(OSSL_STORE_CTX *ctx)

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -58,6 +58,7 @@ OSSL_STORE_CTX *OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method,
  * Each command takes different arguments.
  */
 int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ... /* args */);
+int OSSL_STORE_vctrl(OSSL_STORE_CTX *ctx, int cmd, va_list args);
 
 /*
  * Common ctrl commands that different loaders may choose to support.

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4505,3 +4505,4 @@ RAND_DRBG_lock                          4446	1_1_1	EXIST::FUNCTION:
 RAND_DRBG_unlock                        4447	1_1_1	EXIST::FUNCTION:
 RAND_DRBG_enable_locking                4448	1_1_1	EXIST::FUNCTION:
 RAND_DRBG_secure_new                    4449	1_1_1	EXIST::FUNCTION:
+OSSL_STORE_vctrl                        4450	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
It's a convenient complement to OSSL_STORE_ctrl()

Suggested by Norm Green
