### PR TITLE
Check for NULL conf in NCONF_get_number

### DIFF
--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -292,10 +292,13 @@ int NCONF_get_number_e(const CONF *conf, const char *group, const char *name,
     if (str == NULL)
         return 0;
 
-    for (*result = 0; conf->meth->is_number(conf, *str);) {
-        *result = (*result) * 10 + conf->meth->to_int(conf, *str);
-        str++;
-    }
+    if (conf == NULL)
+        *result = strtol(str, &str, 10);
+    else
+        for (*result = 0; conf->meth->is_number(conf, *str);) {
+            *result = (*result) * 10 + conf->meth->to_int(conf, *str);
+            str++;
+        }
 
     return 1;
 }

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -123,6 +123,36 @@ static int test_load_config(void)
     return 1;
 }
 
+static int test_check_null_numbers(void)
+{
+#if defined(_BSD_SOURCE) \
+        || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) \
+        || (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600)
+    long val = 0;
+
+    /* Verify that a NULL config with a present environment variable returns
+     * success and the value.
+     */
+    if (!TEST_int_eq(setenv("FNORD", "123", 1), 0)
+            || !TEST_true(NCONF_get_number(NULL, "missing", "FNORD", &val))
+            || !TEST_long_eq(val, 123)) {
+        TEST_note("environment variable with NULL conf failed");
+        return 0;
+    }
+
+    /*
+     * Verify that a NULL config with a missing envrionment variable returns
+     * a failure code.
+     */
+    if (!TEST_int_eq(unsetenv("FNORD"), 0)
+            || !TEST_false(NCONF_get_number(NULL, "missing", "FNORD", &val))) {
+        TEST_note("missing environment variable with NULL conf failed");
+        return 0;
+    }
+#endif
+    return 1;
+}
+
 int setup_tests(void)
 {
     const char *conf_file;
@@ -150,6 +180,7 @@ int setup_tests(void)
     change_path(conf_file);
 
     ADD_TEST(test_load_config);
+    ADD_TEST(test_check_null_numbers);
     return 1;
 }
 


### PR DESCRIPTION
The problematic case falls back to a NULL _conf_ which returns the result of `getenv(2)`.  If this returns NULL, everything was good.  If this returns a string an attempt to convert it to a number is made using the function pointers from _conf_.

This fix uses the `strtol(3)` function instead, we don't have the _conf_ settings and this behaves as the default would.

Includes test cases for both of the NULL cases (with and without an environment variable set).

- [x] tests are added or updated
