### PR TITLE
Fix a possible crash in BN_from_montgomery_word [1.1.0]

### DIFF
--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -95,6 +95,8 @@ static int BN_from_montgomery_word(BIGNUM *ret, BIGNUM *r, BN_MONT_CTX *mont)
 
     /* clear the top words of T */
     i = max - r->top;
+    if (i < 0)
+        return 0;
     if (i)
         memset(&rp[r->top], 0, sizeof(*rp) * i);
 


### PR DESCRIPTION
Thanks to Darovskikh Andrei for for reporting this issue.

Fixes: #5785
Fixes: #6302

Cherry-picked from f91e026e3832 (without test/bntest.c)
