### PR TITLE
DSA: Check for sanity of input parameters

### DIFF
--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -327,6 +327,12 @@ int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
     if (mctx == NULL)
         goto err;
 
+    /* make sure L > N, otherwise we'll get trapped in an infinite loop */
+    if (L <= N) {
+        DSAerr(DSA_F_DSA_BUILTIN_PARAMGEN2, DSA_R_INVALID_PARAMETERS);
+        goto err;
+    }
+
     if (evpmd == NULL) {
         if (N == 160)
             evpmd = EVP_sha1();


### PR DESCRIPTION
dsa_builtin_paramgen2 never finishes when L <= N.

Looking at the FIPS 186-2 DSA specification, which it implements:

Step 3 generates q in the range 2^N-1 and 2^N

Step 8 derives X from the seed value:
  X = W + 2^L-1
  (here W is smaller than 2^L-1 and hence X lies between 2^L-1 and 2^L)

Step 9 computes p by rounding X to a number congruent to 1 mod 2q:
  c = X mod 2q
  p = X - (c - 1)

Step 10
  If p < 2^L-1 then start generating again

So for example if in paramgen2 N and L are both equal to 256.
Then X belongs to the interval (2^255, 2^256) as does q.
This however makes 2q greater than 2^256, consequently also greater than X.

So in Step 9, c = X mod 2q yields back the value of X.
And p = X - (c - 1) thus sets p to the value of 1.
1 is smaller than  2^255 and the condition in step 10 is never fulfilled.

When L and N are equal, the paramgen2 algorithm loops.
L must be greater than N, eg. L=257, N=256 makes it successfully find the DSA parameters.

