### PR TITLE
Allow intermediate CAs to use RSA PSS in 1.1.0

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3265,6 +3265,10 @@ static int check_sig_level(X509_STORE_CTX *ctx, X509 *cert)
     if (level > NUM_AUTH_LEVELS)
         level = NUM_AUTH_LEVELS;
 
+    /* We are not able to look up the CA MD for RSA PSS in this version */
+    if (nid == NID_rsassaPss)
+        return 1;
+
     /* Lookup signature algorithm digest */
     if (nid && OBJ_find_sigid_algs(nid, &mdnid, NULL)) {
         const EVP_MD *md;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -4188,6 +4188,9 @@ static int ssl_security_cert_sig(SSL *s, SSL_CTX *ctx, X509 *x, int op)
     if ((X509_get_extension_flags(x) & EXFLAG_SS) != 0)
         return 1;
     sig_nid = X509_get_signature_nid(x);
+    /* We are not able to look up the CA MD for RSA PSS in this version */
+    if (sig_nid == NID_rsassaPss)
+        return 1;
     if (sig_nid && OBJ_find_sigid_algs(sig_nid, &md_nid, NULL)) {
         const EVP_MD *md;
         if (md_nid && (md = EVP_get_digestbynid(md_nid)))


### PR DESCRIPTION
In 1.1.0 and above we check the digest algorithm used to create signatures
in intermediate CA certs. If it is not sufficiently strong then we reject
the cert. To work out what digest was used we look at the OID for the
signature. This works for most signatures, but not for RSA PSS where the
digest is stored as parameter of the SignatureAlgorithmIdentifier. This
results in the digest look up routines failing and the cert being rejected.

PR #3301 added support for doing this properly in master. So in that
branch this all works as expected. It also works properly in 1.0.2 where we
don't have the digest checks at all. So the only branch where this fails is
1.1.0.

PR #3301 seems too significant to backport to 1.1.0. Instead we simply skip
the signature digest algorithm strength checks if we detect RSA PSS.

Fixes #3558.
