### PR TITLE
VMS: turn on name mangling for all our programs

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1732,10 +1732,15 @@ my %targets = (
         lflags           => picker(default => "/MAP='F\$PARSE(\".MAP\",\"\$\@\")'",
                                    debug   => "/DEBUG/TRACEBACK",
                                    release => "/NODEBUG/NOTRACEBACK"),
+        # Because of dso_cflags below, we can't set the generic |cflags| here,
+        # as it can't be overriden, so we set separate C flags for libraries
+        # and binaries instead.
+        bin_cflags       => add("/NAMES=(AS_IS,SHORTENED)/EXTERN_MODEL=STRICT_REFDEF"),
         lib_cflags       => add("/NAMES=(AS_IS,SHORTENED)/EXTERN_MODEL=STRICT_REFDEF"),
-        # no_inst_lib_cflags is used instead of lib_cflags by descrip.mms.tmpl
-        # for object files belonging to selected internal libraries
-        no_inst_lib_cflags => "",
+        # For modules specifically, we assume that they only use public
+        # OpenSSL symbols, and therefore don't need to mangle names on
+        # their own.
+        dso_cflags       => "",
         ex_libs          => add(sub { return vms_info()->{zlib} || (); }),
         shared_target    => "vms-shared",
         dso_scheme       => "vms",

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -298,8 +298,8 @@ BIN_CPPFLAGS={- join('', "'qual_includes'",
                          $target{bin_cppflags} || (),
                          @{$config{bin_cppflag}},
                          '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
-BIN_CFLAGS={- join('', $target{bin_cflag} || (),
-                       @{$config{bin_cflag}},
+BIN_CFLAGS={- join('', $target{bin_cflags} || (),
+                       @{$config{bin_cflags}},
                        '$(CNF_CFLAGS)', '$(CFLAGS)') -}
 BIN_LDFLAGS={- join('', $target{bin_lflags} || (),
                         @{$config{bin_lflags}} || (),
@@ -312,12 +312,14 @@ NO_INST_LIB_CFLAGS={- join('', $target{no_inst_lib_cflags}
                                @{$config{lib_cflags}},
                                @{$config{shared_cflag}},
                                '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-NO_INST_DSO_CFLAGS={- join('', $target{no_inst_lib_cflags}
-                               // $target{lib_cflags}
+NO_INST_DSO_CFLAGS={- join('', $target{no_inst_dso_cflags}
+                               // $target{dso_cflags}
                                // (),
-                               $target{dso_cflags} || (),
-                               @{$config{lib_cflags}},
+                               $target{no_inst_module_cflags}
+                               // $target{module_cflags}
+                               // (),
                                @{$config{dso_cflags}},
+                               @{$config{module_cflags}},
                                '$(CNF_CFLAGS)', '$(CFLAGS)') -}
 NO_INST_BIN_CFLAGS={- join('', $target{no_inst_bin_cflags}
                                // $target{bin_cflags}

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -1034,7 +1034,9 @@ EOF
                                  "\@ WRITE OPT_FILE \"$x" } @objs).
           "\"";
       my $write_opt2 =
-          join("\n\t", map { my @lines = ();
+          join("\n\t", map { my @lines = (
+                                 "\ WRITE OPT_FILE \"CASE_SENSITIVE=YES\""
+                             );
                              my $x = $_ =~ /\[/ ? $_ : "[]".$_;
                              if ($x =~ m|\.EXE$|) {
                                  push @lines, "\@ WRITE OPT_FILE \"$x/SHARE\"";

--- a/test/build.info
+++ b/test/build.info
@@ -17,10 +17,10 @@ IF[{- !$disabled{tests} -}]
   DEPEND[libtestutil.a]=../libcrypto
 
   # Special hack for descrip.mms to include the MAIN object module
-  # explicitly.  This will only be done if there isn't a MAIN in the
+  # explicitly.  This will only be done if there isn't a 'main' in the
   # program's object modules already.
   BEGINRAW[descrip.mms]
-INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
+INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   ENDRAW[descrip.mms]
 
   PROGRAMS_NO_INST=\

--- a/test/cipher_overhead_test.c
+++ b/test/cipher_overhead_test.c
@@ -9,17 +9,7 @@
 
 #include "internal/nelem.h"
 #include "testutil.h"
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "../ssl/ssl_locl.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
 
 static int cipher_overhead(void)
 {

--- a/test/curve448_internal_test.c
+++ b/test/curve448_internal_test.c
@@ -10,18 +10,7 @@
 #include <string.h>
 #include <openssl/e_os2.h>
 #include <openssl/evp.h>
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "curve448_lcl.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "testutil.h"
 
 static unsigned int max = 1000;

--- a/test/ssl_cert_table_internal_test.c
+++ b/test/ssl_cert_table_internal_test.c
@@ -15,18 +15,8 @@
 #include <openssl/ssl.h>
 #include "testutil.h"
 #include "internal/nelem.h"
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "../ssl/ssl_locl.h"
 #include "../ssl/ssl_cert_table.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
 
 #define test_cert_table(nid, amask, idx) \
     do_test_cert_table(nid, amask, idx, #idx)

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -9,19 +9,8 @@
 
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "../ssl/ssl_locl.h"
 #include "../ssl/record/record_locl.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "internal/nelem.h"
 #include "testutil.h"
 

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -10,17 +10,7 @@
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
 
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "../ssl/ssl_locl.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "testutil.h"
 
 #define IVLEN   12

--- a/test/wpackettest.c
+++ b/test/wpackettest.c
@@ -9,18 +9,7 @@
 
 #include <string.h>
 #include <openssl/buffer.h>
-
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "../ssl/packet_locl.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
-
 #include "testutil.h"
 
 static const unsigned char simple1[] = { 0xff };

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -23,17 +23,8 @@
  *
  ***/
 
-#ifdef __VMS
-# pragma names save
-# pragma names as_is,shortened
-#endif
-
 #include "../crypto/x509v3/ext_dat.h"
 #include "../crypto/x509v3/standard_exts.h"
-
-#ifdef __VMS
-# pragma names restore
-#endif
 
 static int test_standard_exts(void)
 {


### PR DESCRIPTION
With the change to have separate object files by intent, VMS name
mangling gets done differently.  While we previously had that for
libraries only, we must now turn that on generally for our programs,
because some of them depend in internal libraries where mangled names
are all that there is.

Dynamic modules are still built with non-mangled names, which is good
enough to show that it's possible to build with our public libraries
using our public headers.