### PR TITLE
Don't create an invalid CertificateRequest (1.0.2)

### DIFF
--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -2091,6 +2091,11 @@ int ssl3_send_certificate_request(SSL *s)
         if (SSL_USE_SIGALGS(s)) {
             const unsigned char *psigs;
             nl = tls12_get_psigalgs(s, 1, &psigs);
+            if (nl > SSL_MAX_2_BYTE_LEN) {
+                SSLerr(SSL_F_SSL3_SEND_CERTIFICATE_REQUEST,
+                       SSL_R_LENGTH_TOO_LONG);
+                goto err;
+            }
             s2n(nl, p);
             memcpy(p, psigs, nl);
             p += nl;
@@ -2107,6 +2112,11 @@ int ssl3_send_certificate_request(SSL *s)
             for (i = 0; i < sk_X509_NAME_num(sk); i++) {
                 name = sk_X509_NAME_value(sk, i);
                 j = i2d_X509_NAME(name, NULL);
+                if (j > SSL_MAX_2_BYTE_LEN) {
+                    SSLerr(SSL_F_SSL3_SEND_CERTIFICATE_REQUEST,
+                           SSL_R_LENGTH_TOO_LONG);
+                    goto err;
+                }
                 if (!BUF_MEM_grow_clean
                     (buf, SSL_HM_HEADER_LENGTH(s) + n + j + 2)) {
                     SSLerr(SSL_F_SSL3_SEND_CERTIFICATE_REQUEST,
@@ -2127,6 +2137,11 @@ int ssl3_send_certificate_request(SSL *s)
                     j += 2;
                     n += j;
                     nl += j;
+                }
+                if (nl > SSL_MAX_2_BYTE_LEN) {
+                    SSLerr(SSL_F_SSL3_SEND_CERTIFICATE_REQUEST,
+                           SSL_R_LENGTH_TOO_LONG);
+                    goto err;
                 }
             }
         }

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -2954,6 +2954,7 @@ void ERR_load_SSL_strings(void);
 # define SSL_R_KRB5_S_TKT_NYV                             294
 # define SSL_R_KRB5_S_TKT_SKEW                            295
 # define SSL_R_LENGTH_MISMATCH                            159
+# define SSL_R_LENGTH_TOO_LONG                            404
 # define SSL_R_LENGTH_TOO_SHORT                           160
 # define SSL_R_LIBRARY_BUG                                274
 # define SSL_R_LIBRARY_HAS_NO_CIPHERS                     161

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -259,6 +259,8 @@
                           c[1]=(unsigned char)(((l)>> 8)&0xff), \
                           c[2]=(unsigned char)(((l)    )&0xff)),c+=3)
 
+# define SSL_MAX_2_BYTE_LEN     (0xffff)
+
 /* LOCAL STUFF */
 
 # define SSL_DECRYPT     0


### PR DESCRIPTION
We should validate that the various fields we put into the
CertificateRequest are not too long. Otherwise we will construct an
invalid message.

Fixes #6609

This is the 1.0.2 version of #6628.

