### PR TITLE
Fixes #6525 Fix EVP_TESTS for no-sm2

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2527,17 +2527,20 @@ top:
             TEST_info("Duplicate key %s", pp->value);
             return 0;
         }
-        if (!TEST_ptr(key = OPENSSL_malloc(sizeof(*key))))
-            return 0;
-        key->name = take_value(pp);
+        /* Only add key if it exists */
+        if (pkey) {
+            if (!TEST_ptr(key = OPENSSL_malloc(sizeof(*key))))
+                return 0;
+            key->name = take_value(pp);
 
-        /* Hack to detect SM2 keys */
-        if(strstr(key->name, "SM2"))
-            EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2);
+            /* Hack to detect SM2 keys */
+            if(strstr(key->name, "SM2"))
+                EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2);
 
-        key->key = pkey;
-        key->next = *klist;
-        *klist = key;
+            key->key = pkey;
+            key->next = *klist;
+            *klist = key;
+        }
 
         /* Go back and start a new stanza. */
         if (t->s.numpairs != 1)


### PR DESCRIPTION
When an algorithm is disabled, the EVP_PKEY is NULL.
NULL EVP_PKEY's are being added to the key database for tests.
Tests fail due to NULL EVP_PKEYS.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
