### PR TITLE
asn1/tasn_utl.c: fix logical error in asn1_do_lock.

### DIFF
--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -76,7 +76,7 @@ int asn1_do_lock(ASN1_VALUE **pval, int op, const ASN1_ITEM *it)
         }
         return 1;
     }
-    if (CRYPTO_atomic_add(lck, op, &ret, *lock) < 0)
+    if (!CRYPTO_atomic_add(lck, op, &ret, *lock))
         return -1;  /* failed */
 #ifdef REF_PRINT
     fprintf(stderr, "%p:%4d:%s\n", it, *lck, it->sname);


### PR DESCRIPTION
This is fix for over-enthusiastic cherry-pick of #6827. Reported in #6839. It's revert on last commit and minimalistic one-line fix for logical error.