### PR TITLE
 Prefer SHA-256 ciphersuites if using old style PSKs

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -71,6 +71,9 @@ B<openssl> B<s_client>
 [B<-crlf>]
 [B<-ign_eof>]
 [B<-no_ign_eof>]
+[B<-psk_identity identity>]
+[B<-psk key>]
+[B<-psk_session file>]
 [B<-quiet>]
 [B<-ssl3>]
 [B<-tls1>]
@@ -408,6 +411,11 @@ Use the PSK key B<key> when using a PSK cipher suite. The key is
 given as a hexadecimal number without leading 0x, for example -psk
 1a2b3c4d.
 This option must be provided in order to use a PSK cipher.
+
+=item B<-psk_session file>
+
+Use the pem encoded SSL_SESSION data stored in B<file> as the basis of a PSK.
+Note that this will only work if TLSv1.3 is negotiated.
 
 =item B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -157,6 +157,7 @@ B<openssl> B<s_server>
 [B<-psk_identity val>]
 [B<-psk_hint val>]
 [B<-psk val>]
+[B<-psk_session file>]
 [B<-srpvfile infile>]
 [B<-srpuserseed val>]
 [B<-ssl3>]
@@ -596,6 +597,11 @@ Use the PSK key B<val> when using a PSK cipher suite. The key is
 given as a hexadecimal number without leading 0x, for example -psk
 1a2b3c4d.
 This option must be provided in order to use a PSK cipher.
+
+=item B<-psk_session file>
+
+Use the pem encoded SSL_SESSION data stored in B<file> as the basis of a PSK.
+Note that this will only work if TLSv1.3 is negotiated.
 
 =item B<-listen>
 

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -594,12 +594,15 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
                                                             max_proto_version)))))
         goto err;
 
-    if (!TEST_int_eq(SSL_CTX_use_certificate_file(serverctx, certfile,
-                                                  SSL_FILETYPE_PEM), 1)
-            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(serverctx, privkeyfile,
-                                                        SSL_FILETYPE_PEM), 1)
-            || !TEST_int_eq(SSL_CTX_check_private_key(serverctx), 1))
-        goto err;
+    if (certfile != NULL && privkeyfile != NULL) {
+        if (!TEST_int_eq(SSL_CTX_use_certificate_file(serverctx, certfile,
+                                                      SSL_FILETYPE_PEM), 1)
+                || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(serverctx,
+                                                            privkeyfile,
+                                                            SSL_FILETYPE_PEM), 1)
+                || !TEST_int_eq(SSL_CTX_check_private_key(serverctx), 1))
+            goto err;
+    }
 
 #ifndef OPENSSL_NO_DH
     SSL_CTX_set_dh_auto(serverctx, 1);


### PR DESCRIPTION
If we have no certificate and we are using "old style" PSKs then we will
always default to using SHA-256 for that PSK. However we may have selected
a ciphersuite that is not based on SHA-256. Therefore if we see that there
are no certificates and we have been configured for "old style" PSKs then
we should prefer SHA-256 based ciphersuites during the selection process.

Fixes #6197

While I was at it I also fixed the documentation issue also noted in #6197.