### PR TITLE
Configure: move --noexestack probe to Configure.

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -65,7 +65,7 @@
             my ($api, $arch) = ($1, $2);
 
             my $triarch = $triplet{$arch};
-            my $cflags = "-Wa,--noexecstack";
+            my $cflags;
             my $cppflags;
 
             # see if there is NDK clang on $PATH

--- a/Configure
+++ b/Configure
@@ -1434,7 +1434,7 @@ if (!$disabled{asm}) {
         # but it apparently recognizes the option in question on all
         # supported platforms even when it's meaningless. In other words
         # probe would fail, but probed option always accepted...
-        push @{$config{cflags}}, "-Wa,--noexecstack";
+        push @{$config{cflags}}, "-Wa,--noexecstack", "-Qunused-arguments";
     } elsif ($^O ne 'VMS') {
         my $cc = $config{CROSS_COMPILE}.$config{CC};
         open(PIPE, "$cc -Wa,--help -c -o null.$$.o -x assembler /dev/null 2>&1 |");
@@ -1487,11 +1487,6 @@ if (defined($config{api})) {
     $config{openssl_api_defines} = [ "OPENSSL_MIN_API=".$apitable->{$config{api}} ];
     my $apiflag = sprintf("OPENSSL_API_COMPAT=%s", $apitable->{$config{api}});
     push @{$config{defines}}, $apiflag;
-}
-
-if (defined($predefined{__clang__}) && !$disabled{asm}) {
-    push @{$config{cflags}}, "-Qunused-arguments";
-    push @{$config{cxxflags}}, "-Qunused-arguments" if $config{CXX};
 }
 
 if ($strict_warnings)

--- a/Configure
+++ b/Configure
@@ -1427,6 +1427,27 @@ if (!$disabled{makedepend}) {
     }
 }
 
+if (!$disabled{asm}) {
+    # probe for -Wa,--noexecstack option...
+    if ($predefined{__clang__}) {
+        # clang has builtin assembler, which doesn't recognize --help,
+        # but it apparently recognizes the option in question on all
+        # supported platforms even when it's meaningless. In other words
+        # probe would fail, but probed option always accepted...
+        push @{$config{cflags}}, "-Wa,--noexecstack";
+    } elsif ($^O ne 'VMS') {
+        my $cc = $config{CROSS_COMPILE}.$config{CC};
+        open(PIPE, "$cc -Wa,--help -c -o null.$$.o -x assembler /dev/null 2>&1 |");
+        while(<PIPE>) {
+            if (m/--noexecstack/) {
+                push @{$config{cflags}}, "-Wa,--noexecstack";
+                last;
+            }
+        }
+        close(PIPE);
+        unlink("null.$$.o");
+    }
+}
 
 # Deal with bn_ops ###################################################
 

--- a/Configure
+++ b/Configure
@@ -1407,7 +1407,7 @@ unless ($disabled{asm}) {
     }
 }
 
-my %predefined = compiler_predefined($config{CC});
+my %predefined = compiler_predefined($config{CROSS_COMPILE}.$config{CC});
 
 # Check for makedepend capabilities.
 if (!$disabled{makedepend}) {
@@ -3073,28 +3073,27 @@ sub run_dofile
 
 sub compiler_predefined {
     state %predefined;
-    my $default_compiler = shift;
+    my $cc = shift;
 
     return () if $^O eq 'VMS';
 
-    die 'compiler_predefined called without a default compiler'
-        unless $default_compiler;
+    die 'compiler_predefined called without a compiler command'
+        unless $cc;
 
-    if (! $predefined{$default_compiler}) {
-        my $cc = "$config{CROSS_COMPILE}$default_compiler";
+    if (! $predefined{$cc}) {
 
-        $predefined{$default_compiler} = {};
+        $predefined{$cc} = {};
 
         # collect compiler pre-defines from gcc or gcc-alike...
         open(PIPE, "$cc -dM -E -x c /dev/null 2>&1 |");
         while (my $l = <PIPE>) {
             $l =~ m/^#define\s+(\w+(?:\(\w+\))?)(?:\s+(.+))?/ or last;
-            $predefined{$default_compiler}->{$1} = $2 // '';
+            $predefined{$cc}->{$1} = $2 // '';
         }
         close(PIPE);
     }
 
-    return %{$predefined{$default_compiler}};
+    return %{$predefined{$cc}};
 }
 
 sub which

--- a/config
+++ b/config
@@ -840,14 +840,6 @@ if [ -n "$CONFIG_OPTIONS" ]; then
   options="$options $CONFIG_OPTIONS"
 fi
 
-if expr "$options" : '.*no\-asm' > /dev/null; then :; else
-  if sh -c "$CROSS_COMPILE${CC:-gcc} -Wa,--help -c -o /tmp/null.$$.o -x assembler /dev/null && rm /tmp/null.$$.o" 2>&1 | \
-         grep \\--noexecstack >/dev/null; then
-    __CNF_CFLAGS="$__CNF_CFLAGS -Wa,--noexecstack"
-    __CNF_CXXFLAGS="$__CNF_CXXFLAGS -Wa,--noexecstack"
-  fi
-fi
-
 # gcc < 2.8 does not support -march=ultrasparc
 if [ "$OUT" = solaris-sparcv9-gcc -a $GCCVER -lt 28 ]
 then


### PR DESCRIPTION
Second commit is not directly related, so feel free to approve only first commit. But rationale for second commit is that adding cross-compile prefix in the compile_predefined function doesn't feel like right spot. And variable named default_compiler appears misleading in the context. Function appears to mean to cache predefines for multiple compilers, i.e. it doesn't sound like it's supposed to have a notion of "default compiler".