### PR TITLE
Fix ocsp app exit code (1.1.0/1.0.2)

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -639,7 +639,6 @@ int ocsp_main(int argc, char **argv)
                    OCSP_response_status_str(i), i);
         if (ignore_err)
             goto redo_accept;
-        ret = 0;
         goto end;
     }
 


### PR DESCRIPTION
If we run the ocsp command line app and the responder returns a
non-successful status code then the app should exit with a failure code.

Based on an original patch by Tatsuhiro Tsujikawa.

Fixes #2387

This is the 1.1.0/1.0.2 version of #5998.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
