### PR TITLE
Use gethostbyname_r if available [1.0.2 only]

### DIFF
--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -171,6 +171,12 @@ int BIO_get_host_ip(const char *str, unsigned char *ip)
     err = gethostbyname_r(str, he, buf, sizeof(buf), &result, &h_errnop);
     if (err != 0 || result == NULL) {
         BIOerr(BIO_F_BIO_GET_HOST_IP, BIO_R_BAD_HOSTNAME_LOOKUP);
+        /*
+         * if there are no entry found, then gethostbyname_r returns 0 with
+         * result set to NULL.
+         * so reset err to no-zero
+         */
+        err = 1;
         goto err;
     }
 # else

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -56,6 +56,9 @@
  * [including the GNU Public Licence.]
  */
 
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -84,24 +87,9 @@ static int wsa_init_done = 0;
 # endif
 
 # if defined(__GLIBC__)
-#  if defined(__GLIBC_PREREQ)
-#   if __GLIBC_PREREQ(2, 19)
-#    if defined(_DEFAULT_SOURCE)
-#     define HAVE_GETHOSTBYNAME_R
-#    endif
-#   else
-#    if defined(_BSD_SOURCE) || defined(_SVID_SOURCE)
-#     define HAVE_GETHOSTBYNAME_R
-#    endif
-#   endif
-#  else
-#   if defined(_BSD_SOURCE) || defined(_SVID_SOURCE)
-#    define HAVE_GETHOSTBYNAME_R
-#   endif
-#  endif
+#  define HAVE_GETHOSTBYNAME_R
+#  define GETHOSTNAME_R_BUF     (2 * 1024)
 # endif
-
-# define GETHOSTNAME_R_BUF     (2 * 1024)
 
 /*
  * WSAAPI specifier is required to make indirect calls to run-time

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -137,8 +137,10 @@ int BIO_get_host_ip(const char *str, unsigned char *ip)
     int err = 1;
     int locked = 0;
     struct hostent *he;
+# ifdef HAVE_GETHOSTBYNAME_R
     struct hostent *result = NULL;
     struct hostent hostent;
+# endif
 
     i = get_ip(str, ip);
     if (i < 0) {

--- a/crypto/bio/bio.h
+++ b/crypto/bio/bio.h
@@ -734,8 +734,6 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
                    int datalen);
 
 struct hostent *BIO_gethostbyname(const char *name);
-int BIO_gethostbyname_r(const char *name, struct hostent *he,
-        struct hostent **result);
 int BIO_sock_error(int sock);
 int BIO_socket_ioctl(int fd, long type, void *arg);
 int BIO_socket_nbio(int fd, int mode);

--- a/crypto/bio/bio.h
+++ b/crypto/bio/bio.h
@@ -734,15 +734,8 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
                    int datalen);
 
 struct hostent *BIO_gethostbyname(const char *name);
-/*-
- * We might want a thread-safe interface too:
- * struct hostent *BIO_gethostbyname_r(const char *name,
- *     struct hostent *result, void *buffer, size_t buflen);
- * or something similar (caller allocates a struct hostent,
- * pointed to by "result", and additional buffer space for the various
- * substructures; if the buffer does not suffice, NULL is returned
- * and an appropriate error code is set).
- */
+int BIO_gethostbyname_r(const char *name, struct hostent *he,
+        struct hostent **result);
 int BIO_sock_error(int sock);
 int BIO_socket_ioctl(int fd, long type, void *arg);
 int BIO_socket_nbio(int fd, int mode);

--- a/crypto/bio/bio.h
+++ b/crypto/bio/bio.h
@@ -734,6 +734,15 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
                    int datalen);
 
 struct hostent *BIO_gethostbyname(const char *name);
+/*-
+ * We might want a thread-safe interface too:
+ * struct hostent *BIO_gethostbyname_r(const char *name,
+ *     struct hostent *result, void *buffer, size_t buflen);
+ * or something similar (caller allocates a struct hostent,
+ * pointed to by "result", and additional buffer space for the various
+ * substructures; if the buffer does not suffice, NULL is returned
+ * and an appropriate error code is set).
+ */
 int BIO_sock_error(int sock);
 int BIO_socket_ioctl(int fd, long type, void *arg);
 int BIO_socket_nbio(int fd, int mode);


### PR DESCRIPTION
Fixes # 7228
The function BIO_get_host_ip uses gethostbyname, which is not thread safe
and hence we grab a lock. In multi-threaded applications, this lock sometimes
causes performance bottlenecks.
This patch uses the function gethostbyname_r (thread safe version), when
available.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

