### PR TITLE
Clarify BN_mod_exp docs (1.1.0/1.0.2)

### DIFF
--- a/doc/crypto/BN_add.pod
+++ b/doc/crypto/BN_add.pod
@@ -92,9 +92,9 @@ BN_exp() raises I<a> to the I<p>-th power and places the result in I<r>
 BN_mul().
 
 BN_mod_exp() computes I<a> to the I<p>-th power modulo I<m> (C<r=a^p %
-m>). This function uses less time and space than BN_exp().  Note that calling
-this function with an even modulus and when any of B<a>, B<p> or B<m> have the
-BN_FLG_CONSTTIME flag set is not supported.
+m>). This function uses less time and space than BN_exp(). Do not call this
+function when B<m> is even and any of the parameters have the
+B<BN_FLG_CONSTTIME> flag set.
 
 BN_gcd() computes the greatest common divisor of I<a> and I<b> and
 places the result in I<r>. I<r> may be the same B<BIGNUM> as I<a> or

--- a/doc/crypto/BN_add.pod
+++ b/doc/crypto/BN_add.pod
@@ -92,7 +92,9 @@ BN_exp() raises I<a> to the I<p>-th power and places the result in I<r>
 BN_mul().
 
 BN_mod_exp() computes I<a> to the I<p>-th power modulo I<m> (C<r=a^p %
-m>). This function uses less time and space than BN_exp().
+m>). This function uses less time and space than BN_exp().  Note that calling
+this function with an even modulus and when any of B<a>, B<p> or B<m> have the
+BN_FLG_CONSTTIME flag set is not supported.
 
 BN_gcd() computes the greatest common divisor of I<a> and I<b> and
 places the result in I<r>. I<r> may be the same B<BIGNUM> as I<a> or


### PR DESCRIPTION
Specifically this is not supported with an even modulus and
BN_FLG_CONSTTIME.

Fixes #5082

This is the 1.1.0/1.0.2 version of #6137

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
