### PR TITLE
Skip the GOST test where appropriate

### DIFF
--- a/test/recipes/90-test_gost.t
+++ b/test/recipes/90-test_gost.t
@@ -11,8 +11,12 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_gost");
 
+# The GOST ciphers are dynamically loaded via the GOST engine, so we must be
+# able to support that. The engine also uses DSA and CMS symbols, so we skip
+# this test on no-dsa or no-cms.
 plan skip_all => "GOST support is disabled in this OpenSSL build"
-    if disabled("gost");
+    if disabled("gost") || disabled("engine") || disabled("dynamic-engine")
+       || disabled("dsa") || disabled("cms");
 
 plan skip_all => "TLSv1.3 or TLSv1.2 are disabled in this OpenSSL build"
     if disabled("tls1_3") || disabled("tls1_2");


### PR DESCRIPTION
The GOST ciphers are dynamically loaded via the GOST engine, so we must
be able to support that. The engine also uses DSA and CMS symbols, so we
skip the test on no-dsa or no-cms.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
