### PR TITLE
VMS: add alias macros to avoid 31 character symbol name limit warning

### DIFF
--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -58,6 +58,11 @@ int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
 int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
                            unsigned int cookie_len);
 
+#ifdef __VMS                     /* 31 char symbol name limit */
+# define generate_stateless_cookie_callback      generate_stateless_cookie_cb
+# define verify_stateless_cookie_callback        verify_stateless_cookie_cb
+#endif
+
 int generate_stateless_cookie_callback(SSL *ssl, unsigned char *cookie,
                                        size_t *cookie_len);
 int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cookie,


### PR DESCRIPTION
Affected symbol names:

generate_stateless_cookie_callback
verify_stateless_cookie_callback
