### PR TITLE
Remove __cplusplus preamble from internal headers

### DIFF
--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -23,10 +23,6 @@
 
 # include "internal/bn_int.h"
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 /*
  * These preprocessor symbols control various aspects of the bignum headers
  * and library code. They're not defined by any "normal" configuration, as
@@ -658,9 +654,5 @@ static ossl_inline BIGNUM *bn_expand(BIGNUM *a, int bits)
 
     return bn_expand2((a),(bits+BN_BITS2-1)/BN_BITS2);
 }
-
-#ifdef  __cplusplus
-}
-#endif
 
 #endif

--- a/crypto/cms/cms_lcl.h
+++ b/crypto/cms/cms_lcl.h
@@ -10,10 +10,6 @@
 #ifndef HEADER_CMS_LCL_H
 # define HEADER_CMS_LCL_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 # include <openssl/x509.h>
 
 /*
@@ -438,7 +434,4 @@ DECLARE_ASN1_ITEM(CMS_RevocationInfoChoice)
 DECLARE_ASN1_ITEM(CMS_SignedData)
 DECLARE_ASN1_ITEM(CMS_CompressedData)
 
-#ifdef  __cplusplus
-}
-#endif
 #endif

--- a/crypto/engine/eng_int.h
+++ b/crypto/engine/eng_int.h
@@ -16,10 +16,6 @@
 # include "internal/thread_once.h"
 # include "internal/refcount.h"
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 extern CRYPTO_RWLOCK *global_engine_lock;
 
 /*
@@ -171,9 +167,5 @@ struct engine_st {
 typedef struct st_engine_pile ENGINE_PILE;
 
 DEFINE_LHASH_OF(ENGINE_PILE);
-
-#ifdef  __cplusplus
-}
-#endif
 
 #endif                          /* HEADER_ENGINE_INT_H */

--- a/crypto/hmac/hmac_lcl.h
+++ b/crypto/hmac/hmac_lcl.h
@@ -10,13 +10,6 @@
 #ifndef HEADER_HMAC_LCL_H
 # define HEADER_HMAC_LCL_H
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-#if 0                            /* emacs indentation fix */
-}
-#endif
-
 struct hmac_ctx_st {
     const EVP_MD *md;
     EVP_MD_CTX *md_ctx;
@@ -25,9 +18,5 @@ struct hmac_ctx_st {
     unsigned int key_length;
     unsigned char key[HMAC_MAX_MD_CBLOCK];
 };
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
 
 #endif

--- a/crypto/include/internal/aria.h
+++ b/crypto/include/internal/aria.h
@@ -25,10 +25,6 @@
 # define ARIA_BLOCK_SIZE    16  /* Size of each encryption/decryption block */
 # define ARIA_MAX_KEYS      17  /* Number of keys needed in the worst case  */
 
-# ifdef  __cplusplus
-extern "C" {
-# endif
-
 typedef union {
     unsigned char c[ARIA_BLOCK_SIZE];
     unsigned int u[ARIA_BLOCK_SIZE / sizeof(unsigned int)];
@@ -50,9 +46,5 @@ int aria_set_decrypt_key(const unsigned char *userKey, const int bits,
 
 void aria_encrypt(const unsigned char *in, unsigned char *out,
                   const ARIA_KEY *key);
-
-# ifdef  __cplusplus
-}
-# endif
 
 #endif

--- a/crypto/include/internal/bn_int.h
+++ b/crypto/include/internal/bn_int.h
@@ -13,10 +13,6 @@
 # include <openssl/bn.h>
 # include <limits.h>
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 BIGNUM *bn_wexpand(BIGNUM *a, int words);
 BIGNUM *bn_expand2(BIGNUM *a, int words);
 
@@ -63,9 +59,5 @@ void bn_set_static_words(BIGNUM *a, BN_ULONG *words, int size);
  * function so we simply trust callers not to pass negative values.
  */
 int bn_set_words(BIGNUM *a, BN_ULONG *words, int num_words);
-
-#ifdef  __cplusplus
-}
-#endif
 
 #endif

--- a/crypto/include/internal/chacha.h
+++ b/crypto/include/internal/chacha.h
@@ -12,10 +12,6 @@
 
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * ChaCha20_ctr32 encrypts |len| bytes from |inp| with the given key and
  * nonce and writes the result to |out|, which may be equal to |inp|.
@@ -43,7 +39,4 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
 #define CHACHA_CTR_SIZE		16
 #define CHACHA_BLK_SIZE		64
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/crypto/include/internal/sm2.h
+++ b/crypto/include/internal/sm2.h
@@ -15,10 +15,6 @@
 
 # ifndef OPENSSL_NO_SM2
 
-#  ifdef __cplusplus
-extern "C" {
-#  endif
-
 #  include <openssl/ec.h>
 
 /* The default user id as specified in GM/T 0009-2012 */
@@ -73,10 +69,6 @@ int sm2_decrypt(const EC_KEY *key,
                 const EVP_MD *digest,
                 const uint8_t *ciphertext,
                 size_t ciphertext_len, uint8_t *ptext_buf, size_t *ptext_len);
-
-#  ifdef __cplusplus
-}
-#  endif
 
 # endif /* OPENSSL_NO_SM2 */
 #endif

--- a/crypto/include/internal/sm2err.h
+++ b/crypto/include/internal/sm2err.h
@@ -15,9 +15,6 @@
 
 # ifndef OPENSSL_NO_SM2
 
-#  ifdef  __cplusplus
-extern "C"
-#  endif
 int ERR_load_SM2_strings(void);
 
 /*

--- a/crypto/include/internal/store_int.h
+++ b/crypto/include/internal/store_int.h
@@ -14,10 +14,6 @@
 # include <openssl/store.h>
 # include <openssl/ui.h>
 
-# ifdef  __cplusplus
-extern "C" {
-# endif
-
 /*
  * Two functions to read PEM data off an already opened BIO.  To be used
  * instead of OSSLSTORE_open() and OSSLSTORE_close().  Everything is done
@@ -27,7 +23,4 @@ OSSL_STORE_CTX *ossl_store_attach_pem_bio(BIO *bp, const UI_METHOD *ui_method,
                                           void *ui_data);
 int ossl_store_detach_pem_bio(OSSL_STORE_CTX *ctx);
 
-# ifdef  __cplusplus
-}
-# endif
 #endif

--- a/crypto/seed/seed_locl.h
+++ b/crypto/seed/seed_locl.h
@@ -45,10 +45,6 @@ typedef unsigned int seed_word;
 # endif
 
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 # define char2word(c, i)  \
         (i) = ((((seed_word)(c)[0]) << 24) | (((seed_word)(c)[1]) << 16) | (((seed_word)(c)[2]) << 8) | ((seed_word)(c)[3]))
 
@@ -112,9 +108,5 @@ extern "C" {
         (T0) = ((T0) + (T1)) & 0xffffffff;       \
         (X1) ^= (T0);                            \
         (X2) ^= (T1)
-
-#ifdef  __cplusplus
-}
-#endif
 
 #endif                          /* HEADER_SEED_LOCL_H */

--- a/crypto/x509v3/v3_admis.h
+++ b/crypto/x509v3/v3_admis.h
@@ -10,10 +10,6 @@
 #ifndef HEADER_V3_ADMISSION_H
 # define HEADER_V3_ADMISSION_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 struct NamingAuthority_st {
     ASN1_OBJECT* namingAuthorityId;
     ASN1_IA5STRING* namingAuthorityUrl;
@@ -39,7 +35,4 @@ struct AdmissionSyntax_st {
     STACK_OF(ADMISSIONS)* contentsOfAdmissions;
 };
 
-#ifdef  __cplusplus
-}
-#endif
 #endif

--- a/e_os.h
+++ b/e_os.h
@@ -22,10 +22,6 @@
  * outside; this file e_os.h is not part of the exported interface.
  */
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 # ifndef DEVRANDOM
 /*
  * set this to a comma-separated list of 'random' device files to try out. By
@@ -323,10 +319,6 @@ struct servent *getservbyname(const char *name, const char *proto);
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 # define CRYPTO_memcmp memcmp
-#endif
-
-#ifdef  __cplusplus
-}
 #endif
 
 #endif

--- a/include/internal/conf.h
+++ b/include/internal/conf.h
@@ -12,11 +12,6 @@
 
 #include <openssl/conf.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 struct ossl_init_settings_st {
     char *appname;
 };
@@ -24,9 +19,5 @@ struct ossl_init_settings_st {
 void openssl_config_int(const char *appname);
 void openssl_no_config_int(void);
 void conf_modules_free_int(void);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/internal/constant_time_locl.h
+++ b/include/internal/constant_time_locl.h
@@ -14,10 +14,6 @@
 # include <string.h>
 # include <openssl/e_os2.h>              /* For 'ossl_inline' */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*-
  * The boolean methods return a bitmask of all ones (0xff...f) for true
  * and 0 for false. This is useful for choosing a value based on the result
@@ -327,9 +323,5 @@ static ossl_inline void constant_time_lookup(void *out,
             *(outc + j) |= constant_time_select_8(mask, *(tablec++), 0);
     }
 }
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif                          /* HEADER_CONSTANT_TIME_LOCL_H */

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -25,10 +25,6 @@
 # include <openssl/err.h>
 # include "internal/nelem.h"
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 #ifdef NDEBUG
 # define ossl_assert(x) ((x) != 0)
 #else
@@ -95,9 +91,5 @@ void *openssl_fopen(const char *filename, const char *mode);
 # endif
 
 uint32_t OPENSSL_rdtsc(void);
-
-#ifdef  __cplusplus
-}
-#endif
 
 #endif

--- a/include/internal/dso.h
+++ b/include/internal/dso.h
@@ -13,10 +13,6 @@
 # include <openssl/crypto.h>
 # include "internal/dsoerr.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* These values are used as commands to DSO_ctrl() */
 # define DSO_CTRL_GET_FLAGS      1
 # define DSO_CTRL_SET_FLAGS      2
@@ -166,7 +162,4 @@ void *DSO_global_lookup(const char *name);
 
 int ERR_load_DSO_strings(void);
 
-# ifdef  __cplusplus
-}
-# endif
 #endif

--- a/include/internal/dsoerr.h
+++ b/include/internal/dsoerr.h
@@ -15,9 +15,6 @@
 
 # ifndef OPENSSL_NO_DSO
 
-#  ifdef  __cplusplus
-extern "C"
-#  endif
 int ERR_load_DSO_strings(void);
 
 /*

--- a/include/internal/o_dir.h
+++ b/include/internal/o_dir.h
@@ -39,10 +39,6 @@
 #ifndef O_DIR_H
 # define O_DIR_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef struct OPENSSL_dir_context_st OPENSSL_DIR_CTX;
 
 /*
@@ -52,9 +48,5 @@ typedef struct OPENSSL_dir_context_st OPENSSL_DIR_CTX;
 const char *OPENSSL_DIR_read(OPENSSL_DIR_CTX **ctx, const char *directory);
 /* returns 1 on success, 0 on error */
 int OPENSSL_DIR_end(OPENSSL_DIR_CTX **ctx);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif                          /* LPDIR_H */

--- a/ssl/packet_locl.h
+++ b/ssl/packet_locl.h
@@ -18,10 +18,6 @@
 
 # include "internal/numbers.h"
 
-# ifdef __cplusplus
-extern "C" {
-# endif
-
 typedef struct {
     /* Pointer to where we are currently reading from */
     const unsigned char *curr;
@@ -874,9 +870,5 @@ unsigned char *WPACKET_get_curr(WPACKET *pkt);
 
 /* Release resources in a WPACKET if a failure has occurred. */
 void WPACKET_cleanup(WPACKET *pkt);
-
-# ifdef __cplusplus
-}
-# endif
 
 #endif                          /* HEADER_PACKET_LOCL_H */


### PR DESCRIPTION
From https://github.com/openssl/openssl/pull/6521#discussion_r197262781 , spotted by @dot-asm :

> This is internal header and it's never exposed to C++ compiler, hence there is no need for this. 

This was later extended to all the internal headers I could think of!