### PR TITLE
Don't generate buildtest_*err.c

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -528,6 +528,7 @@ ENDIF
    my @nogo_headers = ( "asn1_mac.h",
                         "__decc_include_prologue.h",
                         "__decc_include_epilogue.h" );
+   my @nogo_headers_re = ( qr/.*err\.h/ );
    my @headerfiles = glob catfile($sourcedir,
                                   updir(), "include", "openssl", "*.h");
 
@@ -535,6 +536,7 @@ ENDIF
        my $name = basename($headerfile, ".h");
        next if $disabled{$name};
        next if grep { $_ eq lc("$name.h") } @nogo_headers;
+       next if grep { lc("$name.h") =~ m/$_/i } @nogo_headers_re;
        $OUT .= <<"_____";
 
   PROGRAMS_NO_INST=buildtest_$name


### PR DESCRIPTION
The error string header files aren't supposed to be included directly,
so there's no point testing that they can.
