### PR TITLE
DSA mod inverse fix.

### DIFF
--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -23,7 +23,8 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
                          DSA_SIG *sig, DSA *dsa);
 static int dsa_init(DSA *dsa);
 static int dsa_finish(DSA *dsa);
-static BIGNUM *dsa_inverse_mod(const BIGNUM *k, const BIGNUM *q, BN_CTX *ctx);
+static BIGNUM *dsa_mod_inverse_fermat(const BIGNUM *k, const BIGNUM *q,
+                                      BN_CTX *ctx);
 
 static DSA_METHOD openssl_dsa_meth = {
     "OpenSSL DSA method",
@@ -260,7 +261,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
         goto err;
 
     /* Compute  part of 's = inv(k) (m + xr) mod q' */
-    if ((kinv = dsa_inverse_mod(k, dsa->q, ctx)) == NULL)
+    if ((kinv = dsa_mod_inverse_fermat(k, dsa->q, ctx)) == NULL)
         goto err;
 
     BN_clear_free(*kinvp);
@@ -402,7 +403,8 @@ static int dsa_finish(DSA *dsa)
  * so a constant time mod-exp shouldn't be required.  A newly allocated BIGNUM
  * is returned which the caller must free.
  */
-static BIGNUM *dsa_inverse_mod(const BIGNUM *k, const BIGNUM *q, BN_CTX *ctx)
+static BIGNUM *dsa_mod_inverse_fermat(const BIGNUM *k, const BIGNUM *q,
+                                      BN_CTX *ctx)
 {
     BIGNUM *res = NULL;
     BIGNUM *r, *e;

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -400,8 +400,8 @@ static int dsa_finish(DSA *dsa)
  * Compute the inverse of k modulo q.
  * Since q is prime, Fermat's Little Theorem applies, which reduces this to
  * mod-exp operation.  Both the exponent and modulus are public information
- * so a constant time mod-exp shouldn't be required.  A newly allocated BIGNUM
- * is returned which the caller must free.
+ * so a mod-exp that doesn't leak the base is sufficient.  A newly allocated
+ * BIGNUM is returned which the caller must free.
  */
 static BIGNUM *dsa_mod_inverse_fermat(const BIGNUM *k, const BIGNUM *q,
                                       BN_CTX *ctx)
@@ -416,7 +416,7 @@ static BIGNUM *dsa_mod_inverse_fermat(const BIGNUM *k, const BIGNUM *q,
     if ((e = BN_CTX_get(ctx)) != NULL
             && BN_set_word(r, 2)
             && BN_sub(e, q, r)
-            && BN_mod_exp(r, k, e, q, ctx))
+            && BN_mod_exp_mont(r, k, e, q, ctx, NULL))
         res = r;
     else
         BN_free(r);

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -23,6 +23,7 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
                          DSA_SIG *sig, DSA *dsa);
 static int dsa_init(DSA *dsa);
 static int dsa_finish(DSA *dsa);
+static BIGNUM *dsa_inverse_mod(const BIGNUM *k, const BIGNUM *q, BN_CTX *ctx);
 
 static DSA_METHOD openssl_dsa_meth = {
     "OpenSSL DSA method",
@@ -259,7 +260,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
         goto err;
 
     /* Compute  part of 's = inv(k) (m + xr) mod q' */
-    if ((kinv = BN_mod_inverse(NULL, k, dsa->q, ctx)) == NULL)
+    if ((kinv = dsa_inverse_mod(k, dsa->q, ctx)) == NULL)
         goto err;
 
     BN_clear_free(*kinvp);
@@ -392,4 +393,31 @@ static int dsa_finish(DSA *dsa)
 {
     BN_MONT_CTX_free(dsa->method_mont_p);
     return 1;
+}
+
+/*
+ * Compute the inverse of k modulo q.
+ * Since q is prime, Fermat's Little Theorem applies, which reduces this to
+ * mod-exp operation.  Both the exponent and modulus are public information
+ * so a constant time mod-exp shouldn't be required.  A newly allocated BIGNUM
+ * is returned which the caller must free.
+ */
+static BIGNUM *dsa_inverse_mod(const BIGNUM *k, const BIGNUM *q, BN_CTX *ctx)
+{
+    BIGNUM *res = NULL;
+    BIGNUM *r, *e;
+
+    if ((r = BN_new()) == NULL)
+        return NULL;
+
+    BN_CTX_start(ctx);
+    if ((e = BN_CTX_get(ctx)) != NULL
+            && BN_set_word(r, 2)
+            && BN_sub(e, q, r)
+            && BN_mod_exp(r, k, e, q, ctx))
+        res = r;
+    else
+        BN_free(r);
+    BN_CTX_end(ctx);
+    return res;
 }


### PR DESCRIPTION
There is a side channel attack against the division used to calculate one of
the modulo inverses in the DSA algorithm.  This change takes advantage of the
primality of the modulo and Fermat's little theorem to calculate the inverse
without leaking information.

Thanks to Samuel Weiser for finding and reporting this.
