### PR TITLE
Rework partial packet handling once more

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -464,7 +464,7 @@ sub process_packet
 
     print "\n";
 
-    if (scalar(@{$ret[0]}) == 0) {
+    if (scalar(@{$ret[0]}) == 0 or length($ret[2]) != 0) {
         return "";
     }
 
@@ -476,6 +476,10 @@ sub process_packet
     #Reconstruct the packet
     $packet = "";
     foreach my $record (@{$self->record_list}) {
+        #We only replay the records in the same direction
+        if (($record->flight ^ $self->flight) & 1) {
+            next;
+        }
         $packet .= $record->reconstruct_record($server);
     }
 

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -476,10 +476,6 @@ sub process_packet
     #Reconstruct the packet
     $packet = "";
     foreach my $record (@{$self->record_list}) {
-        #We only replay the records in the same direction
-        if (($record->flight ^ $self->flight) & 1) {
-            next;
-        }
         $packet .= $record->reconstruct_record($server);
     }
 

--- a/util/perl/TLSProxy/Record.pm
+++ b/util/perl/TLSProxy/Record.pm
@@ -279,7 +279,8 @@ sub reconstruct_record
     my $server = shift;
     my $data;
 
-    if ($self->{sent}) {
+    #We only replay the records in the same direction
+    if ($self->{sent} || ($self->flight & 1) != $server) {
         return "";
     }
     $self->{sent} = 1;


### PR DESCRIPTION
Address the concern that commit c53c2fec raised differently.

The original direction of the traffic is encoded in bit 0
of the flight number.
