### PR TITLE
Fix openssl ca, to correctly make output file binary when using -spkac

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -726,7 +726,6 @@ end_of_options:
             output_der = 1;
             batch = 1;
         }
-        /* FIXME: Is it really always text? */
         Sout = bio_open_default(outfile, 'w',
                                 output_der ? FORMAT_ASN1 : FORMAT_TEXT);
         if (Sout == NULL)

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -722,8 +722,13 @@ end_of_options:
 
     /*****************************************************************/
     if (req || gencrl) {
+        if (spkac_file != NULL) {
+            output_der = 1;
+            batch = 1;
+        }
         /* FIXME: Is it really always text? */
-        Sout = bio_open_default(outfile, 'w', FORMAT_TEXT);
+        Sout = bio_open_default(outfile, 'w',
+                                output_der ? FORMAT_ASN1 : FORMAT_TEXT);
         if (Sout == NULL)
             goto end;
     }
@@ -876,10 +881,6 @@ end_of_options:
                 if (!sk_X509_push(cert_sk, x)) {
                     BIO_printf(bio_err, "Memory allocation failure\n");
                     goto end;
-                }
-                if (outfile) {
-                    output_der = 1;
-                    batch = 1;
                 }
             }
         }


### PR DESCRIPTION
On Unix, this doesn't matter, but on other platforms, it may.
