### PR TITLE
Fix test_out_option

### DIFF
--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -36,7 +36,8 @@ test_illegal_path('../');
 
 # Test for trying to create a file in a non-exist directory
 my @chars = ("A".."Z", "a".."z", "0".."9");
-my $rand_path = $chars[rand @chars] for 1..32;
+my $rand_path = "";
+$rand_path .= $chars[rand @chars] for 1..32;
 $rand_path .= "/test.pem";
 
 test_illegal_path($rand_path);


### PR DESCRIPTION
Random path generation code in test/recipes/15-test_out_option.t does not work:
```
# Test for trying to create a file in a non-exist directory
my @chars = ("A".."Z", "a".."z", "0".."9");
my $rand_path = $chars[rand @chars] for 1..32;
$rand_path .= "/test.pem";

```
The code sets rand_path to "/test.pem". I.e. the test will fail as expected for unprivileged user but will pass for root user.

- [x] tests are added or updated
