### PR TITLE
CI config: no need to make both install and install_docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -229,7 +229,7 @@ script:
       fi
     - if [ -n "$DESTDIR" ]; then
           mkdir "$top/$DESTDIR";
-          if $make install install_docs DESTDIR="$top/$DESTDIR" >~/install.log 2>&1 ; then
+          if $make install DESTDIR="$top/$DESTDIR" >~/install.log 2>&1 ; then
               echo -e '+\057\057\057\057\057\057\057 MAKE INSTALL OK';
           else
               echo -e '+\057\057\057\057\057\057\057 MAKE INSTALL FAILED';

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,6 @@ test_script:
     - ps: >-
         if ($env:EXTENDED_TESTS) {
             mkdir ..\_install
-            cmd /c "nmake install install_docs DESTDIR=..\_install 2>&1"
+            cmd /c "nmake install DESTDIR=..\_install 2>&1"
         }
     - cd ..


### PR DESCRIPTION
'install' depends on 'install_docs', so making the latter explicit is
a waste.
