### PR TITLE
Fix build problem on Solaris x64.

### DIFF
--- a/crypto/ec/asm/x25519-x86_64.pl
+++ b/crypto/ec/asm/x25519-x86_64.pl
@@ -802,7 +802,6 @@ x25519_fe64_sqr:
 x25519_fe64_mul121666:
 x25519_fe64_add:
 x25519_fe64_sub:
-x25519_fe64_sub:
 x25519_fe64_tobytes:
 	.byte	0x0f,0x0b	# ud2
 ___


### PR DESCRIPTION
Remove the duplicated label.

Fixes #5440 
