### PR TITLE
Docs for OpenSSL_init_crypto: there is no way to specify another file

### DIFF
--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -197,10 +197,10 @@ resources should be freed at an earlier time, or under the circumstances
 described in the NOTES section below.
 
 The B<OPENSSL_INIT_LOAD_CONFIG> flag will load a default configuration
-file.  To specify a different file, an B<OPENSSL_INIT_SETTINGS> must
-be created and used. The routines
-OPENSSL_INIT_new() and OPENSSL_INIT_set_config_appname() can be used to
-allocate the object and set the application name, and then the
+file. For optional configuration file settings, an B<OPENSSL_INIT_SETTINGS>
+must be created and used.
+The routines OPENSSL_init_new() and OPENSSL_INIT_set_config_appname() can
+be used to allocate the object and set the application name, and then the
 object can be released with OPENSSL_INIT_free() when done.
 
 =head1 NOTES


### PR DESCRIPTION
The documentation erroneously stated that one can change the default
configuration file name.

Fixes #5939
