### PR TITLE
build file templates: have targets for all shared library names

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1134,9 +1134,7 @@ EOF
       }
       return $recipe;
   }
-  # On Unix, we build shlibs from static libs, so we're ignoring the
-  # object file array.  We *know* this routine is only called when we've
-  # configure 'shared'.
+  # We *know* this routine is only called when we've configure 'shared'.
   sub obj2shlib {
       my %args = @_;
       my $lib = $args{lib};
@@ -1163,26 +1161,20 @@ EOF
       die "More than one exported symbol map" if scalar @defs > 1;
       my $objs = join(" ", @objs);
       my $deps = join(" ", @objs, @defs, @deps);
-      my $target = shlib_simple($lib);
-      my $target_full = shlib($lib);
+      my $simple = shlib_simple($lib);
+      my $full = shlib($lib);
+      my $target = "$simple $full";
       my $shared_soname = "";
-      $shared_soname .= ' '.$target{shared_sonameflag}.basename($target_full)
+      $shared_soname .= ' '.$target{shared_sonameflag}.basename($full)
           if defined $target{shared_sonameflag};
       my $shared_imp = "";
-      $shared_imp .= ' '.$target{shared_impflag}.basename($target)
+      $shared_imp .= ' '.$target{shared_impflag}.basename($simple)
           if defined $target{shared_impflag};
       my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
       my $recipe = <<"EOF";
-# When building on a Windows POSIX layer (Cygwin or Mingw), we know for a fact
-# that two files get produced, {shlibname}.dll and {libname}.dll.a.
-# With all other Unix platforms, we often build a shared library with the
-# SO version built into the file name and a symlink without the SO version
-# It's not necessary to have both as targets.  The choice falls on the
-# simplest, {libname}\$(SHLIB_EXT_IMPORT) for Windows POSIX layers and
-# {libname}\$(SHLIB_EXT_SIMPLE) for the Unix platforms.
 $target: $deps
 	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
-		-o $target_full$shared_def $objs \\
+		-o $full$shared_def $objs \\
                 $linklibs \$(LIB_EX_LIBS)
 EOF
       if (windowsdll()) {
@@ -1196,14 +1188,14 @@ EOF
 EOF
       } elsif (sharedaix()) {
           $recipe .= <<"EOF";
-	rm -f $target && \\
-	\$(AR) r $target $target_full
+	rm -f $simple && \\
+	\$(AR) r $simple $full
 EOF
       } else {
           $recipe .= <<"EOF";
-	if [ '$target' != '$target_full' ]; then \\
-		rm -f $target; \\
-		ln -s $target_full $target; \\
+	if [ '$simple' != '$full' ]; then \\
+		rm -f $simple; \\
+		ln -s $full $simple; \\
 	fi
 EOF
       }

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -636,7 +636,6 @@ EOF
  sub obj2shlib {
      my %args = @_;
      my $lib = $args{lib};
-     my $shlib = $args{shlib};
      my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x }
                 grep { $_ =~ m/\.(?:o|res)$/ }
                 @{$args{objs}};
@@ -648,26 +647,30 @@ EOF
      my $linklibs = join("", map { "$_\n" } @deps);
      my $objs = join("\n", @objs);
      my $deps = join(" ", @objs, @defs, @deps);
-     my $target = shlib_import($lib) . " " . shlib($lib);
+     my $import = shlib_import($lib);
+     my $dll =  shlib($lib);
      my $shared_def = join("", map { " /def:$_" } @defs);
      return <<"EOF"
 # The import library may look like a static library, but it is not.
-$target: $deps
-	IF EXIST $shlib$shlibext.manifest DEL /F /Q $shlib$shlibext.manifest
+# We MUST make the import library depend on the DLL, in case someone
+# mistakenly removes the latter.
+$import: $dll
+$dll: $deps
+	IF EXIST $full.manifest DEL /F /Q $full.manifest
 	IF EXIST \$@ DEL /F /Q \$@
 	\$(LD) \$(LDFLAGS) \$(LIB_LDFLAGS) \\
-		/implib:\$@ \$(LDOUTFLAG)$shlib$shlibext$shared_def @<< || (DEL /Q \$(\@B).* $shlib.* && EXIT 1)
+		/implib:$import \$(LDOUTFLAG)$dll$shared_def @<< || (DEL /Q \$(\@B).* $import && EXIT 1)
 $objs
 $linklibs\$(LIB_EX_LIBS)
 <<
-	IF EXIST $shlib$shlibext.manifest \\
-	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$shlib$shlibext.manifest \$(MTOUTFLAG)$shlib$shlibext
-	IF EXIST apps\\$shlib$shlibext DEL /Q /F apps\\$shlib$shlibext
-	IF EXIST test\\$shlib$shlibext DEL /Q /F test\\$shlib$shlibext
-	IF EXIST fuzz\\$shlib$shlibext DEL /Q /F fuzz\\$shlib$shlibext
-	COPY $shlib$shlibext apps
-	COPY $shlib$shlibext test
-	COPY $shlib$shlibext fuzz
+	IF EXIST $dll.manifest \\
+	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$dll.manifest \$(MTOUTFLAG)$dll
+	IF EXIST apps\\$dll DEL /Q /F apps\\$dll
+	IF EXIST test\\$dll DEL /Q /F test\\$dll
+	IF EXIST fuzz\\$dll DEL /Q /F fuzz\\$dll
+	COPY $dll apps
+	COPY $dll test
+	COPY $dll fuzz
 EOF
  }
  sub obj2dso {

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -630,9 +630,9 @@ $obj$objext: $deps
 EOF
  }
 
- # On Unix, we build shlibs from static libs, so we're ignoring the
- # object file array.  We *know* this routine is only called when we've
- # configure 'shared'.
+ # We *know* this routine is only called when we've configure 'shared'.
+ # Also, note that even though the import library built here looks like
+ # a static library, it really isn't.
  sub obj2shlib {
      my %args = @_;
      my $lib = $args{lib};
@@ -648,9 +648,10 @@ EOF
      my $linklibs = join("", map { "$_\n" } @deps);
      my $objs = join("\n", @objs);
      my $deps = join(" ", @objs, @defs, @deps);
-     my $target = shlib_import($lib);
+     my $target = shlib_import($lib) . " " . shlib($lib);
      my $shared_def = join("", map { " /def:$_" } @defs);
      return <<"EOF"
+# The import library may look like a static library, but it is not.
 $target: $deps
 	IF EXIST $shlib$shlibext.manifest DEL /F /Q $shlib$shlibext.manifest
 	IF EXIST \$@ DEL /F /Q \$@


### PR DESCRIPTION
We only had targets for the "simple" shared library names (libfoo.so
and not libfoo.so.x.y on Unix, import library libfoo.lib but not
libfoo.dll on Windows).  This has created some confusion why it wasn't
possible to rebuild the less "simple" name directly (just as an
example, someone who mistook the import library on Windows for a
static library, removed the DLL and then found it was difficult to
rebuild directly), so we change the target to include all possible
names.
