### PR TITLE
Ensure symbols don't get deprecated too early

### DIFF
--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -9,6 +9,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/opensslv.h>
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -97,7 +99,13 @@ extern "C" {
 # define OPENSSL_API_COMPAT OPENSSL_MIN_API
 #endif
 
-#if OPENSSL_API_COMPAT < 0x10200000L
+/*
+ * Do not deprecate things to be deprecated in version 1.2.0 before the
+ * OpenSSL version number matches.
+ */
+#if OPENSSL_VERSION_NUMBER < 0x10200000L
+# define DEPRECATEDIN_1_2_0(f)   f;
+#elif OPENSSL_API_COMPAT < 0x10200000L
 # define DEPRECATEDIN_1_2_0(f)   DECLARE_DEPRECATED(f)
 #else
 # define DEPRECATEDIN_1_2_0(f)


### PR DESCRIPTION
There are symbols we've marked for deprecation in OpenSSL 1.2.0.  We
must ensure that they don't actually become deprecated before that.

Fixes #6814 
