### PR TITLE
add no-ecp_nistz256_asm config option

### DIFF
--- a/Configure
+++ b/Configure
@@ -352,6 +352,7 @@ my @disablables = (
     "ecdh",
     "ecdsa",
     "ec_nistp_64_gcc_128",
+    "ecp_nistz256_asm",
     "egd",
     "engine",
     "err",
@@ -1393,9 +1394,7 @@ unless ($disabled{asm}) {
     if ($target{modes_asm_src} =~ /ghash-/) {
 	push @{$config{lib_defines}}, "GHASH_ASM";
     }
-    if ($target{ec_asm_src} =~ /ecp_nistz256/) {
-	push @{$config{lib_defines}}, "ECP_NISTZ256_ASM";
-    }
+    push @{$config{lib_defines}}, "ECP_NISTZ256_ASM" if (!$disabled{ecp_nistz256_asm} && $target{ec_asm_src} =~ /ecp_nistz256/);
     if ($target{ec_asm_src} =~ /x25519/) {
 	push @{$config{lib_defines}}, "X25519_ASM";
     }


### PR DESCRIPTION
I do a lot of testing for different architecture-dependent code paths. This is a handy option in regression testing.