### PR TITLE
Prevent a possible recursion in ERR_get_state and fix the problem that

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -667,25 +667,23 @@ ERR_STATE *ERR_get_state(void)
     if (!RUN_ONCE(&err_init, err_do_init))
         return NULL;
 
-    /*
-     * If base OPENSSL_init_crypto() hasn't been called yet, be sure to call
-     * it now to avoid state to be doubly allocated and thereby leak memory.
-     * Needed on any platform that doesn't define OPENSSL_USE_NODELETE.
-     */
-    if (!OPENSSL_init_crypto(0, NULL))
+    state = CRYPTO_THREAD_get_local(&err_thread_local);
+    if (state == (ERR_STATE*)-1)
         return NULL;
 
-    state = CRYPTO_THREAD_get_local(&err_thread_local);
-
     if (state == NULL) {
+        if (!CRYPTO_THREAD_set_local(&err_thread_local, (ERR_STATE*)-1))
+            return NULL;
+
         if ((state = OPENSSL_zalloc(sizeof(*state))) == NULL) {
-            /* ERRerr(ERR_F_ERR_GET_STATE, ERR_R_MALLOC_FAILURE); */
+            CRYPTO_THREAD_set_local(&err_thread_local, NULL);
             return NULL;
         }
 
         if (!ossl_init_thread_start(OPENSSL_INIT_THREAD_ERR_STATE)
-            || !CRYPTO_THREAD_set_local(&err_thread_local, state)) {
+                || !CRYPTO_THREAD_set_local(&err_thread_local, state)) {
             ERR_STATE_free(state);
+            CRYPTO_THREAD_set_local(&err_thread_local, NULL);
             return NULL;
         }
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -540,18 +540,8 @@ void OPENSSL_cleanup(void)
  */
 int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
 {
-    static int stoperrset = 0;
-
     if (stopped) {
-        if (!stoperrset) {
-            /*
-             * We only ever set this once to avoid getting into an infinite
-             * loop where the error system keeps trying to init and fails so
-             * sets an error etc
-             */
-            stoperrset = 1;
-            CRYPTOerr(CRYPTO_F_OPENSSL_INIT_CRYPTO, ERR_R_INIT_FAIL);
-        }
+        CRYPTOerr(CRYPTO_F_OPENSSL_INIT_CRYPTO, ERR_R_INIT_FAIL);
         return 0;
     }
 


### PR DESCRIPTION
was pointed out in commit aef84bb4efbddfd95d042f3f5f1d362ed7d4faeb
differently.

This is just a too fragile solution and when more calls to ERR_get_state
are added over time, it will eventually trigger a stack overflow.