### PR TITLE
WIP: More VMS assembler build fixes

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -847,7 +847,7 @@ EOF
 
   sub src2obj {
       my %args = @_;
-      my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x
+      my @srcs = map { (my $x = $_) =~ s/\.[sS]$/.asm/; $x
                      } ( @{$args{srcs}} );
       (my $obj = $args{obj}) =~ s|\.o$||;
       my $deps = join(", -\n\t\t", @srcs, @{$args{deps}});

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -823,7 +823,7 @@ $target : $args{generator}->[0] $deps
         \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
         RENAME \$\@-i \$\@
-        DELETE \$\@-S
+        DELETE \$\@-S;
 EOF
               }
               # Otherwise....


### PR DESCRIPTION
VMS build: in descrip.mms.tmpl's src2obj, do .S -> .asm too

We only convert lowercase .s to .asm, that turned out not to be sufficient.

-----

VMS build: don't forget the generation marker when removing files