### PR TITLE
SSL_CTX_set_tlsext_ticket_key_cb.pod: fix error check of RAND_bytes()…

### DIFF
--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -133,7 +133,7 @@ Reference Implementation:
                                      HMAC_CTX *hctx, int enc)
  {
      if (enc) { /* create new session */
-         if (RAND_bytes(iv, EVP_MAX_IV_LENGTH))
+         if (RAND_bytes(iv, EVP_MAX_IV_LENGTH) <= 0)
              return -1; /* insufficient random */
 
          key = currentkey(); /* something that you need to implement */


### PR DESCRIPTION
[skip ci]

_(It's just example code in a man page. Label will be removed when merging)_
