### PR TITLE
Reject excessively large primes in DH key generation.

### DIFF
--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -78,9 +78,14 @@ static int generate_key(DH *dh)
     int ok = 0;
     int generate_new_key = 0;
     unsigned l;
-    BN_CTX *ctx;
+    BN_CTX *ctx = NULL;
     BN_MONT_CTX *mont = NULL;
     BIGNUM *pub_key = NULL, *priv_key = NULL;
+
+    if (BN_num_bits(dh->p) > OPENSSL_DH_MAX_MODULUS_BITS) {
+        DHerr(DH_F_GENERATE_KEY, DH_R_MODULUS_TOO_LARGE);
+        goto err;
+    }
 
     ctx = BN_CTX_new();
     if (ctx == NULL)


### PR DESCRIPTION
CVE-2018-0732

Signed-off-by: Guido Vranken <guidovranken@gmail.com>
