### PR TITLE
crypto/bn/asm/x86_64-gcc.c: remove unnecessary redefinition of BN_ULONG

### DIFF
--- a/crypto/bn/asm/x86_64-gcc.c
+++ b/crypto/bn/asm/x86_64-gcc.c
@@ -64,12 +64,6 @@
  *    machine.
  */
 
-# if defined(_WIN64) || !defined(__LP64__)
-#  define BN_ULONG unsigned long long
-# else
-#  define BN_ULONG unsigned long
-# endif
-
 # undef mul
 # undef mul_add
 


### PR DESCRIPTION
This module includes bn.h via other headers, so it picks up the
definition from there and doesn't need to define them locally (any
more?).  Worst case scenario, the redefinition may be different and
cause all sorts of compile errors.

Fixes #7227
