### PR TITLE
shorten the travis output so that it fits into viewer

### DIFF
--- a/.travis-create-release.sh
+++ b/.travis-create-release.sh
@@ -5,7 +5,7 @@
 ./Configure dist
 if [ "$1" == osx ]; then
     make NAME='_srcdist' TARFILE='_srcdist.tar' \
-         TAR_COMMAND='$(TAR) $(TARFLAGS) -cvf -' tar
+         TAR_COMMAND='$(TAR) $(TARFLAGS) -cf -' tar
 else
     make TARFILE='_srcdist.tar' NAME='_srcdist' dist
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ before_script:
       fi
     - if [ -n "$DESTDIR" ]; then
           sh .travis-create-release.sh $TRAVIS_OS_NAME;
-          tar -xvzf _srcdist.tar.gz;
+          tar -xzf _srcdist.tar.gz;
           mkdir _build;
           cd _build;
           srcdir=../_srcdist;
@@ -133,14 +133,14 @@ before_script:
           srcdir=.;
           top=.;
       fi
-    - if [ "$CC" == i686-w64-mingw32-gcc ]; then
+    - if [ "$CC" = i686-w64-mingw32-gcc ]; then
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw $CONFIG_OPTS -Wno-pedantic-ms-format;
-      elif [ "$CC" == x86_64-w64-mingw32-gcc ]; then
+      elif [ "$CC" = x86_64-w64-mingw32-gcc ]; then
           export CROSS_COMPILE=${CC%%gcc}; unset CC;
           $srcdir/Configure mingw64 $CONFIG_OPTS -Wno-pedantic-ms-format;
       else
-          if [ "$CC" == clang-3.9 ]; then
+          if [ "$CC" = clang-3.9 ]; then
               sudo cp .travis-apt-pin.preferences /etc/apt/preferences.d/no-ubuntu-clang;
               curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -;
               echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee -a /etc/apt/sources.list > /dev/null;
@@ -199,18 +199,22 @@ script:
               echo -e '+\057\057\057\057 MAKE TEST FAILED'; false;
           fi;
       else
-          if $make build_tests; then
+          if $make build_tests >~/build.log 2>&1; then
               echo -e '+\057\057\057\057\057 MAKE BUILD_TESTS OK';
           else
-              echo -e '+\057\057\057\057\057 MAKE BUILD_TESTS FAILED'; false;
+              echo -e '+\057\057\057\057\057 MAKE BUILD_TESTS FAILED';
+              cat ~/build.log
+              false;
           fi;
       fi
     - if [ -n "$DESTDIR" ]; then
           mkdir "$top/$DESTDIR";
-          if $make install install_docs DESTDIR="$top/$DESTDIR"; then
+          if $make install install_docs DESTDIR="$top/$DESTDIR" >~/install_docs.log 2>&1 ; then
               echo -e '+\057\057\057\057\057\057 MAKE INSTALL OK';
           else
-              echo -e '+\057\057\057\057\057\057 MAKE INSTALL FAILED'; false;
+              echo -e '+\057\057\057\057\057\057 MAKE INSTALL FAILED';
+              cat ~/install_docs.log;
+              false;
           fi;
       fi
     - cd $top

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -787,7 +787,7 @@ tags TAGS: FORCE
 
 # If your tar command doesn't support --owner and --group, make sure to
 # use one that does, for example GNU tar
-TAR_COMMAND=$(TAR) $(TARFLAGS) --owner 0 --group 0 -cvf -
+TAR_COMMAND=$(TAR) $(TARFLAGS) --owner 0 --group 0 -cf -
 PREPARE_CMD=:
 tar:
 	set -e; \


### PR DESCRIPTION
travis builds the tar file and extracts it with "v" option, which results in around 6000 lines of junk,
and the buffer is only about 10,000 lines long.  Not all of the -v options are removed, as one could 
not be located.
The build process only needs to be seen if it fails.
The make install progress does not need to be logged. 
