### PR TITLE
Keep the externally visible macro BIO_FLAGS_UPLINK in bio.h

### DIFF
--- a/crypto/bio/bio_lcl.h
+++ b/crypto/bio/bio_lcl.h
@@ -150,7 +150,7 @@ extern CRYPTO_RWLOCK *bio_type_lock;
 
 void bio_sock_cleanup_int(void);
 
-#if BIO_FLAGS_UPLINK==0
+#if BIO_FLAGS_UPLINK_INTERNAL==0
 /* Shortcut UPLINK calls on most platforms... */
 # define UP_stdin        stdin
 # define UP_stdout       stdout

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -90,7 +90,7 @@ static int fd_new(BIO *bi)
     bi->init = 0;
     bi->num = -1;
     bi->ptr = NULL;
-    bi->flags = BIO_FLAGS_UPLINK; /* essentially redundant */
+    bi->flags = BIO_FLAGS_UPLINK_INTERNAL; /* essentially redundant */
     return (1);
 }
 
@@ -103,7 +103,7 @@ static int fd_free(BIO *a)
             UP_close(a->num);
         }
         a->init = 0;
-        a->flags = BIO_FLAGS_UPLINK;
+        a->flags = BIO_FLAGS_UPLINK_INTERNAL;
     }
     return (1);
 }

--- a/crypto/include/internal/cryptlib.h
+++ b/crypto/include/internal/cryptlib.h
@@ -16,9 +16,10 @@
 # include "e_os.h"
 
 # ifdef OPENSSL_USE_APPLINK
-#  undef BIO_FLAGS_UPLINK
-#  define BIO_FLAGS_UPLINK 0x8000
+#  define BIO_FLAGS_UPLINK_INTERNAL 0x8000
 #  include "ms/uplink.h"
+# else
+#  define BIO_FLAGS_UPLINK_INTERNAL 0
 # endif
 
 # include <openssl/crypto.h>

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -154,12 +154,9 @@ extern "C" {
 # define BIO_FLAGS_IO_SPECIAL    0x04
 # define BIO_FLAGS_RWS (BIO_FLAGS_READ|BIO_FLAGS_WRITE|BIO_FLAGS_IO_SPECIAL)
 # define BIO_FLAGS_SHOULD_RETRY  0x08
-# ifndef BIO_FLAGS_UPLINK
-/*
- * "UPLINK" flag denotes file descriptors provided by application. It
- * defaults to 0, as most platforms don't require UPLINK interface.
- */
-#  define BIO_FLAGS_UPLINK        0
+# if OPENSSL_API_COMPAT < 0x10200000L
+/* This #define was replaced by an internal constant and should not be used. */
+#  define BIO_FLAGS_UPLINK       0
 # endif
 
 # define BIO_FLAGS_BASE64_NO_NL  0x100


### PR DESCRIPTION
and rename the internally used macro to BIO_FLAGS_UPLINK_INTERNAL.
Deprecate the externally visible definition of BIO_FLAGS_UPLINK.

Backport of #7307 to 110
