### PR TITLE
drbg_get_entropy: force a reseed before calling ssleay_rand_bytes() [first attempt]

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -202,9 +202,6 @@ static size_t drbg_get_entropy(DRBG_CTX *ctx, unsigned char **pout,
     /*
      * Since ssleay_rand_bytes() calls RAND_poll() only on first call,
      * we do it manually on every following call.
-     *
-     * Note: it is threadsafe to increment the counter, since RAND_bytes()
-     * takes the CRYPTO_LOCK_RAND somewhere up the stack.
      */
     if (++counter > 1)
         RAND_poll();


### PR DESCRIPTION
Fixes #7240

In FIPS mode, the default FIPS DRBG uses the drbg_get_entropy()
callback to reseed itself, which is provided by the wrapping
libcrypto library. This callback in turn uses ssleay_rand_bytes()
to generate random bytes.

Now ssleay_rand_bytes() calls RAND_poll() once on first call to
seed itself, but RAND_poll() is never called again (unless the
application calls RAND_poll() explicitely). This implies that
whenever the DRBG reseeds itself (which happens every 2^14
generate requests) this happens without obtaining fresh random
data from the operating system's entropy sources.

This patch forces a reseed from system entropy sources on every
call to drbg_get_entropy(). In contrary to the automatic reseeding
of the DRBG in master, this reseeding does not break applications
running in a chroot() environment (see c7504aeb640a), because the
SSLEAY PRNG does not maintain an error state. (It does not even
check the return value of RAND_poll() on its instantiation.)

In the worst case, if no random device is available for reseeding,
no fresh entropy will be added to the SSLEAY PRNG but it will happily
continue to generate random bytes as 'entropy' input for the DRBG's
reseeding, which is just as good (or bad) as before this patch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
