### PR TITLE
Support minimum and maximum protocol version [1.1.0]

### DIFF
--- a/apps/apps.h
+++ b/apps/apps.h
@@ -214,7 +214,7 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         OPT_S_SERVERPREF, OPT_S_LEGACYRENEG, OPT_S_LEGACYCONN, \
         OPT_S_ONRESUMP, OPT_S_NOLEGACYCONN, OPT_S_STRICT, OPT_S_SIGALGS, \
         OPT_S_CLIENTSIGALGS, OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, \
-        OPT_S_DEBUGBROKE, OPT_S_COMP, \
+        OPT_S_DEBUGBROKE, OPT_S_COMP, OPT_S_MINPROTO, OPT_S_MAXPROTO, \
         OPT_S_NO_RENEGOTIATION, OPT_S__LAST
 
 # define OPT_S_OPTIONS \
@@ -250,6 +250,8 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         {"named_curve", OPT_S_NAMEDCURVE, 's', \
             "Elliptic curve used for ECDHE (server-side only)" }, \
         {"cipher", OPT_S_CIPHER, 's', "Specify cipher list to be used"}, \
+        {"min_protocol", OPT_S_MINPROTO, 's', "Specify the minimum protocol version to be used"}, \
+        {"max_protocol", OPT_S_MAXPROTO, 's', "Specify the maximum protocol version to be used"}, \
         {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \
             "Perform all sorts of protocol violations for testing purposes"}
 
@@ -274,6 +276,8 @@ int set_cert_times(X509 *x, const char *startdate, const char *enddate,
         case OPT_S_CURVES: \
         case OPT_S_NAMEDCURVE: \
         case OPT_S_CIPHER: \
+        case OPT_S_MINPROTO: \
+        case OPT_S_MAXPROTO: \
         case OPT_S_NO_RENEGOTIATION: \
         case OPT_S_DEBUGBROKE
 

--- a/test/asynciotest.c
+++ b/test/asynciotest.c
@@ -255,6 +255,7 @@ int main(int argc, char *argv[])
     }
 
     if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
+                             TLS1_VERSION, TLS_MAX_VERSION,
                              &serverctx, &clientctx, argv[1], argv[2])) {
         printf("Failed to create SSL_CTX pair\n");
         goto end;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -31,8 +31,8 @@
 
 int main(int argc, char *argv[])
 {
-    SSL_CTX *ctx;
-    SSL *con;
+    SSL_CTX *ctx = NULL;
+    SSL *con = NULL;
     BIO *rbio;
     BIO *wbio;
     BIO *err;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -56,6 +56,8 @@ int main(int argc, char *argv[])
     for (; currtest < TOTAL_NUM_TESTS; currtest++) {
         testresult = 0;
         ctx = SSL_CTX_new(TLS_method());
+        if (!SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION))
+            goto end;
         con = SSL_new(ctx);
 
         rbio = BIO_new(BIO_s_mem());

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -49,8 +49,9 @@ static int test_dtls_unprocessed(int testidx)
 
     printf("Starting Test %d\n", testidx);
 
-    if (!create_ssl_ctx_pair(DTLS_server_method(), DTLS_client_method(), &sctx,
-                             &cctx, cert, privkey)) {
+    if (!create_ssl_ctx_pair(DTLS_server_method(), DTLS_client_method(),
+                             DTLS1_VERSION, DTLS_MAX_VERSION, &sctx, &cctx,
+                             cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }

--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -28,7 +28,8 @@ static int test_fatalerr(void)
         0x17, 0x03, 0x03, 0x00, 0x05, 'D', 'u', 'm', 'm', 'y'
     };
 
-    if (!create_ssl_ctx_pair(SSLv23_method(), SSLv23_method(), &sctx, &cctx,
+    if (!create_ssl_ctx_pair(SSLv23_method(), SSLv23_method(),
+                             SSL3_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
                              cert, privkey)) {
         printf("Failed to create SSL_CTX pair\n");
         goto err;

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -249,15 +249,21 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
 #ifndef OPENSSL_NO_DTLS
     if (test_ctx->method == SSL_TEST_METHOD_DTLS) {
         server_ctx = SSL_CTX_new(DTLS_server_method());
+        TEST_check(SSL_CTX_set_max_proto_version(server_ctx, DTLS_MAX_VERSION));
         if (test_ctx->extra.server.servername_callback !=
             SSL_TEST_SERVERNAME_CB_NONE) {
             server2_ctx = SSL_CTX_new(DTLS_server_method());
             TEST_check(server2_ctx != NULL);
         }
         client_ctx = SSL_CTX_new(DTLS_client_method());
+        TEST_check(SSL_CTX_set_max_proto_version(client_ctx, DTLS_MAX_VERSION));
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
             resume_server_ctx = SSL_CTX_new(DTLS_server_method());
+            TEST_check(SSL_CTX_set_max_proto_version(resume_server_ctx,
+                                                     DTLS_MAX_VERSION));
             resume_client_ctx = SSL_CTX_new(DTLS_client_method());
+            TEST_check(SSL_CTX_set_max_proto_version(resume_client_ctx,
+                                                     DTLS_MAX_VERSION));
             TEST_check(resume_server_ctx != NULL);
             TEST_check(resume_client_ctx != NULL);
         }
@@ -265,6 +271,7 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
 #endif
     if (test_ctx->method == SSL_TEST_METHOD_TLS) {
         server_ctx = SSL_CTX_new(TLS_server_method());
+        TEST_check(SSL_CTX_set_max_proto_version(server_ctx, TLS_MAX_VERSION));
         /* SNI on resumption isn't supported/tested yet. */
         if (test_ctx->extra.server.servername_callback !=
             SSL_TEST_SERVERNAME_CB_NONE) {
@@ -272,10 +279,15 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
             TEST_check(server2_ctx != NULL);
         }
         client_ctx = SSL_CTX_new(TLS_client_method());
+        TEST_check(SSL_CTX_set_max_proto_version(client_ctx, TLS_MAX_VERSION));
 
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
             resume_server_ctx = SSL_CTX_new(TLS_server_method());
+            TEST_check(SSL_CTX_set_max_proto_version(resume_server_ctx,
+                                                     TLS_MAX_VERSION));
             resume_client_ctx = SSL_CTX_new(TLS_client_method());
+            TEST_check(SSL_CTX_set_max_proto_version(resume_client_ctx,
+                                                     TLS_MAX_VERSION));
             TEST_check(resume_server_ctx != NULL);
             TEST_check(resume_client_ctx != NULL);
         }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -34,7 +34,9 @@ static X509 *ocspcert = NULL;
 #define NUM_EXTRA_CERTS 40
 
 static int execute_test_large_message(const SSL_METHOD *smeth,
-                                      const SSL_METHOD *cmeth, int read_ahead)
+                                      const SSL_METHOD *cmeth,
+                                      int min_version, int max_version,
+                                      int read_ahead)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
@@ -56,7 +58,7 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
         goto end;
     }
 
-    if (!create_ssl_ctx_pair(smeth, cmeth, &sctx,
+    if (!create_ssl_ctx_pair(smeth, cmeth, min_version, max_version, &sctx,
                              &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         goto end;
@@ -125,12 +127,14 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
 static int test_large_message_tls(void)
 {
     return execute_test_large_message(TLS_server_method(), TLS_client_method(),
+                                      TLS1_VERSION, TLS_MAX_VERSION,
                                       0);
 }
 
 static int test_large_message_tls_read_ahead(void)
 {
     return execute_test_large_message(TLS_server_method(), TLS_client_method(),
+                                      TLS1_VERSION, TLS_MAX_VERSION,
                                       1);
 }
 
@@ -142,7 +146,9 @@ static int test_large_message_dtls(void)
      * read_ahead is set.
      */
     return execute_test_large_message(DTLS_server_method(),
-                                      DTLS_client_method(), 0);
+                                      DTLS_client_method(),
+                                      DTLS1_VERSION, DTLS_MAX_VERSION,
+                                      0);
 }
 #endif
 
@@ -207,8 +213,9 @@ static int test_tlsext_status_type(void)
     OCSP_RESPID *id = NULL;
     BIO *certbio = NULL;
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
-                             &cctx, cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
+                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
+                             cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }
@@ -431,8 +438,9 @@ static int execute_test_session(SSL_SESSION_TEST_FIXTURE fix)
     SSL_SESSION *sess1 = NULL, *sess2 = NULL;
     int testresult = 0;
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
-                             &cctx, cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
+                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
+                             cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }
@@ -928,8 +936,9 @@ static int test_set_sigalgs(int idx)
     curr = testctx ? &testsigalgs[idx]
                    : &testsigalgs[idx - OSSL_NELEM(testsigalgs)];
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
-                             &cctx, cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
+                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
+                             cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }
@@ -1079,14 +1088,16 @@ static int test_custom_exts(int tst)
     clntaddcb = clntparsecb = srvaddcb = srvparsecb = 0;
     snicb = 0;
 
-    if (!create_ssl_ctx_pair(TLS_server_method(),  TLS_client_method(), &sctx,
-                             &cctx, cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(),  TLS_client_method(),
+                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
+                             cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         goto end;
     }
 
     if (tst == 1
-            && !create_ssl_ctx_pair(TLS_server_method(), NULL, &sctx2, NULL,
+            && !create_ssl_ctx_pair(TLS_server_method(), NULL,
+                                    TLS1_VERSION, TLS_MAX_VERSION, &sctx2, NULL,
                                     cert, privkey)) {
         printf("Unable to create SSL_CTX pair (2)\n");
         goto end;

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -185,8 +185,9 @@ static int test_ssl_corrupt(int testidx)
 
     printf("Starting Test %d, %s\n", testidx, cipher_list[testidx]);
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
-                             &cctx, cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
+                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
+                             cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -1432,17 +1432,24 @@ int main(int argc, char *argv[])
     } else if (tls1) {
         min_version = TLS1_VERSION;
         max_version = TLS1_VERSION;
+    } else {
+        min_version = SSL3_VERSION;
+        max_version = TLS_MAX_VERSION;
     }
 #endif
 #ifndef OPENSSL_NO_DTLS
-    if (dtls || dtls1 || dtls12)
+    if (dtls || dtls1 || dtls12) {
         meth = DTLS_method();
-    if (dtls1) {
-        min_version = DTLS1_VERSION;
-        max_version = DTLS1_VERSION;
-    } else if (dtls12) {
-        min_version = DTLS1_2_VERSION;
-        max_version = DTLS1_2_VERSION;
+        if (dtls1) {
+            min_version = DTLS1_VERSION;
+            max_version = DTLS1_VERSION;
+        } else if (dtls12) {
+            min_version = DTLS1_2_VERSION;
+            max_version = DTLS1_2_VERSION;
+        } else {
+            min_version = DTLS_MIN_VERSION;
+            max_version = DTLS_MAX_VERSION;
+        }
     }
 #endif
 
@@ -1467,14 +1474,26 @@ int main(int argc, char *argv[])
         SSL_CTX_set_options(s_ctx, SSL_OP_NO_TICKET);
     }
 
-    if (SSL_CTX_set_min_proto_version(c_ctx, min_version) == 0)
+    if (SSL_CTX_set_min_proto_version(c_ctx, min_version) == 0) {
+        printf("Unable to set client min protocol version (0x%X)\n",
+               min_version);
         goto end;
-    if (SSL_CTX_set_max_proto_version(c_ctx, max_version) == 0)
+    }
+    if (SSL_CTX_set_max_proto_version(c_ctx, max_version) == 0) {
+        printf("Unable to set client max protocol version (0x%X)\n",
+               max_version);
         goto end;
-    if (SSL_CTX_set_min_proto_version(s_ctx, min_version) == 0)
+    }
+    if (SSL_CTX_set_min_proto_version(s_ctx, min_version) == 0) {
+        printf("Unable to set server min protocol version (0x%X)\n",
+               min_version);
         goto end;
-    if (SSL_CTX_set_max_proto_version(s_ctx, max_version) == 0)
+    }
+    if (SSL_CTX_set_max_proto_version(s_ctx, max_version) == 0) {
+        printf("Unable to set server max protocol version (0x%X)\n",
+               max_version);
         goto end;
+    }
 
     if (cipher != NULL) {
         if (!SSL_CTX_set_cipher_list(c_ctx, cipher)

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -524,6 +524,7 @@ static int mempacket_test_puts(BIO *bio, const char *str)
 }
 
 int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
+                        int min_proto_version, int max_proto_version,
                         SSL_CTX **sctx, SSL_CTX **cctx, char *certfile,
                         char *privkeyfile)
 {
@@ -536,6 +537,30 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
     if (serverctx == NULL || (cctx != NULL && clientctx == NULL)) {
         printf("Failed to create SSL_CTX\n");
         goto err;
+    }
+
+    if (min_proto_version > 0
+        && !SSL_CTX_set_min_proto_version(serverctx, min_proto_version)) {
+        printf("Unable to set server min protocol versions\n");
+        goto err;
+    }
+    if (max_proto_version > 0
+        && !SSL_CTX_set_max_proto_version(serverctx, max_proto_version)) {
+        printf("Unable to set server max protocol versions\n");
+        goto err;
+    }
+
+    if (clientctx != NULL) {
+        if (min_proto_version > 0
+            && !SSL_CTX_set_max_proto_version(clientctx, max_proto_version)) {
+            printf("Unable to set client max protocol versions\n");
+            goto err;
+        }
+        if (max_proto_version > 0
+            && !SSL_CTX_set_min_proto_version(clientctx, min_proto_version)) {
+            printf("Unable to set client min protocol versions\n");
+            goto err;
+        }
     }
 
     if (SSL_CTX_use_certificate_file(serverctx, certfile,

--- a/test/ssltestlib.h
+++ b/test/ssltestlib.h
@@ -13,6 +13,7 @@
 # include <openssl/ssl.h>
 
 int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
+                        int min_proto_version, int max_proto_version,
                         SSL_CTX **sctx, SSL_CTX **cctx, char *certfile,
                         char *privkeyfile);
 int create_ssl_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -178,7 +178,7 @@ sub start
     $pid = fork();
     if ($pid == 0) {
         my $execcmd = $self->execute
-            ." s_server -no_comp -rev -engine ossltest -accept "
+            ." s_server -max_protocol TLSv1.2 -no_comp -rev -engine ossltest -accept "
             .($self->server_port)
             ." -cert ".$self->cert." -naccept ".$self->serverconnects;
         unless ($self->supports_IPv6) {
@@ -215,7 +215,7 @@ sub clientstart
                 $echostr = "test";
             }
             my $execcmd = "echo ".$echostr." | ".$self->execute
-                 ." s_client -engine ossltest -connect "
+                 ." s_client -max_protocol TLSv1.2 -engine ossltest -connect "
                  .($self->proxy_addr).":".($self->proxy_port);
             unless ($self->supports_IPv6) {
                 $execcmd .= " -4";


### PR DESCRIPTION
If for nothing else, they are needed when doing a regression test

Partially fixes #5661