### PR TITLE
util/domd: harmonize with compiler detection in Configure.

### DIFF
--- a/util/domd
+++ b/util/domd
@@ -6,7 +6,11 @@ TOP=$1
 shift
 if [ "$1" = "-MD" ]; then
     shift
-    MAKEDEPEND=$1
+    MAKEDEPEND=""
+    while [ "$1" != "--" ]; do
+        MAKEDEPEND="$MAKEDEPEND $1"
+        shift
+    done
     shift
 fi
 if [ "$MAKEDEPEND" = "" ]; then MAKEDEPEND=makedepend; fi
@@ -16,8 +20,11 @@ mv Makefile Makefile.save
 cp Makefile.save Makefile
 # fake the presence of Kerberos
 touch $TOP/krb5.h
-if ${MAKEDEPEND} --version 2>&1 | grep "clang" > /dev/null ||
-   echo $MAKEDEPEND | grep "gcc" > /dev/null; then
+if expr "$MAKEDEPEND" : ".*makedepend" > /dev/null; then
+    ${MAKEDEPEND} -D OPENSSL_DOING_MAKEDEPEND $@ && \
+    ${PERL} $TOP/util/clean-depend.pl < Makefile > Makefile.new
+    RC=$?
+else
     args=""
     while [ $# -gt 0 ]; do
 	if [ "$1" != "--" ]; then args="$args $1"; fi
@@ -29,10 +36,6 @@ if ${MAKEDEPEND} --version 2>&1 | grep "clang" > /dev/null ||
     ${PERL} $TOP/util/clean-depend.pl < Makefile.tmp > Makefile.new
     RC=$?
     rm -f Makefile.tmp
-else
-    ${MAKEDEPEND} -D OPENSSL_DOING_MAKEDEPEND $@ && \
-    ${PERL} $TOP/util/clean-depend.pl < Makefile > Makefile.new
-    RC=$?
 fi
 if cmp -s Makefile.save Makefile.new; then
     mv Makefile.save Makefile


### PR DESCRIPTION
Configure detects if compiler can generate dependency lists for any
command name, while this script didn't quite tolerate arbitrary one.
