### PR TITLE
openssl list -mac-algorithms support.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -297,6 +297,20 @@ static void list_md_fn(const EVP_MD *m,
     }
 }
 
+static void list_mac_fn(const EVP_MAC *m,
+                        const char *from, const char *to, void *arg)
+{
+    if (m != NULL) {
+        BIO_printf(arg, "%s\n", EVP_MAC_name(m));
+    } else {
+        if (from == NULL)
+            from = "<undefined>";
+        if (to == NULL)
+            to = "<undefined>";
+        BIO_printf(arg, "%s => %s\n", from, to);
+    }
+}
+
 static void list_missing_help(void)
 {
     const FUNCTION *fp;
@@ -396,7 +410,7 @@ static void list_options_for_command(const char *command)
 /* Unified enum for help and list commands. */
 typedef enum HELPLIST_CHOICE {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP, OPT_ONE,
-    OPT_COMMANDS, OPT_DIGEST_COMMANDS, OPT_OPTIONS,
+    OPT_COMMANDS, OPT_DIGEST_COMMANDS, OPT_MAC_ALGORITHMS, OPT_OPTIONS,
     OPT_DIGEST_ALGORITHMS, OPT_CIPHER_COMMANDS, OPT_CIPHER_ALGORITHMS,
     OPT_PK_ALGORITHMS, OPT_PK_METHOD, OPT_DISABLED, OPT_MISSING_HELP,
     OPT_OBJECTS
@@ -410,6 +424,8 @@ const OPTIONS list_options[] = {
      "List of message digest commands"},
     {"digest-algorithms", OPT_DIGEST_ALGORITHMS, '-',
      "List of message digest algorithms"},
+    {"mac-algorithms", OPT_MAC_ALGORITHMS, '-',
+     "List of message authentication code algorithms"},
     {"cipher-commands", OPT_CIPHER_COMMANDS, '-', "List of cipher commands"},
     {"cipher-algorithms", OPT_CIPHER_ALGORITHMS, '-',
      "List of cipher algorithms"},
@@ -456,6 +472,9 @@ opthelp:
             break;
         case OPT_DIGEST_ALGORITHMS:
             EVP_MD_do_all_sorted(list_md_fn, bio_out);
+            break;
+        case OPT_MAC_ALGORITHMS:
+            EVP_MAC_do_all_sorted(list_mac_fn, bio_out);
             break;
         case OPT_CIPHER_COMMANDS:
             list_type(FT_cipher, one);

--- a/doc/man1/list.pod
+++ b/doc/man1/list.pod
@@ -13,6 +13,7 @@ B<openssl list>
 [B<-commands>]
 [B<-digest-commands>]
 [B<-digest-algorithms>]
+[B<-mac-algorithms>]
 [B<-cipher-commands>]
 [B<-cipher-algorithms>]
 [B<-public-key-algorithms>]
@@ -49,6 +50,13 @@ as input to the L<dgst(1)> or L<speed(1)> commands.
 =item B<-digest-algorithms>
 
 Display a list of message digest algorithms.
+If a line is of the form
+  foo => bar
+then B<foo> is an alias for the official algorithm name, B<bar>.
+
+=item B<-mac-algorithms>
+
+Display a list of message authentication code algorithms.
 If a line is of the form
   foo => bar
 then B<foo> is an alias for the official algorithm name, B<bar>.


### PR DESCRIPTION
- [x] documentation is added or updated

Add a new option to the `openssl list` command to enable listing of supported MACs.

