### PR TITLE
Configurations/10-main.conf: add -fno-common back to darwin-ppc-cc.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1583,6 +1583,7 @@ sub vms_info {
         inherit_from     => [ "darwin-common", asm("ppc32_asm") ],
         cflags           => add("-arch ppc -std=gnu9x -DB_ENDIAN -Wa,-force_cpusubtype_ALL"),
         perlasm_scheme   => "osx32",
+        shared_cflag     => add("-fno-common"),
         shared_ldflag    => "-arch ppc -dynamiclib",
     },
     "darwin64-ppc-cc" => {


### PR DESCRIPTION
-fno-common was removed for all Darwin targets in
0c8734198d4282f6997965a03cd2e0ceaf207549 with rationale "it's either
'ranlib -c' or '-fno-common'." However, it's still absolutely required
in 32-bit darwin-ppc-cc. And when trying things out I didn't quite
see why it was formulated as one-or-another choice, as 'ranlib -c'
shouldn't [and doesn't] have problems with object modules without
commons. [Well, to be frank, I didn't manage to reproduce the problem
the modification was meaning to resolve either...]

(backport of 107783d9c56e7dcb338c011fa202ffa8f066dbca)

#5518 didn't cherry-pick :-(