### PR TITLE
Avoid mentioning uninitialised contexts.

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -57,7 +57,7 @@ and should be used instead of the cipher-specific functions.
 
 =item EVP_MD_CTX_new()
 
-Allocates, initializes and returns a digest context.
+Allocates and returns a digest context.
 
 =item EVP_MD_CTX_reset()
 
@@ -75,9 +75,8 @@ Performs digest-specific control actions on context B<ctx>.
 =item EVP_DigestInit_ex()
 
 Sets up digest context B<ctx> to use a digest B<type> from ENGINE B<impl>.
-B<ctx> must be initialized before calling this function. B<type> will typically
-be supplied by a function such as EVP_sha1().  If B<impl> is NULL then the
-default implementation of digest B<type> is used.
+B<type> will typically be supplied by a function such as EVP_sha1().  If
+B<impl> is NULL then the default implementation of digest B<type> is used.
 
 =item EVP_DigestUpdate()
 
@@ -105,13 +104,12 @@ made, but EVP_DigestInit_ex() can be called to initialize a new operation.
 
 Can be used to copy the message digest state from B<in> to B<out>. This is
 useful if large amounts of data are to be hashed which only differ in the last
-few bytes. B<out> must be initialized before calling this function.
+few bytes.
 
 =item EVP_DigestInit()
 
-Behaves in the same way as EVP_DigestInit_ex() except the passed context B<ctx>
-does not have to be initialized, and it always uses the default digest
-implementation.
+Behaves in the same way as EVP_DigestInit_ex() except it always uses the
+default digest implementation.
 
 =item EVP_DigestFinal()
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -190,8 +190,7 @@ series of calls.
 
 EVP_EncryptInit(), EVP_DecryptInit() and EVP_CipherInit() behave in a
 similar way to EVP_EncryptInit_ex(), EVP_DecryptInit_ex() and
-EVP_CipherInit_ex() except the B<ctx> parameter does not need to be
-initialized and they always use the default cipher implementation.
+EVP_CipherInit_ex() except they always use the default cipher implementation.
 
 EVP_EncryptFinal(), EVP_DecryptFinal() and EVP_CipherFinal() are
 identical to EVP_EncryptFinal_ex(), EVP_DecryptFinal_ex() and


### PR DESCRIPTION
All contexts must be initialised because they can only be created using the _new() calls since the structures were hidden.  Remove the outdated mentions of uninitialised and initialised contexts.

- [x] documentation is added or updated

