### PR TITLE
Configuration: when building the dirinfo structure, include shared_sources

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -210,47 +210,6 @@
  # Start with populating the cache with all the overrides
  %cache = map { $_ => 1 } @{$unified_info{overrides}};
 
- # For convenience collect information regarding directories where
- # files are generated, those generated files and the end product
- # they end up in where applicable.  Then, add build rules for those
- # directories
- if (exists &generatedir) {
-     my %loopinfo = ( "dso" => [ @{$unified_info{engines}} ],
-                      "lib" => [ @{$unified_info{libraries}} ],
-                      "bin" => [ @{$unified_info{programs}} ],
-                      "script" => [ @{$unified_info{scripts}} ] );
-     foreach my $type (keys %loopinfo) {
-         foreach my $product (@{$loopinfo{$type}}) {
-             my %dirs = ();
-             my $pd = dirname($product);
-
-             # We already have a "test" target, and the current directory
-             # is just silly to make a target for
-             $dirs{$pd} = 1 unless $pd eq "test" || $pd eq ".";
-
-             foreach (@{$unified_info{sources}->{$product}}) {
-                 my $d = dirname($_);
-
-                 # We don't want to create targets for source directories
-                 # when building out of source
-                 next if ($config{sourcedir} ne $config{builddir}
-                          && $d =~ m|^\Q$config{sourcedir}\E|);
-                 # We already have a "test" target, and the current directory
-                 # is just silly to make a target for
-                 next if $d eq "test" || $d eq ".";
-
-                 $dirs{$d} = 1;
-                 push @{$unified_info{dirinfo}->{$d}->{deps}}, $_
-                     if $d ne $pd;
-             }
-             foreach (keys %dirs) {
-                 push @{$unified_info{dirinfo}->{$_}->{products}->{$type}},
-                 $product;
-             }
-         }
-     }
- }
-
  # Build mandatory generated headers
  foreach (@{$unified_info{depends}->{""}}) { dogenerate($_); }
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1311,6 +1311,10 @@ EOF
                       lib => $libext,
                       bin => $exeext );
 
+      # We already have a 'test' target, and the top directory is just plain
+      # silly
+      return if $dir eq "test" || $dir eq ".";
+
       foreach my $type (("dso", "lib", "bin", "script")) {
           next unless defined($unified_info{dirinfo}->{$dir}->{products}->{$type});
           # For lib object files, we could update the library.  However, it
@@ -1331,7 +1335,7 @@ EOF
       my $deps = join(" ", @deps);
       my $actions = join("\n", "", @actions);
       return <<"EOF";
-$args{dir} $args{dir}/: $deps$actions
+$dir $dir/: $deps$actions
 EOF
   }
   ""    # Important!  This becomes part of the template result.

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -758,6 +758,10 @@ EOF
                       lib => $libext,
                       bin => $exeext );
 
+      # We already have a 'test' target, and the top directory is just plain
+      # silly
+      return if $dir eq "test" || $dir eq ".";
+
       foreach my $type (("dso", "lib", "bin", "script")) {
           next unless defined($unified_info{dirinfo}->{$dir}->{products}->{$type});
           # For lib object files, we could update the library.  However,
@@ -775,7 +779,7 @@ EOF
       my $deps = join(" ", @deps);
       my $actions = join("\n", "", @actions);
       return <<"EOF";
-$args{dir} $args{dir}\\ : $deps$actions
+$dir $dir\\ : $deps$actions
 EOF
   }
   ""    # Important!  This becomes part of the template result.

--- a/Configure
+++ b/Configure
@@ -2325,6 +2325,42 @@ EOF
             delete $unified_info{includes}->{$dest};
         }
     }
+
+    # For convenience collect information regarding directories where
+    # files are generated, those generated files and the end product
+    # they end up in where applicable.  Then, add build rules for those
+    # directories
+    my %loopinfo = ( "lib" => [ @{$unified_info{libraries}} ],
+                     "dso" => [ @{$unified_info{engines}} ],
+                     "bin" => [ @{$unified_info{programs}} ],
+                     "script" => [ @{$unified_info{scripts}} ] );
+    foreach my $type (keys %loopinfo) {
+        foreach my $product (@{$loopinfo{$type}}) {
+            my %dirs = ();
+            my $pd = dirname($product);
+
+            foreach (@{$unified_info{sources}->{$product}},
+                     @{$unified_info{shared_sources}->{$product} // []}) {
+                my $d = dirname($_);
+
+                # We don't want to create targets for source directories
+                # when building out of source
+                next if ($config{sourcedir} ne $config{builddir}
+                             && $d =~ m|^\Q$config{sourcedir}\E|);
+                # We already have a "test" target, and the current directory
+                # is just silly to make a target for
+                next if $d eq "test" || $d eq ".";
+
+                $dirs{$d} = 1;
+                push @{$unified_info{dirinfo}->{$d}->{deps}}, $_
+                    if $d ne $pd;
+            }
+            foreach (keys %dirs) {
+                push @{$unified_info{dirinfo}->{$_}->{products}->{$type}},
+                    $product;
+            }
+        }
+    }
 }
 
 # For the schemes that need it, we provide the old *_obj configs


### PR DESCRIPTION
This makes sure that any resulting directory target in the build files
also depend on object files meant for shared libraries.

As a side effect, we move the production of the dirinfo structure from
common.tmpl to Configure, to make it easier to check the result.
