### PR TITLE
Trivial: typo ANS1 -> ASN1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11496,7 +11496,7 @@ des-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
      (still largely untested)
      [Bodo Moeller]
 
-  *) New function ANS1_tag2str() to convert an ASN1 tag to a descriptive
+  *) New function ASN1_tag2str() to convert an ASN1 tag to a descriptive
      ASCII string. This was handled independently in various places before.
      [Steve Henson]
 

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -16,7 +16,7 @@
 /* This is the primary function used to parse ASN1_UTCTIME */
 int asn1_utctime_to_tm(struct tm *tm, const ASN1_UTCTIME *d)
 {
-    /* wrapper around ans1_time_to_tm */
+    /* wrapper around asn1_time_to_tm */
     if (d->type != V_ASN1_UTCTIME)
         return 0;
     return asn1_time_to_tm(tm, d);

--- a/test/asn1_string_table_test.c
+++ b/test/asn1_string_table_test.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* Tests for the ANS1_STRING_TABLE_* functions */
+/* Tests for the ASN1_STRING_TABLE_* functions */
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
small typo fixes for ANS to ASN

##### Checklist
👍 