### PR TITLE
Add methods to clear out peer certs

### DIFF
--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -5,6 +5,7 @@
 SSL_SESSION_new,
 SSL_SESSION_dup,
 SSL_SESSION_up_ref,
+SSL_SESSION_clear_peer_certificate,
 SSL_SESSION_free - create, free and manage SSL_SESSION structures
 
 =head1 SYNOPSIS
@@ -14,6 +15,7 @@ SSL_SESSION_free - create, free and manage SSL_SESSION structures
  SSL_SESSION *SSL_SESSION_new(void);
  SSL_SESSION *SSL_SESSION_dup(SSL_SESSION *src);
  int SSL_SESSION_up_ref(SSL_SESSION *ses);
+ void SSL_SESSION_clear_peer_certificate(SSL_SESSION *session);
  void SSL_SESSION_free(SSL_SESSION *session);
 
 =head1 DESCRIPTION
@@ -49,6 +51,19 @@ incorrectly became 0, but it is still referenced in the internal
 session cache and the cache list is processed during a
 L<SSL_CTX_flush_sessions(3)> operation.
 
+SSL_SESSION_clear_peer_certificate() frees up the peer certificate and peer
+certificate chain associated with the session, provided it does not reside in
+an internal session cache.  Applications should call this to free up RAM after
+the handshake has occurred.  This must be called with care as it can affect
+subsequent session resumptions, ticket issuance, and renegotiation.  For server
+side sessions, it is advised to call this only if the internal session cache is
+disabled and the server is using ticket based session resumption.  Applications
+managing an external session cache must take care to ensure safety of this call.
+If the application code causes the server to issue new tickets while a
+connection is established or initiate renegotiation, this method should not be
+called. For clients, it is generally safe to call this if the session is not
+cached elsewhere and renegotiation is disabled or never called.
+
 SSL_SESSION_free() must only be called for SSL_SESSION objects, for
 which the reference count was explicitly incremented (e.g.
 by calling SSL_get1_session(), see L<SSL_get_session(3)>)
@@ -74,6 +89,7 @@ L<d2i_SSL_SESSION(3)>
 =head1 HISTORY
 
 SSL_SESSION_dup() was added in OpenSSL 1.1.1.
+SSL_SESSION_clear_peer_certificate() was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1595,6 +1595,7 @@ int SSL_SESSION_print_fp(FILE *fp, const SSL_SESSION *ses);
 int SSL_SESSION_print(BIO *fp, const SSL_SESSION *ses);
 int SSL_SESSION_print_keylog(BIO *bp, const SSL_SESSION *x);
 int SSL_SESSION_up_ref(SSL_SESSION *ses);
+void SSL_SESSION_clear_peer_certificate(SSL_SESSION *ses);
 void SSL_SESSION_free(SSL_SESSION *ses);
 __owur int i2d_SSL_SESSION(SSL_SESSION *in, unsigned char **pp);
 __owur int SSL_set_session(SSL *to, SSL_SESSION *session);
@@ -1610,7 +1611,6 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
 # ifdef HEADER_X509_H
 __owur X509 *SSL_get_peer_certificate(const SSL *s);
 # endif
-
 __owur STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *s);
 
 __owur int SSL_CTX_get_verify_mode(const SSL_CTX *ctx);

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -767,6 +767,21 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck)
     return ret;
 }
 
+void SSL_SESSION_clear_peer_certificate(SSL_SESSION *ss)
+{
+    if (ss == NULL)
+        return;
+
+    CRYPTO_THREAD_write_lock(ss->lock);
+    if ((ss->next == NULL) && (ss->prev == NULL)) {
+        X509_free(ss->peer);
+        ss->peer = NULL;
+        sk_X509_pop_free(ss->peer_chain, X509_free);
+        ss->peer_chain = NULL;
+    }
+    CRYPTO_THREAD_unlock(ss->lock);
+}
+
 void SSL_SESSION_free(SSL_SESSION *ss)
 {
     int i;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -477,3 +477,4 @@ SSL_stateless                           477	1_1_1	EXIST::FUNCTION:
 SSL_verify_client_post_handshake        478	1_1_1	EXIST::FUNCTION:
 SSL_force_post_handshake_auth           479	1_1_1	EXIST::FUNCTION:
 SSL_export_keying_material_early        480	1_1_1	EXIST::FUNCTION:
+SSL_SESSION_clear_peer_certificate      481	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Once an SSL connection is established, applications may want to free up some memory by clearing out peer cert information.  This provides an API to let them free up peer cert information when needed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
