### PR TITLE
Fix older Mac build that still use makedepend [1.0.2]

### DIFF
--- a/Configure
+++ b/Configure
@@ -1671,6 +1671,13 @@ while (<PIPE>) {
 }
 close(PIPE);
 
+# Xcode did not handle $cc -M before clang support
+my $cc_as_makedepend = 0;
+if ($predefined{__GNUC__} >= 3 && !(defined($predefined{__APPLE_CC__})
+                                    && !defined($predefined{__clang__}))) {
+  $cc_as_makedepend = 1;
+}
+
 if ($strict_warnings)
 	{
 	my $wopt;
@@ -1730,14 +1737,14 @@ while (<IN>)
 		s/^NM=\s*/NM= \$\(CROSS_COMPILE\)/;
 		s/^RANLIB=\s*/RANLIB= \$\(CROSS_COMPILE\)/;
 		s/^RC=\s*/RC= \$\(CROSS_COMPILE\)/;
-		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= \$\(CROSS_COMPILE\)$cc/ if $predefined{__GNUC__} >= 3;
+		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= \$\(CROSS_COMPILE\)$cc/ if $cc_as_makedepend;
 		}
 	else	{
 		s/^CC=.*$/CC= $cc/;
 		s/^AR=\s*ar/AR= $ar/;
 		s/^RANLIB=.*/RANLIB= $ranlib/;
 		s/^RC=.*/RC= $windres/;
-		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $predefined{__GNUC__} >= 3;
+		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $cc_as_makedepend;
 		}
 	s/^CFLAG=.*$/CFLAG= $cflags/;
 	s/^DEPFLAG=.*$/DEPFLAG=$depflags/;


### PR DESCRIPTION
Fixes an issue with PR #4755.

Xcode on Mac OS X 10.7 and earlier still uses `makedepend`, its C compiler does not support the `-M` option.
This was fixed with Xcode on Mac OS X 10.8, which added the capability to do `cc -M`.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
