### PR TITLE
o_fopen.c,rand/randfile.c: compensate for e_os.h omission.

### DIFF
--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -47,7 +47,7 @@ FILE *openssl_fopen(const char *filename, const char *mode)
         if (MultiByteToWideChar(CP_UTF8, flags,
                                 filename, len_0, wfilename, sz) &&
             MultiByteToWideChar(CP_UTF8, 0, mode, strlen(mode) + 1,
-                                wmode, sizeof(wmode) / sizeof(wmode[0])) &&
+                                wmode, OSSL_NELEM(wmode)) &&
             (file = _wfopen(wfilename, wmode)) == NULL &&
             (errno == ENOENT || errno == EBADF)
             ) {

--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/opensslconf.h>
+#include "internal/cryptlib.h"
 
 #if !defined(OPENSSL_NO_STDIO)
 

--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -7,11 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/cryptlib.h"
+#include <openssl/opensslconf.h>
 
 #if !defined(OPENSSL_NO_STDIO)
 
 # include <stdio.h>
+# ifdef _WIN32
+#  include <windows.h>
+# endif
 
 FILE *openssl_fopen(const char *filename, const char *mode)
 {
@@ -44,7 +47,7 @@ FILE *openssl_fopen(const char *filename, const char *mode)
         if (MultiByteToWideChar(CP_UTF8, flags,
                                 filename, len_0, wfilename, sz) &&
             MultiByteToWideChar(CP_UTF8, 0, mode, strlen(mode) + 1,
-                                wmode, OSSL_NELEM(wmode)) &&
+                                wmode, sizeof(wmode) / sizeof(wmode[0])) &&
             (file = _wfopen(wfilename, wmode)) == NULL &&
             (errno == ENOENT || errno == EBADF)
             ) {

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -26,7 +26,12 @@
 # include <sys/stat.h>
 # include <fcntl.h>
 # ifdef _WIN32
+#  include <windows.h>
 #  include <io.h>
+#  define stat    _stat
+#  define chmod   _chmod
+#  define open    _open
+#  define fdopen  _fdopen
 # endif
 #endif
 
@@ -40,13 +45,6 @@
 # if !defined(S_ISREG)
 #   define S_ISREG(m) ((m) & S_IFREG)
 # endif
-
-#ifdef _WIN32
-# define stat    _stat
-# define chmod   _chmod
-# define open    _open
-# define fdopen  _fdopen
-#endif
 
 #define RAND_FILE_SIZE 1024
 #define RFILE ".rnd"


### PR DESCRIPTION
At earlier point e_os.h was omitted from a number of headers (in order
to emphasize OS neutrality), but this affected o_fopen.c and randfile.c
which are not OS-neutral, and contain some Win32-specific code.

[Just in case for reference, 1.1.0 is not affected, it has the code that is being re-enabled here, so that one can even say that it actually addresses a regression.]