### PR TITLE
Remove dependency on strsignal for HP-UX.

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -878,7 +878,6 @@ static void noteterm (int sig)
  */
 static void spawn_loop(void)
 {
-    const char *signame;
     pid_t *kidpids = NULL;
     int status;
     int procs = 0;
@@ -971,9 +970,7 @@ static void spawn_loop(void)
     }
 
     /* The loop above can only break on termsig */
-    signame = strsignal(termsig);
-    syslog(LOG_INFO, "terminating on signal: %s(%d)",
-           signame ? signame : "", termsig);
+    syslog(LOG_INFO, "terminating on signal: %d", termsig);
     killall(0, kidpids);
 }
 # endif


### PR DESCRIPTION
HP-UX does not support the system call strsignal.
Checked for Itanium HP-UX 11i v3.

The alternative would be to supply our own versions of the two missing calls.

Broken by  3e3c7c3646878fbbef07865aca007e112cf0fc26 earlier this month.