### PR TITLE
Configure: Add option to disable build of applications

### DIFF
--- a/Configure
+++ b/Configure
@@ -319,6 +319,7 @@ my @dtls = qw(dtls1 dtls1_2);
 
 my @disablables = (
     "afalgeng",
+    "apps",
     "aria",
     "asan",
     "asm",


### PR DESCRIPTION
Exposing `apps` as an option gives users a chance to skip building openssl application executables.

CLA: trivial
