### PR TITLE
The record version for ClientHello2 should be TLS1.2

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -839,7 +839,9 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
          * and record version number > TLS 1.0
          */
         if (SSL_get_state(s) == TLS_ST_CW_CLNT_HELLO
-            && !s->renegotiate && TLS1_get_version(s) > TLS1_VERSION)
+                && !s->renegotiate
+                && TLS1_get_version(s) > TLS1_VERSION
+                && s->hello_retry_request == SSL_HRR_NONE)
             version = TLS1_VERSION;
 
         maxcomplen = pipelens[j];

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -118,7 +118,7 @@ static int watchccs_write(BIO *bio, const char *in, int inl)
                 return 0;
             if (msgtype == SSL3_MT_CLIENT_HELLO) {
                 chseen++;
-                expectedrecvers = TLS1_VERSION;
+
                 /*
                  * Skip legacy_version (2 bytes) and Random (32 bytes) to read
                  * session_id.
@@ -128,6 +128,8 @@ static int watchccs_write(BIO *bio, const char *in, int inl)
                     return 0;
 
                 if (chseen == 1) {
+                    expectedrecvers = TLS1_VERSION;
+
                     /* Save the session id for later */
                     chsessidlen = PACKET_remaining(&sessionid);
                     if (!PACKET_copy_bytes(&sessionid, chsessid, chsessidlen))


### PR DESCRIPTION
According to TLSv1.3 draft-24 the record version for ClientHello2 should
be TLS1.2, and not TLS1.0 as it is now.

This bring us into line with TLSv1.3 draft-24. I have not up lifted the negotiated version to be draft-24 (it stays at draft-23). This is because this change should not have any interoperability impacts. Therefore unless other implementations uplift to negotiating the draft-24 version, we are better off sticking at draft-23.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
