### PR TITLE
Set eol=lf for configuration scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 *.der binary
 /fuzz/corpora/** binary
 *.pfx binary
+/config eol=lf
+/Configure eol=lf
+/Configurations/* eol=lf


### PR DESCRIPTION
If rsync is used for copying the sources from Windows to Linux, the scripts fail if they have crlf line endings, which is the default behavior on Windows.