### PR TITLE
Configure: print generic advice when dying

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -17,7 +17,7 @@ sub vc_win64a_info {
                                 asflags   => "/c /Cp /Cx",
                                 asoutflag => "/Fo" };
         } else {
-            $die->("NASM not found - make sure it's installed or configure with 'no-asm'\n");
+            $die->("NASM not found - make sure it's installed and avaible\n");
             $vc_win64a_info = { AS        => "{unknown}",
                                 ASFLAGS   => "",
                                 asflags   => "",
@@ -46,7 +46,7 @@ sub vc_win32_info {
                                asoutflag => "/Fo",
                                perlasm_scheme => "win32" };
         } else {
-            $die->("NASM not found - make sure it's installed or configure with 'no-asm'\n");
+            $die->("NASM not found - make sure it's installed and avaible\n");
             $vc_win32_info = { AS        => "{unknown}",
                                ASFLAGS   => "",
                                asflags   => "",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -17,7 +17,7 @@ sub vc_win64a_info {
                                 asflags   => "/c /Cp /Cx",
                                 asoutflag => "/Fo" };
         } else {
-            $die->("NASM not found - please read INSTALL and NOTES.WIN for further details\n");
+            $die->("NASM not found - make sure it's installed or configure with 'no-asm'\n");
             $vc_win64a_info = { AS        => "{unknown}",
                                 ASFLAGS   => "",
                                 asflags   => "",
@@ -46,7 +46,7 @@ sub vc_win32_info {
                                asoutflag => "/Fo",
                                perlasm_scheme => "win32" };
         } else {
-            $die->("NASM not found - please read INSTALL and NOTES.WIN for further details\n");
+            $die->("NASM not found - make sure it's installed or configure with 'no-asm'\n");
             $vc_win32_info = { AS        => "{unknown}",
                                ASFLAGS   => "",
                                asflags   => "",

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -17,7 +17,7 @@ sub vc_win64a_info {
                                 asflags   => "/c /Cp /Cx",
                                 asoutflag => "/Fo" };
         } else {
-            $die->("NASM not found - make sure it's installed and avaible\n");
+            $die->("NASM not found - make sure it's installed and available on %PATH%\n");
             $vc_win64a_info = { AS        => "{unknown}",
                                 ASFLAGS   => "",
                                 asflags   => "",
@@ -46,7 +46,7 @@ sub vc_win32_info {
                                asoutflag => "/Fo",
                                perlasm_scheme => "win32" };
         } else {
-            $die->("NASM not found - make sure it's installed and avaible\n");
+            $die->("NASM not found - make sure it's installed and available on %PATH%\n");
             $vc_win32_info = { AS        => "{unknown}",
                                ASFLAGS   => "",
                                asflags   => "",

--- a/Configure
+++ b/Configure
@@ -2726,8 +2726,8 @@ sub death_handler {
     print STDERR <<"_____";
 
 Failure!  $build_file wasn't produced.
-Please read INSTALL and associated NOTES files, look over your available
-compiler tool chain or change your configuration.
+Please read INSTALL and associated NOTES files.  You may also have to look over
+your available compiler tool chain or change your configuration.
 
 _____
 }

--- a/Configure
+++ b/Configure
@@ -21,6 +21,9 @@ use OpenSSL::Glob;
 
 # see INSTALL for instructions.
 
+my $orig_death_handler = $SIG{__DIE__};
+$SIG{__DIE__} = \&death_handler;
+
 my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
 
 # Options:
@@ -2679,6 +2682,8 @@ my %builders = (
 
 $builders{$builder}->($builder_platform, @builder_opts);
 
+$SIG{__DIE__} = $orig_death_handler;
+
 print <<"EOF" if ($disabled{threads} eq "unavailable");
 
 The library could not be configured for supporting multi-threaded
@@ -2713,6 +2718,19 @@ exit(0);
 #
 # Helpers and utility functions
 #
+
+# Death handler, to print a helpful message in case of failure #######
+#
+sub death_handler {
+    my $build_file = $target{build_file} // "build file";
+    print STDERR <<"_____";
+
+Failure!  $build_file wasn't produced
+Please read INSTALL and associated NOTES files, look over your available
+compiler tool chain or change your configuration.
+
+_____
+}
 
 # Configuration file reading #########################################
 

--- a/Configure
+++ b/Configure
@@ -2725,7 +2725,7 @@ sub death_handler {
     my $build_file = $target{build_file} // "build file";
     print STDERR <<"_____";
 
-Failure!  $build_file wasn't produced
+Failure!  $build_file wasn't produced.
 Please read INSTALL and associated NOTES files, look over your available
 compiler tool chain or change your configuration.
 


### PR DESCRIPTION
On the same note, change the 'NASM not found' message to give specific
advice on how to handle the failure.

Fixes #6765
