### PR TITLE
Configurations/10-main.conf: interpret -D_WIN32_WINNT in VC-* targets.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -57,6 +57,22 @@ sub vc_win32_info {
     return $vc_win32_info;
 }
 
+sub vc_win32_ver {
+    state $ver;
+
+    return $ver if defined($ver);
+
+    $ver = "";
+    for (@{$useradd{CPPDEFINES}}) {
+        if (m/_WIN32_WINNT=(0x[0-9a-f]+)/i) {
+            my $v = oct($1);
+            $ver = sprintf(",%d.%d", $v >> 8, $v & 255);
+            last;
+        }
+    }
+    return $ver;
+}
+
 my $vc_wince_info = {};
 sub vc_wince_info {
     unless (%$vc_wince_info) {
@@ -1272,7 +1288,13 @@ my %targets = (
         bin_cflags       => add(picker(debug   => "/MDd",
                                        release => sub { $disabled{shared} ? "/MT" : () },
                                       )),
-        bin_lflags       => add("/subsystem:console /opt:ref"),
+        bin_lflags       => add(sub {
+            return "/subsystem:console".vc_win32_ver()." /opt:ref";
+        }),
+        shared_ldflag    => add(sub {
+            my $ver = vc_win32_ver();
+            return $ver ? "/subsystem:windows$ver" : ();
+        }),
         ex_libs          => add(sub {
             my @ex_libs = ();
             push @ex_libs, 'ws2_32.lib' unless $disabled{sock};

--- a/NOTES.WIN
+++ b/NOTES.WIN
@@ -53,6 +53,9 @@
    64-bit version is exercised through continuous integration of
    VC-WIN64A-masm target.
 
+ If you want to target non-default, older Windows version, just pass
+ additional -D_WIN32_WINNT=0xNml flag to ./Configure. For example pass
+ -D_WIN32_WINNT=0x501 to target XP.
 
  Installation directories
  ------------------------


### PR DESCRIPTION
Besides affecting Win32 API availability at systems headers level the
option translates even to LINK /SUBSYSTEM:{*},version. Fro example
-D_WIN32_WIN32=0x501 is translated to /SUBSYSTEM:[windows|console],5.1.
