### PR TITLE
RAND: ensure INT32_MAX is defined

### DIFF
--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -17,6 +17,8 @@
 # include <openssl/ec.h>
 # include <openssl/rand_drbg.h>
 
+# include "internal/numbers.h"
+
 /* How many times to read the TSC as a randomness source. */
 # define TSC_READ_COUNT                 4
 


### PR DESCRIPTION
This value is used to set DRBG_MAX_LENGTH
