### PR TITLE
Fix rpath-related Linux "test_shlibload" failure.

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -102,6 +102,8 @@ my %targets=(
                                      ? "ranlib" : "" },
         RC              => "windres",
 
+        shared_extension => ".so",
+
         build_scheme    => [ "unified", "unix" ],
         build_file      => "Makefile",
     },
@@ -142,6 +144,8 @@ my %targets=(
         mtinflag        => "-manifest ",
         mtoutflag       => "-outputresource:",
 
+        shared_extension => ".dll",
+
         build_file      => "makefile",
         build_scheme    => [ "unified", "windows" ],
     },
@@ -159,6 +163,8 @@ my %targets=(
                         if !$disabled{zlib} && !$withargs{zlib_include};
                     return [ @incs ];
                 }),
+
+        shared_extension => ".exe",
 
         build_file       => "descrip.mms",
         build_scheme     => [ "unified", "VMS" ],

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -6,8 +6,7 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-
-use OpenSSL::Test qw/:DEFAULT bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT bldtop_dir bldtop_file/;
 use OpenSSL::Test::Utils;
 
 #Load configdata.pm
@@ -23,12 +22,13 @@ plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 
 plan tests => 4;
 
-my $libcrypto_idx = $unified_info{rename}->{libcrypto} // "libcrypto";
-my $libssl_idx = $unified_info{rename}->{libssl} // "libssl";
-my $libcrypto =
-    $unified_info{sharednames}->{$libcrypto_idx}.$target{shared_extension_simple};
-my $libssl =
-    $unified_info{sharednames}->{$libssl_idx}.$target{shared_extension_simple};
+# When libssl and libcrypto are compiled on Linux with "-rpath", but not
+# "--enable-new-dtags", the RPATH takes precedence over LD_LIBRARY_PATH,
+# and we end up running with the wrong libraries.  This is resolved by
+# using paths to the shared objects, not just the names.
+
+my $libcrypto = bldtop_file(shlib('libcrypto'));
+my $libssl = bldtop_file(shlib('libssl'));
 
 ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl])),
    "running shlibloadtest -crypto_first");
@@ -39,3 +39,14 @@ ok(run(test(["shlibloadtest", "-just_crypto", $libcrypto, $libssl])),
 ok(run(test(["shlibloadtest", "-dso_ref", $libcrypto, $libssl])),
    "running shlibloadtest -dso_ref");
 
+sub shlib {
+    my $lib = shift;
+    $lib = $unified_info{rename}->{$lib}
+        if defined $unified_info{rename}->{$lib};
+    $lib = $unified_info{sharednames}->{$lib}
+        . ($target{shlib_variant} || "")
+        . ($target{shared_extension} || ".so");
+    $lib =~ s|\.\$\(SHLIB_VERSION_NUMBER\)
+             |.$config{shlib_version_number}|x;
+    return $lib;
+}

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -1,5 +1,22 @@
 #!/bin/sh
+{-
+    use lib '.';
+    use configdata;
 
+    sub shlib {
+        my $lib = shift;
+        return "" if $disabled{shared};
+        $lib = $unified_info{rename}->{$lib}
+            if defined $unified_info{rename}->{$lib};
+        $lib = $unified_info{sharednames}->{$lib}
+            . ($target{shlib_variant} || "")
+            . ($target{shared_extension} || ".so");
+        $lib =~ s|\.\$\(SHLIB_VERSION_NUMBER\)
+                 |.$config{shlib_version_number}|x;
+        return $lib;
+    }
+    "";     # Make sure no left over string sneaks its way into the script
+-}
 # To test this OpenSSL version's applications against another version's
 # shared libraries, simply set
 #
@@ -25,15 +42,8 @@ fi
 THERE="`echo $0 | sed -e 's|[^/]*$||' 2>/dev/null`.."
 [ -d "${THERE}" ] || exec "$@"	# should never happen...
 
-# Alternative to this is to parse ${THERE}/Makefile...
-LIBCRYPTOSO="${THERE}/libcrypto.so"
-if [ -f "$LIBCRYPTOSO" ]; then
-    while [ -h "$LIBCRYPTOSO" ]; do
-	LIBCRYPTOSO="${THERE}/`ls -l "$LIBCRYPTOSO" | sed -e 's|.*\-> ||'`"
-    done
-    SOSUFFIX=`echo ${LIBCRYPTOSO} | sed -e 's|.*\.so||' 2>/dev/null`
-    LIBSSLSO="${THERE}/libssl.so${SOSUFFIX}"
-fi
+LIBCRYPTOSO="${THERE}/{- shlib('libcrypto') -}"
+LIBSSLSO="${THERE}/{- shlib('libssl') -}"
 
 SYSNAME=`(uname -s) 2>/dev/null`;
 case "$SYSNAME" in


### PR DESCRIPTION
When libssl and libcrypto are compiled on Linux with "-rpath", but
not "--enable-new-dtags", the RPATH takes precedence over
LD_LIBRARY_PATH, and we end up running with the wrong libraries.
This is resolved by using full (or at least relative, rather than
just the filename to be found on LD_LIBRARY_PATH) paths to the
shared objects.

-----

Alternative to #7596, on request