### PR TITLE
Mitigation of the One-and-Done side-channel attack (USENIX Security'18)

### DIFF
--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -1038,7 +1038,8 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
             }
         }
 
-        /* The exponent may not have a whole number of fixed-size windows.
+        /* 
+         * The exponent may not have a whole number of fixed-size windows.
          * To simplify the main loop, the initial window has between 1 and
          * full-window-size bits such that what remains is always a whole
          * number of windows
@@ -1051,7 +1052,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
                                             window))
             goto err;
 
-        wmask= (1 << window) - 1;
+        wmask = (1 << window) - 1;
         /*
          * Scan the exponent one window at a time starting from the most
          * significant bits.
@@ -1063,7 +1064,8 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
                 if (!BN_mod_mul_montgomery(&tmp, &tmp, &tmp, mont, ctx))
                     goto err;
 
-            /* Get a window's worth of bits from the exponent
+            /* 
+             * Get a window's worth of bits from the exponent
              * This avoids calling BN_is_bit_set for each bit, which
              * is not only slower but also makes each bit vulnerable to
              * EM (and likely other) side-channel attacks like One&Done


### PR DESCRIPTION
The One&Done attack, which is described in a paper to appear in the USENIX Security'18 conference, uses EM emanations to recover the values of the bits that are obtained using BN_is_bit_set while constructing the value of the window in BN_mod_exp_consttime. The EM signal changes slightly depending on the value of the bit, and since the lookup of a bit is surrounded by highly regular execution (constant-time Montgomery multiplications) the attack is able to isolate the (very brief) part of the signal that changes depending on the bit. Although the change is slight, the attack recovers it successfully >90% of the time on several phones and IoT devices (all with ARM processors with clock rates around 1GHz), so after only one RSA decryption more than 90% of the bits in d_p and d_q are recovered correctly, which enables rapid recovery of the full RSA key using an algorithm (also described in the paper) that modifies the branch-and-prune approach for a situation in which the exponents' bits are recovered with errors, i.e. where we do not know a priori which bits are correctly recovered.

The mitigation for the attack is relatively simple - all the bits of the window are obtained at once, along with other bits so that an entire integer's worth of bits are obtained together using masking and shifts, without unnecessarily considering each bit in isolation. This improves performance somewhat (one call to bn_get_bits is faster than several calls to BN_is_bit_set), so the attacker now gets one signal snippet per window (rather than one per bit) in which the signal is affected by all bits in the integer (rather than just the one bit). This forces the attacker to try to match the signal snippet against billions of possibilities (rather than just two) using approximately the same amount of side-channel signal. This not only dramatically increases the computational requirements for the attack, it also makes the attack much less likely to succeed because the signal snippet when using one bit and when using several bits exhibits value-dependent changes of similar magnitude, so wile that amount of change may be sufficient to distinguish between two levels (for 0 and for 1), it is not sufficient to distinguish between many levels where each is very similar to (practically indistinguishable from) many others.

This code has been tested on ARM and x86 systems (with -no-asm so this code actually ends up being used), and in all tested systems it improves performance slightly. We also verified that it indeed prevents the One&Done-style attacks (the attack's recovery of the exponent's bits is now around 50%, i.e. no better than random guessing). 
 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
