### PR TITLE
WIP: Add generic trace and debug hook API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,13 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Added support for enabling instrumentation through trace and debug output.
+     This is left to application control, by allowing it to register callbacks
+     for a number of tracing and debugging types.  The 'openssl' application
+     has been expanded to enable any of the types available via environment
+     variables defined by the user, and serves as one possible example.
+     [Richard Levitte]
+
   *) Move strictness check from EVP_PKEY_asn1_new() to EVP_PKEY_asn1_add0().
      [Richard Levitte]
 

--- a/Configure
+++ b/Configure
@@ -406,6 +406,7 @@ my @disablables = (
     "tests",
     "threads",
     "tls",
+    "trace",
     "ts",
     "ubsan",
     "ui-console",

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@
 
   Major changes between OpenSSL 1.1.1 and OpenSSL 3.0.0 [under development]
 
+      o Add support for enabling instrumentation through trace and debug
+        output.
       o Changed our version number scheme and set the next major release to
         3.0.0
       o Added EVP_MAC, an EVP layer MAC API, and a generic EVP_PKEY to EVP_MAC

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -132,13 +132,11 @@ static size_t internal_debug_cb(const char *buf, size_t cnt, void *data)
     return ret < 0 ? 0 : ret;
 }
 
-static void setup_trace(void)
+static void setup_trace(const char *str)
 {
-    const char *env;
     char *val;
 
-    env = getenv("OPENSSL_TRACE");
-    val = OPENSSL_strdup(env);
+    val = OPENSSL_strdup(str);
 
     if (val != NULL) {
         char *valp = val;
@@ -155,13 +153,11 @@ static void setup_trace(void)
     OPENSSL_free(val);
 }
 
-static void setup_debug(void)
+static void setup_debug(const char *str)
 {
-    const char *env;
     char *val;
 
-    env = getenv("OPENSSL_DEBUG");
-    val = OPENSSL_strdup(env);
+    val = OPENSSL_strdup(str);
 
     if (val != NULL) {
         char *valp = val;
@@ -219,8 +215,8 @@ int main(int argc, char *argv[])
     win32_utf8argv(&argc, &argv);
 #endif
 
-    setup_trace();
-    setup_debug();
+    setup_trace(getenv("OPENSSL_TRACE"));
+    setup_debug(getenv("OPENSSL_DEBUG"));
 
     p = getenv("OPENSSL_DEBUG_MEMORY");
     if (p != NULL && strcmp(p, "on") == 0)

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -38,6 +38,7 @@ typedef unsigned int u_int;
 #include <openssl/rand.h>
 #include <openssl/ocsp.h>
 #include <openssl/bn.h>
+#include <openssl/trace.h>
 #include <openssl/async.h>
 #ifndef OPENSSL_NO_SRP
 # include <openssl/srp.h>
@@ -1497,6 +1498,7 @@ int s_client_main(int argc, char **argv)
             break;
         }
     }
+
     if (count4or6 >= 2) {
         BIO_printf(bio_err, "%s: Can't use both -4 and -6\n", prog);
         goto opthelp;
@@ -3250,8 +3252,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
         BIO_printf(bio_err, "Using Kernel TLS for sending\n");
 #endif
 
-#ifdef SSL_DEBUG
-    {
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
         /* Print out local port of connection: useful for debugging */
         int sock;
         union BIO_sock_info_u info;
@@ -3264,7 +3265,6 @@ static void print_stuff(BIO *bio, SSL *s, int full)
         }
         BIO_ADDR_free(info.addr);
     }
-#endif
 
 #if !defined(OPENSSL_NO_NEXTPROTONEG)
     if (next_proto.status != -1) {

--- a/crypto/bio/b_dump.c
+++ b/crypto/bio/b_dump.c
@@ -20,14 +20,15 @@
 #define SPACE(buf, pos, n)   (sizeof(buf) - (pos) > (n))
 
 int BIO_dump_cb(int (*cb) (const void *data, size_t len, void *u),
-                void *u, const char *s, int len)
+                void *u, const void *s, int len)
 {
     return BIO_dump_indent_cb(cb, u, s, len, 0);
 }
 
 int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
-                       void *u, const char *s, int len, int indent)
+                       void *u, const void *v, int len, int indent)
 {
+    const unsigned char *s = v;
     int ret = 0;
     char buf[288 + 1];
     int i, j, rows, n;
@@ -51,7 +52,7 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
                 if (((i * dump_width) + j) >= len) {
                     strcpy(buf + n, "   ");
                 } else {
-                    ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
+                    ch = *(s + i * dump_width + j) & 0xff;
                     BIO_snprintf(buf + n, 4, "%02x%c", ch,
                                  j == 7 ? '-' : ' ');
                 }
@@ -66,7 +67,7 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
             if (((i * dump_width) + j) >= len)
                 break;
             if (SPACE(buf, n, 1)) {
-                ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
+                ch = *(s + i * dump_width + j) & 0xff;
 #ifndef CHARSET_EBCDIC
                 buf[n++] = ((ch >= ' ') && (ch <= '~')) ? ch : '.';
 #else
@@ -96,12 +97,12 @@ static int write_fp(const void *data, size_t len, void *fp)
     return UP_fwrite(data, len, 1, fp);
 }
 
-int BIO_dump_fp(FILE *fp, const char *s, int len)
+int BIO_dump_fp(FILE *fp, const void *s, int len)
 {
     return BIO_dump_cb(write_fp, fp, s, len);
 }
 
-int BIO_dump_indent_fp(FILE *fp, const char *s, int len, int indent)
+int BIO_dump_indent_fp(FILE *fp, const void *s, int len, int indent)
 {
     return BIO_dump_indent_cb(write_fp, fp, s, len, indent);
 }
@@ -112,19 +113,20 @@ static int write_bio(const void *data, size_t len, void *bp)
     return BIO_write((BIO *)bp, (const char *)data, len);
 }
 
-int BIO_dump(BIO *bp, const char *s, int len)
+int BIO_dump(BIO *bp, const void *s, int len)
 {
     return BIO_dump_cb(write_bio, bp, s, len);
 }
 
-int BIO_dump_indent(BIO *bp, const char *s, int len, int indent)
+int BIO_dump_indent(BIO *bp, const void *s, int len, int indent)
 {
     return BIO_dump_indent_cb(write_bio, bp, s, len, indent);
 }
 
-int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
+int BIO_hex_string(BIO *out, int indent, int width, const void *data,
                    int datalen)
 {
+    const unsigned char *d = data;
     int i, j = 0;
 
     if (datalen < 1)
@@ -134,7 +136,7 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
         if (i && !j)
             BIO_printf(out, "%*s", indent, "");
 
-        BIO_printf(out, "%02X:", data[i]);
+        BIO_printf(out, "%02X:", d[i]);
 
         j = (j + 1) % width;
         if (!j)
@@ -143,6 +145,6 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
 
     if (i && !j)
         BIO_printf(out, "%*s", indent, "");
-    BIO_printf(out, "%02X", data[datalen - 1]);
+    BIO_printf(out, "%02X", d[datalen - 1]);
     return 1;
 }

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -12,8 +12,8 @@ SOURCE[../libcrypto]=\
         cryptlib.c mem.c mem_dbg.c cversion.c ex_data.c cpt_err.c \
         ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c ctype.c \
         threads_pthread.c threads_win.c threads_none.c getenv.c \
-        o_init.c o_fips.c mem_sec.c init.c {- $target{cpuid_asm_src} -} \
-        {- $target{uplink_aux_src} -}
+        o_init.c o_fips.c mem_sec.c init.c trace.c \
+        {- $target{cpuid_asm_src} -} {- $target{uplink_aux_src} -}
 EXTRA=  ../ms/uplink-x86.pl ../ms/uplink.c ../ms/applink.c \
         x86cpuid.pl x86_64cpuid.pl ia64cpuid.S \
         ppccpuid.pl pariscid.pl alphacpuid.pl arm64cpuid.pl armv4cpuid.pl

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -9,8 +9,7 @@
 
 #include "eng_int.h"
 #include <openssl/conf.h>
-
-/* #define ENGINE_CONF_DEBUG */
+#include <openssl/trace.h>
 
 /* ENGINE config module */
 
@@ -50,9 +49,8 @@ static int int_engine_configure(const char *name, const char *value, const CONF 
     int soft = 0;
 
     name = skip_dot(name);
-#ifdef ENGINE_CONF_DEBUG
-    fprintf(stderr, "Configuring engine %s\n", name);
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_CONF))
+        OSSL_debug(OSSL_DEBUG_ENGINE_CONF, "Configuring engine %s\n", name);
     /* Value is a section containing ENGINE commands */
     ecmds = NCONF_get_section(cnf, value);
 
@@ -66,10 +64,10 @@ static int int_engine_configure(const char *name, const char *value, const CONF 
         ecmd = sk_CONF_VALUE_value(ecmds, i);
         ctrlname = skip_dot(ecmd->name);
         ctrlvalue = ecmd->value;
-#ifdef ENGINE_CONF_DEBUG
-        fprintf(stderr, "ENGINE conf: doing ctrl(%s,%s)\n", ctrlname,
-                ctrlvalue);
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_CONF))
+            OSSL_debug(OSSL_DEBUG_ENGINE_CONF,
+                       "ENGINE conf: doing ctrl(%s,%s)\n", ctrlname,
+                       ctrlvalue);
 
         /* First handle some special pseudo ctrls */
 
@@ -153,10 +151,10 @@ static int int_engine_module_init(CONF_IMODULE *md, const CONF *cnf)
     STACK_OF(CONF_VALUE) *elist;
     CONF_VALUE *cval;
     int i;
-#ifdef ENGINE_CONF_DEBUG
-    fprintf(stderr, "Called engine module: name %s, value %s\n",
-            CONF_imodule_get_name(md), CONF_imodule_get_value(md));
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_CONF))
+        OSSL_debug(OSSL_DEBUG_ENGINE_CONF,
+                   "Called engine module: name %s, value %s\n",
+                   CONF_imodule_get_name(md), CONF_imodule_get_value(md));
     /* Value is a section containing ENGINEs to configure */
     elist = NCONF_get_section(cnf, CONF_imodule_get_value(md));
 

--- a/crypto/engine/eng_int.h
+++ b/crypto/engine/eng_int.h
@@ -20,27 +20,21 @@
 extern CRYPTO_RWLOCK *global_engine_lock;
 
 /*
- * If we compile with this symbol defined, then both reference counts in the
- * ENGINE structure will be monitored with a line of output on stderr for
- * each change. This prints the engine's pointer address (truncated to
- * unsigned int), "struct" or "funct" to indicate the reference type, the
- * before and after reference count, and the file:line-number pair. The
- * "engine_ref_debug" statements must come *after* the change.
+ * This prints the engine's pointer address (truncated to unsigned int),
+ * "struct" or "funct" to indicate the reference type, the before and after
+ * reference count, and the file:line-number pair. The "engine_ref_debug"
+ * statements must come *after* the change.
  */
-# ifdef ENGINE_REF_COUNT_DEBUG
-
-#  define engine_ref_debug(e, isfunct, diff) \
-        fprintf(stderr, "engine: %08x %s from %d to %d (%s:%d)\n", \
-                (unsigned int)(e), (isfunct ? "funct" : "struct"), \
-                ((isfunct) ? ((e)->funct_ref - (diff)) : ((e)->struct_ref - (diff))), \
-                ((isfunct) ? (e)->funct_ref : (e)->struct_ref), \
-                (OPENSSL_FILE), (OPENSSL_LINE))
-
-# else
-
-#  define engine_ref_debug(e, isfunct, diff)
-
-# endif
+# define engine_ref_debug(e, isfunct, diff)                             \
+    if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_REF_COUNT))                 \
+        OSSL_debug(OSSL_DEBUG_ENGINE_REF_COUNT,                         \
+                   "engine: %08p %s from %d to %d (%s:%d)\n",           \
+                   (void *)(e), (isfunct ? "funct" : "struct"),         \
+                   ((isfunct)                                           \
+                    ? ((e)->funct_ref - (diff))                         \
+                    : ((e)->struct_ref - (diff))),                      \
+                   ((isfunct) ? (e)->funct_ref : (e)->struct_ref),      \
+                   (OPENSSL_FILE), (OPENSSL_LINE))
 
 /*
  * Any code that will need cleanup operations should use these functions to

--- a/crypto/engine/eng_int.h
+++ b/crypto/engine/eng_int.h
@@ -11,6 +11,7 @@
 #ifndef HEADER_ENGINE_INT_H
 # define HEADER_ENGINE_INT_H
 
+# include <openssl/trace.h>
 # include "internal/cryptlib.h"
 # include "internal/engine.h"
 # include "internal/thread_once.h"
@@ -59,14 +60,6 @@ void engine_cleanup_add_last(ENGINE_CLEANUP_CB *cb);
 DEFINE_STACK_OF(ENGINE)
 
 /*
- * If this symbol is defined then engine_table_select(), the function that is
- * used by RSA, DSA (etc) code to select registered ENGINEs, cache defaults
- * and functional references (etc), will display debugging summaries to
- * stderr.
- */
-/* #define ENGINE_TABLE_DEBUG */
-
-/*
  * This represents an implementation table. Dependent code should instantiate
  * it as a (ENGINE_TABLE *) pointer value set initially to NULL.
  */
@@ -76,13 +69,10 @@ int engine_table_register(ENGINE_TABLE **table, ENGINE_CLEANUP_CB *cleanup,
                           int setdefault);
 void engine_table_unregister(ENGINE_TABLE **table, ENGINE *e);
 void engine_table_cleanup(ENGINE_TABLE **table);
-# ifndef ENGINE_TABLE_DEBUG
-ENGINE *engine_table_select(ENGINE_TABLE **table, int nid);
-# else
-ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
+ENGINE *engine_table_select_int(ENGINE_TABLE **table, int nid, const char *f,
                                 int l);
-#  define engine_table_select(t,n) engine_table_select_tmp(t,n,OPENSSL_FILE,OPENSSL_LINE)
-# endif
+# define engine_table_select(t,n)                               \
+    engine_table_select_int(t,n,OPENSSL_FILE,OPENSSL_LINE)
 typedef void (engine_table_doall_cb) (int nid, STACK_OF(ENGINE) *sk,
                                       ENGINE *def, void *arg);
 void engine_table_doall(ENGINE_TABLE *table, engine_table_doall_cb *cb,

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -10,6 +10,7 @@
 #include "internal/cryptlib.h"
 #include <openssl/evp.h>
 #include <openssl/lhash.h>
+#include <openssl/trace.h>
 #include "eng_int.h"
 
 /* The type of the items in the table */
@@ -189,29 +190,25 @@ void engine_table_cleanup(ENGINE_TABLE **table)
 }
 
 /* return a functional reference for a given 'nid' */
-#ifndef ENGINE_TABLE_DEBUG
-ENGINE *engine_table_select(ENGINE_TABLE **table, int nid)
-#else
-ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
+ENGINE *engine_table_select_int(ENGINE_TABLE **table, int nid, const char *f,
                                 int l)
-#endif
 {
     ENGINE *ret = NULL;
     ENGINE_PILE tmplate, *fnd = NULL;
     int initres, loop = 0;
 
     if (!(*table)) {
-#ifdef ENGINE_TABLE_DEBUG
-        fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, nothing "
-                "registered!\n", f, l, nid);
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_TABLE))
+            OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                       "engine_table_dbg: %s:%d, nid=%d, nothing registered!\n",
+                       f, l, nid);
         return NULL;
     }
     ERR_set_mark();
     CRYPTO_THREAD_write_lock(global_engine_lock);
     /*
      * Check again inside the lock otherwise we could race against cleanup
-     * operations. But don't worry about a fprintf(stderr).
+     * operations. But don't worry about a debug printout
      */
     if (!int_table_check(table, 0))
         goto end;
@@ -220,10 +217,10 @@ ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
     if (!fnd)
         goto end;
     if (fnd->funct && engine_unlocked_init(fnd->funct)) {
-#ifdef ENGINE_TABLE_DEBUG
-        fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, using "
-                "ENGINE '%s' cached\n", f, l, nid, fnd->funct->id);
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_TABLE))
+            OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                       "engine_table_dbg: %s:%d, nid=%d, using ENGINE '%s' "
+                       "cached\n", f, l, nid, fnd->funct->id);
         ret = fnd->funct;
         goto end;
     }
@@ -234,10 +231,10 @@ ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
  trynext:
     ret = sk_ENGINE_value(fnd->sk, loop++);
     if (!ret) {
-#ifdef ENGINE_TABLE_DEBUG
-        fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, no "
-                "registered implementations would initialise\n", f, l, nid);
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_TABLE))
+            OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                       "engine_table_dbg: %s:%d, nid=%d, no registered "
+                       "implementations would initialise\n", f, l, nid);
         goto end;
     }
     /* Try to initialise the ENGINE? */
@@ -252,15 +249,15 @@ ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
             if (fnd->funct)
                 engine_unlocked_finish(fnd->funct, 0);
             fnd->funct = ret;
-#ifdef ENGINE_TABLE_DEBUG
-            fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, "
-                    "setting default to '%s'\n", f, l, nid, ret->id);
-#endif
+            if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_TABLE))
+                OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                           "engine_table_dbg: %s:%d, nid=%d, "
+                           "setting default to '%s'\n", f, l, nid, ret->id);
         }
-#ifdef ENGINE_TABLE_DEBUG
-        fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, using "
-                "newly initialised '%s'\n", f, l, nid, ret->id);
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_TABLE))
+            OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                       "engine_table_dbg: %s:%d, nid=%d, using "
+                       "newly initialised '%s'\n", f, l, nid, ret->id);
         goto end;
     }
     goto trynext;
@@ -271,14 +268,16 @@ ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
      */
     if (fnd)
         fnd->uptodate = 1;
-#ifdef ENGINE_TABLE_DEBUG
-    if (ret)
-        fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, caching "
-                "ENGINE '%s'\n", f, l, nid, ret->id);
-    else
-        fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, caching "
-                "'no matching ENGINE'\n", f, l, nid);
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_ENGINE_TABLE)) {
+        if (ret)
+            OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                       "engine_table_dbg: %s:%d, nid=%d, caching ENGINE '%s'\n",
+                       f, l, nid, ret->id);
+        else
+            OSSL_debug(OSSL_DEBUG_ENGINE_TABLE,
+                       "engine_table_dbg: %s:%d, nid=%d, caching "
+                       "'no matching ENGINE'\n", f, l, nid);
+    }
     CRYPTO_THREAD_unlock(global_engine_lock);
     /*
      * Whatever happened, any failed init()s are not failures in this

--- a/crypto/pkcs12/p12_decr.c
+++ b/crypto/pkcs12/p12_decr.c
@@ -10,11 +10,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/pkcs12.h>
-
-/* Define this to dump decrypted output to files called DERnnn */
-/*
- * #define OPENSSL_DEBUG_DECRYPT
- */
+#include <openssl/trace.h>
 
 /*
  * Encrypt/Decrypt a buffer based on password and algor, result in a
@@ -95,18 +91,11 @@ void *PKCS12_item_decrypt_d2i(const X509_ALGOR *algor, const ASN1_ITEM *it,
         return NULL;
     }
     p = out;
-#ifdef OPENSSL_DEBUG_DECRYPT
-    {
-        FILE *op;
-
-        char fname[30];
-        static int fnm = 1;
-        sprintf(fname, "DER%d", fnm++);
-        op = fopen(fname, "wb");
-        fwrite(p, 1, outlen, op);
-        fclose(op);
+    if (OSSL_debug_is_set(OSSL_DEBUG_PKCS12_DECRYPT)) {
+        OSSL_debug(OSSL_DEBUG_PKCS12_DECRYPT, "DECRYPT DEBUG\n");
+        BIO_dump(OSSL_debug_bio(OSSL_DEBUG_PKCS12_DECRYPT), out, outlen);
+        OSSL_debug(OSSL_DEBUG_PKCS12_DECRYPT, "\n");
     }
-#endif
     ret = ASN1_item_d2i(NULL, &p, outlen, it);
     if (zbuf)
         OPENSSL_cleanse(out, outlen);

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -169,6 +169,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(SSL),
     DEFNAME(TLS_CIPHER),
     DEFNAME(SSL_CIPHER),
+    DEFNAME(ENGINE_CONF),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -164,6 +164,8 @@ int OSSL_vtrace(int type, char *fmt, va_list args)
 
 static const struct namenum_st debugnames[] = {
     DEFNAME(DEFAULT),
+    DEFNAME(TLS),
+    DEFNAME(SSL),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -16,6 +16,8 @@
 #include "internal/bio.h"
 #include "internal/nelem.h"
 
+#include "e_os.h"                /* strcasecmp for Windows */
+
 #ifndef OPENSSL_NO_TRACE
 
 /*-

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -174,6 +174,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(ENGINE_REF_COUNT),
     DEFNAME(PKCS5V2),
     DEFNAME(PKCS12_KEYGEN),
+    DEFNAME(X509V3_POLICY),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -171,6 +171,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(SSL_CIPHER),
     DEFNAME(ENGINE_CONF),
     DEFNAME(ENGINE_TABLE),
+    DEFNAME(ENGINE_REF_COUNT),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -16,6 +16,8 @@
 #include "internal/bio.h"
 #include "internal/nelem.h"
 
+#ifndef OPENSSL_NO_TRACE
+
 /*-
  * INTERNAL BIO IMPLEMENTATION
  *
@@ -64,6 +66,8 @@ static int hookputs(BIO *h, const char *str)
     return EOF;
 }
 
+#endif
+
 /* Helper struct and macro to get name string to number mapping */
 struct namenum_st {
     const char * const name;
@@ -89,12 +93,17 @@ int OSSL_trace_get_type(const char *name)
     return -1;                   /* or should that be 0, i.e. DEFAULT? */
 }
 
+#ifndef OPENSSL_NO_TRACE
+
 /* We store one trace BIO for each trace type */
 static struct bio_hook_st trace_data[OSSL_TRACE_NUM] = { { NULL, NULL }, };
 static BIO *trace_bio[OSSL_TRACE_NUM] = { NULL, };
 
+#endif
+
 void OSSL_trace_set(int type, OSSL_tracer_fn fn, void *hookdata)
 {
+#ifndef OPENSSL_NO_TRACE
     if (trace_data[type].hook != NULL && fn == NULL) {
         BIO_free(trace_bio[type]);
         trace_bio[type] = NULL;
@@ -107,7 +116,10 @@ void OSSL_trace_set(int type, OSSL_tracer_fn fn, void *hookdata)
         && fn != NULL
         && (trace_bio[type] = BIO_new(&hook_method)) != NULL)
         BIO_set_data(trace_bio[type], &trace_data[type]);
+#endif
 }
+
+#ifndef OPENSSL_NO_TRACE
 
 int OSSL_trace_is_set(int type)
 {
@@ -121,14 +133,18 @@ BIO *OSSL_trace_bio(int type)
     return trace_bio[OSSL_TRACE_DEFAULT];
 }
 
+#endif
+
 int OSSL_trace(int type, char *fmt, ...)
 {
+    int ret = 1;
+#ifndef OPENSSL_NO_TRACE
     va_list args;
-    int ret;
 
     va_start(args, fmt);
     ret = OSSL_vtrace(type, fmt, args);
     va_end(args);
+#endif
 
     return ret;
 }
@@ -160,12 +176,17 @@ int OSSL_debug_get_type(const char *name)
     return -1;                   /* or should that be 0, i.e. DEFAULT? */
 }
 
+#ifndef OPENSSL_NO_TRACE
+
 /* We store one trace BIO for each debug type */
 static struct bio_hook_st debug_data[OSSL_DEBUG_NUM] = { { NULL, NULL }, };
 static BIO *debug_bio[OSSL_DEBUG_NUM] = { NULL, };
 
+#endif
+
 void OSSL_debug_set(int type, OSSL_tracer_fn fn, void *hookdata)
 {
+#ifndef OPENSSL_NO_TRACE
     if (debug_data[type].hook != NULL && fn == NULL) {
         BIO_free(debug_bio[type]);
         debug_bio[type] = NULL;
@@ -178,7 +199,10 @@ void OSSL_debug_set(int type, OSSL_tracer_fn fn, void *hookdata)
         && fn != NULL
         && (debug_bio[type] = BIO_new(&hook_method)) != NULL)
         BIO_set_data(debug_bio[type], &debug_data[type]);
+#endif
 }
+
+#ifndef OPENSSL_NO_TRACE
 
 int OSSL_debug_is_set(int type)
 {
@@ -192,14 +216,18 @@ BIO *OSSL_debug_bio(int type)
     return debug_bio[OSSL_DEBUG_DEFAULT];
 }
 
+#endif
+
 int OSSL_debug(int type, char *fmt, ...)
 {
+    int ret = 1;
+#ifndef OPENSSL_NO_TRACE
     va_list args;
-    int ret = 0;
 
     va_start(args, fmt);
     ret = OSSL_vdebug(type, fmt, args);
     va_end(args);
+#endif
 
     return ret;
 }

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -117,6 +117,11 @@ void OSSL_trace_set(int type, OSSL_tracer_fn fn, void *hookdata)
         && (trace_bio[type] = BIO_new(&hook_method)) != NULL)
         BIO_set_data(trace_bio[type], &trace_data[type]);
 #endif
+
+    if (OSSL_debug_is_set(OSSL_DEBUG_SELF))
+        OSSL_debug(OSSL_DEBUG_SELF,
+                   "OSSL_TRACE: Set trace %d with hook = %p, hookdata = %p\n",
+                   type, trace_data[type].hook, trace_data[type].hookdata);
 }
 
 #ifndef OPENSSL_NO_TRACE
@@ -164,6 +169,9 @@ int OSSL_vtrace(int type, char *fmt, va_list args)
 
 static const struct namenum_st debugnames[] = {
     DEFNAME(DEFAULT),
+    DEFNAME(SELF),
+    DEFNAME(TRACE),
+    DEFNAME(DEBUG),
     DEFNAME(INIT),
     DEFNAME(TLS),
     DEFNAME(SSL),
@@ -213,6 +221,10 @@ void OSSL_debug_set(int type, OSSL_tracer_fn fn, void *hookdata)
         && (debug_bio[type] = BIO_new(&hook_method)) != NULL)
         BIO_set_data(debug_bio[type], &debug_data[type]);
 #endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_SELF))
+        OSSL_debug(OSSL_DEBUG_SELF,
+                   "OSSL_DEBUG: Set debug %d with hook = %p, hookdata = %p\n",
+                   type, debug_data[type].hook, debug_data[type].hookdata);
 }
 
 #ifndef OPENSSL_NO_TRACE

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/crypto.h>
+#include <openssl/trace.h>
+#include "internal/bio.h"
+#include "internal/nelem.h"
+
+/*-
+ * INTERNAL BIO IMPLEMENTATION
+ *
+ * For our own flexibility, we have an internal BIO whose only job is
+ * to call the application provided hooks for trace and debug output.
+ */
+static int hookwrite(BIO *h, const char *buf, size_t num, size_t *written);
+static int hookputs(BIO *h, const char *str);
+static const BIO_METHOD hook_method = {
+    BIO_TYPE_SOURCE_SINK,
+    "memory buffer",
+    hookwrite,
+    NULL,                        /* old write */
+    NULL,                        /* read_ex */
+    NULL,                        /* read */
+    hookputs,
+    NULL,                        /* gets */
+    NULL,                        /* ctrl */
+    NULL,                        /* create */
+    NULL,                        /* free */
+    NULL,                        /* callback_ctrl */
+};
+
+/* This structure connects the BIO to the corresponding hook function */
+struct bio_hook_st {
+    OSSL_tracer_fn hook;
+    void *hookdata;
+};
+
+static int hookwrite(BIO *h, const char *buf, size_t num, size_t *written)
+{
+    struct bio_hook_st *biodata = (struct bio_hook_st *)BIO_get_data(h);
+    size_t cnt = biodata->hook(buf, num, biodata->hookdata);
+
+    *written = cnt;
+    return cnt != 0;
+}
+
+static int hookputs(BIO *h, const char *str)
+{
+    size_t written;
+
+    if (hookwrite(h, str, strlen(str), &written))
+        return (int)written;
+
+    return EOF;
+}
+
+/* Helper struct and macro to get name string to number mapping */
+struct namenum_st {
+    const char * const name;
+    const int num;
+};
+#define DEFNAME(typename)       { #typename, OSSL_DEBUG_##typename }
+
+/*-
+ * TRACE
+ */
+
+static const struct namenum_st tracenames[] = {
+    DEFNAME(DEFAULT),
+};
+
+int OSSL_trace_get_type(const char *name)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(tracenames); i++)
+        if (strcasecmp(name, tracenames[i].name) == 0)
+            return tracenames[i].num;
+    return -1;                   /* or should that be 0, i.e. DEFAULT? */
+}
+
+/* We store one trace BIO for each trace type */
+static struct bio_hook_st trace_data[OSSL_TRACE_NUM] = { { NULL, NULL }, };
+static BIO *trace_bio[OSSL_TRACE_NUM] = { NULL, };
+
+void OSSL_trace_set(int type, OSSL_tracer_fn fn, void *hookdata)
+{
+    if (trace_data[type].hook != NULL && fn == NULL) {
+        BIO_free(trace_bio[type]);
+        trace_bio[type] = NULL;
+    }
+
+    trace_data[type].hook = fn;
+    trace_data[type].hookdata = hookdata;
+
+    if (trace_bio[type] == NULL
+        && fn != NULL
+        && (trace_bio[type] = BIO_new(&hook_method)) != NULL)
+        BIO_set_data(trace_bio[type], &trace_data[type]);
+}
+
+int OSSL_trace_is_set(int type)
+{
+    return OSSL_trace_bio(type) != NULL;
+}
+
+BIO *OSSL_trace_bio(int type)
+{
+    if (trace_bio[type] != NULL)
+        return trace_bio[type];
+    return trace_bio[OSSL_TRACE_DEFAULT];
+}
+
+int OSSL_trace(int type, char *fmt, ...)
+{
+    va_list args;
+    int ret;
+
+    va_start(args, fmt);
+    ret = OSSL_vtrace(type, fmt, args);
+    va_end(args);
+
+    return ret;
+}
+
+int OSSL_vtrace(int type, char *fmt, va_list args)
+{
+    BIO *bio = OSSL_trace_bio(type);
+
+    if (bio != NULL)
+        return BIO_vprintf(bio, fmt, args) >= 0;
+    return 1;
+}
+
+/*-
+ * DEBUG
+ */
+
+static const struct namenum_st debugnames[] = {
+    DEFNAME(DEFAULT),
+};
+
+int OSSL_debug_get_type(const char *name)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(debugnames); i++)
+        if (strcasecmp(name, debugnames[i].name) == 0)
+            return debugnames[i].num;
+    return -1;                   /* or should that be 0, i.e. DEFAULT? */
+}
+
+/* We store one trace BIO for each debug type */
+static struct bio_hook_st debug_data[OSSL_DEBUG_NUM] = { { NULL, NULL }, };
+static BIO *debug_bio[OSSL_DEBUG_NUM] = { NULL, };
+
+void OSSL_debug_set(int type, OSSL_tracer_fn fn, void *hookdata)
+{
+    if (debug_data[type].hook != NULL && fn == NULL) {
+        BIO_free(debug_bio[type]);
+        debug_bio[type] = NULL;
+    }
+
+    debug_data[type].hook = fn;
+    debug_data[type].hookdata = hookdata;
+
+    if (debug_bio[type] == NULL
+        && fn != NULL
+        && (debug_bio[type] = BIO_new(&hook_method)) != NULL)
+        BIO_set_data(debug_bio[type], &debug_data[type]);
+}
+
+int OSSL_debug_is_set(int type)
+{
+    return OSSL_debug_bio(type) != NULL;
+}
+
+BIO *OSSL_debug_bio(int type)
+{
+    if (debug_bio[type] != NULL)
+        return debug_bio[type];
+    return debug_bio[OSSL_DEBUG_DEFAULT];
+}
+
+int OSSL_debug(int type, char *fmt, ...)
+{
+    va_list args;
+    int ret = 0;
+
+    va_start(args, fmt);
+    ret = OSSL_vdebug(type, fmt, args);
+    va_end(args);
+
+    return ret;
+}
+
+int OSSL_vdebug(int type, char *fmt, va_list args)
+{
+    BIO *bio = OSSL_debug_bio(type);
+
+    if (bio != NULL)
+        return BIO_vprintf(bio, fmt, args) >= 0;
+    return 1;
+}

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -173,6 +173,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(ENGINE_TABLE),
     DEFNAME(ENGINE_REF_COUNT),
     DEFNAME(PKCS5V2),
+    DEFNAME(PKCS12_KEYGEN),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -176,6 +176,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(PKCS12_KEYGEN),
     DEFNAME(PKCS12_DECRYPT),
     DEFNAME(X509V3_POLICY),
+    DEFNAME(BN_CTX),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -172,6 +172,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(ENGINE_CONF),
     DEFNAME(ENGINE_TABLE),
     DEFNAME(ENGINE_REF_COUNT),
+    DEFNAME(PKCS5V2),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -170,6 +170,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(TLS_CIPHER),
     DEFNAME(SSL_CIPHER),
     DEFNAME(ENGINE_CONF),
+    DEFNAME(ENGINE_TABLE),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -174,6 +174,7 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(ENGINE_REF_COUNT),
     DEFNAME(PKCS5V2),
     DEFNAME(PKCS12_KEYGEN),
+    DEFNAME(PKCS12_DECRYPT),
     DEFNAME(X509V3_POLICY),
 };
 

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -166,6 +166,8 @@ static const struct namenum_st debugnames[] = {
     DEFNAME(DEFAULT),
     DEFNAME(TLS),
     DEFNAME(SSL),
+    DEFNAME(TLS_CIPHER),
+    DEFNAME(SSL_CIPHER),
 };
 
 int OSSL_debug_get_type(const char *name)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -164,6 +164,7 @@ int OSSL_vtrace(int type, char *fmt, va_list args)
 
 static const struct namenum_st debugnames[] = {
     DEFNAME(DEFAULT),
+    DEFNAME(INIT),
     DEFNAME(TLS),
     DEFNAME(SSL),
     DEFNAME(TLS_CIPHER),

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -531,6 +531,74 @@ Read the password from standard input.
 
 =back
 
+=head1 ENVIRONMENT
+
+=over 4
+
+=item B<OPENSSL_DEBUG=>I<name,...>
+
+Enable debugging output of OpenSSL library, by name.
+This output will only make sense if you know OpenSSL internals well.
+Also, it might not give you any output at all, depending on how
+OpenSSL was built.
+
+The value is a comma separated list of names, with the following
+available:
+
+=over 4
+
+=item B<DEBUG> | B<TRACE>
+
+The tracing and debugging support functionality.
+
+=item B<TLS> | B<SSL>
+
+General SSL/TLS.
+
+=item B<TLS_CIPHER> | B<SSL_CIPHER>
+
+SSL/TLS cipher.
+
+=item B<ENGINE_CONF>
+
+ENGINE configuration.
+
+=item B<ENGINE_TABLE>
+
+The function that is used by RSA, DSA (etc) code to select registered
+ENGINEs, cache defaults and functional references (etc), will generate
+debugging summaries.
+
+=item B<ENGINE_REF_COUNT>
+
+Reference counts in the ENGINE structure will be monitored with a line
+of generated for each change.
+
+=item B<PKCS5V2>
+
+PKCS#5 v2 keygen.
+
+=item B<PKCS12_KEYGEN>
+
+PKCS#12 key generation.
+
+=item B<PKCS12_DECRYPT>
+
+PKCS#12 decryption.
+
+=item B<X509V3_POLICY>
+
+Generates the complete policy tree at various point during X.509 v3
+policy evaluation.
+
+=item B<BN_CTX>
+
+BIGNUM context.
+
+=back
+
+=back
+
 =head1 SEE ALSO
 
 L<asn1parse(1)>, L<ca(1)>, L<ciphers(1)>, L<cms(1)>, L<config(5)>,

--- a/doc/man3/OSSL_trace.pod
+++ b/doc/man3/OSSL_trace.pod
@@ -1,0 +1,109 @@
+=pod
+
+=head1 NAME
+
+OSSL_trace_is_set, OSSL_debug_is_set,
+OSSL_trace, OSSL_vtrace, OSSL_debug, OSSL_vdebug,
+OSSL_trace_bio, OSSL_debug_bio
+- Tracing and debugging output developer tools
+
+=head1 SYNOPSIS
+
+ #include <openssl/trace.h>
+
+ int OSSL_trace_is_set(int type);
+ int OSSL_debug_is_set(int type);
+
+ int OSSL_trace(int type, char *fmt, ...);
+ int OSSL_vtrace(int type, char *fmt, va_list args);
+ int OSSL_debug(int type, char *fmt, ...);
+ int OSSL_vdebug(int type, char *fmt, va_list args);
+
+ BIO *OSSL_trace_bio(int type);
+ BIO *OSSL_debug_bio(int type);
+
+=head1 DESCRIPTION
+
+The functions described here are mainly interesting for those provide
+OpenSSL functionality, either in OpenSSL itself or in engine modules
+or similar.
+
+If operational (see L</NOTES> below), these functions are used to
+generate free text tracing and debugging output.
+
+The tracing or debugging output is divided into types which are
+enabled individually by the application.
+The tracing and debugging types are described in detail in
+L<OSSL_trace_set(3)/Trace types> and L<OSSL_trace_set(3)/Debug types>.
+The fallback types C<OSSL_TRACE_DEFAULT> and C<OSSL_DEBUG_DEFAULT>
+should I<not> be used with the functions described here.
+
+=head2 Functions
+
+OSSL_trace() and OSSL_debug() are the main convenience functions to
+generate tracing or debugging to a given B<type>.
+These are L<fprintf(3)> style functions, except that the output is
+sent to a trace or debug type rather than a C<FILE *>.
+
+OSSL_vtrace() and OSSL_vdebug() are similar to OSSL_trace() and
+OSSL_debug(), but instead of an undefined amount of arguments, they
+take B<args>, which is a stdarg argument list.
+
+As an alternative, one can use OSSL_trace_bio() or OSSL_debug_bio() to
+get a C<BIO *> that can be used with any suitable L<bio(7)> function
+to generate tracing or debugging output, for example L<BIO_printf(3)>.
+
+OSSL_trace_is_set() and OSSL_debug_is_set() are used to determine if
+the application has enabled tracing or debugging output on the given
+B<type>.
+See the L</NOTES> below for an discussion on these and their
+usefulness.
+
+=head1 NOTES
+
+These functions are always present, but may or may not be operational
+(see L<OSSL_trace_set(3)/NOTES> for details).
+In case they aren't operational, OSSL_trace_is_set(),
+OSSL_debug_is_set(), OSSL_trace_bio() and OSSL_debug_bio() are
+implemented as macros that return constant values that evaluate to
+false.
+
+It is advisable to always check that a trace or debug type has a
+tracer function attached with OSSL_trace_is_set() or
+OSSL_trace_is_set() before generating any output, for example:
+
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "FOO %d\n", somevalue);
+        BIO_dump(OSSL_debug_bio(OSSL_DEBUG_SSL), somememory, somememory_l);
+    }
+
+When this API isn't operational, OSSL_debug_is_set() is a constant
+zero, and the compiler will be able to recognise this example code as
+dead code.
+
+=head1 RETURN VALUES
+
+OSSL_trace_is_set() and OSSL_debug_is_set() return 1 if tracing or
+debugging for the given B<type> is enabled, otherwise 0.
+
+OSSL_trace(), OSSL_vtrace(), OSSL_debug() and OSSL_vdebug() return 1
+if tracing / debugging output isn't enabled for the given B<type>,
+otherwise the number of bytes that were output, or 0 on error.
+
+OSSL_trace_bio() and OSSL_debug_bio() return a C<BIO *> if the given
+B<type> is enabled, otherwise C<NULL>.
+
+=head1 HISTORY
+
+Everything described here was added to OpenSSL 3.0.0.
+
+=head1 COPYRIGHT
+
+Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OSSL_trace_set.pod
+++ b/doc/man3/OSSL_trace_set.pod
@@ -1,0 +1,155 @@
+=pod
+
+=head1 NAME
+
+OSSL_trace_set, OSSL_debug_set, OSSL_tracer_fn
+- Enabling tracing and debugging output
+
+=head1 SYNOPSIS
+
+ #include <openssl/trace.h>
+
+ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
+
+ void OSSL_trace_set(int type, OSSL_tracer_fn *fn, void *hookdata);
+ void OSSL_debug_set(int type, OSSL_tracer_fn *fn, void *hookdata);
+
+=head1 DESCRIPTION
+
+If available (see L</NOTES> below), the application can request
+internal tracing and debugging output.
+This output comes in form of free text for humans to read.
+
+The tracing or debugging output is divided into types which can be
+enabled individually.
+They are enabled by giving them a tracer function, which is
+responsible for performing the actual output.
+
+=head2 Functions
+
+OSSL_trace_set() is used to enable a trace type by giving it the tracer
+function B<fn> with the associated data B<hookdata>, which will simply
+be passed through to B<fn> whenever it's called.
+
+OSSL_trace_set() is used to enable a debug type by giving it the tracer
+function B<fn> with the associated data B<hookdata>, which will simply
+be passed through to B<fn> whenever it's called.
+
+The tracer function must return a C<size_t>, which must be zero on
+error and otherwise return the number of bytes that were output.
+It receives a text buffer B<buf> with B<cnt> bytes of text, as well as
+the B<hookdata> that was passed to OSSL_trace_set() or
+OSSL_debug_set().
+
+Disabling debugging or tracing on any type is done by calling
+OSSL_trace_set() or OSSL_debug_set() with C<NULL> for B<fn>.
+
+=head2 Trace types
+
+There is C<OSSL_TRACE_DEFAULT>, which works as a fallback and can
+be used to get I<all> tracing output.
+
+=head2 Debug types
+
+The debug types are simple numbers available through macros:
+
+=over 4
+
+=item C<OSSL_DEBUG_SELF> | C<OSSL_DEBUG_DEBUG> | C<OSSL_DEBUG_TRACE>
+
+OpenSSL library trace and debug setting output.
+More precisely, this will generate debugging output any time a new
+tracing or debugging hook is set.
+
+=item C<OSSL_DEBUG_INIT>
+
+OpenSSL library init and cleanup output.
+
+This needs special care, as OpenSSL will do automatic cleanup after
+exit from C<main()>.
+If the tracer function outputs to the standard handles C<stderr> or
+C<stdout>, this isn't an issue.
+However, if the output is sent somewhere else, this "somewhere else"
+needs to be cleaned away very late to ensure that the debugging output
+from OpenSSL's cleanup comes through.
+A suggestion is to make such cleanup part of a function that's
+registered very early with L<atexit(3)>.
+
+=item C<OSSL_DEBUG_TLS> | C<OSSL_DEBUG_SSL>
+
+OpenSSL library general TLS/SSL output.
+
+=item C<OSSL_DEBUG_TLS_CIPHER> | C<OSSL_DEBUG_SSL_CIPHER>
+
+OpenSSL library TLS/SSL cipher output.
+
+=item C<OSSL_DEBUG_ENGINE_CONF>
+
+OpenSSL library ENGINE configuration output.
+
+=item C<OSSL_DEBUG_ENGINE_TABLE>
+
+OpenSSL library ENGINE algorithm table output.
+More precisely, engine_table_select(), the function that is used by
+RSA, DSA (etc) code to select registered ENGINEs, cache defaults and
+functional references (etc), will generate debugging summaries.
+
+=item C<OSSL_DEBUG_ENGINE_REF_COUNT>
+
+OpenSSL library ENGINE reference counting output.
+More precisely, both reference counts in the ENGINE structure will be
+monitored with a line of generated for each change.
+
+=item C<OSSL_DEBUG_PKCS5V2>
+
+OpenSSL library PKCS#5 v2 keygen output.
+
+=item C<OSSL_DEBUG_PKCS12_KEYGEN>
+
+OpenSSL library PKCS#12 key generation output.
+
+=item C<OSSL_DEBUG_PKCS12_DECRYPT>
+
+OpenSSL library PKCS#12 decryption output.
+
+=item C<OSSL_DEBUG_X509V3_POLICY>
+
+OpenSSL library X509 v3 policy processing output.
+More precisely, this generates the complete policy tree at various
+point during evaluation.
+
+=item C<OSSL_DEBUG_BN_CTX>
+
+OpenSSL library BIGNUM context output.
+
+=back
+
+There is also C<OSSL_DEBUG_DEFAULT>, which works as a fallback and can
+be used to get I<all> debugging output.
+
+=head1 NOTES
+
+The functionality documented here may have no effect, depending on how
+the OpenSSL library was built.
+The functions are always available, but may be non-operational.
+If the macro C<OPENSSL_NO_TRACE> is defined in
+C<openssl/opensslconf.h>, these functions are not operational.
+
+=head1 RETURN VALUES
+
+OSSL_trace_set() and OSSL_debug_set() do not return any value.
+
+=head1 HISTORY
+
+Everything described here was added to OpenSSL 3.0.0.
+
+=head1 COPYRIGHT
+
+Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -641,16 +641,16 @@ int BIO_sock_non_fatal_error(int error);
 int BIO_fd_should_retry(int i);
 int BIO_fd_non_fatal_error(int error);
 int BIO_dump_cb(int (*cb) (const void *data, size_t len, void *u),
-                void *u, const char *s, int len);
+                void *u, const void *s, int len);
 int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
-                       void *u, const char *s, int len, int indent);
-int BIO_dump(BIO *b, const char *bytes, int len);
-int BIO_dump_indent(BIO *b, const char *bytes, int len, int indent);
+                       void *u, const void *s, int len, int indent);
+int BIO_dump(BIO *b, const void *bytes, int len);
+int BIO_dump_indent(BIO *b, const void *bytes, int len, int indent);
 # ifndef OPENSSL_NO_STDIO
-int BIO_dump_fp(FILE *fp, const char *s, int len);
-int BIO_dump_indent_fp(FILE *fp, const char *s, int len, int indent);
+int BIO_dump_fp(FILE *fp, const void *s, int len);
+int BIO_dump_indent_fp(FILE *fp, const void *s, int len, int indent);
 # endif
-int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
+int BIO_hex_string(BIO *out, int indent, int width, const void *data,
                    int datalen);
 
 # ifndef OPENSSL_NO_SOCK

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -37,7 +37,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_SSL                 OSSL_DEBUG_TLS
 # define OSSL_DEBUG_TLS_CIPHER          3
 # define OSSL_DEBUG_SSL_CIPHER          OSSL_DEBUG_TLS_CIPHER
-# define OSSL_DEBUG_NUM                 4
+# define OSSL_DEBUG_ENGINE_CONF         4
+# define OSSL_DEBUG_NUM                 5
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -32,11 +32,12 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
  * a hook for.  The DEFAULT type works as a single fallback.
  */
 # define OSSL_DEBUG_DEFAULT             0 /* The fallback */
-# define OSSL_DEBUG_TLS                 1
+# define OSSL_DEBUG_INIT                1
+# define OSSL_DEBUG_TLS                 2
 # define OSSL_DEBUG_SSL                 OSSL_DEBUG_TLS
-# define OSSL_DEBUG_TLS_CIPHER          2
+# define OSSL_DEBUG_TLS_CIPHER          3
 # define OSSL_DEBUG_SSL_CIPHER          OSSL_DEBUG_TLS_CIPHER
-# define OSSL_DEBUG_NUM                 3
+# define OSSL_DEBUG_NUM                 4
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -44,7 +44,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_PKCS12_KEYGEN       8
 # define OSSL_DEBUG_PKCS12_DECRYPT      9
 # define OSSL_DEBUG_X509V3_POLICY      10
-# define OSSL_DEBUG_NUM                11
+# define OSSL_DEBUG_BN_CTX             11
+# define OSSL_DEBUG_NUM                12
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_TRACE_H
+# define OSSL_TRACE_H
+
+# include <stdarg.h>
+
+# include <openssl/bio.h>
+
+# ifdef  __cplusplus
+extern "C" {
+# endif
+
+/*
+ * OSSL_tracer_fn is the type of the function that the application defines.
+ * It MUST return the number of bytes written, or 0 on error (in other words,
+ * it can never write zero bytes).
+ *
+ * The data to write will always be text, and may be several lines.
+ */
+typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
+
+/*
+ * The DEBUG and TRACE types or "channels" that the application can register
+ * a hook for.  The DEFAULT type works as a single fallback.
+ */
+# define OSSL_DEBUG_DEFAULT             0 /* The fallback */
+# define OSSL_DEBUG_NUM                 1
+
+# define OSSL_TRACE_DEFAULT             0 /* The fallback */
+# define OSSL_TRACE_NUM                 1
+
+/* Functions to get a type number from its name */
+int OSSL_trace_get_type(const char *name);
+int OSSL_debug_get_type(const char *name);
+
+/* Functions to associate a hook with a TRACE and DEBUG type / "channel" */
+void OSSL_trace_set(int type, OSSL_tracer_fn fn, void *hookdata);
+void OSSL_debug_set(int type, OSSL_tracer_fn fn, void *hookdata);
+
+/*
+ * Functions to check that a type / "channel" has a hook registered.
+ * These are used within OpenSSL libraries to avoid unnecessary work.
+ */
+int OSSL_trace_is_set(int type);
+int OSSL_debug_is_set(int type);
+
+/*
+ * Each type / "channel" is implemented as a BIO.  These functions are used to
+ * get that BIO, which can then be used with any chose BIO output function.
+ */
+BIO *OSSL_trace_bio(int type);
+BIO *OSSL_debug_bio(int type);
+
+/*
+ * Convenience functions that are shortcuts for
+ * BIO_printf(BIO_trace_bio(type), fmt, ...),
+ * BIO_vprintf(BIO_trace_bio(type), fmt, args),
+ * BIO_printf(BIO_debug_bio(type), fmt, ...),
+ * BIO_vprintf(BIO_debug_bio(type), fmt, args),
+ */
+int OSSL_trace(int type, char *fmt, ...);
+int OSSL_vtrace(int type, char *fmt, va_list args);
+int OSSL_debug(int type, char *fmt, ...);
+int OSSL_vdebug(int type, char *fmt, va_list args);
+
+#endif

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -32,20 +32,23 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
  * a hook for.  The DEFAULT type works as a single fallback.
  */
 # define OSSL_DEBUG_DEFAULT             0 /* The fallback */
-# define OSSL_DEBUG_INIT                1
-# define OSSL_DEBUG_TLS                 2
+# define OSSL_DEBUG_SELF                1
+# define OSSL_DEBUG_TRACE               OSSL_DEBUG_SELF
+# define OSSL_DEBUG_DEBUG               OSSL_DEBUG_SELF
+# define OSSL_DEBUG_INIT                2
+# define OSSL_DEBUG_TLS                 3
 # define OSSL_DEBUG_SSL                 OSSL_DEBUG_TLS
-# define OSSL_DEBUG_TLS_CIPHER          3
+# define OSSL_DEBUG_TLS_CIPHER          4
 # define OSSL_DEBUG_SSL_CIPHER          OSSL_DEBUG_TLS_CIPHER
-# define OSSL_DEBUG_ENGINE_CONF         4
-# define OSSL_DEBUG_ENGINE_TABLE        5
-# define OSSL_DEBUG_ENGINE_REF_COUNT    6
-# define OSSL_DEBUG_PKCS5V2             7
-# define OSSL_DEBUG_PKCS12_KEYGEN       8
-# define OSSL_DEBUG_PKCS12_DECRYPT      9
-# define OSSL_DEBUG_X509V3_POLICY      10
-# define OSSL_DEBUG_BN_CTX             11
-# define OSSL_DEBUG_NUM                12
+# define OSSL_DEBUG_ENGINE_CONF         5
+# define OSSL_DEBUG_ENGINE_TABLE        6
+# define OSSL_DEBUG_ENGINE_REF_COUNT    7
+# define OSSL_DEBUG_PKCS5V2             8
+# define OSSL_DEBUG_PKCS12_KEYGEN       9
+# define OSSL_DEBUG_PKCS12_DECRYPT     10
+# define OSSL_DEBUG_X509V3_POLICY      11
+# define OSSL_DEBUG_BN_CTX             12
+# define OSSL_DEBUG_NUM                13
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -45,6 +45,8 @@ int OSSL_debug_get_type(const char *name);
 void OSSL_trace_set(int type, OSSL_tracer_fn fn, void *hookdata);
 void OSSL_debug_set(int type, OSSL_tracer_fn fn, void *hookdata);
 
+# ifndef OPENSSL_NO_TRACE
+
 /*
  * Functions to check that a type / "channel" has a hook registered.
  * These are used within OpenSSL libraries to avoid unnecessary work.
@@ -58,6 +60,13 @@ int OSSL_debug_is_set(int type);
  */
 BIO *OSSL_trace_bio(int type);
 BIO *OSSL_debug_bio(int type);
+
+# else
+#  define OSSL_trace_is_set(type)               0
+#  define OSSL_debug_is_set(type)               0
+#  define OSSL_trace_bio(type)                  NULL
+#  define OSSL_debug_bio(type)                  NULL
+# endif
 
 /*
  * Convenience functions that are shortcuts for

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -34,7 +34,9 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_DEFAULT             0 /* The fallback */
 # define OSSL_DEBUG_TLS                 1
 # define OSSL_DEBUG_SSL                 OSSL_DEBUG_TLS
-# define OSSL_DEBUG_NUM                 2
+# define OSSL_DEBUG_TLS_CIPHER          2
+# define OSSL_DEBUG_SSL_CIPHER          OSSL_DEBUG_TLS_CIPHER
+# define OSSL_DEBUG_NUM                 3
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -38,7 +38,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_TLS_CIPHER          3
 # define OSSL_DEBUG_SSL_CIPHER          OSSL_DEBUG_TLS_CIPHER
 # define OSSL_DEBUG_ENGINE_CONF         4
-# define OSSL_DEBUG_NUM                 5
+# define OSSL_DEBUG_ENGINE_TABLE        5
+# define OSSL_DEBUG_NUM                 6
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -42,8 +42,9 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_ENGINE_REF_COUNT    6
 # define OSSL_DEBUG_PKCS5V2             7
 # define OSSL_DEBUG_PKCS12_KEYGEN       8
-# define OSSL_DEBUG_X509V3_POLICY       9
-# define OSSL_DEBUG_NUM                10
+# define OSSL_DEBUG_PKCS12_DECRYPT      9
+# define OSSL_DEBUG_X509V3_POLICY      10
+# define OSSL_DEBUG_NUM                11
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -40,7 +40,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_ENGINE_CONF         4
 # define OSSL_DEBUG_ENGINE_TABLE        5
 # define OSSL_DEBUG_ENGINE_REF_COUNT    6
-# define OSSL_DEBUG_NUM                 7
+# define OSSL_DEBUG_PKCS5V2             7
+# define OSSL_DEBUG_NUM                 8
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -32,7 +32,9 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
  * a hook for.  The DEFAULT type works as a single fallback.
  */
 # define OSSL_DEBUG_DEFAULT             0 /* The fallback */
-# define OSSL_DEBUG_NUM                 1
+# define OSSL_DEBUG_TLS                 1
+# define OSSL_DEBUG_SSL                 OSSL_DEBUG_TLS
+# define OSSL_DEBUG_NUM                 2
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1
@@ -62,10 +64,10 @@ BIO *OSSL_trace_bio(int type);
 BIO *OSSL_debug_bio(int type);
 
 # else
-#  define OSSL_trace_is_set(type)               0
-#  define OSSL_debug_is_set(type)               0
-#  define OSSL_trace_bio(type)                  NULL
-#  define OSSL_debug_bio(type)                  NULL
+#  define OSSL_trace_is_set(type)       0
+#  define OSSL_debug_is_set(type)       0
+#  define OSSL_trace_bio(type)          NULL
+#  define OSSL_debug_bio(type)          NULL
 # endif
 
 /*

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -39,7 +39,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_SSL_CIPHER          OSSL_DEBUG_TLS_CIPHER
 # define OSSL_DEBUG_ENGINE_CONF         4
 # define OSSL_DEBUG_ENGINE_TABLE        5
-# define OSSL_DEBUG_NUM                 6
+# define OSSL_DEBUG_ENGINE_REF_COUNT    6
+# define OSSL_DEBUG_NUM                 7
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -42,7 +42,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_ENGINE_REF_COUNT    6
 # define OSSL_DEBUG_PKCS5V2             7
 # define OSSL_DEBUG_PKCS12_KEYGEN       8
-# define OSSL_DEBUG_NUM                 9
+# define OSSL_DEBUG_X509V3_POLICY       9
+# define OSSL_DEBUG_NUM                10
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -41,7 +41,8 @@ typedef size_t (*OSSL_tracer_fn)(const char *buf, size_t cnt, void *hookdata);
 # define OSSL_DEBUG_ENGINE_TABLE        5
 # define OSSL_DEBUG_ENGINE_REF_COUNT    6
 # define OSSL_DEBUG_PKCS5V2             7
-# define OSSL_DEBUG_NUM                 8
+# define OSSL_DEBUG_PKCS12_KEYGEN       8
+# define OSSL_DEBUG_NUM                 9
 
 # define OSSL_TRACE_DEFAULT             0 /* The fallback */
 # define OSSL_TRACE_NUM                 1

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -9,6 +9,7 @@
 
 #include "../ssl_locl.h"
 #include "internal/constant_time_locl.h"
+#include <openssl/trace.h>
 #include <openssl/rand.h>
 #include "record_locl.h"
 #include "internal/cryptlib.h"
@@ -563,15 +564,11 @@ int ssl3_get_record(SSL *s)
                  SSL_R_BLOCK_CIPHER_PAD_IS_WRONG);
         return -1;
     }
-#ifdef SSL_DEBUG
-    printf("dec %lu\n", (unsigned long)rr[0].length);
-    {
-        size_t z;
-        for (z = 0; z < rr[0].length; z++)
-            printf("%02X%c", rr[0].data[z], ((z + 1) % 16) ? ' ' : '\n');
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "dec %lu\n", (unsigned long)rr[0].length);
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), rr[0].data, rr[0].length,
+                        4);
     }
-    printf("\n");
-#endif
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) &&
@@ -1361,22 +1358,15 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
 
     EVP_MD_CTX_free(hmac);
 
-#ifdef SSL_DEBUG
-    fprintf(stderr, "seq=");
-    {
-        int z;
-        for (z = 0; z < 8; z++)
-            fprintf(stderr, "%02X ", seq[z]);
-        fprintf(stderr, "\n");
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "seq:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), seq, 8, 4);
     }
-    fprintf(stderr, "rec=");
-    {
-        size_t z;
-        for (z = 0; z < rec->length; z++)
-            fprintf(stderr, "%02X ", rec->data[z]);
-        fprintf(stderr, "\n");
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "rec:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), rec->data, rec->length,
+                        4);
     }
-#endif
 
     if (!SSL_IS_DTLS(ssl)) {
         for (i = 7; i >= 0; i--) {
@@ -1385,14 +1375,10 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
                 break;
         }
     }
-#ifdef SSL_DEBUG
-    {
-        unsigned int z;
-        for (z = 0; z < md_size; z++)
-            fprintf(stderr, "%02X ", md[z]);
-        fprintf(stderr, "\n");
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "md:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), md, md_size, 4);
     }
-#endif
     return 1;
 }
 
@@ -1683,15 +1669,10 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         RECORD_LAYER_reset_packet_length(&s->rlayer);
         return 0;
     }
-#ifdef SSL_DEBUG
-    printf("dec %ld\n", rr->length);
-    {
-        size_t z;
-        for (z = 0; z < rr->length; z++)
-            printf("%02X%c", rr->data[z], ((z + 1) % 16) ? ' ' : '\n');
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "dec %ld\n", rr->length);
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), rr->data, rr->length, 4);
     }
-    printf("\n");
-#endif
 
     /* r->length is now the compressed data plus mac */
     if ((sess != NULL) && !SSL_READ_ETM(s) &&

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -16,6 +16,7 @@
 #include <openssl/md5.h>
 #include <openssl/dh.h>
 #include <openssl/rand.h>
+#include <openssl/trace.h>
 #include "internal/cryptlib.h"
 
 #define TLS13_NUM_CIPHERS       OSSL_NELEM(tls13_ciphers)
@@ -4153,20 +4154,20 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
      * pay with the price of sk_SSL_CIPHER_dup().
      */
 
-#ifdef CIPHER_DEBUG
-    fprintf(stderr, "Server has %d from %p:\n", sk_SSL_CIPHER_num(srvr),
-            (void *)srvr);
-    for (i = 0; i < sk_SSL_CIPHER_num(srvr); ++i) {
-        c = sk_SSL_CIPHER_value(srvr, i);
-        fprintf(stderr, "%p:%s\n", (void *)c, c->name);
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL_CIPHER)) {
+        OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "Server has %d from %p:\n",
+                   sk_SSL_CIPHER_num(srvr), (void *)srvr);
+        for (i = 0; i < sk_SSL_CIPHER_num(srvr); ++i) {
+            c = sk_SSL_CIPHER_value(srvr, i);
+            OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "%p:%s\n", (void *)c, c->name);
+        }
+        OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "Client sent %d from %p:\n",
+                   sk_SSL_CIPHER_num(clnt), (void *)clnt);
+        for (i = 0; i < sk_SSL_CIPHER_num(clnt); ++i) {
+            c = sk_SSL_CIPHER_value(clnt, i);
+            OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "%p:%s\n", (void *)c, c->name);
+        }
     }
-    fprintf(stderr, "Client sent %d from %p:\n", sk_SSL_CIPHER_num(clnt),
-            (void *)clnt);
-    for (i = 0; i < sk_SSL_CIPHER_num(clnt); ++i) {
-        c = sk_SSL_CIPHER_value(clnt, i);
-        fprintf(stderr, "%p:%s\n", (void *)c, c->name);
-    }
-#endif
 
     /* SUITE-B takes precedence over server preference and ChaCha priortiy */
     if (tls1_suiteb(s)) {
@@ -4280,10 +4281,10 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
 #endif                          /* OPENSSL_NO_PSK */
 
             ok = (alg_k & mask_k) && (alg_a & mask_a);
-#ifdef CIPHER_DEBUG
-            fprintf(stderr, "%d:[%08lX:%08lX:%08lX:%08lX]%p:%s\n", ok, alg_k,
-                    alg_a, mask_k, mask_a, (void *)c, c->name);
-#endif
+            if (OSSL_debug_is_set(OSSL_DEBUG_SSL_CIPHER))
+                OSSL_debug(OSSL_DEBUG_SSL_CIPHER,
+                           "%d:[%08lX:%08lX:%08lX:%08lX]%p:%s\n", ok, alg_k,
+                           alg_a, mask_k, mask_a, (void *)c, c->name);
 
 #ifndef OPENSSL_NO_EC
             /*

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -12,6 +12,7 @@
 #include "internal/err.h"
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
+#include <openssl/trace.h>
 #include "ssl_locl.h"
 #include "internal/thread_once.h"
 
@@ -23,10 +24,9 @@ static CRYPTO_ONCE ssl_base = CRYPTO_ONCE_STATIC_INIT;
 static int ssl_base_inited = 0;
 DEFINE_RUN_ONCE_STATIC(ossl_init_ssl_base)
 {
-#ifdef OPENSSL_INIT_DEBUG
-    fprintf(stderr, "OPENSSL_INIT: ossl_init_ssl_base: "
-            "Adding SSL ciphers and digests\n");
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_INIT))
+        OSSL_debug(OSSL_DEBUG_INIT, "OPENSSL_INIT: ossl_init_ssl_base: "
+                   "Adding SSL ciphers and digests\n");
 #ifndef OPENSSL_NO_DES
     EVP_add_cipher(EVP_des_cbc());
     EVP_add_cipher(EVP_des_ede3_cbc());
@@ -88,10 +88,9 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_ssl_base)
     EVP_add_digest(EVP_sha384());
     EVP_add_digest(EVP_sha512());
 #ifndef OPENSSL_NO_COMP
-# ifdef OPENSSL_INIT_DEBUG
-    fprintf(stderr, "OPENSSL_INIT: ossl_init_ssl_base: "
-            "SSL_COMP_get_compression_methods()\n");
-# endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_INIT))
+        OSSL_debug(OSSL_DEBUG_INIT, "OPENSSL_INIT: ossl_init_ssl_base: "
+                   "SSL_COMP_get_compression_methods()\n");
     /*
      * This will initialise the built-in compression algorithms. The value
      * returned is a STACK_OF(SSL_COMP), but that can be discarded safely
@@ -102,10 +101,9 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_ssl_base)
     if (!ssl_load_ciphers())
         return 0;
 
-#ifdef OPENSSL_INIT_DEBUG
-    fprintf(stderr, "OPENSSL_INIT: ossl_init_ssl_base: "
-            "SSL_add_ssl_module()\n");
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_INIT))
+        OSSL_debug(OSSL_DEBUG_INIT, "OPENSSL_INIT: ossl_init_ssl_base: "
+                   "SSL_add_ssl_module()\n");
     /*
      * We ignore an error return here. Not much we can do - but not that bad
      * either. We can still safely continue.
@@ -124,10 +122,9 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_ssl_strings)
      * pulling in all the error strings during static linking
      */
 #if !defined(OPENSSL_NO_ERR) && !defined(OPENSSL_NO_AUTOERRINIT)
-# ifdef OPENSSL_INIT_DEBUG
-    fprintf(stderr, "OPENSSL_INIT: ossl_init_load_ssl_strings: "
-            "ERR_load_SSL_strings()\n");
-# endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_INIT))
+        OSSL_debug(OSSL_DEBUG_INIT, "OPENSSL_INIT: ossl_init_load_ssl_strings: "
+                   "ERR_load_SSL_strings()\n");
     ERR_load_SSL_strings();
     ssl_strings_inited = 1;
 #endif
@@ -149,19 +146,17 @@ static void ssl_library_stop(void)
 
     if (ssl_base_inited) {
 #ifndef OPENSSL_NO_COMP
-# ifdef OPENSSL_INIT_DEBUG
-        fprintf(stderr, "OPENSSL_INIT: ssl_library_stop: "
-                "ssl_comp_free_compression_methods_int()\n");
-# endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_INIT))
+            OSSL_debug(OSSL_DEBUG_INIT, "OPENSSL_INIT: ssl_library_stop: "
+                       "ssl_comp_free_compression_methods_int()\n");
         ssl_comp_free_compression_methods_int();
 #endif
     }
 
     if (ssl_strings_inited) {
-#ifdef OPENSSL_INIT_DEBUG
-        fprintf(stderr, "OPENSSL_INIT: ssl_library_stop: "
-                "err_free_strings_int()\n");
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_INIT))
+            OSSL_debug(OSSL_DEBUG_INIT, "OPENSSL_INIT: ssl_library_stop: "
+                       "err_free_strings_int()\n");
         /*
          * If both crypto and ssl error strings are inited we will end up
          * calling err_free_strings_int() twice - but that's ok. The second

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -20,6 +20,7 @@
 #include <openssl/engine.h>
 #include <openssl/async.h>
 #include <openssl/ct.h>
+#include <openssl/trace.h>
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
 #include "internal/ktls.h"
@@ -3261,10 +3262,9 @@ void ssl_set_masks(SSL *s)
     mask_k = 0;
     mask_a = 0;
 
-#ifdef CIPHER_DEBUG
-    fprintf(stderr, "dht=%d re=%d rs=%d ds=%d\n",
-            dh_tmp, rsa_enc, rsa_sign, dsa_sign);
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL_CIPHER))
+        OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "dht=%d re=%d rs=%d ds=%d\n",
+                   dh_tmp, rsa_enc, rsa_sign, dsa_sign);
 
 #ifndef OPENSSL_NO_GOST
     if (ssl_has_cert(s, SSL_PKEY_GOST12_512)) {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -22,6 +22,7 @@
 #include <openssl/dh.h>
 #include <openssl/bn.h>
 #include <openssl/engine.h>
+#include <openssl/trace.h>
 #include <internal/cryptlib.h>
 
 static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL *s, PACKET *pkt);
@@ -2351,11 +2352,11 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
                      ERR_R_INTERNAL_ERROR);
             goto err;
         }
-#ifdef SSL_DEBUG
-        if (SSL_USE_SIGALGS(s))
-            fprintf(stderr, "USING TLSv1.2 HASH %s\n",
-                    md == NULL ? "n/a" : EVP_MD_name(md));
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+            if (SSL_USE_SIGALGS(s))
+                OSSL_debug(OSSL_DEBUG_SSL, "USING TLSv1.2 HASH %s\n",
+                           md == NULL ? "n/a" : EVP_MD_name(md));
+        }
 
         if (!PACKET_get_length_prefixed_2(pkt, &signature)
             || PACKET_remaining(pkt) != 0) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -18,6 +18,7 @@
 #include <openssl/objects.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
+#include <openssl/trace.h>
 
 /*
  * Map error codes to TLS/SSL alart types.
@@ -394,11 +395,11 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto err;
     }
 
-#ifdef SSL_DEBUG
-    if (SSL_USE_SIGALGS(s))
-        fprintf(stderr, "USING TLSv1.2 HASH %s\n",
-                md == NULL ? "n/a" : EVP_MD_name(md));
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        if (SSL_USE_SIGALGS(s))
+            OSSL_debug(OSSL_DEBUG_SSL, "USING TLSv1.2 HASH %s\n",
+                       md == NULL ? "n/a" : EVP_MD_name(md));
+    }
 
     /* Check for broken implementations of GOST ciphersuites */
     /*
@@ -439,10 +440,10 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         goto err;
     }
 
-#ifdef SSL_DEBUG
-    fprintf(stderr, "Using client verify alg %s\n",
-            md == NULL ? "n/a" : EVP_MD_name(md));
-#endif
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "Using client verify alg %s\n",
+                   md == NULL ? "n/a" : EVP_MD_name(md));
+    }
     if (EVP_DigestVerifyInit(mctx, &pctx, md, NULL, pkey) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CERT_VERIFY,
                  ERR_R_EVP_LIB);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -23,6 +23,7 @@
 #include <openssl/dh.h>
 #include <openssl/bn.h>
 #include <openssl/md5.h>
+#include <openssl/trace.h>
 
 #define TICKET_NONCE_SIZE       8
 
@@ -1829,15 +1830,14 @@ static int tls_early_post_process_client_hello(SSL *s)
         j = 0;
         id = s->session->cipher->id;
 
-#ifdef CIPHER_DEBUG
-        fprintf(stderr, "client sent %d ciphers\n", sk_SSL_CIPHER_num(ciphers));
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_SSL_CIPHER))
+            OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "client sent %d ciphers\n",
+                       sk_SSL_CIPHER_num(ciphers));
         for (i = 0; i < sk_SSL_CIPHER_num(ciphers); i++) {
             c = sk_SSL_CIPHER_value(ciphers, i);
-#ifdef CIPHER_DEBUG
-            fprintf(stderr, "client [%2d of %2d]:%s\n",
-                    i, sk_SSL_CIPHER_num(ciphers), SSL_CIPHER_get_name(c));
-#endif
+            if (OSSL_debug_is_set(OSSL_DEBUG_SSL_CIPHER))
+                OSSL_debug(OSSL_DEBUG_SSL_CIPHER, "client [%2d of %2d]:%s\n", i,
+                           sk_SSL_CIPHER_num(ciphers), SSL_CIPHER_get_name(c));
             if (c->id == id) {
                 j = 1;
                 break;

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -18,6 +18,7 @@
 #include <openssl/kdf.h>
 #include <openssl/rand.h>
 #include <openssl/obj_mac.h>
+#include <openssl/trace.h>
 
 /* seed1 through seed5 are concatenated */
 static int tls1_PRF(SSL *s,
@@ -280,14 +281,11 @@ int tls1_change_cipher_state(SSL *s, int which)
         }
         EVP_PKEY_free(mac_key);
     }
-#ifdef SSL_DEBUG
-    printf("which = %04X\nmac key=", which);
-    {
-        size_t z;
-        for (z = 0; z < i; z++)
-            printf("%02X%c", ms[z], ((z + 1) % 16) ? ' ' : '\n');
+
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "which = %04X, mac key:\n", which);
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), ms, i, 4);
     }
-#endif
 
     if (EVP_CIPHER_mode(c) == EVP_CIPH_GCM_MODE) {
         if (!EVP_CipherInit_ex(dd, c, NULL, key, NULL, (which & SSL3_CC_WRITE))
@@ -392,21 +390,15 @@ int tls1_change_cipher_state(SSL *s, int which)
 #endif                          /* OPENSSL_NO_KTLS */
     s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
 
-#ifdef SSL_DEBUG
-    printf("which = %04X\nkey=", which);
-    {
-        int z;
-        for (z = 0; z < EVP_CIPHER_key_length(c); z++)
-            printf("%02X%c", key[z], ((z + 1) % 16) ? ' ' : '\n');
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "which = %04X, key:\n", which);
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL),
+                        key, EVP_CIPHER_key_length(c), 4);
     }
-    printf("\niv=");
-    {
-        size_t z;
-        for (z = 0; z < k; z++)
-            printf("%02X%c", iv[z], ((z + 1) % 16) ? ' ' : '\n');
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "iv:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), iv, k, 4);
     }
-    printf("\n");
-#endif
 
     OPENSSL_cleanse(tmp1, sizeof(tmp1));
     OPENSSL_cleanse(tmp2, sizeof(tmp1));
@@ -459,41 +451,27 @@ int tls1_setup_key_block(SSL *s)
     s->s3->tmp.key_block_length = num;
     s->s3->tmp.key_block = p;
 
-#ifdef SSL_DEBUG
-    printf("client random\n");
-    {
-        int z;
-        for (z = 0; z < SSL3_RANDOM_SIZE; z++)
-            printf("%02X%c", s->s3->client_random[z],
-                   ((z + 1) % 16) ? ' ' : '\n');
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "client random\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), s->s3->client_random,
+                        SSL3_RANDOM_SIZE, 4);
+        OSSL_debug(OSSL_DEBUG_SSL, "server random\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), s->s3->server_random,
+                        SSL3_RANDOM_SIZE, 4);
+        OSSL_debug(OSSL_DEBUG_SSL, "master key\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), s->session->master_key,
+                        s->session->master_key_length, 4);
     }
-    printf("server random\n");
-    {
-        int z;
-        for (z = 0; z < SSL3_RANDOM_SIZE; z++)
-            printf("%02X%c", s->s3->server_random[z],
-                   ((z + 1) % 16) ? ' ' : '\n');
-    }
-    printf("master key\n");
-    {
-        size_t z;
-        for (z = 0; z < s->session->master_key_length; z++)
-            printf("%02X%c", s->session->master_key[z],
-                   ((z + 1) % 16) ? ' ' : '\n');
-    }
-#endif
+
     if (!tls1_generate_key_block(s, p, num)) {
         /* SSLfatal() already called */
         goto err;
     }
-#ifdef SSL_DEBUG
-    printf("\nkey block\n");
-    {
-        size_t z;
-        for (z = 0; z < num; z++)
-            printf("%02X%c", p[z], ((z + 1) % 16) ? ' ' : '\n');
+
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "key block\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), p, num, 4);
     }
-#endif
 
     if (!(s->options & SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS)
         && s->method->version <= TLS1_VERSION) {
@@ -561,10 +539,10 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
             /* SSLfatal() already called */
             return 0;
         }
-#ifdef SSL_DEBUG
-        fprintf(stderr, "Handshake hashes:\n");
-        BIO_dump_fp(stderr, (char *)hash, hashlen);
-#endif
+        if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+            OSSL_debug(OSSL_DEBUG_SSL, "Handshake hashes:\n");
+            BIO_dump(OSSL_debug_bio(OSSL_DEBUG_SSL), (char *)hash, hashlen);
+        }
         if (!tls1_PRF(s,
                       TLS_MD_EXTENDED_MASTER_SECRET_CONST,
                       TLS_MD_EXTENDED_MASTER_SECRET_CONST_SIZE,
@@ -590,17 +568,20 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
             return 0;
         }
     }
-#ifdef SSL_DEBUG
-    fprintf(stderr, "Premaster Secret:\n");
-    BIO_dump_fp(stderr, (char *)p, len);
-    fprintf(stderr, "Client Random:\n");
-    BIO_dump_fp(stderr, (char *)s->s3->client_random, SSL3_RANDOM_SIZE);
-    fprintf(stderr, "Server Random:\n");
-    BIO_dump_fp(stderr, (char *)s->s3->server_random, SSL3_RANDOM_SIZE);
-    fprintf(stderr, "Master Secret:\n");
-    BIO_dump_fp(stderr, (char *)s->session->master_key,
-                SSL3_MASTER_SECRET_SIZE);
-#endif
+
+    if (OSSL_debug_is_set(OSSL_DEBUG_SSL)) {
+        OSSL_debug(OSSL_DEBUG_SSL, "Premaster Secret:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), p, len, 4);
+        OSSL_debug(OSSL_DEBUG_SSL, "Client Random:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), s->s3->client_random,
+                        SSL3_RANDOM_SIZE, 4);
+        OSSL_debug(OSSL_DEBUG_SSL, "Server Random:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), s->s3->server_random,
+                        SSL3_RANDOM_SIZE, 4);
+        OSSL_debug(OSSL_DEBUG_SSL, "Master Secret:\n");
+        BIO_dump_indent(OSSL_debug_bio(OSSL_DEBUG_SSL), s->session->master_key,
+                        SSL3_MASTER_SECRET_SIZE, 4);
+    }
 
     *secret_size = SSL3_MASTER_SECRET_SIZE;
     return 1;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4622,10 +4622,10 @@ CRYPTO_siv128_cleanup                   4577	3_0_0	EXIST::FUNCTION:SIV
 CRYPTO_siv128_speed                     4578	3_0_0	EXIST::FUNCTION:SIV
 OSSL_trace_set                          4579	3_0_0	EXIST::FUNCTION:
 OSSL_debug_set                          4580	3_0_0	EXIST::FUNCTION:
-OSSL_trace_is_set                       4581	3_0_0	EXIST::FUNCTION:
-OSSL_debug_is_set                       4582	3_0_0	EXIST::FUNCTION:
-OSSL_trace_bio                          4583	3_0_0	EXIST::FUNCTION:
-OSSL_debug_bio                          4584	3_0_0	EXIST::FUNCTION:
+OSSL_trace_is_set                       4581	3_0_0	EXIST::FUNCTION:TRACE
+OSSL_debug_is_set                       4582	3_0_0	EXIST::FUNCTION:TRACE
+OSSL_trace_bio                          4583	3_0_0	EXIST::FUNCTION:TRACE
+OSSL_debug_bio                          4584	3_0_0	EXIST::FUNCTION:TRACE
 OSSL_trace                              4585	3_0_0	EXIST::FUNCTION:
 OSSL_vtrace                             4586	3_0_0	EXIST::FUNCTION:
 OSSL_debug                              4587	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4620,3 +4620,15 @@ CRYPTO_siv128_set_tag                   4575	3_0_0	EXIST::FUNCTION:SIV
 CRYPTO_siv128_get_tag                   4576	3_0_0	EXIST::FUNCTION:SIV
 CRYPTO_siv128_cleanup                   4577	3_0_0	EXIST::FUNCTION:SIV
 CRYPTO_siv128_speed                     4578	3_0_0	EXIST::FUNCTION:SIV
+OSSL_trace_set                          4579	3_0_0	EXIST::FUNCTION:
+OSSL_debug_set                          4580	3_0_0	EXIST::FUNCTION:
+OSSL_trace_is_set                       4581	3_0_0	EXIST::FUNCTION:
+OSSL_debug_is_set                       4582	3_0_0	EXIST::FUNCTION:
+OSSL_trace_bio                          4583	3_0_0	EXIST::FUNCTION:
+OSSL_debug_bio                          4584	3_0_0	EXIST::FUNCTION:
+OSSL_trace                              4585	3_0_0	EXIST::FUNCTION:
+OSSL_vtrace                             4586	3_0_0	EXIST::FUNCTION:
+OSSL_debug                              4587	3_0_0	EXIST::FUNCTION:
+OSSL_vdebug                             4588	3_0_0	EXIST::FUNCTION:
+OSSL_trace_get_type                     4589	3_0_0	EXIST::FUNCTION:
+OSSL_debug_get_type                     4590	3_0_0	EXIST::FUNCTION:

--- a/util/private.num
+++ b/util/private.num
@@ -44,6 +44,7 @@ OSSL_STORE_error_fn                     datatype
 OSSL_STORE_load_fn                      datatype
 OSSL_STORE_open_fn                      datatype
 OSSL_STORE_post_process_info_fn         datatype
+OSSL_tracer_fn                          datatype
 PROFESSION_INFO                         datatype
 PROFESSION_INFOS                        datatype
 RAND_DRBG_cleanup_entropy_fn            datatype


### PR DESCRIPTION
The idea is that the application shall be able to register callbacks
to print tracing and debugging output as it sees fit.

OpenSSL internals, on the other hand, want to print thoses texts using
normal printing routines, such as BIO_printf() or BIO_dump().

Internally, this is solved by creating BIOs that simply forward
received text to the appropriate application provided callback.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
