### PR TITLE
Remove a contribution

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -257,7 +257,7 @@ int tls1_change_cipher_state(SSL *s, int which)
 
     if (!(EVP_CIPHER_flags(c) & EVP_CIPH_FLAG_AEAD_CIPHER)) {
         /* TODO(size_t): Convert this function */
-        mac_key = EVP_PKEY_new_raw_private_key(mac_type, NULL, mac_secret,
+        mac_key = EVP_PKEY_new_mac_key(mac_type, NULL, mac_secret,
                                                (int)*mac_secret_size);
         if (mac_key == NULL
             || EVP_DigestSignInit(mac_ctx, NULL, m, NULL, mac_key) <= 0) {

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -184,6 +184,8 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
     {0x006B, "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"},
     {0x006C, "TLS_DH_anon_WITH_AES_128_CBC_SHA256"},
     {0x006D, "TLS_DH_anon_WITH_AES_256_CBC_SHA256"},
+    {0x0081, "TLS_GOSTR341001_WITH_28147_CNT_IMIT"},
+    {0x0083, "TLS_GOSTR341001_WITH_NULL_GOSTR3411"},
     {0x0084, "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA"},
     {0x0085, "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA"},
     {0x0086, "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA"},
@@ -441,6 +443,8 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
     {0x1305, "TLS_AES_128_CCM_8_SHA256"},
     {0xFEFE, "SSL_RSA_FIPS_WITH_DES_CBC_SHA"},
     {0xFEFF, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA"},
+    {0xFF85, "GOST2012-GOST8912-GOST8912"},
+    {0xFF87, "GOST2012-NULL-GOST12"},
 };
 
 /* Compression methods */


### PR DESCRIPTION
This reverts commit 4a56d9a.

We have been unable to trace the contributor of that code to gain their
agreement for the licence change so the code has to be removed.

This commit reverts that contribution. The contribution had no functional
impact so the original way of doing things is still valid. However the
surrounding code has changed significantly so that the exact code as it
was orignally cannot be used. This commit uses the original code as a basis,
but rewrites it to use the PACKET API.

This is a change in the GOST ciphersuite code. In order to test it I discovered a bug that prevents GOST from working in 1.1.1 so I fixed that issue too (in a separate commit). Finally I also fixed some missing ciphersuite names in the trace code that also came to light during testing (also in a separate commit).

It seems the GOST code has other problems when used from our command line apps, and also when used in TLSv1.2 (due to sig algs problems). I will raise separate issues for those.