### PR TITLE
Fix a memory leak in n_ssl3_mac

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -947,7 +947,7 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
             || EVP_DigestUpdate(md_ctx, ssl3_pad_2, npad) <= 0
             || EVP_DigestUpdate(md_ctx, md, md_size) <= 0
             || EVP_DigestFinal_ex(md_ctx, md, &md_size_u) <= 0) {
-            EVP_MD_CTX_reset(md_ctx);
+            EVP_MD_CTX_free(md_ctx);
             return -1;
         }
         md_size = md_size_u;


### PR DESCRIPTION
Backport of #5648 to 1.1.0 (1.0.2 is not affected)