### PR TITLE
Refactor util/mkdef.pl for DSOs

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -78,6 +78,7 @@
              if ref $unified_info{generate}->{$src} eq "";
          my $script = $unified_info{generate}->{$src}->[0];
          $OUT .= generatesrc(src => $src,
+                             product => $bin,
                              generator => $unified_info{generate}->{$src},
                              generator_incs => $unified_info{includes}->{$script},
                              generator_deps => $unified_info{depends}->{$script},
@@ -159,7 +160,13 @@
                      deps => [ resolvedepends($lib) ],
                      installed => is_installed($lib));
      foreach (@{$unified_info{shared_sources}->{$lib}}) {
-         doobj($_, $lib, intent => "dso", installed => is_installed($lib));
+         # If this is somehow a compiled object, take care of it that way
+         # Otherwise, it might simply be generated
+         if (defined $unified_info{sources}->{$_}) {
+             doobj($_, $lib, intent => "dso", installed => is_installed($lib));
+         } else {
+             dogenerate($_, undef, $lib, intent => "dso");
+         }
      }
      $cache{$lib} = 1;
  }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -761,9 +761,12 @@ reconfigure reconf :
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
           my $ord_name =
               $args{generator}->[1] || basename($args{product}, '.EXE');
+          my $case_insensitive =
+              $target{$args{intent}.'_cflags'} =~ m|/NAMES=[^/]*AS_IS|i
+              ? '' : ' --case-insensitive';
           return <<"EOF";
 $target : $args{generator}->[0] $deps $mkdef
-	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS" > $target
+	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS"$case_insensitive > $target
 EOF
       } elsif ($target !~ /\.[sS]$/) {
           my $target = $args{src};

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -758,9 +758,12 @@ reconfigure reconf :
       if ($args{src} =~ /\.ld$/) {
           (my $target = $args{src}) =~ s/\.ld$/.OPT/;
           my $mkdef = sourcefile('util', 'mkdef.pl');
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_name =
+              $args{generator}->[1] || basename($args{product}, '.EXE');
           return <<"EOF";
-$target : $args{generator}->[0] $deps
-	\$(PERL) $mkdef --ordinals $args{generator}->[0] --name $args{generator}->[1] "--OS" "VMS" > $target
+$target : $args{generator}->[0] $deps $mkdef
+	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS" > $target
 EOF
       } elsif ($target !~ /\.[sS]$/) {
           my $target = $args{src};
@@ -925,7 +928,7 @@ EOF
                  grep { $_ =~ m|\.o$| }
                  @{$args{objs}};
       my @defs = map { (my $x = $_) =~ s|\.ld$|.OPT|; $x }
-                 grep { $_ =~ /\.ld$/ }
+                 grep { $_ =~ m|\.ld$| }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       die "More than one symbol vector" if scalar @defs > 1;
@@ -971,13 +974,16 @@ EOF
       my $libd = dirname($lib);
       my $libn = basename($lib);
       (my $libn_nolib = $libn) =~ s/^lib//;
-      my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x } @{$args{objs}};
+      my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x }
+                 grep { $_ =~ m|\.o$| }
+                 @{$args{objs}};
+      my @defs = map { (my $x = $_) =~ s|\.ld$|.OPT|; $x }
+                 grep { $_ =~ m|\.ld$| }
+                 @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
-      my $deps = join(", -\n\t\t", @objs, @deps);
+      my $deps = join(", -\n\t\t", @objs, @defs, @deps);
+      die "More than one symbol vector" if scalar @defs > 1;
       my $shlib_target = $disabled{shared} ? "" : $target{shared_target};
-      my $engine_opt = abs2rel(rel2abs(catfile($config{sourcedir},
-                                               "VMS", "engine.opt")),
-                               rel2abs($config{builddir}));
       # The "[]" hack is because in .OPT files, each line inherits the
       # previous line's file spec as default, so if no directory spec
       # is present in the current line and the previous line has one that
@@ -994,12 +1000,12 @@ EOF
           || "\@ !";
       return <<"EOF"
 $lib.EXE : $deps
-        OPEN/WRITE/SHARE=READ OPT_FILE $lib.OPT
-        TYPE $engine_opt /OUTPUT=OPT_FILE:
+        OPEN/WRITE/SHARE=READ OPT_FILE $lib-components.OPT
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
-        LINK \$(DSO_LDFLAGS)/SHARE=\$\@ $lib.OPT/OPT \$(DSO_EX_LIBS)
+        LINK \$(DSO_LDFLAGS)/SHARE=\$\@ $defs[0]/OPT,-
+		$lib-components.OPT/OPT \$(DSO_EX_LIBS)
         - PURGE $lib.EXE,$lib.OPT,$lib.MAP
 EOF
         . ($config{target} =~ m|alpha| ? "" : <<"EOF"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1001,9 +1001,12 @@ reconfigure reconf:
       if ($args{src} =~ /\.ld$/) {
           (my $target = $args{src}) =~ s/\.ld$/${defext}/;
           (my $mkdef_os = $target{shared_target}) =~ s|-shared$||;
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_name =
+              $args{generator}->[1] || basename($args{product}, $dsoext);
           return <<"EOF";
-$target: $args{generator}->[0] $deps
-	\$(PERL) \$(SRCDIR)/util/mkdef.pl --ordinals $args{generator}->[0] --name $args{generator}->[1] --OS $mkdef_os > $target
+$target: $args{generator}->[0] $deps \$(SRCDIR)/util/mkdef.pl
+	\$(PERL) \$(SRCDIR)/util/mkdef.pl$ord_ver --ordinals $args{generator}->[0]  --name $ord_name --OS $mkdef_os > $target
 EOF
       } elsif ($args{src} !~ /\.[sS]$/) {
           if ($args{generator}->[0] =~ m|^.*\.in$|) {
@@ -1222,14 +1225,18 @@ EOF
       my @objs = map { (my $x = $_) =~ s|\.o$||; "$x$objext" }
                  grep { $_ !~ m/\.ld$/ }
                  @{$args{objs}};
+      my @defs = map { (my $x = $_) =~ s|\.ld$||; "$x$defext" }
+                 grep { $_ =~ /\.ld$/ }
+                 @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       my $objs = join(" ", @objs);
-      my $deps = join(" ", @deps);
+      my $deps = join(" ", @objs, @defs, @deps);
       my $target = dso($dso);
+      my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
       return <<"EOF";
-$target: $objs $deps
+$target: $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
-		-o $target $objs \\
+		-o $target$shared_def $objs \\
                 $linklibs \$(DSO_EX_LIBS)
 EOF
   }

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -512,9 +512,10 @@ reconfigure reconf:
           my $mkdef = abs2rel(rel2abs(catfile($config{sourcedir},
                                               "util", "mkdef.pl")),
                               rel2abs($config{builddir}));
+          my $mkdef_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
           return <<"EOF";
-$target: $args{generator}->[0] $deps
-	\$(PERL) $mkdef --ordinals $args{generator}->[0] --name $args{generator}->[1] --OS windows > $target
+$target: $args{generator}->[0] $deps $mkdef
+	\$(PERL) $mkdef$mkdef_ver --ordinals $args{generator}->[0] --name $args{generator}->[1] --OS windows > $target
 EOF
       } elsif ($args{src} !~ /\.[sS]$/) {
           my $target = $args{src};
@@ -675,15 +676,12 @@ EOF
      my $objs = join("\n", @objs);
      my $linklibs = join("", map { "$_\n" } @deps);
      my $deps = join(" ", @objs, @deps);
+     my $shared_def = join("", map { " /def:$_" } @defs);
      return <<"EOF";
 $dso$dsoext: $deps
 	IF EXIST $dso$dsoext.manifest DEL /F /Q $dso$dsoext.manifest
-	\$(LD) \$(LDFLAGS) \$(DSO_LDFLAGS) \$(LDOUTFLAG)$dso$dsoext /def:<< @<<
-LIBRARY         $dso_n
-EXPORTS
-    bind_engine		@1
-    v_check		@2
-<<
+	\$(LD) \$(LDFLAGS) \$(DSO_LDFLAGS) \\
+		\$(LDOUTFLAG)$dso$dsoext$shared_def @<< || (DEL /Q \$(\@B).* $dso.* && EXIT 1)
 $objs
 $linklibs \$(DSO_EX_LIBS)
 <<

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -671,7 +671,12 @@ EOF
      my %args = @_;
      my $dso = $args{lib};
      my $dso_n = basename($dso);
-     my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x } @{$args{objs}};
+     my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x }
+                grep { $_ =~ m/\.(?:o|res)$/ }
+                @{$args{objs}};
+     my @defs = map { (my $x = $_) =~ s|\.ld$|$defext|; $x }
+                grep { $_ =~ /\.ld$/ }
+                @{$args{objs}};
      my @deps = compute_lib_depends(@{$args{deps}});
      my $objs = join("\n", @objs);
      my $linklibs = join("", map { "$_\n" } @deps);

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -512,10 +512,12 @@ reconfigure reconf:
           my $mkdef = abs2rel(rel2abs(catfile($config{sourcedir},
                                               "util", "mkdef.pl")),
                               rel2abs($config{builddir}));
-          my $mkdef_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_name =
+              $args{generator}->[1] || basename($args{product}, $dsoext);
           return <<"EOF";
 $target: $args{generator}->[0] $deps $mkdef
-	\$(PERL) $mkdef$mkdef_ver --ordinals $args{generator}->[0] --name $args{generator}->[1] --OS windows > $target
+	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name --OS windows > $target
 EOF
       } elsif ($args{src} !~ /\.[sS]$/) {
           my $target = $args{src};

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -680,7 +680,7 @@ EOF
      my @deps = compute_lib_depends(@{$args{deps}});
      my $objs = join("\n", @objs);
      my $linklibs = join("", map { "$_\n" } @deps);
-     my $deps = join(" ", @objs, @deps);
+     my $deps = join(" ", @objs, @defs, @deps);
      my $shared_def = join("", map { " /def:$_" } @defs);
      return <<"EOF";
 $dso$dsoext: $deps

--- a/Configure
+++ b/Configure
@@ -2079,7 +2079,7 @@ EOF
                 } elsif ($s =~ /\.ld$/) {
                     # We also recognise linker scripts (or corresponding)
                     # We know they are generated files
-                    my $ld = cleanfile($buildd, $s, $blddir);
+                    my $ld = cleanfile($buildd, $_, $blddir);
                     $unified_info{shared_sources}->{$ddest}->{$ld} = 1;
                 } else {
                     die "unrecognised source file type for shared library: $s\n";

--- a/engines/build.info
+++ b/engines/build.info
@@ -15,26 +15,46 @@ IF[{- !$disabled{"engine"} -}]
     SOURCE[padlock]=e_padlock.c {- $target{padlock_asm_src} -}
     DEPEND[padlock]=../libcrypto
     INCLUDE[padlock]=../include
+    IF[{- defined $target{shared_defflag} -}]
+      SHARED_SOURCE[padlock]=padlock.ld
+      GENERATE[padlock.ld]=../util/engines.num
+    ENDIF
     IF[{- !$disabled{capieng} -}]
       ENGINES=capi
       SOURCE[capi]=e_capi.c
       DEPEND[capi]=../libcrypto
       INCLUDE[capi]=../include
+      IF[{- defined $target{shared_defflag} -}]
+        SHARED_SOURCE[capi]=capi.ld
+        GENERATE[capi.ld]=../util/engines.num
+      ENDIF
     ENDIF
     IF[{- !$disabled{afalgeng} -}]
       ENGINES=afalg
       SOURCE[afalg]=e_afalg.c
       DEPEND[afalg]=../libcrypto
       INCLUDE[afalg]= ../include
+      IF[{- defined $target{shared_defflag} -}]
+        SHARED_SOURCE[afalg]=afalg.ld
+        GENERATE[afalg.ld]=../util/engines.num
+      ENDIF
     ENDIF
 
     ENGINES_NO_INST=ossltest dasync
     SOURCE[dasync]=e_dasync.c
     DEPEND[dasync]=../libcrypto
     INCLUDE[dasync]=../include
+    IF[{- defined $target{shared_defflag} -}]
+      SHARED_SOURCE[dasync]=dasync.ld
+      GENERATE[dasync.ld]=../util/engines.num
+    ENDIF
     SOURCE[ossltest]=e_ossltest.c
     DEPEND[ossltest]=../libcrypto
     INCLUDE[ossltest]=../include
+    IF[{- defined $target{shared_defflag} -}]
+      SHARED_SOURCE[ossltest]=ossltest.ld
+      GENERATE[ossltest.ld]=../util/engines.num
+    ENDIF
   ENDIF
 
   GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl \

--- a/util/engines.num
+++ b/util/engines.num
@@ -1,0 +1,2 @@
+bind_engine                            1	*	EXIST::FUNCTION:
+v_check                                2	*	EXIST::FUNCTION:


### PR DESCRIPTION
So far, `util/mkdef.pl` has only been used to create symbol export maps for out shared libraries.  This PR expands the concept to work on DSOs (engines) as well.

This was done in a hard coded manner for Windows and VMS already, but with this PR, the same thing can be done on Unix as well (wasn't so far), and also becomes uniform on all supported platforms.