### PR TITLE
UI console: Restore tty settings, do not force ECHO after prompt [1.0.2]

### DIFF
--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -318,8 +318,8 @@ static int read_string(UI *ui, UI_STRING *uis);
 static int write_string(UI *ui, UI_STRING *uis);
 
 static int open_console(UI *ui);
-static int noecho_console(UI *ui);
 static int echo_console(UI *ui);
+static int noecho_console(UI *ui);
 static int close_console(UI *ui);
 
 static UI_METHOD ui_openssl = {

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -567,9 +567,6 @@ static int echo_console(UI *ui)
 {
 #if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
-#endif
-
-#if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     if (is_a_tty && (TTY_set(fileno(tty_in), &tty_new) == -1))
         return 0;
 #endif

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -318,8 +318,8 @@ static int read_string(UI *ui, UI_STRING *uis);
 static int write_string(UI *ui, UI_STRING *uis);
 
 static int open_console(UI *ui);
-static int echo_console(UI *ui);
 static int noecho_console(UI *ui);
+static int echo_console(UI *ui);
 static int close_console(UI *ui);
 
 static UI_METHOD ui_openssl = {
@@ -567,7 +567,6 @@ static int echo_console(UI *ui)
 {
 #if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
-    tty_new.TTY_FLAGS |= ECHO;
 #endif
 
 #if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
@@ -577,7 +576,7 @@ static int echo_console(UI *ui)
 #ifdef OPENSSL_SYS_VMS
     if (is_a_tty) {
         tty_new[0] = tty_orig[0];
-        tty_new[1] = tty_orig[1] & ~TT$M_NOECHO;
+        tty_new[1] = tty_orig[1];
         tty_new[2] = tty_orig[2];
         status = sys$qiow(0, channel, IO$_SETMODE, &iosb, 0, 0, tty_new, 12,
                           0, 0, 0, 0);


### PR DESCRIPTION
The Console UI method always set echo on after prompting without
echo.  However, echo might not have been on originally, so just
restore the original TTY settings.

Fixes #2373
