### PR TITLE
Add a protection against fault attack on message v2

### DIFF
--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -914,7 +914,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *Iconst, RSA *rsa, BN_CTX *
          */
         if (!BN_mod(I,I,rsa->n,ctx))
             goto err;
-        if (!BN_cmp(vrfy,I)) // same big number
+        if (!BN_cmp(vrfy,I)) /* same big number */
         {
             bn_correct_top(r0);
             ret = 1;


### PR DESCRIPTION
The aim of this pull request is to mitigate two monobit faults that we found 
with my team on RSA signature.
I here briefly give explanation of those faults and the mitigation, but you can
find more details on the paper, presented at DSD 2018 in Prague
(I sent it to @mattcaswell I think, but I can send it to you again if you ask for).

In brief, here is the rationale for our drive to change RSA in OpenSSL.
Today, RSA, when it uses secret elements (e.g., in a signature), checks for 
faults.
Indeed, this is good practice in view of "hardware bugs" (recall Adi Shamir's 
bug attack) and "Bellcore attack" (one strike and you're out, by Dan Boneh et 
al.), which can be triggered by RowHammer (or NetHammer, etc.)
But we actually show that a single bit fault both allows to fault RSA in an 
exploitable ways AND bypasses the check!
The currently implementation does not meet the requirement of protection, 
therefore we propose a more safe alternative (see below).

By the way, we try to consider your remarks on 
https://github.com/openssl/openssl/pull/6344 .
We agree with most of your remarks, but we think that it is our work to 
to propose some mitigation even if the final decision to accept the pull request
is up to you and the community.

# Description of the first fault:
The first fault makes BN_sub() function always return 0. Then the final 
signature is equal to the signature modulo q instead of modulo n because of the
BN_sub() function in Garner recombination inside rsa_ossl_mod_exp() function.
Moreover, BN_sub is also used to check the correctness of the signature with 
BN_sub(vrfy,vrfy,I): OpenSSL checks if this difference is equal to 0 in the 
case where no error occurs. Then, because BN_sub() is the zero function, 
faulty results are never detected as faulty, hence are disclosed, which 
allows for a Bellcore attack.

# Mitigation of the first fault:
We replace BN_sub(vrfy,vrfy,I) by BN_cmp(vrfy,I). The fault is then well 
detected since BN_cmp() does not use BN_sub (please correct me if I am wrong, 
but our tool does not detect any problem after this correction). Note that this
modification requires that the message `I` to be reduced modulo N. We do that 
before calling BN_cmp() by using BN_mod() function.

# Description of the second fault:
In case of a badly computed signature, OpenSSL recomputes the signature without
using CTR (to prevent Bellcore attack, right?). However, our fault is able to 
change the message to its version reduced modulo q. The fault is detected, but 
the correction actually computes the signature of the faulted message (the 
message modulo q) which makes possible to get private key by Bellcore attack.

# Mitigation of the second fault:
The second modification consists in returning an error when a signature has 
been badly computed instead of trying to correct it. Note that checking if the 
corrected signature is well computed is not necessarily efficient if one 
compares S^e mod n with the message since the message is faulted and it will 
match with the faulted signature.

We also clear sensitive variables included badly computed signature and 
modified message. Note that clearing the message require to have a copy of it 
(that is fault sensitive) since the message in rsa_ossl_mod_exp() is declared 
with const flag.

With those mitigations, we fail to found exploitable monobit fault on RSA 
signature.

We can still discuss here and adapt the mitigations if you want.
I will do my best to answer your remarks or questions.
