### PR TITLE
Fix no-posix-io compile failure

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -36,7 +36,8 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <openssl/x509v3.h>
 # include <openssl/rand.h>
 
-# if defined(OPENSSL_SYS_UNIX) && !defined(OPENSSL_NO_SOCK)
+# if defined(OPENSSL_SYS_UNIX) && !defined(OPENSSL_NO_SOCK) \
+     && !defined(OPENSSL_NO_POSIX_IO)
 #  define OCSP_DAEMON
 #  include <sys/types.h>
 #  include <sys/wait.h>

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -30,7 +30,7 @@
 #else
 /* the test does not work without chdir() */
 # define chdir(x) (-1);
-# define DIRSEP ""
+# define DIRSEP "/"
 #  define DIRSEP_PRESERVE 0
 #endif
 


### PR DESCRIPTION
I marked this as WIP because I still get a compile error with this in another file (when using `--strict-warnings`):

````
test/conf_include_test.c
test/conf_include_test.c: In function 'change_path':
test/conf_include_test.c:48:15: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
     while ((p = strpbrk(p, DIRSEP)) != NULL) {
               ^
cc1: all warnings being treated as errors
````

In the above `p` is declared as a `char *`. This error only occurs with gcc (not clang). Casting the return from strpbrk() to `char *` doesn't make the error go away:

````
test/conf_include_test.c: In function 'change_path':
test/conf_include_test.c:48:15: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
     while ((p = (char *)strpbrk(p, DIRSEP)) != NULL) {
               ^
cc1: all warnings being treated as errors
````
I can work around it with a hacky intermediate variable - but it's quite nasty and the thing is, I don't understand why we get this with no-posix-io? The code in question doesn't seem particularly related to posix-io and this compiles fine without that option. Also according to my man page, and my C89 spec, `strpbrk` returns a `char *` anyway - not a `const char *`!!

````
char *strpbrk(const char *s, const char *accept);
````

Can anyone offer any insight as to what is going on here?