### PR TITLE
test/recipes/test_genrsa.t : don't fail because of size limit changes

### DIFF
--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -24,8 +24,8 @@ is(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', '8'])), 0, "ge
 # Depending on the shared library, we might have different lower limits.
 # Let's find it!
 note "Looking for lowest amount of bits";
-my $bad = 3;                    # Number of bits
-my $good = 11;                  # Number of bits
+my $bad = 3;                    # Log2 of number of bits
+my $good = 11;                  # Log2 of number of bits
 my $checked = int(($good + $bad + 1) / 2);
 while ($good > $bad + 1) {
     if (run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem',

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -22,24 +22,28 @@ plan tests => 5;
 is(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', '8'])), 0, "genrsa -3 8");
 
 # Depending on the shared library, we might have different lower limits.
-# Let's find it!
+# Let's find it!  This is a simple binary search
+# ------------------------------------------------------------
+# NOTE: $good may need an update in the future
+# ------------------------------------------------------------
 note "Looking for lowest amount of bits";
-my $bad = 3;                    # Log2 of number of bits
-my $good = 11;                  # Log2 of number of bits
-my $checked = int(($good + $bad + 1) / 2);
+my $bad = 3;                    # Log2 of number of bits (2 << 3  == 8)
+my $good = 11;                  # Log2 of number of bits (2 << 11 == 2048)
 while ($good > $bad + 1) {
+    my $checked = int(($good + $bad + 1) / 2);
     if (run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem',
                   2 ** $checked ], stderr => undef))) {
+        note 2 ** $checked, " bits is good";
         $good = $checked;
     } else {
+        note 2 ** $checked, " bits is bad";
         $bad = $checked;
     }
-    $checked = int(($good + $bad + 1) / 2);
 }
 $good++ if $good == $bad;
+$good = 2 ** $good;
 note "Found lowest allowed amount of bits to be $good";
 
-$good = 2 ** $good;
 ok(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', $good ])),
    "genrsa -3 $good");
 ok(run(app([ 'openssl', 'rsa', '-check', '-in', 'genrsatest.pem', '-noout' ])),


### PR DESCRIPTION
There is a test to check that 'genrsa' doesn't accept absurdly low
number of bits.  Apart from that, this test is designed to check the
working functionality of 'openssl genrsa', so instead of having a hard
coded lower limit on the size key, let's figure out what it is.

Partially fixes #5751
