### PR TITLE
Fix a man macro usage error on the rehash page.

### DIFF
--- a/doc/man1/rehash.pod
+++ b/doc/man1/rehash.pod
@@ -5,8 +5,7 @@ Original text by James Westby, contributed under the OpenSSL license.
 
 =head1 NAME
 
-openssl-c_rehash, openssl-rehash,
-c_rehash, rehash - Create symbolic links to files named by the hash values
+rehash \- Create symbolic links to files named by the hash values
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
The previous version of the NAME line was dodgy both because it was
multiline and because it listed multiple names.

Found with doclifter. While this works OK when run through man itself,
some third-party viewers and any tool that parses the markup will get
confused.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
