### PR TITLE
bnrand_range: Always call bnrand() with the correct flag

### DIFF
--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -112,7 +112,7 @@ int BN_priv_rand(BIGNUM *rnd, int bits, int top, int bottom)
 /* random number r:  0 <= r < range */
 static int bnrand_range(BNRAND_FLAG flag, BIGNUM *r, const BIGNUM *range)
 {
-    int b, n;
+    int n;
     int count = 100;
 
     if (range->neg || BN_is_zero(range)) {
@@ -132,11 +132,9 @@ static int bnrand_range(BNRAND_FLAG flag, BIGNUM *r, const BIGNUM *range)
          * than range
          */
         do {
-            b = flag == NORMAL
-                ? BN_rand(r, n + 1, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY)
-                : BN_priv_rand(r, n + 1, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY);
-            if (!b)
+            if (!bnrand(flag, r, n + 1, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
                 return 0;
+
             /*
              * If r < 3*range, use r := r MOD range (which is either r, r -
              * range, or r - 2*range). Otherwise, iterate once more. Since
@@ -161,7 +159,7 @@ static int bnrand_range(BNRAND_FLAG flag, BIGNUM *r, const BIGNUM *range)
     } else {
         do {
             /* range = 11..._2  or  range = 101..._2 */
-            if (!BN_rand(r, n, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
+            if (!bnrand(flag, r, n, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
                 return 0;
 
             if (!--count) {


### PR DESCRIPTION
It was calling the BN_rand() when it should have call BN_priv_rand()

I at least assume that it should always call bnrand()