### PR TITLE
 add warning to mkerr.pl in case a new crypto sub-library is not represented in openssl.ec

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -168,6 +168,18 @@ while ( <IN> ) {
 }
 close IN;
 
+if ( $internal ) {
+    my @dirs = glob('crypto/*/');
+    my $excl = "aes aria bf blake2 buffer camellia cast chacha cmac des hmac idea include lhash md2 md4 md5 mdc2 modes objects perlasm poly1305 rc2 rc4 rc5 ripemd seed sha siphash sm3 sm4 srp stack store txt_db whrlpool";
+    foreach my $dir ( @dirs ) {
+        my $lib = $dir;
+        $lib =~ s/^(crypto|ssl)\///;
+        $lib =~ s/\/$//;
+        print STDERR "WARNING: no entry for $lib in $config\n"
+            if ( index($excl, $lib) == -1 && ! $hinc{uc $lib} );
+    }
+}
+
 if ( ! $statefile ) {
     $statefile = $config;
     $statefile =~ s/.ec/.txt/;


### PR DESCRIPTION
When adding a sub-library , among others the file `crypto/err/openssl.ec` needs to be extended as described in `crypto/err/README`. 
It may happen that this is forgotten or the new entry gets lost. Then `util/mkerr.pl` will simply not add the error declarations for the new sub-library, which later will lead to compilation failures. Such an omission so far is hard to debug - for instance, I spent more than an hour trying to find out why the new error symbols were not generated any more (after an inadvertent reset of  `crypto/err/openssl.ec`). 
For this reason I propose to add a warning like the one contained in this PR.
