### PR TITLE
Configuration: only include shared_sources in dirinfo in shared config

### DIFF
--- a/Configure
+++ b/Configure
@@ -2249,6 +2249,9 @@ EOF
                                            dst => 'sources' } }
                } -> {$prodtype};
             foreach my $kind (keys %$intent) {
+                next if ($intent->{$kind}->{dst} eq 'shared_sources'
+                             && $disabled{shared});
+
                 my @src = @{$intent->{$kind}->{src}};
                 my $dst = $intent->{$kind}->{dst};
                 my $prodselect = $intent->{$kind}->{prodselect} // sub { @_ };


### PR DESCRIPTION
Without this precaution, we end up having directory targets depend on
shlib object files for which there are no rules.
