### PR TITLE
Configure: add attributes to end product build.info variables

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -130,6 +130,7 @@
      unless ($disabled{shared} || $lib =~ /\.a$/) {
          my $obj2shlib = defined &obj2shlib ? \&obj2shlib : \&libobj2shlib;
          $OUT .= $obj2shlib->(lib => $lib,
+                              attrs => $unified_info{attributes}->{$lib},
                               objs => $unified_info{shared_sources}->{$lib},
                               deps => [ reducedepends(resolvedepends($lib)) ],
                               installed => is_installed($lib));
@@ -145,6 +146,7 @@
          }
      }
      $OUT .= obj2lib(lib => $lib,
+                     attrs => $unified_info{attributes}->{$lib},
                      objs => [ @{$unified_info{sources}->{$lib}} ]);
      foreach (@{$unified_info{sources}->{$lib}}) {
          doobj($_, $lib, intent => "lib", installed => is_installed($lib));
@@ -159,6 +161,7 @@
      my $lib = shift;
      return "" if $cache{$lib};
      $OUT .= obj2dso(lib => $lib,
+                     attrs => $unified_info{attributes}->{$lib},
                      objs => $unified_info{shared_sources}->{$lib},
                      deps => [ resolvedepends($lib) ],
                      installed => is_installed($lib));
@@ -181,6 +184,7 @@
      return "" if $cache{$bin};
      my $deps = [ reducedepends(resolvedepends($bin)) ];
      $OUT .= obj2bin(bin => $bin,
+                     attrs => $unified_info{attributes}->{$bin},
                      objs => [ @{$unified_info{sources}->{$bin}} ],
                      deps => $deps,
                      installed => is_installed($bin));
@@ -196,6 +200,7 @@
      my $script = shift;
      return "" if $cache{$script};
      $OUT .= in2script(script => $script,
+                       attrs => $unified_info{attributes}->{$script},
                        sources => $unified_info{sources}->{$script},
                        installed => is_installed($script));
      $cache{$script} = 1;

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -48,10 +48,18 @@
       @{$unified_info{libraries}};
   our @install_libs =
       map { platform->staticname($_) }
-      @{$unified_info{install}->{libraries}};
+      grep { !$unified_info{attributes}->{$_}->{noinst} }
+      @{$unified_info{libraries}};
   our @install_shlibs =
       map { platform->sharedname($_) // () }
-      @{$unified_info{install}->{libraries}};
+      grep { !$unified_info{attributes}->{$_}->{noinst} }
+      @{$unified_info{libraries}};
+  our @install_engines =
+      grep { !$unified_info{attributes}->{$_}->{noinst} }
+      @{$unified_info{engines}};
+  our @install_programs =
+      grep { !$unified_info{attributes}->{$_}->{noinst} }
+      @{$unified_info{programs}};
 
   # This is a horrible hack, but is needed because recursive inclusion of files
   # in different directories does not work well with HP C.
@@ -124,8 +132,8 @@ GENERATED={- # common0.tmpl provides @generated
 
 INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}
 INSTALL_SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @install_shlibs) -}
-INSTALL_ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{install}->{engines}}) -}
-INSTALL_PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{install}->{programs}}) -}
+INSTALL_ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @install_engines) -}
+INSTALL_PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @install_programs) -}
 {- output_off() if $disabled{apps}; "" -}
 BIN_SCRIPTS=[.tools]c_rehash.pl
 MISC_SCRIPTS=[.apps]CA.pl, [.apps]tsget.pl
@@ -552,7 +560,7 @@ install_engines : check_INSTALLTOP install_runtime_libs build_engines
         - CREATE/DIR ossl_installroot:[ENGINES{- $sover_dirname.$target{pointer_size} -}.'arch']
         {- join("\n        ",
                 map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover_dirname$target{pointer_size}.'arch']" }
-                @{$unified_info{install}->{engines}}) -}
+                @install_engines) -}
         @ {- output_on() unless scalar @{$unified_info{engines}}; "" -} !
 
 install_runtime : install_programs

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -60,6 +60,14 @@
   our @install_programs =
       grep { !$unified_info{attributes}->{$_}->{noinst} }
       @{$unified_info{programs}};
+  our @install_bin_scripts =
+      grep { !$unified_info{attributes}->{$_}->{noinst}
+             && !$unified_info{attributes}->{$_}->{misc} }
+      @{$unified_info{scripts}};
+  our @install_misc_scripts =
+      grep { !$unified_info{attributes}->{$_}->{noinst}
+             && $unified_info{attributes}->{$_}->{misc} }
+      @{$unified_info{scripts}};
 
   # This is a horrible hack, but is needed because recursive inclusion of files
   # in different directories does not work well with HP C.
@@ -134,10 +142,8 @@ INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}
 INSTALL_SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @install_shlibs) -}
 INSTALL_ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @install_engines) -}
 INSTALL_PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @install_programs) -}
-{- output_off() if $disabled{apps}; "" -}
-BIN_SCRIPTS=[.tools]c_rehash.pl
-MISC_SCRIPTS=[.apps]CA.pl, [.apps]tsget.pl
-{- output_on() if $disabled{apps}; "" -}
+BIN_SCRIPTS={- join(", ", @install_bin_scripts) -}
+MISC_SCRIPTS={- join(", ", @install_misc_scripts) -}
 
 APPS_OPENSSL={- use File::Spec::Functions;
                 catfile("apps","openssl") -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -79,10 +79,20 @@ INSTALL_PROGRAMS={-
                   grep { !$unified_info{attributes}->{$_}->{noinst} }
                   @{$unified_info{programs}})
 -}
-{- output_off() if $disabled{apps}; "" -}
-BIN_SCRIPTS=$(BLDDIR)/tools/c_rehash
-MISC_SCRIPTS=$(BLDDIR)/apps/CA.pl $(BLDDIR)/apps/tsget.pl:tsget
-{- output_on() if $disabled{apps}; "" -}
+BIN_SCRIPTS={-
+        join(" ", map { my $x = $unified_info{attributes}->{$_}->{linkname};
+                        $x ? "$_:$x" : $_ }
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && !$unified_info{attributes}->{$_}->{misc} }
+                  @{$unified_info{scripts}})
+-}
+MISC_SCRIPTS={-
+        join(" ", map { my $x = $unified_info{attributes}->{$_}->{linkname};
+                        $x ? "$_:$x" : $_ }
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && $unified_info{attributes}->{$_}->{misc} }
+                  @{$unified_info{scripts}})
+-}
 
 APPS_OPENSSL={- use File::Spec::Functions;
                 catfile("apps","openssl") -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -52,14 +52,33 @@ GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}}) -}
 GENERATED={- # common0.tmpl provides @generated
              join(" ", map { platform->convertext($_) } @generated ) -}
 
-INSTALL_LIBS={- join(" ", map { platform->staticlib($_) // () } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBS={- join(" ", map { platform->sharedlib($_) // () } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIB_INFO={- join(" ", map { my $x = platform->sharedlib($_);
-                                      my $y = platform->sharedlib_simple($_);
-                                      $x ? "\"$x;$y\"" : () }
-                                @{$unified_info{install}->{libraries}}) -}
-INSTALL_ENGINES={- join(" ", map { platform->dso($_) } @{$unified_info{install}->{engines}}) -}
-INSTALL_PROGRAMS={- join(" ", map { platform->bin($_) } @{$unified_info{install}->{programs}}) -}
+INSTALL_LIBS={-
+        join(" ", map { platform->staticlib($_) // () }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{libraries}})
+-}
+INSTALL_SHLIBS={-
+        join(" ", map { platform->sharedlib($_) // () }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{libraries}})
+-}
+INSTALL_SHLIB_INFO={-
+        join(" ", map { my $x = platform->sharedlib($_);
+                        my $y = platform->sharedlib_simple($_);
+                        $x ? "\"$x;$y\"" : () }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{libraries}})
+-}
+INSTALL_ENGINES={-
+        join(" ", map { platform->dso($_) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{engines}})
+-}
+INSTALL_PROGRAMS={-
+        join(" ", map { platform->bin($_) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{programs}})
+-}
 {- output_off() if $disabled{apps}; "" -}
 BIN_SCRIPTS=$(BLDDIR)/tools/c_rehash
 MISC_SCRIPTS=$(BLDDIR)/apps/CA.pl $(BLDDIR)/apps/tsget.pl:tsget

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -59,15 +59,44 @@ GENERATED_MANDATORY={- join(" ", @{$unified_info{depends}->{""}} ) -}
 GENERATED={- # common0.tmpl provides @generated
              join(" ", map { platform->convertext($_) } @generated) -}
 
-INSTALL_LIBS={- join(" ", map { quotify1(platform->sharedlib_import($_) // platform->staticlib($_)) } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBS={- join(" ", map { my $x = platform->sharedlib($_);
-                                  $x ? quotify_l($x) : () } @{$unified_info{install}->{libraries}}) -}
-INSTALL_SHLIBPDBS={- join(" ", map { my $x = platform->sharedlibpdb($_);
-                                     $x ? quotify_l($x) : () } @{$unified_info{install}->{libraries}}) -}
-INSTALL_ENGINES={- join(" ", map { quotify1(platform->dso($_)) } @{$unified_info{install}->{engines}}) -}
-INSTALL_ENGINEPDBS={- join(" ", map { quotify1(platform->dsopdb($_)) } @{$unified_info{install}->{engines}}) -}
-INSTALL_PROGRAMS={- join(" ", map { quotify1(platform->bin($_)) } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
-INSTALL_PROGRAMPDBS={- join(" ", map { quotify1(platform->binpdb($_)) } grep { !m|^test\\| } @{$unified_info{install}->{programs}}) -}
+INSTALL_LIBS={-
+        join(" ", map { quotify1(platform->sharedlib_import($_)
+                                 // platform->staticlib($_)) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{libraries}})
+-}
+INSTALL_SHLIBS={-
+        join(" ", map { my $x = platform->sharedlib($_);
+                        $x ? quotify_l($x) : () }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{libraries}})
+-}
+INSTALL_SHLIBPDBS={-
+        join(" ", map { my $x = platform->sharedlibpdb($_);
+                        $x ? quotify_l($x) : () }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{libraries}})
+-}
+INSTALL_ENGINES={-
+        join(" ", map { quotify1(platform->dso($_)) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{engines}})
+-}
+INSTALL_ENGINEPDBS={-
+        join(" ", map { quotify1(platform->dsopdb($_)) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{engines}})
+-}
+INSTALL_PROGRAMS={-
+        join(" ", map { quotify1(platform->bin($_)) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{programs}})
+-}
+INSTALL_PROGRAMPDBS={-
+        join(" ", map { quotify1(platform->binpdb($_)) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst} }
+                  @{$unified_info{programs}})
+-}
 {- output_off() if $disabled{apps}; "" -}
 BIN_SCRIPTS="$(BLDDIR)\tools\c_rehash.pl"
 MISC_SCRIPTS="$(BLDDIR)\apps\CA.pl" "$(BLDDIR)\apps\tsget.pl"

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -97,10 +97,18 @@ INSTALL_PROGRAMPDBS={-
                   grep { !$unified_info{attributes}->{$_}->{noinst} }
                   @{$unified_info{programs}})
 -}
-{- output_off() if $disabled{apps}; "" -}
-BIN_SCRIPTS="$(BLDDIR)\tools\c_rehash.pl"
-MISC_SCRIPTS="$(BLDDIR)\apps\CA.pl" "$(BLDDIR)\apps\tsget.pl"
-{- output_on() if $disabled{apps}; "" -}
+BIN_SCRIPTS={-
+        join(" ", map { quotify1($_) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && !$unified_info{attributes}->{$_}->{misc} }
+                  @{$unified_info{scripts}})
+-}
+MISC_SCRIPTS={-
+        join(" ", map { quotify1($_) }
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && $unified_info{attributes}->{$_}->{misc} }
+                  @{$unified_info{scripts}})
+-}
 
 APPS_OPENSSL={- use File::Spec::Functions;
                 "\"".catfile("apps","openssl")."\"" -}

--- a/Configure
+++ b/Configure
@@ -1710,18 +1710,15 @@ if ($builder eq "unified") {
         my $f = 'build.info';
         # The basic things we're trying to build
         my @programs = ();
-        my @programs_install = ();
         my @libraries = ();
-        my @libraries_install = ();
         my @engines = ();
-        my @engines_install = ();
         my @scripts = ();
-        my @scripts_install = ();
         my @extra = ();
         my @overrides = ();
         my @intermediates = ();
         my @rawlines = ();
 
+        my %attributes = ();
         my %sources = ();
         my %shared_sources = ();
         my %includes = ();
@@ -1792,40 +1789,84 @@ if ($builder eq "unified") {
                     }
                 }
             },
-            qr/^\s*PROGRAMS(_NO_INST)?\s*=\s*(.*)\s*$/
+            qr/^\s*PROGRAMS(?:{([\w=]+(?:\s*,\s*[\w=]+)*)})?\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
-                    my $install = $1;
-                    my @x = tokenize($2);
-                    push @programs, @x;
-                    push @programs_install, @x unless $install;
+                    my @a = tokenize($1, qr|\s*,\s*|);
+                    my @p = tokenize($2);
+                    push @programs, @p;
+                    foreach my $a (@a) {
+                        my $ak = $a;
+                        my $av = 1;
+                        if ($a =~ m|^(.*?)\s*=\s*(.*?)$|) {
+                            $ak = $1;
+                            $av = $2;
+                        }
+                        foreach my $p (@p) {
+                            $attributes{$p}->{$ak} = $av;
+                        }
+                    }
+                    push @programs, @p;
                 }
             },
-            qr/^\s*LIBS(_NO_INST)?\s*=\s*(.*)\s*$/
+            qr/^\s*LIBS(?:{([\w=]+(?:\s*,\s*[\w=]+)*)})?\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
-                    my $install = $1;
-                    my @x = tokenize($2);
-                    push @libraries, @x;
-                    push @libraries_install, @x unless $install;
+                    my @a = tokenize($1, qr|\s*,\s*|);
+                    my @l = tokenize($2);
+                    push @libraries, @l;
+                    foreach my $a (@a) {
+                        my $ak = $a;
+                        my $av = 1;
+                        if ($a =~ m|^(.*?)\s*=\s*(.*?)$|) {
+                            $ak = $1;
+                            $av = $2;
+                        }
+                        foreach my $l (@l) {
+                            $attributes{$l}->{$ak} = $av;
+                        }
+                    }
+                    push @libraries, @l;
                 }
             },
-            qr/^\s*ENGINES(_NO_INST)?\s*=\s*(.*)\s*$/
+            qr/^\s*ENGINES(?:{([\w=]+(?:\s*,\s*[\w=]+)*)})?\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
-                    my $install = $1;
-                    my @x = tokenize($2);
-                    push @engines, @x;
-                    push @engines_install, @x unless $install;
+                    my @a = tokenize($1, qr|\s*,\s*|);
+                    my @e = tokenize($2);
+                    push @engines, @e;
+                    foreach my $a (@a) {
+                        my $ak = $a;
+                        my $av = 1;
+                        if ($a =~ m|^(.*?)\s*=\s*(.*?)$|) {
+                            $ak = $1;
+                            $av = $2;
+                        }
+                        foreach my $e (@e) {
+                            $attributes{$e}->{$ak} = $av;
+                        }
+                    }
+                    push @engines, @e;
                 }
             },
-            qr/^\s*SCRIPTS(_NO_INST)?\s*=\s*(.*)\s*$/
+            qr/^\s*SCRIPTS(?:{([\w=]+(?:\s*,\s*[\w=]+)*)})?\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
-                    my $install = $1;
-                    my @x = tokenize($2);
-                    push @scripts, @x;
-                    push @scripts_install, @x unless $install;
+                    my @a = tokenize($1, qr|\s*,\s*|);
+                    my @s = tokenize($2);
+                    push @scripts, @s;
+                    foreach my $a (@a) {
+                        my $ak = $a;
+                        my $av = 1;
+                        if ($a =~ m|^(.*?)\s*=\s*(.*?)$|) {
+                            $ak = $1;
+                            $av = $2;
+                        }
+                        foreach my $s (@s) {
+                            $attributes{$s}->{$ak} = $av;
+                        }
+                    }
+                    push @scripts, @s;
                 }
             },
             qr/^\s*EXTRA\s*=\s*(.*)\s*$/
@@ -1893,58 +1934,33 @@ if ($builder eq "unified") {
             );
         die "runaway IF?" if (@skip);
 
-        foreach (@programs) {
-            my $program = cleanfile($buildd, $_, $blddir);
-            $unified_info{programs}->{$program} = 1;
-        }
-
-        foreach (@programs_install) {
-            my $program = cleanfile($buildd, $_, $blddir);
-            $unified_info{install}->{programs}->{$program} = 1;
-        }
-
-        foreach (@libraries) {
-            my $library = cleanfile($buildd, $_, $blddir);
-            $unified_info{libraries}->{$library} = 1;
-        }
-
-        foreach (@libraries_install) {
-            my $library = cleanfile($buildd, $_, $blddir);
-            $unified_info{install}->{libraries}->{$library} = 1;
-        }
-
         die <<"EOF" if scalar @engines and !$config{dynamic_engines};
 ENGINES can only be used if configured with 'dynamic-engine'.
 This is usually a fault in a build.info file.
 EOF
-        foreach (@engines) {
-            my $library = cleanfile($buildd, $_, $blddir);
-            $unified_info{engines}->{$library} = 1;
+
+        foreach (keys %attributes) {
+            my $dest = $_;
+            my $ddest = cleanfile($buildd, $_, $blddir);
+            foreach (keys %{$attributes{$dest} // {}}) {
+                $unified_info{attributes}->{$ddest}->{$_} =
+                    $attributes{$dest}->{$_};
+            }
         }
 
-        foreach (@engines_install) {
-            my $library = cleanfile($buildd, $_, $blddir);
-            $unified_info{install}->{engines}->{$library} = 1;
-        }
-
-        foreach (@scripts) {
-            my $script = cleanfile($buildd, $_, $blddir);
-            $unified_info{scripts}->{$script} = 1;
-        }
-
-        foreach (@scripts_install) {
-            my $script = cleanfile($buildd, $_, $blddir);
-            $unified_info{install}->{scripts}->{$script} = 1;
-        }
-
-        foreach (@extra) {
-            my $extra = cleanfile($buildd, $_, $blddir);
-            $unified_info{extra}->{$extra} = 1;
-        }
-
-        foreach (@overrides) {
-            my $override = cleanfile($buildd, $_, $blddir);
-            $unified_info{overrides}->{$override} = 1;
+        {
+            my %infos = ( programs  => [ @programs  ],
+                          libraries => [ @libraries ],
+                          engines   => [ @engines   ],
+                          scripts   => [ @scripts   ],
+                          extra     => [ @extra     ],
+                          overrides => [ @overrides ] );
+            foreach my $k (keys %infos) {
+                foreach (@{$infos{$k}}) {
+                    my $item = cleanfile($buildd, $_, $blddir);
+                    $unified_info{$k}->{$item} = 1;
+                }
+            }
         }
 
         push @{$unified_info{rawlines}}, @rawlines;
@@ -2247,7 +2263,7 @@ EOF
         $unified_info{$_} = [ sort keys %{$unified_info{$_}} ];
     }
     # Two level structures
-    foreach my $l1 (("install", "sources", "shared_sources", "ldadd", "depends")) {
+    foreach my $l1 (("sources", "shared_sources", "ldadd", "depends")) {
         foreach my $l2 (sort keys %{$unified_info{$l1}}) {
             my @items =
                 sort

--- a/Configure
+++ b/Configure
@@ -3508,39 +3508,50 @@ sub collect_information {
 }
 
 # tokenize($line)
+# tokenize($line,$separator)
 # $line is a line of text to split up into tokens
-# returns a list of tokens
+# $separator [optional] is a regular expression that separates the tokens,
+# the default being spaces.  Do not use quotes of any kind as separators,
+# that will give undefined results.
+# Returns a list of tokens.
 #
-# Tokens are divided by spaces.  If the tokens include spaces, they
-# have to be quoted with single or double quotes.  Double quotes
-# inside a double quoted token must be escaped.  Escaping is done
+# Tokens are divided by separator (spaces by default.  If the tokens include
+# the separators, they have to be quoted with single or double quotes.
+# Double quotes inside a double quoted token must be escaped.  Escaping is done
 # with backslash.
 # Basically, the same quoting rules apply for " and ' as in any
 # Unix shell.
 sub tokenize {
     my $line = my $debug_line = shift;
+    my $separator = shift // qr|\s+|;
     my @result = ();
 
-    while ($line =~ s|^\s+||, $line ne "") {
+    if ($ENV{CONFIGURE_DEBUG_TOKENIZE}) {
+        print STDERR "DEBUG[tokenize]: \$separator = $separator\n";
+    }
+
+    while ($line =~ s|^${separator}||, $line ne "") {
         my $token = "";
-        while ($line ne "" && $line !~ m|^\s|) {
-            if ($line =~ m/^"((?:[^"\\]+|\\.)*)"/) {
-                $token .= $1;
-                $line = $';
-            } elsif ($line =~ m/^'([^']*)'/) {
-                $token .= $1;
-                $line = $';
-            } elsif ($line =~ m/^(\S+)/) {
-                $token .= $1;
-                $line = $';
-            }
+    again:
+        $line =~ m/^(.*?)(${separator}|"|'|$)/;
+        $token .= $1;
+        $line = $2.$';
+
+        if ($line =~ m/^"((?:[^"\\]+|\\.)*)"/) {
+            $token .= $1;
+            $line = $';
+            goto again;
+        } elsif ($line =~ m/^'([^']*)'/) {
+            $token .= $1;
+            $line = $';
+            goto again;
         }
         push @result, $token;
     }
 
     if ($ENV{CONFIGURE_DEBUG_TOKENIZE}) {
-	print STDERR "DEBUG[tokenize]: Parsed '$debug_line' into:\n";
-	print STDERR "DEBUG[tokenize]: ('", join("', '", @result), "')\n";
+        print STDERR "DEBUG[tokenize]: Parsed '$debug_line' into:\n";
+        print STDERR "DEBUG[tokenize]: ('", join("', '", @result), "')\n";
     }
     return @result;
 }

--- a/apps/build.info
+++ b/apps/build.info
@@ -32,7 +32,10 @@ ENDIF
   GENERATE[progs.h]=progs.pl $(APPS_OPENSSL)
   DEPEND[progs.h]=../configdata.pm
 
-  SCRIPTS=CA.pl tsget.pl
+  SCRIPTS{misc}=CA.pl
   SOURCE[CA.pl]=CA.pl.in
+  # linkname tells build files that a symbolic link or copy of this script
+  # without extension must be installed as well.  Unix or Unix lookalike only.
+  SCRIPTS{misc,linkname=tsget}=tsget.pl
   SOURCE[tsget.pl]=tsget.in
 ENDIF

--- a/apps/build.info
+++ b/apps/build.info
@@ -12,7 +12,7 @@
    our @apps_init_src = split(/\s+/, $target{apps_init_src});
    "" -}
 IF[{- !$disabled{apps} -}]
-  LIBS_NO_INST=libapps.a
+  LIBS{noinst}=libapps.a
   SOURCE[libapps.a]={- join(" ", @apps_lib_src) -}
   INCLUDE[libapps.a]=.. ../include
 

--- a/engines/build.info
+++ b/engines/build.info
@@ -40,7 +40,7 @@ IF[{- !$disabled{"engine"} -}]
       ENDIF
     ENDIF
 
-    ENGINES_NO_INST=ossltest dasync
+    ENGINES{noinst}=ossltest dasync
     SOURCE[dasync]=e_dasync.c
     DEPEND[dasync]=../libcrypto
     INCLUDE[dasync]=../include

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -9,14 +9,14 @@
 -}
 
 IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
-  PROGRAMS_NO_INST=asn1 asn1parse bignum bndiv client conf crl server x509
+  PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server x509
 
   IF[{- !$disabled{"cms"} -}]
-    PROGRAMS_NO_INST=cms
+    PROGRAMS{noinst}=cms
   ENDIF
 
   IF[{- !$disabled{"ct"} -}]
-    PROGRAMS_NO_INST=ct
+    PROGRAMS{noinst}=ct
   ENDIF
 
   SOURCE[asn1]=asn1.c driver.c
@@ -65,14 +65,14 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
 ENDIF
 
 IF[{- !$disabled{tests} -}]
-  PROGRAMS_NO_INST=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test x509-test
+  PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test x509-test
 
   IF[{- !$disabled{"cms"} -}]
-    PROGRAMS_NO_INST=cms-test
+    PROGRAMS{noinst}=cms-test
   ENDIF
 
   IF[{- !$disabled{"ct"} -}]
-    PROGRAMS_NO_INST=ct-test
+    PROGRAMS{noinst}=ct-test
   ENDIF
 
   SOURCE[asn1-test]=asn1.c test-corpus.c

--- a/test/build.info
+++ b/test/build.info
@@ -9,7 +9,7 @@ SUBDIRS=ossl_shim
      ""
 -}
 IF[{- !$disabled{tests} -}]
-  LIBS_NO_INST=libtestutil.a
+  LIBS{noinst}=libtestutil.a
   SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output_helpers.c \
           testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
           testutil/format_output.c testutil/tap_bio.c \
@@ -24,7 +24,7 @@ IF[{- !$disabled{tests} -}]
 INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   ENDRAW[descrip.mms]
 
-  PROGRAMS_NO_INST=\
+  PROGRAMS{noinst}=\
           versions \
           aborttest test_test \
           sanitytest rsa_complex exdatatest bntest \
@@ -379,27 +379,27 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   DEPEND[servername_test]=../libcrypto ../libssl libtestutil.a
 
   IF[{- !$disabled{cms} -}]
-    PROGRAMS_NO_INST=cmsapitest
+    PROGRAMS{noinst}=cmsapitest
     SOURCE[cmsapitest]=cmsapitest.c
     INCLUDE[cmsapitest]=../include
     DEPEND[cmsapitest]=../libcrypto libtestutil.a
   ENDIF
 
   IF[{- !$disabled{psk} -}]
-    PROGRAMS_NO_INST=dtls_mtu_test
+    PROGRAMS{noinst}=dtls_mtu_test
     SOURCE[dtls_mtu_test]=dtls_mtu_test.c ssltestlib.c
     INCLUDE[dtls_mtu_test]=.. ../include
     DEPEND[dtls_mtu_test]=../libcrypto ../libssl libtestutil.a
   ENDIF
 
   IF[{- !$disabled{shared} -}]
-    PROGRAMS_NO_INST=shlibloadtest
+    PROGRAMS{noinst}=shlibloadtest
     SOURCE[shlibloadtest]=shlibloadtest.c
     INCLUDE[shlibloadtest]=../include ../crypto/include
   ENDIF
 
   IF[{- $disabled{shared} -}]
-    PROGRAMS_NO_INST=cipher_overhead_test
+    PROGRAMS{noinst}=cipher_overhead_test
     SOURCE[cipher_overhead_test]=cipher_overhead_test.c
     INCLUDE[cipher_overhead_test]=.. ../include
     DEPEND[cipher_overhead_test]=../libcrypto ../libssl libtestutil.a
@@ -442,26 +442,26 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   # programs are forcibly linked with the static libraries, where all symbols
   # are always available.
   IF[1]
-    PROGRAMS_NO_INST=asn1_internal_test modes_internal_test x509_internal_test \
+    PROGRAMS{noinst}=asn1_internal_test modes_internal_test x509_internal_test \
                      tls13encryptiontest wpackettest ctype_internal_test \
                      rdrand_sanitytest
     IF[{- !$disabled{poly1305} -}]
-      PROGRAMS_NO_INST=poly1305_internal_test
+      PROGRAMS{noinst}=poly1305_internal_test
     ENDIF
     IF[{- !$disabled{chacha} -}]
-      PROGRAMS_NO_INST=chacha_internal_test
+      PROGRAMS{noinst}=chacha_internal_test
     ENDIF
     IF[{- !$disabled{siphash} -}]
-      PROGRAMS_NO_INST=siphash_internal_test
+      PROGRAMS{noinst}=siphash_internal_test
     ENDIF
     IF[{- !$disabled{sm2} -}]
-      PROGRAMS_NO_INST=sm2_internal_test
+      PROGRAMS{noinst}=sm2_internal_test
     ENDIF
     IF[{- !$disabled{sm4} -}]
-      PROGRAMS_NO_INST=sm4_internal_test
+      PROGRAMS{noinst}=sm4_internal_test
     ENDIF
     IF[{- !$disabled{ec} -}]
-      PROGRAMS_NO_INST=curve448_internal_test
+      PROGRAMS{noinst}=curve448_internal_test
     ENDIF
 
     SOURCE[poly1305_internal_test]=poly1305_internal_test.c
@@ -518,14 +518,14 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   ENDIF
 
   IF[{- !$disabled{mdc2} -}]
-    PROGRAMS_NO_INST=mdc2_internal_test
+    PROGRAMS{noinst}=mdc2_internal_test
   ENDIF
 
   SOURCE[mdc2_internal_test]=mdc2_internal_test.c
   INCLUDE[mdc2_internal_test]=.. ../include
   DEPEND[mdc2_internal_test]=../libcrypto libtestutil.a
 
-  PROGRAMS_NO_INST=asn1_time_test
+  PROGRAMS{noinst}=asn1_time_test
   SOURCE[asn1_time_test]=asn1_time_test.c
   INCLUDE[asn1_time_test]=../include
   DEPEND[asn1_time_test]=../libcrypto libtestutil.a
@@ -534,7 +534,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
   # redefines some internal libssl symbols. This doesn't work in a non-shared
   # build
   IF[{- !$disabled{shared} -}]
-    PROGRAMS_NO_INST=tls13secretstest
+    PROGRAMS{noinst}=tls13secretstest
     SOURCE[tls13secretstest]=tls13secretstest.c
     SOURCE[tls13secretstest]= ../ssl/tls13_enc.c ../ssl/packet.c
     INCLUDE[tls13secretstest]=.. ../include
@@ -578,7 +578,7 @@ ENDIF
        next if grep { lc("$name.h") =~ m/$_/i } @nogo_headers_re;
        $OUT .= <<"_____";
 
-  PROGRAMS_NO_INST=buildtest_$name
+  PROGRAMS{noinst}=buildtest_$name
   GENERATE[buildtest_$name.c]=generate_buildtest.pl $name
   SOURCE[buildtest_$name]=buildtest_$name.c
   INCLUDE[buildtest_$name]=../include

--- a/test/ossl_shim/build.info
+++ b/test/ossl_shim/build.info
@@ -1,5 +1,5 @@
 IF[{- defined $target{CXX} && !$disabled{"external-tests"} -}]
-  PROGRAMS_NO_INST=ossl_shim
+  PROGRAMS{noinst}=ossl_shim
   SOURCE[ossl_shim]=ossl_shim.cc async_bio.cc packeted_bio.cc test_config.cc
   INCLUDE[ossl_shim]=. include ../../include
   DEPEND[ossl_shim]=../../libssl ../../libcrypto

--- a/util/build.info
+++ b/util/build.info
@@ -1,8 +1,8 @@
 IF[{- $target{build_scheme}->[1] eq "VMS" -}]
- SCRIPTS_NO_INST=local_shlib.com unlocal_shlib.com
+ SCRIPTS{noinst}=local_shlib.com unlocal_shlib.com
  SOURCE[local_shlib.com]=local_shlib.com.in
  SOURCE[unlocal_shlib.com]=unlocal_shlib.com.in
 ELSIF[{- $target{build_scheme}->[1] eq "unix" -}]
- SCRIPTS_NO_INST=shlib_wrap.sh
+ SCRIPTS{noinst}=shlib_wrap.sh
  SOURCE[shlib_wrap.sh]=shlib_wrap.sh.in
 ENDIF


### PR DESCRIPTION
Among others, this avoids having special variables like
PROGRAMS_NO_INST.  Instead, we can have something like this:

    PROGRAMS{noinst}=foo bar

Configure itself is entirely agnostic to these attributes, they are
simply passed to the build file templates, to be used as they see fit.

Attributes can also have values, for example:

    SCRIPTS{linkname=foo}=foo.pl

This could help indicate to build file templates that care that the
perl script 'foo.pl' should also exist with the name 'foo', preferably
as a symbolic link.

Fixes #7568