### PR TITLE
AIX: make sure that the arflags value includes the command letter (r)

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1232,7 +1232,7 @@ my %targets = (
         shared_target    => "aix-shared",
         shared_ldflag    => "-shared -static-libgcc -Wl,-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X32",
+        arflags          => "-X32 r",
     },
     "aix64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
@@ -1251,7 +1251,7 @@ my %targets = (
         shared_target    => "aix-shared",
         shared_ldflag    => "-shared -static-libgcc -Wl,-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X64",
+        arflags          => "-X64 r",
     },
     "aix-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
@@ -1270,7 +1270,7 @@ my %targets = (
         shared_target    => "aix-shared",
         shared_ldflag    => "-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X 32",
+        arflags          => "-X32 r",
     },
     "aix64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
@@ -1289,7 +1289,7 @@ my %targets = (
         shared_target    => "aix-shared",
         shared_ldflag    => "-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X 64",
+        arflags          => "-X64 r",
     },
 
 # SIEMENS BS2000/OSD: an EBCDIC-based mainframe

--- a/Configurations/README
+++ b/Configurations/README
@@ -95,7 +95,8 @@ In each table entry, the following keys are significant:
                            (NOTE: this is here for future use, it's
                            not implemented yet)
         arflags         => Flags to be used with the library archive
-                           command.
+                           command.  On Unix, this includes the
+                           command letter, 'r' by default.
 
         ranlib          => The library archive indexing command, the
                            default is 'ranlib' it it exists.


### PR DESCRIPTION
In previous OpenSSL versions, this letter was part of the make
variable AR.  However, following the usual convention (read: GNU),
this letter is supposed to be part of ARFLAGS.
