### PR TITLE
Build files: when using $(CPP), use the C flags alongside the CPP flags

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -658,9 +658,11 @@ EOF
               die "Generator type for $src unknown: $generator\n";
           }
 
-          my $cppflags = { lib => '$(LIB_CPPFLAGS)',
-                           dso => '$(DSO_CPPFLAGS)',
-                           bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+          my $cppflags = {
+              lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
+              dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
+              bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
+          } -> {$args{intent}};
           my @incs_cmds = includes({ lib => '$(LIB_INCLUDES)',
                                      dso => '$(DSO_INCLUDES)',
                                      bin => '$(BIN_INCLUDES)' } -> {$args{intent}},

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -850,9 +850,9 @@ EOF
           }
 
           my $cppflags = {
-              lib => '$(LIB_CPPFLAGS)',
-              dso => '$(DSO_CPPFLAGS)',
-              bin => '$(BIN_CPPFLAGS)'
+              lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
+              dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
+              bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
           } -> {$args{intent}};
           if (defined($generator)) {
               # If the target is named foo.S in build.info, we want to

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -436,9 +436,11 @@ EOF
           }
 
           my $cppflags = $incs;
-          $cppflags .= { lib => '$(LIB_CPPFLAGS)',
-                         dso => '$(DSO_CPPFLAGS)',
-                         bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+          $cppflags .= {
+              lib => ' $(LIB_CFLAGS) $(LIB_CPPFLAGS)',
+              dso => ' $(DSO_CFLAGS) $(DSO_CPPFLAGS)',
+              bin => ' $(BIN_CFLAGS) $(BIN_CPPFLAGS)'
+          } -> {$args{intent}};
           if (defined($generator)) {
               # If the target is named foo.S in build.info, we want to
               # end up generating foo.s in two steps.


### PR DESCRIPTION
The reason for this is that some of the C flags affect built in macros
that we may depend on.