### PR TITLE
Update pkeyutl

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,10 @@
  release branch.
 
  Changes between 1.1.0h and 1.1.1 [xx XXX xxxx]
+  *) Enforce checking in the pkeyutl command line app to ensure that the input
+     length does not exceed the maximum supported digest length when performing
+     a sign, verify or verifyrecover operation.
+     [Matt Caswell]
 
   *) When unlocking a pass phrase protected PEM file or PKCS#8 container, we
      now allow empty (zero character) pass phrases.

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -282,7 +282,7 @@ int pkeyutl_main(int argc, char **argv)
         buf_inlen = bio_to_mem(&buf_in, keysize * 10, in);
         if (buf_inlen < 0) {
             BIO_printf(bio_err, "Error reading input Data\n");
-            exit(1);
+            goto end;
         }
         if (rev) {
             size_t i;
@@ -294,6 +294,16 @@ int pkeyutl_main(int argc, char **argv)
                 buf_in[l - 1 - i] = ctmp;
             }
         }
+    }
+
+    /* Sanity check the input */
+    if (buf_inlen > EVP_MAX_MD_SIZE
+            && (pkey_op == EVP_PKEY_OP_SIGN
+                || pkey_op == EVP_PKEY_OP_VERIFY
+                || pkey_op == EVP_PKEY_OP_VERIFYRECOVER)) {
+        BIO_printf(bio_err,
+                   "Error: The input data looks too long to be a hash\n");
+        goto end;
     }
 
     if (pkey_op == EVP_PKEY_OP_VERIFY) {

--- a/crypto/ec/ec_err.c
+++ b/crypto/ec/ec_err.c
@@ -250,8 +250,6 @@ static const ERR_STRING_DATA EC_str_functs[] = {
      "pkey_ecd_digestsign25519"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECD_DIGESTSIGN448, 0),
      "pkey_ecd_digestsign448"},
-    {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECD_SIGN25519, 0), "pkey_ecd_sign25519"},
-    {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECD_SIGN448, 0), "pkey_ecd_sign448"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_ECX_DERIVE, 0), "pkey_ecx_derive"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_EC_CTRL, 0), "pkey_ec_ctrl"},
     {ERR_PACK(ERR_LIB_EC, EC_F_PKEY_EC_CTRL_STR, 0), "pkey_ec_ctrl_str"},

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -675,18 +675,18 @@ const EVP_PKEY_METHOD ecx448_pkey_meth = {
     0
 };
 
-static int pkey_ecd_sign25519(EVP_PKEY_CTX *ctx, unsigned char *sig,
-                              size_t *siglen, const unsigned char *tbs,
-                              size_t tbslen)
+static int pkey_ecd_digestsign25519(EVP_MD_CTX *ctx, unsigned char *sig,
+                                    size_t *siglen, const unsigned char *tbs,
+                                    size_t tbslen)
 {
-    const ECX_KEY *edkey = ctx->pkey->pkey.ecx;
+    const ECX_KEY *edkey = EVP_MD_CTX_pkey_ctx(ctx)->pkey->pkey.ecx;
 
     if (sig == NULL) {
         *siglen = ED25519_SIGSIZE;
         return 1;
     }
     if (*siglen < ED25519_SIGSIZE) {
-        ECerr(EC_F_PKEY_ECD_SIGN25519, EC_R_BUFFER_TOO_SMALL);
+        ECerr(EC_F_PKEY_ECD_DIGESTSIGN25519, EC_R_BUFFER_TOO_SMALL);
         return 0;
     }
 
@@ -696,26 +696,18 @@ static int pkey_ecd_sign25519(EVP_PKEY_CTX *ctx, unsigned char *sig,
     return 1;
 }
 
-static int pkey_ecd_digestsign25519(EVP_MD_CTX *ctx, unsigned char *sig,
-                                    size_t *siglen, const unsigned char *tbs,
-                                    size_t tbslen)
+static int pkey_ecd_digestsign448(EVP_MD_CTX *ctx, unsigned char *sig,
+                                  size_t *siglen, const unsigned char *tbs,
+                                  size_t tbslen)
 {
-    return pkey_ecd_sign25519(EVP_MD_CTX_pkey_ctx(ctx), sig, siglen, tbs,
-                              tbslen);
-}
-
-static int pkey_ecd_sign448(EVP_PKEY_CTX *ctx, unsigned char *sig,
-                            size_t *siglen, const unsigned char *tbs,
-                            size_t tbslen)
-{
-    const ECX_KEY *edkey = ctx->pkey->pkey.ecx;
+    const ECX_KEY *edkey = EVP_MD_CTX_pkey_ctx(ctx)->pkey->pkey.ecx;
 
     if (sig == NULL) {
         *siglen = ED448_SIGSIZE;
         return 1;
     }
     if (*siglen < ED448_SIGSIZE) {
-        ECerr(EC_F_PKEY_ECD_SIGN448, EC_R_BUFFER_TOO_SMALL);
+        ECerr(EC_F_PKEY_ECD_DIGESTSIGN448, EC_R_BUFFER_TOO_SMALL);
         return 0;
     }
 
@@ -726,18 +718,11 @@ static int pkey_ecd_sign448(EVP_PKEY_CTX *ctx, unsigned char *sig,
     return 1;
 }
 
-static int pkey_ecd_digestsign448(EVP_MD_CTX *ctx, unsigned char *sig,
-                                  size_t *siglen, const unsigned char *tbs,
-                                  size_t tbslen)
+static int pkey_ecd_digestverify25519(EVP_MD_CTX *ctx, const unsigned char *sig,
+                                      size_t siglen, const unsigned char *tbs,
+                                      size_t tbslen)
 {
-    return pkey_ecd_sign448(EVP_MD_CTX_pkey_ctx(ctx), sig, siglen, tbs, tbslen);
-}
-
-static int pkey_ecd_verify25519(EVP_PKEY_CTX *ctx, const unsigned char *sig,
-                                size_t siglen, const unsigned char *tbs,
-                                size_t tbslen)
-{
-    const ECX_KEY *edkey = ctx->pkey->pkey.ecx;
+    const ECX_KEY *edkey = EVP_MD_CTX_pkey_ctx(ctx)->pkey->pkey.ecx;
 
     if (siglen != ED25519_SIGSIZE)
         return 0;
@@ -745,32 +730,16 @@ static int pkey_ecd_verify25519(EVP_PKEY_CTX *ctx, const unsigned char *sig,
     return ED25519_verify(tbs, tbslen, sig, edkey->pubkey);
 }
 
-static int pkey_ecd_digestverify25519(EVP_MD_CTX *ctx, const unsigned char *sig,
-                                      size_t siglen, const unsigned char *tbs,
-                                      size_t tbslen)
+static int pkey_ecd_digestverify448(EVP_MD_CTX *ctx, const unsigned char *sig,
+                                    size_t siglen, const unsigned char *tbs,
+                                    size_t tbslen)
 {
-    return pkey_ecd_verify25519(EVP_MD_CTX_pkey_ctx(ctx), sig, siglen, tbs,
-                                tbslen);
-}
-
-static int pkey_ecd_verify448(EVP_PKEY_CTX *ctx, const unsigned char *sig,
-                              size_t siglen, const unsigned char *tbs,
-                              size_t tbslen)
-{
-    const ECX_KEY *edkey = ctx->pkey->pkey.ecx;
+    const ECX_KEY *edkey = EVP_MD_CTX_pkey_ctx(ctx)->pkey->pkey.ecx;
 
     if (siglen != ED448_SIGSIZE)
         return 0;
 
     return ED448_verify(tbs, tbslen, sig, edkey->pubkey, NULL, 0);
-}
-
-static int pkey_ecd_digestverify448(EVP_MD_CTX *ctx, const unsigned char *sig,
-                                    size_t siglen, const unsigned char *tbs,
-                                    size_t tbslen)
-{
-    return pkey_ecd_verify448(EVP_MD_CTX_pkey_ctx(ctx), sig, siglen, tbs,
-                              tbslen);
 }
 
 static int pkey_ecd_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
@@ -793,11 +762,7 @@ const EVP_PKEY_METHOD ed25519_pkey_meth = {
     EVP_PKEY_ED25519, EVP_PKEY_FLAG_SIGCTX_CUSTOM,
     0, 0, 0, 0, 0, 0,
     pkey_ecx_keygen,
-    0,
-    pkey_ecd_sign25519,
-    0,
-    pkey_ecd_verify25519,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     pkey_ecd_ctrl,
     0,
     pkey_ecd_digestsign25519,
@@ -808,11 +773,7 @@ const EVP_PKEY_METHOD ed448_pkey_meth = {
     EVP_PKEY_ED448, EVP_PKEY_FLAG_SIGCTX_CUSTOM,
     0, 0, 0, 0, 0, 0,
     pkey_ecx_keygen,
-    0,
-    pkey_ecd_sign448,
-    0,
-    pkey_ecd_verify448,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     pkey_ecd_ctrl,
     0,
     pkey_ecd_digestsign448,

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -647,8 +647,6 @@ EC_F_PKEY_ECD_CTRL:271:pkey_ecd_ctrl
 EC_F_PKEY_ECD_DIGESTSIGN:272:pkey_ecd_digestsign
 EC_F_PKEY_ECD_DIGESTSIGN25519:276:pkey_ecd_digestsign25519
 EC_F_PKEY_ECD_DIGESTSIGN448:277:pkey_ecd_digestsign448
-EC_F_PKEY_ECD_SIGN25519:284:pkey_ecd_sign25519
-EC_F_PKEY_ECD_SIGN448:285:pkey_ecd_sign448
 EC_F_PKEY_ECX_DERIVE:269:pkey_ecx_derive
 EC_F_PKEY_EC_CTRL:197:pkey_ec_ctrl
 EC_F_PKEY_EC_CTRL_STR:198:pkey_ec_ctrl_str

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -38,8 +38,8 @@ B<openssl> B<pkeyutl>
 
 =head1 DESCRIPTION
 
-The B<pkeyutl> command can be used to perform public key operations using
-any supported algorithm.
+The B<pkeyutl> command can be used to perform low level public key operations
+using any supported algorithm.
 
 =head1 OPTIONS
 
@@ -99,17 +99,17 @@ Reverse the order of the input buffer. This is useful for some libraries
 
 =item B<-sign>
 
-Sign the input data and output the signed result. This requires
-a private key.
+Sign the input data (which must be a hash) and output the signed result. This
+requires a private key.
 
 =item B<-verify>
 
-Verify the input data against the signature file and indicate if the
-verification succeeded or failed.
+Verify the input data (which must be a hash) against the signature file and
+indicate if the verification succeeded or failed.
 
 =item B<-verifyrecover>
 
-Verify the input data and output the recovered data.
+Verify the input data (which must be a hash) and output the recovered data.
 
 =item B<-encrypt>
 
@@ -184,20 +184,25 @@ and its implementation. The OpenSSL operations and options are indicated below.
 Unless otherwise mentioned all algorithms support the B<digest:alg> option
 which specifies the digest in use for sign, verify and verifyrecover operations.
 The value B<alg> should represent a digest name as used in the
-EVP_get_digestbyname() function for example B<sha1>.
-This value is used only for sanity-checking the lengths of data passed in to
-the B<pkeyutl> and for creating the structures that make up the signature
-(e.g. B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
-In case of RSA, ECDSA and DSA signatures, this utility
-will not perform hashing on input data but rather use the data directly as
-input of signature algorithm. Depending on key type, signature type and mode
-of padding, the maximum acceptable lengths of input data differ. In general,
-with RSA the signed data can't be longer than the key modulus, in case of ECDSA
-and DSA the data shouldn't be longer than field size, otherwise it will be
-silently truncated to field size.
+EVP_get_digestbyname() function for example B<sha1>. This value is not used to
+hash the input data. It is used (by some algorithms) for sanity-checking the
+lengths of data passed in to the B<pkeyutl> and for creating the structures that
+make up the signature (e.g. B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
 
-In other words, if the value of digest is B<sha1> the input should be 20 bytes
-long binary encoding of SHA-1 hash function output.
+This utility will not perform hashing on input data but rather it will use the
+data directly as input to the signature algorithm. Depending on the key type,
+signature type and mode of padding, the maximum acceptable lengths of input data
+differ. In general, with RSA the signed data can't be longer than the key
+modulus. In case of ECDSA and DSA the data shouldn't be longer than the field
+size, otherwise it will be silently truncated to the field size. In any event
+the input size must not be larger than the largest supported digest size.
+
+In other words, if the value of digest is B<sha1> the input should be the 20
+bytes long binary encoding of the SHA-1 hash function output.
+
+The Ed25519 and Ed448 signature algorithms are not supported by this utility.
+They accept non-hashed input, but this utility can only be used to sign hashed
+input.
 
 =head1 RSA ALGORITHM
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -189,11 +189,11 @@ hash the input data. It is used (by some algorithms) for sanity-checking the
 lengths of data passed in to the B<pkeyutl> and for creating the structures that
 make up the signature (e.g. B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
 
-This utility will not perform hashing on input data but rather it will use the
-data directly as input to the signature algorithm. Depending on the key type,
-signature type and mode of padding, the maximum acceptable lengths of input data
-differ. In general, with RSA the signed data can't be longer than the key
-modulus. In case of ECDSA and DSA the data shouldn't be longer than the field
+This utility does not hash the input data but rather it will use the data
+directly as input to the signature algorithm. Depending on the key type,
+signature type, and mode of padding, the maximum acceptable lengths of input
+data differ. The signed data can't be longer than the key modulus with RSA. In
+case of ECDSA and DSA the data shouldn't be longer than the field
 size, otherwise it will be silently truncated to the field size. In any event
 the input size must not be larger than the largest supported digest size.
 

--- a/include/openssl/ecerr.h
+++ b/include/openssl/ecerr.h
@@ -173,8 +173,6 @@ int ERR_load_EC_strings(void);
 #  define EC_F_PKEY_ECD_DIGESTSIGN                         272
 #  define EC_F_PKEY_ECD_DIGESTSIGN25519                    276
 #  define EC_F_PKEY_ECD_DIGESTSIGN448                      277
-#  define EC_F_PKEY_ECD_SIGN25519                          284
-#  define EC_F_PKEY_ECD_SIGN448                            285
 #  define EC_F_PKEY_ECX_DERIVE                             269
 #  define EC_F_PKEY_EC_CTRL                                197
 #  define EC_F_PKEY_EC_CTRL_STR                            198


### PR DESCRIPTION
As mentioned in the discussion on #5880 by @davidben, Ed448/Ed25519 should not implement EVP_PKEY_sign() because they take unhashed input. Therefore I have reverted the change that did that. The original motivation was to enable support in the pkeyutl application. Instead I have simply noted in the docs that those algorithms are not supported.

While looking into this I discovered some other issues. When signing, pkeyutl expects hashed input. If the hash is too long any you are using an EC key, then ECDSA will silently truncate its input. This behaviour is mentioned in the docs but they are quite confusing, so I have tried to clarify things. I have also implemented a sanity check which refuses to sign anything longer than the maximum supported digest length. This could be classed as breaking behaviour, e.g. if you really know what you're doing (such as using a hash algorithm that isn't supported by OpenSSL with a very long output), then you won't be able to do that any more. However I think such corner cases would be very rare, and this will protect a lot of people from a big foot gun.
