### PR TITLE
asn1/ans_moid.c: overhaul do_create.

### DIFF
--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -64,7 +64,7 @@ static int do_create(const char *value, const char *name)
     char *lntmp = NULL;
 
     p = strrchr(value, ',');
-    if (p != NULL) {
+    if (p == NULL) {
         ln = name;
         ostr = value;
     } else {

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -60,29 +60,20 @@ void ASN1_add_oid_module(void)
 static int do_create(const char *value, const char *name)
 {
     int nid;
-    ASN1_OBJECT *oid;
     const char *ln, *ostr, *p;
-    char *lntmp;
+    char *lntmp = NULL;
+
     p = strrchr(value, ',');
-    if (!p) {
+    if (p != NULL) {
         ln = name;
         ostr = value;
     } else {
-        ln = NULL;
+        ln = value;
         ostr = p + 1;
-        if (!*ostr)
+        if (*ostr == '\0')
             return 0;
         while (ossl_isspace(*ostr))
             ostr++;
-    }
-
-    nid = OBJ_create(ostr, name, ln);
-
-    if (nid == NID_undef)
-        return 0;
-
-    if (p) {
-        ln = value;
         while (ossl_isspace(*ln))
             ln++;
         p--;
@@ -97,10 +88,13 @@ static int do_create(const char *value, const char *name)
             return 0;
         }
         memcpy(lntmp, ln, p - ln);
-        lntmp[p - ln] = 0;
-        oid = OBJ_nid2obj(nid);
-        oid->ln = lntmp;
+        lntmp[p - ln] = '\0';
+        ln = lntmp;
     }
 
-    return 1;
+    nid = OBJ_create(ostr, name, ln);
+
+    OPENSSL_free(lntmp);
+
+    return nid != NID_undef;
 }

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -84,7 +84,8 @@ OBJ_dup() returns a copy of B<o>.
 
 OBJ_create() adds a new object to the internal table. B<oid> is the
 numerical form of the object, B<sn> the short name and B<ln> the
-long name. A new NID is returned for the created object.
+long name. A new NID is returned for the created object in case of
+success and NID_undef in case of failure.
 
 OBJ_length() returns the size of the content octets of B<obj>.
 


### PR DESCRIPTION
Original could allocate nid and then bail out on malloc failure. Instead
allocate first *then* attempt to create object.

Triggered by #6982.