### PR TITLE
minor Windows fixes [1.1.1]

### DIFF
--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -133,7 +133,9 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
  */
 int BIO_bind(int sock, const BIO_ADDR *addr, int options)
 {
+# ifndef OPENSSL_SYS_WINDOWS
     int on = 1;
+# endif
 
     if (sock == -1) {
         BIOerr(BIO_F_BIO_BIND, BIO_R_INVALID_SOCKET);

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -204,7 +204,7 @@ int OPENSSL_isservice(void)
 
     if (_OPENSSL_isservice.p == NULL) {
         HANDLE mod = GetModuleHandle(NULL);
-        FARPROC f;
+        FARPROC f = NULL;
 
         if (mod != NULL)
             f = GetProcAddress(mod, "_OPENSSL_isservice");

--- a/util/mkrc.pl
+++ b/util/mkrc.pl
@@ -70,7 +70,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             // Required:
-            VALUE "CompanyName", "The OpenSSL Project, http://www.openssl.org/\\0"
+            VALUE "CompanyName", "The OpenSSL Project, https://www.openssl.org/\\0"
             VALUE "FileDescription", "$description\\0"
             VALUE "FileVersion", "$version\\0"
             VALUE "InternalName", "$filename\\0"


### PR DESCRIPTION
- fix to use secure URL in generated Windows resources
- fix a potentially uninitialized variable
- fix an unused variable warning

CLA: trivial