### PR TITLE
Wait until s_client connects

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -349,7 +349,7 @@ sub clientstart
 
     # Wait for incoming connection from client
     my $fdset = IO::Select->new($self->{proxy_sock});
-    if (!$fdset->can_read(1)) {
+    if (!$fdset->can_read(60)) {
         kill(3, $self->{real_serverpid});
         die "s_client didn't try to connect\n";
     }


### PR DESCRIPTION
This seems to fix the test failures on my win32/cygwin machine.