### PR TITLE
bn/bn_mod.c: harmonize BN_mod_add_quick with original implementation.

### DIFF
--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -83,6 +83,7 @@ int bn_mod_add_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
         ((volatile BN_ULONG *)tp)[i] = 0;
     }
     r->top = mtop;
+    r->neg = 0;
 
     if (tp != storage)
         OPENSSL_free(tp);


### PR DESCRIPTION
New implementation failed to correctly reset r->neg flag. Spotted by
OSSFuzz.

1.0.2 and 1.1.0 labels indicate back-port intention, not direct applicability. Well, 1.1.0 is being back-ported in #6707, and once this goes to master, I'll merge #6707 and cherry-pick this one. 1.0.2 back-port will follow...