### PR TITLE
crypto/threads_*: remove CRYPTO_atomic_{read|write}.

### DIFF
--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -128,18 +128,6 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
-{
-    *ret = *val;
-    return 1;
-}
-
-int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock)
-{
-    *val = n;
-    return 1;
-}
-
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -175,44 +175,6 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
-{
-# if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
-    if (__atomic_is_lock_free(sizeof(*val), val)) {
-        __atomic_load(val, ret, __ATOMIC_ACQUIRE);
-        return 1;
-    }
-# endif
-    if (!CRYPTO_THREAD_read_lock(lock))
-        return 0;
-
-    *ret  = *val;
-
-    if (!CRYPTO_THREAD_unlock(lock))
-        return 0;
-
-    return 1;
-}
-
-int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock)
-{
-# if defined(__GNUC__) && defined(__ATOMIC_RELEASE)
-    if (__atomic_is_lock_free(sizeof(*val), val)) {
-        __atomic_store(val, &n, __ATOMIC_RELEASE);
-        return 1;
-    }
-# endif
-    if (!CRYPTO_THREAD_write_lock(lock))
-        return 0;
-
-    *val = n;
-
-    if (!CRYPTO_THREAD_unlock(lock))
-        return 0;
-
-    return 1;
-}
-
 # ifdef OPENSSL_SYS_UNIX
 static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -155,18 +155,6 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock)
-{
-    *ret = InterlockedCompareExchange(val, 0, 0);
-    return 1;
-}
-
-int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock)
-{
-    InterlockedExchange(val, n);
-    return 1;
-}
-
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -4,8 +4,8 @@
 
 CRYPTO_THREAD_run_once,
 CRYPTO_THREAD_lock_new, CRYPTO_THREAD_read_lock, CRYPTO_THREAD_write_lock,
-CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free, CRYPTO_atomic_add,
-CRYPTO_atomic_read, CRYPTO_atomic_write - OpenSSL thread support
+CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free,
+CRYPTO_atomic_add - OpenSSL thread support
 
 =head1 SYNOPSIS
 
@@ -21,8 +21,6 @@ CRYPTO_atomic_read, CRYPTO_atomic_write - OpenSSL thread support
  void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
 
  int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
- int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock);
- int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock);
 
 =head1 DESCRIPTION
 
@@ -76,17 +74,6 @@ result of the operation in B<ret>. B<lock> will be locked, unless atomic
 operations are supported on the specific platform. Because of this, if a
 variable is modified by CRYPTO_atomic_add() then CRYPTO_atomic_add() must
 be the only way that the variable is modified.
-
-=item *
-
-CRYPTO_atomic_read() atomically reads B<val> and returns the result of
-the operation in B<ret>. B<lock> will be locked, unless atomic operations
-are supported on the specific platform.
-
-=item *
-
-CRYPTO_atomic_write() atomically writes B<n> to B<val>. B<lock> will be
-locked, unless atomic operations are supported on the specific platform.
 
 =back
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -73,8 +73,6 @@ int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);
 void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
 
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
-int CRYPTO_atomic_read(int *val, int *ret, CRYPTO_RWLOCK *lock);
-int CRYPTO_atomic_write(int *val, int n, CRYPTO_RWLOCK *lock);
 
 /*
  * The following can be used to detect memory leaks in the library. If

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4396,8 +4396,6 @@ EVP_PKEY_meth_set_check                 4341	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_check                 4342	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_remove                    4343	1_1_1	EXIST::FUNCTION:
 OPENSSL_sk_reserve                      4344	1_1_1	EXIST::FUNCTION:
-CRYPTO_atomic_read                      4345	1_1_1	EXIST::FUNCTION:
-CRYPTO_atomic_write                     4346	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_set1_engine                    4347	1_1_0g	EXIST::FUNCTION:ENGINE
 DH_new_by_nid                           4348	1_1_1	EXIST::FUNCTION:DH
 DH_get_nid                              4349	1_1_1	EXIST::FUNCTION:DH


### PR DESCRIPTION
Even stop providing lock-free option in CRYPTO_atomic_add. Rationale
is that combination does not provide coherent interface.

CRYPTO_atomic_read was added with intention to read statistics counters,
but readings are effectively indistinguishable from regular load (even
in non-lock-free case). This is because you can get out-dated value in
both cases. CRYPTO_atomic_write was added for symmetry and was never used.
In more general case involving standalone access to a variable application
is unlikely to make sensible decision without keeping a lock for the time
decision is made, and not just for the time the variable is read (which
would still be indistinguishable from regular load). For this reason
application wouldn't have use for CRYPTO_atomic_read, and resort to
acquiring a lock by itself. But then application wouldn't be able to use
CRYPTO_atomic_add *if* it offers lock-free as target-specific option.