### PR TITLE
Update DSA_sign_setup() documentation to avoid nonce reuse

### DIFF
--- a/doc/crypto/DSA_do_sign.pod
+++ b/doc/crypto/DSA_do_sign.pod
@@ -20,8 +20,8 @@ digest B<dgst> using the private key B<dsa> and returns it in a
 newly allocated B<DSA_SIG> structure.
 
 L<DSA_sign_setup(3)|DSA_sign_setup(3)> may be used to precompute part
-of the signing operation in case signature generation is
-time-critical.
+of the signing operation for each signature in case signature generation
+is time-critical.
 
 DSA_do_verify() verifies that the signature B<sig> matches a given
 message digest B<dgst> of size B<len>.  B<dsa> is the signer's public

--- a/doc/crypto/DSA_sign.pod
+++ b/doc/crypto/DSA_sign.pod
@@ -31,6 +31,10 @@ in newly allocated B<BIGNUM>s at *B<kinvp> and *B<rp>, after freeing
 the old ones unless *B<kinvp> and *B<rp> are NULL. These values may
 be passed to DSA_sign() in B<dsa-E<gt>kinv> and B<dsa-E<gt>r>.
 B<ctx> is a pre-allocated B<BN_CTX> or NULL.
+The precomputed values from DSA_sign_setup() B<MUST NOT be used> for
+more than one signature: using the same B<dsa-E<gt>kinv> and
+B<dsa-E<gt>r> pair twice under the same private key on different
+plaintexts will result in permanently exposing the DSA private key.
 
 DSA_verify() verifies that the signature B<sigbuf> of size B<siglen>
 matches a given message digest B<dgst> of size B<len>.


### PR DESCRIPTION
This directly derives from #6447 and aims to warn users of OpenSSL 1.0.2 about using `DSA_sign_setup()` the wrong way, resulting in nonce reuse and private key exposure.

This is supposed to be an analogue of #6460 for the OpenSSL_1_0_2-stable branch.

##### Checklist
- [x] documentation is added or updated

