### PR TITLE
Consolidate SSL_DEBUG data dump

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -564,7 +564,7 @@ int ssl3_get_record(SSL *s)
         return -1;
     }
 
-    SSL_DEBUG_data_dump("dec %u:\n", rr[0].length, rr[0].data, rr[0].length);
+    SSL_DEBUG_data_dump(rr[0].data, rr[0].length, "dec %lu\n", rr[0].length);
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) &&
@@ -1354,8 +1354,8 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
 
     EVP_MD_CTX_free(hmac);
 
-    SSL_DEBUG_data_dump("seq:\n", 0, seq, 8);
-    SSL_DEBUG_data_dump("rec:\n", 0, rec->data, rec->length);
+    SSL_DEBUG_data_dump(seq, 8, "seq:\n");
+    SSL_DEBUG_data_dump(rec->data, rec->length, "rec:\n");
 
     if (!SSL_IS_DTLS(ssl)) {
         for (i = 7; i >= 0; i--) {
@@ -1365,7 +1365,7 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         }
     }
 
-    SSL_DEBUG_data_dump("md:\n", 0, md, md_size);
+    SSL_DEBUG_data_dump(md, md_size, "md:\n");
 
     return 1;
 }
@@ -1658,7 +1658,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         return 0;
     }
 
-    SSL_DEBUG_data_dump("dec %d:\n", rr->length, rr->data, rr->length);
+    SSL_DEBUG_data_dump(rr->data, rr->length, "dec %d: \m", rr->length);
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) && !SSL_READ_ETM(s) &&

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -564,7 +564,7 @@ int ssl3_get_record(SSL *s)
         return -1;
     }
 
-    SSL_DEBUG_data_dump(rr[0].data, rr[0].length, "dec %lu\n", rr[0].length);
+    SSL_DEBUG_data_dump(rr[0].data, rr[0].length, "dec %lu\n", (unsigned long)rr[0].length);
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) &&
@@ -1658,7 +1658,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         return 0;
     }
 
-    SSL_DEBUG_data_dump(rr->data, rr->length, "dec %d: \m", rr->length);
+    SSL_DEBUG_data_dump(rr->data, rr->length, "dec %d: \n", rr->length);
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) && !SSL_READ_ETM(s) &&

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -563,15 +563,8 @@ int ssl3_get_record(SSL *s)
                  SSL_R_BLOCK_CIPHER_PAD_IS_WRONG);
         return -1;
     }
-#ifdef SSL_DEBUG
-    printf("dec %lu\n", (unsigned long)rr[0].length);
-    {
-        size_t z;
-        for (z = 0; z < rr[0].length; z++)
-            printf("%02X%c", rr[0].data[z], ((z + 1) % 16) ? ' ' : '\n');
-    }
-    printf("\n");
-#endif
+
+    SSL_DEBUG_data_dump("dec %u:\n", rr[0].length, rr[0].data, rr[0].length);
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) &&
@@ -1361,22 +1354,8 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
 
     EVP_MD_CTX_free(hmac);
 
-#ifdef SSL_DEBUG
-    fprintf(stderr, "seq=");
-    {
-        int z;
-        for (z = 0; z < 8; z++)
-            fprintf(stderr, "%02X ", seq[z]);
-        fprintf(stderr, "\n");
-    }
-    fprintf(stderr, "rec=");
-    {
-        size_t z;
-        for (z = 0; z < rec->length; z++)
-            fprintf(stderr, "%02X ", rec->data[z]);
-        fprintf(stderr, "\n");
-    }
-#endif
+    SSL_DEBUG_data_dump("seq:\n", 0, seq, 8);
+    SSL_DEBUG_data_dump("rec:\n", 0, rec->data, rec->length);
 
     if (!SSL_IS_DTLS(ssl)) {
         for (i = 7; i >= 0; i--) {
@@ -1385,14 +1364,9 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
                 break;
         }
     }
-#ifdef SSL_DEBUG
-    {
-        unsigned int z;
-        for (z = 0; z < md_size; z++)
-            fprintf(stderr, "%02X ", md[z]);
-        fprintf(stderr, "\n");
-    }
-#endif
+
+    SSL_DEBUG_data_dump("md:\n", 0, md, md_size);
+
     return 1;
 }
 
@@ -1683,15 +1657,8 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         RECORD_LAYER_reset_packet_length(&s->rlayer);
         return 0;
     }
-#ifdef SSL_DEBUG
-    printf("dec %ld\n", rr->length);
-    {
-        size_t z;
-        for (z = 0; z < rr->length; z++)
-            printf("%02X%c", rr->data[z], ((z + 1) % 16) ? ' ' : '\n');
-    }
-    printf("\n");
-#endif
+
+    SSL_DEBUG_data_dump("dec %d:\n", rr->length, rr->data, rr->length);
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) && !SSL_READ_ETM(s) &&

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5583,14 +5583,18 @@ void SSL_set_allow_early_data_cb(SSL *s,
     s->allow_early_data_cb_data = arg;
 }
 
-#ifdef SSL_DEBUG
-/* 
+/*
  * Debug routine, uses the prefix with a possible int argument |ival|
  */
-void ssl_debug_data_dump(const char* prefix, unsigned int ival, void *data, size_t len)
+void ssl_debug_data_dump(const void *data, size_t len, const char *prefix, ...)
 {
+#ifdef SSL_DEBUG
+    va_list ap;
+
+    va_start(ap, prefix);
     /* Coverity and other tools may complain about this, but it's debug! */
-    fprintf(stderr, prefix, ival);
+    vfprintf(stderr, prefix, ap);
     BIO_dump_fp(stderr, data, len);
-}
+    va_end(ap);
 #endif
+}

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5594,7 +5594,8 @@ void ssl_debug_data_dump(const void *data, size_t len, const char *prefix, ...)
     va_start(ap, prefix);
     /* Coverity and other tools may complain about this, but it's debug! */
     vfprintf(stderr, prefix, ap);
-    BIO_dump_fp(stderr, data, len);
+    if (data != NULL && len != 0)
+        BIO_dump_fp(stderr, data, len);
     va_end(ap);
 #endif
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5582,3 +5582,15 @@ void SSL_set_allow_early_data_cb(SSL *s,
     s->allow_early_data_cb = cb;
     s->allow_early_data_cb_data = arg;
 }
+
+#ifdef SSL_DEBUG
+/* 
+ * Debug routine, uses the prefix with a possible int argument |ival|
+ */
+void ssl_debug_data_dump(const char* prefix, unsigned int ival, void *data, size_t len)
+{
+    /* Coverity and other tools may complain about this, but it's debug! */
+    fprintf(stderr, prefix, ival);
+    BIO_dump_fp(stderr, data, len);
+}
+#endif

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2666,4 +2666,12 @@ void ssl_ctx_system_config(SSL_CTX *ctx);
 #  define ssl3_setup_buffers SSL_test_functions()->p_ssl3_setup_buffers
 
 # endif
+
+# ifdef SSL_DEBUG
+void ssl_debug_data_dump(const char* prefix, unsigned int ival, void *data, size_t len);
+#  define SSL_DEBUG_data_dump(a,b,c,d) ssl_debug_data_dump(a,b,c,d)
+# else
+#  define SSL_DEBUG_data_dump(a,b,c,d)
+# endif
+
 #endif

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2667,11 +2667,30 @@ void ssl_ctx_system_config(SSL_CTX *ctx);
 
 # endif
 
-# ifdef SSL_DEBUG
-void ssl_debug_data_dump(const char* prefix, unsigned int ival, void *data, size_t len);
-#  define SSL_DEBUG_data_dump(a,b,c,d) ssl_debug_data_dump(a,b,c,d)
+/*
+ * SSL_DEBUG support
+ */
+# if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L
+#  define SSL_DEBUG_data_dump ssl_debug_data_dump
 # else
-#  define SSL_DEBUG_data_dump(a,b,c,d)
+#  ifdef SSL_DEBUG
+#   define SSL_DEBUG_data_dump(...) ssl_debug_data_dump(__VA_ARGS__)
+#  else
+#   define SSL_DEBUG_data_dump(...)
+#  endif
 # endif
+
+# undef PRINTF_FORMAT
+# define PRINTF_FORMAT(a, b)
+# if defined(__GNUC__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+  /*
+   * Because we support the 'z' modifier, which made its appearance in C99,
+   * we can't use __attribute__ with pre C99 dialects.
+   */
+#  undef PRINTF_FORMAT
+#  define PRINTF_FORMAT(a, b)   __attribute__ ((format(printf, a, b)))
+# endif
+void ssl_debug_data_dump(const void *data, size_t len, const char *prefix, ...) PRINTF_FORMAT(3, 4);
+# undef PRINTF_FORMAT
 
 #endif

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2351,11 +2351,10 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
                      ERR_R_INTERNAL_ERROR);
             goto err;
         }
-#ifdef SSL_DEBUG
+
         if (SSL_USE_SIGALGS(s))
-            fprintf(stderr, "USING TLSv1.2 HASH %s\n",
-                    md == NULL ? "n/a" : EVP_MD_name(md));
-#endif
+            SSL_DEBUG_data_dump(NULL, 0, "USING TLSv1.2 HASH %s\n",
+                                md == NULL ? "n/a" : EVP_MD_name(md));
 
         if (!PACKET_get_length_prefixed_2(pkt, &signature)
             || PACKET_remaining(pkt) != 0) {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2352,9 +2352,10 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
             goto err;
         }
 
-        if (SSL_USE_SIGALGS(s))
+        if (SSL_USE_SIGALGS(s)) {
             SSL_DEBUG_data_dump(NULL, 0, "USING TLSv1.2 HASH %s\n",
                                 md == NULL ? "n/a" : EVP_MD_name(md));
+        }
 
         if (!PACKET_get_length_prefixed_2(pkt, &signature)
             || PACKET_remaining(pkt) != 0) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -394,9 +394,10 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto err;
     }
 
-    if (SSL_USE_SIGALGS(s))
+    if (SSL_USE_SIGALGS(s)) {
         SSL_DEBUG_data_dump(NULL, 0, "USING TLSv1.2 HASH %s\n",
                             md == NULL ? "n/a" : EVP_MD_name(md));
+    }
 
     /* Check for broken implementations of GOST ciphersuites */
     /*

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -394,11 +394,9 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto err;
     }
 
-#ifdef SSL_DEBUG
     if (SSL_USE_SIGALGS(s))
-        fprintf(stderr, "USING TLSv1.2 HASH %s\n",
-                md == NULL ? "n/a" : EVP_MD_name(md));
-#endif
+        SSL_DEBUG_data_dump(NULL, 0, "USING TLSv1.2 HASH %s\n",
+                            md == NULL ? "n/a" : EVP_MD_name(md));
 
     /* Check for broken implementations of GOST ciphersuites */
     /*
@@ -439,10 +437,9 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto err;
     }
 
-#ifdef SSL_DEBUG
-    fprintf(stderr, "Using client verify alg %s\n",
-            md == NULL ? "n/a" : EVP_MD_name(md));
-#endif
+    SSL_DEBUG_data_dump(NULL, 0, "Using client verify alg %s\n",
+                        md == NULL ? "n/a" : EVP_MD_name(md));
+
     if (EVP_DigestVerifyInit(mctx, &pctx, md, NULL, pkey) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CERT_VERIFY,
                  ERR_R_EVP_LIB);

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -280,7 +280,7 @@ int tls1_change_cipher_state(SSL *s, int which)
         }
         EVP_PKEY_free(mac_key);
     }
-    SSL_DEBUG_data_dump("which = %04X, nmac key:\n", which, ms, i);
+    SSL_DEBUG_data_dump(ms, i, "which = %04X, nmac key:\n", which);
 
     if (EVP_CIPHER_mode(c) == EVP_CIPH_GCM_MODE) {
         if (!EVP_CipherInit_ex(dd, c, NULL, key, NULL, (which & SSL3_CC_WRITE))
@@ -385,8 +385,8 @@ int tls1_change_cipher_state(SSL *s, int which)
 #endif                          /* OPENSSL_NO_KTLS */
     s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
 
-    SSL_DEBUG_data_dump("which = %04X, key:\n", which, key, EVP_CIPHER_key_length(c));
-    SSL_DEBUG_data_dump("iv:\n", 0, iv, k);
+    SSL_DEBUG_data_dump(key, EVP_CIPHER_key_length(c), "which = %04X, key:\n", which);
+    SSL_DEBUG_data_dump(iv, k, "iv:\n");
 
     OPENSSL_cleanse(tmp1, sizeof(tmp1));
     OPENSSL_cleanse(tmp2, sizeof(tmp1));
@@ -439,15 +439,15 @@ int tls1_setup_key_block(SSL *s)
     s->s3->tmp.key_block_length = num;
     s->s3->tmp.key_block = p;
 
-    SSL_DEBUG_data_dump("client random:\n", 0, s->s3->client_random, SSL3_RANDOM_SIZE);
-    SSL_DEBUG_data_dump("server random:\n", 0, s->s3->server_random, SSL3_RANDOM_SIZE);
-    SSL_DEBUG_data_dump("master key:\n", 0, s->session->master_key, s->session->master_key_length);
+    SSL_DEBUG_data_dump(s->s3->client_random, SSL3_RANDOM_SIZE, "client random:\n");
+    SSL_DEBUG_data_dump(s->s3->server_random, SSL3_RANDOM_SIZE, "server random:\n");
+    SSL_DEBUG_data_dump(s->session->master_key, s->session->master_key_length, "master key:\n");
     if (!tls1_generate_key_block(s, p, num)) {
         /* SSLfatal() already called */
         goto err;
     }
 
-    SSL_DEBUG_data_dump("key block:\n", 0, p, num);
+    SSL_DEBUG_data_dump(p, num, "key block:\n");
 
     if (!(s->options & SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS)
         && s->method->version <= TLS1_VERSION) {
@@ -516,7 +516,7 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
             return 0;
         }
 
-        SSL_DEBUG_data_dump("Handshake hashes:\n", 0, hash, hashlen);
+        SSL_DEBUG_data_dump(hash, hashlen, "Handshake hashes:\n");
 
         if (!tls1_PRF(s,
                       TLS_MD_EXTENDED_MASTER_SECRET_CONST,
@@ -544,10 +544,10 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
         }
     }
 
-    SSL_DEBUG_data_dump("Premaster Secret:\n", 0, p, len);
-    SSL_DEBUG_data_dump("Client Random:\n", 0, s->s3->client_random, SSL3_RANDOM_SIZE);
-    SSL_DEBUG_data_dump("Server Random:\n", 0, s->s3->server_random, SSL3_RANDOM_SIZE);
-    SSL_DEBUG_data_dump("Master Secret:\n", 0, s->session->master_key, SSL3_MASTER_SECRET_SIZE);
+    SSL_DEBUG_data_dump(p, len, "Premaster Secret:\n");
+    SSL_DEBUG_data_dump(s->s3->client_random, SSL3_RANDOM_SIZE, "Client Random:\n");
+    SSL_DEBUG_data_dump(s->s3->server_random, SSL3_RANDOM_SIZE, "Server Random\n");
+    SSL_DEBUG_data_dump(s->session->master_key, SSL3_MASTER_SECRET_SIZE, "Master Secret\n");
 
     *secret_size = SSL3_MASTER_SECRET_SIZE;
     return 1;


### PR DESCRIPTION
Clean up SSL_DEBUG data dumping code; use a single, common API.
Send all SSL_DEBUG output to stderr
Use BIO dump routines for consistency

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
