### PR TITLE
Clarify the return value of SSL_client_version()

### DIFF
--- a/doc/man3/SSL_get_version.pod
+++ b/doc/man3/SSL_get_version.pod
@@ -19,12 +19,14 @@ protocol information of a connection
 
 =head1 DESCRIPTION
 
-SSL_client_version() returns the protocol version used by the client when
-initiating the connection. SSL_get_version() returns the name of the protocol
-used for the connection. SSL_version() returns the protocol version used for the
-connection. They should only be called after the initial handshake has been
-completed. Prior to that the results returned from these functions may be
-unreliable.
+SSL_client_version() returns the protocol version advertised by the client in
+the legacy_version field of the ClientHello when initiating the connection.
+Note that, for TLS, this value will never indicate a version greater than
+TLSv1.2 even if TLSv1.3 is subsequently negotiated. SSL_get_version() returns
+the name of the protocol used for the connection. SSL_version() returns the
+protocol version used for the connection. They should only be called after the
+initial handshake has been completed. Prior to that the results returned from
+these functions may be unreliable.
 
 SSL_is_dtls() returns one if the connection is using DTLS, zero if not.
 
@@ -60,8 +62,8 @@ This indicates an unknown protocol version.
 
 =back
 
-SSL_version() and SSL_client_version() return an integer which could include any of
-the following:
+SSL_version() and SSL_client_version() return an integer which could include any
+of the following:
 
 =over 4
 
@@ -83,7 +85,8 @@ The connection uses the TLSv1.2 protocol.
 
 =item TLS1_3_VERSION
 
-The connection uses the TLSv1.3 protocol.
+The connection uses the TLSv1.3 protocol (never returned for
+SSL_client_version()).
 
 =back
 

--- a/doc/man3/SSL_get_version.pod
+++ b/doc/man3/SSL_get_version.pod
@@ -19,18 +19,19 @@ protocol information of a connection
 
 =head1 DESCRIPTION
 
-SSL_client_version() returns the protocol version advertised by the client in
-the legacy_version field of the ClientHello when initiating the connection.
-Note that, for TLS, this value will never indicate a version greater than
-TLSv1.2 even if TLSv1.3 is subsequently negotiated. SSL_get_version() returns
-the name of the protocol used for the connection. SSL_version() returns the
-protocol version used for the connection. They should only be called after the
-initial handshake has been completed. Prior to that the results returned from
-these functions may be unreliable.
+SSL_client_version() returns the numeric protocol version advertised by the
+client in the legacy_version field of the ClientHello when initiating the
+connection. Note that, for TLS, this value will never indicate a version greater
+than TLSv1.2 even if TLSv1.3 is subsequently negotiated. SSL_get_version()
+returns the name of the protocol used for the connection. SSL_version() returns
+the numeric protocol version used for the connection. They should only be called
+after the initial handshake has been completed. Prior to that the results
+returned from these functions may be unreliable.
 
 SSL_is_dtls() returns one if the connection is using DTLS, zero if not.
 
 =head1 RETURN VALUES
+
 
 SSL_get_version() returns one of the following strings:
 
@@ -62,7 +63,8 @@ This indicates an unknown protocol version.
 
 =back
 
-SSL_version() and SSL_client_version() return an integer which could include any
+SSL_version() and SSL_client_version() return an integ
+er which could include any
 of the following:
 
 =over 4


### PR DESCRIPTION
The SSL_client_version() function returns the value held in the
legacy_version field of the ClientHello. This is never greater than
TLSv1.2, even if TLSv1.3 later gets negotiated.

Fixes #7079

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
