### PR TITLE
Build: make it possibly to specify subdirs in build.info

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.1 and 1.1.2 [xx XXX xxxx]
 
+  *) Instead of having the source directories listed in Configure, add
+     a 'build.info' keyword SUBDIRS to indicate what sub-directories to
+     look into.
+     [Richard Levitte]
+
   *) Ported the HMAC, CMAC and SipHash EVP_PKEY_METHODs to EVP_MAC.
      [Richard Levitte]
 

--- a/Configurations/README
+++ b/Configurations/README
@@ -400,7 +400,13 @@ $sourcedir and $builddir, which are the locations of the source
 directory for the current build.info file and the corresponding build
 directory, all relative to the top of the build tree.
 
-To begin with, things to be built are declared by setting specific
+'Configure' only knows inherently about the top build.info file.  For
+any other directory that has one, further directories to look into
+must be indicated like this:
+
+    SUBDIRS=something someelse
+
+On to things to be built; they are declared by setting specific
 variables:
 
     PROGRAMS=foo bar

--- a/Configure
+++ b/Configure
@@ -298,21 +298,6 @@ $config{libdir}="";
 my $auto_threads=1;    # enable threads automatically? true by default
 my $default_ranlib;
 
-# Top level directories to build
-$config{dirs} = [ "crypto", "ssl", "engines", "apps", "test", "util", "tools", "fuzz" ];
-# crypto/ subdirectories to build
-$config{sdirs} = [
-    "objects",
-    "md2", "md4", "md5", "sha", "mdc2", "hmac", "ripemd", "whrlpool", "poly1305", "blake2", "siphash", "sm3",
-    "des", "aes", "rc2", "rc4", "rc5", "idea", "aria", "bf", "cast", "camellia", "seed", "sm4", "chacha", "modes",
-    "bn", "ec", "rsa", "dsa", "dh", "sm2", "dso", "engine",
-    "buffer", "bio", "stack", "lhash", "rand", "err",
-    "evp", "asn1", "pem", "x509", "x509v3", "conf", "txt_db", "pkcs7", "pkcs12", "comp", "ocsp", "ui",
-    "cms", "ts", "srp", "cmac", "ct", "async", "kdf", "store"
-    ];
-# test/ subdirectories to build
-$config{tdirs} = [ "ossl_shim" ];
-
 # Known TLS and DTLS protocols
 my @tls = qw(ssl3 tls1 tls1_1 tls1_2 tls1_3);
 my @dtls = qw(dtls1 dtls1_2);
@@ -1171,6 +1156,19 @@ foreach (keys %user) {
 # Allow overriding the build file name
 $config{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
 
+######################################################################
+# Build up information for skipping certain directories depending on disabled
+# features, as well as setting up macros for disabled features.
+
+# This is a tentative database of directories to skip.  Some entries may not
+# correspond to anything real, but that's ok, they will simply be ignored.
+# The actual processing of these entries is done in the build.info lookup
+# loop further down.
+#
+# The key is a Unix formated path in the source tree, the value is an index
+# into %disabled_info, so any existing path gets added to a corresponding
+# 'skipped' entry in there with the list of skipped directories.
+my %skipdir = ();
 my %disabled_info = ();         # For configdata.pm
 foreach my $what (sort keys %disabled) {
     $config{options} .= " no-$what";
@@ -1179,32 +1177,18 @@ foreach my $what (sort keys %disabled) {
                                 'dynamic-engine', 'makedepend',
                                 'zlib-dynamic', 'zlib', 'sse2' )) {
         (my $WHAT = uc $what) =~ s|-|_|g;
-
-        # Fix up C macro end names
-        $WHAT = "RMD160" if $what eq "ripemd";
+        my $skipdir = $what;
 
         # fix-up crypto/directory name(s)
-        $what = "ripemd" if $what eq "rmd160";
-        $what = "whrlpool" if $what eq "whirlpool";
+        $skipdir = "ripemd" if $what eq "rmd160";
+        $skipdir = "whrlpool" if $what eq "whirlpool";
 
         my $macro = $disabled_info{$what}->{macro} = "OPENSSL_NO_$WHAT";
+        push @{$config{openssl_feature_defines}}, $macro;
 
-        if ((grep { $what eq $_ } @{$config{sdirs}})
-                && $what ne 'async' && $what ne 'err') {
-            @{$config{sdirs}} = grep { $what ne $_} @{$config{sdirs}};
-            $disabled_info{$what}->{skipped} = [ catdir('crypto', $what) ];
-
-            if ($what ne 'engine') {
-                push @{$config{openssl_feature_defines}}, $macro;
-            } else {
-                @{$config{dirs}} = grep !/^engines$/, @{$config{dirs}};
-                push @{$disabled_info{engine}->{skipped}}, catdir('engines');
-                push @{$config{openssl_feature_defines}}, $macro;
-            }
-        } else {
-            push @{$config{openssl_feature_defines}}, $macro;
-        }
-
+        $skipdir{engines} = $what if $what eq 'engine';
+        $skipdir{"crypto/$skipdir"} = $what
+            unless $what eq 'async' || $what eq 'err';
     }
 }
 
@@ -1684,6 +1668,12 @@ if ($builder eq "unified") {
         my @curd = @{shift @build_dirs};
         my $sourced = catdir($srcdir, @curd);
         my $buildd = catdir($blddir, @curd);
+
+        my $unixdir = join('/', @curd);
+        if (exists $skipdir{$unixdir}) {
+            my $what = $skipdir{$unixdir};
+            push @{$disabled_info{$what}->{skipped}}, catdir(@curd);
+        }
 
         mkpath($buildd);
 

--- a/Configure
+++ b/Configure
@@ -1673,6 +1673,7 @@ if ($builder eq "unified") {
         if (exists $skipdir{$unixdir}) {
             my $what = $skipdir{$unixdir};
             push @{$disabled_info{$what}->{skipped}}, catdir(@curd);
+            next;
         }
 
         mkpath($buildd);

--- a/Configure
+++ b/Configure
@@ -606,10 +606,8 @@ $config{lflags} = [ env('__CNF_LDFLAGS') || () ];
 $config{ex_libs} = [ env('__CNF_LDLIBS') || () ];
 
 $config{openssl_api_defines}=[];
-$config{openssl_algorithm_defines}=[];
-$config{openssl_thread_defines}=[];
 $config{openssl_sys_defines}=[];
-$config{openssl_other_defines}=[];
+$config{openssl_feature_defines}=[];
 $config{options}="";
 $config{build_type} = "release";
 my $target="";
@@ -1027,7 +1025,7 @@ INSTALL instructions and the RAND_DRBG(7) manual page for more details.
 
 _____
 }
-push @{$config{openssl_other_defines}},
+push @{$config{openssl_feature_defines}},
      map { (my $x = $_) =~ tr|[\-a-z]|[_A-Z]|; "OPENSSL_RAND_SEED_$x" }
 	@seed_sources;
 
@@ -1197,14 +1195,14 @@ foreach my $what (sort keys %disabled) {
             $disabled_info{$what}->{skipped} = [ catdir('crypto', $what) ];
 
             if ($what ne 'engine') {
-                push @{$config{openssl_algorithm_defines}}, $macro;
+                push @{$config{openssl_feature_defines}}, $macro;
             } else {
                 @{$config{dirs}} = grep !/^engines$/, @{$config{dirs}};
                 push @{$disabled_info{engine}->{skipped}}, catdir('engines');
-                push @{$config{openssl_other_defines}}, $macro;
+                push @{$config{openssl_feature_defines}}, $macro;
             }
         } else {
-            push @{$config{openssl_other_defines}}, $macro;
+            push @{$config{openssl_feature_defines}}, $macro;
         }
 
     }
@@ -1284,7 +1282,7 @@ unless ($disabled{threads}) {
 # If threads still aren't disabled, add a C macro to ensure the source
 # code knows about it.  Any other flag is taken care of by the configs.
 unless($disabled{threads}) {
-    push @{$config{openssl_thread_defines}}, "OPENSSL_THREADS";
+    push @{$config{openssl_feature_defines}}, "OPENSSL_THREADS";
 }
 
 # With "deprecated" disable all deprecated features.
@@ -1303,10 +1301,10 @@ if ($target{shared_target} eq "")
 	}
 
 if ($disabled{"dynamic-engine"}) {
-        push @{$config{openssl_other_defines}}, "OPENSSL_NO_DYNAMIC_ENGINE";
+        push @{$config{openssl_feature_defines}}, "OPENSSL_NO_DYNAMIC_ENGINE";
         $config{dynamic_engines} = 0;
 } else {
-        push @{$config{openssl_other_defines}}, "OPENSSL_NO_STATIC_ENGINE";
+        push @{$config{openssl_feature_defines}}, "OPENSSL_NO_STATIC_ENGINE";
         $config{dynamic_engines} = 1;
 }
 
@@ -1576,7 +1574,7 @@ unless ($disabled{afalgeng}) {
     }
 }
 
-push @{$config{openssl_other_defines}}, "OPENSSL_NO_AFALGENG" if ($disabled{afalgeng});
+push @{$config{openssl_feature_defines}}, "OPENSSL_NO_AFALGENG" if ($disabled{afalgeng});
 
 # Finish up %config by appending things the user gave us on the command line
 # apart from "make variables"

--- a/Configure
+++ b/Configure
@@ -15,7 +15,7 @@ use Config;
 use FindBin;
 use lib "$FindBin::Bin/util/perl";
 use File::Basename;
-use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs/;
+use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs splitdir/;
 use File::Path qw/mkpath/;
 use OpenSSL::Glob;
 
@@ -1677,34 +1677,19 @@ if ($builder eq "unified") {
           cleanfile($srcdir, catfile("Configurations", "common.tmpl"),
                     $blddir) ];
 
-    my @build_infos = ( [ ".", "build.info" ] );
-    foreach (@{$config{dirs}}) {
-        push @build_infos, [ $_, "build.info" ]
-            if (-f catfile($srcdir, $_, "build.info"));
-    }
-    foreach (@{$config{sdirs}}) {
-        push @build_infos, [ catdir("crypto", $_), "build.info" ]
-            if (-f catfile($srcdir, "crypto", $_, "build.info"));
-    }
-    foreach (@{$config{engdirs}}) {
-        push @build_infos, [ catdir("engines", $_), "build.info" ]
-            if (-f catfile($srcdir, "engines", $_, "build.info"));
-    }
-    foreach (@{$config{tdirs}}) {
-        push @build_infos, [ catdir("test", $_), "build.info" ]
-            if (-f catfile($srcdir, "test", $_, "build.info"));
-    }
+    my @build_dirs = ( [ ] );   # current directory
 
     $config{build_infos} = [ ];
 
     my %ordinals = ();
-    foreach (@build_infos) {
-        my $sourced = catdir($srcdir, $_->[0]);
-        my $buildd = catdir($blddir, $_->[0]);
+    while (@build_dirs) {
+        my @curd = @{shift @build_dirs};
+        my $sourced = catdir($srcdir, @curd);
+        my $buildd = catdir($blddir, @curd);
 
         mkpath($buildd);
 
-        my $f = $_->[1];
+        my $f = 'build.info';
         # The basic things we're trying to build
         my @programs = ();
         my @programs_install = ();
@@ -1782,6 +1767,14 @@ if ($builder eq "unified") {
             qr/^\s*ENDIF\s*$/
             => sub { die "ENDIF out of scope" if ! @skip;
                      pop @skip; },
+            qr/^\s*SUBDIRS\s*=\s*(.*)\s*$/
+            => sub {
+                if (!@skip || $skip[$#skip] > 0) {
+                    foreach (tokenize($1)) {
+                        push @build_dirs, [ @curd, splitdir($_, 1) ];
+                    }
+                }
+            },
             qr/^\s*PROGRAMS(_NO_INST)?\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {

--- a/build.info
+++ b/build.info
@@ -1,3 +1,5 @@
+# Note that some of these directories are filtered in Configure.  Look for
+# %skipdir there for further explanations.
 SUBDIRS=crypto ssl apps test util tools fuzz engines
 
 {-

--- a/build.info
+++ b/build.info
@@ -1,3 +1,5 @@
+SUBDIRS=crypto ssl apps test util tools fuzz engines
+
 {-
      use File::Spec::Functions;
 

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -1,3 +1,5 @@
+# Note that these directories are filtered in Configure.  Look for %skipdir
+# there for further explanations.
 SUBDIRS=objects buffer bio stack lhash rand evp asn1 pem x509 x509v3 conf \
         txt_db pkcs7 pkcs12 ui kdf store \
         md2 md4 md5 sha mdc2 hmac ripemd whrlpool poly1305 blake2 \

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -1,3 +1,10 @@
+SUBDIRS=objects buffer bio stack lhash rand evp asn1 pem x509 x509v3 conf \
+        txt_db pkcs7 pkcs12 ui kdf store \
+        md2 md4 md5 sha mdc2 hmac ripemd whrlpool poly1305 blake2 \
+        siphash sm3 des aes rc2 rc4 rc5 idea aria bf cast camellia \
+        seed sm4 chacha modes bn ec rsa dsa dh sm2 dso engine \
+        err comp ocsp cms ts srp cmac ct async
+
 LIBS=../libcrypto
 SOURCE[../libcrypto]=\
         cryptlib.c mem.c mem_dbg.c cversion.c ex_data.c cpt_err.c \

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -34,22 +34,8 @@ extern "C" {
         (my $macro, my $value) = $_ =~ /^(.*?)=(.*?)$/;
         $OUT .= "#define $macro $value\n";
     }
-    if (@{$config{openssl_algorithm_defines}}) {
-      foreach (@{$config{openssl_algorithm_defines}}) {
-	$OUT .= "#ifndef $_\n";
-	$OUT .= "# define $_\n";
-	$OUT .= "#endif\n";
-      }
-    }
-    if (@{$config{openssl_thread_defines}}) {
-      foreach (@{$config{openssl_thread_defines}}) {
-	$OUT .= "#ifndef $_\n";
-	$OUT .= "# define $_\n";
-	$OUT .= "#endif\n";
-      }
-    }
-    if (@{$config{openssl_other_defines}}) {
-      foreach (@{$config{openssl_other_defines}}) {
+    if (@{$config{openssl_feature_defines}}) {
+      foreach (@{$config{openssl_feature_defines}}) {
 	$OUT .= "#ifndef $_\n";
 	$OUT .= "# define $_\n";
 	$OUT .= "#endif\n";

--- a/test/build.info
+++ b/test/build.info
@@ -1,3 +1,4 @@
+SUBDIRS=ossl_shim
 {-
      use File::Spec::Functions;
      sub rebase_files


### PR DESCRIPTION
This adds a keyword SUBDIRS for build.info, to be used like this:

    SUBDIRS=foo bar

This tells Configure that it should look for 'build.info' in the
relative subdirectories 'foo' and 'bar' as well.
