### PR TITLE
Small cleanup (util/mkdef.pl, crypto/bio/bss_log.c, include/openssl/ocsp.h)

### DIFF
--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -408,4 +408,9 @@ static void xcloselog(BIO *bp)
 
 # endif                         /* Unix */
 
+#else                           /* NO_SYSLOG */
+const BIO_METHOD *BIO_s_log(void)
+{
+    return NULL;
+}
 #endif                          /* NO_SYSLOG */

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -93,7 +93,6 @@ typedef struct ocsp_resp_bytes_st OCSP_RESPBYTES;
 #  define V_OCSP_RESPID_KEY  1
 
 DEFINE_STACK_OF(OCSP_RESPID)
-DECLARE_ASN1_FUNCTIONS(OCSP_RESPID)
 
 typedef struct ocsp_revoked_info_st OCSP_REVOKEDINFO;
 
@@ -162,8 +161,6 @@ int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it,
 int OCSP_REQ_CTX_nbio_d2i(OCSP_REQ_CTX *rctx, ASN1_VALUE **pval,
                           const ASN1_ITEM *it);
 BIO *OCSP_REQ_CTX_get0_mem_bio(OCSP_REQ_CTX *rctx);
-int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it,
-                     ASN1_VALUE *val);
 int OCSP_REQ_CTX_http(OCSP_REQ_CTX *rctx, const char *op, const char *path);
 int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, OCSP_REQUEST *req);
 int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,

--- a/include/openssl/symhacks.h
+++ b/include/openssl/symhacks.h
@@ -28,21 +28,6 @@
 #  undef i2d_ECPKPARAMETERS
 #  define i2d_ECPKPARAMETERS                      i2d_UC_ECPKPARAMETERS
 
-/*
- * These functions do not seem to exist! However, I'm paranoid... Original
- * command in x509v3.h: These functions are being redefined in another
- * directory, and clash when the linker is case-insensitive, so let's hide
- * them a little, by giving them an extra 'o' at the beginning of the name...
- */
-#  undef X509v3_cleanup_extensions
-#  define X509v3_cleanup_extensions               oX509v3_cleanup_extensions
-#  undef X509v3_add_extension
-#  define X509v3_add_extension                    oX509v3_add_extension
-#  undef X509v3_add_netscape_extensions
-#  define X509v3_add_netscape_extensions          oX509v3_add_netscape_extensions
-#  undef X509v3_add_standard_extensions
-#  define X509v3_add_standard_extensions          oX509v3_add_standard_extensions
-
 /* This one clashes with CMS_data_create */
 #  undef cms_Data_create
 #  define cms_Data_create                         priv_cms_Data_create

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -282,7 +282,7 @@ TS_REQ_free                             282	1_1_0	EXIST::FUNCTION:TS
 PEM_read_DHparams                       283	1_1_0	EXIST::FUNCTION:DH,STDIO
 RSA_private_decrypt                     284	1_1_0	EXIST::FUNCTION:RSA
 X509V3_EXT_get_nid                      285	1_1_0	EXIST::FUNCTION:
-BIO_s_log                               286	1_1_0	EXIST:!WIN32,!macintosh:FUNCTION:
+BIO_s_log                               286	1_1_0	EXIST::FUNCTION:
 EC_POINT_set_to_infinity                287	1_1_0	EXIST::FUNCTION:EC
 EVP_des_ede_ofb                         288	1_1_0	EXIST::FUNCTION:DES
 ECDH_KDF_X9_62                          289	1_1_0	EXIST::FUNCTION:EC

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -936,16 +936,6 @@ sub do_defs
 		}
 	}
 
-	# Prune the returned symbols
-
-        delete $syms{"bn_dump1"};
-	$platform{"BIO_s_log"} .= ",!WIN32,!macintosh";
-
-	$platform{"PEM_read_NS_CERT_SEQ"} = "VMS";
-	$platform{"PEM_write_NS_CERT_SEQ"} = "VMS";
-	$platform{"PEM_read_P8_PRIV_KEY_INFO"} = "VMS";
-	$platform{"PEM_write_P8_PRIV_KEY_INFO"} = "VMS";
-
 	# Info we know about
 
 	push @ret, map { $_."\\".&info_string($_,"EXIST",


### PR DESCRIPTION
BIO_s_log() is declared for everyone, so should return NULL when not
actually implemented.  Also, it had explicit platform limitations in
util/mkdef.pl that didn't correspond to what was actually in code.
While at it, a few other hard coded things that have lost their
relevance were removed.

include/openssl/ocsp.h had a few duplicate declarations.
