### PR TITLE
NOTES.UNIX: expand the description of RPATHs

### DIFF
--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -5,21 +5,27 @@
  For Unix/POSIX runtime systems on Windows, please see NOTES.WIN.
 
 
- Shared libraries and installation in non-standard locations
- -----------------------------------------------------------
+ Shared libraries and installation in non-default locations
+ ----------------------------------------------------------
 
  Binaries on some Unix variants expect to find shared libraries in
- standard locations, such as /usr/lib and possibly /usr/local/lib.  If
- the libraries are installed in non-standard locations, binaries will not
- find them and therefore fail to run unless they get a bit of help from
- a defined runtime shared library search path.
+ default locations, such as /lib, /usr/lib or possibly /usr/local/lib.
+ (what the default locations are depends on the system the libraries are
+ going to be installed in)
+ If the libraries are installed in non-default locations, binaries will
+ not find them and therefore fail to run unless they get a bit of help
+ from a defined runtime shared library search path.
 
- It is possible to specify additonal directories for the runtime shared
- library search path when linking a shared library or an application.
- They are specified with different linking options depending on operating
- system and versions thereof, and are talked about differently in their
- respective documentation, where variations of RPATH are the most usual
- (to be noted: GNU ld.so systems have two such tags, more on that below).
+ OpenSSL's configuration scripts do NOT generally set the runtime shared
+ library search path for you.  It's therefore advisable to set it
+ explicitelly when configuring unless the libraries are to be installed
+ in directories that are known to be default.
+
+ Runtime shared library search paths are specified with different
+ linking options depending on operating system and versions thereof, and
+ are talked about differently in their respective documentation, where
+ variations of RPATH are the most usual (to be noted: ELF systems have
+ two such tags, more on that below).
 
  Possible options to set the runtime shared library search path are:
 
@@ -41,20 +47,30 @@
  this example:
 
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
-        '-rpath $(LIBRPATH)'
+        '-Wl,-rpath,$(LIBRPATH)'
 
  (the quotes are needed for two reasons: 1) the configuration scripts
  will otherwise -rpath and $(LIBRPATH) as two entirely separate
  arguments, and 2) the shell will try to expand $(LIBRPATH))
 
- On modern systems using GNU ld.so, there are two runtime search paths
- tags to consider, DT_RPATH and DT_RUNPATH.  DT_RUNPATH is considered
- after the environment variable LD_LIBRARY_PATH, while DT_RPATH is
- considered before that environment variable (which means that the
- values in that environment variable won't matter if the library is
- found in the paths given by DT_RPATH).  Giving the configurations
- scripts the option '-Wl,-rpath,$(LIBRPATH)' will set DT_RPATH, which
- may be undesirable.  To set DT_RUNPATH, use the new dtags, like this:
+ On modern ELF based systems, there are two runtime search paths tags to
+ consider, DT_RPATH and DT_RUNPATH.  DT_RUNPATH is considered after the
+ environment variable LD_LIBRARY_PATH, while DT_RPATH is considered
+ before that environment variable (which means that the values in that
+ environment variable won't matter if the library is found in the paths
+ given by DT_RPATH).
+
+ Exactly which of DT_RPATH or DT_RUNPATH is normally set appears to
+ depend on the system.  For example, according to documentation,
+ DT_RPATH appears to be deprecated on Solaris for the benefit of
+ DT_RUNPATH, while with GNU ld, either tag may be set.
+
+ With GNU ld, '-Wl,-rpath,$(LIBRPATH)' will set DT_RPATH.  To set
+ DT_RUNPATH, use the new dtags, like this:
 
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
         '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
+
+ Some other linkers may support the same syntax, or something other.
+ please refer to ld(1) for the exact information on your system.
+

--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -5,53 +5,51 @@
  For Unix/POSIX runtime systems on Windows, please see NOTES.WIN.
 
 
- Using compiler to link programs and shared libraries
- ----------------------------------------------------
+ OpenSSL uses the compiler to link programs and shared libraries
+ ---------------------------------------------------------------
 
  OpenSSL's generated Makefile uses the C compiler command line to
  link programs, shared libraries and dynamically loadable shared
- objects.  With this in mind, any linking option that's given to the
+ objects.  Because of this, any linking option that's given to the
  configuration scripts MUST be in a form that the compiler can accept.
  This varies between systems, where some have compilers that accept
  linker flags directly, while others take them in '-Wl,' form.  You need
- to read your compiler documentation to figure out what it can take, and
- ld(1) to figure out what linker options are available.
+ to read your compiler documentation to figure out what is acceptable,
+ and ld(1) to figure out what linker options are available.
 
 
  Shared libraries and installation in non-default locations
  ----------------------------------------------------------
 
- Binaries on some Unix variants expect to find shared libraries in
- default locations, such as /lib, /usr/lib or possibly /usr/local/lib.
- (what the default locations are depends on the system the libraries are
- going to be installed in)
- If the libraries are installed in non-default locations, binaries will
- not find them and therefore fail to run unless they get a bit of help
- from a defined runtime shared library search path.
+ Every Unix system has its own set of default locations for shared
+ libraries, such as /lib, /usr/lib or possibly /usr/local/lib.  If
+ libraries are installed in non-default locations, dynamically linked
+ binaries will not find them and therefore fail to run unless they get a
+ bit of help from a defined runtime shared library search path.
 
  For OpenSSL's application (the 'openssl' command), our configuration
  scripts do NOT generally set the runtime shared library search path for
  you.  It's therefore advisable to set it explicitelly when configuring
- unless the libraries are to be installed in directories that are known
- to be default.
+ unless the libraries are to be installed in directories that you know
+ to be in the default list.
 
  Runtime shared library search paths are specified with different
  linking options depending on operating system and versions thereof, and
- are talked about differently in their respective documentation, where
- variations of RPATH are the most usual (to be noted: ELF systems have
- two such tags, more on that below).
+ are talked about differently in their respective documentation;
+ variations of RPATH are the most usual (note: ELF systems have two such
+ tags, more on that below).
 
- Possible options to set the runtime shared library search path are:
+ Possible options to set the runtime shared library search path include
+ the following:
 
     -Wl,-rpath,/whatever/path
     -R /whatever/path
     -rpath /whatever/path
 
  OpenSSL's configuration scripts recognise all these options and pass
- them to the Makefile that they build.
- (as a matter of fact, it recognises anything starting with '-Wl,' as a
- linker option, so for example, HP-UX' '-Wl,+b,/whatever/path' would
- be used correctly)
+ them to the Makefile that they build.  (In fact, it recognises anything
+ starting with '-Wl,' as a linker option, so for example, HP-UX'
+ '-Wl,+b,/whatever/path' would be used correctly)
 
  Please do not use verbatim directories in your runtime shared library
  search path!  Some OpenSSL config targets add an extra directory level
@@ -63,10 +61,6 @@
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
         '-Wl,-rpath,$(LIBRPATH)'
 
- (the quotes are needed for two reasons: 1) the configuration scripts
- will otherwise -rpath and $(LIBRPATH) as two entirely separate
- arguments, and 2) the shell will try to expand $(LIBRPATH))
-
  On modern ELF based systems, there are two runtime search paths tags to
  consider, DT_RPATH and DT_RUNPATH.  Shared objects are searched for in
  this order:
@@ -77,14 +71,15 @@
     3. Using directories specified in DT_RUNPATH.
     4. Using system shared object caches and default directories.
 
- This means that the values in that environment variable LD_LIBRARY_PATH
- won't matter if the library is found in the paths given by DT_RPATH.
+ This means that the values in the environment variable LD_LIBRARY_PATH
+ won't matter if the library is found in the paths given by DT_RPATH
+ (and DT_RUNPATH isn't set).
 
  Exactly which of DT_RPATH or DT_RUNPATH is set by default appears to
  depend on the system.  For example, according to documentation,
- DT_RPATH appears to be deprecated on Solaris for the benefit of
- DT_RUNPATH, while on Debian GNU/Linux, either can be set, and DT_RPATH
- is the default at the time of writing.
+ DT_RPATH appears to be deprecated on Solaris in favor of DT_RUNPATH,
+ while on Debian GNU/Linux, either can be set, and DT_RPATH is the
+ default at the time of writing.
 
  How to choose which runtime search path tag is to be set depends on
  your system, please refer to ld(1) for the exact information on your

--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -5,6 +5,19 @@
  For Unix/POSIX runtime systems on Windows, please see NOTES.WIN.
 
 
+ Using compiler to link programs and shared libraries
+ ----------------------------------------------------
+
+ OpenSSL's generated Makefile generally uses $(CC) (the C compiler) to
+ link programs, shared libraries and dynamically loadable shared
+ objects.  With this in mind, any linking option that's given to the
+ configuration scripts MUST be in a form that the compiler can accept.
+ This varies between systems, where some have compilers that accept
+ linker flags directly, while others take them in '-Wl,' form.  You need
+ to read your compiler documentation to figure out what it can take, and
+ ld(1) to figure out what linker options are available.
+
+
  Shared libraries and installation in non-default locations
  ----------------------------------------------------------
 

--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -8,35 +8,53 @@
  Shared libraries and installation in non-standard locations
  -----------------------------------------------------------
 
- Binaries on Unix variants expect to find shared libraries in standard
- locations, such as /usr/lib, /usr/local/lib and some other locations
- configured in the system (for example /etc/ld.so.conf on some systems).
- If the libraries are installed in non-standard locations, binaries
- will not find them and therefore fail to run unless they get a bit of
- help from a defined RPATH or RUNPATH.  This can be applied by adding
- the appropriate linker flags to the configuration command, such as
- this (/usr/local/ssl was the default location for OpenSSL installation
- in versions before 1.1.0):
+ Binaries on some Unix variants expect to find shared libraries in
+ standard locations, such as /usr/lib and possibly /usr/local/lib.  If
+ the libraries are installed in non-standard locations, binaries will not
+ find them and therefore fail to run unless they get a bit of help from
+ a defined runtime shared library search path.
+
+ It is possible to specify additonal directories for the runtime shared
+ library search path when linking a shared library or an application.
+ They are specified with different linking options depending on operating
+ system and versions thereof, and are talked about differently in their
+ respective documentation, where variations of RPATH are the most usual
+ (to be noted: GNU ld.so systems have two such tags, more on that below).
+
+ Possible options to set the runtime shared library search path are:
+
+    -rpath /whatever/path
+    -R /whatever/path
+    -Wl,-rpath,/whatever/path
+
+ OpenSSL's configuration scripts recognise all these options and pass
+ them to the Makefile that they build.
+ (as a matter of fact, it recognises anything starting with '-Wl,' as a
+ linker option, so for example, HP-UX' '-Wl,+b,/whatever/path' would
+ be used correctly)
+
+ Please do not use verbatim directories in your runtime shared library
+ search path!  Some OpenSSL config targets add an extra directory level
+ for multilib installations.  To help with that, the produced Makefile
+ includes the variable LIBRPATH, which is a convenience variable to be
+ used with the runtime shared library search path options, as shown in
+ this example:
 
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
-        -Wl,-rpath,/usr/local/ssl/lib
+        '-rpath $(LIBRPATH)'
 
- Because the actual library location may vary further (for example on
- multilib installations), there is a convenience variable in Makefile
- that holds the exact installation directory and that can be used like
- this:
+ (the quotes are needed for two reasons: 1) the configuration scripts
+ will otherwise -rpath and $(LIBRPATH) as two entirely separate
+ arguments, and 2) the shell will try to expand $(LIBRPATH))
+
+ On modern systems using GNU ld.so, there are two runtime search paths
+ tags to consider, DT_RPATH and DT_RUNPATH.  DT_RUNPATH is considered
+ after the environment variable LD_LIBRARY_PATH, while DT_RPATH is
+ considered before that environment variable (which means that the
+ values in that environment variable won't matter if the library is
+ found in the paths given by DT_RPATH).  Giving the configurations
+ scripts the option '-Wl,-rpath,$(LIBRPATH)' will set DT_RPATH, which
+ may be undesirable.  To set DT_RUNPATH, use the new dtags, like this:
 
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
-        -Wl,-rpath,'$(LIBRPATH)'
-
- On modern systems using GNU ld.so, a better choice may be to use the
- new dtags, like this:
-
-    $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
-        -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)'
-
- This sets DT_RUNPATH instead of DT_RPATH.  DT_RUNPATH is considered after
- the environment variable LD_LIBRARY_PATH, while DT_RPATH is considered
- before that environment variable (which means that the values in that
- environment variable won't matter if the library is found in the
- paths given by DT_RPATH).
+        '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'

--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -16,10 +16,11 @@
  not find them and therefore fail to run unless they get a bit of help
  from a defined runtime shared library search path.
 
- OpenSSL's configuration scripts do NOT generally set the runtime shared
- library search path for you.  It's therefore advisable to set it
- explicitelly when configuring unless the libraries are to be installed
- in directories that are known to be default.
+ For OpenSSL's application (the 'openssl' command), our configuration
+ scripts do NOT generally set the runtime shared library search path for
+ you.  It's therefore advisable to set it explicitelly when configuring
+ unless the libraries are to be installed in directories that are known
+ to be default.
 
  Runtime shared library search paths are specified with different
  linking options depending on operating system and versions thereof, and
@@ -60,17 +61,17 @@
  environment variable won't matter if the library is found in the paths
  given by DT_RPATH).
 
- Exactly which of DT_RPATH or DT_RUNPATH is normally set appears to
+ Exactly which of DT_RPATH or DT_RUNPATH is set by default appears to
  depend on the system.  For example, according to documentation,
  DT_RPATH appears to be deprecated on Solaris for the benefit of
- DT_RUNPATH, while with GNU ld, either tag may be set.
+ DT_RUNPATH, while on Debian GNU/Linux, either can be set, and DT_RPATH
+ is the default.
 
- With GNU ld, '-Wl,-rpath,$(LIBRPATH)' will set DT_RPATH.  To set
- DT_RUNPATH, use the new dtags, like this:
+ How to choose which runtime search path tag is to be set depends on
+ your system, please refer to ld(1) for the exact information on your
+ system.  As an example, the way to ensure the DT_RUNPATH is set on
+ Debian GNU/Linux systems rather than DT_RPATH is to tell the linker to
+ set new dtags, like this:
 
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
         '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
-
- Some other linkers may support the same syntax, or something other.
- please refer to ld(1) for the exact information on your system.
-

--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -8,7 +8,7 @@
  Using compiler to link programs and shared libraries
  ----------------------------------------------------
 
- OpenSSL's generated Makefile generally uses $(CC) (the C compiler) to
+ OpenSSL's generated Makefile uses the C compiler command line to
  link programs, shared libraries and dynamically loadable shared
  objects.  With this in mind, any linking option that's given to the
  configuration scripts MUST be in a form that the compiler can accept.
@@ -43,9 +43,9 @@
 
  Possible options to set the runtime shared library search path are:
 
-    -rpath /whatever/path
-    -R /whatever/path
     -Wl,-rpath,/whatever/path
+    -R /whatever/path
+    -rpath /whatever/path
 
  OpenSSL's configuration scripts recognise all these options and pass
  them to the Makefile that they build.
@@ -68,17 +68,23 @@
  arguments, and 2) the shell will try to expand $(LIBRPATH))
 
  On modern ELF based systems, there are two runtime search paths tags to
- consider, DT_RPATH and DT_RUNPATH.  DT_RUNPATH is considered after the
- environment variable LD_LIBRARY_PATH, while DT_RPATH is considered
- before that environment variable (which means that the values in that
- environment variable won't matter if the library is found in the paths
- given by DT_RPATH).
+ consider, DT_RPATH and DT_RUNPATH.  Shared objects are searched for in
+ this order:
+
+    1. Using directories specified in DT_RPATH, unless DT_RUNPATH is
+       also set.
+    2. Using the environment variable LD_LIBRARY_PATH
+    3. Using directories specified in DT_RUNPATH.
+    4. Using system shared object caches and default directories.
+
+ This means that the values in that environment variable LD_LIBRARY_PATH
+ won't matter if the library is found in the paths given by DT_RPATH.
 
  Exactly which of DT_RPATH or DT_RUNPATH is set by default appears to
  depend on the system.  For example, according to documentation,
  DT_RPATH appears to be deprecated on Solaris for the benefit of
  DT_RUNPATH, while on Debian GNU/Linux, either can be set, and DT_RPATH
- is the default.
+ is the default at the time of writing.
 
  How to choose which runtime search path tag is to be set depends on
  your system, please refer to ld(1) for the exact information on your


### PR DESCRIPTION
Hopefully, this will make it more clear that it isn't only ELF
specific, even though there is a part that is (or even more
restrictively GNU ld.so specific).
