### PR TITLE
Add a missing SSLfatal call

### DIFF
--- a/ssl/s3_msg.c
+++ b/ssl/s3_msg.c
@@ -26,12 +26,16 @@ int ssl3_do_change_cipher_spec(SSL *s)
         }
 
         s->session->cipher = s->s3->tmp.new_cipher;
-        if (!s->method->ssl3_enc->setup_key_block(s))
+        if (!s->method->ssl3_enc->setup_key_block(s)) {
+            /* SSLfatal() already called */
             return 0;
+        }
     }
 
-    if (!s->method->ssl3_enc->change_cipher_state(s, i))
+    if (!s->method->ssl3_enc->change_cipher_state(s, i)) {
+        /* SSLfatal() already called */
         return 0;
+    }
 
     return 1;
 }

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -131,8 +131,11 @@ int tls1_change_cipher_state(SSL *s, int which)
         }
         dd = s->enc_read_ctx;
         mac_ctx = ssl_replace_hash(&s->read_hash, NULL);
-        if (mac_ctx == NULL)
+        if (mac_ctx == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS1_CHANGE_CIPHER_STATE,
+                     ERR_R_INTERNAL_ERROR);
             goto err;
+        }
 #ifndef OPENSSL_NO_COMP
         COMP_CTX_free(s->expand);
         s->expand = NULL;


### PR DESCRIPTION
A missing SSLfatal call can result in an assertion failed error if the
condition gets triggered.

