### PR TITLE
Rework building - standard file extensions and product names

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -164,10 +164,10 @@ my %targets=(
                     return [ @incs ];
                 }),
 
-        shared_extension => ".exe",
-
         build_file       => "descrip.mms",
         build_scheme     => [ "unified", "VMS" ],
+
+        perl_platform    => 'VMS',
     },
 
     uplink_common => {

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -144,10 +144,10 @@ my %targets=(
         mtinflag        => "-manifest ",
         mtoutflag       => "-outputresource:",
 
-        shared_extension => ".dll",
-
         build_file      => "makefile",
         build_scheme    => [ "unified", "windows" ],
+
+        perl_platform   => 'Windows',
     },
 
     BASE_VMS => {

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -42,7 +42,6 @@ my %targets=(
 	shared_defines	=> [],
 	shared_ldflag	=> "",
 	shared_rcflag	=> "",
-	shared_extension	=> "",
 
 	#### Defaults for the benefit of the config targets who don't inherit
 	#### a BASE and assume Unix defaults
@@ -102,10 +101,10 @@ my %targets=(
                                      ? "ranlib" : "" },
         RC              => "windres",
 
-        shared_extension => ".so",
-
         build_scheme    => [ "unified", "unix" ],
         build_file      => "Makefile",
+
+        perl_platform   => 'Unix',
     },
 
     BASE_Windows => {

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1235,6 +1235,7 @@ my %targets = (
         dso_scheme       => "win32",
         apps_aux_src     => add("win32_init.c"),
         bn_ops           => "EXPORT_VAR_AS_FN",
+        perl_platform    => 'Windows::MSVC',
         # additional parameter to build_scheme denotes install-path "flavour"
         build_scheme     => add("VC-common", { separator => undef }),
     },

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -212,7 +212,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         thread_scheme    => "pthreads",
         shared_target    => "solaris",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         shared_ldflag    => "-Wl,-Bsymbolic",
         shared_defflag   => "-Wl,-M,",
         shared_sonameflag=> "-Wl,-h,",
@@ -365,7 +364,6 @@ my %targets = (
         thread_scheme    => "pthreads",
         dso_scheme       => "dlfcn",
         shared_target    => "self",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         shared_ldflag    => "-shared -Wl,-Bsymbolic",
         shared_sonameflag=> "-Wl,-soname,",
     },
@@ -534,7 +532,6 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT",
         shared_cflag     => "+Z",
         shared_ldflag    => add_before("-b"),
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux32",
     },
     "hpux64-ia64-cc" => {
@@ -548,7 +545,6 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         shared_cflag     => "+Z",
         shared_ldflag    => add_before("-b"),
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux64",
     },
     # GCC builds...
@@ -562,7 +558,6 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT",
         shared_cflag     => "-fpic",
         shared_ldflag    => add_before("-shared"),
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux32",
     },
     "hpux64-ia64-gcc" => {
@@ -575,7 +570,6 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         shared_cflag     => "-fpic",
         shared_ldflag    => add_before("-shared"),
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "/hpux64",
     },
 
@@ -652,7 +646,6 @@ my %targets = (
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => sub { $disabled{pinshared} ? () : "-Wl,-znodelete" },
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         enable           => [ "afalgeng" ],
     },
     "linux-generic64" => {
@@ -906,7 +899,6 @@ my %targets = (
         shared_target    => "linux-shared",
         shared_cflag     => "--pic",
         shared_ldflag    => add("-z --sysv --shared"),
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         ranlib           => "true",
     },
 
@@ -933,7 +925,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "BSD-generic64" => {
         inherit_from     => [ "BSD-generic32" ],
@@ -991,7 +982,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
     "nextstep" => {
@@ -1052,7 +1042,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "svr5-shared",
         shared_cflag     => "-Kpic",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "unixware-7-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
@@ -1067,7 +1056,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "gnu-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 # SCO 5 - Ben Laurie says the -O breaks the SCO cc.
     "sco5-cc" => {
@@ -1080,7 +1068,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "svr3-shared",
         shared_cflag     => "-Kpic",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "sco5-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
@@ -1093,7 +1080,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "svr3-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
 #### IBM's AIX.
@@ -1114,8 +1100,6 @@ my %targets = (
         module_ldflags   => "-Wl,-G,-bsymbolic,-bexpall",
         shared_ldflag    => "-Wl,-G,-bsymbolic",
         shared_defflag   => "-Wl,-bE:",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
-        dso_extension    => ".so",
         lib_extension    => shared("_a.a"),
         shared_extension_simple => shared(".a"),
     },
@@ -1376,30 +1360,37 @@ my %targets = (
     },
 
 #### MinGW
-    "mingw" => {
-        inherit_from     => [ "BASE_unix", asm("x86_asm"),
-                              sub { $disabled{shared} ? () : "x86_uplink" } ],
+    "mingw-common" => {
+        inherit_from     => [ 'BASE_unix' ],
+        template         => 1,
         CC               => "gcc",
         CFLAGS           => picker(default => "-Wall",
                                    debug   => "-g -O0",
-                                   release => "-O3 -fomit-frame-pointer"),
-        cflags           => "-m32",
+                                   release => "-O3"),
         cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
                                     threads("-D_MT")),
         lib_cppflags     => "-DL_ENDIAN",
-        sys_id           => "MINGW32",
         ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
-        bn_ops           => "BN_LLONG EXPORT_VAR_AS_FN",
+        bn_ops           => "EXPORT_VAR_AS_FN",
         thread_scheme    => "winthreads",
-        perlasm_scheme   => "coff",
         dso_scheme       => "win32",
         shared_target    => "mingw-shared",
         shared_cppflags  => add("_WINDLL"),
         shared_ldflag    => "-static-libgcc",
-        shared_rcflag    => "--target=pe-i386",
-        shared_extension => ".dll",
-        multilib         => "",
         apps_aux_src     => add("win32_init.c"),
+
+        perl_platform    => 'mingw',
+    },
+    "mingw" => {
+        inherit_from     => [ "mingw-common", asm("x86_asm"),
+                              sub { $disabled{shared} ? () : "x86_uplink" } ],
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+        cflags           => "-m32",
+        sys_id           => "MINGW32",
+        bn_ops           => add("BN_LLONG"),
+        perlasm_scheme   => "coff",
+        shared_rcflag    => "--target=pe-i386",
+        multilib         => "",
     },
     "mingw64" => {
         # As for OPENSSL_USE_APPLINK. Applink makes it possible to use
@@ -1410,28 +1401,13 @@ my %targets = (
         # consider its binaries for using with non-mingw64 run-time
         # environment. And as mingw64 is always consistent with itself,
         # Applink is never engaged and can as well be omitted.
-        inherit_from     => [ "BASE_unix", asm("x86_64_asm") ],
-        CC               => "gcc",
-        CFLAGS           => picker(default => "-Wall",
-                                   debug   => "-g -O0",
-                                   release => "-O3"),
+        inherit_from     => [ "mingw-common", asm("x86_64_asm") ],
         cflags           => "-m64",
-        cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
-                                    threads("-D_MT")),
-        lib_cppflags     => "-DL_ENDIAN",
         sys_id           => "MINGW64",
-        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
-        bn_ops           => "SIXTY_FOUR_BIT EXPORT_VAR_AS_FN",
-        thread_scheme    => "winthreads",
+        bn_ops           => add("SIXTY_FOUR_BIT"),
         perlasm_scheme   => "mingw64",
-        dso_scheme       => "win32",
-        shared_target    => "mingw-shared",
-        shared_cppflags  => add("_WINDLL"),
-        shared_ldflag    => "-static-libgcc",
         shared_rcflag    => "--target=pe-x86-64",
-        shared_extension => ".dll",
         multilib         => "64",
-        apps_aux_src     => add("win32_init.c"),
     },
 
 #### UEFI
@@ -1455,37 +1431,34 @@ my %targets = (
     },
 
 #### Cygwin
-    "Cygwin-x86" => {
+    "Cygwin-common" => {
         inherit_from     => [ "BASE_unix", asm("x86_asm") ],
-        CC               => "gcc",
-        CFLAGS           => picker(default => "-Wall",
-                                   debug   => "-g -O0",
-                                   release => "-O3 -fomit-frame-pointer"),
-        lib_cppflags     => "-DTERMIOS -DL_ENDIAN",
-        sys_id           => "CYGWIN",
-        bn_ops           => "BN_LLONG",
-        thread_scheme    => "pthread",
-        perlasm_scheme   => "coff",
-        dso_scheme       => "dlfcn",
-        shared_target    => "cygwin-shared",
-        shared_cppflags  => "-D_WINDLL",
-        shared_extension => ".dll",
-    },
-    "Cygwin-x86_64" => {
-        inherit_from     => [ "BASE_unix", asm("x86_64_asm") ],
+        template         => 1,
+
         CC               => "gcc",
         CFLAGS           => picker(default => "-Wall",
                                    debug   => "-g -O0",
                                    release => "-O3"),
         lib_cppflags     => "-DTERMIOS -DL_ENDIAN",
         sys_id           => "CYGWIN",
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
         thread_scheme    => "pthread",
-        perlasm_scheme   => "mingw64",
         dso_scheme       => "dlfcn",
         shared_target    => "cygwin-shared",
         shared_cppflags  => "-D_WINDLL",
-        shared_extension => ".dll",
+
+        perl_platform    => 'Cygwin',
+    },
+    "Cygwin-x86" => {
+        inherit_from     => [ "Cygwin-common", asm("x86_asm") ],
+        CFLAGS           => add(picker(release => "-O3 -fomit-frame-pointer")),
+        bn_ops           => "BN_LLONG",
+        perlasm_scheme   => "coff",
+    },
+    "Cygwin-x86_64" => {
+        inherit_from     => [ "Cygwin-common", asm("x86_64_asm") ],
+        CC               => "gcc",
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "mingw64",
     },
     # Backward compatibility for those using this target
     "Cygwin" => {
@@ -1572,7 +1545,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
 
 ##### VxWorks for various targets
@@ -1688,7 +1660,6 @@ my %targets = (
         dso_scheme       => sub { env('LIBSSL_dlfcn') },
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         ranlib           => sub { env('RANLIB') },
     },
     "uClinux-dist64" => {
@@ -1701,7 +1672,6 @@ my %targets = (
         dso_scheme       => sub { env('LIBSSL_dlfcn') },
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         ranlib           => sub { env('RANLIB') },
     },
 

--- a/Configurations/50-haiku.conf
+++ b/Configurations/50-haiku.conf
@@ -15,7 +15,7 @@ my %targets = (
         shared_target    => "gnu-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-shared",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
+        perl_platform    => 'Unix',
     },
     "haiku-x86" => {
         inherit_from     => [ "haiku-common", asm("x86_elf_asm") ],

--- a/Configurations/90-team.norelease.conf
+++ b/Configurations/90-team.norelease.conf
@@ -28,7 +28,6 @@ my %targets = (
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => "-m64",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         multilib         => "64",
     },
     "debug-linux-pentium" => {
@@ -77,7 +76,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "debug-test-64-clang" => {
         inherit_from     => [ 'BASE_unix', "x86_64_asm" ],
@@ -90,7 +88,6 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "bsd-gcc-shared",
         shared_cflag     => "-fPIC",
-        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
     },
     "darwin64-debug-test-64-clang" => {
         inherit_from     => [ 'BASE_unix', "x86_64_asm" ],

--- a/Configurations/README
+++ b/Configurations/README
@@ -446,23 +446,6 @@ support building static libraries and DLLs at the same time, so using
 static libraries on Windows can only be done when configured
 'no-shared'.
 
-One some platforms, shared libraries come with a name that's different
-from their static counterpart.  That's declared as follows:
-
-    SHARED_NAME[libfoo]=cygfoo-{- $config{shlibver} -}
-
-The example is from Cygwin, which has a required naming convention.
-
-Sometimes, it makes sense to rename an output file, for example a
-library:
-
-    RENAME[libfoo]=libbar
-
-That line has "libfoo" renamed to "libbar".  While it makes no
-sense at all to just have a rename like that (why not just use
-"libbar" everywhere?), it does make sense when it can be used
-conditionally.  See a little further below for an example.
-
 In some cases, it's desirable to include some source files in the
 shared form of a library only:
 
@@ -569,15 +552,6 @@ conditions based on something in the passed variables, for example:
     ELSE
       LIBS=libfoo
       SOURCE[libfoo]=...
-    ENDIF
-
-or:
-
-    # VMS has a cultural standard where all libraries are prefixed.
-    # For OpenSSL, the choice is 'ossl_'
-    IF[{- $config{target} =~ /^vms/ -}]
-     RENAME[libcrypto]=ossl_libcrypto
-     RENAME[libssl]=ossl_libssl
     ENDIF
 
 

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -129,8 +129,7 @@
      return "" if $cache{$lib};
      unless ($disabled{shared} || $lib =~ /\.a$/) {
          my $obj2shlib = defined &obj2shlib ? \&obj2shlib : \&libobj2shlib;
-         $OUT .= $obj2shlib->(shlib => $unified_info{sharednames}->{$lib},
-                              lib => $lib,
+         $OUT .= $obj2shlib->(lib => $lib,
                               objs => $unified_info{shared_sources}->{$lib},
                               deps => [ reducedepends(resolvedepends($lib)) ],
                               installed => is_installed($lib));

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -5,10 +5,7 @@
   use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs/;
   use File::Basename;
 
-  # Our prefix, claimed when speaking with the VSI folks Tuesday
-  # January 26th 2016
-  our $osslprefix = 'OSSL$';
-  (our $osslprefix_q = $osslprefix) =~ s/\$/\\\$/;
+  (our $osslprefix_q = platform->osslprefix()) =~ s/\$/\\\$/;
 
   our $sover_dirname = sprintf "%02d%02d", split(/\./, $config{shlib_version});
   our $osslver = sprintf "%02d%02d", split(/\./, $config{version});
@@ -44,27 +41,27 @@
   # Because we need to make two computations of these data,
   # we store them in arrays for reuse
   our @libs =
-      map { (my $x = $_) =~ s/\.a$//; $x }
+      map { platform->staticname($_) }
       @{$unified_info{libraries}};
   our @shlibs =
-      map { $unified_info{sharednames}->{$_} || () }
-      grep(!/\.a$/, @{$unified_info{libraries}});
+      map { platform->sharedname($_) // () }
+      @{$unified_info{libraries}};
   our @install_libs =
-      map { (my $x = $_) =~ s/\.a$//; $x }
+      map { platform->staticname($_) }
       @{$unified_info{install}->{libraries}};
   our @install_shlibs =
-      map { $unified_info{sharednames}->{$_} || () }
-      grep(!/\.a$/, @{$unified_info{install}->{libraries}});
+      map { platform->sharedname($_) // () }
+      @{$unified_info{install}->{libraries}};
 
   # This is a horrible hack, but is needed because recursive inclusion of files
   # in different directories does not work well with HP C.
   my $sd = sourcedir("crypto", "async", "arch");
   foreach (grep /\[\.crypto\.async\.arch\].*\.o$/, keys %{$unified_info{sources}}) {
-      (my $x = $_) =~ s|\.o$|.OBJ|;
-      $unified_info{before}->{$x}
+      my $obj = platform->obj($_);
+      $unified_info{before}->{$obj}
           = qq(arch_include = F\$PARSE("$sd","A.;",,,"SYNTAX_ONLY") - "A.;"
         define arch 'arch_include');
-      $unified_info{after}->{$x}
+      $unified_info{after}->{$obj}
           = qq(deassign arch);
   }
   my $sd1 = sourcedir("ssl","record");
@@ -72,13 +69,13 @@
   my @ssl_locl_users = grep(/^\[\.(?:ssl\.(?:record|statem)|test)\].*\.o$/,
                             keys %{$unified_info{sources}});
   foreach (@ssl_locl_users) {
-      (my $x = $_) =~ s|\.o$|.OBJ|;
-      $unified_info{before}->{$x}
+      my $obj = platform->obj($_);
+      $unified_info{before}->{$obj}
           = qq(record_include = F\$PARSE("$sd1","A.;",,,"SYNTAX_ONLY") - "A.;"
         define record 'record_include'
         statem_include = F\$PARSE("$sd2","A.;",,,"SYNTAX_ONLY") - "A.;"
         define statem 'statem_include');
-      $unified_info{after}->{$x}
+      $unified_info{after}->{$obj}
           = qq(deassign statem
         deassign record);
   }
@@ -110,30 +107,20 @@ MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
 SHLIB_TARGET={- $target{shared_target} -}
 
-EXE_EXT=.EXE
-LIB_EXT=.OLB
-SHLIB_EXT=.EXE
-OBJ_EXT=.OBJ
-DEP_EXT=.D
-
 LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @libs) -}
 SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @shlibs) -}
 ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{engines}}) -}
 PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(", ", map { "-\n\t".$_ } @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}
-DEPS={- our @deps = map { (my $x = $_) =~ s|\.o$|\$(DEP_EXT)|; $x; }
+DEPS={- our @deps = map { platform->isobj($_) ? platform->dep($_) : $_ }
                     grep { $unified_info{sources}->{$_}->[0] =~ /\.c$/ }
                     keys %{$unified_info{sources}};
         join(", ", map { "-\n\t".$_ } @deps); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(", ", map { "-\n\t".$_ } @{$unified_info{depends}->{""}} ) -}
 GENERATED={- # common0.tmpl provides @generated
-             join(", ", map { my $x = $_;
-                              $x =~ s|\.[sS]$|.asm|;
-                              $x =~ s|\.ld$|.OPT|;
-                              "-\n\t".$x }
-                        @generated) -}
+             join(", ", map { platform->convertext($_) } @generated) -}
 
 INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}
 INSTALL_SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @install_shlibs) -}
@@ -165,9 +152,9 @@ OPENSSLDIR={- catdir($config{openssldir}) or
               $config{prefix} ? catdir($config{prefix},"COMMON")
                               : "SYS\$COMMON:[OPENSSL-COMMON]" -}
 # The same, but for C
-OPENSSLDIR_C={- $osslprefix -}DATAROOT:[000000]
+OPENSSLDIR_C={- platform->osslprefix() -}DATAROOT:[000000]
 # Where installed engines reside, for C
-ENGINESDIR_C={- $osslprefix -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
+ENGINESDIR_C={- platform->osslprefix() -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
 ##### User defined commands and flags ################################
 
@@ -694,12 +681,10 @@ reconfigure reconf :
   # Helper function to figure out dependencies on libraries
   # It takes a list of library names and outputs a list of dependencies
   sub compute_lib_depends {
-      if ($disabled{shared}) {
-          return map { $_ =~ /\.a$/ ? $`.".OLB" : $_.".OLB" } @_;
-      }
-      return map { $_ =~ /\.a$/
-                   ? $`.".OLB"
-                   : $unified_info{sharednames}->{$_}.".EXE" } @_;
+      # Depending on shared libraries:
+      # On Windows POSIX layers, we depend on {libname}.dll.a
+      # On Unix platforms, we depend on {shlibname}.so
+      return map { platform->sharedlib($_) // platform->staticlib($_) } @_;
   }
 
   # Helper function to deal with inclusion directory specs.
@@ -750,8 +735,8 @@ reconfigure reconf :
       my $generator_incs = join("", map { ' "-I'.$_.'"' } @{$args{generator_incs}});
       my $deps = join(", -\n\t\t", @{$args{generator_deps}}, @{$args{deps}});
 
-      if ($args{src} =~ /\.ld$/) {
-          (my $target = $args{src}) =~ s/\.ld$/.OPT/;
+      if (platform->isdef($args{src})) {
+          my $target = platform->def($args{src});
           my $mkdef = sourcefile('util', 'mkdef.pl');
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
           my $ord_name =
@@ -763,7 +748,7 @@ reconfigure reconf :
 $target : $args{generator}->[0] $deps $mkdef
 	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS"$case_insensitive > $target
 EOF
-      } elsif ($args{src} !~ /\.[sS]$/) {
+      } elsif (!platform->isasm($args{src})) {
           my $target = $args{src};
           if ($args{generator}->[0] =~ m|^.*\.in$|) {
 	      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
@@ -781,7 +766,7 @@ $target : $args{generator}->[0] $deps
 EOF
 	  }
       } else {
-          (my $target = $args{src}) =~ s/\.[sS]$/.asm/;
+          my $target = platform->asm($args{src});
           if ($args{generator}->[0] =~ /\.pl$/) {
               $generator = '$(PERL)'.$generator_incs.' '.$generator;
           } elsif ($args{generator}->[0] =~ /\.S$/) {
@@ -844,9 +829,8 @@ EOF
 
   sub src2obj {
       my %args = @_;
-      my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x
-                     } ( @{$args{srcs}} );
-      (my $obj = $args{obj}) =~ s|\.o$||;
+      my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x } ( @{$args{srcs}} );
+      my $obj = platform->obj($args{obj});
       my $deps = join(", -\n\t\t", @srcs, @{$args{deps}});
 
       # Because VMS C isn't very good at combining a /INCLUDE path with
@@ -858,11 +842,25 @@ EOF
       my $forward = dirname($args{srcs}->[0]);
       my $backward = abs2rel(rel2abs("."), rel2abs($forward));
       my $objd = abs2rel(rel2abs(dirname($obj)), rel2abs($forward));
-      my $objn = basename($obj);
+      my $objn = basename($obj, platform->objext());
       my $srcs =
           join(", ", map { abs2rel(rel2abs($_), rel2abs($forward)) } @srcs);
-      my $before = $unified_info{before}->{$obj.".OBJ"} || "\@ !";
-      my $after = $unified_info{after}->{$obj.".OBJ"} || "\@ !";
+      my $before = $unified_info{before}->{$obj} || "\@ !";
+      my $after = $unified_info{after}->{$obj} || "\@ !";
+
+      if ($srcs[0] =~ /\.asm$/) {
+          my $asflags = { shlib => ' $(LIB_ASFLAGS)',
+		          lib => ' $(LIB_ASFLAGS)',
+		          dso => ' $(DSO_ASFLAGS)',
+		          bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
+          return <<"EOF";
+$obj : $deps
+        ${before}
+        SET DEFAULT $forward
+        \$(AS) $asflags \$(ASOUTFLAG)${objd}${objn}.OBJ $srcs
+        SET DEFAULT $backward
+EOF
+      }
 
       my $cflags;
       if ($args{installed}) {
@@ -928,10 +926,10 @@ EOF
       }
 
       my $depbuild = $disabled{makedepend} ? ""
-          : " /MMS=(FILE=${objd}${objn}.D,TARGET=$obj.OBJ)";
+          : " /MMS=(FILE=${objd}${objn}.D,TARGET=$obj)";
 
       return <<"EOF";
-$obj.OBJ : $deps
+$obj : $deps
         ${before}
         SET DEFAULT $forward
         \@ $incs_on
@@ -941,20 +939,18 @@ $obj.OBJ : $deps
         \@ $incs_off
         SET DEFAULT $backward
         ${after}
-        - PURGE $obj.OBJ
+        - PURGE $obj
 EOF
   }
   sub obj2shlib {
       my %args = @_;
-      my $lib = $args{lib};
-      my $shlib = $args{shlib};
-      my $libd = dirname($lib);
-      my $libn = basename($lib);
-      my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x }
-                 grep { $_ =~ m|\.o$| }
+      my $shlibname = platform->sharedname($args{lib});
+      my $shlib = platform->sharedlib($args{lib});
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) }
                  @{$args{objs}};
-      my @defs = map { (my $x = $_) =~ s|\.ld$|.OPT|; $x }
-                 grep { $_ =~ m|\.ld$| }
+      my @defs = map { platform->convertext($_) }
+                 grep { platform->isdef($_) }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       die "More than one symbol vector" if scalar @defs > 1;
@@ -978,16 +974,16 @@ EOF
                              "WRITE OPT_FILE \"$x\"" } @deps)
           || "\@ !";
       return <<"EOF"
-$shlib.EXE : $deps
+$shlib : $deps
         \$(PERL) $translatesyms_pl \$(BLDDIR)CXX\$DEMANGLER_DB. < $defs[0] > $defs[0]-translated
-        OPEN/WRITE/SHARE=READ OPT_FILE $lib-components.OPT
+        OPEN/WRITE/SHARE=READ OPT_FILE $shlibname-components.OPT
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
         LINK \$(LIB_LDFLAGS)/SHARE=\$\@ $defs[0]-translated/OPT,-
-                $lib-components.OPT/OPT \$(LIB_EX_LIBS)
-        DELETE $defs[0]-translated;*,$lib-components.OPT;*
-        PURGE $shlib.EXE,$shlib.MAP
+                $shlibname-components.OPT/OPT \$(LIB_EX_LIBS)
+        DELETE $defs[0]-translated;*,$shlibname-components.OPT;*
+        PURGE $shlibname.EXE,$shlibname.MAP
 EOF
         . ($config{target} =~ m|alpha| ? "" : <<"EOF"
         SET IMAGE/FLAGS=(NOCALL_DEBUG) \$\@
@@ -996,15 +992,13 @@ EOF
   }
   sub obj2dso {
       my %args = @_;
-      my $lib = $args{lib};
-      my $libd = dirname($lib);
-      my $libn = basename($lib);
-      (my $libn_nolib = $libn) =~ s/^lib//;
-      my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x }
-                 grep { $_ =~ m|\.o$| }
+      my $dsoname = platform->dsoname($args{lib});
+      my $dso = platform->dso($args{lib});
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) }
                  @{$args{objs}};
-      my @defs = map { (my $x = $_) =~ s|\.ld$|.OPT|; $x }
-                 grep { $_ =~ m|\.ld$| }
+      my @defs = map { platform->convertext($_) }
+                 grep { platform->isdef($_) }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       my $deps = join(", -\n\t\t", @objs, @defs, @deps);
@@ -1025,14 +1019,14 @@ EOF
                              "WRITE OPT_FILE \"$x\"" } @deps)
           || "\@ !";
       return <<"EOF"
-$lib.EXE : $deps
-        OPEN/WRITE/SHARE=READ OPT_FILE $lib-components.OPT
+$dso : $deps
+        OPEN/WRITE/SHARE=READ OPT_FILE $dsoname-components.OPT
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
         LINK \$(DSO_LDFLAGS)/SHARE=\$\@ $defs[0]/OPT,-
-		$lib-components.OPT/OPT \$(DSO_EX_LIBS)
-        - PURGE $lib.EXE,$lib.OPT,$lib.MAP
+		$dsoname-components.OPT/OPT \$(DSO_EX_LIBS)
+        - PURGE $dsoname.EXE,$dsoname.OPT,$dsoname.MAP
 EOF
         . ($config{target} =~ m|alpha| ? "" : <<"EOF"
         SET IMAGE/FLAGS=(NOCALL_DEBUG) \$\@
@@ -1041,24 +1035,26 @@ EOF
   }
   sub obj2lib {
       my %args = @_;
-      (my $lib = $args{lib}) =~ s/\.a$//;
-      my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x } @{$args{objs}};
+      my $lib = platform->staticlib($args{lib});
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) }
+                 @{$args{objs}};
       my $objs = join(", -\n\t\t", @objs);
-      my $fill_lib = join("\n\t", (map { "LIBRARY/REPLACE $lib.OLB $_" }
-                                   @objs));
+      my $fill_lib = join("\n\t", (map { "LIBRARY/REPLACE $lib $_" } @objs));
       return <<"EOF";
-$lib.OLB : $objs
-        LIBRARY/CREATE/OBJECT $lib.OLB
+$lib : $objs
+        LIBRARY/CREATE/OBJECT $lib
         $fill_lib
-        - PURGE $lib.OLB
+        - PURGE $lib
 EOF
   }
   sub obj2bin {
       my %args = @_;
-      my $bin = $args{bin};
-      my $bind = dirname($bin);
-      my $binn = basename($bin);
-      my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x } @{$args{objs}};
+      my $bin = platform->bin($args{bin});
+      my $binname = platform->binname($args{bin});
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) }
+                 @{$args{objs}};
       my $objs = join(",", @objs);
       my @deps = compute_lib_depends(@{$args{deps}});
       my $deps = join(", -\n\t\t", @objs, @deps);
@@ -1113,19 +1109,19 @@ EOF
       # isn't necessary.  If there are other warnings, however, we show them
       # and let it break the build.
       return <<"EOF"
-$bin.EXE : $deps
+$bin : $deps
         $analyse_objs
-        @ OPEN/WRITE/SHARE=READ OPT_FILE $bin.OPT
+        @ OPEN/WRITE/SHARE=READ OPT_FILE $binname.OPT
         $write_opt1
         $write_opt2
         @ CLOSE OPT_FILE
-        TYPE $bin.opt ! For debugging
-        - pipe SPAWN/WAIT/NOLOG/OUT=$bin.LINKLOG -
-                    LINK \$(BIN_LDFLAGS)/EXEC=\$\@ $bin.OPT/OPT \$(BIN_EX_LIBS) ; -
+        TYPE $binname.OPT ! For debugging
+        - pipe SPAWN/WAIT/NOLOG/OUT=$binname.LINKLOG -
+                    LINK \$(BIN_LDFLAGS)/EXEC=\$\@ $binname.OPT/OPT \$(BIN_EX_LIBS) ; -
                link_status = \$status ; link_severity = link_status .AND. 7
         @ search_severity = 1
         -@ IF link_severity .EQ. 0 THEN -
-                pipe SEARCH $bin.LINKLOG "%","-"/MATCH=AND | -
+                pipe SEARCH $binname.LINKLOG "%","-"/MATCH=AND | -
                      SPAWN/WAIT/NOLOG/OUT=NLA0: -
                           SEARCH SYS\$INPUT: "-W-MULDEF,"/MATCH=NOR ; -
                      search_severity = \$severity
@@ -1136,10 +1132,10 @@ $bin.EXE : $deps
         @ IF search_severity .EQ. 3 THEN link_severity = 1
         @ ! At this point, if link_severity shows that there was a fault
         @ ! or warning, make sure to restore the linking status.
-        -@ IF .NOT. link_severity THEN TYPE $bin.LINKLOG
-        -@ DELETE $bin.LINKLOG;*
+        -@ IF .NOT. link_severity THEN TYPE $binname.LINKLOG
+        -@ DELETE $binname.LINKLOG;*
         @ IF .NOT. link_severity THEN SPAWN/WAIT/NOLOG EXIT 'link_status'
-        - PURGE $bin.EXE,$bin.OPT
+        - PURGE $bin,$binname.OPT
 EOF
       . ($config{target} =~ m|alpha| ? "" : <<"EOF"
         SET IMAGE/FLAGS=(NOCALL_DEBUG) \$\@

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -7,7 +7,7 @@
 
   (our $osslprefix_q = platform->osslprefix()) =~ s/\$/\\\$/;
 
-  our $sover_dirname = sprintf "%02d%02d", split(/\./, $config{shlib_version});
+  our $sover_dirname = platform->shlib_version_as_filename();
   our $osslver = sprintf "%02d%02d", split(/\./, $config{version});
 
   our $sourcedir = $config{sourcedir};

--- a/Configurations/platform.pm
+++ b/Configurations/platform.pm
@@ -1,0 +1,18 @@
+package platform;
+
+use strict;
+use warnings;
+use vars qw(@ISA);
+
+# Callers must make sure @INC has the build directory
+use configdata;
+
+my $module = $target{perl_platform} || 'Unix';
+(my $module_path = $module) =~ s|::|/|g;
+
+require "platform/$module_path.pm";
+@ISA = ("platform::$module");
+
+1;
+
+__END__

--- a/Configurations/platform/BASE.pm
+++ b/Configurations/platform/BASE.pm
@@ -27,6 +27,10 @@ sub dsoname     { return $_[1] } # Name of dynamic shared object (DSO)
 sub sharedname  { return __isshared($_[1]) ? $_[1] : undef } # Name of shared lib
 sub staticname  { return __base($_[1], '.a') } # Name of static lib
 
+# Convenience function to convert the shlib version to an acceptable part
+# of a file or directory name.
+sub shlib_version_as_filename { return $_[1] }
+
 # Convenience functions to convert the possible extension of an input file name
 sub bin         { return $_[0]->binname($_[1]) . $_[0]->binext() }
 sub dso         { return $_[0]->dsoname($_[1]) . $_[0]->dsoext() }

--- a/Configurations/platform/BASE.pm
+++ b/Configurations/platform/BASE.pm
@@ -1,0 +1,92 @@
+package platform::BASE;
+
+use strict;
+use warnings;
+use Carp;
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+# Globally defined "platform specific" extensions, available for uniformity
+sub depext      { '.d' }
+
+# Functions to convert internal file representations to platform specific
+# ones.  Note that these all depend on extension functions that MUST be
+# defined per platform.
+#
+# Currently known internal or semi-internal extensions are:
+#
+# .a            For libraries that are made static only.
+#               Internal libraries only.
+# .o            For object files.
+# .s, .S        Assembler files.  This is an actual extension on Unix
+# .res          Resource file.  This is an actual extension on Windows
+
+sub binname     { return $_[1] } # Name of executable binary
+sub dsoname     { return $_[1] } # Name of dynamic shared object (DSO)
+sub sharedname  { return __isshared($_[1]) ? $_[1] : undef } # Name of shared lib
+sub staticname  { return __base($_[1], '.a') } # Name of static lib
+
+# Convenience functions to convert the possible extension of an input file name
+sub bin         { return $_[0]->binname($_[1]) . $_[0]->binext() }
+sub dso         { return $_[0]->dsoname($_[1]) . $_[0]->dsoext() }
+sub sharedlib   { return __concat($_[0]->sharedname($_[1]), $_[0]->shlibext()) }
+sub staticlib   { return $_[0]->staticname($_[1]) . $_[0]->libext() }
+
+# More convenience functions for intermediary files
+sub def         { return __base($_[1], '.ld') . $_[0]->defext() }
+sub obj         { return __base($_[1], '.o') . $_[0]->objext() }
+sub res         { return __base($_[1], '.res') . $_[0]->resext() }
+sub dep         { return __base($_[1], '.o') . $_[0]->depext() } # <- objname
+sub asm         { return __base($_[1], '.S', '.s') . $_[0]->asmext() }
+
+# Another set of convenience functions for standard checks of certain
+# internal extensions and conversion from internal to platform specific
+# extension.  Note that the latter doesn't deal with libraries because
+# of ambivalence
+sub isdef       { return $_[1] =~ m|\.ld$|;   }
+sub isobj       { return $_[1] =~ m|\.o$|;    }
+sub isres       { return $_[1] =~ m|\.res$|;  }
+sub isasm       { return $_[1] =~ m|\.[Ss]$|; }
+sub convertext {
+    if ($_[0]->isdef($_[1]))    { return $_[0]->def($_[1]); }
+    if ($_[0]->isobj($_[1]))    { return $_[0]->obj($_[1]); }
+    if ($_[0]->isres($_[1]))    { return $_[0]->res($_[1]); }
+    if ($_[0]->isasm($_[1]))    { return $_[0]->asm($_[1]); }
+    return $_[1];
+}
+
+# Helpers ############################################################
+
+# __base EXPR, LIST
+# This returns the given path (EXPR) with the matching suffix from LIST stripped
+sub __base {
+    my $path = shift;
+    foreach (@_) {
+        if ($path =~ m|\Q${_}\E$|) {
+            return $`;
+        }
+    }
+    return $path;
+}
+
+# __isshared EXPR
+# EXPR is supposed to be a library name.  This will return true if that library
+# can be assumed to be a shared library, otherwise false
+sub __isshared {
+    return !($disabled{shared} || $_[0] =~ /\.a$/);
+}
+
+# __concat LIST
+# Returns the concatenation of all elements of LIST if none of them is
+# undefined.  If one of them is undefined, returns undef instead.
+sub __concat {
+    my $result = '';
+    foreach (@_) {
+        return undef unless defined $_;
+        $result .= $_;
+    }
+    return $result;
+}
+
+1;

--- a/Configurations/platform/Cygwin.pm
+++ b/Configurations/platform/Cygwin.pm
@@ -1,0 +1,22 @@
+package platform::Cygwin;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::mingw;
+@ISA = qw(platform::mingw);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub sharedname {
+    my $class = shift;
+    my $lib = platform::mingw->sharedname(@_);
+    $lib =~ s|^lib|cyg| if defined $lib;
+    return $lib;
+}
+
+1;

--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -19,7 +19,7 @@ sub dsoext              { $target{dso_extension} || '.so' }
 sub shlibext            { (my $x = $target{shared_extension}
                                || '.so.$(SHLIB_VERSION_NUMBER)')
                               =~ s|\.\$\(SHLIB_VERSION_NUMBER\)
-                                  |.$config{shlib_version_number}|x;
+                                  |.$config{shlib_version}|x;
                           $x; }
 sub libext              { $target{lib_extension} || '.a' }
 sub defext              { $target{def_extension} || '.ld' }

--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -1,0 +1,70 @@
+package platform::Unix;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::BASE;
+@ISA = qw(platform::BASE);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub binext              { $target{exe_extension} || '' }
+sub dsoext              { $target{dso_extension} || '.so' }
+# Because these are also used in scripts and not just Makefile, we must
+# convert $(SHLIB_VERSION_NUMBER) to the actual number.
+sub shlibext            { (my $x = $target{shared_extension}
+                               || '.so.$(SHLIB_VERSION_NUMBER)')
+                              =~ s|\.\$\(SHLIB_VERSION_NUMBER\)
+                                  |.$config{shlib_version_number}|x;
+                          $x; }
+sub libext              { $target{lib_extension} || '.a' }
+sub defext              { $target{def_extension} || '.ld' }
+sub objext              { $target{obj_extension} || '.o' }
+sub depext              { $target{obj_extension} || '.d' }
+
+# Other extra that aren't defined in platform::BASE
+sub shlibextsimple      { (my $x = $target{shared_extension} || '.so')
+                              =~ s|\.\$\(SHLIB_VERSION_NUMBER\)||;
+                          $x; }
+sub shlibvariant        { $target{shlib_variant} || "" }
+sub makedepprog         { $disabled{makedepend} ? undef : $config{makedepprog} }
+
+# No conversion of assembler extension on Unix
+sub asm {
+    return $_[1];
+}
+
+# At some point, we might decide that static libraries are called something
+# other than the default...
+sub staticname {
+    # Non-installed libraries are *always* static, and their names remain
+    # the same, except for the mandatory extension
+    my $in_libname = platform::BASE->staticname($_[1]);
+    return $in_libname
+        unless ( grep { platform::BASE->staticname($_) eq $in_libname }
+                 @{$unified_info{install}->{libraries}} );
+
+    # We currently return the same name anyway...  but we might choose to
+    # append '_static' or '_a' some time in the future.
+    return platform::BASE->staticname($_[1]);
+}
+
+sub sharedname {
+    return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
+                                    ($_[0]->shlibvariant() // ''));
+}
+
+sub sharedname_simple {
+    return platform::BASE::__isshared($_[1]) ? $_[1] : undef;
+}
+
+sub sharedlib_simple {
+    return platform::BASE::__concat($_[0]->sharedname_simple($_[1]),
+                                    $_[0]->shlibextsimple());
+}
+
+1;

--- a/Configurations/platform/VMS.pm
+++ b/Configurations/platform/VMS.pm
@@ -1,0 +1,63 @@
+package platform::VMS;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::BASE;
+@ISA = qw(platform::BASE);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+# VMS has a cultural standard where all installed libraries are prefixed.
+# For OpenSSL, the choice is 'ossl$' (this prefix was claimed in a
+# conversation with VSI, Tuesday January 26 2016)
+sub osslprefix          { 'OSSL$' }
+
+sub binext              { '.EXE' }
+sub dsoext              { '.EXE' }
+sub shlibext            { '.EXE' }
+sub libext              { '.OLB' }
+sub defext              { '.OPT' }
+sub objext              { '.OBJ' }
+sub depext              { '.D' }
+sub asmext              { '.ASM' }
+
+# Other extra that aren't defined in platform::BASE
+sub shlibvariant        { $target{shlib_variant} || '' }
+
+sub optext              { '.OPT' }
+sub optname             { return $_[1] }
+sub opt                 { return $_[0]->optname($_[1]) . $_[0]->optext() }
+
+# Other projects include the pointer size in the name of installed libraries,
+# so we do too.
+sub staticname {
+    # Non-installed libraries are *always* static, and their names remain
+    # the same, except for the mandatory extension
+    my $in_libname = platform::BASE->staticname($_[1]);
+    return $in_libname
+        unless ( grep { platform::BASE->staticname($_) eq $in_libname }
+                 @{$unified_info{install}->{libraries}} );
+
+    return platform::BASE::__concat($_[0]->osslprefix(),
+                                    platform::BASE->staticname($_[1]),
+                                    $target{pointer_size});
+}
+
+# To enable installation of multiple major OpenSSL releases, we include the
+# version number in installed shared library names.
+my $sover_filename =
+    sprintf "%02d%02d", split m|\.|, $config{shlib_version_number};
+sub sharedname {
+    return platform::BASE::__concat($_[0]->osslprefix(),
+                                    platform::BASE->sharedname($_[1]),
+                                    "$sover_filename",
+                                    ($_[0]->shlibvariant() // ''),
+                                    "_shr$target{pointer_size}");
+}
+
+1;

--- a/Configurations/platform/VMS.pm
+++ b/Configurations/platform/VMS.pm
@@ -51,11 +51,14 @@ sub staticname {
 # To enable installation of multiple major OpenSSL releases, we include the
 # version number in installed shared library names.
 my $sover_filename =
-    sprintf "%02d%02d", split m|\.|, $config{shlib_version_number};
+    join('', map { sprintf "%02d", $_ } split(m|\.|, $config{shlib_version}));
+sub shlib_version_as_filename {
+    return $sover_filename;
+}
 sub sharedname {
     return platform::BASE::__concat($_[0]->osslprefix(),
                                     platform::BASE->sharedname($_[1]),
-                                    "$sover_filename",
+                                    $_[0]->shlib_version_as_filename(),
                                     ($_[0]->shlibvariant() // ''),
                                     "_shr$target{pointer_size}");
 }

--- a/Configurations/platform/Windows.pm
+++ b/Configurations/platform/Windows.pm
@@ -42,10 +42,14 @@ sub staticname {
 
 # To mark forward compatibility, we include the OpenSSL major release version
 # number in the installed shared library names.
-(my $sover_filename = $config{shlib_version_number}) =~ s|\.|_|g;
+(my $sover_filename = $config{shlib_version}) =~ s|\.|_|g;
+sub shlib_version_as_filename {
+    return $sover_filename
+}
 sub sharedname {
     return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
-                                    "-$sover_filename",
+                                    "-",
+                                    $_[0]->shlib_version_as_filename(),
                                     ($_[0]->shlibvariant() // ''));
 }
 

--- a/Configurations/platform/Windows.pm
+++ b/Configurations/platform/Windows.pm
@@ -1,0 +1,61 @@
+package platform::Windows;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::BASE;
+@ISA = qw(platform::BASE);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub binext              { '.exe' }
+sub dsoext              { '.dll' }
+sub shlibext            { '.dll' }
+sub libext              { '.lib' }
+sub defext              { '.def' }
+sub objext              { '.obj' }
+sub depext              { '.d' }
+sub asmext              { '.asm' }
+
+# Other extra that aren't defined in platform::BASE
+sub resext              { '.res' }
+sub shlibextimport      { '.lib' }
+sub shlibvariant        { $target{shlib_variant} || '' }
+
+sub staticname {
+    # Non-installed libraries are *always* static, and their names remain
+    # the same, except for the mandatory extension
+    my $in_libname = platform::BASE->staticname($_[1]);
+    return $in_libname
+        unless ( grep { platform::BASE->staticname($_) eq $in_libname }
+                 @{$unified_info{install}->{libraries}} );
+
+    # To make sure not to clash with an import library, we make the static
+    # variant of our installed libraries get '_static' added to their names.
+    return platform::BASE->staticname($_[1])
+        . ($disabled{shared} ? '' : '_static');
+}
+
+# To mark forward compatibility, we include the OpenSSL major release version
+# number in the installed shared library names.
+(my $sover_filename = $config{shlib_version_number}) =~ s|\.|_|g;
+sub sharedname {
+    return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
+                                    "-$sover_filename",
+                                    ($_[0]->shlibvariant() // ''));
+}
+
+sub sharedname_import {
+    return platform::BASE::__isshared($_[1]) ? $_[1] : undef;
+}
+
+sub sharedlib_import {
+    return platform::BASE::__concat($_[0]->sharedname_import($_[1]),
+                                    $_[0]->shlibextimport());
+}
+
+1;

--- a/Configurations/platform/Windows/MSVC.pm
+++ b/Configurations/platform/Windows/MSVC.pm
@@ -1,0 +1,33 @@
+package platform::Windows::MSVC;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::Windows;
+@ISA = qw(platform::Windows);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub pdbext              { '.pdb' }
+
+sub staticlibpdb {
+    return platform::BASE::__concat($_[0]->staticname($_[1]), $_[0]->pdbext());
+}
+
+sub sharedlibpdb {
+    return platform::BASE::__concat($_[0]->sharedname($_[1]), $_[0]->pdbext());
+}
+
+sub dsopdb {
+    return platform::BASE::__concat($_[0]->dsoname($_[1]), $_[0]->pdbext());
+}
+
+sub binpdb {
+    return platform::BASE::__concat($_[0]->binname($_[1]), $_[0]->pdbext());
+}
+
+1;

--- a/Configurations/platform/mingw.pm
+++ b/Configurations/platform/mingw.pm
@@ -1,0 +1,41 @@
+package platform::mingw;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::Unix;
+@ISA = qw(platform::Unix);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub binext              { '.exe' }
+sub objext              { '.obj' }
+sub libext              { '.a' }
+sub dsoext              { '.dll' }
+sub defext              { '.def' }
+sub shlibext            { '.dll' }
+sub shlibextimport      { $target{shared_import_extension} || '.dll.a' }
+sub shlibextsimple      { undef }
+sub makedepprog         { $disabled{makedepend} ? undef : $config{makedepprog} }
+
+(my $sover_filename = $config{shlib_version_number}) =~ s|\.|_|g;
+sub sharedname {
+    return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
+                                    "-$sover_filename",
+                                    ($config{target} eq "mingw64"
+                                         ? "-x64" : ""));
+}
+
+# With Mingw and other DLL producers, there isn't really any "simpler"
+# shared library name.  However, there is a static import library, so
+# we return that instead.
+sub sharedlib_simple {
+    return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
+                                    $_[0]->shlibextimport());
+}
+
+1;

--- a/Configurations/platform/mingw.pm
+++ b/Configurations/platform/mingw.pm
@@ -22,10 +22,14 @@ sub shlibextimport      { $target{shared_import_extension} || '.dll.a' }
 sub shlibextsimple      { undef }
 sub makedepprog         { $disabled{makedepend} ? undef : $config{makedepprog} }
 
-(my $sover_filename = $config{shlib_version_number}) =~ s|\.|_|g;
+(my $sover_filename = $config{shlib_version}) =~ s|\.|_|g;
+sub shlib_version_as_filename {
+    return $sover_filename;
+}
 sub sharedname {
     return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
-                                    "-$sover_filename",
+                                    "-",
+                                    $_[0]->shlib_version_as_filename(),
                                     ($config{target} eq "mingw64"
                                          ? "-x64" : ""));
 }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -11,9 +11,7 @@
      # libcrypto.a and use libcrypto_a.a as static one.
      sub sharedaix  { !$disabled{shared} && $config{target} =~ /^aix/ }
 
-     our $sover_dirname = $config{shlib_version};
-     $sover_dirname =~ s|\.|_|g
-         if $config{target} =~ /^mingw/;
+     our $sover_dirname = platform->shlib_version_as_filename();
 
      # This makes sure things get built in the order they need
      # to. You're welcome.

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -3,17 +3,7 @@
 ##
 ## {- join("\n## ", @autowarntext) -}
 {-
-     our $objext = $target{obj_extension} || ".o";
-     our $defext = $target{def_extension} || ".ld";
-     our $depext = $target{dep_extension} || ".d";
-     our $exeext = $target{exe_extension} || "";
-     our $libext = $target{lib_extension} || ".a";
-     our $shlibext = $target{shared_extension} || ".so";
-     our $shlibvariant = $target{shlib_variant} || "";
-     our $shlibextsimple = $target{shared_extension_simple} || ".so";
-     our $shlibextimport = $target{shared_import_extension} || "";
-     our $dsoext = $target{dso_extension} || ".so";
-     our $makedepprog = $disabled{makedepend} ? undef : $config{makedepprog};
+     our $makedepprog = platform->makedepprog();
 
      sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw)/ }
 
@@ -25,54 +15,6 @@
      $sover_dirname =~ s|\.|_|g
          if $config{target} =~ /^mingw/;
 
-     # shlib and shlib_simple both take a static library name and figure
-     # out what the shlib name should be.
-     #
-     # When OpenSSL is configured "no-shared", these functions will just
-     # return empty lists, making them suitable to join().
-     #
-     # With Windows DLL producers, shlib($libname) will return the shared
-     # library name (which usually is different from the static library
-     # name) with the default shared extension appended to it, while
-     # shlib_simple($libname) will return the static library name with
-     # the shared extension followed by ".a" appended to it.  The former
-     # result is used as the runtime shared library while the latter is
-     # used as the DLL import library.
-     #
-     # On all Unix systems, shlib($libname) will return the library name
-     # with the default shared extension, while shlib_simple($libname)
-     # will return the name from shlib($libname) with any SO version number
-     # removed.  On some systems, they may therefore return the exact same
-     # string.
-     sub shlib {
-         my $lib = shift;
-         return () if $disabled{shared} || $lib =~ /\.a$/;
-         return $unified_info{sharednames}->{$lib}. $shlibvariant. '$(SHLIB_EXT)';
-     }
-     sub shlib_simple {
-         my $lib = shift;
-         return () if $disabled{shared} || $lib =~ /\.a$/;
-
-         if (windowsdll()) {
-             return $lib . '$(SHLIB_EXT_IMPORT)';
-         }
-         return $lib .  '$(SHLIB_EXT_SIMPLE)';
-     }
-
-     # Easy fixing of static library names
-     sub lib {
-         (my $lib = shift) =~ s/\.a$//;
-         return $lib . $libext;
-     }
-
-     # dso is a complement to shlib / shlib_simple that returns the
-     # given libname with the simple shared extension (possible SO version
-     # removed).  This differs from shlib_simple() by being unconditional.
-     sub dso {
-         my $engine = shift;
-
-         return $engine . $dsoext;
-     }
      # This makes sure things get built in the order they need
      # to. You're welcome.
      sub dependmagic {
@@ -93,33 +35,33 @@ MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
 SHLIB_TARGET={- $target{shared_target} -}
-SHLIB_EXT={- $shlibext -}
-SHLIB_EXT_SIMPLE={- $shlibextsimple -}
-SHLIB_EXT_IMPORT={- $shlibextimport -}
 
-LIBS={- join(" ", map { lib($_) } @{$unified_info{libraries}}) -}
-SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{libraries}}) -}
-SHLIB_INFO={- join(" ", map { "\"".shlib($_).";".shlib_simple($_)."\"" } @{$unified_info{libraries}}) -}
-ENGINES={- join(" ", map { dso($_) } @{$unified_info{engines}}) -}
-PROGRAMS={- join(" ", map { $_.$exeext } @{$unified_info{programs}}) -}
+LIBS={- join(" ", map { platform->staticlib($_) // () } @{$unified_info{libraries}}) -}
+SHLIBS={- join(" ", map { platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
+SHLIB_INFO={- join(" ", map { my $x = platform->sharedlib($_);
+                              my $y = platform->sharedlib_simple($_);
+                              $x ? "\"$x;$y\"" : () }
+                        @{$unified_info{libraries}}) -}
+ENGINES={- join(" ", map { platform->dso($_) } @{$unified_info{engines}}) -}
+PROGRAMS={- join(" ", map { platform->bin($_) } @{$unified_info{programs}}) -}
 SCRIPTS={- join(" ", @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}
-DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
+DEPS={- join(" ", map { platform->isobj($_) ? platform->dep($_) : () }
                   grep { $unified_info{sources}->{$_}->[0] =~ /\.c$/ }
                   keys %{$unified_info{sources}}); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}}) -}
 GENERATED={- # common0.tmpl provides @generated
-             join(" ", map { my $x = $_;
-                             $x =~ s|\.ld$|$defext|;
-                             $x }
-                       @generated ) -}
+             join(" ", map { platform->convertext($_) } @generated ) -}
 
-INSTALL_LIBS={- join(" ", map { lib($_) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIB_INFO={- join(" ", map { "\"".shlib($_).";".shlib_simple($_)."\"" } @{$unified_info{install}->{libraries}}) -}
-INSTALL_ENGINES={- join(" ", map { dso($_) } @{$unified_info{install}->{engines}}) -}
-INSTALL_PROGRAMS={- join(" ", map { $_.$exeext } @{$unified_info{install}->{programs}}) -}
+INSTALL_LIBS={- join(" ", map { platform->staticlib($_) // () } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIBS={- join(" ", map { platform->sharedlib($_) // () } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIB_INFO={- join(" ", map { my $x = platform->sharedlib($_);
+                                      my $y = platform->sharedlib_simple($_);
+                                      $x ? "\"$x;$y\"" : () }
+                                @{$unified_info{install}->{libraries}}) -}
+INSTALL_ENGINES={- join(" ", map { platform->dso($_) } @{$unified_info{install}->{engines}}) -}
+INSTALL_PROGRAMS={- join(" ", map { platform->bin($_) } @{$unified_info{install}->{programs}}) -}
 {- output_off() if $disabled{apps}; "" -}
 BIN_SCRIPTS=$(BLDDIR)/tools/c_rehash
 MISC_SCRIPTS=$(BLDDIR)/apps/CA.pl $(BLDDIR)/apps/tsget.pl:tsget
@@ -374,7 +316,7 @@ test: tests
 	  BLDTOP=../$(BLDDIR) \
 	  RESULT_D=test-runs \
 	  PERL="$(PERL)" \
-	  EXE_EXT={- $exeext -} \
+	  EXE_EXT={- platform->binext() -} \
 	  OPENSSL_ENGINES=`cd ../$(BLDDIR)/engines 2>/dev/null && pwd` \
 	  OPENSSL_DEBUG_MEMORY=on \
 	    $(PERL) ../$(SRCDIR)/test/run_tests.pl $(TESTS) )
@@ -410,13 +352,13 @@ libclean:
 		fi; \
 	done
 	$(RM) $(LIBS)
-	$(RM) *.{- $defext -}
+	$(RM) *{- platform->defext() -}
 
 clean: libclean
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(ENGINES) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
-	-$(RM) `find . -name .git -prune -o -name '*{- $depext -}' -print`
-	-$(RM) `find . -name .git -prune -o -name '*{- $objext -}' -print`
+	-$(RM) `find . -name .git -prune -o -name '*{- platform->depext() -}' -print`
+	-$(RM) `find . -name .git -prune -o -name '*{- platform->objext() -}' -print`
 	$(RM) core
 	$(RM) tags TAGS doc-nits
 	$(RM) -r test/test-runs
@@ -628,7 +570,7 @@ uninstall_engines:
 	@set -e; for e in dummy $(INSTALL_ENGINES); do \
 		if [ "$$e" = "dummy" ]; then continue; fi; \
 		fn=`basename $$e`; \
-		if [ "$$fn" = '{- dso("ossltest") -}' ]; then \
+		if [ "$$fn" = '{- platform->dso("ossltest") -}' ]; then \
 			continue; \
 		fi; \
 		$(ECHO) "$(RM) $(DESTDIR)$(ENGINESDIR)/$$fn"; \
@@ -887,7 +829,7 @@ FORCE:
 
 # Building targets ###################################################
 
-libcrypto.pc libssl.pc openssl.pc: configdata.pm $(LIBS) {- join(" ",map { shlib_simple($_) } @{$unified_info{libraries}}) -}
+libcrypto.pc libssl.pc openssl.pc: configdata.pm $(LIBS) {- join(" ",map { platform->sharedlib_simple($_) // () } @{$unified_info{libraries}}) -}
 libcrypto.pc:
 	@ ( echo 'prefix=$(INSTALLTOP)'; \
 	    echo 'exec_prefix=$${prefix}'; \
@@ -958,14 +900,10 @@ reconfigure reconf:
   # Helper function to figure out dependencies on libraries
   # It takes a list of library names and outputs a list of dependencies
   sub compute_lib_depends {
-      if ($disabled{shared}) {
-          return map { lib($_) } @_;
-      }
-
       # Depending on shared libraries:
       # On Windows POSIX layers, we depend on {libname}.dll.a
       # On Unix platforms, we depend on {shlibname}.so
-      return map { $_ =~ /\.a$/ ? $`.$libext : shlib_simple($_) } @_;
+      return map { platform->sharedlib_simple($_) // platform->staticlib($_) } @_;
   }
 
   sub generatesrc {
@@ -976,17 +914,16 @@ reconfigure reconf:
       my $defs = join("", map { " -D".$_ } @{$args{defs}});
       my $deps = join(" ", @{$args{generator_deps}}, @{$args{deps}});
 
-      if ($args{src} =~ /\.ld$/) {
-          (my $target = $args{src}) =~ s/\.ld$/${defext}/;
+      if (platform->isdef($args{src})) {
+          my $target = platform->def($args{src});
           (my $mkdef_os = $target{shared_target}) =~ s|-shared$||;
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
-          my $ord_name =
-              $args{generator}->[1] || basename($args{product}, $dsoext);
+          my $ord_name = $args{generator}->[1] || $args{product};
           return <<"EOF";
 $target: $args{generator}->[0] $deps \$(SRCDIR)/util/mkdef.pl
 	\$(PERL) \$(SRCDIR)/util/mkdef.pl$ord_ver --ordinals $args{generator}->[0]  --name $ord_name --OS $mkdef_os > $target
 EOF
-      } elsif ($args{src} !~ /\.[sS]$/) {
+      } elsif (!platform->isasm($args{src})) {
           if ($args{generator}->[0] =~ m|^.*\.in$|) {
               my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                    "util", "dofile.pl")),
@@ -1038,7 +975,8 @@ EOF
   # last in the line.  We may therefore need to put back a line ending.
   sub src2obj {
       my %args = @_;
-      (my $obj = $args{obj}) =~ s|\.o$||;
+      my $obj = platform->obj($args{obj});
+      my $dep = platform->dep($args{obj});
       my @srcs = @{$args{srcs}};
       my $srcs = join(" ",  @srcs);
       my $deps = join(" ", @srcs, @{$args{deps}});
@@ -1074,7 +1012,7 @@ EOF
       # extension-specific rules
       if (grep /\.s$/, @srcs) {
           $recipe .= <<"EOF";
-$obj$objext: $deps
+$obj: $deps
 	$cmd $cmdflags -c -o \$\@ $srcs
 EOF
       } elsif (grep /\.S$/, @srcs) {
@@ -1084,30 +1022,30 @@ EOF
           # The platform is long discontinued by vendor so there is
           # hardly a point to drag it along...
           $recipe .= <<"EOF";
-$obj$objext: $deps
+$obj: $deps
 	$cmd $incs $defs $cmdflags -c -o \$\@ $srcs
 EOF
       } elsif (defined $makedepprog && $makedepprog !~ /\/makedepend/
                && !grep /\.rc$/, @srcs) {
           $recipe .= <<"EOF";
-$obj$objext: $deps
-	$cmd $incs $defs $cmdflags -MMD -MF $obj$depext.tmp -MT \$\@ -c -o \$\@ $srcs
-	\@touch $obj$depext.tmp
-	\@if cmp $obj$depext.tmp $obj$depext > /dev/null 2> /dev/null; then \\
-		rm -f $obj$depext.tmp; \\
+$obj: $deps
+	$cmd $incs $defs $cmdflags -MMD -MF $dep.tmp -MT \$\@ -c -o \$\@ $srcs
+	\@touch $dep.tmp
+	\@if cmp $dep.tmp $dep > /dev/null 2> /dev/null; then \\
+		rm -f $dep.tmp; \\
 	else \\
-		mv $obj$depext.tmp $obj$depext; \\
+		mv $dep.tmp $dep; \\
 	fi
 EOF
       } else {
           $recipe .= <<"EOF";
-$obj$objext: $deps
+$obj: $deps
 	$cmd $incs $defs $cmdflags $cmdcompile -o \$\@ $srcs
 EOF
           if (defined $makedepprog  && $makedepprog =~ /\/makedepend/) {
               $recipe .= <<"EOF";
 	\$(MAKEDEPEND) -f- -Y -- $incs $cmdflags -- $srcs 2>/dev/null \\
-	    > $obj$depext
+	    > $dep
 EOF
           }
       }
@@ -1116,11 +1054,6 @@ EOF
   # We *know* this routine is only called when we've configure 'shared'.
   sub obj2shlib {
       my %args = @_;
-      my $lib = $args{lib};
-      my $shlib = $args{shlib};
-      my $libd = dirname($lib);
-      my $libn = basename($lib);
-      (my $libname = $libn) =~ s/^lib//;
       my @linkdirs = ();
       foreach (@{args{deps}}) {
           my $d = dirname($_);
@@ -1130,19 +1063,18 @@ EOF
       my $linklibs = join("", map { my $f = basename($_);
                                     (my $l = $f) =~ s/^lib//;
                                     " -l$l" } @{$args{deps}});
-      my @objs = map { (my $x = $_) =~ s|\.o$||; "$x$objext" }
-                 grep { $_ !~ m/\.ld$/ }
+      my @objs = map { platform->obj($_) }
+                 grep { !platform->isdef($_) }
                  @{$args{objs}};
-      my @defs = map { (my $x = $_) =~ s|\.ld$||; "$x$defext" }
-                 grep { $_ =~ /\.ld$/ }
+      my @defs = map { platform->def($_) }
+                 grep { platform->isdef($_) }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       die "More than one exported symbol map" if scalar @defs > 1;
       my $objs = join(" ", @objs);
       my $deps = join(" ", @objs, @defs, @deps);
-      my $simple = shlib_simple($lib);
-      my $full = shlib($lib);
-      my $target = "$simple $full";
+      my $simple = platform->sharedlib_simple($args{lib});
+      my $full = platform->sharedlib($args{lib});
       my $shared_soname = "";
       $shared_soname .= ' '.$target{shared_sonameflag}.basename($full)
           if defined $target{shared_sonameflag};
@@ -1151,39 +1083,40 @@ EOF
           if defined $target{shared_impflag};
       my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
       my $recipe = <<"EOF";
-$target: $deps
+$simple: $full
+EOF
+      if (sharedaix()) {
+          $recipe .= <<"EOF";
+	rm -f $simple && \\
+	\$(AR) r $simple $full
+EOF
+      } elsif ($simple ne $full) {
+          $recipe .= <<"EOF";
+	rm -f $simple && \\
+	ln -s $full $simple
+EOF
+      }
+      $recipe .= <<"EOF";
+$full: $deps
 	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
 		-o $full$shared_def $objs \\
                 $linklibs \$(LIB_EX_LIBS)
 EOF
       if (windowsdll()) {
           $recipe .= <<"EOF";
-	rm -f apps/$shlib'\$(SHLIB_EXT)'
-	rm -f test/$shlib'\$(SHLIB_EXT)'
-	rm -f fuzz/$shlib'\$(SHLIB_EXT)'
-	cp -p $shlib'\$(SHLIB_EXT)' apps/
-	cp -p $shlib'\$(SHLIB_EXT)' test/
-	cp -p $shlib'\$(SHLIB_EXT)' fuzz/
-EOF
-      } elsif (sharedaix()) {
-          $recipe .= <<"EOF";
-	rm -f $simple && \\
-	\$(AR) r $simple $full
-EOF
-      } else {
-          $recipe .= <<"EOF";
-	if [ '$simple' != '$full' ]; then \\
-		rm -f $simple; \\
-		ln -s $full $simple; \\
-	fi
+	rm -f apps/$full
+	rm -f test/$full
+	rm -f fuzz/$full
+	cp -p $full apps/
+	cp -p $full test/
+	cp -p $full fuzz/
 EOF
       }
+      return $recipe;
   }
   sub obj2dso {
       my %args = @_;
-      my $dso = $args{lib};
-      my $dsod = dirname($dso);
-      my $dson = basename($dso);
+      my $dso = platform->dso($args{lib});
       my @linkdirs = ();
       foreach (@{args{deps}}) {
           my $d = dirname($_);
@@ -1193,43 +1126,39 @@ EOF
       my $linklibs = join("", map { my $f = basename($_);
                                     (my $l = $f) =~ s/^lib//;
                                     " -l$l" } @{$args{deps}});
-      my @objs = map { (my $x = $_) =~ s|\.o$||; "$x$objext" }
-                 grep { $_ !~ m/\.ld$/ }
+      my @objs = map { platform->obj($_) }
+                 grep { !platform->isdef($_) }
                  @{$args{objs}};
-      my @defs = map { (my $x = $_) =~ s|\.ld$||; "$x$defext" }
-                 grep { $_ =~ /\.ld$/ }
+      my @defs = map { platform->def($_) }
+                 grep { platform->isdef($_) }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       my $objs = join(" ", @objs);
       my $deps = join(" ", @objs, @defs, @deps);
-      my $target = dso($dso);
       my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
       return <<"EOF";
-$target: $deps
+$dso: $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
-		-o $target$shared_def $objs \\
+		-o $dso$shared_def $objs \\
                 $linklibs \$(DSO_EX_LIBS)
 EOF
   }
   sub obj2lib {
       my %args = @_;
-      (my $lib = $args{lib}) =~ s/\.a$//;
-      my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x } @{$args{objs}};
+      my $lib = platform->staticlib($args{lib});
+      my @objs = map { platform->obj($_) } @{$args{objs}};
       my $objs = join(" ", @objs);
       return <<"EOF";
-$lib$libext: $objs
+$lib: $objs
 	\$(AR) \$(ARFLAGS) \$\@ \$\?
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF
   }
   sub obj2bin {
       my %args = @_;
-      my $bin = $args{bin};
-      my $bind = dirname($bin);
-      my $binn = basename($bin);
-      my $objs = join(" ", map { (my $x = $_) =~ s|\.o$||; "$x$objext" }
-                           @{$args{objs}});
-      my $deps = join(" ",compute_lib_depends(@{$args{deps}}));
+      my $bin = platform->bin($args{bin});
+      my $objs = join(" ", map { platform->obj($_) } @{$args{objs}});
+      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
       my @linkdirs = ();
       foreach (@{args{deps}}) {
           next if $_ =~ /\.a$/;
@@ -1238,7 +1167,7 @@ EOF
       }
       my $linkflags = join("", map { "-L$_ " } @linkdirs);
       my $linklibs = join("", map { if ($_ =~ s/\.a$//) {
-                                        " $_$libext";
+                                        " ".platform->staticlib($_);
                                     } else {
                                         my $f = basename($_);
                                         (my $l = $f) =~ s/^lib//;
@@ -1252,10 +1181,10 @@ EOF
           $cmdflags = '$(BIN_CXXFLAGS)';
       }
       return <<"EOF";
-$bin$exeext: $objs $deps
-	rm -f $bin$exeext
+$bin: $objs $deps
+	rm -f $bin
 	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(BIN_LDFLAGS) \\
-		-o $bin$exeext $objs \\
+		-o $bin $objs \\
 		$linklibs \$(BIN_EX_LIBS)
 EOF
   }
@@ -1276,11 +1205,11 @@ EOF
   sub generatedir {
       my %args = @_;
       my $dir = $args{dir};
-      my @deps = map { s|\.o$|$objext|; $_ } @{$args{deps}};
+      my @deps = map { platform->convertext($_) } @{$args{deps}};
       my @actions = ();
-      my %extinfo = ( dso => $dsoext,
-                      lib => $libext,
-                      bin => $exeext );
+      my %extinfo = ( dso => platform->dsoext(),
+                      lib => platform->libext(),
+                      bin => platform->binext() );
 
       # We already have a 'test' target, and the top directory is just plain
       # silly

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -3,7 +3,7 @@
 ##
 ## {- join("\n## ", @autowarntext) -}
 {-
- (our $sover_dirname = $config{shlib_version}) =~ s|\.|_|g;
+ our $sover_dirname = platform->shlib_version_as_filename();
 
  my $build_scheme = $target{build_scheme};
  my $install_flavour = $build_scheme->[$#$build_scheme]; # last element

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -3,16 +3,6 @@
 ##
 ## {- join("\n## ", @autowarntext) -}
 {-
- our $objext = $target{obj_extension} || ".obj";
- our $resext = $target{res_extension} || ".res";
- our $depext = $target{dep_extension} || ".d";
- our $defext = $target{dep_extension} || ".def";
- our $exeext = $target{exe_extension} || ".exe";
- our $libext = $target{lib_extension} || ".lib";
- our $shlibext = $target{shared_extension} || ".dll";
- our $shlibextimport = $target{shared_import_extension} || ".lib";
- our $dsoext = $target{dso_extension} || ".dll";
-
  (our $sover_dirname = $config{shlib_version}) =~ s|\.|_|g;
 
  my $build_scheme = $target{build_scheme};
@@ -32,31 +22,6 @@
  $win_installroot = $ENV{$win_installroot};
  $win_commonroot = $ENV{$win_commonroot};
 
- sub shlib {
-     my $lib = shift;
-     return () if $disabled{shared} || $lib =~ /\.a$/;
-     return () unless defined $unified_info{sharednames}->{$lib};
-     return $unified_info{sharednames}->{$lib} . $shlibext;
- }
-
- sub lib {
-     (my $lib = shift) =~ s/\.a$//;
-     $lib .= '_static'
-         if (defined $unified_info{sharednames}->{$lib});
-     return $lib . $libext;
- }
-
- sub shlib_import {
-     my $lib = shift;
-     return () if $disabled{shared} || $lib =~ /\.a$/;
-     return $lib . $shlibextimport;
- }
-
- sub dso {
-     my $dso = shift;
-
-     return $dso . $dsoext;
- }
  # This makes sure things get built in the order they need
  # to. You're welcome.
  sub dependmagic {
@@ -77,34 +42,32 @@ MINOR={- $config{minor} -}
 
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
 
-LIBS={- join(" ", map { ( shlib_import($_), lib($_) ) } @{$unified_info{libraries}}) -}
-SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{libraries}}) -}
-SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; shlib($_) } @{$unified_info{libraries}}) -}
-ENGINES={- join(" ", map { dso($_) } @{$unified_info{engines}}) -}
-ENGINEPDBS={- join(" ", map { local $dsoext = ".pdb"; dso($_) } @{$unified_info{engines}}) -}
-PROGRAMS={- our @PROGRAMS = map { $_.$exeext } @{$unified_info{programs}}; join(" ", @PROGRAMS) -}
+LIBS={- join(" ", map { ( platform->sharedlib_import($_), platform->staticlib($_) ) } @{$unified_info{libraries}}) -}
+SHLIBS={- join(" ", map { platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
+SHLIBPDBS={- join(" ", map { platform->sharedlibpdb($_) // () } @{$unified_info{libraries}}) -}
+ENGINES={- join(" ", map { platform->dso($_) } @{$unified_info{engines}}) -}
+ENGINEPDBS={- join(" ", map { platform->dsopdb($_) } @{$unified_info{engines}}) -}
+PROGRAMS={- our @PROGRAMS = map { platform->bin($_) } @{$unified_info{programs}}; join(" ", @PROGRAMS) -}
 PROGRAMPDBS={- join(" ", map { $_.".pdb" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(" ", @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}
-DEPS={- join(" ", map { (my $x = $_) =~ s|\.o$|$depext|; $x; }
+DEPS={- join(" ", map { platform->isobj($_) ? platform->dep($_) : () }
                   grep { $unified_info{sources}->{$_}->[0] =~ /\.c$/ }
                   keys %{$unified_info{sources}}); -}
 {- output_on() if $disabled{makedepend}; "" -}
 GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
 GENERATED={- # common0.tmpl provides @generated
-             join(" ", map { my $x = $_;
-                             $x =~ s|\.[sS]$|.asm|;
-                             $x =~ s|\.ld$|$defext|;
-                             $x }
-                       @generated) -}
+             join(" ", map { platform->convertext($_) } @generated) -}
 
-INSTALL_LIBS={- join(" ", map { quotify1(shlib_import($_) or lib($_)) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBS={- join(" ", map { quotify_l(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; quotify_l(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_ENGINES={- join(" ", map { quotify1(dso($_)) } @{$unified_info{install}->{engines}}) -}
-INSTALL_ENGINEPDBS={- join(" ", map { local $dsoext = ".pdb"; quotify1(dso($_)) } @{$unified_info{install}->{engines}}) -}
-INSTALL_PROGRAMS={- join(" ", map { quotify1($_.$exeext) } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
-INSTALL_PROGRAMPDBS={- join(" ", map { quotify1($_.".pdb") } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
+INSTALL_LIBS={- join(" ", map { quotify1(platform->sharedlib_import($_) // platform->staticlib($_)) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIBS={- join(" ", map { my $x = platform->sharedlib($_);
+                                  $x ? quotify_l($x) : () } @{$unified_info{install}->{libraries}}) -}
+INSTALL_SHLIBPDBS={- join(" ", map { my $x = platform->sharedlibpdb($_);
+                                     $x ? quotify_l($x) : () } @{$unified_info{install}->{libraries}}) -}
+INSTALL_ENGINES={- join(" ", map { quotify1(platform->dso($_)) } @{$unified_info{install}->{engines}}) -}
+INSTALL_ENGINEPDBS={- join(" ", map { quotify1(platform->dsopdb($_)) } @{$unified_info{install}->{engines}}) -}
+INSTALL_PROGRAMS={- join(" ", map { quotify1(platform->bin($_)) } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
+INSTALL_PROGRAMPDBS={- join(" ", map { quotify1(platform->binpdb($_)) } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
 {- output_off() if $disabled{apps}; "" -}
 BIN_SCRIPTS="$(BLDDIR)\tools\c_rehash.pl"
 MISC_SCRIPTS="$(BLDDIR)\apps\CA.pl" "$(BLDDIR)\apps\tsget.pl"
@@ -317,7 +280,7 @@ PROCESSOR= {- $config{processor} -}
 {- dependmagic('build_programs'); -}: build_programs_nodep
 
 build_generated: $(GENERATED_MANDATORY)
-build_libs_nodep: $(LIBS) {- join(" ",map { shlib_import($_) } @{$unified_info{libraries}}) -}
+build_libs_nodep: $(LIBS) {- join(" ",map { platform->sharedlib_import($_) // () } @{$unified_info{libraries}}) -}
 build_engines_nodep: $(ENGINES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
 
@@ -497,9 +460,9 @@ reconfigure reconf:
  # It takes a list of library names and outputs a list of dependencies
  sub compute_lib_depends {
      if ($disabled{shared}) {
-	 return map { lib($_) } @_;
+	 return map { platform->staticlib($_) } @_;
      }
-     return map { shlib_import($_) or lib($_) } @_;
+     return map { platform->sharedlib_import($_) // platform->staticlib($_) } @_;
  }
 
   sub generatesrc {
@@ -512,19 +475,19 @@ reconfigure reconf:
       my $deps = @{$args{deps}} ?
           '"'.join('" "', @{$args{generator_deps}}, @{$args{deps}}).'"' : '';
 
-      if ($args{src} =~ /\.ld$/) {
-          (my $target = $args{src}) =~ s/\.ld$/$defext/;
+      if (platform->isdef($args{src})) {
+          my $target = platform->def($args{src});
           my $mkdef = abs2rel(rel2abs(catfile($config{sourcedir},
                                               "util", "mkdef.pl")),
                               rel2abs($config{builddir}));
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
           my $ord_name =
-              $args{generator}->[1] || basename($args{product}, $dsoext);
+              $args{generator}->[1] || platform->dsoname($args{product});
           return <<"EOF";
 $target: $args{generator}->[0] $deps $mkdef
 	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name --OS windows > $target
 EOF
-      } elsif ($args{src} !~ /\.[sS]$/) {
+      } elsif (!platform->isasm($args{src})) {
           my $target = $args{src};
           if ($args{generator}->[0] =~ m|^.*\.in$|) {
               my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
@@ -542,7 +505,7 @@ $target: "$args{generator}->[0]" $deps
 EOF
 	  }
       } else {
-          (my $target = $args{src}) =~ s/\.[sS]$/.asm/;
+          my $target = platform->asm($args{src});
           if ($args{generator}->[0] =~ /\.pl$/) {
               $generator = '"$(PERL)"'.$generator_incs.' '.$generator;
           } elsif ($args{generator}->[0] =~ /\.S$/) {
@@ -586,8 +549,7 @@ EOF
 
  sub src2obj {
      my %args = @_;
-     my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x
-                    } ( @{$args{srcs}} );
+     my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x } ( @{$args{srcs}} );
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
@@ -607,29 +569,30 @@ EOF
 		     bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
      my $makedepprog = $config{makedepprog};
      if ($srcs[0] =~ /\.rc$/) {
+         my $res = platform->res($args{obj});
          return <<"EOF";
-$args{obj}: $deps
+$res: $deps
 	\$(RC) \$(RCOUTFLAG)\$\@ $srcs
 EOF
      }
-     (my $obj = $args{obj}) =~ s|\.o$||;
+     my $obj = platform->obj($args{obj});
      if ($srcs[0] =~ /\.asm$/) {
          return <<"EOF";
-$obj$objext: $deps
+$obj: $deps
 	\$(AS) $asflags \$(ASOUTFLAG)\$\@ $srcs
 EOF
      } elsif ($srcs[0] =~ /.S$/) {
          return <<"EOF";
-$obj$objext: $deps
+$obj: $deps
 	\$(CC) /EP /D__ASSEMBLER__ $cflags $defs $srcs > \$@.asm && \$(AS) $asflags \$(ASOUTFLAG)\$\@ \$@.asm
 EOF
      }
      my $recipe = <<"EOF";
-$obj$objext: $deps
+$obj: $deps
 	\$(CC) $cflags $defs -c \$(COUTFLAG)\$\@ $srcs
 EOF
      $recipe .= <<"EOF"	unless $disabled{makedepend};
-	\$(CC) $cflags $defs /Zs /showIncludes $srcs 2>&1 > $obj$depext
+	\$(CC) $cflags $defs /Zs /showIncludes $srcs 2>&1 > $dep
 EOF
      return $recipe;
  }
@@ -640,19 +603,19 @@ EOF
  sub obj2shlib {
      my %args = @_;
      my $lib = $args{lib};
-     my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x }
-                grep { $_ =~ m/\.(?:o|res)$/ }
+     my @objs = map { platform->convertext($_) }
+                grep { platform->isobj($_) || platform->isres($_) }
                 @{$args{objs}};
-     my @defs = map { (my $x = $_) =~ s|\.ld$||; "$x$defext" }
-                grep { $_ =~ /\.ld$/ }
+     my @defs = map { platform->def($_) }
+                grep { platform->isdef($_) }
                 @{$args{objs}};
      my @deps = compute_lib_depends(@{$args{deps}});
      die "More than one exported symbols list" if scalar @defs > 1;
      my $linklibs = join("", map { "$_\n" } @deps);
      my $objs = join("\n", @objs);
      my $deps = join(" ", @objs, @defs, @deps);
-     my $import = shlib_import($lib);
-     my $dll =  shlib($lib);
+     my $import = platform->sharedlib_import($lib);
+     my $dll =  platform->sharedlib($lib);
      my $shared_def = join("", map { " /def:$_" } @defs);
      return <<"EOF"
 # The import library may look like a static library, but it is not.
@@ -679,13 +642,13 @@ EOF
  }
  sub obj2dso {
      my %args = @_;
-     my $dso = $args{lib};
-     my $dso_n = basename($dso);
-     my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x }
-                grep { $_ =~ m/\.(?:o|res)$/ }
+     my $dso = platform->dso($args{lib});
+     my $dso_n = platform->dsoname($args{lib});
+     my @objs = map { platform->convertext($_) }
+                grep { platform->isobj($_) || platform->isres($_) }
                 @{$args{objs}};
-     my @defs = map { (my $x = $_) =~ s|\.ld$|$defext|; $x }
-                grep { $_ =~ /\.ld$/ }
+     my @defs = map { platform->def($_) }
+                grep { platform->isdef($_) }
                 @{$args{objs}};
      my @deps = compute_lib_depends(@{$args{deps}});
      my $objs = join("\n", @objs);
@@ -693,21 +656,21 @@ EOF
      my $deps = join(" ", @objs, @defs, @deps);
      my $shared_def = join("", map { " /def:$_" } @defs);
      return <<"EOF";
-$dso$dsoext: $deps
-	IF EXIST $dso$dsoext.manifest DEL /F /Q $dso$dsoext.manifest
+$dso: $deps
+	IF EXIST $dso.manifest DEL /F /Q $dso.manifest
 	\$(LD) \$(LDFLAGS) \$(DSO_LDFLAGS) \\
-		\$(LDOUTFLAG)$dso$dsoext$shared_def @<< || (DEL /Q \$(\@B).* $dso.* && EXIT 1)
+		\$(LDOUTFLAG)$dso$shared_def @<< || (DEL /Q \$(\@B).* $dso_n.* && EXIT 1)
 $objs
 $linklibs \$(DSO_EX_LIBS)
 <<
-	IF EXIST $dso$dsoext.manifest \\
-	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$dso$dsoext.manifest \$(MTOUTFLAG)$dso$dsoext
+	IF EXIST $dso.manifest \\
+	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$dso.manifest \$(MTOUTFLAG)$dso
 EOF
  }
  sub obj2lib {
      my %args = @_;
-     my $lib = lib($args{lib});
-     my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x } @{$args{objs}};
+     my $lib = platform->staticlib($args{lib});
+     my @objs = map { platform->obj($_) } @{$args{objs}};
      my $objs = join("\n", @objs);
      my $deps = join(" ", @objs);
      return <<"EOF";
@@ -719,22 +682,24 @@ EOF
  }
  sub obj2bin {
      my %args = @_;
-     my $bin = $args{bin};
-     my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x } @{$args{objs}};
+     my $bin = platform->bin($args{bin});
+     my @objs = map { platform->convertext($_) }
+                grep { platform->isobj($_) || platform->isres($_) }
+                @{$args{objs}};
      my @deps = compute_lib_depends(@{$args{deps}});
      my $objs = join("\n", @objs);
      my $linklibs = join("", map { "$_\n" } @deps);
      my $deps = join(" ", @objs, @deps);
      return <<"EOF";
-$bin$exeext: $deps
-	IF EXIST $bin$exeext.manifest DEL /F /Q $bin$exeext.manifest
-	\$(LD) \$(LDFLAGS) \$(BIN_LDFLAGS) \$(LDOUTFLAG)$bin$exeext @<<
+$bin: $deps
+	IF EXIST $bin.manifest DEL /F /Q $bin.manifest
+	\$(LD) \$(LDFLAGS) \$(BIN_LDFLAGS) \$(LDOUTFLAG)$bin @<<
 $objs
 setargv.obj
 $linklibs\$(BIN_EX_LIBS)
 <<
-	IF EXIST $bin$exeext.manifest \\
-	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$bin$exeext.manifest \$(MTOUTFLAG)$bin$exeext
+	IF EXIST $bin.manifest \\
+	   \$(MT) \$(MTFLAGS) \$(MTINFLAG)$bin.manifest \$(MTOUTFLAG)$bin
 EOF
   }
   sub in2script {
@@ -753,11 +718,11 @@ EOF
   sub generatedir {
       my %args = @_;
       my $dir = $args{dir};
-      my @deps = map { s|\.o$|$objext|; $_ } @{$args{deps}};
+      my @deps = map { platform->convertext($_) } @{$args{deps}};
       my @actions = ();
-      my %extinfo = ( dso => $dsoext,
-                      lib => $libext,
-                      bin => $exeext );
+      my %extinfo = ( dso => platform->dsoext(),
+                      lib => platform->libext(),
+                      bin => platform->binext() );
 
       # We already have a 'test' target, and the top directory is just plain
       # silly

--- a/Configure
+++ b/Configure
@@ -1130,7 +1130,7 @@ $target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
                                   || $config{target} =~ /^(?:Cygwin|mingw)/);
 $target{exe_extension}=".pm"  if ($config{target} =~ /vos/);
 $target{def_extension}=".ld";
-$target{def_extension}=".def" if $config{target} =~ /^mingw|VC-/;
+$target{def_extension}=".def" if $config{target} =~ /^mingw/;
 $target{def_extension}=".opt" if $config{target} =~ /^vms/;
 ($target{shared_extension_simple}=$target{shared_extension})
     =~ s|\.\$\(SHLIB_VERSION_NUMBER\)||

--- a/Configure
+++ b/Configure
@@ -1727,8 +1727,6 @@ if ($builder eq "unified") {
         my %includes = ();
         my %defines = ();
         my %depends = ();
-        my %renames = ();
-        my %sharednames = ();
         my %generate = ();
 
         # We want to detect configdata.pm in the source tree, so we
@@ -1859,11 +1857,9 @@ if ($builder eq "unified") {
             => sub { push @{$generate{$1}}, $2
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*RENAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$renames{$1}}, tokenize($2)
-                         if !@skip || $skip[$#skip] > 0 },
-            qr/^\s*SHARED_NAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$sharednames{$1}}, tokenize($2)
-                         if !@skip || $skip[$#skip] > 0 },
+            => sub { warn "RENAME is no longer supported\n" },
+             qr/^\s*SHARED_NAME\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
+            => sub { warn "SHARED_NAME is no longer supported\n" },
             qr/^\s*BEGINRAW\[((?:\\.|[^\\\]])+)\]\s*$/
             => sub {
                 my $lineiterator = shift;
@@ -1897,48 +1893,23 @@ if ($builder eq "unified") {
             );
         die "runaway IF?" if (@skip);
 
-        foreach (keys %renames) {
-            die "$_ renamed to more than one thing: "
-                ,join(" ", @{$renames{$_}}),"\n"
-                if scalar @{$renames{$_}} > 1;
-            my $dest = cleanfile($buildd, $_, $blddir);
-            my $to = cleanfile($buildd, $renames{$_}->[0], $blddir);
-            die "$dest renamed to more than one thing: "
-                ,$unified_info{rename}->{$dest}, $to
-                unless !defined($unified_info{rename}->{$dest})
-                or $unified_info{rename}->{$dest} eq $to;
-            $unified_info{rename}->{$dest} = $to;
-        }
-
         foreach (@programs) {
             my $program = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$program}) {
-                $program = $unified_info{rename}->{$program};
-            }
             $unified_info{programs}->{$program} = 1;
         }
 
         foreach (@programs_install) {
             my $program = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$program}) {
-                $program = $unified_info{rename}->{$program};
-            }
             $unified_info{install}->{programs}->{$program} = 1;
         }
 
         foreach (@libraries) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{libraries}->{$library} = 1;
         }
 
         foreach (@libraries_install) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{install}->{libraries}->{$library} = 1;
         }
 
@@ -1948,33 +1919,21 @@ This is usually a fault in a build.info file.
 EOF
         foreach (@engines) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{engines}->{$library} = 1;
         }
 
         foreach (@engines_install) {
             my $library = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$library}) {
-                $library = $unified_info{rename}->{$library};
-            }
             $unified_info{install}->{engines}->{$library} = 1;
         }
 
         foreach (@scripts) {
             my $script = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$script}) {
-                $script = $unified_info{rename}->{$script};
-            }
             $unified_info{scripts}->{$script} = 1;
         }
 
         foreach (@scripts_install) {
             my $script = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$script}) {
-                $script = $unified_info{rename}->{$script};
-            }
             $unified_info{install}->{scripts}->{$script} = 1;
         }
 
@@ -1990,53 +1949,20 @@ EOF
 
         push @{$unified_info{rawlines}}, @rawlines;
 
-        unless ($disabled{shared}) {
-            # Check sharednames.
-            foreach (keys %sharednames) {
-                my $dest = cleanfile($buildd, $_, $blddir);
-                if ($unified_info{rename}->{$dest}) {
-                    $dest = $unified_info{rename}->{$dest};
-                }
-                die "shared_name for $dest with multiple values: "
-                    ,join(" ", @{$sharednames{$_}}),"\n"
-                    if scalar @{$sharednames{$_}} > 1;
-                my $to = cleanfile($buildd, $sharednames{$_}->[0], $blddir);
-                die "shared_name found for a library $dest that isn't defined\n"
-                    unless $unified_info{libraries}->{$dest};
-                die "shared_name for $dest with multiple values: "
-                    ,$unified_info{sharednames}->{$dest}, ", ", $to
-                    unless !defined($unified_info{sharednames}->{$dest})
-                    or $unified_info{sharednames}->{$dest} eq $to;
-                $unified_info{sharednames}->{$dest} = $to;
-            }
-
-            # Additionally, we set up sharednames for libraries that don't
-            # have any, as themselves.  Only for libraries that aren't
-            # explicitly static.
-            foreach (grep !/\.a$/, keys %{$unified_info{libraries}}) {
-                if (!defined $unified_info{sharednames}->{$_}) {
-                    $unified_info{sharednames}->{$_} = $_
-                }
-            }
-
-            # Check that we haven't defined any library as both shared and
-            # explicitly static.  That is forbidden.
-            my @doubles = ();
-            foreach (grep /\.a$/, keys %{$unified_info{libraries}}) {
-                (my $l = $_) =~ s/\.a$//;
-                push @doubles, $l if defined $unified_info{sharednames}->{$l};
-            }
-            die "these libraries are both explicitly static and shared:\n  ",
-                join(" ", @doubles), "\n"
-                if @doubles;
+        # Check that we haven't defined any library as both shared and
+        # explicitly static.  That is forbidden.
+        my @doubles = ();
+        foreach (grep /\.a$/, keys %{$unified_info{libraries}}) {
+            (my $l = $_) =~ s/\.a$//;
+            push @doubles, $l if defined $unified_info{libraries}->{$l};
         }
+        die "these libraries are both explicitly static and shared:\n  ",
+            join(" ", @doubles), "\n"
+            if @doubles;
 
         foreach (keys %sources) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
             foreach (@{$sources{$dest}}) {
                 my $s = cleanfile($sourced, $_, $blddir);
 
@@ -2069,9 +1995,6 @@ EOF
         foreach (keys %shared_sources) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
             foreach (@{$shared_sources{$dest}}) {
                 my $s = cleanfile($sourced, $_, $blddir);
 
@@ -2110,9 +2033,6 @@ EOF
         foreach (keys %generate) {
             my $dest = $_;
             my $ddest = cleanfile($buildd, $_, $blddir);
-            if ($unified_info{rename}->{$ddest}) {
-                $ddest = $unified_info{rename}->{$ddest};
-            }
             die "more than one generator for $dest: "
                     ,join(" ", @{$generate{$_}}),"\n"
                     if scalar @{$generate{$_}} > 1;
@@ -2129,9 +2049,6 @@ EOF
             # a generated file in the build tree.
             if ($ddest ne "" && ($ddest eq $src_configdata || ! -f $ddest)) {
                 $ddest = cleanfile($buildd, $_, $blddir);
-                if ($unified_info{rename}->{$ddest}) {
-                    $ddest = $unified_info{rename}->{$ddest};
-                }
             }
             foreach (@{$depends{$dest}}) {
                 my $d = cleanfile($sourced, $_, $blddir);
@@ -2154,11 +2071,7 @@ EOF
                 # should be added back after treatment.
                 $d =~ /(\.a)?$/;
                 my $e = $1 // "";
-                $d = $`;
-                if ($unified_info{rename}->{$d}) {
-                    $d = $unified_info{rename}->{$d};
-                }
-                $d .= $e;
+                $d = $`.$e;
                 $unified_info{depends}->{$ddest}->{$d} = 1;
             }
         }
@@ -2171,9 +2084,6 @@ EOF
             # a generated file in the build tree.
             if ($ddest eq $src_configdata || ! -f $ddest) {
                 $ddest = cleanfile($buildd, $_, $blddir);
-                if ($unified_info{rename}->{$ddest}) {
-                    $ddest = $unified_info{rename}->{$ddest};
-                }
             }
             foreach (@{$includes{$dest}}) {
                 my $is = cleandir($sourced, $_, $blddir);

--- a/Configure
+++ b/Configure
@@ -1125,18 +1125,8 @@ foreach my $feature (@{$target{enable}}) {
 
 $target{CXXFLAGS}//=$target{CFLAGS} if $target{CXX};
 $target{cxxflags}//=$target{cflags} if $target{CXX};
-$target{exe_extension}="";
-$target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
-                                  || $config{target} =~ /^(?:Cygwin|mingw)/);
+$target{exe_extension}=".exe" if ($config{target} eq "DJGPP");
 $target{exe_extension}=".pm"  if ($config{target} =~ /vos/);
-$target{def_extension}=".ld";
-$target{def_extension}=".def" if $config{target} =~ /^mingw/;
-($target{shared_extension_simple}=$target{shared_extension})
-    =~ s|\.\$\(SHLIB_VERSION_NUMBER\)||
-    unless defined($target{shared_extension_simple});
-$target{dso_extension}//=$target{shared_extension_simple};
-($target{shared_import_extension}=$target{shared_extension_simple}.".a")
-    if ($config{target} =~ /^(?:Cygwin|mingw)/);
 
 # Fill %config with values from %user, and in case those are undefined or
 # empty, use values from %target (acting as a default).

--- a/Configure
+++ b/Configure
@@ -1131,7 +1131,6 @@ $target{exe_extension}=".exe" if ($config{target} eq "DJGPP"
 $target{exe_extension}=".pm"  if ($config{target} =~ /vos/);
 $target{def_extension}=".ld";
 $target{def_extension}=".def" if $config{target} =~ /^mingw/;
-$target{def_extension}=".opt" if $config{target} =~ /^vms/;
 ($target{shared_extension_simple}=$target{shared_extension})
     =~ s|\.\$\(SHLIB_VERSION_NUMBER\)||
     unless defined($target{shared_extension_simple});

--- a/build.info
+++ b/build.info
@@ -2,15 +2,6 @@
 # %skipdir there for further explanations.
 SUBDIRS=crypto ssl apps test util tools fuzz engines
 
-{-
-     my @sover = split(/\./, $config{shlib_version});
-     our $sover_filename;
-     $sover_filename = join('.', @sover)
-         if $config{target} =~ /^mingw/ || $config{target} =~ /^VC-/;
-     $sover_filename = join('', map { sprintf "%02d", $_ } @sover)
-         if $config{target} =~ /^vms/;
-     "";
--}
 LIBS=libcrypto libssl
 INCLUDE[libcrypto]=. crypto/include include
 INCLUDE[libssl]=. include
@@ -43,27 +34,4 @@ IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
 
   SHARED_SOURCE[libcrypto]=libcrypto.rc
   SHARED_SOURCE[libssl]=libssl.rc
-ENDIF
-
-IF[{- $config{target} =~ /^Cygwin/ -}]
- SHARED_NAME[libcrypto]=cygcrypto-{- $sover_filename -}
- SHARED_NAME[libssl]=cygssl-{- $sover_filename -}
-ELSIF[{- $config{target} =~ /^mingw/ -}]
- SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
- SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $config{target} eq "mingw64" ? "-x64" : "" -}
-ELSIF[{- $config{target} =~ /^VC-/ -}]
- SHARED_NAME[libcrypto]=libcrypto-{- $sover_filename -}{- $target{multilib} -}
- SHARED_NAME[libssl]=libssl-{- $sover_filename -}{- $target{multilib} -}
-ENDIF
-
-# VMS has a cultural standard where all libraries are prefixed.
-# For OpenSSL, the choice is 'ossl$' (this prefix was claimed in a
-# conversation with VSI, Tuesday January 26 2016)
-# Also, it seems it's usual to have the pointer size the libraries
-# were built for as part of the name.
-IF[{- $config{target} =~ /^vms/ -}]
- RENAME[libcrypto]=ossl$libcrypto{- $target{pointer_size} -}
- RENAME[libssl]=ossl$libssl{- $target{pointer_size} -}
- SHARED_NAME[libcrypto]=ossl$libcrypto{- $sover_filename -}_shr{- $target{pointer_size} -}
- SHARED_NAME[libssl]=ossl$libssl{- $sover_filename -}_shr{- $target{pointer_size} -}
 ENDIF

--- a/crypto/include/internal/dso_conf.h.in
+++ b/crypto/include/internal/dso_conf.h.in
@@ -25,6 +25,6 @@
         @macros = ( "DSO_DLFCN" );
     }
     join("\n", map { "# define $_" } @macros); -}
-# define DSO_EXTENSION "{- $target{dso_extension} -}"
+# define DSO_EXTENSION "{- platform->dsoext() -}"
 {- output_on() if $disabled{dso} -}
 #endif

--- a/util/dofile.pl
+++ b/util/dofile.pl
@@ -176,10 +176,20 @@ my $text =
 # Load the full template (combination of files) into Text::Template
 # and fill it up with our data.  Output goes directly to STDOUT
 
+my $prepend = qq{
+use File::Spec::Functions;
+use lib catdir('$config{sourcedir}', 'util', 'perl');
+};
+$prepend .= qq{
+use lib catdir('$config{sourcedir}', 'Configurations');
+use lib '$config{builddir}';
+use platform;
+} if defined $target{perl_platform};
+
 my $template =
     OpenSSL::Template->new(TYPE => 'STRING',
                            SOURCE => $text,
-                           PREPEND => qq{use lib "$FindBin::Bin/perl";});
+                           PREPEND => $prepend);
 
 sub output_reset_on {
     $template->output_reset_on();

--- a/util/local_shlib.com.in
+++ b/util/local_shlib.com.in
@@ -1,10 +1,7 @@
 ${-
-  use File::Spec::Functions qw(rel2abs);
-
-  my $bldtop = rel2abs($config{builddir});
-  our %names = ( map { $_ => $bldtop.$_.".EXE" }
-                 map { $unified_info{sharednames}->{$_} || () }
-                 @{$unified_info{libraries}} );
+  our %names = ( map { platform->sharedname($_) =>
+                           $bldtop.platform->sharedlib($_) }
+                 @{$unified_info{install}->{libraries}} );
   "" -}
 $       ! Create a local environment with the shared library logical names
 $       ! properly set.  Undo this with unlocal_shlib.com
@@ -15,7 +12,7 @@ $       DEFINE/TABLE='OPENSSL_NAMES' OSSL_FLAG YES
 $
 $       NAMES := {- join(",", keys %names); -}
 {-
-  join("\n", map { "\$       __$_ = \"".$names{$_}."\"" } keys %names);
+  join("\n", map { "\$       __$_ = \"".$names{$_}."\"" } sort keys %names);
 -}      
 $       I = 0
 $       LOOP:

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -21,6 +21,10 @@ use OpenSSL::Ordinals;
 use lib '.';
 use configdata;
 
+use File::Spec::Functions;
+use lib catdir($config{sourcedir}, 'Configurations');
+use platform;
+
 my $name = undef;               # internal library/module name
 my $ordinals_file = undef;      # the ordinals file to use
 my $version = undef;            # the version to use for the library
@@ -100,7 +104,7 @@ my $apiv = undef;
 $apiv = sprintf "%x%02x%02x", split(/\./, $config{api})
     if $config{api};
 
-my $libname = $unified_info{sharednames}->{$name} // $name;
+my $libname = platform->sharedname($name);
 
 my %OS_data = (
     solaris     => { writer     => \&writer_linux,

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -2,20 +2,8 @@
 {-
     use lib '.';
     use configdata;
-
-    sub shlib {
-        my $lib = shift;
-        return "" if $disabled{shared};
-        $lib = $unified_info{rename}->{$lib}
-            if defined $unified_info{rename}->{$lib};
-        $lib = $unified_info{sharednames}->{$lib}
-            . ($target{shlib_variant} || "")
-            . ($target{shared_extension} || ".so");
-        $lib =~ s|\.\$\(SHLIB_VERSION_NUMBER\)
-                 |.$config{shlib_version}|x;
-        return $lib;
-    }
-    "";     # Make sure no left over string sneaks its way into the script
+    use lib catdir($config{sourcedir}, 'Configurations');
+    use platform;
 -}
 # To test this OpenSSL version's applications against another version's
 # shared libraries, simply set
@@ -42,8 +30,8 @@ fi
 THERE="`echo $0 | sed -e 's|[^/]*$||' 2>/dev/null`.."
 [ -d "${THERE}" ] || exec "$@"	# should never happen...
 
-LIBCRYPTOSO="${THERE}/{- shlib('libcrypto') -}"
-LIBSSLSO="${THERE}/{- shlib('libssl') -}"
+LIBCRYPTOSO="${THERE}/{- platform->sharedlib('libcrypto') -}"
+LIBSSLSO="${THERE}/{- platform->sharedlib('libssl') -}"
 
 SYSNAME=`(uname -s) 2>/dev/null`;
 case "$SYSNAME" in

--- a/util/unlocal_shlib.com.in
+++ b/util/unlocal_shlib.com.in
@@ -1,17 +1,14 @@
 ${-
-  use File::Spec::Functions qw(rel2abs);
-
-  my $bldtop = rel2abs($config{builddir});
-  our %names = ( map { $_ => $bldtop.$_.".EXE" }
-                 map { $unified_info{sharednames}->{$_} || () }
-                 @{$unified_info{libraries}} );
+  our %names = ( map { platform->sharedname($_) =>
+                           $bldtop.platform->sharedlib($_) }
+                 @{$unified_info{install}->{libraries}} );
   "" -}
 $       ! Remove the local environment created by local_shlib.com
 $
 $       OPENSSL_NAMES := OPENSSL_NAMES_'F$GETJPI("","PID")'
 $       IF F$TRNLNM("OSSL_FLAG",OPENSSL_NAMES) .EQS. "" THEN EXIT 0
 $
-$       NAMES := {- join(",", keys %names); -}
+$       NAMES := {- join(",", sort keys %names); -}
 $       I = 0
 $       LOOP:
 $           E = F$ELEMENT(I,",",NAMES)


### PR DESCRIPTION
This is the start of a major work to correct some quirks in the
building system.  The base for this is to move certain attributes that
lack desired flexibility from `Configurations/*.conf` to Perl modules
that can be selected with one single attribute in the config targets.

The way this is meant to work is by adding this attribute in select
config targets:

    perl_module         => 'Name';      # Name to be replaced

Then, in the perl scripts or modules that need the functionality,
these lines should be added:

    use lib catdir($srcdir, 'Configurations');	# Ensure access to platform.pm
    use lib $blddir;    # Ensure access to configdata.pm
    use platform;       # Will load platform::$target{perl_module}


The main work here is to move file extension information as well as
library name manipulation to modules.  The main platform modules
added are `platform::Unix`, `platform::Windows` and `platform::VMS`.
Along with them are `platform::mingw` and `platform::Cygwin`, which
are specializations of `platform::Unix` adapted for those specific
targets.

This is related to #7470