### PR TITLE
doc/man3: remove copy&paste leftover

### DIFF
--- a/doc/man3/X509_NAME_ENTRY_get_object.pod
+++ b/doc/man3/X509_NAME_ENTRY_get_object.pod
@@ -51,9 +51,6 @@ X509_NAME_ENTRY_get_object() and X509_NAME_ENTRY_get_data() can be
 used to examine an B<X509_NAME_ENTRY> function as returned by
 X509_NAME_get_entry() for example.
 
-X509_NAME_ENTRY_create_by_txt(), X509_NAME_ENTRY_create_by_NID(),
-and X509_NAME_ENTRY_create_by_OBJ() create and return an
-
 X509_NAME_ENTRY_create_by_txt(), X509_NAME_ENTRY_create_by_OBJ(),
 X509_NAME_ENTRY_create_by_NID() and X509_NAME_ENTRY_set_data()
 are seldom used in practice because B<X509_NAME_ENTRY> structures


### PR DESCRIPTION
Fixes #7883

This patch removes a copy&paste leftover from the DESCRIPTION section

https://github.com/openssl/openssl/blob/4746f25ac62e5bbdc07eedcec9c9a27547577141/doc/man3/X509_NAME_ENTRY_get_object.pod#L44-L46

The RETURN VALUE section already contains the necessary documentation.

https://github.com/openssl/openssl/blob/4746f25ac62e5bbdc07eedcec9c9a27547577141/doc/man3/X509_NAME_ENTRY_get_object.pod#L81-L83

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
