### PR TITLE
Configure: allow alternate object file names in build.info

### DIFF
--- a/Configure
+++ b/Configure
@@ -2023,8 +2023,10 @@ EOF
                 if ($s eq $src_configdata || ! -f $s || $generate{$_}) {
                     $s = cleanfile($buildd, $_, $blddir);
                 }
-                # We recognise C++, C and asm files
-                if ($s =~ /\.(cc|cpp|c|s|S)$/) {
+                # We recognise C++, C and asm files and set up an intermediate
+                # object file step, except when the destination is an object
+                # file.
+                if ($s =~ /\.(cc|cpp|c|s|S)$/ && $ddest !~ /\.o$/) {
                     my $o = $_;
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++


### PR DESCRIPTION
Usually, building a thing (let's call it 'foo'), you just specify the
source files used to build it, and Configure will make sure to
generate what information is needed to build the intermediary object
files.

This change allows object files to be specified specifically from with
a different name:

    SOURCE[foo]=... something-variant.o ...
    SOURCE[something-variant.o]=something.c

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
