### PR TITLE
Update fuzz/README.md

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -37,7 +37,7 @@ Configure for fuzzing:
 
     $ CC=clang ./config enable-fuzz-libfuzzer \
             --with-fuzzer-include=../../svn-work/Fuzzer \
-            --with-fuzzer-lib=../../svn-work/Fuzzer/libFuzzer \
+            --with-fuzzer-lib=../../svn-work/Fuzzer/libFuzzer.a \
             -DPEDANTIC enable-asan enable-ubsan no-shared \
             -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION \
             -fsanitize-coverage=trace-pc-guard,indirect-calls,trace-cmp \


### PR DESCRIPTION
Fixes a minor typo that would cause the linker to complain about not finding -lFuzzer

CLA: trivial
