### PR TITLE
WIP: bio/b_addr.c: resolve HP-UX compiler warnings.

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -66,18 +66,18 @@ void BIO_ADDR_clear(BIO_ADDR *ap)
 int BIO_ADDR_make(BIO_ADDR *ap, const struct sockaddr *sa)
 {
     if (sa->sa_family == AF_INET) {
-        ap->s_in = *(const struct sockaddr_in *)sa;
+        memcpy(&(ap->s_in), sa, sizeof(struct sockaddr_in));
         return 1;
     }
 #ifdef AF_INET6
     if (sa->sa_family == AF_INET6) {
-        ap->s_in6 = *(const struct sockaddr_in6 *)sa;
+        memcpy(&(ap->s_in6), sa, sizeof(struct sockaddr_in6));
         return 1;
     }
 #endif
 #ifdef AF_UNIX
     if (sa->sa_family == AF_UNIX) {
-        ap->s_un = *(const struct sockaddr_un *)sa;
+        memcpy(&(ap->s_un), sa, sizeof(struct sockaddr_un));
         return 1;
     }
 #endif


### PR DESCRIPTION
The warning reads "[cast] may cause misaligned access". Even though
this can be application-supplied pointer, misaligned access shouldn't
happen, because structure type is "encoded" into data itself, and
application would customarily pass correctly aligned pointer. But
there is no harm in resolving the warning...
