### PR TITLE
Rename object files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,11 @@
 
   *)
 
+  *) Rename the object files, i.e. give them other names than in previous
+     versions.  Their names now include the name of the final product, as
+     well as its type mnemonic (bin, lib, shlib).
+     [Richard Levitte]
+
  Changes between 1.1.0i and 1.1.1 [11 Sep 2018]
 
   *) Add a new ClientHello callback. Provides a callback interface that gives

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -125,8 +125,7 @@
      unless ($disabled{shared} || $lib =~ /\.a$/) {
          $OUT .= libobj2shlib(shlib => $unified_info{sharednames}->{$lib},
                               lib => $lib,
-                              objs => [ @{$unified_info{shared_sources}->{$lib}},
-                                        @{$unified_info{sources}->{$lib}} ],
+                              objs => $unified_info{shared_sources}->{$lib},
                               deps => [ reducedepends(resolvedepends($lib)) ],
                               installed => is_installed($lib));
          foreach ((@{$unified_info{shared_sources}->{$lib}},
@@ -155,12 +154,10 @@
      my $lib = shift;
      return "" if $cache{$lib};
      $OUT .= obj2dso(lib => $lib,
-                     objs => [ @{$unified_info{sources}->{$lib}},
-                               @{$unified_info{shared_sources}->{$lib}} ],
+                     objs => $unified_info{shared_sources}->{$lib},
                      deps => [ resolvedepends($lib) ],
                      installed => is_installed($lib));
-     foreach ((@{$unified_info{sources}->{$lib}},
-               @{$unified_info{shared_sources}->{$lib}})) {
+     foreach (@{$unified_info{shared_sources}->{$lib}}) {
          doobj($_, $lib, intent => "dso", installed => is_installed($lib));
      }
      $cache{$lib} = 1;

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -82,7 +82,8 @@
                              generator_incs => $unified_info{includes}->{$script},
                              generator_deps => $unified_info{depends}->{$script},
                              deps => $unified_info{depends}->{$src},
-                             incs => $unified_info{includes}->{$obj},
+                             incs => [ @{$unified_info{includes}->{$obj}},
+                                       @{$unified_info{includes}->{$bin}} ],
                              %opts);
          foreach (@{$unified_info{depends}->{$src}}) {
              dogenerate($_, $obj, $bin, %opts);
@@ -103,7 +104,8 @@
                          product => $bin,
                          srcs => $unified_info{sources}->{$obj},
                          deps => $unified_info{depends}->{$obj},
-                         incs => $unified_info{includes}->{$obj},
+                         incs => [ @{$unified_info{includes}->{$obj}},
+                                   @{$unified_info{includes}->{$bin}} ],
                          %opts);
          foreach ((@{$unified_info{sources}->{$obj}},
                    @{$unified_info{depends}->{$obj}})) {

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -133,7 +133,7 @@
              # If this is somehow a compiled object, take care of it that way
              # Otherwise, it might simply be generated
              if (defined $unified_info{sources}->{$_}) {
-                 doobj($_, $lib, intent => "lib", installed => is_installed($lib));
+                 doobj($_, $lib, intent => "shlib", installed => is_installed($lib));
              } else {
                  dogenerate($_, undef, undef, intent => "lib");
              }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -777,11 +777,13 @@ EOF
           }
 
           my $cppflags = {
+              shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
               bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
           } -> {$args{intent}};
-          my @incs_cmds = includes({ lib => '$(LIB_INCLUDES)',
+          my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
+                                     lib => '$(LIB_INCLUDES)',
                                      dso => '$(DSO_INCLUDES)',
                                      bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
                                    '$(CNF_INCLUDES)',
@@ -844,7 +846,8 @@ EOF
       my $after = $unified_info{after}->{$obj.".OBJ"} || "\@ !";
 
       if ($srcs[0] =~ /\.asm$/) {
-          my $asflags = { lib => ' $(LIB_ASFLAGS)',
+          my $asflags = { shlib => ' $(LIB_ASFLAGS)',
+		          lib => ' $(LIB_ASFLAGS)',
 		          dso => ' $(DSO_ASFLAGS)',
 		          bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
           return <<"EOF";
@@ -858,19 +861,23 @@ EOF
 
       my $cflags;
       if ($args{installed}) {
-          $cflags = { lib => '$(LIB_CFLAGS)',
+          $cflags = { shlib => '$(LIB_CFLAGS)',
+                      lib => '$(LIB_CFLAGS)',
                       dso => '$(DSO_CFLAGS)',
                       bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
       } else {
-          $cflags = { lib => '$(NO_INST_LIB_CFLAGS)',
+          $cflags = { shlib => '$(NO_INST_LIB_CFLAGS)',
+                      lib => '$(NO_INST_LIB_CFLAGS)',
                       dso => '$(NO_INST_DSO_CFLAGS)',
                       bin => '$(NO_INST_BIN_CFLAGS)' } -> {$args{intent}};
       }
-      $cflags .= { lib => '$(LIB_CPPFLAGS)',
+      $cflags .= { shlib => '$(LIB_CPPFLAGS)',
+		   lib => '$(LIB_CPPFLAGS)',
 		   dso => '$(DSO_CPPFLAGS)',
 		   bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
 
-      my @incs_cmds = includes({ lib => '$(LIB_INCLUDES)',
+      my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
+                                 lib => '$(LIB_INCLUDES)',
                                  dso => '$(DSO_INCLUDES)',
                                  bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
                                '$(INCLUDES)',

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -984,6 +984,7 @@ EOF
           }
 
           my $cppflags = {
+              shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
               bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
@@ -1023,6 +1024,7 @@ EOF
           $cmd = '$(CXX)';
           $cmdcompile = ' -c';
           $cmdflags = {
+              shlib => '$(LIB_CXXFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CXXFLAGS) $(LIB_CPPFLAGS)',
               dso => '$(DSO_CXXFLAGS) $(DSO_CPPFLAGS)',
               bin => '$(BIN_CXXFLAGS) $(BIN_CPPFLAGS)'
@@ -1031,6 +1033,7 @@ EOF
           $cmd = '$(CC)';
           $cmdcompile = ' -c';
           $cmdflags = {
+              shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
               bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -531,6 +531,7 @@ EOF
 
           my $cppflags = $incs;
           $cppflags .= {
+              shlib => ' $(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => ' $(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               dso => ' $(DSO_CFLAGS) $(DSO_CPPFLAGS)',
               bin => ' $(BIN_CFLAGS) $(BIN_CPPFLAGS)'
@@ -568,14 +569,17 @@ EOF
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
-     my $cflags = { lib => ' $(LIB_CFLAGS)',
+     my $cflags = { shlib => ' $(LIB_CFLAGS)',
+		    lib => ' $(LIB_CFLAGS)',
 		    dso => ' $(DSO_CFLAGS)',
 		    bin => ' $(BIN_CFLAGS)' } -> {$args{intent}};
      $cflags .= $incs;
-     $cflags .= { lib => ' $(LIB_CPPFLAGS)',
+     $cflags .= { shlib => ' $(LIB_CPPFLAGS)',
+		  lib => ' $(LIB_CPPFLAGS)',
 		  dso => ' $(DSO_CPPFLAGS)',
 		  bin => ' $(BIN_CPPFLAGS)' } -> {$args{intent}};
-     my $asflags = { lib => ' $(LIB_ASFLAGS)',
+     my $asflags = { shlib => ' $(LIB_ASFLAGS)',
+		     lib => ' $(LIB_ASFLAGS)',
 		     dso => ' $(DSO_ASFLAGS)',
 		     bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
      my $makedepprog = $config{makedepprog};

--- a/Configure
+++ b/Configure
@@ -2189,25 +2189,25 @@ EOF
         }
     }
 
-    # Trickle down includes placed on libraries, engines and programs to
-    # their sources (i.e. object files)
-    foreach my $dest (keys %{$unified_info{engines}},
-                      keys %{$unified_info{libraries}},
-                      keys %{$unified_info{programs}}) {
-        foreach my $k (("source", "build")) {
-            next unless defined($unified_info{includes}->{$dest}->{$k});
-            my @incs = reverse @{$unified_info{includes}->{$dest}->{$k}};
-            foreach my $obj (grep /\.o$/,
-                             (keys %{$unified_info{sources}->{$dest}},
-                              keys %{$unified_info{shared_sources}->{$dest}})) {
-                foreach my $inc (@incs) {
-                    unshift @{$unified_info{includes}->{$obj}->{$k}}, $inc
-                        unless grep { $_ eq $inc } @{$unified_info{includes}->{$obj}->{$k}};
-                }
-            }
-        }
-        delete $unified_info{includes}->{$dest};
-    }
+#    # Trickle down includes placed on libraries, engines and programs to
+#    # their sources (i.e. object files)
+#    foreach my $dest (keys %{$unified_info{engines}},
+#                      keys %{$unified_info{libraries}},
+#                      keys %{$unified_info{programs}}) {
+#        foreach my $k (("source", "build")) {
+#            next unless defined($unified_info{includes}->{$dest}->{$k});
+#            my @incs = reverse @{$unified_info{includes}->{$dest}->{$k}};
+#            foreach my $obj (grep /\.o$/,
+#                             (keys %{$unified_info{sources}->{$dest}},
+#                              keys %{$unified_info{shared_sources}->{$dest}})) {
+#                foreach my $inc (@incs) {
+#                    unshift @{$unified_info{includes}->{$obj}->{$k}}, $inc
+#                        unless grep { $_ eq $inc } @{$unified_info{includes}->{$obj}->{$k}};
+#                }
+#            }
+#        }
+#        delete $unified_info{includes}->{$dest};
+#    }
 
     ### Make unified_info a bit more efficient
     # One level structures
@@ -2233,9 +2233,11 @@ EOF
                 push @{$unified_info{includes}->{$dest}}, $inc
                     unless grep { $_ eq $inc } @{$unified_info{includes}->{$dest}};
             }
-        } else {
+        } elsif (defined($unified_info{includes}->{$dest}->{source})) {
             $unified_info{includes}->{$dest} =
                 [ @{$unified_info{includes}->{$dest}->{source}} ];
+        } else {
+            delete $unified_info{includes}->{$dest};
         }
     }
 }

--- a/Configure
+++ b/Configure
@@ -2029,15 +2029,15 @@ EOF
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++
                     $o = cleanfile($buildd, $o, $blddir);
-                    $unified_info{sources}->{$ddest}->{$o} = 1;
-                    $unified_info{sources}->{$o}->{$s} = 1;
+                    $unified_info{sources}->{$ddest}->{$o} = -1;
+                    $unified_info{sources}->{$o}->{$s} = -1;
                 } elsif ($s =~ /\.rc$/) {
                     # We also recognise resource files
                     my $o = $_;
                     $o =~ s/\.rc$/.res/; # Resource configuration
                     my $o = cleanfile($buildd, $o, $blddir);
-                    $unified_info{sources}->{$ddest}->{$o} = 1;
-                    $unified_info{sources}->{$o}->{$s} = 1;
+                    $unified_info{sources}->{$ddest}->{$o} = -1;
+                    $unified_info{sources}->{$o}->{$s} = -1;
                 } else {
                     $unified_info{sources}->{$ddest}->{$s} = 1;
                 }
@@ -2065,15 +2065,15 @@ EOF
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++
                     $o = cleanfile($buildd, $o, $blddir);
-                    $unified_info{shared_sources}->{$ddest}->{$o} = 1;
-                    $unified_info{sources}->{$o}->{$s} = 1;
+                    $unified_info{shared_sources}->{$ddest}->{$o} = -1;
+                    $unified_info{sources}->{$o}->{$s} = -1;
                 } elsif ($s =~ /\.rc$/) {
                     # We also recognise resource files
                     my $o = $_;
                     $o =~ s/\.rc$/.res/; # Resource configuration
                     my $o = cleanfile($buildd, $o, $blddir);
-                    $unified_info{shared_sources}->{$ddest}->{$o} = 1;
-                    $unified_info{sources}->{$o}->{$s} = 1;
+                    $unified_info{shared_sources}->{$ddest}->{$o} = -1;
+                    $unified_info{sources}->{$o}->{$s} = -1;
                 } elsif ($s =~ /\.(def|map|opt)$/) {
                     # We also recognise .def / .map / .opt files
                     # We know they are generated files
@@ -2209,6 +2209,93 @@ EOF
 #        delete $unified_info{includes}->{$dest};
 #    }
 
+    # Go through all object files and change their names to something that
+    # reflects what they will be built for.  Note that for some source files,
+    # this leads to duplicate object files because they are used multiple times.
+    # the goal is to rename all object files according to this scheme:
+    #    {productname}-{midfix}-{origobjname}.[o|res]
+    # the {midfix} is a keyword indicating the type of product, which is mostly
+    # valuable for libraries since they come in two forms.
+    {
+        # Take copies so we don't get interference from added stuff
+        my %unified_copy = (
+            sources =>        { %{$unified_info{sources}} },
+            shared_sources => { %{$unified_info{shared_sources}} },
+           );
+        delete $unified_info{sources};
+        delete $unified_info{shared_sources};
+        foreach my $prodtype (('programs', 'libraries', 'engines', 'scripts')) {
+            # $intent serves multi purposes:
+            # - give a prefix for the new object files names
+            # - in the case of libraries, rearrange the object files so static
+            #   libraries use the 'sources' structure exclusively, while shared
+            #   libraries use the 'shared_sources' structure exclusively.
+            my $intent = {
+                programs  => { bin    => { src => [ 'sources' ],
+                                           dst => 'sources' } },
+                libraries => { lib    => { src => [ 'sources' ],
+                                           dst => 'sources' },
+                               shlib  => { prodselect =>
+                                               sub { grep !/\.a$/, @_ },
+                                           src => [ 'sources',
+                                                    'shared_sources' ],
+                                           dst => 'shared_sources' } },
+                engines   => { dso    => { src => [ 'sources',
+                                                    'shared_sources' ],
+                                           dst => 'shared_sources' } },
+                scripts   => { script => { src => [ 'sources' ],
+                                           dst => 'sources' } }
+               } -> {$prodtype};
+            foreach my $kind (keys %$intent) {
+                my @src = @{$intent->{$kind}->{src}};
+                my $dst = $intent->{$kind}->{dst};
+                my $prodselect = $intent->{$kind}->{prodselect} // sub { @_ };
+                foreach my $prod ($prodselect->(keys %{$unified_info{$prodtype}})) {
+                    # %prod_sources has all applicable objects as keys, and
+                    # their corresponding sources as values
+                    my %prod_sources =
+                        map { $_ => [ keys %{$unified_copy{sources}->{$_}} ] }
+                        map { keys %{$unified_copy{$_}->{$prod}} }
+                        @src;
+                    foreach (keys %prod_sources) {
+                        # Only affect object or resource files, the others
+                        # simply get a new value (+1 instead of -1)
+                        if ($_ =~ /\.(o|res)$/) {
+                            (my $prodname = $prod) =~ s|\.a$||;
+                            my $newobj =
+                                catfile(dirname($_),
+                                        basename($prodname)
+                                            . '-' . $kind
+                                            . '-' . basename($_));
+                            $unified_info{$dst}->{$prod}->{$newobj} = 1;
+                            foreach my $src (@{$prod_sources{$_}}) {
+                                $unified_info{sources}->{$newobj}->{$src} = 1;
+                            }
+                            # Adjust dependencies
+                            foreach my $deps (keys %{$unified_info{depends}->{$_}}) {
+                                $unified_info{depends}->{$_}->{$deps} = -1;
+                                $unified_info{depends}->{$newobj}->{$deps} = 1;
+                            }
+                            # Adjust includes
+                            foreach my $k (('source', 'build')) {
+                                next unless
+                                    defined($unified_info{includes}->{$_}->{$k});
+                                my @incs = @{$unified_info{includes}->{$_}->{$k}};
+                                $unified_info{includes}->{$newobj}->{$k} = [ @incs ];
+                            }
+                        } else {
+                            $unified_info{$dst}->{$prod}->{$_} = 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    # At this point, we have a number of sources with the value -1.  They
+    # aren't part of the local build and are probably meant for a different
+    # platform, and can therefore be cleaned away.  That happens when making
+    # %unified_info more efficient below.
+
     ### Make unified_info a bit more efficient
     # One level structures
     foreach (("programs", "libraries", "engines", "scripts", "extra", "overrides")) {
@@ -2217,8 +2304,15 @@ EOF
     # Two level structures
     foreach my $l1 (("install", "sources", "shared_sources", "ldadd", "depends")) {
         foreach my $l2 (sort keys %{$unified_info{$l1}}) {
-            $unified_info{$l1}->{$l2} =
-                [ sort keys %{$unified_info{$l1}->{$l2}} ];
+            my @items =
+                sort
+                grep { $unified_info{$l1}->{$l2}->{$_} > 0 }
+                keys %{$unified_info{$l1}->{$l2}};
+            if (@items) {
+                $unified_info{$l1}->{$l2} = [ @items ];
+            } else {
+                delete $unified_info{$l1}->{$l2};
+            }
         }
     }
     # Includes

--- a/Configure
+++ b/Configure
@@ -2216,6 +2216,14 @@ EOF
     #    {productname}-{midfix}-{origobjname}.[o|res]
     # the {midfix} is a keyword indicating the type of product, which is mostly
     # valuable for libraries since they come in two forms.
+    #
+    # This also reorganises the {sources} and {shared_sources} so that the
+    # former only contains ALL object files that are supposed to end up in
+    # static libraries and programs, while the latter contains ALL object files
+    # that are supposed to end up in shared libraries and DSOs.
+    # The main reason for having two different source structures is to allow
+    # the same name to be used for the static and the shared variants of a
+    # library.
     {
         # Take copies so we don't get interference from added stuff
         my %unified_copy = ();

--- a/Configure
+++ b/Configure
@@ -2189,26 +2189,6 @@ EOF
         }
     }
 
-#    # Trickle down includes placed on libraries, engines and programs to
-#    # their sources (i.e. object files)
-#    foreach my $dest (keys %{$unified_info{engines}},
-#                      keys %{$unified_info{libraries}},
-#                      keys %{$unified_info{programs}}) {
-#        foreach my $k (("source", "build")) {
-#            next unless defined($unified_info{includes}->{$dest}->{$k});
-#            my @incs = reverse @{$unified_info{includes}->{$dest}->{$k}};
-#            foreach my $obj (grep /\.o$/,
-#                             (keys %{$unified_info{sources}->{$dest}},
-#                              keys %{$unified_info{shared_sources}->{$dest}})) {
-#                foreach my $inc (@incs) {
-#                    unshift @{$unified_info{includes}->{$obj}->{$k}}, $inc
-#                        unless grep { $_ eq $inc } @{$unified_info{includes}->{$obj}->{$k}};
-#                }
-#            }
-#        }
-#        delete $unified_info{includes}->{$dest};
-#    }
-
     # Go through all object files and change their names to something that
     # reflects what they will be built for.  Note that for some source files,
     # this leads to duplicate object files because they are used multiple times.

--- a/Configure
+++ b/Configure
@@ -2218,12 +2218,12 @@ EOF
     # valuable for libraries since they come in two forms.
     {
         # Take copies so we don't get interference from added stuff
-        my %unified_copy = (
-            sources =>        { %{$unified_info{sources}} },
-            shared_sources => { %{$unified_info{shared_sources}} },
-           );
-        delete $unified_info{sources};
-        delete $unified_info{shared_sources};
+        my %unified_copy = ();
+        foreach (('sources', 'shared_sources')) {
+            $unified_copy{$_} = { %{$unified_info{$_}} }
+                if defined($unified_info{$_});
+            delete $unified_info{$_};
+        }
         foreach my $prodtype (('programs', 'libraries', 'engines', 'scripts')) {
             # $intent serves multi purposes:
             # - give a prefix for the new object files names


### PR DESCRIPTION
This is a fairly big change, with the goal of making builds of object files specific to the product they are built for, which gives possibilities for variety in the builds.  For example, this makes it possible to have something like this:

    SOURCES[libfoo]=cookie.c
    INCLUDES[libfoo]=include/foo
    SOURCES[libbar]=cookie.c
    INCLUDES[libbar]=include/bar
    
This would mean that the object files and libraries would be build
somewhat like this (very simplified):
    
    $(CC) -Iinclude/foo -o libfoo-lib-cookie.o cookie.c
    $(AR) $(ARFLAGS) libfoo.a libfoo-lib-cookie.o
    $(CC) -Iinclude/bar -o libbar-lib-cookie.o cookie.c
    $(AR) $(ARFLAGS) libbar.a libbar-lib-cookie.o
