### PR TITLE
Add missing locks in X509_check_issued

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -760,8 +760,12 @@ int X509_check_issued(X509 *issuer, X509 *subject)
     if (X509_NAME_cmp(X509_get_subject_name(issuer),
                       X509_get_issuer_name(subject)))
         return X509_V_ERR_SUBJECT_ISSUER_MISMATCH;
+    CRYPTO_THREAD_write_lock(issuer->lock);
     x509v3_cache_extensions(issuer);
+    CRYPTO_THREAD_unlock(issuer->lock);
+    CRYPTO_THREAD_write_lock(subject->lock);
     x509v3_cache_extensions(subject);
+    CRYPTO_THREAD_unlock(subject->lock);
 
     if (subject->akid) {
         int ret = X509_check_akid(issuer, subject->akid);


### PR DESCRIPTION
Thanks to Mingtao Yang for reporting this bug.
Fixes #6121.
Not going to backport if it doesn't cherry-pick cleanly.

