### PR TITLE
crypto/init.c: use destructor_key even as guard in OPENSSL_thread_stop.

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -198,10 +198,14 @@ int OPENSSL_isservice(void)
 
     if (_OPENSSL_isservice.p == NULL) {
         HANDLE mod = GetModuleHandle(NULL);
+        FARPROC f;
+
         if (mod != NULL)
-            _OPENSSL_isservice.f = GetProcAddress(mod, "_OPENSSL_isservice");
-        if (_OPENSSL_isservice.p == NULL)
+            f = GetProcAddress(mod, "_OPENSSL_isservice");
+        if (f == NULL)
             _OPENSSL_isservice.p = (void *)-1;
+        else
+            _OPENSSL_isservice.f = f;
     }
 
     if (_OPENSSL_isservice.p != (void *)-1)

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -32,12 +32,13 @@ extern unsigned int OPENSSL_ia32cap_P[4];
 #  ifdef _WIN32
 typedef WCHAR ossl_char;
 
-/*
- * Since we pull only one environment variable, it's simpler to
- * to just ignore |name| and use eqivalent wide-char L-literal.
- */
 static ossl_char *ossl_getenv(const char *name)
 {
+    /*
+     * Since we pull only one environment variable, it's simpler to
+     * to just ignore |name| and use equivalent wide-char L-literal.
+     * As well as to ignore excessively long values...
+     */
     static WCHAR value[48];
     DWORD len = GetEnvironmentVariableW(L"OPENSSL_ia32cap", value, 48);
 

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -52,6 +52,7 @@ static int todigit(ossl_char c)
     else if (ossl_isxdigit(ossl_tolower(c)))
         return c - 'a' + 10;
 
+    /* return largest base value to make caller terminate the loop */
     return 16;
 }
 

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -22,7 +22,7 @@ extern unsigned int OPENSSL_ia32cap_P[4];
 
 /*
  * Purpose of these minimalistic and character-type-agnostic subroutines
- * is to break dependency on MSCVRT (on Windows) and locale. This makes
+ * is to break dependency on MSVCRT (on Windows) and locale. This makes
  * OPENSSL_cpuid_setup safe to use as "constructor". "Character-type-
  * agnostic" means that they work with either wide or 8-bit characters,
  * exploiting the fact that first 127 characters can be simply casted

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -154,7 +154,6 @@ void OPENSSL_cpuid_setup(void)
 unsigned int OPENSSL_ia32cap_P[4];
 # endif
 #endif
-int OPENSSL_NONPIC_relocated = 0;
 #if !defined(OPENSSL_CPUID_SETUP) && !defined(OPENSSL_CPUID_OBJ)
 void OPENSSL_cpuid_setup(void)
 {

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -30,9 +30,9 @@ extern unsigned int OPENSSL_ia32cap_P[4];
  * subroutines.
  */
 #  ifdef _WIN32
-typedef WCHAR ossl_char;
+typedef WCHAR variant_char;
 
-static ossl_char *ossl_getenv(const char *name)
+static variant_char *ossl_getenv(const char *name)
 {
     /*
      * Since we pull only one environment variable, it's simpler to
@@ -45,13 +45,13 @@ static ossl_char *ossl_getenv(const char *name)
     return (len > 0 && len < 48) ? value : NULL;
 }
 #  else
-typedef char ossl_char;
+typedef char variant_char;
 #   define ossl_getenv getenv
 #  endif
 
 #  include "internal/ctype.h"
 
-static int todigit(ossl_char c)
+static int todigit(variant_char c)
 {
     if (ossl_isdigit(c))
         return c - '0';
@@ -62,7 +62,7 @@ static int todigit(ossl_char c)
     return 16;
 }
 
-static uint64_t ossl_strtouint64(const ossl_char *str)
+static uint64_t ossl_strtouint64(const variant_char *str)
 {
     uint64_t ret = 0;
     unsigned int digit, base = 10;
@@ -79,12 +79,12 @@ static uint64_t ossl_strtouint64(const ossl_char *str)
     return ret;
 }
 
-static ossl_char *ossl_strchr(const ossl_char *str, char srch)
-{   ossl_char c;
+static variant_char *ossl_strchr(const variant_char *str, char srch)
+{   variant_char c;
 
     while((c = *str)) {
         if (c == srch)
-	    return (ossl_char *)str;
+	    return (variant_char *)str;
         str++;
     }
 
@@ -99,7 +99,7 @@ void OPENSSL_cpuid_setup(void)
     static int trigger = 0;
     IA32CAP OPENSSL_ia32_cpuid(unsigned int *);
     IA32CAP vec;
-    const ossl_char *env;
+    const variant_char *env;
 
     if (trigger)
         return;

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -55,8 +55,8 @@ static int todigit(ossl_char c)
 {
     if (ossl_isdigit(c))
         return c - '0';
-    else if (ossl_isxdigit(ossl_tolower(c)))
-        return c - 'a' + 10;
+    else if (ossl_isxdigit(c))
+        return ossl_tolower(c) - 'a' + 10;
 
     /* return largest base value to make caller terminate the loop */
     return 16;

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -31,12 +31,17 @@ extern unsigned int OPENSSL_ia32cap_P[4];
  */
 #  ifdef _WIN32
 typedef WCHAR ossl_char;
+
+/*
+ * Since we pull only one environment variable, it's simpler to
+ * to just ignore |name| and use eqivalent wide-char L-literal.
+ */
 static ossl_char *ossl_getenv(const char *name)
 {
     static WCHAR value[48];
     DWORD len = GetEnvironmentVariableW(L"OPENSSL_ia32cap", value, 48);
 
-    return (len > 0 && len <= 48) ? value : NULL;
+    return (len > 0 && len < 48) ? value : NULL;
 }
 #  else
 typedef char ossl_char;

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -31,21 +31,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     switch (fdwReason) {
     case DLL_PROCESS_ATTACH:
         OPENSSL_cpuid_setup();
-# if defined(_WIN32_WINNT)
-        {
-            IMAGE_DOS_HEADER *dos_header = (IMAGE_DOS_HEADER *) hinstDLL;
-            IMAGE_NT_HEADERS *nt_headers;
-
-            if (dos_header->e_magic == IMAGE_DOS_SIGNATURE) {
-                nt_headers = (IMAGE_NT_HEADERS *) ((char *)dos_header
-                                                   + dos_header->e_lfanew);
-                if (nt_headers->Signature == IMAGE_NT_SIGNATURE &&
-                    hinstDLL !=
-                    (HINSTANCE) (nt_headers->OptionalHeader.ImageBase))
-                    OPENSSL_NONPIC_relocated = 1;
-            }
-        }
-# endif
         break;
     case DLL_THREAD_ATTACH:
         break;

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -30,11 +30,23 @@
 
 static int stopped = 0;
 
+/*
+ * Since per-thread-specific-data destructors are not universally
+ * available, i.e. not on *cough*-dows, only below CRYPTO_THREAD_LOCAL
+ * key is assumed to have destructor associated. And then an effort is
+ * made to call this single destructor on non-pthread platform[s].
+ * Initial value is "impossible". It is used as guard value to shortcut
+ * destructor for threads terminating before libcrypto is initialized.
+ * Access to the key doesn't have to be serialized for the said threads,
+ * because they didn't use libcrypto and it doesn't matter if they pick
+ * "impossible" or real NULL value past initialization in the first
+ * thread that intend to use libcrypto.
+ */
+static CRYPTO_THREAD_LOCAL destructor_key = (CRYPTO_THREAD_LOCAL)-1;
+
 static void ossl_init_thread_stop(struct thread_local_inits_st *locals);
 
-static CRYPTO_THREAD_LOCAL threadstopkey;
-
-static void ossl_init_thread_stop_wrap(void *local)
+static void ossl_init_thread_destructor(void *local)
 {
     ossl_init_thread_stop((struct thread_local_inits_st *)local);
 }
@@ -42,17 +54,17 @@ static void ossl_init_thread_stop_wrap(void *local)
 static struct thread_local_inits_st *ossl_init_get_thread_local(int alloc)
 {
     struct thread_local_inits_st *local =
-        CRYPTO_THREAD_get_local(&threadstopkey);
+        CRYPTO_THREAD_get_local(&destructor_key);
 
-    if (local == NULL && alloc) {
-        local = OPENSSL_zalloc(sizeof(*local));
-        if (local != NULL && !CRYPTO_THREAD_set_local(&threadstopkey, local)) {
+    if (alloc) {
+        if (local == NULL
+            && (local = OPENSSL_zalloc(sizeof(*local))) != NULL
+            && !CRYPTO_THREAD_set_local(&destructor_key, local)) {
             OPENSSL_free(local);
             return NULL;
         }
-    }
-    if (!alloc) {
-        CRYPTO_THREAD_set_local(&threadstopkey, NULL);
+    } else {
+        CRYPTO_THREAD_set_local(&destructor_key, NULL);
     }
 
     return local;
@@ -71,17 +83,15 @@ static CRYPTO_ONCE base = CRYPTO_ONCE_STATIC_INIT;
 static int base_inited = 0;
 DEFINE_RUN_ONCE_STATIC(ossl_init_base)
 {
+    CRYPTO_THREAD_LOCAL key;
+
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: ossl_init_base: Setting up stop handlers\n");
 #endif
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
     ossl_malloc_setup_failures();
 #endif
-    /*
-     * We use a dummy thread local key here. We use the destructor to detect
-     * when the thread is going to stop (where that feature is available)
-     */
-    if (!CRYPTO_THREAD_init_local(&threadstopkey, ossl_init_thread_stop_wrap))
+    if (!CRYPTO_THREAD_init_local(&key, ossl_init_thread_destructor))
         return 0;
     if ((init_lock = CRYPTO_THREAD_lock_new()) == NULL)
         goto err;
@@ -91,6 +101,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
 #endif
     OPENSSL_cpuid_setup();
 
+    destructor_key = key;
     base_inited = 1;
     return 1;
 
@@ -101,7 +112,7 @@ err:
     CRYPTO_THREAD_lock_free(init_lock);
     init_lock = NULL;
 
-    CRYPTO_THREAD_cleanup_local(&threadstopkey);
+    CRYPTO_THREAD_cleanup_local(&key);
     return 0;
 }
 
@@ -396,8 +407,8 @@ static void ossl_init_thread_stop(struct thread_local_inits_st *locals)
 
 void OPENSSL_thread_stop(void)
 {
-    ossl_init_thread_stop(
-        (struct thread_local_inits_st *)ossl_init_get_thread_local(0));
+    if (destructor_key != (CRYPTO_THREAD_LOCAL)-1)
+        ossl_init_thread_stop(ossl_init_get_thread_local(0));
 }
 
 int ossl_init_thread_start(uint64_t opts)
@@ -442,6 +453,7 @@ int ossl_init_thread_start(uint64_t opts)
 void OPENSSL_cleanup(void)
 {
     OPENSSL_INIT_STOP *currhandler, *lasthandler;
+    CRYPTO_THREAD_LOCAL key;
 
     /* If we've not been inited then no need to deinit */
     if (!base_inited)
@@ -501,7 +513,9 @@ void OPENSSL_cleanup(void)
         err_free_strings_int();
     }
 
-    CRYPTO_THREAD_cleanup_local(&threadstopkey);
+    key = destructor_key;
+    destructor_key = (CRYPTO_THREAD_LOCAL)-1;
+    CRYPTO_THREAD_cleanup_local(&key);
 
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: OPENSSL_cleanup: "

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -32,15 +32,17 @@ static int stopped = 0;
 
 /*
  * Since per-thread-specific-data destructors are not universally
- * available, i.e. not on *cough*-dows, only below CRYPTO_THREAD_LOCAL
- * key is assumed to have destructor associated. And then an effort is
- * made to call this single destructor on non-pthread platform[s].
+ * available, i.e. not on Windows, only below CRYPTO_THREAD_LOCAL key
+ * is assumed to have destructor associated. And then an effort is made
+ * to call this single destructor on non-pthread platform[s].
+ *
  * Initial value is "impossible". It is used as guard value to shortcut
- * destructor for threads terminating before libcrypto is initialized.
- * Access to the key doesn't have to be serialized for the said threads,
- * because they didn't use libcrypto and it doesn't matter if they pick
- * "impossible" or real NULL value past initialization in the first
- * thread that intend to use libcrypto.
+ * destructor for threads terminating before libcrypto is initialized or
+ * after it's de-initialized. Access to the key doesn't have to be
+ * serialized for the said threads, because they didn't use libcrypto
+ * and it doesn't matter if they pick "impossible" or derefernce real
+ * key value and pull NULL past initialization in the first thread that
+ * intends to use libcrypto.
  */
 static CRYPTO_THREAD_LOCAL destructor_key = (CRYPTO_THREAD_LOCAL)-1;
 

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -78,7 +78,6 @@ DEFINE_LHASH_OF(MEM);
 void OPENSSL_cpuid_setup(void);
 extern unsigned int OPENSSL_ia32cap_P[];
 void OPENSSL_showfatal(const char *fmta, ...);
-extern int OPENSSL_NONPIC_relocated;
 void crypto_cleanup_all_ex_data_int(void);
 int openssl_init_fork_handlers(void);
 


### PR DESCRIPTION
Problem was that Windows threads that were terminating before libcrypto
was initialized were referencing uninitialized or possibly even
unrelated thread local storage index.

Request covers even couple of other issues related to dllmain. This is alternative to #6627 and #6711.

1.0.2 and 1.1.0 labels are speculative in sense that not everything should be back-ported and those commits that should be won't necessarily cherry-pick.