### PR TITLE
Documentation typo fix in BN_bn2bin.pod

### DIFF
--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -55,8 +55,8 @@ freed later using OPENSSL_free().
 BN_hex2bn() takes as many characters as possible from the string B<str>,
 including the leading character '-' which means negative, to form a valid
 hexadecimal number representation and converts them to a B<BIGNUM> and
-stores it in **B<bn>. If *B<bn> is NULL, a new B<BIGNUM> is created. If
-B<bn> is NULL, it only computes the length of valid representation.
+stores it in **B<a>. If *B<a> is NULL, a new B<BIGNUM> is created. If
+B<a> is NULL, it only computes the length of valid representation.
 A "negative zero" is converted to zero.
 BN_dec2bn() is the same using the decimal system.
 


### PR DESCRIPTION
Change the description for BN_hex2bn() so that it uses the same BIGNUM argument name as its prototype.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated