### PR TITLE
Travis CI: Use flake8 to find Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,18 @@ matrix:
                       - gcc-mingw-w64
           compiler: x86_64-w64-mingw32-gcc
           env: EXTENDED_TEST="yes" CONFIG_OPTS="no-pic"
+        - os: linux
+          language: python
+          python: 3.7
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+          install: pip install flake8
+          before_script:
+            # stop the build if there are Python syntax errors or undefined names
+            - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+            # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+            - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          script: true
     exclude:
         - os: linux
           compiler: clang


### PR DESCRIPTION
In Travis CI, add a Python linting step that run [flake8](http://flake8.pycqa.org) tests in Travis CI to find syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
