### PR TITLE
RAND_POOL: Add missing implementations for djgpp

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -71,7 +71,7 @@ static uint64_t get_timer_bits(void);
 #   define OSSL_POSIX_TIMER_OKAY
 #  endif
 # endif
-#endif
+#endif /* defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__) */
 
 int syscall_random(void *buf, size_t buflen);
 
@@ -503,4 +503,4 @@ static uint64_t get_timer_bits(void)
 # endif
     return time(NULL);
 }
-#endif /* OPENSSL_SYS_UNIX || __DJGPP__ */
+#endif /* defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__) */

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -27,7 +27,8 @@
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 # include <sys/param.h>
 #endif
-#ifdef OPENSSL_SYS_UNIX
+
+#if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
 # include <sys/types.h>
 # include <unistd.h>
 # include <sys/time.h>
@@ -382,7 +383,7 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
 # endif
 #endif
 
-#ifdef OPENSSL_SYS_UNIX
+#if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
 int rand_pool_add_nonce_data(RAND_POOL *pool)
 {
     struct {
@@ -502,4 +503,4 @@ static uint64_t get_timer_bits(void)
 # endif
     return time(NULL);
 }
-#endif
+#endif /* OPENSSL_SYS_UNIX || __DJGPP__ */


### PR DESCRIPTION
Calling the functions rand_pool_add_{additional,nonce}_data()
in crypto/rand/rand_lib.c with no implementation for djgpp/MSDOS
causees unresolved symbols when linking with djgpp.

Reported and fixed by Gisle Vanem (see [his patch](https://github.com/openssl/openssl/commit/5bc6bcf82d2adce982e04837b0810b1a6cd55a19#commitcomment-29252192)).