### PR TITLE
Some protocol versions are build-time

### DIFF
--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -73,30 +73,12 @@ L<SSL_CIPHER_description(3)>.
 
 Like B<-v>, but include the official cipher suite values in hex.
 
-=item B<-tls1_3>
+=item B<-tls1_3>, B<-tls1_2>, B<-tls1_1>, B<-tls1>, B<-ssl3>
 
-In combination with the B<-s> option, list the ciphers which would be used if
-TLSv1.3 were negotiated.
-
-=item B<-tls1_2>
-
-In combination with the B<-s> option, list the ciphers which would be used if
-TLSv1.2 were negotiated.
-
-=item B<-ssl3>
-
-In combination with the B<-s> option, list the ciphers which would be used if
-SSLv3 were negotiated.
-
-=item B<-tls1>
-
-In combination with the B<-s> option, list the ciphers which would be used if
-TLSv1 were negotiated.
-
-=item B<-tls1_1>
-
-In combination with the B<-s> option, list the ciphers which would be used if
-TLSv1.1 were negotiated.
+In combination with the B<-s> option, list the ciphers which could be used if
+the specified protocol were negotiated.
+Note that not all protocols and flags may be available, depending on how
+OpenSSL was built.
 
 =item B<-stdname>
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -473,6 +473,8 @@ By default B<s_client> will negotiate the highest mutually supported protocol
 version.
 When a specific TLS version is required, only that version will be offered to
 and accepted from the server.
+Note that not all protocols and flags may be available, depending on how
+OpenSSL was built.
 
 =item B<-dtls>, B<-dtls1>, B<-dtls1_2>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -532,6 +532,8 @@ By default B<s_server> will negotiate the highest mutually supported protocol
 version.
 When a specific TLS version is required, only that version will be accepted
 from the client.
+Note that not all protocols and flags may be available, depending on how
+OpenSSL was built.
 
 =item B<-bugs>
 

--- a/doc/man1/s_time.pod
+++ b/doc/man1/s_time.pod
@@ -112,15 +112,18 @@ specified, they are both on by default and executed in sequence.
 
 =item B<-ssl3>
 
-These options disable the use of certain SSL or TLS protocols. By default
+This option disables the use of SSL version 3. By default
 the initial handshake uses a method which should be compatible with all
 servers and permit them to use SSL v3 or TLS as appropriate.
+
 The timing program is not as rich in options to turn protocols on and off as
 the L<s_client(1)> program and may not connect to all servers.
-
 Unfortunately there are a lot of ancient and broken servers in use which
 cannot handle this technique and will fail to connect. Some servers only
 work if TLS is turned off with the B<-ssl3> option.
+
+Note that this option may not be available, depending on how
+OpenSSL was built.
 
 =item B<-bugs>
 


### PR DESCRIPTION
Clarify docs to list that some protocol flags might not be available
depending on how OpenSSL was build.

Fixes #6801 

Not going to backport, since this is a minor doc fix.