### PR TITLE
Bug fixes for RAND_add(), RAND_seed() and RAND_load_file()

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -1031,11 +1031,53 @@ static int drbg_bytes(unsigned char *out, int count)
     return ret;
 }
 
+/*
+ * Calculates the minimum length of a full entropy buffer
+ * which is necessary to seed (i.e. instantiate) the DRBG
+ * successfully.
+ *
+ * NOTE: There is a copy of this function in drbgtest.c.
+ *       If you change anything here, you need to update
+ *       the copy accordingly.
+ */
+static size_t rand_drbg_seedlen(RAND_DRBG *drbg)
+{
+    /*
+     * If no os entropy source is available then RAND_seed(buffer, bufsize)
+     * is expected to succeed if and only if the buffer length satisfies
+     * the following requirements, which follow from the calculations
+     * in RAND_DRBG_instantiate().
+     */
+    size_t min_entropy = drbg->strength;
+    size_t min_entropylen = drbg->min_entropylen;
+
+    /*
+     * Extra entropy for the random nonce in the absence of a
+     * get_nonce callback, see comment in RAND_DRBG_instantiate().
+     */
+    if (drbg->min_noncelen > 0 && drbg->get_nonce == NULL) {
+        min_entropy += drbg->strength / 2;
+        min_entropylen += drbg->min_noncelen;
+    }
+
+    /*
+     * Convert entropy requirement from bits to bytes
+     * (dividing by 8 without rounding upwards, because
+     * all entropy requirements are divisible by 8).
+     */
+    min_entropy >>= 3;
+
+    /* Return a value that satisfies both requirements */
+    return min_entropy > min_entropylen ? min_entropy : min_entropylen;
+}
+
 /* Implements the default OpenSSL RAND_add() method */
 static int drbg_add(const void *buf, int num, double randomness)
 {
     int ret = 0;
     RAND_DRBG *drbg = RAND_DRBG_get0_master();
+    size_t buflen;
+    size_t seedlen = rand_drbg_seedlen(drbg);
 
     if (drbg == NULL)
         return 0;
@@ -1043,7 +1085,31 @@ static int drbg_add(const void *buf, int num, double randomness)
     if (num < 0 || randomness < 0.0)
         return 0;
 
-    if (randomness > (double)RAND_DRBG_STRENGTH) {
+    buflen = (size_t)num;
+
+    if (buflen < seedlen || randomness < (double) seedlen) {
+#if defined(OPENSSL_RAND_SEED_NONE)
+        /*
+         * If no os entropy source is available, a reseeding will fail
+         * inevitably. So we use a trick to mix the buffer contents into
+         * the DRBG state without forcing a reseeding: we generate a
+         * dummy random byte, using the buffer content as additional data.
+         */
+        unsigned char dummy[1];
+
+        return RAND_DRBG_generate(drbg, dummy, sizeof(dummy), 0, buf, buflen);
+#else
+        /*
+         * If an os entropy source is avaible then we declare the buffer content
+         * as additional data by setting randomness to zero and trigger a regular
+         * reseeding.
+         */
+        randomness = 0.0;
+#endif
+    }
+
+
+    if (randomness > (double)seedlen) {
         /*
          * The purpose of this check is to bound |randomness| by a
          * relatively small value in order to prevent an integer
@@ -1052,13 +1118,11 @@ static int drbg_add(const void *buf, int num, double randomness)
          * not bits, so this value corresponds to eight times the
          * security strength.
          */
-        randomness = (double)RAND_DRBG_STRENGTH;
+        randomness = (double)seedlen;
     }
 
     rand_drbg_lock(drbg);
-    ret = rand_drbg_restart(drbg, buf,
-                            (size_t)(unsigned int)num,
-                            (size_t)(8*randomness));
+    ret = rand_drbg_restart(drbg, buf, buflen, (size_t)(8 * randomness));
     rand_drbg_unlock(drbg);
 
     return ret;

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -16,6 +16,7 @@
 
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
+#include <openssl/rand_drbg.h>
 #include <openssl/buffer.h>
 
 #ifdef OPENSSL_SYS_VMS
@@ -48,7 +49,7 @@
 #   define S_ISREG(m) ((m) & S_IFREG)
 # endif
 
-#define RAND_FILE_SIZE 1024
+#define RAND_BUF_SIZE 1024
 #define RFILE ".rnd"
 
 #ifdef OPENSSL_SYS_VMS
@@ -74,7 +75,16 @@ static __FILE_ptr32 (*const vms_fopen)(const char *, const char *, ...) =
  */
 int RAND_load_file(const char *file, long bytes)
 {
-    unsigned char buf[RAND_FILE_SIZE];
+    /*
+     * The load buffer size exceeds the chunk size by the comfortable amount
+     * of 'RAND_DRBG_STRENGTH' bytes (not bits!). This is done on purpose
+     * to avoid calling RAND_add() with a small final chunk. Instead, such
+     * a small final chunk will be added together with the previous chunk
+     * (unless it's the only one).
+     */
+#define RAND_LOAD_BUF_SIZE (RAND_BUF_SIZE + RAND_DRBG_STRENGTH)
+    unsigned char buf[RAND_LOAD_BUF_SIZE];
+
 #ifndef OPENSSL_NO_POSIX_IO
     struct stat sb;
 #endif
@@ -98,8 +108,12 @@ int RAND_load_file(const char *file, long bytes)
         return -1;
     }
 
-    if (!S_ISREG(sb.st_mode) && bytes < 0)
-        bytes = 256;
+    if (bytes < 0) {
+        if (S_ISREG(sb.st_mode))
+            bytes = (sb.st_size <= LONG_MAX) ? sb.st_size : LONG_MAX;
+        else
+            bytes = RAND_DRBG_STRENGTH;
+    }
 #endif
     /*
      * On VMS, setbuf() will only take 32-bit pointers, and a compilation
@@ -124,9 +138,9 @@ int RAND_load_file(const char *file, long bytes)
 
     for ( ; ; ) {
         if (bytes > 0)
-            n = (bytes < RAND_FILE_SIZE) ? (int)bytes : RAND_FILE_SIZE;
+            n = (bytes <= RAND_LOAD_BUF_SIZE) ? (int)bytes : RAND_BUF_SIZE;
         else
-            n = RAND_FILE_SIZE;
+            n = RAND_LOAD_BUF_SIZE;
         i = fread(buf, 1, n, in);
 #ifdef EINTR
         if (ferror(in) && errno == EINTR){
@@ -159,7 +173,7 @@ int RAND_load_file(const char *file, long bytes)
 
 int RAND_write_file(const char *file)
 {
-    unsigned char buf[RAND_FILE_SIZE];
+    unsigned char buf[RAND_BUF_SIZE];
     int ret = -1;
     FILE *out = NULL;
 #ifndef OPENSSL_NO_POSIX_IO
@@ -228,9 +242,9 @@ int RAND_write_file(const char *file)
     chmod(file, 0600);
 #endif
 
-    ret = fwrite(buf, 1, RAND_FILE_SIZE, out);
+    ret = fwrite(buf, 1, RAND_BUF_SIZE, out);
     fclose(out);
-    OPENSSL_cleanse(buf, RAND_FILE_SIZE);
+    OPENSSL_cleanse(buf, RAND_BUF_SIZE);
     return ret;
 }
 

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -148,6 +148,12 @@ int RAND_load_file(const char *file, long bytes)
 
     OPENSSL_cleanse(buf, sizeof(buf));
     fclose(in);
+    if (!RAND_status()) {
+        RANDerr(RAND_F_RAND_LOAD_FILE, RAND_R_RESEED_ERROR);
+        ERR_add_error_data(2, "Filename=", file);
+        return -1;
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
~~(Note: this pull request is based on #7455)~~

It turned out that the heap corruption #7449 was only the tip of an iceberg and solving it revealed several other problems. The long story short is

* RAND_add()/RAND_seed() failed for buffer sizes less than 32 bytes (i.e. 256 bits). This bug was introduced by (#7382).
* The error handling was incorrect, which resulted in the heap corruption (fixed by #7455).
* RAND_load_file() currently slices its input in chunks in an inconvenient way such that the final chunk can be small (which casued RAND_add() to fail).
* The failure of RAND_add() went unnoticed by RAND_load_file() because it did not check RAND_status().

This pull request attempts to

* fix RAND_add()/RAND_seed()
* make RAND_load_file() smarter in the way it slices the input
* add more tests

The third part is an essential conclusion from the analysis of #7449: How can it be that such a cardinal error was not caught by a test? It would have gone unnoticed if it hadn't been for the heap corruption to unveil it. So I tried to improve testing. Currently, the tests are commit separately _before_ fixing the issue they address, such that one can test whether the tests work by resetting the HEAD to the respective commit. In the end, I might squash them into the commits which their failures.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated (wip)
