### PR TITLE
[1.1.0] Backport #6648 to OpenSSL_1_1_0-stable

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -382,30 +382,32 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         return EC_POINT_set_to_infinity(group, r);
     }
 
-    /*-
-     * Handle the common cases where the scalar is secret, enforcing a constant
-     * time scalar multiplication algorithm.
-     */
-    if ((scalar != NULL) && (num == 0)) {
+    if (!BN_is_zero(group->order) && !BN_is_zero(group->cofactor)) {
         /*-
-         * In this case we want to compute scalar * GeneratorPoint: this
-         * codepath is reached most prominently by (ephemeral) key generation
-         * of EC cryptosystems (i.e. ECDSA keygen and sign setup, ECDH
-         * keygen/first half), where the scalar is always secret. This is why
-         * we ignore if BN_FLG_CONSTTIME is actually set and we always call the
-         * constant time version.
+         * Handle the common cases where the scalar is secret, enforcing a constant
+         * time scalar multiplication algorithm.
          */
-        return ec_mul_consttime(group, r, scalar, NULL, ctx);
-    }
-    if ((scalar == NULL) && (num == 1)) {
-        /*-
-         * In this case we want to compute scalar * GenericPoint: this codepath
-         * is reached most prominently by the second half of ECDH, where the
-         * secret scalar is multiplied by the peer's public point. To protect
-         * the secret scalar, we ignore if BN_FLG_CONSTTIME is actually set and
-         * we always call the constant time version.
-         */
-        return ec_mul_consttime(group, r, scalars[0], points[0], ctx);
+        if ((scalar != NULL) && (num == 0)) {
+            /*-
+             * In this case we want to compute scalar * GeneratorPoint: this
+             * codepath is reached most prominently by (ephemeral) key generation
+             * of EC cryptosystems (i.e. ECDSA keygen and sign setup, ECDH
+             * keygen/first half), where the scalar is always secret. This is why
+             * we ignore if BN_FLG_CONSTTIME is actually set and we always call the
+             * constant time version.
+             */
+            return ec_mul_consttime(group, r, scalar, NULL, ctx);
+        }
+        if ((scalar == NULL) && (num == 1)) {
+            /*-
+             * In this case we want to compute scalar * GenericPoint: this codepath
+             * is reached most prominently by the second half of ECDH, where the
+             * secret scalar is multiplied by the peer's public point. To protect
+             * the secret scalar, we ignore if BN_FLG_CONSTTIME is actually set and
+             * we always call the constant time version.
+             */
+            return ec_mul_consttime(group, r, scalars[0], points[0], ctx);
+        }
     }
 
     for (i = 0; i < num; i++) {


### PR DESCRIPTION
We forgot to backport #6648 to 1.1.0 stable.

The original PR cherry-pciked cleanly to 1.1.0, so I'm not entirely sure if this PR is required or superfluous.

Fixes #7012  