### PR TITLE
Fix enable-ssl3 enable-ssl3-method

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1573,6 +1573,9 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_SSL3_READ_BYTES,
                      SSL_R_NO_RENEGOTIATION);
             return -1;
+        } else if (alert_level == SSL3_AL_WARNING) {
+            /* We ignore any other warning alert in TLSv1.2 and below */
+            goto start;
         }
 
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_SSL3_READ_BYTES,


### PR DESCRIPTION
Commit 4aa5a5669 accidentally missed off the catch all case of ignoring all
warning alerts that are otherwise unhandled. This breaks the SSLv3 tests
which send a "no certificate" warning alert.

Fixes #6496

