### PR TITLE
Support Poly1305 via EVP interface

### DIFF
--- a/crypto/evp/c_alld.c
+++ b/crypto/evp/c_alld.c
@@ -57,4 +57,7 @@ void openssl_add_all_digests_int(void)
     EVP_add_digest(EVP_sha3_512());
     EVP_add_digest(EVP_shake128());
     EVP_add_digest(EVP_shake256());
+#ifndef OPENSSL_NO_POLY1305
+    EVP_add_digest(EVP_poly1305());
+#endif
 }

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -2,6 +2,7 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         poly1305_pmeth.c \
         poly1305_ameth.c \
+        m_poly1305.c \
         poly1305.c {- $target{poly1305_asm_src} -}
 
 GENERATE[poly1305-sparcv9.S]=asm/poly1305-sparcv9.pl $(PERLASM_SCHEME)

--- a/crypto/poly1305/m_poly1305.c
+++ b/crypto/poly1305/m_poly1305.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/cryptlib.h"
+
+#ifndef OPENSSL_NO_POLY1305
+# include <openssl/evp.h>
+# include "internal/evp_int.h"
+# include "internal/poly1305.h"
+# include "poly1305_local.h"
+
+static int init(EVP_MD_CTX *ctx)
+{
+    POLY1305 *poly_ctx = EVP_MD_CTX_md_data(ctx);
+
+    Poly1305_Init(poly_ctx, poly_ctx->key);
+    return 1;
+}
+
+static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
+{
+    Poly1305_Update(EVP_MD_CTX_md_data(ctx), data, count);
+    return 1;
+}
+
+static int final(EVP_MD_CTX *ctx, unsigned char *md)
+{
+    Poly1305_Final(EVP_MD_CTX_md_data(ctx), md);
+    return 1;
+}
+
+static int poly1305_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
+{
+    POLY1305 *poly_ctx = EVP_MD_CTX_md_data(ctx);
+
+    switch(cmd) {
+    case EVP_CTRL_SET_POLY1305_KEY:
+        if (p1 != POLY1305_KEY_SIZE)
+            return 0;
+        memcpy(poly_ctx->key, p2, POLY1305_KEY_SIZE);
+        return 1;
+    default:
+        return -1;
+    }
+}
+
+static const EVP_MD poly1305_md = {
+    NID_poly1305,
+    0,
+    POLY1305_DIGEST_SIZE,
+    0,
+    init,
+    update,
+    final,
+    NULL,
+    NULL,
+    POLY1305_BLOCK_SIZE,
+    sizeof(EVP_MD *) + sizeof(POLY1305),
+    poly1305_ctrl
+};
+
+const EVP_MD *EVP_poly1305(void)
+{
+    return &poly1305_md;
+}
+#endif

--- a/crypto/poly1305/poly1305_local.h
+++ b/crypto/poly1305/poly1305_local.h
@@ -24,4 +24,6 @@ struct poly1305_context {
         poly1305_blocks_f blocks;
         poly1305_emit_f emit;
     } func;
+    /* for direct usage of poly1305 */
+    unsigned char key[32];
 };

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -2,9 +2,10 @@
 
 =head1 NAME
 
-EVP_MD_CTX_new, EVP_MD_CTX_reset, EVP_MD_CTX_free, EVP_MD_CTX_copy_ex,
-EVP_MD_CTX_ctrl, EVP_MD_CTX_set_flags, EVP_MD_CTX_clear_flags,
-EVP_MD_CTX_test_flags, EVP_DigestInit_ex, EVP_DigestInit, EVP_DigestUpdate,
+EVP_MD_CTX_new, EVP_MD_CTX_new_ex, EVP_MD_CTX_reset, EVP_MD_CTX_free,
+EVP_MD_CTX_copy_ex, EVP_MD_CTX_ctrl,
+EVP_MD_CTX_set_flags, EVP_MD_CTX_clear_flags, EVP_MD_CTX_test_flags,
+EVP_DigestInit_ex, EVP_DigestInit, EVP_DigestUpdate,
 EVP_DigestFinal_ex, EVP_DigestFinalXOF, EVP_DigestFinal,
 EVP_MD_CTX_copy, EVP_MD_type, EVP_MD_pkey_type, EVP_MD_size,
 EVP_MD_block_size, EVP_MD_CTX_md, EVP_MD_CTX_size,
@@ -19,6 +20,7 @@ EVP_MD_CTX_set_pkey_ctx - EVP digest routines
  #include <openssl/evp.h>
 
  EVP_MD_CTX *EVP_MD_CTX_new(void);
+ EVP_MD_CTX *EVP_MD_CTX_new_ex(const EVP_MD *type, ENGINE *impl);
  int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
  void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
  void EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void* p2);
@@ -67,6 +69,14 @@ and should be used instead of the cipher-specific functions.
 =item EVP_MD_CTX_new()
 
 Allocates and returns a digest context.
+
+=item EVP_MD_CTX_new_ex()
+
+Allocates a digest context and then sets up the context with a digest B<type>
+from ENGINE B<impl>. B<type> will typically be supplied by a function such
+as EVP_sha1().  If B<impl> is NULL then the default implementation of digest
+B<type> is used. Unlike the EVP_DigestInit_ex() function, no further B<type>
+specified initialization function will be called in this function.
 
 =item EVP_MD_CTX_reset()
 
@@ -377,6 +387,8 @@ later, so now EVP_sha1() can be used with RSA and DSA.
 EVP_dss1() was removed in OpenSSL 1.1.0.
 
 EVP_MD_CTX_set_pkey_ctx() was added in 1.1.1.
+
+EVP_MD_CTX_new_ex() was added in 1.2.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_poly1305.pod
+++ b/doc/man3/EVP_poly1305.pod
@@ -1,0 +1,92 @@
+=pod
+
+=head1 NAME
+
+EVP_poly1305
+- Poly1305 for EVP
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ const EVP_MD *EVP_poly1305(void);
+
+=head1 DESCRIPTION
+
+Poly1305 is an one-time authenticator designed by D. J. Bernstein. Poly1305
+takes a 32-byte one-time key and a message and produces a 16-byte tag. This tag
+is used to authenticate the message.
+
+=over 4
+
+=item EVP_poly1305()
+
+The Poly1305 hash function.
+
+=back
+
+
+=head1 RETURN VALUES
+
+This function retursn an B<EVP_MD> structure that contains the implementation
+of the hash function. See L<EVP_MD_meth_new(3)> for details of the B<EVP_MD>
+structure.
+
+=head1 CONFORMING TO
+
+RFC 7539.
+
+=head1 EXAMPLE
+
+This example demonstrates the calling sequence for using Poly1305 hash function
+via EVP interface:
+
+ #include <stdio.h>
+ #include <string.h>
+ #include <openssl/evp.h>
+
+ int main(int argc, char *argv[])
+ {
+     EVP_MD_CTX *mdctx;
+     char raw_meat[] = "Cryptographic Forum Research Group";
+     unsigned char key[32] = "\x85\xd6\xbe\x78\x57\x55\x6d\x33"
+                             "\x7f\x44\x52\xfe\x42\xd5\x06\xa8"
+                             "\x01\x03\x80\x8a\xfb\x0d\xb2\xfd"
+                             "\x4a\xbf\xf6\xaf\x41\x49\xf5\x1b";
+     unsigned char md_value[EVP_MAX_MD_SIZE];
+     unsigned int md_len, i;
+
+     /* configure Poly1305 as the hash function... */
+     mdctx = EVP_MD_CTX_new_ex(EVP_poly1305(), NULL);
+     /* setup poly1305 key */
+     EVP_MD_CTX_ctrl(mdctx, EVP_CTRL_SET_POLY1305_KEY, 32, key);
+     /* init Poly1305... */
+     EVP_DigestInit_ex(mdctx, NULL, NULL);
+     /* calculate the hash... */
+     EVP_DigestUpdate(mdctx, raw_meat, strlen(raw_meat));
+     EVP_DigestFinal_ex(mdctx, md_value, &md_len);
+     EVP_MD_CTX_free(mdctx);
+
+     printf("Digest is: ");
+     for (i = 0; i < md_len; i++)
+         printf("%02x", md_value[i]);
+     printf("\n");
+
+     return 0;
+ }
+
+=head1 SEE ALSO
+
+L<evp(7)>,
+L<EVP_DigestInit(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -348,6 +348,8 @@ int (*EVP_CIPHER_meth_get_ctrl(const EVP_CIPHER *cipher))(EVP_CIPHER_CTX *,
 # define         EVP_CTRL_SET_PIPELINE_INPUT_BUFS        0x23
 /* Set the input buffer lengths to use for a pipelined operation */
 # define         EVP_CTRL_SET_PIPELINE_INPUT_LENS        0x24
+/* Set Poly1305 key for standalone usage of this hash function */
+# define         EVP_CTRL_SET_POLY1305_KEY               0x25
 
 /* Padding modes */
 #define EVP_PADDING_PKCS7       1
@@ -532,9 +534,11 @@ void BIO_set_md(BIO *, const EVP_MD *md);
 
 int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
 EVP_MD_CTX *EVP_MD_CTX_new(void);
+EVP_MD_CTX *EVP_MD_CTX_new_ex(const EVP_MD *type, ENGINE *impl);
 int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
 # define EVP_MD_CTX_create()     EVP_MD_CTX_new()
+# define EVP_MD_CTX_create_ex()  EVP_MD_CTX_new_ex()
 # define EVP_MD_CTX_init(ctx)    EVP_MD_CTX_reset((ctx))
 # define EVP_MD_CTX_destroy(ctx) EVP_MD_CTX_free((ctx))
 __owur int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in);
@@ -726,6 +730,9 @@ const EVP_MD *EVP_whirlpool(void);
 # endif
 # ifndef OPENSSL_NO_SM3
 const EVP_MD *EVP_sm3(void);
+# endif
+# ifndef OPENSSL_NO_POLY1305
+const EVP_MD *EVP_poly1305(void);
 # endif
 const EVP_CIPHER *EVP_enc_null(void); /* does nothing :-) */
 # ifndef OPENSSL_NO_DES

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4577,3 +4577,5 @@ OCSP_resp_get0_respdata                 4530	1_1_0j	EXIST::FUNCTION:OCSP
 EVP_MD_CTX_set_pkey_ctx                 4531	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_set_digest_custom         4532	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_digest_custom         4533	1_1_1	EXIST::FUNCTION:
+EVP_MD_CTX_new_ex                       4534	1_2_0	EXIST::FUNCTION:
+EVP_poly1305                            4535	1_2_0	EXIST::FUNCTION:POLY1305


### PR DESCRIPTION
EVP_poly1305() is added to support its usage with EVP interface.

When I was implementing this feature I encountered ~to~ the same problem we have faced when SM2 was being implemented - there is no way to set up a parameter before the calling to the `EVP_XXXInit` functions, this time it's the `EVP_DigestInit_ex()` and the parameter is the hash key of Poly1305.

The root cause of this is that current EVP_XXXInit series functions combines the 'customized context' and the 'initialization of algorithm' together, which leads to an impossible situation of setting up parameters after the context is created but before it's initialized.

To address this issue, a new API `EVP_MD_CTX_new_ex()` is added in this PR. In the new `EVP_MD_CTX_new_ex()` API, users can specify the digest algorithm function (e.g. `EVP_poly1305()`) to initialize the `MD_CTX` to the specific digest without really initializing the digest algorithm. This
provides an opportunity for the caller to set up other parameters (like the hash key of Poly1305) before initializing a digest.

Thus, a typical usage of evp-poly1305 could be:

```
     /* configure Poly1305 as the hash function... */
     mdctx = EVP_MD_CTX_new_ex(EVP_poly1305(), NULL);
     /* setup poly1305 key */
     EVP_MD_CTX_ctrl(mdctx, EVP_CTRL_SET_POLY1305_KEY, 32, key);
     /* init Poly1305, no need to re-specify the digest type... */
     EVP_DigestInit_ex(mdctx, NULL, NULL);
     /* calculate the hash... */
     EVP_DigestUpdate(mdctx, raw_meat, strlen(raw_meat));
     EVP_DigestFinal_ex(mdctx, md_value, &md_len);
     EVP_MD_CTX_free(mdctx);
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
