### PR TITLE
limit getauxval weak reference to linux

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -66,7 +66,7 @@ void OPENSSL_cpuid_setup(void) __attribute__ ((constructor));
  * Use a weak reference to getauxval() so we can use it if it is available but
  * don't break the build if it is not.
  */
-# if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__)
+# if defined(__linux__)
 extern unsigned long getauxval(unsigned long type) __attribute__ ((weak));
 # else
 static unsigned long (*getauxval) (unsigned long) = NULL;

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -174,7 +174,7 @@ void OPENSSL_madd300_probe(void);
  * feature detection, not *run-time*. In other words if we link with
  * symbol present, it's expected to be present even at run-time.
  */
-#if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__)
+#if defined(__linux__)
 extern unsigned long getauxval(unsigned long type) __attribute__ ((weak));
 #else
 static unsigned long (*getauxval) (unsigned long) = NULL;


### PR DESCRIPTION
__GNUC__ applies to almost everyone: it implies a GNU-like compiler
(GCC and clang define this).

getauxval is apparently a thing in several linux libcs.
It would've been better to test for the existence of the function, but
we seem to have weak configure abilities.

The issue will remain for uClibc, which doesn't provide the function
either.

Creating a widely visible getauxval symbol is confusing packages
using this library, for example:
http://mail-index.netbsd.org/netbsd-users/2018/06/thread1.html#020956