### PR TITLE
Update documentation for PEM callback: error is now -1.

### DIFF
--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -295,7 +295,7 @@ for it twice) if B<rwflag> is 1. The B<u> parameter has the same
 value as the B<u> parameter passed to the PEM routine. It allows
 arbitrary data to be passed to the callback by the application
 (for example a window handle in a GUI application). The callback
-B<must> return the number of characters in the passphrase or 0 if
+B<must> return the number of characters in the passphrase or -1 if
 an error occurred.
 
 =head1 EXAMPLES

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -346,17 +346,16 @@ Skeleton pass phrase callback:
 
  int pass_cb(char *buf, int size, int rwflag, void *u)
  {
-     int len;
-     char *tmp;
 
      /* We'd probably do something else if 'rwflag' is 1 */
      printf("Enter pass phrase for \"%s\"\n", (char *)u);
 
      /* get pass phrase, length 'len' into 'tmp' */
-     tmp = "hello";
-     len = strlen(tmp);
-     if (len <= 0)
-         return 0;
+     char *tmp = "hello";
+     if (tmp == NULL) /* An error occurred */
+         return -1;
+
+     size_t len = strlen(tmp);
 
      if (len > size)
          len = size;


### PR DESCRIPTION
In previous versions of OpenSSL, the documentation for PEM_read_*
said:

   The callback B<must> return the number of characters in the
   passphrase or 0 if an error occurred.

But since c82c3462267afdbbaa5, 0 is now treated as a non-error
return value.  Applications that want to indicate an error need to
return -1 instead.

