### PR TITLE
crypto/sm2/sm2_za.c: include internal/numbers.h

### DIFF
--- a/crypto/sm2/sm2_za.c
+++ b/crypto/sm2/sm2_za.c
@@ -15,6 +15,7 @@
 #include <openssl/evp.h>
 #include <openssl/bn.h>
 #include <string.h>
+#include "internal/numbers.h"
 
 int sm2_compute_userid_digest(uint8_t *out,
                               const EVP_MD *digest,


### PR DESCRIPTION
Needed for the platforms that don't define UINT16_MAX.
