### PR TITLE
Ignore the status_request extension in a resumption handshake

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -324,6 +324,10 @@ int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
 {
     PACKET responder_id_list, exts;
 
+    /* We ignore this in a resumption handshake */
+    if (s->hit)
+        return 1;
+
     /* Not defined if we get one of these in a client Certificate */
     if (x != NULL)
         return 1;


### PR DESCRIPTION
We cannot provide a certificate status on a resumption so we should
ignore this extension in that case.

Fixes #1662

Actually the issues discussed in #1662 do not apply to master anyway. We accidentally fixed it a while ago. However we should still not process in the incoming extension. Other PRs will address 1.1.0 and 1.0.2 where the issue does still exist.