### PR TITLE
rand_drbg.h: include <openssl/obj_mac.h>

### DIFF
--- a/include/openssl/rand_drbg.h
+++ b/include/openssl/rand_drbg.h
@@ -12,6 +12,7 @@
 
 # include <time.h>
 # include <openssl/ossl_typ.h>
+# include <openssl/obj_mac.h>
 
 /*
  * RAND_DRBG  flags


### PR DESCRIPTION
The RAND_DRBG_TYPE preprocessor define depends on a NID, so  we have
to include obj_mac.h to make the header selfcontained.

Fixes #7521
