### PR TITLE
Document when a session gets removed from cache

### DIFF
--- a/doc/man3/SSL_get_session.pod
+++ b/doc/man3/SSL_get_session.pod
@@ -48,6 +48,11 @@ SSL_SESSION object that cannot be used for resumption in TLSv1.3. It also
 enables applications to obtain information about all sessions sent by the
 server.
 
+A session will be automatically removed from the session cache and marked as
+non-resumable if the connection is not closed down cleanly, e.g. if a fatal
+error occurs on the connection or L<SSL_shutdown(3)> is not called prior to
+L<SSL_free(3)>.
+
 In TLSv1.3 it is recommended that each SSL_SESSION object is only used for
 resumption once.
 


### PR DESCRIPTION
Document the fact that if a session is not closed down cleanly then the
session gets removed from the cache and marked as non-resumable.

Fixes #4720

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
