### PR TITLE
OpenSSL-II style for emacs: don't indent because of extern block

### DIFF
--- a/doc/openssl-c-indent.el
+++ b/doc/openssl-c-indent.el
@@ -54,6 +54,7 @@
                 (arglist-close . c-lineup-arglist)           ; From "gnu" style
                 (inline-open . 0)                            ; From "gnu" style
                 (brace-list-open . +)                        ; From "gnu" style
+                (inextern-lang . 0)     ; Don't indent inside extern block
                 (topmost-intro-cont first c-lineup-topmost-intro-cont
                                     c-lineup-gnu-DEFUN-intro-cont) ; From "gnu" style
                 )


### PR DESCRIPTION
We don't want an indentation step inside a 'extern "C" {' .. '}'
block.  Apparently, cc-mode has a c-offsets-alist keyword to allow
exactly this.
