### PR TITLE
Allow the ca application to use EdDSA

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -735,17 +735,21 @@ end_of_options:
     if (md == NULL && (md = lookup_conf(conf, section, ENV_DEFAULT_MD)) == NULL)
         goto end;
 
-    if (strcmp(md, "default") == 0) {
-        int def_nid;
-        if (EVP_PKEY_get_default_digest_nid(pkey, &def_nid) <= 0) {
-            BIO_puts(bio_err, "no default digest\n");
+    if (strcmp(md, "null") == 0) {
+        dgst = EVP_md_null();
+    } else {
+        if (strcmp(md, "default") == 0) {
+            int def_nid;
+            if (EVP_PKEY_get_default_digest_nid(pkey, &def_nid) <= 0) {
+                BIO_puts(bio_err, "no default digest\n");
+                goto end;
+            }
+            md = (char *)OBJ_nid2sn(def_nid);
+        }
+
+        if (!opt_md(md, &dgst)) {
             goto end;
         }
-        md = (char *)OBJ_nid2sn(def_nid);
-    }
-
-    if (!opt_md(md, &dgst)) {
-        goto end;
     }
 
     if (req) {

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -778,7 +778,7 @@ static int pkey_ecd_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     switch (type) {
     case EVP_PKEY_CTRL_MD:
         /* Only NULL allowed as digest */
-        if (p2 == NULL)
+        if (p2 == NULL || (const EVP_MD *)p2 == EVP_md_null())
             return 1;
         ECerr(EC_F_PKEY_ECD_CTRL, EC_R_INVALID_DIGEST_TYPE);
         return 0;

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -184,7 +184,8 @@ The number of days to certify the certificate for.
 =item B<-md alg>
 
 The message digest to use.
-Any digest supported by the OpenSSL B<dgst> command can be used.
+Any digest supported by the OpenSSL B<dgst> command can be used. If the signing
+key is using Ed25519 or Ed448 then you should specify "null" for the digest.
 This option also applies to CRLs.
 
 =item B<-policy arg>


### PR DESCRIPTION
Using the ca application to sign certificates with EdDSA failed because it
is not possible to set the digest to "null". This adds the capability and
updates the documentation accordingly.

Fixes #6201

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
