### PR TITLE
Split configuration of TLSv1.3 ciphers from older ciphers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,15 @@
 
  Changes between 1.1.0g and 1.1.1 [xx XXX xxxx]
 
+  *) Separated TLSv1.3 ciphersuite configuration out from TLSv1.2 ciphersuite
+     configuration. TLSv1.3 ciphersuites are not compatible with TLSv1.2 and
+     below. Similarly TLSv1.2 ciphersuites are not compatible with TLSv1.3.
+     In order to avoid issues where legacy TLSv1.2 ciphersuite configuration
+     would otherwise inadvertently disable all TLSv1.3 ciphersuites the
+     configuraton has been separated out. See the ciphers man page or the
+     SSL_CTX_set_ciphersuites() man page for more information.
+     [Matt Caswell]
+
   *) On POSIX (BSD, Linux, ...) systems the ocsp(1) command running
      in responder mode now supports the new "-multi" option, which
      spawns the specified number of child processes to handle OCSP
@@ -35,12 +44,7 @@
 
   *) Support for TLSv1.3 added. Note that users upgrading from an earlier
      version of OpenSSL should review their configuration settings to ensure
-     that they are still appropriate for TLSv1.3. In particular if no TLSv1.3
-     ciphersuites are enabled then OpenSSL will refuse to make a connection
-     unless (1) TLSv1.3 is explicitly disabled or (2) the ciphersuite
-     configuration is updated to include suitable ciphersuites. The DEFAULT
-     ciphersuite configuration does include TLSv1.3 ciphersuites. For further
-     information on this and other related issues please see:
+     that they are still appropriate for TLSv1.3. For further information see:
      https://www.openssl.org/blog/blog/2018/02/08/tlsv1.3/
 
      NOTE: In this pre-release of OpenSSL a draft version of the

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -229,7 +229,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_ALLOW_NO_DHE_KEX, \
         OPT_S_PRIORITIZE_CHACHA, \
         OPT_S_STRICT, OPT_S_SIGALGS, OPT_S_CLIENTSIGALGS, OPT_S_GROUPS, \
-        OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, \
+        OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, OPT_S_CIPHERSUITES, \
         OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, OPT_S_COMP, \
         OPT_S_NO_RENEGOTIATION, OPT_S_NO_MIDDLEBOX, OPT_S__LAST
 
@@ -272,7 +272,8 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
             "Groups to advertise (colon-separated list)" }, \
         {"named_curve", OPT_S_NAMEDCURVE, 's', \
             "Elliptic curve used for ECDHE (server-side only)" }, \
-        {"cipher", OPT_S_CIPHER, 's', "Specify cipher list to be used"}, \
+        {"cipher", OPT_S_CIPHER, 's', "Specify TLSv1.2 and below cipher list to be used"}, \
+        {"ciphersuites", OPT_S_CIPHERSUITES, 's', "Specify TLSv1.3 ciphersuites to be used"}, \
         {"record_padding", OPT_S_RECORD_PADDING, 's', \
             "Block size to pad TLS 1.3 records to."}, \
         {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \
@@ -305,6 +306,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         case OPT_S_CURVES: \
         case OPT_S_NAMEDCURVE: \
         case OPT_S_CIPHER: \
+        case OPT_S_CIPHERSUITES: \
         case OPT_S_RECORD_PADDING: \
         case OPT_S_NO_RENEGOTIATION: \
         case OPT_S_DEBUGBROKE: \

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -986,6 +986,7 @@ SSL_F_ADD_CLIENT_KEY_SHARE_EXT:438:*
 SSL_F_ADD_KEY_SHARE:512:add_key_share
 SSL_F_BYTES_TO_CIPHER_LIST:519:bytes_to_cipher_list
 SSL_F_CHECK_SUITEB_CIPHER_LIST:331:check_suiteb_cipher_list
+SSL_F_CIPHERSUITE_CB:621:ciphersuite_cb
 SSL_F_CONSTRUCT_CA_NAMES:552:construct_ca_names
 SSL_F_CONSTRUCT_KEY_EXCHANGE_TBS:553:construct_key_exchange_tbs
 SSL_F_CREATE_SYNTHETIC_MESSAGE_HASH:539:create_synthetic_message_hash

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -22,6 +22,7 @@ B<openssl> B<ciphers>
 [B<-srp>]
 [B<-stdname>]
 [B<-convert name>]
+[B<-ciphersuites val>]
 [B<cipherlist>]
 
 =head1 DESCRIPTION
@@ -105,10 +106,21 @@ Precede each cipher suite by its standard name.
 
 Convert a standard cipher B<name> to its OpenSSL name.
 
+=item B<-ciphersuites val>
+
+Sets the list of TLSv1.3 ciphersuites. This list will be combined with any
+TLSv1.2 and below ciphersuites that have been configured. The format for this
+list is a simple colon (":") separated list of TLSv1.3 ciphersuite names. By
+default this value is:
+
+"TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+
 =item B<cipherlist>
 
-A cipher list to convert to a cipher preference list. If it is not included
-then the default cipher list will be used. The format is described below.
+A cipher list of TLSv1.2 and below ciphersuites to convert to a cipher
+preference list. This list will be combined with any TLSv1.3 ciphersuites that
+have been configured. If it is not included then the default cipher list will be
+used. The format is described below.
 
 =back
 
@@ -705,11 +717,11 @@ Note: the CBC modes mentioned in this RFC are not supported.
 
 =head2 TLS v1.3 cipher suites
 
- TLS_AES_128_GCM_SHA256                     TLS13-AES-128-GCM-SHA256
- TLS_AES_256_GCM_SHA384                     TLS13-AES-256-GCM-SHA384
- TLS_CHACHA20_POLY1305_SHA256               TLS13-CHACHA20-POLY1305-SHA256
- TLS_AES_128_CCM_SHA256                     TLS13-AES-128-CCM-SHA256
- TLS_AES_128_CCM_8_SHA256                   TLS13-AES-128-CCM-8-SHA256
+ TLS_AES_128_GCM_SHA256                     TLS_AES_128_GCM_SHA256
+ TLS_AES_256_GCM_SHA384                     TLS_AES_256_GCM_SHA384
+ TLS_CHACHA20_POLY1305_SHA256               TLS_CHACHA20_POLY1305_SHA256
+ TLS_AES_128_CCM_SHA256                     TLS_AES_128_CCM_SHA256
+ TLS_AES_128_CCM_8_SHA256                   TLS_AES_128_CCM_8_SHA256
 
 =head2 Older names used by OpenSSL
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -99,6 +99,7 @@ B<openssl> B<s_client>
 [B<-sigalgs sigalglist>]
 [B<-curves curvelist>]
 [B<-cipher cipherlist>]
+[B<-ciphersuites val>]
 [B<-serverpref>]
 [B<-starttls protocol>]
 [B<-xmpphost hostname>]
@@ -505,10 +506,20 @@ ultimately selected by the server. For a list of all curves, use:
 
 =item B<-cipher cipherlist>
 
-This allows the cipher list sent by the client to be modified. Although
-the server determines which cipher suite is used it should take the first
-supported cipher in the list sent by the client. See the B<ciphers>
-command for more information.
+This allows the TLSv1.2 and below cipher list sent by the client to be modified.
+This list will be combined with any TLSv1.3 ciphersuites that have been
+configured. Although the server determines which ciphersuite is used it should
+take the first supported cipher in the list sent by the client. See the
+B<ciphers> command for more information.
+
+=item B<-ciphersuites val>
+
+This allows the TLSv1.3 ciphersuites sent by the client to be modified. This
+list will be combined with any TLSv1.2 and below ciphersuites that have been
+configured. Although the server determines which cipher suite is used it should
+take the first supported cipher in the list sent by the client. See the
+B<ciphers> command for more information. The format for this list is a simple
+colon (":") separated list of TLSv1.3 ciphersuite names.
 
 =item B<-starttls protocol>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -113,6 +113,7 @@ B<openssl> B<s_server>
 [B<-curves val>]
 [B<-named_curve val>]
 [B<-cipher val>]
+[B<-ciphersuites val>]
 [B<-dhparam infile>]
 [B<-record_padding val>]
 [B<-debug_broken_protocol>]
@@ -533,11 +534,22 @@ For a list of all possible curves, use:
 
 =item B<-cipher val>
 
-This allows the cipher list used by the server to be modified.  When
-the client sends a list of supported ciphers the first client cipher
-also included in the server list is used. Because the client specifies
-the preference order, the order of the server cipherlist irrelevant. See
+This allows the list of TLSv1.2 and below ciphersuites used by the server to be
+modified. This list is combined with any TLSv1.3 ciphersuites that have been
+configured. When the client sends a list of supported ciphers the first client
+cipher also included in the server list is used. Because the client specifies
+the preference order, the order of the server cipherlist is irrelevant. See
 the B<ciphers> command for more information.
+
+=item B<-ciphersuites val>
+
+This allows the list of TLSv1.3 ciphersuites used by the server to be modified.
+This list is combined with any TLSv1.2 and below ciphersuites that have been
+configured. When the client sends a list of supported ciphers the first client
+cipher also included in the server list is used. Because the client specifies
+the preference order, the order of the server cipherlist is irrelevant. See
+the B<ciphers> command for more information. The format for this list is a
+simple colon (":") separated list of TLSv1.3 ciphersuite names.
 
 =item B<-dhparam infile>
 

--- a/doc/man1/s_time.pod
+++ b/doc/man1/s_time.pod
@@ -25,6 +25,7 @@ B<openssl> B<s_time>
 [B<-ssl3>]
 [B<-bugs>]
 [B<-cipher cipherlist>]
+[B<-ciphersuites val>]
 
 =head1 DESCRIPTION
 
@@ -128,10 +129,20 @@ option enables various workarounds.
 
 =item B<-cipher cipherlist>
 
-This allows the cipher list sent by the client to be modified. Although
-the server determines which cipher suite is used it should take the first
-supported cipher in the list sent by the client.
-See the L<ciphers(1)> command for more information.
+This allows the TLSv1.2 and below cipher list sent by the client to be modified.
+This list will be combined with any TLSv1.3 ciphersuites that have been
+configured. Although the server determines which cipher suite is used it should
+take the first supported cipher in the list sent by the client. See the
+L<ciphers(1)> command for more information.
+
+=item B<-ciphersuites val>
+
+This allows the TLSv1.3 ciphersuites sent by the client to be modified. This
+list will be combined with any TLSv1.2 and below ciphersuites that have been
+configured. Although the server determines which cipher suite is used it should
+take the first supported cipher in the list sent by the client. See the
+B<ciphers> command for more information. The format for this list is a simple
+colon (":") separated list of TLSv1.3 ciphersuite names.
 
 =item B<-time length>
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -89,9 +89,17 @@ can be either the B<NIST> name (e.g. B<P-256>) or an OpenSSL OID name
 
 =item B<-cipher>
 
-Sets the cipher suite list to B<value>. Note: syntax checking of B<value> is
-currently not performed unless a B<SSL> or B<SSL_CTX> structure is
+Sets the TLSv1.2 and below ciphersuite list to B<value>. This list will be
+combined with any configured TLSv1.3 ciphersuites. Note: syntax checking
+of B<value> is currently not performed unless a B<SSL> or B<SSL_CTX> structure is
 associated with B<cctx>.
+
+=item B<-ciphersuites>
+
+Sets the available ciphersuites for TLSv1.3 to value. This is a simple colon
+(":") separated list of TLSv1.3 ciphersuite names in order of preference. This
+list will be combined any configured TLSv1.2 and below ciphersuites.
+
 
 =item B<-cert>
 
@@ -219,9 +227,16 @@ Note: the command prefix (if set) alters the recognised B<cmd> values.
 
 =item B<CipherString>
 
-Sets the cipher suite list to B<value>. Note: syntax checking of B<value> is
-currently not performed unless an B<SSL> or B<SSL_CTX> structure is
-associated with B<cctx>.
+Sets the ciphersuite list for TLSv1.2 and below to B<value>. This list will be
+combined with any configured TLSv1.3 ciphersuites. Note: syntax
+checking of B<value> is currently not performed unless an B<SSL> or B<SSL_CTX>
+structure is associated with B<cctx>.
+
+=item B<Ciphersuites>
+
+Sets the available ciphersuites for TLSv1.3 to B<value>. This is a simple colon
+(":") separated list of TLSv1.3 ciphersuite names in order of preference. This
+list will be combined any configured TLSv1.2 and below ciphersuites.
 
 =item B<Certificate>
 

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -2,7 +2,11 @@
 
 =head1 NAME
 
-SSL_CTX_set_cipher_list, SSL_set_cipher_list - choose list of available SSL_CIPHERs
+SSL_CTX_set_cipher_list,
+SSL_set_cipher_list,
+SSL_CTX_set_ciphersuites,
+SSL_set_ciphersuites
+- choose list of available SSL_CIPHERs
 
 =head1 SYNOPSIS
 
@@ -11,18 +15,49 @@ SSL_CTX_set_cipher_list, SSL_set_cipher_list - choose list of available SSL_CIPH
  int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
  int SSL_set_cipher_list(SSL *ssl, const char *str);
 
+ int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str);
+ int SSL_set_ciphersuites(SSL *s, const char *str);
+
 =head1 DESCRIPTION
 
-SSL_CTX_set_cipher_list() sets the list of available ciphers for B<ctx>
-using the control string B<str>. The format of the string is described
+SSL_CTX_set_cipher_list() sets the list of available ciphers (TLSv1.2 and below)
+for B<ctx> using the control string B<str>. The format of the string is described
 in L<ciphers(1)>. The list of ciphers is inherited by all
-B<ssl> objects created from B<ctx>.
+B<ssl> objects created from B<ctx>. This function does not impact TLSv1.3
+ciphersuites. Use SSL_CTX_set_ciphersuites() to configure those.
 
-SSL_set_cipher_list() sets the list of ciphers only for B<ssl>.
+SSL_set_cipher_list() sets the list of ciphers (TLSv1.2 and below) only for
+B<ssl>.
+
+SSL_CTX_set_ciphersuites() is used to configure the available TLSv1.3
+ciphersuites for B<ctx>. This is a simple colon (":") separated list of TLSv1.3
+ciphersuite names in order of perference. Valid TLSv1.3 ciphersuite names are:
+
+=over 4
+
+=item TLS_AES_128_GCM_SHA256
+
+=item TLS_AES_256_GCM_SHA384
+
+=item TLS_CHACHA20_POLY1305_SHA256
+
+=item TLS_AES_128_CCM_SHA256
+
+=item TLS_AES_128_CCM_8_SHA256
+
+=back
+
+An empty list is permissible. The default value for the this setting is:
+
+"TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+
+SSL_set_ciphersuites() is the same as SSL_CTX_set_ciphersuites() except it
+configures the ciphersuites for B<ssl>.
 
 =head1 NOTES
 
-The control string B<str> should be universally usable and not depend
+The control string B<str> for SSL_CTX_set_cipher_list() and
+SSL_set_cipher_list() should be universally usable and not depend
 on details of the library configuration (ciphers compiled in). Thus no
 syntax checking takes place. Items that are not recognized, because the
 corresponding ciphers are not compiled in or because they are mistyped,
@@ -54,6 +89,9 @@ and the handshake will fail.
 
 SSL_CTX_set_cipher_list() and SSL_set_cipher_list() return 1 if any cipher
 could be selected and 0 on complete failure.
+
+SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() return 1 if the requested
+ciphersuite list was configured, and 0 otherwise.
 
 =head1 SEE ALSO
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1500,6 +1500,8 @@ void SSL_set_bio(SSL *s, BIO *rbio, BIO *wbio);
 __owur BIO *SSL_get_rbio(const SSL *s);
 __owur BIO *SSL_get_wbio(const SSL *s);
 __owur int SSL_set_cipher_list(SSL *s, const char *str);
+__owur int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str);
+__owur int SSL_set_ciphersuites(SSL *s, const char *str);
 void SSL_set_read_ahead(SSL *s, int yes);
 __owur int SSL_get_verify_mode(const SSL *s);
 __owur int SSL_get_verify_depth(const SSL *s);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -169,8 +169,13 @@ extern "C" {
 /*
  * The following cipher list is used by default. It also is substituted when
  * an application-defined cipher list string starts with 'DEFAULT'.
+ * This applies to ciphersuites for TLSv1.2 and below.
  */
 # define SSL_DEFAULT_CIPHER_LIST "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+/* This is the default set of TLSv1.3 ciphersuites */
+# define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
+                                  "TLS_CHACHA20_POLY1305_SHA256:" \
+                                  "TLS_AES_128_GCM_SHA256"
 /*
  * As of OpenSSL 1.0.0, ssl_create_cipher_list() in ssl/ssl_ciph.c always
  * starts with a reasonable order, and all we have to do for DEFAULT is

--- a/include/openssl/sslerr.h
+++ b/include/openssl/sslerr.h
@@ -23,6 +23,7 @@ int ERR_load_SSL_strings(void);
 # define SSL_F_ADD_KEY_SHARE                              512
 # define SSL_F_BYTES_TO_CIPHER_LIST                       519
 # define SSL_F_CHECK_SUITEB_CIPHER_LIST                   331
+# define SSL_F_CIPHERSUITE_CB                             621
 # define SSL_F_CONSTRUCT_CA_NAMES                         552
 # define SSL_F_CONSTRUCT_KEY_EXCHANGE_TBS                 553
 # define SSL_F_CREATE_SYNTHETIC_MESSAGE_HASH              539

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -1131,18 +1131,6 @@ __owur int SSL_check_chain(SSL *s, X509 *x, EVP_PKEY *pk, STACK_OF(X509) *chain)
 # define TLS1_TXT_RSA_PSK_WITH_ARIA_128_GCM_SHA256         "RSA-PSK-ARIA128-GCM-SHA256"
 # define TLS1_TXT_RSA_PSK_WITH_ARIA_256_GCM_SHA384         "RSA-PSK-ARIA256-GCM-SHA384"
 
-
-/* TLSv1.3 ciphersuites */
-/*
- * TODO(TLS1.3): Review the naming scheme for TLSv1.3 ciphers and also the
- * cipherstring selection process for these ciphers
- */
-# define TLS1_3_TXT_AES_128_GCM_SHA256                     "TLS13-AES-128-GCM-SHA256"
-# define TLS1_3_TXT_AES_256_GCM_SHA384                     "TLS13-AES-256-GCM-SHA384"
-# define TLS1_3_TXT_CHACHA20_POLY1305_SHA256               "TLS13-CHACHA20-POLY1305-SHA256"
-# define TLS1_3_TXT_AES_128_CCM_SHA256                     "TLS13-AES-128-CCM-SHA256"
-# define TLS1_3_TXT_AES_128_CCM_8_SHA256                   "TLS13-AES-128-CCM-8-SHA256"
-
 # define TLS_CT_RSA_SIGN                 1
 # define TLS_CT_DSS_SIGN                 2
 # define TLS_CT_RSA_FIXED_DH             3

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -18,6 +18,7 @@
 #include <openssl/rand.h>
 #include "internal/cryptlib.h"
 
+#define TLS13_NUM_CIPHERS       OSSL_NELEM(tls13_ciphers)
 #define SSL3_NUM_CIPHERS        OSSL_NELEM(ssl3_ciphers)
 #define SSL3_NUM_SCSVS          OSSL_NELEM(ssl3_scsvs)
 
@@ -27,6 +28,90 @@ const unsigned char tls11downgrade[] = {
 };
 const unsigned char tls12downgrade[] = {
     0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01
+};
+
+/* The list of available TLSv1.3 ciphers */
+static SSL_CIPHER tls13_ciphers[] = {
+    {
+        1,
+        TLS1_3_RFC_AES_128_GCM_SHA256,
+        TLS1_3_RFC_AES_128_GCM_SHA256,
+        TLS1_3_CK_AES_128_GCM_SHA256,
+        0, 0,
+        SSL_AES128GCM,
+        SSL_AEAD,
+        TLS1_3_VERSION, TLS1_3_VERSION,
+        SSL_kANY,
+        SSL_aANY,
+        SSL_HIGH,
+        SSL_HANDSHAKE_MAC_SHA256,
+        128,
+        128,
+    }, {
+        1,
+        TLS1_3_RFC_AES_256_GCM_SHA384,
+        TLS1_3_RFC_AES_256_GCM_SHA384,
+        TLS1_3_CK_AES_256_GCM_SHA384,
+        SSL_kANY,
+        SSL_aANY,
+        SSL_AES256GCM,
+        SSL_AEAD,
+        TLS1_3_VERSION, TLS1_3_VERSION,
+        0, 0,
+        SSL_HIGH,
+        SSL_HANDSHAKE_MAC_SHA384,
+        256,
+        256,
+    },
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+    {
+        1,
+        TLS1_3_RFC_CHACHA20_POLY1305_SHA256,
+        TLS1_3_RFC_CHACHA20_POLY1305_SHA256,
+        TLS1_3_CK_CHACHA20_POLY1305_SHA256,
+        SSL_kANY,
+        SSL_aANY,
+        SSL_CHACHA20POLY1305,
+        SSL_AEAD,
+        TLS1_3_VERSION, TLS1_3_VERSION,
+        0, 0,
+        SSL_HIGH,
+        SSL_HANDSHAKE_MAC_SHA256,
+        256,
+        256,
+    },
+#endif
+    {
+        1,
+        TLS1_3_RFC_AES_128_CCM_SHA256,
+        TLS1_3_RFC_AES_128_CCM_SHA256,
+        TLS1_3_CK_AES_128_CCM_SHA256,
+        SSL_kANY,
+        SSL_aANY,
+        SSL_AES128CCM,
+        SSL_AEAD,
+        TLS1_3_VERSION, TLS1_3_VERSION,
+        0, 0,
+        SSL_NOT_DEFAULT | SSL_HIGH,
+        SSL_HANDSHAKE_MAC_SHA256,
+        128,
+        128,
+    }, {
+        1,
+        TLS1_3_RFC_AES_128_CCM_8_SHA256,
+        TLS1_3_RFC_AES_128_CCM_8_SHA256,
+        TLS1_3_CK_AES_128_CCM_8_SHA256,
+        SSL_kANY,
+        SSL_aANY,
+        SSL_AES128CCM8,
+        SSL_AEAD,
+        TLS1_3_VERSION, TLS1_3_VERSION,
+        0, 0,
+        SSL_NOT_DEFAULT | SSL_HIGH,
+        SSL_HANDSHAKE_MAC_SHA256,
+        128,
+        128,
+    }
 };
 
 /*
@@ -857,88 +942,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
      256,
      256,
-     },
-    {
-     1,
-     TLS1_3_TXT_AES_128_GCM_SHA256,
-     TLS1_3_RFC_AES_128_GCM_SHA256,
-     TLS1_3_CK_AES_128_GCM_SHA256,
-     0, 0,
-     SSL_AES128GCM,
-     SSL_AEAD,
-     TLS1_3_VERSION, TLS1_3_VERSION,
-     SSL_kANY,
-     SSL_aANY,
-     SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SHA256,
-     128,
-     128,
-     },
-    {
-     1,
-     TLS1_3_TXT_AES_256_GCM_SHA384,
-     TLS1_3_RFC_AES_256_GCM_SHA384,
-     TLS1_3_CK_AES_256_GCM_SHA384,
-     SSL_kANY,
-     SSL_aANY,
-     SSL_AES256GCM,
-     SSL_AEAD,
-     TLS1_3_VERSION, TLS1_3_VERSION,
-     0, 0,
-     SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SHA384,
-     256,
-     256,
-     },
-#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
-    {
-     1,
-     TLS1_3_TXT_CHACHA20_POLY1305_SHA256,
-     TLS1_3_RFC_CHACHA20_POLY1305_SHA256,
-     TLS1_3_CK_CHACHA20_POLY1305_SHA256,
-     SSL_kANY,
-     SSL_aANY,
-     SSL_CHACHA20POLY1305,
-     SSL_AEAD,
-     TLS1_3_VERSION, TLS1_3_VERSION,
-     0, 0,
-     SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SHA256,
-     256,
-     256,
-     },
-#endif
-    {
-     1,
-     TLS1_3_TXT_AES_128_CCM_SHA256,
-     TLS1_3_RFC_AES_128_CCM_SHA256,
-     TLS1_3_CK_AES_128_CCM_SHA256,
-     SSL_kANY,
-     SSL_aANY,
-     SSL_AES128CCM,
-     SSL_AEAD,
-     TLS1_3_VERSION, TLS1_3_VERSION,
-     0, 0,
-     SSL_NOT_DEFAULT | SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SHA256,
-     128,
-     128,
-     },
-    {
-     1,
-     TLS1_3_TXT_AES_128_CCM_8_SHA256,
-     TLS1_3_RFC_AES_128_CCM_8_SHA256,
-     TLS1_3_CK_AES_128_CCM_8_SHA256,
-     SSL_kANY,
-     SSL_aANY,
-     SSL_AES128CCM8,
-     SSL_AEAD,
-     TLS1_3_VERSION, TLS1_3_VERSION,
-     0, 0,
-     SSL_NOT_DEFAULT | SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SHA256,
-     128,
-     128,
      },
     {
      1,
@@ -3207,6 +3210,8 @@ static int cipher_compare(const void *a, const void *b)
 
 void ssl_sort_cipher_list(void)
 {
+    qsort(tls13_ciphers, TLS13_NUM_CIPHERS, sizeof(tls13_ciphers[0]),
+          cipher_compare);
     qsort(ssl3_ciphers, SSL3_NUM_CIPHERS, sizeof(ssl3_ciphers[0]),
           cipher_compare);
     qsort(ssl3_scsvs, SSL3_NUM_SCSVS, sizeof(ssl3_scsvs[0]), cipher_compare);
@@ -4027,6 +4032,9 @@ const SSL_CIPHER *ssl3_get_cipher_by_id(uint32_t id)
     const SSL_CIPHER *cp;
 
     c.id = id;
+    cp = OBJ_bsearch_ssl_cipher_id(&c, tls13_ciphers, TLS13_NUM_CIPHERS);
+    if (cp != NULL)
+        return cp;
     cp = OBJ_bsearch_ssl_cipher_id(&c, ssl3_ciphers, SSL3_NUM_CIPHERS);
     if (cp != NULL)
         return cp;
@@ -4035,17 +4043,19 @@ const SSL_CIPHER *ssl3_get_cipher_by_id(uint32_t id)
 
 const SSL_CIPHER *ssl3_get_cipher_by_std_name(const char *stdname)
 {
-    SSL_CIPHER *c = NULL;
-    SSL_CIPHER *tbl = ssl3_ciphers;
-    size_t i;
+    SSL_CIPHER *c = NULL, *tbl;
+    SSL_CIPHER *alltabs[] = {tls13_ciphers, ssl3_ciphers};
+    size_t i, j, tblsize[] = {TLS13_NUM_CIPHERS, SSL3_NUM_CIPHERS};
 
     /* this is not efficient, necessary to optimize this? */
-    for (i = 0; i < SSL3_NUM_CIPHERS; i++, tbl++) {
-        if (tbl->stdname == NULL)
-            continue;
-        if (strcmp(stdname, tbl->stdname) == 0) {
-            c = tbl;
-            break;
+    for (j = 0; j < OSSL_NELEM(alltabs); j++) {
+        for (i = 0, tbl = alltabs[j]; i < tblsize[j]; i++, tbl++) {
+            if (tbl->stdname == NULL)
+                continue;
+            if (strcmp(stdname, tbl->stdname) == 0) {
+                c = tbl;
+                break;
+            }
         }
     }
     if (c == NULL) {

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -256,10 +256,22 @@ static int cmd_ECDHParameters(SSL_CONF_CTX *cctx, const char *value)
 static int cmd_CipherString(SSL_CONF_CTX *cctx, const char *value)
 {
     int rv = 1;
+
     if (cctx->ctx)
         rv = SSL_CTX_set_cipher_list(cctx->ctx, value);
     if (cctx->ssl)
         rv = SSL_set_cipher_list(cctx->ssl, value);
+    return rv > 0;
+}
+
+static int cmd_Ciphersuites(SSL_CONF_CTX *cctx, const char *value)
+{
+    int rv = 1;
+
+    if (cctx->ctx)
+        rv = SSL_CTX_set_ciphersuites(cctx->ctx, value);
+    if (cctx->ssl)
+        rv = SSL_set_ciphersuites(cctx->ssl, value);
     return rv > 0;
 }
 
@@ -606,6 +618,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_STRING(ECDHParameters, "named_curve", SSL_CONF_FLAG_SERVER),
 #endif
     SSL_CONF_CMD_STRING(CipherString, "cipher", 0),
+    SSL_CONF_CMD_STRING(Ciphersuites, "ciphersuites", 0),
     SSL_CONF_CMD_STRING(Protocol, NULL, 0),
     SSL_CONF_CMD_STRING(MinProtocol, "min_protocol", 0),
     SSL_CONF_CMD_STRING(MaxProtocol, "max_protocol", 0),

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -20,6 +20,7 @@ static const ERR_STRING_DATA SSL_str_functs[] = {
      "bytes_to_cipher_list"},
     {ERR_PACK(ERR_LIB_SSL, SSL_F_CHECK_SUITEB_CIPHER_LIST, 0),
      "check_suiteb_cipher_list"},
+    {ERR_PACK(ERR_LIB_SSL, SSL_F_CIPHERSUITE_CB, 0), "ciphersuite_cb"},
     {ERR_PACK(ERR_LIB_SSL, SSL_F_CONSTRUCT_CA_NAMES, 0), "construct_ca_names"},
     {ERR_PACK(ERR_LIB_SSL, SSL_F_CONSTRUCT_KEY_EXCHANGE_TBS, 0),
      "construct_key_exchange_tbs"},

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3019,10 +3019,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         goto err;
 #endif
 
-    if (!SSL_CTX_set_ciphersuites(ret,
-            "TLS_AES_256_GCM_SHA384:"
-            "TLS_CHACHA20_POLY1305_SHA256:"
-            "TLS_AES_128_GCM_SHA256"))
+    if (!SSL_CTX_set_ciphersuites(ret, TLS_DEFAULT_CIPHERSUITES))
         goto err;
 
     if (!ssl_create_cipher_list(ret->method,

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -740,6 +740,8 @@ struct ssl_ctx_st {
     STACK_OF(SSL_CIPHER) *cipher_list;
     /* same as above but sorted for lookup */
     STACK_OF(SSL_CIPHER) *cipher_list_by_id;
+    /* TLSv1.3 specific ciphersuites */
+    STACK_OF(SSL_CIPHER) *tls13_ciphersuites;
     struct x509_store_st /* X509_STORE */ *cert_store;
     LHASH_OF(SSL_SESSION) *sessions;
     /*
@@ -1108,6 +1110,8 @@ struct ssl_st {
     /* crypto */
     STACK_OF(SSL_CIPHER) *cipher_list;
     STACK_OF(SSL_CIPHER) *cipher_list_by_id;
+    /* TLSv1.3 specific ciphersuites */
+    STACK_OF(SSL_CIPHER) *tls13_ciphersuites;
     /*
      * These are the ones being used, the ones in SSL_SESSION are the ones to
      * be 'copied' into these ones
@@ -2198,10 +2202,10 @@ __owur int ssl_cipher_id_cmp(const SSL_CIPHER *a, const SSL_CIPHER *b);
 DECLARE_OBJ_BSEARCH_GLOBAL_CMP_FN(SSL_CIPHER, SSL_CIPHER, ssl_cipher_id);
 __owur int ssl_cipher_ptr_id_cmp(const SSL_CIPHER *const *ap,
                                  const SSL_CIPHER *const *bp);
-__owur STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *meth,
-                                                    STACK_OF(SSL_CIPHER) **pref,
-                                                    STACK_OF(SSL_CIPHER)
-                                                    **sorted,
+__owur STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *ssl_method,
+                                                    STACK_OF(SSL_CIPHER) *tls13_ciphersuites,
+                                                    STACK_OF(SSL_CIPHER) **cipher_list,
+                                                    STACK_OF(SSL_CIPHER) **cipher_list_by_id,
                                                     const char *rule_str,
                                                     CERT *c);
 __owur int ssl_cache_cipherlist(SSL *s, PACKET *cipher_suites, int sslv2format);

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -63,6 +63,13 @@ static CIPHERLIST_TEST_FIXTURE *set_up(const char *const test_case_name)
  * are currently broken and should be considered mission impossible in libssl.
  */
 static const uint32_t default_ciphers_in_order[] = {
+#ifndef OPENSSL_NO_TLS1_3
+    TLS1_3_CK_AES_256_GCM_SHA384,
+# if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+    TLS1_3_CK_CHACHA20_POLY1305_SHA256,
+# endif
+    TLS1_3_CK_AES_128_GCM_SHA256,
+#endif
 #ifndef OPENSSL_NO_TLS1_2
 # ifndef OPENSSL_NO_EC
     TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -126,13 +133,6 @@ static const uint32_t default_ciphers_in_order[] = {
 #ifndef OPENSSL_NO_TLS1_2
     TLS1_CK_RSA_WITH_AES_256_GCM_SHA384,
     TLS1_CK_RSA_WITH_AES_128_GCM_SHA256,
-#endif
-#ifndef OPENSSL_NO_TLS1_3
-    TLS1_3_CK_AES_256_GCM_SHA384,
-# if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
-    TLS1_3_CK_CHACHA20_POLY1305_SHA256,
-# endif
-    TLS1_3_CK_AES_128_GCM_SHA256,
 #endif
 #ifndef OPENSSL_NO_TLS1_2
     TLS1_CK_RSA_WITH_AES_256_SHA256,

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -120,7 +120,9 @@ static int test_client_hello(int currtest)
          * not need padding.
          */
         } else if (!TEST_true(SSL_CTX_set_cipher_list(ctx,
-                              "AES128-SHA:TLS13-AES-128-GCM-SHA256"))) {
+                              "AES128-SHA"))
+                   || !TEST_true(SSL_CTX_set_ciphersuites(ctx,
+                                 "TLS_AES_128_GCM_SHA256"))) {
             goto end;
         }
         break;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -97,8 +97,7 @@ static int test_client_hello(int currtest)
          * ClientHello is already going to be quite long. To avoid getting one
          * that is too long for this test we use a restricted ciphersuite list
          */
-        if (!TEST_true(SSL_CTX_set_cipher_list(ctx,
-                                               "TLS13-AES-128-GCM-SHA256")))
+        if (!TEST_true(SSL_CTX_set_cipher_list(ctx, "")))
             goto end;
          /* Fall through */
     case TEST_ADD_PADDING:

--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -38,6 +38,10 @@ static int test_fatalerr(void)
      */
     if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "AES128-SHA"))
             || !TEST_true(SSL_CTX_set_cipher_list(cctx, "AES256-SHA"))
+            || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
+                                                   "TLS_AES_128_GCM_SHA256"))
+            || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
+                                                   "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL,
                           NULL)))
         goto err;

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -116,7 +116,7 @@ SKIP: {
     #        should succeed
     $proxy->clear();
     $proxy->serverflags("-no_tls1_3");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->filter(undef);
     $proxy->start();
     ok(TLSProxy::Message->success, "TLSv1.3 client TLSv1.2 server");
@@ -131,7 +131,7 @@ SKIP: {
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
     $proxy->clientflags("-no_tls1_3");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs");
 
@@ -139,7 +139,7 @@ SKIP: {
     $proxy->clear();
     $testtype = EMPTY_SIG_ALGS_EXT;
     $proxy->clientflags("-no_tls1_3");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->fail, "Empty TLSv1.2 sigalgs");
 
@@ -147,7 +147,7 @@ SKIP: {
     $proxy->clear();
     $testtype = NO_KNOWN_SIG_ALGS;
     $proxy->clientflags("-no_tls1_3");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->fail, "No known TLSv1.3 sigalgs");
 
@@ -156,7 +156,7 @@ SKIP: {
     $proxy->clear();
     $testtype = NO_PSS_SIG_ALGS;
     $proxy->clientflags("-no_tls1_3");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->success, "No PSS TLSv1.2 sigalgs");
 
@@ -164,7 +164,7 @@ SKIP: {
     $proxy->clear();
     $testtype = PSS_ONLY_SIG_ALGS;
     $proxy->serverflags("-no_tls1_3");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->success, "PSS only sigalgs in TLSv1.2");
 
@@ -175,7 +175,7 @@ SKIP: {
     $proxy->clear();
     $testtype = PSS_ONLY_SIG_ALGS;
     $proxy->clientflags("-no_tls1_3 -sigalgs RSA+SHA256");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->fail, "Sigalg we did not send in TLSv1.2");
 
@@ -183,7 +183,7 @@ SKIP: {
     #         matches the certificate should fail in TLSv1.2
     $proxy->clear();
     $proxy->clientflags("-no_tls1_3 -sigalgs ECDSA+SHA256");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA");
     $proxy->filter(undef);
     $proxy->start();
     ok(TLSProxy::Message->fail, "No matching TLSv1.2 sigalgs");
@@ -197,7 +197,7 @@ SKIP: {
                                                "server-ecdsa-cert.pem") .
                         " -key " . srctop_file("test", "certs",
                                                "server-ecdsa-key.pem")),
-    $proxy->ciphers("ECDHE-ECDSA-AES128-SHA:TLS13-AES-128-GCM-SHA256");
+    $proxy->ciphers("ECDHE-ECDSA-AES128-SHA");
     $proxy->start();
     ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs, ECDSA");
 }

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -53,7 +53,7 @@ ok(TLSProxy::Message->fail(), "Server ciphersuite changes");
 #        we end up selecting a different ciphersuite between HRR and the SH
 $proxy->clear();
 $proxy->serverflags("-curves P-256");
-$proxy->ciphers("TLS13-AES-128-GCM-SHA256:TLS13-AES-256-GCM-SHA384");
+$proxy->ciphersuitess("TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384");
 $testtype = CHANGE_CH1_CIPHERSUITE;
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Client ciphersuite changes");
@@ -85,8 +85,7 @@ sub hrr_filter
 
     my $ch1 = ${$proxy->message_list}[0];
 
-    # The server prefers TLS13-AES-256-GCM-SHA384 so it will pick that next
-    # time around
+    # The server will always pick TLS_AES_256_GCM_SHA384
     my @ciphersuites = (TLSProxy::Message::CIPHER_TLS13_AES_128_GCM_SHA256);
     $ch1->ciphersuite_len(2 * scalar @ciphersuites);
     $ch1->ciphersuites(\@ciphersuites);

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -82,10 +82,10 @@ $proxy->clear();
 $proxy->clientflags("-sess_in ".$session);
 $proxy->filter(\&modify_psk_filter);
 $proxy->serverflags("-curves P-256");
-$proxy->cipherc("TLS13-AES-128-GCM-SHA256:TLS13-AES-256-GCM-SHA384");
-$proxy->ciphers("TLS13-AES-256-GCM-SHA384");
+$proxy->ciphersuitesc("TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384");
+$proxy->ciphersuitess("TLS_AES_256_GCM_SHA384");
 #We force an early failure because TLS Proxy doesn't actually support
-#TLS13-AES-256-GCM-SHA384. That doesn't matter for this test though.
+#TLS_AES_256_GCM_SHA384. That doesn't matter for this test though.
 $testtype = ILLEGAL_EXT_SECOND_CH;
 $proxy->start();
 #Check if the PSK is present in the second ClientHello

--- a/test/ssl-tests/02-protocol-version.conf
+++ b/test/ssl-tests/02-protocol-version.conf
@@ -18787,6 +18787,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [676-ciphersuite-sanity-check-client-client]
 CipherString = AES128-SHA
+Ciphersuites = 
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -18806,6 +18807,7 @@ client = 677-ciphersuite-sanity-check-server-client
 [677-ciphersuite-sanity-check-server-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = AES128-SHA
+Ciphersuites = 
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [677-ciphersuite-sanity-check-server-client]

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -137,6 +137,7 @@ sub generate_version_tests {
         "client" => {
             #Offering only <=TLSv1.2 ciphersuites with TLSv1.3 should fail
             "CipherString" => "AES128-SHA",
+            "Ciphersuites" => "",
         },
         "server" => {
             "MaxProtocol" => "TLSv1.2"
@@ -154,6 +155,7 @@ sub generate_version_tests {
         "server" => {
             #Allowing only <=TLSv1.2 ciphersuites with TLSv1.3 should fail
             "CipherString" => "AES128-SHA",
+            "Ciphersuites" => "",
         },
         "test" => {
             "ExpectedResult" => "ServerFail",

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2381,8 +2381,8 @@ static int test_ciphersuite_change(void)
     if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
                                        TLS_client_method(), &sctx,
                                        &cctx, cert, privkey))
-            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
-                                                  "TLS13-AES-128-GCM-SHA256"))
+            || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
+                                                   "TLS_AES_128_GCM_SHA256"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
                                           &clientssl, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -2400,8 +2400,8 @@ static int test_ciphersuite_change(void)
 
 # if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     /* Check we can resume a session with a different SHA-256 ciphersuite */
-    if (!TEST_true(SSL_CTX_set_cipher_list(cctx,
-                                           "TLS13-CHACHA20-POLY1305-SHA256"))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx,
+                                            "TLS_CHACHA20_POLY1305_SHA256"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                              NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
@@ -2423,7 +2423,7 @@ static int test_ciphersuite_change(void)
      * Check attempting to resume a SHA-256 session with no SHA-256 ciphersuites
      * succeeds but does not resume.
      */
-    if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "TLS13-AES-256-GCM-SHA384"))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                              NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
@@ -2441,7 +2441,7 @@ static int test_ciphersuite_change(void)
     serverssl = clientssl = NULL;
 
     /* Create a session based on SHA384 */
-    if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "TLS13-AES-256-GCM-SHA384"))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
                                           &clientssl, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -2455,10 +2455,10 @@ static int test_ciphersuite_change(void)
     SSL_free(clientssl);
     serverssl = clientssl = NULL;
 
-    if (!TEST_true(SSL_CTX_set_cipher_list(cctx,
-                   "TLS13-AES-128-GCM-SHA256:TLS13-AES-256-GCM-SHA384"))
-            || !TEST_true(SSL_CTX_set_cipher_list(sctx,
-                                                  "TLS13-AES-256-GCM-SHA384"))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx,
+                   "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"))
+            || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
+                                                   "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                              NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
@@ -2520,7 +2520,7 @@ static int test_tls13_psk(int idx)
      * We use a ciphersuite with SHA256 to ease testing old style PSK callbacks
      * which will always default to SHA256
      */
-    if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "TLS13-AES-128-GCM-SHA256")))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_128_GCM_SHA256")))
         goto end;
 
     /*

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -202,19 +202,17 @@ static int test_ssl_corrupt(int testidx)
         goto end;
 
     if (!TEST_ptr(ciphers = SSL_CTX_get_ciphers(cctx))
+            || !TEST_true(SSL_CTX_set_ciphersuites(cctx, ""))
             || !TEST_int_eq(sk_SSL_CIPHER_num(ciphers), 1)
             || !TEST_ptr(currcipher = sk_SSL_CIPHER_value(ciphers, 0)))
         goto end;
 
     /*
-     * If we haven't got a TLSv1.3 cipher, then we mustn't attempt to use
-     * TLSv1.3. Version negotiation happens before cipher selection, so we will
-     * get a "no shared cipher" error.
+     * No ciphers we are using are TLSv1.3 compatible so we should not attempt
+     * to negotiate TLSv1.3
      */
-    if (strcmp(SSL_CIPHER_get_version(currcipher), "TLSv1.3") != 0) {
-        if (!TEST_true(SSL_CTX_set_max_proto_version(cctx, TLS1_2_VERSION)))
-            goto end;
-    }
+    if (!TEST_true(SSL_CTX_set_max_proto_version(cctx, TLS1_2_VERSION)))
+        goto end;
 
     if (!TEST_ptr(c_to_s_fbio = BIO_new(bio_f_tls_corrupt_filter())))
         goto end;

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -612,6 +612,7 @@ static int custom_ext_3_srv_add_cb(SSL *s, unsigned int ext_type,
 }
 
 static char *cipher = NULL;
+static char *ciphersuites = NULL;
 static int verbose = 0;
 static int debug = 0;
 
@@ -671,7 +672,8 @@ static void sv_usage(void)
     fprintf(stderr, " -c_cert arg   - Client certificate file\n");
     fprintf(stderr,
             " -c_key arg    - Client key file (default: same as -c_cert)\n");
-    fprintf(stderr, " -cipher arg   - The cipher list\n");
+    fprintf(stderr, " -cipher arg   - The TLSv1.2 and below cipher list\n");
+    fprintf(stderr, " -ciphersuites arg   - The TLSv1.3 ciphersuites\n");
     fprintf(stderr, " -bio_pair     - Use BIO pairs\n");
     fprintf(stderr, " -ipv4         - Use IPv4 connection on localhost\n");
     fprintf(stderr, " -ipv6         - Use IPv6 connection on localhost\n");
@@ -918,7 +920,6 @@ int main(int argc, char *argv[])
 
     verbose = 0;
     debug = 0;
-    cipher = 0;
 
     bio_err = BIO_new_fp(stderr, BIO_NOCLOSE | BIO_FP_TEXT);
 
@@ -1046,6 +1047,10 @@ int main(int argc, char *argv[])
             if (--argc < 1)
                 goto bad;
             cipher = *(++argv);
+        } else if (strcmp(*argv, "-ciphersuites") == 0) {
+            if (--argc < 1)
+                goto bad;
+            ciphersuites = *(++argv);
         } else if (strcmp(*argv, "-CApath") == 0) {
             if (--argc < 1)
                 goto bad;
@@ -1373,6 +1378,14 @@ int main(int argc, char *argv[])
         if (!SSL_CTX_set_cipher_list(c_ctx, cipher)
             || !SSL_CTX_set_cipher_list(s_ctx, cipher)
             || !SSL_CTX_set_cipher_list(s_ctx2, cipher)) {
+            ERR_print_errors(bio_err);
+            goto end;
+        }
+    }
+    if (ciphersuites != NULL) {
+        if (!SSL_CTX_set_ciphersuites(c_ctx, ciphersuites)
+            || !SSL_CTX_set_ciphersuites(s_ctx, ciphersuites)
+            || !SSL_CTX_set_ciphersuites(s_ctx2, ciphersuites)) {
             ERR_print_errors(bio_err);
             goto end;
         }

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -484,3 +484,5 @@ SSL_SESSION_set1_ticket_appdata         484	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_session_ticket_cb           485	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_stateless_cookie_generate_cb 486	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_stateless_cookie_verify_cb  487	1_1_1	EXIST::FUNCTION:
+SSL_CTX_set_ciphersuites                488	1_1_1	EXIST::FUNCTION:
+SSL_set_ciphersuites                    489	1_1_1	EXIST::FUNCTION:

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -58,7 +58,9 @@ sub new
         cert => $cert,
         debug => $debug,
         cipherc => "",
-        ciphers => "AES128-SHA:TLS13-AES-128-GCM-SHA256",
+        ciphersuitesc => "",
+        ciphers => "AES128-SHA",
+        ciphersuitess => "TLS_AES_128_GCM_SHA256",
         flight => 0,
         record_list => [],
         message_list => [],
@@ -135,6 +137,7 @@ sub clearClient
     my $self = shift;
 
     $self->{cipherc} = "";
+    $self->{ciphersuitec} = "";
     $self->{flight} = 0;
     $self->{record_list} = [];
     $self->{message_list} = [];
@@ -153,7 +156,8 @@ sub clear
     my $self = shift;
 
     $self->clearClient;
-    $self->{ciphers} = "AES128-SHA:TLS13-AES-128-GCM-SHA256";
+    $self->{ciphers} = "AES128-SHA";
+    $self->{ciphersuitess} = "TLS_AES_128_GCM_SHA256";
     $self->{serverflags} = "";
     $self->{serverconnects} = 1;
     $self->{serverpid} = 0;
@@ -198,6 +202,9 @@ sub start
         if ($self->ciphers ne "") {
             $execcmd .= " -cipher ".$self->ciphers;
         }
+        if ($self->ciphersuitess ne "") {
+            $execcmd .= " -ciphersuites ".$self->ciphersuitess;
+        }
         if ($self->serverflags ne "") {
             $execcmd .= " ".$self->serverflags;
         }
@@ -233,6 +240,9 @@ sub clientstart
             }
             if ($self->cipherc ne "") {
                 $execcmd .= " -cipher ".$self->cipherc;
+            }
+            if ($self->ciphersuitesc ne "") {
+                $execcmd .= " -ciphersuites ".$self->ciphersuitesc;
             }
             if ($self->clientflags ne "") {
                 $execcmd .= " ".$self->clientflags;
@@ -487,6 +497,14 @@ sub cipherc
     }
     return $self->{cipherc};
 }
+sub ciphersuitesc
+{
+    my $self = shift;
+    if (@_) {
+        $self->{ciphersuitesc} = shift;
+    }
+    return $self->{ciphersuitesc};
+}
 sub ciphers
 {
     my $self = shift;
@@ -494,6 +512,14 @@ sub ciphers
         $self->{ciphers} = shift;
     }
     return $self->{ciphers};
+}
+sub ciphersuitess
+{
+    my $self = shift;
+    if (@_) {
+        $self->{ciphersuitess} = shift;
+    }
+    return $self->{ciphersuitess};
 }
 sub serverflags
 {


### PR DESCRIPTION
With the current mechanism, old cipher strings that used to work in 1.1.0,
may inadvertently disable all TLSv1.3 ciphersuites causing connections to
fail. This is confusing for users.

In reality TLSv1.3 are quite different to older ciphers. They are much
simpler and there are only a small number of them so, arguably, they don't
need the same level of control that the older ciphers have.

This change splits the configuration of TLSv1.3 ciphers from older ones.
By default the TLSv1.3 ciphers are on, so you cannot inadvertently disable
them through your existing config.

Fixes #5359

A few things to note about this (which may or may not be controversial):

- I have taken the opportunity to replace the OpenSSL specific names for the ciphersuites with the RFC standard names. The only reason to have OpenSSL specific ones was to make them a bit more consistent with the rest of the ciphersuite names. Now that they are treated differently anyway that reason seems less compelling (if it ever was).

- This PR also changes the default ordering of the TLSv1.3 ciphersuites. Previously the TLSv1.3 ciphersuites were mixed in with the rest of the ciphersuites in the order "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256". Now they are at the top of the ciphersuites list (on the basis that we would rather use these TLSv1.3 ciphersuites than older ones) and in the order "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384". This is on the basis that AES-256 seems overkill for the default choice (it also has the side benefit that the default hash will now be SHA-256 which is one step towards easing the PSK transition as discussed in #5378). I'm not sure which we would prefer as the top choice out of the AES vs chacha20 ciphersuites. Note this is slightly inconsistent with the default ordering of the older ciphersuites which are sorted by strength (so AES-256 is preferred over AES-128). Since we are handling the two lists differently, I kind of think that is ok.

- I have added new functions `SSL_CTX_set_ciphersuites()`/`SSL_set_ciphersuites()` for configuring the TLSv1.3 specific ciphersuites. There is also a new "Ciphersuites" SSL_CONF parameter, as well as a new "-ciphersuites" command line option for s_server/s_client/ciphers.

- We possibly need `SSL_CTX_get0_ciphersuites()` and `SSL_get0_ciphersuites()` too.

- Under the hood the TLSv1.3 ciphersuites still get added into the same cipher_list as all the others. This is visible to an application if it calls `SSL_get_ciphers()` et al.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
