### PR TITLE
Add missing include file.

### DIFF
--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -25,14 +25,12 @@
 #  endif
 # endif
 
+#include "e_os.h"
 #include "internal/cryptlib.h"
 
 #if !defined(OPENSSL_NO_STDIO)
 
 # include <stdio.h>
-# ifdef _WIN32
-#  include <windows.h>
-# endif
 # ifdef __DJGPP__
 #  include <unistd.h>
 # endif


### PR DESCRIPTION
Specifically, include e_os.h to pick up alloca definition for WIN32.
