### PR TITLE
Make X509_VERIFY_PARAM_get_hostflags() take a const arg (1.1.0)

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -412,7 +412,7 @@ void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
     param->hostflags = flags;
 }
 
-unsigned int X509_VERIFY_PARAM_get_hostflags(X509_VERIFY_PARAM *param)
+unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param)
 {
     return param->hostflags;
 }

--- a/doc/crypto/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/crypto/X509_VERIFY_PARAM_set_flags.pod
@@ -56,7 +56,7 @@ X509_VERIFY_PARAM_set1_ip_asc
                                  const char *name, size_t namelen);
  void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                       unsigned int flags);
- unsigned int X509_VERIFY_PARAM_get_hostflags(X509_VERIFY_PARAM *param);
+ unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);
  char *X509_VERIFY_PARAM_get0_peername(X509_VERIFY_PARAM *param);
  int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
                                  const char *email, size_t emaillen);

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -475,7 +475,7 @@ int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
                                 const char *name, size_t namelen);
 void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                      unsigned int flags);
-unsigned int X509_VERIFY_PARAM_get_hostflags(X509_VERIFY_PARAM *param);
+unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);
 char *X509_VERIFY_PARAM_get0_peername(X509_VERIFY_PARAM *);
 void X509_VERIFY_PARAM_move_peername(X509_VERIFY_PARAM *, X509_VERIFY_PARAM *);
 int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,


### PR DESCRIPTION
Commit 14e55560 added this function which should have taken a const
argument.

This is the 1.1.0 version of #6154.