### PR TITLE
openssl pkcs12: convert pass phrase to UTF-8 when exporting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,12 @@
  release branch.
 
  Changes between 1.1.0h and 1.1.1 [xx XXX xxxx]
+
+  *) Enforce UTF-8 encoding of the pass phrase when exporting to PKCS#12
+     objects using 'openssl pkcs12', to ensure that we generate standard
+     compliant objects at all times.
+     [Richard Levitte]
+
   *) Enforce checking in the pkeyutl command line app to ensure that the input
      length does not exceed the maximum supported digest length when performing
      a sign, verify or verifyrecover operation.

--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,8 @@
 
   *) Enforce UTF-8 encoding of the pass phrase when exporting to PKCS#12
      objects using 'openssl pkcs12', to ensure that we generate standard
-     compliant objects at all times.
+     compliant objects at all times.  This can be bypassed with the option
+     '-nointerop' (for "not interoperable").
      [Richard Levitte]
 
   *) Enforce checking in the pkeyutl command line app to ensure that the input

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1529,6 +1529,7 @@ my %targets = (
                                    release => "-O3"),
         cppflags         => threads("-D_REENTRANT"),
         lflags           => "-Wl,-search_paths_first",
+        bin_ex_libs      => "-liconv",
         sys_id           => "MACOSX",
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -252,7 +252,11 @@ LIB_LDFLAGS={- join('', $target{lib_lflags} || (),
                         @{$config{lib_lflags}},
                         @{$config{shared_ldflag}},
                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-LIB_EX_LIBS=$(CNF_EX_LIBS)$(EX_LIBS)
+LIB_EX_LIBS={- join('', (map { ",$_" } $target{lib_ex_libs} || (),
+                                       $target{shared_ex_libs} || (),
+                                       @{$config{lib_ex_libs}},
+                                       @{$config{shared_ex_libs}}))
+            -} $(CNF_EX_LIBS)$(EX_LIBS)
 DSO_ASFLAGS={- join(' ', $target{dso_asflags} || (),
                          $target{module_asflags} || (),
                          @{$config{dso_asflags}},
@@ -284,7 +288,11 @@ DSO_LDFLAGS={- join('', $target{dso_lflags} || (),
                         @{$config{dso_lflags}},
                         @{$config{module_ldflags}},
                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+DSO_EX_LIBS={- join('', (map { ",$_" } $target{dso_ex_libs} || (),
+                                       $target{module_ex_libs} || (),
+                                       @{$config{dso_ex_libs}},
+                                       @{$config{module_ex_libs}}))
+            -} $(CNF_EX_LIBS)$(EX_LIBS)
 BIN_ASFLAGS={- join(' ', $target{bin_asflags} || (),
                          @{$config{bin_asflags}},
                          '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
@@ -304,7 +312,9 @@ BIN_CFLAGS={- join('', $target{bin_cflag} || (),
 BIN_LDFLAGS={- join('', $target{bin_lflags} || (),
                         @{$config{bin_lflags}} || (),
                         '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+BIN_EX_LIBS={- join('', (map { ",$_" } $target{bin_ex_libs} || (),
+                                       @{$config{bin_ex_libs}},
+            -} $(CNF_EX_LIBS)$(EX_LIBS)
 NO_INST_LIB_CFLAGS={- join('', $target{no_inst_lib_cflags}
                                // $target{lib_cflags}
                                // (),

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -277,7 +277,11 @@ LIB_CXXFLAGS={- join(' ', $target{lib_cxxflags} || (),
 LIB_LDFLAGS={- join(' ', $target{shared_ldflag} || (),
                          $config{shared_ldflag} || (),
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-LIB_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+LIB_EX_LIBS={- join(' ', $target{lib_ex_libs} || (),
+                         $target{shared_ex_libs} || (),
+                         @{$config{lib_ex_libs}},
+                         @{$config{shared_ex_libs}},
+                         '$(CNF_EX_LIBS)', '$(EX_LIBS)') -}
 DSO_CPPFLAGS={- join(' ', $target{dso_cppflags} || (),
                           $target{module_cppflags} || (),
                           @{$config{dso_cppflags}},
@@ -298,7 +302,11 @@ DSO_LDFLAGS={- join(' ', $target{dso_ldflags} || (),
                          @{$config{dso_ldflags}},
                          @{$config{module_ldflags}},
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+DSO_EX_LIBS={- join(' ', $target{dso_ex_libs} || (),
+                         $target{module_ex_libs} || (),
+                         @{$config{dso_ex_libs}},
+                         @{$config{module_ex_libs}},
+                         '$(CNF_EX_LIBS)', '$(EX_LIBS)') -}
 BIN_CPPFLAGS={- join(' ', $target{bin_cppflags} || (),
                           @{$config{bin_cppflags}},
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
@@ -311,7 +319,9 @@ BIN_CXXFLAGS={- join(' ', $target{bin_cxxflags} || (),
 BIN_LDFLAGS={- join(' ', $target{bin_lflags} || (),
                          @{$config{bin_lflags}},
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+BIN_EX_LIBS={- join(' ', $target{bin_ex_libs} || (),
+                         @{$config{bin_ex_libs}},
+                         '$(CNF_EX_LIBS)', '$(EX_LIBS)') -}
 
 # CPPFLAGS_Q is used for one thing only: to build up buildinf.h
 CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -255,7 +255,11 @@ LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
 LIB_LDFLAGS={- join(' ', $target{shared_ldflag} || (),
                          $config{shared_ldflag} || (),
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-LIB_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+LIB_EX_LIBS={- join(' ', $target{lib_ex_libs} || (),
+                         $target{shared_ex_libs} || (),
+                         @{$config{lib_ex_libs}},
+                         @{$config{shared_ex_libs}},
+                         '$(CNF_EX_LIBS)', '$(EX_LIBS)') -}
 DSO_ASFLAGS={- join(' ', $target{dso_asflags} || (),
                          $target{module_asflags} || (),
                          @{$config{dso_asflags}},
@@ -276,7 +280,11 @@ DSO_LDFLAGS={- join(' ', $target{dso_lflags} || (),
                          @{$config{dso_lflags}},
                          @{$config{module_ldflags}},
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+DSO_EX_LIBS={- join(' ', $target{dso_ex_libs} || (),
+                         $target{module_ex_libs} || (),
+                         @{$config{dso_ex_libs}},
+                         @{$config{module_ex_libs}},
+                         '$(CNF_EX_LIBS)', '$(EX_LIBS)') -}
 BIN_ASFLAGS={- join(' ', $target{bin_asflags} || (),
                          @{$config{bin_asflags}},
                          '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
@@ -289,7 +297,9 @@ BIN_CFLAGS={- join(' ', $target{bin_cflags} || (),
 BIN_LDFLAGS={- join(' ', $target{bin_lflags} || (),
                          @{$config{bin_lflags}},
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+BIN_EX_LIBS={- join(' ', $target{bin_ex_libs} || (),
+                         @{$config{bin_ex_libs}},
+                         '$(CNF_EX_LIBS)', '$(EX_LIBS)') -}
 
 # CPPFLAGS_Q is used for one thing only: to build up buildinf.h
 CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;

--- a/apps/app_utf8.c
+++ b/apps/app_utf8.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include "apps.h"
+#include <openssl/asn1.h>        /* For UTF8_putc */
+
+/* Fallback to iconv */
+# define IMPLEMENT_ICONV
+
+/* Decide on more specific implementations */
+#ifdef _WIN32
+/* Windows has its own stuff */
+# undef IMPLEMENT_ICONV
+# define IMPLEMENT_WIN32
+#endif
+
+/* The check of GNU libc is a bit more complex */
+/* Note that __GLIBC__ gets defined on the fly via string.h */
+#ifdef __GLIBC__
+# if __GLIBC__ >= 2
+#  undef IMPLEMENT_ICONV
+#  define IMPLEMENT_MBSTOWCS
+# endif
+#endif
+
+#if defined(OPENSSL_TEST_ICONV) || defined(OPENSSL_TEST_NOCONV)
+# undef IMPLEMENT_WIN32
+# undef IMPLEMENT_MBSTOWCS
+# undef IMPLEMENT_ICONV
+#endif
+#ifdef OPENSSL_TEST_ICONV
+# define IMPLEMENT_ICONV
+#endif
+
+#if !defined(OPENSSL_TEST_NOCONV) && defined(OPENSSL_DEBUG_KEYGEN)
+static void display_str(const char *txt, const char *str)
+{
+    if (txt != NULL)
+        fprintf(stderr, "%s", txt);
+    if (str != NULL) {
+        size_t len = strlen(str);
+        for (; len--; str++)
+            fprintf(stderr, "%02X", *(const unsigned char *)str);
+        fprintf(stderr, "\n");
+    }
+}
+#else
+# define display_str(txt, s) do {} while(0)
+#endif
+
+#if defined(IMPLEMENT_WIN32) || defined(IMPLEMENT_MBSTOWCS)
+/* This can be used if we know that wchar_t contains UCS-x */
+/*
+ * We use our own rather than iconv for two reasons:
+ * 1. We're not sure iconv is available "everywhere"
+ * 2. We assume that any normalization is done by
+ *    mbstowcs() and that a naïve conversion to UTF8
+ *    is therefore harmless.
+ */
+static char *wchar_t2utf8(const wchar_t *wstr, size_t wstr_size)
+{
+    char *str_utf8 = NULL;
+    size_t utf8_count, i, j;
+
+    utf8_count = 0;
+    for (i = 0; i < wstr_size; i++)
+        utf8_count += UTF8_putc(NULL, 0, wstr[i]);
+
+    if ((str_utf8 = OPENSSL_malloc(utf8_count + 1)) != NULL) {
+        for (i = 0, j = 0; i < wstr_size; i++)
+            j += UTF8_putc((unsigned char *)&str_utf8[j], utf8_count - j,
+                           wstr[i]);
+    }
+
+    return str_utf8;
+}
+#endif
+
+#if defined(IMPLEMENT_WIN32)
+
+#include <windows.h>
+
+char *to_utf8(const char *str)
+{
+    char *str_utf8 = NULL;
+    wchar_t *wstr = NULL;
+    size_t wstr_size;
+
+    display_str("Input chars [WIN32]: ", str);
+
+    if (GetEnvironmentVariableW(L"OPENSSL_WIN32_UTF8", NULL, 0) != 0) {
+        display_str("is already UTF-8\n", NULL);
+        return OPENSSL_strdup(str);
+    }
+
+    if ((wstr_size = MultiByteToWideChar(CP_ACP,
+                                         MB_ERR_INVALID_CHARS | MB_PRECOMPOSED,
+                                         str, -1, NULL, 0)) == 0
+        || (wstr = OPENSSL_malloc(wstr_size * sizeof(*wstr))) == NULL)
+        return NULL;
+    MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS | MB_PRECOMPOSED,
+                        str, -1, wstr, wstr_size);
+
+    /* We know that wstr is UCS-2, we can use this */
+    str_utf8 = wchar_t2utf8(wstr, wstr_size);
+    OPENSSL_free(wstr);
+
+    display_str("Output chars [WIN32]: ", str_utf8);
+    return str_utf8;
+}
+
+#elif defined(IMPLEMENT_MBSTOWCS)
+
+#include <stdlib.h>
+#include <wchar.h>
+
+char *to_utf8(const char *str)
+{
+    char *str_utf8 = NULL;
+    wchar_t *wstr = NULL;
+    size_t wstr_size;
+
+    display_str("Input chars[mbstowcs]: ", str);
+
+    if ((wstr_size = mbstowcs(NULL, str, 0)) == (size_t)-1
+        || (wstr = OPENSSL_malloc(++wstr_size * sizeof(*wstr))) == NULL)
+        return NULL;
+    mbstowcs(wstr, str, wstr_size);
+
+    /* We know that wstr is UCS-2, we can use this */
+    str_utf8 = wchar_t2utf8(wstr, wstr_size);
+    OPENSSL_free(wstr);
+
+    display_str("Output chars[mbstowcs]: ", str_utf8);
+    return str_utf8;
+}
+
+#elif defined(IMPLEMENT_ICONV)
+
+/* Fall back to iconv */
+
+#include <langinfo.h>
+#include <iconv.h>
+
+char *to_utf8(const char *str)
+{
+    const char *from = nl_langinfo(CODESET);
+    iconv_t cd;
+    char *inptr = (char *)str;
+    size_t insize = strlen(str) + 1; /* Include NUL byte */
+    size_t inbytesleft = insize;
+    char *outbuf = NULL;
+    char *outptr = NULL;
+    size_t outsize = 0;
+    size_t outbytesleft = 0;
+    size_t iconv_res = 0;
+
+    display_str("Input chars[iconv]: ", str);
+
+    if ((cd = iconv_open("UTF-8", from)) == (iconv_t)-1)
+        return NULL;
+
+    while(1) {
+        char *newbuf = NULL;
+
+        if ((newbuf = OPENSSL_realloc(outbuf, outsize + 1024)) == NULL) {
+            errno = E2BIG;
+            iconv_res = (size_t)-1;
+            break;
+        }
+        outbuf = newbuf;
+        outsize += 1024;
+        outbytesleft += 1024;
+        outptr = outbuf + outsize - outbytesleft;
+
+        if ((iconv_res = iconv(cd, &inptr, &inbytesleft,
+                               &outptr, &outbytesleft)) != (size_t)-1
+            || errno != E2BIG)
+            break;
+    }
+
+    if (iconv_res == (size_t)-1) {
+        OPENSSL_free(outbuf);
+        outbuf = NULL;
+    }
+
+    iconv_close(cd);
+
+    display_str("Output chars[iconv]: ", outbuf);
+    return outbuf;
+}
+
+#else
+
+/* Fallback that fails for everything but ASCII */
+
+char *to_utf8(const char *str)
+{
+    return NULL;
+}
+
+#endif
+
+int is_asciistr(const char *str)
+{
+    for(; *str != '\0'; str++)
+        if ((*str & 0x80) != 0)
+            return 0;
+    return 1;
+}

--- a/apps/apps.h
+++ b/apps/apps.h
@@ -631,4 +631,6 @@ typedef struct verify_options_st {
 
 extern VERIFY_CB_ARGS verify_args;
 
+char *to_utf8(const char *str);
+int is_asciistr(const char *str);
 #endif

--- a/apps/build.info
+++ b/apps/build.info
@@ -8,7 +8,7 @@
           s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c
           srp.c ts.c verify.c version.c x509.c rehash.c storeutl.c);
    our @apps_lib_src =
-       ( qw(apps.c opt.c s_cb.c s_socket.c app_rand.c bf_prefix.c),
+       ( qw(apps.c opt.c s_cb.c s_socket.c app_rand.c app_utf8.c bf_prefix.c),
          split(/\s+/, $target{apps_aux_src}) );
    our @apps_init_src = split(/\s+/, $target{apps_init_src});
    "" -}

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -8,6 +8,7 @@
  */
 
 #include <internal/cryptlib.h>
+#include <locale.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -76,6 +77,8 @@ static void calculate_columns(DISPLAY_COLUMNS *dc)
 
 static int apps_startup(void)
 {
+    setlocale(LC_ALL, "");
+
 #ifdef SIGPIPE
     signal(SIGPIPE, SIG_IGN);
 #endif

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -28,6 +28,7 @@ B<openssl> B<pkcs12>
 [B<-noiter>]
 [B<-maciter | -nomaciter | -nomac>]
 [B<-twopass>]
+[B<-nointerop>]
 [B<-descert>]
 [B<-certpbe cipher>]
 [B<-keypbe cipher>]
@@ -155,6 +156,16 @@ Don't attempt to verify the integrity MAC before reading the file.
 Prompt for separate integrity and encryption passwords: most software
 always assumes these are the same so this option will render such
 PKCS#12 files unreadable.
+
+=item B<-interop>
+
+When creating a PKCS#12 file, the B<openssl pkcs12> command will do
+what it can to ensure that pass phrases are UTF-8 encoded.  If they
+aren't, the default is to generate an error and stop without creating
+the file.  This option makes the error a warning instead, and proceeds
+with creating the file, at the risk of making it non-interoperable,
+which means it isn't safe to try and use the file with other programs
+or with other character sets.
 
 =back
 


### PR DESCRIPTION
To create standard compliant PKCS#12 objects at all times, we must
ensure that the pass phrase is UTF-8 encoded.  This relies on locale
(or the code page on Windows) being set to match the input method.
