### PR TITLE
Configure: imply no-async with no-engine.

### DIFF
--- a/Configure
+++ b/Configure
@@ -483,7 +483,7 @@ my @disable_cascades = (
     # Without position independent code, there can be no shared libraries or DSOs
     "pic"               => [ "shared" ],
     "shared"            => [ "dynamic-engine" ],
-    "engine"            => [ "afalgeng", "devcryptoeng" ],
+    "engine"            => [ "afalgeng", "devcryptoeng", "async" ],
 
     # no-autoalginit is only useful when building non-shared
     "autoalginit"       => [ "shared", "apps" ],


### PR DESCRIPTION
Async interface is used by an external engine, and if no-engine is passed,
there is no point to engage async. The modification was triggered by
Apple rejecting iOS apps, because {get|set|make}_context used by async
code are not approved to redistributable code.
