### PR TITLE
Configurations/10-main.conf: force no-engine on ios targets.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1592,6 +1592,7 @@ my %targets = (
         inherit_from     => [ "darwin-common" ],
         cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
         sys_id           => "iOS",
+        disable          => [ "engine" ],
     },
     "ios-cross" => {
         inherit_from     => [ "darwin-common", asm("armv4_asm") ],
@@ -1601,6 +1602,7 @@ my %targets = (
         cflags           => add("-arch armv7 -mios-version-min=6.0.0 -isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
         sys_id           => "iOS",
         perlasm_scheme   => "ios32",
+        disable          => [ "engine" ],
     },
     "ios64-cross" => {
         inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
@@ -1608,6 +1610,7 @@ my %targets = (
         sys_id           => "iOS",
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         perlasm_scheme   => "ios64",
+        disable          => [ "engine" ],
     },
 
 ##### GNU Hurd

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -369,7 +369,7 @@ test: tests
 	  RESULT_D=test-runs \
 	  PERL="$(PERL)" \
 	  EXE_EXT={- $exeext -} \
-	  OPENSSL_ENGINES=`cd ../$(BLDDIR)/engines; pwd` \
+	  OPENSSL_ENGINES=`cd ../$(BLDDIR)/engines 2>/dev/null && pwd` \
 	  OPENSSL_DEBUG_MEMORY=on \
 	    $(PERL) ../$(SRCDIR)/test/run_tests.pl $(TESTS) )
 	@ : {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}


### PR DESCRIPTION
Rationale for enforcing no-engine is because of dirsconnect between compile-time config and run-time, which is a per-application sandbox directory which one can't predict in advance.
