### PR TITLE
test/asn1_internal_test.c: silence the new check for the ASN1 method table

### DIFF
--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -85,10 +85,8 @@ static int test_standard_methods(void)
          *
          * Anything else is an error and may lead to a corrupt ASN1 method table
          */
-        if (!TEST_true((*tmp)->pem_str == NULL &&
-                       ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0)
-            && !TEST_true((*tmp)->pem_str != NULL &&
-                          ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) == 0)) {
+        if (!TEST_true(((*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0)
+                       || ((*tmp)->pem_str != NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) == 0))) {
             TEST_note("asn1 standard methods: Index %zu, pkey ID %d, Name=%s",
                       i, (*tmp)->pkey_id, OBJ_nid2sn((*tmp)->pkey_id));
             ok = 0;


### PR DESCRIPTION
In 38eca7fed09a a new check for the `pem_str` member of the entries of the
ASN1 method table was introduced. Because the test condition was split
into two `TEST_true(...)` conditions, the test outputs error diagnostics
for all entries which have `pem_str != NULL`. This commit joins the two
test conditions into a single condition.


(see also remark https://github.com/openssl/openssl/pull/6880#discussion_r208104605 and its followers.)

### master

```
msp@msppc:~/src/openssl$ util/shlib_wrap.sh test/asn1_internal_test
1..2
# INFO:  @ test/asn1_internal_test.c:44
# asn1 tbl_standard: Table order OK
ok 1 - test_tbl_standard
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# ERROR: (bool) '(*tmp)->pem_str == NULL && ((*tmp)->pkey_flags & ASN1_PKEY_ALIAS) != 0 == true' failed @ test/asn1_internal_test.c:89
# false
# INFO:  @ test/asn1_internal_test.c:99
# asn1 standard methods: Table order OK
ok 2 - test_standard_methods
```


### This branch

```
msp@msppc:~/src/openssl$ util/shlib_wrap.sh test/asn1_internal_test
1..2
# INFO:  @ test/asn1_internal_test.c:44
# asn1 tbl_standard: Table order OK
ok 1 - test_tbl_standard
# INFO:  @ test/asn1_internal_test.c:81
# asn1 standard methods: Table order OK
ok 2 - test_standard_methods
```


