### PR TITLE
rand/rand_unix.c: address macro redifinition warning.

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -7,7 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #include "e_os.h"
 #include <stdio.h>
 #include "internal/cryptlib.h"


### PR DESCRIPTION
Occasionally, e.g. when compiling for elderly glibc, you end up passing
-D_GNU_SOURCE on command line, and doing so triggered warning...
