### PR TITLE
Replace accidentally used C99 macro __func__ with __FILE__/__LINE__

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -148,7 +148,7 @@ static int afalg_setup_async_event_notification(afalg_aio *aio)
         /* Async mode */
         waitctx = ASYNC_get_wait_ctx(job);
         if (waitctx == NULL) {
-            ALG_WARN("%s: ASYNC_get_wait_ctx error", __func__);
+            ALG_WARN("%s(%d): ASYNC_get_wait_ctx error", __FILE__, __LINE__);
             return 0;
         }
         /* Get waitfd from ASYNC_WAIT_CTX if it is already set */
@@ -161,7 +161,8 @@ static int afalg_setup_async_event_notification(afalg_aio *aio)
              */
             aio->efd = eventfd(0);
             if (aio->efd == -1) {
-                ALG_PERR("%s: Failed to get eventfd : ", __func__);
+                ALG_PERR("%s(%d): Failed to get eventfd : ", __FILE__,
+                         __LINE__);
                 AFALGerr(AFALG_F_AFALG_SETUP_ASYNC_EVENT_NOTIFICATION,
                          AFALG_R_EVENTFD_FAILED);
                 return 0;
@@ -170,14 +171,14 @@ static int afalg_setup_async_event_notification(afalg_aio *aio)
                                              aio->efd, custom,
                                              afalg_waitfd_cleanup);
             if (ret == 0) {
-                ALG_WARN("%s: Failed to set wait fd", __func__);
+                ALG_WARN("%s(%d): Failed to set wait fd", __FILE__, __LINE__);
                 close(aio->efd);
                 return 0;
             }
             /* make fd non-blocking in async mode */
             if (fcntl(aio->efd, F_SETFL, O_NONBLOCK) != 0) {
-                ALG_WARN("%s: Failed to set event fd as NONBLOCKING",
-                         __func__);
+                ALG_WARN("%s(%d): Failed to set event fd as NONBLOCKING",
+                         __FILE__, __LINE__);
             }
         }
         aio->mode = MODE_ASYNC;
@@ -185,7 +186,7 @@ static int afalg_setup_async_event_notification(afalg_aio *aio)
         /* Sync mode */
         aio->efd = eventfd(0);
         if (aio->efd == -1) {
-            ALG_PERR("%s: Failed to get eventfd : ", __func__);
+            ALG_PERR("%s(%d): Failed to get eventfd : ", __FILE__, __LINE__);
             AFALGerr(AFALG_F_AFALG_SETUP_ASYNC_EVENT_NOTIFICATION,
                      AFALG_R_EVENTFD_FAILED);
             return 0;
@@ -203,7 +204,7 @@ static int afalg_init_aio(afalg_aio *aio)
     aio->aio_ctx = 0;
     r = io_setup(MAX_INFLIGHTS, &aio->aio_ctx);
     if (r < 0) {
-        ALG_PERR("%s: io_setup error : ", __func__);
+        ALG_PERR("%s(%d): io_setup error : ", __FILE__, __LINE__);
         AFALGerr(AFALG_F_AFALG_INIT_AIO, AFALG_R_IO_SETUP_FAILED);
         return 0;
     }
@@ -257,7 +258,7 @@ static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
      */
     r = io_read(aio->aio_ctx, 1, &cb);
     if (r < 0) {
-        ALG_PWARN("%s: io_read failed : ", __func__);
+        ALG_PWARN("%s(%d): io_read failed : ", __FILE__, __LINE__);
         return 0;
     }
 
@@ -270,11 +271,11 @@ static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
         if (r < 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK)
                 continue;
-            ALG_PERR("%s: read failed for event fd : ", __func__);
+            ALG_PERR("%s(%d): read failed for event fd : ", __FILE__, __LINE__);
             return 0;
         } else if (r == 0 || eval <= 0) {
-            ALG_WARN("%s: eventfd read %d bytes, eval = %lu\n", __func__, r,
-                     eval);
+            ALG_WARN("%s(%d): eventfd read %d bytes, eval = %lu\n", __FILE__,
+                     __LINE__, r, eval);
         }
         if (eval > 0) {
 
@@ -294,8 +295,8 @@ static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
                     if (events[0].res == -EBUSY && retry++ < 3) {
                         r = io_read(aio->aio_ctx, 1, &cb);
                         if (r < 0) {
-                            ALG_PERR("%s: retry %d for io_read failed : ",
-                                     __func__, retry);
+                            ALG_PERR("%s(%d): retry %d for io_read failed : ",
+                                     __FILE__, __LINE__, retry);
                             return 0;
                         }
                         continue;
@@ -305,18 +306,19 @@ static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
                          * condition for this instance of operation.
                          */
                         ALG_WARN
-                            ("%s: Crypto Operation failed with code %lld\n",
-                             __func__, events[0].res);
+                            ("%s(%d): Crypto Operation failed with code %lld\n",
+                             __FILE__, __LINE__, events[0].res);
                         return 0;
                     }
                 }
                 /* Operation successful. */
                 done = 1;
             } else if (r < 0) {
-                ALG_PERR("%s: io_getevents failed : ", __func__);
+                ALG_PERR("%s(%d): io_getevents failed : ", __FILE__, __LINE__);
                 return 0;
             } else {
-                ALG_WARN("%s: io_geteventd read 0 bytes\n", __func__);
+                ALG_WARN("%s(%d): io_geteventd read 0 bytes\n", __FILE__,
+                         __LINE__);
             }
         }
     } while (!done);
@@ -352,7 +354,7 @@ static ossl_inline int afalg_set_key(afalg_ctx *actx, const unsigned char *key,
     int ret;
     ret = setsockopt(actx->bfd, SOL_ALG, ALG_SET_KEY, key, klen);
     if (ret < 0) {
-        ALG_PERR("%s: Failed to set socket option : ", __func__);
+        ALG_PERR("%s(%d): Failed to set socket option : ", __FILE__, __LINE__);
         AFALGerr(AFALG_F_AFALG_SET_KEY, AFALG_R_SOCKET_SET_KEY_FAILED);
         return 0;
     }
@@ -376,21 +378,21 @@ static int afalg_create_sk(afalg_ctx *actx, const char *ciphertype,
 
     actx->bfd = socket(AF_ALG, SOCK_SEQPACKET, 0);
     if (actx->bfd == -1) {
-        ALG_PERR("%s: Failed to open socket : ", __func__);
+        ALG_PERR("%s(%d): Failed to open socket : ", __FILE__, __LINE__);
         AFALGerr(AFALG_F_AFALG_CREATE_SK, AFALG_R_SOCKET_CREATE_FAILED);
         goto err;
     }
 
     r = bind(actx->bfd, (struct sockaddr *)&sa, sizeof(sa));
     if (r < 0) {
-        ALG_PERR("%s: Failed to bind socket : ", __func__);
+        ALG_PERR("%s(%d): Failed to bind socket : ", __FILE__, __LINE__);
         AFALGerr(AFALG_F_AFALG_CREATE_SK, AFALG_R_SOCKET_BIND_FAILED);
         goto err;
     }
 
     actx->sfd = accept(actx->bfd, NULL, 0);
     if (actx->sfd < 0) {
-        ALG_PERR("%s: Socket Accept Failed : ", __func__);
+        ALG_PERR("%s(%d): Socket Accept Failed : ", __FILE__, __LINE__);
         AFALGerr(AFALG_F_AFALG_CREATE_SK, AFALG_R_SOCKET_ACCEPT_FAILED);
         goto err;
     }
@@ -452,8 +454,8 @@ static int afalg_start_cipher_sk(afalg_ctx *actx, const unsigned char *in,
     /* Sendmsg() sends iv and cipher direction to the kernel */
     sbytes = sendmsg(actx->sfd, &msg, 0);
     if (sbytes < 0) {
-        ALG_PERR("%s: sendmsg failed for zero copy cipher operation : ",
-                 __func__);
+        ALG_PERR("%s(%d): sendmsg failed for zero copy cipher operation : ",
+                 __FILE__, __LINE__);
         return 0;
     }
 
@@ -463,13 +465,13 @@ static int afalg_start_cipher_sk(afalg_ctx *actx, const unsigned char *in,
      */
     ret = vmsplice(actx->zc_pipe[1], &iov, 1, SPLICE_F_GIFT);
     if (ret < 0) {
-        ALG_PERR("%s: vmsplice failed : ", __func__);
+        ALG_PERR("%s(%d): vmsplice failed : ", __FILE__, __LINE__);
         return 0;
     }
 
     ret = splice(actx->zc_pipe[0], NULL, actx->sfd, NULL, inl, 0);
     if (ret < 0) {
-        ALG_PERR("%s: splice failed : ", __func__);
+        ALG_PERR("%s(%d): splice failed : ", __FILE__, __LINE__);
         return 0;
     }
 # else
@@ -479,7 +481,8 @@ static int afalg_start_cipher_sk(afalg_ctx *actx, const unsigned char *in,
     /* Sendmsg() sends iv, cipher direction and input data to the kernel */
     sbytes = sendmsg(actx->sfd, &msg, 0);
     if (sbytes < 0) {
-        ALG_PERR("%s: sendmsg failed for cipher operation : ", __func__);
+        ALG_PERR("%s(%d): sendmsg failed for cipher operation : ", __FILE__,
+                 __LINE__);
         return 0;
     }
 
@@ -502,18 +505,18 @@ static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     char ciphername[ALG_MAX_SALG_NAME];
 
     if (ctx == NULL || key == NULL) {
-        ALG_WARN("%s: Null Parameter\n", __func__);
+        ALG_WARN("%s(%d): Null Parameter\n", __FILE__, __LINE__);
         return 0;
     }
 
     if (EVP_CIPHER_CTX_cipher(ctx) == NULL) {
-        ALG_WARN("%s: Cipher object NULL\n", __func__);
+        ALG_WARN("%s(%d): Cipher object NULL\n", __FILE__, __LINE__);
         return 0;
     }
 
     actx = EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (actx == NULL) {
-        ALG_WARN("%s: Cipher data NULL\n", __func__);
+        ALG_WARN("%s(%d): Cipher data NULL\n", __FILE__, __LINE__);
         return 0;
     }
 
@@ -525,14 +528,15 @@ static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         strncpy(ciphername, "cbc(aes)", ALG_MAX_SALG_NAME);
         break;
     default:
-        ALG_WARN("%s: Unsupported Cipher type %d\n", __func__, ciphertype);
+        ALG_WARN("%s(%d): Unsupported Cipher type %d\n", __FILE__, __LINE__,
+                 ciphertype);
         return 0;
     }
     ciphername[ALG_MAX_SALG_NAME-1]='\0';
 
     if (ALG_AES_IV_LEN != EVP_CIPHER_CTX_iv_length(ctx)) {
-        ALG_WARN("%s: Unsupported IV length :%d\n", __func__,
-                EVP_CIPHER_CTX_iv_length(ctx));
+        ALG_WARN("%s(%d): Unsupported IV length :%d\n", __FILE__, __LINE__,
+                 EVP_CIPHER_CTX_iv_length(ctx));
         return 0;
     }
 
@@ -572,7 +576,8 @@ static int afalg_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     char nxtiv[ALG_AES_IV_LEN] = { 0 };
 
     if (ctx == NULL || out == NULL || in == NULL) {
-        ALG_WARN("NULL parameter passed to function %s\n", __func__);
+        ALG_WARN("NULL parameter passed to function %s(%d)\n", __FILE__,
+                 __LINE__);
         return 0;
     }
 
@@ -619,7 +624,8 @@ static int afalg_cipher_cleanup(EVP_CIPHER_CTX *ctx)
     afalg_ctx *actx;
 
     if (ctx == NULL) {
-        ALG_WARN("NULL parameter passed to function %s\n", __func__);
+        ALG_WARN("NULL parameter passed to function %s(%d)\n", __FILE__,
+                 __LINE__);
         return 0;
     }
 


### PR DESCRIPTION
when configured with `./config --strict-warnings -std=gnu90`
the build fails in engines/e_afalg.c:
```
In file included from engines/e_afalg.c:48:0:
engines/e_afalg.c: In function 'afalg_setup_async_event_notification':
engines/e_afalg.c:164:58: error: ISO C90 does not support '__func__' predefined identifier [-Werror=pedantic]
                 ALG_PERR("%s: Failed to get eventfd : ", __func__);
                                                          ^
engines/e_afalg.h:31:53: note: in definition of macro 'ALG_PERR'
                     fprintf(stderr, "ALG_PERR: " x, __VA_ARGS__); \
                                                     ^
```

this removes the C99 feature.