### PR TITLE
DH: add simple getters for commonly used DH struct members

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -243,6 +243,31 @@ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
     return 1;
 }
 
+const BIGNUM *DH_get0_p(const DH *dh)
+{
+    return dh->p;
+}
+
+const BIGNUM *DH_get0_q(const DH *dh)
+{
+    return dh->q;
+}
+
+const BIGNUM *DH_get0_g(const DH *dh)
+{
+    return dh->g;
+}
+
+const BIGNUM *DH_get0_priv_key(const DH *dh)
+{
+    return dh->priv_key;
+}
+
+const BIGNUM *DH_get0_pub_key(const DH *dh)
+{
+    return dh->pub_key;
+}
+
 void DH_clear_flags(DH *dh, int flags)
 {
     dh->flags &= ~flags;

--- a/doc/man3/DH_get0_pqg.pod
+++ b/doc/man3/DH_get0_pqg.pod
@@ -2,9 +2,11 @@
 
 =head1 NAME
 
-DH_get0_pqg, DH_set0_pqg, DH_get0_key, DH_set0_key, DH_clear_flags,
-DH_test_flags, DH_set_flags, DH_get0_engine, DH_get_length,
-DH_set_length - Routines for getting and setting data in a DH object
+DH_get0_pqg, DH_set0_pqg, DH_get0_key, DH_set0_key,
+DH_get0_p, DH_get0_q, DH_get0_g,
+DH_get0_priv_key, DH_get0_pub_key,
+DH_clear_flags, DH_test_flags, DH_set_flags, DH_get0_engine,
+DH_get_length, DH_set_length - Routines for getting and setting data in a DH object
 
 =head1 SYNOPSIS
 
@@ -16,6 +18,11 @@ DH_set_length - Routines for getting and setting data in a DH object
  void DH_get0_key(const DH *dh,
                   const BIGNUM **pub_key, const BIGNUM **priv_key);
  int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key);
+ const BIGNUM *DH_get0_p(const DH *dh);
+ const BIGNUM *DH_get0_q(const DH *dh);
+ const BIGNUM *DH_get0_g(const DH *dh);
+ const BIGNUM *DH_get0_priv_key(const DH *dh);
+ const BIGNUM *DH_get0_pub_key(const DH *dh);
  void DH_clear_flags(DH *dh, int flags);
  int DH_test_flags(const DH *dh, int flags);
  void DH_set_flags(DH *dh, int flags);
@@ -54,6 +61,10 @@ untouched. As with DH_set0_pqg() this function transfers the memory management
 of the key values to the DH object, and therefore they should not be freed
 directly after this function has been called.
 
+Any of the values B<p>, B<q>, B<g>, B<priv_key>, and B<pub_key> can also be
+retrieved separately by the corresponding function DH_get0_p(), DH_get0_q(),
+DH_get0_g(), DH_get0_priv_key(), and DH_get0_pub_key(), respectively.
+
 DH_set_flags() sets the flags in the B<flags> parameter on the DH object.
 Multiple flags can be passed in one go (bitwise ORed together). Any flags that
 are already set are left set. DH_test_flags() tests to see whether the flags
@@ -80,6 +91,9 @@ duplicate.  The same applies to DH_get0_pqg() and DH_set0_pqg().
 =head1 RETURN VALUES
 
 DH_set0_pqg() and DH_set0_key() return 1 on success or 0 on failure.
+
+DH_get0_p(), DH_get0_q(), DH_get0_g(), DH_get0_priv_key(), and DH_get0_pub_key()
+return the respective value.
 
 DH_test_flags() returns the current state of the flags in the DH object.
 

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -183,6 +183,11 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 void DH_get0_key(const DH *dh,
                  const BIGNUM **pub_key, const BIGNUM **priv_key);
 int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key);
+const BIGNUM *DH_get0_p(const DH *dh);
+const BIGNUM *DH_get0_q(const DH *dh);
+const BIGNUM *DH_get0_g(const DH *dh);
+const BIGNUM *DH_get0_priv_key(const DH *dh);
+const BIGNUM *DH_get0_pub_key(const DH *dh);
 void DH_clear_flags(DH *dh, int flags);
 int DH_test_flags(const DH *dh, int flags);
 void DH_set_flags(DH *dh, int flags);

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -26,6 +26,11 @@ static int cb(int p, int n, BN_GENCB *arg);
 
 static int dh_test(void)
 {
+    DH *dh;
+    BIGNUM *p, *q, *g;
+    const BIGNUM *p2, *q2, *g2;
+    BIGNUM *priv_key;
+    const BIGNUM *pub_key2, *priv_key2;
     BN_GENCB *_cb = NULL;
     DH *a = NULL;
     DH *b = NULL;
@@ -39,6 +44,77 @@ static int dh_test(void)
     int i, alen, blen, clen, aout, bout, cout;
     int ret = 0;
 
+    if (!TEST_ptr(dh = DH_new())
+        || !TEST_ptr(p = BN_new())
+        || !TEST_ptr(q = BN_new())
+        || !TEST_ptr(g = BN_new())
+        || !TEST_ptr(priv_key = BN_new()))
+        goto err;
+
+    /*
+     * I) basic tests
+     */
+
+    /* using a small predefined Sophie Germain DH group with generator 3 */
+    if (!TEST_true(BN_set_word(p, 4079L))
+        || !TEST_true(BN_set_word(q, 2039L))
+        || !TEST_true(BN_set_word(g, 3L))
+        || !TEST_true(DH_set0_pqg(dh, p, q, g)))
+        goto err;
+
+    /* test the combined getter for p, q, and g */
+    DH_get0_pqg(dh, &p2, &q2, &g2);
+    if (!TEST_ptr_eq(p2, p)
+        || !TEST_ptr_eq(q2, q)
+        || !TEST_ptr_eq(g2, g))
+        goto err;
+
+    /* test the simple getters for p, q, and g */
+    if (!TEST_ptr_eq(DH_get0_p(dh), p2)
+        || !TEST_ptr_eq(DH_get0_q(dh), q2)
+        || !TEST_ptr_eq(DH_get0_g(dh), g2))
+        goto err;
+
+    /* set the private key only*/
+    if (!TEST_true(BN_set_word(priv_key, 1234L))
+        || !TEST_true(DH_set0_key(dh, NULL, priv_key)))
+        goto err;
+
+    /* test the combined getter for pub_key and priv_key */
+    DH_get0_key(dh, &pub_key2, &priv_key2);
+    if (!TEST_ptr_eq(pub_key2, NULL)
+        || !TEST_ptr_eq(priv_key2, priv_key))
+        goto err;
+
+    /* test the simple getters for pub_key and priv_key */
+    if (!TEST_ptr_eq(DH_get0_pub_key(dh), pub_key2)
+        || !TEST_ptr_eq(DH_get0_priv_key(dh), priv_key2))
+        goto err;
+
+    /* now generate a key pair ... */
+    if (!DH_generate_key(dh))
+        goto err;
+
+    /* ... and check whether the private key was reused: */
+
+    /* test it with the combined getter for pub_key and priv_key */
+    DH_get0_key(dh, &pub_key2, &priv_key2);
+    if (!TEST_ptr(pub_key2)
+        || !TEST_ptr_eq(priv_key2, priv_key))
+        goto err;
+    /* test it the simple getters for pub_key and priv_key */
+    if (!TEST_ptr_eq(DH_get0_pub_key(dh), pub_key2)
+        || !TEST_ptr_eq(DH_get0_priv_key(dh), priv_key2))
+        goto err;
+
+    /* check whether the public key was calculated correclty */
+    TEST_uint_eq(BN_get_word(pub_key2), 3331L);
+
+    /*
+     * II) key generation
+     */
+
+    /* generate a DH group ... */
     if (!TEST_ptr(_cb = BN_GENCB_new()))
         goto err;
     BN_GENCB_set(_cb, &cb, NULL);
@@ -47,6 +123,7 @@ static int dh_test(void)
                                                     DH_GENERATOR_5, _cb)))
         goto err;
 
+    /* ... and check whether it is valid */
     if (!DH_check(a, &i))
         goto err;
     if (!TEST_false(i & DH_CHECK_P_NOT_PRIME)
@@ -57,6 +134,7 @@ static int dh_test(void)
 
     DH_get0_pqg(a, &ap, NULL, &ag);
 
+    /* now create another copy of the DH group for the peer */
     if (!TEST_ptr(b = DH_new()))
         goto err;
 
@@ -65,6 +143,10 @@ static int dh_test(void)
             || !TEST_true(DH_set0_pqg(b, bp, NULL, bg)))
         goto err;
     bp = bg = NULL;
+
+    /*
+     * III) simulate a key exchange
+     */
 
     if (!DH_generate_key(a))
         goto err;
@@ -114,6 +196,8 @@ static int dh_test(void)
     BN_free(bg);
     BN_free(cpriv_key);
     BN_GENCB_free(_cb);
+    DH_free(dh);
+
     return ret;
 }
 

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -102,6 +102,7 @@ static int dh_test(void)
     if (!TEST_ptr(pub_key2)
         || !TEST_ptr_eq(priv_key2, priv_key))
         goto err;
+
     /* test it the simple getters for pub_key and priv_key */
     if (!TEST_ptr_eq(DH_get0_pub_key(dh), pub_key2)
         || !TEST_ptr_eq(DH_get0_priv_key(dh), priv_key2))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4528,3 +4528,8 @@ conf_ssl_name_find                      4469	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get_cmd                        4470	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get                            4471	1_1_0i	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_hostflags         4472	1_1_0i	EXIST::FUNCTION:
+DH_get0_p                               4473	1_1_0i	EXIST::FUNCTION:DH
+DH_get0_q                               4474	1_1_0i	EXIST::FUNCTION:DH
+DH_get0_g                               4475	1_1_0i	EXIST::FUNCTION:DH
+DH_get0_priv_key                        4476	1_1_0i	EXIST::FUNCTION:DH
+DH_get0_pub_key                         4477	1_1_0i	EXIST::FUNCTION:DH


### PR DESCRIPTION
When porting application code from openssl 1.0.2 to 1.1.1 api, I noticed that I was faced with replacing a lot of expressions of the form

```
	call_some_function(dh->pub_key);
```

by something awkward like

```
    const BIGNUM *pub_key;
	
    DH_get0_key(dh, &pub_key, NULL);
    call_some_function(pub_key)
```
not to mention the fact that I always had to look up whether the pub_key is the second or third argument of DH_get0_key(). This commit adds simple getters for the most commonly used struct members and enables to write

```
	call_some_function(DH_get0_pub_key(dh));
```

instead.



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
