### PR TITLE
Revert "Temporarily disable some tests that hang"

### DIFF
--- a/test/recipes/99-test_fuzz.t
+++ b/test/recipes/99-test_fuzz.t
@@ -15,10 +15,6 @@ use OpenSSL::Test::Utils;
 
 setup("test_fuzz");
 
-# TODO vvvv Remove this line
-plan skip_all => "TLSProxy isn't usable on $^O";
-# TODO ^^^^ Remove this line
-
 my @fuzzers = ('asn1', 'asn1parse', 'bignum', 'bndiv', 'client', 'conf', 'crl', 'server', 'x509');
 if (!disabled("cms")) {
     push @fuzzers, 'cms';

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -68,11 +68,6 @@ sub new
         message_list => [],
     };
 
-    ### TODO vvvv REMOVE THIS AGAIN
-    warn "Proxy tests temporarily disabled!\n";
-    $self->{proxy_sock} = 0;
-    return bless $self, $class;
-    ### TODO ^^^^ REMOVE THIS AGAIN
     # IO::Socket::IP is on the core module list, IO::Socket::INET6 isn't.
     # However, IO::Socket::INET6 is older and is said to be more widely
     # deployed for the moment, and may have less bugs, so we try the latter


### PR DESCRIPTION
This reverts commit 37a385956461ab526ecea2739a8a40364a8db259.

These tests should now be fixed by commit e6e9170d6.
