### PR TITLE
Configuration: Simplify generating list of generated files in build file templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ compiler:
 env:
     - CONFIG_OPTS="" DESTDIR="_install"
     - CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2"
-    - CONFIG_OPTS="no-asm --strict-warnings" BUILDONLY="yes" CHECKDOCS="yes"
+    - CONFIG_OPTS="no-asm --strict-warnings" BUILDONLY="yes" CHECKDOCS="yes" GENERATE="yes"
 
 matrix:
     include:
@@ -161,6 +161,11 @@ script:
       else
           make="make";
       fi
+    - if [ -n "$GENERATE" ]; then
+          make2="$make PERL=foobar";
+      else
+          make2="$make";
+      fi
     - top=${PWD}
     - if [ -n "$DESTDIR" ]; then
           cd _build;
@@ -178,10 +183,17 @@ script:
               echo -e '+\057\057 MAKE DOC-NITS FAILED'; false;
           fi;
       fi
-    - if $make; then
-          echo -e '+\057\057\057 MAKE OK';
+    - if [ -n "$GENERATE" ]; then
+          if $make build_all_generated; then
+              echo -e '+\057\057\057 MAKE BUILD_ALL_GENERATED OK';
+          else
+              echo -e '+\057\057\057 MAKE BUILD_ALL_GENERATED FAILED'; false;
+          fi;
+      fi
+    - if $make2; then
+          echo -e '+\057\057\057\057 MAKE OK';
       else
-          echo -e '+\057\057\057 MAKE FAILED'; false;
+          echo -e '+\057\057\057\057 MAKE FAILED'; false;
       fi;
     - if [ -z "$BUILDONLY" ]; then
           if [ -n "$CROSS_COMPILE" ]; then
@@ -194,15 +206,15 @@ script:
               sudo apt-get -yq install bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python-cjson python-paste python-pyrad slapd tcl-dev tcsh;
           fi;
           if HARNESS_VERBOSE=yes BORING_RUNNER_DIR=$top/boringssl/ssl/test/runner make test; then
-              echo -e '+\057\057\057\057 MAKE TEST OK';
+              echo -e '+\057\057\057\057\057 MAKE TEST OK';
           else
-              echo -e '+\057\057\057\057 MAKE TEST FAILED'; false;
+              echo -e '+\057\057\057\057\057 MAKE TEST FAILED'; false;
           fi;
       else
           if $make build_tests >~/build.log 2>&1; then
-              echo -e '+\057\057\057\057\057 MAKE BUILD_TESTS OK';
+              echo -e '+\057\057\057\057\057\057 MAKE BUILD_TESTS OK';
           else
-              echo -e '+\057\057\057\057\057 MAKE BUILD_TESTS FAILED';
+              echo -e '+\057\057\057\057\057\057 MAKE BUILD_TESTS FAILED';
               cat ~/build.log
               false;
           fi;
@@ -210,9 +222,9 @@ script:
     - if [ -n "$DESTDIR" ]; then
           mkdir "$top/$DESTDIR";
           if $make install install_docs DESTDIR="$top/$DESTDIR" >~/install.log 2>&1 ; then
-              echo -e '+\057\057\057\057\057\057 MAKE INSTALL OK';
+              echo -e '+\057\057\057\057\057\057\057 MAKE INSTALL OK';
           else
-              echo -e '+\057\057\057\057\057\057 MAKE INSTALL FAILED';
+              echo -e '+\057\057\057\057\057\057\057 MAKE INSTALL FAILED';
               cat ~/install.log;
               false;
           fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ compiler:
 env:
     - CONFIG_OPTS="" DESTDIR="_install"
     - CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2"
-    - CONFIG_OPTS="no-asm --strict-warnings" BUILDONLY="yes" CHECKDOCS="yes" GENERATE="yes"
+    - CONFIG_OPTS="no-asm no-makedepend --strict-warnings" BUILDONLY="yes" CHECKDOCS="yes" GENERATE="yes"
 
 matrix:
     include:
@@ -162,7 +162,7 @@ script:
           make="make";
       fi
     - if [ -n "$GENERATE" ]; then
-          make2="$make PERL=foobar";
+          make2="$make PERL=no-perl";
       else
           make2="$make";
       fi

--- a/Configurations/common0.tmpl
+++ b/Configurations/common0.tmpl
@@ -16,14 +16,15 @@
              ? ()
              : ( map { @{$unified_info{shared_sources}->{$_}} }
                  keys %{$unified_info{shared_sources}} ),
-         # Sources keys may be scripts, and thereby generated
-         keys %{$unified_info{sources}},
          # Things we explicitely depend on are usually generated
          ( map { $_ eq "" ? () : @{$unified_info{depends}->{$_}} }
                keys %{$unified_info{depends}} ));
  our @generated =
-     grep { defined $unified_info{generate}->{$_} }
-     sort keys %generatables;
+     sort ( ( grep { defined $unified_info{generate}->{$_} }
+              sort keys %generatables ),
+            # Scripts are assumed to be generated, so add thhem too
+            ( grep { defined $unified_info{sources}->{$_} }
+              @{$unified_info{scripts}} ) );
 
  # Avoid strange output
  "";

--- a/Configurations/common0.tmpl
+++ b/Configurations/common0.tmpl
@@ -12,8 +12,10 @@
      ( # The sources of stuff may be generated
          ( map { @{$unified_info{sources}->{$_}} }
                keys %{$unified_info{sources}} ),
-         ( map { @{$unified_info{shared_sources}->{$_}} }
-               keys %{$unified_info{shared_sources}} ),
+         $disabled{shared}
+             ? ()
+             : ( map { @{$unified_info{shared_sources}->{$_}} }
+                 keys %{$unified_info{shared_sources}} ),
          # Sources keys may be scripts, and thereby generated
          keys %{$unified_info{sources}},
          # Things we explicitely depend on are usually generated

--- a/Configurations/common0.tmpl
+++ b/Configurations/common0.tmpl
@@ -1,0 +1,28 @@
+{- # -*- Mode: perl -*-
+
+ # Commonly used list of generated files
+ # The reason for the complexity is that the build.info files provide
+ # GENERATE rules for *all* platforms without discrimination, while the
+ # build files only want those for a particular build.  Therefore, we
+ # need to extrapolate exactly what we need to generate.  The way to do
+ # that is to extract all possible source files from diverse tables and
+ # filter out all that are not generated
+ my %generatables =
+     map { $_ => 1 }
+     ( # The sources of stuff may be generated
+         ( map { @{$unified_info{sources}->{$_}} }
+               keys %{$unified_info{sources}} ),
+         ( map { @{$unified_info{shared_sources}->{$_}} }
+               keys %{$unified_info{shared_sources}} ),
+         # Sources keys may be scripts, and thereby generated
+         keys %{$unified_info{sources}},
+         # Things we explicitely depend on are usually generated
+         ( map { $_ eq "" ? () : @{$unified_info{depends}->{$_}} }
+               keys %{$unified_info{depends}} ));
+ our @generated =
+     grep { defined $unified_info{generate}->{$_} }
+     sort keys %generatables;
+
+ # Avoid strange output
+ "";
+-}

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -131,7 +131,8 @@ DEPS={- our @deps = map { (my $x = $_) =~ s|\.o$|\$(DEP_EXT)|; $x; }
         join(", ", map { "-\n\t".$_ } @deps); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(", ", map { "-\n\t".$_ } @{$unified_info{depends}->{""}} ) -}
-GENERATED={- join(", ", map { my ($x = $_) =~ s|\.[sS]$|.asm|; "-\n\t".$x }
+GENERATED={- # common0.tmpl provides @generated
+             join(", ", map { my ($x = $_) =~ s|\.[sS]$|.asm|; "-\n\t".$x }
                         @generated) -}
 
 INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -132,7 +132,7 @@ DEPS={- our @deps = map { (my $x = $_) =~ s|\.o$|\$(DEP_EXT)|; $x; }
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(", ", map { "-\n\t".$_ } @{$unified_info{depends}->{""}} ) -}
 GENERATED={- # common0.tmpl provides @generated
-             join(", ", map { my ($x = $_) =~ s|\.[sS]$|.asm|; "-\n\t".$x }
+             join(", ", map { (my $x = $_) =~ s|\.[sS]$|.asm|; "-\n\t".$x }
                         @generated) -}
 
 INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -55,11 +55,6 @@
   our @install_shlibs =
       map { $unified_info{sharednames}->{$_} || () }
       grep(!/\.a$/, @{$unified_info{install}->{libraries}});
-  our @generated = ( ( map { (my $x = $_) =~ s|\.[sS]$|\.asm|; $x }
-                       grep { defined $unified_info{generate}->{$_} }
-                       map { @{$unified_info{sources}->{$_}} }
-                       grep { /\.o$/ } keys %{$unified_info{sources}} ),
-                     ( grep { /\.(?:h|opt)$/ } keys %{$unified_info{generate}} ) );
 
   # This is a horrible hack, but is needed because recursive inclusion of files
   # in different directories does not work well with HP C.

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -131,7 +131,8 @@ DEPS={- our @deps = map { (my $x = $_) =~ s|\.o$|\$(DEP_EXT)|; $x; }
         join(", ", map { "-\n\t".$_ } @deps); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(", ", map { "-\n\t".$_ } @{$unified_info{depends}->{""}} ) -}
-GENERATED={- join(", ", map { "-\n\t".$_ } @generated) -}
+GENERATED={- join(", ", map { my ($x = $_) =~ s|\.[sS]$|.asm|; "-\n\t".$x }
+                        @generated) -}
 
 INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}
 INSTALL_SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @install_shlibs) -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -107,7 +107,7 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
                   keys %{$unified_info{sources}}); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}}) -}
-GENERATED={- # common.tmpl provides @generated
+GENERATED={- # common0.tmpl provides @generated
              join(" ", @generated ) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -106,12 +106,9 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
                   grep { $unified_info{sources}->{$_}->[0] =~ /\.c$/ }
                   keys %{$unified_info{sources}}); -}
 {- output_on() if $disabled{makedepend}; "" -}
-GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
-GENERATED={- join(" ",
-                  ( grep { defined $unified_info{generate}->{$_} }
-                    map { @{$unified_info{sources}->{$_}} }
-                    grep { /\.(?:o|res)$/ } keys %{$unified_info{sources}} ),
-                  ( grep { /\.(?:h|map|def)$/ } keys %{$unified_info{generate}} )) -}
+GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}}) -}
+GENERATED={- # common.tmpl provides @generated
+             join(" ", @generated ) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -88,7 +88,7 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
                   keys %{$unified_info{sources}}); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
-GENERATED={- # common.tmpl provides @generated
+GENERATED={- # common0.tmpl provides @generated
              join(" ", map { (my $x = $_) =~ s|\.[sS]$|.asm|; $x }
                        @generated) -}
 

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -89,7 +89,7 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
 GENERATED={- # common.tmpl provides @generated
-             join(" ", map { my ($x = $_) =~ s|\.[sS]$|.asm|; $x }
+             join(" ", map { (my $x = $_) =~ s|\.[sS]$|.asm|; $x }
                        @generated) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -89,7 +89,8 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
 GENERATED={- # common.tmpl provides @generated
-             join(" ", @generated ) -}
+             join(" ", map { my ($x = $_) =~ s|\.[sS]$|.asm|; $x }
+                       @generated) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -88,12 +88,8 @@ DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
                   keys %{$unified_info{sources}}); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
-GENERATED={- join(" ",
-                  ( map { (my $x = $_) =~ s|\.[sS]$|\.asm|; $x }
-                    grep { defined $unified_info{generate}->{$_} }
-                    map { @{$unified_info{sources}->{$_}} }
-                    grep { /\.o$/ } keys %{$unified_info{sources}} ),
-                  ( grep { /\.(?:h|def)$/ } keys %{$unified_info{generate}} )) -}
+GENERATED={- # common.tmpl provides @generated
+             join(" ", @generated ) -}
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}

--- a/Configure
+++ b/Configure
@@ -1630,7 +1630,9 @@ if ($builder eq "unified") {
 	die "*** Couldn't find any of:\n", join("\n", @build_file_templates), "\n";
     }
     $config{build_file_templates}
-      = [ $build_file_template,
+      = [ cleanfile($srcdir, catfile("Configurations", "common0.tmpl"),
+                    $blddir),
+          $build_file_template,
           cleanfile($srcdir, catfile("Configurations", "common.tmpl"),
                     $blddir) ];
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,8 @@ build_script:
     - cd _build
     - ps: >-
         If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
-            cmd /c "nmake 2>&1"
+            cmd /c "nmake build_all_generated 2>&1"
+            cmd /c "nmake PERL=no-perl 2>&1"
         }
     - cd ..
 


### PR DESCRIPTION
Computing the value of the GENERATED variable in the build file
templates is somewhat overcomplicated, and because of possible
duplication errors, changes are potentially error prone.

Looking more closely at how this list is determined, it can be
observed that the exact list of files to check is consistently
available in all the values found in the `%unified_info` tables
'depends', 'sources' and 'shared_sources', and all that's needed is to
filter those values so only those present as keys in the 'generate'
table are left.

This computation is also common for all build files, so due to its
apparent complexity, we move it to common0.tmpl, with the result left
in a global variable (`@generated`), to be consumed by all build file
templates.

common0.tmpl is included among the files to process when creating
build files, but unlike common.tmpl, it comes first of all.
