### PR TITLE
Fix mixed indentation (and other whitespace issues)

### DIFF
--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -98,7 +98,7 @@ int spkac_main(int argc, char **argv)
         case OPT_KEYFORM:
             if (!opt_format(opt_arg(), OPT_FMT_ANY, &keyformat))
                 goto opthelp;
-	    break;
+            break;
         case OPT_CHALLENGE:
             challenge = opt_arg();
             break;

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -33,7 +33,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
     EVP_PKEY *ret = NULL;
 
     if (!PEM_bytes_read_bio_secmem(&data, &len, &nm, PEM_STRING_EVP_PKEY, bp,
-				   cb, u))
+                                   cb, u))
         return NULL;
     p = data;
 

--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -97,10 +97,10 @@ unsigned char *OPENSSL_utf82uni(const char *asc, int asclen,
          * decoding failure...
          */
         if (j < 0)
-	    return OPENSSL_asc2uni(asc, asclen, uni, unilen);
+            return OPENSSL_asc2uni(asc, asclen, uni, unilen);
 
         if (utf32chr > 0x10FFFF)        /* UTF-16 cap */
-	    return NULL;
+            return NULL;
 
         if (utf32chr >= 0x10000)        /* pair of UTF-16 characters */
             ulen += 2*2;

--- a/crypto/poly1305/poly1305_ieee754.c
+++ b/crypto/poly1305/poly1305_ieee754.c
@@ -20,30 +20,30 @@
  * for x86_64 code. And since we are at it, just for sense of it,
  * large-block performance in cycles per processed byte for *this* code
  * is:
- *			gcc-4.8		icc-15.0	clang-3.4(*)
+ *                      gcc-4.8         icc-15.0        clang-3.4(*)
  *
- * Westmere		4.96		5.09		4.37
- * Sandy Bridge		4.95		4.90		4.17
- * Haswell		4.92		4.87		3.78
- * Bulldozer		4.67		4.49		4.68
- * VIA Nano		7.07		7.05		5.98
- * Silvermont		10.6		9.61		12.6
+ * Westmere             4.96            5.09            4.37
+ * Sandy Bridge         4.95            4.90            4.17
+ * Haswell              4.92            4.87            3.78
+ * Bulldozer            4.67            4.49            4.68
+ * VIA Nano             7.07            7.05            5.98
+ * Silvermont           10.6            9.61            12.6
  *
- * (*)	clang managed to discover parallelism and deployed SIMD;
+ * (*)  clang managed to discover parallelism and deployed SIMD;
  *
  * And for range of other platforms with unspecified gcc versions:
  *
- * Freescale e300	12.5
- * PPC74x0		10.8
- * POWER6		4.92
- * POWER7		4.50
- * POWER8		4.10
+ * Freescale e300       12.5
+ * PPC74x0              10.8
+ * POWER6               4.92
+ * POWER7               4.50
+ * POWER8               4.10
  *
- * z10			11.2
- * z196+		7.30
+ * z10                  11.2
+ * z196+                7.30
  *
- * UltraSPARC III	16.0
- * SPARC T4		16.1
+ * UltraSPARC III       16.0
+ * SPARC T4             16.1
  */
 
 #if !(defined(__GNUC__) && __GNUC__>=2)
@@ -57,33 +57,33 @@ typedef unsigned int u32;
 typedef unsigned long long u64;
 typedef union { double d; u64 u; } elem64;
 
-#define TWO(p)		((double)(1ULL<<(p)))
-#define TWO0		TWO(0)
-#define TWO32		TWO(32)
-#define TWO64		(TWO32*TWO(32))
-#define TWO96		(TWO64*TWO(32))
-#define TWO130		(TWO96*TWO(34))
+#define TWO(p)          ((double)(1ULL<<(p)))
+#define TWO0            TWO(0)
+#define TWO32           TWO(32)
+#define TWO64           (TWO32*TWO(32))
+#define TWO96           (TWO64*TWO(32))
+#define TWO130          (TWO96*TWO(34))
 
-#define EXP(p)		((1023ULL+(p))<<52)
+#define EXP(p)          ((1023ULL+(p))<<52)
 
 #if defined(__x86_64__) || (defined(__PPC__) && defined(__LITTLE_ENDIAN__))
-# define U8TOU32(p)	(*(const u32 *)(p))
-# define U32TO8(p,v)	(*(u32 *)(p) = (v))
+# define U8TOU32(p)     (*(const u32 *)(p))
+# define U32TO8(p,v)    (*(u32 *)(p) = (v))
 #elif defined(__PPC__)
-# define U8TOU32(p)	({u32 ret; asm ("lwbrx	%0,0,%1":"=r"(ret):"b"(p)); ret; })
-# define U32TO8(p,v)	asm ("stwbrx %0,0,%1"::"r"(v),"b"(p):"memory")
+# define U8TOU32(p)     ({u32 ret; asm ("lwbrx	%0,0,%1":"=r"(ret):"b"(p)); ret; })
+# define U32TO8(p,v)    asm ("stwbrx %0,0,%1"::"r"(v),"b"(p):"memory")
 #elif defined(__s390x__)
-# define U8TOU32(p)	({u32 ret; asm ("lrv	%0,%1":"=d"(ret):"m"(*(u32 *)(p))); ret; })
-# define U32TO8(p,v)	asm ("strv	%1,%0":"=m"(*(u32 *)(p)):"d"(v))
+# define U8TOU32(p)     ({u32 ret; asm ("lrv	%0,%1":"=d"(ret):"m"(*(u32 *)(p))); ret; })
+# define U32TO8(p,v)    asm ("strv	%1,%0":"=m"(*(u32 *)(p)):"d"(v))
 #endif
 
 #ifndef U8TOU32
-# define U8TOU32(p)	((u32)(p)[0]     | (u32)(p)[1]<<8 | \
-			 (u32)(p)[2]<<16 | (u32)(p)[3]<<24  )
+# define U8TOU32(p)     ((u32)(p)[0]     | (u32)(p)[1]<<8 |     \
+                         (u32)(p)[2]<<16 | (u32)(p)[3]<<24  )
 #endif
 #ifndef U32TO8
-# define U32TO8(p,v)	((p)[0] = (u8)(v),       (p)[1] = (u8)((v)>>8), \
-			 (p)[2] = (u8)((v)>>16), (p)[3] = (u8)((v)>>24) )
+# define U32TO8(p,v)    ((p)[0] = (u8)(v),       (p)[1] = (u8)((v)>>8), \
+                         (p)[2] = (u8)((v)>>16), (p)[3] = (u8)((v)>>24) )
 #endif
 
 typedef struct {
@@ -359,9 +359,9 @@ void poly1305_blocks(void *ctx, const unsigned char *inp, size_t len,
 #ifndef __clang__
     fast_entry:
 #endif
-	/*
-	 * base 2^32 * base 2^16 = base 2^48
-	 */
+        /*
+         * base 2^32 * base 2^16 = base 2^48
+         */
         h0lo = s3lo * x1 + s2lo * x2 + s1lo * x3 + r0lo * x0;
         h1lo = r0lo * x1 + s3lo * x2 + s2lo * x3 + r1lo * x0;
         h2lo = r1lo * x1 + r0lo * x2 + s3lo * x3 + r2lo * x0;

--- a/engines/e_capi.c
+++ b/engines/e_capi.c
@@ -577,7 +577,7 @@ static int bind_helper(ENGINE *e, const char *id)
 }
 
 IMPLEMENT_DYNAMIC_CHECK_FN()
-    IMPLEMENT_DYNAMIC_BIND_FN(bind_helper)
+IMPLEMENT_DYNAMIC_BIND_FN(bind_helper)
 # else
 static ENGINE *engine_capi(void)
 {
@@ -835,7 +835,7 @@ int capi_rsa_sign(int dtype, const unsigned char *m, unsigned int m_len,
         CAPIerr(CAPI_F_CAPI_RSA_SIGN, CAPI_R_CANT_GET_KEY);
         return -1;
     }
-/* Convert the signature type to a CryptoAPI algorithm ID */
+    /* Convert the signature type to a CryptoAPI algorithm ID */
     switch (dtype) {
     case NID_sha256:
         alg = CALG_SHA_256;
@@ -870,13 +870,13 @@ int capi_rsa_sign(int dtype, const unsigned char *m, unsigned int m_len,
         }
     }
 
-/* Create the hash object */
+    /* Create the hash object */
     if (!CryptCreateHash(capi_key->hprov, alg, 0, 0, &hash)) {
         CAPIerr(CAPI_F_CAPI_RSA_SIGN, CAPI_R_CANT_CREATE_HASH_OBJECT);
         capi_addlasterror();
         return -1;
     }
-/* Set the hash value to the value passed */
+    /* Set the hash value to the value passed */
 
     if (!CryptSetHashParam(hash, HP_HASHVAL, (unsigned char *)m, 0)) {
         CAPIerr(CAPI_F_CAPI_RSA_SIGN, CAPI_R_CANT_SET_HASH_VALUE);
@@ -884,7 +884,7 @@ int capi_rsa_sign(int dtype, const unsigned char *m, unsigned int m_len,
         goto err;
     }
 
-/* Finally sign it */
+    /* Finally sign it */
     slen = RSA_size(rsa);
     if (!CryptSignHash(hash, capi_key->keyspec, NULL, 0, sigret, &slen)) {
         CAPIerr(CAPI_F_CAPI_RSA_SIGN, CAPI_R_ERROR_SIGNING_HASH);
@@ -1477,8 +1477,10 @@ static CAPI_KEY *capi_get_key(CAPI_CTX *ctx, const WCHAR *contname,
         ptype = PROV_RSA_AES;
     }
     if (ctx && ctx->debug_level >= CAPI_DBG_TRACE && ctx->debug_file) {
-        /* above 'if' is [complementary] copy from CAPI_trace and serves
-	 * as optimization to minimize [below] malloc-ations */
+        /*
+         * above 'if' is [complementary] copy from CAPI_trace and serves
+         * as optimization to minimize [below] malloc-ations
+         */
         char *_contname = wide_to_asc(contname);
         char *_provname = wide_to_asc(provname);
 

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -19,11 +19,11 @@ typedef struct {
 } ssl_trace_tbl;
 
 # define ssl_trace_str(val, tbl) \
-        do_ssl_trace_str(val, tbl, OSSL_NELEM(tbl))
+    do_ssl_trace_str(val, tbl, OSSL_NELEM(tbl))
 
 # define ssl_trace_list(bio, indent, msg, msglen, value, table) \
-        do_ssl_trace_list(bio, indent, msg, msglen, value, \
-         table, OSSL_NELEM(table))
+    do_ssl_trace_list(bio, indent, msg, msglen, value, \
+                      table, OSSL_NELEM(table))
 
 static const char *do_ssl_trace_str(int val, const ssl_trace_tbl *tbl,
                                     size_t ntbl)
@@ -1362,8 +1362,8 @@ static int ssl_print_ticket(BIO *bio, int indent, const SSL *ssl,
 
         if (msglen < 4)
             return 0;
-        ticket_age_add = (msg[0] << 24) | (msg[1] << 16) | (msg[2] << 8)
-                          | msg[3];
+        ticket_age_add =
+            (msg[0] << 24) | (msg[1] << 16) | (msg[2] << 8) | msg[3];
         msglen -= 4;
         msg += 4;
         BIO_indent(bio, indent + 2, 80);
@@ -1505,7 +1505,7 @@ void SSL_trace(int write_p, int version, int content_type,
 
             /* avoid overlapping with length at the end of buffer */
             if (msglen < (size_t)(SSL_IS_DTLS(ssl) ?
-	                 DTLS1_RT_HEADER_LENGTH : SSL3_RT_HEADER_LENGTH)) {
+                     DTLS1_RT_HEADER_LENGTH : SSL3_RT_HEADER_LENGTH)) {
                 BIO_puts(bio, write_p ? "Sent" : "Received");
                 ssl_print_hex(bio, 0, " too short message", msg, msglen);
                 break;


### PR DESCRIPTION
After stumbling over a mixed indentation in pkcs12/p12_utl.c, I searched for them systematically using the following command

```
find \( -name '*.c' -o -name '*.h' \) -exec grep -nH -E $'^\t+ +' {} +
```

and found the following locations:

```
./crypto/pem/pem_pkey.c:36:				   cb, u))
./crypto/poly1305/poly1305_ieee754.c:82:			 (u32)(p)[2]<<16 | (u32)(p)[3]<<24  )
./crypto/poly1305/poly1305_ieee754.c:86:			 (p)[2] = (u8)((v)>>16), (p)[3] = (u8)((v)>>24) )
./crypto/poly1305/poly1305_ieee754.c:363:	 * base 2^32 * base 2^16 = base 2^48
./crypto/poly1305/poly1305_ieee754.c:364:	 */
./crypto/pkcs12/p12_utl.c:100:	    return OPENSSL_asc2uni(asc, asclen, uni, unilen);
./crypto/pkcs12/p12_utl.c:103:	    return NULL;
./engines/e_capi.c:1481:	 * as optimization to minimize [below] malloc-ations */
./ssl/t1_trce.c:1508:	                 DTLS1_RT_HEADER_LENGTH : SSL3_RT_HEADER_LENGTH)) {
./apps/spkac.c:101:	    break;
```

For every file, I ran the emacs commands `indent-region` and `whitespace-cleanup`, using @levitte's `openssl-II` indentation style. Some unnecessary changes were reverted by me. The changes are committed separately, one for every file touched:

795da17402 ssl/t1_trce.c: fix mixed indentation (and other whitespace issues)
685e3d4b71 engines/e_capi.c: fix mixed indentation (and other whitespace issues)
fe5b55b11f crypto/poly1305/poly1305_ieee754.c: fix mixed indentation (and other whitespace issues)
031fbc13bf crypto/pem/pem_pkey.c: fix mixed indentation (and other whitespace issues)
c62cbc8f99 apps/spkac.c: fix mixed indentation (and other whitespace issues)
1a818ab21a pkcs12/p12_utl.c: fix mixed indentation (and other whitespace issues)

@dot-asm, please have a look at fe5b55b11f and let me know whether the changes are ok for you.
