### PR TITLE
crypto/init.c: do not try to load itself when linked statically

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -111,7 +111,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: ossl_init_load_crypto_nodelete()\n");
 #endif
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if defined(OPENSSL_NO_STATIC_ENGINE) && \
+    !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
 # ifdef DSO_WIN32
     {
         HMODULE handle = NULL;
@@ -676,7 +677,8 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if defined(OPENSSL_NO_STATIC_ENGINE) && \
+    !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
     {
         union {
             void *sym;


### PR DESCRIPTION
The leak-one-reference trick for keeping the crypto module loaded is
pointless when the program has already statically linked OpenSSL.
It can be also dangerous, because DSO_dsobyaddr will try to load
the main program itself.

In Linux, for example, trying to load an executable file will generate an
error and be ignored, but bad things will happen when the main program is
compiled and linked with PIE hardening. Because the PIE-hardened program acts
more like a shared object, it can be accidentally dlopen() and loaded into
memory again, mess up the mapping and flush the global state.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

