### PR TITLE
Don't allow -early_data with other options where it doesn't work

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1622,6 +1622,11 @@ int s_server_main(int argc, char *argv[])
         goto end;
     }
 #endif
+    if (early_data && (www > 0 || rev)) {
+        BIO_printf(bio_err,
+                   "Can't use -early_data in combination with -www, -WWW, -HTTP, or -rev\n");
+        goto end;
+    }
 
 #ifndef OPENSSL_NO_SCTP
     if (protocol == IPPROTO_SCTP) {

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -405,13 +405,14 @@ Inhibit printing of session and certificate information.
 Sends a status message back to the client when it connects. This includes
 information about the ciphers used and various session parameters.
 The output is in HTML format so this option will normally be used with a
-web browser.
+web browser. Cannot be used in conjunction with B<-early_data>.
 
 =item B<-WWW>
 
 Emulates a simple web server. Pages will be resolved relative to the
 current directory, for example if the URL https://myhost/page.html is
-requested the file ./page.html will be loaded.
+requested the file ./page.html will be loaded. Cannot be used in conjunction
+with B<-early_data>.
 
 =item B<-tlsextdebug>
 
@@ -423,7 +424,8 @@ Emulates a simple web server. Pages will be resolved relative to the
 current directory, for example if the URL https://myhost/page.html is
 requested the file ./page.html will be loaded. The files loaded are
 assumed to contain a complete and correct HTTP response (lines that
-are part of the HTTP response line and headers must end with CRLF).
+are part of the HTTP response line and headers must end with CRLF). Cannot be
+used in conjunction with B<-early_data>.
 
 =item B<-id_prefix val>
 
@@ -488,7 +490,8 @@ output.
 =item B<-rev>
 
 Simple test server which just reverses the text received from the client
-and sends it back to the server. Also sets B<-brief>.
+and sends it back to the server. Also sets B<-brief>. Cannot be used in
+conjunction with B<-early_data>.
 
 =item B<-async>
 
@@ -711,7 +714,8 @@ greater than or equal to 0.
 
 =item B<-early_data>
 
-Accept early data where possible.
+Accept early data where possible. Cannot be used in conjunction with B<-www>,
+B<-WWW>, B<-HTTP> or B<-rev>.
 
 =item B<-anti_replay>, B<-no_anti_replay>
 


### PR DESCRIPTION
-early_data is not compatible with -www, -WWW, -HTTP or -rev.

Fixes #7200