### PR TITLE
Make Ed25519/Ed448 usable from the command line

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -235,6 +235,8 @@ int dgst_main(int argc, char **argv)
     }
 
     if (keyfile != NULL) {
+        int type;
+
         if (want_pub)
             sigkey = load_pubkey(keyfile, keyform, 0, NULL, e, "key file");
         else
@@ -243,6 +245,15 @@ int dgst_main(int argc, char **argv)
             /*
              * load_[pub]key() has already printed an appropriate message
              */
+            goto end;
+        }
+        type = EVP_PKEY_id(sigkey);
+        if (type == EVP_PKEY_ED25519 || type == EVP_PKEY_ED448) {
+            /*
+             * We implement PureEdDSA for these which doesn't have a separate
+             * digest, and only supports one shot.
+             */
+            BIO_printf(bio_err, "Key type not supported for this operation\n");
             goto end;
         }
     }

--- a/crypto/ec/ec_err.c
+++ b/crypto/ec/ec_err.c
@@ -249,6 +249,8 @@ static const ERR_STRING_DATA EC_str_functs[] = {
      "pkey_ecd_digestsign25519"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECD_DIGESTSIGN448, 0),
      "pkey_ecd_digestsign448"},
+    {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECD_SIGN25519, 0), "pkey_ecd_sign25519"},
+    {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECD_SIGN448, 0), "pkey_ecd_sign448"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECX_DERIVE, 0), "pkey_ecx_derive"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_EC_CTRL, 0), "pkey_ec_ctrl"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_EC_CTRL_STR, 0), "pkey_ec_ctrl_str"},

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -626,6 +626,8 @@ EC_F_PKEY_ECD_CTRL:271:pkey_ecd_ctrl
 EC_F_PKEY_ECD_DIGESTSIGN:272:pkey_ecd_digestsign
 EC_F_PKEY_ECD_DIGESTSIGN25519:276:pkey_ecd_digestsign25519
 EC_F_PKEY_ECD_DIGESTSIGN448:277:pkey_ecd_digestsign448
+EC_F_PKEY_ECD_SIGN25519:284:pkey_ecd_sign25519
+EC_F_PKEY_ECD_SIGN448:285:pkey_ecd_sign448
 EC_F_PKEY_ECX_DERIVE:269:pkey_ecx_derive
 EC_F_PKEY_EC_CTRL:197:pkey_ec_ctrl
 EC_F_PKEY_EC_CTRL_STR:198:pkey_ec_ctrl_str

--- a/doc/man1/dgst.pod
+++ b/doc/man1/dgst.pod
@@ -86,7 +86,9 @@ Filename to output to, or standard output by default.
 
 =item B<-sign filename>
 
-Digitally sign the digest using the private key in "filename".
+Digitally sign the digest using the private key in "filename". Note this option
+does not support Ed25519 or Ed448 private keys. Use the B<pkeyutl> command
+instead for this.
 
 =item B<-keyform arg>
 

--- a/include/openssl/ecerr.h
+++ b/include/openssl/ecerr.h
@@ -172,6 +172,8 @@ int ERR_load_EC_strings(void);
 #  define EC_F_PKEY_ECD_DIGESTSIGN                         272
 #  define EC_F_PKEY_ECD_DIGESTSIGN25519                    276
 #  define EC_F_PKEY_ECD_DIGESTSIGN448                      277
+#  define EC_F_PKEY_ECD_SIGN25519                          284
+#  define EC_F_PKEY_ECD_SIGN448                            285
 #  define EC_F_PKEY_ECX_DERIVE                             269
 #  define EC_F_PKEY_EC_CTRL                                197
 #  define EC_F_PKEY_EC_CTRL_STR                            198


### PR DESCRIPTION
Issue #5873 describes two different ways that trying to use Ed25519/Ed448 from the command line fails.

The pkeyutl failure is due to us not supporting the EVP_PKEY_sign()/EVP_PKEY_verify() functions for those algorithms. This PR adds support for that. You could argue that is a new feature - but I'd argue its a bug fix. There really is no reason why they shouldn't be there - I think it was just an omission when these algorithms were implemented. The fix is trivially easy.

The dgst failure is probably valid. I don't think we should try to fix that, but the error message is very cryptic, so I've tried to add something more helpful and updated the documentation.

Fixes #5873.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
