### PR TITLE
Remove redundant ASN1_INTEGER_set call

### DIFF
--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -134,7 +134,6 @@ int PKCS7_set_type(PKCS7 *p7, int type)
         if ((p7->d.signed_and_enveloped = PKCS7_SIGN_ENVELOPE_new())
             == NULL)
             goto err;
-        ASN1_INTEGER_set(p7->d.signed_and_enveloped->version, 1);
         if (!ASN1_INTEGER_set(p7->d.signed_and_enveloped->version, 1))
             goto err;
         p7->d.signed_and_enveloped->enc_data->content_type


### PR DESCRIPTION
This trivial patch removes a duplicated call to ASN1_INTEGER_set.

Fixes Issue #6977

Signed-off-by: Eric Brown <browne@vmware.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

