### PR TITLE
ec/ecp_nistz256.c: fix ecp_nistz256_set_from_affine.

### DIFF
--- a/crypto/bn/bn_intern.c
+++ b/crypto/bn/bn_intern.c
@@ -172,16 +172,20 @@ BN_ULONG *bn_get_words(const BIGNUM *a)
     return a->d;
 }
 
-void bn_set_static_words(BIGNUM *a, BN_ULONG *words, int size)
+void bn_set_static_words(BIGNUM *a, const BN_ULONG *words, int size)
 {
-    a->d = words;
+    /*
+     * |const| qualifier omission is compensated by BN_FLG_STATIC_DATA
+     * flag, which effectively means "read-only data".
+     */
+    a->d = (BN_ULONG *)words;
     a->dmax = a->top = size;
     a->neg = 0;
     a->flags |= BN_FLG_STATIC_DATA;
     bn_correct_top(a);
 }
 
-int bn_set_words(BIGNUM *a, BN_ULONG *words, int num_words)
+int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words)
 {
     if (bn_wexpand(a, num_words) == NULL) {
         BNerr(BN_F_BN_SET_WORDS, ERR_R_MALLOC_FAILURE);

--- a/crypto/ec/asm/ecp_nistz256-armv4.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv4.pl
@@ -894,13 +894,13 @@ ecp_nistz256_scatter_w7:
 .Loop_scatter_w7:
 	ldr	$mask,[$inp],#4
 	subs	$index,$index,#1
-	strb	$mask,[$out,#64*0-1]
+	strb	$mask,[$out,#64*0]
 	mov	$mask,$mask,lsr#8
-	strb	$mask,[$out,#64*1-1]
+	strb	$mask,[$out,#64*1]
 	mov	$mask,$mask,lsr#8
-	strb	$mask,[$out,#64*2-1]
+	strb	$mask,[$out,#64*2]
 	mov	$mask,$mask,lsr#8
-	strb	$mask,[$out,#64*3-1]
+	strb	$mask,[$out,#64*3]
 	add	$out,$out,#64*4
 	bne	.Loop_scatter_w7
 

--- a/crypto/ec/asm/ecp_nistz256-armv8.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv8.pl
@@ -1776,21 +1776,21 @@ ecp_nistz256_scatter_w7:
 	prfm	pstl1strm,[$out,#4096+64*5]
 	prfm	pstl1strm,[$out,#4096+64*6]
 	prfm	pstl1strm,[$out,#4096+64*7]
-	strb	w3,[$out,#64*0-1]
+	strb	w3,[$out,#64*0]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*1-1]
+	strb	w3,[$out,#64*1]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*2-1]
+	strb	w3,[$out,#64*2]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*3-1]
+	strb	w3,[$out,#64*3]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*4-1]
+	strb	w3,[$out,#64*4]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*5-1]
+	strb	w3,[$out,#64*5]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*6-1]
+	strb	w3,[$out,#64*6]
 	lsr	x3,x3,#8
-	strb	w3,[$out,#64*7-1]
+	strb	w3,[$out,#64*7]
 	add	$out,$out,#64*8
 	b.ne	.Loop_scatter_w7
 

--- a/crypto/ec/asm/ecp_nistz256-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistz256-ppc64.pl
@@ -2297,21 +2297,21 @@ ecp_nistz256_scatter_w7:
 
 .Loop_scatter_w7:
 	ldu	r0,8($inp)
-	stb	r0,64*0-1($out)
+	stb	r0,64*0($out)
 	srdi	r0,r0,8
-	stb	r0,64*1-1($out)
+	stb	r0,64*1($out)
 	srdi	r0,r0,8
-	stb	r0,64*2-1($out)
+	stb	r0,64*2($out)
 	srdi	r0,r0,8
-	stb	r0,64*3-1($out)
+	stb	r0,64*3($out)
 	srdi	r0,r0,8
-	stb	r0,64*4-1($out)
+	stb	r0,64*4($out)
 	srdi	r0,r0,8
-	stb	r0,64*5-1($out)
+	stb	r0,64*5($out)
 	srdi	r0,r0,8
-	stb	r0,64*6-1($out)
+	stb	r0,64*6($out)
 	srdi	r0,r0,8
-	stb	r0,64*7-1($out)
+	stb	r0,64*7($out)
 	addi	$out,$out,64*8
 	bdnz	.Loop_scatter_w7
 

--- a/crypto/ec/asm/ecp_nistz256-sparcv9.pl
+++ b/crypto/ec/asm/ecp_nistz256-sparcv9.pl
@@ -1531,13 +1531,13 @@ ecp_nistz256_scatter_w7:
 	ld	[$inp],%l0
 	add	$inp,4,$inp
 	subcc	$index,1,$index
-	stb	%l0,[$out+64*0-1]
+	stb	%l0,[$out+64*0]
 	srl	%l0,8,%l1
-	stb	%l1,[$out+64*1-1]
+	stb	%l1,[$out+64*1]
 	srl	%l0,16,%l2
-	stb	%l2,[$out+64*2-1]
+	stb	%l2,[$out+64*2]
 	srl	%l0,24,%l3
-	stb	%l3,[$out+64*3-1]
+	stb	%l3,[$out+64*3]
 	bne	.Loop_scatter_w7
 	add	$out,64*4,$out
 

--- a/crypto/ec/asm/ecp_nistz256-x86.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86.pl
@@ -1179,7 +1179,7 @@ for ($i=0;$i<7;$i++) {
 	&mov	("esi",&wparam(1));
 	&mov	("ebp",&wparam(2));
 
-	&lea	("edi",&DWP(-1,"edi","ebp"));
+	&lea	("edi",&DWP(0,"edi","ebp"));
 	&mov	("ebp",64/4);
 &set_label("scatter_w7_loop");
 	&mov	("eax",&DWP(0,"esi"));

--- a/crypto/include/internal/bn_int.h
+++ b/crypto/include/internal/bn_int.h
@@ -47,7 +47,7 @@ BN_ULONG *bn_get_words(const BIGNUM *a);
  * Set the internal data words in a to point to words which contains size
  * elements. The BN_FLG_STATIC_DATA flag is set
  */
-void bn_set_static_words(BIGNUM *a, BN_ULONG *words, int size);
+void bn_set_static_words(BIGNUM *a, const BN_ULONG *words, int size);
 
 /*
  * Copy words into the BIGNUM |a|, reallocating space as necessary.
@@ -58,7 +58,7 @@ void bn_set_static_words(BIGNUM *a, BN_ULONG *words, int size);
  * |num_words| is int because bn_expand2 takes an int. This is an internal
  * function so we simply trust callers not to pass negative values.
  */
-int bn_set_words(BIGNUM *a, BN_ULONG *words, int num_words);
+int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words);
 
 /*
  * Some BIGNUM functions assume most significant limb to be non-zero, which


### PR DESCRIPTION
ecp_nistz256_set_from_affine is called when application attempts to use
custom generator, i.e. rarely. Even though it was wrong, it didn't
affect point operations, they were just not as fast as expected.

1.1.0 and 1.0.2 labels are speculative in sense that this will have to be back-ported.

Addresses #6714.