### PR TITLE
Do not reset SNI data in SSL_do_handshake()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3559,12 +3559,6 @@ int SSL_do_handshake(SSL *s)
 
     s->method->ssl_renegotiate_check(s, 0);
 
-    if (SSL_is_server(s)) {
-        /* clear SNI settings at server-side */
-        OPENSSL_free(s->ext.hostname);
-        s->ext.hostname = NULL;
-    }
-
     if (SSL_in_init(s) || SSL_in_before(s)) {
         if ((s->mode & SSL_MODE_ASYNC) && ASYNC_get_current_job() == NULL) {
             struct ssl_async_args args;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -904,8 +904,12 @@ static int final_renegotiate(SSL *s, unsigned int context, int sent)
 
 static int init_server_name(SSL *s, unsigned int context)
 {
-    if (s->server)
+    if (s->server) {
         s->servername_done = 0;
+
+        OPENSSL_free(s->ext.hostname);
+        s->ext.hostname = NULL;
+    }
 
     return 1;
 }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -139,10 +139,6 @@ int tls_setup_handshake(SSL *s)
 
             s->s3->tmp.cert_request = 0;
         }
-
-        /* clear SNI settings at server-side */
-        OPENSSL_free(s->ext.hostname);
-        s->ext.hostname = NULL;
     } else {
         if (SSL_IS_FIRST_HANDSHAKE(s))
             tsan_counter(&s->session_ctx->stats.sess_connect);

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -139,6 +139,10 @@ int tls_setup_handshake(SSL *s)
 
             s->s3->tmp.cert_request = 0;
         }
+
+        /* clear SNI settings at server-side */
+        OPENSSL_free(s->ext.hostname);
+        s->ext.hostname = NULL;
     } else {
         if (SSL_IS_FIRST_HANDSHAKE(s))
             tsan_counter(&s->session_ctx->stats.sess_connect);

--- a/test/build.info
+++ b/test/build.info
@@ -364,7 +364,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   INCLUDE[ciphername_test]=../include
   DEPEND[ciphername_test]=../libcrypto ../libssl libtestutil.a
 
-  SOURCE[servername_test]=servername_test.c
+  SOURCE[servername_test]=servername_test.c ssltestlib.c
   INCLUDE[servername_test]=../include
   DEPEND[servername_test]=../libcrypto ../libssl libtestutil.a
 

--- a/test/recipes/70-test_servername.t
+++ b/test/recipes/70-test_servername.t
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use OpenSSL::Test::Simple;
-use OpenSSL::Test;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
 use OpenSSL::Test::Utils qw(alldisabled available_protocols);
 
 setup("test_servername");
@@ -19,4 +19,8 @@ setup("test_servername");
 plan skip_all => "No TLS/SSL protocols are supported by this OpenSSL build"
     if alldisabled(grep { $_ ne "ssl3" } available_protocols("tls"));
 
-simple_test("test_servername", "servername_test");
+plan tests => 1;
+
+ok(run(test(["servername_test", srctop_file("apps", "server.pem"),
+             srctop_file("apps", "server.pem")])),
+             "running servername_test");


### PR DESCRIPTION
PR #3783 introduce coded to reset the server side SNI state in
SSL_do_handshake() to ensure any erroneous config time SNI changes are
cleared. Unfortunately SSL_do_handshake() can be called mid-handshake
multiple times so this is the wrong place to do this and can mean that
any SNI data is cleared later on in the handshake too.

Therefore move the code to a more appropriate place.

Fixes #7014
