### PR TITLE
WIP: Revert TLSv1.2 to TLSv1.3 PSK reuse

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -459,12 +459,21 @@ The default value is "Client_identity" (without the quotes).
 Use the PSK key B<key> when using a PSK cipher suite. The key is
 given as a hexadecimal number without leading 0x, for example -psk
 1a2b3c4d.
-This option must be provided in order to use a PSK cipher.
+This option must be provided in order to use a PSK cipher. Using this option
+will restrict the TLSv1.3 ciphersuites that are offered to those that support
+SHA256, unless TLSv1.3 ciphersuites are explicitly configured using the
+B<-ciphersuites> option or B<-psk_session> is used.
 
 =item B<-psk_session file>
 
 Use the pem encoded SSL_SESSION data stored in B<file> as the basis of a PSK.
-Note that this will only work if TLSv1.3 is negotiated.
+Note that this will only work if TLSv1.3 is negotiated. Using this option will
+restrict the TLSv1.3 ciphersuites that are offered to those that are compatible
+with the PSK, unless TLSv1.3 ciphersuites are explicitly configured using the
+B<-ciphersuites> option.
+
+If B<-psk> is also used then that option will set the TLSv1.2 and below
+PSK, and this option will set the TLSv1.3 PSK.
 
 =item B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>, B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
 

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -16,7 +16,9 @@ SSL_CIPHER_get_auth_nid,
 SSL_CIPHER_is_aead,
 SSL_CIPHER_find,
 SSL_CIPHER_get_id,
-SSL_CIPHER_get_protocol_id
+SSL_CIPHER_get_protocol_id,
+SSL_CIPHER_get_min_tls,
+SSL_CIPHER_get_max_tls
 - get SSL_CIPHER properties
 
 =head1 SYNOPSIS
@@ -38,6 +40,8 @@ SSL_CIPHER_get_protocol_id
  const SSL_CIPHER *SSL_CIPHER_find(SSL *ssl, const unsigned char *ptr);
  uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
  uint32_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c);
+ int SSL_CIPHER_get_min_tls(const SSL_CIPHER *c);
+ int SSL_CIPHER_get_max_tls(const SSL_CIPHER *c);
 
 =head1 DESCRIPTION
 
@@ -150,6 +154,12 @@ Some examples for the output of SSL_CIPHER_description():
  ECDHE-RSA-AES256-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(256) Mac=AEAD
  RSA-PSK-AES256-CBC-SHA384 TLSv1.0 Kx=RSAPSK   Au=RSA  Enc=AES(256)  Mac=SHA384
 
+SSL_CIPHER_get_min_tls() returns the minimum SSL/TLS version that is supported
+by the cipher B<c>.
+
+SSL_CIPHER_get_max_tls() returns the maximum SSL/TLS version that is supported
+by the cipher B<c>.
+
 =head1 RETURN VALUES
 
 SSL_CIPHER_get_name(), SSL_CIPHER_standard_name(), OPENSSL_cipher_name(),
@@ -185,13 +195,13 @@ string in OpenSSL 1.1.0.
 SSL_CIPHER_description() was changed to return B<NULL> on error,
 rather than a fixed string, in OpenSSL 1.1.0.
 
-SSL_CIPHER_get_handshake_digest() was added in OpenSSL 1.1.1.
+SSL_CIPHER_get_handshake_digest(), OPENSSL_cipher_name(),
+SSL_CIPHER_get_min_tls() and SSL_CIPHER_get_max_tls() were added in OpenSSL
+1.1.1.
 
 SSL_CIPHER_standard_name() was globally available in OpenSSL 1.1.1. Before
 OpenSSL 1.1.1, tracing (B<enable-ssl-trace> argument to Configure) was
 required to enable this function.
-
-OPENSSL_cipher_name() was added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_CTX_set_psk_client_callback.pod
+++ b/doc/man3/SSL_CTX_set_psk_client_callback.pod
@@ -114,16 +114,8 @@ B<NUL>-terminated identity is to be stored, and a buffer B<psk> of
 length B<max_psk_len> bytes where the resulting pre-shared key is to
 be stored.
 
-The callback for use in TLSv1.2 will also work in TLSv1.3 although it is
-recommended to use SSL_CTX_set_psk_use_session_callback()
-or SSL_set_psk_use_session_callback() for this purpose instead. If TLSv1.3 has
-been negotiated then OpenSSL will first check to see if a callback has been set
-via SSL_CTX_set_psk_use_session_callback() or SSL_set_psk_use_session_callback()
-and it will use that in preference. If no such callback is present then it will
-check to see if a callback has been set via SSL_CTX_set_psk_client_callback() or
-SSL_set_psk_client_callback() and use that. In this case the B<hint> value will
-always be NULL and the handshake digest will default to SHA-256 for any returned
-PSK.
+Note that setting a callback for a TLSv1.2 and below PSK without also setting a
+callback for a TLSv1.3 PSK will force TLSv1.3 to be disabled.
 
 =head1 NOTES
 

--- a/doc/man3/SSL_CTX_use_psk_identity_hint.pod
+++ b/doc/man3/SSL_CTX_use_psk_identity_hint.pod
@@ -39,9 +39,9 @@ SSL_set_psk_find_session_callback
 
 =head1 DESCRIPTION
 
-A client application wishing to use TLSv1.3 PSKs should set a callback
-using either SSL_CTX_set_psk_use_session_callback() or
-SSL_set_psk_use_session_callback() as appropriate.
+A server application wishing to use TLSv1.3 PSKs should set a callback
+using either SSL_CTX_set_psk_find_session_callback() or
+SSL_set_psk_find_session_callback() as appropriate.
 
 The callback function is given a pointer to the SSL connection in B<ssl> and
 an identity in B<identity> of length B<identity_len>. The callback function
@@ -75,15 +75,8 @@ function is given the connection in parameter B<ssl>, B<NUL>-terminated PSK
 identity sent by the client in parameter B<identity>, and a buffer B<psk> of
 length B<max_psk_len> bytes where the pre-shared key is to be stored.
 
-The callback for use in TLSv1.2 will also work in TLSv1.3 although it is
-recommended to use SSL_CTX_set_psk_find_session_callback()
-or SSL_set_psk_find_session_callback() for this purpose instead. If TLSv1.3 has
-been negotiated then OpenSSL will first check to see if a callback has been set
-via SSL_CTX_set_psk_find_session_callback() or SSL_set_psk_find_session_callback()
-and it will use that in preference. If no such callback is present then it will
-check to see if a callback has been set via SSL_CTX_set_psk_server_callback() or
-SSL_set_psk_server_callback() and use that. In this case the handshake digest
-will default to SHA-256 for any returned PSK.
+Note that setting a callback for a TLSv1.2 and below PSK without also setting a
+callback for a TLSv1.3 PSK will force TLSv1.3 to be disabled.
 
 =head1 NOTES
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1492,6 +1492,8 @@ __owur const SSL_CIPHER *SSL_get_current_cipher(const SSL *s);
 __owur const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s);
 __owur int SSL_CIPHER_get_bits(const SSL_CIPHER *c, int *alg_bits);
 __owur const char *SSL_CIPHER_get_version(const SSL_CIPHER *c);
+__owur int SSL_CIPHER_get_min_tls(const SSL_CIPHER *c);
+__owur int SSL_CIPHER_get_max_tls(const SSL_CIPHER *c);
 __owur const char *SSL_CIPHER_get_name(const SSL_CIPHER *c);
 __owur const char *SSL_CIPHER_standard_name(const SSL_CIPHER *c);
 __owur const char *OPENSSL_cipher_name(const char *rfc_name);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4117,9 +4117,8 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
 {
     const SSL_CIPHER *c, *ret = NULL;
     STACK_OF(SSL_CIPHER) *prio, *allow;
-    int i, ii, ok, prefer_sha256 = 0;
+    int i, ii, ok;
     unsigned long alg_k = 0, alg_a = 0, mask_k = 0, mask_a = 0;
-    const EVP_MD *mdsha256 = EVP_sha256();
 #ifndef OPENSSL_NO_CHACHA
     STACK_OF(SSL_CIPHER) *prio_chacha = NULL;
 #endif
@@ -4200,26 +4199,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
         allow = srvr;
     }
 
-    if (SSL_IS_TLS13(s)) {
-#ifndef OPENSSL_NO_PSK
-        int j;
-
-        /*
-         * If we allow "old" style PSK callbacks, and we have no certificate (so
-         * we're not going to succeed without a PSK anyway), and we're in
-         * TLSv1.3 then the default hash for a PSK is SHA-256 (as per the
-         * TLSv1.3 spec). Therefore we should prioritise ciphersuites using
-         * that.
-         */
-        if (s->psk_server_callback != NULL) {
-            for (j = 0; j < SSL_PKEY_NUM && !ssl_has_cert(s, j); j++);
-            if (j == SSL_PKEY_NUM) {
-                /* There are no certificates */
-                prefer_sha256 = 1;
-            }
-        }
-#endif
-    } else {
+    if (!SSL_IS_TLS13(s)) {
         tls1_set_cert_validity(s);
         ssl_set_masks(s);
     }
@@ -4291,17 +4271,6 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
                 continue;
             }
 #endif
-            if (prefer_sha256) {
-                const SSL_CIPHER *tmp = sk_SSL_CIPHER_value(allow, ii);
-
-                if (ssl_md(tmp->algorithm2) == mdsha256) {
-                    ret = tmp;
-                    break;
-                }
-                if (ret == NULL)
-                    ret = tmp;
-                continue;
-            }
             ret = sk_SSL_CIPHER_value(allow, ii);
             break;
         }

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1848,6 +1848,16 @@ const char *SSL_CIPHER_get_version(const SSL_CIPHER *c)
     return ssl_protocol_to_string(c->min_tls);
 }
 
+int SSL_CIPHER_get_min_tls(const SSL_CIPHER *c)
+{
+    return c->min_tls;
+}
+
+int SSL_CIPHER_get_max_tls(const SSL_CIPHER *c)
+{
+    return c->max_tls;
+}
+
 /* return the actual cipher being used */
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *c)
 {

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -746,9 +746,6 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
                                          unsigned int context, X509 *x,
                                          size_t chainidx)
 {
-#ifndef OPENSSL_NO_PSK
-    char identity[PSK_MAX_IDENTITY_LEN + 1];
-#endif  /* OPENSSL_NO_PSK */
     const unsigned char *id = NULL;
     size_t idlen = 0;
     SSL_SESSION *psksess = NULL;
@@ -767,60 +764,6 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
                  SSL_R_BAD_PSK);
         return EXT_RETURN_FAIL;
     }
-
-#ifndef OPENSSL_NO_PSK
-    if (psksess == NULL && s->psk_client_callback != NULL) {
-        unsigned char psk[PSK_MAX_PSK_LEN];
-        size_t psklen = 0;
-
-        memset(identity, 0, sizeof(identity));
-        psklen = s->psk_client_callback(s, NULL, identity, sizeof(identity) - 1,
-                                        psk, sizeof(psk));
-
-        if (psklen > PSK_MAX_PSK_LEN) {
-            SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
-                     SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA, ERR_R_INTERNAL_ERROR);
-            return EXT_RETURN_FAIL;
-        } else if (psklen > 0) {
-            const unsigned char tls13_aes128gcmsha256_id[] = { 0x13, 0x01 };
-            const SSL_CIPHER *cipher;
-
-            idlen = strlen(identity);
-            if (idlen > PSK_MAX_IDENTITY_LEN) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
-                         SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA,
-                         ERR_R_INTERNAL_ERROR);
-                return EXT_RETURN_FAIL;
-            }
-            id = (unsigned char *)identity;
-
-            /*
-             * We found a PSK using an old style callback. We don't know
-             * the digest so we default to SHA256 as per the TLSv1.3 spec
-             */
-            cipher = SSL_CIPHER_find(s, tls13_aes128gcmsha256_id);
-            if (cipher == NULL) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
-                         SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA,
-                         ERR_R_INTERNAL_ERROR);
-                return EXT_RETURN_FAIL;
-            }
-
-            psksess = SSL_SESSION_new();
-            if (psksess == NULL
-                    || !SSL_SESSION_set1_master_key(psksess, psk, psklen)
-                    || !SSL_SESSION_set_cipher(psksess, cipher)
-                    || !SSL_SESSION_set_protocol_version(psksess, TLS1_3_VERSION)) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
-                         SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA,
-                         ERR_R_INTERNAL_ERROR);
-                OPENSSL_cleanse(psk, psklen);
-                return EXT_RETURN_FAIL;
-            }
-            OPENSSL_cleanse(psk, psklen);
-        }
-    }
-#endif  /* OPENSSL_NO_PSK */
 
     SSL_SESSION_free(s->psksession);
     s->psksession = psksess;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1087,59 +1087,6 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             return 0;
         }
 
-#ifndef OPENSSL_NO_PSK
-        if(sess == NULL
-                && s->psk_server_callback != NULL
-                && idlen <= PSK_MAX_IDENTITY_LEN) {
-            char *pskid = NULL;
-            unsigned char pskdata[PSK_MAX_PSK_LEN];
-            unsigned int pskdatalen;
-
-            if (!PACKET_strndup(&identity, &pskid)) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_PSK,
-                         ERR_R_INTERNAL_ERROR);
-                return 0;
-            }
-            pskdatalen = s->psk_server_callback(s, pskid, pskdata,
-                                                sizeof(pskdata));
-            OPENSSL_free(pskid);
-            if (pskdatalen > PSK_MAX_PSK_LEN) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_PSK,
-                         ERR_R_INTERNAL_ERROR);
-                return 0;
-            } else if (pskdatalen > 0) {
-                const SSL_CIPHER *cipher;
-                const unsigned char tls13_aes128gcmsha256_id[] = { 0x13, 0x01 };
-
-                /*
-                 * We found a PSK using an old style callback. We don't know
-                 * the digest so we default to SHA256 as per the TLSv1.3 spec
-                 */
-                cipher = SSL_CIPHER_find(s, tls13_aes128gcmsha256_id);
-                if (cipher == NULL) {
-                    OPENSSL_cleanse(pskdata, pskdatalen);
-                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_PSK,
-                             ERR_R_INTERNAL_ERROR);
-                    return 0;
-                }
-
-                sess = SSL_SESSION_new();
-                if (sess == NULL
-                        || !SSL_SESSION_set1_master_key(sess, pskdata,
-                                                        pskdatalen)
-                        || !SSL_SESSION_set_cipher(sess, cipher)
-                        || !SSL_SESSION_set_protocol_version(sess,
-                                                             TLS1_3_VERSION)) {
-                    OPENSSL_cleanse(pskdata, pskdatalen);
-                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_PSK,
-                             ERR_R_INTERNAL_ERROR);
-                    goto err;
-                }
-                OPENSSL_cleanse(pskdata, pskdatalen);
-            }
-        }
-#endif /* OPENSSL_NO_PSK */
-
         if (sess != NULL) {
             /* We found a PSK */
             SSL_SESSION *sesstmp = ssl_session_dup(sess, 0);

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1487,14 +1487,23 @@ static int ssl_method_error(const SSL *s, const SSL_METHOD *method)
 
 /*
  * Only called by servers. Returns 1 if the server has a TLSv1.3 capable
- * certificate type, or has PSK configured. Otherwise returns 0.
+ * certificate type and not TLSv1.2 PSK, or has TLSv1.3 PSK configured.
+ * Otherwise returns 0.
  */
 static int is_tls13_capable(const SSL *s)
 {
     int i;
 
+    /* We have a TLSv1.3 PSK, so we are TLSv1.3 capable */
     if (s->psk_find_session_cb != NULL)
         return 1;
+
+    /*
+     * We don't have TLSv1.3 PSK, but we do have TLSv1.2 PSK. We mustn't select
+     * TLSv1.3.
+     */
+    if (s->psk_server_callback != NULL)
+        return 0;
 
     for (i = 0; i < SSL_PKEY_NUM; i++) {
         /* Skip over certs disallowed for TLSv1.3 */
@@ -2045,6 +2054,16 @@ int ssl_get_min_max_version(const SSL *s, int *min_version, int *max_version)
          * "version capability" vector.
          */
         if (vent->cmeth == NULL) {
+            hole = 1;
+            continue;
+        }
+        if (s->psk_client_callback != NULL
+                && vent->version == TLS1_3_VERSION
+                && s->psk_use_session_cb == NULL) {
+            /*
+             * We are configured for TLSv1.2 PSKs and not TLSv1.3 PSKs, so we
+             * don't offer TLSv1.3.
+             */
             hole = 1;
             continue;
         }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1493,11 +1493,6 @@ static int is_tls13_capable(const SSL *s)
 {
     int i;
 
-#ifndef OPENSSL_NO_PSK
-    if (s->psk_server_callback != NULL)
-        return 1;
-#endif
-
     if (s->psk_find_session_cb != NULL)
         return 1;
 

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -496,3 +496,5 @@ SSL_set_recv_max_early_data             496	1_1_1	EXIST::FUNCTION:
 SSL_get_recv_max_early_data             497	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get_recv_max_early_data         498	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_recv_max_early_data         499	1_1_1	EXIST::FUNCTION:
+SSL_CIPHER_get_max_tls                  500	1_1_1	EXIST::FUNCTION:
+SSL_CIPHER_get_min_tls                  501	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
If the outcome of #6490 is that we should remove the reuse of PSKs between TLSv1.2 and TLSv1.3 then this PR will do it.

Instead if TLSv1.2 PSKs are configured but TLSv1.3 PSKs are not then we will never select TLSv1.3. The s_client "-psk" option will still reuse the PSK between both TLSv1.2 and TLSv1.3 - but that is specific to that application and I think this is ok for a testing tool.

I'm marking this as WIP pending the outcome of #6490 (which is subject to ongoing TLS WG discussions).