### PR TITLE
Fix ocsp app exit code

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -696,10 +696,8 @@ redo_accept:
     if (i != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
         BIO_printf(out, "Responder Error: %s (%d)\n",
                    OCSP_response_status_str(i), i);
-        if (!ignore_err) {
-                ret = 0;
+        if (!ignore_err)
                 goto end;
-        }
     }
 
     if (resp_text)


### PR DESCRIPTION
If we run the ocsp command line app and the responder returns a
non-successful status code then the app should exit with a failure code.

Based on an original patch by Tatsuhiro Tsujikawa.

Fixes #2387

