### PR TITLE
Clarify the EVP_DigestSignInit docs

### DIFF
--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -26,8 +26,10 @@ EVP_DigestSignInit() sets up signing context B<ctx> to use digest B<type> from
 ENGINE B<e> and private key B<pkey>. B<ctx> must be created with
 EVP_MD_CTX_new() before calling this function. If B<pctx> is not NULL the
 EVP_PKEY_CTX of the signing operation will be written to B<*pctx>: this can
-be used to set alternative signing options. The digest B<type> may be NULL if
-the signing algorithm supports it.
+be used to set alternative signing options. Note that any existing value in
+B<*pctx> is overwritten. The EVP_PKEY_CTX value returned must not be freed
+directly by the application (it will be freed automatically when the EVP_MD_CTX
+is freed). The digest B<type> may be NULL if the signing algorithm supports it.
 
 Only EVP_PKEY types that support signing can be used with these functions. This
 includes MAC algorithms where the MAC generation is considered as a form of


### PR DESCRIPTION
They did not make it clear how the memory management works for the |pctx|
parameter.

Fixes #7037