### PR TITLE
Fix rpath-related Linux "test_shlibload" failure. [1.1.0]

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -68,6 +68,8 @@
                 }
                 return (); },
 
+        shared_extension => ".so",
+
         build_scheme    => [ "unified", "unix" ],
         build_file      => "Makefile",
     },
@@ -99,6 +101,8 @@
         mtinflag        => "-manifest ",
         mtoutflag       => "-outputresource:",
 
+        shared_extension => ".dll",
+
         build_file      => "makefile",
         build_scheme    => [ "unified", "windows" ],
     },
@@ -106,6 +110,8 @@
     BASE_VMS => {
         inherit_from    => [ "BASE_common" ],
         template        => 1,
+
+        shared_extension => ".exe",
 
         build_file       => "descrip.mms",
         build_scheme     => [ "unified", "VMS" ],

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -1,5 +1,22 @@
 #!/bin/sh
+{-
+    use lib '.';
+    use configdata;
 
+    sub shlib {
+        my $lib = shift;
+        return "" if $disabled{shared};
+        $lib = $unified_info{rename}->{$lib}
+            if defined $unified_info{rename}->{$lib};
+        $lib = $unified_info{sharednames}->{$lib}
+            . ($target{shlib_variant} || "")
+            . ($target{shared_extension} || ".so");
+        $lib =~ s|\.\$\(SHLIB_MAJOR\)\.\$\(SHLIB_MINOR\)
+                 |.$config{shlib_version_number}|x;
+        return $lib;
+    }
+    "";     # Make sure no left over string sneaks its way into the script
+-}
 # To test this OpenSSL version's applications against another version's
 # shared libraries, simply set
 #
@@ -25,15 +42,8 @@ fi
 THERE="`echo $0 | sed -e 's|[^/]*$||' 2>/dev/null`.."
 [ -d "${THERE}" ] || exec "$@"	# should never happen...
 
-# Alternative to this is to parse ${THERE}/Makefile...
-LIBCRYPTOSO="${THERE}/libcrypto.so"
-if [ -f "$LIBCRYPTOSO" ]; then
-    while [ -h "$LIBCRYPTOSO" ]; do
-	LIBCRYPTOSO="${THERE}/`ls -l "$LIBCRYPTOSO" | sed -e 's|.*\-> ||'`"
-    done
-    SOSUFFIX=`echo ${LIBCRYPTOSO} | sed -e 's|.*\.so||' 2>/dev/null`
-    LIBSSLSO="${THERE}/libssl.so${SOSUFFIX}"
-fi
+LIBCRYPTOSO="${THERE}/{- shlib('libcrypto') -}"
+LIBSSLSO="${THERE}/{- shlib('libssl') -}"
 
 SYSNAME=`(uname -s) 2>/dev/null`;
 case "$SYSNAME" in


### PR DESCRIPTION
When libssl and libcrypto are compiled on Linux with "-rpath", but
not "--enable-new-dtags", the RPATH takes precedence over
LD_LIBRARY_PATH, and we end up running with the wrong libraries.
This is resolved by using full (or at least relative, rather than
just the filename to be found on LD_LIBRARY_PATH) paths to the
shared objects.

-----

This is a backport of #7626