### PR TITLE
Add optional lib_suffix

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -44,6 +44,8 @@ my %targets=(
 	shared_rcflag	=> "",
 	shared_extension	=> "",
 
+	lib_suffix => "",
+
 	#### Defaults for the benefit of the config targets who don't inherit
 	#### a BASE and assume Unixly defaults
 	#### THESE WILL DISAPPEAR IN OpenSSL 1.2

--- a/Configurations/50-windows-suffixes.conf
+++ b/Configurations/50-windows-suffixes.conf
@@ -1,0 +1,23 @@
+## -*- mode: perl; -*-
+## Extra openssl configuration targets for windows.
+
+my %targets = (
+    "VC-WIN64A-shared-release" => {
+	    inherit_from => [ "VC-WIN64A" ],
+	    lib_suffix => "MD"
+    },
+    "VC-WIN64A-shared-debug" => {
+	    inherit_from => [ "VC-WIN64A" ],
+	    build_type => "debug",
+	    lib_suffix => "MDd"
+    },
+    "VC-WIN64A-static-release" => {
+	    inherit_from => [ "VC-WIN64A" ],
+	    lib_suffix => "MT"
+    },
+    "VC-WIN64A-static-debug" => {
+	    inherit_from => [ "VC-WIN64A" ],
+	    build_type => "debug",
+	    lib_suffix => "MTd"
+    },
+);

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -3,14 +3,16 @@
 ##
 ## {- join("\n## ", @autowarntext) -}
 {-
+
+ our $lib_suffix = $target{lib_suffix} || "";
  our $objext = $target{obj_extension} || ".obj";
  our $resext = $target{res_extension} || ".res";
  our $depext = $target{dep_extension} || ".d";
  our $exeext = $target{exe_extension} || ".exe";
- our $libext = $target{lib_extension} || ".lib";
- our $shlibext = $target{shared_extension} || ".dll";
- our $shlibextimport = $target{shared_import_extension} || ".lib";
- our $dsoext = $target{dso_extension} || ".dll";
+ our $libext = $lib_suffix . ($target{lib_extension} || ".lib");
+ our $shlibext = $lib_suffix . ($target{shared_extension} || ".dll");
+ our $shlibextimport = $lib_suffix . ($target{shared_import_extension} || ".lib");
+ our $dsoext = $lib_suffix . ($target{dso_extension} || ".dll");
 
  (our $sover_dirname = $config{shlib_version_number}) =~ s|\.|_|g;
 
@@ -76,11 +78,11 @@ SHLIB_VERSION_NUMBER={- $config{shlib_version_number} -}
 
 LIBS={- join(" ", map { lib($_) } @{$unified_info{libraries}}) -}
 SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{libraries}}) -}
-SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; shlib($_) } @{$unified_info{libraries}}) -}
+SHLIBPDBS={- join(" ", map { local $shlibext = $lib_suffix.".pdb"; shlib($_) } @{$unified_info{libraries}}) -}
 ENGINES={- join(" ", map { dso($_) } @{$unified_info{engines}}) -}
-ENGINEPDBS={- join(" ", map { local $dsoext = ".pdb"; dso($_) } @{$unified_info{engines}}) -}
+ENGINEPDBS={- join(" ", map { local $dsoext = $lib_suffix.".pdb"; dso($_) } @{$unified_info{engines}}) -}
 PROGRAMS={- our @PROGRAMS = map { $_.$exeext } @{$unified_info{programs}}; join(" ", @PROGRAMS) -}
-PROGRAMPDBS={- join(" ", map { $_.".pdb" } @{$unified_info{programs}}) -}
+PROGRAMPDBS={- join(" ", map { $_.$lib_suffix.".pdb" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(" ", @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}
 DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
@@ -94,9 +96,9 @@ GENERATED={- # common0.tmpl provides @generated
 
 INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; shlib($_) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = $lib_suffix.".pdb"; shlib($_) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_ENGINES={- join(" ", map { dso($_) } @{$unified_info{install}->{engines}}) -}
-INSTALL_ENGINEPDBS={- join(" ", map { local $dsoext = ".pdb"; dso($_) } @{$unified_info{install}->{engines}}) -}
+INSTALL_ENGINEPDBS={- join(" ", map { local $dsoext = $lib_suffix.".pdb"; dso($_) } @{$unified_info{install}->{engines}}) -}
 INSTALL_PROGRAMS={- join(" ", map { $_.$exeext } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
 INSTALL_PROGRAMPDBS={- join(" ", map { $_.".pdb" } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
 {- output_off() if $disabled{apps}; "" -}
@@ -354,7 +356,7 @@ uninstall: uninstall_docs uninstall_sw
 
 libclean:
 	"$(PERL)" -e "map { m/(.*)\.dll$$/; unlink glob """{.,apps,test,fuzz}/$$1.*"""; } @ARGV" $(SHLIBS)
-	-del /Q /F $(LIBS) libcrypto.* libssl.* ossl_static.pdb
+	-del /Q /F $(LIBS) libcrypto*.* libssl*.* ossl_static*.pdb
 
 clean: libclean
 	{- join("\n\t", map { "-del /Q /F $_" } @PROGRAMS) -}


### PR DESCRIPTION
**What:**

This patch should allow for easier building of openssl windows libraries like they can be found on:
https://www.npcglib.org/~stathis/blog/precompiled-openssl/

**Why:**

We have currently the situation that we want to use a recent windows lib that is build with Visual Studio 2017. But there are only precompiled libraries that are not up to date or not compiled with Visual Studio 2017. First
I tried to apply the patches provided by _stathis_ (in the link above) to a more recent version but failed. So I came up with this patch that seems to solve our problem but most probably still needs a lot of reviewing and work to get it in the official repository.

I think it is important that people are able to build and use a recent openssl versions on windows that works together with tools like CMake. Of course I could have changed https://github.com/Kitware/CMake/blob/master/Modules/FindOpenSSL.cmake and introduced more places openssl is searched for. I did decide against it because the situation on windows concerning library locations is bad enough.

Please let me know what needs to be changed. Please note that I am a total perl newbie:)