### PR TITLE
Prevent ec_precompute_mont_data() in FIPS mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,8 +10,8 @@
  Changes between 1.0.2p and 1.0.2q [xx XXX xxxx]
 
   *) Resolve a compatibility issue in EC_GROUP handling with the FIPS Object
-     Module, accidentally introduced while reverting blinding in ECDSA sign and
-     hindering the use of ECC in FIPS mode.
+     Module, accidentally introduced while backporting security fixes from the
+     development branch and hindering the use of ECC in FIPS mode.
      [Nicola Tuveri]
 
  Changes between 1.0.2o and 1.0.2p [14 Aug 2018]

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,10 @@
 
  Changes between 1.0.2p and 1.0.2q [xx XXX xxxx]
 
-  *)
+  *) Resolve a compatibility issue in EC_GROUP handling with the FIPS Object
+     Module, accidentally introduced while reverting blinding in ECDSA sign and
+     hindering the use of ECC in FIPS mode.
+     [Nicola Tuveri]
 
  Changes between 1.0.2o and 1.0.2p [14 Aug 2018]
 

--- a/crypto/ec/ec_lcl.h
+++ b/crypto/ec/ec_lcl.h
@@ -214,7 +214,7 @@ struct ec_group_st {
     int asn1_flag;              /* flag to control the asn1 encoding */
     /*
      * Kludge: upper bit of ans1_flag is used to denote structure
-     * version. Is set, then last field is present. This is done
+     * version. If set, then last field is present. This is done
      * for interoperation with FIPS code.
      */
 #define EC_GROUP_ASN1_FLAG_MASK 0x7fffffff
@@ -549,7 +549,6 @@ void ec_GFp_nistp_points_make_affine_internal(size_t num, void *point_array,
 void ec_GFp_nistp_recode_scalar_bits(unsigned char *sign,
                                      unsigned char *digit, unsigned char in);
 #endif
-int ec_precompute_mont_data(EC_GROUP *);
 
 #ifdef ECP_NISTZ256_ASM
 /** Returns GFp methods using montgomery multiplication, with x86-64 optimized

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -318,14 +318,6 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     } else
         BN_zero(&group->cofactor);
 
-    /*-
-     * In FIPS mode ec_precompute_mont_data() always fails: in this case we
-     * skip to the end to clear the group->mont_data pointer and return success,
-     * as there is nothing left to do.
-     */
-    if (FIPS_mode())
-        goto end;
-
     /*
      * Some groups have an order with
      * factors of two, which makes the Montgomery setup fail.
@@ -336,7 +328,6 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     }
 
     BN_MONT_CTX_free(group->mont_data);
- end:
     group->mont_data = NULL;
     return 1;
 }

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -72,7 +72,7 @@ const char EC_version[] = "EC" OPENSSL_VERSION_PTEXT;
 
 /* local function prototypes */
 
-static inline int ec_precompute_mont_data(EC_GROUP *);
+static int ec_precompute_mont_data(EC_GROUP *group);
 
 /* functions for EC_GROUP objects */
 
@@ -1121,7 +1121,7 @@ int EC_GROUP_have_precompute_mult(const EC_GROUP *group)
  * OOB accesses, as the group might come from the FIPS module, which does not
  * define the `mont_data` field inside the EC_GROUP structure.
  */
-static inline
+static
 int ec_precompute_mont_data(EC_GROUP *group)
 {
     BN_CTX *ctx = BN_CTX_new();

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -318,6 +318,14 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     } else
         BN_zero(&group->cofactor);
 
+    /*-
+     * In FIPS mode ec_precompute_mont_data() always fails: in this case we
+     * skip to the end to clear the group->mont_data pointer and return success,
+     * as there is nothing left to do.
+     */
+    if (FIPS_mode())
+        goto end;
+
     /*
      * Some groups have an order with
      * factors of two, which makes the Montgomery setup fail.
@@ -328,6 +336,7 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     }
 
     BN_MONT_CTX_free(group->mont_data);
+ end:
     group->mont_data = NULL;
     return 1;
 }

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -70,6 +70,10 @@
 
 const char EC_version[] = "EC" OPENSSL_VERSION_PTEXT;
 
+/* local function prototypes */
+
+static inline int ec_precompute_mont_data(EC_GROUP *);
+
 /* functions for EC_GROUP objects */
 
 EC_GROUP *EC_GROUP_new(const EC_METHOD *meth)
@@ -1106,17 +1110,22 @@ int EC_GROUP_have_precompute_mult(const EC_GROUP *group)
                                  * been performed */
 }
 
-/*
+/*-
  * ec_precompute_mont_data sets |group->mont_data| from |group->order| and
  * returns one on success. On error it returns zero.
+ *
+ * Note: this function must be called only after verifying that
+ * EC_GROUP_VERSION(group) returns true.
+ * The reason for this is that access to the `mont_data` field of an EC_GROUP
+ * struct should always be guarded by an EC_GROUP_VERSION(group) check to avoid
+ * OOB accesses, as the group might come from the FIPS module, which does not
+ * define the `mont_data` field inside the EC_GROUP structure.
  */
+static inline
 int ec_precompute_mont_data(EC_GROUP *group)
 {
     BN_CTX *ctx = BN_CTX_new();
     int ret = 0;
-
-    if (!EC_GROUP_VERSION(group))
-        goto err;
 
     if (group->mont_data) {
         BN_MONT_CTX_free(group->mont_data);


### PR DESCRIPTION
This PR is a tentative fix for #7127 : since 1.0.2p when in FIPS mode, something fails after parsing the explicit parameters in the PEM file, during `PEM_read_bio_ECPrivateKey()`.

It seems that the problem was introduced with e3ab8cc460d1a43fe6310c8d9a92589db1d4f8a3 from #6810 : 
~~~diff
diff --git a/crypto/ec/ec_lib.c b/crypto/ec/ec_lib.c
index 3241aa51d9..0890109980 100644
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -319,12 +319,16 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
         BN_zero(&group->cofactor);
 
     /*
-     * We ignore the return value because some groups have an order with
+     * Some groups have an order with
      * factors of two, which makes the Montgomery setup fail.
      * |group->mont_data| will be NULL in this case.
      */
-    ec_precompute_mont_data(group);
+    if (BN_is_odd(&group->order)) {
+        return ec_precompute_mont_data(group);
+    }
 
+    BN_MONT_CTX_free(group->mont_data);
+    group->mont_data = NULL;
     return 1;
 }
 
~~~

It appears that in FIPS mode `ec_precompute_mont_data()` always fails, before the above change it was failing silently as the return value was ignored. ~~As a *fix*, while in FIPS mode we skip `ec_precompute_mont_data()` completely, clear the group->mont_data pointer and return success, as there is nothing left to do for this function.~~

**Update** (after the analysis in https://github.com/openssl/openssl/pull/7135#discussion_r215781835):

The actual problem lies in the fact that access to the `mont_data` field of an `EC_GROUP` struct should always be guarded by an `EC_GROUP_VERSION(group)` check to avoid OOB accesses, because `group` might come from the FIPS module, which does not define the `mont_data` field inside the `EC_GROUP` structure.

# Reproducing the bug

## Sample code

~~~c
/*-
 * test client for https://github.com/openssl/openssl/issues/7127
 *
 * compiled with:
 *   export OPENSSL_PREFIX=/opt/openssl-102-dbg
 *   gcc -o issue7127 -g -O0 -I${OPENSSL_PREFIX}/include issue7127.c -L${OPENSSL_PREFIX}/lib -lcrypto -Wl,--enable-new-dtags,-rpath,${OPENSSL_PREFIX}/lib
 *
 */

#include <stdlib.h>
#include <stdio.h>

#include <openssl/crypto.h>
#include <openssl/evp.h>
#include <openssl/bio.h>
#include <openssl/pem.h>
#include <openssl/ec.h>
#include <openssl/err.h>

#define TS_ASSERT(a) \
    if (!(a)) { \
        fprintf(stderr, "%s:%d:%s()\t assert failure: " #a "\n", \
                __FILE__, __LINE__, __func__); \
        ERR_print_errors_fp(stderr); \
        exit(100); \
    }

#define TS_ASSERT_EQUALS(a,b) \
    if ((a) != (b)) { \
        fprintf(stderr, "%s:%d:%s()\t assert failure: " #a " == " #b "\n", \
                __FILE__, __LINE__, __func__); \
        ERR_print_errors_fp(stderr); \
        exit(100); \
    }

int main(void)
{
    ERR_load_crypto_strings();
    OpenSSL_add_all_algorithms();
    TS_ASSERT(FIPS_mode_set(1) != 0);
    EC_KEY *ecdsa_key = EC_KEY_new();
    TS_ASSERT(ecdsa_key != NULL);
    EC_GROUP *ecgroup = EC_GROUP_new_by_curve_name(NID_secp224k1);
    TS_ASSERT(ecgroup != NULL);
    TS_ASSERT_EQUALS(1, EC_KEY_set_group(ecdsa_key, ecgroup));
    TS_ASSERT_EQUALS(1, EC_KEY_generate_key(ecdsa_key));
    BIO *bp_private = BIO_new(BIO_s_mem());
    TS_ASSERT(bp_private != NULL);
    if (!PEM_write_bio_ECPrivateKey(bp_private, ecdsa_key, NULL, NULL, 0, NULL, NULL)) {
            TS_ASSERT(0);
    }
    EC_KEY *private_key = PEM_read_bio_ECPrivateKey(bp_private, NULL, NULL, NULL);
    TS_ASSERT(private_key != NULL);

    fprintf(stderr, "SUCCESS\n");
    ERR_print_errors_fp(stderr);
    return 0;
}
~~~

## Backtrace

Here is a backtrace just before hitting the error:
~~~
#0  ec_precompute_mont_data (group=0x5555557766c0) at ec_lib.c:1111
#1  0x00007ffff7a1fdd8 in EC_GROUP_set_generator (group=0x5555557766c0, generator=0x555555776420,
    order=0x555555777d30, cofactor=0x555555777d70) at ec_lib.c:327
#2  0x00007ffff7a2a7d2 in ec_asn1_parameters2group (params=0x555555773220) at ec_asn1.c:912
#3  0x00007ffff7a2a963 in ec_asn1_pkparameters2group (params=0x5555557747c0) at ec_asn1.c:956
#4  0x00007ffff7a2aa8a in d2i_ECPKParameters (a=0x555555774bf8, in=0x7fffffffd5d0, len=149) at ec_asn1.c:986
#5  0x00007ffff7a2b63b in d2i_ECParameters (a=0x0, in=0x7fffffffd5d0, len=149) at ec_asn1.c:1255
#6  0x00007ffff7a2f6ce in eckey_type2param (ptype=16, pval=0x5555557740f0) at ec_ameth.c:153
#7  0x00007ffff7a2fa75 in eckey_priv_decode (pkey=0x555555774760, p8=0x555555774730) at ec_ameth.c:249
#8  0x00007ffff7a80936 in EVP_PKCS82PKEY (p8=0x555555774730) at evp_pkey.c:91
#9  0x00007ffff7ab6c59 in PEM_read_bio_PrivateKey (bp=0x5555557732b0, x=0x0, cb=0x0, u=0x0) at pem_pkey.c:97
#10 0x00007ffff7ab5402 in PEM_read_bio_ECPrivateKey (bp=0x5555557732b0, key=0x0, cb=0x0, u=0x0) at pem_all.c:354
#11 0x0000555555554ed0 in main () at issue7127.c:52
~~~

The error is hit in [ec_lib.c:1110](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/ec/ec_lib.c#L1110).