### PR TITLE
Reference RFC 8410 for curves 25519 and 448.

### DIFF
--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -1605,7 +1605,7 @@ secg-scheme 14 3 : dhSinglePass-cofactorDH-sha512kdf-scheme
 id-pkinit 4                     : pkInitClientAuth      : PKINIT Client Auth
 id-pkinit 5                     : pkInitKDC             : Signing KDC Response
 
-# New algorithms from draft-ietf-curdle-pkix-04
+# From RFC8410
 1 3 101 110 : X25519
 1 3 101 111 : X448
 1 3 101 112 : ED25519


### PR DESCRIPTION
Change the OID references for X25519, X448, ED25519 and ED448 from the draft RFC to the now released RFC 8410.

This is a change to the comment only.
