### PR TITLE
Avoid unconditional store in CRYPTO_malloc.

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -201,7 +201,14 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
         return NULL;
 
     FAILTEST();
-    allow_customize = 0;
+    if (allow_customize) {
+        /*
+         * Disallow customization after the first allocation. We only set this
+         * if necessary to avoid a store to the same cache line on every
+         * allocation.
+         */
+        allow_customize = 0;
+    }
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
     if (call_malloc_debug) {
         CRYPTO_mem_debug_malloc(NULL, num, 0, file, line);
@@ -243,7 +250,6 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
         return NULL;
     }
 
-    allow_customize = 0;
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
     if (call_malloc_debug) {
         void *ret;


### PR DESCRIPTION
Currently every memory allocation causes a store to the static global variable allow_customize. This causes every allocation to dirty the same cache line, which at high load can cause signifigant contention and performance degradation. Adding the conditional, while functionally equivalent, prevents this.

The write in CRYPTO_realloc is unnecessary as the first allocation would have gone through CRYPTO_malloc.

I request this be merged to 1.1.0 as well as this is a regression from 1.0.2 (https://github.com/openssl/openssl/commit/bbd86bf5424a611cb6b77a3a17fc522931c4dcb8) and was causing us issues.