### PR TITLE
testutil/driver.c: Fix function prototype warning [-Wstrict-prototypes]

### DIFF
--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -74,7 +74,7 @@ int subtest_level(void)
 }
 
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
-static int should_report_leaks()
+static int should_report_leaks(void)
 {
     /*
      * When compiled with enable-crypto-mdebug, OPENSSL_DEBUG_MEMORY=0


### PR DESCRIPTION
[extended tests]

(introduced by commit 91860165820d, which added -Wstrict-prototypes)
