### PR TITLE
Auto-size more of configdata.pm "disabled features"

### DIFF
--- a/Configure
+++ b/Configure
@@ -2379,8 +2379,10 @@ _____
     }
     if ($dump || $options) {
         my $longest = 0;
+        my $longest2 = 0;
         foreach my $what (@disablables) {
             $longest = length($what) if $longest < length($what);
+            $longest2 = length($disabled{$what}) if $longest2 < length($disabled{$what});
         }
         print "\nEnabled features:\n\n";
         foreach my $what (@disablables) {
@@ -2390,7 +2392,7 @@ _____
         foreach my $what (@disablables) {
             if ($disabled{$what}) {
                 print "    $what", ' ' x ($longest - length($what) + 1),
-                    "[$disabled{$what}]", ' ' x (10 - length($disabled{$what}));
+                    "[$disabled{$what}]", ' ' x ($longest2 - length($disabled{$what}) + 1);
                 print $disabled_info{$what}->{macro}
                     if $disabled_info{$what}->{macro};
                 print ' (skip ',


### PR DESCRIPTION
configdata.pm -d prints out a lot of information, including a table
of what features are disabled, why, and the effect of that disablement
(in terms of preprocessor symbols defined and directories skipped).
The first column is already auto-sized, to easily accomodate future
disableable features with long names.  Also auto-size the second column,
to accomodate future reasons for disablement with long names as well.

Failing to take such precautions results in stderr spew from
configdata.pm -d when such long reasons are in use:

   Negative repeat count does nothing at ./configdata.pm line 14504.

Such output is pretty distracting from the actual desired output,
so try to avoid it if possible.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
