### PR TITLE
Checks ec_points_format extension size

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2284,8 +2284,13 @@ static int ssl_scan_clienthello_tlsext(SSL *s, unsigned char **p,
 # ifndef OPENSSL_NO_EC
         else if (type == TLSEXT_TYPE_ec_point_formats) {
             unsigned char *sdata = data;
-            int ecpointformatlist_length = *(sdata++);
+            int ecpointformatlist_length;
 
+            if (size == 0) {
+                goto err;
+            }
+
+            ecpointformatlist_length = *(sdata++);
             if (ecpointformatlist_length != size - 1 ||
                 ecpointformatlist_length < 1)
                 goto err;
@@ -2711,8 +2716,14 @@ static int ssl_scan_serverhello_tlsext(SSL *s, unsigned char **p,
 # ifndef OPENSSL_NO_EC
         else if (type == TLSEXT_TYPE_ec_point_formats) {
             unsigned char *sdata = data;
-            int ecpointformatlist_length = *(sdata++);
+            int ecpointformatlist_length;
 
+            if (size == 0) {
+                *al = TLS1_AD_DECODE_ERROR;
+                return 0;
+            }
+
+            ecpointformatlist_length = *(sdata++);
             if (ecpointformatlist_length != size - 1) {
                 *al = TLS1_AD_DECODE_ERROR;
                 return 0;


### PR DESCRIPTION
Before reading first byte as length.

Avoids buffer overread even if this bug has not much consequences :
- not a security issue thanks to BUF_MEM_grow growing the buffer to more 
- whatever the value overread, it cannot be equal to size - 1 (ie -1) 
