### PR TITLE
s_client, s_server: do generic SSL configuration first, specialization after

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1672,6 +1672,9 @@ int s_client_main(int argc, char **argv)
     if (sdebug)
         ssl_ctx_security_debug(ctx, sdebug);
 
+    if (!config_ctx(cctx, ssl_args, ctx))
+        goto end;
+
     if (ssl_config != NULL) {
         if (SSL_CTX_config(ctx, ssl_config) == 0) {
             BIO_printf(bio_err, "Error using configuration \"%s\"\n",
@@ -1728,9 +1731,6 @@ int s_client_main(int argc, char **argv)
                    "\n", prog, maxfraglen);
         goto end;
     }
-
-    if (!config_ctx(cctx, ssl_args, ctx))
-        goto end;
 
     if (!ssl_load_stores(ctx, vfyCApath, vfyCAfile, chCApath, chCAfile,
                          crls, crl_download)) {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1684,9 +1684,11 @@ int s_client_main(int argc, char **argv)
         }
     }
 
-    if (SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
+    if (min_version != 0
+        && SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
         goto end;
-    if (SSL_CTX_set_max_proto_version(ctx, max_version) == 0)
+    if (max_version != 0
+        && SSL_CTX_set_max_proto_version(ctx, max_version) == 0)
         goto end;
 
     if (vpmtouched && !SSL_CTX_set1_param(ctx, vpm)) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1767,9 +1767,11 @@ int s_server_main(int argc, char *argv[])
             goto end;
         }
     }
-    if (SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
+    if (min_version != 0
+        && SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
         goto end;
-    if (SSL_CTX_set_max_proto_version(ctx, max_version) == 0)
+    if (max_version != 0
+        && SSL_CTX_set_max_proto_version(ctx, max_version) == 0)
         goto end;
 
     if (session_id_prefix) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1755,6 +1755,10 @@ int s_server_main(int argc, char *argv[])
     }
     if (sdebug)
         ssl_ctx_security_debug(ctx, sdebug);
+
+    if (!config_ctx(cctx, ssl_args, ctx))
+        goto end;
+
     if (ssl_config) {
         if (SSL_CTX_config(ctx, ssl_config) == 0) {
             BIO_printf(bio_err, "Error using configuration \"%s\"\n",
@@ -1841,8 +1845,6 @@ int s_server_main(int argc, char *argv[])
     }
 
     ssl_ctx_add_crls(ctx, crls, 0);
-    if (!config_ctx(cctx, ssl_args, ctx))
-        goto end;
 
     if (!ssl_load_stores(ctx, vfyCApath, vfyCAfile, chCApath, chCAfile,
                          crls, crl_download)) {


### PR DESCRIPTION
We did the SSL_CONF_cmd() pass last of all things that could affect
the SSL ctx.  However, the results of this, for example:

    -max_protocol TLSv1.3 -tls1_2

... would mean that the protocol min got set to TLSv1.2 and the
protocol max to TLSv1.3, when they should clearly both be TLSv1.2.

However, if we see the SSL_CONF_cmd() switches as generic and those
internal to s_client and s_server as specialisations, we get something
that makes a little more sense.
