### PR TITLE
Add a Configure option - no-atexit

### DIFF
--- a/Configure
+++ b/Configure
@@ -327,6 +327,7 @@ my @disablables = (
     "asan",
     "asm",
     "async",
+    "atexit",
     "autoalginit",
     "autoerrinit",
     "autoload-config",

--- a/INSTALL
+++ b/INSTALL
@@ -266,6 +266,11 @@
   no-async
                    Do not build support for async operations.
 
+  no-atexit
+                   Do not clean up OpenSSL automatically at process exit. This
+                   means applications will have to manually cleanup OpenSSL
+                   using OPENSSL_cleanup().
+
   no-autoalginit
                    Don't automatically load all supported ciphers and digests.
                    Typically OpenSSL will make available all of its supported

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -100,7 +100,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
         return 0;
     if ((init_lock = CRYPTO_THREAD_lock_new()) == NULL)
         goto err;
-#ifndef OPENSSL_SYS_UEFI
+#if !defined(OPENSSL_SYS_UEFI) && !defined(OPENSSL_NO_ATEXIT)
     if (atexit(OPENSSL_cleanup) != 0)
         goto err;
 #endif
@@ -127,7 +127,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: ossl_init_load_crypto_nodelete()\n");
 #endif
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE) \
+    && !defined(OPENSSL_NO_ATEXIT)
 # ifdef DSO_WIN32
     {
         HMODULE handle = NULL;
@@ -695,7 +696,8 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE) \
+    && !defined(OPENSSL_NO_ATEXIT)
     {
         union {
             void *sym;


### PR DESCRIPTION
This turns off the standard auto-deinit processing via "atexit()". Instead
applications must clean up manually using OPENSSL_cleanup().

