### PR TITLE
 util/ck_errf.pl: add functionality that brings it closer to util/mkerr.pl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,8 +186,8 @@ script:
           echo -e '+\057 MAKE UPDATE OK';
       else
           echo -e '+\057 MAKE UPDATE FAILED'; false;
-      fi;
-      git diff --exit-code
+      fi
+    - git diff --exit-code
     - if [ -n "$CHECKDOCS" ]; then
           if $make doc-nits; then
               echo -e '+\057\057 MAKE DOC-NITS OK';

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -761,11 +761,12 @@ generate_fuzz_oids:
 ERROR_REBUILD=
 errors:
 	( b=`pwd`; set -e; cd $(SRCDIR); \
-	  $(PERL) util/ck_errf.pl -strict -internal; \
+          $(PERL) util/ck_errf.pl -strict -internal; \
           $(PERL) -I$$b util/mkerr.pl $(ERROR_REBUILD) -internal )
 	( b=`pwd`; set -e; cd $(SRCDIR)/engines; \
           for E in *.ec ; do \
-	      $(PERL) util/ck_errf.pl -strict -conf $$E `basename $$E .ec`.c; \
+              $(PERL) ../util/ck_errf.pl -strict \
+                -conf $$E `basename $$E .ec`.c; \
               $(PERL) -I$$b ../util/mkerr.pl $(ERROR_REBUILD) -static \
                 -conf $$E `basename $$E .ec`.c ; \
           done )

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -760,11 +760,12 @@ generate_fuzz_oids:
 # Set to -force to force a rebuild
 ERROR_REBUILD=
 errors:
-	( cd $(SRCDIR); $(PERL) util/ck_errf.pl -strict */*.c */*/*.c )
-	( b=`pwd`; cd $(SRCDIR); \
+	( b=`pwd`; set -e; cd $(SRCDIR); \
+	  $(PERL) util/ck_errf.pl -strict -internal; \
           $(PERL) -I$$b util/mkerr.pl $(ERROR_REBUILD) -internal )
-	( b=`pwd`; cd $(SRCDIR)/engines; \
+	( b=`pwd`; set -e; cd $(SRCDIR)/engines; \
           for E in *.ec ; do \
+	      $(PERL) util/ck_errf.pl -strict -conf $$E `basename $$E .ec`.c; \
               $(PERL) -I$$b ../util/mkerr.pl $(ERROR_REBUILD) -static \
                 -conf $$E `basename $$E .ec`.c ; \
           done )

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -189,7 +189,7 @@ static SRP_user_pwd *SRP_user_pwd_new(void)
     SRP_user_pwd *ret;
     
     if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL) {
-        /* SRPerr(SRP_F_SRP_USER_PWD_NEW, ERR_R_MALLOC_FAILURE); */
+        /* SRPerr(SRP_F_SRP_USER_PWD_NEW, ERR_R_MALLOC_FAILURE); */ /*ckerr_ignore*/
         return NULL;
     }
     ret->N = NULL;

--- a/util/ck_errf.pl
+++ b/util/ck_errf.pl
@@ -16,15 +16,73 @@
 use strict;
 use warnings;
 
+my $config;
 my $err_strict = 0;
-my $bad        = 0;
+my $debug      = 0;
+my $internal   = 0;
+
+sub help
+{
+    print STDERR <<"EOF";
+mkerr.pl [options] [files...]
+
+Options:
+
+    -conf FILE  Use the named config file FILE instead of the default.
+
+    -debug      Verbose output debugging on stderr.
+
+    -internal   Generate code that is to be built as part of OpenSSL itself.
+                Also scans internal list of files.
+
+    -strict     If any error was found, fail with exit code 1, otherwise 0.
+
+    -help       Show this help text.
+
+    ...         Additional arguments are added to the file list to scan,
+                if '-internal' was NOT specified on the command line.
+
+EOF
+}
+
+while ( @ARGV ) {
+    my $arg = $ARGV[0];
+    last unless $arg =~ /-.*/;
+    $arg = $1 if $arg =~ /-(-.*)/;
+    if ( $arg eq "-conf" ) {
+        $config = $ARGV[1];
+        shift @ARGV;
+    } elsif ( $arg eq "-debug" ) {
+        $debug = 1;
+    } elsif ( $arg eq "-internal" ) {
+        $internal = 1;
+    } elsif ( $arg eq "-strict" ) {
+        $err_strict = 1;
+    } elsif ( $arg =~ /-*h(elp)?/ ) {
+        &help();
+        exit;
+    } elsif ( $arg =~ /-.*/ ) {
+        die "Unknown option $arg; use -h for help.\n";
+    }
+    shift @ARGV;
+}
+
+my @source;
+if ( $internal ) {
+    die "Extra parameters given.\n" if @ARGV;
+    $config = "crypto/err/openssl.ec" unless defined $config;
+    @source = ( glob('crypto/*.c'), glob('crypto/*/*.c'),
+                glob('ssl/*.c'), glob('ssl/*/*.c') );
+} else {
+    @source = @ARGV;
+}
 
 # To detect if there is any error generation for a libcrypto/libssl libs
 # we don't know, we need to find out what libs we do know.  That list is
 # readily available in crypto/err/openssl.ec, in form of lines starting
-# with "L ".
-my $config     = "crypto/err/openssl.ec";
-my %libs       = ( "SYS" => 1 );
+# with "L ".  Note that we always rely on the modules SYS and ERR to be
+# generally available.
+my %libs       = ( SYS => 1, ERR => 1 );
 open my $cfh, $config or die "Trying to read $config: $!\n";
 while (<$cfh>) {
     s|\R$||;                    # Better chomp
@@ -33,11 +91,8 @@ while (<$cfh>) {
     $libs{$1} = 1;
 }
 
-foreach my $file (@ARGV) {
-    if ( $file eq "-strict" ) {
-        $err_strict = 1;
-        next;
-    }
+my $bad = 0;
+foreach my $file (@source) {
     open( IN, "<$file" ) || die "Can't open $file, $!";
     my $func = "";
     while (<IN>) {

--- a/util/ck_errf.pl
+++ b/util/ck_errf.pl
@@ -74,6 +74,8 @@ if ( $internal ) {
     @source = ( glob('crypto/*.c'), glob('crypto/*/*.c'),
                 glob('ssl/*.c'), glob('ssl/*/*.c') );
 } else {
+    die "Configuration file not given.\nSee '$0 -help' for information\n"
+        unless defined $config;
     @source = @ARGV;
 }
 
@@ -107,7 +109,8 @@ foreach my $file (@source) {
             my $n      = $2;
 
             unless ( $libs{$errlib} ) {
-                print "$file:$.:$errlib unknown\n";
+                print "$file:$.:$errlib not listed in $config\n";
+                $libs{$errlib} = 1; # To not display it again
                 $bad = 1;
             }
 


### PR DESCRIPTION
There was no option to give other config files than the default
crypto/err/openssl.ec, and yet it tried to check the errors generated
in engines (and failing, of course).

Also added the same '-internal' option as util/mkerr.pl.

Use these options in Configurations/unix-Makefile.tmpl