### PR TITLE
MSCV: Use gmtime_s instead of gmtime

### DIFF
--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -109,6 +109,10 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;
+#elif defined (OPENSSL_SYS_WINDOWS) && defined(_MSC_VER) && _MSC_VER >= 1400
+    if (gmtime_s(result, timer))
+        return NULL;
+    ts = result;
 #elif !defined(OPENSSL_SYS_VMS) || defined(VMS_GMTIME_OK)
     ts = gmtime(timer);
     if (ts == NULL)


### PR DESCRIPTION
Windows implementation uses unsafe gmtime which causes issues in multithreaded environments.