### PR TITLE
Windows: Produce a static version of the public libraries, always

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -41,6 +41,8 @@
 
  sub lib {
      (my $lib = shift) =~ s/\.a$//;
+     $lib .= '_static'
+         if (defined $unified_info{sharednames}->{$lib});
      return $lib . $libext;
  }
 
@@ -75,7 +77,7 @@ MINOR={- $config{minor} -}
 
 SHLIB_VERSION_NUMBER={- $config{shlib_version_number} -}
 
-LIBS={- join(" ", map { lib($_) } @{$unified_info{libraries}}) -}
+LIBS={- join(" ", map { ( shlib_import($_), lib($_) ) } @{$unified_info{libraries}}) -}
 SHLIBS={- join(" ", map { shlib($_) } @{$unified_info{libraries}}) -}
 SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; shlib($_) } @{$unified_info{libraries}}) -}
 ENGINES={- join(" ", map { dso($_) } @{$unified_info{engines}}) -}
@@ -96,7 +98,7 @@ GENERATED={- # common0.tmpl provides @generated
                              $x }
                        @generated) -}
 
-INSTALL_LIBS={- join(" ", map { quotify1(lib($_)) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_LIBS={- join(" ", map { quotify1(shlib_import($_) or lib($_)) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { quotify_l(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; quotify_l(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_ENGINES={- join(" ", map { quotify1(dso($_)) } @{$unified_info{install}->{engines}}) -}
@@ -490,11 +492,6 @@ reconfigure reconf:
      if ($disabled{shared}) {
 	 return map { lib($_) } @_;
      }
-     foreach (@_) {
-         (my $l = $_) =~ s/\.a$//;
-         die "Linking with static variants of shared libraries is not supported in this configuration\n"
-             if $l ne $_ && shlib($l);
-     }
      return map { shlib_import($_) or lib($_) } @_;
  }
 
@@ -702,20 +699,13 @@ EOF
  }
  sub obj2lib {
      my %args = @_;
-     my $lib = $args{lib};
-
-     # Because static libs and import libs are both named the same in native
-     # Windows, we can't have both.  We skip the static lib in that case,
-     # as the shared libs are what we use anyway.
-     return "" unless $disabled{"shared"} || $lib =~ /\.a$/;
-
-     $lib =~ s/\.a$//;
+     my $lib = lib($args{lib});
      my @objs = map { (my $x = $_) =~ s|\.o$|$objext|; $x } @{$args{objs}};
      my $objs = join("\n", @objs);
      my $deps = join(" ", @objs);
      return <<"EOF";
-$lib$libext: $deps
-	\$(AR) \$(ARFLAGS) \$(AROUTFLAG)$lib$libext @<<
+$lib: $deps
+	\$(AR) \$(ARFLAGS) \$(AROUTFLAG)$lib @<<
 $objs
 <<
 EOF

--- a/test/build.info
+++ b/test/build.info
@@ -436,10 +436,8 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   # available through the shared library (at least on Linux, Solaris, Windows
   # and VMS, where the exported symbols are those listed in util/*.num), these
   # programs are forcibly linked with the static libraries, where all symbols
-  # are always available.  This excludes linking these programs natively on
-  # Windows when building shared libraries, since the static libraries share
-  # names with the DLL import libraries.
-  IF[{- $disabled{shared} || $target{build_scheme}->[1] ne 'windows' -}]
+  # are always available.
+  IF[1]
     PROGRAMS_NO_INST=asn1_internal_test modes_internal_test x509_internal_test \
                      tls13encryptiontest wpackettest ctype_internal_test \
                      rdrand_sanitytest


### PR DESCRIPTION
When building shared libraries on Windows, we had a clash between
'libcrypto.lib' the static routine library and 'libcrypto.lib' the
import library.

We now change it so the static versions of our libraries get '_static'
appended to their names.  These will never get installed, but can
still be used for our internal purposes, such as internal tests.

When building non-shared, the renaming mechanism doesn't com into
play.  In that case, the static libraries 'libcrypto.lib' and
'libssl.lib' are installed, just as always.

Fixes #7492

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
