### PR TITLE
Don't negotiate TLSv1.3 with the ossl_shim

### DIFF
--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -533,6 +533,12 @@ static bssl::UniquePtr<SSL_CTX> SetupCtx(const TestConfig *config) {
       !SSL_CTX_set_max_proto_version(ssl_ctx.get(), TLS1_3_VERSION)) {
     return nullptr;
   }
+#else
+  /* Ensure we don't negotiate TLSv1.3 until we can handle it */
+  if (!config->is_dtls &&
+      !SSL_CTX_set_max_proto_version(ssl_ctx.get(), TLS1_2_VERSION)) {
+    return nullptr;
+  }
 #endif
 
   std::string cipher_list = "ALL";


### PR DESCRIPTION
The ossl_shim doesn't know about TLSv1.3 so we should disable that
protocol version for all tests for now.

This fixes the current Travis failures.

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
