### PR TITLE
Fix stack-use-after-scope

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -744,6 +744,9 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
                                          unsigned int context, X509 *x,
                                          size_t chainidx)
 {
+#ifndef OPENSSL_NO_PSK
+    char identity[PSK_MAX_IDENTITY_LEN + 1];
+#endif  /* OPENSSL_NO_PSK */
     const unsigned char *id = NULL;
     size_t idlen = 0;
     SSL_SESSION *psksess = NULL;
@@ -765,7 +768,6 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_PSK
     if (psksess == NULL && s->psk_client_callback != NULL) {
-        char identity[PSK_MAX_IDENTITY_LEN + 1];
         unsigned char psk[PSK_MAX_PSK_LEN];
         size_t psklen = 0;
 


### PR DESCRIPTION
Fixes regression from #5667.
___
Found while running sslapitest with ASAN and GCC 7.3.0.