### PR TITLE
Move the handling of dso_scheme to dso_conf.h

### DIFF
--- a/Configure
+++ b/Configure
@@ -1232,29 +1232,6 @@ if ($target =~ /linux.*-mips/ && !$disabled{asm}
 	unshift @{$config{cxxflags}}, $value if $config{CXX};
 }
 
-# The DSO code currently always implements all functions so that no
-# applications will have to worry about that from a compilation point
-# of view. However, the "method"s may return zero unless that platform
-# has support compiled in for them. Currently each method is enabled
-# by a define "DSO_<name>" ... we translate the "dso_scheme" config
-# string entry into using the following logic;
-if (!$disabled{dso} && $target{dso_scheme} ne "")
-	{
-	$target{dso_scheme} =~ tr/[a-z]/[A-Z]/;
-	if ($target{dso_scheme} eq "DLFCN")
-		{
-		unshift @{$config{lib_defines}}, "DSO_DLFCN", "HAVE_DLFCN_H";
-		}
-	elsif ($target{dso_scheme} eq "DLFCN_NO_H")
-		{
-		unshift @{$config{lib_defines}}, "DSO_DLFCN";
-		}
-	else
-		{
-		unshift @{$config{lib_defines}}, "DSO_$target{dso_scheme}";
-		}
-	}
-
 # If threads aren't disabled, check how possible they are
 unless ($disabled{threads}) {
     if ($auto_threads) {

--- a/crypto/include/internal/dso_conf.h.in
+++ b/crypto/include/internal/dso_conf.h.in
@@ -10,6 +10,21 @@
 
 #ifndef HEADER_DSO_CONF_H
 # define HEADER_DSO_CONF_H
-
+{- output_off() if $disabled{dso} -}
+{-  # The DSO code currently always implements all functions so that no
+    # applications will have to worry about that from a compilation point
+    # of view. However, the "method"s may return zero unless that platform
+    # has support compiled in for them. Currently each method is enabled
+    # by a define "DSO_<name>" ... we translate the "dso_scheme" config
+    # string entry into using the following logic;
+    my $scheme = uc $target{dso_scheme};
+    my @macros = ( "DSO_$scheme" );
+    if ($scheme eq 'DLFCN') {
+        @macros = ( "DSO_DLFCN", "HAVE_DLFCN_H" );
+    } elsif ($scheme eq "DLFCN_NO_H") {
+        @macros = ( "DSO_DLFCN" );
+    }
+    join("\n", map { "# define $_" } @macros); -}
 # define DSO_EXTENSION "{- $target{dso_extension} -}"
+{- output_on() if $disabled{dso} -}
 #endif

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "internal/thread_once.h"
+#include "internal/dso_conf.h"
 #include "internal/dso.h"
 #include "internal/store.h"
 

--- a/test/build.info
+++ b/test/build.info
@@ -378,7 +378,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   IF[{- !$disabled{shared} -}]
     PROGRAMS_NO_INST=shlibloadtest
     SOURCE[shlibloadtest]=shlibloadtest.c
-    INCLUDE[shlibloadtest]=../include
+    INCLUDE[shlibloadtest]=../include ../crypto/include
     DEPEND[shlibloadtest]=libtestutil.a
   ENDIF
 

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -108,8 +108,6 @@ static int test_lib(void)
     SSL_CTX_free_t mySSL_CTX_free;
     ERR_get_error_t myERR_get_error;
     OpenSSL_version_num_t myOpenSSL_version_num;
-    DSO_dsobyaddr_t myDSO_dsobyaddr;
-    DSO_free_t myDSO_free;
     int result = 0;
 
     switch (test_type) {
@@ -171,6 +169,9 @@ static int test_lib(void)
 
     if (test_type == DSO_REFTEST) {
 # ifdef DSO_DLFCN
+        DSO_dsobyaddr_t myDSO_dsobyaddr;
+        DSO_free_t myDSO_free;
+
         /*
          * This is resembling the code used in ossl_init_base() and
          * OPENSSL_atexit() to block unloading the library after dlclose().

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -13,6 +13,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/ssl.h>
 #include <openssl/ossl_typ.h>
+#include "internal/dso_conf.h"
 #include "testutil.h"
 
 typedef void DSO;

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -163,10 +163,10 @@ static int test_lib(void)
 # define COMPATIBILITY_MASK 0xfff00000L
     myOpenSSL_version_num = (OpenSSL_version_num_t)symbols[1].func;
     if (!TEST_int_eq(myOpenSSL_version_num() & COMPATIBILITY_MASK,
-                     OPENSSL_VERSION_NUMBER & COMPATIBILITY_MASK)
+                     OPENSSL_VERSION_NUMBER & COMPATIBILITY_MASK))
         goto end;
     if (!TEST_int_ge(myOpenSSL_version_num() & ~COMPATIBILITY_MASK,
-                     OPENSSL_VERSION_NUMBER & ~COMPATIBILITY_MASK)
+                     OPENSSL_VERSION_NUMBER & ~COMPATIBILITY_MASK))
         goto end;
 
     if (test_type == DSO_REFTEST) {
@@ -190,9 +190,9 @@ static int test_lib(void)
         {
             DSO *hndl;
             /* use known symbol from crypto module */
-            if (!TEST_ptr(hndl = DSO_dsobyaddr((void (*)())ERR_get_error, 0)))
+            if (!TEST_ptr(hndl = myDSO_dsobyaddr((void (*)())ERR_get_error, 0)))
                 goto end;
-            DSO_free(hndl);
+            myDSO_free(hndl);
         }
 # endif /* DSO_DLFCN */
     }


### PR DESCRIPTION
The macros resulting from the dso_scheme attribute were defined for
libraries only, but there's a test program that uses the macros as
well.  The easier way is to move the handling of this macro to
crypto/include/internal/dso_conf.h and having the modules that need it
include it.
