### PR TITLE
Improve documentation of behaviour of DEFAULT in the cipherstring.

### DIFF
--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -167,7 +167,8 @@ The following is a list of all permitted cipher strings and their meanings.
 The default cipher list.
 This is determined at compile time and is normally
 B<ALL:!COMPLEMENTOFDEFAULT:!eNULL>.
-When used, this must be the first cipherstring specified.
+When used, this must be the first cipherstring specified and it does not have
+to be separated by B<:> from the rest of the cipherstring.
 
 =item B<COMPLEMENTOFDEFAULT>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Fixes #5420 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
