### PR TITLE
Fix wrong function name for set_bio in return values section

### DIFF
--- a/doc/man3/SSL_set_bio.pod
+++ b/doc/man3/SSL_set_bio.pod
@@ -90,7 +90,7 @@ use SSL_set0_rbio() and SSL_set0_wbio() instead.
 
 =head1 RETURN VALUES
 
-SSL_set_bio(), SSL_set_rbio() and SSL_set_wbio() cannot fail.
+SSL_set_bio(), SSL_set0_rbio() and SSL_set0_wbio() cannot fail.
 
 =head1 SEE ALSO
 
@@ -104,7 +104,7 @@ SSL_set0_rbio() and SSL_set0_wbio() were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
- [x] documentation is added or updated
