### PR TITLE
Improve the usability of the ca app using EdDSA

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -255,7 +255,7 @@ int ca_main(int argc, char **argv)
     int batch = 0, default_op = 1, doupdatedb = 0, ext_copy = EXT_COPY_NONE;
     int keyformat = FORMAT_PEM, multirdn = 0, notext = 0, output_der = 0;
     int ret = 1, email_dn = 1, req = 0, verbose = 0, gencrl = 0, dorevoke = 0;
-    int rand_ser = 0, i, j, selfsign = 0;
+    int rand_ser = 0, i, j, selfsign = 0, def_nid, def_ret;
     long crldays = 0, crlhours = 0, crlsec = 0, days = 0;
     unsigned long chtype = MBSTRING_ASC, certopt = 0;
     X509 *x509 = NULL, *x509p = NULL, *x = NULL;
@@ -728,24 +728,28 @@ end_of_options:
         }
     }
 
-    if (md == NULL && (md = lookup_conf(conf, section, ENV_DEFAULT_MD)) == NULL)
-        goto end;
-
-    if (strcmp(md, "null") == 0) {
+    def_ret = EVP_PKEY_get_default_digest_nid(pkey, &def_nid);
+    /*
+     * EVP_PKEY_get_default_digest_nid() returns 2 if the digest is
+     * mandatory for this algorithm.
+     */
+    if (def_ret == 2 && def_nid == NID_undef) {
+        /* The signing algorithm requires there to be no digest */
         dgst = EVP_md_null();
+    } else if (md == NULL
+               && (md = lookup_conf(conf, section, ENV_DEFAULT_MD)) == NULL) {
+        goto end;
     } else {
         if (strcmp(md, "default") == 0) {
-            int def_nid;
-            if (EVP_PKEY_get_default_digest_nid(pkey, &def_nid) <= 0) {
+            if (def_ret <= 0) {
                 BIO_puts(bio_err, "no default digest\n");
                 goto end;
             }
             md = (char *)OBJ_nid2sn(def_nid);
         }
 
-        if (!opt_md(md, &dgst)) {
+        if (!opt_md(md, &dgst))
             goto end;
-        }
     }
 
     if (req) {

--- a/apps/req.c
+++ b/apps/req.c
@@ -1601,10 +1601,19 @@ static int do_sign_init(EVP_MD_CTX *ctx, EVP_PKEY *pkey,
                         const EVP_MD *md, STACK_OF(OPENSSL_STRING) *sigopts)
 {
     EVP_PKEY_CTX *pkctx = NULL;
-    int i;
+    int i, def_nid;
 
     if (ctx == NULL)
         return 0;
+    /*
+     * EVP_PKEY_get_default_digest_nid() returns 2 if the digest is mandatory
+     * for this algorithm.
+     */
+    if (EVP_PKEY_get_default_digest_nid(pkey, &def_nid) == 2
+            && def_nid == NID_undef) {
+        /* The signing algorithm requires there to be no digest */
+        md = NULL;
+    }
     if (!EVP_DigestSignInit(ctx, &pkctx, md, NULL, pkey))
         return 0;
     for (i = 0; i < sk_OPENSSL_STRING_num(sigopts); i++) {

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -313,7 +313,7 @@ static int ecx_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
     return ecx_key_print(bp, pkey, indent, ctx, KEY_OP_PUBLIC);
 }
 
-static int ecx_xctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int ecx_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     switch (op) {
 
@@ -337,7 +337,7 @@ static int ecx_xctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
     }
 }
 
-static int ecx_edctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int ecd_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     switch (op) {
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
@@ -430,7 +430,7 @@ const EVP_PKEY_ASN1_METHOD ecx25519_asn1_meth = {
     0, 0,
 
     ecx_free,
-    ecx_xctrl,
+    ecx_ctrl,
     NULL,
     NULL,
 
@@ -473,7 +473,7 @@ const EVP_PKEY_ASN1_METHOD ecx448_asn1_meth = {
     0, 0,
 
     ecx_free,
-    ecx_xctrl,
+    ecx_ctrl,
     NULL,
     NULL,
 
@@ -589,7 +589,7 @@ const EVP_PKEY_ASN1_METHOD ed25519_asn1_meth = {
     0, 0,
 
     ecx_free,
-    ecx_edctrl,
+    ecd_ctrl,
     NULL,
     NULL,
     ecd_item_verify,
@@ -631,7 +631,7 @@ const EVP_PKEY_ASN1_METHOD ed448_asn1_meth = {
     0, 0,
 
     ecx_free,
-    ecx_edctrl,
+    ecd_ctrl,
     NULL,
     NULL,
     ecd_item_verify,

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -313,7 +313,7 @@ static int ecx_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
     return ecx_key_print(bp, pkey, indent, ctx, KEY_OP_PUBLIC);
 }
 
-static int ecx_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int ecx_xctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     switch (op) {
 
@@ -331,8 +331,18 @@ static int ecx_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         }
         return 0;
 
+    default:
+        return -2;
+
+    }
+}
+
+static int ecx_edctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+{
+    switch (op) {
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
-        *(int *)arg2 = NID_sha256;
+        /* We currently only support Pure EdDSA which takes no digest */
+        *(int *)arg2 = NID_undef;
         return 2;
 
     default:
@@ -420,7 +430,7 @@ const EVP_PKEY_ASN1_METHOD ecx25519_asn1_meth = {
     0, 0,
 
     ecx_free,
-    ecx_ctrl,
+    ecx_xctrl,
     NULL,
     NULL,
 
@@ -463,7 +473,7 @@ const EVP_PKEY_ASN1_METHOD ecx448_asn1_meth = {
     0, 0,
 
     ecx_free,
-    ecx_ctrl,
+    ecx_xctrl,
     NULL,
     NULL,
 
@@ -579,7 +589,7 @@ const EVP_PKEY_ASN1_METHOD ed25519_asn1_meth = {
     0, 0,
 
     ecx_free,
-    0,
+    ecx_edctrl,
     NULL,
     NULL,
     ecd_item_verify,
@@ -621,7 +631,7 @@ const EVP_PKEY_ASN1_METHOD ed448_asn1_meth = {
     0, 0,
 
     ecx_free,
-    0,
+    ecx_edctrl,
     NULL,
     NULL,
     ecd_item_verify,

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -184,9 +184,9 @@ The number of days to certify the certificate for.
 =item B<-md alg>
 
 The message digest to use.
-Any digest supported by the OpenSSL B<dgst> command can be used. If the signing
-key is using Ed25519 or Ed448 then you should specify "null" for the digest.
-This option also applies to CRLs.
+Any digest supported by the OpenSSL B<dgst> command can be used. For signing
+algorithms that do not support a digest (i.e. Ed25519 and Ed448) any message
+digest that is set is ignored. This option also applies to CRLs.
 
 =item B<-policy arg>
 
@@ -453,7 +453,8 @@ least one of these must be present to generate a CRL.
 
 =item B<default_md>
 
-The same as the B<-md> option. Mandatory.
+The same as the B<-md> option. Mandatory except where the signing algorithm does
+not require a digest (i.e. Ed25519 and Ed448).
 
 =item B<database>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -209,7 +209,7 @@ the configuration file.
 
 Some public key algorithms may override this choice. For instance, DSA
 signatures always use SHA1, GOST R 34.10 signatures always use
-GOST R 34.11-94 (B<-md_gost94>).
+GOST R 34.11-94 (B<-md_gost94>), Ed25519 and Ed448 never use any digest.
 
 =item B<-config filename>
 
@@ -394,10 +394,10 @@ option. For compatibility B<encrypt_rsa_key> is an equivalent option.
 
 =item B<default_md>
 
-This option specifies the digest algorithm to use.
-Any digest supported by the OpenSSL B<dgst> command can be used.
-If not present then MD5 is used.
-This option can be overridden on the command line.
+This option specifies the digest algorithm to use. Any digest supported by the
+OpenSSL B<dgst> command can be used. This option can be overridden on the
+command line. Certain signing algorithms (i.e. Ed25519 and Ed448) will ignore
+any digest that has been set.
 
 =item B<string_mask>
 

--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -13,7 +13,8 @@ EVP_PKEY_get_default_digest_nid - get default signature digest
 
 The EVP_PKEY_get_default_digest_nid() function sets B<pnid> to the default
 message digest NID for the public key signature operations associated with key
-B<pkey>.
+B<pkey>. Note that some signature algorithms (i.e. Ed25519 and Ed448) do not use
+a digest during signing. In this case B<pnid> will be set to NID_undef.
 
 =head1 NOTES
 


### PR DESCRIPTION
Previously you had to supply "null" as the digest to use EdDSA. This changes
things so that any digest is ignored.