### PR TITLE
ssl/s23_clnt.c: set TLS version to 0 in msg_callback for record messages

### DIFF
--- a/ssl/s23_clnt.c
+++ b/ssl/s23_clnt.c
@@ -606,7 +606,7 @@ static int ssl23_client_hello(SSL *s)
             s->msg_callback(1, SSL2_VERSION, 0, s->init_buf->data + 2,
                             ret - 2, s, s->msg_callback_arg);
         else {
-            s->msg_callback(1, version, SSL3_RT_HEADER, s->init_buf->data, 5,
+            s->msg_callback(1, 0, SSL3_RT_HEADER, s->init_buf->data, 5,
                             s, s->msg_callback_arg);
             s->msg_callback(1, version, SSL3_RT_HANDSHAKE,
                             s->init_buf->data + 5, ret - 5, s,
@@ -792,7 +792,7 @@ static int ssl23_get_server_hello(SSL *s)
             }
 
             if (s->msg_callback) {
-                s->msg_callback(0, s->version, SSL3_RT_HEADER, p, 5, s,
+                s->msg_callback(0, 0, SSL3_RT_HEADER, p, 5, s,
                                 s->msg_callback_arg);
                 s->msg_callback(0, s->version, SSL3_RT_ALERT, p + 5, 2, s,
                                 s->msg_callback_arg);


### PR DESCRIPTION
In some cases, the msg_callback was invoked on the record protocol
messages without setting the version to zero.
This confuses the applications which then misinterpret the record's
content.
Eg. the record layer ContentType value 22 (handshake) gets mistakenly
interpreted as HandshakeType value 22 (certificate_status).

This was fixed in 1.1 and above by the version negotiation rewrite
(a3680c8f9c33d4190c367572645980ccdb9d5bbf)
