### PR TITLE
Use issetugid on netbsd too.

### DIFF
--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -10,7 +10,7 @@
 #include <openssl/crypto.h>
 #include <openssl/opensslconf.h>
 
-#if defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__)
+#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 # include OPENSSL_UNISTD
 


### PR DESCRIPTION
Don't bother handling FreeBSD<=2, that's a release from 1994.