### PR TITLE
Revert ".travis.yml: omit linux-ppc64le target."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ env:
 
 matrix:
     include:
-        #- os: linux-ppc64le
-        #  sudo: false
-        #  compiler: clang
-        #  env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES"
+        - os: linux-ppc64le
+          sudo: false
+          compiler: clang
+          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES"
         - os: linux
           addons:
               apt:


### PR DESCRIPTION
IBM POWER Open Source Ecosystem division asserts commitment to providing
more reliable service. GH#7016.

This reverts commit 275bfc56a6c4efa7e80c8cbb11fda0c3f9be818d.
