### PR TITLE
Don't build AFALG on android

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -132,6 +132,7 @@ my %targets = (
         cxxflags         => add(sub { android_ndk()->{cflags} }),
         bn_ops           => sub { android_ndk()->{bn_ops} },
         bin_cflags       => "-pie",
+        enable           => [ ],
     },
     "android-arm" => {
         ################################################################


### PR DESCRIPTION
This didn't get built anyway for gcc because it was detected as a cross
compile. But it did get built for clang - even though this is still a cross
compile build. This disables it in all cases for Android.

Fixes #5748