### PR TITLE
New openssl subject parser hard to debug

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1768,8 +1768,14 @@ X509_NAME *parse_name(const char *cp, long chtype, int canmulti)
     char *work;
     X509_NAME *n;
 
-    if (*cp++ != '/')
+    if (*cp++ != '/') {
+        BIO_printf(bio_err,
+                   "name is expected to be in the format "
+                   "/type0=value0/type1=value1/type2=... where characters may "
+                   "be escaped by \\. This name is not in that format: '%s'\n",
+                   --cp);
         return NULL;
+    }
 
     n = X509_NAME_new();
     if (n == NULL)


### PR DESCRIPTION
-subj 'subject=C = US, ST = A, L = root, O = Hewlett Packard Enterprise Company, OU = Remote Device Access, CN = Hewlett Packard Enterprise Remote Device Access Test Local CA, emailAddress = rda@hpe.com'
was a valid subject in openssl 1.0. Error received in 1.1 is:

problems making Certificate Request

Not very informative, I only figured this out because I compiled the
code and added logging.
