### PR TITLE
rand_unix.c: open random devices on first use only

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -386,21 +386,13 @@ static void close_random_device(size_t n)
     rd->fd = -1;
 }
 
-static void open_random_devices(void)
-{
-    size_t i;
-
-    for (i = 0; i < OSSL_NELEM(random_devices); i++)
-        (void)get_random_device(i);
-}
-
 int rand_pool_init(void)
 {
     size_t i;
 
     for (i = 0; i < OSSL_NELEM(random_devices); i++)
         random_devices[i].fd = -1;
-    open_random_devices();
+
     return 1;
 }
 
@@ -414,10 +406,9 @@ void rand_pool_cleanup(void)
 
 void rand_pool_keep_random_devices_open(int keep)
 {
-    if (keep)
-        open_random_devices();
-    else
+    if (!keep)
         rand_pool_cleanup();
+
     keep_random_devices_open = keep;
 }
 


### PR DESCRIPTION
Commit c7504aeb640a (pr #6432) fixed a regression for applications in
chroot environments, which compensated the fact that the new OpenSSL CSPRNG
(based on the NIST DRBG) now reseeds periodically, which the previous
one didn't. Now the reseeding could fail in the chroot environment if the
DEVRANDOM devices were not present anymore and no other entropy source
(e.g. getrandom()) was available.

The solution was to keep the file handles for the DEVRANDOM devices open
by default. In fact, the fix did more than this, it opened the DEVRANDOM
devices early and unconditionally in rand_pool_init(), which had the
unwanted side effect that the devices were opened (and kept open) even
in cases when they were not used at all, for example when the getrandom()
system call was available. Due  to a bug (issue #7419) this even happened
when the feature was disabled by the application.

This commit removes the unconditional opening of all DEVRANDOM devices.
They will now only be opened (and kept open) on first use. In particular,
if getrandom() is available, the handles will not be opened unnecessarily.

This change does not introduce a regression for applications compiled for
libcrypto 1.1.0, because the SSLEAY RNG also seeds on first use. So in the
above constellation the CSPRNG will only be properly seeded if it is happens
before the forking and chrooting.

Fixes #7419
Alternative to #7429