### PR TITLE
Fix documentation for the -showcerts s_client option (1.0.2)

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -337,7 +337,7 @@ static void sc_usage(void)
     BIO_printf(bio_err,
                " -prexit       - print session information even on connection failure\n");
     BIO_printf(bio_err,
-               " -showcerts    - show all certificates in the chain\n");
+               " -showcerts    - Show all certificates sent by the server\n");
     BIO_printf(bio_err, " -debug        - extra output\n");
 #ifdef WATT32
     BIO_printf(bio_err, " -wdebug       - WATT-32 tcp debugging\n");

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -141,8 +141,9 @@ pauses 1 second between each read and write call.
 
 =item B<-showcerts>
 
-display the whole server certificate chain: normally only the server
-certificate itself is displayed.
+Displays the server certificate chain as sent by the server: it only consists of
+certificates the server has sent (in the order the server has sent them). It is
+B<not> a verified chain.
 
 =item B<-prexit>
 
@@ -354,7 +355,8 @@ a client certificate. Therefor merely including a client certificate
 on the command line is no guarantee that the certificate works.
 
 If there are problems verifying a server certificate then the
-B<-showcerts> option can be used to show the whole chain.
+B<-showcerts> option can be used to show all the certificates sent by the
+server.
 
 Since the SSLv23 client hello cannot include compression methods or extensions
 these will only be supported if its use is disabled, for example by using the


### PR DESCRIPTION
This option shows the certificates as sent by the server. It is not the
full verified chain.

Fixes #4933

This is the 1.0.2 version of #6067.
