### PR TITLE
Key zeroization fix for EVP_SealInit. [1.1.0]

### DIFF
--- a/crypto/evp/p_seal.c
+++ b/crypto/evp/p_seal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -21,6 +21,7 @@ int EVP_SealInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
 {
     unsigned char key[EVP_MAX_KEY_LENGTH];
     int i;
+    int rv = 0;
 
     if (type) {
         EVP_CIPHER_CTX_reset(ctx);
@@ -31,21 +32,27 @@ int EVP_SealInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
         return 1;
     if (EVP_CIPHER_CTX_rand_key(ctx, key) <= 0)
         return 0;
+
     if (EVP_CIPHER_CTX_iv_length(ctx)
-        && RAND_bytes(iv, EVP_CIPHER_CTX_iv_length(ctx)) <= 0)
-        return 0;
+            && RAND_bytes(iv, EVP_CIPHER_CTX_iv_length(ctx)) <= 0)
+        goto err;
 
     if (!EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
-        return 0;
+        goto err;
 
     for (i = 0; i < npubk; i++) {
         ekl[i] =
             EVP_PKEY_encrypt_old(ek[i], key, EVP_CIPHER_CTX_key_length(ctx),
                                  pubk[i]);
-        if (ekl[i] <= 0)
-            return (-1);
+        if (ekl[i] <= 0) {
+            rv = -1;
+            goto err;
+        }
     }
-    return (npubk);
+    rv = npubk;
+err:
+    OPENSSL_cleanse(key, sizeof(key));
+    return rv;
 }
 
 /*- MACRO


### PR DESCRIPTION
Manual back port from master.

Preemptively jumping ahead of things a little.

- [x] tests are added or updated
