### PR TITLE
Configure: Improve warning if no random seed source was configured

### DIFF
--- a/Configure
+++ b/Configure
@@ -1013,13 +1013,18 @@ if (scalar(@seed_sources) == 0) {
 if (scalar(grep { $_ eq 'none' } @seed_sources) > 0) {
     die "Cannot seed with none and anything else" if scalar(@seed_sources) > 1;
     warn <<_____ if scalar(@seed_sources) == 1;
-You have selected the --with-rand-seed=none option, which effectively disables
-automatic reseeding of the OpenSSL random generator. All operations depending
-on the random generator such as creating keys will not work unless the random
-generator is seeded manually by the application.
 
-Please read the 'Note on random number generation' section in the INSTALL
-instructions and the RAND_DRBG(7) manual page for more details.
+============================== WARNING ===============================
+You have selected the --with-rand-seed=none option, which effectively
+disables automatic reseeding of the OpenSSL random generator.
+All operations depending on the random generator such as creating keys
+will not work unless the random generator is seeded manually by the
+application.
+
+Please read the 'Note on random number generation' section in the
+INSTALL instructions and the RAND_DRBG(7) manual page for more details.
+============================== WARNING ===============================
+
 _____
 }
 push @{$config{openssl_other_defines}},


### PR DESCRIPTION
The new Configure summary box (41349b5e6db) hides the warning about the missing seed source (2805ee1e095) too much. To make it more visible again, place it into a box of the same width.

### Before

```
/usr/bin/perl ./Configure debug-linux-x86_64 shared enable-crypto-mdebug --strict-warnings --prefix=/opt/openssl-dev --with-rand-seed=none
Configuring OpenSSL version 1.1.2-dev (0x10102000L) for debug-linux-x86_64
You have selected the --with-rand-seed=none option, which effectively disables
automatic reseeding of the OpenSSL random generator. All operations depending
on the random generator such as creating keys will not work unless the random
generator is seeded manually by the application.

Please read the 'Note on random number generation' section in the INSTALL
instructions and the RAND_DRBG(7) manual page for more details.
Creating configdata.pm
Creating Makefile

**********************************************************************
***                                                                ***
***   OpenSSL has been successfully configured                     ***
***                                                                ***
***   If you encounter a problem while building, please open an    ***
***   issue on GitHub <https://github.com/openssl/openssl/issues>  ***
***   and include the output from the following command:           ***
***                                                                ***
***       perl configdata.pm --dump                                ***
***                                                                ***
***   (If you are new to OpenSSL, you might want to consult the    ***
***   'Troubleshooting' section in the INSTALL file first)         ***
***                                                                ***
**********************************************************************
```

### After

```
/usr/bin/perl ./Configure debug-linux-x86_64 shared enable-crypto-mdebug --strict-warnings --prefix=/opt/openssl-dev --with-rand-seed=none
Configuring OpenSSL version 1.1.2-dev (0x10102000L) for debug-linux-x86_64

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!                                                                !!!
!!! OpenSSL has been configured without random seed source         !!!
!!!                                                                !!!
!!! The configuration includes the --with-rand-seed=none option,   !!!
!!! which effectively disables automatic reseeding of the OpenSSL  !!!
!!! random generator. All operations depending on the random       !!!
!!! generator such as creating keys will not work unless the       !!!
!!! random generator is seeded manually by the application.        !!!
!!!                                                                !!!
!!! Please read the 'Note on random number generation' section in  !!!
!!! the INSTALL instructions and the RAND_DRBG(7) manual page.     !!!
!!!                                                                !!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Creating configdata.pm
Creating Makefile

**********************************************************************
***                                                                ***
***   OpenSSL has been successfully configured                     ***
***                                                                ***
***   If you encounter a problem while building, please open an    ***
***   issue on GitHub <https://github.com/openssl/openssl/issues>  ***
***   and include the output from the following command:           ***
***                                                                ***
***       perl configdata.pm --dump                                ***
***                                                                ***
***   (If you are new to OpenSSL, you might want to consult the    ***
***   'Troubleshooting' section in the INSTALL file first)         ***
***                                                                ***
**********************************************************************
```
