### PR TITLE
 Mark DTLS records as read when we have finished with them

### DIFF
--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -146,7 +146,8 @@ int init_client(int *sock, const char *host, const char *port,
         }
 #endif
 
-        if (!BIO_connect(*sock, BIO_ADDRINFO_address(ai), BIO_SOCK_NODELAY)) {
+        if (!BIO_connect(*sock, BIO_ADDRINFO_address(ai),
+                         type == SOCK_STREAM ? BIO_SOCK_NODELAY : 0)) {
             BIO_closesocket(*sock);
             *sock = INVALID_SOCKET;
             continue;

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1882,6 +1882,7 @@ int dtls1_get_record(SSL *s)
         p += 6;
 
         n2s(p, rr->length);
+        rr->read = 0;
 
         /*
          * Lets check the version. We tolerate alerts that don't have the exact
@@ -1891,6 +1892,7 @@ int dtls1_get_record(SSL *s)
             if (version != s->version) {
                 /* unexpected version, silently discard */
                 rr->length = 0;
+                rr->read = 1;
                 RECORD_LAYER_reset_packet_length(&s->rlayer);
                 goto again;
             }
@@ -1899,6 +1901,7 @@ int dtls1_get_record(SSL *s)
         if ((version & 0xff00) != (s->version & 0xff00)) {
             /* wrong version, silently discard record */
             rr->length = 0;
+            rr->read = 1;
             RECORD_LAYER_reset_packet_length(&s->rlayer);
             goto again;
         }
@@ -1906,6 +1909,7 @@ int dtls1_get_record(SSL *s)
         if (rr->length > SSL3_RT_MAX_ENCRYPTED_LENGTH) {
             /* record too long, silently discard it */
             rr->length = 0;
+            rr->read = 1;
             RECORD_LAYER_reset_packet_length(&s->rlayer);
             goto again;
         }
@@ -1915,6 +1919,7 @@ int dtls1_get_record(SSL *s)
                 && rr->length > GET_MAX_FRAGMENT_LENGTH(s->session)) {
             /* record too long, silently discard it */
             rr->length = 0;
+            rr->read = 1;
             RECORD_LAYER_reset_packet_length(&s->rlayer);
             goto again;
         }
@@ -1936,6 +1941,7 @@ int dtls1_get_record(SSL *s)
                 return -1;
             }
             rr->length = 0;
+            rr->read = 1;
             RECORD_LAYER_reset_packet_length(&s->rlayer);
             goto again;
         }
@@ -1966,6 +1972,7 @@ int dtls1_get_record(SSL *s)
          */
         if (!dtls1_record_replay_check(s, bitmap)) {
             rr->length = 0;
+            rr->read = 1;
             RECORD_LAYER_reset_packet_length(&s->rlayer); /* dump this record */
             goto again;         /* get another record */
         }
@@ -1974,8 +1981,10 @@ int dtls1_get_record(SSL *s)
 #endif
 
     /* just read a 0 length packet */
-    if (rr->length == 0)
+    if (rr->length == 0) {
+        rr->read = 1;
         goto again;
+    }
 
     /*
      * If this record is from the next epoch (either HM or ALERT), and a
@@ -1992,6 +2001,7 @@ int dtls1_get_record(SSL *s)
             }
         }
         rr->length = 0;
+        rr->read = 1;
         RECORD_LAYER_reset_packet_length(&s->rlayer);
         goto again;
     }
@@ -2002,6 +2012,7 @@ int dtls1_get_record(SSL *s)
             return -1;
         }
         rr->length = 0;
+        rr->read = 1;
         RECORD_LAYER_reset_packet_length(&s->rlayer); /* dump this record */
         goto again;             /* get another record */
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4434,11 +4434,16 @@ static int test_ssl_pending(int tst)
                                                 SSL_ERROR_NONE)))
         goto end;
 
-    if (!TEST_true(SSL_write_ex(serverssl, msg, sizeof(msg), &written))
+    if (!TEST_int_eq(SSL_pending(clientssl), 0)
+            || !TEST_false(SSL_has_pending(clientssl))
+            || !TEST_int_eq(SSL_pending(serverssl), 0)
+            || !TEST_false(SSL_has_pending(serverssl))
+            || !TEST_true(SSL_write_ex(serverssl, msg, sizeof(msg), &written))
             || !TEST_size_t_eq(written, sizeof(msg))
             || !TEST_true(SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes))
             || !TEST_size_t_eq(readbytes, sizeof(buf))
-            || !TEST_int_eq(SSL_pending(clientssl), (int)(written - readbytes)))
+            || !TEST_int_eq(SSL_pending(clientssl), (int)(written - readbytes))
+            || !TEST_true(SSL_has_pending(clientssl)))
         goto end;
 
     testresult = 1;


### PR DESCRIPTION
The TLS code marks records as read when its finished using a record. The DTLS code did
not do that. However SSL_has_pending() relies on it. So we should make DTLS consistent.

Also we shouldn't set TCP_NODELAY on a UDP socket