### PR TITLE
TLSProxy/Proxy.pm: harmonize inner loop with the way sockets are.

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3051,19 +3051,6 @@ int s_client_main(int argc, char **argv)
     do_ssl_shutdown(con);
 
     /*
-     * Give the socket time to send its last data before we close it.
-     * No amount of setting SO_LINGER etc on the socket seems to persuade
-     * Windows to send the data before closing the socket...but sleeping
-     * for a short time seems to do it (units in ms)
-     * TODO: Find a better way to do this
-     */
-#if defined(OPENSSL_SYS_WINDOWS)
-    Sleep(50);
-#elif defined(OPENSSL_SYS_CYGWIN)
-    usleep(50000);
-#endif
-
-    /*
      * If we ended with an alert being sent, but still with data in the
      * network buffer to be read, then calling BIO_closesocket() will
      * result in a TCP-RST being sent. On some platforms (notably
@@ -3074,6 +3061,20 @@ int s_client_main(int argc, char **argv)
      * TCP-RST. This seems to allow the peer to read the alert data.
      */
     shutdown(SSL_get_fd(con), 1); /* SHUT_WR */
+#if 0
+    /*
+     * Formally speaking it's appropriate to consume incoming data after you
+     * shutdown your side, but TCP_NODELAY seems to be sufficient. But if
+     * problems are reported, this would be the solution...
+     */
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 500000;  /* some extreme round-trip */
+    do {
+        FD_ZERO(&readfds);
+        openssl_fdset(s, &readfds);
+    } while (select(s + 1, &readfds, NULL, NULL, &timeout) > 0
+             && BIO_read(sbio, sbuf, BUFSIZZ) > 0);
+#endif
     BIO_closesocket(SSL_get_fd(con));
  end:
     if (con != NULL) {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3061,11 +3061,10 @@ int s_client_main(int argc, char **argv)
      * TCP-RST. This seems to allow the peer to read the alert data.
      */
     shutdown(SSL_get_fd(con), 1); /* SHUT_WR */
-#if 0
     /*
-     * Formally speaking it's appropriate to consume incoming data after you
-     * shutdown your side, but TCP_NODELAY seems to be sufficient. But if
-     * problems are reported, this would be the solution...
+     * We just said we have nothing else to say, but it doesn't mean that
+     * the other side has nothing. It's even commended to consume incoming
+     * data. This ensures that alerts are passed on...
      */
     timeout.tv_sec = 0;
     timeout.tv_usec = 500000;  /* some extreme round-trip */
@@ -3074,7 +3073,7 @@ int s_client_main(int argc, char **argv)
         openssl_fdset(s, &readfds);
     } while (select(s + 1, &readfds, NULL, NULL, &timeout) > 0
              && BIO_read(sbio, sbuf, BUFSIZZ) > 0);
-#endif
+
     BIO_closesocket(SSL_get_fd(con));
  end:
     if (con != NULL) {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3063,8 +3063,8 @@ int s_client_main(int argc, char **argv)
     shutdown(SSL_get_fd(con), 1); /* SHUT_WR */
     /*
      * We just said we have nothing else to say, but it doesn't mean that
-     * the other side has nothing. It's even commended to consume incoming
-     * data. This ensures that alerts are passed on...
+     * the other side has nothing. It's even recommended to consume incoming
+     * data. [In testing context this ensures that alerts are passed on...]
      */
     timeout.tv_sec = 0;
     timeout.tv_usec = 500000;  /* some extreme round-trip */

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -146,7 +146,7 @@ int init_client(int *sock, const char *host, const char *port,
         }
 #endif
 
-        if (!BIO_connect(*sock, BIO_ADDRINFO_address(ai), 0)) {
+        if (!BIO_connect(*sock, BIO_ADDRINFO_address(ai), BIO_SOCK_NODELAY)) {
             BIO_closesocket(*sock);
             *sock = INVALID_SOCKET;
             continue;
@@ -330,6 +330,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
                 BIO_closesocket(asock);
                 break;
             }
+            BIO_set_tcp_ndelay(sock, 1);
             i = (*cb)(sock, type, protocol, context);
 
             /*

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -334,19 +334,6 @@ int do_server(int *accept_sock, const char *host, const char *port,
             i = (*cb)(sock, type, protocol, context);
 
             /*
-             * Give the socket time to send its last data before we close it.
-             * No amount of setting SO_LINGER etc on the socket seems to
-             * persuade Windows to send the data before closing the socket...
-             * but sleeping for a short time seems to do it (units in ms)
-             * TODO: Find a better way to do this
-             */
-#if defined(OPENSSL_SYS_WINDOWS)
-            Sleep(50);
-#elif defined(OPENSSL_SYS_CYGWIN)
-            usleep(50000);
-#endif
-
-            /*
              * If we ended with an alert being sent, but still with data in the
              * network buffer to be read, then calling BIO_closesocket() will
              * result in a TCP-RST being sent. On some platforms (notably

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -456,14 +456,15 @@ sub process_packet
 
     #Return contains the list of record found in the packet followed by the
     #list of messages in those records and any partial message
-    my @ret = TLSProxy::Record->get_records($server, $self->flight, $self->{partial}[$server].$packet);
+    my @ret = TLSProxy::Record->get_records($server, $self->flight,
+                                            $self->{partial}[$server].$packet);
     $self->{partial}[$server] = $ret[2];
     push @{$self->{record_list}}, @{$ret[0]};
     push @{$self->{message_list}}, @{$ret[1]};
 
     print "\n";
 
-    if (scalar(@{$ret[0]}) == 0 or length($ret[2]) != 0) {
+    if (scalar(@{$ret[0]}) == 0) {
         return "";
     }
 

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -356,7 +356,8 @@ sub clientstart
     my @ready;
     my $ctr = 0;
     local $SIG{PIPE} = "IGNORE";
-    while(     (!(TLSProxy::Message->end)
+    while($fdset->count
+            && (!(TLSProxy::Message->end)
                 || (defined $self->sessionfile()
                     && (-s $self->sessionfile()) == 0))
             && $ctr < 10) {
@@ -366,15 +367,23 @@ sub clientstart
         }
         foreach my $hand (@ready) {
             if ($hand == $server_sock) {
-                $server_sock->sysread($indata, 16384) or goto END;
-                $indata = $self->process_packet(1, $indata);
-                $client_sock->syswrite($indata);
-                $ctr = 0;
+                if ($server_sock->sysread($indata, 16384)) {
+                    $indata = $self->process_packet(1, $indata);
+                    $client_sock->syswrite($indata) or goto END;
+                    $ctr = 0;
+                } else {
+                    $fdset->remove($server_sock);
+                    $client_sock->shutdown(SHUT_WR);
+                }
             } elsif ($hand == $client_sock) {
-                $client_sock->sysread($indata, 16384) or goto END;
-                $indata = $self->process_packet(0, $indata);
-                $server_sock->syswrite($indata);
-                $ctr = 0;
+                if ($client_sock->sysread($indata, 16384)) {
+                    $indata = $self->process_packet(0, $indata);
+                    $server_sock->syswrite($indata) or goto END;
+                    $ctr = 0;
+                } else {
+                    $fdset->remove($client_sock);
+                    $server_sock->shutdown(SHUT_WR);
+                }
             } else {
                 kill(3, $self->{real_serverpid});
                 die "Unexpected handle";

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -368,8 +368,9 @@ sub clientstart
         foreach my $hand (@ready) {
             if ($hand == $server_sock) {
                 if ($server_sock->sysread($indata, 16384)) {
-                    $indata = $self->process_packet(1, $indata);
-                    $client_sock->syswrite($indata) or goto END;
+                    if ($indata = $self->process_packet(1, $indata)) {
+                        $client_sock->syswrite($indata) or goto END;
+                    }
                     $ctr = 0;
                 } else {
                     $fdset->remove($server_sock);
@@ -377,8 +378,9 @@ sub clientstart
                 }
             } elsif ($hand == $client_sock) {
                 if ($client_sock->sysread($indata, 16384)) {
-                    $indata = $self->process_packet(0, $indata);
-                    $server_sock->syswrite($indata) or goto END;
+                    if ($indata = $self->process_packet(0, $indata)) {
+                        $server_sock->syswrite($indata) or goto END;
+                    }
                     $ctr = 0;
                 } else {
                     $fdset->remove($client_sock);


### PR DESCRIPTION
This resolves test failures on HP-UX (mentioned in [#5691](https://github.com/openssl/openssl/issues/5691#issuecomment-378355961))