### PR TITLE
OpenSSL::Test: add data_dir()

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -607,6 +607,23 @@ sub srctop_file {
 
 =over 4
 
+=item B<data_dir LIST>
+
+LIST is a list of directories that make up a path from the data directory
+associated with the test (see L</DESCRIPTION> above).
+C<data_dir> returns the resulting directory as a string, adapted to the local
+operating system.
+
+=back
+
+=cut
+
+sub data_dir {
+    return __data_dir(@_);
+}
+
+=over 4
+
 =item B<data_file LIST, FILENAME>
 
 LIST is a list of directories that make up a path from the data directory
@@ -965,6 +982,12 @@ sub __data_file {
 
     my $f = pop;
     return catfile($directories{SRCDATA},@_,$f);
+}
+
+sub __data_dir {
+    BAIL_OUT("Must run setup() first") if (! $test_name);
+
+    return catdir($directories{SRCDATA},@_);
 }
 
 sub __results_file {


### PR DESCRIPTION
For test recipes that want to use the directory of the data directory
or a subdirectory thereof, rather than just individual files.
