### PR TITLE
Configure: don't try to be clever when configuring afalgeng

### DIFF
--- a/Configure
+++ b/Configure
@@ -1680,20 +1680,7 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-strict-warnings'
 unless ($disabled{afalgeng}) {
     $config{afalgeng}="";
     if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
-        my $minver = 4*10000 + 1*100 + 0;
-        if ($config{CROSS_COMPILE} eq "") {
-            my $verstr = `uname -r`;
-            my ($ma, $mi1, $mi2) = split("\\.", $verstr);
-            ($mi2) = $mi2 =~ /(\d+)/;
-            my $ver = $ma*10000 + $mi1*100 + $mi2;
-            if ($ver < $minver) {
-                disable('too-old-kernel', 'afalgeng');
-            } else {
-                push @{$config{engdirs}}, "afalg";
-            }
-        } else {
-            disable('cross-compiling', 'afalgeng');
-        }
+        push @{$config{engdirs}}, "afalg";
     } else {
         disable('not-linux', 'afalgeng');
     }


### PR DESCRIPTION
If the afalgeng is enabled then Configure tries to be clever but fails, by only
actually building afalgeng if it isn't being cross-compiled and if the current
kernel is 4.1+.

This means that everyone cross compiling, or whose builder machines are running
older kernels (not uncommon for build farms), can't enable afalgeng.

Instead remove the cleverness and simply enable/disable as requested.

Fixes #7687
