### PR TITLE
Reflect special `DEFAULT` behavior in ciphers(1)

### DIFF
--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -156,18 +156,19 @@ The cipher string B<@SECLEVEL=n> can be used at any point to set the security
 level to B<n>, which should be a number between zero and five, inclusive.
 See L<SSL_CTX_set_security_level> for a description of what each level means.
 
+The cipher list can be prefixed with the B<DEFAULT> keyword, which enables
+the default cipher list as defined below.  Unlike the cipher string,
+this prefix may not be combined with other strings using B<+> character.
+For example, B<DEFAULT+DES> is not a valid cipher string.
+
+The content of the default list is determined at compile time and normally
+corresponds to B<ALL:!COMPLEMENTOFDEFAULT:!eNULL>.
+
 =head1 CIPHER STRINGS
 
 The following is a list of all permitted cipher strings and their meanings.
 
 =over 4
-
-=item B<DEFAULT>
-
-The default cipher list.
-This is determined at compile time and is normally
-B<ALL:!COMPLEMENTOFDEFAULT:!eNULL>.
-When used, this must be the first cipherstring specified.
 
 =item B<COMPLEMENTOFDEFAULT>
 


### PR DESCRIPTION
Actual behavior of DEFAULT is different than currently described.
Rather than actinf as cipher string, DEFAULT cannot be combined using
logical operators, etc.

Fixes #5420.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
