### PR TITLE
Do not ignore EVP_PKEY_print_public/EVP_PKEY_print_private return values

### DIFF
--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -186,23 +186,29 @@ int pkey_main(int argc, char **argv)
     if (!noout) {
         if (outformat == FORMAT_PEM) {
             if (pubout) {
-                PEM_write_bio_PUBKEY(out, pkey);
+                if (!PEM_write_bio_PUBKEY(out, pkey))
+                    goto end;
             } else {
                 assert(private);
-                if (traditional)
-                    PEM_write_bio_PrivateKey_traditional(out, pkey, cipher,
+                if (traditional) {
+                    if (!PEM_write_bio_PrivateKey_traditional(out, pkey, cipher,
                                                          NULL, 0, NULL,
-                                                         passout);
-                else
-                    PEM_write_bio_PrivateKey(out, pkey, cipher,
-                                             NULL, 0, NULL, passout);
+                                                         passout))
+                        goto end;
+                } else {
+                    if (!PEM_write_bio_PrivateKey(out, pkey, cipher,
+                                             NULL, 0, NULL, passout))
+                        goto end;
+                }
             }
         } else if (outformat == FORMAT_ASN1) {
             if (pubout) {
-                i2d_PUBKEY_bio(out, pkey);
+                if (!i2d_PUBKEY_bio(out, pkey))
+                    goto end;
             } else {
                 assert(private);
-                i2d_PrivateKey_bio(out, pkey);
+                if (!i2d_PrivateKey_bio(out, pkey))
+                    goto end;
             }
         } else {
             BIO_printf(bio_err, "Bad format specified for key\n");

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -212,10 +212,12 @@ int pkey_main(int argc, char **argv)
 
     if (text) {
         if (pubtext) {
-            EVP_PKEY_print_public(out, pkey, 0, NULL);
+            if (EVP_PKEY_print_public(out, pkey, 0, NULL) <= 0)
+                goto end;
         } else {
             assert(private);
-            EVP_PKEY_print_private(out, pkey, 0, NULL);
+            if (EVP_PKEY_print_private(out, pkey, 0, NULL) <= 0)
+                goto end;
         }
     }
 

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -192,12 +192,12 @@ int pkey_main(int argc, char **argv)
                 assert(private);
                 if (traditional) {
                     if (!PEM_write_bio_PrivateKey_traditional(out, pkey, cipher,
-                                                         NULL, 0, NULL,
-                                                         passout))
+                                                              NULL, 0, NULL,
+                                                              passout))
                         goto end;
                 } else {
                     if (!PEM_write_bio_PrivateKey(out, pkey, cipher,
-                                             NULL, 0, NULL, passout))
+                                                  NULL, 0, NULL, passout))
                         goto end;
                 }
             }


### PR DESCRIPTION
openssl pkey command ignored the return codes of EVP_PKEY_print_public/EVP_PKEY_print_private

This commit provides the missing checks.