### PR TITLE
Fix documentation link to reference man3

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -217,8 +217,8 @@ preference to the low level interfaces. This is because the code then becomes
 transparent to the digest used and much more flexible.
 
 New applications should use the SHA-2 (such as L<EVP_sha256(3)>) or the SHA-3
-digest algorithms (such as L<EVP_sha3_512>). The other digest algorithms are
-still in common use.
+digest algorithms (such as L<EVP_sha3_512(3)>). The other digest algorithms
+are still in common use.
 
 For most applications the B<impl> parameter to EVP_DigestInit_ex() will be
 set to NULL to use the default digest implementation.


### PR DESCRIPTION
Was helping someone find their way around the SHA-3 EVP documentation and ran into this link error (stolen from https://www.openssl.org/docs/manmaster/man3/EVP_DigestInit.html):

`<p>New applications should use the SHA-2 (such as <a href="/docs/manmaster/man3/EVP_sha256.html">EVP_sha256(3)</a>) or the SHA-3 digest algorithms (such as <a href="/docs/manmaster/manEVP_sha3_512.html">EVP_sha3_512</a>). The other digest algorithms are still in common use.</p>`

After this change this particular documentation area is generated properly (built from openssl/master locally):

`<p>New applications should use the SHA-2 (such as <a href="../man3/EVP_sha256.html">EVP_sha256(3)</a>) or the SHA-3 digest algorithms (such as <a href="../man3/EVP_sha3_512.html">EVP_sha3_512(3)</a>). The other digest algorithms are still in common use.</p>`
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
- [X] documentation is added or updated
