### PR TITLE
Check ameth->pem_str before strlen

### DIFF
--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -127,9 +127,14 @@ const EVP_PKEY_ASN1_METHOD *EVP_PKEY_asn1_find_str(ENGINE **pe,
     }
     for (i = EVP_PKEY_asn1_get_count(); i-- > 0; ) {
         ameth = EVP_PKEY_asn1_get0(i);
+        if (ameth == NULL) {
+           continue;
+        }
+
         if (ameth->pkey_flags & ASN1_PKEY_ALIAS)
             continue;
-        if ((int)strlen(ameth->pem_str) == len
+
+        if (ameth->pem_str != NULL && (int)strlen(ameth->pem_str) == len
             && strncasecmp(ameth->pem_str, str, len) == 0)
             return ameth;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

Got a crash:

```
Program received signal SIGSEGV, Segmentation fault.
strlen () at ../sysdeps/x86_64/strlen.S:106
106	../sysdeps/x86_64/strlen.S: No such file or directory.
(gdb) bt full
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
No locals.
#1  0x000000000048320d in __interceptor_strlen.part.31 ()
No symbol table info available.
#2  0x00007ffff769ae1b in EVP_PKEY_asn1_find_str (pe=0x7fffffff1cc8, str=0x7ffff7bb18de "gost-mac", len=8) at crypto/asn1/ameth_lib.c:132
        i = 6
        ameth = 0x7ffff7af8f68 <dsa_asn1_meths+840>
#3  0x00007ffff7b5e385 in get_optional_pkey_id (pkey_name=0x7ffff7bb18de "gost-mac") at ssl/ssl_ciph.c:337
        ameth = 0x7ffff7bb18a0
        tmpeng = 0x0
        pkey_id = 0
#4  0x00007ffff7b5e61c in ssl_load_ciphers () at ssl/ssl_ciph.c:420
        i = 12
        t = 0x7ffff7bb1580 <ssl_cipher_table_kx>
#5  0x00007ffff7b639b1 in ossl_init_ssl_base () at ssl/ssl_init.c:102
No locals.
#6  0x00007ffff7b637bf in ossl_init_ssl_base_ossl_ () at ssl/ssl_init.c:24
No locals.
#7  0x00007ffff6b57a99 in __pthread_once_slow (once_control=0x7ffff7dd6798 <ssl_base>, init_routine=0x7ffff7b637b6 <ossl_init_ssl_base_ossl_>) at pthread_once.c:116
        _buffer = {__routine = 0x7ffff6b57ae0 <clear_once_control>, __arg = 0x7ffff7dd6798 <ssl_base>, __canceltype = 65792, __prev = 0x0}
        val = 0
        newval = <optimized out>
#8  0x00007ffff7823a7b in CRYPTO_THREAD_run_once (once=0x7ffff7dd6798 <ssl_base>, init=0x7ffff7b637b6 <ossl_init_ssl_base_ossl_>) at crypto/threads_pthread.c:113
No locals.
#9  0x00007ffff7b63af1 in OPENSSL_init_ssl (opts=2097152, settings=0x0) at ssl/ssl_init.c:206
        stoperrset = 0
#10 0x00007ffff7b6a5db in SSL_CTX_new (meth=0x7ffff7dcfa80 <TLS_method_data.22184>) at ssl/ssl_lib.c:2889

```

`dsa_asn1_meths[0-3]` does not have pem_str.

Please feel free to close it if this bug has been fixed.  