### PR TITLE
VMS: lower the entropy demand for this platform specifically

### DIFF
--- a/include/openssl/rand_drbg.h
+++ b/include/openssl/rand_drbg.h
@@ -35,9 +35,17 @@
  *
  * Currently supported ciphers are: NID_aes_128_ctr, NID_aes_192_ctr and
  * NID_aes_256_ctr
+ *
+ * Note: VMS entropy acquisition cannot deliver more than 256 bits for the
+ * moment. a DRBG strength of 256 bits  + 50% for nonce is more than that,
+ * so we currently must require lower strength on VMS.
  */
 # define RAND_DRBG_STRENGTH             256
-# define RAND_DRBG_TYPE                 NID_aes_256_ctr
+# ifndef __VMS
+#  define RAND_DRBG_TYPE                 NID_aes_256_ctr
+# else
+#  define RAND_DRBG_TYPE                 NID_aes_128_ctr
+# endif
 # define RAND_DRBG_FLAGS                0
 
 


### PR DESCRIPTION
Currently, the VMS version of rand_pool_acquire_entropy() delivers 256
bits of entropy.  The DRBG using AES-256-CTR and wanting 50% extra
bits for the nonce demands 384 bits of entropy.  Obviously, this makes
anything random related to fail on VMS.

The solution for now, until we get the VMS rand_pool_acquire_entropy()
to deliver more entropy, is to lower the bar for VMS specifically,
i.e. making the default scrambling cipher AES-128-CTR instead of
AES-256-CTR.

Fixes #5849
