### PR TITLE
Allow TLSv1.3 EC certs to use uncompressed points

### DIFF
--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -971,7 +971,11 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-28]
-ExpectedResult = ServerFail
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
 
 
 # ===========================================================

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -511,7 +511,11 @@ my @tests_tls_1_3 = (
             "SignatureAlgorithms" => "ECDSA+SHA256",
         },
         test   => {
-            "ExpectedResult" => "ServerFail"
+            "ExpectedServerCertType" => "P-256",
+            "ExpectedServerSignHash" => "SHA256",
+            "ExpectedServerSignType" => "EC",
+            "ExpectedServerCANames" => "empty",
+            "ExpectedResult" => "Success"
         },
     },
     {


### PR DESCRIPTION
The spec does not prohib certs form using compressed points. It only
requires that points in a key share are uncompressed. It says nothing
about point compression for certs, so we should not fail if a cert uses a
compressed point.

Fixes #5743

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
