### PR TITLE
BIO_s_mem() write: Skip early when input length is zero

### DIFF
--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -216,6 +216,8 @@ static int mem_write(BIO *b, const char *in, int inl)
         goto end;
     }
     BIO_clear_retry_flags(b);
+    if (inl == 0)
+        return 0;
     blen = bbm->readp->length;
     mem_buf_sync(b);
     if (BUF_MEM_grow_clean(bbm->buf, blen + inl) == 0)


### PR DESCRIPTION
When the input length is zero, just return zero early.  Otherwise,
there's a small chance that memory allocation is engaged, fails and
returns -1, which is a bit confusing when nothing should be written.

Fixes #4782 #4827
