### PR TITLE
Only store negotiated (not offered) SNI hostname in SSL_SESSION

### DIFF
--- a/doc/man3/SSL_in_init.pod
+++ b/doc/man3/SSL_in_init.pod
@@ -14,9 +14,9 @@ SSL_get_state
 
  #include <openssl/ssl.h>
 
- int SSL_in_init(SSL *s);
- int SSL_in_before(SSL *s);
- int SSL_is_init_finished(SSL *s);
+ int SSL_in_init(const SSL *s);
+ int SSL_in_before(const SSL *s);
+ int SSL_is_init_finished(const SSL *s);
 
  int SSL_in_connect_init(SSL *s);
  int SSL_in_accept_init(SSL *s);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1049,9 +1049,9 @@ typedef enum {
 /* Is the SSL_connection established? */
 # define SSL_in_connect_init(a)          (SSL_in_init(a) && !SSL_is_server(a))
 # define SSL_in_accept_init(a)           (SSL_in_init(a) && SSL_is_server(a))
-int SSL_in_init(SSL *s);
-int SSL_in_before(SSL *s);
-int SSL_is_init_finished(SSL *s);
+int SSL_in_init(const SSL *s);
+int SSL_in_before(const SSL *s);
+int SSL_is_init_finished(const SSL *s);
 
 /*
  * The following 3 states are kept in ssl->rlayer.rstate when reads fail, you

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3466,25 +3466,15 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         break;
 #endif                          /* !OPENSSL_NO_EC */
     case SSL_CTRL_SET_TLSEXT_HOSTNAME:
-#if 0
         /*
-         * TODO(OpenSSL1.2) s->server is initially set based on the absence
-         * of an accept method, and can be a false positive when a generic
-         * SSL_METHOD is used.  We rely on the ability to set a (client)
-         * SNI hostname before forcing 'client' status, as tested in
-         * test_servername.c:client_setup_sni_before_state(), so this
-         * block of code cannot be enabled until ABI-breaking changes
-         * are permitted by release policy.
+         * TODO(OpenSSL1.2)
+         * This API is only used for a client to set what SNI it will request
+         * from the server, but we currently allow it to be used on servers
+         * as well, which is a programming error.  Currently we just clear
+         * the field in SSL_do_handshake() for server SSLs, but when we can
+         * make ABI-breaking changes, we may want to make use of this API
+         * an error on server SSLs.
          */
-        /*
-         * This is the API to set what SNI a client requests; it makes no
-         * sense for a server.
-         */
-        if (s->server) {
-            SSLerr(SSL_F_SSL3_CTRL, SSL_R_SSL3_EXT_INVALID_SERVERNAME);
-            return 0;
-        }
-#endif
         if (larg == TLSEXT_NAMETYPE_host_name) {
             size_t len;
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3466,6 +3466,25 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         break;
 #endif                          /* !OPENSSL_NO_EC */
     case SSL_CTRL_SET_TLSEXT_HOSTNAME:
+#if 0
+        /*
+         * TODO(OpenSSL1.2) s->server is initially set based on the absence
+         * of an accept method, and can be a false positive when a generic
+         * SSL_METHOD is used.  We rely on the ability to set a (client)
+         * SNI hostname before forcing 'client' status, as tested in
+         * test_servername.c:client_setup_sni_before_state(), so this
+         * block of code cannot be enabled until ABI-breaking changes
+         * are permitted by release policy.
+         */
+        /*
+         * This is the API to set what SNI a client requests; it makes no
+         * sense for a server.
+         */
+        if (s->server) {
+            SSLerr(SSL_F_SSL3_CTRL, SSL_R_SSL3_EXT_INVALID_SERVERNAME);
+            return 0;
+        }
+#endif
         if (larg == TLSEXT_NAMETYPE_host_name) {
             size_t len;
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2608,7 +2608,15 @@ const char *SSL_get_servername(const SSL *s, const int type)
     if (type != TLSEXT_NAMETYPE_host_name)
         return NULL;
 
-    return s->session && !s->ext.hostname ?
+    /*
+     * TODO(OpenSSL1.2) clean up this compat mess.  This API is
+     * currently a mix of "what did I configure" and "what did the
+     * peer send" and "what was actually negotiated"; we should have
+     * a clear distinction amongst those three.
+     */
+    if (SSL_in_init(s))
+        return s->ext.hostname;
+    return (s->session != NULL && s->ext.hostname != NULL) ?
         s->session->ext.hostname : s->ext.hostname;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2616,7 +2616,7 @@ const char *SSL_get_servername(const SSL *s, const int type)
      */
     if (SSL_in_init(s))
         return s->ext.hostname;
-    return (s->session != NULL && s->ext.hostname != NULL) ?
+    return (s->session != NULL && s->ext.hostname == NULL) ?
         s->session->ext.hostname : s->ext.hostname;
 }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -430,15 +430,6 @@ int ssl_get_new_session(SSL *s, int session)
             return 0;
         }
 
-        if (s->ext.hostname) {
-            ss->ext.hostname = OPENSSL_strdup(s->ext.hostname);
-            if (ss->ext.hostname == NULL) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_GET_NEW_SESSION,
-                         ERR_R_INTERNAL_ERROR);
-                SSL_SESSION_free(ss);
-                return 0;
-            }
-        }
     } else {
         ss->session_id_length = 0;
     }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -929,9 +929,27 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
         ret = s->session_ctx->ext.servername_cb(s, &altmp,
                                        s->session_ctx->ext.servername_arg);
 
-    if (!sent) {
-        OPENSSL_free(s->session->ext.hostname);
-        s->session->ext.hostname = NULL;
+    /*
+     * For servers, propagate the SNI hostname from the temporary
+     * storage in the SSL to the persistent SSL_SESSION, now that we
+     * know we accepted it.
+     * Clients make this copy when parsing the server's response to
+     * the extension, which is when they find out that the negotiation
+     * was successful.
+     */
+    if (s->server) {
+        if (!sent) {
+            OPENSSL_free(s->ext.hostname);
+            s->ext.hostname = NULL;
+        } else if (!s->hit || SSL_IS_TLS13(s)) {
+            /* Only store the hostname in the session if we accepted it. */
+            OPENSSL_free(s->session->ext.hostname);
+            s->session->ext.hostname = OPENSSL_strdup(s->ext.hostname);
+            if (s->session->ext.hostname == NULL && s->ext.hostname != NULL) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_FINAL_SERVER_NAME,
+                         ERR_R_INTERNAL_ERROR);
+            }
+        }
     }
 
     /*

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -939,9 +939,10 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
      */
     if (s->server) {
         if (!sent) {
+            /* Nothing from the client this handshake; cleanup stale value */
             OPENSSL_free(s->ext.hostname);
             s->ext.hostname = NULL;
-        } else if (!s->hit || SSL_IS_TLS13(s)) {
+        } else if (ret == SSL_TLSEXT_ERR_OK && (!s->hit || SSL_IS_TLS13(s))) {
             /* Only store the hostname in the session if we accepted it. */
             OPENSSL_free(s->session->ext.hostname);
             s->session->ext.hostname = OPENSSL_strdup(s->ext.hostname);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -142,8 +142,10 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
             return 0;
         }
 
-        /* Store the requested SNI in the SSL as temporary storage.
-         * If we accept it, it will get stored in the SSL_SESSION as well. */
+        /*
+         * Store the requested SNI in the SSL as temporary storage.
+         * If we accept it, it will get stored in the SSL_SESSION as well.
+         */
         OPENSSL_free(s->ext.hostname);
         s->ext.hostname = NULL;
         if (!PACKET_strndup(&hostname, &s->ext.hostname)) {

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -127,7 +127,7 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
         return 0;
     }
 
-    if (!s->hit) {
+    if (!s->hit || SSL_IS_TLS13(s)) {
         if (PACKET_remaining(&hostname) > TLSEXT_MAXLEN_host_name) {
             SSLfatal(s, SSL_AD_UNRECOGNIZED_NAME,
                      SSL_F_TLS_PARSE_CTOS_SERVER_NAME,
@@ -153,7 +153,8 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
         }
 
         s->servername_done = 1;
-    } else {
+    }
+    if (s->hit) {
         /*
          * TODO(openssl-team): if the SNI doesn't match, we MUST
          * fall back to a full handshake.

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -142,9 +142,11 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
             return 0;
         }
 
-        OPENSSL_free(s->session->ext.hostname);
-        s->session->ext.hostname = NULL;
-        if (!PACKET_strndup(&hostname, &s->session->ext.hostname)) {
+        /* Store the requested SNI in the SSL as temporary storage.
+         * If we accept it, it will get stored in the SSL_SESSION as well. */
+        OPENSSL_free(s->ext.hostname);
+        s->ext.hostname = NULL;
+        if (!PACKET_strndup(&hostname, &s->ext.hostname)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_SERVER_NAME,
                      ERR_R_INTERNAL_ERROR);
             return 0;
@@ -156,7 +158,7 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
          * TODO(openssl-team): if the SNI doesn't match, we MUST
          * fall back to a full handshake.
          */
-        s->servername_done = s->session->ext.hostname
+        s->servername_done = (s->session->ext.hostname != NULL)
             && PACKET_equal(&hostname, s->session->ext.hostname,
                             strlen(s->session->ext.hostname));
 
@@ -1286,7 +1288,7 @@ EXT_RETURN tls_construct_stoc_server_name(SSL *s, WPACKET *pkt,
                                           size_t chainidx)
 {
     if (s->hit || s->servername_done != 1
-            || s->session->ext.hostname == NULL)
+            || s->ext.hostname == NULL)
         return EXT_RETURN_NOT_SENT;
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_server_name)

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -68,17 +68,17 @@ OSSL_HANDSHAKE_STATE SSL_get_state(const SSL *ssl)
     return ssl->statem.hand_state;
 }
 
-int SSL_in_init(SSL *s)
+int SSL_in_init(const SSL *s)
 {
     return s->statem.in_init;
 }
 
-int SSL_is_init_finished(SSL *s)
+int SSL_is_init_finished(const SSL *s)
 {
     return !(s->statem.in_init) && (s->statem.hand_state == TLS_ST_OK);
 }
 
-int SSL_in_before(SSL *s)
+int SSL_in_before(const SSL *s)
 {
     /*
      * Historically being "in before" meant before anything had happened. In the


### PR DESCRIPTION
Fix a thread-safety issue from #4519 by only writing to the SSL_SESSION during non-resumption handshakes and only when SNI is negotiated.

const-ify a few interfaces that can trivially do so (in order to use one of them), and also leave a comment noting work that can only be done at an API-breaking release boundary.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
