### PR TITLE
PEM_read_bio_PrivateKey.pod: update documentation for PrivateKey write routines

### DIFF
--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -366,12 +366,19 @@ Skeleton pass phrase callback:
 
 =head1 NOTES
 
-The old B<PrivateKey> write routines are retained for compatibility.
-New applications should write private keys using the
-PEM_write_bio_PKCS8PrivateKey() or PEM_write_PKCS8PrivateKey() routines
-because they are more secure (they use an iteration count of 2048 whereas
-the traditional routines use a count of 1) unless compatibility with older
-versions of OpenSSL is important.
+New applications should use the B<PKCS8PrivateKey> write routines
+to write private keys in the PKCS#8 format, unless compatibility
+with really old versions (< 1.0.0) of OpenSSL is important.
+The PKCS#8 format is more secure than the traditional format,
+since its encryption uses an iteration count of 2048 whereas
+the traditional format uses a count of 1.
+
+The B<PrivateKey> write routines are retained for compatibility.
+Since they use the B<PKCS8PrivateKey> routines by default,
+it generally does not make a difference which of the write routines
+you use.
+Only in the following cases (B<TODO>: which cases?) the B<PrivateKey>
+routines fall back to writing the "traditional" format.
 
 The B<PrivateKey> read routines can be used in all applications because
 they handle all formats transparently.


### PR DESCRIPTION

The manual pages for OpenSSL master and OpenSSL 1.0.2 state that the **PrivateKey** write routines should not be used anymore, because they use the traditional key format. 


```
=head1 NOTES

The old B<PrivateKey> write routines are retained for compatibility.
New applications should write private keys using the
PEM_write_bio_PKCS8PrivateKey() or PEM_write_PKCS8PrivateKey() routines
because they are more secure (they use an iteration count of 2048 whereas
the traditional routines use a count of 1) unless compatibility with older
versions of OpenSSL is important.
```
This formulation is identical in master, 1.1.0, and 1.0.2 (although in different locations),

```
openssl-master/doc/man3/PEM_read_bio_PrivateKey.pod
openssl-1.1.0/doc/crypto/PEM_read_bio_PrivateKey.pod
openssl-1.0.2/doc/crypto/pem.pod
```
and is unchanged since the initial revision of the PEM documention a29d78e90bea. However, this information is not accurate anymore as of commit 8125d9f99ceb (Jan 2009), which changed the default write format for private keys to PKCS#8. This commit is contained in all stable branches down to 1.0.0.

#### Questions


- The implementations for master, 1.1.0, and 1.0.2 are practically identical, see below. They all contain a fallback to the traditional format of which I don't understand in which use case it will take place. Can anyone of the experts enlighten me on that question?
- I added labels for master, 1.1.0, and 1.0.2 as indication of my intent to backport. Please let me know whether it makes sense to backport to 1.0.2 or not.


#### master, 1.1.0

```C
int PEM_write_bio_PrivateKey(BIO *bp, EVP_PKEY *x, const EVP_CIPHER *enc,
                             unsigned char *kstr, int klen,
                             pem_password_cb *cb, void *u)
{
    if (x->ameth == NULL || x->ameth->priv_encode != NULL)
        return PEM_write_bio_PKCS8PrivateKey(bp, x, enc,
                                             (char *)kstr, klen, cb, u);
    return PEM_write_bio_PrivateKey_traditional(bp, x, enc, kstr, klen, cb, u);
}
```

#### master, 1.0.2
```C
int PEM_write_bio_PrivateKey(BIO *bp, EVP_PKEY *x, const EVP_CIPHER *enc,
                             unsigned char *kstr, int klen,
                             pem_password_cb *cb, void *u)
{
    char pem_str[80];
    if (!x->ameth || x->ameth->priv_encode)
        return PEM_write_bio_PKCS8PrivateKey(bp, x, enc,
                                             (char *)kstr, klen, cb, u);

    BIO_snprintf(pem_str, 80, "%s PRIVATE KEY", x->ameth->pem_str);
    return PEM_ASN1_write_bio((i2d_of_void *)i2d_PrivateKey,
                              pem_str, bp, x, enc, kstr, klen, cb, u);
}
```
