### PR TITLE
speed: add ecdhx448 to ecdh choices

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -118,7 +118,7 @@
 #define RSA_NUM         7
 #define DSA_NUM         3
 
-#define EC_NUM          17
+#define EC_NUM          18
 #define MAX_ECDH_SIZE   256
 #define MISALIGN        64
 
@@ -533,6 +533,7 @@ static OPT_PAIR rsa_choices[] = {
 #define R_EC_B409    14
 #define R_EC_B571    15
 #define R_EC_X25519  16
+#define R_EC_X448    17
 #ifndef OPENSSL_NO_EC
 static OPT_PAIR ecdsa_choices[] = {
     {"ecdsap160", R_EC_P160},
@@ -572,6 +573,7 @@ static OPT_PAIR ecdh_choices[] = {
     {"ecdhb409", R_EC_B409},
     {"ecdhb571", R_EC_B571},
     {"ecdhx25519", R_EC_X25519},
+    {"ecdhx448", R_EC_X448},
     {NULL}
 };
 #endif
@@ -1377,7 +1379,7 @@ int speed_main(int argc, char **argv)
         NID_sect233r1, NID_sect283r1, NID_sect409r1,
         NID_sect571r1,
         /* Other */
-        NID_X25519
+        NID_X25519, NID_X448
     };
     static const char *test_curves_names[EC_NUM] = {
         /* Prime Curves */
@@ -1389,7 +1391,7 @@ int speed_main(int argc, char **argv)
         "nistb233", "nistb283", "nistb409",
         "nistb571",
         /* Other */
-        "X25519"
+        "X25519", "X448"
     };
     static const int test_curves_bits[EC_NUM] = {
         160, 192, 224,
@@ -1397,7 +1399,7 @@ int speed_main(int argc, char **argv)
         163, 233, 283,
         409, 571, 163,
         233, 283, 409,
-        571, 253                /* X25519 */
+        571, 253, 448
     };
 
     int ecdsa_doit[EC_NUM] = { 0 };


### PR DESCRIPTION
I noticed that `ecdhx25519` was an option for `openssl speed`, but `ecdhx448` wasn't added when Ed448/X448 support was implemented.