### PR TITLE
Fix miscellaneous typos in docs and source

### DIFF
--- a/crypto/bn/asm/ppc.pl
+++ b/crypto/bn/asm/ppc.pl
@@ -40,7 +40,7 @@
 #dsa  512 bits   0.0087s   0.0106s    114.3     94.5
 #dsa 1024 bits   0.0256s   0.0313s     39.0     32.0
 #
-#	Same bechmark with this assembler code:
+#	Same benchmark with this assembler code:
 #
 #rsa  512 bits   0.0056s   0.0005s    178.6   2049.2
 #rsa 1024 bits   0.0283s   0.0015s     35.3    674.1

--- a/doc/man1/speed.pod
+++ b/doc/man1/speed.pod
@@ -73,11 +73,11 @@ is only effective if RSA algorithm is specified to test.
 
 =item B<-seconds num>
 
-Run bechmarks for B<num> seconds.
+Run benchmarks for B<num> seconds.
 
 =item B<-bytes num>
 
-Run bechmarks on B<num>-byte buffers. Affects ciphers, digests and the CSPRNG.
+Run benchmarks on B<num>-byte buffers. Affects ciphers, digests and the CSPRNG.
 
 =item B<[zero or more test algorithms]>
 

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -44,7 +44,7 @@ These functions are similar to the d2i_X509() functions; see L<d2i_X509(3)>.
 
 All these functions use DER format and unencrypted keys. Applications wishing
 to encrypt or decrypt private keys should use other functions such as
-d2i_PKC8PrivateKey() instead.
+d2i_PKCS8PrivateKey() instead.
 
 If the B<*a> is not NULL when calling d2i_PrivateKey() or d2i_AutoPrivateKey()
 (i.e. an existing structure is being reused) and the key format is PKCS#8

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1086,10 +1086,10 @@ static int ssl_print_client_keyex(BIO *bio, int indent, const SSL *ssl,
     case SSL_kRSAPSK:
         if (TLS1_get_version(ssl) == SSL3_VERSION) {
             ssl_print_hex(bio, indent + 2,
-                          "EncyptedPreMasterSecret", msg, msglen);
+                          "EncryptedPreMasterSecret", msg, msglen);
         } else {
             if (!ssl_print_hexbuf(bio, indent + 2,
-                                  "EncyptedPreMasterSecret", 2, &msg, &msglen))
+                                  "EncryptedPreMasterSecret", 2, &msg, &msglen))
                 return 0;
         }
         break;

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -63,7 +63,7 @@ $proxy->start();
 ok(TLSProxy::Message->fail(), "PSK not last");
 
 #Test 3: Attempt a resume after an HRR where PSK hash matches selected
-#        ciperhsuite. Should see PSK on second ClientHello
+#        ciphersuite. Should see PSK on second ClientHello
 $proxy->clear();
 $proxy->clientflags("-sess_in ".$session);
 $proxy->serverflags("-curves P-256");


### PR DESCRIPTION
#### Fix miscellaneous typos in docs and source

- d2i_PKC8PrivateKey -> d2i_PKCS8PrivateKey
- bechmark -> benchmark
- ciperhsuite -> ciphersuite
- EncyptedPreMasterSecret -> EncryptedPreMasterSecret

Update: Originally it was my intention to backport the fixes as possible. However, since none of the recent typo fixes was backported, I won't bother to do it either.
