### PR TITLE
util/libcrypto.num: fix symbol collision between 1.1.0 and master

### DIFF
--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4232,8 +4232,8 @@ ZINT64_it                               4215	1_1_0f	EXIST:!EXPORT_VAR_AS_FUNCTIO
 ZINT64_it                               4215	1_1_0f	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 CRYPTO_secure_clear_free                4315	1_1_0g	EXIST::FUNCTION:
 EVP_PKEY_set1_engine                    4347	1_1_0g	EXIST::FUNCTION:ENGINE
-OCSP_resp_get0_signer                   4374	1_1_0h	EXIST::FUNCTION:OCSP
-X509_get0_authority_key_id              4448	1_1_0h	EXIST::FUNCTION:
+OCSP_resp_get0_signer                   4360	1_1_0h	EXIST::FUNCTION:OCSP
+X509_get0_authority_key_id              4434	1_1_0h	EXIST::FUNCTION:
 conf_ssl_name_find                      4469	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get_cmd                        4470	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get                            4471	1_1_0i	EXIST::FUNCTION:


### PR DESCRIPTION
In commit 6decf9436f7, fourteen public symbols were removed from `util\libcrypto.num` and the following symbols renumbered in agreement with @levitte.

Unfortunately, she symbols `OCSP_resp_get0_signer` and `X509_get0_authority_key_id` were not adjusted on OpenSSL_1_1_0-stable accordingly.

```diff
--- openssl-1.1.0/symbols-1.1.0.num	2018-05-16 16:25:09.437665266 +0200
+++ openssl-master/symbols-1.1.0.num	2018-05-16 16:25:22.452804974 +0200
@@ -27,8 +27,8 @@
 ZINT64_it                               4215	1_1_0f	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
 CRYPTO_secure_clear_free                4315	1_1_0g	EXIST::FUNCTION:
 EVP_PKEY_set1_engine                    4347	1_1_0g	EXIST::FUNCTION:ENGINE
-OCSP_resp_get0_signer                   4374	1_1_0h	EXIST::FUNCTION:OCSP
-X509_get0_authority_key_id              4448	1_1_0h	EXIST::FUNCTION:
+OCSP_resp_get0_signer                   4360	1_1_0h	EXIST::FUNCTION:OCSP
+X509_get0_authority_key_id              4434	1_1_0h	EXIST::FUNCTION:
 conf_ssl_name_find                      4469	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get_cmd                        4470	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get                            4471	1_1_0i	EXIST::FUNCTION:
```

Since 1.1.0h was released only recently, the least intrusive fix is to adjust the numbers in OpenSSL_1_1_0-stable to match the numbers in master. Of course this would have to be communicated in CHANGES.

The alternative, adjusting the numbers in master, also affects a released (beta) version, and it requires more numbers to be changed, because 4374 and and 4448 are already used in master:

4374: [OCSP_resp_get0_signer (1.1.0)](https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/util/libcrypto.num#L4235) vs. [RSA_get0_multi_prime_factors (master)](https://github.com/openssl/openssl/blob/master/util/libcrypto.num#L4428)

4448: [X509_get0_authority_key_id (1.1.0)](https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/util/libcrypto.num#L4236) vs. [OSSL_STORE_SEARCH_by_alias (master)](https://github.com/openssl/openssl/blob/master/util/libcrypto.num#L4506)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] CHANGES is added or updated
