### PR TITLE
Fix AAD-only case with AAD length not divisible by 16

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -1440,7 +1440,7 @@ int CRYPTO_gcm128_finish(GCM128_CONTEXT *ctx,const unsigned char *tag,
 	void (*gcm_gmult_p)(u64 Xi[2],const u128 Htable[16])	= ctx->gmult;
 #endif
 
-	if (ctx->mres)
+	if (ctx->mres || ctx->ares)
 		GCM_MUL(ctx,Xi);
 
 	if (is_endian.little) {


### PR DESCRIPTION
Cherry pick of:
gcm128.c: fix AAD-only case with AAD length not divisible by 16.
PR: 2859
Submitted by: John Foley

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
