### PR TITLE
crypto/engine/eng_cryptodev.c: don't treat a void* like an array [1.0.2 only]

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -1057,7 +1057,7 @@ static int crparam2bn(struct crparam *crp, BIGNUM *a)
         return (-1);
 
     for (i = 0; i < bytes; i++)
-        pd[i] = crp->crp_p[bytes - i - 1];
+        pd[i] = ((char *)crp->crp_p)[bytes - i - 1];
 
     BN_bin2bn(pd, bytes, a);
     free(pd);


### PR DESCRIPTION
The void* needs to be cast to a char* first.

Fixes #5614
