### PR TITLE
Fix minor windows build issues

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -92,20 +92,20 @@ GENERATED={- # common0.tmpl provides @generated
              join(" ", map { (my $x = $_) =~ s|\.[sS]$|.asm|; $x }
                        @generated) -}
 
-INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; shlib($_) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_ENGINES={- join(" ", map { dso($_) } @{$unified_info{install}->{engines}}) -}
-INSTALL_ENGINEPDBS={- join(" ", map { local $dsoext = ".pdb"; dso($_) } @{$unified_info{install}->{engines}}) -}
-INSTALL_PROGRAMS={- join(" ", map { $_.$exeext } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
-INSTALL_PROGRAMPDBS={- join(" ", map { $_.".pdb" } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
+INSTALL_LIBS={- join(" ", map { quotify1(lib($_)) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIBS={- join(" ", map { quotify1(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; quotify1(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_ENGINES={- join(" ", map { quotify1(dso($_)) } @{$unified_info{install}->{engines}}) -}
+INSTALL_ENGINEPDBS={- join(" ", map { local $dsoext = ".pdb"; quotify1(dso($_)) } @{$unified_info{install}->{engines}}) -}
+INSTALL_PROGRAMS={- join(" ", map { quotify1($_.$exeext) } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
+INSTALL_PROGRAMPDBS={- join(" ", map { quotify1($_.".pdb") } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
 {- output_off() if $disabled{apps}; "" -}
-BIN_SCRIPTS=$(BLDDIR)\tools\c_rehash.pl
-MISC_SCRIPTS=$(BLDDIR)\apps\CA.pl $(BLDDIR)\apps\tsget.pl
+BIN_SCRIPTS="$(BLDDIR)\tools\c_rehash.pl"
+MISC_SCRIPTS="$(BLDDIR)\apps\CA.pl" "$(BLDDIR)\apps\tsget.pl"
 {- output_on() if $disabled{apps}; "" -}
 
 APPS_OPENSSL={- use File::Spec::Functions;
-                catfile("apps","openssl") -}
+                quotify1(catfile("apps","openssl")) -}
 
 # Do not edit these manually. Use Configure with --prefix or --openssldir
 # to change this!  Short explanation in the top comment in Configure
@@ -415,7 +415,7 @@ install_dev:
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "-exclude_re=/__DECC_" \
 				       "$(SRCDIR)\include\openssl\*.h" \
 				       "$(INSTALLTOP)\include\openssl"
-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(BLDDIR)\include\openssl\*.h \
+	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(BLDDIR)\include\openssl\*.h" \
 				       "$(INSTALLTOP)\include\openssl"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(libdir)"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_LIBS) "$(libdir)"

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -105,7 +105,7 @@ MISC_SCRIPTS="$(BLDDIR)\apps\CA.pl" "$(BLDDIR)\apps\tsget.pl"
 {- output_on() if $disabled{apps}; "" -}
 
 APPS_OPENSSL={- use File::Spec::Functions;
-                quotify1(catfile("apps","openssl")) -}
+                "\"".catfile("apps","openssl")."\"" -}
 
 # Do not edit these manually. Use Configure with --prefix or --openssldir
 # to change this!  Short explanation in the top comment in Configure

--- a/Configure
+++ b/Configure
@@ -1120,7 +1120,7 @@ $target{dso_extension}//=$target{shared_extension_simple};
 # Allow overriding the names of some tools.  USE WITH CARE
 # Note: only Unix cares about HASHBANGPERL...  that explains
 # the default string.
-$config{perl} = env('PERL') || ($^O ne "VMS" ? $^X : "perl");
+$config{perl} =    ($^O ne "VMS" ? $^X : "perl");
 foreach (keys %user) {
     my $ref_type = ref $user{$_};
 

--- a/Configure
+++ b/Configure
@@ -1120,7 +1120,7 @@ $target{dso_extension}//=$target{shared_extension_simple};
 # Allow overriding the names of some tools.  USE WITH CARE
 # Note: only Unix cares about HASHBANGPERL...  that explains
 # the default string.
-$config{perl} =    ($^O ne "VMS" ? $^X : "perl");
+$config{perl} = env('PERL') || ($^O ne "VMS" ? $^X : "perl");
 foreach (keys %user) {
     my $ref_type = ref $user{$_};
 


### PR DESCRIPTION
This allows cygwin perl to be used (build and install works, only nmake test doesn't)
in order to do so it is only necessary to
`set CONFIGURE_INSIST=YES`
`set PERL=perl`
before invoking `perl Configure`