### PR TITLE
Don't open random devices while cleaning up.

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -31,6 +31,8 @@ int rand_fork_count;
 static CRYPTO_RWLOCK *rand_nonce_lock;
 static int rand_nonce_count;
 
+static int rand_cleaning_up = 0;
+
 #ifdef OPENSSL_RAND_SEED_RDTSC
 /*
  * IMPORTANT NOTE:  It is not currently possible to use this code
@@ -324,8 +326,9 @@ DEFINE_RUN_ONCE_STATIC(do_rand_init)
     if (rand_nonce_lock == NULL)
         goto err2;
 
-    if (!rand_pool_init())
-        goto err3;
+    if (!rand_cleaning_up)
+        if (!rand_pool_init())
+            goto err3;
 
     return 1;
 
@@ -346,10 +349,12 @@ void rand_cleanup_int(void)
 {
     const RAND_METHOD *meth = default_RAND_meth;
 
+    rand_cleaning_up = 1;
+
     if (meth != NULL && meth->cleanup != NULL)
         meth->cleanup();
-    rand_pool_cleanup();
     RAND_set_rand_method(NULL);
+    rand_pool_cleanup();
 #ifndef OPENSSL_NO_ENGINE
     CRYPTO_THREAD_lock_free(rand_engine_lock);
     rand_engine_lock = NULL;

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -326,9 +326,8 @@ DEFINE_RUN_ONCE_STATIC(do_rand_init)
     if (rand_nonce_lock == NULL)
         goto err2;
 
-    if (!rand_cleaning_up)
-        if (!rand_pool_init())
-            goto err3;
+    if (!rand_cleaning_up && !rand_pool_init())
+        goto err3;
 
     return 1;
 


### PR DESCRIPTION
Fixes #7022

In pull request #6432 a change was made to keep the handles to the
random devices opened in order to avoid reseeding problems for
applications in chroot environments.

As a consequence, the handles of the random devices were leaked at exit
if the random generator was not used by the application. This happened,
because the call to RAND_set_rand_method(NULL) in rand_cleanup_int()
triggered a call to the call_once function do_rand_init, which opened
the random devices via rand_pool_init(void).

Thanks to GitHub user @bwelling for reporting this issue.