### PR TITLE
Don't distribute team internal config targets [1.1.0]

### DIFF
--- a/Configurations/90-team.norelease.conf
+++ b/Configurations/90-team.norelease.conf
@@ -76,11 +76,6 @@
         shared_cflag     => "-fPIC",
         shared_extension => ".so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
     },
-    "dist" => {
-        cc               => "cc",
-        cflags           => "-O",
-        thread_scheme    => "(unknown)",
-    },
     "debug-test-64-clang" => {
         inherit_from     => [ "x86_64_asm" ],
         cc               => "clang",

--- a/Configurations/dist.conf
+++ b/Configurations/dist.conf
@@ -1,0 +1,12 @@
+## -*- mode: perl; -*-
+## Build configuration targets for openssl-team members
+
+# This is to support 'make dist'
+%targets = (
+    "dist" => {
+        inherit_from     => [ 'BASE_unix' ],
+        cc               => "cc",
+        cflags           => "-O",
+        thread_scheme    => "(unknown)",
+    },
+);

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -664,8 +664,10 @@ tar:
 	DISTDIR=$(NAME); \
 	mkdir -p $$TMPDIR/$$DISTDIR; \
 	(cd $(SRCDIR); \
+	 excl_re="^(fuzz/corpora|Configurations/.*\.norelease\.conf)"; \
+	 echo "$$excl_re"; \
 	 git ls-tree -r --name-only --full-tree HEAD \
-         | grep -v '^fuzz/corpora' \
+	 | egrep -v "$$excl_re" \
 	 | while read F; do \
 	       mkdir -p $$TMPDIR/$$DISTDIR/`dirname $$F`; \
 	       cp $$F $$TMPDIR/$$DISTDIR/$$F; \


### PR DESCRIPTION
Configurations/90-team.conf isn't for public consumption, so we rename
it to 90-team.norelease.conf and make sure 'make dist' and 'make tar'
don't include it in the tarball.

-----

This is the backport of #5836 to 1.1.0