### PR TITLE
Minor doc fixes for EVP_MAC

### DIFF
--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -111,7 +111,7 @@ This functions takes variable arguments, the exact expected arguments
 depend on C<cmd>.
 EVP_MAC_ctrl() can be called both before and after EVP_MAC_init(), but
 the effect will depend on what control is being use.
-See </CONTROLS> below for a description of standard controls.
+See L</CONTROLS> below for a description of standard controls.
 
 EVP_MAC_vctrl() is the variant of EVP_MAC_ctrl() that takes a
 C<va_list> argument instead of variadic arguments.

--- a/doc/man7/EVP_MAC_HMAC.pod
+++ b/doc/man7/EVP_MAC_HMAC.pod
@@ -49,7 +49,7 @@ There are no corresponding string control types.
 
 These work as described in L<EVP_MAC(3)/CONTROLS>.
 
-EVP_MAC_ctrl_str() type string for B<EVP_MAC_CTRL_SET_DIGEST>: "digest"
+EVP_MAC_ctrl_str() type string for B<EVP_MAC_CTRL_SET_MD>: "digest"
 
 The value is expected to be the name of a cipher.
 


### PR DESCRIPTION
Missing "L" for a link and fixed a ctrl name.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
