### PR TITLE
Revert "Add OPENSSL_VERSION_AT_LEAST"

### DIFF
--- a/doc/man3/OPENSSL_VERSION_NUMBER.pod
+++ b/doc/man3/OPENSSL_VERSION_NUMBER.pod
@@ -47,11 +47,6 @@ number was therefore 0x0090581f.
 
 OpenSSL_version_num() returns the version number.
 
-The macro OPENSSL_VERSION_AT_LEAST(major,minor) can be used at compile
-time test if the current version is at least as new as the version provided.
-The arguments major, minor and fix correspond to the version information
-as given above.
-
 OpenSSL_version() returns different strings depending on B<t>:
 
 =over 4

--- a/doc/man7/ssl.pod
+++ b/doc/man7/ssl.pod
@@ -89,12 +89,6 @@ includes both more private SSL headers and headers from the B<crypto> library.
 Whenever you need hard-core details on the internals of the SSL API, look
 inside this header file.
 
-OPENSSL_VERSION_AT_LEAST(major,minor) can be
-used in C<#if> statements in order to determine which version of the library is
-being used. This can be used to either enable optional features at compile
-time, or work around issues with a previous version.
-See L<OPENSSL_VERSION_NUMBER(3)>.
-
 =item B<ssl2.h>
 
 Unused. Present for backwards compatibility only.

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -42,11 +42,6 @@ extern "C" {
 # define OPENSSL_VERSION_NUMBER  0x10101005L
 # define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1-pre5-dev  xx XXX xxxx"
 
-#define OPENSSL_MAKE_VERSION(maj,min,fix,patch) ((0x10000000L)+((maj&0xff)<<20)+((min&0xff)<<12)+((fix&0xff)<<4)+patch)
-
-/* use this for #if tests, should never depend upon fix/patch */
-#define OPENSSL_VERSION_AT_LEAST(maj,min) (OPENSSL_MAKE_VERSION(maj,min, 0, 0) >= OPENSSL_VERSION_NUMBER)
-
 /*-
  * The macros below are to be used for shared library (.so, .dll, ...)
  * versioning.  That kind of versioning works a bit differently between


### PR DESCRIPTION
Fixes #5961

This reverts commit 3c5a61dd0f9d9a9eac098419bcaf47d1c296ca81.

The macros OPENSSL_MAKE_VERSION() and OPENSSL_VERSION_AT_LEAST() contain errors and don't work as designed. Apart from that, their introduction should be held back until a decision has been mad about the future versioning scheme.
