### PR TITLE
Travis: don't generate git clone progress for logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: c
 cache: ccache
 git:
     submodules: false
+    quiet: true
 
 before_install:
     - if [ -n "$COVERALLS" ]; then


### PR DESCRIPTION
The logs are usually not looked at, and when they are it's almost
always after they've completed and returned a status.  That being
the case, "progress" output is useless if it's always seen after
the fact.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
