### PR TITLE
Fixed typo in description of EVP_CIPHER_meth_set_iv_length().

### DIFF
--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -73,7 +73,7 @@ EVP_CIPHER_meth_dup() creates a copy of B<cipher>.
 
 EVP_CIPHER_meth_free() destroys a B<EVP_CIPHER> structure.
 
-EVP_CIPHER_meth_iv_length() sets the length of the IV.
+EVP_CIPHER_meth_set_iv_length() sets the length of the IV.
 This is only needed when the implemented cipher mode requires it.
 
 EVP_CIPHER_meth_set_flags() sets the flags to describe optional


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
