### PR TITLE
internal/cryptlib.h: add ossl_is_null() macro

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -824,7 +824,7 @@ doapr_outch(char **sbuffer,
                 return 0;
             }
             if (*currlen > 0) {
-                if (!ossl_assert(*sbuffer != NULL))
+                if (ossl_is_null(*sbuffer))
                     return 0;
                 memcpy(*buffer, *sbuffer, *currlen);
             }

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -234,7 +234,7 @@ int X509v3_asid_add_id_or_range(ASIdentifiers *asid,
 static int extract_min_max(ASIdOrRange *aor,
                            ASN1_INTEGER **min, ASN1_INTEGER **max)
 {
-    if (!ossl_assert(aor != NULL))
+    if (ossl_is_null(aor))
         return 0;
     switch (aor->type) {
     case ASIdOrRange_id:
@@ -777,7 +777,7 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
      */
     for (i++; i < sk_X509_num(chain); i++) {
         x = sk_X509_value(chain, i);
-        if (!ossl_assert(x != NULL)) {
+        if (ossl_is_null(x)) {
             if (ctx != NULL)
                 ctx->error = X509_V_ERR_UNSPECIFIED;
             return 0;
@@ -827,7 +827,7 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     /*
      * Trust anchor can't inherit.
      */
-    if (!ossl_assert(x != NULL)) {
+    if (ossl_assert(x)) {
         if (ctx != NULL)
             ctx->error = X509_V_ERR_UNSPECIFIED;
         return 0;

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -827,7 +827,7 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     /*
      * Trust anchor can't inherit.
      */
-    if (ossl_assert(x)) {
+    if (ossl_is_null(x)) {
         if (ctx != NULL)
             ctx->error = X509_V_ERR_UNSPECIFIED;
         return 0;

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -27,6 +27,7 @@
 
 #ifdef NDEBUG
 # define ossl_assert(x) ((x) != 0)
+# define ossl_is_null(x) ((x) == NULL)
 #else
 __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)
@@ -39,7 +40,8 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
 
 # define ossl_assert(x) ossl_assert_int((x) != 0, "Assertion failed: "#x, \
                                          __FILE__, __LINE__)
-
+# define ossl_is_null(x) ossl_assert_int((x) != NULL, "Invalid NULL pointer: "#x, \
+                                         __FILE__, __LINE__)
 #endif
 
 typedef struct ex_callback_st EX_CALLBACK;

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -27,7 +27,7 @@
 
 #ifdef NDEBUG
 # define ossl_assert(x) ((x) != 0)
-# define ossl_is_null(x) (((x) == NULL) != 0)
+# define ossl_is_null(x) (!ossl_assert((x) != NULL))
 #else
 __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -27,7 +27,7 @@
 
 #ifdef NDEBUG
 # define ossl_assert(x) ((x) != 0)
-# define ossl_is_null(x) ((x) == NULL)
+# define ossl_is_null(x) (((x) == NULL) != 0)
 #else
 __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)
@@ -40,8 +40,8 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
 
 # define ossl_assert(x) ossl_assert_int((x) != 0, "Assertion failed: "#x, \
                                          __FILE__, __LINE__)
-# define ossl_is_null(x) ossl_assert_int((x) != NULL, "Invalid NULL pointer: "#x, \
-                                         __FILE__, __LINE__)
+# define ossl_is_null(x) (!ossl_assert_int((x) != NULL, "Invalid NULL pointer: "#x, \
+                                           __FILE__, __LINE__))
 #endif
 
 typedef struct ex_callback_st EX_CALLBACK;

--- a/ssl/packet.c
+++ b/ssl/packet.c
@@ -134,7 +134,7 @@ int WPACKET_init_static_len(WPACKET *pkt, unsigned char *buf, size_t len,
 int WPACKET_init_len(WPACKET *pkt, BUF_MEM *buf, size_t lenbytes)
 {
     /* Internal API, so should not fail */
-    if (!ossl_assert(buf != NULL))
+    if (ossl_is_null(buf))
         return 0;
 
     pkt->staticbuf = NULL;
@@ -152,7 +152,7 @@ int WPACKET_init(WPACKET *pkt, BUF_MEM *buf)
 int WPACKET_set_flags(WPACKET *pkt, unsigned int flags)
 {
     /* Internal API, so should not fail */
-    if (!ossl_assert(pkt->subs != NULL))
+    if (ossl_is_null(pkt->subs))
         return 0;
 
     pkt->subs->flags = flags;
@@ -226,7 +226,7 @@ int WPACKET_fill_lengths(WPACKET *pkt)
 {
     WPACKET_SUB *sub;
 
-    if (!ossl_assert(pkt->subs != NULL))
+    if (ossl_is_null(pkt->subs))
         return 0;
 
     for (sub = pkt->subs; sub != NULL; sub = sub->parent) {
@@ -275,7 +275,7 @@ int WPACKET_start_sub_packet_len__(WPACKET *pkt, size_t lenbytes)
     unsigned char *lenchars;
 
     /* Internal API, so should not fail */
-    if (!ossl_assert(pkt->subs != NULL))
+    if (ossl_is_null(pkt->subs))
         return 0;
 
     if ((sub = OPENSSL_zalloc(sizeof(*sub))) == NULL) {
@@ -325,7 +325,7 @@ int WPACKET_set_max_size(WPACKET *pkt, size_t maxsize)
     size_t lenbytes;
 
     /* Internal API, so should not fail */
-    if (!ossl_assert(pkt->subs != NULL))
+    if (ossl_is_null(pkt->subs))
         return 0;
 
     /* Find the WPACKET_SUB for the top level */
@@ -388,7 +388,7 @@ int WPACKET_sub_memcpy__(WPACKET *pkt, const void *src, size_t len,
 int WPACKET_get_total_written(WPACKET *pkt, size_t *written)
 {
     /* Internal API, so should not fail */
-    if (!ossl_assert(written != NULL))
+    if (ossl_is_null(written))
         return 0;
 
     *written = pkt->written;

--- a/ssl/record/ssl3_record_tls13.c
+++ b/ssl/record/ssl3_record_tls13.c
@@ -84,7 +84,7 @@ int tls13_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending)
          * To get here we must have selected a ciphersuite - otherwise ctx would
          * be NULL
          */
-        if (!ossl_assert(s->s3->tmp.new_cipher != NULL)) {
+        if (ossl_is_null(s->s3->tmp.new_cipher)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS13_ENC,
                      ERR_R_INTERNAL_ERROR);
             return -1;

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -106,7 +106,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
     c = s->s3->tmp.new_sym_enc;
     m = s->s3->tmp.new_hash;
     /* m == NULL will lead to a crash later */
-    if (!ossl_assert(m != NULL)) {
+    if (ossl_is_null(m)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL3_CHANGE_CIPHER_STATE,
                  ERR_R_INTERNAL_ERROR);
         goto err;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -383,9 +383,9 @@ int ssl_load_ciphers(void)
         }
     }
     /* Make sure we can access MD5 and SHA1 */
-    if (!ossl_assert(ssl_digest_methods[SSL_MD_MD5_IDX] != NULL))
+    if (ossl_is_null(ssl_digest_methods[SSL_MD_MD5_IDX]))
         return 0;
-    if (!ossl_assert(ssl_digest_methods[SSL_MD_SHA1_IDX] != NULL))
+    if (ossl_is_null(ssl_digest_methods[SSL_MD_SHA1_IDX]))
         return 0;
 
     disabled_mkey_mask = 0;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -432,7 +432,7 @@ int tls_validate_all_contexts(SSL *s, unsigned int thisctx, RAW_EXTENSION *exts)
 
             meth = custom_ext_find(&s->cert->custext, role, thisext->type,
                                    &offset);
-            if (!ossl_assert(meth != NULL))
+            if (ossl_is_null(meth))
                 return 0;
             context = meth->context;
         }
@@ -920,7 +920,7 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
     int altmp = SSL_AD_UNRECOGNIZED_NAME;
     int was_ticket = (SSL_get_options(s) & SSL_OP_NO_TICKET) == 0;
 
-    if (!ossl_assert(s->ctx != NULL) || !ossl_assert(s->session_ctx != NULL)) {
+    if (ossl_is_null(s->ctx) || ossl_is_null(s->session_ctx)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_FINAL_SERVER_NAME,
                  ERR_R_INTERNAL_ERROR);
         return 0;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -624,7 +624,7 @@ dtls1_reassemble_fragment(SSL *s, const struct hm_header_st *msg_hdr)
          * would have returned it and control would never have reached this
          * branch.
          */
-        if (!ossl_assert(item != NULL))
+        if (ossl_is_null(item))
             goto err;
     }
 
@@ -722,7 +722,7 @@ dtls1_process_out_of_seq_message(SSL *s, const struct hm_header_st *msg_hdr)
          * have been processed with |dtls1_reassemble_fragment|, above, or
          * the record will have been discarded.
          */
-        if (!ossl_assert(item != NULL))
+        if (ossl_is_null(item))
             goto err;
     }
 


### PR DESCRIPTION
Adds an ossl_is_null() macro, which facilitates writing expressions as the following
```C
    if (ossl_is_null(p))
        return error;
```
In debug builds the macro will print an error message and abort if a NULL pointer is passed. In release builds, the above statement will simply expand to
```C
    if ((p) == NULL)
        return error;
```
The commit also introduces this macro in obvious places by replacing all current occurrences of `if (!ossl_assert(... != NULL))`.

