### PR TITLE
Check return value of EVP_PKEY_new

### DIFF
--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -269,6 +269,9 @@ int rsa_main(int argc, char **argv)
     } else if (outformat == FORMAT_MSBLOB || outformat == FORMAT_PVK) {
         EVP_PKEY *pk;
         pk = EVP_PKEY_new();
+        if (pk == NULL)
+            goto end;
+
         EVP_PKEY_set1_RSA(pk, rsa);
         if (outformat == FORMAT_PVK) {
             if (pubin) {


### PR DESCRIPTION
This should fix #7416

make the rsa app consistent with the dsa app on checking return value of EVP_PKEY_new
