### PR TITLE
Save and restore the Windows error around TlsGetValue.

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -98,7 +98,26 @@ int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 
 void *CRYPTO_THREAD_get_local(CRYPTO_THREAD_LOCAL *key)
 {
-    return TlsGetValue(*key);
+    DWORD last_error;
+    void *ret;
+
+    /*
+     * TlsGetValue clears the last error even on success, so that callers may
+     * distinguish it successfully returning NULL or failing. It is documented
+     * to never fail if the argument is a valid index from TlsAlloc, so we do
+     * not need to handle this.
+     *
+     * However, this error-mangling behavior interferes with the caller's use of
+     * GetLastError. In particular SSL_get_error queries the error queue to
+     * determine whether the caller should look at the OS's errors. To avoid
+     * destroying state, save and restore the Windows error.
+     *
+     * https://msdn.microsoft.com/en-us/library/windows/desktop/ms686812(v=vs.85).aspx
+     */
+    last_error = GetLastError();
+    ret = TlsGetValue(*key);
+    SetLastError(last_error);
+    return ret;
 }
 
 int CRYPTO_THREAD_set_local(CRYPTO_THREAD_LOCAL *key, void *val)

--- a/test/build.info
+++ b/test/build.info
@@ -18,7 +18,7 @@ IF[{- !$disabled{tests} -}]
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
-          ocspapitest fatalerrtest x509_time_test
+          ocspapitest fatalerrtest x509_time_test errtest
 
   SOURCE[versions]=versions.c
   INCLUDE[versions]=../include
@@ -306,6 +306,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[shlibloadtest]=shlibloadtest.c
     INCLUDE[shlibloadtest]=../include
   ENDIF
+
+  SOURCE[errtest]=errtest.c testutil.c
+  INCLUDE[errtest]=../include
+  DEPEND[errtest]=../libcrypto
 ENDIF
 
 {-

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/opensslconf.h>
+#include <openssl/err.h>
+
+#include "testutil.h"
+
+#if defined(OPENSSL_SYS_WINDOWS)
+# include <windows.h>
+#else
+# include <errno.h>
+#endif
+
+/* Test that querying the error queue preserves the OS error. */
+static int preserves_system_error(void)
+{
+#if defined(OPENSSL_SYS_WINDOWS)
+    SetLastError(ERROR_INVALID_FUNCTION);
+    ERR_get_error();
+    return GetLastError() == ERROR_INVALID_FUNCTION;
+#else
+    errno = EINVAL;
+    ERR_get_error();
+    return errno == EINVAL;
+#endif
+}
+
+int main(int argc, char **argv)
+{
+    ADD_TEST(preserves_system_error);
+
+    return run_tests(argv[0]);
+}

--- a/test/recipes/04-test_err.t
+++ b/test/recipes/04-test_err.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_err", "errtest");


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openssl/openssl/pull/6316 to master, with the test rewritten for the older conventions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
