### PR TITLE
rec_layer_s3.c:ssl3_read_bytes: Problems with 2-way shutdown if other side manages to send application data before receiving close notify

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1586,7 +1586,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
         s->rwstate = SSL_NOTHING;
         SSL3_RECORD_set_length(rr, 0);
         SSL3_RECORD_set_read(rr);
-        return 0;
+        goto start;
     }
 
     if (SSL3_RECORD_get_type(rr) == SSL3_RT_CHANGE_CIPHER_SPEC) {


### PR DESCRIPTION
We found a problem. Steps to reproduce:
1) Make TLS 1.x connection via BIOs (not sockets). Use 4 BIOs: ServerOut, ServerIn, ClientOut, ClientIn.
2) Perform handshake, exchange data via BIOs. (ClientOut->ServerIn, ServerOut->ClientIn, ...).
3) Client performs SSL_shutdown (ret:0).
4) Server performs SSL_write with some data.
5) ServerOut -> ClientIn
6) ClientOut -> ServerIn
7) Server:SSL_read (connection closed).
8) ServerOut -> ClientIn
9) Client:SSL_shutdown. Problem! Returns -1 (instead of 1),
SSL_get_error returns SSL_ERROR_SYSCALL.

The problem is that ssl3_read_bytes doesn't handle app_data records correctly when it is
waiting for shutdown acknowledge.

Our patch seem to fix the problem, but we are not sure that it doesn't break anything else.

Thank you!


##### Checklist
