### PR TITLE
Fix no-sm2 with clang

### DIFF
--- a/crypto/ec/ec_pmeth.c
+++ b/crypto/ec/ec_pmeth.c
@@ -124,7 +124,7 @@ static int pkey_ec_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
 
     if (ec_nid == NID_sm2) {
 #if defined(OPENSSL_NO_SM2)
-        ret = -1;
+        return -1;
 #else
         ret = SM2_sign(type, tbs, tbslen, sig, &sltmp, ec);
 #endif


### PR DESCRIPTION
Return immediately upon discovery of bad message digest.

clang-3.6 issues the following error when `no-sm2` is configured:

```
crypto/ec/ec_pmeth.c:137:23: error: variable 'sltmp' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
    *siglen = (size_t)sltmp;
                      ^~~~~
crypto/ec/ec_pmeth.c:107:23: note: initialize the variable 'sltmp' to silence this warning
    unsigned int sltmp;
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
