### PR TITLE
Fixes #5979: apps/ec: Always output public key if no_public is not present

### DIFF
--- a/apps/ec.c
+++ b/apps/ec.c
@@ -219,6 +219,8 @@ int ec_main(int argc, char **argv)
 
     if (no_public)
         EC_KEY_set_enc_flags(eckey, EC_PKEY_NO_PUBKEY);
+    else
+        EC_KEY_clear_enc_flag(eckey, EC_PKEY_NO_PUBKEY);
 
     if (text) {
         assert(pubin || private);

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -218,7 +218,7 @@ int ec_main(int argc, char **argv)
         EC_KEY_set_asn1_flag(eckey, asn1_flag);
 
     if (no_public)
-        EC_KEY_set_enc_flags(eckey, EC_PKEY_NO_PUBKEY);
+        EC_KEY_set_enc_flag(eckey, EC_PKEY_NO_PUBKEY);
     else
         EC_KEY_clear_enc_flag(eckey, EC_PKEY_NO_PUBKEY);
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -475,6 +475,16 @@ void EC_KEY_set_enc_flags(EC_KEY *key, unsigned int flags)
     key->enc_flag = flags;
 }
 
+void EC_KEY_set_enc_flag(EC_KEY *key, unsigned int flag)
+{
+    key->enc_flag |= flag;
+}
+
+void EC_KEY_clear_enc_flag(EC_KEY *key, unsigned int flag)
+{
+    key->enc_flag &= ~flag;
+}
+
 point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key)
 {
     return key->conv_form;

--- a/doc/man3/EC_KEY_get_enc_flags.pod
+++ b/doc/man3/EC_KEY_get_enc_flags.pod
@@ -2,8 +2,9 @@
 
 =head1 NAME
 
-EC_KEY_get_enc_flags, EC_KEY_set_enc_flags
-- Get and set flags for encoding EC_KEY structures
+EC_KEY_get_enc_flags, EC_KEY_set_enc_flags, EC_KEY_clear_enc_flag,
+EC_KEY_set_enc_flag
+- Get, set and clear flags for encoding EC_KEY structures
 
 =head1 SYNOPSIS
 
@@ -11,6 +12,8 @@ EC_KEY_get_enc_flags, EC_KEY_set_enc_flags
 
  unsigned int EC_KEY_get_enc_flags(const EC_KEY *key);
  void EC_KEY_set_enc_flags(EC_KEY *eckey, unsigned int flags);
+ void EC_KEY_set_enc_flag(EC_KEY *key, unsigned int flag);
+ void EC_KEY_clear_enc_flag(EC_KEY *key, unsigned int flag);
 
 =head1 DESCRIPTION
 
@@ -26,12 +29,16 @@ the missing public key automatically. Private keys encoded without parameters
 d2i_ECPrivateKey().
 
 The functions EC_KEY_get_enc_flags() and EC_KEY_set_enc_flags() get and set the
-value of the encoding flags for the B<key>. There are two encoding flags
-currently defined - EC_PKEY_NO_PARAMETERS and EC_PKEY_NO_PUBKEY.  These flags
-define the behaviour of how the  B<key> is converted into ASN1 in a call to
-i2d_ECPrivateKey(). If EC_PKEY_NO_PARAMETERS is set then the public parameters for
-the curve are not encoded along with the private key. If EC_PKEY_NO_PUBKEY is
-set then the public key is not encoded along with the private key.
+value of the encoding flags for the B<key>. EC_KEY_set_enc_flag() sets the flags
+in the B<flags> parameter on the EC_KEY object. Any flags that are already set
+are left set. EC_KEY_clear_enc_flag() clears the flags indicated by the B<flags>
+parameter; all other flags are left in their existing state. There are two
+encoding flags currently defined - EC_PKEY_NO_PARAMETERS and EC_PKEY_NO_PUBKEY.
+These flags define the behaviour of how the  B<key> is converted into ASN1 in a
+call to i2d_ECPrivateKey(). If EC_PKEY_NO_PARAMETERS is set then the public
+parameters for the curve are not encoded along with the private key. If
+EC_PKEY_NO_PUBKEY is set then the public key is not encoded along with the
+private key.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -823,6 +823,8 @@ int EC_KEY_set_public_key(EC_KEY *key, const EC_POINT *pub);
 
 unsigned EC_KEY_get_enc_flags(const EC_KEY *key);
 void EC_KEY_set_enc_flags(EC_KEY *eckey, unsigned int flags);
+void EC_KEY_set_enc_flag(EC_KEY *key, unsigned int flag);
+void EC_KEY_clear_enc_flag(EC_KEY *key, unsigned int flag);
 point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
 void EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4527,3 +4527,5 @@ SM2_plaintext_size                      4468	1_1_1	EXIST::FUNCTION:SM2
 conf_ssl_name_find                      4469	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get_cmd                        4470	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get                            4471	1_1_0i	EXIST::FUNCTION:
+EC_KEY_set_enc_flag                     4472	1_1_1	EXIST::FUNCTION:EC
+EC_KEY_clear_enc_flag                   4473	1_1_1	EXIST::FUNCTION:EC


### PR DESCRIPTION
If public key is missing in input file, it was also missing in output file even if no_public was not given.