### PR TITLE
Use malloc to avoid alignment problems.

### DIFF
--- a/test/asn1_encode_test.c
+++ b/test/asn1_encode_test.c
@@ -709,15 +709,18 @@ static int do_encode_custom(EXPECTED *input,
 static int do_print_item(const TEST_PACKAGE *package)
 {
 #define DATA_BUF_SIZE 256
-    unsigned char buf[DATA_BUF_SIZE];
     const ASN1_ITEM *i = ASN1_ITEM_ptr(package->asn1_type);
-    ASN1_VALUE *o = (ASN1_VALUE *)&buf;
+    ASN1_VALUE *o;
     int ret;
 
     OPENSSL_assert(package->encode_expectations_elem_size <= DATA_BUF_SIZE);
+    if ((o = OPENSSL_malloc(DATA_BUF_SIZE)) == NULL)
+        return 0;
 
-    (void)RAND_bytes(buf, (int)package->encode_expectations_elem_size);
+    (void)RAND_bytes((unsigned char*)o,
+                     (int)package->encode_expectations_elem_size);
     ret = ASN1_item_print(bio_err, o, 0, i, NULL);
+    OPENSSL_free(o);
 
     return ret;
 }


### PR DESCRIPTION
Thanks to Norm Green for reporting this issue.

This PR is based on code @vdukhovni wrote and posted.