### PR TITLE
Define CPP in Configurations/unix-Makefile.tmpl

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -174,6 +174,7 @@ HTMLSUFFIX=html
 
 CROSS_COMPILE= {- $config{cross_compile_prefix} -}
 CC= $(CROSS_COMPILE){- $target{cc} -}
+CPP=$(CC) -E
 CFLAGS={- our $cflags2 = join(" ",(map { "-D".$_} @{$target{defines}}, @{$config{defines}}),"-DOPENSSLDIR=\"\\\"\$(OPENSSLDIR)\\\"\"","-DENGINESDIR=\"\\\"\$(ENGINESDIR)\\\"\"") -} {- $target{cflags} -} {- $config{cflags} -}
 CFLAGS_Q={- $cflags2 =~ s|([\\"])|\\$1|g; $cflags2 -} {- $config{cflags} -}
 LDFLAGS= {- $target{lflags} -}


### PR DESCRIPTION
We use CPP, with the assumption that it would be predefined.  This is,
however, not always true, and rather depends on the 'make'
implementation.  We therefore define it with the value '$(CC) -E',
which is what we used before CPP came along anyway.

Fixes #5867

Note: this affects config targets that use s390x, IA64 or Sparc
assembler modules.
