### PR TITLE
Support directories with "." in x509_load_serial()

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -916,7 +916,7 @@ static ASN1_INTEGER *x509_load_serial(const char *CAfile,
     BIGNUM *serial = NULL;
 
     if (serialfile == NULL) {
-        const char *p = strchr(CAfile, '.');
+        const char *p = strrchr(CAfile, '.');
         size_t len = p != NULL ? (size_t)(p - CAfile) : strlen(CAfile);
 
         buf = app_malloc(len + sizeof(POSTFIX), "serial# buffer");


### PR DESCRIPTION
Use [`strrchr`](https://www.tutorialspoint.com/c_standard_library/c_function_strrchr.htm) to get a pointer to the last occurrence of `.` in the path string, instead of the first one with [`strchr`](https://www.tutorialspoint.com/c_standard_library/c_function_strchr.htm).  This prevent the path to be wrongly split if it contains several `.`, and not only the one for the extension. :bowtie: 

Fixes https://github.com/openssl/openssl/issues/6489