### PR TITLE
Build: Add macro capability

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -467,6 +467,10 @@ include paths the build of their source files should use:
 
     INCLUDE[foo]=include
 
+It's also possible to specify C macros that should be defined:
+
+    DEFINE[foo]=FOO BAR=1
+
 In some cases, one might want to generate some source files from
 others, that's done as follows:
 

--- a/Configurations/README.design
+++ b/Configurations/README.design
@@ -41,9 +41,10 @@ end products.  There are variants for them with '_NO_INST' as suffix
 (PROGRAM_NO_INST etc) to specify end products that shouldn't get
 installed.
 
-The variables SOURCE, DEPEND and INCLUDE are indexed by a produced
-file, and their values are the source used to produce that particular
-produced file, extra dependencies, and include directories needed.
+The variables SOURCE, DEPEND, INCLUDE and DEFINE are indexed by a
+produced file, and their values are the source used to produce that
+particular produced file, extra dependencies, include directories
+needed, or C macros to be defined.
 
 All their values in all the build.info throughout the source tree are
 collected together and form a set of programs, libraries, engines and

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -85,7 +85,8 @@
                              deps => $unified_info{depends}->{$src},
                              incs => [ @{$unified_info{includes}->{$obj}},
                                        @{$unified_info{includes}->{$bin}} ],
-                             defs => $unified_info{defines}->{$obj},
+                             defs => [ @{$unified_info{defines}->{$obj}},
+                                       @{$unified_info{defines}->{$bin}} ],
                              %opts);
          foreach (@{$unified_info{depends}->{$src}}) {
              dogenerate($_, $obj, $bin, %opts);
@@ -108,7 +109,8 @@
                          deps => $unified_info{depends}->{$obj},
                          incs => [ @{$unified_info{includes}->{$obj}},
                                    @{$unified_info{includes}->{$bin}} ],
-                         defs => $unified_info{defines}->{$obj},
+                         defs => [ @{$unified_info{defines}->{$obj}},
+                                   @{$unified_info{defines}->{$bin}} ],
                          %opts);
          foreach ((@{$unified_info{sources}->{$obj}},
                    @{$unified_info{depends}->{$obj}})) {

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -85,6 +85,7 @@
                              deps => $unified_info{depends}->{$src},
                              incs => [ @{$unified_info{includes}->{$obj}},
                                        @{$unified_info{includes}->{$bin}} ],
+                             defs => $unified_info{defines}->{$obj},
                              %opts);
          foreach (@{$unified_info{depends}->{$src}}) {
              dogenerate($_, $obj, $bin, %opts);
@@ -107,6 +108,7 @@
                          deps => $unified_info{depends}->{$obj},
                          incs => [ @{$unified_info{includes}->{$obj}},
                                    @{$unified_info{includes}->{$bin}} ],
+                         defs => $unified_info{defines}->{$obj},
                          %opts);
          foreach ((@{$unified_info{sources}->{$obj}},
                    @{$unified_info{depends}->{$obj}})) {

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -199,7 +199,8 @@ ASOUTFLAG={- $target{asoutflag} -}$(OSSL_EMPTY)
 CNF_ASFLAGS={- join('', $target{asflags} || (),
                         @{$config{asflags}}) -}
 CNF_DEFINES={- our $defines2 = join('', map { ",$_" } @{$target{defines}},
-                                                      @{$config{defines}}) -}
+                                                      @{$config{defines}},
+                                                      "'extradefines'") -}
 CNF_INCLUDES={- our $includes2 = join(',', @{$target{includes}},
                                            @{$config{includes}}) -}
 CNF_CPPFLAGS={- our $cppflags2 = join('', $target{cppflags} || (),
@@ -810,6 +811,7 @@ EOF
                                    @{$args{incs}});
           my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
           my $incs_off = join("\n\t\@ ", @{$incs_cmds[1]}) || '!';
+          my $defs = join("", map { ",".$_ } @{$args{defs}});
           if (defined($generator)) {
               # If the target is named foo.S in build.info, we want to
               # end up generating foo.s in two steps.
@@ -818,8 +820,10 @@ EOF
 $target : $args{generator}->[0] $deps
 	$generator \$\@-S
         \@ $incs_on
+        \@ extradefines = "$defs"
 	PIPE \$(CPP) $cppflags \$\@-S | -
         \$(PERL) -ne "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@-i
+        \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
         RENAME \$\@-i \$\@
         DELETE \$\@-S
@@ -834,9 +838,11 @@ EOF
           return <<"EOF";
 $target : $args{generator}->[0] $deps
         \@ $incs_on
+        \@ extradefines = "$defs"
         SHOW SYMBOL qual_includes
         PIPE \$(CPP) $cppflags $args{generator}->[0] | -
         \$(PERL) "-ne" "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@
+        \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
 EOF
       }
@@ -894,6 +900,7 @@ EOF
 		   lib => '$(LIB_CPPFLAGS)',
 		   dso => '$(DSO_CPPFLAGS)',
 		   bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+      my $defs = join("", map { ",".$_ } @{$args{defs}});
 
       my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
                                  lib => '$(LIB_INCLUDES)',
@@ -914,7 +921,9 @@ $obj.OBJ : $deps
         ${before}
         SET DEFAULT $forward
         \@ $incs_on
+        \@ extradefines = "$defs"
         \$(CC) ${cflags}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
+        \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
         SET DEFAULT $backward
         ${after}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -996,6 +996,7 @@ reconfigure reconf:
       my $generator = join(" ", @{$args{generator}});
       my $generator_incs = join("", map { " -I".$_ } @{$args{generator_incs}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
+      my $defs = join("", map { " -D".$_ } @{$args{defs}});
       my $deps = join(" ", @{$args{generator_deps}}, @{$args{deps}});
 
       if ($args{src} =~ /\.ld$/) {
@@ -1049,7 +1050,7 @@ EOF
           }
           return <<"EOF";
 $args{src}: $args{generator}->[0] $deps
-	\$(CC) $incs $cppflags -E $args{generator}->[0] | \\
+	\$(CC) $incs $cppflags $defs -E $args{generator}->[0] | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
 EOF
       }
@@ -1065,6 +1066,7 @@ EOF
       my $srcs = join(" ",  @srcs);
       my $deps = join(" ", @srcs, @{$args{deps}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
+      my $defs = join("", map { " -D".$_ } @{$args{defs}});
       my $cmd;
       my $cmdflags;
       my $cmdcompile;
@@ -1106,13 +1108,13 @@ EOF
           # hardly a point to drag it along...
           $recipe .= <<"EOF";
 $obj$objext: $deps
-	$cmd $incs $cmdflags -c -o \$\@ $srcs
+	$cmd $incs $defs $cmdflags -c -o \$\@ $srcs
 EOF
       } elsif (defined $makedepprog && $makedepprog !~ /\/makedepend/
                && !grep /\.rc$/, @srcs) {
           $recipe .= <<"EOF";
 $obj$objext: $deps
-	$cmd $incs $cmdflags -MMD -MF $obj$depext.tmp -MT \$\@ -c -o \$\@ $srcs
+	$cmd $incs $defs $cmdflags -MMD -MF $obj$depext.tmp -MT \$\@ -c -o \$\@ $srcs
 	\@touch $obj$depext.tmp
 	\@if cmp $obj$depext.tmp $obj$depext > /dev/null 2> /dev/null; then \\
 		rm -f $obj$depext.tmp; \\
@@ -1123,7 +1125,7 @@ EOF
       } else {
           $recipe .= <<"EOF";
 $obj$objext: $deps
-	$cmd $incs $cmdflags $cmdcompile -o \$\@ $srcs
+	$cmd $incs $defs $cmdflags $cmdcompile -o \$\@ $srcs
 EOF
           if (defined $makedepprog  && $makedepprog =~ /\/makedepend/) {
               $recipe .= <<"EOF";

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -501,6 +501,7 @@ reconfigure reconf:
       my $generator = '"'.$gen0.'"'.join('', map { " $_" } @gens);
       my $generator_incs = join("", map { " -I \"$_\"" } @{$args{generator_incs}});
       my $incs = join("", map { " /I \"$_\"" } @{$args{incs}});
+      my $defs = join("", map { " /D".$_ } @{$args{defs}});
       my $deps = @{$args{deps}} ?
           '"'.join('" "', @{$args{generator_deps}}, @{$args{deps}}).'"' : '';
 
@@ -558,7 +559,7 @@ EOF
 $target: "$args{generator}->[0]" $deps
 	set ASM=\$(AS)
 	$generator \$@.S
-	\$(CPP) $cppflags \$@.S > \$@.i && move /Y \$@.i \$@
+	\$(CPP) $cppflags $defs \$@.S > \$@.i && move /Y \$@.i \$@
         del /Q \$@.S
 EOF
               }
@@ -571,7 +572,7 @@ EOF
           }
           return <<"EOF";
 $target: "$args{generator}->[0]" $deps
-	\$(CPP) $incs $cppflags "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
+	\$(CPP) $incs $cppflags $defs "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
 EOF
       }
   }
@@ -583,6 +584,7 @@ EOF
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
+     my $defs = join("", map { " /D".$_ } @{$args{defs}});
      my $cflags = { shlib => ' $(LIB_CFLAGS)',
 		    lib => ' $(LIB_CFLAGS)',
 		    dso => ' $(DSO_CFLAGS)',
@@ -612,15 +614,15 @@ EOF
      } elsif ($srcs[0] =~ /.S$/) {
          return <<"EOF";
 $obj$objext: $deps
-	\$(CC) /EP /D__ASSEMBLER__ $cflags $srcs > \$@.asm && \$(AS) $asflags \$(ASOUTFLAG)\$\@ \$@.asm
+	\$(CC) /EP /D__ASSEMBLER__ $cflags $defs $srcs > \$@.asm && \$(AS) $asflags \$(ASOUTFLAG)\$\@ \$@.asm
 EOF
      }
      my $recipe = <<"EOF";
 $obj$objext: $deps
-	\$(CC) $cflags -c \$(COUTFLAG)\$\@ $srcs
+	\$(CC) $cflags $defs -c \$(COUTFLAG)\$\@ $srcs
 EOF
      $recipe .= <<"EOF"	unless $disabled{makedepend};
-	\$(CC) $cflags /Zs /showIncludes $srcs 2>&1 > $obj$depext
+	\$(CC) $cflags $defs /Zs /showIncludes $srcs 2>&1 > $obj$depext
 EOF
      return $recipe;
  }

--- a/Configure
+++ b/Configure
@@ -1722,6 +1722,7 @@ if ($builder eq "unified") {
         my %sources = ();
         my %shared_sources = ();
         my %includes = ();
+        my %defines = ();
         my %depends = ();
         my %renames = ();
         my %sharednames = ();
@@ -1836,6 +1837,9 @@ if ($builder eq "unified") {
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*INCLUDE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
             => sub { push @{$includes{$1}}, tokenize($2)
+                         if !@skip || $skip[$#skip] > 0 },
+            qr/^\s*DEFINE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
+            => sub { push @{$defines{$1}}, tokenize($2)
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*DEPEND\[((?:\\.|[^\\\]])*)\]\s*=\s*(.*)\s*$/
             => sub { push @{$depends{$1}}, tokenize($2)
@@ -2169,6 +2173,27 @@ EOF
                     unless grep { $_ eq $ib } @{$unified_info{includes}->{$ddest}->{build}};
             }
         }
+
+        foreach (keys %defines) {
+            my $dest = $_;
+            my $ddest = cleanfile($sourced, $_, $blddir);
+
+            # If the destination doesn't exist in source, it can only be
+            # a generated file in the build tree.
+            if (! -f $ddest) {
+                $ddest = cleanfile($buildd, $_, $blddir);
+                if ($unified_info{rename}->{$ddest}) {
+                    $ddest = $unified_info{rename}->{$ddest};
+                }
+            }
+            foreach (@{$defines{$dest}}) {
+                m|^([^=]*)(=.*)?$|;
+                die "0 length macro name not permitted\n" if $1 eq "";
+                die "$1 defined more than once\n"
+                    if defined $unified_info{defines}->{$ddest}->{$1};
+                $unified_info{defines}->{$ddest}->{$1} = $2;
+            }
+        }
     }
 
     my $ordinals_text = join(', ', sort keys %ordinals);
@@ -2310,6 +2335,12 @@ EOF
                 delete $unified_info{$l1}->{$l2};
             }
         }
+    }
+    # Defines
+    foreach my $dest (sort keys %{$unified_info{defines}}) {
+        $unified_info{defines}->{$dest}
+            = [ map { $_.$unified_info{defines}->{$dest}->{$_} }
+                sort keys %{$unified_info{defines}->{$dest}} ];
     }
     # Includes
     foreach my $dest (sort keys %{$unified_info{includes}}) {


### PR DESCRIPTION
This PR adds the keyword `DEFINE` to the `build.info` file language, making it possible to add C macro definitions selectively per file.