### PR TITLE
Backport #7007 to 1.1.0

### DIFF
--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -187,6 +187,8 @@ int pkey_main(int argc, char **argv)
     ret = 0;
 
  end:
+    if (ret != 0)
+        ERR_print_errors(bio_err);
     EVP_PKEY_free(pkey);
     release_engine(e);
     BIO_free_all(out);


### PR DESCRIPTION
openssl pkey command ignored the return codes of EVP_PKEY_print_public/EVP_PKEY_print_private

This commit provides the missing checks.

Backport of #7007 to 1_1_0-stable branch.
