### PR TITLE
crypto/sm2/sm2_sign.c: ensure UINT16_MAX is properly defined

### DIFF
--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -12,6 +12,7 @@
 #include "internal/sm2.h"
 #include "internal/sm2err.h"
 #include "internal/ec_int.h" /* ec_group_do_inverse_ord() */
+#include "internal/numbers.h"
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>


### PR DESCRIPTION
Fixes #7186
