### PR TITLE
Free the correct type in OBJ_add_object()

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -213,7 +213,7 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
  err:
     for (i = ADDED_DATA; i <= ADDED_NID; i++)
         OPENSSL_free(ao[i]);
-    OPENSSL_free(o);
+    ASN1_OBJECT_free(o);
     return NID_undef;
 }
 


### PR DESCRIPTION
We should be using ASN1_OBJECT_free() not OPENSSL_free().

Fixes #5568
