### PR TITLE
correct spelling errors detected by Debian lintian

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,7 +22,7 @@
      below. Similarly TLSv1.2 ciphersuites are not compatible with TLSv1.3.
      In order to avoid issues where legacy TLSv1.2 ciphersuite configuration
      would otherwise inadvertently disable all TLSv1.3 ciphersuites the
-     configuraton has been separated out. See the ciphers man page or the
+     configuration has been separated out. See the ciphers man page or the
      SSL_CTX_set_ciphersuites() man page for more information.
      [Matt Caswell]
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -365,7 +365,7 @@ int req_main(int argc, char **argv)
     if (addext_bio) {
         if (verbose)
             BIO_printf(bio_err,
-                       "Using additional configuraton from command line\n");
+                       "Using additional configuration from command line\n");
         addext_conf = app_load_config_bio(addext_bio, NULL);
     }
     if (template != default_config_file && !app_load_modules(req_conf))

--- a/doc/man3/OPENSSL_fork_prepare.pod
+++ b/doc/man3/OPENSSL_fork_prepare.pod
@@ -30,7 +30,7 @@ such as Linux that have both functions will normally not need to call these
 functions as the OpenSSL library will do so automatically.
 
 L<OPENSSL_init_crypto(3)> will register these functions with the appropriate
-hander, when the B<OPENSSL_INIT_ATFORK> flag is used. For other
+handler, when the B<OPENSSL_INIT_ATFORK> flag is used. For other
 applications, these functions can be called directly. They should be used
 according to the calling sequence described by the pthreads_atfork(3)
 documentation, which is summarized here.  OPENSSL_fork_prepare() should

--- a/doc/man3/SSL_CTX_set_session_ticket_cb.pod
+++ b/doc/man3/SSL_CTX_set_session_ticket_cb.pod
@@ -42,7 +42,7 @@ B<dec_cb> is the application defined callback invoked after session ticket
 decryption has been attempted and any session ticket application data is available.
 The application can call SSL_SESSION_get_ticket_appdata() at this time to retrieve
 the application data. The value of B<arg> is the same as that given to
-SSL_CTX_set_session_ticket_cb(). The B<retv> arguement is the result of the ticket
+SSL_CTX_set_session_ticket_cb(). The B<retv> argument is the result of the ticket
 decryption. The B<keyname> and B<keyname_len> identify the key used to decrypt the
 session ticket. The B<dec_cb> callback is defined as type
 B<SSL_CTX_decrypt_session_ticket_fn>.

--- a/doc/man3/SSL_CTX_use_certificate.pod
+++ b/doc/man3/SSL_CTX_use_certificate.pod
@@ -106,7 +106,7 @@ B<x>, B<pkey> and B<chain> are set only if all were not previously set.
 If B<override> is non-0, then the certificate, private key and chain certs
 are always set. If B<pkey> is NULL, then the public key of B<x> is used as
 the private key. This is intended to be used with hardware (via the ENGINE
-inteface) that stores the private key securely, such that it cannot be
+interface) that stores the private key securely, such that it cannot be
 accessed by OpenSSL. The reference count of the public key is incremented
 (twice if there is no private key); it is not copied nor duplicated. This
 allows all private key validations checks to succeed without an actual


### PR DESCRIPTION
trivial contribution
CLA: trivial
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated