### PR TITLE
 Fix SSL_get_shared_ciphers() (1.1.0)

### DIFF
--- a/doc/ssl/SSL_get_ciphers.pod
+++ b/doc/ssl/SSL_get_ciphers.pod
@@ -2,8 +2,12 @@
 
 =head1 NAME
 
-SSL_get1_supported_ciphers, SSL_get_client_ciphers,
-SSL_get_ciphers, SSL_CTX_get_ciphers, SSL_get_cipher_list
+SSL_get1_supported_ciphers,
+SSL_get_client_ciphers,
+SSL_get_ciphers,
+SSL_CTX_get_ciphers,
+SSL_get_cipher_list,
+SSL_get_shared_ciphers
 - get list of available SSL_CIPHERs
 
 =head1 SYNOPSIS
@@ -15,6 +19,7 @@ SSL_get_ciphers, SSL_CTX_get_ciphers, SSL_get_cipher_list
  STACK_OF(SSL_CIPHER) *SSL_get1_supported_ciphers(SSL *s);
  STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
  const char *SSL_get_cipher_list(const SSL *ssl, int priority);
+ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len);
 
 =head1 DESCRIPTION
 
@@ -25,16 +30,16 @@ is returned.
 SSL_CTX_get_ciphers() returns the stack of available SSL_CIPHERs for B<ctx>.
 
 SSL_get1_supported_ciphers() returns the stack of enabled SSL_CIPHERs for
-B<ssl>, sorted by preference.
+B<ssl> as would be sent in a ClientHello (that is, sorted by preference).
 The list depends on settings like the cipher list, the supported protocol
 versions, the security level, and the enabled signature algorithms.
 SRP and PSK ciphers are only enabled if the appropriate callbacks or settings
 have been applied.
-This is the list that will be sent by the client to the server.
-The list supported by the server might include more ciphers in case there is a
-hole in the list of supported protocols.
-The server will also not use ciphers from this list depending on the
-configured certificates and DH parameters.
+The list of ciphers that would be sent in a ClientHello can differ from
+the list of ciphers that would be acceptable when acting as a server.
+For example, additional ciphers may be usable by a server if there is
+a gap in the list of supported protocols, and some ciphers may not be
+usable by a server if there is not a suitable certificate configured.
 If B<ssl> is NULL or no ciphers are available, NULL is returned.
 
 SSL_get_client_ciphers() returns the stack of available SSL_CIPHERs matching the
@@ -45,6 +50,19 @@ SSL_get_cipher_list() returns a pointer to the name of the SSL_CIPHER
 listed for B<ssl> with B<priority>. If B<ssl> is NULL, no ciphers are
 available, or there are less ciphers than B<priority> available, NULL
 is returned.
+
+SSL_get_shared_ciphers() creates a colon separated and NUL terminated list of
+SSL_CIPHER names that are available in both the client and the server. B<buf> is
+the buffer that should be populated with the list of names and B<len> is the
+size of that buffer. A pointer to B<buf> is returned on success or NULL on
+error. If the supplied buffer is not large enough to contain the complete list
+of names then a truncated list of names will be returned. Note that just because
+a ciphersuite is available (i.e. it is configured in the cipher list) and shared
+by both the client and the server it does not mean that it is enabled (see the
+description of SSL_get1_supported_ciphers() above). This function will return
+available shared ciphersuites whether or not they are enabled. This is a server
+side function only and must only be called after the completion of the initial
+handshake.
 
 =head1 NOTES
 

--- a/doc/ssl/SSL_get_ciphers.pod
+++ b/doc/ssl/SSL_get_ciphers.pod
@@ -19,7 +19,7 @@ SSL_get_shared_ciphers
  STACK_OF(SSL_CIPHER) *SSL_get1_supported_ciphers(SSL *s);
  STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
  const char *SSL_get_cipher_list(const SSL *ssl, int priority);
- char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len);
+ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size);
 
 =head1 DESCRIPTION
 
@@ -53,7 +53,7 @@ is returned.
 
 SSL_get_shared_ciphers() creates a colon separated and NUL terminated list of
 SSL_CIPHER names that are available in both the client and the server. B<buf> is
-the buffer that should be populated with the list of names and B<len> is the
+the buffer that should be populated with the list of names and B<size> is the
 size of that buffer. A pointer to B<buf> is returned on success or NULL on
 error. If the supplied buffer is not large enough to contain the complete list
 of names then a truncated list of names will be returned. Note that just because

--- a/doc/ssl/ssl.pod
+++ b/doc/ssl/ssl.pod
@@ -568,7 +568,7 @@ fresh handle for each connection.
 
 =item SSL_SESSION *B<SSL_get_session>(const SSL *ssl);
 
-=item char *B<SSL_get_shared_ciphers>(const SSL *ssl, char *buf, int len);
+=item char *B<SSL_get_shared_ciphers>(const SSL *ssl, char *buf, int size);
 
 =item int B<SSL_get_shutdown>(const SSL *ssl);
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1358,7 +1358,7 @@ __owur int SSL_get_fd(const SSL *s);
 __owur int SSL_get_rfd(const SSL *s);
 __owur int SSL_get_wfd(const SSL *s);
 __owur const char *SSL_get_cipher_list(const SSL *s, int n);
-__owur char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len);
+__owur char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size);
 __owur int SSL_get_read_ahead(const SSL *s);
 __owur int SSL_pending(const SSL *s);
 __owur int SSL_has_pending(const SSL *s);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2213,7 +2213,7 @@ int SSL_set_cipher_list(SSL *s, const char *str)
     return 1;
 }
 
-char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
+char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
 {
     char *p;
     STACK_OF(SSL_CIPHER) *clntsk, *srvrsk;
@@ -2223,7 +2223,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
     if (!s->server
             || s->session == NULL
             || s->session->ciphers == NULL
-            || len < 2)
+            || size < 2)
         return NULL;
 
     p = buf;
@@ -2243,7 +2243,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
             continue;
 
         n = strlen(c->name);
-        if (n + 1 > len) {
+        if (n + 1 > size) {
             if (p != buf)
                 --p;
             *p = '\0';
@@ -2252,7 +2252,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
         memcpy(p, c->name, n + 1);
         p += n;
         *(p++) = ':';
-        len -= n + 1;
+        size -= n + 1;
     }
     p[-1] = '\0';
     return (buf);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2216,23 +2216,32 @@ int SSL_set_cipher_list(SSL *s, const char *str)
 char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
 {
     char *p;
-    STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *clntsk, *srvrsk;
     const SSL_CIPHER *c;
     int i;
 
-    if ((s->session == NULL) || (s->session->ciphers == NULL) || (len < 2))
-        return (NULL);
-
-    p = buf;
-    sk = s->session->ciphers;
-
-    if (sk_SSL_CIPHER_num(sk) == 0)
+    if (!s->server
+            || s->session == NULL
+            || s->session->ciphers == NULL
+            || len < 2)
         return NULL;
 
-    for (i = 0; i < sk_SSL_CIPHER_num(sk); i++) {
+    p = buf;
+    clntsk = s->session->ciphers;
+    srvrsk = SSL_get_ciphers(s);
+    if (clntsk == NULL || srvrsk == NULL)
+        return NULL;
+
+    if (sk_SSL_CIPHER_num(clntsk) == 0 || sk_SSL_CIPHER_num(srvrsk) == 0)
+        return NULL;
+
+    for (i = 0; i < sk_SSL_CIPHER_num(clntsk); i++) {
         int n;
 
-        c = sk_SSL_CIPHER_value(sk, i);
+        c = sk_SSL_CIPHER_value(clntsk, i);
+        if (sk_SSL_CIPHER_find(srvrsk, c) < 0)
+            continue;
+
         n = strlen(c->name);
         if (n + 1 > len) {
             if (p != buf)

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -540,7 +540,7 @@ struct ssl_session_st {
     const SSL_CIPHER *cipher;
     unsigned long cipher_id;    /* when ASN.1 loaded, this needs to be used to
                                  * load the 'cipher' structure */
-    STACK_OF(SSL_CIPHER) *ciphers; /* shared ciphers? */
+    STACK_OF(SSL_CIPHER) *ciphers; /* ciphers offered by the client */
     CRYPTO_EX_DATA ex_data;     /* application specific data */
     /*
      * These are used to make removal of session-ids more efficient and to


### PR DESCRIPTION
The function SSL_get_shared_ciphers() is supposed to return ciphers shared
by the client and the server. However it only ever returned the client
ciphers.

Fixes #5317

This is the 1.1.0 version of #6113