### PR TITLE
Fix ecparam -genkey with point compression or DER outform

### DIFF
--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -384,6 +384,9 @@ int ecparam_main(int argc, char **argv)
                         "}\n");
     }
 
+    if (outformat == FORMAT_ASN1 && genkey)
+        noout = 1;
+
     if (!noout) {
         if (outformat == FORMAT_ASN1)
             i = i2d_ECPKParameters_bio(out, group);
@@ -409,6 +412,9 @@ int ecparam_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             goto end;
         }
+
+        if (new_form)
+            EC_KEY_set_conv_form(eckey, form);
 
         if (!EC_KEY_generate_key(eckey)) {
             BIO_printf(bio_err, "unable to generate key\n");


### PR DESCRIPTION
Points are not in compressed format when ecparam -genkey is used.
DER form output is unusable when both ecgroup and eckey are written to out.