### PR TITLE
ASN.1 DER: Make INT32 / INT64 types read badly encoded LONG zeroes

### DIFF
--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -77,6 +77,15 @@ static int uint64_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     char *cp;
     int neg = 0;
 
+    /*
+     * Strictly speaking, zero length is malformed.  However, long_c2i
+     * (x_long.c) encodes 0 as a zero length INTEGER (wrongly, of course),
+     * so for the sake of backward compatibility, we still decode zero
+     * length INTEGERs as the number zero.
+     */
+    if (len == 0)
+        goto long_compat;
+
     if (*pval == NULL && !uint64_new(pval, it))
         return 0;
 
@@ -95,6 +104,8 @@ static int uint64_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     if (neg)
         /* c2i_uint64_int() returns positive values */
         utmp = 0 - utmp;
+
+ long_compat:
     memcpy(cp, &utmp, sizeof(utmp));
     return 1;
 }
@@ -168,6 +179,15 @@ static int uint32_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     char *cp;
     int neg = 0;
 
+    /*
+     * Strictly speaking, zero length is malformed.  However, long_c2i
+     * (x_long.c) encodes 0 as a zero length INTEGER (wrongly, of course),
+     * so for the sake of backward compatibility, we still decode zero
+     * length INTEGERs as the number zero.
+     */
+    if (len == 0)
+        goto long_compat;
+
     if (*pval == NULL && !uint64_new(pval, it))
         return 0;
 
@@ -191,6 +211,8 @@ static int uint32_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
             return 0;
         }
     }
+
+ long_compat:
     utmp2 = (uint32_t)utmp;
     memcpy(cp, &utmp2, sizeof(utmp2));
     return 1;

--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -77,6 +77,11 @@ static int uint64_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     char *cp;
     int neg = 0;
 
+    if (*pval == NULL && !uint64_new(pval, it))
+        return 0;
+
+    cp = (char *)*pval;
+
     /*
      * Strictly speaking, zero length is malformed.  However, long_c2i
      * (x_long.c) encodes 0 as a zero length INTEGER (wrongly, of course),
@@ -86,10 +91,6 @@ static int uint64_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     if (len == 0)
         goto long_compat;
 
-    if (*pval == NULL && !uint64_new(pval, it))
-        return 0;
-
-    cp = (char *)*pval;
     if (!c2i_uint64_int(&utmp, &neg, &cont, len))
         return 0;
     if ((it->size & INTxx_FLAG_SIGNED) == 0 && neg) {
@@ -179,6 +180,11 @@ static int uint32_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     char *cp;
     int neg = 0;
 
+    if (*pval == NULL && !uint64_new(pval, it))
+        return 0;
+
+    cp = (char *)*pval;
+
     /*
      * Strictly speaking, zero length is malformed.  However, long_c2i
      * (x_long.c) encodes 0 as a zero length INTEGER (wrongly, of course),
@@ -188,10 +194,6 @@ static int uint32_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     if (len == 0)
         goto long_compat;
 
-    if (*pval == NULL && !uint64_new(pval, it))
-        return 0;
-
-    cp = (char *)*pval;
     if (!c2i_uint64_int(&utmp, &neg, &cont, len))
         return 0;
     if ((it->size & INTxx_FLAG_SIGNED) == 0 && neg) {

--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/rand.h>
+#include <openssl/asn1t.h>
+#include "internal/numbers.h"
+#include "testutil.h"
+
+#ifdef __GNUC__
+# pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+#ifdef __clang__
+# pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
+/* Badly coded ASN.1 INTEGER zero wrapped in a sequence */
+unsigned char t_invalid_zero[] = {
+    0x30, 0x02,                  /* SEQUENCE tag + length */
+    0x02, 0x00                   /* INTEGER tag + length */
+};
+
+/* INT32 case ************************************************************* */
+
+typedef struct {
+    int32_t test_int32;
+} ASN1_INT32_DATA;
+
+ASN1_SEQUENCE(ASN1_INT32_DATA) = {
+    ASN1_EMBED(ASN1_INT32_DATA, test_int32, INT32),
+} static_ASN1_SEQUENCE_END(ASN1_INT32_DATA)
+
+IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(ASN1_INT32_DATA)
+IMPLEMENT_STATIC_ASN1_ALLOC_FUNCTIONS(ASN1_INT32_DATA)
+
+static int test_int32(void)
+{
+    const unsigned char *p = t_invalid_zero;
+    ASN1_INT32_DATA *dectst =
+        d2i_ASN1_INT32_DATA(NULL, &p, sizeof(t_invalid_zero));
+
+    if (dectst == NULL)
+        return 0;                /* Fail */
+
+    ASN1_INT32_DATA_free(dectst);
+    return 1;
+}
+
+/* UINT32 case ************************************************************* */
+
+typedef struct {
+    uint32_t test_uint32;
+} ASN1_UINT32_DATA;
+
+ASN1_SEQUENCE(ASN1_UINT32_DATA) = {
+    ASN1_EMBED(ASN1_UINT32_DATA, test_uint32, UINT32),
+} static_ASN1_SEQUENCE_END(ASN1_UINT32_DATA)
+
+IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(ASN1_UINT32_DATA)
+IMPLEMENT_STATIC_ASN1_ALLOC_FUNCTIONS(ASN1_UINT32_DATA)
+
+static int test_uint32(void)
+{
+    const unsigned char *p = t_invalid_zero;
+    ASN1_UINT32_DATA *dectst =
+        d2i_ASN1_UINT32_DATA(NULL, &p, sizeof(t_invalid_zero));
+
+    if (dectst == NULL)
+        return 0;                /* Fail */
+
+    ASN1_UINT32_DATA_free(dectst);
+    return 1;
+}
+
+/* INT64 case ************************************************************* */
+
+typedef struct {
+    int64_t test_int64;
+} ASN1_INT64_DATA;
+
+ASN1_SEQUENCE(ASN1_INT64_DATA) = {
+    ASN1_EMBED(ASN1_INT64_DATA, test_int64, INT64),
+} static_ASN1_SEQUENCE_END(ASN1_INT64_DATA)
+
+IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(ASN1_INT64_DATA)
+IMPLEMENT_STATIC_ASN1_ALLOC_FUNCTIONS(ASN1_INT64_DATA)
+
+static int test_int64(void)
+{
+    const unsigned char *p = t_invalid_zero;
+    ASN1_INT64_DATA *dectst =
+        d2i_ASN1_INT64_DATA(NULL, &p, sizeof(t_invalid_zero));
+
+    if (dectst == NULL)
+        return 0;                /* Fail */
+
+    ASN1_INT64_DATA_free(dectst);
+    return 1;
+}
+
+/* UINT64 case ************************************************************* */
+
+typedef struct {
+    uint64_t test_uint64;
+} ASN1_UINT64_DATA;
+
+ASN1_SEQUENCE(ASN1_UINT64_DATA) = {
+    ASN1_EMBED(ASN1_UINT64_DATA, test_uint64, UINT64),
+} static_ASN1_SEQUENCE_END(ASN1_UINT64_DATA)
+
+IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(ASN1_UINT64_DATA)
+IMPLEMENT_STATIC_ASN1_ALLOC_FUNCTIONS(ASN1_UINT64_DATA)
+
+static int test_uint64(void)
+{
+    const unsigned char *p = t_invalid_zero;
+    ASN1_UINT64_DATA *dectst =
+        d2i_ASN1_UINT64_DATA(NULL, &p, sizeof(t_invalid_zero));
+
+    if (dectst == NULL)
+        return 0;                /* Fail */
+
+    ASN1_UINT64_DATA_free(dectst);
+    return 1;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_int32);
+    ADD_TEST(test_uint32);
+    ADD_TEST(test_int64);
+    ADD_TEST(test_uint64);
+    return 1;
+}

--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -23,7 +23,7 @@
 #endif
 
 /* Badly coded ASN.1 INTEGER zero wrapped in a sequence */
-unsigned char t_invalid_zero[] = {
+static unsigned char t_invalid_zero[] = {
     0x30, 0x02,                  /* SEQUENCE tag + length */
     0x02, 0x00                   /* INTEGER tag + length */
 };

--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -28,6 +28,34 @@ unsigned char t_invalid_zero[] = {
     0x02, 0x00                   /* INTEGER tag + length */
 };
 
+#if OPENSSL_API_COMPAT < 0x10200000L
+/* LONG case ************************************************************* */
+
+typedef struct {
+    long test_long;
+} ASN1_LONG_DATA;
+
+ASN1_SEQUENCE(ASN1_LONG_DATA) = {
+    ASN1_EMBED(ASN1_LONG_DATA, test_long, LONG),
+} static_ASN1_SEQUENCE_END(ASN1_LONG_DATA)
+
+IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(ASN1_LONG_DATA)
+IMPLEMENT_STATIC_ASN1_ALLOC_FUNCTIONS(ASN1_LONG_DATA)
+
+static int test_long(void)
+{
+    const unsigned char *p = t_invalid_zero;
+    ASN1_LONG_DATA *dectst =
+        d2i_ASN1_LONG_DATA(NULL, &p, sizeof(t_invalid_zero));
+
+    if (dectst == NULL)
+        return 0;                /* Fail */
+
+    ASN1_LONG_DATA_free(dectst);
+    return 1;
+}
+#endif
+
 /* INT32 case ************************************************************* */
 
 typedef struct {
@@ -134,6 +162,9 @@ static int test_uint64(void)
 
 int setup_tests(void)
 {
+#if OPENSSL_API_COMPAT < 0x10200000L
+    ADD_TEST(test_long);
+#endif
     ADD_TEST(test_int32);
     ADD_TEST(test_uint32);
     ADD_TEST(test_int64);

--- a/test/build.info
+++ b/test/build.info
@@ -44,7 +44,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
           bio_callback_test \
           bioprinttest sslapitest dtlstest sslcorrupttest bio_enc_test \
           pkey_meth_test pkey_meth_kdf_test uitest cipherbytes_test \
-          asn1_encode_test asn1_string_table_test \
+          asn1_encode_test asn1_decode_test asn1_string_table_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest sslbuffertest \
           recordlentest drbgtest drbg_cavs_test sslbuffertest \
@@ -409,6 +409,10 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[asn1_encode_test]=asn1_encode_test.c
   INCLUDE[asn1_encode_test]=../include
   DEPEND[asn1_encode_test]=../libcrypto libtestutil.a
+
+  SOURCE[asn1_decode_test]=asn1_decode_test.c
+  INCLUDE[asn1_decode_test]=../include
+  DEPEND[asn1_decode_test]=../libcrypto libtestutil.a
 
   SOURCE[asn1_string_table_test]=asn1_string_table_test.c
   INCLUDE[asn1_string_table_test]=../include

--- a/test/recipes/04-test_asn1_decode.t
+++ b/test/recipes/04-test_asn1_decode.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_asn1_decode", "asn1_decode_test");


### PR DESCRIPTION
The deprecated ASN.1 type LONG / ZLONG (incorrectly) produced zero
length INTEGER encoding for zeroes.  For the sake of backward
compatibility, we allow those to be read without fault when using the
replacement types INT32 / UINT32 / INT64 / UINT64.

Fixes #7134
