### PR TITLE
md_rand.c: don't stop polling until properly initialized [1.1.0]

### DIFF
--- a/crypto/rand/md_rand.c
+++ b/crypto/rand/md_rand.c
@@ -275,7 +275,6 @@ static int rand_bytes(unsigned char *buf, int num, int pseudo)
     static volatile int stirred_pool = 0;
     int i, j, k;
     size_t num_ceil, st_idx, st_num;
-    int ok;
     long md_c[2];
     unsigned char local_md[MD_DIGEST_LENGTH];
     EVP_MD_CTX *m;
@@ -362,14 +361,13 @@ static int rand_bytes(unsigned char *buf, int num, int pseudo)
 
     if (!initialized) {
         RAND_poll();
-        initialized = 1;
+        initialized = (entropy >= ENTROPY_NEEDED);
     }
 
     if (!stirred_pool)
         do_stir_pool = 1;
 
-    ok = (entropy >= ENTROPY_NEEDED);
-    if (!ok) {
+    if (!initialized) {
         /*
          * If the PRNG state is not yet unpredictable, then seeing the PRNG
          * output may help attackers to determine the new state; thus we have
@@ -408,7 +406,7 @@ static int rand_bytes(unsigned char *buf, int num, int pseudo)
             rand_add(DUMMY_SEED, MD_DIGEST_LENGTH, 0.0);
             n -= MD_DIGEST_LENGTH;
         }
-        if (ok)
+        if (initialized)
             stirred_pool = 1;
     }
 
@@ -500,7 +498,7 @@ static int rand_bytes(unsigned char *buf, int num, int pseudo)
     CRYPTO_THREAD_unlock(rand_lock);
 
     EVP_MD_CTX_free(m);
-    if (ok)
+    if (initialized)
         return (1);
     else if (pseudo)
         return 0;


### PR DESCRIPTION
Previously, the RNG sets `initialized=1` after the first call to
RAND_poll(), although its criterion for being initialized actually
is whether condition `entropy >= ENTROPY_NEEDED` is true.

This commit now assigns `initialized=(entropy >= ENTROPY_NEEDED)`,
which has the effect that on the next call, RAND_poll() will be
called again, if it previously failed to obtain enough entropy.

Noticed while working on #7437