### PR TITLE
Make "make variables" config attributes for overridable flags

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -46,16 +46,16 @@ my %targets=(
 	build_scheme	=> [ "unified", "unix" ],
 	build_file	=> "Makefile",
 
-	ar		=> "ar",
-	arflags		=> "r",
-	cc		=> "cc",
-	hashbangperl	=> "/usr/bin/env perl",
-	ranlib		=> sub { which("$config{cross_compile_prefix}ranlib")
+	AR		=> "ar",
+	ARFLAGS		=> "r",
+	CC		=> "cc",
+	HASHBANGPERL	=> "/usr/bin/env perl",
+	RANLIB		=> sub { which("$config{cross_compile_prefix}ranlib")
                                      ? "ranlib" : "" },
-	rc		=> "windres",
+	RC		=> "windres",
 
 	#### THESE WILL BE ENABLED IN OpenSSL 1.2
-	#hashbangperl	=> "PERL", # Only Unix actually cares
+	#HASHBANGPERL	=> "PERL", # Only Unix actually cares
     },
 
     BASE_common => {
@@ -84,19 +84,19 @@ my %targets=(
         inherit_from    => [ "BASE_common" ],
         template        => 1,
 
-        ar              => "ar",
-        arflags         => "r",
-        cc              => "cc",
+        AR              => "ar",
+        ARFLAGS         => "r",
+        CC              => "cc",
         lflags          =>
             sub { $withargs{zlib_lib} ? "-L".$withargs{zlib_lib} : () },
         ex_libs         =>
             sub { !defined($disabled{zlib})
                   && defined($disabled{"zlib-dynamic"})
                   ? "-lz" : () },
-        hashbangperl    => "/usr/bin/env perl", # Only Unix actually cares
-        ranlib          => sub { which("$config{cross_compile_prefix}ranlib")
+        HASHBANGPERL    => "/usr/bin/env perl", # Only Unix actually cares
+        RANLIB          => sub { which("$config{cross_compile_prefix}ranlib")
                                      ? "ranlib" : "" },
-        rc              => "windres",
+        RC              => "windres",
 
         build_scheme    => [ "unified", "unix" ],
         build_file      => "Makefile",
@@ -116,16 +116,16 @@ my %targets=(
                 return ();
             },
 
-        ld              => "link",
-        lflags          => "/nologo",
-        loutflag        => "/out:",
-        ar              => "lib",
-        arflags         => "/nologo",
+        LD              => "link",
+        LDFLAGS         => "/nologo",
+        ldoutflag       => "/out:",
+        AR              => "lib",
+        ARFLAGS         => "/nologo",
         aroutflag       => "/out:",
-        rc               => "rc",
+        RC               => "rc",
         rcoutflag        => "/fo",
-        mt              => "mt",
-        mtflags         => "-nologo",
+        MT              => "mt",
+        MTFLAGS         => "-nologo",
         mtinflag        => "-manifest ",
         mtoutflag       => "-outputresource:",
 

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -9,7 +9,7 @@ sub vc_win64a_info {
             $vc_win64a_info = { AS        => "nasm",
                                 ASFLAGS   => "-g",
                                 asflags   => "-Ox -f win64 -DNEAR",
-                                asoutflag => "-o" };
+                                asoutflag => "-o " };
         } elsif ($disabled{asm}) {
             $vc_win64a_info = { AS        => "ml64",
                                 ASFLAGS   => "/Zi",
@@ -35,7 +35,7 @@ sub vc_win32_info {
             $vc_win32_info = { AS        => $ver ge $vew ? "nasm" : "nasmw",
                                ASFLAGS   => "",
                                asflags   => "-f win32",
-                               asoutflag => "-o",
+                               asoutflag => "-o ",
                                perlasm_scheme => "win32n" };
         } elsif ($disabled{asm}) {
             $vc_win32_info = { AS        => "ml",
@@ -159,7 +159,7 @@ sub vms_info {
                 $vms_info->{AS} = "ias";
                 $vms_info->{ASFLAGS} = '-d debug';
                 $vms_info->{asflags} = '"-N" vms_upcase';
-                $vms_info->{asoutflag} = "-o";
+                $vms_info->{asoutflag} = "-o ";
                 $vms_info->{perlasm_scheme} = "ias";
             }
         }

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -6,16 +6,19 @@ my $vc_win64a_info = {};
 sub vc_win64a_info {
     unless (%$vc_win64a_info) {
         if (`nasm -v 2>NUL` =~ /NASM version ([0-9]+\.[0-9]+)/ && $1 >= 2.0) {
-            $vc_win64a_info = { as        => "nasm",
-                                asflags   => "-f win64 -DNEAR -Ox -g",
+            $vc_win64a_info = { AS        => "nasm",
+                                ASFLAGS   => "-g",
+                                asflags   => "-Ox -f win64 -DNEAR",
                                 asoutflag => "-o" };
         } elsif ($disabled{asm}) {
-            $vc_win64a_info = { as        => "ml64",
-                                asflags   => "/c /Cp /Cx /Zi",
+            $vc_win64a_info = { AS        => "ml64",
+                                ASFLAGS   => "/Zi",
+                                asflags   => "/c /Cp /Cx",
                                 asoutflag => "/Fo" };
         } else {
             $die->("NASM not found - please read INSTALL and NOTES.WIN for further details\n");
-            $vc_win64a_info = { as        => "{unknown}",
+            $vc_win64a_info = { AS        => "{unknown}",
+                                ASFLAGS   => "",
                                 asflags   => "",
                                 asoutflag => "" };
         }
@@ -29,18 +32,21 @@ sub vc_win32_info {
         my $ver=`nasm -v 2>NUL`;
         my $vew=`nasmw -v 2>NUL`;
         if ($ver ne "" || $vew ne "") {
-            $vc_win32_info = { as        => $ver ge $vew ? "nasm" : "nasmw",
+            $vc_win32_info = { AS        => $ver ge $vew ? "nasm" : "nasmw",
+                               ASFLAGS   => "",
                                asflags   => "-f win32",
                                asoutflag => "-o",
                                perlasm_scheme => "win32n" };
         } elsif ($disabled{asm}) {
-            $vc_win32_info = { as        => "ml",
-                               asflags   => "/nologo /Cp /coff /c /Cx /Zi",
+            $vc_win32_info = { AS        => "ml",
+                               ASFLAGS   => "/nologo /Zi",
+                               asflags   => "/Cp /coff /c /Cx",
                                asoutflag => "/Fo",
                                perlasm_scheme => "win32" };
         } else {
             $die->("NASM not found - please read INSTALL and NOTES.WIN for further details\n");
-            $vc_win32_info = { as        => "{unknown}",
+            $vc_win32_info = { AS        => "{unknown}",
+                               ASFLAGS   => "",
                                asflags   => "",
                                asoutflag => "",
                                perlasm_scheme => "win32" };
@@ -150,8 +156,9 @@ sub vms_info {
         if ($config{target} =~ /-ia64/) {
             `PIPE ias -H 2> NL:`;
             if ($? == 0) {
-                $vms_info->{as} = "ias";
-                $vms_info->{asflags} = '-d debug "-N" vms_upcase';
+                $vms_info->{AS} = "ias";
+                $vms_info->{ASFLAGS} = '-d debug';
+                $vms_info->{asflags} = '"-N" vms_upcase';
                 $vms_info->{asoutflag} = "-o";
                 $vms_info->{perlasm_scheme} = "ias";
             }
@@ -165,24 +172,24 @@ my %targets = (
 #### Basic configs that should work on any 32-bit box
     "gcc" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "gcc",
-        cflags           => picker(debug   => "-O0 -g",
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-O0 -g",
                                    release => "-O3"),
         thread_scheme    => "(unknown)",
         bn_ops           => "BN_LLONG",
     },
     "cc" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => "-O",
+        CC               => "cc",
+        CFLAGS           => "-O",
         thread_scheme    => "(unknown)",
     },
 
 #### VOS Configurations
     "vos-gcc" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "gcc",
-        cflags           => picker(default => "-Wall",
+        CC               => "gcc",
+        CFLAGS           => picker(default => "-Wall",
                                    debug   => "-O0 -g",
                                    release => "-O3"),
         cppflags         => "-D_POSIX_C_SOURCE=200112L -D_BSD -D_VOS_EXTENDED_NAMES -DB_ENDIAN",
@@ -210,11 +217,11 @@ my %targets = (
         # /usr/ccs/bin/as. Failure to comply will result in compile
         # failures [at least] in 32-bit build.
         inherit_from     => [ "solaris-common", asm("x86_elf_asm") ],
-        cc               => "gcc",
-        cflags           => add_before(picker(default => "-Wall",
+        CC               => "gcc",
+        CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
-                                              release => "-O3 -fomit-frame-pointer"),
-                                       threads("-pthread")),
+                                              release => "-O3 -fomit-frame-pointer")),
+        cflags           => add(threads("-pthread")),
         cppflags         => add("-DL_ENDIAN"),
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG",
@@ -231,11 +238,11 @@ my %targets = (
         # to consider using gcc shared build even with vendor compiler:-)
         #                        -- <appro@openssl.org>
         inherit_from     => [ "solaris-common", asm("x86_64_asm") ],
-        cc               => "gcc",
-        cflags           => add_before(picker(default => "-m64 -Wall",
+        CC               => "gcc",
+        CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
-                                              release => "-O3"),
-                                       threads("-pthread")),
+                                              release => "-O3")),
+        cflags           => add_before("-m64", threads("-pthread")),
         cppflags         => add("-DL_ENDIAN"),
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -260,10 +267,10 @@ my %targets = (
     #
     "solaris64-x86_64-cc" => {
         inherit_from     => [ "solaris-common", asm("x86_64_asm") ],
-        cc               => "cc",
-        cflags           => add_before(picker(default => "-xarch=generic64 -xstrconst -Xa",
-                                              debug   => "-g",
+        CC               => "cc",
+        CFLAGS           => add_before(picker(debug   => "-g",
                                               release => "-xO5 -xdepend -xbuiltin")),
+        cflags           => add_before("-xarch=generic64 -xstrconst -Xa"),
         cppflags         => add("-DL_ENDIAN", threads("-D_REENTRANT")),
         thread_scheme    => "pthreads",
         lflags           => add(threads("-mt")),
@@ -278,11 +285,11 @@ my %targets = (
 #### SPARC Solaris with GNU C setups
     "solaris-sparcv7-gcc" => {
         inherit_from     => [ "solaris-common" ],
-        cc               => "gcc",
-        cflags           => add_before(picker(default => "-Wall",
+        CC               => "gcc",
+        CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
-                                              release => "-O3"),
-                                       threads("-pthread")),
+                                              release => "-O3")),
+        cflags           => add(threads("-pthread")),
         cppflags         => add("-DB_ENDIAN -DBN_DIV2W"),
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
@@ -312,10 +319,10 @@ my %targets = (
 # SC5.0 note: Compiler common patch 107357-01 or later is required!
     "solaris-sparcv7-cc" => {
         inherit_from     => [ "solaris-common" ],
-        cc               => "cc",
-        cflags           => add_before(picker(default => "-xstrconst -Xa",
-                                              debug   => "-g",
+        CC               => "cc",
+        CFLAGS           => add_before(picker(debug   => "-g",
                                               release => "-xO5 -xdepend")),
+        cflags           => add_before("-xstrconst -Xa"),
         cppflags         => add("-DB_ENDIAN -DBN_DIV2W",
                                 threads("-D_REENTRANT")),
         lflags           => add(threads("-mt")),
@@ -344,10 +351,10 @@ my %targets = (
 # Only N32 and N64 ABIs are supported.
     "irix-mips3-gcc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(default => "-mabi=n32",
-                                           debug   => "-g -O0",
-                                           release => "-O3")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-g -O0",
+                                   release => "-O3"),
+        cflags           => "-mabi=n32",
         cppflags         => combine("-DB_ENDIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
@@ -361,10 +368,10 @@ my %targets = (
     },
     "irix-mips3-cc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-n32 -mips3 -use_readonly_const -G0 -rdata_shared",
-                                           debug   => "-g -O0",
-                                           release => "-O2")),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "-g -O0",
+                                   release => "-O2"),
+        cflags           => "-n32 -mips3 -use_readonly_const -G0 -rdata_shared",
         cppflags         => combine("-DB_ENDIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
@@ -379,10 +386,10 @@ my %targets = (
     # N64 ABI builds.
     "irix64-mips4-gcc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(default => "-mabi=64 -mips4",
-                                           debug   => "-g -O0",
-                                           release => "-O3")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-g -O0",
+                                   release => "-O3"),
+        cflags           => "-mabi=64 -mips4",
         cppflags         => combine("-DB_ENDIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
         ex_libs          => add(threads("-lpthread")),
@@ -396,13 +403,14 @@ my %targets = (
     },
     "irix64-mips4-cc" => {
         inherit_from     => [ "BASE_unix", asm("mips64_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-64 -mips4 -use_readonly_const -G0 -rdata_shared",
-                                           debug   => "-g -O0",
-                                           release => "-O2")),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "-g -O0",
+                                   release => "-O2"),
+        cppflags         => threads("-D_SGI_MP_SOURCE"),
+        cflags           => "-64 -mips4 -use_readonly_const -G0 -rdata_shared",
         cppflags         => combine("-DB_ENDIAN -DBN_DIV3W",
                                     threads("-D_SGI_MP_SOURCE")),
-        ex_libs          => add(threads("-lpthread")),
+        ex_libs          => threads("-lpthread"),
         bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthreads",
         perlasm_scheme   => "64",
@@ -441,10 +449,10 @@ my %targets = (
 #   thus adequate performance is provided even with PA-RISC 1.1 build.
     "hpux-parisc-gcc" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "gcc",
-        cflags           => combine(picker(debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O3"),
+        cflags           => add(threads("-pthread")),
         cppflags         => "-DB_ENDIAN -DBN_DIV2W",
         ex_libs          => add("-Wl,+s -ldld", threads("-pthread")),
         bn_ops           => "BN_LLONG",
@@ -461,8 +469,8 @@ my %targets = (
     },
     "hpux64-parisc2-gcc" => {
         inherit_from     => [ "BASE_unix", asm("parisc20_64_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(debug   => "-O0 -g",
+        CC               => "gcc",
+        CFLAGS           => combine(picker(debug   => "-O0 -g",
                                            release => "-O3")),
         cppflags         => combine("-DB_ENDIAN", threads("-D_REENTRANT")),
         ex_libs          => add("-ldl"),
@@ -479,10 +487,10 @@ my %targets = (
     # More attempts at unified 10.X and 11.X targets for HP C compiler.
     "hpux-parisc-cc" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "+Optrs_strongly_typed -Ae +ESlit",
-                                           debug   => "+O0 +d -g",
-                                           release => "+O3")),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "+O0 +d -g",
+                                   release => "+O3"),
+        cflags           => "+Optrs_strongly_typed -Ae +ESlit",
         cppflags         => combine("-DB_ENDIAN -DBN_DIV2W -DMD32_XARRAY",
                                     threads("-D_REENTRANT")),
         ex_libs          => add("-Wl,+s -ldld",threads("-lpthread")),
@@ -501,10 +509,10 @@ my %targets = (
     },
     "hpux64-parisc2-cc" => {
         inherit_from     => [ "BASE_unix", asm("parisc20_64_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "+DD64 +Optrs_strongly_typed -Ae +ESlit",
-                                           debug   => "+O0 +d -g",
-                                           release => "+O3")),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "+O0 +d -g",
+                                   release => "+O3") ,
+        cflags           => "+DD64 +Optrs_strongly_typed -Ae +ESlit",
         cppflags         => combine("-DB_ENDIAN -DMD32_XARRAY",
                                     threads("-D_REENTRANT")),
         ex_libs          => add("-ldl",threads("-lpthread")),
@@ -521,10 +529,10 @@ my %targets = (
     # HP/UX IA-64 targets
     "hpux-ia64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-Ae +DD32 +Olit=all -z",
-                                           debug   => "+O0 +d -g",
-                                           release => "+O2")),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "+O0 +d -g",
+                                   release => "+O2"),
+        cflags           => "-Ae +DD32 +Olit=all -z",
         cppflags         => combine("-DB_ENDIAN", threads("-D_REENTRANT")),
         ex_libs          => add("-ldl",threads("-lpthread")),
         bn_ops           => "SIXTY_FOUR_BIT",
@@ -538,10 +546,10 @@ my %targets = (
     },
     "hpux64-ia64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-Ae +DD64 +Olit=all -z",
-                                           debug   => "+O0 +d -g",
-                                           release => "+O3")),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "+O0 +d -g",
+                                   release => "+O3"),
+        cflags           => "-Ae +DD64 +Olit=all -z",
         cppflags         => combine("-DB_ENDIAN", threads("-D_REENTRANT")),
         ex_libs          => add("-ldl", threads("-lpthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -556,10 +564,10 @@ my %targets = (
     # GCC builds...
     "hpux-ia64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O3"),
+        cflags           => add(threads("-pthread")),
         cppflags         => "-DB_ENDIAN",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "SIXTY_FOUR_BIT",
@@ -573,11 +581,10 @@ my %targets = (
     },
     "hpux64-ia64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(default => "-mlp64",
-                                           debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O3"),
+        cflags           => combine("-mlp64", threads("-pthread")),
         cppflags         => "-DB_ENDIAN",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -593,8 +600,8 @@ my %targets = (
 #### HP MPE/iX http://jazz.external.hp.com/src/openssl/
     "MPE/iX-gcc" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "gcc",
-        cflags           => "-O3",
+        CC               => "gcc",
+        CFLAGS           => "-O3",
         cppflags         => "-D_ENDIAN -DBN_DIV2W -D_POSIX_SOURCE -D_SOCKET_SOURCE",
         includes         => add("/SYSLOG/PUB"),
         sys_id           => "MPE",
@@ -610,8 +617,9 @@ my %targets = (
 #### but not anymore...
     "tru64-alpha-gcc" => {
         inherit_from     => [ "BASE_unix", asm("alpha_asm") ],
-        cc               => "gcc",
-        cflags           => combine("-std=c9x -O3", threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => "-O3",
+        cflags           => add("-std=c9x", threads("-pthread")),
         cppflags         => "-D_XOPEN_SOURCE=500 -D_OSF_SOURCE",
         ex_libs          => add("-lrt", threads("-pthread")), # for mlock(2)
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -622,9 +630,10 @@ my %targets = (
     },
     "tru64-alpha-cc" => {
         inherit_from     => [ "BASE_unix", asm("alpha_asm") ],
-        cc               => "cc",
-        cflags           => combine("-std1 -tune host -fast -readonly_strings",
-                                    threads("-pthread")),
+        CC               => "cc",
+        CFLAGS           => "-tune host -fast",
+        cflags           => add("-std1 -readonly_strings",
+                                threads("-pthread")),
         cppflags         => "-D_XOPEN_SOURCE=500 -D_OSF_SOURCE",
         ex_libs          => add("-lrt", threads("-pthread")), # for mlock(2)
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -642,16 +651,16 @@ my %targets = (
 # throw in -D[BL]_ENDIAN, whichever appropriate...
     "linux-generic32" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "gcc",
-        cxx              => "g++",
-        cflags           => combine(picker(default => "-Wall",
-                                           debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-pthread")),
-        cxxflags         => combine(picker(default => "-std=c++11 -Wall",
-                                           debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CXX              => "g++",
+        CFLAGS           => picker(default => "-Wall",
+                                   debug   => "-O0 -g",
+                                   release => "-O3"),
+        CXXFLAGS         => picker(default => "-Wall",
+                                   debug   => "-O0 -g",
+                                   release => "-O3"),
+        cflags           => threads("-pthread"),
+        cxxflags         => combine("-std=c++11", threads("-pthread")),
         cppflags         => "-DOPENSSL_USE_NODELETE",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
@@ -762,14 +771,14 @@ my %targets = (
     #### machines where gcc doesn't understand -m32 and -m64
     "linux-elf" => {
         inherit_from     => [ "linux-generic32", asm("x86_elf_asm") ],
-        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
     },
     "linux-aout" => {
         inherit_from     => [ "BASE_unix", asm("x86_asm") ],
-        cc               => "gcc",
-        cflags           => add(picker(default => "-Wall",
+        CC               => "gcc",
+        CFLAGS           => add(picker(default => "-Wall",
                                        debug   => "-O0 -g",
                                        release => "-O3 -fomit-frame-pointer")),
         cppflags         => add("-DL_ENDIAN"),
@@ -781,17 +790,17 @@ my %targets = (
     #### X86 / X86_64 targets
     "linux-x86" => {
         inherit_from     => [ "linux-generic32", asm("x86_asm") ],
-        cflags           => add(picker(default => "-m32",
-                                       release => "-fomit-frame-pointer")),
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+        cflags           => add("-m32"),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
         perlasm_scheme   => "elf",
     },
     "linux-x86-clang" => {
         inherit_from     => [ "linux-x86" ],
-        cc               => "clang",
-        cxx              => "clang++",
-        cflags           => add("-Wextra"),
+        CC               => "clang",
+        CXX              => "clang++",
+        CFLAGS           => add("-Wextra"),
     },
     "linux-x86_64" => {
         inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
@@ -803,9 +812,9 @@ my %targets = (
     },
     "linux-x86_64-clang" => {
         inherit_from     => [ "linux-x86_64" ],
-        cc               => "clang",
-        cxx              => "clang++",
-        cflags           => add("-Wextra"),
+        CC               => "clang",
+        CXX              => "clang++",
+        CFLAGS           => add("-Wextra"),
     },
     "linux-x32" => {
         inherit_from     => [ "linux-generic32", asm("x86_64_asm") ],
@@ -857,34 +866,35 @@ my %targets = (
     "linux-sparcv8" => {
         inherit_from     => [ "linux-generic32", asm("sparcv8_asm") ],
         cflags           => add("-mcpu=v8"),
-        cppflags         => add("-DB_ENDIAN -DBN_DIV2W"),
+        lib_cppflags     => add("-DB_ENDIAN -DBN_DIV2W"),
     },
     "linux-sparcv9" => {
         # it's a real mess with -mcpu=ultrasparc option under Linux,
         # but -Wa,-Av8plus should do the trick no matter what.
         inherit_from     => [ "linux-generic32", asm("sparcv9_asm") ],
         cflags           => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus"),
-        cppflags         => add("-DB_ENDIAN -DBN_DIV2W"),
+        lib_cppflags     => add("-DB_ENDIAN -DBN_DIV2W"),
     },
     "linux64-sparcv9" => {
         # GCC 3.1 is a requirement
         inherit_from     => [ "linux-generic64", asm("sparcv9_asm") ],
         cflags           => add("-m64 -mcpu=ultrasparc"),
-        cppflags         => add("-DB_ENDIAN"),
+        lib_cppflags     => add("-DB_ENDIAN"),
         bn_ops           => "BN_LLONG RC4_CHAR",
         multilib         => "64",
     },
 
     "linux-alpha-gcc" => {
         inherit_from     => [ "linux-generic64", asm("alpha_asm") ],
-        cppflags         => add("-DL_ENDIAN"),
+        lib_cppflags     => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
     },
     "linux-c64xplus" => {
         inherit_from     => [ "BASE_unix" ],
         # TI_CGT_C6000_7.3.x is a requirement
-        cc               => "cl6x",
-        cflags           => "--linux -ea=.s -eo=.o -mv6400+ -o2 -ox -ms -pden",
+        CC               => "cl6x",
+        CFLAGS           => "-o2 -ox -ms",
+        cflags           => "--linux -ea=.s -eo=.o -mv6400+ -pden",
         cppflags         => combine("-DOPENSSL_SMALL_FOOTPRINT",
                                     threads("-D_REENTRANT")),
         bn_ops           => "BN_LLONG",
@@ -937,7 +947,7 @@ my %targets = (
     },
     "android-x86" => {
         inherit_from     => [ "android", asm("x86_asm") ],
-        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
         bn_ops           => "BN_LLONG",
         perlasm_scheme   => "android",
     },
@@ -1007,11 +1017,11 @@ my %targets = (
         # -D_THREAD_SAFE and sometimes -D_REENTRANT. FreeBSD 5.x
         # expands it as -lc_r, which seems to be sufficient?
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-Wall",
-                                           debug   => "-O0 -g",
-                                           release => "-O3"),
-                                    threads("-pthread")),
+        CC               => "cc",
+        CFLAGS           => picker(default => "-Wall",
+                                   debug   => "-O0 -g",
+                                   release => "-O3"),
+        cflags           => threads("-pthread"),
         cppflags         => threads("-D_THREAD_SAFE -D_REENTRANT"),
         ex_libs          => add(threads("-pthread")),
         enable           => add("devcryptoeng"),
@@ -1029,7 +1039,7 @@ my %targets = (
 
     "BSD-x86" => {
         inherit_from     => [ "BSD-generic32", asm("x86_asm") ],
-        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
         shared_target    => "bsd-shared",
@@ -1069,8 +1079,8 @@ my %targets = (
 
     "bsdi-elf-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
-        cc               => "gcc",
-        cflags           => "-fomit-frame-pointer -O3 -Wall",
+        CC               => "gcc",
+        CFLAGS           => "-fomit-frame-pointer -O3 -Wall",
         cppflags         => "-DPERL5 -DL_ENDIAN",
         ex_libs          => add("-ldl"),
         bn_ops           => "BN_LLONG",
@@ -1083,16 +1093,16 @@ my %targets = (
 
     "nextstep" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => "-O -Wall",
+        CC               => "cc",
+        CFLAGS           => "-O -Wall",
         unistd           => "<libc.h>",
         bn_ops           => "BN_LLONG",
         thread_scheme    => "(unknown)",
     },
     "nextstep3.3" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => "-O3 -Wall",
+        CC               => "cc",
+        CFLAGS           => "-O3 -Wall",
         unistd           => "<libc.h>",
         bn_ops           => "BN_LLONG",
         thread_scheme    => "(unknown)",
@@ -1101,14 +1111,14 @@ my %targets = (
 # QNX
     "qnx4" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => "",
+        CC               => "cc",
+        CFLAGS           => "",
         cppflags         => "-DL_ENDIAN -DTERMIO",
         thread_scheme    => "(unknown)",
     },
     "QNX6" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "gcc",
+        CC               => "gcc",
         ex_libs          => add("-lsocket"),
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
@@ -1117,8 +1127,8 @@ my %targets = (
     },
     "QNX6-i386" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
-        cc               => "gcc",
-        cflags           => "-O2 -Wall",
+        CC               => "gcc",
+        CFLAGS           => "-O2 -Wall",
         cppflags         => "-DL_ENDIAN",
         ex_libs          => add("-lsocket"),
         dso_scheme       => "dlfcn",
@@ -1140,24 +1150,26 @@ my %targets = (
 # UnixWare 2.0x fails destest with -O.
     "unixware-2.0" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => combine(threads("-Kthread")),
+        CC               => "cc",
+        cflags           => threads("-Kthread"),
         cppflags         => "-DFILIO_H -DNO_STRINGS_H",
         ex_libs          => add("-lsocket -lnsl -lresolv -lx"),
         thread_scheme    => "uithreads",
     },
     "unixware-2.1" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => combine("-O", threads("-Kthread")),
+        CC               => "cc",
+        CFLAGS           => "-O",
+        cflags           => threads("-Kthread"),
         cppflags         => "-DFILIO_H",
         ex_libs          => add("-lsocket -lnsl -lresolv -lx"),
         thread_scheme    => "uithreads",
     },
     "unixware-7" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
-        cc               => "cc",
-        cflags           => combine("-O -Kalloca", threads("-Kthread")),
+        CC               => "cc",
+        CFLAGS           => "-O",
+        cflags           => combine("-Kalloca", threads("-Kthread")),
         cppflags         => "-DFILIO_H",
         ex_libs          => add("-lsocket -lnsl"),
         thread_scheme    => "uithreads",
@@ -1170,8 +1182,8 @@ my %targets = (
     },
     "unixware-7-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
-        cc               => "gcc",
-        cflags           => combine("-O3 -fomit-frame-pointer -Wall"),
+        CC               => "gcc",
+        CFLAGS           => "-O3 -fomit-frame-pointer -Wall",
         cppflags         => add("-DL_ENDIAN -DFILIO_H",
                                 threads("-D_REENTRANT")),
         ex_libs          => add("-lsocket -lnsl"),
@@ -1218,10 +1230,10 @@ my %targets = (
     # current value of $OBJECT_MODE.
     "aix-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(debug   => "-O0 -g",
-                                           release => "-O"),
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O"),
+        cflags           => add(threads("-pthread")),
         cppflags         => "-DB_ENDIAN",
         ex_libs          => add(threads("-pthread")),
         sys_id           => "AIX",
@@ -1236,11 +1248,10 @@ my %targets = (
     },
     "aix64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
-        cc               => "gcc",
-        cflags           => combine(picker(default => "-maix64",
-                                           debug   => "-O0 -g",
-                                           release => "-O"),
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O"),
+        cflags           => combine("-maix64", threads("-pthread")),
         cppflags         => "-DB_ENDIAN",
         ex_libs          => add(threads("-pthread")),
         sys_id           => "AIX",
@@ -1255,10 +1266,10 @@ my %targets = (
     },
     "aix-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-q32 -qmaxmem=16384 -qro -qroconst",
-                                           debug   => "-O0 -g",
-                                           release => "-O"),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O"),
+        cflags           => combine("-q32 -qmaxmem=16384 -qro -qroconst",
                                     threads("-qthreaded")),
         cppflags         => combine("-DB_ENDIAN", threads("-D_THREAD_SAFE")),
         sys_id           => "AIX",
@@ -1274,10 +1285,10 @@ my %targets = (
     },
     "aix64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
-        cc               => "cc",
-        cflags           => combine(picker(default => "-q64 -qmaxmem=16384 -qro -qroconst",
-                                           debug   => "-O0 -g",
-                                           release => "-O"),
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O"),
+        cflags           => combine("-q64 -qmaxmem=16384 -qro -qroconst",
                                     threads("-qthreaded")),
         cppflags         => combine("-DB_ENDIAN", threads("-D_THREAD_SAFE")),
         sys_id           => "AIX",
@@ -1295,8 +1306,9 @@ my %targets = (
 # SIEMENS BS2000/OSD: an EBCDIC-based mainframe
     "BS2000-OSD" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "c89",
-        cflags           => "-O -XLLML -XLLMK -XL",
+        CC               => "c89",
+        CFLAGS           => "-O",
+        cflags           => "-XLLML -XLLMK -XL",
         cppflags         => "-DB_ENDIAN -DCHARSET_EBCDIC",
         ex_libs          => add("-lsocket -lnsl"),
         bn_ops           => "THIRTY_TWO_BIT RC4_CHAR",
@@ -1317,9 +1329,12 @@ my %targets = (
     "VC-common" => {
         inherit_from     => [ "BASE_Windows" ],
         template         => 1,
-        cc               => "cl",
-        cpp              => '$(CC) /EP /C',
-        cflags           => "-W3 -wd4090 -Gs0 -GF -Gy -nologo",
+        CC               => "cl",
+        CPP              => '$(CC) /EP /C',
+        CFLAGS           => "-W3 -wd4090 -nologo",
+        LDFLAGS          => add("/debug"),
+        coutflag         => "/Fo",
+        cflags           => '-Gs0 -GF -Gy',
         defines          => add("OPENSSL_SYS_WIN32", "WIN32_LEAN_AND_MEAN",
                                 "L_ENDIAN", "_CRT_SECURE_NO_DEPRECATE",
                                 "_WINSOCK_DEPRECATED_NO_WARNINGS",
@@ -1333,11 +1348,9 @@ my %targets = (
                                       }
                                       return [ @defs ];
                                   }),
-        coutflag         => "/Fo",
         lib_cflags       => add("/Zi /Fdossl_static"),
         dso_cflags       => "/Zi /Fddso",
         bin_cflags       => "/Zi /Fdapp",
-        lflags           => add("/debug"),
         shared_ldflag    => "/dll",
         shared_target    => "win-shared", # meaningless except it gives Configure a hint
         thread_scheme    => "winthreads",
@@ -1347,15 +1360,15 @@ my %targets = (
     "VC-noCE-common" => {
         inherit_from     => [ "VC-common" ],
         template         => 1,
+        CFLAGS           => add(picker(debug   => '/Od',
+                                       release => '/O2')),
         cflags           => add(picker(debug   =>
                                        sub {
-                                           ($disabled{shared} ? "" : "/MDd")
-                                               ." /Od";
+                                           ($disabled{shared} ? "" : "/MDd");
                                        },
                                        release =>
                                        sub {
-                                           ($disabled{shared} ? "" : "/MD")
-                                               ." /O2";
+                                           ($disabled{shared} ? "" : "/MD");
                                        })),
         defines          => add(picker(default => [ "UNICODE", "_UNICODE" ],
                                        debug   => [ "DEBUG", "_DEBUG" ])),
@@ -1396,8 +1409,8 @@ my %targets = (
     "VC-WIN64I" => {
         inherit_from     => [ "VC-WIN64-common", asm("ia64_asm"),
                               sub { $disabled{shared} ? () : "ia64_uplink" } ],
-        as               => "ias",
-        asflags          => "-d debug",
+        AS               => "ias",
+        ASFLAGS          => "-d debug",
         asoutflag        => "-o",
         sys_id           => "WIN64I",
         bn_asm_src       => sub { return undef unless @_;
@@ -1408,9 +1421,10 @@ my %targets = (
     "VC-WIN64A" => {
         inherit_from     => [ "VC-WIN64-common", asm("x86_64_asm"),
                               sub { $disabled{shared} ? () : "x86_64_uplink" } ],
-        as               => sub { vc_win64a_info()->{as} },
-        asflags          => sub { vc_win64a_info()->{asflags} },
+        AS               => sub { vc_win64a_info()->{AS} },
+        ASFLAGS          => sub { vc_win64a_info()->{ASFLAGS} },
         asoutflag        => sub { vc_win64a_info()->{asoutflag} },
+        asflags          => sub { vc_win64a_info()->{asflags} },
         sys_id           => "WIN64A",
         bn_asm_src       => sub { return undef unless @_;
                                   my $r=join(" ",@_); $r=~s|asm/x86_64-gcc|bn_asm|; $r; },
@@ -1422,10 +1436,11 @@ my %targets = (
         # configure with 'perl Configure VC-WIN32 -DUNICODE -D_UNICODE'
         inherit_from     => [ "VC-noCE-common", asm("x86_asm"),
                               sub { $disabled{shared} ? () : "uplink_common" } ],
-        cflags           => add("-WX"),
-        as               => sub { vc_win32_info()->{as} },
-        asflags          => sub { vc_win32_info()->{asflags} },
+        CFLAGS           => add("-WX"),
+        AS               => sub { vc_win32_info()->{AS} },
+        ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
         asoutflag        => sub { vc_win32_info()->{asoutflag} },
+        asflags          => sub { vc_win32_info()->{asflags} },
         ex_libs          => add(sub {
             my @ex_libs = ();
             # WIN32 UNICODE build gets linked with unicows.lib for
@@ -1441,33 +1456,33 @@ my %targets = (
     },
     "VC-CE" => {
         inherit_from     => [ "VC-common" ],
-        as               => "ml",
-        asflags          => "/nologo /Cp /coff /c /Cx /Zi",
+        AS               => "ml",
+        ASFLAGS          => "/nologo",
         asoutflag        => "/Fo",
-        cc               => "cl",
+        asflags          => "/Cp /coff /c /Cx /Zi",
+        CC               => "cl",
+        CFLAGS           => picker(default => '/W3 /WX /nologo',
+                                   debug   => "/Od",
+                                   release => "/O1i"),
+        CPPDEFINES       => picker(debug   => [ "DEBUG", "_DEBUG" ]),
+        LDFLAGS          => add("/nologo /opt:ref"),
         cflags           =>
-            picker(default =>
-                   combine('/W3 /WX /GF /Gy /nologo',
-                           sub { vc_wince_info()->{cflags}; },
-                           sub { `cl 2>&1` =~ /Version ([0-9]+)\./ && $1>=14
-                                     ? ($disabled{shared} ? " /MT" : " /MD")
-                                     : " /MC"; }),
-                   debug   => "/Od",
-                   release => "/O1i"),
+            combine('/GF /Gy',
+                    sub { vc_wince_info()->{cflags}; },
+                    sub { `cl 2>&1` =~ /Version ([0-9]+)\./ && $1>=14
+                              ? ($disabled{shared} ? " /MT" : " /MD")
+                              : " /MC"; }),
         cppflags         => sub { vc_wince_info()->{cppflags}; },
-        defines          =>
-            picker(default => [ "UNICODE", "_UNICODE", "OPENSSL_SYS_WINCE",
-                                "WIN32_LEAN_AND_MEAN", "L_ENDIAN", "DSO_WIN32",
-                                "NO_CHMOD", "OPENSSL_SMALL_FOOTPRINT" ],
-                   debug   => [ "DEBUG", "_DEBUG" ]),
+        defines          => [ "UNICODE", "_UNICODE", "L_ENDIAN", "DSO_WIN32",
+                              "NO_CHMOD", "OPENSSL_SMALL_FOOTPRINT",
+                              "WIN32_LEAN_AND_MEAN" ],
         includes         =>
             add(combine(sub { defined(env('WCECOMPAT'))
                               ? '$(WCECOMPAT)/include' : (); },
                         sub { defined(env('PORTSDK_LIBPATH'))
                                   ? '$(PORTSDK_LIBPATH)/../../include'
                                   : (); })),
-        lflags           => add(combine("/nologo /opt:ref",
-                                        sub { vc_wince_info()->{lflags}; },
+        lflags           => add(combine(sub { vc_wince_info()->{lflags}; },
                                         sub { defined(env('PORTSDK_LIBPATH'))
                                                   ? "/entry:mainCRTstartup" : (); })),
         sys_id           => "WINCE",
@@ -1498,12 +1513,14 @@ my %targets = (
     "mingw" => {
         inherit_from     => [ "BASE_unix", asm("x86_asm"),
                               sub { $disabled{shared} ? () : "x86_uplink" } ],
-        cc               => "gcc",
-        cflags           => picker(default => "-m32 -Wall",
+        CC               => "gcc",
+        CFLAGS           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3 -fomit-frame-pointer"),
-        cppflags         => combine("-DL_ENDIAN -DWIN32_LEAN_AND_MEAN",
-                                    "-DUNICODE -D_UNICODE", threads("-D_MT")),
+        cflags           => "-m32",
+        cppflags         => combine("-DL_ENDIAN -DUNICODE -D_UNICODE",
+                                    "-DWIN32_LEAN_AND_MEAN",
+                                    threads("-D_MT")),
         sys_id           => "MINGW32",
         ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
         bn_ops           => "BN_LLONG EXPORT_VAR_AS_FN",
@@ -1528,12 +1545,14 @@ my %targets = (
         # environment. And as mingw64 is always consistent with itself,
         # Applink is never engaged and can as well be omitted.
         inherit_from     => [ "BASE_unix", asm("x86_64_asm") ],
-        cc               => "gcc",
-        cflags           => picker(default => "-m64 -Wall",
+        CC               => "gcc",
+        CFLAGS           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3"),
-        cppflags         => combine("-DL_ENDIAN -DWIN32_LEAN_AND_MEAN",
-                                    "-DUNICODE -D_UNICODE", threads("-D_MT")),
+        cflags           => "-m64",
+        cppflags         => combine("-DL_ENDIAN -DUNICODE -D_UNICODE",
+                                    "-DWIN32_LEAN_AND_MEAN",
+                                    threads("-D_MT")),
         sys_id           => "MINGW64",
         ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
         bn_ops           => "SIXTY_FOUR_BIT EXPORT_VAR_AS_FN",
@@ -1552,8 +1571,8 @@ my %targets = (
 #### UEFI
     "UEFI" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => "-O",
+        CC               => "cc",
+        CFLAGS           => "-O",
         cppflags         => "-DL_ENDIAN",
         sys_id           => "UEFI",
     },
@@ -1561,9 +1580,9 @@ my %targets = (
 #### UWIN
     "UWIN" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "cc",
-        cflags           => "-O -Wall",
-        cppflags         => "-DTERMIOS -DL_ENDIAN",
+        CC               => "cc",
+        CFLAGS           => "-O -Wall",
+        lib_cppflags     => "-DTERMIOS -DL_ENDIAN",
         sys_id           => "UWIN",
         bn_ops           => "BN_LLONG",
         dso_scheme       => "win32",
@@ -1572,8 +1591,8 @@ my %targets = (
 #### Cygwin
     "Cygwin-x86" => {
         inherit_from     => [ "BASE_unix", asm("x86_asm") ],
-        cc               => "gcc",
-        cflags           => picker(default => "-Wall",
+        CC               => "gcc",
+        CFLAGS           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3 -fomit-frame-pointer"),
         cppflags         => "-DTERMIOS -DL_ENDIAN",
@@ -1588,8 +1607,8 @@ my %targets = (
     },
     "Cygwin-x86_64" => {
         inherit_from     => [ "BASE_unix", asm("x86_64_asm") ],
-        cc               => "gcc",
-        cflags           => picker(default => "-Wall",
+        CC               => "gcc",
+        CFLAGS           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3"),
         cppflags         => "-DTERMIOS -DL_ENDIAN",
@@ -1624,13 +1643,12 @@ my %targets = (
     "darwin-common" => {
         inherit_from     => [ "BASE_unix" ],
         template         => 1,
-        cc               => "cc",
-        cflags           => picker(default => "",
-                                   debug   => "-g -O0",
+        CC               => "cc",
+        CFLAGS           => picker(debug   => "-g -O0",
                                    release => "-O3"),
         cppflags         => threads("-D_REENTRANT"),
+        lflags           => "-Wl,-search_paths_first",
         sys_id           => "MACOSX",
-        plib_lflags      => "-Wl,-search_paths_first",
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",
         perlasm_scheme   => "osx32",
@@ -1659,15 +1677,16 @@ my %targets = (
     },
     "darwin-i386-cc" => {
         inherit_from     => [ "darwin-common", asm("x86_asm") ],
-        cflags           => add(picker(default => "-arch i386",
-                                       release => "-fomit-frame-pointer")),
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+        cflags           => add("-arch i386"),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG RC4_INT",
         perlasm_scheme   => "macosx",
     },
     "darwin64-x86_64-cc" => {
         inherit_from     => [ "darwin-common", asm("x86_64_asm") ],
-        cflags           => add("-arch x86_64 -Wall"),
+        CFLAGS           => add("-Wall"),
+        cflags           => add("-arch x86_64"),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "macosx",
@@ -1714,9 +1733,9 @@ my %targets = (
     "hurd-x86" => {
         inherit_from     => [ "BASE_unix" ],
         inherit_from     => [ asm("x86_elf_asm") ],
-        cc               => "gcc",
-        cflags           => combine("-O3 -fomit-frame-pointer -Wall",
-                                    threads("-pthread")),
+        CC               => "gcc",
+        CFLAGS           => "-O3 -fomit-frame-pointer -Wall",
+        cflags           => threads("-pthread"),
         cppflags         => "-DL_ENDIAN",
         ex_libs          => add("-ldl", threads("-pthread")),
         bn_ops           => "BN_LLONG",
@@ -1730,8 +1749,9 @@ my %targets = (
 ##### VxWorks for various targets
     "vxworks-ppc60x" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccppc",
-        cflags           => "-mrtp -mhard-float -mstrict-align -fno-implicit-fp -O2 -fstrength-reduce -fno-builtin -fno-strict-aliasing -Wall",
+        CC               => "ccppc",
+        CFLAGS           => "-O2 -Wall -fstrength-reduce",
+        cflags           => "-mrtp -mhard-float -mstrict-align -fno-implicit-fp -fno-builtin -fno-strict-aliasing",
         cppflags         => combine("-D_REENTRANT -DPPC32_fp60x -DCPU=PPC32",
                                     "_DTOOL_FAMILY=gnu -DTOOL=gnu",
                                     "-I\$(WIND_BASE)/target/usr/h",
@@ -1742,8 +1762,9 @@ my %targets = (
     },
     "vxworks-ppcgen" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccppc",
-        cflags           => "-mrtp -msoft-float -mstrict-align -O1 -fno-builtin -fno-strict-aliasing -Wall",
+        CC               => "ccppc",
+        CFLAGS           => "-O1 -Wall",
+        cflags           => "-mrtp -msoft-float -mstrict-align -fno-builtin -fno-strict-aliasing",
         cppflags         => combine("-D_REENTRANT -DPPC32 -DCPU=PPC32",
                                     "-DTOOL_FAMILY=gnu -DTOOL=gnu",
                                     "-I\$(WIND_BASE)/target/usr/h",
@@ -1754,8 +1775,9 @@ my %targets = (
     },
     "vxworks-ppc405" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccppc",
-        cflags           => "-g -msoft-float -mlongcall",
+        CC               => "ccppc",
+        CFLAGS           => "-g",
+        cflags           => "-msoft-float -mlongcall",
         cppflags         => combine("-D_REENTRANT -DPPC32 -DCPU=PPC405",
                                     "-DTOOL_FAMILY=gnu -DTOOL=gnu",
                                     "-I\$(WIND_BASE)/target/h"),
@@ -1764,8 +1786,9 @@ my %targets = (
     },
     "vxworks-ppc750" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccppc",
-        cflags           => "-ansi -nostdinc -fvolatile -fno-builtin -fno-for-scope -fsigned-char -Wall -msoft-float -mlongcall \$(DEBUG_FLAG)",
+        CC               => "ccppc",
+        CFLAGS           => "-ansi -fvolatile -Wall \$(DEBUG_FLAG)",
+        cflags           => "-nostdinc -fno-builtin -fno-for-scope -fsigned-char -msoft-float -mlongcall",
         cppflags         => combine("-DPPC750 -D_REENTRANT -DCPU=PPC604",
                                     "-I\$(WIND_BASE)/target/h"),
         sys_id           => "VXWORKS",
@@ -1773,8 +1796,9 @@ my %targets = (
     },
     "vxworks-ppc750-debug" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccppc",
-        cflags           => "-ansi -nostdinc -fvolatile -fno-builtin -fno-for-scope -fsigned-char -Wall -msoft-float -mlongcall -g",
+        CC               => "ccppc",
+        CFLAGS           => "-ansi -fvolatile -Wall -g",
+        cflags           => "-nostdinc -fno-builtin -fno-for-scope -fsigned-char -msoft-float -mlongcall",
         cppflags         => combine("-DPPC750 -D_REENTRANT -DCPU=PPC604",
                                     "-DPEDANTIC -DDEBUG",
                                     "-I\$(WIND_BASE)/target/h"),
@@ -1783,7 +1807,7 @@ my %targets = (
     },
     "vxworks-ppc860" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccppc",
+        CC               => "ccppc",
         cflags           => "-nostdinc -msoft-float",
         cppflags         => combine("-DCPU=PPC860 -DNO_STRINGS_H",
                                     "-I\$(WIND_BASE)/target/h"),
@@ -1792,7 +1816,7 @@ my %targets = (
     },
     "vxworks-simlinux" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => "ccpentium",
+        CC               => "ccpentium",
         cflags           => "-B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -fno-builtin -fno-defer-pop",
         cppflags         => combine("-D_VSB_CONFIG_FILE=\"\$(WIND_BASE)/target/lib/h/config/vsbConfig.h\"",
                                     "-DL_ENDIAN -DCPU=SIMLINUX -DNO_STRINGS_H",
@@ -1806,8 +1830,9 @@ my %targets = (
     },
     "vxworks-mips" => {
         inherit_from     => [ "BASE_unix", asm("mips32_asm") ],
-        cc               => "ccmips",
-        cflags           => "-mrtp -mips2 -O -G 0 -B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -msoft-float -mno-branch-likely -fno-builtin -fno-defer-pop",
+        CC               => "ccmips",
+        CFLAGS           => "-O -G 0",
+        cflags           => "-mrtp -mips2 -B\$(WIND_BASE)/host/\$(WIND_HOST_TYPE)/lib/gcc-lib/ -msoft-float -mno-branch-likely -fno-builtin -fno-defer-pop",
         cppflags         => combine("-D_VSB_CONFIG_FILE=\"\$(WIND_BASE)/target/lib/h/config/vsbConfig.h\"",
                                     "-DCPU=MIPS32 -DNO_STRINGS_H",
                                     "-DTOOL_FAMILY=gnu -DTOOL=gnu",
@@ -1826,7 +1851,7 @@ my %targets = (
 #### uClinux
     "uClinux-dist" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => sub { env('CC') },
+        CC               => sub { env('CC') },
         cppflags         => threads("-D_REENTRANT"),
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "BN_LLONG",
@@ -1839,7 +1864,7 @@ my %targets = (
     },
     "uClinux-dist64" => {
         inherit_from     => [ "BASE_unix" ],
-        cc               => sub { env('CC') },
+        CC               => sub { env('CC') },
         cppflags         => threads("-D_REENTRANT"),
         ex_libs          => add("\$(LDLIBS)"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
@@ -1859,9 +1884,9 @@ my %targets = (
     "vms-generic" => {
         inherit_from     => [ "BASE_VMS" ],
         template         => 1,
-        cc               => "CC/DECC",
-        cpp              => '$(CC)/PREPROCESS_ONLY=SYS$OUTPUT:',
-        cflags           =>
+        CC               => "CC/DECC",
+        CPP              => '$(CC)/PREPROCESS_ONLY=SYS$OUTPUT:',
+        CFLAGS           =>
             combine(picker(default => "/STANDARD=(ISOC94,RELAXED)/NOLIST/PREFIX=ALL",
                            debug   => "/NOOPTIMIZE/DEBUG",
                            release => "/OPTIMIZE/NODEBUG"),
@@ -1887,9 +1912,10 @@ my %targets = (
         dso_scheme       => "vms",
         thread_scheme    => "pthreads",
 
-        as               => sub { vms_info()->{as} },
-        asflags          => sub { vms_info()->{asflags} },
+        AS               => sub { vms_info()->{AS} },
+        ASFLAGS          => sub { vms_info()->{ASFLAGS} },
         asoutflag        => sub { vms_info()->{asoutflag} },
+        asflags          => sub { vms_info()->{asflags} },
         perlasm_scheme   => sub { vms_info()->{perlasm_scheme} },
 
         apps_aux_src     => "vms_term_sock.c",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -683,6 +683,7 @@ my %targets = (
     "linux-ppc64" => {
         inherit_from     => [ "linux-generic64", asm("ppc64_asm") ],
         cflags           => add("-m64"),
+        cxxflags         => add("-m64"),
         cppflags         => add("-DB_ENDIAN"),
         perlasm_scheme   => "linux64",
         multilib         => "64",
@@ -690,6 +691,7 @@ my %targets = (
     "linux-ppc64le" => {
         inherit_from     => [ "linux-generic64", asm("ppc64_asm") ],
         cflags           => add("-m64"),
+        cxxflags         => add("-m64"),
         cppflags         => add("-DL_ENDIAN"),
         perlasm_scheme   => "linux64le",
     },
@@ -736,6 +738,7 @@ my %targets = (
     "linux-arm64ilp32" => {  # https://wiki.linaro.org/Platform/arm64-ilp32
         inherit_from     => [ "linux-generic32", asm("aarch64_asm") ],
         cflags           => add("-mabi=ilp32"),
+        cxxflags         => add("-mabi=ilp32"),
         bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR",
         perlasm_scheme   => "linux64",
     },
@@ -745,6 +748,7 @@ my %targets = (
         # support, if no -march was specified at command line.
         inherit_from     => [ "linux-generic32", asm("mips32_asm") ],
         cflags           => add("-mabi=32"),
+        cxxflags         => add("-mabi=32"),
         cppflags         => add("-DBN_DIV3W"),
         perlasm_scheme   => "o32",
     },
@@ -753,6 +757,7 @@ my %targets = (
     "linux-mips64" => {
         inherit_from     => [ "linux-generic32", asm("mips64_asm") ],
         cflags           => add("-mabi=n32"),
+        cxxflags         => add("-mabi=n32"),
         cppflags         => add("-DBN_DIV3W"),
         bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR",
         perlasm_scheme   => "n32",
@@ -761,6 +766,7 @@ my %targets = (
     "linux64-mips64" => {
         inherit_from     => [ "linux-generic64", asm("mips64_asm") ],
         cflags           => add("-mabi=64"),
+        cxxflags         => add("-mabi=64"),
         cppflags         => add("-DBN_DIV3W"),
         perlasm_scheme   => "64",
         multilib         => "64",
@@ -792,6 +798,7 @@ my %targets = (
         inherit_from     => [ "linux-generic32", asm("x86_asm") ],
         CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
         cflags           => add("-m32"),
+        cxxflags         => add("-m32"),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
         perlasm_scheme   => "elf",
@@ -805,6 +812,7 @@ my %targets = (
     "linux-x86_64" => {
         inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
         cflags           => add("-m64"),
+        cxxflags         => add("-m64"),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "elf",
@@ -819,6 +827,7 @@ my %targets = (
     "linux-x32" => {
         inherit_from     => [ "linux-generic32", asm("x86_64_asm") ],
         cflags           => add("-mx32"),
+        cxxflags         => add("-mx32"),
         cppflags         => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT",
         perlasm_scheme   => "elf32",
@@ -833,6 +842,7 @@ my %targets = (
     "linux64-s390x" => {
         inherit_from     => [ "linux-generic64", asm("s390x_asm") ],
         cflags           => add("-m64"),
+        cxxflags         => add("-m64"),
         cppflags         => add("-DB_ENDIAN"),
         perlasm_scheme   => "64",
         multilib         => "64",
@@ -856,6 +866,7 @@ my %targets = (
         #
         inherit_from     => [ "linux-generic32", asm("s390x_asm") ],
         cflags           => add("-m31 -Wa,-mzarch"),
+        cxxflags         => add("-m31 -Wa,-mzarch"),
         cppflags         => add("-DB_ENDIAN"),
         bn_asm_src       => sub { my $r=join(" ",@_); $r=~s|asm/s390x\.S|bn_asm.c|; $r; },
         perlasm_scheme   => "31",
@@ -866,6 +877,7 @@ my %targets = (
     "linux-sparcv8" => {
         inherit_from     => [ "linux-generic32", asm("sparcv8_asm") ],
         cflags           => add("-mcpu=v8"),
+        cxxflags         => add("-mcpu=v8"),
         lib_cppflags     => add("-DB_ENDIAN -DBN_DIV2W"),
     },
     "linux-sparcv9" => {
@@ -873,12 +885,14 @@ my %targets = (
         # but -Wa,-Av8plus should do the trick no matter what.
         inherit_from     => [ "linux-generic32", asm("sparcv9_asm") ],
         cflags           => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus"),
+        cxxflags         => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus"),
         lib_cppflags     => add("-DB_ENDIAN -DBN_DIV2W"),
     },
     "linux64-sparcv9" => {
         # GCC 3.1 is a requirement
         inherit_from     => [ "linux-generic64", asm("sparcv9_asm") ],
         cflags           => add("-m64 -mcpu=ultrasparc"),
+        cxxflags         => add("-m64 -mcpu=ultrasparc"),
         lib_cppflags     => add("-DB_ENDIAN"),
         bn_ops           => "BN_LLONG RC4_CHAR",
         multilib         => "64",
@@ -895,6 +909,7 @@ my %targets = (
         CC               => "cl6x",
         CFLAGS           => "-o2 -ox -ms",
         cflags           => "--linux -ea=.s -eo=.o -mv6400+ -pden",
+        cxxflags         => "--linux -ea=.s -eo=.o -mv6400+ -pden",
         cppflags         => combine("-DOPENSSL_SMALL_FOOTPRINT",
                                     threads("-D_REENTRANT")),
         bn_ops           => "BN_LLONG",
@@ -942,7 +957,8 @@ my %targets = (
         # systems are perfectly capable of executing binaries targeting
         # Froyo. Keep in mind that in the nutshell Android builds are
         # about JNI, i.e. shared libraries, not applications.
-        cflags           => add(picker(default => "-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack")),
+        cflags           => add("-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack"),
+        cxxflags         => add("-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack"),
         bin_cflags       => "-pie",
     },
     "android-x86" => {
@@ -982,7 +998,8 @@ my %targets = (
 
     "android64" => {
         inherit_from     => [ "linux-generic64" ],
-        cflags           => add(picker(default => "-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack")),
+        cflags           => add("-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack"),
+        cxxflags         => add("-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack"),
         bin_cflags       => "-pie",
     },
     "android64-aarch64" => {

--- a/Configurations/50-djgpp.conf
+++ b/Configurations/50-djgpp.conf
@@ -5,8 +5,9 @@
 my %targets = (
     "DJGPP" => {
         inherit_from     => [ asm("x86_asm") ],
-        cc               => "gcc",
-        cflags           => "-I/dev/env/WATT_ROOT/inc -DTERMIOS -DL_ENDIAN -fomit-frame-pointer -O2 -Wall",
+        CC               => "gcc",
+        CFLAGS           => "-fomit-frame-pointer -O2 -Wall",
+        cflags           => "-I/dev/env/WATT_ROOT/inc -DTERMIOS -DL_ENDIAN",
         sys_id           => "MSDOS",
         lflags           => add("-L/dev/env/WATT_ROOT/lib"),
         ex_libs          => add("-lwatt"),

--- a/Configurations/50-haiku.conf
+++ b/Configurations/50-haiku.conf
@@ -1,10 +1,11 @@
 my %targets = (
     "haiku-common" => {
         template         => 1,
-        cc               => "cc",
-        cflags           => add_before(picker(default => "-DL_ENDIAN -Wall -include \$(SRCDIR)/os-dep/haiku.h",
+        CC               => "cc",
+        CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-g -O0",
-                                              release => "-O2"),
+                                              release => "-O2")),
+        cflags           => add_before("-DL_ENDIAN -include \$(SRCDIR)/os-dep/haiku.h",
                                        threads("-D_REENTRANT")),
         sys_id           => "HAIKU",
         ex_libs          => "-lnetwork",
@@ -18,7 +19,7 @@ my %targets = (
     },
     "haiku-x86" => {
         inherit_from     => [ "haiku-common", asm("x86_elf_asm") ],
-        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
         bn_ops           => "BN_LLONG",
     },
     "haiku-x86_64" => {

--- a/Configurations/50-masm.conf
+++ b/Configurations/50-masm.conf
@@ -11,9 +11,10 @@ my %targets = (
     "VC-WIN64A-masm" => {
         inherit_from    => [ "VC-WIN64-common", asm("x86_64_asm"),
                              sub { $disabled{shared} ? () : "x86_64_uplink" } ],
-        as              => "ml64",
-        asflags         => "/nologo /c /Cp /Cx /Zi",
+        AS              => "ml64",
+        ASFLAGS         => "/nologo",
         asoutflag       => "/Fo",
+        asflags         => "/c /Cp /Cx /Zi",
         sys_id          => "WIN64A",
         bn_asm_src      => sub { return undef unless @_;
                                  my $r=join(" ",@_); $r=~s|asm/x86_64-gcc|bn_asm|; $r; },

--- a/Configurations/50-masm.conf
+++ b/Configurations/50-masm.conf
@@ -12,9 +12,9 @@ my %targets = (
         inherit_from    => [ "VC-WIN64-common", asm("x86_64_asm"),
                              sub { $disabled{shared} ? () : "x86_64_uplink" } ],
         AS              => "ml64",
-        ASFLAGS         => "/nologo",
+        ASFLAGS         => "/nologo /Zi",
         asoutflag       => "/Fo",
-        asflags         => "/c /Cp /Cx /Zi",
+        asflags         => "/c /Cp /Cx",
         sys_id          => "WIN64A",
         bn_asm_src      => sub { return undef unless @_;
                                  my $r=join(" ",@_); $r=~s|asm/x86_64-gcc|bn_asm|; $r; },

--- a/Configurations/90-team.conf
+++ b/Configurations/90-team.conf
@@ -5,7 +5,7 @@ my %targets = (
     "purify" => {
         inherit_from     => [ 'BASE_unix' ],
         cc               => "purify gcc",
-        cflags           => "-g -Wall",
+        CFLAGS           => "-g -Wall",
         thread_scheme    => "(unknown)",
         ex_libs          => add(" ","-lsocket -lnsl"),
     },
@@ -81,8 +81,8 @@ my %targets = (
     },
     "dist" => {
         inherit_from     => [ 'BASE_unix' ],
-        cc               => "cc",
-        cflags           => "-O",
+        CC               => "cc",
+        CFLAGS           => "-O",
         thread_scheme    => "(unknown)",
     },
     "debug-test-64-clang" => {

--- a/Configurations/README
+++ b/Configurations/README
@@ -85,8 +85,6 @@ In each table entry, the following keys are significant:
         lflags          => Flags that are used when linking apps.
         shared_ldflag   => Flags that are used when linking shared
                            or dynamic libraries.
-        plib_lflags     => Extra linking flags to appear just before
-                           the libraries on the command line.
         ex_libs         => Extra libraries that are needed when
                            linking.
 
@@ -340,15 +338,15 @@ In each table entry, the following keys are significant:
     shared libraries:
         {ld} $(CFLAGS) {shared_ldflag} -shared -o libfoo.so \
             -Wl,--whole-archive libfoo.a -Wl,--no-whole-archive \
-            {plib_lflags} -lcrypto {ex_libs}
+            -lcrypto {ex_libs}
 
     shared objects:
-        {ld} $(CFLAGS) {shared_ldflag} -shared -o libeng.so \
-            blah1.o blah2.o {plib_lflags} -lcrypto {ex_libs}
+        {ld} $(CFLAGS) {lflags} {module_lflags} -o libeng.so \
+            blah1.o blah2.o -lcrypto {ex_libs}
 
     applications:
         {ld} $(CFLAGS) {lflags} -o app \
-            app1.o utils.o {plib_lflags} -lssl -lcrypto {ex_libs}
+            app1.o utils.o -lssl -lcrypto {ex_libs}
 
 
 Historically, the target configurations came in form of a string with

--- a/Configurations/README
+++ b/Configurations/README
@@ -45,10 +45,10 @@ In each table entry, the following keys are significant:
                            Note: if the same feature is both enabled
                            and disabled, disable wins.
 
-        as              => The Assembler compiler.  This is not always
+        as              => The assembler command.  This is not always
                            used (for example on Unix, where the C
                            compiler is used instead).
-        asflags         => Default Assembler compiler flags [4].
+        asflags         => Default assembler command flags [4].
         cpp             => The C preprocessor command, normally not
                            given, as the build file defaults are
                            usually good enough.

--- a/Configurations/README
+++ b/Configurations/README
@@ -72,17 +72,9 @@ In each table entry, the following keys are significant:
                            also used when linking a program where at
                            least one of the object file is made from
                            C++ source.
-        cflags          => Defaults flags used when compiling C object
-                           files [4].
-        cxxflags        => Default flags used when compiling C++
-                           object files [4].  If unset, it gets the
-                           same value as cflags.
-        shared_cflag    => Extra compilation flags used when
-                           compiling for shared libraries, typically
-                           something like "-fPIC".
-        module_cflags   => Extra compilation flags used when
-                           compiling for DSOs, typically something
-                           like "-fPIC".
+        cflags          => Defaults C compiler flags [4].
+        cxxflags        => Default  C++ compiler flags [4].  If unset,
+                           it gets the same value as cflags.
 
         (linking is a complex thing, see [3] below)
         ld              => Linker command, usually not defined
@@ -92,20 +84,22 @@ In each table entry, the following keys are significant:
                            not implemented yet)
         lflags          => Default flags used when linking apps,
                            shared libraries or DSOs [4].
+        ex_libs         => Extra libraries that are needed when
+                           linking shared libraries, DSOs or programs.
+
         shared_cppflags => Extra C preprocessor flags used when
-                           processing C files that will be part of a
-                           shared library.
+                           processing C files for shared libraries.
         shared_cflag    => Extra C compiler flags used when compiling
-                           objects files that will be part of a shared
-                           library.
+                           for shared libraries, typically something
+                           like "-fPIC".
         shared_ldflag   => Extra linking flags used when linking
                            shared libraries.
         module_cppflags
         module_cflags
         module_ldflags  => Has the same function as the corresponding
                            `shared_' attributes, but for building DSOs.
-        ex_libs         => Extra libraries that are needed when
-                           linking shared libraries, DSOs or programs.
+                           When unset, they get the same values as the
+                           corresponding `shared_' attributes.
 
         ar              => The library archive command, the default is
                            "ar".

--- a/Configurations/README
+++ b/Configurations/README
@@ -45,19 +45,24 @@ In each table entry, the following keys are significant:
                            Note: if the same feature is both enabled
                            and disabled, disable wins.
 
+        as              => The Assembler compiler.  This is not always
+                           used (for example on Unix, where the C
+                           compiler is used instead).
+        asflags         => Default Assembler compiler flags [4].
         cpp             => The C preprocessor command, normally not
                            given, as the build file defaults are
                            usually good enough.
-        cppflags        => The C preprocessor flags.
+        cppflags        => Default C preprocessor flags [4].
         defines         => As an alternative, macro definitions may be
-                           given here instead of in `cppflags'.  If
-                           given here, they MUST be as an array of the
-                           string such as "MACRO=value", or just
+                           given here instead of in `cppflags' [4].
+                           If given here, they MUST be as an array of
+                           the string such as "MACRO=value", or just
                            "MACRO" for definitions without value.
         includes        => As an alternative, inclusion directories
-                           may be given here instead of in `cppflags'.
-                           If given here, the MUST be an array of
-                           strings, one directory specification each.
+                           may be given here instead of in `cppflags'
+                           [4].  If given here, the MUST be an array
+                           of strings, one directory specification
+                           each.
         cc              => The C compiler command, usually one of "cc",
                            "gcc" or "clang".  This command is normally
                            also used to link object files and
@@ -67,14 +72,17 @@ In each table entry, the following keys are significant:
                            also used when linking a program where at
                            least one of the object file is made from
                            C++ source.
-        cflags          => Flags that are used at all times when
-                           compiling C object files.
-        cxxflags        => Flags that are used at all times when
-                           compiling C++ object files.  If unset, it
-                           gets the same value as cflags.
+        cflags          => Defaults flags used when compiling C object
+                           files [4].
+        cxxflags        => Default flags used when compiling C++
+                           object files [4].  If unset, it gets the
+                           same value as cflags.
         shared_cflag    => Extra compilation flags used when
                            compiling for shared libraries, typically
                            something like "-fPIC".
+        module_cflags   => Extra compilation flags used when
+                           compiling for DSOs, typically something
+                           like "-fPIC".
 
         (linking is a complex thing, see [3] below)
         ld              => Linker command, usually not defined
@@ -82,11 +90,22 @@ In each table entry, the following keys are significant:
                            instead).
                            (NOTE: this is here for future use, it's
                            not implemented yet)
-        lflags          => Flags that are used when linking apps.
-        shared_ldflag   => Flags that are used when linking shared
-                           or dynamic libraries.
+        lflags          => Default flags used when linking apps,
+                           shared libraries or DSOs [4].
+        shared_cppflags => Extra C preprocessor flags used when
+                           processing C files that will be part of a
+                           shared library.
+        shared_cflag    => Extra C compiler flags used when compiling
+                           objects files that will be part of a shared
+                           library.
+        shared_ldflag   => Extra linking flags used when linking
+                           shared libraries.
+        module_cppflags
+        module_cflags
+        module_ldflags  => Has the same function as the corresponding
+                           `shared_' attributes, but for building DSOs.
         ex_libs         => Extra libraries that are needed when
-                           linking.
+                           linking shared libraries, DSOs or programs.
 
         ar              => The library archive command, the default is
                            "ar".
@@ -336,18 +355,20 @@ In each table entry, the following keys are significant:
     of this file):
 
     shared libraries:
-        {ld} $(CFLAGS) {shared_ldflag} -shared -o libfoo.so \
-            -Wl,--whole-archive libfoo.a -Wl,--no-whole-archive \
-            -lcrypto {ex_libs}
+        {ld} $(CFLAGS) {lflags} {shared_ldflag} -o libfoo.so \
+            foo/something.o foo/somethingelse.o {ex_libs}
 
     shared objects:
-        {ld} $(CFLAGS) {lflags} {module_lflags} -o libeng.so \
+        {ld} $(CFLAGS) {lflags} {module_ldflags} -o libeng.so \
             blah1.o blah2.o -lcrypto {ex_libs}
 
     applications:
         {ld} $(CFLAGS) {lflags} -o app \
             app1.o utils.o -lssl -lcrypto {ex_libs}
 
+[4] There are variants of these attribute, prefixed with `lib_',
+    `dso_' or `bin_'.  Those variants replace the unprefixed attribute
+    when building library, DSO or program modules specifically.
 
 Historically, the target configurations came in form of a string with
 values separated by colons.  This use is deprecated.  The string form

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -171,50 +171,167 @@ OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 # Where installed engines reside, for C
 ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
-CC= {- $config{cc} -}
-CPP= {- $config{cpp} -}
-DEFINES={- our $defines = join(",",
-                               '__dummy', # To make comma processing easier
-                               @{$config{defines}}) -}
-INCLUDES={- our $includes = join(',', @{$config{includes}}) -}
-CPPFLAGS='qual_includes'{- our $cppflags = join('', @{$config{cppflags}}) -}
-CPPFLAGS_Q={- (my $x = $cppflags) =~ s|"|""|g;
-              (my $d = $defines) =~ s|"|""|g;
-              $x .= "/INCLUDE=($includes)" if $includes;
-              $x .= "/DEFINE=($d)";
-              $x; -}
-CFLAGS={- join('', @{$config{cflags}}) -}
-LDFLAGS= {- join('', @{$config{lflags}}) -}
-EX_LIBS= {- join('', map { ','.$_ } @{$config{ex_libs}}) -}
+##### User defined commands and flags ################################
 
-LIB_DEFINES=$(DEFINES){- join("", (map { ",$_" }
-                                   @{$target{shared_defines}},
-                                   'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
-                                   'ENGINESDIR="""$(ENGINESDIR_C)"""')) -}
-LIB_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(LIB_DEFINES))
-LIB_CFLAGS=$(CFLAGS){- $target{lib_cflags} // "" -}
-DSO_DEFINES=$(DEFINES){- join("", (map { ",$_" } @{$target{dso_defines}})) -}
-DSO_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(DSO_DEFINES))
-DSO_CFLAGS=$(CFLAGS){- $target{dso_cflags} // "" -}
-BIN_DEFINES=$(DEFINES){- join("", (map { ",$_" } @{$target{bin_defines}})) -}
-BIN_CPPFLAGS=$(CPPFLAGS)/DEFINE=($(BIN_DEFINES))
-BIN_CFLAGS=$(CFLAGS){- $target{bin_cflags} // "" -}
-NO_INST_LIB_CFLAGS=$(CFLAGS){- $target{no_inst_lib_cflags}
-                               // $target{lib_cflags}
-                               // "" -}
-NO_INST_DSO_CFLAGS=$(CFLAGS){- $target{no_inst_dso_cflags}
-                               // $target{dso_cflags}
-                               // "" -}
-NO_INST_BIN_CFLAGS=$(CFLAGS){- $target{no_inst_bin_cflags}
-                               // $target{bin_cflags}
-                               // "" -}
+CC={- $config{CC} -}
+CPP={- $config{CPP} -}
+DEFINES={- our $defines1 = join('', map { ",$_" } @{$config{CPPDEFINES}}) -}
+INCLUDES={- our $includes1 = join('', map { ",$_" } @{$config{CPPINCLUDES}}) -}
+CPPFLAGS={- our $cppflags1 = join('', @{$config{CPPFLAGS}}) -}
+CFLAGS={- join('', @{$config{CFLAGS}}) -}
+LDFLAGS={- join('', @{$config{LFLAGS}}) -}
+EX_LIBS={- join('', map { ",$_" } @{$config{LDLIBS}}) -}
 
 PERL={- $config{perl} -}
 
-AS={- $config{as} -}
-ASFLAGS={- join(' ', @{$config{asflags}}) -}
+AS={- $config{AS} -}
+ASFLAGS={- join(' ', @{$config{ASFLAGS}}) -}
+
+##### Special command flags ##########################################
+
 ASOUTFLAG={- $target{asoutflag} -}$(OSSL_EMPTY)
+
+##### Project flags ##################################################
+
+# Variables starting with CNF_ are common variables for all product types
+
+CNF_ASFLAGS={- join('', $target{asflags} || (),
+                        @{$config{asflags}}) -}
+CNF_DEFINES={- our $defines2 = join('', map { ",$_" } @{$target{defines}},
+                                                      @{$config{defines}}) -}
+CNF_INCLUDES={- our $includes2 = join(',', @{$target{includes}},
+                                           @{$config{includes}}) -}
+CNF_CPPFLAGS={- our $cppflags2 = join('', $target{cppflags} || (),
+                                          @{$config{cppflags}}) -}
+CNF_CFLAGS={- join('', $target{cflags} || (),
+                       @{$config{cflags}}) -}
+CNF_CXXFLAGS={- join('', $target{cxxflags} || (),
+                         @{$config{cxxflags}}) -}
+CNF_LDFLAGS={- join('', $target{lflags} || (),
+                        @{$config{lflags}}) -}
+CNF_EX_LIBS={- join('', map{ ",$_" } @{$target{ex_libs}},
+                                     @{$config{ex_libs}}) -}
+
+# Variables starting with LIB_ are used to build library object files
+# and shared libraries.
+# Variables starting with DSO_ are used to build DSOs and their object files.
+# Variables starting with BIN_ are used to build programs and their object
+# files.
+
+LIB_ASFLAGS={- join(' ', $target{lib_asflags} || (),
+                         @{$config{lib_asflags}},
+                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
+LIB_DEFINES={- join('', (map { ",$_" } @{$target{lib_defines}},
+                                       @{$target{shared_defines}},
+                                       @{$config{lib_defines}},
+                                       @{$config{shared_defines}},
+                                       'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
+                                       'ENGINESDIR="""$(ENGINESDIR_C)"""'),
+                        '$(CNF_DEFINES)', '$(DEFINES)') -}
+LIB_INCLUDES={- join(',', @{$target{lib_includes}},
+                          @{$target{shared_includes}},
+                          @{$config{lib_includes}},
+                          @{$config{shared_includes}}) -}
+LIB_CPPFLAGS={- join('', "'qual_includes'",
+                         '/DEFINE=(__dummy$(LIB_DEFINES))',
+                         $target{lib_cppflags} || (),
+                         $target{shared_cppflags} || (),
+                         @{$config{lib_cppflags}},
+                         @{$config{shared_cppflag}},
+                         '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+LIB_CFLAGS={- join('', $target{lib_cflags} || (),
+                       $target{shared_cflag} || (),
+                       @{$config{lib_cflags}},
+                       @{$config{shared_cflag}},
+                       '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+LIB_LDFLAGS={- join('', $target{lib_lflags} || (),
+                        $target{shared_ldflag} || (),
+                        @{$config{lib_lflags}},
+                        @{$config{shared_ldflag}},
+                        '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+LIB_EX_LIBS=$(CNF_EX_LIBS)$(EX_LIBS)
+DSO_ASFLAGS={- join(' ', $target{dso_asflags} || (),
+                         $target{module_asflags} || (),
+                         @{$config{dso_asflags}},
+                         @{$config{module_asflags}},
+                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
+DSO_DEFINES={- join('', (map { ",$_" } @{$target{dso_defines}},
+                                       @{$target{module_defines}},
+                                       @{$config{dso_defines}},
+                                       @{$config{module_defines}}),
+                        '$(CNF_DEFINES)', '$(DEFINES)') -}
+DSO_INCLUDES={- join(',', @{$target{dso_includes}},
+                          @{$target{module_includes}},
+                          @{$config{dso_includes}},
+                          @{$config{module_includes}}) -}
+DSO_CPPFLAGS={- join('', "'qual_includes'",
+                         '/DEFINE=(__dummy$(DSO_DEFINES))',
+                         $target{dso_cppflags} || (),
+                         $target{module_cppflags} || (),
+                         @{$config{dso_cppflags}},
+                         @{$config{module_cppflags}},
+                         '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+DSO_CFLAGS={- join('', $target{dso_cflags} || (),
+                       $target{module_cflags} || (),
+                       @{$config{dso_cflags}},
+                       @{$config{module_cflags}},
+                       '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+DSO_LDFLAGS={- join('', $target{dso_lflags} || (),
+                        $target{module_ldflags} || (),
+                        @{$config{dso_lflags}},
+                        @{$config{module_ldflags}},
+                        '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+BIN_ASFLAGS={- join(' ', $target{bin_asflags} || (),
+                         @{$config{bin_asflags}},
+                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
+BIN_DEFINES={- join('', (map { ",$_" } @{$target{bin_defines}},
+                                       @{$config{bin_defines}}),
+                        '$(CNF_DEFINES)', '$(DEFINES)') -}
+BIN_INCLUDES={- join(',', @{$target{bin_includes}},
+                          @{$config{bin_includes}}) -}
+BIN_CPPFLAGS={- join('', "'qual_includes'",
+                         '/DEFINE=(__dummy$(DSO_DEFINES))',
+                         $target{bin_cppflags} || (),
+                         @{$config{bin_cppflag}},
+                         '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+BIN_CFLAGS={- join('', $target{bin_cflag} || (),
+                       @{$config{bin_cflag}},
+                       '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+BIN_LDFLAGS={- join('', $target{bin_lflags} || (),
+                        @{$config{bin_lflags}} || (),
+                        '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+NO_INST_LIB_CFLAGS={- join('', $target{no_inst_lib_cflags}
+                               // $target{lib_cflags}
+                               // (),
+                               $target{shared_cflag} || (),
+                               @{$config{lib_cflags}},
+                               @{$config{shared_cflag}},
+                               '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+NO_INST_DSO_CFLAGS={- join('', $target{no_inst_lib_cflags}
+                               // $target{lib_cflags}
+                               // (),
+                               $target{dso_cflags} || (),
+                               @{$config{lib_cflags}},
+                               @{$config{dso_cflags}},
+                               '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+NO_INST_BIN_CFLAGS={- join('', $target{no_inst_bin_cflags}
+                               // $target{bin_cflags}
+                               // (),
+                               @{$config{bin_cflags}},
+                               '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+
 PERLASM_SCHEME={- $target{perlasm_scheme} -}
+
+# CPPFLAGS_Q is used for one thing only: to build up buildinf.h
+CPPFLAGS_Q={- (my $c = $cppflags1.$cppflags2) =~ s|"|""|g;
+              (my $d = $defines1.$defines2) =~ s|"|""|g;
+              my $i = join(',', $includes1 || (), $includes2 || ());
+              my $x = $c;
+              $x .= "/INCLUDE=($i)" if $i;
+              $x .= "/DEFINE=($d)" if $d;
+              $x; -}
 
 # .FIRST and .LAST are special targets with MMS and MMK.
 # The defines in there are for C.  includes that look like
@@ -666,6 +783,7 @@ EOF
           my @incs_cmds = includes({ lib => '$(LIB_INCLUDES)',
                                      dso => '$(DSO_INCLUDES)',
                                      bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
+                                   '$(CNF_INCLUDES)',
                                    '$(INCLUDES)',
                                    @{$args{incs}});
           my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
@@ -725,11 +843,14 @@ EOF
       my $after = $unified_info{after}->{$obj.".OBJ"} || "\@ !";
 
       if ($srcs[0] =~ /\.asm$/) {
+          my $asflags = { lib => ' $(LIB_ASFLAGS)',
+		          dso => ' $(DSO_ASFLAGS)',
+		          bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
           return <<"EOF";
 $obj.OBJ : $deps
         ${before}
         SET DEFAULT $forward
-        \$(AS) \$(ASFLAGS) \$(ASOUTFLAG)${objd}${objn}.OBJ $srcs
+        \$(AS) $asflags \$(ASOUTFLAG)${objd}${objn}.OBJ $srcs
         SET DEFAULT $backward
 EOF
       }
@@ -817,8 +938,8 @@ $shlib.EXE : $lib.OLB $deps
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
-        LINK \$(LDFLAGS)/SHARE=\$\@ $defs[0]-translated/OPT,-
-                $lib-components.OPT/OPT \$(EX_LIBS)
+        LINK \$(LIB_LDFLAGS)/SHARE=\$\@ $defs[0]-translated/OPT,-
+                $lib-components.OPT/OPT \$(LIB_EX_LIBS)
         DELETE $defs[0]-translated;*,$lib-components.OPT;*
         PURGE $shlib.EXE,$shlib.MAP
 EOF
@@ -861,7 +982,7 @@ $lib.EXE : $deps
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
-        LINK \$(LDFLAGS)/SHARE=\$\@ $lib.OPT/OPT \$(EX_LIBS)
+        LINK \$(DSO_LDFLAGS)/SHARE=\$\@ $lib.OPT/OPT \$(DSO_EX_LIBS)
         - PURGE $lib.EXE,$lib.OPT,$lib.MAP
 EOF
         . ($config{target} =~ m|alpha| ? "" : <<"EOF"
@@ -949,7 +1070,7 @@ $bin.EXE : $deps
         @ CLOSE OPT_FILE
         TYPE $bin.opt ! For debugging
         - pipe SPAWN/WAIT/NOLOG/OUT=$bin.LINKLOG -
-                    LINK \$(LDFLAGS)/EXEC=\$\@ $bin.OPT/OPT \$(EX_LIBS) ; -
+                    LINK \$(BIN_LDFLAGS)/EXEC=\$\@ $bin.OPT/OPT \$(BIN_EX_LIBS) ; -
                link_status = \$status ; link_severity = link_status .AND. 7
         @ search_severity = 1
         -@ IF link_severity .EQ. 0 THEN -

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -13,12 +13,12 @@
 
 sub detect_gnu_ld {
     my @lines =
-        `$config{cross_compile_prefix}$config{cc} -Wl,-V /dev/null 2>&1`;
+        `$config{CROSS_COMPILE}$config{CC} -Wl,-V /dev/null 2>&1`;
     return grep /^GNU ld/, @lines;
 }
 sub detect_gnu_cc {
     my @lines =
-        `$config{cross_compile_prefix}$config{cc} -v 2>&1`;
+        `$config{CROSS_COMPILE}$config{CC} -v 2>&1`;
     return grep /gcc/, @lines;
 }
 

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -42,7 +42,7 @@ my %shared_info;
         };
     },
     'darwin-shared' => {
-        module_lflags         => '-bundle',
+        module_ldflags        => '-bundle',
         shared_ldflag         => '-dynamiclib -current_version $(SHLIB_VERSION_NUMBER) -compatibility_version $(SHLIB_VERSION_NUMBER)',
         shared_sonameflag     => '-install_name $(INSTALLTOP)/$(LIBDIR)/',
     },
@@ -61,7 +61,7 @@ my %shared_info;
     'alpha-osf1-shared' => sub {
         return $shared_info{'gnu-shared'} if detect_gnu_ld();
         return {
-            module_lflags     => '-shared -Wl,-Bsymbolic',
+            module_ldflags    => '-shared -Wl,-Bsymbolic',
             shared_ldflag     => '-shared -Wl,-Bsymbolic -set_version $(SHLIB_VERSION_NUMBER)',
         };
     },

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -42,7 +42,7 @@ my %shared_info;
         };
     },
     'darwin-shared' => {
-        dso_lflags            => '-bundle',
+        module_lflags         => '-bundle',
         shared_ldflag         => '-dynamiclib -current_version $(SHLIB_VERSION_NUMBER) -compatibility_version $(SHLIB_VERSION_NUMBER)',
         shared_sonameflag     => '-install_name $(INSTALLTOP)/$(LIBDIR)/',
     },
@@ -61,7 +61,7 @@ my %shared_info;
     'alpha-osf1-shared' => sub {
         return $shared_info{'gnu-shared'} if detect_gnu_ld();
         return {
-            dso_lflags        => '-shared -Wl,-Bsymbolic',
+            module_lflags     => '-shared -Wl,-Bsymbolic',
             shared_ldflag     => '-shared -Wl,-Bsymbolic -set_version $(SHLIB_VERSION_NUMBER)',
         };
     },

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1100,7 +1100,7 @@ EOF
 $target: $deps
 	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
 		-o $target_full$shared_def $objs \\
-                \$(PLIB_LDFLAGS) $linklibs \$(LIB_EX_LIBS)
+                $linklibs \$(LIB_EX_LIBS)
 EOF
       if (windowsdll()) {
           $recipe .= <<"EOF";
@@ -1143,7 +1143,7 @@ EOF
 $target: $objs $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
 		-o $target $objs \\
-                \$(PLIB_LDFLAGS) $linklibs \$(DSO_EX_LIBS)
+                $linklibs \$(DSO_EX_LIBS)
 EOF
   }
   sub obj2lib {
@@ -1191,7 +1191,7 @@ $bin$exeext: $objs $deps
 	rm -f $bin$exeext
 	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(BIN_LDFLAGS) \\
 		-o $bin$exeext $objs \\
-		\$(PLIB_LDFLAGS) $linklibs \$(BIN_EX_LIBS)
+		$linklibs \$(BIN_EX_LIBS)
 EOF
   }
   sub in2script {

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -188,53 +188,7 @@ HTMLSUFFIX=html
 # For "optional" echo messages, to get "real" silence
 ECHO = echo
 
-CROSS_COMPILE= {- $config{cross_compile_prefix} -}
-CPPFLAGS={- our $cppflags = join(" ",
-                                 (map { "-D".$_} @{$config{defines}}),
-                                 (map { "-I".$_} @{$config{includes}}),
-                                 @{$config{cppflags}}) -}
-CPPFLAGS_Q={- $cppflags =~ s|([\\"])|\\$1|g; $cppflags -}
-CC= $(CROSS_COMPILE){- $config{cc} -}
-CFLAGS={- join(' ', @{$config{cflags}}) -}
-CXX={- $config{cxx} ? "\$(CROSS_COMPILE)$config{cxx}" : '' -}
-CXXFLAGS={- join(' ', @{$config{cxxflags}}) -}
-LDFLAGS= {- join(' ', @{$config{lflags}}) -}
-PLIB_LDFLAGS= {- join(' ', @{$config{plib_lflags}}) -}
-EX_LIBS= {- join(' ', @{$config{ex_libs}}) -}
-
-LIB_CPPFLAGS={- join(' ', '$(CPPFLAGS)',
-                          $target{shared_cppflag} || (),
-                          (map { '-D'.$_ }
-                               ('OPENSSLDIR="\"$(OPENSSLDIR)\""',
-                                'ENGINESDIR="\"$(ENGINESDIR)\""'))) -}
-LIB_CFLAGS={- join(' ', '$(CFLAGS)', $target{shared_cflag} || ()) -}
-LIB_CXXFLAGS={- join(' ', '$(CXXFLAGS)', $target{shared_cxxflag} || ()) -}
-LIB_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{shared_ldflag} || (), $config{shared_ldflag} || ()) -}
-DSO_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{dso_cppflags} || ()) -}
-DSO_CFLAGS={- join(' ', '$(CFLAGS)', $target{dso_cflags} || ()) -}
-DSO_CXXFLAGS={- join(' ', '$(CXXFLAGS)', $target{dso_cxxflags} || ()) -}
-DSO_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{dso_lflags} || ()) -}
-BIN_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{bin_cppflags} || ()) -}
-BIN_CFLAGS={- join(' ', '$(CFLAGS)', $target{bin_cflags} || ()) -}
-BIN_CXXFLAGS={- join(' ', '$(CXXFLAGS)', $target{bin_cxxflags} || ()) -}
-BIN_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{bin_lflags} || ()) -}
-
-PERL={- $config{perl} -}
-
-AR=$(CROSS_COMPILE){- $config{ar} -}
-ARFLAGS= {- join(' ', @{$config{arflags}}) -}
-RANLIB={- $config{ranlib} ? "\$(CROSS_COMPILE)$config{ranlib}" : "true"; -}
-RC= $(CROSS_COMPILE){- $target{rc} || "windres" -}
-RCFLAGS={- join(' ', @{$config{rcflags}}) -} {- $target{shared_rcflag} -}
-RM= rm -f
-RMDIR= rmdir
-TAR= {- $target{tar} || "tar" -}
-TARFLAGS= {- $target{tarflags} -}
-MAKEDEPEND={- $config{makedepprog} -}
-
-BASENAME=       openssl
-NAME=           $(BASENAME)-$(VERSION)
-TARFILE=        ../$(NAME).tar
+##### User defined commands and flags ################################
 
 # We let the C compiler driver to take care of .s files. This is done in
 # order to be excused from maintaining a separate set of architecture
@@ -242,6 +196,128 @@ TARFILE=        ../$(NAME).tar
 # gcc, then the driver will automatically translate it to -xarch=v8plus
 # and pass it down to assembler.  In any case, we do not define AS or
 # ASFLAGS for this reason.
+
+CROSS_COMPILE={- $config{CROSS_COMPILE} -}
+CC=$(CROSS_COMPILE){- $config{CC} -}
+CXX={- $config{CXX} ? "\$(CROSS_COMPILE)$config{CXX}" : '' -}
+CPPFLAGS={- our $cppflags1 = join(" ",
+                                  (map { "-D".$_} @{$config{CPPDEFINES}}),
+                                  (map { "-I".$_} @{$config{CPPINCLUDES}}),
+                                  @{$config{CPPFLAGS}}) -}
+CFLAGS={- join(' ', @{$config{CFLAGS}}) -}
+CXXFLAGS={- join(' ', @{$config{CXXFLAGS}}) -}
+LDFLAGS= {- join(' ', @{$config{LDFLAGS}}) -}
+EX_LIBS= {- join(' ', @{$config{LDLIBS}}) -}
+
+MAKEDEPEND={- $config{makedepprog} -}
+
+PERL={- $config{perl} -}
+
+AR=$(CROSS_COMPILE){- $config{AR} -}
+ARFLAGS= {- join(' ', @{$config{ARFLAGS}}) -}
+RANLIB={- $config{RANLIB} ? "\$(CROSS_COMPILE)$config{RANLIB}" : "true"; -}
+RC= $(CROSS_COMPILE){- $config{RC} -}
+RCFLAGS={- join(' ', @{$config{RCFLAGS}}) -} {- $target{shared_rcflag} -}
+
+RM= rm -f
+RMDIR= rmdir
+TAR= {- $target{TAR} || "tar" -}
+TARFLAGS= {- $target{TARFLAGS} -}
+
+BASENAME=       openssl
+NAME=           $(BASENAME)-$(VERSION)
+TARFILE=        ../$(NAME).tar
+
+##### Project flags ##################################################
+
+# Variables starting with CNF_ are common variables for all product types
+
+CNF_CPPFLAGS={- our $cppflags2 =
+                    join(' ', $target{cppflags} || (),
+                              (map { "-D".$_} @{$target{defines}},
+                                              @{$config{defines}}),
+                              (map { "-I".$_} @{$target{includes}},
+                                              @{$config{includes}}),
+                              @{$config{cppflags}}) -}
+CNF_CFLAGS={- join(' ', $target{cflags} || (),
+                        @{$config{cflags}}) -}
+CNF_CXXFLAGS={- join(' ', $target{cxxflags} || (),
+                          @{$config{cxxflags}}) -}
+CNF_LDFLAGS={- join(' ', $target{lflags} || (),
+                         @{$config{lflags}}) -}
+CNF_EX_LIBS={- join(' ', $target{ex_libs} || (),
+                         @{$config{ex_libs}}) -}
+
+# Variables starting with LIB_ are used to build library object files
+# and shared libraries.
+# Variables starting with DSO_ are used to build DSOs and their object files.
+# Variables starting with BIN_ are used to build programs and their object
+# files.
+
+LIB_CPPFLAGS={- join(' ', $target{lib_cppflags} || (),
+                          $target{shared_cppflag} || (),
+                          (map { '-D'.$_ }
+                               @{$config{lib_defines}},
+                               @{$config{shared_defines}},
+                               'OPENSSLDIR="\"$(OPENSSLDIR)\""',
+                               'ENGINESDIR="\"$(ENGINESDIR)\""'),
+                          @{$config{lib_cppflags}},
+                          @{$config{shared_cppflag}},
+                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
+                        $target{shared_cflag} || (),
+                        @{$config{lib_cflags}},
+                        @{$config{shared_cflag}},
+                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+LIB_CXXFLAGS={- join(' ', $target{lib_cxxflags} || (),
+                          $target{shared_cxxflag} || (),
+                          @{$config{lib_cxxflags}},
+                          @{$config{shared_cxxflag}},
+                          '$(CNF_CXXFLAGS)', '$(CXXFLAGS)') -}
+LIB_LDFLAGS={- join(' ', $target{shared_ldflag} || (),
+                         $config{shared_ldflag} || (),
+                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+LIB_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+DSO_CPPFLAGS={- join(' ', $target{dso_cppflags} || (),
+                          $target{module_cppflags} || (),
+                          @{$config{dso_cppflags}},
+                          @{$config{module_cppflags}},
+                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+DSO_CFLAGS={- join(' ', $target{dso_cflags} || (),
+                        $target{module_cflags} || (),
+                        @{$config{dso_cflags}},
+                        @{$config{module_cflags}},
+                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+DSO_CXXFLAGS={- join(' ', $target{dso_cxxflags} || (),
+                          $target{module_cxxflags} || (),
+                          @{$config{dso_cxxflags}},
+                          @{$config{module_cxxflag}},
+                          '$(CNF_CXXFLAGS)', '$(CXXFLAGS)') -}
+DSO_LDFLAGS={- join(' ', $target{dso_ldflags} || (),
+                         $target{module_ldflags} || (),
+                         @{$config{dso_ldflags}},
+                         @{$config{module_ldflags}},
+                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+BIN_CPPFLAGS={- join(' ', $target{bin_cppflags} || (),
+                          @{$config{bin_cppflags}},
+                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+BIN_CFLAGS={- join(' ', $target{bin_cflags} || (),
+                        @{$config{bin_cflags}},
+                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+BIN_CXXFLAGS={- join(' ', $target{bin_cxxflags} || (),
+                          @{$config{bin_cxxflags}},
+                          '$(CNF_CXXFLAGS)', '$(CXXFLAGS)') -}
+BIN_LDFLAGS={- join(' ', $target{bin_lflags} || (),
+                         @{$config{bin_lflags}},
+                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+
+# CPPFLAGS_Q is used for one thing only: to build up buildinf.h
+CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;
+              $cppflags2 =~ s|([\\"])|\\$1|g;
+              join(' ', $cppflags1 || (), $cppflags2 || ()) -}
+
 PERLASM_SCHEME= {- $target{perlasm_scheme} -}
 
 # For x86 assembler: Set PROCESSOR to 386 if you want to support
@@ -771,7 +847,7 @@ libcrypto.pc:
 	    echo 'Description: OpenSSL cryptography library'; \
 	    echo 'Version: '$(VERSION); \
 	    echo 'Libs: -L$${libdir} -lcrypto'; \
-	    echo 'Libs.private: $(EX_LIBS)'; \
+	    echo 'Libs.private: $(LIB_EX_LIBS)'; \
 	    echo 'Cflags: -I$${includedir}' ) > libcrypto.pc
 
 libssl.pc:
@@ -1024,7 +1100,7 @@ EOF
 $target: $deps
 	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
 		-o $target_full$shared_def $objs \\
-                \$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
+                \$(PLIB_LDFLAGS) $linklibs \$(LIB_EX_LIBS)
 EOF
       if (windowsdll()) {
           $recipe .= <<"EOF";
@@ -1067,7 +1143,7 @@ EOF
 $target: $objs $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
 		-o $target $objs \\
-                \$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
+                \$(PLIB_LDFLAGS) $linklibs \$(DSO_EX_LIBS)
 EOF
   }
   sub obj2lib {
@@ -1115,7 +1191,7 @@ $bin$exeext: $objs $deps
 	rm -f $bin$exeext
 	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(BIN_LDFLAGS) \\
 		-o $bin$exeext $objs \\
-		\$(PLIB_LDFLAGS) $linklibs \$(EX_LIBS)
+		\$(PLIB_LDFLAGS) $linklibs \$(BIN_EX_LIBS)
 EOF
   }
   sub in2script {

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -163,50 +163,139 @@ ENGINESDIR=$(ENGINESDIR_dev)$(ENGINESDIR_dir)
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)\$(LIBDIR)' -}
 
-CC={- $config{cc} -}
-CPP={- $config{cpp} -}
-CPPFLAGS={- our $cppflags = join(" ",
-                                 (map { "-D".$_} @{$config{defines}}),
-                                 (map { " /I ".$_} @{$config{includes}}),
-                                 @{$config{cppflags}}) -}
-CPPFLAGS_Q={- $cppflags =~ s|([\\"])|\\$1|g; $cppflags -}
-CFLAGS={- join(' ', @{$config{cflags}}) -}
-COUTFLAG={- $target{coutflag} || "/Fo" -}$(OSSL_EMPTY)
-RC={- $config{rc} -}
-RCOUTFLAG={- $target{rcoutflag} || "/fo" -}$(OSSL_EMPTY)
-LD={- $config{ld} -}
-LDFLAGS={- join(' ', @{$config{lflags}}) -}
-LDOUTFLAG={- $target{loutflag} || "/out:" -}$(OSSL_EMPTY)
-EX_LIBS={- join(' ', @{$config{ex_libs}}) -}
+##### User defined commands and flags ################################
 
-LIB_CPPFLAGS={- join(' ', '$(CPPFLAGS)',
-                          $target{shared_cppflag} || (),
-                          (map { quotify_l("-D".$_) }
-                           "OPENSSLDIR=\"$openssldir\"",
-                           "ENGINESDIR=\"$enginesdir\"")) -}
-LIB_CFLAGS={- join(' ', '$(CFLAGS)', $target{lib_cflags} || (), $target{shared_cflag} || ()) -}
-LIB_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{shared_ldflag} || (), $config{shared_ldflag} || ()) -}
-DSO_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{dso_cppflags} || ()) -}
-DSO_CFLAGS={- join(' ', '$(CFLAGS)', $target{dso_cflags} || ()) -}
-DSO_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{dso_ldflag} || ()) -}
-BIN_CPPFLAGS={- join(' ', '$(CPPFLAGS)', $target{dso_cppflags} || ()) -}
-BIN_CFLAGS={- join(' ', '$(CFLAGS)', $target{bin_cflags} || ()) -}
-BIN_LDFLAGS={- join(' ', '$(LDFLAGS)', $target{bin_lflags} || ()) -}
+CC={- $config{CC} -}
+CPP={- $config{CPP} -}
+CPPFLAGS={- our $cppflags1 = join(" ",
+                                  (map { "-D".$_} @{$config{CPPDEFINES}}),
+                                  (map { " /I ".$_} @{$config{CPPINCLUDES}}),
+                                  @{$config{CPPFLAGS}}) -}
+CFLAGS={- join(' ', @{$config{CFLAGS}}) -}
+LD={- $config{LD} -}
+LDFLAGS={- join(' ', @{$config{LDFLAGS}}) -}
+EX_LIBS={- join(' ', @{$config{LDLIBS}}) -}
 
 PERL={- $config{perl} -}
 
-AR={- $config{ar} -}
-ARFLAGS= {- join(' ', @{$config{arflags}}) -}
-AROUTFLAG={- $target{aroutflag} || "/out:" -}$(OSSL_EMPTY)
+AR={- $config{AR} -}
+ARFLAGS= {- join(' ', @{$config{ARFLAGS}}) -}
 
-MT={- $config{mt} -}
-MTFLAGS= {- join(' ', @{$config{mtflags}}) -}
-MTINFLAG={- $target{mtinflag} || "-manifest " -}$(OSSL_EMPTY)
-MTOUTFLAG={- $target{mtoutflag} || "-outputresource:" -}$(OSSL_EMPTY)
+MT={- $config{MT} -}
+MTFLAGS= {- join(' ', @{$config{MTFLAGS}}) -}
 
-AS={- $config{as} -}
-ASFLAGS={- join(' ', @{$config{asflags}}) -}
+AS={- $config{AS} -}
+ASFLAGS={- join(' ', @{$config{ASFLAGS}}) -}
+
+RC={- $config{RC} -}
+
+##### Special command flags ##########################################
+
+COUTFLAG={- $target{coutflag} -}$(OSSL_EMPTY)
+LDOUTFLAG={- $target{ldoutflag} -}$(OSSL_EMPTY)
+AROUTFLAG={- $target{aroutflag} -}$(OSSL_EMPTY)
+MTINFLAG={- $target{mtinflag} -}$(OSSL_EMPTY)
+MTOUTFLAG={- $target{mtoutflag} -}$(OSSL_EMPTY)
 ASOUTFLAG={- $target{asoutflag} -}$(OSSL_EMPTY)
+RCOUTFLAG={- $target{rcoutflag} -}$(OSSL_EMPTY)
+
+##### Project flags ##################################################
+
+# Variables starting with CNF_ are common variables for all product types
+
+CNF_ASFLAGS={- join(' ', $target{asflags} || (),
+                         @{$config{asflags}}) -}
+CNF_CPPFLAGS={- our $cppfags2 =
+                    join(' ', $target{cppflags} || (),
+                              (map { quotify_l("-D".$_) } @{$target{defines}},
+                                                          @{$config{defines}}),
+                              (map { quotify_l("-I".$_) } @{$target{includes}},
+                                                          @{$config{includes}}),
+                              @{$config{cppflags}}) -}
+CNF_CFLAGS={- join(' ', $target{cflags} || (),
+                        @{$config{cflags}}) -}
+CNF_CXXFLAGS={- join(' ', $target{cxxflags} || (),
+                          @{$config{cxxflags}}) -}
+CNF_LDFLAGS={- join(' ', $target{lflags} || (),
+                         @{$config{lflags}}) -}
+CNF_EX_LIBS={- join(' ', $target{ex_libs} || (),
+                         @{$config{ex_libs}}) -}
+
+# Variables starting with LIB_ are used to build library object files
+# and shared libraries.
+# Variables starting with DSO_ are used to build DSOs and their object files.
+# Variables starting with BIN_ are used to build programs and their object
+# files.
+
+LIB_ASFLAGS={- join(' ', $target{lib_asflags} || (),
+                         @{$config{lib_asflags}},
+                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
+LIB_CPPFLAGS={- join(' ', $target{lib_cppflags} || (),
+                          $target{shared_cppflag} || (),
+                          (map { quotify_l("-D".$_) }
+                               @{$target{lib_defines}},
+                               @{$target{shared_defines}},
+                               @{$config{lib_defines}},
+                               @{$config{shared_defines}},
+                               "OPENSSLDIR=\"$openssldir\"",
+                               "ENGINESDIR=\"$enginesdir\""),
+                          (map { quotify_l("-I".$_) }
+                               @{$target{lib_includes}},
+                               @{$target{shared_includes}},
+                               @{$config{lib_includes}},
+                               @{$config{shared_includes}}),
+                          @{$config{lib_cppflags}},
+                          @{$config{shared_cppflag}},
+                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
+                        $target{shared_cflag} || (),
+                        @{$config{lib_cflags}},
+                        @{$config{shared_cflag}},
+                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+LIB_LDFLAGS={- join(' ', $target{shared_ldflag} || (),
+                         $config{shared_ldflag} || (),
+                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+LIB_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+DSO_ASFLAGS={- join(' ', $target{dso_asflags} || (),
+                         $target{module_asflags} || (),
+                         @{$config{dso_asflags}},
+                         @{$config{module_asflags}},
+                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
+DSO_CPPFLAGS={- join(' ', $target{dso_cppflags} || (),
+                          $target{module_cppflags} || (),
+                          @{$config{dso_cppflags}},
+                          @{$config{module_cppflags}},
+                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+DSO_CFLAGS={- join(' ', $target{dso_cflags} || (),
+                        $target{module_cflags} || (),
+                        @{$config{dso_cflags}},
+                        @{$config{module_cflags}},
+                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+DSO_LDFLAGS={- join(' ', $target{dso_lflags} || (),
+                         $target{module_ldflags} || (),
+                         @{$config{dso_lflags}},
+                         @{$config{module_ldflags}},
+                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+BIN_ASFLAGS={- join(' ', $target{bin_asflags} || (),
+                         @{$config{bin_asflags}},
+                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
+BIN_CPPFLAGS={- join(' ', $target{bin_cppflags} || (),
+                          @{$config{bin_cppflags}},
+                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
+BIN_CFLAGS={- join(' ', $target{bin_cflags} || (),
+                        @{$config{bin_cflags}},
+                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
+BIN_LDFLAGS={- join(' ', $target{bin_lflags} || (),
+                         @{$config{bin_lflags}},
+                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+
+# CPPFLAGS_Q is used for one thing only: to build up buildinf.h
+CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;
+              $cppflags2 =~ s|([\\"])|\\$1|g;
+              join(' ', $cppflags1 || (), $cppflags2 || ()) -}
+
 PERLASM_SCHEME= {- $target{perlasm_scheme} -}
 
 PROCESSOR= {- $config{processor} -}
@@ -484,6 +573,9 @@ EOF
      $cflags .= { lib => ' $(LIB_CPPFLAGS)',
 		  dso => ' $(DSO_CPPFLAGS)',
 		  bin => ' $(BIN_CPPFLAGS)' } -> {$args{intent}};
+     my $asflags = { lib => ' $(LIB_ASFLAGS)',
+		     dso => ' $(DSO_ASFLAGS)',
+		     bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
      my $makedepprog = $config{makedepprog};
      if ($srcs[0] =~ /\.rc$/) {
          return <<"EOF";
@@ -495,7 +587,7 @@ EOF
      if ($srcs[0] =~ /\.asm$/) {
          return <<"EOF";
 $obj$objext: $deps
-	\$(AS) \$(ASFLAGS) \$(ASOUTFLAG)\$\@ $srcs
+	\$(AS) $asflags \$(ASOUTFLAG)\$\@ $srcs
 EOF
      }
      return <<"EOF"	if (!$disabled{makedepend});
@@ -542,7 +634,7 @@ $target: $deps
 	\$(LD) \$(LDFLAGS) \$(LIB_LDFLAGS) \\
 		/implib:\$@ \$(LDOUTFLAG)$shlib$shlibext$shared_def @<< || (DEL /Q \$(\@B).* $shlib.* && EXIT 1)
 $objs
-$linklibs\$(EX_LIBS)
+$linklibs\$(LIB_EX_LIBS)
 <<
 	IF EXIST $shlib$shlibext.manifest \\
 	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$shlib$shlibext.manifest \$(MTOUTFLAG)$shlib$shlibext
@@ -573,7 +665,7 @@ EXPORTS
     v_check		@2
 <<
 $objs
-$linklibs \$(EX_LIBS)
+$linklibs \$(DSO_EX_LIBS)
 <<
 	IF EXIST $dso$dsoext.manifest \\
 	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$dso$dsoext.manifest \$(MTOUTFLAG)$dso$dsoext
@@ -613,7 +705,7 @@ $bin$exeext: $deps
 	\$(LD) \$(LDFLAGS) \$(BIN_LDFLAGS) \$(LDOUTFLAG)$bin$exeext @<<
 $objs
 setargv.obj
-$linklibs\$(EX_LIBS)
+$linklibs\$(BIN_EX_LIBS)
 <<
 	IF EXIST $bin$exeext.manifest \\
 	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$bin$exeext.manifest \$(MTOUTFLAG)$bin$exeext

--- a/Configure
+++ b/Configure
@@ -1101,7 +1101,6 @@ foreach (keys %user) {
         || $mkvalue->($ref_type, $target{$_});
     delete $config{$_} unless defined $config{$_};
 }
-$config{plib_lflags} = [ $target{plib_lflags} ];
 
 # Allow overriding the build file name
 $config{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
@@ -3104,7 +3103,6 @@ sub print_table_entry
 	"ld",
 	"lflags",
 	"loutflag",
-	"plib_lflags",
 	"ex_libs",
 	"bn_ops",
 	"apps_aux_src",

--- a/Configure
+++ b/Configure
@@ -568,13 +568,20 @@ my %user_synonyms = (
     HASHBANGPERL=> 'PERL',
     RC          => 'WINDRES',
    );
-my %user_to_target = (
-    # If not given here, the value is the lc of the key
-    CPPDEFINES  => 'defines',
-    CPPINCLUDES => 'includes',
-    CROSS_COMPILE => 'cross_compile_prefix',
-    LDFLAGS     => 'lflags',
-    LDLIBS      => 'ex_libs',
+
+# Some target attributes have been renamed, this is the translation table
+my %target_attr_translate =(
+    ar          => 'AR',
+    as          => 'AS',
+    cc          => 'CC',
+    cxx         => 'CXX',
+    cpp         => 'CPP',
+    hashbangperl => 'HASHBANGPERL',
+    ld          => 'LD',
+    mt          => 'MT',
+    ranlib      => 'RANLIB',
+    rc          => 'RC',
+    rm          => 'RM',
    );
 
 $config{openssl_api_defines}=[];
@@ -969,6 +976,12 @@ my %target = resolve_config($target);
 
 &usage if (!%target || $target{template});
 
+foreach (keys %target_attr_translate) {
+    $target{$target_attr_translate{$_}} = $target{$_}
+        if $target{$_};
+    delete $target{$_};
+}
+
 %target = ( %{$table{DEFAULTS}}, %target );
 
 # Make the flags to build DSOs the same as for shared libraries unless they
@@ -1031,7 +1044,8 @@ foreach my $feature (@{$target{enable}}) {
     }
 }
 
-$target{cxxflags}//=$target{cflags} if $target{cxx};
+$target{CXXFLAGS}//=$target{CFLAGS} if $target{CXX};
+$target{cxxflags}//=$target{cflags} if $target{CXX};
 $target{exe_extension}="";
 $target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
                                   || $config{target} =~ /^(?:Cygwin|mingw)/);
@@ -1048,7 +1062,6 @@ $target{dso_extension}=$target{shared_extension_simple};
 # the default string.
 $config{perl} =    ($^O ne "VMS" ? $^X : "perl");
 foreach (keys %user) {
-    my $target_key = $user_to_target{$_} // lc $_;
     my $ref_type = ref $user{$_};
 
     # Temporary function.  Takes an intended ref type (empty string or "ARRAY")
@@ -1074,10 +1087,10 @@ foreach (keys %user) {
         return $value;
     };
 
-    $config{$target_key} =
+    $config{$_} =
         $mkvalue->($ref_type, $user{$_})
-        || $mkvalue->($ref_type, $target{$target_key});
-    delete $config{$target_key} unless defined $config{$target_key};
+        || $mkvalue->($ref_type, $target{$_});
+    delete $config{$_} unless defined $config{$_};
 }
 $config{plib_lflags} = [ $target{plib_lflags} ];
 
@@ -1149,10 +1162,10 @@ foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
 
 push @{$config{defines}}, "NDEBUG"    if $config{build_type} eq "release";
 
-if ($target =~ /^mingw/ && `$config{cc} --target-help 2>&1` =~ m/-mno-cygwin/m)
+if ($target =~ /^mingw/ && `$config{CC} --target-help 2>&1` =~ m/-mno-cygwin/m)
 	{
 	push @{$config{cflags}}, "-mno-cygwin";
-	push @{$config{cxxflags}}, "-mno-cygwin" if $config{cxx};
+	push @{$config{cxxflags}}, "-mno-cygwin" if $config{CXX};
 	push @{$config{shared_ldflag}}, "-mno-cygwin";
 	}
 
@@ -1164,7 +1177,7 @@ if ($target =~ /linux.*-mips/ && !$disabled{asm}
 	$value = '-mips2' if ($target =~ /mips32/);
 	$value = '-mips3' if ($target =~ /mips64/);
 	unshift @{$config{cflags}}, $value;
-	unshift @{$config{cxxflags}}, $value if $config{cxx};
+	unshift @{$config{cxxflags}}, $value if $config{CXX};
 }
 
 # The DSO code currently always implements all functions so that no
@@ -1246,7 +1259,7 @@ if ($disabled{"dynamic-engine"}) {
 
 unless ($disabled{asan}) {
     push @{$config{cflags}}, "-fsanitize=address";
-    push @{$config{cxxflags}}, "-fsanitize=address" if $config{cxx};
+    push @{$config{cxxflags}}, "-fsanitize=address" if $config{CXX};
 }
 
 unless ($disabled{ubsan}) {
@@ -1254,18 +1267,18 @@ unless ($disabled{ubsan}) {
     # platforms.
     push @{$config{cflags}}, "-fsanitize=undefined", "-fno-sanitize-recover=all";
     push @{$config{cxxflags}}, "-fsanitize=undefined", "-fno-sanitize-recover=all"
-        if $config{cxx};
+        if $config{CXX};
 }
 
 unless ($disabled{msan}) {
   push @{$config{cflags}}, "-fsanitize=memory";
-  push @{$config{cxxflags}}, "-fsanitize=memory" if $config{cxx};
+  push @{$config{cxxflags}}, "-fsanitize=memory" if $config{CXX};
 }
 
 unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
         && $disabled{asan} && $disabled{ubsan} && $disabled{msan}) {
     push @{$config{cflags}}, "-fno-omit-frame-pointer", "-g";
-    push @{$config{cxxflags}}, "-fno-omit-frame-pointer", "-g" if $config{cxx};
+    push @{$config{cxxflags}}, "-fno-omit-frame-pointer", "-g" if $config{CXX};
 }
 #
 # Platform fix-ups
@@ -1357,7 +1370,7 @@ unless ($disabled{asm}) {
     }
 }
 
-my %predefined = compiler_predefined($config{cc});
+my %predefined = compiler_predefined($config{CC});
 
 # Check for makedepend capabilities.
 if (!$disabled{makedepend}) {
@@ -1368,7 +1381,7 @@ if (!$disabled{makedepend}) {
     } elsif ($predefined{__GNUC__} >= 3) {
         # We know that GNU C version 3 and up as well as all clang
         # versions support dependency generation
-        $config{makedepprog} = "\$(CROSS_COMPILE)$config{cc}";
+        $config{makedepprog} = "\$(CROSS_COMPILE)$config{CC}";
     } else {
         # In all other cases, we look for 'makedepend', and disable the
         # capability if not found.
@@ -1410,7 +1423,7 @@ die "Exactly one of SIXTY_FOUR_BIT|SIXTY_FOUR_BIT_LONG|THIRTY_TWO_BIT can be set
 $config{cflags} = [ map { (my $x = $_) =~ s/([\\\"])/\\$1/g; $x }
                         @{$config{cflags}} ];
 $config{cxxflags} = [ map { (my $x = $_) =~ s/([\\\"])/\\$1/g; $x }
-                          @{$config{cxxflags}} ] if $config{cxx};
+                          @{$config{cxxflags}} ] if $config{CXX};
 
 if (defined($config{api})) {
     $config{openssl_api_defines} = [ "OPENSSL_MIN_API=".$apitable->{$config{api}} ];
@@ -1420,7 +1433,7 @@ if (defined($config{api})) {
 
 if (defined($predefined{__clang__}) && !$disabled{asm}) {
     push @{$config{cflags}}, "-Qunused-arguments";
-    push @{$config{cxxflags}}, "-Qunused-arguments" if $config{cxx};
+    push @{$config{cxxflags}}, "-Qunused-arguments" if $config{CXX};
 }
 
 if ($strict_warnings)
@@ -1436,7 +1449,7 @@ if ($strict_warnings)
 		push @{$config{cflags}}, $wopt
 			unless grep { $_ eq $wopt } @{$config{cflags}};
 		push @{$config{cxxflags}}, $wopt
-			if ($config{cxx}
+			if ($config{CXX}
 			    && !grep { $_ eq $wopt } @{$config{cxxflags}});
 		}
 	if (defined($predefined{__clang__}))
@@ -1446,7 +1459,7 @@ if ($strict_warnings)
 			push @{$config{cflags}}, $wopt
 				unless grep { $_ eq $wopt } @{$config{cflags}};
 			push @{$config{cxxflags}}, $wopt
-				if ($config{cxx}
+				if ($config{CXX}
 				    && !grep { $_ eq $wopt } @{$config{cxxflags}});
 			}
 		}
@@ -1459,7 +1472,7 @@ unless ($disabled{"crypto-mdebug-backtrace"})
 		push @{$config{cflags}}, $wopt
 			unless grep { $_ eq $wopt } @{$config{cflags}};
 		push @{$config{cxxflags}}, $wopt
-			if ($config{cxx}
+			if ($config{CXX}
 			    && !grep { $_ eq $wopt } @{$config{cxxflags}});
 		}
 	if ($target =~ /^BSD-/)
@@ -1472,7 +1485,7 @@ unless ($disabled{afalgeng}) {
     $config{afalgeng}="";
     if ($target =~ m/^linux/) {
         my $minver = 4*10000 + 1*100 + 0;
-        if ($config{cross_compile_prefix} eq "") {
+        if ($config{CROSS_COMPILE} eq "") {
             my $verstr = `uname -r`;
             my ($ma, $mi1, $mi2) = split("\\.", $verstr);
             ($mi2) = $mi2 =~ /(\d+)/;
@@ -1499,12 +1512,10 @@ foreach (keys %useradd) {
     die "internal error: \$useradd{$_} isn't an ARRAY\n"
         unless ref $useradd{$_} eq 'ARRAY';
 
-    my $target_key = $user_to_target{$_} // lc $_;
-
-    if (defined $config{$target_key}) {
-        push @{$config{$target_key}}, @{$useradd{$_}};
+    if (defined $config{$_}) {
+        push @{$config{$_}}, @{$useradd{$_}};
     } else {
-        $config{$target_key} = [ @{$useradd{$_}} ];
+        $config{$_} = [ @{$useradd{$_}} ];
     }
 }
 
@@ -2168,7 +2179,7 @@ foreach (grep /_(asm|aux)_src$/, keys %target) {
 print "Creating configdata.pm\n";
 open(OUT,">configdata.pm") || die "unable to create configdata.pm: $!\n";
 print OUT <<"EOF";
-#! $config{hashbangperl}
+#! $config{HASHBANGPERL}
 
 package configdata;
 
@@ -2306,10 +2317,9 @@ EOF
 }
 print OUT
     "# The following data is only used when this files is use as a script\n";
-print OUT "my \%makevars = (\n";
+print OUT "my \@makevars = (\n";
 foreach (sort keys %user) {
-    print OUT '    ',$_,' ' x (20 - length $_),'=> ',
-        "'",$user_to_target{$_} || lc $_,"',\n";
+    print OUT "    '",$_,"',\n";
 }
 print OUT ");\n";
 print OUT "my \%disabled_info = (\n";
@@ -2440,17 +2450,17 @@ _____
     }
     if ($dump || $makevars) {
         print "\nMakevars:\n\n";
-        foreach my $var (sort keys %makevars) {
+        foreach my $var (@makevars) {
             my $prefix = '';
-            $prefix = $config{cross_compile_prefix}
+            $prefix = $config{CROSS_COMPILE}
                 if grep { $var eq $_ } @user_crossable;
             $prefix //= '';
             print '    ',$var,' ' x (16 - length $var),'= ',
-                (ref $config{$makevars{$var}} eq 'ARRAY'
-                 ? join(' ', @{$config{$makevars{$var}}})
-                 : $prefix.$config{$makevars{$var}}),
+                (ref $config{$var} eq 'ARRAY'
+                 ? join(' ', @{$config{$var}})
+                 : $prefix.$config{$var}),
                 "\n"
-                if defined $config{$makevars{$var}};
+                if defined $config{$var};
         }
 
         my @buildfile = ($config{builddir}, $config{build_file});
@@ -3012,7 +3022,7 @@ sub compiler_predefined {
         unless $default_compiler;
 
     if (! $predefined{$default_compiler}) {
-        my $cc = "$config{cross_compile_prefix}$default_compiler";
+        my $cc = "$config{CROSS_COMPILE}$default_compiler";
 
         $predefined{$default_compiler} = {};
 

--- a/Configure
+++ b/Configure
@@ -584,6 +584,15 @@ my %target_attr_translate =(
     rm          => 'RM',
    );
 
+# Initialisers coming from 'config' scripts
+$config{defines} = [ split(/$list_separator_re/, env('__CNF_CPPDEFINES')) ],
+$config{includes} = [ split(/$list_separator_re/, env('__CNF_CPPINCLUDES')) ],
+$config{cppflags} = [ env('__CNF_CPPFLAGS') || () ],
+$config{cflags} = [ env('__CNF_CFLAGS') || () ],
+$config{cxxflags} = [ env('__CNF_CXXFLAGS') || () ],
+$config{lflags} = [ env('__CNF_LDFLAGS') || () ],
+$config{ex_libs} = [ env('__CNF_LDLIBS') || () ],
+
 $config{openssl_api_defines}=[];
 $config{openssl_algorithm_defines}=[];
 $config{openssl_thread_defines}=[];

--- a/Configure
+++ b/Configure
@@ -896,8 +896,8 @@ if (grep { scalar @$_ > 0 } values %useradd) {
                                   sort keys %useradd);
     if ($detected_env) {
         die <<"_____";
-***** Mixing env / make variables and configure line compiling or linking flags
-***** is not permitted.
+***** Mixing env / make variables and additional compiler/linker flags as
+***** configure command line option is not permitted.
 ***** Affected env / make variables: $detected_env
 _____
     }

--- a/Configure
+++ b/Configure
@@ -892,7 +892,8 @@ while (@argvcopy)
 	}
 
 if (grep { scalar @$_ > 0 } values %useradd) {
-    my $detected_env = join(', ', grep { @{$useradd{$_}} } sort keys %useradd);
+    my $detected_env = join(', ', grep { @{$useradd{$_}} || env($_) }
+                                  sort keys %useradd);
     if ($detected_env) {
         die <<"_____";
 ***** Mixing env / make variables and configure line compiling or linking flags

--- a/Configure
+++ b/Configure
@@ -621,10 +621,10 @@ while (@argvcopy)
 			{
 			$user{$1} = ref $user{$1} eq "ARRAY" ? [] : undef;
 			}
-		if (exists $useradd{$1})
-			{
-			$useradd{$1} = [];
-			}
+		#if (exists $useradd{$1})
+		#	{
+		#	$useradd{$1} = [];
+		#	}
 		next;
 		}
 
@@ -890,6 +890,17 @@ while (@argvcopy)
 			join(", ", keys %unsupported_options), "\n";
 		}
 	}
+
+if (grep { scalar @$_ > 0 } values %useradd) {
+    my $detected_env = join(', ', grep { @{$useradd{$_}} } sort keys %useradd);
+    if ($detected_env) {
+        die <<"_____";
+***** Mixing env / make variables and configure line compiling or linking flags
+***** is not permitted.
+***** Affected env / make variables: $detected_env
+_____
+    }
+}
 
 foreach (keys %user) {
     my $value = env($_);

--- a/Configure
+++ b/Configure
@@ -975,7 +975,7 @@ my %target = resolve_config($target);
 # are already defined
 $target{module_cflags} = $target{shared_cflag} unless defined $target{module_cflags};
 $target{module_cxxflags} = $target{shared_cxxflag} unless defined $target{module_cxxflags};
-$target{module_lflags} = $target{shared_ldflag} unless defined $target{module_lflags};
+$target{module_ldflags} = $target{shared_ldflag} unless defined $target{module_ldflags};
 {
     my $shared_info_pl =
         catfile(dirname($0), "Configurations", "shared-info.pl");
@@ -1000,7 +1000,7 @@ $target{module_lflags} = $target{shared_ldflag} unless defined $target{module_lf
         # module_ attribute unless the latter is already defined
         $si->{module_cflags} = $si->{shared_cflag} unless defined $si->{module_cflags};
         $si->{module_cxxflags} = $si->{shared_cxxflag} unless defined $si->{module_cxxflags};
-        $si->{module_lflags} = $si->{shared_ldflag} unless defined $si->{module_lflags};
+        $si->{module_ldflags} = $si->{shared_ldflag} unless defined $si->{module_ldflags};
         foreach (sort keys %$si) {
             $target{$_} = defined $target{$_}
                 ? add($si->{$_})->($target{$_})

--- a/Configure
+++ b/Configure
@@ -1275,9 +1275,9 @@ unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
 if ($disabled{pic})
 	{
 	foreach (qw(shared_cflag shared_cxxflag shared_cppflag
-                    shared_defines shared_includes shared_ldflag
+		    shared_defines shared_includes shared_ldflag
 		    module_cflags module_cxxflags module_cppflags
-                    module_defines module_includes module_lflags))
+		    module_defines module_includes module_lflags))
 		{
 		delete $config{$_};
 		$target{$_} = "";

--- a/Configure
+++ b/Configure
@@ -973,9 +973,9 @@ my %target = resolve_config($target);
 
 # Make the flags to build DSOs the same as for shared libraries unless they
 # are already defined
-$target{dso_cflags} = $target{shared_cflag} unless defined $target{dso_cflags};
-$target{dso_cxxflags} = $target{shared_cxxflag} unless defined $target{dso_cxxflags};
-$target{dso_lflags} = $target{shared_ldflag} unless defined $target{dso_lflags};
+$target{module_cflags} = $target{shared_cflag} unless defined $target{module_cflags};
+$target{module_cxxflags} = $target{shared_cxxflag} unless defined $target{module_cxxflags};
+$target{module_lflags} = $target{shared_ldflag} unless defined $target{module_lflags};
 {
     my $shared_info_pl =
         catfile(dirname($0), "Configurations", "shared-info.pl");
@@ -997,10 +997,10 @@ $target{dso_lflags} = $target{shared_ldflag} unless defined $target{dso_lflags};
     # Windows and VMS.
     if (defined $si) {
         # Just as above, copy certain shared_* attributes to the corresponding
-        # dso_ attribute unless the latter is already defined
-        $si->{dso_cflags} = $si->{shared_cflag} unless defined $si->{dso_cflags};
-        $si->{dso_cxxflags} = $si->{shared_cxxflag} unless defined $si->{dso_cxxflags};
-        $si->{dso_lflags} = $si->{shared_ldflag} unless defined $si->{dso_lflags};
+        # module_ attribute unless the latter is already defined
+        $si->{module_cflags} = $si->{shared_cflag} unless defined $si->{module_cflags};
+        $si->{module_cxxflags} = $si->{shared_cxxflag} unless defined $si->{module_cxxflags};
+        $si->{module_lflags} = $si->{shared_ldflag} unless defined $si->{module_lflags};
         foreach (sort keys %$si) {
             $target{$_} = defined $target{$_}
                 ? add($si->{$_})->($target{$_})
@@ -1276,8 +1276,8 @@ if ($disabled{pic})
 	{
 	foreach (qw(shared_cflag shared_cxxflag shared_cppflag
                     shared_defines shared_includes shared_ldflag
-		    dso_cflags dso_cxxflags dso_cppflags
-                    dso_defines dso_includes dso_lflags))
+		    module_cflags module_cxxflags module_cppflags
+                    module_defines module_includes module_lflags))
 		{
 		delete $config{$_};
 		$target{$_} = "";

--- a/INSTALL
+++ b/INSTALL
@@ -581,29 +581,11 @@
                    RCFLAGS         Flags for the Windows reources manipulator.
                    RM              The command to remove files and directories.
 
-                   These can be mixed with flags given on the command line.
-                   Any variable assignment resets any corresponding flags
-                   given before it, so for example:
+                   These cannot be mixed with compiling / linking flags given
+                   on the command line.  In other words, something like this
+                   isn't permitted.
 
                        ./config -DFOO CPPFLAGS=-DBAR -DCOOKIE
-
-                   Will end up having 'CPPFLAGS=-DBAR -DCOOKIE'.
-
-                   Here is how the flags documented above are collected as
-                   augmentation of these variables:
-
-                   -Dxxx           xxx is collected in CPPDEFINES
-                   -Ixxx           xxx is collected in CPPINCLUDES
-                   -Wp,xxx         collected in CPPFLAGS
-                   -Lxxx           collected in LDFLAGS
-                   -lxxx           collected in LDLIBS
-                   -Wp,xxx         collected in LDLIBS
-                   -rpath xxx      collected in LDLIBS
-                   -R xxx          collected in LDLIBS
-                   -framework xxx  collected in LDLIBS
-                   -static         collected in LDLIBS
-                   -xxx            collected in CFLAGS
-                   +xxx            collected in CFLAGS
 
   reconf
   reconfigure

--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -1,4 +1,4 @@
-#!{- $config{hashbangperl} -}
+#!{- $config{HASHBANGPERL} -}
 # Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use

--- a/apps/tsget.in
+++ b/apps/tsget.in
@@ -1,4 +1,4 @@
-#!{- $config{hashbangperl} -}
+#!{- $config{HASHBANGPERL} -}
 # Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
 # Copyright (c) 2002 The OpenTSA Project. All rights reserved.
 #

--- a/config
+++ b/config
@@ -40,6 +40,15 @@ EOF
 esac
 done
 
+# Environment that's being passed to Configure
+__CNF_CPPDEFINES=
+__CNF_CPPINCLUDES=
+__CNF_CPPFLAGS=
+__CNF_CFLAGS=
+__CNF_CXXFLAGS=
+__CNF_LDFLAGS=
+__CNF_LDLIBS=
+
 # First get uname entries that we use below
 
 [ "$MACHINE" ] || MACHINE=`(uname -m) 2>/dev/null` || MACHINE="unknown"
@@ -504,10 +513,12 @@ case "$GUESSOS" in
 	    OUT="darwin64-x86_64-cc"
 	fi ;;
   armv6+7-*-iphoneos)
-	options="$options -arch%20armv6 -arch%20armv7"
+	__CNF_CFLAGS="$__CNF_CFLAGS -arch%20armv6 -arch%20armv7"
+	__CNF_CXXFLAGS="$__CNF_CXXFLAGS -arch%20armv6 -arch%20armv7"
 	OUT="iphoneos-cross" ;;
   *-*-iphoneos)
-	options="$options -arch%20${MACHINE}"
+	__CNF_CFLAGS="$__CNF_CFLAGS -arch%20${MACHINE}"
+	__CNF_CXXFLAGS="$__CNF_CXXFLAGS -arch%20${MACHINE}"
 	OUT="iphoneos-cross" ;;
   arm64-*-iphoneos|*-*-ios64)
 	OUT="ios64-cross" ;;
@@ -519,9 +530,12 @@ case "$GUESSOS" in
 	esac
 	if [ "$CC" = "gcc" ]; then
 	    case ${ISA:-generic} in
-	    EV5|EV45)		options="$options -mcpu=ev5";;
-	    EV56|PCA56)		options="$options -mcpu=ev56";;
-	    *)			options="$options -mcpu=ev6";;
+	    EV5|EV45)		__CNF_CFLAGS="$__CNF_CFLAGS -mcpu=ev5"
+                                __CNF_CXXFLAGS="$__CNF_CFLAGS -mcpu=ev5";;
+	    EV56|PCA56)		__CNF_CFLAGS="$__CNF_CFLAGS -mcpu=ev56"
+                                __CNF_CXXFLAGS="$__CNF_CXXFLAGS -mcpu=ev56";;
+	    *)			__CNF_CFLAGS="$__CNF_CFLAGS -mcpu=ev6"
+                                __CNF_CXXFLAGS="$__CNF_CXXFLAGS -mcpu=ev6";;
 	    esac
 	fi
 	;;
@@ -538,7 +552,12 @@ case "$GUESSOS" in
 	    OUT="linux-ppc64"
 	else
 	    OUT="linux-ppc"
-	    (echo "__LP64__" | gcc -E -x c - 2>/dev/null | grep "^__LP64__" 2>&1 > /dev/null) || options="$options -m32"
+	    if (echo "__LP64__" | gcc -E -x c - 2>/dev/null | grep "^__LP64__" 2>&1 > /dev/null); then
+                :;
+            else
+                __CNF_CFLAGS="$__CNF_CFLAGS -m32"
+                __CNF_CXXFLAGS="$__CNF_CXXFLAGS -m32"
+            fi
 	fi
 	;;
   ppc64le-*-linux2) OUT="linux-ppc64le" ;;
@@ -574,7 +593,8 @@ case "$GUESSOS" in
 	sun4u*)	OUT="linux-sparcv9" ;;
 	sun4m)	OUT="linux-sparcv8" ;;
 	sun4d)	OUT="linux-sparcv8" ;;
-	*)	OUT="linux-generic32"; options="$options -DB_ENDIAN" ;;
+	*)	OUT="linux-generic32";
+                __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
 	esac ;;
   parisc*-*-linux2)
 	# 64-bit builds under parisc64 linux are not supported and
@@ -596,16 +616,21 @@ case "$GUESSOS" in
 	CPUSCHEDULE=`echo $CPUSCHEDULE|sed -e 's/7300LC/7100LC/' -e 's/8.00/8000/'`
 	# Finish Model transformations
 
-	options="$options -DB_ENDIAN -mschedule=$CPUSCHEDULE -march=$CPUARCH"
+	__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN"
+        __CNF_CFLAGS="$__CNF_CFLAGS -mschedule=$CPUSCHEDULE -march=$CPUARCH"
+        __CNF_CXXFLAGS="$__CNF_CXXFLAGS -mschedule=$CPUSCHEDULE -march=$CPUARCH"
 	OUT="linux-generic32" ;;
   armv[1-3]*-*-linux2) OUT="linux-generic32" ;;
-  armv[7-9]*-*-linux2) OUT="linux-armv4"; options="$options -march=armv7-a" ;;
+  armv[7-9]*-*-linux2) OUT="linux-armv4"
+                       __CNF_CFLAGS="$__CNF_CFLAGS -march=armv7-a"
+                       __CNF_CXXFLAGS="$__CNF_CXXFLAGS -march=armv7-a"
+                       ;;
   arm*-*-linux2) OUT="linux-armv4" ;;
   aarch64-*-linux2) OUT="linux-aarch64" ;;
-  sh*b-*-linux2) OUT="linux-generic32"; options="$options -DB_ENDIAN" ;;
-  sh*-*-linux2)  OUT="linux-generic32"; options="$options -DL_ENDIAN" ;;
-  m68k*-*-linux2) OUT="linux-generic32"; options="$options -DB_ENDIAN" ;;
-  s390-*-linux2) OUT="linux-generic32"; options="$options -DB_ENDIAN" ;;
+  sh*b-*-linux2) OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+  sh*-*-linux2)  OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
+  m68k*-*-linux2) OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+  s390-*-linux2) OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
   s390x-*-linux2)
 	# To be uncommented when glibc bug is fixed, see Configure...
 	#if egrep -e '^features.* highgprs' /proc/cpuinfo >/dev/null ; then
@@ -687,9 +712,12 @@ case "$GUESSOS" in
 	;;
   *-*-sunos4)		OUT="sunos-$CC" ;;
 
-  *86*-*-bsdi4)		OUT="BSD-x86-elf"; options="$options no-sse2 -ldl" ;;
-  alpha*-*-*bsd*)	OUT="BSD-generic64"; options="$options -DL_ENDIAN" ;;
-  powerpc64-*-*bsd*)	OUT="BSD-generic64"; options="$options -DB_ENDIAN" ;;
+  *86*-*-bsdi4)		OUT="BSD-x86-elf"; options="$options no-sse2";
+                        __CNF_LDFLAGS="$__CNF_LDFLAGS -ldl" ;;
+  alpha*-*-*bsd*)	OUT="BSD-generic64";
+                        __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
+  powerpc64-*-*bsd*)	OUT="BSD-generic64";
+                        __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
   sparc64-*-*bsd*)	OUT="BSD-sparc64" ;;
   ia64-*-*bsd*)		OUT="BSD-ia64" ;;
   x86_64-*-dragonfly*)  OUT="BSD-x86_64" ;;
@@ -716,7 +744,8 @@ case "$GUESSOS" in
 	if [ "$CC" = "gcc" ]; then
 	  OUT="unixware-7-gcc" ; options="$options no-sse2"
 	else    
-	  OUT="unixware-7" ; options="$options no-sse2 -D__i386__"
+	  OUT="unixware-7" ; options="$options no-sse2"
+          __CNF_CPPFLAGS="$__CNF_CPPFLAGS -D__i386__"
 	fi
 	;;
   *-*-[Uu]nix[Ww]are20*) OUT="unixware-2.0"; options="$options no-sse2 no-sha512" ;;
@@ -763,7 +792,7 @@ case "$GUESSOS" in
 	else					# Motorola(?) CPU
 	     OUT="hpux-$CC"
 	fi
-	options="$options -D_REENTRANT" ;;
+	__CNF_CPPFLAGS="$__CNF_CPPFLAGS -D_REENTRANT" ;;
   *-hpux)	OUT="hpux-parisc-$CC" ;;
   *-aix)
 	[ "$KERNEL_BITS" ] || KERNEL_BITS=`(getconf KERNEL_BITMODE) 2>/dev/null`
@@ -802,7 +831,9 @@ case "$GUESSOS" in
   *-*-qnx6) OUT="QNX6" ;;
   x86-*-android|i?86-*-android) OUT="android-x86" ;;
   armv[7-9]*-*-android)
-      OUT="android-armeabi"; options="$options -march=armv7-a" ;;
+      OUT="android-armeabi"
+      __CNF_CFLAGS="$__CNF_CFLAGS -march=armv7-a"
+      __CNF_CXXFLAGS="$__CNF_CXXFLAGS -march=armv7-a";;
   arm*-*-android) OUT="android-armeabi" ;;
   *) OUT=`echo $GUESSOS | awk -F- '{print $3}'`;;
 esac
@@ -816,7 +847,7 @@ esac
 # See whether we can compile Atalla support
 #if [ -f /usr/include/atasi.h ]
 #then
-#  options="$options -DATALLA"
+#  __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DATALLA"
 #fi
 
 if [ -n "$CONFIG_OPTIONS" ]; then
@@ -824,9 +855,11 @@ if [ -n "$CONFIG_OPTIONS" ]; then
 fi
 
 if expr "$options" : '.*no\-asm' > /dev/null; then :; else
-  sh -c "$CROSS_COMPILE${CC:-gcc} -Wa,--help -c -o /tmp/null.$$.o -x assembler /dev/null && rm /tmp/null.$$.o" 2>&1 | \
-  grep \\--noexecstack >/dev/null && \
-  options="$options -Wa,--noexecstack"
+  if sh -c "$CROSS_COMPILE${CC:-gcc} -Wa,--help -c -o /tmp/null.$$.o -x assembler /dev/null && rm /tmp/null.$$.o" 2>&1 | \
+         grep \\--noexecstack >/dev/null; then
+    __CNF_CFLAGS="$__CNF_CFLAGS -Wa,--noexecstack"
+    __CNF_CXXFLAGS="$__CNF_CXXFLAGS -Wa,--noexecstack"
+  fi
 fi
 
 # gcc < 2.8 does not support -march=ultrasparc
@@ -900,12 +933,28 @@ OUT="$OUT"
 $PERL $THERE/Configure LIST | grep "$OUT" > /dev/null
 if [ $? = "0" ]; then
   if [ "$VERBOSE" = "true" ]; then
-    echo $PERL $THERE/Configure $OUT $options
+      echo /usr/bin/env \
+           __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \
+           __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
+           __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
+           __CNF_CFLAGS="'$__CNF_CFLAGS'" \
+           __CNF_CXXFLAGS="'$__CNF_CXXFLAGS'" \
+           __CNF_LDFLAGS="'$__CNF_LDFLAGS'" \
+           __CNF_LDLIBS="'$__CNF_LDLIBS'" \
+           $PERL $THERE/Configure $OUT $options
   fi  
   if [ "$DRYRUN" = "false" ]; then
     # eval to make sure quoted options, possibly with spaces inside,
     # are treated right
-    eval $PERL $THERE/Configure $OUT $options
+      eval /usr/bin/env \
+           __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \
+           __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
+           __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
+           __CNF_CFLAGS="'$__CNF_CFLAGS'" \
+           __CNF_CXXFLAGS="'$__CNF_CXXFLAGS'" \
+           __CNF_LDFLAGS="'$__CNF_LDFLAGS'" \
+           __CNF_LDLIBS="'$__CNF_LDLIBS'" \
+           $PERL $THERE/Configure $OUT $options
   fi
 else
   echo "This system ($OUT) is not supported. See file INSTALL for details."

--- a/config
+++ b/config
@@ -531,11 +531,11 @@ case "$GUESSOS" in
 	if [ "$CC" = "gcc" ]; then
 	    case ${ISA:-generic} in
 	    EV5|EV45)		__CNF_CFLAGS="$__CNF_CFLAGS -mcpu=ev5"
-                                __CNF_CXXFLAGS="$__CNF_CFLAGS -mcpu=ev5";;
+				__CNF_CXXFLAGS="$__CNF_CFLAGS -mcpu=ev5";;
 	    EV56|PCA56)		__CNF_CFLAGS="$__CNF_CFLAGS -mcpu=ev56"
-                                __CNF_CXXFLAGS="$__CNF_CXXFLAGS -mcpu=ev56";;
+				__CNF_CXXFLAGS="$__CNF_CXXFLAGS -mcpu=ev56";;
 	    *)			__CNF_CFLAGS="$__CNF_CFLAGS -mcpu=ev6"
-                                __CNF_CXXFLAGS="$__CNF_CXXFLAGS -mcpu=ev6";;
+				__CNF_CXXFLAGS="$__CNF_CXXFLAGS -mcpu=ev6";;
 	    esac
 	fi
 	;;
@@ -553,11 +553,11 @@ case "$GUESSOS" in
 	else
 	    OUT="linux-ppc"
 	    if (echo "__LP64__" | gcc -E -x c - 2>/dev/null | grep "^__LP64__" 2>&1 > /dev/null); then
-                :;
-            else
-                __CNF_CFLAGS="$__CNF_CFLAGS -m32"
-                __CNF_CXXFLAGS="$__CNF_CXXFLAGS -m32"
-            fi
+		:;
+	    else
+		__CNF_CFLAGS="$__CNF_CFLAGS -m32"
+		__CNF_CXXFLAGS="$__CNF_CXXFLAGS -m32"
+	    fi
 	fi
 	;;
   ppc64le-*-linux2) OUT="linux-ppc64le" ;;
@@ -594,7 +594,7 @@ case "$GUESSOS" in
 	sun4m)	OUT="linux-sparcv8" ;;
 	sun4d)	OUT="linux-sparcv8" ;;
 	*)	OUT="linux-generic32";
-                __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+		__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
 	esac ;;
   parisc*-*-linux2)
 	# 64-bit builds under parisc64 linux are not supported and
@@ -617,20 +617,24 @@ case "$GUESSOS" in
 	# Finish Model transformations
 
 	__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN"
-        __CNF_CFLAGS="$__CNF_CFLAGS -mschedule=$CPUSCHEDULE -march=$CPUARCH"
-        __CNF_CXXFLAGS="$__CNF_CXXFLAGS -mschedule=$CPUSCHEDULE -march=$CPUARCH"
+	__CNF_CFLAGS="$__CNF_CFLAGS -mschedule=$CPUSCHEDULE -march=$CPUARCH"
+	__CNF_CXXFLAGS="$__CNF_CXXFLAGS -mschedule=$CPUSCHEDULE -march=$CPUARCH"
 	OUT="linux-generic32" ;;
   armv[1-3]*-*-linux2) OUT="linux-generic32" ;;
   armv[7-9]*-*-linux2) OUT="linux-armv4"
-                       __CNF_CFLAGS="$__CNF_CFLAGS -march=armv7-a"
-                       __CNF_CXXFLAGS="$__CNF_CXXFLAGS -march=armv7-a"
-                       ;;
+		       __CNF_CFLAGS="$__CNF_CFLAGS -march=armv7-a"
+		       __CNF_CXXFLAGS="$__CNF_CXXFLAGS -march=armv7-a"
+		       ;;
   arm*-*-linux2) OUT="linux-armv4" ;;
   aarch64-*-linux2) OUT="linux-aarch64" ;;
-  sh*b-*-linux2) OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
-  sh*-*-linux2)  OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
-  m68k*-*-linux2) OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
-  s390-*-linux2) OUT="linux-generic32"; __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+  sh*b-*-linux2) OUT="linux-generic32";
+		 __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+  sh*-*-linux2)	 OUT="linux-generic32";
+		 __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
+  m68k*-*-linux2) OUT="linux-generic32";
+		  __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+  s390-*-linux2) OUT="linux-generic32";
+		 __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
   s390x-*-linux2)
 	# To be uncommented when glibc bug is fixed, see Configure...
 	#if egrep -e '^features.* highgprs' /proc/cpuinfo >/dev/null ; then
@@ -713,11 +717,11 @@ case "$GUESSOS" in
   *-*-sunos4)		OUT="sunos-$CC" ;;
 
   *86*-*-bsdi4)		OUT="BSD-x86-elf"; options="$options no-sse2";
-                        __CNF_LDFLAGS="$__CNF_LDFLAGS -ldl" ;;
+			__CNF_LDFLAGS="$__CNF_LDFLAGS -ldl" ;;
   alpha*-*-*bsd*)	OUT="BSD-generic64";
-                        __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
+			__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
   powerpc64-*-*bsd*)	OUT="BSD-generic64";
-                        __CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+			__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
   sparc64-*-*bsd*)	OUT="BSD-sparc64" ;;
   ia64-*-*bsd*)		OUT="BSD-ia64" ;;
   x86_64-*-dragonfly*)  OUT="BSD-x86_64" ;;
@@ -745,7 +749,7 @@ case "$GUESSOS" in
 	  OUT="unixware-7-gcc" ; options="$options no-sse2"
 	else    
 	  OUT="unixware-7" ; options="$options no-sse2"
-          __CNF_CPPFLAGS="$__CNF_CPPFLAGS -D__i386__"
+	  __CNF_CPPFLAGS="$__CNF_CPPFLAGS -D__i386__"
 	fi
 	;;
   *-*-[Uu]nix[Ww]are20*) OUT="unixware-2.0"; options="$options no-sse2 no-sha512" ;;
@@ -933,28 +937,28 @@ OUT="$OUT"
 $PERL $THERE/Configure LIST | grep "$OUT" > /dev/null
 if [ $? = "0" ]; then
   if [ "$VERBOSE" = "true" ]; then
-      echo /usr/bin/env \
-           __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \
-           __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
-           __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
-           __CNF_CFLAGS="'$__CNF_CFLAGS'" \
-           __CNF_CXXFLAGS="'$__CNF_CXXFLAGS'" \
-           __CNF_LDFLAGS="'$__CNF_LDFLAGS'" \
-           __CNF_LDLIBS="'$__CNF_LDLIBS'" \
-           $PERL $THERE/Configure $OUT $options
+    echo /usr/bin/env \
+	 __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \
+	 __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
+	 __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
+	 __CNF_CFLAGS="'$__CNF_CFLAGS'" \
+	 __CNF_CXXFLAGS="'$__CNF_CXXFLAGS'" \
+	 __CNF_LDFLAGS="'$__CNF_LDFLAGS'" \
+	 __CNF_LDLIBS="'$__CNF_LDLIBS'" \
+	 $PERL $THERE/Configure $OUT $options
   fi  
   if [ "$DRYRUN" = "false" ]; then
     # eval to make sure quoted options, possibly with spaces inside,
     # are treated right
-      eval /usr/bin/env \
-           __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \
-           __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
-           __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
-           __CNF_CFLAGS="'$__CNF_CFLAGS'" \
-           __CNF_CXXFLAGS="'$__CNF_CXXFLAGS'" \
-           __CNF_LDFLAGS="'$__CNF_LDFLAGS'" \
-           __CNF_LDLIBS="'$__CNF_LDLIBS'" \
-           $PERL $THERE/Configure $OUT $options
+    eval /usr/bin/env \
+	 __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \
+	 __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
+	 __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
+	 __CNF_CFLAGS="'$__CNF_CFLAGS'" \
+	 __CNF_CXXFLAGS="'$__CNF_CXXFLAGS'" \
+	 __CNF_LDFLAGS="'$__CNF_LDFLAGS'" \
+	 __CNF_LDLIBS="'$__CNF_LDLIBS'" \
+	 $PERL $THERE/Configure $OUT $options
   fi
 else
   echo "This system ($OUT) is not supported. See file INSTALL for details."

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -11,7 +11,7 @@ EXTRA=  ../ms/uplink-x86.pl ../ms/uplink.c ../ms/applink.c \
         ppccpuid.pl pariscid.pl alphacpuid.pl arm64cpuid.pl armv4cpuid.pl
 
 DEPEND[cversion.o]=buildinf.h
-GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
+GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(CNF_CFLAGS) $(CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
 DEPEND[buildinf.h]=../configdata.pm
 
 GENERATE[uplink-x86.s]=../ms/uplink-x86.pl $(PERLASM_SCHEME)

--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -1,4 +1,4 @@
-#!{- $config{hashbangperl} -}
+#!{- $config{HASHBANGPERL} -}
 
 # {- join("\n# ", @autowarntext) -}
 # Copyright 1999-2016 The OpenSSL Project Authors. All Rights Reserved.


### PR DESCRIPTION
With the support of "make variables" comes the possibility for the
user to override them.  However, we need to make a difference between
defaults that we use (and that should be overridable by the user) and
flags that are crucial for building OpenSSL (should not be
overridable).

Typically, overridable flags are those setting optimization levels,
warnings levels, that kind of thing, while non-overridable flags are,
for example, macros that indicate aspects of how the config target
should be treated, such as L_ENDIAN and B_ENDIAN.

We do that differentiation by allowing upper case attributes in the
config targets, named exactly like the "make variables" we support,
and reserving the lower case attributes for non-overridable project
flags.
