### PR TITLE
Don't crash if there are no trusted certs (1.1.0)

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -265,6 +265,9 @@ int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, X509_LOOKUP_TYPE type,
     X509_OBJECT stmp, *tmp;
     int i, j;
 
+    if (ctx == NULL)
+        return 0;
+
     CRYPTO_THREAD_write_lock(ctx->lock);
     tmp = X509_OBJECT_retrieve_by_subject(ctx->objs, type, name);
     CRYPTO_THREAD_unlock(ctx->lock);
@@ -489,6 +492,9 @@ STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *ctx, X509_NAME *nm)
     X509 *x;
     X509_OBJECT *obj;
 
+    if (ctx->ctx == NULL)
+        return NULL;
+
     CRYPTO_THREAD_write_lock(ctx->ctx->lock);
     idx = x509_object_idx_cnt(ctx->ctx->objs, X509_LU_X509, nm, &cnt);
     if (idx < 0) {
@@ -538,8 +544,10 @@ STACK_OF(X509_CRL) *X509_STORE_CTX_get1_crls(X509_STORE_CTX *ctx, X509_NAME *nm)
     X509_OBJECT *obj, *xobj = X509_OBJECT_new();
 
     /* Always do lookup to possibly add new CRLs to cache */
-    if (sk == NULL || xobj == NULL ||
-            !X509_STORE_CTX_get_by_subject(ctx, X509_LU_CRL, nm, xobj)) {
+    if (sk == NULL
+            || xobj == NULL
+            || ctx->ctx == NULL
+            || !X509_STORE_CTX_get_by_subject(ctx, X509_LU_CRL, nm, xobj)) {
         X509_OBJECT_free(xobj);
         sk_X509_CRL_free(sk);
         return NULL;
@@ -632,6 +640,9 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x)
         }
     }
     X509_OBJECT_free(obj);
+
+    if (ctx->ctx == NULL)
+        return 0;
 
     /* Else find index of first cert accepted by 'check_issued' */
     ret = 0;

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -137,6 +137,43 @@ static int test_alt_chains_cert_forgery(const char *roots_f,
     return ret;
 }
 
+static int test_store_ctx(const char *bad_f)
+{
+    X509_STORE_CTX *sctx = NULL;
+    X509 *x = NULL;
+    BIO *bio = NULL;
+    int testresult = 0, ret;
+
+    bio = BIO_new_file(bad_f, "r");
+    if (bio == NULL)
+        goto err;
+
+    x = PEM_read_bio_X509(bio, NULL, 0, NULL);
+    if (x == NULL)
+        goto err;
+
+    sctx = X509_STORE_CTX_new();
+    if (sctx == NULL)
+        goto err;
+
+    if (!X509_STORE_CTX_init(sctx, NULL, x, NULL))
+        goto err;
+
+    /* Verifying a cert where we have no trusted certs should fail */
+    ret = X509_verify_cert(sctx);
+
+    if (ret == 0) {
+        /* This is the result we were expecting: Test passed */
+        testresult = 1;
+    }
+
+ err:
+    X509_STORE_CTX_free(sctx);
+    X509_free(x);
+    BIO_free(bio);
+    return testresult;
+}
+
 int main(int argc, char **argv)
 {
     CRYPTO_set_mem_debug(1);
@@ -149,6 +186,11 @@ int main(int argc, char **argv)
 
     if (!test_alt_chains_cert_forgery(argv[1], argv[2], argv[3])) {
         fprintf(stderr, "Test alt chains cert forgery failed\n");
+        return 1;
+    }
+
+    if (!test_store_ctx(argv[3])) {
+        fprintf(stderr, "Test X509_STORE_CTX failed\n");
         return 1;
     }
 


### PR DESCRIPTION
The X509_STORE_CTX_init() docs explicitly allow a NULL parameter for the X509_STORE. Therefore we shouldn't crash if we subsequently call X509_verify_cert() and no X509_STORE has been set.

Fixes #2462

This is the 1.1.0 version of #6001

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
