### PR TITLE
Added BN_count_low_zero_bits method

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -640,6 +640,24 @@ int BN_is_bit_set(const BIGNUM *a, int n)
     return (int)(((a->d[i]) >> j) & ((BN_ULONG)1));
 }
 
+int BN_count_low_zero_bits(const BIGNUM *a) 
+{
+    int i, bits;
+    BN_ULONG w;
+
+    bn_check_top(a);
+    for (i = 0; i < a->top; i++) {
+        if (a->d[i] != 0) {
+            bits = 0;
+            for (w = a->d[i]; (w & 1) == 0; w >>= 1)
+                bits++;
+            return i * BN_BITS2 + bits;
+        }
+    }
+    /* No low non-zero words in |bn| */
+    return 0;
+}
+
 int BN_mask_bits(BIGNUM *a, int n)
 {
     int b, w;

--- a/doc/man3/BN_set_bit.pod
+++ b/doc/man3/BN_set_bit.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-BN_set_bit, BN_clear_bit, BN_is_bit_set, BN_mask_bits, BN_lshift,
-BN_lshift1, BN_rshift, BN_rshift1 - bit operations on BIGNUMs
+BN_set_bit, BN_clear_bit, BN_is_bit_set, BN_count_low_zero_bits, BN_mask_bits,
+BN_lshift, BN_lshift1, BN_rshift, BN_rshift1 - bit operations on BIGNUMs
 
 =head1 SYNOPSIS
 
@@ -13,6 +13,8 @@ BN_lshift1, BN_rshift, BN_rshift1 - bit operations on BIGNUMs
  int BN_clear_bit(BIGNUM *a, int n);
 
  int BN_is_bit_set(const BIGNUM *a, int n);
+
+ int BN_count_low_zero_bits(const BIGNUM *a);
 
  int BN_mask_bits(BIGNUM *a, int n);
 
@@ -32,6 +34,8 @@ error occurs if B<a> is shorter than B<n> bits.
 
 BN_is_bit_set() tests if bit B<n> in B<a> is set.
 
+BN_count_low_zero_bits() counts the number of low-order zero bits
+
 BN_mask_bits() truncates B<a> to an B<n> bit number
 (C<a&=~((~0)E<gt>E<gt>n)>).  An error occurs if B<a> already is
 shorter than B<n> bits.
@@ -49,6 +53,8 @@ For the shift functions, B<r> and B<a> may be the same variable.
 =head1 RETURN VALUES
 
 BN_is_bit_set() returns 1 if the bit is set, 0 otherwise.
+
+BN_count_low_zero_bits() returns the number of low-order zero bits
 
 All other functions return 1 for success, 0 on error. The error codes
 can be obtained by L<ERR_get_error(3)>.

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -223,6 +223,7 @@ BN_ULONG BN_get_word(const BIGNUM *a);
 int BN_cmp(const BIGNUM *a, const BIGNUM *b);
 void BN_free(BIGNUM *a);
 int BN_is_bit_set(const BIGNUM *a, int n);
+int BN_count_low_zero_bits(const BIGNUM *a);
 int BN_lshift(BIGNUM *r, const BIGNUM *a, int n);
 int BN_lshift1(BIGNUM *r, const BIGNUM *a);
 int BN_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx);

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -1964,6 +1964,45 @@ err:
     return st;
 }
 
+static int test_count_low_zero(void) {
+  BIGNUM *a = NULL, *b = NULL, *c = NULL, *d = 0;
+  int st = 0;
+  
+  if (!TEST_ptr(a = BN_new())
+          || !TEST_ptr(b = BN_new())
+          || !TEST_ptr(c = BN_new())
+          || !TEST_ptr(d = BN_new()))
+    goto err;
+  
+  if (!TEST_true(BN_set_word(a, 17)))
+    goto err;
+  
+  if (!TEST_true(BN_lshift(b, BN_value_one(), 128)))
+    goto err;
+  
+  if (!TEST_true(BN_lshift(c, BN_value_one(), 256)))
+    goto err;
+  
+  if (!TEST_true(BN_add_word(c, 4)))
+    goto err;
+  
+  if (!TEST_true(BN_zero(d)))
+    goto err;
+
+  if (!TEST_true(BN_count_low_zero_bits(a) == 4) ||
+      !TEST_true(BN_count_low_zero_bits(b) == 128) ||
+      !TEST_true(BN_count_low_zero_bits(c) == 3) ||
+      !TEST_true(BN_count_low_zero_bits(d) == 0))
+  
+    st = 1;
+err:
+  BN_free(a);
+  BN_free(b);
+  BN_free(c);
+  BN_free(d);
+  return st;
+}
+
 static int test_badmod(void)
 {
     BIGNUM *a = NULL, *b = NULL, *zero = NULL;
@@ -2187,6 +2226,7 @@ int setup_tests(void)
         ADD_TEST(test_asc2bn);
         ADD_ALL_TESTS(test_mpi, (int)OSSL_NELEM(kMPITests));
         ADD_TEST(test_negzero);
+        ADD_TEST(test_count_low_zero);
         ADD_TEST(test_badmod);
         ADD_TEST(test_expmodzero);
         ADD_TEST(test_smallprime);

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -1964,43 +1964,44 @@ err:
     return st;
 }
 
-static int test_count_low_zero(void) {
-  BIGNUM *a = NULL, *b = NULL, *c = NULL, *d = 0;
-  int st = 0;
-  
-  if (!TEST_ptr(a = BN_new())
-          || !TEST_ptr(b = BN_new())
-          || !TEST_ptr(c = BN_new())
-          || !TEST_ptr(d = BN_new()))
-    goto err;
-  
-  if (!TEST_true(BN_set_word(a, 17)))
-    goto err;
-  
-  if (!TEST_true(BN_lshift(b, BN_value_one(), 128)))
-    goto err;
-  
-  if (!TEST_true(BN_lshift(c, BN_value_one(), 256)))
-    goto err;
-  
-  if (!TEST_true(BN_add_word(c, 4)))
-    goto err;
-  
-  if (!TEST_true(BN_zero(d)))
-    goto err;
+static int test_count_low_zero(void) 
+{
+    BIGNUM *a = NULL, *b = NULL, *c = NULL, *d = 0;
+    int st = 0;
 
-  if (!TEST_true(BN_count_low_zero_bits(a) == 4) ||
-      !TEST_true(BN_count_low_zero_bits(b) == 128) ||
-      !TEST_true(BN_count_low_zero_bits(c) == 3) ||
-      !TEST_true(BN_count_low_zero_bits(d) == 0))
-  
+    if (!TEST_ptr(a = BN_new())
+            || !TEST_ptr(b = BN_new())
+            || !TEST_ptr(c = BN_new())
+            || !TEST_ptr(d = BN_new()))
+        goto err;
+
+    if (!TEST_true(BN_set_word(a, 112)))
+        goto err;
+
+    if (!TEST_true(BN_lshift(b, BN_value_one(), 128)))
+        goto err;
+
+    if (!TEST_true(BN_lshift(c, BN_value_one(), 256)))
+        goto err;
+
+    if (!TEST_true(BN_add_word(c, 4)))
+        goto err;
+
+    BN_zero(d);
+
+    if (!TEST_true(BN_count_low_zero_bits(a) == 4) ||
+        !TEST_true(BN_count_low_zero_bits(b) == 128) ||
+        !TEST_true(BN_count_low_zero_bits(c) == 2) ||
+        !TEST_true(BN_count_low_zero_bits(d) == 0))
+        goto err;
+
     st = 1;
 err:
-  BN_free(a);
-  BN_free(b);
-  BN_free(c);
-  BN_free(d);
-  return st;
+    BN_free(a);
+    BN_free(b);
+    BN_free(c);
+    BN_free(d);
+    return st;
 }
 
 static int test_badmod(void)

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4528,3 +4528,4 @@ conf_ssl_name_find                      4469	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get_cmd                        4470	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get                            4471	1_1_0i	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_hostflags         4472	1_1_0i	EXIST::FUNCTION:
+BN_count_low_zero_bits                  4473	1_1_0i	EXIST::FUNCTION:


### PR DESCRIPTION
In openssl 1.1 the BIGNUM internals are in a private header file. This makes it more difficult to efficiently caclulate the number of trailing zero bits in that BIGENUM. 
Therefore I would like to add a small helper function to calculate the number of low zero bits for a BIGNUM.

The new function is similar to the one found in OpenSSL derivatives (like BoringSSL).

- [x] documentation is added or updated
- [x] tests are added or updated
