### PR TITLE
use ndk_bundle if present

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -23,6 +23,18 @@
             }
 
             my $ndk = $ENV{ANDROID_NDK};
+            if (!$ndk) {
+                my $android_home = $ENV{ANDROID_HOME};
+                if ($android_home && -d $android_home && -d "$android_home/ndk-bundle") {
+                    $ndk = "$android_home/ndk-bundle";
+                }
+                if (!$ndk) {
+                    my $home = $ENV{HOME};
+                    if (-d "$home/Android/Sdk/ndk-bundle") {
+                        $ndk = "$home/Android/Sdk/ndk-bundle";
+                    }
+                }
+            }
             die "\$ANDROID_NDK is not defined"  if (!$ndk);
             die "\$ANDROID_NDK=$ndk is invalid" if (!-d "$ndk/platforms");
             $ndk = canonpath($ndk);
@@ -63,7 +75,7 @@
                 $sysroot = "@platforms[$#platforms]/arch-$1";
             }
             die "no sysroot=$sysroot"   if (!-d $sysroot);
-
+print "sysroot=${sysroot}\n";
             $sysroot =~ m|/android-([0-9]+)/arch-(\w+)/?$|;
             my ($api, $arch) = ($1, $2);
 
@@ -79,7 +91,7 @@
                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
                 $cflags .= " -target $tridefault "
-                        .  "-gcc-toolchain \$(ANDROID_NDK)/toolchains"
+                        .  "-gcc-toolchain $ndk/toolchains"
                         .  "/$tritools-4.9/prebuilt/$host";
                 $user{CC} = "clang" if ($user{CC} !~ m|clang|);
                 $user{CROSS_COMPILE} = undef;
@@ -99,13 +111,13 @@
                 die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
                 $incroot =~ s|^$ndk/||;
                 $cppflags  = "-D__ANDROID_API__=$api";
-                $cppflags .= " -isystem \$(ANDROID_NDK)/$incroot/$triarch";
-                $cppflags .= " -isystem \$(ANDROID_NDK)/$incroot";
+                $cppflags .= " -isystem $ndk/$incroot/$triarch";
+                $cppflags .= " -isystem $ndk/$incroot";
             }
 
             $sysroot =~ s|^$ndk/||;
             $android_ndk = {
-                cflags   => "$cflags --sysroot=\$(ANDROID_NDK)/$sysroot",
+                cflags   => "$cflags --sysroot=$ndk/$sysroot",
                 cppflags => $cppflags,
                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
                                             : "BN_LLONG",

--- a/NOTES.ANDROID
+++ b/NOTES.ANDROID
@@ -35,6 +35,13 @@
     PATH=$ANDROID_NDK/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin:$PATH
     ./Configure android-arm -D__ANDROID_API__=14
 
+ Newer versions of Android Studio put the NDK in $HOME/Android/Sdk/ndk-bundle.
+ ./Configure is now searching there for the NDK so you don't have to
+ specify ANDROID_NDK. E.g. try this:
+
+    PATH=$HOME/Android/Sdk/ndk-bundle/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin:$PATH
+    ./Configure android-arm -D__ANDROID_API__=14
+
  Caveat lector! Earlier OpenSSL versions relied on additional CROSS_SYSROOT
  variable set to $ANDROID_NDK/platforms/android-<api>/arch-<arch> to
  appoint headers-n-libraries' location. It's still recognized in order


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel@nennker.de>

newer versions of Android Studio put the NDK in this directory $HOME/Android/Sdk/ndk_bundle
Use this if present and ANDROID_NDK is not set

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
