### PR TITLE
Crash fixes for various crypto algorithms when engine only sets RNG.

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -59,14 +59,15 @@ DH *DH_new_method(ENGINE *engine)
     ret->meth = DH_get_default_method();
 #ifndef OPENSSL_NO_ENGINE
     ret->flags = ret->meth->flags;  /* early default init */
-    if (engine) {
+    if (engine && ENGINE_get_DH(engine)) {
         if (!ENGINE_init(engine)) {
             DHerr(DH_F_DH_NEW_METHOD, ERR_R_ENGINE_LIB);
             goto err;
         }
         ret->engine = engine;
-    } else
+    } else {
         ret->engine = ENGINE_get_default_DH();
+    }
     if (ret->engine) {
         ret->meth = ENGINE_get_DH(ret->engine);
         if (ret->meth == NULL) {

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -66,14 +66,15 @@ DSA *DSA_new_method(ENGINE *engine)
     ret->meth = DSA_get_default_method();
 #ifndef OPENSSL_NO_ENGINE
     ret->flags = ret->meth->flags & ~DSA_FLAG_NON_FIPS_ALLOW; /* early default init */
-    if (engine) {
+    if (engine && ENGINE_get_DSA(engine)) {
         if (!ENGINE_init(engine)) {
             DSAerr(DSA_F_DSA_NEW_METHOD, ERR_R_ENGINE_LIB);
             goto err;
         }
         ret->engine = engine;
-    } else
+    } else {
         ret->engine = ENGINE_get_default_DSA();
+    }
     if (ret->engine) {
         ret->meth = ENGINE_get_DSA(ret->engine);
         if (ret->meth == NULL) {

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -89,7 +89,7 @@ EC_KEY *EC_KEY_new_method(ENGINE *engine)
 
     ret->meth = EC_KEY_get_default_method();
 #ifndef OPENSSL_NO_ENGINE
-    if (engine != NULL) {
+    if ((engine != NULL) && (ENGINE_get_EC(engine) != NULL)) {
         if (!ENGINE_init(engine)) {
             ECerr(EC_F_EC_KEY_NEW_METHOD, ERR_R_ENGINE_LIB);
             goto err;

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -67,7 +67,7 @@ RSA *RSA_new_method(ENGINE *engine)
     ret->meth = RSA_get_default_method();
 #ifndef OPENSSL_NO_ENGINE
     ret->flags = ret->meth->flags & ~RSA_FLAG_NON_FIPS_ALLOW;
-    if (engine) {
+    if (engine && ENGINE_get_RSA(engine)) {
         if (!ENGINE_init(engine)) {
             RSAerr(RSA_F_RSA_NEW_METHOD, ERR_R_ENGINE_LIB);
             goto err;


### PR DESCRIPTION
The code was assuming that just because an engine is provided, that the engine would provide the crypto method for the type of operation performed (RSA, EC, DSA, DH). However, if only an RNG is provided for key or salt generation, crashes would occur.

Fixes: #7102