### PR TITLE
x509v3/v3_purp.c: resolve Thread Sanitizer nit.

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -396,11 +396,7 @@ static void x509v3_cache_extensions(X509 *x)
     ASN1_BIT_STRING *ns;
     EXTENDED_KEY_USAGE *extusage;
     X509_EXTENSION *ex;
-
     int i;
-
-    if (x->ex_flags & EXFLAG_SET)
-        return;
 
     CRYPTO_w_lock(CRYPTO_LOCK_X509);
     if (x->ex_flags & EXFLAG_SET) {


### PR DESCRIPTION
Reviewed-by: Paul Dale <paul.dale@oracle.com>
Reviewed-by: Rich Salz <rsalz@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/6786)

(cherry picked from commit 0da7358b0757fa35f2c3a8f51fa036466ae50fd7)

Resolved conflicts:
	crypto/x509v3/v3_purp.c

Torture never stops, #6891 didn't cherry-pick to 1.0.2...