### PR TITLE
RAND_DRBG: add a function for setting the reseeding defaults

### DIFF
--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -366,6 +366,6 @@ int drbg_ctr_init(RAND_DRBG *drbg)
     }
 
     drbg->max_request = 1 << 16;
-    drbg->reseed_interval = MAX_RESEED_INTERVAL;
+
     return 1;
 }

--- a/include/internal/rand.h
+++ b/include/internal/rand.h
@@ -56,6 +56,13 @@ int RAND_DRBG_bytes(RAND_DRBG *drbg, unsigned char *out, size_t outlen);
 int RAND_DRBG_set_reseed_interval(RAND_DRBG *drbg, unsigned int interval);
 int RAND_DRBG_set_reseed_time_interval(RAND_DRBG *drbg, time_t interval);
 
+int RAND_DRBG_set_reseed_defaults(
+                                  unsigned int master_reseed_interval,
+                                  unsigned int slave_reseed_interval,
+                                  time_t master_reseed_time_interval,
+                                  time_t slave_reseed_time_interval
+                                  );
+
 RAND_DRBG *RAND_DRBG_get0_master(void);
 RAND_DRBG *RAND_DRBG_get0_public(void);
 RAND_DRBG *RAND_DRBG_get0_private(void);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4521,3 +4521,4 @@ OSSL_STORE_SEARCH_by_alias              4462	1_1_1	EXIST::FUNCTION:
 OSSL_STORE_LOADER_set_find              4463	1_1_1	EXIST::FUNCTION:
 OSSL_STORE_SEARCH_free                  4464	1_1_1	EXIST::FUNCTION:
 OSSL_STORE_SEARCH_get0_digest           4465	1_1_1	EXIST::FUNCTION:
+RAND_DRBG_set_reseed_defaults           4466	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
The introduction of thread local public and private DRBG instances makes it very cumbersome to change the reseeding (time) intervals for those instances, see https://github.com/openssl/openssl/pull/5547#pullrequestreview-102119053. This commit provides a function to set the default values for all subsequently created DRBG instances.

```
 int RAND_DRBG_set_reseed_defaults(
                                   unsigned int master_reseed_interval,
                                   unsigned int slave_reseed_interval,
                                   time_t master_reseed_time_interval,
                                   time_t slave_reseed_time_interval
                                   )
```
The function is intended only to be used during application initialization, before any threads are created and before any random bytes are generated.

~~This pull request is based on top of #5462. (Only the second commit is relevant.) It will have to be adopted to the thread local case (#5547) after that one is merged, or vice versa.~~

Edit: this pull request does not conflict with #5547.

##### Checklist
- [ ] documentation will be added by #5461
