### PR TITLE
Fix fibre stack to prevent memory corruption if stack overflows.

### DIFF
--- a/crypto/async/arch/async_posix.c
+++ b/crypto/async/arch/async_posix.c
@@ -13,9 +13,14 @@
 #ifdef ASYNC_POSIX
 
 # include <stddef.h>
+# include <string.h>
 # include <unistd.h>
+# include <sys/mman.h>
 
-#define STACKSIZE       32768
+# define STACKSIZE     32768
+# ifndef PAGE_SIZE
+#  define PAGE_SIZE    4096
+# endif
 
 int ASYNC_is_capable(void)
 {
@@ -34,25 +39,98 @@ void async_local_cleanup(void)
 
 int async_fibre_makecontext(async_fibre *fibre)
 {
+    size_t pagesize;
+    size_t stackallocsize;
+    size_t stacksize = STACKSIZE;
+    char *stackallocaddr = NULL;
+
+# if defined(_SC_PAGE_SIZE) || defined (_SC_PAGESIZE)
+    {
+#  if defined(_SC_PAGE_SIZE)
+        long tmppgsize = sysconf(_SC_PAGE_SIZE);
+#  else
+        long tmppgsize = sysconf(_SC_PAGESIZE);
+#  endif
+        if (tmppgsize < 1)
+            pagesize = PAGE_SIZE;
+        else
+            pagesize = (size_t)tmppgsize;
+    }
+# else
+    pagesize = PAGE_SIZE;
+# endif
+    if (pagesize > stacksize)
+        stacksize = pagesize;
+
+    stackallocsize = stacksize + 2 * pagesize;
+
     fibre->env_init = 0;
     if (getcontext(&fibre->fibre) == 0) {
-        fibre->fibre.uc_stack.ss_sp = OPENSSL_malloc(STACKSIZE);
-        if (fibre->fibre.uc_stack.ss_sp != NULL) {
-            fibre->fibre.uc_stack.ss_size = STACKSIZE;
+        if (posix_memalign((void **)&stackallocaddr,
+                           pagesize,
+                           stackallocsize) == 0) {
+            fibre->fibre.uc_stack.ss_sp = stackallocaddr + pagesize;
+            fibre->fibre.uc_stack.ss_size = stacksize;
             fibre->fibre.uc_link = NULL;
+            /* Make a best effort to create guard pages, lock the
+               stack into memory and prevent it getting dumped
+               on a core dump. */
+            mprotect(stackallocaddr,
+                     pagesize,
+                     PROT_NONE);
+            mprotect(stackallocaddr + pagesize + stacksize,
+                     pagesize,
+                     PROT_NONE);
+            mlock(fibre->fibre.uc_stack.ss_sp, stacksize);
+# ifdef MADV_DONTDUMP
+            madvise(fibre->fibre.uc_stack.ss_sp, stacksize, MADV_DONTDUMP);
+# endif
             makecontext(&fibre->fibre, async_start_func, 0);
             return 1;
         }
-    } else {
-        fibre->fibre.uc_stack.ss_sp = NULL;
     }
+    fibre->fibre.uc_stack.ss_sp = NULL;
     return 0;
 }
 
 void async_fibre_free(async_fibre *fibre)
 {
-    OPENSSL_free(fibre->fibre.uc_stack.ss_sp);
-    fibre->fibre.uc_stack.ss_sp = NULL;
+    size_t pagesize;
+    size_t stacksize = fibre->fibre.uc_stack.ss_size;
+    char *stackallocaddr = NULL;
+
+# if defined(_SC_PAGE_SIZE) || defined (_SC_PAGESIZE)
+    {
+#  if defined(_SC_PAGE_SIZE)
+        long tmppgsize = sysconf(_SC_PAGE_SIZE);
+#  else
+        long tmppgsize = sysconf(_SC_PAGESIZE);
+#  endif
+        if (tmppgsize < 1)
+            pagesize = PAGE_SIZE;
+        else
+            pagesize = (size_t)tmppgsize;
+    }
+# else
+    pagesize = PAGE_SIZE;
+# endif
+
+    if (fibre->fibre.uc_stack.ss_sp) {
+        stackallocaddr = (char *)fibre->fibre.uc_stack.ss_sp - pagesize;
+        /* Make a best effort to reverse the stack setup and guard pages.
+           Purposely not checking return values as there is nothing we
+           can do if they fail. */
+        madvise(fibre->fibre.uc_stack.ss_sp, stacksize, MADV_NORMAL);
+        munlock(fibre->fibre.uc_stack.ss_sp, stacksize);
+        mprotect(stackallocaddr,
+                 pagesize,
+                 PROT_READ|PROT_WRITE);
+        mprotect(stackallocaddr + pagesize + stacksize,
+                 pagesize,
+                 PROT_READ|PROT_WRITE);
+        free(stackallocaddr);
+        fibre->fibre.uc_stack.ss_sp = NULL;
+    }
 }
 
 #endif


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
This pull request is a fix for the fact there is nothing to catch fibre stack overflows when running OpenSSL with the asynchronous jobs feature. Currently in the posix implementation each job(fibre) is allocated a stack of a fixed size of 32KB, if this is exceeded then memory corruption occurs leading to strange behaviour and/or crashing in an unrelated part of the code. This fix adds guard pages around the stack so that an obvious seg fault will occur if the stack overflows. As part of this fix it is necessary to allocate on a page boundary. This fix also takes the opportunity to lock the fibre stack into memory to prevent it getting paged to disk and also disables dumping the fibre stack to a core dump for analysis like the secure heap code does.

I have some observations that people may want to comment on:

1) This fix will cause each async job (fibre) to use 2 additional pages of memory, is this additional memory footprint an issue for anyone?
2) Do we need a guard page at both ends of the stack? I implemented it this way because it is not easy to determine if you are running on a platform where the stack grows down or up, so it was safest to protect both ends. If it is okay to make an assumption that the stack will always grow downwards then I can remove one of the guard pages.
3) Is it acceptable to lock the stack into memory and disable it from being dumped to core dumps by default? Could it have a negative impact on debugging asynchronous functionality? Should there be a flag of some kind to allow a build with it disabled?  
4) At the moment the code does not check for failures when using mprotect to set the guard pages, when locking the stack into memory, and when disabling the stack from getting dumped on a core dump. Effectively it is making a best effort and continuing regardless. If people feel the success of those new operations should be mandatory to use async fibres then I can add checking. It also doesn't check them during cleanup, but by that point there is not much you can do if they fail anyway apart from assert or something.
5) This fix does not add the ability for the stack to grow/shrink dynamically, it would require a much bigger change to achieve that and I think that would be considered a new feature rather than a bug fix.
6) This does not change the behaviour of the windows implementation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

