### PR TITLE
Check the return from BN_sub() in BN_X931_generate_Xpq().

### DIFF
--- a/crypto/bn/bn_x931p.c
+++ b/crypto/bn/bn_x931p.c
@@ -184,8 +184,10 @@ int BN_X931_generate_Xpq(BIGNUM *Xp, BIGNUM *Xq, int nbits, BN_CTX *ctx)
     for (i = 0; i < 1000; i++) {
         if (!BN_priv_rand(Xq, nbits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ANY))
             goto err;
+
         /* Check that |Xp - Xq| > 2^(nbits - 100) */
-        BN_sub(t, Xp, Xq);
+        if (!BN_sub(t, Xp, Xq))
+            goto err;
         if (BN_num_bits(t) > (nbits - 100))
             break;
     }


### PR DESCRIPTION
The return code from `BN_sub()` in `BN_X931_generate_Xpq()` wasn't being checked for failure.
This adds such a check.

Fixes:  #6983

