### PR TITLE
Add options to avoid atexit, and to avoid pinning the libraries in memory

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -651,7 +651,7 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
-        shared_ldflag    => "-Wl,-znodelete",
+        shared_ldflag    => sub { $disabled{pinshared} ? () : "-Wl,-znodelete" },
         shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
         enable           => [ "afalgeng" ],
     },

--- a/Configure
+++ b/Configure
@@ -374,6 +374,7 @@ my @disablables = (
     "msan",
     "multiblock",
     "nextprotoneg",
+    "pinshared",
     "ocb",
     "ocsp",
     "pic",

--- a/INSTALL
+++ b/INSTALL
@@ -411,6 +411,23 @@
   no-pic
                    Don't build with support for Position Independent Code.
 
+  no-pinshared     By default OpenSSL will attempt to stay in memory until the
+                   process exits. This is so that libcrypto and libssl can be
+                   properly cleaned up automatically via an "atexit()" handler.
+                   The handler is registered by libcrypto and cleans up both
+                   libraries. On some platforms the atexit() handler will run on
+                   unload of libcrypto (if it has been dynamically loaded)
+                   rather than at process exit. This option can be used to stop
+                   OpenSSL from attempting to stay in memory until the process
+                   exits. This could lead to crashes if either libcrypto or
+                   libssl have already been unloaded at the point
+                   that the atexit handler is invoked, e.g. on a platform which
+                   calls atexit() on unload of the library, and libssl is
+                   unloaded before libcrypto then a crash is likely to happen.
+                   Applications can suppress running of the atexit() handler at
+                   run time by using the OPENSSL_INIT_NO_ATEXIT option to
+                   OPENSSL_init_crypto(). See the man page for further details.
+
   no-posix-io
                    Don't use POSIX IO capabilities.
 

--- a/INSTALL
+++ b/INSTALL
@@ -426,7 +426,8 @@
                    unloaded before libcrypto then a crash is likely to happen.
                    Applications can suppress running of the atexit() handler at
                    run time by using the OPENSSL_INIT_NO_ATEXIT option to
-                   OPENSSL_init_crypto(). See the man page for further details.
+                   OPENSSL_init_crypto(). See the man page for it for further
+                   details.
 
   no-posix-io
                    Don't use POSIX IO capabilities.

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -147,7 +147,9 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: ossl_init_load_crypto_nodelete()\n");
 #endif
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if !defined(OPENSSL_NO_DSO) \
+    && !defined(OPENSSL_USE_NODELETE) \
+    && !defined(OPENSSL_NO_PINSHARED)
 # ifdef DSO_WIN32
     {
         HMODULE handle = NULL;
@@ -767,7 +769,9 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if !defined(OPENSSL_NO_DSO) \
+    && !defined(OPENSSL_USE_NODELETE)\
+    && !defined(OPENSSL_NO_PINSHARED)
     {
         union {
             void *sym;

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -177,12 +177,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
 
 static CRYPTO_ONCE load_crypto_strings = CRYPTO_ONCE_STATIC_INIT;
 static int load_crypto_strings_inited = 0;
-DEFINE_RUN_ONCE_STATIC(ossl_init_no_load_crypto_strings)
-{
-    /* Do nothing in this case */
-    return 1;
-}
-
 DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_strings)
 {
     int ret = 1;
@@ -201,6 +195,13 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_strings)
     return ret;
 }
 
+DEFINE_RUN_ONCE_STATIC_ALT(ossl_init_no_load_crypto_strings,
+                           ossl_init_load_crypto_strings)
+{
+    /* Do nothing in this case */
+    return 1;
+}
+
 static CRYPTO_ONCE add_all_ciphers = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(ossl_init_add_all_ciphers)
 {
@@ -215,6 +216,13 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_add_all_ciphers)
 # endif
     openssl_add_all_ciphers_int();
 #endif
+    return 1;
+}
+
+DEFINE_RUN_ONCE_STATIC_ALT(ossl_init_no_add_all_ciphers,
+                           ossl_init_add_all_ciphers)
+{
+    /* Do nothing */
     return 1;
 }
 
@@ -235,6 +243,13 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_add_all_digests)
     return 1;
 }
 
+DEFINE_RUN_ONCE_STATIC_ALT(ossl_init_no_add_all_digests,
+                           ossl_init_add_all_digests)
+{
+    /* Do nothing */
+    return 1;
+}
+
 static CRYPTO_ONCE add_all_macs = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(ossl_init_add_all_macs)
 {
@@ -252,7 +267,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_add_all_macs)
     return 1;
 }
 
-DEFINE_RUN_ONCE_STATIC(ossl_init_no_add_algs)
+DEFINE_RUN_ONCE_STATIC_ALT(ossl_init_no_add_all_macs, ossl_init_add_all_macs)
 {
     /* Do nothing */
     return 1;
@@ -272,7 +287,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_config)
     config_inited = 1;
     return 1;
 }
-DEFINE_RUN_ONCE_STATIC(ossl_init_no_config)
+DEFINE_RUN_ONCE_STATIC_ALT(ossl_init_no_config, ossl_init_config)
 {
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr,
@@ -612,8 +627,9 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_LOAD_CRYPTO_STRINGS)
-            && !RUN_ONCE(&load_crypto_strings,
-                         ossl_init_no_load_crypto_strings))
+            && !RUN_ONCE_ALT(&load_crypto_strings,
+                             ossl_init_no_load_crypto_strings,
+                             ossl_init_load_crypto_strings))
         return 0;
 
     if ((opts & OPENSSL_INIT_LOAD_CRYPTO_STRINGS)
@@ -621,7 +637,8 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_ADD_ALL_CIPHERS)
-            && !RUN_ONCE(&add_all_ciphers, ossl_init_no_add_algs))
+            && !RUN_ONCE_ALT(&add_all_ciphers, ossl_init_no_add_all_ciphers,
+                             ossl_init_add_all_ciphers))
         return 0;
 
     if ((opts & OPENSSL_INIT_ADD_ALL_CIPHERS)
@@ -629,7 +646,8 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_ADD_ALL_DIGESTS)
-            && !RUN_ONCE(&add_all_digests, ossl_init_no_add_algs))
+            && !RUN_ONCE_ALT(&add_all_digests, ossl_init_no_add_all_digests,
+                             ossl_init_add_all_digests))
         return 0;
 
     if ((opts & OPENSSL_INIT_ADD_ALL_DIGESTS)
@@ -637,7 +655,8 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_ADD_ALL_MACS)
-            && !RUN_ONCE(&add_all_macs, ossl_init_no_add_algs))
+            && !RUN_ONCE_ALT(&add_all_macs, ossl_init_no_add_all_macs,
+                             ossl_init_add_all_macs))
         return 0;
 
     if ((opts & OPENSSL_INIT_ADD_ALL_MACS)
@@ -649,7 +668,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_LOAD_CONFIG)
-            && !RUN_ONCE(&config, ossl_init_no_config))
+            && !RUN_ONCE_ALT(&config, ossl_init_no_config, ossl_init_config))
         return 0;
 
     if (opts & OPENSSL_INIT_LOAD_CONFIG) {

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -33,7 +33,7 @@ As of version 1.1.0 OpenSSL will automatically allocate all resources that it
 needs so no explicit initialisation is required. Similarly it will also
 automatically deinitialise as required.
 
-However, there way be situations when explicit initialisation is desirable or
+However, there may be situations when explicit initialisation is desirable or
 needed, for example when some non-default initialisation is required. The
 function OPENSSL_init_crypto() can be used for this purpose for
 libcrypto (see also L<OPENSSL_init_ssl(3)> for the libssl
@@ -156,6 +156,13 @@ engines. This not a default option.
 
 With this option the library will register its fork handlers.
 See OPENSSL_fork_prepare(3) for details.
+
+=item OPENSSL_INIT_NOATEXIT
+
+By default OpenSSL will attempt to clean itself up when the process exits via an
+"atexit" handler. Using this option suppresses that behaviour. This means that
+the application will have to clean up OpenSSL explicitly using
+OPENSSL_cleanup().
 
 =back
 

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -157,7 +157,7 @@ engines. This not a default option.
 With this option the library will register its fork handlers.
 See OPENSSL_fork_prepare(3) for details.
 
-=item OPENSSL_INIT_NOATEXIT
+=item OPENSSL_INIT_NO_ATEXIT
 
 By default OpenSSL will attempt to clean itself up when the process exits via an
 "atexit" handler. Using this option suppresses that behaviour. This means that

--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -9,6 +9,20 @@
 
 #include <openssl/crypto.h>
 
+/*
+ * DEFINE_RUN_ONCE: Define an initialiser function that should be run exactly
+ * once. It takes no arguments and returns and int result (1 for success or
+ * 0 for failure). Typical usage might be:
+ * 
+ * DEFINE_RUN_ONCE(myinitfunc)
+ * {
+ *     do_some_initialisation();
+ *     if (init_is_successful())
+ *         return 1;
+ *
+ *     return 0;
+ * }
+ */
 #define DEFINE_RUN_ONCE(init)                   \
     static int init(void);                     \
     int init##_ossl_ret_ = 0;                   \
@@ -17,10 +31,30 @@
         init##_ossl_ret_ = init();              \
     }                                           \
     static int init(void)
+
+/*
+ * DECLARE_RUN_ONCE: Declare an initialiser function that should be run exactly
+ * once that has been defined in another file via DEFINE_RUN_ONCE().
+ */
 #define DECLARE_RUN_ONCE(init)                  \
     extern int init##_ossl_ret_;                \
     void init##_ossl_(void);
 
+/*
+ * DEFINE_RUN_ONCE_STATIC: Define an initialiser function that should be run
+ * exactly once. This function will be declared as static within the file. It
+ * takes no arguments and returns and int result (1 for success or 0 for
+ * failure). Typical usage might be:
+ * 
+ * DEFINE_RUN_ONCE_STATIC(myinitfunc)
+ * {
+ *     do_some_initialisation();
+ *     if (init_is_successful())
+ *         return 1;
+ *
+ *     return 0;
+ * }
+ */
 #define DEFINE_RUN_ONCE_STATIC(init)            \
     static int init(void);                     \
     static int init##_ossl_ret_ = 0;            \
@@ -30,6 +64,38 @@
     }                                           \
     static int init(void)
 
+/*
+ * DEFINE_RUN_ONCE_STATIC_ALT: Define an alternative initialiser function. This
+ * function will be declared as static within the file. It takes no arguments
+ * and returns and int result (1 for success or 0 for failure). An alternative
+ * initialiser function is expected to be associated with a primary initialiser
+ * function defined via DEFINE_ONCE_STATIC where both functions use the same
+ * CRYPTO_ONCE object to synchronise. Where an alternative initialiser function
+ * is used only one of the primary or the alternative initialiser function will
+ * ever be called - and that function will be called excatly once. Definitition
+ * of an alternative initialiser function MUST occur AFTER the definition of the
+ * primiary initialiser function. 
+ * 
+ * Typical usage might be:
+ * 
+ * DEFINE_RUN_ONCE_STATIC(myinitfunc)
+ * {
+ *     do_some_initialisation();
+ *     if (init_is_successful())
+ *         return 1;
+ *
+ *     return 0;
+ * }
+ * 
+ * DEFINE_RUN_ONCE_STATIC_ALT(myaltinitfunc)
+ * {
+ *     do_some_alternative_initialisation();
+ *     if (init_is_successful())
+ *         return 1;
+ *
+ *     return 0;
+ * }
+ */
 #define DEFINE_RUN_ONCE_STATIC_ALT(initalt, init) \
     static int initalt(void);                     \
     static void initalt##_ossl_(void)             \
@@ -52,5 +118,20 @@
 #define RUN_ONCE(once, init)                                            \
     (CRYPTO_THREAD_run_once(once, init##_ossl_) ? init##_ossl_ret_ : 0)
 
+/*
+ * RUN_ONCE_ALT - use CRYPTO_THREAD_run_once, to run an alternative initialiser
+ *                function and check if that initialisation succeeded
+ * @once:    pointer to static object of type CRYPTO_ONCE
+ * @initalt: alternative initialiser function name that was previously given to
+ *           DEFINE_RUN_ONCE_STATIC_ALT.  This function must return 1 for
+ *           success or 0 for failure.
+ * @init:    primary initialiser function name that was previously given to
+ *           DEFINE_RUN_ONCE_STATIC.  This function must return 1 for success or
+ *           0 for failure.
+ *
+ * The return value is 1 on success (*) or 0 in case of error.
+ *
+ * (*) by convention, since the init function must return 1 on success.
+ */
 #define RUN_ONCE_ALT(once, initalt, init)                               \
     (CRYPTO_THREAD_run_once(once, initalt##_ossl_) ? init##_ossl_ret_ : 0)

--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -30,6 +30,14 @@
     }                                           \
     static int init(void)
 
+#define DEFINE_RUN_ONCE_STATIC_ALT(initalt, init) \
+    static int initalt(void);                     \
+    static void initalt##_ossl_(void)             \
+    {                                             \
+        init##_ossl_ret_ = initalt();             \
+    }                                             \
+    static int initalt(void)
+
 /*
  * RUN_ONCE - use CRYPTO_THREAD_run_once, and check if the init succeeded
  * @once: pointer to static object of type CRYPTO_ONCE
@@ -43,3 +51,6 @@
  */
 #define RUN_ONCE(once, init)                                            \
     (CRYPTO_THREAD_run_once(once, init##_ossl_) ? init##_ossl_ret_ : 0)
+
+#define RUN_ONCE_ALT(once, initalt, init)                               \
+    (CRYPTO_THREAD_run_once(once, initalt##_ossl_) ? init##_ossl_ret_ : 0)

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -379,7 +379,7 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 /* OPENSSL_INIT_ZLIB                         0x00010000L */
 # define OPENSSL_INIT_ATFORK                 0x00020000L
 /* OPENSSL_INIT_BASE_ONLY                    0x00040000L */
-/* FREE: 0x00080000L */
+# define OPENSSL_INIT_NO_ATEXIT              0x00080000L
 /* OPENSSL_INIT flag range 0x03f00000 reserved for OPENSSL_init_ssl() */
 # define OPENSSL_INIT_NO_ADD_ALL_MACS        0x04000000L
 # define OPENSSL_INIT_ADD_ALL_MACS           0x08000000L

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -134,7 +134,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_ssl_strings)
     return 1;
 }
 
-DEFINE_RUN_ONCE_STATIC(ossl_init_no_load_ssl_strings)
+DEFINE_RUN_ONCE_STATIC_ALT(ossl_init_no_load_ssl_strings,
+                           ossl_init_load_ssl_strings)
 {
     /* Do nothing in this case */
     return 1;
@@ -208,7 +209,8 @@ int OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS * settings)
         return 0;
 
     if ((opts & OPENSSL_INIT_NO_LOAD_SSL_STRINGS)
-        && !RUN_ONCE(&ssl_strings, ossl_init_no_load_ssl_strings))
+        && !RUN_ONCE_ALT(&ssl_strings, ossl_init_no_load_ssl_strings,
+                         ossl_init_load_ssl_strings))
         return 0;
 
     if ((opts & OPENSSL_INIT_LOAD_SSL_STRINGS)

--- a/test/build.info
+++ b/test/build.info
@@ -392,7 +392,6 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=main
     PROGRAMS_NO_INST=shlibloadtest
     SOURCE[shlibloadtest]=shlibloadtest.c
     INCLUDE[shlibloadtest]=../include ../crypto/include
-    DEPEND[shlibloadtest]=libtestutil.a
   ENDIF
 
   IF[{- $disabled{shared} -}]

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -8,6 +8,7 @@
 
 use OpenSSL::Test qw/:DEFAULT bldtop_dir bldtop_file/;
 use OpenSSL::Test::Utils;
+use File::Temp qw(tempfile);
 
 #Load configdata.pm
 
@@ -20,7 +21,7 @@ use configdata;
 plan skip_all => "Test only supported in a shared build" if disabled("shared");
 plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 
-plan tests => 4;
+plan tests => 10;
 
 # When libssl and libcrypto are compiled on Linux with "-rpath", but not
 # "--enable-new-dtags", the RPATH takes precedence over LD_LIBRARY_PATH,
@@ -30,14 +31,31 @@ plan tests => 4;
 my $libcrypto = bldtop_file(shlib('libcrypto'));
 my $libssl = bldtop_file(shlib('libssl'));
 
-ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl])),
-   "running shlibloadtest -crypto_first");
-ok(run(test(["shlibloadtest", "-ssl_first", $libcrypto, $libssl])),
-   "running shlibloadtest -ssl_first");
-ok(run(test(["shlibloadtest", "-just_crypto", $libcrypto, $libssl])),
-   "running shlibloadtest -just_crypto");
-ok(run(test(["shlibloadtest", "-dso_ref", $libcrypto, $libssl])),
-   "running shlibloadtest -dso_ref");
+(my $fh, my $filename) = tempfile();
+ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl, $filename])),
+   "running shlibloadtest -crypto_first $filename");
+ok(check_atexit($fh));
+unlink $filename;
+($fh, $filename) = tempfile();
+ok(run(test(["shlibloadtest", "-ssl_first", $libcrypto, $libssl, $filename])),
+   "running shlibloadtest -ssl_first $filename");
+ok(check_atexit($fh));
+unlink $filename;
+($fh, $filename) = tempfile();
+ok(run(test(["shlibloadtest", "-just_crypto", $libcrypto, $libssl, $filename])),
+   "running shlibloadtest -just_crypto $filename");
+ok(check_atexit($fh));
+unlink $filename;
+($fh, $filename) = tempfile();
+ok(run(test(["shlibloadtest", "-dso_ref", $libcrypto, $libssl, $filename])),
+   "running shlibloadtest -dso_ref $filename");
+ok(check_atexit($fh));
+unlink $filename;
+($fh, $filename) = tempfile();
+ok(run(test(["shlibloadtest", "-no_atexit", $libcrypto, $libssl, $filename])),
+   "running shlibloadtest -no_atexit $filename");
+ok(!check_atexit($fh));
+unlink $filename;
 
 sub shlib {
     my $lib = shift;
@@ -48,4 +66,13 @@ sub shlib {
         . ($target{shared_extension} || ".so");
     $lib =~ s|\.\$\(SHLIB_VERSION_NUMBER\)|.$config{shlib_version}|;
     return $lib;
+}
+
+sub check_atexit {
+    my $fh = shift;
+    my $data = <$fh>;
+
+    return 1 if (defined $data && $data =~ m/atexit\(\) run/);
+
+    return 0;
 }

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -121,6 +121,7 @@ static int test_lib(void)
 
     switch (test_type) {
     case JUST_CRYPTO:
+    case DSO_REFTEST:
         if (!TEST_true(shlib_load(path_crypto, &cryptolib)))
             goto end;
         break;
@@ -132,10 +133,6 @@ static int test_lib(void)
     case SSL_FIRST:
         if (!TEST_true(shlib_load(path_ssl, &ssllib))
                 || !TEST_true(shlib_load(path_crypto, &cryptolib)))
-            goto end;
-        break;
-    case DSO_REFTEST:
-        if (!TEST_true(shlib_load(path_crypto, &cryptolib)))
             goto end;
         break;
     }
@@ -210,6 +207,7 @@ static int test_lib(void)
 
     switch (test_type) {
     case JUST_CRYPTO:
+    case DSO_REFTEST:
         if (!TEST_true(shlib_close(cryptolib)))
             goto end;
         break;
@@ -221,10 +219,6 @@ static int test_lib(void)
     case SSL_FIRST:
         if (!TEST_true(shlib_close(ssllib))
                 || !TEST_true(shlib_close(cryptolib)))
-            goto end;
-        break;
-    case DSO_REFTEST:
-        if (!TEST_true(shlib_close(cryptolib)))
             goto end;
         break;
     }
@@ -247,7 +241,7 @@ int setup_tests(void)
     } else if (strcmp(p, "-just_crypto") == 0) {
         test_type = JUST_CRYPTO;
     } else if (strcmp(p, "-dso_ref") == 0) {
-        test_type = JUST_CRYPTO;
+        test_type = DSO_REFTEST;
     } else {
         TEST_error("Unrecognised argument");
         return 0;

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -20,6 +20,8 @@ typedef void DSO;
 typedef const SSL_METHOD * (*TLS_method_t)(void);
 typedef SSL_CTX * (*SSL_CTX_new_t)(const SSL_METHOD *meth);
 typedef void (*SSL_CTX_free_t)(SSL_CTX *);
+typedef int (*OPENSSL_init_crypto_t)(uint64_t, void *);
+typedef int (*OPENSSL_atexit_t)(void (*handler)(void));
 typedef unsigned long (*ERR_get_error_t)(void);
 typedef unsigned long (*OPENSSL_version_major_t)(void);
 typedef unsigned long (*OPENSSL_version_minor_t)(void);
@@ -31,12 +33,14 @@ typedef enum test_types_en {
     CRYPTO_FIRST,
     SSL_FIRST,
     JUST_CRYPTO,
-    DSO_REFTEST
+    DSO_REFTEST,
+    NO_ATEXIT
 } TEST_TYPE;
 
 static TEST_TYPE test_type;
 static const char *path_crypto;
 static const char *path_ssl;
+static const char *path_atexit;
 
 #ifdef DSO_DLFCN
 
@@ -100,6 +104,17 @@ static int shlib_close(SHLIB lib)
 
 #if defined(DSO_DLFCN) || defined(DSO_WIN32)
 
+static void atexit_handler(void)
+{
+    FILE *atexit_file = fopen(path_atexit, "w");
+
+    if (atexit_file == NULL)
+        return;
+
+    fprintf(atexit_file, "atexit() run\n");
+    fclose(atexit_file);
+}
+
 static int test_lib(void)
 {
     SHLIB ssllib = SHLIB_INIT;
@@ -108,7 +123,7 @@ static int test_lib(void)
     union {
         void (*func)(void);
         SHLIB_SYM sym;
-    } symbols[4];
+    } symbols[5];
     TLS_method_t myTLS_method;
     SSL_CTX_new_t mySSL_CTX_new;
     SSL_CTX_free_t mySSL_CTX_free;
@@ -116,11 +131,13 @@ static int test_lib(void)
     OPENSSL_version_major_t myOPENSSL_version_major;
     OPENSSL_version_minor_t myOPENSSL_version_minor;
     OPENSSL_version_patch_t myOPENSSL_version_patch;
+    OPENSSL_atexit_t myOPENSSL_atexit;
     int result = 0;
 
     switch (test_type) {
     case JUST_CRYPTO:
     case DSO_REFTEST:
+    case NO_ATEXIT:
     case CRYPTO_FIRST:
         if (!shlib_load(path_crypto, &cryptolib)) {
             fprintf(stderr, "Failed to load libcrypto\n");
@@ -144,7 +161,23 @@ static int test_lib(void)
         break;
     }
 
-    if (test_type != JUST_CRYPTO && test_type != DSO_REFTEST) {
+    if (test_type == NO_ATEXIT) {
+        OPENSSL_init_crypto_t myOPENSSL_init_crypto;
+
+        if (!shlib_sym(cryptolib, "OPENSSL_init_crypto", &symbols[0].sym)) {
+            fprintf(stderr, "Failed to load OPENSSL_init_crypto symbol\n");
+            goto end;
+        }
+        myOPENSSL_init_crypto = (OPENSSL_init_crypto_t)symbols[0].func;
+        if (!myOPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, NULL)) {
+            fprintf(stderr, "Failed to initialise libcrypto\n");
+            goto end;
+        }
+    }
+
+    if (test_type != JUST_CRYPTO
+            && test_type != DSO_REFTEST
+            && test_type != NO_ATEXIT) {
         if (!shlib_sym(ssllib, "TLS_method", &symbols[0].sym)
                 || !shlib_sym(ssllib, "SSL_CTX_new", &symbols[1].sym)
                 || !shlib_sym(ssllib, "SSL_CTX_free", &symbols[2].sym)) {
@@ -165,7 +198,8 @@ static int test_lib(void)
     if (!shlib_sym(cryptolib, "ERR_get_error", &symbols[0].sym)
            || !shlib_sym(cryptolib, "OPENSSL_version_major", &symbols[1].sym)
            || !shlib_sym(cryptolib, "OPENSSL_version_minor", &symbols[2].sym)
-           || !shlib_sym(cryptolib, "OPENSSL_version_patch", &symbols[3].sym)) {
+           || !shlib_sym(cryptolib, "OPENSSL_version_patch", &symbols[3].sym)
+           || !shlib_sym(cryptolib, "OPENSSL_atexit", &symbols[4].sym)) {
         fprintf(stderr, "Failed to load libcrypto symbols\n");
         goto end;
     }
@@ -183,6 +217,12 @@ static int test_lib(void)
             || myOPENSSL_version_minor() != OPENSSL_VERSION_MINOR
             || myOPENSSL_version_patch() != OPENSSL_VERSION_PATCH) {
         fprintf(stderr, "Invalid library version number\n");
+        goto end;
+    }
+
+    myOPENSSL_atexit = (OPENSSL_atexit_t)symbols[4].func;
+    if (!myOPENSSL_atexit(atexit_handler)) {
+        fprintf(stderr, "Failed to register atexit handler\n");
         goto end;
     }
 
@@ -224,6 +264,7 @@ static int test_lib(void)
     switch (test_type) {
     case JUST_CRYPTO:
     case DSO_REFTEST:
+    case NO_ATEXIT:
     case CRYPTO_FIRST:
         if (!shlib_close(cryptolib)) {
             fprintf(stderr, "Failed to close libcrypto\n");
@@ -264,8 +305,8 @@ int main(int argc, char *argv[])
 {
     const char *p;
 
-    if (argc != 4) {
-        fprintf(stderr, "Incorrect number of arguments");
+    if (argc != 5) {
+        fprintf(stderr, "Incorrect number of arguments\n");
         return 1;
     }
 
@@ -279,12 +320,15 @@ int main(int argc, char *argv[])
         test_type = JUST_CRYPTO;
     } else if (strcmp(p, "-dso_ref") == 0) {
         test_type = DSO_REFTEST;
+    } else if (strcmp(p, "-no_atexit") == 0) {
+        test_type = NO_ATEXIT;
     } else {
-        fprintf(stderr, "Unrecognised argument");
+        fprintf(stderr, "Unrecognised argument\n");
         return 1;
     }
     path_crypto = argv[2];
     path_ssl = argv[3];
+    path_atexit = argv[4];
     if (path_crypto == NULL || path_ssl == NULL) {
         fprintf(stderr, "Invalid libcrypto/libssl path\n");
         return 1;

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -14,7 +14,6 @@
 #include <openssl/ssl.h>
 #include <openssl/ossl_typ.h>
 #include "internal/dso_conf.h"
-#include "testutil.h"
 
 typedef void DSO;
 
@@ -122,57 +121,70 @@ static int test_lib(void)
     switch (test_type) {
     case JUST_CRYPTO:
     case DSO_REFTEST:
-        if (!TEST_true(shlib_load(path_crypto, &cryptolib)))
-            goto end;
-        break;
     case CRYPTO_FIRST:
-        if (!TEST_true(shlib_load(path_crypto, &cryptolib))
-                || !TEST_true(shlib_load(path_ssl, &ssllib)))
+        if (!shlib_load(path_crypto, &cryptolib)) {
+            fprintf(stderr, "Failed to load libcrypto\n");
             goto end;
-        break;
+        }
+        if (test_type != CRYPTO_FIRST)
+            break;
+        /* Fall through */
+
     case SSL_FIRST:
-        if (!TEST_true(shlib_load(path_ssl, &ssllib))
-                || !TEST_true(shlib_load(path_crypto, &cryptolib)))
+        if (!shlib_load(path_ssl, &ssllib)) {
+            fprintf(stderr, "Failed to load libssl\n");
             goto end;
+        }
+        if (test_type != SSL_FIRST)
+            break;
+        if (!shlib_load(path_crypto, &cryptolib)) {
+            fprintf(stderr, "Failed to load libcrypto\n");
+            goto end;
+        }
         break;
     }
 
     if (test_type != JUST_CRYPTO && test_type != DSO_REFTEST) {
-        if (!TEST_true(shlib_sym(ssllib, "TLS_method", &symbols[0].sym))
-                || !TEST_true(shlib_sym(ssllib, "SSL_CTX_new", &symbols[1].sym))
-                || !TEST_true(shlib_sym(ssllib, "SSL_CTX_free", &symbols[2].sym)))
+        if (!shlib_sym(ssllib, "TLS_method", &symbols[0].sym)
+                || !shlib_sym(ssllib, "SSL_CTX_new", &symbols[1].sym)
+                || !shlib_sym(ssllib, "SSL_CTX_free", &symbols[2].sym)) {
+            fprintf(stderr, "Failed to load libssl symbols\n");
             goto end;
+        }
         myTLS_method = (TLS_method_t)symbols[0].func;
         mySSL_CTX_new = (SSL_CTX_new_t)symbols[1].func;
         mySSL_CTX_free = (SSL_CTX_free_t)symbols[2].func;
-        if (!TEST_ptr(ctx = mySSL_CTX_new(myTLS_method())))
+        ctx = mySSL_CTX_new(myTLS_method());
+        if (ctx == NULL) {
+            fprintf(stderr, "Failed to create SSL_CTX\n");
             goto end;
+        }
         mySSL_CTX_free(ctx);
     }
 
-    if (!TEST_true(shlib_sym(cryptolib, "ERR_get_error", &symbols[0].sym))
-           || !TEST_true(shlib_sym(cryptolib, "OPENSSL_version_major",
-                                   &symbols[1].sym))
-           || !TEST_true(shlib_sym(cryptolib, "OPENSSL_version_minor",
-                                   &symbols[2].sym))
-           || !TEST_true(shlib_sym(cryptolib, "OPENSSL_version_patch",
-                                   &symbols[3].sym)))
+    if (!shlib_sym(cryptolib, "ERR_get_error", &symbols[0].sym)
+           || !shlib_sym(cryptolib, "OPENSSL_version_major", &symbols[1].sym)
+           || !shlib_sym(cryptolib, "OPENSSL_version_minor", &symbols[2].sym)
+           || !shlib_sym(cryptolib, "OPENSSL_version_patch", &symbols[3].sym)) {
+        fprintf(stderr, "Failed to load libcrypto symbols\n");
         goto end;
+    }
     myERR_get_error = (ERR_get_error_t)symbols[0].func;
-    if (!TEST_int_eq(myERR_get_error(), 0))
+    if (myERR_get_error() != 0) {
+        fprintf(stderr, "Unexpected ERR_get_error() response\n");
         goto end;
+    }
 
-    /* Make sure the libraries are a compatible version */
+    /* Library and header version should be identical in this test */
     myOPENSSL_version_major = (OPENSSL_version_major_t)symbols[1].func;
     myOPENSSL_version_minor = (OPENSSL_version_minor_t)symbols[2].func;
     myOPENSSL_version_patch = (OPENSSL_version_patch_t)symbols[3].func;
-    if (!TEST_int_eq(myOPENSSL_version_major(), OPENSSL_VERSION_MAJOR))
+    if (myOPENSSL_version_major() != OPENSSL_VERSION_MAJOR
+            || myOPENSSL_version_minor() != OPENSSL_VERSION_MINOR
+            || myOPENSSL_version_patch() != OPENSSL_VERSION_PATCH) {
+        fprintf(stderr, "Invalid library version number\n");
         goto end;
-    if (!TEST_int_ge(myOPENSSL_version_minor(), OPENSSL_VERSION_MINOR))
-        goto end;
-    if (myOPENSSL_version_minor() == OPENSSL_VERSION_MINOR
-        && !TEST_int_ge(myOPENSSL_version_patch(), OPENSSL_VERSION_PATCH))
-        goto end;
+    }
 
     if (test_type == DSO_REFTEST) {
 # ifdef DSO_DLFCN
@@ -187,10 +199,11 @@ static int test_lib(void)
          * will always return an error, because DSO_pathbyaddr() is not
          * implemented there.
          */
-        if (!TEST_true(shlib_sym(cryptolib, "DSO_dsobyaddr", &symbols[0].sym))
-                || !TEST_true(shlib_sym(cryptolib, "DSO_free",
-                                        &symbols[1].sym)))
+        if (!shlib_sym(cryptolib, "DSO_dsobyaddr", &symbols[0].sym)
+                || !shlib_sym(cryptolib, "DSO_free", &symbols[1].sym)) {
+            fprintf(stderr, "Unable to load DSO symbols\n");
             goto end;
+        }
 
         myDSO_dsobyaddr = (DSO_dsobyaddr_t)symbols[0].func;
         myDSO_free = (DSO_free_t)symbols[1].func;
@@ -198,8 +211,11 @@ static int test_lib(void)
         {
             DSO *hndl;
             /* use known symbol from crypto module */
-            if (!TEST_ptr(hndl = myDSO_dsobyaddr((void (*)(void))ERR_get_error, 0)))
+            hndl = myDSO_dsobyaddr((void (*)(void))myERR_get_error, 0);
+            if (hndl == NULL) {
+                fprintf(stderr, "DSO_dsobyaddr() failed\n");
                 goto end;
+            }
             myDSO_free(hndl);
         }
 # endif /* DSO_DLFCN */
@@ -208,18 +224,27 @@ static int test_lib(void)
     switch (test_type) {
     case JUST_CRYPTO:
     case DSO_REFTEST:
-        if (!TEST_true(shlib_close(cryptolib)))
-            goto end;
-        break;
     case CRYPTO_FIRST:
-        if (!TEST_true(shlib_close(cryptolib))
-                || !TEST_true(shlib_close(ssllib)))
+        if (!shlib_close(cryptolib)) {
+            fprintf(stderr, "Failed to close libcrypto\n");
             goto end;
-        break;
+        }
+        if (test_type != CRYPTO_FIRST)
+            break;
+        /* Fall through */
+
     case SSL_FIRST:
-        if (!TEST_true(shlib_close(ssllib))
-                || !TEST_true(shlib_close(cryptolib)))
+        if (test_type == CRYPTO_FIRST && !shlib_close(ssllib)) {
+            fprintf(stderr, "Failed to close libssl\n");
             goto end;
+        }
+        if (test_type != SSL_FIRST)
+            break;
+
+        if (!shlib_close(cryptolib)) {
+            fprintf(stderr, "Failed to close libcrypto\n");
+            goto end;
+        }
         break;
     }
 
@@ -230,9 +255,21 @@ end:
 #endif
 
 
-int setup_tests(void)
+/*
+ * shlibloadtest should not use the normal test framework because we don't want
+ * it to link against libcrypto (which the framework uses). The point of the
+ * test is to check dynamic loading and unloading of libcrypto/libssl.
+ */
+int main(int argc, char *argv[])
 {
-    const char *p = test_get_argument(0);
+    const char *p;
+
+    if (argc != 4) {
+        fprintf(stderr, "Incorrect number of arguments");
+        return 1;
+    }
+
+    p = argv[1];
 
     if (strcmp(p, "-crypto_first") == 0) {
         test_type = CRYPTO_FIRST;
@@ -243,15 +280,19 @@ int setup_tests(void)
     } else if (strcmp(p, "-dso_ref") == 0) {
         test_type = DSO_REFTEST;
     } else {
-        TEST_error("Unrecognised argument");
-        return 0;
+        fprintf(stderr, "Unrecognised argument");
+        return 1;
     }
-    if (!TEST_ptr(path_crypto = test_get_argument(1))
-            || !TEST_ptr(path_ssl = test_get_argument(2)))
-        return 0;
+    path_crypto = argv[2];
+    path_ssl = argv[3];
+    if (path_crypto == NULL || path_ssl == NULL) {
+        fprintf(stderr, "Invalid libcrypto/libssl path\n");
+        return 1;
+    }
 
 #if defined(DSO_DLFCN) || defined(DSO_WIN32)
-    ADD_TEST(test_lib);
+    if (!test_lib())
+        return 1;
 #endif
-    return 1;
+    return 0;
 }

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -104,6 +104,8 @@ static int shlib_close(SHLIB lib)
 
 #if defined(DSO_DLFCN) || defined(DSO_WIN32)
 
+static int atexit_handler_done = 0;
+
 static void atexit_handler(void)
 {
     FILE *atexit_file = fopen(path_atexit, "w");
@@ -113,6 +115,7 @@ static void atexit_handler(void)
 
     fprintf(atexit_file, "atexit() run\n");
     fclose(atexit_file);
+    atexit_handler_done++;
 }
 
 static int test_lib(void)
@@ -261,33 +264,34 @@ static int test_lib(void)
 # endif /* DSO_DLFCN */
     }
 
-    switch (test_type) {
-    case JUST_CRYPTO:
-    case DSO_REFTEST:
-    case NO_ATEXIT:
-    case CRYPTO_FIRST:
-        if (!shlib_close(cryptolib)) {
-            fprintf(stderr, "Failed to close libcrypto\n");
-            goto end;
-        }
-        if (test_type != CRYPTO_FIRST)
-            break;
-        /* Fall through */
+    if (!shlib_close(cryptolib)) {
+        fprintf(stderr, "Failed to close libcrypto\n");
+        goto end;
+    }
 
-    case SSL_FIRST:
-        if (test_type == CRYPTO_FIRST && !shlib_close(ssllib)) {
+    if (test_type == CRYPTO_FIRST || test_type == SSL_FIRST) {
+        if (!shlib_close(ssllib)) {
             fprintf(stderr, "Failed to close libssl\n");
             goto end;
         }
-        if (test_type != SSL_FIRST)
-            break;
-
-        if (!shlib_close(cryptolib)) {
-            fprintf(stderr, "Failed to close libcrypto\n");
-            goto end;
-        }
-        break;
     }
+
+# if defined(OPENSSL_NO_PINSHARED) \
+    && defined(__GLIBC__) \
+    && defined(__GLIBC_PREREQ) \
+    && defined(OPENSSL_SYS_LINUX)
+#  if __GLIBC_PREREQ(2, 3)
+    /*
+     * If we didn't pin the so then we are hopefully on a platform that supports
+     * running atexit() on so unload. If not we might crash. We know this is
+     * true on linux since glibc 2.2.3
+     */
+    if (test_type != NO_ATEXIT && atexit_handler_done != 1) {
+        fprintf(stderr, "atexit() handler did not run\n");
+        goto end;
+    }
+#  endif
+# endif
 
     result = 1;
 end:


### PR DESCRIPTION
This PR introduces a compile time option and a run time option to control the clean up behaviour. At the moment we attempt to "pin" OpenSSL in memory until process exit. This is because of our use of the "atexit" handler. This handler is defined to run at process exit - but it can cause crashes if the library has already been unloaded at process exit. Some platforms (such as Linux) run the atexit handler when the library gets unloaded instead of at process exit.

We add two options to control this behaviour. Firstly a compile time option "no-pinso" which stops the so from being pinned in memory until process exit. Secondly a run time option OPENSSL_INIT_NO_ATEXIT which prevents the atexit handler from being registered. Using this option will require the application to clean up OpenSSL explicitly by using OPENSSL_cleanup().

As part of this I made 2 other related changes: Firstly fixed a bug in the `DSO_REFTEST` test in shlibloadtest, which effectively meant that the test was never run. Secondly I rewrote shlibloadtest to NOT use the test framework. The reason for this is that the test framework implicitly requires libcrypto to be linked (it uses BIOs). However the point about shlibloadtest is to test dynamic loading and unloading of the library. I am concerned that linking directly against libcrypto and also dynamically loading it might mask certain failure modes.

This PR supersedes and replaces #7388.

Fixes #7598 

It's not clear to me which branches this should go to. Technically these are features. You could also argue that the inability to control this is a bug (see #7598).
