### PR TITLE
openssl req: don't try to report bits

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -622,8 +622,7 @@ int req_main(int argc, char **argv)
         if (pkey_type == EVP_PKEY_EC) {
             BIO_printf(bio_err, "Generating an EC private key\n");
         } else {
-            BIO_printf(bio_err, "Generating a %ld bit %s private key\n",
-                       newkey, keyalgstr);
+            BIO_printf(bio_err, "Generating a %s private key\n", keyalgstr);
         }
 
         EVP_PKEY_CTX_set_cb(genctx, genpkey_cb);


### PR DESCRIPTION
With the introduction of -pkeyopt, the number of bits may change
without |newkey| being updated.  Unfortunately, there is no API to
retrieve the information from a EVP_PKEY_CTX either, so chances are
that we report incorrect information.  For the moment, it's better not
to try to report the number of bits at all.

Fixes #7086
