### PR TITLE
bn/bn_mul.c: forcibly disable BN_RECURSION [for constant-time-ness].

### DIFF
--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -74,14 +74,19 @@ int bn_sqr_fixed_top(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
             j = BN_num_bits_word((BN_ULONG)al);
             j = 1 << (j - 1);
             k = j + j;
-            if (al == j) {
-                if (bn_wexpand(tmp, k * 2) == NULL)
-                    goto err;
-                bn_sqr_recursive(rr->d, a->d, al, tmp->d);
-            } else {
-                if (bn_wexpand(tmp, max) == NULL)
-                    goto err;
-                bn_sqr_normal(rr->d, a->d, al, tmp->d);
+            if (bn_wexpand(tmp, k * 2) == NULL)
+                goto err;
+
+            bn_sqr_recursive(rr->d, a->d, j, tmp->d);
+
+            if (al > j) {
+                int i;
+                BN_ULONG *tail = &(rr->d[k]);
+
+                for (i = j; i < al; i++)
+                    *tail++ = bn_mul_add_words(&(rr->d[i]), a->d, j, a->d[i]);
+                for (i = j; i < al; i++)
+                    *tail++ = bn_mul_add_words(&(rr->d[i]), a->d, al, a->d[i]);
             }
         }
 #else
@@ -155,9 +160,8 @@ void bn_sqr_normal(BN_ULONG *r, const BN_ULONG *a, int n, BN_ULONG *tmp)
  */
 void bn_sqr_recursive(BN_ULONG *r, const BN_ULONG *a, int n2, BN_ULONG *t)
 {
-    int n = n2 / 2;
-    int zero, c1;
-    BN_ULONG ln, lo, *p;
+    int i, n = n2 / 2;
+    BN_ULONG carry, w, *p;
 
     if (n2 == 4) {
 # ifndef BN_SQR_COMBA
@@ -179,22 +183,15 @@ void bn_sqr_recursive(BN_ULONG *r, const BN_ULONG *a, int n2, BN_ULONG *t)
         return;
     }
     /* r=(a[0]-a[1])*(a[1]-a[0]) */
-    c1 = bn_cmp_words(a, &(a[n]), n);
-    zero = 0;
-    if (c1 > 0)
-        bn_sub_words(t, a, &(a[n]), n);
-    else if (c1 < 0)
-        bn_sub_words(t, &(a[n]), a, n);
-    else
-        zero = 1;
+    carry = bn_sub_words(&(t[0]), a, &(a[n]), n);
+    carry = bn_sub_words(&(t[n]), &(a[n]), a, n);
+    for (carry = 0 - carry, i = 0; i < n; i++)
+        t[i] = (t[i] & carry) | (t[n + i] & ~carry);
 
     /* The result will always be negative unless it is zero */
     p = &(t[n2 * 2]);
 
-    if (!zero)
-        bn_sqr_recursive(&(t[n2]), t, n, p);
-    else
-        memset(&t[n2], 0, sizeof(*t) * n2);
+    bn_sqr_recursive(&(t[n2]), t, n, p);
     bn_sqr_recursive(r, a, n, p);
     bn_sqr_recursive(&(r[n2]), &(a[n]), n, p);
 
@@ -204,10 +201,10 @@ void bn_sqr_recursive(BN_ULONG *r, const BN_ULONG *a, int n2, BN_ULONG *t)
      * r[32] holds (b[1]*b[1])
      */
 
-    c1 = (int)(bn_add_words(t, r, &(r[n2]), n2));
+    carry = bn_add_words(t, r, &(r[n2]), n2);
 
     /* t[32] is negative */
-    c1 -= (int)(bn_sub_words(&(t[n2]), t, &(t[n2]), n2));
+    carry -= bn_sub_words(&(t[n2]), t, &(t[n2]), n2);
 
     /*-
      * t[32] holds (a[0]-a[1])*(a[1]-a[0])+(a[0]*a[0])+(a[1]*a[1])
@@ -215,25 +212,10 @@ void bn_sqr_recursive(BN_ULONG *r, const BN_ULONG *a, int n2, BN_ULONG *t)
      * r[32] holds (a[1]*a[1])
      * c1 holds the carry bits
      */
-    c1 += (int)(bn_add_words(&(r[n]), &(r[n]), &(t[n2]), n2));
-    if (c1) {
-        p = &(r[n + n2]);
-        lo = *p;
-        ln = (lo + c1) & BN_MASK2;
-        *p = ln;
-
-        /*
-         * The overflow will stop before we over write words we should not
-         * overwrite
-         */
-        if (ln < (BN_ULONG)c1) {
-            do {
-                p++;
-                lo = *p;
-                ln = (lo + 1) & BN_MASK2;
-                *p = ln;
-            } while (ln == 0);
-        }
+    carry += bn_add_words(&(r[n]), &(r[n]), &(t[n2]), n2);
+    for (p = &(r[n + n2]), i = 0; i < n; i++) {
+        w = p[i] += carry;
+        carry = w < carry;
     }
 }
 #endif


### PR DESCRIPTION
Just in case for reference. "Significantly slower" mentioned in commentary is platform-specific, but it's ~40% on most popular platform (for 33x32 or 33x33 multiplications). Recall that "50% slower" mean "2x slower".