### PR TITLE
[test] ECC: make sure negative tests pass for the right reasons

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -757,6 +757,10 @@ int EC_POINT_get_affine_coordinates(const EC_GROUP *group,
         ECerr(EC_F_EC_POINT_GET_AFFINE_COORDINATES, EC_R_INCOMPATIBLE_OBJECTS);
         return 0;
     }
+    if (EC_POINT_is_at_infinity(group, point)) {
+        ECerr(EC_F_EC_POINT_GET_AFFINE_COORDINATES, EC_R_POINT_AT_INFINITY);
+        return 0;
+    }
     return group->meth->point_get_affine_coordinates(group, point, x, y, ctx);
 }
 

--- a/test/recipes/30-test_evp_data/evppkey.txt
+++ b/test/recipes/30-test_evp_data/evppkey.txt
@@ -17286,6 +17286,8 @@ Derive=ALICE_cf_sect283k1
 PeerKey=BOB_cf_sect283k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result = DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title = Test keypair mismatches
 

--- a/test/recipes/30-test_evp_data/evppkey.txt
+++ b/test/recipes/30-test_evp_data/evppkey.txt
@@ -17286,7 +17286,7 @@ Derive=ALICE_cf_sect283k1
 PeerKey=BOB_cf_sect283k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result = DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title = Test keypair mismatches

--- a/test/recipes/30-test_evp_data/evppkey_ecc.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecc.txt
@@ -623,7 +623,7 @@ Derive=BOB_cf_c2pnb163v1
 PeerKey=MALICE_cf_c2pnb163v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -631,7 +631,7 @@ Derive=ALICE_cf_c2pnb163v1
 PeerKey=MALICE_cf_c2pnb163v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb163v2 curve tests
@@ -695,7 +695,7 @@ Derive=BOB_cf_c2pnb163v2
 PeerKey=MALICE_cf_c2pnb163v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -703,7 +703,7 @@ Derive=ALICE_cf_c2pnb163v2
 PeerKey=MALICE_cf_c2pnb163v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb163v3 curve tests
@@ -767,7 +767,7 @@ Derive=BOB_cf_c2pnb163v3
 PeerKey=MALICE_cf_c2pnb163v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -775,7 +775,7 @@ Derive=ALICE_cf_c2pnb163v3
 PeerKey=MALICE_cf_c2pnb163v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb176v1 curve tests
@@ -839,7 +839,7 @@ Derive=BOB_cf_c2pnb176v1
 PeerKey=MALICE_cf_c2pnb176v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -847,7 +847,7 @@ Derive=ALICE_cf_c2pnb176v1
 PeerKey=MALICE_cf_c2pnb176v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb208w1 curve tests
@@ -913,7 +913,7 @@ Derive=BOB_cf_c2pnb208w1
 PeerKey=MALICE_cf_c2pnb208w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -921,7 +921,7 @@ Derive=ALICE_cf_c2pnb208w1
 PeerKey=MALICE_cf_c2pnb208w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb272w1 curve tests
@@ -987,7 +987,7 @@ Derive=BOB_cf_c2pnb272w1
 PeerKey=MALICE_cf_c2pnb272w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -995,7 +995,7 @@ Derive=ALICE_cf_c2pnb272w1
 PeerKey=MALICE_cf_c2pnb272w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb304w1 curve tests
@@ -1061,7 +1061,7 @@ Derive=BOB_cf_c2pnb304w1
 PeerKey=MALICE_cf_c2pnb304w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1069,7 +1069,7 @@ Derive=ALICE_cf_c2pnb304w1
 PeerKey=MALICE_cf_c2pnb304w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2pnb368w1 curve tests
@@ -1138,7 +1138,7 @@ Derive=BOB_cf_c2pnb368w1
 PeerKey=MALICE_cf_c2pnb368w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1146,7 +1146,7 @@ Derive=ALICE_cf_c2pnb368w1
 PeerKey=MALICE_cf_c2pnb368w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb191v1 curve tests
@@ -1212,7 +1212,7 @@ Derive=BOB_cf_c2tnb191v1
 PeerKey=MALICE_cf_c2tnb191v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1220,7 +1220,7 @@ Derive=ALICE_cf_c2tnb191v1
 PeerKey=MALICE_cf_c2tnb191v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb191v2 curve tests
@@ -1286,7 +1286,7 @@ Derive=BOB_cf_c2tnb191v2
 PeerKey=MALICE_cf_c2tnb191v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1294,7 +1294,7 @@ Derive=ALICE_cf_c2tnb191v2
 PeerKey=MALICE_cf_c2tnb191v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb191v3 curve tests
@@ -1360,7 +1360,7 @@ Derive=BOB_cf_c2tnb191v3
 PeerKey=MALICE_cf_c2tnb191v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1368,7 +1368,7 @@ Derive=ALICE_cf_c2tnb191v3
 PeerKey=MALICE_cf_c2tnb191v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb239v1 curve tests
@@ -1434,7 +1434,7 @@ Derive=BOB_cf_c2tnb239v1
 PeerKey=MALICE_cf_c2tnb239v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1442,7 +1442,7 @@ Derive=ALICE_cf_c2tnb239v1
 PeerKey=MALICE_cf_c2tnb239v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb239v2 curve tests
@@ -1508,7 +1508,7 @@ Derive=BOB_cf_c2tnb239v2
 PeerKey=MALICE_cf_c2tnb239v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1516,7 +1516,7 @@ Derive=ALICE_cf_c2tnb239v2
 PeerKey=MALICE_cf_c2tnb239v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb239v3 curve tests
@@ -1582,7 +1582,7 @@ Derive=BOB_cf_c2tnb239v3
 PeerKey=MALICE_cf_c2tnb239v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1590,7 +1590,7 @@ Derive=ALICE_cf_c2tnb239v3
 PeerKey=MALICE_cf_c2tnb239v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb359v1 curve tests
@@ -1659,7 +1659,7 @@ Derive=BOB_cf_c2tnb359v1
 PeerKey=MALICE_cf_c2tnb359v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1667,7 +1667,7 @@ Derive=ALICE_cf_c2tnb359v1
 PeerKey=MALICE_cf_c2tnb359v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=c2tnb431r1 curve tests
@@ -1736,7 +1736,7 @@ Derive=BOB_cf_c2tnb431r1
 PeerKey=MALICE_cf_c2tnb431r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -1744,7 +1744,7 @@ Derive=ALICE_cf_c2tnb431r1
 PeerKey=MALICE_cf_c2tnb431r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=prime192v1 curve tests
@@ -2121,7 +2121,7 @@ Derive=BOB_cf_secp112r2
 PeerKey=MALICE_cf_secp112r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GFp_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2129,7 +2129,7 @@ Derive=ALICE_cf_secp112r2
 PeerKey=MALICE_cf_secp112r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GFp_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=secp128r1 curve tests
@@ -2226,7 +2226,7 @@ Derive=BOB_cf_secp128r2
 PeerKey=MALICE_cf_secp128r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GFp_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2234,7 +2234,7 @@ Derive=ALICE_cf_secp128r2
 PeerKey=MALICE_cf_secp128r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GFp_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=secp160k1 curve tests
@@ -2651,7 +2651,7 @@ Derive=BOB_cf_sect113r1
 PeerKey=MALICE_cf_sect113r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2659,7 +2659,7 @@ Derive=ALICE_cf_sect113r1
 PeerKey=MALICE_cf_sect113r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect113r2 curve tests
@@ -2720,7 +2720,7 @@ Derive=BOB_cf_sect113r2
 PeerKey=MALICE_cf_sect113r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2728,7 +2728,7 @@ Derive=ALICE_cf_sect113r2
 PeerKey=MALICE_cf_sect113r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect131r1 curve tests
@@ -2792,7 +2792,7 @@ Derive=BOB_cf_sect131r1
 PeerKey=MALICE_cf_sect131r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2800,7 +2800,7 @@ Derive=ALICE_cf_sect131r1
 PeerKey=MALICE_cf_sect131r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect131r2 curve tests
@@ -2864,7 +2864,7 @@ Derive=BOB_cf_sect131r2
 PeerKey=MALICE_cf_sect131r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2872,7 +2872,7 @@ Derive=ALICE_cf_sect131r2
 PeerKey=MALICE_cf_sect131r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect163k1 curve tests
@@ -2936,7 +2936,7 @@ Derive=BOB_cf_sect163k1
 PeerKey=MALICE_cf_sect163k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -2944,7 +2944,7 @@ Derive=ALICE_cf_sect163k1
 PeerKey=MALICE_cf_sect163k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect163r1 curve tests
@@ -3008,7 +3008,7 @@ Derive=BOB_cf_sect163r1
 PeerKey=MALICE_cf_sect163r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3016,7 +3016,7 @@ Derive=ALICE_cf_sect163r1
 PeerKey=MALICE_cf_sect163r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect163r2 curve tests
@@ -3080,7 +3080,7 @@ Derive=BOB_cf_sect163r2
 PeerKey=MALICE_cf_sect163r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3088,7 +3088,7 @@ Derive=ALICE_cf_sect163r2
 PeerKey=MALICE_cf_sect163r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect193r1 curve tests
@@ -3152,7 +3152,7 @@ Derive=BOB_cf_sect193r1
 PeerKey=MALICE_cf_sect193r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3160,7 +3160,7 @@ Derive=ALICE_cf_sect193r1
 PeerKey=MALICE_cf_sect193r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect193r2 curve tests
@@ -3224,7 +3224,7 @@ Derive=BOB_cf_sect193r2
 PeerKey=MALICE_cf_sect193r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3232,7 +3232,7 @@ Derive=ALICE_cf_sect193r2
 PeerKey=MALICE_cf_sect193r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect233k1 curve tests
@@ -3298,7 +3298,7 @@ Derive=BOB_cf_sect233k1
 PeerKey=MALICE_cf_sect233k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3306,7 +3306,7 @@ Derive=ALICE_cf_sect233k1
 PeerKey=MALICE_cf_sect233k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect233r1 curve tests
@@ -3372,7 +3372,7 @@ Derive=BOB_cf_sect233r1
 PeerKey=MALICE_cf_sect233r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3380,7 +3380,7 @@ Derive=ALICE_cf_sect233r1
 PeerKey=MALICE_cf_sect233r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect239k1 curve tests
@@ -3446,7 +3446,7 @@ Derive=BOB_cf_sect239k1
 PeerKey=MALICE_cf_sect239k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3454,7 +3454,7 @@ Derive=ALICE_cf_sect239k1
 PeerKey=MALICE_cf_sect239k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect283k1 curve tests
@@ -3520,7 +3520,7 @@ Derive=BOB_cf_sect283k1
 PeerKey=MALICE_cf_sect283k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3528,7 +3528,7 @@ Derive=ALICE_cf_sect283k1
 PeerKey=MALICE_cf_sect283k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect283r1 curve tests
@@ -3594,7 +3594,7 @@ Derive=BOB_cf_sect283r1
 PeerKey=MALICE_cf_sect283r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3602,7 +3602,7 @@ Derive=ALICE_cf_sect283r1
 PeerKey=MALICE_cf_sect283r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect409k1 curve tests
@@ -3671,7 +3671,7 @@ Derive=BOB_cf_sect409k1
 PeerKey=MALICE_cf_sect409k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3679,7 +3679,7 @@ Derive=ALICE_cf_sect409k1
 PeerKey=MALICE_cf_sect409k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect409r1 curve tests
@@ -3748,7 +3748,7 @@ Derive=BOB_cf_sect409r1
 PeerKey=MALICE_cf_sect409r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3756,7 +3756,7 @@ Derive=ALICE_cf_sect409r1
 PeerKey=MALICE_cf_sect409r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect571k1 curve tests
@@ -3825,7 +3825,7 @@ Derive=BOB_cf_sect571k1
 PeerKey=MALICE_cf_sect571k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3833,7 +3833,7 @@ Derive=ALICE_cf_sect571k1
 PeerKey=MALICE_cf_sect571k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=sect571r1 curve tests
@@ -3902,7 +3902,7 @@ Derive=BOB_cf_sect571r1
 PeerKey=MALICE_cf_sect571r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3910,7 +3910,7 @@ Derive=ALICE_cf_sect571r1
 PeerKey=MALICE_cf_sect571r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls10 curve tests
@@ -3976,7 +3976,7 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls10
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -3984,7 +3984,7 @@ Derive=ALICE_cf_wap-wsg-idm-ecid-wtls10
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls11 curve tests
@@ -4050,7 +4050,7 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls11
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -4058,7 +4058,7 @@ Derive=ALICE_cf_wap-wsg-idm-ecid-wtls11
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls12 curve tests
@@ -4159,7 +4159,7 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls1
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -4167,7 +4167,7 @@ Derive=ALICE_cf_wap-wsg-idm-ecid-wtls1
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls3 curve tests
@@ -4231,7 +4231,7 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls3
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -4239,7 +4239,7 @@ Derive=ALICE_cf_wap-wsg-idm-ecid-wtls3
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls4 curve tests
@@ -4300,7 +4300,7 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls4
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -4308,7 +4308,7 @@ Derive=ALICE_cf_wap-wsg-idm-ecid-wtls4
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls5 curve tests
@@ -4372,7 +4372,7 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls5
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
@@ -4380,7 +4380,7 @@ Derive=ALICE_cf_wap-wsg-idm-ecid-wtls5
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
-Function=ec_GF2m_simple_point_get_affine_coordinates
+Function=EC_POINT_get_affine_coordinates
 Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls6 curve tests

--- a/test/recipes/30-test_evp_data/evppkey_ecc.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecc.txt
@@ -623,12 +623,16 @@ Derive=BOB_cf_c2pnb163v1
 PeerKey=MALICE_cf_c2pnb163v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb163v1
 PeerKey=MALICE_cf_c2pnb163v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb163v2 curve tests
 
@@ -691,12 +695,16 @@ Derive=BOB_cf_c2pnb163v2
 PeerKey=MALICE_cf_c2pnb163v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb163v2
 PeerKey=MALICE_cf_c2pnb163v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb163v3 curve tests
 
@@ -759,12 +767,16 @@ Derive=BOB_cf_c2pnb163v3
 PeerKey=MALICE_cf_c2pnb163v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb163v3
 PeerKey=MALICE_cf_c2pnb163v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb176v1 curve tests
 
@@ -827,12 +839,16 @@ Derive=BOB_cf_c2pnb176v1
 PeerKey=MALICE_cf_c2pnb176v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb176v1
 PeerKey=MALICE_cf_c2pnb176v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb208w1 curve tests
 
@@ -897,12 +913,16 @@ Derive=BOB_cf_c2pnb208w1
 PeerKey=MALICE_cf_c2pnb208w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb208w1
 PeerKey=MALICE_cf_c2pnb208w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb272w1 curve tests
 
@@ -967,12 +987,16 @@ Derive=BOB_cf_c2pnb272w1
 PeerKey=MALICE_cf_c2pnb272w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb272w1
 PeerKey=MALICE_cf_c2pnb272w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb304w1 curve tests
 
@@ -1037,12 +1061,16 @@ Derive=BOB_cf_c2pnb304w1
 PeerKey=MALICE_cf_c2pnb304w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb304w1
 PeerKey=MALICE_cf_c2pnb304w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2pnb368w1 curve tests
 
@@ -1110,12 +1138,16 @@ Derive=BOB_cf_c2pnb368w1
 PeerKey=MALICE_cf_c2pnb368w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2pnb368w1
 PeerKey=MALICE_cf_c2pnb368w1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb191v1 curve tests
 
@@ -1180,12 +1212,16 @@ Derive=BOB_cf_c2tnb191v1
 PeerKey=MALICE_cf_c2tnb191v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb191v1
 PeerKey=MALICE_cf_c2tnb191v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb191v2 curve tests
 
@@ -1250,12 +1286,16 @@ Derive=BOB_cf_c2tnb191v2
 PeerKey=MALICE_cf_c2tnb191v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb191v2
 PeerKey=MALICE_cf_c2tnb191v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb191v3 curve tests
 
@@ -1320,12 +1360,16 @@ Derive=BOB_cf_c2tnb191v3
 PeerKey=MALICE_cf_c2tnb191v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb191v3
 PeerKey=MALICE_cf_c2tnb191v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb239v1 curve tests
 
@@ -1390,12 +1434,16 @@ Derive=BOB_cf_c2tnb239v1
 PeerKey=MALICE_cf_c2tnb239v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb239v1
 PeerKey=MALICE_cf_c2tnb239v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb239v2 curve tests
 
@@ -1460,12 +1508,16 @@ Derive=BOB_cf_c2tnb239v2
 PeerKey=MALICE_cf_c2tnb239v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb239v2
 PeerKey=MALICE_cf_c2tnb239v2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb239v3 curve tests
 
@@ -1530,12 +1582,16 @@ Derive=BOB_cf_c2tnb239v3
 PeerKey=MALICE_cf_c2tnb239v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb239v3
 PeerKey=MALICE_cf_c2tnb239v3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb359v1 curve tests
 
@@ -1603,12 +1659,16 @@ Derive=BOB_cf_c2tnb359v1
 PeerKey=MALICE_cf_c2tnb359v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb359v1
 PeerKey=MALICE_cf_c2tnb359v1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=c2tnb431r1 curve tests
 
@@ -1676,12 +1736,16 @@ Derive=BOB_cf_c2tnb431r1
 PeerKey=MALICE_cf_c2tnb431r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_c2tnb431r1
 PeerKey=MALICE_cf_c2tnb431r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=prime192v1 curve tests
 
@@ -2057,12 +2121,16 @@ Derive=BOB_cf_secp112r2
 PeerKey=MALICE_cf_secp112r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GFp_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_secp112r2
 PeerKey=MALICE_cf_secp112r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GFp_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=secp128r1 curve tests
 
@@ -2158,12 +2226,16 @@ Derive=BOB_cf_secp128r2
 PeerKey=MALICE_cf_secp128r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GFp_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_secp128r2
 PeerKey=MALICE_cf_secp128r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GFp_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=secp160k1 curve tests
 
@@ -2579,12 +2651,16 @@ Derive=BOB_cf_sect113r1
 PeerKey=MALICE_cf_sect113r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect113r1
 PeerKey=MALICE_cf_sect113r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect113r2 curve tests
 
@@ -2644,12 +2720,16 @@ Derive=BOB_cf_sect113r2
 PeerKey=MALICE_cf_sect113r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect113r2
 PeerKey=MALICE_cf_sect113r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect131r1 curve tests
 
@@ -2712,12 +2792,16 @@ Derive=BOB_cf_sect131r1
 PeerKey=MALICE_cf_sect131r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect131r1
 PeerKey=MALICE_cf_sect131r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect131r2 curve tests
 
@@ -2780,12 +2864,16 @@ Derive=BOB_cf_sect131r2
 PeerKey=MALICE_cf_sect131r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect131r2
 PeerKey=MALICE_cf_sect131r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect163k1 curve tests
 
@@ -2848,12 +2936,16 @@ Derive=BOB_cf_sect163k1
 PeerKey=MALICE_cf_sect163k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect163k1
 PeerKey=MALICE_cf_sect163k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect163r1 curve tests
 
@@ -2916,12 +3008,16 @@ Derive=BOB_cf_sect163r1
 PeerKey=MALICE_cf_sect163r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect163r1
 PeerKey=MALICE_cf_sect163r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect163r2 curve tests
 
@@ -2984,12 +3080,16 @@ Derive=BOB_cf_sect163r2
 PeerKey=MALICE_cf_sect163r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect163r2
 PeerKey=MALICE_cf_sect163r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect193r1 curve tests
 
@@ -3052,12 +3152,16 @@ Derive=BOB_cf_sect193r1
 PeerKey=MALICE_cf_sect193r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect193r1
 PeerKey=MALICE_cf_sect193r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect193r2 curve tests
 
@@ -3120,12 +3224,16 @@ Derive=BOB_cf_sect193r2
 PeerKey=MALICE_cf_sect193r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect193r2
 PeerKey=MALICE_cf_sect193r2_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect233k1 curve tests
 
@@ -3190,12 +3298,16 @@ Derive=BOB_cf_sect233k1
 PeerKey=MALICE_cf_sect233k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect233k1
 PeerKey=MALICE_cf_sect233k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect233r1 curve tests
 
@@ -3260,12 +3372,16 @@ Derive=BOB_cf_sect233r1
 PeerKey=MALICE_cf_sect233r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect233r1
 PeerKey=MALICE_cf_sect233r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect239k1 curve tests
 
@@ -3330,12 +3446,16 @@ Derive=BOB_cf_sect239k1
 PeerKey=MALICE_cf_sect239k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect239k1
 PeerKey=MALICE_cf_sect239k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect283k1 curve tests
 
@@ -3400,12 +3520,16 @@ Derive=BOB_cf_sect283k1
 PeerKey=MALICE_cf_sect283k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect283k1
 PeerKey=MALICE_cf_sect283k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect283r1 curve tests
 
@@ -3470,12 +3594,16 @@ Derive=BOB_cf_sect283r1
 PeerKey=MALICE_cf_sect283r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect283r1
 PeerKey=MALICE_cf_sect283r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect409k1 curve tests
 
@@ -3543,12 +3671,16 @@ Derive=BOB_cf_sect409k1
 PeerKey=MALICE_cf_sect409k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect409k1
 PeerKey=MALICE_cf_sect409k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect409r1 curve tests
 
@@ -3616,12 +3748,16 @@ Derive=BOB_cf_sect409r1
 PeerKey=MALICE_cf_sect409r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect409r1
 PeerKey=MALICE_cf_sect409r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect571k1 curve tests
 
@@ -3689,12 +3825,16 @@ Derive=BOB_cf_sect571k1
 PeerKey=MALICE_cf_sect571k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect571k1
 PeerKey=MALICE_cf_sect571k1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=sect571r1 curve tests
 
@@ -3762,12 +3902,16 @@ Derive=BOB_cf_sect571r1
 PeerKey=MALICE_cf_sect571r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_sect571r1
 PeerKey=MALICE_cf_sect571r1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls10 curve tests
 
@@ -3832,12 +3976,16 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls10
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_wap-wsg-idm-ecid-wtls10
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls10_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls11 curve tests
 
@@ -3902,12 +4050,16 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls11
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_wap-wsg-idm-ecid-wtls11
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls11_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls12 curve tests
 
@@ -4007,12 +4159,16 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls1
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_wap-wsg-idm-ecid-wtls1
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls1_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls3 curve tests
 
@@ -4075,12 +4231,16 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls3
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_wap-wsg-idm-ecid-wtls3
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls3_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls4 curve tests
 
@@ -4140,12 +4300,16 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls4
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_wap-wsg-idm-ecid-wtls4
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls4_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls5 curve tests
 
@@ -4208,12 +4372,16 @@ Derive=BOB_cf_wap-wsg-idm-ecid-wtls5
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 # ECC CDH Alice with Malice peer
 Derive=ALICE_cf_wap-wsg-idm-ecid-wtls5
 PeerKey=MALICE_cf_wap-wsg-idm-ecid-wtls5_PUB
 Ctrl=ecdh_cofactor_mode:1
 Result=DERIVE_ERROR
+Function=ec_GF2m_simple_point_get_affine_coordinates
+Reason=point at infinity
 
 Title=wap-wsg-idm-ecid-wtls6 curve tests
 


### PR DESCRIPTION
My team was implementing a custom `EC_METHOD` a while back. Knowing the state of our code, we were expecting the positive tests to pass, but the negative tests from #6608 to fail. But everything was passing. Turns out we were getting `DERIVE_ERROR`, but caused by the wrong function failing.

The negative tests modified in this PR should fail when retrieving the affine coordinates of the point at infinity.