### PR TITLE
Test.pm workaround mitigating Perl abs2rel bug

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -65,6 +65,7 @@ use File::Spec::Functions qw/file_name_is_absolute curdir canonpath splitdir
                              rel2abs/;
 use File::Path 2.00 qw/rmtree mkpath/;
 use File::Basename;
+use Cwd qw/abs_path/;
 
 my $level = 0;
 
@@ -869,8 +870,8 @@ failures will result in a C<BAIL_OUT> at the end of its run.
 sub __env {
     (my $recipe_datadir = basename($0)) =~ s/\.t$/_data/i;
 
-    $directories{SRCTOP}  = $ENV{SRCTOP} || $ENV{TOP};
-    $directories{BLDTOP}  = $ENV{BLDTOP} || $ENV{TOP};
+    $directories{SRCTOP}  = abs_path($ENV{SRCTOP} || $ENV{TOP});
+    $directories{BLDTOP}  = abs_path($ENV{BLDTOP} || $ENV{TOP});
     $directories{BLDAPPS} = $ENV{BIN_D}  || __bldtop_dir("apps");
     $directories{SRCAPPS} =                 __srctop_dir("apps");
     $directories{BLDFUZZ} =                 __bldtop_dir("fuzz");


### PR DESCRIPTION
If SRCTOP != BLDTOP, and SRCTOP is given in relative form, e.g.
"./config ../openssl", then a bug in Perl's abs2rel may trigger that directory-
rewriting in __cwd results in wrong entries in %directories under certain
circumstances, e.g. when a test executes run(app(["openssl"]) after indir.

There should not be any need to go to a higher directory from BLDDIR or SRCDIR,
so it should be OK to use them in their absolute form, also resolving all
possible symlinks, right from the start.

Following the File::Spec::Functions bug description (reported to perl.org):

When abs2rel gets a path argument with ..s that are crossing over the ..s
trailing the base argument, the result is wrong.

Example
PATH: /home/goal/test/..
BASE: /home/goal/test/../../base
Good result: ../goal
Bad  result: ../..

Bug verified with File::Spec versions
- 3.6301
- 3.74 (latest)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
