### PR TITLE
Add support for Zhaoxin's x86 platfrom

### DIFF
--- a/engines/asm/e_padlock-x86_64.pl
+++ b/engines/asm/e_padlock-x86_64.pl
@@ -57,11 +57,20 @@ padlock_capability:
 	cpuid
 	xor	%eax,%eax
 	cmp	\$`"0x".unpack("H*",'tneC')`,%ebx
-	jne	.Lnoluck
+	jne	.Shanghai             # not CentaurHauls, try to match Shanghai id
 	cmp	\$`"0x".unpack("H*",'Hrua')`,%edx
 	jne	.Lnoluck
 	cmp	\$`"0x".unpack("H*",'slua')`,%ecx
 	jne	.Lnoluck
+	jmp     .ShanghaiEnd          # matched CentaurHauls, skip Shanghai id check
+.Shanghai:
+	cmp	\$`"0x".unpack("H*",'hS  ')`,%ebx
+	jne	.Lnoluck
+	cmp	\$`"0x".unpack("H*",'hgna')`,%edx
+	jne	.Lnoluck
+	cmp	\$`"0x".unpack("H*",'  ia')`,%ecx
+	jne	.Lnoluck
+.ShanghaiEnd:
 	mov	\$0xC0000000,%eax
 	cpuid
 	mov	%eax,%edx


### PR DESCRIPTION
VIA and Shanghai United Investment Co.,Ltd. found Shanghai ZhaoXin, which is a fabless x86 CPU IC design company. ZhaoXin has issued ZX-C, ZX-D x86 processors, which have 'Shanghai' CPU vendor id.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
