### PR TITLE
Revise and cleanup; use strict,warnings

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -558,7 +558,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
                 s++;
             cp = section;
             e = np = s;
-            while (IS_ALPHA_NUMERIC(conf, *e))
+            while (IS_ALNUM(conf, *e))
                 e++;
             if ((e[0] == ':') && (e[1] == ':')) {
                 cp = np;
@@ -567,7 +567,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
                 *rrp = '\0';
                 e += 2;
                 np = e;
-                while (IS_ALPHA_NUMERIC(conf, *e))
+                while (IS_ALNUM(conf, *e))
                     e++;
             }
             r = *e;
@@ -759,7 +759,7 @@ static char *eat_alpha_numeric(CONF *conf, char *p)
             p = scan_esc(conf, p);
             continue;
         }
-        if (!IS_ALPHA_NUMERIC_PUNCT(conf, *p))
+        if (!IS_ALNUM_PUNCT(conf, *p))
             return p;
         p++;
     }

--- a/crypto/conf/conf_def.h
+++ b/crypto/conf/conf_def.h
@@ -9,54 +9,42 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define CONF_NUMBER             1
-#define CONF_UPPER              2
-#define CONF_LOWER              4
-#define CONF_UNDER              256
-#define CONF_PUNCTUATION        512
-#define CONF_WS                 16
-#define CONF_ESC                32
-#define CONF_QUOTE              64
-#define CONF_DQUOTE             1024
-#define CONF_COMMENT            128
-#define CONF_FCOMMENT           2048
-#define CONF_EOF                8
-#define CONF_HIGHBIT            4096
-#define CONF_ALPHA              (CONF_UPPER|CONF_LOWER)
-#define CONF_ALPHA_NUMERIC      (CONF_ALPHA|CONF_NUMBER|CONF_UNDER)
-#define CONF_ALPHA_NUMERIC_PUNCT (CONF_ALPHA|CONF_NUMBER|CONF_UNDER| \
-                                        CONF_PUNCTUATION)
+#define CONF_NUMBER       1
+#define CONF_UPPER        2
+#define CONF_LOWER        4
+#define CONF_UNDER        256
+#define CONF_PUNCT        512
+#define CONF_WS           16
+#define CONF_ESC          32
+#define CONF_QUOTE        64
+#define CONF_DQUOTE       1024
+#define CONF_COMMENT      128
+#define CONF_FCOMMENT     2048
+#define CONF_EOF          8
+#define CONF_HIGHBIT      4096
+#define CONF_ALPHA        (CONF_UPPER|CONF_LOWER)
+#define CONF_ALNUM        (CONF_ALPHA|CONF_NUMBER|CONF_UNDER)
+#define CONF_ALNUM_PUNCT  (CONF_ALPHA|CONF_NUMBER|CONF_UNDER|CONF_PUNCT)
 
-#define KEYTYPES(c)             ((const unsigned short *)((c)->meth_data))
+#define KEYTYPES(c)       ((const unsigned short *)((c)->meth_data))
+
 #ifndef CHARSET_EBCDIC
-# define IS_COMMENT(c,a)         (KEYTYPES(c)[(a)&0xff]&CONF_COMMENT)
-# define IS_FCOMMENT(c,a)        (KEYTYPES(c)[(a)&0xff]&CONF_FCOMMENT)
-# define IS_EOF(c,a)             (KEYTYPES(c)[(a)&0xff]&CONF_EOF)
-# define IS_ESC(c,a)             (KEYTYPES(c)[(a)&0xff]&CONF_ESC)
-# define IS_NUMBER(c,a)          (KEYTYPES(c)[(a)&0xff]&CONF_NUMBER)
-# define IS_WS(c,a)              (KEYTYPES(c)[(a)&0xff]&CONF_WS)
-# define IS_ALPHA_NUMERIC(c,a)   (KEYTYPES(c)[(a)&0xff]&CONF_ALPHA_NUMERIC)
-# define IS_ALPHA_NUMERIC_PUNCT(c,a) \
-                                (KEYTYPES(c)[(a)&0xff]&CONF_ALPHA_NUMERIC_PUNCT)
-# define IS_QUOTE(c,a)           (KEYTYPES(c)[(a)&0xff]&CONF_QUOTE)
-# define IS_DQUOTE(c,a)          (KEYTYPES(c)[(a)&0xff]&CONF_DQUOTE)
-# define IS_HIGHBIT(c,a)         (KEYTYPES(c)[(a)&0xff]&CONF_HIGHBIT)
+# define CVT(a) ((a) & 0xFF)
+#else
+# define CVT(a) os_toascci[(a) & 0FF]
+#endif
 
-#else                           /* CHARSET_EBCDIC */
-
-# define IS_COMMENT(c,a)         (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_COMMENT)
-# define IS_FCOMMENT(c,a)        (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_FCOMMENT)
-# define IS_EOF(c,a)             (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_EOF)
-# define IS_ESC(c,a)             (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_ESC)
-# define IS_NUMBER(c,a)          (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_NUMBER)
-# define IS_WS(c,a)              (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_WS)
-# define IS_ALPHA_NUMERIC(c,a)   (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_ALPHA_NUMERIC)
-# define IS_ALPHA_NUMERIC_PUNCT(c,a) \
-                                (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_ALPHA_NUMERIC_PUNCT)
-# define IS_QUOTE(c,a)           (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_QUOTE)
-# define IS_DQUOTE(c,a)          (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_DQUOTE)
-# define IS_HIGHBIT(c,a)         (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_HIGHBIT)
-#endif                          /* CHARSET_EBCDIC */
+#define IS_COMMENT(c,a)     (KEYTYPES(c)[CVT(a)] & CONF_COMMENT)
+#define IS_FCOMMENT(c,a)    (KEYTYPES(c)[CVT(a)] & CONF_FCOMMENT)
+#define IS_EOF(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_EOF)
+#define IS_ESC(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_ESC)
+#define IS_NUMBER(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_NUMBER)
+#define IS_WS(c,a)          (KEYTYPES(c)[CVT(a)] & CONF_WS)
+#define IS_ALNUM(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_ALNUM)
+#define IS_ALNUM_PUNCT(c,a) (KEYTYPES(c)[CVT(a)] & CONF_ALNUM_PUNCT)
+#define IS_QUOTE(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_QUOTE)
+#define IS_DQUOTE(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_DQUOTE)
+#define IS_HIGHBIT(c,a)     (KEYTYPES(c)[CVT(a)] & CONF_HIGHBIT)
 
 static const unsigned short CONF_type_default[256] = {
     0x0008, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,

--- a/crypto/conf/keysets.pl
+++ b/crypto/conf/keysets.pl
@@ -6,59 +6,60 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-$NUMBER=0x01;
-$UPPER=0x02;
-$LOWER=0x04;
-$UNDER=0x100;
-$PUNCTUATION=0x200;
-$WS=0x10;
-$ESC=0x20;
-$QUOTE=0x40;
-$DQUOTE=0x400;
-$COMMENT=0x80;
-$FCOMMENT=0x800;
-$EOF=0x08;
-$HIGHBIT=0x1000;
+use strict;
+use warnings;
 
-foreach (0 .. 255)
-	{
-	$v=0;
-	$c=sprintf("%c",$_);
-	$v|=$NUMBER	if ($c =~ /[0-9]/);
-	$v|=$UPPER	if ($c =~ /[A-Z]/);
-	$v|=$LOWER	if ($c =~ /[a-z]/);
-	$v|=$UNDER	if ($c =~ /_/);
-	$v|=$PUNCTUATION if ($c =~ /[!\.%&\*\+,\/;\?\@\^\~\|-]/);
-	$v|=$WS		if ($c =~ /[ \t\r\n]/);
-	$v|=$ESC	if ($c =~ /\\/);
-	$v|=$QUOTE	if ($c =~ /['`"]/); # for emacs: "`'}/)
-	$v|=$COMMENT	if ($c =~ /\#/);
-	$v|=$EOF	if ($c =~ /\0/);
-	$v|=$HIGHBIT	if ($c =~/[\x80-\xff]/);
+my $NUMBER      = 0x0001;
+my $UPPER       = 0x0002;
+my $LOWER       = 0x0004;
+my $UNDER       = 0x0100;
+my $PUNCTUATION = 0x0200;
+my $WS          = 0x0010;
+my $ESC         = 0x0020;
+my $QUOTE       = 0x0040;
+my $DQUOTE      = 0x0400;
+my $COMMENT     = 0x0080;
+my $FCOMMENT    = 0x0800;
+my $EOF         = 0x0008;
+my $HIGHBIT     = 0x1000;
+my @V_def;
+my @V_w32;
 
-	push(@V_def,$v);
-	}
+my $v;
+my $c;
+foreach (0 .. 255) {
+    $c = sprintf("%c", $_);
+    $v = 0;
+    $v |= $NUMBER      if $c =~ /[0-9]/;
+    $v |= $UPPER       if $c =~ /[A-Z]/;
+    $v |= $LOWER       if $c =~ /[a-z]/;
+    $v |= $UNDER       if $c =~ /_/;
+    $v |= $PUNCTUATION if $c =~ /[!\.%&\*\+,\/;\?\@\^\~\|-]/;
+    $v |= $WS          if $c =~ /[ \t\r\n]/;
+    $v |= $ESC         if $c =~ /\\/;
+    $v |= $QUOTE       if $c =~ /['`"]/;         # for emacs: "`'
+    $v |= $COMMENT     if $c =~ /\#/;
+    $v |= $EOF         if $c =~ /\0/;
+    $v |= $HIGHBIT     if $c =~ /[\x80-\xff]/;
+    push(@V_def, $v);
 
-foreach (0 .. 255)
-	{
-	$v=0;
-	$c=sprintf("%c",$_);
-	$v|=$NUMBER	if ($c =~ /[0-9]/);
-	$v|=$UPPER	if ($c =~ /[A-Z]/);
-	$v|=$LOWER	if ($c =~ /[a-z]/);
-	$v|=$UNDER	if ($c =~ /_/);
-	$v|=$PUNCTUATION if ($c =~ /[!\.%&\*\+,\/;\?\@\^\~\|-]/);
-	$v|=$WS		if ($c =~ /[ \t\r\n]/);
-	$v|=$DQUOTE	if ($c =~ /["]/); # for emacs: "}/)
-	$v|=$FCOMMENT	if ($c =~ /;/);
-	$v|=$EOF	if ($c =~ /\0/);
-	$v|=$HIGHBIT	if ($c =~/[\x80-\xff]/);
-
-	push(@V_w32,$v);
-	}
+    $v = 0;
+    $v |= $NUMBER      if $c =~ /[0-9]/;
+    $v |= $UPPER       if $c =~ /[A-Z]/;
+    $v |= $LOWER       if $c =~ /[a-z]/;
+    $v |= $UNDER       if $c =~ /_/;
+    $v |= $PUNCTUATION if $c =~ /[!\.%&\*\+,\/;\?\@\^\~\|-]/;
+    $v |= $WS          if $c =~ /[ \t\r\n]/;
+    $v |= $DQUOTE      if $c =~ /["]/;           # for emacs: "
+    $v |= $FCOMMENT    if $c =~ /;/;
+    $v |= $EOF         if $c =~ /\0/;
+    $v |= $HIGHBIT     if $c =~ /[\x80-\xff]/;
+    push(@V_w32, $v);
+}
 
 # Output year depends on the year of the script.
 my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+
 print <<"EOF";
 /*
  * WARNING: do not edit!
@@ -71,73 +72,57 @@ print <<"EOF";
  * https://www.openssl.org/source/license.html
  */
 
-#define CONF_NUMBER             $NUMBER
-#define CONF_UPPER              $UPPER
-#define CONF_LOWER              $LOWER
-#define CONF_UNDER              $UNDER
-#define CONF_PUNCTUATION        $PUNCTUATION
-#define CONF_WS                 $WS
-#define CONF_ESC                $ESC
-#define CONF_QUOTE              $QUOTE
-#define CONF_DQUOTE             $DQUOTE
-#define CONF_COMMENT            $COMMENT
-#define CONF_FCOMMENT           $FCOMMENT
-#define CONF_EOF                $EOF
-#define CONF_HIGHBIT            $HIGHBIT
-#define CONF_ALPHA              (CONF_UPPER|CONF_LOWER)
-#define CONF_ALPHA_NUMERIC      (CONF_ALPHA|CONF_NUMBER|CONF_UNDER)
-#define CONF_ALPHA_NUMERIC_PUNCT (CONF_ALPHA|CONF_NUMBER|CONF_UNDER| \\
-                                        CONF_PUNCTUATION)
+#define CONF_NUMBER       $NUMBER
+#define CONF_UPPER        $UPPER
+#define CONF_LOWER        $LOWER
+#define CONF_UNDER        $UNDER
+#define CONF_PUNCT        $PUNCTUATION
+#define CONF_WS           $WS
+#define CONF_ESC          $ESC
+#define CONF_QUOTE        $QUOTE
+#define CONF_DQUOTE       $DQUOTE
+#define CONF_COMMENT      $COMMENT
+#define CONF_FCOMMENT     $FCOMMENT
+#define CONF_EOF          $EOF
+#define CONF_HIGHBIT      $HIGHBIT
+#define CONF_ALPHA        (CONF_UPPER|CONF_LOWER)
+#define CONF_ALNUM        (CONF_ALPHA|CONF_NUMBER|CONF_UNDER)
+#define CONF_ALNUM_PUNCT  (CONF_ALPHA|CONF_NUMBER|CONF_UNDER|CONF_PUNCT)
 
-#define KEYTYPES(c)             ((const unsigned short *)((c)->meth_data))
+#define KEYTYPES(c)       ((const unsigned short *)((c)->meth_data))
+
 #ifndef CHARSET_EBCDIC
-# define IS_COMMENT(c,a)         (KEYTYPES(c)[(a)&0xff]&CONF_COMMENT)
-# define IS_FCOMMENT(c,a)        (KEYTYPES(c)[(a)&0xff]&CONF_FCOMMENT)
-# define IS_EOF(c,a)             (KEYTYPES(c)[(a)&0xff]&CONF_EOF)
-# define IS_ESC(c,a)             (KEYTYPES(c)[(a)&0xff]&CONF_ESC)
-# define IS_NUMBER(c,a)          (KEYTYPES(c)[(a)&0xff]&CONF_NUMBER)
-# define IS_WS(c,a)              (KEYTYPES(c)[(a)&0xff]&CONF_WS)
-# define IS_ALPHA_NUMERIC(c,a)   (KEYTYPES(c)[(a)&0xff]&CONF_ALPHA_NUMERIC)
-# define IS_ALPHA_NUMERIC_PUNCT(c,a) \\
-                                (KEYTYPES(c)[(a)&0xff]&CONF_ALPHA_NUMERIC_PUNCT)
-# define IS_QUOTE(c,a)           (KEYTYPES(c)[(a)&0xff]&CONF_QUOTE)
-# define IS_DQUOTE(c,a)          (KEYTYPES(c)[(a)&0xff]&CONF_DQUOTE)
-# define IS_HIGHBIT(c,a)         (KEYTYPES(c)[(a)&0xff]&CONF_HIGHBIT)
+# define CVT(a) ((a) & 0xFF)
+#else
+# define CVT(a) os_toascci[(a) & 0FF]
+#endif
 
-#else                           /* CHARSET_EBCDIC */
-
-# define IS_COMMENT(c,a)         (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_COMMENT)
-# define IS_FCOMMENT(c,a)        (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_FCOMMENT)
-# define IS_EOF(c,a)             (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_EOF)
-# define IS_ESC(c,a)             (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_ESC)
-# define IS_NUMBER(c,a)          (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_NUMBER)
-# define IS_WS(c,a)              (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_WS)
-# define IS_ALPHA_NUMERIC(c,a)   (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_ALPHA_NUMERIC)
-# define IS_ALPHA_NUMERIC_PUNCT(c,a) \\
-                                (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_ALPHA_NUMERIC_PUNCT)
-# define IS_QUOTE(c,a)           (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_QUOTE)
-# define IS_DQUOTE(c,a)          (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_DQUOTE)
-# define IS_HIGHBIT(c,a)         (KEYTYPES(c)[os_toascii[a & 0xff]]&CONF_HIGHBIT)
-#endif                          /* CHARSET_EBCDIC */
+#define IS_COMMENT(c,a)     (KEYTYPES(c)[CVT(a)] & CONF_COMMENT)
+#define IS_FCOMMENT(c,a)    (KEYTYPES(c)[CVT(a)] & CONF_FCOMMENT)
+#define IS_EOF(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_EOF)
+#define IS_ESC(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_ESC)
+#define IS_NUMBER(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_NUMBER)
+#define IS_WS(c,a)          (KEYTYPES(c)[CVT(a)] & CONF_WS)
+#define IS_ALNUM(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_ALNUM)
+#define IS_ALNUM_PUNCT(c,a) (KEYTYPES(c)[CVT(a)] & CONF_ALNUM_PUNCT)
+#define IS_QUOTE(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_QUOTE)
+#define IS_DQUOTE(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_DQUOTE)
+#define IS_HIGHBIT(c,a)     (KEYTYPES(c)[CVT(a)] & CONF_HIGHBIT)
 
 EOF
 
+my $i;
+
 print "static const unsigned short CONF_type_default[256] = {";
-
-for ($i=0; $i<256; $i++)
-	{
-	print "\n   " if ($i % 8) == 0;
-	printf " 0x%04X,",$V_def[$i];
-	}
-
+for ($i = 0; $i < 256; $i++) {
+    print "\n   " if ($i % 8) == 0;
+    printf " 0x%04X,", $V_def[$i];
+}
 print "\n};\n\n";
 
 print "static const unsigned short CONF_type_win32[256] = {";
-
-for ($i=0; $i<256; $i++)
-	{
-	print "\n   " if ($i % 8) == 0;
-	printf " 0x%04X,",$V_w32[$i];
-	}
-
+for ($i = 0; $i < 256; $i++) {
+    print "\n   " if ($i % 8) == 0;
+    printf " 0x%04X,", $V_w32[$i];
+}
 print "\n};\n";


### PR DESCRIPTION
Use shorter names for some defines, so also had to change the .c file
that used them.

The biggest change is making this pass 'use strict; use warnings;' and running perltidy over the file.
