### PR TITLE
Configurations/10-main.conf: add magic macros to hpux targets.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -428,8 +428,13 @@ sub vms_info {
 #   even PA-RISC 2.0-specific code paths, which are chosen at run-time,
 #   thus adequate performance is provided even with PA-RISC 1.1 build.
 #					<appro@fy.chalmers.se>
+    "hpux-network" => {
+        template         => 1,
+        defines          => add("_XOPEN_SOURCE", "_XOPEN_SOURCE_EXTENDED",
+                                "_HPUX_ALT_XOPEN_SOCKET_API"),
+    },
     "hpux-parisc-gcc" => {
-        inherit_from     => [ "BASE_unix" ],
+        inherit_from     => [ "BASE_unix", "hpux-network" ],
         cc               => "gcc",
         cflags           => combine(picker(default => "-DB_ENDIAN -DBN_DIV2W",
                                            debug   => "-O0 -g",
@@ -449,7 +454,8 @@ sub vms_info {
         multilib         => "/pa1.1",
     },
     "hpux64-parisc2-gcc" => {
-        inherit_from     => [ "BASE_unix", asm("parisc20_64_asm") ],
+        inherit_from     => [ "BASE_unix", "hpux-network",
+                              asm("parisc20_64_asm") ],
         cc               => "gcc",
         cflags           => combine(picker(default => "-DB_ENDIAN",
                                            debug   => "-O0 -g",
@@ -471,7 +477,7 @@ sub vms_info {
     # Chris Ruemmler <ruemmler@cup.hp.com>
     # Kevin Steves <ks@hp.se>
     "hpux-parisc-cc" => {
-        inherit_from     => [ "BASE_unix" ],
+        inherit_from     => [ "BASE_unix", "hpux-network" ],
         cc               => "cc",
         cflags           => combine(picker(default => "+Optrs_strongly_typed -Ae +ESlit -DB_ENDIAN -DBN_DIV2W -DMD32_XARRAY",
                                            debug   => "+O0 +d -g",
@@ -492,7 +498,8 @@ sub vms_info {
         multilib         => "/pa1.1",
     },
     "hpux64-parisc2-cc" => {
-        inherit_from     => [ "BASE_unix", asm("parisc20_64_asm") ],
+        inherit_from     => [ "BASE_unix", "hpux-network",
+                              asm("parisc20_64_asm") ],
         cc               => "cc",
         cflags           => combine(picker(default => "+DD64 +Optrs_strongly_typed -Ae +ESlit -DB_ENDIAN -DMD32_XARRAY",
                                            debug   => "+O0 +d -g",
@@ -511,7 +518,7 @@ sub vms_info {
 
     # HP/UX IA-64 targets
     "hpux-ia64-cc" => {
-        inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
+        inherit_from     => [ "BASE_unix", "hpux-network", asm("ia64_asm") ],
         cc               => "cc",
         cflags           => combine(picker(default => "-Ae +DD32 +Olit=all -z -DB_ENDIAN",
                                            debug   => "+O0 +d -g",
@@ -530,7 +537,7 @@ sub vms_info {
     # Frank Geurts <frank.geurts@nl.abnamro.com> has patiently assisted
     # with debugging of the following config.
     "hpux64-ia64-cc" => {
-        inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
+        inherit_from     => [ "BASE_unix", "hpux-network", asm("ia64_asm") ],
         cc               => "cc",
         cflags           => combine(picker(default => "-Ae +DD64 +Olit=all -z -DB_ENDIAN",
                                            debug   => "+O0 +d -g",
@@ -548,7 +555,7 @@ sub vms_info {
     },
     # GCC builds...
     "hpux-ia64-gcc" => {
-        inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
+        inherit_from     => [ "BASE_unix", "hpux-network", asm("ia64_asm") ],
         cc               => "gcc",
         cflags           => combine(picker(default => "-DB_ENDIAN",
                                            debug   => "-O0 -g",
@@ -565,7 +572,7 @@ sub vms_info {
         multilib         => "/hpux32",
     },
     "hpux64-ia64-gcc" => {
-        inherit_from     => [ "BASE_unix", asm("ia64_asm") ],
+        inherit_from     => [ "BASE_unix", "hpux-network", asm("ia64_asm") ],
         cc               => "gcc",
         cflags           => combine(picker(default => "-mlp64 -DB_ENDIAN",
                                            debug   => "-O0 -g",


### PR DESCRIPTION
HP-UX provides sockets symbols with incompatible prototypes under same
names. Additional macros force unambitious symbols with unambitious
prototypes.

Backport of relevant part of #5742, partially addresses #5691.
