### PR TITLE
Add RSA key digests

### DIFF
--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -119,3 +119,16 @@ RSA *RSAPrivateKey_dup(RSA *rsa)
 {
     return ASN1_item_dup(ASN1_ITEM_rptr(RSAPrivateKey), rsa);
 }
+
+int RSA_public_digest(RSA *rsa, const EVP_MD *mdtype, unsigned char *md,
+                      unsigned int *mdlen)
+{
+    return ASN1_item_digest(ASN1_ITEM_rptr(RSAPublicKey), mdtype, rsa, md, mdlen);
+}
+
+int RSA_private_digest(RSA *rsa, const EVP_MD *mdtype, unsigned char *md,
+                       unsigned int *mdlen)
+{
+    return ASN1_item_digest(ASN1_ITEM_rptr(RSAPrivateKey), mdtype, rsa, md,
+                            mdlen);
+}

--- a/doc/man3/RSA_public_digest.pod
+++ b/doc/man3/RSA_public_digest.pod
@@ -1,0 +1,41 @@
+=pod
+
+=head1 NAME
+
+RSA_public_digest, RSA_private_digest - get RSA digests for the public or private keys
+
+=head1 SYNOPSIS
+
+ #include <openssl/rsa.h>
+
+ int RSA_public_digest(RSA *rsa, const EVP_MD *mdtype, unsigned char *md,
+                       unsigned int *mdlen);
+ int RSA_private_digest(RSA *rsa, const EVP_MD *mdtype, unsigned char *md,
+                        unsigned int *mdlen);
+
+=head1 DESCRIPTION
+
+RSA_public_digest() computes a digest of the ASN.1 encoded
+B<RSAPublicKey> as specified by B<mdtype> and deposits the value into B<md>,
+setting B<mdlen> to the size of the digest.
+The buffer must be at least large enough to receive B<mdlen> octets.
+
+RSA_private_digest() computes a digest of the ASN.1 encoded
+B<RSAPrivateKey> as specified by B<mdtype> and desposits
+the value into B<md>, setting B<mdlen> to the size of the digest.
+
+=head1 RETURN VALUES
+
+RSA_public_digest() and RSA_private_digest() return 1 on success,
+or zero on failure.
+
+=head1 COPYRIGHT
+
+Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -263,6 +263,11 @@ void RSA_free(RSA *r);
 /* "up" the RSA object's reference count */
 int RSA_up_ref(RSA *r);
 
+int RSA_public_digest(RSA *rsa, const EVP_MD *mdtype,
+                      unsigned char *md, unsigned int *mdlen);
+int RSA_private_digest(RSA *rsa, const EVP_MD *mdtype,
+                       unsigned char *md, unsigned int *mdlen);
+
 int RSA_flags(const RSA *r);
 
 void RSA_set_default_method(const RSA_METHOD *meth);

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -18,6 +18,7 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/bn.h>
+#include <openssl/evp.h>
 
 #include "testutil.h"
 
@@ -43,9 +44,13 @@ int setup_tests(void)
                         BN_bin2bn(dmq1, sizeof(dmq1)-1, NULL),  \
                         BN_bin2bn(iqmp, sizeof(iqmp)-1, NULL)); \
     memcpy(c, ctext_ex, sizeof(ctext_ex) - 1);                  \
+    if (h != NULL && h2 != NULL) {                              \
+        memcpy(h, hash_ex, sizeof(hash_ex) - 1);                \
+        memcpy(h2, hash2_ex, sizeof(hash2_ex) - 1);             \
+    }                                                           \
     return sizeof(ctext_ex) - 1;
 
-static int key1(RSA *key, unsigned char *c)
+static int key1(RSA *key, unsigned char *c, unsigned char *h, unsigned char *h2)
 {
     static unsigned char n[] =
         "\x00\xAA\x36\xAB\xCE\x88\xAC\xFD\xFF\x55\x52\x3C\x7F\xC4\x52\x3F"
@@ -91,10 +96,16 @@ static int key1(RSA *key, unsigned char *c)
         "\x33\x89\x5c\x74\x95\x8d\x5d\x02\xab\x8c\x0f\xd0\x40\xeb\x58\x44"
         "\xb0\x05\xc3\x9e\xd8\x27\x4a\x9d\xbf\xa8\x06\x71\x40\x94\x39\xd2";
 
+    static unsigned char hash_ex[] =
+        "\x02\xdc\xea\x68\x17\x83\xba\xa7\xa6\x60\x3e\xe8\x32\x67\x21\xaf";
+
+    static unsigned char hash2_ex[] =
+        "\x7d\xd7\x3b\x73\xc3\xd2\x4d\x03\x95\x5e\xc3\xdc\x25\x2b\xf6\xc1";
+
     SetKey;
 }
 
-static int key2(RSA *key, unsigned char *c)
+static int key2(RSA *key, unsigned char *c, unsigned char *h, unsigned char *h2)
 {
     static unsigned char n[] =
         "\x00\xA3\x07\x9A\x90\xDF\x0D\xFD\x72\xAC\x09\x0C\xCC\x2A\x78\xB8"
@@ -136,10 +147,16 @@ static int key2(RSA *key, unsigned char *c)
         "\x17\x53\x03\x29\xa9\x34\x90\x74\xb1\x52\x13\x54\x29\x08\x24\x52"
         "\x62\x51";
 
+    static unsigned char hash_ex[] =
+        "\xf5\xf0\xa1\xbd\x88\x72\xbb\xab\x35\xb8\xae\x5f\x5f\x86\xd7\x07";
+
+    static unsigned char hash2_ex[] =
+        "\xd2\xfc\xc1\x1f\x0e\x26\x40\xd8\xf9\x0d\xf5\x42\x8c\x0d\x87\x75";
+
     SetKey;
 }
 
-static int key3(RSA *key, unsigned char *c)
+static int key3(RSA *key, unsigned char *c, unsigned char *h, unsigned char *h2)
 {
     static unsigned char n[] =
         "\x00\xBB\xF8\x2F\x09\x06\x82\xCE\x9C\x23\x38\xAC\x2B\x9D\xA8\x71"
@@ -208,6 +225,12 @@ static int key3(RSA *key, unsigned char *c)
         "\x74\xb2\x6f\x7c\x48\xb4\x2e\xe6\x8e\x1f\x57\x2a\x1f\xc4\x02\x6a"
         "\xc4\x56\xb4\xf5\x9f\x7b\x62\x1e\xa1\xb9\xd8\x8f\x64\x20\x2f\xb1";
 
+    static unsigned char hash_ex[] =
+        "\xa1\xc3\x79\x8c\xa8\x7a\x4c\x08\x86\x75\xf2\x72\xde\xa6\x02\xc0";
+
+    static unsigned char hash2_ex[] =
+        "\x6e\x77\x4c\x80\x0b\x0a\xec\xdd\x34\xd2\x56\x1b\x5c\x0b\xb0\x3b";
+
     SetKey;
 }
 
@@ -220,19 +243,20 @@ static int pad_unknown(void)
     return 0;
 }
 
-static int rsa_setkey(RSA** key, unsigned char* ctext, int idx)
+static int rsa_setkey(RSA** key, unsigned char* ctext, unsigned char* hash_ex,
+                      unsigned char* hash2_ex, int idx)
 {
     int clen = 0;
     *key = RSA_new();
     switch (idx) {
     case 0:
-        clen = key1(*key, ctext);
+        clen = key1(*key, ctext, hash_ex, hash2_ex);
         break;
     case 1:
-        clen = key2(*key, ctext);
+        clen = key2(*key, ctext, hash_ex, hash2_ex);
         break;
     case 2:
-        clen = key3(*key, ctext);
+        clen = key3(*key, ctext, hash_ex, hash2_ex);
         break;
     }
     return clen;
@@ -251,7 +275,7 @@ static int test_rsa_pkcs1(int idx)
     int num;
 
     plen = sizeof(ptext_ex) - 1;
-    clen = rsa_setkey(&key, ctext_ex, idx);
+    clen = rsa_setkey(&key, ctext_ex, NULL, NULL, idx);
 
     num = RSA_public_encrypt(plen, ptext_ex, ctext, key,
                              RSA_PKCS1_PADDING);
@@ -263,6 +287,7 @@ static int test_rsa_pkcs1(int idx)
         goto err;
 
     ret = 1;
+
 err:
     RSA_free(key);
     return ret;
@@ -282,7 +307,7 @@ static int test_rsa_oaep(int idx)
     int n;
 
     plen = sizeof(ptext_ex) - 1;
-    clen = rsa_setkey(&key, ctext_ex, idx);
+    clen = rsa_setkey(&key, ctext_ex, NULL, NULL, idx);
 
     num = RSA_public_encrypt(plen, ptext_ex, ctext, key,
                              RSA_PKCS1_OAEP_PADDING);
@@ -329,10 +354,40 @@ err:
     return ret;
 }
 
+static int test_rsa_keydigest(int idx)
+{
+    int ret = 0;
+    RSA *key;
+    unsigned char ctext_ex[256];
+    unsigned char hash_ex[16], hash2_ex[16];
+    unsigned char md5[16];
+    unsigned md5len;
+
+    (void) rsa_setkey(&key, ctext_ex, hash_ex, hash2_ex, idx);
+
+    if (!TEST_true(RSA_public_digest(key, EVP_md5(), md5, &md5len)))
+        goto err;
+
+    if (!TEST_mem_eq(md5, md5len, hash_ex, sizeof(hash_ex)))
+        goto err;
+
+    if (!TEST_true(RSA_private_digest(key, EVP_md5(), md5, &md5len)))
+        goto err;
+
+    if (!TEST_mem_eq(md5, md5len, hash2_ex, sizeof(hash2_ex)))
+        goto err;
+
+    ret = 1;
+err:
+    RSA_free(key);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_rsa_pkcs1, 3);
     ADD_ALL_TESTS(test_rsa_oaep, 3);
+    ADD_ALL_TESTS(test_rsa_keydigest, 3);
     return 1;
 }
 #endif

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4574,3 +4574,5 @@ EC_POINT_set_affine_coordinates         4525	1_1_1	EXIST::FUNCTION:EC
 EC_POINT_get_affine_coordinates         4526	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_set_curve                      4527	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_get_curve                      4528	1_1_1	EXIST::FUNCTION:EC
+RSA_public_digest                       4529	1_1_1	EXIST::FUNCTION:RSA
+RSA_private_digest                      4530	1_1_1	EXIST::FUNCTION:RSA


### PR DESCRIPTION
Fingerprints of keys are useful in a variety of places including summarizing ssh keys without disclosing the keys themselves, building X.509 certificates, etc.