### PR TITLE
pkeyparam.pod: correct the command description

### DIFF
--- a/doc/man1/pkeyparam.pod
+++ b/doc/man1/pkeyparam.pod
@@ -18,8 +18,8 @@ B<openssl> B<pkeyparam>
 
 =head1 DESCRIPTION
 
-The B<pkey> command processes public or private keys. They can be converted
-between various forms and their components printed out.
+The B<pkeyparam> command processes public key algorithm parameters.
+They can be checked for correctness and their components printed out.
 
 =head1 OPTIONS
 


### PR DESCRIPTION
The description was probably copy&pasted from pkey.pod and forgotten.

