### PR TITLE
Fix a memory leak in tls1_mac

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -988,8 +988,10 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         mac_ctx = hash;
     } else {
         hmac = EVP_MD_CTX_new();
-        if (hmac == NULL || !EVP_MD_CTX_copy(hmac, hash))
+        if (hmac == NULL || !EVP_MD_CTX_copy(hmac, hash)) {
+            EVP_MD_CTX_free(hmac);
             return -1;
+        }
         mac_ctx = hmac;
     }
 


### PR DESCRIPTION
Backport of #5650 to 1.1.0 (1.0.2 is not affected)