### PR TITLE
Don't complain and fail about unknown TLSv1.3 PSK identities in s_server

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -193,9 +193,8 @@ static int psk_find_session_cb(SSL *ssl, const unsigned char *identity,
 
     if (strlen(psk_identity) != identity_len
             || memcmp(psk_identity, identity, identity_len) != 0) {
-        BIO_printf(bio_s_out,
-                   "PSK warning: client identity not what we expected"
-                   " (got '%s' expected '%s')\n", identity, psk_identity);
+        *sess = NULL;
+        return 1;
     }
 
     if (psksess != NULL) {


### PR DESCRIPTION
An unknown PSK identity could be because its actually a session resumption
attempt. Sessions resumptions and external PSKs are indistinguishable so
the callbacks need to fail gracefully if they don't recognise the identity.

Fixes #7433

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
