### PR TITLE
PEM_def_callback(): don't loop because of too short password given

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -44,28 +44,19 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
     if (prompt == NULL)
         prompt = "Enter PEM pass phrase:";
 
-    for (;;) {
-        /*
-         * We assume that w == 0 means decryption,
-         * while w == 1 means encryption
-         */
-        int min_len = w ? MIN_LENGTH : 0;
+    /*
+     * We assume that w == 0 means decryption,
+     * while w == 1 means encryption
+     */
+    int min_len = w ? MIN_LENGTH : 0;
 
-        i = EVP_read_pw_string_min(buf, min_len, num, prompt, w);
-        if (i != 0) {
-            PEMerr(PEM_F_PEM_DEF_CALLBACK, PEM_R_PROBLEMS_GETTING_PASSWORD);
-            memset(buf, 0, (unsigned int)num);
-            return -1;
-        }
-        j = strlen(buf);
-        if (min_len && j < min_len) {
-            fprintf(stderr,
-                    "phrase is too short, needs to be at least %d chars\n",
-                    min_len);
-        } else
-            break;
+    i = EVP_read_pw_string_min(buf, min_len, num, prompt, w);
+    if (i != 0) {
+        PEMerr(PEM_F_PEM_DEF_CALLBACK, PEM_R_PROBLEMS_GETTING_PASSWORD);
+        memset(buf, 0, (unsigned int)num);
+        return -1;
     }
-    return j;
+    return strlen(buf);
 }
 
 void PEM_proc_type(char *buf, int type)

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -30,7 +30,7 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 int PEM_def_callback(char *buf, int num, int w, void *key)
 {
-    int i, j;
+    int i;
     const char *prompt;
 
     if (key) {

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -30,7 +30,7 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 int PEM_def_callback(char *buf, int num, int w, void *key)
 {
-    int i;
+    int i, min_len;
     const char *prompt;
 
     if (key) {
@@ -48,7 +48,7 @@ int PEM_def_callback(char *buf, int num, int w, void *key)
      * We assume that w == 0 means decryption,
      * while w == 1 means encryption
      */
-    int min_len = w ? MIN_LENGTH : 0;
+    min_len = w ? MIN_LENGTH : 0;
 
     i = EVP_read_pw_string_min(buf, min_len, num, prompt, w);
     if (i != 0) {

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -280,7 +280,8 @@ int PEM_SignUpdate(EVP_MD_CTX *ctx, unsigned char *d, unsigned int cnt);
 int PEM_SignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
                   unsigned int *siglen, EVP_PKEY *pkey);
 
-int PEM_def_callback(char *buf, int num, int w, void *key);
+/* The default pem_password_cb that's used internally */
+int PEM_def_callback(char *buf, int num, int rwflag, void *userdata);
 void PEM_proc_type(char *buf, int type);
 void PEM_dek_info(char *buf, const char *type, int len, char *str);
 


### PR DESCRIPTION
That error is already caught by EVP_read_pw_string_min, and causes
this function to return -1, so the code detecting too short passwords
in this function is practically dead.

Fixes #5465
