### PR TITLE
Ensure certificate callbacks work correctly in TLSv1.3

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1486,7 +1486,8 @@ static int ssl_method_error(const SSL *s, const SSL_METHOD *method)
 
 /*
  * Only called by servers. Returns 1 if the server has a TLSv1.3 capable
- * certificate type, or has PSK configured. Otherwise returns 0.
+ * certificate type, or has PSK or a certificate callback configured. Otherwise
+ * returns 0.
  */
 static int is_tls13_capable(const SSL *s)
 {
@@ -1497,7 +1498,7 @@ static int is_tls13_capable(const SSL *s)
         return 1;
 #endif
 
-    if (s->psk_find_session_cb != NULL)
+    if (s->psk_find_session_cb != NULL || s->cert->cert_cb != NULL)
         return 1;
 
     for (i = 0; i < SSL_PKEY_NUM; i++) {


### PR DESCRIPTION
The `is_tls13_capable()` function should not return 0 if no certificates
are configured directly because a certificate callback is present.

Fixes #7140