### PR TITLE
Attempt to fix boringssl tests

### DIFF
--- a/test/ossl_shim/build.info
+++ b/test/ossl_shim/build.info
@@ -1,4 +1,4 @@
-IF[{- defined $target{cxx} && !$disabled{"external-tests"}-}]
+IF[{- defined $target{CXX} && !$disabled{"external-tests"} -}]
   PROGRAMS_NO_INST=ossl_shim
   SOURCE[ossl_shim]=ossl_shim.cc async_bio.cc packeted_bio.cc test_config.cc
   INCLUDE[ossl_shim]=. include ../../include


### PR DESCRIPTION
Maybe this build.info formatting nit causes a template expansion
failure so we don't actually process the stanzas needed to provide make
rules for test/ossl_shim/ossl_shim, and thus the boringssl tests fail
to find it at runtime and panic.

[extended tests]

