### PR TITLE
arch/async_posix.h: improve portability.

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -17,7 +17,8 @@
 
 # include <unistd.h>
 
-# if _POSIX_VERSION >= 200112L
+# if _POSIX_VERSION >= 200112L \
+     && (_POSIX_VERSION < 200809L || defined(__GLIBC__))
 
 # include <pthread.h>
 


### PR DESCRIPTION
{make|swap|get|set}context are removed in POSIX.1-2008, but glibc
apparently keeps providing it.
