### PR TITLE
gendsa: dsaparam: introduce -verbose option to suppress output

### DIFF
--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -25,12 +25,15 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <openssl/x509.h>
 # include <openssl/pem.h>
 
+static int verbose = 0;
+
 static int dsa_cb(int p, int n, BN_GENCB *cb);
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_TEXT, OPT_C,
-    OPT_NOOUT, OPT_GENKEY, OPT_ENGINE, OPT_R_ENUM
+    OPT_NOOUT, OPT_GENKEY, OPT_ENGINE, OPT_VERBOSE,
+    OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS dsaparam_options[] = {
@@ -47,6 +50,7 @@ const OPTIONS dsaparam_options[] = {
 # ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine e, possibly a hardware device"},
 # endif
+    {"verbose", OPT_VERBOSE, '-', "Verbose output"},
     {NULL}
 };
 
@@ -107,6 +111,9 @@ int dsaparam_main(int argc, char **argv)
         case OPT_NOOUT:
             noout = 1;
             break;
+        case OPT_VERBOSE:
+            verbose = 1;
+            break;
         }
     }
     argc = opt_num_rest();
@@ -145,9 +152,11 @@ int dsaparam_main(int argc, char **argv)
             BIO_printf(bio_err, "Error allocating DSA object\n");
             goto end;
         }
-        BIO_printf(bio_err, "Generating DSA parameters, %d bit long prime\n",
-                   num);
-        BIO_printf(bio_err, "This could take some time\n");
+        if (verbose) {
+            BIO_printf(bio_err, "Generating DSA parameters, %d bit long prime\n",
+                       num);
+            BIO_printf(bio_err, "This could take some time\n");
+        }
         if (!DSA_generate_parameters_ex(dsa, num, NULL, 0, NULL, NULL, cb)) {
             ERR_print_errors(bio_err);
             BIO_printf(bio_err, "Error, DSA key generation failed\n");
@@ -250,6 +259,9 @@ static int dsa_cb(int p, int n, BN_GENCB *cb)
 {
     static const char symbols[] = ".+*\n";
     char c = (p >= 0 && (size_t)p < sizeof(symbols) - 1) ? symbols[p] : '?';
+
+    if (!verbose)
+        return 1;
 
     BIO_write(BN_GENCB_get_arg(cb), &c, 1);
     (void)BIO_flush(BN_GENCB_get_arg(cb));

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -27,7 +27,7 @@ NON_EMPTY_TRANSLATION_UNIT
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_CIPHER,
+    OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_CIPHER, OPT_VERBOSE,
     OPT_R_ENUM
 } OPTION_CHOICE;
 
@@ -42,6 +42,7 @@ const OPTIONS gendsa_options[] = {
 # ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
 # endif
+    {"verbose", OPT_VERBOSE, '-', "Verbose output"},
     {NULL}
 };
 
@@ -54,7 +55,7 @@ int gendsa_main(int argc, char **argv)
     char *dsaparams = NULL;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL, *prog;
     OPTION_CHOICE o;
-    int ret = 1, private = 0;
+    int ret = 1, private = 0, verbose = 0;
     const BIGNUM *p = NULL;
 
     prog = opt_init(argc, argv, gendsa_options);
@@ -85,6 +86,9 @@ int gendsa_main(int argc, char **argv)
         case OPT_CIPHER:
             if (!opt_cipher(opt_unknown(), &enc))
                 goto end;
+            break;
+        case OPT_VERBOSE:
+            verbose = 1;
             break;
         }
     }
@@ -124,7 +128,8 @@ int gendsa_main(int argc, char **argv)
                    "         Your key size is %d! Larger key size may behave not as expected.\n",
                    OPENSSL_DSA_MAX_MODULUS_BITS, BN_num_bits(p));
 
-    BIO_printf(bio_err, "Generating DSA key, %d bits\n", BN_num_bits(p));
+    if (verbose)
+        BIO_printf(bio_err, "Generating DSA key, %d bits\n", BN_num_bits(p));
     if (!DSA_generate_key(dsa))
         goto end;
 

--- a/doc/man1/dsaparam.pod
+++ b/doc/man1/dsaparam.pod
@@ -20,6 +20,7 @@ B<openssl dsaparam>
 [B<-writerand file>]
 [B<-genkey>]
 [B<-engine id>]
+[B<-verbose>]
 [B<numbits>]
 
 =head1 DESCRIPTION
@@ -89,18 +90,22 @@ all others.
 Writes random data to the specified I<file> upon exit.
 This can be used with a subsequent B<-rand> flag.
 
-=item B<numbits>
-
-This option specifies that a parameter set should be generated of size
-B<numbits>. It must be the last option. If this option is included then
-the input file (if any) is ignored.
-
 =item B<-engine id>
 
 Specifying an engine (by its unique B<id> string) will cause B<dsaparam>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms.
+
+=item B<-verbose>
+
+Print extra details about the operations being performed.
+
+=item B<numbits>
+
+This option specifies that a parameter set should be generated of size
+B<numbits>. It must be the last option. If this option is included then
+the input file (if any) is ignored.
 
 =back
 

--- a/doc/man1/gendsa.pod
+++ b/doc/man1/gendsa.pod
@@ -25,6 +25,7 @@ B<openssl> B<gendsa>
 [B<-rand file...>]
 [B<-writerand file>]
 [B<-engine id>]
+[B<-verbose>]
 [B<paramfile>]
 
 =head1 DESCRIPTION
@@ -70,6 +71,10 @@ Specifying an engine (by its unique B<id> string) will cause B<gendsa>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms.
+
+=item B<-verbose>
+
+Print extra details about the operations being performed.
 
 =item B<paramfile>
 


### PR DESCRIPTION
Other commands like 'req' support -verbose, so why not gendsa and dsaparam?

Part of a larger and more ambitious effort to add -verbose to all apps
that might be used in scripts and need to otherwise run silently (well,
without belching out anything that isn't a warning or error... which ties
into a later scrub of using STDOUT were appropriate for informative
messages instead of STDERR)... so that scripts also have the option of
doing >/dev/null without losing anything critical.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

