### PR TITLE
Windows builds: remove over-quotation of LIBZ macro

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -114,7 +114,7 @@ my %targets=(
                 my @defs = ();
                 unless ($disabled{"zlib-dynamic"}) {
                     my $zlib = $withargs{zlib_lib} // "ZLIB1";
-                    push @defs, quotify("perl", 'LIBZ="' . $zlib . '"');
+                    push @defs, 'LIBZ=' . (quotify("perl", $zlib))[0];
                 }
                 return [ @defs ];
             },

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -207,10 +207,10 @@ CNF_ASFLAGS={- join(' ', $target{asflags} || (),
                          @{$config{asflags}}) -}
 CNF_CPPFLAGS={- our $cppfags2 =
                     join(' ', $target{cppflags} || (),
-                              (map { quotify_l("-D".$_) } @{$target{defines}},
-                                                          @{$config{defines}}),
-                              (map { quotify_l("-I".$_) } @{$target{includes}},
-                                                          @{$config{includes}}),
+                              (map { '-D'.quotify1($_) } @{$target{defines}},
+                                                         @{$config{defines}}),
+                              (map { '-I'.quotify1($_) } @{$target{includes}},
+                                                         @{$config{includes}}),
                               @{$config{cppflags}}) -}
 CNF_CFLAGS={- join(' ', $target{cflags} || (),
                         @{$config{cflags}}) -}
@@ -233,12 +233,12 @@ LIB_ASFLAGS={- join(' ', $target{lib_asflags} || (),
 LIB_CPPFLAGS={- our $lib_cppflags =
                 join(' ', $target{lib_cppflags} || (),
                           $target{shared_cppflag} || (),
-                          (map { quotify_l("-D".$_) }
+                          (map { '-D'.quotify1($_) }
                                @{$target{lib_defines}},
                                @{$target{shared_defines}},
                                @{$config{lib_defines}},
                                @{$config{shared_defines}}),
-                          (map { quotify_l("-I".$_) }
+                          (map { '-I'.quotify1($_) }
                                @{$target{lib_includes}},
                                @{$target{shared_includes}},
                                @{$config{lib_includes}},
@@ -246,7 +246,7 @@ LIB_CPPFLAGS={- our $lib_cppflags =
                           @{$config{lib_cppflags}},
                           @{$config{shared_cppflag}});
                 join(' ', $lib_cppflags,
-                          (map { quotify_l("-D".$_) }
+                          (map { '-D'.quotify1($_) }
                                "OPENSSLDIR=\"$openssldir\"",
                                "ENGINESDIR=\"$enginesdir\""),
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}


### PR DESCRIPTION
The LIBZ macro definition was already quoted in BASE_windows, then got
quotified once more in windows-makefile.tmpl.  That's a bit too much
quotations, ending up with the compiler being asked to define the
macro |"LIBZ=\"ZLIB1\""| (no, not the macro LIBZ with the value
"ZLIB1").  This is solved by removing the extra quoting in
BASE_windows.

Along with this, change the quotation of macro definitions and include
file specification, so we end up with things like -I"QuotedPath" and
-D"Macro=\"some weird value\"" rather than "-IQuotedPath" and
"-DMacro=\"some weird value\"".

Fixes #5827
