### PR TITLE
Add constant time code for BN_is_bit_set call.

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -648,7 +648,7 @@ int BN_clear_bit(BIGNUM *a, int n)
 
 int BN_is_bit_set(const BIGNUM *a, int n)
 {
-    int i, j, k;
+    int i, j;
     BN_ULONG s;
 
     bn_check_top(a);
@@ -658,12 +658,12 @@ int BN_is_bit_set(const BIGNUM *a, int n)
     j = n % BN_BITS2;
 
     if (a->flags & BN_FLG_CONSTTIME) {
-        s = 0;
-        for (k = 0; k < a->dmax; k++) {
-            const int it = constant_time_eq(i, k) & constant_time_lt(i, a->top);
+        int it;
 
-            s = constant_time_select_bn(constant_time_lsb_bn(it), a->d[k], s);
-        }
+        if (i >= a->dmax)
+            return 0;
+        it = constant_time_lt(i, a->top);
+        s = constant_time_select_bn(constant_time_lsb_bn(it), a->d[i], 0);
     } else {
         if (a->top <= i)
             return 0;

--- a/doc/man3/BN_set_bit.pod
+++ b/doc/man3/BN_set_bit.pod
@@ -30,7 +30,8 @@ number is expanded if necessary.
 BN_clear_bit() sets bit B<n> in B<a> to 0 (C<a&=~(1E<lt>E<lt>n)>). An
 error occurs if B<a> is shorter than B<n> bits.
 
-BN_is_bit_set() tests if bit B<n> in B<a> is set.
+BN_is_bit_set() tests if bit B<n> in B<a> is set. The bit number B<n> is
+considered to be pubilc information, whereas the contents of B<a> are secret.
 
 BN_mask_bits() truncates B<a> to an B<n> bit number
 (C<a&=~((~0)E<gt>E<gt>n)>).  An error occurs if B<a> already is


### PR DESCRIPTION
The `BN_is_bit_set` call isn't constant time, specifically when the bit asked for is larger than the topmost bit of the final limb.  This change makes that case constant time.

The changed code path only applies to big numbers that have the constant time flag set.

Reported by Samuel Weiser.

- [x] tests are added or updated
