### PR TITLE
drbg_lib: avoid NULL pointer dereference in drbg_add

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -1086,13 +1086,15 @@ static int drbg_add(const void *buf, int num, double randomness)
     int ret = 0;
     RAND_DRBG *drbg = RAND_DRBG_get0_master();
     size_t buflen;
-    size_t seedlen = rand_drbg_seedlen(drbg);
+    size_t seedlen;
 
     if (drbg == NULL)
         return 0;
 
     if (num < 0 || randomness < 0.0)
         return 0;
+
+    seedlen = rand_drbg_seedlen(drbg);
 
     buflen = (size_t)num;
 


### PR DESCRIPTION
Found by Coverity Scan

```
*** CID 1440764:  Null pointer dereferences  (REVERSE_INULL)
/crypto/rand/drbg_lib.c: 1091 in drbg_add()
1085     {
1086         int ret = 0;
1087         RAND_DRBG *drbg = RAND_DRBG_get0_master();
1088         size_t buflen;
1089         size_t seedlen = rand_drbg_seedlen(drbg);
1090     
>>>     CID 1440764:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "drbg" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1091         if (drbg == NULL)
1092             return 0;
1093     
1094         if (num < 0 || randomness < 0.0)
1095             return 0;
1096     
```