### PR TITLE
Remove import/use of File::Spec::Function

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -1,4 +1,3 @@
-{- use File::Spec::Functions qw/catdir catfile/; -}
 LIBS=../libcrypto
 SOURCE[../libcrypto]=\
         cryptlib.c mem.c mem_dbg.c cversion.c ex_data.c cpt_err.c \


### PR DESCRIPTION
It looks like the usage of these functions were removed in
in commit 0a4edb931b883b9973721ae012e60c028387dd50 ("Unified - adapt
the generation of cpuid, uplink and buildinf to use GENERATE").

This commit removes the import/use of File::Spec::Functions module as it
is no longer needed by crypto/build.info.


