### PR TITLE
eng_devcrypto: add configuration options, misc fixes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -335,6 +335,11 @@
                    Don't build support for datagram based BIOs. Selecting this
                    option will also force the disabling of DTLS.
 
+  enable-devcryptoeng
+                   Build the /dev/crypto engine.  It is automatically selected
+                   on BSD implementations, in which case it can be disabled with
+                   no-devcryptoeng.
+
   no-dso
                    Don't build support for loading Dynamic Shared Objects.
 

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -619,11 +619,6 @@ void engine_load_devcrypto_int()
         return;
     }
 
-    prepare_cipher_methods();
-#ifdef IMPLEMENT_DIGEST
-    prepare_digest_methods();
-#endif
-
     if ((e = ENGINE_new()) == NULL
         || !ENGINE_set_destroy_function(e, devcrypto_unload)) {
         ENGINE_free(e);
@@ -635,6 +630,11 @@ void engine_load_devcrypto_int()
         close(cfd);
         return;
     }
+
+    prepare_cipher_methods();
+#ifdef IMPLEMENT_DIGEST
+    prepare_digest_methods();
+#endif
 
     if (!ENGINE_set_id(e, "devcrypto")
         || !ENGINE_set_name(e, "/dev/crypto engine")

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -338,7 +338,8 @@ static int devcrypto_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
 
 struct digest_ctx {
     struct session_op sess;
-    int init;
+    /* This signals that the init function was called, not that it succeeded. */
+    int init_called;
 };
 
 static const struct digest_data_st {
@@ -403,7 +404,7 @@ static int digest_init(EVP_MD_CTX *ctx)
     const struct digest_data_st *digest_d =
         get_digest_data(EVP_MD_CTX_type(ctx));
 
-    digest_ctx->init = 1;
+    digest_ctx->init_called = 1;
 
     memset(&digest_ctx->sess, 0, sizeof(digest_ctx->sess));
     digest_ctx->sess.mac = digest_d->devcryptoid;
@@ -476,13 +477,8 @@ static int digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
         (struct digest_ctx *)EVP_MD_CTX_md_data(to);
     struct cphash_op cphash;
 
-    if (digest_from == NULL)
+    if (digest_from == NULL || digest_from->init_called != 1)
         return 1;
-
-    if (digest_from->init != 1) {
-        SYSerr(SYS_F_IOCTL, EINVAL);
-        return 0;
-    }
 
     if (!digest_init(to)) {
         SYSerr(SYS_F_IOCTL, errno);

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -601,6 +601,30 @@ static int digest_cleanup(EVP_MD_CTX *ctx)
     return 1;
 }
 
+static int devcrypto_test_digest(size_t digest_data_index)
+{
+    struct session_op sess1, sess2;
+    struct cphash_op cphash;
+    int ret=0;
+
+    memset(&sess1, 0, sizeof(sess1));
+    memset(&sess2, 0, sizeof(sess2));
+    sess1.mac = digest_data[digest_data_index].devcryptoid;
+    if (ioctl(cfd, CIOCGSESSION, &sess1) < 0)
+        return 0;
+    /* Make sure the driver is capable of hash state copy */
+    sess2.mac = sess1.mac;
+    if (ioctl(cfd, CIOCGSESSION, &sess2) >= 0) {
+        cphash.src_ses = sess1.ses;
+        cphash.dst_ses = sess2.ses;
+        if (ioctl(cfd, CIOCCPHASH, &cphash) >= 0)
+            ret = 1;
+        ioctl(cfd, CIOCFSESSION, &sess2.ses);
+    }
+    ioctl(cfd, CIOCFSESSION, &sess1.ses);
+    return ret;
+}
+
 /*
  * Keep a table of known nids and associated methods.
  * Note that known_digest_nids[] isn't necessarily indexed the same way as
@@ -613,20 +637,14 @@ static EVP_MD *known_digest_methods[OSSL_NELEM(digest_data)] = { NULL, };
 static void prepare_digest_methods(void)
 {
     size_t i;
-    struct session_op sess;
-
-    memset(&sess, 0, sizeof(sess));
 
     for (i = 0, known_digest_nids_amount = 0; i < OSSL_NELEM(digest_data);
          i++) {
 
         /*
-         * Check that the algo is really availably by trying to open and close
-         * a session.
+         * Check that the algo is usable
          */
-        sess.mac = digest_data[i].devcryptoid;
-        if (ioctl(cfd, CIOCGSESSION, &sess) < 0
-            || ioctl(cfd, CIOCFSESSION, &sess.ses) < 0)
+        if (!devcrypto_test_digest(i))
             continue;
 
         if ((known_digest_methods[i] = EVP_MD_meth_new(digest_data[i].nid,

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -437,6 +437,7 @@ struct digest_ctx {
     struct session_op sess;
     /* This signals that the init function was called, not that it succeeded. */
     int init_called;
+    unsigned char digest_res[HASH_MAX_LEN];
 };
 
 static const struct digest_data_st {
@@ -539,12 +540,15 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     if (digest_ctx == NULL)
         return 0;
 
-    if (digest_op(digest_ctx, data, count, NULL, COP_FLAG_UPDATE) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
-        return 0;
+    if (EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
+        if (digest_op(digest_ctx, data, count, digest_ctx->digest_res, 0) >= 0)
+            return 1;
+    } else if (digest_op(digest_ctx, data, count, NULL, COP_FLAG_UPDATE) >= 0) {
+        return 1;
     }
 
-    return 1;
+    SYSerr(SYS_F_IOCTL, errno);
+    return 0;
 }
 
 static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
@@ -554,7 +558,10 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
 
     if (md == NULL || digest_ctx == NULL)
         return 0;
-    if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
+
+    if (EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
+        memcpy(md, digest_ctx->digest_res, EVP_MD_CTX_size(ctx));
+    } else if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
         SYSerr(SYS_F_IOCTL, errno);
         return 0;
     }

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -48,16 +48,20 @@ static int use_softdrivers = DEVCRYPTO_DEFAULT_USE_SOFDTRIVERS;
  */
 struct driver_info_st {
     enum devcrypto_status_t {
-        DEVCRYPTO_STATUS_UNUSABLE       = -1, /* session open failed */
-        DEVCRYPTO_STATUS_UNKNOWN        =  0, /* not tested yet */
-        DEVCRYPTO_STATUS_USABLE         =  1  /* algo can be used */
+        DEVCRYPTO_STATUS_FAILURE         = -3, /* unusable for other reason */
+        DEVCRYPTO_STATUS_NO_CIOCCPHASH   = -2, /* hash state copy not supported */
+        DEVCRYPTO_STATUS_NO_CIOCGSESSION = -1, /* session open failed */
+        DEVCRYPTO_STATUS_UNKNOWN         =  0, /* not tested yet */
+        DEVCRYPTO_STATUS_USABLE          =  1  /* algo can be used */
     } status;
 
     enum devcrypto_accelerated_t {
-        DEVCRYPTO_NOT_ACCELERATED       = -1, /* software implemented */
-        DEVCRYPTO_ACCELERATION_UNKNOWN  =  0, /* acceleration support unkown */
-        DEVCRYPTO_ACCELERATED           =  1  /* hardware accelerated */
+        DEVCRYPTO_NOT_ACCELERATED        = -1, /* software implemented */
+        DEVCRYPTO_ACCELERATION_UNKNOWN   =  0, /* acceleration support unkown */
+        DEVCRYPTO_ACCELERATED            =  1  /* hardware accelerated */
     } accelerated;
+
+    char *driver_name;
 };
 
 /******************************************************************************
@@ -392,7 +396,7 @@ static void prepare_cipher_methods(void)
         sess.cipher = cipher_data[i].devcryptoid;
         sess.keylen = cipher_data[i].keylen;
         if (ioctl(cfd, CIOCGSESSION, &sess) < 0) {
-            cipher_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            cipher_driver_info[i].status = DEVCRYPTO_STATUS_NO_CIOCGSESSION;
             continue;
         }
 
@@ -419,19 +423,24 @@ static void prepare_cipher_methods(void)
                                             cipher_cleanup)
             || !EVP_CIPHER_meth_set_impl_ctx_size(known_cipher_methods[i],
                                                   sizeof(struct cipher_ctx))) {
-            cipher_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            cipher_driver_info[i].status = DEVCRYPTO_STATUS_FAILURE;
             EVP_CIPHER_meth_free(known_cipher_methods[i]);
             known_cipher_methods[i] = NULL;
         } else {
             cipher_driver_info[i].status = DEVCRYPTO_STATUS_USABLE;
 #ifdef CIOCGSESSINFO
             siop.ses = sess.ses;
-            if (ioctl(cfd, CIOCGSESSINFO, &siop) < 0)
+            if (ioctl(cfd, CIOCGSESSINFO, &siop) < 0) {
                 cipher_driver_info[i].accelerated = DEVCRYPTO_ACCELERATION_UNKNOWN;
-            else if (!(siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY))
-                cipher_driver_info[i].accelerated = DEVCRYPTO_NOT_ACCELERATED;
-            else
-                cipher_driver_info[i].accelerated = DEVCRYPTO_ACCELERATED;
+            } else {
+                cipher_driver_info[i].driver_name =
+                    OPENSSL_strndup(siop.cipher_info.cra_driver_name,
+                                    CRYPTODEV_MAX_ALG_NAME);
+                if (!(siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY))
+                    cipher_driver_info[i].accelerated = DEVCRYPTO_NOT_ACCELERATED;
+                else
+                    cipher_driver_info[i].accelerated = DEVCRYPTO_ACCELERATED;
+            }
 #endif /* CIOCGSESSINFO */
         }
         ioctl(cfd, CIOCFSESSION, &sess.ses);
@@ -481,8 +490,11 @@ static void destroy_all_cipher_methods(void)
 {
     size_t i;
 
-    for (i = 0; i < OSSL_NELEM(cipher_data); i++)
+    for (i = 0; i < OSSL_NELEM(cipher_data); i++) {
         destroy_cipher_method(cipher_data[i].nid);
+        OPENSSL_free(cipher_driver_info[i].driver_name);
+        cipher_driver_info[i].driver_name = NULL;
+    }
 }
 
 static int devcrypto_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
@@ -524,6 +536,40 @@ static int cryptodev_select_cipher_cb(const char *str, int len, void *usr)
         fprintf(stderr, "devcrypto: cipher %s not available\n", name);
     OPENSSL_free(name);
     return 1;
+}
+
+static void dump_cipher_info(void)
+{
+    size_t i;
+    const char *name;
+
+    fprintf (stderr, "Information about ciphers supported by the /dev/crypto"
+             " engine:\n");
+#ifndef CIOCGSESSINFO
+    fprintf(stderr, "CIOCGSESSINFO (session info call) unavailable\n");
+#endif
+    for (i = 0; i < OSSL_NELEM(cipher_data); i++) {
+        name = OBJ_nid2sn(cipher_data[i].nid);
+        fprintf (stderr, "Cipher %s, NID=%d, /dev/crypto info: id=%d, ",
+                 name ? name : "unknown", cipher_data[i].nid,
+                 cipher_data[i].devcryptoid);
+        if (cipher_driver_info[i].status == DEVCRYPTO_STATUS_NO_CIOCGSESSION ) {
+            fprintf (stderr, "CIOCGSESSION (session open call) failed\n");
+            continue;
+        }
+        fprintf (stderr, "driver=%s ", cipher_driver_info[i].driver_name ?
+                 cipher_driver_info[i].driver_name : "unknown");
+        if (cipher_driver_info[i].accelerated == DEVCRYPTO_ACCELERATED)
+            fprintf(stderr, "(hw accelerated)");
+        else if (cipher_driver_info[i].accelerated == DEVCRYPTO_NOT_ACCELERATED)
+            fprintf(stderr, "(software)");
+        else
+            fprintf(stderr, "(acceleration status unknown)");
+        if (cipher_driver_info[i].status == DEVCRYPTO_STATUS_FAILURE)
+            fprintf (stderr, ". Cipher setup failed");
+        fprintf(stderr, "\n");
+    }
+    fprintf(stderr, "\n");
 }
 
 /*
@@ -790,31 +836,36 @@ static void prepare_digest_methods(void)
         sess1.mac = digest_data[i].devcryptoid;
         sess2.ses = 0;
         if (ioctl(cfd, CIOCGSESSION, &sess1) < 0) {
-            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_NO_CIOCGSESSION;
             goto finish;
         }
 
 #ifdef CIOCGSESSINFO
         /* gather hardware acceleration info from the driver */
         siop.ses = sess1.ses;
-        if (ioctl(cfd, CIOCGSESSINFO, &siop) < 0)
+        if (ioctl(cfd, CIOCGSESSINFO, &siop) < 0) {
             digest_driver_info[i].accelerated = DEVCRYPTO_ACCELERATION_UNKNOWN;
-        else if (siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY)
-            digest_driver_info[i].accelerated = DEVCRYPTO_ACCELERATED;
-        else
-            digest_driver_info[i].accelerated = DEVCRYPTO_NOT_ACCELERATED;
+        } else {
+            digest_driver_info[i].driver_name =
+                OPENSSL_strndup(siop.hash_info.cra_driver_name,
+                                CRYPTODEV_MAX_ALG_NAME);
+            if (siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY)
+                digest_driver_info[i].accelerated = DEVCRYPTO_ACCELERATED;
+            else
+                digest_driver_info[i].accelerated = DEVCRYPTO_NOT_ACCELERATED;
+        }
 #endif
 
         /* digest must be capable of hash state copy */
         sess2.mac = sess1.mac;
         if (ioctl(cfd, CIOCGSESSION, &sess2) < 0) {
-            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_FAILURE;
             goto finish;
         }
         cphash.src_ses = sess1.ses;
         cphash.dst_ses = sess2.ses;
         if (ioctl(cfd, CIOCCPHASH, &cphash) < 0) {
-            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_NO_CIOCCPHASH;
             goto finish;
         }
         if ((known_digest_methods[i] = EVP_MD_meth_new(digest_data[i].nid,
@@ -828,7 +879,7 @@ static void prepare_digest_methods(void)
             || !EVP_MD_meth_set_cleanup(known_digest_methods[i], digest_cleanup)
             || !EVP_MD_meth_set_app_datasize(known_digest_methods[i],
                                              sizeof(struct digest_ctx))) {
-            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_FAILURE;
             EVP_MD_meth_free(known_digest_methods[i]);
             known_digest_methods[i] = NULL;
             goto finish;
@@ -870,8 +921,11 @@ static void destroy_all_digest_methods(void)
 {
     size_t i;
 
-    for (i = 0; i < OSSL_NELEM(digest_data); i++)
+    for (i = 0; i < OSSL_NELEM(digest_data); i++) {
         destroy_digest_method(digest_data[i].nid);
+        OPENSSL_free(digest_driver_info[i].driver_name);
+        digest_driver_info[i].driver_name = NULL;
+    }
 }
 
 static int devcrypto_digests(ENGINE *e, const EVP_MD **digest,
@@ -915,6 +969,43 @@ static int cryptodev_select_digest_cb(const char *str, int len, void *usr)
     return 1;
 }
 
+static void dump_digest_info(void)
+{
+    size_t i;
+    const char *name;
+
+    fprintf (stderr, "Information about digests supported by the /dev/crypto"
+             " engine:\n");
+#ifndef CIOCGSESSINFO
+    fprintf(stderr, "CIOCGSESSINFO (session info call) unavailable\n");
+#endif
+
+    for (i = 0; i < OSSL_NELEM(digest_data); i++) {
+        name = OBJ_nid2sn(digest_data[i].nid);
+        fprintf (stderr, "Digest %s, NID=%d, /dev/crypto info: id=%d, driver=%s",
+                 name ? name : "unknown", digest_data[i].nid,
+                 digest_data[i].devcryptoid,
+                 digest_driver_info[i].driver_name ? digest_driver_info[i].driver_name : "unknown");
+        if (digest_driver_info[i].status == DEVCRYPTO_STATUS_NO_CIOCGSESSION) {
+            fprintf (stderr, ". CIOCGSESSION (session open) failed\n");
+            continue;
+        }
+        if (digest_driver_info[i].accelerated == DEVCRYPTO_ACCELERATED)
+            fprintf(stderr, " (hw accelerated)");
+        else if (digest_driver_info[i].accelerated == DEVCRYPTO_NOT_ACCELERATED)
+            fprintf(stderr, " (software)");
+        else
+            fprintf(stderr, " (acceleration status unknown)");
+        if (cipher_driver_info[i].status == DEVCRYPTO_STATUS_FAILURE)
+            fprintf (stderr, ". Cipher setup failed\n");
+        else if (digest_driver_info[i].status == DEVCRYPTO_STATUS_NO_CIOCCPHASH)
+            fprintf(stderr, ", CIOCCPHASH failed\n");
+        else
+            fprintf(stderr, ", CIOCCPHASH capable\n");
+    }
+    fprintf(stderr, "\n");
+}
+
 #endif
 
 /******************************************************************************
@@ -952,6 +1043,11 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
     "either ALL, NONE, or a comma-separated list of digests to enable [default=ALL]",
     ENGINE_CMD_FLAG_STRING},
 #endif
+
+   {DEVCRYPTO_CMD_DUMP_INFO,
+    "DUMP_INFO",
+    "dump info about each algorithm to stderr; use 'openssl engine -pre DUMP_INFO devcrypto'",
+    ENGINE_CMD_FLAG_NO_INPUT},
 
    {0, NULL, NULL, 0}
 };
@@ -1020,6 +1116,13 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
         rebuild_known_digest_nids(e);
         return 1;
 #endif /* IMPLEMENT_DIGEST */
+
+    case DEVCRYPTO_CMD_DUMP_INFO:
+        dump_cipher_info();
+#ifdef IMPLEMENT_DIGEST
+        dump_digest_info();
+#endif
+        return 1;
 
     default:
         break;

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -47,10 +47,12 @@ static int cfd;
 
 struct cipher_ctx {
     struct session_op sess;
-
-    /* to pass from init to do_cipher */
-    const unsigned char *iv;
     int op;                      /* COP_ENCRYPT or COP_DECRYPT */
+    unsigned long mode;          /* EVP_CIPH_*_MODE */
+
+    /* to handle ctr mode being a stream cipher */
+    unsigned char partial[EVP_MAX_BLOCK_LENGTH];
+    unsigned int blocksize, num;
 };
 
 static const struct cipher_data_st {
@@ -87,9 +89,9 @@ static const struct cipher_data_st {
     { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_ECB)
-    { NID_aes_128_ecb, 16, 128 / 8, 16, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
-    { NID_aes_192_ecb, 16, 192 / 8, 16, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
-    { NID_aes_256_ecb, 16, 256 / 8, 16, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+    { NID_aes_128_ecb, 16, 128 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+    { NID_aes_192_ecb, 16, 192 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+    { NID_aes_256_ecb, 16, 256 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
 #endif
 #if 0                            /* Not yet supported */
     { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
@@ -146,6 +148,8 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     cipher_ctx->sess.keylen = cipher_d->keylen;
     cipher_ctx->sess.key = (void *)key;
     cipher_ctx->op = enc ? COP_ENCRYPT : COP_DECRYPT;
+    cipher_ctx->mode = cipher_d->flags & EVP_CIPH_MODE;
+    cipher_ctx->blocksize = cipher_d->blocksize;
     if (ioctl(cfd, CIOCGSESSION, &cipher_ctx->sess) < 0) {
         SYSerr(SYS_F_IOCTL, errno);
         return 0;
@@ -160,8 +164,11 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     struct cipher_ctx *cipher_ctx =
         (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     struct crypt_op cryp;
+    unsigned char *iv = EVP_CIPHER_CTX_iv_noconst(ctx);
 #if !defined(COP_FLAG_WRITE_IV)
     unsigned char saved_iv[EVP_MAX_IV_LENGTH];
+    const unsigned char *ivptr;
+    size_t nblocks, ivlen;
 #endif
 
     memset(&cryp, 0, sizeof(cryp));
@@ -169,19 +176,28 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     cryp.len = inl;
     cryp.src = (void *)in;
     cryp.dst = (void *)out;
-    cryp.iv = (void *)EVP_CIPHER_CTX_iv_noconst(ctx);
+    cryp.iv = (void *)iv;
     cryp.op = cipher_ctx->op;
 #if !defined(COP_FLAG_WRITE_IV)
     cryp.flags = 0;
 
-    if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
-        assert(inl >= EVP_CIPHER_CTX_iv_length(ctx));
-        if (!EVP_CIPHER_CTX_encrypting(ctx)) {
-            unsigned char *ivptr = in + inl - EVP_CIPHER_CTX_iv_length(ctx);
+    ivlen = EVP_CIPHER_CTX_iv_length(ctx);
+    if (ivlen > 0)
+        switch (cipher_ctx->mode) {
+        case EVP_CIPH_CBC_MODE:
+            assert(inl >= ivlen);
+            if (!EVP_CIPHER_CTX_encrypting(ctx)) {
+                ivptr = in + inl - ivlen;
+                memcpy(saved_iv, ivptr, ivlen);
+            }
+            break;
 
-            memcpy(saved_iv, ivptr, EVP_CIPHER_CTX_iv_length(ctx));
+        case EVP_CIPH_CTR_MODE:
+            break;
+
+        default: /* should not happen */
+            return 0;
         }
-    }
 #else
     cryp.flags = COP_FLAG_WRITE_IV;
 #endif
@@ -192,17 +208,74 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     }
 
 #if !defined(COP_FLAG_WRITE_IV)
-    if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
-        unsigned char *ivptr = saved_iv;
+    if (ivlen > 0)
+        switch (cipher_ctx->mode) {
+        case EVP_CIPH_CBC_MODE:
+            assert(inl >= ivlen);
+            if (EVP_CIPHER_CTX_encrypting(ctx))
+                ivptr = out + inl - ivlen;
+            else
+                ivptr = saved_iv;
 
-        assert(inl >= EVP_CIPHER_CTX_iv_length(ctx));
-        if (!EVP_CIPHER_CTX_encrypting(ctx))
-            ivptr = out + inl - EVP_CIPHER_CTX_iv_length(ctx);
+            memcpy(iv, ivptr, ivlen);
+            break;
 
-        memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), ivptr,
-               EVP_CIPHER_CTX_iv_length(ctx));
-    }
+        case EVP_CIPH_CTR_MODE:
+            nblocks = (inl + cipher_ctx->blocksize - 1)
+                      / cipher_ctx->blocksize;
+            do {
+                ivlen--;
+                nblocks += iv[ivlen];
+                iv[ivlen] = (uint8_t) nblocks;
+                nblocks >>= 8;
+            } while (ivlen);
+            break;
+
+        default: /* should not happen */
+            return 0;
+        }
 #endif
+
+    return 1;
+}
+
+static int ctr_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                         const unsigned char *in, size_t inl)
+{
+    struct cipher_ctx *cipher_ctx =
+        (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    size_t nblocks, len;
+
+    /* initial partial block */
+    while (cipher_ctx->num && inl) {
+        (*out++) = *(in++) ^ cipher_ctx->partial[cipher_ctx->num];
+        --inl;
+        cipher_ctx->num = (cipher_ctx->num + 1) % cipher_ctx->blocksize;
+    }
+
+    /* full blocks */
+    if (inl > (unsigned int) cipher_ctx->blocksize) {
+        nblocks = inl/cipher_ctx->blocksize;
+        len = nblocks * cipher_ctx->blocksize;
+        if (cipher_do_cipher(ctx, out, in, len) < 1)
+            return 0;
+        inl -= len;
+        out += len;
+        in += len;
+    }
+
+    /* final partial block */
+    if (inl) {
+        memset(cipher_ctx->partial, 0, cipher_ctx->blocksize);
+        if (cipher_do_cipher(ctx, cipher_ctx->partial, cipher_ctx->partial,
+            cipher_ctx->blocksize) < 1)
+            return 0;
+        while (inl--) {
+            out[cipher_ctx->num] = in[cipher_ctx->num]
+                                   ^ cipher_ctx->partial[cipher_ctx->num];
+            cipher_ctx->num++;
+        }
+    }
 
     return 1;
 }
@@ -249,6 +322,7 @@ static void prepare_cipher_methods(void)
 {
     size_t i;
     struct session_op sess;
+    unsigned long cipher_mode;
 
     memset(&sess, 0, sizeof(sess));
     sess.key = (void *)"01234567890123456789012345678901234567890123456789";
@@ -266,9 +340,12 @@ static void prepare_cipher_methods(void)
             || ioctl(cfd, CIOCFSESSION, &sess.ses) < 0)
             continue;
 
+        cipher_mode = cipher_data[i].flags & EVP_CIPH_MODE;
+
         if ((known_cipher_methods[i] =
                  EVP_CIPHER_meth_new(cipher_data[i].nid,
-                                     cipher_data[i].blocksize,
+                                     cipher_mode == EVP_CIPH_CTR_MODE ? 1 :
+                                                    cipher_data[i].blocksize,
                                      cipher_data[i].keylen)) == NULL
             || !EVP_CIPHER_meth_set_iv_length(known_cipher_methods[i],
                                               cipher_data[i].ivlen)
@@ -278,6 +355,8 @@ static void prepare_cipher_methods(void)
                                           | EVP_CIPH_FLAG_DEFAULT_ASN1)
             || !EVP_CIPHER_meth_set_init(known_cipher_methods[i], cipher_init)
             || !EVP_CIPHER_meth_set_do_cipher(known_cipher_methods[i],
+                                     cipher_mode == EVP_CIPH_CTR_MODE ?
+                                              ctr_do_cipher :
                                               cipher_do_cipher)
             || !EVP_CIPHER_meth_set_ctrl(known_cipher_methods[i], cipher_ctrl)
             || !EVP_CIPHER_meth_set_cleanup(known_cipher_methods[i],

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <assert.h>
 
+#include <openssl/conf.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/engine.h>
@@ -34,6 +35,30 @@
  * saner...  why re-open /dev/crypto for every session?
  */
 static int cfd;
+#define DEVCRYPTO_REQUIRE_ACCELERATED 0 /* require confirmation of acceleration */
+#define DEVCRYPTO_USE_SOFTWARE        1 /* allow software drivers */
+#define DEVCRYPTO_REJECT_SOFTWARE     2 /* only disallow confirmed software drivers */
+
+#define DEVCRYPTO_DEFAULT_USE_SOFDTRIVERS DEVCRYPTO_REJECT_SOFTWARE
+static int use_softdrivers = DEVCRYPTO_DEFAULT_USE_SOFDTRIVERS;
+
+/*
+ * cipher/digest status & acceleration definitions
+ * Make sure the defaults are set to 0
+ */
+struct driver_info_st {
+    enum devcrypto_status_t {
+        DEVCRYPTO_STATUS_UNUSABLE       = -1, /* session open failed */
+        DEVCRYPTO_STATUS_UNKNOWN        =  0, /* not tested yet */
+        DEVCRYPTO_STATUS_USABLE         =  1  /* algo can be used */
+    } status;
+
+    enum devcrypto_accelerated_t {
+        DEVCRYPTO_NOT_ACCELERATED       = -1, /* software implemented */
+        DEVCRYPTO_ACCELERATION_UNKNOWN  =  0, /* acceleration support unkown */
+        DEVCRYPTO_ACCELERATED           =  1  /* hardware accelerated */
+    } accelerated;
+};
 
 /******************************************************************************
  *
@@ -108,13 +133,22 @@ static const struct cipher_data_st {
 #endif
 };
 
-static size_t get_cipher_data_index(int nid)
+static size_t find_cipher_data_index(int nid)
 {
     size_t i;
 
     for (i = 0; i < OSSL_NELEM(cipher_data); i++)
         if (nid == cipher_data[i].nid)
             return i;
+    return (size_t)-1;
+}
+
+static size_t get_cipher_data_index(int nid)
+{
+    size_t i = find_cipher_data_index(nid);
+
+    if (i != (size_t)-1)
+        return i;
 
     /*
      * Code further down must make sure that only NIDs in the table above
@@ -310,19 +344,40 @@ static int cipher_cleanup(EVP_CIPHER_CTX *ctx)
 }
 
 /*
- * Keep a table of known nids and associated methods.
+ * Keep tables of known nids, associated methods, selected ciphers, and driver
+ * info.
  * Note that known_cipher_nids[] isn't necessarily indexed the same way as
- * cipher_data[] above, which known_cipher_methods[] is.
+ * cipher_data[] above, which the other tables are.
  */
 static int known_cipher_nids[OSSL_NELEM(cipher_data)];
 static int known_cipher_nids_amount = -1; /* -1 indicates not yet initialised */
 static EVP_CIPHER *known_cipher_methods[OSSL_NELEM(cipher_data)] = { NULL, };
+static int selected_ciphers[OSSL_NELEM(cipher_data)];
+static struct driver_info_st cipher_driver_info[OSSL_NELEM(cipher_data)];
+
+
+static int devcrypto_test_cipher(size_t cipher_data_index)
+{
+    return (cipher_driver_info[cipher_data_index].status == DEVCRYPTO_STATUS_USABLE
+            && selected_ciphers[cipher_data_index] == 1
+            && (cipher_driver_info[cipher_data_index].accelerated
+                    == DEVCRYPTO_ACCELERATED
+                || use_softdrivers == DEVCRYPTO_USE_SOFTWARE
+                || (cipher_driver_info[cipher_data_index].accelerated
+                        != DEVCRYPTO_NOT_ACCELERATED
+                    && use_softdrivers == DEVCRYPTO_REJECT_SOFTWARE)));
+}
 
 static void prepare_cipher_methods(void)
 {
     size_t i;
     struct session_op sess;
     unsigned long cipher_mode;
+#ifdef CIOCGSESSINFO
+    struct session_info_op siop;
+#endif
+
+    memset(&cipher_driver_info, 0, sizeof(cipher_driver_info));
 
     memset(&sess, 0, sizeof(sess));
     sess.key = (void *)"01234567890123456789012345678901234567890123456789";
@@ -330,15 +385,16 @@ static void prepare_cipher_methods(void)
     for (i = 0, known_cipher_nids_amount = 0;
          i < OSSL_NELEM(cipher_data); i++) {
 
+        selected_ciphers[i] = 1;
         /*
-         * Check that the algo is really availably by trying to open and close
-         * a session.
+         * Check that the cipher is usable
          */
         sess.cipher = cipher_data[i].devcryptoid;
         sess.keylen = cipher_data[i].keylen;
-        if (ioctl(cfd, CIOCGSESSION, &sess) < 0
-            || ioctl(cfd, CIOCFSESSION, &sess.ses) < 0)
+        if (ioctl(cfd, CIOCGSESSION, &sess) < 0) {
+            cipher_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
             continue;
+        }
 
         cipher_mode = cipher_data[i].flags & EVP_CIPH_MODE;
 
@@ -363,13 +419,39 @@ static void prepare_cipher_methods(void)
                                             cipher_cleanup)
             || !EVP_CIPHER_meth_set_impl_ctx_size(known_cipher_methods[i],
                                                   sizeof(struct cipher_ctx))) {
+            cipher_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
             EVP_CIPHER_meth_free(known_cipher_methods[i]);
             known_cipher_methods[i] = NULL;
         } else {
+            cipher_driver_info[i].status = DEVCRYPTO_STATUS_USABLE;
+#ifdef CIOCGSESSINFO
+            siop.ses = sess.ses;
+            if (ioctl(cfd, CIOCGSESSINFO, &siop) < 0)
+                cipher_driver_info[i].accelerated = DEVCRYPTO_ACCELERATION_UNKNOWN;
+            else if (!(siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY))
+                cipher_driver_info[i].accelerated = DEVCRYPTO_NOT_ACCELERATED;
+            else
+                cipher_driver_info[i].accelerated = DEVCRYPTO_ACCELERATED;
+#endif /* CIOCGSESSINFO */
+        }
+        ioctl(cfd, CIOCFSESSION, &sess.ses);
+        if (devcrypto_test_cipher(i)) {
             known_cipher_nids[known_cipher_nids_amount++] =
                 cipher_data[i].nid;
         }
     }
+}
+
+static void rebuild_known_cipher_nids(ENGINE *e)
+{
+    size_t i;
+
+    for (i = 0, known_cipher_nids_amount = 0; i < OSSL_NELEM(cipher_data); i++) {
+        if (devcrypto_test_cipher(i))
+            known_cipher_nids[known_cipher_nids_amount++] = cipher_data[i].nid;
+    }
+    ENGINE_unregister_ciphers(e);
+    ENGINE_register_ciphers(e);
 }
 
 static const EVP_CIPHER *get_cipher_method(int nid)
@@ -412,6 +494,36 @@ static int devcrypto_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
     *cipher = get_cipher_method(nid);
 
     return *cipher != NULL;
+}
+
+static void devcrypto_select_all_ciphers(int *cipher_list)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(cipher_data); i++)
+        cipher_list[i] = 1;
+}
+
+static int cryptodev_select_cipher_cb(const char *str, int len, void *usr)
+{
+    int *cipher_list = (int *)usr;
+    char *name;
+    const EVP_CIPHER *EVP;
+    size_t i;
+
+    if (len == 0)
+        return 1;
+    if (usr == NULL || (name = OPENSSL_strndup(str, len)) == NULL)
+        return 0;
+    EVP = EVP_get_cipherbyname(name);
+    if (EVP == NULL)
+        fprintf(stderr, "devcrypto: unknown cipher %s\n", name);
+    else if ((i = find_cipher_data_index(EVP_CIPHER_nid(EVP))) != (size_t)-1)
+        cipher_list[i] = 1;
+    else
+        fprintf(stderr, "devcrypto: cipher %s not available\n", name);
+    OPENSSL_free(name);
+    return 1;
 }
 
 /*
@@ -468,13 +580,22 @@ static const struct digest_data_st {
 #endif
 };
 
-static size_t get_digest_data_index(int nid)
+static size_t find_digest_data_index(int nid)
 {
     size_t i;
 
     for (i = 0; i < OSSL_NELEM(digest_data); i++)
         if (nid == digest_data[i].nid)
             return i;
+    return (size_t)-1;
+}
+
+static size_t get_digest_data_index(int nid)
+{
+    size_t i = find_digest_data_index(nid);
+
+    if (i != (size_t)-1)
+        return i;
 
     /*
      * Code further down must make sure that only NIDs in the table above
@@ -491,8 +612,8 @@ static const struct digest_data_st *get_digest_data(int nid)
 }
 
 /*
- * Following are the four necessary functions to map OpenSSL functionality
- * with cryptodev.
+ * Following are the five necessary functions to map OpenSSL functionality
+ * with cryptodev: init, update, final, cleanup, and copy.
  */
 
 static int digest_init(EVP_MD_CTX *ctx)
@@ -608,52 +729,94 @@ static int digest_cleanup(EVP_MD_CTX *ctx)
     return 1;
 }
 
-static int devcrypto_test_digest(size_t digest_data_index)
-{
-    struct session_op sess1, sess2;
-    struct cphash_op cphash;
-    int ret=0;
-
-    memset(&sess1, 0, sizeof(sess1));
-    memset(&sess2, 0, sizeof(sess2));
-    sess1.mac = digest_data[digest_data_index].devcryptoid;
-    if (ioctl(cfd, CIOCGSESSION, &sess1) < 0)
-        return 0;
-    /* Make sure the driver is capable of hash state copy */
-    sess2.mac = sess1.mac;
-    if (ioctl(cfd, CIOCGSESSION, &sess2) >= 0) {
-        cphash.src_ses = sess1.ses;
-        cphash.dst_ses = sess2.ses;
-        if (ioctl(cfd, CIOCCPHASH, &cphash) >= 0)
-            ret = 1;
-        ioctl(cfd, CIOCFSESSION, &sess2.ses);
-    }
-    ioctl(cfd, CIOCFSESSION, &sess1.ses);
-    return ret;
-}
-
 /*
- * Keep a table of known nids and associated methods.
+ * Keep tables of known nids, associated methods, selected digests, and
+ * driver info.
  * Note that known_digest_nids[] isn't necessarily indexed the same way as
- * digest_data[] above, which known_digest_methods[] is.
+ * digest_data[] above, which the other tables are.
  */
 static int known_digest_nids[OSSL_NELEM(digest_data)];
 static int known_digest_nids_amount = -1; /* -1 indicates not yet initialised */
 static EVP_MD *known_digest_methods[OSSL_NELEM(digest_data)] = { NULL, };
+static int selected_digests[OSSL_NELEM(digest_data)];
+static struct driver_info_st digest_driver_info[OSSL_NELEM(digest_data)];
+
+static int devcrypto_test_digest(size_t digest_data_index)
+{
+    return (digest_driver_info[digest_data_index].status == DEVCRYPTO_STATUS_USABLE
+            && selected_digests[digest_data_index] == 1
+            && (digest_driver_info[digest_data_index].accelerated
+                    == DEVCRYPTO_ACCELERATED
+                || use_softdrivers == DEVCRYPTO_USE_SOFTWARE
+                || (digest_driver_info[digest_data_index].accelerated
+                        != DEVCRYPTO_NOT_ACCELERATED
+                    && use_softdrivers == DEVCRYPTO_REJECT_SOFTWARE)));
+}
+
+static void rebuild_known_digest_nids(ENGINE *e)
+{
+    size_t i;
+
+    for (i = 0, known_digest_nids_amount = 0; i < OSSL_NELEM(digest_data); i++) {
+        if (devcrypto_test_digest(i))
+            known_digest_nids[known_digest_nids_amount++] = digest_data[i].nid;
+    }
+    ENGINE_unregister_digests(e);
+    ENGINE_register_digests(e);
+}
 
 static void prepare_digest_methods(void)
 {
     size_t i;
+    struct session_op sess1, sess2;
+#ifdef CIOCGSESSINFO
+    struct session_info_op siop;
+#endif
+    struct cphash_op cphash;
+
+    memset(&digest_driver_info, 0, sizeof(digest_driver_info));
+
+    memset(&sess1, 0, sizeof(sess1));
+    memset(&sess2, 0, sizeof(sess2));
 
     for (i = 0, known_digest_nids_amount = 0; i < OSSL_NELEM(digest_data);
          i++) {
 
-        /*
-         * Check that the algo is usable
-         */
-        if (!devcrypto_test_digest(i))
-            continue;
+        selected_digests[i] = 1;
 
+        /*
+         * Check that the digest is usable
+         */
+        sess1.mac = digest_data[i].devcryptoid;
+        sess2.ses = 0;
+        if (ioctl(cfd, CIOCGSESSION, &sess1) < 0) {
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            goto finish;
+        }
+
+#ifdef CIOCGSESSINFO
+        /* gather hardware acceleration info from the driver */
+        siop.ses = sess1.ses;
+        if (ioctl(cfd, CIOCGSESSINFO, &siop) < 0)
+            digest_driver_info[i].accelerated = DEVCRYPTO_ACCELERATION_UNKNOWN;
+        else if (siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY)
+            digest_driver_info[i].accelerated = DEVCRYPTO_ACCELERATED;
+        else
+            digest_driver_info[i].accelerated = DEVCRYPTO_NOT_ACCELERATED;
+#endif
+
+        /* digest must be capable of hash state copy */
+        sess2.mac = sess1.mac;
+        if (ioctl(cfd, CIOCGSESSION, &sess2) < 0) {
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            goto finish;
+        }
+        cphash.src_ses = sess1.ses;
+        cphash.dst_ses = sess2.ses;
+        if (ioctl(cfd, CIOCCPHASH, &cphash) < 0) {
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
+            goto finish;
+        }
         if ((known_digest_methods[i] = EVP_MD_meth_new(digest_data[i].nid,
                                                        NID_undef)) == NULL
             || !EVP_MD_meth_set_result_size(known_digest_methods[i],
@@ -665,11 +828,18 @@ static void prepare_digest_methods(void)
             || !EVP_MD_meth_set_cleanup(known_digest_methods[i], digest_cleanup)
             || !EVP_MD_meth_set_app_datasize(known_digest_methods[i],
                                              sizeof(struct digest_ctx))) {
+            digest_driver_info[i].status = DEVCRYPTO_STATUS_UNUSABLE;
             EVP_MD_meth_free(known_digest_methods[i]);
             known_digest_methods[i] = NULL;
-        } else {
-            known_digest_nids[known_digest_nids_amount++] = digest_data[i].nid;
+            goto finish;
         }
+        digest_driver_info[i].status = DEVCRYPTO_STATUS_USABLE;
+finish:
+        ioctl(cfd, CIOCFSESSION, &sess1.ses);
+        if (sess2.ses != 0)
+            ioctl(cfd, CIOCFSESSION, &sess2.ses);
+        if (devcrypto_test_digest(i))
+            known_digest_nids[known_digest_nids_amount++] = digest_data[i].nid;
     }
 }
 
@@ -715,7 +885,147 @@ static int devcrypto_digests(ENGINE *e, const EVP_MD **digest,
     return *digest != NULL;
 }
 
+static void devcrypto_select_all_digests(int *digest_list)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(digest_data); i++)
+        digest_list[i] = 1;
+}
+
+static int cryptodev_select_digest_cb(const char *str, int len, void *usr)
+{
+    int *digest_list = (int *)usr;
+    char *name;
+    const EVP_MD *EVP;
+    size_t i;
+
+    if (len == 0)
+        return 1;
+    if (usr == NULL || (name = OPENSSL_strndup(str, len)) == NULL)
+        return 0;
+    EVP = EVP_get_digestbyname(name);
+    if (EVP == NULL)
+        fprintf(stderr, "devcrypto: unknown digest %s\n", name);
+    else if ((i = find_digest_data_index(EVP_MD_type(EVP))) != (size_t)-1)
+        digest_list[i] = 1;
+    else
+        fprintf(stderr, "devcrypto: digest %s not available\n", name);
+    OPENSSL_free(name);
+    return 1;
+}
+
 #endif
+
+/******************************************************************************
+ *
+ * CONTROL COMMANDS
+ *
+ *****/
+
+#define DEVCRYPTO_CMD_USE_SOFTDRIVERS ENGINE_CMD_BASE
+#define DEVCRYPTO_CMD_CIPHERS (ENGINE_CMD_BASE + 1)
+#define DEVCRYPTO_CMD_DIGESTS (ENGINE_CMD_BASE + 2)
+#define DEVCRYPTO_CMD_DUMP_INFO (ENGINE_CMD_BASE + 3)
+
+static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
+#ifdef CIOCGSESSINFO
+   {DEVCRYPTO_CMD_USE_SOFTDRIVERS,
+    "USE_SOFTDRIVERS",
+    "specifies whether to use software (not accelerated) drivers ("
+        OPENSSL_MSTR(DEVCRYPTO_REQUIRE_ACCELERATED) "=use only accelerated drivers, "
+        OPENSSL_MSTR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
+        OPENSSL_MSTR(DEVCRYPTO_REJECT_SOFTWARE)
+        "=use if acceleration can't be determined) [default="
+        OPENSSL_MSTR(DEVCRYPTO_DEFAULT_USE_SOFDTRIVERS) "]",
+    ENGINE_CMD_FLAG_NUMERIC},
+#endif
+
+   {DEVCRYPTO_CMD_CIPHERS,
+    "CIPHERS",
+    "either ALL, NONE, or a comma-separated list of ciphers to enable [default=ALL]",
+    ENGINE_CMD_FLAG_STRING},
+
+#ifdef IMPLEMENT_DIGEST
+   {DEVCRYPTO_CMD_DIGESTS,
+    "DIGESTS",
+    "either ALL, NONE, or a comma-separated list of digests to enable [default=ALL]",
+    ENGINE_CMD_FLAG_STRING},
+#endif
+
+   {0, NULL, NULL, 0}
+};
+
+static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+{
+    int *new_list;
+    switch (cmd) {
+#ifdef CIOCGSESSINFO
+    case DEVCRYPTO_CMD_USE_SOFTDRIVERS:
+        switch (i) {
+        case DEVCRYPTO_REQUIRE_ACCELERATED:
+        case DEVCRYPTO_USE_SOFTWARE:
+        case DEVCRYPTO_REJECT_SOFTWARE:
+            break;
+        default:
+            fprintf(stderr, "devcrypto: invalid value (%ld) for USE_SOFTDRIVERS\n", i);
+            return 0;
+        }
+        if (use_softdrivers == i)
+            return 1;
+        use_softdrivers = i;
+#ifdef IMPLEMENT_DIGEST
+        rebuild_known_digest_nids(e);
+#endif
+        rebuild_known_cipher_nids(e);
+        return 1;
+#endif /* CIOCGSESSINFO */
+
+    case DEVCRYPTO_CMD_CIPHERS:
+        if (p == NULL)
+            return 1;
+        if (strcasecmp((const char *)p, "ALL") == 0) {
+            devcrypto_select_all_ciphers(selected_ciphers);
+        } else if (strcasecmp((const char*)p, "NONE") == 0) {
+            memset(selected_ciphers, 0, sizeof(selected_ciphers));
+        } else {
+            new_list=OPENSSL_zalloc(sizeof(selected_ciphers));
+            if (!CONF_parse_list(p, ',', 1, cryptodev_select_cipher_cb, new_list)) {
+                OPENSSL_free(new_list);
+                return 0;
+            }
+            memcpy(selected_ciphers, new_list, sizeof(selected_ciphers));
+            OPENSSL_free(new_list);
+        }
+        rebuild_known_cipher_nids(e);
+        return 1;
+
+#ifdef IMPLEMENT_DIGEST
+    case DEVCRYPTO_CMD_DIGESTS:
+        if (p == NULL)
+            return 1;
+        if (strcasecmp((const char *)p, "ALL") == 0) {
+            devcrypto_select_all_digests(selected_digests);
+        } else if (strcasecmp((const char*)p, "NONE") == 0) {
+            memset(selected_digests, 0, sizeof(selected_digests));
+        } else {
+            new_list=OPENSSL_zalloc(sizeof(selected_digests));
+            if (!CONF_parse_list(p, ',', 1, cryptodev_select_digest_cb, new_list)) {
+                OPENSSL_free(new_list);
+                return 0;
+            }
+            memcpy(selected_digests, new_list, sizeof(selected_digests));
+            OPENSSL_free(new_list);
+        }
+        rebuild_known_digest_nids(e);
+        return 1;
+#endif /* IMPLEMENT_DIGEST */
+
+    default:
+        break;
+    }
+    return 0;
+}
 
 /******************************************************************************
  *
@@ -766,6 +1076,8 @@ void engine_load_devcrypto_int()
 
     if (!ENGINE_set_id(e, "devcrypto")
         || !ENGINE_set_name(e, "/dev/crypto engine")
+        || !ENGINE_set_cmd_defns(e, devcrypto_cmds)
+        || !ENGINE_set_ctrl_function(e, devcrypto_ctrl)
 
 /*
  * Asymmetric ciphers aren't well supported with /dev/crypto.  Among the BSD

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -207,6 +207,22 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     return 1;
 }
 
+static int cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void* p2)
+{
+    EVP_CIPHER_CTX *to_ctx = (EVP_CIPHER_CTX *)p2;
+    struct cipher_ctx *cipher_ctx;
+
+    if (type == EVP_CTRL_COPY) {
+        /* when copying the context, a new session needs to be initialized */
+        cipher_ctx = (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+        return (cipher_ctx == NULL)
+            || cipher_init(to_ctx, cipher_ctx->sess.key, EVP_CIPHER_CTX_iv(ctx),
+                           (cipher_ctx->op == COP_ENCRYPT));
+    }
+
+    return -1;
+}
+
 static int cipher_cleanup(EVP_CIPHER_CTX *ctx)
 {
     struct cipher_ctx *cipher_ctx =
@@ -258,10 +274,12 @@ static void prepare_cipher_methods(void)
                                               cipher_data[i].ivlen)
             || !EVP_CIPHER_meth_set_flags(known_cipher_methods[i],
                                           cipher_data[i].flags
+                                          | EVP_CIPH_CUSTOM_COPY
                                           | EVP_CIPH_FLAG_DEFAULT_ASN1)
             || !EVP_CIPHER_meth_set_init(known_cipher_methods[i], cipher_init)
             || !EVP_CIPHER_meth_set_do_cipher(known_cipher_methods[i],
                                               cipher_do_cipher)
+            || !EVP_CIPHER_meth_set_ctrl(known_cipher_methods[i], cipher_ctrl)
             || !EVP_CIPHER_meth_set_cleanup(known_cipher_methods[i],
                                             cipher_cleanup)
             || !EVP_CIPHER_meth_set_impl_ctx_size(known_cipher_methods[i],

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -461,10 +461,6 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
         SYSerr(SYS_F_IOCTL, errno);
         return 0;
     }
-    if (ioctl(cfd, CIOCFSESSION, &digest_ctx->sess.ses) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
-        return 0;
-    }
 
     return 1;
 }
@@ -496,6 +492,15 @@ static int digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 
 static int digest_cleanup(EVP_MD_CTX *ctx)
 {
+    struct digest_ctx *digest_ctx =
+        (struct digest_ctx *)EVP_MD_CTX_md_data(ctx);
+
+    if (digest_ctx == NULL)
+        return 1;
+    if (ioctl(cfd, CIOCFSESSION, &digest_ctx->sess.ses) < 0) {
+        SYSerr(SYS_F_IOCTL, errno);
+        return 0;
+    }
     return 1;
 }
 

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -438,6 +438,9 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     if (count == 0)
         return 1;
 
+    if (digest_ctx == NULL)
+        return 0;
+
     if (digest_op(digest_ctx, data, count, NULL, COP_FLAG_UPDATE) < 0) {
         SYSerr(SYS_F_IOCTL, errno);
         return 0;
@@ -451,6 +454,8 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     struct digest_ctx *digest_ctx =
         (struct digest_ctx *)EVP_MD_CTX_md_data(ctx);
 
+    if (md == NULL || digest_ctx == NULL)
+        return 0;
     if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
         SYSerr(SYS_F_IOCTL, errno);
         return 0;


### PR DESCRIPTION
This adds some features to the engine:
- performing a `CIOCCPHASH` operation during initialization to decide if a digest is usable or not. The import/export functions used by digest_copy were available since linux 2.6.29, but it was not mandatory for drivers to implement them until linux 4.17.

- use `CIOCGSESSINFO` to query if an algorithm is accelerated or not, disabling those that are software-only.

- configuration options to select the list of ciphers digests to enable, and to control the use of unaccelerated drivers

- command to dump /dev/crypto driver information and capabilities to stderr

- use EVP_MD_CTX_FLAG_ONESHOT flag to save an ioctl call.

There were a couple of fixups as well:
- avoid leaking the EVP methods if the engine does not finish initialization

- closing the digest session in `digest_cleanup` instead of in `digest_final`

##### Checklist
- [x] documentation is added or updated - new options have their usage explained in their description.
