### PR TITLE
VMS: fix library compatibility settings in util/mkdef.pl

### DIFF
--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -386,7 +386,10 @@ _____
 _____
 
     if (defined $version) {
-        my ($libvmajor, $libvminor) = $version =~ /^(\d+)_(\d+)$/;
+        print STDERR "DEBUG: \$version = $version\n";
+        $version =~ /^(\d+)\.(\d+)\.(\d+)/;
+        my $libvmajor = $1;
+        my $libvminor = $2 * 100 + $3;
         print <<"_____";
 GSMATCH=LEQUAL,$libvmajor,$libvminor;
 _____

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -386,7 +386,6 @@ _____
 _____
 
     if (defined $version) {
-        print STDERR "DEBUG: \$version = $version\n";
         $version =~ /^(\d+)\.(\d+)\.(\d+)/;
         my $libvmajor = $1;
         my $libvminor = $2 * 100 + $3;


### PR DESCRIPTION
The regexp to parse the incoming version number was flawed, and since
we allow ourselves to add missing APIs in PATCH releases, the
compatibility settings still need to include the PATCH part of the
version number.
