### PR TITLE
.travis.yml: minor facelift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,6 @@ before_install:
           git submodule update --init --recursive;
       fi;
 
-addons:
-    apt:
-        packages:
-            - ccache
-            - golang-1.6
-
 os:
     - linux
     - osx
@@ -48,8 +42,8 @@ matrix:
           compiler: gcc-5
           env: CONFIG_OPTS="--strict-warnings" COMMENT="Move to the BORINGTEST build when interoperable"
         - os: linux
-          compiler: clang-3.9
-          env: CONFIG_OPTS="--strict-warnings no-deprecated" BUILDONLY="yes"
+          compiler: clang
+          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES no-deprecated" BUILDONLY="yes"
         - os: linux
           addons:
               apt:
@@ -64,6 +58,7 @@ matrix:
                   packages:
                       - gcc-5
                       - g++-5
+                      - golang-1.6
                   sources:
                       - ubuntu-toolchain-r-test
           compiler: gcc-5
@@ -74,19 +69,20 @@ matrix:
                   packages:
                       - gcc-5
                       - g++-5
+                      - golang-1.6
                   sources:
                       - ubuntu-toolchain-r-test
           compiler: gcc-5
           env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-external-tests" BORINGSSL_TESTS="yes" CXX="g++-5" TESTS=95
         - os: linux
-          compiler: clang-3.9
-          env: EXTENDED_TEST="yes" CONFIG_OPTS="enable-msan"
+          compiler: clang
+          env: EXTENDED_TEST="yes" CONFIG_OPTS="enable-msan -D__NO_STRING_INLINES -Wno-unused-command-line-argument"
         - os: linux
-          compiler: clang-3.9
-          env:  EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg -fno-sanitize=alignment no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+          compiler: clang
+          env:  EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg no-shared -fno-sanitize=alignment -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -D__NO_STRING_INLINES -Wno-unused-command-line-argument"
         - os: linux
-          compiler: clang-3.9
-          env: EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2 no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+          compiler: clang
+          env: EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2 no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -D__NO_STRING_INLINES -Wno-unused-command-line-argument"
         - os: linux
           addons:
               apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,16 +83,16 @@ matrix:
         - os: linux
           compiler: clang
           env: EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-asan enable-rc5 enable-md2 no-shared -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -D__NO_STRING_INLINES -Wno-unused-command-line-argument"
-        - os: linux
-          addons:
-              apt:
-                  packages:
-                      - gcc-5
-                      - g++-5
-                  sources:
-                      - ubuntu-toolchain-r-test
-          compiler: gcc-5
-          env: EXTENDED_TEST="yes" CONFIG_OPTS="--debug no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC" OPENSSL_TEST_RAND_ORDER=0
+        #- os: linux
+        #  addons:
+        #      apt:
+        #          packages:
+        #              - gcc-5
+        #              - g++-5
+        #          sources:
+        #              - ubuntu-toolchain-r-test
+        #  compiler: gcc-5
+        #  env: EXTENDED_TEST="yes" CONFIG_OPTS="--debug no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC" OPENSSL_TEST_RAND_ORDER=0
         - os: linux
           addons:
               apt:


### PR DESCRIPTION
Apparently trusty image has newer clang, there is no need to pull
clang-3.9 packages. It's clang-5.0.0, installation is a bit buggy,
as it fails to compile for example strcmp(s,"-") without warning,
but it's argued that benefits of exercising newer sanitizer outweights
the inconvenience of additional -Wno-array-bounds.
    
Also pull golang when actually needed.
