### PR TITLE
Revert "util/dofile.pl: only quote stuff that actually needs quoting"

### DIFF
--- a/util/dofile.pl
+++ b/util/dofile.pl
@@ -99,9 +99,9 @@ package main;
 # This adds quotes (") around the given string, and escapes any $, @, \,
 # " and ' by prepending a \ to them.
 sub quotify1 {
-    my $s = my $orig = shift @_;
+    my $s = shift @_;
     $s =~ s/([\$\@\\"'])/\\$1/g;
-    $s ne $orig || $s =~ /\s/ ? '"'.$s.'"' : $s;
+    '"'.$s.'"';
 }
 
 # quotify_l LIST


### PR DESCRIPTION
This wasn't a good solution, too many things depend on the quotes being
there consistently.

This reverts commit 49cd47eaababc8c57871b929080fc1357e2ad7b8.

Fixes #5772
