### PR TITLE
Document EC_POINT_get_affine_coordinates_*.

### DIFF
--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -40,7 +40,7 @@ int ecdh_simple_compute_key(unsigned char **pout, size_t *poutlen,
 {
     BN_CTX *ctx;
     EC_POINT *tmp = NULL;
-    BIGNUM *x = NULL, *y = NULL;
+    BIGNUM *x = NULL;
     const BIGNUM *priv_key;
     const EC_GROUP *group;
     int ret = 0;
@@ -51,8 +51,7 @@ int ecdh_simple_compute_key(unsigned char **pout, size_t *poutlen,
         goto err;
     BN_CTX_start(ctx);
     x = BN_CTX_get(ctx);
-    y = BN_CTX_get(ctx);
-    if (y == NULL) {
+    if (x == NULL) {
         ECerr(EC_F_ECDH_SIMPLE_COMPUTE_KEY, ERR_R_MALLOC_FAILURE);
         goto err;
     }
@@ -86,14 +85,14 @@ int ecdh_simple_compute_key(unsigned char **pout, size_t *poutlen,
 
     if (EC_METHOD_get_field_type(EC_GROUP_method_of(group)) ==
         NID_X9_62_prime_field) {
-        if (!EC_POINT_get_affine_coordinates_GFp(group, tmp, x, y, ctx)) {
+        if (!EC_POINT_get_affine_coordinates_GFp(group, tmp, x, NULL, ctx)) {
             ECerr(EC_F_ECDH_SIMPLE_COMPUTE_KEY, EC_R_POINT_ARITHMETIC_FAILURE);
             goto err;
         }
     }
 #ifndef OPENSSL_NO_EC2M
     else {
-        if (!EC_POINT_get_affine_coordinates_GF2m(group, tmp, x, y, ctx)) {
+        if (!EC_POINT_get_affine_coordinates_GF2m(group, tmp, x, NULL, ctx)) {
             ECerr(EC_F_ECDH_SIMPLE_COMPUTE_KEY, EC_R_POINT_ARITHMETIC_FAILURE);
             goto err;
         }

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -99,7 +99,10 @@ be at infinity by calling EC_POINT_set_to_infinity().
 The affine co-ordinates for a point describe a point in terms of its x and y
 position. The functions EC_POINT_set_affine_coordinates_GFp() and
 EC_POINT_set_affine_coordinates_GF2m() set the B<x> and B<y> co-ordinates for
-the point B<p> defined over the curve given in B<group>.
+the point B<p> defined over the curve given in B<group>. The functions
+EC_POINT_get_affine_coordinates_GFp() and
+EC_POINT_get_affine_coordinates_GF2m() set B<x> and B<y>, either of which may
+be NULL, to the corresponding coordinates of B<p>.
 
 As well as the affine co-ordinates, a point can alternatively be described in
 terms of its Jacobian projective co-ordinates (for Fp curves only). Jacobian


### PR DESCRIPTION
In particular, x and y may be NULL, as used in ecdsa_ossl.c. Make use of
this in ecdh_ossl.c as well, to save an otherwise unnecessary temporary.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
