### PR TITLE
Fix tls_cbc_digest_record is slow using SHA-384 and short messages

### DIFF
--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -262,7 +262,7 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
      * short and there obviously cannot be this many blocks then
      * variance_blocks can be reduced.
      */
-    variance_blocks = is_sslv3 ? 2 : (384/md_block_size);
+    variance_blocks = is_sslv3 ? 2 : ( ((255 + 1 + md_size + md_block_size - 1) / md_block_size) + 1);
     /*
      * From now on we're dealing with the MAC, which conceptually has 13
      * bytes of `header' before the start of the data (TLS) or 71/75 bytes

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -256,12 +256,13 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
      * of hash termination (0x80 + 64-bit length) don't fit in the final
      * block, we say that the final two blocks can vary based on the padding.
      * TLSv1 has MACs up to 48 bytes long (SHA-384) and the padding is not
-     * required to be minimal. Therefore we say that the final six blocks can
+     * required to be minimal. Therefore we say that the final |variance_blocks|
+     * blocks can
      * vary based on the padding. Later in the function, if the message is
      * short and there obviously cannot be this many blocks then
      * variance_blocks can be reduced.
      */
-    variance_blocks = is_sslv3 ? 2 : 6;
+    variance_blocks = is_sslv3 ? 2 : (384/md_block_size);
     /*
      * From now on we're dealing with the MAC, which conceptually has 13
      * bytes of `header' before the start of the data (TLS) or 71/75 bytes


### PR DESCRIPTION
The right value for this variable is
````
kVarianceBlocks = 384 / md_block_size;
````

Notice that `md_block_size=64` for SHA256, which results on the
magic constant `kVarianceBlocks = 384/64 = 6`.
However, `md_block_size=128` for SHA384 leading to
`kVarianceBlocks = 384/128 = 3`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

CLA:trivial

