### PR TITLE
Configuration/15-android.conf: slightly move NDK canonisation

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -24,8 +24,8 @@
 
             my $ndk = $ENV{ANDROID_NDK};
             die "\$ANDROID_NDK is not defined"  if (!$ndk);
-            $ndk = canonpath($ndk);
             die "\$ANDROID_NDK=$ndk is invalid" if (!-d "$ndk/platforms");
+            $ndk = canonpath($ndk);
 
             my $ndkver = undef;
 


### PR DESCRIPTION
This allows the original path to be displayed when it's shown
to be invalid, so the user can relate without question.
