### PR TITLE
 Make sure SSL_in_init() returns 0 at SSL_CB_HANDSHAKE_DONE

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1090,13 +1090,18 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs, int stop)
     else if (s->ctx->info_callback != NULL)
         cb = s->ctx->info_callback;
 
+    /* The callback may expect us to not be in init at handshake done */
+    ossl_statem_set_in_init(s, 0);
+
     if (cb != NULL)
         cb(s, SSL_CB_HANDSHAKE_DONE, 1);
 
-    if (!stop)
+    if (!stop) {
+        /* If we've got more work to do we go back into init */
+        ossl_statem_set_in_init(s, 1);
         return WORK_FINISHED_CONTINUE;
+    }
 
-    ossl_statem_set_in_init(s, 0);
     return WORK_FINISHED_STOP;
 }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4269,6 +4269,12 @@ static void sslapi_info_callback(const SSL *s, int where, int ret)
         info_cb_failed = 1;
         return;
     }
+
+    /* Check that, if we've got SSL_CB_HANDSHAKE_DONE we are not in init */
+    if ((where & SSL_CB_HANDSHAKE_DONE) && SSL_in_init((SSL *)s) != 0) {
+        info_cb_failed = 1;
+        return;
+    }
 }
 
 /*


### PR DESCRIPTION
In 1.1.0 and before calling SSL_in_init() from the info_callback
at SSL_CB_HANDSHAKE_DONE would return 0. This commit Fixes it so
that it does again for 1.1.1. This broke Node.

Fixes #4574

