### PR TITLE
The req documentation incorrectly states that we default to md5 (1.1.0)

### DIFF
--- a/doc/apps/req.pod
+++ b/doc/apps/req.pod
@@ -369,7 +369,6 @@ option. For compatibility B<encrypt_rsa_key> is an equivalent option.
 
 This option specifies the digest algorithm to use.
 Any digest supported by the OpenSSL B<dgst> command can be used.
-If not present then MD5 is used.
 This option can be overridden on the command line.
 
 =item B<string_mask>


### PR DESCRIPTION
Just remove that statement. It's not been true since 2005.

This is for 1.1.0. It is fixed by #6901 on master.