### PR TITLE
Configurations/unix-Makefile.tmpl: overhaul assembler make rules.

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -98,8 +98,7 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
 GENERATED={- join(" ",
-                  ( map { (my $x = $_) =~ s|\.S$|\.s|; $x }
-                    grep { defined $unified_info{generate}->{$_} }
+                  ( grep { defined $unified_info{generate}->{$_} }
                     map { @{$unified_info{sources}->{$_}} }
                     grep { /\.o$/ } keys %{$unified_info{sources}} ),
                   ( grep { /\.h$/ } keys %{$unified_info{generate}} )) -}
@@ -800,20 +799,6 @@ EOF
           }
 
           if (defined($generator)) {
-              # If the target is named foo.S in build.info, we want to
-              # end up generating foo.s in two steps.
-              if ($args{src} =~ /\.S$/) {
-                   (my $target = $args{src}) =~ s|\.S$|.s|;
-                   return <<"EOF";
-$target: $args{generator}->[0] $deps
-	( trap "rm -f \$@.*" INT 0; \\
-	  $generator \$@.S; \\
-	  \$(CC) $incs \$(CFLAGS) -E \$@.S | \\
-	  \$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@.i && \\
-	  mv -f \$@.i \$@ )
-EOF
-              }
-              # Otherwise....
               return <<"EOF";
 $args{src}: $args{generator}->[0] $deps
 	$generator \$@
@@ -833,12 +818,7 @@ EOF
   sub src2obj {
       my %args = @_;
       my $obj = $args{obj};
-      my @srcs = map { if ($unified_info{generate}->{$_}) {
-                           (my $x = $_) =~ s/\.S$/.s/; $x
-                       } else {
-                           $_
-                       }
-                     } ( @{$args{srcs}} );
+      my @srcs = @{$args{srcs}};
       my $srcs = join(" ",  @srcs);
       my $deps = join(" ", @srcs, @{$args{deps}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
@@ -851,11 +831,30 @@ EOF
                       dso => '$(DSO_CFLAGS)',
                       bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
       my $makedepprog = $config{makedepprog};
-      my $recipe = <<"EOF";
-$obj$objext: $deps
-EOF
-      if (!$disabled{makedepend} && $makedepprog !~ /\/makedepend/) {
+      my $recipe;
+      # extension-specific rules
+      if (grep /\.s$/, @srcs) {
           $recipe .= <<"EOF";
+$obj$objext: $deps
+	\$(CC) \$(CFLAGS) $ecflags -c -o \$\@ $srcs
+EOF
+      } elsif (grep /\.S$/, @srcs) {
+          # In case one wonders why not just $(CC) -c file.S. While it
+          # does work with contemporary compilers, there are some legacy
+          # ones that get it wrong. Hence the elaborate scheme... We
+          # don't care to maintain dependecy lists, because dependency
+          # is rather weak, at most one header file that lists constants
+          # which are assigned in ascending order.
+          $recipe .= <<"EOF";
+$obj$objext: $deps
+	( trap "rm -f \$@.*" INT 0; \\
+	  \$(CPP) $incs \$(CFLAGS) $ecflags $srcs | \\
+	  \$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@.s && \\
+	  \$(CC) \$(CFLAGS) $ecflags -c -o \$\@ \$@.s )
+EOF
+      } elsif (!$disabled{makedepend} && $makedepprog !~ /\/makedepend/) {
+          $recipe .= <<"EOF";
+$obj$objext: $deps
 	\$(CC) $incs \$(CFLAGS) $ecflags -MMD -MF $obj$depext.tmp -MT \$\@ -c -o \$\@ $srcs
 	\@touch $obj$depext.tmp
 	\@if cmp $obj$depext.tmp $obj$depext > /dev/null 2> /dev/null; then \\
@@ -866,6 +865,7 @@ EOF
 EOF
       } else {
           $recipe .= <<"EOF";
+$obj$objext: $deps
 	\$(CC) $incs \$(CFLAGS) $ecflags -c -o \$\@ $srcs
 EOF
           if (!$disabled{makedepend} && $makedepprog =~ /\/makedepend/) {


### PR DESCRIPTION
So far assembly modules were built as .pl->.S->.s followed by .s->.o.
This posed a problem in build_all_generated rule if it was executed
on another computer. So we change rule sequence to .pl->.S and then
.S->.s->.o.

(backport of a23f03166e0ec49ac09b3671e7ab4ba4fa57d42a)

#5573 didn't cherry-pick, hence this request.