### PR TITLE
WIP: Avoid external config files during tests

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -430,6 +430,7 @@ test : tests
         DEFINE BLDTOP {- builddir() -}
         DEFINE RESULT_D {- builddir(qw(test test-runs)) -}
         DEFINE OPENSSL_ENGINES {- builddir("engines") -}
+        DEFINE OPENSSL_CONF {- sourcefile("test", "defaults.cnf") -}
         DEFINE OPENSSL_DEBUG_MEMORY "on"
         IF "$(VERBOSE)" .NES. "" THEN DEFINE VERBOSE "$(VERBOSE)"
         $(PERL) {- sourcefile("test", "run_tests.pl") -} $(TESTS)

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -370,6 +370,7 @@ test: tests
 	  PERL="$(PERL)" \
 	  EXE_EXT={- $exeext -} \
 	  OPENSSL_ENGINES=`cd ../$(BLDDIR)/engines; pwd` \
+	  OPENSSL_CONF=`cd ../$(SRCDIR)/test; pwd`/defaults.cnf \
 	  OPENSSL_DEBUG_MEMORY=on \
 	    $(PERL) ../$(SRCDIR)/test/run_tests.pl $(TESTS) )
 	@ : {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -334,6 +334,7 @@ test: tests
 	set RESULT_D=$(BLDDIR)\test\test-runs
 	set PERL=$(PERL)
 	set OPENSSL_ENGINES=$(MAKEDIR)\engines
+	set TMPCUR=%CD% & cd $(SRCDIR)\test & set OPENSSL_CONF=%CD%\defaults.cnf & cd %TMPCUR%
 	set OPENSSL_DEBUG_MEMORY=on
 	"$(PERL)" "$(SRCDIR)\test\run_tests.pl" $(TESTS)
 	@rem {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}

--- a/test/defaults.cnf
+++ b/test/defaults.cnf
@@ -1,0 +1,7 @@
+#
+# Test defaults config file
+# This literally forces openssl, libcrypto and libssl to run with built in
+# defaults
+#
+
+RANDFILE		= ./.rnd


### PR DESCRIPTION
The tests might pick up an openssl.cnf from default locations.  To
avoid that, we force the use of a test default that contains nothing
(i.e. forces OpenSSL to run with build in values)

Fixes #6046
