### PR TITLE
Allow util/dofile.pl to require Text::Template 1.46 (fix with_fallback to allow this)

### DIFF
--- a/external/perl/transfer/Text/Template.pm
+++ b/external/perl/transfer/Text/Template.pm
@@ -7,6 +7,9 @@
 
 # Quick transfer to the downloaded Text::Template
 
+package transfer::Text::Template;
+$VERSION = 1.46;
+
 BEGIN {
     use File::Spec::Functions;
     use File::Basename;

--- a/util/dofile.pl
+++ b/util/dofile.pl
@@ -40,7 +40,7 @@ package OpenSSL::Template;
 use File::Basename;
 use File::Spec::Functions;
 use lib "$FindBin::Bin/perl";
-use with_fallback qw(Text::Template);
+use with_fallback "Text::Template 1.46";
 
 #use parent qw/Text::Template/;
 use vars qw/@ISA/;

--- a/util/perl/with_fallback.pm
+++ b/util/perl/with_fallback.pm
@@ -8,15 +8,17 @@
 package with_fallback;
 
 sub import {
+    shift;
+
     use File::Basename;
     use File::Spec::Functions;
     foreach (@_) {
-	eval "require $_";
+	eval "use $_";
 	if ($@) {
 	    unshift @INC, catdir(dirname(__FILE__),
                                  "..", "..", "external", "perl");
 	    my $transfer = "transfer::$_";
-	    eval "require $transfer";
+	    eval "use $transfer";
 	    shift @INC;
 	    warn $@ if $@;
 	}


### PR DESCRIPTION
In #6641, we found that with Text::Template < 1.46, the produced build files are gravely faulty.  We therefore need to fix the mechanism for loading fallback modules to be able to handle minimum module versions, and adapt `util/dofile.pl` to require a minimum Text::Template version that we know works.

Fixes #6641