### PR TITLE
Always use adr with __thumb2__

### DIFF
--- a/crypto/aes/asm/aes-armv4.pl
+++ b/crypto/aes/asm/aes-armv4.pl
@@ -203,7 +203,7 @@ AES_encrypt:
 	adr	r3,.
 #endif
 	stmdb   sp!,{r1,r4-r12,lr}
-#ifdef	__APPLE__
+#if defined(__thumb2__) || defined(__APPLE__)
 	adr	$tbl,AES_Te
 #else
 	sub	$tbl,r3,#AES_encrypt-AES_Te	@ Te
@@ -481,7 +481,7 @@ _armv4_AES_set_encrypt_key:
 	mov	lr,r1			@ bits
 	mov	$key,r2			@ key
 
-#ifdef	__APPLE__
+#if defined(__thumb2__) || defined(__APPLE__)
 	adr	$tbl,AES_Te+1024				@ Te4
 #else
 	sub	$tbl,r3,#_armv4_AES_set_encrypt_key-AES_Te-1024	@ Te4
@@ -979,7 +979,7 @@ AES_decrypt:
 	adr	r3,.
 #endif
 	stmdb   sp!,{r1,r4-r12,lr}
-#ifdef	__APPLE__
+#if defined(__thumb2__) || defined(__APPLE__)
 	adr	$tbl,AES_Td
 #else
 	sub	$tbl,r3,#AES_decrypt-AES_Td	@ Td

--- a/crypto/aes/asm/bsaes-armv7.pl
+++ b/crypto/aes/asm/bsaes-armv7.pl
@@ -742,7 +742,7 @@ $code.=<<___;
 _bsaes_decrypt8:
 	adr	$const,.
 	vldmia	$key!, {@XMM[9]}		@ round 0 key
-#ifdef	__APPLE__
+#if defined(__thumb2__) || defined(__APPLE__)
 	adr	$const,.LM0ISR
 #else
 	add	$const,$const,#.LM0ISR-_bsaes_decrypt8
@@ -841,7 +841,7 @@ _bsaes_const:
 _bsaes_encrypt8:
 	adr	$const,.
 	vldmia	$key!, {@XMM[9]}		@ round 0 key
-#ifdef	__APPLE__
+#if defined(__thumb2__) || defined(__APPLE__)
 	adr	$const,.LM0SR
 #else
 	sub	$const,$const,#_bsaes_encrypt8-.LM0SR
@@ -949,7 +949,7 @@ $code.=<<___;
 _bsaes_key_convert:
 	adr	$const,.
 	vld1.8	{@XMM[7]},  [$inp]!		@ load round 0 key
-#ifdef	__APPLE__
+#if defined(__thumb2__) || defined(__APPLE__)
 	adr	$const,.LM0
 #else
 	sub	$const,$const,#_bsaes_key_convert-.LM0


### PR DESCRIPTION
@dot-asm, does this look right to you? I don't know all that much about ARM and the history of assemblers for it, so I am largely piecing together things as I go and probably all kinds of incorrect assumptions.

---

Thumb2 addresses are a bit a mess, depending on whether a label is interpreted as a function pointer value (for use with BX and BLX) or as a program counter value (for use with PC-relative addressing). Clang's integrated assembler mis-assembles this code. See https://crbug.com/124610#c54 for details.

Instead, use the ADR pseudo-instruction which has clear semantics and should be supported by every assembler that handles the OpenSSL Thumb2 code. (Or so I assume; in other files, the ADR vs SUB conditionals are based on `__thumb2__` already. For some reason, this one is based on `__APPLE__`, I'm guessing to deal with an older version of clang assembler.)

It's unclear to me which of clang or binutils is "correct" or if this is even a well-defined notion beyond "whatever binutils does". But I will note that https://github.com/openssl/openssl/pull/4669 suggests binutils has also changed behavior around this before.