### PR TITLE
.travis.yml: remove osx from build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
 
 os:
     - linux
-    - osx
 
 compiler:
     - clang


### PR DESCRIPTION
Travis OS X backlog is off charts and only getting worse. This holds
whole queue back, so we again remove osx till better days.
