### PR TITLE
crypto/bio: bio_call_callback()'s processed argument can be null

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -52,7 +52,7 @@ static long bio_call_callback(BIO *b, int oper, const char *argp, size_t len,
 
         argi = (int)len;
 
-        if (inret && (oper & BIO_CB_RETURN)) {
+        if (inret && (oper & BIO_CB_RETURN) && processed != NULL) {
             if (*processed > INT_MAX)
                 return -1;
             inret = *processed;
@@ -62,7 +62,8 @@ static long bio_call_callback(BIO *b, int oper, const char *argp, size_t len,
     ret = b->callback(b, oper, argp, argi, argl, inret);
 
     if (ret >= 0 && (HAS_LEN_OPER(bareoper) || bareoper == BIO_CB_PUTS)) {
-        *processed = (size_t)ret;
+        if (processed != NULL)
+            *processed = (size_t)ret;
         ret = 1;
     }
 


### PR DESCRIPTION
Introduced in commit d07aee2c7a33 ("Create BIO_read_ex() which handles
size_t arguments"). I have a BIO_new(BIO_s_mem()) test case which
segfaults, a file based one works.
Guard the access to `processed' in case it is NULL.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>