### PR TITLE
genpkey: introduce -verbose option to suppress output

### DIFF
--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -19,6 +19,7 @@ B<openssl> B<genpkey>
 [B<-pkeyopt opt:value>]
 [B<-genparam>]
 [B<-text>]
+[B<-verbose>]
 
 =head1 DESCRIPTION
 
@@ -102,6 +103,10 @@ are mutually exclusive.
 
 Print an (unencrypted) text representation of private and public keys and
 parameters along with the PEM or DER structure.
+
+=item B<-verbose>
+
+Print extra details about the operations being performed.
 
 =back
 


### PR DESCRIPTION
Other commands like 'req' support -verbose, so why not genpkey?

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

