### PR TITLE
Refuse to run test_cipherlist unless shared library matches build

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -1,5 +1,6 @@
 IF[{- !$disabled{tests} -}]
   PROGRAMS_NO_INST=\
+          versions \
           aborttest \
           sanitytest exdatatest bntest \
           ectest ecdsatest gmdifftest pbelutest ideatest \
@@ -18,6 +19,10 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
           ocspapitest fatalerrtest
+
+  SOURCE[versions]=versions.c
+  INCLUDE[versions]=../include
+  DEPEND[versions]=../libcrypto
 
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include

--- a/test/recipes/80-test_cipherlist.t
+++ b/test/recipes/80-test_cipherlist.t
@@ -12,10 +12,15 @@ use strict;
 use warnings;
 
 use OpenSSL::Test::Simple;
-use OpenSSL::Test;
+use OpenSSL::Test qw(:DEFAULT openssl_versions);
 use OpenSSL::Test::Utils qw(alldisabled available_protocols);
 
 setup("test_cipherlist");
+
+my ($build_version, $library_version) = openssl_versions();
+plan skip_all =>
+    "This test recipe isn't supported when doing regression testing"
+    if $build_version != $library_version;
 
 my $no_anytls = alldisabled(available_protocols("tls"));
 

--- a/test/versions.c
+++ b/test/versions.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <openssl/opensslv.h>
+#include <openssl/crypto.h>
+
+/* A simple helper for the perl function OpenSSL::Test::openssl_versions */
+int main(void)
+{
+    printf("Build version: 0x%08lX\n", OPENSSL_VERSION_NUMBER);
+    printf("Library version: 0x%08lX\n", OpenSSL_version_num());
+}

--- a/test/versions.c
+++ b/test/versions.c
@@ -16,4 +16,5 @@ int main(void)
 {
     printf("Build version: 0x%08lX\n", OPENSSL_VERSION_NUMBER);
     printf("Library version: 0x%08lX\n", OpenSSL_version_num());
+    return 0;
 }

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -21,7 +21,8 @@ $VERSION = "0.8";
 @EXPORT_OK = (@Test::More::EXPORT_OK, qw(bldtop_dir bldtop_file
                                          srctop_dir srctop_file
                                          data_file
-                                         pipe with cmdstr quotify));
+                                         pipe with cmdstr quotify
+                                         openssl_versions));
 
 =head1 NAME
 
@@ -693,6 +694,32 @@ sub quotify {
     }
 
     return map { $arg_formatter->($_) } @_;
+}
+
+=over 4
+
+=item B<openssl_versions>
+
+Returns a list of two numbers, the first representing the build version,
+the second representing the library version.  See opensslv.h for more
+information on those numbers.
+
+= back
+
+=cut
+
+my @versions = ();
+sub openssl_versions {
+    unless (@versions) {
+        my %lines =
+            map { s/\R$//;
+                  /^(.*): (0x[[:xdigit:]]{8})$/;
+                  die "Weird line: $_" unless defined $1;
+                  $1 => hex($2) }
+            run(test(['versions']), capture => 1);
+        @versions = ( $lines{'Build version'}, $lines{'Library version'} );
+    }
+    return @versions;
 }
 
 ######################################################################


### PR DESCRIPTION
test/cipherlist_test.c is an internal consistency check, and therefore
requires that the shared library it runs against matches what it was
built for.  test/recipes/test_cipherlist.t is made to refuse running
unless library version and build version match.

This adds a helper program test/versions.c, that simply displays the
library and the build version.

Partially fixes #5751
