### PR TITLE
Fix the comment of PEM_read_bio_ex

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -880,8 +880,7 @@ err:
  * Read in PEM-formatted data from the given BIO.
  *
  * By nature of the PEM format, all content must be printable ASCII (except
- * for line endings).  Other characters, or lines that are longer than 80
- * characters, are malformed input and will be rejected.
+ * for line endings).  Other characters are malformed input and will be rejected.
  */
 int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
                     unsigned char **data, long *len_out, unsigned int flags)

--- a/test/pemtest.c
+++ b/test/pemtest.c
@@ -12,18 +12,31 @@
 #include <openssl/pem.h>
 
 #include "testutil.h"
+#include "internal/nelem.h"
 
-static const char raw[] = "hello world";
-static const char encoded[] = "aGVsbG8gd29ybGQ=";
-static const char pemtype[] = "PEMTESTDATA";
+typedef struct {
+    const char *raw;
+    const char *encoded;
+} TESTDATA;
 
-static int test_b64(void)
+static TESTDATA b64_pem_data[] = {
+    { "hello world",
+      "aGVsbG8gd29ybGQ=" },
+    { "a very ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong input",
+      "YSB2ZXJ5IG9vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29uZyBpbnB1dA==" }
+};
+
+static const char *pemtype = "PEMTESTDATA";
+
+static int test_b64(int idx)
 {
     BIO *b = BIO_new(BIO_s_mem());
     char *name = NULL, *header = NULL;
     unsigned char *data = NULL;
     long len;
     int ret = 0;
+    const char *raw = b64_pem_data[idx].raw;
+    const char *encoded = b64_pem_data[idx].encoded;
 
     if (!TEST_ptr(b)
         || !TEST_true(BIO_printf(b, "-----BEGIN %s-----\n", pemtype))
@@ -32,9 +45,9 @@ static int test_b64(void)
         || !TEST_true(PEM_read_bio_ex(b, &name, &header, &data, &len,
                                       PEM_FLAG_ONLY_B64)))
         goto err;
-    if (!TEST_int_eq(memcmp(pemtype, name, sizeof(pemtype) - 1), 0)
-        || !TEST_int_eq(len,sizeof(raw) - 1)
-        || !TEST_int_eq(memcmp(data, raw, sizeof(raw) - 1), 0))
+    if (!TEST_int_eq(memcmp(pemtype, name, strlen(pemtype)), 0)
+        || !TEST_int_eq(len, strlen(raw))
+        || !TEST_int_eq(memcmp(data, raw, strlen(raw)), 0))
         goto err;
     ret = 1;
  err:
@@ -51,6 +64,7 @@ static int test_invalid(void)
     char *name = NULL, *header = NULL;
     unsigned char *data = NULL;
     long len;
+    const char *encoded = b64_pem_data[0].encoded;
 
     if (!TEST_ptr(b)
         || !TEST_true(BIO_printf(b, "-----BEGIN %s-----\n", pemtype))
@@ -71,7 +85,7 @@ static int test_invalid(void)
 
 int setup_tests(void)
 {
-    ADD_TEST(test_b64);
+    ADD_ALL_TESTS(test_b64, OSSL_NELEM(b64_pem_data));
     ADD_TEST(test_invalid);
     return 1;
 }


### PR DESCRIPTION
PEM_read_bio_ex function could read line of arbitrary length.
It's actually covered by the test 
https://github.com/openssl/openssl/blob/master/test/recipes/04-test_pem.t#L27

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
