### PR TITLE
Fix a gcc-8 warning -Wcast-function-type

### DIFF
--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -23,7 +23,7 @@ typedef SSL_CTX * (*SSL_CTX_new_t)(const SSL_METHOD *meth);
 typedef void (*SSL_CTX_free_t)(SSL_CTX *);
 typedef unsigned long (*ERR_get_error_t)(void);
 typedef unsigned long (*OpenSSL_version_num_t)(void);
-typedef DSO * (*DSO_dsobyaddr_t)(void (*addr)(), int flags);
+typedef DSO * (*DSO_dsobyaddr_t)(void (*addr)(void), int flags);
 typedef int (*DSO_free_t)(DSO *dso);
 
 typedef enum test_types_en {
@@ -191,7 +191,7 @@ static int test_lib(void)
         {
             DSO *hndl;
             /* use known symbol from crypto module */
-            if (!TEST_ptr(hndl = myDSO_dsobyaddr((void (*)())ERR_get_error, 0)))
+            if (!TEST_ptr(hndl = myDSO_dsobyaddr((void (*)(void))ERR_get_error, 0)))
                 goto end;
             myDSO_free(hndl);
         }


### PR DESCRIPTION
Casting to the generic function type "void (*)(void)"
prevents the warning.
