### PR TITLE
crypto/o_fopen.c: alias fopen to fopen64.

### DIFF
--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -7,6 +7,24 @@
  * https://www.openssl.org/source/license.html
  */
 
+# if defined(__linux) || defined(__sun) || defined(__hpux)
+/*
+ * Following definition aliases fopen to fopen64 on above mentioned
+ * platforms. This makes it possible to open and sequentially access files
+ * larger than 2GB from 32-bit application. It does not allow to traverse
+ * them beyond 2GB with fseek/ftell, but on the other hand *no* 32-bit
+ * platform permits that, not with fseek/ftell. Not to mention that breaking
+ * 2GB limit for seeking would require surgery to *our* API. But sequential
+ * access suffices for practical cases when you can run into large files,
+ * such as fingerprinting, so we can let API alone. For reference, the list
+ * of 32-bit platforms which allow for sequential access of large files
+ * without extra "magic" comprise *BSD, Darwin, IRIX...
+ */
+#  ifndef _FILE_OFFSET_BITS
+#   define _FILE_OFFSET_BITS 64
+#  endif
+# endif
+
 #include "internal/cryptlib.h"
 
 #if !defined(OPENSSL_NO_STDIO)


### PR DESCRIPTION
Originally fopen(3) was called from bio/bss_file.c, which performed the
aliasing. Then fopen(3) was moved to o_fopen.c, while "magic" definition
was left behind. It's still useful on 32-bit platforms, so pull it to
o_fopen.c.
