### PR TITLE
Don't change a session once its in the cache

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3796,10 +3796,11 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
             cb(s, SSL_CB_HANDSHAKE_START, 1);
         }
         /*
-         * If we already sent one NewSessionTicket then we need to take a copy
-         * of it and create a new session from it.
+         * If we already sent one NewSessionTicket, or we resumed then
+         * s->session may already be in a cache and so we must not modify it.
+         * Instead we need to take a copy of it and modify that.
          */
-        if (s->sent_tickets != 0) {
+        if (s->sent_tickets != 0 || s->hit) {
             SSL_SESSION *new_sess = ssl_session_dup(s->session, 0);
 
             if (new_sess == NULL) {


### PR DESCRIPTION
Sessions should be immutable once they are in the cache because they could
be shared with other threads. If you change them then this can cause
corruptions and races

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
