### PR TITLE
optionally suppress verbose output of passed tests by VERBOSE=2

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -11,7 +11,7 @@ use warnings;
 
 # Recognise VERBOSE and V which is common on other projects.
 BEGIN {
-    $ENV{HARNESS_VERBOSE} = "yes" if $ENV{VERBOSE} || $ENV{V};
+    $ENV{HARNESS_VERBOSE} = $ENV{V} ? $ENV{V} : $ENV{VERBOSE}
 }
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
@@ -31,7 +31,7 @@ my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 $ENV{OPENSSL_CONF} = catdir($srctop, "apps", "openssl.cnf");
 
 my %tapargs =
-    ( verbosity => $ENV{VERBOSE} || $ENV{V} || $ENV{HARNESS_VERBOSE} ? 1 : 0,
+    ( verbosity => $ENV{HARNESS_VERBOSE},
       lib       => [ $libdir ],
       switches  => '-w',
       merge     => 1

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -11,7 +11,7 @@ use warnings;
 
 # Recognise VERBOSE and V which is common on other projects.
 BEGIN {
-    $ENV{HARNESS_VERBOSE} = $ENV{V} ? $ENV{V} : $ENV{VERBOSE}
+    $ENV{HARNESS_VERBOSE} = $ENV{V} // $ENV{VERBOSE};
 }
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -312,13 +312,13 @@ sub cmd {
     my $cmd = shift;
     my %opts = @_;
     return sub {
-        my $num = shift;
+        my %internal_opts = @_;
         # Make a copy to not destroy the caller's array
         my @cmdargs = ( @$cmd );
         my @prog = __wrap_cmd(shift @cmdargs, $opts{exe_shell} // ());
 
-        return __decorate_cmd($num, [ @prog, quotify(@cmdargs) ],
-                              %opts);
+        return __decorate_cmd([ @prog, quotify(@cmdargs) ],
+                              %internal_opts, %opts);
     }
 }
 
@@ -329,7 +329,7 @@ sub app {
         my @cmdargs = ( @{$cmd} );
         my @prog = __fixup_prg(__apps_file(shift @cmdargs, __exeext()));
         return cmd([ @prog, @cmdargs ],
-                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (@_);
     }
 }
 
@@ -340,7 +340,7 @@ sub fuzz {
         my @cmdargs = ( @{$cmd} );
         my @prog = __fixup_prg(__fuzz_file(shift @cmdargs, __exeext()));
         return cmd([ @prog, @cmdargs ],
-                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (@_);
     }
 }
 
@@ -351,7 +351,7 @@ sub test {
         my @cmdargs = ( @{$cmd} );
         my @prog = __fixup_prg(__test_file(shift @cmdargs, __exeext()));
         return cmd([ @prog, @cmdargs ],
-                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (@_);
     }
 }
 
@@ -365,7 +365,7 @@ sub perlapp {
         my @cmdargs = ( @{$cmd} );
         my @prog = __apps_file(shift @cmdargs, undef);
         return cmd([ @interpreter, @interpreter_args,
-                     @prog, @cmdargs ], %opts) -> (shift);
+                     @prog, @cmdargs ], %opts) -> (@_);
     }
 }
 
@@ -379,7 +379,7 @@ sub perltest {
         my @cmdargs = ( @{$cmd} );
         my @prog = __test_file(shift @cmdargs, undef);
         return cmd([ @interpreter, @interpreter_args,
-                     @prog, @cmdargs ], %opts) -> (shift);
+                     @prog, @cmdargs ], %opts) -> (@_);
     }
 }
 
@@ -428,7 +428,7 @@ the function C<with> further down.
 =cut
 
 sub run {
-    my ($cmd, $display_cmd) = shift->(0);
+    my ($cmd, $display_cmd) = shift->();
     my %opts = @_;
 
     return () if !$cmd;
@@ -670,7 +670,7 @@ sub pipe {
 	    my @els = ();
 	    my $counter = 0;
 	    foreach (@cmds) {
-		my ($c, $dc, @el) = $_->(++$counter);
+		my ($c, $dc, @el) = $_->();
 
 		return () if !$c;
 
@@ -759,7 +759,7 @@ Default: 0
 =cut
 
 sub cmdstr {
-    my ($cmd, $display_cmd) = shift->(0);
+    my ($cmd, $display_cmd) = shift->();
     my %opts = @_;
 
     if ($opts{display}) {
@@ -1172,7 +1172,6 @@ sub __fixup_prg {
 sub __decorate_cmd {
     BAIL_OUT("Must run setup() first") if (! $test_name);
 
-    my $num = shift;
     my $cmd = shift;
     my %opts = @_;
 


### PR DESCRIPTION
In particular when adding new test cases it typically happens that some of them fail while others pass.
When setting the environment variable `VERBOSE=1` (or `V=1`) for debugging, the output of all tests is shown.
It can be quite annoying and a waste of time to manually skip over (irrelevant) output of passed tests when one just wants to find out which test cases failed for what reason.
This PR adds a new verbosity level `2` that shows verbose output only for those tests that failed.
The implementation is done essentially in `util/perl/OpenSSL/Test.pm` by buffering `STDOUT` and `STDERR`.

This new option required a generalization of the verbosity levels passed by `test/runtests.pl`: so far it has supported only levels `0` and `1`. Now it passes any value given as the level to `Test.pm`. 
Note that according to https://metacpan.org/pod/release/LEONT/Test-Harness-3.42/lib/TAP/Harness.pm the underlying `TAP::Harness` already supports some more levels:
```
 1   verbose        Print individual test results to STDOUT. 
 0   normal
-1   quiet          Suppress some test output (mostly failures while tests are running).
-2   really quiet   Suppress everything but the tests summary.
-3   silent         Suppress everything.
```
