### PR TITLE
(Minor) Fix NULL-check

### DIFF
--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -44,18 +44,18 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
 
     if (x->cipher == NULL) {
         if (((x->cipher_id) & 0xff000000) == 0x02000000) {
-            if (BIO_printf
-                (bp, "    Cipher    : %06lX\n", x->cipher_id & 0xffffff) <= 0)
+            if (BIO_printf(bp, "    Cipher    : %06lX\n",
+                           x->cipher_id & 0xffffff) <= 0)
                 goto err;
         } else {
-            if (BIO_printf
-                (bp, "    Cipher    : %04lX\n", x->cipher_id & 0xffff) <= 0)
+            if (BIO_printf(bp, "    Cipher    : %04lX\n",
+                           x->cipher_id & 0xffff) <= 0)
                 goto err;
         }
     } else {
-        if (BIO_printf
-            (bp, "    Cipher    : %s\n",
-             ((x->cipher == NULL) ? "unknown" : x->cipher->name)) <= 0)
+        if (BIO_printf(bp, "    Cipher    : %s\n",
+                       ((x->cipher->name == NULL) ? "unknown"
+                                                  : x->cipher->name)) <= 0)
             goto err;
     }
     if (BIO_puts(bp, "    Session-ID: ") <= 0)


### PR DESCRIPTION
NULL-check for cipher is redundant, instead check if cipher->name is NULL

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
