### PR TITLE
Move OSSLzu to separate file

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -26,33 +26,6 @@
 extern "C" {
 #endif
 
-/*
- * Format specifier for printing size_t. Original conundrum was to
- * get it working with -Wformat [-Werror], which can be considered
- * overzealous, especially in multi-platform context, but it's
- * conscious choice...
- */
-# if defined(_WIN64)
-#  define OSSLzu  "I64u"    /* One would expect _WIN{64|32} cases after
-                             * __STDC_VERSION__, but there are corner
-                             * cases of MinGW compilers that link with
-                             * non-compliant MSVCRT.DLL... */
-# elif defined(_WIN32)
-#  define OSSLzu  "u"
-# elif defined(__VMS)
-#  define OSSLzu  "u"       /* VMS suffers from similar problem as MinGW,
-                             * i.e. C RTL falling behind compiler. Recall
-                             * that sizeof(size_t)==4 even in LP64 case. */
-# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#  define OSSLzu  "zu"
-# elif defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__==4
-#  define OSSLzu  "u"       /* 'lu' should have worked, but when generating
-                             * 32-bit code gcc still complains :-( */
-# else
-#  define OSSLzu  "lu"      /* To see that is works recall what does L
-                             * stand for in ILP32 and LP64 */
-# endif
-
 # ifndef DEVRANDOM
 /*
  * set this to a comma-separated list of 'random' device files to try out. By

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -550,7 +550,7 @@ int ssl3_get_record(SSL *s)
         return -1;
     }
 #ifdef SSL_DEBUG
-    printf("dec %"OSSLzu"\n", rr[0].length);
+    printf("dec %lu\n", (unsigned long)rr[0].length);
     {
         size_t z;
         for (z = 0; z < rr[0].length; z++)


### PR DESCRIPTION
Only one file needed this, so move OSSLzu to separate internal header.
See also #5438.
