### PR TITLE
Support EdDSA in apps/speed

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1529,7 +1529,7 @@ int speed_main(int argc, char **argv)
     } test_ed_curves[] = {
         /* EdDSA */
         {"Ed25519", NID_ED25519, 253, 64},
-        {"Ed448", NID_ED448, 448, 114}
+        {"Ed448", NID_ED448, 456, 114}
     };
     int ecdsa_doit[ECDSA_NUM] = { 0 };
     int ecdh_doit[EC_NUM] = { 0 };
@@ -3081,14 +3081,18 @@ int speed_main(int argc, char **argv)
                 || !EVP_PKEY_keygen_init(ed_pctx)
                 || !EVP_PKEY_keygen(ed_pctx, &ed_pkey)) {
                 st = 0;
+                EVP_PKEY_CTX_free(ed_pctx);
                 break;
             }
+            EVP_PKEY_CTX_free(ed_pctx);
 
             if (!EVP_DigestSignInit(loopargs[i].eddsa_ctx[testnum], NULL, NULL,
                                     NULL, ed_pkey)) {
                 st = 0;
+                EVP_PKEY_free(ed_pkey);
                 break;
             }
+            EVP_PKEY_free(ed_pkey);
         }
         if (st == 0) {
             BIO_printf(bio_err, "EdDSA failure.\n");
@@ -3159,9 +3163,6 @@ int speed_main(int argc, char **argv)
                 for (testnum++; testnum < EdDSA_NUM; testnum++)
                     eddsa_doit[testnum] = 0;
             }
-
-            EVP_PKEY_CTX_free(ed_pctx);
-            EVP_PKEY_free(ed_pkey);
         }
     }
 
@@ -3339,6 +3340,8 @@ int speed_main(int argc, char **argv)
             EC_KEY_free(loopargs[i].ecdsa[k]);
         for (k = 0; k < EC_NUM; k++)
             EVP_PKEY_CTX_free(loopargs[i].ecdh_ctx[k]);
+        for (k = 0; k < EdDSA_NUM; k++)
+            EVP_MD_CTX_free(loopargs[i].eddsa_ctx[k]);
         OPENSSL_free(loopargs[i].secret_a);
         OPENSSL_free(loopargs[i].secret_b);
 #endif

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -14,6 +14,7 @@
 #define DSA_SECONDS             10
 #define ECDSA_SECONDS   10
 #define ECDH_SECONDS    10
+#define EdDSA_SECONDS   10
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -122,6 +123,7 @@ typedef struct openssl_speed_sec_st {
     int dsa;
     int ecdsa;
     int ecdh;
+    int eddsa;
 } openssl_speed_sec_t;
 
 static volatile int run = 0;
@@ -182,6 +184,8 @@ static int DSA_verify_loop(void *args);
 #ifndef OPENSSL_NO_EC
 static int ECDSA_sign_loop(void *args);
 static int ECDSA_verify_loop(void *args);
+static int EdDSA_sign_loop(void *args);
+static int EdDSA_verify_loop(void *args);
 #endif
 
 static double Time_F(int s);
@@ -567,6 +571,16 @@ static const OPT_PAIR ecdh_choices[] = {
 # define EC_NUM       OSSL_NELEM(ecdh_choices)
 
 static double ecdh_results[EC_NUM][1];  /* 1 op: derivation */
+
+#define R_EC_Ed25519    0
+#define R_EC_Ed448      1
+static OPT_PAIR eddsa_choices[] = {
+    {"ed25519", R_EC_Ed25519},
+    {"ed448", R_EC_Ed448}
+};
+# define EdDSA_NUM       OSSL_NELEM(eddsa_choices)
+
+static double eddsa_results[EdDSA_NUM][2];    /* 2 ops: sign then verify */
 #endif /* OPENSSL_NO_EC */
 
 #ifndef SIGALRM
@@ -595,6 +609,7 @@ typedef struct loopargs_st {
 #ifndef OPENSSL_NO_EC
     EC_KEY *ecdsa[ECDSA_NUM];
     EVP_PKEY_CTX *ecdh_ctx[EC_NUM];
+    EVP_MD_CTX *eddsa_ctx[EdDSA_NUM];
     unsigned char *secret_a;
     unsigned char *secret_b;
     size_t outlen[EC_NUM];
@@ -1163,6 +1178,48 @@ static int ECDH_EVP_derive_key_loop(void *args)
     return count;
 }
 
+static long eddsa_c[EdDSA_NUM][2];
+static int EdDSA_sign_loop(void *args)
+{
+    loopargs_t *tempargs = *(loopargs_t **) args;
+    unsigned char *buf = tempargs->buf;
+    EVP_MD_CTX **edctx = tempargs->eddsa_ctx;
+    unsigned char *eddsasig = tempargs->buf2;
+    unsigned int *eddsasiglen = &tempargs->siglen;
+    int ret, count;
+
+    for (count = 0; COND(eddsa_c[testnum][0]); count++) {
+        ret = EVP_DigestSign(edctx[testnum], eddsasig, (size_t *)eddsasiglen, buf, 20);
+        if (ret == 0) {
+            BIO_printf(bio_err, "EdDSA sign failure\n");
+            ERR_print_errors(bio_err);
+            count = -1;
+            break;
+        }
+    }
+    return count;
+}
+
+static int EdDSA_verify_loop(void *args)
+{
+    loopargs_t *tempargs = *(loopargs_t **) args;
+    unsigned char *buf = tempargs->buf;
+    EVP_MD_CTX **edctx = tempargs->eddsa_ctx;
+    unsigned char *eddsasig = tempargs->buf2;
+    unsigned int eddsasiglen = tempargs->siglen;
+    int ret, count;
+
+    for (count = 0; COND(eddsa_c[testnum][1]); count++) {
+        ret = EVP_DigestVerify(edctx[testnum], eddsasig, eddsasiglen, buf, 20);
+        if (ret != 1) {
+            BIO_printf(bio_err, "EdDSA verify failure\n");
+            ERR_print_errors(bio_err);
+            count = -1;
+            break;
+        }
+    }
+    return count;
+}
 #endif                          /* OPENSSL_NO_EC */
 
 static int run_benchmark(int async_jobs,
@@ -1343,7 +1400,8 @@ int speed_main(int argc, char **argv)
     long rsa_count = 1;
 #endif
     openssl_speed_sec_t seconds = { SECONDS, RSA_SECONDS, DSA_SECONDS,
-                                    ECDSA_SECONDS, ECDH_SECONDS };
+                                    ECDSA_SECONDS, ECDH_SECONDS,
+                                    EdDSA_SECONDS };
 
     /* What follows are the buffers and key material. */
 #ifndef OPENSSL_NO_RC5
@@ -1463,9 +1521,21 @@ int speed_main(int argc, char **argv)
         {"X25519", NID_X25519, 253},
         {"X448", NID_X448, 448}
     };
+    static const struct {
+        const char *name;
+        unsigned int nid;
+        unsigned int bits;
+        unsigned int siglen;
+    } test_ed_curves[] = {
+        /* EdDSA */
+        {"Ed25519", NID_ED25519, 253, 64},
+        {"Ed448", NID_ED448, 448, 114}
+    };
     int ecdsa_doit[ECDSA_NUM] = { 0 };
     int ecdh_doit[EC_NUM] = { 0 };
+    int eddsa_doit[EdDSA_NUM] = { 0 };
     OPENSSL_assert(OSSL_NELEM(test_curves) >= EC_NUM);
+    OPENSSL_assert(OSSL_NELEM(test_ed_curves) >= EdDSA_NUM);
 #endif                          /* ndef OPENSSL_NO_EC */
 
     prog = opt_init(argc, argv, speed_options);
@@ -1558,7 +1628,7 @@ int speed_main(int argc, char **argv)
             break;
         case OPT_SECONDS:
             seconds.sym = seconds.rsa = seconds.dsa = seconds.ecdsa
-                        = seconds.ecdh = atoi(opt_arg());
+                        = seconds.ecdh = seconds.eddsa = atoi(opt_arg());
             break;
         case OPT_BYTES:
             lengths_single = atoi(opt_arg());
@@ -1640,6 +1710,15 @@ int speed_main(int argc, char **argv)
         }
         if (found(*argv, ecdh_choices, &i)) {
             ecdh_doit[i] = 2;
+            continue;
+        }
+        if (strcmp(*argv, "eddsa") == 0) {
+            for (loop = 0; loop < OSSL_NELEM(eddsa_doit); loop++)
+                eddsa_doit[loop] = 1;
+            continue;
+        }
+        if (found(*argv, eddsa_choices, &i)) {
+            eddsa_doit[i] = 2;
             continue;
         }
 #endif
@@ -1742,6 +1821,8 @@ int speed_main(int argc, char **argv)
             ecdsa_doit[loop] = 1;
         for (loop = 0; loop < OSSL_NELEM(ecdh_doit); loop++)
             ecdh_doit[loop] = 1;
+        for (loop = 0; loop < OSSL_NELEM(eddsa_doit); loop++)
+            eddsa_doit[loop] = 1;
 #endif
     }
     for (i = 0; i < ALGOR_NUM; i++)
@@ -2037,6 +2118,9 @@ int speed_main(int argc, char **argv)
     /* default iteration count for the last two EC Curves */
     ecdh_c[R_EC_X25519][0] = count / 1800;
     ecdh_c[R_EC_X448][0] = count / 7200;
+
+    eddsa_c[R_EC_Ed25519][0] = count / 1800;
+    eddsa_c[R_EC_Ed448][0] = count / 7200;
 #  endif
 
 # else
@@ -2977,6 +3061,110 @@ int speed_main(int argc, char **argv)
                 ecdh_doit[testnum] = 0;
         }
     }
+
+    for (testnum = 0; testnum < EdDSA_NUM; testnum++) {
+        int st = 1;
+        EVP_PKEY *ed_pkey = NULL;
+        EVP_PKEY_CTX *ed_pctx = NULL;
+
+        if (!eddsa_doit[testnum])
+            continue;           /* Ignore Curve */
+        for (i = 0; i < loopargs_len; i++) {
+            loopargs[i].eddsa_ctx[testnum] = EVP_MD_CTX_new();
+            if (loopargs[i].eddsa_ctx[testnum] == NULL) {
+                st = 0;
+                break;
+            }
+
+            if ((ed_pctx = EVP_PKEY_CTX_new_id(test_ed_curves[testnum].nid, NULL))
+                    == NULL
+                || !EVP_PKEY_keygen_init(ed_pctx)
+                || !EVP_PKEY_keygen(ed_pctx, &ed_pkey)) {
+                st = 0;
+                break;
+            }
+
+            if (!EVP_DigestSignInit(loopargs[i].eddsa_ctx[testnum], NULL, NULL,
+                                    NULL, ed_pkey)) {
+                st = 0;
+                break;
+            }
+        }
+        if (st == 0) {
+            BIO_printf(bio_err, "EdDSA failure.\n");
+            ERR_print_errors(bio_err);
+            rsa_count = 1;
+        } else {
+            for (i = 0; i < loopargs_len; i++) {
+                /* Perform EdDSA signature test */
+                loopargs[i].siglen = test_ed_curves[testnum].siglen;
+                st = EVP_DigestSign(loopargs[i].eddsa_ctx[testnum],
+                                    loopargs[i].buf2, (size_t *)&loopargs[i].siglen,
+                                    loopargs[i].buf, 20);
+                if (st == 0)
+                    break;
+            }
+            if (st == 0) {
+                BIO_printf(bio_err,
+                           "EdDSA sign failure.  No EdDSA sign will be done.\n");
+                ERR_print_errors(bio_err);
+                rsa_count = 1;
+            } else {
+                pkey_print_message("sign", test_ed_curves[testnum].name,
+                                   eddsa_c[testnum][0],
+                                   test_ed_curves[testnum].bits, seconds.eddsa);
+                Time_F(START);
+                count = run_benchmark(async_jobs, EdDSA_sign_loop, loopargs);
+                d = Time_F(STOP);
+
+                BIO_printf(bio_err,
+                           mr ? "+R8:%ld:%u:%s:%.2f\n" :
+                           "%ld %u bits %s signs in %.2fs \n",
+                           count, test_ed_curves[testnum].bits,
+                           test_ed_curves[testnum].name, d);
+                eddsa_results[testnum][0] = (double)count / d;
+                rsa_count = count;
+            }
+
+            /* Perform EdDSA verification test */
+            for (i = 0; i < loopargs_len; i++) {
+                st = EVP_DigestVerify(loopargs[i].eddsa_ctx[testnum],
+                                      loopargs[i].buf2, loopargs[i].siglen,
+                                      loopargs[i].buf, 20);
+                if (st != 1)
+                    break;
+            }
+            if (st != 1) {
+                BIO_printf(bio_err,
+                           "EdDSA verify failure.  No EdDSA verify will be done.\n");
+                ERR_print_errors(bio_err);
+                eddsa_doit[testnum] = 0;
+            } else {
+                pkey_print_message("verify", test_ed_curves[testnum].name,
+                                   eddsa_c[testnum][1],
+                                   test_ed_curves[testnum].bits, seconds.eddsa);
+                Time_F(START);
+                count = run_benchmark(async_jobs, EdDSA_verify_loop, loopargs);
+                d = Time_F(STOP);
+                BIO_printf(bio_err,
+                           mr ? "+R9:%ld:%u:%s:%.2f\n"
+                           : "%ld %u bits %s verify in %.2fs\n",
+                           count, test_ed_curves[testnum].bits,
+                           test_ed_curves[testnum].name, d);
+                eddsa_results[testnum][1] = (double)count / d;
+            }
+
+            if (rsa_count <= 1) {
+                /* if longer than 10s, don't do any more */
+                for (testnum++; testnum < EdDSA_NUM; testnum++)
+                    eddsa_doit[testnum] = 0;
+            }
+
+            EVP_PKEY_CTX_free(ed_pctx);
+            EVP_PKEY_free(ed_pkey);
+        }
+    }
+
 #endif                          /* OPENSSL_NO_EC */
 #ifndef NO_FORK
  show_res:
@@ -3107,6 +3295,26 @@ int speed_main(int argc, char **argv)
             printf("%4u bits ecdh (%s) %8.4fs %8.1f\n",
                    test_curves[k].bits, test_curves[k].name,
                    1.0 / ecdh_results[k][0], ecdh_results[k][0]);
+    }
+
+    testnum = 1;
+    for (k = 0; k < OSSL_NELEM(eddsa_doit); k++) {
+        if (!eddsa_doit[k])
+            continue;
+        if (testnum && !mr) {
+            printf("%30ssign    verify    sign/s verify/s\n", " ");
+            testnum = 0;
+        }
+
+        if (mr)
+            printf("+F6:%u:%u:%s:%f:%f\n",
+                   k, test_ed_curves[k].bits, test_ed_curves[k].name,
+                   eddsa_results[k][0], eddsa_results[k][1]);
+        else
+            printf("%4u bits EdDSA (%s) %8.4fs %8.4fs %8.1f %8.1f\n",
+                   test_ed_curves[k].bits, test_ed_curves[k].name,
+                   1.0 / eddsa_results[k][0], 1.0 / eddsa_results[k][1],
+                   eddsa_results[k][0], eddsa_results[k][1]);
     }
 #endif
 
@@ -3338,6 +3546,19 @@ static int do_multi(int multi, int size_num)
 
                 d = atof(sstrsep(&p, sep));
                 ecdh_results[k][0] += d;
+            } else if (strncmp(buf, "+F6:", 4) == 0) {
+                int k;
+                double d;
+
+                p = buf + 4;
+                k = atoi(sstrsep(&p, sep));
+                sstrsep(&p, sep);
+
+                d = atof(sstrsep(&p, sep));
+                eddsa_results[k][0] += d;
+
+                d = atof(sstrsep(&p, sep));
+                eddsa_results[k][1] += d;
             }
 # endif
 

--- a/doc/man7/Ed25519.pod
+++ b/doc/man7/Ed25519.pod
@@ -49,6 +49,10 @@ Ed25519 or Ed448 public keys can be set directly using
 L<EVP_PKEY_new_raw_public_key(3)> or loaded from a SubjectPublicKeyInfo
 structure in a PEM file using L<PEM_read_bio_PUBKEY(3)> (or similar function).
 
+Ed25519 and Ed448 can be tested within L<speed(1)> application since version 1.1.1.
+In details, B<ed25519>, B<ed448> and B<eddsa> are valid algorithm names. If B<eddsa>
+is specified to L<speed(1)> application, then both Ed25519 and Ed448 are benchmarked.
+
 =head1 EXAMPLE
 
 This example generates an B<ED25519> private key and writes it to standard

--- a/doc/man7/Ed25519.pod
+++ b/doc/man7/Ed25519.pod
@@ -50,8 +50,8 @@ L<EVP_PKEY_new_raw_public_key(3)> or loaded from a SubjectPublicKeyInfo
 structure in a PEM file using L<PEM_read_bio_PUBKEY(3)> (or similar function).
 
 Ed25519 and Ed448 can be tested within L<speed(1)> application since version 1.1.1.
-In details, B<ed25519>, B<ed448> and B<eddsa> are valid algorithm names. If B<eddsa>
-is specified to L<speed(1)> application, then both Ed25519 and Ed448 are benchmarked.
+Valid algorithm names are B<ed25519>, B<ed448> and B<eddsa>. If B<eddsa> is
+specified, then both Ed25519 and Ed448 are benchmarked.
 
 =head1 EXAMPLE
 


### PR DESCRIPTION
This addresses issue #6922, which is a '1.1.1' ~labeled~milestoned issue.

Originally I wanted to put EdDSA related stuff in the `-evp` option of `speed` command, but that requires changes to the apps/speed structure, so I finally decided to make a quick fix by following what ECDSA and ECDH do in `speed` command.

I think other algorithms in `speed`, for instance RSA, DSA, ECDSA..., should be changed to use EVP interface as well, but that would happen after 1.1.1 is release. And the structure changes could be addressed together.

Usage:

Benchmark of all EdDSA algorihtms: `openssl speed eddsa`
Benchmark of Ed25519:  `openssl speed ed25519`
Benchmark of Ed448: `openssl speed ed448`

some results from my laptop:

```
Infs-Lair:openssl paul$ bin/openssl speed -seconds 5 eddsa
Doing 253 bits sign Ed25519's for 5s: 58650 253 bits Ed25519 signs in 4.87s
Doing 253 bits verify Ed25519's for 5s: 21531 253 bits Ed25519 verify in 4.93s
Doing 448 bits sign Ed448's for 5s: 7701 448 bits Ed448 signs in 4.92s
Doing 448 bits verify Ed448's for 5s: 1995 448 bits Ed448 verify in 4.84s
OpenSSL 1.1.1-pre10-dev  xx XXX xxxx
built on: Mon Aug 27 13:42:54 2018 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr)
compiler: cc -fPIC -arch x86_64 -fsanitize=address -fno-omit-frame-pointer -g -O3 -Wall -Wall -g -Wno-unused-parameter -Wno-missing-field-initializers -Werror -Wmissing-variable-declarations -Wno-format -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_CPUID_OBJ -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DKECCAK1600_ASM -DRC4_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DX25519_ASM -DPADLOCK_ASM -DPOLY1305_ASM -D_REENTRANT -DNDEBUG
                              sign    verify    sign/s verify/s
 253 bits EdDSA (Ed25519)   0.0001s   0.0002s  12043.1   4367.3
 448 bits EdDSA (Ed448)   0.0006s   0.0024s   1565.2    412.2
```

I didn't find a more proper place to document this, so I left a message in Ed25519(7) man page...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
