### PR TITLE
Configurations/*.conf: ios targets face-lift.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1573,46 +1573,6 @@ my %targets = (
         perlasm_scheme   => "macosx",
     },
 
-#### iPhoneOS/iOS
-#
-# It takes three prior-set environment variables to make it work:
-#
-# CROSS_COMPILE=/where/toolchain/is/usr/bin/ [note ending slash]
-# CROSS_TOP=/where/SDKs/are
-# CROSS_SDK=iPhoneOSx.y.sdk
-#
-# Exact paths vary with Xcode releases, but for couple of last ones
-# they would look like this:
-#
-# CROSS_COMPILE=`xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/bin/
-# CROSS_TOP=`xcode-select --print-path`/Platforms/iPhoneOS.platform/Developer
-# CROSS_SDK=iPhoneOS.sdk
-#
-    "iphoneos-cross" => {
-        inherit_from     => [ "darwin-common" ],
-        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
-        sys_id           => "iOS",
-        disable          => [ "engine" ],
-    },
-    "ios-cross" => {
-        inherit_from     => [ "darwin-common", asm("armv4_asm") ],
-        # It should be possible to go below iOS 6 and even add -arch armv6,
-        # thus targeting iPhone pre-3GS, but it's assumed to be irrelevant
-        # at this point.
-        cflags           => add("-arch armv7 -mios-version-min=6.0.0 -isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
-        sys_id           => "iOS",
-        perlasm_scheme   => "ios32",
-        disable          => [ "engine" ],
-    },
-    "ios64-cross" => {
-        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
-        cflags           => add("-arch arm64 -mios-version-min=7.0.0 -isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
-        sys_id           => "iOS",
-        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
-        perlasm_scheme   => "ios64",
-        disable          => [ "engine" ],
-    },
-
 ##### GNU Hurd
     "hurd-x86" => {
         inherit_from     => [ "BASE_unix" ],

--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -26,6 +26,12 @@ my %targets = (
         perlasm_scheme   => "ios64",
         disable          => [ "engine" ],
     },
+    "iossimulator-xcrun" => {
+        inherit_from     => [ "darwin-common" ],
+        CC               => "xcrun -sdk iphonesimulator cc",
+        sys_id           => "iOS",
+        disable          => [ "engine" ],
+    },
 # It takes three prior-set environment variables to make it work:
 #
 # CROSS_COMPILE=/where/toolchain/is/usr/bin/ [note ending slash]

--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -1,0 +1,58 @@
+#### iPhoneOS/iOS
+#
+# It takes recent enough XCode to use following two targets. It shouldn't
+# be a problem by now, but if they don't work, original targets below
+# that depend on manual definition of environment variables should still
+# work...
+#
+my %targets = (
+    "ios-xcrun" => {
+        inherit_from     => [ "darwin-common", asm("armv4_asm") ],
+        # It should be possible to go below iOS 6 and even add -arch armv6,
+        # thus targeting iPhone pre-3GS, but it's assumed to be irrelevant
+        # at this point.
+        CC               => "xcrun -sdk iphoneos cc",
+        cflags           => add("-arch armv7 -mios-version-min=6.0.0 -fno-common"),
+        sys_id           => "iOS",
+        perlasm_scheme   => "ios32",
+        disable          => [ "engine" ],
+    },
+    "ios64-xcrun" => {
+        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
+        CC               => "xcrun -sdk iphoneos cc",
+        cflags           => add("-arch arm64 -mios-version-min=7.0.0 -fno-common"),
+        sys_id           => "iOS",
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        perlasm_scheme   => "ios64",
+        disable          => [ "engine" ],
+    },
+# It takes three prior-set environment variables to make it work:
+#
+# CROSS_COMPILE=/where/toolchain/is/usr/bin/ [note ending slash]
+# CROSS_TOP=/where/SDKs/are
+# CROSS_SDK=iPhoneOSx.y.sdk
+#
+# Exact paths vary with Xcode releases, but for couple of last ones
+# they would look like this:
+#
+# CROSS_COMPILE=`xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/bin/
+# CROSS_TOP=`xcode-select --print-path`/Platforms/iPhoneOS.platform/Developer
+# CROSS_SDK=iPhoneOS.sdk
+#
+    "iphoneos-cross" => {
+        inherit_from     => [ "darwin-common" ],
+        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
+        sys_id           => "iOS",
+        disable          => [ "engine" ],
+    },
+    "ios-cross" => {
+        inherit_from     => [ "ios-xcrun" ],
+        CC               => "cc",
+        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK)"),
+    },
+    "ios64-cross" => {
+        inherit_from     => [ "ios64-xcrun" ],
+        CC               => "cc",
+        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK)"),
+    },
+);


### PR DESCRIPTION
Move ios targets to 15-ios.conf and modernize by deploying xcrun.
This excuses user from looking for paths and setting environment
variables. [Thanks to @0neday for hint.]
