### PR TITLE
Deprecate public use of the RAND_DRBG_USED_FLAGS define

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -82,6 +82,12 @@ static unsigned int slave_reseed_interval  = SLAVE_RESEED_INTERVAL;
 static time_t master_reseed_time_interval = MASTER_RESEED_TIME_INTERVAL;
 static time_t slave_reseed_time_interval  = SLAVE_RESEED_TIME_INTERVAL;
 
+/* A logical OR of all used DRBG flag bits (currently there is only one) */
+static const unsigned int rand_drbg_used_flags =
+    RAND_DRBG_FLAG_CTR_NO_DF |
+    /* add new entries before this line */
+    0;
+
 static RAND_DRBG *drbg_setup(RAND_DRBG *parent);
 
 static RAND_DRBG *rand_drbg_new(int secure,
@@ -147,7 +153,7 @@ int RAND_DRBG_set_defaults(int type, unsigned int flags)
         break;
     }
 
-    if ((flags & ~RAND_DRBG_USED_FLAGS) != 0) {
+    if ((flags & ~rand_drbg_used_flags) != 0) {
         RANDerr(RAND_F_RAND_DRBG_SET_DEFAULTS, RAND_R_UNSUPPORTED_DRBG_FLAGS);
         return 0;
     }

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -84,9 +84,7 @@ static time_t slave_reseed_time_interval  = SLAVE_RESEED_TIME_INTERVAL;
 
 /* A logical OR of all used DRBG flag bits (currently there is only one) */
 static const unsigned int rand_drbg_used_flags =
-    RAND_DRBG_FLAG_CTR_NO_DF |
-    /* add new entries before this line */
-    0;
+    RAND_DRBG_FLAG_CTR_NO_DF;
 
 static RAND_DRBG *drbg_setup(RAND_DRBG *parent);
 

--- a/include/openssl/rand_drbg.h
+++ b/include/openssl/rand_drbg.h
@@ -13,14 +13,21 @@
 # include <time.h>
 # include <openssl/ossl_typ.h>
 
+/*
+ * RAND_DRBG  flags
+ *
+ * Note: if new flags are added, the constant `rand_drbg_used_flags`
+ *       in drbg_lib.c needs to be updated accordingly.
+ */
 
 /* In CTR mode, disable derivation function ctr_df */
 # define RAND_DRBG_FLAG_CTR_NO_DF            0x1
 
-/* A logical OR of all used flag bits (currently there is only one) */
-# define RAND_DRBG_USED_FLAGS  ( \
-    RAND_DRBG_FLAG_CTR_NO_DF \
-                                 )
+
+# if OPENSSL_API_COMPAT < 0x10200000L
+/* This #define was replaced by an internal constant and should not be used. */
+#  define RAND_DRBG_USED_FLAGS  (RAND_DRBG_FLAG_CTR_NO_DF)
+# endif
 
 /*
  * Default security strength (in the sense of [NIST SP 800-90Ar1])


### PR DESCRIPTION
The new DRBG API added the aforementioned define. However, it
is used internally only and having it defined publicly does not
serve any purpose except causing potential version compatibilty
problems.
