### PR TITLE
Quiet pod2html warnings

### DIFF
--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -98,7 +98,7 @@ foreach my $section (sort @{$options{section}}) {
         my $suffix = { man  => ".$podinfo{section}".($options{suffix} // ""),
                        html => ".html" } -> {$options{type}};
         my $generate = { man  => "pod2man --name=$name --section=$podinfo{section} --center=OpenSSL --release=$config{version} \"$podpath\"",
-                         html => "pod2html \"--podroot=$options{sourcedir}\" --htmldir=$updir --podpath=man1:man3:man5:man7 \"--infile=$podpath\" \"--title=$podname\""
+                         html => "pod2html \"--podroot=$options{sourcedir}\" --htmldir=$updir --podpath=man1:man3:man5:man7 \"--infile=$podpath\" \"--title=$podname\" --quiet"
                          } -> {$options{type}};
         my $output_dir = catdir($options{destdir}, "man$podinfo{section}");
         my $output_file = $podname . $suffix;


### PR DESCRIPTION
--quiet stops warnings of this sort:

    Cannot find "BIO_read_ex" in podpath: cannot find suitable replacement path, cannot resolve link

We know what causes these warnings, it's perfectly innocuous, and we
don't want to hear it any more.

Partial fix for #3254
