### PR TITLE
crypto/ui/ui_openssl.c: make sure to recognise ENXIO and EIO too

### DIFF
--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -426,7 +426,7 @@ static int open_console(UI *ui)
 #  endif
 #  ifdef EIO
             /*
-             * Linux can return ENXIO.
+             * Linux can return EIO.
              * This should be ok
              */
         if (errno == EIO)

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -415,6 +415,24 @@ static int open_console(UI *ui)
             is_a_tty = 0;
         else
 #  endif
+#  ifdef ENXIO
+            /*
+             * Solaris can return ENXIO.
+             * This should be ok
+             */
+        if (errno == ENXIO)
+            is_a_tty = 0;
+        else
+#  endif
+#  ifdef EIO
+            /*
+             * Linux can return ENXIO.
+             * This should be ok
+             */
+        if (errno == EIO)
+            is_a_tty = 0;
+        else
+#  endif
 #  ifdef ENODEV
             /*
              * MacOS X returns ENODEV (Operation not supported by device),


### PR DESCRIPTION
These both indicate that the file descriptor we're trying to use as a
terminal isn't, in fact, a terminal.

Fixes #7271
