### PR TITLE
Fix MSVC warning C4819

### DIFF
--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -1077,7 +1077,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
              * is not only slower but also makes each bit vulnerable to
              * EM (and likely other) side-channel attacks like One&Done
              * (for details see "One&Done: A Single-Decryption EM-Based
-             *  Attack on OpenSSL’s Constant-Time Blinded RSA" by M. Alam,
+             *  Attack on OpenSSL's Constant-Time Blinded RSA" by M. Alam,
              *  H. Khan, M. Dey, N. Sinha, R. Callan, A. Zajic, and
              *  M. Prvulovic, in USENIX Security'18)
              */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated


MSDN doc: https://msdn.microsoft.com/en-us//library/ms173715.aspx

I was compiling in MSVC2017 (nmake), targeting x86 and the OS is Windows in Traditional Chinese (default codepage 950) and the warning comes up, normally a warning wouldn't pose a problem, however got hit due to `/WX` (treat warning as error) is set.