### PR TITLE
Rename SSL[_CTX]_add1_CA_list -> SSL[_CTX]_add1_to_CA_list

### DIFF
--- a/doc/man3/SSL_CTX_set0_CA_list.pod
+++ b/doc/man3/SSL_CTX_set0_CA_list.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 SSL_set0_CA_list, SSL_CTX_set0_CA_list, SSL_get0_CA_list,
-SSL_CTX_get0_CA_list, SSL_add1_CA, SSL_CTX_add1_CA,
+SSL_CTX_get0_CA_list, SSL_add1_to_CA_list, SSL_CTX_add1_to_CA_list,
 SSL_get0_peer_CA_list - get or set CA list
 
 =head1 SYNOPSIS
@@ -14,8 +14,8 @@ SSL_get0_peer_CA_list - get or set CA list
  void SSL_set0_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list);
  const STACK_OF(X509_NAME) *SSL_CTX_get0_CA_list(const SSL_CTX *ctx);
  const STACK_OF(X509_NAME) *SSL_get0_CA_list(const SSL *s);
- int SSL_CTX_add1_CA(SSL_CTX *ctx, const X509 *x);
- int SSL_add1_CA(SSL *ssl, const X509 *x);
+ int SSL_CTX_add1_to_CA_list(SSL_CTX *ctx, const X509 *x);
+ int SSL_add1_to_CA_list(SSL *ssl, const X509 *x);
 
  const STACK_OF(X509_NAME) *SSL_get0_peer_CA_list(const SSL *s);
 
@@ -35,10 +35,10 @@ B<ctx>.
 SSL_CTX_get0_CA_list() retrieves any previously set list of CAs set for
 B<s> or if none are set the list from the parent B<SSL_CTX> is retrieved.
 
-SSL_CTX_add1_CA() appends the CA subject name extracted from B<x> to the
+SSL_CTX_add1_to_CA_list() appends the CA subject name extracted from B<x> to the
 list of CAs sent to peer for B<ctx>.
 
-SSL_add1_CA() appends the CA subject name extracted from B<x> to the
+SSL_add1_to_CA_list() appends the CA subject name extracted from B<x> to the
 list of CAs sent to the peer for B<s>, overriding the setting in the parent
 B<SSL_CTX>.
 
@@ -66,7 +66,7 @@ SSL_CTX_set0_CA_list() and SSL_set0_CA_list() do not return a value.
 SSL_CTX_get0_CA_list() and SSL_get0_CA_list() return a stack of CA names
 or B<NULL> is no CA names are set.
 
-SSL_CTX_add1_CA() and SSL_add1_CA() return 1 for success and 0
+SSL_CTX_add1_to_CA_list() and SSL_add1_to_CA_list() return 1 for success and 0
 for failure.
 
 SSL_get0_peer_CA_list() returns a stack of CA names sent by the peer or

--- a/doc/man3/SSL_CTX_set0_CA_list.pod
+++ b/doc/man3/SSL_CTX_set0_CA_list.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 SSL_set0_CA_list, SSL_CTX_set0_CA_list, SSL_get0_CA_list,
-SSL_CTX_get0_CA_list, SSL_add1_CA_list, SSL_CTX_add1_CA_list,
+SSL_CTX_get0_CA_list, SSL_add1_CA, SSL_CTX_add1_CA,
 SSL_get0_peer_CA_list - get or set CA list
 
 =head1 SYNOPSIS
@@ -14,8 +14,8 @@ SSL_get0_peer_CA_list - get or set CA list
  void SSL_set0_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list);
  const STACK_OF(X509_NAME) *SSL_CTX_get0_CA_list(const SSL_CTX *ctx);
  const STACK_OF(X509_NAME) *SSL_get0_CA_list(const SSL *s);
- int SSL_CTX_add1_CA_list(SSL_CTX *ctx, const X509 *x);
- int SSL_add1_CA_list(SSL *ssl, const X509 *x);
+ int SSL_CTX_add1_CA(SSL_CTX *ctx, const X509 *x);
+ int SSL_add1_CA(SSL *ssl, const X509 *x);
 
  const STACK_OF(X509_NAME) *SSL_get0_peer_CA_list(const SSL *s);
 
@@ -35,10 +35,10 @@ B<ctx>.
 SSL_CTX_get0_CA_list() retrieves any previously set list of CAs set for
 B<s> or if none are set the list from the parent B<SSL_CTX> is retrieved.
 
-SSL_CTX_add1_CA_list() appends the CA subject name extracted from B<x> to the
+SSL_CTX_add1_CA() appends the CA subject name extracted from B<x> to the
 list of CAs sent to peer for B<ctx>.
 
-SSL_add1_CA_list() appends the CA subject name extracted from B<x> to the
+SSL_add1_CA() appends the CA subject name extracted from B<x> to the
 list of CAs sent to the peer for B<s>, overriding the setting in the parent
 B<SSL_CTX>.
 
@@ -66,7 +66,7 @@ SSL_CTX_set0_CA_list() and SSL_set0_CA_list() do not return a value.
 SSL_CTX_get0_CA_list() and SSL_get0_CA_list() return a stack of CA names
 or B<NULL> is no CA names are set.
 
-SSL_CTX_add1_CA_list() and SSL_add1_CA_list() return 1 for success and 0
+SSL_CTX_add1_CA() and SSL_add1_CA() return 1 for success and 0
 for failure.
 
 SSL_get0_peer_CA_list() returns a stack of CA names sent by the peer or

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1912,8 +1912,8 @@ void SSL_set0_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list);
 void SSL_CTX_set0_CA_list(SSL_CTX *ctx, STACK_OF(X509_NAME) *name_list);
 __owur const STACK_OF(X509_NAME) *SSL_get0_CA_list(const SSL *s);
 __owur const STACK_OF(X509_NAME) *SSL_CTX_get0_CA_list(const SSL_CTX *ctx);
-__owur int SSL_add1_CA_list(SSL *ssl, const X509 *x);
-__owur int SSL_CTX_add1_CA_list(SSL_CTX *ctx, const X509 *x);
+__owur int SSL_add1_CA(SSL *ssl, const X509 *x);
+__owur int SSL_CTX_add1_CA(SSL_CTX *ctx, const X509 *x);
 __owur const STACK_OF(X509_NAME) *SSL_get0_peer_CA_list(const SSL *s);
 
 void SSL_set_client_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1912,8 +1912,8 @@ void SSL_set0_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list);
 void SSL_CTX_set0_CA_list(SSL_CTX *ctx, STACK_OF(X509_NAME) *name_list);
 __owur const STACK_OF(X509_NAME) *SSL_get0_CA_list(const SSL *s);
 __owur const STACK_OF(X509_NAME) *SSL_CTX_get0_CA_list(const SSL_CTX *ctx);
-__owur int SSL_add1_CA(SSL *ssl, const X509 *x);
-__owur int SSL_CTX_add1_CA(SSL_CTX *ctx, const X509 *x);
+__owur int SSL_add1_to_CA_list(SSL *ssl, const X509 *x);
+__owur int SSL_CTX_add1_to_CA_list(SSL_CTX *ctx, const X509 *x);
 __owur const STACK_OF(X509_NAME) *SSL_get0_peer_CA_list(const SSL *s);
 
 void SSL_set_client_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list);

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -545,18 +545,19 @@ static int add_ca_name(STACK_OF(X509_NAME) **sk, const X509 *x)
     return 1;
 }
 
-int SSL_add1_CA(SSL *ssl, const X509 *x)
+int SSL_add1_to_CA_list(SSL *ssl, const X509 *x)
 {
     return add_ca_name(&ssl->ca_names, x);
 }
 
-int SSL_CTX_add1_CA(SSL_CTX *ctx, const X509 *x)
+int SSL_CTX_add1_to_CA_list(SSL_CTX *ctx, const X509 *x)
 {
     return add_ca_name(&ctx->ca_names, x);
 }
 
 /*
- * The following two are older names are to be replaced with SSL(_CTX)_add1_CA
+ * The following two are older names are to be replaced with
+ * SSL(_CTX)_add1_to_CA_list
  */
 int SSL_add_client_CA(SSL *ssl, X509 *x)
 {

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -545,16 +545,19 @@ static int add_ca_name(STACK_OF(X509_NAME) **sk, const X509 *x)
     return 1;
 }
 
-int SSL_add1_CA_list(SSL *ssl, const X509 *x)
+int SSL_add1_CA(SSL *ssl, const X509 *x)
 {
     return add_ca_name(&ssl->ca_names, x);
 }
 
-int SSL_CTX_add1_CA_list(SSL_CTX *ctx, const X509 *x)
+int SSL_CTX_add1_CA(SSL_CTX *ctx, const X509 *x)
 {
     return add_ca_name(&ctx->ca_names, x);
 }
 
+/*
+ * The following two are older names are to be replaced with SSL(_CTX)_add1_CA
+ */
 int SSL_add_client_CA(SSL *ssl, X509 *x)
 {
     return add_ca_name(&ssl->ca_names, x);

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -432,12 +432,12 @@ SSL_write_early_data                    432	1_1_1	EXIST::FUNCTION:
 SSL_read_early_data                     433	1_1_1	EXIST::FUNCTION:
 SSL_get_early_data_status               434	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_get_max_early_data          435	1_1_1	EXIST::FUNCTION:
-SSL_add1_CA_list                        436	1_1_1	EXIST::FUNCTION:
+SSL_add1_CA                             436	1_1_1	EXIST::FUNCTION:
 SSL_set0_CA_list                        437	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set0_CA_list                    438	1_1_1	EXIST::FUNCTION:
 SSL_get0_CA_list                        439	1_1_1	EXIST::FUNCTION:
 SSL_get0_peer_CA_list                   440	1_1_1	EXIST::FUNCTION:
-SSL_CTX_add1_CA_list                    441	1_1_1	EXIST::FUNCTION:
+SSL_CTX_add1_CA                         441	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get0_CA_list                    442	1_1_1	EXIST::FUNCTION:
 SSL_CTX_add_custom_ext                  443	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_is_resumable                444	1_1_1	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -432,12 +432,12 @@ SSL_write_early_data                    432	1_1_1	EXIST::FUNCTION:
 SSL_read_early_data                     433	1_1_1	EXIST::FUNCTION:
 SSL_get_early_data_status               434	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_get_max_early_data          435	1_1_1	EXIST::FUNCTION:
-SSL_add1_CA                             436	1_1_1	EXIST::FUNCTION:
+SSL_add1_to_CA_list                     436	1_1_1	EXIST::FUNCTION:
 SSL_set0_CA_list                        437	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set0_CA_list                    438	1_1_1	EXIST::FUNCTION:
 SSL_get0_CA_list                        439	1_1_1	EXIST::FUNCTION:
 SSL_get0_peer_CA_list                   440	1_1_1	EXIST::FUNCTION:
-SSL_CTX_add1_CA                         441	1_1_1	EXIST::FUNCTION:
+SSL_CTX_add1_to_CA_list                 441	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get0_CA_list                    442	1_1_1	EXIST::FUNCTION:
 SSL_CTX_add_custom_ext                  443	1_1_1	EXIST::FUNCTION:
 SSL_SESSION_is_resumable                444	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
They add a single item, so the names give a false impression of what
they do, making them hard to remember.  Better to give them a somewhat
better name.

Fixes #6930
