### PR TITLE
Configure option 'no-deprecated' means '-DOPENSSL_API_COMPAT=0x10100000L'

### DIFF
--- a/crypto/engine/eng_all.c
+++ b/crypto/engine/eng_all.c
@@ -18,7 +18,7 @@ void ENGINE_load_builtin_engines(void)
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
 }
 
-#if (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)) && !defined(OPENSSL_NO_DEPRECATED)
+#if (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)) && OPENSSL_API_COMPAT < 0x10100000L
 void ENGINE_setup_bsd_cryptodev(void)
 {
 }

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -68,9 +68,7 @@ extern "C" {
  * still won't see them if the library has been built to disable deprecated
  * functions.
  */
-#if defined(OPENSSL_NO_DEPRECATED)
-# define DECLARE_DEPRECATED(f)
-#elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
 # define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
 #else
 # define DECLARE_DEPRECATED(f)   f;


### PR DESCRIPTION
(that is, until 1.2.0 comes along)

Since we allow future deprecation (and that shouldn't be affected
by 'no-deprecated'), we need to distinguish what to have deprecated
on the value of OPENSSL_API_COMPAT, not the existence of
OPENSSL_NO_DEPRECATED.

Note that the macro OPENSSL_NO_DEPRECATED still exists, in case
someone still uses it.
