### PR TITLE
Adds multiple checks to avoid buffer over reads

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -888,6 +888,8 @@ static int ssl_print_extensions(BIO *bio, int indent, int server,
         BIO_puts(bio, "No Extensions\n");
         return 1;
     }
+    if (msglen < 2)
+        return 0;
     extslen = (msg[0] << 8) | msg[1];
     if (extslen != msglen - 2)
         return 0;
@@ -1293,6 +1295,8 @@ static int ssl_print_cert_request(BIO *bio, int indent, const SSL *ssl,
         msg += xlen;
     }
 
+    if (msglen < 2)
+        return 0;
     xlen = (msg[0] << 8) | msg[1];
     BIO_indent(bio, indent, 80);
     if (msglen < xlen + 2)
@@ -1493,7 +1497,15 @@ void SSL_trace(int write_p, int version, int content_type,
     switch (content_type) {
     case SSL3_RT_HEADER:
         {
-            int hvers = msg[1] << 8 | msg[2];
+            int hvers;
+
+            /* avoid overlapping with length at the end of buffer */
+            if (msglen < (SSL_IS_DTLS(ssl) ? 13 : 5)) {
+                BIO_puts(bio, write_p ? "Sent" : "Received");
+                ssl_print_hex(bio, 0, " too short message", msg, msglen);
+                break;
+            }
+            hvers = msg[1] << 8 | msg[2];
             BIO_puts(bio, write_p ? "Sent" : "Received");
             BIO_printf(bio, " Record\nHeader:\n  Version = %s (0x%x)\n",
                        ssl_trace_str(hvers, ssl_version_tbl), hvers);


### PR DESCRIPTION
Not a security issue as buffers are overgrown and overreads are two bytes at most.