### PR TITLE
Configure: Don't fail if there were "make variables" set in env

### DIFF
--- a/Configure
+++ b/Configure
@@ -602,6 +602,7 @@ $config{options}="";
 $config{build_type} = "release";
 my $target="";
 
+my %cmdvars = ();               # Stores FOO='blah' type arguments
 my %unsupported_options = ();
 my %deprecated_options = ();
 # If you change this, update apps/version.c
@@ -614,7 +615,7 @@ while (@argvcopy)
 	# Support env variable assignments among the options
 	if (m|^(\w+)=(.+)?$|)
 		{
-		$config{perlenv}->{$1} = $2;
+		$cmdvars{$1} = $2;
 		# Every time a variable is given as a configuration argument,
 		# it acts as a reset if the variable.
 		if (exists $user{$1})
@@ -891,36 +892,46 @@ while (@argvcopy)
 		}
 	}
 
-# If any %useradd entry has been set, we must check that the environment
-# variables haven't been set.  We start by checking of any %useradd entry
+# If any %useradd entry has been set, we must check that the "make
+# variables" haven't been set.  We start by checking of any %useradd entry
 # is set.
 if (grep { scalar @$_ > 0 } values %useradd) {
     # Hash of env / make variables names.  The possible values are:
-    # 1 - environment set
+    # 1 - "make vars"
     # 2 - %useradd entry set
     # 3 - both set
-    my %detected_env =
+    my %detected_vars =
         map { my $v = 0;
-              $v += 1 if env($_);
+              $v += 1 if $cmdvars{$_};
               $v += 2 if @{$useradd{$_}};
               $_ => $v }
         keys %useradd;
 
-    # If any of the corresponding environment variables is set, we error
-    if (grep { $_ & 1 } values %detected_env) {
-        my $names = join(', ', grep { $detected_env{$_} > 0 }
-                               sort keys %detected_env);
+    # If any of the corresponding "make variables" is set, we error
+    if (grep { $_ & 1 } values %detected_vars) {
+        my $names = join(', ', grep { $detected_vars{$_} > 0 }
+                               sort keys %detected_vars);
         die <<"_____";
-***** Mixing env / make variables and additional compiler/linker flags as
+***** Mixing make variables and additional compiler/linker flags as
 ***** configure command line option is not permitted.
-***** Affected env / make variables: $names
+***** Affected make variables: $names
 _____
     }
 }
 
+# Check through all supported command line variables to see if any of them
+# were set, and canonicalise the values we got.  If no compiler or linker
+# flag or anything else that affects %useradd was set, we also check the
+# environment for values.
+my $anyuseradd =
+    grep { defined $_ && (ref $_ ne 'ARRAY' || @$_) } values %useradd;
 foreach (keys %user) {
-    my $value = env($_);
-    $value //= defined $user_synonyms{$_} ? env($user_synonyms{$_}) : undef;
+    my $value = $cmdvars{$_};
+    $value //= env($_) unless $anyuseradd;
+    $value //=
+        defined $user_synonyms{$_} ? $cmdvars{$user_synonyms{$_}} : undef;
+    $value //= defined $user_synonyms{$_} ? env($user_synonyms{$_}) : undef
+        unless $anyuseradd;
 
     if (defined $value) {
         if (ref $user{$_} eq 'ARRAY') {
@@ -3090,13 +3101,16 @@ sub which
 sub env
 {
     my $name = shift;
+    my %opts = @_;
 
-    # Note that if $ENV{$name} doesn't exist or is undefined,
-    # $config{perlenv}->{$name} will be created with the value
-    # undef.  This is intentional.
+    unless ($opts{cacheonly}) {
+        # Note that if $ENV{$name} doesn't exist or is undefined,
+        # $config{perlenv}->{$name} will be created with the value
+        # undef.  This is intentional.
 
-    $config{perlenv}->{$name} = $ENV{$name}
-        if ! exists $config{perlenv}->{$name};
+        $config{perlenv}->{$name} = $ENV{$name}
+            if ! exists $config{perlenv}->{$name};
+    }
     return $config{perlenv}->{$name};
 }
 

--- a/Configure
+++ b/Configure
@@ -523,28 +523,30 @@ my $list_separator_re =
     { VMS           => qr/(?<!\^),/,
       MSWin32       => qr/(?<!\\);/ } -> {$^O} // qr/(?<!\\)[:\s]/;
 # All the "make variables" we support
+# Some get pre-populated for the sake of backward compatibility
+# (we supported those before the change to "make variable" support.
 my %user = (
-    AR          => undef,
+    AR          => env('AR'),
     ARFLAGS     => [],
     AS          => undef,
     ASFLAGS     => [],
-    CC          => undef,
+    CC          => env('CC'),
     CFLAGS      => [],
-    CXX         => undef,
+    CXX         => env('CXX'),
     CXXFLAGS    => [],
     CPP         => undef,
     CPPFLAGS    => [],  # -D, -I, -Wp,
     CPPDEFINES  => [],  # Alternative for -D
     CPPINCLUDES => [],  # Alternative for -I
-    CROSS_COMPILE => undef,
-    HASHBANGPERL=> undef,
+    CROSS_COMPILE => env('CROSS_COMPILE'),
+    HASHBANGPERL=> env('HASHBANGPERL') || env('PERL'),
     LD          => undef,
     LDFLAGS     => [],  # -L, -Wl,
     LDLIBS      => [],  # -l
     MT          => undef,
     MTFLAGS     => [],
-    RANLIB      => undef,
-    RC          => undef,
+    RANLIB      => env('RANLIB'),
+    RC          => env('RC') || env('WINDRES'),
     RCFLAGS     => [],
     RM          => undef,
    );

--- a/INSTALL
+++ b/INSTALL
@@ -590,8 +590,8 @@
                    Backward compatibility note:
 
                    To be compatible with older configuration scripts, the
-                   environment variables are ignored compiling / linking flags
-                   are given on the command line, except for these:
+                   environment variables are ignored if compiling / linking
+                   flags are given on the command line, except for these:
 
                    AR, CC, CXX, CROSS_COMPILE, HASHBANGPERL, PERL, RANLIB, RC
                    and WINDRES

--- a/INSTALL
+++ b/INSTALL
@@ -536,7 +536,7 @@
                    these flags interact with those variables.
 
   VAR=value
-                   Assignment if environment variable for Configure.  These
+                   Assignment of environment variable for Configure.  These
                    work just like normal environment variable assignments,
                    but are supported on all platforms and are confined to
                    the configuration scripts only.  These assignments override
@@ -586,6 +586,24 @@
                    isn't permitted.
 
                        ./config -DFOO CPPFLAGS=-DBAR -DCOOKIE
+
+                   Backward compatibility note:
+
+                   To be compatible with older configuration scripts, the
+                   environment variables are ignored compiling / linking flags
+                   are given on the command line, except for these:
+
+                   AR, CC, CXX, CROSS_COMPILE, HASHBANGPERL, PERL, RANLIB, RC
+                   and WINDRES
+
+                   For example, the following command will not see -DBAR:
+
+                        CPPFLAGS=-DBAR ./config -DCOOKIE
+
+                   However, the following will see both set variables:
+
+                        CC=gcc CROSS_COMPILE=x86_64-w64-mingw32- \
+                        ./config -DCOOKIE
 
   reconf
   reconfigure


### PR DESCRIPTION
The original intent was that if someone had a "make variable" set in
any kind of way, be it as an environment variable or as an argument to
Configure, we wouldn't allow compiler or linker flags as arguments as
well.  That made both of these configurations equivalently impossible:

    ./Configure target CFLAGS=-foo -lextra

     CFLAGS=-foo ./Configure target -lextra

While this makes things look nice and consistent, real world use makes
this hard, as many projects where OpenSSL is a component also set
these variables for other components that use GNU autotools.

Therefore, we need to adapt our Configure accordingly.  By
consequence, the two Configure lines above will not be equivalent any
more:

    ./Configure target CFLAGS=-foo -lextra

This command line will still fail, because the "make variable" was
given as a command line argument.  This cannot be a mistake and is
therefore not allowed.

     CFLAGS=-foo ./Configure target -lextra

This command line will work, but because the there is a linker flag as
a command line arguments, the environment (i.e. CFLAGS) is ignored.
That isn't quite consistent with the previous command, but is the old
Configure behavior, before the support for "make variables" was added,
and is therefore the least surprising behavior.

Fixes google/oss-fuzz#1244
