### PR TITLE
Fix compil warnings in example code

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -310,16 +310,17 @@ This example digests the data "Test Message\n" and "Hello World\n", using the
 digest name passed on the command line.
 
  #include <stdio.h>
+ #include <string.h>
  #include <openssl/evp.h>
 
- main(int argc, char *argv[])
+ int main(int argc, char *argv[])
  {
      EVP_MD_CTX *mdctx;
      const EVP_MD *md;
      char mess1[] = "Test Message\n";
      char mess2[] = "Hello World\n";
      unsigned char md_value[EVP_MAX_MD_SIZE];
-     int md_len, i;
+     unsigned int md_len, i;
 
      if (argv[1] == NULL) {
          printf("Usage: mdtest digestname\n");


### PR DESCRIPTION
The example code in EVP_DigestInit.pod generates warnings if users try
to compile it.

This PR fixes the nits in the code.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
