### PR TITLE
OpenSSL 1.1.1a: Fixing static inline issue with SunCC

### DIFF
--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -209,6 +209,31 @@ DEFINE_LHASH_OF(OPENSSL_CSTRING);
 # ifdef _MSC_VER
 #  pragma warning (pop)
 # endif
+
+/*
+ * If called without higher optimization (min. -xO3) the Oracle Developer
+ * Studio compiler generates code for the defined (static inline) functions
+ * above.
+ * This would later lead to the linker complaining about missing symbols when
+ * this header file is included but the resulting object is not linked against
+ * the Crypto library (openssl#6912).
+ */
+# ifdef __SUNPRO_C
+#  pragma weak OPENSSL_LH_new
+#  pragma weak OPENSSL_LH_free
+#  pragma weak OPENSSL_LH_insert
+#  pragma weak OPENSSL_LH_delete
+#  pragma weak OPENSSL_LH_retrieve
+#  pragma weak OPENSSL_LH_error
+#  pragma weak OPENSSL_LH_num_items
+#  pragma weak OPENSSL_LH_node_stats_bio
+#  pragma weak OPENSSL_LH_node_usage_stats_bio
+#  pragma weak OPENSSL_LH_stats_bio
+#  pragma weak OPENSSL_LH_get_down_load
+#  pragma weak OPENSSL_LH_set_down_load
+#  pragma weak OPENSSL_LH_doall
+#  pragma weak OPENSSL_LH_doall_arg
+# endif /* __SUNPRO_C */
 
 #ifdef  __cplusplus
 }

--- a/include/openssl/safestack.h
+++ b/include/openssl/safestack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2017 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -165,6 +165,40 @@ DEFINE_SPECIAL_STACK_OF_CONST(OPENSSL_CSTRING, char)
  */
 typedef void *OPENSSL_BLOCK;
 DEFINE_SPECIAL_STACK_OF(OPENSSL_BLOCK, void)
+
+/*
+ * If called without higher optimization the Oracle Developer Studio compiler
+ * generates code for the defined (inline) functions above. This would later
+ * lead to the linker complaining about missing symbols when this header
+ * file is included but the resulting object is not linked against the
+ * Crypto library (openssl#6912).
+ */
+#ifdef __SUNPRO_C
+# pragma weak OPENSSL_sk_num
+# pragma weak OPENSSL_sk_value
+# pragma weak OPENSSL_sk_new
+# pragma weak OPENSSL_sk_new_null
+# pragma weak OPENSSL_sk_new_reserve
+# pragma weak OPENSSL_sk_reserve
+# pragma weak OPENSSL_sk_free
+# pragma weak OPENSSL_sk_zero
+# pragma weak OPENSSL_sk_delete
+# pragma weak OPENSSL_sk_delete_ptr
+# pragma weak OPENSSL_sk_push
+# pragma weak OPENSSL_sk_unshift
+# pragma weak OPENSSL_sk_pop
+# pragma weak OPENSSL_sk_shift
+# pragma weak OPENSSL_sk_pop_free
+# pragma weak OPENSSL_sk_insert
+# pragma weak OPENSSL_sk_set
+# pragma weak OPENSSL_sk_find
+# pragma weak OPENSSL_sk_find_ex
+# pragma weak OPENSSL_sk_sort
+# pragma weak OPENSSL_sk_is_sorted
+# pragma weak OPENSSL_sk_dup
+# pragma weak OPENSSL_sk_deep_copy
+# pragma weak OPENSSL_sk_set_cmp_func
+#endif /* __SUNPRO_C */
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/safestack.h
+++ b/include/openssl/safestack.h
@@ -167,38 +167,39 @@ typedef void *OPENSSL_BLOCK;
 DEFINE_SPECIAL_STACK_OF(OPENSSL_BLOCK, void)
 
 /*
- * If called without higher optimization the Oracle Developer Studio compiler
- * generates code for the defined (inline) functions above. This would later
- * lead to the linker complaining about missing symbols when this header
- * file is included but the resulting object is not linked against the
- * Crypto library (openssl#6912).
+ * If called without higher optimization (min. -xO3) the Oracle Developer
+ * Studio compiler generates code for the defined (static inline) functions
+ * above.
+ * This would later lead to the linker complaining about missing symbols when
+ * this header file is included but the resulting object is not linked against
+ * the Crypto library (openssl#6912).
  */
-#ifdef __SUNPRO_C
-# pragma weak OPENSSL_sk_num
-# pragma weak OPENSSL_sk_value
-# pragma weak OPENSSL_sk_new
-# pragma weak OPENSSL_sk_new_null
-# pragma weak OPENSSL_sk_new_reserve
-# pragma weak OPENSSL_sk_reserve
-# pragma weak OPENSSL_sk_free
-# pragma weak OPENSSL_sk_zero
-# pragma weak OPENSSL_sk_delete
-# pragma weak OPENSSL_sk_delete_ptr
-# pragma weak OPENSSL_sk_push
-# pragma weak OPENSSL_sk_unshift
-# pragma weak OPENSSL_sk_pop
-# pragma weak OPENSSL_sk_shift
-# pragma weak OPENSSL_sk_pop_free
-# pragma weak OPENSSL_sk_insert
-# pragma weak OPENSSL_sk_set
-# pragma weak OPENSSL_sk_find
-# pragma weak OPENSSL_sk_find_ex
-# pragma weak OPENSSL_sk_sort
-# pragma weak OPENSSL_sk_is_sorted
-# pragma weak OPENSSL_sk_dup
-# pragma weak OPENSSL_sk_deep_copy
-# pragma weak OPENSSL_sk_set_cmp_func
-#endif /* __SUNPRO_C */
+# ifdef __SUNPRO_C
+#  pragma weak OPENSSL_sk_num
+#  pragma weak OPENSSL_sk_value
+#  pragma weak OPENSSL_sk_new
+#  pragma weak OPENSSL_sk_new_null
+#  pragma weak OPENSSL_sk_new_reserve
+#  pragma weak OPENSSL_sk_reserve
+#  pragma weak OPENSSL_sk_free
+#  pragma weak OPENSSL_sk_zero
+#  pragma weak OPENSSL_sk_delete
+#  pragma weak OPENSSL_sk_delete_ptr
+#  pragma weak OPENSSL_sk_push
+#  pragma weak OPENSSL_sk_unshift
+#  pragma weak OPENSSL_sk_pop
+#  pragma weak OPENSSL_sk_shift
+#  pragma weak OPENSSL_sk_pop_free
+#  pragma weak OPENSSL_sk_insert
+#  pragma weak OPENSSL_sk_set
+#  pragma weak OPENSSL_sk_find
+#  pragma weak OPENSSL_sk_find_ex
+#  pragma weak OPENSSL_sk_sort
+#  pragma weak OPENSSL_sk_is_sorted
+#  pragma weak OPENSSL_sk_dup
+#  pragma weak OPENSSL_sk_deep_copy
+#  pragma weak OPENSSL_sk_set_cmp_func
+# endif /* __SUNPRO_C */
 
 # ifdef  __cplusplus
 }

--- a/test/rsa_complex.c
+++ b/test/rsa_complex.c
@@ -20,33 +20,6 @@
 #include <openssl/rsa.h>
 #include <stdlib.h>
 
-#ifdef __SUNPRO_C
-# pragma weak OPENSSL_sk_pop_free
-# pragma weak OPENSSL_sk_dup
-# pragma weak OPENSSL_sk_pop
-# pragma weak OPENSSL_sk_num
-# pragma weak OPENSSL_sk_new
-# pragma weak OPENSSL_sk_set
-# pragma weak OPENSSL_sk_free
-# pragma weak OPENSSL_sk_find
-# pragma weak OPENSSL_sk_push
-# pragma weak OPENSSL_sk_sort
-# pragma weak OPENSSL_sk_zero
-# pragma weak OPENSSL_sk_is_sorted
-# pragma weak OPENSSL_sk_shift
-# pragma weak OPENSSL_sk_value
-# pragma weak OPENSSL_sk_delete_ptr
-# pragma weak OPENSSL_sk_unshift
-# pragma weak OPENSSL_sk_new_null
-# pragma weak OPENSSL_sk_set_cmp_func
-# pragma weak OPENSSL_sk_delete
-# pragma weak OPENSSL_sk_insert
-# pragma weak OPENSSL_sk_deep_copy
-# pragma weak OPENSSL_sk_find_ex
-# pragma weak OPENSSL_sk_reserve
-# pragma weak OPENSSL_sk_new_reserve
-#endif /* __SUNPRO_C */
-
 int main(int argc, char *argv[])
 {
     /* There are explicitly no run time checks for this one */

--- a/test/rsa_complex.c
+++ b/test/rsa_complex.c
@@ -20,6 +20,33 @@
 #include <openssl/rsa.h>
 #include <stdlib.h>
 
+#ifdef __SUNPRO_C
+# pragma weak OPENSSL_sk_pop_free
+# pragma weak OPENSSL_sk_dup
+# pragma weak OPENSSL_sk_pop
+# pragma weak OPENSSL_sk_num
+# pragma weak OPENSSL_sk_new
+# pragma weak OPENSSL_sk_set
+# pragma weak OPENSSL_sk_free
+# pragma weak OPENSSL_sk_find
+# pragma weak OPENSSL_sk_push
+# pragma weak OPENSSL_sk_sort
+# pragma weak OPENSSL_sk_zero
+# pragma weak OPENSSL_sk_is_sorted
+# pragma weak OPENSSL_sk_shift
+# pragma weak OPENSSL_sk_value
+# pragma weak OPENSSL_sk_delete_ptr
+# pragma weak OPENSSL_sk_unshift
+# pragma weak OPENSSL_sk_new_null
+# pragma weak OPENSSL_sk_set_cmp_func
+# pragma weak OPENSSL_sk_delete
+# pragma weak OPENSSL_sk_insert
+# pragma weak OPENSSL_sk_deep_copy
+# pragma weak OPENSSL_sk_find_ex
+# pragma weak OPENSSL_sk_reserve
+# pragma weak OPENSSL_sk_new_reserve
+#endif /* __SUNPRO_C */
+
 int main(int argc, char *argv[])
 {
     /* There are explicitly no run time checks for this one */


### PR DESCRIPTION
Work around a failing 'make test' with Oracle Developer Studio 12.5 and a configured OpenSSL debug build. Marks all mentioned symbols as weak.
Partly fixes openssl#6912.