### PR TITLE
Undeprecate OpenSSL_version_num

### DIFF
--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -11,12 +11,10 @@
 
 #include "buildinf.h"
 
-#if !OPENSSL_API_3
 unsigned long OpenSSL_version_num(void)
 {
     return OPENSSL_VERSION_NUMBER;
 }
-#endif
 
 unsigned int OPENSSL_version_major(void)
 {

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -158,7 +158,7 @@ int OPENSSL_hexchar2int(unsigned char c);
 
 # define OPENSSL_MALLOC_MAX_NELEMS(type)  (((1U<<(sizeof(int)*8-1))-1)/sizeof(type))
 
-DEPRECATEDIN_3(unsigned long OpenSSL_version_num(void))
+unsigned long OpenSSL_version_num(void);
 const char *OpenSSL_version(int type);
 # define OPENSSL_VERSION                0
 # define OPENSSL_CFLAGS                 1

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -121,21 +121,17 @@ const char *OPENSSL_version_build_metadata(void);
 /*
  * SECTION 4: BACKWARD COMPATIBILITY
  */
-# include <openssl/macros.h>
-
-# if !OPENSSL_API_4
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
-#  ifdef OPENSSL_VERSION_PRE_RELEASE
-#   define _OPENSSL_VERSION_PRE_RELEASE 0x0L
-#  else
-#   define _OPENSSL_VERSION_PRE_RELEASE 0xfL
-#  endif
-#  define OPENSSL_VERSION_NUMBER        \
-          ( (OPENSSL_VERSION_MAJOR<<28)  \
-            |(OPENSSL_VERSION_MINOR<<20) \
-            |(OPENSSL_VERSION_PATCH<<4)  \
-            |_OPENSSL_VERSION_PRE_RELEASE )
+# ifdef OPENSSL_VERSION_PRE_RELEASE
+#  define _OPENSSL_VERSION_PRE_RELEASE 0x0
+# else
+#  define _OPENSSL_VERSION_PRE_RELEASE 0xf
 # endif
+# define OPENSSL_VERSION_NUMBER          \
+    ( (OPENSSL_VERSION_MAJOR<<28)        \
+      |(OPENSSL_VERSION_MINOR<<20)       \
+      |(OPENSSL_VERSION_PATCH<<4)        \
+      |_OPENSSL_VERSION_PRE_RELEASE )
 
 # ifdef  __cplusplus
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3150,7 +3150,7 @@ CMS_RecipientInfo_get0_pkey_ctx         3215	3_0_0	EXIST::FUNCTION:CMS
 OCSP_REQINFO_free                       3216	3_0_0	EXIST::FUNCTION:OCSP
 AUTHORITY_KEYID_new                     3217	3_0_0	EXIST::FUNCTION:
 i2d_DIST_POINT_NAME                     3218	3_0_0	EXIST::FUNCTION:
-OpenSSL_version_num                     3219	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
+OpenSSL_version_num                     3219	3_0_0	EXIST::FUNCTION:
 OCSP_CERTID_free                        3220	3_0_0	EXIST::FUNCTION:OCSP
 BIO_hex_string                          3221	3_0_0	EXIST::FUNCTION:
 X509_REQ_sign_ctx                       3222	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The OpenSSL_version_num() function returns at runtime the
OPENSSL_VERSION_NUMBER of the compiled OpenSSL library.  This is a
used and useful interface, and should not (at least yet) be
deprecated, we just introduced the new versioning schema, it seems
too early to deprecate the old.
