### PR TITLE
ms/uplink-x86.pl: close the file handle that was opened

### DIFF
--- a/ms/uplink-x86.pl
+++ b/ms/uplink-x86.pl
@@ -41,4 +41,4 @@ for ($i=1;$i<=$N;$i++) {
 }
 &asm_finish();
 
-close OUTPUT;
+close STDOUT;


### PR DESCRIPTION
Fixes #5656
