### PR TITLE
MacOS and iOS fixups.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1647,6 +1647,7 @@ my %targets = (
         inherit_from     => [ "darwin-common", asm("ppc32_asm") ],
         cflags           => add("-arch ppc -std=gnu9x -Wa,-force_cpusubtype_ALL"),
         cppflags         => add("-DB_ENDIAN"),
+        shared_cflag     => add("-fno-common"),
         perlasm_scheme   => "osx32",
     },
     "darwin64-ppc-cc" => {

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -191,7 +191,7 @@ void OPENSSL_cpuid_setup(void)
             _armv8_sha256_probe();
             OPENSSL_armcap_P |= ARMV8_SHA256;
         }
-# ifdef __aarch64__
+# if defined(__aarch64__) && !defined(__APPLE__)
         if (sigsetjmp(ill_jmp, 1) == 0) {
             _armv8_sha512_probe();
             OPENSSL_armcap_P |= ARMV8_SHA512;


### PR DESCRIPTION
1.1.0 label applies only to first commit, the -fno-common one.