### PR TITLE
Remove ambiguity in rand_pool_add[_end] return value

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -130,26 +130,20 @@ size_t rand_acquire_entropy_from_cpu(RAND_POOL *pool)
         buffer = rand_pool_add_begin(pool, bytes_needed);
 
         if (buffer != NULL) {
-
-            /* If RDSEED is available, use that. */
+            /* Whichever comes first, use RDSEED, RDRAND or nothing */
             if ((OPENSSL_ia32cap_P[2] & (1 << 18)) != 0) {
                 if (OPENSSL_ia32_rdseed_bytes(buffer, bytes_needed)
-                    == bytes_needed)
-                    return rand_pool_add_end(pool,
-                                             bytes_needed,
-                                             8 * bytes_needed);
-            }
-
-            /* Second choice is RDRAND. */
-            if ((OPENSSL_ia32cap_P[1] & (1 << (62 - 32))) != 0) {
+                    == bytes_needed) {
+                    rand_pool_add_end(pool, bytes_needed, 8 * bytes_needed);
+                }
+            } else if ((OPENSSL_ia32cap_P[1] & (1 << (62 - 32))) != 0) {
                 if (OPENSSL_ia32_rdrand_bytes(buffer, bytes_needed)
-                    == bytes_needed)
-                    return rand_pool_add_end(pool,
-                                             bytes_needed,
-                                             8 * bytes_needed);
+                    == bytes_needed) {
+                    rand_pool_add_end(pool, bytes_needed, 8 * bytes_needed);
+                }
+            } else {
+                rand_pool_add_end(pool, 0, 0);
             }
-
-            return rand_pool_add_end(pool, 0, 0);
         }
     }
 
@@ -222,7 +216,8 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
                 bytes = bytes_needed;
             rand_drbg_unlock(drbg->parent);
 
-            entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+            rand_pool_add_end(pool, bytes, 8 * bytes);
+            entropy_available = rand_pool_entropy_available(pool);
         }
 
     } else {
@@ -631,8 +626,7 @@ size_t rand_pool_bytes_remaining(RAND_POOL *pool)
  * random input which contains at least |entropy| bits of
  * randomness.
  *
- * Return available amount of entropy after this operation.
- * (see rand_pool_entropy_available(pool))
+ * Returns 1 if the added amount is adequate, otherwise 0
  */
 size_t rand_pool_add(RAND_POOL *pool,
                      const unsigned char *buffer, size_t len, size_t entropy)
@@ -648,7 +642,7 @@ size_t rand_pool_add(RAND_POOL *pool,
         pool->entropy += entropy;
     }
 
-    return rand_pool_entropy_available(pool);
+    return 1;
 }
 
 /*
@@ -697,7 +691,7 @@ size_t rand_pool_add_end(RAND_POOL *pool, size_t len, size_t entropy)
         pool->entropy += entropy;
     }
 
-    return rand_pool_entropy_available(pool);
+    return 1;
 }
 
 int RAND_set_rand_method(const RAND_METHOD *meth)

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -628,8 +628,8 @@ size_t rand_pool_bytes_remaining(RAND_POOL *pool)
  *
  * Returns 1 if the added amount is adequate, otherwise 0
  */
-size_t rand_pool_add(RAND_POOL *pool,
-                     const unsigned char *buffer, size_t len, size_t entropy)
+int rand_pool_add(RAND_POOL *pool,
+                  const unsigned char *buffer, size_t len, size_t entropy)
 {
     if (len > pool->max_len - pool->len) {
         RANDerr(RAND_F_RAND_POOL_ADD, RAND_R_ENTROPY_INPUT_TOO_LONG);
@@ -679,7 +679,7 @@ unsigned char *rand_pool_add_begin(RAND_POOL *pool, size_t len)
  * to the buffer which contain at least |entropy| bits of randomness.
  * It is allowed to add less bytes than originally reserved.
  */
-size_t rand_pool_add_end(RAND_POOL *pool, size_t len, size_t entropy)
+int rand_pool_add_end(RAND_POOL *pool, size_t len, size_t entropy)
 {
     if (len > pool->max_len - pool->len) {
         RANDerr(RAND_F_RAND_POOL_ADD_END, RAND_R_RANDOM_POOL_OVERFLOW);

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -174,7 +174,8 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
         if (getrandom(buffer, bytes_needed, 0) == (int)bytes_needed)
             bytes = bytes_needed;
 
-        entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+        rand_pool_add_end(pool, bytes, 8 * bytes);
+        entropy_available = rand_pool_entropy_available(pool);
     }
     if (entropy_available > 0)
         return entropy_available;
@@ -203,7 +204,8 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
                 if (fread(buffer, 1, bytes_needed, fp) == bytes_needed)
                     bytes = bytes_needed;
 
-                entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+                rand_pool_add_end(pool, bytes, 8 * bytes);
+                entropy_available = rand_pool_entropy_available(pool);
             }
             fclose(fp);
             if (entropy_available > 0)
@@ -241,7 +243,8 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
                 if (num == (int)bytes_needed)
                     bytes = bytes_needed;
 
-                entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+                rand_pool_add_end(pool, bytes, 8 * bytes);
+                entropy_available = rand_pool_entropy_available(pool);
             }
             if (entropy_available > 0)
                 return entropy_available;

--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -148,8 +148,9 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
     if (total_length > bytes_remaining)
         total_length = bytes_remaining;
 
-    return rand_pool_add(pool, (PTR_T)data_buffer, total_length,
-                         total_length * ENTROPY_BITS_PER_BYTE);
+    rand_pool_add(pool, (PTR_T)data_buffer, total_length,
+                  total_length * ENTROPY_BITS_PER_BYTE);
+    return rand_pool_entropy_available(pool);
 }
 
 #endif

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -70,7 +70,8 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
             BCRYPT_USE_SYSTEM_PREFERRED_RNG) == STATUS_SUCCESS)
             bytes = bytes_needed;
 
-        entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+        rand_pool_add_end(pool, bytes, 8 * bytes);
+        entropy_available = rand_pool_entropy_available(pool);
     }
     if (entropy_available > 0)
         return entropy_available;
@@ -88,7 +89,8 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
             CryptReleaseContext(hProvider, 0);
         }
 
-        entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+        rand_pool_add_end(pool, bytes, 8 * bytes);
+        entropy_available = rand_pool_entropy_available(pool);
     }
     if (entropy_available > 0)
         return entropy_available;
@@ -106,7 +108,8 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
 
             CryptReleaseContext(hProvider, 0);
         }
-        entropy_available = rand_pool_add_end(pool, bytes, 8 * bytes);
+        rand_pool_add_end(pool, bytes, 8 * bytes);
+        entropy_available = rand_pool_entropy_available(pool);
     }
     if (entropy_available > 0)
         return entropy_available;


### PR DESCRIPTION
When these two functions returned zero, it could mean:

1. that an error occured.  In their case, the error is an overflow of
   the pool, i.e. the correct response from the caller would be to
   stop trying to fill the pool.
2. that there isn't enought entropy acquired yet, i.e. the correct
   response from the caller would be to try and add more entropy to
   the pool.

Because of this ambiguity, the returned zero turns out to be useless.
This change makes the returned value more consistent.  1 means the
addition of new entropy was successful, 0 means it wasn't.  To know if
the pool has been filled enough, the caller will have to call some
other function, such as rand_pool_entropy_available().

Fixes #5846

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
