### PR TITLE
test/secmemtest: test secure memory only if it is implemented

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -20,12 +20,8 @@
 
 #include <string.h>
 
-/* e_os.h includes unistd.h, which defines _POSIX_VERSION */
-#if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
-    && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L) \
-         || defined(__sun) || defined(__hpux) || defined(__sgi) \
-         || defined(__osf__) )
-# define IMPLEMENTED
+/* e_os.h defines OPENSSL_SECURE_MEMORY if secure memory can be implemented */
+#ifdef OPENSSL_SECURE_MEMORY
 # include <stdlib.h>
 # include <assert.h>
 # include <unistd.h>
@@ -51,7 +47,7 @@
 # define MAP_ANON MAP_ANONYMOUS
 #endif
 
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
 static size_t secure_mem_used;
 
 static int secure_mem_initialized;
@@ -71,7 +67,7 @@ static int sh_allocated(const char *ptr);
 
 int CRYPTO_secure_malloc_init(size_t size, int minsize)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     int ret = 0;
 
     if (!secure_mem_initialized) {
@@ -89,12 +85,12 @@ int CRYPTO_secure_malloc_init(size_t size, int minsize)
     return ret;
 #else
     return 0;
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 int CRYPTO_secure_malloc_done(void)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     if (secure_mem_used == 0) {
         sh_done();
         secure_mem_initialized = 0;
@@ -102,22 +98,22 @@ int CRYPTO_secure_malloc_done(void)
         sec_malloc_lock = NULL;
         return 1;
     }
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
     return 0;
 }
 
 int CRYPTO_secure_malloc_initialized(void)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     return secure_mem_initialized;
 #else
     return 0;
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 void *CRYPTO_secure_malloc(size_t num, const char *file, int line)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     void *ret;
     size_t actual_size;
 
@@ -132,12 +128,12 @@ void *CRYPTO_secure_malloc(size_t num, const char *file, int line)
     return ret;
 #else
     return CRYPTO_malloc(num, file, line);
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     if (secure_mem_initialized)
         /* CRYPTO_secure_malloc() zeroes allocations when it is implemented */
         return CRYPTO_secure_malloc(num, file, line);
@@ -147,7 +143,7 @@ void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
 
 void CRYPTO_secure_free(void *ptr, const char *file, int line)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     size_t actual_size;
 
     if (ptr == NULL)
@@ -164,13 +160,13 @@ void CRYPTO_secure_free(void *ptr, const char *file, int line)
     CRYPTO_THREAD_unlock(sec_malloc_lock);
 #else
     CRYPTO_free(ptr, file, line);
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 void CRYPTO_secure_clear_free(void *ptr, size_t num,
                               const char *file, int line)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     size_t actual_size;
 
     if (ptr == NULL)
@@ -191,12 +187,12 @@ void CRYPTO_secure_clear_free(void *ptr, size_t num,
         return;
     OPENSSL_cleanse(ptr, num);
     CRYPTO_free(ptr, file, line);
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 int CRYPTO_secure_allocated(const void *ptr)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     int ret;
 
     if (!secure_mem_initialized)
@@ -207,21 +203,21 @@ int CRYPTO_secure_allocated(const void *ptr)
     return ret;
 #else
     return 0;
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 size_t CRYPTO_secure_used(void)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     return secure_mem_used;
 #else
     return 0;
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */
 }
 
 size_t CRYPTO_secure_actual_size(void *ptr)
 {
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
     size_t actual_size;
 
     CRYPTO_THREAD_write_lock(sec_malloc_lock);
@@ -239,7 +235,7 @@ size_t CRYPTO_secure_actual_size(void *ptr)
 /*
  * SECURE HEAP IMPLEMENTATION
  */
-#ifdef IMPLEMENTED
+#ifdef OPENSSL_SECURE_MEMORY
 
 
 /*
@@ -647,4 +643,4 @@ static size_t sh_actual_size(char *ptr)
     OPENSSL_assert(sh_testbit(ptr, list, sh.bittable));
     return sh.arena_size / (ONE << list);
 }
-#endif /* IMPLEMENTED */
+#endif /* OPENSSL_SECURE_MEMORY */

--- a/e_os.h
+++ b/e_os.h
@@ -317,8 +317,15 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-# define CRYPTO_memcmp memcmp
-#endif
+# ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#  define CRYPTO_memcmp memcmp
+# endif
 
+/* unistd.h defines _POSIX_VERSION */
+# if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
+     && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
+          || defined(__sun) || defined(__hpux) || defined(__sgi)      \
+          || defined(__osf__) )
+#  define OPENSSL_SECURE_MEMORY  /* secure memory is implemented */
+# endif
 #endif

--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -10,12 +10,15 @@
 #include <openssl/crypto.h>
 
 #include "testutil.h"
+#include "../e_os.h"
 
 static int test_sec_mem(void)
 {
-#if defined(OPENSSL_SYS_LINUX) || defined(OPENSSL_SYS_UNIX)
+#ifdef OPENSSL_SECURE_MEMORY
     int testresult = 0;
     char *p = NULL, *q = NULL, *r = NULL, *s = NULL;
+
+    TEST_info("Secure memory is implemented.");
 
     s = OPENSSL_secure_malloc(20);
     /* s = non-secure 20 */
@@ -124,6 +127,7 @@ static int test_sec_mem(void)
     OPENSSL_secure_free(s);
     return testresult;
 #else
+    TEST_info("Secure memory is *not* implemented.");
     /* Should fail. */
     return TEST_false(CRYPTO_secure_malloc_init(4096, 32));
 #endif
@@ -131,7 +135,7 @@ static int test_sec_mem(void)
 
 static int test_sec_mem_clear(void)
 {
-#if defined(OPENSSL_SYS_LINUX) || defined(OPENSSL_SYS_UNIX)
+#ifdef OPENSSL_SECURE_MEMORY
     const int size = 64;
     unsigned char *p = NULL;
     int i, res = 0;
@@ -162,7 +166,6 @@ static int test_sec_mem_clear(void)
 
     res = 1;
     p = NULL;
-
 err:
     OPENSSL_secure_free(p);
     CRYPTO_secure_malloc_done();


### PR DESCRIPTION
Fixes #7322

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
