### PR TITLE
Fix a travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ matrix:
                   sources:
                       - ubuntu-toolchain-r-test
           compiler: gcc-5
-          env: EXTENDED_TEST="yes" CONFIG_OPTS="--debug no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC" OPENSSL_TEST_RAND_ORDER=0
+          env: EXTENDED_TEST="yes" CONFIG_OPTS="--debug no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC" OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz"
         - os: linux
           addons:
               apt:


### PR DESCRIPTION
One of the travis builds is consistently failing because it hits the
maximum log output length (4Mb). A large chunk of that output is from
the fuzz tests, so we switch that off for the problematic build.

This isn't ideal because that build incorporates ubsan. However there
is another build with ubsan that has fuzzing turned on (although that
build uses clang not gcc).

[extended tests]


