### PR TITLE
Restore the display of options with 'openssl version -a'

### DIFF
--- a/apps/version.c
+++ b/apps/version.c
@@ -105,7 +105,8 @@ opthelp:
             dirty = version = 1;
             break;
         case OPT_A:
-            seed = cflags = version = date = platform = dir = engdir = 1;
+            seed = options = cflags = version = date = platform = dir = engdir
+                = 1;
             break;
         }
     }


### PR DESCRIPTION
I assume this was omitted by mistake before 1.1.0 was released.