### PR TITLE
DRBG: fix coverity issues

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -864,7 +864,7 @@ static RAND_DRBG *drbg_setup(RAND_DRBG *parent)
     drbg->reseed_counter = 1;
 
     /*
-     * Ignore instantiation error so support just-in-time instantiation.
+     * Ignore instantiation error to support just-in-time instantiation.
      *
      * The state of the drbg will be checked in RAND_DRBG_generate() and
      * an automatic recovery is attempted.

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -869,9 +869,9 @@ static RAND_DRBG *drbg_setup(RAND_DRBG *parent)
      * The state of the drbg will be checked in RAND_DRBG_generate() and
      * an automatic recovery is attempted.
      */
-    RAND_DRBG_instantiate(drbg,
-                          (const unsigned char *) ossl_pers_string,
-                          sizeof(ossl_pers_string) - 1);
+    (void)RAND_DRBG_instantiate(drbg,
+                                (const unsigned char *) ossl_pers_string,
+                                sizeof(ossl_pers_string) - 1);
     return drbg;
 
 err:


### PR DESCRIPTION
[extended tests] 
(_Note: This label will be removed when merging.)_


- drbg_lib.c: Silence coverity warning: the comment preceding the
  RAND_DRBG_instantiate() call explicitely states that the error
  is ignored and explains the reason why.

- drbgtest: Add checks for the return values of RAND_bytes() and
  RAND_priv_bytes() to run_multi_thread_test().

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
