### PR TITLE
sha/asm/keccak1600-s390x.pl: resolve -march=z900 portability issue.

### DIFF
--- a/crypto/sha/asm/keccak1600-s390x.pl
+++ b/crypto/sha/asm/keccak1600-s390x.pl
@@ -432,9 +432,9 @@ SHA3_absorb:
 	lrvg	%r0,0($inp)
 	la	$inp,8($inp)
 	xg	%r0,0(%r1)
-	la	%r1,8(%r1)
 	a${g}hi	$len,-8
-	stg	%r0,-8(%r1)
+	stg	%r0,0(%r1)
+	la	%r1,8(%r1)
 	brct	$bsz,.Lblock_absorb
 
 	stm${g}	$inp,$len,$frame+3*$SIZE_T($sp)


### PR DESCRIPTION
Negative displacement in memory references was not originally specified,
so that for maximum coverage one should abstain from it, just like with
any other extension. [Unless it's guarded by run-time switch, but there
is no switch in keccak1600-s390x.]
