### PR TITLE
Backport some DRBG renamings and typo fixes

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -341,13 +341,13 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
     }
 
     drbg->state = DRBG_READY;
-    drbg->generate_counter = 0;
+    drbg->reseed_gen_counter = 0;
     drbg->reseed_time = time(NULL);
-    if (drbg->reseed_counter > 0) {
+    if (drbg->reseed_prop_counter > 0) {
         if (drbg->parent == NULL)
-            drbg->reseed_counter++;
+            drbg->reseed_prop_counter++;
         else
-            drbg->reseed_counter = drbg->parent->reseed_counter;
+            drbg->reseed_prop_counter = drbg->parent->reseed_prop_counter;
     }
 
  end:
@@ -438,13 +438,13 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
         goto end;
 
     drbg->state = DRBG_READY;
-    drbg->generate_counter = 0;
+    drbg->reseed_gen_counter = 0;
     drbg->reseed_time = time(NULL);
-    if (drbg->reseed_counter > 0) {
+    if (drbg->reseed_prop_counter > 0) {
         if (drbg->parent == NULL)
-            drbg->reseed_counter++;
+            drbg->reseed_prop_counter++;
         else
-            drbg->reseed_counter = drbg->parent->reseed_counter;
+            drbg->reseed_prop_counter = drbg->parent->reseed_prop_counter;
     }
 
  end:
@@ -607,7 +607,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
     }
 
     if (drbg->reseed_interval > 0) {
-        if (drbg->generate_counter >= drbg->reseed_interval)
+        if (drbg->reseed_gen_counter >= drbg->reseed_interval)
             reseed_required = 1;
     }
     if (drbg->reseed_time_interval > 0) {
@@ -616,8 +616,8 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
             || now - drbg->reseed_time >= drbg->reseed_time_interval)
             reseed_required = 1;
     }
-    if (drbg->reseed_counter > 0 && drbg->parent != NULL) {
-        if (drbg->reseed_counter != drbg->parent->reseed_counter)
+    if (drbg->reseed_prop_counter > 0 && drbg->parent != NULL) {
+        if (drbg->reseed_prop_counter != drbg->parent->reseed_prop_counter)
             reseed_required = 1;
     }
 
@@ -636,7 +636,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
         return 0;
     }
 
-    drbg->generate_counter++;
+    drbg->reseed_gen_counter++;
 
     return 1;
 }
@@ -866,7 +866,7 @@ static RAND_DRBG *drbg_setup(RAND_DRBG *parent)
         goto err;
 
     /* enable seed propagation */
-    drbg->reseed_counter = 1;
+    drbg->reseed_prop_counter = 1;
 
     /*
      * Ignore instantiation error to support just-in-time instantiation.

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -80,7 +80,7 @@ typedef enum drbg_status_e {
 } DRBG_STATUS;
 
 
-/* intantiate */
+/* instantiate */
 typedef int (*RAND_DRBG_instantiate_fn)(RAND_DRBG *ctx,
                                         const unsigned char *ent,
                                         size_t entlen,
@@ -94,7 +94,7 @@ typedef int (*RAND_DRBG_reseed_fn)(RAND_DRBG *ctx,
                                    size_t entlen,
                                    const unsigned char *adin,
                                    size_t adinlen);
-/* generat output */
+/* generate output */
 typedef int (*RAND_DRBG_generate_fn)(RAND_DRBG *ctx,
                                      unsigned char *out,
                                      size_t outlen,
@@ -167,7 +167,7 @@ struct rand_drbg_st {
     int type; /* the nid of the underlying algorithm */
     /*
      * Stores the value of the rand_fork_count global as of when we last
-     * reseeded.  The DRG reseeds automatically whenever drbg->fork_count !=
+     * reseeded.  The DRBG reseeds automatically whenever drbg->fork_count !=
      * rand_fork_count.  Used to provide fork-safety and reseed this DRBG in
      * the child process.
      */
@@ -208,7 +208,7 @@ struct rand_drbg_st {
     size_t max_perslen, max_adinlen;
 
     /* Counts the number of generate requests since the last reseed. */
-    unsigned int generate_counter;
+    unsigned int reseed_gen_counter;
     /*
      * Maximum number of generate requests until a reseed is required.
      * This value is ignored if it is zero.
@@ -231,7 +231,7 @@ struct rand_drbg_st {
      * is added by RAND_add() or RAND_seed() will have an immediate effect on
      * the output of RAND_bytes() resp. RAND_priv_bytes().
      */
-    unsigned int reseed_counter;
+    unsigned int reseed_prop_counter;
 
     size_t seedlen;
     DRBG_STATUS state;

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -584,7 +584,7 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
 
     /*
      * Add process id, thread id, and a high resolution timestamp to
-     * ensure that the nonce is unique whith high probability for
+     * ensure that the nonce is unique with high probability for
      * different process instances.
      */
     data.pid = getpid();

--- a/include/openssl/rand_drbg.h
+++ b/include/openssl/rand_drbg.h
@@ -33,9 +33,9 @@
  * Default security strength (in the sense of [NIST SP 800-90Ar1])
  *
  * NIST SP 800-90Ar1 supports the strength of the DRBG being smaller than that
- * of the cipher by collecting less entropy. The current DRBG implemantion does
- * not take RAND_DRBG_STRENGTH into account and sets the strength of the DRBG
- * to that of the cipher.
+ * of the cipher by collecting less entropy. The current DRBG implementation
+ * does not take RAND_DRBG_STRENGTH into account and sets the strength of the
+ * DRBG to that of the cipher.
  *
  * RAND_DRBG_STRENGTH is currently only used for the legacy RAND
  * implementation.
@@ -44,7 +44,9 @@
  * NID_aes_256_ctr
  */
 # define RAND_DRBG_STRENGTH             256
+/* Default drbg type */
 # define RAND_DRBG_TYPE                 NID_aes_256_ctr
+/* Default drbg flags */
 # define RAND_DRBG_FLAGS                0
 
 

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -283,7 +283,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     RAND_DRBG *drbg = NULL;
     TEST_CTX t;
     unsigned char buff[1024];
-    unsigned int generate_counter_tmp;
+    unsigned int reseed_counter_tmp;
     int ret = 0;
 
     if (!TEST_ptr(drbg = RAND_DRBG_new(0, 0, NULL)))
@@ -302,7 +302,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
      * Entropy source tests
      */
 
-    /* Test entropy source failure detecion: i.e. returns no data */
+    /* Test entropy source failure detection: i.e. returns no data */
     t.entropylen = 0;
     if (TEST_int_le(RAND_DRBG_instantiate(drbg, td->pers, td->perslen), 0))
         goto err;
@@ -378,15 +378,15 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     /* Instantiate again with valid data */
     if (!instantiate(drbg, td, &t))
         goto err;
-    generate_counter_tmp = drbg->generate_counter;
-    drbg->generate_counter = drbg->reseed_interval;
+    reseed_counter_tmp = drbg->reseed_gen_counter;
+    drbg->reseed_gen_counter = drbg->reseed_interval;
 
     /* Generate output and check entropy has been requested for reseed */
     t.entropycnt = 0;
     if (!TEST_true(RAND_DRBG_generate(drbg, buff, td->exlen, 0,
                                       td->adin, td->adinlen))
             || !TEST_int_eq(t.entropycnt, 1)
-            || !TEST_int_eq(drbg->generate_counter, generate_counter_tmp + 1)
+            || !TEST_int_eq(drbg->reseed_gen_counter, reseed_counter_tmp + 1)
             || !uninstantiate(drbg))
         goto err;
 
@@ -403,15 +403,15 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     /* Test reseed counter works */
     if (!instantiate(drbg, td, &t))
         goto err;
-    generate_counter_tmp = drbg->generate_counter;
-    drbg->generate_counter = drbg->reseed_interval;
+    reseed_counter_tmp = drbg->reseed_gen_counter;
+    drbg->reseed_gen_counter = drbg->reseed_interval;
 
     /* Generate output and check entropy has been requested for reseed */
     t.entropycnt = 0;
     if (!TEST_true(RAND_DRBG_generate(drbg, buff, td->exlen, 0,
                                       td->adin, td->adinlen))
             || !TEST_int_eq(t.entropycnt, 1)
-            || !TEST_int_eq(drbg->generate_counter, generate_counter_tmp + 1)
+            || !TEST_int_eq(drbg->reseed_gen_counter, reseed_counter_tmp + 1)
             || !uninstantiate(drbg))
         goto err;
 
@@ -591,14 +591,14 @@ static int test_drbg_reseed(int expect_success,
      */
 
     /* Test whether seed propagation is enabled */
-    if (!TEST_int_ne(master->reseed_counter, 0)
-        || !TEST_int_ne(public->reseed_counter, 0)
-        || !TEST_int_ne(private->reseed_counter, 0))
+    if (!TEST_int_ne(master->reseed_prop_counter, 0)
+        || !TEST_int_ne(public->reseed_prop_counter, 0)
+        || !TEST_int_ne(private->reseed_prop_counter, 0))
         return 0;
 
     /* Check whether the master DRBG's reseed counter is the largest one */
-    if (!TEST_int_le(public->reseed_counter, master->reseed_counter)
-        || !TEST_int_le(private->reseed_counter, master->reseed_counter))
+    if (!TEST_int_le(public->reseed_prop_counter, master->reseed_prop_counter)
+        || !TEST_int_le(private->reseed_prop_counter, master->reseed_prop_counter))
         return 0;
 
     /*
@@ -643,8 +643,8 @@ static int test_drbg_reseed(int expect_success,
 
     if (expect_success == 1) {
         /* Test whether all three reseed counters are synchronized */
-        if (!TEST_int_eq(public->reseed_counter, master->reseed_counter)
-            || !TEST_int_eq(private->reseed_counter, master->reseed_counter))
+        if (!TEST_int_eq(public->reseed_prop_counter, master->reseed_prop_counter)
+            || !TEST_int_eq(private->reseed_prop_counter, master->reseed_prop_counter))
             return 0;
 
         /* Test whether reseed time of master DRBG is set correctly */
@@ -723,7 +723,7 @@ static int test_rand_reseed(void)
      * Test whether the public and private DRBG are both reseeded when their
      * reseed counters differ from the master's reseed counter.
      */
-    master->reseed_counter++;
+    master->reseed_prop_counter++;
     if (!TEST_true(test_drbg_reseed(1, master, public, private, 0, 1, 1)))
         goto error;
     reset_drbg_hook_ctx();
@@ -732,8 +732,8 @@ static int test_rand_reseed(void)
      * Test whether the public DRBG is reseeded when its reseed counter differs
      * from the master's reseed counter.
      */
-    master->reseed_counter++;
-    private->reseed_counter++;
+    master->reseed_prop_counter++;
+    private->reseed_prop_counter++;
     if (!TEST_true(test_drbg_reseed(1, master, public, private, 0, 1, 0)))
         goto error;
     reset_drbg_hook_ctx();
@@ -742,8 +742,8 @@ static int test_rand_reseed(void)
      * Test whether the private DRBG is reseeded when its reseed counter differs
      * from the master's reseed counter.
      */
-    master->reseed_counter++;
-    public->reseed_counter++;
+    master->reseed_prop_counter++;
+    public->reseed_prop_counter++;
     if (!TEST_true(test_drbg_reseed(1, master, public, private, 0, 0, 1)))
         goto error;
     reset_drbg_hook_ctx();
@@ -765,7 +765,7 @@ static int test_rand_reseed(void)
      * Test whether none of the DRBGs is reseed if the master fails to reseed
      */
     master_ctx.fail = 1;
-    master->reseed_counter++;
+    master->reseed_prop_counter++;
     RAND_add(rand_add_buf, sizeof(rand_add_buf), sizeof(rand_add_buf));
     if (!TEST_true(test_drbg_reseed(0, master, public, private, 0, 0, 0)))
         goto error;
@@ -920,7 +920,7 @@ static int test_rand_add(void)
 
     master->get_entropy = get_pool_entropy;
     master->cleanup_entropy = cleanup_pool_entropy;
-    master->reseed_counter++;
+    master->reseed_prop_counter++;
     RAND_DRBG_uninstantiate(master);
     memset(rand_add_buf, 0xCD, sizeof(rand_add_buf));
     RAND_add(rand_add_buf, sizeof(rand_add_buf), sizeof(rand_add_buf));


### PR DESCRIPTION
In commit 8bf366519661 some renamings andd typo fixes were made
while adding back the DRBG-HMAC and DRBG-HASH implementation.
Since the commit could not be backported, a lot of unnecessary
differences between master and 1.1.1 were introduced.

These differences result in tiresome merge conflicts when
cherry-picking. To minimize these merge-conflicts, this patch
ports all 'non-feature' changes of commit 8bf366519661
(e.g., renamings of private variables, fixes of typographical
errors, comment changes) manually back to 1.1.1.

The commits a83dc59afa2e (#7399) and 8817215d5c52 (#7456)
failed to cherry-pick previously to 1.1.1, with this patch
they both [cherry-pick without conflicts](https://github.com/mspncp/openssl/commits/pick-the-cherries).