### PR TITLE
Use get_last_sys_error() instead of get_last_rtl_error()

### DIFF
--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -308,7 +308,7 @@ int BIO_socket_nbio(int s, int mode)
 
     l = fcntl(s, F_GETFL, 0);
     if (l == -1) {
-        SYSerr(SYS_F_FCNTL, get_last_rtl_error());
+        SYSerr(SYS_F_FCNTL, get_last_sys_error());
         ret = -1;
     } else {
 #  if defined(O_NONBLOCK)
@@ -326,7 +326,7 @@ int BIO_socket_nbio(int s, int mode)
         ret = fcntl(s, F_SETFL, l);
 
         if (ret < 0) {
-            SYSerr(SYS_F_FCNTL, get_last_rtl_error());
+            SYSerr(SYS_F_FCNTL, get_last_sys_error());
         }
     }
 # else


### PR DESCRIPTION
get_last_sys_error() already exists, so there's no need for yet
another macro that fulfills the same purpose.

Fixes #4120
