### PR TITLE
windows-makefile.tmpl: delete export library prior link.

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -627,6 +627,7 @@ EOF
      return <<"EOF"
 $target: $deps
 	IF EXIST $shlib$shlibext.manifest DEL /F /Q $shlib$shlibext.manifest
+	IF EXIST \$@ DEL /F /Q \$@
 	\$(LD) \$(LDFLAGS) \$(LIB_LDFLAGS) \\
 		/implib:\$@ \$(LDOUTFLAG)$shlib$shlibext$shared_def @<< || (DEL /Q \$(\@B).* $shlib.* && EXIT 1)
 $objs


### PR DESCRIPTION
LINK can outsmart itself and choose to not update export .lib upon
corresponding .dll re-link. Since dependency is between .lib and all
.obj-s, re-compilation of any .obj makes NMAKE relink .dll and all
.exe-s over and over...
