### PR TITLE
Avoid two memory allocations in each RAND_DRBG_bytes

### DIFF
--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -45,9 +45,9 @@ size_t rand_drbg_get_nonce(RAND_DRBG *drbg,
 void rand_drbg_cleanup_nonce(RAND_DRBG *drbg,
                              unsigned char *out, size_t outlen);
 
-size_t rand_drbg_get_additional_data(unsigned char **pout, size_t max_len);
+size_t rand_drbg_get_additional_data(RAND_POOL *pool, unsigned char **pout);
 
-void rand_drbg_cleanup_additional_data(unsigned char *out, size_t outlen);
+void rand_drbg_cleanup_additional_data(RAND_POOL *pool, unsigned char *out);
 
 /*
  * RAND_POOL functions
@@ -59,6 +59,7 @@ void rand_pool_free(RAND_POOL *pool);
 
 const unsigned char *rand_pool_buffer(RAND_POOL *pool);
 unsigned char *rand_pool_detach(RAND_POOL *pool);
+void rand_pool_reattach(RAND_POOL *pool, unsigned char *buffer);
 
 size_t rand_pool_entropy(RAND_POOL *pool);
 size_t rand_pool_length(RAND_POOL *pool);

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -158,8 +158,10 @@ int RAND_DRBG_set(RAND_DRBG *drbg, int type, unsigned int flags)
     }
 
     /* If set is called multiple times - clear the old one */
-    if (type != drbg->type && drbg->type != 0 && drbg->meth != NULL) {
+    if (drbg->type != 0 && (type != drbg->type || flags != drbg->flags)) {
         drbg->meth->uninstantiate(drbg);
+        rand_pool_free(drbg->adin_pool);
+        drbg->adin_pool = NULL;
     }
 
     drbg->state = DRBG_UNINITIALISED;
@@ -168,6 +170,7 @@ int RAND_DRBG_set(RAND_DRBG *drbg, int type, unsigned int flags)
 
     if (type == 0) {
         /* Uninitialized; that's okay. */
+        drbg->meth = NULL;
         return 1;
     } else if (is_ctr(type)) {
         ret = drbg_ctr_init(drbg);
@@ -315,6 +318,7 @@ void RAND_DRBG_free(RAND_DRBG *drbg)
 
     if (drbg->meth != NULL)
         drbg->meth->uninstantiate(drbg);
+    rand_pool_free(drbg->adin_pool);
     CRYPTO_THREAD_lock_free(drbg->lock);
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_DRBG, drbg, &drbg->ex_data);
 
@@ -722,9 +726,18 @@ int RAND_DRBG_bytes(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
     unsigned char *additional = NULL;
     size_t additional_len;
     size_t chunk;
-    size_t ret;
+    size_t ret = 0;
 
-    additional_len = rand_drbg_get_additional_data(&additional, drbg->max_adinlen);
+    if (drbg->adin_pool == NULL) {
+        if (drbg->type == 0)
+            goto err;
+        drbg->adin_pool = rand_pool_new(0, 0, drbg->max_adinlen);
+        if (drbg->adin_pool == NULL)
+            goto err;
+    }
+
+    additional_len = rand_drbg_get_additional_data(drbg->adin_pool,
+                                                   &additional);
 
     for ( ; outlen > 0; outlen -= chunk, out += chunk) {
         chunk = outlen;
@@ -736,9 +749,9 @@ int RAND_DRBG_bytes(RAND_DRBG *drbg, unsigned char *out, size_t outlen)
     }
     ret = 1;
 
-err:
-    if (additional_len != 0)
-        OPENSSL_secure_clear_free(additional, additional_len);
+ err:
+    if (additional != NULL)
+        rand_drbg_cleanup_additional_data(drbg->adin_pool, additional);
 
     return ret;
 }

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -206,6 +206,11 @@ struct rand_drbg_st {
     struct rand_pool_st *pool;
 
     /*
+     * Auxiliary pool for additional data.
+     */
+    struct rand_pool_st *adin_pool;
+
+    /*
      * The following parameters are setup by the per-type "init" function.
      *
      * The supported types and their init functions are:


### PR DESCRIPTION
This is based on #7504 
Reusing the additional entropy pool on each RAND_DRBG_bytes
gives a very nice speed-up, measured with openssl speed rand:

un-patched master:
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
rand              5298.06k    20338.28k    38471.90k    62435.82k   122110.62k   111786.32k

master with patch:
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
rand              8055.33k    29506.63k    89650.94k   182102.82k   259083.64k   264094.74k

It is intended to back-port this to 1.1.1, but it will likely need an extra PR due to merge conflicts.