### PR TITLE
Fix illegal instructions on x86 CPU that have MMX but not SSE

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -762,11 +762,8 @@ void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)
 #  endif
     gcm_init_4bit(ctx->Htable, ctx->H.u);
 #  if   defined(GHASH_ASM_X86)  /* x86 only */
-#   if  defined(OPENSSL_IA32_SSE2)
-    if (OPENSSL_ia32cap_P[0] & (1 << 25)) { /* check SSE bit */
-#   else
-    if (OPENSSL_ia32cap_P[0] & (1 << 23)) { /* check MMX bit */
-#   endif
+    if (OPENSSL_ia32cap_P[0] & (1 << 25) && /* check SSE bit */
+        OPENSSL_ia32cap_P[0] & (1 << 23)) { /* check MMX bit */
         ctx->gmult = gcm_gmult_4bit_mmx;
         CTX__GHASH(gcm_ghash_4bit_mmx);
     } else {


### PR DESCRIPTION
On x86, CRYPTO_gcm128_init() uses a MMX-enabled version if the CPU has
the MMX flag. Unfortunately, the code contains the pinsrw instruction,
which is only available when the CPU has the SSE flag.

A CPU such as Geode GX1 has MMX but not SSE. Since it only checks MMX
flag OpenSSL uses the unimplemented pinsrw instruction and the program
crashes.

This change makes sure the offending code is only used when the CPU
has both MMX and SSE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
