### PR TITLE
Fix ca crash (attempt 2)

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1721,6 +1721,20 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         goto end;
     }
 
+    if (row[DB_name][0] == '\0') {
+        /*
+         * An empty subject! We'll use the serial number instead. If
+         * unique_subject is in use then we don't want different entries with
+         * empty subjects matching each other.
+         */
+        OPENSSL_free(row[DB_name]);
+        row[DB_name] = OPENSSL_strdup(row[DB_serial]);
+        if (row[DB_name] == NULL) {
+            BIO_printf(bio_err, "Memory allocation failure\n");
+            goto end;
+        }
+    }
+
     if (db->attributes.unique_subject) {
         OPENSSL_STRING *crow = row;
 
@@ -2034,6 +2048,11 @@ static int do_revoke(X509 *x509, CA_DB *db, REVINFO_TYPE rev_type,
     else
         row[DB_serial] = BN_bn2hex(bn);
     BN_free(bn);
+    if (row[DB_name] != NULL && row[DB_name][0] == '\0') {
+        /* Entries with empty Subjects actually use the serial number instead */
+        OPENSSL_free(row[DB_name]);
+        row[DB_name] = OPENSSL_strdup(row[DB_serial]);
+    }
     if ((row[DB_name] == NULL) || (row[DB_serial] == NULL)) {
         BIO_printf(bio_err, "Memory allocation failure\n");
         goto end;

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -664,10 +664,6 @@ end_of_options:
                 goto end;
             }
         }
-        if (pp[DB_name][0] == '\0') {
-            BIO_printf(bio_err, "entry %d: bad Subject\n", i + 1);
-            goto end;
-        }
     }
     if (verbose) {
         TXT_DB_write(bio_out, db->db);

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1861,11 +1861,11 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
     irow = NULL;
     ok = 1;
  end:
-    if (irow != NULL) {
+    if (ok != 1) {
         for (i = 0; i < DB_NUMBER; i++)
             OPENSSL_free(row[i]);
-        OPENSSL_free(irow);
     }
+    OPENSSL_free(irow);
 
     X509_NAME_free(CAname);
     X509_NAME_free(subject);

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1404,10 +1404,6 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         BIO_printf(bio_err, "The Subject's Distinguished Name is as follows\n");
 
     name = X509_REQ_get_subject_name(req);
-    if (X509_NAME_entry_count(name) == 0) {
-        BIO_printf(bio_err, "Error: The supplied Subject is empty\n");
-        goto end;
-    }
     for (i = 0; i < X509_NAME_entry_count(name); i++) {
         ne = X509_NAME_get_entry(name, i);
         str = X509_NAME_ENTRY_get_data(ne);
@@ -1567,12 +1563,6 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         subject = X509_NAME_dup(name);
         if (subject == NULL)
             goto end;
-    }
-
-    if (X509_NAME_entry_count(subject) == 0) {
-        BIO_printf(bio_err,
-                   "Error: After applying policy the Subject is empty\n");
-        goto end;
     }
 
     if (verbose)

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -469,6 +469,10 @@ versions of OpenSSL.  However, to make CA certificate roll-over easier,
 it's recommended to use the value B<no>, especially if combined with
 the B<-selfsign> command line option.
 
+Note that it is valid in some circumstances for certificates to be created
+without any subject. In the case where there are multiple certificates without
+subjects this does not count as a duplicate. 
+
 =item B<serial>
 
 A text file containing the next serial number to use in hex. Mandatory.


### PR DESCRIPTION
This is another attempt at fixing the issue originally described in #5109. A fix for that was committed as a result of #5114 (#5115 for 1.0.2). Unfortunately that fix prevented empty Subjects from being used completely. As pointed out by @vdukhovni in #5115, an empty Subject is actually permissible in some situations.

This PR reverts the original commits and implements a new fix. The core issue is the name comparison function which cannot handle NULL as an input parameter. This PR updates that function to be able to correctly process that.

Note: that the default database configuration setting is to disallow multiple subjects with the same value. If two certs are issued without a subject then this counts as two with the same value. Therefore to allow this the database should be configured with the "unique_subject = no" setting (see the ca man page for details).

Fixes #5109 

This PR is for master/1.1.0. A separate PR will fix 1.0.2.
