### PR TITLE
Fixed compiling with Visual Studio 2005.

### DIFF
--- a/crypto/ct/ct_prn.c
+++ b/crypto/ct/ct_prn.c
@@ -35,7 +35,7 @@ static void timestamp_print(uint64_t timestamp, BIO *out)
         return;
     ASN1_GENERALIZEDTIME_adj(gen, (time_t)0,
                              (int)(timestamp / 86400000),
-                             (timestamp % 86400000) / 1000);
+                             (long)((timestamp % 86400000) / 1000));
     /*
      * Note GeneralizedTime from ASN1_GENERALIZETIME_adj is always 15
      * characters long with a final Z. Update it with fractional seconds.

--- a/crypto/ec/curve448/arch_32/f_impl.c
+++ b/crypto/ec/curve448/arch_32/f_impl.c
@@ -74,9 +74,9 @@ void gf_mulw_unsigned(gf_s * RESTRICT cs, const gf as, uint32_t b)
     for (i = 0; i < 8; i++) {
         accum0 += widemul(b, a[i]);
         accum8 += widemul(b, a[i + 8]);
-        c[i] = accum0 & mask;
+        c[i] = (uint32_t)(accum0 & mask);
         accum0 >>= 28;
-        c[i + 8] = accum8 & mask;
+        c[i + 8] = (uint32_t)(accum8 & mask);
         accum8 >>= 28;
     }
 

--- a/crypto/ec/curve448/f_generic.c
+++ b/crypto/ec/curve448/f_generic.c
@@ -113,7 +113,7 @@ void gf_strong_reduce(gf a)
     scarry = 0;
     for (i = 0; i < NLIMBS; i++) {
         scarry = scarry + a->limb[LIMBPERM(i)] - MODULUS->limb[LIMBPERM(i)];
-        a->limb[LIMBPERM(i)] = scarry & LIMB_MASK(LIMBPERM(i));
+        a->limb[LIMBPERM(i)] = (word_t)(scarry & LIMB_MASK(LIMBPERM(i)));
         scarry >>= LIMB_PLACE_VALUE(LIMBPERM(i));
     }
 
@@ -131,7 +131,7 @@ void gf_strong_reduce(gf a)
         carry =
             carry + a->limb[LIMBPERM(i)] +
             (scarry_0 & MODULUS->limb[LIMBPERM(i)]);
-        a->limb[LIMBPERM(i)] = carry & LIMB_MASK(LIMBPERM(i));
+        a->limb[LIMBPERM(i)] = (word_t)(carry & LIMB_MASK(LIMBPERM(i)));
         carry >>= LIMB_PLACE_VALUE(LIMBPERM(i));
     }
 

--- a/crypto/ec/curve448/scalar.c
+++ b/crypto/ec/curve448/scalar.c
@@ -100,7 +100,7 @@ static void sc_montmul(curve448_scalar_t out, const curve448_scalar_t a,
         chain += accum[j];
         chain += hi_carry;
         accum[j - 1] = (c448_word_t)chain;
-        hi_carry = chain >> WBITS;
+        hi_carry = (c448_word_t)(chain >> WBITS);
     }
 
     sc_subx(out, accum, sc_p, sc_p, hi_carry);

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -99,7 +99,7 @@ static void scryptROMix(unsigned char *B, uint64_t r, uint64_t N,
 
     for (i = 0; i < N; i++) {
         uint32_t j;
-        j = X[16 * (2 * r - 1)] % N;
+        j = (uint32_t)(X[16 * (2 * r - 1)] % N);
         pV = V + 32 * r * j;
         for (k = 0; k < 32 * r; k++)
             T[k] = X[k] ^ *pV++;

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -284,12 +284,12 @@ static int send_record(BIO *rbio, unsigned char type, uint64_t seqnr,
     unsigned char pad;
     unsigned char *enc;
 
-    seq[0] = (seqnr >> 40) & 0xff;
-    seq[1] = (seqnr >> 32) & 0xff;
-    seq[2] = (seqnr >> 24) & 0xff;
-    seq[3] = (seqnr >> 16) & 0xff;
-    seq[4] = (seqnr >> 8) & 0xff;
-    seq[5] = seqnr & 0xff;
+    seq[0] = (unsigned char)((seqnr >> 40) & 0xff);
+    seq[1] = (unsigned char)((seqnr >> 32) & 0xff);
+    seq[2] = (unsigned char)((seqnr >> 24) & 0xff);
+    seq[3] = (unsigned char)((seqnr >> 16) & 0xff);
+    seq[4] = (unsigned char)((seqnr >> 8) & 0xff);
+    seq[5] = (unsigned char)(seqnr & 0xff);
 
     pad = 15 - ((len + SHA_DIGEST_LENGTH) % 16);
     enc = OPENSSL_malloc(len + SHA_DIGEST_LENGTH + 1 + pad);


### PR DESCRIPTION
Compiling with VS 2005 does not work since OpenSSL 1.1.1, due to warnings being interpreted as errors. This patch explicitly casts all those integers to the respective type of whatever it is being assigned to, effectively writing what the compiler has been doing before explicitly to get rid of the warnings.