### PR TITLE
openssl s_server: don't use sendto() with connected UDP socket

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2754,6 +2754,8 @@ static int init_ssl_connection(SSL *con)
                     BIO_ADDR_free(client);
                     return 0;
                 }
+
+                (void)BIO_ctrl_set_connected(wbio, client);
                 BIO_ADDR_free(client);
                 dtlslisten = 0;
             } else {


### PR DESCRIPTION
Fixes https://github.com/openssl/openssl/issues/7675

On macOS, if you call connect() on a UDP socket you cannot then
call sendto() with a destination, otherwise it fails with Err#56
('socket is already connected').

By calling BIO_CTRL_DGRAM_SET_CONNECTED on the wbio we can tell
bio that the socket has been bound and make it call send() rather
than sendto().

CLA: Trivial