### PR TITLE
test/recipes/15-test_out_option.t: add further tests

### DIFF
--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -61,7 +61,7 @@ push @success_paths, $tempfile;
 # we don't have write permission to.
 push @failure_paths, File::Spec->catfile($tempdir, "unwritable.pem");
 
-plan tests => 2 * scalar @failure_paths + scalar @success_paths;
+plan tests => (2 * scalar @failure_paths) + scalar @success_paths;
 
 test_illegal_path($_) foreach @failure_paths;
 test_legal_path($_) foreach @success_paths;

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -37,11 +37,11 @@ $rand_path .= "/test.pem";
 
 push @failure_paths, $rand_path;
 
-# Specifically for mingw, the NULL device might not be what's expected.
-# For example, if cross compiled and tested on the build host, perl will
-# generate an incorrect NULL device name.
-# We might expand the exceptions...
-unless (config('target') =~ m|^mingw| && $^O ne 'msys') {
+# All explicit cross compilations run a risk of failing this, because the
+# null device provided by perl might not match what the cross compiled
+# application expects to see as a null device.  Therefore, we skip the check
+# of outputing to the null device if the cross compile prefix is set.
+if ((config('CROSS_COMPILE') // '') eq '') {
     # Check that we can write to the NULL device
     push @success_paths, File::Spec->devnull();
 }

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -50,12 +50,12 @@ plan tests => scalar @failure_paths + scalar @success_paths;
 
 foreach (@failure_paths) {
     my $path = File::Spec->canonpath($_);
-    ok(!run(app([ 'openssl', 'genrsa', '-out', $path, '2048'])),
+    ok(!run(app([ 'openssl', 'rand', '-out', $path, '1'])),
        "invalid output path: $path");
 }
 foreach (@success_paths) {
     my $path = File::Spec->canonpath($_);
-    ok(run(app([ 'openssl', 'genrsa', '-out', $path, '2048'])),
+    ok(run(app([ 'openssl', 'rand', '-out', $path, '1'])),
        "valid output path: $path");
 }
 

--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -54,15 +54,17 @@ unless (config('target') =~ m|^mingw| && $^O ne 'msys') {
     push @success_paths, File::Spec->devnull();
 }
 
+my $tempdir;
+my $tempfile;
 # chmod doesn't seem to work as expected in Windows Command prompt,
 # so these test are meaningless in that environment (for example,
 # "unwritable.pem" turns out to be writable...
 unless ($^O eq 'MSWin32') {
     # Check that we can write to a file that we have write permission to
     # in a directory that we don't have write permission to.
-    my $tempdir = File::Spec->catdir('.', "test_out_option-nowrite-$$");
+    $tempdir = File::Spec->catdir('.', "test_out_option-nowrite-$$");
     mkdir $tempdir or die "Trying to create $tempdir: $!\n";
-    my $tempfile = File::Spec->catfile($tempdir, "writable.pem");
+    $tempfile = File::Spec->catfile($tempdir, "writable.pem");
     open my $fh, ">", $tempfile or die "Trying to create $tempfile: $!\n";
     chmod 0555, $tempdir;
     push @success_paths, $tempfile;
@@ -78,7 +80,7 @@ test_illegal_path($_) foreach @failure_paths;
 test_legal_path($_) foreach @success_paths;
 
 END {
-    if (-d $tempdir) {
+    if (defined $tempdir && -d $tempdir) {
         chmod 0755, $tempdir;
         unlink $tempfile if -f $tempfile;
         rmdir $tempdir;


### PR DESCRIPTION
Test writing to the null device.  This should be successful.
Test writing to a writable file in a write protected directory.  This
should be successful.

Also, refactor so the planned number of tests is calculated.

[extended tests]

-----

The only reason for WIP is the controversy of devnull() on some platforms or cross compilations.  I want to have a closer look at what's actually affected.