### PR TITLE
Improve the output of `make doc-nits`

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -708,10 +708,11 @@ update: generate errors ordinals
 generate: generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
 
+.PHONY: doc-nits
 doc-nits:
 	(cd $(SRCDIR); $(PERL) util/find-doc-nits -n -p ) >doc-nits
-	@if [ -s doc-nits ] ; then cat doc-nits; rm doc-nits ; exit 1; \
-	else echo 'find-doc-nits: no errors.' ; fi
+	@if [ -s doc-nits ] ; then cat doc-nits ; exit 1; \
+	else echo 'doc-nits: no errors.'; rm doc-nits ; fi
 
 # Test coverage is a good idea for the future
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -710,7 +710,8 @@ generate: generate_apps generate_crypto_bn generate_crypto_objects \
 
 doc-nits:
 	(cd $(SRCDIR); $(PERL) util/find-doc-nits -n -p ) >doc-nits
-	if [ -s doc-nits ] ; then cat doc-nits; rm doc-nits ; exit 1; fi
+	@if [ -s doc-nits ] ; then cat doc-nits; rm doc-nits ; exit 1; \
+	else echo 'find-doc-nits: no errors.' ; fi
 
 # Test coverage is a good idea for the future
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)


### PR DESCRIPTION
 Inspired by https://github.com/openssl/openssl/pull/6514#issuecomment-398165080 this pull request makes the output of `make doc-nits`a bit more explicit.

Note that the echo of the if-else statement was suppressed in the makefile using an \@ character to make the output more readable.

Here is the output from some testruns of `make doc-nits`:

**Error Case**
```
msp@msppc:~/src/openssl$ make doc-nits
(cd .; /usr/bin/perl util/find-doc-nits -n -p ) >doc-nits
doc/man3/RAND_bytes.pod:1: RAND_bytes (filename) missing from NAME section
doc/man3/RAND_bytes.pod:1: RAND_bytes missing from NAME section
make: *** [Makefile:515: doc-nits] Error 1
```

**Success Case**

```
msp@msppc:~/src/openssl$ make doc-nits
(cd .; /usr/bin/perl util/find-doc-nits -n -p ) >doc-nits
find-doc-nits: no errors.
```

**Already done**

```
msp@msppc:~/src/openssl$ make doc-nits
make: 'doc-nits' is up to date.
```

c/o @romen, @richsalz 
