### PR TITLE
Use a nonce for the ctr drbg

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -299,6 +299,9 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
 {
     unsigned char *nonce = NULL, *entropy = NULL;
     size_t noncelen = 0, entropylen = 0;
+    size_t min_entropy = drbg->strength;
+    size_t min_entropylen = drbg->min_entropylen;
+    size_t max_entropylen = drbg->max_entropylen;
 
     if (perslen > drbg->max_perslen) {
         RANDerr(RAND_F_RAND_DRBG_INSTANTIATE,
@@ -321,22 +324,33 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
     }
 
     drbg->state = DRBG_ERROR;
+
+    /*
+     * NIST SP800-90Ar1 section 9.1 says you can combine getting the entropy
+     * and nonce in 1 call by increasing the entropy with 50% and increasing
+     * the minimum length to accomadate the length of the nonce.
+     * We do this in case a nonce is require and get_nonce is NULL.
+     */
+    if (drbg->min_noncelen > 0 && drbg->get_nonce == NULL) {
+        min_entropy += drbg->strength / 2;
+        min_entropylen += drbg->min_noncelen;
+        max_entropylen += drbg->max_noncelen;
+    }
+
     if (drbg->get_entropy != NULL)
-        entropylen = drbg->get_entropy(drbg, &entropy, drbg->strength,
-                                       drbg->min_entropylen,
-                                       drbg->max_entropylen, 0);
-    if (entropylen < drbg->min_entropylen
-        || entropylen > drbg->max_entropylen) {
+        entropylen = drbg->get_entropy(drbg, &entropy, min_entropy,
+                                       min_entropylen, max_entropylen, 0);
+    if (entropylen < min_entropylen
+        || entropylen > max_entropylen) {
         RANDerr(RAND_F_RAND_DRBG_INSTANTIATE, RAND_R_ERROR_RETRIEVING_ENTROPY);
         goto end;
     }
 
-    if (drbg->max_noncelen > 0 && drbg->get_nonce != NULL) {
-        noncelen = drbg->get_nonce(drbg, &nonce, drbg->strength / 2,
-                                   drbg->min_noncelen, drbg->max_noncelen);
+    if (drbg->min_noncelen > 0 && drbg->get_nonce != NULL) {
+            noncelen = drbg->get_nonce(drbg, &nonce, drbg->strength / 2,
+                                       drbg->min_noncelen, drbg->max_noncelen);
         if (noncelen < drbg->min_noncelen || noncelen > drbg->max_noncelen) {
-            RANDerr(RAND_F_RAND_DRBG_INSTANTIATE,
-                    RAND_R_ERROR_RETRIEVING_NONCE);
+            RANDerr(RAND_F_RAND_DRBG_INSTANTIATE, RAND_R_ERROR_RETRIEVING_NONCE);
             goto end;
         }
     }

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -347,8 +347,8 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
     }
 
     if (drbg->min_noncelen > 0 && drbg->get_nonce != NULL) {
-            noncelen = drbg->get_nonce(drbg, &nonce, drbg->strength / 2,
-                                       drbg->min_noncelen, drbg->max_noncelen);
+        noncelen = drbg->get_nonce(drbg, &nonce, drbg->strength / 2,
+                                   drbg->min_noncelen, drbg->max_noncelen);
         if (noncelen < drbg->min_noncelen || noncelen > drbg->max_noncelen) {
             RANDerr(RAND_F_RAND_DRBG_INSTANTIATE, RAND_R_ERROR_RETRIEVING_NONCE);
             goto end;

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -108,6 +108,27 @@ typedef struct rand_drbg_ctr_st {
 
 
 /*
+ * The 'random pool' acts as a dumb container for collecting random
+ * input from various entropy sources. The pool has no knowledge about
+ * whether its randomness is fed into a legacy RAND_METHOD via RAND_add()
+ * or into a new style RAND_DRBG. It is the callers duty to 1) initialize the
+ * random pool, 2) pass it to the polling callbacks, 3) seed the RNG, and
+ * 4) cleanup the random pool again.
+ *
+ * The random pool contains no locking mechanism because its scope and
+ * lifetime is intended to be restricted to a single stack frame.
+ */
+struct rand_pool_st {
+    unsigned char *buffer;  /* points to the beginning of the random pool */
+    size_t len; /* current number of random bytes contained in the pool */
+
+    size_t min_len; /* minimum number of random bytes requested */
+    size_t max_len; /* maximum number of random bytes (allocated buffer size) */
+    size_t entropy; /* current entropy count in bits */
+    size_t requested_entropy; /* requested entropy count in bits */
+};
+
+/*
  * The state of all types of DRBGs, even though we only have CTR mode
  * right now.
  */

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -467,27 +467,6 @@ err:
 }
 
 /*
- * The 'random pool' acts as a dumb container for collecting random
- * input from various entropy sources. The pool has no knowledge about
- * whether its randomness is fed into a legacy RAND_METHOD via RAND_add()
- * or into a new style RAND_DRBG. It is the callers duty to 1) initialize the
- * random pool, 2) pass it to the polling callbacks, 3) seed the RNG, and
- * 4) cleanup the random pool again.
- *
- * The random pool contains no locking mechanism because its scope and
- * lifetime is intended to be restricted to a single stack frame.
- */
-struct rand_pool_st {
-    unsigned char *buffer;  /* points to the beginning of the random pool */
-    size_t len; /* current number of random bytes contained in the pool */
-
-    size_t min_len; /* minimum number of random bytes requested */
-    size_t max_len; /* maximum number of random bytes (allocated buffer size) */
-    size_t entropy; /* current entropy count in bits */
-    size_t requested_entropy; /* requested entropy count in bits */
-};
-
-/*
  * Allocate memory and initialize a new random pool
  */
 

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -901,7 +901,7 @@ static void cleanup_pool_entropy(RAND_DRBG *drbg, unsigned char *out, size_t out
  * Test that instantiating works when OS entropy is not available and that
  * RAND_add() is enough to reseed it.
  */
-static int test_rand_add()
+static int test_rand_add(void)
 {
     RAND_DRBG *master = RAND_DRBG_get0_master();
     RAND_DRBG_get_entropy_fn old_get_entropy = master->get_entropy;

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -869,7 +869,7 @@ static int test_multi_thread(void)
  * This function is only returns the entropy already added with RAND_add(),
  * and does not get entropy from the OS.
  */
-static size_t rand_add_entropy(RAND_DRBG *drbg,
+static size_t get_pool_entropy(RAND_DRBG *drbg,
                                unsigned char **pout,
                                int entropy, size_t min_len, size_t max_len,
                                int prediction_resistance)
@@ -885,7 +885,7 @@ static size_t rand_add_entropy(RAND_DRBG *drbg,
     return drbg->pool->len;
 }
 
-static void rand_add_clean_entropy(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
+static void cleanup_pool_entropy(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
 {
     OPENSSL_secure_clear_free(drbg->pool->buffer, drbg->pool->max_len);
     OPENSSL_free(drbg->pool);
@@ -904,8 +904,8 @@ static int test_rand_add()
     int rv = 0;
     unsigned char rand_add_buf[256];
 
-    master->get_entropy = rand_add_entropy;
-    master->cleanup_entropy = rand_add_clean_entropy;
+    master->get_entropy = get_pool_entropy;
+    master->cleanup_entropy = cleanup_pool_entropy;
     master->reseed_counter++;
     RAND_DRBG_uninstantiate(master);
     memset(rand_add_buf, 0xCD, sizeof(rand_add_buf));

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -866,8 +866,10 @@ static int test_multi_thread(void)
 #endif
 
 /*
- * This function is only returns the entropy already added with RAND_add(),
+ * This function only returns the entropy already added with RAND_add(),
  * and does not get entropy from the OS.
+ *
+ * Returns 0 on failure and the size of the buffer on success.
  */
 static size_t get_pool_entropy(RAND_DRBG *drbg,
                                unsigned char **pout,
@@ -885,6 +887,9 @@ static size_t get_pool_entropy(RAND_DRBG *drbg,
     return drbg->pool->len;
 }
 
+/*
+ * Clean up the entropy that get_pool_entropy() returned.
+ */
 static void cleanup_pool_entropy(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
 {
     OPENSSL_secure_clear_free(drbg->pool->buffer, drbg->pool->max_len);


### PR DESCRIPTION
The ctr drbg with df requires the use of a nonce. An alternative is that we increase min_entropy with the min_nonce value and set min_nonce and max_nonce to 0.