### PR TITLE
Backport #2181: Convert _meth_get_ functions to const getters

### DIFF
--- a/crypto/bio/bio_meth.c
+++ b/crypto/bio/bio_meth.c
@@ -54,7 +54,7 @@ void BIO_meth_free(BIO_METHOD *biom)
     }
 }
 
-int (*BIO_meth_get_write(BIO_METHOD *biom)) (BIO *, const char *, int)
+int (*BIO_meth_get_write(const BIO_METHOD *biom)) (BIO *, const char *, int)
 {
     return biom->bwrite;
 }
@@ -66,7 +66,7 @@ int BIO_meth_set_write(BIO_METHOD *biom,
     return 1;
 }
 
-int (*BIO_meth_get_read(BIO_METHOD *biom)) (BIO *, char *, int)
+int (*BIO_meth_get_read(const BIO_METHOD *biom)) (BIO *, char *, int)
 {
     return biom->bread;
 }
@@ -78,7 +78,7 @@ int BIO_meth_set_read(BIO_METHOD *biom,
     return 1;
 }
 
-int (*BIO_meth_get_puts(BIO_METHOD *biom)) (BIO *, const char *)
+int (*BIO_meth_get_puts(const BIO_METHOD *biom)) (BIO *, const char *)
 {
     return biom->bputs;
 }
@@ -90,7 +90,7 @@ int BIO_meth_set_puts(BIO_METHOD *biom,
     return 1;
 }
 
-int (*BIO_meth_get_gets(BIO_METHOD *biom)) (BIO *, char *, int)
+int (*BIO_meth_get_gets(const BIO_METHOD *biom)) (BIO *, char *, int)
 {
     return biom->bgets;
 }
@@ -102,7 +102,7 @@ int BIO_meth_set_gets(BIO_METHOD *biom,
     return 1;
 }
 
-long (*BIO_meth_get_ctrl(BIO_METHOD *biom)) (BIO *, int, long, void *)
+long (*BIO_meth_get_ctrl(const BIO_METHOD *biom)) (BIO *, int, long, void *)
 {
     return biom->ctrl;
 }
@@ -114,7 +114,7 @@ int BIO_meth_set_ctrl(BIO_METHOD *biom,
     return 1;
 }
 
-int (*BIO_meth_get_create(BIO_METHOD *biom)) (BIO *)
+int (*BIO_meth_get_create(const BIO_METHOD *biom)) (BIO *)
 {
     return biom->create;
 }
@@ -125,7 +125,7 @@ int BIO_meth_set_create(BIO_METHOD *biom, int (*create) (BIO *))
     return 1;
 }
 
-int (*BIO_meth_get_destroy(BIO_METHOD *biom)) (BIO *)
+int (*BIO_meth_get_destroy(const BIO_METHOD *biom)) (BIO *)
 {
     return biom->destroy;
 }
@@ -136,7 +136,7 @@ int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *))
     return 1;
 }
 
-long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom)) (BIO *, int, BIO_info_cb *)
+long (*BIO_meth_get_callback_ctrl(const BIO_METHOD *biom)) (BIO *, int, BIO_info_cb *)
 {
     return biom->callback_ctrl;
 }

--- a/crypto/dh/dh_meth.c
+++ b/crypto/dh/dh_meth.c
@@ -75,7 +75,7 @@ int DH_meth_set1_name(DH_METHOD *dhm, const char *name)
     return 1;
 }
 
-int DH_meth_get_flags(DH_METHOD *dhm)
+int DH_meth_get_flags(const DH_METHOD *dhm)
 {
     return dhm->flags;
 }

--- a/crypto/dsa/dsa_meth.c
+++ b/crypto/dsa/dsa_meth.c
@@ -83,7 +83,7 @@ int DSA_meth_set1_name(DSA_METHOD *dsam, const char *name)
     return 1;
 }
 
-int DSA_meth_get_flags(DSA_METHOD *dsam)
+int DSA_meth_get_flags(const DSA_METHOD *dsam)
 {
     return dsam->flags;
 }

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -557,26 +557,26 @@ void EVP_PKEY_meth_set_ctrl(EVP_PKEY_METHOD *pmeth,
     pmeth->ctrl_str = ctrl_str;
 }
 
-void EVP_PKEY_meth_get_init(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_init(const EVP_PKEY_METHOD *pmeth,
                             int (**pinit) (EVP_PKEY_CTX *ctx))
 {
     *pinit = pmeth->init;
 }
 
-void EVP_PKEY_meth_get_copy(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_copy(const EVP_PKEY_METHOD *pmeth,
                             int (**pcopy) (EVP_PKEY_CTX *dst,
                                            EVP_PKEY_CTX *src))
 {
     *pcopy = pmeth->copy;
 }
 
-void EVP_PKEY_meth_get_cleanup(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_cleanup(const EVP_PKEY_METHOD *pmeth,
                                void (**pcleanup) (EVP_PKEY_CTX *ctx))
 {
     *pcleanup = pmeth->cleanup;
 }
 
-void EVP_PKEY_meth_get_paramgen(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_paramgen(const EVP_PKEY_METHOD *pmeth,
                                 int (**pparamgen_init) (EVP_PKEY_CTX *ctx),
                                 int (**pparamgen) (EVP_PKEY_CTX *ctx,
                                                    EVP_PKEY *pkey))
@@ -587,7 +587,7 @@ void EVP_PKEY_meth_get_paramgen(EVP_PKEY_METHOD *pmeth,
         *pparamgen = pmeth->paramgen;
 }
 
-void EVP_PKEY_meth_get_keygen(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_keygen(const EVP_PKEY_METHOD *pmeth,
                               int (**pkeygen_init) (EVP_PKEY_CTX *ctx),
                               int (**pkeygen) (EVP_PKEY_CTX *ctx,
                                                EVP_PKEY *pkey))
@@ -598,7 +598,7 @@ void EVP_PKEY_meth_get_keygen(EVP_PKEY_METHOD *pmeth,
         *pkeygen = pmeth->keygen;
 }
 
-void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_sign(const EVP_PKEY_METHOD *pmeth,
                             int (**psign_init) (EVP_PKEY_CTX *ctx),
                             int (**psign) (EVP_PKEY_CTX *ctx,
                                            unsigned char *sig, size_t *siglen,
@@ -611,7 +611,7 @@ void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
         *psign = pmeth->sign;
 }
 
-void EVP_PKEY_meth_get_verify(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_verify(const EVP_PKEY_METHOD *pmeth,
                               int (**pverify_init) (EVP_PKEY_CTX *ctx),
                               int (**pverify) (EVP_PKEY_CTX *ctx,
                                                const unsigned char *sig,
@@ -625,7 +625,7 @@ void EVP_PKEY_meth_get_verify(EVP_PKEY_METHOD *pmeth,
         *pverify = pmeth->verify;
 }
 
-void EVP_PKEY_meth_get_verify_recover(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_verify_recover(const EVP_PKEY_METHOD *pmeth,
                                       int (**pverify_recover_init) (EVP_PKEY_CTX
                                                                     *ctx),
                                       int (**pverify_recover) (EVP_PKEY_CTX
@@ -643,7 +643,7 @@ void EVP_PKEY_meth_get_verify_recover(EVP_PKEY_METHOD *pmeth,
         *pverify_recover = pmeth->verify_recover;
 }
 
-void EVP_PKEY_meth_get_signctx(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_signctx(const EVP_PKEY_METHOD *pmeth,
                                int (**psignctx_init) (EVP_PKEY_CTX *ctx,
                                                       EVP_MD_CTX *mctx),
                                int (**psignctx) (EVP_PKEY_CTX *ctx,
@@ -657,7 +657,7 @@ void EVP_PKEY_meth_get_signctx(EVP_PKEY_METHOD *pmeth,
         *psignctx = pmeth->signctx;
 }
 
-void EVP_PKEY_meth_get_verifyctx(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_verifyctx(const EVP_PKEY_METHOD *pmeth,
                                  int (**pverifyctx_init) (EVP_PKEY_CTX *ctx,
                                                           EVP_MD_CTX *mctx),
                                  int (**pverifyctx) (EVP_PKEY_CTX *ctx,
@@ -671,7 +671,7 @@ void EVP_PKEY_meth_get_verifyctx(EVP_PKEY_METHOD *pmeth,
         *pverifyctx = pmeth->verifyctx;
 }
 
-void EVP_PKEY_meth_get_encrypt(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_encrypt(const EVP_PKEY_METHOD *pmeth,
                                int (**pencrypt_init) (EVP_PKEY_CTX *ctx),
                                int (**pencryptfn) (EVP_PKEY_CTX *ctx,
                                                    unsigned char *out,
@@ -685,7 +685,7 @@ void EVP_PKEY_meth_get_encrypt(EVP_PKEY_METHOD *pmeth,
         *pencryptfn = pmeth->encrypt;
 }
 
-void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_decrypt(const EVP_PKEY_METHOD *pmeth,
                                int (**pdecrypt_init) (EVP_PKEY_CTX *ctx),
                                int (**pdecrypt) (EVP_PKEY_CTX *ctx,
                                                  unsigned char *out,
@@ -699,7 +699,7 @@ void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
         *pdecrypt = pmeth->decrypt;
 }
 
-void EVP_PKEY_meth_get_derive(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_derive(const EVP_PKEY_METHOD *pmeth,
                               int (**pderive_init) (EVP_PKEY_CTX *ctx),
                               int (**pderive) (EVP_PKEY_CTX *ctx,
                                                unsigned char *key,
@@ -711,7 +711,7 @@ void EVP_PKEY_meth_get_derive(EVP_PKEY_METHOD *pmeth,
         *pderive = pmeth->derive;
 }
 
-void EVP_PKEY_meth_get_ctrl(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_ctrl(const EVP_PKEY_METHOD *pmeth,
                             int (**pctrl) (EVP_PKEY_CTX *ctx, int type, int p1,
                                            void *p2),
                             int (**pctrl_str) (EVP_PKEY_CTX *ctx,

--- a/crypto/rsa/rsa_meth.c
+++ b/crypto/rsa/rsa_meth.c
@@ -75,7 +75,7 @@ int RSA_meth_set1_name(RSA_METHOD *meth, const char *name)
     return 1;
 }
 
-int RSA_meth_get_flags(RSA_METHOD *meth)
+int RSA_meth_get_flags(const RSA_METHOD *meth)
 {
     return meth->flags;
 }

--- a/doc/crypto/BIO_meth_new.pod
+++ b/doc/crypto/BIO_meth_new.pod
@@ -17,26 +17,26 @@ BIO_meth_set_callback_ctrl - Routines to build up BIO methods
  int BIO_get_new_index(void);
  BIO_METHOD *BIO_meth_new(int type, const char *name);
  void BIO_meth_free(BIO_METHOD *biom);
- int (*BIO_meth_get_write(BIO_METHOD *biom)) (BIO *, const char *, int);
+ int (*BIO_meth_get_write(const BIO_METHOD *biom)) (BIO *, const char *, int);
  int BIO_meth_set_write(BIO_METHOD *biom,
                         int (*write) (BIO *, const char *, int));
- int (*BIO_meth_get_read(BIO_METHOD *biom)) (BIO *, char *, int);
+ int (*BIO_meth_get_read(const BIO_METHOD *biom)) (BIO *, char *, int);
  int BIO_meth_set_read(BIO_METHOD *biom,
                        int (*read) (BIO *, char *, int));
- int (*BIO_meth_get_puts(BIO_METHOD *biom)) (BIO *, const char *);
+ int (*BIO_meth_get_puts(const BIO_METHOD *biom)) (BIO *, const char *);
  int BIO_meth_set_puts(BIO_METHOD *biom,
                        int (*puts) (BIO *, const char *));
- int (*BIO_meth_get_gets(BIO_METHOD *biom)) (BIO *, char *, int);
+ int (*BIO_meth_get_gets(const BIO_METHOD *biom)) (BIO *, char *, int);
  int BIO_meth_set_gets(BIO_METHOD *biom,
                        int (*gets) (BIO *, char *, int));
- long (*BIO_meth_get_ctrl(BIO_METHOD *biom)) (BIO *, int, long, void *);
+ long (*BIO_meth_get_ctrl(const BIO_METHOD *biom)) (BIO *, int, long, void *);
  int BIO_meth_set_ctrl(BIO_METHOD *biom,
                        long (*ctrl) (BIO *, int, long, void *));
- int (*BIO_meth_get_create(BIO_METHOD *bion)) (BIO *);
+ int (*BIO_meth_get_create(const BIO_METHOD *bion)) (BIO *);
  int BIO_meth_set_create(BIO_METHOD *biom, int (*create) (BIO *));
- int (*BIO_meth_get_destroy(BIO_METHOD *biom)) (BIO *);
+ int (*BIO_meth_get_destroy(const BIO_METHOD *biom)) (BIO *);
  int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *));
- long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom))
+ long (*BIO_meth_get_callback_ctrl(const BIO_METHOD *biom))
                                   (BIO *, int, BIO_info_cb *);
  int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
                                 long (*callback_ctrl) (BIO *, int,

--- a/doc/crypto/DH_meth_new.pod
+++ b/doc/crypto/DH_meth_new.pod
@@ -19,7 +19,7 @@ DH_meth_set_generate_params - Routines to build up DH methods
  DH_METHOD *DH_meth_dup(const DH_METHOD *dhm);
  const char *DH_meth_get0_name(const DH_METHOD *dhm);
  int DH_meth_set1_name(DH_METHOD *dhm, const char *name);
- int DH_meth_get_flags(DH_METHOD *dhm);
+ int DH_meth_get_flags(const DH_METHOD *dhm);
  int DH_meth_set_flags(DH_METHOD *dhm, int flags);
  void *DH_meth_get0_app_data(const DH_METHOD *dhm);
  int DH_meth_set0_app_data(DH_METHOD *dhm, void *app_data);

--- a/doc/crypto/DSA_meth_new.pod
+++ b/doc/crypto/DSA_meth_new.pod
@@ -21,7 +21,7 @@ DSA_meth_set_keygen - Routines to build up DSA methods
  DSA_METHOD *DSA_meth_dup(const DSA_METHOD *meth);
  const char *DSA_meth_get0_name(const DSA_METHOD *dsam);
  int DSA_meth_set1_name(DSA_METHOD *dsam, const char *name);
- int DSA_meth_get_flags(DSA_METHOD *dsam);
+ int DSA_meth_get_flags(const DSA_METHOD *dsam);
  int DSA_meth_set_flags(DSA_METHOD *dsam, int flags);
  void *DSA_meth_get0_app_data(const DSA_METHOD *dsam);
  int DSA_meth_set0_app_data(DSA_METHOD *dsam, void *app_data);

--- a/doc/crypto/RSA_meth_new.pod
+++ b/doc/crypto/RSA_meth_new.pod
@@ -24,7 +24,7 @@ RSA_meth_set_verify, RSA_meth_get_keygen, RSA_meth_set_keygen
  RSA_METHOD *RSA_meth_dup(const RSA_METHOD *meth);
  const char *RSA_meth_get0_name(const RSA_METHOD *meth);
  int RSA_meth_set1_name(RSA_METHOD *meth, const char *name);
- int RSA_meth_get_flags(RSA_METHOD *meth);
+ int RSA_meth_get_flags(const RSA_METHOD *meth);
  int RSA_meth_set_flags(RSA_METHOD *meth, int flags);
  void *RSA_meth_get0_app_data(const RSA_METHOD *meth);
  int RSA_meth_set0_app_data(RSA_METHOD *meth, void *app_data);

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -730,26 +730,26 @@ __bio_h__attr__((__format__(__printf__, 3, 0)));
 
 BIO_METHOD *BIO_meth_new(int type, const char *name);
 void BIO_meth_free(BIO_METHOD *biom);
-int (*BIO_meth_get_write(BIO_METHOD *biom)) (BIO *, const char *, int);
+int (*BIO_meth_get_write(const BIO_METHOD *biom)) (BIO *, const char *, int);
 int BIO_meth_set_write(BIO_METHOD *biom,
                        int (*write) (BIO *, const char *, int));
-int (*BIO_meth_get_read(BIO_METHOD *biom)) (BIO *, char *, int);
+int (*BIO_meth_get_read(const BIO_METHOD *biom)) (BIO *, char *, int);
 int BIO_meth_set_read(BIO_METHOD *biom,
                       int (*read) (BIO *, char *, int));
-int (*BIO_meth_get_puts(BIO_METHOD *biom)) (BIO *, const char *);
+int (*BIO_meth_get_puts(const BIO_METHOD *biom)) (BIO *, const char *);
 int BIO_meth_set_puts(BIO_METHOD *biom,
                       int (*puts) (BIO *, const char *));
-int (*BIO_meth_get_gets(BIO_METHOD *biom)) (BIO *, char *, int);
+int (*BIO_meth_get_gets(const BIO_METHOD *biom)) (BIO *, char *, int);
 int BIO_meth_set_gets(BIO_METHOD *biom,
                       int (*gets) (BIO *, char *, int));
-long (*BIO_meth_get_ctrl(BIO_METHOD *biom)) (BIO *, int, long, void *);
+long (*BIO_meth_get_ctrl(const BIO_METHOD *biom)) (BIO *, int, long, void *);
 int BIO_meth_set_ctrl(BIO_METHOD *biom,
                       long (*ctrl) (BIO *, int, long, void *));
-int (*BIO_meth_get_create(BIO_METHOD *bion)) (BIO *);
+int (*BIO_meth_get_create(const BIO_METHOD *bion)) (BIO *);
 int BIO_meth_set_create(BIO_METHOD *biom, int (*create) (BIO *));
-int (*BIO_meth_get_destroy(BIO_METHOD *biom)) (BIO *);
+int (*BIO_meth_get_destroy(const BIO_METHOD *biom)) (BIO *);
 int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *));
-long (*BIO_meth_get_callback_ctrl(BIO_METHOD *biom))
+long (*BIO_meth_get_callback_ctrl(const BIO_METHOD *biom))
                                  (BIO *, int, BIO_info_cb *);
 int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
                                long (*callback_ctrl) (BIO *, int,

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -187,7 +187,7 @@ void DH_meth_free(DH_METHOD *dhm);
 DH_METHOD *DH_meth_dup(const DH_METHOD *dhm);
 const char *DH_meth_get0_name(const DH_METHOD *dhm);
 int DH_meth_set1_name(DH_METHOD *dhm, const char *name);
-int DH_meth_get_flags(DH_METHOD *dhm);
+int DH_meth_get_flags(const DH_METHOD *dhm);
 int DH_meth_set_flags(DH_METHOD *dhm, int flags);
 void *DH_meth_get0_app_data(const DH_METHOD *dhm);
 int DH_meth_set0_app_data(DH_METHOD *dhm, void *app_data);

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -186,7 +186,7 @@ void DSA_meth_free(DSA_METHOD *dsam);
 DSA_METHOD *DSA_meth_dup(const DSA_METHOD *dsam);
 const char *DSA_meth_get0_name(const DSA_METHOD *dsam);
 int DSA_meth_set1_name(DSA_METHOD *dsam, const char *name);
-int DSA_meth_get_flags(DSA_METHOD *dsam);
+int DSA_meth_get_flags(const DSA_METHOD *dsam);
 int DSA_meth_set_flags(DSA_METHOD *dsam, int flags);
 void *DSA_meth_get0_app_data(const DSA_METHOD *dsam);
 int DSA_meth_set0_app_data(DSA_METHOD *dsam, void *app_data);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1351,34 +1351,34 @@ void EVP_PKEY_meth_set_ctrl(EVP_PKEY_METHOD *pmeth,
                                              const char *type,
                                              const char *value));
 
-void EVP_PKEY_meth_get_init(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_init(const EVP_PKEY_METHOD *pmeth,
                             int (**pinit) (EVP_PKEY_CTX *ctx));
 
-void EVP_PKEY_meth_get_copy(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_copy(const EVP_PKEY_METHOD *pmeth,
                             int (**pcopy) (EVP_PKEY_CTX *dst,
                                            EVP_PKEY_CTX *src));
 
-void EVP_PKEY_meth_get_cleanup(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_cleanup(const EVP_PKEY_METHOD *pmeth,
                                void (**pcleanup) (EVP_PKEY_CTX *ctx));
 
-void EVP_PKEY_meth_get_paramgen(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_paramgen(const EVP_PKEY_METHOD *pmeth,
                                 int (**pparamgen_init) (EVP_PKEY_CTX *ctx),
                                 int (**pparamgen) (EVP_PKEY_CTX *ctx,
                                                    EVP_PKEY *pkey));
 
-void EVP_PKEY_meth_get_keygen(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_keygen(const EVP_PKEY_METHOD *pmeth,
                               int (**pkeygen_init) (EVP_PKEY_CTX *ctx),
                               int (**pkeygen) (EVP_PKEY_CTX *ctx,
                                                EVP_PKEY *pkey));
 
-void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_sign(const EVP_PKEY_METHOD *pmeth,
                             int (**psign_init) (EVP_PKEY_CTX *ctx),
                             int (**psign) (EVP_PKEY_CTX *ctx,
                                            unsigned char *sig, size_t *siglen,
                                            const unsigned char *tbs,
                                            size_t tbslen));
 
-void EVP_PKEY_meth_get_verify(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_verify(const EVP_PKEY_METHOD *pmeth,
                               int (**pverify_init) (EVP_PKEY_CTX *ctx),
                               int (**pverify) (EVP_PKEY_CTX *ctx,
                                                const unsigned char *sig,
@@ -1386,7 +1386,7 @@ void EVP_PKEY_meth_get_verify(EVP_PKEY_METHOD *pmeth,
                                                const unsigned char *tbs,
                                                size_t tbslen));
 
-void EVP_PKEY_meth_get_verify_recover(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_verify_recover(const EVP_PKEY_METHOD *pmeth,
                                       int (**pverify_recover_init) (EVP_PKEY_CTX
                                                                     *ctx),
                                       int (**pverify_recover) (EVP_PKEY_CTX
@@ -1398,7 +1398,7 @@ void EVP_PKEY_meth_get_verify_recover(EVP_PKEY_METHOD *pmeth,
                                                                char *tbs,
                                                                size_t tbslen));
 
-void EVP_PKEY_meth_get_signctx(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_signctx(const EVP_PKEY_METHOD *pmeth,
                                int (**psignctx_init) (EVP_PKEY_CTX *ctx,
                                                       EVP_MD_CTX *mctx),
                                int (**psignctx) (EVP_PKEY_CTX *ctx,
@@ -1406,7 +1406,7 @@ void EVP_PKEY_meth_get_signctx(EVP_PKEY_METHOD *pmeth,
                                                  size_t *siglen,
                                                  EVP_MD_CTX *mctx));
 
-void EVP_PKEY_meth_get_verifyctx(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_verifyctx(const EVP_PKEY_METHOD *pmeth,
                                  int (**pverifyctx_init) (EVP_PKEY_CTX *ctx,
                                                           EVP_MD_CTX *mctx),
                                  int (**pverifyctx) (EVP_PKEY_CTX *ctx,
@@ -1414,7 +1414,7 @@ void EVP_PKEY_meth_get_verifyctx(EVP_PKEY_METHOD *pmeth,
                                                      int siglen,
                                                      EVP_MD_CTX *mctx));
 
-void EVP_PKEY_meth_get_encrypt(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_encrypt(const EVP_PKEY_METHOD *pmeth,
                                int (**pencrypt_init) (EVP_PKEY_CTX *ctx),
                                int (**pencryptfn) (EVP_PKEY_CTX *ctx,
                                                    unsigned char *out,
@@ -1422,7 +1422,7 @@ void EVP_PKEY_meth_get_encrypt(EVP_PKEY_METHOD *pmeth,
                                                    const unsigned char *in,
                                                    size_t inlen));
 
-void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_decrypt(const EVP_PKEY_METHOD *pmeth,
                                int (**pdecrypt_init) (EVP_PKEY_CTX *ctx),
                                int (**pdecrypt) (EVP_PKEY_CTX *ctx,
                                                  unsigned char *out,
@@ -1430,13 +1430,13 @@ void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
                                                  const unsigned char *in,
                                                  size_t inlen));
 
-void EVP_PKEY_meth_get_derive(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_derive(const EVP_PKEY_METHOD *pmeth,
                               int (**pderive_init) (EVP_PKEY_CTX *ctx),
                               int (**pderive) (EVP_PKEY_CTX *ctx,
                                                unsigned char *key,
                                                size_t *keylen));
 
-void EVP_PKEY_meth_get_ctrl(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_ctrl(const EVP_PKEY_METHOD *pmeth,
                             int (**pctrl) (EVP_PKEY_CTX *ctx, int type, int p1,
                                            void *p2),
                             int (**pctrl_str) (EVP_PKEY_CTX *ctx,

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -374,7 +374,7 @@ void RSA_meth_free(RSA_METHOD *meth);
 RSA_METHOD *RSA_meth_dup(const RSA_METHOD *meth);
 const char *RSA_meth_get0_name(const RSA_METHOD *meth);
 int RSA_meth_set1_name(RSA_METHOD *meth, const char *name);
-int RSA_meth_get_flags(RSA_METHOD *meth);
+int RSA_meth_get_flags(const RSA_METHOD *meth);
 int RSA_meth_set_flags(RSA_METHOD *meth, int flags);
 void *RSA_meth_get0_app_data(const RSA_METHOD *meth);
 int RSA_meth_set0_app_data(RSA_METHOD *meth, void *app_data);


### PR DESCRIPTION
(cherry picked from commit 693be9a2cb0fc79fe856259feea54772c18a3637)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated