### PR TITLE
ECDSA_SIG: restore doc comments which were deleted accidentally

### DIFF
--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1078,6 +1078,8 @@ const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
 
 /** Setter for r and s fields of ECDSA_SIG
  *  \param  sig  pointer to ECDSA_SIG structure
+ *  \param  r    pointer to BIGNUM for r (may be NULL)
+ *  \param  s    pointer to BIGNUM for s (may be NULL)
  */
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 


### PR DESCRIPTION
amends 0396401d1c3f


(These two lines were deleted accidentally in #6290. Sorry for the inconvenience.)