### PR TITLE
Refactor the 'depend' target

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -504,16 +504,7 @@ distclean : clean
 depend : descrip.mms
 descrip.mms : FORCE
 	@ ! {- output_off() if $disabled{makedepend}; "" -}
-        @ $(PERL) -pe "if (/^# DO NOT DELETE.*/) { exit(0); }" -
-                < descrip.mms > descrip.mms-new
-        @ OPEN/APPEND DESCRIP descrip.mms-new
-        @ WRITE DESCRIP "# DO NOT DELETE THIS LINE -- make depend depends on it."
-        {- join("\n\t", map { "\@ IF F\$SEARCH(\"$_\") .NES. \"\" THEN TYPE $_ /OUTPUT=DESCRIP:" } @deps); -}
-        @ CLOSE DESCRIP
-        @ PIPE ( $(PERL) -e "use File::Compare qw/compare_text/; my $x = compare_text(""descrip.mms"",""descrip.mms-new""); exit(0x10000000 + ($x == 0));" || -
-                 RENAME descrip.mms-new descrip.mms )
-        @ IF F$SEARCH("descrip.mms-new") .NES. "" THEN DELETE descrip.mms-new;*
-        -@ SPAWN/OUTPUT=NLA0: PURGE/NOLOG descrip.mms
+	@ $(PERL) {- sourcefile("util", "add-depends.pl") -}
 	@ ! {- output_on() if $disabled{makedepend}; "" -}
 
 # Install helper targets #############################################

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -419,19 +419,7 @@ distclean: clean
 # concatenate only if that is true.
 depend:
 	@: {- output_off() if $disabled{makedepend}; "" -}
-	@if egrep "^# DO NOT DELETE THIS LINE" Makefile >/dev/null && [ -z "`find $(DEPS) -newer Makefile 2>/dev/null; exit 0`" ]; then :; else \
-	  ( $(PERL) -pe 'exit 0 if /^# DO NOT DELETE THIS LINE.*/' < Makefile; \
-	    echo '# DO NOT DELETE THIS LINE -- make depend depends on it.'; \
-	    echo; \
-	    for f in $(DEPS); do \
-	      if [ -f $$f ]; then cat $$f; fi; \
-	    done ) > Makefile.new; \
-	  if cmp Makefile.new Makefile >/dev/null 2>&1; then \
-	    rm -f Makefile.new; \
-	  else \
-	    mv -f Makefile.new Makefile; \
-	  fi; \
-	fi
+	@$(PERL) $(SRCDIR)/util/add-depends.pl
 	@: {- output_on() if $disabled{makedepend}; "" -}
 
 # Install helper targets #############################################

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -381,6 +381,9 @@ distclean: clean
 	-del /Q /F makefile
 
 depend:
+	@ rem {- output_off() if $disabled{makedepend}; "" -}
+	@ $(PERL) $(SRCDIR)\util\add-depends.pl
+	@ rem {- output_on() if $disabled{makedepend}; "" -}
 
 # Install helper targets #############################################
 

--- a/util/add-depends.pl
+++ b/util/add-depends.pl
@@ -1,0 +1,50 @@
+#! /usr/bin/env perl
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use lib '.';
+use configdata;
+
+use File::Compare qw(compare_text);
+
+my $buildfile = $config{build_file};
+my $buildfile_new = "$buildfile.$$";
+my $depext = $target{dep_extension} || ".d";
+my @deps =
+    grep { print STDERR "$_ exists: ", -f $_ ? "yes" : "no", "\n"; -f $_ }
+    map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
+    grep { $unified_info{sources}->{$_}->[0] =~ /\.cc?$/ }
+    keys %{$unified_info{sources}};
+
+print STDERR "\@deps = ( ", join(", ", @deps), " )\n";
+
+open IBF, $buildfile or die "Trying to read $buildfile: $!\n";
+open OBF, '>', $buildfile_new or die "Trying to write $buildfile_new: $!\n";
+while (<IBF>) {
+    $force_rewrite = 0;
+    last if /^# DO NOT DELETE THIS LINE/;
+    print OBF or die "$!\n";
+    $force_rewrite = 1;
+}
+close IBF;
+
+print OBF "# DO NOT DELETE THIS LINE -- make depend depends on it.\n";
+
+foreach (@deps) {
+    open IBF,$_ or die "Trying to read $_: $!\n";
+    while (<IBF>) {
+        print OBF or die "$!\n";
+    }
+    close IBF;
+}
+close OBF;
+
+if (compare_text($buildfile_new, $buildfile) != 0) {
+    rename $buildfile_new, $buildfile
+        or die "Trying to rename $buildfile_new -> $buildfile: $!\n";
+}
+


### PR DESCRIPTION
With the help of the perl script util/add-depends.pl, which takes all
its information directly from configdata.pm, the dependency adding
procedure can be streamlined for all support platforms.
