### PR TITLE
Update the *use_certificate* docs (1.1.0/1.0.2)

### DIFF
--- a/doc/ssl/SSL_CTX_use_certificate.pod
+++ b/doc/ssl/SSL_CTX_use_certificate.pod
@@ -153,6 +153,13 @@ L<SSL_CTX_set_default_passwd_cb(3)>.
 of view, it however does not make sense as the data in the certificate
 is considered public anyway.)
 
+All of the functions to set a new certificate will replace any existing
+certificate of the same type that has already been set. Similarly all of the
+functions to set a new private key will replace any private key that has already
+been set. Applications should call L<SSL_CTX_check_private_key(3)> or
+L<SSL_check_private_key(3)> as appropriate after loading a new certificate and
+private key to confirm that the certificate and key match.
+
 =head1 RETURN VALUES
 
 On success, the functions return 1.


### PR DESCRIPTION
Note that calling the *use_certificate* functions will replace any existing
certificate of the same type. The same thing applies for private keys.

Fixes #2147

This is the 1.1.0/1.0.2 version of #6092.
