### PR TITLE
Remove markdown links from HTML comments in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,8 +2,8 @@
 NOTE:
 
     If you're asking about how to use OpenSSL, this isn't the right 
-    forum.  Please see our
-    [User Support resources](https://github.com/openssl/openssl/blob/master/.github/SUPPORT.md)
+    forum.  Please see our User Support resources:
+    https://github.com/openssl/openssl/blob/master/.github/SUPPORT.md
 
 If relevant, please remember to tell us in what OpenSSL version you
 found the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,8 @@ Thank you for your bug report.
 NOTE:
 
     If you're asking about how to use OpenSSL, this isn't the right 
-    forum.  Please see our
-    [User Support resources](https://github.com/openssl/openssl/blob/master/.github/SUPPORT.md)
+    forum.  Please see our User Support resources:
+    https://github.com/openssl/openssl/blob/master/.github/SUPPORT.md
 
 Please remember to tell us in what OpenSSL version you found the issue.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,8 +10,8 @@ Thank you for your feature request.
 NOTE:
 
     If you're asking about how to use OpenSSL, this isn't the right 
-    forum.  Please see our
-    [User Support resources](https://github.com/openssl/openssl/blob/master/.github/SUPPORT.md)
+    forum.  Please see our User Support resources:
+    https://github.com/openssl/openssl/blob/master/.github/SUPPORT.md
 
 Please remember to put ``` lines before and after any commands plus
 output and code, like this:


### PR DESCRIPTION
HTML comments aren't rendered, so markdown link syntax is irrelevant
inside them, and more confusing than useful.

-----

Followup on #7623