### PR TITLE
OpenSSL_add_ssl_algorithm-is-deprecated() is deprecated, make it so

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1079,8 +1079,8 @@ size_t SSL_get_peer_finished(const SSL *s, void *buf, size_t count);
 # define SSL_VERIFY_CLIENT_ONCE          0x04
 # define SSL_VERIFY_POST_HANDSHAKE       0x08
 
-# define OpenSSL_add_ssl_algorithms()    SSL_library_init()
 # if OPENSSL_API_COMPAT < 0x10100000L
+#  define OpenSSL_add_ssl_algorithms()   SSL_library_init()
 #  define SSLeay_add_ssl_algorithms()    SSL_library_init()
 # endif
 


### PR DESCRIPTION
This function is documented to be deprecated since OpenSSL 1.1.0.  We
need to make it so in openssl/ssl.h as well.

Fixes #6565
