### PR TITLE
randfile.c: fix a Coverity warning

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -110,7 +110,7 @@ int RAND_load_file(const char *file, long bytes)
 
     if (bytes < 0) {
         if (S_ISREG(sb.st_mode))
-            bytes = (sb.st_size <= LONG_MAX) ? sb.st_size : LONG_MAX;
+            bytes = sb.st_size;
         else
             bytes = RAND_DRBG_STRENGTH;
     }


### PR DESCRIPTION
Fixes the following Coverity warning:

```
*** CID 1440766:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
/crypto/rand/randfile.c: 113 in RAND_load_file()
107             fclose(in);
108             return -1;
109         }
110     
111         if (bytes < 0) {
112             if (S_ISREG(sb.st_mode))
>>>     CID 1440766:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
>>>     "sb.st_size <= 9223372036854775807L" is always true regardless of the values of its operands. This occurs as the logical first operand of "?:".
113                 bytes = (sb.st_size <= LONG_MAX) ? sb.st_size : LONG_MAX;
114             else
115                 bytes = RAND_DRBG_STRENGTH;
116         }
117     #endif
118         /*
```