### PR TITLE
Properly handle duplicated messages from the next epoch

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -185,14 +185,11 @@ int dtls1_buffer_record(SSL *s, record_pqueue *queue, unsigned char *priority)
         return -1;
     }
 
-    /* insert should not fail, since duplicates are dropped */
     if (pqueue_insert(queue->q, item) == NULL) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_DTLS1_BUFFER_RECORD,
-                 ERR_R_INTERNAL_ERROR);
+        /* Must be a duplicate so ignore it */
         OPENSSL_free(rdata->rbuf.buf);
         OPENSSL_free(rdata);
         pitem_free(item);
-        return -1;
     }
 
     return 1;

--- a/test/ssltestlib.h
+++ b/test/ssltestlib.h
@@ -37,9 +37,10 @@ void bio_s_mempacket_test_free(void);
  * Mempacket BIO ctrls. We make them large enough to not clash with standard BIO
  * ctrl codes.
  */
-#define MEMPACKET_CTRL_SET_DROP_EPOCH  (1 << 15)
-#define MEMPACKET_CTRL_SET_DROP_REC    (2 << 15)
-#define MEMPACKET_CTRL_GET_DROP_REC    (3 << 15)
+#define MEMPACKET_CTRL_SET_DROP_EPOCH       (1 << 15)
+#define MEMPACKET_CTRL_SET_DROP_REC         (2 << 15)
+#define MEMPACKET_CTRL_GET_DROP_REC         (3 << 15)
+#define MEMPACKET_CTRL_SET_DUPLICATE_REC    (4 << 15)
 
 int mempacket_test_inject(BIO *bio, const char *in, int inl, int pktnum,
                           int type);


### PR DESCRIPTION
Since 1fb9fdc we may attempt to buffer a record from the next epoch that has already been buffered. Prior to that this never occurred.

We simply ignore a failure to buffer a duplicated record.

Fixes #6902

This is for master and 1.1.1. A separate PR will handle 1.0.2. I don't intend to backport to 1.1.0 since that is in security fix only mode.