### PR TITLE
Add a simple method to run regression tests

### DIFF
--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -141,8 +141,20 @@ static int test_lib(void)
     myERR_get_error = (ERR_get_error_t)symbols[0].func;
     if (!TEST_int_eq(myERR_get_error(), 0))
         goto end;
+
+    /*
+     * The bits that COMPATIBILITY_MASK lets through MUST be the same in
+     * the library and in the application.
+     * The bits that are masked away MUST be a larger or equal number in
+     * the library compared to the application.
+     */
+# define COMPATIBILITY_MASK 0xfff00000L
     myOpenSSL_version_num = (OpenSSL_version_num_t)symbols[1].func;
-    if (!TEST_int_eq(myOpenSSL_version_num(), OPENSSL_VERSION_NUMBER))
+    if (!TEST_int_eq(myOpenSSL_version_num() & COMPATIBILITY_MASK,
+                     OPENSSL_VERSION_NUMBER & COMPATIBILITY_MASK)
+        goto end;
+    if (!TEST_int_ge(myOpenSSL_version_num() & ~COMPATIBILITY_MASK,
+                     OPENSSL_VERSION_NUMBER & ~COMPATIBILITY_MASK)
         goto end;
 
     switch (test_type) {

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -6,7 +6,9 @@
 #     OPENSSL_REGRESSION=/path/to/other/OpenSSL/build/tree
 if [ -n "$OPENSSL_REGRESSION" -a \
         -f "$OPENSSL_REGRESSION/util/shlib_wrap.sh" ]; then
-    exec $OPENSSL_REGRESSION/util/shlib_wrap.sh "$@"
+    # We clear OPENSSL_REGRESSION to avoid a loop, should the shlib_wrap.sh
+    # we exec also support that mechanism...
+    OPENSSL_REGRESSION= exec $OPENSSL_REGRESSION/util/shlib_wrap.sh "$@"
 fi
 
 [ $# -ne 0 ] || set -x		# debug mode without arguments:-)

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -5,13 +5,13 @@
 #
 #     OPENSSL_REGRESSION=/path/to/other/OpenSSL/build/tree
 if [ -n "$OPENSSL_REGRESSION" ]; then
-    shlibwrap=$OPENSSL_REGRESSION/util/shlib_wrap.sh
+    shlibwrap="$OPENSSL_REGRESSION/util/shlib_wrap.sh"
     if [ -x "$shlibwrap" ]; then
         # We clear OPENSSL_REGRESSION to avoid a loop, should the shlib_wrap.sh
         # we exec also support that mechanism...
         OPENSSL_REGRESSION= exec "$shlibwrap" "$@"
     else
-        if [ -f "$OPENSSL_REGRESSION" ]; then
+        if [ -f "$shlibwrap" ]; then
             echo "Not permitted to run $shlibwrap" >&2
         else
             echo "No $shlibwrap, perhaps OPENSSL_REGRESSION isn't properly set?" >&2

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# To test this OpenSSL version's applications against another version's
+# shared libraries, simply set
+#
+#     OPENSSL_REGRESSION=/path/to/other/OpenSSL/build/tree
+if [ -n "$OPENSSL_REGRESSION" -a \
+        -f "$OPENSSL_REGRESSION/util/shlib_wrap.sh" ]; then
+    exec $OPENSSL_REGRESSION/util/shlib_wrap.sh "$@"
+fi
+
 [ $# -ne 0 ] || set -x		# debug mode without arguments:-)
 
 THERE="`echo $0 | sed -e 's|[^/]*$||' 2>/dev/null`.."

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -4,11 +4,20 @@
 # shared libraries, simply set
 #
 #     OPENSSL_REGRESSION=/path/to/other/OpenSSL/build/tree
-if [ -n "$OPENSSL_REGRESSION" -a \
-        -f "$OPENSSL_REGRESSION/util/shlib_wrap.sh" ]; then
-    # We clear OPENSSL_REGRESSION to avoid a loop, should the shlib_wrap.sh
-    # we exec also support that mechanism...
-    OPENSSL_REGRESSION= exec $OPENSSL_REGRESSION/util/shlib_wrap.sh "$@"
+if [ -n "$OPENSSL_REGRESSION" ]; then
+    shlibwrap=$OPENSSL_REGRESSION/util/shlib_wrap.sh
+    if [ -x "$shlibwrap" ]; then
+        # We clear OPENSSL_REGRESSION to avoid a loop, should the shlib_wrap.sh
+        # we exec also support that mechanism...
+        OPENSSL_REGRESSION= exec "$shlibwrap" "$@"
+    else
+        if [ -f "$OPENSSL_REGRESSION" ]; then
+            echo "Not permitted to run $shlibwrap" >&2
+        else
+            echo "No $shlibwrap, perhaps OPENSSL_REGRESSION isn't properly set?" >&2
+        fi
+        exit 1
+    fi
 fi
 
 [ $# -ne 0 ] || set -x		# debug mode without arguments:-)


### PR DESCRIPTION
This is only useful when building shared libraries.  This allows us to
run our tests against newer libraries when the time comes.  Simply do
this:

    OPENSSL_REGRESSION=/other/OpenSSL/build/tree make test

(`$OPENSSL_REGRESSION` *must* be an absolute path)