### PR TITLE
Support parallel builds with MSVC [1.1.0]

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1272,9 +1272,9 @@ sub vms_info {
                                       return [ @defs ];
                                     }),
         coutflag         => "/Fo",
-        lib_cflags       => add("/Zi /Fdossl_static"),
-        dso_cflags       => "/Zi /Fddso",
-        bin_cflags       => "/Zi /Fdapp",
+        lib_cflags       => add("/Zi /FS /Fdossl_static"),
+        dso_cflags       => "/Zi /FS /Fddso",
+        bin_cflags       => "/Zi /FS /Fdapp",
         lflags           => add("/debug"),
         shared_ldflag    => "/dll",
         shared_target    => "win-shared", # meaningless except it gives Configure a hint


### PR DESCRIPTION
Jom is an nmake clone that allows parallel builds.  To support that,
we need to make sure updates of the PDB files are serialized, or there
will be errors.

Fixes #3272
