### PR TITLE
DSA,RSA,ECDSA_SIG: add simple getters for commonly used struct members

### DIFF
--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -305,6 +305,31 @@ int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
     return 1;
 }
 
+const BIGNUM *DSA_get0_p(const DSA *d)
+{
+    return d->p;
+}
+
+const BIGNUM *DSA_get0_q(const DSA *d)
+{
+    return d->q;
+}
+
+const BIGNUM *DSA_get0_g(const DSA *d)
+{
+    return d->g;
+}
+
+const BIGNUM *DSA_get0_pub_key(const DSA *d)
+{
+    return d->pub_key;
+}
+
+const BIGNUM *DSA_get0_priv_key(const DSA *d)
+{
+    return d->priv_key;
+}
+
 void DSA_clear_flags(DSA *d, int flags)
 {
     d->flags &= ~flags;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1183,6 +1183,16 @@ void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps)
         *ps = sig->s;
 }
 
+const BIGNUM *ECDSA_SIG_get0_r(const ECDSA_SIG *sig)
+{
+    return sig->r;
+}
+
+const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig)
+{
+    return sig->s;
+}
+
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
     if (r == NULL || s == NULL)

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -402,6 +402,46 @@ int RSA_get0_multi_prime_crt_params(const RSA *r, const BIGNUM *exps[],
     return 1;
 }
 
+const BIGNUM *RSA_get0_n(const RSA *r)
+{
+    return r->n;
+}
+
+const BIGNUM *RSA_get0_e(const RSA *r)
+{
+    return r->e;
+}
+
+const BIGNUM *RSA_get0_d(const RSA *r)
+{
+    return r->d;
+}
+
+const BIGNUM *RSA_get0_p(const RSA *r)
+{
+    return r->p;
+}
+
+const BIGNUM *RSA_get0_q(const RSA *r)
+{
+    return r->q;
+}
+
+const BIGNUM *RSA_get0_dmp1(const RSA *r)
+{
+    return r->dmp1;
+}
+
+const BIGNUM *RSA_get0_dmq1(const RSA *r)
+{
+    return r->dmq1;
+}
+
+const BIGNUM *RSA_get0_iqmp(const RSA *r)
+{
+    return r->iqmp;
+}
+
 void RSA_clear_flags(RSA *r, int flags)
 {
     r->flags &= ~flags;

--- a/doc/man3/DH_get0_pqg.pod
+++ b/doc/man3/DH_get0_pqg.pod
@@ -41,6 +41,8 @@ If the parameters have not yet been set then B<*p>, B<*q> and B<*g> will be set
 to NULL. Otherwise they are set to pointers to their respective values. These
 point directly to the internal representations of the values and therefore
 should not be freed directly.
+Any of the out parameters B<p>, B<q>, and B<g> can be NULL, in which case no
+value will be returned for that parameter.
 
 The B<p>, B<q> and B<g> values can be set by calling DH_set0_pqg() and passing
 the new values for B<p>, B<q> and B<g> as parameters to the function. Calling
@@ -54,6 +56,8 @@ private key will be stored in B<*priv_key>. Either may be NULL if they have not
 been set yet, although if the private key has been set then the public key must
 be. The values point to the internal representation of the public key and
 private key values. This memory should not be freed directly.
+Any of the out parameters B<pub_key> and B<priv_key> can be NULL, in which case
+no value will be returned for that parameter.
 
 The public and private key values can be set using DH_set0_key(). Either
 parameter may be NULL, which means the corresponding DH field is left
@@ -93,7 +97,7 @@ duplicate.  The same applies to DH_get0_pqg() and DH_set0_pqg().
 DH_set0_pqg() and DH_set0_key() return 1 on success or 0 on failure.
 
 DH_get0_p(), DH_get0_q(), DH_get0_g(), DH_get0_priv_key(), and DH_get0_pub_key()
-return the respective value.
+return the respective value, or NULL if it is unset.
 
 DH_test_flags() returns the current state of the flags in the DH object.
 

--- a/doc/man3/DSA_get0_pqg.pod
+++ b/doc/man3/DSA_get0_pqg.pod
@@ -2,8 +2,11 @@
 
 =head1 NAME
 
-DSA_get0_pqg, DSA_set0_pqg, DSA_get0_key, DSA_set0_key, DSA_clear_flags,
-DSA_test_flags, DSA_set_flags, DSA_get0_engine - Routines for getting and
+DSA_get0_pqg, DSA_set0_pqg, DSA_get0_key, DSA_set0_key,
+DSA_get0_p, DSA_get0_q, DSA_get0_g,
+DSA_get0_pub_key, DSA_get0_priv_key,
+DSA_clear_flags, DSA_test_flags, DSA_set_flags,
+DSA_get0_engine - Routines for getting and
 setting data in a DSA object
 
 =head1 SYNOPSIS
@@ -16,6 +19,11 @@ setting data in a DSA object
  void DSA_get0_key(const DSA *d,
                    const BIGNUM **pub_key, const BIGNUM **priv_key);
  int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key);
+ const BIGNUM *DSA_get0_p(const DSA *d);
+ const BIGNUM *DSA_get0_q(const DSA *d);
+ const BIGNUM *DSA_get0_g(const DSA *d);
+ const BIGNUM *DSA_get0_pub_key(const DSA *d);
+ const BIGNUM *DSA_get0_priv_key(const DSA *d);
  void DSA_clear_flags(DSA *d, int flags);
  int DSA_test_flags(const DSA *d, int flags);
  void DSA_set_flags(DSA *d, int flags);
@@ -52,6 +60,10 @@ which means the corresponding DSA field is left untouched. As for DSA_set0_pqg()
 this function transfers the memory management of the key values to the DSA
 object, and therefore they should not be freed directly after this function has
 been called.
+
+Any of the values B<p>, B<q>, B<g>, B<priv_key>, and B<pub_key> can also be
+retrieved separately by the corresponding function DSA_get0_p(), DSA_get0_q(),
+DSA_get0_g(), DSA_get0_priv_key(), and DSA_get0_pub_key(), respectively.
 
 DSA_set_flags() sets the flags in the B<flags> parameter on the DSA object.
 Multiple flags can be passed in one go (bitwise ORed together). Any flags that

--- a/doc/man3/ECDSA_SIG_new.pod
+++ b/doc/man3/ECDSA_SIG_new.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-ECDSA_SIG_get0, ECDSA_SIG_set0,
+ECDSA_SIG_get0, ECDSA_SIG_get0_r, ECDSA_SIG_get0_s, ECDSA_SIG_set0,
 ECDSA_SIG_new, ECDSA_SIG_free, i2d_ECDSA_SIG, d2i_ECDSA_SIG, ECDSA_size,
 ECDSA_sign, ECDSA_do_sign, ECDSA_verify, ECDSA_do_verify, ECDSA_sign_setup,
 ECDSA_sign_ex, ECDSA_do_sign_ex - low level elliptic curve digital signature
@@ -15,6 +15,8 @@ algorithm (ECDSA) functions
  ECDSA_SIG *ECDSA_SIG_new(void);
  void ECDSA_SIG_free(ECDSA_SIG *sig);
  void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
+ const BIGNUM *ECDSA_SIG_get0_r(const ECDSA_SIG *sig);
+ const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
  int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
  int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
  ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
@@ -53,7 +55,12 @@ OpenSSL 1.1.0 the: the B<r> and B<s> components were initialised.
 ECDSA_SIG_free() frees the B<ECDSA_SIG> structure B<sig>.
 
 ECDSA_SIG_get0() returns internal pointers the B<r> and B<s> values contained
-in B<sig>.
+in B<sig> and stores them in B<*pr> and B<*ps>, respectively.
+The pointer B<pr> or B<ps> can be NULL, in which case the corresponding value
+is not returned.
+
+The values B<r>, B<s> can also be retrieved separately by the corresponding
+function ECDSA_SIG_get0_r() and ECDSA_SIG_get0_s(), respectively.
 
 The B<r> and B<s> values can be set by calling ECDSA_SIG_set0() and passing the
 new values for B<r> and B<s> as parameters to the function. Calling this
@@ -115,6 +122,9 @@ returned as a newly allocated B<ECDSA_SIG> structure (or NULL on error).
 =head1 RETURN VALUES
 
 ECDSA_SIG_set0() returns 1 on success or 0 on failure.
+
+ECDSA_SIG_get0_r() and ECDSA_SIG_get0_s() return the corresponding value,
+or NULL if it is unset.
 
 ECDSA_size() returns the maximum length signature or 0 on error.
 

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -3,7 +3,10 @@
 =head1 NAME
 
 RSA_set0_key, RSA_set0_factors, RSA_set0_crt_params, RSA_get0_key,
-RSA_get0_factors, RSA_get0_crt_params, RSA_clear_flags,
+RSA_get0_factors, RSA_get0_crt_params,
+RSA_get0_n, RSA_get0_e, RSA_get0_d, RSA_get0_p, RSA_get0_q,
+RSA_get0_dmp1, RSA_get0_dmq1, RSA_get0_iqmp,
+RSA_clear_flags,
 RSA_test_flags, RSA_set_flags, RSA_get0_engine, RSA_get_multi_prime_extra_count,
 RSA_get0_multi_prime_factors, RSA_get0_multi_prime_crt_params,
 RSA_set0_multi_prime_params, RSA_get_version
@@ -22,6 +25,14 @@ RSA_set0_multi_prime_params, RSA_get_version
  void RSA_get0_crt_params(const RSA *r,
                           const BIGNUM **dmp1, const BIGNUM **dmq1,
                           const BIGNUM **iqmp);
+ const BIGNUM *RSA_get0_n(const RSA *d);
+ const BIGNUM *RSA_get0_e(const RSA *d);
+ const BIGNUM *RSA_get0_d(const RSA *d);
+ const BIGNUM *RSA_get0_p(const RSA *d);
+ const BIGNUM *RSA_get0_q(const RSA *d);
+ const BIGNUM *RSA_get0_dmp1(const RSA *r);
+ const BIGNUM *RSA_get0_dmq1(const RSA *r);
+ const BIGNUM *RSA_get0_iqmp(const RSA *r);
  void RSA_clear_flags(RSA *r, int flags);
  int RSA_test_flags(const RSA *r, int flags);
  void RSA_set_flags(RSA *r, int flags);
@@ -82,6 +93,11 @@ return values are stored in an array of B<BIGNUM *>. RSA_set0_multi_prime_params
 sets a collect of multi-prime 'triplet' members (prime, exponent and coefficient)
 into an RSA object.
 
+Any of the values B<n>, B<e>, B<d>, B<p>, B<q>, B<dmp1>, B<dmq1>, and B<iqmp> can also be
+retrieved separately by the corresponding function
+RSA_get0_n(), RSA_get0_e(), RSA_get0_d(), RSA_get0_p(), RSA_get0_q(),
+RSA_get0_dmp1(), RSA_get0_dmq1(), and RSA_get0_iqmp(), respectively.
+
 RSA_set_flags() sets the flags in the B<flags> parameter on the RSA
 object. Multiple flags can be passed in one go (bitwise ORed together).
 Any flags that are already set are left set. RSA_test_flags() tests to
@@ -115,6 +131,10 @@ triplets in RSA object B<r> and assign the new set of triplets into it.
 
 RSA_set0_key(), RSA_set0_factors(), RSA_set0_crt_params() and
 RSA_set0_multi_prime_params() return 1 on success or 0 on failure.
+
+RSA_get0_n(), RSA_get0_e(), RSA_get0_d(), RSA_get0_p(), RSA_get0_q(),
+RSA_get0_dmp1(), RSA_get0_dmq1(), and RSA_get0_iqmp()
+return the respective value.
 
 RSA_get0_multi_prime_factors() and RSA_get0_multi_prime_crt_params() return
 1 on success or 0 on failure.

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -171,6 +171,11 @@ int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 void DSA_get0_key(const DSA *d,
                   const BIGNUM **pub_key, const BIGNUM **priv_key);
 int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key);
+const BIGNUM *DSA_get0_p(const DSA *d);
+const BIGNUM *DSA_get0_q(const DSA *d);
+const BIGNUM *DSA_get0_g(const DSA *d);
+const BIGNUM *DSA_get0_pub_key(const DSA *d);
+const BIGNUM *DSA_get0_priv_key(const DSA *d);
 void DSA_clear_flags(DSA *d, int flags);
 int DSA_test_flags(const DSA *d, int flags);
 void DSA_set_flags(DSA *d, int flags);

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1066,6 +1066,16 @@ ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
  */
 void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
 
+/** Accessor for r field of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG structure
+ */
+const BIGNUM *ECDSA_SIG_get0_r(const ECDSA_SIG *sig);
+
+/** Accessor for s field of ECDSA_SIG
+ *  \param  sig  pointer to ECDSA_SIG structure
+ */
+const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
+
 /** Setter for r and s fields of ECDSA_SIG
  *  \param  sig  pointer to ECDSA_SIG pointer
  *  \param  r    pointer to BIGNUM for r (may be NULL)

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1060,7 +1060,7 @@ int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
 ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
 
 /** Accessor for r and s fields of ECDSA_SIG
- *  \param  sig  pointer to ECDSA_SIG pointer
+ *  \param  sig  pointer to ECDSA_SIG structure
  *  \param  pr   pointer to BIGNUM pointer for r (may be NULL)
  *  \param  ps   pointer to BIGNUM pointer for s (may be NULL)
  */
@@ -1077,9 +1077,7 @@ const BIGNUM *ECDSA_SIG_get0_r(const ECDSA_SIG *sig);
 const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
 
 /** Setter for r and s fields of ECDSA_SIG
- *  \param  sig  pointer to ECDSA_SIG pointer
- *  \param  r    pointer to BIGNUM for r (may be NULL)
- *  \param  s    pointer to BIGNUM for s (may be NULL)
+ *  \param  sig  pointer to ECDSA_SIG structure
  */
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -216,6 +216,14 @@ void RSA_get0_crt_params(const RSA *r,
                          const BIGNUM **iqmp);
 int RSA_get0_multi_prime_crt_params(const RSA *r, const BIGNUM *exps[],
                                     const BIGNUM *coeffs[]);
+const BIGNUM *RSA_get0_n(const RSA *d);
+const BIGNUM *RSA_get0_e(const RSA *d);
+const BIGNUM *RSA_get0_d(const RSA *d);
+const BIGNUM *RSA_get0_p(const RSA *d);
+const BIGNUM *RSA_get0_q(const RSA *d);
+const BIGNUM *RSA_get0_dmp1(const RSA *r);
+const BIGNUM *RSA_get0_dmq1(const RSA *r);
+const BIGNUM *RSA_get0_iqmp(const RSA *r);
 void RSA_clear_flags(RSA *r, int flags);
 int RSA_test_flags(const RSA *r, int flags);
 void RSA_set_flags(RSA *r, int flags);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4546,3 +4546,5 @@ RSA_get0_e                              4487	1_1_1	EXIST::FUNCTION:RSA
 RSA_get0_q                              4488	1_1_1	EXIST::FUNCTION:RSA
 RSA_get0_p                              4489	1_1_1	EXIST::FUNCTION:RSA
 RSA_get0_iqmp                           4490	1_1_1	EXIST::FUNCTION:RSA
+ECDSA_SIG_get0_r                        4491	1_1_1	EXIST::FUNCTION:EC
+ECDSA_SIG_get0_s                        4492	1_1_1	EXIST::FUNCTION:EC

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4538,3 +4538,11 @@ DSA_get0_pub_key                        4479	1_1_1	EXIST::FUNCTION:DSA
 DSA_get0_q                              4480	1_1_1	EXIST::FUNCTION:DSA
 DSA_get0_p                              4481	1_1_1	EXIST::FUNCTION:DSA
 DSA_get0_g                              4482	1_1_1	EXIST::FUNCTION:DSA
+RSA_get0_dmp1                           4483	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_d                              4484	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_n                              4485	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_dmq1                           4486	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_e                              4487	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_q                              4488	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_p                              4489	1_1_1	EXIST::FUNCTION:RSA
+RSA_get0_iqmp                           4490	1_1_1	EXIST::FUNCTION:RSA

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4528,8 +4528,8 @@ conf_ssl_name_find                      4469	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get_cmd                        4470	1_1_0i	EXIST::FUNCTION:
 conf_ssl_get                            4471	1_1_0i	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_hostflags         4472	1_1_0i	EXIST::FUNCTION:
-DH_get0_p                               4473	1_1_0i	EXIST::FUNCTION:DH
-DH_get0_q                               4474	1_1_0i	EXIST::FUNCTION:DH
-DH_get0_g                               4475	1_1_0i	EXIST::FUNCTION:DH
-DH_get0_priv_key                        4476	1_1_0i	EXIST::FUNCTION:DH
-DH_get0_pub_key                         4477	1_1_0i	EXIST::FUNCTION:DH
+DH_get0_p                               4473	1_1_1	EXIST::FUNCTION:DH
+DH_get0_q                               4474	1_1_1	EXIST::FUNCTION:DH
+DH_get0_g                               4475	1_1_1	EXIST::FUNCTION:DH
+DH_get0_priv_key                        4476	1_1_1	EXIST::FUNCTION:DH
+DH_get0_pub_key                         4477	1_1_1	EXIST::FUNCTION:DH

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4533,3 +4533,8 @@ DH_get0_q                               4474	1_1_1	EXIST::FUNCTION:DH
 DH_get0_g                               4475	1_1_1	EXIST::FUNCTION:DH
 DH_get0_priv_key                        4476	1_1_1	EXIST::FUNCTION:DH
 DH_get0_pub_key                         4477	1_1_1	EXIST::FUNCTION:DH
+DSA_get0_priv_key                       4478	1_1_1	EXIST::FUNCTION:DSA
+DSA_get0_pub_key                        4479	1_1_1	EXIST::FUNCTION:DSA
+DSA_get0_q                              4480	1_1_1	EXIST::FUNCTION:DSA
+DSA_get0_p                              4481	1_1_1	EXIST::FUNCTION:DSA
+DSA_get0_g                              4482	1_1_1	EXIST::FUNCTION:DSA


### PR DESCRIPTION
This continues #6273 which added simple accessors for DH, amending the accessors

```
void DH_get0_pqg(const DH *dh,
                 const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);

void DH_get0_key(const DH *dh,
                 const BIGNUM **pub_key, const BIGNUM **priv_key);
```

For DSA, we add simple accessors amending

```
void DSA_get0_pqg(const DSA *d,
                  const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);

void DSA_get0_key(const DSA *d,
                  const BIGNUM **pub_key, const BIGNUM **priv_key);
```

and for RSA:

```
void RSA_get0_key(const RSA *r,
                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);

void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);

```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
