### PR TITLE
ENGINE_pkey_asn1_find_str(): don't assume an engine implements ASN1 method

### DIFF
--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -215,7 +215,7 @@ static void look_str_cb(int nid, STACK_OF(ENGINE) *sk, ENGINE *def, void *arg)
         ENGINE *e = sk_ENGINE_value(sk, i);
         EVP_PKEY_ASN1_METHOD *ameth;
         e->pkey_asn1_meths(e, &ameth, NULL, nid);
-        if (((int)strlen(ameth->pem_str) == lk->len) &&
+        if (ameth != NULL && ((int)strlen(ameth->pem_str) == lk->len) &&
             !strncasecmp(ameth->pem_str, lk->str, lk->len)) {
             lk->e = e;
             lk->ameth = ameth;


### PR DESCRIPTION
Just because an engine implements algorithm methods, that doesn't mean
it also implements the ASN1 method.  Therefore, be careful when looking
for an ASN1 method among all engines, don't try to use one that doesn't
exist.

Fixes #6381
