### PR TITLE
update for dladdr() implementation on AIX for master

### DIFF
--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -363,26 +363,26 @@ static int dladdr(void *ptr, Dl_info *dl)
             || ((addr >= (uintptr_t)this_ldi->ldinfo_dataorg)
                 && (addr < ((uintptr_t)this_ldi->ldinfo_dataorg +
                             this_ldi->ldinfo_datasize)))) {
+            char *fname;
             char *member = (char *)((uintptr_t)this_ldi->ldinfo_filename +
                                     strlen(this_ldi->ldinfo_filename) + 1);
             size_t member_len = strlen(member);
             found = 1;
-            if ((dl->dli_fname =
-                 OPENSSL_strdup(this_ldi->ldinfo_filename)) != NULL) {
+            if ((fname = OPENSSL_strdup(this_ldi->ldinfo_filename)) != NULL) {
                 if ((member_len > 0)
-                    && (dl->dli_fname =
-                        OPENSSL_realloc(dl->dli_fname, strlen(dl->dli_fname) +
-                                                       1 + member_len + 2)) {
+                    && (fname = OPENSSL_realloc((void *)fname, strlen(fname) +
+                                                    1 + member_len + 2))) {
                     /*
                      * Need to respect a possible member name and not just
                      * returning the path name in this case. See docs:
                      * sys/ldr.h, loadquery() and dlopen()/RTLD_MEMBER.
                      */
-                    strcat(dl->dli_fname, "(");
-                    strcat(dl->dli_fname, member);
-                    strcat(dl->dli_fname, ")");
+                    strcat(fname, "(");
+                    strcat(fname, member);
+                    strcat(fname, ")");
                 } else
                     errno = ENOMEM;
+                dl->dli_fname = fname;
             } else
                 errno = ENOMEM;
         } else {

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -336,7 +336,7 @@ static int dladdr(void *ptr, Dl_info *dl)
     unsigned int found = 0;
     struct ld_info *ldinfos, *next_ldi, *this_ldi;
 
-    if ((ldinfos = (struct ld_info *)OPENSSL_malloc(DLFCN_LDINFO_SIZE)) == NULL) {
+    if ((ldinfos = OPENSSL_malloc(DLFCN_LDINFO_SIZE)) == NULL) {
         errno = ENOMEM;
         dl->dli_fname = NULL;
         return 0;
@@ -365,9 +365,9 @@ static int dladdr(void *ptr, Dl_info *dl)
                             this_ldi->ldinfo_datasize)))) {
             char *buffer, *member;
             size_t buffer_sz, member_len;
+
             buffer_sz = strlen(this_ldi->ldinfo_filename) + 1;
-            member = (char *)((uintptr_t)this_ldi->ldinfo_filename +
-                              buffer_sz);
+            member = this_ldi->ldinfo_filename + buffer_sz;
             if ((member_len = strlen(member)) > 0)
                 buffer_sz += 1 + member_len + 1;
             found = 1;

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -48,7 +48,12 @@ typedef void *SHLIB_SYM;
 
 static int shlib_load(const char *filename, SHLIB *lib)
 {
-    *lib = dlopen(filename, RTLD_GLOBAL | RTLD_LAZY);
+    int dl_flags = (RTLD_GLOBAL|RTLD_LAZY);
+#ifdef _AIX
+    if (filename[strlen(filename) - 1] == ')')
+        dl_flags |= RTLD_MEMBER;
+#endif
+    *lib = dlopen(filename, dl_flags);
     return *lib == NULL ? 0 : 1;
 }
 


### PR DESCRIPTION
This is updating the dladdr() implementation for AIX in order to find the shared libraries, which are now stored as members of library archives.

Fixes #6368 
Fixes #6439 

( and has been asked for again in #6912 )
