### PR TITLE
Reset HKDF state between runs

### DIFF
--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -175,6 +175,18 @@ static int pkey_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     return -2;
 }
 
+static int pkey_hkdf_derive_init(EVP_PKEY_CTX *ctx)
+{
+    HKDF_PKEY_CTX *kctx = ctx->data;
+
+    OPENSSL_clear_free(kctx->key, kctx->key_len);
+    OPENSSL_clear_free(kctx->salt, kctx->salt_len);
+    OPENSSL_cleanse(kctx->info, kctx->info_len);
+    memset(kctx, 0, sizeof(*kctx));
+
+    return 1;
+}
+
 static int pkey_hkdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
                             size_t *keylen)
 {
@@ -236,7 +248,7 @@ const EVP_PKEY_METHOD hkdf_pkey_meth = {
 
     0, 0,
 
-    0,
+    pkey_hkdf_derive_init,
     pkey_hkdf_derive,
     pkey_hkdf_ctrl,
     pkey_hkdf_ctrl_str


### PR DESCRIPTION
You are supposed to be able to reuse an EVP_PKEY_CTX across multiple operations. This didn't work for HKDF.

Fixes #7497