### PR TITLE
WIP: Harmonize calls to EVP_Digest*{Init,Update,Final}()

### DIFF
--- a/crypto/cms/cms_dd.c
+++ b/crypto/cms/cms_dd.c
@@ -70,7 +70,7 @@ int cms_DigestedData_do_final(CMS_ContentInfo *cms, BIO *chain, int verify)
     if (!cms_DigestAlgorithm_find_ctx(mctx, chain, dd->digestAlgorithm))
         goto err;
 
-    if (EVP_DigestFinal_ex(mctx, md, &mdlen) <= 0)
+    if (!EVP_DigestFinal_ex(mctx, md, &mdlen))
         goto err;
 
     if (verify) {

--- a/crypto/ct/ct_vfy.c
+++ b/crypto/ct/ct_vfy.c
@@ -87,7 +87,7 @@ static int sct_ctx_update(EVP_MD_CTX *ctx, const SCT_CTX *sctx, const SCT *sct)
     if (!EVP_DigestUpdate(ctx, tmpbuf, 2))
         return 0;
 
-    if (sct->ext_len && !EVP_DigestUpdate(ctx, sct->ext, sct->ext_len))
+    if (!EVP_DigestUpdate(ctx, sct->ext, sct->ext_len))
         return 0;
 
     return 1;

--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -226,7 +226,7 @@ static int md_gets(BIO *bp, char *buf, int size)
     if (size < ctx->digest->md_size)
         return 0;
 
-    if (EVP_DigestFinal_ex(ctx, (unsigned char *)buf, &ret) <= 0)
+    if (!EVP_DigestFinal_ex(ctx, (unsigned char *)buf, &ret))
         return -1;
 
     return (int)ret;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -158,7 +158,7 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
 {
     if (ctx->pctx->pmeth->digestsign != NULL)
         return ctx->pctx->pmeth->digestsign(ctx, sigret, siglen, tbs, tbslen);
-    if (sigret != NULL && EVP_DigestSignUpdate(ctx, tbs, tbslen) <= 0)
+    if (sigret != NULL && !EVP_DigestSignUpdate(ctx, tbs, tbslen))
         return 0;
     return EVP_DigestSignFinal(ctx, sigret, siglen);
 }

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -201,7 +201,7 @@ static int tls1_prf_P_hash(const EVP_MD *md,
         goto err;
     if (!EVP_MD_CTX_copy_ex(ctx, ctx_init))
         goto err;
-    if (seed != NULL && !EVP_DigestSignUpdate(ctx, seed, seed_len))
+    if (!EVP_DigestSignUpdate(ctx, seed, seed_len))
         goto err;
     if (!EVP_DigestSignFinal(ctx, A1, &A1_len))
         goto err;
@@ -214,7 +214,7 @@ static int tls1_prf_P_hash(const EVP_MD *md,
             goto err;
         if (olen > (size_t)chunk && !EVP_MD_CTX_copy_ex(ctx_tmp, ctx))
             goto err;
-        if (seed && !EVP_DigestSignUpdate(ctx, seed, seed_len))
+        if (!EVP_DigestSignUpdate(ctx, seed, seed_len))
             goto err;
 
         if (olen > (size_t)chunk) {

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -831,7 +831,7 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
         goto err;
     }
 
-    if (EVP_DigestSignInit(mctx, &pctx, md, NULL, si->pkey) <= 0)
+    if (!EVP_DigestSignInit(mctx, &pctx, md, NULL, si->pkey))
         goto err;
 
     if (EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_SIGN,
@@ -844,16 +844,16 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
                          ASN1_ITEM_rptr(PKCS7_ATTR_SIGN));
     if (!abuf)
         goto err;
-    if (EVP_DigestSignUpdate(mctx, abuf, alen) <= 0)
+    if (!EVP_DigestSignUpdate(mctx, abuf, alen))
         goto err;
     OPENSSL_free(abuf);
     abuf = NULL;
-    if (EVP_DigestSignFinal(mctx, NULL, &siglen) <= 0)
+    if (!EVP_DigestSignFinal(mctx, NULL, &siglen))
         goto err;
     abuf = OPENSSL_malloc(siglen);
     if (abuf == NULL)
         goto err;
-    if (EVP_DigestSignFinal(mctx, abuf, &siglen) <= 0)
+    if (!EVP_DigestSignFinal(mctx, abuf, &siglen))
         goto err;
 
     if (EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_SIGN,

--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -212,7 +212,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
         || !EVP_DigestUpdate(ctx, zeroes, sizeof(zeroes))
         || !EVP_DigestUpdate(ctx, mHash, hLen))
         goto err;
-    if (sLen && !EVP_DigestUpdate(ctx, salt, sLen))
+    if (!EVP_DigestUpdate(ctx, salt, sLen))
         goto err;
     if (!EVP_DigestFinal_ex(ctx, H, NULL))
         goto err;

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -219,7 +219,10 @@ disabled with this flag.
 
 =item EVP_DigestInit_ex(),
 EVP_DigestUpdate(),
-EVP_DigestFinal_ex()
+EVP_DigestFinal_ex(),
+EVP_DigestFinalXOF(),
+EVP_DigestInit(),
+EVP_DigestFinal()
 
 Returns 1 for
 success and 0 for failure.

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1249,18 +1249,18 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         p = md;
         s2n(rec->length, p);
         if (EVP_MD_CTX_copy_ex(md_ctx, hash) <= 0
-            || EVP_DigestUpdate(md_ctx, mac_sec, md_size) <= 0
-            || EVP_DigestUpdate(md_ctx, ssl3_pad_1, npad) <= 0
-            || EVP_DigestUpdate(md_ctx, seq, 8) <= 0
-            || EVP_DigestUpdate(md_ctx, &rec_char, 1) <= 0
-            || EVP_DigestUpdate(md_ctx, md, 2) <= 0
-            || EVP_DigestUpdate(md_ctx, rec->input, rec->length) <= 0
-            || EVP_DigestFinal_ex(md_ctx, md, NULL) <= 0
+            || !EVP_DigestUpdate(md_ctx, mac_sec, md_size)
+            || !EVP_DigestUpdate(md_ctx, ssl3_pad_1, npad)
+            || !EVP_DigestUpdate(md_ctx, seq, 8)
+            || !EVP_DigestUpdate(md_ctx, &rec_char, 1)
+            || !EVP_DigestUpdate(md_ctx, md, 2)
+            || !EVP_DigestUpdate(md_ctx, rec->input, rec->length)
+            || !EVP_DigestFinal_ex(md_ctx, md, NULL)
             || EVP_MD_CTX_copy_ex(md_ctx, hash) <= 0
-            || EVP_DigestUpdate(md_ctx, mac_sec, md_size) <= 0
-            || EVP_DigestUpdate(md_ctx, ssl3_pad_2, npad) <= 0
-            || EVP_DigestUpdate(md_ctx, md, md_size) <= 0
-            || EVP_DigestFinal_ex(md_ctx, md, &md_size_u) <= 0) {
+            || !EVP_DigestUpdate(md_ctx, mac_sec, md_size)
+            || !EVP_DigestUpdate(md_ctx, ssl3_pad_2, npad)
+            || !EVP_DigestUpdate(md_ctx, md, md_size)
+            || !EVP_DigestFinal_ex(md_ctx, md, &md_size_u)) {
             EVP_MD_CTX_free(md_ctx);
             return 0;
         }
@@ -1346,9 +1346,9 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         }
     } else {
         /* TODO(size_t): Convert these calls */
-        if (EVP_DigestSignUpdate(mac_ctx, header, sizeof(header)) <= 0
-            || EVP_DigestSignUpdate(mac_ctx, rec->input, rec->length) <= 0
-            || EVP_DigestSignFinal(mac_ctx, md, &md_size) <= 0) {
+        if (!EVP_DigestSignUpdate(mac_ctx, header, sizeof(header))
+            || !EVP_DigestSignUpdate(mac_ctx, rec->input, rec->length)
+            || !EVP_DigestSignFinal(mac_ctx, md, &md_size)) {
             EVP_MD_CTX_free(hmac);
             return 0;
         }

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -454,23 +454,23 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
     md_ctx = EVP_MD_CTX_new();
     if (md_ctx == NULL)
         goto err;
-    if (EVP_DigestInit_ex(md_ctx, EVP_MD_CTX_md(ctx), NULL /* engine */ ) <= 0)
+    if (!EVP_DigestInit_ex(md_ctx, EVP_MD_CTX_md(ctx), NULL /* engine */ ))
         goto err;
     if (is_sslv3) {
         /* We repurpose |hmac_pad| to contain the SSLv3 pad2 block. */
         memset(hmac_pad, 0x5c, sslv3_pad_length);
 
-        if (EVP_DigestUpdate(md_ctx, mac_secret, mac_secret_length) <= 0
-            || EVP_DigestUpdate(md_ctx, hmac_pad, sslv3_pad_length) <= 0
-            || EVP_DigestUpdate(md_ctx, mac_out, md_size) <= 0)
+        if (!EVP_DigestUpdate(md_ctx, mac_secret, mac_secret_length)
+            || !EVP_DigestUpdate(md_ctx, hmac_pad, sslv3_pad_length)
+            || !EVP_DigestUpdate(md_ctx, mac_out, md_size))
             goto err;
     } else {
         /* Complete the HMAC in the standard manner. */
         for (i = 0; i < md_block_size; i++)
             hmac_pad[i] ^= 0x6a;
 
-        if (EVP_DigestUpdate(md_ctx, hmac_pad, md_block_size) <= 0
-            || EVP_DigestUpdate(md_ctx, mac_out, md_size) <= 0)
+        if (!EVP_DigestUpdate(md_ctx, hmac_pad, md_block_size)
+            || !EVP_DigestUpdate(md_ctx, mac_out, md_size))
             goto err;
     }
     /* TODO(size_t): Convert me */

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -453,7 +453,7 @@ size_t ssl3_final_finish_mac(SSL *s, const char *sender, size_t len,
         return 0;
     }
 
-    if ((sender != NULL && EVP_DigestUpdate(ctx, sender, len) <= 0)
+    if (EVP_DigestUpdate(ctx, sender, len) <= 0
         || EVP_MD_CTX_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
                            (int)s->session->master_key_length,
                            s->session->master_key) <= 0

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -453,11 +453,11 @@ size_t ssl3_final_finish_mac(SSL *s, const char *sender, size_t len,
         return 0;
     }
 
-    if (EVP_DigestUpdate(ctx, sender, len) <= 0
+    if (!EVP_DigestUpdate(ctx, sender, len)
         || EVP_MD_CTX_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
                            (int)s->session->master_key_length,
                            s->session->master_key) <= 0
-        || EVP_DigestFinal_ex(ctx, p, NULL) <= 0) {
+        || !EVP_DigestFinal_ex(ctx, p, NULL)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL3_FINAL_FINISH_MAC,
                  ERR_R_INTERNAL_ERROR);
         ret = 0;
@@ -494,20 +494,20 @@ int ssl3_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
         return 0;
     }
     for (i = 0; i < 3; i++) {
-        if (EVP_DigestInit_ex(ctx, s->ctx->sha1, NULL) <= 0
-            || EVP_DigestUpdate(ctx, salt[i],
-                                strlen((const char *)salt[i])) <= 0
-            || EVP_DigestUpdate(ctx, p, len) <= 0
-            || EVP_DigestUpdate(ctx, &(s->s3->client_random[0]),
-                                SSL3_RANDOM_SIZE) <= 0
-            || EVP_DigestUpdate(ctx, &(s->s3->server_random[0]),
-                                SSL3_RANDOM_SIZE) <= 0
+        if (!EVP_DigestInit_ex(ctx, s->ctx->sha1, NULL)
+            || !EVP_DigestUpdate(ctx, salt[i],
+                                strlen((const char *)salt[i]))
+            || !EVP_DigestUpdate(ctx, p, len)
+            || !EVP_DigestUpdate(ctx, &(s->s3->client_random[0]),
+                                SSL3_RANDOM_SIZE)
+            || !EVP_DigestUpdate(ctx, &(s->s3->server_random[0]),
+                                SSL3_RANDOM_SIZE)
                /* TODO(size_t) : convert me */
-            || EVP_DigestFinal_ex(ctx, buf, &n) <= 0
-            || EVP_DigestInit_ex(ctx, s->ctx->md5, NULL) <= 0
-            || EVP_DigestUpdate(ctx, p, len) <= 0
-            || EVP_DigestUpdate(ctx, buf, n) <= 0
-            || EVP_DigestFinal_ex(ctx, out, &n) <= 0) {
+            || !EVP_DigestFinal_ex(ctx, buf, &n)
+            || !EVP_DigestInit_ex(ctx, s->ctx->md5, NULL)
+            || !EVP_DigestUpdate(ctx, p, len)
+            || !EVP_DigestUpdate(ctx, buf, n)
+            || !EVP_DigestFinal_ex(ctx, out, &n)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_SSL3_GENERATE_MASTER_SECRET, ERR_R_INTERNAL_ERROR);
             ret = 0;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4404,7 +4404,7 @@ EVP_MD_CTX *ssl_replace_hash(EVP_MD_CTX **hash, const EVP_MD *md)
 {
     ssl_clear_hash_ctx(hash);
     *hash = EVP_MD_CTX_new();
-    if (*hash == NULL || (md && EVP_DigestInit_ex(*hash, md, NULL) <= 0)) {
+    if (*hash == NULL || (md && !EVP_DigestInit_ex(*hash, md, NULL))) {
         EVP_MD_CTX_free(*hash);
         *hash = NULL;
         return NULL;
@@ -4439,7 +4439,7 @@ int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
         goto err;
 
     if (!EVP_MD_CTX_copy_ex(ctx, hdgst)
-        || EVP_DigestFinal_ex(ctx, out, NULL) <= 0) {
+        || !EVP_DigestFinal_ex(ctx, out, NULL)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_HANDSHAKE_HASH,
                  ERR_R_INTERNAL_ERROR);
         goto err;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1498,8 +1498,8 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
      */
     mctx = EVP_MD_CTX_new();
     if (mctx == NULL
-            || EVP_DigestInit_ex(mctx, md, NULL) <= 0
-            || EVP_DigestFinal_ex(mctx, hash, NULL) <= 0) {
+            || !EVP_DigestInit_ex(mctx, md, NULL)
+            || !EVP_DigestFinal_ex(mctx, hash, NULL)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PSK_DO_BINDER,
                  ERR_R_INTERNAL_ERROR);
         goto err;
@@ -1518,7 +1518,7 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
         goto err;
     }
 
-    if (EVP_DigestInit_ex(mctx, md, NULL) <= 0) {
+    if (!EVP_DigestInit_ex(mctx, md, NULL)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PSK_DO_BINDER,
                  ERR_R_INTERNAL_ERROR);
         goto err;
@@ -1560,15 +1560,15 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
             hdatalen -= PACKET_remaining(&hashprefix);
         }
 
-        if (EVP_DigestUpdate(mctx, hdata, hdatalen) <= 0) {
+        if (!EVP_DigestUpdate(mctx, hdata, hdatalen)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PSK_DO_BINDER,
                      ERR_R_INTERNAL_ERROR);
             goto err;
         }
     }
 
-    if (EVP_DigestUpdate(mctx, msgstart, binderoffset) <= 0
-            || EVP_DigestFinal_ex(mctx, hash, NULL) <= 0) {
+    if (!EVP_DigestUpdate(mctx, msgstart, binderoffset)
+            || !EVP_DigestFinal_ex(mctx, hash, NULL)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PSK_DO_BINDER,
                  ERR_R_INTERNAL_ERROR);
         goto err;
@@ -1586,9 +1586,9 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
         binderout = tmpbinder;
 
     bindersize = hashsize;
-    if (EVP_DigestSignInit(mctx, NULL, md, NULL, mackey) <= 0
-            || EVP_DigestSignUpdate(mctx, hash, hashsize) <= 0
-            || EVP_DigestSignFinal(mctx, binderout, &bindersize) <= 0
+    if (!EVP_DigestSignInit(mctx, NULL, md, NULL, mackey)
+            || !EVP_DigestSignUpdate(mctx, hash, hashsize)
+            || !EVP_DigestSignFinal(mctx, binderout, &bindersize)
             || bindersize != hashsize) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PSK_DO_BINDER,
                  ERR_R_INTERNAL_ERROR);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -775,9 +775,9 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     hmaclen = SHA256_DIGEST_LENGTH;
-    if (EVP_DigestSignInit(hctx, NULL, EVP_sha256(), NULL, pkey) <= 0
-            || EVP_DigestSign(hctx, hmac, &hmaclen, data,
-                              rawlen - SHA256_DIGEST_LENGTH) <= 0
+    if (!EVP_DigestSignInit(hctx, NULL, EVP_sha256(), NULL, pkey)
+            || !EVP_DigestSign(hctx, hmac, &hmaclen, data,
+                               rawlen - SHA256_DIGEST_LENGTH)
             || hmaclen != SHA256_DIGEST_LENGTH) {
         EVP_MD_CTX_free(hctx);
         EVP_PKEY_free(pkey);
@@ -1844,9 +1844,8 @@ EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
         goto err;
     }
 
-    if (EVP_DigestSignInit(hctx, NULL, EVP_sha256(), NULL, pkey) <= 0
-            || EVP_DigestSign(hctx, hmac, &hmaclen, cookie,
-                              totcookielen) <= 0) {
+    if (!EVP_DigestSignInit(hctx, NULL, EVP_sha256(), NULL, pkey)
+            || !EVP_DigestSign(hctx, hmac, &hmaclen, cookie, totcookielen)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_STOC_COOKIE,
                  ERR_R_INTERNAL_ERROR);
         goto err;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3202,12 +3202,12 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt)
      */
     ukm_hash = EVP_MD_CTX_new();
     if (ukm_hash == NULL
-        || EVP_DigestInit(ukm_hash, EVP_get_digestbynid(dgst_nid)) <= 0
-        || EVP_DigestUpdate(ukm_hash, s->s3->client_random,
-                            SSL3_RANDOM_SIZE) <= 0
-        || EVP_DigestUpdate(ukm_hash, s->s3->server_random,
-                            SSL3_RANDOM_SIZE) <= 0
-        || EVP_DigestFinal_ex(ukm_hash, shared_ukm, &md_len) <= 0) {
+        || !EVP_DigestInit(ukm_hash, EVP_get_digestbynid(dgst_nid))
+        || !EVP_DigestUpdate(ukm_hash, s->s3->client_random,
+                            SSL3_RANDOM_SIZE)
+        || !EVP_DigestUpdate(ukm_hash, s->s3->server_random,
+                            SSL3_RANDOM_SIZE)
+        || !EVP_DigestFinal_ex(ukm_hash, shared_ukm, &md_len)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_GOST,
                  ERR_R_INTERNAL_ERROR);
         goto err;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -272,7 +272,7 @@ int tls_construct_cert_verify(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    if (EVP_DigestSignInit(mctx, &pctx, md, NULL, pkey) <= 0) {
+    if (!EVP_DigestSignInit(mctx, &pctx, md, NULL, pkey)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CERT_VERIFY,
                  ERR_R_EVP_LIB);
         goto err;
@@ -288,11 +288,11 @@ int tls_construct_cert_verify(SSL *s, WPACKET *pkt)
         }
     }
     if (s->version == SSL3_VERSION) {
-        if (EVP_DigestSignUpdate(mctx, hdata, hdatalen) <= 0
+        if (!EVP_DigestSignUpdate(mctx, hdata, hdatalen)
             || !EVP_MD_CTX_ctrl(mctx, EVP_CTRL_SSL3_MASTER_SECRET,
                                 (int)s->session->master_key_length,
                                 s->session->master_key)
-            || EVP_DigestSignFinal(mctx, sig, &siglen) <= 0) {
+            || !EVP_DigestSignFinal(mctx, sig, &siglen)) {
 
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CERT_VERIFY,
                      ERR_R_EVP_LIB);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2733,7 +2733,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
          */
         siglen = EVP_PKEY_size(pkey);
         if (!WPACKET_sub_reserve_bytes_u16(pkt, siglen, &sigbytes1)
-            || EVP_DigestSignInit(md_ctx, &pctx, md, NULL, pkey) <= 0) {
+            || !EVP_DigestSignInit(md_ctx, &pctx, md, NULL, pkey)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -260,7 +260,7 @@ int tls1_change_cipher_state(SSL *s, int which)
         mac_key = EVP_PKEY_new_mac_key(mac_type, NULL, mac_secret,
                                                (int)*mac_secret_size);
         if (mac_key == NULL
-            || EVP_DigestSignInit(mac_ctx, NULL, m, NULL, mac_key) <= 0) {
+            || !EVP_DigestSignInit(mac_ctx, NULL, m, NULL, mac_key)) {
             EVP_PKEY_free(mac_key);
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS1_CHANGE_CIPHER_STATE,
                      ERR_R_INTERNAL_ERROR);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -163,8 +163,8 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
 
         /* The pre-extract derive step uses a hash of no messages */
         if (mctx == NULL
-                || EVP_DigestInit_ex(mctx, md, NULL) <= 0
-                || EVP_DigestFinal_ex(mctx, hash, NULL) <= 0) {
+                || !EVP_DigestInit_ex(mctx, md, NULL)
+                || !EVP_DigestFinal_ex(mctx, hash, NULL)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS13_GENERATE_SECRET,
                      ERR_R_INTERNAL_ERROR);
             EVP_MD_CTX_free(mctx);
@@ -275,9 +275,9 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
 
     if (key == NULL
             || ctx == NULL
-            || EVP_DigestSignInit(ctx, NULL, md, NULL, key) <= 0
-            || EVP_DigestSignUpdate(ctx, hash, hashlen) <= 0
-            || EVP_DigestSignFinal(ctx, out, &hashlen) <= 0) {
+            || !EVP_DigestSignInit(ctx, NULL, md, NULL, key)
+            || !EVP_DigestSignUpdate(ctx, hash, hashlen)
+            || !EVP_DigestSignFinal(ctx, out, &hashlen)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS13_FINAL_FINISH_MAC,
                  ERR_R_INTERNAL_ERROR);
         goto err;
@@ -727,11 +727,11 @@ int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
     if (!use_context)
         contextlen = 0;
 
-    if (EVP_DigestInit_ex(ctx, md, NULL) <= 0
-            || EVP_DigestUpdate(ctx, context, contextlen) <= 0
-            || EVP_DigestFinal_ex(ctx, hash, &hashsize) <= 0
-            || EVP_DigestInit_ex(ctx, md, NULL) <= 0
-            || EVP_DigestFinal_ex(ctx, data, &datalen) <= 0
+    if (!EVP_DigestInit_ex(ctx, md, NULL)
+            || !EVP_DigestUpdate(ctx, context, contextlen)
+            || !EVP_DigestFinal_ex(ctx, hash, &hashsize)
+            || !EVP_DigestInit_ex(ctx, md, NULL)
+            || !EVP_DigestFinal_ex(ctx, data, &datalen)
             || !tls13_hkdf_expand(s, md, s->exporter_master_secret,
                                   (const unsigned char *)label, llen,
                                   data, datalen, exportsecret, hashsize)
@@ -786,11 +786,11 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
      *
      * Here Transcript-Hash is the cipher suite hash algorithm.
      */
-    if (EVP_DigestInit_ex(ctx, md, NULL) <= 0
-            || EVP_DigestUpdate(ctx, context, contextlen) <= 0
-            || EVP_DigestFinal_ex(ctx, hash, &hashsize) <= 0
-            || EVP_DigestInit_ex(ctx, md, NULL) <= 0
-            || EVP_DigestFinal_ex(ctx, data, &datalen) <= 0
+    if (!EVP_DigestInit_ex(ctx, md, NULL)
+            || !EVP_DigestUpdate(ctx, context, contextlen)
+            || !EVP_DigestFinal_ex(ctx, hash, &hashsize)
+            || !EVP_DigestInit_ex(ctx, md, NULL)
+            || !EVP_DigestFinal_ex(ctx, data, &datalen)
             || !tls13_hkdf_expand(s, md, s->early_exporter_master_secret,
                                   (const unsigned char *)label, llen,
                                   data, datalen, exportsecret, hashsize)


### PR DESCRIPTION
Commit 2 was motivated by @Bugcheckers remark https://github.com/openssl/openssl/pull/6819#issuecomment-410296964. The other two commits are by-products.





### Commit 1

```
    EVP_DigestInit.pod: add missing entries to RETURN VALUES section
```

### Commit 2

```
    Harmonize calls to EVP_Digest*Update()
    
    The majority of callers does not check for an empty buffer (buffer_length == 0) before calling
    EVP_Digest*Update(), because all implementations handle this case correctly as no-op.
    (See discussions in #6800, #6817, and #6838.)
```

### Commit 3

Noticed while working on commit 2. Can be squashed with commit 2 if desired, or discarded if you think it is consistency overkill.

```
    Harmonize calls to EVP_Digest*{Init,Update,Final}()
    
    According to the manual pages, the functions return a boolean value,
    so checking for `EVP_Digest*() <= 0` is misleading. Also the
    statistics show a clear tendency towards using `!EVP_*()`
    
    ~/src/openssl$ grep -rn 'EVP_Digest\(Sign\)\?\(Init\|Update\|Final\).*<=' | wc -l
    77
    ~/src/openssl$ grep -rn '!EVP_Digest\(Sign\)\?\(Init\|Update\|Final\)' | wc -l
    245
```