### PR TITLE
Add OPENSSL_s390xcap environment variable

### DIFF
--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -49,6 +49,9 @@ struct OPENSSL_s390xcap_st {
 
 extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 
+/* Max number of 64-bit words currently returned by STFLE */
+#  define S390X_STFLE_MAX	3
+
 /* convert facility bit number or function code to bit mask */
 #  define S390X_CAPBIT(i)	(1ULL << (63 - (i) % 64))
 
@@ -68,9 +71,15 @@ extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 # define S390X_KMA		0xb0
 
 /* Facility Bit Numbers */
-# define S390X_VX		129
-# define S390X_VXD		134
-# define S390X_VXE		135
+# define S390X_MSA		17	/* message-security-assist */
+# define S390X_STCKF		25	/* store-clock-fast */
+# define S390X_MSA5		57	/* message-security-assist-ext. 5 */
+# define S390X_MSA3		76	/* message-security-assist-ext. 3 */
+# define S390X_MSA4		77	/* message-security-assist-ext. 4 */
+# define S390X_VX		129	/* vector */
+# define S390X_VXD		134	/* vector packed decimal */
+# define S390X_VXE		135	/* vector enhancements 1 */
+# define S390X_MSA8		146	/* message-security-assist-ext. 8 */
 
 /* Function Codes */
 
@@ -78,6 +87,9 @@ extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 # define S390X_QUERY		0
 
 /* kimd/klmd */
+# define S390X_SHA_1		1
+# define S390X_SHA_256		2
+# define S390X_SHA_512		3
 # define S390X_SHA3_224		32
 # define S390X_SHA3_256		33
 # define S390X_SHA3_384		34
@@ -91,7 +103,12 @@ extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 # define S390X_AES_192		19
 # define S390X_AES_256		20
 
+/* km */
+# define S390X_XTS_AES_128	50
+# define S390X_XTS_AES_256	52
+
 /* prno */
+# define S390X_SHA_512_DRNG	3
 # define S390X_TRNG		114
 
 /* Register 0 Flags */

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -13,7 +13,39 @@
 #include <setjmp.h>
 #include <signal.h>
 #include "internal/cryptlib.h"
+#include "internal/ctype.h"
 #include "s390x_arch.h"
+
+#define LEN	128
+#define STR_(S)	#S
+#define STR(S)	STR_(S)
+
+#define TOK_FUNC(NAME)							\
+    (sscanf(tok_begin,							\
+            " " STR(NAME) " : %" STR(LEN) "[^:] : "			\
+            "%" STR(LEN) "s %" STR(LEN) "s ",				\
+            tok[0], tok[1], tok[2]) == 2) {				\
+									\
+        off = (tok[0][0] == '~') ? 1 : 0;				\
+        if (sscanf(tok[0] + off, "%llx", &cap->NAME[0]) != 1)		\
+            goto ret;							\
+        if (off)							\
+            cap->NAME[0] = ~cap->NAME[0];				\
+									\
+        off = (tok[1][0] == '~') ? 1 : 0;				\
+        if (sscanf(tok[1] + off, "%llx", &cap->NAME[1]) != 1)		\
+            goto ret;							\
+        if (off)							\
+            cap->NAME[1] = ~cap->NAME[1];				\
+    }
+
+#define TOK_CPU(NAME)							\
+    (sscanf(tok_begin,							\
+            " %" STR(LEN) "s %" STR(LEN) "s ",				\
+            tok[0], tok[1]) == 1					\
+     && !strcmp(tok[0], #NAME)) {					\
+            memcpy(cap, &NAME, sizeof(*cap));				\
+    }
 
 static sigjmp_buf ill_jmp;
 static void ill_handler(int sig)
@@ -21,7 +53,11 @@ static void ill_handler(int sig)
     siglongjmp(ill_jmp, sig);
 }
 
+static const char *env;
+static int parse_env(struct OPENSSL_s390xcap_st *cap);
+
 void OPENSSL_s390x_facilities(void);
+void OPENSSL_s390x_functions(void);
 void OPENSSL_vx_probe(void);
 
 struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
@@ -30,12 +66,19 @@ void OPENSSL_cpuid_setup(void)
 {
     sigset_t oset;
     struct sigaction ill_act, oact;
+    struct OPENSSL_s390xcap_st cap;
 
     if (OPENSSL_s390xcap_P.stfle[0])
         return;
 
     /* set a bit that will not be tested later */
     OPENSSL_s390xcap_P.stfle[0] |= S390X_CAPBIT(0);
+
+    env = getenv("OPENSSL_s390xcap");
+    if (env != NULL) {
+        if (!parse_env(&cap))
+            env = NULL;
+    }
 
     memset(&ill_act, 0, sizeof(ill_act));
     ill_act.sa_handler = ill_handler;
@@ -51,6 +94,12 @@ void OPENSSL_cpuid_setup(void)
     if (sigsetjmp(ill_jmp, 1) == 0)
         OPENSSL_s390x_facilities();
 
+    if (env != NULL) {
+        OPENSSL_s390xcap_P.stfle[0] &= cap.stfle[0];
+        OPENSSL_s390xcap_P.stfle[1] &= cap.stfle[1];
+        OPENSSL_s390xcap_P.stfle[2] &= cap.stfle[2];
+    }
+
     /* protection against disabled vector facility */
     if ((OPENSSL_s390xcap_P.stfle[2] & S390X_CAPBIT(S390X_VX))
         && (sigsetjmp(ill_jmp, 1) == 0)) {
@@ -64,4 +113,470 @@ void OPENSSL_cpuid_setup(void)
     sigaction(SIGFPE, &oact, NULL);
     sigaction(SIGILL, &oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);
+
+    OPENSSL_s390x_functions();
+
+    if (env != NULL) {
+        OPENSSL_s390xcap_P.kimd[0] &= cap.kimd[0];
+        OPENSSL_s390xcap_P.kimd[1] &= cap.kimd[1];
+        OPENSSL_s390xcap_P.klmd[0] &= cap.klmd[0];
+        OPENSSL_s390xcap_P.klmd[1] &= cap.klmd[1];
+        OPENSSL_s390xcap_P.km[0] &= cap.km[0];
+        OPENSSL_s390xcap_P.km[1] &= cap.km[1];
+        OPENSSL_s390xcap_P.kmc[0] &= cap.kmc[0];
+        OPENSSL_s390xcap_P.kmc[1] &= cap.kmc[1];
+        OPENSSL_s390xcap_P.kmac[0] &= cap.kmac[0];
+        OPENSSL_s390xcap_P.kmac[1] &= cap.kmac[1];
+        OPENSSL_s390xcap_P.kmctr[0] &= cap.kmctr[0];
+        OPENSSL_s390xcap_P.kmctr[1] &= cap.kmctr[1];
+        OPENSSL_s390xcap_P.kmo[0] &= cap.kmo[0];
+        OPENSSL_s390xcap_P.kmo[1] &= cap.kmo[1];
+        OPENSSL_s390xcap_P.kmf[0] &= cap.kmf[0];
+        OPENSSL_s390xcap_P.kmf[1] &= cap.kmf[1];
+        OPENSSL_s390xcap_P.prno[0] &= cap.prno[0];
+        OPENSSL_s390xcap_P.prno[1] &= cap.prno[1];
+        OPENSSL_s390xcap_P.kma[0] &= cap.kma[0];
+        OPENSSL_s390xcap_P.kma[1] &= cap.kma[1];
+    }
+}
+
+static int parse_env(struct OPENSSL_s390xcap_st *cap)
+{
+    /*-
+     * CPU model data
+     * (only the STFLE- and QUERY-bits relevant to libcrypto are set)
+     */
+
+    /*-
+     * z900 (2000) - z/Architecture POP SA22-7832-00
+     * Facility detection would fail on real hw (no STFLE).
+     */
+    static const struct OPENSSL_s390xcap_st z900 = {
+        .stfle  = {0ULL, 0ULL, 0ULL, 0ULL},
+        .kimd   = {0ULL, 0ULL},
+        .klmd   = {0ULL, 0ULL},
+        .km     = {0ULL, 0ULL},
+        .kmc    = {0ULL, 0ULL},
+        .kmac   = {0ULL, 0ULL},
+        .kmctr  = {0ULL, 0ULL},
+        .kmo    = {0ULL, 0ULL},
+        .kmf    = {0ULL, 0ULL},
+        .prno   = {0ULL, 0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * z990 (2003) - z/Architecture POP SA22-7832-02
+     * Implements MSA. Facility detection would fail on real hw (no STFLE).
+     */
+    static const struct OPENSSL_s390xcap_st z990 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA),
+                   0ULL, 0ULL, 0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1),
+                   0ULL},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY),
+                   0ULL},
+        .kmctr  = {0ULL, 0ULL},
+        .kmo    = {0ULL, 0ULL},
+        .kmf    = {0ULL, 0ULL},
+        .prno   = {0ULL, 0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * z9 (2005) - z/Architecture POP SA22-7832-04
+     * Implements MSA and MSA1.
+     */
+    static const struct OPENSSL_s390xcap_st z9 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA)
+                     | S390X_CAPBIT(S390X_STCKF),
+                   0ULL, 0ULL, 0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256),
+                   0ULL},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY),
+                   0ULL},
+        .kmctr  = {0ULL, 0ULL},
+        .kmo    = {0ULL, 0ULL},
+        .kmf    = {0ULL, 0ULL},
+        .prno   = {0ULL, 0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * z10 (2008) - z/Architecture POP SA22-7832-06
+     * Implements MSA and MSA1-2.
+     */
+    static const struct OPENSSL_s390xcap_st z10 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA)
+                     | S390X_CAPBIT(S390X_STCKF),
+                   0ULL, 0ULL, 0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   0ULL},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY),
+                   0ULL},
+        .kmctr  = {0ULL, 0ULL},
+        .kmo    = {0ULL, 0ULL},
+        .kmf    = {0ULL, 0ULL},
+        .prno   = {0ULL, 0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * z196 (2010) - z/Architecture POP SA22-7832-08
+     * Implements MSA and MSA1-4.
+     */
+    static const struct OPENSSL_s390xcap_st z196 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA)
+                     | S390X_CAPBIT(S390X_STCKF),
+                   S390X_CAPBIT(S390X_MSA3)
+                     | S390X_CAPBIT(S390X_MSA4),
+                   0ULL, 0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   S390X_CAPBIT(S390X_GHASH)},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256)
+                     | S390X_CAPBIT(S390X_XTS_AES_128)
+                     | S390X_CAPBIT(S390X_XTS_AES_256),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmctr  = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmo    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmf    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .prno   = {0ULL, 0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * zEC12 (2012) - z/Architecture POP SA22-7832-09
+     * Implements MSA and MSA1-4.
+     */
+    static const struct OPENSSL_s390xcap_st zEC12 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA)
+                     | S390X_CAPBIT(S390X_STCKF),
+                   S390X_CAPBIT(S390X_MSA3)
+                     | S390X_CAPBIT(S390X_MSA4),
+                   0ULL, 0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   S390X_CAPBIT(S390X_GHASH)},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256)
+                     | S390X_CAPBIT(S390X_XTS_AES_128)
+                     | S390X_CAPBIT(S390X_XTS_AES_256),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmctr  = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmo    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmf    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .prno   = {0ULL, 0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * z13 (2015) - z/Architecture POP SA22-7832-10
+     * Implements MSA and MSA1-5.
+     */
+    static const struct OPENSSL_s390xcap_st z13 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA)
+                     | S390X_CAPBIT(S390X_STCKF)
+                     | S390X_CAPBIT(S390X_MSA5),
+                   S390X_CAPBIT(S390X_MSA3)
+                     | S390X_CAPBIT(S390X_MSA4),
+                   S390X_CAPBIT(S390X_VX),
+                   0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   S390X_CAPBIT(S390X_GHASH)},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256)
+                     | S390X_CAPBIT(S390X_XTS_AES_128)
+                     | S390X_CAPBIT(S390X_XTS_AES_256),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmctr  = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmo    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmf    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .prno   = {S390X_CAPBIT(S390X_QUERY)
+                   | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                   0ULL},
+        .kma    = {0ULL, 0ULL},
+    };
+
+    /*-
+     * z14 (2017) - z/Architecture POP SA22-7832-11
+     * Implements MSA and MSA1-8.
+     */
+    static const struct OPENSSL_s390xcap_st z14 = {
+        .stfle  = {S390X_CAPBIT(S390X_MSA)
+                     | S390X_CAPBIT(S390X_STCKF)
+                     | S390X_CAPBIT(S390X_MSA5),
+                   S390X_CAPBIT(S390X_MSA3)
+                     | S390X_CAPBIT(S390X_MSA4),
+                   S390X_CAPBIT(S390X_VX)
+                     | S390X_CAPBIT(S390X_VXD)
+                     | S390X_CAPBIT(S390X_VXE)
+                     | S390X_CAPBIT(S390X_MSA8),
+                   0ULL},
+        .kimd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512)
+                     | S390X_CAPBIT(S390X_SHA3_224)
+                     | S390X_CAPBIT(S390X_SHA3_256)
+                     | S390X_CAPBIT(S390X_SHA3_384)
+                     | S390X_CAPBIT(S390X_SHA3_512)
+                     | S390X_CAPBIT(S390X_SHAKE_128)
+                     | S390X_CAPBIT(S390X_SHAKE_256),
+                   S390X_CAPBIT(S390X_GHASH)},
+        .klmd   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_SHA_1)
+                     | S390X_CAPBIT(S390X_SHA_256)
+                     | S390X_CAPBIT(S390X_SHA_512)
+                     | S390X_CAPBIT(S390X_SHA3_224)
+                     | S390X_CAPBIT(S390X_SHA3_256)
+                     | S390X_CAPBIT(S390X_SHA3_384)
+                     | S390X_CAPBIT(S390X_SHA3_512)
+                     | S390X_CAPBIT(S390X_SHAKE_128)
+                     | S390X_CAPBIT(S390X_SHAKE_256),
+                   0ULL},
+        .km     = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256)
+                     | S390X_CAPBIT(S390X_XTS_AES_128)
+                     | S390X_CAPBIT(S390X_XTS_AES_256),
+                   0ULL},
+        .kmc    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmac   = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmctr  = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmo    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .kmf    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+        .prno   = {S390X_CAPBIT(S390X_QUERY)
+                   | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                   S390X_CAPBIT(S390X_TRNG)},
+        .kma    = {S390X_CAPBIT(S390X_QUERY)
+                     | S390X_CAPBIT(S390X_AES_128)
+                     | S390X_CAPBIT(S390X_AES_192)
+                     | S390X_CAPBIT(S390X_AES_256),
+                   0ULL},
+    };
+
+    char *tok_begin, *tok_end, *buff, tok[S390X_STFLE_MAX][LEN + 1];
+    int rc, off, i, n;
+
+    buff = malloc(strlen(env) + 1);
+    if (buff == NULL)
+        return 0;
+
+    rc = 0;
+    memset(cap, ~0, sizeof(*cap));
+    strcpy(buff, env);
+
+    tok_begin = buff + strspn(buff, ";");
+    strtok(tok_begin, ";");
+    tok_end = strtok(NULL, ";");
+
+    while (tok_begin != NULL) {
+        /* stfle token */
+        if ((n = sscanf(tok_begin,
+                        " stfle : %" STR(LEN) "[^:] : "
+                        "%" STR(LEN) "[^:] : %" STR(LEN) "s ",
+                        tok[0], tok[1], tok[2]))) {
+            for (i = 0; i < n; i++) {
+                off = (tok[i][0] == '~') ? 1 : 0;
+                if (sscanf(tok[i] + off, "%llx", &cap->stfle[i]) != 1)
+                    goto ret;
+                if (off)
+                    cap->stfle[i] = ~cap->stfle[i];
+            }
+        }
+
+        /* query function tokens */
+        else if TOK_FUNC(kimd)
+        else if TOK_FUNC(klmd)
+        else if TOK_FUNC(km)
+        else if TOK_FUNC(kmc)
+        else if TOK_FUNC(kmac)
+        else if TOK_FUNC(kmctr)
+        else if TOK_FUNC(kmo)
+        else if TOK_FUNC(kmf)
+        else if TOK_FUNC(prno)
+        else if TOK_FUNC(kma)
+
+        /* CPU model tokens */
+        else if TOK_CPU(z900)
+        else if TOK_CPU(z990)
+        else if TOK_CPU(z9)
+        else if TOK_CPU(z10)
+        else if TOK_CPU(z196)
+        else if TOK_CPU(zEC12)
+        else if TOK_CPU(z13)
+        else if TOK_CPU(z14)
+
+        /* whitespace(ignored) or invalid tokens */
+        else {
+            while (*tok_begin != '\0') {
+                if (!ossl_isspace(*tok_begin))
+                    goto ret;
+                tok_begin++;
+            }
+        }
+
+        tok_begin = tok_end;
+        tok_end = strtok(NULL, ";");
+    }
+
+    rc = 1;
+ret:
+    free(buff);
+    return rc;
 }

--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -38,7 +38,26 @@ OPENSSL_s390x_facilities:
 	stg	%r0,S390X_STFLE+8(%r4)	# wipe capability vectors
 	stg	%r0,S390X_STFLE+16(%r4)
 	stg	%r0,S390X_STFLE+24(%r4)
-	stg	%r0,S390X_KIMD(%r4)
+
+	.long	0xb2b04000		# stfle	0(%r4)
+	brc	8,.Ldone
+	lghi	%r0,1
+	.long	0xb2b04000		# stfle 0(%r4)
+	brc	8,.Ldone
+	lghi	%r0,2
+	.long	0xb2b04000		# stfle 0(%r4)
+.Ldone:
+	br	$ra
+.size	OPENSSL_s390x_facilities,.-OPENSSL_s390x_facilities
+
+.globl	OPENSSL_s390x_functions
+.type	OPENSSL_s390x_functions,\@function
+.align	16
+OPENSSL_s390x_functions:
+	lghi	%r0,0
+	larl	%r4,OPENSSL_s390xcap_P
+
+	stg	%r0,S390X_KIMD(%r4)	# wipe capability vectors
 	stg	%r0,S390X_KIMD+8(%r4)
 	stg	%r0,S390X_KLMD(%r4)
 	stg	%r0,S390X_KLMD+8(%r4)
@@ -59,14 +78,6 @@ OPENSSL_s390x_facilities:
 	stg	%r0,S390X_KMA(%r4)
 	stg	%r0,S390X_KMA+8(%r4)
 
-	.long	0xb2b04000		# stfle	0(%r4)
-	brc	8,.Ldone
-	lghi	%r0,1
-	.long	0xb2b04000		# stfle 0(%r4)
-	brc	8,.Ldone
-	lghi	%r0,2
-	.long	0xb2b04000		# stfle 0(%r4)
-.Ldone:
 	lmg	%r2,%r3,S390X_STFLE(%r4)
 	tmhl	%r2,0x4000		# check for message-security-assist
 	jz	.Lret
@@ -123,7 +134,7 @@ OPENSSL_s390x_facilities:
 
 .Lret:
 	br	$ra
-.size	OPENSSL_s390x_facilities,.-OPENSSL_s390x_facilities
+.size	OPENSSL_s390x_functions,.-OPENSSL_s390x_functions
 
 .globl	OPENSSL_rdtsc
 .type	OPENSSL_rdtsc,\@function

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -1,0 +1,173 @@
+=pod
+
+=head1 NAME
+
+OPENSSL_s390xcap - the IBM z processor capabilities vector
+
+=head1 SYNOPSIS
+
+ env OPENSSL_s390xcap=... <application>
+
+=head1 DESCRIPTION
+
+libcrypto supports z/Architecture instruction set extensions. These
+extensions are denoted by individual bits in the capabilities vector.
+When libcrypto is initialized, the bits returned by the STFLE instruction
+and by the QUERY functions are stored in the vector.
+
+To change the set of instructions available to an application, you can
+set the OPENSSL_s390xcap environment variable before you start the
+application. After initialization, the capability vector is ANDed bitwise
+with a mask which is derived from the environment variable.
+
+The environment variable is a semicolon-separated list of tokens which is
+processed from left to right (whitespace is ignored):
+
+ OPENSSL_s390xcap="<tok1>;<tok2>;..."
+
+There are three types of tokens:
+
+=over 4
+
+=item <string>
+
+The name of a processor generation. A bit in the environment variable's
+mask is set to one if and only if the specified processor generation
+implements the corresponding instruction set extension. Possible values
+are z900, z990, z9, z10, z196, zEC12, z13 and z14.
+
+=item <string>:<mask>:<mask>
+
+The name of an instruction followed by two 64-bit masks. The part of the
+environment variable's mask corresponding to the specified instruction is
+set to the specified 128-bit mask. Possible values are kimd, klmd, km, kmc,
+kmac, kmctr, kmo, kmf, prno and kma.
+
+=item stfle:<mask>:<mask>:<mask>
+
+Store-facility-list-extended (stfle) followed by three 64-bit masks. The
+part of the environment variable's mask corresponding to the stfle
+instruction is set to the specified 192-bit mask.
+
+=back
+
+The 64-bit masks are specified in hexadecimal notation. The 0x prefix is
+optional. Prefix a mask with a tilde (~) to denote a bitwise NOT operation.
+
+The following is a list of significant bits for each instruction. Colon
+rows separate the individual 64-bit masks. The bit numbers in the first
+column are consistent with [1], that is, 0 denotes the leftmost bit and
+the numbering is continuous across 64-bit mask boundaries.
+
+      Bit     Mask     Facility/Function
+
+ stfle:
+      # 17    1<<46    message-security assist
+      # 25    1<<38    store-clock-fast facility
+      :
+      # 76    1<<51    message-security assist extension 3
+      # 77    1<<50    message-security assist extension 4
+      :
+      #129    1<<62    vector facility
+      #134    1<<57    vector packed decimal facility
+      #135    1<<56    vector enhancements facility 1
+      #146    1<<45    message-security assist extension 8
+
+ kimd :
+      #  1    1<<62    KIMD-SHA-1
+      #  2    1<<61    KIMD-SHA-256
+      #  3    1<<60    KIMD-SHA-512
+      # 32    1<<31    KIMD-SHA3-224
+      # 33    1<<30    KIMD-SHA3-256
+      # 34    1<<29    KIMD-SHA3-384
+      # 35    1<<28    KIMD-SHA3-512
+      # 36    1<<27    KIMD-SHAKE-128
+      # 37    1<<26    KIMD-SHAKE-256
+      :
+      # 65    1<<62    KIMD-GHASH
+
+ klmd :
+      # 32    1<<31    KLMD-SHA3-224
+      # 33    1<<30    KLMD-SHA3-256
+      # 34    1<<29    KLMD-SHA3-384
+      # 35    1<<28    KLMD-SHA3-512
+      # 36    1<<27    KLMD-SHAKE-128
+      # 37    1<<26    KLMD-SHAKE-256
+      :
+
+ km   :
+      # 18    1<<45    KM-AES-128
+      # 19    1<<44    KM-AES-192
+      # 20    1<<43    KM-AES-256
+      # 50    1<<13    KM-XTS-AES-128
+      # 52    1<<11    KM-XTS-AES-256
+      :
+
+ kmc  :
+      # 18    1<<45    KMC-AES-128
+      # 19    1<<44    KMC-AES-192
+      # 20    1<<43    KMC-AES-256
+      :
+
+ kmac :
+      # 18    1<<45    KMAC-AES-128
+      # 19    1<<44    KMAC-AES-192
+      # 20    1<<43    KMAC-AES-256
+      :
+
+ kmctr:
+      :
+
+ kmo  :
+      # 18    1<<45    KMO-AES-128
+      # 19    1<<44    KMO-AES-192
+      # 20    1<<43    KMO-AES-256
+      :
+
+ kmf  :
+      # 18    1<<45    KMF-AES-128
+      # 19    1<<44    KMF-AES-192
+      # 20    1<<43    KMF-AES-256
+      :
+
+ prno :
+      :
+
+ kma  :
+      # 18    1<<45    KMA-GCM-AES-128
+      # 19    1<<44    KMA-GCM-AES-192
+      # 20    1<<43    KMA-GCM-AES-256
+      :
+
+=head1 EXAMPLES
+
+Disables all instruction set extensions which the z196 processor does not implement:
+
+ OPENSSL_s390xcap="z196"
+
+Disables the vector facility:
+
+ OPENSSL_s390xcap="stfle:~0:~0:~0x4000000000000000"
+
+Disables the KM-XTS-AES and and the KIMD-SHAKE function codes:
+
+ OPENSSL_s390xcap="km:~0x2800:~0;kimd:~0xc000000:~0"
+
+=head1 RETURN VALUES
+
+Not available.
+
+=head1 SEE ALSO
+
+[1] z/Architecture Principles of Operation, SA22-7832-11
+
+=head1 COPYRIGHT
+
+Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/util/private.num
+++ b/util/private.num
@@ -3,6 +3,7 @@
 # assembly language, etc.
 #
 OPENSSL_ia32cap                         environment
+OPENSSL_s390xcap                        environment
 OPENSSL_MALLOC_FD                       environment
 OPENSSL_MALLOC_FAILURES                 environment
 OPENSSL_instrument_bus                  assembler


### PR DESCRIPTION
This is the next patch in my s390 series.

I reworked the environment variable's semantics based on a discussion with @dot-asm :
https://github.com/openssl/openssl/pull/4542#discussion_r145554770

- [x] documentation is added or updated
