### PR TITLE
Remove '-Wextra' as default user flags for the Linux clang targets

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -816,7 +816,6 @@ my %targets = (
         inherit_from     => [ "linux-x86" ],
         CC               => "clang",
         CXX              => "clang++",
-        CFLAGS           => add("-Wextra"),
     },
     "linux-x86_64" => {
         inherit_from     => [ "linux-generic64", asm("x86_64_asm") ],
@@ -831,7 +830,6 @@ my %targets = (
         inherit_from     => [ "linux-x86_64" ],
         CC               => "clang",
         CXX              => "clang++",
-        CFLAGS           => add("-Wextra"),
     },
     "linux-x32" => {
         inherit_from     => [ "linux-generic32", asm("x86_64_asm") ],


### PR DESCRIPTION
We have '--strict-warnings' for this kind of stuff...  also, user
flags are added last, so this overrides any warning supression
--strict-warnings may put in place (for good reasons).

Fixes #5609
