### PR TITLE
Ignore the status_request extension in a resumption handshake (1.0.2)

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2408,8 +2408,7 @@ static int ssl_scan_clienthello_tlsext(SSL *s, unsigned char **p,
                 goto err;
             if (!tls1_save_sigalgs(s, data, dsize))
                 goto err;
-        } else if (type == TLSEXT_TYPE_status_request) {
-
+        } else if (type == TLSEXT_TYPE_status_request && !s->hit) {
             if (size < 5)
                 goto err;
 


### PR DESCRIPTION
We cannot provide a certificate status on a resumption so we should
ignore this extension in that case.

Fixes #1662

This is the 1.0.2 version of #5896 
