### PR TITLE
[test/recipes] more EVP ECC testing: positive and negative

### DIFF
--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT data_file/;
 setup("test_evp");
 
 my @files = ( "evpciph.txt", "evpdigest.txt", "evpencod.txt", "evpkdf.txt",
-    "evpmac.txt", "evppbe.txt", "evppkey.txt" );
+    "evpmac.txt", "evppbe.txt", "evppkey.txt", "evppkey_ecc.txt" );
 
 plan tests => scalar(@files);
 

--- a/test/recipes/30-test_evp_data/evppkey_ecc.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecc.txt
@@ -1,0 +1,4366 @@
+Title=brainpoolP160r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP160r1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEBBBswGQIBAQQUo0UiM85512uHsr2DkIOYgyxSQxk=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP160r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEIwFAYHKoZIzj0CAQYJKyQDAwIIAQEBAyoABI7OZhLqr+8c3D9Tn6++CqQtc9jG5a1COb1okeZb
+wKJUkmWn6NvNCQQ=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP160r1:ALICE_cf_brainpoolP160r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP160r1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEBBBswGQIBAQQUmr0Vq3Z/feXq9tg9s8dxJXne1dU=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP160r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEIwFAYHKoZIzj0CAQYJKyQDAwIIAQEBAyoABAu+ovBXBFQuw3Rt9qeImT6mLh9rerLFnTRL0+LH
+sptS1Mbd0R4+5HM=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP160r1:BOB_cf_brainpoolP160r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP160r1
+PeerKey=BOB_cf_brainpoolP160r1_PUB
+SharedSecret=2e75cb6a8f13951b437e04a0ed1d714a610036cc
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP160r1
+PeerKey=ALICE_cf_brainpoolP160r1_PUB
+SharedSecret=2e75cb6a8f13951b437e04a0ed1d714a610036cc
+
+Title=brainpoolP160t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP160t1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQECBBswGQIBAQQU1P/o5GQx5PA0kQoiwUtaXBUASUY=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP160t1_PUB
+-----BEGIN PUBLIC KEY-----
+MEIwFAYHKoZIzj0CAQYJKyQDAwIIAQECAyoABANetsUNsxVmDo7X4LQ9yPYTcjN1HvLTo9GEEQtV
+lG71NyzLPQwPDwM=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP160t1:ALICE_cf_brainpoolP160t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP160t1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQECBBswGQIBAQQUck4Sh9X3JjSUIRoxxKv8qLM6Ijc=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP160t1_PUB
+-----BEGIN PUBLIC KEY-----
+MEIwFAYHKoZIzj0CAQYJKyQDAwIIAQECAyoABEtd7DRUMYXeoxhxpWgPz/esQkXtoTAAune8CAAo
+HqNNlR11VDctfkw=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP160t1:BOB_cf_brainpoolP160t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP160t1
+PeerKey=BOB_cf_brainpoolP160t1_PUB
+SharedSecret=6ea603a6a1a83812b967c83ef1867bd807be761e
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP160t1
+PeerKey=ALICE_cf_brainpoolP160t1_PUB
+SharedSecret=6ea603a6a1a83812b967c83ef1867bd807be761e
+
+Title=brainpoolP192r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP192r1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEDBB8wHQIBAQQYlF5JxzV9Doezn3hLoiidvy5TnIA7
+aR+j
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP192r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEowFAYHKoZIzj0CAQYJKyQDAwIIAQEDAzIABELUMqBZrH66DIJ1a3a42k86THdH1DevigK0dc57
+8XEZ3HcuSQ+ycrMmit1PUQItbg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP192r1:ALICE_cf_brainpoolP192r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP192r1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEDBB8wHQIBAQQYjdu95CL1DQMGpsOmsfYOAjF5cW99
+bQie
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP192r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEowFAYHKoZIzj0CAQYJKyQDAwIIAQEDAzIABInqyC1mAfyF7LU5tX/dRF5S/S9uPlQjNAhTRP6/
+/kAbKsXmABQXFeM0+P3hMw4UxQ==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP192r1:BOB_cf_brainpoolP192r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP192r1
+PeerKey=BOB_cf_brainpoolP192r1_PUB
+SharedSecret=2b34396d02a40df0b9f8f9c0b8623be05b41249fbd69e02a
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP192r1
+PeerKey=ALICE_cf_brainpoolP192r1_PUB
+SharedSecret=2b34396d02a40df0b9f8f9c0b8623be05b41249fbd69e02a
+
+Title=brainpoolP192t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP192t1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEEBB8wHQIBAQQYKkFNgJ5sJKNIyYPK1h+gdPw04bxa
+zIV7
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP192t1_PUB
+-----BEGIN PUBLIC KEY-----
+MEowFAYHKoZIzj0CAQYJKyQDAwIIAQEEAzIABAzDb+niXBQFn9f0zXf8z+kfdBIYTws8FSfdWFdU
+NGo4haY9+fL8D40kNNShgBnlKw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP192t1:ALICE_cf_brainpoolP192t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP192t1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEEBB8wHQIBAQQYFpxTrRJBEpyCePM20Fmw0uYPoxTm
+T/sq
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP192t1_PUB
+-----BEGIN PUBLIC KEY-----
+MEowFAYHKoZIzj0CAQYJKyQDAwIIAQEEAzIABC6CPE1t5PwHpXSS1u4R0JTs1IeDW8hiqarIn3pM
+I9wh+oCRjVcqvB4WDaql1bHCYg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP192t1:BOB_cf_brainpoolP192t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP192t1
+PeerKey=BOB_cf_brainpoolP192t1_PUB
+SharedSecret=84049068441a342d7c2951ff159cdc9d05c4bddf2a6e6309
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP192t1
+PeerKey=ALICE_cf_brainpoolP192t1_PUB
+SharedSecret=84049068441a342d7c2951ff159cdc9d05c4bddf2a6e6309
+
+Title=brainpoolP224r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP224r1
+-----BEGIN PRIVATE KEY-----
+MD4CAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEFBCMwIQIBAQQcHhlSkNTFJbZSy79CADDwo855nH2+
+cWxwSl6BpQ==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP224r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABBF4+KObaB0yJTPHPrCN6EOnr5M8zKb5CHa7SSyL
+4L9nRjgA8TfoU03LQsrtE9beREkxK3EHc25Z
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP224r1:ALICE_cf_brainpoolP224r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP224r1
+-----BEGIN PRIVATE KEY-----
+MD4CAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEFBCMwIQIBAQQczslMgGENRTriMWvDfGrM/ilLpzy0
+Js79UiVzLA==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP224r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABIGGu4+PPMwOihplm2tLO7dLcDqXZB1MQHloOU8a
+taeDvYHIck4z08+1DATvPqpIDzyn9WtXRqmG
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP224r1:BOB_cf_brainpoolP224r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP224r1
+PeerKey=BOB_cf_brainpoolP224r1_PUB
+SharedSecret=477240c0587dea6aecfcac5a154d7ba3a5d4eb1ab30a69012d4401de
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP224r1
+PeerKey=ALICE_cf_brainpoolP224r1_PUB
+SharedSecret=477240c0587dea6aecfcac5a154d7ba3a5d4eb1ab30a69012d4401de
+
+Title=brainpoolP224t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP224t1
+-----BEGIN PRIVATE KEY-----
+MD4CAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEGBCMwIQIBAQQca9rhmcgHV6etILVB9ccK2jIFXw4N
+YrvlljcGFw==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP224t1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEGAzoABHA9XoULjM967710RPgT1ICW0b+y9pFpm2yCUq2m
+kSiy/JZvuWXhTJ+KmXGnAOTIlyiOUG8tZm39
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP224t1:ALICE_cf_brainpoolP224t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP224t1
+-----BEGIN PRIVATE KEY-----
+MD4CAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEGBCMwIQIBAQQcFaiqaheY0xBo5lUY8hOXMUICdOAu
+NWP/Uw3l+Q==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP224t1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEGAzoABLvPkrvyCeS/QdTX5D/AFfF0lTuPpXhSRPKocViS
+nUIZAEziCuOsgx+BqAOxNg+CN/tNzHsG1srf
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP224t1:BOB_cf_brainpoolP224t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP224t1
+PeerKey=BOB_cf_brainpoolP224t1_PUB
+SharedSecret=2c8dd0dbf3a62a202150e12443461d348be57bc58db0f2f7d8938933
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP224t1
+PeerKey=ALICE_cf_brainpoolP224t1_PUB
+SharedSecret=2c8dd0dbf3a62a202150e12443461d348be57bc58db0f2f7d8938933
+
+Title=brainpoolP256r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP256r1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEHBCcwJQIBAQQgcH7I5THTXm+bu+vwtyNt+XBxk/uJ
+R5V/zzRyMoXjuek=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP256r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABDFYVAzLX03nHXeFY7aJspsp525bbgzfnT68kJXB
+HhChZmPaa5BAV5Cn4DXJ5HQ5N/V8Z8Dz0aux0SWtl6ctENM=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP256r1:ALICE_cf_brainpoolP256r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP256r1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEHBCcwJQIBAQQgDEj/wLk/4z4Wcv8rOc9lNnRQ6hpr
+XfiuUSRqgedZkRU=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP256r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABHJdRWXtaxwI0AdvDXEk+a6XuQp72Zi+wxCrxFFW
+NgJbmH0yr4jDklp4oiC2UHkapvT6XanGMKFo2ZSziltas0A=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP256r1:BOB_cf_brainpoolP256r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP256r1
+PeerKey=BOB_cf_brainpoolP256r1_PUB
+SharedSecret=2fdd9d97efdcba3f5b181df53331db0ee42a3b1072147325ce8521dbaeafc3e4
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP256r1
+PeerKey=ALICE_cf_brainpoolP256r1_PUB
+SharedSecret=2fdd9d97efdcba3f5b181df53331db0ee42a3b1072147325ce8521dbaeafc3e4
+
+Title=brainpoolP256t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP256t1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEIBCcwJQIBAQQgBDlYKiUEsm+tEN/DDQBhlWKJhF4J
+We+4fqVSaPNT3VY=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP256t1_PUB
+-----BEGIN PUBLIC KEY-----
+MFowFAYHKoZIzj0CAQYJKyQDAwIIAQEIA0IABE6XKfvmlGKrXKN/FHhW9cMThPFUIq6Au3cCujPI
+rHejQQJnsz9mSRBtzRkMM1abUc4Mf9xhkWbrT+QuJ3FcLWI=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP256t1:ALICE_cf_brainpoolP256t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP256t1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEIBCcwJQIBAQQgDUCTqTrVwouIU3hFoO3hwiME17PF
+X7ntzOWKS2ebqGs=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP256t1_PUB
+-----BEGIN PUBLIC KEY-----
+MFowFAYHKoZIzj0CAQYJKyQDAwIIAQEIA0IABBwxGpomQmgqgsUYHmpYt3qGKRVT/pJfyU+lpLXi
+/XAibEp/IvX3oFMEolSoy39poO6Zkq6npAniBqer+bS9Jpw=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP256t1:BOB_cf_brainpoolP256t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP256t1
+PeerKey=BOB_cf_brainpoolP256t1_PUB
+SharedSecret=7f177af329a4b377aea6e80bddf14f09c17c4fe81598703898fb62c929cbff04
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP256t1
+PeerKey=ALICE_cf_brainpoolP256t1_PUB
+SharedSecret=7f177af329a4b377aea6e80bddf14f09c17c4fe81598703898fb62c929cbff04
+
+Title=brainpoolP320r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP320r1
+-----BEGIN PRIVATE KEY-----
+MEoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEJBC8wLQIBAQQophG1zB+U2lRdetiZlk9C4+q7APJ9
+xqGQ0+GPq68+WmyZon1lDRQ5/g==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP320r1_PUB
+-----BEGIN PUBLIC KEY-----
+MGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABM9TaT9Q2j+VTlQ1pfcXx9SjlU1fEk0RvEbaY1O8
+pq8OgkQeulcgSXiI1rJI0wjV/qJoi0coZUHhsJ7bXmdO8vSTdgCMbavZScCkN6iFsALm
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP320r1:ALICE_cf_brainpoolP320r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP320r1
+-----BEGIN PRIVATE KEY-----
+MEoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEJBC8wLQIBAQQoO6MtFhs8dwul0iRbyfssxtFF6Ubt
+q2oHlzvkFL5q4uLSY7pRcDz4vw==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP320r1_PUB
+-----BEGIN PUBLIC KEY-----
+MGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABM50yDpoBMhirlHQqjMmVj/KZR0dfvmudoDt02qY
+3lKei94evfTHmPG/9BjMYQGQcRM4CDGHR0iUIUJa99e/rxj9IguPkkNiAmDZQaKsqmKB
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP320r1:BOB_cf_brainpoolP320r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP320r1
+PeerKey=BOB_cf_brainpoolP320r1_PUB
+SharedSecret=4ee386c231d0a7c9bb6dc05362f56ca70bf7ba5dcb66d8c4574c0497fdab6a5b79818a64ff5dc87e
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP320r1
+PeerKey=ALICE_cf_brainpoolP320r1_PUB
+SharedSecret=4ee386c231d0a7c9bb6dc05362f56ca70bf7ba5dcb66d8c4574c0497fdab6a5b79818a64ff5dc87e
+
+Title=brainpoolP320t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP320t1
+-----BEGIN PRIVATE KEY-----
+MEoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEKBC8wLQIBAQQoMsI2lsl5Sj0I4A3J0I5XStMSLT4P
+hMxwrbFdtKQh+At6RN2s12W4Kg==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP320t1_PUB
+-----BEGIN PUBLIC KEY-----
+MGowFAYHKoZIzj0CAQYJKyQDAwIIAQEKA1IABAvtZgehjOIdjsYKMcK08LaS8zVb6znYb6Qa9Fzf
+LhLUSH5S728KJHWXMh7RqZMI3yTC5I0ESqB0CvG5N0hR+3y8L3eQJisCNdnzAgMyy0ab
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP320t1:ALICE_cf_brainpoolP320t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP320t1
+-----BEGIN PRIVATE KEY-----
+MEoCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEKBC8wLQIBAQQoNtZiGbwSl0NNHBmTaJKf7/VMqZjo
+yWavjg6CPa6ZgpKRR7vIQt5d9Q==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP320t1_PUB
+-----BEGIN PUBLIC KEY-----
+MGowFAYHKoZIzj0CAQYJKyQDAwIIAQEKA1IABHlS/OtqhHctabDCsDexScvQ2DGXhBuypaEeKOUq
+vbLUovatBoreEj1j5YrOl9mKpd9Hj6YqYGWH+7KKjua+5DBn9rlxlmmkst+gb+vm3UE/
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP320t1:BOB_cf_brainpoolP320t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP320t1
+PeerKey=BOB_cf_brainpoolP320t1_PUB
+SharedSecret=079d62bad81ceeab9f213818faf249f7b29b87a81b56a33b774b2631860f90a25f5377da504cb619
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP320t1
+PeerKey=ALICE_cf_brainpoolP320t1_PUB
+SharedSecret=079d62bad81ceeab9f213818faf249f7b29b87a81b56a33b774b2631860f90a25f5377da504cb619
+
+Title=brainpoolP384r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP384r1
+-----BEGIN PRIVATE KEY-----
+MFICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQELBDcwNQIBAQQwUW3EKrK8Rr80Jn5wwvTLC+HDTApA
+ndycbRYiQkew7SgijhNO+cV0pE0sNpMZY+Wo
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP384r1_PUB
+-----BEGIN PUBLIC KEY-----
+MHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABBvE/fg0tIrsrIiAL07MlREd5zYk52mW7oQ+jPky
+PmGeUoZq1LtpEzQCE1uuruOuyQH1M2c7flVA8Gh3IbSCupwVBCR2QObolwk1w5qK/l/KR26tMeXI
+qL2Sy85NCUpMDw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP384r1:ALICE_cf_brainpoolP384r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP384r1
+-----BEGIN PRIVATE KEY-----
+MFICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQELBDcwNQIBAQQwdG7bSygpM2GpxDPAb4hOTtFZrP2n
+qbyf7v3jFe8/ERpzREPcSntkNDyu/iAsmQKj
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP384r1_PUB
+-----BEGIN PUBLIC KEY-----
+MHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABIIxQfeqZ+uWNKAwZtxAt4ieZW7lCg7Bezpn1dG/
+VDvy/Dd5YpAuDtVxFCLfCUVH+gXfC2wUpWj8j8lgPhP1wBat/hu/PN/AQPg9C/J2EcQRVQXwyZvQ
+PzgiZeo1aWw2+w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP384r1:BOB_cf_brainpoolP384r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP384r1
+PeerKey=BOB_cf_brainpoolP384r1_PUB
+SharedSecret=35e9a3f86a38888d183cc343801dcdaecb664d5b37f7fbc0459fd4612da6b29831bd2d8e5b599376ca510fcc3ac78be6
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP384r1
+PeerKey=ALICE_cf_brainpoolP384r1_PUB
+SharedSecret=35e9a3f86a38888d183cc343801dcdaecb664d5b37f7fbc0459fd4612da6b29831bd2d8e5b599376ca510fcc3ac78be6
+
+Title=brainpoolP384t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP384t1
+-----BEGIN PRIVATE KEY-----
+MFICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEMBDcwNQIBAQQwGyCfuKlQDK4EflGVc01hBKW+OB/L
+ojNz6kgnAWMuWoCyOM8SOkSTbOCimaVqZrlq
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP384t1_PUB
+-----BEGIN PUBLIC KEY-----
+MHowFAYHKoZIzj0CAQYJKyQDAwIIAQEMA2IABE1O0qNzgozAxaQC7qX2wS+HNfKIAMc7eX4G4Z0w
+M30kgGyCn4CtWCBFgG15laf6OnYcdJgC8284B2smZiqHuvssw12SZwOlaXoLGyIsqygTitCO3Ebd
+k2dmuYdWzxj5/g==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP384t1:ALICE_cf_brainpoolP384t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP384t1
+-----BEGIN PRIVATE KEY-----
+MFICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEMBDcwNQIBAQQwbpabbL6g9HZUZ4VusnNGHsHujUsA
+cDuviAZTBaHWJsCd5jA64hVFZXlZ9Jj/nSLs
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP384t1_PUB
+-----BEGIN PUBLIC KEY-----
+MHowFAYHKoZIzj0CAQYJKyQDAwIIAQEMA2IABAyawWqAcNlcwOauu2b93XXqpZQeRM26AYcDcHIf
+tZahQrwFpLgt6Tn7tzA2CgRGvSvBGZTxkzuHasxJn+dBDGLraias3U/sLD3P4TQuP9v8cO6i7g4x
+T+DZbNUQQ3ePDQ==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP384t1:BOB_cf_brainpoolP384t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP384t1
+PeerKey=BOB_cf_brainpoolP384t1_PUB
+SharedSecret=030113dd1662230f1e47418c3044a0852dcd74fa508dbabb02d1fe5d788aa49d8047d02a802f796af21473ab17f6f85f
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP384t1
+PeerKey=ALICE_cf_brainpoolP384t1_PUB
+SharedSecret=030113dd1662230f1e47418c3044a0852dcd74fa508dbabb02d1fe5d788aa49d8047d02a802f796af21473ab17f6f85f
+
+Title=brainpoolP512r1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP512r1
+-----BEGIN PRIVATE KEY-----
+MGICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQENBEcwRQIBAQRAagAsEAU5t/T4yI0MvyTWuPcrQfaa
+1xZr99hRfeY7+pDV4yooxTIXUESqk/dBQlFSrVUkdvMQHq/8vm5V/w97LQ==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP512r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEJLmN88iMClNBtyLHzmSgIE9d+v/GRtBr1+r+
+Wvz5XOwsiHWWFTRO5Um+3HUVZH+S3nky6n/3Yjn4DFA4lhxV+y40g8p+kkXYKwpXTByQhERcPPPS
+wKh/S7Y3k3KSLkphjiBExzlBcj9r3gLww9+0nVer/fnUgRz7YwWldv4PR2E=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP512r1:ALICE_cf_brainpoolP512r1_PUB
+
+PrivateKey=BOB_cf_brainpoolP512r1
+-----BEGIN PRIVATE KEY-----
+MGICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQENBEcwRQIBAQRAgHKjBCUMVJTF41vKv+Lp2xVz6bsF
+P1Aqc+2ehlxlEoYL4H8CbUBh89F1QPjGjIOLEebJcN/KnnpyRGVdx4UV2g==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP512r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAElWuk6uPxVgBSLSK9Zfqbid/ipXbIFKVaetCI
+YsYOdzkbjGIWLd2MFZIjZ9r7ePEcHXqQiwGvW+8itGM/xwLpA4qZ2QYazqtAbT187d5cdyZf4PQT
+/kv/ZTvXTl7xHDtaujQ1re00Z3liEKgKstI80BkA6eA4Jfy4G2F7CX/WuSQ=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP512r1:BOB_cf_brainpoolP512r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP512r1
+PeerKey=BOB_cf_brainpoolP512r1_PUB
+SharedSecret=84269a8f2932b7e09b23deabaeab26eda6bbdee8846153b0c62b7d2663506a9e71d32cf0cc127ec130f6880612f4e054bc79adb57ddbee97949508ce1eda0bb1
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP512r1
+PeerKey=ALICE_cf_brainpoolP512r1_PUB
+SharedSecret=84269a8f2932b7e09b23deabaeab26eda6bbdee8846153b0c62b7d2663506a9e71d32cf0cc127ec130f6880612f4e054bc79adb57ddbee97949508ce1eda0bb1
+
+Title=brainpoolP512t1 curve tests
+
+PrivateKey=ALICE_cf_brainpoolP512t1
+-----BEGIN PRIVATE KEY-----
+MGICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEOBEcwRQIBAQRAd92o2JLX5lk2v6fGr1pH5TT8KUKR
+6FaCm6CRk0dC/xK6h0rpONjx+37VuH3uS+HoRlru83maSoeHQneWCc32XA==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_brainpoolP512t1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGbMBQGByqGSM49AgEGCSskAwMCCAEBDgOBggAEob+TJkhNP6D+HoQtlWcLITI3MM25Axi++awv
+HnMoclRLLur7CjQsKd0v6aEzmG2+4WZSZFGLA9L8Z5sh9L916p5CD5nk1pNfy5QKNi2H5R3QC/oc
+RfNNxhXdVVekfTaAiqhe8UF3aMngmDAc7sq794DVZvCf1sqq8v5cHrnqRcQ=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_brainpoolP512t1:ALICE_cf_brainpoolP512t1_PUB
+
+PrivateKey=BOB_cf_brainpoolP512t1
+-----BEGIN PRIVATE KEY-----
+MGICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEOBEcwRQIBAQRAVW4ZQKgDeHAkubwYYlp2JKklrbpp
+gvez/prOdyHJXJbVriU4lCH/MpH2I+nXjaZ9zLcl9JbnrUOJ6xGPHfZJrw==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_brainpoolP512t1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGbMBQGByqGSM49AgEGCSskAwMCCAEBDgOBggAEJbQFKxq27CuY7/mgNwEnH3GSYGXy9s6n48qq
+gbMrp5uREi8JXZ+BuLQmzZuF15ZPOOmh+EJFjbD8i9NDiUkYLnm1oy/EuE1f5VUNoXFeFFIa21vZ
+2kzPYYKYyUNOdG8p/s4rPBFyCMf6Tizt0D4XA4oLptKUUIX2SC1Sd+qakKA=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_brainpoolP512t1:BOB_cf_brainpoolP512t1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_brainpoolP512t1
+PeerKey=BOB_cf_brainpoolP512t1_PUB
+SharedSecret=48bc4ebdb9a88ca38bed58f5e547eb11d803fd01b6eadff1761ecb48c54525cba43bdb0ee4a4d7aa6701985e0bc12fd32382c035d80acc7ec26adfcb108a07cb
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_brainpoolP512t1
+PeerKey=ALICE_cf_brainpoolP512t1_PUB
+SharedSecret=48bc4ebdb9a88ca38bed58f5e547eb11d803fd01b6eadff1761ecb48c54525cba43bdb0ee4a4d7aa6701985e0bc12fd32382c035d80acc7ec26adfcb108a07cb
+
+Title=c2pnb163v1 curve tests
+
+PrivateKey=ALICE_cf_c2pnb163v1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAEEHDAaAgEBBBUD1JfG8cLNP9418YW+hVhriqH6O5Y=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb163v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAEDLAAEBXgoOgVlWTLQnrQZXgQuSBcIS3bQAlXQ+yJhS03B
+4G8rKQXbrc0mvWsF
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb163v1:ALICE_cf_c2pnb163v1_PUB
+
+PrivateKey=BOB_cf_c2pnb163v1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAEEHDAaAgEBBBUAc3EaoMmMORTzQhMkhPIXY+/jUSI=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb163v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAEDLAAEBn9J0jo39aFVZqhBsAKZ6bViAu6zBC8WaFGExnpZ
+KuBh8tP8VSTHPCHF
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb163v1:BOB_cf_c2pnb163v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb163v1
+PeerKey=BOB_cf_c2pnb163v1_PUB
+SharedSecret=065dd38fb6de7f394778e1bf65d840a2c0e7219acd
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb163v1
+PeerKey=ALICE_cf_c2pnb163v1_PUB
+SharedSecret=065dd38fb6de7f394778e1bf65d840a2c0e7219acd
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb163v1
+PeerKey=BOB_cf_c2pnb163v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=066fc46e8cc4327634dd127748020f2de6aab67585
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb163v1
+PeerKey=ALICE_cf_c2pnb163v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=066fc46e8cc4327634dd127748020f2de6aab67585
+
+PublicKey=MALICE_cf_c2pnb163v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAEDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC8JxepS05nN
+/piKdhDD3dDKXUih
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb163v1
+PeerKey=MALICE_cf_c2pnb163v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb163v1
+PeerKey=MALICE_cf_c2pnb163v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb163v2 curve tests
+
+PrivateKey=ALICE_cf_c2pnb163v2
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAIEHDAaAgEBBBUA4KFv7c1dygtVbdp/g2z2TqLAHkI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb163v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAIDLAAEAVnlL7lMBaASwCIJaf9x2LgNPVmEAb43huHQlo3Q
+4PzawHXQoYm/qgDd
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb163v2:ALICE_cf_c2pnb163v2_PUB
+
+PrivateKey=BOB_cf_c2pnb163v2
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAIEHDAaAgEBBBUCEdYqClRWIl2m+X34e+DB2iZSxmQ=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb163v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAIDLAAEAVWNIKn7/WMfzuNnd5ws9J0DI2CfBkEJizZHAFqy
+kBF3juAQuARgxuT6
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb163v2:BOB_cf_c2pnb163v2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb163v2
+PeerKey=BOB_cf_c2pnb163v2_PUB
+SharedSecret=0078ebb986d4f9b0aa0bc4af99e82c2bd24130f3f4
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb163v2
+PeerKey=ALICE_cf_c2pnb163v2_PUB
+SharedSecret=0078ebb986d4f9b0aa0bc4af99e82c2bd24130f3f4
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb163v2
+PeerKey=BOB_cf_c2pnb163v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=069a80bcd45987fd1c874cd9dc5453207a09b61d41
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb163v2
+PeerKey=ALICE_cf_c2pnb163v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=069a80bcd45987fd1c874cd9dc5453207a09b61d41
+
+PublicKey=MALICE_cf_c2pnb163v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAIDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAABuVBl1V5uysY
+n6HANPEoMoK+7Sv0
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb163v2
+PeerKey=MALICE_cf_c2pnb163v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb163v2
+PeerKey=MALICE_cf_c2pnb163v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb163v3 curve tests
+
+PrivateKey=ALICE_cf_c2pnb163v3
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAMEHDAaAgEBBBUBItB0y/QeJ+cCh9yoHf0zqLVyMZc=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb163v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAMDLAAEBx1HRyjuBMjt+vlbWaQbKOpNvWKFAslzEbPv6MpK
+YnObLnq34LRuWznb
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb163v3:ALICE_cf_c2pnb163v3_PUB
+
+PrivateKey=BOB_cf_c2pnb163v3
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAMEHDAaAgEBBBUAXVHUHeP8Ioz7IqXOWbjaUXEHE5M=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb163v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAMDLAAEAqXF7rsAZ40Z1PT4TeeC45RKTxP4AJBAdfuknJ/J
+DZnBLhxBwtqnfUpA
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb163v3:BOB_cf_c2pnb163v3_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb163v3
+PeerKey=BOB_cf_c2pnb163v3_PUB
+SharedSecret=07fd2ffe9b18973c51caeadbc2154b97a9a0390be9
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb163v3
+PeerKey=ALICE_cf_c2pnb163v3_PUB
+SharedSecret=07fd2ffe9b18973c51caeadbc2154b97a9a0390be9
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb163v3
+PeerKey=BOB_cf_c2pnb163v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=06f7daf1c963594e1a13f9f17b62aaab2934872c16
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb163v3
+PeerKey=ALICE_cf_c2pnb163v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=06f7daf1c963594e1a13f9f17b62aaab2934872c16
+
+PublicKey=MALICE_cf_c2pnb163v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEMwEwYHKoZIzj0CAQYIKoZIzj0DAAMDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7jRlUg9oaLK
+LwAuHF8g5Y0JjJnI
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb163v3
+PeerKey=MALICE_cf_c2pnb163v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb163v3
+PeerKey=MALICE_cf_c2pnb163v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb176v1 curve tests
+
+PrivateKey=ALICE_cf_c2pnb176v1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAQEHDAaAgEBBBUAaZ1jV1jM9meV5iiNGPU/WMSfWOM=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb176v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEUwEwYHKoZIzj0CAQYIKoZIzj0DAAQDLgAEPjME7IV6Tuz2P++wIT60hRxTkk0M0PNgvqYcUoCI
+iw3girDLhNzOu3IQ8Ac=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb176v1:ALICE_cf_c2pnb176v1_PUB
+
+PrivateKey=BOB_cf_c2pnb176v1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAQEHDAaAgEBBBUAreyYbcF+ONIf64KmeSzV82OI/50=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb176v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEUwEwYHKoZIzj0CAQYIKoZIzj0DAAQDLgAEpJn1IDmFj5LceLGfY2wlhI1VHq5vJ+qNIAOXVZhX
+uMtp6pzy63rCEK53bgs=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb176v1:BOB_cf_c2pnb176v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb176v1
+PeerKey=BOB_cf_c2pnb176v1_PUB
+SharedSecret=3a8021848ee0b2c1c377404267a515225781c181e6ab
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb176v1
+PeerKey=ALICE_cf_c2pnb176v1_PUB
+SharedSecret=3a8021848ee0b2c1c377404267a515225781c181e6ab
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb176v1
+PeerKey=BOB_cf_c2pnb176v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=b06cdc633b56e813d63326c69d2cfa335352279540ac
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb176v1
+PeerKey=ALICE_cf_c2pnb176v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=b06cdc633b56e813d63326c69d2cfa335352279540ac
+
+PublicKey=MALICE_cf_c2pnb176v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEUwEwYHKoZIzj0CAQYIKoZIzj0DAAQDLgAE4ePri2opCoAUJIUQnaQlvDaxZd9bsdKnjWSvh+FL
+zXV3l5j8K3pow+GJBE4=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb176v1
+PeerKey=MALICE_cf_c2pnb176v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb176v1
+PeerKey=MALICE_cf_c2pnb176v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb208w1 curve tests
+
+PrivateKey=ALICE_cf_c2pnb208w1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAoEIDAeAgEBBBkAiENroXMYNbK/7DQQwCpbXk00gnVd
+XF2k
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb208w1_PUB
+-----BEGIN PUBLIC KEY-----
+ME0wEwYHKoZIzj0CAQYIKoZIzj0DAAoDNgAEL+IHOL2IfeLRiE6Wqsc0Frqjq7t/JnBmhN1lMB9Y
+Yj3+Btcne4CPWf8KvfGjAdMs6JKP4A==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb208w1:ALICE_cf_c2pnb208w1_PUB
+
+PrivateKey=BOB_cf_c2pnb208w1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAoEIDAeAgEBBBkAY1GZLynO/IDWwOOjEWUE7k+I/MkP
+cJot
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb208w1_PUB
+-----BEGIN PUBLIC KEY-----
+ME0wEwYHKoZIzj0CAQYIKoZIzj0DAAoDNgAENBvdzCDOIvu9zo7reJq1ummhR+0jaDc+EoSlW984
+cl9FTi/JJznwC+RNgwVfJ1WKJun1YA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb208w1:BOB_cf_c2pnb208w1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb208w1
+PeerKey=BOB_cf_c2pnb208w1_PUB
+SharedSecret=ba32bf80c0f7ab53cb083f267a902a1ad6396eb283237fad91cd
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb208w1
+PeerKey=ALICE_cf_c2pnb208w1_PUB
+SharedSecret=ba32bf80c0f7ab53cb083f267a902a1ad6396eb283237fad91cd
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb208w1
+PeerKey=BOB_cf_c2pnb208w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=f09f5fc8bf20677558bc65939bf1b7fbbbe2579702729304258b
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb208w1
+PeerKey=ALICE_cf_c2pnb208w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=f09f5fc8bf20677558bc65939bf1b7fbbbe2579702729304258b
+
+PublicKey=MALICE_cf_c2pnb208w1_PUB
+-----BEGIN PUBLIC KEY-----
+ME0wEwYHKoZIzj0CAQYIKoZIzj0DAAoDNgAEfuWB9pBZQin+VnmqgYVpbUpKxSQsnXxNqiDtVwqJ
+oPkHxRWnu5e7qI2idMcqaKDeeniUaA==
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb208w1
+PeerKey=MALICE_cf_c2pnb208w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb208w1
+PeerKey=MALICE_cf_c2pnb208w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb272w1 curve tests
+
+PrivateKey=ALICE_cf_c2pnb272w1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwEwYHKoZIzj0CAQYIKoZIzj0DABAEKDAmAgEBBCEA0SoHwKAgKb7WQ+s0w1iNBemDZ3+f
+StHU67fpP7YoF8U=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb272w1_PUB
+-----BEGIN PUBLIC KEY-----
+MF0wEwYHKoZIzj0CAQYIKoZIzj0DABADRgAE0IH60bGi46FDzEprGZ8EBK5uMMcVke/txeBRNGHQ
+DzG68r3EMLZkOfE1+g04MN7HgY7zt3jMYb8ImyLRmvqR2abjs6c=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb272w1:ALICE_cf_c2pnb272w1_PUB
+
+PrivateKey=BOB_cf_c2pnb272w1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwEwYHKoZIzj0CAQYIKoZIzj0DABAEKDAmAgEBBCEAFqB5GbPJ4d+X7ye7m05l/OirDqfn
+MOsOJ6xObBph3zQ=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb272w1_PUB
+-----BEGIN PUBLIC KEY-----
+MF0wEwYHKoZIzj0CAQYIKoZIzj0DABADRgAEIeIkcMHAuOgvHt2Wp52vVe0DYPNnUX79t/mLSx03
+cUlDmcxL7vIXdx9hB4OmQBYbm+YLDNfTFGAIlDfr2tELpVVPWPo=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb272w1:BOB_cf_c2pnb272w1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb272w1
+PeerKey=BOB_cf_c2pnb272w1_PUB
+SharedSecret=cfebd65006520a40f081d8940edf0ebb8e54491ba1499d9f3c63deecee84ddc07142
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb272w1
+PeerKey=ALICE_cf_c2pnb272w1_PUB
+SharedSecret=cfebd65006520a40f081d8940edf0ebb8e54491ba1499d9f3c63deecee84ddc07142
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb272w1
+PeerKey=BOB_cf_c2pnb272w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=756fc20b27352ac74e5135359c63d375d2732c6d02f25cd526155bac0882a9211dd4
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb272w1
+PeerKey=ALICE_cf_c2pnb272w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=756fc20b27352ac74e5135359c63d375d2732c6d02f25cd526155bac0882a9211dd4
+
+PublicKey=MALICE_cf_c2pnb272w1_PUB
+-----BEGIN PUBLIC KEY-----
+MF0wEwYHKoZIzj0CAQYIKoZIzj0DABADRgAEvID3AM7qzpKDnOLFY00+E7EKZz/vS/pXgsUA3bWN
+oJF8ElXFXv59s/SykQBCTHPqzmUbVmrXmtD44Kt1wUBRJfuwxy4=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb272w1
+PeerKey=MALICE_cf_c2pnb272w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb272w1
+PeerKey=MALICE_cf_c2pnb272w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb304w1 curve tests
+
+PrivateKey=ALICE_cf_c2pnb304w1
+-----BEGIN PRIVATE KEY-----
+MEYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DABEELDAqAgEBBCUAqJxh50ZIUXOJ1HE3cVkech9OTTPJ
+8jy/v5cFcO0X6dykHgnZ
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb304w1_PUB
+-----BEGIN PUBLIC KEY-----
+MGUwEwYHKoZIzj0CAQYIKoZIzj0DABEDTgAEvoaqRX6qiNQiFH1BhgLCPTpYszoRhmlLirkvlw/Q
+iXBlfQ7U4g+iRR/kmu2RlwwOHgNNL+mWcvLkFfS8Kr4jzv1EY1Ecx96n21l0YQ==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb304w1:ALICE_cf_c2pnb304w1_PUB
+
+PrivateKey=BOB_cf_c2pnb304w1
+-----BEGIN PRIVATE KEY-----
+MEYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DABEELDAqAgEBBCUAOScHepX+IwqC8TjyAJI1bkR3cYYt
+X9BbqYM9GQfVNSLHntTg
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb304w1_PUB
+-----BEGIN PUBLIC KEY-----
+MGUwEwYHKoZIzj0CAQYIKoZIzj0DABEDTgAEYuAq/6Yw5HxMeMohlWmwl+ZK4ZQucfr1tWDKwhDb
+kAOUO2P/Q/H+uelM3VVwxeu6A1kaX7K0UZpNa96NRBwI4aevc+vOxCgYkGt9BA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb304w1:BOB_cf_c2pnb304w1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb304w1
+PeerKey=BOB_cf_c2pnb304w1_PUB
+SharedSecret=bfddf9f923210e8231a702e3a1c987cf27661de1bc243c1890e437d67d9f49c6ccfadc035d9d
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb304w1
+PeerKey=ALICE_cf_c2pnb304w1_PUB
+SharedSecret=bfddf9f923210e8231a702e3a1c987cf27661de1bc243c1890e437d67d9f49c6ccfadc035d9d
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb304w1
+PeerKey=BOB_cf_c2pnb304w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0c7afb3143f93ef2166c05437a1757a62c916ff1751c6d456dd7f2356dcbc75df48015eb5ce8
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb304w1
+PeerKey=ALICE_cf_c2pnb304w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0c7afb3143f93ef2166c05437a1757a62c916ff1751c6d456dd7f2356dcbc75df48015eb5ce8
+
+PublicKey=MALICE_cf_c2pnb304w1_PUB
+-----BEGIN PUBLIC KEY-----
+MGUwEwYHKoZIzj0CAQYIKoZIzj0DABEDTgAEBZ5FuthQt0mxTJ8NQWN2J37kYT8ySD893IXEmXYP
+fMTr+CSNkf/sfF/13GEdVGnHmBgCH61sPWG69RgzdjRPprZFZxXjubIWYkp0DQ==
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb304w1
+PeerKey=MALICE_cf_c2pnb304w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb304w1
+PeerKey=MALICE_cf_c2pnb304w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2pnb368w1 curve tests
+
+PrivateKey=ALICE_cf_c2pnb368w1
+-----BEGIN PRIVATE KEY-----
+ME4CAQAwEwYHKoZIzj0CAQYIKoZIzj0DABMENDAyAgEBBC0AXeSTXsHb2PEH12tZL8w2q6evA2mi
+KfLLIa1c29BTmM//oWdKpqeuvwMIBto=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2pnb368w1_PUB
+-----BEGIN PUBLIC KEY-----
+MHUwEwYHKoZIzj0CAQYIKoZIzj0DABMDXgAEmEBXcvMgnHwJW7wAKM4cqboco6zF01J9ntUwoACI
+euvf3cpPXBvxUawJXfO9FwFRQabDRagGP99Walidd2JW8nWDWZgZMKj15Wh+4bp2dZHc2tPIIHHd
+3makbwQ=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2pnb368w1:ALICE_cf_c2pnb368w1_PUB
+
+PrivateKey=BOB_cf_c2pnb368w1
+-----BEGIN PRIVATE KEY-----
+ME4CAQAwEwYHKoZIzj0CAQYIKoZIzj0DABMENDAyAgEBBC0Aq1R9M/mCMbJMj6VBUpBkS4HXywEz
+Qun6d6uXgyU4LZRszA7Dz9+eKbXEMsk=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2pnb368w1_PUB
+-----BEGIN PUBLIC KEY-----
+MHUwEwYHKoZIzj0CAQYIKoZIzj0DABMDXgAEJOSnsaXA9wb5p8CGLPvYI47Yf3IdZSbWQ3Sn6G2v
+At+zYlpzGax1oJ1CW8fGA0Gu0RnvAfDeW9vgrtzshH1Vy/Ni6a7LPho99PtUP2nzUBnv+hfhFSra
+gqfRaOs=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2pnb368w1:BOB_cf_c2pnb368w1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb368w1
+PeerKey=BOB_cf_c2pnb368w1_PUB
+SharedSecret=008d20ede3961be3b01051d6fdae63db43865664804d432293a2edb13dcc8be0fe5b0c655297a84b9067a29c2a6f
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2pnb368w1
+PeerKey=ALICE_cf_c2pnb368w1_PUB
+SharedSecret=008d20ede3961be3b01051d6fdae63db43865664804d432293a2edb13dcc8be0fe5b0c655297a84b9067a29c2a6f
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2pnb368w1
+PeerKey=BOB_cf_c2pnb368w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=df32ddeeffa029aeadabad000a79c3154a0ddd0aeacf4e3de426f5c10096eff8912038c64d4c899131dcd4df2561
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2pnb368w1
+PeerKey=ALICE_cf_c2pnb368w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=df32ddeeffa029aeadabad000a79c3154a0ddd0aeacf4e3de426f5c10096eff8912038c64d4c899131dcd4df2561
+
+PublicKey=MALICE_cf_c2pnb368w1_PUB
+-----BEGIN PUBLIC KEY-----
+MHUwEwYHKoZIzj0CAQYIKoZIzj0DABMDXgAEWDn/U9rymClM/a0Q1mawHjQjvpxSehRWstSE+2Sd
+ubcZowJ+rw5LsEZteQyeVrCpKYUiIBmIVuFb2LDjtNLIJD1lr8C+vdco24ciLS9RzF/Dc9X+tcIj
+726e1BE=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2pnb368w1
+PeerKey=MALICE_cf_c2pnb368w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2pnb368w1
+PeerKey=MALICE_cf_c2pnb368w1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb191v1 curve tests
+
+PrivateKey=ALICE_cf_c2tnb191v1
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAUEHzAdAgEBBBgXyG7A4BvSmjKEl3aU+FQUt02p9U7x
+Jk4=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb191v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAUDMgAEG9iuZmnhz2H/YQKmVUaO//fm7hvV+CP5c2iszpR3
+7lRimqLWHPyvKgcP+PRCIUom
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb191v1:ALICE_cf_c2tnb191v1_PUB
+
+PrivateKey=BOB_cf_c2tnb191v1
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAUEHzAdAgEBBBg4+2hv9x9HxFy0c2c1XESDdgOamHu0
+MTU=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb191v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAUDMgAEdO/4ii8gi8eQfBrv3XmsOETwIfT8OIpBW/kUoHD+
+adqalcB6SIWOfoJReDLcpxAD
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb191v1:BOB_cf_c2tnb191v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb191v1
+PeerKey=BOB_cf_c2tnb191v1_PUB
+SharedSecret=2ee8a85151c397600984285307c14f0ea0e4c2071d753a99
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb191v1
+PeerKey=ALICE_cf_c2tnb191v1_PUB
+SharedSecret=2ee8a85151c397600984285307c14f0ea0e4c2071d753a99
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb191v1
+PeerKey=BOB_cf_c2tnb191v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=334051dfd62237e69e280ce2fab979bd77260f8dfe4df989
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb191v1
+PeerKey=ALICE_cf_c2tnb191v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=334051dfd62237e69e280ce2fab979bd77260f8dfe4df989
+
+PublicKey=MALICE_cf_c2tnb191v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAUDMgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcPEwZ1wj
+iNoFyzyANZl8IDB0fF1RmZD6
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb191v1
+PeerKey=MALICE_cf_c2tnb191v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb191v1
+PeerKey=MALICE_cf_c2tnb191v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb191v2 curve tests
+
+PrivateKey=ALICE_cf_c2tnb191v2
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAYEHzAdAgEBBBgQZHIQIPrAsbJqq4ZX3JdMrZAkaIGP
+jbo=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb191v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAYDMgAEAyQdwZYRIiv7O4/WRLDKJ249TM8dr2Y+Oz8rSxCI
+UVvJT/Jv9m462J6Iz1XOohhP
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb191v2:ALICE_cf_c2tnb191v2_PUB
+
+PrivateKey=BOB_cf_c2tnb191v2
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAYEHzAdAgEBBBgThhW6d5QDaqM8yhm16q6Pu/VFBpf7
+wcs=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb191v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAYDMgAEBVkB4O6fFvGzMHv4BF51muFA0npOGKoOdKbIIMQY
+JBIoz1RNNXTcgdpguLcrvcPJ
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb191v2:BOB_cf_c2tnb191v2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb191v2
+PeerKey=BOB_cf_c2tnb191v2_PUB
+SharedSecret=711f90cb2aaea65e939065cbd1896affe1d490ba14571400
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb191v2
+PeerKey=ALICE_cf_c2tnb191v2_PUB
+SharedSecret=711f90cb2aaea65e939065cbd1896affe1d490ba14571400
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb191v2
+PeerKey=BOB_cf_c2tnb191v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=1740db5b771fa2889d3ec7c1ba8eeffa7741f0ee62433dce
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb191v2
+PeerKey=ALICE_cf_c2tnb191v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=1740db5b771fa2889d3ec7c1ba8eeffa7741f0ee62433dce
+
+PublicKey=MALICE_cf_c2tnb191v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAYDMgAEA3yPV6Ilx7PU7dWIDzgKzFV07LNsn1EhMyLQaa5U
+2vqunpWef+/CaO2pFBcwwW+x
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb191v2
+PeerKey=MALICE_cf_c2tnb191v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb191v2
+PeerKey=MALICE_cf_c2tnb191v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb191v3 curve tests
+
+PrivateKey=ALICE_cf_c2tnb191v3
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAcEHzAdAgEBBBgTPjf06B01Jq59qU1iczNuA29WfW+b
+erU=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb191v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAcDMgAEL4NGEUX2CXY18MyoH1inKq5kde9RGr25ODm/0BEX
+HWsGvDE2HC+6pL2BMl3MRCty
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb191v3:ALICE_cf_c2tnb191v3_PUB
+
+PrivateKey=BOB_cf_c2tnb191v3
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAcEHzAdAgEBBBgUC2bC465JTXYLUaaET/r5n7X85gRH
+iSQ=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb191v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAcDMgAEPKekNkT9mQ8KRCTR2RwCFkhNvsjL+/mLHYzbMrYe
+QFIb5QwXAdbg2tEOl7yj9qkk
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb191v3:BOB_cf_c2tnb191v3_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb191v3
+PeerKey=BOB_cf_c2tnb191v3_PUB
+SharedSecret=196200f7ea06c43c35516b995cf4a4dd4151dbd0ed998561
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb191v3
+PeerKey=ALICE_cf_c2tnb191v3_PUB
+SharedSecret=196200f7ea06c43c35516b995cf4a4dd4151dbd0ed998561
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb191v3
+PeerKey=BOB_cf_c2tnb191v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=311939377670a8a1ed1ee17f9dd182167da00c5a19e2e109
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb191v3
+PeerKey=ALICE_cf_c2tnb191v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=311939377670a8a1ed1ee17f9dd182167da00c5a19e2e109
+
+PublicKey=MALICE_cf_c2tnb191v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAAcDMgAESvPjWlLnANK2j38hHZ0uqueaniovkhwwdJZjrmUk
+n5vQBTxUzkIkMjL33v6Lr3z7
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb191v3
+PeerKey=MALICE_cf_c2tnb191v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb191v3
+PeerKey=MALICE_cf_c2tnb191v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb239v1 curve tests
+
+PrivateKey=ALICE_cf_c2tnb239v1
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAsEJTAjAgEBBB4fMJDhCEiuEf/RF6oGjHVcNwN+wCYG
+rJMnJLIXiCI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb239v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAAsDPgAEUgG/uMWy4k0R/kbVJEapF6r5ik4Q9WPsDXAd0856
+dVL8PvBXgixk2tKfyY1xUVebcEVlgdZP1pN1Xyvi
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb239v1:ALICE_cf_c2tnb239v1_PUB
+
+PrivateKey=BOB_cf_c2tnb239v1
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAsEJTAjAgEBBB4JLDwVJQw3+00FiZBDWFErd7PXnchH
+sfpZeV3i5FM=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb239v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAAsDPgAEcwKt31cWaoFUd7QxYSdwgMDOqEhjPbD3Z9AfR3tc
+G77/MY5z1oQegqImBog645vtPWI8lZd1zcl6QYRS
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb239v1:BOB_cf_c2tnb239v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb239v1
+PeerKey=BOB_cf_c2tnb239v1_PUB
+SharedSecret=413ea943cdf40c45795c77aeea7099b81cc42566067924d1fdbae42ddf99
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb239v1
+PeerKey=ALICE_cf_c2tnb239v1_PUB
+SharedSecret=413ea943cdf40c45795c77aeea7099b81cc42566067924d1fdbae42ddf99
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb239v1
+PeerKey=BOB_cf_c2tnb239v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=1f1e5a6084492e895c35d76a5d2b4a3fafbd96c4b2230ea71cc1c711fa38
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb239v1
+PeerKey=ALICE_cf_c2tnb239v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=1f1e5a6084492e895c35d76a5d2b4a3fafbd96c4b2230ea71cc1c711fa38
+
+PublicKey=MALICE_cf_c2tnb239v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAAsDPgAEJFn89FF7xaa5m+XGxWKFwCH+Mu4rbxwi6lvhuEuT
+Itl/OAosALFh8xpt+N5gmKtUdhpjyok2udC4B/mY
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb239v1
+PeerKey=MALICE_cf_c2tnb239v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb239v1
+PeerKey=MALICE_cf_c2tnb239v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb239v2 curve tests
+
+PrivateKey=ALICE_cf_c2tnb239v2
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAwEJTAjAgEBBB4KU4YKdzFOkl6M1biHkxtVGD2uNXr6
+GbEcp4PbJKU=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb239v2_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAAwDPgAEKzpycflUrsyqVV/+fzvC2+AuX3r0b0Syn8acvn78
+VnKA9mZKwPLWhnMJcLyzarIzc/6/UcfYGNmTyUlG
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb239v2:ALICE_cf_c2tnb239v2_PUB
+
+PrivateKey=BOB_cf_c2tnb239v2
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAwEJTAjAgEBBB4HZQLKGKBpIKiyTq6XYZWQNph1oGP+
+JLwCwn7lYx0=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb239v2_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAAwDPgAETPSkhMs3JW3BG66FSfCov76JKdcRiBhMCW453Wku
+N7yBxBmWjeclHhnXIzfc4qM4qf9n3KzMSXejPVYg
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb239v2:BOB_cf_c2tnb239v2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb239v2
+PeerKey=BOB_cf_c2tnb239v2_PUB
+SharedSecret=2e738f14795b2e19ee791c1bf30c5e462ca6c6ed0ec5c6c6402d0730cf4c
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb239v2
+PeerKey=ALICE_cf_c2tnb239v2_PUB
+SharedSecret=2e738f14795b2e19ee791c1bf30c5e462ca6c6ed0ec5c6c6402d0730cf4c
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb239v2
+PeerKey=BOB_cf_c2tnb239v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=7662d8b94d3f0d20eb8e112ca8b7d5699d81f35902df5b77561977df3946
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb239v2
+PeerKey=ALICE_cf_c2tnb239v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=7662d8b94d3f0d20eb8e112ca8b7d5699d81f35902df5b77561977df3946
+
+PublicKey=MALICE_cf_c2tnb239v2_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAAwDPgAES8fLc5mtVI0HqgKRJ7mN8MU1B0FBkiim6jCHYJf3
+JYUX3Gn3Ai11cHie+nVb3z51jSkpDQENHESTv5K2
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb239v2
+PeerKey=MALICE_cf_c2tnb239v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb239v2
+PeerKey=MALICE_cf_c2tnb239v2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb239v3 curve tests
+
+PrivateKey=ALICE_cf_c2tnb239v3
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAA0EJTAjAgEBBB4BZZXtcMw5GrpgHJLx4D8z7M6ocWdv
+rDl2fV9ObC8=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb239v3_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAA0DPgAEOu2HIAUX+r6IbRlrPUJUBDL814dR++maVAAkUIjD
+H33ewqcI9ZLtpvuR8P8hgRNUTXlh1GWgrB6F21Eo
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb239v3:ALICE_cf_c2tnb239v3_PUB
+
+PrivateKey=BOB_cf_c2tnb239v3
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAA0EJTAjAgEBBB4BDxw3SA54y6uYOW1n4yZaUK22J9ef
+XG3HcQX+4i0=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb239v3_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAA0DPgAEVaEi76wyzlpzkkSElf4SmGZ7kf1ghHMP82HkGk7K
+BC10zUyppoSOAr0eX4pHAkDUF1m/KGoJa7QcJJww
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb239v3:BOB_cf_c2tnb239v3_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb239v3
+PeerKey=BOB_cf_c2tnb239v3_PUB
+SharedSecret=6a756022ec2ea89b0fa757824909707102acf3b7da39dc625c6252eb4c48
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb239v3
+PeerKey=ALICE_cf_c2tnb239v3_PUB
+SharedSecret=6a756022ec2ea89b0fa757824909707102acf3b7da39dc625c6252eb4c48
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb239v3
+PeerKey=BOB_cf_c2tnb239v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=3240e19dd8c290e5e1749df60ad0166dd9dbfad645e518b4948e14f774ce
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb239v3
+PeerKey=ALICE_cf_c2tnb239v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=3240e19dd8c290e5e1749df60ad0166dd9dbfad645e518b4948e14f774ce
+
+PublicKey=MALICE_cf_c2tnb239v3_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAA0DPgAELe/znC87/2ucKX7mXUUyiUvg67slWRdH+WHDct9d
+LcXDyB342ZN1nm0NCAmBMcLjohX0Zza0ji3YNjT1
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb239v3
+PeerKey=MALICE_cf_c2tnb239v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb239v3
+PeerKey=MALICE_cf_c2tnb239v3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb359v1 curve tests
+
+PrivateKey=ALICE_cf_c2tnb359v1
+-----BEGIN PRIVATE KEY-----
+ME4CAQAwEwYHKoZIzj0CAQYIKoZIzj0DABIENDAyAgEBBC0Afea/a1NrRf6rRRr/UDsI559ADTFP
+Bd5HaS33laTZkCdNLITw1UUrESUIOiU=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb359v1_PUB
+-----BEGIN PUBLIC KEY-----
+MHMwEwYHKoZIzj0CAQYIKoZIzj0DABIDXAAEZMJU3QF9UJJp2m6qyCnhPuVlPKPHtav3DCgH27SY
+RLMN7C4rRmqiJakD11QtOforOgbPW5r/v7t4TUWIlq8jV7kapJNtxQtg/S87L0NQGgHBq/lnJL8x
+fN3Y
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb359v1:ALICE_cf_c2tnb359v1_PUB
+
+PrivateKey=BOB_cf_c2tnb359v1
+-----BEGIN PRIVATE KEY-----
+ME4CAQAwEwYHKoZIzj0CAQYIKoZIzj0DABIENDAyAgEBBC0Aaw+yr7Atz8CXjLsbI5msXLqxFoMr
+esHVfU53i6ucCsnPTWSDWSb5CePtI9g=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb359v1_PUB
+-----BEGIN PUBLIC KEY-----
+MHMwEwYHKoZIzj0CAQYIKoZIzj0DABIDXAAEUQde0iyDHbsFJZ459d4zUhsrJYAkqndmEBRwSlg5
+ZNX8SSS79Zf2HsQl+LWIZyzeYzoHobKXufChw9/H4ThS58VwV5/0hoE929PIgJ1MSEqr5LvJXi+b
+R8fe
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb359v1:BOB_cf_c2tnb359v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb359v1
+PeerKey=BOB_cf_c2tnb359v1_PUB
+SharedSecret=623a71122b5acad467d40d97ef8d8fd46541d8c41d7de6ba181c24e2714c1bc35bcefcf089af69c406eedecc12
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb359v1
+PeerKey=ALICE_cf_c2tnb359v1_PUB
+SharedSecret=623a71122b5acad467d40d97ef8d8fd46541d8c41d7de6ba181c24e2714c1bc35bcefcf089af69c406eedecc12
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb359v1
+PeerKey=BOB_cf_c2tnb359v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=1c9c4cea3251dace2cb763eabf60f106cc1b03f2491e6f20d7bea78e062f8f14c4e82e4d43786eefa44d33f7e9
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb359v1
+PeerKey=ALICE_cf_c2tnb359v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=1c9c4cea3251dace2cb763eabf60f106cc1b03f2491e6f20d7bea78e062f8f14c4e82e4d43786eefa44d33f7e9
+
+PublicKey=MALICE_cf_c2tnb359v1_PUB
+-----BEGIN PUBLIC KEY-----
+MHMwEwYHKoZIzj0CAQYIKoZIzj0DABIDXAAEDW1DxeJfyPPnxX4WiLM5ZnX9AypqqeKj7FTHxanl
+++A6FgVFjUCatt8Sr4xnSc3zDE0kh6f/wS9SbtCAi74i8HAX5SJiccCMPRkw6kBuHZgiG8EmFJ53
+OEQw
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb359v1
+PeerKey=MALICE_cf_c2tnb359v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb359v1
+PeerKey=MALICE_cf_c2tnb359v1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=c2tnb431r1 curve tests
+
+PrivateKey=ALICE_cf_c2tnb431r1
+-----BEGIN PRIVATE KEY-----
+MFYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DABQEPDA6AgEBBDUAG1rgUnH3+PSxqlzt9+QTWv7PrYxz
+Qgqj5A2Mqi0LbdixVDciVSSgrU6keVu72oCmHVP+OQ==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_c2tnb431r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGFMBMGByqGSM49AgEGCCqGSM49AwAUA24ABFcQEDic9pYxtxStk/oBxafqyUux1kvEOOwR4FxJ
+pGEMTh8B+YfkWuq+IDY5zSqNKtg7cRlAFX2dlHhRSvNxrN3DJCrhe/TQq8SIYawcqEQnM39F8hHM
+7VQJLEsBpJ/WUonwMJXknjgfONP7GA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_c2tnb431r1:ALICE_cf_c2tnb431r1_PUB
+
+PrivateKey=BOB_cf_c2tnb431r1
+-----BEGIN PRIVATE KEY-----
+MFYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DABQEPDA6AgEBBDUBOsZrpI6hTgImR8DBhKOOrh2SvcT/
+VwmzYnbuCRrtr/zwIQcqKKI1ztlrl+kxFxJfk5L7UQ==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_c2tnb431r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGFMBMGByqGSM49AgEGCCqGSM49AwAUA24ABHeTG6xjbsKKxn4oYQt9qUM9LrSPZfY11XsBmROc
+fb9kEbBLU+QixSbYZOrqPasesDV9dApDXF+w6EfIeNyJEK5Lk+aXamrn7fRMUAQ2m7+Odp87GgA+
+8Cg6YpgbK314SK5STziqoZwzEISJ9w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_c2tnb431r1:BOB_cf_c2tnb431r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb431r1
+PeerKey=BOB_cf_c2tnb431r1_PUB
+SharedSecret=1c9a64de0b706f0e562d5144ceeb4806ce8782865dc0e3fab694967955bd40afc79bf9241ef4a173fbf9baeac0d416392fb13bdc6978
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_c2tnb431r1
+PeerKey=ALICE_cf_c2tnb431r1_PUB
+SharedSecret=1c9a64de0b706f0e562d5144ceeb4806ce8782865dc0e3fab694967955bd40afc79bf9241ef4a173fbf9baeac0d416392fb13bdc6978
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_c2tnb431r1
+PeerKey=BOB_cf_c2tnb431r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=059e2ea2d0d8bad5005a9401196ebb1633377c7ded8ec58a0398cf1d0f42ea82614f68cb836ecfc33612b8a705b4c3b7b4ed12eb6e22
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_c2tnb431r1
+PeerKey=ALICE_cf_c2tnb431r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=059e2ea2d0d8bad5005a9401196ebb1633377c7ded8ec58a0398cf1d0f42ea82614f68cb836ecfc33612b8a705b4c3b7b4ed12eb6e22
+
+PublicKey=MALICE_cf_c2tnb431r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGFMBMGByqGSM49AgEGCCqGSM49AwAUA24ABA/cHJ1bNJ2l3GcrT67WEoU0w/Ajy28T9X4XLv8a
+5EpnkembeFlRG8ILplDcZimE8kjNQWynAk+NbJRsIU/XLzcm7VXkkqEkx/yCQ/TOcbeB3qrpzWYr
+F3Cls9x60wuFYNc9d6eIe4B+puz9IQ==
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_c2tnb431r1
+PeerKey=MALICE_cf_c2tnb431r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_c2tnb431r1
+PeerKey=MALICE_cf_c2tnb431r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=prime192v1 curve tests
+
+PrivateKey=ALICE_cf_prime192v1
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEHzAdAgEBBBhQFYLaobJ47BVWWZv/ByY8Ti69m/U9
+TeI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime192v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEHYbt14KzucSpmKMrlDx1IGz/a28nDs21OjKgx3BK
+PZ78UrllIr69kgrYUKsRg4sd
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime192v1:ALICE_cf_prime192v1_PUB
+
+PrivateKey=BOB_cf_prime192v1
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEHzAdAgEBBBhsbmKHAtygIqirkmUXSbniDJOx0/fI
+CWM=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime192v1_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEJA+FQcXq5Axzv8pLDslxq1QVt1hjN2i0TgoO6Yxp
+bAekMot69VorE8ibSzgJixXJ
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime192v1:BOB_cf_prime192v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime192v1
+PeerKey=BOB_cf_prime192v1_PUB
+SharedSecret=e36cad3b0f8d00f60f090440a76df47896713ae61421c354
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime192v1
+PeerKey=ALICE_cf_prime192v1_PUB
+SharedSecret=e36cad3b0f8d00f60f090440a76df47896713ae61421c354
+
+Title=prime192v2 curve tests
+
+PrivateKey=ALICE_cf_prime192v2
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQIEHzAdAgEBBBh6rcgPFDmA2P4CGSrC7ii9DAjepljX
+sMM=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime192v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQIDMgAET6wOPoDU3BeU7VKozsGEvDeJs//9Z/aNEcbbLQ0d
+g5IzsS/XMJzifjCJZgNsb7mi
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime192v2:ALICE_cf_prime192v2_PUB
+
+PrivateKey=BOB_cf_prime192v2
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQIEHzAdAgEBBBja4R9iZuiu95XEuM1558ArTwNnAl7M
+xqI=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime192v2_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQIDMgAEcgWNAOL4pZCmouZl+be+rC0yLAJkm2YuPWs+FX2u
+Y6OU1aHkkspZTC1uUVWjchy5
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime192v2:BOB_cf_prime192v2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime192v2
+PeerKey=BOB_cf_prime192v2_PUB
+SharedSecret=ae2ff9f1f9f24e6d281dc78993d9f71913e1e105965000a1
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime192v2
+PeerKey=ALICE_cf_prime192v2_PUB
+SharedSecret=ae2ff9f1f9f24e6d281dc78993d9f71913e1e105965000a1
+
+Title=prime192v3 curve tests
+
+PrivateKey=ALICE_cf_prime192v3
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQMEHzAdAgEBBBij5blPQRKM1/9c57YDZXIIue80MDqx
+Igw=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime192v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQMDMgAE1+mLeiT/jjHO71IL/C/ZcnF6+yj9FV6eqfuPdHAi
+MsDRFCB6/h8TcCUFuospu5l0
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime192v3:ALICE_cf_prime192v3_PUB
+
+PrivateKey=BOB_cf_prime192v3
+-----BEGIN PRIVATE KEY-----
+MDkCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQMEHzAdAgEBBBhgFP4fFLtm/yk5tsosBUBKTg370FOu
+92g=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime192v3_PUB
+-----BEGIN PUBLIC KEY-----
+MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQMDMgAEv35bOz0xqLeJqpZdZ8LyiUgsJMBEtN2UMJm8blX2
+vMWAgEeLhzar86BUlS7dZwS7
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime192v3:BOB_cf_prime192v3_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime192v3
+PeerKey=BOB_cf_prime192v3_PUB
+SharedSecret=9e562ecbe29c510a13b0daea822ec864c2a9684d2a382812
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime192v3
+PeerKey=ALICE_cf_prime192v3_PUB
+SharedSecret=9e562ecbe29c510a13b0daea822ec864c2a9684d2a382812
+
+Title=prime239v1 curve tests
+
+PrivateKey=ALICE_cf_prime239v1
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQQEJTAjAgEBBB5nH2mt/GUx+I/60NlcuQlrdupDXwMY
+SF/w+SUTNqY=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime239v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAQQDPgAEMqQLCgDR9njkq9QELuOu+J/9YGcxJHULdvxHImLW
+RXqBUM5Xea+Qk2SKIpWcogxr2zFeQyeLj2bQysuo
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime239v1:ALICE_cf_prime239v1_PUB
+
+PrivateKey=BOB_cf_prime239v1
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQQEJTAjAgEBBB5RZgYV+j+zhwI12zCzB+mdPofMx0kB
+jZ9gplgXxzk=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime239v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAQQDPgAEBR5m/kllh025oO4GvqALkjRliVv7q4x8ro/tkYnT
+L2U4hkT6xUeRu9QC4KOz7KUVH+nBbQASL4XQg/3C
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime239v1:BOB_cf_prime239v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime239v1
+PeerKey=BOB_cf_prime239v1_PUB
+SharedSecret=196b1d0206d4f87c313c266bfb12c90dd1f1f64b89bfc16518086b9801b8
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime239v1
+PeerKey=ALICE_cf_prime239v1_PUB
+SharedSecret=196b1d0206d4f87c313c266bfb12c90dd1f1f64b89bfc16518086b9801b8
+
+Title=prime239v2 curve tests
+
+PrivateKey=ALICE_cf_prime239v2
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQUEJTAjAgEBBB5uLCwofbD2Suc/iIRhXJsPqZ4me87h
++tFevsg1pPE=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime239v2_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAQUDPgAETH77jXHBItV673gTNK/HTFldo4VxPiscbideUgKd
+CWjdVsXebgAZbqQwf0h9QWcIgM7K7ODdW5kCuZ1G
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime239v2:ALICE_cf_prime239v2_PUB
+
+PrivateKey=BOB_cf_prime239v2
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQUEJTAjAgEBBB5nlF+ouuw3Ljkgy3pHkCN+/JoHAMyT
+KY0wlvJdo/w=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime239v2_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAQUDPgAELUQYo0UH8HbK/RMD2jVphBU+iB4OTOfvaaTlHq06
+dcJ8a9a+mAQKhb1OZVEq1n4nQsgRiI1rPxugVERM
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime239v2:BOB_cf_prime239v2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime239v2
+PeerKey=BOB_cf_prime239v2_PUB
+SharedSecret=1d18ca6366bceba3c1477daa0e08202088abcf14fc2b8fbf98ba95858fcf
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime239v2
+PeerKey=ALICE_cf_prime239v2_PUB
+SharedSecret=1d18ca6366bceba3c1477daa0e08202088abcf14fc2b8fbf98ba95858fcf
+
+Title=prime239v3 curve tests
+
+PrivateKey=ALICE_cf_prime239v3
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQYEJTAjAgEBBB5J95JRhBDTzlyAPAfu6T2Pb9vK0NKu
+Y9AfhA2G+mI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime239v3_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAQYDPgAEZEN48pqgLF08Yjj/8BLM2Nr5ZhpYxyBurbzKRuBb
+GLpzZLteJN9vZjN7ouNpMxLVUFQxTOwpsvUw86Lk
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime239v3:ALICE_cf_prime239v3_PUB
+
+PrivateKey=BOB_cf_prime239v3
+-----BEGIN PRIVATE KEY-----
+MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQYEJTAjAgEBBB5Z7rMZML1xeryBaYYr+QuMiQxHT44I
+d9bmIVvG3dM=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime239v3_PUB
+-----BEGIN PUBLIC KEY-----
+MFUwEwYHKoZIzj0CAQYIKoZIzj0DAQYDPgAEQUWKqohAPAoIYEZOvc1QwSlcB+gW0febaNxGOy47
+LaIWdsNM7GJVP9xpdSwm/L+Dip/oH4E59f3SiOAd
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime239v3:BOB_cf_prime239v3_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime239v3
+PeerKey=BOB_cf_prime239v3_PUB
+SharedSecret=4dcc2c67c5993162ed71ebb33077bbb85395b0d3eec2311aa404e45901a0
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime239v3
+PeerKey=ALICE_cf_prime239v3_PUB
+SharedSecret=4dcc2c67c5993162ed71ebb33077bbb85395b0d3eec2311aa404e45901a0
+
+Title=prime256v1 curve tests
+
+PrivateKey=ALICE_cf_prime256v1
+-----BEGIN PRIVATE KEY-----
+MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCDZE0NZiGAFJX6JQxumKTFRT+XFCQqJ
+gHCUxmU2fRcn9Q==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_prime256v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5kDOrX6kmk1/jHfEdMBluFos6dyCbzKVOX3v2aa2
+y5IhlhTKtCJdydX+XWLDXWW9sbtIRNP94R3iOOpRPBqpGg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_prime256v1:ALICE_cf_prime256v1_PUB
+
+PrivateKey=BOB_cf_prime256v1
+-----BEGIN PRIVATE KEY-----
+MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCAxJgV1dLJw/o2Dmh1fIY1KpBd88WCP
+23wZzR8DzhyCrA==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_prime256v1_PUB
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5J6yA+j0zrGi6RilUhjrcL7OUMzYTwpnw5DdRXr0
+creHgE03EFV//7xqadB4BDwFIGM9MV2sE6qREEomWhZFeg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_prime256v1:BOB_cf_prime256v1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_prime256v1
+PeerKey=BOB_cf_prime256v1_PUB
+SharedSecret=ee63690b553dcd9bccb066137725f0489395a83f4d280f309339d606c969734a
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_prime256v1
+PeerKey=ALICE_cf_prime256v1_PUB
+SharedSecret=ee63690b553dcd9bccb066137725f0489395a83f4d280f309339d606c969734a
+
+Title=secp112r1 curve tests
+
+PrivateKey=ALICE_cf_secp112r1
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFK4EEAAYEFTATAgEBBA6zC5ZzEIIdvY4Q7DS0uw==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp112r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFK4EEAAYDHgAEYIawfjH3qRrJJWwuG3Ys5ZhDJsmdWi34aHgKAA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp112r1:ALICE_cf_secp112r1_PUB
+
+PrivateKey=BOB_cf_secp112r1
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFK4EEAAYEFTATAgEBBA6WPx4YxBODium8BKDw0A==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp112r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFK4EEAAYDHgAEchh3iQdPN1rrzrpdZRQ95G6tvdwEBQ+gfu1tvA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp112r1:BOB_cf_secp112r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp112r1
+PeerKey=BOB_cf_secp112r1_PUB
+SharedSecret=4ddd1d504b444d4be67ba2e4610a
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp112r1
+PeerKey=ALICE_cf_secp112r1_PUB
+SharedSecret=4ddd1d504b444d4be67ba2e4610a
+
+Title=secp112r2 curve tests
+
+PrivateKey=ALICE_cf_secp112r2
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFK4EEAAcEFTATAgEBBA4GcvIx97ePHdAiH0Z9EA==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp112r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFK4EEAAcDHgAEHK9uNAILHBmPZdKKh79/nzYE0HbvC//rA7i0Xw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp112r2:ALICE_cf_secp112r2_PUB
+
+PrivateKey=BOB_cf_secp112r2
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFK4EEAAcEFTATAgEBBA4WzpVFZnZv9mvtpnYNyw==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp112r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFK4EEAAcDHgAEUzBLNQupqUpGgmZl9JVjKBpwusl52rFg5OVFJA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp112r2:BOB_cf_secp112r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp112r2
+PeerKey=BOB_cf_secp112r2_PUB
+SharedSecret=a6d05c7ba5128a9685c705b5030b
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp112r2
+PeerKey=ALICE_cf_secp112r2_PUB
+SharedSecret=a6d05c7ba5128a9685c705b5030b
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_secp112r2
+PeerKey=BOB_cf_secp112r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=04f3280e92c269d794aa779efcef
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_secp112r2
+PeerKey=ALICE_cf_secp112r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=04f3280e92c269d794aa779efcef
+
+PublicKey=MALICE_cf_secp112r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFK4EEAAcDHgAEsf2N4SfUZWtXPrUTmEyr71I/JSn8VtzQsFHuqQ==
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_secp112r2
+PeerKey=MALICE_cf_secp112r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_secp112r2
+PeerKey=MALICE_cf_secp112r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=secp128r1 curve tests
+
+PrivateKey=ALICE_cf_secp128r1
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwEAYHKoZIzj0CAQYFK4EEABwEFzAVAgEBBBB+RX18d0+gKpdcKbJJTrEZ
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp128r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDYwEAYHKoZIzj0CAQYFK4EEABwDIgAEG0XMAdrAZOPUW6L9ADU8XK8sZr7dtIcDinSWU1zSV9s=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp128r1:ALICE_cf_secp128r1_PUB
+
+PrivateKey=BOB_cf_secp128r1
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwEAYHKoZIzj0CAQYFK4EEABwEFzAVAgEBBBB/J9/eClt9mimGwOcOsjJF
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp128r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDYwEAYHKoZIzj0CAQYFK4EEABwDIgAE82nknsOS+u8mybP0KJqQhvm83gbPNTZOcvm0ZDVR5sU=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp128r1:BOB_cf_secp128r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp128r1
+PeerKey=BOB_cf_secp128r1_PUB
+SharedSecret=5020f1b759da1f737a61a29a268d7669
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp128r1
+PeerKey=ALICE_cf_secp128r1_PUB
+SharedSecret=5020f1b759da1f737a61a29a268d7669
+
+Title=secp128r2 curve tests
+
+PrivateKey=ALICE_cf_secp128r2
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwEAYHKoZIzj0CAQYFK4EEAB0EFzAVAgEBBBALPaUYCnPgNiLhez93Z1Gi
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp128r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDYwEAYHKoZIzj0CAQYFK4EEAB0DIgAEOKiPRGtZXwxmvTr35NmUkNsAGGk9RKNA4D5BE9ZrjZQ=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp128r2:ALICE_cf_secp128r2_PUB
+
+PrivateKey=BOB_cf_secp128r2
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwEAYHKoZIzj0CAQYFK4EEAB0EFzAVAgEBBBARg3vb436QgyHdyt6l/b6G
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp128r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDYwEAYHKoZIzj0CAQYFK4EEAB0DIgAELph7h27BYjIINC2EddcpIOxKbdz8Xe7h3Az1ZuR9bAI=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp128r2:BOB_cf_secp128r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp128r2
+PeerKey=BOB_cf_secp128r2_PUB
+SharedSecret=8f4d8c75141e9b084328222440eb5dfa
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp128r2
+PeerKey=ALICE_cf_secp128r2_PUB
+SharedSecret=8f4d8c75141e9b084328222440eb5dfa
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_secp128r2
+PeerKey=BOB_cf_secp128r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=baaa0c16e16eef291001475d638e4830
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_secp128r2
+PeerKey=ALICE_cf_secp128r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=baaa0c16e16eef291001475d638e4830
+
+PublicKey=MALICE_cf_secp128r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDYwEAYHKoZIzj0CAQYFK4EEAB0DIgAE6h6RzJIp6HLR6RDOPtyzGDurkuE9aAaZqHosPTnkLxQ=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_secp128r2
+PeerKey=MALICE_cf_secp128r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_secp128r2
+PeerKey=MALICE_cf_secp128r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=secp160k1 curve tests
+
+PrivateKey=ALICE_cf_secp160k1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAkEHDAaAgEBBBUAlxTBO50KwFwWKPtk1rutu68m+zI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp160k1_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEcVWIjtPZn1cHckclpn5jKDCphQUVHxFN5tSeFG9wsJZT
+EvqPyLS64w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp160k1:ALICE_cf_secp160k1_PUB
+
+PrivateKey=BOB_cf_secp160k1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAkEHDAaAgEBBBUAdrPkoNkRVUloiuwzruQszSUuwpY=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp160k1_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAESGN41cAj8Fg4pAJM7FUKHiawbCR0b9unMpZWxqOKeW1/
+bxT/CqEkyw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp160k1:BOB_cf_secp160k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp160k1
+PeerKey=BOB_cf_secp160k1_PUB
+SharedSecret=b738a0bf17f3271a9a155bfdfe2f0f1d51494d42
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp160k1
+PeerKey=ALICE_cf_secp160k1_PUB
+SharedSecret=b738a0bf17f3271a9a155bfdfe2f0f1d51494d42
+
+Title=secp160r1 curve tests
+
+PrivateKey=ALICE_cf_secp160r1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAgEHDAaAgEBBBUAR6m1+jIBuJnSKx9fHmyAYhsnYe8=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp160r1_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEO78GZuBaCfJjHK97c9N21z+4mm37b5x7/Hr3Xc4pUbtb
+OoNj/A+W9w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp160r1:ALICE_cf_secp160r1_PUB
+
+PrivateKey=BOB_cf_secp160r1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAgEHDAaAgEBBBUATqvd54Jj7TbnrLAd2dMYCpExLws=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp160r1_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEBKDbBSPTwmb00MFvMtJMxQ2YDmcPOZHE8YbVr5hp8s5J
+Jwy17FaNNg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp160r1:BOB_cf_secp160r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp160r1
+PeerKey=BOB_cf_secp160r1_PUB
+SharedSecret=1912ea7b9bb1de5b8d3cef83e7a6e7a917816541
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp160r1
+PeerKey=ALICE_cf_secp160r1_PUB
+SharedSecret=1912ea7b9bb1de5b8d3cef83e7a6e7a917816541
+
+Title=secp160r2 curve tests
+
+PrivateKey=ALICE_cf_secp160r2
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAB4EHDAaAgEBBBUA3IsVg4R4paXaPATDHvzfnvM+vjQ=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp160r2_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAE4V+25YCpVkKF6NF/UPc1SYxohYWcf3qT3JDoPRhnm/rj
+mSqCCA6gUw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp160r2:ALICE_cf_secp160r2_PUB
+
+PrivateKey=BOB_cf_secp160r2
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAB4EHDAaAgEBBBUAYT/5C7UpD17DnZm4ObswmGFMI1Q=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp160r2_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEB7YVzBmzhnIdouvN/nb8VMXCqO8dkhmebyVzoD0oAzuH
+nN+SfWr6aQ==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp160r2:BOB_cf_secp160r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp160r2
+PeerKey=BOB_cf_secp160r2_PUB
+SharedSecret=ccb9cae5c9487ff60c487bd1b39a62eb4680e9b6
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp160r2
+PeerKey=ALICE_cf_secp160r2_PUB
+SharedSecret=ccb9cae5c9487ff60c487bd1b39a62eb4680e9b6
+
+Title=secp192k1 curve tests
+
+PrivateKey=ALICE_cf_secp192k1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEAYHKoZIzj0CAQYFK4EEAB8EHzAdAgEBBBikVZrCZQB7ZtkhNfQYpjKHZ9KxXgooJ90=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp192k1_PUB
+-----BEGIN PUBLIC KEY-----
+MEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEyV4EzMZglBXtYdn38hNTrCGflAsJprMkxkOlw58chZ25
+6EAu7gVvYDTpnRkymKyH
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp192k1:ALICE_cf_secp192k1_PUB
+
+PrivateKey=BOB_cf_secp192k1
+-----BEGIN PRIVATE KEY-----
+MDYCAQAwEAYHKoZIzj0CAQYFK4EEAB8EHzAdAgEBBBiJQ/PunKGk9QPUyqIBGMgHKKg+yxJr5io=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp192k1_PUB
+-----BEGIN PUBLIC KEY-----
+MEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAE990Tnmh9QQQHVHuLpfrAsgjvB9R2MJXzhBZN1WvtxLqF
+OZ2oFMP0Kfcr7HbI7a5j
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp192k1:BOB_cf_secp192k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp192k1
+PeerKey=BOB_cf_secp192k1_PUB
+SharedSecret=a46a6bfb279d4dc30cffac585d1fbec905dbe46aca5e3c9d
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp192k1
+PeerKey=ALICE_cf_secp192k1_PUB
+SharedSecret=a46a6bfb279d4dc30cffac585d1fbec905dbe46aca5e3c9d
+
+Title=secp224k1 curve tests
+
+PrivateKey=ALICE_cf_secp224k1
+-----BEGIN PRIVATE KEY-----
+MDsCAQAwEAYHKoZIzj0CAQYFK4EEACAEJDAiAgEBBB0AZPk3TzxGhX7TljBBhJDLBfulAMp6Bh3W
+w40Qyg==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp224k1_PUB
+-----BEGIN PUBLIC KEY-----
+ME4wEAYHKoZIzj0CAQYFK4EEACADOgAE4o7LGdJDixqJZ5imnqaX4IeE55NG4W0HEe72LVC7pmn2
+e3m7uC92ZQhduF9lJli4dXD5en/1wkE=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp224k1:ALICE_cf_secp224k1_PUB
+
+PrivateKey=BOB_cf_secp224k1
+-----BEGIN PRIVATE KEY-----
+MDsCAQAwEAYHKoZIzj0CAQYFK4EEACAEJDAiAgEBBB0AdQ02GguRy3yHOjLkpoWb27QA/L1abfWe
+q2xUfA==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp224k1_PUB
+-----BEGIN PUBLIC KEY-----
+ME4wEAYHKoZIzj0CAQYFK4EEACADOgAEzp00m0DaADn1mGiDCT7K1LZnoj/vCxHPowUDC9yQd17K
+KpJM5sGILrTkkgxqtt5pBeYE1NC1QUQ=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp224k1:BOB_cf_secp224k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp224k1
+PeerKey=BOB_cf_secp224k1_PUB
+SharedSecret=6f7b9d16c9c1d3a5c84b6028f2a4fed9ae8e02455e678a27243bcc48
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp224k1
+PeerKey=ALICE_cf_secp224k1_PUB
+SharedSecret=6f7b9d16c9c1d3a5c84b6028f2a4fed9ae8e02455e678a27243bcc48
+
+Title=secp224r1 curve tests
+
+PrivateKey=ALICE_cf_secp224r1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwEAYHKoZIzj0CAQYFK4EEACEEIzAhAgEBBBzeo7Y0HMfrIqKNm3r997jcfVAa4osa0AR2
+JA28
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp224r1_PUB
+-----BEGIN PUBLIC KEY-----
+ME4wEAYHKoZIzj0CAQYFK4EEACEDOgAExZc6o84XjBGLOosGj2t0QctgiyzF3NcVgy+DeW7stkVs
+yS2tRzMPBpwnApRzoRsdJR99sb3eM2s=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp224r1:ALICE_cf_secp224r1_PUB
+
+PrivateKey=BOB_cf_secp224r1
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwEAYHKoZIzj0CAQYFK4EEACEEIzAhAgEBBBy2LsqxHhdlSiAmMYKQAEmjJWT22T42GYKo
+ZvXM
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp224r1_PUB
+-----BEGIN PUBLIC KEY-----
+ME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE71Eh6hwTKUrmyl2PdkY787GwxiohIcaqB4eK2Mwg6tU4
+LeJHWcgY18CgPKCaeldUgnkMcJzKj20=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp224r1:BOB_cf_secp224r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp224r1
+PeerKey=BOB_cf_secp224r1_PUB
+SharedSecret=29d8b75934d74d5153bbb94e0370437c63ecc30bf3d2800ed1cb7eb5
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp224r1
+PeerKey=ALICE_cf_secp224r1_PUB
+SharedSecret=29d8b75934d74d5153bbb94e0370437c63ecc30bf3d2800ed1cb7eb5
+
+Title=secp256k1 curve tests
+
+PrivateKey=ALICE_cf_secp256k1
+-----BEGIN PRIVATE KEY-----
+MD4CAQAwEAYHKoZIzj0CAQYFK4EEAAoEJzAlAgEBBCDV8jMZ/aJfiMEkW7HsYqbT57Y7vmvm5KN/
+QEXqsNCSpw==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp256k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElytZZZHc9CelGzZkNGpzY2CHQ+3z6tUnfsQxUmtiZnUg
+7oKfQC5BV8pZ5WYNPWnbT0RRg5kyBtzry9oQIhO5Lw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp256k1:ALICE_cf_secp256k1_PUB
+
+PrivateKey=BOB_cf_secp256k1
+-----BEGIN PRIVATE KEY-----
+MD4CAQAwEAYHKoZIzj0CAQYFK4EEAAoEJzAlAgEBBCBh7awFyPey/w4pKBycpAlhvT4DlLQsi1TT
+BxJPHrAjrA==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp256k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2BQeSJOa7kJAQsAPUbLseHjHhMe3tUOAl3bqoDqtrfO+
+2m2MP/IC/R9Kof2nmaiQ6DostdbS8kB+CnnprK375w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp256k1:BOB_cf_secp256k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp256k1
+PeerKey=BOB_cf_secp256k1_PUB
+SharedSecret=a4745cc4d19cabb9e5cb0abdd5c604cab2846a4638ad844ed9175f3cadda2da1
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp256k1
+PeerKey=ALICE_cf_secp256k1_PUB
+SharedSecret=a4745cc4d19cabb9e5cb0abdd5c604cab2846a4638ad844ed9175f3cadda2da1
+
+Title=secp384r1 curve tests
+
+PrivateKey=ALICE_cf_secp384r1
+-----BEGIN PRIVATE KEY-----
+ME4CAQAwEAYHKoZIzj0CAQYFK4EEACIENzA1AgEBBDAp1ErG6wVjuJs90qVbUBxNpQK1wtV4ieX1
+bIU/4HssZK6WjOOTyYguyEBCOf/rUnw=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp384r1_PUB
+-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEx5rt+yujIuPoIXpHGmExKSi/P+58sGYoqgdpdOJUXzn2
+Rc4alCpSxVJeC55xvwaFHc3pzNyRGwnhPmN6oU/KMP6XjBvR4wq35mr/Sym5s0B2blAzkJU37idq
+nTi3xGHx
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp384r1:ALICE_cf_secp384r1_PUB
+
+PrivateKey=BOB_cf_secp384r1
+-----BEGIN PRIVATE KEY-----
+ME4CAQAwEAYHKoZIzj0CAQYFK4EEACIENzA1AgEBBDAUjVgPpiI+xXye0nfRhc8+12hLdWY4fpsO
+Jq2MCp+W85xJwtXsEPrHj1XFnKVpM4c=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp384r1_PUB
+-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+JUBXRSHixH0TrcvYvIzep7+/WNpEhWdCPsLMygigW5j
+pzP30MF41GnQYgfJu5wI/gu1C/jFTv1X6Dgmla3JxBYlPeD+1L0lEMT3evmHKMM/BFe3WKBuXyhP
+ilrNtfee
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp384r1:BOB_cf_secp384r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp384r1
+PeerKey=BOB_cf_secp384r1_PUB
+SharedSecret=b3cfe488126e2731fb7c19f82e94fcc05e1dd303649a9257e858030b795c2d344a054b0c44a24fd7f5821f531a9b8cfb
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp384r1
+PeerKey=ALICE_cf_secp384r1_PUB
+SharedSecret=b3cfe488126e2731fb7c19f82e94fcc05e1dd303649a9257e858030b795c2d344a054b0c44a24fd7f5821f531a9b8cfb
+
+Title=secp521r1 curve tests
+
+PrivateKey=ALICE_cf_secp521r1
+-----BEGIN PRIVATE KEY-----
+MGACAQAwEAYHKoZIzj0CAQYFK4EEACMESTBHAgEBBEIBsYIcUKeN2evB626LCdYWH/xzUiEDCdRP
+rEENsC8//dowKnOCtlLtawh0DXTIZ/HhpUREuaoffdsmYb6+Oq1TRjc=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_secp521r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBufYxJf/4Ds6g7LlFRVS62ljm3xApV2T79hfWH8Lv
+iroIaCFjLBIfOVDF8jvj2PO1ar3yCLiSA2RiLZz1Y+tv/tcATHE0nS7l3SfGiGmEnVycEnhgqlKM
+UM3kpdd7eNkQn5/GO8KAPQqA/sOnvTavg5S01t0ub+PY/w0Y6oBgthaUAW0=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_secp521r1:ALICE_cf_secp521r1_PUB
+
+PrivateKey=BOB_cf_secp521r1
+-----BEGIN PRIVATE KEY-----
+MGACAQAwEAYHKoZIzj0CAQYFK4EEACMESTBHAgEBBEIB+3/adZnNwr6GFUzZpi8So7pC/5FYQ0+0
+lMmoUjGvy8DNADcHaPpW68hX/M+z7LrK0Jpnonb9JSEXlgjOPVe4Ea8=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_secp521r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBLq2fjyCalnvr24tjaz87ijIWlLMoCH7Hmyq1t2l8
+PFbyBIZbngDC0gwFM5ZI582QSWlW79G3clJP9VxlJOsms50BYBYgd6o2JF4w8AnShVXxFSJU1py4
+klCDNhTFybRHFXpujfuUeNnFxAGIUb4edJ0fAqqc7kkERhYe8EPEZYMKp3Q=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_secp521r1:BOB_cf_secp521r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_secp521r1
+PeerKey=BOB_cf_secp521r1_PUB
+SharedSecret=01dd4aa9037bb4ad298b420998dcd32b3a9af1cda8b7919e372aeb4e54ccfb4d2409a340ed896bfbc5dd462f8d96b8784bc17b29db3ca04700e6ec752f9bec777695
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_secp521r1
+PeerKey=ALICE_cf_secp521r1_PUB
+SharedSecret=01dd4aa9037bb4ad298b420998dcd32b3a9af1cda8b7919e372aeb4e54ccfb4d2409a340ed896bfbc5dd462f8d96b8784bc17b29db3ca04700e6ec752f9bec777695
+
+Title=sect113r1 curve tests
+
+PrivateKey=ALICE_cf_sect113r1
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFK4EEAAQEFjAUAgEBBA8ALw9CgsuNBkkhhUHE8bQ=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect113r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFK4EEAAQDIAAEASO9jcamlg1pRE7JffrTAe9kyRZO2xrymHXoGdnA
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect113r1:ALICE_cf_sect113r1_PUB
+
+PrivateKey=BOB_cf_sect113r1
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFK4EEAAQEFjAUAgEBBA8A/9qbs8sTFNkjS9/4CuM=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect113r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFK4EEAAQDIAAEATykaf/cvJzLOUto1EbbAEz/3++nut6q0dcJOQeV
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect113r1:BOB_cf_sect113r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect113r1
+PeerKey=BOB_cf_sect113r1_PUB
+SharedSecret=01ed16f1948dcb368a54004237842d
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect113r1
+PeerKey=ALICE_cf_sect113r1_PUB
+SharedSecret=01ed16f1948dcb368a54004237842d
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect113r1
+PeerKey=BOB_cf_sect113r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=012e5f3e348c2a8a88d9590a639219
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect113r1
+PeerKey=ALICE_cf_sect113r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=012e5f3e348c2a8a88d9590a639219
+
+PublicKey=MALICE_cf_sect113r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFK4EEAAQDIAAEAAAAAAAAAAAAAAAAAAAAAd+TqiBXnTd/lyA/OFsR
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect113r1
+PeerKey=MALICE_cf_sect113r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect113r1
+PeerKey=MALICE_cf_sect113r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect113r2 curve tests
+
+PrivateKey=ALICE_cf_sect113r2
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFK4EEAAUEFjAUAgEBBA8AvovirHrqTxoKJ3l+7y0=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect113r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFK4EEAAUDIAAEAFvQ4JgQTS8kjGeVfuITAS81qNcOQvt3PYa1HuCk
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect113r2:ALICE_cf_sect113r2_PUB
+
+PrivateKey=BOB_cf_sect113r2
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFK4EEAAUEFjAUAgEBBA8ArUjgvp/goxRYb4WuQ80=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect113r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFK4EEAAUDIAAEAUoS3of8y28meYu/NoI5AVdhJZCuDjMqFHTriWY4
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect113r2:BOB_cf_sect113r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect113r2
+PeerKey=BOB_cf_sect113r2_PUB
+SharedSecret=0057a287ba1ea05cb4735e673647e1
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect113r2
+PeerKey=ALICE_cf_sect113r2_PUB
+SharedSecret=0057a287ba1ea05cb4735e673647e1
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect113r2
+PeerKey=BOB_cf_sect113r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00fec2454e46732aca42b22b6d4f13
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect113r2
+PeerKey=ALICE_cf_sect113r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00fec2454e46732aca42b22b6d4f13
+
+PublicKey=MALICE_cf_sect113r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFK4EEAAUDIAAEAAAAAAAAAAAAAAAAAAAAAR3dbPHrhFekzJ7Azskr
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect113r2
+PeerKey=MALICE_cf_sect113r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect113r2
+PeerKey=MALICE_cf_sect113r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect131r1 curve tests
+
+PrivateKey=ALICE_cf_sect131r1
+-----BEGIN PRIVATE KEY-----
+MC8CAQAwEAYHKoZIzj0CAQYFK4EEABYEGDAWAgEBBBEA5C6zHMQM7pXPZ6cJz72Niw==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect131r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDgwEAYHKoZIzj0CAQYFK4EEABYDJAAEBXCuXD6wOOif91GUlJNKXf8FBNw8crgqi5aEJEZbCdBJ
+Ag==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect131r1:ALICE_cf_sect131r1_PUB
+
+PrivateKey=BOB_cf_sect131r1
+-----BEGIN PRIVATE KEY-----
+MC8CAQAwEAYHKoZIzj0CAQYFK4EEABYEGDAWAgEBBBEDYZmjiokBJ/SnTv8sskBR3A==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect131r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDgwEAYHKoZIzj0CAQYFK4EEABYDJAAEB8vGy3OQXwWKcJUSSJbCtpMBjFgJeZxzAaI420+B1B+1
+5A==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect131r1:BOB_cf_sect131r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect131r1
+PeerKey=BOB_cf_sect131r1_PUB
+SharedSecret=05346248f77f81fff50cc656e119976871
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect131r1
+PeerKey=ALICE_cf_sect131r1_PUB
+SharedSecret=05346248f77f81fff50cc656e119976871
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect131r1
+PeerKey=BOB_cf_sect131r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01f151ae26efa507acc2597356baf7e8ab
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect131r1
+PeerKey=ALICE_cf_sect131r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01f151ae26efa507acc2597356baf7e8ab
+
+PublicKey=MALICE_cf_sect131r1_PUB
+-----BEGIN PUBLIC KEY-----
+MDgwEAYHKoZIzj0CAQYFK4EEABYDJAAEAAAAAAAAAAAAAAAAAAAAAAABfiJEFG0vRzEGxk2BxjmK
+zw==
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect131r1
+PeerKey=MALICE_cf_sect131r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect131r1
+PeerKey=MALICE_cf_sect131r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect131r2 curve tests
+
+PrivateKey=ALICE_cf_sect131r2
+-----BEGIN PRIVATE KEY-----
+MC8CAQAwEAYHKoZIzj0CAQYFK4EEABcEGDAWAgEBBBEBnZRUKAQetk5kyUwhIaAyxg==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect131r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDgwEAYHKoZIzj0CAQYFK4EEABcDJAAEA5+Y20L8q989I4jnKknZ7hcGlQ6RUIGni9RahT88kB/d
+dw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect131r2:ALICE_cf_sect131r2_PUB
+
+PrivateKey=BOB_cf_sect131r2
+-----BEGIN PRIVATE KEY-----
+MC8CAQAwEAYHKoZIzj0CAQYFK4EEABcEGDAWAgEBBBEBnafx9vcMeoCqj/1YNuflzw==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect131r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDgwEAYHKoZIzj0CAQYFK4EEABcDJAAEB2G2uNkhQNjjl0/Ov6UYpxoFaWNXO+qy7poV6cdrFN7z
+pA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect131r2:BOB_cf_sect131r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect131r2
+PeerKey=BOB_cf_sect131r2_PUB
+SharedSecret=058d8a8be33068ed8c1dc9f551ef2c3f3c
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect131r2
+PeerKey=ALICE_cf_sect131r2_PUB
+SharedSecret=058d8a8be33068ed8c1dc9f551ef2c3f3c
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect131r2
+PeerKey=BOB_cf_sect131r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=037b16d85f27c2c878ef96c79a536f89a5
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect131r2
+PeerKey=ALICE_cf_sect131r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=037b16d85f27c2c878ef96c79a536f89a5
+
+PublicKey=MALICE_cf_sect131r2_PUB
+-----BEGIN PUBLIC KEY-----
+MDgwEAYHKoZIzj0CAQYFK4EEABcDJAAEAAAAAAAAAAAAAAAAAAAAAAAGG5fiIbgziwBZHVzTYqCY
+1w==
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect131r2
+PeerKey=MALICE_cf_sect131r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect131r2
+PeerKey=MALICE_cf_sect131r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect163k1 curve tests
+
+PrivateKey=ALICE_cf_sect163k1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAEEHDAaAgEBBBUB905PYfmej8LzbzX6Bg51GJzXQjQ=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect163k1_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAAEDLAAEBfvs5A1hD8YySP9O2ub8GEUfotVuBpfRx4GIHdAfx8wV
+1UVeTRnyAlWU
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect163k1:ALICE_cf_sect163k1_PUB
+
+PrivateKey=BOB_cf_sect163k1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAEEHDAaAgEBBBUCHPtCjJ4/K8ylQBcLlb5VE0bkaUE=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect163k1_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAAEDLAAEBvgfX1mTRlt6Z4TE1D1MNWo4loH4AoeYa6oowK104LKk
+nsdg7isQ8XBD
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect163k1:BOB_cf_sect163k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect163k1
+PeerKey=BOB_cf_sect163k1_PUB
+SharedSecret=04d0e40788c5ce5220818055277cae53eac55c1e6b
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect163k1
+PeerKey=ALICE_cf_sect163k1_PUB
+SharedSecret=04d0e40788c5ce5220818055277cae53eac55c1e6b
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect163k1
+PeerKey=BOB_cf_sect163k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=04c902a91110244d89110034dd2b099c49cbab6c77
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect163k1
+PeerKey=ALICE_cf_sect163k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=04c902a91110244d89110034dd2b099c49cbab6c77
+
+PublicKey=MALICE_cf_sect163k1_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAAEDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAB
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect163k1
+PeerKey=MALICE_cf_sect163k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect163k1
+PeerKey=MALICE_cf_sect163k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect163r1 curve tests
+
+PrivateKey=ALICE_cf_sect163r1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAIEHDAaAgEBBBUAlbn4x1UGJnAimsXufB/UvUaxU5U=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect163r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAAIDLAAEA0f195HCcD4D+7wWyl3QuPkRovG/ATy5l7fpMl4BNIg/
+sbtEXluCzANF
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect163r1:ALICE_cf_sect163r1_PUB
+
+PrivateKey=BOB_cf_sect163r1
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAIEHDAaAgEBBBUAoStq6Fjb7nB2PNL6WrzKKqhCGdE=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect163r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAAIDLAAEAul/oBKr9B5MsPHWGF+q07j0JC+WAxj1JzfcIXR98n+r
+9FHWU5LC5pDM
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect163r1:BOB_cf_sect163r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect163r1
+PeerKey=BOB_cf_sect163r1_PUB
+SharedSecret=06135eef489fe613c0d8bd522a2a640ff7ae6fb73d
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect163r1
+PeerKey=ALICE_cf_sect163r1_PUB
+SharedSecret=06135eef489fe613c0d8bd522a2a640ff7ae6fb73d
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect163r1
+PeerKey=BOB_cf_sect163r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0580f5e8efb242a19ae1023acbcab8702c799751e7
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect163r1
+PeerKey=ALICE_cf_sect163r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0580f5e8efb242a19ae1023acbcab8702c799751e7
+
+PublicKey=MALICE_cf_sect163r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAAIDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJkXolVuGFa8fqmk
+cs0Bv7iJuVg1
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect163r1
+PeerKey=MALICE_cf_sect163r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect163r1
+PeerKey=MALICE_cf_sect163r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect163r2 curve tests
+
+PrivateKey=ALICE_cf_sect163r2
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAA8EHDAaAgEBBBUBjCs/M3N31jsAueYrOq21vdETwAI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect163r2_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAA8DLAAEBd8Z1/HpA+89hF4I98EST3svWns3BAEbhWmL/fgxk2uu
+YwVrmqhgqH/C
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect163r2:ALICE_cf_sect163r2_PUB
+
+PrivateKey=BOB_cf_sect163r2
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFK4EEAA8EHDAaAgEBBBUBsiouT9Df+mwHWrpPg1JSrY9nqlI=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect163r2_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAA8DLAAEBULqBZ+nhLhDEMYY8NEEzZ126MdxAcFXWv8zmPEH9505
+8vT5zU3aq6HV
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect163r2:BOB_cf_sect163r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect163r2
+PeerKey=BOB_cf_sect163r2_PUB
+SharedSecret=019f829a53c4e6544bdec1395a23082169efaf369d
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect163r2
+PeerKey=ALICE_cf_sect163r2_PUB
+SharedSecret=019f829a53c4e6544bdec1395a23082169efaf369d
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect163r2
+PeerKey=BOB_cf_sect163r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=048870d39235ecbc16a000ee478833509b9318a53f
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect163r2
+PeerKey=ALICE_cf_sect163r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=048870d39235ecbc16a000ee478833509b9318a53f
+
+PublicKey=MALICE_cf_sect163r2_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFK4EEAA8DLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsJbhbrfiSdZPSHD
+ZtqJwDlp802l
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect163r2
+PeerKey=MALICE_cf_sect163r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect163r2
+PeerKey=MALICE_cf_sect163r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect193r1 curve tests
+
+PrivateKey=ALICE_cf_sect193r1
+-----BEGIN PRIVATE KEY-----
+MDcCAQAwEAYHKoZIzj0CAQYFK4EEABgEIDAeAgEBBBkACmcvidKWLtPFB2xqg76F8VhM1Njzrkgo
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect193r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEgwEAYHKoZIzj0CAQYFK4EEABgDNAAEAeqP0VQobenduwtf4MPmlYQVDjUmxKq50QFHnaBfzwXY
+1TYShZZgBr0R6a5dUGCbiF0=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect193r1:ALICE_cf_sect193r1_PUB
+
+PrivateKey=BOB_cf_sect193r1
+-----BEGIN PRIVATE KEY-----
+MDcCAQAwEAYHKoZIzj0CAQYFK4EEABgEIDAeAgEBBBkAKlSknQ66vpuLjC1mbQyfHOTdJ5Kw5jMh
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect193r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEgwEAYHKoZIzj0CAQYFK4EEABgDNAAEAaFZVIeqfV9wbPydaBSJKSWJjVyFVSB/QQB5rHonYQmK
+f40zok8PJS6ratIcZwk/n20=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect193r1:BOB_cf_sect193r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect193r1
+PeerKey=BOB_cf_sect193r1_PUB
+SharedSecret=012b8849991814f8c7ed9d40cf9dc204c3a83e0b10675543a5
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect193r1
+PeerKey=ALICE_cf_sect193r1_PUB
+SharedSecret=012b8849991814f8c7ed9d40cf9dc204c3a83e0b10675543a5
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect193r1
+PeerKey=BOB_cf_sect193r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0110180a18844859c52f6f012909522a2d87b5ab143bc80a55
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect193r1
+PeerKey=ALICE_cf_sect193r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0110180a18844859c52f6f012909522a2d87b5ab143bc80a55
+
+PublicKey=MALICE_cf_sect193r1_PUB
+-----BEGIN PUBLIC KEY-----
+MEgwEAYHKoZIzj0CAQYFK4EEABgDNAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHeX7PX3e5n
+zROUg6/STkLp1D+L51L9+wY=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect193r1
+PeerKey=MALICE_cf_sect193r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect193r1
+PeerKey=MALICE_cf_sect193r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect193r2 curve tests
+
+PrivateKey=ALICE_cf_sect193r2
+-----BEGIN PRIVATE KEY-----
+MDcCAQAwEAYHKoZIzj0CAQYFK4EEABkEIDAeAgEBBBkAhjkv8lXK/nPp3Qc4IwL/29JUKWi2VBMp
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect193r2_PUB
+-----BEGIN PUBLIC KEY-----
+MEgwEAYHKoZIzj0CAQYFK4EEABkDNAAEAIn7oSu3adu4ChNXniHKkMIv9gT24rpzzwAeCTDPIkUT
+kJ+Tit6e4RpgkB/dph4V+uI=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect193r2:ALICE_cf_sect193r2_PUB
+
+PrivateKey=BOB_cf_sect193r2
+-----BEGIN PRIVATE KEY-----
+MDcCAQAwEAYHKoZIzj0CAQYFK4EEABkEIDAeAgEBBBkAwGkR3qSQdfh7Q6KbJ4lH5FShGsX8o/jD
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect193r2_PUB
+-----BEGIN PUBLIC KEY-----
+MEgwEAYHKoZIzj0CAQYFK4EEABkDNAAEAFdSLKI0tlwZDpkndutOLsnHii1aJO8snwEJ0m/AZgMp
+xiDevOQ/xE9SpMX25W7YqkU=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect193r2:BOB_cf_sect193r2_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect193r2
+PeerKey=BOB_cf_sect193r2_PUB
+SharedSecret=01e2f66a63c24c1de8a399c484228a5ad5b6d911c6e5e83ae3
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect193r2
+PeerKey=ALICE_cf_sect193r2_PUB
+SharedSecret=01e2f66a63c24c1de8a399c484228a5ad5b6d911c6e5e83ae3
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect193r2
+PeerKey=BOB_cf_sect193r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00bc82d393bd74406683aea003977a86a109f444a833652e43
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect193r2
+PeerKey=ALICE_cf_sect193r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00bc82d393bd74406683aea003977a86a109f444a833652e43
+
+PublicKey=MALICE_cf_sect193r2_PUB
+-----BEGIN PUBLIC KEY-----
+MEgwEAYHKoZIzj0CAQYFK4EEABkDNAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFfdLEkrvsO
+Y7+6QpEvOay9A4MJCUZfZmI=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect193r2
+PeerKey=MALICE_cf_sect193r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect193r2
+PeerKey=MALICE_cf_sect193r2_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect233k1 curve tests
+
+PrivateKey=ALICE_cf_sect233k1
+-----BEGIN PRIVATE KEY-----
+MDsCAQAwEAYHKoZIzj0CAQYFK4EEABoEJDAiAgEBBB0z/3heNFjJL+2sAT/38yRsN3kt2iXz7u+y
+Gua8Kw==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect233k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEABoDPgAEALQyn0zJmOrHm4S2EIjxRe899PadBnfpYjLKWGvpAIzf
+MEG861Nv1IYJkmkO1xlfNHeeRtqFgsQVFKZh
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect233k1:ALICE_cf_sect233k1_PUB
+
+PrivateKey=BOB_cf_sect233k1
+-----BEGIN PRIVATE KEY-----
+MDsCAQAwEAYHKoZIzj0CAQYFK4EEABoEJDAiAgEBBB1I0ucrC4d9i6Z+0cbar5r7uKpF5iiQkSJA
+DFMTUA==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect233k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEABoDPgAEAatdqazxSghJ568CBFyMXhEvVeAiLewOY/jk9H5DAOB4
+ufNGbdd131KLaKPivB38a6n5Y+2BVSJangow
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect233k1:BOB_cf_sect233k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect233k1
+PeerKey=BOB_cf_sect233k1_PUB
+SharedSecret=012145026e8de65973c154e085456fc5539ba9e25663e7f5816abfcab310
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect233k1
+PeerKey=ALICE_cf_sect233k1_PUB
+SharedSecret=012145026e8de65973c154e085456fc5539ba9e25663e7f5816abfcab310
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect233k1
+PeerKey=BOB_cf_sect233k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00ff7d6c6b80f39d2ae68fbd00adbcd75fa599ed0bc1aac0e3f49c1c164d
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect233k1
+PeerKey=ALICE_cf_sect233k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00ff7d6c6b80f39d2ae68fbd00adbcd75fa599ed0bc1aac0e3f49c1c164d
+
+PublicKey=MALICE_cf_sect233k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEABoDPgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect233k1
+PeerKey=MALICE_cf_sect233k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect233k1
+PeerKey=MALICE_cf_sect233k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect233r1 curve tests
+
+PrivateKey=ALICE_cf_sect233r1
+-----BEGIN PRIVATE KEY-----
+MDwCAQAwEAYHKoZIzj0CAQYFK4EEABsEJTAjAgEBBB4ATcy7zVpIsJ9rl5EIDmzRz5wxjrDIQyDm
+HP3Pt8Y=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect233r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEABsDPgAEAQMQHiJ44LiCnZkEg1zyww1h+idTbsw8E07P33WUAUfD
+NeQ4hWEhTXPnytIbEhFKpnd3j/FbyZnJqxh8
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect233r1:ALICE_cf_sect233r1_PUB
+
+PrivateKey=BOB_cf_sect233r1
+-----BEGIN PRIVATE KEY-----
+MDwCAQAwEAYHKoZIzj0CAQYFK4EEABsEJTAjAgEBBB4ALpOlFn4OfiIAkRAZGOsn7L6W3XoQBSV8
+mQVC2pw=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect233r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEABsDPgAEAJQw+NWqFJXYw4dVMovzvw76OYnYOTaDaEPNW8ECAQbl
+TzzbBSTp5iqM13mP0/Bo4OO66NS3lA9e/GTO
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect233r1:BOB_cf_sect233r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect233r1
+PeerKey=BOB_cf_sect233r1_PUB
+SharedSecret=00209d2995a63f1e8b7a5c33dee5abb602e32e1835ae8bb57eb264d8d795
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect233r1
+PeerKey=ALICE_cf_sect233r1_PUB
+SharedSecret=00209d2995a63f1e8b7a5c33dee5abb602e32e1835ae8bb57eb264d8d795
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect233r1
+PeerKey=BOB_cf_sect233r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00c3cd1d38a65f5e421399409a76cec1136bc84149f054a7f55e7980c612
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect233r1
+PeerKey=ALICE_cf_sect233r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00c3cd1d38a65f5e421399409a76cec1136bc84149f054a7f55e7980c612
+
+PublicKey=MALICE_cf_sect233r1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEABsDPgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYf4
+Vie5eHTnR+4x4G1xyq7qUvISU+X5RtBh2pE4
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect233r1
+PeerKey=MALICE_cf_sect233r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect233r1
+PeerKey=MALICE_cf_sect233r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect239k1 curve tests
+
+PrivateKey=ALICE_cf_sect239k1
+-----BEGIN PRIVATE KEY-----
+MDwCAQAwEAYHKoZIzj0CAQYFK4EEAAMEJTAjAgEBBB4G4nbQDUtTnkrPOvDGIlhH9XdjirUSbTI5
+5z6lf7o=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect239k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEAAMDPgAEf5paOMjzcnpVAPMQnIkikE4K2jne3ubX2TD1P3aedknF
+lUr6tOU4BsiUQJACF90rQ9/KdeR5mYvYHzvI
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect239k1:ALICE_cf_sect239k1_PUB
+
+PrivateKey=BOB_cf_sect239k1
+-----BEGIN PRIVATE KEY-----
+MDwCAQAwEAYHKoZIzj0CAQYFK4EEAAMEJTAjAgEBBB4e0F0NpepAF+iNrEtoZeo4TrQFspkUNLcx
+Ly4Klfg=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect239k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEAAMDPgAEKnjJ4RHe+EiElXMrF4ou7VGy1pn0ZiO17FouF31Zbvjc
+TcbhfE6ziXM8sekQJBwcwRKQ9+G/Qzq/2A9x
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect239k1:BOB_cf_sect239k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect239k1
+PeerKey=BOB_cf_sect239k1_PUB
+SharedSecret=0ef54c7b7dbf55d4278e7a6924dc4833c63ec708e820d501cacdfb4935d5
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect239k1
+PeerKey=ALICE_cf_sect239k1_PUB
+SharedSecret=0ef54c7b7dbf55d4278e7a6924dc4833c63ec708e820d501cacdfb4935d5
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect239k1
+PeerKey=BOB_cf_sect239k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=592e4b33ac99624fe7f2f879cf52f12a70f189c5d90785db26a12e0a46c0
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect239k1
+PeerKey=ALICE_cf_sect239k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=592e4b33ac99624fe7f2f879cf52f12a70f189c5d90785db26a12e0a46c0
+
+PublicKey=MALICE_cf_sect239k1_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFK4EEAAMDPgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect239k1
+PeerKey=MALICE_cf_sect239k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect239k1
+PeerKey=MALICE_cf_sect239k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect283k1 curve tests
+
+PrivateKey=ALICE_cf_sect283k1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwEAYHKoZIzj0CAQYFK4EEABAEKzApAgEBBCQAY1Mi9rST7PiP1t03qYRczV/kSZ+VjQu8
+5EFCgxyvkaLManw=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect283k1_PUB
+-----BEGIN PUBLIC KEY-----
+MF4wEAYHKoZIzj0CAQYFK4EEABADSgAEBMjBO8WoxHS/vz8po52WZGxS+RK5yolrUe6tfbAMA3Sd
+5/JjBDVjOz95vM4gUnqzUWHN5nKBQtj6HiU9Q/R+zqg98OiQKTyA
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect283k1:ALICE_cf_sect283k1_PUB
+
+PrivateKey=BOB_cf_sect283k1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwEAYHKoZIzj0CAQYFK4EEABAEKzApAgEBBCQBCZC8Is+YSjgXJBBDioEl6gu14QpGHllD
+1J6957vBTPSQdH0=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect283k1_PUB
+-----BEGIN PUBLIC KEY-----
+MF4wEAYHKoZIzj0CAQYFK4EEABADSgAEAGEQKZVHYAlvtjHrFyZVm12qUb5j+T5/WNoC962+kwUM
+QkBYA5BpuG8Knlugq1iB31whPAgRCZfdLKHpHRPJSfXvKyUIdeUm
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect283k1:BOB_cf_sect283k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect283k1
+PeerKey=BOB_cf_sect283k1_PUB
+SharedSecret=03f67c88bdc230b43773d17fdb4d0a980556d074ceccee726932160e4ed965e3be72803c
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect283k1
+PeerKey=ALICE_cf_sect283k1_PUB
+SharedSecret=03f67c88bdc230b43773d17fdb4d0a980556d074ceccee726932160e4ed965e3be72803c
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect283k1
+PeerKey=BOB_cf_sect283k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0677ba01c84d139609ca145cb5b6079fc9ca67f59c9c913e47cad1073f1d1dfaddde0169
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect283k1
+PeerKey=ALICE_cf_sect283k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0677ba01c84d139609ca145cb5b6079fc9ca67f59c9c913e47cad1073f1d1dfaddde0169
+
+PublicKey=MALICE_cf_sect283k1_PUB
+-----BEGIN PUBLIC KEY-----
+MF4wEAYHKoZIzj0CAQYFK4EEABADSgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect283k1
+PeerKey=MALICE_cf_sect283k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect283k1
+PeerKey=MALICE_cf_sect283k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect283r1 curve tests
+
+PrivateKey=ALICE_cf_sect283r1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwEAYHKoZIzj0CAQYFK4EEABEEKzApAgEBBCQCQ5pqKvPxDysd1pi2Bv8Z11cFhsRZfuaf
+4Pi0hpGr4ubZcHE=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect283r1_PUB
+-----BEGIN PUBLIC KEY-----
+MF4wEAYHKoZIzj0CAQYFK4EEABEDSgAEBcsrGDgO7pbGybQX/00gRHtQq3+X9XrGb7Uzv9Nabwc/
+kntnBMF0I2KU+aaTjQx1GVtmNf7CvFwPLEBnfKjJAjekjsGyIqoq
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect283r1:ALICE_cf_sect283r1_PUB
+
+PrivateKey=BOB_cf_sect283r1
+-----BEGIN PRIVATE KEY-----
+MEICAQAwEAYHKoZIzj0CAQYFK4EEABEEKzApAgEBBCQDxItnY3cDCrX/jGnVuAKDPaySZCr3E83Q
+UdFnP6YIykt7+Pg=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect283r1_PUB
+-----BEGIN PUBLIC KEY-----
+MF4wEAYHKoZIzj0CAQYFK4EEABEDSgAEBJ2C9BCkX0YRfs2ufgUKvreUXFWp2AGK+iHlZB4N3LqO
+PKpmAkrAeCMty6mw2mEnOR5HA1d4Ee+z7/NJgJJ80Ra9bFnreOW3
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect283r1:BOB_cf_sect283r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect283r1
+PeerKey=BOB_cf_sect283r1_PUB
+SharedSecret=0424259cf09727574fb863cab7c27d8fe3835e96433110a45a951f94347fc81939ec4773
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect283r1
+PeerKey=ALICE_cf_sect283r1_PUB
+SharedSecret=0424259cf09727574fb863cab7c27d8fe3835e96433110a45a951f94347fc81939ec4773
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect283r1
+PeerKey=BOB_cf_sect283r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01c2a542654ce85b17456ed75b6bca6b6eb761580913670debc426a3525f236df0e875c8
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect283r1
+PeerKey=ALICE_cf_sect283r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01c2a542654ce85b17456ed75b6bca6b6eb761580913670debc426a3525f236df0e875c8
+
+PublicKey=MALICE_cf_sect283r1_PUB
+-----BEGIN PUBLIC KEY-----
+MF4wEAYHKoZIzj0CAQYFK4EEABEDSgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAByvMnFeSsevoGYMIn7b4NaL9IgowRCTKF8CCrhdEKu3pubP2
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect283r1
+PeerKey=MALICE_cf_sect283r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect283r1
+PeerKey=MALICE_cf_sect283r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect409k1 curve tests
+
+PrivateKey=ALICE_cf_sect409k1
+-----BEGIN PRIVATE KEY-----
+MFECAQAwEAYHKoZIzj0CAQYFK4EEACQEOjA4AgEBBDMOthcLahkXFgM0wjOzm767D1A72sFRGlhb
+bVH+EB7z2WpIcPX4OD+M4Y1pf/a7wSaoSAo=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect409k1_PUB
+-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACQDagAEAbiYYpeFgCMsZFMzQaiwMJDrC+mCMT7KmhYtD5EMMgLW
+5OvhaqYdpRf49A8LOtVcRT7J5gGcMrXQgmQeS3FenA5owWnB2NIgrTNf5d8AAEtrOupsJ4c3kL6e
+aAzayZ1+UCEj8skbC9U=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect409k1:ALICE_cf_sect409k1_PUB
+
+PrivateKey=BOB_cf_sect409k1
+-----BEGIN PRIVATE KEY-----
+MFECAQAwEAYHKoZIzj0CAQYFK4EEACQEOjA4AgEBBDMO43ldQllTewdZwffH4OEXdzBrLwabKsn4
+6/hjgIAaYda/pt4yCEQLMp18QgtfMey5ENI=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect409k1_PUB
+-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACQDagAEAVTQj6hRizVmOx4Z6vroN/zMkmAY+QhkQ0CnFeJ0AydY
+Fv+f+/420vMC1Mhqsc9VzPMmIAH6ZrgGKDsd4Ce9JUtYE0rVhGeiG2RaN1U5RlhVK4avkWhFlyQ5
+vuu4aApQiWE3yQd9v/I=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect409k1:BOB_cf_sect409k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect409k1
+PeerKey=BOB_cf_sect409k1_PUB
+SharedSecret=01fbe13188588c9d1ac3a8a2680ea9a009b28e4b7d7fa4efcb1a22553876fb7973616819fd87c75e5b8ce6e3628595e4ce12edb0
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect409k1
+PeerKey=ALICE_cf_sect409k1_PUB
+SharedSecret=01fbe13188588c9d1ac3a8a2680ea9a009b28e4b7d7fa4efcb1a22553876fb7973616819fd87c75e5b8ce6e3628595e4ce12edb0
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect409k1
+PeerKey=BOB_cf_sect409k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=007e9485f7234bb2255bb40e51f4be867cb0ef31f8e489a697b31b51c4d5346daaee51e96ae6f9636e6e3af56095fe28755325ee
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect409k1
+PeerKey=ALICE_cf_sect409k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=007e9485f7234bb2255bb40e51f4be867cb0ef31f8e489a697b31b51c4d5346daaee51e96ae6f9636e6e3af56095fe28755325ee
+
+PublicKey=MALICE_cf_sect409k1_PUB
+-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACQDagAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAA=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect409k1
+PeerKey=MALICE_cf_sect409k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect409k1
+PeerKey=MALICE_cf_sect409k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect409r1 curve tests
+
+PrivateKey=ALICE_cf_sect409r1
+-----BEGIN PRIVATE KEY-----
+MFICAQAwEAYHKoZIzj0CAQYFK4EEACUEOzA5AgEBBDQAxSC9lST5dtfXQI1Ug9VMMoue3GGni5ON
++gieyXK2KKbd29KAPs4/AOd8kX2wQDsZPO7E
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect409r1_PUB
+-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACUDagAEASAvXAM15DJerAu1JttpBuMJK1/fEfFohu2iEpt3r7Ui
+iQoER6HUsWiw1hhcJyTv7WzpJQHFWrOlJMe/KjmQa/CygSc65YHDzG27oUL+KGdQUGc79ZRSwl/q
+fGZqa3D+bDVMwrhmZto=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect409r1:ALICE_cf_sect409r1_PUB
+
+PrivateKey=BOB_cf_sect409r1
+-----BEGIN PRIVATE KEY-----
+MFICAQAwEAYHKoZIzj0CAQYFK4EEACUEOzA5AgEBBDQARen+1P3JQzBgOv0pUYwsZTPRVLpqqDAU
+7mKL2lk9eH7zSGmtNoMvP2m1S2dBnXxFY/bV
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect409r1_PUB
+-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACUDagAEAbDUw066TtdfOpDvrlKosEyqUNEG7rY+AKvDqKw+HOzf
+sUTYee6cEf71oqJ1sCKPQiYzlwCu/HLQeWPxISE6Uo+53kkeJml2xpMBwoE25Gq/DSS61dR7SRTZ
++sUmumbIuGzbrjtMRmw=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect409r1:BOB_cf_sect409r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect409r1
+PeerKey=BOB_cf_sect409r1_PUB
+SharedSecret=00a751259cdb3b445ce71a40a01a2189dfce70226111190505fc6eabe4e5a05bff7af55f2015e1ffcab6aea7ea9a6e74905da2a1
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect409r1
+PeerKey=ALICE_cf_sect409r1_PUB
+SharedSecret=00a751259cdb3b445ce71a40a01a2189dfce70226111190505fc6eabe4e5a05bff7af55f2015e1ffcab6aea7ea9a6e74905da2a1
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect409r1
+PeerKey=BOB_cf_sect409r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0115a31aed416c5089d74a263ec300aff13a5329c6ad27de950ae0b0917b40a3464fccf5691ac9633a51e5177a82b15cfc434aad
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect409r1
+PeerKey=ALICE_cf_sect409r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=0115a31aed416c5089d74a263ec300aff13a5329c6ad27de950ae0b0917b40a3464fccf5691ac9633a51e5177a82b15cfc434aad
+
+PublicKey=MALICE_cf_sect409r1_PUB
+-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACUDagAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAACZNffkdo7i7yL5tKKfU8tdk6su0K185XwbJkn96JWVDPZXZ3My
+bFKKSOJ7hyrM8Lwl1e8=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect409r1
+PeerKey=MALICE_cf_sect409r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect409r1
+PeerKey=MALICE_cf_sect409r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect571k1 curve tests
+
+PrivateKey=ALICE_cf_sect571k1
+-----BEGIN PRIVATE KEY-----
+MGYCAQAwEAYHKoZIzj0CAQYFK4EEACYETzBNAgEBBEgB4agvk7Qdf9bVb9aMVdtXL0MuVw6dTleB
+zrpPMYty/piI5GWkQEGVp4OJSjF1BGgWmtYSYlV0oI8jJ7hfWTjVGfVWix4ipb8=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect571k1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGnMBAGByqGSM49AgEGBSuBBAAmA4GSAAQDUZq0ZrgYpTXNpOptjExaur0K9FAYHv1j9cvAptwX
+dcmQf3VqekMkGZCfNdqNeqCajG3QHRkBHe4FZhWr3FXi8whvvr463lUDf+t46un1kE6FTYfhILGa
+sBZm7OdfkarYd9TXBbmnkFA+XkyPlkM1+6daM3/WmnegK+TYghFDXLgwiyF8s0ElllF7z38Gmc4=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect571k1:ALICE_cf_sect571k1_PUB
+
+PrivateKey=BOB_cf_sect571k1
+-----BEGIN PRIVATE KEY-----
+MGYCAQAwEAYHKoZIzj0CAQYFK4EEACYETzBNAgEBBEgA3pINxGOI7L9M+Mil+bm/udPwI4xu7ubJ
+p3aoOepTXW94laf8wjFLcQnRUwH87Vbq9VLQEfCAFvr2vZoBc+5asnNuDhRNNeQ=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect571k1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGnMBAGByqGSM49AgEGBSuBBAAmA4GSAAQDZRr5GCSq2uzGxmWNB+bED7zye18Rr/KehwXrbn1r
+rKtR8fe+dg2V15FieC3qZe/wCpMtyp79VmEabGi6iGLlAN/rUE81URsA/K7GVpmklslV5gmwryR0
+3E7jGKPFesun9iNtmpgM18P9y3aJd4Qr4hMlwW2Nyw187l6QB/W2e/i+8vKXFTLHlz5WLAyAcpA=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect571k1:BOB_cf_sect571k1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect571k1
+PeerKey=BOB_cf_sect571k1_PUB
+SharedSecret=02b79c92cee50dc5b9fdddce36d4fa2e28d7d178cd74e575961f39429496305b38815c840c2e66327435c044ed885ec964068531251a2112717602532e8b6d5411db2fe05c1ac18c
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect571k1
+PeerKey=ALICE_cf_sect571k1_PUB
+SharedSecret=02b79c92cee50dc5b9fdddce36d4fa2e28d7d178cd74e575961f39429496305b38815c840c2e66327435c044ed885ec964068531251a2112717602532e8b6d5411db2fe05c1ac18c
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect571k1
+PeerKey=BOB_cf_sect571k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=063aea789492c9727a5a6b7f24e8d3d377c70ee8e86b13664e191a53b1905e90e78b85960b1881db5160c7c5cacca0d686d9e104140d565eeeec17426f93d3a7ba639ecd716b43d2
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect571k1
+PeerKey=ALICE_cf_sect571k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=063aea789492c9727a5a6b7f24e8d3d377c70ee8e86b13664e191a53b1905e90e78b85960b1881db5160c7c5cacca0d686d9e104140d565eeeec17426f93d3a7ba639ecd716b43d2
+
+PublicKey=MALICE_cf_sect571k1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGnMBAGByqGSM49AgEGBSuBBAAmA4GSAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect571k1
+PeerKey=MALICE_cf_sect571k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect571k1
+PeerKey=MALICE_cf_sect571k1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=sect571r1 curve tests
+
+PrivateKey=ALICE_cf_sect571r1
+-----BEGIN PRIVATE KEY-----
+MGYCAQAwEAYHKoZIzj0CAQYFK4EEACcETzBNAgEBBEgAxfL2/gUsmJonvDMR95Azq1ySgXMlKSRk
++PL+WaS92ZyOo45HaC7RpH5sdkf4b948u6y1BXOxGZuORXy6lgbgZ1Zx2UgL3cI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_sect571r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGnMBAGByqGSM49AgEGBSuBBAAnA4GSAAQBK5L9ccIWacU2A1srZ35opPu6kcbEOsBPmvj/rlMS
+fFrdMOcagOYfcD0/ouYHPhvkHbr9k87IlQJfnV6ZNRA4PmWSp/FjkNwETm/fqTCUQHti/qqnKH7R
+Ed4fYROLFGvz+PX6E20SryOt1vrmoRyC7Z5FVmgMVOQQ1AaBNAHi3+IPtKx41YdXdbqHJxuI5jE=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_sect571r1:ALICE_cf_sect571r1_PUB
+
+PrivateKey=BOB_cf_sect571r1
+-----BEGIN PRIVATE KEY-----
+MGYCAQAwEAYHKoZIzj0CAQYFK4EEACcETzBNAgEBBEgAzcRvASPpWi0ybpOGlj0Lozz01C2a5oDA
+G5alib1EmZKcpVULxJXn75FQlTKpkUEuWUgA4yk5X5DTiScUuh4LDhaF3AFhsEY=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_sect571r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGnMBAGByqGSM49AgEGBSuBBAAnA4GSAAQH3dnL22NajtqDWTX6qD14w1BOlpHFBUPTr24VySlh
+kiiBlOF95u7hFr/hSb7gm/3f+IVKyE18Sh2kR4KaxWcPWKY5xKTiqiICT7hCistuzNRt8gR+kNOT
+c1rETMV6ZruZinwzEWWWjwJf6612oy2HG3CX3B8Rm+a3sS0q6IzowEwqmDv6v9bMTFk8bsCv0Fk=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_sect571r1:BOB_cf_sect571r1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_sect571r1
+PeerKey=BOB_cf_sect571r1_PUB
+SharedSecret=0031f9879fa75b8c67ba81ee861be634e2b53aa79f834e9a8ca4df7f4461bcb02f083d9fa5b4767f881a710caa6524b58eb626623ba394961d46535204c26d165089e7d4f7be1827
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_sect571r1
+PeerKey=ALICE_cf_sect571r1_PUB
+SharedSecret=0031f9879fa75b8c67ba81ee861be634e2b53aa79f834e9a8ca4df7f4461bcb02f083d9fa5b4767f881a710caa6524b58eb626623ba394961d46535204c26d165089e7d4f7be1827
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_sect571r1
+PeerKey=BOB_cf_sect571r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=012e8c2c1554988fe20c5ae7d11cdcfe15c7c6e8d2b6f46a43a45d724bfc7b415ea7594d5c16f770a95d6e65bbcb1f34619db95e89f4fecbcb0bc6a3f92d52df6a49b0e7773e0ac0
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_sect571r1
+PeerKey=ALICE_cf_sect571r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=012e8c2c1554988fe20c5ae7d11cdcfe15c7c6e8d2b6f46a43a45d724bfc7b415ea7594d5c16f770a95d6e65bbcb1f34619db95e89f4fecbcb0bc6a3f92d52df6a49b0e7773e0ac0
+
+PublicKey=MALICE_cf_sect571r1_PUB
+-----BEGIN PUBLIC KEY-----
+MIGnMBAGByqGSM49AgEGBSuBBAAnA4GSAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHMtVWZAwgtd1zmgWN/9WC
+aNQcWRNUKesEHXqhJVkC5jYsSACodKsLYFNrWEYM0gwG8DQONZSn93G+38EM45tkaZsIRDt2HEM=
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_sect571r1
+PeerKey=MALICE_cf_sect571r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_sect571r1
+PeerKey=MALICE_cf_sect571r1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls10 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls10
+-----BEGIN PRIVATE KEY-----
+MDsCAQAwEAYHKoZIzj0CAQYFZysBBAoEJDAiAgEBBB1zvDMHGgcytka5KvlvQvJzTA4l2ts2NzBp
+SJiGyw==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFZysBBAoDPgAEAZkrhWBz/Q4GB8DY4Ia114ew6H7Eg7ri2uxwxd3rAZs5
+/ShvunNyndjCt3Qaq8sulBM0nUyERSDakyD+
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls10:ALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls10
+-----BEGIN PRIVATE KEY-----
+MDsCAQAwEAYHKoZIzj0CAQYFZysBBAoEJDAiAgEBBB1SowkHU79PqokOfgllN53rNS8a3h1wFBY0
+dKPkQg==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls10_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFZysBBAoDPgAEAGavw4ChHCoWplAumMEBwJgJ2aYtw+utu4vhWnscAPIT
+IJ4IiIGj18rCFBap1sgVbpXjhEBLYg6Itwv2
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls10:BOB_cf_wap-wsg-idm-ecid-wtls10_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls10
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls10_PUB
+SharedSecret=0194ef5d80fdfe9df366b2273b983c3dbd440faf76964fcfc06c509f289d
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls10
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+SharedSecret=0194ef5d80fdfe9df366b2273b983c3dbd440faf76964fcfc06c509f289d
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls10
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls10_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01bedc5cdf63fbf18c3e2bc9765e12f7990c0c0c64f0267ae7c37b9f49f0
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls10
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01bedc5cdf63fbf18c3e2bc9765e12f7990c0c0c64f0267ae7c37b9f49f0
+
+PublicKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFZysBBAoDPgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls10
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls10
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls11 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls11
+-----BEGIN PRIVATE KEY-----
+MDwCAQAwEAYHKoZIzj0CAQYFZysBBAsEJTAjAgEBBB4AkzS3zoqHNCLug/nwoYMQW3UigmZ9t56k
+5jp+FiY=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFZysBBAsDPgAEABttgKKYeGZRmcH/5UZR56lOSgbU4TH2AuIhvj88AL6H
+zTCX9elzXpck+u22bnmkuvL2A8XKB5+fabMR
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls11:ALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls11
+-----BEGIN PRIVATE KEY-----
+MDwCAQAwEAYHKoZIzj0CAQYFZysBBAsEJTAjAgEBBB4AWU05mbqPxsB749llNON1//l0w8RJJ3z5
+h/kzfNM=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls11_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFZysBBAsDPgAEAL6Xj/KCmXAQAAo847t0bl0wqBrteWRg93OvIJsPAAOE
+ehdIgJyruc3KsH0RFlipu5QD8pnGSIXvif19
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls11:BOB_cf_wap-wsg-idm-ecid-wtls11_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls11
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls11_PUB
+SharedSecret=01ac8a23ddeeafb4d3bb243fe409f2f9c8b1a3fc11d4690da583f2e21637
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls11
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+SharedSecret=01ac8a23ddeeafb4d3bb243fe409f2f9c8b1a3fc11d4690da583f2e21637
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls11
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls11_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01b9992992572d3a59d424f8c9cc195576461ed6c1dadf6fb523717fab19
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls11
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=01b9992992572d3a59d424f8c9cc195576461ed6c1dadf6fb523717fab19
+
+PublicKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+-----BEGIN PUBLIC KEY-----
+MFIwEAYHKoZIzj0CAQYFZysBBAsDPgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYf4
+Vie5eHTnR+4x4G1xyq7qUvISU+X5RtBh2pE4
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls11
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls11
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls12 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls12
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwEAYHKoZIzj0CAQYFZysBBAwEIzAhAgEBBBxwvll9Eb9mm2Xadq1evIi1zIK+6u0Nv8bP
+LI9a
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls12_PUB
+-----BEGIN PUBLIC KEY-----
+ME4wEAYHKoZIzj0CAQYFZysBBAwDOgAE0t0WqG/pFsiCt6agmebw3FCEWAzf9BpNLuzoCkPEe0Li
+bqn5udrckL6s3stwCTVFaZUfY2qS9QE=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls12:ALICE_cf_wap-wsg-idm-ecid-wtls12_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls12
+-----BEGIN PRIVATE KEY-----
+MDoCAQAwEAYHKoZIzj0CAQYFZysBBAwEIzAhAgEBBBz+5P6gpqXxbeXvvaD5W9Ft69BTxcn7zc6q
+K3Ax
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls12_PUB
+-----BEGIN PUBLIC KEY-----
+ME4wEAYHKoZIzj0CAQYFZysBBAwDOgAEvyxedqaWkoAOMjaV5W3/tJpheiHAR0zV6BlIeUuGP2mx
++xsOK9/QB7hzipq9cXx1K/dXu58EoSY=
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls12:BOB_cf_wap-wsg-idm-ecid-wtls12_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls12
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls12_PUB
+SharedSecret=a3b3f20af8c33a0f5c246b4b9d9dda1cd40c294d1f53365d18a8b54b
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls12
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls12_PUB
+SharedSecret=a3b3f20af8c33a0f5c246b4b9d9dda1cd40c294d1f53365d18a8b54b
+
+Title=wap-wsg-idm-ecid-wtls1 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls1
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFZysBBAEEFTATAgEBBA5ZNASTt4/g6XPQwRiQ0Q==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFZysBBAEDIAAEACBNPI48xxsPVQBy07jRAAcWzbIkMo8BQotxpfGJ
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls1:ALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls1
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFZysBBAEEFTATAgEBBA6+0x9qk0NIKHSRvlTemQ==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls1_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFZysBBAEDIAAEAEeHMSBTx/EtOu+bjBinALHSkQuJyiP3mg1tu+I2
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls1:BOB_cf_wap-wsg-idm-ecid-wtls1_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls1
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls1_PUB
+SharedSecret=0040ba2fadc1da97c973e5e59ade31
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls1
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+SharedSecret=0040ba2fadc1da97c973e5e59ade31
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls1
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=008919696215a89e03d6c4c9265d6b
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls1
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=008919696215a89e03d6c4c9265d6b
+
+PublicKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFZysBBAEDIAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls1
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls1
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls3 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls3
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAMEHDAaAgEBBBUDO2cHbqQBUxuJBl6UT9UrasuRVrI=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFZysBBAMDLAAEBRIzvK9o7eO2NGmtPFV/zo9/1mlvBwjG7+e6hbPG1KdI
+01f8oGBuXMQH
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls3:ALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls3
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAMEHDAaAgEBBBUAhZv9WZ00bDnU9MOaqEegP771nes=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls3_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFZysBBAMDLAAEAYOspjEbzyZw61jCtUrxARr+w66nBH+73QIvlaRVSG/4
+hlBUf5kmG4Yn
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls3:BOB_cf_wap-wsg-idm-ecid-wtls3_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls3
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls3_PUB
+SharedSecret=0311924428a839b7dcada662722945e62bf1131f4f
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls3
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+SharedSecret=0311924428a839b7dcada662722945e62bf1131f4f
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls3
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=047f1aee6a1a1d7c9c1f0e8dce4349429f737aa658
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls3
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=047f1aee6a1a1d7c9c1f0e8dce4349429f737aa658
+
+PublicKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFZysBBAMDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAB
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls3
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls3
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls4 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls4
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFZysBBAQEFjAUAgEBBA8ACFOrBbOh5LjNtJQCuEE=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFZysBBAQDIAAEAW3K4Mus5+KAJVGLzEYrAYuCJSEYXFTo17aW0TwN
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls4:ALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls4
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFZysBBAQEFjAUAgEBBA8Auz4XRc3Rg0bNcbrray8=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls4_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFZysBBAQDIAAEAI0F7ixGqOhnYpsuR80nAdTdSXM+YbcUbLe/U/xG
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls4:BOB_cf_wap-wsg-idm-ecid-wtls4_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls4
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls4_PUB
+SharedSecret=0077378ddfdadff704a0b6646949e7
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls4
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+SharedSecret=0077378ddfdadff704a0b6646949e7
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls4
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls4_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=008f3713fe1ff1fa5d5041899817d1
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls4
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=008f3713fe1ff1fa5d5041899817d1
+
+PublicKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+-----BEGIN PUBLIC KEY-----
+MDQwEAYHKoZIzj0CAQYFZysBBAQDIAAEAAAAAAAAAAAAAAAAAAAAAd+TqiBXnTd/lyA/OFsR
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls4
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls4
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls5 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls5
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAUEHDAaAgEBBBUD9gVh3zbLTA7BuRVVi9T8QKZ1uco=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFZysBBAUDLAAEAH5xyUrvbuN+tWmRhwqrQfFHPHNUBKtAGvJuvSFVwTKk
+uFzn9fPvIDe6
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls5:ALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls5
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAUEHDAaAgEBBBUAr9ZlmuO7bNfqB42xUivJXyVHKNI=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls5_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFZysBBAUDLAAEBdXxEk0L2XAVzRNLPcnMxGXXyDfZAoA1Qw2XpOfVWIVR
+jdoMGRgUuJmO
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls5:BOB_cf_wap-wsg-idm-ecid-wtls5_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls5
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls5_PUB
+SharedSecret=0190c68d80e94fbe9f193ae7d9a156bf0b8d097c23
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls5
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+SharedSecret=0190c68d80e94fbe9f193ae7d9a156bf0b8d097c23
+
+# ECC CDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls5
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls5_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00aabc9b45c200e41294aa922ab06da6655731e0ea
+
+# ECC CDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls5
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+Ctrl=ecdh_cofactor_mode:1
+SharedSecret=00aabc9b45c200e41294aa922ab06da6655731e0ea
+
+PublicKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+-----BEGIN PUBLIC KEY-----
+MEAwEAYHKoZIzj0CAQYFZysBBAUDLAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC8JxepS05nN/piK
+dhDD3dDKXUih
+-----END PUBLIC KEY-----
+
+# ECC CDH Bob with Malice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls5
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+# ECC CDH Alice with Malice peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls5
+PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
+Ctrl=ecdh_cofactor_mode:1
+Result=DERIVE_ERROR
+
+Title=wap-wsg-idm-ecid-wtls6 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls6
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFZysBBAYEFTATAgEBBA4ayMbswPbvYMwpwo80jA==
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls6_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFZysBBAYDHgAERPw/8Ip/RrXr0gMgLGRQeiQ4Qd6W+Li0ylGKzg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls6:ALICE_cf_wap-wsg-idm-ecid-wtls6_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls6
+-----BEGIN PRIVATE KEY-----
+MCwCAQAwEAYHKoZIzj0CAQYFZysBBAYEFTATAgEBBA6kbCpFt3tX2hYBQHMXbg==
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls6_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFZysBBAYDHgAEhJXqpYGxE/l1X/LiBeyRbIcyzqPxUP5Tkv3U3w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls6:BOB_cf_wap-wsg-idm-ecid-wtls6_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls6
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls6_PUB
+SharedSecret=b4cae255268f11a1e46fecad04c2
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls6
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls6_PUB
+SharedSecret=b4cae255268f11a1e46fecad04c2
+
+Title=wap-wsg-idm-ecid-wtls7 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls7
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAcEHDAaAgEBBBUABcyzh4ot9ck/j4/3ehK0aYngYoM=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls7_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFZysBBAcDKgAEwQLnZ70n45RLqRtAGNzEa3Rl/9nwyjqYUtw2eeHhnNLT
+feGY4CNH0w==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls7:ALICE_cf_wap-wsg-idm-ecid-wtls7_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls7
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAcEHDAaAgEBBBUAPyrGRY1SR13hKQswS6yXs8w8PUQ=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls7_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFZysBBAcDKgAEZGN44YbN5r3zcNtOHrvbQLt8/lE7BHp4D/9eKLmwFDn1
+QneRu3xwPA==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls7:BOB_cf_wap-wsg-idm-ecid-wtls7_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls7
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls7_PUB
+SharedSecret=ae9f5bcc6457c0422866bf855921eabc42b7121a
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls7
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls7_PUB
+SharedSecret=ae9f5bcc6457c0422866bf855921eabc42b7121a
+
+Title=wap-wsg-idm-ecid-wtls8 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls8
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFZysBBAgEFjAUAgEBBA8AnkC18b3pH2O5TIYIqAQ=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls8_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFZysBBAgDHgAEJD0h4HEfchwxqhp9eMHh9gczQKHX4MtWVoAxKQ==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls8:ALICE_cf_wap-wsg-idm-ecid-wtls8_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls8
+-----BEGIN PRIVATE KEY-----
+MC0CAQAwEAYHKoZIzj0CAQYFZysBBAgEFjAUAgEBBA8AXxPMnqbl3rOuIM5nsvc=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls8_PUB
+-----BEGIN PUBLIC KEY-----
+MDIwEAYHKoZIzj0CAQYFZysBBAgDHgAEZawmRmzr9P+jihImUi6ykOzaSH484JhMKNdrgw==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls8:BOB_cf_wap-wsg-idm-ecid-wtls8_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls8
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls8_PUB
+SharedSecret=48baf4f1f5e8a0eb5dae28ef6290
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls8
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls8_PUB
+SharedSecret=48baf4f1f5e8a0eb5dae28ef6290
+
+Title=wap-wsg-idm-ecid-wtls9 curve tests
+
+PrivateKey=ALICE_cf_wap-wsg-idm-ecid-wtls9
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAkEHDAaAgEBBBUALwvuKs3RLthMAsChbqKjXw6vTYo=
+-----END PRIVATE KEY-----
+
+PublicKey=ALICE_cf_wap-wsg-idm-ecid-wtls9_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFZysBBAkDKgAET0ppOvd9DU4v+tkKDQ5wRBrN1FwD9+F9t5l3Im+mz3rw
+DB/RYdZuUg==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=ALICE_cf_wap-wsg-idm-ecid-wtls9:ALICE_cf_wap-wsg-idm-ecid-wtls9_PUB
+
+PrivateKey=BOB_cf_wap-wsg-idm-ecid-wtls9
+-----BEGIN PRIVATE KEY-----
+MDMCAQAwEAYHKoZIzj0CAQYFZysBBAkEHDAaAgEBBBUAgeb/vqEM7X5AAAxyBu3M+C8pWLM=
+-----END PRIVATE KEY-----
+
+PublicKey=BOB_cf_wap-wsg-idm-ecid-wtls9_PUB
+-----BEGIN PUBLIC KEY-----
+MD4wEAYHKoZIzj0CAQYFZysBBAkDKgAEWc37LGt6lt90iF4lhtDYNFdjAqoczebuNgzGff/Uq8ov
+a3EVJ9yK1A==
+-----END PUBLIC KEY-----
+
+PrivPubKeyPair=BOB_cf_wap-wsg-idm-ecid-wtls9:BOB_cf_wap-wsg-idm-ecid-wtls9_PUB
+
+# ECDH Alice with Bob peer
+Derive=ALICE_cf_wap-wsg-idm-ecid-wtls9
+PeerKey=BOB_cf_wap-wsg-idm-ecid-wtls9_PUB
+SharedSecret=948d3030e95cead39a1bb3d8a01c2be178517ba7
+
+# ECDH Bob with Alice peer
+Derive=BOB_cf_wap-wsg-idm-ecid-wtls9
+PeerKey=ALICE_cf_wap-wsg-idm-ecid-wtls9_PUB
+SharedSecret=948d3030e95cead39a1bb3d8a01c2be178517ba7
+
+# tests: 484


### PR DESCRIPTION
This is a follow up to #6535. It adds:
1. For every named curve, two “golden” keypair positive tests.
2. Also two “golden” stock ECDH positive tests.
3. For named curves with non-trivial cofactors, additionally two “golden” ECC CDH positive tests.
4. For named curves with non-trivial cofactors, additionally two negative tests.

There is some overlap with existing EVP tests, especially for the NIST curves (for example, positive testing ECC CDH KATs for NIST curves). It started as just (4), but once the scripting was there (1-3) were essentially for free.

"Golden" here means all the values are independent from OpenSSL's ECC code. I used sage to calculate them. What comes from OpenSSL is:
1. The OIDs (parsed by tooling)
2. The curve parameters (parsing `ecparam` output with tooling)

The values inside the PEMs (private keys, public keys) and shared keys are from sage. The PEMs themselves are the output of `asn1parse`, with input taken from sage.