### PR TITLE
Fix & update documentation about RAND_priv_bytes()

### DIFF
--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -48,8 +48,9 @@ BN_rand() and BN_rand_range() respectively.  They are intended to be
 used for generating values that should remain private, and mirror the
 same difference between RAND_bytes() and RAND_priv_bytes().
 
-The PRNG must be seeded prior to calling BN_rand(), BN_rand_range(),
-BN_priv_rand(), or BN_priv_rand_range().
+An error occurs in the underlying B<RAND> functions if the CSPRNG has
+not been seeded with enough randomness to ensure an unpredictable byte
+sequence.
 
 =head1 RETURN VALUES
 
@@ -64,6 +65,8 @@ and
 BN_pseudo_rand_range() has been identical to BN_rand_range().
 The "pseudo" functions should not be used and may be deprecated in
 a future release.
+
+BN_priv_rand() and BN_priv_rand_range() were added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -50,7 +50,7 @@ same difference between L<RAND_bytes(3)> and L<RAND_priv_bytes(3)>.
 
 =head1 NOTES
 
-Always check the error return value of these functions and don't take
+Always check the error return value of these functions and do not take
 randomness for granted: an error occurs if the CSPRNG has not been
 seeded with enough randomness to ensure an unpredictable byte sequence.
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -74,7 +74,7 @@ L<ERR_get_error(3)>, L<RAND_add(3)>, L<RAND_bytes(3)>, L<RAND_priv_bytes(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -2,7 +2,9 @@
 
 =head1 NAME
 
-BN_rand, BN_pseudo_rand, BN_rand_range, BN_pseudo_rand_range - generate pseudo-random number
+BN_rand, BN_priv_rand, BN_pseudo_rand,
+BN_rand_range, BN_priv_rand_range, BN_pseudo_rand_range
+- generate pseudo-random number
 
 =head1 SYNOPSIS
 
@@ -10,9 +12,13 @@ BN_rand, BN_pseudo_rand, BN_rand_range, BN_pseudo_rand_range - generate pseudo-r
 
  int BN_rand(BIGNUM *rnd, int bits, int top, int bottom);
 
+ int BN_priv_rand(BIGNUM *rnd, int bits, int top, int bottom);
+
  int BN_pseudo_rand(BIGNUM *rnd, int bits, int top, int bottom);
 
  int BN_rand_range(BIGNUM *rnd, BIGNUM *range);
+
+ int BN_priv_rand_range(BIGNUM *rnd, BIGNUM *range);
 
  int BN_pseudo_rand_range(BIGNUM *rnd, BIGNUM *range);
 
@@ -37,7 +43,13 @@ If B<bits> is 1 then B<top> cannot also be B<BN_RAND_FLG_TOPTWO>.
 BN_rand_range() generates a cryptographically strong pseudo-random
 number B<rnd> in the range 0 E<lt>= B<rnd> E<lt> B<range>.
 
-The PRNG must be seeded prior to calling BN_rand() or BN_rand_range().
+BN_priv_rand() and BN_priv_rand_range() have the same semantics as
+BN_rand() and BN_rand_range() respectively.  They are intended to be
+used for generating values that should remain private, and mirror the
+same difference between RAND_bytes() and RAND_priv_bytes().
+
+The PRNG must be seeded prior to calling BN_rand(), BN_rand_range(),
+BN_priv_rand(), or BN_priv_rand_range().
 
 =head1 RETURN VALUES
 
@@ -55,7 +67,7 @@ a future release.
 
 =head1 SEE ALSO
 
-L<ERR_get_error(3)>, L<RAND_add(3)>, L<RAND_bytes(3)>
+L<ERR_get_error(3)>, L<RAND_add(3)>, L<RAND_bytes(3)>, L<RAND_priv_bytes(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -46,7 +46,7 @@ number B<rnd> in the range 0 E<lt>= B<rnd> E<lt> B<range>.
 BN_priv_rand() and BN_priv_rand_range() have the same semantics as
 BN_rand() and BN_rand_range() respectively.  They are intended to be
 used for generating values that should remain private, and mirror the
-same difference between RAND_bytes() and RAND_priv_bytes().
+same difference between L<RAND_bytes(3)> and L<RAND_priv_bytes(3)>.
 
 =head1 NOTES
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -48,9 +48,11 @@ BN_rand() and BN_rand_range() respectively.  They are intended to be
 used for generating values that should remain private, and mirror the
 same difference between RAND_bytes() and RAND_priv_bytes().
 
-An error occurs in the underlying B<RAND> functions if the CSPRNG has
-not been seeded with enough randomness to ensure an unpredictable byte
-sequence.
+=head1 NOTES
+
+Always check the error return value of these functions and don't take
+randomness for granted: an error occurs if the CSPRNG has not been
+seeded with enough randomness to ensure an unpredictable byte sequence.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -59,18 +59,30 @@ The error codes can be obtained by L<ERR_get_error(3)>.
 
 =head1 HISTORY
 
-Starting with OpenSSL release 1.1.0,
-BN_pseudo_rand() has been identical to BN_rand()
-and
-BN_pseudo_rand_range() has been identical to BN_rand_range().
+=over 2
+
+=item *
+
+Starting with OpenSSL release 1.1.0, BN_pseudo_rand() has been identical
+to BN_rand() and BN_pseudo_rand_range() has been identical to
+BN_rand_range().
 The "pseudo" functions should not be used and may be deprecated in
 a future release.
 
+=item *
+
 BN_priv_rand() and BN_priv_rand_range() were added in OpenSSL 1.1.1.
+
+=back
 
 =head1 SEE ALSO
 
-L<ERR_get_error(3)>, L<RAND_add(3)>, L<RAND_bytes(3)>, L<RAND_priv_bytes(3)>
+L<ERR_get_error(3)>,
+L<RAND_add(3)>,
+L<RAND_bytes(3)>,
+L<RAND_priv_bytes(3)>,
+L<RAND(7)>,
+L<RAND_DRBG(7)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -24,9 +24,10 @@ into B<buf>. An error occurs if the CSPRNG has not been seeded with
 enough randomness to ensure an unpredictable byte sequence.
 
 RAND_priv_bytes() has the same semantics as RAND_bytes().  It is intended to
-be used for generating long-term private keys. If using the default
-RAND_METHOD, this function uses a separate instance of the PRNG so that
-a compromise of the global generator will not affect such key generation.
+be used for generating values that should remain private. If using the
+default RAND_METHOD, this function uses a separate instance of the PRNG
+so that a compromise of the global generator will not affect the secrecy
+of such values.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -32,7 +32,7 @@ and L<RAND_DRBG(7)>.
 =head1 NOTES
 
 Always check the error return value of RAND_bytes() and
-RAND_priv_bytes() and don't take randomness for granted: an error occurs
+RAND_priv_bytes() and do not take randomness for granted: an error occurs
 if the CSPRNG has not been seeded with enough randomness to ensure an
 unpredictable byte sequence.
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -26,8 +26,8 @@ enough randomness to ensure an unpredictable byte sequence.
 RAND_priv_bytes() has the same semantics as RAND_bytes().  It is intended to
 be used for generating values that should remain private. If using the
 default RAND_METHOD, this function uses a separate instance of the PRNG
-so that a compromise of the global generator will not affect the secrecy
-of such values.
+so that a compromise of the PRNG used for public-facing values will not
+affect the secrecy of the values from the private generator.
 
 =head1 RETURN VALUES
 
@@ -39,6 +39,8 @@ obtained by L<ERR_get_error(3)>.
 =head1 HISTORY
 
 RAND_pseudo_bytes() was deprecated in OpenSSL 1.1.0; use RAND_bytes() instead.
+
+RAND_priv_bytes() was added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -25,9 +25,10 @@ enough randomness to ensure an unpredictable byte sequence.
 
 RAND_priv_bytes() has the same semantics as RAND_bytes().  It is intended to
 be used for generating values that should remain private. If using the
-default RAND_METHOD, this function uses a separate instance of the PRNG
-so that a compromise of the PRNG used for public-facing values will not
-affect the secrecy of the values from the private generator.
+default RAND_METHOD, this function uses a separate "private" PRNG
+instance so that a compromise of the "public" PRNG instance will not
+affect the secrecy of these private values, as described in L<RAND(7)>
+and L<RAND_DRBG(7)>.
 
 =head1 RETURN VALUES
 
@@ -38,16 +39,26 @@ obtained by L<ERR_get_error(3)>.
 
 =head1 HISTORY
 
+=over 2
+
+=item *
+
 RAND_pseudo_bytes() was deprecated in OpenSSL 1.1.0; use RAND_bytes() instead.
 
+=item *
+
 RAND_priv_bytes() was added in OpenSSL 1.1.1.
+
+=back
 
 =head1 SEE ALSO
 
 L<RAND_add(3)>,
 L<RAND_bytes(3)>,
+L<RAND_priv_bytes(3)>,
 L<ERR_get_error(3)>,
-L<RAND(7)>
+L<RAND(7)>,
+L<RAND_DRBG(7)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -20,8 +20,7 @@ Deprecated:
 =head1 DESCRIPTION
 
 RAND_bytes() puts B<num> cryptographically strong pseudo-random bytes
-into B<buf>. An error occurs if the CSPRNG has not been seeded with
-enough randomness to ensure an unpredictable byte sequence.
+into B<buf>.
 
 RAND_priv_bytes() has the same semantics as RAND_bytes().  It is intended to
 be used for generating values that should remain private. If using the
@@ -29,6 +28,13 @@ default RAND_METHOD, this function uses a separate "private" PRNG
 instance so that a compromise of the "public" PRNG instance will not
 affect the secrecy of these private values, as described in L<RAND(7)>
 and L<RAND_DRBG(7)>.
+
+=head1 NOTES
+
+Always check the error return value of RAND_bytes() and
+RAND_priv_bytes() and don't take randomness for granted: an error occurs
+if the CSPRNG has not been seeded with enough randomness to ensure an
+unpredictable byte sequence.
 
 =head1 RETURN VALUES
 

--- a/doc/man7/RAND.pod
+++ b/doc/man7/RAND.pod
@@ -24,16 +24,16 @@ to be initialized ('seeded') explicitly.
 It seeds and reseeds itself automatically using trusted random sources
 provided by the operating system.
 
-As a normal application developer, you don't have to worry about any details,
+As a normal application developer, you do not have to worry about any details,
 just use L<RAND_bytes(3)> to obtain random data.
 Having said that, there is one important rule to obey: Always check the error
-return value of L<RAND_bytes(3)> and don't take randomness for granted.
+return value of L<RAND_bytes(3)> and do not take randomness for granted.
 
 For values that should remain secret, you can use L<RAND_priv_bytes(3)>
 instead.
 This method does not provide 'better' randomness, it uses the same type of CSPRNG.
 The intention behind using a dedicated CSPRNG exclusively for private
-values is that none of its output should be visible to an attacker (e.g
+values is that none of its output should be visible to an attacker (e.g.,
 used as salt value), in order to reveal as little information as
 possible about its internal state, and that a compromise of the "public"
 CSPRNG instance will not affect the secrecy of these private values.

--- a/doc/man7/RAND.pod
+++ b/doc/man7/RAND.pod
@@ -29,11 +29,14 @@ just use L<RAND_bytes(3)> to obtain random data.
 Having said that, there is one important rule to obey: Always check the error
 return value of L<RAND_bytes(3)> and don't take randomness for granted.
 
-For long-term secrets, you can use L<RAND_priv_bytes(3)> instead.
+For values that should remain secret, you can use L<RAND_priv_bytes(3)>
+instead.
 This method does not provide 'better' randomness, it uses the same type of CSPRNG.
-The intention behind using a dedicated CSPRNG exclusively for long-term secrets is
-that none of its output should be visible to an attacker (e.g used as salt value),
-in order to reveal as little information as possible about its internal state.
+The intention behind using a dedicated CSPRNG exclusively for private
+values is that none of its output should be visible to an attacker (e.g
+used as salt value), in order to reveal as little information as
+possible about its internal state, and that a compromise of the "public"
+CSPRNG instance will not affect the secrecy of these private values.
 
 In the rare case where the default implementation does not satisfy your special
 requirements, there are two options:
@@ -64,7 +67,7 @@ L<RAND_priv_bytes(3)>,
 L<RAND_get_rand_method(3)>
 L<RAND_set_rand_method(3)>
 L<RAND_OpenSSL(3)>,
-L<RAND_DRBG(7)>,
+L<RAND_DRBG(7)>
 
 =head1 COPYRIGHT
 

--- a/doc/man7/RAND.pod
+++ b/doc/man7/RAND.pod
@@ -64,8 +64,8 @@ of cryptographic principles and understand the implications of your changes.
 L<RAND_add(3)>,
 L<RAND_bytes(3)>,
 L<RAND_priv_bytes(3)>,
-L<RAND_get_rand_method(3)>
-L<RAND_set_rand_method(3)>
+L<RAND_get_rand_method(3)>,
+L<RAND_set_rand_method(3)>,
 L<RAND_OpenSSL(3)>,
 L<RAND_DRBG(7)>
 


### PR DESCRIPTION
Stemming from https://github.com/openssl/openssl/pull/6501#discussion_r195978940 this PR updates the documentation about `RAND_priv_bytes()` and then adds missing documentation about `BN_priv_rand()` and `BN_priv_rand_range()`:
- [x] documentation is updated
- [x] documentation is added

Pinging @kroeckx , @richsalz and @mspncp  for comments: bear in mind that I'm not entirely familiar with pod syntax, so please double check for newbie errors!