### PR TITLE
Remove brace from bad cherry-pick of DSA reallocation fix to 1.1.0

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -178,7 +178,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
     cardinality_bits = BN_num_bits(cardinality);
     group_top = bn_get_top(cardinality);
     if ((bn_wexpand(k, group_top + 2) == NULL)
-        || (bn_wexpand(lambda, group_top + 2) == NULL)) {
+        || (bn_wexpand(lambda, group_top + 2) == NULL))
         goto err;
 
     if (!BN_copy(k, scalar))


### PR DESCRIPTION
Commit 56fb454 backported the DSA reallocation fix to 1.1.0, however a code block that has multiple statements in 1.1.1+ only has a `goto` in 1.1.0 so introduces a brace that causes a compile failure.

/cc @paulidale