### PR TITLE
Fix some undefined behaviour in the Curve448 code (2nd attempt)

### DIFF
--- a/crypto/ec/curve448/eddsa.c
+++ b/crypto/ec/curve448/eddsa.c
@@ -63,8 +63,7 @@ static c448_error_t hash_init_with_dom(EVP_MD_CTX *hashctx, uint8_t prehashed,
     if (!EVP_DigestInit_ex(hashctx, EVP_shake256(), NULL)
             || !EVP_DigestUpdate(hashctx, dom_s, strlen(dom_s))
             || !EVP_DigestUpdate(hashctx, dom, sizeof(dom))
-            || (context_len > 0
-                && !EVP_DigestUpdate(hashctx, context, context_len)))
+            || !EVP_DigestUpdate(hashctx, context, context_len))
         return C448_FAILURE;
 
     return C448_SUCCESS;
@@ -161,8 +160,7 @@ c448_error_t c448_ed448_sign(
                 || !EVP_DigestUpdate(hashctx,
                                      expanded + EDDSA_448_PRIVATE_BYTES,
                                      EDDSA_448_PRIVATE_BYTES)
-                || (message_len > 0
-                    && !EVP_DigestUpdate(hashctx, message, message_len))) {
+                || !EVP_DigestUpdate(hashctx, message, message_len)) {
             OPENSSL_cleanse(expanded, sizeof(expanded));
             goto err;
         }
@@ -202,8 +200,7 @@ c448_error_t c448_ed448_sign(
         if (!hash_init_with_dom(hashctx, prehashed, 0, context, context_len)
                 || !EVP_DigestUpdate(hashctx, nonce_point, sizeof(nonce_point))
                 || !EVP_DigestUpdate(hashctx, pubkey, EDDSA_448_PUBLIC_BYTES)
-                || (message_len > 0
-                    && !EVP_DigestUpdate(hashctx, message, message_len))
+                || !EVP_DigestUpdate(hashctx, message, message_len)
                 || !EVP_DigestFinalXOF(hashctx, challenge, sizeof(challenge)))
             goto err;
 

--- a/crypto/evp/m_sha3.c
+++ b/crypto/evp/m_sha3.c
@@ -66,6 +66,9 @@ static int sha3_update(EVP_MD_CTX *evp_ctx, const void *_inp, size_t len)
     size_t bsz = ctx->block_size;
     size_t num, rem;
 
+    if (len == 0)
+        return 1;
+
     if ((num = ctx->num) != 0) {      /* process intermediate buffer? */
         rem = bsz - num;
 


### PR DESCRIPTION
[extended tests]

Fixes #6800  (Alternative to #6819)
Replaces #5418

This commit reverts commit 5b56dd1b7e3b and moves the check for a zero-length input down the callstack into sha3_update().
