### PR TITLE
Add missing RAND initialisation call.

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -363,7 +363,8 @@ void rand_cleanup_int(void)
  */
 void RAND_keep_random_devices_open(int keep)
 {
-    rand_pool_keep_random_devices_open(keep);
+    if (RUN_ONCE(&rand_init, do_rand_init))
+        rand_pool_keep_random_devices_open(keep);
 }
 
 /*


### PR DESCRIPTION
As noted in #7429 there is a missing call to `do__rand_init` in `RAND_keep_random_devices_open`.
