### PR TITLE
Add getters for X509_VERIFY_PARAM fields

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -437,6 +437,15 @@ int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                                (char *)ip, iplen);
 }
 
+size_t X509_VERIFY_PARAM_get_ip(X509_VERIFY_PARAM *param, unsigned char *dest,
+                                size_t destlen)
+{
+    if (param->iplen > destlen)
+        return param->iplen;
+    memcpy(dest, &param->ip, param->iplen);
+    return param->iplen;
+}
+
 int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *param, const char *ipasc)
 {
     unsigned char ipout[16];

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -387,6 +387,25 @@ int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
     return int_x509_param_set_hosts(param, ADD_HOST, name, namelen);
 }
 
+int X509_VERIFY_PARAM_get1_hosts(X509_VERIFY_PARAM *param,
+                                 STACK_OF(OPENSSL_STRING)** dest)
+{
+    STACK_OF(OPENSSL_STRING) *tmp;
+
+    if (!param->hosts) {
+        *dest = NULL;
+        return 1;
+    }
+
+    tmp = sk_OPENSSL_STRING_deep_copy(param->hosts, str_copy, str_free);
+    if (tmp == NULL)
+        return 0;
+
+    *dest = tmp;
+
+    return 1;
+}
+
 void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                      unsigned int flags)
 {

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -428,6 +428,15 @@ int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
                                email, emaillen);
 }
 
+size_t X509_VERIFY_PARAM_get_email(X509_VERIFY_PARAM *param, unsigned char *dest,
+                                   size_t destlen)
+{
+    if (param->emaillen > destlen)
+        return param->emaillen;
+    memcpy(dest, &param->email, param->emaillen);
+    return param->emaillen;
+}
+
 int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                               const unsigned char *ip, size_t iplen)
 {

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -13,7 +13,7 @@ X509_VERIFY_PARAM_add0_policy, X509_VERIFY_PARAM_set1_policies,
 X509_VERIFY_PARAM_set1_host, X509_VERIFY_PARAM_add1_host,
 X509_VERIFY_PARAM_set_hostflags,
 X509_VERIFY_PARAM_get_hostflags,
-X509_VERIFY_PARAM_get0_peername,
+X509_VERIFY_PARAM_get0_peername, X509_VERIFY_PARAM_get_email
 X509_VERIFY_PARAM_set1_email, X509_VERIFY_PARAM_set1_ip,
 X509_VERIFY_PARAM_get_ip, X509_VERIFY_PARAM_set1_ip_asc
 - X509 verification parameters
@@ -60,6 +60,8 @@ X509_VERIFY_PARAM_get_ip, X509_VERIFY_PARAM_set1_ip_asc
  char *X509_VERIFY_PARAM_get0_peername(X509_VERIFY_PARAM *param);
  int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
                                   const char *email, size_t emaillen);
+ size_t X509_VERIFY_PARAM_get_email(X509_VERIFY_PARAM *param,
+                                    unsigned char *dest, size_t destlen);
  int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                                const unsigned char *ip, size_t iplen);
  size_t X509_VERIFY_PARAM_get_ip(X509_VERIFY_PARAM *param, unsigned char *dest,
@@ -185,6 +187,10 @@ B<emaillen> must be set to the length of B<email>.  When an email address
 is specified, certificate verification automatically invokes
 L<X509_check_email(3)>.
 
+X509_VERIFY_PARAM_get_email() fills the user provided buffer B<dest> of length
+B<destlen> with the set email address (if any). If the destination buffer is
+not large enough, then no data is written.
+
 X509_VERIFY_PARAM_set1_ip() sets the expected IP address to B<ip>.
 The B<ip> argument is in binary format, in network byte-order and
 B<iplen> must be set to 4 for IPv4 and 16 for IPv6.  When an IP
@@ -226,9 +232,9 @@ X509_VERIFY_PARAM_get_depth() returns the current verification depth.
 X509_VERIFY_PARAM_get_auth_level() returns the current authentication security
 level.
 
-X509_VERIFY_PARAM_get_ip() returns the number of bytes written to the buffer,
-or if B<destlen> was not large enough, the buffer size required. If no IP is
-set then returns 0.
+X509_VERIFY_PARAM_get_email() and X509_VERIFY_PARAM_get_ip() return the number
+of bytes written to the buffer, or if B<destlen> was not large enough, the
+buffer size required. If the field is not set then they return 0.
 
 =head1 VERIFICATION FLAGS
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -11,6 +11,7 @@ X509_VERIFY_PARAM_get_auth_level, X509_VERIFY_PARAM_set_time,
 X509_VERIFY_PARAM_get_time,
 X509_VERIFY_PARAM_add0_policy, X509_VERIFY_PARAM_set1_policies,
 X509_VERIFY_PARAM_set1_host, X509_VERIFY_PARAM_add1_host,
+X509_VERIFY_PARAM_get1_hosts,
 X509_VERIFY_PARAM_set_hostflags,
 X509_VERIFY_PARAM_get_hostflags,
 X509_VERIFY_PARAM_get0_peername, X509_VERIFY_PARAM_get_email
@@ -54,6 +55,8 @@ X509_VERIFY_PARAM_get_ip, X509_VERIFY_PARAM_set1_ip_asc
                                  const char *name, size_t namelen);
  int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
                                  const char *name, size_t namelen);
+ int X509_VERIFY_PARAM_get1_hosts(X509_VERIFY_PARAM *param,
+                                  STACK_OF(OPENSSL_STRING)** dest);
  void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                       unsigned int flags);
  unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);
@@ -171,6 +174,10 @@ are retained, no change is made if B<name> is NULL or empty.  When
 multiple names are configured, the peer is considered verified when
 any name matches.
 
+X509_VERIFY_PARAM_get1_hosts() gets a copy of the list of hosts previously
+set with X509_VERIFY_PARAM_set1_host() and X509_VERIFY_PARAM_add1_host().
+If no hosts have been set then B<dest> will be set to B<NULL>.
+
 X509_VERIFY_PARAM_get0_peername() returns the DNS hostname or subject
 CommonName from the peer certificate that matched one of the reference
 identifiers.  When wildcard matching is not disabled, or when a
@@ -214,9 +221,9 @@ X509_VERIFY_PARAM_set_inh_flags(),
 X509_VERIFY_PARAM_set_purpose(), X509_VERIFY_PARAM_set_trust(),
 X509_VERIFY_PARAM_add0_policy() X509_VERIFY_PARAM_set1_policies(),
 X509_VERIFY_PARAM_set1_host(), X509_VERIFY_PARAM_add1_host(),
-X509_VERIFY_PARAM_set1_email(), X509_VERIFY_PARAM_set1_ip() and
-X509_VERIFY_PARAM_set1_ip_asc() return 1 for success and 0 for
-failure.
+X509_VERIFY_PARAM_get1_hosts(), X509_VERIFY_PARAM_set1_email(),
+X509_VERIFY_PARAM_set1_ip() and X509_VERIFY_PARAM_set1_ip_asc()
+return 1 for success and 0 for failure.
 
 X509_VERIFY_PARAM_get_flags() returns the current verification flags.
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -15,7 +15,7 @@ X509_VERIFY_PARAM_set_hostflags,
 X509_VERIFY_PARAM_get_hostflags,
 X509_VERIFY_PARAM_get0_peername,
 X509_VERIFY_PARAM_set1_email, X509_VERIFY_PARAM_set1_ip,
-X509_VERIFY_PARAM_set1_ip_asc
+X509_VERIFY_PARAM_get_ip, X509_VERIFY_PARAM_set1_ip_asc
 - X509 verification parameters
 
 =head1 SYNOPSIS
@@ -62,6 +62,8 @@ X509_VERIFY_PARAM_set1_ip_asc
                                   const char *email, size_t emaillen);
  int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                                const unsigned char *ip, size_t iplen);
+ size_t X509_VERIFY_PARAM_get_ip(X509_VERIFY_PARAM *param, unsigned char *dest,
+                                 size_t destlen);
  int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *param, const char *ipasc);
 
 =head1 DESCRIPTION
@@ -189,6 +191,11 @@ B<iplen> must be set to 4 for IPv4 and 16 for IPv6.  When an IP
 address is specified, certificate verification automatically invokes
 L<X509_check_ip(3)>.
 
+X509_VERIFY_PARAM_get_ip() fills the user provided buffer B<dest> of length
+B<destlen> with the set IP address (if any). If the destination buffer is not
+large enough, then no data is written. The B<ip> will be written in binary
+format, in network byte-order.
+
 X509_VERIFY_PARAM_set1_ip_asc() sets the expected IP address to
 B<ipasc>.  The B<ipasc> argument is a NUL-terminal ASCII string:
 dotted decimal quad for IPv4 and colon-separated hexadecimal for
@@ -218,6 +225,10 @@ X509_VERIFY_PARAM_get_depth() returns the current verification depth.
 
 X509_VERIFY_PARAM_get_auth_level() returns the current authentication security
 level.
+
+X509_VERIFY_PARAM_get_ip() returns the number of bytes written to the buffer,
+or if B<destlen> was not large enough, the buffer size required. If no IP is
+set then returns 0.
 
 =head1 VERIFICATION FLAGS
 

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -561,6 +561,8 @@ int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
                                  const char *email, size_t emaillen);
 int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                               const unsigned char *ip, size_t iplen);
+size_t X509_VERIFY_PARAM_get_ip(X509_VERIFY_PARAM *param, unsigned char *dest,
+                                size_t destlen);
 int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *param,
                                   const char *ipasc);
 

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -552,6 +552,8 @@ int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
                                 const char *name, size_t namelen);
 int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
                                 const char *name, size_t namelen);
+int X509_VERIFY_PARAM_get1_hosts(X509_VERIFY_PARAM *param,
+                                 STACK_OF(OPENSSL_STRING)** dest);
 void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                      unsigned int flags);
 unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -559,6 +559,8 @@ char *X509_VERIFY_PARAM_get0_peername(X509_VERIFY_PARAM *);
 void X509_VERIFY_PARAM_move_peername(X509_VERIFY_PARAM *, X509_VERIFY_PARAM *);
 int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
                                  const char *email, size_t emaillen);
+size_t X509_VERIFY_PARAM_get_email(X509_VERIFY_PARAM *param,
+                                   unsigned char *dest, size_t destlen);
 int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                               const unsigned char *ip, size_t iplen);
 size_t X509_VERIFY_PARAM_get_ip(X509_VERIFY_PARAM *param, unsigned char *dest,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4575,3 +4575,4 @@ EC_POINT_get_affine_coordinates         4526	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_set_curve                      4527	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_get_curve                      4528	1_1_1	EXIST::FUNCTION:EC
 X509_VERIFY_PARAM_get_ip                4529	1_1_1	EXIST::FUNCTION:
+X509_VERIFY_PARAM_get_email             4530	1_1_1	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4576,3 +4576,4 @@ EC_GROUP_set_curve                      4527	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_get_curve                      4528	1_1_1	EXIST::FUNCTION:EC
 X509_VERIFY_PARAM_get_ip                4529	1_1_1	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_email             4530	1_1_1	EXIST::FUNCTION:
+X509_VERIFY_PARAM_get1_hosts            4531	1_1_1	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4574,3 +4574,4 @@ EC_POINT_set_affine_coordinates         4525	1_1_1	EXIST::FUNCTION:EC
 EC_POINT_get_affine_coordinates         4526	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_set_curve                      4527	1_1_1	EXIST::FUNCTION:EC
 EC_GROUP_get_curve                      4528	1_1_1	EXIST::FUNCTION:EC
+X509_VERIFY_PARAM_get_ip                4529	1_1_1	EXIST::FUNCTION:


### PR DESCRIPTION
Fixes #2673 

Let me know if this style is okay; I wasn't sure of the best return convention to do, copying into a user-provided buffer seemed the most sensible option.


##### Checklist

- [x] documentation is added or updated
- [ ] tests are added or updated

