### PR TITLE
Configurations/shared-info.pl: reinstate soname on Solaris.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -211,8 +211,11 @@ my %targets = (
         ex_libs          => add("-lsocket -lnsl -ldl"),
         dso_scheme       => "dlfcn",
         thread_scheme    => "pthreads",
-        shared_target    => "solaris-shared",
+        shared_target    => "self",
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
+        shared_ldflag    => "-Wl,-Bsymbolic",
+        shared_defflag   => "-Wl,-M,",
+        shared_sonameflag=> "-Wl,-h,",
     },
 #### Solaris x86 with GNU C setups
     "solaris-x86-gcc" => {
@@ -229,7 +232,7 @@ my %targets = (
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG",
         shared_cflag     => "-fPIC",
-        shared_ldflag    => "-shared -static-libgcc",
+        shared_ldflag    => add("-shared -static-libgcc"),
     },
     "solaris64-x86_64-gcc" => {
         # -shared -static-libgcc might appear controversial, but modules
@@ -251,7 +254,7 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "elf",
         shared_cflag     => "-fPIC",
-        shared_ldflag    => "-shared -static-libgcc",
+        shared_ldflag    => add("-shared -static-libgcc"),
         multilib         => "/64",
     },
 
@@ -282,7 +285,7 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "elf",
         shared_cflag     => "-KPIC",
-        shared_ldflag    => "-G -dy -z text",
+        shared_ldflag    => add("-G -dy -z text"),
         multilib         => "/64",
     },
 
@@ -298,7 +301,7 @@ my %targets = (
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         shared_cflag     => "-fPIC",
-        shared_ldflag    => "-shared",
+        shared_ldflag    => add("-shared"),
     },
     "solaris-sparcv8-gcc" => {
         inherit_from     => [ "solaris-sparcv7-gcc", asm("sparcv8_asm") ],
@@ -333,7 +336,7 @@ my %targets = (
         ex_libs          => add(threads("-lpthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         shared_cflag     => "-KPIC",
-        shared_ldflag    => "-G -dy -z text",
+        shared_ldflag    => add("-G -dy -z text"),
     },
 ####
     "solaris-sparcv8-cc" => {

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -65,11 +65,6 @@ my %shared_info;
             shared_ldflag     => '-shared -Wl,-Bsymbolic -set_version $(SHLIB_VERSION_NUMBER)',
         };
     },
-    'solaris-shared' => {
-        shared_ldflag     => '-Wl,-Bsymbolic',
-        shared_defflag    => '-Wl,-M,',
-        shared_sonameflag => '-Wl,-h,',
-    },
     'svr3-shared' => sub {
         return $shared_info{'gnu-shared'} if detect_gnu_ld();
         return {

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -68,6 +68,7 @@ my %shared_info;
     'solaris-shared' => {
         shared_ldflag     => '-Wl,-Bsymbolic',
         shared_defflag    => '-Wl,-M,',
+        shared_sonameflag => '-Wl,-h,',
     },
     'svr3-shared' => sub {
         return $shared_info{'gnu-shared'} if detect_gnu_ld();


### PR DESCRIPTION
The flag was apparently omitted in switch from Makefile.shared to
shared-info.pl. Do put it back!
