### PR TITLE
Windows build: build foo.d after foo.obj

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -618,16 +618,14 @@ $obj$objext: $deps
 	\$(CC) /EP /D__ASSEMBLER__ $cflags $srcs > \$@.asm && \$(AS) $asflags \$(ASOUTFLAG)\$\@ \$@.asm
 EOF
      }
-     return <<"EOF"	if (!$disabled{makedepend});
-$obj$depext: $deps
-	\$(CC) $cflags /Zs /showIncludes $srcs 2>&1 > $obj$depext
-$obj$objext: $obj$depext
-	\$(CC) $cflags -c \$(COUTFLAG)\$\@ $srcs
-EOF
-    return <<"EOF"	if ($disabled{makedepend});
+     my $recipe = <<"EOF"
 $obj$objext: $deps
 	\$(CC) $cflags -c \$(COUTFLAG)\$\@ $srcs
 EOF
+     $recipe .= <<"EOF"	if (!$disabled{makedepend});
+	\$(CC) $cflags /Zs /showIncludes $srcs 2>&1 > $obj$depext
+EOF
+     return $recipe;
  }
 
  # We *know* this routine is only called when we've configure 'shared'.

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -618,11 +618,11 @@ $obj$objext: $deps
 	\$(CC) /EP /D__ASSEMBLER__ $cflags $srcs > \$@.asm && \$(AS) $asflags \$(ASOUTFLAG)\$\@ \$@.asm
 EOF
      }
-     my $recipe = <<"EOF"
+     my $recipe = <<"EOF";
 $obj$objext: $deps
 	\$(CC) $cflags -c \$(COUTFLAG)\$\@ $srcs
 EOF
-     $recipe .= <<"EOF"	if (!$disabled{makedepend});
+     $recipe .= <<"EOF"	unless $disabled{makedepend};
 	\$(CC) $cflags /Zs /showIncludes $srcs 2>&1 > $obj$depext
 EOF
      return $recipe;


### PR DESCRIPTION
We made the build of foo.obj depend on foo.d, meaning the latter gets
built first.  Unfortunately, the way the compiler works, we are forced
to redirect all output to foo.d, meaning that if the source contains
an error, the build fails without showing those errors.

We therefore remove the dependency and force the build of foo.d to
always happen after build of foo.obj.
