### PR TITLE
Fix usage of deprecated SSL_set_tmp_ecdh()

### DIFF
--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -225,7 +225,6 @@ static int cmd_Curves(SSL_CONF_CTX *cctx, const char *value)
 static int cmd_ECDHParameters(SSL_CONF_CTX *cctx, const char *value)
 {
     int rv = 1;
-    EC_KEY *ecdh;
     int nid;
 
     /* Ignore values supported by 1.0.2 for the automatic selection */
@@ -242,14 +241,11 @@ static int cmd_ECDHParameters(SSL_CONF_CTX *cctx, const char *value)
         nid = OBJ_sn2nid(value);
     if (nid == 0)
         return 0;
-    ecdh = EC_KEY_new_by_curve_name(nid);
-    if (!ecdh)
-        return 0;
+
     if (cctx->ctx)
-        rv = SSL_CTX_set_tmp_ecdh(cctx->ctx, ecdh);
+        rv = SSL_CTX_set1_groups(cctx->ctx, &nid, 1);
     else if (cctx->ssl)
-        rv = SSL_set_tmp_ecdh(cctx->ssl, ecdh);
-    EC_KEY_free(ecdh);
+        rv = SSL_set1_groups(cctx->ssl, &nid, 1);
 
     return rv > 0;
 }


### PR DESCRIPTION
This fixes an oversight in #7522 where functions marked as deprecated were not replaced in `ssl_conf`.

Signed-off-by: Antoine Salon <asalon@vmware.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

