### PR TITLE
doc/BN_generate_prime: alert the reader about other callback values

### DIFF
--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -72,6 +72,11 @@ B<BN_GENCB_call(cb, 1, j)> is called as described below.
 
 When a prime has been found, B<BN_GENCB_call(cb, 2, i)> is called.
 
+=item *
+
+The callers of BN_generate_prime_ex() may call B<BN_GENCB_call(cb, i, j)> with
+other values as described in their respective man pages; see L</SEE ALSO>.
+
 =back
 
 The prime may have to fulfill additional requirements for use in
@@ -187,7 +192,8 @@ Instead applications should create a BN_GENCB structure using BN_GENCB_new:
 
 =head1 SEE ALSO
 
-L<ERR_get_error(3)>, L<RAND_bytes(3)>
+L<DH_generate_parameters(3)>, L<DSA_generate_parameters(3)>,
+L<RSA_generate_key(3)>, L<ERR_get_error(3)>, L<RAND_bytes(3)>
 
 =head1 HISTORY
 


### PR DESCRIPTION
This here page only documents the callback values 0 to 2, but the
callers of BN_generate_prime_ex() call it with the value 3.

The list of manual pages in the SEE ALSO section was extended with the
output from

    git grep BN_GENCB_call.*[3-9]

while in the doc/man3 directory.

Signed-off-by: Beat Bolli <dev@drbeat.li>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
