### PR TITLE
Remove some code

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -611,7 +611,6 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
     EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
     int reason = ERR_R_BUF_LIB;
     int retval = 0;
-    int bufsize = 0;
 
     if (ctx == NULL) {
         reason = ERR_R_MALLOC_FAILURE;
@@ -632,8 +631,7 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
             goto err;
     }
 
-    bufsize = PEM_BUFSIZE * 8;
-    buf = OPENSSL_malloc(bufsize);
+    buf = OPENSSL_malloc(PEM_BUFSIZE * 8);
     if (buf == NULL) {
         reason = ERR_R_MALLOC_FAILURE;
         goto err;
@@ -658,7 +656,6 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
         (BIO_write(bp, "-----\n", 6) != 6))
         goto err;
     retval = i + outl;
-    /* Fallthrough */
 
  err:
     if (retval == 0)

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -88,7 +88,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
         PEMerr(PEM_F_PEM_READ_BIO_PRIVATEKEY, ERR_R_ASN1_LIB);
  err:
     OPENSSL_secure_free(nm);
-    OPENSSL_secure_free(data);
+    OPENSSL_secure_clear_free(data, len);
     return ret;
 }
 

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -88,7 +88,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
         PEMerr(PEM_F_PEM_READ_BIO_PRIVATEKEY, ERR_R_ASN1_LIB);
  err:
     OPENSSL_secure_free(nm);
-    OPENSSL_secure_clear_free(data, len);
+    OPENSSL_secure_free(data);
     return ret;
 }
 


### PR DESCRIPTION
This commit removes the contribution of a user that we cannot
trace to gain their consent for the licence change.

I also cleaned up the return/error-return flow a bit.

Removing this is, unfortunately, a security issue.  The buffers used for PEM_write_bio and PEM_read_bio_PrivateKey should be cleansed before being cleared.
