### PR TITLE
Restore historical SSL_get_servername() behavior

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2600,18 +2600,14 @@ const char *SSL_get_servername(const SSL *s, const int type)
         return NULL;
 
     /*
-     * TODO(OpenSSL1.2) clean up this compat mess.  This API is
-     * currently a mix of "what did I configure" and "what did the
-     * peer send" and "what was actually negotiated"; we should have
-     * a clear distinction amongst those three.
+     * SNI is not negotiated in pre-TLS-1.3 resumption flows, so fake up an
+     * SNI value to return if we are resuming.  N.B. that we still call the
+     * relevant callbacks for such resumption flows, and callbacks might error
+     * out if there is not a SNI value available.
      */
-    if (SSL_in_init(s)) {
-        if (s->hit)
-            return s->session->ext.hostname;
-        return s->ext.hostname;
-    }
-    return (s->session != NULL && s->ext.hostname == NULL) ?
-        s->session->ext.hostname : s->ext.hostname;
+    if (SSL_in_init(s) && s->hit)
+	return s->session->ext.hostname;
+    return s->ext.hostname;
 }
 
 int SSL_get_servername_type(const SSL *s)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2606,7 +2606,7 @@ const char *SSL_get_servername(const SSL *s, const int type)
      * out if there is not a SNI value available.
      */
     if (SSL_in_init(s) && s->hit)
-	return s->session->ext.hostname;
+        return s->session->ext.hostname;
     return s->ext.hostname;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2601,11 +2601,11 @@ const char *SSL_get_servername(const SSL *s, const int type)
 
     /*
      * SNI is not negotiated in pre-TLS-1.3 resumption flows, so fake up an
-     * SNI value to return if we are resuming.  N.B. that we still call the
-     * relevant callbacks for such resumption flows, and callbacks might error
-     * out if there is not a SNI value available.
+     * SNI value to return if we are resuming/resumed.  N.B. that we still
+     * call the relevant callbacks for such resumption flows, and callbacks
+     * might error out if there is not a SNI value available.
      */
-    if (SSL_in_init(s) && s->hit)
+    if (s->hit)
         return s->session->ext.hostname;
     return s->ext.hostname;
 }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -947,7 +947,6 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
              * was not used to negotiate an SNI value for this session.
              * TODO(OpenSSL1.2) cleanup stale value.
              */
-            ;
         } else if (ret == SSL_TLSEXT_ERR_OK && (!s->hit || SSL_IS_TLS13(s))) {
             /* Only store the hostname in the session if we accepted it. */
             OPENSSL_free(s->session->ext.hostname);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -938,16 +938,8 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
      * was successful.
      */
     if (s->server) {
-        if (!sent) {
-            /*
-             * Nothing used from the client this handshake; from the
-             * perspective of TLS any value here is stale/unused.  However,
-             * we have a de facto stable ABI guarantee to preserve this value
-             * for subsequent retrieval with SSL_get_servername() even if it
-             * was not used to negotiate an SNI value for this session.
-             * TODO(OpenSSL1.2) cleanup stale value.
-             */
-        } else if (ret == SSL_TLSEXT_ERR_OK && (!s->hit || SSL_IS_TLS13(s))) {
+        /* TODO(OpenSSL1.2) revisit !sent case */
+        if (sent && ret == SSL_TLSEXT_ERR_OK && (!s->hit || SSL_IS_TLS13(s))) {
             /* Only store the hostname in the session if we accepted it. */
             OPENSSL_free(s->session->ext.hostname);
             s->session->ext.hostname = OPENSSL_strdup(s->ext.hostname);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -939,9 +939,15 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
      */
     if (s->server) {
         if (!sent) {
-            /* Nothing from the client this handshake; cleanup stale value */
-            OPENSSL_free(s->ext.hostname);
-            s->ext.hostname = NULL;
+            /*
+             * Nothing used from the client this handshake; from the
+             * perspective of TLS any value here is stale/unused.  However,
+             * we have a de facto stable ABI guarantee to preserve this value
+             * for subsequent retrieval with SSL_get_servername() even if it
+             * was not used to negotiate an SNI value for this session.
+             * TODO(OpenSSL1.2) cleanup stale value.
+             */
+            ;
         } else if (ret == SSL_TLSEXT_ERR_OK && (!s->hit || SSL_IS_TLS13(s))) {
             /* Only store the hostname in the session if we accepted it. */
             OPENSSL_free(s->session->ext.hostname);


### PR DESCRIPTION
Commit 1c4aa31d79821dee9be98e915159d52cc30d8403 modified the state machine
to clean up stale ext.hostname values from SSL objects in the case when
SNI was not negotiated for the current handshake.  This is natural from
the TLS perspective, since this information is an extension that the client
offered but we ignored, and since we ignored it we do not need to keep it
around for anything else.

However, as documented in https://github.com/openssl/openssl/issues/7014 ,
there appear to be some deployed code that relies on retrieving such an
ignored SNI value from the client, after the handshake has completed.
Because the 1.1.1 release is on a stable branch and should preserve the
published ABI, restore the historical behavior by retaining the ext.hostname
value sent by the client, in the SSL structure, for subsequent retrieval.

[extended tests]

