### PR TITLE
Test: link drbgtest statically against libcrypto

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -1044,12 +1044,8 @@ static int drbg_bytes(unsigned char *out, int count)
  * Calculates the minimum length of a full entropy buffer
  * which is necessary to seed (i.e. instantiate) the DRBG
  * successfully.
- *
- * NOTE: There is a copy of this function in drbgtest.c.
- *       If you change anything here, you need to update
- *       the copy accordingly.
  */
-static size_t rand_drbg_seedlen(RAND_DRBG *drbg)
+size_t rand_drbg_seedlen(RAND_DRBG *drbg)
 {
     /*
      * If no os entropy source is available then RAND_seed(buffer, bufsize)

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -304,7 +304,7 @@ extern int rand_fork_count;
 /* DRBG helpers */
 int rand_drbg_restart(RAND_DRBG *drbg,
                       const unsigned char *buffer, size_t len, size_t entropy);
-
+size_t rand_drbg_seedlen(RAND_DRBG *drbg);
 /* locking api */
 int rand_drbg_lock(RAND_DRBG *drbg);
 int rand_drbg_unlock(RAND_DRBG *drbg);

--- a/test/build.info
+++ b/test/build.info
@@ -341,7 +341,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
 
   SOURCE[drbgtest]=drbgtest.c
   INCLUDE[drbgtest]=../include
-  DEPEND[drbgtest]=../libcrypto libtestutil.a
+  DEPEND[drbgtest]=../libcrypto.a libtestutil.a
 
   SOURCE[drbg_cavs_test]=drbg_cavs_test.c drbg_cavs_data_ctr.c \
                          drbg_cavs_data_hash.c drbg_cavs_data_hmac.c

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -884,46 +884,6 @@ static int test_multi_thread(void)
 }
 #endif
 
-#ifdef OPENSSL_RAND_SEED_NONE
-/*
- * Calculates the minimum buffer length which needs to be
- * provided to RAND_seed() in order to successfully
- * instantiate the DRBG.
- *
- * Copied from rand_drbg_seedlen() in rand_drbg.c
- */
-static size_t rand_drbg_seedlen(RAND_DRBG *drbg)
-{
-    /*
-     * If no os entropy source is available then RAND_seed(buffer, bufsize)
-     * is expected to succeed if and only if the buffer length satisfies
-     * the following requirements, which follow from the calculations
-     * in RAND_DRBG_instantiate().
-     */
-    size_t min_entropy = drbg->strength;
-    size_t min_entropylen = drbg->min_entropylen;
-
-    /*
-     * Extra entropy for the random nonce in the absence of a
-     * get_nonce callback, see comment in RAND_DRBG_instantiate().
-     */
-    if (drbg->min_noncelen > 0 && drbg->get_nonce == NULL) {
-        min_entropy += drbg->strength / 2;
-        min_entropylen += drbg->min_noncelen;
-    }
-
-    /*
-     * Convert entropy requirement from bits to bytes
-     * (dividing by 8 without rounding upwards, because
-     * all entropy requirements are divisible by 8).
-     */
-    min_entropy >>= 3;
-
-    /* Return a value that satisfies both requirements */
-    return min_entropy > min_entropylen ? min_entropy : min_entropylen;
-}
-#endif /*OPENSSL_RAND_SEED_NONE*/
-
 /*
  * Test that instantiation with RAND_seed() works as expected
  *

--- a/test/recipes/02-test_internal_ctype.t
+++ b/test/recipes/02-test_internal_ctype.t
@@ -14,7 +14,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_ctype");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_ctype", "ctype_internal_test");

--- a/test/recipes/03-test_internal_asn1.t
+++ b/test/recipes/03-test_internal_asn1.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_asn1");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_asn1", "asn1_internal_test");

--- a/test/recipes/03-test_internal_chacha.t
+++ b/test/recipes/03-test_internal_chacha.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_chacha");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_chacha", "chacha_internal_test", "chacha");

--- a/test/recipes/03-test_internal_curve448.t
+++ b/test/recipes/03-test_internal_curve448.t
@@ -13,9 +13,6 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_curve448");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 plan skip_all => "This test is unsupported in a no-ec build"
     if disabled("ec");
 

--- a/test/recipes/03-test_internal_modes.t
+++ b/test/recipes/03-test_internal_modes.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_modes");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_modes", "modes_internal_test");

--- a/test/recipes/03-test_internal_poly1305.t
+++ b/test/recipes/03-test_internal_poly1305.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_poly1305");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_poly1305", "poly1305_internal_test", "poly1305");

--- a/test/recipes/03-test_internal_siphash.t
+++ b/test/recipes/03-test_internal_siphash.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_siphash");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_siphash", "siphash_internal_test", "siphash");

--- a/test/recipes/03-test_internal_sm2.t
+++ b/test/recipes/03-test_internal_sm2.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_sm2");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_sm2", "sm2_internal_test", "sm2");

--- a/test/recipes/03-test_internal_sm4.t
+++ b/test/recipes/03-test_internal_sm4.t
@@ -14,7 +14,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_sm4");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_sm4", "sm4_internal_test", "sm4");

--- a/test/recipes/03-test_internal_ssl_cert_table.t
+++ b/test/recipes/03-test_internal_ssl_cert_table.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_ssl_cert_table");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_ssl_cert_table", "ssl_cert_table_internal_test");

--- a/test/recipes/03-test_internal_x509.t
+++ b/test/recipes/03-test_internal_x509.t
@@ -13,7 +13,4 @@ use OpenSSL::Test::Utils;
 
 setup("test_internal_x509");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 simple_test("test_internal_x509", "x509_internal_test");

--- a/test/recipes/06-test-rdrand.t
+++ b/test/recipes/06-test-rdrand.t
@@ -15,9 +15,6 @@ use OpenSSL::Test::Utils;
 
 setup("test_rdrand_sanity");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 # We also need static builds to be enabled even on linux
 plan skip_all => "This test is unsupported if static builds are not enabled"
     if disabled("static");

--- a/test/recipes/90-test_tls13encryption.t
+++ b/test/recipes/90-test_tls13encryption.t
@@ -15,9 +15,6 @@ setup($test_name);
 plan skip_all => "$test_name is not supported in this build"
     if disabled("tls1_3");
 
-plan skip_all => "This test is unsupported in a shared library build on Windows"
-    if $^O eq 'MSWin32' && !disabled("shared");
-
 plan tests => 1;
 
 ok(run(test(["tls13encryptiontest"])), "running tls13encryptiontest");


### PR DESCRIPTION
Preparation for #7456, as suggested by @paulidale: https://github.com/openssl/openssl/pull/7456/files#r226880669

I ran the drbgtest several time in random order

```
msp@msppc:~/src/openssl$ make test TESTS=test_rand V=1 OPENSSL_TEST_RAND_ORDER=yes |& grep -E 'ok [0-9]+ - test_'
    ok 1 - test_multi_thread
    ok 2 - test_kats
    ok 3 - test_set_defaults
    ok 4 - test_error_checks
    ok 5 - test_multi_set
    ok 6 - test_rand_reseed
    ok 7 - test_rand_add
    ok 1 - test_cavs_hash
    ok 2 - test_cavs_ctr
    ok 3 - test_cavs_hmac
```