### PR TITLE
Missing macro for TLS v1.3

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -145,7 +145,8 @@ extern "C" {
 # define SSL_TXT_TLSV1           "TLSv1"
 # define SSL_TXT_TLSV1_1         "TLSv1.1"
 # define SSL_TXT_TLSV1_2         "TLSv1.2"
-
+# define SSL_TXT_TLSV1_3         "TLSv1.3"
+  
 # define SSL_TXT_ALL             "ALL"
 
 /*-


### PR DESCRIPTION
Adding missing macro SSL_TXT_TLSV1_3 in file ssl.h.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
