### PR TITLE
x509v3/v3_purp.c: resolve Thread Sanitizer nit.

### DIFF
--- a/crypto/include/internal/x509_int.h
+++ b/crypto/include/internal/x509_int.h
@@ -166,6 +166,7 @@ struct x509_st {
     unsigned char sha1_hash[SHA_DIGEST_LENGTH];
     X509_CERT_AUX *aux;
     CRYPTO_RWLOCK *lock;
+    volatile int ex_cached;
 } /* X509 */ ;
 
 /*

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -350,11 +350,7 @@ static void x509v3_cache_extensions(X509 *x)
     ASN1_BIT_STRING *ns;
     EXTENDED_KEY_USAGE *extusage;
     X509_EXTENSION *ex;
-
     int i;
-
-    if (x->ex_flags & EXFLAG_SET)
-        return;
 
     CRYPTO_THREAD_write_lock(x->lock);
     if (x->ex_flags & EXFLAG_SET) {


### PR DESCRIPTION
This is partial back-port of #6786. "Partial" means that it touches v3_purp.c only. There are two commits, first one is cherry-picked from master and will be cherry-picked to 1.0.2. Second commit can't be backported to 1.0.2, because X509 structure is public.