### PR TITLE
Fix potential NULL pointer dereference in EVP "int_ctx_new".

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -106,6 +106,10 @@ static EVP_PKEY_CTX *int_ctx_new(EVP_PKEY *pkey, ENGINE *e, int id)
     const EVP_PKEY_METHOD *pmeth;
 
     if (id == -1) {
+        if (!pkey){
+            EVPerr(EVP_F_INT_CTX_NEW, ERR_R_PASSED_NULL_PARAMETER);
+            return NULL;
+        }
         id = pkey->type;
     }
 #ifndef OPENSSL_NO_ENGINE


### PR DESCRIPTION
CLA: trivial

Fix potential NULL pointer dereference in EVP "int_ctx_new".
This bug only affects version "1.1.1-pre8".
The value "-1" in the parameter "type" (EVP_PKEY_new_mac_key)  or NULL in the parameter "pkey" (EVP_DigestSignInit, EVP_DigestVerifyInit, EVP_VerifyFinal, ...) leads to a NULL pointer dereference "init_ctx_new"
