### PR TITLE
poly1305/asm/poly1305-armv4.pl: avoid conditional branch to PLT in THUMB-2

### DIFF
--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -186,6 +186,7 @@ $code.=<<___;
 .type	poly1305_blocks,%function
 .align	5
 poly1305_blocks:
+.Lpoly1305_blocks:
 	stmdb	sp!,{r3-r11,lr}
 
 	ands	$len,$len,#-16
@@ -677,7 +678,7 @@ poly1305_blocks_neon:
 	cmp	$len,#64
 	bhs	.Lenter_neon
 	tst	ip,ip			@ is_base2_26?
-	beq	poly1305_blocks
+	beq	.Lpoly1305_blocks
 
 .Lenter_neon:
 	stmdb	sp!,{r4-r7}


### PR DESCRIPTION
When compiling for THUMB-2, the conditional branch to PLT results in a
R_ARM_THM_JUMP19 relocation. Some linkers don't support this relocation
in THUMB-2 (ld.gold), while others can end up truncating the relocation
to fit (ld.bfd).

Adding an "it eq" before the branch converts it into an unconditional
branch, which uses R_ARM_THM_JUMP24 relocation that has a range of 16MB.

See https://github.com/android-ndk/ndk/issues/337 for background.

The current workaround is to disable poly1305 optimization assembly,
which is not optimal and can be reverted after this patch:
https://github.com/freedesktop/gstreamer-cerbero/commit/beab607d2b1ff23c41b7e01aa9c64be5e247d1e6

CLA: trivial
