### PR TITLE
Free the correct type in OBJ_add_object() (1.1.0)

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -213,8 +213,8 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
  err:
     for (i = ADDED_DATA; i <= ADDED_NID; i++)
         OPENSSL_free(ao[i]);
-    OPENSSL_free(o);
-    return (NID_undef);
+    ASN1_OBJECT_free(o);
+    return NID_undef;
 }
 
 ASN1_OBJECT *OBJ_nid2obj(int n)


### PR DESCRIPTION
We should be using ASN1_OBJECT_free() not OPENSSL_free().

Fixes #5568

This is the 1.1.0 version of #5597