### PR TITLE
util/domd: omit superfluous shift in -MD handling.

### DIFF
--- a/util/domd
+++ b/util/domd
@@ -11,7 +11,6 @@ if [ "$1" = "-MD" ]; then
         MAKEDEPEND="$MAKEDEPEND $1"
         shift
     done
-    shift
 fi
 if [ "$MAKEDEPEND" = "" ]; then MAKEDEPEND=makedepend; fi
 


### PR DESCRIPTION
While reviewing last modification in GH#6261 Richard actually spotted
the inconsistency, but withdrew the remark, correct one in aftermath...
