### PR TITLE
v3_purp.c: add locking to x509v3_cache_extensions()  (1.0.2)

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -128,11 +128,10 @@ int X509_check_purpose(X509 *x, int id, int ca)
 {
     int idx;
     const X509_PURPOSE *pt;
-    if (!(x->ex_flags & EXFLAG_SET)) {
-        CRYPTO_w_lock(CRYPTO_LOCK_X509);
-        x509v3_cache_extensions(x);
-        CRYPTO_w_unlock(CRYPTO_LOCK_X509);
-    }
+
+    x509v3_cache_extensions(x);
+
+    /* Return if side-effect only call */
     if (id == -1)
         return 1;
     idx = X509_PURPOSE_get_by_id(id);
@@ -399,8 +398,16 @@ static void x509v3_cache_extensions(X509 *x)
     X509_EXTENSION *ex;
 
     int i;
+
     if (x->ex_flags & EXFLAG_SET)
         return;
+
+    CRYPTO_w_lock(CRYPTO_LOCK_X509);
+    if (x->ex_flags & EXFLAG_SET) {
+        CRYPTO_w_unlock(CRYPTO_LOCK_X509);
+        return;
+    }
+
 #ifndef OPENSSL_NO_SHA
     X509_digest(x, EVP_sha1(), x->sha1_hash, NULL);
 #endif
@@ -536,6 +543,7 @@ static void x509v3_cache_extensions(X509 *x)
         }
     }
     x->ex_flags |= EXFLAG_SET;
+    CRYPTO_w_unlock(CRYPTO_LOCK_X509);
 }
 
 /*-
@@ -578,11 +586,7 @@ static int check_ca(const X509 *x)
 
 int X509_check_ca(X509 *x)
 {
-    if (!(x->ex_flags & EXFLAG_SET)) {
-        CRYPTO_w_lock(CRYPTO_LOCK_X509);
-        x509v3_cache_extensions(x);
-        CRYPTO_w_unlock(CRYPTO_LOCK_X509);
-    }
+    x509v3_cache_extensions(x);
 
     return check_ca(x);
 }
@@ -796,6 +800,7 @@ int X509_check_issued(X509 *issuer, X509 *subject)
     if (X509_NAME_cmp(X509_get_subject_name(issuer),
                       X509_get_issuer_name(subject)))
         return X509_V_ERR_SUBJECT_ISSUER_MISMATCH;
+
     x509v3_cache_extensions(issuer);
     x509v3_cache_extensions(subject);
 


### PR DESCRIPTION
Fixes #6121

Backport of #6162

Thanks to Mingtao Yang for reporting this bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
