### PR TITLE
Make ca command silently use default if .attr file does not exist

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1561,7 +1561,7 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
 #else
     BIO_snprintf(buf, sizeof(buf), "%s-attr", dbfile);
 #endif
-    dbattr_conf = app_load_config(buf);
+    dbattr_conf = app_load_config_quiet(buf);
 
     retdb = app_malloc(sizeof(*retdb), "new DB");
     retdb->db = tmpdb;


### PR DESCRIPTION
Currently the ca command loudly complains if the .attr file does not exist,
but uses the default silently if the unique_subject line is missing.