### PR TITLE
DRBG: fix reseeding via RAND_add()/RAND_seed() with large input

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,17 @@
      list of built in objects, i.e. OIDs with names.
      [Richard Levitte]
 
+ Changes between 1.1.1 and 1.1.1a [xx XXX xxxx]
+
+  *) Fixed the issue that RAND_add()/RAND_seed() silently discards random input
+     if its length exceeds 4096 bytes. The limit has been raised to a buffer size
+     of two gigabyte and the error handling was improved.
+
+     This issue was reported to OpenSSL on 2nd October 2018 by Dr. Falko Strenzke.
+     Is has been categorized as a normal bug, not a security issue, because the
+     DRBG reseeds automatically and is fully functional even without additional
+     randomness provided by the application.
+
  Changes between 1.1.0i and 1.1.1 [11 Sep 2018]
 
   *) Add a new ClientHello callback. Provides a callback interface that gives
@@ -13121,4 +13132,3 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
   *) A minor bug in ssl/s3_clnt.c where there would always be 4 0
      bytes sent in the client random.
      [Edward Bishop <ebishop@spyglass.com>]
-

--- a/CHANGES
+++ b/CHANGES
@@ -29,12 +29,12 @@
 
   *) Fixed the issue that RAND_add()/RAND_seed() silently discards random input
      if its length exceeds 4096 bytes. The limit has been raised to a buffer size
-     of two gigabyte and the error handling was improved.
+     of two gigabytes and the error handling improved.
 
-     This issue was reported to OpenSSL on 2nd October 2018 by Dr. Falko Strenzke.
-     Is has been categorized as a normal bug, not a security issue, because the
-     DRBG reseeds automatically and is fully functional even without additional
-     randomness provided by the application.
+     This issue was reported to OpenSSL by Dr. Falko Strenzke. It has been
+     categorized as a normal bug, not a security issue, because the DRBG reseeds
+     automatically and is fully functional even without additional randomness
+     provided by the application.
 
  Changes between 1.1.0i and 1.1.1 [11 Sep 2018]
 

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1016,6 +1016,7 @@ RAND_F_RAND_POOL_ACQUIRE_ENTROPY:122:rand_pool_acquire_entropy
 RAND_F_RAND_POOL_ADD:103:rand_pool_add
 RAND_F_RAND_POOL_ADD_BEGIN:113:rand_pool_add_begin
 RAND_F_RAND_POOL_ADD_END:114:rand_pool_add_end
+RAND_F_RAND_POOL_ATTACH:124:rand_pool_attach
 RAND_F_RAND_POOL_BYTES_NEEDED:115:rand_pool_bytes_needed
 RAND_F_RAND_POOL_NEW:116:rand_pool_new
 RAND_F_RAND_WRITE_FILE:112:RAND_write_file
@@ -2455,6 +2456,7 @@ RAND_R_ENTROPY_OUT_OF_RANGE:124:entropy out of range
 RAND_R_ERROR_ENTROPY_POOL_WAS_IGNORED:127:error entropy pool was ignored
 RAND_R_ERROR_INITIALISING_DRBG:107:error initialising drbg
 RAND_R_ERROR_INSTANTIATING_DRBG:108:error instantiating drbg
+RAND_R_RANDOM_DATA_WAS_IGNORED:137:random data was ignored
 RAND_R_ERROR_RETRIEVING_ADDITIONAL_INPUT:109:error retrieving additional input
 RAND_R_ERROR_RETRIEVING_ENTROPY:110:error retrieving entropy
 RAND_R_ERROR_RETRIEVING_NONCE:111:error retrieving nonce

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2456,7 +2456,6 @@ RAND_R_ENTROPY_OUT_OF_RANGE:124:entropy out of range
 RAND_R_ERROR_ENTROPY_POOL_WAS_IGNORED:127:error entropy pool was ignored
 RAND_R_ERROR_INITIALISING_DRBG:107:error initialising drbg
 RAND_R_ERROR_INSTANTIATING_DRBG:108:error instantiating drbg
-RAND_R_RANDOM_DATA_WAS_IGNORED:137:random data was ignored
 RAND_R_ERROR_RETRIEVING_ADDITIONAL_INPUT:109:error retrieving additional input
 RAND_R_ERROR_RETRIEVING_ENTROPY:110:error retrieving entropy
 RAND_R_ERROR_RETRIEVING_NONCE:111:error retrieving nonce

--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -53,6 +53,8 @@ void rand_drbg_cleanup_additional_data(unsigned char *out, size_t outlen);
  * RAND_POOL functions
  */
 RAND_POOL *rand_pool_new(int entropy_requested, size_t min_len, size_t max_len);
+RAND_POOL *rand_pool_attach(const unsigned char *buffer, size_t len,
+                            size_t entropy);
 void rand_pool_free(RAND_POOL *pool);
 
 const unsigned char *rand_pool_buffer(RAND_POOL *pool);

--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -416,9 +416,9 @@ int drbg_ctr_init(RAND_DRBG *drbg)
             return 0;
 
         drbg->min_entropylen = ctr->keylen;
-        drbg->max_entropylen = DRBG_MINMAX_FACTOR * drbg->min_entropylen;
+        drbg->max_entropylen = DRBG_MAX_LENGTH;
         drbg->min_noncelen = drbg->min_entropylen / 2;
-        drbg->max_noncelen = DRBG_MINMAX_FACTOR * drbg->min_noncelen;
+        drbg->max_noncelen = DRBG_MAX_LENGTH;
         drbg->max_perslen = DRBG_MAX_LENGTH;
         drbg->max_adinlen = DRBG_MAX_LENGTH;
     } else {

--- a/crypto/rand/drbg_hash.c
+++ b/crypto/rand/drbg_hash.c
@@ -332,10 +332,10 @@ int drbg_hash_init(RAND_DRBG *drbg)
         drbg->seedlen = HASH_PRNG_SMALL_SEEDLEN;
 
     drbg->min_entropylen = drbg->strength / 8;
-    drbg->max_entropylen = DRBG_MINMAX_FACTOR * drbg->min_entropylen;
+    drbg->max_entropylen = DRBG_MAX_LENGTH;
 
     drbg->min_noncelen = drbg->min_entropylen / 2;
-    drbg->max_noncelen = DRBG_MINMAX_FACTOR * drbg->min_noncelen;
+    drbg->max_noncelen = DRBG_MAX_LENGTH;
 
     drbg->max_perslen = DRBG_MAX_LENGTH;
     drbg->max_adinlen = DRBG_MAX_LENGTH;

--- a/crypto/rand/drbg_hmac.c
+++ b/crypto/rand/drbg_hmac.c
@@ -223,10 +223,10 @@ int drbg_hmac_init(RAND_DRBG *drbg)
     drbg->seedlen = hmac->blocklen;
 
     drbg->min_entropylen = drbg->strength / 8;
-    drbg->max_entropylen = DRBG_MINMAX_FACTOR * drbg->min_entropylen;
+    drbg->max_entropylen = DRBG_MAX_LENGTH;
 
     drbg->min_noncelen = drbg->min_entropylen / 2;
-    drbg->max_noncelen = DRBG_MINMAX_FACTOR * drbg->min_noncelen;
+    drbg->max_noncelen = DRBG_MAX_LENGTH;
 
     drbg->max_perslen = DRBG_MAX_LENGTH;
     drbg->max_adinlen = DRBG_MAX_LENGTH;

--- a/crypto/rand/rand_err.c
+++ b/crypto/rand/rand_err.c
@@ -44,6 +44,7 @@ static const ERR_STRING_DATA RAND_str_functs[] = {
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_ADD_BEGIN, 0),
      "rand_pool_add_begin"},
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_ADD_END, 0), "rand_pool_add_end"},
+    {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_ATTACH, 0), "rand_pool_attach"},
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_BYTES_NEEDED, 0),
      "rand_pool_bytes_needed"},
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_NEW, 0), "rand_pool_new"},

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -48,7 +48,7 @@
  *
  * The max_len value for the buffer provided to the rand_drbg_get_entropy()
  * callback is currently 2^31 bytes (2 gigabytes), if a derivation function
- * is used. Since this is much to large to be allocated, the rand_pool_new()
+ * is used. Since this is much too large to be allocated, the rand_pool_new()
  * function chooses more modest values as default pool length, bounded
  * by RAND_POOL_MIN_LENGTH and RAND_POOL_MAX_LENGTH
  *

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -32,18 +32,42 @@
 
 
 
-/* Max size of additional input and personalization string. */
-# define DRBG_MAX_LENGTH                4096
+/*
+ * Maximum input size for the DRBG (entropy, nonce, personalization string)
+ *
+ * NIST SP800 90Ar1 allows a maximum of (1 << 35) bits i.e., (1 << 32) bytes.
+ *
+ * We lower it to 'only' (1 << 31) bytes, which is equivalent to 2 gigabytes.
+ */
+# define DRBG_MAX_LENGTH                         INT32_MAX
+
+
 
 /*
- * The quotient between max_{entropy,nonce}len and min_{entropy,nonce}len
+ * Maximum allocation size for RANDOM_POOL buffers
  *
- * The current factor is large enough that the RAND_POOL can store a
- * random input which has a lousy entropy rate of 0.0625 bits per byte.
- * This input will be sent through the derivation function which 'compresses'
- * the low quality input into a high quality output.
+ * The max_len value for the buffer provided to the rand_drbg_get_entropy()
+ * callback is currently 2^31 bytes (2 gigabytes), if a derivation function
+ * is used. Since this is much to large to be allocated, the rand_pool_new()
+ * function chooses more modest values as default pool length, bounded
+ * by RAND_POOL_MIN_LENGTH and RAND_POOL_MAX_LENGTH
+ *
+ * The choice of the RAND_POOL_FACTOR is large enough such that the
+ * RAND_POOL can store a random input which has a lousy entropy rate of
+ * 8/256 (= 0.03125) bits per byte. This input will be sent through the
+ * derivation function which 'compresses' the low quality input into a
+ * high quality output.
+ *
+ * The factor 1.5 below is the pessimistic estimate for the extra amount
+ * of entropy required when no get_nonce() callback is defined.
  */
-# define DRBG_MINMAX_FACTOR              128
+# define RAND_POOL_FACTOR        256
+# define RAND_POOL_MAX_LENGTH    (RAND_POOL_FACTOR * \
+                                  3 * (RAND_DRBG_STRENGTH / 16))
+/*
+ *                             = (RAND_POOL_FACTOR * \
+ *                                1.5 * (RAND_DRBG_STRENGTH / 8))
+ */
 
 
 /* DRBG status values */
@@ -142,10 +166,12 @@ struct rand_pool_st {
     unsigned char *buffer;  /* points to the beginning of the random pool */
     size_t len; /* current number of random bytes contained in the pool */
 
+    int attached;  /* true pool was attached to existing buffer */
+
     size_t min_len; /* minimum number of random bytes requested */
     size_t max_len; /* maximum number of random bytes (allocated buffer size) */
     size_t entropy; /* current entropy count in bits */
-    size_t requested_entropy; /* requested entropy count in bits */
+    size_t entropy_requested; /* requested entropy count in bits */
 };
 
 /*
@@ -167,7 +193,7 @@ struct rand_drbg_st {
     unsigned short flags; /* various external flags */
 
     /*
-     * The random pool is used by RAND_add()/drbg_add() to attach random
+     * The random_data is used by RAND_add()/drbg_add() to attach random
      * data to the global drbg, such that the rand_drbg_get_entropy() callback
      * can pull it during instantiation and reseeding. This is necessary to
      * reconcile the different philosophies of the RAND and the RAND_DRBG

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -37,7 +37,7 @@
  *
  * NIST SP800 90Ar1 allows a maximum of (1 << 35) bits i.e., (1 << 32) bytes.
  *
- * We lower it to 'only' (1 << 31) bytes, which is equivalent to 2 gigabytes.
+ * We lower it to 'only' INT32_MAX bytes, which is equivalent to 2 gigabytes.
  */
 # define DRBG_MAX_LENGTH                         INT32_MAX
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -493,6 +493,12 @@ void rand_pool_free(RAND_POOL *pool)
     if (pool == NULL)
         return;
 
+    /*
+     * Although it would be advisable from a cryptographical viewpoint,
+     * we are not allowed to clear attached buffers, since they are passed
+     * to rand_pool_attach() as `const unsigned char*`.
+     * (see corresponding comment in rand_pool_attach()).
+     */
     if (!pool->attached)
         OPENSSL_secure_clear_free(pool->buffer, pool->max_len);
     OPENSSL_free(pool);

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -146,17 +146,11 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
         return 0;
     }
 
-    pool = rand_pool_new(entropy, min_len, max_len);
-    if (pool == NULL)
-        return 0;
-
-    if (drbg->pool) {
-        rand_pool_add(pool,
-                      rand_pool_buffer(drbg->pool),
-                      rand_pool_length(drbg->pool),
-                      rand_pool_entropy(drbg->pool));
-        rand_pool_free(drbg->pool);
-        drbg->pool = NULL;
+    if (drbg->pool != NULL) {
+        pool = drbg->pool;
+        pool->entropy_requested = entropy;
+    } else {
+        pool = rand_pool_new(entropy, min_len, max_len);
     }
 
     if (drbg->parent) {
@@ -217,7 +211,10 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
 void rand_drbg_cleanup_entropy(RAND_DRBG *drbg,
                                unsigned char *out, size_t outlen)
 {
-    OPENSSL_secure_clear_free(out, outlen);
+    if (drbg->pool == NULL)
+        OPENSSL_secure_clear_free(out, outlen);
+    else
+        drbg->pool = NULL;
 }
 
 
@@ -405,7 +402,7 @@ int RAND_poll(void)
         /* fill random pool and seed the current legacy RNG */
         pool = rand_pool_new(RAND_DRBG_STRENGTH,
                              RAND_DRBG_STRENGTH / 8,
-                             DRBG_MINMAX_FACTOR * (RAND_DRBG_STRENGTH / 8));
+                             RAND_POOL_MAX_LENGTH);
         if (pool == NULL)
             return 0;
 
@@ -430,17 +427,18 @@ err:
  * Allocate memory and initialize a new random pool
  */
 
-RAND_POOL *rand_pool_new(int entropy, size_t min_len, size_t max_len)
+RAND_POOL *rand_pool_new(int entropy_requested, size_t min_len, size_t max_len)
 {
     RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
 
     if (pool == NULL) {
         RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
-        goto err;
+        return NULL;
     }
 
     pool->min_len = min_len;
-    pool->max_len = max_len;
+    pool->max_len = (max_len > RAND_POOL_MAX_LENGTH) ?
+        RAND_POOL_MAX_LENGTH : max_len;
 
     pool->buffer = OPENSSL_secure_zalloc(pool->max_len);
     if (pool->buffer == NULL) {
@@ -448,13 +446,43 @@ RAND_POOL *rand_pool_new(int entropy, size_t min_len, size_t max_len)
         goto err;
     }
 
-    pool->requested_entropy = entropy;
+    pool->entropy_requested = entropy_requested;
 
     return pool;
 
 err:
     OPENSSL_free(pool);
     return NULL;
+}
+
+/*
+ * Attach new random pool to the given buffer
+ */
+
+RAND_POOL *rand_pool_attach(const unsigned char *buffer, size_t len,
+                            size_t entropy)
+{
+    RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
+
+    if (pool == NULL) {
+        RANDerr(RAND_F_RAND_POOL_ATTACH, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+
+    /*
+     * The const needs to be cast away, but attached buffers will not be
+     * modified (in contrary to allocated buffers which are zeroed and
+     * freed in the end).
+     */
+    pool->buffer = (unsigned char *) buffer;
+    pool->len = len;
+
+    pool->attached = 1;
+
+    pool->min_len = pool->max_len = pool->len;
+    pool->entropy = entropy;
+
+    return pool;
 }
 
 /*
@@ -465,7 +493,8 @@ void rand_pool_free(RAND_POOL *pool)
     if (pool == NULL)
         return;
 
-    OPENSSL_secure_clear_free(pool->buffer, pool->max_len);
+    if (!pool->attached)
+        OPENSSL_secure_clear_free(pool->buffer, pool->max_len);
     OPENSSL_free(pool);
 }
 
@@ -524,7 +553,7 @@ unsigned char *rand_pool_detach(RAND_POOL *pool)
  */
 size_t rand_pool_entropy_available(RAND_POOL *pool)
 {
-    if (pool->entropy < pool->requested_entropy)
+    if (pool->entropy < pool->entropy_requested)
         return 0;
 
     if (pool->len < pool->min_len)
@@ -540,8 +569,8 @@ size_t rand_pool_entropy_available(RAND_POOL *pool)
 
 size_t rand_pool_entropy_needed(RAND_POOL *pool)
 {
-    if (pool->entropy < pool->requested_entropy)
-        return pool->requested_entropy - pool->entropy;
+    if (pool->entropy < pool->entropy_requested)
+        return pool->entropy_requested - pool->entropy;
 
     return 0;
 }

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -457,8 +457,10 @@ err:
 
 /*
  * Attach new random pool to the given buffer
+ *
+ * This function is intended to be used only for feeding random data
+ * provided by RAND_add() and RAND_seed() into the <master> DRBG.
  */
-
 RAND_POOL *rand_pool_attach(const unsigned char *buffer, size_t len,
                             size_t entropy)
 {

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -264,7 +264,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
      * Note: 'buflen' equals the size of the buffer which is used by the
      * get_entropy() callback of the RAND_DRBG. It is roughly bounded by
      *
-     *   2 * DRBG_MINMAX_FACTOR * (RAND_DRBG_STRENGTH / 8) = 2^13
+     *   2 * RAND_POOL_FACTOR * (RAND_DRBG_STRENGTH / 8) = 2^14
      *
      * which is way below the OSSL_SSIZE_MAX limit. Therefore sign conversion
      * between size_t and ssize_t is safe even without a range check.

--- a/include/openssl/randerr.h
+++ b/include/openssl/randerr.h
@@ -59,7 +59,6 @@ int ERR_load_RAND_strings(void);
 # define RAND_R_ERROR_ENTROPY_POOL_WAS_IGNORED            127
 # define RAND_R_ERROR_INITIALISING_DRBG                   107
 # define RAND_R_ERROR_INSTANTIATING_DRBG                  108
-# define RAND_R_RANDOM_DATA_WAS_IGNORED             137
 # define RAND_R_ERROR_RETRIEVING_ADDITIONAL_INPUT         109
 # define RAND_R_ERROR_RETRIEVING_ENTROPY                  110
 # define RAND_R_ERROR_RETRIEVING_NONCE                    111

--- a/include/openssl/randerr.h
+++ b/include/openssl/randerr.h
@@ -40,6 +40,7 @@ int ERR_load_RAND_strings(void);
 # define RAND_F_RAND_POOL_ADD                             103
 # define RAND_F_RAND_POOL_ADD_BEGIN                       113
 # define RAND_F_RAND_POOL_ADD_END                         114
+# define RAND_F_RAND_POOL_ATTACH                          124
 # define RAND_F_RAND_POOL_BYTES_NEEDED                    115
 # define RAND_F_RAND_POOL_NEW                             116
 # define RAND_F_RAND_WRITE_FILE                           112
@@ -58,6 +59,7 @@ int ERR_load_RAND_strings(void);
 # define RAND_R_ERROR_ENTROPY_POOL_WAS_IGNORED            127
 # define RAND_R_ERROR_INITIALISING_DRBG                   107
 # define RAND_R_ERROR_INSTANTIATING_DRBG                  108
+# define RAND_R_RANDOM_DATA_WAS_IGNORED             137
 # define RAND_R_ERROR_RETRIEVING_ADDITIONAL_INPUT         109
 # define RAND_R_ERROR_RETRIEVING_ENTROPY                  110
 # define RAND_R_ERROR_RETRIEVING_NONCE                    111

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -911,7 +911,6 @@ static size_t get_pool_entropy(RAND_DRBG *drbg,
  */
 static void cleanup_pool_entropy(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
 {
-    OPENSSL_secure_clear_free(drbg->pool->buffer, drbg->pool->max_len);
     OPENSSL_free(drbg->pool);
     drbg->pool = NULL;
 }


### PR DESCRIPTION
In pull request #4328 the seeding of the DRBG via RAND_add()/RAND_seed() was implemented by buffering the data in a random pool where it is picked up later by the rand_drbg_get_entropy() callback. This buffer was limited to the size of 4096 bytes.

When a larger input was added via RAND_add() or RAND_seed() to the DRBG, the reseeding failed, but the error returned by the DRBG was ignored by the two calling functions, which both don't return an error code. As a consequence, the data provided by the application was effectively ignored.

This commit fixes the problem by a more efficient implementation which does not copy the data in memory and by raising the buffer the size limit to INT32_MAX (2 gigabytes). This is less than the NIST limit of 2^35 bits but it was chosen intentionally to avoid platform dependent problems like integer sizes and/or signed/unsigned conversion.

Additionally, the DRBG is now less permissive on errors: In addition to pushing a message to the openssl error stack, it enters the error state, which forces a reinstantiation on next call.

Thanks go to Dr. Falko Strenzke for reporting this issue to the openssl-security mailing list. After internal discussion the issue has been categorized as not being security relevant, because the DRBG reseeds automatically and is fully functional even without additional randomness provided by the application.

Fixes #7381
