### PR TITLE
Add SSL_clear_session() API

### DIFF
--- a/doc/man3/SSL_set_session.pod
+++ b/doc/man3/SSL_set_session.pod
@@ -2,12 +2,14 @@
 
 =head1 NAME
 
-SSL_set_session - set a TLS/SSL session to be used during TLS/SSL connect
+SSL_clear_session,
+SSL_set_session - clear or set a TLS/SSL session to be used during TLS/SSL connect
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
+ int SSL_clear_session(SSL *ssl);
  int SSL_set_session(SSL *ssl, SSL_SESSION *session);
 
 =head1 DESCRIPTION
@@ -18,6 +20,10 @@ When the session is set, the reference count of B<session> is incremented
 by 1. If the session is not reused, the reference count is decremented
 again during SSL_connect(). Whether the session was reused can be queried
 with the L<SSL_session_reused(3)> call.
+
+SSL_clear_session() removes the session from a TLS/SSL connection.
+SSL_clear_session() is only useful for TLS/SSL servers. When the session is cleared,
+it will cause L<SSL_session_reused(3)> to return 0;
 
 If there is already a session set inside B<ssl> (because it was set with
 SSL_set_session() before or because the same B<ssl> was already used for

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1623,6 +1623,7 @@ int SSL_SESSION_up_ref(SSL_SESSION *ses);
 void SSL_SESSION_free(SSL_SESSION *ses);
 __owur int i2d_SSL_SESSION(SSL_SESSION *in, unsigned char **pp);
 __owur int SSL_set_session(SSL *to, SSL_SESSION *session);
+__owur int SSL_clear_session(SSL *s);
 int SSL_CTX_add_session(SSL_CTX *s, SSL_SESSION *c);
 int SSL_CTX_remove_session(SSL_CTX *, SSL_SESSION *c);
 __owur int SSL_CTX_set_generate_session_id(SSL_CTX *, GEN_SESSION_CB);

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -854,6 +854,14 @@ int SSL_set_session(SSL *s, SSL_SESSION *session)
     return 1;
 }
 
+int SSL_clear_session(SSL *s)
+{
+    if (!SSL_set_session(s, NULL))
+        return 0;
+    s->hit = 0;
+    return 1;
+}
+
 int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
                         unsigned int sid_len)
 {

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -486,3 +486,4 @@ SSL_CTX_set_stateless_cookie_generate_cb 486	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_stateless_cookie_verify_cb  487	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_ciphersuites                488	1_1_1	EXIST::FUNCTION:
 SSL_set_ciphersuites                    489	1_1_1	EXIST::FUNCTION:
+SSL_clear_session                       490	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Enhances SSL_set_session() API by clearing the |hit| flag

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
