### PR TITLE
Free the correct type in OBJ_add_object() (1.0.2)

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -305,9 +305,8 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
     for (i = ADDED_DATA; i <= ADDED_NID; i++)
         if (ao[i] != NULL)
             OPENSSL_free(ao[i]);
-    if (o != NULL)
-        OPENSSL_free(o);
-    return (NID_undef);
+    ASN1_OBJECT_free(o);
+    return NID_undef;
 }
 
 ASN1_OBJECT *OBJ_nid2obj(int n)


### PR DESCRIPTION
We should be using ASN1_OBJECT_free() not OPENSSL_free().

Fixes #5568

This is the 1.0.2 version of #5597