### PR TITLE
Fix example in crl(1) man page

### DIFF
--- a/doc/man1/crl.pod
+++ b/doc/man1/crl.pod
@@ -120,7 +120,7 @@ Convert a CRL file from PEM to DER:
 
 Output the text form of a DER encoded certificate:
 
- openssl crl -in crl.der -text -noout
+ openssl crl -in crl.der -inform DER -text -noout
 
 =head1 BUGS
 


### PR DESCRIPTION
The default input format is PEM, so explicit `-inform DER` is needed to read DER-encoded CRL.