### PR TITLE
internal/refcount.h: remove fence in CRYPTO_DOWN_REF.

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -37,9 +37,7 @@ static ossl_inline int CRYPTO_UP_REF(_Atomic int *val, int *ret, void *lock)
 
 static ossl_inline int CRYPTO_DOWN_REF(_Atomic int *val, int *ret, void *lock)
 {
-    *ret = atomic_fetch_sub_explicit(val, 1, memory_order_release) - 1;
-    if (*ret == 0)
-        atomic_thread_fence(memory_order_acquire);
+    *ret = atomic_fetch_sub_explicit(val, 1, memory_order_relaxed) - 1;
     return 1;
 }
 
@@ -57,9 +55,7 @@ static ossl_inline int CRYPTO_UP_REF(int *val, int *ret, void *lock)
 
 static ossl_inline int CRYPTO_DOWN_REF(int *val, int *ret, void *lock)
 {
-    *ret = __atomic_fetch_sub(val, 1, __ATOMIC_RELEASE) - 1;
-    if (*ret == 0)
-        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+    *ret = __atomic_fetch_sub(val, 1, __ATOMIC_RELAXED) - 1;
     return 1;
 }
 


### PR DESCRIPTION
Fencing is about data visibility in multi-processor system and ordering
loads and stores. When reference counter hits zero, current thread is
last one to hold the reference, and it's actually about to discard the
object. It doesn't have to care about data becoming visible to other
processors. Nor is there reason to assume that speculative loads in
destructor would yield stale data, because object was already assumed
to be "stable" when it was used just before reference counter hit zero.

This is a spin-off from #6883, where it was said that original code was based on assertions made [here](https://www.boost.org/doc/libs/1_53_0/doc/html/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters). I don't quite accept their premise, hence this request. First some definitions. What's "release fence"? Ensuring that all **preceding stores** are complete and visible to all processors. What's "acquire fence"? Ensuring that none of **following loads** are initiated before fence. Wording at referred page suggests that that an object is discarded while it's still being used by another thread. But thing is that if this was actual case, i.e. object is still in use by another thread, then no amount of fencing would help. Whole point with reference counters is that when current thread observes zero, it's supposed to be actual proof that nobody else is using the object. Which means that all stores are long committed and one doesn't have to worry about loads. Even if some were speculatively performed earlier the outcome would be same. In sense that if reference counter didn't hit zero, then result will be discarded. And if it did hit zero, then result is still valid.