### PR TITLE
Make some return checks consistent with others

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -837,21 +837,21 @@ void EVP_PKEY_meth_get_ctrl(const EVP_PKEY_METHOD *pmeth,
 void EVP_PKEY_meth_get_check(const EVP_PKEY_METHOD *pmeth,
                              int (**pcheck) (EVP_PKEY *pkey))
 {
-    if (*pcheck)
+    if (pcheck != NULL)
         *pcheck = pmeth->check;
 }
 
 void EVP_PKEY_meth_get_public_check(const EVP_PKEY_METHOD *pmeth,
                                     int (**pcheck) (EVP_PKEY *pkey))
 {
-    if (*pcheck)
+    if (pcheck != NULL)
         *pcheck = pmeth->public_check;
 }
 
 void EVP_PKEY_meth_get_param_check(const EVP_PKEY_METHOD *pmeth,
                                    int (**pcheck) (EVP_PKEY *pkey))
 {
-    if (*pcheck)
+    if (pcheck != NULL)
         *pcheck = pmeth->param_check;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Three 'getters' introduced in 1.1.1 checks the return values different from what other getters do. Make them consistent
