### PR TITLE
Fix some more gcc-9 warnings [-Wstringop-truncation]

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -306,9 +306,9 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
     out_buf[0] = '$';
     out_buf[1] = 0;
     assert(strlen(magic) <= 4); /* "1" or "apr1" */
-    strncat(out_buf, magic, 4);
-    strncat(out_buf, "$", 1);
-    strncat(out_buf, salt, 8);
+    BUF_strlcat(out_buf, magic, sizeof(out_buf));
+    BUF_strlcat(out_buf, "$", sizeof(out_buf));
+    BUF_strlcat(out_buf, salt, sizeof(out_buf));
     assert(strlen(out_buf) <= 6 + 8); /* "$apr1$..salt.." */
     salt_out = out_buf + 2 + strlen(magic);
     salt_len = strlen(salt_out);

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -1959,11 +1959,12 @@ int ssl3_send_server_key_exchange(SSL *s)
 
 #ifndef OPENSSL_NO_PSK
         if (type & SSL_kPSK) {
+            size_t len = strlen(s->ctx->psk_identity_hint);
+
             /* copy PSK identity hint */
-            s2n(strlen(s->ctx->psk_identity_hint), p);
-            strncpy((char *)p, s->ctx->psk_identity_hint,
-                    strlen(s->ctx->psk_identity_hint));
-            p += strlen(s->ctx->psk_identity_hint);
+            s2n(len, p);
+            memcpy(p, s->ctx->psk_identity_hint, len);
+            p += len;
         }
 #endif
 


### PR DESCRIPTION
A few more instances of -Wstringop-truncation for 1.0.2 branch:

```
gcc -I../crypto -I.. -I../include  -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -Wa,--noexecstack -m64 -DL_ENDIAN -O3 -Wall -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DRC4_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DWHIRLPOOL_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -pedantic -DPEDANTIC -Wno-long-long -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wundef -Werror -DCRYPTO_MDEBUG_ALL -DCRYPTO_MDEBUG_ABORT -DREF_CHECK -DOPENSSL_NO_DEPRECATED   -c -o s3_srvr.o s3_srvr.c
In file included from /usr/include/string.h:630,
                 from ssl_locl.h:147,
                 from s3_srvr.c:155:
s3_srvr.c: In function 'ssl3_send_server_key_exchange':
s3_srvr.c:1964:13: error: '__builtin_strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
             strncpy((char *)p, s->ctx->psk_identity_hint,
             ^~~~~~~
s3_srvr.c:1964:13: note: length computed here
cc1: all warnings being treated as errors
gcc -DMONOLITH -I.. -I../include  -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -Wa,--noexecstack -m64 -DL_ENDIAN -O3 -Wall -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DRC4_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DWHIRLPOOL_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -pedantic -DPEDANTIC -Wno-long-long -Wsign-compare -Wmissing-prototypes -Wshadow -Wformat -Wundef -Werror -DCRYPTO_MDEBUG_ALL -DCRYPTO_MDEBUG_ABORT -DREF_CHECK -DOPENSSL_NO_DEPRECATED   -c -o passwd.o passwd.c
In file included from /usr/include/string.h:630,
                 from passwd.c:10:
In function 'md5crypt',
    inlined from 'do_passwd' at passwd.c:472:16:
passwd.c:309:5: error: '__builtin_strncat' output may be truncated copying 4 bytes from a string of length 4 [-Werror=stringop-truncation]
     strncat(out_buf, magic, 4);
     ^~~~~~~
cc1: all warnings being treated as errors
```