### PR TITLE
Support EC_GROUP_set_generator with FIPS

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -318,17 +318,19 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     } else
         BN_zero(&group->cofactor);
 
-    /*
-     * Some groups have an order with
-     * factors of two, which makes the Montgomery setup fail.
-     * |group->mont_data| will be NULL in this case.
-     */
-    if (BN_is_odd(&group->order)) {
-        return ec_precompute_mont_data(group);
-    }
+    if (EC_GROUP_VERSION(group)) {
+        /*
+         * Some groups have an order with
+         * factors of two, which makes the Montgomery setup fail.
+         * |group->mont_data| will be NULL in this case.
+         */
+        if (BN_is_odd(&group->order)) {
+            return ec_precompute_mont_data(group);
+        }
 
-    BN_MONT_CTX_free(group->mont_data);
-    group->mont_data = NULL;
+        BN_MONT_CTX_free(group->mont_data);
+        group->mont_data = NULL;
+    }
     return 1;
 }
 


### PR DESCRIPTION
FIPS ECC structure has no mont_data, and so ec_precompute_mont_data
always fails, plus mont_data must not be accessed.

Without this change EC_GROUP_set_generator fails in FIPS mode for
curves with odd order, and accesses mont_data field that may not
exist for curves with even order.

(fixes commit e3ab8cc460d1a)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
