### PR TITLE
Fix segfault in RSA_free() (and DSA/DH/EC_KEY)

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -83,12 +83,14 @@ DH *DH_new_method(ENGINE *engine)
 
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         DHerr(DH_F_DH_NEW_METHOD, ERR_R_INIT_FAIL);
-err:
-        DH_free(ret);
-        ret = NULL;
+        goto err;
     }
 
     return ret;
+
+ err:
+    DH_free(ret);
+    return NULL;
 }
 
 void DH_free(DH *r)

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -106,7 +106,7 @@ void DH_free(DH *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if ((r->meth != NULL) && (r->meth->finish != NULL))
+    if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(r->engine);

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -104,7 +104,7 @@ void DH_free(DH *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if (r->meth->finish)
+    if ((r->meth != NULL) && (r->meth->finish != NULL))
         r->meth->finish(r);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(r->engine);

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -90,12 +90,14 @@ DSA *DSA_new_method(ENGINE *engine)
 
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         DSAerr(DSA_F_DSA_NEW_METHOD, ERR_R_INIT_FAIL);
-err:
-        DSA_free(ret);
-        ret = NULL;
+        goto err;
     }
 
     return ret;
+
+ err:
+    DSA_free(ret);
+    return NULL;
 }
 
 void DSA_free(DSA *r)

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -111,7 +111,7 @@ void DSA_free(DSA *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if (r->meth->finish)
+    if ((r->meth != NULL) && (r->meth->finish != NULL))
         r->meth->finish(r);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(r->engine);

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -113,7 +113,7 @@ void DSA_free(DSA *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if ((r->meth != NULL) && (r->meth->finish != NULL))
+    if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(r->engine);

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -51,7 +51,7 @@ void EC_KEY_free(EC_KEY *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if (r->meth->finish != NULL)
+    if ((r->meth != NULL) && (r->meth->finish != NULL))
         r->meth->finish(r);
 
 #ifndef OPENSSL_NO_ENGINE

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -51,7 +51,7 @@ void EC_KEY_free(EC_KEY *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if ((r->meth != NULL) && (r->meth->finish != NULL))
+    if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
 
 #ifndef OPENSSL_NO_ENGINE

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -119,7 +119,7 @@ EC_KEY *EC_KEY_new_method(ENGINE *engine)
     }
     return ret;
 
-err:
+ err:
     EC_KEY_free(ret);
     return NULL;
 }

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -97,7 +97,7 @@ RSA *RSA_new_method(ENGINE *engine)
 
     return ret;
 
-err:
+ err:
     RSA_free(ret);
     return NULL;
 }

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -115,7 +115,7 @@ void RSA_free(RSA *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if (r->meth->finish)
+    if ((r->meth != NULL) && (r->meth->finish != NULL))
         r->meth->finish(r);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(r->engine);

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -115,7 +115,7 @@ void RSA_free(RSA *r)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    if ((r->meth != NULL) && (r->meth->finish != NULL))
+    if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_finish(r->engine);


### PR DESCRIPTION
`RSA_free()` and friends are called in case of error from `RSA_new_method(ENGINE *e)` (or the respective equivalent functions).

For the rest of the description I'll talk about `RSA_*`, but the same applies for the equivalent `DSA_free()`, `DH_free()`, `EC_KEY_free()`.

If `RSA_new_method()` fails because the engine does not implement the required method, when `RSA_free(RSA *r)` is called, `r->meth == NULL` and a segfault happens while checking if `r->meth->finish` is defined.

This commit fixes this issue by ensuring that `r->meth` is not NULL before dereferencing it to check for `r->meth->finish`.

This is an alternative to #7103 and fixes #7102 (it fixes the segfault, not the behaviour of `genrsa -engine foo` if `foo` does not implement an RSA method).

This bugfix applies to master and 1.1.0 (and does currently cherry-pick cleanly to `OpenSSL_1_1_0-stable`)

The second commit in the PR is just meant to harmonize the error handling codepaths of the functions related to this bug, and to add a space before the label according to the style guidelines.