### PR TITLE
Fix false positives of IS_*() macros for 8-bit ASCII characters (Take 2)

### DIFF
--- a/crypto/conf/conf_def.h
+++ b/crypto/conf/conf_def.h
@@ -25,24 +25,17 @@
 #define CONF_ALNUM        (CONF_ALPHA|CONF_NUMBER|CONF_UNDER)
 #define CONF_ALNUM_PUNCT  (CONF_ALPHA|CONF_NUMBER|CONF_UNDER|CONF_PUNCT)
 
-#define KEYTYPES(c)       ((const unsigned short *)((c)->meth_data))
 
-#ifndef CHARSET_EBCDIC
-# define CVT(a) ((a) & 0x7F)
-#else
-# define CVT(a) os_toascci[(a) & 0x7F]
-#endif
-
-#define IS_COMMENT(c,a)     (KEYTYPES(c)[CVT(a)] & CONF_COMMENT)
-#define IS_FCOMMENT(c,a)    (KEYTYPES(c)[CVT(a)] & CONF_FCOMMENT)
-#define IS_EOF(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_EOF)
-#define IS_ESC(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_ESC)
-#define IS_NUMBER(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_NUMBER)
-#define IS_WS(c,a)          (KEYTYPES(c)[CVT(a)] & CONF_WS)
-#define IS_ALNUM(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_ALNUM)
-#define IS_ALNUM_PUNCT(c,a) (KEYTYPES(c)[CVT(a)] & CONF_ALNUM_PUNCT)
-#define IS_QUOTE(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_QUOTE)
-#define IS_DQUOTE(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_DQUOTE)
+#define IS_COMMENT(conf,c)     is_keytype(conf, c, CONF_COMMENT)
+#define IS_FCOMMENT(conf,c)    is_keytype(conf, c, CONF_FCOMMENT)
+#define IS_EOF(conf,c)         is_keytype(conf, c, CONF_EOF)
+#define IS_ESC(conf,c)         is_keytype(conf, c, CONF_ESC)
+#define IS_NUMBER(conf,c)      is_keytype(conf, c, CONF_NUMBER)
+#define IS_WS(conf,c)          is_keytype(conf, c, CONF_WS)
+#define IS_ALNUM(conf,c)       is_keytype(conf, c, CONF_ALNUM)
+#define IS_ALNUM_PUNCT(conf,c) is_keytype(conf, c, CONF_ALNUM_PUNCT)
+#define IS_QUOTE(conf,c)       is_keytype(conf, c, CONF_QUOTE)
+#define IS_DQUOTE(conf,c)      is_keytype(conf, c, CONF_DQUOTE)
 
 static const unsigned short CONF_type_default[128] = {
     0x0008, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,

--- a/crypto/conf/keysets.pl
+++ b/crypto/conf/keysets.pl
@@ -85,24 +85,17 @@ print <<"EOF";
 #define CONF_ALNUM        (CONF_ALPHA|CONF_NUMBER|CONF_UNDER)
 #define CONF_ALNUM_PUNCT  (CONF_ALPHA|CONF_NUMBER|CONF_UNDER|CONF_PUNCT)
 
-#define KEYTYPES(c)       ((const unsigned short *)((c)->meth_data))
 
-#ifndef CHARSET_EBCDIC
-# define CVT(a) ((a) & 0x7F)
-#else
-# define CVT(a) os_toascci[(a) & 0x7F]
-#endif
-
-#define IS_COMMENT(c,a)     (KEYTYPES(c)[CVT(a)] & CONF_COMMENT)
-#define IS_FCOMMENT(c,a)    (KEYTYPES(c)[CVT(a)] & CONF_FCOMMENT)
-#define IS_EOF(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_EOF)
-#define IS_ESC(c,a)         (KEYTYPES(c)[CVT(a)] & CONF_ESC)
-#define IS_NUMBER(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_NUMBER)
-#define IS_WS(c,a)          (KEYTYPES(c)[CVT(a)] & CONF_WS)
-#define IS_ALNUM(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_ALNUM)
-#define IS_ALNUM_PUNCT(c,a) (KEYTYPES(c)[CVT(a)] & CONF_ALNUM_PUNCT)
-#define IS_QUOTE(c,a)       (KEYTYPES(c)[CVT(a)] & CONF_QUOTE)
-#define IS_DQUOTE(c,a)      (KEYTYPES(c)[CVT(a)] & CONF_DQUOTE)
+#define IS_COMMENT(conf,c)     is_keytype(conf, c, CONF_COMMENT)
+#define IS_FCOMMENT(conf,c)    is_keytype(conf, c, CONF_FCOMMENT)
+#define IS_EOF(conf,c)         is_keytype(conf, c, CONF_EOF)
+#define IS_ESC(conf,c)         is_keytype(conf, c, CONF_ESC)
+#define IS_NUMBER(conf,c)      is_keytype(conf, c, CONF_NUMBER)
+#define IS_WS(conf,c)          is_keytype(conf, c, CONF_WS)
+#define IS_ALNUM(conf,c)       is_keytype(conf, c, CONF_ALNUM)
+#define IS_ALNUM_PUNCT(conf,c) is_keytype(conf, c, CONF_ALNUM_PUNCT)
+#define IS_QUOTE(conf,c)       is_keytype(conf, c, CONF_QUOTE)
+#define IS_DQUOTE(conf,c)      is_keytype(conf, c, CONF_DQUOTE)
 
 EOF
 


### PR DESCRIPTION
Fixes #5778, #5840

This is an improvement of #5844

The various `IS_*()` macros did not work correctly for 8-bit ASCII characters with the high bit set, because the `CVT(a)` preprocessor macro and'ed the given ASCII value with 0x7F, effectively folding the high value range 128-255 over the low value range 0-127. As a consequence, some of the `IS_*()` erroneously returned TRUE.

This commit fixes the issue by adding range checks instead of cutting off high order bits using a mask. In order avoid multiple evaluation of macro arguments, most of the implementation was moved from macros into a static function is_keytype().
