### PR TITLE
Enable SSL_MODE_AUTO_RETRY by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@
 
  Changes between 1.1.0h and 1.1.1 [xx XXX xxxx]
 
+  *) SSL_MODE_AUTO_RETRY is enabled by default.
+
   *) When unlocking a pass phrase protected PEM file or PKCS#8 container, we
      now allow empty (zero character) pass phrases.
      [Richard Levitte]

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,16 @@
 
  Changes between 1.1.0h and 1.1.1 [xx XXX xxxx]
 
-  *) SSL_MODE_AUTO_RETRY is enabled by default.
+  *) SSL_MODE_AUTO_RETRY is enabled by default. Applications that use blocking
+     I/O in combination with something like select() or poll() will hang. This
+     can be turned off again using SSL_CTX_clear_mode().
+     Many applications do not properly handle non-application data records, and
+     TLS 1.3 sends more of such records. Setting SSL_MODE_AUTO_RETRY works
+     around the problems in those applications, but can also break some.
+     It's recommended to read the manpages about SSL_read(), SSL_write(),
+     SSL_get_error(), SSL_shutdown(), SSL_CTX_set_mode() and
+     SSL_CTX_set_read_ahead() again.
+     [Kurt Roeckx]
 
   *) When unlocking a pass phrase protected PEM file or PKCS#8 container, we
      now allow empty (zero character) pass phrases.

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -974,7 +974,7 @@ int s_client_main(int argc, char **argv)
     c_quiet = 0;
     c_debug = 0;
     c_showcerts = 0;
-    c_nbio = 1;
+    c_nbio = 0;
     vpm = X509_VERIFY_PARAM_new();
     cctx = SSL_CONF_CTX_new();
 
@@ -1670,6 +1670,8 @@ int s_client_main(int argc, char **argv)
         ERR_print_errors(bio_err);
         goto end;
     }
+
+    SSL_CTX_clear_mode(ctx, SSL_MODE_AUTO_RETRY);
 
     if (sdebug)
         ssl_ctx_security_debug(ctx, sdebug);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -974,7 +974,7 @@ int s_client_main(int argc, char **argv)
     c_quiet = 0;
     c_debug = 0;
     c_showcerts = 0;
-    c_nbio = 0;
+    c_nbio = 1;
     vpm = X509_VERIFY_PARAM_new();
     cctx = SSL_CONF_CTX_new();
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1041,7 +1041,8 @@ int s_server_main(int argc, char *argv[])
     local_argv = argv;
 
     ctx = ctx2 = NULL;
-    s_nbio = s_nbio_test = 0;
+    s_nbio = 1;
+    s_nbio_test = 0;
     www = 0;
     bio_s_out = NULL;
     s_debug = 0;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1041,8 +1041,7 @@ int s_server_main(int argc, char *argv[])
     local_argv = argv;
 
     ctx = ctx2 = NULL;
-    s_nbio = 1;
-    s_nbio_test = 0;
+    s_nbio = s_nbio_test = 0;
     www = 0;
     bio_s_out = NULL;
     s_debug = 0;
@@ -1747,6 +1746,9 @@ int s_server_main(int argc, char *argv[])
         ERR_print_errors(bio_err);
         goto end;
     }
+
+    SSL_CTX_clear_mode(ctx, SSL_MODE_AUTO_RETRY);
+
     if (sdebug)
         ssl_ctx_security_debug(ctx, sdebug);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2894,6 +2894,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
     ret->method = meth;
     ret->min_proto_version = 0;
     ret->max_proto_version = 0;
+    ret->mode = SSL_MODE_AUTO_RETRY;
     ret->session_cache_mode = SSL_SESS_CACHE_SERVER;
     ret->session_cache_size = SSL_SESSION_CACHE_MAX_SIZE_DEFAULT;
     /* We take the system default. */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2205,15 +2205,6 @@ static int test_early_data_not_sent(int idx)
             || !TEST_size_t_eq(written, strlen(MSG2)))
         goto end;
 
-    /*
-     * Should block due to the NewSessionTicket arrival unless we're using
-     * read_ahead, or PSKs
-     */
-    if (idx != 1 && idx != 2) {
-        if (!TEST_false(SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes)))
-            goto end;
-    }
-
     if (!TEST_true(SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes))
             || !TEST_mem_eq(buf, readbytes, MSG2, strlen(MSG2)))
         goto end;


### PR DESCRIPTION
Because TLS 1.3 sends more non-application data records some clients run
into problems because they don't expect SSL_read() to return and set
SSL_ERROR_WANT_READ after processing it.

This can cause problems for clients that use blocking I/O and use
select() to see if data is available. It can be cleared using
SSL_CTX_clear_mode().
