### PR TITLE
Merge of DSA reallocation fix.

### DIFF
--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -279,7 +279,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in, BIGNUM **kinvp,
         goto err;
 
     /* Preallocate space */
-    q_bits = BN_num_bits(dsa->q);
+    q_bits = BN_num_bits(dsa->q) + sizeof(dsa->q->d[0]) * 16;
     if (!BN_set_bit(&k, q_bits)
         || !BN_set_bit(&l, q_bits)
         || !BN_set_bit(&m, q_bits))


### PR DESCRIPTION
Timing vulnerability in DSA signature generation (CVE-2018-0734)
    
Preallocate two extra limbs for some of the big numbers to avoid a reallocation
 that can potentially provide a side channel.
