### PR TITLE
Don't trust the OPENSSL_ia32cap envvar more than the cpuid instruction

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -100,28 +100,34 @@ void OPENSSL_cpuid_setup(void) __attribute__ ((constructor));
 
 void OPENSSL_cpuid_setup(void)
 {
+# ifndef OPENSSL_ARMCAP_OVERRIDE
     const char *e;
     struct sigaction ill_oact, ill_act;
     sigset_t oset;
+    volatile unsigned int mask;
+# endif
     static int trigger = 0;
 
     if (trigger)
         return;
     trigger = 1;
 
-    if ((e = getenv("OPENSSL_armcap"))) {
-        OPENSSL_armcap_P = (unsigned int)strtoul(e, NULL, 0);
-        return;
-    }
+# ifdef OPENSSL_ARMCAP_OVERRIDE
+    OPENSSL_armcap_P = OPENSSL_ARMCAP_OVERRIDE;
+# else
+    if ((e = getenv("OPENSSL_armcap")))
+        mask = (unsigned int)strtoul(e, NULL, 0);
+    else
+        mask = 0xFFFFFFFF;
 
-# if defined(__APPLE__) && !defined(__aarch64__)
+#  if defined(__APPLE__) && !defined(__aarch64__)
     /*
      * Capability probing by catching SIGILL appears to be problematic
      * on iOS. But since Apple universe is "monocultural", it's actually
      * possible to simply set pre-defined processor capability mask.
      */
     if (1) {
-        OPENSSL_armcap_P = ARMV7_NEON;
+        OPENSSL_armcap_P = mask & ARMV7_NEON;
         return;
     }
     /*
@@ -130,7 +136,7 @@ void OPENSSL_cpuid_setup(void)
      * Unified code works because it never triggers SIGILL on Apple
      * devices...
      */
-# endif
+#  endif
 
     OPENSSL_armcap_P = 0;
 
@@ -156,6 +162,8 @@ void OPENSSL_cpuid_setup(void)
         if (hwcap & HWCAP_CE_SHA512)
             OPENSSL_armcap_P |= ARMV8_SHA512;
 #  endif
+
+        OPENSSL_armcap_P &= mask;
     }
 # endif
 
@@ -175,40 +183,58 @@ void OPENSSL_cpuid_setup(void)
 
     /* If we used getauxval, we already have all the values */
 # ifndef OSSL_IMPLEMENT_GETAUXVAL
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv7_neon_probe();
-        OPENSSL_armcap_P |= ARMV7_NEON;
+    if (mask & ARMV7_NEON) {
         if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_pmull_probe();
-            OPENSSL_armcap_P |= ARMV8_PMULL | ARMV8_AES;
-        } else if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_aes_probe();
-            OPENSSL_armcap_P |= ARMV8_AES;
-        }
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sha1_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA1;
-        }
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sha256_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA256;
-        }
+            _armv7_neon_probe();
+            OPENSSL_armcap_P |= ARMV7_NEON;
+            if ((mask & ARMV8_PMULL) && (mask & ARMV8_AES)) {
+                if (sigsetjmp(ill_jmp, 1) == 0) {
+                    _armv8_pmull_probe();
+                    OPENSSL_armcap_P |= ARMV8_PMULL | ARMV8_AES;
+                    goto test_sha1;
+                }
+            }
+            if (mask & ARMV8_AES) {
+                if (sigsetjmp(ill_jmp, 1) == 0) {
+                    _armv8_aes_probe();
+                    OPENSSL_armcap_P |= ARMV8_AES;
+                }
+            }
+        test_sha1:
+            if (mask & ARMV8_SHA1) {
+                if (sigsetjmp(ill_jmp, 1) == 0) {
+                    _armv8_sha1_probe();
+                    OPENSSL_armcap_P |= ARMV8_SHA1;
+                }
+            }
+            if (mask & ARMV8_SHA256) {
+                if (sigsetjmp(ill_jmp, 1) == 0) {
+                    _armv8_sha256_probe();
+                    OPENSSL_armcap_P |= ARMV8_SHA256;
+                }
+            }
 #  if defined(__aarch64__) && !defined(__APPLE__)
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sha512_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA512;
-        }
+            if (mask & ARMV8_SHA512) {
+                if (sigsetjmp(ill_jmp, 1) == 0) {
+                    _armv8_sha512_probe();
+                    OPENSSL_armcap_P |= ARMV8_SHA512;
+                }
+            }
 #  endif
+        }
     }
 # endif
 
     /* Things that getauxval didn't tell us */
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv7_tick();
-        OPENSSL_armcap_P |= ARMV7_TICK;
+    if (mask & ARMV7_TICK) {
+        if (sigsetjmp(ill_jmp, 1) == 0) {
+            _armv7_tick();
+            OPENSSL_armcap_P |= ARMV7_TICK;
+        }
     }
 
     sigaction(SIGILL, &ill_oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);
+# endif /* !OPENSSL_ARMCAP_OVERRIDE */
 }
 #endif

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -241,41 +241,51 @@ size_t OPENSSL_instrument_bus2(unsigned int *out, size_t cnt, size_t max)
 #define HWCAP_VEC_CRYPTO        (1U << 25)
 #define HWCAP_ARCH_3_00         (1U << 23)
 
-# if defined(__GNUC__) && __GNUC__>=2
+#if defined(__GNUC__) && __GNUC__>=2
 __attribute__ ((constructor))
-# endif
+#endif
 void OPENSSL_cpuid_setup(void)
 {
+#ifndef OPENSSL_PPCCAP_OVERRIDE
     char *e;
     struct sigaction ill_oact, ill_act;
     sigset_t oset;
+    volatile unsigned int mask;
+#endif
     static int trigger = 0;
 
     if (trigger)
         return;
     trigger = 1;
 
-    if ((e = getenv("OPENSSL_ppccap"))) {
-        OPENSSL_ppccap_P = strtoul(e, NULL, 0);
-        return;
-    }
+#ifdef OPENSSL_PPCCAP_OVERRIDE
+    OPENSSL_ppccap_P = OPENSSL_PPCCAP_OVERRIDE;
+#else
+    if ((e = getenv("OPENSSL_ppccap")))
+        mask = (unsigned int)strtoul(e, NULL, 0);
+    else
+        mask = 0xFFFFFFFF;
 
     OPENSSL_ppccap_P = 0;
 
-#if defined(_AIX)
-    OPENSSL_ppccap_P |= PPC_FPU;
-
+# if defined(_AIX)
     if (sizeof(size_t) == 4) {
         struct utsname uts;
-# if defined(_SC_AIX_KERNEL_BITMODE)
-        if (sysconf(_SC_AIX_KERNEL_BITMODE) != 64)
+#  if defined(_SC_AIX_KERNEL_BITMODE)
+        if (sysconf(_SC_AIX_KERNEL_BITMODE) != 64) {
+            OPENSSL_ppccap_P = mask & PPC_FPU;
             return;
-# endif
-        if (uname(&uts) != 0 || atoi(uts.version) < 6)
+        }
+#  endif
+        if (uname(&uts) != 0 || atoi(uts.version) < 6) {
+            OPENSSL_ppccap_P = mask & PPC_FPU;
             return;
+        }
     }
 
-# if defined(__power_set)
+#  if defined(__power_set)
+    OPENSSL_ppccap_P |= PPC_FPU;
+
     /*
      * Value used in __power_set is a single-bit 1<<n one denoting
      * specific processor class. Incidentally 0xffffffff<<n can be
@@ -300,11 +310,12 @@ void OPENSSL_cpuid_setup(void)
     if (__power_set(0xffffffffU<<17))           /* POWER9 and later */
         OPENSSL_ppccap_P |= PPC_MADD300;
 
+    OPENSSL_ppccap_P &= mask;
     return;
+#  endif
 # endif
-#endif
 
-#if defined(__APPLE__) && defined(__MACH__)
+# if defined(__APPLE__) && defined(__MACH__)
     OPENSSL_ppccap_P |= PPC_FPU;
 
     {
@@ -322,11 +333,12 @@ void OPENSSL_cpuid_setup(void)
                 OPENSSL_ppccap_P |= PPC_ALTIVEC;
         }
 
+        OPENSSL_ppccap_P &= mask;
         return;
     }
-#endif
+# endif
 
-#ifdef OSSL_IMPLEMENT_GETAUXVAL
+# ifdef OSSL_IMPLEMENT_GETAUXVAL
     {
         unsigned long hwcap = getauxval(HWCAP);
         unsigned long hwcap2 = getauxval(HWCAP2);
@@ -355,15 +367,17 @@ void OPENSSL_cpuid_setup(void)
         if (hwcap2 & HWCAP_ARCH_3_00) {
             OPENSSL_ppccap_P |= PPC_MADD300;
         }
+
+        OPENSSL_ppccap_P &= mask;
     }
-#endif
+# endif
 
     sigfillset(&all_masked);
     sigdelset(&all_masked, SIGILL);
     sigdelset(&all_masked, SIGTRAP);
-#ifdef SIGEMT
+# ifdef SIGEMT
     sigdelset(&all_masked, SIGEMT);
-#endif
+# endif
     sigdelset(&all_masked, SIGFPE);
     sigdelset(&all_masked, SIGBUS);
     sigdelset(&all_masked, SIGSEGV);
@@ -375,50 +389,68 @@ void OPENSSL_cpuid_setup(void)
     sigprocmask(SIG_SETMASK, &ill_act.sa_mask, &oset);
     sigaction(SIGILL, &ill_act, &ill_oact);
 
-#ifndef OSSL_IMPLEMENT_GETAUXVAL
-    if (sigsetjmp(ill_jmp,1) == 0) {
-        OPENSSL_fpu_probe();
-        OPENSSL_ppccap_P |= PPC_FPU;
+# ifndef OSSL_IMPLEMENT_GETAUXVAL
+    if (mask & PPC_FPU) {
+        if (sigsetjmp(ill_jmp,1) == 0) {
+            OPENSSL_fpu_probe();
+            OPENSSL_ppccap_P |= PPC_FPU;
 
-        if (sizeof(size_t) == 4) {
-# ifdef __linux
-            struct utsname uts;
-            if (uname(&uts) == 0 && strcmp(uts.machine, "ppc64") == 0)
-# endif
-                if (sigsetjmp(ill_jmp, 1) == 0) {
-                    OPENSSL_ppc64_probe();
-                    OPENSSL_ppccap_P |= PPC_FPU64;
-                }
-        } else {
-            /*
-             * Wanted code detecting POWER6 CPU and setting PPC_FPU64
-             */
+            if (sizeof(size_t) == 4 && (mask & PPC_FPU64)) {
+#  ifdef __linux
+                struct utsname uts;
+                if (uname(&uts) == 0 && strcmp(uts.machine, "ppc64") == 0)
+#  endif
+                    if (sigsetjmp(ill_jmp, 1) == 0) {
+                        OPENSSL_ppc64_probe();
+                        OPENSSL_ppccap_P |= PPC_FPU64;
+                    }
+            } else {
+                /*
+                 * Wanted code detecting POWER6 CPU and setting PPC_FPU64
+                 */
+            }
         }
     }
 
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        OPENSSL_altivec_probe();
-        OPENSSL_ppccap_P |= PPC_ALTIVEC;
+    if (mask & PPC_ALTIVEC) {
         if (sigsetjmp(ill_jmp, 1) == 0) {
-            OPENSSL_crypto207_probe();
-            OPENSSL_ppccap_P |= PPC_CRYPTO207;
+            OPENSSL_altivec_probe();
+            OPENSSL_ppccap_P |= PPC_ALTIVEC;
+            if (mask & PPC_CRYPTO207) {
+                if (sigsetjmp(ill_jmp, 1) == 0) {
+                    OPENSSL_crypto207_probe();
+                    OPENSSL_ppccap_P |= PPC_CRYPTO207;
+                }
+            }
         }
     }
 
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        OPENSSL_madd300_probe();
-        OPENSSL_ppccap_P |= PPC_MADD300;
+    if (mask & PPC_MADD300) {
+        if (sigsetjmp(ill_jmp, 1) == 0) {
+            OPENSSL_madd300_probe();
+            OPENSSL_ppccap_P |= PPC_MADD300;
+        }
     }
-#endif
+# endif
 
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        OPENSSL_rdtsc_mftb();
-        OPENSSL_ppccap_P |= PPC_MFTB;
-    } else if (sigsetjmp(ill_jmp, 1) == 0) {
-        OPENSSL_rdtsc_mfspr268();
-        OPENSSL_ppccap_P |= PPC_MFSPR268;
+    /* Things that getauxval didn't tell us */
+    if (mask & PPC_MFTB) {
+        if (sigsetjmp(ill_jmp, 1) == 0) {
+            OPENSSL_rdtsc_mftb();
+            OPENSSL_ppccap_P |= PPC_MFTB;
+            goto done;
+        }
     }
+
+    if (mask & PPC_MFSPR268) {
+        if (sigsetjmp(ill_jmp, 1) == 0) {
+            OPENSSL_rdtsc_mfspr268();
+            OPENSSL_ppccap_P |= PPC_MFSPR268;
+        }
+    }
+ done:
 
     sigaction(SIGILL, &ill_oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);
+#endif /* !OPENSSL_PPCCAP_OVERRIDE */
 }

--- a/doc/man3/OPENSSL_ia32cap.pod
+++ b/doc/man3/OPENSSL_ia32cap.pod
@@ -3,10 +3,12 @@
 =head1 NAME
 
 OPENSSL_ia32cap - the x86[_64] processor capabilities vector
+OPENSSL_IA32CAP_OVERRIDE - compile option override define
 
 =head1 SYNOPSIS
 
  env OPENSSL_ia32cap=... <application>
+ ./config -DOPENSSL_IA32CAP_OVERRIDE=...
 
 =head1 DESCRIPTION
 
@@ -150,6 +152,16 @@ the problem by making build procedure use following script:
 
 instead of real clang. In which case it doesn't matter which clang
 version is used, as it is GNU assembler version that will be checked.
+
+The environment value is limited to whatever the cpuid instruction
+allows, thus it cannot enable features that are not available by
+the hardware detection.  Previous versions allowed the environment
+variable to enable unavailable hardware features, and thus cause the
+application to fail.
+
+If the compile option is used, the environment variable is ignored.
+It can be used to enable features that are not enabled by the cpuid
+instruction, however using it in this way is not recommended.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
Fixes test failures with illegal values in OPENSSL_ia32cap, i.e.:
OPENSSL_ia32cap=0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF make test

@dot-asm this one's for you ;)