### PR TITLE
Remove OPENSSL_USE_NODELETE guards in shlibloadtest

### DIFF
--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -52,12 +52,10 @@ static int shlib_sym(SHLIB lib, const char *symname, SHLIB_SYM *sym)
     return *sym != NULL;
 }
 
-# ifdef OPENSSL_USE_NODELETE
 static int shlib_close(SHLIB lib)
 {
     return dlclose(lib) != 0 ? 0 : 1;
 }
-# endif
 #endif
 
 #ifdef DSO_WIN32
@@ -81,12 +79,10 @@ static int shlib_sym(SHLIB lib, const char *symname, SHLIB_SYM *sym)
     return *sym != NULL;
 }
 
-# ifdef OPENSSL_USE_NODELETE
 static int shlib_close(SHLIB lib)
 {
     return FreeLibrary(lib) == 0 ? 0 : 1;
 }
-# endif
 #endif
 
 
@@ -149,7 +145,6 @@ static int test_lib(void)
     if (!TEST_int_eq(myOpenSSL_version_num(), OPENSSL_VERSION_NUMBER))
         goto end;
 
-#ifdef OPENSSL_USE_NODELETE
     switch (test_type) {
     case JUST_CRYPTO:
         if (!TEST_true(shlib_close(cryptolib)))
@@ -166,7 +161,6 @@ static int test_lib(void)
             goto end;
         break;
     }
-#endif
 
     result = 1;
 end:


### PR DESCRIPTION
PR #3399 converted shlibloadtest to the new test framework. It also
seemed to add some `OPENSSL_USE_NODELETE` guards to the library
unloading part of the test. This part was added in a commit with this
description:

    Review feedback; use single main, #ifdef ADD_TEST

    Suppose OPENSSL_USE_NODELETE (via Nick Reilly)

Strangely though there doesn't seem to be any relevant review feedback
in that PR that could justify the addition of those guards. The guards
do not appear in 1.1.0.

Having the guards changes the nature of the test, so that we only test
library unloading on platforms where OPENSSL_USE_NODELETE is set (Linux
and Windows). I can't think of any good reason for this and as it doesn't
seem to be necessary in 1.1.0 so I think we should remove them.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
