### PR TITLE
 Process KeyUpdate and NewSessionTicket messages after a close_notify

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1557,29 +1557,15 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
     if ((s->shutdown & SSL_SENT_SHUTDOWN) != 0) {
         if (SSL3_RECORD_get_type(rr) == SSL3_RT_HANDSHAKE) {
             BIO *rbio;
-            /*
-             * We need to check the message type of the received data. We're not
-             * "in init" otherwise we won't have got here - so this is a new
-             * handshake message. However it's theoretically possible for us to
-             * have received part of the message header before us sending
-             * close_notify, and for us to be receiving the remainder of it now.
-             */
-            unsigned char mt = s->rlayer.handshake_fragment_len > 0
-                               ? s->rlayer.handshake_fragment[0]
-                               : *SSL3_RECORD_get_data(rr);
 
             /*
              * We ignore any handshake messages sent to us unless they are
-             * TLSv1.3 NewSessionTicket or KeyUpdate, in which case we want to
-             * process them. For all other handshake messages we can't do
-             * anything reasonable with them because we are unable to write any
-             * response due to having already sent close_notify.
+             * TLSv1.3 in which case we want to process them. For all other
+             * handshake messages we can't do anything reasonable with them
+             * because we are unable to write any response due to having already
+             * sent close_notify.
              */
-            if (!SSL_IS_TLS13(s)
-                       /* Shouldn't ever be 0 but lets be safe */
-                    || SSL3_RECORD_get_length(rr) == 0
-                    || (mt != SSL3_MT_NEWSESSION_TICKET
-                        && mt != SSL3_MT_KEY_UPDATE)) {
+            if (!SSL_IS_TLS13(s)) {
                 SSL3_RECORD_set_length(rr, 0);
                 SSL3_RECORD_set_read(rr);
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -638,9 +638,12 @@ MSG_PROCESS_RETURN tls_process_key_update(SSL *s, PACKET *pkt)
     /*
      * If we get a request for us to update our sending keys too then, we need
      * to additionally send a KeyUpdate message. However that message should
-     * not also request an update (otherwise we get into an infinite loop).
+     * not also request an update (otherwise we get into an infinite loop). We
+     * ignore a request for us to update our sending keys too if we already
+     * sent close_notify.
      */
-    if (updatetype == SSL_KEY_UPDATE_REQUESTED)
+    if (updatetype == SSL_KEY_UPDATE_REQUESTED
+            && (s->shutdown & SSL_SENT_SHUTDOWN) == 0)
         s->key_update = SSL_KEY_UPDATE_NOT_REQUESTED;
 
     if (!tls13_update_key(s, 0)) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5408,7 +5408,7 @@ static int test_shutdown(int tst)
                 || !TEST_true(SSL_write(serverssl, msg, sizeof(msg))))
             goto end;
         if (tst == 4 &&
-                (!TEST_true(SSL_key_update(serverssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+                (!TEST_true(SSL_key_update(serverssl, SSL_KEY_UPDATE_REQUESTED))
                 || !TEST_true(SSL_write(serverssl, msg, sizeof(msg)))))
             goto end;
         if (!TEST_int_eq(SSL_shutdown(serverssl), 1))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5341,8 +5341,8 @@ static int test_ticket_callbacks(int tst)
  * Test 1: TLSv1.2, server continues to read/write after client shutdown
  * Test 2: TLSv1.3, no pending NewSessionTicket messages
  * Test 3: TLSv1.3, pending NewSessionTicket messages
- * Test 4: TLSv1.3, server continues to read/write after client shutdown, client
- *                  reads it
+ * Test 4: TLSv1.3, server continues to read/write after client shutdown, server
+ *                  sends key update, client reads it
  * Test 5: TLSv1.3, server continues to read/write after client shutdown, client
  *                  doesn't read it
  */
@@ -5354,6 +5354,7 @@ static int test_shutdown(int tst)
     char msg[] = "A test message";
     char buf[80];
     size_t written, readbytes;
+    SSL_SESSION *sess;
 
 #ifdef OPENSSL_NO_TLS1_2
     if (tst <= 1)
@@ -5376,10 +5377,14 @@ static int test_shutdown(int tst)
 
     if (tst == 3) {
         if (!TEST_true(create_bare_ssl_connection(serverssl, clientssl,
-                                                  SSL_ERROR_NONE)))
+                                                  SSL_ERROR_NONE))
+                || !TEST_ptr_ne(sess = SSL_get_session(clientssl), NULL)
+                || !TEST_false(SSL_SESSION_is_resumable(sess)))
             goto end;
     } else if (!TEST_true(create_ssl_connection(serverssl, clientssl,
-                                              SSL_ERROR_NONE))) {
+                                              SSL_ERROR_NONE))
+            || !TEST_ptr_ne(sess = SSL_get_session(clientssl), NULL)
+            || !TEST_true(SSL_SESSION_is_resumable(sess))) {
         goto end;
     }
 
@@ -5400,13 +5405,22 @@ static int test_shutdown(int tst)
                     * Even though we're shutdown on receive we should still be
                     * able to write.
                     */
-                || !TEST_true(SSL_write(serverssl, msg, sizeof(msg)))
-                || !TEST_int_eq(SSL_shutdown(serverssl), 1))
+                || !TEST_true(SSL_write(serverssl, msg, sizeof(msg))))
+            goto end;
+        if (tst == 4 &&
+                (!TEST_true(SSL_key_update(serverssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+                || !TEST_true(SSL_write(serverssl, msg, sizeof(msg)))))
+            goto end;
+        if (!TEST_int_eq(SSL_shutdown(serverssl), 1))
             goto end;
         if (tst == 4) {
-                   /* Should still be able to read data from server */
+            /* Should still be able to read data from server */
             if (!TEST_true(SSL_read_ex(clientssl, buf, sizeof(buf),
-                                          &readbytes))
+                                       &readbytes))
+                    || !TEST_size_t_eq(readbytes, sizeof(msg))
+                    || !TEST_int_eq(memcmp(msg, buf, readbytes), 0)
+                    || !TEST_true(SSL_read_ex(clientssl, buf, sizeof(buf),
+                                              &readbytes))
                     || !TEST_size_t_eq(readbytes, sizeof(msg))
                     || !TEST_int_eq(memcmp(msg, buf, readbytes), 0))
                 goto end;
@@ -5430,6 +5444,8 @@ static int test_shutdown(int tst)
                     */
                 || !TEST_false(SSL_write_ex(serverssl, msg, sizeof(msg), &written))
                 || !TEST_int_eq(SSL_shutdown(clientssl), 1)
+                || !TEST_ptr_ne(sess = SSL_get_session(clientssl), NULL)
+                || !TEST_true(SSL_SESSION_is_resumable(sess))
                 || !TEST_int_eq(SSL_shutdown(serverssl), 1))
             goto end;
     } else if (tst == 4) {
@@ -5438,7 +5454,9 @@ static int test_shutdown(int tst)
          * received by the server which has responded with a close_notify. The
          * client needs to read the close_notify sent by the server.
          */
-        if (!TEST_int_eq(SSL_shutdown(clientssl), 1))
+        if (!TEST_int_eq(SSL_shutdown(clientssl), 1)
+                || !TEST_ptr_ne(sess = SSL_get_session(clientssl), NULL)
+                || !TEST_true(SSL_SESSION_is_resumable(sess)))
             goto end;
     } else {
         /*


### PR DESCRIPTION
If we've sent a close_notify then we are restricted about what we can do in response to handshake messages that we receive. However we can sensibly process NewSessionTicket messages. We can also process a KeyUpdate message as long as we also ignore any request for us to update our sending keys.

This is an alternative to #7058. I've used the same test proposed in that PR, so @kroeckx is shown as the author in the second commit.