### PR TITLE
Check for a failure return from EVP_MD_CTX_new() in OCSP_basic_sign().

### DIFF
--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -237,6 +237,9 @@ int OCSP_basic_sign(OCSP_BASICRESP *brsp,
     EVP_PKEY_CTX *pkctx = NULL;
     int i;
 
+    if (ctx == NULL)
+        return 0;
+
     if (!EVP_DigestSignInit(ctx, &pkctx, dgst, NULL, key)) {
         EVP_MD_CTX_free(ctx);
         return 0;


### PR DESCRIPTION
There was no check of the return value from EVP_MD_CTX_new() in the OCSP_basic_sign() function.
This adds such a check.

Fixes #6973
Replaces #6983

