### PR TITLE
Small cleanups about opensslconf.h

### DIFF
--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -38,7 +38,6 @@ int RAND_egd_bytes(const char *path, int bytes)
 
 # else
 
-#  include <openssl/opensslconf.h>
 #  include OPENSSL_UNISTD
 #  include <stddef.h>
 #  include <sys/types.h>

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -20,7 +20,6 @@ extern "C" {
 # include <openssl/bio.h>
 # include <openssl/crypto.h>
 # include <openssl/ossl_typ.h>
-# include <openssl/opensslconf.h>
 # include <openssl/bn.h>
 # if OPENSSL_API_COMPAT < 0x10100000L
 #  include <openssl/dh.h>

--- a/test/build.info
+++ b/test/build.info
@@ -536,6 +536,7 @@ ENDIF
    use OpenSSL::Glob;
 
    my @nogo_headers = ( "asn1_mac.h",
+                        "opensslconf.h",
                         "__decc_include_prologue.h",
                         "__decc_include_epilogue.h" );
    my @nogo_headers_re = ( qr/.*err\.h/ );


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] compilation tested ! 

There two duplicate inclusions,
And no need to `generate_buildtest.pl` on opensslconf.h as it is the 1st include made in it.
