### PR TITLE
VMS: simplify config targets

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1873,7 +1873,6 @@ my %targets = (
         shared_target    => "vms-shared",
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",
-        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
 
         apps_aux_src     => "vms_term_sock.c",
         apps_init_src    => "vms_decc_init.c",
@@ -1881,6 +1880,7 @@ my %targets = (
 
     "vms-alpha" => {
         inherit_from     => [ "vms-generic" ],
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
         pointer_size     => "",
     },
     "vms-alpha-p32" => {
@@ -1895,6 +1895,7 @@ my %targets = (
     },
     "vms-ia64" => {
         inherit_from     => [ "vms-generic" ],
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
         pointer_size     => "",
     },
     "vms-ia64-p32" => {

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -116,13 +116,19 @@ sub vc_wince_info {
 # Helper functions for the VMS configs
 my $vms_info = {};
 sub vms_info {
-    unless (%$vms_info) {
-        my $pointer_size = shift;
-        my $pointer_size_str = $pointer_size == 0 ? "" : "$pointer_size";
+    my $pointer_size_str = $config{target} =~ m|-p(\d+)$| ? $1 : "";
 
+    # For the case where Configure iterate through all config targets, such
+    # as when listing them and their details, we reset info if the pointer
+    # size changes.
+    if (%$vms_info && $vms_info->{pointer_size} ne $pointer_size_str) {
+        $vms_info = {};
+    }
+
+    unless (%$vms_info) {
         $vms_info->{disable_warns} = [ ];
         $vms_info->{pointer_size} = $pointer_size_str;
-        if ($pointer_size == 64) {
+        if ($pointer_size_str eq "64") {
             `PIPE CC /NOCROSS_REFERENCE /NOLIST /NOOBJECT /WARNINGS = DISABLE = ( MAYLOSEDATA3, EMPTYFILE ) NL: 2> NL:`;
             if ($? == 0) {
                 push @{$vms_info->{disable_warns}}, "MAYLOSEDATA3";
@@ -1834,14 +1840,28 @@ my %targets = (
     },
 
     ##### VMS
+    # Most things happen in vms-generic.
+    # Note that vms_info extracts the pointer size from the end of
+    # the target name, and will assume that anything matching /-p\d+$/
+    # indicates the pointer size setting for the desired target.
     "vms-generic" => {
         inherit_from     => [ "BASE_VMS" ],
         template         => 1,
         cc               => "CC/DECC",
-        cflags           => picker(default => "/STANDARD=(ISOC94,RELAXED)/NOLIST/PREFIX=ALL",
-                                   debug   => "/NOOPTIMIZE/DEBUG",
-                                   release => "/OPTIMIZE/NODEBUG"),
-        defines          => add("OPENSSL_USE_NODELETE"),
+        cflags           =>
+            combine(picker(default => "/STANDARD=(ISOC94,RELAXED)/NOLIST/PREFIX=ALL",
+                           debug   => "/NOOPTIMIZE/DEBUG",
+                           release => "/OPTIMIZE/NODEBUG"),
+                    sub { my @warnings =
+                              @{vms_info()->{disable_warns}};
+                          @warnings
+                              ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : (); }),
+        defines          =>
+            add("OPENSSL_USE_NODELETE",
+                sub {
+                    return vms_info()->{def_zlib}
+                        ? "LIBZ=\"\"\"".vms_info()->{def_zlib}."\"\"\"" : ();
+                }),
         lflags           => picker(default => "/MAP='F\$PARSE(\".MAP\",\"\$\@\")'",
                                    debug   => "/DEBUG/TRACEBACK",
                                    release => "/NODEBUG/NOTRACEBACK"),
@@ -1849,9 +1869,11 @@ my %targets = (
         # no_inst_lib_cflags is used instead of lib_cflags by descrip.mms.tmpl
         # for object files belonging to selected internal libraries
         no_inst_lib_cflags => "",
+        ex_libs          => add(sub { return vms_info()->{zlib} || (); }),
         shared_target    => "vms-shared",
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",
+        bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
 
         apps_aux_src     => "vms_term_sock.c",
         apps_init_src    => "vms_decc_init.c",
@@ -1859,107 +1881,31 @@ my %targets = (
 
     "vms-alpha" => {
         inherit_from     => [ "vms-generic" ],
-        cflags           => add(sub { my @warnings =
-                                          @{vms_info(0)->{disable_warns}};
-                                      @warnings
-                                          ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : (); }),
-        defines          =>
-                    add(sub {
-                            return vms_info(0)->{def_zlib}
-                                ? "LIBZ=\"\"\"".vms_info(0)->{def_zlib}."\"\"\"" : ();
-                            }),
-        ex_libs          => add(sub { return vms_info(0)->{zlib} || (); }),
-        pointer_size     => sub { return vms_info(0)->{pointer_size} },
-        #as               => "???",
-        #debug_aflags     => "/NOOPTIMIZE/DEBUG",
-        #release_aflags   => "/OPTIMIZE/NODEBUG",
-        bn_opts          => "SIXTY_FOUR_BIT RC4_INT",
+        pointer_size     => "",
     },
     "vms-alpha-p32" => {
-        inherit_from     => [ "vms-generic" ],
-        cflags           =>
-            add("/POINTER_SIZE=32",
-                sub { my @warnings =
-                          @{vms_info(32)->{disable_warns}};
-                      @warnings
-                          ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : ();
-                } ),
-        defines          =>
-                    add(sub {
-                            return vms_info(32)->{def_zlib}
-                                ? "LIBZ=\"\"\"".vms_info(32)->{def_zlib}."\"\"\"" : ();
-                            }),
-        ex_libs          => add(sub { return vms_info(32)->{zlib} || (); }),
-        pointer_size     => sub { return vms_info(32)->{pointer_size} },
+        inherit_from     => [ "vms-alpha" ],
+        cflags           => add("/POINTER_SIZE=32"),
+        pointer_size     => "32",
     },
     "vms-alpha-p64" => {
-        inherit_from     => [ "vms-generic" ],
-        cflags           =>
-            add("/POINTER_SIZE=64=ARGV",
-                sub { my @warnings =
-                          @{vms_info(64)->{disable_warns}};
-                      @warnings
-                          ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : ();
-                } ),
-        defines          =>
-                    add(sub {
-                            return vms_info(64)->{def_zlib}
-                                ? "LIBZ=\"\"\"".vms_info(64)->{def_zlib}."\"\"\"" : ();
-                            }),
-        ex_libs          => add(sub { return vms_info(64)->{zlib} || (); }),
-        pointer_size     => sub { return vms_info(64)->{pointer_size} },
+        inherit_from     => [ "vms-alpha" ],
+        cflags           => add("/POINTER_SIZE=64=ARGV"),
+        pointer_size     => "64",
     },
     "vms-ia64" => {
         inherit_from     => [ "vms-generic" ],
-        cflags           => add(sub { my @warnings =
-                                          @{vms_info(0)->{disable_warns}};
-                                      @warnings
-                                          ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : (); }),
-        defines          =>
-                    add(sub {
-                            return vms_info(0)->{def_zlib}
-                                ? "LIBZ=\"\"\"".vms_info(0)->{def_zlib}."\"\"\"" : ();
-                            }),
-        ex_libs          => add(sub { return vms_info(0)->{zlib} || (); }),
-        pointer_size     => sub { return vms_info(0)->{pointer_size} },
-        #as               => "I4S",
-        #debug_aflags     => "/NOOPTIMIZE/DEBUG",
-        #release_aflags   => "/OPTIMIZE/NODEBUG",
-        bn_opts          => "SIXTY_FOUR_BIT RC4_INT",
+        pointer_size     => "",
     },
     "vms-ia64-p32" => {
-        inherit_from     => [ "vms-generic" ],
-        cflags           =>
-            add("/POINTER_SIZE=32",
-                sub { my @warnings =
-                          @{vms_info(32)->{disable_warns}};
-                      @warnings
-                          ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : ();
-                } ),
-        defines          =>
-                    add(sub {
-                            return vms_info(32)->{def_zlib}
-                                ? "LIBZ=\"\"\"".vms_info(32)->{def_zlib}."\"\"\"" : ();
-                            }),
-        ex_libs          => add(sub { return vms_info(32)->{zlib} || (); }),
-        pointer_size     => sub { return vms_info(32)->{pointer_size} },
+        inherit_from     => [ "vms-ia64" ],
+        cflags           => add("/POINTER_SIZE=32"),
+        pointer_size     => "32",
     },
     "vms-ia64-p64" => {
-        inherit_from     => [ "vms-generic" ],
-        cflags           =>
-            add("/POINTER_SIZE=64=ARGV",
-                sub { my @warnings =
-                          @{vms_info(64)->{disable_warns}};
-                      @warnings
-                          ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : ();
-                } ),
-        defines          =>
-                    add(sub {
-                            return vms_info(64)->{def_zlib}
-                                ? "LIBZ=\"\"\"".vms_info(64)->{def_zlib}."\"\"\"" : ();
-                            }),
-        ex_libs          => add(sub { return vms_info(64)->{zlib} || (); }),
-        pointer_size     => sub { return vms_info(64)->{pointer_size} },
+        inherit_from     => [ "vms-ia64" ],
+        cflags           => add("/POINTER_SIZE=64=ARGV"),
+        pointer_size     => "64",
     },
 
 );

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1878,6 +1878,20 @@ my %targets = (
         apps_init_src    => "vms_decc_init.c",
     },
 
+    # From HELP CC/POINTER_SIZE:
+    #
+    # ----------
+    # LONG[=ARGV] The compiler assumes 64-bit pointers. If the ARGV option to
+    #             LONG or 64 is present, the main argument argv will be an
+    #             array of long pointers instead of an array of short pointers.
+    #
+    # 64[=ARGV]   Same as LONG.
+    # ----------
+    #
+    # We don't want the hassle of dealing with 32-bit pointers with argv, so
+    # we force it to have 64-bit pointers, see the added cflags in the -p64
+    # config targets below.
+
     "vms-alpha" => {
         inherit_from     => [ "vms-generic" ],
         bn_ops           => "SIXTY_FOUR_BIT RC4_INT",


### PR DESCRIPTION
All VMS config targets were literally copies of each other, only
differing in what argument the parameter seeking function vms_info()
received (the pointer size).

This could be hugely simplified by letting vms_info() detect what
pointer size was desired from the desired config target name instead.
