### PR TITLE
Configure: ensure empty arrays aren't created inadvertently

### DIFF
--- a/Configure
+++ b/Configure
@@ -2344,7 +2344,7 @@ EOF
             my %dirs = ();
             my $pd = dirname($product);
 
-            foreach (@{$unified_info{sources}->{$product}},
+            foreach (@{$unified_info{sources}->{$product} // []},
                      @{$unified_info{shared_sources}->{$product} // []}) {
                 my $d = dirname($_);
 


### PR DESCRIPTION
Just refering to a hash table element as an array reference will
automatically create that element.  Avoid that by defaulting to
a separate empty array reference.

Fixes #7543
