### PR TITLE
apps/asn1parse: improve RFC7468 compliance

### DIFF
--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -32,7 +32,7 @@ const OPTIONS asn1parse_options[] = {
     {"oid", OPT_OID, '<', "file of extra oid definitions"},
 
     OPT_SECTION("I/O"),
-    {"inform", OPT_INFORM, 'F', "input format - one of DER PEM"},
+    {"inform", OPT_INFORM, 'A', "input format - one of DER PEM B64"},
     {"in", OPT_IN, '<', "input file"},
     {"out", OPT_OUT, '>', "output file (output format is always DER)"},
     {"noout", OPT_NOOUT, 0, "do not produce any output"},
@@ -44,7 +44,7 @@ const OPTIONS asn1parse_options[] = {
     {OPT_MORE_STR, 0, 0, "into multiple ASN1 blob wrappings"},
     {"genconf", OPT_GENCONF, 's', "file to generate ASN1 structure from"},
     {"strictpem", OPT_STRICTPEM, 0,
-     "do not attempt base64 decode outside PEM markers"},
+     "equivalent to '-inform pem' (obsolete)"},
     {"item", OPT_ITEM, 's', "item to parse and print"},
     {OPT_MORE_STR, 0, 0, "(-inform  will be ignored)"},
 
@@ -69,7 +69,7 @@ int asn1parse_main(int argc, char **argv)
     unsigned char *str = NULL;
     char *name = NULL, *header = NULL, *prog;
     const unsigned char *ctmpbuf;
-    int indent = 0, noout = 0, dump = 0, strictpem = 0, informat = FORMAT_PEM;
+    int indent = 0, noout = 0, dump = 0, informat = FORMAT_PEM;
     int offset = 0, ret = 1, i, j;
     long num, tmplen;
     unsigned char *tmpbuf;
@@ -96,7 +96,7 @@ int asn1parse_main(int argc, char **argv)
             ret = 0;
             goto end;
         case OPT_INFORM:
-            if (!opt_format(opt_arg(), OPT_FMT_PEMDER, &informat))
+            if (!opt_format(opt_arg(), OPT_FMT_ASN1, &informat))
                 goto opthelp;
             break;
         case OPT_IN:
@@ -136,7 +136,7 @@ int asn1parse_main(int argc, char **argv)
             genconf = opt_arg();
             break;
         case OPT_STRICTPEM:
-            strictpem = 1;
+            /* accepted for backward compatibility */
             informat = FORMAT_PEM;
             break;
         case OPT_ITEM:
@@ -178,7 +178,7 @@ int asn1parse_main(int argc, char **argv)
 
     if ((buf = BUF_MEM_new()) == NULL)
         goto end;
-    if (strictpem) {
+    if (informat == FORMAT_PEM) {
         if (PEM_read_bio(in, &name, &header, &str, &num) != 1) {
             BIO_printf(bio_err, "Error reading PEM file\n");
             ERR_print_errors(bio_err);
@@ -198,7 +198,7 @@ int asn1parse_main(int argc, char **argv)
             }
         } else {
 
-            if (informat == FORMAT_PEM) {
+            if (informat == FORMAT_BASE64) {
                 BIO *tmp;
 
                 if ((b64 = BIO_new(BIO_f_base64())) == NULL)

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -343,22 +343,27 @@ typedef struct string_int_pair_st {
 } OPT_PAIR, STRINT_PAIR;
 
 /* Flags to pass into opt_format; see FORMAT_xxx, below. */
-# define OPT_FMT_PEMDER          (1L <<  1)
-# define OPT_FMT_PKCS12          (1L <<  2)
-# define OPT_FMT_SMIME           (1L <<  3)
-# define OPT_FMT_ENGINE          (1L <<  4)
-# define OPT_FMT_MSBLOB          (1L <<  5)
-/* (1L <<  6) was OPT_FMT_NETSCAPE, but wasn't used */
-# define OPT_FMT_NSS             (1L <<  7)
-# define OPT_FMT_TEXT            (1L <<  8)
-# define OPT_FMT_HTTP            (1L <<  9)
-# define OPT_FMT_PVK             (1L << 10)
+# define OPT_FMT_PEM             (1L <<  1)
+# define OPT_FMT_DER             (1L <<  2)
+# define OPT_FMT_B64             (1L <<  3)
+# define OPT_FMT_PKCS12          (1L <<  4)
+# define OPT_FMT_SMIME           (1L <<  5)
+# define OPT_FMT_ENGINE          (1L <<  6)
+# define OPT_FMT_MSBLOB          (1L <<  7)
+# define OPT_FMT_NSS             (1L <<  8)
+# define OPT_FMT_TEXT            (1L <<  9)
+# define OPT_FMT_HTTP            (1L << 10)
+# define OPT_FMT_PVK             (1L << 11)
+
+# define OPT_FMT_PEMDER  (OPT_FMT_PEM | OPT_FMT_DER)
+# define OPT_FMT_ASN1    (OPT_FMT_PEM | OPT_FMT_DER | OPT_FMT_B64)
 # define OPT_FMT_PDE     (OPT_FMT_PEMDER | OPT_FMT_ENGINE)
 # define OPT_FMT_PDS     (OPT_FMT_PEMDER | OPT_FMT_SMIME)
 # define OPT_FMT_ANY     ( \
-        OPT_FMT_PEMDER | OPT_FMT_PKCS12 | OPT_FMT_SMIME | \
-        OPT_FMT_ENGINE | OPT_FMT_MSBLOB | OPT_FMT_NSS   | \
-        OPT_FMT_TEXT   | OPT_FMT_HTTP   | OPT_FMT_PVK)
+        OPT_FMT_PEM | OPT_FMT_DER | OPT_FMT_B64 | \
+        OPT_FMT_PKCS12 | OPT_FMT_SMIME |                     \
+        OPT_FMT_ENGINE | OPT_FMT_MSBLOB | OPT_FMT_NSS | \
+        OPT_FMT_TEXT | OPT_FMT_HTTP | OPT_FMT_PVK)
 
 /* Divide options into sections when displaying usage */
 #define OPT_SECTION(sec) { OPT_SECTION_STR, 1, '-', sec " options:\n" }

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -319,11 +319,28 @@ extern const char OPT_PARAM_STR[];
 typedef struct options_st {
     const char *name;
     int retval;
-    /*
-     * value type: - no value (also the value zero), n number, p positive
-     * number, u unsigned, l long, s string, < input file, > output file,
-     * f any format, F der/pem format, E der/pem/engine format identifier.
-     * l, n and u include zero; p does not.
+    /*-
+     * value type:
+     *
+     *   '-' no value (also the value zero)
+     *   'n' number (type 'int')
+     *   'p' positive number (type 'int')
+     *   'u' unsigned number (type 'unsigned long')
+     *   'l' number (type 'unsigned long')
+     *   'M' number (type 'intmax_t')
+     *   'U' unsigned number (type 'uintmax_t')
+     *   's' string
+     *   '<' input file
+     *   '>' output file
+     *   '/' directory
+     *   'f' any format                    [OPT_FMT_ANY]
+     *   'F' der/pem format                [OPT_FMT_PEMDER]
+     *   'A' any ASN1, der/pem/b64 format  [OPT_FMT_ASN1]
+     *   'E' der/pem/engine format         [OPT_FMT_PDE]
+     *   'c' pem/der/smime format          [OPT_FMT_PDS]
+     *
+     * The 'l', 'n' and 'u' value types include the values zero,
+     * the 'p' value type does not.
      */
     int valtype;
     const char *helpstr;

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -194,7 +194,7 @@ char *opt_init(int ac, char **av, const OPTIONS *o)
         case   0: case '-': case '.':
         case '/': case '<': case '>': case 'E': case 'F':
         case 'M': case 'U': case 'f': case 'l': case 'n': case 'p': case 's':
-        case 'u': case 'c': case ':': case 'N':
+        case 'u': case 'c': case ':': case 'N': case 'A':
             break;
         default:
             OPENSSL_assert(0);
@@ -225,7 +225,9 @@ char *opt_init(int ac, char **av, const OPTIONS *o)
 }
 
 static OPT_PAIR formats[] = {
-    {"PEM/DER", OPT_FMT_PEMDER},
+    {"pem", OPT_FMT_PEM},
+    {"der", OPT_FMT_DER},
+    {"b64", OPT_FMT_B64},
     {"pkcs12", OPT_FMT_PKCS12},
     {"smime", OPT_FMT_SMIME},
     {"engine", OPT_FMT_ENGINE},
@@ -247,16 +249,12 @@ static int opt_format_error(const char *s, unsigned long flags)
 {
     OPT_PAIR *ap;
 
-    if (flags == OPT_FMT_PEMDER) {
-        opt_printf_stderr("%s: Bad format \"%s\"; must be pem or der\n",
-                          prog, s);
-    } else {
-        opt_printf_stderr("%s: Bad format \"%s\"; must be one of:\n",
-                          prog, s);
-        for (ap = formats; ap->name; ap++)
-            if (flags & ap->retval)
-                opt_printf_stderr("   %s\n", ap->name);
-    }
+    opt_printf_stderr("%s: Bad format \"%s\"; must be one of: ", prog, s);
+    for (ap = formats; ap->name; ap++)
+        if (flags & ap->retval)
+            opt_printf_stderr(" %s", ap->name);
+    opt_printf_stderr("\n");
+
     return 0;
 }
 
@@ -267,9 +265,21 @@ int opt_format(const char *s, unsigned long flags, int *result)
     default:
         opt_printf_stderr("%s: Bad format \"%s\"\n", prog, s);
         return 0;
+    case 'B':
+    case 'b':
+        if (s[1] == '\0'
+            || strcmp(s, "B64") == 0 || strcmp(s, "b64") == 0
+            || strcmp(s, "BASE64") == 0 || strcmp(s, "base64") == 0 ) {
+            if ((flags & OPT_FMT_B64) == 0)
+                return opt_format_error(s, flags);
+            *result = FORMAT_BASE64;
+        } else {
+            return 0;
+        }
+        break;
     case 'D':
     case 'd':
-        if ((flags & OPT_FMT_PEMDER) == 0)
+        if ((flags & OPT_FMT_DER) == 0)
             return opt_format_error(s, flags);
         *result = FORMAT_ASN1;
         break;
@@ -319,7 +329,7 @@ int opt_format(const char *s, unsigned long flags, int *result)
     case 'P':
     case 'p':
         if (s[1] == '\0' || strcmp(s, "PEM") == 0 || strcmp(s, "pem") == 0) {
-            if ((flags & OPT_FMT_PEMDER) == 0)
+            if ((flags & OPT_FMT_PEM) == 0)
                 return opt_format_error(s, flags);
             *result = FORMAT_PEM;
         } else if (strcmp(s, "PVK") == 0 || strcmp(s, "pvk") == 0) {
@@ -976,11 +986,14 @@ int opt_next(void)
         case 'E':
         case 'F':
         case 'f':
+        case 'A':
+        case 'a':
             if (opt_format(arg,
                            o->valtype == 'c' ? OPT_FMT_PDS :
                            o->valtype == 'E' ? OPT_FMT_PDE :
-                           o->valtype == 'F' ? OPT_FMT_PEMDER
-                           : OPT_FMT_ANY, &ival))
+                           o->valtype == 'F' ? OPT_FMT_PEMDER :
+                           o->valtype == 'A' ? OPT_FMT_ASN1 :
+                           OPT_FMT_ANY, &ival))
                 break;
             opt_printf_stderr("%s: Invalid format \"%s\" for option -%s\n",
                               prog, arg, o->name);

--- a/doc/man1/openssl-asn1parse.pod.in
+++ b/doc/man1/openssl-asn1parse.pod.in
@@ -9,7 +9,7 @@ openssl-asn1parse - ASN.1 parsing command
 
 B<openssl> B<asn1parse>
 [B<-help>]
-[B<-inform> B<DER>|B<PEM>]
+[B<-inform> B<DER>|B<PEM>|B<B64>]
 [B<-in> I<filename>]
 [B<-out> I<filename>]
 [B<-noout>]
@@ -38,7 +38,7 @@ It can also be used to extract data from ASN.1 formatted data.
 
 Print out a usage message.
 
-=item B<-inform> B<DER>|B<PEM>
+=item B<-inform> B<DER>|B<PEM>|B<B64>
 
 The input format; the default is B<PEM>.
 See L<openssl-format-options(1)> for details.

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1083,7 +1083,7 @@ sub checkflags {
                 err("$cmd does not implement help for -$expect_helpstr") unless m/^\s*"/;
                 $expect_helpstr = "";
             }
-            if (m/\{\s*"([^"]+)"\s*,\s*OPT_[A-Z0-9_]+\s*,\s*('[-\/:<>cEfFlMnNpsuU]'|0)(.*)$/
+            if (m/\{\s*"([^"]+)"\s*,\s*OPT_[A-Z0-9_]+\s*,\s*('[-\/:<>cAEfFlMnNpsuU]'|0)(.*)$/
                     && !($cmd eq "s_client" && $1 eq "wdebug")) {
                 push @cmdopts, $1;
                 $expect_helpstr = $1;
@@ -1122,7 +1122,7 @@ sub checkflags {
         err("$doc: undocumented $cmd option -$_");
     }
 
-    # See what's in the command not the manpage.
+    # See what's in the manpage not the command.
     my @unimpl = sort grep { my $e = $_; !(grep /^\Q$e\E$/, @cmdopts) } keys %docopts;
     foreach ( @unimpl ) {
         next if $_ eq "-"; # Skip the -- end-of-flags marker


### PR DESCRIPTION
Fixes #7317

This pull request attempts to make the asn1parse command more RFC7468 compliant by default. It consists of two commits:

6bfb8ed20b **apps/opt: refactor input format parsing**

```
    - split OPT_FMT_PEMDER flag into OPT_FMT_PEM and OPT_FMT_DER
    - add OPT_FMT_B64 option (`-inform b64`)
```

1ed71e12d9 **apps/asn1parse: improve RFC7468 compliance**
```
    Fixes #7317

    The asn1parse command now supports three different input formats:

         openssl asn1parse -inform PEM|DER|B64

           PEM: base64 encoded data enclosed by PEM markers (RFC7468)
           DER: der encoded binary data
           B64: raw base64 encoded data

    The PEM input format is the default format. It is equivalent
    to the former `-strictpem` option which is now marked obsolete and
    kept for compatibility reasons only.

    The B64 is equivalent to the former default input format of the
    asn1parse command (without `-strictpem`)
```

The pull request is currently marked WIP because it still needs a little time for (st)aging and testing and the documentation is still missing.


##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
