### PR TITLE
Remove mandatory generated files on windows too

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -491,6 +491,7 @@ clean : libclean
         {- join("\n\t", map { "- DELETE $_.EXE;*,$_.OPT;*" } @{$unified_info{programs}}) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_.EXE;*,$_.OPT;*" } @{$unified_info{engines}}) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_;*" } @{$unified_info{scripts}}) || "@ !" -}
+        {- join("\n\t", map { "- DELETE $_;*" } @{$unified_info{depends}->{""}}) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_;*" } @generated) || "@ !" -}
         - DELETE [...]*.MAP;*
         - DELETE [...]*.D;*

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -360,10 +360,12 @@ clean: libclean
 	{- join("\n\t", map { "-del /Q /F $_" } @PROGRAMS) -}
 	-del /Q /F $(ENGINES)
 	-del /Q /F $(SCRIPTS)
+	-del /Q /F $(GENERATED_MANDATORY)
 	-del /Q /F $(GENERATED)
 	-del /Q /S /F *.d *.obj *.pdb *.exp *.ilk *.manifest
 	-del /Q /S /F engines\*.lib
 	-del /Q /S /F apps\*.lib apps\*.rc apps\*.res
+	-rmdir /Q /S test\test-runs
 
 distclean: clean
 	-del /Q /F configdata.pm


### PR DESCRIPTION
There is still one more file lying around: test\uitest.lib
I don't know where that came from.