### PR TITLE
Zero memory in CRYPTO_secure_malloc.

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -138,16 +138,11 @@ void *CRYPTO_secure_malloc(size_t num, const char *file, int line)
 void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
 {
 #ifdef IMPLEMENTED
-    if (!secure_mem_initialized)
-        return CRYPTO_zalloc(num, file, line);
-    return CRYPTO_secure_malloc(num, file, line);
-#else
-    void *ret = CRYPTO_secure_malloc(num, file, line);
-
-    if (ret != NULL)
-        memset(ret, 0, num);
-    return ret;
+    if (secure_mem_initialized)
+        /* CRYPTO_secure_malloc() zeroes allocations when it is implemented */
+        return CRYPTO_secure_malloc(num, file, line);
 #endif
+    return CRYPTO_zalloc(num, file, line);
 }
 
 void CRYPTO_secure_free(void *ptr, const char *file, int line)


### PR DESCRIPTION
The destroys the free list pointers that would otherwise be present in the return memory block.  This in turn help prevent information leakage from the secure memory area.

Fixes: #6989

- [x] tests are added or updated
