### PR TITLE
prevent app_get_pass() from revealing cleartext password on syntax error

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -265,7 +265,7 @@ static char *app_get_pass(const char *arg, int keepbio)
             else
                 BIO_printf(bio_err,
                           "Invalid password argument, starting with \"%.*s\"\n",
-                           tmp - arg + 1, arg);
+                           (int)(tmp - arg + 1), arg);
             return NULL;
         }
     }

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -207,6 +207,7 @@ static char *app_get_pass(const char *arg, int keepbio)
     char *tmp, tpass[APP_PASS_LEN];
     int i;
 
+    /* PASS_SOURCE_SIZE_MAX = max number of chars before ':' in below strings */
     if (strncmp(arg, "pass:", 5) == 0)
         return OPENSSL_strdup(arg + 5);
     if (strncmp(arg, "env:", 4) == 0) {

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -253,7 +253,17 @@ static char *app_get_pass(const char *arg, int keepbio)
                 return NULL;
             }
         } else {
-            BIO_printf(bio_err, "Invalid password argument \"%s\"\n", arg);
+            /* argument syntax error; do not reveal too much about arg */
+            #define SOURCE_SIZE_MAX 4
+            tmp = strchr(arg, ':');
+            if (tmp == NULL || tmp - arg > SOURCE_SIZE_MAX)
+                BIO_printf(bio_err,
+           "Invalid password argument, missing ':' within the first %d chars\n",
+                           SOURCE_SIZE_MAX + 1);
+            else
+                BIO_printf(bio_err,
+                          "Invalid password argument, starting with \"%.*s\"\n",
+                           tmp - arg + 1, arg);
             return NULL;
         }
     }

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -260,7 +260,7 @@ static char *app_get_pass(const char *arg, int keepbio)
             tmp = strchr(arg, ':');
             if (tmp == NULL || tmp - arg > PASS_SOURCE_SIZE_MAX)
                 BIO_printf(bio_err,
-           "Invalid password argument, missing ':' within the first %d chars\n",
+                           "Invalid password argument, missing ':' within the first %d chars\n",
                            PASS_SOURCE_SIZE_MAX + 1);
             else
                 BIO_printf(bio_err,

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -264,7 +264,7 @@ static char *app_get_pass(const char *arg, int keepbio)
                            PASS_SOURCE_SIZE_MAX + 1);
             else
                 BIO_printf(bio_err,
-                          "Invalid password argument, starting with \"%.*s\"\n",
+                           "Invalid password argument, starting with \"%.*s\"\n",
                            (int)(tmp - arg + 1), arg);
             return NULL;
         }

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -48,6 +48,8 @@ static int WIN32_rename(const char *from, const char *to);
 # define rename(from,to) WIN32_rename((from),(to))
 #endif
 
+#define PASS_SOURCE_SIZE_MAX 4
+
 typedef struct {
     const char *name;
     unsigned long flag;
@@ -254,12 +256,11 @@ static char *app_get_pass(const char *arg, int keepbio)
             }
         } else {
             /* argument syntax error; do not reveal too much about arg */
-            #define SOURCE_SIZE_MAX 4
             tmp = strchr(arg, ':');
-            if (tmp == NULL || tmp - arg > SOURCE_SIZE_MAX)
+            if (tmp == NULL || tmp - arg > PASS_SOURCE_SIZE_MAX)
                 BIO_printf(bio_err,
            "Invalid password argument, missing ':' within the first %d chars\n",
-                           SOURCE_SIZE_MAX + 1);
+                           PASS_SOURCE_SIZE_MAX + 1);
             else
                 BIO_printf(bio_err,
                           "Invalid password argument, starting with \"%.*s\"\n",


### PR DESCRIPTION
When a user of the OpenSSL CLI makes a syntax error with the password argument of any of the `openssl` apps, the whole argument is echoed on the console for diagnostic purposes. I find this a bit risky since this may reveal sensitive password contents on the screen or in logs. 

This PR limits the diagnostic output to at most, e.g., 4 characters and does not echo the argument of the `-pass` option at all if it does not contain a '`:`' within the first 5 characters, indicating that a prefix like `pass:` or `file:` is missing.