### PR TITLE
bio_b64.c: prevent base64 filter BIO from decoding out-of-bound data

### DIFF
--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -289,6 +289,14 @@ static int b64_read(BIO *b, char *out, int outl)
                                  (unsigned char *)ctx->tmp, i);
             ctx->tmp_len = 0;
         }
+        /*
+         * If eof or an error was signalled, then the condition
+         * 'ctx->cont <= 0' will prevent b64_read() from reading
+         * more data on subsequent calls. This assignment was
+         * deleted accidentally in commit 5562cfaca4f3.
+         */
+        ctx->cont = i;
+
         ctx->buf_off = 0;
         if (i < 0) {
             ret_code = 0;


### PR DESCRIPTION
Fixes #5405, #1381

The base64 filter BIO reads its input in chunks of B64_BLOCK_SIZE bytes. When processing input in PEM format it can happen in rare cases that

- the trailing PEM marker crosses the boundary of a chunk, and
- the beginning of the following chunk contains valid base64 encoded data.

This happened in issue #5405, where the PEM marker was split into `-----END CER` and `TIFICATE-----` at the end of the first chunk.

The decoding of the first chunk terminated correctly at the '-' character, which is treated as an EOF marker, and b64_read() returned. However, when called the second time, b64_read() read the next chunk and interpreted the string "TIFICATE" as valid base64 encoded data, adding 6 extra bytes `4c 81 48 08 04 c4`.

This patch ~~clears the continuation flag so that b64_read() correctly returns zero on subsequent calls to indicate EOF~~ restores the assignment of the error code to `ctx->cont`, which was deleted accidentally in commit 5562cfa and which prevents `b64_read()` from reading additional data on subsequent calls.

This issue was observed and reported by Annie Yousar.


This is marked WIP, because I still have to think about whether the fix is perfect and introduces no regressions. Also, I intend to add a testcase.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added  (a proper commit message)
- [x] ~~tests are added or updated (a testcase for issue #5405)~~ Did a lot of manual testing.
