### PR TITLE
Avoid shadowing 'free' in X509_LOOKUP_met_set_free

### DIFF
--- a/crypto/x509/x509_meth.c
+++ b/crypto/x509/x509_meth.c
@@ -58,9 +58,9 @@ int (*X509_LOOKUP_meth_get_new_item(const X509_LOOKUP_METHOD* method))
 
 int X509_LOOKUP_meth_set_free(
     X509_LOOKUP_METHOD *method,
-    void (*free) (X509_LOOKUP *ctx))
+    void (*free_fn) (X509_LOOKUP *ctx))
 {
-    method->free = free;
+    method->free = free_fn;
     return 1;
 }
 

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -401,7 +401,7 @@ int (*X509_LOOKUP_meth_get_new_item(const X509_LOOKUP_METHOD* method))
     (X509_LOOKUP *ctx);
 
 int X509_LOOKUP_meth_set_free(X509_LOOKUP_METHOD *method,
-                              void (*free) (X509_LOOKUP *ctx));
+                              void (*free_fn) (X509_LOOKUP *ctx));
 void (*X509_LOOKUP_meth_get_free(const X509_LOOKUP_METHOD* method))
     (X509_LOOKUP *ctx);
 


### PR DESCRIPTION
gcc 4.6 (arguably erroneously) warns about our use of 'free' as
the name of a function parameter, when --strict-warnings is enabled:

crypto/x509/x509_meth.c: In function 'X509_LOOKUP_meth_set_free':
crypto/x509/x509_meth.c:61:12: error: declaration of 'free' shadows a global declaration [-Werror=shadow]
cc1: all warnings being treated as errors
make[1]: *** [crypto/x509/x509_meth.o] Error 1

(gcc 4.8 is fine with this code, as are newer compilers.)

%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

One might argue about changing the name of the parameter in the public header,
of course.  In particular projects that bundle (old versions of) our headers into their
projects would likely experience build failure on the conflicting definition.