### PR TITLE
Fix dsaparam -genkey with DER outform

### DIFF
--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -195,6 +195,9 @@ int dsaparam_main(int argc, char **argv)
         OPENSSL_free(data);
     }
 
+    if (outformat == FORMAT_ASN1 && genkey)
+        noout = 1;
+
     if (!noout) {
         if (outformat == FORMAT_ASN1)
             i = i2d_DSAparams_bio(out, dsa);


### PR DESCRIPTION
dsaparam -genkey produces unusable ASN1 output