### PR TITLE
Make openssl/rsa.h coexist with complex.h.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Makefile
 /test/v3ext
 /test/versions
 /test/ossl_shim/ossl_shim
+/test/rsa_complex
 
 # Certain files that get created by tests on the fly
 /test/test-runs

--- a/crypto/rsa/rsa_meth.c
+++ b/crypto/rsa/rsa_meth.c
@@ -163,13 +163,13 @@ int RSA_meth_set_priv_dec(RSA_METHOD *meth,
 
     /* Can be null */
 int (*RSA_meth_get_mod_exp(const RSA_METHOD *meth))
-    (BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
+    (BIGNUM *r0, const BIGNUM *i, RSA *rsa, BN_CTX *ctx)
 {
     return meth->rsa_mod_exp;
 }
 
 int RSA_meth_set_mod_exp(RSA_METHOD *meth,
-                         int (*mod_exp) (BIGNUM *r0, const BIGNUM *I, RSA *rsa,
+                         int (*mod_exp) (BIGNUM *r0, const BIGNUM *i, RSA *rsa,
                                          BN_CTX *ctx))
 {
     meth->rsa_mod_exp = mod_exp;

--- a/doc/man3/RSA_meth_new.pod
+++ b/doc/man3/RSA_meth_new.pod
@@ -64,10 +64,10 @@ RSA_meth_get_multi_prime_keygen, RSA_meth_set_multi_prime_keygen
                                            unsigned char *to, RSA *rsa, int padding));
 
  /* Can be null */
- int (*RSA_meth_get_mod_exp(const RSA_METHOD *meth))(BIGNUM *r0, const BIGNUM *I,
+ int (*RSA_meth_get_mod_exp(const RSA_METHOD *meth))(BIGNUM *r0, const BIGNUM *i,
                                                      RSA *rsa, BN_CTX *ctx);
  int RSA_meth_set_mod_exp(RSA_METHOD *rsa,
-                          int (*mod_exp)(BIGNUM *r0, const BIGNUM *I, RSA *rsa,
+                          int (*mod_exp)(BIGNUM *r0, const BIGNUM *i, RSA *rsa,
                                          BN_CTX *ctx));
 
  /* Can be null */

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -456,9 +456,9 @@ int RSA_meth_set_priv_dec(RSA_METHOD *rsa,
                                            unsigned char *to, RSA *rsa,
                                            int padding));
 int (*RSA_meth_get_mod_exp(const RSA_METHOD *meth))
-    (BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx);
+    (BIGNUM *r0, const BIGNUM *i, RSA *rsa, BN_CTX *ctx);
 int RSA_meth_set_mod_exp(RSA_METHOD *rsa,
-                         int (*mod_exp) (BIGNUM *r0, const BIGNUM *I, RSA *rsa,
+                         int (*mod_exp) (BIGNUM *r0, const BIGNUM *i, RSA *rsa,
                                          BN_CTX *ctx));
 int (*RSA_meth_get_bn_mod_exp(const RSA_METHOD *meth))
     (BIGNUM *r, const BIGNUM *a, const BIGNUM *p,

--- a/test/build.info
+++ b/test/build.info
@@ -26,7 +26,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   PROGRAMS_NO_INST=\
           versions \
           aborttest test_test \
-          sanitytest exdatatest bntest \
+          sanitytest rsa_complex exdatatest bntest \
           ectest ecstresstest ecdsatest gmdifftest pbelutest ideatest \
           md2test \
           hmactest \
@@ -63,6 +63,9 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   SOURCE[sanitytest]=sanitytest.c
   INCLUDE[sanitytest]=../include
   DEPEND[sanitytest]=../libcrypto libtestutil.a
+
+  SOURCE[rsa_complex]=rsa_complex.c
+  INCLUDE[rsa_complex]=../include
 
   SOURCE[test_test]=test_test.c
   INCLUDE[test_test]=../include

--- a/test/rsa_complex.c
+++ b/test/rsa_complex.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Check to see if there is a conflict between complex.h and openssl/rsa.h.
+ * The former defines "I" as a macro and earlier versions of the latter use
+ * for function arguments.
+ */
+#if defined(__STDC_VERSION__)
+# if __STDC_VERSION__ >= 199901L
+#  include <complex.h>
+# endif
+#endif
+#include <openssl/rsa.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+    /* There are explicitly no run time checks for this one */
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Use 'i' as parameter name not 'I'.
The latter causes problems when complex.h is #included.


- [x] documentation is added or updated
- [x] tests are added or updated

Fixes: #7224 