### PR TITLE
Fix no-ec

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2489,7 +2489,7 @@ top:
             pkey = EVP_PKEY_new_raw_private_key(nid, NULL, keybin, keylen);
         else
             pkey = EVP_PKEY_new_raw_public_key(nid, NULL, keybin, keylen);
-        if (pkey == NULL) {
+        if (pkey == NULL && !key_unsupported()) {
             TEST_info("Can't read %s data", pp->key);
             OPENSSL_free(keybin);
             TEST_openssl_errors();

--- a/test/recipes/30-test_evp_data/evppkey.txt
+++ b/test/recipes/30-test_evp_data/evppkey.txt
@@ -737,6 +737,7 @@ PrivPubKeyPair = Alice-25519-Raw:Alice-25519-PUBLIC-Raw
 PrivateKeyRaw=Bob-25519-Raw:X25519:5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb
 
 PublicKeyRaw=Bob-25519-PUBLIC-Raw:X25519:de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f
+
 PrivPubKeyPair = Bob-25519:Bob-25519-PUBLIC
 
 PrivPubKeyPair = Bob-25519-Raw:Bob-25519-PUBLIC-Raw


### PR DESCRIPTION
Raw private/public key loading may fail for X25519/X448 if ec has been
disabled.

Also fixed a missing blank line in evppkey.txt resulting in a warning in
the test output.

