### PR TITLE
Prevent unaligned memory access in cfb128.c, ctr128.c, ofb128.c

### DIFF
--- a/crypto/modes/cfb128.c
+++ b/crypto/modes/cfb128.c
@@ -43,8 +43,12 @@ void CRYPTO_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                 while (len >= 16) {
                     (*block) (ivec, ivec, key);
                     for (; n < 16; n += sizeof(size_t)) {
-                        *(size_t *)(out + n) =
-                            *(size_t *)(ivec + n) ^= *(size_t *)(in + n);
+                        size_t a, b;
+                        memcpy(&a, ivec + n, sizeof(a));
+                        memcpy(&b, in + n, sizeof(b));
+                        a ^= b;
+                        memcpy(ivec + n, &a, sizeof(a));
+                        memcpy(out + n, &a, sizeof(a));
                     }
                     len -= 16;
                     out += 16;
@@ -92,9 +96,12 @@ void CRYPTO_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                 while (len >= 16) {
                     (*block) (ivec, ivec, key);
                     for (; n < 16; n += sizeof(size_t)) {
-                        size_t t = *(size_t *)(in + n);
-                        *(size_t *)(out + n) = *(size_t *)(ivec + n) ^ t;
-                        *(size_t *)(ivec + n) = t;
+                        size_t a, b;
+                        memcpy(&a, ivec + n, sizeof(a));
+                        memcpy(&b, in + n, sizeof(b));
+                        a ^= b;
+                        memcpy(out + n, &a, sizeof(a));
+                        memcpy(ivec + n, &b, sizeof(b));
                     }
                     len -= 16;
                     out += 16;

--- a/crypto/modes/ctr128.c
+++ b/crypto/modes/ctr128.c
@@ -96,9 +96,13 @@ void CRYPTO_ctr128_encrypt(const unsigned char *in, unsigned char *out,
             while (len >= 16) {
                 (*block) (ivec, ecount_buf, key);
                 ctr128_inc_aligned(ivec);
-                for (n = 0; n < 16; n += sizeof(size_t))
-                    *(size_t *)(out + n) =
-                        *(size_t *)(in + n) ^ *(size_t *)(ecount_buf + n);
+                for (n = 0; n < 16; n += sizeof(size_t)) {
+                    size_t a, b;
+                    memcpy(&a, in + n, sizeof(a));
+                    memcpy(&b, ecount_buf + n, sizeof(b));
+                    a ^= b;
+                    memcpy(out + n, &a, sizeof(a));
+                }
                 len -= 16;
                 out += 16;
                 in += 16;

--- a/crypto/modes/ofb128.c
+++ b/crypto/modes/ofb128.c
@@ -40,9 +40,13 @@ void CRYPTO_ofb128_encrypt(const unsigned char *in, unsigned char *out,
 # endif
             while (len >= 16) {
                 (*block) (ivec, ivec, key);
-                for (; n < 16; n += sizeof(size_t))
-                    *(size_t *)(out + n) =
-                        *(size_t *)(in + n) ^ *(size_t *)(ivec + n);
+                for (; n < 16; n += sizeof(size_t)) {
+                    size_t a, b;
+                    memcpy(&a, in + n, sizeof(a));
+                    memcpy(&b, ivec + n, sizeof(b));
+                    a ^= b;
+                    memcpy(out + n, &a, sizeof(a));
+                }
                 len -= 16;
                 out += 16;
                 in += 16;


### PR DESCRIPTION
Refer to https://github.com/openssl/openssl/issues/7325