### PR TITLE
Restore check of |*xn| against |name| in X509_NAME_set

### DIFF
--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -481,6 +481,8 @@ static int i2d_name_canon(STACK_OF(STACK_OF_X509_NAME_ENTRY) * _intname,
 
 int X509_NAME_set(X509_NAME **xn, X509_NAME *name)
 {
+    if (*xn == name)
+        return *xn != NULL;
     if ((name = X509_NAME_dup(name)) == NULL)
         return 0;
     X509_NAME_free(*xn);


### PR DESCRIPTION
A previous change of this function introduced a fragility when the
destination happens to be the same as the source.  Such alias isn't
recommended, but could still happen, for example in this kind of code:

    X509_NAME *subject = X509_get_issuer_name(x);

    /* ... some code passes ... */

    X509_set_issuer_name(x, subject);

Fixes #4710
