### PR TITLE
Configure: Check that enabling ec_nistp_64_gcc_128 is possible

### DIFF
--- a/Configure
+++ b/Configure
@@ -1451,13 +1451,6 @@ if (!$disabled{asm}) {
     }
 }
 
-if (!$disabled{ec_nistp_64_gcc_128} && !$predefined{__SIZEOF_INT128__}) {
-    die <<"_____";
-Your compiler doesn't pre-define __SIZEOF_INT128__.  Enabling
-ec_nistp_64_gcc_128 is therefore not permitted.
-_____
-}
-
 # Deal with bn_ops ###################################################
 
 $config{bn_ll}			=0;

--- a/Configure
+++ b/Configure
@@ -1451,6 +1451,13 @@ if (!$disabled{asm}) {
     }
 }
 
+if (!$disabled{ec_nistp_64_gcc_128} && !$predefined{__SIZEOF_INT128__}) {
+    die <<"_____";
+Your compiler doesn't pre-define __SIZEOF_INT128__.  Enabling
+ec_nistp_64_gcc_128 is therefore not permitted.
+_____
+}
+
 # Deal with bn_ops ###################################################
 
 $config{bn_ll}			=0;

--- a/INSTALL
+++ b/INSTALL
@@ -337,11 +337,12 @@
   enable-ec_nistp_64_gcc_128
                    Enable support for optimised implementations of some commonly
                    used NIST elliptic curves.
-                   This is only supported with compilers that:
-                   - support the non-standard type __uint128_t
-                   - define the built-in macro __SIZEOF_INT128__
-                   - support little-endian integers
-                   - tolerate misaligned memory references
+                   This is only supported on platforms:
+                   - with little-endian storage of non-byte types
+                   - that tolerate misaligned memory references
+                   - where the compiler:
+                     - supports the non-standard type __uint128_t
+                     - defines the built-in macro __SIZEOF_INT128__
 
   enable-egd
                    Build support for gathering entropy from EGD (Entropy

--- a/INSTALL
+++ b/INSTALL
@@ -336,8 +336,9 @@
 
   enable-ec_nistp_64_gcc_128
                    Enable support for optimised implementations of some commonly
-                   used NIST elliptic curves. This is only supported on some
-                   platforms.
+                   used NIST elliptic curves.
+                   This is only supported on little endian platforms that
+                   tolerate misaligned memory references.
 
   enable-egd
                    Build support for gathering entropy from EGD (Entropy

--- a/INSTALL
+++ b/INSTALL
@@ -337,8 +337,11 @@
   enable-ec_nistp_64_gcc_128
                    Enable support for optimised implementations of some commonly
                    used NIST elliptic curves.
-                   This is only supported on little endian platforms that
-                   tolerate misaligned memory references.
+                   This is only supported with compilers that:
+                   - support the non-standard type __uint128_t
+                   - define the built-in macro __SIZEOF_INT128__
+                   - support little-endian integers
+                   - tolerate misaligned memory references
 
   enable-egd
                    Build support for gathering entropy from EGD (Entropy

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -45,7 +45,7 @@ NON_EMPTY_TRANSLATION_UNIT
 typedef __uint128_t uint128_t;  /* nonstandard; implemented by gcc on 64-bit
                                  * platforms */
 # else
-#  error "Need GCC 4.0 or later to define type uint128_t"
+#  error "Your compiler doesn't appear to support 128-bit integer types"
 # endif
 
 typedef uint8_t u8;

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -47,7 +47,7 @@ typedef __uint128_t uint128_t;  /* nonstandard; implemented by gcc on 64-bit
                                  * platforms */
 typedef __int128_t int128_t;
 # else
-#  error "Need GCC 4.0 or later to define type uint128_t"
+#  error "Your compiler doesn't appear to support 128-bit integer types"
 # endif
 
 typedef uint8_t u8;

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -45,7 +45,7 @@ NON_EMPTY_TRANSLATION_UNIT
 typedef __uint128_t uint128_t;  /* nonstandard; implemented by gcc on 64-bit
                                  * platforms */
 # else
-#  error "Need GCC 4.0 or later to define type uint128_t"
+#  error "Your compiler doesn't appear to support 128-bit integer types"
 # endif
 
 typedef uint8_t u8;


### PR DESCRIPTION
To check if 128-bit integers are possible, we look for the predefined
macro `__SIZEOF_INT128__`, the same macro that's used as guard in the
relevant code.

Also, change the error message in the code.

Fixes #6327 
