### PR TITLE
Update gcc-5 to gcc-8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,11 @@ matrix:
           addons:
               apt:
                   packages:
-                      - gcc-5
-                      - g++-5
+                      - gcc-8
+                      - g++-8
                   sources:
                       - ubuntu-toolchain-r-test
-          compiler: gcc-5
+          compiler: gcc-8
           env: CONFIG_OPTS="--strict-warnings" COMMENT="Move to the BORINGTEST build when interoperable"
         - os: linux
           compiler: clang
@@ -67,24 +67,24 @@ matrix:
           addons:
               apt:
                   packages:
-                      - gcc-5
-                      - g++-5
+                      - gcc-8
+                      - g++-8
                       - golang-1.6
                   sources:
                       - ubuntu-toolchain-r-test
-          compiler: gcc-5
-          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers no-shared -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" COVERALLS="yes" BORINGSSL_TESTS="yes" CXX="g++-5"
+          compiler: gcc-8
+          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug --coverage no-asm enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers no-shared -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" COVERALLS="yes" BORINGSSL_TESTS="yes" CXX="g++-8"
         - os: linux
           addons:
               apt:
                   packages:
-                      - gcc-5
-                      - g++-5
+                      - gcc-8
+                      - g++-8
                       - golang-1.6
                   sources:
                       - ubuntu-toolchain-r-test
-          compiler: gcc-5
-          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-external-tests" BORINGSSL_TESTS="yes" CXX="g++-5" TESTS=95
+          compiler: gcc-8
+          env:  EXTENDED_TEST="yes" CONFIG_OPTS="--debug enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-external-tests" BORINGSSL_TESTS="yes" CXX="g++-8" TESTS=95
         - os: linux
           compiler: clang
           env: EXTENDED_TEST="yes" CONFIG_OPTS="enable-msan -D__NO_STRING_INLINES -Wno-unused-command-line-argument"
@@ -98,11 +98,11 @@ matrix:
           addons:
               apt:
                   packages:
-                      - gcc-5
-                      - g++-5
+                      - gcc-8
+                      - g++-8
                   sources:
                       - ubuntu-toolchain-r-test
-          compiler: gcc-5
+          compiler: gcc-8
           env: UBUNTU_GCC_HACK="yes" EXTENDED_TEST="yes" CONFIG_OPTS="--debug no-asm enable-ubsan enable-rc5 enable-md2 -DPEDANTIC" OPENSSL_TEST_RAND_ORDER=0
         - os: linux
           addons:

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -342,7 +342,7 @@ int engine_main(int argc, char **argv)
             break;
         case OPT_TT:
             test_avail_noise++;
-            /* fall thru */
+            /* FALLTHROUGH */
         case OPT_T:
             test_avail++;
             break;

--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -130,7 +130,7 @@ int ASN1_item_ex_i2d(ASN1_VALUE **pval, unsigned char **out,
         /* Use indefinite length constructed if requested */
         if (aclass & ASN1_TFLG_NDEF)
             ndef = 2;
-        /* fall through */
+        /* FALLTHROUGH */
 
     case ASN1_ITYPE_SEQUENCE:
         i = asn1_enc_restore(&seqcontlen, out, pval, it);


### PR DESCRIPTION
I want to propose to change gcc-5 to latest version gcc-8.

There is an issue on gcc-8.
Maybe `implicit-fallthrough` warning became more strict.
We have to fix those or have to set `-Wimplicit-fallthrough=2` explicitly.

Could you give me advice how to fix?

## References

https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
