### PR TITLE
Configuration: only include shared_sources in dirinfo in shared config [1.1.1]

### DIFF
--- a/Configure
+++ b/Configure
@@ -2179,6 +2179,16 @@ EOF
 
     # Massage the result
 
+    # If the user configured no-shared, we allow no shared sources
+    if ($disabled{shared}) {
+        foreach (keys %{$unified_info{shared_sources}}) {
+            foreach (keys %{$unified_info{shared_sources}->{$_}}) {
+                delete $unified_info{sources}->{$_};
+            }
+        }
+        $unified_info{shared_sources} = {};
+    }
+
     # If we depend on a header file or a perl module, add an inclusion of
     # its directory to allow smoothe inclusion
     foreach my $dest (keys %{$unified_info{depends}}) {


### PR DESCRIPTION
Without this precaution, we end up having directory targets depend on
shlib object files for which there are no rules.
