### PR TITLE
crypto/ocsp/ocsp_srv.c: add missing check for EVP_MD_CTX_new()

### DIFF
--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -234,6 +234,9 @@ int OCSP_basic_sign(OCSP_BASICRESP *brsp,
                     STACK_OF(X509) *certs, unsigned long flags)
 {
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return 0;
+    
     EVP_PKEY_CTX *pkctx = NULL;
     int i;
 


### PR DESCRIPTION
Function EVP_MD_CTX_new() may return NULL on failure, add nptr checking.
Fixes #6973 
