### PR TITLE
Fix assertion failure in SSL_set_bio()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3844,8 +3844,6 @@ int ssl_free_wbio_buffer(SSL *s)
         return 1;
 
     s->wbio = BIO_pop(s->wbio);
-    if (!ossl_assert(s->wbio != NULL))
-        return 0;
     BIO_free(s->bbio);
     s->bbio = NULL;
 


### PR DESCRIPTION
If SSL_set_bio() is called with a NULL wbio after a failed connection then this can trigger an assertion failure. This should be valid behaviour and the assertion is in fact invalid and can simply be removed.

The SSL_set_bio() tests only did standalone testing without being in the context of an actual connection. We extend this to do additional tests following a successful or failed connection attempt. This would have caught the issue above.

The tests won't cherry-pick to 1.1.0, so I'm only planning on cherry-pick the fix to that branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
