### PR TITLE
Don't use OPENSSL_strdup() for copying alpn_selected

### DIFF
--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -328,7 +328,8 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
 
     ret->ext.tick_lifetime_hint = (unsigned long)as->tlsext_tick_lifetime_hint;
     ret->ext.tick_age_add = as->tlsext_tick_age_add;
-    if (as->tlsext_tick) {
+    OPENSSL_free(ret->ext.tick);
+    if (as->tlsext_tick != NULL) {
         ret->ext.tick = as->tlsext_tick->data;
         ret->ext.ticklen = as->tlsext_tick->length;
         as->tlsext_tick->data = NULL;
@@ -355,11 +356,11 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
     ret->flags = (int32_t)as->flags;
     ret->ext.max_early_data = as->max_early_data;
 
+    OPENSSL_free(ret->ext.alpn_selected);
     if (as->alpn_selected != NULL) {
-        if (!ssl_session_strndup((char **)&ret->ext.alpn_selected,
-                                 as->alpn_selected))
-            goto err;
+        ret->ext.alpn_selected = as->alpn_selected->data;
         ret->ext.alpn_selected_len = as->alpn_selected->length;
+        as->alpn_selected->data = NULL;
     } else {
         ret->ext.alpn_selected = NULL;
         ret->ext.alpn_selected_len = 0;
@@ -367,6 +368,7 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
 
     ret->ext.max_fragment_len_mode = as->tlsext_max_fragment_len_mode;
 
+    OPENSSL_free(ret->ticket_appdata);
     if (as->ticket_appdata != NULL) {
         ret->ticket_appdata = as->ticket_appdata->data;
         ret->ticket_appdata_len = as->ticket_appdata->length;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -220,13 +220,11 @@ SSL_SESSION *ssl_session_dup(SSL_SESSION *src, int ticket)
         dest->ext.ticklen = 0;
     }
 
-    if (src->ext.alpn_selected) {
-        dest->ext.alpn_selected =
-            (unsigned char*)OPENSSL_strndup((char*)src->ext.alpn_selected,
-                                            src->ext.alpn_selected_len);
-        if (dest->ext.alpn_selected == NULL) {
+    if (src->ext.alpn_selected != NULL) {
+        dest->ext.alpn_selected = OPENSSL_memdup(src->ext.alpn_selected,
+                                                 src->ext.alpn_selected_len);
+        if (dest->ext.alpn_selected == NULL)
             goto err;
-        }
     }
 
 #ifndef OPENSSL_NO_SRP


### PR DESCRIPTION
An alpn_selected value containing NUL bytes in it will result in
ext.alpn_selected_len having a larger value than the number of bytes
allocated in ext.alpn_selected.

Issue found by OSS-fuzz.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
