### PR TITLE
apps: allow empty attribute values with -subj

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1831,6 +1831,12 @@ X509_NAME *parse_name(const char *cp, long chtype, int canmulti)
                       opt_getprog(), typestr);
             continue;
         }
+        if (*valstr == '\0') {
+            BIO_printf(bio_err,
+                       "%s: No value provided for Subject Attribute %s, skipped\n",
+                       opt_getprog(), typestr);
+            continue;
+        }
         if (!X509_NAME_add_entry_by_NID(n, nid, chtype,
                                         valstr, strlen((char *)valstr),
                                         -1, ismulti ? -1 : 0))

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -250,8 +250,10 @@ for all available algorithms.
 =item B<-subj arg>
 
 Supersedes subject name given in the request.
-The arg must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by \ (backslash), no spaces are skipped.
+The arg must be formatted as I</type0=value0/type1=value1/type2=...>.
+Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Empty values are permitted, but the corresponding type will not be included
+in the resulting certificate.
 
 =item B<-utf8>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -221,8 +221,10 @@ see L<openssl(1)/COMMAND SUMMARY>.
 
 Sets subject name for new request or supersedes the subject name
 when processing a request.
-The arg must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by \ (backslash), no spaces are skipped.
+The arg must be formatted as I</type0=value0/type1=value1/type2=...>.
+Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Empty values are permitted, but the corresponding type will not be included
+in the request.
 
 =item B<-multivalue-rdn>
 

--- a/doc/man1/storeutl.pod
+++ b/doc/man1/storeutl.pod
@@ -82,8 +82,11 @@ returned.
 =item B<-subject arg>
 
 Search for an object having the subject name B<arg>.
-The arg must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by \ (backslash), no spaces are skipped.
+The arg must be formatted as I</type0=value0/type1=value1/type2=...>.
+Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Empty values are permitted but are ignored for the search.  That is,
+a search with an empty value will have the same effect as not specifying
+the type at all.
 
 =item B<-issuer arg>
 


### PR DESCRIPTION
Historically (i.e., OpenSSL 1.0.x), the openssl applications would
allow for empty subject attributes to be passed via the -subj argument,
e.g., `opensl req -subj '/CN=joe/O=/OU=local' ...`.  Commit
db4c08f0194d58c6192f0d8311bf3f20e251cf4f applied a badly needed rewrite
to the parse_name() helper function that parses these strings, but
in the process dropped a check that would skip attributes with no
associated value.  As a result, such strings are now treated as
hard errors and the operation fails.

Restore the check to skip empty attribute values and restore
the historical behavior.

