### PR TITLE
Kernel TLS Receive Side

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3313,6 +3313,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 #ifndef OPENSSL_NO_KTLS
     if (BIO_get_ktls_send(SSL_get_wbio(s)))
         BIO_printf(bio_err, "Using Kernel TLS for sending\n");
+    if (BIO_get_ktls_recv(SSL_get_rbio(s)))
+        BIO_printf(bio_err, "Using Kernel TLS for receiving\n");
 #endif
 
     if (OSSL_TRACE_ENABLED(TLS)) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2921,6 +2921,8 @@ static void print_connection_info(SSL *con)
 #ifndef OPENSSL_NO_KTLS
     if (BIO_get_ktls_send(SSL_get_wbio(con)))
         BIO_printf(bio_err, "Using Kernel TLS for sending\n");
+    if (BIO_get_ktls_recv(SSL_get_rbio(con)))
+        BIO_printf(bio_err, "Using Kernel TLS for receiving\n");
 #endif
 
     (void)BIO_flush(bio_s_out);

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -5,7 +5,8 @@
 BIO_ctrl, BIO_callback_ctrl, BIO_ptr_ctrl, BIO_int_ctrl, BIO_reset,
 BIO_seek, BIO_tell, BIO_flush, BIO_eof, BIO_set_close, BIO_get_close,
 BIO_pending, BIO_wpending, BIO_ctrl_pending, BIO_ctrl_wpending,
-BIO_get_info_callback, BIO_set_info_callback, BIO_info_cb, BIO_get_ktls_send
+BIO_get_info_callback, BIO_set_info_callback, BIO_info_cb, BIO_get_ktls_send,
+BIO_get_ktls_recv
 - BIO control operations
 
 =head1 SYNOPSIS
@@ -35,6 +36,7 @@ BIO_get_info_callback, BIO_set_info_callback, BIO_info_cb, BIO_get_ktls_send
  int BIO_set_info_callback(BIO *b, BIO_info_cb *cb);
 
  int BIO_get_ktls_send(BIO *b);
+ int BIO_get_ktls_recv(BIO *b);
 
 =head1 DESCRIPTION
 
@@ -74,8 +76,10 @@ Not all BIOs support these calls. BIO_ctrl_pending() and BIO_ctrl_wpending()
 return a size_t type and are functions, BIO_pending() and BIO_wpending() are
 macros which call BIO_ctrl().
 
-BIO_get_ktls_send() return 1 if the BIO is using the Kernel TLS data-path for
+BIO_get_ktls_send() returns 1 if the BIO is using the Kernel TLS data-path for
 sending. Otherwise, it returns zero.
+BIO_get_ktls_recv() returns 1 if the BIO is using the Kernel TLS data-path for
+receiving. Otherwise, it returns zero.
 
 =head1 RETURN VALUES
 
@@ -97,8 +101,10 @@ BIO_get_close() returns the close flag value: BIO_CLOSE or BIO_NOCLOSE.
 BIO_pending(), BIO_ctrl_pending(), BIO_wpending() and BIO_ctrl_wpending()
 return the amount of pending data.
 
-BIO_get_ktls_send() return 1 if the BIO is using the Kernel TLS data-path for
+BIO_get_ktls_send() returns 1 if the BIO is using the Kernel TLS data-path for
 sending. Otherwise, it returns zero.
+BIO_get_ktls_recv() returns 1 if the BIO is using the Kernel TLS data-path for
+receiving. Otherwise, it returns zero.
 
 =head1 NOTES
 
@@ -134,7 +140,8 @@ the case of BIO_seek() on a file BIO for a successful operation.
 
 =head1 HISTORY
 
-The BIO_get_ktls_send() function was added in OpenSSL 3.0.0.
+The BIO_get_ktls_send() and BIO_get_ktls_recv() functions were added in
+OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -35,35 +35,38 @@ void bio_cleanup(void);
 int bwrite_conv(BIO *bio, const char *data, size_t datal, size_t *written);
 int bread_conv(BIO *bio, char *data, size_t datal, size_t *read);
 
-# define BIO_CTRL_SET_KTLS_SEND                 72
-# define BIO_CTRL_SET_KTLS_SEND_CTRL_MSG        74
-# define BIO_CTRL_CLEAR_KTLS_CTRL_MSG      75
+/* Changes to these internal BIOs must also update include/openssl/bio.h */
+# define BIO_CTRL_SET_KTLS                      72
+# define BIO_CTRL_SET_KTLS_TX_SEND_CTRL_MSG     74
+# define BIO_CTRL_CLEAR_KTLS_TX_CTRL_MSG        75
 
 /*
  * This is used with socket BIOs:
- * BIO_FLAGS_KTLS means we are using ktls with this BIO.
- * BIO_FLAGS_KTLS_CTRL_MSG means we are about to send a ctrl message next.
+ * BIO_FLAGS_KTLS_TX means we are using ktls with this BIO for sending.
+ * BIO_FLAGS_KTLS_TX_CTRL_MSG means we are about to send a ctrl message next.
+ * BIO_FLAGS_KTLS_RX means we are using ktls with this BIO for receiving.
  */
-# define BIO_FLAGS_KTLS          0x800
-# define BIO_FLAGS_KTLS_CTRL_MSG 0x1000
+# define BIO_FLAGS_KTLS_TX          0x800
+# define BIO_FLAGS_KTLS_TX_CTRL_MSG 0x1000
+# define BIO_FLAGS_KTLS_RX          0x2000
 
 /* KTLS related controls and flags */
-# define BIO_set_ktls_flag(b) \
-    BIO_set_flags(b, BIO_FLAGS_KTLS)
-# define BIO_should_ktls_flag(b) \
-    BIO_test_flags(b, BIO_FLAGS_KTLS)
+# define BIO_set_ktls_flag(b, is_tx) \
+    BIO_set_flags(b, (is_tx) ? BIO_FLAGS_KTLS_TX : BIO_FLAGS_KTLS_RX)
+# define BIO_should_ktls_flag(b, is_tx) \
+    BIO_test_flags(b, (is_tx) ? BIO_FLAGS_KTLS_TX : BIO_FLAGS_KTLS_RX)
 # define BIO_set_ktls_ctrl_msg_flag(b) \
-    BIO_set_flags(b, BIO_FLAGS_KTLS_CTRL_MSG)
+    BIO_set_flags(b, BIO_FLAGS_KTLS_TX_CTRL_MSG)
 # define BIO_should_ktls_ctrl_msg_flag(b) \
-    BIO_test_flags(b, (BIO_FLAGS_KTLS_CTRL_MSG))
+    BIO_test_flags(b, BIO_FLAGS_KTLS_TX_CTRL_MSG)
 # define BIO_clear_ktls_ctrl_msg_flag(b) \
-    BIO_clear_flags(b, (BIO_FLAGS_KTLS_CTRL_MSG))
+    BIO_clear_flags(b, BIO_FLAGS_KTLS_TX_CTRL_MSG)
 
 #  define BIO_set_ktls(b, keyblob, is_tx)   \
-     BIO_ctrl(b, BIO_CTRL_SET_KTLS_SEND, is_tx, keyblob)
+     BIO_ctrl(b, BIO_CTRL_SET_KTLS, is_tx, keyblob)
 #  define BIO_set_ktls_ctrl_msg(b, record_type)   \
-     BIO_ctrl(b, BIO_CTRL_SET_KTLS_SEND_CTRL_MSG, record_type, NULL)
+     BIO_ctrl(b, BIO_CTRL_SET_KTLS_TX_SEND_CTRL_MSG, record_type, NULL)
 #  define BIO_clear_ktls_ctrl_msg(b) \
-     BIO_ctrl(b, BIO_CTRL_CLEAR_KTLS_CTRL_MSG, 0, NULL)
+     BIO_ctrl(b, BIO_CTRL_CLEAR_KTLS_TX_CTRL_MSG, 0, NULL)
 
 #endif

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -21,10 +21,11 @@
 
 #    ifndef PEDANTIC
 #     warning "KTLS requires Kernel Headers >= 4.13.0"
-#     warning "Skipping Compilation of KTLS data path"
+#     warning "Skipping Compilation of KTLS"
 #    endif
 
 #    define TLS_TX                  1
+#    define TLS_RX                  2
 
 #    define TLS_CIPHER_AES_GCM_128                          51
 #    define TLS_CIPHER_AES_GCM_128_IV_SIZE                  8
@@ -67,11 +68,19 @@ static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
     return -1;
 }
 
+static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+{
+    return -1;
+}
+
 #   else                        /* KERNEL_VERSION */
 
 #    include <netinet/tcp.h>
 #    include <linux/tls.h>
 #    include <linux/socket.h>
+#    include "openssl/ssl3.h"
+#    include "openssl/tls1.h"
+#    include "openssl/evp.h"
 
 #    ifndef SOL_TLS
 #     define SOL_TLS 282
@@ -96,16 +105,16 @@ static ossl_inline int ktls_enable(int fd)
  * The TLS_TX socket option changes the send/sendmsg handlers of the TCP socket.
  * If successful, then data sent using this socket will be encrypted and
  * encapsulated in TLS records using the crypto_info provided here.
+ * The TLS_RX socket option changes the recv/recvmsg handlers of the TCP socket.
+ * If successful, then data received using this socket will be decrypted,
+ * authenticated and decapsulated using the crypto_info provided here.
  */
 static ossl_inline int ktls_start(int fd,
                                   struct tls12_crypto_info_aes_gcm_128
                                   *crypto_info, size_t len, int is_tx)
 {
-    if (is_tx)
-        return setsockopt(fd, SOL_TLS, TLS_TX, crypto_info,
-                          sizeof(*crypto_info)) ? 0 : 1;
-    else
-        return 0;
+    return setsockopt(fd, SOL_TLS, is_tx ? TLS_TX : TLS_RX,
+                      crypto_info, sizeof(*crypto_info)) ? 0 : 1;
 }
 
 /*
@@ -121,12 +130,15 @@ static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
     struct msghdr msg;
     int cmsg_len = sizeof(record_type);
     struct cmsghdr *cmsg;
-    char buf[CMSG_SPACE(cmsg_len)];
+    union {
+        struct cmsghdr hdr;
+        char buf[CMSG_SPACE(sizeof(unsigned char))];
+    } cmsgbuf;
     struct iovec msg_iov;       /* Vector of data to send/receive into */
 
     memset(&msg, 0, sizeof(msg));
-    msg.msg_control = buf;
-    msg.msg_controllen = sizeof(buf);
+    msg.msg_control = cmsgbuf.buf;
+    msg.msg_controllen = sizeof(cmsgbuf.buf);
     cmsg = CMSG_FIRSTHDR(&msg);
     cmsg->cmsg_level = SOL_TLS;
     cmsg->cmsg_type = TLS_SET_RECORD_TYPE;
@@ -142,7 +154,76 @@ static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
     return sendmsg(fd, &msg, 0);
 }
 
-#   endif                       /* KERNEL_VERSION */
-#  endif                        /* OPENSSL_SYS_LINUX */
-# endif                         /* HEADER_INTERNAL_KTLS */
-#endif                          /* OPENSSL_NO_KTLS */
+#    define K_MIN1_RX  17
+#    if LINUX_VERSION_CODE < KERNEL_VERSION(K_MAJ, K_MIN1_RX, K_MIN2)
+
+#     ifndef PEDANTIC
+#      warning "KTLS requires Kernel Headers >= 4.17.0 for receiving"
+#      warning "Skipping Compilation of KTLS receive data path"
+#     endif
+
+static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+{
+    return -1;
+}
+
+#    else
+
+/*
+ * Receive a TLS record using the crypto_info provided in ktls_start.
+ * The kernel strips the TLS record header, IV and authentication tag,
+ * returning only the plaintext data or an error on failure.
+ * We add the TLS record header here to satisfy routines in rec_layer_s3.c
+ */
+static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+{
+    struct msghdr msg;
+    struct cmsghdr *cmsg;
+    union {
+        struct cmsghdr hdr;
+        char buf[CMSG_SPACE(sizeof(unsigned char))];
+    } cmsgbuf;
+    struct iovec msg_iov;
+    int ret;
+    unsigned char *p = data;
+    const size_t prepend_length = SSL3_RT_HEADER_LENGTH;
+
+    if (length < prepend_length + EVP_GCM_TLS_TAG_LEN) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_control = cmsgbuf.buf;
+    msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+    msg_iov.iov_base = p + prepend_length;
+    msg_iov.iov_len = length - prepend_length - EVP_GCM_TLS_TAG_LEN;
+    msg.msg_iov = &msg_iov;
+    msg.msg_iovlen = 1;
+
+    ret = recvmsg(fd, &msg, 0);
+    if (ret < 0)
+        return ret;
+
+    if (msg.msg_controllen > 0) {
+        cmsg = CMSG_FIRSTHDR(&msg);
+        if (cmsg->cmsg_type == TLS_GET_RECORD_TYPE) {
+            p[0] = *((unsigned char *)CMSG_DATA(cmsg));
+            p[1] = TLS1_2_VERSION_MAJOR;
+            p[2] = TLS1_2_VERSION_MINOR;
+            /* returned length is limited to msg_iov.iov_len above */
+            p[3] = (ret >> 8) & 0xff;
+            p[4] = ret & 0xff;
+            ret += prepend_length;
+        }
+    }
+
+    return ret;
+}
+
+#    endif
+#   endif
+#  endif
+# endif
+#endif

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -145,15 +145,20 @@ extern "C" {
 
 # define BIO_CTRL_DGRAM_SET_PEEK_MODE      71
 
-/* internal BIO see include/internal/bio.h:
+/*
+ * internal BIO see include/internal/bio.h:
  * # define BIO_CTRL_SET_KTLS_SEND                 72
  * # define BIO_CTRL_SET_KTLS_SEND_CTRL_MSG        74
- * # define BIO_CTRL_CLEAR_KTLS_CTRL_MSG      75
+ * # define BIO_CTRL_CLEAR_KTLS_CTRL_MSG           75
  */
 
 #  define BIO_CTRL_GET_KTLS_SEND                 73
+#  define BIO_CTRL_GET_KTLS_RECV                 76
+
 #  define BIO_get_ktls_send(b)         \
      BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL)
+#  define BIO_get_ktls_recv(b)         \
+     BIO_ctrl(b, BIO_CTRL_GET_KTLS_RECV, 0, NULL)
 
 /* modifiers */
 # define BIO_FP_READ             0x02

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -500,7 +500,7 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
  */
 # define SSL_MODE_ASYNC 0x00000100U
 /*
- * Use the kernel TLS transmission data-path.
+ * Don't use the kernel TLS data-path for sending.
  */
 # define SSL_MODE_NO_KTLS_TX 0x00000200U
 /*
@@ -515,6 +515,10 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
  * - OpenSSL 1.1.1 and 1.1.1a
  */
 # define SSL_MODE_DTLS_SCTP_LABEL_LENGTH_BUG 0x00000400U
+/*
+ * Don't use the kernel TLS data-path for receiving.
+ */
+# define SSL_MODE_NO_KTLS_RX 0x00000800U
 
 /* Cert related flags */
 /*

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -268,11 +268,15 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
         return -1;
     }
 
-    /* We always act like read_ahead is set for DTLS */
-    if (!s->rlayer.read_ahead && !SSL_IS_DTLS(s))
+    /*
+     * Ktls always reads full records.
+     * Also, we always act like read_ahead is set for DTLS.
+     */
+    if (!BIO_get_ktls_recv(s->rbio) && !s->rlayer.read_ahead
+        && !SSL_IS_DTLS(s)) {
         /* ignore max parameter */
         max = n;
-    else {
+    } else {
         if (max < n)
             max = n;
         if (max > rb->len - rb->offset)

--- a/util/private.num
+++ b/util/private.num
@@ -116,6 +116,7 @@ BIO_get_cipher_ctx                      define
 BIO_get_cipher_status                   define
 BIO_get_close                           define
 BIO_get_ktls_send                       define
+BIO_get_ktls_recv                       define
 BIO_get_conn_address                    define
 BIO_get_conn_hostname                   define
 BIO_get_conn_port                       define


### PR DESCRIPTION
This pull request completes the support for the Linux kernel TLS data-path
by adding receive-side support to the send-side support introduced in pull
request [5253](https://github.com/openssl/openssl/pull/5253).

Similarly to the send-side, in the receive-side the kernel returns
plaintext data while stripping the TLS record layer. This should improve
efficiency, because the kernel can decrypt data directly into user space
buffers and avoid a data-copy.

The user API is as follows: (also see [[1]](https://github.com/torvalds/linux/blob/master/Documentation/networking/tls.txt))

After setting the TLS_RX socket option, all recv family socket calls
are decrypted using TLS parameters provided.  A full TLS record must
be received before decryption can happen.

  char buffer[16384];
  recv(sock, buffer, 16384);

Received data is decrypted directly in to the user buffer if it is
large enough, and no additional allocations occur.  If the userspace
buffer is too small, data is decrypted in the kernel and copied to
userspace.

EINVAL is returned if the TLS version in the received message does not
match the version passed in setsockopt.

EMSGSIZE is returned if the received message is too big.

EBADMSG is returned if decryption failed for any other reason.
