### PR TITLE
Documentation typo fix in EVP_EncryptInit.pod

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -99,7 +99,6 @@ EVP_enc_null
 
  int EVP_CIPHER_nid(const EVP_CIPHER *e);
  int EVP_CIPHER_block_size(const EVP_CIPHER *e);
- int EVP_CIPHER_key_length(const EVP_CIPHER *e)
  int EVP_CIPHER_key_length(const EVP_CIPHER *e);
  int EVP_CIPHER_iv_length(const EVP_CIPHER *e);
  unsigned long EVP_CIPHER_flags(const EVP_CIPHER *e);


### PR DESCRIPTION
Remove duplicate declaration of `EVP_CIPHER_key_length` in the synopsis.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
N/A
