### PR TITLE
[crypto/ec] disable SCA mitigations for curves with incomplete parame…

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -389,30 +389,32 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         return EC_POINT_set_to_infinity(group, r);
     }
 
-    /*-
-     * Handle the common cases where the scalar is secret, enforcing a constant
-     * time scalar multiplication algorithm.
-     */
-    if ((scalar != NULL) && (num == 0)) {
+    if (!BN_is_zero(group->order) && !BN_is_zero(group->cofactor)) {
         /*-
-         * In this case we want to compute scalar * GeneratorPoint: this
-         * codepath is reached most prominently by (ephemeral) key generation
-         * of EC cryptosystems (i.e. ECDSA keygen and sign setup, ECDH
-         * keygen/first half), where the scalar is always secret. This is why
-         * we ignore if BN_FLG_CONSTTIME is actually set and we always call the
-         * constant time version.
+         * Handle the common cases where the scalar is secret, enforcing a constant
+         * time scalar multiplication algorithm.
          */
-        return ec_mul_consttime(group, r, scalar, NULL, ctx);
-    }
-    if ((scalar == NULL) && (num == 1)) {
-        /*-
-         * In this case we want to compute scalar * GenericPoint: this codepath
-         * is reached most prominently by the second half of ECDH, where the
-         * secret scalar is multiplied by the peer's public point. To protect
-         * the secret scalar, we ignore if BN_FLG_CONSTTIME is actually set and
-         * we always call the constant time version.
-         */
-        return ec_mul_consttime(group, r, scalars[0], points[0], ctx);
+        if ((scalar != NULL) && (num == 0)) {
+            /*-
+             * In this case we want to compute scalar * GeneratorPoint: this
+             * codepath is reached most prominently by (ephemeral) key generation
+             * of EC cryptosystems (i.e. ECDSA keygen and sign setup, ECDH
+             * keygen/first half), where the scalar is always secret. This is why
+             * we ignore if BN_FLG_CONSTTIME is actually set and we always call the
+             * constant time version.
+             */
+            return ec_mul_consttime(group, r, scalar, NULL, ctx);
+        }
+        if ((scalar == NULL) && (num == 1)) {
+            /*-
+             * In this case we want to compute scalar * GenericPoint: this codepath
+             * is reached most prominently by the second half of ECDH, where the
+             * secret scalar is multiplied by the peer's public point. To protect
+             * the secret scalar, we ignore if BN_FLG_CONSTTIME is actually set and
+             * we always call the constant time version.
+             */
+            return ec_mul_consttime(group, r, scalars[0], points[0], ctx);
+        }
     }
 
     for (i = 0; i < num; i++) {


### PR DESCRIPTION
Who wants to do cryptography on curves with incomplete parameters? Show of hands :)

This patch bypasses new SCA-resistant scalar multiplication paths for arbitrary curves constructed without all of the expected parameters. (order, cofactor)

Play stupid games, win stupid prizes.

Solves #6637. Hopefully the GOST engine maintainers go fix their own defect.