### PR TITLE
Honour mandatory digest on private key in tls1_process_sigalgs() (1.0.2 backport of PR#7408) 

### DIFF
--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -601,7 +601,7 @@ static int ec_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
         *(int *)arg2 = NID_sha256;
-        return 2;
+        return 1;
 
     default:
         return -2;


### PR DESCRIPTION
Stop TLS from using digests that the `EVP_PKEY` *tells* us it doesn't support.
And stop the EC keys from lying about what they support, while we're at it.
Fixes #7348