### PR TITLE
Fix a new gcc-9 warning [-Wstringop-truncation]

### DIFF
--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -200,7 +200,7 @@ static int slg_write(BIO *b, const char *in, int inl)
         BIOerr(BIO_F_SLG_WRITE, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    strncpy(buf, in, inl);
+    memcpy(buf, in, inl);
     buf[inl] = '\0';
 
     i = 0;


### PR DESCRIPTION
Recently gcc-9 has improved the -Wstringop-truncation warning to diagnose
the following which breaks the --strict-warnings build:

```
gcc  -I. -Icrypto/include -Iinclude -fPIC -pthread -m64 -Wa,--noexecstack -DDEBUG_UNUSED -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wswitch -Wsign-compare -Wmissing-prototypes -Wstrict-prototypes -Wshadow -Wformat -Wtype-limits -Wundef -Werror -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_CPUID_OBJ -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DKECCAK1600_ASM -DRC4_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DX25519_ASM -DPADLOCK_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib/engines-1.1\"" -DNDEBUG  -MMD -MF crypto/bio/bss_log.d.tmp -MT crypto/bio/bss_log.o -c -o crypto/bio/bss_log.o crypto/bio/bss_log.c
In file included from /usr/include/string.h:635,
                 from /usr/include/x86_64-linux-gnu/sys/un.h:37,
                 from include/internal/sockets.h:78,
                 from crypto/bio/bio_lcl.h:11,
                 from crypto/bio/bss_log.c:22:
In function 'slg_write.constprop',
    inlined from 'slg_puts' at crypto/bio/bss_log.c:236:11:
crypto/bio/bss_log.c:203:5: error: '__builtin_strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
     strncpy(buf, in, inl);
     ^~~~~~~
crypto/bio/bss_log.c: In function 'slg_puts':
crypto/bio/bss_log.c:235:9: note: length computed here
     n = strlen(str);
         ^~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [crypto/bio/bss_log.o] Error 1
```