### PR TITLE
apps: when the 'compat' nameopt has been set, leave it be

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1050,7 +1050,8 @@ int set_name_ex(unsigned long *flags, const char *arg)
     };
     if (set_multi_opts(flags, arg, ex_tbl) == 0)
         return 0;
-    if ((*flags & XN_FLAG_SEP_MASK) == 0)
+    if (*flags != XN_FLAG_COMPAT
+        && (*flags & XN_FLAG_SEP_MASK) == 0)
         *flags |= XN_FLAG_SEP_CPLUS_SPC;
     return 1;
 }


### PR DESCRIPTION
XN_FLAG_COMPAT has a unique property, its zero for value.  This means
it needs special treatment; if it has been set (which can only be
determined indirectly) and set alone (*), no other flags should be
set.

(*) if any other nameopt flag has been set by the user, compatibility
mode is blown away.
