### PR TITLE
test/recipes/80-test_pkcs12.t: handle lack of Win32::API.

### DIFF
--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -41,6 +41,8 @@ if (eval { require Win32::API; 1; }) {
         SetConsoleOutputCP(1253);
         $pass = Encode::encode("cp1253",Encode::decode("utf-8",$pass));
     }
+} elsif ($^O eq "MSWin32") {
+    plan skip_all => "Win32::API unavailable";
 } else {
     # Running MinGW tests transparently under Wine apparently requires
     # UTF-8 locale...


### PR DESCRIPTION
So far check for availability of Win32::API served as implicit check
for $^O being MSWin32. Reportedly it's not safe assumption, and check
for MSWin32 has to be explicit.

- [ ] documentation is added or updated
- [x ] tests are added or updated
