### PR TITLE
Rethink regression fixes done in 1.1.0

### DIFF
--- a/test/asynciotest.c
+++ b/test/asynciotest.c
@@ -255,7 +255,6 @@ int main(int argc, char *argv[])
     }
 
     if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
-                             TLS1_VERSION, TLS_MAX_VERSION,
                              &serverctx, &clientctx, argv[1], argv[2])) {
         printf("Failed to create SSL_CTX pair\n");
         goto end;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -31,8 +31,8 @@
 
 int main(int argc, char *argv[])
 {
-    SSL_CTX *ctx = NULL;
-    SSL *con = NULL;
+    SSL_CTX *ctx;
+    SSL *con;
     BIO *rbio;
     BIO *wbio;
     BIO *err;
@@ -56,8 +56,6 @@ int main(int argc, char *argv[])
     for (; currtest < TOTAL_NUM_TESTS; currtest++) {
         testresult = 0;
         ctx = SSL_CTX_new(TLS_method());
-        if (!SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION))
-            goto end;
         con = SSL_new(ctx);
 
         rbio = BIO_new(BIO_s_mem());

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -49,9 +49,8 @@ static int test_dtls_unprocessed(int testidx)
 
     printf("Starting Test %d\n", testidx);
 
-    if (!create_ssl_ctx_pair(DTLS_server_method(), DTLS_client_method(),
-                             DTLS1_VERSION, DTLS_MAX_VERSION, &sctx, &cctx,
-                             cert, privkey)) {
+    if (!create_ssl_ctx_pair(DTLS_server_method(), DTLS_client_method(), &sctx,
+                             &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }

--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -28,8 +28,7 @@ static int test_fatalerr(void)
         0x17, 0x03, 0x03, 0x00, 0x05, 'D', 'u', 'm', 'm', 'y'
     };
 
-    if (!create_ssl_ctx_pair(SSLv23_method(), SSLv23_method(),
-                             SSL3_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
+    if (!create_ssl_ctx_pair(SSLv23_method(), SSLv23_method(), &sctx, &cctx,
                              cert, privkey)) {
         printf("Failed to create SSL_CTX pair\n");
         goto err;

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -249,21 +249,15 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
 #ifndef OPENSSL_NO_DTLS
     if (test_ctx->method == SSL_TEST_METHOD_DTLS) {
         server_ctx = SSL_CTX_new(DTLS_server_method());
-        TEST_check(SSL_CTX_set_max_proto_version(server_ctx, DTLS_MAX_VERSION));
         if (test_ctx->extra.server.servername_callback !=
             SSL_TEST_SERVERNAME_CB_NONE) {
             server2_ctx = SSL_CTX_new(DTLS_server_method());
             TEST_check(server2_ctx != NULL);
         }
         client_ctx = SSL_CTX_new(DTLS_client_method());
-        TEST_check(SSL_CTX_set_max_proto_version(client_ctx, DTLS_MAX_VERSION));
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
             resume_server_ctx = SSL_CTX_new(DTLS_server_method());
-            TEST_check(SSL_CTX_set_max_proto_version(resume_server_ctx,
-                                                     DTLS_MAX_VERSION));
             resume_client_ctx = SSL_CTX_new(DTLS_client_method());
-            TEST_check(SSL_CTX_set_max_proto_version(resume_client_ctx,
-                                                     DTLS_MAX_VERSION));
             TEST_check(resume_server_ctx != NULL);
             TEST_check(resume_client_ctx != NULL);
         }
@@ -271,7 +265,6 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
 #endif
     if (test_ctx->method == SSL_TEST_METHOD_TLS) {
         server_ctx = SSL_CTX_new(TLS_server_method());
-        TEST_check(SSL_CTX_set_max_proto_version(server_ctx, TLS_MAX_VERSION));
         /* SNI on resumption isn't supported/tested yet. */
         if (test_ctx->extra.server.servername_callback !=
             SSL_TEST_SERVERNAME_CB_NONE) {
@@ -279,15 +272,10 @@ static int execute_test(SSL_TEST_FIXTURE fixture)
             TEST_check(server2_ctx != NULL);
         }
         client_ctx = SSL_CTX_new(TLS_client_method());
-        TEST_check(SSL_CTX_set_max_proto_version(client_ctx, TLS_MAX_VERSION));
 
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
             resume_server_ctx = SSL_CTX_new(TLS_server_method());
-            TEST_check(SSL_CTX_set_max_proto_version(resume_server_ctx,
-                                                     TLS_MAX_VERSION));
             resume_client_ctx = SSL_CTX_new(TLS_client_method());
-            TEST_check(SSL_CTX_set_max_proto_version(resume_client_ctx,
-                                                     TLS_MAX_VERSION));
             TEST_check(resume_server_ctx != NULL);
             TEST_check(resume_client_ctx != NULL);
         }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -34,9 +34,7 @@ static X509 *ocspcert = NULL;
 #define NUM_EXTRA_CERTS 40
 
 static int execute_test_large_message(const SSL_METHOD *smeth,
-                                      const SSL_METHOD *cmeth,
-                                      int min_version, int max_version,
-                                      int read_ahead)
+                                      const SSL_METHOD *cmeth, int read_ahead)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
@@ -58,7 +56,7 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
         goto end;
     }
 
-    if (!create_ssl_ctx_pair(smeth, cmeth, min_version, max_version, &sctx,
+    if (!create_ssl_ctx_pair(smeth, cmeth, &sctx,
                              &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         goto end;
@@ -127,14 +125,12 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
 static int test_large_message_tls(void)
 {
     return execute_test_large_message(TLS_server_method(), TLS_client_method(),
-                                      TLS1_VERSION, TLS_MAX_VERSION,
                                       0);
 }
 
 static int test_large_message_tls_read_ahead(void)
 {
     return execute_test_large_message(TLS_server_method(), TLS_client_method(),
-                                      TLS1_VERSION, TLS_MAX_VERSION,
                                       1);
 }
 
@@ -146,9 +142,7 @@ static int test_large_message_dtls(void)
      * read_ahead is set.
      */
     return execute_test_large_message(DTLS_server_method(),
-                                      DTLS_client_method(),
-                                      DTLS1_VERSION, DTLS_MAX_VERSION,
-                                      0);
+                                      DTLS_client_method(), 0);
 }
 #endif
 
@@ -213,9 +207,8 @@ static int test_tlsext_status_type(void)
     OCSP_RESPID *id = NULL;
     BIO *certbio = NULL;
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
-                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
-                             cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
+                             &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }
@@ -438,9 +431,8 @@ static int execute_test_session(SSL_SESSION_TEST_FIXTURE fix)
     SSL_SESSION *sess1 = NULL, *sess2 = NULL;
     int testresult = 0;
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
-                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
-                             cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
+                             &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }
@@ -936,9 +928,8 @@ static int test_set_sigalgs(int idx)
     curr = testctx ? &testsigalgs[idx]
                    : &testsigalgs[idx - OSSL_NELEM(testsigalgs)];
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
-                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
-                             cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
+                             &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }
@@ -1088,16 +1079,14 @@ static int test_custom_exts(int tst)
     clntaddcb = clntparsecb = srvaddcb = srvparsecb = 0;
     snicb = 0;
 
-    if (!create_ssl_ctx_pair(TLS_server_method(),  TLS_client_method(),
-                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
-                             cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(),  TLS_client_method(), &sctx,
+                             &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         goto end;
     }
 
     if (tst == 1
-            && !create_ssl_ctx_pair(TLS_server_method(), NULL,
-                                    TLS1_VERSION, TLS_MAX_VERSION, &sctx2, NULL,
+            && !create_ssl_ctx_pair(TLS_server_method(), NULL, &sctx2, NULL,
                                     cert, privkey)) {
         printf("Unable to create SSL_CTX pair (2)\n");
         goto end;

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -185,9 +185,8 @@ static int test_ssl_corrupt(int testidx)
 
     printf("Starting Test %d, %s\n", testidx, cipher_list[testidx]);
 
-    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),
-                             TLS1_VERSION, TLS_MAX_VERSION, &sctx, &cctx,
-                             cert, privkey)) {
+    if (!create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(), &sctx,
+                             &cctx, cert, privkey)) {
         printf("Unable to create SSL_CTX pair\n");
         return 0;
     }

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -1432,24 +1432,17 @@ int main(int argc, char *argv[])
     } else if (tls1) {
         min_version = TLS1_VERSION;
         max_version = TLS1_VERSION;
-    } else {
-        min_version = SSL3_VERSION;
-        max_version = TLS_MAX_VERSION;
     }
 #endif
 #ifndef OPENSSL_NO_DTLS
-    if (dtls || dtls1 || dtls12) {
+    if (dtls || dtls1 || dtls12)
         meth = DTLS_method();
-        if (dtls1) {
-            min_version = DTLS1_VERSION;
-            max_version = DTLS1_VERSION;
-        } else if (dtls12) {
-            min_version = DTLS1_2_VERSION;
-            max_version = DTLS1_2_VERSION;
-        } else {
-            min_version = DTLS_MIN_VERSION;
-            max_version = DTLS_MAX_VERSION;
-        }
+    if (dtls1) {
+        min_version = DTLS1_VERSION;
+        max_version = DTLS1_VERSION;
+    } else if (dtls12) {
+        min_version = DTLS1_2_VERSION;
+        max_version = DTLS1_2_VERSION;
     }
 #endif
 
@@ -1474,26 +1467,14 @@ int main(int argc, char *argv[])
         SSL_CTX_set_options(s_ctx, SSL_OP_NO_TICKET);
     }
 
-    if (SSL_CTX_set_min_proto_version(c_ctx, min_version) == 0) {
-        printf("Unable to set client min protocol version (0x%X)\n",
-               min_version);
+    if (SSL_CTX_set_min_proto_version(c_ctx, min_version) == 0)
         goto end;
-    }
-    if (SSL_CTX_set_max_proto_version(c_ctx, max_version) == 0) {
-        printf("Unable to set client max protocol version (0x%X)\n",
-               max_version);
+    if (SSL_CTX_set_max_proto_version(c_ctx, max_version) == 0)
         goto end;
-    }
-    if (SSL_CTX_set_min_proto_version(s_ctx, min_version) == 0) {
-        printf("Unable to set server min protocol version (0x%X)\n",
-               min_version);
+    if (SSL_CTX_set_min_proto_version(s_ctx, min_version) == 0)
         goto end;
-    }
-    if (SSL_CTX_set_max_proto_version(s_ctx, max_version) == 0) {
-        printf("Unable to set server max protocol version (0x%X)\n",
-               max_version);
+    if (SSL_CTX_set_max_proto_version(s_ctx, max_version) == 0)
         goto end;
-    }
 
     if (cipher != NULL) {
         if (!SSL_CTX_set_cipher_list(c_ctx, cipher)

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -524,7 +524,6 @@ static int mempacket_test_puts(BIO *bio, const char *str)
 }
 
 int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
-                        int min_proto_version, int max_proto_version,
                         SSL_CTX **sctx, SSL_CTX **cctx, char *certfile,
                         char *privkeyfile)
 {
@@ -537,30 +536,6 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
     if (serverctx == NULL || (cctx != NULL && clientctx == NULL)) {
         printf("Failed to create SSL_CTX\n");
         goto err;
-    }
-
-    if (min_proto_version > 0
-        && !SSL_CTX_set_min_proto_version(serverctx, min_proto_version)) {
-        printf("Unable to set server min protocol versions\n");
-        goto err;
-    }
-    if (max_proto_version > 0
-        && !SSL_CTX_set_max_proto_version(serverctx, max_proto_version)) {
-        printf("Unable to set server max protocol versions\n");
-        goto err;
-    }
-
-    if (clientctx != NULL) {
-        if (min_proto_version > 0
-            && !SSL_CTX_set_max_proto_version(clientctx, max_proto_version)) {
-            printf("Unable to set client max protocol versions\n");
-            goto err;
-        }
-        if (max_proto_version > 0
-            && !SSL_CTX_set_min_proto_version(clientctx, min_proto_version)) {
-            printf("Unable to set client min protocol versions\n");
-            goto err;
-        }
     }
 
     if (SSL_CTX_use_certificate_file(serverctx, certfile,

--- a/test/ssltestlib.h
+++ b/test/ssltestlib.h
@@ -13,7 +13,6 @@
 # include <openssl/ssl.h>
 
 int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
-                        int min_proto_version, int max_proto_version,
                         SSL_CTX **sctx, SSL_CTX **cctx, char *certfile,
                         char *privkeyfile);
 int create_ssl_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -182,7 +182,7 @@ sub start
     $pid = fork();
     if ($pid == 0) {
         my $execcmd = $self->execute
-            ." s_server -max_protocol TLSv1.2 -no_comp -rev -engine ossltest -accept "
+            ." s_server -no_comp -rev -engine ossltest -accept "
             .($self->server_port)
             ." -cert ".$self->cert." -naccept ".$self->serverconnects;
         unless ($self->supports_IPv6) {
@@ -219,7 +219,7 @@ sub clientstart
                 $echostr = "test";
             }
             my $execcmd = "echo ".$echostr." | ".$self->execute
-                 ." s_client -max_protocol TLSv1.2 -engine ossltest -connect "
+                 ." s_client -engine ossltest -connect "
                  .($self->proxy_addr).":".($self->proxy_port);
             unless ($self->supports_IPv6) {
                 $execcmd .= " -4";


### PR DESCRIPTION
There were some changes in 1.1.0 to mitigate against regression errors when re-linking with 1.1.1 libssl. Those changes suggest that we cannot upgrade OpenSSL 1.1.0 to 1.1.1 without changes. This is wrong and is therefore reverted.