### PR TITLE
Re-org the output of opensslconf.h.in

### DIFF
--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -22,13 +22,9 @@ extern "C" {
 /*
  * OpenSSL was configured with the following options:
  */
-
-{- if (@{$config{openssl_sys_defines}}) {
-      foreach (@{$config{openssl_sys_defines}}) {
-	$OUT .= "#ifndef $_\n";
-	$OUT .= "# define $_ 1\n";
-	$OUT .= "#endif\n";
-      }
+{-
+    foreach (@{$config{openssl_sys_defines}}) {
+        $OUT .= "#define $_ 1\n";
     }
     foreach (@{$config{openssl_api_defines}}) {
         (my $macro, my $value) = $_ =~ /^(.*?)=(.*?)$/;
@@ -36,13 +32,38 @@ extern "C" {
     }
     if (@{$config{openssl_feature_defines}}) {
       foreach (@{$config{openssl_feature_defines}}) {
-	$OUT .= "#ifndef $_\n";
 	$OUT .= "# define $_\n";
-	$OUT .= "#endif\n";
       }
     }
-    "";
--}
+    foreach (@{$config{openssl_other_defines}}) {
+      $OUT .= "#define $_\n";
+    } -}
+#define OPENSSL_UNISTD {- $target{unistd} -}
+{- $config{export_var_as_fn} ? "#define" : "#undef" -} OPENSSL_EXPORT_VAR_AS_FUNCTION
+{- $config{processor} eq "386" ? "#define" : "#undef" -} I386_ONLY /* Generate 80386 code? */
+
+/*
+ * The following are cipher-specific, but are part of the public API.
+ */
+#if !defined(OPENSSL_SYS_UEFI)
+{- $config{bn_ll} ? "# define" : "# undef" -} BN_LLONG
+/* Only one for the following should be defined */
+{- $config{b64l} ? "# define" : "# undef" -} SIXTY_FOUR_BIT_LONG
+{- $config{b64}  ? "# define" : "# undef" -} SIXTY_FOUR_BIT
+{- $config{b32}  ? "# define" : "# undef" -} THIRTY_TWO_BIT
+#endif
+#define RC4_INT {- $config{rc4_int} -}
+
+/*
+ * Put filenames/line-numbers into malloc calls (for debugging)?
+ */
+#ifdef OPENSSL_NO_FILENAMES
+# define OPENSSL_FILE ""
+# define OPENSSL_LINE 0
+#else
+# define OPENSSL_FILE __FILE__
+# define OPENSSL_LINE __LINE__
+#endif
 
 /*
  * Sometimes OPENSSSL_NO_xxx ends up with an empty file and some compilers
@@ -158,27 +179,6 @@ extern "C" {
 #  define OPENSSL_LINE __LINE__
 # endif
 #endif
-
-/* Generate 80386 code? */
-{- $config{processor} eq "386" ? "#define" : "#undef" -} I386_ONLY
-
-#undef OPENSSL_UNISTD
-#define OPENSSL_UNISTD {- $target{unistd} -}
-
-{- $config{export_var_as_fn} ? "#define" : "#undef" -} OPENSSL_EXPORT_VAR_AS_FUNCTION
-
-/*
- * The following are cipher-specific, but are part of the public API.
- */
-#if !defined(OPENSSL_SYS_UEFI)
-{- $config{bn_ll} ? "# define" : "# undef" -} BN_LLONG
-/* Only one for the following should be defined */
-{- $config{b64l} ? "# define" : "# undef" -} SIXTY_FOUR_BIT_LONG
-{- $config{b64}  ? "# define" : "# undef" -} SIXTY_FOUR_BIT
-{- $config{b32}  ? "# define" : "# undef" -} THIRTY_TWO_BIT
-#endif
-
-#define RC4_INT {- $config{rc4_int} -}
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
I re-ordered conf.h to be more sensible.  I also removed the ifndef wrappers because I don't think they really work right.  Ping @levitte and @dot-asm to take a look at this, please.
