### PR TITLE
Faster fuzz test: teach the fuzz test programs to handle directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ compiler:
     - gcc
 
 env:
-    - CONFIG_OPTS="" DESTDIR="_install" TESTS="-test_fuzz"
-    - CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2" TESTS="-test_fuzz"
+    - CONFIG_OPTS="" DESTDIR="_install"
+    - CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2"
     - CONFIG_OPTS="no-asm --strict-warnings" BUILDONLY="yes" CHECKDOCS="yes"
 
 matrix:
@@ -44,7 +44,7 @@ matrix:
                   sources:
                       - ubuntu-toolchain-r-test
           compiler: gcc-5
-          env: CONFIG_OPTS="--strict-warnings" TESTS="-test_fuzz" COMMENT="Move to the BORINGTEST build when interoperable"
+          env: CONFIG_OPTS="--strict-warnings" COMMENT="Move to the BORINGTEST build when interoperable"
         - os: linux
           compiler: clang-3.9
           env: CONFIG_OPTS="--strict-warnings no-deprecated" BUILDONLY="yes"
@@ -102,7 +102,7 @@ matrix:
                       - binutils-mingw-w64
                       - gcc-mingw-w64
           compiler: i686-w64-mingw32-gcc
-          env: EXTENDED_TEST="yes" CONFIG_OPTS="no-pic" TESTS="-test_fuzz"
+          env: EXTENDED_TEST="yes" CONFIG_OPTS="no-pic"
         - os: linux
           addons:
               apt:
@@ -110,7 +110,7 @@ matrix:
                       - binutils-mingw-w64
                       - gcc-mingw-w64
           compiler: x86_64-w64-mingw32-gcc
-          env: EXTENDED_TEST="yes" CONFIG_OPTS="no-pic" TESTS="-test_fuzz"
+          env: EXTENDED_TEST="yes" CONFIG_OPTS="no-pic"
     exclude:
         - os: linux
           compiler: clang

--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -22,13 +22,17 @@
 #include "fuzzer.h"
 #include "internal/o_dir.h"
 
-#ifdef __WIN32
+#if defined(_WIN32) && defined(_MAX_PATH)
 # define PATH_MAX _MAX_PATH
 #endif
 
 #ifndef PATH_MAX
 # define PATH_MAX 4096
 #endif
+
+# if !defined(S_ISREG)
+#   define S_ISREG(m) ((m) & S_IFREG)
+# endif
 
 static void testfile(const char *pathname)
 {

--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -49,12 +49,12 @@ static void testfile(const char *pathname)
     if (f == NULL)
         return;
     buf = malloc(st.st_size);
-    if (buf == NULL)
-        return;
-    s = fread(buf, 1, st.st_size, f);
-    OPENSSL_assert(s == (size_t)st.st_size);
-    FuzzerTestOneInput(buf, s);
-    free(buf);
+    if (buf != NULL) {
+        s = fread(buf, 1, st.st_size, f);
+        OPENSSL_assert(s == (size_t)st.st_size);
+        FuzzerTestOneInput(buf, s);
+        free(buf);
+    }
     fclose(f);
 }
 

--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -16,9 +16,36 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <openssl/crypto.h>
 #include "fuzzer.h"
+#include "internal/o_dir.h"
+
+static void testfile(const char *pathname)
+{
+    struct stat st;
+    FILE *f;
+    unsigned char *buf;
+    size_t s;
+
+    stat(pathname, &st);
+    if (!S_ISREG(st.st_mode))
+        return;
+    printf("# %s\n", pathname);
+    fflush(stdout);
+    f = fopen(pathname, "rb");
+    if (f == NULL)
+        return;
+    buf = malloc(st.st_size);
+    if (buf == NULL)
+        return;
+    s = fread(buf, 1, st.st_size, f);
+    OPENSSL_assert(s == (size_t)st.st_size);
+    FuzzerTestOneInput(buf, s);
+    free(buf);
+    fclose(f);
+}
 
 int main(int argc, char **argv) {
     int n;
@@ -26,21 +53,38 @@ int main(int argc, char **argv) {
     FuzzerInitialize(&argc, &argv);
 
     for (n = 1; n < argc; ++n) {
-        struct stat st;
-        FILE *f;
-        unsigned char *buf;
-        size_t s;
+        size_t dirname_len = strlen(argv[n]);
+        const char *filename = NULL;
+        char *pathname = NULL;
+        OPENSSL_DIR_CTX *ctx = NULL;
+        int wasdir = 0;
 
-        stat(argv[n], &st);
-        f = fopen(argv[n], "rb");
-        if (f == NULL)
-            continue;
-        buf = malloc(st.st_size);
-        s = fread(buf, 1, st.st_size, f);
-        OPENSSL_assert(s == (size_t)st.st_size);
-        FuzzerTestOneInput(buf, s);
-        free(buf);
-        fclose(f);
+        /*
+         * We start with trying to read the given path as a directory.
+         */
+        while ((filename = OPENSSL_DIR_read(&ctx, argv[n])) != NULL) {
+            wasdir = 1;
+            if (pathname == NULL) {
+                pathname = malloc(PATH_MAX);
+                if (pathname == NULL)
+                    break;
+                strcpy(pathname, argv[n]);
+#ifdef __VMS
+                if (strchr(":<]", pathname[dirname_len - 1]) == NULL)
+#endif
+                    pathname[dirname_len++] = '/';
+                pathname[dirname_len] = '\0';
+            }
+            strcpy(pathname + dirname_len, filename);
+            testfile(pathname);
+        }
+        OPENSSL_DIR_end(&ctx);
+
+        /* If it wasn't a directory, treat it as a file instead */
+        if (!wasdir)
+            testfile(argv[n]);
+
+        free(pathname);
     }
 
     FuzzerCleanup();

--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -22,6 +22,14 @@
 #include "fuzzer.h"
 #include "internal/o_dir.h"
 
+#ifdef __WIN32
+# define PATH_MAX _MAX_PATH
+#endif
+
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
+
 static void testfile(const char *pathname)
 {
     struct stat st;
@@ -29,8 +37,7 @@ static void testfile(const char *pathname)
     unsigned char *buf;
     size_t s;
 
-    stat(pathname, &st);
-    if (!S_ISREG(st.st_mode))
+    if (stat(pathname, &st) < 0 || !S_ISREG(st.st_mode))
         return;
     printf("# %s\n", pathname);
     fflush(stdout);

--- a/test/recipes/99-test_fuzz.t
+++ b/test/recipes/99-test_fuzz.t
@@ -26,14 +26,14 @@ plan tests => scalar @fuzzers;
 
 foreach my $f (@fuzzers) {
     subtest "Fuzzing $f" => sub {
-        my @files = glob(srctop_file('fuzz', 'corpora', $f, '*'));
-        push @files, glob(srctop_file('fuzz', 'corpora', "$f-*", '*'));
+        my @dirs = glob(srctop_file('fuzz', 'corpora', $f));
+        push @dirs, glob(srctop_file('fuzz', 'corpora', "$f-*"));
 
-        plan skip_all => "No corpora for $f-test" unless @files;
+        plan skip_all => "No corpora for $f-test" unless @dirs;
 
-        plan tests => scalar @files;
+        plan tests => scalar @dirs;
 
-        foreach (@files) {
+        foreach (@dirs) {
             ok(run(fuzz(["$f-test", $_])));
         }
     }


### PR DESCRIPTION
Instead of invoking the fuzz test programs once for every corpora
file, we invoke them once for each directory of corpora files.  This
dramatically reduces the number of program invikations, as well as the
time 99-test_fuzz.t takes to complete.

fuzz/test-corpus.c was enhanced to handle directories as well as
regular files.

-----
This is an alternative to #5771.  The speed reduction is still dramatic, but "only" of a factor of 10.