### PR TITLE
Configurations/10-main.conf: fix VC-noCE-common template.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1285,7 +1285,8 @@ my %targets = (
                                        sub {
                                            ($disabled{shared} ? "" : "/MD");
                                        })),
-        defines          => add(picker(debug   => [ "DEBUG", "_DEBUG" ])),
+        defines          => add(picker(default => [], # works as type cast
+                                       debug   => [ "DEBUG", "_DEBUG" ])),
         lib_cflags       => add(sub { $disabled{shared} ? "/MT /Zl" : () }),
         # Following might/should appears controversial, i.e. defining
         # /MDd without evaluating $disabled{shared}. It works in

--- a/Configure
+++ b/Configure
@@ -593,13 +593,13 @@ my %target_attr_translate =(
    );
 
 # Initialisers coming from 'config' scripts
-$config{defines} = [ split(/$list_separator_re/, env('__CNF_CPPDEFINES')) ],
-$config{includes} = [ split(/$list_separator_re/, env('__CNF_CPPINCLUDES')) ],
-$config{cppflags} = [ env('__CNF_CPPFLAGS') || () ],
-$config{cflags} = [ env('__CNF_CFLAGS') || () ],
-$config{cxxflags} = [ env('__CNF_CXXFLAGS') || () ],
-$config{lflags} = [ env('__CNF_LDFLAGS') || () ],
-$config{ex_libs} = [ env('__CNF_LDLIBS') || () ],
+$config{defines} = [ split(/$list_separator_re/, env('__CNF_CPPDEFINES')) ];
+$config{includes} = [ split(/$list_separator_re/, env('__CNF_CPPINCLUDES')) ];
+$config{cppflags} = [ env('__CNF_CPPFLAGS') || () ];
+$config{cflags} = [ env('__CNF_CFLAGS') || () ];
+$config{cxxflags} = [ env('__CNF_CXXFLAGS') || () ];
+$config{lflags} = [ env('__CNF_LDFLAGS') || () ];
+$config{ex_libs} = [ env('__CNF_LDLIBS') || () ];
 
 $config{openssl_api_defines}=[];
 $config{openssl_algorithm_defines}=[];


### PR DESCRIPTION
picker() is type agnostic, but its output's consumer is not. Or rather
it doesn't work if picker() picks nothing when consumer expects
array. So ensure array is returned when array is expected.

[skip ci]

I'm using glitch that [skip ci] is ineffective in appveyor context. So that Windows-specific mods will be checked on Windows. Second commit is cosmetics.