### PR TITLE
Don't use CPP in Configurations/unix-Makefile.tmpl

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -954,7 +954,7 @@ EOF
           }
           return <<"EOF";
 $args{src}: $args{generator}->[0] $deps
-	\$(CPP) $incs $cppflags $args{generator}->[0] | \\
+	\$(CC) $incs $cppflags -E $args{generator}->[0] | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
 EOF
       }
@@ -1012,7 +1012,7 @@ EOF
           $recipe .= <<"EOF";
 $obj$objext: $deps
 	( trap "rm -f \$@.*" INT 0; \\
-	  \$(CPP) $incs $cmdflags $srcs | \\
+	  \$(CC) $incs $cmdflags -E $srcs | \\
 	  \$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@.s && \\
 	  $cmd $cmdflags -c -o \$\@ \$@.s )
 EOF


### PR DESCRIPTION
We started using $(CPP) instead of $(CC) -E, with the assumption that
CPP would be predefined.  This is, however, not always true, and
rather depends on the 'make' implementation.  Furthermore, on
platforms where CPP=cpp or something else other than '$(CC) -E',
there's a risk that it won't understand machine specific flags that we
pass to it.  So it turns out that trying to use $(CPP) was a mistake,
and we therefore revert that use back to using $(CC) -E directly.

Fixes #5867

Note: this affects config targets that use Alpha, ARM, IA64, MIPS,
s390x or SPARC assembler modules.
