### PR TITLE
VMS: Fix curve448 internal test program

### DIFF
--- a/test/curve448_internal_test.c
+++ b/test/curve448_internal_test.c
@@ -10,7 +10,18 @@
 #include <string.h>
 #include <openssl/e_os2.h>
 #include <openssl/evp.h>
+
+#ifdef __VMS
+# pragma names save
+# pragma names as_is,shortened
+#endif
+
 #include "curve448_lcl.h"
+
+#ifdef __VMS
+# pragma names restore
+#endif
+
 #include "testutil.h"
 
 static unsigned int max = 1000;


### PR DESCRIPTION
The internals test programs access header files that aren't guarded by
the public __DECC_INCLUDE_PROLOGUE.H and __DECC_INCLUDE_EPILOGUE.H
files, and therefore have no idea what the naming convention is.
Therefore, we need to specify that explicitely in the internals test
programs, since they aren't built with the same naming convention as
the library they belong with.
