### PR TITLE
Frees alpn_selected before reassigning it

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1623,6 +1623,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
     if (!s->hit) {
         /* If a new session then update it with the selected ALPN */
+        OPENSSL_free(s->session->ext.alpn_selected);
         s->session->ext.alpn_selected =
             OPENSSL_memdup(s->s3->alpn_selected, s->s3->alpn_selected_len);
         if (s->session->ext.alpn_selected == NULL) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2101,6 +2101,7 @@ int tls_handle_alpn(SSL *s)
 
                 if (!s->hit) {
                     /* If a new session update it with the new ALPN value */
+                    OPENSSL_free(s->session->ext.alpn_selected);
                     s->session->ext.alpn_selected = OPENSSL_memdup(selected,
                                                                    selected_len);
                     if (s->session->ext.alpn_selected == NULL) {


### PR DESCRIPTION
To avoid memory leaks.

I am not sure if a memory leak can really happen now but :
- code and comments do not explain how memory leaks are avoided 
- it is the only calls to `OPENSSL_memdup` which were not following a `OPENSSL_free` 

For server side, I found no leaks as :
- `tls_handle_alpn`assumes we only have one client hello by handshake
- `tls_parse_ctos_alpn`assigns alpn_proposed only on first handshake