### PR TITLE
Clear some sslapitest global variables after use

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3227,6 +3227,7 @@ static int test_export_key_mat_early(int idx)
         SSL_SESSION_free(sess);
     SSL_SESSION_free(clientpsk);
     SSL_SESSION_free(serverpsk);
+    clientpsk = serverpsk = NULL;
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);


### PR DESCRIPTION
Otherwise we get a use after free if the test order is randomised.

This should fix the current Travis failure on master.

Once approved I plan to push this asap irrespective of the current code freeze.