### PR TITLE
Improve fallback protection

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1914,6 +1914,9 @@ int ssl_choose_client_version(SSL *s, int version, RAW_EXTENSION *extensions)
         if (highver != 0 && s->version != vent->version)
             continue;
 
+        if (highver == 0 && (s->mode & SSL_MODE_SEND_FALLBACK_SCSV) != 0)
+            highver = vent->version;
+
         method = vent->cmeth();
         err = ssl_method_error(s, method);
         if (err != 0) {

--- a/util/perl/TLSProxy/Message.pm
+++ b/util/perl/TLSProxy/Message.pm
@@ -41,6 +41,7 @@ use constant {
 use constant {
     AL_DESC_CLOSE_NOTIFY => 0,
     AL_DESC_UNEXPECTED_MESSAGE => 10,
+    AL_DESC_ILLEGAL_PARAMETER => 47,
     AL_DESC_NO_RENEGOTIATION => 100
 };
 
@@ -125,6 +126,7 @@ use constant {
 };
 
 use constant {
+    CIPHER_RSA_WITH_AES_128_CBC_SHA => 0x002f,
     CIPHER_DHE_RSA_AES_128_SHA => 0x0033,
     CIPHER_ADH_AES_128_SHA => 0x0034,
     CIPHER_TLS13_AES_128_GCM_SHA256 => 0x1301,


### PR DESCRIPTION
A client that has fallen back could detect an inappropriate fallback if the TLSv1.3 downgrade protection sentinels are present.

Fixes #6756 

Whether this is a bug or not is at least debatable. For the avoidance of doubt I think this needs 2 OMC approvals.