### PR TITLE
Gostcerts2012 1 1 1

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -234,6 +234,15 @@ static const char *get_sigtype(int nid)
      case NID_ED448:
         return "Ed448";
 
+     case NID_id_GostR3410_2001:
+        return "gost2001";
+
+     case NID_id_GostR3410_2012_256:
+        return "gost2012_256";
+
+     case NID_id_GostR3410_2012_512:
+        return "gost2012_512";
+
     default:
         return NULL;
     }

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -383,11 +383,6 @@
 # define SSL_PKEY_ED25519        7
 # define SSL_PKEY_ED448          8
 # define SSL_PKEY_NUM            9
-/*
- * Pseudo-constant. GOST cipher suites can use different certs for 1
- * SSL_CIPHER. So let's see which one we have in fact.
- */
-# define SSL_PKEY_GOST_EC SSL_PKEY_NUM+1
 
 /*-
  * SSL_kRSA <- RSA_ENC

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -661,7 +661,12 @@ static const uint16_t tls12_sigalgs[] = {
 
     TLSEXT_SIGALG_dsa_sha256,
     TLSEXT_SIGALG_dsa_sha384,
-    TLSEXT_SIGALG_dsa_sha512
+    TLSEXT_SIGALG_dsa_sha512,
+#endif
+#ifndef OPENSSL_NO_GOST
+    TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256,
+    TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512,
+    TLSEXT_SIGALG_gostr34102001_gostr3411,
 #endif
 };
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -875,17 +875,16 @@ static const SIGALG_LOOKUP *tls1_get_legacy_sigalg(const SSL *s, int idx)
         /*
          * Some GOST ciphersuites allow more than one signature algorithms
          * */
-        if ((start_idx == -1) && (s->server) && (idx == SSL_PKEY_GOST01) && (s->s3->tmp.new_cipher->algorithm_auth != SSL_aGOST01))
-        {
-          int real_idx;
-          for (real_idx = SSL_PKEY_GOST01; real_idx <= SSL_PKEY_GOST12_512; real_idx++)
-          {
-            if (s->cert->pkeys[real_idx].privatekey != NULL)
-            {
-              break;
+        if ((start_idx == -1) && (s->server) && (idx == SSL_PKEY_GOST01)
+            && (s->s3->tmp.new_cipher->algorithm_auth != SSL_aGOST01)) {
+            int real_idx;
+            for (real_idx = SSL_PKEY_GOST01; real_idx <= SSL_PKEY_GOST12_512;
+                 real_idx++) {
+                if (s->cert->pkeys[real_idx].privatekey != NULL) {
+                    break;
+                }
             }
-          }
-        lu = tls1_lookup_sigalg(tls_default_sigalg[real_idx]);
+            lu = tls1_lookup_sigalg(tls_default_sigalg[real_idx]);
         }
 
         if (!tls1_lookup_md(lu, NULL))

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -844,6 +844,7 @@ static int rsa_pss_check_min_key_size(const RSA *rsa, const SIGALG_LOOKUP *lu)
  */
 static const SIGALG_LOOKUP *tls1_get_legacy_sigalg(const SSL *s, int idx)
 {
+    int start_idx = idx;
     if (idx == -1) {
         if (s->server) {
             size_t i;
@@ -865,6 +866,22 @@ static const SIGALG_LOOKUP *tls1_get_legacy_sigalg(const SSL *s, int idx)
         return NULL;
     if (SSL_USE_SIGALGS(s) || idx != SSL_PKEY_RSA) {
         const SIGALG_LOOKUP *lu = tls1_lookup_sigalg(tls_default_sigalg[idx]);
+
+        /*
+         * Some GOST ciphersuites allow more than one signature algorithms
+         * */
+        if ((start_idx == -1) && (s->server) && (idx == SSL_PKEY_GOST01) && (s->s3->tmp.new_cipher->algorithm_auth != SSL_aGOST01))
+        {
+          int real_idx;
+          for (real_idx = SSL_PKEY_GOST01; real_idx <= SSL_PKEY_GOST12_512; real_idx++)
+          {
+            if (s->cert->pkeys[real_idx].privatekey != NULL)
+            {
+              break;
+            }
+          }
+        lu = tls1_lookup_sigalg(tls_default_sigalg[real_idx]);
+        }
 
         if (!tls1_lookup_md(lu, NULL))
             return NULL;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -877,7 +877,6 @@ static const SIGALG_LOOKUP *tls1_get_legacy_sigalg(const SSL *s, int idx)
                     }
                 }
             }
-
         } else {
             idx = s->cert->key - s->cert->pkeys;
         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -869,8 +869,8 @@ static const SIGALG_LOOKUP *tls1_get_legacy_sigalg(const SSL *s, int idx)
             if (idx == SSL_PKEY_GOST01 && s->s3->tmp.new_cipher->algorithm_auth != SSL_aGOST01) {
                 int real_idx;
 
-                for (real_idx = SSL_PKEY_GOST01; real_idx <= SSL_PKEY_GOST12_512;
-                     real_idx++) {
+                for (real_idx = SSL_PKEY_GOST12_512; real_idx >= SSL_PKEY_GOST01;
+                     real_idx--) {
                     if (s->cert->pkeys[real_idx].privatekey != NULL) {
                         idx = real_idx;
                         break;


### PR DESCRIPTION
Restoring GOST TLS support in upstream/master.

Provided GOST SignatureAlgorithms for TLS 1.2
Restored selection of certificate for GOST ciphersuites allowing more than one auth type.

