### PR TITLE
apps/opt.c: refactor the check of the -out argument

### DIFF
--- a/apps/opt.c
+++ b/apps/opt.c
@@ -620,10 +620,6 @@ int opt_next(void)
     unsigned long ulval;
     ossl_intmax_t imval;
     ossl_uintmax_t umval;
-#if !defined(_WIN32)
-    char *c;
-    int oerrno;
-#endif
 
     /* Look at current arg; at end of the list? */
     arg = NULL;
@@ -722,7 +718,7 @@ int opt_next(void)
                  * directory it's going to be written in is writable (which
                  * implies it exists).
                  */
-                c = OPENSSL_strdup(arg);
+                char *c = OPENSSL_strdup(arg);
                 if (c == NULL) {
                     BIO_printf(bio_err,
                                "%s: Memory allocation failure\n", prog);

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -42,6 +42,7 @@ $rand_path .= "/test.pem";
 
 test_illegal_path($rand_path);
 test_legal_path('test.pem');
+test_legal_path(File::Spec->devnull());
 unlink 'test.pem';
 
 sub test_illegal_path {

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -42,7 +42,11 @@ $rand_path .= "/test.pem";
 
 test_illegal_path($rand_path);
 test_legal_path('test.pem');
-test_legal_path(File::Spec->devnull());
+SKIP: {
+    skip "'".File::Spec->devnull()."' may not be a workable null device for this cross compiled build", 1
+        unless (config('CROSS_COMPILE') // '') eq '';
+    test_legal_path(File::Spec->devnull());
+}
 unlink 'test.pem';
 
 sub test_illegal_path {

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -19,7 +19,7 @@ setup("test_out_option");
 plan skip_all => "'-out' option tests are not available on Windows"
     if $^O eq 'MSWin32';
 
-plan tests => 11;
+plan tests => 12;
 
 # The following patterns should be tested:
 #


### PR DESCRIPTION
It was observed that 'openssl -rand /dev/null' gives a permission
denied error.  The reason is that we start with checking that the
parent directory (/dev in this case) is writable (which /dev isn't
except for root).

The solution is to change the check like this:

- if the file exists then
  - fail if it is a directory or we don't have write access
- otherwise
  - fail if the parent directory isn't writable

An extra test is added in the test recipe to see if we can output to
the null device.

Fixes #5590
