### PR TITLE
crypto/rsa/rsa_pss.c: silence coverity warning

### DIFF
--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -244,7 +244,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
 
  err:
     EVP_MD_CTX_free(ctx);
-    OPENSSL_clear_free(salt, sLen);
+    OPENSSL_clear_free(salt, (size_t)sLen); /* salt != NULL implies sLen > 0 */
 
     return ret;
 


### PR DESCRIPTION
Reported by Coverity Scan (CID ~~1439136~~ 1439138)
