### PR TITLE
EVP_MD_CTX_cleanup replaced with EVP_MD_CTX_reset

### DIFF
--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -77,7 +77,7 @@ context. This means that calls to EVP_DigestSignUpdate() and
 EVP_DigestSignFinal() can be called later to digest and sign additional data.
 
 Since only a copy of the digest context is ever finalized the context must
-be cleaned up after use by calling EVP_MD_CTX_cleanup() or a memory leak
+be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
 The use of EVP_PKEY_size() with these functions is discouraged because some

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -76,7 +76,7 @@ context. This means that EVP_VerifyUpdate() and EVP_VerifyFinal() can
 be called later to digest and verify additional data.
 
 Since only a copy of the digest context is ever finalized the context must
-be cleaned up after use by calling EVP_MD_CTX_cleanup() or a memory leak
+be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
 =head1 SEE ALSO

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -75,7 +75,7 @@ This means that calls to EVP_SignUpdate() and EVP_SignFinal() can be called
 later to digest and sign additional data.
 
 Since only a copy of the digest context is ever finalized the context must
-be cleaned up after use by calling EVP_MD_CTX_cleanup() or a memory leak
+be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
 =head1 BUGS

--- a/doc/man3/EVP_VerifyInit.pod
+++ b/doc/man3/EVP_VerifyInit.pod
@@ -57,7 +57,7 @@ This means that calls to EVP_VerifyUpdate() and EVP_VerifyFinal() can be called
 later to digest and verify additional data.
 
 Since only a copy of the digest context is ever finalized the context must
-be cleaned up after use by calling EVP_MD_CTX_cleanup() or a memory leak
+be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
 =head1 BUGS


### PR DESCRIPTION
The EVP_MD_CTX_cleanup() function was merged into EVP_MD_CTX_init()
which was subsequently renamed to EVP_MD_CTX_reset(). Adjust the
documentation accordingly.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
