### PR TITLE
Set a received record to "read" if we've already had close_notify

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1339,6 +1339,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
      */
     if (s->shutdown & SSL_RECEIVED_SHUTDOWN) {
         SSL3_RECORD_set_length(rr, 0);
+        SSL3_RECORD_set_read(rr);
         s->rwstate = SSL_NOTHING;
         return 0;
     }


### PR DESCRIPTION
If the peer already sent close_notify the comment in the code says that
we throw anything away that is sent to us. In reality though we weren't
setting the record as "read" and so it was never thrown away. This would
mean any further records will never be removed from the underlying BIO.
I don't think this makes any practical difference (we shouldn't be trying
to read stuff after having a close_notify anyway). But we should do it
for consistency and cleanliness of the code.

Impacts master and 1.1.0
