### PR TITLE
 Fix SSL_get_shared_ciphers() (1.0.2)

### DIFF
--- a/doc/ssl/SSL_get_ciphers.pod
+++ b/doc/ssl/SSL_get_ciphers.pod
@@ -2,7 +2,10 @@
 
 =head1 NAME
 
-SSL_get_ciphers, SSL_get_cipher_list - get list of available SSL_CIPHERs
+SSL_get_ciphers,
+SSL_get_cipher_list,
+SSL_get_shared_ciphers
+- get list of available SSL_CIPHERs
 
 =head1 SYNOPSIS
 
@@ -10,6 +13,7 @@ SSL_get_ciphers, SSL_get_cipher_list - get list of available SSL_CIPHERs
 
  STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
  const char *SSL_get_cipher_list(const SSL *ssl, int priority);
+ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len);
 
 =head1 DESCRIPTION
 
@@ -21,6 +25,19 @@ SSL_get_cipher_list() returns a pointer to the name of the SSL_CIPHER
 listed for B<ssl> with B<priority>. If B<ssl> is NULL, no ciphers are
 available, or there are less ciphers than B<priority> available, NULL
 is returned.
+
+SSL_get_shared_ciphers() creates a colon separated and NUL terminated list of
+SSL_CIPHER names that are available in both the client and the server. B<buf> is
+the buffer that should be populated with the list of names and B<len> is the
+size of that buffer. A pointer to B<buf> is returned on success or NULL on
+error. If the supplied buffer is not large enough to contain the complete list
+of names then a truncated list of names will be returned. Note that just because
+a ciphersuite is available (i.e. it is configured in the cipher list) and shared
+by both the client and the server it does not mean that it is enabled (for
+example some ciphers may not be usable by a server if there is not a suitable
+certificate configured). This function will return available shared ciphersuites
+whether or not they are enabled. This is a server side function only and must
+only be called after the completion of the initial handshake.
 
 =head1 NOTES
 

--- a/doc/ssl/SSL_get_ciphers.pod
+++ b/doc/ssl/SSL_get_ciphers.pod
@@ -13,7 +13,7 @@ SSL_get_shared_ciphers
 
  STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
  const char *SSL_get_cipher_list(const SSL *ssl, int priority);
- char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len);
+ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size);
 
 =head1 DESCRIPTION
 
@@ -28,7 +28,7 @@ is returned.
 
 SSL_get_shared_ciphers() creates a colon separated and NUL terminated list of
 SSL_CIPHER names that are available in both the client and the server. B<buf> is
-the buffer that should be populated with the list of names and B<len> is the
+the buffer that should be populated with the list of names and B<size> is the
 size of that buffer. A pointer to B<buf> is returned on success or NULL on
 error. If the supplied buffer is not large enough to contain the complete list
 of names then a truncated list of names will be returned. Note that just because

--- a/doc/ssl/ssl.pod
+++ b/doc/ssl/ssl.pod
@@ -572,7 +572,7 @@ connection defined in the B<SSL> structure.
 
 =item SSL_SESSION *B<SSL_get_session>(const SSL *ssl);
 
-=item char *B<SSL_get_shared_ciphers>(const SSL *ssl, char *buf, int len);
+=item char *B<SSL_get_shared_ciphers>(const SSL *ssl, char *buf, int size);
 
 =item int B<SSL_get_shutdown>(const SSL *ssl);
 

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -548,7 +548,7 @@ struct ssl_session_st {
     const SSL_CIPHER *cipher;
     unsigned long cipher_id;    /* when ASN.1 loaded, this needs to be used
                                  * to load the 'cipher' structure */
-    STACK_OF(SSL_CIPHER) *ciphers; /* shared ciphers? */
+    STACK_OF(SSL_CIPHER) *ciphers; /* ciphers offered by the client */
     CRYPTO_EX_DATA ex_data;     /* application specific data */
     /*
      * These are used to make removal of session-ids more efficient and to

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -2149,7 +2149,7 @@ int SSL_get_fd(const SSL *s);
 int SSL_get_rfd(const SSL *s);
 int SSL_get_wfd(const SSL *s);
 const char *SSL_get_cipher_list(const SSL *s, int n);
-char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len);
+char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size);
 int SSL_get_read_ahead(const SSL *s);
 int SSL_pending(const SSL *s);
 # ifndef OPENSSL_NO_SOCK

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1404,7 +1404,7 @@ int SSL_set_cipher_list(SSL *s, const char *str)
 }
 
 /* works well for SSLv2, not so good for SSLv3 */
-char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
+char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
 {
     char *p;
     STACK_OF(SSL_CIPHER) *clntsk, *srvrsk;
@@ -1414,7 +1414,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
     if (!s->server
             || s->session == NULL
             || s->session->ciphers == NULL
-            || len < 2)
+            || size < 2)
         return NULL;
 
     p = buf;
@@ -1434,7 +1434,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
             continue;
 
         n = strlen(c->name);
-        if (n + 1 > len) {
+        if (n + 1 > size) {
             if (p != buf)
                 --p;
             *p = '\0';
@@ -1443,7 +1443,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
         strcpy(p, c->name);
         p += n;
         *(p++) = ':';
-        len -= n + 1;
+        size -= n + 1;
     }
     p[-1] = '\0';
     return (buf);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1407,23 +1407,32 @@ int SSL_set_cipher_list(SSL *s, const char *str)
 char *SSL_get_shared_ciphers(const SSL *s, char *buf, int len)
 {
     char *p;
-    STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *clntsk, *srvrsk;
     SSL_CIPHER *c;
     int i;
 
-    if ((s->session == NULL) || (s->session->ciphers == NULL) || (len < 2))
-        return (NULL);
-
-    p = buf;
-    sk = s->session->ciphers;
-
-    if (sk_SSL_CIPHER_num(sk) == 0)
+    if (!s->server
+            || s->session == NULL
+            || s->session->ciphers == NULL
+            || len < 2)
         return NULL;
 
-    for (i = 0; i < sk_SSL_CIPHER_num(sk); i++) {
+    p = buf;
+    clntsk = s->session->ciphers;
+    srvrsk = SSL_get_ciphers(s);
+    if (clntsk == NULL || srvrsk == NULL)
+        return NULL;
+
+    if (sk_SSL_CIPHER_num(clntsk) == 0 || sk_SSL_CIPHER_num(srvrsk) == 0)
+        return NULL;
+
+    for (i = 0; i < sk_SSL_CIPHER_num(clntsk); i++) {
         int n;
 
-        c = sk_SSL_CIPHER_value(sk, i);
+        c = sk_SSL_CIPHER_value(clntsk, i);
+        if (sk_SSL_CIPHER_find(srvrsk, c) < 0)
+            continue;
+
         n = strlen(c->name);
         if (n + 1 > len) {
             if (p != buf)


### PR DESCRIPTION
The function SSL_get_shared_ciphers() is supposed to return ciphers shared
by the client and the server. However it only ever returned the client
ciphers.

Fixes #5317

This is the 1.0.2 version of #6113.