### PR TITLE
Add a constant time flag to one of the bignums to avoid a timing leak.

### DIFF
--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -223,6 +223,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
     } while (BN_is_zero(k));
 
     BN_set_flags(k, BN_FLG_CONSTTIME);
+    BN_set_flags(l, BN_FLG_CONSTTIME);
 
     if (dsa->flags & DSA_FLAG_CACHE_MONT_P) {
         if (!BN_MONT_CTX_set_locked(&dsa->method_mont_p,


### PR DESCRIPTION
Follow on introduced by the fix for CVE-2018-0734.