### PR TITLE
Add a zero length check to EVP_DigestUpdate.

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -145,6 +145,8 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 
 int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
 {
+    if (count == 0)
+        return 1;
     return ctx->update(ctx, data, count);
 }
 


### PR DESCRIPTION
`EVP_EncryptUpdate` and `EVP_DecryptUpdate` already handle this case properly.
`HASH_UPDATE` was not modified because the legacy interfaces use it.

Refer #6800 #6817 
