### PR TITLE
Configurations/10-main.conf: correct AIX targets.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1176,7 +1176,8 @@ my %targets = (
         shared_target    => "aix-shared",
         shared_ldflag    => "-shared -static-libgcc -Wl,-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X32 r",
+        AR               => add("-X32"),
+        RANLIB           => add("-X32"),
     },
     "aix64-gcc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
@@ -1194,7 +1195,8 @@ my %targets = (
         shared_target    => "aix-shared",
         shared_ldflag    => "-shared -static-libgcc -Wl,-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X64 r",
+        AR               => add("-X64"),
+        RANLIB           => add("-X64"),
     },
     "aix-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc32_asm") ],
@@ -1215,7 +1217,8 @@ my %targets = (
         shared_cflag     => "-qpic",
         shared_ldflag    => "-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X32 r",
+        AR               => add("-X32"),
+        RANLIB           => add("-X32"),
     },
     "aix64-cc" => {
         inherit_from     => [ "BASE_unix", asm("ppc64_asm") ],
@@ -1236,7 +1239,8 @@ my %targets = (
         shared_cflag     => "-qpic",
         shared_ldflag    => "-G",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        arflags          => "-X64 r",
+        AR               => add("-X64"),
+        RANLIB           => add("-X64"),
     },
 
 # SIEMENS BS2000/OSD: an EBCDIC-based mainframe


### PR DESCRIPTION
I'm adding WIP, because it's just *one* way to solve the problem, and it's open question if it's ~more~ most suitable. See #5659 for background info. On additional not, manual says that ranlib needs -X option too. I don't seem to have the problem, but it might be problematic on older systems...