### PR TITLE
fix sess_accept counter tracking

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -962,7 +962,7 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
      */
     if (SSL_IS_FIRST_HANDSHAKE(s) && s->ctx != s->session_ctx) {
         tsan_counter(&s->ctx->stats.sess_accept);
-        tsan_counter(&s->session_ctx->stats.sess_accept);
+        tsan_decr(&s->session_ctx->stats.sess_accept);
     }
 
     /*


### PR DESCRIPTION
Commit 9ef9088c1585e13b9727796f15f77da64dbbe623 changed an "add -1" operation to "add +1", resulting in triple-counting accepted sessions in some cases.