### PR TITLE
Fix undefined clock_gettime in Solaris 9/10

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -64,7 +64,7 @@ static uint64_t get_timer_bits(void);
  * macro that might be undefined.
  */
 # undef OSSL_POSIX_TIMER_OKAY
-# if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+# if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0 && !defined(__sun)
 #  if defined(__GLIBC__)
 #   if defined(__GLIBC_PREREQ)
 #    if __GLIBC_PREREQ(2, 17)


### PR DESCRIPTION
Linking error in Solaris 9 (GCC 4.6.4) and Solaris 10 (GCC 4.9.2)：

```
Undefined                       first referenced
 symbol                             in file
clock_gettime                       ./libcrypto.so
```