### PR TITLE
Document OPENSSL_VERSION_TEXT macro

### DIFF
--- a/doc/man3/OPENSSL_VERSION_NUMBER.pod
+++ b/doc/man3/OPENSSL_VERSION_NUMBER.pod
@@ -9,6 +9,7 @@ OpenSSL_version_num - get OpenSSL version number
 
  #include <openssl/opensslv.h>
  #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnnL
+ #define OPENSSL_VERSION_TEXT "OpenSSL x.y.z xx XXX xxxx"
 
  #include <openssl/crypto.h>
 

--- a/doc/man3/OPENSSL_VERSION_NUMBER.pod
+++ b/doc/man3/OPENSSL_VERSION_NUMBER.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OPENSSL_VERSION_NUMBER, OpenSSL_version,
+OPENSSL_VERSION_NUMBER, OPENSSL_VERSION_TEXT, OpenSSL_version,
 OpenSSL_version_num - get OpenSSL version number
 
 =head1 SYNOPSIS
@@ -44,6 +44,10 @@ for example
 Version 0.9.5a had an interim interpretation that is like the current one,
 except the patch level got the highest bit set, to keep continuity.  The
 number was therefore 0x0090581f.
+
+OPENSSL_VERSION_TEXT is the text variant of the version number and the
+release date.  For example,
+"OpenSSL 1.0.1a 15 Oct 2015".
 
 OpenSSL_version_num() returns the version number.
 

--- a/util/private.num
+++ b/util/private.num
@@ -241,6 +241,7 @@ EVP_seed_cfb                            define
 EVP_sm4_cfb                             define
 OBJ_cleanup                             define deprecated 1.1.0
 OPENSSL_VERSION_NUMBER                  define
+OPENSSL_VERSION_TEXT                    define
 OPENSSL_clear_free                      define
 OPENSSL_clear_realloc                   define
 OPENSSL_free                            define


### PR DESCRIPTION
This commit documents the OPENSSL_VERSION_TEXT which is currently
missing in the man page.

Refs: https://github.com/openssl/openssl/pull/7285#discussion_r219423305

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

