### PR TITLE
VMS config: Typo fix, as -> AS

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1791,7 +1791,7 @@ my %targets = (
     },
     "vms-ia64" => {
         inherit_from     => [ "vms-generic",
-                              sub { vms_info()->{as}
+                              sub { vms_info()->{AS}
                                         ? asm("ia64_asm")->() : () } ],
         bn_ops           => "SIXTY_FOUR_BIT RC4_INT",
         pointer_size     => "",

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -766,7 +766,7 @@ reconfigure reconf :
 $target : $args{generator}->[0] $deps $mkdef
 	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS"$case_insensitive > $target
 EOF
-      } elsif ($target !~ /\.[sS]$/) {
+      } elsif ($args{src} !~ /\.[sS]$/) {
           my $target = $args{src};
           if ($args{generator}->[0] =~ m|^.*\.in$|) {
 	      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},


### PR DESCRIPTION
This typo prevented ia64 assembler to be compiled on VMS
