### PR TITLE
Don't test the collected system errors when configured to not have them

### DIFF
--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -31,6 +31,9 @@ setup('test_errstr');
 plan skip_all => 'This is unsupported for cross compiled configurations'
     if config('CROSS_COMPILE');
 
+plan skip_all => 'OpenSSL is configured "no-autoerrinit" or "no-err"'
+    if disabled('autoerrinit') || disabled('err');
+
 # These are POSIX error names, which Errno implements as functions
 # (this is documented)
 my @posix_errors = @{$Errno::EXPORT_TAGS{POSIX}};


### PR DESCRIPTION
Config options 'no-err' and 'no-autoerrinit'
