### PR TITLE
rand/rand_unix.c: omit error from DSO_global_lookup.

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -247,7 +247,9 @@ int syscall_random(void *buf, size_t buflen)
      * - Linux since 3.17 with glibc 2.25
      * - FreeBSD since 12.0 (1200061)
      */
+    ERR_set_mark();
     p_getentropy.p = DSO_global_lookup("getentropy");
+    ERR_pop_to_mark();
     if (p_getentropy.p != NULL)
         return p_getentropy.f(buf, buflen) == 0 ? buflen : 0;
 


### PR DESCRIPTION
There are two commits, first one is the one I'm "nominating"(*) and second one is kind of "what would you think of that". It means that one can as well approve first commit and reject second one.

(*) If built with no-dso DSO_global_lookup leaves "unsupported" message in error queue. Since there is a fall-back code, it's unnecessary distraction.
