### PR TITLE
Simplify unnecessary computation

### DIFF
--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -525,8 +525,7 @@ static int aesni_cbc_hmac_sha1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             /* figure out payload length */
             pad = out[len - 1];
             maxpad = len - (SHA_DIGEST_LENGTH + 1);
-            maxpad |= (255 - maxpad) >> (sizeof(maxpad) * 8 - 8);
-            maxpad &= 255;
+            maxpad = maxpad > 255 ? 255 : maxpad;
 
             mask = constant_time_ge(maxpad, pad);
             ret &= mask;

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -537,8 +537,7 @@ static int aesni_cbc_hmac_sha256_cipher(EVP_CIPHER_CTX *ctx,
             /* figure out payload length */
             pad = out[len - 1];
             maxpad = len - (SHA256_DIGEST_LENGTH + 1);
-            maxpad |= (255 - maxpad) >> (sizeof(maxpad) * 8 - 8);
-            maxpad &= 255;
+            maxpad = maxpad > 255 ? 255 : maxpad;
 
             mask = constant_time_ge(maxpad, pad);
             ret &= mask;


### PR DESCRIPTION
The removed code caps "maxpad" at at most 255 without leaking its value
via side channels. However, the value of "maxpad" is computed entirely
from data that would already be known to any attacker, and so the bit
hacker serves only to needlessly obfuscate the code.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
