### PR TITLE
Disable async on iOS platforms (#7318)

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -15,7 +15,7 @@ my %targets = (
         cflags           => add("-arch armv7 -mios-version-min=6.0.0 -fno-common"),
         sys_id           => "iOS",
         perlasm_scheme   => "ios32",
-        disable          => [ "engine" ],
+        disable          => [ "engine", "async" ],
     },
     "ios64-xcrun" => {
         inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
@@ -24,13 +24,13 @@ my %targets = (
         sys_id           => "iOS",
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         perlasm_scheme   => "ios64",
-        disable          => [ "engine" ],
+        disable          => [ "engine", "async" ],
     },
     "iossimulator-xcrun" => {
         inherit_from     => [ "darwin-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
         sys_id           => "iOS",
-        disable          => [ "engine" ],
+        disable          => [ "engine", "async" ],
     },
 # It takes three prior-set environment variables to make it work:
 #
@@ -49,7 +49,7 @@ my %targets = (
         inherit_from     => [ "darwin-common" ],
         cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
         sys_id           => "iOS",
-        disable          => [ "engine" ],
+        disable          => [ "engine", "async" ],
     },
     "ios-cross" => {
         inherit_from     => [ "ios-xcrun" ],


### PR DESCRIPTION
Async support is highly unlikely to be used on iOS,
and currently references symbols to APIs that apple does not allow
and will result in rejected apps.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
