### PR TITLE
fix inconsistent flen check in rsa_pk1 and rsa_oaep

### DIFF
--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -161,7 +161,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     unsigned int good, found_zero_byte, mask;
     int zero_index = 0, msg_index, mlen = -1;
 
-    if (tlen < 0 || flen < 0)
+    if (tlen <= 0 || flen <= 0)
         return -1;
 
     /*


### PR DESCRIPTION
Fixes #7117.

Although we noticed that memcpy has been removed in this commit e875b0cf2f10bf2adf73e0c2ec81428290f4660c , the inconsistency still remains.