### PR TITLE
Add option to read pkeyopts interactively

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -255,7 +255,7 @@ int pkeyutl_main(int argc, char **argv)
             if (passin == NULL) {
                 /* Get password interactively */
                 char passwd_buf[4096];
-                snprintf(passwd_buf, sizeof(passwd_buf), "Enter %s: ", opt);
+                BIO_snprintf(passwd_buf, sizeof(passwd_buf), "Enter %s: ", opt);
                 EVP_read_pw_string(passwd_buf, sizeof(passwd_buf) - 1,
                                    passwd_buf, 0);
                 passwd = OPENSSL_strdup(passwd_buf);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -37,8 +37,8 @@ typedef enum OPTION_choice {
     OPT_PUBIN, OPT_CERTIN, OPT_ASN1PARSE, OPT_HEXDUMP, OPT_SIGN,
     OPT_VERIFY, OPT_VERIFYRECOVER, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
     OPT_DERIVE, OPT_SIGFILE, OPT_INKEY, OPT_PEERKEY, OPT_PASSIN,
-    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_KDF, OPT_KDFLEN,
-    OPT_R_ENUM
+    OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_PKEYOPT_PASSIN, OPT_KDF,
+    OPT_KDFLEN, OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkeyutl_options[] = {
@@ -66,6 +66,8 @@ const OPTIONS pkeyutl_options[] = {
     {"peerform", OPT_PEERFORM, 'E', "Peer key format - default PEM"},
     {"keyform", OPT_KEYFORM, 'E', "Private key format - default PEM"},
     {"pkeyopt", OPT_PKEYOPT, 's', "Public key options as opt:value"},
+    {"pkeyopt_passin", OPT_PKEYOPT_PASSIN, 's',
+     "Public key option that is read as a passphrase argument opt:passphrase"},
     OPT_R_OPTIONS,
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
@@ -95,6 +97,7 @@ int pkeyutl_main(int argc, char **argv)
     const char *kdfalg = NULL;
     int kdflen = 0;
     STACK_OF(OPENSSL_STRING) *pkeyopts = NULL;
+    STACK_OF(OPENSSL_STRING) *pkeyopts_passin = NULL;
 
     prog = opt_init(argc, argv, pkeyutl_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -193,6 +196,14 @@ int pkeyutl_main(int argc, char **argv)
                 goto end;
             }
             break;
+        case OPT_PKEYOPT_PASSIN:
+            if ((pkeyopts_passin == NULL &&
+                 (pkeyopts_passin = sk_OPENSSL_STRING_new_null()) == NULL) ||
+                sk_OPENSSL_STRING_push(pkeyopts_passin, opt_arg()) == 0) {
+                BIO_puts(bio_err, "out of memory\n");
+                goto end;
+            }
+            break;
         }
     }
     argc = opt_num_rest();
@@ -230,6 +241,45 @@ int pkeyutl_main(int argc, char **argv)
                 ERR_print_errors(bio_err);
                 goto end;
             }
+        }
+    }
+    if (pkeyopts_passin != NULL) {
+        int num = sk_OPENSSL_STRING_num(pkeyopts_passin);
+        int i;
+
+        for (i = 0; i < num; i++) {
+            char *opt = sk_OPENSSL_STRING_value(pkeyopts_passin, i);
+            char *passin = strchr(opt, ':');
+            char *passwd;
+
+            if (passin == NULL) {
+                /* Get password interactively */
+                char passwd_buf[4096];
+                snprintf(passwd_buf, sizeof(passwd_buf), "Enter %s: ", opt);
+                EVP_read_pw_string(passwd_buf, sizeof(passwd_buf) - 1,
+                                   passwd_buf, 0);
+                passwd = OPENSSL_strdup(passwd_buf);
+                if (passwd == NULL) {
+                    BIO_puts(bio_err, "out of memory\n");
+                    goto end;
+                }
+            } else {
+                /* Get password as a passin argument: First split option name
+                 * and passphrase argument into two strings */
+                *passin = 0;
+                passin++;
+                if (app_passwd(passin, NULL, &passwd, NULL) == 0) {
+                    BIO_printf(bio_err, "failed to get '%s'\n", opt);
+                    goto end;
+                }
+            }
+
+            if (EVP_PKEY_CTX_ctrl_str(ctx, opt, passwd) <= 0) {
+                BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n",
+                           prog, opt);
+                goto end;
+            }
+            OPENSSL_free(passwd);
         }
     }
 
@@ -337,6 +387,7 @@ int pkeyutl_main(int argc, char **argv)
     OPENSSL_free(buf_out);
     OPENSSL_free(sig);
     sk_OPENSSL_STRING_free(pkeyopts);
+    sk_OPENSSL_STRING_free(pkeyopts_passin);
     return ret;
 }
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -29,6 +29,7 @@ B<openssl> B<pkeyutl>
 [B<-kdf algorithm>]
 [B<-kdflen length>]
 [B<-pkeyopt opt:value>]
+[B<-pkeyopt_passin opt:passarg>]
 [B<-hexdump>]
 [B<-asn1parse>]
 [B<-rand file...>]
@@ -139,6 +140,13 @@ Set the output length for KDF.
 =item B<-pkeyopt opt:value>
 
 Public key options specified as opt:value. See NOTES below for more details.
+
+=item B<-pkeyopt_passin opt:passarg>
+
+Allows reading a public key option B<opt> from stdin or a password source. If
+only opt is specified, the user will be prompted to enter the value on stdin.
+Alternatively, passarg can be specified which can be any value supported by
+B<PASS PHRASE ARGUMENTS> in L<openssl(1)>.
 
 =item B<-hexdump>
 
@@ -314,6 +322,16 @@ seed consisting of the single byte 0xFF:
 
  openssl pkeyutl -kdf TLS1-PRF -kdflen 48 -pkeyopt md:SHA256 \
     -pkeyopt hexsecret:ff -pkeyopt hexseed:ff -hexdump
+
+Derive a key using B<scrypt> where the password is read from command line:
+
+ openssl pkeyutl -kdf scrypt -kdflen 16 -pkeyopt_passin pass \
+    -pkeyopt hexsalt:aabbcc -pkeyopt N:16384 -pkeyopt r:8 -pkeyopt p:1
+
+Derive using the same algorithm, but read key from environment variable MYPASS:
+
+ openssl pkeyutl -kdf scrypt -kdflen 16 -pkeyopt_passin pass:env:MYPASS \
+    -pkeyopt hexsalt:aabbcc -pkeyopt N:16384 -pkeyopt r:8 -pkeyopt p:1
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This patch adds the ability to interactively enter passphrases for
the pkeyutl application. As requested by @mattcaswell in https://github.com/openssl/openssl/pull/3987, it is a cherrypicked commit that was originally included there.

Illustration of functionality: For example, you could use

$ openssl pkeyutl -kdf TLS1-PRF -kdflen 8 -pkeyopt md:md5
  -pkeyopt_passin secret -pkeyopt_passin seed

To have the "secret" and "seed" values read interactively from keyboard
(with hidden input). Alternatively, the pass phrase argument syntax is
also supported, e.g.:

$ openssl pkeyutl -kdf TLS1-PRF -kdflen 8 -pkeyopt md:md5
  -pkeyopt_passin secret:stdin -pkeyopt_passin seed:env:SEEDVAR

To have "secret" read from stdin and "seed" from the environment
variable SEEDVAR.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
