### PR TITLE
Fix rpath-related Linux "test_shlibload" failure.

### DIFF
--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -18,6 +18,13 @@ BEGIN {
 use lib bldtop_dir('.');
 use configdata;
 
+# When libssl and libcrypto are compiled on Linux with "-rpath", but not
+# "--enable-new-dtags", the RPATH takes precedence over LD_LIBRARY_PATH,
+# and we end up running with the wrong libraries.  This is resolved by
+# using full paths to the shared objects.
+#
+my $top = bldtop_dir('.');
+
 plan skip_all => "Test only supported in a shared build" if disabled("shared");
 plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 
@@ -25,9 +32,9 @@ plan tests => 4;
 
 my $libcrypto_idx = $unified_info{rename}->{libcrypto} // "libcrypto";
 my $libssl_idx = $unified_info{rename}->{libssl} // "libssl";
-my $libcrypto =
+my $libcrypto = "$top/".
     $unified_info{sharednames}->{$libcrypto_idx}.$target{shared_extension_simple};
-my $libssl =
+my $libssl = "$top/".
     $unified_info{sharednames}->{$libssl_idx}.$target{shared_extension_simple};
 
 ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl])),

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -1,4 +1,21 @@
 #!/bin/sh
+{-
+    use lib '.';
+    use configdata;
+
+    our %libs = undef;
+    unless ($disabled{shared}) {
+        for (('libcrypto', 'libssl')) {
+            $libs{$_} =
+                $unified_info{sharednames}->{$_}
+                . ($target{shlib_variant} || "")
+                . ($target{shared_extension} || ".so");
+            $libs{$_} =~ s|\.\$\(SHLIB_VERSION_NUMBER\)
+                          |.$config{shlib_version_number}|x;
+        }
+    }
+    ""     # Make sure no left over string sneaks its way into the script
+-}
 
 # To test this OpenSSL version's applications against another version's
 # shared libraries, simply set
@@ -25,15 +42,8 @@ fi
 THERE="`echo $0 | sed -e 's|[^/]*$||' 2>/dev/null`.."
 [ -d "${THERE}" ] || exec "$@"	# should never happen...
 
-# Alternative to this is to parse ${THERE}/Makefile...
-LIBCRYPTOSO="${THERE}/libcrypto.so"
-if [ -f "$LIBCRYPTOSO" ]; then
-    while [ -h "$LIBCRYPTOSO" ]; do
-	LIBCRYPTOSO="${THERE}/`ls -l "$LIBCRYPTOSO" | sed -e 's|.*\-> ||'`"
-    done
-    SOSUFFIX=`echo ${LIBCRYPTOSO} | sed -e 's|.*\.so||' 2>/dev/null`
-    LIBSSLSO="${THERE}/libssl.so${SOSUFFIX}"
-fi
+LIBCRYPTOSO="${THERE}/{- $libs{libcrypto} -}"
+LIBSSLSO="${THERE}/{- $libs{libssl} -}"
 
 SYSNAME=`(uname -s) 2>/dev/null`;
 case "$SYSNAME" in
@@ -41,6 +51,7 @@ SunOS|IRIX*)
 	# SunOS and IRIX run-time linkers evaluate alternative
 	# variables depending on target ABI...
 	rld_var=LD_LIBRARY_PATH
+
 	case "`(/usr/bin/file "$LIBCRYPTOSO") 2>/dev/null`" in
 	*ELF\ 64*SPARC*|*ELF\ 64*AMD64*)
 		[ -n "$LD_LIBRARY_PATH_64" ] && rld_var=LD_LIBRARY_PATH_64


### PR DESCRIPTION
When libssl and libcrypto are compiled on Linux with "-rpath", but
not "--enable-new-dtags", the RPATH takes precedence over
LD_LIBRARY_PATH, and we end up running with the wrong libraries.
This is resolved by using full (or at least relative, rather than
just the filename to be found on LD_LIBRARY_PATH) paths to the
shared objects.