### PR TITLE
store/loader_file.c: fix char-subscripts warning.

### DIFF
--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -1216,9 +1216,9 @@ static int file_name_check(OSSL_STORE_LOADER_CTX *ctx, const char *name)
      * Last, check that the rest of the extension is a decimal number, at
      * least one digit long.
      */
-    if (!isdigit(*p))
+    if (!ossl_isdigit(*p))
         return 0;
-    while (isdigit(*p))
+    while (ossl_isdigit(*p))
         p++;
 
 # ifdef __VMS
@@ -1227,7 +1227,7 @@ static int file_name_check(OSSL_STORE_LOADER_CTX *ctx, const char *name)
      */
     if (*p == ';')
         for (p++; *p != '\0'; p++)
-            if (!isdigit(*p))
+            if (!ossl_isdigit(*p))
                 break;
 # endif
 


### PR DESCRIPTION
This happens on systems that perform is* character classifictions as
array lookup, e.g. NetBSD.
