### PR TITLE
Ignore libcrypto.ld and libssl.ld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ Makefile
 /TAGS
 /libcrypto.map
 /libssl.map
+/libcrypto.ld
+/libssl.ld
 
 # Windows (legacy)
 /tmp32

--- a/.gitignore
+++ b/.gitignore
@@ -82,10 +82,8 @@ Makefile
 /util/shlib_wrap.sh
 /tags
 /TAGS
-/libcrypto.map
-/libssl.map
-/libcrypto.ld
-/libssl.ld
+/*.map
+/*.ld
 
 # Windows (legacy)
 /tmp32

--- a/.gitignore
+++ b/.gitignore
@@ -82,8 +82,8 @@ Makefile
 /util/shlib_wrap.sh
 /tags
 /TAGS
-/*.map
-/*.ld
+*.map
+*.ld
 
 # Windows (legacy)
 /tmp32


### PR DESCRIPTION
These are auto generated files that should not be checked into git

