### PR TITLE
Initialize pem_str field in some DSA methods.

### DIFF
--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -516,33 +516,16 @@ static int dsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
 const EVP_PKEY_ASN1_METHOD dsa_asn1_meths[5] = {
 
-    {
-     EVP_PKEY_DSA2,
-     EVP_PKEY_DSA,
-     ASN1_PKEY_ALIAS},
+    {EVP_PKEY_DSA2, EVP_PKEY_DSA, ASN1_PKEY_ALIAS, "DSA-with-SHA"},
+
+    {EVP_PKEY_DSA1, EVP_PKEY_DSA, ASN1_PKEY_ALIAS, "DSA-2"},
+
+    {EVP_PKEY_DSA4, EVP_PKEY_DSA, ASN1_PKEY_ALIAS, "DSA-with-SHA1.2"},
+
+    {EVP_PKEY_DSA3, EVP_PKEY_DSA, ASN1_PKEY_ALIAS, "DSA-with-SHA1"},
 
     {
-     EVP_PKEY_DSA1,
-     EVP_PKEY_DSA,
-     ASN1_PKEY_ALIAS},
-
-    {
-     EVP_PKEY_DSA4,
-     EVP_PKEY_DSA,
-     ASN1_PKEY_ALIAS},
-
-    {
-     EVP_PKEY_DSA3,
-     EVP_PKEY_DSA,
-     ASN1_PKEY_ALIAS},
-
-    {
-     EVP_PKEY_DSA,
-     EVP_PKEY_DSA,
-     0,
-
-     "DSA",
-     "OpenSSL DSA method",
+        EVP_PKEY_DSA, EVP_PKEY_DSA, 0, "DSA", "OpenSSL DSA method",
 
      dsa_pub_decode,
      dsa_pub_encode,


### PR DESCRIPTION
Thanks to GitHub user scw00 for reporting this.

Alternative fix for #6868.
