### PR TITLE
CONF: On VMS, treat VMS syntax inclusion paths correctly

### DIFF
--- a/crypto/LPdir_unix.c
+++ b/crypto/LPdir_unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2004-2018 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,7 +11,7 @@
  * This file is dual-licensed and is also available under the following
  * terms:
  *
- * Copyright (c) 2004, Richard Levitte <richard@levitte.org>
+ * Copyright (c) 2004, 2018, Richard Levitte <richard@levitte.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,6 +46,9 @@
 #ifndef LPDIR_H
 # include "LPdir.h"
 #endif
+#ifdef __VMS
+# include <ctype.h>
+#endif
 
 /*
  * The POSIXly macro for the maximum number of characters in a file path is
@@ -73,6 +76,10 @@
 struct LP_dir_context_st {
     DIR *dir;
     char entry_name[LP_ENTRY_SIZE + 1];
+#ifdef __VMS
+    int expect_file_generations;
+    char previous_entry_name[LP_ENTRY_SIZE + 1];
+#endif
 };
 
 const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
@@ -93,6 +100,15 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
         }
         memset(*ctx, 0, sizeof(**ctx));
 
+#ifdef __VMS
+        {
+            char c = directory[strlen(directory) - 1];
+
+            if (c == ']' || c == '>' || c == ':')
+                (*ctx)->expect_file_generations = 1;
+        }
+#endif
+
         (*ctx)->dir = opendir(directory);
         if ((*ctx)->dir == NULL) {
             int save_errno = errno; /* Probably not needed, but I'm paranoid */
@@ -103,6 +119,13 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
         }
     }
 
+#ifdef __VMS
+    strncpy((*ctx)->previous_entry_name, (*ctx)->entry_name,
+            sizeof((*ctx)->previous_entry_name));
+
+ again:
+#endif
+
     direntry = readdir((*ctx)->dir);
     if (direntry == NULL) {
         return 0;
@@ -111,6 +134,18 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
     strncpy((*ctx)->entry_name, direntry->d_name,
             sizeof((*ctx)->entry_name) - 1);
     (*ctx)->entry_name[sizeof((*ctx)->entry_name) - 1] = '\0';
+#ifdef __VMS
+    if ((*ctx)->expect_file_generations) {
+        char *p = (*ctx)->entry_name + strlen((*ctx)->entry_name);
+
+        while(p > (*ctx)->entry_name && isdigit(p[-1]))
+            p--;
+        if (p > (*ctx)->entry_name && p[-1] == ';')
+            p[-1] = '\0';
+        if (strcasecmp((*ctx)->entry_name, (*ctx)->previous_entry_name) == 0)
+            goto again;
+    }
+#endif
     return (*ctx)->entry_name;
 }
 

--- a/test/recipes/90-test_includes.t
+++ b/test/recipes/90-test_includes.t
@@ -10,8 +10,16 @@ setup("test_includes");
 plan skip_all => "test_includes doesn't work without posix-io"
     if disabled("posix-io");
 
-plan tests => 3;                # The number of tests being performed
+plan tests =>                   # The number of tests being performed
+    3
+    + ($^O eq "VMS" ? 2 : 0);
 
 ok(run(test(["conf_include_test", data_file("includes.cnf")])), "test directory includes");
 ok(run(test(["conf_include_test", data_file("includes-file.cnf")])), "test file includes");
+if ($^O eq "VMS") {
+    ok(run(test(["conf_include_test", data_file("vms-includes.cnf")])),
+       "test directory includes, VMS syntax");
+    ok(run(test(["conf_include_test", data_file("vms-includes-file.cnf")])),
+       "test file includes, VMS syntax");
+}
 ok(run(test(["conf_include_test", data_file("includes-broken.cnf"), "f"])), "test broken includes");

--- a/test/recipes/90-test_includes_data/vms-includes-file.cnf
+++ b/test/recipes/90-test_includes_data/vms-includes-file.cnf
@@ -1,0 +1,5 @@
+#
+# Example configuration file using includes.
+#
+
+.include vms-includes.cnf

--- a/test/recipes/90-test_includes_data/vms-includes.cnf
+++ b/test/recipes/90-test_includes_data/vms-includes.cnf
@@ -1,0 +1,5 @@
+#
+# Example configuration file using includes.
+#
+
+.include [.conf-includes]


### PR DESCRIPTION
non-VMS syntax inclusion paths get the same treatment as on Unix.