### PR TITLE
Fix use after free

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -864,6 +864,7 @@ static void killall(int ret, pid_t *kidpids)
         if (kidpids[i] != 0)
             (void)kill(kidpids[i], SIGTERM);
     sleep(1);
+    OPENSSL_free(kidpids);
     exit(ret);
 }
 
@@ -977,7 +978,6 @@ static void spawn_loop(void)
     }
 
     /* The loop above can only break on termsig */
-    OPENSSL_free(kidpids);
     syslog(LOG_INFO, "terminating on signal: %d", termsig);
     killall(0, kidpids);
 }


### PR DESCRIPTION
Move the free of the mem immediately before the exit. Technically its not
really required at all because of the exit, but its straight forward to
do and stops automated complaints.

The use-after-free was identified by Coverity.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
