### PR TITLE
Configure, et al.: add --run-path convenience option.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -216,6 +216,7 @@ my %targets = (
         shared_ldflag    => "-Wl,-Bsymbolic",
         shared_defflag   => "-Wl,-M,",
         shared_sonameflag=> "-Wl,-h,",
+        rpath_flag       => "-Wl,-R,",
     },
 #### Solaris x86 with GNU C setups
     "solaris-x86-gcc" => {
@@ -368,6 +369,7 @@ my %targets = (
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         shared_ldflag    => "-shared -Wl,-Bsymbolic",
         shared_sonameflag=> "-Wl,-soname,",
+        rpath_flag       => "-rpath ",
     },
     "irix-mips3-gcc" => {
         inherit_from     => [ "irix-common", asm("mips64_asm") ],
@@ -452,6 +454,7 @@ my %targets = (
         bin_lflags       => "-Wl,+s,+cdp,../:,+cdp,./:",
         shared_ldflag    => "-Wl,-B,symbolic,+vnocompatwarnings,-z,+s,+cdp,../:,+cdp,./:",
         shared_sonameflag=> "-Wl,+h,",
+        rpath_flag       => "-Wl,+b,",
     },
     "hpux-parisc-gcc" => {
         inherit_from     => [ "hpux-common" ],
@@ -1121,6 +1124,7 @@ my %targets = (
         dso_extension    => ".so",
         lib_extension    => shared("_a.a"),
         shared_extension_simple => shared(".a"),
+        rpath_flag       => "-Wl,-R,",
     },
     "aix-gcc" => {
         inherit_from     => [ "aix-common", asm("ppc32_asm") ],

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -27,6 +27,7 @@ my %shared_info;
     'gnu-shared' => {
         shared_ldflag         => '-shared -Wl,-Bsymbolic',
         shared_sonameflag     => '-Wl,-soname=',
+        rpath_flag            => '-Wl,-rpath=',
     },
     'linux-shared' => sub {
         return {
@@ -63,6 +64,7 @@ my %shared_info;
         return {
             module_ldflags    => '-shared -Wl,-Bsymbolic',
             shared_ldflag     => '-shared -Wl,-Bsymbolic -set_version $(SHLIB_VERSION_NUMBER)',
+            rpath_flag        => '-rpath ',
         };
     },
     'svr3-shared' => sub {

--- a/Configure
+++ b/Configure
@@ -88,6 +88,8 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 #               the lookup requests. For this reason on Linux statically
 #               linked openssl executable has rather debugging value than
 #               production quality.
+# --run-path    pass target-specific linker option that sets runtime shared
+#               library search path to $(LIBRPATH).
 #
 # DEBUG_SAFESTACK use type-safe stacks to enforce type-safety on stack items
 #		provided to stack calls. Generates unique stack functions for
@@ -845,6 +847,10 @@ while (@argvcopy)
 			$rpath .= " " if $rpath ne "";
 			push @{$useradd{LDFLAGS}}, $_, $rpath;
 			}
+		elsif (/^--run-path$/)
+			{
+			$config{runpath} = 1;
+			}
 		elsif (/^-static$/)
 			{
 			push @{$useradd{LDFLAGS}}, $_;
@@ -956,7 +962,7 @@ foreach (keys %user) {
     }
 }
 
-if (grep { /-rpath\b/ } ($user{LDFLAGS} ? @{$user{LDFLAGS}} : ())
+if ((grep (/-rpath\b/, @{$user{LDFLAGS}}) || $config{runpath})
     && !$disabled{shared}
     && !($disabled{asan} && $disabled{msan} && $disabled{ubsan})) {
     die "***** Cannot simultaneously use -rpath, shared libraries, and\n",
@@ -1463,6 +1469,12 @@ if (!$disabled{asm} && !$predefined{__MACH__} && $^O ne 'VMS') {
         close(PIPE);
         unlink("null.$$.o");
     }
+}
+
+if (!$disabled{shared} && $config{runpath} && $target{rpath_flag}) {
+    die "double runtime path options" if grep($target{rpath_flag},
+                                              @{$useradd{LDFLAGS}});
+    push @{$useradd{LDFLAGS}}, $target{rpath_flag}.'$(LIBRPATH)';
 }
 
 # Deal with bn_ops ###################################################

--- a/NOTES.UNIX
+++ b/NOTES.UNIX
@@ -62,6 +62,9 @@
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
         '-Wl,-rpath,$(LIBRPATH)'
 
+ There is a convenience --run-path option that passes option suitable
+ for target system.
+
  On modern ELF based systems, there are two runtime search paths tags to
  consider, DT_RPATH and DT_RUNPATH.  Shared objects are searched for in
  this order:
@@ -90,6 +93,9 @@
 
     $ ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
         '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
+
+ If you chose to use --run-path option, just pass additional
+ -Wl,--enable-new-dtags.
 
  It might be worth noting that some/most ELF systems implement support
  for runtime search path relative to the directory containing current

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -101,7 +101,7 @@ SunOS|IRIX*)
 	;;
 esac
 
-{- output_off() unless grep (/-rpath\b/, @{$config{LDFLAGS}}); ""; -}
+{- output_off() unless $config{runpath} or grep (/-rpath\b/, @{$config{LDFLAGS}}); ""; -}
 if [ -f "$LIBCRYPTOSO" -a -z "$preload_var" ]; then
 	# Following three lines are major excuse for isolating them into
 	# this wrapper script. Original reason for setting LD_PRELOAD
@@ -117,7 +117,7 @@ if [ -f "$LIBCRYPTOSO" -a -z "$preload_var" ]; then
 	DYLD_INSERT_LIBRARIES="$LIBCRYPTOSO:$LIBSSLSO"	# MacOS X
 	export LD_PRELOAD _RLD_LIST DYLD_INSERT_LIBRARIES
 fi
-{- output_on() unless grep (/-rpath\b/, @{$config{LDFLAGS}}); ""; -}
+{- output_on() unless $config{runpath} or grep (/-rpath\b/, @{$config{LDFLAGS}}); ""; -}
 
 cmd="$1"; [ -x "$cmd" ] || cmd="$cmd${EXE_EXT}"
 shift


### PR DESCRIPTION
--run-path passes platform-specific option that adds installation
location to runtime shared library search path.

Background is in #6500.