### PR TITLE
Clarify the configuration module in config.pod

### DIFF
--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -88,9 +88,9 @@ of the configuration file.
 
 The configuration section should consist of a set of name value pairs which
 contain specific module configuration information. The B<name> represents
-the name of the I<configuration module> the meaning of the B<value> is
+the name of the I<configuration module>. The meaning of the B<value> is
 module specific: it may, for example, represent a further configuration
-section containing configuration module specific information. E.g.
+section containing configuration module specific information. E.g.:
 
  # This must be in the default section
  openssl_conf = openssl_init


### PR DESCRIPTION
Similar to 0652e8a7 ("Clarify default section in config.pod",
2018-04-12), reword a sentence to make it easier to parse.

##### Checklist
- [x] documentation is added or updated
