### PR TITLE
Add an explicit cast to time_t

### DIFF
--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -500,8 +500,8 @@ static int test_default_ct_policy_eval_ctx_time_is_now(void)
 {
     int success = 0;
     CT_POLICY_EVAL_CTX *ct_policy_ctx = CT_POLICY_EVAL_CTX_new();
-    const time_t default_time = CT_POLICY_EVAL_CTX_get_time(ct_policy_ctx) /
-                                1000;
+    const time_t default_time =
+        (time_t)(CT_POLICY_EVAL_CTX_get_time(ct_policy_ctx) / 1000);
     const time_t time_tolerance = 600;  /* 10 minutes */
 
     if (!TEST_time_t_le(abs((int)difftime(time(NULL), default_time)),


### PR DESCRIPTION
Caused a compilation failure in some environments

Fixes #7204

