### PR TITLE
Configurations/15-android.conf: Make sure that the NDK path is canonical

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -4,6 +4,8 @@
 # comments below...
 
 {
+    use File::Spec::Functions;
+
     my $android_ndk = {};
     my %triplet = (
         arm    => "arm-linux-androideabi",
@@ -22,6 +24,7 @@
 
             my $ndk = $ENV{ANDROID_NDK};
             die "\$ANDROID_NDK is not defined"  if (!$ndk);
+            $ndk = canonpath($ndk);
             die "\$ANDROID_NDK=$ndk is invalid" if (!-d "$ndk/platforms");
 
             my $ndkver = undef;


### PR DESCRIPTION
Extra slashes in paths are permissible in Unix-like platforms...
however, when compared with the result from 'which', which returns
canonical paths, the comparison might fail even though the compared
paths may be equivalent.  We make the NDK path canonical internally to
ensure the equivalence compares as equal, at least for the most
trivial cases.

Fixes #6917
