### PR TITLE
eng_devcrypto: add option to build as a dynamic engine

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Build devcrypto engine as a dynamic engine.
+     [Eneas U de Queiroz]
+
   *) Add keyed BLAKE2 to EVP_MAC.
      [Antoine Salon]
 

--- a/crypto/engine/build.info
+++ b/crypto/engine/build.info
@@ -6,6 +6,3 @@ SOURCE[../../libcrypto]=\
         tb_cipher.c tb_digest.c tb_pkmeth.c tb_asnmth.c tb_eckey.c \
         eng_openssl.c eng_cnf.c eng_dyn.c \
         eng_rdrand.c
-IF[{- !$disabled{devcryptoeng} -}]
-  SOURCE[../../libcrypto]=eng_devcrypto.c
-ENDIF

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -353,18 +353,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
     engine_load_openssl_int();
     return 1;
 }
-# ifndef OPENSSL_NO_DEVCRYPTOENG
-static CRYPTO_ONCE engine_devcrypto = CRYPTO_ONCE_STATIC_INIT;
-DEFINE_RUN_ONCE_STATIC(ossl_init_engine_devcrypto)
-{
-#  ifdef OPENSSL_INIT_DEBUG
-    fprintf(stderr, "OPENSSL_INIT: ossl_init_engine_devcrypto: "
-                    "engine_load_devcrypto_int()\n");
-#  endif
-    engine_load_devcrypto_int();
-    return 1;
-}
-# endif
 
 # ifndef OPENSSL_NO_RDRAND
 static CRYPTO_ONCE engine_rdrand = CRYPTO_ONCE_STATIC_INIT;
@@ -389,6 +377,18 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_dynamic)
     return 1;
 }
 # ifndef OPENSSL_NO_STATIC_ENGINE
+#  ifndef OPENSSL_NO_DEVCRYPTOENG
+static CRYPTO_ONCE engine_devcrypto = CRYPTO_ONCE_STATIC_INIT;
+DEFINE_RUN_ONCE_STATIC(ossl_init_engine_devcrypto)
+{
+#   ifdef OPENSSL_INIT_DEBUG
+    fprintf(stderr, "OPENSSL_INIT: ossl_init_engine_devcrypto: "
+                    "engine_load_devcrypto_int()\n");
+#   endif
+    engine_load_devcrypto_int();
+    return 1;
+}
+#  endif
 #  if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_HW_PADLOCK)
 static CRYPTO_ONCE engine_padlock = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(ossl_init_engine_padlock)
@@ -747,11 +747,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     if ((opts & OPENSSL_INIT_ENGINE_OPENSSL)
             && !RUN_ONCE(&engine_openssl, ossl_init_engine_openssl))
         return 0;
-# if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_DEVCRYPTOENG)
-    if ((opts & OPENSSL_INIT_ENGINE_CRYPTODEV)
-            && !RUN_ONCE(&engine_devcrypto, ossl_init_engine_devcrypto))
-        return 0;
-# endif
 # ifndef OPENSSL_NO_RDRAND
     if ((opts & OPENSSL_INIT_ENGINE_RDRAND)
             && !RUN_ONCE(&engine_rdrand, ossl_init_engine_rdrand))
@@ -761,6 +756,11 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             && !RUN_ONCE(&engine_dynamic, ossl_init_engine_dynamic))
         return 0;
 # ifndef OPENSSL_NO_STATIC_ENGINE
+#  ifndef OPENSSL_NO_DEVCRYPTOENG
+    if ((opts & OPENSSL_INIT_ENGINE_CRYPTODEV)
+            && !RUN_ONCE(&engine_devcrypto, ossl_init_engine_devcrypto))
+        return 0;
+#  endif
 #  if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_HW_PADLOCK)
     if ((opts & OPENSSL_INIT_ENGINE_PADLOCK)
             && !RUN_ONCE(&engine_padlock, ossl_init_engine_padlock))

--- a/engines/build.info
+++ b/engines/build.info
@@ -10,6 +10,9 @@ IF[{- !$disabled{"engine"} -}]
     IF[{- !$disabled{afalgeng} -}]
       SOURCE[../libcrypto]=e_afalg.c
     ENDIF
+    IF[{- !$disabled{"devcryptoeng"} -}]
+      SOURCE[../libcrypto]=e_devcrypto.c
+    ENDIF
   ELSE
     ENGINES=padlock
     SOURCE[padlock]=e_padlock.c {- $target{padlock_asm_src} -}
@@ -37,6 +40,16 @@ IF[{- !$disabled{"engine"} -}]
       IF[{- defined $target{shared_defflag} -}]
         SHARED_SOURCE[afalg]=afalg.ld
         GENERATE[afalg.ld]=../util/engines.num
+      ENDIF
+    ENDIF
+    IF[{- !$disabled{"devcryptoeng"} -}]
+      ENGINES=devcrypto
+      SOURCE[devcrypto]=e_devcrypto.c
+      DEPEND[devcrypto]=../libcrypto
+      INCLUDE[devcrypto]=../include
+      IF[{- defined $target{shared_defflag} -}]
+        SHARED_SOURCE[devcrypto]=devcrypto.ld
+        GENERATE[devcrypto.ld]=../util/engines.num
       ENDIF
     ENDIF
 


### PR DESCRIPTION
This is useful to distribute /dev/crypto support as a separate package.

- [x] documentation is added or updated
