### PR TITLE
Address coverity-reported NULL dereference in SSL_SESSION_print()

### DIFF
--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -33,10 +33,11 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
 {
     size_t i;
     const char *s;
-    int istls13 = (x->ssl_version == TLS1_3_VERSION);
+    int istls13;
 
     if (x == NULL)
         goto err;
+    istls13 = (x->ssl_version == TLS1_3_VERSION);
     if (BIO_puts(bp, "SSL-Session:\n") <= 0)
         goto err;
     s = ssl_protocol_to_string(x->ssl_version);


### PR DESCRIPTION
We need to check the provided SSL_SESSION* for NULL before
attempting to derference it to see if it's a TLS 1.3 session.

