### PR TITLE
Update X509 public key handler to accept rsaesOaep for 1.0.2

### DIFF
--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -96,6 +96,9 @@ static const EVP_PKEY_ASN1_METHOD *standard_methods[] = {
 #ifndef OPENSSL_NO_CMAC
     &cmac_asn1_meth,
 #endif
+#ifndef OPENSSL_NO_RSA
+    &rsa_asn1_meths[2],
+#endif
 #ifndef OPENSSL_NO_DH
     &dhx_asn1_meth
 #endif

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -963,5 +963,10 @@ const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[] = {
     {
      EVP_PKEY_RSA2,
      EVP_PKEY_RSA,
-     ASN1_PKEY_ALIAS}
+     ASN1_PKEY_ALIAS},
+    {
+     NID_rsaesOaep,
+     EVP_PKEY_RSA,
+     ASN1_PKEY_ALIAS
+    }
 };


### PR DESCRIPTION
This patch was given to me by Dr Henson via email in 2012.
It is required for the TCG's TPM 1.2 endorsement key
certificates, which use this Public Key Algorithm.

I can supply a sample X509 certifcate (and certificate
chain) for testing.
