### PR TITLE
Mark SSL_CTX_set_ssl_version() as deprecated in 3.0

### DIFF
--- a/doc/man3/SSL_CTX_set_ssl_version.pod
+++ b/doc/man3/SSL_CTX_set_ssl_version.pod
@@ -16,9 +16,11 @@ SSL_CTX_set_ssl_version, SSL_set_ssl_method, SSL_get_ssl_method
 =head1 DESCRIPTION
 
 SSL_CTX_set_ssl_version() sets a new default TLS/SSL B<method> for SSL objects
-newly created from this B<ctx>. SSL objects already created with
-L<SSL_new(3)> are not affected, except when
-L<SSL_clear(3)> is being called.
+newly created from this B<ctx>.  Most of the configuration attached to the
+SSL_CTX object is retained, with the exception of the configured TLS ciphers,
+which are reset to the default values.  SSL objects already created from this
+SSL_CTX with L<SSL_new(3)> are not affected, except when L<SSL_clear(3)> is
+being called, as described below.
 
 SSL_set_ssl_method() sets a new TLS/SSL B<method> for a particular B<ssl>
 object. It may be reset, when SSL_clear() is called.
@@ -34,6 +36,11 @@ L<SSL_CTX_new(3)>.
 When L<SSL_clear(3)> is called and no session is connected to
 an SSL object, the method of the SSL object is reset to the method currently
 set in the corresponding SSL_CTX object.
+
+SSL_CTX_set_version() has unusual semantics and no clear use case;
+it would usually be preferable to create a new SSL_CTX object than to
+try to reuse an existing one in this fashion.  Its usage is considered
+deprecated.
 
 =head1 RETURN VALUES
 
@@ -57,6 +64,10 @@ The operation succeeded.
 L<SSL_CTX_new(3)>, L<SSL_new(3)>,
 L<SSL_clear(3)>, L<ssl(7)>,
 L<SSL_set_connect_state(3)>
+
+=head1 HISTORY
+
+SSL_CTX_set_ssl_version() was deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1903,7 +1903,7 @@ __owur int SSL_get_error(const SSL *s, int ret_code);
 __owur const char *SSL_get_version(const SSL *s);
 
 /* This sets the 'default' SSL version that SSL_new() will create */
-__owur int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth);
+DEPRECATEDIN_3_0(__owur int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth))
 
 # ifndef OPENSSL_NO_SSL3_METHOD
 DEPRECATEDIN_1_1_0(__owur const SSL_METHOD *SSLv3_method(void)) /* SSLv3 */

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -643,6 +643,7 @@ int SSL_clear(SSL *s)
     return 1;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 /** Used to change an SSL_CTXs default SSL method type */
 int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth)
 {
@@ -665,6 +666,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth)
     }
     return 1;
 }
+#endif
 
 SSL *SSL_new(SSL_CTX *ctx)
 {

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -239,7 +239,7 @@ DTLSv1_method                           239	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1
 SSL_set0_wbio                           240	3_0_0	EXIST::FUNCTION:
 SSL_read                                241	3_0_0	EXIST::FUNCTION:
 SSL_CTX_get_options                     242	3_0_0	EXIST::FUNCTION:
-SSL_CTX_set_ssl_version                 243	3_0_0	EXIST::FUNCTION:
+SSL_CTX_set_ssl_version                 243	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 SSL_set_SSL_CTX                         244	3_0_0	EXIST::FUNCTION:
 SSL_renegotiate_abbreviated             245	3_0_0	EXIST::FUNCTION:
 SSL_get_verify_mode                     246	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Also, document its unusual semantics of resetting the
cipher list (but preserving other configuration).

- [x] documentation is added or updated

Note that this takes the bold route of deprecating in addition to documenting; discussion welcome.