### PR TITLE
openssl rehash: no more need to massage the files on VMS

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -293,24 +293,6 @@ static int ends_with_dirsep(const char *path)
     return *path == '/';
 }
 
-static int massage_filename(char *name)
-{
-# ifdef __VMS
-    char *p = strchr(name, ';');
-    char *q = p;
-
-    if (q != NULL) {
-        for (q++; *q != '\0'; q++) {
-            if (!isdigit((unsigned char)*q))
-                return 1;
-        }
-    }
-
-    *p = '\0';
-# endif
-    return 1;
-}
-
 /*
  * Process a directory; return number of errors found.
  */
@@ -346,7 +328,6 @@ static int do_dir(const char *dirname, enum Hash h)
     }
     while ((filename = OPENSSL_DIR_read(&d, dirname)) != NULL) {
         if ((copy = strdup(filename)) == NULL
-                || !massage_filename(copy)
                 || sk_OPENSSL_STRING_push(files, copy) == 0) {
             BIO_puts(bio_err, "out of memory\n");
             exit(1);


### PR DESCRIPTION
OPENSSL_DIR_read() now returns unique file names on VMS, no generation
number.  We therefore do not need to handle that case in apps/rehash.c
any more.
