### PR TITLE
Unix build: for mingw and cygwin, create the right location for DLLs

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -644,7 +644,9 @@ install_runtime_libs: build_libs
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@ : {- output_off() if windowsdll(); "" -}
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(libdir)
-	@ : {- output_on() if windowsdll(); "" -}
+	@ : {- output_on() if windowsdll(); output_off() unless windowsdll(); "" -}
+	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/bin
+	@ : {- output_on() unless windowsdll(); "" -}
 	@$(ECHO) "*** Installing runtime libraries"
 	@set -e; for s in dummy $(INSTALL_SHLIBS); do \
 		if [ "$$s" = "dummy" ]; then continue; fi; \


### PR DESCRIPTION
Mingw and Cygwin builds install the DLLs in the application directory,
not the library directory, so ensure that one is created for them when
installing the DLLs.

Fixes #7653
