### PR TITLE
Fix a gcc warning about possible fall through

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1155,6 +1155,7 @@ static handshake_status_t handshake_status(peer_status_t last_status,
              */
             return INTERNAL_ERROR;
         }
+        break;
 
     case PEER_RETRY:
         return HANDSHAKE_RETRY;


### PR DESCRIPTION
This is actually not reachable but the switch above this line does not have a default label.