### PR TITLE
Support parallel builds with MSVC

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1241,10 +1241,10 @@ my %targets = (
                                 "UNICODE", "_UNICODE",
                                 "_CRT_SECURE_NO_DEPRECATE",
                                 "_WINSOCK_DEPRECATED_NO_WARNINGS"),
-        lib_cflags       => add("/Zi /Fdossl_static.pdb"),
+        lib_cflags       => add("/Zi /FS /Fdossl_static.pdb"),
         lib_defines      => add("L_ENDIAN"),
-        dso_cflags       => "/Zi /Fddso.pdb",
-        bin_cflags       => "/Zi /Fdapp.pdb",
+        dso_cflags       => "/Zi /FS /Fddso.pdb",
+        bin_cflags       => "/Zi /FS /Fdapp.pdb",
         shared_ldflag    => "/dll",
         shared_target    => "win-shared", # meaningless except it gives Configure a hint
         thread_scheme    => "winthreads",


### PR DESCRIPTION
Jom is an nmake clone that allows parallel builds.  To support that,
we need to make sure updates of the PDB files are serialized, or there
will be errors.

Fixes #3272

-----

I'll make a separate PR for 1.1.0