### PR TITLE
Remove mention of link between message digests and public key algorithms.

### DIFF
--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -66,11 +66,6 @@ The B<EVP> interface to digital signatures should almost always be used in
 preference to the low level interfaces. This is because the code then becomes
 transparent to the algorithm used and much more flexible.
 
-Due to the link between message digests and public key algorithms the correct
-digest algorithm must be used with the correct public key type. A list of
-algorithms and associated public key algorithms appears in
-L<EVP_DigestInit(3)>.
-
 When signing with DSA private keys the random number generator must be seeded
 or the operation will fail. The random number generator does not need to be
 seeded for RSA signatures.

--- a/doc/man3/EVP_VerifyInit.pod
+++ b/doc/man3/EVP_VerifyInit.pod
@@ -52,11 +52,6 @@ The B<EVP> interface to digital signatures should almost always be used in
 preference to the low level interfaces. This is because the code then becomes
 transparent to the algorithm used and much more flexible.
 
-Due to the link between message digests and public key algorithms the correct
-digest algorithm must be used with the correct public key type. A list of
-algorithms and associated public key algorithms appears in
-L<EVP_DigestInit(3)>.
-
 The call to EVP_VerifyFinal() internally finalizes a copy of the digest context.
 This means that calls to EVP_VerifyUpdate() and EVP_VerifyFinal() can be called
 later to digest and verify additional data.


### PR DESCRIPTION

The comment in EVP_DigestInit.pod is:

> Returns the NID of the public key signing algorithm associated with this
digest. For example EVP_sha1() is associated with RSA so this will return
B<NID_sha1WithRSAEncryption>. Since digests and signature algorithms are no
longer linked this function is only retained for compatibility reasons.


I.e. there is no link anymore.

This attempts to fix the referencing PODs.  There are no code changes.


- [x] documentation is added or updated

