### PR TITLE
Avoid __GNUC__ warnings when defining DECLARE_DEPRECATED [1.1.0]

### DIFF
--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -70,10 +70,14 @@ extern "C" {
  */
 #if defined(OPENSSL_NO_DEPRECATED)
 # define DECLARE_DEPRECATED(f)
-#elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-# define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
 #else
 # define DECLARE_DEPRECATED(f)   f;
+#endif
+#ifdef __GNUC__
+# if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#  undef DECLARE_DEPRECATED
+#  define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+# endif
 #endif
 
 #ifndef OPENSSL_FILE

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -68,15 +68,17 @@ extern "C" {
  * still won't see them if the library has been built to disable deprecated
  * functions.
  */
-#if defined(OPENSSL_NO_DEPRECATED)
-# define DECLARE_DEPRECATED(f)
-#else
-# define DECLARE_DEPRECATED(f)   f;
-#endif
-#ifdef __GNUC__
-# if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-#  undef DECLARE_DEPRECATED
-#  define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#ifndef DECLARE_DEPRECATED
+# if defined(OPENSSL_NO_DEPRECATED)
+#  define DECLARE_DEPRECATED(f)
+# else
+#  define DECLARE_DEPRECATED(f)   f;
+# endif
+# ifdef __GNUC__
+#  if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#   undef DECLARE_DEPRECATED
+#   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#  endif
 # endif
 #endif
 

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -73,11 +73,11 @@ extern "C" {
 #  define DECLARE_DEPRECATED(f)
 # else
 #  define DECLARE_DEPRECATED(f)   f;
-# endif
-# ifdef __GNUC__
-#  if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-#   undef DECLARE_DEPRECATED
-#   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#  ifdef __GNUC__
+#   if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#    undef DECLARE_DEPRECATED
+#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#   endif
 #  endif
 # endif
 #endif


### PR DESCRIPTION
We need to check that __GNUC__ is defined before trying to use it.
This demands a slightly different way to define DECLARE_DEPRECATED.

-----

This is a backport of #6680 and #6689 for 1.1.0