### PR TITLE
Sanity check the ticket length before using key name/IV (1.0.2)

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3505,6 +3505,10 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     EVP_CIPHER_CTX ctx;
     SSL_CTX *tctx = s->initial_ctx;
 
+    /* Need at least keyname + iv */
+    if (eticklen < 16 + EVP_MAX_IV_LENGTH)
+        return 2;
+
     /* Initialize session ticket encryption and HMAC contexts */
     HMAC_CTX_init(&hctx);
     EVP_CIPHER_CTX_init(&ctx);


### PR DESCRIPTION
This could in theory result in an overread - but due to the over allocation
of the underlying buffer does not represent a security issue.

This is the 1.0.2 version of #5414.