### PR TITLE
iOS config targets: disable "async" by default

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -6,31 +6,31 @@
 # work...
 #
 my %targets = (
+    "ios-common" => {
+        template         => 1,
+        inherit_from     => [ "darwin-common" ],
+        sys_id           => "iOS",
+        disable          => [ "engine", "async" ],
+    },
     "ios-xcrun" => {
-        inherit_from     => [ "darwin-common", asm("armv4_asm") ],
+        inherit_from     => [ "ios-common", asm("armv4_asm") ],
         # It should be possible to go below iOS 6 and even add -arch armv6,
         # thus targeting iPhone pre-3GS, but it's assumed to be irrelevant
         # at this point.
         CC               => "xcrun -sdk iphoneos cc",
         cflags           => add("-arch armv7 -mios-version-min=6.0.0 -fno-common"),
-        sys_id           => "iOS",
         perlasm_scheme   => "ios32",
-        disable          => [ "engine" ],
     },
     "ios64-xcrun" => {
-        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
+        inherit_from     => [ "ios-common", asm("aarch64_asm") ],
         CC               => "xcrun -sdk iphoneos cc",
         cflags           => add("-arch arm64 -mios-version-min=7.0.0 -fno-common"),
-        sys_id           => "iOS",
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         perlasm_scheme   => "ios64",
-        disable          => [ "engine" ],
     },
     "iossimulator-xcrun" => {
-        inherit_from     => [ "darwin-common" ],
+        inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
-        sys_id           => "iOS",
-        disable          => [ "engine" ],
     },
 # It takes three prior-set environment variables to make it work:
 #
@@ -46,10 +46,8 @@ my %targets = (
 # CROSS_SDK=iPhoneOS.sdk
 #
     "iphoneos-cross" => {
-        inherit_from     => [ "darwin-common" ],
+        inherit_from     => [ "ios-common" ],
         cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
-        sys_id           => "iOS",
-        disable          => [ "engine" ],
     },
     "ios-cross" => {
         inherit_from     => [ "ios-xcrun" ],


### PR DESCRIPTION
This also gave enough reason to collect the stuff that's common for
all iOS config targets into the template "ios-common".

Fixes #7318
