### PR TITLE
Create the .rnd file it it does not exist

### DIFF
--- a/apps/app_rand.c
+++ b/apps/app_rand.c
@@ -26,7 +26,6 @@ void app_RAND_load_conf(CONF *c, const char *section)
     if (RAND_load_file(randfile, -1) < 0) {
         BIO_printf(bio_err, "Can't load %s into RNG\n", randfile);
         ERR_print_errors(bio_err);
-        return;
     }
     if (save_rand_file == NULL)
         save_rand_file = OPENSSL_strdup(randfile);

--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -10,7 +10,6 @@
 # This definition stops the following lines choking if HOME isn't
 # defined.
 HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
 #oid_file		= $ENV::HOME/.oid
@@ -57,7 +56,6 @@ crlnumber	= $dir]crlnumber.	# the current crl number
 					# must be commented out to leave a V1 CRL
 crl		= $dir]crl.pem 		# The current CRL
 private_key	= $dir.private]cakey.pem# The private key
-RANDFILE	= $dir.private].rand	# private random number file
 
 x509_extensions	= usr_cert		# The extensions to add to the cert
 

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -10,7 +10,6 @@
 # This definition stops the following lines choking if HOME isn't
 # defined.
 HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
 #oid_file		= $ENV::HOME/.oid
@@ -57,7 +56,6 @@ crlnumber	= $dir/crlnumber	# the current crl number
 					# must be commented out to leave a V1 CRL
 crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem# The private key
-RANDFILE	= $dir/private/.rand	# private random number file
 
 x509_extensions	= usr_cert		# The extensions to add to the cert
 


### PR DESCRIPTION
It's a bit annoying some commands try to read a .rnd file, and print
an error message if the file does not exist.

But previously a .rnd file was created on exit, and that does no longer
happen.
Fixed by continuing in app_RAND_load_conf regardless of the error in
RAND_load_file.
If the random number generator is still not initalized on exit,
the function RAND_write_file will fail