### PR TITLE
Collapse ssl3_state_st (s3) into ssl_st

### DIFF
--- a/ssl/d1_msg.c
+++ b/ssl/d1_msg.c
@@ -41,22 +41,22 @@ int dtls1_dispatch_alert(SSL *s)
     unsigned char *ptr = &buf[0];
     size_t written;
 
-    s->s3->alert_dispatch = 0;
+    s->s3.alert_dispatch = 0;
 
     memset(buf, 0, sizeof(buf));
-    *ptr++ = s->s3->send_alert[0];
-    *ptr++ = s->s3->send_alert[1];
+    *ptr++ = s->s3.send_alert[0];
+    *ptr++ = s->s3.send_alert[1];
 
     i = do_dtls1_write(s, SSL3_RT_ALERT, &buf[0], sizeof(buf), 0, &written);
     if (i <= 0) {
-        s->s3->alert_dispatch = 1;
+        s->s3.alert_dispatch = 1;
         /* fprintf( stderr, "not done with alert\n" ); */
     } else {
-        if (s->s3->send_alert[0] == SSL3_AL_FATAL)
+        if (s->s3.send_alert[0] == SSL3_AL_FATAL)
             (void)BIO_flush(s->wbio);
 
         if (s->msg_callback)
-            s->msg_callback(1, s->version, SSL3_RT_ALERT, s->s3->send_alert,
+            s->msg_callback(1, s->version, SSL3_RT_ALERT, s->s3.send_alert,
                             2, s, s->msg_callback_arg);
 
         if (s->info_callback != NULL)
@@ -65,7 +65,7 @@ int dtls1_dispatch_alert(SSL *s)
             cb = s->ctx->info_callback;
 
         if (cb != NULL) {
-            j = (s->s3->send_alert[0] << 8) | s->s3->send_alert[1];
+            j = (s->s3.send_alert[0] << 8) | s->s3.send_alert[1];
             cb(s, SSL_CB_WRITE_ALERT, j);
         }
     }

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -374,10 +374,10 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
     s->rwstate = SSL_NOTHING;
 
     /*-
-     * s->s3->rrec.type         - is the type of record
-     * s->s3->rrec.data,    - data
-     * s->s3->rrec.off,     - offset into 'data' for next read
-     * s->s3->rrec.length,  - number of bytes.
+     * s->s3.rrec.type     - is the type of record
+     * s->s3.rrec.data,    - data
+     * s->s3.rrec.off,     - offset into 'data' for next read
+     * s->s3.rrec.length,  - number of bytes.
      */
     rr = s->rlayer.rrec;
 
@@ -442,8 +442,8 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
 
     /* we now have a packet which can be read and processed */
 
-    if (s->s3->change_cipher_spec /* set when we receive ChangeCipherSpec,
-                                   * reset by ssl3_get_finished */
+    if (s->s3.change_cipher_spec /* set when we receive ChangeCipherSpec,
+                                  * reset by ssl3_get_finished */
         && (SSL3_RECORD_get_type(rr) != SSL3_RT_HANDSHAKE)) {
         /*
          * We now have application data between CCS and Finished. Most likely
@@ -574,7 +574,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
         }
 
         if (alert_level == SSL3_AL_WARNING) {
-            s->s3->warn_alert = alert_descr;
+            s->s3.warn_alert = alert_descr;
             SSL3_RECORD_set_read(rr);
 
             s->rlayer.alert_count++;
@@ -607,7 +607,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             char tmp[16];
 
             s->rwstate = SSL_NOTHING;
-            s->s3->fatal_alert = alert_descr;
+            s->s3.fatal_alert = alert_descr;
             SSLfatal(s, SSL_AD_NO_ALERT, SSL_F_DTLS1_READ_BYTES,
                      SSL_AD_REASON_OFFSET + alert_descr);
             BIO_snprintf(tmp, sizeof tmp, "%d", alert_descr);
@@ -761,10 +761,10 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
          * application data at this point (session renegotiation not yet
          * started), we will indulge it.
          */
-        if (s->s3->in_read_app_data &&
-            (s->s3->total_renegotiations != 0) &&
+        if (s->s3.in_read_app_data &&
+            (s->s3.total_renegotiations != 0) &&
             ossl_statem_app_data_allowed(s)) {
-            s->s3->in_read_app_data = 2;
+            s->s3.in_read_app_data = 2;
             return -1;
         } else {
             SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE, SSL_F_DTLS1_READ_BYTES,
@@ -818,7 +818,7 @@ int do_dtls1_write(SSL *s, int type, const unsigned char *buf,
     }
 
     /* If we have an alert to send, lets send it */
-    if (s->s3->alert_dispatch) {
+    if (s->s3.alert_dispatch) {
         i = s->method->ssl_dispatch_alert(s);
         if (i <= 0)
             return i;

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -172,7 +172,7 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
     /*
      * If extend == 0, obtain new n-byte packet; if extend == 1, increase
      * packet by another n bytes. The packet will be in the sub-array of
-     * s->s3->rbuf.buf specified by s->packet and s->packet_length. (If
+     * s->s3.rbuf.buf specified by s->packet and s->packet_length. (If
      * s->rlayer.read_ahead is set, 'max' bytes may be stored in rbuf [plus
      * s->packet_length bytes if extend == 1].)
      * if clearold == 1, move the packet to the start of the buffer; if
@@ -284,7 +284,7 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
         int ret;
 
         /*
-         * Now we have len+left bytes at the front of s->s3->rbuf.buf and
+         * Now we have len+left bytes at the front of s->s3.rbuf.buf and
          * need to read in more until we have len+n (up to len+max if
          * possible)
          */
@@ -457,7 +457,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
                 break;
             }
 
-            if (s->s3->alert_dispatch) {
+            if (s->s3.alert_dispatch) {
                 i = s->method->ssl_dispatch_alert(s);
                 if (i <= 0) {
                     /* SSLfatal() already called if appropriate */
@@ -626,7 +626,7 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
              * next chunk of data should get another prepended empty fragment
              * in ciphersuites with known-IV weakness:
              */
-            s->s3->empty_fragment_done = 0;
+            s->s3.empty_fragment_done = 0;
 
             if ((i == (int)n) && s->mode & SSL_MODE_RELEASE_BUFFERS &&
                 !SSL_IS_DTLS(s))
@@ -671,7 +671,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
     }
 
     /* If we have an alert to send, lets send it */
-    if (s->s3->alert_dispatch) {
+    if (s->s3.alert_dispatch) {
         i = s->method->ssl_dispatch_alert(s);
         if (i <= 0) {
             /* SSLfatal() already called if appropriate */
@@ -709,13 +709,13 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
     /*
      * 'create_empty_fragment' is true only when this function calls itself
      */
-    if (!clear && !create_empty_fragment && !s->s3->empty_fragment_done) {
+    if (!clear && !create_empty_fragment && !s->s3.empty_fragment_done) {
         /*
          * countermeasure against known-IV weakness in CBC ciphersuites (see
          * http://www.openssl.org/~bodo/tls-cbc.txt)
          */
 
-        if (s->s3->need_empty_fragments && type == SSL3_RT_APPLICATION_DATA) {
+        if (s->s3.need_empty_fragments && type == SSL3_RT_APPLICATION_DATA) {
             /*
              * recursive function call with 'create_empty_fragment' set; this
              * prepares and buffers the data for an empty fragment (these
@@ -740,7 +740,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
             }
         }
 
-        s->s3->empty_fragment_done = 1;
+        s->s3.empty_fragment_done = 1;
     }
 
     if (BIO_get_ktls_send(s->wbio)) {
@@ -1144,7 +1144,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
     return -1;
 }
 
-/* if s->s3->wbuf.left != 0, we need to call this
+/* if s->s3.wbuf.left != 0, we need to call this
  *
  * Return values are as per SSL_write()
  */
@@ -1381,8 +1381,8 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
 
     /* we now have a packet which can be read and processed */
 
-    if (s->s3->change_cipher_spec /* set when we receive ChangeCipherSpec,
-                                   * reset by ssl3_get_finished */
+    if (s->s3.change_cipher_spec /* set when we receive ChangeCipherSpec,
+                                  * reset by ssl3_get_finished */
         && (SSL3_RECORD_get_type(rr) != SSL3_RT_HANDSHAKE)) {
         SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE, SSL_F_SSL3_READ_BYTES,
                  SSL_R_DATA_BETWEEN_CCS_AND_FINISHED);
@@ -1554,7 +1554,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
 
         if (alert_level == SSL3_AL_WARNING
                 || (is_tls13 && alert_descr == SSL_AD_USER_CANCELLED)) {
-            s->s3->warn_alert = alert_descr;
+            s->s3.warn_alert = alert_descr;
             SSL3_RECORD_set_read(rr);
 
             s->rlayer.alert_count++;
@@ -1579,7 +1579,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             char tmp[16];
 
             s->rwstate = SSL_NOTHING;
-            s->s3->fatal_alert = alert_descr;
+            s->s3.fatal_alert = alert_descr;
             SSLfatal(s, SSL_AD_NO_ALERT, SSL_F_SSL3_READ_BYTES,
                      SSL_AD_REASON_OFFSET + alert_descr);
             BIO_snprintf(tmp, sizeof tmp, "%d", alert_descr);
@@ -1763,7 +1763,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
          * started), we will indulge it.
          */
         if (ossl_statem_app_data_allowed(s)) {
-            s->s3->in_read_app_data = 2;
+            s->s3.in_read_app_data = 2;
             return -1;
         } else if (ossl_statem_skip_early_data(s)) {
             /*

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1187,11 +1187,11 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     int t;
 
     if (sending) {
-        mac_sec = &(ssl->s3->write_mac_secret[0]);
+        mac_sec = &(ssl->s3.write_mac_secret[0]);
         seq = RECORD_LAYER_get_write_sequence(&ssl->rlayer);
         hash = ssl->write_hash;
     } else {
-        mac_sec = &(ssl->s3->read_mac_secret[0]);
+        mac_sec = &(ssl->s3.read_mac_secret[0]);
         seq = RECORD_LAYER_get_read_sequence(&ssl->rlayer);
         hash = ssl->read_hash;
     }
@@ -1340,8 +1340,8 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
                                    md, &md_size,
                                    header, rec->input,
                                    rec->length + md_size, rec->orig_len,
-                                   ssl->s3->read_mac_secret,
-                                   ssl->s3->read_mac_secret_size, 0) <= 0) {
+                                   ssl->s3.read_mac_secret,
+                                   ssl->s3.read_mac_secret_size, 0) <= 0) {
             EVP_MD_CTX_free(hmac);
             return 0;
         }
@@ -1768,11 +1768,11 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
     rr->off = 0;
     /*-
      * So at this point the following is true
-     * ssl->s3->rrec.type   is the type of record
-     * ssl->s3->rrec.length == number of bytes in record
-     * ssl->s3->rrec.off    == offset to first valid byte
-     * ssl->s3->rrec.data   == where to take bytes from, increment
-     *                         after use :-).
+     * ssl->s3.rrec.type   is the type of record
+     * ssl->s3.rrec.length == number of bytes in record
+     * ssl->s3.rrec.off    == offset to first valid byte
+     * ssl->s3.rrec.data   == where to take bytes from, increment
+     *                        after use :-).
      */
 
     /* we have pulled in a full packet so zero things */
@@ -1796,9 +1796,9 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
  * It will return <= 0 if more data is needed, normally due to an error
  * or non-blocking IO.
  * When it finishes, one packet has been decoded and can be found in
- * ssl->s3->rrec.type    - is the type of record
- * ssl->s3->rrec.data,   - data
- * ssl->s3->rrec.length, - number of bytes
+ * ssl->s3.rrec.type    - is the type of record
+ * ssl->s3.rrec.data    - data
+ * ssl->s3.rrec.length  - number of bytes
  */
 /* used only by dtls1_read_bytes */
 int dtls1_get_record(SSL *s)

--- a/ssl/record/ssl3_record_tls13.c
+++ b/ssl/record/ssl3_record_tls13.c
@@ -84,12 +84,12 @@ int tls13_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending)
          * To get here we must have selected a ciphersuite - otherwise ctx would
          * be NULL
          */
-        if (!ossl_assert(s->s3->tmp.new_cipher != NULL)) {
+        if (!ossl_assert(s->s3.tmp.new_cipher != NULL)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS13_ENC,
                      ERR_R_INTERNAL_ERROR);
             return -1;
         }
-        alg_enc = s->s3->tmp.new_cipher->algorithm_enc;
+        alg_enc = s->s3.tmp.new_cipher->algorithm_enc;
     }
 
     if (alg_enc & SSL_AESCCM) {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3292,11 +3292,6 @@ int ssl3_handshake_write(SSL *s)
 
 int ssl3_new(SSL *s)
 {
-    SSL3_STATE *s3;
-
-    if ((s3 = OPENSSL_zalloc(sizeof(*s3))) == NULL)
-        goto err;
-    s->s3 = s3;
 
 #ifndef OPENSSL_NO_SRP
     if (!SSL_SRP_CTX_init(s))
@@ -3313,57 +3308,56 @@ int ssl3_new(SSL *s)
 
 void ssl3_free(SSL *s)
 {
-    if (s == NULL || s->s3 == NULL)
+    if (s == NULL)
         return;
 
     ssl3_cleanup_key_block(s);
 
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-    EVP_PKEY_free(s->s3->peer_tmp);
-    s->s3->peer_tmp = NULL;
-    EVP_PKEY_free(s->s3->tmp.pkey);
-    s->s3->tmp.pkey = NULL;
+    EVP_PKEY_free(s->s3.peer_tmp);
+    s->s3.peer_tmp = NULL;
+    EVP_PKEY_free(s->s3.tmp.pkey);
+    s->s3.tmp.pkey = NULL;
 #endif
 
-    OPENSSL_free(s->s3->tmp.ctype);
-    sk_X509_NAME_pop_free(s->s3->tmp.peer_ca_names, X509_NAME_free);
-    OPENSSL_free(s->s3->tmp.ciphers_raw);
-    OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
-    OPENSSL_free(s->s3->tmp.peer_sigalgs);
-    OPENSSL_free(s->s3->tmp.peer_cert_sigalgs);
+    OPENSSL_free(s->s3.tmp.ctype);
+    sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
+    OPENSSL_free(s->s3.tmp.ciphers_raw);
+    OPENSSL_clear_free(s->s3.tmp.pms, s->s3.tmp.pmslen);
+    OPENSSL_free(s->s3.tmp.peer_sigalgs);
+    OPENSSL_free(s->s3.tmp.peer_cert_sigalgs);
     ssl3_free_digest_list(s);
-    OPENSSL_free(s->s3->alpn_selected);
-    OPENSSL_free(s->s3->alpn_proposed);
+    OPENSSL_free(s->s3.alpn_selected);
+    OPENSSL_free(s->s3.alpn_proposed);
 
 #ifndef OPENSSL_NO_SRP
     SSL_SRP_CTX_free(s);
 #endif
-    OPENSSL_clear_free(s->s3, sizeof(*s->s3));
-    s->s3 = NULL;
+    memset(&s->s3, 0, sizeof(s->s3));
 }
 
 int ssl3_clear(SSL *s)
 {
     ssl3_cleanup_key_block(s);
-    OPENSSL_free(s->s3->tmp.ctype);
-    sk_X509_NAME_pop_free(s->s3->tmp.peer_ca_names, X509_NAME_free);
-    OPENSSL_free(s->s3->tmp.ciphers_raw);
-    OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
-    OPENSSL_free(s->s3->tmp.peer_sigalgs);
-    OPENSSL_free(s->s3->tmp.peer_cert_sigalgs);
+    OPENSSL_free(s->s3.tmp.ctype);
+    sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
+    OPENSSL_free(s->s3.tmp.ciphers_raw);
+    OPENSSL_clear_free(s->s3.tmp.pms, s->s3.tmp.pmslen);
+    OPENSSL_free(s->s3.tmp.peer_sigalgs);
+    OPENSSL_free(s->s3.tmp.peer_cert_sigalgs);
 
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-    EVP_PKEY_free(s->s3->tmp.pkey);
-    EVP_PKEY_free(s->s3->peer_tmp);
+    EVP_PKEY_free(s->s3.tmp.pkey);
+    EVP_PKEY_free(s->s3.peer_tmp);
 #endif                          /* !OPENSSL_NO_EC */
 
     ssl3_free_digest_list(s);
 
-    OPENSSL_free(s->s3->alpn_selected);
-    OPENSSL_free(s->s3->alpn_proposed);
+    OPENSSL_free(s->s3.alpn_selected);
+    OPENSSL_free(s->s3.alpn_proposed);
 
     /* NULL/zero-out everything in the s3 struct */
-    memset(s->s3, 0, sizeof(*s->s3));
+    memset(&s->s3, 0, sizeof(s->s3));
 
     if (!ssl_free_wbio_buffer(s))
         return 0;
@@ -3396,17 +3390,17 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_CLIENT_CERT_REQUEST:
         break;
     case SSL_CTRL_GET_NUM_RENEGOTIATIONS:
-        ret = s->s3->num_renegotiations;
+        ret = s->s3.num_renegotiations;
         break;
     case SSL_CTRL_CLEAR_NUM_RENEGOTIATIONS:
-        ret = s->s3->num_renegotiations;
-        s->s3->num_renegotiations = 0;
+        ret = s->s3.num_renegotiations;
+        s->s3.num_renegotiations = 0;
         break;
     case SSL_CTRL_GET_TOTAL_RENEGOTIATIONS:
-        ret = s->s3->total_renegotiations;
+        ret = s->s3.total_renegotiations;
         break;
     case SSL_CTRL_GET_FLAGS:
-        ret = (int)(s->s3->flags);
+        ret = (int)(s->s3.flags);
         break;
 #ifndef OPENSSL_NO_DH
     case SSL_CTRL_SET_TMP_DH:
@@ -3578,7 +3572,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             const SSL_CIPHER *cipher;
             if (!s->server)
                 return 0;
-            cipher = s->s3->tmp.new_cipher;
+            cipher = s->s3.tmp.new_cipher;
             if (cipher == NULL)
                 return 0;
             /*
@@ -3587,9 +3581,9 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
              */
             if (cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
                 return 2;
-            if (s->s3->tmp.cert == NULL)
+            if (s->s3.tmp.cert == NULL)
                 return 0;
-            s->cert->key = s->s3->tmp.cert;
+            s->cert->key = s->s3.tmp.cert;
             return 1;
         }
         return ssl_cert_set_current(s->cert, larg);
@@ -3655,11 +3649,11 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_CLIENT_CERT_TYPES:
         {
             const unsigned char **pctype = parg;
-            if (s->server || !s->s3->tmp.cert_req)
+            if (s->server || !s->s3.tmp.cert_req)
                 return 0;
             if (pctype)
-                *pctype = s->s3->tmp.ctype;
-            return s->s3->tmp.ctype_len;
+                *pctype = s->s3.tmp.ctype;
+            return s->s3.tmp.ctype_len;
         }
 
     case SSL_CTRL_SET_CLIENT_CERT_TYPES:
@@ -3677,24 +3671,24 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         return ssl_cert_set_cert_store(s->cert, parg, 1, larg);
 
     case SSL_CTRL_GET_PEER_SIGNATURE_NID:
-        if (s->s3->tmp.peer_sigalg == NULL)
+        if (s->s3.tmp.peer_sigalg == NULL)
             return 0;
-        *(int *)parg = s->s3->tmp.peer_sigalg->hash;
+        *(int *)parg = s->s3.tmp.peer_sigalg->hash;
         return 1;
 
     case SSL_CTRL_GET_SIGNATURE_NID:
-        if (s->s3->tmp.sigalg == NULL)
+        if (s->s3.tmp.sigalg == NULL)
             return 0;
-        *(int *)parg = s->s3->tmp.sigalg->hash;
+        *(int *)parg = s->s3.tmp.sigalg->hash;
         return 1;
 
     case SSL_CTRL_GET_PEER_TMP_KEY:
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
-        if (s->session == NULL || s->s3->peer_tmp == NULL) {
+        if (s->session == NULL || s->s3.peer_tmp == NULL) {
             return 0;
         } else {
-            EVP_PKEY_up_ref(s->s3->peer_tmp);
-            *(EVP_PKEY **)parg = s->s3->peer_tmp;
+            EVP_PKEY_up_ref(s->s3.peer_tmp);
+            *(EVP_PKEY **)parg = s->s3.peer_tmp;
             return 1;
         }
 #else
@@ -3703,11 +3697,11 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 
     case SSL_CTRL_GET_TMP_KEY:
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
-        if (s->session == NULL || s->s3->tmp.pkey == NULL) {
+        if (s->session == NULL || s->s3.tmp.pkey == NULL) {
             return 0;
         } else {
-            EVP_PKEY_up_ref(s->s3->tmp.pkey);
-            *(EVP_PKEY **)parg = s->s3->tmp.pkey;
+            EVP_PKEY_up_ref(s->s3.tmp.pkey);
+            *(EVP_PKEY **)parg = s->s3.tmp.pkey;
             return 1;
         }
 #else
@@ -4262,8 +4256,8 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
          * key exchange scheme skip tests.
          */
         if (!SSL_IS_TLS13(s)) {
-            mask_k = s->s3->tmp.mask_k;
-            mask_a = s->s3->tmp.mask_a;
+            mask_k = s->s3.tmp.mask_k;
+            mask_a = s->s3.tmp.mask_a;
 #ifndef OPENSSL_NO_SRP
             if (s->srp_ctx.srp_Mask & SSL_kSRP) {
                 mask_k |= SSL_kSRP;
@@ -4305,7 +4299,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
                 continue;
 #if !defined(OPENSSL_NO_EC)
             if ((alg_k & SSL_kECDHE) && (alg_a & SSL_aECDSA)
-                && s->s3->is_probably_safari) {
+                && s->s3.is_probably_safari) {
                 if (!ret)
                     ret = sk_SSL_CIPHER_value(allow, ii);
                 continue;
@@ -4342,7 +4336,7 @@ int ssl3_get_req_cert_type(SSL *s, WPACKET *pkt)
     /* Get mask of algorithms disabled by signature list */
     ssl_set_sig_mask(&alg_a, s, SSL_SECOP_SIGALG_MASK);
 
-    alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
 
 #ifndef OPENSSL_NO_GOST
     if (s->version >= TLS1_VERSION && (alg_k & SSL_kGOST))
@@ -4418,11 +4412,11 @@ int ssl3_shutdown(SSL *s)
         ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_CLOSE_NOTIFY);
         /*
          * our shutdown alert has been sent now, and if it still needs to be
-         * written, s->s3->alert_dispatch will be true
+         * written, s->s3.alert_dispatch will be true
          */
-        if (s->s3->alert_dispatch)
+        if (s->s3.alert_dispatch)
             return -1;        /* return WANT_WRITE */
-    } else if (s->s3->alert_dispatch) {
+    } else if (s->s3.alert_dispatch) {
         /* resend it if not sent */
         ret = s->method->ssl_dispatch_alert(s);
         if (ret == -1) {
@@ -4445,7 +4439,7 @@ int ssl3_shutdown(SSL *s)
     }
 
     if ((s->shutdown == (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN)) &&
-        !s->s3->alert_dispatch)
+        !s->s3.alert_dispatch)
         return 1;
     else
         return 0;
@@ -4454,7 +4448,7 @@ int ssl3_shutdown(SSL *s)
 int ssl3_write(SSL *s, const void *buf, size_t len, size_t *written)
 {
     clear_sys_error();
-    if (s->s3->renegotiate)
+    if (s->s3.renegotiate)
         ssl3_renegotiate_check(s, 0);
 
     return s->method->ssl_write_bytes(s, SSL3_RT_APPLICATION_DATA, buf, len,
@@ -4467,13 +4461,13 @@ static int ssl3_read_internal(SSL *s, void *buf, size_t len, int peek,
     int ret;
 
     clear_sys_error();
-    if (s->s3->renegotiate)
+    if (s->s3.renegotiate)
         ssl3_renegotiate_check(s, 0);
-    s->s3->in_read_app_data = 1;
+    s->s3.in_read_app_data = 1;
     ret =
         s->method->ssl_read_bytes(s, SSL3_RT_APPLICATION_DATA, NULL, buf, len,
                                   peek, readbytes);
-    if ((ret == -1) && (s->s3->in_read_app_data == 2)) {
+    if ((ret == -1) && (s->s3.in_read_app_data == 2)) {
         /*
          * ssl3_read_bytes decided to call s->handshake_func, which called
          * ssl3_read_bytes to read handshake data. However, ssl3_read_bytes
@@ -4487,7 +4481,7 @@ static int ssl3_read_internal(SSL *s, void *buf, size_t len, int peek,
                                       len, peek, readbytes);
         ossl_statem_set_in_handshake(s, 0);
     } else
-        s->s3->in_read_app_data = 0;
+        s->s3.in_read_app_data = 0;
 
     return ret;
 }
@@ -4507,7 +4501,7 @@ int ssl3_renegotiate(SSL *s)
     if (s->handshake_func == NULL)
         return 1;
 
-    s->s3->renegotiate = 1;
+    s->s3.renegotiate = 1;
     return 1;
 }
 
@@ -4523,7 +4517,7 @@ int ssl3_renegotiate_check(SSL *s, int initok)
 {
     int ret = 0;
 
-    if (s->s3->renegotiate) {
+    if (s->s3.renegotiate) {
         if (!RECORD_LAYER_read_pending(&s->rlayer)
             && !RECORD_LAYER_write_pending(&s->rlayer)
             && (initok || !SSL_in_init(s))) {
@@ -4533,9 +4527,9 @@ int ssl3_renegotiate_check(SSL *s, int initok)
              * state.
              */
             ossl_statem_set_renegotiate(s);
-            s->s3->renegotiate = 0;
-            s->s3->num_renegotiations++;
-            s->s3->total_renegotiations++;
+            s->s3.renegotiate = 0;
+            s->s3.num_renegotiations++;
+            s->s3.total_renegotiations++;
             ret = 1;
         }
     }
@@ -4551,13 +4545,13 @@ int ssl3_renegotiate_check(SSL *s, int initok)
 long ssl_get_algorithm2(SSL *s)
 {
     long alg2;
-    if (s->s3 == NULL || s->s3->tmp.new_cipher == NULL)
+    if (s->s3.tmp.new_cipher == NULL)
         return -1;
-    alg2 = s->s3->tmp.new_cipher->algorithm2;
+    alg2 = s->s3.tmp.new_cipher->algorithm2;
     if (s->method->ssl3_enc->enc_flags & SSL_ENC_FLAG_SHA256_PRF) {
         if (alg2 == (SSL_HANDSHAKE_MAC_DEFAULT | TLS1_PRF))
             return SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256;
-    } else if (s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK) {
+    } else if (s->s3.tmp.new_cipher->algorithm_mkey & SSL_PSK) {
         if (alg2 == (SSL_HANDSHAKE_MAC_SHA384 | TLS1_PRF_SHA384))
             return SSL_HANDSHAKE_MAC_DEFAULT | TLS1_PRF;
     }
@@ -4607,13 +4601,13 @@ int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
 int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
                                int free_pms)
 {
-    unsigned long alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    unsigned long alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
     int ret = 0;
 
     if (alg_k & SSL_PSK) {
 #ifndef OPENSSL_NO_PSK
         unsigned char *pskpms, *t;
-        size_t psklen = s->s3->tmp.psklen;
+        size_t psklen = s->s3.tmp.psklen;
         size_t pskpmslen;
 
         /* create PSK premaster_secret */
@@ -4634,10 +4628,10 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
             memcpy(t, pms, pmslen);
         t += pmslen;
         s2n(psklen, t);
-        memcpy(t, s->s3->tmp.psk, psklen);
+        memcpy(t, s->s3.tmp.psk, psklen);
 
-        OPENSSL_clear_free(s->s3->tmp.psk, psklen);
-        s->s3->tmp.psk = NULL;
+        OPENSSL_clear_free(s->s3.tmp.psk, psklen);
+        s->s3.tmp.psk = NULL;
         if (!s->method->ssl3_enc->generate_master_secret(s,
                     s->session->master_key,pskpms, pskpmslen,
                     &s->session->master_key_length)) {
@@ -4668,7 +4662,7 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
             OPENSSL_cleanse(pms, pmslen);
     }
     if (s->server == 0)
-        s->s3->tmp.pms = NULL;
+        s->s3.tmp.pms = NULL;
     return ret;
 }
 
@@ -4836,8 +4830,8 @@ int ssl_derive(SSL *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gensecret)
         }
     } else {
         /* Save premaster secret */
-        s->s3->tmp.pms = pms;
-        s->s3->tmp.pmslen = pmslen;
+        s->s3.tmp.pms = pms;
+        s->s3.tmp.pmslen = pmslen;
         pms = NULL;
         rv = 1;
     }

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -516,13 +516,13 @@ void SSL_set_client_CA_list(SSL *s, STACK_OF(X509_NAME) *name_list)
 
 const STACK_OF(X509_NAME) *SSL_get0_peer_CA_list(const SSL *s)
 {
-    return s->s3 != NULL ? s->s3->tmp.peer_ca_names : NULL;
+    return s->s3.tmp.peer_ca_names;
 }
 
 STACK_OF(X509_NAME) *SSL_get_client_CA_list(const SSL *s)
 {
     if (!s->server)
-        return s->s3 != NULL ?  s->s3->tmp.peer_ca_names : NULL;
+        return s->s3.tmp.peer_ca_names;
     return s->client_ca_names != NULL ?  s->client_ca_names
                                       : s->ctx->client_ca_names;
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1421,12 +1421,10 @@ size_t SSL_get_finished(const SSL *s, void *buf, size_t count)
 {
     size_t ret = 0;
 
-    if (s->s3 != NULL) {
-        ret = s->s3->tmp.finish_md_len;
-        if (count > ret)
-            count = ret;
-        memcpy(buf, s->s3->tmp.finish_md, count);
-    }
+    ret = s->s3.tmp.finish_md_len;
+    if (count > ret)
+        count = ret;
+    memcpy(buf, s->s3.tmp.finish_md, count);
     return ret;
 }
 
@@ -1435,12 +1433,10 @@ size_t SSL_get_peer_finished(const SSL *s, void *buf, size_t count)
 {
     size_t ret = 0;
 
-    if (s->s3 != NULL) {
-        ret = s->s3->tmp.peer_finish_md_len;
-        if (count > ret)
-            count = ret;
-        memcpy(buf, s->s3->tmp.peer_finish_md, count);
-    }
+    ret = s->s3.tmp.peer_finish_md_len;
+    if (count > ret)
+        count = ret;
+    memcpy(buf, s->s3.tmp.peer_finish_md, count);
     return ret;
 }
 
@@ -2277,10 +2273,7 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
             RECORD_LAYER_set_read_ahead(&s->rlayer, 1);
         return 1;
     case SSL_CTRL_GET_RI_SUPPORT:
-        if (s->s3)
-            return s->s3->send_connection_binding;
-        else
-            return 0;
+        return s->s3.send_connection_binding;
     case SSL_CTRL_CERT_FLAGS:
         return (s->cert->cert_flags |= larg);
     case SSL_CTRL_CLEAR_CERT_FLAGS:
@@ -2288,10 +2281,10 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
 
     case SSL_CTRL_GET_RAW_CIPHERLIST:
         if (parg) {
-            if (s->s3->tmp.ciphers_raw == NULL)
+            if (s->s3.tmp.ciphers_raw == NULL)
                 return 0;
-            *(unsigned char **)parg = s->s3->tmp.ciphers_raw;
-            return (int)s->s3->tmp.ciphers_rawlen;
+            *(unsigned char **)parg = s->s3.tmp.ciphers_raw;
+            return (int)s->s3.tmp.ciphers_rawlen;
         } else {
             return TLS_CIPHER_LEN;
         }
@@ -2891,13 +2884,11 @@ void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
 void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
                             unsigned int *len)
 {
-    *data = NULL;
-    if (ssl->s3)
-        *data = ssl->s3->alpn_selected;
+    *data = ssl->s3.alpn_selected;
     if (*data == NULL)
         *len = 0;
     else
-        *len = (unsigned int)ssl->s3->alpn_selected_len;
+        *len = (unsigned int)ssl->s3.alpn_selected_len;
 }
 
 int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
@@ -3306,7 +3297,7 @@ void SSL_set_cert_cb(SSL *s, int (*cb) (SSL *ssl, void *arg), void *arg)
 void ssl_set_masks(SSL *s)
 {
     CERT *c = s->cert;
-    uint32_t *pvalid = s->s3->tmp.valid_flags;
+    uint32_t *pvalid = s->s3.tmp.valid_flags;
     int rsa_enc, rsa_sign, dh_tmp, dsa_sign;
     unsigned long mask_k, mask_a;
 #ifndef OPENSSL_NO_EC
@@ -3412,15 +3403,15 @@ void ssl_set_masks(SSL *s)
         mask_k |= SSL_kECDHEPSK;
 #endif
 
-    s->s3->tmp.mask_k = mask_k;
-    s->s3->tmp.mask_a = mask_a;
+    s->s3.tmp.mask_k = mask_k;
+    s->s3.tmp.mask_a = mask_a;
 }
 
 #ifndef OPENSSL_NO_EC
 
 int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL *s)
 {
-    if (s->s3->tmp.new_cipher->algorithm_auth & SSL_aECDSA) {
+    if (s->s3.tmp.new_cipher->algorithm_auth & SSL_aECDSA) {
         /* key usage, if present, must allow signing */
         if (!(X509_get_key_usage(x) & X509v3_KU_DIGITAL_SIGNATURE)) {
             SSLerr(SSL_F_SSL_CHECK_SRVR_ECC_CERT_AND_ALG,
@@ -3436,7 +3427,7 @@ int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL *s)
 int ssl_get_server_cert_serverinfo(SSL *s, const unsigned char **serverinfo,
                                    size_t *serverinfo_length)
 {
-    CERT_PKEY *cpk = s->s3->tmp.cert;
+    CERT_PKEY *cpk = s->s3.tmp.cert;
     *serverinfo_length = 0;
 
     if (cpk == NULL || cpk->serverinfo == NULL)
@@ -3628,7 +3619,7 @@ int SSL_get_error(const SSL *s, int i)
         return SSL_ERROR_WANT_CLIENT_HELLO_CB;
 
     if ((s->shutdown & SSL_RECEIVED_SHUTDOWN) &&
-        (s->s3->warn_alert == SSL_AD_CLOSE_NOTIFY))
+        (s->s3.warn_alert == SSL_AD_CLOSE_NOTIFY))
         return SSL_ERROR_ZERO_RETURN;
 
     return SSL_ERROR_SYSCALL;
@@ -3958,7 +3949,7 @@ const SSL_CIPHER *SSL_get_current_cipher(const SSL *s)
 
 const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s)
 {
-    return s->s3->tmp.new_cipher;
+    return s->s3.tmp.new_cipher;
 }
 
 const COMP_METHOD *SSL_get_current_compression(const SSL *s)
@@ -4176,20 +4167,20 @@ long SSL_get_verify_result(const SSL *ssl)
 size_t SSL_get_client_random(const SSL *ssl, unsigned char *out, size_t outlen)
 {
     if (outlen == 0)
-        return sizeof(ssl->s3->client_random);
-    if (outlen > sizeof(ssl->s3->client_random))
-        outlen = sizeof(ssl->s3->client_random);
-    memcpy(out, ssl->s3->client_random, outlen);
+        return sizeof(ssl->s3.client_random);
+    if (outlen > sizeof(ssl->s3.client_random))
+        outlen = sizeof(ssl->s3.client_random);
+    memcpy(out, ssl->s3.client_random, outlen);
     return outlen;
 }
 
 size_t SSL_get_server_random(const SSL *ssl, unsigned char *out, size_t outlen)
 {
     if (outlen == 0)
-        return sizeof(ssl->s3->server_random);
-    if (outlen > sizeof(ssl->s3->server_random))
-        outlen = sizeof(ssl->s3->server_random);
-    memcpy(out, ssl->s3->server_random, outlen);
+        return sizeof(ssl->s3.server_random);
+    if (outlen > sizeof(ssl->s3.server_random))
+        outlen = sizeof(ssl->s3.server_random);
+    memcpy(out, ssl->s3.server_random, outlen);
     return outlen;
 }
 
@@ -4519,7 +4510,7 @@ int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
                        size_t *hashlen)
 {
     EVP_MD_CTX *ctx = NULL;
-    EVP_MD_CTX *hdgst = s->s3->handshake_dgst;
+    EVP_MD_CTX *hdgst = s->s3.handshake_dgst;
     int hashleni = EVP_MD_CTX_size(hdgst);
     int ret = 0;
 
@@ -5290,7 +5281,7 @@ int ssl_log_secret(SSL *ssl,
 {
     return nss_keylog_int(label,
                           ssl,
-                          ssl->s3->client_random,
+                          ssl->s3.client_random,
                           SSL3_RANDOM_SIZE,
                           secret,
                           secret_len);
@@ -5316,9 +5307,9 @@ int ssl_cache_cipherlist(SSL *s, PACKET *cipher_suites, int sslv2format)
         return 0;
     }
 
-    OPENSSL_free(s->s3->tmp.ciphers_raw);
-    s->s3->tmp.ciphers_raw = NULL;
-    s->s3->tmp.ciphers_rawlen = 0;
+    OPENSSL_free(s->s3.tmp.ciphers_raw);
+    s->s3.tmp.ciphers_raw = NULL;
+    s->s3.tmp.ciphers_rawlen = 0;
 
     if (sslv2format) {
         size_t numciphers = PACKET_remaining(cipher_suites) / n;
@@ -5334,13 +5325,13 @@ int ssl_cache_cipherlist(SSL *s, PACKET *cipher_suites, int sslv2format)
          * problem.
          */
         raw = OPENSSL_malloc(numciphers * TLS_CIPHER_LEN);
-        s->s3->tmp.ciphers_raw = raw;
+        s->s3.tmp.ciphers_raw = raw;
         if (raw == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_CACHE_CIPHERLIST,
                      ERR_R_MALLOC_FAILURE);
             return 0;
         }
-        for (s->s3->tmp.ciphers_rawlen = 0;
+        for (s->s3.tmp.ciphers_rawlen = 0;
              PACKET_remaining(&sslv2ciphers) > 0;
              raw += TLS_CIPHER_LEN) {
             if (!PACKET_get_1(&sslv2ciphers, &leadbyte)
@@ -5351,16 +5342,16 @@ int ssl_cache_cipherlist(SSL *s, PACKET *cipher_suites, int sslv2format)
                         && !PACKET_forward(&sslv2ciphers, TLS_CIPHER_LEN))) {
                 SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_SSL_CACHE_CIPHERLIST,
                          SSL_R_BAD_PACKET);
-                OPENSSL_free(s->s3->tmp.ciphers_raw);
-                s->s3->tmp.ciphers_raw = NULL;
-                s->s3->tmp.ciphers_rawlen = 0;
+                OPENSSL_free(s->s3.tmp.ciphers_raw);
+                s->s3.tmp.ciphers_raw = NULL;
+                s->s3.tmp.ciphers_rawlen = 0;
                 return 0;
             }
             if (leadbyte == 0)
-                s->s3->tmp.ciphers_rawlen += TLS_CIPHER_LEN;
+                s->s3.tmp.ciphers_rawlen += TLS_CIPHER_LEN;
         }
-    } else if (!PACKET_memdup(cipher_suites, &s->s3->tmp.ciphers_raw,
-                           &s->s3->tmp.ciphers_rawlen)) {
+    } else if (!PACKET_memdup(cipher_suites, &s->s3.tmp.ciphers_raw,
+                           &s->s3.tmp.ciphers_rawlen)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_CACHE_CIPHERLIST,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -5553,9 +5544,9 @@ int SSL_stateless(SSL *s)
 
     ERR_clear_error();
 
-    s->s3->flags |= TLS1_FLAGS_STATELESS;
+    s->s3.flags |= TLS1_FLAGS_STATELESS;
     ret = SSL_accept(s);
-    s->s3->flags &= ~TLS1_FLAGS_STATELESS;
+    s->s3.flags &= ~TLS1_FLAGS_STATELESS;
 
     if (ret > 0 && s->ext.cookieok)
         return 1;

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -334,8 +334,8 @@
      || (s)->early_data_state == SSL_EARLY_DATA_WRITE_RETRY \
      || (s)->hello_retry_request == SSL_HRR_PENDING)
 
-# define SSL_IS_FIRST_HANDSHAKE(S) ((s)->s3->tmp.finish_md_len == 0 \
-                                    || (s)->s3->tmp.peer_finish_md_len == 0)
+# define SSL_IS_FIRST_HANDSHAKE(S) ((s)->s3.tmp.finish_md_len == 0 \
+                                    || (s)->s3.tmp.peer_finish_md_len == 0)
 
 /* See if we need explicit IV */
 # define SSL_USE_EXPLICIT_IV(s)  \
@@ -374,8 +374,8 @@
 # define GET_MAX_FRAGMENT_LENGTH(session) \
     (512U << (session->ext.max_fragment_len_mode - 1))
 
-# define SSL_READ_ETM(s) (s->s3->flags & TLS1_FLAGS_ENCRYPT_THEN_MAC_READ)
-# define SSL_WRITE_ETM(s) (s->s3->flags & TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE)
+# define SSL_READ_ETM(s) (s->s3.flags & TLS1_FLAGS_ENCRYPT_THEN_MAC_READ)
+# define SSL_WRITE_ETM(s) (s->s3.flags & TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE)
 
 /* Mostly for SSLv3 */
 # define SSL_PKEY_RSA            0
@@ -1081,6 +1081,8 @@ struct ssl_ctx_st {
     void *async_cb_arg;
 };
 
+typedef struct cert_pkey_st CERT_PKEY;
+
 struct ssl_st {
     /*
      * protocol version (one of SSL2_VERSION, SSL3_VERSION, TLS1_VERSION,
@@ -1134,7 +1136,179 @@ struct ssl_st {
                                  * ssl3_get_message() */
     size_t init_num;               /* amount read/written */
     size_t init_off;               /* amount read/written */
-    struct ssl3_state_st *s3;   /* SSLv3 variables */
+
+    struct {
+        long flags;
+        size_t read_mac_secret_size;
+        unsigned char read_mac_secret[EVP_MAX_MD_SIZE];
+        size_t write_mac_secret_size;
+        unsigned char write_mac_secret[EVP_MAX_MD_SIZE];
+        unsigned char server_random[SSL3_RANDOM_SIZE];
+        unsigned char client_random[SSL3_RANDOM_SIZE];
+        /* flags for countermeasure against known-IV weakness */
+        int need_empty_fragments;
+        int empty_fragment_done;
+        /* used during startup, digest all incoming/outgoing packets */
+        BIO *handshake_buffer;
+        /*
+         * When handshake digest is determined, buffer is hashed and
+         * freed and MD_CTX for the required digest is stored here.
+         */
+        EVP_MD_CTX *handshake_dgst;
+        /*
+         * Set whenever an expected ChangeCipherSpec message is processed.
+         * Unset when the peer's Finished message is received.
+         * Unexpected ChangeCipherSpec messages trigger a fatal alert.
+         */
+        int change_cipher_spec;
+        int warn_alert;
+        int fatal_alert;
+        /*
+         * we allow one fatal and one warning alert to be outstanding, send close
+         * alert via the warning alert
+         */
+        int alert_dispatch;
+        unsigned char send_alert[2];
+        /*
+         * This flag is set when we should renegotiate ASAP, basically when there
+         * is no more data in the read or write buffers
+         */
+        int renegotiate;
+        int total_renegotiations;
+        int num_renegotiations;
+        int in_read_app_data;
+        struct {
+            /* actually only need to be 16+20 for SSLv3 and 12 for TLS */
+            unsigned char finish_md[EVP_MAX_MD_SIZE * 2];
+            size_t finish_md_len;
+            unsigned char peer_finish_md[EVP_MAX_MD_SIZE * 2];
+            size_t peer_finish_md_len;
+            size_t message_size;
+            int message_type;
+            /* used to hold the new cipher we are going to use */
+            const SSL_CIPHER *new_cipher;
+# if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
+            EVP_PKEY *pkey;         /* holds short lived DH/ECDH key */
+# endif
+            /* used for certificate requests */
+            int cert_req;
+            /* Certificate types in certificate request message. */
+            uint8_t *ctype;
+            size_t ctype_len;
+            /* Certificate authorities list peer sent */
+            STACK_OF(X509_NAME) *peer_ca_names;
+            size_t key_block_length;
+            unsigned char *key_block;
+            const EVP_CIPHER *new_sym_enc;
+            const EVP_MD *new_hash;
+            int new_mac_pkey_type;
+            size_t new_mac_secret_size;
+# ifndef OPENSSL_NO_COMP
+            const SSL_COMP *new_compression;
+# else
+            char *new_compression;
+# endif
+            int cert_request;
+            /* Raw values of the cipher list from a client */
+            unsigned char *ciphers_raw;
+            size_t ciphers_rawlen;
+            /* Temporary storage for premaster secret */
+            unsigned char *pms;
+            size_t pmslen;
+# ifndef OPENSSL_NO_PSK
+            /* Temporary storage for PSK key */
+            unsigned char *psk;
+            size_t psklen;
+# endif
+            /* Signature algorithm we actually use */
+            const struct sigalg_lookup_st *sigalg;
+            /* Pointer to certificate we use */
+            CERT_PKEY *cert;
+            /*
+             * signature algorithms peer reports: e.g. supported signature
+             * algorithms extension for server or as part of a certificate
+             * request for client.
+             * Keep track of the algorithms for TLS and X.509 usage separately.
+             */
+            uint16_t *peer_sigalgs;
+            uint16_t *peer_cert_sigalgs;
+            /* Size of above arrays */
+            size_t peer_sigalgslen;
+            size_t peer_cert_sigalgslen;
+            /* Sigalg peer actually uses */
+            const struct sigalg_lookup_st *peer_sigalg;
+            /*
+             * Set if corresponding CERT_PKEY can be used with current
+             * SSL session: e.g. appropriate curve, signature algorithms etc.
+             * If zero it can't be used at all.
+             */
+            uint32_t valid_flags[SSL_PKEY_NUM];
+            /*
+             * For servers the following masks are for the key and auth algorithms
+             * that are supported by the certs below. For clients they are masks of
+             * *disabled* algorithms based on the current session.
+             */
+            uint32_t mask_k;
+            uint32_t mask_a;
+            /*
+             * The following are used by the client to see if a cipher is allowed or
+             * not.  It contains the minimum and maximum version the client's using
+             * based on what it knows so far.
+             */
+            int min_ver;
+            int max_ver;
+        } tmp;
+
+        /* Connection binding to prevent renegotiation attacks */
+        unsigned char previous_client_finished[EVP_MAX_MD_SIZE];
+        size_t previous_client_finished_len;
+        unsigned char previous_server_finished[EVP_MAX_MD_SIZE];
+        size_t previous_server_finished_len;
+        int send_connection_binding; /* TODOEKR */
+
+# ifndef OPENSSL_NO_NEXTPROTONEG
+        /*
+         * Set if we saw the Next Protocol Negotiation extension from our peer.
+         */
+        int npn_seen;
+# endif
+
+        /*
+         * ALPN information (we are in the process of transitioning from NPN to
+         * ALPN.)
+         */
+
+        /*
+         * In a server these point to the selected ALPN protocol after the
+         * ClientHello has been processed. In a client these contain the protocol
+         * that the server selected once the ServerHello has been processed.
+         */
+        unsigned char *alpn_selected;
+        size_t alpn_selected_len;
+        /* used by the server to know what options were proposed */
+        unsigned char *alpn_proposed;
+        size_t alpn_proposed_len;
+        /* used by the client to know if it actually sent alpn */
+        int alpn_sent;
+
+# ifndef OPENSSL_NO_EC
+        /*
+         * This is set to true if we believe that this is a version of Safari
+         * running on OS X 10.6 or newer. We wish to know this because Safari on
+         * 10.8 .. 10.8.3 has broken ECDHE-ECDSA support.
+         */
+        char is_probably_safari;
+# endif                         /* !OPENSSL_NO_EC */
+
+        /* For clients: peer temporary key */
+# if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
+        /* The group_id for the DH/ECDH key */
+        uint16_t group_id;
+        EVP_PKEY *peer_tmp;
+# endif
+
+    } s3;
+
     struct dtls1_state_st *d1;  /* DTLSv1 variables */
     /* callback that allows applications to peek at protocol messages */
     void (*msg_callback) (int write_p, int version, int content_type,
@@ -1520,8 +1694,6 @@ typedef struct tls_group_info_st {
 # define TLS_CURVE_CHAR2         0x1
 # define TLS_CURVE_CUSTOM        0x2
 
-typedef struct cert_pkey_st CERT_PKEY;
-
 /*
  * Structure containing table entry of certificate info corresponding to
  * CERT_PKEY entries
@@ -1530,178 +1702,6 @@ typedef struct {
     int nid; /* NID of pubic key algorithm */
     uint32_t amask; /* authmask corresponding to key type */
 } SSL_CERT_LOOKUP;
-
-typedef struct ssl3_state_st {
-    long flags;
-    size_t read_mac_secret_size;
-    unsigned char read_mac_secret[EVP_MAX_MD_SIZE];
-    size_t write_mac_secret_size;
-    unsigned char write_mac_secret[EVP_MAX_MD_SIZE];
-    unsigned char server_random[SSL3_RANDOM_SIZE];
-    unsigned char client_random[SSL3_RANDOM_SIZE];
-    /* flags for countermeasure against known-IV weakness */
-    int need_empty_fragments;
-    int empty_fragment_done;
-    /* used during startup, digest all incoming/outgoing packets */
-    BIO *handshake_buffer;
-    /*
-     * When handshake digest is determined, buffer is hashed and
-     * freed and MD_CTX for the required digest is stored here.
-     */
-    EVP_MD_CTX *handshake_dgst;
-    /*
-     * Set whenever an expected ChangeCipherSpec message is processed.
-     * Unset when the peer's Finished message is received.
-     * Unexpected ChangeCipherSpec messages trigger a fatal alert.
-     */
-    int change_cipher_spec;
-    int warn_alert;
-    int fatal_alert;
-    /*
-     * we allow one fatal and one warning alert to be outstanding, send close
-     * alert via the warning alert
-     */
-    int alert_dispatch;
-    unsigned char send_alert[2];
-    /*
-     * This flag is set when we should renegotiate ASAP, basically when there
-     * is no more data in the read or write buffers
-     */
-    int renegotiate;
-    int total_renegotiations;
-    int num_renegotiations;
-    int in_read_app_data;
-    struct {
-        /* actually only need to be 16+20 for SSLv3 and 12 for TLS */
-        unsigned char finish_md[EVP_MAX_MD_SIZE * 2];
-        size_t finish_md_len;
-        unsigned char peer_finish_md[EVP_MAX_MD_SIZE * 2];
-        size_t peer_finish_md_len;
-        size_t message_size;
-        int message_type;
-        /* used to hold the new cipher we are going to use */
-        const SSL_CIPHER *new_cipher;
-# if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-        EVP_PKEY *pkey;         /* holds short lived DH/ECDH key */
-# endif
-        /* used for certificate requests */
-        int cert_req;
-        /* Certificate types in certificate request message. */
-        uint8_t *ctype;
-        size_t ctype_len;
-        /* Certificate authorities list peer sent */
-        STACK_OF(X509_NAME) *peer_ca_names;
-        size_t key_block_length;
-        unsigned char *key_block;
-        const EVP_CIPHER *new_sym_enc;
-        const EVP_MD *new_hash;
-        int new_mac_pkey_type;
-        size_t new_mac_secret_size;
-# ifndef OPENSSL_NO_COMP
-        const SSL_COMP *new_compression;
-# else
-        char *new_compression;
-# endif
-        int cert_request;
-        /* Raw values of the cipher list from a client */
-        unsigned char *ciphers_raw;
-        size_t ciphers_rawlen;
-        /* Temporary storage for premaster secret */
-        unsigned char *pms;
-        size_t pmslen;
-# ifndef OPENSSL_NO_PSK
-        /* Temporary storage for PSK key */
-        unsigned char *psk;
-        size_t psklen;
-# endif
-        /* Signature algorithm we actually use */
-        const SIGALG_LOOKUP *sigalg;
-        /* Pointer to certificate we use */
-        CERT_PKEY *cert;
-        /*
-         * signature algorithms peer reports: e.g. supported signature
-         * algorithms extension for server or as part of a certificate
-         * request for client.
-         * Keep track of the algorithms for TLS and X.509 usage separately.
-         */
-        uint16_t *peer_sigalgs;
-        uint16_t *peer_cert_sigalgs;
-        /* Size of above arrays */
-        size_t peer_sigalgslen;
-        size_t peer_cert_sigalgslen;
-        /* Sigalg peer actually uses */
-        const SIGALG_LOOKUP *peer_sigalg;
-        /*
-         * Set if corresponding CERT_PKEY can be used with current
-         * SSL session: e.g. appropriate curve, signature algorithms etc.
-         * If zero it can't be used at all.
-         */
-        uint32_t valid_flags[SSL_PKEY_NUM];
-        /*
-         * For servers the following masks are for the key and auth algorithms
-         * that are supported by the certs below. For clients they are masks of
-         * *disabled* algorithms based on the current session.
-         */
-        uint32_t mask_k;
-        uint32_t mask_a;
-        /*
-         * The following are used by the client to see if a cipher is allowed or
-         * not.  It contains the minimum and maximum version the client's using
-         * based on what it knows so far.
-         */
-        int min_ver;
-        int max_ver;
-    } tmp;
-
-    /* Connection binding to prevent renegotiation attacks */
-    unsigned char previous_client_finished[EVP_MAX_MD_SIZE];
-    size_t previous_client_finished_len;
-    unsigned char previous_server_finished[EVP_MAX_MD_SIZE];
-    size_t previous_server_finished_len;
-    int send_connection_binding; /* TODOEKR */
-
-# ifndef OPENSSL_NO_NEXTPROTONEG
-    /*
-     * Set if we saw the Next Protocol Negotiation extension from our peer.
-     */
-    int npn_seen;
-# endif
-
-    /*
-     * ALPN information (we are in the process of transitioning from NPN to
-     * ALPN.)
-     */
-
-    /*
-     * In a server these point to the selected ALPN protocol after the
-     * ClientHello has been processed. In a client these contain the protocol
-     * that the server selected once the ServerHello has been processed.
-     */
-    unsigned char *alpn_selected;
-    size_t alpn_selected_len;
-    /* used by the server to know what options were proposed */
-    unsigned char *alpn_proposed;
-    size_t alpn_proposed_len;
-    /* used by the client to know if it actually sent alpn */
-    int alpn_sent;
-
-# ifndef OPENSSL_NO_EC
-    /*
-     * This is set to true if we believe that this is a version of Safari
-     * running on OS X 10.6 or newer. We wish to know this because Safari on
-     * 10.8 .. 10.8.3 has broken ECDHE-ECDSA support.
-     */
-    char is_probably_safari;
-# endif                         /* !OPENSSL_NO_EC */
-
-    /* For clients: peer temporary key */
-# if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-    /* The group_id for the DH/ECDH key */
-    uint16_t group_id;
-    EVP_PKEY *peer_tmp;
-# endif
-
-} SSL3_STATE;
 
 /* DTLS structures */
 
@@ -2070,8 +2070,8 @@ typedef enum downgrade_en {
 #define TLSEXT_KEX_MODE_FLAG_KE                                 1
 #define TLSEXT_KEX_MODE_FLAG_KE_DHE                             2
 
-#define SSL_USE_PSS(s) (s->s3->tmp.peer_sigalg != NULL && \
-                        s->s3->tmp.peer_sigalg->sig == EVP_PKEY_RSA_PSS)
+#define SSL_USE_PSS(s) (s->s3.tmp.peer_sigalg != NULL && \
+                        s->s3.tmp.peer_sigalg->sig == EVP_PKEY_RSA_PSS)
 
 /* A dummy signature value not valid for TLSv1.2 signature algs */
 #define TLSEXT_signature_rsa_pss                                0x0101

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -438,7 +438,7 @@ int ssl_get_new_session(SSL *s, int session)
     ss->verify_result = X509_V_OK;
 
     /* If client supports extended master secret set it in session */
-    if (s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS)
+    if (s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS)
         ss->flags |= SSL_SESS_FLAG_EXTMS;
 
     return 1;
@@ -620,13 +620,13 @@ int ssl_get_prev_session(SSL *s, CLIENTHELLO_MSG *hello)
     /* Check extended master secret extension consistency */
     if (ret->flags & SSL_SESS_FLAG_EXTMS) {
         /* If old session includes extms, but new does not: abort handshake */
-        if (!(s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS)) {
+        if (!(s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS)) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_SSL_GET_PREV_SESSION,
                      SSL_R_INCONSISTENT_EXTMS);
             fatal = 1;
             goto err;
         }
-    } else if (s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS) {
+    } else if (s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS) {
         /* If new session includes extms, but old does not: do not resume */
         goto err;
     }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1030,8 +1030,8 @@ static int final_ec_pt_formats(SSL *s, unsigned int context, int sent)
     if (s->server)
         return 1;
 
-    alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
-    alg_a = s->s3->tmp.new_cipher->algorithm_auth;
+    alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
+    alg_a = s->s3.tmp.new_cipher->algorithm_auth;
 
     /*
      * If we are client and using an elliptic curve cryptography cipher
@@ -1092,7 +1092,7 @@ static int init_status_request(SSL *s, unsigned int context)
 #ifndef OPENSSL_NO_NEXTPROTONEG
 static int init_npn(SSL *s, unsigned int context)
 {
-    s->s3->npn_seen = 0;
+    s->s3.npn_seen = 0;
 
     return 1;
 }
@@ -1100,13 +1100,13 @@ static int init_npn(SSL *s, unsigned int context)
 
 static int init_alpn(SSL *s, unsigned int context)
 {
-    OPENSSL_free(s->s3->alpn_selected);
-    s->s3->alpn_selected = NULL;
-    s->s3->alpn_selected_len = 0;
+    OPENSSL_free(s->s3.alpn_selected);
+    s->s3.alpn_selected = NULL;
+    s->s3.alpn_selected_len = 0;
     if (s->server) {
-        OPENSSL_free(s->s3->alpn_proposed);
-        s->s3->alpn_proposed = NULL;
-        s->s3->alpn_proposed_len = 0;
+        OPENSSL_free(s->s3.alpn_proposed);
+        s->s3.alpn_proposed = NULL;
+        s->s3.alpn_proposed_len = 0;
     }
     return 1;
 }
@@ -1134,8 +1134,8 @@ static int final_alpn(SSL *s, unsigned int context, int sent)
 static int init_sig_algs(SSL *s, unsigned int context)
 {
     /* Clear any signature algorithms extension received */
-    OPENSSL_free(s->s3->tmp.peer_sigalgs);
-    s->s3->tmp.peer_sigalgs = NULL;
+    OPENSSL_free(s->s3.tmp.peer_sigalgs);
+    s->s3.tmp.peer_sigalgs = NULL;
 
     return 1;
 }
@@ -1143,8 +1143,8 @@ static int init_sig_algs(SSL *s, unsigned int context)
 static int init_sig_algs_cert(SSL *s, unsigned int context)
 {
     /* Clear any signature algorithms extension received */
-    OPENSSL_free(s->s3->tmp.peer_cert_sigalgs);
-    s->s3->tmp.peer_cert_sigalgs = NULL;
+    OPENSSL_free(s->s3.tmp.peer_cert_sigalgs);
+    s->s3.tmp.peer_cert_sigalgs = NULL;
 
     return 1;
 }
@@ -1168,7 +1168,7 @@ static int init_etm(SSL *s, unsigned int context)
 
 static int init_ems(SSL *s, unsigned int context)
 {
-    s->s3->flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
+    s->s3.flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
 
     return 1;
 }
@@ -1180,7 +1180,7 @@ static int final_ems(SSL *s, unsigned int context, int sent)
          * Check extended master secret extension is consistent with
          * original session.
          */
-        if (!(s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS) !=
+        if (!(s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS) !=
             !(s->session->flags & SSL_SESS_FLAG_EXTMS)) {
             SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_FINAL_EMS,
                      SSL_R_INCONSISTENT_EXTMS);
@@ -1193,8 +1193,8 @@ static int final_ems(SSL *s, unsigned int context, int sent)
 
 static int init_certificate_authorities(SSL *s, unsigned int context)
 {
-    sk_X509_NAME_pop_free(s->s3->tmp.peer_ca_names, X509_NAME_free);
-    s->s3->tmp.peer_ca_names = NULL;
+    sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
+    s->s3.tmp.peer_ca_names = NULL;
     return 1;
 }
 
@@ -1331,9 +1331,9 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
      *             send a HelloRetryRequest
      */
     if (s->server) {
-        if (s->s3->peer_tmp != NULL) {
+        if (s->s3.peer_tmp != NULL) {
             /* We have a suitable key_share */
-            if ((s->s3->flags & TLS1_FLAGS_STATELESS) != 0
+            if ((s->s3.flags & TLS1_FLAGS_STATELESS) != 0
                     && !s->ext.cookieok) {
                 if (!ossl_assert(s->hello_retry_request == SSL_HRR_NONE)) {
                     /*
@@ -1377,7 +1377,7 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
 
                 if (i < num_groups) {
                     /* A shared group exists so send a HelloRetryRequest */
-                    s->s3->group_id = group_id;
+                    s->s3.group_id = group_id;
                     s->hello_retry_request = SSL_HRR_PENDING;
                     return 1;
                 }
@@ -1391,7 +1391,7 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
                 return 0;
             }
 
-            if ((s->s3->flags & TLS1_FLAGS_STATELESS) != 0
+            if ((s->s3.flags & TLS1_FLAGS_STATELESS) != 0
                     && !s->ext.cookieok) {
                 if (!ossl_assert(s->hello_retry_request == SSL_HRR_NONE)) {
                     /*
@@ -1539,7 +1539,7 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
         void *hdata;
 
         hdatalen = hdatalen_l =
-            BIO_get_mem_data(s->s3->handshake_buffer, &hdata);
+            BIO_get_mem_data(s->s3.handshake_buffer, &hdata);
         if (hdatalen_l <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PSK_DO_BINDER,
                      SSL_R_BAD_HANDSHAKE_LENGTH);

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -22,8 +22,8 @@ EXT_RETURN tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt,
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_renegotiate)
             || !WPACKET_start_sub_packet_u16(pkt)
-            || !WPACKET_sub_memcpy_u8(pkt, s->s3->previous_client_finished,
-                               s->s3->previous_client_finished_len)
+            || !WPACKET_sub_memcpy_u8(pkt, s->s3.previous_client_finished,
+                               s->s3.previous_client_finished_len)
             || !WPACKET_close(pkt)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CTOS_RENEGOTIATE,
                  ERR_R_INTERNAL_ERROR);
@@ -387,7 +387,7 @@ EXT_RETURN tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context,
 EXT_RETURN tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx)
 {
-    s->s3->alpn_sent = 0;
+    s->s3.alpn_sent = 0;
 
     if (s->ext.alpn == NULL || !SSL_IS_FIRST_HANDSHAKE(s))
         return EXT_RETURN_NOT_SENT;
@@ -402,7 +402,7 @@ EXT_RETURN tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context,
                  ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;
     }
-    s->s3->alpn_sent = 1;
+    s->s3.alpn_sent = 1;
 
     return EXT_RETURN_SENT;
 }
@@ -591,7 +591,7 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
     EVP_PKEY *key_share_key = NULL;
     size_t encodedlen;
 
-    if (s->s3->tmp.pkey != NULL) {
+    if (s->s3.tmp.pkey != NULL) {
         if (!ossl_assert(s->hello_retry_request == SSL_HRR_PENDING)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE,
                      ERR_R_INTERNAL_ERROR);
@@ -600,7 +600,7 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
         /*
          * Could happen if we got an HRR that wasn't requesting a new key_share
          */
-        key_share_key = s->s3->tmp.pkey;
+        key_share_key = s->s3.tmp.pkey;
     } else {
         key_share_key = ssl_generate_pkey_group(s, curve_id);
         if (key_share_key == NULL) {
@@ -630,13 +630,13 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
      * going to need to be able to save more than one EVP_PKEY. For now
      * we reuse the existing tmp.pkey
      */
-    s->s3->tmp.pkey = key_share_key;
-    s->s3->group_id = curve_id;
+    s->s3.tmp.pkey = key_share_key;
+    s->s3.group_id = curve_id;
     OPENSSL_free(encoded_point);
 
     return 1;
  err:
-    if (s->s3->tmp.pkey == NULL)
+    if (s->s3.tmp.pkey == NULL)
         EVP_PKEY_free(key_share_key);
     OPENSSL_free(encoded_point);
     return 0;
@@ -669,8 +669,8 @@ EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
      * TODO(TLS1.3): Make the number of key_shares sent configurable. For
      * now, just send one
      */
-    if (s->s3->group_id != 0) {
-        curve_id = s->s3->group_id;
+    if (s->s3.group_id != 0) {
+        curve_id = s->s3.group_id;
     } else {
         for (i = 0; i < num_groups; i++) {
 
@@ -1224,16 +1224,16 @@ EXT_RETURN tls_construct_ctos_post_handshake_auth(SSL *s, WPACKET *pkt,
 int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
                                X509 *x, size_t chainidx)
 {
-    size_t expected_len = s->s3->previous_client_finished_len
-        + s->s3->previous_server_finished_len;
+    size_t expected_len = s->s3.previous_client_finished_len
+        + s->s3.previous_server_finished_len;
     size_t ilen;
     const unsigned char *data;
 
     /* Check for logic errors */
     if (!ossl_assert(expected_len == 0
-                     || s->s3->previous_client_finished_len != 0)
+                     || s->s3.previous_client_finished_len != 0)
         || !ossl_assert(expected_len == 0
-                        || s->s3->previous_server_finished_len != 0)) {
+                        || s->s3.previous_server_finished_len != 0)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_RENEGOTIATE,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -1260,22 +1260,22 @@ int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
         return 0;
     }
 
-    if (!PACKET_get_bytes(pkt, &data, s->s3->previous_client_finished_len)
-        || memcmp(data, s->s3->previous_client_finished,
-                  s->s3->previous_client_finished_len) != 0) {
+    if (!PACKET_get_bytes(pkt, &data, s->s3.previous_client_finished_len)
+        || memcmp(data, s->s3.previous_client_finished,
+                  s->s3.previous_client_finished_len) != 0) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_TLS_PARSE_STOC_RENEGOTIATE,
                  SSL_R_RENEGOTIATION_MISMATCH);
         return 0;
     }
 
-    if (!PACKET_get_bytes(pkt, &data, s->s3->previous_server_finished_len)
-        || memcmp(data, s->s3->previous_server_finished,
-                  s->s3->previous_server_finished_len) != 0) {
+    if (!PACKET_get_bytes(pkt, &data, s->s3.previous_server_finished_len)
+        || memcmp(data, s->s3.previous_server_finished,
+                  s->s3.previous_server_finished_len) != 0) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_TLS_PARSE_STOC_RENEGOTIATE,
                  SSL_R_RENEGOTIATION_MISMATCH);
         return 0;
     }
-    s->s3->send_connection_binding = 1;
+    s->s3.send_connection_binding = 1;
 
     return 1;
 }
@@ -1602,7 +1602,7 @@ int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     memcpy(s->ext.npn, selected, selected_len);
     s->ext.npn_len = selected_len;
-    s->s3->npn_seen = 1;
+    s->s3.npn_seen = 1;
 
     return 1;
 }
@@ -1614,7 +1614,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     size_t len;
 
     /* We must have requested it. */
-    if (!s->s3->alpn_sent) {
+    if (!s->s3.alpn_sent) {
         SSLfatal(s, SSL_AD_UNSUPPORTED_EXTENSION, SSL_F_TLS_PARSE_STOC_ALPN,
                  SSL_R_BAD_EXTENSION);
         return 0;
@@ -1632,23 +1632,23 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                  SSL_R_BAD_EXTENSION);
         return 0;
     }
-    OPENSSL_free(s->s3->alpn_selected);
-    s->s3->alpn_selected = OPENSSL_malloc(len);
-    if (s->s3->alpn_selected == NULL) {
+    OPENSSL_free(s->s3.alpn_selected);
+    s->s3.alpn_selected = OPENSSL_malloc(len);
+    if (s->s3.alpn_selected == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_ALPN,
                  ERR_R_INTERNAL_ERROR);
         return 0;
     }
-    if (!PACKET_copy_bytes(pkt, s->s3->alpn_selected, len)) {
+    if (!PACKET_copy_bytes(pkt, s->s3.alpn_selected, len)) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PARSE_STOC_ALPN,
                  SSL_R_BAD_EXTENSION);
         return 0;
     }
-    s->s3->alpn_selected_len = len;
+    s->s3.alpn_selected_len = len;
 
     if (s->session->ext.alpn_selected == NULL
             || s->session->ext.alpn_selected_len != len
-            || memcmp(s->session->ext.alpn_selected, s->s3->alpn_selected, len)
+            || memcmp(s->session->ext.alpn_selected, s->s3.alpn_selected, len)
                != 0) {
         /* ALPN not consistent with the old session so cannot use early_data */
         s->ext.early_data_ok = 0;
@@ -1664,13 +1664,13 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             return 0;
         }
         s->session->ext.alpn_selected =
-            OPENSSL_memdup(s->s3->alpn_selected, s->s3->alpn_selected_len);
+            OPENSSL_memdup(s->s3.alpn_selected, s->s3.alpn_selected_len);
         if (s->session->ext.alpn_selected == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_ALPN,
                      ERR_R_INTERNAL_ERROR);
             return 0;
         }
-        s->session->ext.alpn_selected_len = s->s3->alpn_selected_len;
+        s->session->ext.alpn_selected_len = s->s3.alpn_selected_len;
     }
 
     return 1;
@@ -1733,8 +1733,8 @@ int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     /* Ignore if inappropriate ciphersuite */
     if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)
-            && s->s3->tmp.new_cipher->algorithm_mac != SSL_AEAD
-            && s->s3->tmp.new_cipher->algorithm_enc != SSL_RC4)
+            && s->s3.tmp.new_cipher->algorithm_mac != SSL_AEAD
+            && s->s3.tmp.new_cipher->algorithm_enc != SSL_RC4)
         s->ext.use_etm = 1;
 
     return 1;
@@ -1745,7 +1745,7 @@ int tls_parse_stoc_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 {
     if (s->options & SSL_OP_NO_EXTENDED_MASTER_SECRET)
         return 1;
-    s->s3->flags |= TLS1_FLAGS_RECEIVED_EXTMS;
+    s->s3.flags |= TLS1_FLAGS_RECEIVED_EXTMS;
     if (!s->hit)
         s->session->flags |= SSL_SESS_FLAG_EXTMS;
 
@@ -1792,10 +1792,10 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 #ifndef OPENSSL_NO_TLS1_3
     unsigned int group_id;
     PACKET encoded_pt;
-    EVP_PKEY *ckey = s->s3->tmp.pkey, *skey = NULL;
+    EVP_PKEY *ckey = s->s3.tmp.pkey, *skey = NULL;
 
     /* Sanity check */
-    if (ckey == NULL || s->s3->peer_tmp != NULL) {
+    if (ckey == NULL || s->s3.peer_tmp != NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -1821,7 +1821,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
          * It is an error if the HelloRetryRequest wants a key_share that we
          * already sent in the first ClientHello
          */
-        if (group_id == s->s3->group_id) {
+        if (group_id == s->s3.group_id) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_F_TLS_PARSE_STOC_KEY_SHARE, SSL_R_BAD_KEY_SHARE);
             return 0;
@@ -1840,13 +1840,13 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             return 0;
         }
 
-        s->s3->group_id = group_id;
-        EVP_PKEY_free(s->s3->tmp.pkey);
-        s->s3->tmp.pkey = NULL;
+        s->s3.group_id = group_id;
+        EVP_PKEY_free(s->s3.tmp.pkey);
+        s->s3.tmp.pkey = NULL;
         return 1;
     }
 
-    if (group_id != s->s3->group_id) {
+    if (group_id != s->s3.group_id) {
         /*
          * This isn't for the group that we sent in the original
          * key_share!
@@ -1882,7 +1882,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         EVP_PKEY_free(skey);
         return 0;
     }
-    s->s3->peer_tmp = skey;
+    s->s3.peer_tmp = skey;
 #endif
 
     return 1;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -53,20 +53,20 @@ int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
     }
 
     /* Check that the extension matches */
-    if (ilen != s->s3->previous_client_finished_len) {
+    if (ilen != s->s3.previous_client_finished_len) {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_TLS_PARSE_CTOS_RENEGOTIATE,
                  SSL_R_RENEGOTIATION_MISMATCH);
         return 0;
     }
 
-    if (memcmp(data, s->s3->previous_client_finished,
-               s->s3->previous_client_finished_len)) {
+    if (memcmp(data, s->s3.previous_client_finished,
+               s->s3.previous_client_finished_len)) {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_TLS_PARSE_CTOS_RENEGOTIATE,
                  SSL_R_RENEGOTIATION_MISMATCH);
         return 0;
     }
 
-    s->s3->send_connection_binding = 1;
+    s->s3.send_connection_binding = 1;
 
     return 1;
 }
@@ -446,7 +446,7 @@ int tls_parse_ctos_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
      * renegotiation.
      */
     if (SSL_IS_FIRST_HANDSHAKE(s))
-        s->s3->npn_seen = 1;
+        s->s3.npn_seen = 1;
 
     return 1;
 }
@@ -482,11 +482,11 @@ int tls_parse_ctos_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         }
     } while (PACKET_remaining(&protocol_list) != 0);
 
-    OPENSSL_free(s->s3->alpn_proposed);
-    s->s3->alpn_proposed = NULL;
-    s->s3->alpn_proposed_len = 0;
+    OPENSSL_free(s->s3.alpn_proposed);
+    s->s3.alpn_proposed = NULL;
+    s->s3.alpn_proposed_len = 0;
     if (!PACKET_memdup(&save_protocol_list,
-                       &s->s3->alpn_proposed, &s->s3->alpn_proposed_len)) {
+                       &s->s3.alpn_proposed, &s->s3.alpn_proposed_len)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_ALPN,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -621,7 +621,7 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 1;
 
     /* Sanity check */
-    if (s->s3->peer_tmp != NULL) {
+    if (s->s3.peer_tmp != NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_KEY_SHARE,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -648,7 +648,7 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 0;
     }
 
-    if (s->s3->group_id != 0 && PACKET_remaining(&key_share_list) == 0) {
+    if (s->s3.group_id != 0 && PACKET_remaining(&key_share_list) == 0) {
         /*
          * If we set a group_id already, then we must have sent an HRR
          * requesting a new key_share. If we haven't got one then that is an
@@ -679,8 +679,8 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
          * If we sent an HRR then the key_share sent back MUST be for the group
          * we requested, and must be the only key_share sent.
          */
-        if (s->s3->group_id != 0
-                && (group_id != s->s3->group_id
+        if (s->s3.group_id != 0
+                && (group_id != s->s3.group_id
                     || PACKET_remaining(&key_share_list) != 0)) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_F_TLS_PARSE_CTOS_KEY_SHARE, SSL_R_BAD_KEY_SHARE);
@@ -700,15 +700,15 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             continue;
         }
 
-        if ((s->s3->peer_tmp = ssl_generate_param_group(group_id)) == NULL) {
+        if ((s->s3.peer_tmp = ssl_generate_param_group(group_id)) == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_KEY_SHARE,
                    SSL_R_UNABLE_TO_FIND_ECDH_PARAMETERS);
             return 0;
         }
 
-        s->s3->group_id = group_id;
+        s->s3.group_id = group_id;
 
-        if (!EVP_PKEY_set1_tls_encodedpoint(s->s3->peer_tmp,
+        if (!EVP_PKEY_set1_tls_encodedpoint(s->s3.peer_tmp,
                 PACKET_data(&encoded_pt),
                 PACKET_remaining(&encoded_pt))) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
@@ -740,7 +740,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     /* Ignore any cookie if we're not set up to verify it */
     if (s->ctx->verify_stateless_cookie_cb == NULL
-            || (s->s3->flags & TLS1_FLAGS_STATELESS) == 0)
+            || (s->s3.flags & TLS1_FLAGS_STATELESS) == 0)
         return 1;
 
     if (!PACKET_as_length_prefixed_2(pkt, &cookie)) {
@@ -833,8 +833,8 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                  SSL_R_LENGTH_MISMATCH);
         return 0;
     }
-    if (group_id != s->s3->group_id
-            || s->s3->tmp.new_cipher
+    if (group_id != s->s3.group_id
+            || s->s3.tmp.new_cipher
                != ssl_get_cipher_by_char(s, ciphdata, 0)) {
         /*
          * We chose a different cipher or group id this time around to what is
@@ -886,7 +886,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             || !WPACKET_memcpy(&hrrpkt, hrrrandom, SSL3_RANDOM_SIZE)
             || !WPACKET_sub_memcpy_u8(&hrrpkt, s->tmp_session_id,
                                       s->tmp_session_id_len)
-            || !s->method->put_cipher_by_char(s->s3->tmp.new_cipher, &hrrpkt,
+            || !s->method->put_cipher_by_char(s->s3.tmp.new_cipher, &hrrpkt,
                                               &ciphlen)
             || !WPACKET_put_bytes_u8(&hrrpkt, 0)
             || !WPACKET_start_sub_packet_u16(&hrrpkt)) {
@@ -907,7 +907,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     if (key_share) {
         if (!WPACKET_put_bytes_u16(&hrrpkt, TLSEXT_TYPE_key_share)
                 || !WPACKET_start_sub_packet_u16(&hrrpkt)
-                || !WPACKET_put_bytes_u16(&hrrpkt, s->s3->group_id)
+                || !WPACKET_put_bytes_u16(&hrrpkt, s->s3.group_id)
                 || !WPACKET_close(&hrrpkt)) {
             WPACKET_cleanup(&hrrpkt);
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_COOKIE,
@@ -992,7 +992,7 @@ int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     if (s->options & SSL_OP_NO_EXTENDED_MASTER_SECRET)
         return 1;
 
-    s->s3->flags |= TLS1_FLAGS_RECEIVED_EXTMS;
+    s->s3.flags |= TLS1_FLAGS_RECEIVED_EXTMS;
 
     return 1;
 }
@@ -1234,7 +1234,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         }
 
         md = ssl_md(sess->cipher->algorithm2);
-        if (md != ssl_md(s->s3->tmp.new_cipher->algorithm2)) {
+        if (md != ssl_md(s->s3.tmp.new_cipher->algorithm2)) {
             /* The ciphersuite is not compatible with this session. */
             SSL_SESSION_free(sess);
             sess = NULL;
@@ -1308,17 +1308,17 @@ EXT_RETURN tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt,
                                           unsigned int context, X509 *x,
                                           size_t chainidx)
 {
-    if (!s->s3->send_connection_binding)
+    if (!s->s3.send_connection_binding)
         return EXT_RETURN_NOT_SENT;
 
     /* Still add this even if SSL_OP_NO_RENEGOTIATION is set */
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_renegotiate)
             || !WPACKET_start_sub_packet_u16(pkt)
             || !WPACKET_start_sub_packet_u8(pkt)
-            || !WPACKET_memcpy(pkt, s->s3->previous_client_finished,
-                               s->s3->previous_client_finished_len)
-            || !WPACKET_memcpy(pkt, s->s3->previous_server_finished,
-                               s->s3->previous_server_finished_len)
+            || !WPACKET_memcpy(pkt, s->s3.previous_client_finished,
+                               s->s3.previous_client_finished_len)
+            || !WPACKET_memcpy(pkt, s->s3.previous_server_finished,
+                               s->s3.previous_server_finished_len)
             || !WPACKET_close(pkt)
             || !WPACKET_close(pkt)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_STOC_RENEGOTIATE,
@@ -1376,8 +1376,8 @@ EXT_RETURN tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt,
                                             unsigned int context, X509 *x,
                                             size_t chainidx)
 {
-    unsigned long alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
-    unsigned long alg_a = s->s3->tmp.new_cipher->algorithm_auth;
+    unsigned long alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
+    unsigned long alg_a = s->s3.tmp.new_cipher->algorithm_auth;
     int using_ecc = ((alg_k & SSL_kECDHE) || (alg_a & SSL_aECDSA))
                     && (s->session->ext.ecpointformats != NULL);
     const unsigned char *plist;
@@ -1408,8 +1408,8 @@ EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
     const uint16_t *groups;
     size_t numgroups, i, first = 1;
 
-    /* s->s3->group_id is non zero if we accepted a key_share */
-    if (s->s3->group_id == 0)
+    /* s->s3.group_id is non zero if we accepted a key_share */
+    if (s->s3.group_id == 0)
         return EXT_RETURN_NOT_SENT;
 
     /* Get our list of supported groups */
@@ -1430,7 +1430,7 @@ EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
                  * Check if the client is already using our preferred group. If
                  * so we don't need to add this extension
                  */
-                if (s->s3->group_id == group)
+                if (s->s3.group_id == group)
                     return EXT_RETURN_NOT_SENT;
 
                 /* Add extension header */
@@ -1530,9 +1530,9 @@ EXT_RETURN tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
     const unsigned char *npa;
     unsigned int npalen;
     int ret;
-    int npn_seen = s->s3->npn_seen;
+    int npn_seen = s->s3.npn_seen;
 
-    s->s3->npn_seen = 0;
+    s->s3.npn_seen = 0;
     if (!npn_seen || s->ctx->ext.npn_advertised_cb == NULL)
         return EXT_RETURN_NOT_SENT;
 
@@ -1546,7 +1546,7 @@ EXT_RETURN tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
                      ERR_R_INTERNAL_ERROR);
             return EXT_RETURN_FAIL;
         }
-        s->s3->npn_seen = 1;
+        s->s3.npn_seen = 1;
     }
 
     return EXT_RETURN_SENT;
@@ -1556,15 +1556,15 @@ EXT_RETURN tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
 EXT_RETURN tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context,
                                    X509 *x, size_t chainidx)
 {
-    if (s->s3->alpn_selected == NULL)
+    if (s->s3.alpn_selected == NULL)
         return EXT_RETURN_NOT_SENT;
 
     if (!WPACKET_put_bytes_u16(pkt,
                 TLSEXT_TYPE_application_layer_protocol_negotiation)
             || !WPACKET_start_sub_packet_u16(pkt)
             || !WPACKET_start_sub_packet_u16(pkt)
-            || !WPACKET_sub_memcpy_u8(pkt, s->s3->alpn_selected,
-                                      s->s3->alpn_selected_len)
+            || !WPACKET_sub_memcpy_u8(pkt, s->s3.alpn_selected,
+                                      s->s3.alpn_selected_len)
             || !WPACKET_close(pkt)
             || !WPACKET_close(pkt)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
@@ -1608,10 +1608,10 @@ EXT_RETURN tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context,
      * Don't use encrypt_then_mac if AEAD or RC4 might want to disable
      * for other cases too.
      */
-    if (s->s3->tmp.new_cipher->algorithm_mac == SSL_AEAD
-        || s->s3->tmp.new_cipher->algorithm_enc == SSL_RC4
-        || s->s3->tmp.new_cipher->algorithm_enc == SSL_eGOST2814789CNT
-        || s->s3->tmp.new_cipher->algorithm_enc == SSL_eGOST2814789CNT12) {
+    if (s->s3.tmp.new_cipher->algorithm_mac == SSL_AEAD
+        || s->s3.tmp.new_cipher->algorithm_enc == SSL_RC4
+        || s->s3.tmp.new_cipher->algorithm_enc == SSL_eGOST2814789CNT
+        || s->s3.tmp.new_cipher->algorithm_enc == SSL_eGOST2814789CNT12) {
         s->ext.use_etm = 0;
         return EXT_RETURN_NOT_SENT;
     }
@@ -1629,7 +1629,7 @@ EXT_RETURN tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context,
 EXT_RETURN tls_construct_stoc_ems(SSL *s, WPACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx)
 {
-    if ((s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS) == 0)
+    if ((s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS) == 0)
         return EXT_RETURN_NOT_SENT;
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_extended_master_secret)
@@ -1673,7 +1673,7 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
 #ifndef OPENSSL_NO_TLS1_3
     unsigned char *encodedPoint;
     size_t encoded_pt_len = 0;
-    EVP_PKEY *ckey = s->s3->peer_tmp, *skey = NULL;
+    EVP_PKEY *ckey = s->s3.peer_tmp, *skey = NULL;
 
     if (s->hello_retry_request == SSL_HRR_PENDING) {
         if (ckey != NULL) {
@@ -1682,7 +1682,7 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
         }
         if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_key_share)
                 || !WPACKET_start_sub_packet_u16(pkt)
-                || !WPACKET_put_bytes_u16(pkt, s->s3->group_id)
+                || !WPACKET_put_bytes_u16(pkt, s->s3.group_id)
                 || !WPACKET_close(pkt)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE,
@@ -1705,7 +1705,7 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_key_share)
             || !WPACKET_start_sub_packet_u16(pkt)
-            || !WPACKET_put_bytes_u16(pkt, s->s3->group_id)) {
+            || !WPACKET_put_bytes_u16(pkt, s->s3.group_id)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;
@@ -1738,7 +1738,7 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
     OPENSSL_free(encodedPoint);
 
     /* This causes the crypto state to be updated based on the derived keys */
-    s->s3->tmp.pkey = skey;
+    s->s3.tmp.pkey = skey;
     if (ssl_derive(s, skey, ckey, 1) == 0) {
         /* SSLfatal() already called */
         return EXT_RETURN_FAIL;
@@ -1760,7 +1760,7 @@ EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
     EVP_PKEY *pkey;
     int ret = EXT_RETURN_FAIL;
 
-    if ((s->s3->flags & TLS1_FLAGS_STATELESS) == 0)
+    if ((s->s3.flags & TLS1_FLAGS_STATELESS) == 0)
         return EXT_RETURN_NOT_SENT;
 
     if (s->ctx->gen_stateless_cookie_cb == NULL) {
@@ -1776,11 +1776,11 @@ EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
             || !WPACKET_reserve_bytes(pkt, MAX_COOKIE_SIZE, &cookie)
             || !WPACKET_put_bytes_u16(pkt, COOKIE_STATE_FORMAT_VERSION)
             || !WPACKET_put_bytes_u16(pkt, TLS1_3_VERSION)
-            || !WPACKET_put_bytes_u16(pkt, s->s3->group_id)
-            || !s->method->put_cipher_by_char(s->s3->tmp.new_cipher, pkt,
+            || !WPACKET_put_bytes_u16(pkt, s->s3.group_id)
+            || !s->method->put_cipher_by_char(s->s3.tmp.new_cipher, pkt,
                                               &ciphlen)
                /* Is there a key_share extension present in this HRR? */
-            || !WPACKET_put_bytes_u8(pkt, s->s3->peer_tmp == NULL)
+            || !WPACKET_put_bytes_u8(pkt, s->s3.peer_tmp == NULL)
             || !WPACKET_put_bytes_u32(pkt, (unsigned int)time(NULL))
             || !WPACKET_start_sub_packet_u16(pkt)
             || !WPACKET_reserve_bytes(pkt, EVP_MAX_MD_SIZE, &hashval1)) {
@@ -1895,8 +1895,8 @@ EXT_RETURN tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt,
         0x06, 0x06, 0x2a, 0x85, 0x03, 0x02, 0x02, 0x17
     };
 
-    if (((s->s3->tmp.new_cipher->id & 0xFFFF) != 0x80
-         && (s->s3->tmp.new_cipher->id & 0xFFFF) != 0x81)
+    if (((s->s3.tmp.new_cipher->id & 0xFFFF) != 0x80
+         && (s->s3.tmp.new_cipher->id & 0xFFFF) != 0x81)
             || (SSL_get_options(s) & SSL_OP_CRYPTOPRO_TLSEXT_BUG) == 0)
         return EXT_RETURN_NOT_SENT;
 

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -319,7 +319,7 @@ static int state_machine(SSL *s, int server)
          * If we are stateless then we already called SSL_clear() - don't do
          * it again and clear the STATELESS flag itself.
          */
-        if ((s->s3->flags & TLS1_FLAGS_STATELESS) == 0 && !SSL_clear(s))
+        if ((s->s3.flags & TLS1_FLAGS_STATELESS) == 0 && !SSL_clear(s))
             return -1;
     }
 #ifndef OPENSSL_NO_SCTP
@@ -399,7 +399,7 @@ static int state_machine(SSL *s, int server)
         /*
          * Should have been reset by tls_process_finished, too.
          */
-        s->s3->change_cipher_spec = 0;
+        s->s3.change_cipher_spec = 0;
 
         /*
          * Ok, we now need to push on a buffering BIO ...but not with
@@ -598,7 +598,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
             if (!transition(s, mt))
                 return SUB_STATE_ERROR;
 
-            if (s->s3->tmp.message_size > max_message_size(s)) {
+            if (s->s3.tmp.message_size > max_message_size(s)) {
                 SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_READ_STATE_MACHINE,
                          SSL_R_EXCESSIVE_MESSAGE_SIZE);
                 return SUB_STATE_ERROR;
@@ -606,8 +606,8 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
 
             /* dtls_get_message already did this */
             if (!SSL_IS_DTLS(s)
-                    && s->s3->tmp.message_size > 0
-                    && !grow_init_buf(s, s->s3->tmp.message_size
+                    && s->s3.tmp.message_size > 0
+                    && !grow_init_buf(s, s->s3.tmp.message_size
                                          + SSL3_HM_HEADER_LENGTH)) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_READ_STATE_MACHINE,
                          ERR_R_BUF_LIB);
@@ -923,7 +923,7 @@ int ossl_statem_app_data_allowed(SSL *s)
     if (st->state == MSG_FLOW_UNINITED)
         return 0;
 
-    if (!s->s3->in_read_app_data || (s->s3->total_renegotiations == 0))
+    if (!s->s3.in_read_app_data || (s->s3.total_renegotiations == 0))
         return 0;
 
     if (s->server) {
@@ -952,7 +952,7 @@ int ossl_statem_app_data_allowed(SSL *s)
  */
 int ossl_statem_export_allowed(SSL *s)
 {
-    return s->s3->previous_server_finished_len != 0
+    return s->s3.previous_server_finished_len != 0
            && s->statem.hand_state != TLS_ST_SW_FINISHED;
 }
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -44,8 +44,8 @@ static ossl_inline int cert_req_allowed(SSL *s)
 {
     /* TLS does not like anon-DH with client cert */
     if ((s->version > SSL3_VERSION
-         && (s->s3->tmp.new_cipher->algorithm_auth & SSL_aNULL))
-        || (s->s3->tmp.new_cipher->algorithm_auth & (SSL_aSRP | SSL_aPSK)))
+         && (s->s3.tmp.new_cipher->algorithm_auth & SSL_aNULL))
+        || (s->s3.tmp.new_cipher->algorithm_auth & (SSL_aSRP | SSL_aPSK)))
         return 0;
 
     return 1;
@@ -60,7 +60,7 @@ static ossl_inline int cert_req_allowed(SSL *s)
  */
 static int key_exchange_expected(SSL *s)
 {
-    long alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    long alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
 
     /*
      * Can't skip server key exchange if this is an ephemeral
@@ -272,7 +272,7 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
                 s->hit = 1;
                 st->hand_state = TLS_ST_CR_CHANGE;
                 return 1;
-            } else if (!(s->s3->tmp.new_cipher->algorithm_auth
+            } else if (!(s->s3.tmp.new_cipher->algorithm_auth
                          & (SSL_aNULL | SSL_aSRP | SSL_aPSK))) {
                 if (mt == SSL3_MT_CERTIFICATE) {
                     st->hand_state = TLS_ST_CR_CERT;
@@ -282,7 +282,7 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
                 ske_expected = key_exchange_expected(s);
                 /* SKE is optional for some PSK ciphersuites */
                 if (ske_expected
-                    || ((s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK)
+                    || ((s->s3.tmp.new_cipher->algorithm_mkey & SSL_PSK)
                         && mt == SSL3_MT_SERVER_KEY_EXCHANGE)) {
                     if (mt == SSL3_MT_SERVER_KEY_EXCHANGE) {
                         st->hand_state = TLS_ST_CR_KEY_EXCH;
@@ -314,7 +314,7 @@ int ossl_statem_client_read_transition(SSL *s, int mt)
     case TLS_ST_CR_CERT_STATUS:
         ske_expected = key_exchange_expected(s);
         /* SKE is optional for some PSK ciphersuites */
-        if (ske_expected || ((s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK)
+        if (ske_expected || ((s->s3.tmp.new_cipher->algorithm_mkey & SSL_PSK)
                              && mt == SSL3_MT_SERVER_KEY_EXCHANGE)) {
             if (mt == SSL3_MT_SERVER_KEY_EXCHANGE) {
                 st->hand_state = TLS_ST_CR_KEY_EXCH;
@@ -446,7 +446,7 @@ static WRITE_TRAN ossl_statem_client13_write_transition(SSL *s)
                  && s->hello_retry_request == SSL_HRR_NONE)
             st->hand_state = TLS_ST_CW_CHANGE;
         else
-            st->hand_state = (s->s3->tmp.cert_req != 0) ? TLS_ST_CW_CERT
+            st->hand_state = (s->s3.tmp.cert_req != 0) ? TLS_ST_CW_CERT
                                                         : TLS_ST_CW_FINISHED;
         return WRITE_TRAN_CONTINUE;
 
@@ -459,13 +459,13 @@ static WRITE_TRAN ossl_statem_client13_write_transition(SSL *s)
 
     case TLS_ST_CW_END_OF_EARLY_DATA:
     case TLS_ST_CW_CHANGE:
-        st->hand_state = (s->s3->tmp.cert_req != 0) ? TLS_ST_CW_CERT
+        st->hand_state = (s->s3.tmp.cert_req != 0) ? TLS_ST_CW_CERT
                                                     : TLS_ST_CW_FINISHED;
         return WRITE_TRAN_CONTINUE;
 
     case TLS_ST_CW_CERT:
         /* If a non-empty Certificate we also send CertificateVerify */
-        st->hand_state = (s->s3->tmp.cert_req == 1) ? TLS_ST_CW_CERT_VRFY
+        st->hand_state = (s->s3.tmp.cert_req == 1) ? TLS_ST_CW_CERT_VRFY
                                                     : TLS_ST_CW_FINISHED;
         return WRITE_TRAN_CONTINUE;
 
@@ -574,7 +574,7 @@ WRITE_TRAN ossl_statem_client_write_transition(SSL *s)
         return WRITE_TRAN_CONTINUE;
 
     case TLS_ST_CR_SRVR_DONE:
-        if (s->s3->tmp.cert_req)
+        if (s->s3.tmp.cert_req)
             st->hand_state = TLS_ST_CW_CERT;
         else
             st->hand_state = TLS_ST_CW_KEY_EXCH;
@@ -595,12 +595,12 @@ WRITE_TRAN ossl_statem_client_write_transition(SSL *s)
          * need to skip the certificate verify message when client's
          * ECDH public key is sent inside the client certificate.
          */
-        if (s->s3->tmp.cert_req == 1) {
+        if (s->s3.tmp.cert_req == 1) {
             st->hand_state = TLS_ST_CW_CERT_VRFY;
         } else {
             st->hand_state = TLS_ST_CW_CHANGE;
         }
-        if (s->s3->flags & TLS1_FLAGS_SKIP_CERT_VERIFY) {
+        if (s->s3.flags & TLS1_FLAGS_SKIP_CERT_VERIFY) {
             st->hand_state = TLS_ST_CW_CHANGE;
         }
         return WRITE_TRAN_CONTINUE;
@@ -618,7 +618,7 @@ WRITE_TRAN ossl_statem_client_write_transition(SSL *s)
 #if defined(OPENSSL_NO_NEXTPROTONEG)
             st->hand_state = TLS_ST_CW_FINISHED;
 #else
-            if (!SSL_IS_DTLS(s) && s->s3->npn_seen)
+            if (!SSL_IS_DTLS(s) && s->s3.npn_seen)
                 st->hand_state = TLS_ST_CW_NEXT_PROTO;
             else
                 st->hand_state = TLS_ST_CW_FINISHED;
@@ -803,14 +803,14 @@ WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst)
                 return WORK_ERROR;
             break;
         }
-        s->session->cipher = s->s3->tmp.new_cipher;
+        s->session->cipher = s->s3.tmp.new_cipher;
 #ifdef OPENSSL_NO_COMP
         s->session->compress_meth = 0;
 #else
-        if (s->s3->tmp.new_compression == NULL)
+        if (s->s3.tmp.new_compression == NULL)
             s->session->compress_meth = 0;
         else
-            s->session->compress_meth = s->s3->tmp.new_compression->id;
+            s->session->compress_meth = s->s3.tmp.new_compression->id;
 #endif
         if (!s->method->ssl3_enc->setup_key_block(s)) {
             /* SSLfatal() already called */
@@ -1132,7 +1132,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
     }
     /* else use the pre-loaded session */
 
-    p = s->s3->client_random;
+    p = s->s3.client_random;
 
     /*
      * for DTLS if client_random is initialized, reuse it, we are
@@ -1141,7 +1141,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
     if (SSL_IS_DTLS(s)) {
         size_t idx;
         i = 1;
-        for (idx = 0; idx < sizeof(s->s3->client_random); idx++) {
+        for (idx = 0; idx < sizeof(s->s3.client_random); idx++) {
             if (p[idx]) {
                 i = 0;
                 break;
@@ -1151,7 +1151,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
         i = (s->hello_retry_request == SSL_HRR_NONE);
     }
 
-    if (i && ssl_fill_hello_random(s, 0, p, sizeof(s->s3->client_random),
+    if (i && ssl_fill_hello_random(s, 0, p, sizeof(s->s3.client_random),
                                    DOWNGRADE_NONE) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CLIENT_HELLO,
                  ERR_R_INTERNAL_ERROR);
@@ -1192,7 +1192,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
      * supported_versions extension for the real supported versions.
      */
     if (!WPACKET_put_bytes_u16(pkt, s->client_version)
-            || !WPACKET_memcpy(pkt, s->s3->client_random, SSL3_RANDOM_SIZE)) {
+            || !WPACKET_memcpy(pkt, s->s3.client_random, SSL3_RANDOM_SIZE)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CLIENT_HELLO,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -1270,7 +1270,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
 #ifndef OPENSSL_NO_COMP
     if (ssl_allow_compression(s)
             && s->ctx->comp_methods
-            && (SSL_IS_DTLS(s) || s->s3->tmp.max_ver < TLS1_3_VERSION)) {
+            && (SSL_IS_DTLS(s) || s->s3.tmp.max_ver < TLS1_3_VERSION)) {
         int compnum = sk_SSL_COMP_num(s->ctx->comp_methods);
         for (i = 0; i < compnum; i++) {
             comp = sk_SSL_COMP_value(s->ctx->comp_methods, i);
@@ -1360,8 +1360,8 @@ static int set_client_ciphersuite(SSL *s, const unsigned char *cipherchars)
         return 0;
     }
 
-    if (SSL_IS_TLS13(s) && s->s3->tmp.new_cipher != NULL
-            && s->s3->tmp.new_cipher->id != c->id) {
+    if (SSL_IS_TLS13(s) && s->s3.tmp.new_cipher != NULL
+            && s->s3.tmp.new_cipher->id != c->id) {
         /* ServerHello selected a different ciphersuite to that in the HRR */
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_SET_CLIENT_CIPHERSUITE,
                  SSL_R_WRONG_CIPHER_RETURNED);
@@ -1398,7 +1398,7 @@ static int set_client_ciphersuite(SSL *s, const unsigned char *cipherchars)
             return 0;
         }
     }
-    s->s3->tmp.new_cipher = c;
+    s->s3.tmp.new_cipher = c;
 
     return 1;
 }
@@ -1436,7 +1436,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
             goto err;
         }
     } else {
-        if (!PACKET_copy_bytes(pkt, s->s3->server_random, SSL3_RANDOM_SIZE)) {
+        if (!PACKET_copy_bytes(pkt, s->s3.server_random, SSL3_RANDOM_SIZE)) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PROCESS_SERVER_HELLO,
                      SSL_R_LENGTH_MISMATCH);
             goto err;
@@ -1648,8 +1648,8 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
      * Now that we know the version, update the check to see if it's an allowed
      * version.
      */
-    s->s3->tmp.min_ver = s->version;
-    s->s3->tmp.max_ver = s->version;
+    s->s3.tmp.min_ver = s->version;
+    s->s3.tmp.max_ver = s->version;
 
     if (!set_client_ciphersuite(s, cipherchars)) {
         /* SSLfatal() already called */
@@ -1692,7 +1692,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
                  SSL_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
         goto err;
     } else {
-        s->s3->tmp.new_compression = comp;
+        s->s3.tmp.new_compression = comp;
     }
 #endif
 
@@ -1778,7 +1778,7 @@ static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL *s,
 
     if (s->ext.tls13_cookie_len == 0
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-        && s->s3->tmp.pkey != NULL
+        && s->s3.tmp.pkey != NULL
 #endif
         ) {
         /*
@@ -1959,7 +1959,7 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt)
      * type.
      */
     if (!SSL_IS_TLS13(s)) {
-        if ((clu->amask & s->s3->tmp.new_cipher->algorithm_auth) == 0) {
+        if ((clu->amask & s->s3.tmp.new_cipher->algorithm_auth) == 0) {
             x = NULL;
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_F_TLS_PROCESS_SERVER_CERTIFICATE,
@@ -2074,7 +2074,7 @@ static int tls_process_ske_srp(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
     }
 
     /* We must check if there is a certificate */
-    if (s->s3->tmp.new_cipher->algorithm_auth & (SSL_aRSA | SSL_aDSS))
+    if (s->s3.tmp.new_cipher->algorithm_auth & (SSL_aRSA | SSL_aDSS))
         *pkey = X509_get0_pubkey(s->session->peer);
 
     return 1;
@@ -2164,13 +2164,13 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
         goto err;
     }
 
-    s->s3->peer_tmp = peer_tmp;
+    s->s3.peer_tmp = peer_tmp;
 
     /*
      * FIXME: This makes assumptions about which ciphersuites come with
      * public keys. We should have a less ad-hoc way of doing this
      */
-    if (s->s3->tmp.new_cipher->algorithm_auth & (SSL_aRSA | SSL_aDSS))
+    if (s->s3.tmp.new_cipher->algorithm_auth & (SSL_aRSA | SSL_aDSS))
         *pkey = X509_get0_pubkey(s->session->peer);
     /* else anonymous DH, so no certificate or pkey. */
 
@@ -2218,7 +2218,7 @@ static int tls_process_ske_ecdhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
         return 0;
     }
 
-    if ((s->s3->peer_tmp = ssl_generate_param_group(curve_id)) == NULL) {
+    if ((s->s3.peer_tmp = ssl_generate_param_group(curve_id)) == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_SKE_ECDHE,
                  SSL_R_UNABLE_TO_FIND_ECDH_PARAMETERS);
         return 0;
@@ -2230,7 +2230,7 @@ static int tls_process_ske_ecdhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
         return 0;
     }
 
-    if (!EVP_PKEY_set1_tls_encodedpoint(s->s3->peer_tmp,
+    if (!EVP_PKEY_set1_tls_encodedpoint(s->s3.peer_tmp,
                                         PACKET_data(&encoded_pt),
                                         PACKET_remaining(&encoded_pt))) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_TLS_PROCESS_SKE_ECDHE,
@@ -2243,9 +2243,9 @@ static int tls_process_ske_ecdhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
      * ECParameters in the server key exchange message. We do support RSA
      * and ECDSA.
      */
-    if (s->s3->tmp.new_cipher->algorithm_auth & SSL_aECDSA)
+    if (s->s3.tmp.new_cipher->algorithm_auth & SSL_aECDSA)
         *pkey = X509_get0_pubkey(s->session->peer);
-    else if (s->s3->tmp.new_cipher->algorithm_auth & SSL_aRSA)
+    else if (s->s3.tmp.new_cipher->algorithm_auth & SSL_aRSA)
         *pkey = X509_get0_pubkey(s->session->peer);
     /* else anonymous ECDH, so no certificate or pkey. */
 
@@ -2265,13 +2265,13 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
     EVP_PKEY_CTX *pctx = NULL;
     PACKET save_param_start, signature;
 
-    alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
 
     save_param_start = *pkt;
 
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-    EVP_PKEY_free(s->s3->peer_tmp);
-    s->s3->peer_tmp = NULL;
+    EVP_PKEY_free(s->s3.peer_tmp);
+    s->s3.peer_tmp = NULL;
 #endif
 
     if (alg_k & SSL_PSK) {
@@ -2343,7 +2343,7 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
             goto err;
         }
 
-        if (!tls1_lookup_md(s->s3->tmp.peer_sigalg, &md)) {
+        if (!tls1_lookup_md(s->s3.tmp.peer_sigalg, &md)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);
             goto err;
@@ -2415,7 +2415,7 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
         md_ctx = NULL;
     } else {
         /* aNULL, aSRP or PSK do not need public keys */
-        if (!(s->s3->tmp.new_cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
+        if (!(s->s3.tmp.new_cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
             && !(alg_k & SSL_PSK)) {
             /* Might be wrong key type, check it */
             if (ssl3_check_cert_and_algorithm(s)) {
@@ -2445,7 +2445,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
 
     /* Clear certificate validity flags */
     for (i = 0; i < SSL_PKEY_NUM; i++)
-        s->s3->tmp.valid_flags[i] = 0;
+        s->s3.tmp.valid_flags[i] = 0;
 
     if (SSL_IS_TLS13(s)) {
         PACKET reqctx, extensions;
@@ -2461,9 +2461,9 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
         }
 
         /* Free and zero certificate types: it is not present in TLS 1.3 */
-        OPENSSL_free(s->s3->tmp.ctype);
-        s->s3->tmp.ctype = NULL;
-        s->s3->tmp.ctype_len = 0;
+        OPENSSL_free(s->s3.tmp.ctype);
+        s->s3.tmp.ctype = NULL;
+        s->s3.tmp.ctype_len = 0;
         OPENSSL_free(s->pha_context);
         s->pha_context = NULL;
 
@@ -2508,7 +2508,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
             return MSG_PROCESS_ERROR;
         }
 
-        if (!PACKET_memdup(&ctypes, &s->s3->tmp.ctype, &s->s3->tmp.ctype_len)) {
+        if (!PACKET_memdup(&ctypes, &s->s3.tmp.ctype, &s->s3.tmp.ctype_len)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_PROCESS_CERTIFICATE_REQUEST,
                      ERR_R_INTERNAL_ERROR);
@@ -2558,7 +2558,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt)
     }
 
     /* we should setup a certificate to return.... */
-    s->s3->tmp.cert_req = 1;
+    s->s3.tmp.cert_req = 1;
 
     /*
      * In TLSv1.3 we don't prepare the client certificate yet. We wait until
@@ -2861,7 +2861,7 @@ MSG_PROCESS_RETURN tls_process_server_done(SSL *s, PACKET *pkt)
         return MSG_PROCESS_ERROR;
     }
 #ifndef OPENSSL_NO_SRP
-    if (s->s3->tmp.new_cipher->algorithm_mkey & SSL_kSRP) {
+    if (s->s3.tmp.new_cipher->algorithm_mkey & SSL_kSRP) {
         if (SRP_Calc_A_param(s) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_SERVER_DONE,
                      SSL_R_SRP_A_CALC);
@@ -2932,9 +2932,9 @@ static int tls_construct_cke_psk_preamble(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    OPENSSL_free(s->s3->tmp.psk);
-    s->s3->tmp.psk = tmppsk;
-    s->s3->tmp.psklen = psklen;
+    OPENSSL_free(s->s3.tmp.psk);
+    s->s3.tmp.psk = tmppsk;
+    s->s3.tmp.psklen = psklen;
     tmppsk = NULL;
     OPENSSL_free(s->session->psk_identity);
     s->session->psk_identity = tmpidentity;
@@ -3040,8 +3040,8 @@ static int tls_construct_cke_rsa(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    s->s3->tmp.pms = pms;
-    s->s3->tmp.pmslen = pmslen;
+    s->s3.tmp.pms = pms;
+    s->s3.tmp.pmslen = pmslen;
 
     return 1;
  err:
@@ -3064,7 +3064,7 @@ static int tls_construct_cke_dhe(SSL *s, WPACKET *pkt)
     EVP_PKEY *ckey = NULL, *skey = NULL;
     unsigned char *keybytes = NULL;
 
-    skey = s->s3->peer_tmp;
+    skey = s->s3.peer_tmp;
     if (skey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_DHE,
                  ERR_R_INTERNAL_ERROR);
@@ -3122,7 +3122,7 @@ static int tls_construct_cke_ecdhe(SSL *s, WPACKET *pkt)
     EVP_PKEY *ckey = NULL, *skey = NULL;
     int ret = 0;
 
-    skey = s->s3->peer_tmp;
+    skey = s->s3.peer_tmp;
     if (skey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_ECDHE,
                  ERR_R_INTERNAL_ERROR);
@@ -3182,7 +3182,7 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt)
     unsigned char *pms = NULL;
     size_t pmslen = 0;
 
-    if ((s->s3->tmp.new_cipher->algorithm_auth & SSL_aGOST12) != 0)
+    if ((s->s3.tmp.new_cipher->algorithm_auth & SSL_aGOST12) != 0)
         dgst_nid = NID_id_GostR3411_2012_256;
 
     /*
@@ -3232,9 +3232,9 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt)
     ukm_hash = EVP_MD_CTX_new();
     if (ukm_hash == NULL
         || EVP_DigestInit(ukm_hash, EVP_get_digestbynid(dgst_nid)) <= 0
-        || EVP_DigestUpdate(ukm_hash, s->s3->client_random,
+        || EVP_DigestUpdate(ukm_hash, s->s3.client_random,
                             SSL3_RANDOM_SIZE) <= 0
-        || EVP_DigestUpdate(ukm_hash, s->s3->server_random,
+        || EVP_DigestUpdate(ukm_hash, s->s3.server_random,
                             SSL3_RANDOM_SIZE) <= 0
         || EVP_DigestFinal_ex(ukm_hash, shared_ukm, &md_len) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_GOST,
@@ -3269,8 +3269,8 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt)
     }
 
     EVP_PKEY_CTX_free(pkey_ctx);
-    s->s3->tmp.pms = pms;
-    s->s3->tmp.pmslen = pmslen;
+    s->s3.tmp.pms = pms;
+    s->s3.tmp.pmslen = pmslen;
 
     return 1;
  err:
@@ -3319,7 +3319,7 @@ int tls_construct_client_key_exchange(SSL *s, WPACKET *pkt)
 {
     unsigned long alg_k;
 
-    alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
 
     /*
      * All of the construct functions below call SSLfatal() if necessary so
@@ -3352,11 +3352,11 @@ int tls_construct_client_key_exchange(SSL *s, WPACKET *pkt)
 
     return 1;
  err:
-    OPENSSL_clear_free(s->s3->tmp.pms, s->s3->tmp.pmslen);
-    s->s3->tmp.pms = NULL;
+    OPENSSL_clear_free(s->s3.tmp.pms, s->s3.tmp.pmslen);
+    s->s3.tmp.pms = NULL;
 #ifndef OPENSSL_NO_PSK
-    OPENSSL_clear_free(s->s3->tmp.psk, s->s3->tmp.psklen);
-    s->s3->tmp.psk = NULL;
+    OPENSSL_clear_free(s->s3.tmp.psk, s->s3.tmp.psklen);
+    s->s3.tmp.psk = NULL;
 #endif
     return 0;
 }
@@ -3366,12 +3366,12 @@ int tls_client_key_exchange_post_work(SSL *s)
     unsigned char *pms = NULL;
     size_t pmslen = 0;
 
-    pms = s->s3->tmp.pms;
-    pmslen = s->s3->tmp.pmslen;
+    pms = s->s3.tmp.pms;
+    pmslen = s->s3.tmp.pmslen;
 
 #ifndef OPENSSL_NO_SRP
     /* Check for SRP */
-    if (s->s3->tmp.new_cipher->algorithm_mkey & SSL_kSRP) {
+    if (s->s3.tmp.new_cipher->algorithm_mkey & SSL_kSRP) {
         if (!srp_generate_client_master_secret(s)) {
             /* SSLfatal() already called */
             goto err;
@@ -3380,7 +3380,7 @@ int tls_client_key_exchange_post_work(SSL *s)
     }
 #endif
 
-    if (pms == NULL && !(s->s3->tmp.new_cipher->algorithm_mkey & SSL_kPSK)) {
+    if (pms == NULL && !(s->s3.tmp.new_cipher->algorithm_mkey & SSL_kPSK)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_TLS_CLIENT_KEY_EXCHANGE_POST_WORK, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -3430,7 +3430,7 @@ int tls_client_key_exchange_post_work(SSL *s)
     return 1;
  err:
     OPENSSL_clear_free(pms, pmslen);
-    s->s3->tmp.pms = NULL;
+    s->s3.tmp.pms = NULL;
     return 0;
 }
 
@@ -3442,7 +3442,7 @@ int tls_client_key_exchange_post_work(SSL *s)
 static int ssl3_check_client_certificate(SSL *s)
 {
     /* If no suitable signature algorithm can't use certificate */
-    if (!tls_choose_sigalg(s, 0) || s->s3->tmp.sigalg == NULL)
+    if (!tls_choose_sigalg(s, 0) || s->s3.tmp.sigalg == NULL)
         return 0;
     /*
      * If strict mode check suitability of chain before using it. This also
@@ -3514,11 +3514,11 @@ WORK_STATE tls_prepare_client_certificate(SSL *s, WORK_STATE wst)
             i = 0;
         if (i == 0) {
             if (s->version == SSL3_VERSION) {
-                s->s3->tmp.cert_req = 0;
+                s->s3.tmp.cert_req = 0;
                 ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_NO_CERTIFICATE);
                 return WORK_FINISHED_CONTINUE;
             } else {
-                s->s3->tmp.cert_req = 2;
+                s->s3.tmp.cert_req = 2;
                 if (!ssl3_digest_cached_records(s, 0)) {
                     /* SSLfatal() already called */
                     return WORK_ERROR;
@@ -3554,7 +3554,7 @@ int tls_construct_client_certificate(SSL *s, WPACKET *pkt)
         }
     }
     if (!ssl3_output_cert_chain(s, pkt,
-                                (s->s3->tmp.cert_req == 2) ? NULL
+                                (s->s3.tmp.cert_req == 2) ? NULL
                                                            : s->cert->key)) {
         /* SSLfatal() already called */
         return 0;
@@ -3582,8 +3582,8 @@ int ssl3_check_cert_and_algorithm(SSL *s)
     size_t idx;
     long alg_k, alg_a;
 
-    alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
-    alg_a = s->s3->tmp.new_cipher->algorithm_auth;
+    alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
+    alg_a = s->s3.tmp.new_cipher->algorithm_auth;
 
     /* we don't have a certificate */
     if (!(alg_a & SSL_aCERT))
@@ -3618,7 +3618,7 @@ int ssl3_check_cert_and_algorithm(SSL *s)
     }
 #endif
 #ifndef OPENSSL_NO_DH
-    if ((alg_k & SSL_kDHE) && (s->s3->peer_tmp == NULL)) {
+    if ((alg_k & SSL_kDHE) && (s->s3.peer_tmp == NULL)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL3_CHECK_CERT_AND_ALGORITHM,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -3782,12 +3782,12 @@ int ssl_cipher_list_to_bytes(SSL *s, STACK_OF(SSL_CIPHER) *sk, WPACKET *pkt)
         /* Sanity check that the maximum version we offer has ciphers enabled */
         if (!maxverok) {
             if (SSL_IS_DTLS(s)) {
-                if (DTLS_VERSION_GE(c->max_dtls, s->s3->tmp.max_ver)
-                        && DTLS_VERSION_LE(c->min_dtls, s->s3->tmp.max_ver))
+                if (DTLS_VERSION_GE(c->max_dtls, s->s3.tmp.max_ver)
+                        && DTLS_VERSION_LE(c->min_dtls, s->s3.tmp.max_ver))
                     maxverok = 1;
             } else {
-                if (c->max_tls >= s->s3->tmp.max_ver
-                        && c->min_tls <= s->s3->tmp.max_ver)
+                if (c->max_tls >= s->s3.tmp.max_ver
+                        && c->min_tls <= s->s3.tmp.max_ver)
                     maxverok = 1;
             }
         }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -349,7 +349,7 @@ int dtls_get_message(SSL *s, int *mt, size_t *len)
         return 0;
     }
 
-    *mt = s->s3->tmp.message_type;
+    *mt = s->s3.tmp.message_type;
 
     p = (unsigned char *)s->init_buf->data;
     *len = s->init_num;
@@ -442,9 +442,9 @@ static int dtls1_preprocess_fragment(SSL *s, struct hm_header_st *msg_hdr)
             return 0;
         }
 
-        s->s3->tmp.message_size = msg_len;
+        s->s3.tmp.message_size = msg_len;
         s->d1->r_msg_hdr.msg_len = msg_len;
-        s->s3->tmp.message_type = msg_hdr->type;
+        s->s3.tmp.message_type = msg_hdr->type;
         s->d1->r_msg_hdr.type = msg_hdr->type;
         s->d1->r_msg_hdr.seq = msg_hdr->seq;
     } else if (msg_len != s->d1->r_msg_hdr.msg_len) {
@@ -776,8 +776,8 @@ static int dtls_get_reassembled_message(SSL *s, int *errtype, size_t *len)
         memcpy(s->init_buf->data, wire, readbytes);
         s->init_num = readbytes - 1;
         s->init_msg = s->init_buf->data + 1;
-        s->s3->tmp.message_type = SSL3_MT_CHANGE_CIPHER_SPEC;
-        s->s3->tmp.message_size = readbytes - 1;
+        s->s3.tmp.message_type = SSL3_MT_CHANGE_CIPHER_SPEC;
+        s->s3.tmp.message_size = readbytes - 1;
         *len = readbytes - 1;
         return 1;
     }
@@ -902,7 +902,7 @@ static int dtls_get_reassembled_message(SSL *s, int *errtype, size_t *len)
  * for these 2 messages, we need to
  * ssl->enc_read_ctx                    re-init
  * ssl->rlayer.read_sequence            zero
- * ssl->s3->read_mac_secret             re-init
+ * ssl->s3.read_mac_secret             re-init
  * ssl->session->read_sym_enc           assign
  * ssl->session->read_compression       assign
  * ssl->session->read_hash              assign
@@ -955,7 +955,7 @@ WORK_STATE dtls_wait_for_dry(SSL *s)
             return WORK_ERROR;
         }
 
-        s->s3->in_read_app_data = 2;
+        s->s3.in_read_app_data = 2;
         s->rwstate = SSL_READING;
         BIO_clear_retry_flags(SSL_get_rbio(s));
         BIO_set_retry_read(SSL_get_rbio(s));

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -138,7 +138,7 @@ int tls_setup_handshake(SSL *s)
             /* N.B. s->ctx may not equal s->session_ctx */
             tsan_counter(&s->ctx->stats.sess_accept_renegotiate);
 
-            s->s3->tmp.cert_request = 0;
+            s->s3.tmp.cert_request = 0;
         }
     } else {
         if (SSL_IS_FIRST_HANDSHAKE(s))
@@ -147,10 +147,10 @@ int tls_setup_handshake(SSL *s)
             tsan_counter(&s->session_ctx->stats.sess_connect_renegotiate);
 
         /* mark client_random uninitialized */
-        memset(s->s3->client_random, 0, sizeof(s->s3->client_random));
+        memset(s->s3.client_random, 0, sizeof(s->s3.client_random));
         s->hit = 0;
 
-        s->s3->tmp.cert_req = 0;
+        s->s3.tmp.cert_req = 0;
 
         if (SSL_IS_DTLS(s))
             s->statem.use_timer = 1;
@@ -206,7 +206,7 @@ static int get_cert_verify_tbs_data(SSL *s, unsigned char *tls13tbs,
         size_t retlen;
         long retlen_l;
 
-        retlen = retlen_l = BIO_get_mem_data(s->s3->handshake_buffer, hdata);
+        retlen = retlen_l = BIO_get_mem_data(s->s3.handshake_buffer, hdata);
         if (retlen_l <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_GET_CERT_VERIFY_TBS_DATA,
                      ERR_R_INTERNAL_ERROR);
@@ -228,14 +228,14 @@ int tls_construct_cert_verify(SSL *s, WPACKET *pkt)
     void *hdata;
     unsigned char *sig = NULL;
     unsigned char tls13tbs[TLS13_TBS_PREAMBLE_SIZE + EVP_MAX_MD_SIZE];
-    const SIGALG_LOOKUP *lu = s->s3->tmp.sigalg;
+    const SIGALG_LOOKUP *lu = s->s3.tmp.sigalg;
 
-    if (lu == NULL || s->s3->tmp.cert == NULL) {
+    if (lu == NULL || s->s3.tmp.cert == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CERT_VERIFY,
                  ERR_R_INTERNAL_ERROR);
         goto err;
     }
-    pkey = s->s3->tmp.cert->privatekey;
+    pkey = s->s3.tmp.cert->privatekey;
 
     if (pkey == NULL || !tls1_lookup_md(lu, &md)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CERT_VERIFY,
@@ -389,7 +389,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
             goto err;
     }
 
-    if (!tls1_lookup_md(s->s3->tmp.peer_sigalg, &md)) {
+    if (!tls1_lookup_md(s->s3.tmp.peer_sigalg, &md)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CERT_VERIFY,
                  ERR_R_INTERNAL_ERROR);
         goto err;
@@ -503,13 +503,13 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
      * want to make sure that SSL_get_peer_certificate() will return the actual
      * server certificate from the client_cert_cb callback.
      */
-    if (!s->server && SSL_IS_TLS13(s) && s->s3->tmp.cert_req == 1)
+    if (!s->server && SSL_IS_TLS13(s) && s->s3.tmp.cert_req == 1)
         ret = MSG_PROCESS_CONTINUE_PROCESSING;
     else
         ret = MSG_PROCESS_CONTINUE_READING;
  err:
-    BIO_free(s->s3->handshake_buffer);
-    s->s3->handshake_buffer = NULL;
+    BIO_free(s->s3.handshake_buffer);
+    s->s3.handshake_buffer = NULL;
     EVP_MD_CTX_free(mctx);
 #ifndef OPENSSL_NO_GOST
     OPENSSL_free(gost_data);
@@ -533,7 +533,7 @@ int tls_construct_finished(SSL *s, WPACKET *pkt)
      */
     if (SSL_IS_TLS13(s)
             && !s->server
-            && s->s3->tmp.cert_req == 0
+            && s->s3.tmp.cert_req == 0
             && (!s->method->ssl3_enc->change_cipher_state(s,
                     SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {;
         /* SSLfatal() already called */
@@ -550,15 +550,15 @@ int tls_construct_finished(SSL *s, WPACKET *pkt)
 
     finish_md_len = s->method->ssl3_enc->final_finish_mac(s,
                                                           sender, slen,
-                                                          s->s3->tmp.finish_md);
+                                                          s->s3.tmp.finish_md);
     if (finish_md_len == 0) {
         /* SSLfatal() already called */
         return 0;
     }
 
-    s->s3->tmp.finish_md_len = finish_md_len;
+    s->s3.tmp.finish_md_len = finish_md_len;
 
-    if (!WPACKET_memcpy(pkt, s->s3->tmp.finish_md, finish_md_len)) {
+    if (!WPACKET_memcpy(pkt, s->s3.tmp.finish_md, finish_md_len)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_FINISHED,
                  ERR_R_INTERNAL_ERROR);
         return 0;
@@ -584,13 +584,13 @@ int tls_construct_finished(SSL *s, WPACKET *pkt)
         return 0;
     }
     if (!s->server) {
-        memcpy(s->s3->previous_client_finished, s->s3->tmp.finish_md,
+        memcpy(s->s3.previous_client_finished, s->s3.tmp.finish_md,
                finish_md_len);
-        s->s3->previous_client_finished_len = finish_md_len;
+        s->s3.previous_client_finished_len = finish_md_len;
     } else {
-        memcpy(s->s3->previous_server_finished, s->s3->tmp.finish_md,
+        memcpy(s->s3.previous_server_finished, s->s3.tmp.finish_md,
                finish_md_len);
-        s->s3->previous_server_finished_len = finish_md_len;
+        s->s3.previous_server_finished_len = finish_md_len;
     }
 
     return 1;
@@ -676,11 +676,11 @@ int ssl3_take_mac(SSL *s)
         slen = s->method->ssl3_enc->client_finished_label_len;
     }
 
-    s->s3->tmp.peer_finish_md_len =
+    s->s3.tmp.peer_finish_md_len =
         s->method->ssl3_enc->final_finish_mac(s, sender, slen,
-                                              s->s3->tmp.peer_finish_md);
+                                              s->s3.tmp.peer_finish_md);
 
-    if (s->s3->tmp.peer_finish_md_len == 0) {
+    if (s->s3.tmp.peer_finish_md_len == 0) {
         /* SSLfatal() already called */
         return 0;
     }
@@ -718,13 +718,13 @@ MSG_PROCESS_RETURN tls_process_change_cipher_spec(SSL *s, PACKET *pkt)
     }
 
     /* Check we have a cipher to change to */
-    if (s->s3->tmp.new_cipher == NULL) {
+    if (s->s3.tmp.new_cipher == NULL) {
         SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE,
                  SSL_F_TLS_PROCESS_CHANGE_CIPHER_SPEC, SSL_R_CCS_RECEIVED_EARLY);
         return MSG_PROCESS_ERROR;
     }
 
-    s->s3->change_cipher_spec = 1;
+    s->s3.change_cipher_spec = 1;
     if (!ssl3_do_change_cipher_spec(s)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CHANGE_CIPHER_SPEC,
                  ERR_R_INTERNAL_ERROR);
@@ -782,14 +782,14 @@ MSG_PROCESS_RETURN tls_process_finished(SSL *s, PACKET *pkt)
     }
 
     /* If this occurs, we have missed a message */
-    if (!SSL_IS_TLS13(s) && !s->s3->change_cipher_spec) {
+    if (!SSL_IS_TLS13(s) && !s->s3.change_cipher_spec) {
         SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE, SSL_F_TLS_PROCESS_FINISHED,
                  SSL_R_GOT_A_FIN_BEFORE_A_CCS);
         return MSG_PROCESS_ERROR;
     }
-    s->s3->change_cipher_spec = 0;
+    s->s3.change_cipher_spec = 0;
 
-    md_len = s->s3->tmp.peer_finish_md_len;
+    md_len = s->s3.tmp.peer_finish_md_len;
 
     if (md_len != PACKET_remaining(pkt)) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PROCESS_FINISHED,
@@ -797,7 +797,7 @@ MSG_PROCESS_RETURN tls_process_finished(SSL *s, PACKET *pkt)
         return MSG_PROCESS_ERROR;
     }
 
-    if (CRYPTO_memcmp(PACKET_data(pkt), s->s3->tmp.peer_finish_md,
+    if (CRYPTO_memcmp(PACKET_data(pkt), s->s3.tmp.peer_finish_md,
                       md_len) != 0) {
         SSLfatal(s, SSL_AD_DECRYPT_ERROR, SSL_F_TLS_PROCESS_FINISHED,
                  SSL_R_DIGEST_CHECK_FAILED);
@@ -813,13 +813,13 @@ MSG_PROCESS_RETURN tls_process_finished(SSL *s, PACKET *pkt)
         return MSG_PROCESS_ERROR;
     }
     if (s->server) {
-        memcpy(s->s3->previous_client_finished, s->s3->tmp.peer_finish_md,
+        memcpy(s->s3.previous_client_finished, s->s3.tmp.peer_finish_md,
                md_len);
-        s->s3->previous_client_finished_len = md_len;
+        s->s3.previous_client_finished_len = md_len;
     } else {
-        memcpy(s->s3->previous_server_finished, s->s3->tmp.peer_finish_md,
+        memcpy(s->s3.previous_server_finished, s->s3.tmp.peer_finish_md,
                md_len);
-        s->s3->previous_server_finished_len = md_len;
+        s->s3.previous_server_finished_len = md_len;
     }
 
     /*
@@ -1155,7 +1155,7 @@ int tls_get_message_header(SSL *s, int *mt)
                     return 0;
                 }
                 if (s->statem.hand_state == TLS_ST_BEFORE
-                        && (s->s3->flags & TLS1_FLAGS_STATELESS) != 0) {
+                        && (s->s3.flags & TLS1_FLAGS_STATELESS) != 0) {
                     /*
                      * We are stateless and we received a CCS. Probably this is
                      * from a client between the first and second ClientHellos.
@@ -1165,10 +1165,10 @@ int tls_get_message_header(SSL *s, int *mt)
                      */
                     return 0;
                 }
-                s->s3->tmp.message_type = *mt = SSL3_MT_CHANGE_CIPHER_SPEC;
+                s->s3.tmp.message_type = *mt = SSL3_MT_CHANGE_CIPHER_SPEC;
                 s->init_num = readbytes - 1;
                 s->init_msg = s->init_buf->data;
-                s->s3->tmp.message_size = readbytes;
+                s->s3.tmp.message_size = readbytes;
                 return 1;
             } else if (recvd_type != SSL3_RT_HANDSHAKE) {
                 SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE,
@@ -1202,7 +1202,7 @@ int tls_get_message_header(SSL *s, int *mt)
     /* s->init_num == SSL3_HM_HEADER_LENGTH */
 
     *mt = *p;
-    s->s3->tmp.message_type = *(p++);
+    s->s3.tmp.message_type = *(p++);
 
     if (RECORD_LAYER_is_sslv2_record(&s->rlayer)) {
         /*
@@ -1214,7 +1214,7 @@ int tls_get_message_header(SSL *s, int *mt)
          */
         l = RECORD_LAYER_get_rrec_length(&s->rlayer)
             + SSL3_HM_HEADER_LENGTH;
-        s->s3->tmp.message_size = l;
+        s->s3.tmp.message_size = l;
 
         s->init_msg = s->init_buf->data;
         s->init_num = SSL3_HM_HEADER_LENGTH;
@@ -1226,7 +1226,7 @@ int tls_get_message_header(SSL *s, int *mt)
                      SSL_R_EXCESSIVE_MESSAGE_SIZE);
             return 0;
         }
-        s->s3->tmp.message_size = l;
+        s->s3.tmp.message_size = l;
 
         s->init_msg = s->init_buf->data + SSL3_HM_HEADER_LENGTH;
         s->init_num = 0;
@@ -1241,14 +1241,14 @@ int tls_get_message_body(SSL *s, size_t *len)
     unsigned char *p;
     int i;
 
-    if (s->s3->tmp.message_type == SSL3_MT_CHANGE_CIPHER_SPEC) {
+    if (s->s3.tmp.message_type == SSL3_MT_CHANGE_CIPHER_SPEC) {
         /* We've already read everything in */
         *len = (unsigned long)s->init_num;
         return 1;
     }
 
     p = s->init_msg;
-    n = s->s3->tmp.message_size - s->init_num;
+    n = s->s3.tmp.message_size - s->init_num;
     while (n > 0) {
         i = s->method->ssl_read_bytes(s, SSL3_RT_HANDSHAKE, NULL,
                                       &p[s->init_num], n, 0, &readbytes);
@@ -1291,9 +1291,9 @@ int tls_get_message_body(SSL *s, size_t *len)
          */
 #define SERVER_HELLO_RANDOM_OFFSET  (SSL3_HM_HEADER_LENGTH + 2)
         /* KeyUpdate and NewSessionTicket do not need to be added */
-        if (!SSL_IS_TLS13(s) || (s->s3->tmp.message_type != SSL3_MT_NEWSESSION_TICKET
-                                 && s->s3->tmp.message_type != SSL3_MT_KEY_UPDATE)) {
-            if (s->s3->tmp.message_type != SSL3_MT_SERVER_HELLO
+        if (!SSL_IS_TLS13(s) || (s->s3.tmp.message_type != SSL3_MT_NEWSESSION_TICKET
+                                 && s->s3.tmp.message_type != SSL3_MT_KEY_UPDATE)) {
+            if (s->s3.tmp.message_type != SSL3_MT_SERVER_HELLO
                     || s->init_num < SERVER_HELLO_RANDOM_OFFSET + SSL3_RANDOM_SIZE
                     || memcmp(hrrrandom,
                               s->init_buf->data + SERVER_HELLO_RANDOM_OFFSET,
@@ -1933,7 +1933,7 @@ int ssl_choose_client_version(SSL *s, int version, RAW_EXTENSION *extensions)
     /* Check for downgrades */
     if (s->version == TLS1_2_VERSION && real_max > s->version) {
         if (memcmp(tls12downgrade,
-                   s->s3->server_random + SSL3_RANDOM_SIZE
+                   s->s3.server_random + SSL3_RANDOM_SIZE
                                         - sizeof(tls12downgrade),
                    sizeof(tls12downgrade)) == 0) {
             s->version = origv;
@@ -1946,7 +1946,7 @@ int ssl_choose_client_version(SSL *s, int version, RAW_EXTENSION *extensions)
                && s->version < TLS1_2_VERSION
                && real_max > s->version) {
         if (memcmp(tls11downgrade,
-                   s->s3->server_random + SSL3_RANDOM_SIZE
+                   s->s3.server_random + SSL3_RANDOM_SIZE
                                         - sizeof(tls11downgrade),
                    sizeof(tls11downgrade)) == 0) {
             s->version = origv;
@@ -2200,7 +2200,7 @@ int create_synthetic_message_hash(SSL *s, const unsigned char *hashval,
     if (hrr != NULL
             && (!ssl3_finish_mac(s, hrr, hrrlen)
                 || !ssl3_finish_mac(s, (unsigned char *)s->init_buf->data,
-                                    s->s3->tmp.message_size
+                                    s->s3.tmp.message_size
                                     + SSL3_HM_HEADER_LENGTH))) {
         /* SSLfatal() already called */
         return 0;
@@ -2263,8 +2263,8 @@ int parse_ca_names(SSL *s, PACKET *pkt)
         xn = NULL;
     }
 
-    sk_X509_NAME_pop_free(s->s3->tmp.peer_ca_names, X509_NAME_free);
-    s->s3->tmp.peer_ca_names = ca_sk;
+    sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
+    s->s3.tmp.peer_ca_names = ca_sk;
 
     return 1;
 
@@ -2340,8 +2340,8 @@ size_t construct_key_exchange_tbs(SSL *s, unsigned char **ptbs,
                  ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    memcpy(tbs, s->s3->client_random, SSL3_RANDOM_SIZE);
-    memcpy(tbs + SSL3_RANDOM_SIZE, s->s3->server_random, SSL3_RANDOM_SIZE);
+    memcpy(tbs, s->s3.client_random, SSL3_RANDOM_SIZE);
+    memcpy(tbs + SSL3_RANDOM_SIZE, s->s3.server_random, SSL3_RANDOM_SIZE);
 
     memcpy(tbs + SSL3_RANDOM_SIZE * 2, param, paramlen);
 
@@ -2368,7 +2368,7 @@ int tls13_save_handshake_digest_for_pha(SSL *s)
             return 0;
         }
         if (!EVP_MD_CTX_copy_ex(s->pha_dgst,
-                                s->s3->handshake_dgst)) {
+                                s->s3.handshake_dgst)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS13_SAVE_HANDSHAKE_DIGEST_FOR_PHA,
                      ERR_R_INTERNAL_ERROR);
@@ -2390,7 +2390,7 @@ int tls13_restore_handshake_digest_for_pha(SSL *s)
                  ERR_R_INTERNAL_ERROR);
         return 0;
     }
-    if (!EVP_MD_CTX_copy_ex(s->s3->handshake_dgst,
+    if (!EVP_MD_CTX_copy_ex(s->s3.handshake_dgst,
                             s->pha_dgst)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_TLS13_RESTORE_HANDSHAKE_DIGEST_FOR_PHA,

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -69,7 +69,7 @@ static int ossl_statem_server13_read_transition(SSL *s, int mt)
 
     case TLS_ST_SR_END_OF_EARLY_DATA:
     case TLS_ST_SW_FINISHED:
-        if (s->s3->tmp.cert_request) {
+        if (s->s3.tmp.cert_request) {
             if (mt == SSL3_MT_CERTIFICATE) {
                 st->hand_state = TLS_ST_SR_CERT;
                 return 1;
@@ -172,7 +172,7 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
          *         list if we requested a certificate)
          */
         if (mt == SSL3_MT_CLIENT_KEY_EXCHANGE) {
-            if (s->s3->tmp.cert_request) {
+            if (s->s3.tmp.cert_request) {
                 if (s->version == SSL3_VERSION) {
                     if ((s->verify_mode & SSL_VERIFY_PEER)
                         && (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
@@ -193,7 +193,7 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
                 st->hand_state = TLS_ST_SR_KEY_EXCH;
                 return 1;
             }
-        } else if (s->s3->tmp.cert_request) {
+        } else if (s->s3.tmp.cert_request) {
             if (mt == SSL3_MT_CERTIFICATE) {
                 st->hand_state = TLS_ST_SR_CERT;
                 return 1;
@@ -245,7 +245,7 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
 
     case TLS_ST_SR_CHANGE:
 #ifndef OPENSSL_NO_NEXTPROTONEG
-        if (s->s3->npn_seen) {
+        if (s->s3.npn_seen) {
             if (mt == SSL3_MT_NEXT_PROTO) {
                 st->hand_state = TLS_ST_SR_NEXT_PROTO;
                 return 1;
@@ -309,7 +309,7 @@ int ossl_statem_server_read_transition(SSL *s, int mt)
  */
 static int send_server_key_exchange(SSL *s)
 {
-    unsigned long alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    unsigned long alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
 
     /*
      * only send a ServerKeyExchange if DH or fortezza but we have a
@@ -371,7 +371,7 @@ int send_certificate_request(SSL *s)
             * section "Certificate request" in SSL 3 drafts and in
             * RFC 2246):
             */
-           && (!(s->s3->tmp.new_cipher->algorithm_auth & SSL_aNULL)
+           && (!(s->s3.tmp.new_cipher->algorithm_auth & SSL_aNULL)
                /*
                 * ... except when the application insists on
                 * verification (against the specs, but statem_clnt.c accepts
@@ -379,12 +379,12 @@ int send_certificate_request(SSL *s)
                 */
                || (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT))
            /* don't request certificate for SRP auth */
-           && !(s->s3->tmp.new_cipher->algorithm_auth & SSL_aSRP)
+           && !(s->s3.tmp.new_cipher->algorithm_auth & SSL_aSRP)
            /*
             * With normal PSK Certificates and Certificate Requests
             * are omitted
             */
-           && !(s->s3->tmp.new_cipher->algorithm_auth & SSL_aPSK)) {
+           && !(s->s3.tmp.new_cipher->algorithm_auth & SSL_aPSK)) {
         return 1;
     }
 
@@ -597,7 +597,7 @@ WRITE_TRAN ossl_statem_server_write_transition(SSL *s)
         } else {
             /* Check if it is anon DH or anon ECDH, */
             /* normal PSK or SRP */
-            if (!(s->s3->tmp.new_cipher->algorithm_auth &
+            if (!(s->s3.tmp.new_cipher->algorithm_auth &
                   (SSL_aNULL | SSL_aSRP | SSL_aPSK))) {
                 st->hand_state = TLS_ST_SW_CERT;
             } else if (send_server_key_exchange(s)) {
@@ -735,7 +735,7 @@ WORK_STATE ossl_statem_server_pre_work(SSL *s, WORK_STATE wst)
     case TLS_ST_SW_CHANGE:
         if (SSL_IS_TLS13(s))
             break;
-        s->session->cipher = s->s3->tmp.new_cipher;
+        s->session->cipher = s->s3.tmp.new_cipher;
         if (!s->method->ssl3_enc->setup_key_block(s)) {
             /* SSLfatal() already called */
             return WORK_ERROR;
@@ -753,7 +753,7 @@ WORK_STATE ossl_statem_server_pre_work(SSL *s, WORK_STATE wst)
 
     case TLS_ST_EARLY_DATA:
         if (s->early_data_state != SSL_EARLY_DATA_ACCEPTING
-                && (s->s3->flags & TLS1_FLAGS_STATELESS) == 0)
+                && (s->s3.flags & TLS1_FLAGS_STATELESS) == 0)
             return WORK_FINISHED_CONTINUE;
         /* Fall through */
 
@@ -1232,7 +1232,7 @@ static int ssl_check_srp_ext_ClientHello(SSL *s)
     int ret;
     int al = SSL_AD_UNRECOGNIZED_NAME;
 
-    if ((s->s3->tmp.new_cipher->algorithm_mkey & SSL_kSRP) &&
+    if ((s->s3.tmp.new_cipher->algorithm_mkey & SSL_kSRP) &&
         (s->srp_ctx.TLS_ext_srp_username_callback != NULL)) {
         if (s->srp_ctx.login == NULL) {
             /*
@@ -1353,7 +1353,7 @@ static void ssl_check_for_safari(SSL *s, const CLIENTHELLO_MSG *hello)
     ext_len = TLS1_get_client_version(s) >= TLS1_2_VERSION ?
         sizeof(kSafariExtensionsBlock) : kSafariCommonExtensionsLength;
 
-    s->s3->is_probably_safari = PACKET_equal(&tmppkt, kSafariExtensionsBlock,
+    s->s3.is_probably_safari = PACKET_equal(&tmppkt, kSafariExtensionsBlock,
                                              ext_len);
 }
 #endif                          /* !OPENSSL_NO_EC */
@@ -1373,7 +1373,7 @@ MSG_PROCESS_RETURN tls_process_client_hello(SSL *s, PACKET *pkt)
             goto err;
         }
         if ((s->options & SSL_OP_NO_RENEGOTIATION) != 0
-                || (!s->s3->send_connection_binding
+                || (!s->s3.send_connection_binding
                     && (s->options
                         & SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION) == 0)) {
             ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_NO_RENEGOTIATION);
@@ -1622,7 +1622,7 @@ static int tls_early_post_process_client_hello(SSL *s)
     }
 
     /* Set up the client_random */
-    memcpy(s->s3->client_random, clienthello->random, SSL3_RANDOM_SIZE);
+    memcpy(s->s3.client_random, clienthello->random, SSL3_RANDOM_SIZE);
 
     /* Choose the version */
 
@@ -1717,7 +1717,7 @@ static int tls_early_post_process_client_hello(SSL *s)
         goto err;
     }
 
-    s->s3->send_connection_binding = 0;
+    s->s3.send_connection_binding = 0;
     /* Check what signalling cipher-suite values were received. */
     if (scsvs != NULL) {
         for(i = 0; i < sk_SSL_CIPHER_num(scsvs); i++) {
@@ -1730,7 +1730,7 @@ static int tls_early_post_process_client_hello(SSL *s)
                              SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING);
                     goto err;
                 }
-                s->s3->send_connection_binding = 1;
+                s->s3.send_connection_binding = 1;
             } else if (SSL_CIPHER_get_id(c) == SSL3_CK_FALLBACK_SCSV &&
                        !ssl_check_version_downgrade(s)) {
                 /*
@@ -1760,8 +1760,8 @@ static int tls_early_post_process_client_hello(SSL *s)
             goto err;
         }
         if (s->hello_retry_request == SSL_HRR_PENDING
-                && (s->s3->tmp.new_cipher == NULL
-                    || s->s3->tmp.new_cipher->id != cipher->id)) {
+                && (s->s3.tmp.new_cipher == NULL
+                    || s->s3.tmp.new_cipher->id != cipher->id)) {
             /*
              * A previous HRR picked a different ciphersuite to the one we
              * just selected. Something must have changed.
@@ -1771,7 +1771,7 @@ static int tls_early_post_process_client_hello(SSL *s)
                      SSL_R_BAD_CIPHER);
             goto err;
         }
-        s->s3->tmp.new_cipher = cipher;
+        s->s3.tmp.new_cipher = cipher;
     }
 
     /* We need to do this before getting the session */
@@ -1897,7 +1897,7 @@ static int tls_early_post_process_client_hello(SSL *s)
      */
     {
         unsigned char *pos;
-        pos = s->s3->server_random;
+        pos = s->s3.server_random;
         if (ssl_fill_hello_random(s, 1, pos, SSL3_RANDOM_SIZE, dgrd) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_EARLY_POST_PROCESS_CLIENT_HELLO,
@@ -1955,7 +1955,7 @@ static int tls_early_post_process_client_hello(SSL *s)
      * options, we will now look for them.  We have complen-1 compression
      * algorithms from the client, starting at q.
      */
-    s->s3->tmp.new_compression = NULL;
+    s->s3.tmp.new_compression = NULL;
     if (SSL_IS_TLS13(s)) {
         /*
          * We already checked above that the NULL compression method appears in
@@ -1986,11 +1986,11 @@ static int tls_early_post_process_client_hello(SSL *s)
         for (m = 0; m < sk_SSL_COMP_num(s->ctx->comp_methods); m++) {
             comp = sk_SSL_COMP_value(s->ctx->comp_methods, m);
             if (comp_id == comp->id) {
-                s->s3->tmp.new_compression = comp;
+                s->s3.tmp.new_compression = comp;
                 break;
             }
         }
-        if (s->s3->tmp.new_compression == NULL) {
+        if (s->s3.tmp.new_compression == NULL) {
             SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
                      SSL_F_TLS_EARLY_POST_PROCESS_CLIENT_HELLO,
                      SSL_R_INVALID_COMPRESSION_ALGORITHM);
@@ -2028,7 +2028,7 @@ static int tls_early_post_process_client_hello(SSL *s)
                 break;
         }
         if (done)
-            s->s3->tmp.new_compression = comp;
+            s->s3.tmp.new_compression = comp;
         else
             comp = NULL;
     }
@@ -2104,12 +2104,12 @@ static int tls_handle_status_request(SSL *s)
         int ret;
 
         /* If no certificate can't return certificate status */
-        if (s->s3->tmp.cert != NULL) {
+        if (s->s3.tmp.cert != NULL) {
             /*
              * Set current certificate to one we will use so SSL_get_certificate
              * et al can pick it up.
              */
-            s->cert->key = s->s3->tmp.cert;
+            s->cert->key = s->s3.tmp.cert;
             ret = s->ctx->ext.status_cb(s, s->ctx->ext.status_arg);
             switch (ret) {
                 /* We don't want to send a status request response */
@@ -2144,24 +2144,24 @@ int tls_handle_alpn(SSL *s)
     const unsigned char *selected = NULL;
     unsigned char selected_len = 0;
 
-    if (s->ctx->ext.alpn_select_cb != NULL && s->s3->alpn_proposed != NULL) {
+    if (s->ctx->ext.alpn_select_cb != NULL && s->s3.alpn_proposed != NULL) {
         int r = s->ctx->ext.alpn_select_cb(s, &selected, &selected_len,
-                                           s->s3->alpn_proposed,
-                                           (unsigned int)s->s3->alpn_proposed_len,
+                                           s->s3.alpn_proposed,
+                                           (unsigned int)s->s3.alpn_proposed_len,
                                            s->ctx->ext.alpn_select_cb_arg);
 
         if (r == SSL_TLSEXT_ERR_OK) {
-            OPENSSL_free(s->s3->alpn_selected);
-            s->s3->alpn_selected = OPENSSL_memdup(selected, selected_len);
-            if (s->s3->alpn_selected == NULL) {
+            OPENSSL_free(s->s3.alpn_selected);
+            s->s3.alpn_selected = OPENSSL_memdup(selected, selected_len);
+            if (s->s3.alpn_selected == NULL) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_HANDLE_ALPN,
                          ERR_R_INTERNAL_ERROR);
                 return 0;
             }
-            s->s3->alpn_selected_len = selected_len;
+            s->s3.alpn_selected_len = selected_len;
 #ifndef OPENSSL_NO_NEXTPROTONEG
             /* ALPN takes precedence over NPN. */
-            s->s3->npn_seen = 0;
+            s->s3.npn_seen = 0;
 #endif
 
             /* Check ALPN is consistent with session */
@@ -2266,7 +2266,7 @@ WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst)
                              SSL_R_NO_SHARED_CIPHER);
                     goto err;
                 }
-                s->s3->tmp.new_cipher = cipher;
+                s->s3.tmp.new_cipher = cipher;
             }
             if (!s->hit) {
                 if (!tls_choose_sigalg(s, 1)) {
@@ -2277,7 +2277,7 @@ WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst)
                 if (s->not_resumable_session_cb != NULL)
                     s->session->not_resumable =
                         s->not_resumable_session_cb(s,
-                            ((s->s3->tmp.new_cipher->algorithm_mkey
+                            ((s->s3.tmp.new_cipher->algorithm_mkey
                               & (SSL_kDHE | SSL_kECDHE)) != 0));
                 if (s->session->not_resumable)
                     /* do not send a session ticket */
@@ -2285,7 +2285,7 @@ WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst)
             }
         } else {
             /* Session-id reuse */
-            s->s3->tmp.new_cipher = s->session->cipher;
+            s->s3.tmp.new_cipher = s->session->cipher;
         }
 
         /*-
@@ -2297,7 +2297,7 @@ WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst)
          * ssl version is set   - sslv3
          * s->session           - The ssl session has been setup.
          * s->hit               - session reuse flag
-         * s->s3->tmp.new_cipher- the new cipher to use.
+         * s->s3.tmp.new_cipher - the new cipher to use.
          */
 
         /*
@@ -2359,7 +2359,7 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
                 */
             || !WPACKET_memcpy(pkt,
                                s->hello_retry_request == SSL_HRR_PENDING
-                                   ? hrrrandom : s->s3->server_random,
+                                   ? hrrrandom : s->s3.server_random,
                                SSL3_RANDOM_SIZE)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_SERVER_HELLO,
                  ERR_R_INTERNAL_ERROR);
@@ -2407,14 +2407,14 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
 #ifdef OPENSSL_NO_COMP
     compm = 0;
 #else
-    if (usetls13 || s->s3->tmp.new_compression == NULL)
+    if (usetls13 || s->s3.tmp.new_compression == NULL)
         compm = 0;
     else
-        compm = s->s3->tmp.new_compression->id;
+        compm = s->s3.tmp.new_compression->id;
 #endif
 
     if (!WPACKET_sub_memcpy_u8(pkt, session_id, sl)
-            || !s->method->put_cipher_by_char(s->s3->tmp.new_cipher, pkt, &len)
+            || !s->method->put_cipher_by_char(s->s3.tmp.new_cipher, pkt, &len)
             || !WPACKET_put_bytes_u8(pkt, compm)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_SERVER_HELLO,
                  ERR_R_INTERNAL_ERROR);
@@ -2457,7 +2457,7 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
 
 int tls_construct_server_done(SSL *s, WPACKET *pkt)
 {
-    if (!s->s3->tmp.cert_request) {
+    if (!s->s3.tmp.cert_request) {
         if (!ssl3_digest_cached_records(s, 0)) {
             /* SSLfatal() already called */
             return 0;
@@ -2476,7 +2476,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
     size_t encodedlen = 0;
     int curve_id = 0;
 #endif
-    const SIGALG_LOOKUP *lu = s->s3->tmp.sigalg;
+    const SIGALG_LOOKUP *lu = s->s3.tmp.sigalg;
     int i;
     unsigned long type;
     const BIGNUM *r[4];
@@ -2496,7 +2496,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    type = s->s3->tmp.new_cipher->algorithm_mkey;
+    type = s->s3.tmp.new_cipher->algorithm_mkey;
 
     r[0] = r[1] = r[2] = r[3] = NULL;
 #ifndef OPENSSL_NO_PSK
@@ -2550,20 +2550,20 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
                      SSL_R_DH_KEY_TOO_SMALL);
             goto err;
         }
-        if (s->s3->tmp.pkey != NULL) {
+        if (s->s3.tmp.pkey != NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);
             goto err;
         }
 
-        s->s3->tmp.pkey = ssl_generate_pkey(pkdhp);
-        if (s->s3->tmp.pkey == NULL) {
+        s->s3.tmp.pkey = ssl_generate_pkey(pkdhp);
+        if (s->s3.tmp.pkey == NULL) {
             /* SSLfatal() already called */
             goto err;
         }
 
-        dh = EVP_PKEY_get0_DH(s->s3->tmp.pkey);
+        dh = EVP_PKEY_get0_DH(s->s3.tmp.pkey);
         if (dh == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,
@@ -2581,7 +2581,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
 #ifndef OPENSSL_NO_EC
     if (type & (SSL_kECDHE | SSL_kECDHEPSK)) {
 
-        if (s->s3->tmp.pkey != NULL) {
+        if (s->s3.tmp.pkey != NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);
@@ -2596,15 +2596,15 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
                      SSL_R_UNSUPPORTED_ELLIPTIC_CURVE);
             goto err;
         }
-        s->s3->tmp.pkey = ssl_generate_pkey_group(s, curve_id);
+        s->s3.tmp.pkey = ssl_generate_pkey_group(s, curve_id);
         /* Generate a new key for this curve */
-        if (s->s3->tmp.pkey == NULL) {
+        if (s->s3.tmp.pkey == NULL) {
             /* SSLfatal() already called */
             goto err;
         }
 
         /* Encode the public key. */
-        encodedlen = EVP_PKEY_get1_tls_encodedpoint(s->s3->tmp.pkey,
+        encodedlen = EVP_PKEY_get1_tls_encodedpoint(s->s3.tmp.pkey,
                                                     &encodedPoint);
         if (encodedlen == 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
@@ -2645,8 +2645,8 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    if (((s->s3->tmp.new_cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP)) != 0)
-        || ((s->s3->tmp.new_cipher->algorithm_mkey & SSL_PSK)) != 0) {
+    if (((s->s3.tmp.new_cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP)) != 0)
+        || ((s->s3.tmp.new_cipher->algorithm_mkey & SSL_PSK)) != 0) {
         lu = NULL;
     } else if (lu == NULL) {
         SSLfatal(s, SSL_AD_DECODE_ERROR,
@@ -2747,7 +2747,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
 
     /* not anonymous */
     if (lu != NULL) {
-        EVP_PKEY *pkey = s->s3->tmp.cert->privatekey;
+        EVP_PKEY *pkey = s->s3.tmp.cert->privatekey;
         const EVP_MD *md;
         unsigned char *sigbytes1, *sigbytes2, *tbs;
         size_t siglen, tbslen;
@@ -2896,7 +2896,7 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
 
  done:
     s->certreqs_sent++;
-    s->s3->tmp.cert_request = 1;
+    s->s3.tmp.cert_request = 1;
     return 1;
 }
 
@@ -2946,17 +2946,17 @@ static int tls_process_cke_psk_preamble(SSL *s, PACKET *pkt)
         return 0;
     }
 
-    OPENSSL_free(s->s3->tmp.psk);
-    s->s3->tmp.psk = OPENSSL_memdup(psk, psklen);
+    OPENSSL_free(s->s3.tmp.psk);
+    s->s3.tmp.psk = OPENSSL_memdup(psk, psklen);
     OPENSSL_cleanse(psk, psklen);
 
-    if (s->s3->tmp.psk == NULL) {
+    if (s->s3.tmp.psk == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_TLS_PROCESS_CKE_PSK_PREAMBLE, ERR_R_MALLOC_FAILURE);
         return 0;
     }
 
-    s->s3->tmp.psklen = psklen;
+    s->s3.tmp.psklen = psklen;
 
     return 1;
 #else
@@ -3154,7 +3154,7 @@ static int tls_process_cke_dhe(SSL *s, PACKET *pkt)
                SSL_R_DH_PUBLIC_VALUE_LENGTH_IS_WRONG);
         goto err;
     }
-    skey = s->s3->tmp.pkey;
+    skey = s->s3.tmp.pkey;
     if (skey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CKE_DHE,
                  SSL_R_MISSING_TMP_DH_KEY);
@@ -3194,8 +3194,8 @@ static int tls_process_cke_dhe(SSL *s, PACKET *pkt)
     }
 
     ret = 1;
-    EVP_PKEY_free(s->s3->tmp.pkey);
-    s->s3->tmp.pkey = NULL;
+    EVP_PKEY_free(s->s3.tmp.pkey);
+    s->s3.tmp.pkey = NULL;
  err:
     EVP_PKEY_free(ckey);
     return ret;
@@ -3210,7 +3210,7 @@ static int tls_process_cke_dhe(SSL *s, PACKET *pkt)
 static int tls_process_cke_ecdhe(SSL *s, PACKET *pkt)
 {
 #ifndef OPENSSL_NO_EC
-    EVP_PKEY *skey = s->s3->tmp.pkey;
+    EVP_PKEY *skey = s->s3.tmp.pkey;
     EVP_PKEY *ckey = NULL;
     int ret = 0;
 
@@ -3260,8 +3260,8 @@ static int tls_process_cke_ecdhe(SSL *s, PACKET *pkt)
     }
 
     ret = 1;
-    EVP_PKEY_free(s->s3->tmp.pkey);
-    s->s3->tmp.pkey = NULL;
+    EVP_PKEY_free(s->s3.tmp.pkey);
+    s->s3.tmp.pkey = NULL;
  err:
     EVP_PKEY_free(ckey);
 
@@ -3332,7 +3332,7 @@ static int tls_process_cke_gost(SSL *s, PACKET *pkt)
     PACKET encdata;
 
     /* Get our certificate private key */
-    alg_a = s->s3->tmp.new_cipher->algorithm_auth;
+    alg_a = s->s3.tmp.new_cipher->algorithm_auth;
     if (alg_a & SSL_aGOST12) {
         /*
          * New GOST ciphersuites have SSL_aGOST01 bit too
@@ -3440,7 +3440,7 @@ MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL *s, PACKET *pkt)
 {
     unsigned long alg_k;
 
-    alg_k = s->s3->tmp.new_cipher->algorithm_mkey;
+    alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
 
     /* For PSK parse and retrieve identity, obtain PSK key */
     if ((alg_k & SSL_PSK) && !tls_process_cke_psk_preamble(s, pkt)) {
@@ -3496,8 +3496,8 @@ MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL *s, PACKET *pkt)
     return MSG_PROCESS_CONTINUE_PROCESSING;
  err:
 #ifndef OPENSSL_NO_PSK
-    OPENSSL_clear_free(s->s3->tmp.psk, s->s3->tmp.psklen);
-    s->s3->tmp.psk = NULL;
+    OPENSSL_clear_free(s->s3.tmp.psk, s->s3.tmp.psklen);
+    s->s3.tmp.psk = NULL;
 #endif
     return MSG_PROCESS_ERROR;
 }
@@ -3549,7 +3549,7 @@ WORK_STATE tls_post_process_client_key_exchange(SSL *s, WORK_STATE wst)
         }
         return WORK_FINISHED_CONTINUE;
     } else {
-        if (!s->s3->handshake_buffer) {
+        if (!s->s3.handshake_buffer) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_POST_PROCESS_CLIENT_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);
@@ -3680,7 +3680,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
             goto err;
         }
         /* No client certificate so digest cached records */
-        if (s->s3->handshake_buffer && !ssl3_digest_cached_records(s, 0)) {
+        if (s->s3.handshake_buffer && !ssl3_digest_cached_records(s, 0)) {
             /* SSLfatal() already called */
             goto err;
         }
@@ -3772,7 +3772,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
 
 int tls_construct_server_certificate(SSL *s, WPACKET *pkt)
 {
-    CERT_PKEY *cpk = s->s3->tmp.cert;
+    CERT_PKEY *cpk = s->s3.tmp.cert;
 
     if (cpk == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
@@ -4102,17 +4102,17 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
         s->session->master_key_length = hashlen;
 
         s->session->time = (long)time(NULL);
-        if (s->s3->alpn_selected != NULL) {
+        if (s->s3.alpn_selected != NULL) {
             OPENSSL_free(s->session->ext.alpn_selected);
             s->session->ext.alpn_selected =
-                OPENSSL_memdup(s->s3->alpn_selected, s->s3->alpn_selected_len);
+                OPENSSL_memdup(s->s3.alpn_selected, s->s3.alpn_selected_len);
             if (s->session->ext.alpn_selected == NULL) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                          SSL_F_TLS_CONSTRUCT_NEW_SESSION_TICKET,
                          ERR_R_MALLOC_FAILURE);
                 goto err;
             }
-            s->session->ext.alpn_selected_len = s->s3->alpn_selected_len;
+            s->session->ext.alpn_selected_len = s->s3.alpn_selected_len;
         }
         s->session->ext.max_early_data = s->max_early_data;
     }

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -75,8 +75,8 @@ static int tls1_generate_key_block(SSL *s, unsigned char *km, size_t num)
     /* Calls SSLfatal() as required */
     ret = tls1_PRF(s,
                    TLS_MD_KEY_EXPANSION_CONST,
-                   TLS_MD_KEY_EXPANSION_CONST_SIZE, s->s3->server_random,
-                   SSL3_RANDOM_SIZE, s->s3->client_random, SSL3_RANDOM_SIZE,
+                   TLS_MD_KEY_EXPANSION_CONST_SIZE, s->s3.server_random,
+                   SSL3_RANDOM_SIZE, s->s3.client_random, SSL3_RANDOM_SIZE,
                    NULL, 0, NULL, 0, s->session->master_key,
                    s->session->master_key_length, km, num, 1);
 
@@ -105,20 +105,20 @@ int tls1_change_cipher_state(SSL *s, int which)
     unsigned char geniv[12];
 #endif
 
-    c = s->s3->tmp.new_sym_enc;
-    m = s->s3->tmp.new_hash;
-    mac_type = s->s3->tmp.new_mac_pkey_type;
+    c = s->s3.tmp.new_sym_enc;
+    m = s->s3.tmp.new_hash;
+    mac_type = s->s3.tmp.new_mac_pkey_type;
 #ifndef OPENSSL_NO_COMP
-    comp = s->s3->tmp.new_compression;
+    comp = s->s3.tmp.new_compression;
 #endif
 
     if (which & SSL3_CC_READ) {
         if (s->ext.use_etm)
-            s->s3->flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC_READ;
+            s->s3.flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC_READ;
         else
-            s->s3->flags &= ~TLS1_FLAGS_ENCRYPT_THEN_MAC_READ;
+            s->s3.flags &= ~TLS1_FLAGS_ENCRYPT_THEN_MAC_READ;
 
-        if (s->s3->tmp.new_cipher->algorithm2 & TLS1_STREAM_MAC)
+        if (s->s3.tmp.new_cipher->algorithm2 & TLS1_STREAM_MAC)
             s->mac_flags |= SSL_MAC_FLAG_READ_MAC_STREAM;
         else
             s->mac_flags &= ~SSL_MAC_FLAG_READ_MAC_STREAM;
@@ -160,16 +160,16 @@ int tls1_change_cipher_state(SSL *s, int which)
          */
         if (!SSL_IS_DTLS(s))
             RECORD_LAYER_reset_read_sequence(&s->rlayer);
-        mac_secret = &(s->s3->read_mac_secret[0]);
-        mac_secret_size = &(s->s3->read_mac_secret_size);
+        mac_secret = &(s->s3.read_mac_secret[0]);
+        mac_secret_size = &(s->s3.read_mac_secret_size);
     } else {
         s->statem.enc_write_state = ENC_WRITE_STATE_INVALID;
         if (s->ext.use_etm)
-            s->s3->flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE;
+            s->s3.flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE;
         else
-            s->s3->flags &= ~TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE;
+            s->s3.flags &= ~TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE;
 
-        if (s->s3->tmp.new_cipher->algorithm2 & TLS1_STREAM_MAC)
+        if (s->s3.tmp.new_cipher->algorithm2 & TLS1_STREAM_MAC)
             s->mac_flags |= SSL_MAC_FLAG_WRITE_MAC_STREAM;
         else
             s->mac_flags &= ~SSL_MAC_FLAG_WRITE_MAC_STREAM;
@@ -217,15 +217,15 @@ int tls1_change_cipher_state(SSL *s, int which)
          */
         if (!SSL_IS_DTLS(s))
             RECORD_LAYER_reset_write_sequence(&s->rlayer);
-        mac_secret = &(s->s3->write_mac_secret[0]);
-        mac_secret_size = &(s->s3->write_mac_secret_size);
+        mac_secret = &(s->s3.write_mac_secret[0]);
+        mac_secret_size = &(s->s3.write_mac_secret_size);
     }
 
     if (reuse_dd)
         EVP_CIPHER_CTX_reset(dd);
 
-    p = s->s3->tmp.key_block;
-    i = *mac_secret_size = s->s3->tmp.new_mac_secret_size;
+    p = s->s3.tmp.key_block;
+    i = *mac_secret_size = s->s3.tmp.new_mac_secret_size;
 
     /* TODO(size_t): convert me */
     cl = EVP_CIPHER_key_length(c);
@@ -256,7 +256,7 @@ int tls1_change_cipher_state(SSL *s, int which)
         n += k;
     }
 
-    if (n > s->s3->tmp.key_block_length) {
+    if (n > s->s3.tmp.key_block_length) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS1_CHANGE_CIPHER_STATE,
                  ERR_R_INTERNAL_ERROR);
         goto err;
@@ -293,7 +293,7 @@ int tls1_change_cipher_state(SSL *s, int which)
         }
     } else if (EVP_CIPHER_mode(c) == EVP_CIPH_CCM_MODE) {
         int taglen;
-        if (s->s3->tmp.
+        if (s->s3.tmp.
             new_cipher->algorithm_enc & (SSL_AES128CCM8 | SSL_AES256CCM8))
             taglen = EVP_CCM8_TLS_TAG_LEN;
         else
@@ -408,7 +408,7 @@ int tls1_setup_key_block(SSL *s)
     size_t num, mac_secret_size = 0;
     int ret = 0;
 
-    if (s->s3->tmp.key_block_length != 0)
+    if (s->s3.tmp.key_block_length != 0)
         return 1;
 
     if (!ssl_cipher_get_evp(s->session, &c, &hash, &mac_type, &mac_secret_size,
@@ -418,10 +418,10 @@ int tls1_setup_key_block(SSL *s)
         return 0;
     }
 
-    s->s3->tmp.new_sym_enc = c;
-    s->s3->tmp.new_hash = hash;
-    s->s3->tmp.new_mac_pkey_type = mac_type;
-    s->s3->tmp.new_mac_secret_size = mac_secret_size;
+    s->s3.tmp.new_sym_enc = c;
+    s->s3.tmp.new_hash = hash;
+    s->s3.tmp.new_mac_pkey_type = mac_type;
+    s->s3.tmp.new_mac_secret_size = mac_secret_size;
     num = EVP_CIPHER_key_length(c) + mac_secret_size + EVP_CIPHER_iv_length(c);
     num *= 2;
 
@@ -433,14 +433,14 @@ int tls1_setup_key_block(SSL *s)
         goto err;
     }
 
-    s->s3->tmp.key_block_length = num;
-    s->s3->tmp.key_block = p;
+    s->s3.tmp.key_block_length = num;
+    s->s3.tmp.key_block = p;
 
     OSSL_TRACE_BEGIN(TLS) {
         BIO_printf(trc_out, "client random\n");
-        BIO_dump_indent(trc_out, s->s3->client_random, SSL3_RANDOM_SIZE, 4);
+        BIO_dump_indent(trc_out, s->s3.client_random, SSL3_RANDOM_SIZE, 4);
         BIO_printf(trc_out, "server random\n");
-        BIO_dump_indent(trc_out, s->s3->server_random, SSL3_RANDOM_SIZE, 4);
+        BIO_dump_indent(trc_out, s->s3.server_random, SSL3_RANDOM_SIZE, 4);
         BIO_printf(trc_out, "master key\n");
         BIO_dump_indent(trc_out,
                         s->session->master_key,
@@ -463,15 +463,15 @@ int tls1_setup_key_block(SSL *s)
          * enable vulnerability countermeasure for CBC ciphers with known-IV
          * problem (http://www.openssl.org/~bodo/tls-cbc.txt)
          */
-        s->s3->need_empty_fragments = 1;
+        s->s3.need_empty_fragments = 1;
 
         if (s->session->cipher != NULL) {
             if (s->session->cipher->algorithm_enc == SSL_eNULL)
-                s->s3->need_empty_fragments = 0;
+                s->s3.need_empty_fragments = 0;
 
 #ifndef OPENSSL_NO_RC4
             if (s->session->cipher->algorithm_enc == SSL_RC4)
-                s->s3->need_empty_fragments = 0;
+                s->s3.need_empty_fragments = 0;
 #endif
         }
     }
@@ -543,9 +543,9 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
         if (!tls1_PRF(s,
                       TLS_MD_MASTER_SECRET_CONST,
                       TLS_MD_MASTER_SECRET_CONST_SIZE,
-                      s->s3->client_random, SSL3_RANDOM_SIZE,
+                      s->s3.client_random, SSL3_RANDOM_SIZE,
                       NULL, 0,
-                      s->s3->server_random, SSL3_RANDOM_SIZE,
+                      s->s3.server_random, SSL3_RANDOM_SIZE,
                       NULL, 0, p, len, out,
                       SSL3_MASTER_SECRET_SIZE, 1)) {
            /* SSLfatal() already called */
@@ -557,9 +557,9 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
         BIO_printf(trc_out, "Premaster Secret:\n");
         BIO_dump_indent(trc_out, p, len, 4);
         BIO_printf(trc_out, "Client Random:\n");
-        BIO_dump_indent(trc_out, s->s3->client_random, SSL3_RANDOM_SIZE, 4);
+        BIO_dump_indent(trc_out, s->s3.client_random, SSL3_RANDOM_SIZE, 4);
         BIO_printf(trc_out, "Server Random:\n");
-        BIO_dump_indent(trc_out, s->s3->server_random, SSL3_RANDOM_SIZE, 4);
+        BIO_dump_indent(trc_out, s->s3.server_random, SSL3_RANDOM_SIZE, 4);
         BIO_printf(trc_out, "Master Secret:\n");
         BIO_dump_indent(trc_out,
                         s->session->master_key,
@@ -595,9 +595,9 @@ int tls1_export_keying_material(SSL *s, unsigned char *out, size_t olen,
     currentvalpos = 0;
     memcpy(val + currentvalpos, (unsigned char *)label, llen);
     currentvalpos += llen;
-    memcpy(val + currentvalpos, s->s3->client_random, SSL3_RANDOM_SIZE);
+    memcpy(val + currentvalpos, s->s3.client_random, SSL3_RANDOM_SIZE);
     currentvalpos += SSL3_RANDOM_SIZE;
-    memcpy(val + currentvalpos, s->s3->server_random, SSL3_RANDOM_SIZE);
+    memcpy(val + currentvalpos, s->s3.server_random, SSL3_RANDOM_SIZE);
     currentvalpos += SSL3_RANDOM_SIZE;
 
     if (use_context) {

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1034,7 +1034,7 @@ static int ssl_print_server_hello(BIO *bio, int indent,
 
 static int ssl_get_keyex(const char **pname, const SSL *ssl)
 {
-    unsigned long alg_k = ssl->s3->tmp.new_cipher->algorithm_mkey;
+    unsigned long alg_k = ssl->s3.tmp.new_cipher->algorithm_mkey;
 
     if (alg_k & SSL_kRSA) {
         *pname = "rsa";

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -324,15 +324,15 @@ int tls13_setup_key_block(SSL *s)
     const EVP_CIPHER *c;
     const EVP_MD *hash;
 
-    s->session->cipher = s->s3->tmp.new_cipher;
+    s->session->cipher = s->s3.tmp.new_cipher;
     if (!ssl_cipher_get_evp(s->session, &c, &hash, NULL, NULL, NULL, 0)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS13_SETUP_KEY_BLOCK,
                  SSL_R_CIPHER_OR_HASH_UNAVAILABLE);
         return 0;
     }
 
-    s->s3->tmp.new_sym_enc = c;
-    s->s3->tmp.new_hash = hash;
+    s->s3.tmp.new_sym_enc = c;
+    s->s3.tmp.new_hash = hash;
 
     return 1;
 }
@@ -370,11 +370,11 @@ static int derive_secret_key_and_iv(SSL *s, int sending, const EVP_MD *md,
         uint32_t algenc;
 
         ivlen = EVP_CCM_TLS_IV_LEN;
-        if (s->s3->tmp.new_cipher == NULL) {
+        if (s->s3.tmp.new_cipher == NULL) {
             /* We've not selected a cipher yet - we must be doing early data */
             algenc = s->session->cipher->algorithm_enc;
         } else {
-            algenc = s->s3->tmp.new_cipher->algorithm_enc;
+            algenc = s->s3.tmp.new_cipher->algorithm_enc;
         }
         if (algenc & (SSL_AES128CCM8 | SSL_AES256CCM8))
             taglen = EVP_CCM8_TLS_TAG_LEN;
@@ -479,7 +479,7 @@ int tls13_change_cipher_state(SSL *s, int which)
             labellen = sizeof(client_early_traffic) - 1;
             log_label = CLIENT_EARLY_LABEL;
 
-            handlen = BIO_get_mem_data(s->s3->handshake_buffer, &hdata);
+            handlen = BIO_get_mem_data(s->s3.handshake_buffer, &hdata);
             if (handlen <= 0) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                          SSL_F_TLS13_CHANGE_CIPHER_STATE,
@@ -600,7 +600,7 @@ int tls13_change_cipher_state(SSL *s, int which)
 
     if (!(which & SSL3_CC_EARLY)) {
         md = ssl_handshake_md(s);
-        cipher = s->s3->tmp.new_sym_enc;
+        cipher = s->s3.tmp.new_sym_enc;
         if (!ssl3_digest_cached_records(s, 1)
                 || !ssl_handshake_hash(s, hashval, sizeof(hashval), &hashlen)) {
             /* SSLfatal() already called */;
@@ -709,7 +709,7 @@ int tls13_update_key(SSL *s, int sending)
     }
 
     if (!derive_secret_key_and_iv(s, sending, ssl_handshake_md(s),
-                                  s->s3->tmp.new_sym_enc, insecret, NULL,
+                                  s->s3.tmp.new_sym_enc, insecret, NULL,
                                   application_traffic,
                                   sizeof(application_traffic) - 1, secret, iv,
                                   ciph_ctx)) {

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -339,8 +339,8 @@ static int test_tls13_encryption(void)
     if (!TEST_ptr(s->enc_write_ctx))
         goto err;
 
-    s->s3->tmp.new_cipher = SSL_CIPHER_find(s, TLS13_AES_128_GCM_SHA256_BYTES);
-    if (!TEST_ptr(s->s3->tmp.new_cipher)) {
+    s->s3.tmp.new_cipher = SSL_CIPHER_find(s, TLS13_AES_128_GCM_SHA256_BYTES);
+    if (!TEST_ptr(s->s3.tmp.new_cipher)) {
         TEST_info("Failed to find cipher");
         goto err;
     }


### PR DESCRIPTION
With the removal of SSLv2, the s3 structure is always allocated, so
there is little point in having it be an allocated pointer. Collapse
the ssl3_state_st structure into ssl_st and fixup any references.

This should be faster than going through an indirection and due to
fewer allocations, but I'm not seeing any significant performance
improvement; it seems to be within the margin of error in timing.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
