### PR TITLE
When configuring 'no-comp', zlib support should be disabled too [1.0.2]

### DIFF
--- a/Configure
+++ b/Configure
@@ -1173,6 +1173,7 @@ foreach (sort (keys %disabled))
 				$depflags .= " -DOPENSSL_NO_$ALGO";
 				}
 			}
+                        if (/^comp$/)	{ $zlib = 0; }
 		}
 
 	print "\n";


### PR DESCRIPTION
Fixes #6241
