### PR TITLE
ecdsa_ossl: address coverity nit

### DIFF
--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -360,7 +360,8 @@ ECDSA_SIG *ossl_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
         ECDSA_SIG_free(ret);
         ret = NULL;
     }
-    BN_CTX_end(ctx);
+    if (ctx != NULL)
+        BN_CTX_end(ctx);
     BN_CTX_free(ctx);
     BN_clear_free(kinv);
     return ret;


### PR DESCRIPTION
BN_CTX_end() does not handle NULL input, so we must manually check
before calling from the cleanup handler.

