### PR TITLE
Fix no-comp

### DIFF
--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -49,8 +49,8 @@ int FuzzerInitialize(int *argc, char ***argv)
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
-    sk_SSL_COMP_sort(comp_methods);
-
+    if (comp_methods != NULL)
+        sk_SSL_COMP_sort(comp_methods);
 
     return 1;
 }

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -496,8 +496,8 @@ int FuzzerInitialize(int *argc, char ***argv)
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
-    sk_SSL_COMP_sort(comp_methods);
-
+    if (comp_methods != NULL)
+        sk_SSL_COMP_sort(comp_methods);
 
     return 1;
 }


### PR DESCRIPTION
Commit 8839324 removed some NULL checks from the stack code. This caused
a no-comp build to fail in the client and server fuzzers.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
