### PR TITLE
Fix the max psk len for TLSv1.3

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -471,7 +471,7 @@ struct ssl_method_st {
     long (*ssl_ctx_callback_ctrl) (SSL_CTX *s, int cb_id, void (*fp) (void));
 };
 
-# define TLS13_MAX_RESUMPTION_PSK_LENGTH      64
+# define TLS13_MAX_RESUMPTION_PSK_LENGTH      PSK_MAX_PSK_LEN
 
 /*-
  * Lets make this into an ASN.1 type structure as follows


### PR DESCRIPTION
If using an old style TLSv1.2 PSK callback then the maximum possible PSK
len is PSK_MAX_PSK_LEN (256) - not 64.

Fixes #7261