### PR TITLE
man: harmonize the various formulations in the HISTORY sections

### DIFF
--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -762,7 +762,7 @@ The B<-V> option for the B<ciphers> command was added in OpenSSL 1.0.0.
 The B<-stdname> is only available if OpenSSL is built with tracing enabled
 (B<enable-ssl-trace> argument to Configure) before OpenSSL 1.1.1.
 
-The B<-convert> was added in OpenSSL 1.1.1.
+The B<-convert> option was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -731,7 +731,7 @@ Support for RSA-OAEP and RSA-PSS was added in OpenSSL 1.0.2.
 The use of non-RSA keys with B<-encrypt> and B<-decrypt>
 was added in OpenSSL 1.0.2.
 
-The -no_alt_chains options was added in OpenSSL 1.0.2b.
+The -no_alt_chains option was added in OpenSSL 1.0.2b.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -724,14 +724,14 @@ No revocation checking is done on the signer's certificate.
 The use of multiple B<-signer> options and the B<-resign> command were first
 added in OpenSSL 1.0.0.
 
-The B<keyopt> option was first added in OpenSSL 1.0.2.
+The B<keyopt> option was added in OpenSSL 1.0.2.
 
-Support for RSA-OAEP and RSA-PSS was first added to OpenSSL 1.0.2.
+Support for RSA-OAEP and RSA-PSS was added in OpenSSL 1.0.2.
 
-The use of non-RSA keys with B<-encrypt> and B<-decrypt> was first added
-to OpenSSL 1.0.2.
+The use of non-RSA keys with B<-encrypt> and B<-decrypt>
+was added in OpenSSL 1.0.2.
 
-The -no_alt_chains options was first added to OpenSSL 1.0.2b.
+The -no_alt_chains options was added in OpenSSL 1.0.2b.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -417,7 +417,7 @@ certain parameters. So if, for example, you want to use RC2 with a
 
 =head1 HISTORY
 
-The default digest was changed from MD5 to SHA256 in Openssl 1.1.0.
+The default digest was changed from MD5 to SHA256 in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -319,9 +319,9 @@ Generate an ED448 private key:
 =head1 HISTORY
 
 The ability to use NIST curve names, and to generate an EC key directly,
-were added in OpenSSL 1.0.2. The ability to generate X25519 keys was added in
-OpenSSL 1.1.0. The ability to generate X448, ED25519 and ED448 keys was added in
-OpenSSL 1.1.1.
+were added in OpenSSL 1.0.2.
+The ability to generate X25519 keys was added in OpenSSL 1.1.0.
+The ability to generate X448, ED25519 and ED448 keys was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/ocsp.pod
+++ b/doc/man1/ocsp.pod
@@ -486,7 +486,7 @@ to a second file.
 
 =head1 HISTORY
 
-The -no_alt_chains options was added in OpenSSL 1.1.0.
+The -no_alt_chains option was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/ocsp.pod
+++ b/doc/man1/ocsp.pod
@@ -486,7 +486,7 @@ to a second file.
 
 =head1 HISTORY
 
-The -no_alt_chains options was first added to OpenSSL 1.1.0.
+The -no_alt_chains options was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -305,7 +305,7 @@ L<gendsa(1)>
 
 =head1 HISTORY
 
-The B<-iter> option was added to OpenSSL 1.1.0.
+The B<-iter> option was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -811,7 +811,7 @@ L<SSL_CTX_set_max_pipelines(3)>
 
 =head1 HISTORY
 
-The B<-no_alt_chains> option was first added to OpenSSL 1.1.0.
+The B<-no_alt_chains> option was added in OpenSSL 1.1.0.
 The B<-name> option was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -821,10 +821,10 @@ L<SSL_CTX_set_max_pipelines(3)>
 
 =head1 HISTORY
 
-The -no_alt_chains option was first added to OpenSSL 1.1.0.
+The -no_alt_chains option was added in OpenSSL 1.1.0.
 
-The -allow-no-dhe-kex and -prioritize_chacha options were first added to
-OpenSSL 1.1.1.
+The
+-allow-no-dhe-kex and -prioritize_chacha options were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -510,7 +510,7 @@ structures may cause parsing errors.
 The use of multiple B<-signer> options and the B<-resign> command were first
 added in OpenSSL 1.0.0
 
-The -no_alt_chains options was first added to OpenSSL 1.1.0.
+The -no_alt_chains options was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -510,7 +510,7 @@ structures may cause parsing errors.
 The use of multiple B<-signer> options and the B<-resign> command were first
 added in OpenSSL 1.0.0
 
-The -no_alt_chains options was added in OpenSSL 1.1.0.
+The -no_alt_chains option was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/storeutl.pod
+++ b/doc/man1/storeutl.pod
@@ -119,7 +119,7 @@ L<openssl(1)>
 
 =head1 HISTORY
 
-B<openssl> B<storeutl> was added to OpenSSL 1.1.1.
+The B<openssl> B<storeutl> app was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/verify.pod
+++ b/doc/man1/verify.pod
@@ -762,7 +762,7 @@ L<x509(1)>
 
 =head1 HISTORY
 
-The B<-show_chain> option was first added to OpenSSL 1.1.0.
+The B<-show_chain> option was added in OpenSSL 1.1.0.
 
 The B<-issuer_checks> option is deprecated as of OpenSSL 1.1.0 and
 is silently ignored.

--- a/doc/man3/ASN1_INTEGER_get_int64.pod
+++ b/doc/man3/ASN1_INTEGER_get_int64.pod
@@ -119,7 +119,7 @@ L<ERR_get_error(3)>
 
 ASN1_INTEGER_set_int64(), ASN1_INTEGER_get_int64(),
 ASN1_ENUMERATED_set_int64() and ASN1_ENUMERATED_get_int64()
-were added to OpenSSL 1.1.0.
+were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/ASYNC_WAIT_CTX_new.pod
+++ b/doc/man3/ASYNC_WAIT_CTX_new.pod
@@ -127,10 +127,10 @@ L<crypto(7)>, L<ASYNC_start_job(3)>
 
 =head1 HISTORY
 
-ASYNC_WAIT_CTX_new, ASYNC_WAIT_CTX_free, ASYNC_WAIT_CTX_set_wait_fd,
-ASYNC_WAIT_CTX_get_fd, ASYNC_WAIT_CTX_get_all_fds,
-ASYNC_WAIT_CTX_get_changed_fds, ASYNC_WAIT_CTX_clear_fd were first added to
-OpenSSL 1.1.0.
+ASYNC_WAIT_CTX_new(), ASYNC_WAIT_CTX_free(), ASYNC_WAIT_CTX_set_wait_fd(),
+ASYNC_WAIT_CTX_get_fd(), ASYNC_WAIT_CTX_get_all_fds(),
+ASYNC_WAIT_CTX_get_changed_fds() and ASYNC_WAIT_CTX_clear_fd()
+were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/ASYNC_start_job.pod
+++ b/doc/man3/ASYNC_start_job.pod
@@ -317,7 +317,7 @@ L<crypto(7)>, L<ERR_print_errors(3)>
 ASYNC_init_thread, ASYNC_cleanup_thread,
 ASYNC_start_job, ASYNC_pause_job, ASYNC_get_current_job, ASYNC_get_wait_ctx(),
 ASYNC_block_pause(), ASYNC_unblock_pause() and ASYNC_is_capable() were first
-added to OpenSSL 1.1.0.
+added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BIO_new_CMS.pod
+++ b/doc/man3/BIO_new_CMS.pod
@@ -61,7 +61,7 @@ L<CMS_encrypt(3)>
 
 =head1 HISTORY
 
-BIO_new_CMS() was added to OpenSSL 1.0.0
+The BIO_new_CMS() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -197,8 +197,8 @@ L<RSA_generate_key(3)>, L<ERR_get_error(3)>, L<RAND_bytes(3)>
 
 =head1 HISTORY
 
-BN_GENCB_new(), BN_GENCB_free(),
-and BN_GENCB_get_arg() were added in OpenSSL 1.1.0
+The BN_GENCB_new(), BN_GENCB_free(),
+and BN_GENCB_get_arg() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -73,7 +73,8 @@ a future release.
 
 =item *
 
-BN_priv_rand() and BN_priv_rand_range() were added in OpenSSL 1.1.1.
+The
+BN_priv_rand() and BN_priv_rand_range() functions were added in OpenSSL 1.1.1.
 
 =back
 

--- a/doc/man3/BN_security_bits.pod
+++ b/doc/man3/BN_security_bits.pod
@@ -33,7 +33,7 @@ function. The symmetric algorithms are not covered neither.
 
 =head1 HISTORY
 
-BN_security_bits() was added in OpenSSL 1.1.0.
+The BN_security_bits() function was added in OpenSSL 1.1.0.
 
 =head1 SEE ALSO
 

--- a/doc/man3/BUF_MEM_new.pod
+++ b/doc/man3/BUF_MEM_new.pod
@@ -61,7 +61,7 @@ L<CRYPTO_secure_malloc(3)>.
 
 =head1 HISTORY
 
-BUF_MEM_new_ex() was added in OpenSSL 1.1.0.
+The BUF_MEM_new_ex() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CTLOG_STORE_get0_log_by_id.pod
+++ b/doc/man3/CTLOG_STORE_get0_log_by_id.pod
@@ -35,7 +35,7 @@ L<CTLOG_STORE_new(3)>
 
 =head1 HISTORY
 
-This function was added in OpenSSL 1.1.0.
+The CTLOG_STORE_get0_log_by_id() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/DH_size.pod
+++ b/doc/man3/DH_size.pod
@@ -43,7 +43,7 @@ L<BN_num_bits(3)>
 
 =head1 HISTORY
 
-DH_bits() was added in OpenSSL 1.1.0.
+The DH_bits() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/DTLS_get_data_mtu.pod
+++ b/doc/man3/DTLS_get_data_mtu.pod
@@ -22,7 +22,7 @@ Returns the maximum data payload size on success, or 0 on failure.
 
 =head1 HISTORY
 
-This function was added in OpenSSL 1.1.1
+The DTLS_get_data_mtu() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/DTLS_set_timer_cb.pod
+++ b/doc/man3/DTLS_set_timer_cb.pod
@@ -26,7 +26,7 @@ Returns void.
 
 =head1 HISTORY
 
-This function was added in OpenSSL 1.1.1
+The DTLS_set_timer_cb() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -117,10 +117,10 @@ L<ssl(7)>, L<bio(7)>
 
 =head1 HISTORY
 
-SSL_stateless() was first added in OpenSSL 1.1.1.
+The SSL_stateless() function was added in OpenSSL 1.1.1.
 
-DTLSv1_listen() return codes were clarified in OpenSSL 1.1.0. The type of "peer"
-also changed in OpenSSL 1.1.0.
+The DTLSv1_listen() return codes were clarified in OpenSSL 1.1.0.
+The type of "peer" also changed in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_GROUP_copy.pod
+++ b/doc/man3/EC_GROUP_copy.pod
@@ -89,7 +89,7 @@ named curve form is used and the parameters must have a corresponding
 named curve NID set. If asn1_flags is B<OPENSSL_EC_EXPLICIT_CURVE> the
 parameters are explicitly encoded. The functions EC_GROUP_get_asn1_flag and
 EC_GROUP_set_asn1_flag get and set the status of the asn1_flag for the curve.
-Note: B<OPENSSL_EC_EXPLICIT_CURVE> was first added to OpenSSL 1.1.0, for
+Note: B<OPENSSL_EC_EXPLICIT_CURVE> was added in OpenSSL 1.1.0, for
 previous versions of OpenSSL the value 0 must be used instead. Before OpenSSL
 1.1.0 the default form was to use explicit parameters (meaning that
 applications would have to explicitly set the named curve form) in OpenSSL

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -369,15 +369,15 @@ L<EVP_whirlpool(3)>
 
 =head1 HISTORY
 
-EVP_MD_CTX_create() and EVP_MD_CTX_destroy() were renamed to
-EVP_MD_CTX_new() and EVP_MD_CTX_free() in OpenSSL 1.1.0.
+The EVP_MD_CTX_create() and EVP_MD_CTX_destroy() functions were renamed to
+EVP_MD_CTX_new() and EVP_MD_CTX_free() in OpenSSL 1.1.0, respectively.
 
 The link between digests and signing algorithms was fixed in OpenSSL 1.0 and
 later, so now EVP_sha1() can be used with RSA and DSA.
 
-EVP_dss1() was removed in OpenSSL 1.1.0.
+The EVP_dss1() function was removed in OpenSSL 1.1.0.
 
-EVP_MD_CTX_set_pkey_ctx() was added in 1.1.1.
+The EVP_MD_CTX_set_pkey_ctx() function was added in 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -152,7 +152,7 @@ L<SHA1(3)>, L<dgst(1)>
 =head1 HISTORY
 
 EVP_DigestSignInit(), EVP_DigestSignUpdate() and EVP_DigestSignFinal()
-were first added to OpenSSL 1.0.0.
+were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -98,7 +98,7 @@ L<SHA1(3)>, L<dgst(1)>
 =head1 HISTORY
 
 EVP_DigestVerifyInit(), EVP_DigestVerifyUpdate() and EVP_DigestVerifyFinal()
-were first added to OpenSSL 1.0.0.
+were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -632,7 +632,7 @@ L<EVP_sm4(3)>
 
 =head1 HISTORY
 
-Support for OCB mode was added in OpenSSL 1.1.0
+Support for OCB mode was added in OpenSSL 1.1.0.
 
 B<EVP_CIPHER_CTX> was made opaque in OpenSSL 1.1.0.  As a result,
 EVP_CIPHER_CTX_reset() appeared and EVP_CIPHER_CTX_cleanup()

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -359,7 +359,7 @@ B<param_enc> when generating EC parameters or an EC key. The encoding can be
 B<OPENSSL_EC_EXPLICIT_CURVE> for explicit parameters (the default in versions
 of OpenSSL before 1.1.0) or B<OPENSSL_EC_NAMED_CURVE> to use named curve form.
 For maximum compatibility the named curve form should be used. Note: the
-B<OPENSSL_EC_NAMED_CURVE> value was only added to OpenSSL 1.1.0; previous
+B<OPENSSL_EC_NAMED_CURVE> value was added in OpenSSL 1.1.0; previous
 versions should use 0 instead.
 
 =head2 ECDH parameters
@@ -439,8 +439,9 @@ L<EVP_PKEY_keygen(3)>
 
 =head1 HISTORY
 
+The
 EVP_PKEY_CTX_set1_id(), EVP_PKEY_CTX_get1_id() and EVP_PKEY_CTX_get1_id_len()
-macros were added in 1.1.1, other functions were first added to OpenSSL 1.0.0.
+macros were added in 1.1.1, other functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -48,7 +48,7 @@ L<EVP_PKEY_new(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_decrypt.pod
+++ b/doc/man3/EVP_PKEY_decrypt.pod
@@ -91,7 +91,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_derive.pod
+++ b/doc/man3/EVP_PKEY_derive.pod
@@ -89,7 +89,7 @@ L<EVP_PKEY_verify_recover(3)>,
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_encrypt.pod
+++ b/doc/man3/EVP_PKEY_encrypt.pod
@@ -96,7 +96,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -38,7 +38,7 @@ L<EVP_PKEY_verify_recover(3)>,
 
 =head1 HISTORY
 
-This function was first added to OpenSSL 1.0.0.
+This function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -189,7 +189,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 EVP_PKEY_check(), EVP_PKEY_public_check() and EVP_PKEY_param_check() were added
 in OpenSSL 1.1.1.

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -114,12 +114,15 @@ L<EVP_PKEY_set1_EC_KEY>
 
 =head1 HISTORY
 
-EVP_PKEY_new() and EVP_PKEY_free() exist in all versions of OpenSSL.
+The
+EVP_PKEY_new() and EVP_PKEY_free() functions exist in all versions of OpenSSL.
 
-EVP_PKEY_up_ref() was first added to OpenSSL 1.1.0.
+The EVP_PKEY_up_ref() function was added in OpenSSL 1.1.0.
+
+The
 EVP_PKEY_new_raw_private_key(), EVP_PKEY_new_raw_public_key(),
 EVP_PKEY_new_CMAC_key(), EVP_PKEY_new_raw_private_key() and
-EVP_PKEY_get_raw_public_key() were first added to OpenSSL 1.1.1.
+EVP_PKEY_get_raw_public_key() functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_print_private.pod
+++ b/doc/man3/EVP_PKEY_print_private.pod
@@ -47,7 +47,7 @@ L<EVP_PKEY_keygen(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_sign.pod
+++ b/doc/man3/EVP_PKEY_sign.pod
@@ -101,7 +101,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_supports_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_supports_digest_nid.pod
@@ -39,7 +39,7 @@ L<EVP_PKEY_verify_recover(3)>,
 
 =head1 HISTORY
 
-This function was first added to OpenSSL 3.0.0.
+The EVP_PKEY_supports_digest_nid() function was added in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_verify.pod
+++ b/doc/man3/EVP_PKEY_verify.pod
@@ -89,7 +89,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_verify_recover.pod
+++ b/doc/man3/EVP_PKEY_verify_recover.pod
@@ -100,7 +100,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.0.
+These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OPENSSL_secure_malloc.pod
+++ b/doc/man3/OPENSSL_secure_malloc.pod
@@ -120,7 +120,7 @@ L<BN_new(3)>
 
 =head1 HISTORY
 
-OPENSSL_secure_clear_free() was added in OpenSSL 1.1.0g.
+The OPENSSL_secure_clear_free() function was added in OpenSSL 1.1.0g.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_STORE_INFO.pod
+++ b/doc/man3/OSSL_STORE_INFO.pod
@@ -190,7 +190,7 @@ OSSL_STORE_INFO_get0_CERT(), OSSL_STORE_INFO_get0_CRL(),
 OSSL_STORE_INFO_type_string(), OSSL_STORE_INFO_free(), OSSL_STORE_INFO_new_NAME(),
 OSSL_STORE_INFO_new_PARAMS(), OSSL_STORE_INFO_new_PKEY(),
 OSSL_STORE_INFO_new_CERT() and OSSL_STORE_INFO_new_CRL()
-were added to OpenSSL 1.1.1.
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -250,7 +250,7 @@ OSSL_STORE_LOADER_set_eof(), OSSL_STORE_LOADER_set_close(),
 OSSL_STORE_LOADER_free(), OSSL_STORE_register_loader(),
 OSSL_STORE_unregister_loader(), OSSL_STORE_open_fn(), OSSL_STORE_ctrl_fn(),
 OSSL_STORE_load_fn(), OSSL_STORE_eof_fn() and OSSL_STORE_close_fn()
-were added to OpenSSL 1.1.1.
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_STORE_SEARCH.pod
+++ b/doc/man3/OSSL_STORE_SEARCH.pod
@@ -179,7 +179,7 @@ OSSL_STORE_SEARCH_get0_name(),
 OSSL_STORE_SEARCH_get0_serial(),
 OSSL_STORE_SEARCH_get0_bytes(),
 and OSSL_STORE_SEARCH_get0_string()
-were added to OpenSSL 1.1.1.
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_STORE_expect.pod
+++ b/doc/man3/OSSL_STORE_expect.pod
@@ -65,7 +65,7 @@ L<OSSL_STORE_load(3)>
 =head1 HISTORY
 
 OSSL_STORE_expect(), OSSL_STORE_supports_search() and OSSL_STORE_find()
-were added to OpenSSL 1.1.1.
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -147,7 +147,7 @@ L<passphrase-encoding(7)>
 
 OSSL_STORE_CTX(), OSSL_STORE_post_process_info_fn(), OSSL_STORE_open(),
 OSSL_STORE_ctrl(), OSSL_STORE_load(), OSSL_STORE_eof() and OSSL_STORE_close()
-were added to OpenSSL 1.1.1.
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -176,7 +176,7 @@ L<crypto(7)>
 
 =head1 HISTORY
 
-The macros and functions described here were added to OpenSSL 3.0.0,
+The macros and functions described here were added in OpenSSL 3.0.0,
 with the exception of the L</BACKWARD COMPATIBILITY> ones.
 
 =head1 COPYRIGHT

--- a/doc/man3/PEM_read_bio_ex.pod
+++ b/doc/man3/PEM_read_bio_ex.pod
@@ -56,7 +56,7 @@ L<PEM(3)>
 
 =head1 HISTORY
 
-PEM_read_bio_ex() was added in OpenSSL 1.1.1.
+The PEM_read_bio_ex() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/PEM_write_bio_CMS_stream.pod
+++ b/doc/man3/PEM_write_bio_CMS_stream.pod
@@ -36,7 +36,7 @@ L<i2d_CMS_bio_stream(3)>
 
 =head1 HISTORY
 
-PEM_write_bio_CMS_stream() was added to OpenSSL 1.0.0
+The PEM_write_bio_CMS_stream() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/PEM_write_bio_PKCS7_stream.pod
+++ b/doc/man3/PEM_write_bio_PKCS7_stream.pod
@@ -35,7 +35,7 @@ L<i2d_PKCS7_bio_stream(3)>
 
 =head1 HISTORY
 
-PEM_write_bio_PKCS7_stream() was added to OpenSSL 1.0.0
+The PEM_write_bio_PKCS7_stream() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/PKCS7_sign.pod
+++ b/doc/man3/PKCS7_sign.pod
@@ -108,9 +108,9 @@ L<ERR_get_error(3)>, L<PKCS7_verify(3)>
 =head1 HISTORY
 
 The B<PKCS7_PARTIAL> flag, and the ability for B<certs>, B<signcert>,
-and B<pkey> parameters to be B<NULL> to be was added in OpenSSL 1.0.0
+and B<pkey> parameters to be B<NULL> were added in OpenSSL 1.0.0.
 
-The B<PKCS7_STREAM> flag was added in OpenSSL 1.0.0
+The B<PKCS7_STREAM> flag was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/PKCS7_sign_add_signer.pod
+++ b/doc/man3/PKCS7_sign_add_signer.pod
@@ -83,7 +83,7 @@ L<PKCS7_final(3)>,
 
 =head1 HISTORY
 
-PPKCS7_sign_add_signer() was added to OpenSSL 1.0.0
+The PPKCS7_sign_add_signer() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -53,7 +53,7 @@ RAND_pseudo_bytes() was deprecated in OpenSSL 1.1.0; use RAND_bytes() instead.
 
 =item *
 
-RAND_priv_bytes() was added in OpenSSL 1.1.1.
+The RAND_priv_bytes() function was added in OpenSSL 1.1.1.
 
 =back
 

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -157,6 +157,7 @@ L<RSA_new(3)>, L<RSA_size(3)>
 
 =head1 HISTORY
 
+The
 RSA_get_multi_prime_extra_count(), RSA_get0_multi_prime_factors(),
 RSA_get0_multi_prime_crt_params(), RSA_set0_multi_prime_params(),
 and RSA_get_version() functions were added in OpenSSL 1.1.1.

--- a/doc/man3/RSA_size.pod
+++ b/doc/man3/RSA_size.pod
@@ -41,7 +41,7 @@ L<BN_num_bits(3)>
 
 =head1 HISTORY
 
-RSA_bits() was added in OpenSSL 1.1.0.
+The RSA_bits() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_VBASE_new.pod
+++ b/doc/man3/SRP_VBASE_new.pod
@@ -85,7 +85,7 @@ L<SSL_CTX_set_srp_password(3)>
 
 SRP_VBASE_add0_user() was first added to OpenSSL 1.2.0.
 
-All other functions were first added to OpenSSL 1.0.1.
+All other functions were added in OpenSSL 1.0.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_VBASE_new.pod
+++ b/doc/man3/SRP_VBASE_new.pod
@@ -83,7 +83,7 @@ L<SSL_CTX_set_srp_password(3)>
 
 =head1 HISTORY
 
-SRP_VBASE_add0_user() was first added to OpenSSL 1.2.0.
+The SRP_VBASE_add0_user() function was added in OpenSSL 3.0.0.
 
 All other functions were added in OpenSSL 1.0.1.
 

--- a/doc/man3/SRP_create_verifier.pod
+++ b/doc/man3/SRP_create_verifier.pod
@@ -96,7 +96,7 @@ L<SRP_user_pwd_new(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.1.
+These functions were added in OpenSSL 1.0.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_user_pwd_new.pod
+++ b/doc/man3/SRP_user_pwd_new.pod
@@ -56,7 +56,7 @@ L<SSL_CTX_set_srp_password(3)>
 
 =head1 HISTORY
 
-These functions were made public in OpenSSL 1.2.0.
+These functions were made public in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -182,7 +182,7 @@ protocol-specific ID.
 The SSL_CIPHER_get_version() function was updated to always return the
 correct protocol string in OpenSSL 1.1.0.
 
-The SSL_CIPHER_description() functio nwas changed to return B<NULL> on error,
+The SSL_CIPHER_description() function was changed to return B<NULL> on error,
 rather than a fixed string, in OpenSSL 1.1.0.
 
 The SSL_CIPHER_get_handshake_digest() function was added in OpenSSL 1.1.1.

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -179,19 +179,19 @@ protocol-specific ID.
 
 =head1 HISTORY
 
-SSL_CIPHER_get_version() was updated to always return the correct protocol
-string in OpenSSL 1.1.0.
+The SSL_CIPHER_get_version() function was updated to always return the
+correct protocol string in OpenSSL 1.1.0.
 
-SSL_CIPHER_description() was changed to return B<NULL> on error,
+The SSL_CIPHER_description() functio nwas changed to return B<NULL> on error,
 rather than a fixed string, in OpenSSL 1.1.0.
 
-SSL_CIPHER_get_handshake_digest() was added in OpenSSL 1.1.1.
+The SSL_CIPHER_get_handshake_digest() function was added in OpenSSL 1.1.1.
 
-SSL_CIPHER_standard_name() was globally available in OpenSSL 1.1.1. Before
-OpenSSL 1.1.1, tracing (B<enable-ssl-trace> argument to Configure) was
+The SSL_CIPHER_standard_name() function was globally available in OpenSSL 1.1.1.
+ Before OpenSSL 1.1.1, tracing (B<enable-ssl-trace> argument to Configure) was
 required to enable this function.
 
-OPENSSL_cipher_name() was added in OpenSSL 1.1.1.
+The OPENSSL_cipher_name() function was added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -91,9 +91,8 @@ L<ssl(7)>
 
 =head1 HISTORY
 
-SSL_COMP_free_compression_methods() was deprecated in OpenSSL 1.1.0;
-do not use it.
-SSL_COMP_get0_name() and SSL_comp_get_id() were added in OpenSSL 1.1.0d.
+The SSL_COMP_free_compression_methods() function was deprecated in OpenSSL 1.1.0.
+The SSL_COMP_get0_name() and SSL_comp_get_id() functions were added in OpenSSL 1.1.0d.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CONF_CTX_new.pod
+++ b/doc/man3/SSL_CONF_CTX_new.pod
@@ -36,7 +36,7 @@ L<SSL_CONF_cmd_argv(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CONF_CTX_set1_prefix.pod
+++ b/doc/man3/SSL_CONF_CTX_set1_prefix.pod
@@ -44,7 +44,7 @@ L<SSL_CONF_cmd_argv(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CONF_CTX_set_flags.pod
+++ b/doc/man3/SSL_CONF_CTX_set_flags.pod
@@ -70,7 +70,7 @@ L<SSL_CONF_cmd_argv(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CONF_CTX_set_ssl_ctx.pod
+++ b/doc/man3/SSL_CONF_CTX_set_ssl_ctx.pod
@@ -42,7 +42,7 @@ L<SSL_CONF_cmd_argv(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -670,12 +670,12 @@ L<SSL_CTX_set_options(3)>
 
 =head1 HISTORY
 
-SSL_CONF_cmd() was first added to OpenSSL 1.0.2
+The SSL_CONF_cmd() function was added in OpenSSL 1.0.2.
 
-B<SSL_OP_NO_SSL2> doesn't have effect since 1.1.0, but the macro is retained
-for backwards compatibility.
+The B<SSL_OP_NO_SSL2> option doesn't have effect since 1.1.0, but the macro
+is retained for backwards compatibility.
 
-B<SSL_CONF_TYPE_NONE> was first added to OpenSSL 1.1.0. In earlier versions of
+The B<SSL_CONF_TYPE_NONE> was added in OpenSSL 1.1.0. In earlier versions of
 OpenSSL passing a command which didn't take an argument would return
 B<SSL_CONF_TYPE_UNKNOWN>.
 

--- a/doc/man3/SSL_CONF_cmd_argv.pod
+++ b/doc/man3/SSL_CONF_cmd_argv.pod
@@ -37,7 +37,7 @@ L<SSL_CONF_cmd(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_add1_chain_cert.pod
+++ b/doc/man3/SSL_CTX_add1_chain_cert.pod
@@ -144,7 +144,7 @@ L<SSL_CTX_add_extra_chain_cert(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2.
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_config.pod
+++ b/doc/man3/SSL_CTX_config.pod
@@ -77,7 +77,7 @@ L<CONF_modules_load_file(3)>
 
 =head1 HISTORY
 
-SSL_CTX_config() and SSL_config() were first added to OpenSSL 1.1.0
+The SSL_CTX_config() and SSL_config() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_dane_enable.pod
+++ b/doc/man3/SSL_CTX_dane_enable.pod
@@ -368,7 +368,7 @@ L<EVP_PKEY_free(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.1.0.
+These functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_get0_param.pod
+++ b/doc/man3/SSL_CTX_get0_param.pod
@@ -50,7 +50,7 @@ L<X509_VERIFY_PARAM_set_flags(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2.
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -97,8 +97,8 @@ L<SSL_CTX_add_extra_chain_cert(3)>
 
 =head1 HISTORY
 
-The curve functions were first added to OpenSSL 1.0.2. The equivalent group
-functions were first added to OpenSSL 1.1.1.
+The curve functions were added in OpenSSL 1.0.2. The equivalent group
+functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set1_verify_cert_store.pod
+++ b/doc/man3/SSL_CTX_set1_verify_cert_store.pod
@@ -86,7 +86,7 @@ L<SSL_build_cert_chain(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.2.
+These functions were added in OpenSSL 1.0.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_default_passwd_cb.pod
+++ b/doc/man3/SSL_CTX_set_default_passwd_cb.pod
@@ -94,7 +94,7 @@ truncated.
 
 SSL_CTX_get_default_passwd_cb(), SSL_CTX_get_default_passwd_cb_userdata(),
 SSL_set_default_passwd_cb() and SSL_set_default_passwd_cb_userdata() were
-first added to OpenSSL 1.1.0
+added in OpenSSL 1.1.0.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_CTX_set_mode.pod
+++ b/doc/man3/SSL_CTX_set_mode.pod
@@ -140,7 +140,7 @@ L<SSL_write(3)>, L<SSL_get_error(3)>
 
 =head1 HISTORY
 
-SSL_MODE_ASYNC was first added to OpenSSL 1.1.0.
+SSL_MODE_ASYNC was added in OpenSSL 1.1.0.
 SSL_MODE_NO_KTLS_TX was first added to OpenSSL 3.0.0.
 
 =head1 COPYRIGHT

--- a/doc/man3/SSL_CTX_set_mode.pod
+++ b/doc/man3/SSL_CTX_set_mode.pod
@@ -141,7 +141,7 @@ L<SSL_write(3)>, L<SSL_get_error(3)>
 =head1 HISTORY
 
 SSL_MODE_ASYNC was added in OpenSSL 1.1.0.
-SSL_MODE_NO_KTLS_TX was first added to OpenSSL 3.0.0.
+SSL_MODE_NO_KTLS_TX was added in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_msg_callback.pod
+++ b/doc/man3/SSL_CTX_set_msg_callback.pod
@@ -128,8 +128,7 @@ L<ssl(7)>, L<SSL_new(3)>
 
 =head1 HISTORY
 
-The pseudo content type B<SSL3_RT_INNER_CONTENT_TYPE> was added in OpenSSL
-1.1.1.
+The pseudo content type B<SSL3_RT_INNER_CONTENT_TYPE> was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -361,7 +361,7 @@ L<dhparam(1)>
 =head1 HISTORY
 
 The attempt to always try to use secure renegotiation was added in
-Openssl 0.9.8m.
+OpenSSL 0.9.8m.
 
 The B<SSL_OP_PRIORITIZE_CHACHA> and B<SSL_OP_NO_RENEGOTIATION> options
 were added in OpenSSL 1.1.1.

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -363,8 +363,8 @@ L<dhparam(1)>
 The attempt to always try to use secure renegotiation was added in
 Openssl 0.9.8m.
 
-B<SSL_OP_PRIORITIZE_CHACHA> and B<SSL_OP_NO_RENEGOTIATION> were added in
-OpenSSL 1.1.1.
+The B<SSL_OP_PRIORITIZE_CHACHA> and B<SSL_OP_NO_RENEGOTIATION> options
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -176,7 +176,7 @@ data pointer or NULL if the ex data is not set.
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.1.0
+These functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_session_ticket_cb.pod
+++ b/doc/man3/SSL_CTX_set_session_ticket_cb.pod
@@ -177,8 +177,8 @@ L<SSL_get_session(3)>
 
 =head1 HISTORY
 
-SSL_CTX_set_session_ticket_cb(), SSSL_SESSION_set1_ticket_appdata() and
-SSL_SESSION_get_ticket_appdata() were added to OpenSSL 1.1.1.
+The SSL_CTX_set_session_ticket_cb(), SSSL_SESSION_set1_ticket_appdata()
+and SSL_SESSION_get_ticket_appdata() functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_split_send_fragment.pod
+++ b/doc/man3/SSL_CTX_set_split_send_fragment.pod
@@ -169,8 +169,8 @@ SSL_CTX_set_split_send_fragment(), SSL_set_split_send_fragment(),
 SSL_CTX_set_default_read_buffer_len() and  SSL_set_default_read_buffer_len()
 functions were added in OpenSSL 1.1.0.
 
-SSL_CTX_set_tlsext_max_fragment_length(), SSL_set_tlsext_max_fragment_length()
-and SSL_SESSION_get_max_fragment_length() were added in OpenSSL 1.1.1.
+The SSL_CTX_set_tlsext_max_fragment_length(), SSL_set_tlsext_max_fragment_length()
+and SSL_SESSION_get_max_fragment_length() functions were added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_CTX_set_srp_password.pod
+++ b/doc/man3/SSL_CTX_set_srp_password.pod
@@ -202,7 +202,7 @@ L<SRP_create_verifier(3)>
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.0.1.
+These functions were added in OpenSSL 1.0.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_tlsext_status_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_status_cb.pod
@@ -108,8 +108,8 @@ side if the client requested OCSP stapling. Otherwise -1 is returned.
 
 =head1 HISTORY
 
-SSL_get_tlsext_status_type(), SSL_CTX_get_tlsext_status_type() and
-SSL_CTX_set_tlsext_status_type() were added in OpenSSL 1.1.0.
+The SSL_get_tlsext_status_type(), SSL_CTX_get_tlsext_status_type()
+and SSL_CTX_set_tlsext_status_type() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -73,7 +73,7 @@ L<d2i_SSL_SESSION(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_dup() was added in OpenSSL 1.1.1.
+The SSL_SESSION_dup() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_get0_cipher.pod
+++ b/doc/man3/SSL_SESSION_get0_cipher.pod
@@ -43,8 +43,8 @@ L<SSL_CTX_set_psk_use_session_callback(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_get0_cipher() was first added to OpenSSL 1.1.0.
-SSL_SESSION_set_cipher() was first added to OpenSSL 1.1.1.
+The SSL_SESSION_get0_cipher() function was added in OpenSSL 1.1.0.
+The SSL_SESSION_set_cipher() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_get0_hostname.pod
+++ b/doc/man3/SSL_SESSION_get0_hostname.pod
@@ -59,8 +59,8 @@ L<SSL_SESSION_free(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_set1_hostname(), SSL_SESSION_get0_alpn_selected() and
-SSL_SESSION_set1_alpn_selected() were added in OpenSSL 1.1.1.
+The SSL_SESSION_set1_hostname(), SSL_SESSION_get0_alpn_selected() and
+SSL_SESSION_set1_alpn_selected() functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_get0_id_context.pod
+++ b/doc/man3/SSL_SESSION_get0_id_context.pod
@@ -42,7 +42,7 @@ L<SSL_set_session_id_context(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_get0_id_context() was first added to OpenSSL 1.1.0
+The SSL_SESSION_get0_id_context() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_get_protocol_version.pod
+++ b/doc/man3/SSL_SESSION_get_protocol_version.pod
@@ -41,8 +41,8 @@ L<SSL_CTX_set_psk_use_session_callback(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_get_protocol_version() was first added to OpenSSL 1.1.0.
-SSL_SESSION_set_protocol_version() was first added to OpenSSL 1.1.1.
+The SSL_SESSION_get_protocol_version() function was added in OpenSSL 1.1.0.
+The SSL_SESSION_set_protocol_version() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_has_ticket.pod
+++ b/doc/man3/SSL_SESSION_has_ticket.pod
@@ -44,8 +44,8 @@ L<SSL_SESSION_free(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_has_ticket, SSL_SESSION_get_ticket_lifetime_hint and
-SSL_SESSION_get0_ticket were added in OpenSSL 1.1.0.
+The SSL_SESSION_has_ticket(), SSL_SESSION_get_ticket_lifetime_hint()
+and SSL_SESSION_get0_ticket() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_is_resumable.pod
+++ b/doc/man3/SSL_SESSION_is_resumable.pod
@@ -30,7 +30,7 @@ L<SSL_CTX_sess_set_new_cb(3)>
 
 =head1 HISTORY
 
-SSL_SESSION_is_resumable() was first added to OpenSSL 1.1.1
+The SSL_SESSION_is_resumable() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_SESSION_set1_id.pod
+++ b/doc/man3/SSL_SESSION_set1_id.pod
@@ -36,7 +36,7 @@ L<ssl(7)>
 
 =head1 HISTORY
 
-SSL_SESSION_set1_id() was first added to OpenSSL 1.1.0
+The SSL_SESSION_set1_id() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_export_keying_material.pod
+++ b/doc/man3/SSL_export_keying_material.pod
@@ -73,7 +73,7 @@ SSL_export_keying_material_early() returns 0 on failure or 1 on success.
 
 =head1 HISTORY
 
-SSL_export_keying_material_early() was first added in OpenSSL 1.1.1.
+The SSL_export_keying_material_early() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_extension_supported.pod
+++ b/doc/man3/SSL_extension_supported.pod
@@ -277,7 +277,7 @@ internally by OpenSSL and 0 otherwise.
 
 =head1 HISTORY
 
-The function SSL_CTX_add_custom_ext() was added in OpenSSL 1.1.1.
+The SSL_CTX_add_custom_ext() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_get_all_async_fds.pod
+++ b/doc/man3/SSL_get_all_async_fds.pod
@@ -73,8 +73,8 @@ L<SSL_get_error(3)>, L<SSL_CTX_set_mode(3)>
 
 =head1 HISTORY
 
-SSL_waiting_for_async(), SSL_get_all_async_fds() and SSL_get_changed_async_fds()
-were first added to OpenSSL 1.1.0.
+The SSL_waiting_for_async(), SSL_get_all_async_fds()
+and SSL_get_changed_async_fds() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -158,8 +158,8 @@ L<ssl(7)>
 
 =head1 HISTORY
 
-SSL_ERROR_WANT_ASYNC was added in OpenSSL 1.1.0.
-SSL_ERROR_WANT_CLIENT_HELLO_CB was added in OpenSSL 1.1.1.
+The SSL_ERROR_WANT_ASYNC error code was added in OpenSSL 1.1.0.
+The SSL_ERROR_WANT_CLIENT_HELLO_CB error code was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_get_version.pod
+++ b/doc/man3/SSL_get_version.pod
@@ -97,7 +97,7 @@ L<ssl(7)>
 
 =head1 HISTORY
 
-SSL_is_dtls() was added in OpenSSL 1.1.0.
+The SSL_is_dtls() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_read.pod
+++ b/doc/man3/SSL_read.pod
@@ -128,7 +128,7 @@ You should instead call SSL_get_error() to find out if it's retryable.
 
 =head1 HISTORY
 
-SSL_read_ex() and SSL_peek_ex() were added in OpenSSL 1.1.1.
+The SSL_read_ex() and SSL_peek_ex() functions were added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_set1_host.pod
+++ b/doc/man3/SSL_set1_host.pod
@@ -104,7 +104,7 @@ L<SSL_dane_enable(3)>.
 
 =head1 HISTORY
 
-These functions were first added to OpenSSL 1.1.0.
+These functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_want.pod
+++ b/doc/man3/SSL_want.pod
@@ -101,7 +101,8 @@ L<ssl(7)>, L<SSL_get_error(3)>
 
 =head1 HISTORY
 
-SSL_want_client_hello_cb() and SSL_CLIENT_HELLO_CB were added in OpenSSL 1.1.1.
+The SSL_want_client_hello_cb() function and the SSL_CLIENT_HELLO_CB return value
+were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -106,7 +106,7 @@ You should instead call SSL_get_error() to find out if it's retryable.
 
 =head1 HISTORY
 
-SSL_write_ex() was added in OpenSSL 1.1.1.
+The SSL_write_ex() function was added in OpenSSL 1.1.1.
 
 =head1 SEE ALSO
 

--- a/doc/man3/UI_create_method.pod
+++ b/doc/man3/UI_create_method.pod
@@ -205,9 +205,8 @@ L<UI(3)>, L<CRYPTO_get_ex_data(3)>, L<UI_STRING(3)>
 
 =head1 HISTORY
 
-UI_method_set_data_duplicator(), UI_method_get_data_duplicator() and
-UI_method_get_data_destructor()
-were added in OpenSSL 1.1.1.
+The UI_method_set_data_duplicator(), UI_method_get_data_duplicator()
+and UI_method_get_data_destructor() functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -239,8 +239,7 @@ respectively.
 
 =head1 HISTORY
 
-UI_dup_user_data()
-was added in OpenSSL 1.1.1.
+The UI_dup_user_data() function was added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -233,7 +233,7 @@ UI_process() returns 0 on success or a negative value on error.
 
 UI_ctrl() returns a mask on success or -1 on error.
 
-UI_get_default_method(), UI_get_method(), UI_Openssl(), UI_null() and
+UI_get_default_method(), UI_get_method(), UI_OpenSSL(), UI_null() and
 UI_set_method() return either a valid B<UI_METHOD> structure or NULL
 respectively.
 

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -159,8 +159,8 @@ L<X509_VERIFY_PARAM_set_flags(3)>
 
 =head1 HISTORY
 
-X509_STORE_CTX_set0_crls() was first added to OpenSSL 1.0.0
-X509_STORE_CTX_get_num_untrusted() was first added to OpenSSL 1.1.0
+The X509_STORE_CTX_set0_crls() function was added in OpenSSL 1.0.0.
+The X509_STORE_CTX_get_num_untrusted() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_STORE_CTX_set_verify_cb.pod
+++ b/doc/man3/X509_STORE_CTX_set_verify_cb.pod
@@ -192,12 +192,13 @@ L<X509_STORE_CTX_get_ex_new_index(3)>
 
 =head1 HISTORY
 
+The
 X509_STORE_CTX_get_get_issuer(),
 X509_STORE_CTX_get_check_issued(), X509_STORE_CTX_get_check_revocation(),
 X509_STORE_CTX_get_get_crl(), X509_STORE_CTX_get_check_crl(),
 X509_STORE_CTX_get_cert_crl(), X509_STORE_CTX_get_check_policy(),
 X509_STORE_CTX_get_lookup_certs(), X509_STORE_CTX_get_lookup_crls()
-and X509_STORE_CTX_get_cleanup() were added in OpenSSL 1.1.0.
+and X509_STORE_CTX_get_cleanup() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_STORE_new.pod
+++ b/doc/man3/X509_STORE_new.pod
@@ -44,7 +44,7 @@ L<X509_STORE_get0_param(3)>
 =head1 HISTORY
 
 The X509_STORE_up_ref(), X509_STORE_lock() and X509_STORE_unlock()
-functions were added in OpenSSL 1.1.0
+functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_STORE_set_verify_cb_func.pod
+++ b/doc/man3/X509_STORE_set_verify_cb_func.pod
@@ -237,8 +237,9 @@ L<CMS_verify(3)>
 
 =head1 HISTORY
 
-X509_STORE_set_verify_cb() was added to OpenSSL 1.0.0.
+The X509_STORE_set_verify_cb() function was added in OpenSSL 1.0.0.
 
+The functions
 X509_STORE_set_verify_cb(), X509_STORE_get_verify_cb(),
 X509_STORE_set_verify(), X509_STORE_CTX_get_verify(),
 X509_STORE_set_get_issuer(), X509_STORE_get_get_issuer(),
@@ -250,8 +251,8 @@ X509_STORE_set_cert_crl(), X509_STORE_get_cert_crl(),
 X509_STORE_set_check_policy(), X509_STORE_get_check_policy(),
 X509_STORE_set_lookup_certs(), X509_STORE_get_lookup_certs(),
 X509_STORE_set_lookup_crls(), X509_STORE_get_lookup_crls(),
-X509_STORE_set_cleanup() and X509_STORE_get_cleanup() were added in
-OpenSSL 1.1.0.
+X509_STORE_set_cleanup() and X509_STORE_get_cleanup()
+were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -368,11 +368,11 @@ L<x509(1)>
 
 =head1 HISTORY
 
-The B<X509_V_FLAG_NO_ALT_CHAINS> flag was added in OpenSSL 1.1.0
-The flag B<X509_V_FLAG_CB_ISSUER_CHECK> was deprecated in
-OpenSSL 1.1.0, and has no effect.
+The B<X509_V_FLAG_NO_ALT_CHAINS> flag was added in OpenSSL 1.1.0.
+The flag B<X509_V_FLAG_CB_ISSUER_CHECK> was deprecated in OpenSSL 1.1.0
+and has no effect.
 
-X509_VERIFY_PARAM_get_hostflags() was added in OpenSSL 1.1.0i.
+The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_get0_signature.pod
+++ b/doc/man3/X509_get0_signature.pod
@@ -109,12 +109,14 @@ L<X509_verify_cert(3)>
 
 =head1 HISTORY
 
-X509_get0_signature() and X509_get_signature_nid() were first added to
-OpenSSL 1.0.2.
+The
+X509_get0_signature() and X509_get_signature_nid() functions were
+added in OpenSSL 1.0.2.
 
+The
 X509_REQ_get0_signature(), X509_REQ_get_signature_nid(),
-X509_CRL_get0_signature() and X509_CRL_get_signature_nid() were first added
-to OpenSSL 1.1.0.
+X509_CRL_get0_signature() and X509_CRL_get_signature_nid() were
+added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_get_serialNumber.pod
+++ b/doc/man3/X509_get_serialNumber.pod
@@ -56,8 +56,9 @@ L<X509_verify_cert(3)>
 
 =head1 HISTORY
 
-X509_get_serialNumber() and X509_set_serialNumber() are available in
-all versions of OpenSSL. X509_get0_serialNumber() was added in OpenSSL 1.1.0.
+The X509_get_serialNumber() and X509_set_serialNumber() functions are
+available in all versions of OpenSSL.
+The X509_get0_serialNumber() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_get_subject_name.pod
+++ b/doc/man3/X509_get_subject_name.pod
@@ -53,8 +53,8 @@ and X509_CRL_set_issuer_name() return 1 for success and 0 for failure.
 X509_REQ_get_subject_name() is a function in OpenSSL 1.1.0 and a macro in
 earlier versions.
 
-X509_CRL_get_issuer() is a function in OpenSSL 1.1.0. It was first added
-to OpenSSL 1.0.0 as a macro.
+X509_CRL_get_issuer() is a function in OpenSSL 1.1.0. It was previously
+added in OpenSSL 1.0.0 as a macro.
 
 =head1 SEE ALSO
 

--- a/doc/man3/X509_sign.pod
+++ b/doc/man3/X509_sign.pod
@@ -81,11 +81,11 @@ L<X509_verify_cert(3)>
 
 =head1 HISTORY
 
-X509_sign(), X509_REQ_sign() and X509_CRL_sign() are available in all
-versions of OpenSSL.
+The X509_sign(), X509_REQ_sign() and X509_CRL_sign() functions are
+available in all versions of OpenSSL.
 
-X509_sign_ctx(), X509_REQ_sign_ctx() and X509_CRL_sign_ctx() were first added
-to OpenSSL 1.0.1.
+The X509_sign_ctx(), X509_REQ_sign_ctx()
+and X509_CRL_sign_ctx() functions were added OpenSSL 1.0.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/i2d_CMS_bio_stream.pod
+++ b/doc/man3/i2d_CMS_bio_stream.pod
@@ -39,7 +39,7 @@ L<PEM_write_bio_CMS_stream(3)>
 
 =head1 HISTORY
 
-i2d_CMS_bio_stream() was added to OpenSSL 1.0.0
+The i2d_CMS_bio_stream() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/i2d_PKCS7_bio_stream.pod
+++ b/doc/man3/i2d_PKCS7_bio_stream.pod
@@ -39,7 +39,7 @@ L<PEM_write_bio_PKCS7_stream(3)>
 
 =head1 HISTORY
 
-i2d_PKCS7_bio_stream() was added to OpenSSL 1.0.0
+The i2d_PKCS7_bio_stream() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/ct.pod
+++ b/doc/man7/ct.pod
@@ -39,7 +39,7 @@ L<SSL_CTX_set_ct_validation_callback(3)>
 
 =head1 HISTORY
 
-This library was added in OpenSSL 1.1.0.
+The ct library was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
While stereotyped repetitions are frowned upon in literature, they serve a useful purpose in manual pages, because it is easier for the user to find certain information if it is always presented in the same way. For that reason, this commit harmonizes the varying formulations in the HISTORY section about which functions, flags, etc. were added in which OpenSSL version (as suggested by @t-j-h in https://github.com/openssl/openssl/pull/5253#discussion_r239726142).

It also attempts to make the pod files more grep friendly by avoiding to insert line breaks between the symbol names and the corresponding version number in which they were introduced (wherever possible). Some punctuation and typographical errors were fixed on the way.

