### PR TITLE
test/ct_test.c: remove dependency on -lm.

### DIFF
--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -8,7 +8,6 @@
  */
 
 #include <ctype.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -297,7 +296,8 @@ static int execute_cert_test(CT_TEST_FIXTURE *fixture)
             for (i = 0; i < sk_SCT_num(scts); ++i) {
                 SCT *sct_i = sk_SCT_value(scts, i);
 
-                if (!TEST_int_eq(SCT_get_source(sct_i), SCT_SOURCE_X509V3_EXTENSION)) {
+                if (!TEST_int_eq(SCT_get_source(sct_i),
+                                 SCT_SOURCE_X509V3_EXTENSION)) {
                     goto end;
                 }
             }
@@ -504,8 +504,8 @@ static int test_default_ct_policy_eval_ctx_time_is_now(void)
                                 1000;
     const time_t time_tolerance = 600;  /* 10 minutes */
 
-    if (!TEST_uint_le((unsigned int)fabs(difftime(time(NULL), default_time)),
-                      (unsigned int)time_tolerance))
+    if (!TEST_time_t_le(abs(difftime(time(NULL), default_time)),
+                        time_tolerance))
         goto end;
 
     success = 1;

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -504,7 +504,7 @@ static int test_default_ct_policy_eval_ctx_time_is_now(void)
                                 1000;
     const time_t time_tolerance = 600;  /* 10 minutes */
 
-    if (!TEST_time_t_le(abs(difftime(time(NULL), default_time)),
+    if (!TEST_time_t_le(abs((int)difftime(time(NULL), default_time)),
                         time_tolerance))
         goto end;
 


### PR DESCRIPTION
fabs is customarily inlined, but it's not, one has to link with -lm.
Since fabs is the only reference, it makes more sense to avoid it.

~I~ It might make sense to backport it to 1.1.0, but it won't cherry-pick.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
