### PR TITLE
Fix a mem leak in CMS

### DIFF
--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -282,6 +282,7 @@ int CMS_RecipientInfo_set0_pkey(CMS_RecipientInfo *ri, EVP_PKEY *pkey)
         CMSerr(CMS_F_CMS_RECIPIENTINFO_SET0_PKEY, CMS_R_NOT_KEY_TRANSPORT);
         return 0;
     }
+    EVP_PKEY_free(ri->d.ktri->pkey);
     ri->d.ktri->pkey = pkey;
     return 1;
 }

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -631,6 +631,7 @@ int CMS_decrypt_set1_pkey(CMS_ContentInfo *cms, EVP_PKEY *pk, X509 *cert)
          * all.
          */
         else if (!cert || !CMS_RecipientInfo_ktri_cert_cmp(ri, cert)) {
+            EVP_PKEY_up_ref(pk);
             CMS_RecipientInfo_set0_pkey(ri, pk);
             r = CMS_RecipientInfo_decrypt(cms, ri);
             CMS_RecipientInfo_set0_pkey(ri, NULL);

--- a/test/build.info
+++ b/test/build.info
@@ -51,7 +51,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           recordlentest drbgtest drbg_cavs_test sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest \
-          sysdefaulttest
+          sysdefaulttest cmsapitest
 
   SOURCE[versions]=versions.c
   INCLUDE[versions]=../include
@@ -372,6 +372,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[servername_test]=servername_test.c
   INCLUDE[servername_test]=../include
   DEPEND[servername_test]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[cmsapitest]=cmsapitest.c
+  INCLUDE[cmsapitest]=../include
+  DEPEND[cmsapitest]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{psk} -}]
     PROGRAMS_NO_INST=dtls_mtu_test

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -1,0 +1,93 @@
+#include <string.h>
+
+#include <openssl/cms.h>
+#include <openssl/bio.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+
+#include "testutil.h"
+
+static X509 *cert = NULL;
+static EVP_PKEY *privkey = NULL;
+
+static int test_encrypt_decrypt(void)
+{
+    int testresult = 0;
+    STACK_OF(X509) *certstack = sk_X509_new_null();
+    const char *msg = "Hello world";
+    BIO *msgbio = BIO_new_mem_buf(msg, strlen(msg));
+    BIO *outmsgbio = BIO_new(BIO_s_mem());
+    CMS_ContentInfo* content = NULL;
+    char buf[80];
+
+    if (!TEST_ptr(certstack) || !TEST_ptr(msgbio) || !TEST_ptr(outmsgbio))
+        goto end;
+
+    if (!TEST_int_gt(sk_X509_push(certstack, cert), 0))
+        goto end;
+
+    content = CMS_encrypt(certstack, msgbio, EVP_aes_128_cbc(), CMS_TEXT);
+    if (!TEST_ptr(content))
+        goto end;
+
+    if (!TEST_true(CMS_decrypt(content, privkey, cert, NULL, outmsgbio,
+                               CMS_TEXT)))
+        goto end;
+
+    /* Check we got the message we first started with */
+    if (!TEST_int_eq(BIO_gets(outmsgbio, buf, sizeof(buf)), strlen(msg))
+            || !TEST_int_eq(strcmp(buf, msg), 0))
+        goto end;
+
+    testresult = 1;
+ end:
+    sk_X509_free(certstack);
+    BIO_free(msgbio);
+    BIO_free(outmsgbio);
+    CMS_ContentInfo_free(content);
+
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    char *certin = NULL, *privkeyin = NULL;
+    BIO *certbio = NULL, *privkeybio = NULL;
+
+    if (!TEST_ptr(certin = test_get_argument(0))
+            || !TEST_ptr(privkeyin = test_get_argument(1)))
+        return 0;
+
+    certbio = BIO_new_file(certin, "r");
+    if (!TEST_ptr(certbio))
+        return 0;
+    if (!TEST_true(PEM_read_bio_X509(certbio, &cert, NULL, NULL))) {
+        BIO_free(certbio);
+        return 0;
+    }
+    BIO_free(certbio);
+
+    privkeybio = BIO_new_file(privkeyin, "r");
+    if (!TEST_ptr(privkeybio)) {
+        X509_free(cert);
+        cert = NULL;
+        return 0;
+    }
+    if (!TEST_true(PEM_read_bio_PrivateKey(privkeybio, &privkey, NULL, NULL))) {
+        BIO_free(privkeybio);
+        X509_free(cert);
+        cert = NULL;
+        return 0;
+    }
+    BIO_free(privkeybio);
+
+    ADD_TEST(test_encrypt_decrypt);
+
+    return 1;
+}
+
+void cleanup_tests(void)
+{
+    X509_free(cert);
+    EVP_PKEY_free(privkey);
+}

--- a/test/recipes/80-test_cmsapi.t
+++ b/test/recipes/80-test_cmsapi.t
@@ -1,0 +1,21 @@
+#! /usr/bin/env perl
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_cmsapi");
+
+plan skip_all => "CMS is disabled in this build" if disabled("cms");
+
+plan tests => 1;
+
+ok(run(test(["cmsapitest", srctop_file("test", "certs", "servercert.pem"),
+             srctop_file("test", "certs", "serverkey.pem")])),
+             "running cmsapitest");


### PR DESCRIPTION
The function CMS_RecipientInfo_set0_pkey() is a "set0" and therefore
memory management passes to OpenSSL. If the same function is called again
then we should ensure that any previous value that was set is freed first
before we set it again.

Fixes #5052

Only the first commit is for 1.1.0. The test will not backport.

