### PR TITLE
WIP: Configuration: move physical shared library name knowledge

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -440,23 +440,6 @@ support building static libraries and DLLs at the same time, so using
 static libraries on Windows can only be done when configured
 'no-shared'.
 
-One some platforms, shared libraries come with a name that's different
-from their static counterpart.  That's declared as follows:
-
-    SHARED_NAME[libfoo]=cygfoo-{- $config{shlibver} -}
-
-The example is from Cygwin, which has a required naming convention.
-
-Sometimes, it makes sense to rename an output file, for example a
-library:
-
-    RENAME[libfoo]=libbar
-
-That line has "libfoo" renamed to "libbar".  While it makes no
-sense at all to just have a rename like that (why not just use
-"libbar" everywhere?), it does make sense when it can be used
-conditionally.  See a little further below for an example.
-
 In some cases, it's desirable to include some source files in the
 shared form of a library only:
 
@@ -559,15 +542,6 @@ conditions based on something in the passed variables, for example:
     ELSE
       LIBS=libfoo
       SOURCE[libfoo]=...
-    ENDIF
-
-or:
-
-    # VMS has a cultural standard where all libraries are prefixed.
-    # For OpenSSL, the choice is 'ossl_'
-    IF[{- $config{target} =~ /^vms/ -}]
-     RENAME[libcrypto]=ossl_libcrypto
-     RENAME[libssl]=ossl_libssl
     ENDIF
 
 

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -125,8 +125,7 @@
      return "" if $cache{$lib};
      unless ($disabled{shared} || $lib =~ /\.a$/) {
          my $obj2shlib = defined &obj2shlib ? \&obj2shlib : \&libobj2shlib;
-         $OUT .= $obj2shlib->(shlib => $unified_info{sharednames}->{$lib},
-                              lib => $lib,
+         $OUT .= $obj2shlib->(lib => $lib,
                               objs => $unified_info{shared_sources}->{$lib},
                               deps => [ reducedepends(resolvedepends($lib)) ],
                               installed => is_installed($lib));

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -10,7 +10,7 @@
   our $osslprefix = 'OSSL$';
   (our $osslprefix_q = $osslprefix) =~ s/\$/\\\$/;
 
-  our $sover_dirname = sprintf "%02d%02d", split(/\./, $config{shlib_version_number});
+  our $sover_filename = sprintf "%02d%02d", split(/\./, $config{shlib_version_number});
   our $osslver = sprintf "%02d%02d", split(/\./, $config{version});
 
   our $sourcedir = $config{sourcedir};
@@ -41,19 +41,50 @@
       "";
   }
 
+  # VMS has a cultural standard where all libraries are prefixed.
+  # Also, it seems it's usual to have the pointer size the libraries
+  # were built for as part of the name.
+  sub sharedname {
+      my $lib = shift;
+      my $lib_uc = uc $lib;
+      return undef if $disabled{shared} || $lib =~ /\.a$/;
+      return "${osslprefix}${lib_uc}${sover_filename}_SHR$target{pointer_size}";
+  }
+
+  sub staticname {
+      my $lib = shift;
+      $lib =~ s|\.a$||;
+      return "${osslprefix}${lib_uc}$target{pointer_size}";
+  }
+
+  sub shlib {
+      return sharedname(shift) . ".EXE";
+  }
+
+  sub lib {
+      my $lib = shift;
+
+      # Non-installed names remain, except for the mandatory extension
+      unless (grep { $_ eq $lib } @{$unified_info{install}->{libraries}}) {
+          $lib =~ s|\.a$||;
+          return $lib . ".OLB";
+      }
+      return sharedname($lib) . ".OLB";
+  }
+
   # Because we need to make two computations of these data,
   # we store them in arrays for reuse
   our @libs =
-      map { (my $x = $_) =~ s/\.a$//; $x }
+      map { staticname($_) }
       @{$unified_info{libraries}};
   our @shlibs =
-      map { $unified_info{sharednames}->{$_} || () }
+      map { sharedname($_) // () }
       grep(!/\.a$/, @{$unified_info{libraries}});
   our @install_libs =
-      map { (my $x = $_) =~ s/\.a$//; $x }
+      map { staticname($_) }
       @{$unified_info{install}->{libraries}};
   our @install_shlibs =
-      map { $unified_info{sharednames}->{$_} || () }
+      map { sharedname($_) // () }
       grep(!/\.a$/, @{$unified_info{install}->{libraries}});
 
   # This is a horrible hack, but is needed because recursive inclusion of files
@@ -170,7 +201,7 @@ OPENSSLDIR={- catdir($config{openssldir}) or
 # The same, but for C
 OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
 # Where installed engines reside, for C
-ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
+ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_filename.$target{pointer_size} -}:
 
 ##### User defined commands and flags ################################
 
@@ -589,9 +620,9 @@ install_runtime : install_shared _install_runtime_ns
 install_engines : check_INSTALLTOP
         @ {- output_off() unless scalar @{$unified_info{engines}}; "" -} !
         @ WRITE SYS$OUTPUT "*** Installing engines"
-        - CREATE/DIR ossl_installroot:[ENGINES{- $sover_dirname.$target{pointer_size} -}.'arch']
+        - CREATE/DIR ossl_installroot:[ENGINES{- $sover_filename.$target{pointer_size} -}.'arch']
         {- join("\n        ",
-                map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover_dirname$target{pointer_size}.'arch']" }
+                map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover_filename$target{pointer_size}.'arch']" }
                 @{$unified_info{install}->{engines}}) -}
         @ {- output_on() unless scalar @{$unified_info{engines}}; "" -} !
 
@@ -700,11 +731,9 @@ reconfigure reconf :
   # It takes a list of library names and outputs a list of dependencies
   sub compute_lib_depends {
       if ($disabled{shared}) {
-          return map { $_ =~ /\.a$/ ? $`.".OLB" : $_.".OLB" } @_;
+          return map { lib($_) } @_;
       }
-      return map { $_ =~ /\.a$/
-                   ? $`.".OLB"
-                   : $unified_info{sharednames}->{$_}.".EXE" } @_;
+      return map { $_ =~ /\.a$/ ? lib($`) : shlib($_) } @_;
   }
 
   # Helper function to deal with inclusion directory specs.
@@ -923,10 +952,7 @@ EOF
   }
   sub obj2shlib {
       my %args = @_;
-      my $lib = $args{lib};
-      my $shlib = $args{shlib};
-      my $libd = dirname($lib);
-      my $libn = basename($lib);
+      my $shlib = sharedname($args{lib});
       my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x }
                  grep { $_ =~ m|\.o$| }
                  @{$args{objs}};
@@ -957,13 +983,13 @@ EOF
       return <<"EOF"
 $shlib.EXE : $deps
         \$(PERL) $translatesyms_pl \$(BLDDIR)CXX\$DEMANGLER_DB. < $defs[0] > $defs[0]-translated
-        OPEN/WRITE/SHARE=READ OPT_FILE $lib-components.OPT
+        OPEN/WRITE/SHARE=READ OPT_FILE $shlib-components.OPT
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
         LINK \$(LIB_LDFLAGS)/SHARE=\$\@ $defs[0]-translated/OPT,-
-                $lib-components.OPT/OPT \$(LIB_EX_LIBS)
-        DELETE $defs[0]-translated;*,$lib-components.OPT;*
+                $shlib-components.OPT/OPT \$(LIB_EX_LIBS)
+        DELETE $defs[0]-translated;*,$shlib-components.OPT;*
         PURGE $shlib.EXE,$shlib.MAP
 EOF
         . ($config{target} =~ m|alpha| ? "" : <<"EOF"
@@ -1018,7 +1044,7 @@ EOF
   }
   sub obj2lib {
       my %args = @_;
-      (my $lib = $args{lib}) =~ s/\.a$//;
+      my $lib = staticname($args{lib});
       my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x } @{$args{objs}};
       my $objs = join(", -\n\t\t", @objs);
       my $fill_lib = join("\n\t", (map { "LIBRARY/REPLACE $lib.OLB $_" }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -21,9 +21,29 @@
      # libcrypto.a and use libcrypto_a.a as static one.
      sub sharedaix  { !$disabled{shared} && $config{target} =~ /^aix/ }
 
-     our $sover_dirname = $config{shlib_version_number};
-     $sover_dirname =~ s|\.|_|g
+     our $sover_filename = $config{shlib_version_number};
+     $sover_filename =~ s|\.|_|g
          if $config{target} =~ /^mingw/;
+
+     sub sharedname {
+         my $lib = shift;
+         return undef if $disabled{shared} || $lib =~ /\.a$/;
+         if ($config{target} =~ /^Cygwin/) {
+             $lib =~ s|^lib|cyg|;
+             $lib .= "-$sover_filename";
+         } elsif ($config{target} =~ /^mingw/) {
+             $lib .= "-$sover_filename";
+             $lib .= "-x64" if $config{target} eq "mingw64";
+         }
+         return $lib;
+     }
+
+     # This is currently a no-op, but will change if we decide to add
+     # something like '_a' or '_static' to the name.
+     sub staticname {
+         (my $lib = shift) =~ s/\.a$//;
+         return $lib;
+     }
 
      # shlib and shlib_simple both take a static library name and figure
      # out what the shlib name should be.
@@ -47,7 +67,7 @@
      sub shlib {
          my $lib = shift;
          return () if $disabled{shared} || $lib =~ /\.a$/;
-         return $unified_info{sharednames}->{$lib}. $shlibvariant. '$(SHLIB_EXT)';
+         return sharedname($lib) . $shlibvariant . '$(SHLIB_EXT)';
      }
      sub shlib_simple {
          my $lib = shift;
@@ -61,8 +81,14 @@
 
      # Easy fixing of static library names
      sub lib {
-         (my $lib = shift) =~ s/\.a$//;
-         return $lib . $libext;
+         my $lib = shift;
+
+         # Non-installed names remain, except for the mandatory extension
+         unless (grep { $_ eq $lib } @{$unified_info{install}->{libraries}}) {
+             $lib =~ s|\.a$||;
+             return $lib . $libext;
+         }
+         return staticname($lib) . $libext;
      }
 
      # dso is a complement to shlib / shlib_simple that returns the
@@ -174,7 +200,7 @@ LIBDIR={- our $libdir = $config{libdir};
 # $(libdir) is chosen to be compatible with the GNU coding standards
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
-ENGINESDIR=$(libdir)/engines-{- $sover_dirname -}
+ENGINESDIR=$(libdir)/engines-{- $sover_filename -}
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications
@@ -920,7 +946,7 @@ libcrypto.pc:
 	        echo 'libdir=$(libdir)'; \
 	    fi; \
 	    echo 'includedir=$${prefix}/include'; \
-	    echo 'enginesdir=$${libdir}/engines-{- $sover_dirname -}'; \
+	    echo 'enginesdir=$${libdir}/engines-{- $sover_filename -}'; \
 	    echo ''; \
 	    echo 'Name: OpenSSL-libcrypto'; \
 	    echo 'Description: OpenSSL cryptography library'; \
@@ -988,7 +1014,7 @@ reconfigure reconf:
       # Depending on shared libraries:
       # On Windows POSIX layers, we depend on {libname}.dll.a
       # On Unix platforms, we depend on {shlibname}.so
-      return map { $_ =~ /\.a$/ ? $`.$libext : shlib_simple($_) } @_;
+      return map { $_ =~ /\.a$/ ? lib($`) : shlib_simple($_) } @_;
   }
 
   sub generatesrc {
@@ -1138,10 +1164,6 @@ EOF
   sub obj2shlib {
       my %args = @_;
       my $lib = $args{lib};
-      my $shlib = $args{shlib};
-      my $libd = dirname($lib);
-      my $libn = basename($lib);
-      (my $libname = $libn) =~ s/^lib//;
       my @linkdirs = ();
       foreach (@{args{deps}}) {
           my $d = dirname($_);
@@ -1234,11 +1256,11 @@ EOF
   }
   sub obj2lib {
       my %args = @_;
-      (my $lib = $args{lib}) =~ s/\.a$//;
+      my $lib = lib($args{lib});
       my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x } @{$args{objs}};
       my $objs = join(" ", @objs);
       return <<"EOF";
-$lib$libext: $objs
+$lib: $objs
 	\$(AR) \$(ARFLAGS) \$\@ \$\?
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF
@@ -1258,8 +1280,8 @@ EOF
           push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
       }
       my $linkflags = join("", map { "-L$_ " } @linkdirs);
-      my $linklibs = join("", map { if ($_ =~ s/\.a$//) {
-                                        " $_$libext";
+      my $linklibs = join("", map { if ($_ =~ m|\.a$|) {
+                                        " ".lib($_);
                                     } else {
                                         my $f = basename($_);
                                         (my $l = $f) =~ s/^lib//;

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -13,7 +13,7 @@
  our $shlibextimport = $target{shared_import_extension} || ".lib";
  our $dsoext = $target{dso_extension} || ".dll";
 
- (our $sover_dirname = $config{shlib_version_number}) =~ s|\.|_|g;
+ (our $sover_filename = $config{shlib_version_number}) =~ s|\.|_|g;
 
  my $build_scheme = $target{build_scheme};
  my $install_flavour = $build_scheme->[$#$build_scheme]; # last element
@@ -32,22 +32,44 @@
  $win_installroot = $ENV{$win_installroot};
  $win_commonroot = $ENV{$win_commonroot};
 
- sub shlib {
+ sub importname {
      my $lib = shift;
-     return () if $disabled{shared} || $lib =~ /\.a$/;
-     return () unless defined $unified_info{sharednames}->{$lib};
-     return $unified_info{sharednames}->{$lib} . $shlibext;
+     return undef if $disabled{shared} || $lib =~ /\.a$/;
+     return $lib;
+ }
+
+ sub sharedname {
+     my $lib = shift;
+     return undef if $disabled{shared} || $lib =~ /\.a$/;
+     return "$lib-$sover_filename$target{multilib}";
+ }
+
+ sub staticname {
+     (my $lib = shift) =~ s/\.a$//;
+     return $lib;
+ }
+
+ sub shlib {
+     my $name = sharedname(shift);
+     return () unless defined $name;
+     return $name . $shlibext;
  }
 
  sub lib {
-     (my $lib = shift) =~ s/\.a$//;
-     return $lib . $libext;
+     my $lib = shift;
+
+     # Non-installed names remain, except for the mandatory extension
+     unless (grep { $_ eq $lib } @{$unified_info{install}->{libraries}}) {
+         $lib =~ s|\.a$||;
+         return $lib . $libext;
+     }
+     return staticname($lib) . $libext;
  }
 
  sub shlib_import {
-     my $lib = shift;
-     return () if $disabled{shared} || $lib =~ /\.a$/;
-     return $lib . $shlibextimport;
+     my $name = importname(shift);
+     return () unless defined $name;
+     return $name . $shlibextimport;
  }
 
  sub dso {
@@ -145,7 +167,7 @@ OPENSSLDIR_dir={- canonpath($openssldir_dir) -}
 LIBDIR={- our $libdir = $config{libdir} || "lib";
           file_name_is_absolute($libdir) ? "" : $libdir -}
 ENGINESDIR_dev={- use File::Spec::Functions qw(:DEFAULT splitpath);
-                  our $enginesdir = catdir($prefix,$libdir,"engines-$sover_dirname");
+                  our $enginesdir = catdir($prefix,$libdir,"engines-$sover_filename");
                   our ($enginesdir_dev, $enginesdir_dir, $enginesdir_file) =
                       splitpath($enginesdir, 1);
                   $enginesdir_dev -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -512,11 +512,6 @@ reconfigure reconf:
      if ($disabled{shared}) {
 	 return map { lib($_) } @_;
      }
-     foreach (@_) {
-         (my $l = $_) =~ s/\.a$//;
-         die "Linking with static variants of shared libraries is not supported in this configuration\n"
-             if $l ne $_ && shlib($l);
-     }
      return map { shlib_import($_) or lib($_) } @_;
  }
 

--- a/Configure
+++ b/Configure
@@ -1718,8 +1718,6 @@ if ($builder eq "unified") {
         my %shared_sources = ();
         my %includes = ();
         my %depends = ();
-        my %renames = ();
-        my %sharednames = ();
         my %generate = ();
 
         # We want to detect configdata.pm in the source tree, so we
@@ -1839,11 +1837,9 @@ if ($builder eq "unified") {
             => sub { push @{$generate{$1}}, $2
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*RENAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$renames{$1}}, tokenize($2)
-                         if !@skip || $skip[$#skip] > 0 },
+            => sub { warn "RENAME is no longer supported\n" },
             qr/^\s*SHARED_NAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$sharednames{$1}}, tokenize($2)
-                         if !@skip || $skip[$#skip] > 0 },
+            => sub { warn "SHARED_NAME is no longer supported\n" },
             qr/^\s*BEGINRAW\[((?:\\.|[^\\\]])+)\]\s*$/
             => sub {
                 my $lineiterator = shift;
@@ -1877,48 +1873,23 @@ if ($builder eq "unified") {
             );
         die "runaway IF?" if (@skip);
 
-        foreach (keys %renames) {
-            die "$_ renamed to more than one thing: "
-                ,join(" ", @{$renames{$_}}),"\n"
-                if scalar @{$renames{$_}} > 1;
-            my $dest = cleanfile($buildd, $_, $blddir);
-            my $to = cleanfile($buildd, $renames{$_}->[0], $blddir);
-            die "$dest renamed to more than one thing: "
-                ,$unified_info{rename}->{$dest}, $to
-                unless !defined($unified_info{rename}->{$dest})
-                or $unified_info{rename}->{$dest} eq $to;
-            $unified_info{rename}->{$dest} = $to;
-        }
-
         foreach (@programs) {
             my $program = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$program}) {
-                $program = $unified_info{rename}->{$program};
-            }
             $unified_info{programs}->{$program} = 1;
         }
 
         foreach (@programs_install) {
             my $program = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$program}) {
-                $program = $unified_info{rename}->{$program};
-            }
             $unified_info{install}->{programs}->{$program} = 1;
         }
 
         foreach (@libraries) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{libraries}->{$library} = 1;
         }
 
         foreach (@libraries_install) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{install}->{libraries}->{$library} = 1;
         }
 
@@ -1928,33 +1899,21 @@ This is usually a fault in a build.info file.
 EOF
         foreach (@engines) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{engines}->{$library} = 1;
         }
 
         foreach (@engines_install) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{install}->{engines}->{$library} = 1;
         }
 
         foreach (@scripts) {
             my $script = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$script}) {
-                $script = $unified_info{rename}->{$script};
-            }
             $unified_info{scripts}->{$script} = 1;
         }
 
         foreach (@scripts_install) {
             my $script = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$script}) {
-                $script = $unified_info{rename}->{$script};
-            }
             $unified_info{install}->{scripts}->{$script} = 1;
         }
 
@@ -1970,53 +1929,20 @@ EOF
 
         push @{$unified_info{rawlines}}, @rawlines;
 
-        unless ($disabled{shared}) {
-            # Check sharednames.
-            foreach (keys %sharednames) {
-                my $dest = cleanfile($buildd, $_, $blddir);
-                if ($unified_info{rename}->{$dest}) {
-                    $dest = $unified_info{rename}->{$dest};
-                }
-                die "shared_name for $dest with multiple values: "
-                    ,join(" ", @{$sharednames{$_}}),"\n"
-                    if scalar @{$sharednames{$_}} > 1;
-                my $to = cleanfile($buildd, $sharednames{$_}->[0], $blddir);
-                die "shared_name found for a library $dest that isn't defined\n"
-                    unless $unified_info{libraries}->{$dest};
-                die "shared_name for $dest with multiple values: "
-                    ,$unified_info{sharednames}->{$dest}, ", ", $to
-                    unless !defined($unified_info{sharednames}->{$dest})
-                    or $unified_info{sharednames}->{$dest} eq $to;
-                $unified_info{sharednames}->{$dest} = $to;
-            }
-
-            # Additionally, we set up sharednames for libraries that don't
-            # have any, as themselves.  Only for libraries that aren't
-            # explicitly static.
-            foreach (grep !/\.a$/, keys %{$unified_info{libraries}}) {
-                if (!defined $unified_info{sharednames}->{$_}) {
-                    $unified_info{sharednames}->{$_} = $_
-                }
-            }
-
-            # Check that we haven't defined any library as both shared and
-            # explicitly static.  That is forbidden.
-            my @doubles = ();
-            foreach (grep /\.a$/, keys %{$unified_info{libraries}}) {
-                (my $l = $_) =~ s/\.a$//;
-                push @doubles, $l if defined $unified_info{sharednames}->{$l};
-            }
-            die "these libraries are both explicitly static and shared:\n  ",
-                join(" ", @doubles), "\n"
-                if @doubles;
+        # Check that we haven't defined any library with and without .a
+        # That is forbidden.
+        my @doubles = ();
+        foreach (grep /\.a$/, keys %{$unified_info{libraries}}) {
+            (my $l = $_) =~ s/\.a$//;
+            push @doubles, $l if defined $unified_info{libraries}->{$l};
         }
+        die "these libraries are both explicitly static and possibly shared:\n  ",
+            join(" ", @doubles), "\n"
+            if @doubles;
 
         foreach (keys %sources) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
             foreach (@{$sources{$dest}}) {
                 my $s = cleanfile($sourced, $_, $blddir);
 
@@ -2049,9 +1975,6 @@ EOF
         foreach (keys %shared_sources) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
             foreach (@{$shared_sources{$dest}}) {
                 my $s = cleanfile($sourced, $_, $blddir);
 
@@ -2090,9 +2013,6 @@ EOF
         foreach (keys %generate) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
             die "more than one generator for $dest: "
                     ,join(" ", @{$generate{$_}}),"\n"
                     if scalar @{$generate{$_}} > 1;
@@ -2109,9 +2029,6 @@ EOF
             # a generated file in the build tree.
             if ($ddest ne "" && ($ddest eq $src_configdata || ! -f $ddest)) {
                 $ddest = cleanfile($buildd, $_, $blddir);
-                if ($unified_info{rename}->{$ddest}) {
-                    $ddest = $unified_info{rename}->{$ddest};
-                }
             }
             foreach (@{$depends{$dest}}) {
                 my $d = cleanfile($sourced, $_, $blddir);
@@ -2135,9 +2052,6 @@ EOF
                 $d =~ /(\.a)?$/;
                 my $e = $1 // "";
                 $d = $`;
-                if ($unified_info{rename}->{$d}) {
-                    $d = $unified_info{rename}->{$d};
-                }
                 $d .= $e;
                 $unified_info{depends}->{$ddest}->{$d} = 1;
             }
@@ -2151,9 +2065,6 @@ EOF
             # a generated file in the build tree.
             if ($ddest eq $src_configdata || ! -f $ddest) {
                 $ddest = cleanfile($buildd, $_, $blddir);
-                if ($unified_info{rename}->{$ddest}) {
-                    $ddest = $unified_info{rename}->{$ddest};
-                }
             }
             foreach (@{$includes{$dest}}) {
                 my $is = cleandir($sourced, $_, $blddir);

--- a/build.info
+++ b/build.info
@@ -1,15 +1,3 @@
-{-
-     use File::Spec::Functions;
-
-     our $sover = $config{shlib_version_number};
-     our $sover_filename = $sover;
-     $sover_filename =~ s|\.|_|g
-         if $config{target} =~ /^mingw/ || $config{target} =~ /^VC-/;
-     $sover_filename =
-         sprintf "%02d%02d", split m|\.|, $config{shlib_version_number}
-         if $config{target} =~ /^vms/;
-     "";
--}
 LIBS=libcrypto libssl
 INCLUDE[libcrypto]=. crypto/include include
 INCLUDE[libssl]=. include
@@ -40,27 +28,4 @@ IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
 
   SHARED_SOURCE[libcrypto]=libcrypto.rc
   SHARED_SOURCE[libssl]=libssl.rc
-ENDIF
-
-IF[{- $config{target} =~ /^Cygwin/ -}]
- SHARED_NAME[libcrypto]=cygcrypto-{- $sover_filename -}
- SHARED_NAME[libssl]=cygssl-{- $sover_filename -}
-ELSIF[{- $config{target} =~ /^mingw/ -}]
- SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
- SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
-ELSIF[{- $config{target} =~ /^VC-/ -}]
- SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $target{multilib} -}
- SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $target{multilib} -}
-ENDIF
-
-# VMS has a cultural standard where all libraries are prefixed.
-# For OpenSSL, the choice is 'ossl$' (this prefix was claimed in a
-# conversation with VSI, Tuesday January 26 2016)
-# Also, it seems it's usual to have the pointer size the libraries
-# were built for as part of the name.
-IF[{- $config{target} =~ /^vms/ -}]
- RENAME[libcrypto]=ossl$libcrypto{- $target{pointer_size} -}
- RENAME[libssl]=ossl$libssl{- $target{pointer_size} -}
- SHARED_NAME[libcrypto]=ossl$libcrypto{- $sover_filename -}_shr{- $target{pointer_size} -}
- SHARED_NAME[libssl]=ossl$libssl{- $sover_filename -}_shr{- $target{pointer_size} -}
 ENDIF


### PR DESCRIPTION
We had the knowledge on exact platform specific shared library names
in the top build.info.  Since the build.info files are supposedly
fairly platform agnostic, this made little sense.

This change moves that knowledge to the build file templates, which
are designed to be much more platform specific.

This also means that we no longer need to have the RENAME and
SHARED_NAME keywords in build.info files, so they become deprecated.
They are still parsed, but will only generate a warning and have no
other effect.
