### PR TITLE
Don't crash if there are no trusted certs

### DIFF
--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -138,6 +138,43 @@ static int test_alt_chains_cert_forgery(void)
     return ret;
 }
 
+static int test_store_ctx(void)
+{
+    X509_STORE_CTX *sctx = NULL;
+    X509 *x = NULL;
+    BIO *bio = NULL;
+    int testresult = 0, ret;
+
+    bio = BIO_new_file(bad_f, "r");
+    if (bio == NULL)
+        goto err;
+
+    x = PEM_read_bio_X509(bio, NULL, 0, NULL);
+    if (x == NULL)
+        goto err;
+
+    sctx = X509_STORE_CTX_new();
+    if (sctx == NULL)
+        goto err;
+
+    if (!X509_STORE_CTX_init(sctx, NULL, x, NULL))
+        goto err;
+
+    /* Verifying a cert where we have no trusted certs should fail */
+    ret = X509_verify_cert(sctx);
+
+    if (ret == 0) {
+        /* This is the result we were expecting: Test passed */
+        testresult = 1;
+    }
+
+ err:
+    X509_STORE_CTX_free(sctx);
+    X509_free(x);
+    BIO_free(bio);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(roots_f = test_get_argument(0))
@@ -148,5 +185,6 @@ int setup_tests(void)
     }
 
     ADD_TEST(test_alt_chains_cert_forgery);
+    ADD_TEST(test_store_ctx);
     return 1;
 }


### PR DESCRIPTION
The X509_STORE_CTX_init() docs explicitly allow a NULL parameter for the X509_STORE. Therefore we shouldn't crash if we subsequently call X509_verify_cert() and no X509_STORE has been set.
    
Fixes #2462

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
