### PR TITLE
Add missing index_index() when reloading OCSP responder

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1597,6 +1597,9 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     return retdb;
 }
 
+/*
+ * Returns > 0 on success, <= 0 on error
+ */
 int index_index(CA_DB *db)
 {
     if (!TXT_DB_create_index(db->db, DB_serial, NULL,

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -498,7 +498,7 @@ end_of_options:
         if (db == NULL)
             goto end;
 
-        if (!index_index(db))
+        if (index_index(db) <= 0)
             goto end;
 
         if (get_certificate_status(ser_status, db) != 1)
@@ -672,7 +672,7 @@ end_of_options:
         BIO_printf(bio_err, "generating index\n");
     }
 
-    if (!index_index(db))
+    if (index_index(db) <= 0)
         goto end;
 
     /*****************************************************************/

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -586,6 +586,7 @@ redo_accept:
                 free_index(rdb);
                 rdb = newrdb;
             } else {
+                free_index(newrdb);
                 log_message(LOG_ERR, "error reloading updated index: %s",
                             ridx_filename);
             }

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -559,7 +559,7 @@ int ocsp_main(int argc, char **argv)
 
     if (ridx_filename != NULL) {
         rdb = load_index(ridx_filename, NULL);
-        if (rdb == NULL || !index_index(rdb)) {
+        if (rdb == NULL || index_index(rdb) <= 0) {
             ret = 1;
             goto end;
         }
@@ -582,7 +582,7 @@ redo_accept:
         if (index_changed(rdb)) {
             CA_DB *newrdb = load_index(ridx_filename, NULL);
 
-            if (newrdb != NULL) {
+            if (newrdb != NULL && index_index(newrdb) > 0) {
                 free_index(rdb);
                 rdb = newrdb;
             } else {


### PR DESCRIPTION
Also, future-proof index_index() return codes by requiring success to return a positive value.