### PR TITLE
 Don't use an RSA-PSS cert for RSA key exchange

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2646,8 +2646,9 @@ int tls_choose_sigalg(SSL *s, int fatalerrs)
                 if (i == s->cert->shared_sigalgslen) {
                     if (!fatalerrs)
                         return 1;
-                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CHOOSE_SIGALG,
-                             ERR_R_INTERNAL_ERROR);
+                    SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
+                             SSL_F_TLS_CHOOSE_SIGALG,
+                             SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM);
                     return 0;
                 }
             } else {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2473,7 +2473,10 @@ static int tls12_get_cert_sigalg_idx(const SSL *s, const SIGALG_LOOKUP *lu)
     const SSL_CERT_LOOKUP *clu = ssl_cert_lookup_by_idx(sig_idx);
 
     /* If not recognised or not supported by cipher mask it is not suitable */
-    if (clu == NULL || !(clu->amask & s->s3->tmp.new_cipher->algorithm_auth))
+    if (clu == NULL
+            || (clu->amask & s->s3->tmp.new_cipher->algorithm_auth) == 0
+            || (clu->nid == EVP_PKEY_RSA_PSS
+                && (s->s3->tmp.new_cipher->algorithm_mkey & SSL_kRSA) != 0))
         return -1;
 
     return s->s3->tmp.valid_flags[sig_idx] & CERT_PKEY_VALID ? sig_idx : -1;

--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 47
+num_tests = 49
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-ECDSA CipherString Selection
@@ -24,31 +24,33 @@ test-18 = 18-RSA-PSS Certificate Legacy Signature Algorithm Selection
 test-19 = 19-RSA-PSS Certificate Unified Signature Algorithm Selection
 test-20 = 20-Only RSA-PSS Certificate
 test-21 = 21-RSA-PSS Certificate, no PSS signature algorithms
-test-22 = 22-Suite B P-256 Hash Algorithm Selection
-test-23 = 23-Suite B P-384 Hash Algorithm Selection
-test-24 = 24-TLS 1.2 Ed25519 Client Auth
-test-25 = 25-TLS 1.2 Ed448 Client Auth
-test-26 = 26-Only RSA-PSS Certificate, TLS v1.1
-test-27 = 27-TLS 1.3 ECDSA Signature Algorithm Selection
-test-28 = 28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
-test-29 = 29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1
-test-30 = 30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS
-test-31 = 31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
-test-32 = 32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-33 = 33-TLS 1.3 RSA Signature Algorithm Selection, no PSS
-test-34 = 34-TLS 1.3 RSA-PSS Signature Algorithm Selection
-test-35 = 35-TLS 1.3 Ed25519 Signature Algorithm Selection
-test-36 = 36-TLS 1.3 Ed448 Signature Algorithm Selection
-test-37 = 37-TLS 1.3 Ed25519 CipherString and Groups Selection
-test-38 = 38-TLS 1.3 Ed448 CipherString and Groups Selection
-test-39 = 39-TLS 1.3 RSA Client Auth Signature Algorithm Selection
-test-40 = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
-test-41 = 41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
-test-42 = 42-TLS 1.3 Ed25519 Client Auth
-test-43 = 43-TLS 1.3 Ed448 Client Auth
-test-44 = 44-TLS 1.2 DSA Certificate Test
-test-45 = 45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
-test-46 = 46-TLS 1.3 DSA Certificate Test
+test-22 = 22-RSA key exchange with all RSA certificate types
+test-23 = 23-RSA key exchange with only RSA-PSS certificate
+test-24 = 24-Suite B P-256 Hash Algorithm Selection
+test-25 = 25-Suite B P-384 Hash Algorithm Selection
+test-26 = 26-TLS 1.2 Ed25519 Client Auth
+test-27 = 27-TLS 1.2 Ed448 Client Auth
+test-28 = 28-Only RSA-PSS Certificate, TLS v1.1
+test-29 = 29-TLS 1.3 ECDSA Signature Algorithm Selection
+test-30 = 30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
+test-31 = 31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1
+test-32 = 32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS
+test-33 = 33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
+test-34 = 34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-35 = 35-TLS 1.3 RSA Signature Algorithm Selection, no PSS
+test-36 = 36-TLS 1.3 RSA-PSS Signature Algorithm Selection
+test-37 = 37-TLS 1.3 Ed25519 Signature Algorithm Selection
+test-38 = 38-TLS 1.3 Ed448 Signature Algorithm Selection
+test-39 = 39-TLS 1.3 Ed25519 CipherString and Groups Selection
+test-40 = 40-TLS 1.3 Ed448 CipherString and Groups Selection
+test-41 = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection
+test-42 = 42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
+test-43 = 43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
+test-44 = 44-TLS 1.3 Ed25519 Client Auth
+test-45 = 45-TLS 1.3 Ed448 Client Auth
+test-46 = 46-TLS 1.2 DSA Certificate Test
+test-47 = 47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
+test-48 = 48-TLS 1.3 DSA Certificate Test
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -766,14 +768,65 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[22-Suite B P-256 Hash Algorithm Selection]
-ssl_conf = 22-Suite B P-256 Hash Algorithm Selection-ssl
+[22-RSA key exchange with all RSA certificate types]
+ssl_conf = 22-RSA key exchange with all RSA certificate types-ssl
 
-[22-Suite B P-256 Hash Algorithm Selection-ssl]
-server = 22-Suite B P-256 Hash Algorithm Selection-server
-client = 22-Suite B P-256 Hash Algorithm Selection-client
+[22-RSA key exchange with all RSA certificate types-ssl]
+server = 22-RSA key exchange with all RSA certificate types-server
+client = 22-RSA key exchange with all RSA certificate types-client
 
-[22-Suite B P-256 Hash Algorithm Selection-server]
+[22-RSA key exchange with all RSA certificate types-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[22-RSA key exchange with all RSA certificate types-client]
+CipherString = kRSA
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-22]
+ExpectedResult = Success
+ExpectedServerCertType = RSA
+
+
+# ===========================================================
+
+[23-RSA key exchange with only RSA-PSS certificate]
+ssl_conf = 23-RSA key exchange with only RSA-PSS certificate-ssl
+
+[23-RSA key exchange with only RSA-PSS certificate-ssl]
+server = 23-RSA key exchange with only RSA-PSS certificate-server
+client = 23-RSA key exchange with only RSA-PSS certificate-client
+
+[23-RSA key exchange with only RSA-PSS certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+
+[23-RSA key exchange with only RSA-PSS certificate-client]
+CipherString = kRSA
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-23]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[24-Suite B P-256 Hash Algorithm Selection]
+ssl_conf = 24-Suite B P-256 Hash Algorithm Selection-ssl
+
+[24-Suite B P-256 Hash Algorithm Selection-ssl]
+server = 24-Suite B P-256 Hash Algorithm Selection-server
+client = 24-Suite B P-256 Hash Algorithm Selection-client
+
+[24-Suite B P-256 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
@@ -781,13 +834,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[22-Suite B P-256 Hash Algorithm Selection-client]
+[24-Suite B P-256 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-22]
+[test-24]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -796,14 +849,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[23-Suite B P-384 Hash Algorithm Selection]
-ssl_conf = 23-Suite B P-384 Hash Algorithm Selection-ssl
+[25-Suite B P-384 Hash Algorithm Selection]
+ssl_conf = 25-Suite B P-384 Hash Algorithm Selection-ssl
 
-[23-Suite B P-384 Hash Algorithm Selection-ssl]
-server = 23-Suite B P-384 Hash Algorithm Selection-server
-client = 23-Suite B P-384 Hash Algorithm Selection-client
+[25-Suite B P-384 Hash Algorithm Selection-ssl]
+server = 25-Suite B P-384 Hash Algorithm Selection-server
+client = 25-Suite B P-384 Hash Algorithm Selection-client
 
-[23-Suite B P-384 Hash Algorithm Selection-server]
+[25-Suite B P-384 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
@@ -811,13 +864,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[23-Suite B P-384 Hash Algorithm Selection-client]
+[25-Suite B P-384 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-23]
+[test-25]
 ExpectedResult = Success
 ExpectedServerCertType = P-384
 ExpectedServerSignHash = SHA384
@@ -826,21 +879,21 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[24-TLS 1.2 Ed25519 Client Auth]
-ssl_conf = 24-TLS 1.2 Ed25519 Client Auth-ssl
+[26-TLS 1.2 Ed25519 Client Auth]
+ssl_conf = 26-TLS 1.2 Ed25519 Client Auth-ssl
 
-[24-TLS 1.2 Ed25519 Client Auth-ssl]
-server = 24-TLS 1.2 Ed25519 Client Auth-server
-client = 24-TLS 1.2 Ed25519 Client Auth-client
+[26-TLS 1.2 Ed25519 Client Auth-ssl]
+server = 26-TLS 1.2 Ed25519 Client Auth-server
+client = 26-TLS 1.2 Ed25519 Client Auth-client
 
-[24-TLS 1.2 Ed25519 Client Auth-server]
+[26-TLS 1.2 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[24-TLS 1.2 Ed25519 Client Auth-client]
+[26-TLS 1.2 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -849,7 +902,7 @@ MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-24]
+[test-26]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
@@ -857,21 +910,21 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[25-TLS 1.2 Ed448 Client Auth]
-ssl_conf = 25-TLS 1.2 Ed448 Client Auth-ssl
+[27-TLS 1.2 Ed448 Client Auth]
+ssl_conf = 27-TLS 1.2 Ed448 Client Auth-ssl
 
-[25-TLS 1.2 Ed448 Client Auth-ssl]
-server = 25-TLS 1.2 Ed448 Client Auth-server
-client = 25-TLS 1.2 Ed448 Client Auth-client
+[27-TLS 1.2 Ed448 Client Auth-ssl]
+server = 27-TLS 1.2 Ed448 Client Auth-server
+client = 27-TLS 1.2 Ed448 Client Auth-client
 
-[25-TLS 1.2 Ed448 Client Auth-server]
+[27-TLS 1.2 Ed448 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[25-TLS 1.2 Ed448 Client Auth-client]
+[27-TLS 1.2 Ed448 Client Auth-client]
 CipherString = DEFAULT
 Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
 Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
@@ -880,7 +933,7 @@ MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-25]
+[test-27]
 ExpectedClientCertType = Ed448
 ExpectedClientSignType = Ed448
 ExpectedResult = Success
@@ -888,38 +941,38 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[26-Only RSA-PSS Certificate, TLS v1.1]
-ssl_conf = 26-Only RSA-PSS Certificate, TLS v1.1-ssl
+[28-Only RSA-PSS Certificate, TLS v1.1]
+ssl_conf = 28-Only RSA-PSS Certificate, TLS v1.1-ssl
 
-[26-Only RSA-PSS Certificate, TLS v1.1-ssl]
-server = 26-Only RSA-PSS Certificate, TLS v1.1-server
-client = 26-Only RSA-PSS Certificate, TLS v1.1-client
+[28-Only RSA-PSS Certificate, TLS v1.1-ssl]
+server = 28-Only RSA-PSS Certificate, TLS v1.1-server
+client = 28-Only RSA-PSS Certificate, TLS v1.1-client
 
-[26-Only RSA-PSS Certificate, TLS v1.1-server]
+[28-Only RSA-PSS Certificate, TLS v1.1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[26-Only RSA-PSS Certificate, TLS v1.1-client]
+[28-Only RSA-PSS Certificate, TLS v1.1-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-26]
+[test-28]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[27-TLS 1.3 ECDSA Signature Algorithm Selection]
-ssl_conf = 27-TLS 1.3 ECDSA Signature Algorithm Selection-ssl
+[29-TLS 1.3 ECDSA Signature Algorithm Selection]
+ssl_conf = 29-TLS 1.3 ECDSA Signature Algorithm Selection-ssl
 
-[27-TLS 1.3 ECDSA Signature Algorithm Selection-ssl]
-server = 27-TLS 1.3 ECDSA Signature Algorithm Selection-server
-client = 27-TLS 1.3 ECDSA Signature Algorithm Selection-client
+[29-TLS 1.3 ECDSA Signature Algorithm Selection-ssl]
+server = 29-TLS 1.3 ECDSA Signature Algorithm Selection-server
+client = 29-TLS 1.3 ECDSA Signature Algorithm Selection-client
 
-[27-TLS 1.3 ECDSA Signature Algorithm Selection-server]
+[29-TLS 1.3 ECDSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -932,13 +985,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[27-TLS 1.3 ECDSA Signature Algorithm Selection-client]
+[29-TLS 1.3 ECDSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-27]
+[test-29]
 ExpectedResult = Success
 ExpectedServerCANames = empty
 ExpectedServerCertType = P-256
@@ -948,14 +1001,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl
+[30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point]
+ssl_conf = 30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl
 
-[28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server
-client = 28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client
+[30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl]
+server = 30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server
+client = 30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client
 
-[28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server]
+[30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
@@ -964,13 +1017,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[28-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client]
+[30-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-28]
+[test-30]
 ExpectedResult = Success
 ExpectedServerCANames = empty
 ExpectedServerCertType = P-256
@@ -980,14 +1033,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl
+[31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl
 
-[29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server
-client = 29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
+[31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server
+client = 31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
 
-[29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
+[31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1000,26 +1053,26 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[29-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
+[31-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-29]
+[test-31]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS]
-ssl_conf = 30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl
+[32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS]
+ssl_conf = 32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl
 
-[30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl]
-server = 30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server
-client = 30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client
+[32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl]
+server = 32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server
+client = 32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client
 
-[30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server]
+[32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1032,14 +1085,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[30-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client]
+[32-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client]
 CipherString = DEFAULT
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 SignatureAlgorithms = ECDSA+SHA256:RSA-PSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-30]
+[test-32]
 ExpectedResult = Success
 ExpectedServerCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 ExpectedServerCertType = P-256
@@ -1049,14 +1102,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS]
-ssl_conf = 31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl
+[33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS]
+ssl_conf = 33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl
 
-[31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl]
-server = 31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server
-client = 31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client
+[33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl]
+server = 33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server
+client = 33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client
 
-[31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server]
+[33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1069,13 +1122,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[31-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client]
+[33-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA384:RSA-PSS+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-31]
+[test-33]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA384
@@ -1084,40 +1137,40 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
+[34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
 
-[32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client
+[34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client
 
-[32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
+[34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[32-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
+[34-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-32]
+[test-34]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[33-TLS 1.3 RSA Signature Algorithm Selection, no PSS]
-ssl_conf = 33-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl
+[35-TLS 1.3 RSA Signature Algorithm Selection, no PSS]
+ssl_conf = 35-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl
 
-[33-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl]
-server = 33-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server
-client = 33-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client
+[35-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl]
+server = 35-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server
+client = 35-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client
 
-[33-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server]
+[35-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1130,26 +1183,26 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[33-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client]
+[35-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-33]
+[test-35]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[34-TLS 1.3 RSA-PSS Signature Algorithm Selection]
-ssl_conf = 34-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl
+[36-TLS 1.3 RSA-PSS Signature Algorithm Selection]
+ssl_conf = 36-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl
 
-[34-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl]
-server = 34-TLS 1.3 RSA-PSS Signature Algorithm Selection-server
-client = 34-TLS 1.3 RSA-PSS Signature Algorithm Selection-client
+[36-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl]
+server = 36-TLS 1.3 RSA-PSS Signature Algorithm Selection-server
+client = 36-TLS 1.3 RSA-PSS Signature Algorithm Selection-client
 
-[34-TLS 1.3 RSA-PSS Signature Algorithm Selection-server]
+[36-TLS 1.3 RSA-PSS Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1162,13 +1215,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[34-TLS 1.3 RSA-PSS Signature Algorithm Selection-client]
+[36-TLS 1.3 RSA-PSS Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA-PSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-34]
+[test-36]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -1177,14 +1230,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[35-TLS 1.3 Ed25519 Signature Algorithm Selection]
-ssl_conf = 35-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
+[37-TLS 1.3 Ed25519 Signature Algorithm Selection]
+ssl_conf = 37-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
 
-[35-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
-server = 35-TLS 1.3 Ed25519 Signature Algorithm Selection-server
-client = 35-TLS 1.3 Ed25519 Signature Algorithm Selection-client
+[37-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
+server = 37-TLS 1.3 Ed25519 Signature Algorithm Selection-server
+client = 37-TLS 1.3 Ed25519 Signature Algorithm Selection-client
 
-[35-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
+[37-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1197,13 +1250,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[35-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
+[37-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-35]
+[test-37]
 ExpectedResult = Success
 ExpectedServerCertType = Ed25519
 ExpectedServerSignType = Ed25519
@@ -1211,14 +1264,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[36-TLS 1.3 Ed448 Signature Algorithm Selection]
-ssl_conf = 36-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
+[38-TLS 1.3 Ed448 Signature Algorithm Selection]
+ssl_conf = 38-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
 
-[36-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
-server = 36-TLS 1.3 Ed448 Signature Algorithm Selection-server
-client = 36-TLS 1.3 Ed448 Signature Algorithm Selection-client
+[38-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
+server = 38-TLS 1.3 Ed448 Signature Algorithm Selection-server
+client = 38-TLS 1.3 Ed448 Signature Algorithm Selection-client
 
-[36-TLS 1.3 Ed448 Signature Algorithm Selection-server]
+[38-TLS 1.3 Ed448 Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1231,13 +1284,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[36-TLS 1.3 Ed448 Signature Algorithm Selection-client]
+[38-TLS 1.3 Ed448 Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-36]
+[test-38]
 ExpectedResult = Success
 ExpectedServerCertType = Ed448
 ExpectedServerSignType = Ed448
@@ -1245,14 +1298,14 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[37-TLS 1.3 Ed25519 CipherString and Groups Selection]
-ssl_conf = 37-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
+[39-TLS 1.3 Ed25519 CipherString and Groups Selection]
+ssl_conf = 39-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
 
-[37-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
-server = 37-TLS 1.3 Ed25519 CipherString and Groups Selection-server
-client = 37-TLS 1.3 Ed25519 CipherString and Groups Selection-client
+[39-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
+server = 39-TLS 1.3 Ed25519 CipherString and Groups Selection-server
+client = 39-TLS 1.3 Ed25519 CipherString and Groups Selection-client
 
-[37-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
+[39-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1265,14 +1318,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[37-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
+[39-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
 CipherString = DEFAULT
 Groups = X25519
 SignatureAlgorithms = ECDSA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-37]
+[test-39]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignType = EC
@@ -1280,14 +1333,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[38-TLS 1.3 Ed448 CipherString and Groups Selection]
-ssl_conf = 38-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
+[40-TLS 1.3 Ed448 CipherString and Groups Selection]
+ssl_conf = 40-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
 
-[38-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
-server = 38-TLS 1.3 Ed448 CipherString and Groups Selection-server
-client = 38-TLS 1.3 Ed448 CipherString and Groups Selection-client
+[40-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
+server = 40-TLS 1.3 Ed448 CipherString and Groups Selection-server
+client = 40-TLS 1.3 Ed448 CipherString and Groups Selection-client
 
-[38-TLS 1.3 Ed448 CipherString and Groups Selection-server]
+[40-TLS 1.3 Ed448 CipherString and Groups Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1300,14 +1353,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[38-TLS 1.3 Ed448 CipherString and Groups Selection-client]
+[40-TLS 1.3 Ed448 CipherString and Groups Selection-client]
 CipherString = DEFAULT
 Groups = X448
 SignatureAlgorithms = ECDSA+SHA256:ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-38]
+[test-40]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignType = EC
@@ -1315,14 +1368,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[39-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
-ssl_conf = 39-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
+ssl_conf = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
 
-[39-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
-server = 39-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
-client = 39-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
+server = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
+client = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
 
-[39-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = PSS+SHA256
@@ -1330,80 +1383,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[39-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-RSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-39]
-ExpectedClientCANames = empty
-ExpectedClientCertType = RSA
-ExpectedClientSignHash = SHA256
-ExpectedClientSignType = RSA-PSS
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
-ssl_conf = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
-
-[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
-server = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
-client = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
-
-[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ClientSignatureAlgorithms = PSS+SHA256
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-RSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-40]
-ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-ExpectedClientCertType = RSA
-ExpectedClientSignHash = SHA256
-ExpectedClientSignType = RSA-PSS
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
-ssl_conf = 41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
-
-[41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
-server = 41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
-client = 41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
-
-[41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ClientSignatureAlgorithms = ECDSA+SHA256
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
-
-[41-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1415,6 +1395,79 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-41]
+ExpectedClientCANames = empty
+ExpectedClientCertType = RSA
+ExpectedClientSignHash = SHA256
+ExpectedClientSignType = RSA-PSS
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
+ssl_conf = 42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
+
+[42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
+server = 42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
+client = 42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
+
+[42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ClientSignatureAlgorithms = PSS+SHA256
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[42-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+RSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-42]
+ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedClientCertType = RSA
+ExpectedClientSignHash = SHA256
+ExpectedClientSignType = RSA-PSS
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
+ssl_conf = 43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
+
+[43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
+server = 43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
+client = 43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
+
+[43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ClientSignatureAlgorithms = ECDSA+SHA256
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[43-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+RSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-43]
 ExpectedClientCertType = P-256
 ExpectedClientSignHash = SHA256
 ExpectedClientSignType = EC
@@ -1423,21 +1476,21 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[42-TLS 1.3 Ed25519 Client Auth]
-ssl_conf = 42-TLS 1.3 Ed25519 Client Auth-ssl
+[44-TLS 1.3 Ed25519 Client Auth]
+ssl_conf = 44-TLS 1.3 Ed25519 Client Auth-ssl
 
-[42-TLS 1.3 Ed25519 Client Auth-ssl]
-server = 42-TLS 1.3 Ed25519 Client Auth-server
-client = 42-TLS 1.3 Ed25519 Client Auth-client
+[44-TLS 1.3 Ed25519 Client Auth-ssl]
+server = 44-TLS 1.3 Ed25519 Client Auth-server
+client = 44-TLS 1.3 Ed25519 Client Auth-client
 
-[42-TLS 1.3 Ed25519 Client Auth-server]
+[44-TLS 1.3 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[42-TLS 1.3 Ed25519 Client Auth-client]
+[44-TLS 1.3 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -1446,7 +1499,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-42]
+[test-44]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
@@ -1454,21 +1507,21 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[43-TLS 1.3 Ed448 Client Auth]
-ssl_conf = 43-TLS 1.3 Ed448 Client Auth-ssl
+[45-TLS 1.3 Ed448 Client Auth]
+ssl_conf = 45-TLS 1.3 Ed448 Client Auth-ssl
 
-[43-TLS 1.3 Ed448 Client Auth-ssl]
-server = 43-TLS 1.3 Ed448 Client Auth-server
-client = 43-TLS 1.3 Ed448 Client Auth-client
+[45-TLS 1.3 Ed448 Client Auth-ssl]
+server = 45-TLS 1.3 Ed448 Client Auth-server
+client = 45-TLS 1.3 Ed448 Client Auth-client
 
-[43-TLS 1.3 Ed448 Client Auth-server]
+[45-TLS 1.3 Ed448 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[43-TLS 1.3 Ed448 Client Auth-client]
+[45-TLS 1.3 Ed448 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
@@ -1477,7 +1530,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-43]
+[test-45]
 ExpectedClientCertType = Ed448
 ExpectedClientSignType = Ed448
 ExpectedResult = Success
@@ -1485,14 +1538,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[44-TLS 1.2 DSA Certificate Test]
-ssl_conf = 44-TLS 1.2 DSA Certificate Test-ssl
+[46-TLS 1.2 DSA Certificate Test]
+ssl_conf = 46-TLS 1.2 DSA Certificate Test-ssl
 
-[44-TLS 1.2 DSA Certificate Test-ssl]
-server = 44-TLS 1.2 DSA Certificate Test-server
-client = 44-TLS 1.2 DSA Certificate Test-client
+[46-TLS 1.2 DSA Certificate Test-ssl]
+server = 46-TLS 1.2 DSA Certificate Test-server
+client = 46-TLS 1.2 DSA Certificate Test-client
 
-[44-TLS 1.2 DSA Certificate Test-server]
+[46-TLS 1.2 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DHParameters = ${ENV::TEST_CERTS_DIR}/dhp2048.pem
@@ -1502,26 +1555,26 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[44-TLS 1.2 DSA Certificate Test-client]
+[46-TLS 1.2 DSA Certificate Test-client]
 CipherString = ALL
 SignatureAlgorithms = DSA+SHA256:DSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-44]
+[test-46]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
-ssl_conf = 45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
+[47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
+ssl_conf = 47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
 
-[45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
-server = 45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
-client = 45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
+[47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
+server = 47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
+client = 47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
 
-[45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
+[47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = ECDSA+SHA1:DSA+SHA256:RSA+SHA256
@@ -1529,25 +1582,25 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[45-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
+[47-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-45]
+[test-47]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[46-TLS 1.3 DSA Certificate Test]
-ssl_conf = 46-TLS 1.3 DSA Certificate Test-ssl
+[48-TLS 1.3 DSA Certificate Test]
+ssl_conf = 48-TLS 1.3 DSA Certificate Test-ssl
 
-[46-TLS 1.3 DSA Certificate Test-ssl]
-server = 46-TLS 1.3 DSA Certificate Test-server
-client = 46-TLS 1.3 DSA Certificate Test-client
+[48-TLS 1.3 DSA Certificate Test-ssl]
+server = 48-TLS 1.3 DSA Certificate Test-server
+client = 48-TLS 1.3 DSA Certificate Test-client
 
-[46-TLS 1.3 DSA Certificate Test-server]
+[48-TLS 1.3 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-dsa-cert.pem
@@ -1556,13 +1609,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[46-TLS 1.3 DSA Certificate Test-client]
+[48-TLS 1.3 DSA Certificate Test-client]
 CipherString = ALL
 SignatureAlgorithms = DSA+SHA1:DSA+SHA256:ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-46]
+[test-48]
 ExpectedResult = ServerFail
 
 

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -36,6 +36,13 @@ my $server_pss_only = {
     "PrivateKey" => test_pem("server-pss-key.pem"),
 };
 
+my $server_rsa_all = {
+    "PSS.Certificate" => test_pem("server-pss-cert.pem"),
+    "PSS.PrivateKey" => test_pem("server-pss-key.pem"),
+    "Certificate" => test_pem("servercert.pem"),
+    "PrivateKey" => test_pem("serverkey.pem"),
+};
+
 our @tests = (
     {
         name => "ECDSA CipherString Selection",
@@ -355,6 +362,29 @@ our @tests = (
         server => $server_pss_only,
         client => {
             "SignatureAlgorithms" => "RSA+SHA256",
+        },
+        test   => {
+            "ExpectedResult" => "ServerFail"
+        },
+    },
+    {
+        name => "RSA key exchange with all RSA certificate types",
+        server => $server_rsa_all,
+        client => {
+            "CipherString" => "kRSA",
+            "MaxProtocol" => "TLSv1.2",
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "RSA",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "RSA key exchange with only RSA-PSS certificate",
+        server => $server_pss_only,
+        client => {
+            "CipherString" => "kRSA",
+            "MaxProtocol" => "TLSv1.2",
         },
         test   => {
             "ExpectedResult" => "ServerFail"


### PR DESCRIPTION
If we have selected a ciphersuite using RSA key exchange then we must not attempt to use an RSA-PSS cert for that.

Fixes #7059