### PR TITLE
Dist refactoring fixups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@ fuzz/corpora/**                         export-ignore
 Configurations/*.norelease.conf         export-ignore
 .*                                      export-ignore
 util/mktar.sh                           export-ignore
+boringssl                               export-ignore
+krb5                                    export-ignore
+pyca-cryptography                       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 fuzz/corpora/**                         export-ignore
 Configurations/*.norelease.conf         export-ignore
 .*                                      export-ignore
+util/mktar.sh                           export-ignore

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.1 and 1.1.2 [xx XXX xxxx]
 
+  *) Remove the 'dist' target and add a tarball building script.  The
+     'dist' target has fallen out of use, and it shouldn't be
+     necessary to configure just to create a source distribution.
+     [Richard Levitte]
+
   *) Recreate the OS390-Unix config target.  It no longer relies on a
      special script like it did for OpenSSL pre-1.1.0.
      [Richard Levitte]

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -231,6 +231,7 @@ TARFLAGS= {- $target{TARFLAGS} -}
 
 BASENAME=       openssl
 NAME=           $(BASENAME)-$(VERSION)
+# Relative to $(SRCDIR)
 TARFILE=        ../$(NAME).tar
 
 ##### Project flags ##################################################
@@ -873,7 +874,7 @@ tags TAGS: FORCE
 # Release targets (note: only available on Unix) #####################
 
 tar:
-	$(SRCDIR)/util/mktar.sh --name='$(NAME)' --tarfile='$(TARFILE)'
+	(cd $(SRCDIR); ./util/mktar.sh --name='$(NAME)' --tarfile='$(TARFILE)')
 
 # Helper targets #####################################################
 

--- a/util/mktar.sh
+++ b/util/mktar.sh
@@ -1,4 +1,10 @@
 #! /bin/sh
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
 
 HERE=`dirname $0`
 

--- a/util/mktar.sh
+++ b/util/mktar.sh
@@ -30,4 +30,7 @@ if [ -z "$TARFILE" ]; then TARFILE="$NAME.tar"; fi
 git archive --worktree-attributes --format=tar --prefix="$NAME/" -v HEAD \
     | gzip -9 > "$TARFILE.gz"
 
-ls -l "$TARFILE.gz"
+# Good old way to ensure we display an absolute path
+td=`dirname $TARFILE`
+tf=`basename $TARFILE`
+ls -l "`cd $td; pwd`/$tf.gz"


### PR DESCRIPTION
Document the removed 'dist' target
----------------------------------

Also adds missing copyright boilerplate to `util/mktar.sh`

Don't export util/mktar.sh
--------------------------

When creating a tarball, it's pointless to include scripts that assume
a git workspace.