### PR TITLE
Fix a crash in SSLfatal due to invalid enc_write_ctx

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -155,6 +155,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
         RECORD_LAYER_reset_read_sequence(&s->rlayer);
         mac_secret = &(s->s3->read_mac_secret[0]);
     } else {
+        s->statem.invalid_enc_write_ctx = 1;
         if (s->enc_write_ctx != NULL) {
             reuse_dd = 1;
         } else if ((s->enc_write_ctx = EVP_CIPHER_CTX_new()) == NULL) {
@@ -238,6 +239,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
         goto err;
     }
 
+    s->statem.invalid_enc_write_ctx = 0;
     OPENSSL_cleanse(exp_key, sizeof(exp_key));
     OPENSSL_cleanse(exp_iv, sizeof(exp_iv));
     return 1;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -123,7 +123,7 @@ void ossl_statem_fatal(SSL *s, int al, int func, int reason, const char *file,
     s->statem.in_init = 1;
     s->statem.state = MSG_FLOW_ERROR;
     ERR_put_error(ERR_LIB_SSL, func, reason, file, line);
-    if (al != SSL_AD_NO_ALERT)
+    if (al != SSL_AD_NO_ALERT && !s->statem.invalid_enc_write_ctx)
         ssl3_send_alert(s, SSL3_AL_FATAL, al);
 }
 

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -100,6 +100,7 @@ struct ossl_statem_st {
     /* Should we skip the CertificateVerify message? */
     unsigned int no_cert_verify;
     int use_timer;
+    int invalid_enc_write_ctx;
 };
 typedef struct ossl_statem_st OSSL_STATEM;
 

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -154,6 +154,7 @@ int tls1_change_cipher_state(SSL *s, int which)
         mac_secret = &(s->s3->read_mac_secret[0]);
         mac_secret_size = &(s->s3->read_mac_secret_size);
     } else {
+        s->statem.invalid_enc_write_ctx = 1;
         if (s->ext.use_etm)
             s->s3->flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE;
         else
@@ -316,6 +317,7 @@ int tls1_change_cipher_state(SSL *s, int which)
                  ERR_R_INTERNAL_ERROR);
         goto err;
     }
+    s->statem.invalid_enc_write_ctx = 0;
 
 #ifdef SSL_DEBUG
     printf("which = %04X\nkey=", which);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -397,6 +397,7 @@ int tls13_change_cipher_state(SSL *s, int which)
 
         RECORD_LAYER_reset_read_sequence(&s->rlayer);
     } else {
+        s->statem.invalid_enc_write_ctx = 1;
         if (s->enc_write_ctx != NULL) {
             EVP_CIPHER_CTX_reset(s->enc_write_ctx);
         } else {
@@ -609,6 +610,7 @@ int tls13_change_cipher_state(SSL *s, int which)
         goto err;
     }
 
+    s->statem.invalid_enc_write_ctx = 0;
     ret = 1;
  err:
     OPENSSL_cleanse(secret, sizeof(secret));
@@ -631,6 +633,7 @@ int tls13_update_key(SSL *s, int sending)
         insecret = s->client_app_traffic_secret;
 
     if (sending) {
+        s->statem.invalid_enc_write_ctx = 1;
         iv = s->write_iv;
         ciph_ctx = s->enc_write_ctx;
         RECORD_LAYER_reset_write_sequence(&s->rlayer);
@@ -651,6 +654,7 @@ int tls13_update_key(SSL *s, int sending)
 
     memcpy(insecret, secret, hashlen);
 
+    s->statem.invalid_enc_write_ctx = 0;
     ret = 1;
  err:
     OPENSSL_cleanse(secret, sizeof(secret));


### PR DESCRIPTION
This is to prevent a crash in SSLfatal trying to send an alert, when the enc_write_ctx is not completely
constructed.
Observed (again) with OOM instrumentation:

```
==19528==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000000c (pc 0x0000020f07ba bp 0x7f58d172da60 sp 0x7f58d172da60 T102)
==19528==The signal is caused by a READ memory access.
==19528==Hint: address points to the zero page.
    #0 0x20f07b9 in EVP_CIPHER_CTX_iv_length crypto/evp/evp_lib.c:233
    #1 0x1f82020 in tls13_enc ssl/record/ssl3_record_tls13.c:60
    #2 0x1f747aa in do_ssl3_write ssl/record/rec_layer_s3.c:996
    #3 0x1f8da19 in ssl3_dispatch_alert ssl/s3_msg.c:78
    #4 0x202477d in tls13_hkdf_expand ssl/tls13_enc.c:78
    #5 0x20249ad in derive_secret_key_and_iv ssl/tls13_enc.c:310
    #6 0x2026589 in tls13_change_cipher_state ssl/tls13_enc.c:578
    #7 0x200b958 in ossl_statem_server_post_work ssl/statem/statem_srvr.c:883
    #8 0x1fdc552 in write_state_machine ssl/statem/statem.c:867
    #9 0x1fdc552 in state_machine ssl/statem/statem.c:437
    #10 0x1f775a8 in ssl3_read_bytes ssl/record/rec_layer_s3.c:1262
    #11 0x1f8b1f2 in ssl3_read_internal ssl/s3_lib.c:4404
    #12 0x1f8b1f2 in ssl3_read ssl/s3_lib.c:4427
    #13 0x1f9e9ea in ssl_read_internal ssl/ssl_lib.c:1748
    #14 0x1f9e9ea in SSL_read ssl/ssl_lib.c:1762
    #15 0x1cffd27 in OpcUa_P_SocketService_SslRead platforms/linux/opcua_p_socket_ssl.c:248
    #16 0x1cd5df2 in OpcUa_HttpsStream_Receive transport/https/opcua_httpsstream.c:2110
    #17 0x1cd5df2 in OpcUa_HttpsStream_DataReady transport/https/opcua_httpsstream.c:2635
    #18 0x1ce050e in OpcUa_HttpsListener_ReadEventHandler transport/https/opcua_httpslistener.c:1251
    #19 0x1cdabfc in OpcUa_HttpsListener_EventCallback transport/https/opcua_httpslistener.c:1664
    #20 0x1cfd04f in OpcUa_SslSocket_DoStateMachine platforms/linux/opcua_p_socket_ssl.c:171
    #21 0x1cfe59c in OpcUa_SslSocket_InternalRead platforms/linux/opcua_p_socket_ssl.c:782
    #22 0x1cfe59c in OpcUa_RawSocket_EventCallback platforms/linux/opcua_p_socket_ssl.c:839
    #23 0x1d10f8e in OpcUa_Socket_HandleEvent platforms/linux/opcua_p_socket_internal.c:898
    #24 0x1d13e7c in OpcUa_P_Socket_HandleFdSet platforms/linux/opcua_p_socket_internal.c:1336
    #25 0x1d13e7c in OpcUa_P_SocketManager_ServeLoopInternal platforms/linux/opcua_p_socket_internal.c:1123
    #26 0x1d14a53 in OpcUa_SocketManager_AcceptHandlerThread platforms/linux/opcua_p_socket_internal.c:723
    #27 0x1c7e2ad in pthread_start platforms/linux/opcua_p_thread.c:46
    #28 0x7f58eeb2f6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
    #29 0x7f58edbac41c in clone (/lib/x86_64-linux-gnu/libc.so.6+0x10741c)
```