### PR TITLE
Deallocate previously loaded SSL CONF module data

### DIFF
--- a/crypto/conf/conf_ssl.c
+++ b/crypto/conf/conf_ssl.c
@@ -76,6 +76,7 @@ static int ssl_module_init(CONF_IMODULE *md, const CONF *cnf)
         goto err;
     }
     cnt = sk_CONF_VALUE_num(cmd_lists);
+    ssl_module_free(md);
     ssl_names = OPENSSL_zalloc(sizeof(*ssl_names) * cnt);
     ssl_names_count = cnt;
     for (i = 0; i < ssl_names_count; i++) {


### PR DESCRIPTION
If application explicitly calls CONF_modules_load_file() the SSL
conf module will be initialized twice and the module data would leak.
We need to free it before initializing it again.

Fixes #6835

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
