### PR TITLE
Ignore EPIPE when sending NewSessionTickets in TLSv1.3

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -939,8 +939,23 @@ WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
         break;
 
     case TLS_ST_SW_SESSION_TICKET:
-        if (SSL_IS_TLS13(s) && statem_flush(s) != 1)
+        if (SSL_IS_TLS13(s) && statem_flush(s) != 1) {
+#ifdef EPIPE
+            if (SSL_get_error(s, 0) == SSL_ERROR_SYSCALL
+                    && get_last_sys_error() == EPIPE) {
+                /*
+                 * We ignore EPIPE in TLSv1.3 when sending a NewSessionTicket
+                 * and behave as if we were successful. This is so that we are
+                 * still able to read data sent to us by a client that closes
+                 * soon after the end of the handshake without waiting to read
+                 * our post-handshake NewSessionTickets.
+                 */
+                s->rwstate = SSL_NOTHING;
+                break;
+            }
+#endif
             return WORK_MORE_A;
+        }
         break;
     }
 


### PR DESCRIPTION
If a client sends data to a server and then immediately closes without
waiting to read the NewSessionTickets then the server can receive EPIPE
when trying to write the tickets and never gets the opportunity to read
the data that was sent. Therefore we ignore EPIPE when writing out the
tickets in TLSv1.3

Fixes #6904

