### PR TITLE
15-test_out_option: Refactor and don't test directory write on VMS

### DIFF
--- a/test/recipes/15-test_out_option.t
+++ b/test/recipes/15-test_out_option.t
@@ -16,49 +16,58 @@ use OpenSSL::Test::Utils;
 
 setup("test_out_option");
 
-# Paths that should generate failure when trying to write to them.
-# Directories are a safe bet for failure on all platforms.
-# Note that directories must end with a slash here, because of how
-# File::Spec massages them into directory specs on some platforms.
-my @failure_paths = (
-    './',
-   );
-my @success_paths = (
-    'randomname.bin'
-   );
+plan tests => 4;
 
-# Test for trying to create a file in a non-exist directory
-my $rand_path = "";
-do {
-    my @chars = ("A".."Z", "a".."z", "0".."9");
-    $rand_path .= $chars[rand @chars] for 1..32;
-} while (-d File::Spec->catdir('.', $rand_path));
-$rand_path .= "/randomname.bin";
+# Test 1
+SKIP: {
+    # Paths that should generate failure when trying to write to them.
+    # Directories are a safe bet for failure on most platforms.
+    # Notably, this isn't true on OpenVMS, as a default file name is
+    # appended under the hood when trying to "write" to a directory spec.
+    # From observation, that file is '.' (i.e. a file with no file name
+    # and no extension), so '[]' gets translated to '[].'
+    skip 'Directories become writable files on OpenVMS', 1 if $^O eq 'VMS';
 
-push @failure_paths, $rand_path;
-
-# All explicit cross compilations run a risk of failing this, because the
-# null device provided by perl might not match what the cross compiled
-# application expects to see as a null device.  Therefore, we skip the check
-# of outputing to the null device if the cross compile prefix is set.
-if ((config('CROSS_COMPILE') // '') eq '') {
-    # Check that we can write to the NULL device
-    push @success_paths, File::Spec->devnull();
-}
-
-plan tests => scalar @failure_paths + scalar @success_paths;
-
-foreach (@failure_paths) {
-    my $path = File::Spec->canonpath($_);
+    # Note that directories must end with a slash here, because of how
+    # File::Spec massages them into directory specs on some platforms.
+    my $path = File::Spec->canonpath('./');
     ok(!run(app([ 'openssl', 'rand', '-out', $path, '1'])),
        "invalid output path: $path");
 }
-foreach (@success_paths) {
-    my $path = File::Spec->canonpath($_);
+
+# Test 2
+{
+    my $path = File::Spec->canonpath('randomname.bin');
     ok(run(app([ 'openssl', 'rand', '-out', $path, '1'])),
        "valid output path: $path");
 }
 
+# Test 3
+{
+    # Test for trying to create a file in a non-exist directory
+    my $rand_path = "";
+    do {
+        my @chars = ("A".."Z", "a".."z", "0".."9");
+        $rand_path .= $chars[rand @chars] for 1..32;
+    } while (-d File::Spec->catdir('.', $rand_path));
+    $rand_path .= "/randomname.bin";
+
+    my $path = File::Spec->canonpath($rand_path);
+    ok(!run(app([ 'openssl', 'rand', '-out', $path, '1'])),
+       "invalid output path: $path");
+}
+
+# Test 4
+SKIP: {
+    skip "It's not safe to use perl's idea of the NULL device in an explicitly cross compiled build", 1
+        unless (config('CROSS_COMPILE') // '') eq '';
+
+    my $path = File::Spec->canonpath(File::Spec->devnull());
+    ok(run(app([ 'openssl', 'rand', '-out', $path, '1'])),
+       "valid output path: $path");
+}
+
+# Cleanup
 END {
     unlink 'randomname.bin' if -f 'randomname.bin';
 }


### PR DESCRIPTION
To my surprise, it turns out that on OpenVMS, opening './' (which
is translated to '[]') for writing actually creates a file, '[].'.
On OpenVMS, this is a perfectly valid file with no name or extension,
just the delimiter between the two.

Because of the mess the exception would generate in the test recipe,
it gets refactored again, to clearly separate each test inside it,
and use skips to avoid some of them (that makes it clear that they are
skipped and why, when running the recipe).
