### PR TITLE
Add support SM3 and SM4 for Zhaoxin's platform

### DIFF
--- a/engines/asm/e_padlock-x86.pl
+++ b/engines/asm/e_padlock-x86.pl
@@ -631,19 +631,6 @@ my ($mode,$opcode) = @_;
 	&ret	();
 &function_end_B("gmi_xstore");
 
-&function_begin_B("_win32_segv_handler");
-	&mov	("eax",1);			# ExceptionContinueSearch
-	&mov	("edx",&wparam(0));		# *ExceptionRecord
-	&mov	("ecx",&wparam(2));		# *ContextRecord
-	&cmp	(&DWP(0,"edx"),0xC0000005)	# ExceptionRecord->ExceptionCode == STATUS_ACCESS_VIOLATION
-	&jne	(&label("ret"));
-	&add	(&DWP(184,"ecx"),4);		# skip over rep sha*
-	&mov	("eax",0);			# ExceptionContinueExecution
-&set_label("ret");
-	&ret	();
-&function_end_B("_win32_segv_handler");
-&safeseh("_win32_segv_handler")			if ($::win32);
-
 &function_begin_B("gmi_sm3_oneshot");
 	&push	("ebx");
 	&push	("edi");

--- a/engines/asm/e_padlock-x86.pl
+++ b/engines/asm/e_padlock-x86.pl
@@ -14,6 +14,11 @@
 # details see http://www.openssl.org/~appro/cryptogams/.
 # ====================================================================
 
+# ====================================================================
+# GMI's SM3 and SM4 assembly is Written by yunshen@zhaoxin.com and 
+# kelvinkli@zhaoxin.com. 
+# ====================================================================
+
 # September 2011
 #
 # Assembler helpers for Padlock engine. Compared to original engine
@@ -610,6 +615,147 @@ my ($mode,$opcode) = @_;
 	&pop	("edi");
 	&ret	();
 &function_end_B("padlock_sha512_blocks");
+
+&function_begin_B("gmi_reload_key");
+	&pushf	();
+	&popf	();
+	&ret	();
+&function_end_B("gmi_reload_key");
+
+&function_begin_B("gmi_xstore");
+	&push	("edi");
+	&mov	("edi",&wparam(0));
+	&mov	("edx",&wparam(1));
+	&data_byte(0x0f,0xa7,0xc0);		# xstore
+	&pop	("edi");
+	&ret	();
+&function_end_B("gmi_xstore");
+
+&function_begin_B("_win32_segv_handler");
+	&mov	("eax",1);			# ExceptionContinueSearch
+	&mov	("edx",&wparam(0));		# *ExceptionRecord
+	&mov	("ecx",&wparam(2));		# *ContextRecord
+	&cmp	(&DWP(0,"edx"),0xC0000005)	# ExceptionRecord->ExceptionCode == STATUS_ACCESS_VIOLATION
+	&jne	(&label("ret"));
+	&add	(&DWP(184,"ecx"),4);		# skip over rep sha*
+	&mov	("eax",0);			# ExceptionContinueExecution
+&set_label("ret");
+	&ret	();
+&function_end_B("_win32_segv_handler");
+&safeseh("_win32_segv_handler")			if ($::win32);
+
+&function_begin_B("gmi_sm3_oneshot");
+	&push	("ebx");
+	&push	("edi");
+	&push	("esi");
+	&xor	("eax","eax");
+	&mov	("edi",&wparam(0));
+	&mov	("esi",&wparam(1));
+	&mov	("ecx",&wparam(2));
+    if ($::win32 or $::coff) {
+    	&push	(&::islabel("_win32_segv_handler"));
+	&data_byte(0x64,0xff,0x30);		# push	%fs:(%eax)
+	&data_byte(0x64,0x89,0x20);		# mov	%esp,%fs:(%eax)
+    }
+	&mov	("edx","esp");			# put aside %esp
+	&add	("esp",-128);
+	&movups	("xmm0",&QWP(0,"edi"));		# copy-in context
+	&and	("esp",-16);
+	&movups	("xmm1",&QWP(16,"edi"));
+	&movaps	(&QWP(0,"esp"),"xmm0");
+	&mov	("edi","esp");
+	&movaps	(&QWP(16,"esp"),"xmm1");
+	&mov	("ebx", 0x20);
+	&xor	("eax","eax");
+	&data_byte(0xf3,0x0f,0xa6,0xe8);	# gm5 ccs_hash
+	&movaps	("xmm0",&QWP(0,"esp"));
+	&movaps	("xmm1",&QWP(16,"esp"));
+	&mov	("esp","edx");			# restore %esp
+    if ($::win32 or $::coff) {
+	&data_byte(0x64,0x8f,0x05,0,0,0,0);	# pop	%fs:0
+	&lea	("esp",&DWP(4,"esp"));
+    }
+	&mov	("edi",&wparam(0));
+	&movups	(&QWP(0,"edi"),"xmm0");		# copy-out context
+	&movups	(&QWP(16,"edi"),"xmm1");
+	&pop	("esi");
+	&pop	("edi");
+	&pop	("ebx");
+	&ret	();
+&function_end_B("gmi_sm3_oneshot");
+
+&function_begin_B("gmi_sm3_blocks");
+	&push	("ebx");
+	&push	("edi");
+	&push	("esi");
+	&mov	("edi",&wparam(0));
+	&mov	("esi",&wparam(1));
+	&mov	("ecx",&wparam(2));
+	&mov	("edx","esp");			# put aside %esp
+	&add	("esp",-128);
+	&movups	("xmm0",&QWP(0,"edi"));		# copy-in context
+	&and	("esp",-16);
+	&movups	("xmm1",&QWP(16,"edi"));
+	&movaps	(&QWP(0,"esp"),"xmm0");
+	&mov	("edi","esp");
+	&movaps	(&QWP(16,"esp"),"xmm1");
+	&mov	("ebx", 0x20);
+	&mov	("eax",-1);
+	&data_byte(0xf3,0x0f,0xa6,0xe8);	# gm5 ccs_hash
+	&movaps	("xmm0",&QWP(0,"esp"));
+	&movaps	("xmm1",&QWP(16,"esp"));
+	&mov	("esp","edx");			# restore %esp
+	&mov	("edi",&wparam(0));
+	&movups	(&QWP(0,"edi"),"xmm0");		# copy-out context
+	&movups	(&QWP(16,"edi"),"xmm1");
+	&pop	("esi");
+	&pop	("edi");
+	&pop	("ebx");
+	&ret	();
+&function_end_B("gmi_sm3_blocks");
+
+&function_begin_B("gmi_sm4_encrypt");
+
+	&push	("ebx");
+	&push	("edi");
+	&push	("esi");
+	&mov	("edi",&wparam(0));
+	&mov	("esi",&wparam(1));
+	&mov	("edx",&wparam(2));
+	&mov	("ecx",&wparam(3));
+
+
+	&lea	("ebx",&DWP(32,"edx"));
+	&shr	("ecx", 4);
+	&mov	("eax",&DWP(16,"edx"));
+
+	&data_byte(0xf3,0x0f,0xa7,0xf0);	# gx6 ccs_encrypt
+
+	&pop	("esi");
+	&pop	("edi");
+	&pop	("ebx");
+	&ret	();
+&function_end_B("gmi_sm4_encrypt");
+
+&function_begin_B("gmi_sm4_ecb_enc");
+
+	&push	("ebx");
+	&push	("edi");
+	&push	("esi");
+	&mov	("esi",&wparam(0));
+	&mov	("edi",&wparam(1));
+	&mov	("ebx",&wparam(2));
+
+	&mov 	("ecx", 1);
+	&mov 	("eax", 0x60);
+	
+	&data_byte(0xf3,0x0f,0xa7,0xf0);	# gx6 ccs_encrypt
+
+	&pop	("esi");
+	&pop	("edi");
+	&pop	("ebx");
+	&ret	();
+&function_end_B("gmi_sm4_ecb_enc");
 
 &asciz	("VIA Padlock x86 module, CRYPTOGAMS by <appro\@openssl.org>");
 &align	(16);

--- a/engines/asm/e_padlock-x86.pl
+++ b/engines/asm/e_padlock-x86.pl
@@ -17,6 +17,7 @@
 # ====================================================================
 # GMI's SM3 and SM4 assembly is Written by yunshen@zhaoxin.com and 
 # kelvinkli@zhaoxin.com. 
+#
 # ====================================================================
 
 # September 2011

--- a/engines/asm/e_padlock-x86_64.pl
+++ b/engines/asm/e_padlock-x86_64.pl
@@ -14,6 +14,11 @@
 # details see http://www.openssl.org/~appro/cryptogams/.
 # ====================================================================
 
+# ====================================================================
+# GMI's SM3 and SM4 assembly is Written by yunshen@zhaoxin.com and 
+# kelvinkli@zhaoxin.com. 
+# ====================================================================
+
 # September 2011
 #
 # Assembler helpers for Padlock engine. See even e_padlock-x86.pl for
@@ -276,17 +281,6 @@ padlock_sha512_blocks:
 	movups	%xmm3,48(%rdx)
 	ret
 .size	padlock_sha512_blocks,.-padlock_sha512_blocks
-
-.globl  zx_cpu_info
-.type	zx_cpu_info,\@abi-omnipotent
-.align  16
-zx_cpu_info:
-	mov %rbx, %r8
-	mov \$0x01,%eax
-	cpuid
-	mov %r8, %rbx
-	ret
-.size   zx_cpu_info,.-zx_cpu_info
 
 .globl	gmi_reload_key
 .type	gmi_reload_key,\@abi-omnipotent

--- a/engines/asm/e_padlock-x86_64.pl
+++ b/engines/asm/e_padlock-x86_64.pl
@@ -276,6 +276,127 @@ padlock_sha512_blocks:
 	movups	%xmm3,48(%rdx)
 	ret
 .size	padlock_sha512_blocks,.-padlock_sha512_blocks
+
+.globl  zx_cpu_info
+.type	zx_cpu_info,\@abi-omnipotent
+.align  16
+zx_cpu_info:
+	mov %rbx, %r8
+	mov \$0x01,%eax
+	cpuid
+	mov %r8, %rbx
+	ret
+.size   zx_cpu_info,.-zx_cpu_info
+
+.globl	gmi_reload_key
+.type	gmi_reload_key,\@abi-omnipotent
+.align	16
+gmi_reload_key:
+	pushf
+	popf
+	ret
+.size	gmi_reload_key,.-gmi_reload_key
+
+.globl	gmi_sm3_oneshot
+.type	gmi_sm3_oneshot,\@function,3
+.align	16
+gmi_sm3_oneshot:
+	mov %rbx, %r11 		# save rbx
+	mov	%rdx,%rcx
+	mov	%rdi,%rdx		# put aside %rdi
+	movups	(%rdi),%xmm0		# copy-in context
+	sub	\$128+8,%rsp
+	movups	16(%rdi),%xmm1
+	movaps	%xmm0,(%rsp)
+	mov	%rsp,%rdi
+	movaps	%xmm1,16(%rsp)
+	mov \$0x20, %rbx
+	xor	%rax,%rax
+	.byte	0xf3,0x0f,0xa6,0xe8	# gm5 ccs_hash
+	movaps	(%rsp),%xmm0
+	movaps	16(%rsp),%xmm1
+	add	\$128+8,%rsp
+	movups	%xmm0,(%rdx)		# copy-out context
+	movups	%xmm1,16(%rdx)
+	mov %r11, %rbx		#restore rbx
+	ret
+.size	gmi_sm3_oneshot,.-gmi_sm3_oneshot
+
+.globl	gmi_sm3_blocks
+.type	gmi_sm3_blocks,\@function,3
+.align	16
+gmi_sm3_blocks:
+	mov %rbx, %r11 		# save rbx
+	mov	%rdx,%rcx
+	mov	%rdi,%rdx		# put aside %rdi
+	movups	(%rdi),%xmm0		# copy-in context
+	sub	\$128+8,%rsp
+	movups	16(%rdi),%xmm1
+	movaps	%xmm0,(%rsp)
+	mov	%rsp,%rdi
+	movaps	%xmm1,16(%rsp)
+	mov \$0x20, %rbx
+	mov	\$-1,%rax
+	.byte	0xf3,0x0f,0xa6,0xe8	# gm5 ccs_hash
+	movaps	(%rsp),%xmm0
+	movaps	16(%rsp),%xmm1
+	add	\$128+8,%rsp
+	movups	%xmm0,(%rdx)		# copy-out context
+	movups	%xmm1,16(%rdx)
+	mov %r11, %rbx		#restore rbx
+	ret
+.size	gmi_sm3_blocks,.-gmi_sm3_blocks
+
+.globl	gmi_sm4_encrypt
+.type	gmi_sm4_encrypt,\@function,4
+.align	16
+gmi_sm4_encrypt:
+
+	push %rbp
+	push %rbx	# save rbx
+	push %rdi
+	push %rsi
+
+
+	lea 32(%rdx), %rbx
+	shr	\$0x04, %rcx
+	mov 16(%rdx), %rax
+	
+	.byte	0xf3,0x0f,0xa7,0xf0	# gx6 ccs_encrypt
+
+	pop %rsi
+	pop %rdi
+	pop %rbx		#restore rbx
+	pop %rbp
+	ret
+.size	gmi_sm4_encrypt,.-gmi_sm4_encrypt
+
+.globl	gmi_sm4_ecb_enc
+.type	gmi_sm4_ecb_enc,\@function,3
+.align	16
+gmi_sm4_ecb_enc:
+
+	push %rbp
+	push %rbx	# save rbx
+	push %rdi
+	push %rsi
+
+	mov %rsi, %rax
+	mov %rdi, %rsi
+	mov %rax, %rdi
+
+	mov	%rdx, %rbx
+	mov	\$1, %rcx
+	mov \$0x60, %rax
+	
+	.byte	0xf3,0x0f,0xa7,0xf0	# gx6 ccs_encrypt
+
+	pop %rsi
+	pop %rdi
+	pop %rbx		#restore rbx
+	pop %rbp
+	ret
+.size	gmi_sm4_ecb_enc,.-gmi_sm4_ecb_enc
 ___
 
 sub generate_mode {

--- a/engines/asm/e_padlock-x86_64.pl
+++ b/engines/asm/e_padlock-x86_64.pl
@@ -17,6 +17,7 @@
 # ====================================================================
 # GMI's SM3 and SM4 assembly is Written by yunshen@zhaoxin.com and 
 # kelvinkli@zhaoxin.com. 
+#
 # ====================================================================
 
 # September 2011

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -1132,15 +1132,13 @@ static int gmi_digests(ENGINE *e, const EVP_MD **digest,
 {
     int ok = 1;
 
-	//TODO: Jeff
-	printf("Jeff: got into %s\n", __func__);
-
     if (!digest) {
         /* We are returning a list of supported nids */
         *nids = gmi_digest_nids;
         return (sizeof(gmi_digest_nids) -
                 1) / sizeof(gmi_digest_nids[0]);
     }
+
     /* We are being asked for a specific digest */
     switch (nid) {
     case NID_sm3:

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -291,7 +291,7 @@ static int gmi_available(void)
 	unsigned int leaf = 0x1;
 
 	asm volatile("cpuid":"=a"(eax):"0"(leaf):"ebx", "ecx");
-	cpu_family = (eax & 0xf00) >> 8;  // bit 11-08
+	cpu_family = (eax & 0xf00) >> 8; 
         
     if(cpu_family > 6){
 		edx = padlock_capability();

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -19,6 +19,9 @@
 #include <openssl/err.h>
 #include <openssl/modes.h>
 
+#include "e_zx.h"
+#include "../crypto/include/internal/evp_int.h"
+
 #ifndef OPENSSL_NO_HW
 # ifndef OPENSSL_NO_HW_PADLOCK
 
@@ -69,6 +72,7 @@ void engine_load_padlock_int(void)
 
 /* Function for ENGINE detection and control */
 static int padlock_available(void);
+static int gmi_available(void);
 static int padlock_init(ENGINE *e);
 
 /* RNG Stuff */
@@ -77,6 +81,12 @@ static RAND_METHOD padlock_rand;
 /* Cipher Stuff */
 static int padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
                            const int **nids, int nid);
+static int zx_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
+                           const int **nids, int nid);
+
+/* Digest Stuff*/
+static int gmi_digests(ENGINE *e, const EVP_MD **digest,
+		                          const int **nids, int nid);
 
 /* Engine names */
 static const char *padlock_id = "padlock";
@@ -85,6 +95,7 @@ static char padlock_name[100];
 /* Available features */
 static int padlock_use_ace = 0; /* Advanced Cryptography Engine */
 static int padlock_use_rng = 0; /* Random Number Generator */
+static int padlock_use_ccs = 0; /* SM4 Support */
 
 /* ===== Engine "management" functions ===== */
 
@@ -93,6 +104,7 @@ static int padlock_bind_helper(ENGINE *e)
 {
     /* Check available features */
     padlock_available();
+    gmi_available();
 
     /*
      * RNG is currently disabled for reasons discussed in commentary just
@@ -102,16 +114,19 @@ static int padlock_bind_helper(ENGINE *e)
 
     /* Generate a nice engine name with available features */
     BIO_snprintf(padlock_name, sizeof(padlock_name),
-                 "VIA PadLock (%s, %s)",
+                 "VIA PadLock (%s, %s, %s)",
                  padlock_use_rng ? "RNG" : "no-RNG",
-                 padlock_use_ace ? "ACE" : "no-ACE");
+                 padlock_use_ace ? "ACE" : "no-ACE",
+				 padlock_use_ccs ? "CCS" : "no-CCS");
 
     /* Register everything or return with an error */
     if (!ENGINE_set_id(e, padlock_id) ||
         !ENGINE_set_name(e, padlock_name) ||
         !ENGINE_set_init_function(e, padlock_init) ||
         (padlock_use_ace && !ENGINE_set_ciphers(e, padlock_ciphers)) ||
-        (padlock_use_rng && !ENGINE_set_RAND(e, &padlock_rand))) {
+        (padlock_use_rng && !ENGINE_set_RAND(e, &padlock_rand)) ||
+        (padlock_use_ccs && !ENGINE_set_ciphers(e, zx_ciphers)) ||
+        (padlock_use_ccs && !ENGINE_set_digests(e, gmi_digests))) {
         return 0;
     }
 
@@ -198,8 +213,31 @@ struct padlock_cipher_data {
     AES_KEY ks;                 /* Encryption key */
 };
 
+#define CCS_ENCRYPT_FUNC_SM4     0x10
+
+#define CCS_ENCRYPT_MODE_ECB     0x1
+#define CCS_ENCRYPT_MODE_CBC     0x2
+#define CCS_ENCRYPT_MODE_CFB     0x4
+#define CCS_ENCRYPT_MODE_OFB     0x8
+#define CCS_ENCRYPT_MODE_CTR     0x10
+
+struct gmi_cipher_data {
+    unsigned char iv[SM4_BLOCK_SIZE]; /* Initialization vector */
+    union {
+        unsigned int pad[4];
+        struct {
+            int encdec:1;
+            int func:5;
+            int mode:5;
+            int digest:1; 
+        } b;
+    } cword;                    /* Control word */
+    SM4_KEY ks;                 /* Encryption key */
+};
+
 /* Interface to assembler module */
 unsigned int padlock_capability();
+unsigned int zx_cpu_info();
 void padlock_key_bswap(AES_KEY *key);
 void padlock_verify_context(struct padlock_cipher_data *ctx);
 void padlock_reload_key();
@@ -221,6 +259,14 @@ void padlock_sha1(void *ctx, const void *inp, size_t len);
 void padlock_sha256_oneshot(void *ctx, const void *inp, size_t len);
 void padlock_sha256(void *ctx, const void *inp, size_t len);
 
+void gmi_reload_key();
+void gmi_sm4_encrypt(unsigned char *out, const unsigned char *in, 
+		struct gmi_cipher_data *ctx, size_t len);
+void gmi_sm4_ecb_enc(unsigned char *in, unsigned char *out, 
+		unsigned char *key);
+void gmi_sm3_oneshot(void *ctx, const void *inp, size_t len);
+void gmi_sm3_blocks(void *ctx, const void *inp, size_t len);
+
 /*
  * Load supported features of the CPU to see if the PadLock is available.
  */
@@ -233,6 +279,28 @@ static int padlock_available(void)
     padlock_use_rng = ((edx & (0x3 << 2)) == (0x3 << 2));
 
     return padlock_use_ace + padlock_use_rng;
+}
+
+/*
+ * Load supported features of the CPU to see if the GMI is available.
+ */
+static int gmi_available(void)
+{
+    uint8_t cpu_family;
+    unsigned int eax = 0;
+    unsigned int edx = 0;
+
+	eax = zx_cpu_info();
+	cpu_family = (eax & 0xf00) >> 8;  // bit 11-08
+        
+    if(cpu_family > 6){
+		edx = padlock_capability();
+	    padlock_use_ccs = ((edx & (0x3 << 4)) == (0x3 << 4));
+    }else{
+		padlock_use_ccs = 0;
+    }
+
+    return padlock_use_ccs;
 }
 
 /* ===== AES encryption/decryption ===== */
@@ -279,7 +347,13 @@ static const int padlock_cipher_nids[] = {
     NID_aes_256_cbc,
     NID_aes_256_cfb,
     NID_aes_256_ofb,
-    NID_aes_256_ctr
+    NID_aes_256_ctr,
+
+    NID_sm4_ecb,
+    NID_sm4_cbc,
+    NID_sm4_cfb128,
+    NID_sm4_ofb128,
+    NID_sm4_ctr
 };
 
 static int padlock_cipher_nids_num = (sizeof(padlock_cipher_nids) /
@@ -288,11 +362,16 @@ static int padlock_cipher_nids_num = (sizeof(padlock_cipher_nids) /
 /* Function prototypes ... */
 static int padlock_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                                 const unsigned char *iv, int enc);
+static int gmi_sm4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                                const unsigned char *iv, int enc);
 
 #   define NEAREST_ALIGNED(ptr) ( (unsigned char *)(ptr) +         \
         ( (0x10 - ((size_t)(ptr) & 0x0F)) & 0x0F )      )
 #   define ALIGNED_CIPHER_DATA(ctx) ((struct padlock_cipher_data *)\
         NEAREST_ALIGNED(EVP_CIPHER_CTX_get_cipher_data(ctx)))
+#   define ALIGNED_CIPHER_DATA_GMI(ctx) ((struct gmi_cipher_data *)\
+        NEAREST_ALIGNED(EVP_CIPHER_CTX_get_cipher_data(ctx)))
+
 
 static int
 padlock_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
@@ -466,11 +545,133 @@ padlock_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
     return 1;
 }
 
+
+static int
+gmi_sm4_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
+                   const unsigned char *in_arg, size_t nbytes)
+{
+    struct gmi_cipher_data *cdata = ALIGNED_CIPHER_DATA_GMI(ctx);
+
+    memcpy(cdata->iv, EVP_CIPHER_CTX_iv(ctx), SM4_BLOCK_SIZE);
+
+    gmi_sm4_encrypt(out_arg, in_arg, cdata, nbytes);
+
+    memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), cdata->iv, SM4_BLOCK_SIZE);
+   
+    return 1;
+}
+
+static int
+gmi_sm4_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
+                   const unsigned char *in_arg, size_t nbytes)
+{
+    struct gmi_cipher_data *cdata = ALIGNED_CIPHER_DATA_GMI(ctx);
+	unsigned int num = EVP_CIPHER_CTX_num(ctx);
+	CRYPTO_ctr128_encrypt(in_arg, out_arg, nbytes, cdata->ks.rd_key, 
+			EVP_CIPHER_CTX_iv_noconst(ctx), EVP_CIPHER_CTX_buf_noconst(ctx),
+			&num, (block128_f)gmi_sm4_ecb_enc);
+	EVP_CIPHER_CTX_set_num(ctx, num);
+    
+	/*unsigned int num = EVP_CIPHER_CTX_num(ctx);
+    memcpy(cdata->iv, EVP_CIPHER_CTX_iv(ctx), SM4_BLOCK_SIZE);
+	gmi_sm4_encrypt(out_arg, in_arg, cdata, nbytes);
+    EVP_CIPHER_CTX_set_num(ctx, (size_t)num);*/
+    return 1;
+}
+
+static int
+gmi_sm4_cfb128_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
+                   const unsigned char *in_arg, size_t nbytes)
+{
+	struct gmi_cipher_data *cdata = ALIGNED_CIPHER_DATA_GMI(ctx);
+	int num = EVP_CIPHER_CTX_num(ctx);
+	CRYPTO_cfb128_encrypt(in_arg, out_arg, nbytes, cdata->ks.rd_key, 
+			EVP_CIPHER_CTX_iv_noconst(ctx), &num, EVP_CIPHER_CTX_encrypting(ctx), (block128_f)gmi_sm4_ecb_enc);
+	EVP_CIPHER_CTX_set_num(ctx, num);
+    /*memcpy(cdata->iv, EVP_CIPHER_CTX_iv(ctx), SM4_BLOCK_SIZE);
+	gmi_sm4_encrypt(out_arg, in_arg, cdata, nbytes);
+    memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), cdata->iv, SM4_BLOCK_SIZE);*/
+    return 1;
+}
+
+static int
+gmi_sm4_ofb128_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
+                   const unsigned char *in_arg, size_t nbytes)
+{
+    struct gmi_cipher_data *cdata = ALIGNED_CIPHER_DATA_GMI(ctx);
+	int num = EVP_CIPHER_CTX_num(ctx);
+	CRYPTO_ofb128_encrypt(in_arg, out_arg, nbytes, cdata->ks.rd_key,
+			EVP_CIPHER_CTX_iv_noconst(ctx), &num, (block128_f)gmi_sm4_ecb_enc);
+	EVP_CIPHER_CTX_set_num(ctx, num);
+    /*memcpy(cdata->iv, EVP_CIPHER_CTX_iv(ctx), SM4_BLOCK_SIZE);
+	gmi_sm4_encrypt(out_arg, in_arg, cdata, nbytes);
+    memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), cdata->iv, SM4_BLOCK_SIZE);*/
+	return 1;
+}
+
+static int
+gmi_sm4_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out_arg,
+                   const unsigned char *in_arg, size_t nbytes)
+{
+    struct gmi_cipher_data *cdata = ALIGNED_CIPHER_DATA_GMI(ctx);
+
+    gmi_sm4_encrypt(out_arg, in_arg, cdata, nbytes);
+
+    return 1;
+}
+
+/* Prepare the encryption key for GMI sm4  usage */
+static int
+gmi_sm4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                     const unsigned char *iv, int enc)
+{
+    struct gmi_cipher_data *cdata;
+    unsigned long mode = EVP_CIPHER_CTX_mode(ctx);
+ 
+    if (key == NULL)
+        return 0;               /* ERROR */
+
+    cdata = ALIGNED_CIPHER_DATA_GMI(ctx);
+    memset(cdata, 0, sizeof(*cdata));
+
+    /* Prepare Control word. */
+    if (mode == EVP_CIPH_OFB_MODE || mode == EVP_CIPH_CTR_MODE)
+        cdata->cword.b.encdec = 0;
+    else
+        cdata->cword.b.encdec = (EVP_CIPHER_CTX_encrypting(ctx) == 0);
+
+    cdata->cword.b.func = CCS_ENCRYPT_FUNC_SM4;
+    cdata->cword.b.mode = 1<<(mode-1);;
+    cdata->cword.b.digest = 0;
+
+    if(iv != NULL)
+    {
+        memcpy(cdata->iv, iv, SM4_BLOCK_SIZE);
+    }
+
+    memcpy(cdata->ks.rd_key, key, SM4_KEY_SIZE);
+
+    /*
+     * This is done to cover for cases when user reuses the
+     * context for new key. The catch is that if we don't do
+     * this, gmi_eas_cipher might proceed with old key...
+     */
+    gmi_reload_key();
+
+    return 1;
+}
+
 #   define EVP_CIPHER_block_size_ECB       AES_BLOCK_SIZE
 #   define EVP_CIPHER_block_size_CBC       AES_BLOCK_SIZE
 #   define EVP_CIPHER_block_size_OFB       1
 #   define EVP_CIPHER_block_size_CFB       1
 #   define EVP_CIPHER_block_size_CTR       1
+
+#   define EVP_SM4_CIPHER_block_size_ECB       SM4_BLOCK_SIZE
+#   define EVP_SM4_CIPHER_block_size_CBC       SM4_BLOCK_SIZE
+#   define EVP_SM4_CIPHER_block_size_OFB       1
+#   define EVP_SM4_CIPHER_block_size_CFB       1
+#   define EVP_SM4_CIPHER_block_size_CTR       1
 
 /*
  * Declaring so many ciphers by hand would be a pain. Instead introduce a bit
@@ -505,6 +706,35 @@ static const EVP_CIPHER *padlock_aes_##ksize##_##lmode(void) \
     return _hidden_aes_##ksize##_##lmode;                               \
 }
 
+#   define DECLARE_SM4_EVP(lmode,umode)      \
+static EVP_CIPHER *_hidden_sm4_##lmode = NULL; \
+static const EVP_CIPHER *gmi_sm4_##lmode(void) \
+{                                                                       \
+    if (_hidden_sm4_##lmode == NULL                           \
+        && ((_hidden_sm4_##lmode =                            \
+             EVP_CIPHER_meth_new(NID_sm4_##lmode,             \
+                                 EVP_CIPHER_block_size_##umode,         \
+                                 SM4_KEY_SIZE)) == NULL         \
+            || !EVP_CIPHER_meth_set_iv_length(_hidden_sm4_##lmode, \
+                                              SM4_BLOCK_SIZE)           \
+            || !EVP_CIPHER_meth_set_flags(_hidden_sm4_##lmode, \
+                                          0 | EVP_CIPH_##umode##_MODE)  \
+            || !EVP_CIPHER_meth_set_init(_hidden_sm4_##lmode, \
+                                         gmi_sm4_init_key)          \
+            || !EVP_CIPHER_meth_set_do_cipher(_hidden_sm4_##lmode, \
+                                              gmi_sm4_##lmode##_cipher) \
+            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_sm4_##lmode, \
+                                                  sizeof(struct gmi_cipher_data) + 16) \
+            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_sm4_##lmode, \
+                                                    EVP_CIPHER_set_asn1_iv) \
+            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_sm4_##lmode, \
+                                                    EVP_CIPHER_get_asn1_iv))) { \
+        EVP_CIPHER_meth_free(_hidden_sm4_##lmode);            \
+        _hidden_sm4_##lmode = NULL;                           \
+    }                                                                   \
+    return _hidden_sm4_##lmode;                               \
+}
+
 DECLARE_AES_EVP(128, ecb, ECB)
 DECLARE_AES_EVP(128, cbc, CBC)
 DECLARE_AES_EVP(128, cfb, CFB)
@@ -522,6 +752,12 @@ DECLARE_AES_EVP(256, cbc, CBC)
 DECLARE_AES_EVP(256, cfb, CFB)
 DECLARE_AES_EVP(256, ofb, OFB)
 DECLARE_AES_EVP(256, ctr, CTR)
+
+DECLARE_SM4_EVP(ecb, ECB);
+DECLARE_SM4_EVP(cbc, CBC);
+DECLARE_SM4_EVP(ctr, CTR);
+DECLARE_SM4_EVP(cfb128, CFB);
+DECLARE_SM4_EVP(ofb128, OFB);
 
 static int
 padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
@@ -582,6 +818,91 @@ padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
     case NID_aes_256_ctr:
         *cipher = padlock_aes_256_ctr();
         break;
+
+    default:
+        /* Sorry, we don't support this NID */
+        *cipher = NULL;
+        return 0;
+    }
+
+    return 1;
+}
+
+static int
+zx_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
+                int nid)
+{
+    /* No specific cipher => return a list of supported nids ... */
+    if (!cipher) {
+        *nids = padlock_cipher_nids;
+        return padlock_cipher_nids_num;
+    }
+
+    /* ... or the requested "cipher" otherwise */
+    switch (nid) {
+    case NID_aes_128_ecb:
+        *cipher = padlock_aes_128_ecb();
+        break;
+    case NID_aes_128_cbc:
+        *cipher = padlock_aes_128_cbc();
+        break;
+    case NID_aes_128_cfb:
+        *cipher = padlock_aes_128_cfb();
+        break;
+    case NID_aes_128_ofb:
+        *cipher = padlock_aes_128_ofb();
+        break;
+    case NID_aes_128_ctr:
+        *cipher = padlock_aes_128_ctr();
+        break;
+
+    case NID_aes_192_ecb:
+        *cipher = padlock_aes_192_ecb();
+        break;
+    case NID_aes_192_cbc:
+        *cipher = padlock_aes_192_cbc();
+        break;
+    case NID_aes_192_cfb:
+        *cipher = padlock_aes_192_cfb();
+        break;
+    case NID_aes_192_ofb:
+        *cipher = padlock_aes_192_ofb();
+        break;
+    case NID_aes_192_ctr:
+        *cipher = padlock_aes_192_ctr();
+        break;
+
+    case NID_aes_256_ecb:
+        *cipher = padlock_aes_256_ecb();
+        break;
+    case NID_aes_256_cbc:
+        *cipher = padlock_aes_256_cbc();
+        break;
+    case NID_aes_256_cfb:
+        *cipher = padlock_aes_256_cfb();
+        break;
+    case NID_aes_256_ofb:
+        *cipher = padlock_aes_256_ofb();
+        break;
+    case NID_aes_256_ctr:
+        *cipher = padlock_aes_256_ctr();
+        break;
+	/* zx ciphers supports gmi's sm4 algorithm  */
+	case NID_sm4_ecb:
+		*cipher = gmi_sm4_ecb();
+		break;
+	case NID_sm4_cbc:
+		*cipher = gmi_sm4_cbc();
+		break;
+	case NID_sm4_cfb128:
+		*cipher = gmi_sm4_cfb128();
+		break;
+	case NID_sm4_ofb128:
+		*cipher = gmi_sm4_ofb128();
+		break;
+	case NID_sm4_ctr:
+		*cipher = gmi_sm4_ctr();
+		break;
 
     default:
         /* Sorry, we don't support this NID */
@@ -663,6 +984,7 @@ padlock_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     return 1;
 }
 
+
 /* ===== Random Number Generator ===== */
 /*
  * This code is not engaged. The reason is that it does not comply
@@ -730,6 +1052,168 @@ static RAND_METHOD padlock_rand = {
 #  endif                        /* COMPILE_HW_PADLOCK */
 # endif                         /* !OPENSSL_NO_HW_PADLOCK */
 #endif                          /* !OPENSSL_NO_HW */
+
+/* ===== GMI SM3 digest ===== */
+#define SM3_MAKE_STRING(c, s) do {                     \
+        unsigned long ll;                              \
+        unsigned int  nn;                              \
+        for (nn=0; nn<SM3_DIGEST_LENGTH/4; nn++)       \
+        {   ll=(c)->h[nn]; (void)HOST_l2c(ll,(s));   } \
+                                                       \
+        } while (0)
+
+#define HOST_l2c(l,c)	( { unsigned int r=(l);\
+		asm ("bswapl %0":"=r"(r):"0"(r)); \
+		*((unsigned int *)(c))=r; (c)+=4; r; })
+
+static int gmi_sm3_init(EVP_MD_CTX *ctx)
+{
+    SM3_CTX *c = (SM3_CTX *)EVP_MD_CTX_md_data(ctx);
+
+    c->h[0]=0x6f168073UL;
+   	c->h[1]=0xb9b21449UL;
+   	c->h[2]=0xd7422417UL;
+   	c->h[3]=0x00068adaUL;
+   	c->h[4]=0xbc306fa9UL;
+   	c->h[5]=0xaa383116UL;
+   	c->h[6]=0x4dee8de3UL;
+   	c->h[7]=0x4e0efbb0UL;
+
+    c->num = 0; 
+    return 1;
+}
+
+static int gmi_sm3_update(EVP_MD_CTX *ctx, const void *data_, size_t len)
+{
+    const unsigned char *data = data_;
+    unsigned char *p;
+    SM3_WORD l;
+    size_t n;
+    SM3_CTX *c = (SM3_CTX *)EVP_MD_CTX_md_data(ctx);
+
+    if (len == 0)
+        return 1;
+
+    l = (c->Nl + (((SM3_WORD)len) << 3)) & 0xffffffffUL;
+
+    if (l < c->Nl)              /* overflow */
+        c->Nh++;
+    c->Nh += (SM3_WORD)(len >> 29); /* might cause compiler warning on
+                                       * 16-bit */
+    c->Nl = l;
+
+    n = c->num;
+    if (n != 0) {
+        p = (unsigned char *)c->data;
+
+        if (len >= SM3_CBLOCK || len + n >= SM3_CBLOCK) {
+            memcpy(p + n, data, SM3_CBLOCK - n);
+            gmi_sm3_blocks(c->h, p, 1);
+            n = SM3_CBLOCK - n;
+            data += n;
+            len -= n;
+            c->num = 0;
+            memset(p, 0, SM3_CBLOCK); /* keep it zeroed */
+        } else {
+            memcpy(p + n, data, len);
+            c->num += (unsigned int)len;
+            return 1;
+        }
+    }
+
+    n = len / SM3_CBLOCK;
+    if (n > 0) {
+        gmi_sm3_blocks(c->h, data, n);
+        n *= SM3_CBLOCK;
+        data += n;
+        len -= n;
+    }
+
+    if (len != 0) {
+        p = (unsigned char *)c->data;
+        c->num = (unsigned int)len;
+        memcpy(p, data, len);
+	}
+
+    return 1;
+}
+
+static int gmi_sm3_final(EVP_MD_CTX *ctx, unsigned char *md)
+{
+
+    SM3_CTX *c = (SM3_CTX *)EVP_MD_CTX_md_data(ctx);
+    unsigned char *p = (unsigned char *)c->data;
+    size_t n = c->num;
+
+    p[n] = 0x80;   /* there is always room for one */
+    n++;
+
+    if (n > (SM3_CBLOCK - 8)) {
+        memset(p + n, 0, SM3_CBLOCK - n);
+        n = 0;
+        gmi_sm3_blocks(c->h, p, 1);
+    }
+    memset(p + n, 0, SM3_CBLOCK - 8 - n);
+
+    p += SM3_CBLOCK - 8;
+
+    (void)HOST_l2c(c->Nh, p);
+    (void)HOST_l2c(c->Nl, p);
+
+    p -= SM3_CBLOCK;
+    gmi_sm3_blocks(c->h, p, 1);
+
+    c->num = 0;
+    memset(p, 0, SM3_CBLOCK);
+
+    memcpy(md, c->h, SM3_DIGEST_LENGTH);
+
+    return 1;
+}
+
+static const int gmi_digest_nids[] = {
+    NID_sm3,
+    0
+};
+
+static const EVP_MD digest_sm3 = {
+    NID_sm3,
+    NID_sm3WithRSAEncryption,
+    SM3_DIGEST_LENGTH,
+    EVP_MD_FLAG_DIGALGID_ABSENT,
+    gmi_sm3_init,
+    gmi_sm3_update,
+    gmi_sm3_final,
+    NULL,
+    NULL,
+    SM3_CBLOCK,
+    sizeof(EVP_MD *) + sizeof(SM3_CTX),
+	NULL
+};
+
+static int gmi_digests(ENGINE *e, const EVP_MD **digest,
+                          const int **nids, int nid)
+{
+    int ok = 1;
+
+    if (!digest) {
+        /* We are returning a list of supported nids */
+        *nids = gmi_digest_nids;
+        return (sizeof(gmi_digest_nids) -
+                1) / sizeof(gmi_digest_nids[0]);
+    }
+    /* We are being asked for a specific digest */
+    switch (nid) {
+    case NID_sm3:
+        *digest = &digest_sm3;
+        break;
+    default:
+        ok = 0;
+        *digest = NULL;
+        break;
+    }
+    return ok;
+}
 
 #if defined(OPENSSL_NO_HW) || defined(OPENSSL_NO_HW_PADLOCK) \
         || !defined(COMPILE_HW_PADLOCK)

--- a/engines/e_zx.h
+++ b/engines/e_zx.h
@@ -12,22 +12,22 @@ extern "C" {
 # define SM3_LONG unsigned int
 # define SM3_WORD unsigned int
 
-# define SM3_LBLOCK      16
-# define SM3_CBLOCK      (SM3_LBLOCK*4)/* SHA treats input data as a
-						 				* contiguous array of 32 bit wide
-										* big-endian values. */
+# define SM3_LBLOCK  16
+# define SM3_CBLOCK  (SM3_LBLOCK*4) /* SHA treats input data as a
+                                     * contiguous array of 32 bit wide
+                                     * big-endian values. */
 # define SM3_LAST_BLOCK  (SM3_CBLOCK-8)
 # define SM3_DIGEST_LENGTH 32
 
 typedef struct SM3state_st {
-	SM3_LONG h[8];
-	SM3_LONG Nl, Nh;
-	SM3_LONG data[SM3_LBLOCK];
-	unsigned int num, md_len;
+    SM3_LONG h[8];
+    SM3_LONG Nl, Nh;
+    SM3_LONG data[SM3_LBLOCK];
+    unsigned int num, md_len;
 } SM3_CTX;
 
 # ifdef OPENSSL_NO_SM4
-#  error SM4 is disabled.
+#   error SM4 is disabled.
 # endif
 
 # define SM4_ENCRYPT     1
@@ -43,9 +43,9 @@ typedef struct SM3state_st {
 /* This should be a hidden type, but EVP requires that the size be known */
 struct sm4_key_st {
 # ifdef SM4_LONG
-	unsigned long rd_key[32];
+    unsigned long rd_key[32];
 # else
-	unsigned int rd_key[32];
+    unsigned int rd_key[32];
 # endif
 };
 typedef struct sm4_key_st SM4_KEY;

--- a/engines/e_zx.h
+++ b/engines/e_zx.h
@@ -1,0 +1,57 @@
+#ifndef HEADER_SM4_H
+# define HEADER_SM4_H
+
+# include <openssl/opensslconf.h>
+# include <openssl/e_os2.h>
+# include <stddef.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+# define SM3_LONG unsigned int
+# define SM3_WORD unsigned int
+
+# define SM3_LBLOCK      16
+# define SM3_CBLOCK      (SM3_LBLOCK*4)/* SHA treats input data as a
+						 				* contiguous array of 32 bit wide
+										* big-endian values. */
+# define SM3_LAST_BLOCK  (SM3_CBLOCK-8)
+# define SM3_DIGEST_LENGTH 32
+
+typedef struct SM3state_st {
+	SM3_LONG h[8];
+	SM3_LONG Nl, Nh;
+	SM3_LONG data[SM3_LBLOCK];
+	unsigned int num, md_len;
+} SM3_CTX;
+
+# ifdef OPENSSL_NO_SM4
+#  error SM4 is disabled.
+# endif
+
+# define SM4_ENCRYPT     1
+# define SM4_DECRYPT     0
+
+/*
+ * Because array size can't be a const in C, the following two are macros.
+ * Both sizes are in bytes.
+ */
+#define SM4_BLOCK_SIZE  16
+#define SM4_KEY_SIZE    16
+
+/* This should be a hidden type, but EVP requires that the size be known */
+struct sm4_key_st {
+# ifdef SM4_LONG
+	unsigned long rd_key[32];
+# else
+	unsigned int rd_key[32];
+# endif
+};
+typedef struct sm4_key_st SM4_KEY;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
SM3 and SM4 are supported by Zhaoxin's ZX-D CPUs now, so we integrate
the support with padlock.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
