### PR TITLE
Docs: better deprecation text

### DIFF
--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -34,7 +34,7 @@ for primality
  void *BN_GENCB_get_arg(BN_GENCB *cb);
 
 Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  BIGNUM *BN_generate_prime(BIGNUM *ret, int num, int safe, BIGNUM *add,
                            BIGNUM *rem, void (*callback)(int, int, void *),

--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -33,9 +33,9 @@ for primality
 
  void *BN_GENCB_get_arg(BN_GENCB *cb);
 
-Deprecated:
+Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x00908000L
  BIGNUM *BN_generate_prime(BIGNUM *ret, int num, int safe, BIGNUM *add,
                            BIGNUM *rem, void (*callback)(int, int, void *),
                            void *cb_arg);
@@ -46,7 +46,6 @@ Deprecated:
  int BN_is_prime_fasttest(const BIGNUM *a, int checks,
                           void (*callback)(int, int, void *), BN_CTX *ctx,
                           void *cb_arg, int do_trial_division);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/CONF_modules_free.pod
+++ b/doc/man3/CONF_modules_free.pod
@@ -12,11 +12,10 @@ OpenSSL configuration cleanup functions
  void CONF_modules_finish(void);
  void CONF_modules_unload(int all);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  void CONF_modules_free(void)
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/CONF_modules_free.pod
+++ b/doc/man3/CONF_modules_free.pod
@@ -13,7 +13,7 @@ OpenSSL configuration cleanup functions
  void CONF_modules_unload(int all);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void CONF_modules_free(void)
 

--- a/doc/man3/DH_generate_parameters.pod
+++ b/doc/man3/DH_generate_parameters.pod
@@ -22,7 +22,7 @@ parameters
  int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key);
 
 Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  DH *DH_generate_parameters(int prime_len, int generator,
                             void (*callback)(int, int, void *), void *cb_arg);

--- a/doc/man3/DH_generate_parameters.pod
+++ b/doc/man3/DH_generate_parameters.pod
@@ -21,12 +21,11 @@ parameters
  int DH_check_params_ex(const DH *dh);
  int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key);
 
-Deprecated:
+Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x00908000L
  DH *DH_generate_parameters(int prime_len, int generator,
                             void (*callback)(int, int, void *), void *cb_arg);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/DSA_generate_parameters.pod
+++ b/doc/man3/DSA_generate_parameters.pod
@@ -13,13 +13,12 @@ DSA_generate_parameters_ex, DSA_generate_parameters - generate DSA parameters
                                 int *counter_ret, unsigned long *h_ret,
                                 BN_GENCB *cb);
 
-Deprecated:
+Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x00908000L
  DSA *DSA_generate_parameters(int bits, unsigned char *seed, int seed_len,
                               int *counter_ret, unsigned long *h_ret,
                               void (*callback)(int, int, void *), void *cb_arg);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/DSA_generate_parameters.pod
+++ b/doc/man3/DSA_generate_parameters.pod
@@ -14,7 +14,7 @@ DSA_generate_parameters_ex, DSA_generate_parameters - generate DSA parameters
                                 BN_GENCB *cb);
 
 Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  DSA *DSA_generate_parameters(int bits, unsigned char *seed, int seed_len,
                               int *counter_ret, unsigned long *h_ret,

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -154,11 +154,10 @@ ENGINE_unregister_digests
  EVP_PKEY *ENGINE_load_public_key(ENGINE *e, const char *key_id,
                                   UI_METHOD *ui_method, void *callback_data);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  void ENGINE_cleanup(void)
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -155,7 +155,7 @@ ENGINE_unregister_digests
                                   UI_METHOD *ui_method, void *callback_data);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void ENGINE_cleanup(void)
 

--- a/doc/man3/ERR_load_crypto_strings.pod
+++ b/doc/man3/ERR_load_crypto_strings.pod
@@ -8,7 +8,7 @@ load and free error strings
 =head1 SYNOPSIS
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  #include <openssl/err.h>
 

--- a/doc/man3/ERR_load_crypto_strings.pod
+++ b/doc/man3/ERR_load_crypto_strings.pod
@@ -7,20 +7,17 @@ load and free error strings
 
 =head1 SYNOPSIS
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
  #include <openssl/err.h>
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  void ERR_load_crypto_strings(void);
  void ERR_free_strings(void);
- #endif
 
  #include <openssl/ssl.h>
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  void SSL_load_error_strings(void);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/ERR_remove_state.pod
+++ b/doc/man3/ERR_remove_state.pod
@@ -7,12 +7,12 @@ ERR_remove_thread_state, ERR_remove_state - DEPRECATED
 =head1 SYNOPSIS
 
 Deprecated since OpenSSL 1.0.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void ERR_remove_state(unsigned long tid);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void ERR_remove_thread_state(void *tid);
 

--- a/doc/man3/ERR_remove_state.pod
+++ b/doc/man3/ERR_remove_state.pod
@@ -6,15 +6,15 @@ ERR_remove_thread_state, ERR_remove_state - DEPRECATED
 
 =head1 SYNOPSIS
 
-Deprecated:
+Deprecated since OpenSSL 1.0.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10000000L
  void ERR_remove_state(unsigned long tid);
- #endif
 
- #if OPENSSL_API_COMPAT < 0x10100000L
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+
  void ERR_remove_thread_state(void *tid);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -41,7 +41,7 @@ HMAC_size
  size_t HMAC_size(const HMAC_CTX *e);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  int HMAC_Init(HMAC_CTX *ctx, const void *key, int key_len,
                const EVP_MD *md);

--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -40,12 +40,11 @@ HMAC_size
 
  size_t HMAC_size(const HMAC_CTX *e);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  int HMAC_Init(HMAC_CTX *ctx, const void *key, int key_len,
                const EVP_MD *md);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -35,11 +35,10 @@ OBJ_dup, OBJ_txt2obj, OBJ_obj2txt, OBJ_create, OBJ_cleanup
  size_t OBJ_length(const ASN1_OBJECT *obj);
  const unsigned char *OBJ_get0_data(const ASN1_OBJECT *obj);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  void OBJ_cleanup(void)
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -36,7 +36,7 @@ OBJ_dup, OBJ_txt2obj, OBJ_obj2txt, OBJ_create, OBJ_cleanup
  const unsigned char *OBJ_get0_data(const ASN1_OBJECT *obj);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void OBJ_cleanup(void)
 

--- a/doc/man3/OpenSSL_add_all_algorithms.pod
+++ b/doc/man3/OpenSSL_add_all_algorithms.pod
@@ -9,15 +9,14 @@ add algorithms to internal table
 
  #include <openssl/evp.h>
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- # if OPENSSL_API_COMPAT < 0x10100000L
  void OpenSSL_add_all_algorithms(void);
  void OpenSSL_add_all_ciphers(void);
  void OpenSSL_add_all_digests(void);
 
  void EVP_cleanup(void)
-# endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OpenSSL_add_all_algorithms.pod
+++ b/doc/man3/OpenSSL_add_all_algorithms.pod
@@ -10,7 +10,7 @@ add algorithms to internal table
  #include <openssl/evp.h>
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void OpenSSL_add_all_algorithms(void);
  void OpenSSL_add_all_ciphers(void);

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -18,12 +18,11 @@ RAND_keep_random_devices_open
 
  void RAND_keep_random_devices_open(int keep);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  int RAND_event(UINT iMsg, WPARAM wParam, LPARAM lParam);
  void RAND_screen(void);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -19,7 +19,7 @@ RAND_keep_random_devices_open
  void RAND_keep_random_devices_open(int keep);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  int RAND_event(UINT iMsg, WPARAM wParam, LPARAM lParam);
  void RAND_screen(void);

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -11,11 +11,10 @@ RAND_bytes, RAND_priv_bytes, RAND_pseudo_bytes - generate random data
  int RAND_bytes(unsigned char *buf, int num);
  int RAND_priv_bytes(unsigned char *buf, int num);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  int RAND_pseudo_bytes(unsigned char *buf, int num);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -12,7 +12,7 @@ RAND_bytes, RAND_priv_bytes, RAND_pseudo_bytes - generate random data
  int RAND_priv_bytes(unsigned char *buf, int num);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  int RAND_pseudo_bytes(unsigned char *buf, int num);
 

--- a/doc/man3/RSA_generate_key.pod
+++ b/doc/man3/RSA_generate_key.pod
@@ -13,7 +13,7 @@ RSA_generate_multi_prime_key - generate RSA key pair
  int RSA_generate_multi_prime_key(RSA *rsa, int bits, int primes, BIGNUM *e, BN_GENCB *cb);
 
 Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  RSA *RSA_generate_key(int num, unsigned long e,
                        void (*callback)(int, int, void *), void *cb_arg);

--- a/doc/man3/RSA_generate_key.pod
+++ b/doc/man3/RSA_generate_key.pod
@@ -12,12 +12,11 @@ RSA_generate_multi_prime_key - generate RSA key pair
  int RSA_generate_key_ex(RSA *rsa, int bits, BIGNUM *e, BN_GENCB *cb);
  int RSA_generate_multi_prime_key(RSA *rsa, int bits, int primes, BIGNUM *e, BN_GENCB *cb);
 
-Deprecated:
+Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x00908000L
  RSA *RSA_generate_key(int num, unsigned long e,
                        void (*callback)(int, int, void *), void *cb_arg);
- #endif
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -16,7 +16,7 @@ SSL_COMP_get0_name, SSL_COMP_get_id, SSL_COMP_free_compression_methods
  int SSL_COMP_get_id(const SSL_COMP *comp);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
+B<OPENSSL_API_COMPAT> with a version value, see L<openssl_user_macros(7)>:
 
  void SSL_COMP_free_compression_methods(void)
 

--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -15,11 +15,10 @@ SSL_COMP_get0_name, SSL_COMP_get_id, SSL_COMP_free_compression_methods
  const char *SSL_COMP_get0_name(const SSL_COMP *comp);
  int SSL_COMP_get_id(const SSL_COMP *comp);
 
-Deprecated:
+Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT>, see L<openssl_user_macros(7)>:
 
- #if OPENSSL_API_COMPAT < 0x10100000L
  void SSL_COMP_free_compression_methods(void)
- #endif
 
 =head1 DESCRIPTION
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -96,6 +96,7 @@ sub name_synopsis()
     return unless $contents =~ /=head1 SYNOPSIS(.*)=head1 DESCRIPTION/ms;
     my $syn = $1;
     foreach my $line ( split /\n+/, $syn ) {
+        next unless $line =~ /^\s/;
         my $sym;
         $line =~ s/STACK_OF\([^)]+\)/int/g;
         $line =~ s/__declspec\([^)]+\)//;


### PR DESCRIPTION
Expand the text on deprecation to be more descriptive and to refer
back to openssl_user_macros(7).

Incidently, this required a small change in util/find-doc-nits, to
have it skip over any line that isn't part of a block (i.e. that
hasn't been indented with at least one space.  That makes it skip over
deprecation text.
