### PR TITLE
Fix TLSv1.3 session issues

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1014,6 +1014,8 @@ static SSL_TICKET_STATUS tls_get_stateful_ticket(SSL *s, PACKET *tick,
 {
     SSL_SESSION *tmpsess = NULL;
 
+    s->ext.ticket_expected = 1;
+
     switch (PACKET_remaining(tick)) {
         case 0:
             return SSL_TICKET_EMPTY;
@@ -1031,7 +1033,6 @@ static SSL_TICKET_STATUS tls_get_stateful_ticket(SSL *s, PACKET *tick,
     if (tmpsess == NULL)
         return SSL_TICKET_NO_DECRYPT;
 
-    s->ext.ticket_expected = 1;
     *sess = tmpsess;
     return SSL_TICKET_SUCCESS;
 }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3648,20 +3648,11 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
      */
 
     if (s->post_handshake_auth == SSL_PHA_REQUESTED) {
-        int m = s->session_ctx->session_cache_mode;
-
         if ((new_sess = ssl_session_dup(s->session, 0)) == 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_PROCESS_CLIENT_CERTIFICATE,
                      ERR_R_MALLOC_FAILURE);
             goto err;
-        }
-
-        if (m & SSL_SESS_CACHE_SERVER) {
-            /*
-             * Remove the old session from the cache. We carry on if this fails
-             */
-            SSL_CTX_remove_session(s->session_ctx, s->session);
         }
 
         SSL_SESSION_free(s->session);


### PR DESCRIPTION
This PR does two main things:

-  Don't remove sessions from the cache during PHA in TLSv1.3

If we issue new tickets due to post-handshake authentication there is no reason to remove previous tickets from the cache. The code that did that only removed the last session anyway - so if more than one ticket got issued then those other tickets are still valid.

-  Always issue new tickets when using TLSv1.3 stateful tickets

Previously we were failing to issue new tickets if a resumption attempt failed.

This also improves the testing of this area.

Fixes #6654.