### PR TITLE
Smarter build of system error text database

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -181,8 +181,9 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 }
 
 #ifndef OPENSSL_NO_ERR
+/* A measurement on Linux 2018-11-21 showed about 3.5kib */
+# define SPACE_SYS_STR_REASONS 4 * 1024
 # define NUM_SYS_STR_REASONS 127
-# define LEN_SYS_STR_REASON 32
 
 static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
 /*
@@ -198,7 +199,9 @@ static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
 static void build_SYS_str_reasons(void)
 {
     /* OPENSSL_malloc cannot be used here, use static storage instead */
-    static char strerror_tab[NUM_SYS_STR_REASONS][LEN_SYS_STR_REASON];
+    static char strerror_pool[SPACE_SYS_STR_REASONS];
+    char *cur = strerror_pool;
+    size_t cnt = 0;
     static int init = 1;
     int i;
 
@@ -213,9 +216,13 @@ static void build_SYS_str_reasons(void)
 
         str->error = ERR_PACK(ERR_LIB_SYS, 0, i);
         if (str->string == NULL) {
-            char (*dest)[LEN_SYS_STR_REASON] = &(strerror_tab[i - 1]);
-            if (openssl_strerror_r(i, *dest, sizeof(*dest)))
-                str->string = *dest;
+            if (openssl_strerror_r(i, cur, sizeof(strerror_pool - cnt))) {
+                size_t l = strlen(cur) + 1;
+
+                str->string = cur;
+                cnt += l;
+                cur += l;
+            }
         }
         if (str->string == NULL)
             str->string = "unknown";

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -216,7 +216,7 @@ static void build_SYS_str_reasons(void)
 
         str->error = ERR_PACK(ERR_LIB_SYS, 0, i);
         if (str->string == NULL) {
-            if (openssl_strerror_r(i, cur, sizeof(strerror_pool - cnt))) {
+            if (openssl_strerror_r(i, cur, sizeof(strerror_pool) - cnt)) {
                 size_t l = strlen(cur) + 1;
 
                 str->string = cur;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -221,6 +221,8 @@ static void build_SYS_str_reasons(void)
 
                 str->string = cur;
                 cnt += l;
+                if (cnt > sizeof(strerror_pool))
+                    cnt = sizeof(strerror_pool);
                 cur += l;
             }
         }

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -1,0 +1,41 @@
+#! /usr/bin/env perl
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;
+use POSIX;
+
+setup('test_errstr');
+
+# We actually have space for up to 4095 error messages,
+# numerically speaking...  but we're currently only using
+# numbers 1 through 127.
+plan tests => 128;
+
+my $i;
+
+for ($i = 1; $i < 128; $i++) {
+    # We know that the system reasons are in library 2
+    my @oerr = run(app([ qw(openssl errstr), sprintf("2%06x", $i) ]),
+                   capture => 1);
+    $oerr[0] =~ s|\R$||;
+    $oerr[0] =~ s|.*system library:||g; # The actual message is last
+
+    my $perr = strerror($i);
+    if ($perr =~ m|Unknown error $i|) {
+        ok($oerr[0] eq 'unknown', "($i) '$oerr[0]' == 'unknown' ('$perr')");
+    } else {
+        ok($oerr[0] eq $perr, "($i) '$oerr[0]' == '$perr'");
+    }
+}
+
+my @after = run(app([ qw(openssl errstr), sprintf("2%06x", $i) ]),
+                capture => 1);
+$after[0] =~ s|\R$||;
+$after[0] =~ s|.*system library:||g;
+ok($after[0] eq "reason($i)", "($i) '$after[0]' == 'reason($i)'");

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -7,35 +7,49 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
+no strict 'refs';               # To be able to use strings as function refs
 use OpenSSL::Test;
-use POSIX;
+use Errno qw(:POSIX);
+use POSIX qw(strerror);
 
 setup('test_errstr');
+
+# These are POSIX error names, which Errno implements as functions
+# (this is documented)
+my @posix_errors = @{$Errno::EXPORT_TAGS{POSIX}};
 
 # We actually have space for up to 4095 error messages,
 # numerically speaking...  but we're currently only using
 # numbers 1 through 127.
-plan tests => 128;
+plan tests => scalar @posix_errors
+    +1                          # Checking that error 128 gives 'reason(128)'
+    +1                          # Checking that error 0 gives the library name
+    ;
 
-my $i;
+foreach my $errname (@posix_errors) {
+    my $errnum = "Errno::$errname"->();
+    my $perr = eval {
+        # Set $! to the error number...
+        local $! = $errnum;
+        # ... and $! will give you the error string back
+        $!
+    };
 
-for ($i = 1; $i < 128; $i++) {
-    # We know that the system reasons are in library 2
-    my @oerr = run(app([ qw(openssl errstr), sprintf("2%06x", $i) ]),
+    # We know that the system reasons are in OpenSSL error library 2
+    my @oerr = run(app([ qw(openssl errstr), sprintf("2%06x", $errnum) ]),
                    capture => 1);
     $oerr[0] =~ s|\R$||;
     $oerr[0] =~ s|.*system library:||g; # The actual message is last
 
-    my $perr = strerror($i);
-    if ($perr =~ m|Unknown error $i|) {
-        ok($oerr[0] eq 'unknown', "($i) '$oerr[0]' == 'unknown' ('$perr')");
-    } else {
-        ok($oerr[0] eq $perr, "($i) '$oerr[0]' == '$perr'");
-    }
+    ok($oerr[0] eq $perr, "($errnum) '$oerr[0]' == '$perr'");
 }
 
-my @after = run(app([ qw(openssl errstr), sprintf("2%06x", $i) ]),
-                capture => 1);
+my @after = run(app([ qw(openssl errstr 2000080) ]), capture => 1);
 $after[0] =~ s|\R$||;
 $after[0] =~ s|.*system library:||g;
-ok($after[0] eq "reason($i)", "($i) '$after[0]' == 'reason($i)'");
+ok($after[0] eq "reason(128)", "(128) '$after[0]' == 'reason(128)'");
+
+my @zero = run(app([ qw(openssl errstr 2000000) ]), capture => 1);
+$zero[0] =~ s|\R$||;
+$zero[0] =~ s|.*system library:||g;
+ok($zero[0] eq "system library", "(0) '$zero[0]' == 'system library'");


### PR DESCRIPTION
We stored copies of the system error texts in a fixed line size array,
which is a huge waste.  Instead, use a static memory pool and pack all
the string in there.  The wasted space at the end, if any, gives us
some leeway for longer strings than we have measured so far.
