### PR TITLE
Make the config script fail with an error code if Configure failed

### DIFF
--- a/config
+++ b/config
@@ -929,5 +929,6 @@ if [ $? = "0" ]; then
   fi
 else
   echo "This system ($OUT) is not supported. See file INSTALL for details."
+  exit 1
 fi
 )


### PR DESCRIPTION
config needs to return an error if Configure fails.

We noticed this because:
"./config && make depend && make"
actually "worked" with perl 5.8.8 installed!

It was just odd, that it did not use gcc but cc...