### PR TITLE
Configure: Reword the summary output

### DIFF
--- a/Configure
+++ b/Configure
@@ -2799,10 +2799,16 @@ print <<"EOF";
 
 **********************************************************************
 ***                                                                ***
-***   If you want to report a building issue, please include the   ***
-***   output from this command:                                    ***
+***   OpenSSL has been successfully configured                     ***
 ***                                                                ***
-***     perl configdata.pm --dump                                  ***
+***   If you encounter a problem during building, please open an   ***
+***   issue on GitHub <https://github.com/openssl/openssl/issues>  ***
+***   and include the output from the following command:           ***
+***                                                                ***
+***       perl configdata.pm --dump                                ***
+***                                                                ***
+***   (If you are new to OpenSSL, you might want to consult the    ***
+***   'Troubleshooting' section in the INSTALL file first.)        ***
 ***                                                                ***
 **********************************************************************
 EOF

--- a/Configure
+++ b/Configure
@@ -2808,7 +2808,7 @@ print <<"EOF";
 ***       perl configdata.pm --dump                                ***
 ***                                                                ***
 ***   (If you are new to OpenSSL, you might want to consult the    ***
-***   'Troubleshooting' section in the INSTALL file first.)        ***
+***   'Troubleshooting' section in the INSTALL file first)         ***
 ***                                                                ***
 **********************************************************************
 EOF

--- a/Configure
+++ b/Configure
@@ -2801,7 +2801,7 @@ print <<"EOF";
 ***                                                                ***
 ***   OpenSSL has been successfully configured                     ***
 ***                                                                ***
-***   If you encounter a problem during building, please open an   ***
+***   If you encounter a problem while building, please open an    ***
 ***   issue on GitHub <https://github.com/openssl/openssl/issues>  ***
 ***   and include the output from the following command:           ***
 ***                                                                ***


### PR DESCRIPTION
### The Problem

In commit 820e414d2830 (pr #5247) the summary output of the Configure command was optimized towards instructing people how to create issue reports.


```
/usr/bin/perl ./Configure debug-linux-x86_64 shared enable-crypto-mdebug --strict-warnings --prefix=/opt/openssl-dev
Configuring OpenSSL version 1.1.2-dev (0x10102000L) for debug-linux-x86_64
Using os-specific seed configuration
Creating configdata.pm
Creating Makefile

**********************************************************************
***                                                                ***
***   If you want to report a building issue, please include the   ***
***   output from this command:                                    ***
***                                                                ***
***     perl configdata.pm --dump                                  ***
***                                                                ***
**********************************************************************
```

It turned out that the wording of this message can confuse new OpenSSL users and make them think that they are seeing an error message.

No, I'm not joking. If you don't believe it, have a look at #7068 and #7212, it happened already twice. @mattcaswell is my witness, he was involved in both. You can read the threads starting at comments

* https://github.com/openssl/openssl/issues/7068#issuecomment-416607095
* https://github.com/openssl/openssl/issues/7212#issuecomment-420912350


### Proposal

This commit makes the summary output start with a friendly success message to prevent a misunderstanding from the very beginning. Also it gives more hints to new OpenSSL users.

```
msp@msppc:~/src/openssl$ ./myconfigure
+ /usr/bin/perl ./Configure debug-linux-x86_64 shared enable-crypto-mdebug --strict-warnings --prefix=/opt/openssl-dev
Configuring OpenSSL version 1.1.2-dev (0x10102000L) for debug-linux-x86_64
Using os-specific seed configuration
Creating configdata.pm
Creating Makefile

**********************************************************************
***                                                                ***
***   OpenSSL has been successfully configured                     ***
***                                                                ***
***   If you encounter a problem during building, please open an   ***
***   issue on GitHub <https://github.com/openssl/openssl/issues>  ***
***   and include the output from the following command:           ***
***                                                                ***
***       perl configdata.pm --dump                                ***
***                                                                ***
***   (If you are new to OpenSSL, you might want to consult the    ***
***   'Troubleshooting' section in the INSTALL file first.)        ***
***                                                                ***
**********************************************************************
```

