### PR TITLE
Remove the cast from the definition of OPENSSL_VERSION_NUMBER

### DIFF
--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -11,13 +11,16 @@
 
 #include <openssl/opensslv.h>
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
+#ifndef HEADER_OPENSSLCONF_H
+# define HEADER_OPENSSLCONF_H
 
-#ifdef OPENSSL_ALGORITHM_DEFINES
-# error OPENSSL_ALGORITHM_DEFINES no longer supported
-#endif
+# ifdef  __cplusplus
+extern "C" {
+# endif
+
+# ifdef OPENSSL_ALGORITHM_DEFINES
+#  error OPENSSL_ALGORITHM_DEFINES no longer supported
+# endif
 
 /*
  * OpenSSL was configured with the following options:
@@ -25,20 +28,20 @@ extern "C" {
 
 {- if (@{$config{openssl_sys_defines}}) {
       foreach (@{$config{openssl_sys_defines}}) {
-	$OUT .= "#ifndef $_\n";
-	$OUT .= "# define $_ 1\n";
-	$OUT .= "#endif\n";
+	$OUT .= "# ifndef $_\n";
+	$OUT .= "#  define $_ 1\n";
+	$OUT .= "# endif\n";
       }
     }
     foreach (@{$config{openssl_api_defines}}) {
         (my $macro, my $value) = $_ =~ /^(.*?)=(.*?)$/;
-        $OUT .= "#define $macro $value\n";
+        $OUT .= "# define $macro $value\n";
     }
     if (@{$config{openssl_feature_defines}}) {
       foreach (@{$config{openssl_feature_defines}}) {
-	$OUT .= "#ifndef $_\n";
-	$OUT .= "# define $_\n";
-	$OUT .= "#endif\n";
+	$OUT .= "# ifndef $_\n";
+	$OUT .= "#  define $_\n";
+	$OUT .= "# endif\n";
       }
     }
     "";
@@ -48,7 +51,7 @@ extern "C" {
  * Sometimes OPENSSSL_NO_xxx ends up with an empty file and some compilers
  * don't like that.  This will hopefully silence them.
  */
-#define NON_EMPTY_TRANSLATION_UNIT static void *dummy = &dummy;
+# define NON_EMPTY_TRANSLATION_UNIT static void *dummy = &dummy;
 
 /*
  * Applications should use -DOPENSSL_API_COMPAT=<version> to suppress the
@@ -60,15 +63,15 @@ extern "C" {
  * on, <version> is expected to be only the major version number (i.e. 3 for
  * version 3.0.0).
  */
-#ifndef DECLARE_DEPRECATED
-# define DECLARE_DEPRECATED(f)   f;
-# ifdef __GNUC__
-#  if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-#   undef DECLARE_DEPRECATED
-#   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+# ifndef DECLARE_DEPRECATED
+#  define DECLARE_DEPRECATED(f)   f;
+#  ifdef __GNUC__
+#   if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#    undef DECLARE_DEPRECATED
+#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#   endif
 #  endif
 # endif
-#endif
 
 /*
  * We convert the OPENSSL_API_COMPAT value to an API level.  The API level
@@ -81,105 +84,106 @@ extern "C" {
  */
 
 /* In case someone defined both */
-#if defined(OPENSSL_API_COMPAT) && defined(OPENSSL_API_LEVEL)
-# error "Disallowed to defined both OPENSSL_API_COMPAT and OPENSSL_API_LEVEL"
-#endif
-
-#ifndef OPENSSL_API_COMPAT
-# define OPENSSL_API_LEVEL OPENSSL_MIN_API
-#else
-# if (OPENSSL_API_COMPAT < 0x1000L) /* Major version numbers up to 16777215 */
-#  define OPENSSL_API_LEVEL OPENSSL_API_COMPAT
-# elif (OPENSSL_API_COMPAT & 0xF0000000L) == 0x00000000L
-#  define OPENSSL_API_LEVEL 0
-# elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10000000L
-#  define OPENSSL_API_LEVEL 1
-# elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10100000L
-#  define OPENSSL_API_LEVEL 2
-# else
-/ * Major number 3 to 15 */
-#  define OPENSSL_API_LEVEL ((OPENSSL_API_COMPAT >> 28) & 0xF)
+# if defined(OPENSSL_API_COMPAT) && defined(OPENSSL_API_LEVEL)
+#  error "Disallowed to defined both OPENSSL_API_COMPAT and OPENSSL_API_LEVEL"
 # endif
-#endif
+
+# ifndef OPENSSL_API_COMPAT
+#  define OPENSSL_API_LEVEL OPENSSL_MIN_API
+# else
+#  if (OPENSSL_API_COMPAT < 0x1000L) /* Major version numbers up to 16777215 */
+#   define OPENSSL_API_LEVEL OPENSSL_API_COMPAT
+#  elif (OPENSSL_API_COMPAT & 0xF0000000L) == 0x00000000L
+#   define OPENSSL_API_LEVEL 0
+#  elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10000000L
+#   define OPENSSL_API_LEVEL 1
+#  elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10100000L
+#   define OPENSSL_API_LEVEL 2
+#  else
+/ * Major number 3 to 15 */
+#   define OPENSSL_API_LEVEL ((OPENSSL_API_COMPAT >> 28) & 0xF)
+#  endif
+# endif
 
 /*
  * Do not deprecate things to be deprecated in version 4.0 before the
  * OpenSSL version number matches.
  */
-#if OPENSSL_VERSION_MAJOR < 4
-# define DEPRECATEDIN_4(f)       f;
-# define OPENSSL_API_4 0
-#elif OPENSSL_API_LEVEL < 4
-# define DEPRECATEDIN_4(f)       DECLARE_DEPRECATED(f)
-# define OPENSSL_API_4 0
-#else
-# define DEPRECATEDIN_4(f)
-# define OPENSSL_API_4 1
-#endif
-
-#if OPENSSL_API_LEVEL < 3
-# define DEPRECATEDIN_3(f)       DECLARE_DEPRECATED(f)
-# define OPENSSL_API_3 0
-#else
-# define DEPRECATEDIN_3(f)
-# define OPENSSL_API_3 1
-#endif
-
-#if OPENSSL_API_LEVEL < 2
-# define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
-# define OPENSSL_API_1_1_0 0
-#else
-# define DEPRECATEDIN_1_1_0(f)
-# define OPENSSL_API_1_1_0 1
-#endif
-
-#if OPENSSL_API_LEVEL < 1
-# define DEPRECATEDIN_1_0_0(f)   DECLARE_DEPRECATED(f)
-# define OPENSSL_API_1_0_0 0
-#else
-# define DEPRECATEDIN_1_0_0(f)
-# define OPENSSL_API_1_0_0 1
-#endif
-
-#if OPENSSL_API_LEVEL < 0
-# define DEPRECATEDIN_0_9_8(f)   DECLARE_DEPRECATED(f)
-# define OPENSSL_API_0_9_8 0
-#else
-# define DEPRECATEDIN_0_9_8(f)
-# define OPENSSL_API_0_9_8 1
-#endif
-
-#ifndef OPENSSL_FILE
-# ifdef OPENSSL_NO_FILENAMES
-#  define OPENSSL_FILE ""
-#  define OPENSSL_LINE 0
+# if OPENSSL_VERSION_MAJOR < 4
+#  define DEPRECATEDIN_4(f)       f;
+#  define OPENSSL_API_4 0
+# elif OPENSSL_API_LEVEL < 4
+#  define DEPRECATEDIN_4(f)       DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_4 0
 # else
-#  define OPENSSL_FILE __FILE__
-#  define OPENSSL_LINE __LINE__
+#  define DEPRECATEDIN_4(f)
+#  define OPENSSL_API_4 1
 # endif
-#endif
+
+# if OPENSSL_API_LEVEL < 3
+#  define DEPRECATEDIN_3(f)       DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_3 0
+# else
+#  define DEPRECATEDIN_3(f)
+#  define OPENSSL_API_3 1
+# endif
+
+# if OPENSSL_API_LEVEL < 2
+#  define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_1_1_0 0
+# else
+#  define DEPRECATEDIN_1_1_0(f)
+#  define OPENSSL_API_1_1_0 1
+# endif
+
+# if OPENSSL_API_LEVEL < 1
+#  define DEPRECATEDIN_1_0_0(f)   DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_1_0_0 0
+# else
+#  define DEPRECATEDIN_1_0_0(f)
+#  define OPENSSL_API_1_0_0 1
+# endif
+
+# if OPENSSL_API_LEVEL < 0
+#  define DEPRECATEDIN_0_9_8(f)   DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_0_9_8 0
+# else
+#  define DEPRECATEDIN_0_9_8(f)
+#  define OPENSSL_API_0_9_8 1
+# endif
+
+# ifndef OPENSSL_FILE
+#  ifdef OPENSSL_NO_FILENAMES
+#   define OPENSSL_FILE ""
+#   define OPENSSL_LINE 0
+#  else
+#   define OPENSSL_FILE __FILE__
+#   define OPENSSL_LINE __LINE__
+#  endif
+# endif
 
 /* Generate 80386 code? */
-{- $config{processor} eq "386" ? "#define" : "#undef" -} I386_ONLY
+{- $config{processor} eq "386" ? "# define" : "# undef" -} I386_ONLY
 
-#undef OPENSSL_UNISTD
-#define OPENSSL_UNISTD {- $target{unistd} -}
+# undef OPENSSL_UNISTD
+# define OPENSSL_UNISTD {- $target{unistd} -}
 
-{- $config{export_var_as_fn} ? "#define" : "#undef" -} OPENSSL_EXPORT_VAR_AS_FUNCTION
+{- $config{export_var_as_fn} ? "# define" : "# undef" -} OPENSSL_EXPORT_VAR_AS_FUNCTION
 
 /*
  * The following are cipher-specific, but are part of the public API.
  */
-#if !defined(OPENSSL_SYS_UEFI)
-{- $config{bn_ll} ? "# define" : "# undef" -} BN_LLONG
+# if !defined(OPENSSL_SYS_UEFI)
+{- $config{bn_ll} ? "#  define" : "#  undef" -} BN_LLONG
 /* Only one for the following should be defined */
-{- $config{b64l} ? "# define" : "# undef" -} SIXTY_FOUR_BIT_LONG
-{- $config{b64}  ? "# define" : "# undef" -} SIXTY_FOUR_BIT
-{- $config{b32}  ? "# define" : "# undef" -} THIRTY_TWO_BIT
-#endif
+{- $config{b64l} ? "#  define" : "#  undef" -} SIXTY_FOUR_BIT_LONG
+{- $config{b64}  ? "#  define" : "#  undef" -} SIXTY_FOUR_BIT
+{- $config{b32}  ? "#  define" : "#  undef" -} THIRTY_TWO_BIT
+# endif
 
-#define RC4_INT {- $config{rc4_int} -}
+# define RC4_INT {- $config{rc4_int} -}
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 }
-#endif
+# endif
+#endif                          /* HEADER_OPENSSLCONF_H */

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -131,7 +131,7 @@ const char *OPENSSL_version_build_metadata(void);
 #   define _OPENSSL_VERSION_PRE_RELEASE 0xf
 #  endif
 #  define OPENSSL_VERSION_NUMBER        \
-    (long)( (OPENSSL_VERSION_MAJOR<<28)  \
+          ( (OPENSSL_VERSION_MAJOR<<28)  \
             |(OPENSSL_VERSION_MINOR<<20) \
             |(OPENSSL_VERSION_PATCH<<4)  \
             |_OPENSSL_VERSION_PRE_RELEASE )


### PR DESCRIPTION
If a cast is included in the definition it cannot be used in preprocessor
expressions, e.g. "#if OPENSSL_VERSION_NUMBER > 0x10000000L"

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
