### PR TITLE
Document when a session gets removed from cache (1.1.0/1.0.2)

### DIFF
--- a/doc/ssl/SSL_get_session.pod
+++ b/doc/ssl/SSL_get_session.pod
@@ -28,6 +28,11 @@ count of the B<SSL_SESSION> is incremented by one.
 The ssl session contains all information required to re-establish the
 connection without a new handshake.
 
+A session will be automatically removed from the session cache and marked as
+non-resumable if the connection is not closed down cleanly, e.g. if a fatal
+error occurs on the connection or L<SSL_shutdown(3)> is not called prior to
+L<SSL_free(3)>.
+
 SSL_get0_session() returns a pointer to the actual session. As the
 reference counter is not incremented, the pointer is only valid while
 the connection is in use. If L<SSL_clear(3)> or


### PR DESCRIPTION
Document the fact that if a session is not closed down cleanly then the
session gets removed from the cache and marked as non-resumable.

Fixes #4720

This is the 1.1.0/1.0.2 version of #6053.

