### PR TITLE
WIP: TLSProxy using random ports, take 2

### DIFF
--- a/apps/s_apps.h
+++ b/apps/s_apps.h
@@ -22,9 +22,8 @@
 
 typedef int (*do_server_cb)(int s, int stype, int prot, unsigned char *context);
 int do_server(int *accept_sock, const char *host, const char *port,
-              int family, int type, int protocol,
-              do_server_cb cb,
-              unsigned char *context, int naccept);
+              int family, int type, int protocol, do_server_cb cb,
+              unsigned char *context, int naccept, BIO *bio_s_out);
 #ifdef HEADER_X509_H
 int verify_callback(int ok, X509_STORE_CTX *ctx);
 #endif

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2095,8 +2095,6 @@ int s_server_main(int argc, char *argv[])
     if (max_early_data >= 0)
         SSL_CTX_set_max_early_data(ctx, max_early_data);
 
-    BIO_printf(bio_s_out, "ACCEPT\n");
-    (void)BIO_flush(bio_s_out);
     if (rev)
         server_cb = rev_body;
     else if (www)
@@ -2109,7 +2107,7 @@ int s_server_main(int argc, char *argv[])
         unlink(host);
 #endif
     do_server(&accept_socket, host, port, socket_family, socket_type, protocol,
-              server_cb, context, naccept);
+              server_cb, context, naccept, bio_s_out);
     print_stats(bio_s_out, ctx);
     ret = 0;
  end:
@@ -2673,9 +2671,6 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
     }
     BIO_printf(bio_s_out, "CONNECTION CLOSED\n");
     OPENSSL_clear_free(buf, bufsize);
-    if (ret >= 0)
-        BIO_printf(bio_s_out, "ACCEPT\n");
-    (void)BIO_flush(bio_s_out);
     return ret;
 }
 
@@ -3284,8 +3279,6 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     SSL_set_shutdown(con, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
 
  err:
-    if (ret >= 0)
-        BIO_printf(bio_s_out, "ACCEPT\n");
     OPENSSL_free(buf);
     BIO_free_all(io);
     return ret;

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -204,7 +204,7 @@ out:
  */
 int do_server(int *accept_sock, const char *host, const char *port,
               int family, int type, int protocol, do_server_cb cb,
-              unsigned char *context, int naccept)
+              unsigned char *context, int naccept, BIO *bio_s_out)
 {
     int asock = 0;
     int sock;
@@ -282,6 +282,34 @@ int do_server(int *accept_sock, const char *host, const char *port,
 
     BIO_ADDRINFO_free(res);
     res = NULL;
+
+    {
+        union BIO_sock_info_u info;
+        char *hostname = NULL;
+        char *service = NULL;
+        int success = 0;
+
+        if ((info.addr = BIO_ADDR_new()) != NULL
+            && BIO_sock_info(asock, BIO_SOCK_INFO_ADDRESS, &info)
+            && (hostname = BIO_ADDR_hostname_string(info.addr, 1)) != NULL
+            && (service = BIO_ADDR_service_string(info.addr, 1)) != NULL
+            && BIO_printf(bio_s_out,
+                          strchr(hostname, ':') == NULL
+                          ? /* IPv4 */ "ACCEPT %s:%s\n"
+                          : /* IPv6 */ "ACCEPT [%s]:%s\n",
+                          hostname, service) > 0)
+            success = 1;
+
+        (void)BIO_flush(bio_s_out);
+        OPENSSL_free(hostname);
+        OPENSSL_free(service);
+        BIO_ADDR_free(info.addr);
+        if (!success) {
+            BIO_closesocket(asock);
+            ERR_print_errors(bio_err);
+            goto end;
+        }
+    }
 
     if (accept_sock != NULL)
         *accept_sock = asock;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -41,9 +41,9 @@ sub new
     my $self = {
         #Public read/write
         proxy_addr => "localhost",
-        proxy_port => 4453,
+        proxy_port => 0,
         server_addr => "localhost",
-        server_port => 4443,
+        server_port => 0,
         filter => $filter,
         serverflags => "",
         clientflags => "",
@@ -110,7 +110,7 @@ sub new
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]
     my @proxyargs = (
         LocalHost   => $proxaddr,
-        LocalPort   => $self->{proxy_port},
+        LocalPort   => 0,
         Proto       => "tcp",
         Listen      => SOMAXCONN,
        );
@@ -119,9 +119,10 @@ sub new
     $self->{proxy_sock} = $IP_factory->(@proxyargs);
 
     if ($self->{proxy_sock}) {
+        $self->{proxy_port} = $self->{proxy_sock}->sockport();
         print "Proxy started on port ".$self->{proxy_port}."\n";
     } else {
-        warn "Failed creating proxy socket (".$proxaddr.",".$self->{proxy_port}."): $!\n";
+        warn "Failed creating proxy socket (".$proxaddr.",0): $!\n";
     }
 
     return bless $self, $class;
@@ -193,31 +194,49 @@ sub start
         return 0;
     }
 
-    $pid = fork();
-    if ($pid == 0) {
-        my $execcmd = $self->execute
-            ." s_server -max_protocol TLSv1.3 -no_comp -rev -engine ossltest -accept "
-            .($self->server_port)
-            ." -cert ".$self->cert." -cert2 ".$self->cert
-            ." -naccept ".$self->serverconnects;
-        unless ($self->supports_IPv6) {
-            $execcmd .= " -4";
-        }
-        if ($self->ciphers ne "") {
-            $execcmd .= " -cipher ".$self->ciphers;
-        }
-        if ($self->ciphersuitess ne "") {
-            $execcmd .= " -ciphersuites ".$self->ciphersuitess;
-        }
-        if ($self->serverflags ne "") {
-            $execcmd .= " ".$self->serverflags;
-        }
-        if ($self->debug) {
-            print STDERR "Server command: $execcmd\n";
-        }
-        exec($execcmd);
+    my $execcmd = $self->execute
+        ." s_server -max_protocol TLSv1.3 -no_comp -rev -engine ossltest"
+        ." -accept 0 -cert ".$self->cert." -cert2 ".$self->cert
+        ." -naccept ".$self->serverconnects;
+    unless ($self->supports_IPv6) {
+        $execcmd .= " -4";
     }
-    $self->serverpid($pid);
+    if ($self->ciphers ne "") {
+        $execcmd .= " -cipher ".$self->ciphers;
+    }
+    if ($self->ciphersuitess ne "") {
+        $execcmd .= " -ciphersuites ".$self->ciphersuitess;
+    }
+    if ($self->serverflags ne "") {
+        $execcmd .= " ".$self->serverflags;
+    }
+    if ($self->debug) {
+        print STDERR "Server command: $execcmd\n";
+    }
+
+    open my $savedin, "<&", \*STDIN;
+    $self->serverpid(open(STDIN, "$execcmd |"));
+
+    # Process the output from s_server until we find the ACCEPT line, which
+    # tells us what the accepting address and port are.
+    while (<STDIN>) {
+        print;
+        s/\R$//;                # Better chomp
+        next unless (/^ACCEPT\s.*:(\d+)$/);
+        $self->{server_port} = $1;
+        last;
+    }
+
+    # Just make sure everything else is simply printed.
+    # The sub process simply inherits our STDIN and will keep consuming
+    # and printing it as long as there is anything there, out of our way.
+    if (fork() == 0) { exec ("$^X -ne print"); }
+
+    # Then reset our STDIN back to what it was originally
+    open STDIN,"<&", $savedin;
+
+    print STDERR "Server responds on ",
+        $self->{server_addr}, ":", $self->{server_port}, "\n";
 
     return $self->clientstart;
 }
@@ -471,24 +490,18 @@ sub proxy_port
     my $self = shift;
     return $self->{proxy_port};
 }
-
-#Read/write accessors
 sub server_addr
 {
     my $self = shift;
-    if (@_) {
-        $self->{server_addr} = shift;
-    }
     return $self->{server_addr};
 }
 sub server_port
 {
     my $self = shift;
-    if (@_) {
-        $self->{server_port} = shift;
-    }
     return $self->{server_port};
 }
+
+#Read/write accessors
 sub filter
 {
     my $self = shift;


### PR DESCRIPTION
For quite a while now, the test recipes that use TLSProxy were stuck with the same hard coded ports, which meant that if you wanted to run several test suites at the same time, you had to be careful so TLSProxy based tests wouldn't overlap (in practice, you simply wouldn't run several test suites at the same time).

No longer. With this change, the ports used by TLSProxy are chosen at random.

This makes a small change to the `openssl s_server` output, where this line:

```
ACCEPT
```

now contains a bit more information:

```
ACCEPT 0.0.0.0:45633
```

```
ACCEPT [::]:45633
```

-----

This is an alternative to #5805