### PR TITLE
doc/man1/x509.pod: corrected "S/MIME signing" requirements

### DIFF
--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -871,8 +871,8 @@ this is because some Verisign certificates don't set the S/MIME bit.
 
 =item B<S/MIME Signing>
 
-In addition to the common S/MIME client tests the digitalSignature bit must
-be set if the keyUsage extension is present.
+In addition to the common S/MIME client tests the digitalSignature bit or
+the nonRepudiation bit must be set if the keyUsage extension is present.
 
 =item B<S/MIME Encryption>
 


### PR DESCRIPTION
The manual page for x.509 command states that `S/MIME signing` purpose requires `digitalSignature` bit when `keyUsage` extension is present.

Actually, `crypto/x509v3/v3_purp.c:656` allows either `digitalSignature` or `nonRepudiation`.

Manual page corrected to reflect the above.

- [x] documentation is added or updated