### PR TITLE
Avoid __GNUC__ warnings when defining DECLARE_DEPRECATED

### DIFF
--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -68,10 +68,12 @@ extern "C" {
  * still won't see them if the library has been built to disable deprecated
  * functions.
  */
-#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-# define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
-#else
-# define DECLARE_DEPRECATED(f)   f;
+#define DECLARE_DEPRECATED(f)   f;
+#ifdef __GNUC__
+# if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#  undef DECLARE_DEPRECATED
+#  define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+# endif
 #endif
 
 #ifndef OPENSSL_FILE


### PR DESCRIPTION
We need to check that __GNUC__ is defined before trying to use it.
This demands a slightly different way to define DECLARE_DEPRECATED.
