### PR TITLE
fixing integer overflow in ASN1_STRING_set

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -272,16 +272,19 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len)
 {
     unsigned char *c;
     const char *data = _data;
+    size_t new_len = 0;
 
     if (len < 0) {
         if (data == NULL)
             return 0;
         else
-            len = strlen(data);
+            new_len = strlen(data);
     }
 
-    if ( len < 0)
+    if ( new_len > INT_MAX)
         return 0;
+    else
+        len = (int)new_len;
 
     if ((str->length <= len) || (str->data == NULL)) {
         c = str->data;

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -279,6 +279,10 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len)
         else
             len = strlen(data);
     }
+
+    if ( len < 0)
+        return 0;
+
     if ((str->length <= len) || (str->data == NULL)) {
         c = str->data;
         str->data = OPENSSL_realloc(c, len + 1);

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -281,10 +281,12 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len)
             new_len = strlen(data);
     }
 
-    if ( new_len > INT_MAX)
+    if (new_len > INT_MAX) {
+        ASN1err(ASN1_F_ASN1_STRING_SET, ASN1_R_LENGTH_OUT_OF_RANGE);
         return 0;
-    else
+    } else {
         len = (int)new_len;
+    }
 
     if ((str->length <= len) || (str->data == NULL)) {
         c = str->data;


### PR DESCRIPTION
ASN1_STRING data types are not supposed to contain strings longer than INT_MAX bytes.
Simply returning 0 to the caller might suffice.