### PR TITLE
Windows OneCore console

### DIFF
--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -4,7 +4,11 @@
 # Mobile[?] Windows editions. It's a set up "umbrella" libraries that
 # export subset of Win32 API that are common to all Windows 10 devices.
 #
-# TODO: drop onecore_downlevel.lib.
+# OneCore Configuration temporarly dedicated for console applications 
+# due to disabled event logging, which is incompatible with one core.
+# Error messages are provided via standard error only.
+# TODO: extend error handling to use ETW based eventing
+# (Or rework whole error messaging)
 
 my %targets = (
     "VC-WIN32-ONECORE" => {
@@ -13,12 +17,14 @@ my %targets = (
         # hidden reference to kernel32.lib, but we don't actually want
         # it in "onecore" build.
         lflags          => add("/NODEFAULTLIB:kernel32.lib"),
-        ex_libs         => "onecore.lib onecore_downlevel.lib",
+        defines         => add("OPENSSL_SYS_WIN_CORE"),
+        ex_libs         => "onecore.lib",
     },
     "VC-WIN64A-ONECORE" => {
         inherit_from    => [ "VC-WIN64A" ],
         lflags          => add("/NODEFAULTLIB:kernel32.lib"),
-        ex_libs         => "onecore.lib onecore_downlevel.lib",
+        defines         => add("OPENSSL_SYS_WIN_CORE"),
+        ex_libs         => "onecore.lib",
     },
 
     # Windows on ARM targets. ARM compilers are additional components in
@@ -39,18 +45,20 @@ my %targets = (
 
     "VC-WIN32-ARM" => {
         inherit_from    => [ "VC-noCE-common" ],
-        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE"),
+        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
+                               "OPENSSL_SYS_WIN_CORE"),
         bn_ops          => "BN_LLONG RC4_CHAR EXPORT_VAR_AS_FN",
         lflags          => add("/NODEFAULTLIB:kernel32.lib"),
-        ex_libs         => "onecore.lib onecore_downlevel.lib",
+        ex_libs         => "onecore.lib",
         multilib        => "-arm",
     },
     "VC-WIN64-ARM" => {
         inherit_from    => [ "VC-noCE-common" ],
-        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE"),
+        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
+                               "OPENSSL_SYS_WIN_CORE"),
         bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR EXPORT_VAR_AS_FN",
         lflags          => add("/NODEFAULTLIB:kernel32.lib"),
-        ex_libs         => "onecore.lib onecore_downlevel.lib",
+        ex_libs         => "onecore.lib",
         multilib        => "-arm64",
     },
 );


### PR DESCRIPTION
Split work on OneCore configuration.
Main purpose of OneCore is to use Universal API provided by OneCore.dll or OneCoreUAP.dll,
which can run on every version of (modern) Windows, such as: Windows 10, Windows RT, Windows IoT, Windows S, etc.
To provide it removal of unsupported API is required.
As a first step We can enable OneCore configuration for all kind of Windows by removing that API.
MessageBox, and EventLogging are not part of Universal API and won't be supported anymore.
Therefore MsgBox can be totally removed, but Event logging may need a substitute if someone will want to develop their application as universal, without usage of standard error.

Current pull request aims for enabling OneCore conf for at least console applications, which is denoted in conf file. So some app providers can start their work on Universal API, also non-console can start work as Universal for testing purposes but they probably wont be able to see any critical error messages if NDEBUG flag is specified

Subsequent pull request will aim for spreading this functionality for apps which can not use standard error to communicate.