### PR TITLE
Rename the rand_drbg_st data member "pool" to "seed_pool"

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -557,11 +557,11 @@ int rand_drbg_restart(RAND_DRBG *drbg,
     const unsigned char *adin = NULL;
     size_t adinlen = 0;
 
-    if (drbg->pool != NULL) {
+    if (drbg->seed_pool != NULL) {
         RANDerr(RAND_F_RAND_DRBG_RESTART, ERR_R_INTERNAL_ERROR);
         drbg->state = DRBG_ERROR;
-        rand_pool_free(drbg->pool);
-        drbg->pool = NULL;
+        rand_pool_free(drbg->seed_pool);
+        drbg->seed_pool = NULL;
         return 0;
     }
 
@@ -581,8 +581,8 @@ int rand_drbg_restart(RAND_DRBG *drbg,
             }
 
             /* will be picked up by the rand_drbg_get_entropy() callback */
-            drbg->pool = rand_pool_attach(buffer, len, entropy);
-            if (drbg->pool == NULL)
+            drbg->seed_pool = rand_pool_attach(buffer, len, entropy);
+            if (drbg->seed_pool == NULL)
                 return 0;
         } else {
             if (drbg->max_adinlen < len) {
@@ -628,8 +628,8 @@ int rand_drbg_restart(RAND_DRBG *drbg,
         }
     }
 
-    rand_pool_free(drbg->pool);
-    drbg->pool = NULL;
+    rand_pool_free(drbg->seed_pool);
+    drbg->seed_pool = NULL;
 
     return drbg->state == DRBG_READY;
 }

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -203,7 +203,7 @@ struct rand_drbg_st {
      * with respect to how randomness is added to the RNG during reseeding
      * (see PR #4328).
      */
-    struct rand_pool_st *pool;
+    struct rand_pool_st *seed_pool;
 
     /*
      * Auxiliary pool for additional data.

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -146,8 +146,8 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
         return 0;
     }
 
-    if (drbg->pool != NULL) {
-        pool = drbg->pool;
+    if (drbg->seed_pool != NULL) {
+        pool = drbg->seed_pool;
         pool->entropy_requested = entropy;
     } else {
         pool = rand_pool_new(entropy, min_len, max_len);
@@ -204,7 +204,7 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
     }
 
  err:
-    if (drbg->pool == NULL)
+    if (drbg->seed_pool == NULL)
         rand_pool_free(pool);
     return ret;
 }
@@ -216,7 +216,7 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
 void rand_drbg_cleanup_entropy(RAND_DRBG *drbg,
                                unsigned char *out, size_t outlen)
 {
-    if (drbg->pool == NULL)
+    if (drbg->seed_pool == NULL)
         OPENSSL_secure_clear_free(out, outlen);
 }
 


### PR DESCRIPTION
... to make the intended use more clear and differentiate
it from the data member "adin_pool".
