### PR TITLE
streamline textual output of X509 certs and CRLs: remove empty lines, add/remove tag, correct indentation

### DIFF
--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -458,6 +458,8 @@ static int dsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
         DSA_SIG_free(dsa_sig);
         return rv;
     }
+    if (BIO_puts(bp, "\n") <= 0)
+        return 0;
     return X509_signature_dump(bp, sig, indent);
 }
 

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -447,7 +447,7 @@ static int rsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
         RSA_PSS_PARAMS_free(pss);
         if (!rv)
             return 0;
-    } else if (!sig && BIO_puts(bp, "\n") <= 0) {
+    } else if (BIO_puts(bp, "\n") <= 0) {
         return 0;
     }
     if (sig)

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -302,11 +302,14 @@ int X509_signature_print(BIO *bp, const X509_ALGOR *sigalg,
                          const ASN1_STRING *sig)
 {
     int sig_nid;
-    if (BIO_puts(bp, "    Signature Algorithm: ") <= 0)
+    int indent = 4;
+    if (BIO_printf(bp, "%*sSignature Algorithm: ", indent, "") <= 0)
         return 0;
     if (i2a_ASN1_OBJECT(bp, sigalg->algorithm) <= 0)
         return 0;
 
+    if (sig && BIO_printf(bp, "\n%*sSignature Value:", indent, "") <= 0)
+        return 0;
     sig_nid = OBJ_obj2nid(sigalg->algorithm);
     if (sig_nid != NID_undef) {
         int pkey_nid, dig_nid;
@@ -314,13 +317,13 @@ int X509_signature_print(BIO *bp, const X509_ALGOR *sigalg,
         if (OBJ_find_sigid_algs(sig_nid, &dig_nid, &pkey_nid)) {
             ameth = EVP_PKEY_asn1_find(NULL, pkey_nid);
             if (ameth && ameth->sig_print)
-                return ameth->sig_print(bp, sigalg, sig, 9, 0);
+                return ameth->sig_print(bp, sigalg, sig, indent + 4, 0);
         }
     }
     if (BIO_write(bp, "\n", 1) != 1)
         return 0;
     if (sig)
-        return X509_signature_dump(bp, sig, 9);
+        return X509_signature_dump(bp, sig, indent + 4);
     return 1;
 }
 

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -284,7 +284,7 @@ int X509_signature_dump(BIO *bp, const ASN1_STRING *sig, int indent)
     s = sig->data;
     for (i = 0; i < n; i++) {
         if ((i % 18) == 0) {
-            if (BIO_write(bp, "\n", 1) <= 0)
+            if (i > 0 && BIO_write(bp, "\n", 1) <= 0)
                 return 0;
             if (BIO_indent(bp, indent, indent) <= 0)
                 return 0;
@@ -317,10 +317,10 @@ int X509_signature_print(BIO *bp, const X509_ALGOR *sigalg,
                 return ameth->sig_print(bp, sigalg, sig, 9, 0);
         }
     }
+    if (BIO_write(bp, "\n", 1) != 1)
+        return 0;
     if (sig)
         return X509_signature_dump(bp, sig, 9);
-    else if (BIO_puts(bp, "\n") <= 0)
-        return 0;
     return 1;
 }
 

--- a/crypto/x509v3/v3_akey.c
+++ b/crypto/x509v3/v3_akey.c
@@ -42,7 +42,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     char *tmp;
     if (akeyid->keyid) {
         tmp = OPENSSL_buf2hexstr(akeyid->keyid->data, akeyid->keyid->length);
-        X509V3_add_value("keyid", tmp, &extlist);
+        X509V3_add_value(akeyid->issuer || akeyid->serial ? "keyid" : NULL, tmp, &extlist);
         OPENSSL_free(tmp);
     }
     if (akeyid->issuer)

--- a/crypto/x509v3/v3_akey.c
+++ b/crypto/x509v3/v3_akey.c
@@ -42,7 +42,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     char *tmp;
     if (akeyid->keyid) {
         tmp = OPENSSL_buf2hexstr(akeyid->keyid->data, akeyid->keyid->length);
-        X509V3_add_value(akeyid->issuer || akeyid->serial ? "keyid" : NULL, tmp, &extlist);
+        X509V3_add_value((akeyid->issuer || akeyid->serial) ? "keyid" : NULL, tmp, &extlist);
         OPENSSL_free(tmp);
     }
     if (akeyid->issuer)

--- a/crypto/x509v3/v3_alt.c
+++ b/crypto/x509v3/v3_alt.c
@@ -183,7 +183,6 @@ int GENERAL_NAME_print(BIO *out, GENERAL_NAME *gen)
                 BIO_printf(out, ":%X", p[0] << 8 | p[1]);
                 p += 2;
             }
-            BIO_puts(out, "\n");
         } else {
             BIO_printf(out, "IP Address:<invalid>");
             break;

--- a/crypto/x509v3/v3_cpols.c
+++ b/crypto/x509v3/v3_cpols.c
@@ -403,12 +403,15 @@ static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
     POLICYINFO *pinfo;
     /* First print out the policy OIDs */
     for (i = 0; i < sk_POLICYINFO_num(pol); i++) {
+        if (i > 0)
+            BIO_puts(out, "\n");
         pinfo = sk_POLICYINFO_value(pol, i);
         BIO_printf(out, "%*sPolicy: ", indent, "");
         i2a_ASN1_OBJECT(out, pinfo->policyid);
-        BIO_puts(out, "\n");
-        if (pinfo->qualifiers)
+        if (pinfo->qualifiers) {
+            BIO_puts(out, "\n");
             print_qualifiers(out, pinfo->qualifiers, indent + 2);
+        }
     }
     return 1;
 }
@@ -419,10 +422,12 @@ static void print_qualifiers(BIO *out, STACK_OF(POLICYQUALINFO) *quals,
     POLICYQUALINFO *qualinfo;
     int i;
     for (i = 0; i < sk_POLICYQUALINFO_num(quals); i++) {
+        if (i > 0)
+            BIO_puts(out, "\n");
         qualinfo = sk_POLICYQUALINFO_value(quals, i);
         switch (OBJ_obj2nid(qualinfo->pqualid)) {
         case NID_id_qt_cps:
-            BIO_printf(out, "%*sCPS: %s\n", indent, "",
+            BIO_printf(out, "%*sCPS: %s", indent, "",
                        qualinfo->d.cpsuri->data);
             break;
 
@@ -435,7 +440,6 @@ static void print_qualifiers(BIO *out, STACK_OF(POLICYQUALINFO) *quals,
             BIO_printf(out, "%*sUnknown Qualifier: ", indent + 2, "");
 
             i2a_ASN1_OBJECT(out, qualinfo->pqualid);
-            BIO_puts(out, "\n");
             break;
         }
     }
@@ -467,10 +471,11 @@ static void print_notice(BIO *out, USERNOTICE *notice, int indent)
                 OPENSSL_free(tmp);
             }
         }
-        BIO_puts(out, "\n");
+        if (notice->exptext)
+            BIO_puts(out, "\n");
     }
     if (notice->exptext)
-        BIO_printf(out, "%*sExplicit Text: %s\n", indent, "",
+        BIO_printf(out, "%*sExplicit Text: %s", indent, "",
                    notice->exptext->data);
 }
 
@@ -484,8 +489,10 @@ void X509_POLICY_NODE_print(BIO *out, X509_POLICY_NODE *node, int indent)
     BIO_puts(out, "\n");
     BIO_printf(out, "%*s%s\n", indent + 2, "",
                node_data_critical(dat) ? "Critical" : "Non Critical");
-    if (dat->qualifier_set)
+    if (dat->qualifier_set) {
         print_qualifiers(out, dat->qualifier_set, indent + 2);
+        BIO_puts(out, "\n");
+    }
     else
         BIO_printf(out, "%*sNo Qualifiers\n", indent + 2, "");
 }

--- a/crypto/x509v3/v3_crld.c
+++ b/crypto/x509v3/v3_crld.c
@@ -410,9 +410,10 @@ static int print_gens(BIO *out, STACK_OF(GENERAL_NAME) *gens, int indent)
 {
     int i;
     for (i = 0; i < sk_GENERAL_NAME_num(gens); i++) {
+        if (i > 0)
+            BIO_puts(out, "\n");
         BIO_printf(out, "%*s", indent + 2, "");
         GENERAL_NAME_print(out, sk_GENERAL_NAME_value(gens, i));
-        BIO_puts(out, "\n");
     }
     return 1;
 }
@@ -463,7 +464,8 @@ static int i2r_crldp(const X509V3_EXT_METHOD *method, void *pcrldp, BIO *out,
     DIST_POINT *point;
     int i;
     for (i = 0; i < sk_DIST_POINT_num(crld); i++) {
-        BIO_puts(out, "\n");
+        if (i > 0)
+            BIO_puts(out, "\n");
         point = sk_DIST_POINT_value(crld, i);
         if (point->distpoint)
             print_distpoint(out, point->distpoint, indent);

--- a/crypto/x509v3/v3_ncons.c
+++ b/crypto/x509v3/v3_ncons.c
@@ -158,6 +158,8 @@ static int i2r_NAME_CONSTRAINTS(const X509V3_EXT_METHOD *method, void *a,
     NAME_CONSTRAINTS *ncons = a;
     do_i2r_name_constraints(method, ncons->permittedSubtrees,
                             bp, ind, "Permitted");
+    if (ncons->permittedSubtrees && ncons->excludedSubtrees)
+        BIO_puts(bp, "\n");
     do_i2r_name_constraints(method, ncons->excludedSubtrees,
                             bp, ind, "Excluded");
     return 1;
@@ -172,13 +174,14 @@ static int do_i2r_name_constraints(const X509V3_EXT_METHOD *method,
     if (sk_GENERAL_SUBTREE_num(trees) > 0)
         BIO_printf(bp, "%*s%s:\n", ind, "", name);
     for (i = 0; i < sk_GENERAL_SUBTREE_num(trees); i++) {
+        if (i > 0)
+            BIO_puts(bp, "\n");
         tree = sk_GENERAL_SUBTREE_value(trees, i);
         BIO_printf(bp, "%*s", ind + 2, "");
         if (tree->base->type == GEN_IPADD)
             print_nc_ipadd(bp, tree->base->d.ip);
         else
             GENERAL_NAME_print(bp, tree->base);
-        BIO_puts(bp, "\n");
     }
     return 1;
 }

--- a/crypto/x509v3/v3_pci.c
+++ b/crypto/x509v3/v3_pci.c
@@ -75,9 +75,8 @@ static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *pci,
     BIO_puts(out, "\n");
     BIO_printf(out, "%*sPolicy Language: ", indent, "");
     i2a_ASN1_OBJECT(out, pci->proxyPolicy->policyLanguage);
-    BIO_puts(out, "\n");
     if (pci->proxyPolicy->policy && pci->proxyPolicy->policy->data)
-        BIO_printf(out, "%*sPolicy Text: %s\n", indent, "",
+        BIO_printf(out, "\n%*sPolicy Text: %s", indent, "",
                    pci->proxyPolicy->policy->data);
     return 1;
 }

--- a/crypto/x509v3/v3_prn.c
+++ b/crypto/x509v3/v3_prn.c
@@ -34,8 +34,11 @@ void X509V3_EXT_val_prn(BIO *out, STACK_OF(CONF_VALUE) *val, int indent,
             BIO_puts(out, "<EMPTY>\n");
     }
     for (i = 0; i < sk_CONF_VALUE_num(val); i++) {
-        if (ml)
+        if (ml) {
+            if (i > 0)
+                BIO_printf(out, "\n");
             BIO_printf(out, "%*s", indent, "");
+        }
         else if (i > 0)
             BIO_printf(out, ", ");
         nval = sk_CONF_VALUE_value(val, i);
@@ -59,8 +62,6 @@ void X509V3_EXT_val_prn(BIO *out, STACK_OF(CONF_VALUE) *val, int indent,
             }
         }
 #endif
-        if (ml)
-            BIO_puts(out, "\n");
     }
 }
 

--- a/test/certs/cyrillic.msb
+++ b/test/certs/cyrillic.msb
@@ -40,21 +40,22 @@ Certificate:
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         04:8f:c3:77:48:06:29:c0:8d:66:2e:6b:48:a3:b3:e0:dd:5b:
-         0a:e7:a4:0b:7e:72:91:fc:37:29:7f:81:1e:60:66:7b:ba:94:
-         30:f8:c0:79:56:bc:ed:87:88:d9:bd:d8:7b:dc:1b:87:bb:ef:
-         15:d0:77:74:59:d7:3f:30:09:71:86:da:d7:d7:50:cb:ef:8f:
-         34:26:76:b5:0a:de:d0:ce:ca:40:57:86:ce:13:24:2a:9e:97:
-         db:5d:3e:73:8c:24:cc:89:84:42:04:45:62:f9:fd:4b:79:b2:
-         1b:a0:01:d7:4c:1f:4d:d1:4c:5b:99:0a:27:5e:c9:79:3c:0f:
-         b7:3c:09:db:32:d6:ca:56:91:32:0d:7f:79:94:bc:bc:a8:ba:
-         54:4b:39:6e:2d:9a:21:77:13:f8:b5:62:5d:a8:8c:c8:8d:ec:
-         67:6c:14:2d:f6:ce:e6:d3:a6:fa:37:36:5b:31:7a:80:66:83:
-         02:64:82:c1:ec:bf:38:8e:49:b0:e5:ec:09:9b:80:16:e4:32:
-         91:4e:72:c4:5f:2d:b3:e9:57:b1:00:36:2d:1a:e9:9f:4a:b1:
-         1c:d1:ae:fb:15:79:02:0b:14:97:81:ee:42:01:ed:00:58:38:
-         b2:30:89:f2:89:11:b7:03:7c:16:95:30:eb:32:9c:9f:00:e5:
-         22:12:db:7a
+    Signature Value:
+        04:8f:c3:77:48:06:29:c0:8d:66:2e:6b:48:a3:b3:e0:dd:5b:
+        0a:e7:a4:0b:7e:72:91:fc:37:29:7f:81:1e:60:66:7b:ba:94:
+        30:f8:c0:79:56:bc:ed:87:88:d9:bd:d8:7b:dc:1b:87:bb:ef:
+        15:d0:77:74:59:d7:3f:30:09:71:86:da:d7:d7:50:cb:ef:8f:
+        34:26:76:b5:0a:de:d0:ce:ca:40:57:86:ce:13:24:2a:9e:97:
+        db:5d:3e:73:8c:24:cc:89:84:42:04:45:62:f9:fd:4b:79:b2:
+        1b:a0:01:d7:4c:1f:4d:d1:4c:5b:99:0a:27:5e:c9:79:3c:0f:
+        b7:3c:09:db:32:d6:ca:56:91:32:0d:7f:79:94:bc:bc:a8:ba:
+        54:4b:39:6e:2d:9a:21:77:13:f8:b5:62:5d:a8:8c:c8:8d:ec:
+        67:6c:14:2d:f6:ce:e6:d3:a6:fa:37:36:5b:31:7a:80:66:83:
+        02:64:82:c1:ec:bf:38:8e:49:b0:e5:ec:09:9b:80:16:e4:32:
+        91:4e:72:c4:5f:2d:b3:e9:57:b1:00:36:2d:1a:e9:9f:4a:b1:
+        1c:d1:ae:fb:15:79:02:0b:14:97:81:ee:42:01:ed:00:58:38:
+        b2:30:89:f2:89:11:b7:03:7c:16:95:30:eb:32:9c:9f:00:e5:
+        22:12:db:7a
 -----BEGIN CERTIFICATE-----
 MIIEPTCCAyWgAwIBAgIJAL5HPFOmKsA6MA0GCSqGSIb3DQEBCwUAMIG0MQswCQYD
 VQQGEwJSVTEVMBMGA1UECAwM0JzQvtGB0LrQstCwMRUwEwYDVQQHDAzQnNC+0YHQ

--- a/test/certs/cyrillic.msb
+++ b/test/certs/cyrillic.msb
@@ -36,8 +36,7 @@ Certificate:
             X509v3 Subject Key Identifier: 
                 11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
             X509v3 Authority Key Identifier: 
-                keyid:11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
-
+                11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption

--- a/test/certs/cyrillic.utf8
+++ b/test/certs/cyrillic.utf8
@@ -40,21 +40,22 @@ Certificate:
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         04:8f:c3:77:48:06:29:c0:8d:66:2e:6b:48:a3:b3:e0:dd:5b:
-         0a:e7:a4:0b:7e:72:91:fc:37:29:7f:81:1e:60:66:7b:ba:94:
-         30:f8:c0:79:56:bc:ed:87:88:d9:bd:d8:7b:dc:1b:87:bb:ef:
-         15:d0:77:74:59:d7:3f:30:09:71:86:da:d7:d7:50:cb:ef:8f:
-         34:26:76:b5:0a:de:d0:ce:ca:40:57:86:ce:13:24:2a:9e:97:
-         db:5d:3e:73:8c:24:cc:89:84:42:04:45:62:f9:fd:4b:79:b2:
-         1b:a0:01:d7:4c:1f:4d:d1:4c:5b:99:0a:27:5e:c9:79:3c:0f:
-         b7:3c:09:db:32:d6:ca:56:91:32:0d:7f:79:94:bc:bc:a8:ba:
-         54:4b:39:6e:2d:9a:21:77:13:f8:b5:62:5d:a8:8c:c8:8d:ec:
-         67:6c:14:2d:f6:ce:e6:d3:a6:fa:37:36:5b:31:7a:80:66:83:
-         02:64:82:c1:ec:bf:38:8e:49:b0:e5:ec:09:9b:80:16:e4:32:
-         91:4e:72:c4:5f:2d:b3:e9:57:b1:00:36:2d:1a:e9:9f:4a:b1:
-         1c:d1:ae:fb:15:79:02:0b:14:97:81:ee:42:01:ed:00:58:38:
-         b2:30:89:f2:89:11:b7:03:7c:16:95:30:eb:32:9c:9f:00:e5:
-         22:12:db:7a
+    Signature Value:
+        04:8f:c3:77:48:06:29:c0:8d:66:2e:6b:48:a3:b3:e0:dd:5b:
+        0a:e7:a4:0b:7e:72:91:fc:37:29:7f:81:1e:60:66:7b:ba:94:
+        30:f8:c0:79:56:bc:ed:87:88:d9:bd:d8:7b:dc:1b:87:bb:ef:
+        15:d0:77:74:59:d7:3f:30:09:71:86:da:d7:d7:50:cb:ef:8f:
+        34:26:76:b5:0a:de:d0:ce:ca:40:57:86:ce:13:24:2a:9e:97:
+        db:5d:3e:73:8c:24:cc:89:84:42:04:45:62:f9:fd:4b:79:b2:
+        1b:a0:01:d7:4c:1f:4d:d1:4c:5b:99:0a:27:5e:c9:79:3c:0f:
+        b7:3c:09:db:32:d6:ca:56:91:32:0d:7f:79:94:bc:bc:a8:ba:
+        54:4b:39:6e:2d:9a:21:77:13:f8:b5:62:5d:a8:8c:c8:8d:ec:
+        67:6c:14:2d:f6:ce:e6:d3:a6:fa:37:36:5b:31:7a:80:66:83:
+        02:64:82:c1:ec:bf:38:8e:49:b0:e5:ec:09:9b:80:16:e4:32:
+        91:4e:72:c4:5f:2d:b3:e9:57:b1:00:36:2d:1a:e9:9f:4a:b1:
+        1c:d1:ae:fb:15:79:02:0b:14:97:81:ee:42:01:ed:00:58:38:
+        b2:30:89:f2:89:11:b7:03:7c:16:95:30:eb:32:9c:9f:00:e5:
+        22:12:db:7a
 -----BEGIN CERTIFICATE-----
 MIIEPTCCAyWgAwIBAgIJAL5HPFOmKsA6MA0GCSqGSIb3DQEBCwUAMIG0MQswCQYD
 VQQGEwJSVTEVMBMGA1UECAwM0JzQvtGB0LrQstCwMRUwEwYDVQQHDAzQnNC+0YHQ

--- a/test/certs/cyrillic.utf8
+++ b/test/certs/cyrillic.utf8
@@ -36,8 +36,7 @@ Certificate:
             X509v3 Subject Key Identifier: 
                 11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
             X509v3 Authority Key Identifier: 
-                keyid:11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
-
+                11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption

--- a/test/certs/cyrillic_crl.utf8
+++ b/test/certs/cyrillic_crl.utf8
@@ -9,21 +9,22 @@ Certificate Revocation List (CRL):
                 1
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         85:e5:e5:fe:d4:13:3f:07:1a:07:53:6f:f7:a5:01:c9:80:f4:
-         8a:7a:f3:74:fc:af:dd:6a:21:47:88:99:7b:29:bf:46:0b:02:
-         98:d7:80:75:46:f6:cd:da:b5:0f:ff:9f:0c:b7:e6:aa:8e:f6:
-         ae:7f:5c:81:ce:56:89:41:e2:4a:65:cb:02:98:6f:69:e9:3a:
-         f5:cb:40:49:5e:1a:ea:e6:40:b4:48:bc:8d:0e:c7:c6:51:37:
-         ee:c6:7c:26:a3:e7:25:1d:74:54:fa:02:ae:93:e8:74:5a:42:
-         4b:d3:6d:99:61:b2:77:f3:0e:7c:f2:4e:0d:4f:70:96:54:77:
-         84:db:71:03:0b:6e:b8:a7:de:36:9a:50:c4:ed:e9:fa:33:22:
-         f5:e7:63:de:2d:df:58:ad:68:aa:e6:23:88:3a:b2:1b:40:b1:
-         2b:ab:41:23:c3:1b:c7:1b:db:0c:89:81:54:6b:a5:6b:c2:64:
-         5f:db:a9:f2:67:bb:bd:44:a2:43:3f:ea:36:76:5b:70:76:20:
-         5a:49:70:b7:42:dd:e9:67:c0:48:7e:ff:e5:f3:59:70:a7:c0:
-         eb:eb:74:b0:08:82:36:a4:84:69:97:22:02:75:0a:a6:5f:f6:
-         be:d6:af:24:4e:15:c8:3f:62:b1:f9:7e:3c:83:b5:44:da:8d:
-         97:e1:c7:f2
+    Signature Value:
+        85:e5:e5:fe:d4:13:3f:07:1a:07:53:6f:f7:a5:01:c9:80:f4:
+        8a:7a:f3:74:fc:af:dd:6a:21:47:88:99:7b:29:bf:46:0b:02:
+        98:d7:80:75:46:f6:cd:da:b5:0f:ff:9f:0c:b7:e6:aa:8e:f6:
+        ae:7f:5c:81:ce:56:89:41:e2:4a:65:cb:02:98:6f:69:e9:3a:
+        f5:cb:40:49:5e:1a:ea:e6:40:b4:48:bc:8d:0e:c7:c6:51:37:
+        ee:c6:7c:26:a3:e7:25:1d:74:54:fa:02:ae:93:e8:74:5a:42:
+        4b:d3:6d:99:61:b2:77:f3:0e:7c:f2:4e:0d:4f:70:96:54:77:
+        84:db:71:03:0b:6e:b8:a7:de:36:9a:50:c4:ed:e9:fa:33:22:
+        f5:e7:63:de:2d:df:58:ad:68:aa:e6:23:88:3a:b2:1b:40:b1:
+        2b:ab:41:23:c3:1b:c7:1b:db:0c:89:81:54:6b:a5:6b:c2:64:
+        5f:db:a9:f2:67:bb:bd:44:a2:43:3f:ea:36:76:5b:70:76:20:
+        5a:49:70:b7:42:dd:e9:67:c0:48:7e:ff:e5:f3:59:70:a7:c0:
+        eb:eb:74:b0:08:82:36:a4:84:69:97:22:02:75:0a:a6:5f:f6:
+        be:d6:af:24:4e:15:c8:3f:62:b1:f9:7e:3c:83:b5:44:da:8d:
+        97:e1:c7:f2
 -----BEGIN X509 CRL-----
 MIIB6DCB0QIBATANBgkqhkiG9w0BAQsFADCBjjELMAkGA1UEBhMCUlUxFTATBgNV
 BAgMDNCc0L7RgdC60LLQsDELMAkGA1UECgwC0K8xCzAJBgNVBAsMAtCvMSowKAYD


### PR DESCRIPTION
This makes X.509 printing slightly more consistent.

When viewing textual certificate output, e.g., of the `x509` app, I was often wondering why there is an empty line between the output of "X509v3 Authority Key Identifier:" and "X509v3 Basic Constraints:".
Moreover, the value printed for "X509v3 Authority Key Identifier:" is prepended by the tag `keyid`", which is not the case for "X509v3 Subject Key Identifier:", such that the output in particular for self-signed certs looks a bit odd, for instance:
```
            X509v3 Subject Key Identifier:
                11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
            X509v3 Authority Key Identifier:
                keyid:11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22

            X509v3 Basic Constraints:
                CA:TRUE
```
This PR streamlines such output to, in the above example,
```
            X509v3 Subject Key Identifier:
                11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
            X509v3 Authority Key Identifier:
                11:49:46:19:2A:4E:4D:D1:C8:FB:79:55:3D:81:99:22:EE:34:4F:22
            X509v3 Basic Constraints:
                CA:TRUE
```
The tag `keyid:` is left out only if the X509v3 Authority Key Identifier, as usual, does not also include an `issuer` or `serial` sub-field.
Also other (less common) occurrences of empty lines are eliminated. This was more effort than expected because the handling of newlines is implicit and spread across many places. I did not recognize a consistent design behind it.

I also found that the output of signature values at the end of certs and CRLs is slightly inconsistent because there no tag is given for the `signatureValue` and the indentation of the actual value is 9 rather than 8 (= 2 * 4). This is also corrected, such that, for instance,
```
    Signature Algorithm: sha256WithRSAEncryption
         04:8f:c3:77:48:06:29:c0:8d:66:2e:6b:48:a3:b3:e0:dd:5b:
         0a:e7:a4:0b:7e:72:91:fc:37:29:7f:81:1e:60:66:7b:ba:94:
```
becomes
```
    Signature Algorithm: sha256WithRSAEncryption
    Signature Value:
        04:8f:c3:77:48:06:29:c0:8d:66:2e:6b:48:a3:b3:e0:dd:5b:
        0a:e7:a4:0b:7e:72:91:fc:37:29:7f:81:1e:60:66:7b:ba:94:
```
The overall effect of this PR on printing certs can be seen, at the example of one of the test certs at https://github.com/openssl/openssl/compare/master...siemens:X509V3_EXT_val_prn-multiline-fix?expand=1#diff-da7c216b91096b818848e5b53012606c

- [x] tests are added or updated
