### PR TITLE
Fix Mac OS X builds that still require makedepend [1.1.0]

### DIFF
--- a/Configure
+++ b/Configure
@@ -1215,8 +1215,10 @@ if ($^O ne "VMS") {
 
     if (!$disabled{makedepend}) {
 	# We know that GNU C version 3 and up as well as all clang
-	# versions support dependency generation
-	if ($predefined{__GNUC__} >= 3) {
+	# versions support dependency generation, but Xcode did not
+	# handle $cc -M before clang support (but claims __GNUC__ = 3)
+	if (($predefined{__GNUC__} // -1) >= 3
+		&& !($predefined{__APPLE_CC__} && !$predefined{__clang__})) {
 	    $config{makedepprog} = $cc;
 	} else {
 	    $config{makedepprog} = which('makedepend');


### PR DESCRIPTION
Fixes an issue with [back-port of] PR #4281 (which is similar to #4755 fixed by #6073).

Xcode on Mac OS X 10.7 and earlier still uses makedepend, its C compiler does not support the -M option.
This was fixed with Xcode on Mac OS X 10.8, which added the capability to do cc -M.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
