### PR TITLE
Keep the externally visible macro BIO_FLAGS_UPLINK in bio.h

### DIFF
--- a/crypto/bio/bio.h
+++ b/crypto/bio/bio.h
@@ -204,13 +204,7 @@ extern "C" {
 # define BIO_FLAGS_IO_SPECIAL    0x04
 # define BIO_FLAGS_RWS (BIO_FLAGS_READ|BIO_FLAGS_WRITE|BIO_FLAGS_IO_SPECIAL)
 # define BIO_FLAGS_SHOULD_RETRY  0x08
-# ifndef BIO_FLAGS_UPLINK
-/*
- * "UPLINK" flag denotes file descriptors provided by application. It
- * defaults to 0, as most platforms don't require UPLINK interface.
- */
-#  define BIO_FLAGS_UPLINK        0
-# endif
+# define BIO_FLAGS_UPLINK        0
 
 /* Used in BIO_gethostbyname() */
 # define BIO_GHBN_CTRL_HITS              1

--- a/crypto/bio/bio_lcl.h
+++ b/crypto/bio/bio_lcl.h
@@ -1,6 +1,6 @@
 #include <openssl/bio.h>
 
-#if BIO_FLAGS_UPLINK==0
+#if BIO_FLAGS_UPLINK_INTERNAL==0
 /* Shortcut UPLINK calls on most platforms... */
 # define UP_stdin        stdin
 # define UP_stdout       stdout

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -140,7 +140,7 @@ static int fd_new(BIO *bi)
     bi->init = 0;
     bi->num = -1;
     bi->ptr = NULL;
-    bi->flags = BIO_FLAGS_UPLINK; /* essentially redundant */
+    bi->flags = BIO_FLAGS_UPLINK_INTERNAL; /* essentially redundant */
     return (1);
 }
 
@@ -153,7 +153,7 @@ static int fd_free(BIO *a)
             UP_close(a->num);
         }
         a->init = 0;
-        a->flags = BIO_FLAGS_UPLINK;
+        a->flags = BIO_FLAGS_UPLINK_INTERNAL;
     }
     return (1);
 }

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -189,8 +189,8 @@ BIO *BIO_new_file(const char *filename, const char *mode)
         return (NULL);
     }
 
-    BIO_clear_flags(ret, BIO_FLAGS_UPLINK); /* we did fopen -> we disengage
-                                             * UPLINK */
+    /* we did fopen -> we disengage UPLINK */
+    BIO_clear_flags(ret, BIO_FLAGS_UPLINK_INTERNAL); 
     BIO_set_fp(ret, file, BIO_CLOSE);
     return (ret);
 }
@@ -202,8 +202,8 @@ BIO *BIO_new_fp(FILE *stream, int close_flag)
     if ((ret = BIO_new(BIO_s_file())) == NULL)
         return (NULL);
 
-    BIO_set_flags(ret, BIO_FLAGS_UPLINK); /* redundant, left for
-                                           * documentation puposes */
+    /* redundant, left for documentation puposes */
+    BIO_set_flags(ret, BIO_FLAGS_UPLINK_INTERNAL);
     BIO_set_fp(ret, stream, close_flag);
     return (ret);
 }
@@ -218,7 +218,7 @@ static int MS_CALLBACK file_new(BIO *bi)
     bi->init = 0;
     bi->num = 0;
     bi->ptr = NULL;
-    bi->flags = BIO_FLAGS_UPLINK; /* default to UPLINK */
+    bi->flags = BIO_FLAGS_UPLINK_INTERNAL; /* default to UPLINK */
     return (1);
 }
 
@@ -228,12 +228,12 @@ static int MS_CALLBACK file_free(BIO *a)
         return (0);
     if (a->shutdown) {
         if ((a->init) && (a->ptr != NULL)) {
-            if (a->flags & BIO_FLAGS_UPLINK)
+            if (a->flags & BIO_FLAGS_UPLINK_INTERNAL)
                 UP_fclose(a->ptr);
             else
                 fclose(a->ptr);
             a->ptr = NULL;
-            a->flags = BIO_FLAGS_UPLINK;
+            a->flags = BIO_FLAGS_UPLINK_INTERNAL;
         }
         a->init = 0;
     }
@@ -245,13 +245,13 @@ static int MS_CALLBACK file_read(BIO *b, char *out, int outl)
     int ret = 0;
 
     if (b->init && (out != NULL)) {
-        if (b->flags & BIO_FLAGS_UPLINK)
+        if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = UP_fread(out, 1, (int)outl, b->ptr);
         else
             ret = fread(out, 1, (int)outl, (FILE *)b->ptr);
         if (ret == 0
-            && (b->flags & BIO_FLAGS_UPLINK) ? UP_ferror((FILE *)b->ptr) :
-                                               ferror((FILE *)b->ptr)) {
+            && (b->flags & BIO_FLAGS_UPLINK_INTERNAL
+                ? UP_ferror((FILE *)b->ptr) : ferror((FILE *)b->ptr))) {
             SYSerr(SYS_F_FREAD, get_last_sys_error());
             BIOerr(BIO_F_FILE_READ, ERR_R_SYS_LIB);
             ret = -1;
@@ -265,7 +265,7 @@ static int MS_CALLBACK file_write(BIO *b, const char *in, int inl)
     int ret = 0;
 
     if (b->init && (in != NULL)) {
-        if (b->flags & BIO_FLAGS_UPLINK)
+        if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = UP_fwrite(in, (int)inl, 1, b->ptr);
         else
             ret = fwrite(in, (int)inl, 1, (FILE *)b->ptr);
@@ -292,20 +292,20 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
     switch (cmd) {
     case BIO_C_FILE_SEEK:
     case BIO_CTRL_RESET:
-        if (b->flags & BIO_FLAGS_UPLINK)
+        if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = (long)UP_fseek(b->ptr, num, 0);
         else
             ret = (long)fseek(fp, num, 0);
         break;
     case BIO_CTRL_EOF:
-        if (b->flags & BIO_FLAGS_UPLINK)
+        if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = (long)UP_feof(fp);
         else
             ret = (long)feof(fp);
         break;
     case BIO_C_FILE_TELL:
     case BIO_CTRL_INFO:
-        if (b->flags & BIO_FLAGS_UPLINK)
+        if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = UP_ftell(b->ptr);
         else
             ret = ftell(fp);
@@ -315,22 +315,22 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
         b->shutdown = (int)num & BIO_CLOSE;
         b->ptr = ptr;
         b->init = 1;
-#  if BIO_FLAGS_UPLINK!=0
+#  if BIO_FLAGS_UPLINK_INTERNAL!=0
 #   if defined(__MINGW32__) && defined(__MSVCRT__) && !defined(_IOB_ENTRIES)
 #    define _IOB_ENTRIES 20
 #   endif
         /* Safety net to catch purely internal BIO_set_fp calls */
 #   if defined(_MSC_VER) && _MSC_VER>=1900
         if (ptr == stdin || ptr == stdout || ptr == stderr)
-            BIO_clear_flags(b, BIO_FLAGS_UPLINK);
+            BIO_clear_flags(b, BIO_FLAGS_UPLINK_INTERNAL);
 #   elif defined(_IOB_ENTRIES)
         if ((size_t)ptr >= (size_t)stdin &&
             (size_t)ptr < (size_t)(stdin + _IOB_ENTRIES))
-            BIO_clear_flags(b, BIO_FLAGS_UPLINK);
+            BIO_clear_flags(b, BIO_FLAGS_UPLINK_INTERNAL);
 #   endif
 #  endif
 #  ifdef UP_fsetmod
-        if (b->flags & BIO_FLAGS_UPLINK)
+        if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             UP_fsetmod(b->ptr, (char)((num & BIO_FP_TEXT) ? 't' : 'b'));
         else
 #  endif
@@ -411,8 +411,8 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         b->ptr = fp;
         b->init = 1;
-        BIO_clear_flags(b, BIO_FLAGS_UPLINK); /* we did fopen -> we disengage
-                                               * UPLINK */
+        /* we did fopen -> we disengage UPLINK */
+        BIO_clear_flags(b, BIO_FLAGS_UPLINK_INTERNAL);
         break;
     case BIO_C_GET_FILE_PTR:
         /* the ptr parameter is actually a FILE ** in this case. */
@@ -428,7 +428,7 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
         b->shutdown = (int)num;
         break;
     case BIO_CTRL_FLUSH:
-        st = b->flags & BIO_FLAGS_UPLINK
+        st = b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_fflush(b->ptr) : fflush((FILE *)b->ptr);
         if (st == EOF) {
             SYSerr(SYS_F_FFLUSH, get_last_sys_error());
@@ -457,7 +457,7 @@ static int MS_CALLBACK file_gets(BIO *bp, char *buf, int size)
     int ret = 0;
 
     buf[0] = '\0';
-    if (bp->flags & BIO_FLAGS_UPLINK) {
+    if (bp->flags & BIO_FLAGS_UPLINK_INTERNAL) {
         if (!UP_fgets(buf, size, bp->ptr))
             goto err;
     } else {

--- a/crypto/cryptlib.h
+++ b/crypto/cryptlib.h
@@ -65,8 +65,10 @@
 # include "e_os.h"
 
 # ifdef OPENSSL_USE_APPLINK
-#  define BIO_FLAGS_UPLINK 0x8000
+#  define BIO_FLAGS_UPLINK_INTERNAL 0x8000
 #  include "ms/uplink.h"
+# else
+#  define BIO_FLAGS_UPLINK_INTERNAL 0
 # endif
 
 # include <openssl/crypto.h>


### PR DESCRIPTION
Move definition of BIO_FLAGS_UPLINK completely to cryptlib.h