### PR TITLE
Sanity check the ticket length before using key name/IV (1.1.0)

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3111,8 +3111,14 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     int slen, mlen, renew_ticket = 0, ret = -1;
     unsigned char tick_hmac[EVP_MAX_MD_SIZE];
     HMAC_CTX *hctx = NULL;
-    EVP_CIPHER_CTX *ctx;
+    EVP_CIPHER_CTX *ctx = NULL;
     SSL_CTX *tctx = s->session_ctx;
+
+    /* Need at least keyname + iv */
+    if (eticklen < TLSEXT_KEYNAME_LENGTH + EVP_MAX_IV_LENGTH) {
+        ret = 2;
+        goto err;
+    }
 
     /* Initialize session ticket encryption and HMAC contexts */
     hctx = HMAC_CTX_new();
@@ -3125,7 +3131,8 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     }
     if (tctx->tlsext_ticket_key_cb) {
         unsigned char *nctick = (unsigned char *)etick;
-        int rv = tctx->tlsext_ticket_key_cb(s, nctick, nctick + 16,
+        int rv = tctx->tlsext_ticket_key_cb(s, nctick,
+                                            nctick + TLSEXT_KEYNAME_LENGTH,
                                             ctx, hctx, 0);
         if (rv < 0)
             goto err;
@@ -3138,7 +3145,7 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     } else {
         /* Check key name matches */
         if (memcmp(etick, tctx->tlsext_tick_key_name,
-                   sizeof(tctx->tlsext_tick_key_name)) != 0) {
+                   TLSEXT_KEYNAME_LENGTH) != 0) {
             ret = 2;
             goto err;
         }
@@ -3147,8 +3154,7 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
                          EVP_sha256(), NULL) <= 0
             || EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL,
                                   tctx->tlsext_tick_aes_key,
-                                  etick + sizeof(tctx->tlsext_tick_key_name)) <=
-            0) {
+                                  etick + TLSEXT_KEYNAME_LENGTH) <= 0) {
             goto err;
         }
     }


### PR DESCRIPTION
This could in theory result in an overread - but due to the over allocation
of the underlying buffer does not represent a security issue.

This is the 1.1.0 version of #5414.