### PR TITLE
ecdsa_ossl.c: fix null pointer dereference in an error path

### DIFF
--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -360,8 +360,10 @@ ECDSA_SIG *ossl_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
         ECDSA_SIG_free(ret);
         ret = NULL;
     }
-    BN_CTX_end(ctx);
-    BN_CTX_free(ctx);
+    if (ctx != NULL) {
+        BN_CTX_end(ctx);
+        BN_CTX_free(ctx);
+    }
     BN_clear_free(kinv);
     return ret;
 }


### PR DESCRIPTION
Found by Coverity ([CID 1437050](https://scan5.coverity.com/reports.htm#v36179/p10222/g36179g/fileInstanceId=143058236&defectInstanceId=40165825&mergedDefectId=1437050))

If BN_CTX_secure_new() fails, the error block is executed and BN_CTX_end(ctx)
is called with a null pointer. Howewer, BN_CTX_end() is not prepared to receive
a null pointer and dereferences it.