### PR TITLE
Fix the build_all_generated rule to include generated map files

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -59,7 +59,7 @@
                        grep { defined $unified_info{generate}->{$_} }
                        map { @{$unified_info{sources}->{$_}} }
                        grep { /\.o$/ } keys %{$unified_info{sources}} ),
-                     ( grep { /\.h$/ } keys %{$unified_info{generate}} ) );
+                     ( grep { /\.(?:h|opt)$/ } keys %{$unified_info{generate}} ) );
 
   # This is a horrible hack, but is needed because recursive inclusion of files
   # in different directories does not work well with HP C.

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -111,7 +111,7 @@ GENERATED={- join(" ",
                   ( grep { defined $unified_info{generate}->{$_} }
                     map { @{$unified_info{sources}->{$_}} }
                     grep { /\.(?:o|res)$/ } keys %{$unified_info{sources}} ),
-                  ( grep { /\.h$/ } keys %{$unified_info{generate}} )) -}
+                  ( grep { /\.(?:h|map|def)$/ } keys %{$unified_info{generate}} )) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -93,7 +93,7 @@ GENERATED={- join(" ",
                     grep { defined $unified_info{generate}->{$_} }
                     map { @{$unified_info{sources}->{$_}} }
                     grep { /\.o$/ } keys %{$unified_info{sources}} ),
-                  ( grep { /\.h$/ } keys %{$unified_info{generate}} )) -}
+                  ( grep { /\.(?:h|def)$/ } keys %{$unified_info{generate}} )) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}


### PR DESCRIPTION
This allows the build_all_generated rule to create libcrypto.map and libssl.map.

However the build is still unable to do everything without using perl,
because there are build-steps like these:

```
crypto/aes/aes-armv4.o: crypto/aes/aes-armv4.S
        ( trap "rm -f $@.*" INT 0; \
          $(CC)  -I. -Icrypto/include -Iinclude -Icrypto $(LIB_CFLAGS) $(LIB_CPPFLAGS) -E crypto/aes/aes-armv4.S | \
          $(PERL) -ne '/^#(line)?\s*[0-9]+/ or print' > $@.s && \
          $(CC) $(LIB_CFLAGS) $(LIB_CPPFLAGS) -c -o $@ $@.s )
```

It is still an improvement because this needs only a minimum perl installation.