### PR TITLE
Fix openssl rehash

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -479,13 +479,14 @@ int rehash_main(int argc, char **argv)
     if (*argv != NULL) {
         while (*argv != NULL)
             errs += do_dir(*argv++, h);
-    } else if ((env = getenv("SSL_CERT_DIR")) != NULL) {
+    } else if ((env = getenv(X509_get_default_cert_dir_env())) != NULL) {
+        char lsc[2] = { LIST_SEPARATOR_CHAR, '\0' };
         m = OPENSSL_strdup(env);
-        for (e = strtok(m, ":"); e != NULL; e = strtok(NULL, ":"))
+        for (e = strtok(m, lsc); e != NULL; e = strtok(NULL, lsc))
             errs += do_dir(e, h);
         OPENSSL_free(m);
     } else {
-        errs += do_dir("/etc/ssl/certs", h);
+        errs += do_dir(X509_get_default_cert_dir(), h);
     }
 
  end:

--- a/doc/man1/rehash.pod
+++ b/doc/man1/rehash.pod
@@ -99,6 +99,12 @@ Note that current versions will not use the old style.
 Do not remove existing links.
 This is needed when keeping new and old-style links in the same directory.
 
+=item B<-compat>
+
+Generate links for both old-style (MD5) and new-style (SHA1) hashing.
+This allows releases before 1.0.0 to use these links along-side newer
+releases.
+
 =item B<-v>
 
 Print messages about old links removed and new links created.


### PR DESCRIPTION
Fixes two things:

1. the lack of documentation of `-compat` (see #5902)
2. the use of hard coded (and incorrect) values for default directory.