### PR TITLE
Configure: fix the version string in the configure output

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -104,7 +104,7 @@ BLDDIR={- $config{builddir} -}
 # to testing.
 VERBOSE=$(V)
 
-VERSION={- "$config{major}.$config{minor}.$config{patch}$config{prerelease}$config{build_metadata}" -}
+VERSION={- "$config{full_version}" -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -88,7 +88,7 @@ CONFIGURE_ARGS=({- join(", ",quotify_l(@{$config{perlargv}})) -})
 SRCDIR={- $config{sourcedir} -}
 BLDDIR={- $config{builddir} -}
 
-VERSION={- "$config{major}.$config{minor}.$config{patch}$config{prerelease}$config{build_metadata}" -}
+VERSION={- "$config{full_version}" -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -71,7 +71,7 @@ PLATFORM={- $config{target} -}
 SRCDIR={- $config{sourcedir} -}
 BLDDIR={- $config{builddir} -}
 
-VERSION={- "$config{major}.$config{minor}.$config{patch}$config{prerelease}$config{build_metadata}" -}
+VERSION={- "$config{full_version}" -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 

--- a/Configure
+++ b/Configure
@@ -1000,8 +1000,8 @@ if ($target eq "HASH") {
     exit 0;
 }
 
-print "Configuring OpenSSL version '$config{full_version}' ";
-print "for target '$target'\n";
+print "Configuring OpenSSL version $config{full_version} ";
+print "for target $target\n";
 
 if (scalar(@seed_sources) == 0) {
     print "Using os-specific seed configuration\n";

--- a/Configure
+++ b/Configure
@@ -276,6 +276,9 @@ die "erroneous version information in opensslv.h: ",
             || $config{patch} eq "unknown"
             || $config{shlib_version} eq "unknown");
 
+$config{version} = "$config{major}.$config{minor}.$config{patch}";
+$config{full_version} = "$config{version}$config{prerelease}$config{build_metadata}";
+
 # Collect target configurations
 
 my $pattern = catfile(dirname($0), "Configurations", "*.conf");
@@ -997,8 +1000,8 @@ if ($target eq "HASH") {
     exit 0;
 }
 
-print "Configuring OpenSSL version $config{version} ($config{version_num}) ";
-print "for $target\n";
+print "Configuring OpenSSL version '$config{full_version}' ";
+print "for target '$target'\n";
 
 if (scalar(@seed_sources) == 0) {
     print "Using os-specific seed configuration\n";


### PR DESCRIPTION
Since `$config{version}` and  `$config{version_num}` were removed in commit 3a63dbef15b6, the configure output displays an empty version number string in parentheses instead of the version number.

This pull request fixes that by adding new config variables `version` and `full_version`, analogous to `OPENSSL_VERSION_STR` and `OPENSSL_FULL_VERSION_STR`.


**Before**

```
~/src/openssl$ perl Configure debug-linux-x86_64
Configuring OpenSSL version  () for debug-linux-x86_64
Using os-specific seed configuration
Creating configdata.pm
Creating Makefile
```


**After**

```
~/src/openssl$ perl Configure debug-linux-x86_64
Configuring OpenSSL version '3.0.0-dev' for target 'debug-linux-x86_64'
Using os-specific seed configuration
Creating configdata.pm
Creating Makefile
```
