### PR TITLE
VMS: only use the high precision on VMS v8.4 and up

### DIFF
--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -478,13 +478,18 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
     } data = { 0 };
 
     /*
-     * Add process id, thread id, and a high resolution timestamp to
-     * ensure that the nonce is unique whith high probability for
-     * different process instances.
+     * Add process id, thread id, and a high resolution timestamp
+     * (where available, which is OpenVMS v8.4 and up) to ensure that
+     * the nonce is unique whith high probability for different process
+     * instances.
      */
     data.pid = getpid();
     data.tid = CRYPTO_THREAD_get_current_id();
+#if __CRTL_VER >= 80400000
     sys$gettim_prec(&data.time);
+#else
+    sys$gettim((void*)&data.time);
+#endif
 
     return rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }


### PR DESCRIPTION
It simply isn't available on older versions.

Issue submitted by Mark Daniels

Fixes #7229
