### PR TITLE
Fix a failure in errtest on some platforms

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -21,6 +21,7 @@
 #include "internal/thread_once.h"
 #include "internal/ctype.h"
 #include "internal/constant_time_locl.h"
+#include "e_os.h"
 
 static int err_load_strings(const ERR_STRING_DATA *str);
 
@@ -206,6 +207,7 @@ static void build_SYS_str_reasons(void)
     size_t cnt = 0;
     static int init = 1;
     int i;
+    int saveerrno = get_last_sys_error();
 
     CRYPTO_THREAD_write_lock(err_string_lock);
     if (!init) {
@@ -251,6 +253,8 @@ static void build_SYS_str_reasons(void)
     init = 0;
 
     CRYPTO_THREAD_unlock(err_string_lock);
+    /* openssl_strerror_r could change errno, but we want to preserve it */
+    set_sys_error(saveerrno);
     err_load_strings(SYS_str_reasons);
 }
 #endif

--- a/e_os.h
+++ b/e_os.h
@@ -49,6 +49,7 @@
 
 # define get_last_sys_error()    errno
 # define clear_sys_error()       errno=0
+# define set_sys_error(e)        errno=(e)
 
 /********************************************************************
  The Microsoft section
@@ -66,8 +67,10 @@
 # ifdef WIN32
 #  undef get_last_sys_error
 #  undef clear_sys_error
+#  undef set_sys_error
 #  define get_last_sys_error()    GetLastError()
 #  define clear_sys_error()       SetLastError(0)
+#  define set_sys_error(e)        SetLastError(e)
 #  if !defined(WINNT)
 #   define WIN_CONSOLE_BUG
 #  endif


### PR DESCRIPTION
errtest checks that errno remains unchanged across a call to `ERR_get_error()`. This is required because `SSL_get_error()` calls `ERR_get_error()` (well actually `ERR_peek_error()` but internally they are both handled the same way) and returns `SSL_ERROR_SYSCALL` if a system call error occurred. In that case the user is supposed to consult errno.

In some cases ERR_get_error() can end up calling various system calls, so we need to make sure errno is preserved across all of those.