### PR TITLE
Update genpkey docs and some other fixes (1.0.2)

### DIFF
--- a/crypto/dsa/dsa.h
+++ b/crypto/dsa/dsa.h
@@ -307,6 +307,7 @@ void ERR_load_DSA_strings(void);
 # define DSA_F_I2D_DSA_SIG                                111
 # define DSA_F_OLD_DSA_PRIV_DECODE                        122
 # define DSA_F_PKEY_DSA_CTRL                              120
+# define DSA_F_PKEY_DSA_CTRL_STR                          127
 # define DSA_F_PKEY_DSA_KEYGEN                            121
 # define DSA_F_SIG_CB                                     114
 

--- a/crypto/dsa/dsa_err.c
+++ b/crypto/dsa/dsa_err.c
@@ -1,6 +1,6 @@
 /* crypto/dsa/dsa_err.c */
 /* ====================================================================
- * Copyright (c) 1999-2013 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,6 +95,7 @@ static ERR_STRING_DATA DSA_str_functs[] = {
     {ERR_FUNC(DSA_F_I2D_DSA_SIG), "i2d_DSA_SIG"},
     {ERR_FUNC(DSA_F_OLD_DSA_PRIV_DECODE), "OLD_DSA_PRIV_DECODE"},
     {ERR_FUNC(DSA_F_PKEY_DSA_CTRL), "PKEY_DSA_CTRL"},
+    {ERR_FUNC(DSA_F_PKEY_DSA_CTRL_STR), "PKEY_DSA_CTRL_STR"},
     {ERR_FUNC(DSA_F_PKEY_DSA_KEYGEN), "PKEY_DSA_KEYGEN"},
     {ERR_FUNC(DSA_F_SIG_CB), "SIG_CB"},
     {0, NULL}

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -146,9 +146,16 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
         /* invalid q size */
         return 0;
 
-    if (evpmd == NULL)
-        /* use SHA1 as default */
-        evpmd = EVP_sha1();
+    if (evpmd == NULL) {
+        if (qsize == SHA_DIGEST_LENGTH)
+            evpmd = EVP_sha1();
+        else if (qsize == SHA224_DIGEST_LENGTH)
+            evpmd = EVP_sha224();
+        else
+            evpmd = EVP_sha256();
+    } else {
+        qsize = EVP_MD_size(evpmd);
+    }
 
     if (bits < 512)
         bits = 512;

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -230,10 +230,16 @@ static int pkey_dsa_ctrl_str(EVP_PKEY_CTX *ctx,
                                  EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, qbits,
                                  NULL);
     }
-    if (!strcmp(type, "dsa_paramgen_md")) {
+    if (strcmp(type, "dsa_paramgen_md") == 0) {
+        const EVP_MD *md = EVP_get_digestbyname(value);
+
+        if (md == NULL) {
+            DSAerr(DSA_F_PKEY_DSA_CTRL_STR, DSA_R_INVALID_DIGEST_TYPE);
+            return 0;
+        }
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN,
                                  EVP_PKEY_CTRL_DSA_PARAMGEN_MD, 0,
-                                 (void *)EVP_get_digestbyname(value));
+                                 (void *)md);
     }
     return -2;
 }

--- a/doc/apps/genpkey.pod
+++ b/doc/apps/genpkey.pod
@@ -11,7 +11,7 @@ B<openssl> B<genpkey>
 [B<-out filename>]
 [B<-outform PEM|DER>]
 [B<-pass arg>]
-[B<-cipher>]
+[B<-I<cipher>>]
 [B<-engine id>]
 [B<-paramfile file>]
 [B<-algorithm alg>]
@@ -34,21 +34,21 @@ used.
 
 =item B<-outform DER|PEM>
 
-This specifies the output format DER or PEM.
+This specifies the output format DER or PEM. The default format is PEM.
 
 =item B<-pass arg>
 
-the output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)|openssl(1)>.
+The output file password source. For more information about the format of B<arg>
+see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
 
-=item B<-cipher>
+=item B<-I<cipher>>
 
 This option encrypts the private key with the supplied cipher. Any algorithm
 name accepted by EVP_get_cipherbyname() is acceptable such as B<des3>.
 
 =item B<-engine id>
 
-specifying an engine (by its unique B<id> string) will cause B<genpkey>
+Specifying an engine (by its unique B<id> string) will cause B<genpkey>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms. If used this option should precede all other
@@ -56,20 +56,33 @@ options.
 
 =item B<-algorithm alg>
 
-public key algorithm to use such as RSA, DSA or DH. If used this option must
+Public key algorithm to use such as RSA, DSA or DH. If used this option must
 precede any B<-pkeyopt> options. The options B<-paramfile> and B<-algorithm>
-are mutually exclusive.
+are mutually exclusive. Engines may add algorithms in addition to the standard
+built-in ones.
+
+Valid built-in algorithm names for private key generation are RSA and EC.
+
+Valid built-in algorithm names for parameter generation (see the B<-genparam>
+option) are DH, DSA and EC.
+
+Note that the algorithm name X9.42 DH may be used as a synonym for the DH
+algorithm. These are identical and do not indicate the type of parameters that
+will be generated. Use the B<dh_paramgen_type> option to indicate whether PKCS#3
+or X9.42 DH parameters are required. See L<DH Parameter Generation Options>
+below for more details.
 
 =item B<-pkeyopt opt:value>
 
-set the public key algorithm option B<opt> to B<value>. The precise set of
+Set the public key algorithm option B<opt> to B<value>. The precise set of
 options supported depends on the public key algorithm used and its
-implementation. See B<KEY GENERATION OPTIONS> below for more details.
+implementation. See L<KEY GENERATION OPTIONS> and
+L<PARAMETER GENERATION OPTIONS> below for more details.
 
 =item B<-genparam>
 
-generate a set of parameters instead of a private key. If used this option must
-precede and B<-algorithm>, B<-paramfile> or B<-pkeyopt> options.
+Generate a set of parameters instead of a private key. If used this option must
+precede any B<-algorithm>, B<-paramfile> or B<-pkeyopt> options.
 
 =item B<-paramfile filename>
 
@@ -92,7 +105,7 @@ The options supported by each algorith and indeed each implementation of an
 algorithm can vary. The options for the OpenSSL implementations are detailed
 below.
 
-=head1 RSA KEY GENERATION OPTIONS
+=head2 RSA Key Generation Options
 
 =over 4
 
@@ -107,48 +120,92 @@ hexadecimal value if preceded by B<0x>. Default value is 65537.
 
 =back
 
-=head1 DSA PARAMETER GENERATION OPTIONS
+=head2 EC Key Generation Options
 
-=over 4
-
-=item B<dsa_paramgen_bits:numbits>
-
-The number of bits in the generated parameters. If not specified 1024 is used.
-
-=back
-
-=head1 DH PARAMETER GENERATION OPTIONS
-
-=over 4
-
-=item B<dh_paramgen_prime_len:numbits>
-
-The number of bits in the prime parameter B<p>.
-
-=item B<dh_paramgen_generator:value>
-
-The value to use for the generator B<g>.
-
-=item B<dh_rfc5114:num>
-
-If this option is set then the appropriate RFC5114 parameters are used
-instead of generating new parameters. The value B<num> can take the
-values 1, 2 or 3 corresponding to RFC5114 DH parameters consisting of
-1024 bit group with 160 bit subgroup, 2048 bit group with 224 bit subgroup
-and 2048 bit group with 256 bit subgroup as mentioned in RFC5114 sections
-2.1, 2.2 and 2.3 respectively.
-
-=back
-
-=head1 EC PARAMETER GENERATION OPTIONS
+The EC key generation options can also be used for parameter generation.
 
 =over 4
 
 =item B<ec_paramgen_curve:curve>
 
-the EC curve to use.
+The EC curve to use. OpenSSL supports NIST curve names such as "P-256".
+
+=item B<ec_param_enc:encoding>
+
+The encoding to use for parameters. The "encoding" parameter must be either
+"named_curve" or "explicit". The default value is "named_curve".
 
 =back
+
+=head1 PARAMETER GENERATION OPTIONS
+
+The options supported by each algorithm and indeed each implementation of an
+algorithm can vary. The options for the OpenSSL implementations are detailed
+below.
+
+=head2 DSA Parameter Generation Options
+
+=over 4
+
+=item B<dsa_paramgen_bits:numbits>
+
+The number of bits in the generated prime. If not specified 1024 is used.
+
+=item B<dsa_paramgen_q_bits:numbits>
+
+The number of bits in the q parameter. Must be one of 160, 224 or 256. If not
+specified 160 is used.
+
+=item B<dsa_paramgen_md:digest>
+
+The digest to use during parameter generation. Must be one of B<sha1>, B<sha224>
+or B<sha256>. If set, then the number of bits in B<q> will match the output size
+of the specified digest and the B<dsa_paramgen_q_bits> parameter will be
+ignored. If not set, then a digest will be used that gives an output matching
+the number of bits in B<q>, i.e. B<sha1> if q length is 160, B<sha224> if it 224
+or B<sha256> if it is 256.
+
+=back
+
+=head2 DH Parameter Generation Options
+
+=over 4
+
+=item B<dh_paramgen_prime_len:numbits>
+
+The number of bits in the prime parameter B<p>. The default is 1024.
+
+=item B<dh_paramgen_subprime_len:numbits>
+
+The number of bits in the sub prime parameter B<q>. The default is 256 if the
+prime is at least 2048 bits long or 160 otherwise. Only relevant if used in
+conjunction with the B<dh_paramgen_type> option to generate X9.42 DH parameters.
+
+=item B<dh_paramgen_generator:value>
+
+The value to use for the generator B<g>. The default is 2.
+
+=item B<dh_paramgen_type:value>
+
+The type of DH parameters to generate. Use 0 for PKCS#3 DH and 1 for X9.42 DH.
+The default is 0.
+
+=item B<dh_rfc5114:num>
+
+If this option is set, then the appropriate RFC5114 parameters are used
+instead of generating new parameters. The value B<num> can take the
+values 1, 2 or 3 corresponding to RFC5114 DH parameters consisting of
+1024 bit group with 160 bit subgroup, 2048 bit group with 224 bit subgroup
+and 2048 bit group with 256 bit subgroup as mentioned in RFC5114 sections
+2.1, 2.2 and 2.3 respectively. If present this overrides all other DH parameter
+options.
+
+=back
+
+=head2 EC Parameter Generation Options
+
+The EC parameter generation options are the same as for key generation. See
+L<EC Key Generation Options> above.
 
 =head1 GOST2001 KEY GENERATION AND PARAMETER OPTIONS
 
@@ -179,8 +236,6 @@ numeric OID. Following parameter sets are supported:
 
 =back
 
-
-
 =head1 NOTES
 
 The use of the genpkey program is encouraged over the algorithm specific
@@ -202,19 +257,25 @@ Generate a 2048 bit RSA key using 3 as the public exponent:
  openssl genpkey -algorithm RSA -out key.pem -pkeyopt rsa_keygen_bits:2048 \
  						-pkeyopt rsa_keygen_pubexp:3
 
-Generate 1024 bit DSA parameters:
+Generate 2048 bit DSA parameters:
 
  openssl genpkey -genparam -algorithm DSA -out dsap.pem \
-						-pkeyopt dsa_paramgen_bits:1024
+                                                -pkeyopt dsa_paramgen_bits:2048
 
 Generate DSA key from parameters:
 
  openssl genpkey -paramfile dsap.pem -out dsakey.pem 
 
-Generate 1024 bit DH parameters:
+Generate 2048 bit DH parameters:
 
  openssl genpkey -genparam -algorithm DH -out dhp.pem \
-					-pkeyopt dh_paramgen_prime_len:1024
+                                        -pkeyopt dh_paramgen_prime_len:2048
+
+Generate 2048 bit X9.42 DH parameters:
+
+ openssl genpkey -genparam -algorithm DH -out dhpx.pem \
+                                        -pkeyopt dh_paramgen_prime_len:2048 \
+                                        -pkeyopt dh_paramgen_type:1
 
 Output RFC5114 2048 bit DH parameters with 224 bit subgroup:
 
@@ -224,6 +285,16 @@ Generate DH key from parameters:
 
  openssl genpkey -paramfile dhp.pem -out dhkey.pem 
 
+Generate EC key directly:
+
+ openssl genpkey -algorithm EC -out eckey.pem \
+        -pkeyopt ec_paramgen_curve:P-384 \
+        -pkeyopt ec_param_enc:named_curve
+
+=head1 HISTORY
+
+The ability to use NIST curve names, and to generate an EC key directly,
+were added in OpenSSL 1.0.2.
 
 =cut
 


### PR DESCRIPTION
This is a backport of #5800 to 1.0.2.

See also #5883.