### PR TITLE
mem_sec.c: relax POSIX requirement.

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -22,7 +22,9 @@
 
 /* e_os.h includes unistd.h, which defines _POSIX_VERSION */
 #if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
-    && defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
+    && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L) \
+         || defined(__sun) || defined(__hpux) || defined(__sgi) \
+         || defined(__osf__) )
 # define IMPLEMENTED
 # include <stdlib.h>
 # include <assert.h>


### PR DESCRIPTION
Even though mlock was standardized in POSIX.1-2001, vendors did
implement it prior that point.
