### PR TITLE
Add OPENSSL_VERSION_NUMBER_TEXT macro

### DIFF
--- a/Configure
+++ b/Configure
@@ -249,7 +249,7 @@ $config{shlib_version_history} = "unknown";
 
 collect_information(
     collect_from_file(catfile($srcdir,'include/openssl/opensslv.h')),
-    qr/OPENSSL.VERSION.TEXT.*OpenSSL (\S+) / => sub { $config{version} = $1; },
+    qr/^#\s+define\s+OPENSSL.VERSION.NUMBER.TEXT\s+"([^"]+)"/ => sub { $config{version} = $1; },
     qr/OPENSSL.VERSION.NUMBER.*(0x\S+)/	     => sub { $config{version_num}=$1 },
     qr/SHLIB_VERSION_NUMBER *"([^"]+)"/	     => sub { $config{shlib_version_number}=$1 },
     qr/SHLIB_VERSION_HISTORY *"([^"]*)"/     => sub { $config{shlib_version_history}=$1 }

--- a/doc/man3/OPENSSL_VERSION_NUMBER.pod
+++ b/doc/man3/OPENSSL_VERSION_NUMBER.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-OPENSSL_VERSION_NUMBER, OPENSSL_VERSION_TEXT, OpenSSL_version,
+OPENSSL_VERSION_NUMBER, OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER_TEXT,
+OpenSSL_version,
 OpenSSL_version_num - get OpenSSL version number
 
 =head1 SYNOPSIS
@@ -10,6 +11,7 @@ OpenSSL_version_num - get OpenSSL version number
  #include <openssl/opensslv.h>
  #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnnL
  #define OPENSSL_VERSION_TEXT "OpenSSL x.y.z xx XXX xxxx"
+ #define OPENSSL_VERSION_NUMBER_TEXT "x.y.z"
 
  #include <openssl/crypto.h>
 
@@ -49,6 +51,10 @@ number was therefore 0x0090581f.
 OPENSSL_VERSION_TEXT is the text variant of the version number and the
 release date.  For example,
 "OpenSSL 1.0.1a 15 Oct 2015".
+
+OPENSSL_VERSION_NUMBER_TEXT is a string representation of the numeric release
+version identifier.  For example,
+"1.0.1a"
 
 OpenSSL_version_num() returns the version number.
 

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -40,7 +40,9 @@ extern "C" {
  *  major minor fix final patch/beta)
  */
 # define OPENSSL_VERSION_NUMBER  0x10102000L
-# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.2-dev  xx XXX xxxx"
+# define OPENSSL_VERSION_NUMBER_TEXT "1.1.2-dev"
+# define OPENSSL_VERSION_TEXT \
+   "OpenSSL " OPENSSL_VERSION_NUMBER_TEXT "  xx XXX xxxx"
 
 /*-
  * The macros below are to be used for shared library (.so, .dll, ...)

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -1507,7 +1507,7 @@ sub get_openssl_version()
 	open (IN, "$fn") || die "Can't open opensslv.h";
 
 	while(<IN>) {
-		if (/OPENSSL_VERSION_TEXT\s+"OpenSSL (\d\.\d\.)(\d[a-z]*)(-| )/) {
+		if (/^\#\s+define\s+OPENSSL_VERSION_NUMBER_TEXT\s+"(\d\.\d\.)(\d[a-z]*)(-| )/) {
 			my $suffix = $2;
 			(my $baseversion = $1) =~ s/\./_/g;
 			close IN;

--- a/util/private.num
+++ b/util/private.num
@@ -242,6 +242,7 @@ EVP_sm4_cfb                             define
 OBJ_cleanup                             define deprecated 1.1.0
 OPENSSL_VERSION_NUMBER                  define
 OPENSSL_VERSION_TEXT                    define
+OPENSSL_VERSION_NUMBER_TEXT             define
 OPENSSL_clear_free                      define
 OPENSSL_clear_realloc                   define
 OPENSSL_free                            define


### PR DESCRIPTION
This commit adds a macro named `OPENSSL_VERSION_NUMBER_TEXT` that
contains the number part of `OPENSSL_VERSION_TEXT`.

The motivation for this is that even though the version number can be
parsed from `OPENSSL_VERSION_TEXT`, or by bit-shifting the
`OPENSSL_VERSION_NUMBER`, it would save users from having to
do so by providing this new macro. 

[Node.js](https://github.com/nodejs/node/blob/56493bf1ebfab3ec102fe017f30fa4f81ba6a256/src/node.cc#L239-L258) does this for example and would benefit from this and if there are others perhaps that would warrant this addition.
