### PR TITLE
WIP: Deprecate DSA_sign_setup() in the documentation

### DIFF
--- a/doc/man3/DSA_sign.pod
+++ b/doc/man3/DSA_sign.pod
@@ -23,13 +23,12 @@ digest B<dgst> using the private key B<dsa> and places its ASN.1 DER
 encoding at B<sigret>. The length of the signature is places in
 *B<siglen>. B<sigret> must point to DSA_size(B<dsa>) bytes of memory.
 
-DSA_sign_setup() may be used to precompute part of the signing
-operation in case signature generation is time-critical. It expects
-B<dsa> to contain DSA parameters. It places the precomputed values
-in newly allocated B<BIGNUM>s at *B<kinvp> and *B<rp>, after freeing
-the old ones unless *B<kinvp> and *B<rp> are NULL. These values may
-be passed to DSA_sign() in B<dsa-E<gt>kinv> and B<dsa-E<gt>r>.
-B<ctx> is a pre-allocated B<BN_CTX> or NULL.
+DSA_sign_setup() is defined only for backward binary compatibility and
+should not be used.
+Since OpenSSL 1.1.0 the DSA type is opaque and the output of
+DSA_sign_setup() cannot be used anyway: calling this function will only
+cause overhead, and does not affect the actual signature
+(pre-)computation.
 
 DSA_verify() verifies that the signature B<sigbuf> of size B<siglen>
 matches a given message digest B<dgst> of size B<len>.


### PR DESCRIPTION
Fixes #6447 by updating the documentation about `DSA_sign_setup()` as the current version is misleading and can be easily interpreted by users as suggesting to **reuse the DSA nonce**, which should **never** happen.

This should apply to master (1.1.1) and 1.1.0.

I'm not familiar with the original rationale for suggesting to precompute `kinv` and `r`, but I believe that even in 1.0.2 the paragraph about `DSA_sign_setup()` should be rephrased to explicitly warn users that they should not use it to precompute a single nonce and then cal several `DSA_sign()`.
To cryptographers this might seem obvious, but we should not expect the users of the library to be cryptography experts.

I marked the PR as WIP because I need feedback about ENGINE implementations of `DSA_meth`: what I wrote is true for the default OpenSSL implementation, as a user has no way to feed the precomputed `kinv` and `r` back to `DSA_sign`, but I can imagine HW ENGINEs using this function to alter the internal state and separate the *setup* phase from the *message/digest consuming* phase.

If the above is a concern, I would rewrite the documentation to distinguish between the default OpenSSL DSA implementation (for which what I wrote is true) and alternative ENGINE implementations: to write something meaningful in this case I would definitely welcome details or suggestions on how to properly phrase what to expect from non-default implementations.

Also, depending on the answer to the above concern, I would also open an issue for the next major release about completely removing `DSA_sign_setup` as a public function.

##### Checklist
- [x] documentation is added or updated

