### PR TITLE
Fix assert in EVP_CipherInit_ex

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -152,9 +152,8 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
  skip_to_init:
 #endif
     /* we assume block size is a power of 2 in *cryptUpdate */
-    OPENSSL_assert(ctx->cipher->block_size == 1
-                   || ctx->cipher->block_size == 8
-                   || ctx->cipher->block_size == 16);
+    OPENSSL_assert(ctx->cipher->block_size);
+    OPENSSL_assert(!(ctx->cipher->block_size & (ctx->cipher->block_size - 1)));
 
     if (!(ctx->flags & EVP_CIPHER_CTX_FLAG_WRAP_ALLOW)
         && EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_WRAP_MODE) {

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -152,8 +152,9 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
  skip_to_init:
 #endif
     /* we assume block size is a power of 2 in *cryptUpdate */
-    OPENSSL_assert(ctx->cipher->block_size);
-    OPENSSL_assert(!(ctx->cipher->block_size & (ctx->cipher->block_size - 1)));
+    ossl_assert(ctx->cipher->block_size);
+    ossl_assert((ctx->cipher->block_size & 
+				 (ctx->cipher->block_size - 1)) == 0);
 
     if (!(ctx->flags & EVP_CIPHER_CTX_FLAG_WRAP_ALLOW)
         && EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_WRAP_MODE) {
@@ -176,8 +177,7 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
 
         case EVP_CIPH_CBC_MODE:
 
-            OPENSSL_assert(EVP_CIPHER_CTX_iv_length(ctx) <=
-                           (int)sizeof(ctx->iv));
+            ossl_assert(EVP_CIPHER_CTX_iv_length(ctx) <= (int)sizeof(ctx->iv));
             if (iv)
                 memcpy(ctx->oiv, iv, EVP_CIPHER_CTX_iv_length(ctx));
             memcpy(ctx->iv, ctx->oiv, EVP_CIPHER_CTX_iv_length(ctx));
@@ -337,7 +337,7 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         }
     }
     i = ctx->buf_len;
-    OPENSSL_assert(bl <= (int)sizeof(ctx->buf));
+    ossl_assert(bl <= (int)sizeof(ctx->buf));
     if (i != 0) {
         if (bl - i > inl) {
             memcpy(&(ctx->buf[i]), in, inl);
@@ -392,7 +392,7 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     }
 
     b = ctx->cipher->block_size;
-    OPENSSL_assert(b <= sizeof(ctx->buf));
+    ossl_assert(b <= sizeof(ctx->buf));
     if (b == 1) {
         *outl = 0;
         return 1;
@@ -453,7 +453,7 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     if (ctx->flags & EVP_CIPH_NO_PADDING)
         return EVP_EncryptUpdate(ctx, out, outl, in, inl);
 
-    OPENSSL_assert(b <= sizeof(ctx->final));
+    ossl_assert(b <= sizeof(ctx->final));
 
     if (ctx->final_used) {
         /* see comment about PTRDIFF_T comparison above */
@@ -525,7 +525,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_WRONG_FINAL_BLOCK_LENGTH);
             return 0;
         }
-        OPENSSL_assert(b <= sizeof(ctx->final));
+        ossl_assert(b <= sizeof(ctx->final));
 
         /*
          * The following assumes that the ciphertext has been authenticated.


### PR DESCRIPTION
Cipher block_size can be bigger than 16 bytes. EVP_MAX_BLOCK_LENGTH now is 32 bytes. In new assert I check that block_size is power of 2.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


