### PR TITLE
DEPRECATEDIN_1_2_0 for DSA_sign_setup

### DIFF
--- a/crypto/dsa/dsa_sign.c
+++ b/crypto/dsa/dsa_sign.c
@@ -16,7 +16,9 @@ DSA_SIG *DSA_do_sign(const unsigned char *dgst, int dlen, DSA *dsa)
     return dsa->meth->dsa_do_sign(dgst, dlen, dsa);
 }
 
+#if OPENSSL_API_COMPAT < 0x10200000L
 int DSA_sign_setup(DSA *dsa, BN_CTX *ctx_in, BIGNUM **kinvp, BIGNUM **rp)
 {
     return dsa->meth->dsa_sign_setup(dsa, ctx_in, kinvp, rp);
 }
+#endif

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -99,7 +99,7 @@ int DSA_size(const DSA *);
 int DSA_bits(const DSA *d);
 int DSA_security_bits(const DSA *d);
         /* next 4 return -1 on error */
-int DSA_sign_setup(DSA *dsa, BN_CTX *ctx_in, BIGNUM **kinvp, BIGNUM **rp);
+DEPRECATEDIN_1_2_0(int DSA_sign_setup(DSA *dsa, BN_CTX *ctx_in, BIGNUM **kinvp, BIGNUM **rp))
 int DSA_sign(int type, const unsigned char *dgst, int dlen,
              unsigned char *sig, unsigned int *siglen, DSA *dsa);
 int DSA_verify(int type, const unsigned char *dgst, int dgst_len,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -728,7 +728,7 @@ BIO_snprintf                            726	1_1_0	EXIST::FUNCTION:
 EC_POINT_hex2point                      727	1_1_0	EXIST::FUNCTION:EC
 X509v3_get_ext_by_critical              728	1_1_0	EXIST::FUNCTION:
 ENGINE_get_default_RSA                  729	1_1_0	EXIST::FUNCTION:ENGINE
-DSA_sign_setup                          730	1_1_0	EXIST::FUNCTION:DSA
+DSA_sign_setup                          730	1_1_0	EXIST::FUNCTION:DEPRECATEDIN_1_2_0,DSA
 OPENSSL_sk_new_null                     731	1_1_0	EXIST::FUNCTION:
 PEM_read_PKCS8                          732	1_1_0	EXIST::FUNCTION:STDIO
 BN_mod_sqr                              733	1_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Following up on https://github.com/openssl/openssl/pull/6460#issuecomment-396606234 , as per @levitte  suggestion, this PR uses the `DEPRECATEDIN_1_2_0` macro to mark the `DSA_sign_setup()` declaration.

@levitte is this the right way to use the macro?
Should I also run `make update` or some other util/tool?

**Note**: this concerns only the 1.1.1 branch