### PR TITLE
Fix non-modular header error on Apple platforms

### DIFF
--- a/apps/opt.c
+++ b/apps/opt.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <openssl/bio.h>
 #include <openssl/x509v3.h>

--- a/crypto/aria/aria.c
+++ b/crypto/aria/aria.c
@@ -22,6 +22,7 @@
 #include "internal/aria.h"
 
 #include <assert.h>
+#include <inttypes.h>
 #include <string.h>
 
 #ifndef OPENSSL_SMALL_FOOTPRINT

--- a/crypto/include/internal/sm4.h
+++ b/crypto/include/internal/sm4.h
@@ -13,6 +13,7 @@
 
 # include <openssl/opensslconf.h>
 # include <openssl/e_os2.h>
+# include <inttypes.h>
 
 # ifdef OPENSSL_NO_SM4
 #  error SM4 is disabled.

--- a/crypto/sha/keccak1600.c
+++ b/crypto/sha/keccak1600.c
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/e_os2.h>
+#include <inttypes.h>
 #include <string.h>
 #include <assert.h>
 

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -238,7 +238,9 @@ typedef UINT64 uint64_t;
 # elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
      defined(__osf__) || defined(__sgi) || defined(__hpux) || \
      defined(OPENSSL_SYS_VMS) || defined (__OpenBSD__)
-#  include <inttypes.h>
+#  if !defined(__APPLE__)
+#   include <inttypes.h>
+#  endif
 # elif defined(_MSC_VER) && _MSC_VER<=1500
 /*
  * minimally required typdefs for systems not supporting inttypes.h or


### PR DESCRIPTION
When trying to build a module for openssl, Xcode complains about this include line. Simply removing the include seems to work fine.