### PR TITLE
WIP: Change the behaviour of the `-engine` option for `genrsa`

### DIFF
--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -145,7 +145,7 @@ opthelp:
 
     BIO_printf(bio_err, "Generating RSA private key, %d bit long modulus (%d primes)\n",
                num, primes);
-    rsa = eng ? RSA_new_method(eng) : RSA_new();
+    rsa = eng && ENGINE_get_RSA(eng) != NULL ? RSA_new_method(eng) : RSA_new();
     if (rsa == NULL)
         goto end;
 


### PR DESCRIPTION
This alters the behaviour of the `-engine` option for `genrsa`: currently `-engine` loads the specified engine and then assumes that the specified engine will also implement the RSA method to be used.

If, for example, the specified engine only alters the RNG method but does not specify an ad-hoc RSA method, `genrsa` will report an error:

~~~
$ openssl genrsa -engine rdrand
engine "rdrand" set.
Generating RSA private key, 2048 bit long modulus (2 primes)
140661279535552:error:0406A026:rsa routines:RSA_new_method:ENGINE lib:crypto/rsa/rsa_lib.c:82:
~~~

This is in contrast with using a configuration file to load the engine instead of using the `-engine` command line option.
When such an engine is loaded through the config file, it could replace the RNG functionality, while the default `RSA` method will be used in `genrsa`:

~~~
$ cat /tmp/load_rdrand.cnf
openssl_conf = openssl_def

[openssl_def]
engines = engine_section

[engine_section]
rdrand = rdrand_section

[rdrand_section]
engine_id = rdrand
default_algorithms = ALL

$ OPENSSL_CONF=/tmp/load_rdrand.cnf openssl genrsa
Generating RSA private key, 2048 bit long modulus (2 primes)
..................+++++
.......................................+++++
e is 65537 (0x010001)
-----BEGIN RSA PRIVATE KEY-----
MIIEpQIBAAKCAQEAsptGvoENy7vcBCeNc37vgMq3QljsJj9CDq4yjmATak/RAe7q
[...]
3hwpUQajuBqUVnzQpxLTz3gGS02xSdWjMbXTiKlJlQqEYg9JqHFQkk4=
-----END RSA PRIVATE KEY-----
~~~

Fixes #7102 (the behaviour part)

**Note**: If approved this should be backported to 1.0.2 and 1.1.0 .