### PR TITLE
Windows build: build foo.d after foo.obj [1.1.0]

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -454,22 +454,20 @@ $obj$objext: $deps
 	\$(AS) \$(ASFLAGS) \$(ASOUTFLAG)\$\@ $srcs
 EOF
      }
-     return <<"EOF"	if (!$disabled{makedepend});
-$obj$depext: $deps
-	\$(CC) \$(CFLAGS) $ecflags$inc /Zs /showIncludes $srcs 2>&1 | \\
+     my $recipe = <<"EOF";
+$obj$objext: $deps
+	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ $srcs
+EOF
+     $recipe .= <<"EOF"	unless $disabled{makedepend};
+	\$(CC) $incs \$(CFLAGS) $ecflags /Zs /showIncludes $srcs 2>&1 | \\
 	    "\$(PERL)" -n << > $obj$depext
 chomp;
 s/^Note: including file: *//;
 \$\$collect{\$\$_} = 1;
 END { print '$obj$objext: ',join(" ", sort keys \%collect),"\\n" }
 <<
-$obj$objext: $obj$depext
-	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ $srcs
 EOF
-    return <<"EOF"	if ($disabled{makedepend});
-$obj$objext: $deps
-	\$(CC) $incs \$(CFLAGS) $ecflags -c \$(COUTFLAG)\$\@ $srcs
-EOF
+     return $recipe;
  }
 
  # On Unix, we build shlibs from static libs, so we're ignoring the


### PR DESCRIPTION
We made the build of foo.obj depend on foo.d, meaning the latter gets
built first.  Unfortunately, the way the compiler works, we are forced
to redirect all output to foo.d, meaning that if the source contains
an error, the build fails without showing those errors.

We therefore remove the dependency and force the build of foo.d to
always happen after build of foo.obj.

-----

Note: this is a backport of #7469