### PR TITLE
Handle both prime and binary curves in the SM2 code

### DIFF
--- a/crypto/sm2/sm2_lcl.h
+++ b/crypto/sm2/sm2_lcl.h
@@ -9,6 +9,31 @@
 
 #include <openssl/ec.h>
 
+#ifdef OPENSSL_NO_EC2M
+static ossl_inline int sm2_get_curve(const EC_GROUP *group, BIGNUM *p,
+                                     BIGNUM *a, BIGNUM *b, BN_CTX *ctx)
+{
+    return EC_GROUP_get_curve_GFp(group, p, a, b, ctx);
+}
+
+static ossl_inline int sm2_get_affine_coordinates(const EC_GROUP *group,
+                                                  const EC_POINT *p,
+                                                  BIGNUM *x,
+                                                  BIGNUM *y,
+                                                  BN_CTX *ctx)
+{
+    return EC_POINT_get_affine_coordinates_GFp(group, p, x, y, ctx);
+}
+
+static ossl_inline int sm2_set_affine_coordinates(const EC_GROUP *group,
+                                                  EC_POINT *p,
+                                                  const BIGNUM *x,
+                                                  const BIGNUM *y,
+                                                  BN_CTX *ctx)
+{
+    return EC_POINT_set_affine_coordinates_GFp(group, p, x, y, ctx);
+}
+#else
 static ossl_inline int sm2_get_curve(const EC_GROUP *group, BIGNUM *p,
                                      BIGNUM *a, BIGNUM *b, BN_CTX *ctx)
 {
@@ -41,3 +66,4 @@ static ossl_inline int sm2_set_affine_coordinates(const EC_GROUP *group,
            ? EC_POINT_set_affine_coordinates_GFp(group, p, x, y, ctx)
            : EC_POINT_set_affine_coordinates_GF2m(group, p, x, y, ctx);
 }
+#endif

--- a/crypto/sm2/sm2_lcl.h
+++ b/crypto/sm2/sm2_lcl.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/ec.h>
+
+static ossl_inline int sm2_get_curve(const EC_GROUP *group, BIGNUM *p,
+                                     BIGNUM *a, BIGNUM *b, BN_CTX *ctx)
+{
+    return EC_METHOD_get_field_type(EC_GROUP_method_of(group))
+               == NID_X9_62_prime_field
+           ? EC_GROUP_get_curve_GFp(group, p, a, b, ctx)
+           : EC_GROUP_get_curve_GF2m(group, p, a, b, ctx);
+}
+
+static ossl_inline int sm2_get_affine_coordinates(const EC_GROUP *group,
+                                                  const EC_POINT *p,
+                                                  BIGNUM *x,
+                                                  BIGNUM *y,
+                                                  BN_CTX *ctx)
+{
+    return EC_METHOD_get_field_type(EC_GROUP_method_of(group))
+               == NID_X9_62_prime_field
+           ? EC_POINT_get_affine_coordinates_GFp(group, p, x, y, ctx)
+           : EC_POINT_get_affine_coordinates_GF2m(group, p, x, y, ctx);
+}
+
+static ossl_inline int sm2_set_affine_coordinates(const EC_GROUP *group,
+                                                  EC_POINT *p,
+                                                  const BIGNUM *x,
+                                                  const BIGNUM *y,
+                                                  BN_CTX *ctx)
+{
+    return EC_METHOD_get_field_type(EC_GROUP_method_of(group))
+               == NID_X9_62_prime_field
+           ? EC_POINT_set_affine_coordinates_GFp(group, p, x, y, ctx)
+           : EC_POINT_set_affine_coordinates_GF2m(group, p, x, y, ctx);
+}

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -17,6 +17,7 @@
 #include <openssl/err.h>
 #include <openssl/bn.h>
 #include <string.h>
+#include "sm2_lcl.h"
 
 static BIGNUM *sm2_compute_msg_hash(const EVP_MD *digest,
                                     const EC_KEY *key,
@@ -115,8 +116,7 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
         }
 
         if (!EC_POINT_mul(group, kG, k, NULL, NULL, ctx)
-                || !EC_POINT_get_affine_coordinates_GFp(group, kG, x1, NULL,
-                                                        ctx)
+                || !sm2_get_affine_coordinates(group, kG, x1, NULL, ctx)
                 || !BN_mod_add(r, e, x1, order, ctx)) {
             SM2err(SM2_F_SM2_SIG_GEN, ERR_R_INTERNAL_ERROR);
             goto done;
@@ -224,7 +224,7 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
     }
 
     if (!EC_POINT_mul(group, pt, s, EC_KEY_get0_public_key(key), t, ctx)
-            || !EC_POINT_get_affine_coordinates_GFp(group, pt, x1, NULL, ctx)) {
+            || !sm2_get_affine_coordinates(group, pt, x1, NULL, ctx)) {
         SM2err(SM2_F_SM2_SIG_VERIFY, ERR_R_EC_LIB);
         goto done;
     }


### PR DESCRIPTION
Use the correct form of the various *_GFp and *_GF2m functions in the SM2
code based on the type of curve that we have.

Fixes #6646

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
