### PR TITLE
apps: allow empty attribute values with -subj (1.1.0

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1770,6 +1770,12 @@ X509_NAME *parse_name(const char *cp, long chtype, int canmulti)
                       opt_getprog(), typestr);
             continue;
         }
+        if (*valstr == '\0') {
+            BIO_printf(bio_err,
+                       "%s: No value provided for Subject Attribute %s, skipped\n",
+                       opt_getprog(), typestr);
+            continue;
+        }
         if (!X509_NAME_add_entry_by_NID(n, nid, chtype,
                                         valstr, strlen((char *)valstr),
                                         -1, ismulti ? -1 : 0))

--- a/doc/apps/ca.pod
+++ b/doc/apps/ca.pod
@@ -243,8 +243,10 @@ for all available algorithms.
 =item B<-subj arg>
 
 supersedes subject name given in the request.
-The arg must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by \ (backslash), no spaces are skipped.
+The arg must be formatted as I</type0=value0/type1=value1/type2=...>.
+Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Empty values are permitted, but the corresponding type will not be included
+in the resulting certificate.
 
 =item B<-utf8>
 

--- a/doc/apps/req.pod
+++ b/doc/apps/req.pod
@@ -213,8 +213,10 @@ see L<openssl(1)/COMMAND SUMMARY>.
 
 sets subject name for new request or supersedes the subject name
 when processing a request.
-The arg must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by \ (backslash), no spaces are skipped.
+The arg must be formatted as I</type0=value0/type1=value1/type2=...>.
+Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Empty values are permitted, but the corresponding type will not be included
+in the request.
 
 =item B<-multivalue-rdn>
 


### PR DESCRIPTION
This is the 1.1.0 version of #7349 .
@mattcaswell did the original review.