### PR TITLE
Conditionally open random devices on initialisation.

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -400,7 +400,8 @@ int rand_pool_init(void)
 
     for (i = 0; i < OSSL_NELEM(random_devices); i++)
         random_devices[i].fd = -1;
-    open_random_devices();
+    if (keep_random_devices_open)
+        open_random_devices();
     return 1;
 }
 


### PR DESCRIPTION
The `rand_pool_init` function was always opening the random devices regardless of the _keep them open_ setting.  Now, it conditionally opens them.

Fixes #7419
