### PR TITLE
EVP_MAC ctrl numbering duplicate removal.

### DIFF
--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1023,9 +1023,9 @@ void EVP_MAC_do_all_sorted(void (*fn)
 # define EVP_MAC_CTRL_SET_FLAGS         0x02 /* unsigned long */
 # define EVP_MAC_CTRL_SET_ENGINE        0x03 /* ENGINE * */
 # define EVP_MAC_CTRL_SET_MD            0x04 /* EVP_MD * */
-# define EVP_MAC_CTRL_SET_CIPHER        0x04 /* EVP_CIPHER * */
-# define EVP_MAC_CTRL_SET_SIZE          0x05 /* size_t */
-# define EVP_MAC_CTRL_SET_IV            0x06 /* unsigned char *, size_t */
+# define EVP_MAC_CTRL_SET_CIPHER        0x05 /* EVP_CIPHER * */
+# define EVP_MAC_CTRL_SET_SIZE          0x06 /* size_t */
+# define EVP_MAC_CTRL_SET_IV            0x07 /* unsigned char *, size_t */
 
 /* PKEY stuff */
 int EVP_PKEY_decrypt_old(unsigned char *dec_key,


### PR DESCRIPTION
Both EVP_MAC_CTRL_SET_MD and EVP_MAC_CTRL_SET_CIPHER were numbered 4.
This would preclude any future MAC from using both.
