### PR TITLE
Don't fail if the PSK identity doesn't match

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -192,8 +192,11 @@ static int psk_find_session_cb(SSL *ssl, const unsigned char *identity,
     const SSL_CIPHER *cipher = NULL;
 
     if (strlen(psk_identity) != identity_len
-            || memcmp(psk_identity, identity, identity_len) != 0)
-        return 0;
+            || memcmp(psk_identity, identity, identity_len) != 0) {
+        BIO_printf(bio_s_out,
+                   "PSK warning: client identity not what we expected"
+                   " (got '%s' expected '%s')\n", identity, psk_identity);
+    }
 
     if (psksess != NULL) {
         SSL_SESSION_up_ref(psksess);


### PR DESCRIPTION
In 1.1.0 s_server if the PSK identity doesn't match what we have then
a warning is printed and we continue the connection anyway. In 1.1.1,
if TLSv1.3 is used and the identity doesn't match then we abort the
connection. We should really be consistent with the old behaviour.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
