### PR TITLE
Option to Configure to change Shared Library Version

### DIFF
--- a/Configure
+++ b/Configure
@@ -24,7 +24,7 @@ use OpenSSL::Glob;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--shlib-version=VERSION] [--config=FILE] os/compiler[:flags]\n";
 
 # Options:
 #
@@ -40,9 +40,11 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 #               given with --prefix.
 #               This becomes the value of OPENSSLDIR in Makefile and in C.
 #               (Default: PREFIX/ssl)
-#
-# --cross-compile-prefix Add specified prefix to binutils components.
-#
+# --shlib-version
+#               Specify the version string used as part of the SONAME and/or
+#               filename for shared libraries.
+# --cross-compile-prefix'
+#               Add specified prefix to binutils components.
 # --api         One of 0.9.8, 1.0.0 or 1.1.0.  Do not compile support for
 #               interfaces deprecated as of the specified OpenSSL version.
 #
@@ -255,6 +257,15 @@ collect_information(
     qr/SHLIB_VERSION_HISTORY *"([^"]*)"/     => sub { $config{shlib_version_history}=$1 }
     );
 if ($config{shlib_version_history} ne "") { $config{shlib_version_history} .= ":"; }
+
+# Look for the version number on the command line; this has to be done early
+my @tmpargv = @argvcopy;
+while (@tmpargv) {
+    $_ = shift @tmpargv;
+    if (/^--shlib-version=(.*)$/) {
+	$config{shlib_version_number} = $1;
+    }
+}
 
 ($config{major}, $config{minor})
     = ($config{version} =~ /^([0-9]+)\.([0-9\.]+)/);
@@ -824,6 +835,10 @@ while (@argvcopy)
 		elsif (/^--config=(.*)$/)
 			{
 			read_config $1;
+			}
+		elsif (/^--shlib-version=(.*)$/)
+			{
+			# handled earlier
 			}
 		elsif (/^-l(.*)$/)
 			{

--- a/INSTALL
+++ b/INSTALL
@@ -191,6 +191,14 @@
   --release
                    Build OpenSSL without debugging symbols. This is the default.
 
+  --shlib-version=VERSION
+                   Specify the version string to be used as part of the SONAME
+                   and/or file name for shared libraries.
+                   This value defaults to the value of SHLIB_VERSION_NUMBER in
+                   the include/openssl/opensslv.h file.
+                   At a minimum, VERSION must be in the form of "number.number".
+                   It may contain additional ".number" sequences.
+
   --strict-warnings
                    This is a developer flag that switches on various compiler
                    options recommended for OpenSSL development. It only works


### PR DESCRIPTION
Embedded systems may have multiple versions of OpenSSL installed, and may
need to have different SONAMEs (specifically the version) associated with
them.

The --shlib-version=X option allows the packager to specify the version of
the shared libraries different from the default in include/openssl/opensslv.h

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
