### PR TITLE
Avoid BN reallocations

### DIFF
--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "internal/bn_int.h"
 #include <openssl/bn.h>
 #include <openssl/sha.h>
 #include "dsa_locl.h"
@@ -180,9 +181,9 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
 {
     BN_CTX *ctx = NULL;
     BIGNUM *k, *kinv = NULL, *r = *rp;
-    BIGNUM *l, *m;
+    BIGNUM *l;
     int ret = 0;
-    int q_bits;
+    int q_bits, q_words;
 
     if (!dsa->p || !dsa->q || !dsa->g) {
         DSAerr(DSA_F_DSA_SIGN_SETUP, DSA_R_MISSING_PARAMETERS);
@@ -191,8 +192,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
 
     k = BN_new();
     l = BN_new();
-    m = BN_new();
-    if (k == NULL || l == NULL || m == NULL)
+    if (k == NULL || l == NULL)
         goto err;
 
     if (ctx_in == NULL) {
@@ -203,9 +203,9 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
 
     /* Preallocate space */
     q_bits = BN_num_bits(dsa->q);
-    if (!BN_set_bit(k, q_bits)
-        || !BN_set_bit(l, q_bits)
-        || !BN_set_bit(m, q_bits))
+    q_words = bn_get_top(dsa->q);
+    if (!bn_wexpand(k, q_words + 2)
+        || !bn_wexpand(l, q_words + 2))
         goto err;
 
     /* Get random k */
@@ -240,13 +240,16 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
      * small timing information leakage.  We then choose the sum that is
      * one bit longer than the modulus.
      *
-     * TODO: revisit the BN_copy aiming for a memory access agnostic
-     * conditional copy.
+     * There are some concerns about the efficacy of doing this.  More
+     * specificly refer to the discussion starting with:
+     *     https://github.com/openssl/openssl/pull/7486#discussion_r228323705
+     * The fix is to rework BN so these gymnastics aren't required.
      */
     if (!BN_add(l, k, dsa->q)
-        || !BN_add(m, l, dsa->q)
-        || !BN_copy(k, BN_num_bits(l) > q_bits ? l : m))
+        || !BN_add(k, l, dsa->q))
         goto err;
+
+    BN_consttime_swap(BN_is_bit_set(l, q_bits), k, l, q_words + 2);
 
     if ((dsa)->meth->bn_mod_exp != NULL) {
             if (!dsa->meth->bn_mod_exp(dsa, r, dsa->g, k, dsa->p, ctx,
@@ -260,7 +263,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
     if (!BN_mod(r, r, dsa->q, ctx))
         goto err;
 
-    /* Compute  part of 's = inv(k) (m + xr) mod q' */
+    /* Compute part of 's = inv(k) (m + xr) mod q' */
     if ((kinv = dsa_mod_inverse_fermat(k, dsa->q, ctx)) == NULL)
         goto err;
 
@@ -275,7 +278,6 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
         BN_CTX_free(ctx);
     BN_clear_free(k);
     BN_clear_free(l);
-    BN_clear_free(m);
     return ret;
 }
 

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -206,8 +206,8 @@ int ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
      */
     cardinality_bits = BN_num_bits(cardinality);
     group_top = bn_get_top(cardinality);
-    if ((bn_wexpand(k, group_top + 1) == NULL)
-        || (bn_wexpand(lambda, group_top + 1) == NULL)) {
+    if ((bn_wexpand(k, group_top + 2) == NULL)
+        || (bn_wexpand(lambda, group_top + 2) == NULL)) {
         ECerr(EC_F_EC_SCALAR_MUL_LADDER, ERR_R_BN_LIB);
         goto err;
     }
@@ -244,7 +244,7 @@ int ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
      * k := scalar + 2*cardinality
      */
     kbit = BN_is_bit_set(lambda, cardinality_bits);
-    BN_consttime_swap(kbit, k, lambda, group_top + 1);
+    BN_consttime_swap(kbit, k, lambda, group_top + 2);
 
     group_top = bn_get_top(group->field);
     if ((bn_wexpand(s->X, group_top) == NULL)


### PR DESCRIPTION
The earlier fix -- #4576 -- to avoid side channels in the DSA code was off by one in terms of the size the big numbers were pre-allocated to.  In some cases the allocations needed to be increased by one word and this resulted in a timing attack that could potentially leak information.  Increasing the size of the BNs prior to doing anything with them should prevent the leak.

A second variable time fix is included which avoids a variable length big number copy in favour of a constant time swap.

Thanks to Samuel Weiser for finding and reporting this.
