### PR TITLE
Remove -Wmisleading-indentation from gcc devteam warning options

### DIFF
--- a/Configure
+++ b/Configure
@@ -1476,7 +1476,6 @@ if ($strict_warnings)
 
 	die "ERROR --strict-warnings requires gcc[>=4] or gcc-alike"
             unless $gccver >= 4;
-	$gcc_devteam_warn .= " -Wmisleading-indentation" if $gccver >= 6;
 	foreach $wopt (split /\s+/, $gcc_devteam_warn)
 		{
 		push @{$config{cflags}}, $wopt


### PR DESCRIPTION
because this one is enabled by default anyways
