### PR TITLE
Repair broken C syntax (missing close parens) in a manual page.

### DIFF
--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -19,13 +19,13 @@ lh_TYPE_doall, lh_TYPE_doall_arg, lh_TYPE_error - dynamic hash table
  DECLARE_LHASH_OF(TYPE);
 
  LHASH *lh_TYPE_new();
- void lh_TYPE_free(LHASH_OF(TYPE *table);
+ void lh_TYPE_free(LHASH_OF(TYPE) *table);
 
- TYPE *lh_TYPE_insert(LHASH_OF(TYPE *table, TYPE *data);
- TYPE *lh_TYPE_delete(LHASH_OF(TYPE *table, TYPE *data);
- TYPE *lh_retrieve(LHASH_OFTYPE *table, TYPE *data);
+ TYPE *lh_TYPE_insert(LHASH_OF(TYPE) *table, TYPE *data);
+ TYPE *lh_TYPE_delete(LHASH_OF(TYPE) *table, TYPE *data);
+ TYPE *lh_retrieve(LHASH_OF(TYPE) *table, TYPE *data);
 
- void lh_TYPE_doall(LHASH_OF(TYPE *table, OPENSSL_LH_DOALL_FUNC func);
+ void lh_TYPE_doall(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNC func);
  void lh_TYPE_doall_arg(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNCARG func,
           TYPE, TYPE *arg);
 


### PR DESCRIPTION
- [X ] documentation is added or updated