### PR TITLE
crypto/rand/rand_vms.c: include "internal/rand_int.h"

### DIFF
--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -11,6 +11,7 @@
 
 #if defined(OPENSSL_SYS_VMS)
 # include <openssl/rand.h>
+# include "internal/rand_int.h"
 # include "rand_lcl.h"
 # include <descrip.h>
 # include <jpidef.h>


### PR DESCRIPTION
Without it, the RAND_POOL typedef is missing
