### PR TITLE
Remove SSL_version_str

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2392,8 +2392,6 @@ int SSL_CTX_set_session_ticket_cb(SSL_CTX *ctx,
 int SSL_SESSION_set1_ticket_appdata(SSL_SESSION *ss, const void *data, size_t len);
 int SSL_SESSION_get0_ticket_appdata(SSL_SESSION *ss, void **data, size_t *len);
 
-extern const char SSL_version_str[];
-
 typedef unsigned int (*DTLS_timer_cb)(SSL *s, unsigned int timer_us);
 
 void DTLS_set_timer_cb(SSL *s, DTLS_timer_cb cb);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -23,8 +23,6 @@
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
 
-const char SSL_version_str[] = OPENSSL_VERSION_TEXT;
-
 static int ssl_undefined_function_1(SSL *ssl, SSL3_RECORD *r, size_t s, int t)
 {
     (void)r;


### PR DESCRIPTION
I was never exported in our shared libraries and no one noticed, and
we don't seem to use it ourselves, so clean it away.

In all likelyhood, this is a remain from the 90's, when it was in
fashion to litter library modules with these kinds of strings.
