### PR TITLE
Properly handle duplicated messages from the next epoch (1.0.2)

### DIFF
--- a/ssl/d1_pkt.c
+++ b/ssl/d1_pkt.c
@@ -293,14 +293,12 @@ dtls1_buffer_record(SSL *s, record_pqueue *queue, unsigned char *priority)
         return (-1);
     }
 
-    /* insert should not fail, since duplicates are dropped */
     if (pqueue_insert(queue->q, item) == NULL) {
-        SSLerr(SSL_F_DTLS1_BUFFER_RECORD, ERR_R_INTERNAL_ERROR);
+        /* Must be a duplicate so ignore it */
         if (rdata->rbuf.buf != NULL)
             OPENSSL_free(rdata->rbuf.buf);
         OPENSSL_free(rdata);
         pitem_free(item);
-        return (-1);
     }
 
     return (1);


### PR DESCRIPTION
Since 3884b47b7c we may attempt to buffer a record from the next epoch that has already been buffered. Prior to that this never occurred.

We simply ignore a failure to buffer a duplicated record.

Fixes #6902

This is the 1.0.2 version of #7414.