### PR TITLE
DllMain should allocate TLS on DLL_PROCESS_ATTACH

### DIFF
--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -30,7 +30,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     switch (fdwReason) {
     case DLL_PROCESS_ATTACH:
-        OPENSSL_cpuid_setup();
+        if(!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
+            return FALSE;
 # if defined(_WIN32_WINNT)
         {
             IMAGE_DOS_HEADER *dos_header = (IMAGE_DOS_HEADER *) hinstDLL;


### PR DESCRIPTION
`OPENSSL_thread_stop();` is called on `DLL_THREAD_DETACH` which leads to usage of the Thread local storage (see https://github.com/openssl/openssl/blob/74a8acbdfb2c7f398d1ae2fe914cd32b437f6df4/crypto/init.c#L400) without allocating it beforehand if a thread exits before the user initializes libcrypto.

The suggested fix initializes the libcrypto base only, so that TLS will
be allocated.
(https://github.com/openssl/openssl/blob/74a8acbdfb2c7f398d1ae2fe914cd32b437f6df4/crypto/init.c#L84)

`OPENSSL_cpuid_setup();` has been removed since it is already called by `ossl_init_base`.

Note:This was detected using AppVerifier on windows10
```
VERIFIER STOP 0000000000000301: pid 0x6D20: Invalid TLS index used for current stack trace. 

	0000000000000000 : Invalid TLS index.
	000000000000ABBA : Expected lower part of the index.
	0000000000000000 : Not used.
	0000000000000000 : Not used.

```

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

