### PR TITLE
Added missing signature algorithm reflection functions

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -394,7 +394,8 @@ int ssl_print_groups(BIO *out, SSL *s, int noshared)
 int ssl_print_tmp_key(BIO *out, SSL *s)
 {
     EVP_PKEY *key;
-    if (!SSL_get_server_tmp_key(s, &key))
+
+    if (!SSL_get_peer_tmp_key(s, &key))
         return 1;
     BIO_puts(out, "Server Temp Key: ");
     switch (EVP_PKEY_id(key)) {

--- a/doc/man3/SSL_get_peer_signature_nid.pod
+++ b/doc/man3/SSL_get_peer_signature_nid.pod
@@ -2,8 +2,9 @@
 
 =head1 NAME
 
-SSL_get_peer_signature_nid, SSL_get_peer_signature_type_nid - get TLS
-message signing types
+SSL_get_peer_signature_nid, SSL_get_peer_signature_type_nid,
+SSL_get_signature_nid, SSL_get_signature_type_nid - get TLS message signing
+types
 
 =head1 SYNOPSIS
 
@@ -11,6 +12,8 @@ message signing types
 
  int SSL_get_peer_signature_nid(SSL *ssl, int *psig_nid);
  int SSL_get_peer_signature_type_nid(const SSL *ssl, int *psigtype_nid);
+ int SSL_get_signature_nid(SSL *ssl, int *psig_nid);
+ int SSL_get_signature_type_nid(const SSL *ssl, int *psigtype_nid);
 
 =head1 DESCRIPTION
 
@@ -24,12 +27,15 @@ where it is B<EVP_PKEY_RSA_PSS>. To differentiate between
 B<rsa_pss_rsae_*> and B<rsa_pss_pss_*> signatures, it's necessary to check
 the type of public key in the peer's certificate.
 
+SSL_get_signature_nid() and SSL_get_signature_type_nid() return the equivalent
+information for the local end of the connection.
+
 =head1 RETURN VALUES
 
 These functions return 1 for success and 0 for failure. There are several
 possible reasons for failure: the cipher suite has no signature (e.g. it
 uses RSA key exchange or is anonymous), the TLS version is below 1.2 or
-the functions were called before the peer signed a message.
+the functions were called too early, e.g. before the peer signed a message.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_get_peer_tmp_key.pod
+++ b/doc/man3/SSL_get_peer_tmp_key.pod
@@ -2,26 +2,36 @@
 
 =head1 NAME
 
-SSL_get_server_tmp_key - get information about the server's temporary key used
-during a handshake
+SSL_get_peer_tmp_key, SSL_get_server_tmp_key, SSL_get_tmp_key - get information
+about temporary keys used during a handshake
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
+ long SSL_get_peer_tmp_key(SSL *ssl, EVP_PKEY **key);
  long SSL_get_server_tmp_key(SSL *ssl, EVP_PKEY **key);
+ long SSL_get_tmp_key(SSL *ssl, EVP_PKEY **key);
 
 =head1 DESCRIPTION
 
-SSL_get_server_tmp_key() returns the temporary key provided by the server and
+SSL_get_peer_tmp_key() returns the temporary key provided by the peer and
 used during key exchange. For example, if ECDHE is in use, then this represents
-the server's public ECDHE key. On success a pointer to the key is stored in
+the peer's public ECDHE key. On success a pointer to the key is stored in
 B<*key>. It is the caller's responsibility to free this key after use using
-L<EVP_PKEY_free(3)>. This function may only be called by the client.
+L<EVP_PKEY_free(3)>.
+
+SSL_get_server_tmp_key() is a backwards compatibility alias for
+SSL_get_peer_tmp_key().
+Under that name it worked just on the client side of the connection, its
+behaviour on the server end is release-dependent.
+
+SSL_get_tmp_key() returns the equivalent information for the local
+end of the connection.
 
 =head1 RETURN VALUES
 
-SSL_get_server_tmp_key() returns 1 on success or 0 otherwise.
+All these functions return 1 on success and 0 otherwise.
 
 =head1 NOTES
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1441,11 +1441,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_get_max_proto_version(s) \
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
 
-/*
- * Backwards compatibility, original 1.1.0 names
- *
- * TODO: backport to 1.1.0, ensuring the new API works in both.
- */
+/* Backwards compatibility, original 1.1.0 names */
 # define SSL_CTRL_GET_SERVER_TMP_KEY \
          SSL_CTRL_GET_PEER_TMP_KEY
 # define SSL_get_server_tmp_key(s, pk) \

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1271,7 +1271,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_SET_VERIFY_CERT_STORE          106
 # define SSL_CTRL_SET_CHAIN_CERT_STORE           107
 # define SSL_CTRL_GET_PEER_SIGNATURE_NID         108
-# define SSL_CTRL_GET_SERVER_TMP_KEY             109
+# define SSL_CTRL_GET_PEER_TMP_KEY               109
 # define SSL_CTRL_GET_RAW_CIPHERLIST             110
 # define SSL_CTRL_GET_EC_POINT_FORMATS           111
 # define SSL_CTRL_GET_CHAIN_CERTS                115
@@ -1290,6 +1290,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_GET_TLSEXT_STATUS_REQ_CB_ARG   129
 # define SSL_CTRL_GET_MIN_PROTO_VERSION          130
 # define SSL_CTRL_GET_MAX_PROTO_VERSION          131
+# define SSL_CTRL_GET_SIGNATURE_NID              132
+# define SSL_CTRL_GET_TMP_KEY                    133
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3
@@ -1410,10 +1412,14 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
                      (char *)(clist))
 # define SSL_set1_client_certificate_types(s, clist, clistlen) \
         SSL_ctrl(s,SSL_CTRL_SET_CLIENT_CERT_TYPES,clistlen,(char *)(clist))
+# define SSL_get_signature_nid(s, pn) \
+        SSL_ctrl(s,SSL_CTRL_GET_SIGNATURE_NID,0,pn)
 # define SSL_get_peer_signature_nid(s, pn) \
         SSL_ctrl(s,SSL_CTRL_GET_PEER_SIGNATURE_NID,0,pn)
-# define SSL_get_server_tmp_key(s, pk) \
-        SSL_ctrl(s,SSL_CTRL_GET_SERVER_TMP_KEY,0,pk)
+# define SSL_get_peer_tmp_key(s, pk) \
+        SSL_ctrl(s,SSL_CTRL_GET_PEER_TMP_KEY,0,pk)
+# define SSL_get_tmp_key(s, pk) \
+        SSL_ctrl(s,SSL_CTRL_GET_TMP_KEY,0,pk)
 # define SSL_get0_raw_cipherlist(s, plst) \
         SSL_ctrl(s,SSL_CTRL_GET_RAW_CIPHERLIST,0,plst)
 # define SSL_get0_ec_point_formats(s, plst) \
@@ -1434,6 +1440,16 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_ctrl(s, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, NULL)
 # define SSL_get_max_proto_version(s) \
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
+
+/*
+ * Backwards compatibility, original 1.1.0 names
+ *
+ * TODO: backport to 1.1.0, ensuring the new API works in both.
+ */
+# define SSL_CTRL_GET_SERVER_TMP_KEY \
+         SSL_CTRL_GET_PEER_TMP_KEY
+# define SSL_get_server_tmp_key(s, pk) \
+         SSL_get_peer_tmp_key(s, pk)
 
 /*
  * The following symbol names are old and obsolete. They are kept

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -241,6 +241,7 @@ __owur int SSL_export_keying_material_early(SSL *s, unsigned char *out,
                                             size_t contextlen);
 
 int SSL_get_peer_signature_type_nid(const SSL *s, int *pnid);
+int SSL_get_signature_type_nid(const SSL *s, int *pnid);
 
 int SSL_get_sigalgs(SSL *s, int idx,
                     int *psign, int *phash, int *psignandhash,

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3681,9 +3681,15 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         *(int *)parg = s->s3->tmp.peer_sigalg->hash;
         return 1;
 
-    case SSL_CTRL_GET_SERVER_TMP_KEY:
+    case SSL_CTRL_GET_SIGNATURE_NID:
+        if (s->s3->tmp.sigalg == NULL)
+            return 0;
+        *(int *)parg = s->s3->tmp.sigalg->hash;
+        return 1;
+
+    case SSL_CTRL_GET_PEER_TMP_KEY:
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
-        if (s->server || s->session == NULL || s->s3->peer_tmp == NULL) {
+        if (s->session == NULL || s->s3->peer_tmp == NULL) {
             return 0;
         } else {
             EVP_PKEY_up_ref(s->s3->peer_tmp);
@@ -3693,6 +3699,20 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 #else
         return 0;
 #endif
+
+    case SSL_CTRL_GET_TMP_KEY:
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
+        if (s->session == NULL || s->s3->tmp.pkey == NULL) {
+            return 0;
+        } else {
+            EVP_PKEY_up_ref(s->s3->tmp.pkey);
+            *(EVP_PKEY **)parg = s->s3->tmp.pkey;
+            return 1;
+        }
+#else
+        return 0;
+#endif
+
 #ifndef OPENSSL_NO_EC
     case SSL_CTRL_GET_EC_POINT_FORMATS:
         {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1091,6 +1091,14 @@ int SSL_get_peer_signature_type_nid(const SSL *s, int *pnid)
     return 1;
 }
 
+int SSL_get_signature_type_nid(const SSL *s, int *pnid)
+{
+    if (s->s3->tmp.sigalg == NULL)
+        return 0;
+    *pnid = s->s3->tmp.sigalg->sig;
+    return 1;
+}
+
 /*
  * Set a mask of disabled algorithms: an algorithm is disabled if it isn't
  * supported, doesn't appear in supported signature algorithms, isn't supported

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1673,7 +1673,7 @@ static HANDSHAKE_RESULT *do_handshake_internal(
             *serv_sess_out = SSL_SESSION_dup(tmp);
     }
 
-    if (SSL_get_server_tmp_key(client.ssl, &tmp_key)) {
+    if (SSL_get_peer_tmp_key(client.ssl, &tmp_key)) {
         ret->tmp_key_type = pkey_type(tmp_key);
         EVP_PKEY_free(tmp_key);
     }

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -779,7 +779,7 @@ static void print_details(SSL *c_ssl, const char *prefix)
         }
         X509_free(cert);
     }
-    if (SSL_get_server_tmp_key(c_ssl, &pkey)) {
+    if (SSL_get_peer_tmp_key(c_ssl, &pkey)) {
         BIO_puts(bio_stdout, ", temp key: ");
         print_key_details(bio_stdout, pkey);
         EVP_PKEY_free(pkey);

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -497,3 +497,4 @@ SSL_get_recv_max_early_data             497	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get_recv_max_early_data         498	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_recv_max_early_data         499	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_post_handshake_auth         500	1_1_1	EXIST::FUNCTION:
+SSL_get_signature_type_nid              501	1_1_1a	EXIST::FUNCTION:

--- a/util/private.num
+++ b/util/private.num
@@ -394,14 +394,17 @@ SSL_get_max_proto_version               define
 SSL_get_min_proto_version               define
 SSL_get_mode                            define
 SSL_get_peer_signature_nid              define
+SSL_get_peer_tmp_key                    define
 SSL_get_secure_renegotiation_support    define
 SSL_get_server_tmp_key                  define
 SSL_get_shared_curve                    define
 SSL_get_shared_group                    define
+SSL_get_signature_nid                   define
 SSL_get_time                            define
 SSL_get_timeout                         define
 SSL_get_tlsext_status_ocsp_resp         define
 SSL_get_tlsext_status_type              define
+SSL_get_tmp_key                         define
 SSL_in_accept_init                      define
 SSL_in_connect_init                     define
 SSL_library_init                        define


### PR DESCRIPTION
    SSL_get_signature_nid()      -- local signature algorithm
    SSL_get_signature_type_nid() -- local signature algorithm key type
    SSL_get_peer_tmp_key()       -- Peer key-exchange public key
    SSL_get_tmp_key              -- local key exchange public key

Aliased pre-existing `SSL_get_server_tmp_key()`, which was formerly
just for clients, to `SSL_get_peer_tmp_key()`.  Changed internal
calls to use the new name.

This should resolve #7605

##### Checklist
- [ x] documentation is added or updated

