### PR TITLE
Windows: don't install __DECC_*.H

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -412,7 +412,8 @@ install_dev:
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\ms\applink.c" \
 				       "$(INSTALLTOP)\include\openssl"
 	@rem {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } @{$config{defines}}; "" -}
-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\include\openssl\*.h" \
+	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "-exclude_re=/__DECC_" \
+				       "$(SRCDIR)\include\openssl\*.h" \
 				       "$(INSTALLTOP)\include\openssl"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(BLDDIR)\include\openssl\*.h \
 				       "$(INSTALLTOP)\include\openssl"

--- a/util/copy.pl
+++ b/util/copy.pl
@@ -18,6 +18,7 @@ use Fcntl;
 my $stripcr = 0;
 
 my $arg;
+my @excludes = ();
 
 foreach $arg (@ARGV) {
 	if ($arg eq "-stripcr")
@@ -25,11 +26,16 @@ foreach $arg (@ARGV) {
 		$stripcr = 1;
 		next;
 		}
+	if ($arg =~ /^-exclude_re=(.*)$/)
+		{
+		push @excludes, $1;
+		next;
+		}
 	$arg =~ s|\\|/|g;	# compensate for bug/feature in cygwin glob...
 	$arg = qq("$arg") if ($arg =~ /\s/);	# compensate for bug in 5.10...
-	foreach (glob $arg)
+	foreach my $f (glob $arg)
 		{
-		push @filelist, $_;
+		push @filelist, $f unless grep { $f =~ /$_/ } @excludes;
 		}
 }
 


### PR DESCRIPTION
This adds the possibility to exclude files by regexp in util/copy.pl

Partial fix for #3254
