### PR TITLE
util/mkdef.pl, util/add-depends.pl: don't lowercase file names

### DIFF
--- a/util/add-depends.pl
+++ b/util/add-depends.pl
@@ -63,7 +63,7 @@ my $abs_blddir = rel2abs($blddir);
 # files we depend on in the same directory that only differ by character case,
 # we're fine.
 my %depconv_cache =
-    map { lc catfile($abs_blddir, $_) => $_ }
+    map { catfile($abs_blddir, $_) => $_ }
     keys %{$unified_info{generate}};
 
 my %procedures = (
@@ -139,7 +139,7 @@ my %procedures = (
 
             # VMS C gives us absolute paths, always.  Let's see if we can
             # make them relative instead.
-            $line = lc canonpath($line);
+            $line = canonpath($line);
 
             unless (defined $depconv_cache{$line}) {
                 my $dep = $line;
@@ -184,7 +184,7 @@ my %procedures = (
                 # VC gives us absolute paths for all include files, so to
                 # remove system header dependencies, we need to check that
                 # they don't match $abs_srcdir or $abs_blddir.
-                $tail = lc canonpath($tail);
+                $tail = canonpath($tail);
 
                 unless (defined $depconv_cache{$tail}) {
                     my $dep = $tail;

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -247,7 +247,7 @@ $crypto.=" include/internal/o_str.h";
 $crypto.=" include/internal/err.h";
 $crypto.=" include/internal/sslconf.h";
 foreach my $f ( glob(catfile($config{sourcedir},'include/openssl/*.h')) ) {
-    my $fn = "include/openssl/" . lc(basename($f));
+    my $fn = "include/openssl/" . basename($f);
     $crypto .= " $fn" if !defined $skipthese{$fn};
 }
 


### PR DESCRIPTION
It turns out to be detrimental on some file systems that may or may not
be case sensitive (such as NTFS, which has a case sensitive mode).

Fixes #7172
