### PR TITLE
Check for NULL before calling BN_CTX_end

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2001-2018 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
@@ -309,7 +310,8 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
  err:
     EC_POINT_free(s);
-    BN_CTX_end(ctx);
+    if (ctx != NULL)
+        BN_CTX_end(ctx);
     BN_CTX_free(new_ctx);
 
     return ret;


### PR DESCRIPTION
Fixes a coverity issue reported on April 29.
