### PR TITLE
UI console: Restore tty settings, do not force ECHO after prompt

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1571,7 +1571,7 @@ TS_F_TS_VERIFY:108:*
 TS_F_TS_VERIFY_CERT:109:ts_verify_cert
 TS_F_TS_VERIFY_CTX_NEW:144:TS_VERIFY_CTX_new
 UI_F_CLOSE_CONSOLE:115:close_console
-UI_F_ECHO_CONSOLE:116:restore_console
+UI_F_ECHO_CONSOLE:116:echo_console
 UI_F_GENERAL_ALLOCATE_BOOLEAN:108:general_allocate_boolean
 UI_F_GENERAL_ALLOCATE_PROMPT:109:general_allocate_prompt
 UI_F_NOECHO_CONSOLE:117:noecho_console

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1571,7 +1571,7 @@ TS_F_TS_VERIFY:108:*
 TS_F_TS_VERIFY_CERT:109:ts_verify_cert
 TS_F_TS_VERIFY_CTX_NEW:144:TS_VERIFY_CTX_new
 UI_F_CLOSE_CONSOLE:115:close_console
-UI_F_ECHO_CONSOLE:116:echo_console
+UI_F_ECHO_CONSOLE:116:restore_console
 UI_F_GENERAL_ALLOCATE_BOOLEAN:108:general_allocate_boolean
 UI_F_GENERAL_ALLOCATE_PROMPT:109:general_allocate_prompt
 UI_F_NOECHO_CONSOLE:117:noecho_console

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -503,9 +503,6 @@ static int echo_console(UI *ui)
 {
 # if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
-# endif
-
-# if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     if (is_a_tty && (TTY_set(fileno(tty_in), &tty_new) == -1))
         return 0;
 # endif

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -190,8 +190,8 @@ static int read_string(UI *ui, UI_STRING *uis);
 static int write_string(UI *ui, UI_STRING *uis);
 
 static int open_console(UI *ui);
-static int echo_console(UI *ui);
 static int noecho_console(UI *ui);
+static int echo_console(UI *ui);
 static int close_console(UI *ui);
 
 /*
@@ -503,7 +503,6 @@ static int echo_console(UI *ui)
 {
 # if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
-    tty_new.TTY_FLAGS |= ECHO;
 # endif
 
 # if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
@@ -513,7 +512,7 @@ static int echo_console(UI *ui)
 # ifdef OPENSSL_SYS_VMS
     if (is_a_tty) {
         tty_new[0] = tty_orig[0];
-        tty_new[1] = tty_orig[1] & ~TT$M_NOECHO;
+        tty_new[1] = tty_orig[1];
         tty_new[2] = tty_orig[2];
         status = sys$qiow(0, channel, IO$_SETMODE, &iosb, 0, 0, tty_new, 12,
                           0, 0, 0, 0);
@@ -534,7 +533,6 @@ static int echo_console(UI *ui)
 # if defined(_WIN32) && !defined(_WIN32_WCE)
     if (is_a_tty) {
         tty_new = tty_orig;
-        tty_new |= ENABLE_ECHO_INPUT;
         SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), tty_new);
     }
 # endif

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -190,8 +190,8 @@ static int read_string(UI *ui, UI_STRING *uis);
 static int write_string(UI *ui, UI_STRING *uis);
 
 static int open_console(UI *ui);
-static int noecho_console(UI *ui);
 static int echo_console(UI *ui);
+static int noecho_console(UI *ui);
 static int close_console(UI *ui);
 
 /*


### PR DESCRIPTION
The Console UI method always set echo on after prompting without
echo.  However, echo might not have been on originally, so just
restore the original TTY settings.

Fixes #2373
