### PR TITLE
test/evp_test.c: Fixed strcmp() fault in mac_test_init()

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -865,7 +865,8 @@ static int mac_test_init(EVP_TEST *t, const char *alg)
         size_t sz = strlen(alg);
         static const char epilogue[] = " by EVP_PKEY";
 
-        if (strcmp(alg + sz - (sizeof(epilogue) - 1), epilogue) == 0)
+        if (sz >= sizeof(epilogue)
+            && strcmp(alg + sz - (sizeof(epilogue) - 1), epilogue) == 0)
             sz -= sizeof(epilogue) - 1;
 
         if (strncmp(alg, "HMAC", sz) == 0) {


### PR DESCRIPTION
When wanting to compare the end of a string with another string, make
sure not to start somewhere before the start of the first string.
