### PR TITLE
Relocate memcmp test.

### DIFF
--- a/test/sanitytest.c
+++ b/test/sanitytest.c
@@ -84,6 +84,11 @@ static int test_sanity_range(void)
     return 1;
 }
 
+static int test_sanity_memcmp(void)
+{
+    return CRYPTO_memcmp("ab","cd",2);
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sanity_null_zero);
@@ -92,6 +97,7 @@ int setup_tests(void)
     ADD_TEST(test_sanity_sign);
     ADD_TEST(test_sanity_unsigned_conversion);
     ADD_TEST(test_sanity_range);
+    ADD_TEST(test_sanity_memcmp);
     return 1;
 }
 

--- a/test/test_test.c
+++ b/test/test_test.c
@@ -531,11 +531,6 @@ static int test_bn_output(int n)
     return 1;
 }
 
-static int test_memcmp(void)
-{
-    return CRYPTO_memcmp("ab","cd",2);
-}
-
 int setup_tests(void)
 {
     ADD_TEST(test_int);
@@ -557,7 +552,6 @@ int setup_tests(void)
     ADD_TEST(test_messages);
     ADD_TEST(test_single_eval);
     ADD_TEST(test_output);
-    ADD_TEST(test_memcmp);
     ADD_ALL_TESTS(test_bn_output, OSSL_NELEM(bn_output_tests));
     return 1;
 }


### PR DESCRIPTION
The `CRYPTO_memcmp` test isn't testing the test framework.
It would seem to better belong with the sanity tests.
Move it across.

- [x] tests are added or updated
