### PR TITLE
Add a config option to disable automatic config loading

### DIFF
--- a/Configure
+++ b/Configure
@@ -325,6 +325,7 @@ my @disablables = (
     "async",
     "autoalginit",
     "autoerrinit",
+    "autoload-config",
     "bf",
     "blake2",
     "camellia",
@@ -426,7 +427,7 @@ my %deprecated_disablables = (
 # All of the following are disabled by default:
 
 our %disabled = ( # "what"         => "comment"
-                  "asan"		=> "default",
+		  "asan"		=> "default",
 		  "crypto-mdebug"       => "default",
 		  "crypto-mdebug-backtrace" => "default",
 		  "devcryptoeng"	=> "default",

--- a/INSTALL
+++ b/INSTALL
@@ -276,6 +276,10 @@
                    error strings. For a statically linked application this may
                    be undesirable if small executable size is an objective.
 
+  no-autoload-config
+                   Don't automatically load the default openssl.cnf file.
+                   Typically OpenSSL will automatically load a system config
+                   file which configures default ssl options.
 
   no-capieng
                    Don't build the CAPI engine. This option will be forced if

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -195,7 +195,9 @@ int OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS * settings)
     }
 
     if (!OPENSSL_init_crypto(opts
+#ifndef OPENSSL_NO_AUTOLOAD_CONFIG
                              | OPENSSL_INIT_LOAD_CONFIG
+#endif
                              | OPENSSL_INIT_ADD_ALL_CIPHERS
                              | OPENSSL_INIT_ADD_ALL_DIGESTS,
                              settings))

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -467,6 +467,11 @@ static int test_handshake(int idx)
         }
     }
 
+#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
+    if (!TEST_true(OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL)))
+        goto err;
+#endif
+
     if (!TEST_ptr(server_ctx)
             || !TEST_ptr(client_ctx)
             || !TEST_int_gt(CONF_modules_load(conf, test_app, 0),  0))


### PR DESCRIPTION
I want to be able to load the default config file on demand.
This is useful for static builds that are bundled with the executable.