### PR TITLE
appveyor.yml: omit makedepend step.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,9 @@ before_build:
         }
     - ps: >-
         If ($env:Configuration -Match "shared") {
-            $env:SHARED=""
+            $env:SHARED="no-makedepend"
         } Else {
-            $env:SHARED="no-shared"
+            $env:SHARED="no-shared no-makedepend"
         }
     - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
     - call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%


### PR DESCRIPTION
makedepend makes lesser sense in a throw-away build like CI, but
it spares some computational time, because it takes separate
per-file compiler invocation.

Purpose of the exercise is to see how much faster does it get with no-makedepend, no approval is expected.