### PR TITLE
Handle partial messages in TLSProxy

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -52,7 +52,9 @@ sub new
         debug => $debug,
         cipherc => "",
         ciphers => "AES128-SHA",
-        flight => 0,
+        flight => -1,
+        direction => -1,
+        partial => ["", ""],
         record_list => [],
         message_list => [],
     };
@@ -128,7 +130,9 @@ sub clearClient
     my $self = shift;
 
     $self->{cipherc} = "";
-    $self->{flight} = 0;
+    $self->{flight} = -1;
+    $self->{direction} = -1;
+    $self->{partial} = ["", ""];
     $self->{record_list} = [];
     $self->{message_list} = [];
     $self->{clientflags} = "";
@@ -344,33 +348,37 @@ sub process_packet
         print "Received client packet\n";
     }
 
+    if ($self->{direction} != $server) {
+        $self->{flight} = $self->{flight} + 1;
+        $self->{direction} = $server;
+    }
+
     print "Packet length = ".length($packet)."\n";
     print "Processing flight ".$self->flight."\n";
 
     #Return contains the list of record found in the packet followed by the
-    #list of messages in those records
-    my @ret = TLSProxy::Record->get_records($server, $self->flight, $packet);
+    #list of messages in those records and any partial message
+    my @ret = TLSProxy::Record->get_records($server, $self->flight, $self->{partial}[$server].$packet);
+    $self->{partial}[$server] = $ret[2];
     push @{$self->record_list}, @{$ret[0]};
     push @{$self->{message_list}}, @{$ret[1]};
 
     print "\n";
 
+    if (scalar(@{$ret[0]}) == 0 or length($ret[2]) != 0) {
+        return "";
+    }
+
     #Finished parsing. Call user provided filter here
-    if(defined $self->filter) {
+    if (defined $self->filter) {
         $self->filter->($self);
     }
 
     #Reconstruct the packet
     $packet = "";
     foreach my $record (@{$self->record_list}) {
-        #We only replay the records for the current flight
-        if ($record->flight != $self->flight) {
-            next;
-        }
         $packet .= $record->reconstruct_record();
     }
-
-    $self->{flight} = $self->{flight} + 1;
 
     print "Forwarded packet length = ".length($packet)."\n\n";
 


### PR DESCRIPTION
This is the back-port of #5412 
I used the following in addition to test the fragmentation:

```
diff --git a/util/perl/TLSProxy/Proxy.pm b/util/perl/TLSProxy/Proxy.pm
index 4ca0a7d..86bca5c 100644
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -290,11 +290,11 @@ sub clientstart
     while(!(TLSProxy::Message->end) && (@ready = $sel->can_read)) {
         foreach my $hand (@ready) {
             if ($hand == $server_sock) {
-                $server_sock->sysread($indata, 16384) or goto END;
+                $server_sock->sysread($indata, 256) or goto END;
                 $indata = $self->process_packet(1, $indata);
                 $client_sock->syswrite($indata);
             } elsif ($hand == $client_sock) {
-                $client_sock->sysread($indata, 16384) or goto END;
+                $client_sock->sysread($indata, 256) or goto END;
                 $indata = $self->process_packet(0, $indata);
                 $server_sock->syswrite($indata);
             } else {
```